### PR TITLE
More robust handling of missing answerdepth in QTI

### DIFF
--- a/Modules/TestQuestionPool/classes/import/qti12/class.assOrderingQuestionImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assOrderingQuestionImport.php
@@ -246,7 +246,10 @@ class assOrderingQuestionImport extends assQuestionImport
 			else
 			{
 				$element->setPosition($position++);
-				$element->setIndentation($answer['answerdepth']);
+                if(isset($answer['answerdepth']))
+                {
+                    $element->setIndentation($answer['answerdepth']);
+                }
 			}
 			
 			if( $this->object->isImageOrderingType() )


### PR DESCRIPTION
This is a proposal for a handling QTI imports of ordering questions that miss the `answerdepth` field.

Even though this kind of import is no longer officially supported, we still import tests from ILIAS EA in our installation here.

It's in this context that some tests (from ILIAS EA) will generate an SQL constraint errors due to ordering questions missing the `answerdepth` field, more specifically:

```
PDOException thrown with message "SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'depth' cannot be null"

Stacktrace:
#20 PDOException in /srv/www/htdocs/ilias/Services/Database/classes/PDO/class.ilDBPdo.php:594
#19 PDO:exec in /srv/www/htdocs/ilias/Services/Database/classes/PDO/class.ilDBPdo.php:594
#18 ilDBPdo:insert in /srv/www/htdocs/ilias/Modules/TestQuestionPool/classes/questions/class.ilAssOrderingElementList.php:157
#17 ilAssOrderingElementList:saveToDb in /srv/www/htdocs/ilias/Modules/TestQuestionPool/classes/class.assOrderingQuestion.php:967
#16 assOrderingQuestion:saveAnswerSpecificDataToDb in /srv/www/htdocs/ilias/Modules/TestQuestionPool/classes/class.assOrderingQuestion.php:139
#15 assOrderingQuestion:saveToDb in /srv/www/htdocs/ilias/Modules/TestQuestionPool/classes/import/qti12/class.assOrderingQuestionImport.php:269
#14 assOrderingQuestionImport:fromXML in /srv/www/htdocs/ilias/Modules/TestQuestionPool/classes/class.assQuestion.php:445
#13 assQuestion:fromXML in /srv/www/htdocs/ilias/Services/QTI/classes/class.ilQTIParser.php:1334
#12 ilQTIParser:handlerParseEndTag in /srv/www/htdocs/ilias/Services/QTI/classes/class.ilQTIParser.php:1072
#11 ilQTIParser:handlerEndTag in [internal]:0
#10 xml_parse in /srv/www/htdocs/ilias/Services/Xml/classes/class.ilSaxParser.php:191
#9 ilSaxParser:parse in /srv/www/htdocs/ilias/Services/Xml/classes/class.ilSaxParser.php:115
#8 ilSaxParser:startParsing in /srv/www/htdocs/ilias/Services/QTI/classes/class.ilQTIParser.php:257
#7 ilQTIParser:startParsing in /srv/www/htdocs/ilias/Modules/Test/classes/class.ilObjTestGUI.php:1303
#6 ilObjTestGUI:importVerifiedFileObject in /srv/www/htdocs/ilias/Modules/Test/classes/class.ilObjTestGUI.php:678
#5 ilObjTestGUI:executeCommand in /srv/www/htdocs/ilias/Services/UICore/classes/class.ilCtrl.php:188
#4 ilCtrl:forwardCommand in /srv/www/htdocs/ilias/Services/Repository/classes/class.ilRepositoryGUI.php:350
#3 ilRepositoryGUI:show in /srv/www/htdocs/ilias/Services/Repository/classes/class.ilRepositoryGUI.php:304
#2 ilRepositoryGUI:executeCommand in /srv/www/htdocs/ilias/Services/UICore/classes/class.ilCtrl.php:188
#1 ilCtrl:forwardCommand in /srv/www/htdocs/ilias/Services/UICore/classes/class.ilCtrl.php:150
#0 ilCtrl:callBaseClass in /srv/www/htdocs/ilias/ilias.php:21
```

This PR fixes this by simply checking the existence of the field in the imported QTI.

