### PR TITLE
removed only usage of ilUtil::moveUploadedFile() with a paramater $a_…

### DIFF
--- a/Modules/StudyProgramme/classes/class.ilObjStudyProgramme.php
+++ b/Modules/StudyProgramme/classes/class.ilObjStudyProgramme.php
@@ -2,6 +2,8 @@
 
 /* Copyright (c) 2015 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
 
+use ILIAS\Filesystem\Util\LegacyPathHelper;
+
 require_once("./Services/Container/classes/class.ilContainer.php");
 require_once('./Services/Container/classes/class.ilContainerSorting.php');
 require_once("./Modules/StudyProgramme/classes/model/class.ilStudyProgramme.php");
@@ -1337,16 +1339,15 @@ class ilObjStudyProgramme extends ilContainer {
 	function saveIcons($a_custom_icon)
 	{
 		global $DIC;
-		$ilDB = $DIC['ilDB'];
 
 		$this->createContainerDirectory();
 		$cont_dir = $this->getContainerDirectory();
-		$file_name = "";
+
 		if ($a_custom_icon != "")
 		{
 			$file_name = $cont_dir."/icon_custom.svg";
 
-			ilUtil::moveUploadedFile($a_custom_icon, "icon_custom.svg", $file_name, true, "copy");
+			$DIC->filesystem()->web()->copy(LegacyPathHelper::createRelativePath($a_custom_icon), LegacyPathHelper::createRelativePath($file_name));
 
 			if ($file_name != "" && is_file($file_name))
 			{
@@ -1359,5 +1360,3 @@ class ilObjStudyProgramme extends ilContainer {
 		}
 	}
 }
-
-?>

--- a/Services/Utilities/classes/class.ilUtil.php
+++ b/Services/Utilities/classes/class.ilUtil.php
@@ -4166,7 +4166,6 @@ class ilUtil
 	 * @param string $a_name
 	 * @param string $a_target
 	 * @param bool   $a_raise_errors
-	 * @param string $a_mode
 	 *
 	 * @return bool
 	 *
@@ -4174,7 +4173,7 @@ class ilUtil
 	 *
 	 * @see \ILIAS\DI\Container::upload()
 	 */
-	public static function moveUploadedFile($a_file, $a_name, $a_target, $a_raise_errors = true, $a_mode = "move_uploaded")
+	public static function moveUploadedFile($a_file, $a_name, $a_target, $a_raise_errors = true)
 	{
 		global $DIC;
 		$targetFilename = basename($a_target);


### PR DESCRIPTION
…mode and removed the parameter

*** 
The deprecated method ilUtil::moveUploadedFile() has a parameter mode which could be used to just copy or rename a file. Grepping just found one usage of this so I removed it and changed the consumer code in StudyProgramme