### PR TITLE
Primary mail and secondary mail can lead to faulty behavior

### DIFF
--- a/Services/Mail/classes/Options/class.ilMailTransportSettings.php
+++ b/Services/Mail/classes/Options/class.ilMailTransportSettings.php
@@ -1,7 +1,10 @@
 <?php
+/* Copyright (c) 1998-2017 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/Mail/classes/class.ilMailOptions.php';
-
+ /**
+ * @author Niels Theen <ntheen@databay.de>
+ * @version $Id$
+ */
 class ilMailTransportSettings
 {
 	private $mailOptions;

--- a/Services/Mail/classes/Options/class.ilMailTransportSettings.php
+++ b/Services/Mail/classes/Options/class.ilMailTransportSettings.php
@@ -1,0 +1,44 @@
+<?php
+
+require_once 'Services/Mail/classes/class.ilMailOptions.php';
+
+class ilMailTransportSettings
+{
+	private $mailOptions;
+
+	public function __construct(ilMailOptions $mailOptions)
+	{
+		$this->mailOptions = $mailOptions;
+	}
+
+	/**
+	 * Validates the current instance settings and eventually adjusts these
+	 * @param string $firstMail
+	 * @param string $secondMail
+	 * @return int|string|void
+	 */
+	public function adjust($firstMail, $secondMail)
+	{
+		if ($this->mailOptions->getIncomingType() === ilMailOptions::INCOMING_LOCAL) {
+			return;
+		}
+
+		$hasFirstEmail  = strlen($firstMail);
+		$hasSecondEmail = strlen($secondMail);
+
+		if (!$hasFirstEmail && !$hasSecondEmail) {
+			$this->mailOptions->setIncomingType(ilMailOptions::INCOMING_LOCAL);
+			return $this->mailOptions->updateOptions();
+		}
+
+		if (!$hasFirstEmail && $this->mailOptions->getMailAddressOption() !== ilMailOptions::SECOND_EMAIL) {
+			$this->mailOptions->setMailAddressOption(ilMailOptions::SECOND_EMAIL);
+			return $this->mailOptions->updateOptions();
+		}
+
+		if (!$hasSecondEmail && $this->mailOptions->getMailAddressOption() !== ilMailOptions::FIRST_EMAIL) {
+			$this->mailOptions->setMailAddressOption(ilMailOptions::FIRST_EMAIL);
+			return $this->mailOptions->updateOptions();
+		}
+	}
+}

--- a/Services/Mail/classes/class.ilMailOptions.php
+++ b/Services/Mail/classes/class.ilMailOptions.php
@@ -120,14 +120,12 @@ class ilMailOptions
 		);
 	}
 
-	/**
-	 * @param string $firstMailAddress
-	 * @param string $secondMailAddress
-	 */
-	protected function read($firstMailAddress = '', $secondMailAddress = '')
+	protected function read()
 	{
 		$res = $this->db->queryF(
-			'SELECT * FROM ' . $this->table_mail_options . ' WHERE user_id = %s',
+			'SELECT * FROM mail_options 
+			 LEFT JOIN usr_data ON mail_options.user_id = usr_data.usr_id
+			 WHERE mail_options.user_id = %s',
 			array('integer'),
 			array($this->user_id)
 		);
@@ -139,13 +137,9 @@ class ilMailOptions
 		$this->incoming_type        = $row->incoming_type;
 		$this->mail_address_option  = (int)$row->mail_address_option >= 3 ? $row->mail_address_option : self::FIRST_EMAIL;
 
-		if ($firstMailAddress === '') {
-			$firstMailAddress  = ilObjUser::_lookupEmail($this->user_id);
-		}
+		$firstMailAddress  = $row->email;
 
-		if ($secondMailAddress === '') {
-			$secondMailAddress = ilObjUser::_lookupSecondEmail($this->user_id);
-		}
+		$secondMailAddress = $row->second_email;
 
 		$this->mailTransportSettings->adjust($firstMailAddress, $secondMailAddress);
 	}

--- a/Services/Mail/classes/class.ilMailOptions.php
+++ b/Services/Mail/classes/class.ilMailOptions.php
@@ -123,7 +123,14 @@ class ilMailOptions
 	protected function read()
 	{
 		$res = $this->db->queryF(
-			'SELECT * FROM mail_options 
+			'SELECT mail_options.cronjob_notification,
+					mail_options.signature,
+					mail_options.linebreak,
+					mail_options.incoming_type,
+					mail_options.mail_address_option,
+					usr_data.email,
+					usr_data.second_email
+			 FROM mail_options 
 			 LEFT JOIN usr_data ON mail_options.user_id = usr_data.usr_id
 			 WHERE mail_options.user_id = %s',
 			array('integer'),

--- a/Services/Mail/classes/class.ilMailOptions.php
+++ b/Services/Mail/classes/class.ilMailOptions.php
@@ -1,7 +1,6 @@
 <?php
 /* Copyright (c) 1998-2012 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/Mail/classes/Options/class.ilMailTransportSettings.php';
 /**
 * Class ilMailOptions
 * this class handles user mails 
@@ -71,9 +70,14 @@ class ilMailOptions
 	protected $mail_address_option = self::FIRST_EMAIL;
 
 
+	/**
+	 * @var ilMailTransportSettings
+	 */
 	private $mailTransportSettings;
+
 	/**
 	 * @param int $a_user_id
+	 * @param ilMailTransportSettings|null $mailTransportSettings
 	 */
 	public function __construct($a_user_id, ilMailTransportSettings $mailTransportSettings = null)
 	{
@@ -117,9 +121,10 @@ class ilMailOptions
 	}
 
 	/**
-	 * 
+	 * @param string $firstMailAddress
+	 * @param string $secondMailAddress
 	 */
-	protected function read($firstMail = '', $secondMail = '')
+	protected function read($firstMailAddress = '', $secondMailAddress = '')
 	{
 		$res = $this->db->queryF(
 			'SELECT * FROM ' . $this->table_mail_options . ' WHERE user_id = %s',
@@ -134,15 +139,15 @@ class ilMailOptions
 		$this->incoming_type        = $row->incoming_type;
 		$this->mail_address_option  = (int)$row->mail_address_option >= 3 ? $row->mail_address_option : self::FIRST_EMAIL;
 
-		if ($firstMail === '') {
-			$firstMail  = ilObjUser::_lookupEmail($this->user_id);
+		if ($firstMailAddress === '') {
+			$firstMailAddress  = ilObjUser::_lookupEmail($this->user_id);
 		}
 
-		if ($secondMail === '') {
-			$secondMail = ilObjUser::_lookupSecondEmail($this->user_id);
+		if ($secondMailAddress === '') {
+			$secondMailAddress = ilObjUser::_lookupSecondEmail($this->user_id);
 		}
 
-		$this->mailTransportSettings->adjust($firstMail, $secondMail);
+		$this->mailTransportSettings->adjust($firstMailAddress, $secondMailAddress);
 	}
 
 	/**

--- a/Services/Mail/test/ilMailOptionsTest.php
+++ b/Services/Mail/test/ilMailOptionsTest.php
@@ -22,6 +22,9 @@ class ilMailOptionsTest extends \ilMailBaseTest
 		$object->linebreak = false;
 		$object->incoming_type = 'MY';
 		$object->mail_address_option = 0;
+		$object->email = 'test@test.com';
+		$object->second_email = 'ilias@ilias.com';
+
 
 		$queryMock->method('fetchRow')->willReturn($object);
 		$database->expects($this->atLeastOnce())->method('queryF')->willReturn($queryMock);

--- a/Services/Mail/test/ilMailOptionsTest.php
+++ b/Services/Mail/test/ilMailOptionsTest.php
@@ -1,0 +1,38 @@
+<?php
+
+require_once 'Services/Mail/test/ilMailBaseTest.php';
+
+class ilMailOptionsTest extends \ilMailBaseTest
+{
+	public function testConstructor()
+	{
+		$userId = 1;
+
+		$database = $this->getMockBuilder('ilDBInterface')
+			->disableOriginalConstructor()
+			->getMock();
+		$queryMock = $this->getMockBuilder('ilPDOStatement')
+			->disableOriginalConstructor()
+			->setMethods(array('fetchRow'))
+			->getMock();
+
+		$object = $this->getMockBuilder(stdClass::class)->getMock();
+		$object->cronjob_notification = false;
+		$object->signature = 'smth';
+		$object->linebreak = false;
+		$object->incoming_type = 'MY';
+		$object->mail_address_option = 0;
+
+		$queryMock->method('fetchRow')->willReturn($object);
+		$database->expects($this->atLeastOnce())->method('queryF')->willReturn($queryMock);
+		$database->method('replace')->willReturn(0);
+
+		$this->setGlobalVariable('ilDB', $database);
+
+		$settings = $this->getMockBuilder('\ilSetting')->disableOriginalConstructor()->setMethods(array('set', 'get'))->getMock();
+		$this->setGlobalVariable('ilSetting', $settings);
+
+		$mailOptions = new ilMailOptions($userId);
+	}
+}
+

--- a/Services/Mail/test/ilMailTransportSettingsTest.php
+++ b/Services/Mail/test/ilMailTransportSettingsTest.php
@@ -1,0 +1,96 @@
+<?php
+
+require_once 'Services/Mail/test/ilMailBaseTest.php';
+require_once 'Services/Mail/classes/class.ilMailOptions.php';
+
+class ilMailTransportSettingsTest extends ilMailBaseTest
+{
+	public function testSystemAsIncomingTypeWontUpdate()
+	{
+		$mailOptions = $this->getMockBuilder('ilMailOptions')
+			->disableOriginalConstructor()
+			->setMethods(array('updateOptions'))
+			->getMock();
+
+		$mailOptions->setIncomingType(0);
+		$mailOptions->setMailAddressOption(3);
+
+		$setting = new ilMailTransportSettings($mailOptions);
+		$setting->adjust('test@ilias-test.de', 'someone@php-test.net');
+
+
+		$this->assertEquals(0, $mailOptions->getIncomingType());
+		$this->assertEquals(3, $mailOptions->getMailAddressOption());
+	}
+
+	public function testOnlyFirstMailWillResultInUpdateProcess()
+	{
+		$mailOptions = $this->getMockBuilder('ilMailOptions')
+			->disableOriginalConstructor()
+			->setMethods(array('updateOptions'))
+			->getMock();
+
+		$mailOptions->expects($this->once())->method('updateOptions');
+		$mailOptions->setIncomingType(2);
+		$mailOptions->setMailAddressOption(4);
+
+		$setting = new ilMailTransportSettings($mailOptions);
+		$setting->adjust('test@ilias-test.de', '');
+
+
+		$this->assertEquals(3, $mailOptions->getMailAddressOption());
+	}
+
+	public function testOnlySecondMailWillResultInUpdateProcess()
+	{
+		$mailOptions = $this->getMockBuilder('ilMailOptions')
+			->disableOriginalConstructor()
+			->setMethods(array('updateOptions'))
+			->getMock();
+
+		$mailOptions->expects($this->once())->method('updateOptions');
+		$mailOptions->setIncomingType(2);
+		$mailOptions->setMailAddressOption(3);
+
+		$setting = new ilMailTransportSettings($mailOptions);
+		$setting->adjust('', 'test@ilias-test.de');
+
+
+		$this->assertEquals(4, $mailOptions->getMailAddressOption());
+	}
+
+	public function testNoMailWillResultInUpdateProcess()
+	{
+		$mailOptions = $this->getMockBuilder('ilMailOptions')
+			->disableOriginalConstructor()
+			->setMethods(array('updateOptions'))
+			->getMock();
+
+		$mailOptions->expects($this->once())->method('updateOptions');
+		$mailOptions->setIncomingType(2);
+		$mailOptions->setMailAddressOption(3);
+
+		$setting = new ilMailTransportSettings($mailOptions);
+		$setting->adjust('', '');
+
+		$this->assertEquals(0, $mailOptions->getIncomingType());
+	}
+
+	public function testNothingWillAdjusted()
+	{
+		$mailOptions = $this->getMockBuilder('ilMailOptions')
+			->disableOriginalConstructor()
+			->setMethods(array('updateOptions'))
+			->getMock();
+
+		$mailOptions->expects($this->never())->method('updateOptions');
+		$mailOptions->setIncomingType(2);
+		$mailOptions->setMailAddressOption(5);
+
+		$setting = new ilMailTransportSettings($mailOptions);
+		$setting->adjust('test@ilias-test.de', 'someone@php-test.net');
+
+		$this->assertEquals(2, $mailOptions->getIncomingType());
+		$this->assertEquals(5, $mailOptions->getMailAddressOption());
+	}
+}

--- a/Services/Mail/test/ilMailTransportSettingsTest.php
+++ b/Services/Mail/test/ilMailTransportSettingsTest.php
@@ -76,7 +76,7 @@ class ilMailTransportSettingsTest extends ilMailBaseTest
 		$this->assertEquals(0, $mailOptions->getIncomingType());
 	}
 
-	public function testNothingWillAdjusted()
+	public function testNothingWillBeAdjusted()
 	{
 		$mailOptions = $this->getMockBuilder('ilMailOptions')
 			->disableOriginalConstructor()

--- a/Services/Mail/test/ilServicesMailSuite.php
+++ b/Services/Mail/test/ilServicesMailSuite.php
@@ -22,6 +22,12 @@ class ilServicesMailSuite extends PHPUnit_Framework_TestSuite
 		require_once 'Services/Mail/test/ilMailMimeTest.php';
 		$suite->addTestSuite('ilMailMimeTest');
 
+		require_once 'Services/Mail/test/ilMailOptionsTest.php';
+		$suite->addTestSuite('ilMailOptionsTest');
+
+		require_once 'Services/Mail/test/ilMailTransportSettingsTest.php';
+		$suite->addTestSuite('ilMailTransportSettingsTest');
+
 		return $suite;
 	}
 }

--- a/libs/composer/vendor/composer/autoload_classmap.php
+++ b/libs/composer/vendor/composer/autoload_classmap.php
@@ -4029,6 +4029,7 @@ return array(
     'ilMailTemplateSelectInputGUI' => $baseDir . '/../../Services/Mail/classes/Form/class.ilMailTemplateSelectInputGUI.php',
     'ilMailTemplateService' => $baseDir . '/../../Services/Mail/classes/class.ilMailTemplateService.php',
     'ilMailTemplateTableGUI' => $baseDir . '/../../Services/Mail/classes/class.ilMailTemplateTableGUI.php',
+    'ilMailTransportSettings' => $baseDir . '/../../Services/Mail/classes/Options/class.ilMailTransportSettings.php',
     'ilMailUserActionProvider' => $baseDir . '/../../Services/User/Actions/classes/class.ilMailUserActionProvider.php',
     'ilMailUserCache' => $baseDir . '/../../Services/Mail/classes/class.ilMailUserCache.php',
     'ilMailbox' => $baseDir . '/../../Services/Mail/classes/class.ilMailbox.php',

--- a/libs/composer/vendor/composer/autoload_static.php
+++ b/libs/composer/vendor/composer/autoload_static.php
@@ -4168,6 +4168,7 @@ class ComposerStaticInit0b7e5ccf6ad3b6544d6c5a11478f9b6b
         'ilMailTemplateSelectInputGUI' => __DIR__ . '/../..' . '/../../Services/Mail/classes/Form/class.ilMailTemplateSelectInputGUI.php',
         'ilMailTemplateService' => __DIR__ . '/../..' . '/../../Services/Mail/classes/class.ilMailTemplateService.php',
         'ilMailTemplateTableGUI' => __DIR__ . '/../..' . '/../../Services/Mail/classes/class.ilMailTemplateTableGUI.php',
+        'ilMailTransportSettings' => __DIR__ . '/../..' . '/../../Services/Mail/classes/Options/class.ilMailTransportSettings.php',
         'ilMailUserActionProvider' => __DIR__ . '/../..' . '/../../Services/User/Actions/classes/class.ilMailUserActionProvider.php',
         'ilMailUserCache' => __DIR__ . '/../..' . '/../../Services/Mail/classes/class.ilMailUserCache.php',
         'ilMailbox' => __DIR__ . '/../..' . '/../../Services/Mail/classes/class.ilMailbox.php',


### PR DESCRIPTION
This PR ensures that the option setting of the primary and secondary mail is correct. The current state can lead to a faulty behavior, if the user looses either the primary or secondary address.

This should take care that this won't happen.