### PR TITLE
fixed usage of custom html mail template

### DIFF
--- a/Services/Mail/classes/class.ilMimeMail.php
+++ b/Services/Mail/classes/class.ilMimeMail.php
@@ -381,16 +381,16 @@ class ilMimeMail
 		{
 			$mail->IsHTML(true);
 
-			$style = $ilClientIniFile->readVariable('layout', 'style');
+			$skin = $ilClientIniFile->readVariable('layout', 'skin');
 
 			$bracket_path = './Services/Mail/templates/default/tpl.html_mail_template.html';
-			if($style != 'delos')
+			if($skin != 'delos')
 			{
-				$tplpath = './Customizing/global/skin/' . $style . '/Services/Mail/tpl.html_mail_template.html';
+				$tplpath = './Customizing/global/skin/' . $skin . '/Services/Mail/tpl.html_mail_template.html';
 
 				if(@file_exists($tplpath))
 				{
-					$bracket_path = './Customizing/global/skin/' . $style . '/Services/Mail/tpl.html_mail_template.html';
+					$bracket_path = './Customizing/global/skin/' . $skin . '/Services/Mail/tpl.html_mail_template.html';
 				}
 			}
 			$bracket = file_get_contents($bracket_path);
@@ -410,9 +410,9 @@ class ilMimeMail
 			$mail->Body    = str_replace( '{PLACEHOLDER}', ilUtil::makeClickable( $this->body ), $bracket );
 
 			$directory = './Services/Mail/templates/default/img/';
-			if($style != 'delos')
+			if($skin != 'delos')
 			{
-				$directory = './Customizing/global/skin/' . $style . '/Services/Mail/img/';
+				$directory = './Customizing/global/skin/' . $skin . '/Services/Mail/img/';
 			}
 			$directory_handle  = @opendir($directory);
 			$files = array();


### PR DESCRIPTION
When using html mails with a custom mail template, the template could not be found since ilMimeMail reads the wrong client.ini variable. 'skin' is the name of the folder, whereas 'style' is the id, but not necessarily the name of the skin folder. 