### PR TITLE
Fix/8782/5 2/char limit

### DIFF
--- a/Modules/Test/templates/default/tpl.il_as_tst_output.html
+++ b/Modules/Test/templates/default/tpl.il_as_tst_output.html
@@ -99,22 +99,49 @@
 	{
 		document.forms["taForm"].submit();
 	}
-	function charCounter(e)
+
+	// disable buttons and color counter red if the limit is exhausted
+	function checkCharCount(count) {
+		buttons = document.getElementsByClassName("btn");
+		if (count < 0) {
+			for (var i = 0, len = buttons.length; i < len; i++) {
+				buttons[i].setAttribute('disabled', true);
+			}
+			counterblock.style.color = 'red';
+		} else {
+			counterblock.style.color = 'black';
+			for (var i = 0, len = buttons.length; i < len; i++) {
+				buttons[i].removeAttribute('disabled');
+			}
+		}
+	}
+
+	function charCounter(e, textinput)
 	{
-		if(e.type == 'keyup')
-		{
-			content = tinyMCE.selectedInstance.getDoc().body.innerHTML;
+		if(e.type == 'keydown' || e.type == 'keyup') {
+			if (typeof tinyMCE !== 'undefined') {
+				content = tinyMCE.selectedInstance.getDoc().body.innerHTML;
+			} else {
+				content = textinput.value;
+			}
+
+			counter = YAHOO.util.Dom.get("myCounter");
+
 			content = content.replace(/&lt;/ig, "<");
 			content = content.replace(/&gt;/ig, ">");
-			stripped = content.replace(/(<([^>]+)>)/ig,"");
+			stripped = content.replace(/(<([^>]+)>)/ig, "");
 			counterblock = YAHOO.util.Dom.get("charcounter");
-			if (counterblock != null)
-			{
+			if (counterblock != null && (counter.value > 0 || e.keyCode == 8 || e.keyCode == 46 || (e.ctrlKey && e.keyCode == 88))) {
 				counterblock.style.visibility = 'visible';
-				counter = YAHOO.util.Dom.get("myCounter");
 				if (maxL > 0) counter.value = maxL - stripped.length;
 			}
-			
+
+			// prevent user from entering more characters than allowed
+			if (counter.value < 1 && !(e.keyCode < 47 || (e.ctrlKey && e.keyCode !== 86 && e.keyCode !== 90) || e.altKey || (e.keyCode >= 112 && e.keyCode <= 123))) {  // allow functional keys
+				e.preventDefault();
+			}
+
+			checkCharCount(counter.value);
 		}
 	}
 	
@@ -151,6 +178,11 @@
 					event.preventDefault();
 				}
 			}
+		});
+
+		// add event listener to textarea input - the tinyMCE already has a callback to charCounter()
+		$('textarea#TEXT').on('keyup keydown keypress', function(event) {
+			charCounter(event, this);
 		});
 	}
 	); })(jQuery);

--- a/Modules/Test/templates/default/tpl.il_as_tst_output.html
+++ b/Modules/Test/templates/default/tpl.il_as_tst_output.html
@@ -150,7 +150,8 @@
 		content = YAHOO.util.Dom.get("TEXT").innerHTML;
 		content = content.replace(/&lt;/ig, "<");
 		content = content.replace(/&gt;/ig, ">");
-		stripped = content.replace(/(<([^>]+)>)/ig,"");
+		stripped = content.replace(/(<([^>]+)>)/ig, "");
+		stripped = stripped.replace(/(?:\r\n|\r|\n)/g, '');
 		counterblock = YAHOO.util.Dom.get("charcounter");
 		if (counterblock != null)
 		{
@@ -161,8 +162,6 @@
 	}
 
 <!-- fau: testNav - moved auto saver to ilTestPlayerQuestionEditControl.js -->
-
-	YAHOO.util.Event.onDOMReady(initCharCounter);
 
 	(function($){ $(document).ready( function()
 	{
@@ -186,6 +185,8 @@
 		});
 	}
 	); })(jQuery);
+
+    YAHOO.util.Event.onDOMReady(initCharCounter);
 	
 </script>
 </div>

--- a/Modules/Test/templates/default/tpl.il_as_tst_output.html
+++ b/Modules/Test/templates/default/tpl.il_as_tst_output.html
@@ -130,6 +130,7 @@
 			content = content.replace(/&lt;/ig, "<");
 			content = content.replace(/&gt;/ig, ">");
 			stripped = content.replace(/(<([^>]+)>)/ig, "");
+			stripped = stripped.replace(/&nbsp;/gi, " ");
 			counterblock = YAHOO.util.Dom.get("charcounter");
 			if (counterblock != null && (counter.value > 0 || e.keyCode == 8 || e.keyCode == 46 || (e.ctrlKey && e.keyCode == 88))) {
 				counterblock.style.visibility = 'visible';
@@ -137,7 +138,7 @@
 			}
 
 			// prevent user from entering more characters than allowed
-			if (counter.value < 1 && !(e.keyCode < 47 || (e.ctrlKey && e.keyCode !== 86 && e.keyCode !== 90) || e.altKey || (e.keyCode >= 112 && e.keyCode <= 123))) {  // allow functional keys
+			if (counter.value < 1 && !((e.keyCode < 47 && e.keyCode != 32)|| (e.ctrlKey && e.keyCode !== 86 && e.keyCode !== 90) || e.altKey || (e.keyCode >= 112 && e.keyCode <= 123))) {  // allow functional keys
 				e.preventDefault();
 			}
 
@@ -152,6 +153,7 @@
 		content = content.replace(/&gt;/ig, ">");
 		stripped = content.replace(/(<([^>]+)>)/ig, "");
 		stripped = stripped.replace(/(?:\r\n|\r|\n)/g, '');
+		stripped = stripped.replace(/&nbsp;/gi, " ");
 		counterblock = YAHOO.util.Dom.get("charcounter");
 		if (counterblock != null)
 		{

--- a/Modules/TestQuestionPool/classes/class.assTextQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assTextQuestion.php
@@ -1094,7 +1094,9 @@ class assTextQuestion extends assQuestion implements ilObjQuestionScoringAdjusta
 		$max_chars = $this->getMaxNumOfChars();
 		if($max_chars)
 		{
-			$char_count = strlen(trim(strip_tags($submit)));
+			$stripped = trim(strip_tags($submit));
+			$stripped = str_replace(array("\n", "\r\n", "\r"), '', $stripped);
+			$char_count = strlen($stripped);
 			if($char_count > $max_chars)
 			{
 				$failureMsg = sprintf($this->lng->txt('ass_txt_char_lim_exhausted_hint'),

--- a/Modules/TestQuestionPool/classes/class.assTextQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assTextQuestion.php
@@ -1096,11 +1096,12 @@ class assTextQuestion extends assQuestion implements ilObjQuestionScoringAdjusta
 		{
 			$stripped = trim(strip_tags($submit));
 			$stripped = str_replace(array("\n", "\r\n", "\r"), '', $stripped);
-			$char_count = strlen($stripped);
+			$char_count = ilStr::strLen($stripped, "UTF-8");
+
 			if($char_count > $max_chars)
 			{
 				$failureMsg = sprintf($this->lng->txt('ass_txt_char_lim_exhausted_hint'),
-					$max_chars, $char_count
+					$char_count, $max_chars
 				);
 
 				ilUtil::sendFailure($failureMsg, true);

--- a/Modules/TestQuestionPool/classes/class.assTextQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assTextQuestion.php
@@ -1082,4 +1082,30 @@ class assTextQuestion extends assQuestion implements ilObjQuestionScoringAdjusta
 	{
 		return true;
 	}
+
+
+	/**
+	 * @return bool
+	 */
+	public function validateSolutionSubmit()
+	{
+		$submit = $this->getSolutionSubmit();
+
+		$max_chars = $this->getMaxNumOfChars();
+		if($max_chars)
+		{
+			$char_count = strlen(trim(strip_tags($submit)));
+			if($char_count > $max_chars)
+			{
+				$failureMsg = sprintf($this->lng->txt('ass_txt_char_lim_exhausted_hint'),
+					$max_chars, $char_count
+				);
+
+				ilUtil::sendFailure($failureMsg, true);
+				return false;
+			}
+		}
+
+		return true;
+	}
 }

--- a/Modules/TestQuestionPool/classes/class.assTextQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assTextQuestionGUI.php
@@ -208,7 +208,7 @@ class assTextQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringA
 				$max_no_of_chars = ucfirst($this->lng->txt('unlimited'));
 			}
 			
-			$act_no_of_chars = strlen($user_solution);
+			$act_no_of_chars = strlen(strip_tags(trim($user_solution)));
 			$template->setVariable("CHARACTER_INFO", '<b>' . $max_no_of_chars . '</b>' . 
 				$this->lng->txt('answer_characters') . ' <b>' . $act_no_of_chars . '</b>');
 		}

--- a/Modules/TestQuestionPool/classes/class.assTextQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assTextQuestionGUI.php
@@ -207,9 +207,11 @@ class assTextQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringA
 			{
 				$max_no_of_chars = ucfirst($this->lng->txt('unlimited'));
 			}
-			
-			$act_no_of_chars = strlen(strip_tags(trim($user_solution)));
-			$template->setVariable("CHARACTER_INFO", '<b>' . $max_no_of_chars . '</b>' . 
+
+			$stripped = trim(strip_tags($user_solution));
+			$stripped = str_replace(array("\n", "\r\n", "\r"), '', $stripped);
+			$act_no_of_chars = strlen($stripped);
+			$template->setVariable("CHARACTER_INFO", '<b>' . $max_no_of_chars . '</b>' .
 				$this->lng->txt('answer_characters') . ' <b>' . $act_no_of_chars . '</b>');
 		}
 		if (($active_id > 0) && (!$show_correct_solution))

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -322,6 +322,7 @@ assessment#:#ass_mc_sel_lim_hint#:#Bitte wählen Sie %s von %s Antworten!
 assessment#:#ass_mc_sel_lim_exhausted_hint#:#Bitte wählen Sie nicht mehr als %s von %s Antworten!
 assessment#:#ass_mc_sel_lim_setting#:#Antwortbeschränkung
 assessment#:#ass_mc_sel_lim_setting_desc#:#Mit dieser Einstellung lässt sich die Anzahl durch den Teilnehmer wählbarer Antworten einschränken.
+assessment#:#ass_txt_char_lim_exhausted_hint#:#Ihre Eingabe überschreitet mit %s Zeichen die Zeichenbeschränkung von %s Zeichen!
 assessment#:#essay_scoring_mode#:#Bewertungsmodus
 assessment#:#essay_scoring_mode_without_keywords#:#Keine automatische Bewertung
 assessment#:#essay_scoring_mode_without_keywords_desc#:#Es werden keine Punkte automatisiert vergeben. Die Punktevergabe ist nur mit manueller Bewertung möglich.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -226,6 +226,7 @@ assessment#:#ass_mc_sel_lim_hint#:#Please select %s of %s answers!
 assessment#:#ass_mc_sel_lim_exhausted_hint#:#Please do not select more than %s of %s answers!
 assessment#:#ass_mc_sel_lim_setting#:#Answering Limitation
 assessment#:#ass_mc_sel_lim_setting_desc#:#With this setting the number of answers choosable by the participants can be limited.
+assessment#:#ass_txt_char_lim_exhausted_hint#:#Your answer has %s characters and exceeds the character limit of %s characters!
 assessment#:#essay_scoring_mode#:#Scoring Mode
 assessment#:#essay_scoring_mode_without_keywords#:#No Automatic Scoring
 assessment#:#essay_scoring_mode_without_keywords_desc#:#No points are granted unless the tutor's manual scoring.


### PR DESCRIPTION
This is a possible fix for https://www.ilias.de/mantis/view.php?id=8782 - which was considered "resolved", but I don't think the desired behavior is accomplished. The character limit in text question in tests is still ignored by ILIAS.

This PR implements:

- Modifications in the javascript files prevent users from typing more characters than allowed. 
- Should the limit be exhausted - this is still possible by copy & pasting in texts - would the counter turn red and the navigation buttons are disabled
- Should a user save the question although the limit is exhausted - e.g. by deactivating the javascript, editing the html etc. - would the answer not be accepted by the backend. A failure message is shown.
- All the above work with and without tinyMCE
- After test completion, an incorrect character count was shown when working with tinyMCE. This is fixed now.