### PR TITLE
[FIX] 0020195: Filter strict errors for abstract static methods in php<7.0

### DIFF
--- a/Services/Init/classes/class.ilErrorHandling.php
+++ b/Services/Init/classes/class.ilErrorHandling.php
@@ -454,7 +454,8 @@ class ilErrorHandling extends PEAR
 			if (version_compare(PHP_VERSION, '7.0.0', '<')) {
 				if ($level == E_STRICT) {
 					if (!stristr($message, "should be compatible") &&
-						!stristr($message, "should not be called statically")) {
+						!stristr($message, "should not be called statically") &&
+						!stristr($message, "should not be abstract")) {
 						return true;
 					};
 				}


### PR DESCRIPTION
See https://www.ilias.de/mantis/view.php?id=20195.