### PR TITLE
20510

### DIFF
--- a/Services/Database/classes/PDO/class.ilDBPdo.php
+++ b/Services/Database/classes/PDO/class.ilDBPdo.php
@@ -216,7 +216,7 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface {
 
 	public function generateDSN() {
 		$this->dsn = 'mysql:host=' . $this->getHost() . ($this->getDbname() ? ';dbname=' . $this->getDbname() : '') . ';charset='
-		             . $this->getCharset();
+			. $this->getCharset();
 	}
 
 
@@ -249,9 +249,9 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface {
 			$stmt->closeCursor();
 			$next_id = $rows['sequence'] + 1;
 			$stmt = $this->pdo->prepare("DELETE FROM $sequence_table_name");
-			$stmt->execute(array( "next_id" => $next_id ));
+			$stmt->execute(array("next_id" => $next_id));
 			$stmt = $this->pdo->prepare("INSERT INTO $sequence_table_name (sequence) VALUES (:next_id)");
-			$stmt->execute(array( "next_id" => $next_id ));
+			$stmt->execute(array("next_id" => $next_id));
 
 			return $next_id;
 		}
@@ -354,7 +354,7 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface {
 		}
 		$definition = array(
 			'primary' => true,
-			'fields'  => $fields,
+			'fields' => $fields,
 		);
 		$this->manager->createConstraint($table_name, $this->constraintName($table_name, $this->getPrimaryKeyIdentifier()), $definition);
 
@@ -406,7 +406,7 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface {
 	 */
 	public function tableExists($table_name) {
 		$result = $this->pdo->prepare("SHOW TABLES LIKE :table_name");
-		$result->execute(array( 'table_name' => $table_name ));
+		$result->execute(array('table_name' => $table_name));
 		$return = $result->rowCount();
 		$result->closeCursor();
 
@@ -1265,9 +1265,9 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface {
 	 * @param int $a_len
 	 * @return string
 	 */
-	public function substr($a_exp, $a_pos = 1, $a_len = - 1) {
+	public function substr($a_exp, $a_pos = 1, $a_len = -1) {
 		$lenstr = "";
-		if ($a_len > - 1) {
+		if ($a_len > -1) {
 			$lenstr = ", " . $a_len;
 		}
 
@@ -1307,13 +1307,18 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface {
 	/**
 	 * @param $stmt
 	 * @param array $data
-	 * @return bool
+	 * @throws ilDatabaseException
+	 * @return ilDBStatement
 	 */
 	public function execute($stmt, $data = array()) {
 		/**
 		 * @var $stmt ilPDOStatement
 		 */
-		return $stmt->execute($data);
+		$result = $stmt->execute($data);
+		if ($result === false) {
+			throw new ilDatabaseException(implode(', ', $stmt->errorInfo()), $stmt->errorCode());
+		}
+		return $stmt;
 	}
 
 
@@ -1529,7 +1534,7 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface {
 			throw new ilDatabaseException("ilDB Error: renameTable(" . $a_name . "," . $a_new_name . ")<br />" . $e->getMessage());
 		}
 
-		$this->manager->alterTable($a_name, array( "name" => $a_new_name ), false);
+		$this->manager->alterTable($a_name, array("name" => $a_new_name), false);
 
 		// The abstraction_progress is no longer used in ILIAS, see http://www.ilias.de/mantis/view.php?id=19513
 		//		$query = "UPDATE abstraction_progress " . "SET table_name = " . $this->quote($a_new_name, 'text') . " " . "WHERE table_name = "
@@ -1853,7 +1858,7 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface {
 	 * @param $a_data
 	 */
 	public function executeMultiple($stmt, $a_data) {
-		for ($i = 0, $j = count($a_data); $i < $j; $i ++) {
+		for ($i = 0, $j = count($a_data); $i < $j; $i++) {
 			$stmt->execute($a_data[$i]);
 		}
 	}
@@ -1881,13 +1886,13 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface {
 	 * Generate an insert, update or delete query and call prepare() and execute() on it
 	 *
 	 * @param string $tablename of the table
-	 * @param array $fields     ($key=>$value) where $key is a field name and $value its value
-	 * @param int $mode         of query to build
+	 * @param array $fields ($key=>$value) where $key is a field name and $value its value
+	 * @param int $mode of query to build
 	 *                          ilDBConstants::MDB2_AUTOQUERY_INSERT
 	 *                          ilDBConstants::MDB2_AUTOQUERY_UPDATE
 	 *                          ilDBConstants::MDB2_AUTOQUERY_DELETE
 	 *                          ilDBConstants::MDB2_AUTOQUERY_SELECT
-	 * @param bool $where       (in case of update and delete queries, this string will be put after the sql WHERE statement)
+	 * @param bool $where (in case of update and delete queries, this string will be put after the sql WHERE statement)
 	 *
 	 * @deprecated Will be removed in ILIAS 5.3
 	 * @return bool

--- a/Services/Database/classes/PDO/class.ilPDOStatement.php
+++ b/Services/Database/classes/PDO/class.ilPDOStatement.php
@@ -97,4 +97,18 @@ class ilPDOStatement implements ilDBStatement {
 
 		return $this;
 	}
+
+	/**
+	 * @return string
+	 */
+	public function errorCode() {
+		return $this->pdo_statement->errorCode();
+	}
+
+	/**
+	 * @return array
+	 */
+	public function errorInfo() {
+		return $this->pdo_statement->errorInfo();
+	}
 }

--- a/Services/Database/interfaces/interface.ilDBInterface.php
+++ b/Services/Database/interfaces/interface.ilDBInterface.php
@@ -404,7 +404,8 @@ interface ilDBInterface {
 	/**
 	 * @param $stmt
 	 * @param array $data
-	 * @return bool
+	 * @throws ilDatabaseException
+	 * @return ilDBStatement
 	 */
 	public function execute($stmt, $data = array());
 
@@ -782,13 +783,13 @@ interface ilDBPdoInterface {
 	 * Generate an insert, update or delete query and call prepare() and execute() on it
 	 *
 	 * @param string $tablename of the table
-	 * @param array $fields     ($key=>$value) where $key is a field name and $value its value
-	 * @param int $mode         of query to build
+	 * @param array $fields ($key=>$value) where $key is a field name and $value its value
+	 * @param int $mode of query to build
 	 *                          ilDBConstants::MDB2_AUTOQUERY_INSERT
 	 *                          ilDBConstants::MDB2_AUTOQUERY_UPDATE
 	 *                          ilDBConstants::MDB2_AUTOQUERY_DELETE
 	 *                          ilDBConstants::MDB2_AUTOQUERY_SELECT
-	 * @param string $where     (in case of update and delete queries, this string will be put after the sql WHERE statement)
+	 * @param string $where (in case of update and delete queries, this string will be put after the sql WHERE statement)
 	 *
 	 * @deprecated Will be removed in ILIAS 5.3
 	 * @return bool


### PR DESCRIPTION
Fixes Mantis 20510: `ilDBInterface::execute()` must return the statement again instead of a boolean to guarantee backwards compatibility with `ilDB`.