### PR TITLE
Rename Exception in the ILIAS UI Framework

### DIFF
--- a/src/UI/Implementation/Component/Card/Card.php
+++ b/src/UI/Implementation/Component/Card/Card.php
@@ -6,7 +6,7 @@ namespace ILIAS\UI\Implementation\Component\Card;
 
 use ILIAS\UI\Component\Card as C;
 use ILIAS\UI\Implementation\Component\ComponentHelper;
-use ILIAS\UI\NotImplementedException;
+use ILIAS\UI\NotImplementedUIException;
 
 class Card implements C\Card {
 	use ComponentHelper;
@@ -101,27 +101,27 @@ class Card implements C\Card {
 	 * @inheritdoc
 	 */
 	public function withTitleAction($url){
-		throw new NotImplementedException();
+		throw new NotImplementedUIException();
 	}
 
 	/**
 	 * @inheritdoc
 	 */
 	public function getTitleAction(){
-		throw new NotImplementedException();
+		throw new NotImplementedUIException();
 	}
 
 	/**
 	 * @inheritdoc
 	 */
 	public function withHighlight($status){
-		throw new NotImplementedException();
+		throw new NotImplementedUIException();
 	}
 
 	/**
 	 * @inheritdoc
 	 */
 	public function isHighlighted(){
-		throw new NotImplementedException();
+		throw new NotImplementedUIException();
 	}
 }

--- a/src/UI/Implementation/Component/Image/Image.php
+++ b/src/UI/Implementation/Component/Image/Image.php
@@ -6,7 +6,7 @@ namespace ILIAS\UI\Implementation\Component\Image;
 
 use ILIAS\UI\Component as C;
 use ILIAS\UI\Implementation\Component\ComponentHelper;
-use ILIAS\UI\NotImplementedException;
+use ILIAS\UI\NotImplementedUIException;
 
 /**
  * Class Image
@@ -99,13 +99,13 @@ class Image implements C\Image\Image {
 	 * @inheritdoc
 	 */
 	public function withAction($url){
-		throw new NotImplementedException();
+		throw new NotImplementedUIException();
 	}
 
 	/**
 	 * @inheritdoc
 	 */
 	public function getAction(){
-		throw new NotImplementedException();
+		throw new NotImplementedUIException();
 	}
 }

--- a/src/UI/NotImplementedUIException.php
+++ b/src/UI/NotImplementedUIException.php
@@ -8,5 +8,5 @@ namespace ILIAS\UI;
  * This exception indicates that an UI component was accepted by the JF but is
  * not backed by a real implementation.
  */
-class NotImplementedException extends \Exception {
+class NotImplementedUIException extends \Exception {
 }


### PR DESCRIPTION
Exceptions in the UI Framework should refer to the UI Framework in their name.

The NotImplementedException should be called NotImplemetedUIException.

