### PR TITLE
UI Listing Panel / Standard Item extensions

### DIFF
--- a/src/UI/Component/Item/Factory.php
+++ b/src/UI/Component/Item/Factory.php
@@ -12,7 +12,8 @@ interface Factory {
  	 *   composition: >
 	 *       A list item consists of a title and the following optional elements:
 	 *       description, action drop down, properties (name/value), a text or
-	 *       image lead and a color.
+	 *       image lead and a color. Property values MAY be interactive by using
+	 *       Shy Buttons.
  	 * rules:
 	 *    accessibility:
 	 *      1: >

--- a/src/UI/Component/Item/Factory.php
+++ b/src/UI/Component/Item/Factory.php
@@ -19,7 +19,7 @@ interface Factory {
 	 *       Information MUST NOT be provided by color alone. The same information could
 	 *       be presented, e.g. in a property to enable screen reader access.
 	 * ---
-	 * @param string $title Title of the item
+	 * @param string|\ILIAS\UI\Component\Button\Shy $title Title of the item
 	 * @return \ILIAS\UI\Component\Item\Standard
 	 */
 	public function standard($title);

--- a/src/UI/Component/Item/Item.php
+++ b/src/UI/Component/Item/Item.php
@@ -11,7 +11,7 @@ interface Item extends \ILIAS\UI\Component\Component {
 	/**
 	 * Gets the title of the item 
 	 *
-	 * @return string
+	 * @return string|\ILIAS\UI\Component\Button\Shy
 	 */
 	public function getTitle();
 
@@ -34,7 +34,7 @@ interface Item extends \ILIAS\UI\Component\Component {
 	 * The key is holding the title and the value is holding the content of the
 	 * specific data set.
 	 *
-	 * @param array<string,string> $properties Label => Content
+	 * @param array<string,string|\ILIAS\UI\Component\Button\Shy> $properties Label => Content
 	 * @return self
 	 */
 	public function withProperties(array $properties);
@@ -42,7 +42,7 @@ interface Item extends \ILIAS\UI\Component\Component {
 	/**
 	 * Get the properties of the appointment.
 	 *
-	 * @return array<string,string>		Title => Content
+	 * @return array<string,string|\ILIAS\UI\Component\Button\Shy>		Title => Content
 	 */
 	public function getProperties();
 

--- a/src/UI/Component/Panel/Listing/Listing.php
+++ b/src/UI/Component/Panel/Listing/Listing.php
@@ -22,4 +22,18 @@ interface Listing extends \ILIAS\UI\Component\Component {
 	 * @return \ILIAS\UI\Component\Item\Group[]
 	 */
 	public function getItemGroups();
+
+	/**
+	 * Sets the action drop down to be displayed on the right of the title
+	 * @param \ILIAS\UI\Component\Dropdown\Standard $actions
+	 * @return Listing
+	 */
+	public function withActions(\ILIAS\UI\Component\Dropdown\Standard $actions);
+
+	/**
+	 * Gets the action drop down to be displayed on the right of the title
+	 * @return \ILIAS\UI\Component\Dropdown\Standard|null
+	 */
+	public function getActions();
+
 }

--- a/src/UI/Factory.php
+++ b/src/UI/Factory.php
@@ -546,7 +546,8 @@ interface Factory {
 	 *      An item displays a unique entity within the system. It shows information
 	 *      about that entity in a structured way.
 	 *   composition: >
-	 *      Items contain the name of the entity as a title. The item contains three
+	 *      Items contain the name of the entity as a title. The title MAY be interactive by using
+	 *      a Shy Button. The item contains three
 	 *      sections, where one section contains important information about the item,
 	 *      the second section shows the content of the item and another section shows
 	 *      metadata about the entity.

--- a/src/UI/Implementation/Component/Item/Item.php
+++ b/src/UI/Implementation/Component/Item/Item.php
@@ -20,7 +20,7 @@ abstract class Item implements C\Item\Item {
 	protected $color = null;
 
 	/**
-	 * @var string
+	 * @var string|\ILIAS\UI\Component\Button\Shy
 	 */
 	protected $title;
 
@@ -45,7 +45,10 @@ abstract class Item implements C\Item\Item {
 	protected $lead = null;
 
 	public function __construct($title) {
-		$this->checkStringArg("title", $title);
+		if (! $title instanceof \ILIAS\UI\Component\Button\Shy)
+		{
+			$this->checkStringArg("title", $title);
+		}
 		$this->title = $title;
 	}
 

--- a/src/UI/Implementation/Component/Item/Renderer.php
+++ b/src/UI/Implementation/Component/Item/Renderer.php
@@ -108,6 +108,11 @@ class Renderer extends AbstractComponentRenderer {
 			$cnt = 0;
 			foreach ($props as $name => $value)
 			{
+				if ($value instanceof \ILIAS\UI\Component\Button\Shy)
+				{
+					$value = $default_renderer->render($value);
+				}
+
 				$cnt++;
 				if ($cnt % 2 == 1)
 				{
@@ -131,6 +136,11 @@ class Renderer extends AbstractComponentRenderer {
 		}
 
 		$title = $component->getTitle();
+
+		if ($title instanceof \ILIAS\UI\Component\Button\Shy)
+		{
+			$title = $default_renderer->render($title);
+		}
 
 		$tpl->setVariable("TITLE", $title);
 

--- a/src/UI/Implementation/Component/Panel/Listing/Listing.php
+++ b/src/UI/Implementation/Component/Panel/Listing/Listing.php
@@ -20,6 +20,11 @@ abstract class Listing implements C\Panel\Listing\Listing {
 	protected  $title;
 
 	/**
+	 * @var \ILIAS\UI\Component\Dropdown\Standard
+	 */
+	protected $actions = null;
+
+	/**
 	 * @var \ILIAS\UI\Component\Item\Group[]
 	 */
 	protected $item_groups = array();
@@ -43,6 +48,22 @@ abstract class Listing implements C\Panel\Listing\Listing {
 	 */
 	public function getItemGroups() {
 		return $this->item_groups;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function withActions(\ILIAS\UI\Component\Dropdown\Standard $actions)
+	{
+		$this->actions = $actions;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	function getActions()
+	{
+		return $this->actions;
 	}
 
 }

--- a/src/UI/Implementation/Component/Panel/Listing/Listing.php
+++ b/src/UI/Implementation/Component/Panel/Listing/Listing.php
@@ -55,7 +55,9 @@ abstract class Listing implements C\Panel\Listing\Listing {
 	 */
 	public function withActions(\ILIAS\UI\Component\Dropdown\Standard $actions)
 	{
-		$this->actions = $actions;
+		$clone = clone $this;
+		$clone->actions = $actions;
+		return $clone;
 	}
 
 	/**

--- a/src/UI/Implementation/Component/Panel/Listing/Renderer.php
+++ b/src/UI/Implementation/Component/Panel/Listing/Renderer.php
@@ -41,6 +41,13 @@ class Renderer extends AbstractComponentRenderer {
 		$title = $component->getTitle();
 		$tpl->setVariable("LIST_TITLE", $title);
 
+		// actions
+		$actions = $component->getActions();
+		if ($actions !== null)
+		{
+			$tpl->setVariable("ACTIONS", $default_renderer->render($actions));
+		}
+
 		return $tpl->get();
 	}
 

--- a/src/UI/examples/Item/Standard/with_shy_properties.php
+++ b/src/UI/examples/Item/Standard/with_shy_properties.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * With shy buttons as property values
+ */
+function with_shy_properties() {
+	global $DIC;
+	$f = $DIC->ui()->factory();
+	$renderer = $DIC->ui()->renderer();
+	$app_item = $f->item()->standard("Item Title")
+		->withProperties(array(
+			"LMS" => $f->button()->shy("ILIAS", "https://www.ilias.de"),
+			"Code Repo" => $f->button()->shy("GitHub", "https://www.github.com"),
+			"Location" => "Room 123, Main Street 44, 3012 Bern"))
+		->withDescription("Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.");
+	return $renderer->render($app_item);
+}

--- a/src/UI/examples/Item/Standard/with_shy_title.php
+++ b/src/UI/examples/Item/Standard/with_shy_title.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * With shy button as title
+ */
+function with_shy_title() {
+	global $DIC;
+	$f = $DIC->ui()->factory();
+	$renderer = $DIC->ui()->renderer();
+	$app_item = $f->item()->standard($f->button()->shy("ILIAS", "https://www.ilias.de"))
+		->withProperties(array(
+			"Code Repo" => $f->button()->shy("GitHub", "https://www.github.com"),
+			"Location" => "Room 123, Main Street 44, 3012 Bern"))
+		->withDescription("Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.");
+	return $renderer->render($app_item);
+}

--- a/src/UI/examples/Panel/Listing/Standard/with_list_actions.php
+++ b/src/UI/examples/Panel/Listing/Standard/with_list_actions.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * With list actions
+ */
+function with_list_actions() {
+	global $DIC;
+	$f = $DIC->ui()->factory();
+	$renderer = $DIC->ui()->renderer();
+	$actions = $f->dropdown()->standard(array(
+		$f->button()->shy("ILIAS", "https://www.ilias.de"),
+		$f->button()->shy("GitHub", "https://www.github.com")
+	));
+	$list_item1 = $f->item()->standard("Item Title")
+		->withProperties(array(
+			"Origin" => "Course Title 1",
+			"Last Update" => "24.11.2011",
+			"Location" => "Room 123, Main Street 44, 3012 Bern"))
+		->withDescription("Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.");
+
+	$list_item2 = $f->item()->standard("Item 2 Title")
+		->withDescription("Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.");
+
+	$list_item3 = $f->item()->standard("Item 3 Title")
+		->withDescription("Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.");
+
+	$std_list = $f->panel()->listing()->standard("List Title", array(
+		$f->item()->group("Subtitle 1", array(
+			$list_item1,
+			$list_item2
+		)),
+		$f->item()->group("Subtitle 2", array(
+			$list_item3
+		))
+	))->withActions($actions);
+
+
+	return $renderer->render($std_list);
+}

--- a/src/UI/templates/default/Button/button.less
+++ b/src/UI/templates/default/Button/button.less
@@ -54,3 +54,8 @@ a.btn-link.ilSubmitInactive, a.btn-link.ilSubmitInactive:hover {
 .il-btn-month .dropdown-menu {
 	min-width:250px;
 }
+
+// shy buttons
+.btn-link {
+  padding: 0;
+}

--- a/src/UI/templates/default/Item/item.less
+++ b/src/UI/templates/default/Item/item.less
@@ -46,6 +46,10 @@
 	background-color: @il-highlight-bg;
 }
 
+.il-item-group {
+	clear: both;
+}
+
 .il-item-group h4 {
 	float:left;
 }

--- a/src/UI/templates/default/Item/item.less
+++ b/src/UI/templates/default/Item/item.less
@@ -7,6 +7,10 @@
 		margin: @il-item-h5-margin;
 		font-size: @font-size-h5;
 		float: left;
+
+		.btn-link {
+			font-size: inherit;
+		}
 	}
 
 	.il-item-divider {

--- a/src/UI/templates/default/Panel/panel.less
+++ b/src/UI/templates/default/Panel/panel.less
@@ -27,6 +27,11 @@
 		font-size: @font-size-h3;
 		text-transform: @il-panel-listing-std-container-h3-text-transform;
 		color: @il-panel-listing-std-container-h3-color;
+		float: left;
+	}
+
+	.dropdown {
+		float: right;
 	}
 }
 

--- a/src/UI/templates/default/Panel/tpl.listing_standard.html
+++ b/src/UI/templates/default/Panel/tpl.listing_standard.html
@@ -1,4 +1,4 @@
 <div class="il-panel-listing-std-container">
-<h3>{LIST_TITLE}</h3>
+<h3>{LIST_TITLE}</h3>{ACTIONS}
 <!-- BEGIN group -->{ITEM_GROUP}<!-- END group -->
 </div>

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -6236,6 +6236,10 @@ button.close {
   font-size: 19px;
   text-transform: uppercase;
   color: #909090;
+  float: left;
+}
+.il-panel-listing-std-container .dropdown {
+  float: right;
 }
 /* this is currently experimental, could be removed */
 .il-narrow-content .il-panel-listing-std-container > h3,
@@ -6463,6 +6467,9 @@ hr.il-divider-with-label {
 }
 .il-narrow-content .il-item:hover {
   background-color: #ffffd0;
+}
+.il-item-group {
+  clear: both;
 }
 .il-item-group h4 {
   float: left;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -6409,6 +6409,9 @@ a.btn-link.ilSubmitInactive:hover {
 .il-btn-month .dropdown-menu {
   min-width: 250px;
 }
+.btn-link {
+  padding: 0;
+}
 h6.il-divider {
   padding: 3px 6px;
   background-color: #ececec;
@@ -6438,6 +6441,9 @@ hr.il-divider-with-label {
   margin: 4px 0px 2px 0px;
   font-size: 16px;
   float: left;
+}
+.il-item h5 .btn-link {
+  font-size: inherit;
 }
 .il-item .il-item-divider {
   clear: both;

--- a/templates/default/delos.less
+++ b/templates/default/delos.less
@@ -8,7 +8,6 @@
 bdo[dir="ltr"] { direction: ltr; unicode-bidi: bidi-override; }
 bdo[dir="rtl"] { direction: rtl; unicode-bidi: bidi-override; }
 
-
 /*
 /* rtl-review */
 /* with specifics imports 

--- a/tests/UI/Component/Item/ItemTest.php
+++ b/tests/UI/Component/Item/ItemTest.php
@@ -198,4 +198,32 @@ EOT;
 
 		$this->assertHTMLEquals($expected, $html);
 	}
+
+	public function test_shy_title_and_property() {
+		$f = $this->getFactory();
+		$r = $this->getDefaultRenderer();
+		$df = new \ILIAS\Data\Factory();
+
+		$color = $df->color('#ff00ff');
+
+		$c = $f->item()->standard($f->button()->shy("ILIAS", "https://www.ilias.de"))
+			->withProperties(array("test" => $f->button()->shy("GitHub", "https://www.github.com")));
+
+		$html = $r->render($c);
+		$expected = <<<EOT
+<div class="il-item il-std-item ">
+			<h5><a class="btn btn-link" href="https://www.ilias.de" data-action="https://www.ilias.de">ILIAS</a></h5>
+			<hr class="il-item-divider" />
+			<div class="row">
+				<div class="col-sm-4 col-md-2 il-item-property-name">test</div>
+				<div class="col-sm-8 col-md-4 il-item-property-value"><a class="btn btn-link" href="https://www.github.com" data-action="https://www.github.com">GitHub</a></div>
+				<div class="col-sm-4 col-md-2 il-item-property-name"></div>
+				<div class="col-sm-8 col-md-4 il-item-property-value"></div>
+			</div>
+</div>
+EOT;
+
+		$this->assertHTMLEquals($expected, $html);
+	}
+
 }

--- a/tests/UI/Component/Panel/PanelListingTest.php
+++ b/tests/UI/Component/Panel/PanelListingTest.php
@@ -55,6 +55,22 @@ class PanelListingTest extends ILIAS_UI_TestBase {
 		$this->assertEquals($c->getItemGroups(), $groups);
 	}
 
+	public function test_with_actions() {
+		$f = $this->getFactory();
+
+		$actions = $f->dropdown()->standard(array(
+			$f->button()->shy("ILIAS", "https://www.ilias.de"),
+			$f->button()->shy("GitHub", "https://www.github.com")
+		));
+
+		$groups = array();
+
+		$c = $f->panel()->listing()->standard("title", $groups)
+			->withActions($actions);
+
+		$this->assertEquals($c->getActions(), $actions);
+	}
+
 	public function test_render_base() {
 		$f = $this->getFactory();
 		$r = $this->getDefaultRenderer();
@@ -92,6 +108,35 @@ class PanelListingTest extends ILIAS_UI_TestBase {
 			<h5>title3</h5>
 		</div></div>
 	</div>
+</div>
+</div>
+EOT;
+		$this->assertHTMLEquals($expected, $html);
+	}
+
+	public function test_render_with_actions() {
+		$f = $this->getFactory();
+		$r = $this->getDefaultRenderer();
+
+		$groups = array();
+
+		$actions = $f->dropdown()->standard(array(
+			$f->button()->shy("ILIAS", "https://www.ilias.de"),
+			$f->button()->shy("GitHub", "https://www.github.com")
+		));
+
+		$c = $f->panel()->listing()->standard("title", $groups)
+			->withActions($actions);
+
+		$html = $r->render($c);
+
+		$expected = <<<EOT
+<div class="il-panel-listing-std-container">
+<h3>title</h3><div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"  aria-haspopup="true" aria-expanded="false"> <span class="caret"></span></button>
+<ul class="dropdown-menu">
+	<li><a class="btn btn-link" href="https://www.ilias.de" data-action="https://www.ilias.de">ILIAS</a></li>
+	<li><a class="btn btn-link" href="https://www.github.com" data-action="https://www.github.com">GitHub</a></li>
+</ul>
 </div>
 </div>
 EOT;


### PR DESCRIPTION
This PR
- adds an action Dropdown to Listing Panels. The action Dropdown is rendered similar beside the title of the list like this is done for Item Groups or Standard Items.
- Allows to use A Shy Button for a Standard Item title.
- Allows to use Shy Buttons for property values of Standard Items.

This is all needed for the approved 5.3 feature "Usability Improvements Main Column List Calendar", see https://www.ilias.de/docu/goto_docu_wiki_wpage_4395_1357.html

The Standard Listing Panel rules already stated, that a Dropdown can be added:
https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/src/UI/Component/Panel/Listing/Factory.php

The description for Standard Items has been amended to reflect the optional use of Shy Buttons:
https://github.com/ILIAS-eLearning/ILIAS/pull/571/files#diff-50f8f3ede5cc40ae3097cc424fb6a839
https://github.com/ILIAS-eLearning/ILIAS/pull/571/files#diff-0c3b34e8901a0a9c29aec05f17067584