### PR TITLE
[FIX] 0022406: Fix abstract method implementation of calendar jobs

### DIFF
--- a/Services/Calendar/classes/BackgroundTasks/class.ilCalendarCopyFilesToTempDirectoryJob.php
+++ b/Services/Calendar/classes/BackgroundTasks/class.ilCalendarCopyFilesToTempDirectoryJob.php
@@ -62,8 +62,13 @@ class ilCalendarCopyFilesToTempDirectoryJob extends AbstractJob
 
 	/**
 	 * run the job
-	 * @param Value $input
+	 *
+	 * @param array $input
 	 * @param Observer $observer
+	 *
+	 * @return StringValue
+	 *
+	 * @throws \ILIAS\BackgroundTasks\Exceptions\InvalidArgumentException
 	 */
 	public function run(array $input, Observer $observer)
 	{
@@ -151,7 +156,7 @@ class ilCalendarCopyFilesToTempDirectoryJob extends AbstractJob
 	/**
 	 * @inheritdoc
 	 */
-	public function getExpectedTimeOfTaksInSeconds() {
+	public function getExpectedTimeOfTaskInSeconds() {
 		return 30;
 	}
 }

--- a/Services/Calendar/classes/BackgroundTasks/class.ilCalendarZipJob.php
+++ b/Services/Calendar/classes/BackgroundTasks/class.ilCalendarZipJob.php
@@ -75,7 +75,7 @@ class ilCalendarZipJob extends AbstractJob
 	/**
 	 * @inheritdoc
 	 */
-	public function getExpectedTimeOfTaksInSeconds() {
+	public function getExpectedTimeOfTaskInSeconds() {
 		return 30;
 	}
 }


### PR DESCRIPTION
This PR proposes a fix for the reported error by lauener in [22406](https://www.ilias.de/mantis/view.php?id=22406)

Content:
* Fixed typo in Calendar job classes.
* Small comment adjustment.

Please note that this PR won't solve the originally reported issue of the ticket. But the reported error in the comment section bellow.