### PR TITLE
UI Panel: Add optional Dropdowns for Standard/Sub Panels

### DIFF
--- a/src/UI/Component/Panel/Panel.php
+++ b/src/UI/Component/Panel/Panel.php
@@ -21,4 +21,18 @@ interface Panel extends \ILIAS\UI\Component\Component {
 	 * @return \ILIAS\UI\Component\Component[]|\ILIAS\UI\Component\Component
 	 */
 	public function getContent();
+
+	/**
+	 * Sets action Dropdown being displayed beside the title
+	 * @param \ILIAS\UI\Component\Dropdown\Standard $actions
+	 * @return Sub
+	 */
+	public function withActions(\ILIAS\UI\Component\Dropdown\Standard $actions);
+
+	/**
+	 * Gets action Dropdown being displayed beside the title
+	 * @return \ILIAS\UI\Component\Dropdown\Standard | null
+	 */
+	public function getActions();
+
 }

--- a/src/UI/Factory.php
+++ b/src/UI/Factory.php
@@ -290,7 +290,8 @@ interface Factory {
 	 *     Panels are used to group titled content.
 	 *   composition: >
 	 *      Panels consist of a header and content section. They form one Gestalt and so build a perceivable
-	 *      cluster of information.
+	 *      cluster of information. Additionally an optional Dropdown that offers actions on the entity being
+	 *      represented by the panel is shown at the top of the Panel.
 	 *   effect: The effect of interaction with panels heavily depends on their content.
 	 *
 	 * rules:

--- a/src/UI/Implementation/Component/Panel/Panel.php
+++ b/src/UI/Implementation/Component/Panel/Panel.php
@@ -24,6 +24,10 @@ class Panel implements C\Panel\Panel {
 	 */
 	private  $content;
 
+	/**
+	 * @var \ILIAS\UI\Component\Dropdown\Standard | null
+	 */
+	protected $actions = null;
 
 	/**
 	 * @param string $title
@@ -52,5 +56,22 @@ class Panel implements C\Panel\Panel {
 	public function getContent() {
 		return $this->content;
 	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function withActions(\ILIAS\UI\Component\Dropdown\Standard $actions) {
+		$clone = clone $this;
+		$clone->actions = $actions;
+		return $clone;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getActions(){
+		return $this->actions;
+	}
+
 }
 ?>

--- a/src/UI/Implementation/Component/Panel/Renderer.php
+++ b/src/UI/Implementation/Component/Panel/Renderer.php
@@ -60,6 +60,14 @@ class Renderer extends AbstractComponentRenderer {
 	protected function renderStandard(Component\Panel\Standard $component, RendererInterface $default_renderer)
 	{
 		$tpl = $this->getTemplate("tpl.standard.html", true, true);
+
+		// actions
+		$actions = $component->getActions();
+		if ($actions !== null)
+		{
+			$tpl->setVariable("ACTIONS", $default_renderer->render($actions));
+		}
+
 		$tpl->setVariable("TITLE",  $component->getTitle());
 		$tpl->setVariable("BODY",  $this->getContentAsString($component,$default_renderer));
 		return $tpl->get();
@@ -74,9 +82,19 @@ class Renderer extends AbstractComponentRenderer {
 	{
 		$tpl = $this->getTemplate("tpl.sub.html", true, true);
 
-		if ($component->getTitle() != "")
+		$actions = $component->getActions();
+
+		if ($component->getTitle() != "" || $actions !== null)
 		{
 			$tpl->setCurrentBlock("title");
+
+			// actions
+			if ($actions !== null)
+			{
+				$tpl->setVariable("ACTIONS", $default_renderer->render($actions));
+			}
+
+			// title
 			$tpl->setVariable("TITLE", $component->getTitle());
 			$tpl->parseCurrentBlock();
 		}

--- a/src/UI/examples/Panel/Standard/with_actions.php
+++ b/src/UI/examples/Panel/Standard/with_actions.php
@@ -1,0 +1,19 @@
+<?php
+
+function with_actions() {
+	global $DIC;
+	$f = $DIC->ui()->factory();
+	$renderer = $DIC->ui()->renderer();
+
+	$actions = $f->dropdown()->standard(array(
+		$f->button()->shy("ILIAS", "https://www.ilias.de"),
+		$f->button()->shy("GitHub", "https://www.github.com")
+	));
+
+	$panel = $f->panel()->standard(
+		"Panel Title",
+		$f->legacy("Some Content")
+	)->withActions($actions);
+
+	return $renderer->render($panel);
+}

--- a/src/UI/examples/Panel/Sub/with_actions.php
+++ b/src/UI/examples/Panel/Sub/with_actions.php
@@ -1,0 +1,17 @@
+<?php
+
+function with_actions() {
+	global $DIC;
+	$f = $DIC->ui()->factory();
+	$renderer = $DIC->ui()->renderer();
+
+	$actions = $f->dropdown()->standard(array(
+		$f->button()->shy("ILIAS", "https://www.ilias.de"),
+		$f->button()->shy("GitHub", "https://www.github.com")
+	));
+
+	$block = $f->panel()->standard("Panel Title",
+		$f->panel()->sub("Sub Panel Title",$f->legacy("Some Content"))->withActions($actions));
+
+	return $renderer->render($block);
+}

--- a/src/UI/templates/default/Panel/panel.less
+++ b/src/UI/templates/default/Panel/panel.less
@@ -7,6 +7,24 @@
 	}
 }
 
+.panel-heading {
+	> h3 {
+		float: left;
+	}
+
+	> h4 {
+		float: left;
+	}
+
+	.dropdown {
+		float: right;
+
+		> button.dropdown-toggle {
+			color: @il-btn-standard-color;
+		}
+	}
+}
+
 .il-panel-listing-std-item-container {
 	margin: @il-panel-listing-std-item-container-margin;
 }

--- a/src/UI/templates/default/Panel/tpl.standard.html
+++ b/src/UI/templates/default/Panel/tpl.standard.html
@@ -1,6 +1,6 @@
 <div class="panel panel-primary">
-	<div class="panel-heading ilHeader">
-		<h3 class="ilHeader">{TITLE}</h3>
+	<div class="panel-heading ilHeader clearfix">
+		<h3 class="ilHeader">{TITLE}</h3> {ACTIONS}
 	</div>
 	<div class="panel-body">{BODY}</div>
 </div>

--- a/src/UI/templates/default/Panel/tpl.sub.html
+++ b/src/UI/templates/default/Panel/tpl.sub.html
@@ -1,7 +1,7 @@
 <div class="panel panel-primary">
 	<!-- BEGIN title -->
-	<div class="panel-heading ilBlockHeader">
-		<h4>{TITLE}</h4>
+	<div class="panel-heading ilBlockHeader clearfix">
+		<h4>{TITLE}</h4> {ACTIONS}
 	</div>
 	<!-- END title -->
 	<div class="panel-body">

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -6218,6 +6218,18 @@ button.close {
 .il-panel-report > .panel-body > .panel {
   margin-bottom: 10px;
 }
+.panel-heading > h3 {
+  float: left;
+}
+.panel-heading > h4 {
+  float: left;
+}
+.panel-heading .dropdown {
+  float: right;
+}
+.panel-heading .dropdown > button.dropdown-toggle {
+  color: white;
+}
 .il-panel-listing-std-item-container {
   margin: 0 0 1px 0;
 }

--- a/templates/default/delos.less
+++ b/templates/default/delos.less
@@ -94,10 +94,10 @@ All parts that aren't checked yet are actually marked with "rtl-review"
 
 @import "less/variables.less";             // customized
 
-
 // UI framework components which make use of variables from less/variables.less
 // Note: These files need to be imported after less/variables.less
 @import "@{uibase}Popover/popover.less";
+
 
 .bg-primary {
   color: white;

--- a/tests/UI/Component/Panel/PanelTest.php
+++ b/tests/UI/Component/Panel/PanelTest.php
@@ -65,6 +65,37 @@ class PanelTest extends ILIAS_UI_TestBase {
 		$this->assertEquals($p->getContent(), array($c));
 	}
 
+	public function test_standard_with_actions() {
+		$fp = $this->getPanelFactory();
+		$f = $this->getFactory();
+
+		$p = $fp->standard("Title",array(new ComponentDummy()));
+
+		$actions = $f->dropdown()->standard(array(
+			$f->button()->shy("ILIAS", "https://www.ilias.de"),
+			$f->button()->shy("GitHub", "https://www.github.com")
+		));
+
+		$p = $p->withActions($actions);
+
+		$this->assertEquals($p->getActions(), $actions);
+	}
+
+	public function test_sub_with_actions() {
+		$fp = $this->getPanelFactory();
+		$f = $this->getFactory();
+
+		$p = $fp->sub("Title",array(new ComponentDummy()));
+
+		$actions = $f->dropdown()->standard(array(
+			$f->button()->shy("ILIAS", "https://www.ilias.de"),
+			$f->button()->shy("GitHub", "https://www.github.com")
+		));
+
+		$p = $p->withActions($actions);
+
+		$this->assertEquals($p->getActions(), $actions);
+	}
 
 	public function test_sub_with_card() {
 		$fp = $this->getPanelFactory();
@@ -97,28 +128,32 @@ class PanelTest extends ILIAS_UI_TestBase {
 
 
 	public function test_render_standard() {
-		$f = $this->getPanelFactory();
+		$f = $this->getFactory();
 		$r = $this->getDefaultRenderer();
-		$p = $f->standard("Title",array());
 
-		$html = new DOMDocument();
-		$html->formatOutput = true;
-		$html->preserveWhiteSpace = false;
+		$actions = $f->dropdown()->standard(array(
+			$f->button()->shy("ILIAS", "https://www.ilias.de"),
+			$f->button()->shy("GitHub", "https://www.github.com")
+		));
 
-		$expected = new DOMDocument();
-		$expected->formatOutput = true;
-		$expected->preserveWhiteSpace = false;
+		$p = $f->panel()->standard("Title",array())->withActions($actions);
 
 		$html = $r->render($p);
 
-		$expected_html =
-				"<div class=\"panel panel-primary\">".
-				"   <div class=\"panel-heading ilHeader\">".
-				"       <h3 class=\"ilHeader\">Title</h3>".
-				"   </div>".
-				"   <div class=\"panel-body\"></div>".
-				"</div>";
-
+		$expected_html = <<<EOT
+<div class="panel panel-primary">
+	<div class="panel-heading ilHeader clearfix">
+		<h3 class="ilHeader">Title</h3>
+		<div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"  aria-haspopup="true" aria-expanded="false"> <span class="caret"></span></button>
+			<ul class="dropdown-menu">
+				<li><a class="btn btn-link" href="https://www.ilias.de" data-action="https://www.ilias.de">ILIAS</a></li>
+				<li><a class="btn btn-link" href="https://www.github.com" data-action="https://www.github.com">GitHub</a></li>
+			</ul>
+		</div>
+	</div>
+	<div class="panel-body"></div>
+</div>
+EOT;
 		$this->assertHTMLEquals($expected_html, $html);
 	}
 
@@ -126,23 +161,43 @@ class PanelTest extends ILIAS_UI_TestBase {
 		$f = $this->getFactory();
 		$fp = $this->getPanelFactory();
 		$r = $this->getDefaultRenderer();
-		$p = $fp->sub("Title",array());
+
+		$actions = $f->dropdown()->standard(array(
+			$f->button()->shy("ILIAS", "https://www.ilias.de"),
+			$f->button()->shy("GitHub", "https://www.github.com")
+		));
+
+		$p = $fp->sub("Title",array())->withActions($actions);
 		$card = $f->card("Card Title");
 		$p = $p->withCard($card);
 		$html = $r->render($p);
 
-		$expected_html =
-				"<div class=\"panel panel-primary\">".
-				"   <div class=\"panel-heading ilBlockHeader\">".
-				"       <h4>Title</h4>".
-				"   </div>".
-				"   <div class=\"panel-body\"><div class=\"row\">".
-				"       <div class=\"col-sm-8\"></div>".
-				"       <div class=\"col-sm-4\">".
-				"           <div class=\"il-card thumbnail\"><div class=\"card-no-highlight\"></div><div class=\"caption\"><h5 class=\"card-title\">Card Title</h5></div></div>".
-				"       </div>".
-				"   </div></div>".
-				"</div>";
+		$expected_html = <<<EOT
+<div class="panel panel-primary">
+	<div class="panel-heading ilBlockHeader clearfix">
+		<h4>Title</h4>
+		<div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"  aria-haspopup="true" aria-expanded="false"> <span class="caret"></span></button>
+			<ul class="dropdown-menu">
+				<li><a class="btn btn-link" href="https://www.ilias.de" data-action="https://www.ilias.de">ILIAS</a></li>
+				<li><a class="btn btn-link" href="https://www.github.com" data-action="https://www.github.com">GitHub</a></li>
+			</ul>
+		</div>
+	</div>
+	<div class="panel-body">
+		<div class="row">
+			<div class="col-sm-8"></div>
+			<div class="col-sm-4">
+				<div class="il-card thumbnail">
+					<div class="card-no-highlight"></div>
+					<div class="caption">
+						<h5 class="card-title">Card Title</h5>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+EOT;
 
 		$this->assertHTMLEquals($expected_html, $html);
 	}
@@ -165,7 +220,7 @@ class PanelTest extends ILIAS_UI_TestBase {
 				"   <div class=\"panel-body\">".
 				"
              <div class=\"panel panel-primary\">".
-				"           <div class=\"panel-heading ilBlockHeader\">".
+				"           <div class=\"panel-heading ilBlockHeader clearfix\">".
 				"               <h4>Title</h4>".
 				"           </div>".
 				"           <div class=\"panel-body\"><div class=\"row\">".


### PR DESCRIPTION
This PR adds optional action Dropdowns for Standard and Sub Panels.

This is needed for the approved 5.3 feature "Competence Reporting Panels"
https://www.ilias.de/docu/goto_docu_wiki_wpage_4314_1357.html

Panel description/rules:
https://github.com/ILIAS-eLearning/ILIAS/pull/574/files#diff-0c3b34e8901a0a9c29aec05f17067584
