### PR TITLE
add mapping of glossary terms when glossary is cloned

### DIFF
--- a/Modules/Glossary/classes/class.ilObjGlossary.php
+++ b/Modules/Glossary/classes/class.ilObjGlossary.php
@@ -1266,11 +1266,11 @@ class ilObjGlossary extends ilObject implements ilAdvancedMetaDataSubItems
 		}
 		
 		// copy terms
-        $term_mappings = array();
+		$term_mappings = array();
 		foreach (ilGlossaryTerm::getTermList($this->getId()) as $term)
 		{
 			$new_term_id = ilGlossaryTerm::_copyTerm($term["id"], $new_obj->getId());
-            $term_mappings[$term["id"]] = $new_term_id;
+			$term_mappings[$term["id"]] = $new_term_id;
 			
 			// copy tax node assignments
 			if ($tax_id > 0)
@@ -1289,7 +1289,7 @@ class ilObjGlossary extends ilObject implements ilAdvancedMetaDataSubItems
 		// add mapping of term_ids to copy wizard options
 		if (!empty($term_mappings))
 		{
-            $cp_options->appendMapping($this->getRefId().'_glo_terms', (array) $term_mappings);
+			$cp_options->appendMapping($this->getRefId().'_glo_terms', (array) $term_mappings);
 		}
 
 

--- a/Modules/Glossary/classes/class.ilObjGlossary.php
+++ b/Modules/Glossary/classes/class.ilObjGlossary.php
@@ -1266,9 +1266,11 @@ class ilObjGlossary extends ilObject implements ilAdvancedMetaDataSubItems
 		}
 		
 		// copy terms
+        $term_mappings = array();
 		foreach (ilGlossaryTerm::getTermList($this->getId()) as $term)
 		{
 			$new_term_id = ilGlossaryTerm::_copyTerm($term["id"], $new_obj->getId());
+            $term_mappings[$term["id"]] = $new_term_id;
 			
 			// copy tax node assignments
 			if ($tax_id > 0)
@@ -1283,6 +1285,13 @@ class ilObjGlossary extends ilObject implements ilAdvancedMetaDataSubItems
 				}
 			}
 		}
+
+		// add mapping of term_ids to copy wizard options
+		if (!empty($term_mappings))
+		{
+            $cp_options->appendMapping($this->getRefId().'_glo_terms', (array) $term_mappings);
+		}
+
 
 		return $new_obj;
 	}

--- a/Services/CopyWizard/classes/class.ilCopyWizardOptions.php
+++ b/Services/CopyWizard/classes/class.ilCopyWizardOptions.php
@@ -480,8 +480,8 @@ class ilCopyWizardOptions
 	 * Add mapping of source -> target
 	 *
 	 * @access public
-	 * @param int source ref_id
-	 * @param int target ref_id
+	 * @param int|string    $a_source_id    array key of mapping entry
+	 * @param mixed         $a_target_id    array value of mapping entry
 	 * 
 	 */
 	public function appendMapping($a_source_id,$a_target_id)


### PR DESCRIPTION
This is a new version of pull request #442, now for the trunk. It adds a mapping of glossary term ids to the mappings of the copy wizard options when a glossary is cloned. This allows the Flashcards plugin to update its referenced glossary terms when it is copied together with the source glossary. 

See https://github.com/ILIAS-eLearning/ILIAS/pull/442 for previous discussion.
It would be helpful to merge the changes in the maintaned releases, too. The additional mappings don't change any existing functionality of the core.