### PR TITLE
make txt method in plugin-class non-final

### DIFF
--- a/Services/Component/classes/class.ilPlugin.php
+++ b/Services/Component/classes/class.ilPlugin.php
@@ -484,7 +484,7 @@ abstract class ilPlugin
 	/**
 	* Get Language Variable (prefix will be prepended automatically)
 	*/
-	public final function txt($a_var)
+	public  function txt($a_var)
 	{
 		global $lng;
 		$this->loadLanguageModule();


### PR DESCRIPTION
a pullrequest some weeks ago declared the method _goto in ilObjectPluginGUI static in ILIAS 5.0. In ILIAS 4.4 the method is still undeclared.
now a plugin can't be used in ilias 5 and ilias 4.4 when the method is overridden in the plugin-gui. see these two bugs: 
http://ilias.de/mantis/view.php?id=15785
http://ilias.de/mantis/view.php?id=15650

the pullrequest was merged by @mjansenDatabay but the component is maintained by @alex40724 
