### PR TITLE
add required for missing class file

### DIFF
--- a/Modules/Test/classes/class.ilCronFinishUnfinishedTestPasses.php
+++ b/Modules/Test/classes/class.ilCronFinishUnfinishedTestPasses.php
@@ -3,6 +3,7 @@ require_once 'Services/Cron/classes/class.ilCronJob.php';
 require_once 'Services/Cron/classes/class.ilCronJobResult.php';
 require_once 'Modules/Test/classes/class.ilObjTest.php';
 require_once 'Modules/Test/classes/class.ilTestPassFinishTasks.php';
+require_once 'Services/Logging/classes/public/class.ilLoggerFactory.php';
 
 /* Copyright (c) 1998-2016 ILIAS open source, Extended GPL, see docs/LICENSE */
 


### PR DESCRIPTION
Testing our cli install tool, we stumbled upon ilLoggerFactory is missing as required_once.