### PR TITLE
Remove outdated $a_initial_call-parameter to ilContainerGUI::showRepTree

### DIFF
--- a/Modules/Category/classes/class.ilObjCategoryGUI.php
+++ b/Modules/Category/classes/class.ilObjCategoryGUI.php
@@ -59,7 +59,7 @@ class ilObjCategoryGUI extends ilContainerGUI
 		$cmd = $this->ctrl->getCmd();
 		
 		// show repository tree
-		$this->showRepTree(true);
+		$this->showRepTree();
 		
 		switch($next_class)
 		{

--- a/Modules/Course/classes/class.ilObjCourseGUI.php
+++ b/Modules/Course/classes/class.ilObjCourseGUI.php
@@ -4251,7 +4251,7 @@ class ilObjCourseGUI extends ilContainerGUI
 		$this->prepareOutput();
 		
 		// show repository tree
-		$this->showRepTree(true);
+		$this->showRepTree();
 		
 		// add entry to navigation history
 		if(!$this->getCreationMode() &&

--- a/Modules/Folder/classes/class.ilObjFolderGUI.php
+++ b/Modules/Folder/classes/class.ilObjFolderGUI.php
@@ -81,7 +81,7 @@ class ilObjFolderGUI extends ilContainerGUI
 		$cmd = $this->ctrl->getCmd();
 		
 		// show repository tree
-		$this->showRepTree(true);
+		$this->showRepTree();
 
 		switch ($next_class)
 		{			

--- a/Modules/Group/classes/class.ilObjGroupGUI.php
+++ b/Modules/Group/classes/class.ilObjGroupGUI.php
@@ -45,7 +45,7 @@ class ilObjGroupGUI extends ilContainerGUI
 		$this->prepareOutput();
 		
 		// show repository tree
-		$this->showRepTree(true);
+		$this->showRepTree();
 
 		// add entry to navigation history
 		if (!$this->getCreationMode() &&

--- a/Modules/RootFolder/classes/class.ilObjRootFolderGUI.php
+++ b/Modules/RootFolder/classes/class.ilObjRootFolderGUI.php
@@ -109,7 +109,7 @@ class ilObjRootFolderGUI extends ilContainerGUI
 		$cmd = $this->ctrl->getCmd();
 		
 		// show repository tree
-		$this->showRepTree(true);
+		$this->showRepTree();
 		
 		switch($next_class)
 		{

--- a/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeGUI.php
+++ b/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeGUI.php
@@ -113,7 +113,7 @@ class ilObjStudyProgrammeGUI extends ilContainerGUI {
 		parent::prepareOutput();
 		
 		// show repository tree
-		$this->showRepTree(true);
+		$this->showRepTree();
 
 		switch ($next_class) {
 			case "ilinfoscreengui":

--- a/Services/Container/classes/class.ilContainerGUI.php
+++ b/Services/Container/classes/class.ilContainerGUI.php
@@ -3613,11 +3613,8 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 		
 	/**
 	 * Show tree
-	 *
-	 * @param boolean $a_initial_call should be true if not called through standard
-	 *        $ilCtrl->getCmd() procedure 
 	 */
-	function showRepTree($a_initial_call = false)
+	function showRepTree()
 	{
 		global $tpl, $ilUser, $ilSetting, $ilCtrl;
 		


### PR DESCRIPTION
That parameter seems to be useless.
