### PR TITLE
ilPlugin: the method 'needsUpdate' now checks for a needed update ins…

### DIFF
--- a/Services/Component/classes/class.ilPlugin.php
+++ b/Services/Component/classes/class.ilPlugin.php
@@ -737,7 +737,7 @@ abstract class ilPlugin
 	{
 		global $ilPluginAdmin;
 
-		return $ilPluginAdmin->isActive($this->getComponentType(),
+		return $ilPluginAdmin->needsUpdate($this->getComponentType(),
 			$this->getComponentName(), $this->getSlotId(), $this->getPluginName());
 	}
 


### PR DESCRIPTION
ilPlugin: the method 'needsUpdate' now checks for a needed update instead of checking for 'isActive'.

While working on ilse in my company i discovered that the method 'needsUpdate' in 'ilPlugin' only returns true if a plugin isActive. This method should return true if a plugin needs an update. So i change this.