### PR TITLE
Fatal error occures while openeing "Benchmarks" in "Administration"

### DIFF
--- a/Modules/SystemFolder/classes/class.ilObjSystemFolderGUI.php
+++ b/Modules/SystemFolder/classes/class.ilObjSystemFolderGUI.php
@@ -65,12 +65,27 @@ class ilObjSystemFolderGUI extends ilObjectGUI
 	var $type;
 
 	/**
+	 * @var \ILIAS\DI\Container
+	 */
+	private $dic;
+
+	/**
 	* Constructor
 	* @access public
 	*/
-	function __construct($a_data,$a_id,$a_call_by_reference)
+	function __construct(
+		$a_data,
+		$a_id,
+		$a_call_by_reference,
+		$a_prepare_output = false,
+		\ILIAS\DI\Container $dic = null
+	)
 	{
-		global $DIC;
+		if ($dic === null) {
+			global $DIC;
+			$dic = $DIC;
+		}
+		$this->dic = $dic;
 
 		$this->tabs = $DIC->tabs();
 		$this->access = $DIC->access();
@@ -88,7 +103,7 @@ class ilObjSystemFolderGUI extends ilObjectGUI
 		$this->toolbar = $DIC->toolbar();
 		$this->client_ini = $DIC["ilClientIniFile"];
 		$this->type = "adm";
-		parent::__construct($a_data,$a_id,$a_call_by_reference, false);
+		parent::__construct($a_data,$a_id,$a_call_by_reference, $a_prepare_output);
 
 		$this->lng->loadLanguageModule("administration");
 		$this->lng->loadLanguageModule("adm");
@@ -811,9 +826,7 @@ class ilObjSystemFolderGUI extends ilObjectGUI
 	function showDbBenchResults($a_mode)
 	{
 		$tpl = $this->tpl;
-		global $DIC;
-
-		$ilBench = $DIC["ilBench"];
+		$ilBench = $this->dic["ilBench"];
 		$rec = $ilBench->getDbBenchRecords();
 
 		include_once("./Modules/SystemFolder/classes/class.ilBenchmarkTableGUI.php");
@@ -832,9 +845,8 @@ class ilObjSystemFolderGUI extends ilObjectGUI
 		$ilTabs = $this->tabs;
 		$lng = $this->lng;
 		$ilCtrl = $this->ctrl;
-		global $DIC;
 
-		$ilBench = $DIC["ilBench"];
+		$ilBench = $this->dic["ilBench"];
 		$ilTabs->activateTab("benchmarks"); // #18083
 
 		$ilTabs->addSubtab("settings",

--- a/Modules/SystemFolder/classes/class.ilObjSystemFolderGUI.php
+++ b/Modules/SystemFolder/classes/class.ilObjSystemFolderGUI.php
@@ -811,6 +811,7 @@ class ilObjSystemFolderGUI extends ilObjectGUI
 	function showDbBenchResults($a_mode)
 	{
 		$tpl = $this->tpl;
+		global $DIC;
 
 		$ilBench = $DIC["ilBench"];
 		$rec = $ilBench->getDbBenchRecords();
@@ -831,6 +832,7 @@ class ilObjSystemFolderGUI extends ilObjectGUI
 		$ilTabs = $this->tabs;
 		$lng = $this->lng;
 		$ilCtrl = $this->ctrl;
+		global $DIC;
 
 		$ilBench = $DIC["ilBench"];
 		$ilTabs->activateTab("benchmarks"); // #18083


### PR DESCRIPTION
Currently a PHP error occures when trying to open the submenu "Benchmarks" in the "Administration" menu.
This is caused by the not referenced variable `DIC`. This PR will fix this problem.

Refers to Mantis: [21702](https://www.ilias.de/mantis/view.php?id=21702)