### PR TITLE
Don't use ternary operator for chatroom history  

### DIFF
--- a/Modules/Chatroom/classes/class.ilChatroom.php
+++ b/Modules/Chatroom/classes/class.ilChatroom.php
@@ -725,7 +725,12 @@ class ilChatroom
 
 		while($row = $DIC->database()->fetchAssoc($rset))
 		{
-			$row['message']            = json_decode($row['message']) ?: json_decode('{}');
+			$message = json_decode($row['message']);
+			if ($message === null) {
+				$message = json_decode('{}');
+			}
+
+			$row['message']            =  $message;
 			$row['message']->timestamp = $row['timestamp'];
 			if(
 				$respect_target &&


### PR DESCRIPTION
The ternary operator can be handled different on several PHP versions