### PR TITLE
0022441: Fatal Error when creating WebFeed

### DIFF
--- a/Services/Block/classes/class.ilExternalFeedBlockGUI.php
+++ b/Services/Block/classes/class.ilExternalFeedBlockGUI.php
@@ -466,7 +466,7 @@ class ilExternalFeedBlockGUI extends ilExternalFeedBlockGUIGen
 		
 		$lng->loadLanguageModule("block");
 		
-		include("Services/Form/classes/class.ilPropertyFormGUI.php");
+		require_once("Services/Form/classes/class.ilPropertyFormGUI.php");
 		
 		$this->form_gui = new ilPropertyFormGUI();
 		

--- a/Services/Block/classes/class.ilExternalFeedBlockGUIGen.php
+++ b/Services/Block/classes/class.ilExternalFeedBlockGUIGen.php
@@ -207,7 +207,7 @@ abstract class ilExternalFeedBlockGUIGen extends ilBlockGUI
 		
 		$lng->loadLanguageModule("block");
 		
-		include("Services/Form/classes/class.ilPropertyFormGUI.php");
+		require_once("Services/Form/classes/class.ilPropertyFormGUI.php");
 		
 		$this->form_gui = new ilPropertyFormGUI();
 		

--- a/Services/Feeds/classes/class.ilPDExternalFeedBlockGUI.php
+++ b/Services/Feeds/classes/class.ilPDExternalFeedBlockGUI.php
@@ -396,7 +396,7 @@ class ilPDExternalFeedBlockGUI extends ilExternalFeedBlockGUIGen
 		
 		$lng->loadLanguageModule("block");
 		
-		include("Services/Form/classes/class.ilPropertyFormGUI.php");
+		require_once("Services/Form/classes/class.ilPropertyFormGUI.php");
 		
 		$this->form_gui = new ilPropertyFormGUI();
 		


### PR DESCRIPTION
The include statement doesn't necessarily lead to an error, but it can if there is a UIHook plugin which uses ilPropertyFormGUI. In that case, the plugin imports the ilPropertyFormGUI before the WebFeed does and since it's an not a ".._once", a fatal error appears.