### PR TITLE
[Fix] Calling end(..) on non-referenceable return-value

### DIFF
--- a/Services/ActiveRecord/Connector/Select/class.arSelectCollection.php
+++ b/Services/ActiveRecord/Connector/Select/class.arSelectCollection.php
@@ -16,11 +16,11 @@ class arSelectCollection extends arStatementCollection {
 	public function asSQLStatement() {
 		$return = 'SELECT ';
 		if ($this->hasStatements()) {
-       $activeRecord = $this->getAr();
-       $selectSQLs   = array_map(function($select) use ($activeRecord) {
-         return $select->asSQLStatement($activeRecord);
-       }, $this->getSelects());
-       $return .= join(', ', $selectSQLs);
+			$activeRecord = $this->getAr();
+			$selectSQLs   = array_map(function($select) use ($activeRecord) {
+				return $select->asSQLStatement($activeRecord);
+			}, $this->getSelects());
+       			$return      .= join(', ', $selectSQLs);
  		}
 
 //		$return .= ' FROM ' . $this->getAr()->getConnectorContainerName();

--- a/Services/ActiveRecord/Connector/Select/class.arSelectCollection.php
+++ b/Services/ActiveRecord/Connector/Select/class.arSelectCollection.php
@@ -16,13 +16,12 @@ class arSelectCollection extends arStatementCollection {
 	public function asSQLStatement() {
 		$return = 'SELECT ';
 		if ($this->hasStatements()) {
-			foreach ($this->getSelects() as $select) {
-				$return .= $select->asSQLStatement($this->getAr());
-				if ($select != end($this->getSelects())) {
-					$return .= ', ';
-				}
-			}
-		}
+       $activeRecord = $this->getAr();
+       $selectSQLs   = array_map(function($select) use ($activeRecord) {
+         return $select->asSQLStatement($activeRecord);
+       }, $this->getSelects());
+       $return .= join(', ', $selectSQLs);
+ 		}
 
 //		$return .= ' FROM ' . $this->getAr()->getConnectorContainerName();
 


### PR DESCRIPTION
Mantis: https://www.ilias.de/mantis/view.php?id=21212

The important part is that end(...) can not be called with non-referenceable values, such as temporary return values.

I also took the liberty to replace concatenation-loop with array_map(...) and join(...) to improve [code-taste](https://medium.com/@bartobri/applying-the-linus-tarvolds-good-taste-coding-requirement-99749f37684a).

Note: This is based of d63a8ffe97f9175db54d7b0b3df8e624dd2370eb and should be applicable to all following releases. :smiley: 