### PR TITLE
19419: use needsUpdate from PluginAdmin to check an update 

### DIFF
--- a/Services/Component/classes/class.ilPlugin.php
+++ b/Services/Component/classes/class.ilPlugin.php
@@ -742,7 +742,7 @@ abstract class ilPlugin
 	{
 		global $ilPluginAdmin;
 
-		return $ilPluginAdmin->isActive($this->getComponentType(),
+		return $ilPluginAdmin->needsUpdate($this->getComponentType(),
 			$this->getComponentName(), $this->getSlotId(), $this->getPluginName());
 	}
 


### PR DESCRIPTION
 for plugin is necessary

I tried to install plugins via cli script and wondered why the plugin update is not done. Looked into the ilPlugin and found, in my opinion this little bug. The check for _needsUpdate_ used the ilPluginAdmin method _isActive_.

This bug is also in 4.3 and 4.4. I decide to fix it in 5.0 because there will be no more releases for 4.4 or earlier.

Fixed the bug in this little PR.
