### PR TITLE
Hotfix for mantis 17842

### DIFF
--- a/setup/sql/5_1_hotfixes.php
+++ b/setup/sql/5_1_hotfixes.php
@@ -37,3 +37,54 @@ if($ilDB->tableColumnExists('svy_times', 'first_question'))
 	);
 }
 ?>
+<#4>
+	<?php
+	require_once('./Services/Component/classes/class.ilPluginAdmin.php');
+	require_once('./Services/Component/classes/class.ilPlugin.php');
+	require_once('./Services/UICore/classes/class.ilCtrl.php');
+
+	// Mantis #17842
+	/** @var $ilCtrl ilCtrl */
+	global $ilCtrl, $ilPluginAdmin;
+	if (is_null($ilPluginAdmin)) {
+		$GLOBALS['ilPluginAdmin'] = new ilPluginAdmin();
+	}
+	if (is_null($ilCtrl)) {
+		$GLOBALS['ilCtrl'] = new ilCtrl();
+	}
+	global $ilCtrl;
+
+	function writeCtrlClassEntry(ilPluginSlot $slot, array $plugin_data) {
+		global $ilCtrl;
+		$prefix = $slot->getPrefix() . '_' . $plugin_data['id'];
+		$ilCtrl->insertCtrlCalls("ilobjcomponentsettingsgui", ilPlugin::getConfigureClassName($plugin_data['name']), $prefix);
+	}
+
+	include_once("./Services/Component/classes/class.ilModule.php");
+	$modules = ilModule::getAvailableCoreModules();
+	foreach ($modules as $m) {
+		$plugin_slots = ilComponent::lookupPluginSlots(IL_COMP_MODULE, $m["subdir"]);
+		foreach ($plugin_slots as $ps) {
+			include_once("./Services/Component/classes/class.ilPluginSlot.php");
+			$slot = new ilPluginSlot(IL_COMP_MODULE, $m["subdir"], $ps["id"]);
+			foreach ($slot->getPluginsInformation() as $p) {
+				if (ilPlugin::hasConfigureClass($slot->getPluginsDirectory(), $p["name"]) && $ilCtrl->checkTargetClass(ilPlugin::getConfigureClassName($p["name"]))) {
+					writeCtrlClassEntry($slot, $p);
+				}
+			}
+		}
+	}
+	include_once("./Services/Component/classes/class.ilService.php");
+	$services = ilService::getAvailableCoreServices();
+	foreach ($services as $s) {
+		$plugin_slots = ilComponent::lookupPluginSlots(IL_COMP_SERVICE, $s["subdir"]);
+		foreach ($plugin_slots as $ps) {
+			$slot = new ilPluginSlot(IL_COMP_SERVICE, $s["subdir"], $ps["id"]);
+			foreach ($slot->getPluginsInformation() as $p) {
+				if (ilPlugin::hasConfigureClass($slot->getPluginsDirectory(), $p["name"]) && $ilCtrl->checkTargetClass(ilPlugin::getConfigureClassName($p["name"]))) {
+					writeCtrlClassEntry($slot, $p);
+				}
+			}
+		}
+	}
+	?>


### PR DESCRIPTION
The following DB-Update step introduces a bug when updating ILIAS to 5.x.1: https://github.com/ILIAS-eLearning/ILIAS/blob/release_5-1/setup/sql/dbupdate_04.php#L7555

Configurable plugins are missing an entry in the table `ctrl_calls`. This pull-request fixes this with a hotfix. I'm not sure if this is the best way of doing it... the code to get all the plugins is copied from the table listing all plugins under `Administration > Plugins`. Maybe this logic should be factored out and delegated to `ilPluginAdmin` or some other class, as it's quite a lot of code to write to get the plugins... or maybe there's a better way for this at all :)
