### PR TITLE
#19641: can only create MyISAM-DBs with DB-template as engine is set explicitely there.

### DIFF
--- a/setup/classes/class.ilDbSetup.php
+++ b/setup/classes/class.ilDbSetup.php
@@ -218,10 +218,7 @@ class ilDbSetup {
 			$this->provideGlobalDB();
 			switch ($this->ilDBInterface->getDBType()) {
 				case ilDBConstants::TYPE_PDO_MYSQL_MYISAM:
-				case ilDBConstants::TYPE_PDO_MYSQL_INNODB:
 				case ilDBConstants::TYPE_MYSQL:
-				case ilDBConstants::TYPE_INNODB:
-				case ilDBConstants::TYPE_GALERA:
 					$this->ilDBInterface->connect();
 					//$this->dropTables();
 					//$this->readDump();
@@ -231,6 +228,9 @@ class ilDbSetup {
 					return true;
 
 					break;
+				case ilDBConstants::TYPE_PDO_MYSQL_INNODB:
+				case ilDBConstants::TYPE_INNODB:
+				case ilDBConstants::TYPE_GALERA:
 				case ilDBConstants::TYPE_PDO_POSTGRE:
 				case ilDBConstants::TYPE_POSTGRES:
 				case ilDBConstants::TYPE_ORACLE:


### PR DESCRIPTION
This seems to be the easy fix for [# 19641](http://www.ilias.de/mantis/view.php?id=19641). This also seems to be the way things were handled in 5.1.

In general it might also be a good idea to move the DB template from MyISAM to InnoDB.