### PR TITLE
Set default value for file object rating state

### DIFF
--- a/Modules/File/classes/class.ilObjFile.php
+++ b/Modules/File/classes/class.ilObjFile.php
@@ -22,7 +22,7 @@ class ilObjFile extends ilObject2
 	var $filemaxsize = "20000000";	// not used yet
 	var $raise_upload_error;
 	var $mode = "object";
-	protected $rating;
+	protected $rating = false;
 	
 	private $file_storage = null;
 


### PR DESCRIPTION
Without this default value there is an issue with the XML import (ilFileXMLParser). When no "Rating" element is given $rating defaults to NULL which causes a constraint violation.

This should by cherry-picked to 5.1.x and 5.0.x.
