### PR TITLE
Fix/0020404/5 2/chache miss without active module

### DIFF
--- a/Services/GlobalCache/classes/Xcache/class.ilXcache.php
+++ b/Services/GlobalCache/classes/Xcache/class.ilXcache.php
@@ -4,12 +4,26 @@ require_once('./Services/GlobalCache/classes/class.ilGlobalCacheService.php');
 /**
  * Class ilXcache
  *
+ * Concrete XCache implementation.
+ *
  * @author  Fabian Schmid <fs@studer-raimann.ch>
- * @version 1.0.0
+ * @version 1.0.1
  */
 class ilXcache extends ilGlobalCacheService {
 
 	const MIN_MEMORY = 32;
+
+
+	/**
+	 * ilXcache constructor.
+	 *
+	 * @param $serviceId
+	 * @param $component
+	 */
+	public function __construct($serviceId, $component) {
+		parent::__construct($serviceId, $component);
+		$this->readValid();
+	}
 
 
 	/**
@@ -134,6 +148,37 @@ class ilXcache extends ilGlobalCacheService {
 	protected function getMinMemory() {
 		return self::MIN_MEMORY;
 	}
+
+	/**
+	 * @return void
+	 *
+	 * @description save self::$valid_keys to GlobalCache
+	 */
+	protected function saveValid() {
+		if ($this->isActive()) {
+			if ($this->valid_key_hash != md5(serialize($this->valid_keys))) {
+				$this->set('valid_keys', $this->serialize($this->valid_keys));
+			}
+		}
+	}
+
+
+	/**
+	 * @return void
+	 *
+	 * @description set self::$valid_keys from GlobalCache
+	 */
+	protected function readValid() {
+		if ($this->isActive() && $this->isInstallable()) {
+			$this->valid_keys = $this->unserialize($this->get('valid_keys'));
+			$this->valid_key_hash = md5(serialize($this->valid_keys));
+		}
+	}
+
+	public function __destruct() {
+		$this->saveValid();
+	}
+
 }
 
 ?>

--- a/Services/GlobalCache/classes/class.ilGlobalCacheService.php
+++ b/Services/GlobalCache/classes/class.ilGlobalCacheService.php
@@ -3,8 +3,10 @@
 /**
  * Class ilGlobalCacheService
  *
+ * Base class for all concrete cache implementations.
+ *
  * @author  Fabian Schmid <fs@studer-raimann.ch>
- * @version 1.0.0
+ * @version 1.0.1
  */
 abstract class ilGlobalCacheService {
 
@@ -51,40 +53,6 @@ abstract class ilGlobalCacheService {
 		$this->setServiceId($service_id);
 		self::$active[get_called_class()] = $this->getActive();
 		self::$installable[get_called_class()] = ($this->getInstallable() AND $this->checkMemory());
-		//		$this->current_time = time();
-		$this->readValid();
-	}
-
-
-	public function __destruct() {
-		$this->saveValid();
-	}
-
-
-	/**
-	 * @return bool
-	 *
-	 * @description save self::$valid_keys to GlobalCache
-	 */
-	protected function saveValid() {
-		if ($this->isActive()) {
-			if ($this->valid_key_hash != md5(serialize($this->valid_keys))) {
-				$this->set('valid_keys', $this->serialize($this->valid_keys));
-			}
-		}
-	}
-
-
-	/**
-	 * @return bool
-	 *
-	 * @description set self::$valid_keys from GlobalCache
-	 */
-	protected function readValid() {
-		if ($this->isActive() && $this->isInstallable()) {
-			$this->valid_keys = $this->unserialize($this->get('valid_keys'));
-			$this->valid_key_hash = md5(serialize($this->valid_keys));
-		}
 	}
 
 
@@ -151,17 +119,6 @@ abstract class ilGlobalCacheService {
 
 
 	/**
-	 * @param $key
-	 *
-	 * @return bool|void
-	 */
-	public function setValid($key) {
-		$this->valid_keys[$key] = true;
-		//		$this->valid_keys[$key] = time();
-	}
-
-
-	/**
 	 * @return string
 	 */
 	public function getComponent() {
@@ -174,28 +131,6 @@ abstract class ilGlobalCacheService {
 	 */
 	public function setComponent($component) {
 		$this->component = $component;
-	}
-
-
-	/**
-	 * @param null $key
-	 */
-	public function setInvalid($key = null) {
-		if ($key) {
-			unset($this->valid_keys[$key]);
-		} else {
-			unset($this->valid_keys);
-		}
-	}
-
-
-	/**
-	 * @param $key
-	 *
-	 * @return bool
-	 */
-	public function isValid($key) {
-		return isset($this->valid_keys[$key]);
 	}
 
 
@@ -322,6 +257,55 @@ abstract class ilGlobalCacheService {
 	 */
 	public function getServiceType() {
 		return $this->service_type;
+	}
+
+
+	/**
+	 * Declare a key as valid. If the key is already known no action is taken.
+	 *
+	 * This method exists only for legacy reasons and has only a real function
+	 * in combination with XCache.
+	 *
+	 * @param string $key The key which should be declared as valid.
+	 *
+	 * @return void
+	 */
+	public function setValid($key) {
+		$this->valid_keys[$key] = true;
+	}
+
+	/**
+	 * Set the key as invalid.
+	 * This method will invalidate all keys if no argument is given or null.
+	 *
+	 * This method exists only for legacy reasons and has only a real function
+	 * in combination with XCache.
+	 *
+	 * @param string $key   The key which should be invalidated or null to invalidate all.
+	 *
+	 * @return void
+	 */
+	public function setInvalid($key = null) {
+		if ($key !== NULL) {
+			unset($this->valid_keys[$key]);
+		} else {
+			unset($this->valid_keys);
+		}
+	}
+
+
+	/**
+	 * Checks whether the cache key is valid or not.
+	 *
+	 * This method exists only for legacy reasons and has only a real function
+	 * in combination with XCache.
+	 *
+	 * @param string $key   The key which should be checked.
+	 *
+	 * @return bool True if the key is valid otherwise false.
+	 */
+	public function isValid($key) {
+		return isset($this->valid_keys[$key]);
 	}
 }
 

--- a/Services/GlobalCache/classes/class.ilGlobalCacheService.php
+++ b/Services/GlobalCache/classes/class.ilGlobalCacheService.php
@@ -222,8 +222,6 @@ abstract class ilGlobalCacheService {
 	 */
 	public function returnKey($key) {
 		return $str = $this->getServiceId() . '_' . $this->getComponent() . '_' . $key;
-
-		return str_replace('/', '_', $str);
 	}
 
 


### PR DESCRIPTION
Fixed mantis ticket: 0020404

I moved the read and save valid keys into the XCache implementation specific part to avoid useless cache hits even if no modules are active. Tested with APCu and static cache.