### PR TITLE
0020542: Permissions of Didactic Templates get lost while moving folder

### DIFF
--- a/Services/Container/classes/class.ilContainerGUI.php
+++ b/Services/Container/classes/class.ilContainerGUI.php
@@ -1968,7 +1968,17 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 					
 					include_once('./Services/AccessControl/classes/class.ilConditionHandler.php');
 					ilConditionHandler::_adjustMovedObjectConditions($ref_id);
-	
+
+					// Assign Didactic Template again if assigned
+					require_once('./Services/DidacticTemplate/classes/class.ilDidacticTemplateObjSettings.php');
+					$did_tpl_id = ilDidacticTemplateObjSettings::lookupTemplateId($ref_id);
+					if ($did_tpl_id) {
+						include_once './Services/DidacticTemplate/classes/class.ilDidacticTemplateActionFactory.php';
+						foreach (ilDidacticTemplateActionFactory::getActionsByTemplateId($did_tpl_id) as $action) {
+							$action->setRefId($ref_id);
+							$action->apply();
+						}
+					}
 					// BEGIN ChangeEvent: Record cut event.
 					$node_data = $tree->getNodeData($ref_id);
 					$old_parent_data = $tree->getNodeData($old_parent);


### PR DESCRIPTION
Hi @smeyer-ilias since I has to patch this in a customers repo I provide my solution here as PR. But not sure if this is the best solution, feel free to just close it.

https://www.ilias.de/mantis/view.php?id=20542