### PR TITLE
Replace PREG_REPLACE_EVAL (Improving security + support for HHVM RepoAuthoritative)

### DIFF
--- a/Services/Bookmarks/classes/class.ilBookmarkImportExport.php
+++ b/Services/Bookmarks/classes/class.ilBookmarkImportExport.php
@@ -188,8 +188,20 @@ class ilBookmarkImportExport
 			$trans_table = array_flip(get_html_translation_table(HTML_ENTITIES, ENT_QUOTES));
 			$string = strtr($string, $trans_table );
 		}
-		$string= preg_replace('/&#(\d+);/me',"chr(\\1)",$string); #decimal notation
-		$string= preg_replace('/&#x([a-f0-9]+);/mei',"chr(0x\\1)",$string);  #hex notation
+		$string= preg_replace_callback(
+            '/&#(\d+);/m',
+            function($hit){
+                return chr($hit[1]);
+            },
+            $string
+        ); #decimal notation
+		$string= preg_replace_callback(
+            '/&#x([a-f0-9]+);/mi',
+            function($hit) {
+                return chr(hexdec($hit[1]));
+            },
+            $string
+        );  #hex notation
 		return $string;
 	}
 	/**

--- a/Services/COPage/classes/class.ilPCSourceCode.php
+++ b/Services/COPage/classes/class.ilPCSourceCode.php
@@ -1,4 +1,4 @@
-l<?php
+<?php
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 require_once("./Services/COPage/classes/class.ilPCParagraph.php");

--- a/Services/COPage/classes/class.ilPCSourceCode.php
+++ b/Services/COPage/classes/class.ilPCSourceCode.php
@@ -1,4 +1,4 @@
-<?php
+l<?php
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 require_once("./Services/COPage/classes/class.ilPCParagraph.php");
@@ -82,8 +82,20 @@ class ilPCSourceCode extends ilPCParagraph
 			$rownums = count(split ("\n",$content));
 
 			$plain_content = html_entity_decode($content);
-			$plain_content = preg_replace ("/\&#x([1-9a-f]{2});?/ise","chr (base_convert (\\1, 16, 10))",$plain_content);
-			$plain_content = preg_replace ("/\&#(\d+);?/ise","chr (\\1)",$plain_content);
+			$plain_content = preg_replace_callback(
+                "/\&#x([1-9a-f]{2});?/is",
+                function($hit) {
+                    return chr(base_convert($hit[1], 16, 10));
+                },
+                $plain_content
+            );
+			$plain_content = preg_replace_callback(
+                "/\&#(\d+);?/is",
+                function($hit) {
+                    return chr($hit[1]);
+                },
+                $plain_content
+            );
 			$content = utf8_encode($this->highlightText($plain_content, $subchar, $autoindent));
 
 			$content = str_replace("&amp;lt;", "&lt;", $content);


### PR DESCRIPTION
Replacing PREG_REPLACE_EVAL by PREG_REPLACE_CALLBACK to improve compatibility with HHVM RepoAuthoritative and overall security.

Note: PREG_REPLACE_EVAL has been DEPRECATED as of PHP 5.5.0. Relying on this feature is highly discouraged (php.net docs).
