### PR TITLE
Multible files are no longer reporcessed if ilObjFile is used

### DIFF
--- a/Modules/File/classes/class.ilObjFile.php
+++ b/Modules/File/classes/class.ilObjFile.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+use ILIAS\Filesystem\Util\LegacyPathHelper;
 use ILIAS\FileUpload\Location;
 
 require_once("Services/Object/classes/class.ilObject2.php");
@@ -271,25 +272,27 @@ class ilObjFile extends ilObject2 {
 
 		$this->setVersion($this->getVersion() + 1);
 
-		if (@!is_dir($this->getDirectory($this->getVersion()))) {
+		if (!is_dir($this->getDirectory($this->getVersion()))) {
 			ilUtil::makeDirParents($this->getDirectory($this->getVersion()));
 		}
 
 //		$file = $this->getDirectory($this->getVersion()) . "/" . $a_filename;
 		$target_directory = $this->getDirectory($this->getVersion()) . "/";
-		$relative_path_to_file = \ILIAS\Filesystem\Util\LegacyPathHelper::createRelativePath($target_directory);
+		$relative_path_to_file = LegacyPathHelper::createRelativePath($target_directory);
 
-		if (PATH_TO_GHOSTSCRIPT != "") {
-			$upload->register(new ilCountPDFPagesPreProcessors());
-		}
+	if ($upload->hasUploads()) {
+			if($upload->hasBeenProcessed() !== true) {
+				if (PATH_TO_GHOSTSCRIPT !== "") {
+					$upload->register(new ilCountPDFPagesPreProcessors());
+				}
+				$upload->process();
+			}
 
-		if ($upload->hasUploads()) {
-			$upload->process();
 			$result = $upload->getResults()[$a_upload_file];
 
-			$md = $result->getMetaData()->toArray();
-			if ($md[ilCountPDFPagesPreProcessors::PAGE_COUNT]) {
-				$this->setPageCount($md[ilCountPDFPagesPreProcessors::PAGE_COUNT]);
+			$metadata = $result->getMetaData();
+			if ($metadata->has(ilCountPDFPagesPreProcessors::PAGE_COUNT)) {
+				$this->setPageCount($metadata->get(ilCountPDFPagesPreProcessors::PAGE_COUNT));
 				$this->doUpdate();
 			}
 

--- a/Modules/File/classes/class.ilObjFile.php
+++ b/Modules/File/classes/class.ilObjFile.php
@@ -276,12 +276,11 @@ class ilObjFile extends ilObject2 {
 			ilUtil::makeDirParents($this->getDirectory($this->getVersion()));
 		}
 
-//		$file = $this->getDirectory($this->getVersion()) . "/" . $a_filename;
 		$target_directory = $this->getDirectory($this->getVersion()) . "/";
 		$relative_path_to_file = LegacyPathHelper::createRelativePath($target_directory);
 
-	if ($upload->hasUploads()) {
-			if($upload->hasBeenProcessed() !== true) {
+		if ($upload->hasUploads()) {
+			if ($upload->hasBeenProcessed() !== true) {
 				if (PATH_TO_GHOSTSCRIPT !== "") {
 					$upload->register(new ilCountPDFPagesPreProcessors());
 				}


### PR DESCRIPTION
This PR provides a fix for the bug 0021106.

**Problem:**
The ilObjFile class processed the whole upload each time a file was moved. However the file upload service doesn't permit that.

**Solution:**
An additional check was introduced to process the files only once.
