### PR TITLE
#20295 remove include mixed up for ilObjectPlugin ilObject2 ilObject

### DIFF
--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -1,8 +1,6 @@
 <?php
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once('./Services/Repository/classes/class.ilObjectPlugin.php');
-
 /**
 * Class ilObject
 * Basic functions for all objects
@@ -1671,7 +1669,7 @@ class ilObject
 		}
 		else
 		{
-			include_once("./Services/Component/classes/class.ilPlugin.php");
+			include_once("./Services/Component/classes/class.ilObjectPlugin.php");
 			$options[0] = ilObjectPlugin::lookupTxtById($new_type, "obj_".$new_type."_select");
 		}
 

--- a/Services/Repository/classes/class.ilObjectPlugin.php
+++ b/Services/Repository/classes/class.ilObjectPlugin.php
@@ -3,7 +3,6 @@
 
 include_once("./Services/Object/classes/class.ilObject2.php");
 require_once('./Services/Component/classes/class.ilPlugin.php');
-require_once('./Services/Repository/classes/class.ilObjectPlugin.php');
 
 /*
 * Object class for plugins. This one wraps around ilObject


### PR DESCRIPTION
We tried to run just the tests for the StudyProgramme and got an exception ilObject2 is not found. While researching the error we found this little include mixed up.