### PR TITLE
Issue/3327

### DIFF
--- a/Modules/Chatroom/chat/Bootstrap/SetupServer.js
+++ b/Modules/Chatroom/chat/Bootstrap/SetupServer.js
@@ -17,7 +17,7 @@ module.exports = function SetupServer(callback) {
 	} else {
 		server = protocol.createServer(Container.getApi());
 	}
-	var io = SocketIO(server);
+	var io = SocketIO(server, {path: serverConfig.sub_directory + '/socket.io'});
 
 	Container.setServer(server);
 
@@ -33,8 +33,6 @@ module.exports = function SetupServer(callback) {
 		}
 
 		namespace.getIO().on('connect', handler);
-
-
 
 		next();
 	}, function(err) {

--- a/Modules/Chatroom/classes/admintasks/class.ilChatroomAdminViewTask.php
+++ b/Modules/Chatroom/classes/admintasks/class.ilChatroomAdminViewTask.php
@@ -76,7 +76,8 @@ class ilChatroomAdminViewTask extends ilChatroomTaskHandler
 			'ilias_proxy'  => $form->getInput('ilias_proxy'),
 			'ilias_url'    => $form->getInput('ilias_url'),
 			'client_proxy' => $form->getInput('client_proxy'),
-			'client_url'   => $form->getInput('client_url')
+			'client_url'   => $form->getInput('client_url'),
+			'sub_directory'=> $form->getInput('sub_directory')
 		);
 
 		$adminSettings = new ilChatroomAdmin($this->gui->object->getId());

--- a/Modules/Chatroom/classes/class.ilChatroomFormFactory.php
+++ b/Modules/Chatroom/classes/class.ilChatroomFormFactory.php
@@ -289,6 +289,11 @@ class ilChatroomFormFactory
 		$port->setSize(6);
 		$form->addItem($port);
 
+		$subDirectory = new ilTextInputGUI($lng->txt('sub_directory'), 'sub_directory');
+		$subDirectory->setRequired(false);
+		$subDirectory->setInfo($lng->txt('sub_directory_info'));
+		$form->addItem($subDirectory);
+
 		$protocol = new ilRadioGroupInputGUI($lng->txt('protocol'), 'protocol');
 		$form->addItem($protocol);
 

--- a/Modules/Chatroom/classes/class.ilChatroomServerSettings.php
+++ b/Modules/Chatroom/classes/class.ilChatroomServerSettings.php
@@ -21,6 +21,7 @@ class ilChatroomServerSettings
 	private $clientUrl;
 	private $iliasUrlEnabled;
 	private $iliasUrl;
+	private $subDirectory;
 
 	public static function loadDefault()
 	{
@@ -48,6 +49,7 @@ class ilChatroomServerSettings
 		$settings->setIliasUrlEnabled($server_settings->ilias_proxy);
 		$settings->setClientUrl($server_settings->client_url);
 		$settings->setIliasUrl($server_settings->ilias_url);
+		$settings->setSubDirectory($server_settings->sub_directory);
 
 		return $settings;
 	}
@@ -291,5 +293,21 @@ class ilChatroomServerSettings
 	public function setAuthSecret($authSecret)
 	{
 		$this->authSecret = $authSecret;
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function getSubDirectory()
+	{
+		return $this->subDirectory;
+	}
+
+	/**
+	 * @param mixed $subDirectory
+	 */
+	public function setSubDirectory($subDirectory)
+	{
+		$this->subDirectory = $subDirectory;
 	}
 }

--- a/Services/OnScreenChat/classes/class.ilOnScreenChatGUI.php
+++ b/Services/OnScreenChat/classes/class.ilOnScreenChatGUI.php
@@ -242,9 +242,10 @@ class ilOnScreenChatGUI
 			);
 
 			$chatConfig = array(
-				'url'      => $settings->generateClientUrl() . '/' . $settings->getInstance() . '-im',
-				'userId'   => $DIC->user()->getId(),
-				'username' => $DIC->user()->getLogin()
+				'url'           => $settings->generateClientUrl() . '/' . $settings->getInstance() . '-im',
+				'subDirectory'  => $settings->getSubDirectory() . '/socket.io',
+				'userId'        => $DIC->user()->getId(),
+				'username'      => $DIC->user()->getLogin()
 			);
 
 			$DIC->language()->toJS(array(

--- a/Services/OnScreenChat/js/chat.js
+++ b/Services/OnScreenChat/js/chat.js
@@ -8,7 +8,7 @@
 		},
 
 		init: function(userId, username, callback) {
-			getModule().socket = $io.connect(getModule().config.url);
+			getModule().socket = $io.connect(getModule().config.url, {path: getModule().config.subDirectory});
 			getModule().socket.on('connect', function() {
 				getModule().login(userId, username, callback);
 			});

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -16339,3 +16339,5 @@ usr#:#user_actions_activation_info#:#Die Aktionen werden nur angeboten, wenn die
 chatroom#:#chat_user_action_invite_public_room#:#In öffentlichen Chatraum einladen
 chatroom#:#chat_user_action_invite_osd#:#On-Screen-Chat starten
 form#:#err_invalid_input#:#Es wurde ein ungültiger Wert übertragen. Bitte überprüfen sie ihre Eingabe.
+chatroom#:#sub_directory#:#Relativer Pfad
+chatroom#:#sub_directory_info#:#Wird der Chatserver so konfiguriert, dass die zugehörige URL einen Unterpfad der Form "http(s)://[IP/Domain]/[PFAD]" enthält, muss hier der relative [PFAD] angegeben werden.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -16337,3 +16337,5 @@ usr#:#user_actions_activation_info#:#Actions will only be listet for users, if t
 chatroom#:#chat_user_action_invite_public_room#:#Invite to Public Chatroom
 chatroom#:#chat_user_action_invite_osd#:#Invite to On-Screen Chat
 form#:#err_invalid_input#:#An invalid value has been submited. Please check your input.
+chatroom#:#sub_directory#:#Sub-Directory
+chatroom#:#sub_directory_info#:#If the Chatserver is only reachable through a sub directory with an URL like "http(s)://[IP/Domain]/[PATH]" it is required to insert the [PATH] for this Chatserver.


### PR DESCRIPTION
There may be some configurations which requires the server to be reachable through a subdirectory of the domain. In this case it is required to tell the server the correct subdirectory. Otherwise it will handle http(s)://[IP/DOMAIN]/[PATH] as a namespace and the server wouldnt be reachable through the subdirectory url.
