### PR TITLE
New event in ilObject if object is cloned

### DIFF
--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -1767,8 +1767,10 @@ class ilObject
 
 		$ilAppEventHandler->raise('Services/Object',
 								  'clone',
-								  array('object' => $this,
-								  		'obj_id' => $this->getId()
+								  array('parent' => $this,
+								  		'parent_id' => $this->getId(),
+								  		'new_object' => $new_obj,
+								  		'new_object_id' => $new_obj->getId()
 								  )
 							);
 

--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -1708,7 +1708,7 @@ class ilObject
 	 */
 	public function cloneObject($a_target_id,$a_copy_id = 0, $a_omit_tree = false)
 	{
-		global $objDefinition,$ilUser,$rbacadmin, $ilDB;
+		global $objDefinition,$ilUser,$rbacadmin, $ilDB, $ilAppEventHandler;
 		
 		$location = $objDefinition->getLocation($this->getType());
 		$class_name = ('ilObj'.$objDefinition->getClassName($this->getType()));
@@ -1764,7 +1764,14 @@ class ilObject
 			"WHERE obj_id = ".$ilDB->quote($this->getId(),'integer');
 		$res = $ilDB->manipulate($query);
 		// END WebDAV: Clone WebDAV properties
-		
+
+		$ilAppEventHandler->raise('Services/Object',
+								  'clone',
+								  array('object' => $this,
+								  		'obj_id' => $this->getId()
+								  )
+							);
+
 		return $new_obj;
 	}
 	

--- a/Services/Object/service.xml
+++ b/Services/Object/service.xml
@@ -15,6 +15,7 @@
 		<event type="raise" id="toTrash" />
 		<event type="raise" id="delete" />
 		<event type="raise" id="undelete" />
+		<event type="raise" id="clone" />
 	</events>
 	<logging />
 </service>


### PR DESCRIPTION
This event will be thrown after a object is cloned. We think it would be nice to have the option to act with the new object right after his creation.
For sure it could be possible to use the create event, but we will never now the new is cloned from another.