### PR TITLE
Trunk 21619 - prg-item in RepositoryExplorer is not clickable for users with only visible permissions

### DIFF
--- a/Services/Repository/classes/class.ilRepositoryExplorerGUI.php
+++ b/Services/Repository/classes/class.ilRepositoryExplorerGUI.php
@@ -647,7 +647,7 @@ class ilRepositoryExplorerGUI extends ilTreeExplorerGUI
 				return ilContainerReferenceAccess::_isAccessible($a_node["child"]);
 			
 			case 'prg': 
-					return $rbacsystem->checkAccess("visible", $a_node["child"]);
+					return $rbacsystem->checkAccess("read", $a_node["child"]);
 
 			// all other types are only clickable, if read permission is given
 			default:


### PR DESCRIPTION
Trunk 21619
prg-item in RepositoryExplorer is not clickable for users with only visible permissions