### PR TITLE
 search: adding prefilling of detail search options and add default option

### DIFF
--- a/Services/Search/classes/class.ilObjSearchSettingsGUI.php
+++ b/Services/Search/classes/class.ilObjSearchSettingsGUI.php
@@ -101,10 +101,11 @@ class ilObjSearchSettingsGUI extends ilObjectGUI
 		$this->object->settings_obj->enableLucene($_POST['search_lucene']);
 		$this->object->settings_obj->setHideAdvancedSearch($_POST['hide_adv_search']);
 		$this->object->settings_obj->setAutoCompleteLength($_POST['auto_complete_length']);
+		$this->object->settings_obj->setDetailSearchDefault((int)$_POST['search_detail_default']);
 		$this->object->settings_obj->setDefaultOperator((int) $_POST['operator']);
 		$this->object->settings_obj->enableLuceneItemFilter((int) $_POST['if']);
 		$this->object->settings_obj->setLuceneItemFilter((array) $_POST['filter']);
-		
+
 
 		$rpc_settings = ilRPCServerSettings::getInstance();
 		if($this->object->settings_obj->enabledLucene() and !$rpc_settings->pingServer())
@@ -233,7 +234,6 @@ class ilObjSearchSettingsGUI extends ilObjectGUI
 		$us->setChecked($settings->isLuceneUserSearchEnabled());
 		$this->form->addItem($us);
 		
-		
 		// Item filter
 		$if = new ilCheckboxInputGUI($this->lng->txt('search_item_filter_form'),'if');
 		$if->setValue(1);
@@ -252,7 +252,13 @@ class ilObjSearchSettingsGUI extends ilObjectGUI
 			$ch->setValue(1);
 			$if->addSubItem($ch);
 		}
-		
+
+		$defaultType = new ilCheckboxInputGUI($this->lng->txt('search_detail_default'), 'search_detail_default');
+		$defaultType->setInfo($this->lng->txt('search_detail_default_info'));
+		$defaultType->setValue(1);
+		$defaultType->setChecked($settings->isDetailSearchDefault());
+		$this->form->addItem($defaultType);
+
 		$cdate = new ilCheckboxInputGUI($this->lng->txt('search_cdate_filter'), 'cdate');
 		$cdate->setInfo($this->lng->txt('search_cdate_filter_info'));
 		$cdate->setChecked($settings->isDateFilterEnabled());
@@ -340,6 +346,7 @@ class ilObjSearchSettingsGUI extends ilObjectGUI
 				break;
 		}
 
+		$settings->setDetailSearchDefault((int)$_POST['search_detail_default']);
 		$settings->setDefaultOperator((int) $_POST['operator']);
 		$settings->enableLuceneItemFilter((int) $_POST['if']);
 		$settings->setLuceneItemFilter((array) $_POST['filter']);

--- a/Services/Search/classes/class.ilSearchGUI.php
+++ b/Services/Search/classes/class.ilSearchGUI.php
@@ -46,6 +46,24 @@ class ilSearchGUI extends ilSearchBaseGUI
 		$new_search = isset($_POST['cmd']['performSearch']) ? true : false;
 
 		$enabled_types = ilSearchSettings::getInstance()->getEnabledLuceneItemFilterDefinitions();
+
+		/*
+		 * set detail search checkboxes and search type to the default values.
+		 */
+		if(!isset($_SESSION['search']))
+		{
+			if (ilSearchSettings::getInstance()->isLuceneItemFilterEnabled()
+				&& ilSearchSettings::getInstance()->isDetailSearchDefault()
+			) {
+				$_SESSION['search']['type'] = 2;
+			}
+
+			foreach($enabled_types as $type => $pval)
+			{
+				$_SESSION['search']['details'][$type] = 1;
+			}
+		}
+
 		foreach($enabled_types as $type => $pval)
 		{
 			if($_POST['filter_type'][$type] == 1)

--- a/Services/Search/classes/class.ilSearchSettings.php
+++ b/Services/Search/classes/class.ilSearchSettings.php
@@ -23,6 +23,7 @@ class ilSearchSettings
 	protected static $instance = null;
 	
 	protected $default_operator = self::OPERATOR_AND;
+	protected $is_detail_search_default = false;
 	protected $fragmentSize = 30;
 	protected $fragmentCount =  3;
 	protected $numSubitems = 5;
@@ -224,6 +225,16 @@ class ilSearchSettings
 		return $this->default_operator;
 	}
 	
+	public function isDetailSearchDefault()
+	{
+		return $this->is_detail_search_default ? true : false;
+	}
+	
+	public function setDetailSearchDefault($isDefault)
+	{
+		$this->is_detail_search_default = (bool)$isDefault;
+	}
+
 	public function setDefaultOperator($a_op)
 	{
 		$this->default_operator = $a_op;
@@ -446,7 +457,8 @@ class ilSearchSettings
 		$this->ilias->setSetting('search_max_hits',$this->getMaxHits());
 		$this->ilias->setSetting('search_index',(int) $this->enabledIndex());
 		$this->ilias->setSetting('search_lucene',(int) $this->enabledLucene());
-		
+		$this->ilias->setSetting('search_detail_default', (int)$this->isDetailSearchDefault());
+
 		$this->ilias->setSetting('lucene_default_operator',$this->getDefaultOperator());
 		$this->ilias->setSetting('lucene_fragment_size',$this->getFragmentSize());
 		$this->ilias->setSetting('lucene_fragment_count',$this->getFragmentCount());
@@ -479,7 +491,8 @@ class ilSearchSettings
 		$this->setMaxHits($this->ilias->getSetting('search_max_hits',10));
 		$this->enableIndex($this->ilias->getSetting('search_index',0));
 		$this->enableLucene($this->ilias->getSetting('search_lucene',0));
-		
+		$this->setDetailSearchDefault($this->ilias->getSetting('search_detail_default', false));
+
 		$this->setDefaultOperator($this->ilias->getSetting('lucene_default_operator',self::OPERATOR_AND));
 		$this->setFragmentSize($this->ilias->getSetting('lucene_fragment_size',50));
 		$this->setFragmentCount($this->ilias->getSetting('lucene_fragment_count',3));

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -9845,7 +9845,7 @@ search#:#search_in_result#:#In den Resultaten suchen###deprecated
 search#:#search_inactive#:#Inaktive Benutzer###deprecated 
 search#:#search_index#:#Indizierte Suche
 search#:#search_item_filter#:#Suche nach Typ###deprecated 
-search#:#search_item_filter_form#:#Suche nach Typ
+search#:#search_item_filter_form#:#Detailsuche aktivieren
 search#:#search_item_filter_form_info#:#Beschränkt die Suche auf die ausgewählten Dateitypen
 search#:#search_like_info#:#Wählen Sie diese Suchart, um möglichst genaue Treffer zu erhalten. Auf größeren Installationen kann die Suchgeschwindigkeit jedoch zu langsam sein.
 search#:#search_limit_reached#:#Ihre Suche ergab mehr als %s Treffer. Sie können die Abfrage weiter einschränken, um detailliertere Treffer zu erhalten.
@@ -9900,6 +9900,8 @@ search#:#search_term_combination#:#Kombination
 search#:#search_title_description#:#Titel / Beschreibung
 search#:#search_tst_svy#:#Tests/Umfragen
 search#:#search_type#:#Suchart
+search#:#search_detail_default#:#Detailsuche voreingestellt
+search#:#search_detail_default_info#:#Bei aktivierter Detailsuche wird diese voreingestellt.
 search#:#search_user#:#Benutzer
 search#:#search_user_extended#:#Erweiterte Benutzersuche
 search#:#search_user_simple#:#Einfache Benutzersuche###deprecated 

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -8414,6 +8414,8 @@ search#:#search_term_combination#:#Combination
 search#:#search_title_description#:#Title / Description
 search#:#search_tst_svy#:#Tests/Surveys
 search#:#search_type#:#Type
+search#:#search_detail_default#:#preset detail search
+search#:#search_detail_default_info#:#detail search will be preset.
 search#:#search_user_extended#:#Extended User Search
 search#:#search_user_simple#:#Simple User Search###deprecated 
 search#:#search_user#:#Users
@@ -9581,7 +9583,7 @@ dateplaner#:#cal_notification_info#:#If enabled, all course/group participants w
 dateplaner#:#cal_adm_notification_info#:#Choose this option, to send optional mail notifications to course/group participants about changed appointments.
 rbac#:#rbac_add_new_local_role#:#Add New Local Role
 search#:#search_item_filter#:#Search by Type###deprecated 
-search#:#search_item_filter_form#:#Search by Type
+search#:#search_item_filter_form#:#Enable detail search
 search#:#search_item_filter_form_info#:#Search can be restricted to the chosen file types.
 administration#:#group_export#:#Visible in Groups
 tbl#:#tbl_export_csv#:#Export .csv


### PR DESCRIPTION
if you switch the search from "title & description , ..." to
"fulltext/detail" the user not find any result because "type" is not
pre-checked. he must now active all the types manually to get a
result. the user should not have work manually to find something.

**actual, no results, manually work needed:**

![detail_search](https://user-images.githubusercontent.com/3705274/28857861-ba251568-774c-11e7-84b3-d24366c14b26.png)

**with commit, results, default no manually work needed:**

![detail_search2](https://user-images.githubusercontent.com/3705274/28857930-32cae218-774d-11e7-8fb1-c9156b5df064.png)
