### PR TITLE
UI: Dropzone Wrapper withTitle

### DIFF
--- a/src/UI/Component/Dropzone/File/Wrapper.php
+++ b/src/UI/Component/Dropzone/File/Wrapper.php
@@ -15,6 +15,22 @@ use ILIAS\UI\Component\Component;
  * @package ILIAS\UI\Component\Dropzone\File
  */
 interface Wrapper extends File {
+	/**
+	 * Get a wrapper dropzone like this, but showing a custom title in the appearing modal.
+	 *
+	 * @param Component[]|Component $content
+	 *
+	 * @return $this
+	 */
+	public function withTitle($title);
+
+
+	/**
+	 * Get the custom title if set.
+	 *
+	 * @return Component[]
+	 */
+	public function getTitle();
 
 	/**
 	 * Get a wrapper dropzone like this, wrapping around the given component(s).

--- a/src/UI/Implementation/Component/Dropzone/File/Renderer.php
+++ b/src/UI/Implementation/Component/Dropzone/File/Renderer.php
@@ -115,7 +115,11 @@ class Renderer extends AbstractComponentRenderer {
 		// Create the roundtrip modal which displays the uploaded files
 		$tplUploadFileList = $this->getFileListTemplate($dropzone);
 		$uploadButton = $this->getUIFactory()->button()->primary($this->txt('upload'), '')->withUnavailableAction();
-		$modal = $this->getUIFactory()->modal()->roundtrip($this->txt('upload'), $this->getUIFactory()->legacy($tplUploadFileList->get()))->withActionButtons([ $uploadButton ]);
+		$title = $dropzone->getTitle();
+		if(!$title){
+			$title = $this->txt('upload');
+		}
+		$modal = $this->getUIFactory()->modal()->roundtrip($title, $this->getUIFactory()->legacy($tplUploadFileList->get()))->withActionButtons([ $uploadButton ]);
 
 		// Register JS
 		$dropzone = $dropzone->withAdditionalDrop($modal->getShowSignal());

--- a/src/UI/Implementation/Component/Dropzone/File/Wrapper.php
+++ b/src/UI/Implementation/Component/Dropzone/File/Wrapper.php
@@ -46,6 +46,23 @@ class Wrapper extends File implements \ILIAS\UI\Component\Dropzone\File\Wrapper 
 		return $clone;
 	}
 
+	/**
+	 * @inheritdoc
+	 */
+	public function withTitle($title) {
+		$this->checkStringArg("title", $title);
+		$clone = clone $this;
+		$clone->title = $title;
+
+		return $clone;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getTitle() {
+		return $this->title;
+	}
 
 	/**
 	 * @inheritDoc


### PR DESCRIPTION
Currently it is not possible to adapt the title of the round trip modal apearing if the wrapper dropzone is used. However often it is good to give this upload window a more precise name than just "Upload" (e.g. Upload to Folter XY). With this PR we propose an option to custimize this title.