### PR TITLE
Issue/proxy-urls

### DIFF
--- a/Modules/Chatroom/classes/class.ilChatroomServerSettings.php
+++ b/Modules/Chatroom/classes/class.ilChatroomServerSettings.php
@@ -80,7 +80,14 @@ class ilChatroomServerSettings
 	{
 		if($this->getIliasUrlEnabled())
 		{
-			return $this->getProtocol() . $this->getIliasUrl();
+			$url = $this->getIliasUrl();
+
+			if(strpos($url, '://') === false)
+			{
+				$url = $this->getProtocol() . $url;
+			}
+
+			return $url;
 		}
 		return $this->getBaseURL();
 	}
@@ -210,7 +217,14 @@ class ilChatroomServerSettings
 	{
 		if($this->getClientUrlEnabled())
 		{
-			return $this->getProtocol() . $this->getClientUrl();
+			$url = $this->getClientUrl();
+
+			if(strpos($url, '://') === false)
+			{
+				$url = $this->getProtocol() . $url;
+			}
+
+			return $url;
 		}
 		return $this->getBaseURL();
 	}

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -15818,7 +15818,7 @@ chatroom#:#ilias_chatserver_connection#:#Verbindung ILIAS zum Server
 chatroom#:#ilias_proxy_info#:#Falls der Server nicht über die eigentliche IP-Adresse und Port erreichbar ist, ist es möglich, einen alternative URL für die Verbindung zwischen ILIAS und Server zu definieren.
 chatroom#:#client_chatserver_connection#:#Verbindung Client zum Server
 chatroom#:#client_proxy_info#:#Falls der Server nicht über die eigentliche IP-Adresse und Port erreichbar ist, ist es möglich, einen alternative URL für die Verbindung zwischen Client und Server zu definieren.
-chatroom#:#connection_url_info#:#Tragen Sie hier einen URL <b>ohne</b> Protokoll-Definition ein.
+chatroom#:#connection_url_info#:#Tragen Sie hier einen URL ein, über welchen der Server zu erreichen ist.
 chatroom#:#log#:#Chatserver Log-File
 chatroom#:#error_log#:#Chatserver Error-Log-File
 chatroom#:#delete_private_room_question#:#Separée wirklich löschen?

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -15787,7 +15787,7 @@ chatroom#:#ilias_chatserver_connection#:#ILIAS to Server Connection
 chatroom#:#ilias_proxy_info#:#If the Server is not accessible with the default IP-Address and Port, it is possible to configure a custom URL for ILIAS to Server connection.
 chatroom#:#client_chatserver_connection#:#Client to Server Connection
 chatroom#:#client_proxy_info#:#If the Server is not accessible with the default IP-Address and Port, it is possible to configure a custom URL for Client to Server connection.
-chatroom#:#connection_url_info#:#Please insert an URL <b>without</b> specifying the protocol definition.
+chatroom#:#connection_url_info#:#Please insert an URL for the Server connection.
 chatroom#:#log#:#Chatserver Log
 chatroom#:#error_log#:#Chatserver Error-Log
 chatroom#:#delete_private_room_question#:#Confirm delete private room?


### PR DESCRIPTION
In the Chatserver configuration there is an option to set a specific URL for the connection between ILIAS -> Server and the Client -> Server. This is used if the server is configured behind an reverse proxy and if the URLs how the server can be reached to the servers listening ip-address/FQN. Until now, the proxy paths uses the protocol defined in the configuration. But with this, it was impossible to create an HTTPS reverse proxy but running the chatserver without HTTP. This is now more flexible.
