### PR TITLE
Fix "Limit number of participants on test import"

### DIFF
--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -6023,7 +6023,7 @@ function getAnswerFeedbackPoints()
 					break;
 				case "allowedUsers":
 					$this->setAllowedUsers($metadata["entry"]);
-					$this->setLimitUsersEnabled(strlen($metadata["entry"]) > 0);
+					$this->setLimitUsersEnabled($metadata["entry"] > 0);
 					break;
 				case "allowedUsersTimeGap":
 					$this->setAllowedUsersTimeGap($metadata["entry"]);


### PR DESCRIPTION
The XML parser returns 0 for "allowedUsers" if the option is disabled,
so checking for strlen > 0 doesn't work.
Mantis bug 0015675
