### PR TITLE
5.1_bugfix_19478

### DIFF
--- a/Modules/SurveyQuestionPool/classes/class.SurveyQuestion.php
+++ b/Modules/SurveyQuestionPool/classes/class.SurveyQuestion.php
@@ -835,14 +835,12 @@ class SurveyQuestion
 			"question_id" => array("integer", $this->getId())
 			));
 		}
-		
-		// #12420
-		$set = $ilDB->query("SELECT survey_id FROM svy_svy".
-			" WHERE obj_fi = ".$ilDB->quote($this->getObjId(), "integer"));
+
+		$set = $ilDB->query("SELECT survey_fi FROM svy_svy_qst".
+			" WHERE question_fi = ".$ilDB->quote($this->getId(), "integer"));
 		$survey_fi = $ilDB->fetchAssoc($set);
-		$survey_fi = $survey_fi["survey_id"];
-		
-		// pool?
+		$survey_fi = $survey_fi["survey_fi"];
+
 		if($survey_fi)
 		{		
 			$set = $ilDB->query("SELECT obligatory FROM svy_qst_oblig".


### PR DESCRIPTION
The original query was checking obj_fi from surveys using an object id
from the pool instead of the survey.