### PR TITLE
[FIX] 20245: check if subobjects are visible for the user

### DIFF
--- a/Services/Tracking/classes/repository_statistics/class.ilLPListOfProgressGUI.php
+++ b/Services/Tracking/classes/repository_statistics/class.ilLPListOfProgressGUI.php
@@ -86,7 +86,11 @@ class ilLPListOfProgressGUI extends ilLearningProgressBaseGUI
 
 	function details()
 	{
-		global $ilToolbar,$ilCtrl,$rbacsystem;
+		global $ilToolbar,$ilCtrl,$rbacsystem, $ilAccess;
+
+		/**
+		 * @var $ilAccess ilAccessHandler
+		 */
 
 		// Show back button to crs if called from crs. Otherwise if called from personal desktop or administration
 		// show back to list
@@ -127,8 +131,10 @@ class ilLPListOfProgressGUI extends ilLearningProgressBaseGUI
 			{
 				if($collection instanceof ilLPCollectionOfRepositoryObjects)
 				{
-					$obj_ids[ilObject::_lookupObjectId($item_id)] = array($item_id);
-					
+					$obj_id = ilObject::_lookupObjectId($item_id);
+					if ($ilAccess->checkAccessOfUser($this->tracked_user->getId(), 'visible', '', $item_id)) {
+						$obj_ids[$obj_id] = array( $item_id );
+					}
 				}
 				else
 				{


### PR DESCRIPTION
As described here: http://www.ilias.de/mantis/view.php?id=20245

Not sure if this should be checked for 'visible' or 'read'