### PR TITLE
Bugfix #0022151 - Fixed css caching in custom skins (ILIAS 5.2)

### DIFF
--- a/Services/Style/System/classes/Icons/class.ilSystemStyleIconsGUI.php
+++ b/Services/Style/System/classes/Icons/class.ilSystemStyleIconsGUI.php
@@ -278,6 +278,9 @@ class  ilSystemStyleIconsGUI
 			}
 			$this->getIconFolder()->changeIconColors($color_changes);
 			$this->setIconFolder(new ilSystemStyleIconFolder($this->getStyleContainer()->getImagesSkinPath($_GET["style_id"])));
+            $skin = $this->getStyleContainer()->getSkin();
+            $skin->getVersionStep($skin->getVersion());
+            $this->getStyleContainer()->updateSkin($skin);
 			$message_stack->sendMessages(true);
 			$this->ctrl->redirect($this,"edit");
 		}
@@ -439,6 +442,14 @@ class  ilSystemStyleIconsGUI
 			}
 
 
+			foreach ($message_stack->getJoinedMessages() as $type => $message) {
+			    if($type == ilSystemStyleMessage::TYPE_SUCCESS) {
+                    $skin = $this->getStyleContainer()->getSkin();
+                    $skin->getVersionStep($skin->getVersion());
+                    $this->getStyleContainer()->updateSkin($skin);
+			        continue;
+                }
+            }
 			$message_stack->sendMessages(true);
 			$this->ctrl->setParameter($this,"selected_icon",$icon->getName());
 			$this->ctrl->redirect($this,"editIcon");

--- a/Services/Style/System/classes/Less/class.ilSystemStyleLessGUI.php
+++ b/Services/Style/System/classes/Less/class.ilSystemStyleLessGUI.php
@@ -295,6 +295,9 @@ class ilSystemStyleLessGUI
 			try{
 				$this->getLessFile()->write();
 				$this->getStyleContainer()->compileLess($_GET["style_id"]);
+				$skin = $this->getStyleContainer()->getSkin();
+				$skin->getVersionStep($skin->getVersion());
+				$this->getStyleContainer()->updateSkin($skin);
 				ilUtil::sendSuccess($this->lng->txt("less_file_updated"));
 			}catch(Exception $e){
 				ilUtil::sendFailure($this->lng->txt($e->getMessage()),true);

--- a/Services/Style/System/classes/Settings/class.ilSystemStyleSettingsGUI.php
+++ b/Services/Style/System/classes/Settings/class.ilSystemStyleSettingsGUI.php
@@ -202,6 +202,7 @@ class ilSystemStyleSettingsGUI
 		$new_skin = $container->getSkin();
 		$new_skin->setId($_POST["skin_id"]);
 		$new_skin->setName($_POST["skin_name"]);
+		$new_skin->getVersionStep($_POST['skin_version']);
 
 		$new_style = $new_skin->getStyle($_GET["style_id"]);
 		$new_style->setId($_POST["style_id"]);
@@ -316,6 +317,13 @@ class ilSystemStyleSettingsGUI
 			$ti->setSize(40);
 			$ti->setRequired(true);
 			$form->addItem($ti);
+
+			if($skin->isVersionChangeable()) {
+                $ti = new ilNonEditableValueGUI($this->lng->txt("skin_version"), "skin_version");
+                $ti->setInfo($this->lng->txt("skin_version_description"));
+                $ti->setValue($skin->getVersion());
+                $form->addItem($ti);
+            }
 
 			$section = new ilFormSectionHeaderGUI();
 			$section->setTitle($this->lng->txt("style"));

--- a/Services/Style/System/classes/Utilities/class.ilSkinXML.php
+++ b/Services/Style/System/classes/Utilities/class.ilSkinXML.php
@@ -33,6 +33,13 @@ class ilSkinXML implements \Iterator, \Countable{
 	 */
 	protected $styles = array();
 
+    /**
+     * Version of skin, as provided by the template
+     *
+     * @var string
+     */
+	protected $version = "0.1";
+
 
 	/**
 	 * ilSkinXML constructor.
@@ -58,6 +65,7 @@ class ilSkinXML implements \Iterator, \Countable{
 
 		$id = basename (dirname($path));
 		$skin = new self($id,(string)$xml->attributes()["name"]);
+        $skin->setVersion((string)$xml->attributes()["version"]);
 
 		/**
 		 * @var ilSkinStyleXML $last_style
@@ -93,7 +101,7 @@ class ilSkinXML implements \Iterator, \Countable{
 	public function asXML(){
 		$xml = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><template/>');
 		$xml->addAttribute("xmlns","http://www.w3.org");
-		$xml->addAttribute("version","1");
+		$xml->addAttribute("version",$this->getVersion());
 		$xml->addAttribute("name",$this->getName());
 
 		$last_style = null;
@@ -286,6 +294,42 @@ class ilSkinXML implements \Iterator, \Countable{
 	{
 		$this->styles = $styles;
 	}
+
+    /**
+     * @return string
+     */
+    public function getVersion()
+    {
+        return $this->version;
+    }
+
+    /**
+     * @param string $version
+     */
+    public function setVersion($version)
+    {
+        if($version != null && $version != '' && $this->isVersionChangeable()) {
+            $this->version = $version;
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getVersionStep($version)
+    {
+        if($this->isVersionChangeable()) {
+            $v = explode('.', ($version == "" ? '0.1' : $version));
+            $v[count($v) - 1] = ($v[count($v) - 1] + 1);
+            $this->version = implode('.', $v);
+        }
+        return $this->version;
+    }
+
+    public function isVersionChangeable()
+    {
+        return ($this->version != '$Id$');
+    }
 
 	/**
 	 * @param $style_id

--- a/Services/Style/System/test/fixtures/skins/customSkins/skin1/template.xml
+++ b/Services/Style/System/test/fixtures/skins/customSkins/skin1/template.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<template xmlns="http://www.w3.org" version="1" name="skin 1">
+<template xmlns="http://www.w3.org" version="0.1" name="skin 1">
   <style id="style1" name="Style 1" image_directory="style1image" css_file="style1css" sound_directory="style1sound" font_directory="style1font"/>
   <style id="style2" name="Style 2" image_directory="style2image" css_file="style2css" sound_directory="style2sound" font_directory="style2font"/>
 </template>

--- a/Services/Utilities/classes/class.ilUtil.php
+++ b/Services/Utilities/classes/class.ilUtil.php
@@ -202,6 +202,9 @@ class ilUtil
 		{
 			$vers = str_replace(" ", "-", $ilias->getSetting("ilias_version"));
 			$vers = "?vers=".str_replace(".", "-", $vers);
+			// use version from template xml to force reload on changes
+            $skin = ilStyleDefinition::getSkins()[ilStyleDefinition::getCurrentSkin()];
+            $vers .= ($skin->getVersion() != '' ? str_replace(".", "-", '-' . $skin->getVersion()) : '');
 		}
 		return $filename . $vers;
 	}

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -15583,6 +15583,7 @@ style#:#add_system_style#:#Neuer System Style
 style#:#add_substyle#:#Neuer Substyle
 style#:#skin_id#:#Skin-ID
 style#:#skin_name#:#Skin Name
+style#:#skin_version#:#Skin Version
 style#:#skin#:#Skin
 style#:#style_id#:#Style-ID
 style#:#Style#:#Style
@@ -15658,6 +15659,7 @@ style#:#can_not_read_less_file#:#Less Datei kann nicht gelesen werden. Pfad:
 style#:#msg_sys_style_created#:#Die neue System Style Datei wurde erfolgreich erstellt.
 style#:#skin_id_description#:#Skins sind Behälter für Styles und Substyles. Die Skin-ID setzt den Namen des Ordners, welcher alle Informationen zu Styles und Substyles beinhaltet. Die Skin-ID darf sich nur aus Buchstaben, Nummern sowie Bindestrichen zusammensetzen.
 style#:#skin_name_description#:#Der Skin Name kann als Beschreibung für das Einsatzgebiet verwendet werden. Er wird in allen UI Elementen aufgelistet, in denen ein Skin ausgewählt werden kann.
+style#:#skin_version_description#:#Die Skin Version wird genutzt um die Styles, nach Änderungen, neu zu cachen. Sie wird automatisch aktualisiert.
 style#:#style_id_description#:#Die Style-ID wird für Style-spezifische css- und less-Dateien unterhalb des Skin Ordners verwendet. Die Style-ID darf sich nur aus Buchstaben, Nummern sowie Bindestrichen zusammensetzen.
 style#:#style_name_description#:#Der Style Name kann als Beschreibung für das Einsatzgebiet verwendet werden. Er wird in allen UI Elementen aufgelistet, in denen ein Skin ausgewählt werden kann.
 style#:#sub_style#:#Substyle

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -15591,6 +15591,7 @@ style#:#add_system_style#:#Add System Style
 style#:#add_substyle#:#Add Sub Style
 style#:#skin_id#:#Skin ID
 style#:#skin_name#:#Skin Name
+style#:#skin_version#:#Skin Version
 style#:#skin#:#Skin
 style#:#style_id#:#Style ID
 style#:#Style#:#Style
@@ -15666,6 +15667,7 @@ style#:#can_not_read_less_file#:#Cannot read less file. Path:
 style#:#msg_sys_style_created#:#The new system style has successfully been created.
 style#:#skin_id_description#:#Skins are container for styles and sub styles. The skin ID sets the name of the folder that holds all style and sub style information. Only letters, numbers as well as hyphens or underline characters are to be used in skin ID's.
 style#:#skin_name_description#:#The skin name can be used to describe the area of application of the skin in human readable form. It will appear in all UI elements allowing the selection of skins.
+style#:#skin_version_description#:#The skin version is used to re-cache the style after changes. It gets automatically updated.
 style#:#style_id_description#:#The style id is used as name for style specific files such as css and less placed inside the skins folder. Only letters, numbers as well as hyphens or underline characters are to be used in style ID's.
 style#:#style_name_description#:#The style name can be used to describe the area of application of the style in human readable form. It will appear in all UI elements allowing the selection of styles.
 style#:#sub_style#:#Sub Style


### PR DESCRIPTION
A new PR according to decision of the JF (04 DEC 2017).
https://www.ilias.de/docu/goto.php?target=wiki_1357_JourFixe-2017-12-04#ilPageTocA2105
Bugfix of https://ilias.de/mantis/view.php?id=22151

With this bugfix, ilias uses the version of template.xml
to append the "?ver" parameter on the styles css src-string.
The versions dots will be replaced by hyphens, before
appending the "?ver" paramter.
In case of delos skin is in use, the string will not be
modified. In case you want not to use this feature just add
"$Id$" as version, like it is done at the delos template.xml.
Skins, that have the version "1", like before this bugfix
suggested, the number will simply count up. You may edit
this attribute any time you need in your skins template.xml.
Skins, created by the UI skin editor, will automatically get
the version "0.1" on creation.
The automatic update always count up the last part of the
version (0.[1]). The version may be any number of parts,
separated by dots. Example: 0.1.0.0.[2]
The skin version is shown, but not editable, at the skin
settings inside the UI skin editor. Any successfully save
in the skins' main, less, color or icon settings, will
trigger the version update. So we are able to guarantee the
upadete on any change of the skin.