### PR TITLE
Bugfix #0022151 - Fixed css caching in custom skins (ILIAS trunk)

### DIFF
--- a/Services/Style/System/classes/Icons/class.ilSystemStyleIconsGUI.php
+++ b/Services/Style/System/classes/Icons/class.ilSystemStyleIconsGUI.php
@@ -279,6 +279,9 @@ class  ilSystemStyleIconsGUI
 			}
 			$this->getIconFolder()->changeIconColors($color_changes);
 			$this->setIconFolder(new ilSystemStyleIconFolder($this->getStyleContainer()->getImagesSkinPath($_GET["style_id"])));
+            $skin = $this->getStyleContainer()->getSkin();
+            $skin->getVersionStep($skin->getVersion());
+            $this->getStyleContainer()->updateSkin($skin);
             $message_stack->addMessage(new ilSystemStyleMessage($this->lng->txt("color_update"),
                 ilSystemStyleMessage::TYPE_SUCCESS));
             $message_stack->sendMessages(true);
@@ -443,6 +446,14 @@ class  ilSystemStyleIconsGUI
 
             $message_stack->addMessage(new ilSystemStyleMessage($this->lng->txt("color_update"),ilSystemStyleMessage::TYPE_SUCCESS));
 
+			foreach ($message_stack->getJoinedMessages() as $type => $message) {
+			    if($type == ilSystemStyleMessage::TYPE_SUCCESS) {
+                    $skin = $this->getStyleContainer()->getSkin();
+                    $skin->getVersionStep($skin->getVersion());
+                    $this->getStyleContainer()->updateSkin($skin);
+			        continue;
+                }
+            }
 			$message_stack->sendMessages(true);
 			$this->ctrl->setParameter($this,"selected_icon",$icon->getName());
 			$this->ctrl->redirect($this,"editIcon");

--- a/Services/Style/System/classes/Less/class.ilSystemStyleLessGUI.php
+++ b/Services/Style/System/classes/Less/class.ilSystemStyleLessGUI.php
@@ -296,6 +296,9 @@ class ilSystemStyleLessGUI
 			try{
 				$this->getLessFile()->write();
 				$this->getStyleContainer()->compileLess($_GET["style_id"]);
+				$skin = $this->getStyleContainer()->getSkin();
+				$skin->getVersionStep($skin->getVersion());
+				$this->getStyleContainer()->updateSkin($skin);
 				ilUtil::sendSuccess($this->lng->txt("less_file_updated"));
 			}catch(Exception $e){
 				ilUtil::sendFailure($this->lng->txt($e->getMessage()),true);

--- a/Services/Style/System/classes/Settings/class.ilSystemStyleSettingsGUI.php
+++ b/Services/Style/System/classes/Settings/class.ilSystemStyleSettingsGUI.php
@@ -202,6 +202,7 @@ class ilSystemStyleSettingsGUI
 		$new_skin = $container->getSkin();
 		$new_skin->setId($_POST["skin_id"]);
 		$new_skin->setName($_POST["skin_name"]);
+		$new_skin->getVersionStep($_POST['skin_version']);
 
 		$new_style = $new_skin->getStyle($_GET["style_id"]);
 		$new_style->setId($_POST["style_id"]);
@@ -316,6 +317,13 @@ class ilSystemStyleSettingsGUI
 			$ti->setSize(40);
 			$ti->setRequired(true);
 			$form->addItem($ti);
+
+			if($skin->isVersionChangeable()) {
+                $ti = new ilNonEditableValueGUI($this->lng->txt("skin_version"), "skin_version");
+                $ti->setInfo($this->lng->txt("skin_version_description"));
+                $ti->setValue($skin->getVersion());
+                $form->addItem($ti);
+            }
 
 			$section = new ilFormSectionHeaderGUI();
 			$section->setTitle($this->lng->txt("style"));

--- a/Services/Style/System/classes/Utilities/class.ilSkinXML.php
+++ b/Services/Style/System/classes/Utilities/class.ilSkinXML.php
@@ -33,6 +33,13 @@ class ilSkinXML implements \Iterator, \Countable{
 	 */
 	protected $styles = array();
 
+    /**
+     * Version of skin, as provided by the template
+     *
+     * @var string
+     */
+	protected $version = "0.1";
+
 
 	/**
 	 * ilSkinXML constructor.
@@ -58,6 +65,7 @@ class ilSkinXML implements \Iterator, \Countable{
 
 		$id = basename (dirname($path));
 		$skin = new self($id,(string)$xml->attributes()["name"]);
+        $skin->setVersion((string)$xml->attributes()["version"]);
 
 		/**
 		 * @var ilSkinStyleXML $last_style
@@ -93,7 +101,7 @@ class ilSkinXML implements \Iterator, \Countable{
 	public function asXML(){
 		$xml = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><template/>');
 		$xml->addAttribute("xmlns","http://www.w3.org");
-		$xml->addAttribute("version","1");
+		$xml->addAttribute("version",$this->getVersion());
 		$xml->addAttribute("name",$this->getName());
 
 		$last_style = null;
@@ -286,6 +294,42 @@ class ilSkinXML implements \Iterator, \Countable{
 	{
 		$this->styles = $styles;
 	}
+
+    /**
+     * @return string
+     */
+    public function getVersion()
+    {
+        return $this->version;
+    }
+
+    /**
+     * @param string $version
+     */
+    public function setVersion($version)
+    {
+        if($version != null && $version != '' && $this->isVersionChangeable()) {
+            $this->version = $version;
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getVersionStep($version)
+    {
+        if($this->isVersionChangeable()) {
+            $v = explode('.', ($version == "" ? '0.1' : $version));
+            $v[count($v) - 1] = ($v[count($v) - 1] + 1);
+            $this->version = implode('.', $v);
+        }
+        return $this->version;
+    }
+
+    public function isVersionChangeable()
+    {
+        return ($this->version != '$Id$');
+    }
 
 	/**
 	 * @param $style_id

--- a/Services/Style/System/test/fixtures/skins/customSkins/skin1/template.xml
+++ b/Services/Style/System/test/fixtures/skins/customSkins/skin1/template.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<template xmlns="http://www.w3.org" version="1" name="skin 1">
+<template xmlns="http://www.w3.org" version="0.1" name="skin 1">
   <style id="style1" name="Style 1" image_directory="style1image" css_file="style1css" sound_directory="style1sound" font_directory="style1font"/>
   <style id="style2" name="Style 2" image_directory="style2image" css_file="style2css" sound_directory="style2sound" font_directory="style2font"/>
 </template>

--- a/Services/Utilities/classes/class.ilUtil.php
+++ b/Services/Utilities/classes/class.ilUtil.php
@@ -218,6 +218,9 @@ class ilUtil
 		{
 			$vers = str_replace(" ", "-", $ilSetting->get("ilias_version"));
 			$vers = "?vers=".str_replace(".", "-", $vers);
+			// use version from template xml to force reload on changes
+            $skin = ilStyleDefinition::getSkins()[ilStyleDefinition::getCurrentSkin()];
+            $vers .= ($skin->getVersion() != '' ? str_replace(".", "-", '-' . $skin->getVersion()) : '');
 		}
 		return $filename . $vers;
 	}

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -50,7 +50,7 @@ lti#:#lti_released_objects#:#Objekt-Freigaben
 lti#:#lti_consumer#:#Released for
 orgu#:#orgu_global_set_form#:#Globale Einstellungen
 orgu#:#orgu_global_set_positions#:#Anzeige von Benutzerdaten nach Positionen in Organisationseinheiten
-orgu#:#orgu_global_set_positions_type_active#:#Positionen in 
+orgu#:#orgu_global_set_positions_type_active#:#Positionen in
 orgu#:#orgu_global_set_type_changeable#:#Verhalten neuer Objekte
 orgu#:#orgu_global_set_type_changeable_object#:#Änderbare Einstellung im Objekt
 orgu#:#orgu_global_set_type_changeable_no#:#Positionen sind im Objekt nicht deaktivierbar
@@ -1145,7 +1145,7 @@ assessment#:#finish_pass_for_user_confirmation#:#Wollen Sie wirklich den Test Du
 assessment#:#finish_pass_for_all_users#:#Wollen Sie wirklich die Test Durchläufe für alle Benutzer beenden?
 assessment#:#finish_all_user_passes#:#Alle Testdurchläufe beenden
 assessment#:#finish_unfinished_passes#:#Beendet noch offene Testdurchläufe
-assessment#:#finish_unfinished_passes_desc#:#Testdurchläufe, welche noch nicht beendet wurden, wo aber entweder ein Ende konfiguriert ist, oder welche die Maximale Bearbietungsdauer überschritten haben, werden beendet. 
+assessment#:#finish_unfinished_passes_desc#:#Testdurchläufe, welche noch nicht beendet wurden, wo aber entweder ein Ende konfiguriert ist, oder welche die Maximale Bearbietungsdauer überschritten haben, werden beendet.
 assessment#:#tst_general_properties#:#Einstellungen des Tests
 assessment#:#tst_heading_scoring#:#Bewertung
 assessment#:#tst_hide_side_list#:#Fragenliste aus
@@ -7351,7 +7351,7 @@ news#:#news_period_x_days#:#Letzte %s Tage
 news#:#news_period_x_months#:#Letzte %s Monate
 news#:#news_period_x_weeks#:#Letzte %s Wochen
 news#:#news_public_feed#:#Eigener Webfeed
-news#:#news_public_feed_info#:#Es wird ein RSS-Icon mit einer separaten Webfeed-URL angezeigt. 
+news#:#news_public_feed_info#:#Es wird ein RSS-Icon mit einer separaten Webfeed-URL angezeigt.
 news#:#news_rss_period#:#RSS-Zeitraum
 news#:#news_rss_title_format#:#RSS-Titelformat
 news#:#news_rss_title_format_news_obj#:#Nachrichtentitel (Objekttitel)
@@ -9087,7 +9087,7 @@ trac#:#trac_first_access#:#Erster Zugriff
 trac#:#trac_first_and_last_access#:#Erster und letzter Zugriff
 trac#:#trac_group_materials#:#Gruppierung mit optionalen Materialien erstellen
 trac#:#trac_group_materials_save#:#Anzahl verpflichtender Materialien speichern
-trac#:#trac_grouped_material_obligatory_err#:#Die Anzahl der obligatorischen Materialien muss größer als 0 sein und kleiner als die Anzahl der Materialien, die dieser Gruppierung zugeordnet sind. 
+trac#:#trac_grouped_material_obligatory_err#:#Die Anzahl der obligatorischen Materialien muss größer als 0 sein und kleiner als die Anzahl der Materialien, die dieser Gruppierung zugeordnet sind.
 trac#:#trac_hide#:#Ausblenden
 trac#:#trac_hide_selected#:#Ausgewählte Inhalte ausblenden
 trac#:#trac_in_progress#:#In Bearbeitung
@@ -10125,7 +10125,7 @@ ecs#:#ecs_cms_tree_synchronized#:#Der Baum wurde synchronisiert.
 rep#:#rep_activation_online_object_info#:#Diese Einstellung wirkt sich auf alle Referenzen im Repository aus.
 rep#:#rep_activation_access_ref_info#:#Dieses Einstellung betrifft nur die aktuelle und keine andere Referenz.
 poll#:#poll_block_results_available_on#:#Die Ergebnisse werden am %s veröffentlicht.
-survey#:#svy_activation_online_info#:#Nur wenn die Umfrage online ist, können Benutzer an der Umfrage teilnehmen. 
+survey#:#svy_activation_online_info#:#Nur wenn die Umfrage online ist, können Benutzer an der Umfrage teilnehmen.
 survey#:#svy_activation_limited_visibility_info#:#Außerhalb des angegebenen Zeitraums wird nur der Titel der Umfrage angezeigt, die Fragen sind nicht zugänglich.
 blog#:#blog_add_contributor#:#Mitwirkende hinzufügen
 common#:#il_blog_contributor#:#Blog-Autor
@@ -13368,6 +13368,7 @@ style#:#add_system_style#:#Neuer System Style
 style#:#add_substyle#:#Neuer Sub Style
 style#:#skin_id#:#Skin ID
 style#:#skin_name#:#Skin Name
+style#:#skin_version#:#Skin Version
 style#:#skin#:#Skin
 style#:#style_id#:#Style ID
 style#:#Style#:#Style
@@ -13444,6 +13445,7 @@ style#:#can_not_read_less_file#:#Less Datei kann nicht gelesen werden. Pfad:
 style#:#msg_sys_style_created#:#Die neue System Style Datei wurde erfolgreich erstellt.
 style#:#skin_id_description#:#Skins sind Behälter für Styles und Sub Styles. Die Skin ID setzt den Namen des Ordners, welcher alle Informationen zu Styles und Sub Styles beinhaltet. Die Skin ID darf sich nur aus Buchstaben, Nummern sowie Bindestrichen zusammensetzen.
 style#:#skin_name_description#:#Der Skin Name kann als Beschreibung für das Einsatzgebiet verwendet werden. Er wird in allen UI Elementen aufgelistet, in denen ein Skin ausgewählt werden kann.
+style#:#skin_version_description#:#Die Skin Version wird genutzt um die Styles, nach Änderungen, neu zu cachen. Sie wird automatisch aktualisiert.
 style#:#style_id_description#:#Die Style ID wird für Style-spezifische css- und less-Dateien unterhalb des Skin Ordners verwendet. Die Style ID darf sich nur aus Buchstaben, Nummern sowie Bindestrichen zusammensetzen.
 style#:#style_name_description#:#Der Style Name kann als Beschreibung für das Einsatzgebiet verwendet werden. Er wird in allen UI Elementen aufgelistet, in denen ein Skin ausgewählt werden kann.
 style#:#sub_style#:#Sub Style
@@ -13674,7 +13676,7 @@ chatroom#:#chat_osc_dont_accept_msg#:#Sie können aktuell von anderen Personen n
 chatroom#:#chat_osc_doesnt_accept_msg#:#Konversationen nicht möglich
 chatroom#:#chat_osc_subs_rej_msgs#:#Ihr Chat-Partner möchte zur Zeit keine Nachrichten empfangen. Er kann den Empfang von Chat-Nachrichten in seinen Chat-Einstellungen wieder aktivieren.
 chatroom#:#chat_osc_subs_rej_msgs_p#:#Die folgenden Konversationspartner möchten aktuell keine Nachrichten mehr empfangen: %s
-chatroom#:#chat_osc_self_rej_msgs#:#Sie können aktuell nicht an der Conversation teilnehmen, da Sie den Empfang von Chat-Nachrichten in Ihren Einstellungen aktuell unterdrückt haben. 
+chatroom#:#chat_osc_self_rej_msgs#:#Sie können aktuell nicht an der Conversation teilnehmen, da Sie den Empfang von Chat-Nachrichten in Ihren Einstellungen aktuell unterdrückt haben.
 usr#:#user_actions#:#Benutzeraktionen
 usr#:#user_action#:#Benuzteraktion
 chatroom#:#chtr_activation_online_info#:#Wählen Sie diese Einstellung, um den Chatraum für Benutzer verfügbar zumachen.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -13380,6 +13380,7 @@ style#:#add_system_style#:#Add System Style
 style#:#add_substyle#:#Add Sub Style
 style#:#skin_id#:#Skin ID
 style#:#skin_name#:#Skin Name
+style#:#skin_version#:#Skin Version
 style#:#skin#:#Skin
 style#:#style_id#:#Style ID
 style#:#Style#:#Style
@@ -13456,6 +13457,7 @@ style#:#can_not_read_less_file#:#Cannot read less file. Path:
 style#:#msg_sys_style_created#:#The new system style has successfully been created.
 style#:#skin_id_description#:#Skins are container for styles and sub styles. The skin ID sets the name of the folder that holds all style and sub style information. Only letters, numbers as well as hyphens or underline characters are to be used in skin ID's.
 style#:#skin_name_description#:#The skin name can be used to describe the area of application of the skin in human readable form. It will appear in all UI elements allowing the selection of skins.
+style#:#skin_version_description#:#The skin version is used to re-cache the style after changes. It gets automatically updated.
 style#:#style_id_description#:#The style id is used as name for style specific files such as css and less placed inside the skins folder. Only letters, numbers as well as hyphens or underline characters are to be used in style ID's.
 style#:#style_name_description#:#The style name can be used to describe the area of application of the style in human readable form. It will appear in all UI elements allowing the selection of styles.
 style#:#sub_style#:#Sub Style


### PR DESCRIPTION
A new PR according to decision of the JF (04 DEC 2017).
https://www.ilias.de/docu/goto.php?target=wiki_1357_JourFixe-2017-12-04#ilPageTocA2105
Bugfix of https://ilias.de/mantis/view.php?id=22151

With this bugfix, ilias uses the version of template.xml
to append the "?ver" parameter on the styles css src-string.
The versions dots will be replaced by hyphens, before
appending the "?ver" paramter.
In case of delos skin is in use, the string will not be
modified. In case you want not to use this feature just add
"$Id$" as version, like it is done at the delos template.xml.
Skins, that have the version "1", like before this bugfix
suggested, the number will simply count up. You may edit
this attribute any time you need in your skins template.xml.
Skins, created by the UI skin editor, will automatically get
the version "0.1" on creation.
The automatic update always count up the last part of the
version (0.[1]). The version may be any number of parts,
separated by dots. Example: 0.1.0.0.[2]
The skin version is shown, but not editable, at the skin
settings inside the UI skin editor. Any successfully save
in the skins' main, less, color or icon settings, will
trigger the version update. So we are able to guarantee the
upadete on any change of the skin.