### PR TITLE
0022370: Creating MediaCast and opening settings result in Fatal Error

### DIFF
--- a/Modules/MediaCast/classes/class.ilObjMediaCastGUI.php
+++ b/Modules/MediaCast/classes/class.ilObjMediaCastGUI.php
@@ -1181,7 +1181,7 @@ class ilObjMediaCastGUI extends ilObjectGUI
 		
 		$lng->loadLanguageModule("mcst");
 		
-		include("Services/Form/classes/class.ilPropertyFormGUI.php");
+		require_once("Services/Form/classes/class.ilPropertyFormGUI.php");
 		$this->form_gui = new ilPropertyFormGUI();
 		$this->form_gui->setTitle($lng->txt("mcst_settings"));
 		


### PR DESCRIPTION
The include statement doesn't necessarily lead to an error, but it can if there is a UIHook plugin which uses ilPropertyFormGUI. In that case, the plugin imports the ilPropertyFormGUI before the ilObjMeidaCastGUI does and since it's an not a ".._once", a fatal error appears.