### PR TITLE
Improve documentation of installation dependencies

### DIFF
--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -380,6 +380,15 @@ On RHEL/CentOS execute:
 ```
 yum install zip unzip php-gd libxslt ImageMagick java-1.7.0-openjdk phantomjs
 ```
+
+Depending on your use case, you MAY want to install further dependencies (exact package names vary by distribution):
+* php-curl
+* php-xmlrpc
+* php-soap
+* php-ldap
+* php-mbstring
+* ffmpeg
+
 <a name="installation-wizard"></a>
 ## Installation Wizard
 

--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -388,6 +388,7 @@ Depending on your use case, you MAY want to install further dependencies (exact 
 * php-ldap
 * php-mbstring
 * ffmpeg
+* mimetex
 
 <a name="installation-wizard"></a>
 ## Installation Wizard

--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -366,9 +366,14 @@ FromLineOverride=YES
 <a name="install-other-depedencies"></a>
 ## Install other Depedencies
 
-On Debian/Ubuntu execute: 
+On Debian/Ubuntu 14.04 execute:
 ```
 apt-get install zip unzip php5-gd php5-mysql php-xsl imagemagick openjdk-7-jdk phantomjs
+```
+
+On Ubuntu 16.04 execute:
+```
+apt-get install zip unzip php7.0-gd php7.0-mysql php7.0-xsl php7.0-zip imagemagick openjdk-8-jdk phantomjs
 ```
 
 On RHEL/CentOS execute: 


### PR DESCRIPTION
Ubuntu 16.04 renamed most php packages in order to reflect the switch to php7 and bumped the default java version to 8. This PR extends the installation documentation with a dedicated command for Ubuntu 16.04.

Furthermore, I added a list of optional dependencies which may be required depending on the use case. This list may not be complete yet, further additions are welcome.