### PR TITLE
Fix 16113: Ignore case of auto_https_detect_header_name

### DIFF
--- a/Services/Http/classes/class.ilHTTPS.php
+++ b/Services/Http/classes/class.ilHTTPS.php
@@ -138,7 +138,7 @@ class ilHTTPS
 
 	    if ($this->automaticHTTPSDetectionEnabled)
 		{
-		    $headerName = "HTTP_".str_replace("-","_",$this->headerName);
+		    $headerName = "HTTP_".str_replace("-","_", strtoupper($this->headerName));
 		   /* echo $headerName;
 		    echo $_SERVER[$headerName];*/
 		    if (strcasecmp($_SERVER[$headerName],$this->headerValue)==0) 


### PR DESCRIPTION
See http://www.ilias.de/mantis/view.php?id=16113 for details.

The auto_https_detect_header_name should be case-insensitive.
