### PR TITLE
COPage SourceCode Highlight: fixed violation of naming convention

### DIFF
--- a/Services/COPage/syntax_highlight/php/HFile/HFile_mixedphp.php
+++ b/Services/COPage/syntax_highlight/php/HFile/HFile_mixedphp.php
@@ -3,9 +3,9 @@ $BEAUT_PATH = realpath(".")."/Services/COPage/syntax_highlight/php";
 if (!isset ($BEAUT_PATH)) return;
 require_once("$BEAUT_PATH/Beautifier/HFile.php");
 
-class HFile_plain extends HFile{
+class HFile_mixedphp extends HFile{
 
- function HFile_plain(){
+ function HFile_mixedphp(){
 
     $this->HFile();	
 


### PR DESCRIPTION
 (file=class=function names must be ......identical) - this also removes one classname collision with 'HFile_plain'

see \ilPCSourceCode::highlightText regarding the naming convention

-> was this piece ever usable??

(one step closer to autoloading..)
