### PR TITLE
Use PHPUnits @group Annotation for Tests Requiring Installed ILIAS.

### DIFF
--- a/Modules/Course/test/ilCourseTest.php
+++ b/Modules/Course/test/ilCourseTest.php
@@ -21,6 +21,10 @@
 	+-----------------------------------------------------------------------------+
 */
 
+/**
+ * Class ilCourseTest
+ * @group needsInstalledILIAS
+ */
 class ilCourseTest extends PHPUnit_Framework_TestCase
 {
 	protected $backupGlobals = FALSE;

--- a/Modules/DataCollection/test/ilObjDataCollectionTest.php
+++ b/Modules/DataCollection/test/ilObjDataCollectionTest.php
@@ -4,7 +4,8 @@ include_once("./Services/Database/classes/MDB2/class.ilDBInnoDB.php");
 
 /**
  * Class ilObjDataCollectionTest
- *
+ * @group needsInstalledILIAS
+ *        
  * @author  Theodor Truffer <tt@studer-raimann.ch>
  */
 class ilObjDataCollectionTest extends PHPUnit_Framework_TestCase

--- a/Modules/StudyProgramme/test/ilObjStudyProgrammeTest.php
+++ b/Modules/StudyProgramme/test/ilObjStudyProgrammeTest.php
@@ -25,7 +25,8 @@ require_once(__DIR__."/mocks.php");
 
 /**
  * TestCase for the ilObjStudyProgramme
- *
+ * @group needsInstalledILIAS
+ *        
  * @author Michael Herren <mh@studer-raimann.ch>
  * @author Richard Klees <richard.klees@concepts-and-training.de>
  * @author Stefan Hecken <stefan.hecken@concepts-and-training.de>

--- a/Modules/StudyProgramme/test/ilStudyProgrammeEventsTest.php
+++ b/Modules/StudyProgramme/test/ilStudyProgrammeEventsTest.php
@@ -25,7 +25,8 @@ require_once(__DIR__."/mocks.php");
 
 /**
  * TestCase for the ilObjStudyProgramme
- *
+ * @group needsInstalledILIAS
+ *        
  * @author Michael Herren <mh@studer-raimann.ch>
  * @author Richard Klees <richard.klees@concepts-and-training.de>
  * @version 1.0.0

--- a/Modules/StudyProgramme/test/ilStudyProgrammeLPTest.php
+++ b/Modules/StudyProgramme/test/ilStudyProgrammeLPTest.php
@@ -6,7 +6,8 @@ require_once(__DIR__."/mocks.php");
 
 /**
  * TestCase for the learning progress of users at a programme.
- *
+ * @group needsInstalledILIAS
+ *        
  * @author Michael Herren <mh@studer-raimann.ch>
  * @author Richard Klees <richard.klees@concepts-and-training.de>
  * @version 1.0.0

--- a/Modules/StudyProgramme/test/ilStudyProgrammeProgressCalculationTest.php
+++ b/Modules/StudyProgramme/test/ilStudyProgrammeProgressCalculationTest.php
@@ -6,7 +6,8 @@ require_once(__DIR__."/mocks.php");
 
 /**
  * TestCase for the assignment of users to a programme.
- *
+ * @group needsInstalledILIAS
+ *        
  * @author Richard Klees <richard.klees@concepts-and-training.de>
  * @version 1.0.0
  */

--- a/Modules/StudyProgramme/test/ilStudyProgrammeUserAssignmentTest.php
+++ b/Modules/StudyProgramme/test/ilStudyProgrammeUserAssignmentTest.php
@@ -6,7 +6,8 @@ require_once(__DIR__."/mocks.php");
 
 /**
  * TestCase for the assignment of users to a programme.
- *
+ * @group needsInstalledILIAS
+ *        
  * @author Michael Herren <mh@studer-raimann.ch>
  * @author Richard Klees <richard.klees@concepts-and-training.de>
  * @version 1.0.0

--- a/Modules/StudyProgramme/test/ilStudyProgrammeUserProgressTest.php
+++ b/Modules/StudyProgramme/test/ilStudyProgrammeUserProgressTest.php
@@ -6,7 +6,8 @@ require_once(__DIR__."/mocks.php");
 
 /**
  * TestCase for the progress of users at a programme.
- *
+ * @group needsInstalledILIAS
+ *        
  * @author Michael Herren <mh@studer-raimann.ch>
  * @author Richard Klees <richard.klees@concepts-and-training.de>
  * @version 1.0.0

--- a/Modules/WebResource/test/ilWebResourceTest.php
+++ b/Modules/WebResource/test/ilWebResourceTest.php
@@ -23,7 +23,8 @@
 
 /** 
 * Unit tests for tree table
-* 
+* @group needsInstalledILIAS
+*
 * @author Stefan Meyer <meyer@leifos.com>
 * @version $Id$
 * 

--- a/Services/AccessControl/test/ilRBACTest.php
+++ b/Services/AccessControl/test/ilRBACTest.php
@@ -23,7 +23,8 @@
 
 /** 
 * Unit tests for tree table
-* 
+* @group needsInstalledILIAS
+*
 * @author Stefan Meyer <meyer@leifos.com>
 * @version $Id$
 * 

--- a/Services/Administration/test/ilSettingTest.php
+++ b/Services/Administration/test/ilSettingTest.php
@@ -21,6 +21,10 @@
 	+-----------------------------------------------------------------------------+
 */
 
+/**
+ * Class ilSettingTest
+ * @group needsInstalledILIAS 
+ */
 class ilSettingTest extends PHPUnit_Framework_TestCase
 {
 	protected $backupGlobals = FALSE;

--- a/Services/Authentication/test/ilSessionTest.php
+++ b/Services/Authentication/test/ilSessionTest.php
@@ -21,6 +21,10 @@
 	+-----------------------------------------------------------------------------+
 */
 
+/**
+ * Class ilSessionTest
+ * @group needsInstalledILIAS
+ */
 class ilSessionTest extends PHPUnit_Framework_TestCase
 {
 	protected $backupGlobals = FALSE;

--- a/Services/Cache/test/ilCacheTest.php
+++ b/Services/Cache/test/ilCacheTest.php
@@ -26,8 +26,8 @@
 * 
 * @author Stefan Meyer <meyer@leifos.com>
 * @version $Id$
-* 
 *
+* @group needsInstalledILIAS
 * @ingroup ServicesTree
 */
 class ilCacheTest extends PHPUnit_Framework_TestCase

--- a/Services/Database/test/Basic/ilDatabaseBaseTest.php
+++ b/Services/Database/test/Basic/ilDatabaseBaseTest.php
@@ -25,7 +25,9 @@
 
 /**
  * TestCase for the ilDatabaseCommonTest
- *
+ * 
+ * @group needsInstalledILIAS
+ *        
  * @author  Fabian Schmid <fs@studer-raimann.ch>
  * @version 1.0.0
  */

--- a/Services/Database/test/Implementations/ilDatabaseMDB2InnodbTest.php
+++ b/Services/Database/test/Implementations/ilDatabaseMDB2InnodbTest.php
@@ -26,6 +26,8 @@ require_once('ilDatabaseImplementationBaseTest.php');
 /**
  * TestCase for the ilDatabaseMDB2InnodbTest
  *
+ * @group needsInstalledILIAS
+ *
  * @author  Fabian Schmid <fs@studer-raimann.ch>
  * @version 1.0.0
  */

--- a/Services/Database/test/Implementations/ilDatabaseMDB2MyISAMTest.php
+++ b/Services/Database/test/Implementations/ilDatabaseMDB2MyISAMTest.php
@@ -26,6 +26,8 @@ require_once('ilDatabaseImplementationBaseTest.php');
 /**
  * TestCase for the ilDatabaseMDB2MyISAMTest
  *
+ * @group needsInstalledILIAS
+ *
  * @author  Fabian Schmid <fs@studer-raimann.ch>
  * @version 1.0.0
  */

--- a/Services/Database/test/Implementations/ilDatabaseMDB2PostgresTest.php
+++ b/Services/Database/test/Implementations/ilDatabaseMDB2PostgresTest.php
@@ -26,6 +26,8 @@ require_once('ilDatabaseImplementationBaseTest.php');
 /**
  * TestCase for the ilDatabaseMDB2PostgresTest
  *
+ * @group needsInstalledILIAS
+ *
  * @author  Fabian Schmid <fs@studer-raimann.ch>
  * @version 1.0.0
  */

--- a/Services/Database/test/Implementations/ilDatabasePDOInnodbTest.php
+++ b/Services/Database/test/Implementations/ilDatabasePDOInnodbTest.php
@@ -26,6 +26,8 @@ require_once('ilDatabaseImplementationBaseTest.php');
 /**
  * TestCase for the ilDatabasePDOInnodbTest
  *
+ * @group needsInstalledILIAS
+ *
  * @author  Fabian Schmid <fs@studer-raimann.ch>
  * @version 1.0.0
  */

--- a/Services/Database/test/Implementations/ilDatabasePDOMyISAMTest.php
+++ b/Services/Database/test/Implementations/ilDatabasePDOMyISAMTest.php
@@ -26,6 +26,8 @@ require_once('ilDatabaseImplementationBaseTest.php');
 /**
  * TestCase for the ilDatabasePDOMyISAMTest
  *
+ * @group needsInstalledILIAS
+ *
  * @author  Fabian Schmid <fs@studer-raimann.ch>
  * @version 1.0.0
  */

--- a/Services/Database/test/Implementations/ilDatabasePDOPostgresTest.php
+++ b/Services/Database/test/Implementations/ilDatabasePDOPostgresTest.php
@@ -26,6 +26,8 @@ require_once('ilDatabaseImplementationBaseTest.php');
 /**
  * TestCase for the ilDatabasePDOMyISAMTest
  *
+ * @group needsInstalledILIAS
+ *
  * @author  Fabian Schmid <fs@studer-raimann.ch>
  * @version 1.0.0
  */

--- a/Services/Init/test/ilInitialisationTest.php
+++ b/Services/Init/test/ilInitialisationTest.php
@@ -1,7 +1,8 @@
 <?php
 /**
  * TestCase for the ilContext
- *
+ * @group needsInstalledILIAS
+ *        
  * @author Richard Klees <richard.klees@concepts-and-training.de>
  */
 class ilInitialisationTest extends PHPUnit_Framework_TestCase {

--- a/Services/Membership/test/ilMembershipTest.php
+++ b/Services/Membership/test/ilMembershipTest.php
@@ -23,7 +23,8 @@
 
 /** 
 * Unit tests for tree table
-* 
+* @group needsInstalledILIAS
+*        
 * @author Stefan Meyer <meyer@leifos.com>
 * @version $Id$
 * 

--- a/Services/MetaData/test/ilMDTest.php
+++ b/Services/MetaData/test/ilMDTest.php
@@ -26,8 +26,8 @@
 * 
 * @author Stefan Meyer <meyer@leifos.com>
 * @version $Id$
-* 
 *
+* @group needsInstalledILIAS
 * @ingroup ServicesTree
 */
 class ilMDTest extends PHPUnit_Framework_TestCase

--- a/Services/Object/test/ilObjectDefinitionTest.php
+++ b/Services/Object/test/ilObjectDefinitionTest.php
@@ -1,6 +1,9 @@
 <?php
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+/**
+ * @group needsInstalledILIAS 
+ */
 class ilObjectDefinitionTest extends PHPUnit_Framework_TestCase
 {
 	protected $backupGlobals = FALSE;

--- a/Services/Object/test/ilObjectTest.php
+++ b/Services/Object/test/ilObjectTest.php
@@ -1,6 +1,8 @@
 <?php
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
-
+/**
+ * @group needsInstalledILIAS
+ */
 class ilObjectTest extends PHPUnit_Framework_TestCase
 {
 	protected $backupGlobals = FALSE;

--- a/Services/PHPUnit/test/ilGlobalSuite.php
+++ b/Services/PHPUnit/test/ilGlobalSuite.php
@@ -39,9 +39,9 @@ class ilGlobalSuite extends PHPUnit_Framework_TestSuite
 						include_once($suite_path);
 						
 						$name = "il".$basedir.$file."Suite";
-						$s = new $name();
+						$s = $name::suite();
 						echo "Adding Suite: ".$name."\n";
-						$suite->addTest($s->suite());
+						$suite->addTest($s);
 						//$suite->addTestSuite("ilSettingTest");
 					}
 				}

--- a/Services/PHPUnit/test/ilGlobalSuite.php
+++ b/Services/PHPUnit/test/ilGlobalSuite.php
@@ -82,6 +82,9 @@ class ilGlobalSuite extends PHPUnit_Framework_TestSuite
 			return false;
 		}
 
+		$result->close();
+		$mysqli->close();
+
 		return true;
 	}
 

--- a/Services/PHPUnit/test/ilGlobalSuite.php
+++ b/Services/PHPUnit/test/ilGlobalSuite.php
@@ -57,6 +57,7 @@ class ilGlobalSuite extends PHPUnit_Framework_TestSuite
 		}
 
 		$client_ini = new ilIniFile($client_data_path."/".$client_name."/client.ini.php");
+		$client_ini->read();
 		$host = $client_ini->readVariable("db", "host");
 		$user = $client_ini->readVariable("db", "user");
 		$pass = $client_ini->readVariable("db", "pass");

--- a/Services/PHPUnit/test/ilGlobalSuite.php
+++ b/Services/PHPUnit/test/ilGlobalSuite.php
@@ -72,7 +72,7 @@ class ilGlobalSuite extends PHPUnit_Framework_TestSuite
 		$query = "SELECT value FROM settings WHERE module = 'common' AND keyword = 'setup_ok'";
 		$result = $mysqli->query($query);
 
-		if($result->numRows == 0) {
+		if($result->num_rows == 0) {
 			return false;
 		}
 

--- a/Services/PHPUnit/test/ilGlobalSuite.php
+++ b/Services/PHPUnit/test/ilGlobalSuite.php
@@ -37,7 +37,7 @@ class ilGlobalSuite extends PHPUnit_Framework_TestSuite
 		
 		// scan Modules and Services directories
 		$basedirs = array("Services", "Modules");
-		
+
 		foreach ($basedirs as $basedir)
 		{
 			// read current directory

--- a/Services/PHPUnit/test/ilGlobalSuite.php
+++ b/Services/PHPUnit/test/ilGlobalSuite.php
@@ -13,11 +13,11 @@
 */
 class ilGlobalSuite extends PHPUnit_Framework_TestSuite
 {
-    public static function suite()
-    {
+	public static function suite()
+	{
 		$suite = new ilGlobalSuite();
 
-        require_once('include/inc.get_pear.php');
+		require_once('include/inc.get_pear.php');
 		echo "\n";
 		
 		// scan Modules and Services directories

--- a/Services/PHPUnit/test/ilGlobalSuite.php
+++ b/Services/PHPUnit/test/ilGlobalSuite.php
@@ -39,51 +39,25 @@ class ilGlobalSuite extends PHPUnit_Framework_TestSuite
 			return false;
 		}
 
-		$client_data_path = null;
-		$dir = opendir($client_data_path);
-		while($file = readdir($dir)) {
-			if ($file != "." && $file != ".." && is_dir($client_data_path."/".$file)) {
-				$client_name = $file;
-				break;
-			}
-		}
-
-		if(!$client_name) {
+		if(!is_file($ilias_ini->readVariable("server", "absolute_path")."/Services/PHPUnit/config/cfg.phpunit.php")) {
 			return false;
 		}
 
-		if(!is_file($client_data_path."/".$client_name."/client.ini.php")) {
+		include_once($ilias_ini->readVariable("server", "absolute_path")."/Services/PHPUnit/config/cfg.phpunit.php");
+
+		if(!isset($_GET["client_id"])) {
 			return false;
 		}
 
-		$client_ini = new ilIniFile($client_data_path."/".$client_name."/client.ini.php");
-		$client_ini->read();
-		$host = $client_ini->readVariable("db", "host");
-		$user = $client_ini->readVariable("db", "user");
-		$pass = $client_ini->readVariable("db", "pass");
-		$db = $client_ini->readVariable("db", "name");
+		$phpunit_client = $_GET["client_id"];
 
-		$mysqli = new mysqli($host, $user, $pass, $db);
-
-		if($mysqli->connect_error) {
+		if(!$phpunit_client) {
 			return false;
 		}
 
-		$query = "SELECT value FROM settings WHERE module = 'common' AND keyword = 'setup_ok'";
-		$result = $mysqli->query($query);
-
-		if($result->num_rows == 0) {
+		if(!is_file($client_data_path."/".$phpunit_client."/client.ini.php")) {
 			return false;
 		}
-
-		$row = $result->fetch_assoc();
-
-		if(!(bool)$row["value"]) {
-			return false;
-		}
-
-		$result->close();
-		$mysqli->close();
 
 		return true;
 	}

--- a/Services/PHPUnit/test/ilGlobalSuite.php
+++ b/Services/PHPUnit/test/ilGlobalSuite.php
@@ -13,6 +13,21 @@
 */
 class ilGlobalSuite extends PHPUnit_Framework_TestSuite
 {
+	/**
+	 * @var	string
+	 */
+	const PHPUNIT_GROUP_FOR_TESTS_REQUIRING_INSTALLED_ILIAS = "needsInstalledILIAS";
+
+	/**
+	 * Check if there is an installed ILIAS to run tests on.
+	 *
+	 * TODO: implement me correctly!
+	 * @return	bool
+	 */
+	public function hasInstalledILIAS() {
+		return false;
+	}
+
 	public static function suite()
 	{
 		$suite = new ilGlobalSuite();
@@ -48,6 +63,19 @@ class ilGlobalSuite extends PHPUnit_Framework_TestSuite
 			}
 		}
 		echo "\n";
+
+		if (!$suite->hasInstalledILIAS()) {
+			echo "Removing tests requiring an installed ILIAS.\n";
+			$ff = new PHPUnit_Runner_Filter_Factory();
+			$ff->addFilter
+				( new ReflectionClass("PHPUnit_Runner_Filter_Group_Exclude")
+				, array(self::PHPUNIT_GROUP_FOR_TESTS_REQUIRING_INSTALLED_ILIAS)
+				);
+			$suite->injectFilter($ff);
+		}
+		else {
+			echo "Found installed ILIAS, running all tests.\n";
+		}
 
         return $suite;
     }

--- a/Services/PHPUnit/test/ilGlobalSuite.php
+++ b/Services/PHPUnit/test/ilGlobalSuite.php
@@ -39,10 +39,6 @@ class ilGlobalSuite extends PHPUnit_Framework_TestSuite
 			return false;
 		}
 
-		if(!is_file($ilias_ini->readVariable("server", "absolute_path")."/Services/PHPUnit/config/cfg.phpunit.php")) {
-			return false;
-		}
-
 		include_once($ilias_ini->readVariable("server", "absolute_path")."/Services/PHPUnit/config/cfg.phpunit.php");
 
 		if(!isset($_GET["client_id"])) {

--- a/Services/PHPUnit/test/ilGlobalSuite.php
+++ b/Services/PHPUnit/test/ilGlobalSuite.php
@@ -61,7 +61,7 @@ class ilGlobalSuite extends PHPUnit_Framework_TestSuite
 		$host = $client_ini->readVariable("db", "host");
 		$user = $client_ini->readVariable("db", "user");
 		$pass = $client_ini->readVariable("db", "pass");
-		$db = $client_ini->readVariable("db", "ilias_generali");
+		$db = $client_ini->readVariable("db", "name");
 
 		$mysqli = new mysqli($host, $user, $pass, $db);
 

--- a/Services/Tracking/test/ilTrackingTest.php
+++ b/Services/Tracking/test/ilTrackingTest.php
@@ -23,7 +23,8 @@
 
 /** 
 * Unit tests for tree table
-* 
+* @group needsInstalledILIAS
+*        
 * @author Stefan Meyer <meyer@leifos.com>
 * @version $Id$
 * 

--- a/Services/Tree/test/ilTreeTest.php
+++ b/Services/Tree/test/ilTreeTest.php
@@ -26,8 +26,8 @@
 * 
 * @author Stefan Meyer <meyer@leifos.com>
 * @version $Id$
-* 
 *
+* @group needsInstalledILIAS
 * @ingroup ServicesTree
 */
 class ilTreeTest extends PHPUnit_Framework_TestCase

--- a/Services/UICore/test/ilTemplateTest.php
+++ b/Services/UICore/test/ilTemplateTest.php
@@ -48,7 +48,7 @@ class ilTemplateTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testilTemplateGet()
 	{
-		require_once 'HTML/Template/ITX.php';
+		#require_once 'HTML/Template/ITX.php';
 		include_once("./Services/UICore/classes/class.ilTemplateHTMLITX.php");
 		include_once("./Services/UICore/classes/class.ilTemplate.php");
 		$tpl = new ilTemplate("tpl.test_template_1.html", true, true, "Services/UICore/test");

--- a/Services/UICore/test/ilTemplateTest.php
+++ b/Services/UICore/test/ilTemplateTest.php
@@ -45,6 +45,7 @@ class ilTemplateTest extends PHPUnit_Framework_TestCase
 
 	/**
 	 * @backupGlobals enabled
+	 * @group needsInstalledILIAS
 	 */
 	public function testilTemplateGet()
 	{

--- a/Services/UICore/test/ilTemplateTest.php
+++ b/Services/UICore/test/ilTemplateTest.php
@@ -7,7 +7,7 @@
  * @author Alex Killing <killing@leifos.de>
  *
  * @version $Id$
- *
+ * @group needsInstalledILIAS
  * @ingroup ServicesUICore
  */
 class ilTemplateTest extends PHPUnit_Framework_TestCase

--- a/Services/UICore/test/ilTemplateTest.php
+++ b/Services/UICore/test/ilTemplateTest.php
@@ -45,7 +45,6 @@ class ilTemplateTest extends PHPUnit_Framework_TestCase
 
 	/**
 	 * @backupGlobals enabled
-	 * @group needsInstalledILIAS
 	 */
 	public function testilTemplateGet()
 	{

--- a/Services/User/test/ilObjUserTest.php
+++ b/Services/User/test/ilObjUserTest.php
@@ -1,6 +1,10 @@
 <?php
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+/**
+ * Class ilObjUserTest
+ * @group needsInstalledILIAS
+ */
 class ilObjUserTest extends PHPUnit_Framework_TestCase
 {
 	protected $backupGlobals = FALSE;

--- a/Services/XHTMLPage/test/ilXHTMLPageTest.php
+++ b/Services/XHTMLPage/test/ilXHTMLPageTest.php
@@ -21,6 +21,10 @@
 	+-----------------------------------------------------------------------------+
 */
 
+/**
+ * Class ilXHTMLPageTest
+ * @group needsInstalledILIAS 
+ */
 class ilXHTMLPageTest extends PHPUnit_Framework_TestCase
 {
 	protected $backupGlobals = FALSE;


### PR DESCRIPTION
There currently is the problem that there are automated tests that require an installed ILIAS to be run properly. These make the tests fail fatally very often.

This PR introduces a name for said group (**needsInstalledILIAS**) and modifies ilGlobalSuite to select tests accordingly.

There still is a TODO in ilGlobalSuite::hasInstalledILIAS. Could some ILIAS hero implement this reliably?
