### PR TITLE
Data type "link"

### DIFF
--- a/src/Data/Factory.php
+++ b/src/Data/Factory.php
@@ -40,7 +40,7 @@ class Factory {
 	 * Color is a data type representing a color in HTML.
 	 * Construct a color with a hex-value or list of RGB-values.
 	 *
-	 * @param  string|int[] $value
+	 * @param  string|int[]
 	 * @return Color
 	 */
 	public function color($value) {

--- a/src/Data/Factory.php
+++ b/src/Data/Factory.php
@@ -40,7 +40,7 @@ class Factory {
 	 * Color is a data type representing a color in HTML.
 	 * Construct a color with a hex-value or list of RGB-values.
 	 *
-	 * @param  string|int[]
+	 * @param  string|int[] $value
 	 * @return Color
 	 */
 	public function color($value) {
@@ -50,5 +50,14 @@ class Factory {
 		return $this->colorfactory->build($value);
 	}
 
-
+	/**
+	 * A Link is a pair of label and URL.
+	 *
+	 * @param  string 	$label
+	 * @param  string 	$url
+	 * @return Link
+	 */
+	public function link($label, $url) {
+		return new Link\Link($label, $url);
+	}
 }

--- a/src/Data/Link/Link.php
+++ b/src/Data/Link/Link.php
@@ -36,7 +36,7 @@ class Link {
 	 *
 	 * @return string
 	 */
-	public function getLabel() {
+	public function label() {
 		return $this->label;
 	}
 
@@ -45,7 +45,7 @@ class Link {
 	 *
 	 * @return string
 	 */
-	public function getURL() {
+	public function url() {
 		return $this->url;
 	}
 

--- a/src/Data/Link/Link.php
+++ b/src/Data/Link/Link.php
@@ -1,0 +1,52 @@
+<?php
+/* Copyright (c) 2017 Nils Haagen <nils.haagen@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Data\Link;
+
+/**
+ * A link consists of a label and an URL.
+ *
+ * @author Nils Haagen <nils.haagen@concepts-and-training.de>
+ */
+class Link {
+
+	/**
+	 * @var string
+	 */
+	protected $label;
+
+	/**
+	 * @var string
+	 */
+	protected $url;
+
+
+	public function __construct($label, $url) {
+		assert('is_string($label)');
+		assert('is_string($url)');
+		if(trim($url) === '') {
+			throw new \InvalidArgumentException("You MUST provide an URL.", 1);
+		}
+		$this->label = $label;
+		$this->url = $url;
+	}
+
+	/**
+	 * Return the label
+	 *
+	 * @return string
+	 */
+	public function getLabel() {
+		return $this->label;
+	}
+
+	/**
+	 * Return the url
+	 *
+	 * @return string
+	 */
+	public function getURL() {
+		return $this->url;
+	}
+
+}

--- a/src/Data/README.md
+++ b/src/Data/README.md
@@ -119,29 +119,6 @@ assert($pi->value() === 3);
 ```
 
 
-## Color
-Color is a data type representing a color in HTML.
-Construct a color with a hex-value or list of RGB-values.
-
-### Example
-
-```php
-<?php
-use ILIAS\Data;
-
-$f = new Data\Factory;
-//construct color with rgb-values:
-$rgb = $f->color(array(255,255,0));
-
-//construct color with hex-value:
-$hex = $f->color('#ffff00');
-
-assert($rgb->asHex() === '#ffff00');
-assert($hex->asRGBString() === 'rgb(255, 255, 0)');
-?>
-```
-
-
 ## Link
 A Link is a tuple of label and URL.
 

--- a/src/Data/README.md
+++ b/src/Data/README.md
@@ -154,7 +154,7 @@ use ILIAS\Data;
 $f = new Data\Factory;
 $l = $f->link('ILIAS Homepage', 'http://www.ilias.de');
 
-assert($l->getLabel() === 'ILIAS Homepage');
-assert($l->getURL() === 'http://www.ilias.de');
+assert($l->label() === 'ILIAS Homepage');
+assert($l->url() === 'http://www.ilias.de');
 ?>
 ```

--- a/src/Data/README.md
+++ b/src/Data/README.md
@@ -117,3 +117,39 @@ assert($pi->value() === 3);
 
 ?>
 ```
+
+
+## Color
+Color is a data type representing a color in HTML.
+Construct a color with a hex-value or list of RGB-values.
+<?php
+use ILIAS\Data;
+
+$f = new Data\Factory;
+//construct color with rgb-values:
+$rgb = $f->color(array(255,255,0));
+
+//construct color with hex-value:
+$hex = $f->color('#ffff00');
+
+assert($rgb->asHex() === '#ffff00');
+assert($hex->asRGBString() === 'rgb(255, 255, 0)');
+?>
+```
+
+
+## Link
+A Link is a tuple of label and URL.
+### Example
+
+```php
+<?php
+use ILIAS\Data;
+
+$f = new Data\Factory;
+$l = $f->link('ILIAS Homepage', 'http://www.ilias.de');
+
+assert($l->getLabel() === 'ILIAS Homepage');
+assert($l->getURL() === 'http://www.ilias.de');
+?>
+```

--- a/src/Data/README.md
+++ b/src/Data/README.md
@@ -122,6 +122,10 @@ assert($pi->value() === 3);
 ## Color
 Color is a data type representing a color in HTML.
 Construct a color with a hex-value or list of RGB-values.
+
+### Example
+
+```php
 <?php
 use ILIAS\Data;
 
@@ -140,6 +144,7 @@ assert($hex->asRGBString() === 'rgb(255, 255, 0)');
 
 ## Link
 A Link is a tuple of label and URL.
+
 ### Example
 
 ```php

--- a/tests/Data/LinkTest.php
+++ b/tests/Data/LinkTest.php
@@ -1,0 +1,39 @@
+<?php
+/* Copyright (c) 2017 Nils Haagen <nils.haagen@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+require_once("libs/composer/vendor/autoload.php");
+use ILIAS\Data;
+
+/**
+ * Tests working with link data object
+ *
+ * @author Nils Haagen <nils.haagen@concepts-and-training.de>
+ */
+class LinkTest extends PHPUnit_Framework_TestCase {
+	protected function setUp() {
+		$this->f = new Data\Factory();
+	}
+
+	protected function tearDown() {
+		$this->f = null;
+	}
+
+	public function testContruction() {
+		$l = $this->f->link('the label', 'http://www.ilias.de');
+
+		$this->assertInstanceOf(Data\Link\Link::class, $l);
+		$this->assertEquals('the label', $l->getLabel());
+		$this->assertEquals('http://www.ilias.de', $l->getURL());
+	}
+
+	public function testContructionWrongParams() {
+		try {
+			$v = $this->f->link('the label','');
+			$this->assertFalse("This should not happen.");
+		}
+		catch (\InvalidArgumentException $e) {
+			$this->assertTrue(true);
+		}
+	}
+
+}

--- a/tests/Data/LinkTest.php
+++ b/tests/Data/LinkTest.php
@@ -22,8 +22,8 @@ class LinkTest extends PHPUnit_Framework_TestCase {
 		$l = $this->f->link('the label', 'http://www.ilias.de');
 
 		$this->assertInstanceOf(Data\Link\Link::class, $l);
-		$this->assertEquals('the label', $l->getLabel());
-		$this->assertEquals('http://www.ilias.de', $l->getURL());
+		$this->assertEquals('the label', $l->label());
+		$this->assertEquals('http://www.ilias.de', $l->url());
 	}
 
 	public function testContructionWrongParams() {


### PR DESCRIPTION
As @klees commented [here](https://github.com/ILIAS-eLearning/ILIAS/pull/544#discussion_r121111675), a data-type "link" would come in handy for several components.
There is also a lot of enhancements potential with a link, e.g. alter/retrieve only parts of the URL, add/get params, etc...
