### PR TITLE
XML-User-Import default mapping mode

### DIFF
--- a/Services/User/classes/class.ilUserImportParser.php
+++ b/Services/User/classes/class.ilUserImportParser.php
@@ -297,7 +297,7 @@ class ilUserImportParser extends ilSaxParser
 		$this->localRoleCache = array();
 		$this->parentRolesCache = array();
 		$this->send_mail = false;
-		$this->mapping_mode = IL_USER_MAPPING_LOGIN;
+		$this->mapping_mode = IL_USER_MAPPING_ID;
 		
 		// get all active style  instead of only assigned ones -> cannot transfer all to another otherwise
 		$this->userStyles = array();


### PR DESCRIPTION
This PR changes the default behaviour of the ilUserImportParser (e.g. XML-User Import via GUI).

ilUserImportParser will now try to lookup existing users by ID in the database before falling back to lookup by LOGIN for update and delete actions. This allows to update the login of a user via XML-Import by providing an existing ID and a new LOGIN.

Note: This has already been the case, if the ilUserImportParser was instantiated within a SOAP call - now it also happens for imports via GUI. This should make the import behave more consistent and it also makes it more powerful:

OLD behaviour for **update** and **delete** actions
- Only ID provided: Invalid - can't find user.
- ID + LOGIN provided: Login is used to lookup the user. ID is ignored.
- Only LOGIN provided: Login is used to lookup the user.

NEW behaviour for **update** and **delete** actions
- Only ID provided: ID is used to lookup the user.
- ID + LOGIN provided: ID is used to lookup the user. LOGIN can be updated.
- Only LOGIN provided: Login is used to lookup the user (fallback).

Side note: For **insert** operations the ID is always ignored in both mapping_modes, i.e. NEW = OLD behaviour. This is because the import must ensure that the LOGIN does not exist yet and an ID will always be generated correspondingly. Even if the LOGIN exists and "UPDATE_ON_CONFLICT" is selected, the ID is taken from the existing user account - so any ID-value can and will be ignored in the insert case. 
