### PR TITLE
moved raising to write status

### DIFF
--- a/Services/Tracking/service.xml
+++ b/Services/Tracking/service.xml
@@ -17,4 +17,5 @@
 	<crons>
 		<cron id="lp_object_statistics" class="ilLPCronObjectStatistics" />
 	</crons>
+	<logging />
 </service>


### PR DESCRIPTION
When the learning progress status is changed by a SCORM package, the corresponding "updateStatus" event of the learning progress is currently not fired. I did not test all SCORM configurations, but this is at least true for 1.2 packages that set the LP to be dependend on passing some SCOs.

This results in bugs if other components rely on these events. E.g. the badge system
http://www.ilias.de/mantis/view.php?id=18862

The main reasons are:

- The SCORM component currently calls ilLPStatus::writeStatus directly without calling ilLPStatus::_updateStatus like most other components do.
- Raising the "updateStatus" event is not centralized in writeStatus, which is the place that also updates the database. Instead there are multiple calls in refreshStatus and _updateStatus.

This PR moves the event raising to writeStatus (and adds some logging).