### PR TITLE
use correct file when fetching size of a remote image using curl

### DIFF
--- a/Services/MediaObjects/classes/class.ilMediaImageUtil.php
+++ b/Services/MediaObjects/classes/class.ilMediaImageUtil.php
@@ -44,8 +44,10 @@ class ilMediaImageUtil
 				$c->setOpt(CURLOPT_HEADER, 0);
 				$c->setOpt(CURLOPT_RETURNTRANSFER, 1);
 				$c->setOpt(CURLOPT_FILE, $file);
+				$c->exec();
+				$c->close();
 				fclose($file);
-				$size = @getimagesize($a_location);
+				$size = @getimagesize($filename);
 				unlink($filename);
 			}
 			else


### PR DESCRIPTION
fixing simple copy/paste error ;)

(Forgot to add: Also needs to be fixed in 5.0)
