### PR TITLE
UI: cleanup magic for signal-mechanism

### DIFF
--- a/src/UI/Component/JavaScriptBindable.php
+++ b/src/UI/Component/JavaScriptBindable.php
@@ -42,6 +42,17 @@ interface JavaScriptBindable {
 	public function withOnLoadCode(\Closure $binder);
 
 	/**
+	 * Add some onload-code to the component instead of replacing the existing one.
+	 *
+	 * Must work like getOnLoadCode was called and the result of the existing binder
+	 * (if any) and the result of the new binder are concatenated in a new binder.
+	 *
+	 * @param	\Closure	$binder
+	 * @return	self
+	 */
+	public function withAdditionalOnLoadCode(\Closure $binder);
+
+	/**
 	 * Get the currently bound on load code.
 	 *
 	 * @return	\Closure|null

--- a/src/UI/Component/JavaScriptBindable.php
+++ b/src/UI/Component/JavaScriptBindable.php
@@ -37,7 +37,7 @@ interface JavaScriptBindable {
 	 *		});
 	 *
 	 * @param	\Closure	$binder
-	 * @param	self
+	 * @return	self
 	 */
 	public function withOnLoadCode(\Closure $binder);
 

--- a/src/UI/Component/Triggerable.php
+++ b/src/UI/Component/Triggerable.php
@@ -12,7 +12,7 @@ namespace ILIAS\UI\Component;
  *
  * @package ILIAS\UI\Component
  */
-interface Triggerable {
+interface Triggerable extends JavaScriptBindable {
 
 	/**
 	 * Get a component like this but reset (regenerate) its signals.

--- a/src/UI/Component/Triggerer.php
+++ b/src/UI/Component/Triggerer.php
@@ -11,7 +11,7 @@ use ILIAS\UI\Implementation\Component\TriggeredSignalInterface;
  *
  * @package ILIAS\UI\Component
  */
-interface Triggerer {
+interface Triggerer extends JavaScriptBindable {
 
 	/**
 	 * Get a component like this but reset any triggered signals of other components
@@ -26,5 +26,4 @@ interface Triggerer {
 	 * @return TriggeredSignalInterface[]
 	 */
 	public function getTriggeredSignals();
-
 }

--- a/src/UI/Implementation/Component/Button/Renderer.php
+++ b/src/UI/Implementation/Component/Button/Renderer.php
@@ -101,11 +101,6 @@ class Renderer extends AbstractComponentRenderer {
 
 	protected function maybeRenderId(Component\Component $component, $tpl) {
 		$id = $this->bindJavaScript($component);
-		// Check if the button is acting as triggerer
-		if ($component instanceof Component\Triggerer && count($component->getTriggeredSignals())) {
-			$id = ($id === null) ? $this->createId() : $id;
-			$this->triggerRegisteredSignals($component, $id);
-		}
 		if ($id !== null) {
 			$tpl->setCurrentBlock("with_id");
 			$tpl->setVariable("ID", $id);
@@ -128,11 +123,6 @@ class Renderer extends AbstractComponentRenderer {
 
 		$id = $this->bindJavaScript($component);
 
-		// Check if the button is acting as triggerer
-		if ($component instanceof Component\Triggerer && count($component->getTriggeredSignals())) {
-			$id = ($id === null) ? $this->createId() : $id;
-			$this->triggerRegisteredSignals($component, $id);
-		}
 		if ($id !== null) {
 			$tpl->setCurrentBlock("with_id");
 			$tpl->setVariable("ID", $id);

--- a/src/UI/Implementation/Component/Dropdown/Renderer.php
+++ b/src/UI/Implementation/Component/Dropdown/Renderer.php
@@ -63,11 +63,6 @@ class Renderer extends AbstractComponentRenderer {
 
 	protected function maybeRenderId(Component\Component $component, $tpl, $block, $template_var) {
 		$id = $this->bindJavaScript($component);
-		// Check if the component is acting as triggerer
-		if ($component instanceof Component\Triggerer && count($component->getTriggeredSignals())) {
-			$id = ($id === null) ? $this->createId() : $id;
-			$this->triggerRegisteredSignals($component, $id);
-		}
 		if ($id !== null) {
 			$tpl->setCurrentBlock($block);
 			$tpl->setVariable($template_var, $id);

--- a/src/UI/Implementation/Component/Glyph/Renderer.php
+++ b/src/UI/Implementation/Component/Glyph/Renderer.php
@@ -33,10 +33,6 @@ class Renderer extends AbstractComponentRenderer {
 		$id = $this->bindJavaScript($component);
 
 		$tpl->touchBlock($component->getType());
-		if ($component instanceof Component\Triggerer && count($component->getTriggeredSignals())) {
-			$id = ($id === null) ? $this->createId() : $id;
-			$this->triggerRegisteredSignals($component, $id);
-		}
 
 		if ($id !== null) {
 			$tpl->setCurrentBlock("with_id");

--- a/src/UI/Implementation/Component/JavaScriptBindable.php
+++ b/src/UI/Implementation/Component/JavaScriptBindable.php
@@ -25,6 +25,21 @@ trait JavaScriptBindable {
 	}
 
 	/**
+	 * @see \ILIAS\UI\Component\JavaScriptBindable::withAdditionalOnLoadCode
+	 */
+	public function withAdditionalOnLoadCode(\Closure $binder) {
+		$current_binder = $this->getOnLoadCode();
+		if ($current_binder === null) {
+			return $this->withOnLoadCode($binder);
+		}
+
+		$this->checkBinder($binder);
+		return $this->withOnLoadCode(function($id) use ($current_binder, $binder) {
+			return $current_binder($id)."\n".$binder($id);
+		});		
+	}
+
+	/**
 	 * @see \ILIAS\UI\Component\JavaScriptBindable::getOnLoadCode
 	 */
 	public function getOnLoadCode() {

--- a/src/UI/Implementation/Component/Modal/Renderer.php
+++ b/src/UI/Implementation/Component/Modal/Renderer.php
@@ -54,6 +54,22 @@ class Renderer extends AbstractComponentRenderer {
 			'ajaxRenderUrl' => $modal->getAsyncRenderUrl(),
 			'keyboard' => $modal->getCloseWithKeyboard(),
 		));
+		// ATTENTION, ATTENTION:
+		// with(Additional)OnLoadCode opens a wormhole into the future, where some unspecified
+		// entity magically created an id for the component that can be used to refer to it
+		// via javascript.
+		// This replaced a pattern, where an id was created manually and the java script
+		// code was manually inserted to the (now internal) js-binding of the
+		// AbstractComponentRenderer. (see commit 192144fd1f0e040cadc0149c3dc15fbc4b67858e).
+		// The wormhole solution is considered superior over the manual creation of ids because:
+		// * withAdditionalOnLoadCode introduces no new principles to the UI framework but reuses
+		//   an existing one
+		// * withAdditionalOnLoadCode does not require it to expose internals (js-binding) from
+		//   the AbstractComponentRenderer and thus does have less coupling
+		// * withAdditionalOnLoadCode allows the framework to decide, when ids are actually
+		//   created
+		// * since withAdditionalOnLoadCode refers to some yet unknown future, it disencourages
+		//   tempering with the id _here_.
 		return $modal->withAdditionalOnLoadCode(function($id) use ($show, $close, $options) {
 			return
 				"$(document).on('{$show}', function() { il.UI.modal.showModal('{$id}', {$options}); return false; });".

--- a/src/UI/Implementation/Component/Modal/Renderer.php
+++ b/src/UI/Implementation/Component/Modal/Renderer.php
@@ -47,18 +47,18 @@ class Renderer extends AbstractComponentRenderer {
 	 * @param Component\Modal\Modal $modal
 	 * @param string $id
 	 */
-	protected function registerSignals(Component\Modal\Modal $modal, $id) {
+	protected function registerSignals(Component\Modal\Modal $modal) {
 		$show = $modal->getShowSignal();
 		$close = $modal->getCloseSignal();
-		$js = $this->getJavascriptBinding();
 		$options = json_encode(array(
 			'ajaxRenderUrl' => $modal->getAsyncRenderUrl(),
 			'keyboard' => $modal->getCloseWithKeyboard(),
 		));
-		$js->addOnLoadCode("
-			$(document).on('{$show}', function() { il.UI.modal.showModal('{$id}', {$options}); return false; });
-			$(document).on('{$close}', function() { il.UI.modal.closeModal('{$id}'); return false; });"
-		);
+		return $modal->withAdditionalOnLoadCode(function($id) use ($show, $close, $options) {
+			return
+				"$(document).on('{$show}', function() { il.UI.modal.showModal('{$id}', {$options}); return false; });".
+				"$(document).on('{$close}', function() { il.UI.modal.closeModal('{$id}'); return false; });";
+		});
 	}
 
 	/**
@@ -66,8 +66,8 @@ class Renderer extends AbstractComponentRenderer {
 	 * @return string
 	 */
 	protected function renderAsync(Component\Modal\Modal $modal) {
-		$id = $this->createId();
-		$this->registerSignals($modal, $id);
+		$modal = $this->registerSignals($modal);
+		$id = $this->bindJavaScript($modal);
 		return "<span id='{$id}'></span>";
 	}
 
@@ -79,8 +79,8 @@ class Renderer extends AbstractComponentRenderer {
 	 */
 	protected function renderInterruptive(Component\Modal\Interruptive $modal, RendererInterface $default_renderer) {
 		$tpl = $this->getTemplate('tpl.interruptive.html', true, true);
-		$id = $this->createId();
-		$this->registerSignals($modal, $id);
+		$modal = $this->registerSignals($modal);
+		$id = $this->bindJavaScript($modal);
 		$this->triggerRegisteredSignals($modal, $id);
 		$tpl->setVariable('ID', $id);
 		$tpl->setVariable('FORM_ACTION', $modal->getFormAction());
@@ -113,8 +113,8 @@ class Renderer extends AbstractComponentRenderer {
 	 */
 	protected function renderRoundTrip(Component\Modal\RoundTrip $modal, RendererInterface $default_renderer) {
 		$tpl = $this->getTemplate('tpl.roundtrip.html', true, true);
-		$id = $this->createId();
-		$this->registerSignals($modal, $id);
+		$modal = $this->registerSignals($modal);
+		$id = $this->bindJavaScript($modal);
 		$this->triggerRegisteredSignals($modal, $id);
 		$tpl->setVariable('ID', $id);
 		$tpl->setVariable('TITLE', $modal->getTitle());
@@ -141,11 +141,11 @@ class Renderer extends AbstractComponentRenderer {
 	 */
 	protected function renderLightbox(Component\Modal\Lightbox $modal, RendererInterface $default_renderer) {
 		$tpl = $this->getTemplate('tpl.lightbox.html', true, true);
-		$id = $this->createId();
-		$this->registerSignals($modal, $id);
+		$modal = $this->registerSignals($modal);
+		$id = $this->bindJavaScript($modal);
 		$this->triggerRegisteredSignals($modal, $id);
 		$tpl->setVariable('ID', $id);
-		$id_carousel = $this->createId();
+		$id_carousel = "{$id}_carousel";
 		$pages = $modal->getPages();
 		$tpl->setVariable('TITLE', $pages[0]->getTitle());
 		$tpl->setVariable('ID_CAROUSEL', $id_carousel);

--- a/src/UI/Implementation/Component/Modal/Renderer.php
+++ b/src/UI/Implementation/Component/Modal/Renderer.php
@@ -81,7 +81,6 @@ class Renderer extends AbstractComponentRenderer {
 		$tpl = $this->getTemplate('tpl.interruptive.html', true, true);
 		$modal = $this->registerSignals($modal);
 		$id = $this->bindJavaScript($modal);
-		$this->triggerRegisteredSignals($modal, $id);
 		$tpl->setVariable('ID', $id);
 		$tpl->setVariable('FORM_ACTION', $modal->getFormAction());
 		$tpl->setVariable('TITLE', $modal->getTitle());
@@ -115,7 +114,6 @@ class Renderer extends AbstractComponentRenderer {
 		$tpl = $this->getTemplate('tpl.roundtrip.html', true, true);
 		$modal = $this->registerSignals($modal);
 		$id = $this->bindJavaScript($modal);
-		$this->triggerRegisteredSignals($modal, $id);
 		$tpl->setVariable('ID', $id);
 		$tpl->setVariable('TITLE', $modal->getTitle());
 		foreach ($modal->getContent() as $content) {
@@ -143,7 +141,6 @@ class Renderer extends AbstractComponentRenderer {
 		$tpl = $this->getTemplate('tpl.lightbox.html', true, true);
 		$modal = $this->registerSignals($modal);
 		$id = $this->bindJavaScript($modal);
-		$this->triggerRegisteredSignals($modal, $id);
 		$tpl->setVariable('ID', $id);
 		$id_carousel = "{$id}_carousel";
 		$pages = $modal->getPages();

--- a/src/UI/Implementation/Component/Popover/Popover.php
+++ b/src/UI/Implementation/Component/Popover/Popover.php
@@ -5,6 +5,7 @@ namespace ILIAS\UI\Implementation\Component\Popover;
 use \ILIAS\UI\Component;
 use ILIAS\UI\Component\Signal;
 use ILIAS\UI\Implementation\Component\ComponentHelper;
+use ILIAS\UI\Implementation\Component\JavaScriptBindable;
 use ILIAS\UI\Implementation\Component\SignalGeneratorInterface;
 
 /**
@@ -16,6 +17,8 @@ use ILIAS\UI\Implementation\Component\SignalGeneratorInterface;
 abstract class Popover implements Component\Popover\Popover {
 
 	use ComponentHelper;
+	use JavaScriptBindable;
+
 	/**
 	 * @var string
 	 */

--- a/src/UI/Implementation/Component/ViewControl/Renderer.php
+++ b/src/UI/Implementation/Component/ViewControl/Renderer.php
@@ -105,11 +105,6 @@ class Renderer extends AbstractComponentRenderer
 
 	protected function maybeRenderId(Component\Component $component, $tpl, $block, $template_var) {
 		$id = $this->bindJavaScript($component);
-		// Check if the component is acting as triggerer
-		if ($component instanceof Component\Triggerer && count($component->getTriggeredSignals())) {
-			$id = ($id === null) ? $this->createId() : $id;
-			$this->triggerRegisteredSignals($component, $id);
-		}
 		if ($id !== null) {
 			$tpl->setCurrentBlock($block);
 			$tpl->setVariable($template_var, $id);

--- a/src/UI/Implementation/Render/AbstractComponentRenderer.php
+++ b/src/UI/Implementation/Render/AbstractComponentRenderer.php
@@ -113,7 +113,7 @@ abstract class AbstractComponentRenderer implements ComponentRenderer {
 	 * @return	string|null
 	 */
 	final protected function bindJavaScript(JavaScriptBindable $component) {
-        $binder = $component->getOnLoadCode();
+		$binder = $component->getOnLoadCode();
 		if ($binder === null) {
 			return null;
 		}
@@ -125,7 +125,7 @@ abstract class AbstractComponentRenderer implements ComponentRenderer {
 				" (used component: ".get_class($component).")");
 		}
 		$this->js_binding->addOnLoadCode($on_load_code);
-        return $id;
+		return $id;
 	}
 
 

--- a/src/UI/Implementation/Render/AbstractComponentRenderer.php
+++ b/src/UI/Implementation/Render/AbstractComponentRenderer.php
@@ -128,7 +128,6 @@ abstract class AbstractComponentRenderer implements ComponentRenderer {
 		return $id;
 	}
 
-
 	/**
 	 * Create an ID
 	 *

--- a/src/UI/Implementation/Render/AbstractComponentRenderer.php
+++ b/src/UI/Implementation/Render/AbstractComponentRenderer.php
@@ -123,7 +123,7 @@ abstract class AbstractComponentRenderer implements ComponentRenderer {
 		if ($binder === null) {
 			return null;
 		}
-		$id = $this->createId();
+		$id = $this->js_binding->createId();
 		$on_load_code = $binder($id);
 		if (!is_string($on_load_code)) {
 			throw new \LogicException(
@@ -146,11 +146,12 @@ abstract class AbstractComponentRenderer implements ComponentRenderer {
 			return $triggerer;
 		}
 		return $triggerer->withAdditionalOnLoadCode(function($id) use ($triggered_signals) {
+			$code = "";
 			foreach ($triggered_signals as $triggered_signal) {
 				$signal = $triggered_signal->getSignal();
 				$event = $triggered_signal->getEvent();
 				$options = json_encode($signal->getOptions());
-				$this->js_binding->addOnLoadCode(
+				$code .=
 					"$('#{$id}').{$event}( function(event) {
 						$(this).trigger('{$signal}',
 							{
@@ -160,19 +161,10 @@ abstract class AbstractComponentRenderer implements ComponentRenderer {
 							}
 						);
 						return false;
-					});");
+					});";
 			}
+			return $code;
 		});
-	}
-
-	/**
-	 * Create an ID
-	 *
-	 * @return string
-	 */
-	final protected function createId() {
-		$id = $this->js_binding->createId();
-		return $id;
 	}
 
 	/**

--- a/src/UI/Implementation/Render/AbstractComponentRenderer.php
+++ b/src/UI/Implementation/Render/AbstractComponentRenderer.php
@@ -106,6 +106,19 @@ abstract class AbstractComponentRenderer implements ComponentRenderer {
 	 * @return	string|null
 	 */
 	final protected function bindJavaScript(JavaScriptBindable $component) {
+		if ($component instanceof Triggerer) {
+			$component = $this->addTriggererOnLoadCode($component);
+		}
+		return $this->bindOnloadCode($component);
+	}
+
+	/**
+	 * Bind the JavaScript onload-code.
+	 *
+	 * @param	JavaScriptBindable	$component
+	 * @return	string|null
+	 */
+	private function bindOnloadCode(JavaScriptBindable $component) {
 		$binder = $component->getOnLoadCode();
 		if ($binder === null) {
 			return null;
@@ -122,6 +135,37 @@ abstract class AbstractComponentRenderer implements ComponentRenderer {
 	}
 
 	/**
+	 * Add onload-code for triggerer.
+	 *
+	 * @param	Triggerer	$triggerer
+	 * @return 	Triggerer
+	 */
+	private function addTriggererOnLoadCode(Triggerer $triggerer) {
+		$triggered_signals = $triggerer->getTriggeredSignals();
+		if (count($triggered_signals) == 0) {
+			return $triggerer;
+		}
+		return $triggerer->withAdditionalOnLoadCode(function($id) use ($triggered_signals) {
+			foreach ($triggered_signals as $triggered_signal) {
+				$signal = $triggered_signal->getSignal();
+				$event = $triggered_signal->getEvent();
+				$options = json_encode($signal->getOptions());
+				$this->js_binding->addOnLoadCode(
+					"$('#{$id}').{$event}( function(event) {
+						$(this).trigger('{$signal}',
+							{
+								'id' : '{$signal}', 'event' : '{$event}',
+								'triggerer' : $(this),
+								'options' : JSON.parse('{$options}')
+							}
+						);
+						return false;
+					});");
+			}
+		});
+	}
+
+	/**
 	 * Create an ID
 	 *
 	 * @return string
@@ -129,31 +173,6 @@ abstract class AbstractComponentRenderer implements ComponentRenderer {
 	final protected function createId() {
 		$id = $this->js_binding->createId();
 		return $id;
-	}
-
-	/**
-	 * Renderers of components acting as triggerer can use this method to trigger the registered signals
-	 *
-	 * @param Triggerer $triggerer
-	 * @param string $id The generated ID for the triggerer component
-	 */
-	protected function triggerRegisteredSignals(Triggerer $triggerer, $id) {
-		foreach ($triggerer->getTriggeredSignals() as $triggered_signal) {
-			$signal = $triggered_signal->getSignal();
-			$event = $triggered_signal->getEvent();
-			$options = json_encode($signal->getOptions());
-			$this->js_binding->addOnLoadCode(
-				"$('#{$id}').{$event}( function(event) { 
-					$(this).trigger('{$signal}',
-						{
-							'id' : '{$signal}', 'event' : '{$event}',
-							'triggerer' : $(this),
-							'options' : JSON.parse('{$options}')
-						}
-					);
-					return false;
-				});");
-		}
 	}
 
 	/**

--- a/src/UI/Implementation/Render/AbstractComponentRenderer.php
+++ b/src/UI/Implementation/Render/AbstractComponentRenderer.php
@@ -79,13 +79,6 @@ abstract class AbstractComponentRenderer implements ComponentRenderer {
 	}
 
 	/**
-	 * @return JavaScriptBinding
-	 */
-	final protected function getJavascriptBinding() {
-		return $this->js_binding;
-	}
-
-	/**
 	 * Get template of component this renderer is made for.
 	 *
 	 * Serves as a wrapper around instantiation of ilTemplate, exposes

--- a/tests/UI/Component/JavaScriptBindableTest.php
+++ b/tests/UI/Component/JavaScriptBindableTest.php
@@ -45,4 +45,29 @@ class JavaScriptBindableTest extends PHPUnit_Framework_TestCase {
 			$this->assertTrue(true);
 		}
 	}
+
+	public function test_withAdditionalOnLoadCode() {
+		$m = $this->mock
+			->withOnLoadCode(function($id) {
+				return "Its me, $id!";
+			})
+			->withAdditionalOnLoadCode(function($id) {
+				return "And again, me: $id.";
+			});
+
+		$binder = $m->getOnLoadCode();
+		$this->assertInstanceOf(\Closure::class, $binder);
+		$this->assertEquals("Its me, Mario!\nAnd again, me: Mario.", $binder("Mario"));
+	}
+
+	public function test_withAdditionalOnLoadCode_no_previous() {
+		$m = $this->mock
+			->withAdditionalOnLoadCode(function($id) {
+				return "And again, me: $id.";
+			});
+
+		$binder = $m->getOnLoadCode();
+		$this->assertInstanceOf(\Closure::class, $binder);
+		$this->assertEquals("And again, me: Mario.", $binder("Mario"));
+	}
 }

--- a/tests/UI/Component/Modal/LightboxTest.php
+++ b/tests/UI/Component/Modal/LightboxTest.php
@@ -45,7 +45,7 @@ class LightboxTest extends ModalBase {
 				<h4 class="modal-title">title</h4>
 			</div>
 			<div class="modal-body">
-				<div id="id_2" class="carousel slide" data-ride="carousel" data-interval="false">
+				<div id="id_1_carousel" class="carousel slide" data-ride="carousel" data-interval="false">
 
 
 
@@ -76,7 +76,7 @@ class LightboxTest extends ModalBase {
 		$('#id_1').on('shown.bs.modal', function() {
 			$('.modal-backdrop.in').css('opacity', '0.9');
 		});
-		$('#id_2').on('slid.bs.carousel', function() {
+		$('#id_1_carousel').on('slid.bs.carousel', function() {
 			var title = $(this).find('.carousel-inner .item.active').attr('data-title');
 			$('#id_1').find('.modal-title').text(title);
 		});

--- a/tests/UI/Renderer/ilIndependentTemplate.php
+++ b/tests/UI/Renderer/ilIndependentTemplate.php
@@ -10,6 +10,12 @@ require_once("./Services/UICore/lib/html-it/ITX.php");
 require_once("./Services/UICore/classes/class.ilTemplate.php");
 
 class ilIndependentTemplate extends ilTemplate implements \ILIAS\UI\Implementation\Render\Template {
+	function __construct($file,$flag1,$flag2,$in_module = false, $vars = "DEFAULT",
+		$plugin = false, $a_use_cache = true)
+	{
+		parent::__construct($file, $flag1, $flag2, $in_module, $vars, $plugin, false);
+	}
+
 	/**
 	 * Reads a file from disk and returns its content.
 	 *


### PR DESCRIPTION
I noticed the opportunity to cleanup some magic that was introduced with the signal-mechanism.

People writing Renderers will now have an easier job. `Triggerable` and `Triggerer` need to be `JavaScriptBindable` anyway, because they in fact use that functionality. Some internals of `AbstractComponentRenderer` that were exposed during the introduction of the signal-mechanism are back to being internal. 