### PR TITLE
removed unnecessary checks on PHP <= 5.2.

### DIFF
--- a/Services/Http/classes/class.ilHTTPS.php
+++ b/Services/Http/classes/class.ilHTTPS.php
@@ -214,14 +214,14 @@ class ilHTTPS
 	public function enableSecureCookies()
 	{
 		global $ilLog,$ilClientIniFile;
-		
+
 		$secure_disabled = $ilClientIniFile->readVariable('session','disable_secure_cookies');
 		if(!$secure_disabled and !$this->enabled and $this->isDetected() and !session_id())
 		{
 			#$ilLog->write(__CLASS__.': Enabled secure cookies');
-            session_set_cookie_params(
-                    IL_COOKIE_EXPIRE, IL_COOKIE_PATH, IL_COOKIE_DOMAIN, true, IL_COOKIE_HTTPONLY
-            );
+			session_set_cookie_params(
+				IL_COOKIE_EXPIRE, IL_COOKIE_PATH, IL_COOKIE_DOMAIN, true, IL_COOKIE_HTTPONLY
+			);
 		}
 		return true;
 	}

--- a/Services/Http/classes/class.ilHTTPS.php
+++ b/Services/Http/classes/class.ilHTTPS.php
@@ -219,23 +219,9 @@ class ilHTTPS
 		if(!$secure_disabled and !$this->enabled and $this->isDetected() and !session_id())
 		{
 			#$ilLog->write(__CLASS__.': Enabled secure cookies');
-
-			// session_set_cookie_params() supports 5th parameter
-			// only for php version 5.2.0 and above
-			if( version_compare(PHP_VERSION, '5.2.0', '>=') )
-			{
-				// PHP version >= 5.2.0
-				session_set_cookie_params(
-						IL_COOKIE_EXPIRE, IL_COOKIE_PATH, IL_COOKIE_DOMAIN, true, IL_COOKIE_HTTPONLY
-				);
-			}
-			else
-			{
-				// PHP version < 5.2.0
-				session_set_cookie_params(
-						IL_COOKIE_EXPIRE, IL_COOKIE_PATH, IL_COOKIE_DOMAIN, true
-				);
-			}
+            session_set_cookie_params(
+                    IL_COOKIE_EXPIRE, IL_COOKIE_PATH, IL_COOKIE_DOMAIN, true, IL_COOKIE_HTTPONLY
+            );
 		}
 		return true;
 	}

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -84,16 +84,12 @@ class ilInitialisation
 	 */
 	protected static function includePhp5Compliance()
 	{
-		// php5 downward complaince to php 4 dom xml and clone method
-		if (version_compare(PHP_VERSION,'5','>='))
-		{
-			include_once 'Services/Authentication/classes/class.ilAuthFactory.php';
-			if(ilAuthFactory::getContext() != ilAuthFactory::CONTEXT_CAS)
-			{
-				require_once("include/inc.xml5compliance.php");
-			}
-			require_once("include/inc.xsl5compliance.php");
-		}
+        include_once 'Services/Authentication/classes/class.ilAuthFactory.php';
+        if(ilAuthFactory::getContext() != ilAuthFactory::CONTEXT_CAS)
+        {
+            require_once("include/inc.xml5compliance.php");
+        }
+        require_once("include/inc.xsl5compliance.php");
 	}
 
 	/**
@@ -469,23 +465,10 @@ class ilInitialisation
 		define('IL_COOKIE_DOMAIN','');
 		define('IL_COOKIE_SECURE', $cookie_secure); // Default Value
 
-		// session_set_cookie_params() supports 5th parameter
-		// only for php version 5.2.0 and above
-		if( version_compare(PHP_VERSION, '5.2.0', '>=') )
-		{
-			// PHP version >= 5.2.0
-			define('IL_COOKIE_HTTPONLY',true); // Default Value
-			session_set_cookie_params(
-					IL_COOKIE_EXPIRE, IL_COOKIE_PATH, IL_COOKIE_DOMAIN, IL_COOKIE_SECURE, IL_COOKIE_HTTPONLY
-			);
-		}
-		else
-		{
-			// PHP version < 5.2.0
-			session_set_cookie_params(
-					IL_COOKIE_EXPIRE, IL_COOKIE_PATH, IL_COOKIE_DOMAIN, IL_COOKIE_SECURE
-			);
-		}
+        define('IL_COOKIE_HTTPONLY',true); // Default Value
+        session_set_cookie_params(
+                IL_COOKIE_EXPIRE, IL_COOKIE_PATH, IL_COOKIE_DOMAIN, IL_COOKIE_SECURE, IL_COOKIE_HTTPONLY
+        );
 	}
 
 	/**
@@ -887,14 +870,7 @@ class ilInitialisation
 			// when the error reporting is set to E_ALL anyway
 			
 			// remove notices from error reporting
-			if (version_compare(PHP_VERSION, '5.3.0', '>='))
-			{
-				error_reporting(E_ALL);
-			}
-			else
-			{
-				error_reporting(E_ALL);
-			}
+			error_reporting(E_ALL);
 		}
 
 		include_once "include/inc.debug.php";
@@ -964,13 +940,9 @@ class ilInitialisation
 			
 			error_reporting(((ini_get("error_reporting") & ~E_NOTICE) & ~E_DEPRECATED) & ~E_STRICT);
 		}
-		elseif (version_compare(PHP_VERSION, '5.3.0', '>='))
-		{
-			error_reporting((ini_get("error_reporting") & ~E_NOTICE) & ~E_DEPRECATED);
-		}
 		else
 		{
-			error_reporting(ini_get('error_reporting') & ~E_NOTICE);
+			error_reporting((ini_get("error_reporting") & ~E_NOTICE) & ~E_DEPRECATED);
 		}
 		// breaks CAS: must be included after CAS context isset in AuthUtils
 		//self::includePhp5Compliance();

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -84,12 +84,12 @@ class ilInitialisation
 	 */
 	protected static function includePhp5Compliance()
 	{
-        include_once 'Services/Authentication/classes/class.ilAuthFactory.php';
-        if(ilAuthFactory::getContext() != ilAuthFactory::CONTEXT_CAS)
-        {
-            require_once("include/inc.xml5compliance.php");
-        }
-        require_once("include/inc.xsl5compliance.php");
+		include_once 'Services/Authentication/classes/class.ilAuthFactory.php';
+		if(ilAuthFactory::getContext() != ilAuthFactory::CONTEXT_CAS)
+		{
+			require_once("include/inc.xml5compliance.php");
+		}
+		require_once("include/inc.xsl5compliance.php");
 	}
 
 	/**
@@ -175,7 +175,7 @@ class ilInitialisation
 		include_once './Services/Http/classes/class.ilHTTPS.php';
 		$https = new ilHTTPS();
 
-	    if($https->isDetected())
+		if($https->isDetected())
 		{
 			$protocol = 'https://';
 		}
@@ -465,10 +465,10 @@ class ilInitialisation
 		define('IL_COOKIE_DOMAIN','');
 		define('IL_COOKIE_SECURE', $cookie_secure); // Default Value
 
-        define('IL_COOKIE_HTTPONLY',true); // Default Value
-        session_set_cookie_params(
-                IL_COOKIE_EXPIRE, IL_COOKIE_PATH, IL_COOKIE_DOMAIN, IL_COOKIE_SECURE, IL_COOKIE_HTTPONLY
-        );
+		define('IL_COOKIE_HTTPONLY',true); // Default Value
+		session_set_cookie_params(
+			IL_COOKIE_EXPIRE, IL_COOKIE_PATH, IL_COOKIE_DOMAIN, IL_COOKIE_SECURE, IL_COOKIE_HTTPONLY
+		);
 	}
 
 	/**

--- a/Services/UICore/classes/class.ilTemplate.php
+++ b/Services/UICore/classes/class.ilTemplate.php
@@ -861,7 +861,7 @@ class ilTemplate extends ilTemplateX
 		
 		$link_items["mailto:".ilUtil::prepareFormOutput($ilSetting->get("feedback_recipient"))] = array($lng->txt("contact_sysadmin"), false);
 				
-		if (DEVMODE && version_compare(PHP_VERSION,'5','>='))
+		if (DEVMODE)
 		{
 			$link_items[ilUtil::appendUrlParameterString($_SERVER["REQUEST_URI"], "do_dev_validate=xhtml")] = array("Validate", true);
 			$link_items[ilUtil::appendUrlParameterString($_SERVER["REQUEST_URI"], "do_dev_validate=accessibility")] = array("Accessibility", true);			

--- a/Services/User/classes/class.ilUserImportParser.php
+++ b/Services/User/classes/class.ilUserImportParser.php
@@ -941,11 +941,7 @@ class ilUserImportParser extends ilSaxParser
 						$this->personalPicture["content"] = base64_decode($this->cdata);
 						break;
 					case "UUEncode":
-						// this only works with PHP >= 5
-						if (version_compare(PHP_VERSION,'5','>='))
-						{
-							$this->personalPicture["content"] = convert_uudecode($this->cdata);
-						}
+    					$this->personalPicture["content"] = convert_uudecode($this->cdata);
 						break;
 				}
 				break;

--- a/Services/Utilities/classes/class.ilUtil.php
+++ b/Services/Utilities/classes/class.ilUtil.php
@@ -5014,23 +5014,10 @@ class ilUtil
 		// Temporary fix for feed.php 
 		if(!(bool)$a_set_cookie_invalid) $expire = 0;
 		else $expire = time() - (365*24*60*60);
-		
-		// setcookie() supports 5th parameter
-		// only for php version 5.2.0 and above
-		if( version_compare(PHP_VERSION, '5.2.0', '>=') )
-		{
-			// PHP version >= 5.2.0
-			setcookie( $a_cookie_name, $a_cookie_value, $expire,
-				IL_COOKIE_PATH, IL_COOKIE_DOMAIN, IL_COOKIE_SECURE, IL_COOKIE_HTTPONLY
-			);
-		}
-		else
-		{
-			// PHP version < 5.2.0
-			setcookie( $a_cookie_name, $a_cookie_value, $expire,
-				IL_COOKIE_PATH, IL_COOKIE_DOMAIN, IL_COOKIE_SECURE
-			);
-		}
+
+        setcookie( $a_cookie_name, $a_cookie_value, $expire,
+            IL_COOKIE_PATH, IL_COOKIE_DOMAIN, IL_COOKIE_SECURE, IL_COOKIE_HTTPONLY
+        );
 					
 		if((bool)$a_also_set_super_global) $_COOKIE[$a_cookie_name] = $a_cookie_value;
 	}

--- a/Services/Utilities/classes/class.ilUtil.php
+++ b/Services/Utilities/classes/class.ilUtil.php
@@ -5015,9 +5015,9 @@ class ilUtil
 		if(!(bool)$a_set_cookie_invalid) $expire = 0;
 		else $expire = time() - (365*24*60*60);
 
-        setcookie( $a_cookie_name, $a_cookie_value, $expire,
-            IL_COOKIE_PATH, IL_COOKIE_DOMAIN, IL_COOKIE_SECURE, IL_COOKIE_HTTPONLY
-        );
+		setcookie( $a_cookie_name, $a_cookie_value, $expire,
+			IL_COOKIE_PATH, IL_COOKIE_DOMAIN, IL_COOKIE_SECURE, IL_COOKIE_HTTPONLY
+		);
 					
 		if((bool)$a_also_set_super_global) $_COOKIE[$a_cookie_name] = $a_cookie_value;
 	}

--- a/setup/include/inc.setup_header.php
+++ b/setup/include/inc.setup_header.php
@@ -30,14 +30,7 @@
 */
 
 // remove notices from error reporting
-if (version_compare(PHP_VERSION, '5.3.0', '>='))
-{
-	error_reporting((ini_get("error_reporting") & ~E_NOTICE) & ~E_DEPRECATED);
-}
-else
-{
-	error_reporting(ini_get('error_reporting') & ~E_NOTICE);
-}
+error_reporting((ini_get("error_reporting") & ~E_NOTICE) & ~E_DEPRECATED);
 
 define("DEBUG",false);
 set_include_path("./Services/PEAR/lib".PATH_SEPARATOR.ini_get('include_path'));

--- a/setup/sql/dbupdate.php
+++ b/setup/sql/dbupdate.php
@@ -7832,11 +7832,7 @@ $wd = getcwd();
 
 global $log;
 
-// php5 downward complaince to php 4 dom xml
-if (version_compare(PHP_VERSION,'5','>='))
-{
-	include_once 'Services/Migration/DBUpdate_491/inc.xml5compliance.php';
-}
+include_once 'Services/Migration/DBUpdate_491/inc.xml5compliance.php';
 
 
 //  migration of page content


### PR DESCRIPTION
Current minimum requirement is PHP 5.3. http://www.ilias.de/docu/goto_docu_lm_367.html

Removing those checks also removes some effectively dead else-statements. No libraries changed.

spring-cleaning (Frühjahrsputz) ;-)
