### PR TITLE
Placeholders in mail for course member won't be replaced

### DIFF
--- a/Modules/Course/classes/class.ilCourseMailTemplateTutorContext.php
+++ b/Modules/Course/classes/class.ilCourseMailTemplateTutorContext.php
@@ -122,8 +122,14 @@ class ilCourseMailTemplateTutorContext extends ilMailTemplateContext
 		 */
 		global $ilObjDataCache;
 
-		if(!in_array($placeholder_id, array('crs_title', 'crs_link')))
-		{
+		if(!in_array($placeholder_id, array(
+			'crs_title',
+			'crs_link',
+			'crs_status',
+			'crs_mark',
+			'crs_time_spent',
+			'crs_first_access',
+			'crs_last_access'))) {
 			return '';
 		}
 

--- a/Modules/Course/test/ilCourseMailTemplateTutorContextTest.php
+++ b/Modules/Course/test/ilCourseMailTemplateTutorContextTest.php
@@ -1,0 +1,15 @@
+<?php
+
+include_once 'Modules/Course/classes/class.ilCourseMailTemplateTutorContext.php';
+
+class ilCourseMailTemplateTutorContextTest extends \PHPUnit_Framework_TestCase
+{
+	public function testNonExistingPlaceholderWontBeResolved()
+	{
+		$mailTemplateContext = new ilCourseMailTemplateTutorContext();
+
+		$result = $mailTemplateContext->resolveSpecificPlaceholder('TEST_PLACEHOLDER', array());
+
+		$this->assertEquals($result, '');
+	}
+}

--- a/Modules/Course/test/ilModulesCourseSuite.php
+++ b/Modules/Course/test/ilModulesCourseSuite.php
@@ -30,6 +30,9 @@ class ilModulesCourseSuite extends PHPUnit_Framework_TestSuite
 		include_once("./Modules/Course/test/ilCourseTest.php");
 		$suite->addTestSuite("ilCourseTest");
 
+		include_once("./Modules/Course/test/ilCourseMailTemplateTutorContextTest.php");
+		$suite->addTestSuite("ilCourseMailTemplateTutorContextTest");
+
 		return $suite;
     }
 }


### PR DESCRIPTION
Several placeholders for a course email won't be replaced.

Refers to https://www.ilias.de/mantis/view.php?id=21775