### PR TITLE
Fixes wrong type of $this->return

### DIFF
--- a/Services/UICore/classes/class.ilCtrl.php
+++ b/Services/UICore/classes/class.ilCtrl.php
@@ -72,7 +72,7 @@ class ilCtrl
 		$this->parent = array();			// parent array (reverse forward)
 		$this->save_parameter = array();	// save parameter array
 		$this->parameter = array();			// save parameter array
-		$this->return = "";					// return commmands
+		$this->return = array();			// return commmands
 		$this->location = array();
 		$this->tab = array();
 		$this->current_node = 0;

--- a/Services/UICore/classes/class.ilTemplate.php
+++ b/Services/UICore/classes/class.ilTemplate.php
@@ -41,7 +41,7 @@ class ilTemplate extends HTML_Template_ITX
 	private $addFooter; // creates an output of the ILIAS footer
 
 	protected static $il_cache = array();
-	protected $message = "";
+	protected $message = array();
 	
 	protected $title_desc = "";	
 	protected $title_url = "";


### PR DESCRIPTION
This fixes a very blatant type bug, that probably has evaded recognition due to PHP 5's all too lenient type handling.

I would strongly suggest porting this to ILIAS 5.2.

$this->return is expected to be an array, and not a string; having a string here produces PHP 7 Illegal string offset errors when writing or reading it. This happens as soon as trying to log in into any completely clean PHP 7 installation of ILIAS (which won't succeed, but produce the error described, thus rendering the installation completely unusable).

The typical error one sees on PHP 7 due to this is as follow:

```
Whoops\Exception\ErrorException thrown with message "Illegal string offset 'ilpe
rsonaldesktopgui'"

Stacktrace:
#5 Whoops\Exception\ErrorException in /var/www/html/Services/UICore/classes/clas
s.ilCtrl.php:1502
#4 ilErrorHandling:handlePreWhoops in /var/www/html/Services/UICore/classes/clas
s.ilCtrl.php:1502
#3 ilCtrl:setReturn in /var/www/html/Services/PersonalDesktop/classes/class.ilPe
rsonalDesktopGUI.php:78
#2 ilPersonalDesktopGUI:executeCommand in /var/www/html/Services/UICore/classes/
class.ilCtrl.php:188
#1 ilCtrl:forwardCommand in /var/www/html/Services/UICore/classes/class.ilCtrl.p
hp:150
#0 ilCtrl:callBaseClass in /var/www/html/ilias.php:21
```

**UPDATE** The reason I ran into this is that my `php.ini` didn't carry the recommended ILIAS error reporting flags (http://www.ilias.de/docu/goto.php?target=pg_6531_367&client_id=docu). I still think this should be fixed.