### PR TITLE
Set correct context to ilCtrl for users

### DIFF
--- a/Services/User/classes/class.ilObjUserGUI.php
+++ b/Services/User/classes/class.ilObjUserGUI.php
@@ -56,7 +56,7 @@ class ilObjUserGUI extends ilObjectGUI
 		$this->ctrl = $ilCtrl;
 		$this->ctrl->saveParameter($this, array('obj_id', 'letter'));
 		$this->ctrl->setParameterByClass("ilobjuserfoldergui", "letter", $_GET["letter"]);
-		
+		$this->ctrl->setContext($this->object->getId(), 'usr');
 		$lng->loadLanguageModule('user');
 		
 		// for gender selection. don't change this


### PR DESCRIPTION
`ilCtrl::setContext()` is not called in `ilObjUserGUI`. We often use the context information from `ilCtrl` in plugins, so it would be really useful if this would be available for user objects as well.
Thanks!