### PR TITLE
Issue/3396

### DIFF
--- a/Services/OnScreenChat/js/onscreenchat.js
+++ b/Services/OnScreenChat/js/onscreenchat.js
@@ -112,7 +112,7 @@
 
 	$scope.il.OnScreenChat = {
 		config: {},
-		container: $('<div></div>').addClass('row'),
+		container: $('<div></div>').addClass('row').addClass('iosOnScreenChat'),
 		storage: undefined,
 		user: undefined,
 		historyBlocked: false,

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -11503,6 +11503,9 @@ div.ilPCMyCoursesPath {
   pointer-events: none;
   z-index: 1039;
 }
+#onscreenchat-container .iosOnScreenChat{
+  margin-right: -3px;
+}
 #onscreenchat-container .popover {
   max-width: 200px;
 }

--- a/templates/default/less/Services/OnScreenChat/delos.css
+++ b/templates/default/less/Services/OnScreenChat/delos.css
@@ -9,6 +9,9 @@
   pointer-events: none;
   z-index: 1039;
 }
+#onscreenchat-container .iosOnScreenChat{
+  margin-right: -3px;
+}
 #onscreenchat-container .popover {
   max-width: 200px;
 }

--- a/templates/default/less/Services/OnScreenChat/delos.less
+++ b/templates/default/less/Services/OnScreenChat/delos.less
@@ -13,6 +13,10 @@
 	pointer-events: none;
 	z-index: 1039;
 
+	.iosOnScreenChat{
+		margin-right: -3px;
+	}
+
 	.popover {
 		max-width: 200px;
 


### PR DESCRIPTION
On-Screen Chat: Fixed an issue where on Mac OSX and Firefox 48+ the close icon of the rightest chatwindow was unclickable caused by overlapping scrollbar
