### PR TITLE
Bugfix #0022151 - Fixed css caching in custom skins (ILIAS 5.0)

### DIFF
--- a/Services/Style/classes/class.ilStyleDefinition.php
+++ b/Services/Style/classes/class.ilStyleDefinition.php
@@ -1,4 +1,4 @@
-<?php
+	<?php
 
 /* Copyright (c) 1998-2012 ILIAS open source, Extended GPL, see docs/LICENSE */
 
@@ -441,22 +441,24 @@ class ilStyleDefinition extends ilSaxParser
 		return $cs;
 	}
 
+	/**
+	 * Get version of current skin
+	 *
+	 * @return string skin version
+	 */
 	public static function getCurrentSkinVersion()
 	{
 		/** @var ilStyleDefinition $styleDefinition */
-        global $styleDefinition;
+		global $styleDefinition;
 
-        if (!isset(self::$current_skin))
-        {
-            self::getCurrentSkin();
-        }
+		self::getCurrentSkin();
 
-        $skin_version = '';
-        if (is_object($styleDefinition))
-        {
-            $version = $styleDefinition->getTemplateVersion();
-            if($version != '$Id$') {
-            	$skin_version = $version;
+		$skin_version = '';
+		if (is_object($styleDefinition))
+		{
+			$version = $styleDefinition->getTemplateVersion();
+			if($version != '$Id$') {
+				$skin_version = $version;
 			}
 		}
 

--- a/Services/Style/classes/class.ilStyleDefinition.php
+++ b/Services/Style/classes/class.ilStyleDefinition.php
@@ -1,4 +1,4 @@
-	<?php
+<?php
 
 /* Copyright (c) 1998-2012 ILIAS open source, Extended GPL, see docs/LICENSE */
 

--- a/Services/Style/classes/class.ilStyleDefinition.php
+++ b/Services/Style/classes/class.ilStyleDefinition.php
@@ -92,6 +92,10 @@ class ilStyleDefinition extends ilSaxParser
 		return $this->template_name;
 	}
 
+	function getTemplateVersion()
+	{
+		return $this->template_version;
+	}
 
 	function getStyle($a_id)
 	{
@@ -103,7 +107,6 @@ class ilStyleDefinition extends ilSaxParser
 	{
 		return $this->styles[$a_id]["name"];
 	}
-
 
 	function getImageDirectory($a_master_style, $a_substyle = "")
 	{
@@ -195,6 +198,7 @@ class ilStyleDefinition extends ilSaxParser
 		{
 			case "template" :
 				$this->template_name = $a_attribs["name"];
+				$this->template_version = $a_attribs["version"];
 				break;
 
 			case "style" :
@@ -435,6 +439,28 @@ class ilStyleDefinition extends ilSaxParser
 		self::$current_master_style = $cs;
 		
 		return $cs;
+	}
+
+	public static function getCurrentSkinVersion()
+	{
+		/** @var ilStyleDefinition $styleDefinition */
+        global $styleDefinition;
+
+        if (!isset(self::$current_skin))
+        {
+            self::getCurrentSkin();
+        }
+
+        $skin_version = '';
+        if (is_object($styleDefinition))
+        {
+            $version = $styleDefinition->getTemplateVersion();
+            if($version != '$Id$') {
+            	$skin_version = $version;
+			}
+		}
+
+		return $skin_version;
 	}
 
 	

--- a/Services/Utilities/classes/class.ilUtil.php
+++ b/Services/Utilities/classes/class.ilUtil.php
@@ -204,6 +204,8 @@ class ilUtil
 		{
 			$vers = str_replace(" ", "-", $ilias->getSetting("ilias_version"));
 			$vers = "?vers=".str_replace(".", "-", $vers);
+			$skin_version = ilStyleDefinition::getCurrentSkinVersion();
+			$vers .= ($skin_version != '' ? str_replace(".", "-", '-' . $skin_version) : '');
 		}
 		return $filename . $vers;
 	}


### PR DESCRIPTION
With this bugfix, ilias uses the version of template.xml
to append the "?ver" parameter on the styles css src-string.
The versions dots will be replaced by hyphens, before
appending the "?ver" paramter.
In case of delos skin is in use, the string will not be
modified. In case you want not to use this feature just add
"$Id$" as version, like it is done at the delos template.xml.
You may edit this attribute any time you need in your skins
template.xml.

Bugfix of https://ilias.de/mantis/view.php?id=22151