### PR TITLE
#19685 Bugfix DB setup fail

### DIFF
--- a/setup/sql/ilDBTemplate.php
+++ b/setup/sql/ilDBTemplate.php
@@ -33947,7 +33947,6 @@ $fields = array (
 	)
 	,"insert_time" => array (
 		"notnull" => true
-		,"default" => "NOW()"
 		,"type" => "timestamp"
 	)
 	,"order_nr" => array (


### PR DESCRIPTION
I scoutet for inserts into personal_pc_clipboard. There is only once in ilObjUser Line 3354. In my opinion the default value for "insert_time" is not needed.