### PR TITLE
Test: Fixed #22267

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestion.php
@@ -1100,8 +1100,17 @@ class assFormulaQuestion extends assQuestion implements iQuestionCondition
 			AND value1 like '\$r%'
 			AND value2 is not null
 			AND value2 <> ''
+		";
+
+		if( $this->getStep() !== NULL )
+		{
+			$query .= " AND step = " . $ilDB->quote((int)$this->getStep(), 'integer') . " ";
+		}
+
+		$query .= "
 			GROUP BY authorized
 		";
+
 		$result = $ilDB->query($query);
 
 		while ($row = $ilDB->fetchAssoc($result))
@@ -1136,6 +1145,11 @@ class assFormulaQuestion extends assQuestion implements iQuestionCondition
 			AND pass = " .$ilDB->quote($pass, 'integer') ."
 			AND value1 like '\$r%'
 		";
+
+		if( $this->getStep() !== NULL )
+		{
+			$query .= " AND step = " . $ilDB->quote((int)$this->getStep(), 'integer') . " ";
+		}
 
 		return $ilDB->manipulate($query);
 	}

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestion.php
@@ -994,8 +994,20 @@ class assFormulaQuestion extends assQuestion implements iQuestionCondition
 				$matches = null;
 				if(preg_match("/^result_(\\\$r\\d+)$/", $key, $matches))
 				{
-					if(strlen($value)) $entered_values = TRUE;
-					$result = $ilDB->queryF("SELECT solution_id FROM tst_solutions WHERE active_fi = %s AND pass = %s AND question_fi = %s AND authorized = %s  AND " . $ilDB->like('value1', 'clob', $matches[1]),
+					if(strlen($value))
+					{
+						$entered_values = TRUE;
+					}
+
+					$queryResult = "SELECT solution_id FROM tst_solutions WHERE active_fi = %s AND pass = %s AND question_fi = %s AND authorized = %s  AND " . $ilDB->like('value1', 'clob', $matches[1]);
+
+					if( $this->getStep() !== NULL )
+					{
+						$queryResult .= " AND step = " . $ilDB->quote((int)$this->getStep(), 'integer') . " ";
+					}
+
+					$result = $ilDB->queryF(
+						$queryResult,
 						array('integer', 'integer', 'integer', 'integer'),
 						array($active_id, $pass, $this->getId(), (int)$authorized)
 					);
@@ -1014,7 +1026,15 @@ class assFormulaQuestion extends assQuestion implements iQuestionCondition
 				}
 				else if(preg_match("/^result_(\\\$r\\d+)_unit$/", $key, $matches))
 				{
-					$result = $ilDB->queryF("SELECT solution_id FROM tst_solutions WHERE active_fi = %s AND pass = %s AND question_fi = %s AND authorized = %s AND " . $ilDB->like('value1', 'clob', $matches[1] . "_unit"),
+					$queryResultUnit = "SELECT solution_id FROM tst_solutions WHERE active_fi = %s AND pass = %s AND question_fi = %s AND authorized = %s AND " . $ilDB->like('value1', 'clob', $matches[1] . "_unit");
+
+					if( $this->getStep() !== NULL )
+					{
+						$queryResultUnit .= " AND step = " . $ilDB->quote((int)$this->getStep(), 'integer') . " ";
+					}
+
+					$result = $ilDB->queryF(
+						$queryResultUnit,
 						array('integer', 'integer', 'integer', 'integer'),
 						array($active_id, $pass, $this->getId(), (int)$authorized)
 					);

--- a/Modules/TestQuestionPool/classes/class.assLongMenu.php
+++ b/Modules/TestQuestionPool/classes/class.assLongMenu.php
@@ -726,8 +726,17 @@ class assLongMenu extends assQuestion implements ilObjQuestionScoringAdjustable
 			AND question_fi = ". $ilDB->quote($this->getId(), 'integer') ."
 			AND pass = " .$ilDB->quote($pass, 'integer') ."
 			AND value2 <> '-1'
+		";
+
+		if( $this->getStep() !== NULL )
+		{
+			$query .= " AND step = " . $ilDB->quote((int)$this->getStep(), 'integer') . " ";
+		}
+
+		$query .= "
 			GROUP BY authorized
 		";
+
 		$result = $ilDB->query($query);
 
 		while ($row = $ilDB->fetchAssoc($result))

--- a/Modules/TestQuestionPool/classes/class.assQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assQuestion.php
@@ -4979,7 +4979,12 @@ abstract class assQuestion
 			'active_fi' => array('integer', $activeId),
 			'pass' => array('integer', $pass)
 		);
-		
+
+		if( $this->getStep() !== NULL )
+		{
+			$whereData['step'] = array("integer", $this->getStep());
+		}
+
 		return $ilDB->update('tst_solutions', $fieldData, $whereData);
 	}
 	// fau.

--- a/Modules/TestQuestionPool/classes/class.assQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assQuestion.php
@@ -5222,7 +5222,7 @@ abstract class assQuestion
 
 		if( $this->getStep() !== NULL )
 		{
-			$query .= " AND step = %s " . $ilDB->quote((int)$this->getStep(), 'integer') . " ";
+			$query .= " AND step = " . $ilDB->quote((int)$this->getStep(), 'integer') . " ";
 		}
 
 		$query .= "
@@ -5256,6 +5256,11 @@ abstract class assQuestion
 			AND pass = %s
 		";
 
+		if( $this->getStep() !== NULL )
+		{
+			$query .= " AND step = " . $ilDB->quote((int)$this->getStep(), 'integer') . " ";
+		}
+
 		return $ilDB->manipulateF($query, array('integer', 'integer', 'integer'),
 			array($activeId, $this->getId(), $pass)
 		);
@@ -5281,7 +5286,12 @@ abstract class assQuestion
 			AND question_fi = %s
 			AND pass = %s
 		";
-		
+
+		if( $this->getStep() !== NULL )
+		{
+			$query .= " AND step = " . $ilDB->quote((int)$this->getStep(), 'integer') . " ";
+		}
+
 		return $ilDB->manipulateF($query, array('integer', 'integer', 'integer'),
 			array($activeId, $this->getId(), $pass)
 		);

--- a/Modules/TestQuestionPool/classes/class.assQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assQuestion.php
@@ -5204,6 +5204,7 @@ abstract class assQuestion
 	 */
 	public function lookupForExistingSolutions($activeId, $pass)
 	{
+		/** @var $ilDB \ilDBInterface  */
 		global $ilDB;
 
 		$return = array(
@@ -5217,8 +5218,17 @@ abstract class assQuestion
 			WHERE active_fi = %s
 			AND question_fi = %s
 			AND pass = %s
+		";
+
+		if( $this->getStep() !== NULL )
+		{
+			$query .= " AND step = %s " . $ilDB->quote((int)$this->getStep(), 'integer') . " ";
+		}
+
+		$query .= "
 			GROUP BY authorized
 		";
+
 		$result = $ilDB->queryF($query, array('integer', 'integer', 'integer'), array($activeId, $this->getId(), $pass));
 
 		while ($row = $ilDB->fetchAssoc($result))


### PR DESCRIPTION
ILIAS >= 5.2.x does not respect the "step" state (in particular methods) when operating on questions for pass/active_id cases.

See: https://www.ilias.de/mantis/view.php?id=22267