### PR TITLE
Additional events

### DIFF
--- a/Modules/Course/classes/class.ilCourseParticipants.php
+++ b/Modules/Course/classes/class.ilCourseParticipants.php
@@ -145,17 +145,17 @@ class ilCourseParticipants extends ilParticipants
 	}
 
 
-    /**
-     * Update passed status (static)
-     *
-     * @access public
-     * @param int $a_obj_id
-     * @param int $a_usr_id
-     * @param bool $a_passed
-     * @param bool $a_manual
-     * @param bool $a_no_origin
-     * @return bool
-     */
+	/**
+	 * Update passed status (static)
+	 *
+	 * @access public
+	 * @param int $a_obj_id
+	 * @param int $a_usr_id
+	 * @param bool $a_passed
+	 * @param bool $a_manual
+	 * @param bool $a_no_origin
+	 * @return bool
+	 */
 	public static function _updatePassed($a_obj_id, $a_usr_id, $a_passed, $a_manual = false, $a_no_origin = false)
 	{
 		global $ilDB, $ilUser, $ilAppEventHandler;
@@ -214,12 +214,12 @@ class ilCourseParticipants extends ilParticipants
 		{
 			$ilDB->manipulate($update_query);
 			if ($a_passed) {
-			    $ilAppEventHandler->raise('Modules/Course', 'participantHasPassedCourse', array(
-                        'obj_id' => $a_obj_id,
-                        'usr_id' => $a_usr_id,
-                    )
-                );
-            }
+				$ilAppEventHandler->raise('Modules/Course', 'participantHasPassedCourse', array(
+						'obj_id' => $a_obj_id,
+						'usr_id' => $a_usr_id,
+					)
+				);
+			}
 		}
 		return true;	
 	}

--- a/Modules/Course/classes/class.ilCourseParticipants.php
+++ b/Modules/Course/classes/class.ilCourseParticipants.php
@@ -149,16 +149,21 @@ class ilCourseParticipants extends ilParticipants
 	 * Update passed status (static)
 	 *
 	 * @access public
-	 * @param int $a_obj_id
-	 * @param int $a_usr_id
+	 *
+	 * @param int  $a_obj_id
+	 * @param int  $a_usr_id
 	 * @param bool $a_passed
 	 * @param bool $a_manual
 	 * @param bool $a_no_origin
+	 *
 	 * @return bool
 	 */
 	public static function _updatePassed($a_obj_id, $a_usr_id, $a_passed, $a_manual = false, $a_no_origin = false)
 	{
 		global $ilDB, $ilUser, $ilAppEventHandler;
+		/**
+		 * @var $ilAppEventHandler ilAppEventHandler
+		 */
 
 		// #11600
 		$origin = -1;
@@ -215,10 +220,9 @@ class ilCourseParticipants extends ilParticipants
 			$ilDB->manipulate($update_query);
 			if ($a_passed) {
 				$ilAppEventHandler->raise('Modules/Course', 'participantHasPassedCourse', array(
-						'obj_id' => $a_obj_id,
-						'usr_id' => $a_usr_id,
-					)
-				);
+					'obj_id' => $a_obj_id,
+					'usr_id' => $a_usr_id,
+				));
 			}
 		}
 		return true;	

--- a/Services/AccessControl/classes/class.ilRbacAdmin.php
+++ b/Services/AccessControl/classes/class.ilRbacAdmin.php
@@ -344,24 +344,24 @@ class ilRbacAdmin
 
 		include_once('Services/LDAP/classes/class.ilLDAPRoleGroupMapping.php');
 		$mapping = ilLDAPRoleGroupMapping::_getInstance();
-		$mapping->deassign($a_rol_id,$a_usr_id); 
+		$mapping->deassign($a_rol_id,$a_usr_id);
 
 		if ($res) {
-            $ref_id = $GLOBALS['rbacreview']->getObjectReferenceOfRole($a_rol_id);
-            $obj_id = ilObject::_lookupObjId($ref_id);
-            $type = ilObject::_lookupType($obj_id);
+			$ref_id = $GLOBALS['rbacreview']->getObjectReferenceOfRole($a_rol_id);
+			$obj_id = ilObject::_lookupObjId($ref_id);
+			$type = ilObject::_lookupType($obj_id);
 
-            ilLoggerFactory::getInstance()->getLogger('ac')->debug('Raise event deassign user');
-            $GLOBALS['ilAppEventHandler']->raise(
-                'Services/AccessControl',
-                'deassignUser',
-                array(
-                    'obj_id' => $obj_id,
-                    'usr_id' => $a_usr_id,
-                    'role_id' => $a_rol_id,
-                    'type' => $type
-                )
-            );
+			ilLoggerFactory::getInstance()->getLogger('ac')->debug('Raise event deassign user');
+			$GLOBALS['ilAppEventHandler']->raise(
+				'Services/AccessControl',
+				'deassignUser',
+				array(
+					'obj_id' => $obj_id,
+					'usr_id' => $a_usr_id,
+					'role_id' => $a_rol_id,
+					'type' => $type
+				)
+			);
 		}
 		return TRUE;
 	}

--- a/Services/AccessControl/classes/class.ilRbacAdmin.php
+++ b/Services/AccessControl/classes/class.ilRbacAdmin.php
@@ -263,9 +263,11 @@ class ilRbacAdmin
 
 	/**
 	 * Assigns an user to a role. Update of table rbac_ua
-	 * @param	int	$a_rol_id Object-ID of role
-	 * @param	int	$a_usr_id Object-ID of user
-	 * @return	boolean
+	 *
+	 * @param    int $a_rol_id Object-ID of role
+	 * @param    int $a_usr_id Object-ID of user
+	 *
+	 * @return    boolean
 	 */
 	public function assignUser($a_rol_id,$a_usr_id)
 	{
@@ -318,12 +320,14 @@ class ilRbacAdmin
 		return TRUE;
 	}
 
+
 	/**
 	 * Deassigns a user from a role. Update of table rbac_ua
 	 *
-	 * @param	int	$a_rol_id Object-ID of role
-	 * @param	int	$a_usr_id Object-ID of user
-	 * @return	boolean	true on success
+	 * @param    int $a_rol_id Object-ID of role
+	 * @param    int $a_usr_id Object-ID of user
+	 *
+	 * @return    boolean    true on success
 	 */
 	public function deassignUser($a_rol_id,$a_usr_id)
 	{
@@ -344,7 +348,7 @@ class ilRbacAdmin
 
 		include_once('Services/LDAP/classes/class.ilLDAPRoleGroupMapping.php');
 		$mapping = ilLDAPRoleGroupMapping::_getInstance();
-		$mapping->deassign($a_rol_id,$a_usr_id);
+		$mapping->deassign($a_rol_id, $a_usr_id);
 
 		if ($res) {
 			$ref_id = $GLOBALS['rbacreview']->getObjectReferenceOfRole($a_rol_id);
@@ -352,18 +356,15 @@ class ilRbacAdmin
 			$type = ilObject::_lookupType($obj_id);
 
 			ilLoggerFactory::getInstance()->getLogger('ac')->debug('Raise event deassign user');
-			$GLOBALS['ilAppEventHandler']->raise(
-				'Services/AccessControl',
-				'deassignUser',
-				array(
-					'obj_id' => $obj_id,
-					'usr_id' => $a_usr_id,
+			$GLOBALS['ilAppEventHandler']->raise('Services/AccessControl', 'deassignUser', array(
+					'obj_id'  => $obj_id,
+					'usr_id'  => $a_usr_id,
 					'role_id' => $a_rol_id,
-					'type' => $type
-				)
-			);
+					'type'    => $type,
+			));
 		}
-		return TRUE;
+
+		return true;
 	}
 
 	/**

--- a/Services/AccessControl/classes/class.ilRbacAdmin.php
+++ b/Services/AccessControl/classes/class.ilRbacAdmin.php
@@ -263,11 +263,8 @@ class ilRbacAdmin
 
 	/**
 	 * Assigns an user to a role. Update of table rbac_ua
-	 * TODO: remove deprecated 3rd parameter sometime
-	 * @access	public
-	 * @param	integer	object_id of role
-	 * @param	integer	object_id of user
-	 * @param	boolean	true means default role (optional
+	 * @param	int	$a_rol_id Object-ID of role
+	 * @param	int	$a_usr_id Object-ID of user
 	 * @return	boolean
 	 */
 	public function assignUser($a_rol_id,$a_usr_id)
@@ -323,9 +320,9 @@ class ilRbacAdmin
 
 	/**
 	 * Deassigns a user from a role. Update of table rbac_ua
-	 * @access	public
-	 * @param	integer	object id of role
-	 * @param	integer	object id of user
+	 *
+	 * @param	int	$a_rol_id Object-ID of role
+	 * @param	int	$a_usr_id Object-ID of user
 	 * @return	boolean	true on success
 	 */
 	public function deassignUser($a_rol_id,$a_usr_id)
@@ -348,22 +345,24 @@ class ilRbacAdmin
 		include_once('Services/LDAP/classes/class.ilLDAPRoleGroupMapping.php');
 		$mapping = ilLDAPRoleGroupMapping::_getInstance();
 		$mapping->deassign($a_rol_id,$a_usr_id); 
-		
-		$ref_id = $GLOBALS['rbacreview']->getObjectReferenceOfRole($a_rol_id);
-		$obj_id = ilObject::_lookupObjId($ref_id);
-		$type = ilObject::_lookupType($obj_id);
-		
-		ilLoggerFactory::getInstance()->getLogger('ac')->debug('Raise event deassign user');
-		$GLOBALS['ilAppEventHandler']->raise(
-				'Services/AccessControl',
-				'deassignUser',
-				array(
-					'obj_id' => $obj_id,
-					'usr_id' => $a_usr_id,
-					'role_id' => $a_rol_id,
-					'type' => $type
-				)
-		);
+
+		if ($res) {
+            $ref_id = $GLOBALS['rbacreview']->getObjectReferenceOfRole($a_rol_id);
+            $obj_id = ilObject::_lookupObjId($ref_id);
+            $type = ilObject::_lookupType($obj_id);
+
+            ilLoggerFactory::getInstance()->getLogger('ac')->debug('Raise event deassign user');
+            $GLOBALS['ilAppEventHandler']->raise(
+                'Services/AccessControl',
+                'deassignUser',
+                array(
+                    'obj_id' => $obj_id,
+                    'usr_id' => $a_usr_id,
+                    'role_id' => $a_rol_id,
+                    'type' => $type
+                )
+            );
+		}
 		return TRUE;
 	}
 

--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -1259,11 +1259,15 @@ class ilObject
 	 * maybe this method should be in tree object!?
 	 *
 	 * @todo    role/rbac stuff
+	 *
 	 * @param int $a_parent_ref Ref-ID of the parent object
 	 */
 	function putInTree($a_parent_ref)
 	{
 		global $tree, $log, $ilAppEventHandler;
+		/**
+		 * @var $ilAppEventHandler ilAppEventHandler
+		 */
 
 		$tree->insertNode($this->getRefId(), $a_parent_ref);
 		
@@ -1273,10 +1277,10 @@ class ilObject
 			$this->getType().", title: ".$this->getTitle());
 
 		$ilAppEventHandler->raise('Services/Object', 'putObjectInTree', array(
-			'object' => $this,
-			'obj_type' => $this->getType(),
-			'obj_id' => $this->getId(),
-			'parent_ref_id' => $a_parent_ref,
+				'object'        => $this,
+				'obj_type'      => $this->getType(),
+				'obj_id'        => $this->getId(),
+				'parent_ref_id' => $a_parent_ref,
 			)
 		);
 	}
@@ -1371,20 +1375,22 @@ class ilObject
 	}
 
 
-
-
 	/**
-	* delete object or referenced object
-	* (in the case of a referenced object, object data is only deleted
-	* if last reference is deleted)
-	* This function removes an object entirely from system!!
-	*
- 	* @access	public
-	* @return	boolean	true if object was removed completely; false if only a references was removed
-	*/
+	 * delete object or referenced object
+	 * (in the case of a referenced object, object data is only deleted
+	 * if last reference is deleted)
+	 * This function removes an object entirely from system!!
+	 *
+	 * @access    public
+	 * @return    boolean    true if object was removed completely; false if only a references was
+	 *                       removed
+	 */
 	function delete()
 	{
 		global $rbacadmin, $log, $ilDB, $ilAppEventHandler;
+		/**
+		 * @var $ilAppEventHandler ilAppEventHandler
+		 */
 
 		$remove = false;
 
@@ -1405,9 +1411,9 @@ class ilObject
 				$this->ilias->raiseError("ilObject::delete(): Type mismatch. (".$this->type."/".$this->id.")",$this->ilias->error_obj->WARNING);
 			}
 
-			$ilAppEventHandler->raise('Services/Object', 'beforeDeletion', array('object' => $this));
+			$ilAppEventHandler->raise('Services/Object', 'beforeDeletion', array( 'object' => $this ));
 
-            // delete entry in object_data
+			// delete entry in object_data
 			$q = "DELETE FROM object_data ".
 				"WHERE obj_id = ".$ilDB->quote($this->getId(), "integer");
 			$ilDB->manipulate($q);
@@ -1720,6 +1726,9 @@ class ilObject
 	public function cloneObject($a_target_id,$a_copy_id = 0)
 	{
 		global $objDefinition,$ilUser,$rbacadmin, $ilDB, $ilAppEventHandler;
+		/**
+		 * @var $ilAppEventHandler ilAppEventHandler
+		 */
 		
 		$location = $objDefinition->getLocation($this->getType());
 		$class_name = ('ilObj'.$objDefinition->getClassName($this->getType()));
@@ -1777,7 +1786,7 @@ class ilObject
 		// END WebDAV: Clone WebDAV properties
 
 		$ilAppEventHandler->raise('Services/Object', 'cloneObject', array(
-			'object' => $new_obj,
+			'object'             => $new_obj,
 			'cloned_from_object' => $this,
 		));
 

--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -1254,14 +1254,16 @@ class ilObject
 		return $objects;
 	}
 
-	/**
-	* maybe this method should be in tree object!?
-	*
-	* @todo	role/rbac stuff
-	*/
+
+    /**
+     * maybe this method should be in tree object!?
+     *
+     * @todo    role/rbac stuff
+     * @param int $a_parent_ref Ref-ID of the parent object
+     */
 	function putInTree($a_parent_ref)
 	{
-		global $tree, $log;
+		global $tree, $log, $ilAppEventHandler;
 
 		$tree->insertNode($this->getRefId(), $a_parent_ref);
 		
@@ -1270,6 +1272,13 @@ class ilObject
 			$this->getRefId().", obj_id: ".$this->getId().", type: ".
 			$this->getType().", title: ".$this->getTitle());
 
+		$ilAppEventHandler->raise('Services/Object', 'putObjectInTree', array(
+			'object' => $this,
+			'obj_type' => $this->getType(),
+			'obj_id' => $this->getId(),
+			'parent_ref_id' => $a_parent_ref,
+			)
+        );
 	}
 
 	/**
@@ -1375,7 +1384,7 @@ class ilObject
 	*/
 	function delete()
 	{
-		global $rbacadmin, $log, $ilDB;
+		global $rbacadmin, $log, $ilDB, $ilAppEventHandler;
 
 		$remove = false;
 
@@ -1395,8 +1404,10 @@ class ilObject
 				// raise error
 				$this->ilias->raiseError("ilObject::delete(): Type mismatch. (".$this->type."/".$this->id.")",$this->ilias->error_obj->WARNING);
 			}
-			
-			// delete entry in object_data
+
+            $ilAppEventHandler->raise('Services/Object', 'beforeDeletion', array('object' => $this));
+
+            // delete entry in object_data
 			$q = "DELETE FROM object_data ".
 				"WHERE obj_id = ".$ilDB->quote($this->getId(), "integer");
 			$ilDB->manipulate($q);

--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -1708,7 +1708,7 @@ class ilObject
 	 */
 	public function cloneObject($a_target_id,$a_copy_id = 0)
 	{
-		global $objDefinition,$ilUser,$rbacadmin, $ilDB;
+		global $objDefinition,$ilUser,$rbacadmin, $ilDB, $ilAppEventHandler;
 		
 		$location = $objDefinition->getLocation($this->getType());
 		$class_name = ('ilObj'.$objDefinition->getClassName($this->getType()));
@@ -1764,7 +1764,12 @@ class ilObject
 			"WHERE obj_id = ".$ilDB->quote($this->getId(),'integer');
 		$res = $ilDB->manipulate($query);
 		// END WebDAV: Clone WebDAV properties
-		
+
+		$ilAppEventHandler->raise('Services/Object', 'cloneObject', array(
+			'object' => $new_obj,
+			'cloned_from_object' => $this,
+		));
+
 		return $new_obj;
 	}
 	

--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -1255,12 +1255,12 @@ class ilObject
 	}
 
 
-    /**
-     * maybe this method should be in tree object!?
-     *
-     * @todo    role/rbac stuff
-     * @param int $a_parent_ref Ref-ID of the parent object
-     */
+	/**
+	 * maybe this method should be in tree object!?
+	 *
+	 * @todo    role/rbac stuff
+	 * @param int $a_parent_ref Ref-ID of the parent object
+	 */
 	function putInTree($a_parent_ref)
 	{
 		global $tree, $log, $ilAppEventHandler;
@@ -1278,7 +1278,7 @@ class ilObject
 			'obj_id' => $this->getId(),
 			'parent_ref_id' => $a_parent_ref,
 			)
-        );
+		);
 	}
 
 	/**
@@ -1405,7 +1405,7 @@ class ilObject
 				$this->ilias->raiseError("ilObject::delete(): Type mismatch. (".$this->type."/".$this->id.")",$this->ilias->error_obj->WARNING);
 			}
 
-            $ilAppEventHandler->raise('Services/Object', 'beforeDeletion', array('object' => $this));
+			$ilAppEventHandler->raise('Services/Object', 'beforeDeletion', array('object' => $this));
 
             // delete entry in object_data
 			$q = "DELETE FROM object_data ".


### PR DESCRIPTION
This pull request adds some additional events being useful in our opinion:

* If a course participant has passed a course
* If an object is put into the tree
* If an object is getting deleted (right before the deletion process actually happens, so that the object is still available for the event handler)
* Consistent behavior for the events when assigning/de-assigning a role to a user via `$rbacadmin`

**Explanation regarding the last point:**
The existing event in `ilRbacAdmin::deassignUser()` is currently always thrown, even if the user does not get de-assigned from the role. This behavior is not consistent with the counterpart `ilRbacAdmin::assignUser()`. Here, the event is *NOT* thrown if the user was already assigned to the given role before. Thus, currently an event handler receives the event about a user being de-assigned from a role even though this is not true.

Also currently the debug logging: `ilLoggerFactory::getInstance()->getLogger('ac')->debug('Raise event deassign user');` is not very informative and should include the available parameters.

Could you provide any feedback to the introduced events? We would be happy if these would be available in the core (in the proposed or another form) by default to save us some patches :)

Best regards,
Stefan