### PR TITLE
Error Handling: use error.php via include in case of fatal error (#18313)

### DIFF
--- a/Services/Init/classes/class.ilErrorHandling.php
+++ b/Services/Init/classes/class.ilErrorHandling.php
@@ -359,6 +359,14 @@ class ilErrorHandling extends PEAR
 	 */
 	protected function defaultHandler() {
 		return new CallbackHandler(function(Exception $exception, Inspector $inspector, Run $run) {
+			if ($exception instanceof \Whoops\Exception\ErrorException
+			and $exception->getCode() == E_ERROR) {
+				global $tpl, $lng, $tree;
+				$_SESSION["failure"] = $exception->getMessage();
+				include("error.php");
+				exit();
+			}
+
 			require_once("Services/Utilities/classes/class.ilUtil.php");
 			ilUtil::sendFailure($exception->getMessage(), true);
 			ilUtil::redirect("error.php");


### PR DESCRIPTION
- use error.php via include instead of redirect when whoops catches a fatal error
- i could have gotten rid of the redirect to error.php completely and always include it, but i don't know the reason (if there is any) for the redirect
