### PR TITLE
Fix/0021575/5 3/imports are broken

### DIFF
--- a/Services/Utilities/classes/class.ilUtil.php
+++ b/Services/Utilities/classes/class.ilUtil.php
@@ -4475,6 +4475,9 @@ class ilUtil
 			case strpos($a_target, CLIENT_WEB_DIR) === 0:
 				$targetFilesystem = \ILIAS\FileUpload\Location::WEB;
 				break;
+			case strpos($a_target, CLIENT_DATA_DIR . "/temp") === 0:
+				$targetFilesystem = \ILIAS\FileUpload\Location::TEMPORARY;
+				break;
 			case strpos($a_target, CLIENT_DATA_DIR) === 0:
 				$targetFilesystem = \ILIAS\FileUpload\Location::STORAGE;
 				break;

--- a/Services/Utilities/classes/class.ilUtil.php
+++ b/Services/Utilities/classes/class.ilUtil.php
@@ -4170,6 +4170,8 @@ class ilUtil
 	 *
 	 * @return bool
 	 *
+	 * @throws ilException Thrown if no uploaded files are found and raise error is set to true.
+	 *
 	 * @deprecated in favour of the FileUpload service.
 	 *
 	 * @see \ILIAS\DI\Container::upload()

--- a/src/FileUpload/FileUploadImpl.php
+++ b/src/FileUpload/FileUploadImpl.php
@@ -205,6 +205,8 @@ final class FileUploadImpl implements FileUpload {
 				return $this->filesystems->storage();
 			case Location::WEB:
 				return $this->filesystems->web();
+			case Location::TEMPORARY:
+				return $this->filesystems->temp();
 			default:
 				throw new \InvalidArgumentException("No filesystem found for location code \"$location\"");
 		}

--- a/src/FileUpload/Location.php
+++ b/src/FileUpload/Location.php
@@ -30,4 +30,9 @@ interface Location {
 	 * Equal to the filesystem->customizing
 	 */
 	const CUSTOMIZING = 3;
+	/**
+	 * The ILIAS temporary directory.
+	 * Equal to the filesystem->temp
+	 */
+	const TEMPORARY = 4;
 }

--- a/src/Filesystem/Util/LegacyPathHelper.php
+++ b/src/Filesystem/Util/LegacyPathHelper.php
@@ -34,6 +34,9 @@ class LegacyPathHelper {
 	public static function deriveFilesystemFrom($absolutePath) {
 
 		switch (true) {
+			case strpos($absolutePath, CLIENT_DATA_DIR . "/temp") === 0:
+				return self::filesystems()->temp();
+
 			//ILIAS has a lot of cases were a relative web path is used eg ./data/default
 			case strpos($absolutePath, ILIAS_WEB_DIR . '/' . CLIENT_ID) === 0:
 			case strpos($absolutePath, './' . ILIAS_WEB_DIR . '/' . CLIENT_ID) === 0:
@@ -43,8 +46,6 @@ class LegacyPathHelper {
 				return self::filesystems()->storage();
 			case strpos($absolutePath, ILIAS_ABSOLUTE_PATH . '/Customizing') === 0:
 				return self::filesystems()->customizing();
-			case strpos($absolutePath, sys_get_temp_dir()) === 0:
-				return self::filesystems()->temp();
 			default:
 				throw new \InvalidArgumentException('Invalid path supplied. Path must start with the web, storage, temp or customizing storage location.');
 		}


### PR DESCRIPTION
This PR provides a solution for the broken imports reported in [0021575](https://www.ilias.de/mantis/view.php?id=21575).
The cause was the incorrect handling of the temporary filesystem.