### PR TITLE
LTI: FIXED #22401 LTI Mode: Missing breadcrump navigation

### DIFF
--- a/Services/LTI/classes/class.ilLTIViewGUI.php
+++ b/Services/LTI/classes/class.ilLTIViewGUI.php
@@ -58,7 +58,7 @@ class ilLTIViewGUI
 	/**
 	 * public variables
 	 */
-	public $home_is_container = false;
+	public $show_locator = true;
 	public $member_view = false;
 	public $member_view_url = "";
 	public $member_view_close_txt = "";
@@ -190,7 +190,7 @@ class ilLTIViewGUI
 		if ($this->home_type === '') 
 		{
 			$this->home_type = ilObject::_lookupType($this->home_id,true);
-			$this->home_is_container = $this->isContainer($this->home_type);
+			$this->show_locator = $this->showLocator($this->home_type);
 		}
 		if ($this->home_url === '') 
 		{
@@ -408,9 +408,9 @@ class ilLTIViewGUI
 	/**
 	 * @return bool
 	 */
-	private function isContainer($obj_type) {
+	private function showLocator($obj_type) {
 		//return true;
-		return preg_match("/(crs|grp|cat|root|fold)/",$obj_type);
+		return preg_match("/(crs|grp|cat|root|fold|lm)/",$obj_type);
 	}
 	
 	/**

--- a/Services/Locator/classes/class.ilLocatorGUI.php
+++ b/Services/Locator/classes/class.ilLocatorGUI.php
@@ -294,7 +294,7 @@ class ilLocatorGUI
 	{
 		global $DIC;
 		$ltiview = $DIC["lti"];
-		if ($ltiview->isActive() && !$ltiview->home_is_container) 
+		if ($ltiview->isActive() && !$ltiview->show_locator)
 		{
  			return "";
  		}


### PR DESCRIPTION
The Locator should not only be displayed always in container objects but also in ILIAS LMs for chapter and page navigation. We should shortly discuss for which objects we also should enable the breadcrump navigation. In the LM the root of the locator is currently altered to the LM object itself, and the ".. > PARENT_NODE" is removed. Maybe we don't need this, but i think a LTI content module module should not get any breadcrump nav or at least with a root node to itself.