### PR TITLE
ilTreeTest: tests that lead to fatal errors fail now.

### DIFF
--- a/Services/Tree/test/ilTreeTest.php
+++ b/Services/Tree/test/ilTreeTest.php
@@ -98,6 +98,10 @@ class ilTreeTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testGetPathIdsUsingNestedSet()
 	{
+		// This test leads to a fatal error, as getPathIdsUsingNestedSets is
+		// not defined on ilTree.
+		$this->assertTrue(false, "Testcase leads to fatal error.");
+		
 		$tree = new ilTree(ROOT_FOLDER_ID);
 		$ids = $tree->getPathIdsUsingNestedSets(24,9); // Administration -> Public Chat => should return 9,14,24 (chat server settings)
 		
@@ -107,7 +111,6 @@ class ilTreeTest extends PHPUnit_Framework_TestCase
 		$ids = $tree->getPathIdsUsingNestedSets(24); // Administration -> Public Chat => should return 9,14,24 (chat server settings)
 		
 		$this->assertEquals($ids,array(1,9,14,24));
-
 	}
 	
 	/**
@@ -118,6 +121,10 @@ class ilTreeTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testGetPathIds()
 	{
+		// This test leads to a fatal error, as getPathIdsUsingNestedSets and
+		// getPathIdsUsingAdjacencyMap are not defined on ilTree.
+		$this->assertTrue(false, "Testcase leads to fatal error.");
+		
 		$tree = new ilTree(ROOT_FOLDER_ID);
 		$ids_ns = $tree->getPathIdsUsingNestedSets(24);
 		$ids_al = $tree->getPathIdsUsingAdjacencyMap(24);


### PR DESCRIPTION
Hi Stefan,

i made testGetPathIdsUsingNestedSet and testGetPathIds fail instead of letting them create fatal errors due to undefined methods. I hope that will let the CI recover from it's "Failed to parse xml report" errors. Maybe you could have a look at the two tests later on and make a real fix.

Regards!
