### PR TITLE
Fixed #21627 / \ilSoapLearningProgressAdministration::deleteProgress:…

### DIFF
--- a/webservice/soap/classes/class.ilSoapLearningProgressAdministration.php
+++ b/webservice/soap/classes/class.ilSoapLearningProgressAdministration.php
@@ -154,10 +154,8 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
 					break;
 					
 				case 'tst':
-					foreach((array) $valid_users as $usr_id)
-					{
-						$obj->removeTestResultsForUser($usr_id);
-					}
+					/** @var $obj ilObjTest */
+					$obj->removeTestResultsByUserIds(array_values((array)$valid_users));
 					break;
 			}
 			


### PR DESCRIPTION
… Call to an undefined method ilObjTest::removeTestResultsForUser