### PR TITLE
Replace PREG_REPLACE_EVAL libs (Improving security + support for HHVM RepoAuthoritative)

### DIFF
--- a/Modules/Wiki/mediawiki/normal/UtfNormalTest.php
+++ b/Modules/Wiki/mediawiki/normal/UtfNormalTest.php
@@ -29,18 +29,26 @@ $verbose = true;
 
 if( defined( 'PRETTY_UTF8' ) ) {
 	function pretty( $string ) {
-		return preg_replace( '/([\x00-\xff])/e',
-			'sprintf("%02X", ord("$1"))',
-			$string );
+		return preg_replace_callback(
+            '/([\x00-\xff])/',
+            function($hit) {
+                return sprintf("%02X", ord($hit[1]));
+            },
+            $string
+        );
 	}
 } else {
 	/**
 	 * @ignore
 	 */
 	function pretty( $string ) {
-		return trim( preg_replace( '/(.)/use',
-			'sprintf("%04X ", utf8ToCodepoint("$1"))',
-			$string ) );
+		return trim( preg_replace_callback(
+            '/(.)/us',
+			function($hit) {
+                return sprintf("%04X ", utf8ToCodepoint($hit[1]));
+            },
+			$string
+        ));
 	}
 }
 

--- a/Modules/Wiki/mediawiki/normal/UtfNormalUtil.php
+++ b/Modules/Wiki/mediawiki/normal/UtfNormalUtil.php
@@ -78,9 +78,13 @@ function hexSequenceToUtf8( $sequence ) {
  * @private
  */
 function utf8ToHexSequence( $str ) {
-	return rtrim( preg_replace( '/(.)/uSe',
-	                            'sprintf("%04x ", utf8ToCodepoint("$1"))',
-	                            $str ) );
+	return rtrim( preg_replace_callback(
+        '/(.)/uS',
+        function($hit) {
+            return sprintf("%04x ", utf8ToCodepoint($hit[1]));
+        },
+        $str
+    ));
 }
 
 /**

--- a/Services/Math/classes/class.EvalMath.php
+++ b/Services/Math/classes/class.EvalMath.php
@@ -116,7 +116,13 @@ class EvalMath {
     
     function evaluate($expr) {
 			// convert exponential notation
-			$expr = preg_replace("/(\\d{0,1})e(-{0,1}\\d+)/eis", "'\\1'.((strlen('\\1')) ? '*' : '').'10^(\\2)'", $expr);
+			$expr = preg_replace_callback(
+                "/(\\d{0,1})e(-{0,1}\\d+)/is",
+                function($hit) {
+                    return $hit[1].((strlen($hit[1])) ? '*' : '').'10^('.$hit[2].')';
+                },
+                $expr
+            );
 			// standard functionality
         $this->last_error = null;
         $expr = trim($expr);

--- a/Services/OpenId/lib/Auth/Yadis/ParseHTML.php
+++ b/Services/OpenId/lib/Auth/Yadis/ParseHTML.php
@@ -82,8 +82,20 @@ class Auth_Yadis_ParseHTML {
 
         // Replace numeric entities because html_entity_decode doesn't
         // do it for us.
-        $str = preg_replace('~&#x([0-9a-f]+);~ei', 'chr(hexdec("\\1"))', $str);
-        $str = preg_replace('~&#([0-9]+);~e', 'chr(\\1)', $str);
+        $str = preg_replace_callback(
+            '~&#x([0-9a-f]+);~i',
+            function($hit) {
+                return chr(hexdec($hit[1]));
+            },
+            $str
+        );
+        $str = preg_replace_callback(
+            '~&#([0-9]+);~',
+            function($hit) {
+                return chr($hit[1]);
+            },
+            $str
+        );
 
         return $str;
     }

--- a/Services/PEAR/lib/HTML/Template/IT.php
+++ b/Services/PEAR/lib/HTML/Template/IT.php
@@ -929,8 +929,12 @@ class HTML_Template_IT
         $content = fread($fh, $fsize);
         fclose($fh);
 
-        return preg_replace(
-            "#<!-- INCLUDE (.*) -->#ime", "\$this->getFile('\\1')", $content
+        return preg_replace_callback(
+            "#<!-- INCLUDE (.*) -->#im",
+            function ($hit) {
+                return $this->getFile($hit[1]);
+            },
+            $content
         );
     } // end func getFile
 

--- a/Services/Utilities/classes/Parser.php
+++ b/Services/Utilities/classes/Parser.php
@@ -3564,12 +3564,20 @@ class Parser
 			#     <!--LINK number-->
 			# turns into
 			#     link text with suffix
-			$canonized_headline = preg_replace( '/<!--LINK ([0-9]*)-->/e',
-							    "\$this->mLinkHolders['texts'][\$1]",
-							    $canonized_headline );
-			$canonized_headline = preg_replace( '/<!--IWLINK ([0-9]*)-->/e',
-							    "\$this->mInterwikiLinkHolders['texts'][\$1]",
-							    $canonized_headline );
+			$canonized_headline = preg_replace_callback(
+                '/<!--LINK ([0-9]*)-->/',
+				function($hit) {
+                    return $this->mLinkHolders['texts'][$hit[1]];
+                },
+                $canonized_headline
+            );
+			$canonized_headline = preg_replace_callback(
+                '/<!--IWLINK ([0-9]*)-->/',
+                function($hit) {
+                    return $this->mInterwikiLinkHolders['texts'][$hit[1]];
+                },
+                $canonized_headline
+            );
 
 			# strip out HTML
 			$canonized_headline = preg_replace( '/<.*?' . '>/','',$canonized_headline );

--- a/Services/Utilities/classes/Sanitizer.php
+++ b/Services/Utilities/classes/Sanitizer.php
@@ -619,8 +619,13 @@ class Sanitizer {
 		$value = $stripped;
 
 		// ... and continue checks
-		$stripped = preg_replace( '!\\\\([0-9A-Fa-f]{1,6})[ \\n\\r\\t\\f]?!e',
-			'codepointToUtf8(hexdec("$1"))', $stripped );
+		$stripped = preg_replace_callback(
+            '!\\\\([0-9A-Fa-f]{1,6})[ \\n\\r\\t\\f]?!',
+			function($hit){
+                return codepointToUtf8(hexdec($hit[1]));
+            },
+            $stripped
+        );
 		$stripped = str_replace( '\\', '', $stripped );
 		if( preg_match( '/(?:expression|tps*:\/\/|url\\s*\().*/is',
 				$stripped ) ) {
@@ -1238,7 +1243,13 @@ class Sanitizer {
 		$url = Sanitizer::decodeCharReferences( $url );
 
 		# Escape any control characters introduced by the above step
-		$url = preg_replace( '/[\][<>"\\x00-\\x20\\x7F]/e', "urlencode('\\0')", $url );
+		$url = preg_replace_callback(
+            '/[\][<>"\\x00-\\x20\\x7F]/',
+            function($hit) {
+                return urlencode($hit[0]);
+            },
+            $url
+        );
 
 		# Validate hostname portion
 		$matches = array();

--- a/Services/Utilities/classes/Sanitizer.php
+++ b/Services/Utilities/classes/Sanitizer.php
@@ -1246,7 +1246,16 @@ class Sanitizer {
 		$url = preg_replace_callback(
             '/[\][<>"\\x00-\\x20\\x7F]/',
             function($hit) {
-                return urlencode($hit[0]);
+                if($hit[0] === '"') {
+                    /** NOTE: The original preg_replace/e IMPLICITLY
+                     *        adds a forward-slash on double quotes
+                     *        This could be a bug, but we will just
+                     *        mimic this behaviour 1:1 for now.
+                     */
+                    return urlencode ('\\"');
+                } else {
+                    return urlencode($hit[0]);
+                }
             },
             $url
         );

--- a/include/Unicode/UtfNormalUtil.php
+++ b/include/Unicode/UtfNormalUtil.php
@@ -77,9 +77,12 @@ function hexSequenceToUtf8( $sequence ) {
  * @access private
  */
 function utf8ToHexSequence( $str ) {
-	return rtrim( preg_replace( '/(.)/uSe',
-	                            'sprintf("%04x ", utf8ToCodepoint("$1"))',
-	                            $str ) );
+	return rtrim(preg_replace_callback(
+        '/(.)/uS',
+        function($hit) {
+            return sprintf("%04x ", utf8ToCodepoint($hit[1]));
+        },
+	    $str));
 }
 
 /**


### PR DESCRIPTION
Equivalent to https://github.com/ILIAS-eLearning/ILIAS/pull/5, but this time files which seem to belong to libraries. It would be nice to fix as much of them as possible (especially PEAR IT), because this would enable Repo Authoritative Mode with HHVM which gives another significant speedup. :-)

Note: PREG_REPLACE_EVAL has been DEPRECATED as of PHP 5.5.0. Relying on this feature is highly discouraged (php.net docs). Replacing this with PREG_REPLACE_CALLBACK.
