### PR TITLE
add further error information to error log handler

### DIFF
--- a/Services/Init/classes/class.ilErrorHandling.php
+++ b/Services/Init/classes/class.ilErrorHandling.php
@@ -436,7 +436,8 @@ class ilErrorHandling extends PEAR
 			if(is_object($ilLog)) {
 				// ak: default log level of write() is INFO, which is not appropriate -> set this to warning
 				include_once './Services/Logging/classes/public/class.ilLogLevel.php';
-				$ilLog->write('ERROR (' . $exception->getCode() .') ' . $exception->getMessage(), ilLogLevel::WARNING);
+				$message = $exception->getMessage().' in '.$exception->getFile().":".$exception->getLine();
+				$ilLog->write('ERROR (' . $exception->getCode() .') ' . $message, ilLogLevel::WARNING);
 			}
 			
 			// Send to system logger


### PR DESCRIPTION
Message examples.

Before
`[rnk1l] [2017-04-05 08:52:09.007627] trunk_root.WARNING: ilErrorHandling::{closure}:50 ERROR (4) parse error, expecting `','' or `';''`

After
`[rnk1l] [2017-04-05 09:05:20.662613] trunk_root.WARNING: ilErrorHandling::{closure}:50 ERROR (4) parse error, expecting `','' or `';'' in /Library/WebServer/Documents/ev_ilias/trunk/Modules/Course/classes/class.ilObjCourse.php:42`

Now it is possible to see in log in which class and the exception was thrown.