### PR TITLE
UI: use more entropy in signal generator.

### DIFF
--- a/src/UI/Implementation/Component/SignalGenerator.php
+++ b/src/UI/Implementation/Component/SignalGenerator.php
@@ -24,6 +24,6 @@ class SignalGenerator implements SignalGeneratorInterface {
 	 * @return string
 	 */
 	protected function createId() {
-		return str_replace(".", "_", uniqid(self::PREFIX));
+		return str_replace(".", "_", uniqid(self::PREFIX, true));
 	}
 }


### PR DESCRIPTION
[As PHP-docu states](http://php.net/manual/de/function.uniqid.php) `uniqid` can use more entropy. This will prevent hard to analyse bugs in the future, so lets use it. 