### PR TITLE
This included file does not exist and is not required anymore.

### DIFF
--- a/Services/ActiveRecord/Views/Index/class.arIndexTableGUI.php
+++ b/Services/ActiveRecord/Views/Index/class.arIndexTableGUI.php
@@ -1,4 +1,5 @@
 <?php
+require_once('./Services/Table/classes/class.ilTable2GUI.php');
 require_once('./Services/ActiveRecord/class.ActiveRecordList.php');
 require_once('./Services/ActiveRecord/Views/Index/class.arIndexTableField.php');
 require_once('./Services/ActiveRecord/Views/Index/class.arIndexTableFields.php');

--- a/Services/ActiveRecord/Views/Index/class.arIndexTableGUI.php
+++ b/Services/ActiveRecord/Views/Index/class.arIndexTableGUI.php
@@ -1,5 +1,4 @@
 <?php
-require_once('./Services/ActiveRecord/class.srModelObjectTableGUI.php');
 require_once('./Services/ActiveRecord/class.ActiveRecordList.php');
 require_once('./Services/ActiveRecord/Views/Index/class.arIndexTableField.php');
 require_once('./Services/ActiveRecord/Views/Index/class.arIndexTableFields.php');


### PR DESCRIPTION
This included file does not exist and is not required anymore to build Table GUI’s. Deleting it solves the problem with no adverse effects.

Warning: Uncaught exception 'Whoops\Exception\ErrorException' with message 'require_once(./Services/ActiveRecord/class.srModelObjectTableGUI.php): failed to open stream: No such file or directory