### PR TITLE
fixed mantis #22326

### DIFF
--- a/Services/Export/classes/class.ilImport.php
+++ b/Services/Export/classes/class.ilImport.php
@@ -292,6 +292,15 @@ class ilImport
 			$comp = $expfile["component"];
 			$class = ilImportExportFactory::getImporterClass($comp);
 
+			// log a warning for inactive page component plugins, but continue import
+			// page content will be imported, but not its additional data
+			// (other plugins throw an exception in ilImportExportFactory)
+			if ($class == '')
+			{
+				$this->log->warning("no class found for component: $comp");
+				continue;
+			}
+
 			$this->log->debug("create new class = $class");
 
 			$this->importer = new $class();

--- a/Services/Export/classes/class.ilImportExportFactory.php
+++ b/Services/Export/classes/class.ilImportExportFactory.php
@@ -70,7 +70,14 @@ class ilImportExportFactory
 			return $objDefinition->getComponentForType($a_type);
 		}		
 	}
-	
+
+	/**
+	 * Get the importer class of a component
+	 *
+	 * @param string $a_component	component
+	 * @return string	class name of the importer class (or empty if the importer should be ignored)
+	 * @throws	InvalidArgumentException	the importer class is not found but should not be ignored
+	 */
 	public static function getImporterClass($a_component)
 	{
 		/**
@@ -96,14 +103,19 @@ class ilImportExportFactory
 		{							
 			$class = "il".$component."Importer";
 
-			// page component plugin importer classes are already included
-			// the component is not registered by ilObjDefinition
+			// treat special case of page component plugins
+			// they are imported with component type PLUGINS_DIR
+			// but are not yet recognized by ilObjDefinition::isPlugin()
+			//
+			// if they are active, then their importer class is already included by ilCOPageImporter::init()
 			if (class_exists($class))
 			{
 				return $class;
 			}
 			// the page component plugin is not installed or not active
-			elseif ($component_type == 'Plugins')
+			// return an empty class name instead of throwing an exception
+			// in this case the import should be continued without treating the page component
+			elseif ($component_type == self::PLUGINS_DIR)
 			{
 				return "";
 			}

--- a/Services/Export/classes/class.ilImportExportFactory.php
+++ b/Services/Export/classes/class.ilImportExportFactory.php
@@ -102,6 +102,11 @@ class ilImportExportFactory
 			{
 				return $class;
 			}
+			// the page component plugin is not installed or not active
+			elseif ($component_type == 'Plugins')
+			{
+				return "";
+			}
 
 			if (is_file ("./".$a_component."/classes/class.".$class.".php"))
 			{


### PR DESCRIPTION
A quick fix to enable import of pages with plugged page components when the page component plugin is not installed or active. The page content will be imported, but no additional data needed by the plugin.