### PR TITLE
Mail System: Changes regarding FROM/REPLY-TO according to SPF

### DIFF
--- a/Services/Mail/classes/class.ilMimeMail.php
+++ b/Services/Mail/classes/class.ilMimeMail.php
@@ -336,7 +336,17 @@ class ilMimeMail
 			$mail->Sender = $ilSetting->get('mail_system_return_path', '');
 		}
 
-		$mail->SetFrom($this->xheaders['From'], $this->xheaders['FromName']);
+		require_once 'Services/Mail/classes/class.ilMail.php';
+		$addr = ilMail::getIliasMailerAddress();
+		if($this->xheaders['From'] == $addr[0])
+		{
+			$mail->setFrom($this->xheaders['From'], $this->xheaders['FromName']);
+		}
+		else
+		{
+			$mail->addReplyTo($this->xheaders['From'], $this->xheaders['FromName']);
+			$mail->setFrom($addr[0], $addr[1]);
+		}
 		foreach($this->sendto as $recipients)
 		{
 			$recipient_pieces = array_filter(array_map('trim', explode(',', $recipients)));


### PR DESCRIPTION
Mail system changes according to SPF (Sender Policy Framework): FROM should be always set to the address configured in the ILIAS mail administration/REPLY-TO should be set to the user's email address when an email was created manually by a user.
