### PR TITLE
20904: fixed expand and collapse glyphs

### DIFF
--- a/src/UI/Component/Glyph/Factory.php
+++ b/src/UI/Component/Glyph/Factory.php
@@ -53,7 +53,7 @@ interface Factory {
 	 *          The Collapse Glyph MUST indicate if the toggled Container Collection is visible or not.
 	 *   accessibility:
 	 *       1: >
-	 *          The aria-label MUST be ‘Collapse Content'.
+	 *          The aria-label MUST be ‘Collapse'.
 	 * ---
 	 * @param	string|null	$action
 	 * @return	\ILIAS\UI\Component\Glyph\Glyph
@@ -81,8 +81,8 @@ interface Factory {
 	 *          The Expand Glyph MUST indicate if the toggled Container Collection is visible or not.
 	 *   accessibility:
 	 *       1: >
-	 *          The aria-label MUST be ‘Expand Content'.
-	 * ---
+	 *          The aria-label MUST be ‘Expand'.
+	 ---
 	 * @param	string|null	$action
 	 * @return	\ILIAS\UI\Component\Glyph\Glyph
 	 */

--- a/src/UI/Component/Glyph/Factory.php
+++ b/src/UI/Component/Glyph/Factory.php
@@ -82,7 +82,7 @@ interface Factory {
 	 *   accessibility:
 	 *       1: >
 	 *          The aria-label MUST be ‘Expand'.
-	 ---
+	 * ---
 	 * @param	string|null	$action
 	 * @return	\ILIAS\UI\Component\Glyph\Glyph
 	 */

--- a/src/UI/Implementation/Component/Glyph/Factory.php
+++ b/src/UI/Implementation/Component/Glyph/Factory.php
@@ -18,14 +18,14 @@ class Factory implements G\Factory {
 	 * @inheritdoc
 	 */
 	public function collapse($action = null) {
-		return new Glyph(G\Glyph::COLLAPSE, "collapse_content", $action);
+		return new Glyph(G\Glyph::COLLAPSE, "collapse", $action);
 	}
 
 	/**
 	 * @inheritdoc
 	 */
 	public function expand($action = null) {
-		return new Glyph(G\Glyph::EXPAND, "expand_content", $action);
+		return new Glyph(G\Glyph::EXPAND, "expand", $action);
 	}
 
 	/**

--- a/src/UI/templates/default/Glyph/tpl.glyph.html
+++ b/src/UI/templates/default/Glyph/tpl.glyph.html
@@ -3,8 +3,8 @@
 
 <span class="glyphicon 
 <!-- BEGIN settings -->glyphicon-cog<!-- END settings -->
-<!-- BEGIN collapse -->glyphicon-triangle-bottom<!-- END collapse -->
-<!-- BEGIN expand -->glyphicon-triangle-right<!-- END expand -->
+<!-- BEGIN collapse -->glyphicon-chevron-down<!-- END collapse -->
+<!-- BEGIN expand -->glyphicon-chevron-right<!-- END expand -->
 <!-- BEGIN add -->glyphicon-plus-sign<!-- END add -->
 <!-- BEGIN remove -->glyphicon-minus-sign<!-- END remove -->
 <!-- BEGIN up -->glyphicon-circle-arrow-up<!-- END up -->


### PR DESCRIPTION
As of [20904](https://www.ilias.de/mantis/view.php?id=20904) the collapse and expand glyph is not displayed correctly. The Bootstrap version we use (3.2.0) does not provide the triangle that is used for the two glyphs. This proposes to replace the triangle with a chevron. This also fixes the aria labels of the glyphs.