### PR TITLE
Disable send emails button in svy codes if global SMTP is not disabled.

### DIFF
--- a/Modules/Survey/classes/forms/FormMailCodesGUI.php
+++ b/Modules/Survey/classes/forms/FormMailCodesGUI.php
@@ -52,6 +52,7 @@ class FormMailCodesGUI extends ilPropertyFormGUI
 
 		global $lng;
 		global $ilAccess;
+		global $ilSetting;
 		
 		$this->lng = $lng;
 		$this->guiclass = $guiclass;
@@ -120,7 +121,18 @@ class FormMailCodesGUI extends ilPropertyFormGUI
 			if ($ilAccess->checkAccess("write", "", $_GET["ref_id"])) $this->addCommandButton("deleteSavedMessage", $this->lng->txt("delete_saved_message"));
 			if ($ilAccess->checkAccess("write", "", $_GET["ref_id"])) $this->addCommandButton("insertSavedMessage", $this->lng->txt("insert_saved_message"));
 		}
-		if ($ilAccess->checkAccess("write", "", $_GET["ref_id"])) $this->addCommandButton("sendCodesMail", $this->lng->txt("send"));
+
+		if ($ilAccess->checkAccess("write", "", $_GET["ref_id"]))
+		{
+			if(!(int)$ilSetting->get('prevent_smtp_globally'))
+			{
+				$this->addCommandButton("sendCodesMail", $this->lng->txt("send"));
+			}
+			else
+			{
+				ilUtil::sendInfo($lng->txt("cant_send_email_smtp_disabled"));
+			}
+		}
 	}
 	
 	public function getSavedMessages()

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -16368,3 +16368,4 @@ content#:#cont_permission_object_desc#:#The section will only be presented for u
 grp#:#grp_err_registration_limited#:#please enter a valid start and end date for the registration
 auth#:#auth_activation_code_success#:#Your account has been reactivated. You can now login to ILIAS.
 lng#:#lng_download_deprecated#:#Download Deprecated List
+survey#:#cant_send_email_smtp_disabled#:#Sending external mails is not available. This option is deactivated globally.


### PR DESCRIPTION
With this changes, if the Mail configuration has the option "_Globally prevent sending external mails (via SMTP)_" enabled, then in a "_Survey->Participants->Mail access codes or messages_" The "_send_" button is not available and a "info" message is shown.
The motivation was this bug report [0019956](http://www.ilias.de/mantis/view.php?id=19956)