### PR TITLE
neue implementierung von ilContext

### DIFF
--- a/Services/Context/classes/class.ilContext.php
+++ b/Services/Context/classes/class.ilContext.php
@@ -6,6 +6,7 @@
  * Service context (factory) class
  * 
  * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>
+ * @author Stefan Hecken <stefan.hecken@concepts-and-training.de>
  * @version $Id$
  * 
  * @ingroup ServicesContext
@@ -13,94 +14,36 @@
 class ilContext
 {		
 	protected static $class_name; // [string]
-	protected static $type; // [int]	
+	protected static $type; // [string]	
 	
-	const CONTEXT_WEB = 1;
-	const CONTEXT_CRON = 2;
-	const CONTEXT_RSS = 3;
-	const CONTEXT_ICAL = 4;
-	const CONTEXT_SOAP = 5;
-	const CONTEXT_WEBDAV = 6;
-	const CONTEXT_RSS_AUTH = 7;
-	const CONTEXT_WEB_ACCESS_CHECK = 8;
-	const CONTEXT_SESSION_REMINDER = 9;
-	const CONTEXT_SOAP_WITHOUT_CLIENT = 10;
-	const CONTEXT_UNITTEST = 11;
-	const CONTEXT_REST = 12;
-	const CONTEXT_SCORM = 13;
-	const CONTEXT_WAC = 14;
+	const CONTEXT_WEB = "ilContextWeb";
+	const CONTEXT_CRON = "ilContextCron";
+	const CONTEXT_RSS = "ilContextRss";
+	const CONTEXT_ICAL = "ilContextIcal";
+	const CONTEXT_SOAP = "ilContextSoap";
+	const CONTEXT_WEBDAV = "ilContextWebdav";
+	const CONTEXT_RSS_AUTH = "ilContextRssAuth";
+	const CONTEXT_WEB_ACCESS_CHECK = "ilContextWebAccessCheck";
+	const CONTEXT_SESSION_REMINDER = "ilContextSessionReminder";
+	const CONTEXT_SOAP_WITHOUT_CLIENT = "ilContextSoapWithoutClient";
+	const CONTEXT_UNITTEST = "ilContextUnitTest";
+	const CONTEXT_REST = "ilContextRest";
+	const CONTEXT_SCORM = "ilContextScorm";
+	const CONTEXT_WAC = "ilContextWAC";
 	
 	/**
 	 * Init context by type
 	 * 
-	 * @param int $a_type 
+	 * @param string $a_type 
 	 * @return bool
 	 */
 	public static function init($a_type)
 	{
-		$class_name = self::getClassForType($a_type);
-		if($class_name)
-		{
-			include_once "Services/Context/classes/class.".$class_name.".php";
-			self::$class_name = $class_name;
-			self::$type = $a_type;
-			return true;
-		}
-		return false;
-	}
-	
-	/**
-	 * Get class name for type id
-	 * 	 
-	 * @param int $a_type
-	 * @return string 
-	 */
-	protected function getClassForType($a_type)
-	{
-		switch($a_type)
-		{
-			case self::CONTEXT_WEB:
-				return "ilContextWeb";
-				
-			case self::CONTEXT_CRON:
-				return "ilContextCron";
-				
-			case self::CONTEXT_RSS:
-				return "ilContextRss";
-				
-			case self::CONTEXT_ICAL:
-				return "ilContextIcal";
-				
-			case self::CONTEXT_SOAP:
-				return "ilContextSoap";
-			
-			case self::CONTEXT_WEBDAV:
-				return "ilContextWebdav";	
-				
-			case self::CONTEXT_RSS_AUTH:
-				return "ilContextRssAuth";	
-				
-			case self::CONTEXT_WEB_ACCESS_CHECK:
-				return "ilContextWebAccessCheck";	
-			
-			case self::CONTEXT_SESSION_REMINDER:
-				return "ilContextSessionReminder";	
-				
-			case self::CONTEXT_SOAP_WITHOUT_CLIENT:
-				return "ilContextSoapWithoutClient";
-				
-			case self::CONTEXT_UNITTEST:
-				return "ilContextUnitTest";
-				
-			case self::CONTEXT_REST:
-				return 'ilContextRest';
-
-			case self::CONTEXT_SCORM:
-				return 'ilContextScorm';
-
-			case self::CONTEXT_WAC:
-				return 'ilContextWAC';
-		}
+		include_once "Services/Context/classes/class.".$a_type.".php";
+		self::$class_name = $a_type;
+		self::$type = $a_type;
+		
+		return true;
 	}
 	
 	/**
@@ -199,7 +142,7 @@ class ilContext
 	/**
 	 * Get context type
 	 * 
-	 * @return int
+	 * @return string
 	 */
 	public static function getType()
 	{

--- a/Services/Context/test/class.ilContextExtended.php
+++ b/Services/Context/test/class.ilContextExtended.php
@@ -1,0 +1,30 @@
+<?php
+
+/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/** 
+ * Extended Service context (factory) class
+ *
+ * ONLY FOR TESTS!!!!
+ * 
+ * @author Stefan Hecken <stefan.hecken@concepts-and-training.de>
+ * @version $Id$
+ * 
+ * @ingroup ServicesContext
+ */
+require_once("Services/Context/classes/class.ilContext.php");
+
+class ilContextExtended extends ilContext
+{		
+	/**
+	 * Get context className
+	 * 
+	 * @return int
+	 */
+	public static function getClassName()
+	{
+		return self::$class_name;
+	}
+}
+
+?>

--- a/Services/Context/test/ilContextTest.php
+++ b/Services/Context/test/ilContextTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * TestCase for the ilContext
+ *
+ * @author Stefan Hecken <stefan.hecken@concepts-and-training.de>
+ * @version 1.0.0
+ */
+class ilContextTest extends PHPUnit_Framework_TestCase {
+	protected $backupGlobals = FALSE;
+
+	protected function setUp() {
+		PHPUnit_Framework_Error_Deprecated::$enabled = FALSE;
+		require_once("Services/Context/test/class.ilContextExtended.php");
+	}
+	
+	/**
+	* test init ilContext
+	*
+	* @dataProvider contextProvider
+	*/
+	public function testInit($context, $className) {
+		$context_obj = ilContextExtended::init($context);
+		$this->assertTrue($context_obj);
+		$this->assertEquals(ilContextExtended::getType(), $context);
+		$this->assertEquals(ilContextExtended::getClassName(), $className);
+	}
+
+	public function contextProvider() {
+		require_once("Services/Context/test/class.ilContextExtended.php");
+
+		return array(array(ilContextExtended::CONTEXT_WEB,"ilContextWeb"),
+					array(ilContextExtended::CONTEXT_CRON,"ilContextCron"),
+					array(ilContextExtended::CONTEXT_RSS,"ilContextRss"),
+					array(ilContextExtended::CONTEXT_ICAL,"ilContextIcal"),
+					array(ilContextExtended::CONTEXT_SOAP,"ilContextSoap"),
+					array(ilContextExtended::CONTEXT_WEBDAV,"ilContextWebdav"),
+					array(ilContextExtended::CONTEXT_RSS_AUTH,"ilContextRssAuth"),
+					array(ilContextExtended::CONTEXT_WEB_ACCESS_CHECK,"ilContextWebAccessCheck"),
+					array(ilContextExtended::CONTEXT_SESSION_REMINDER,"ilContextSessionReminder"),
+					array(ilContextExtended::CONTEXT_SOAP_WITHOUT_CLIENT,"ilContextSoapWithoutClient"),
+					array(ilContextExtended::CONTEXT_UNITTEST,"ilContextUnitTest"),
+					array(ilContextExtended::CONTEXT_REST,"ilContextRest"),
+					array(ilContextExtended::CONTEXT_SCORM,"ilContextScorm"),
+					array(ilContextExtended::CONTEXT_WAC,"ilContextWAC"));
+	}
+}

--- a/Services/Context/test/ilServicesContextSuite.php
+++ b/Services/Context/test/ilServicesContextSuite.php
@@ -7,7 +7,7 @@
 class ilServicesContextSuite extends PHPUnit_Framework_TestSuite {
     public static function suite()
     {
-        $suite = new ilModulesStudyProgrammeSuite();
+        $suite = new ilServicesContextSuite();
 
         require_once("/Services/Context/test/ilContextTest.php");
 

--- a/Services/Context/test/ilServicesContextSuite.php
+++ b/Services/Context/test/ilServicesContextSuite.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Context Test-Suite
+ * @author Stefan Hecken <stefan.hecken@concepts-and-training.de>
+ * @version 1.0.0
+ */
+class ilServicesContextSuite extends PHPUnit_Framework_TestSuite {
+    public static function suite()
+    {
+        $suite = new ilModulesStudyProgrammeSuite();
+
+        require_once("/Services/Context/test/ilContextTest.php");
+
+        $suite->addTestSuite("ilContextTest");
+
+        return $suite;
+    }
+}


### PR DESCRIPTION
Hallo zusammen,

wir haben uns die Klasse ilContext einmal angesehen und sind zu dem Entschluss gekommen, das eine relative kleine Änderung einen großen Nutzen haben könnte.

Die Idee ist in diesem Request einmal umgesetzt. 
Unserer Meinung nach, ergibt sich daraus keinerlei Veränderung an der aktuellen Verwendung. Um dies sicher zu stellen, haben wir UnitTests hinzugefügt.

Wir sehen folgende Vorteile dieser Implementierung:
- die Verwendung der Klasse ist noch einfacher
- die Einführung eines neuen Contexts ist deutlich vereinfacht. Man muss nicht die Klasse ilContext verändern
