### PR TITLE
Course: fixed addToWaitingList event

### DIFF
--- a/Modules/Course/classes/class.ilCourseWaitingList.php
+++ b/Modules/Course/classes/class.ilCourseWaitingList.php
@@ -33,7 +33,7 @@ class ilCourseWaitingList extends ilWaitingList
 				"Modules/Course", 
 				'addToWaitingList', 
 				array(
-					'obj_id' => $this->obj_id,
+					'obj_id' => $this->getObjId(),
 					'usr_id' => $a_usr_id
 				)
 			);


### PR DESCRIPTION
The `obj_id` was `null` always, as the ilCourseWaitingList tried to access a private property of ilWaitingList.
