### PR TITLE
Bug fix for #20874: Roundtrip Modal does not output withOnLoadCode()

### DIFF
--- a/src/UI/Implementation/Component/Modal/Renderer.php
+++ b/src/UI/Implementation/Component/Modal/Renderer.php
@@ -113,7 +113,7 @@ class Renderer extends AbstractComponentRenderer {
 	 */
 	protected function renderRoundTrip(Component\Modal\RoundTrip $modal, RendererInterface $default_renderer) {
 		$tpl = $this->getTemplate('tpl.roundtrip.html', true, true);
-		$id = $this->createId();
+		$id = $this->bindJavaScript($modal);
 		$this->registerSignals($modal, $id);
 		$this->triggerRegisteredSignals($modal, $id);
 		$tpl->setVariable('ID', $id);


### PR DESCRIPTION
https://www.ilias.de/mantis/view.php?id=20874

I guess this is true for other modal types as well