### PR TITLE
UI Deck: Slight change of interface

### DIFF
--- a/Services/Link/classes/class.ilInternalLinkGUI.php
+++ b/Services/Link/classes/class.ilInternalLinkGUI.php
@@ -1246,7 +1246,7 @@ class ilInternalLinkGUI
 			$cards[] = $f->card($name, $f->image()->responsive(ilObjUser::_getPersonalPicturePath($user, "small") , $name))
 				->withSections(array($b));
 		}
-		$deck = $f->deck($cards)->withCardsSize(ILIAS\UI\Component\Deck\Deck::SIZE_L);
+		$deck = $f->deck($cards)->withLargeCards();
 
 		return $r->renderAsync($deck);
 	}

--- a/Services/Link/classes/class.ilInternalLinkGUI.php
+++ b/Services/Link/classes/class.ilInternalLinkGUI.php
@@ -1246,7 +1246,7 @@ class ilInternalLinkGUI
 			$cards[] = $f->card($name, $f->image()->responsive(ilObjUser::_getPersonalPicturePath($user, "small") , $name))
 				->withSections(array($b));
 		}
-		$deck = $f->deck($cards)->withLargeCards();
+		$deck = $f->deck($cards)->withLargeCardsSize();
 
 		return $r->renderAsync($deck);
 	}

--- a/src/UI/Component/Deck/Deck.php
+++ b/src/UI/Component/Deck/Deck.php
@@ -37,7 +37,7 @@ interface Deck extends \ILIAS\UI\Component\Component {
 	 * @param int Size of the card
 	 * @return Deck
 	 */
-	public function withExtraSmallCards();
+	public function withExtraSmallCardsSize();
 
 	/**
 	 * Set the cards size to small:
@@ -48,7 +48,7 @@ interface Deck extends \ILIAS\UI\Component\Component {
 	 * @param int Size of the card
 	 * @return Deck
 	 */
-	public function withSmallCards();
+	public function withSmallCardsSize();
 
 	/**
 	 * Set the cards size to normal:
@@ -59,7 +59,7 @@ interface Deck extends \ILIAS\UI\Component\Component {
 	 * @param int Size of the card
 	 * @return Deck
 	 */
-	public function withNormalCards();
+	public function withNormalCardsSize();
 
 	/**
 	 * Set the cards size to large:
@@ -70,7 +70,7 @@ interface Deck extends \ILIAS\UI\Component\Component {
 	 * @param int Size of the card
 	 * @return Deck
 	 */
-	public function withLargeCards();
+	public function withLargeCardsSize();
 
 	/**
 	 * Set the cards size to extra large:
@@ -81,7 +81,7 @@ interface Deck extends \ILIAS\UI\Component\Component {
 	 * @param int Size of the card
 	 * @return Deck
 	 */
-	public function withExtraLargeCards();
+	public function withExtraLargeCardsSize();
 
 	/**
 	 * Set the cards size to full:
@@ -92,7 +92,7 @@ interface Deck extends \ILIAS\UI\Component\Component {
 	 * @param int Size of the card
 	 * @return Deck
 	 */
-	public function withFullSizedCards();
+	public function withFullSizedCardsSize();
 
 	/**
 	 * Get the cards size. Note that this size tells how much space the card is using.

--- a/src/UI/Component/Deck/Deck.php
+++ b/src/UI/Component/Deck/Deck.php
@@ -6,11 +6,11 @@ namespace ILIAS\UI\Component\Deck;
 
 interface Deck extends \ILIAS\UI\Component\Component {
 	/**
-	 * Different sizes of the card.
+	 * Different sizes of the card. Those values will be returned by getCardsSize.
 	 */
-	const SIZE_XS = 1; //12 Cards per row
-	const SIZE_S = 2; //6 Cards per row
-	const SIZE_M = 3; //4 Cards per row
+	const SIZE_XS = 1; //12 Cards per row on normal screen, 6 cards on small screens, 1 card on very small screens.
+	const SIZE_S = 2; //6 Cards per row, 3 cards on small screens, 1 card on very small screens
+	const SIZE_M = 3; //4 Cards per row,
 	const SIZE_L = 4; //3 Cards per row
 	const SIZE_XL = 6; //2 Cards per row
 	const SIZE_FULL = 12; //1 Card per row
@@ -29,13 +29,75 @@ interface Deck extends \ILIAS\UI\Component\Component {
 	public function getCards();
 
 	/**
-	 * Set the cards size
+	 * Set the cards size to extra small:
+	 *  - 12 Cards on normal screens
+	 *  - 6 Cards on small screens
+	 *  - 1 Card on very small screens
+	 *
+	 * @param int Size of the card
 	 * @return Deck
 	 */
-	public function withCardsSize($size);
+	public function withExtraSmallCards();
 
 	/**
-	 * Get the cards size
+	 * Set the cards size to small:
+	 *  - 6 Cards on normal screens
+	 *  - 3 Cards on small screens
+	 *  - 1 Card on very small screens
+	 *
+	 * @param int Size of the card
+	 * @return Deck
+	 */
+	public function withSmallCards();
+
+	/**
+	 * Set the cards size to normal:
+	 *  - 4 Cards on normal screens
+	 *  - 2 Cards on small screens
+	 *  - 1 Card on very small screens
+	 *
+	 * @param int Size of the card
+	 * @return Deck
+	 */
+	public function withNormalCards();
+
+	/**
+	 * Set the cards size to large:
+	 *  - 3 Cards on normal screens
+	 *  - 1 Cards on small screens
+	 *  - 1 Card on very small screens
+	 *
+	 * @param int Size of the card
+	 * @return Deck
+	 */
+	public function withLargeCards();
+
+	/**
+	 * Set the cards size to extra large:
+	 *  - 2 Cards on normal screens
+	 *  - 1 Cards on small screens
+	 *  - 1 Card on very small screens
+	 *
+	 * @param int Size of the card
+	 * @return Deck
+	 */
+	public function withExtraLargeCards();
+
+	/**
+	 * Set the cards size to full:
+	 *  - 1 Cards on normal screens
+	 *  - 1 Cards on small screens
+	 *  - 1 Card on very small screens
+	 *
+	 * @param int Size of the card
+	 * @return Deck
+	 */
+	public function withFullSizedCards();
+
+	/**
+	 * Get the cards size. Note that this size tells how much space the card is using.
+	 * The number of cards displayed by normal screen size is 12/size.
+	 *
 	 * @return int
 	 */
 	public function getCardsSize();

--- a/src/UI/Factory.php
+++ b/src/UI/Factory.php
@@ -172,6 +172,10 @@ interface Factory {
 	 *   composition: >
 	 *      Cards contain a header, which often includes an Image or Icon and a Title as well as possible actions as
 	 *      Default Buttons and 0 to n sections that may contain further textual descriptions, links and buttons.
+	 *      The size of the cards in decks may be set to extra small (12 cards per row),
+	 *      small (6 cards per row, default), medium (4 cards per row), large (3 cards per row),
+	 *      extra large (2 cards per row) and full (1 card per row). The number of cards
+	 *      per row is responsively adapted, if the size of the screen is changed.
 	 *   effect: >
 	 *      Cards may contain Interaction Triggers.
 	 *   rivals:

--- a/src/UI/Implementation/Component/Deck/Deck.php
+++ b/src/UI/Implementation/Component/Deck/Deck.php
@@ -55,41 +55,41 @@ class Deck implements D\Deck {
 	/**
 	 * @inheritdoc
 	 */
-	public function withExtraSmallCards(){
+	public function withExtraSmallCardsSize(){
 		return $this->withCardsSize(self::SIZE_XS);
 	}
 
 	/**
 	 * @inheritdoc
 	 */
-	public function withSmallCards(){
+	public function withSmallCardsSize(){
 		return $this->withCardsSize(self::SIZE_S);
 	}
 	/**
 	 * @inheritdoc
 	 */
-	public function withNormalCards(){
+	public function withNormalCardsSize(){
 		return $this->withCardsSize(self::SIZE_M);
 	}
 
 	/**
 	 * @inheritdoc
 	 */
-	public function withLargeCards(){
+	public function withLargeCardsSize(){
 		return $this->withCardsSize(self::SIZE_L);
 	}
 
 	/**
 	 * @inheritdoc
 	 */
-	public function withExtraLargeCards(){
+	public function withExtraLargeCardsSize(){
 		return $this->withCardsSize(self::SIZE_XL);
 	}
 
 	/**
 	 * @inheritdoc
 	 */
-	public function withFullSizedCards(){
+	public function withFullSizedCardsSize(){
 		return $this->withCardsSize(self::SIZE_FULL);
 	}
 
@@ -113,7 +113,7 @@ class Deck implements D\Deck {
 	}
 
 	/**
-	 * This function is only internal and returns the size of the cards for small displays.
+	 * @internal This function is only internal and returns the size of the cards for small displays.
 	 * Note that this size tells how much space the card is using. The number of cards displayed by normal screen size is 12/size.
 	 *
 	 * @return int
@@ -127,7 +127,9 @@ class Deck implements D\Deck {
 			case self::SIZE_M:
 				return 6;
 			case self::SIZE_L:
+				// no-break
 			case self::SIZE_XL:
+				// no-break
 			case self::SIZE_FULL:
 				return 12;
 		}

--- a/src/UI/Implementation/Component/Deck/Deck.php
+++ b/src/UI/Implementation/Component/Deck/Deck.php
@@ -55,7 +55,49 @@ class Deck implements D\Deck {
 	/**
 	 * @inheritdoc
 	 */
-	public function withCardsSize($size){
+	public function withExtraSmallCards(){
+		return $this->withCardsSize(self::SIZE_XS);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function withSmallCards(){
+		return $this->withCardsSize(self::SIZE_S);
+	}
+	/**
+	 * @inheritdoc
+	 */
+	public function withNormalCards(){
+		return $this->withCardsSize(self::SIZE_M);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function withLargeCards(){
+		return $this->withCardsSize(self::SIZE_L);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function withExtraLargeCards(){
+		return $this->withCardsSize(self::SIZE_XL);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function withFullSizedCards(){
+		return $this->withCardsSize(self::SIZE_FULL);
+	}
+
+	/***
+	 * @param $size
+	 * @return Deck
+	 */
+	protected function withCardsSize($size){
 		$this->checkArgIsElement("size", $size, self::$sizes, "size type");
 
 		$clone = clone $this;
@@ -68,6 +110,27 @@ class Deck implements D\Deck {
 	 */
 	public function getCardsSize(){
 		return $this->size;
+	}
+
+	/**
+	 * This function is only internal and returns the size of the cards for small displays.
+	 * Note that this size tells how much space the card is using. The number of cards displayed by normal screen size is 12/size.
+	 *
+	 * @return int
+	 */
+	public function getCardsSizeSmallDisplays(){
+		switch($this->getCardsSize()){
+			case self::SIZE_XS:
+				return 2;
+			case self::SIZE_S:
+				return 4;
+			case self::SIZE_M:
+				return 6;
+			case self::SIZE_L:
+			case self::SIZE_XL:
+			case self::SIZE_FULL:
+				return 12;
+		}
 	}
 
 	private static $sizes = array

--- a/src/UI/Implementation/Component/Deck/Renderer.php
+++ b/src/UI/Implementation/Component/Deck/Renderer.php
@@ -18,7 +18,8 @@ class Renderer extends AbstractComponentRenderer {
 		$tpl_row = $this->getTemplate("tpl.deck_row.html", true, true);
 
 		$size = $component->getCardsSize();
-		$icons_per_row = 12/$size;
+		$small_size = $component->getCardsSizeSmallDisplays();
+		$cards_per_row = 12/$size;
 
 		$i=1;
 
@@ -26,9 +27,10 @@ class Renderer extends AbstractComponentRenderer {
 			$tpl_card->setCurrentBlock("card");
 			$tpl_card->setVariable("CARD",$default_renderer->render($card,$default_renderer));
 			$tpl_card->setVariable("SIZE",$size);
+			$tpl_card->setVariable("SMALL_SIZE",$small_size);
 			$tpl_card->parseCurrentBlock();
 
-			if(($i % $icons_per_row ) == 0){
+			if(($i % $cards_per_row ) == 0){
 				$this->parseRow($tpl_row,$tpl_card->get());
 				$tpl_card = $this->getTemplate("tpl.deck_card.html", true, true);
 				$i=0;

--- a/src/UI/examples/Deck/base.php
+++ b/src/UI/examples/Deck/base.php
@@ -8,6 +8,7 @@ function base() {
 	$f = $DIC->ui()->factory();
 	$renderer = $DIC->ui()->renderer();
 
+	//Generate some content
 	$content = $f->listing()->descriptive(
 		array(
 			"Entry 1" => "Some text",
@@ -15,9 +16,11 @@ function base() {
 		)
 	);
 
+	//Define the some responsive image
 	$image = $f->image()->responsive(
 		"./templates/default/images/HeaderIcon.svg", "Thumbnail Example");
 
+	//Define the card by using the content and the image
 	$card = $f->card(
 		"Title",
 		$image
@@ -25,6 +28,7 @@ function base() {
 		$content,
 	));
 
+	//Define the deck
 	$deck = $f->deck(array($card,$card,$card,$card,$card,
 		$card,$card,$card,$card));
 

--- a/src/UI/examples/Deck/user.php
+++ b/src/UI/examples/Deck/user.php
@@ -15,16 +15,18 @@ function user() {
 		)
 	);
 
+	//Define the some responsive image
 	$image = $f->image()->responsive(
 		"./templates/default/images/HeaderIcon.svg", "Thumbnail Example");
 
+	//Define the card by using the image and add a new section with a button
 	$card = $f->card(
 		"Timon Amstutz",
 		$image
 	)->withSections(array($address,$f->button()->standard("Request Contact","")));
 
-	$deck = $f->deck(array($card,$card,$card,$card,$card,$card,$card))
-		->withCardsSize(ILIAS\UI\Component\Deck\Deck::SIZE_L);
+	//Create a deck with large cards
+	$deck = $f->deck(array($card,$card,$card,$card,$card,$card,$card))->withLargeCards();
 
 	//Render
 	return $renderer->render($deck);

--- a/src/UI/examples/Deck/user.php
+++ b/src/UI/examples/Deck/user.php
@@ -26,7 +26,7 @@ function user() {
 	)->withSections(array($address,$f->button()->standard("Request Contact","")));
 
 	//Create a deck with large cards
-	$deck = $f->deck(array($card,$card,$card,$card,$card,$card,$card))->withLargeCards();
+	$deck = $f->deck(array($card,$card,$card,$card,$card,$card,$card))->withLargeCardsSize();
 
 	//Render
 	return $renderer->render($deck);

--- a/src/UI/examples/Deck/xl_card.php
+++ b/src/UI/examples/Deck/xl_card.php
@@ -29,7 +29,7 @@ function xl_card() {
 	));
 
 	//Define the extra large deck
-	$deck = $f->deck(array($card,$card,$card))->withExtraLargeCards();
+	$deck = $f->deck(array($card,$card,$card))->withExtraLargeCardsSize();
 
 	//Render
 	return $renderer->render($deck);

--- a/src/UI/examples/Deck/xl_card.php
+++ b/src/UI/examples/Deck/xl_card.php
@@ -8,6 +8,7 @@ function xl_card() {
 	$f = $DIC->ui()->factory();
 	$renderer = $DIC->ui()->renderer();
 
+	//Generate some content
 	$content = $f->listing()->descriptive(
 		array(
 			"Entry 1" => "Some text",
@@ -15,9 +16,11 @@ function xl_card() {
 		)
 	);
 
+	//Define the some responsive image
 	$image = $f->image()->responsive(
 		"./templates/default/images/HeaderIcon.svg", "Thumbnail Example");
 
+	//Define the card by using the content and the image
 	$card = $f->card(
 		"Title",
 		$image
@@ -25,8 +28,8 @@ function xl_card() {
 		$content
 	));
 
-	$deck = $f->deck(array($card,$card,$card))
-		->withCardsSize(ILIAS\UI\Component\Deck\Deck::SIZE_XL);
+	//Define the extra large deck
+	$deck = $f->deck(array($card,$card,$card))->withExtraLargeCards();
 
 	//Render
 	return $renderer->render($deck);

--- a/src/UI/templates/default/Deck/tpl.deck_card.html
+++ b/src/UI/templates/default/Deck/tpl.deck_card.html
@@ -1,3 +1,3 @@
 <!-- BEGIN card -->
-<div class="col-md-{SIZE}">{CARD}</div>
+<div class="col-sm-{SMALL_SIZE} col-md-{SIZE}">{CARD}</div>
 <!-- END card -->

--- a/tests/UI/Component/Deck/DeckTest.php
+++ b/tests/UI/Component/Deck/DeckTest.php
@@ -59,9 +59,24 @@ class DeckTest extends ILIAS_UI_TestBase {
 
 		$c = $f->card("Card Title");
 		$d = $f->deck(array($c));
-		$d = $d->withCardsSize(C\Deck\Deck::SIZE_L);
 
+		$d = $d->withExtraSmallCards();
+		$this->assertEquals($d->getCardsSize(), C\Deck\Deck::SIZE_XS);
+
+		$d = $d->withSmallCards();
+		$this->assertEquals($d->getCardsSize(), C\Deck\Deck::SIZE_S);
+
+		$d = $d->withNormalCards();
+		$this->assertEquals($d->getCardsSize(), C\Deck\Deck::SIZE_M);
+
+		$d = $d->withLargeCards();
 		$this->assertEquals($d->getCardsSize(), C\Deck\Deck::SIZE_L);
+
+		$d = $d->withExtraLargeCards();
+		$this->assertEquals($d->getCardsSize(), C\Deck\Deck::SIZE_XL);
+
+		$d = $d->withFullSizedCards();
+		$this->assertEquals($d->getCardsSize(), C\Deck\Deck::SIZE_FULL);
 	}
 
 	public function test_render_content() {
@@ -70,8 +85,7 @@ class DeckTest extends ILIAS_UI_TestBase {
 		$c = $f->card("Card Title");
 		$d = $f->deck(array($c));
 
-		$d = $d->withCards(array($c,$c,$c,$c,$c,$c,$c));
-		$d = $d->withCardsSize(C\Deck\Deck::SIZE_L);
+		$d = $d->withCards(array($c,$c,$c,$c,$c,$c,$c))->withLargeCards();
 
 		$html = $r->render($d);
 

--- a/tests/UI/Component/Deck/DeckTest.php
+++ b/tests/UI/Component/Deck/DeckTest.php
@@ -60,22 +60,22 @@ class DeckTest extends ILIAS_UI_TestBase {
 		$c = $f->card("Card Title");
 		$d = $f->deck(array($c));
 
-		$d = $d->withExtraSmallCards();
+		$d = $d->withExtraSmallCardsSize();
 		$this->assertEquals($d->getCardsSize(), C\Deck\Deck::SIZE_XS);
 
-		$d = $d->withSmallCards();
+		$d = $d->withSmallCardsSize();
 		$this->assertEquals($d->getCardsSize(), C\Deck\Deck::SIZE_S);
 
-		$d = $d->withNormalCards();
+		$d = $d->withNormalCardsSize();
 		$this->assertEquals($d->getCardsSize(), C\Deck\Deck::SIZE_M);
 
-		$d = $d->withLargeCards();
+		$d = $d->withLargeCardsSize();
 		$this->assertEquals($d->getCardsSize(), C\Deck\Deck::SIZE_L);
 
-		$d = $d->withExtraLargeCards();
+		$d = $d->withExtraLargeCardsSize();
 		$this->assertEquals($d->getCardsSize(), C\Deck\Deck::SIZE_XL);
 
-		$d = $d->withFullSizedCards();
+		$d = $d->withFullSizedCardsSize();
 		$this->assertEquals($d->getCardsSize(), C\Deck\Deck::SIZE_FULL);
 	}
 
@@ -85,7 +85,7 @@ class DeckTest extends ILIAS_UI_TestBase {
 		$c = $f->card("Card Title");
 		$d = $f->deck(array($c));
 
-		$d = $d->withCards(array($c,$c,$c,$c,$c,$c,$c))->withLargeCards();
+		$d = $d->withCards(array($c,$c,$c,$c,$c,$c,$c))->withLargeCardsSize();
 
 		$html = $r->render($d);
 

--- a/tests/UI/Component/Deck/DeckTest.php
+++ b/tests/UI/Component/Deck/DeckTest.php
@@ -92,17 +92,17 @@ class DeckTest extends ILIAS_UI_TestBase {
 		$expected_html =
 				'<div class="il-deck">
 					<div class="row row-eq-height">
-						<div class="col-md-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption"><h5 class="card-title">Card Title</h5></div></div></div>
-						<div class="col-md-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption"><h5 class="card-title">Card Title</h5></div></div></div>
-						<div class="col-md-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption"><h5 class="card-title">Card Title</h5></div></div></div>
+						<div class="col-sm-12 col-md-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption"><h5 class="card-title">Card Title</h5></div></div></div>
+						<div class="col-sm-12 col-md-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption"><h5 class="card-title">Card Title</h5></div></div></div>
+						<div class="col-sm-12 col-md-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption"><h5 class="card-title">Card Title</h5></div></div></div>
 					</div>
 					<div class="row row-eq-height">
-						<div class="col-md-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption"><h5 class="card-title">Card Title</h5></div></div></div>
-						<div class="col-md-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption"><h5 class="card-title">Card Title</h5></div></div></div>
-						<div class="col-md-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption"><h5 class="card-title">Card Title</h5></div></div></div>
+						<div class="col-sm-12 col-md-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption"><h5 class="card-title">Card Title</h5></div></div></div>
+						<div class="col-sm-12 col-md-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption"><h5 class="card-title">Card Title</h5></div></div></div>
+						<div class="col-sm-12 col-md-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption"><h5 class="card-title">Card Title</h5></div></div></div>
 					</div>
 					<div class="row row-eq-height">
-						<div class="col-md-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption"><h5 class="card-title">Card Title</h5></div></div></div>
+						<div class="col-sm-12 col-md-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption"><h5 class="card-title">Card Title</h5></div></div></div>
 					</div>
 				</div>';
 


### PR DESCRIPTION
This is primarily the fix of the bug we discussed in the last JF: https://www.ilias.de/mantis/view.php?id=21422

The proposed solution is to make some finer differentiation of various screen sizes since this seems necessary for decks. The other solution, shifting the breakpoint would have bad issues for various other card context, since the cards would be very small but not xtra and small screen sizes or very large on regular screens (depending on the setting).

The change in the interface would not have been necessary. However while working on this I observed that the former implementation was rather awkward by passing some constant to a function named withCardSize, rather than just offering and naming the different options for card sizes by offering specific functions. Further I extended the documentation a bit, to make the responsiveness of the cards a little easier to grasp.

This PR includes fixes for existing implementations, examples and tests. Additionally no further changes are needed to fix #21422. 