### PR TITLE
Active Record: Fixed outdated includes

### DIFF
--- a/Services/ActiveRecord/Views/Display/class.arDisplayField.php
+++ b/Services/ActiveRecord/Views/Display/class.arDisplayField.php
@@ -1,5 +1,5 @@
 <?php
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Views/class.arViewField.php');
+require_once('./Services/ActiveRecord/Views/class.arViewField.php');
 
 /**
  * GUI-Class arDisplayField

--- a/Services/ActiveRecord/Views/Display/class.arDisplayFields.php
+++ b/Services/ActiveRecord/Views/Display/class.arDisplayFields.php
@@ -1,6 +1,6 @@
 <?php
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Views/class.arViewField.php');
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Views/class.arViewFields.php');
+require_once('./Services/ActiveRecord/Views/class.arViewField.php');
+require_once('./Services/ActiveRecord/Views/class.arViewFields.php');
 
 /**
  * GUI-Class arDisplayFields

--- a/Services/ActiveRecord/Views/Display/class.arDisplayGUI.php
+++ b/Services/ActiveRecord/Views/Display/class.arDisplayGUI.php
@@ -1,7 +1,7 @@
 <?php
 require_once('./Services/Form/classes/class.ilPropertyFormGUI.php');
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Views/Display/class.arDisplayField.php');
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Views/Display/class.arDisplayFields.php');
+require_once('./Services/ActiveRecord/Views/Display/class.arDisplayField.php');
+require_once('./Services/ActiveRecord/Views/Display/class.arDisplayFields.php');
 
 /**
  * GUI-Class arDisplayGUI

--- a/Services/ActiveRecord/Views/Edit/class.arEditField.php
+++ b/Services/ActiveRecord/Views/Edit/class.arEditField.php
@@ -1,5 +1,5 @@
 <?php
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Views/class.arViewField.php');
+require_once('./Services/ActiveRecord/Views/class.arViewField.php');
 
 /**
  * GUI-Class arEditField

--- a/Services/ActiveRecord/Views/Edit/class.arEditFields.php
+++ b/Services/ActiveRecord/Views/Edit/class.arEditFields.php
@@ -1,6 +1,6 @@
 <?php
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Views/class.arViewField.php');
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Views/class.arViewFields.php');
+require_once('./Services/ActiveRecord/Views/class.arViewField.php');
+require_once('./Services/ActiveRecord/Views/class.arViewFields.php');
 
 /**
  * GUI-Class arEditFields

--- a/Services/ActiveRecord/Views/Edit/class.arEditGUI.php
+++ b/Services/ActiveRecord/Views/Edit/class.arEditGUI.php
@@ -1,7 +1,7 @@
 <?php
 require_once('./Services/Form/classes/class.ilPropertyFormGUI.php');
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Views/Edit/class.arEditField.php');
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Views/Edit/class.arEditFields.php');
+require_once('./Services/ActiveRecord/Views/Edit/class.arEditField.php');
+require_once('./Services/ActiveRecord/Views/Edit/class.arEditFields.php');
 
 /**
  * GUI-Class arEditGUI

--- a/Services/ActiveRecord/Views/Index/class.arIndexTableActions.php
+++ b/Services/ActiveRecord/Views/Index/class.arIndexTableActions.php
@@ -1,5 +1,5 @@
 <?php
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Views/Index/class.arIndexTableAction.php');
+require_once('./Services/ActiveRecord/Views/Index/class.arIndexTableAction.php');
 
 /**
  * GUI-Class arIndexTableActions

--- a/Services/ActiveRecord/Views/Index/class.arIndexTableField.php
+++ b/Services/ActiveRecord/Views/Index/class.arIndexTableField.php
@@ -1,5 +1,5 @@
 <?php
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Views/class.arViewField.php');
+require_once('./Services/ActiveRecord/Views/class.arViewField.php');
 
 /**
  * GUI-Class arIndexTableField

--- a/Services/ActiveRecord/Views/Index/class.arIndexTableFields.php
+++ b/Services/ActiveRecord/Views/Index/class.arIndexTableFields.php
@@ -1,6 +1,6 @@
 <?php
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Views/class.arViewField.php');
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Views/class.arViewFields.php');
+require_once('./Services/ActiveRecord/Views/class.arViewField.php');
+require_once('./Services/ActiveRecord/Views/class.arViewFields.php');
 
 /**
  * GUI-Class arIndexTableFields

--- a/Services/ActiveRecord/Views/Index/class.arIndexTableGUI.php
+++ b/Services/ActiveRecord/Views/Index/class.arIndexTableGUI.php
@@ -1,10 +1,10 @@
 <?php
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/class.srModelObjectTableGUI.php');
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/class.ActiveRecordList.php');
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Views/Index/class.arIndexTableField.php');
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Views/Index/class.arIndexTableFields.php');
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Views/Index/class.arIndexTableAction.php');
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Views/Index/class.arIndexTableActions.php');
+require_once('./Services/Table/classes/class.ilTable2GUI.php');
+require_once('./Services/ActiveRecord/class.ActiveRecordList.php');
+require_once('./Services/ActiveRecord/Views/Index/class.arIndexTableField.php');
+require_once('./Services/ActiveRecord/Views/Index/class.arIndexTableFields.php');
+require_once('./Services/ActiveRecord/Views/Index/class.arIndexTableAction.php');
+require_once('./Services/ActiveRecord/Views/Index/class.arIndexTableActions.php');
 
 /**
  * GUI-Class arIndexTableGUI
@@ -282,7 +282,7 @@ class arIndexTableGUI extends ilTable2GUI {
 	 * @description returns false, if dynamic template is needed, otherwise implement your own template by $this->setRowTemplate($a_template, $a_template_dir = '')
 	 */
 	protected function initTableRowTemplate() {
-		$this->setRowTemplate('tpl.record_row.html', './Customizing/global/plugins/Libraries/ActiveRecord/');
+		$this->setRowTemplate('tpl.record_row.html', './Services/ActiveRecord/');
 	}
 
 
@@ -683,7 +683,7 @@ class arIndexTableGUI extends ilTable2GUI {
 	 */
 	public function render() {
 
-		$index_table_tpl = new ilTemplate("tpl.index_table.html", true, true, "./Customizing/global/plugins/Libraries/ActiveRecord/");
+		$index_table_tpl = new ilTemplate("tpl.index_table.html", true, true, "./Services/ActiveRecord/");
 		if ($this->getToolbar()) {
 			$index_table_tpl->setVariable("TOOLBAR", $this->getToolbar()->getHTML());
 		}

--- a/Services/ActiveRecord/Views/class.arGUI.php
+++ b/Services/ActiveRecord/Views/class.arGUI.php
@@ -1,7 +1,7 @@
 <?php
 include_once("./Services/Component/classes/class.ilPluginConfigGUI.php");
-include_once('./Customizing/global/plugins/Libraries/ActiveRecord/class.ActiveRecordList.php');
-include_once('./Customizing/global/plugins/Libraries/ActiveRecord/Views/Index/class.arIndexTableGUI.php');
+include_once('./Services/ActiveRecord/class.ActiveRecordList.php');
+include_once('./Services/ActiveRecord/Views/Index/class.arIndexTableGUI.php');
 include_once('./Services/UICore/classes/class.ilTemplate.php');
 
 /**

--- a/Services/ActiveRecord/Views/class.arViewField.php
+++ b/Services/ActiveRecord/Views/class.arViewField.php
@@ -1,5 +1,5 @@
 <?php
-include_once('./Customizing/global/plugins/Libraries/ActiveRecord/Fields/class.arField.php');
+include_once('./Services/ActiveRecord/Fields/class.arField.php');
 
 /**
  * GUI-Class arViewField
@@ -262,9 +262,9 @@ class arViewField extends arField {
 	 * @return arViewField
 	 */
 	static function castFromFieldToViewField(arField $field) {
-		require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Views/Index/class.arIndexTableField.php');
-		require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Views/Edit/class.arEditField.php');
-		require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Views/Display/class.arDisplayField.php');
+		require_once('./Services/ActiveRecord/Views/Index/class.arIndexTableField.php');
+		require_once('./Services/ActiveRecord/Views/Edit/class.arEditField.php');
+		require_once('./Services/ActiveRecord/Views/Display/class.arDisplayField.php');
 
 		$field_class = get_called_class();
 		$obj = new $field_class($field->getName());

--- a/Services/ActiveRecord/Views/class.arViewFields.php
+++ b/Services/ActiveRecord/Views/class.arViewFields.php
@@ -1,6 +1,6 @@
 <?php
-include_once('./Customizing/global/plugins/Libraries/ActiveRecord/Fields/class.arField.php');
-include_once('./Customizing/global/plugins/Libraries/ActiveRecord/Views/class.arViewField.php');
+include_once('./Services/ActiveRecord/Fields/class.arField.php');
+include_once('./Services/ActiveRecord/Views/class.arViewField.php');
 
 /**
  * GUI-Class arViewFields

--- a/Services/ActiveRecord/_Examples/Config/class.arConfig.php
+++ b/Services/ActiveRecord/_Examples/Config/class.arConfig.php
@@ -1,5 +1,5 @@
 <?php
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/class.ActiveRecord.php');
+require_once('./Services/ActiveRecord/class.ActiveRecord.php');
 
 /**
  * Class arConfig

--- a/Services/ActiveRecord/_Examples/Message/class.arMessageList.php
+++ b/Services/ActiveRecord/_Examples/Message/class.arMessageList.php
@@ -1,5 +1,5 @@
 <?php
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/class.ActiveRecordList.php');
+require_once('./Services/ActiveRecord/class.ActiveRecordList.php');
 require_once('class.arMessage.php');
 
 /**

--- a/Services/ActiveRecord/_Examples/Message/class.arUser.php
+++ b/Services/ActiveRecord/_Examples/Message/class.arUser.php
@@ -1,5 +1,5 @@
 <?php
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/class.ActiveRecord.php');
+require_once('./Services/ActiveRecord/class.ActiveRecord.php');
 
 /**
  * Class arUser

--- a/Services/ActiveRecord/_Examples/RealRecord/class.arRealRecord.php
+++ b/Services/ActiveRecord/_Examples/RealRecord/class.arRealRecord.php
@@ -1,5 +1,5 @@
 <?php
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/class.ActiveRecord.php');
+require_once('./Services/ActiveRecord/class.ActiveRecord.php');
 
 /**
  * Class arRealRecord

--- a/Services/ActiveRecord/_Examples/StorageRecord/class.arStorageRecord.php
+++ b/Services/ActiveRecord/_Examples/StorageRecord/class.arStorageRecord.php
@@ -1,6 +1,6 @@
 <?php
 require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Demo/StorageRecord/class.arStorageRecordStorage.php');
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Storage/int.arStorageInterface.php');
+require_once('./Services/ActiveRecord/Storage/int.arStorageInterface.php');
 
 /**
  * Class arTestRecord

--- a/Services/ActiveRecord/_Examples/StorageRecord/class.arStorageRecord.php
+++ b/Services/ActiveRecord/_Examples/StorageRecord/class.arStorageRecord.php
@@ -1,5 +1,5 @@
 <?php
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Demo/StorageRecord/class.arStorageRecordStorage.php');
+require_once('./Services/ActiveRecord/_Examples/StorageRecord/class.arStorageRecordStorage.php');
 require_once('./Services/ActiveRecord/Storage/int.arStorageInterface.php');
 
 /**

--- a/Services/ActiveRecord/_Examples/StorageRecord/class.arStorageRecordGUI.php
+++ b/Services/ActiveRecord/_Examples/StorageRecord/class.arStorageRecordGUI.php
@@ -1,9 +1,8 @@
 <?php
 require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Demo/StorageRecord/class.arStorageRecord.php');
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Views/Edit/class.arEditGUI.php');
+require_once('./Services/ActiveRecord/Views/Edit/class.arEditGUI.php');
 require_once('./Services/PersonalDesktop/classes/class.ilPersonalDesktopGUI.php');
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Views/Index/class.arIndexTableGUI.php');
-//require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Views/View/class.ActiveRecordViewGUI.php');
+require_once('./Services/ActiveRecord/Views/Index/class.arIndexTableGUI.php');
 
 /**
  * Class arStorageRecordGUI

--- a/Services/ActiveRecord/_Examples/StorageRecord/class.arStorageRecordGUI.php
+++ b/Services/ActiveRecord/_Examples/StorageRecord/class.arStorageRecordGUI.php
@@ -1,5 +1,5 @@
 <?php
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Demo/StorageRecord/class.arStorageRecord.php');
+require_once('./Services/ActiveRecord/_Examples/StorageRecord/class.arStorageRecord.php');
 require_once('./Services/ActiveRecord/Views/Edit/class.arEditGUI.php');
 require_once('./Services/PersonalDesktop/classes/class.ilPersonalDesktopGUI.php');
 require_once('./Services/ActiveRecord/Views/Index/class.arIndexTableGUI.php');

--- a/Services/ActiveRecord/_Examples/StorageRecord/class.arStorageRecordStorage.php
+++ b/Services/ActiveRecord/_Examples/StorageRecord/class.arStorageRecordStorage.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Storage/class.arStorage.php');
+require_once('./Services/ActiveRecord/Storage/class.arStorage.php');
 
 /**
  * Class arTestRecordStorage

--- a/Services/ActiveRecord/_Examples/ilias.php
+++ b/Services/ActiveRecord/_Examples/ilias.php
@@ -13,7 +13,7 @@ global $ilCtrl, $tpl;
 $tpl->getStandardTemplate();
 $tpl->setVariable('BASE', '/');
 
-require_once('./Customizing/global/plugins/Libraries/ActiveRecord/Demo/StorageRecord/class.arStorageRecordGUI.php');
+require_once('./Services/ActiveRecord/_Examples/StorageRecord/class.arStorageRecordGUI.php');
 
 $arTestRecordGUI = new arStorageRecordGUI();
 $arTestRecordGUI->executeCommand();


### PR DESCRIPTION
Fixes File not found errors.

Fixed wrong ActiveRecord includes, which were pointing to the former location (from times when the active record was not part of the ILIAS core) at: /Customizing/global/plugins/Libraries

Please also pull down to branch: release_5-2