### PR TITLE
php unit: only define IL_PHPUNIT_TEST if it is not already defined.

### DIFF
--- a/Services/PHPUnit/classes/class.ilUnitUtil.php
+++ b/Services/PHPUnit/classes/class.ilUnitUtil.php
@@ -18,7 +18,9 @@ class ilUnitUtil
 		 */
 		global $ilErr;
 
-		define('IL_PHPUNIT_TEST', true);
+		if (!defined('IL_PHPUNIT_TEST')) {
+			define('IL_PHPUNIT_TEST', true);
+		}
 
 		session_id('phpunittest');
 		$_SESSION = array();


### PR DESCRIPTION
Maybe that fixes the error in the unit tests on the CI:

 PHPUnit_Framework_Error_Notice
 ilCourseTest::testMemberAgreement
 Constant IL_PHPUNIT_TEST already defined

and many other similarly failing tests...
