### PR TITLE
Fix HTTPS detection for SOAP requests

### DIFF
--- a/webservice/soap/server.php
+++ b/webservice/soap/server.php
@@ -23,6 +23,7 @@ ilContext::init(ilContext::CONTEXT_SOAP);
 
 require_once("./Services/Init/classes/class.ilIniFile.php");
 $ilIliasIniFile = new ilIniFile("./ilias.ini.php");
+$ilIliasIniFile->read();
 
 if ((bool)$ilIliasIniFile->readVariable('https', 'auto_https_detect_enabled')) 
 {


### PR DESCRIPTION
Starting with ILIAS 5.2 the read() method of ilIniFile must be called explicitly. This fixes autodetection of HTTPS for SOAP requests (see http://www.ilias.de/mantis/view.php?id=16143).