### PR TITLE
Remove state_changed_inside as by SF decision

### DIFF
--- a/Services/Object/classes/class.ilObjectListGUI.php
+++ b/Services/Object/classes/class.ilObjectListGUI.php
@@ -1247,49 +1247,6 @@ class ilObjectListGUI
 				}
 			}
 			// END WebDAV Display warning for invisible files and files with special characters
-		
-			// BEGIN ChangeEvent: display changes.
-			require_once('Services/Tracking/classes/class.ilChangeEvent.php');
-			if (ilChangeEvent::_isActive())
-			{
-				global $ilias, $lng, $ilUser;
-				if ($ilias->account->getId() != ANONYMOUS_USER_ID)
-				{
-					// Performance improvement: for container objects
-					// we only display 'changed inside' events, for
-					// leaf objects we only display 'object new/changed'
-					// events
-					$isContainer = in_array($this->type, array('cat', 'fold', 'crs', 'grp'));
-					if($isContainer)
-					{
-						$state = ilChangeEvent::_lookupInsideChangeState($this->obj_id, $ilUser->getId());
-						if($state > 0)
-						{
-							$props[] = array(
-								"alert" => true,
-								"value" => $lng->txt('state_changed_inside'),
-								'propertyNameVisible' => false);
-						}
-					}
-					/*
-					 * elseif(!$objDefinition->isAdministrationObject(ilObject::_lookupType($this->obj_id)))
-					 * 
-					 * only files support write events properly
-					 */
-					elseif($this->type == "file")
-					{
-						$state = ilChangeEvent::_lookupChangeState($this->obj_id, $ilUser->getId());
-						if($state > 0)
-						{
-							$props[] = array(
-								"alert" => true,
-								"value" => $lng->txt(($state == 1) ? 'state_unread' : 'state_changed'),
-								'propertyNameVisible' => false);
-						}
-					}
-				}
-			}
-			// END ChangeEvent: display changes.
 		}
 
 		return $props;

--- a/Services/Tracking/classes/class.ilChangeEvent.php
+++ b/Services/Tracking/classes/class.ilChangeEvent.php
@@ -678,70 +678,7 @@ class ilChangeEvent
 			return 0; // user catched all write events, report as unchanged (0)
 		}
 	}
-	/**
-	 * Returns the changed state of objects which are children of the specified
-	 * parent object.
-	 *
-	 * Note this gives a different result than calling _lookupChangeState of
-	 * each child object. This is because, this function treats a catch on the
-	 * write events on the parent as a catch up for all child objects.
-	 * This difference was made, because it greatly improves performance
-	 * of this function. 
-	 *
-	 * @param $parent_obj_id int The object id of the parent object.
-	 * @param $usr_id int The user who is interested into these events.
-	 * @return 0 = object has not been changed inside
-	 *         1 = object has been changed inside
-	 */
-	public static function _lookupInsideChangeState($parent_obj_id, $usr_id)
-	{
-		global $ilDB;
-		
-		$q = "SELECT ts ".
-			"FROM catch_write_events ".
-			"WHERE obj_id=".$ilDB->quote($parent_obj_id)." ".
-			"AND usr_id=".$ilDB->quote($usr_id);
-		$r = $ilDB->query($q);
-		$catchup = null;
-		while ($row = $r->fetchRow(ilDBConstants::FETCHMODE_ASSOC)) {
-			$catchup = $row['ts'];
-		}
-
-		if($catchup == null)
-		{
-			$ilDB->setLimit(1);
-			$query = sprintf('SELECT * FROM write_event '.
-				'WHERE parent_obj_id = %s '.
-				'AND usr_id <> %s ',
-				$ilDB->quote($parent_obj_id,'integer'),
-				$ilDB->quote($usr_id,'integer'));
-			$res = $ilDB->query($query);
-		}
-		else
-		{
-			$ilDB->setLimit(1);
-			$query = sprintf('SELECT * FROM write_event '.
-				'WHERE parent_obj_id = %s '.
-				'AND usr_id <> %s '.
-				'AND ts > %s ',
-				$ilDB->quote($parent_obj_id,'integer'),
-				$ilDB->quote($usr_id,'integer'),
-				$ilDB->quote($catchup,'timestamp'));
-			$res = $ilDB->query($query);
-		}
-		$numRows = $res->numRows();
-		if ($numRows > 0)
-		{
-			$row = $ilDB->fetchAssoc($res);
-			// if we have write events, and user never catched one, report as new (1)
-			// if we have write events, and user catched an old write event, report as changed (2)
-			return ($catchup == null) ? 1 : 2;
-		}
-		else 
-		{
-			return 0; // user catched all write events, report as unchanged (0)
-		}
-	}
+	
 	/**
 	 * Reads all read events which occured on the object 
 	 * which happened after the last time the user caught up with them.

--- a/Services/Tracking/test/ilTrackingTest.php
+++ b/Services/Tracking/test/ilTrackingTest.php
@@ -56,7 +56,6 @@ class ilTrackingTest extends PHPUnit_Framework_TestCase
 
 		$res = ilChangeEvent::_lookupUncaughtWriteEvents(9,$ilUser->getId());
 		$res = ilChangeEvent::_lookupChangeState(9,$ilUser->getId());
-		$res = ilChangeEvent::_lookupInsideChangeState(9,$ilUser->getId());
 	}
 	
 	/**


### PR DESCRIPTION
As this is my first a little bit bigger commit, I send it per pull request:
I removed the part responsible for showing the changed_inside-information. I left the settings and so on as they are also used for tracking.
