### PR TITLE
PHP 7.2: Changed assert() using strings (deprecated)

### DIFF
--- a/Modules/IndividualAssessment/classes/Members/class.ilIndividualAssessmentMember.php
+++ b/Modules/IndividualAssessment/classes/Members/class.ilIndividualAssessmentMember.php
@@ -149,7 +149,7 @@ class ilIndividualAssessmentMember {
 	 * @return	ilIndividualAssessmentMember
 	 */
 	public function withRecord($record) {
-		assert('is_string($record) || $record === null');
+		assert(is_string($record) || $record === null);
 		$clone = clone $this;
 		$clone->record = $record;
 		return $clone;
@@ -162,7 +162,7 @@ class ilIndividualAssessmentMember {
 	 * @return	ilIndividualAssessmentMember
 	 */
 	public function withInternalNote($internal_note) {
-		assert('is_string($internal_note) || $internal_note === null');
+		assert(is_string($internal_note) || $internal_note === null);
 		$clone = clone $this;
 		$clone->internal_note = $internal_note;
 		return $clone;
@@ -176,7 +176,7 @@ class ilIndividualAssessmentMember {
 	 */
 	public function withPlace($place)
 	{
-		assert('is_string($place) || is_null($place)');
+		assert(is_string($place) || is_null($place));
 		$clone = clone $this;
 		$clone->place = $place;
 		return $clone;
@@ -190,7 +190,7 @@ class ilIndividualAssessmentMember {
 	 */
 	public function withEventTime($event_time)
 	{
-		assert('$event_time instanceof ilDateTime || is_null($event_time)');
+		assert($event_time instanceof ilDateTime || is_null($event_time));
 		$clone = clone $this;
 		$clone->event_time = $event_time;
 		return $clone;
@@ -203,8 +203,8 @@ class ilIndividualAssessmentMember {
 	 * @return	ilIndividualAssessmentMember
 	 */
 	public function withExaminerId($examiner_id) {
-		assert('is_numeric($examiner_id)');
-		assert('ilObjUser::_exists($examiner_id)');
+		assert(is_numeric($examiner_id));
+		assert(ilObjUser::_exists($examiner_id));
 		$clone = clone $this;
 		$clone->examiner_id = $examiner_id;
 		return $clone;
@@ -217,7 +217,7 @@ class ilIndividualAssessmentMember {
 	 * @return	ilIndividualAssessmentMember
 	 */
 	public function withNotify($notify) {
-		assert('is_bool($notify)');
+		assert(is_bool($notify));
 		$clone = clone $this;
 		$clone->notify = (bool)$notify;
 		return $clone;
@@ -351,7 +351,7 @@ class ilIndividualAssessmentMember {
 	 */
 	public function withFileName($file_name)
 	{
-		assert('is_string($file_name)');
+		assert(is_string($file_name));
 		$clone = clone $this;
 		$clone->file_name = $file_name;
 		return $clone;
@@ -376,7 +376,7 @@ class ilIndividualAssessmentMember {
 	 */
 	public function withViewFile($view_file)
 	{
-		assert('is_bool($view_file)');
+		assert(is_bool($view_file));
 		$clone = clone $this;
 		$clone->view_file = $view_file;
 		return $clone;

--- a/Modules/IndividualAssessment/classes/Settings/class.ilIndividualAssessmentInfoSettings.php
+++ b/Modules/IndividualAssessment/classes/Settings/class.ilIndividualAssessmentInfoSettings.php
@@ -53,31 +53,31 @@ class ilIndividualAssessmentInfoSettings {
 
 
 	public function setContact($contact) {
-		assert('is_string($contact) || $contact === null');
+		assert(is_string($contact) || $contact === null);
 		$this->contact = $contact;
 		return $this;
 	}
 
 	public function setResponsibility($responsibility) {
-		assert('is_string($responsibility) || $responsibility === null');
+		assert(is_string($responsibility) || $responsibility === null);
 		$this->responsibility = $responsibility;
 		return $this;
 	}
 
 	public function setPhone($phone) {
-		assert('is_string($phone) || $phone === null');
+		assert(is_string($phone) || $phone === null);
 		$this->phone = $phone;
 		return $this;
 	}
 
 	public function setMails($mails) {
-		assert('is_string($mails) || $mails === null');
+		assert(is_string($mails) || $mails === null);
 		$this->mails = $mails;
 		return $this;
 	}
 
 	public function setConsultationHours($consultation_hours) {
-		assert('is_string($consultation_hours) || $consultation_hours === null');
+		assert(is_string($consultation_hours) || $consultation_hours === null);
 		$this->consultation_hours = $consultation_hours;
 		return $this;
 	}

--- a/Modules/IndividualAssessment/classes/Settings/class.ilIndividualAssessmentSettings.php
+++ b/Modules/IndividualAssessment/classes/Settings/class.ilIndividualAssessmentSettings.php
@@ -99,7 +99,7 @@ class ilIndividualAssessmentSettings {
 	 * @return	ilIndividualAssessment	$this
 	 */
 	public function setContent($content) {
-		assert('is_string($content)');
+		assert(is_string($content));
 		$this->content = $content;
 		return $this;
 	}
@@ -112,7 +112,7 @@ class ilIndividualAssessmentSettings {
 	 * @return	ilIndividualAssessment	$this
 	 */
 	public function setRecordTemplate($record_template) {
-		assert('is_string($record_template)');
+		assert(is_string($record_template));
 		$this->record_template = $record_template;
 		return $this;
 	}
@@ -125,7 +125,7 @@ class ilIndividualAssessmentSettings {
 	 */
 	public function setEventTimePlaceRequired($event_time_place_required)
 	{
-		assert('is_bool($event_time_place_required)');
+		assert(is_bool($event_time_place_required));
 		$this->event_time_place_required = $event_time_place_required;
 		return $this;
 	}
@@ -138,7 +138,7 @@ class ilIndividualAssessmentSettings {
 	 */
 	public function setFileRequired($file_required)
 	{
-		assert('is_bool($file_required)');
+		assert(is_bool($file_required));
 		$this->file_required = $file_required;
 		return $this;
 	}

--- a/Modules/IndividualAssessment/classes/Settings/class.ilIndividualAssessmentSettingsStorageDB.php
+++ b/Modules/IndividualAssessment/classes/Settings/class.ilIndividualAssessmentSettingsStorageDB.php
@@ -43,7 +43,7 @@ class ilIndividualAssessmentSettingsStorageDB implements ilIndividualAssessmentS
 	public function loadSettings(ilObjIndividualAssessment $obj) {
 		if(ilObjIndividualAssessment::_exists($obj->getId(), false, 'iass')) {
 			$obj_id = $obj->getId();
-			assert('is_numeric($obj_id)');
+			assert(is_numeric($obj_id));
 			$sql = "SELECT content, record_template, event_time_place_required, file_required\n"
 				  ." FROM ".self::IASS_SETTINGS_TABLE."\n"
 				  ." WHERE obj_id = ".$this->db->quote($obj_id,'integer');
@@ -88,7 +88,7 @@ class ilIndividualAssessmentSettingsStorageDB implements ilIndividualAssessmentS
 	public function loadInfoSettings(ilObjIndividualAssessment $obj) {
 		if(ilObjIndividualAssessment::_exists($obj->getId(), false, 'iass')) {
 			$obj_id = $obj->getId();
-			assert('is_numeric($obj_id)');
+			assert(is_numeric($obj_id));
 			$sql = "SELECT contact, responsibility, phone, mails, consultation_hours"
 					." FROM ".self::IASS_SETTINGS_INFO_TABLE." WHERE obj_id = ".$this->db->quote($obj_id,'integer');
 

--- a/Modules/IndividualAssessment/classes/class.ilIndividualAssessmentDataSet.php
+++ b/Modules/IndividualAssessment/classes/class.ilIndividualAssessmentDataSet.php
@@ -134,9 +134,9 @@ class ilIndividualAssessmentDataSet extends ilDataSet {
 	 */
 	public function importRecord($entity, $types, array $rec, ilImportMapping $mapping, $schema_version)
 	{
-		assert('is_string($entity)');
-		assert('is_object($types) || is_null($types)');
-		assert('is_string($schema_version)');
+		assert(is_string($entity));
+		assert(is_object($types) || is_null($types));
+		assert(is_string($schema_version));
 
 		switch ($entity)
 		{

--- a/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeMembersGUI.php
+++ b/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeMembersGUI.php
@@ -512,7 +512,7 @@ class ilObjStudyProgrammeMembersGUI {
 	 */
 	protected function getProgressObject($prgrs_id)
 	{
-		assert('is_int($prgrs_id)');
+		assert(is_int($prgrs_id));
 		if (!array_key_exists($prgrs_id, $this->progress_objects)) {
 			require_once("Modules/StudyProgramme/classes/class.ilStudyProgrammeUserProgress.php");
 			$this->progress_objects[$prgrs_id] = $this->sp_user_progress_db->getInstanceById($id);

--- a/Services/Authentication/classes/External/UserAttributeMapping/class.ilExternalAuthUserAttributeMapping.php
+++ b/Services/Authentication/classes/External/UserAttributeMapping/class.ilExternalAuthUserAttributeMapping.php
@@ -36,8 +36,8 @@ class ilExternalAuthUserAttributeMapping implements ArrayAccess, Countable, Iter
 	 */
 	public function __construct($authMode, $authSourceId = 0)
 	{
-		assert('is_string($authMode)');
-		assert('is_numeric($authSourceId)');
+		assert(is_string($authMode));
+		assert(is_numeric($authSourceId));
 
 		$this->db = $GLOBALS['DIC']->database();
 

--- a/Services/COPage/mediawikidiff/class.WordLevelDiff.php
+++ b/Services/COPage/mediawikidiff/class.WordLevelDiff.php
@@ -1088,7 +1088,7 @@ class _DiffEngine
 		$i = 0;
 		$j = 0;
 
-		USE_ASSERTS && assert('sizeof($lines) == sizeof($changed)');
+		USE_ASSERTS && assert(sizeof($lines) == sizeof($changed));
 		$len = sizeof($lines);
 		$other_len = sizeof($other_changed);
 
@@ -1108,7 +1108,7 @@ class _DiffEngine
 				$j++;
 
 			while ($i < $len && ! $changed[$i]) {
-				USE_ASSERTS && assert('$j < $other_len && ! $other_changed[$j]');
+				USE_ASSERTS && assert($j < $other_len && ! $other_changed[$j]);
 				$i++; $j++;
 				while ($j < $other_len && $other_changed[$j])
 					$j++;
@@ -1140,10 +1140,10 @@ class _DiffEngine
 					$changed[--$i] = false;
 					while ($start > 0 && $changed[$start - 1])
 						$start--;
-					USE_ASSERTS && assert('$j > 0');
+					USE_ASSERTS && assert($j > 0);
 					while ($other_changed[--$j])
 						continue;
-					USE_ASSERTS && assert('$j >= 0 && !$other_changed[$j]');
+					USE_ASSERTS && assert($j >= 0 && !$other_changed[$j]);
 				}
 
 				/*
@@ -1166,7 +1166,7 @@ class _DiffEngine
 					while ($i < $len && $changed[$i])
 						$i++;
 
-					USE_ASSERTS && assert('$j < $other_len && ! $other_changed[$j]');
+					USE_ASSERTS && assert($j < $other_len && ! $other_changed[$j]);
 					$j++;
 					if ($j < $other_len && $other_changed[$j]) {
 						$corresponding = $i;
@@ -1183,10 +1183,10 @@ class _DiffEngine
 			while ($corresponding < $i) {
 				$changed[--$start] = 1;
 				$changed[--$i] = 0;
-				USE_ASSERTS && assert('$j > 0');
+				USE_ASSERTS && assert($j > 0);
 				while ($other_changed[--$j])
 					continue;
-				USE_ASSERTS && assert('$j >= 0 && !$other_changed[$j]');
+				USE_ASSERTS && assert($j >= 0 && !$other_changed[$j]);
 			}
 		}
 		//wfProfileOut( $fname );

--- a/Services/Component/classes/class.ilPluginAdmin.php
+++ b/Services/Component/classes/class.ilPluginAdmin.php
@@ -489,7 +489,7 @@ class ilPluginAdmin
 	 * @return 	boolean
 	 */
 	public static function isPluginActive($id) {
-		assert('is_string($id)');
+		assert(is_string($id));
 		$cached_component = ilCachedComponentData::getInstance();
 		$plugs = $cached_component->getIlPluginById();
 		if(array_key_exists($id, $plugs) &&	$plugs[$id]['active']) {
@@ -506,7 +506,7 @@ class ilPluginAdmin
 	 * @return 	ilPlugin
 	 */
 	public static function getPluginObjectById($id) {
-		assert('is_string($id)');
+		assert(is_string($id));
 		$plugs = self::getAllPlugins();
 		if( ! array_key_exists($id, $plugs)) {
 			throw new \InvalidArgumentException("Plugin does not exist: " .$id, 1);

--- a/Services/PersonalDesktop/ItemsBlock/classes/class.ilPDSelectedItemsBlockViewSettings.php
+++ b/Services/PersonalDesktop/ItemsBlock/classes/class.ilPDSelectedItemsBlockViewSettings.php
@@ -194,7 +194,7 @@ class ilPDSelectedItemsBlockViewSettings implements ilPDSelectedItemsBlockConsta
 	 */
 	public function storeDefaultSortType($type)
 	{
-		assert('in_array($type, self::$availableSortOptions)');
+		assert(in_array($type, self::$availableSortOptions));
 		$this->settings->set('my_memberships_def_sort', $type);
 	}
 
@@ -259,7 +259,7 @@ class ilPDSelectedItemsBlockViewSettings implements ilPDSelectedItemsBlockConsta
 	 */
 	public function storeDefaultView($view)
 	{
-		assert('in_array($view, self::$availableViews)');
+		assert(in_array($view, self::$availableViews));
 		$this->settings->set('personal_items_default_view', $view);
 	}
 

--- a/Services/XHTMLValidator/validator/Text_Diff/Diff.php
+++ b/Services/XHTMLValidator/validator/Text_Diff/Diff.php
@@ -619,7 +619,7 @@ class Text_Diff_Engine_native {
         $i = 0;
         $j = 0;
 
-        assert('count($lines) == count($changed)');
+        assert(count($lines) == count($changed));
         $len = count($lines);
         $other_len = count($other_changed);
 
@@ -640,7 +640,7 @@ class Text_Diff_Engine_native {
             }
 
             while ($i < $len && ! $changed[$i]) {
-                assert('$j < $other_len && ! $other_changed[$j]');
+                assert($j < $other_len && ! $other_changed[$j]);
                 $i++; $j++;
                 while ($j < $other_len && $other_changed[$j]) {
                     $j++;
@@ -672,11 +672,11 @@ class Text_Diff_Engine_native {
                     while ($start > 0 && $changed[$start - 1]) {
                         $start--;
                     }
-                    assert('$j > 0');
+                    assert($j > 0);
                     while ($other_changed[--$j]) {
                         continue;
                     }
-                    assert('$j >= 0 && !$other_changed[$j]');
+                    assert($j >= 0 && !$other_changed[$j]);
                 }
 
                 /* Set CORRESPONDING to the end of the changed run, at the
@@ -697,7 +697,7 @@ class Text_Diff_Engine_native {
                         $i++;
                     }
 
-                    assert('$j < $other_len && ! $other_changed[$j]');
+                    assert($j < $other_len && ! $other_changed[$j]);
                     $j++;
                     if ($j < $other_len && $other_changed[$j]) {
                         $corresponding = $i;
@@ -713,11 +713,11 @@ class Text_Diff_Engine_native {
             while ($corresponding < $i) {
                 $changed[--$start] = 1;
                 $changed[--$i] = 0;
-                assert('$j > 0');
+                assert($j > 0);
                 while ($other_changed[--$j]) {
                     continue;
                 }
-                assert('$j >= 0 && !$other_changed[$j]');
+                assert($j >= 0 && !$other_changed[$j]);
             }
         }
     }

--- a/src/DI/LoggingServices.php
+++ b/src/DI/LoggingServices.php
@@ -31,7 +31,7 @@ class LoggingServices {
 	 * @return	\ilLogger
 	 */
 	public function __call($method_name, $args) {
-		assert('count($args) === 0');
+		assert(count($args) === 0);
 		return $this->container["ilLoggerFactory"]->getLogger($method_name);
 	}
 }

--- a/src/UI/Implementation/Component/ComponentHelper.php
+++ b/src/UI/Implementation/Component/ComponentHelper.php
@@ -18,9 +18,9 @@ trait ComponentHelper {
 	 * @return	null
 	 */
 	protected function checkArg($which, $check, $message) {
-		assert('is_string($which)');
-		assert('is_bool($check)');
-		assert('is_string($message)');
+		assert(is_string($which));
+		assert(is_bool($check));
+		assert(is_string($message));
 		if (!$check) {
 			throw new \InvalidArgumentException("Argument '$which': $message");
 		}

--- a/src/UI/Implementation/Component/Dropdown/Renderer.php
+++ b/src/UI/Implementation/Component/Dropdown/Renderer.php
@@ -80,7 +80,7 @@ class Renderer extends AbstractComponentRenderer {
 	 * @return Renderer
 	 */
 	public function withBlocksToBeTouched($block) {
-		assert('is_string($block)');
+		assert(is_string($block));
 		$clone = clone $this;
 		$clone->touch_blocks[] = $block;
 		return $clone;

--- a/src/Validation/Constraints/GreaterThan.php
+++ b/src/Validation/Constraints/GreaterThan.php
@@ -13,7 +13,7 @@ class GreaterThan extends Custom implements Constraint {
 	protected $min;
 
 	public function __construct($min, Data\Factory $data_factory) {
-		assert('is_int($min)');
+		assert(is_int($min));
 		$this->min = $min;
 		parent::__construct( function ($value) {
 				return $value > $this->min;

--- a/src/Validation/Constraints/LessThan.php
+++ b/src/Validation/Constraints/LessThan.php
@@ -13,7 +13,7 @@ class LessThan extends Custom implements Constraint {
 	protected $max;
 
 	public function __construct($max, Data\Factory $data_factory) {
-		assert('is_int($max)');
+		assert(is_int($max));
 		$this->max = $max;
 		parent::__construct( function ($value) {
 				return $value < $this->max;


### PR DESCRIPTION
With PHP 7.2. assertions using strings as argument will emit an E_DEPRECATED .

- http://php.net/manual/en/migration72.deprecated.php#migration72.deprecated.assert-string-arg
- http://php.net/manual/en/function.assert.php