### PR TITLE
use mb_detect_encoding in strict mode (fix for #0019524)

### DIFF
--- a/Services/Utilities/classes/class.ilStr.php
+++ b/Services/Utilities/classes/class.ilStr.php
@@ -155,7 +155,7 @@ class ilStr
 	{
 		if (function_exists("mb_detect_encoding"))
 		{
-			if (mb_detect_encoding($a_str, "UTF-8") == "UTF-8")
+			if (mb_detect_encoding($a_str, "UTF-8", true) == "UTF-8")
 			{
 				return true;
 			}


### PR DESCRIPTION
php's mb_detect_encoding must be used in strict mode, otherwise in won't detect the encoding correctly. Further explanation: http://stackoverflow.com/questions/39117203/php-function-mb-detect-encoding-strict-mode