### PR TITLE
[Fix] Issues with MediaImageUtil

### DIFF
--- a/Services/MediaObjects/classes/class.ilMediaImageUtil.php
+++ b/Services/MediaObjects/classes/class.ilMediaImageUtil.php
@@ -40,6 +40,8 @@ class ilMediaImageUtil
 					}
 					$c->setOpt(CURLOPT_PROXY, $proxy);
 				}
+				$c->setOpt(CURLOPT_SSL_VERIFYHOST, 0);
+				$c->setOpt(CURLOPT_SSL_VERIFYPEER, 0);
 				$c->setOpt(CURLOPT_MAXREDIRS, 3);
 				$c->setOpt(CURLOPT_HEADER, 0);
 				$c->setOpt(CURLOPT_RETURNTRANSFER, 1);

--- a/Services/MediaObjects/classes/class.ilMediaImageUtil.php
+++ b/Services/MediaObjects/classes/class.ilMediaImageUtil.php
@@ -46,10 +46,15 @@ class ilMediaImageUtil
 				$c->setOpt(CURLOPT_HEADER, 0);
 				$c->setOpt(CURLOPT_RETURNTRANSFER, 1);
 				$c->setOpt(CURLOPT_FILE, $file);
-				$c->exec();
+				try {
+				  $c->exec();
+				  $size = @getimagesize($filename);
+				}
+				catch (ilCurlConnectionException $e) {
+				  $size = false;
+				}
 				$c->close();
 				fclose($file);
-				$size = @getimagesize($filename);
 				unlink($filename);
 			}
 			else


### PR DESCRIPTION
Mantis: https://www.ilias.de/mantis/view.php?id=21201

This handles two issues:
* Allow insecure SSL connections for fetching image dimension  
  This should be inline with other usages of ilCurlConnection for non-critical data
* Do not propagate exceptions thrown by curl when called by ilMediaImageUtil::getImageSize(...)  
  Fetching dimension of remote images should not grind every GUI-Element using it to a complete halt