### PR TITLE
Feature "Additional Data for Page Editor Plugins"

### DIFF
--- a/Services/COPage/classes/class.ilCOPageExporter.php
+++ b/Services/COPage/classes/class.ilCOPageExporter.php
@@ -16,10 +16,31 @@ class ilCOPageExporter extends ilXmlExporter
 	protected $config;
 
 	/**
+	 * List of dependencies for page component plugins with an own exporter
+	 *
+	 * The list of ids in the dependency definition has the following format:
+	 * 		<parent_type>:<page_id>:<lang>:<pc_id>
+	 *
+	 * The implementation assumes the following call sequence of methods
+	 * to avoid a multiple instatiation of page objects
+	 * 1. init()
+	 * 2. getXmlRepresentation()
+	 * 3. getXmlExportTailDependencies()
+	 *
+	 *
+ 	 * @var array  	plugin_name => depencency definition array
+	 */
+	protected $plugin_dependencies = array();
+
+	/**
 	 * Initialisation
 	 */
 	function init()
 	{
+		global $DIC;
+		/** @var ilPluginAdmin $ilPluginAdmin */
+		$ilPluginAdmin = $DIC['ilPluginAdmin'];
+
 		include_once("./Services/COPage/classes/class.ilCOPageDataSet.php");
 		$this->ds = new ilCOPageDataSet();
 		$this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
@@ -28,6 +49,23 @@ class ilCOPageExporter extends ilXmlExporter
 		if ($this->config->getMasterLanguageOnly())
 		{
 			$this->ds->setMasterLanguageOnly(true);
+		}
+
+		// collect all page component plugins that have their own exporter
+		require_once('Services/COPage/classes/class.ilPageComponentPluginExporter.php');
+		foreach(ilPluginAdmin::getActivePluginsForSlot(IL_COMP_SERVICE, "COPage", "pgcp") as $plugin_name)
+		{
+			if ($ilPluginAdmin->supportsExport(IL_COMP_SERVICE, "COPage", "pgcp", $plugin_name))
+			{
+				require_once('Customizing/global/plugins/Services/COPage/PageComponent/'
+					.$plugin_name.'/classes/class.il'.$plugin_name.'Exporter.php');
+
+				$this->plugin_dependencies[$plugin_name] = array(
+					"component" => "Plugins/" . $plugin_name,
+					"entity" => "pgcp",
+					"ids" => array()
+				);
+			}
 		}
 	}
 
@@ -118,7 +156,13 @@ class ilCOPageExporter extends ilXmlExporter
 					"ids" => $pg_ids)
 				);
 		}
-		
+
+		if (!empty($this->plugin_dependencies))
+		{
+			// use numeric keys instead plugin names
+			return array_values($this->plugin_dependencies);
+		}
+
 		return array();
 	}
 
@@ -159,6 +203,7 @@ class ilCOPageExporter extends ilXmlExporter
 				$page_object = ilPageObjectFactory::getInstance($id[0], $id[1], 0, $l);
 				$page_object->buildDom();
 				$page_object->insertInstIntoIDs(IL_INST_ID);
+				$this->extractPluginProperties($page_object);
 				$pxml = $page_object->getXMLFromDom(false, false, false, "", true);
 				$pxml = str_replace("&","&amp;", $pxml);
 				$xml.= '<PageObject Language="'.$l.'" Active="'.$page_object->getActive().'" ActivationStart="'.$page_object->getActivationStart().'" ActivationEnd="'.
@@ -213,6 +258,62 @@ class ilCOPageExporter extends ilXmlExporter
 		}
 	}
 
+	/**
+	 * Extract the properties of the plugged page contents
+	 * The page XML is scanned for plugged contents with own exporters
+	 * Their ids are added as dependencies
+	 *
+	 * Called from getXmlRepresentation() for each handled page object
+	 * Extracted data is used by dependent exporters afterwards
+	 *
+	 * @param ilPageObject $a_page
+	 */
+	protected function extractPluginProperties($a_page)
+	{
+		if (empty($this->plugin_dependencies))
+		{
+			return;
+		}
+
+		$a_page->buildDom();
+		$domdoc = $a_page->getDomDoc();
+		$xpath = new DOMXPath($domdoc);
+		$nodes = $xpath->query("//PageContent[child::Plugged]");
+
+		/** @var DOMElement $pcnode */
+		foreach($nodes as $pcnode)
+		{
+			// page content id (unique in the page)
+			$pc_id = $pcnode->getAttribute('PCID');
+			$plnode = $pcnode->childNodes->item(0);
+			$plugin_name = $plnode->getAttribute('PluginName');
+			$plugin_version = $plnode->getAttribute('PluginVersion');
+
+			// dependency should be exported
+			if (isset($this->plugin_dependencies[$plugin_name]))
+			{
+				// construct a unique dependency id of the plugged page content
+				$id = $a_page->getParentType()
+					. ':' . $a_page->getId()
+					. ':' . $a_page->getLanguage()
+					. ':' . $pc_id;
+
+				$properties = array();
+				/** @var DOMElement $child */
+				foreach($plnode->childNodes as $child)
+				{
+					$properties[$child->getAttribute('Name')] = $child->nodeValue;
+				}
+
+				// statical provision of content to the exporter classes
+				ilPageComponentPluginExporter::setPCVersion($id, $plugin_version);
+				ilPageComponentPluginExporter::setPCProperties($id, $properties);
+
+				// each plugin exporter gets only the ids of its own content
+				$this->plugin_dependencies[$plugin_name]['ids'][] = $id;
+			}
+		}
+	}
 }
 
 ?>

--- a/Services/COPage/classes/class.ilPCPlugged.php
+++ b/Services/COPage/classes/class.ilPCPlugged.php
@@ -176,6 +176,92 @@ class ilPCPlugged extends ilPageContent
 	}
 
 	/**
+	 * Handle copied plugged content. This function must, e.g. create copies of
+	 * objects referenced within the content (e.g. question objects)
+	 *
+	 * @param ilPageObject	$a_page			the current page object
+	 * @param DOMDocument 	$a_domdoc 		dom document
+	 */
+	static function handleCopiedPluggedContent(ilPageObject $a_page, DOMDocument $a_domdoc)
+	{
+		global $DIC;
+		$ilPluginAdmin = $DIC['ilPluginAdmin'];
+
+		$xpath = new DOMXPath($a_domdoc);
+		$nodes = $xpath->query("//Plugged");
+
+		/** @var DOMElement $node */
+		foreach($nodes as $node)
+		{
+			$plugin_name = $node->getAttribute('PluginName');
+			$plugin_version = $node->getAttribute('PluginVersion');
+
+			if ($ilPluginAdmin->isActive(IL_COMP_SERVICE, "COPage", "pgcp", $plugin_name))
+			{
+				/** @var ilPageComponentPlugin $plugin_obj */
+				$plugin_obj = $ilPluginAdmin->getPluginObject(IL_COMP_SERVICE, "COPage", "pgcp", $plugin_name);
+				$plugin_obj->setPageObj($a_page);
+
+				$properties = array();
+				/** @var DOMElement $child */
+				foreach($node->childNodes as $child)
+				{
+					$properties[$child->getAttribute('Name')] = $child->nodeValue;
+				}
+
+				// let the plugin copy additional content
+				// and allow it to modify the saved parameters
+				$plugin_obj->onClone($properties, $plugin_version);
+
+				foreach($node->childNodes as $child)
+				{
+					$node->removeChild($child);
+				}
+				foreach ($properties as $name => $value)
+				{
+					$child = new DOMElement('PluggedProperty', $value);
+					$node->appendChild($child);
+					$child->setAttribute('Name',$name);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Handle deleted plugged content. This function must, e.g. delete
+	 * objects referenced within the content (e.g. question objects)
+	 *
+	 * @param ilPageObject	$a_page			the current page object
+	 * @param DOMDocument 	$a_node 		dom node
+	 */
+	static function handleDeletedPluggedNode(ilPageObject $a_page, DOMNode $a_node)
+	{
+		global $DIC;
+		$ilPluginAdmin = $DIC['ilPluginAdmin'];
+
+		$plugin_name = $a_node->getAttribute('PluginName');
+		$plugin_version = $a_node->getAttribute('PluginVersion');
+
+		if ($ilPluginAdmin->isActive(IL_COMP_SERVICE, "COPage", "pgcp", $plugin_name))
+		{
+			/** @var ilPageComponentPlugin $plugin_obj */
+			$plugin_obj = $ilPluginAdmin->getPluginObject(IL_COMP_SERVICE, "COPage", "pgcp", $plugin_name);
+			$plugin_obj->setPageObj($a_page);
+
+			$properties = array();
+			/** @var DOMElement $child */
+			foreach($a_node->childNodes as $child)
+			{
+				$properties[$child->getAttribute('Name')] = $child->nodeValue;
+			}
+
+			// let the plugin delete additional content
+			$plugin_obj->onDelete($properties, $plugin_version);
+		}
+	}
+
+
+	/**
 	 * Modify page content after xsl
 	 *
 	 * @param string $a_output

--- a/Services/COPage/classes/class.ilPageComponentPlugin.php
+++ b/Services/COPage/classes/class.ilPageComponentPlugin.php
@@ -181,5 +181,23 @@ abstract class ilPageComponentPlugin extends ilPlugin
 		return '';
 	}
 
+	/**
+	 * This function is called when the page content is cloned
+	 * @param array 	$a_properties		(properties saved in the page, should be modified if neccessary)
+	 * @param string	$a_plugin_version	(plugin version of the properties)
+	 */
+	public function onClone(&$a_properties, $a_plugin_version)
+	{
+	}
+
+	/**
+	 * This function is called before the page content is deleted
+	 * @param array 	$a_properties		properties saved in the page (will be deleted afterwards)
+	 * @param string	$a_plugin_version	plugin version of the properties
+	 */
+	public function onDelete($a_properties, $a_plugin_version)
+	{
+	}
+
 }
 ?>

--- a/Services/COPage/classes/class.ilPageComponentPluginExporter.php
+++ b/Services/COPage/classes/class.ilPageComponentPluginExporter.php
@@ -1,0 +1,94 @@
+<?php
+
+/* Copyright (c) 1998-2017 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+include_once("./Services/Export/classes/class.ilXmlExporter.php");
+
+/**
+ * Abstract parent class for all page component plugin exporter classes.
+ *
+ * @author Fred Neumann <fred.neumann@gmx.de>
+ * @version $Id$
+ *
+ * @ingroup ServicesCOPage
+ */
+abstract class ilPageComponentPluginExporter extends ilXmlExporter
+{
+	/**
+	 * Properties of exportable plugged page contents
+	 * The id has the following format:
+	 * 		<parent_type>:<page_id>:<lang>:<pc_id>
+	 * This format, however, should be irrelevant to child classes
+	 *
+	 * @var array $pc_properties  id => [ name => value, ... ]
+	 */
+	protected static $pc_properties = array();
+
+	/**
+	 * Plugin versions of exportable plugged page contents
+	 *
+	 * @var array $pc_version	id => version
+	 */
+	protected static $pc_version = array();
+
+
+	/**
+	 * Set the properties of a plugged page content
+	 * This method is used by ilCOPageExporter to provide the properties
+	 *
+	 * @param string $a_id
+	 * @param array $a_properties
+	 */
+	public static function setPCProperties($a_id, $a_properties)
+	{
+		self::$pc_properties[$a_id] = $a_properties;
+	}
+
+	/**
+	 * Get the properties of a plugged page content
+	 *
+	 * @param string $a_id
+	 * @return mixed|null
+	 */
+	public static function getPCProperties($a_id)
+	{
+		if (isset(self::$pc_properties[$a_id]))
+		{
+			return self::$pc_properties[$a_id];
+		}
+		else
+		{
+			return null;
+		}
+	}
+
+	/**
+	 * Set the version of a plugged page content
+	 * This method is used by ilCOPageExporter to provide the version
+	 *
+	 * @param string $a_id
+	 * @param string $a_version
+	 */
+	public static function setPCVersion($a_id, $a_version)
+	{
+		self::$pc_version[$a_id] = $a_version;
+	}
+
+	/**
+	 * Get the version of a plugged page content
+	 *
+	 * @param string $a_id
+	 * @return string|null
+	 */
+	public static function getPCVersion($a_id)
+	{
+		if (isset(self::$pc_version[$a_id]))
+		{
+			return self::$pc_version[$a_id];
+		}
+		else
+		{
+			return null;
+		}
+	}
+}

--- a/Services/COPage/classes/class.ilPageComponentPluginImporter.php
+++ b/Services/COPage/classes/class.ilPageComponentPluginImporter.php
@@ -1,0 +1,113 @@
+<?php
+
+/* Copyright (c) 1998-2017 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+include_once("./Services/Export/classes/class.ilXmlImporter.php");
+
+/**
+ * Abstract parent class for all page component plugin importer classes.
+ *
+ * @author Fred Neumann <fred.neumann@gmx.de>
+ * @version $Id$
+ *
+ * @ingroup ServicesCOPage
+ */
+abstract class ilPageComponentPluginImporter extends ilXmlImporter
+{
+	/**
+	 * Properties of exportable plugged page contents
+	 * The id has the following format:
+	 * 		<parent_type>:<page_id>:<lang>:<pc_id>
+	 * This format, however, should be irrelevant to child classes
+	 *
+	 * @var array $pc_properties  id => [ name => value, ... ]
+	 */
+	protected static $pc_properties = array();
+
+	/**
+	 * Plugin versions of exportable plugged page contents
+	 *
+	 * @var array $pc_version	id => version
+	 */
+	protected static $pc_version = array();
+
+
+	/**
+	 * Set the properties of a plugged page content
+	 * This method is used by ilCOPageExporter to provide the properties
+	 *
+	 * @param string $a_id
+	 * @param array $a_properties
+	 */
+	public static function setPCProperties($a_id, $a_properties)
+	{
+		self::$pc_properties[$a_id] = $a_properties;
+	}
+
+	/**
+	 * Get the properties of a plugged page content
+	 *
+	 * @param string $a_id
+	 * @return mixed|null
+	 */
+	public static function getPCProperties($a_id)
+	{
+		if (isset(self::$pc_properties[$a_id]))
+		{
+			return self::$pc_properties[$a_id];
+		}
+		else
+		{
+			return null;
+		}
+	}
+
+	/**
+	 * Set the version of a plugged page content
+	 * This method is used by ilCOPageExporter to provide the version
+	 *
+	 * @param string $a_id
+	 * @param string $a_version
+	 */
+	public static function setPCVersion($a_id, $a_version)
+	{
+		self::$pc_version[$a_id] = $a_version;
+	}
+
+	/**
+	 * Get the version of a plugged page content
+	 *
+	 * @param string $a_id
+	 * @return string|null
+	 */
+	public static function getPCVersion($a_id)
+	{
+		if (isset(self::$pc_version[$a_id]))
+		{
+			return self::$pc_version[$a_id];
+		}
+		else
+		{
+			return null;
+		}
+	}
+
+
+	/**
+	 * Get the id of the mapped page content
+	 * The id structure should be irrelevant to child classes
+	 * The mapped ID shold be used both for getPCProperties() and setPCProperties()
+	 * when being called in their importXmlRepresentation()
+	 *
+	 * @param 	string				$a_id
+	 * @param	ilImportMapping		$a_mapping
+	 */
+	public static function getPCMapping($a_id, $a_mapping)
+	{
+		$parts = explode(':', $a_id);
+		$old_page_id = $parts[0].':' .$parts[1];
+		$new_page_id = $a_mapping->getMapping("Services/COPage", 'pg', $old_page_id);
+
+		return $new_page_id . ':' . $parts[2] . ':' . $parts[3];
+	}
+}

--- a/Services/COPage/classes/class.ilPageObject.php
+++ b/Services/COPage/classes/class.ilPageObject.php
@@ -1134,11 +1134,56 @@ abstract class ilPageObject
 		{
 			ilCOPagePCDef::requirePCClassByName($def["name"]);
 			$cl = $def["pc_class"];
-			$cl::handleCopiedContent($a_dom, $a_self_ass, $a_clone_mobs);
+			if ($cl == 'ilPCPlugged')
+			{
+				// the page object is provided for ilPageComponentPlugin
+				ilPCPlugged::handleCopiedPluggedContent($this, $a_dom);
+			}
+			else
+			{
+				$cl::handleCopiedContent($a_dom, $a_self_ass, $a_clone_mobs);
+			}
 		}
 		
 	}
-	
+
+	/**
+	 * Handle content before deletion
+	 * This currently treats only plugged content
+	 * If no node is given, then the whole dom will be scanned
+	 *
+	 * @param php4DOMNode|DOMNode|null	$a_node
+	 */
+	function handleDeleteContent($a_node = null)
+	{
+		if (!isset($a_node))
+		{
+			$xpc = xpath_new_context($this->dom);
+			$path = "//PageContent";
+			$res = xpath_eval($xpc, $path);
+			$nodes = $res->nodeset;
+		}
+		else
+		{
+			$nodes = array($a_node);
+		}
+
+		require_once('Services/COPage/classes/class.ilPCPlugged.php');
+		foreach ($nodes as $node)
+		{
+			if ($node instanceof php4DOMNode)
+			{
+				$node = $node->myDOMNode;
+			}
+
+			/** @var DOMElement $node */
+			if ($node->firstChild->nodeName == 'Plugged')
+			{
+				ilPCPlugged::handleDeletedPluggedNode($this, $node->firstChild);
+			}
+		}
+	}
+
 	/**
 	 * Replaces media objects in interactive images
 	 * with copies of the interactive images
@@ -2819,6 +2864,9 @@ abstract class ilPageObject
 
 		$this->__beforeDelete();
 
+		// treat plugged content
+		$this->handleDeleteContent();
+
 		// delete style usages
 		$this->deleteStyleUsages(false);
 
@@ -3166,6 +3214,7 @@ abstract class ilPageObject
 	function deleteContent($a_hid, $a_update = true, $a_pcid = "")
 	{
 		$curr_node = $this->getContentNode($a_hid, $a_pcid);
+		$this->handleDeleteContent($curr_node);
 		$curr_node->unlink_node($curr_node);
 		if ($a_update)
 		{
@@ -3202,6 +3251,7 @@ abstract class ilPageObject
 					$parent_node = $curr_node->parent_node();
 					if ($parent_node->node_name() != "TableRow")
 					{
+						$this->handleDeleteContent($curr_node);
 						$curr_node->unlink_node($curr_node);
 					}
 				}
@@ -3402,6 +3452,7 @@ abstract class ilPageObject
 				if ($hier_id != "pg" && $hier_id >= $a_hid)
 				{
 					$curr_node = $this->getContentNode($hier_id);
+					$this->handleDeleteContent($curr_node);
 					$curr_node->unlink_node($curr_node);
 				}
 			}
@@ -3432,6 +3483,7 @@ abstract class ilPageObject
 				if ($hier_id != "pg" && $hier_id < $a_hid)
 				{
 					$curr_node = $this->getContentNode($hier_id);
+					$this->handleDeleteContent($curr_node);
 					$curr_node->unlink_node($curr_node);
 				}
 			}

--- a/Services/Export/classes/class.ilImportExportFactory.php
+++ b/Services/Export/classes/class.ilImportExportFactory.php
@@ -33,6 +33,13 @@ class ilImportExportFactory
 			$comp = $objDefinition->getComponentForType($a_type);
 			$class = array_pop(explode("/", $comp));
 			$class = "il".$class."Exporter";
+
+			// page component plugin exporter classes are already included
+			// the component is not registered by ilObjDefinition
+			if (class_exists($class))
+			{
+				return $class;
+			}
 			
 			// the next line had a "@" in front of the include_once
 			// I removed this because it tages ages to track down errors
@@ -87,7 +94,15 @@ class ilImportExportFactory
 		}
 		else
 		{							
-			$class = "il".$component."Importer";			
+			$class = "il".$component."Importer";
+
+			// page component plugin importer classes are already included
+			// the component is not registered by ilObjDefinition
+			if (class_exists($class))
+			{
+				return $class;
+			}
+
 			if(include_once "./".$a_component."/classes/class.".$class.".php")
 			{
 				return $class;


### PR DESCRIPTION
See https://www.iias.de/docu/goto_docu_wiki_wpage_4731_1357.html

Page component plugins can now maintain their own database tables or object like files etc. They may store the ids of additional data and object in the properties of their page content. To support this, they must:
- overwrite the **onClone()** and **onDelete()** methods of their base class
- set the **$supports_export= true**  in their plugin.php (like repository object plugins)
- implement an **il<plugin_name>Exporter** class as child of ilPageComponentPluginExporter
- implement an **il<plugin_name>Importer** class as child of ilPageComponentPluginImporter

A Test plugin demonstrating this can be found here:
https://github.com/fneumann/TestPageComponent