### PR TITLE
Bugfix 22440

### DIFF
--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1414,7 +1414,14 @@ class ilInitialisation
 		}
 		
 		self::initGlobal("tpl", $tpl);
-		
+
+		if (ilContext::hasUser() && ilContext::doAuthentication()) {
+			require_once 'Services/User/classes/class.ilUserRequestTargetAdjustment.php';
+			$request_adjuster = new ilUserRequestTargetAdjustment($ilUser, $GLOBALS['DIC']['ilCtrl']);
+			$request_adjuster->adjust();
+		}
+
+
 		// load style sheet depending on user's settings
 		$location_stylesheet = ilUtil::getStyleSheetLocation();
 		$tpl->setVariable("LOCATION_STYLESHEET",$location_stylesheet);				
@@ -1769,10 +1776,6 @@ class ilInitialisation
 			ilInitialisation::goToPublicSection();
 			return true;
 		}
-		
-		require_once 'Services/User/classes/class.ilUserRequestTargetAdjustment.php';
-		$request_adjuster = new ilUserRequestTargetAdjustment($ilUser, $GLOBALS['ilCtrl']);
-		$request_adjuster->adjust(); // possible redirect
 
 		// for password change and incomplete profile 
 		// see ilPersonalDesktopGUI

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1415,7 +1415,7 @@ class ilInitialisation
 		
 		self::initGlobal("tpl", $tpl);
 
-		if (ilContext::hasUser() && ilContext::doAuthentication()) {
+		if (ilContext::hasUser()) {
 			require_once 'Services/User/classes/class.ilUserRequestTargetAdjustment.php';
 			$request_adjuster = new ilUserRequestTargetAdjustment($ilUser, $GLOBALS['DIC']['ilCtrl']);
 			$request_adjuster->adjust();

--- a/Services/User/classes/class.ilUserPasswordResetRequestTargetAdjustmentCase.php
+++ b/Services/User/classes/class.ilUserPasswordResetRequestTargetAdjustmentCase.php
@@ -55,20 +55,8 @@ class ilUserPasswordResetRequestTargetAdjustmentCase extends ilUserRequestTarget
 	 */
 	public function adjust()
 	{
+		$_GET['baseClass'] = 'ilpersonaldesktopgui';
 		$this->ctrl->setTargetScript('ilias.php');
 		ilUtil::redirect($this->ctrl->getLinkTargetByClass(array('ilpersonaldesktopgui', 'ilpersonalsettingsgui'), 'showPassword', '', false, false));
-		
-		
-		/*
-		if(isset($_GET['baseClass']) && strtolower($_GET['baseClass']) == 'ilpersonaldesktopgui')
-		{
-			$this->ctrl->setTargetScript('ilias.php');
-			ilUtil::redirect($this->ctrl->getLinkTargetByClass(array('ilpersonaldesktopgui', 'ilpersonalsettingsgui'), 'showPassword', '', false, false));
-		}
-		else
-		{
-			ilUtil::redirect('ilias.php?baseClass=ilPersonalDesktopGUI');
-		}
-		 */
 	}
 }

--- a/Services/User/classes/class.ilUserProfileIncompleteRequestTargetAdjustmentCase.php
+++ b/Services/User/classes/class.ilUserProfileIncompleteRequestTargetAdjustmentCase.php
@@ -50,6 +50,7 @@ class ilUserProfileIncompleteRequestTargetAdjustmentCase extends ilUserRequestTa
 	 */
 	public function adjust()
 	{
+		$_GET['baseClass'] = 'ilpersonaldesktopgui';
 		// sm: directly redirect to personal desktop -> personal profile
 		$this->ctrl->setTargetScript('ilias.php');
 		ilUtil::redirect($this->ctrl->getLinkTargetByClass(array('ilpersonaldesktopgui', 'ilpersonalprofilegui'), 'showPersonalData', '', false, false));

--- a/Services/User/classes/class.ilUserRequestTargetAdjustment.php
+++ b/Services/User/classes/class.ilUserRequestTargetAdjustment.php
@@ -93,6 +93,11 @@ class ilUserRequestTargetAdjustment
 			$GLOBALS['DIC']->logger()->init()->debug('Anyonymous request. No adjustment.');
 			return false;
 		}
+		else if(ilSession::get(__CLASS__ . '_passed'))
+		{
+			$GLOBALS['DIC']->logger()->init()->debug(__CLASS__ . ' already passed in the current user session.');
+			return false;
+		}
 
 		foreach($this->cases as $case)
 		{
@@ -115,6 +120,7 @@ class ilUserRequestTargetAdjustment
 			}
 		}
 
+		ilSession::set(__CLASS__ . '_passed', 1);
 		return false;
 	}
 }


### PR DESCRIPTION
This PR restores the ... 

* Forced password change
* Forced profile completion
* Forced user agreement acceptance

... behaviour known from ILIAS 5.1.x and below.

I recommend to carefully review the single commits before a possible merge.

See: https://www.ilias.de/mantis/view.php?id=22440

What could be added in future:
* After successful authentication (via login form, via SSO etc.) we could set a flag in our session storage, e.g. `ilSession::set('check_usr_preconditons', 1)`
* After passing the 'request adjustment cascade` once (which means: nothing to do for the user), this session value has to be **unset**. This would **prevent** unintended HTTP redirects while users are doing some serious work in ILIAS.
Scenario: A lot of time passes after your successful login and an administrator decides to remove values for mandatory profile fields, which causes your profile to be considered as 'incomplete'.