### PR TITLE
Set Table ID before calling parent constructor.

### DIFF
--- a/Services/User/classes/class.ilRoleAssignmentTableGUI.php
+++ b/Services/User/classes/class.ilRoleAssignmentTableGUI.php
@@ -22,11 +22,11 @@ class ilRoleAssignmentTableGUI extends ilTable2GUI
 		global $ilCtrl, $lng, $ilAccess;
 
 		$lng->loadLanguageModule('rbac');
-		
+		$this->setId("usrroleass");
+
 		parent::__construct($a_parent_obj, $a_parent_cmd);
 
 		$this->setTitle($lng->txt("role_assignment"));
-		$this->setId("usrroleass");
 		$this->setDefaultOrderField("title");
 		$this->setDefaultOrderDirection("asc");
 		$this->setDisableFilterHiding(true);


### PR DESCRIPTION
I didn't mark this as a bug in Mantis but I did notice this and am proposing a fix. 

If you call parent::__construct before setting this table's ID determineLimit is called before setPrefix in ilTable2GUI so determineLimit never actually finds the GET var and row limiting in this table never ends up working.