### PR TITLE
Fixed control flow serialization

### DIFF
--- a/Services/UICore/classes/class.ilCachedCtrl.php
+++ b/Services/UICore/classes/class.ilCachedCtrl.php
@@ -269,6 +269,34 @@ class ilCachedCtrl {
 	public function getCtrlClassfileParent() {
 		return $this->ctrl_classfile_parent;
 	}
+
+
+	/**
+	 * Declares all fields which should be serialized by php.
+	 * This has to be done, because the PDO objects are not serializable.
+	 *
+	 * @return string[]
+	 */
+	public function __sleep() {
+		return [
+			'changed',
+			'loaded',
+			'module_classes',
+			'service_classes',
+			'ctrl_calls',
+			'ctrl_classfile',
+			'ctrl_classfile_parent'
+		];
+	}
+
+
+	/**
+	 * Restore database connection.
+	 */
+	public function __wakeup() {
+		global $DIC;
+
+		$this->db = $DIC->database();
+	}
 }
 
-?>


### PR DESCRIPTION
This PR fixes the crash which occurs all the time if the control flow cache is enabled.
The bug has been reported with ticket: 0021048

**Problem:**
The ilCachedCtrl class stores a PDO object in a class wide scope and could therefore no longer be serialized.

**Solution:**
Introduced custom sleep and wakeup methods. The sleep method excludes the db variable which enables php to serialize the class again. After the deserialization the db connection is restored by the custom wakeup call.