### PR TITLE
More Error Handlers for Whoops

### DIFF
--- a/Services/Exceptions/classes/class.ilDelegatingHandler.php
+++ b/Services/Exceptions/classes/class.ilDelegatingHandler.php
@@ -14,7 +14,7 @@
 * This class is not ment to be extended, as the definition of error handlers should be handled in one place 
 * in ilErrorHandling, so this class acts rather dump and asks ilErrorHandling for a handler.
 *
-* @author Richard Klees <meyer@leifos.com>
+* @author Richard Klees <richard.klees@concepts-and-training.de>
 * @version $Id$
 * 
 * 

--- a/Services/Exceptions/classes/class.ilPlainTextHandler.php
+++ b/Services/Exceptions/classes/class.ilPlainTextHandler.php
@@ -7,11 +7,10 @@
 *
 * This is used for better coexistence with xdebug, see #16627.
 *
-* @author Richard Klees <meyer@leifos.com>
+* @author Richard Klees <richard.klees@concepts-and-training.de>
 * @version $Id$
 */
 
-require_once("./Services/Exceptions/lib/Whoops/Run.php");
 require_once("./Services/Exceptions/lib/Whoops/Handler/HandlerInterface.php");
 require_once("./Services/Exceptions/lib/Whoops/Handler/Handler.php");
 
@@ -20,7 +19,7 @@ use Whoops\Exception\Formatter;
 
 class ilPlainTextHandler extends Handler {
 	const KEY_SPACE = 25;
-	
+
 	/**
 	 * Last missing method from HandlerInterface.
 	 *
@@ -31,7 +30,7 @@ class ilPlainTextHandler extends Handler {
 		echo $this->content();
 		echo "</pre>\n";
 	}
-	
+
 	/**
 	 * Assemble the output for this handler.
 	 *
@@ -74,7 +73,7 @@ class ilPlainTextHandler extends Handler {
 			if (count($content) > 0) {
 				foreach ($content as $key => $value) {
 					$key = str_pad($key, self::KEY_SPACE);
-					
+
 					// indent multiline values, first print_r, split in lines,
 					// indent all but first line, then implode again.
 					$first = true;
@@ -85,8 +84,7 @@ class ilPlainTextHandler extends Handler {
 								}
 								return str_pad("", self::KEY_SPACE).$line;
 							}, explode("\n", print_r($value, true))));
-					
-					
+
 					$ret .= "$key: $value\n";
 				}
 			}
@@ -96,7 +94,7 @@ class ilPlainTextHandler extends Handler {
 		}
 		return $ret;
 	}
-	
+
 	/**
 	 * Get the tables that should be rendered.
 	 *

--- a/Services/Exceptions/classes/class.ilPlainTextHandler.php
+++ b/Services/Exceptions/classes/class.ilPlainTextHandler.php
@@ -1,0 +1,118 @@
+<?php
+
+/* Copyright (c) 2015 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+/**
+* A Whoops error handler that prints the same content as the PrettyPageHandler but as plain text.
+*
+* This is used for better coexistence with xdebug, see #16627.
+*
+* @author Richard Klees <meyer@leifos.com>
+* @version $Id$
+*/
+
+require_once("./Services/Exceptions/lib/Whoops/Run.php");
+require_once("./Services/Exceptions/lib/Whoops/Handler/HandlerInterface.php");
+require_once("./Services/Exceptions/lib/Whoops/Handler/Handler.php");
+
+use Whoops\Handler\Handler;
+use Whoops\Exception\Formatter;
+
+class ilPlainTextHandler extends Handler {
+	const KEY_SPACE = 25;
+	
+	/**
+	 * Last missing method from HandlerInterface.
+	 *
+	 * @return null
+	 */
+	public function handle() {
+		echo "<pre>\n";
+		echo $this->content();
+		echo "</pre>\n";
+	}
+	
+	/**
+	 * Assemble the output for this handler.
+	 *
+	 * @return string
+	 */
+	protected function content() {
+		return $this->pageHeader()
+			  .$this->exceptionContent()
+			  .$this->tablesContent()
+			  ;
+	}
+
+	/**
+	 * Get the header for the page.
+	 *
+	 * @return string
+	 */
+	protected function pageHeader() {
+		return "";
+	}
+
+	/**
+	 * Get a short info about the exception.
+	 *
+	 * @return string
+	 */
+	protected function exceptionContent() {
+		return Formatter::formatExceptionPlain($this->getInspector());
+	}
+
+	/**
+	 * Get the header for the page.
+	 *
+	 * @return string
+	 */
+	protected function tablesContent() {
+		$ret = "";
+		foreach ($this->tables() as $title => $content) {
+			$ret .= "\n\n-- $title --\n\n";
+			if (count($content) > 0) {
+				foreach ($content as $key => $value) {
+					$key = str_pad($key, self::KEY_SPACE);
+					
+					// indent multiline values, first print_r, split in lines,
+					// indent all but first line, then implode again.
+					$first = true;
+					$value = implode("\n", array_map(function($line) use (&$first) {
+								if ($first) {
+									$first = false;
+									return $line;
+								}
+								return str_pad("", self::KEY_SPACE).$line;
+							}, explode("\n", print_r($value, true))));
+					
+					
+					$ret .= "$key: $value\n";
+				}
+			}
+			else {
+				$ret .= "empty\n";
+			}
+		}
+		return $ret;
+	}
+	
+	/**
+	 * Get the tables that should be rendered.
+	 *
+	 * @return array 	$title => $table
+	 */
+	protected function tables() {
+		return array
+			( "GET Data" => $_GET
+			, "POST Data" => $_POST
+			, "Files" => $_FILES
+			, "Cookies" => $_COOKIES
+			, "Session" => isset($_SESSION) ? $_SESSION : array()
+			, "Server/Request Data" => $_SERVER
+			, "Environment Variables" => $_ENV
+			);
+	}
+}
+
+?>

--- a/Services/Exceptions/classes/class.ilTestingHandler.php
+++ b/Services/Exceptions/classes/class.ilTestingHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+/* Copyright (c) 2015 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+/**
+* A Whoops error handler for testing.
+*
+* This yields the same output as the plain text handler, but prints a nice message to the tester on top of
+* the page.
+*
+* @author Richard Klees <richard.klees@concepts-and-training.de>
+* @version $Id$
+*/
+
+require_once("Services/Exceptions/classes/class.ilPlainTextHandler.php");
+
+class ilTestingHandler extends ilPlainTextHandler {
+	/**
+	 * Get the header for the page.
+	 *
+	 * @return string
+	 */
+	protected function pageHeader() {
+		return "DEAR TESTER! AN ERROR OCCURRED... PLEASE INCLUDE THE FOLLOWING OUTPUT AS ADDITIONAL INFORMATION IN YOUR BUG REPORT.\n\n";
+	}
+
+}

--- a/Services/Init/classes/class.ilErrorHandling.php
+++ b/Services/Init/classes/class.ilErrorHandling.php
@@ -35,6 +35,7 @@ require_once("./Services/Exceptions/lib/Whoops/Util/Misc.php");
 
 require_once("Services/Exceptions/classes/class.ilDelegatingHandler.php");
 require_once("Services/Exceptions/classes/class.ilPlainTextHandler.php");
+require_once("Services/Exceptions/classes/class.ilTestingHandler.php");
 
 use Whoops\Run;
 use Whoops\Handler\PrettyPageHandler;
@@ -372,6 +373,8 @@ class ilErrorHandling extends PEAR
 		global $ilLog;
 		
 		switch (ERROR_HANDLER) {
+			case "TESTING":
+				return new ilTestingHandler();
 			case "PLAIN_TEXT":
 				return new ilPlainTextHandler();
 			case "PRETTY_PAGE":

--- a/Services/Init/classes/class.ilErrorHandling.php
+++ b/Services/Init/classes/class.ilErrorHandling.php
@@ -368,7 +368,16 @@ class ilErrorHandling extends PEAR
 	 * @return Whoops\Handler
 	 */
 	protected function devmodeHandler() {
-		return new PrettyPageHandler();
+		global $ilLog;
+		
+		switch (ERROR_HANDLER) {
+			case "PRETTY_PAGE":
+				return new PrettyPageHandler();
+			default:
+				$ilLog->write("Unknown or undefined error handler '".ERROR_HANDLER."'. "
+							 ."Falling back to PrettyPageHandler.");
+				return new PrettyPageHandler();
+		}
 	}
 	
 	/**

--- a/Services/Init/classes/class.ilErrorHandling.php
+++ b/Services/Init/classes/class.ilErrorHandling.php
@@ -34,6 +34,7 @@ require_once("./Services/Exceptions/lib/Whoops/Util/TemplateHelper.php");
 require_once("./Services/Exceptions/lib/Whoops/Util/Misc.php");
 
 require_once("Services/Exceptions/classes/class.ilDelegatingHandler.php");
+require_once("Services/Exceptions/classes/class.ilPlainTextHandler.php");
 
 use Whoops\Run;
 use Whoops\Handler\PrettyPageHandler;
@@ -371,6 +372,8 @@ class ilErrorHandling extends PEAR
 		global $ilLog;
 		
 		switch (ERROR_HANDLER) {
+			case "PLAIN_TEXT":
+				return new ilPlainTextHandler();
 			case "PRETTY_PAGE":
 				return new PrettyPageHandler();
 			default:

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -330,6 +330,7 @@ class ilInitialisation
 		define ("SYSTEM_FOLDER_ID",$ilClientIniFile->readVariable('system','SYSTEM_FOLDER_ID'));
 		define ("ROLE_FOLDER_ID",$ilClientIniFile->readVariable('system','ROLE_FOLDER_ID'));
 		define ("MAIL_SETTINGS_ID",$ilClientIniFile->readVariable('system','MAIL_SETTINGS_ID'));
+		define ("ERROR_HANDLER",$ilClientIniFile->readVariable('system', 'ERROR_HANDLER'));
 		
 		// this is for the online help installation, which sets OH_REF_ID to the
 		// ref id of the online module


### PR DESCRIPTION
Enhancement for error handling, as we decided on JF:
- introduces two new error handlers, one with plain text output and one for testing
- introduces a new ini setting system/ERROR_HANDLER with possible values TESTING, PLAIN_TEXT and PRETTY_PAGE
- no explicit switch for xdebug in the code, as one can use PLAIN_TEXT error handler in this case
