### PR TITLE
Change directory structure and Naming Convention for the ILIAS UI-Framework

### DIFF
--- a/src/UI/README.md
+++ b/src/UI/README.md
@@ -34,7 +34,7 @@ Testing.
 
 As a user of the ILIAS UI-Framework your entry point to the framework is provided
 via the dependency injection container `$DIC->ui()->factory()`, which gives you
-access to the main factory implementing ILIAS\UI\Factory.
+access to the main factory implementing ILIAS\UI\ComponentFactory.
 
 ### How to Discover the Components in the Framework?
 
@@ -109,7 +109,7 @@ source code in the trunk.
 
 If you would like to implement a new component to the framework you should perform the following tasks:
 
-1. Add your new component into the respective factory interface. E.g. If you introduce a component of a completely new type, you MUST add the description to the main factory (src/UI/Factory.php). If you add a new type of a button, you MUST add the description to the existing factory for buttons, located at src/UI/Component/Button/Factory.
+1. Add your new component into the respective factory interface. E.g. If you introduce a component of a completely new type, you MUST add the description to the main factory (src/UI/ComponentFactory.php). If you add a new type of a button, you MUST add the description to the existing factory for buttons, located at src/UI/Component/Button/ButtonFactory.
 2. The description MUST use the following template:
 
     ``` php
@@ -153,7 +153,7 @@ If you would like to implement a new component to the framework you should perfo
     ```
 
 3. This freshly added function in the factory leads to an error as soon as ILIAS is opened, since the implementation
- of the factory (located at src/UI/Implementation/Factory.php) does not implement that function yet. For
+ of the factory (located at src/UI/ComponentFactoryImpl.php) does not implement that function yet. For
  the moment, implement it, as follows:
  
     ``` php
@@ -162,7 +162,7 @@ If you would like to implement a new component to the framework you should perfo
     */
     public function demo($content)
     {
-        throw new \ILIAS\UI\NotImplementedException();
+        throw new \ILIAS\UI\Exception\NotImplementedUIException();
     }
     ```
 
@@ -239,15 +239,15 @@ If you would like to implement a new component to the framework you should perfo
     class DemoTest extends ILIAS_UI_TestBase {
 
         public function test_implements_factory_interface() {
-            $f = new \ILIAS\UI\Implementation\Factory();
+            $f = new \ILIAS\UI\ComponentFactoryImpl();
 
-            $this->assertInstanceOf("ILIAS\\UI\\Factory", $f);
+            $this->assertInstanceOf("ILIAS\\UI\\ComponentFactory", $f);
             $demo = $f->demo("Demo Implementation!");
             $this->assertInstanceOf( "ILIAS\\UI\\Component\\Demo\\Demo", $demo);
         }
 
         public function test_get_content() {
-            $f = new \ILIAS\UI\Implementation\Factory();
+            $f = new \ILIAS\UI\ComponentFactoryImpl();
             $demo = $f->demo("Demo Implementation!");
 
             $this->assertEquals($demo->getContent(), "Demo Implementation!");
@@ -255,7 +255,7 @@ If you would like to implement a new component to the framework you should perfo
 
         public function test_render_content() {
             $r = $this->getDefaultRenderer();
-            $f = new \ILIAS\UI\Implementation\Factory();
+            $f = new \ILIAS\UI\ComponentFactoryImpl();
             $demo = $f->demo("Demo Implementation!");
 
 
@@ -268,16 +268,15 @@ If you would like to implement a new component to the framework you should perfo
     }
     ```
 
-8. Currently you will only get the NotImplementedException you throwed previously. That needs to be changed.
-  First, add an implementation for the new interface (add it at src/UI/Implementation/Component/Demo/Demo.php):
+8. Currently you will only get the NotImplementedUIException you threw previously. That needs to be changed.
+  First, add an implementation for the new interface (add it at src/UI/Component/Demo/DefaultDemo.php):
     ``` php
     <?php
-    namespace ILIAS\UI\Implementation\Component\Demo;
+    namespace ILIAS\UI\Component\Demo;
+    
+    use ILIAS\UI\Component\ComponentHelper;
 
-    use ILIAS\UI\Component\Demo as D;
-    use ILIAS\UI\Implementation\Component\ComponentHelper;
-
-    class Demo implements D\Demo {
+    class DefaultDemo implements Demo {
         use ComponentHelper;
 
         /**
@@ -302,22 +301,22 @@ If you would like to implement a new component to the framework you should perfo
         }
     }
     ```
-9. Next, make the factory return the new component (change demo() of src/UI/Implementation/Factory.php):
+9. Next, make the factory return the new component (change demo() of src/UI/ComponentFactoryImpl.php):
 
     ``` php
-    return new Component\Demo\Demo($content);
+    return new Component\Demo\DefaultDemo($content);
     ```
 
-10. Then, implement the renderer at src/UI/Implementation/Component/Demo/Demo.php:
+10. Then, implement the renderer for src/UI/Component/Demo/Demo.php:
     ``` php
     <?php
 
     /* Copyright (c) 2016 Timon Amstutz <timon.amstutz@ilub.unibe.ch> Extended GPL, see docs/LICENSE */
 
-    namespace ILIAS\UI\Implementation\Component\Demo;
+    namespace ILIAS\UI\Component\Demo;
 
-    use ILIAS\UI\Implementation\Render\AbstractComponentRenderer;
-    use ILIAS\UI\Renderer as RendererInterface;
+    use ILIAS\UI\Render\AbstractComponentRenderer;
+    use ILIAS\UI\Render\Renderer as RendererInterface;
     use ILIAS\UI\Component;
 
     class Renderer extends AbstractComponentRenderer {


### PR DESCRIPTION
As a preparation, I changed the naming and directory / namespaces in the README file to give a quick overview how it would be.

I will explain why I would change the directory structure and add a name convention to the UI-Framework.

# Why I come up with this?
I started to introduce me to the ILIAS UI-Framework and I easily understood the usage of the framework, but was confused by the directory structure. The main reason for this was, due the heavy separation of interfaces and its implementations as well as the naming of the classes and interfaces. After a while, I could see how to create new types of existing components as well as how to create new components. However, I still think its more complex than it can be. It needs quite a few steps to create a new component and a good knowledge of the Framework. Furthermore, often new interfaces and its implementations needs to be written, even when creating a new kind of an existing component.

Another problem was the naming of the factories. Every factory class or interface is just called *Factory*, which dosen't say anything about what it is. It's only clear when you look at the namespace, which can be bothering when you don't see it at the moment and have to scroll to the top of the class to check the `use` statement.

# What are the changes?
The main change would be to place the implementations of the components to the same directory / namespace like the interface. This would group up parts of the Framework which belong together.

## Move implementations to their interfaces
When moving the implementations to their interfaces it would change the directory structure like this.

Example with the Button component.

```
src/UI/
	Component/
		Button/
			Button.php 			<- interface
			PrimaryButton.php 		<- class implements Button
			StandardButton.php 		<- class implements Button
			JSButton.php 			<- interface
			CloseButton.php 		<- class implements JSButton
			ButtonFactory.php 		<- interface
			ButtonFactoryImpl.php 	        <- class implements ButtonFactory
			ButtonRenderer.php 		<- class
		Card/
		Counter/
		Deck/
		Image/
```

As you can see, you have a component *Button* and all its related classes or interfaces in one place. As a result, if you want to create a new kind of Button, just go to the component dircetory, create the class and add it to the  factory. As long as you don't need additional methods you don't even have to create a new interface, because there is already one for buttons.

> I already used some naming convention in the example above. I will explain this part later.

## Advantages
* exact one place where a component and its related classes or interfaces is located
* less complex
* still referenced with interfaces, so the user doesn't need to know which implementation he gets
* unique namespaces (not meant namespaces aren't unique otherwise, but there are no (almost) equal namespaces expect for that one word which makes the difference e.g. `ILIAS\UI\Component` and `ILIAS\UI\Implementation\Component` like it is at the moment)
* Easy to understand, everyone can find the implementation of a component by just looking into the directory.
* interchange a special kind of a component is still easy

## Disadvantages
* the directories are larger, because the interface and its implementation will be in the same directory
* interchange a whole component will be more complicated, because the interfaces aren't seperetad available

## Sounds cool, but what about...
Currently there are some other implementations in the Implementation directory, e.g. Crawler. Where are they now?

At the moment, there are two other directories and two classes inside the Implementation directory.

* Crawler
* Render
* DefaultRenderer.php
* Factory.php

These directories and classes would be moved to the `src/UI/` directory just like the `Component` directory.

  
# Move specific classes or interfaces to an according place
Currently there are some classes and interfaces which look like they don't have a according place or its just seems wrong where they are.

* `src/UI/Implementation/Factory.php`
	* move to `src/UI/`, because its the main thing of this framework
* `src/UI/Implementation/DefaultRenderer.php`
	* move to `src/UI/Render/`, because its a Renderer, so why not put it into this directory
* `src/UI/Renderer.php`
	* move to `src/UI/Render/`, same reason like for the DefaultRenderer.php 
* `src/UI/NotImplementedException.php`
	* move to `src/UI/Exception`, preperation for further possible exceptions
* `src/UI/table.php` (I'm not sure what this class is about) 
 
 
# Naming Convention
Now, with all these changes there would be a problem with the current names of the classes and interfaces. And in general there should be a naming convention to avoid confusing names.

## Components
Classes and interfaces for componets should use the following rules.

1. The main or default interface is called like the directory.
2. Additional interfaces for more specific components of the same type are called according to the functionallity they provide. e.g. Button with Dropdow is called *DrowdownButton*
3. An implementation of a component has the component name in its name. e.g. *PrimaryButton*

The factory class and interface for a component should use the following rules.

1. The factory interface has the component name ending with the word *Factory* in its name. e.g. *ButtonFactory*
2. An default implementation of a factory interface is called like the interface ending with *Impl*. e.g. *ButtonFactoryImpl*, this is a common way to name default implementations
3. Any further specific implementation of a factory interface, if neccessary, is called according to the functionality it provides ending with the name of the interface. e.g. *MockButtonFactory*

The renderer class of a component should use the following rules.

1. The name of the component ending with *Renderer*.
2. Any further specific renderer, if neccessary, is called according to the functionality it provides ending with *Renderer*. e.g. *MockButtonRenderer*

## Main Factory

The factory class and its implementation for the main factory would be renamed to the following names.

* `Factory` -> `ComponentFactory` (interface)
* `Factory` -> `ComponentFactoryImpl` (implementation of ComponentFactory)

## Exceptions
Exceptions should have something in their name, which refer them to the UI-Framework.

e.g. the *NotImplementedExcepiton* should be called *NotImplementedUIException*.

# How would it look like
With all the changes the directory structure and the names of the classes and interfaces would look like this.

The Button component is taken as a full example

```
scr/UI/
	Component/
		Button/
			Button.php
			PrimaryPutton.php
			StandardButton.php
			JSButton.php
			CloseButton.php
			ButtonFactory.php
			ButtonFactoryImpl.php
			ButtonRenderer.php
		Card/
		Counter/
		Deck/
		Glyph/
		Image/
		Clickable.php
		Component.php
		Hoverable.php
		JavaScriptBindable.php
		Onloadable.php
		Signal.php
		Triggerable.php
		Triggerer.php
	ComponentFactory.php
	ComponentFactoryImpl.php
	Crawler/
	docu/
	examples/
	Exception/
		NotImplementedUIException.php
	Render/
		Renderer.php
		DefaultRenderer.php
		AbstractComponentRenderer.php
		ComponentRenderer.php
		ilJavaSrciptBinding.php
		ilResourceRegistry.php
		ilTemplateWrapper.php
		ilTemplateWrapperFactory.php
		JavaScriptBinding.php
		ResoucreRegistry.php
		Template.php
		TemplateFactory.php
	templates/
```

# A last word
It is important to understand, that all these changes **do not affect the usage** of the UI-Framework.

It **only affects the development process** when creating or editing components.