### PR TITLE
Bugfix #0022151 - Fixed css caching in custom skins (ILIAS 5.0)

### DIFF
--- a/Services/Utilities/classes/class.ilUtil.php
+++ b/Services/Utilities/classes/class.ilUtil.php
@@ -189,23 +189,29 @@ class ilUtil
 		}
 
 		$filename = "";
+		$ver_filename = "";
 		// use ilStyleDefinition instead of account to get the current skin
 		require_once("./Services/Style/classes/class.ilStyleDefinition.php");
 		if (ilStyleDefinition::getCurrentSkin() != "default")
 		{
 			$filename = "./Customizing/global/skin/".ilStyleDefinition::getCurrentSkin()."/".$a_css_location.$stylesheet_name;
+			$ver_filename = "./Customizing/global/skin/".ilStyleDefinition::getCurrentSkin()."/version";
 		}
 		if (strlen($filename) == 0 || !file_exists($filename))
 		{
 			$filename = "./" . $a_css_location . "templates/default/".$stylesheet_name;
 		}
 		$vers = "";
+        $build = "";
 		if ($mode != "filesystem")
 		{
 			$vers = str_replace(" ", "-", $ilias->getSetting("ilias_version"));
 			$vers = "?vers=".str_replace(".", "-", $vers);
+			if (strlen($ver_filename) != 0 && file_exists($ver_filename)) {
+				$build = "-".preg_replace(array("/ /", "/\./"),"-", trim(file_get_contents($ver_filename)));
+			}
 		}
-		return $filename . $vers;
+		return $filename . $vers . $build;
 	}
 
 	/**


### PR DESCRIPTION
To load the css from file instead of cache, just add a file called "version" to your custom skins root folder and insert a number (i.e. a skin version).
If this file does not exists, ilias behaves like before. If the file exists but is empty, also nothing new happens. If the file exists and has content, the content will be added to the "?ver=" string, Spaces and dots in the "skin version" will be replaced with hyphens, like it is done with the standard ilias version.
example (replacing): "0.1.2" => "0-1-2"
example (?ver): ?ver=5-0-23-2017-07-19 => ?ver=5-0-23-2017-07-19-0-1-2

Bugfix of https://ilias.de/mantis/view.php?id=22151