### PR TITLE
Improvement/5 2/plain text alternative

### DIFF
--- a/Services/Mail/classes/class.ilMimeMail.php
+++ b/Services/Mail/classes/class.ilMimeMail.php
@@ -404,7 +404,7 @@ class ilMimeMail
 			{
 				// Let's assume that there is no HTML, set body as plain text alternative and theb convert "\n" to "<br>"
 				$mail->AltBody = $this->body;
-				$this->body = nl2br($this->body);
+				$this->body = ilUtil::makeClickable(nl2br($this->body));
 			}
 			else
 			{
@@ -414,7 +414,7 @@ class ilMimeMail
 				$mail->AltBody = $alt_body;
 			}
 
-			$mail->Body    = str_replace( '{PLACEHOLDER}', ilUtil::makeClickable( $this->body ), $bracket );
+			$mail->Body    = str_replace( '{PLACEHOLDER}', $this->body, $bracket );
 
 			$directory = './Services/Mail/templates/default/img/';
 			if($style != 'delos')

--- a/Services/Mail/classes/class.ilMimeMail.php
+++ b/Services/Mail/classes/class.ilMimeMail.php
@@ -400,13 +400,20 @@ class ilMimeMail
 				$this->body  = ' ';
 			}
 
-			$mail->AltBody = $this->body;
-
 			if(strip_tags($this->body, '<b><u><i><a>') == $this->body)
 			{
-				// Let's assume that there is no HTML, so convert "\n" to "<br>" 
+				// Let's assume that there is no HTML, set body as plain text alternative and theb convert "\n" to "<br>"
+				$mail->AltBody = $this->body;
 				$this->body = nl2br($this->body);
 			}
+			else
+			{
+				// if there is HTML, convert "<br>" to "\n" and strip tags for plain text alternative
+				$breaks = array("<br />","<br>","<br/>");
+				$alt_body = strip_tags(str_ireplace($breaks, "\n", $this->body));
+				$mail->AltBody = $alt_body;
+			}
+
 			$mail->Body    = str_replace( '{PLACEHOLDER}', ilUtil::makeClickable( $this->body ), $bracket );
 
 			$directory = './Services/Mail/templates/default/img/';


### PR DESCRIPTION
This PR changes following:

- The 'AltBody' will now be the mail message without html tags and with '\n' instead of '<br>'. Phpmailer will send this as the plain text alternative to the html mail.

- ilUtil::makeClickable (convert links to html hyperliks) will only be called if there's no html in the mail body. If there is already a html hyperlink in the mail body and makeClickable is called, it would wrap the 'href'-part of the html tag in html tags, which would break the link.

Tell me if this needs more explanation ;)