### PR TITLE
Issue/3417

### DIFF
--- a/Modules/Chatroom/chat/Persistence/Database.js
+++ b/Modules/Chatroom/chat/Persistence/Database.js
@@ -206,12 +206,14 @@ var Database = function Database(config) {
 			_pool.query('SELECT * FROM osc_activity WHERE conversation_id = ? AND user_id = ?', [conversationId, userId]),
 			function(result){
 				emptyResult = false;
-				_pool.query('UPDATE osc_activity SET timestamp = ?, is_closed = ? WHERE conversation_id = ? AND user_id = ?',
-					[timestamp, 0, conversationId, userId],
-					function(err){
-						if(err) throw err;
-					}
-				);
+				if(timestamp > 0) {
+					_pool.query('UPDATE osc_activity SET timestamp = ?, is_closed = ? WHERE conversation_id = ? AND user_id = ?',
+						[timestamp, 0, conversationId, userId],
+						function(err){
+							if(err) throw err;
+						}
+					);
+				}
 			},
 			function() {
 				if(emptyResult)

--- a/Modules/Chatroom/chat/Persistence/Database.js
+++ b/Modules/Chatroom/chat/Persistence/Database.js
@@ -205,13 +205,15 @@ var Database = function Database(config) {
 		_onQueryEvents(
 			_pool.query('SELECT * FROM osc_activity WHERE conversation_id = ? AND user_id = ?', [conversationId, userId]),
 			function(result){
-				emptyResult = false;
-				_pool.query('UPDATE osc_activity SET timestamp = ?, is_closed = ? WHERE conversation_id = ? AND user_id = ?',
-					[timestamp, 0, conversationId, userId],
-					function(err){
-						if(err) throw err;
-					}
-				);
+				if(timestamp > 0) {
+					emptyResult = false;
+					_pool.query('UPDATE osc_activity SET timestamp = ?, is_closed = ? WHERE conversation_id = ? AND user_id = ?',
+						[timestamp, 0, conversationId, userId],
+						function(err){
+							if(err) throw err;
+						}
+					);
+				}
 			},
 			function() {
 				if(emptyResult)

--- a/Modules/Chatroom/chat/SocketTasks/ConversationAddUser.js
+++ b/Modules/Chatroom/chat/SocketTasks/ConversationAddUser.js
@@ -29,7 +29,14 @@ module.exports = function(conversationId, userId, name) {
 
 			var participant = namespace.getSubscriberWithOfflines(userId, name);
 			conversation.addParticipant(participant);
+			participants.push(participant);
 			participant.join(conversation.id);
+
+			for(var key in participants) {
+				if(participants.hasOwnProperty(key)){
+					namespace.getDatabase().trackActivity(conversation.getId(), participants[key].getId(), 0);
+				}
+			}
 
 			Container.getLogger().info('New Participant %s for group conversation %s', participant.getName(), conversation.getId());
 


### PR DESCRIPTION
There was an error, where users which have been added to a group conversation while offline did not get notified about new messages after login. Problem was the missing activity entry which causes the query to return 0 until opening the chat manually once. It has been changed to track an faked activity on invite for each user in the chat.
