### PR TITLE
Extended field size username in registration form.

### DIFF
--- a/Services/User/classes/class.ilUserProfile.php
+++ b/Services/User/classes/class.ilUserProfile.php
@@ -494,7 +494,7 @@ class ilUserProfile
 						{
 							$val->setValue($a_user->getLogin());
 						}
-						$val->setMaxLength(32);
+						$val->setMaxLength(64);
 						$val->setSize(40);
 						$val->setRequired(true);
 					}


### PR DESCRIPTION
It hits its boundaries pretty fast, expecially when people tend to user their email as login.