### PR TITLE
Viewport for Mobile Devices

### DIFF
--- a/Modules/Scorm2004/templates/default/tpl.scorm2004.player.html
+++ b/Modules/Scorm2004/templates/default/tpl.scorm2004.player.html
@@ -6,7 +6,7 @@
 
 		{IE_COMPATIBILITY}
 
-		<meta name="viewport" content="user-scalable=yes, initial-scale=1.0, maximum-scale=2.0">
+		<meta name="viewport" content="user-scalable=yes, initial-scale=1.0, width=device-width">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 
 		<script type="text/javascript">//<![CDATA[

--- a/Modules/Scorm2004/templates/default/tpl.scorm2004.player.html
+++ b/Modules/Scorm2004/templates/default/tpl.scorm2004.player.html
@@ -3,7 +3,12 @@
 <html xmlns="http://www.w3.org/1999/xhtml" id="scormplayer">
 	<head>
 		<title>{DOC_TITLE}</title>
+
 		{IE_COMPATIBILITY}
+
+		<meta name="viewport" content="user-scalable=yes, initial-scale=1.0, maximum-scale=2.0">
+		<meta name="apple-mobile-web-app-capable" content="yes">
+
 		<script type="text/javascript">//<![CDATA[
 		Date.remoteOffset = (new Date()).getTime() - {TIMESTAMP};
 		//]]></script>
@@ -19,7 +24,7 @@
 		<!-- END rte_css -->
 
 		<base target="frmResource" />
-				
+
 		<!-- BEGIN js_file -->
 		<script type="text/javascript" src="{JS_FILE}"></script>
 		<!-- END js_file -->
@@ -66,11 +71,11 @@
 				<iframe id="res" style="width: 100%; height:100%;" frameborder="0"></iframe>
 			</div>
 		</div>
-		
+
 		<script type="text/javascript" src="./Modules/Scorm2004/scripts/rteconfig.js"></script>
 		<script type="text/javascript" src="{TREE_JS}"></script>
 
-		<script type="text/javascript" src="{JS_SCRIPTS}"></script>		
+		<script type="text/javascript" src="{JS_SCRIPTS}"></script>
 		<script type="text/javascript">
 		//<![CDATA[
 			init_cp_data={INIT_CP_DATA};
@@ -80,6 +85,6 @@
 			scorm_init({JS_DATA});
 		//]]>
 		</script>
-		
+
 	</body>
 </html>


### PR DESCRIPTION
When starting a SCORM2004 WBT in a new window, initializing a viewport for tablet devices deals with scalling of contents. We generally experience way better rendering on mobile devices as opposed to crunching measurements manually via CSS.

I know this is a very prominent place to change things, but fail to see downsides. 
Please correct me, if I'm mistaken...