### PR TITLE
#22369 add a constant size for images in the copy object process

### DIFF
--- a/Services/Object/templates/default/tpl.obj_copy_selection_row.html
+++ b/Services/Object/templates/default/tpl.obj_copy_selection_row.html
@@ -2,7 +2,7 @@
 	<td style="padding: 8px" class="std">
 		<!-- BEGIN obj_icon -->
 		<!-- BEGIN padding --><div style="padding-left: 22px"><!-- END padding -->
-		<img src="{TREE_IMG}" style="vertical-align:middle;" alt="{TREE_ALT_IMG}" title="{TREE_ALT_IMG}" border="0" vspace="0" />&nbsp;{TREE_TITLE}
+		<img src="{TREE_IMG}" style="vertical-align:middle;width:32px;height:32px;" alt="{TREE_ALT_IMG}" title="{TREE_ALT_IMG}" border="0" vspace="0" />&nbsp;{TREE_TITLE}
 		<!-- BEGIN end_padding --></div><!-- END end_padding -->
 		<!-- END obj_icon -->
 	</td>


### PR DESCRIPTION
mantis_22369
Add a constant size for images in the copy object process.
Prevent displaying huge images.
  