### PR TITLE
Fix fatal error by displaying history

### DIFF
--- a/Modules/Chatroom/chat/Persistence/Database.js
+++ b/Modules/Chatroom/chat/Persistence/Database.js
@@ -15,7 +15,8 @@ var Database = function Database(config) {
 			port: config.database.port,
 			user: config.database.user,
 			password: config.database.pass,
-			database: config.database.name
+			database: config.database.name,
+			charset: 'UTF8_UNICODE_CI'
 			//debug: true
 		});
 

--- a/Modules/Chatroom/classes/class.ilChatroom.php
+++ b/Modules/Chatroom/classes/class.ilChatroom.php
@@ -725,7 +725,7 @@ class ilChatroom
 
 		while($row = $DIC->database()->fetchAssoc($rset))
 		{
-			$row['message']            = json_decode($row['message']);
+			$row['message']            = json_decode($row['message']) ?: json_decode('{}');
 			$row['message']->timestamp = $row['timestamp'];
 			if(
 				$respect_target &&


### PR DESCRIPTION
Using unicode symbols that are bigger than 3 bytes will be displayed, but will also break the chat history.

Currently it is not possible to store these unicode symbols in the database. (Read [here](https://www.ilias.de/mantis/view.php?id=21888)
and [here](https://www.ilias.de/mantis/view.php?id=12860) for more information)

This PR won't fix the problem that the chat history is still broken, but at least it won't break the whole application caused by an invalid JSON-String in the database.

This PR was provided by @Hufschmidt in https://www.ilias.de/mantis/view.php?id=21888