### PR TITLE
20030 - Certificate offered although certificates were inactive 

### DIFF
--- a/Modules/Course/classes/class.ilCourseCertificateAdapter.php
+++ b/Modules/Course/classes/class.ilCourseCertificateAdapter.php
@@ -214,14 +214,13 @@ class ilCourseCertificateAdapter extends ilCertificateAdapter
 	 */
 	static function _hasUserCertificate($a_usr_id, $a_obj_id)
 	{
+	    self::_preloadListData($a_usr_id, $a_obj_id);
+        
 		if (isset(self::$has_certificate[$a_usr_id][$a_obj_id]))
 		{
 			return self::$has_certificate[$a_usr_id][$a_obj_id];
 		}
-		
-		// obsolete?
-		include_once 'Modules/Course/classes/class.ilCourseParticipants.php';
-		return ilCourseParticipants::getDateTimeOfPassed($a_obj_id, $a_usr_id);				
+		return false;
 	}
 }
 


### PR DESCRIPTION
This should fix a bug, where if a CourseReference has an LP-Status 'complete', the user was offered to download a certificate in the ListGUI, although certificates were inactive.
The part I removed was already commented "// obsolete?".

Originally requested by @theodortruffer some time ago...