### PR TITLE
Fetch $active_id only if neccessary

### DIFF
--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -2024,12 +2024,12 @@ function loadQuestions($active_id = "", $pass = NULL)
 	global $ilDB;
 
 	$this->questions = array();
-	if (strcmp($active_id, "") == 0)
-	{
-		$active_id = $this->getActiveIdOfUser($ilUser->getId());
-	}
 	if ($this->isRandomTest())
 	{
+		if (strcmp($active_id, "") == 0)
+		{
+			$active_id = $this->getActiveIdOfUser($ilUser->getId());
+		}
 		if (is_null($pass))
 		{
 			$pass = $this->_getPass($active_id);


### PR DESCRIPTION
Just loading a test object requires an initialized ilUser, but the $active_id is never used if the test is no RandomTest, so there's no need to try to determine it in this case.
