### PR TITLE
WFLE vs. PHP 7.2: Replaced create_function (deprecated)

### DIFF
--- a/Services/WorkflowEngine/classes/nodes/class.ilCaseNode.php
+++ b/Services/WorkflowEngine/classes/nodes/class.ilCaseNode.php
@@ -151,8 +151,10 @@ class ilCaseNode extends ilBaseNode
 
 		foreach((array)$this->condition_emitter_pairs as $pair)
 		{
-			$that = $this;
-			$eval_function = create_function('$that', $pair['expression']);
+			$eval_function = function($that) use ($pair) {
+				return eval($pair['expression']);
+			};
+
 			if($eval_function($this->detectors) === true)
 			{
 				$emitter = $pair['emitter'];

--- a/Services/WorkflowEngine/classes/nodes/class.ilConditionalNode.php
+++ b/Services/WorkflowEngine/classes/nodes/class.ilConditionalNode.php
@@ -105,7 +105,9 @@ class ilConditionalNode extends ilBaseNode
 	 */
 	public function checkTransitionPreconditions()
 	{
-		$eval_function = create_function('$detectors', $this->evaluation_expression);
+		$eval_function = function($detectors) {
+			return eval($this->evaluation_expression);
+		};
 
 		if ($eval_function($this->detectors) === null)
 		{
@@ -132,7 +134,9 @@ class ilConditionalNode extends ilBaseNode
 	 */	
 	public function attemptTransition()
 	{
-		$eval_function = create_function('$detectors', $this->evaluation_expression);
+		$eval_function = function($detectors) {
+			return eval($this->evaluation_expression);
+		};
 
 		if ($eval_function($this->detectors) === null)
 		{

--- a/Services/WorkflowEngine/classes/nodes/class.ilPluginNode.php
+++ b/Services/WorkflowEngine/classes/nodes/class.ilPluginNode.php
@@ -117,7 +117,9 @@ class ilPluginNode extends ilBaseNode
 	public function checkTransitionPreconditions()
 	{
 		// TODO Call Plugin here.
-		$eval_function = create_function('$detectors', $this->evaluation_expression);
+		$eval_function = function($detectors) {
+			return eval($this->evaluation_expression);
+		};
 
 		if ($eval_function($this->detectors) === null)
 		{
@@ -145,7 +147,9 @@ class ilPluginNode extends ilBaseNode
 	public function attemptTransition()
 	{
 		// TODO Call Plugin here.
-		$eval_function = create_function('$detectors', $this->evaluation_expression);
+		$eval_function = function($detectors) {
+			return eval($this->evaluation_expression);
+		};
 
 		if ($eval_function($this->detectors) === null)
 		{

--- a/Services/WorkflowEngine/test/activities/ilScriptActivityTest.php
+++ b/Services/WorkflowEngine/test/activities/ilScriptActivityTest.php
@@ -97,8 +97,9 @@ class ilScriptActivityTest extends PHPUnit_Framework_TestCase
 		// Arrange
 		$activity = new ilScriptActivity($this->node);
 
-		$code = "return 'Hallo, Welt!';";
-		$activity->setMethod(create_function(null,$code));
+		$activity->setMethod(function($null) {
+			return 'Hallo, Welt!';
+		});
 
 		// Act
 		$response = $activity->getScript();


### PR DESCRIPTION
@mbecker-databay 

create_function() relies on 'eval' to evaluate the second function parameter $code, see: http://php.net/manual/en/function.create-function.php . So I used 'eval' after switching to the closure approach. Maybe you should think about to completely revise this 'eval' voodoo/magic in general.