### PR TITLE
[FIX] Mantis 0020983: Fix ilUtil::moveUploadedFile() behaviour.

### DIFF
--- a/Services/Utilities/classes/class.ilUtil.php
+++ b/Services/Utilities/classes/class.ilUtil.php
@@ -4132,6 +4132,7 @@ class ilUtil
 	public static function moveUploadedFile($a_file, $a_name, $a_target, $a_raise_errors = true, $a_mode = "move_uploaded")
 	{
 		global $DIC;
+		$targetFilename = basename($a_target);
 
 		// Make sure the target is in a valid subfolder. (e.g. no uploads to ilias/setup/....)
 		list($targetFilesystem, $targetDir) = self::sanitateTargetPath($a_target);
@@ -4165,7 +4166,7 @@ class ilUtil
 			return false;
 		}
 
-		$upload->moveOneFileTo($UploadResult, $targetDir, $targetFilesystem, $a_name);
+		$upload->moveOneFileTo($UploadResult, $targetDir, $targetFilesystem, $targetFilename);
 
 		return true;
 	}


### PR DESCRIPTION
Restored the old behaviour of the move uploaded file method.