### PR TITLE
Support $_GET['target'] redirection when using Shibboleth

### DIFF
--- a/login.php
+++ b/login.php
@@ -45,6 +45,11 @@ if (isset($_GET["client_id"]))
 require_once("Services/Init/classes/class.ilInitialisation.php");
 ilInitialisation::initILIAS();
 
+// Save original target
+if (isset($_GET['target']) && !empty($_GET['target'])) {
+	$_SESSION['orig_target']=urlencode($_GET['target']);
+}
+
 $ilCtrl->initBaseClass("ilStartUpGUI");
 $ilCtrl->setCmd("showLogin");
 $ilCtrl->setTargetScript("ilias.php");

--- a/shib_login.php
+++ b/shib_login.php
@@ -34,4 +34,10 @@ if (! $_SERVER[$ilias->getSetting('shib_login')] || ! $_SERVER[$ilias->getSettin
 #}
 
 // We only get here if we didn't login successfully
-ilUtil::redirect("login.php");
+
+// Jump to original target saved in login.php file
+if (isset($_SESSION['orig_target'])) {
+   ilUtil::redirect("login.php?target=".$_SESSION['orig_target']);
+else {
+   ilUtil::redirect("login.php");
+}


### PR DESCRIPTION
We don't want to lose the original target due the redirection implicit in a shibboleth authentication.

In order to avoid that we save the original target in the Session so we can retrieve this value later.
