### PR TITLE
Fixes File not found errors.

### DIFF
--- a/Services/ActiveRecord/Views/Display/class.arDisplayGUI.php
+++ b/Services/ActiveRecord/Views/Display/class.arDisplayGUI.php
@@ -108,7 +108,7 @@ class arDisplayGUI {
 
 
 	protected function initTemplate() {
-		$this->setTemplate(new ilTemplate("tpl.display.html", true, true, "Customizing/global/plugins/Libraries/ActiveRecord"));
+		$this->setTemplate(new ilTemplate("tpl.display.html", true, true, "Services/ActiveRecord"));
 	}
 
 


### PR DESCRIPTION
Fixed wrong ActiveRecord includes, which were pointing to the former location (from times when the active record was not part of the ILIAS core) at: /Customizing/global/plugins/Libraries

Please refer to former pull request: Active Record: Fixed outdated includes #451 and #540