### PR TITLE
Fix for #20054

### DIFF
--- a/Services/WebServices/Curl/classes/class.ilCurlConnection.php
+++ b/Services/WebServices/Curl/classes/class.ilCurlConnection.php
@@ -37,11 +37,6 @@ include_once('Services/WebServices/Curl/classes/class.ilCurlConnectionException.
 
 class ilCurlConnection
 {
-	/**
-	 * @var ilLogger
-	 */
-	protected $log = null;
-	
 	protected $url = '';
 	protected $ch = null;
 
@@ -58,7 +53,6 @@ class ilCurlConnection
 	 */
 	public function __construct($a_url = '')
 	{
-		$this->log = $GLOBALS['DIC']->logger()->wsrv();
 		$this->url = $a_url;
 
 		if(!self::_isCurlExtensionLoaded())

--- a/setup/classes/class.ilClient.php
+++ b/setup/classes/class.ilClient.php
@@ -678,27 +678,41 @@ class ilClient
 	*/
 	function updateNIC($a_nic_url)
 	{
+		$max_redirects = 5;
+		$socket_timeout = 5;
+
+		require_once(__DIR__."/../../Services/WebServices/Curl/classes/class.ilCurlConnection.php");
+		if (!ilCurlConnection::_isCurlExtensionLoaded()) {
+			$this->setError("CURL-extension not loaded.");
+			return false;
+		}
+
+		$url = $this->getURLStringForNIC($a_nic_url);
+		$req = new ilCurlConnection($url);
+		$req->init();
+
 		$settings = $this->getAllSettings();
 		if((bool)$settings['proxy_status'] && strlen($settings['proxy_host']) && strlen($settings['proxy_port']))
 		{
-			$proxy_options = array(
-				'proxy_host' => $settings['proxy_host'],
-				'proxy_port' => $settings['proxy_port']
-			);
-		}
-		else
-		{
-			$proxy_options = array();
+			$req->setOpt(CURLOPT_HTTPPROXYTUNNEL, true);
+			$req->setOpt(CURLOPT_PROXY, $settings["proxy_host"]);
+			$req->setOpt(CURLOPT_PROXYPORT, $settings["proxy_port"]);
 		}
 
-		include_once('HTTP/Request.php');
-		$url = $this->getURLStringForNIC($a_nic_url);
-		$req = new HTTP_Request($url, $proxy_options);
+		$req->setOpt(CURLOPT_HEADER, 1);
+		$req->setOpt(CURLOPT_RETURNTRANSFER, 1);
+		$req->setOpt(CURLOPT_CONNECTTIMEOUT, $socket_timeout);
+		$req->setOpt(CURLOPT_FOLLOWLOCATION, 1);
+		$req->setOpt(CURLOPT_MAXREDIRS, $max_redirects);
+		$response = $req->exec();
 
-		$req->sendRequest();
-		$response = $req->getResponseBody();
+		$info = $req->getInfo();
+		if ($info["http_code"] != "200") {
+			$this->setError("Could not connect to NIC-Server at '".$url."'");
+			return false;
+		}
+
 		$response = explode("\n", $response);
-
 		$this->nic_status = $response;
 
 		return true;


### PR DESCRIPTION
Use ilCurlConnection instead of old PEAR/HTTP_Request for retrieval of NIC-ID.

(Ticket [#20054](http://www.ilias.de/mantis/view.php?id=20054))