### PR TITLE
bug fix: display advanced meta data on info screen

### DIFF
--- a/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeGUI.php
+++ b/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeGUI.php
@@ -612,36 +612,17 @@ class ilObjStudyProgrammeGUI extends ilContainerGUI {
 	protected function fillInfoScreen($a_info_screen) {
 		require_once('./Services/AdvancedMetaData/classes/class.ilAdvancedMDValues.php');
 		require_once('./Services/AdvancedMetaData/classes/class.ilAdvancedMDRecord.php');
+		require_once('Services/AdvancedMetaData/classes/class.ilAdvancedMDRecordGUI.php');
 		require_once('./Services/ADT/classes/class.ilADTFactory.php');
 
 		$type = ilStudyProgrammeType::find($this->object->getSubtypeId());
 		if (!$type) {
 			return;
 		}
-		$assigned_record_ids = $type->getAssignedAdvancedMDRecordIds();
 
-		foreach (ilAdvancedMDValues::getInstancesForObjectId($this->object->getId(), 'prg') as $record_id => $a_values) {
-			// Skip record ids not assigned to the type
-			if (!in_array($record_id, $assigned_record_ids)) {
-				continue;
-			}
-
-			// Note that we have to do this because with the instances above the sub-type and sub-id are missing...
-			$a_values = new ilAdvancedMDValues($record_id, $this->object->getId(), 'prg_type', $this->object->getSubtypeId());
-
-			// this correctly binds group and definitions
-			$a_values->read();
-
-			$a_info_screen->addSection(ilAdvancedMDRecord::_lookupTitle($record_id));
-
-			$defs = $a_values->getDefinitions();
-			foreach ($a_values->getADTGroup()->getElements() as $element_id => $element) {
-				if (!$element->isNull()) {
-					$a_info_screen->addProperty($defs[$element_id]->getTitle(), ilADTFactory::getInstance()->getPresentationBridgeForInstance($element)
-						->getHTML());
-				}
-			}
-		}
+		$record_gui = new ilAdvancedMDRecordGUI(ilAdvancedMDRecordGUI::MODE_INFO, 'prg', $this->object->getId(), 'prg_type', $this->object->getSubtypeId());
+		$record_gui->setInfoObject($a_info_screen);
+		$record_gui->parse();
 	}
 
 	protected function edit(){

--- a/Services/AdvancedMetaData/classes/class.ilAdvancedMDRecordGUI.php
+++ b/Services/AdvancedMetaData/classes/class.ilAdvancedMDRecordGUI.php
@@ -343,7 +343,7 @@ class ilAdvancedMDRecordGUI
 		include_once('Services/AdvancedMetaData/classes/class.ilAdvancedMDRecord.php');
 		include_once('Services/ADT/classes/class.ilADTFactory.php');
 								
-		foreach(ilAdvancedMDValues::getInstancesForObjectId($this->obj_id, $this->obj_type) as $record_id => $a_values)
+		foreach(ilAdvancedMDValues::getInstancesForObjectId($this->obj_id, $this->obj_type, $this->sub_type, $this->sub_id) as $record_id => $a_values)
 		{					
 			// this correctly binds group and definitions
 			$a_values->read();

--- a/Services/AdvancedMetaData/classes/class.ilAdvancedMDValues.php
+++ b/Services/AdvancedMetaData/classes/class.ilAdvancedMDValues.php
@@ -51,7 +51,7 @@ class ilAdvancedMDValues
 	 * @param string $a_obj_type
 	 * @return array
 	 */
-	public static function getInstancesForObjectId($a_obj_id, $a_obj_type = null)
+	public static function getInstancesForObjectId($a_obj_id, $a_obj_type = null, $a_sub_type = "-", $a_sub_id = 0)
 	{		
 		$res = array();
 		
@@ -61,10 +61,10 @@ class ilAdvancedMDValues
 		}
 		
 		include_once "Services/AdvancedMetaData/classes/class.ilAdvancedMDRecord.php";
-		foreach(ilAdvancedMDRecord::_getSelectedRecordsByObject($a_obj_type, $a_obj_id) as $record)
+		foreach(ilAdvancedMDRecord::_getSelectedRecordsByObject($a_obj_type, $a_obj_id, $a_sub_type) as $record)
 		{
 			$id = $record->getRecordId();
-			$res[$id] = new self($id, $a_obj_id);
+			$res[$id] = new self($id, $a_obj_id, $a_sub_type, $a_sub_id);
 		}
 	
 		return $res;


### PR DESCRIPTION
Referencing to Mantis #17650
AMD would not be display on info screen, if there are defined in sub type of object.
