### PR TITLE
removed unused instance var $tpl

### DIFF
--- a/Services/Certificate/classes/class.ilCertificate.php
+++ b/Services/Certificate/classes/class.ilCertificate.php
@@ -36,13 +36,6 @@ class ilCertificate
 	protected $ilias;
 
 	/**
-	* The reference to the Template class
-	*
-	* @var ilTemplate
-	*/
-	protected $tpl;
-
-	/**
 	* The reference to the Language class
 	*
 	* @var ilLanguage
@@ -85,7 +78,6 @@ class ilCertificate
 		global $DIC;
 
 		$this->lng      = $DIC['lng'];
-		$this->tpl      = $DIC['tpl'];
 		$this->ctrl     = $DIC['ilCtrl'];
 		$this->ilias    = $DIC['ilias'];
 		$this->tree     = $DIC['tree'];


### PR DESCRIPTION
ilCertificate instantiates with the Template as instance variable, which it doesn't use tough. Thus a certificate cannot be instantiated while in the CRON context. A cronjob of ours crashes when using certificates, therefore I would appreciate to remove this variable.