### PR TITLE
Bug 20790 Fix:  Different vertical position of text in bib list item table

### DIFF
--- a/Services/Form/templates/default/tpl.non_editable_value.html
+++ b/Services/Form/templates/default/tpl.non_editable_value.html
@@ -1,3 +1,3 @@
-<span id="{ID}">{VALUE}</span>
+<span class="ilFormNonEditable" id="{ID}">{VALUE}</span>
 <!-- BEGIN hidden --><input type="hidden" name="{NON_EDITABLE_ID}" value="{HVALUE}" id="hidden{MULTI_HIDDEN_ID}"/><!-- END hidden -->
 {MULTI_ICONS}

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -7688,6 +7688,10 @@ div.ilFormExternalSetting span {
 div[id^="ilFormField"] {
   margin-bottom: 10px;
 }
+span.ilFormNonEditable {
+  display: inline-block;
+  padding-top: 4px;
+}
 /* Hierarchy Form */
 div.ilHFormHeader,
 div.ilHFormFooter {

--- a/templates/default/less/Services/Form/delos.less
+++ b/templates/default/less/Services/Form/delos.less
@@ -148,6 +148,11 @@ div[id^="ilFormField"] {
 	margin-bottom: 10px;
 }
 
+span.ilFormNonEditable {
+	display:inline-block;
+	padding-top:4px;
+}
+
 /* Hierarchy Form */
 div.ilHFormHeader, div.ilHFormFooter {
 	color: darken(@ilFormColor, 20%);


### PR DESCRIPTION
This is a possible fix for the vertical positioning of non-editable fields "the old way".