### PR TITLE
Replace static `ilMailRfc822AddressParserFactory::getParser()` with non-static approach

### DIFF
--- a/Services/Mail/classes/Address/Parser/class.ilMailRfc822AddressParserFactory.php
+++ b/Services/Mail/classes/Address/Parser/class.ilMailRfc822AddressParserFactory.php
@@ -11,7 +11,7 @@ class ilMailRfc822AddressParserFactory
 	 * @param string $a_address
 	 * @return ilMailRecipientParser
 	 */
-	public static function getParser($a_address)
+	public function getParser($a_address)
 	{
 		require_once 'Services/Mail/classes/Address/Parser/class.ilMailPearRfc822WrapperAddressParser.php';
 		require_once 'Services/Mail/classes/Address/Parser/class.ilMailRfc822AddressParser.php';

--- a/Services/Mail/classes/Address/Parser/class.ilMailRfc822AddressParserFactory.php
+++ b/Services/Mail/classes/Address/Parser/class.ilMailRfc822AddressParserFactory.php
@@ -13,19 +13,8 @@ class ilMailRfc822AddressParserFactory
 	 */
 	public static function getParser($a_address)
 	{
-		switch(true)
-		{
-			// imap_rfc822_parse_adrlist currently not used because we cannot determine which of the addresses in the recipient string is faulty
-//			case function_exists('imap_rfc822_parse_adrlist'):
-//				require_once 'Services/Mail/classes/Address/Parser/class.ilMailImapRfc822AddressParser.php';
-//				return new ilMailImapRfc822AddressParser($a_address);
-//				break;
-
-			default:
-				require_once 'Services/Mail/classes/Address/Parser/class.ilMailPearRfc822WrapperAddressParser.php';
-				require_once 'Services/Mail/classes/Address/Parser/class.ilMailRfc822AddressParser.php';
-				return new ilMailRfc822AddressParser(new ilMailPearRfc822WrapperAddressParser($a_address));
-				break;
-		}
+		require_once 'Services/Mail/classes/Address/Parser/class.ilMailPearRfc822WrapperAddressParser.php';
+		require_once 'Services/Mail/classes/Address/Parser/class.ilMailRfc822AddressParser.php';
+		return new ilMailRfc822AddressParser(new ilMailPearRfc822WrapperAddressParser($a_address));
 	}
 }

--- a/Services/Mail/classes/Address/Type/class.ilMailRoleAddressType.php
+++ b/Services/Mail/classes/Address/Type/class.ilMailRoleAddressType.php
@@ -181,17 +181,25 @@ class ilMailRoleAddressType extends ilBaseMailAddressType
 	 *
 	 * If Pear Mail is not installed, then the mailbox address
 	 * @param $a_address_list
-	 * @param null $dic
-	 * @param null $parser
+	 * @param ilMailRfc822AddressParserFactory|null $parserFactory
+	 * @param ilMailRfc822AddressParser|null $parser
 	 * @return int[] Array with role ids that were found
+	 * @internal param null $dic
 	 * @internal param IETF $string RFX 822 address list containing role mailboxes.
 	 */
-	public static function searchRolesByMailboxAddressList($a_address_list, ilMailRfc822AddressParserFactory $parser = null)
-	{
+	public static function searchRolesByMailboxAddressList(
+		$a_address_list,
+		ilMailRfc822AddressParserFactory $parserFactory = null,
+		ilMailRfc822AddressParser $parser = null
+	) {
 		global $DIC;
+		
+		if ($parserFactory === null) {
+			$parserFactory = new ilMailRfc822AddressParserFactory();
+		}
 
 		if ($parser === null) {
-			$parser = ilMailRfc822AddressParserFactory::getParser($a_address_list);
+			$parser = $parserFactory->getParser($a_address_list);
 		}
 
 		$role_ids = array();
@@ -364,13 +372,22 @@ class ilMailRoleAddressType extends ilBaseMailAddressType
 	 * backslash.
 	 *
 	 *
-	 * @param int a role id
-	 * @param boolean is_localize whether mailbox addresses should be localized
-	 * @return	String mailbox address or null, if role does not exist.
+	 * @param $a_role_id
+	 * @param bool $is_localize is_localize whether mailbox addresses should be localized
+	 * @param ilMailRfc822AddressParserFactory|null $mailAddressParserFactory
+	 * @return String mailbox address or null, if role does not exist.
+	 * @internal param a $int role id
 	 */
-	public static function getRoleMailboxAddress($a_role_id, $is_localize = true)
-	{
+	public static function getRoleMailboxAddress(
+		$a_role_id,
+		$is_localize = true,
+		ilMailRfc822AddressParserFactory $mailAddressParserFactory = null
+	) {
 		global $DIC;
+
+		if ($mailAddressParserFactory === null) {
+			$mailAddressParserFactory = new ilMailRfc822AddressParserFactory();
+		}
 
 		// Retrieve the role title and the object title.
 		$query = "SELECT rdat.title role_title,odat.title object_title, ".
@@ -541,8 +558,7 @@ class ilMailRoleAddressType extends ilBaseMailAddressType
 
 		try
 		{
-			require_once 'Services/Mail/classes/Address/Parser/class.ilMailRfc822AddressParserFactory.php';
-			$parser = ilMailRfc822AddressParserFactory::getParser($mailbox);
+			$parser = $mailAddressParserFactory->getParser($mailbox);
 			$parser->parse();
 
 			return $mailbox;

--- a/Services/Mail/classes/class.ilMail.php
+++ b/Services/Mail/classes/class.ilMail.php
@@ -114,11 +114,18 @@ class ilMail
 	/** @var ilMailAddressTypeFactory */
 	private $mailAddressTypeFactory;
 
+	/** @var ilMailRfc822AddressParserFactory */
+	private $mailAddressParserFactory;
+
 	/**
 	 * @param integer $a_user_id
 	 * @param ilMailAddressTypeFactory|null $mailAddressTypeFactory
+	 * @param ilMailRfc822AddressParserFactory|null $mailAddressParserFactory
 	 */
-	public function __construct($a_user_id, ilMailAddressTypeFactory $mailAddressTypeFactory = null)
+	public function __construct(
+		$a_user_id,
+		ilMailAddressTypeFactory $mailAddressTypeFactory = null,
+		ilMailRfc822AddressParserFactory $mailAddressParserFactory = null)
 	{
 		global $DIC;
 
@@ -128,6 +135,12 @@ class ilMail
 		if ($mailAddressTypeFactory === null) {
 			$mailAddressTypeFactory = new ilMailAddressTypeFactory();
 		}
+
+		if ($mailAddressParserFactory === null) {
+			$mailAddressParserFactory = new ilMailRfc822AddressParserFactory();
+		}
+
+		$this->mailAddressParserFactory = $mailAddressParserFactory;
 		$this->mailAddressTypeFactory = $mailAddressTypeFactory;
 
 		$this->lng              = $DIC->language();
@@ -1433,8 +1446,7 @@ class ilMail
 			));
 		}
 
-		require_once 'Services/Mail/classes/Address/Parser/class.ilMailRfc822AddressParserFactory.php';
-		$parser = ilMailRfc822AddressParserFactory::getParser($addresses);
+		$parser = $this->mailAddressParserFactory->getParser($addresses);
 		$parsedAddresses = $parser->parse();
 
 		if(strlen($addresses) > 0)

--- a/Services/Utilities/classes/class.ilUtil.php
+++ b/Services/Utilities/classes/class.ilUtil.php
@@ -1136,32 +1136,34 @@ class ilUtil
 	}
 
 	/**
-	* This preg-based function checks whether an e-mail address is formally valid.
-	* It works with all top level domains including the new ones (.biz, .info, .museum etc.)
-	* and the special ones (.arpa, .int etc.)
-	* as well as with e-mail addresses based on IPs (e.g. webmaster@123.45.123.45)
-	* Valid top level domains: http://data.iana.org/TLD/tlds-alpha-by-domain.txt
-	* @author	Unknown <mail@philipp-louis.de> (source: http://www.php.net/preg_match)
-	* @access	public
-	* @param	string	email address
-	* @return	boolean	true if valid
-	* @static
-	* 
-	*/
-	public static function is_email($a_email)
+	 * This preg-based function checks whether an e-mail address is formally valid.
+	 * It works with all top level domains including the new ones (.biz, .info, .museum etc.)
+	 * and the special ones (.arpa, .int etc.)
+	 * as well as with e-mail addresses based on IPs (e.g. webmaster@123.45.123.45)
+	 * Valid top level domains: http://data.iana.org/TLD/tlds-alpha-by-domain.txt
+	 * @author    Unknown <mail@philipp-louis.de> (source: http://www.php.net/preg_match)
+	 * @access    public
+	 * @param    string    email address
+	 * @param ilMailRfc822AddressParserFactory|null $mailAddressParserFactory
+	 * @return bool true if valid
+	 * @static
+	 */
+	public static function is_email($a_email, ilMailRfc822AddressParserFactory $mailAddressParserFactory = null)
 	{
 		global $DIC;
 
 		$ilErr = $DIC["ilErr"];
 
+		if ($mailAddressParserFactory === null) {
+			$mailAddressParserFactory = new ilMailRfc822AddressParserFactory();
+		}
 		// additional check for ilias object is needed,
 		// otherwise setup will fail with this if branch
 		if(is_object($ilErr)) // seems to work in Setup now
 		{
 			try
 			{
-				require_once 'Services/Mail/classes/Address/Parser/class.ilMailRfc822AddressParserFactory.php';
-				$parser    = ilMailRfc822AddressParserFactory::getParser($a_email);
+				$parser    = $mailAddressParserFactory->getParser($a_email);
 				$addresses = $parser->parse();
 				return count($addresses) == 1 && $addresses[0]->getHost() != ilMail::ILIAS_HOST;
 			}


### PR DESCRIPTION
Replaces the static call of `getParser` in `ilMailRfc822AddressParserFactory` with an OOP approach.

Create instances of `ilMailRfc822AddressParserFactory` to operate on the object.