### PR TITLE
Disable checkbox for close/delete appraisees when the survey is closed

### DIFF
--- a/Modules/Survey/classes/tables/class.ilSurveyAppraiseesTableGUI.php
+++ b/Modules/Survey/classes/tables/class.ilSurveyAppraiseesTableGUI.php
@@ -127,10 +127,18 @@ class ilSurveyAppraiseesTableGUI extends ilTable2GUI
 		if(!$this->raters_mode)
 		{
 			$this->tpl->setVariable("FINISHED", $data['finished']);
-			$this->tpl->setVariable("CLOSED", $data['closed'] ?
-				ilDatePresentation::formatDate(new ilDateTime($data['closed'], IL_CAL_UNIX))
-				: "");
-			
+
+			if($data['closed'])
+			{
+				$this->tpl->setVariable('DISABLED', "disabled");
+				$this->tpl->setVariable("CLOSED",ilDatePresentation::formatDate(new ilDateTime($data['closed'], IL_CAL_UNIX)));
+			}
+			else
+			{
+				$this->tpl->setVariable('DISABLED', "");
+				$this->tpl->setVariable("CLOSED","");
+			}
+
 			$this->ctrl->setParameter($this->getParentObject(), "appr_id", $data["user_id"]);
 			$this->tpl->setVariable("URL", $lng->txt("survey_360_edit_raters"));
 			$this->tpl->setVariable("HREF", $this->ctrl->getLinkTarget($this->getParentObject(), "editRaters"));

--- a/Modules/Survey/classes/tables/class.ilSurveyAppraiseesTableGUI.php
+++ b/Modules/Survey/classes/tables/class.ilSurveyAppraiseesTableGUI.php
@@ -130,7 +130,7 @@ class ilSurveyAppraiseesTableGUI extends ilTable2GUI
 
 			if($data['closed'])
 			{
-				$this->tpl->setVariable('DISABLED', "disabled");
+				$this->tpl->setVariable('DISABLED', "style='display:none' disabled");
 				$this->tpl->setVariable("CLOSED",ilDatePresentation::formatDate(new ilDateTime($data['closed'], IL_CAL_UNIX)));
 			}
 			else

--- a/Modules/Survey/templates/default/tpl.il_svy_svy_appraisees_row.html
+++ b/Modules/Survey/templates/default/tpl.il_svy_svy_appraisees_row.html
@@ -1,6 +1,6 @@
 <tr class="{CSS_ROW}">
 	<td class="std" style="vertical-align: top">
-		<input type="checkbox" name="{MODE}_id[]" value="{ID}" />
+		<input type="checkbox" name="{MODE}_id[]" value="{ID}" {DISABLED}/>
 	</td>	
 	<td class="std" style="vertical-align: top">{NAME}</td>
 	<td class="std" style="vertical-align: top">{LOGIN}</td>	


### PR DESCRIPTION
Creating/Editing survey 360, in appraisees tab we can select appraisees and then delete them or close their surveys. If one of the selected appraisees has the survey closed and we try to delete/close , appears the message 'Please
select one' and we can not see any change.