### PR TITLE
Maillist in contact view doesn't display correct table site

### DIFF
--- a/Services/Contact/classes/class.ilMailSearchCoursesGUI.php
+++ b/Services/Contact/classes/class.ilMailSearchCoursesGUI.php
@@ -493,7 +493,7 @@ class ilMailSearchCoursesGUI
 			$this->lng->loadLanguageModule('crs');
 			include_once 'Services/Contact/classes/class.ilMailSearchCoursesMembersTableGUI.php';
 			$context = $_GET["ref"] ? $_GET["ref"] : "mail"; 
-			$table = new ilMailSearchCoursesMembersTableGUI($this, 'crs', $context);
+			$table = new ilMailSearchCoursesMembersTableGUI($this, 'crs', $context, $_POST["search_crs"]);
 			$tableData = array();
 			$searchTpl = new ilTemplate('tpl.mail_search_template.html', true, true, 'Services/Contact');
 			foreach($_POST["search_crs"] as $crs_id) 
@@ -549,6 +549,7 @@ class ilMailSearchCoursesGUI
 				}
 			}
 			$table->setData($tableData);
+
 			if (count($tableData))
 			{
 				$searchTpl->setVariable("TXT_MARKED_ENTRIES", $this->lng->txt("marked_entries"));

--- a/Services/Contact/classes/class.ilMailSearchCoursesMembersTableGUI.php
+++ b/Services/Contact/classes/class.ilMailSearchCoursesMembersTableGUI.php
@@ -43,7 +43,7 @@ class ilMailSearchCoursesMembersTableGUI extends ilTable2GUI
 	 *			and 'grp' for groups
 	 * 
 	 */
-	public function __construct($a_parent_obj, $type = 'crs', $context = 'mail')
+	public function __construct($a_parent_obj, $type = 'crs', $context = 'mail', $contextObjects)
 	{
 		global $DIC;
 
@@ -51,7 +51,8 @@ class ilMailSearchCoursesMembersTableGUI extends ilTable2GUI
 		$this->lng  = $DIC['lng'];
 		$this->user = $DIC['ilUser'];
 
-		$this->setId($type. 'table_members');
+		$tableId = $type . '_cml_' . implode('_', (array)$contextObjects);
+		$this->setId($tableId);
 		parent::__construct($a_parent_obj, 'showMembers');
 
 		$this->context = $context;
@@ -95,7 +96,7 @@ class ilMailSearchCoursesMembersTableGUI extends ilTable2GUI
 			$this->ctrl->setParameter($a_parent_obj, $mode["checkbox"], implode(',', $_POST[$mode["checkbox"]]));
 
 		$this->setFormAction($this->ctrl->getFormAction($a_parent_obj));
-		$this->ctrl->clearParameters($a_parent_obj);
+		//$this->ctrl->clearParameters($a_parent_obj);
 
 		$this->setRowTemplate('tpl.mail_search_courses_members_row.html', 'Services/Contact');
 
@@ -124,8 +125,7 @@ class ilMailSearchCoursesMembersTableGUI extends ilTable2GUI
 			$this->lng->loadLanguageModule("wsp");
 			$this->addMultiCommand('share', $this->lng->txt("wsp_share_with_members"));
 		}
-		$this->lng->loadLanguageModule('buddysystem');
-
+ 		$this->lng->loadLanguageModule('buddysystem');
 		$this->addCommandButton('cancel', $this->lng->txt('cancel'));
 	}
 	

--- a/Services/Contact/classes/class.ilMailSearchCoursesMembersTableGUI.php
+++ b/Services/Contact/classes/class.ilMailSearchCoursesMembersTableGUI.php
@@ -63,6 +63,9 @@ class ilMailSearchCoursesMembersTableGUI extends ilTable2GUI
 			$this->mailing_allowed = $DIC->rbac()->system()->checkAccess('internal_mail',$mail->getMailObjectReferenceId());
 		}
 
+		$this->setDefaultOrderDirection('ASC');
+		$this->setDefaultOrderField('members_login');
+
 		$this->lng->loadLanguageModule('crs');
 		$this->lng->loadLanguageModule('buddysystem');
 		$this->parentObject = $a_parent_obj;

--- a/Services/Contact/classes/class.ilMailSearchGroupsGUI.php
+++ b/Services/Contact/classes/class.ilMailSearchGroupsGUI.php
@@ -456,7 +456,7 @@ class ilMailSearchGroupsGUI
 			$this->tpl->setTitle($this->lng->txt("mail_addressbook"));
 			include_once 'Services/Contact/classes/class.ilMailSearchCoursesMembersTableGUI.php';
 			$context = $_GET["ref"] ? $_GET["ref"] : "mail"; 	
-			$table = new ilMailSearchCoursesMembersTableGUI($this, 'grp', $context);
+			$table = new ilMailSearchCoursesMembersTableGUI($this, 'grp', $context, $_POST["search_grp"]);
 			$this->lng->loadLanguageModule('crs');
 
 			$tableData = array();


### PR DESCRIPTION
This PR refers to https://www.ilias.de/mantis/view.php?id=21764

Because of the missing of the default sorting, the current table doesn't display the correct table site number, which leads to an odd behavior.

With acitvating a default sorting this behavior is fixed.