### PR TITLE
New event in ilObject if object is deleted

### DIFF
--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -1375,7 +1375,7 @@ class ilObject
 	*/
 	function delete()
 	{
-		global $rbacadmin, $log, $ilDB;
+		global $rbacadmin, $log, $ilDB, $ilAppEventHandler;
 
 		$remove = false;
 
@@ -1501,6 +1501,13 @@ class ilObject
 			$ch->delete($this->getRefId());
 			unset($ch);
 		}
+
+		$ilAppEventHandler->raise('Services/Object',
+								  'delete',
+								  array('object' => $this,
+								  		'obj_id' => $this->getId()
+								  )
+							);
 
 		return $remove;
 	}


### PR DESCRIPTION
Some objects throws an event after the deletion like category. But at least not all are doing this.
We would like to have that every deleted object throws an event if it is deleted.