### PR TITLE
Issue/3385

### DIFF
--- a/Modules/Chatroom/chat/Model/Conversation.js
+++ b/Modules/Chatroom/chat/Model/Conversation.js
@@ -92,6 +92,10 @@ var Conversation = function Conversation(id, participants)
 		_latestMessage = message;
 	};
 
+	this.isParticipant = function(participant) {
+		return hasParticipant(participant, _participants);
+	};
+
 	this.json = function() {
 		var participants = [];
 

--- a/Modules/Chatroom/chat/SocketTasks/ConversationMessage.js
+++ b/Modules/Chatroom/chat/SocketTasks/ConversationMessage.js
@@ -3,19 +3,26 @@ var HTMLEscape = require('../Helper/HTMLEscape');
 
 module.exports = function(conversationId, userId, message) {
 	if (conversationId !== null && userId !== null && message !== null) {
-		Container.getLogger().info('SendMessage "%s" by "%s" in conversation %s', message, userId, conversationId);
+
 		var namespace = Container.getNamespace(this.nsp.name);
 		var conversation = namespace.getConversations().getById(conversationId);
-		var messageObj = {
-			conversationId: conversationId,
-			userId: userId,
-			message: HTMLEscape.escape(message),
-			timestamp: (new Date).getTime()
-		};
+		var participant = namespace.getSubscriber(userId);
 
-		namespace.getDatabase().persistConversationMessage(messageObj);
+		if(conversation.isParticipant(participant))
+		{
+			var messageObj = {
+				conversationId: conversationId,
+				userId: userId,
+				message: HTMLEscape.escape(message),
+				timestamp: (new Date).getTime()
+			};
 
-		conversation.emit('conversation', conversation.json());
-		conversation.send(messageObj);
+			namespace.getDatabase().persistConversationMessage(messageObj);
+
+			conversation.emit('conversation', conversation.json());
+			conversation.send(messageObj);
+
+			Container.getLogger().info('SendMessage "%s" by "%s" in conversation %s', message, userId, conversationId);
+		}
 	}
 };


### PR DESCRIPTION
It was possible to send the window.il.Chat.sendMessage command from console and send messages to non participating chats by brute forcing the conversation id. After this change only participating users are allowed to send messages to a chat. Other users, knowing the conversation id, but not participating are disallowed to send messages.
