### PR TITLE
php-version of testing environment

### DIFF
--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -699,7 +699,7 @@ The ILIAS Testserver (http://ilias.de/test52) is currently configured as follows
 | Package        | Version                     |
 |----------------|-----------------------------|
 | Distribution   | Ubuntu 14.04.5 LTS          |
-| MySQL          | MySQL 5.5.54                |
+| MySQL          | MySQL 5.5.58                |
 | PHP            | 5.5.9                       |
 | Apache         | 2.4.7                       |
 | Nginx          | 1.4.6                       |

--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -700,7 +700,7 @@ The ILIAS Testserver (http://ilias.de/test52) is currently configured as follows
 |----------------|-----------------------------|
 | Distribution   | Ubuntu 14.04.5 LTS          |
 | MySQL          | MySQL 5.5.54                |
-| PHP            | 7.0.17                      |
+| PHP            | 5.5.9                       |
 | Apache         | 2.4.7                       |
 | Nginx          | 1.4.6                       |
 | zip            | 3.0                         |


### PR DESCRIPTION
As discussed during the TB meeting 2017-11-07, we change the PHP-version of the testing environment to 5.5.9