### PR TITLE
Issue/3357

### DIFF
--- a/Services/OnScreenChat/classes/class.ilOnScreenChatGUI.php
+++ b/Services/OnScreenChat/classes/class.ilOnScreenChatGUI.php
@@ -87,11 +87,28 @@ class ilOnScreenChatGUI
 			case 'getUserProfileImages':
 				$this->getUserProfileImages();
 				break;
-
+			case 'verifyLogin':
+				$this->verifyLogin();
 			case 'getUserlist':
 			default:
 				$this->getUserList();
 		}
+	}
+
+	/**
+	 * Checks if a user is logged in. If not, this function should cause an redirect, to disallow chatting while not logged
+	 * into ILIAS.
+	 *
+	 * @return bool
+	 */
+	public function verifyLogin()
+	{
+		global $DIC;
+
+		echo json_encode(array(
+			'loggedIn' => $DIC->user() && !$DIC->user()->isAnonymous()
+		));
+		exit;
 	}
 
 	public function getUserList()
@@ -217,6 +234,7 @@ class ilOnScreenChatGUI
 				'username'           => $DIC->user()->getLogin(),
 				'userListURL'        => $DIC->ctrl()->getLinkTargetByClass('ilonscreenchatgui', 'getUserList', '', true, false),
 				'userProfileDataURL' => $DIC->ctrl()->getLinkTargetByClass('ilonscreenchatgui', 'getUserProfileImages', '', true, false),
+				'verifyLoginURL'     => $DIC->ctrl()->getLinkTargetByClass('ilonscreenchatgui', 'verifyLogin', '', true, false),
 				'loaderImg'          => ilUtil::getImagePath('loader.svg'),
 				'emoticons'          => self::getEmoticons($settings),
 				'locale'             => $DIC->language()->getLangKey()

--- a/Services/OnScreenChat/classes/class.ilOnScreenChatGUI.php
+++ b/Services/OnScreenChat/classes/class.ilOnScreenChatGUI.php
@@ -89,6 +89,7 @@ class ilOnScreenChatGUI
 				break;
 			case 'verifyLogin':
 				$this->verifyLogin();
+				break;
 			case 'getUserlist':
 			default:
 				$this->getUserList();

--- a/Services/OnScreenChat/js/onscreenchat.js
+++ b/Services/OnScreenChat/js/onscreenchat.js
@@ -168,6 +168,19 @@
 				}
 			});
 
+			setInterval(function(){
+				$.ajax(
+					getConfig().verifyLoginURL
+				).done(function(result) {
+					result = JSON.parse(result);
+					if(!result.loggedIn) {
+						window.location = '/login.php';
+					}
+				}).fail(function(e){
+					window.location = '/login.php';
+				});
+			}, 300000); // 5 minutes
+
 			$chat.init(getConfig().userId, getConfig().username, getModule().onLogin);
 			$chat.receiveMessage(getModule().receiveMessage);
 			$chat.receiveConversation(getModule().onConversation);


### PR DESCRIPTION
If the ILIAS user session expires, the user will now be disallowed to continue chatting. The client checks every 5 minutes for an active user session. If the session has been expired, the user will be redirected to the login menu.
