### PR TITLE
[FIX] Mantis 20264: Undefined method call ilOPObjSettings::_lookupMode()

### DIFF
--- a/webservice/soap/classes/class.ilSoapLearningProgressAdministration.php
+++ b/webservice/soap/classes/class.ilSoapLearningProgressAdministration.php
@@ -207,7 +207,7 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
 		
 		// check lp available
 		include_once './Services/Tracking/classes/class.ilLPObjSettings.php';
-		$mode = ilLPObjSettings::_lookupMode($obj->getId());
+		$mode = ilLPObjSettings::_lookupDBMode($obj->getId());
 		if($mode == LP_MODE_UNDEFINED)
 		{
 			return $this->__raiseError('Error '.self::SOAP_LP_ERROR_LP_NOT_AVAILABLE.': Learning progress not available for objects of type '.


### PR DESCRIPTION
Please Cherry-Pick to other branches as well, where the name does not match.