### PR TITLE
Cronjob Delete Trash. Fails when surveys in trash.

### DIFF
--- a/Modules/Survey/classes/class.ilObjSurvey.php
+++ b/Modules/Survey/classes/class.ilObjSurvey.php
@@ -291,23 +291,27 @@ class ilObjSurvey extends ilObject
 	*/
 	function delete()
 	{
+		if ($this->countReferences() == 1)
+		{
+			$this->deleteMetaData();
+
+			// Delete all survey questions, constraints and materials
+			foreach ($this->questions as $question_id)
+			{
+				$this->removeQuestion($question_id);
+			}
+			$this->deleteSurveyRecord();
+
+			ilUtil::delDir($this->getImportDirectory());
+		}
+
 		$remove = parent::delete();
+
 		// always call parent delete function first!!
 		if (!$remove)
 		{
 			return false;
 		}
-
-		$this->deleteMetaData();
-
-		// Delete all survey questions, constraints and materials
-		foreach ($this->questions as $question_id)
-		{
-			$this->removeQuestion($question_id);
-		}
-		$this->deleteSurveyRecord();
-		
-		ilUtil::delDir($this->getImportDirectory());
 		return true;
 	}
 	


### PR DESCRIPTION
The Cron job "Delete Trash Bin" fails when delete surveys and stops the whole process. The problem is the survey object deletion before delete all the data that belongs to it. 

- Fatal error: Call to a member function delete() on boolean in /Modules/Survey/classes/class.ilObjSurvey.php on line 1969

- Fatal error the objectid(xx)  doesn't exists

This happens in the trunk and 5.1