### PR TITLE
0020582: Fatal Error when opening settings of a wiki

### DIFF
--- a/Modules/Wiki/classes/class.ilObjWikiGUI.php
+++ b/Modules/Wiki/classes/class.ilObjWikiGUI.php
@@ -709,7 +709,7 @@ class ilObjWikiGUI extends ilObjectGUI
 		$lng->loadLanguageModule("wiki");
 		$ilTabs->activateTab("settings");
 		
-		include("Services/Form/classes/class.ilPropertyFormGUI.php");
+		require_once("Services/Form/classes/class.ilPropertyFormGUI.php");
 		$this->form_gui = new ilPropertyFormGUI();
 		
 		// Title


### PR DESCRIPTION
The usage of this include doesn't normally result in an error, but it does e.g. when using a UIHook-Plugin which includes the ilPropertyFormGUI as well. 
That's what will happen: When opening a wiki and clicking on "Settings" in the right pane, the following error occurs: 'Cannot redeclare class ilPropertyFormGUI'

The error also occurs with versions 5.0 and 5.2.