### PR TITLE
#20046, #19140 Throw exception if unserialize went wrong

### DIFF
--- a/Services/Language/classes/class.ilLanguage.php
+++ b/Services/Language/classes/class.ilLanguage.php
@@ -365,6 +365,11 @@ class ilLanguage
 		$row = $r->fetchRow(ilDBConstants::FETCHMODE_ASSOC);
 		
 		$new_text = unserialize($row["lang_array"]);
+
+		if($new_text === false) {
+			throw new Exception("Data for module: ".$a_module." language: ".$lang_key." could not be unserialized");
+		}
+
 		if (is_array($new_text))
 		{
 			$this->text = array_merge($this->text, $new_text);


### PR DESCRIPTION
We stumbled upon this problem in one of our installation. After researching the problem we found, that the array, saved in database, could not be unserialized with used collation of the table. In our case it was utf8_swedish_ci.

We would like to introduce that ILIAS throws an exception, if unserialize went wrong.