### PR TITLE
Roundtrip modal interface: cancel button with custom label.

### DIFF
--- a/src/UI/Component/Modal/RoundTrip.php
+++ b/src/UI/Component/Modal/RoundTrip.php
@@ -48,4 +48,13 @@ interface RoundTrip extends Modal {
 	 * @return RoundTrip
 	 */
 	public function withActionButtons(array $buttons);
+
+	/**
+	 * Get the modal like this with the provided cancel button string.
+	 * The closing button has "Cancel" by default
+	 *
+	 * @param string $label
+	 * @return RoundTrip
+	 */
+	public function withCancelButtonLabel($label);
 }

--- a/src/UI/Factory.php
+++ b/src/UI/Factory.php
@@ -335,7 +335,9 @@ interface Factory {
 	 *     3: Modals SHOULD not be used to perform complex workflows.
 	 *     4: Modals MUST be closable by a little “x”-button on the right side of the header.
 	 *     5: Modals MUST contain a title in the header.
-	 * ---
+	 *   wording: >
+	 *     The label of the Button used to close the Round-Trip-Modal MAY be adapted, if the default label (cancel)
+	 *     does not fit the workflow presented on the screen.
 	 *
 	 * @return \ILIAS\UI\Component\Modal\Factory
 	 **/

--- a/src/UI/Factory.php
+++ b/src/UI/Factory.php
@@ -335,9 +335,10 @@ interface Factory {
 	 *     3: Modals SHOULD not be used to perform complex workflows.
 	 *     4: Modals MUST be closable by a little “x”-button on the right side of the header.
 	 *     5: Modals MUST contain a title in the header.
-	 *   wording: >
-	 *     The label of the Button used to close the Round-Trip-Modal MAY be adapted, if the default label (cancel)
-	 *     does not fit the workflow presented on the screen.
+	 *   wording:
+	 *     1: >
+	 *       The label of the Button used to close the Round-Trip-Modal MAY be adapted, if the default label (cancel)
+	 *       does not fit the workflow presented on the screen.
 	 *
 	 * @return \ILIAS\UI\Component\Modal\Factory
 	 **/

--- a/src/UI/Implementation/Component/Modal/RoundTrip.php
+++ b/src/UI/Implementation/Component/Modal/RoundTrip.php
@@ -89,4 +89,14 @@ class RoundTrip extends Modal implements Component\Modal\RoundTrip {
 	public function getCancelButtonLabel() {
 		return $this->cancel_button_label;
 	}
+
+	/**
+	 * @param string $label
+	 * @return RoundTrip
+	 */
+	public function withCancelButtonLabel($label) {
+		$clone = clone $this;
+		$clone->cancel_button_label = $label;
+		return $clone;
+	}
 }


### PR DESCRIPTION
Bug report: https://www.ilias.de/mantis/view.php?id=22351
Currently the "close" button shown in the Round-Trip-Modal that opens if an appointment is clicked in the calendar, is labeled "Cancel", which implicates, that something is done here. However,  sometimes there is nothing really to do inside this modal, so another string will fit better.