### PR TITLE
loading correct language module for role assignment table

### DIFF
--- a/Services/User/classes/class.ilRoleAssignmentTableGUI.php
+++ b/Services/User/classes/class.ilRoleAssignmentTableGUI.php
@@ -19,9 +19,12 @@ class ilRoleAssignmentTableGUI extends ilTable2GUI
 	*/
 	function __construct($a_parent_obj, $a_parent_cmd)
 	{
-		global $ilCtrl, $lng, $ilAccess, $lng;
+		global $ilCtrl, $lng, $ilAccess;
+
+		$lng->loadLanguageModule('rbac');
 		
 		parent::__construct($a_parent_obj, $a_parent_cmd);
+
 		$this->setTitle($lng->txt("role_assignment"));
 		$this->setId("usrroleass");
 		$this->setDefaultOrderField("title");


### PR DESCRIPTION
Based on the issue: http://www.ilias.de/mantis/view.php?id=15554

Role-Assignment-Table should use the rbac language module. This should allow to remove many lang-vars in the common language module. 

This change might have side-effects on other modules (lang-vars from common-module have to move to the rbac-module)
