### PR TITLE
Small adjustment of UI-Framework rules.

### DIFF
--- a/src/UI/docu/rules.md
+++ b/src/UI/docu/rules.md
@@ -124,8 +124,8 @@ The interface to the main factory is \ILIAS\UI\Factory.
     * SHOULD contain a field `description` that is a dictionary containing one or
       more than one of the following text fields:
         * `purpose` - describes the usage scenario of the component
-        * `composition` - describes how the component is composed with other
-          components
+        * `composition` - describes how the component is composed from and with
+           other components
         * `effect` - describes visual effects that relate to the item
         * `rival` - describes other components fulfilling a similar function
     * MAY contain a text field `background` that gives academic information


### PR DESCRIPTION
In some discussion it became noticeable that the understanding of the description.composition-field is different than the rules say. Both understandings (rules vs. other) seem to be valid, thus rules should be expanded.

The current components in the UI framework also do not respect the original rules completely.