### PR TITLE
CTM CHANGE: moved answer status filter to player screen and restricte…

### DIFF
--- a/Modules/Test/classes/class.ilTestDynamicQuestionSetFilterSelection.php
+++ b/Modules/Test/classes/class.ilTestDynamicQuestionSetFilterSelection.php
@@ -82,10 +82,25 @@ class ilTestDynamicQuestionSetFilterSelection
 		
 		return false;
 	}
+	
+	public function getDefaultAnswerStatusSelection()
+	{
+		return self::ANSWER_STATUS_FILTER_VALUE_ALL_NON_CORRECT;
+	}
 
 	public function isAnswerStatusSelectionWrongAnswered()
 	{
 		return $this->getAnswerStatusSelection() == self::ANSWER_STATUS_FILTER_VALUE_WRONG_ANSWERED;
+	}
+	
+	public function getAnswerStatusAlternatives()
+	{
+		return array_diff(array(
+				self::ANSWER_STATUS_FILTER_VALUE_ALL_NON_CORRECT,
+				self::ANSWER_STATUS_FILTER_VALUE_NON_ANSWERED,
+				self::ANSWER_STATUS_FILTER_VALUE_WRONG_ANSWERED,
+			), array($this->getAnswerStatusSelection())
+		);
 	}
 
 	/**

--- a/Modules/Test/classes/class.ilTestNavigationToolbarGUI.php
+++ b/Modules/Test/classes/class.ilTestNavigationToolbarGUI.php
@@ -232,6 +232,11 @@ class ilTestNavigationToolbarGUI extends ilToolbarGUI
 	
 	public function build()
 	{
+		if( $this->isQuestionSelectionButtonEnabled() )
+		{
+			$this->addQuestionSelectionButton();
+		}
+		
 		if( $this->isQuestionTreeButtonEnabled() )
 		{
 			$this->addQuestionTreeButton();
@@ -240,11 +245,6 @@ class ilTestNavigationToolbarGUI extends ilToolbarGUI
 		if( $this->isQuestionListButtonEnabled() )
 		{
 			$this->addQuestionListButton();
-		}
-
-		if( $this->isQuestionSelectionButtonEnabled() )
-		{
-			$this->addQuestionSelectionButton();
 		}
 
 		if( $this->isSuspendTestButtonEnabled() )

--- a/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -2321,6 +2321,12 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
 
 		return $this->testSession->getLastSequence();
 	}
+	
+	protected function resetSequenceElementParameter()
+	{
+		unset($_GET['sequence']);
+		$this->ctrl->setParameter($this, 'sequence', null);
+	}
 
 	protected function getSequenceElementParameter()
 	{

--- a/Modules/Test/classes/class.ilTestPlayerCommands.php
+++ b/Modules/Test/classes/class.ilTestPlayerCommands.php
@@ -49,6 +49,7 @@ class ilTestPlayerCommands
 	const TOGGLE_SIDE_LIST = 'toggleSideList';
 	
 	const SHOW_QUESTION_SELECTION = 'showQuestionSelection';
+	const FILTER_ANSWER_STATUS = 'filterAnswerStatus';
 	const UNFREEZE_ANSWERS = 'unfreezeCheckedQuestionsAnswers';
 	
 	const AUTO_SAVE = 'autosave';

--- a/Modules/Test/classes/class.ilTestPlayerDynamicQuestionSetGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerDynamicQuestionSetGUI.php
@@ -593,6 +593,7 @@ class ilTestPlayerDynamicQuestionSetGUI extends ilTestPlayerAbstractGUI
 
 		$navigationToolbarGUI = $this->getTestNavigationToolbarGUI();
 		$navigationToolbarGUI->setQuestionSelectionButtonEnabled(true);
+		$this->addAnswerStatusControl($navigationToolbarGUI);
 		
 		if( $this->testSession->getCurrentQuestionId() )
 		{
@@ -679,7 +680,6 @@ class ilTestPlayerDynamicQuestionSetGUI extends ilTestPlayerAbstractGUI
 			}
 			
 			$navigationToolbarGUI->build();
-			$this->addAnswerStatusControl($navigationToolbarGUI);
 			$this->populateTestNavigationToolbar($navigationToolbarGUI);
 
 // fau: testNav - enable the question navigation in edit mode
@@ -710,7 +710,6 @@ class ilTestPlayerDynamicQuestionSetGUI extends ilTestPlayerAbstractGUI
 			$this->prepareTestPage(ilTestPlayerAbstractGUI::PRESENTATION_MODE_VIEW, null, null);
 
 			$navigationToolbarGUI->build();
-			$this->addAnswerStatusControl($navigationToolbarGUI);
 			$this->populateTestNavigationToolbar($navigationToolbarGUI);
 			
 			$this->outCurrentlyFinishedPage();

--- a/Modules/Test/classes/class.ilTestPlayerDynamicQuestionSetGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerDynamicQuestionSetGUI.php
@@ -573,9 +573,13 @@ class ilTestPlayerDynamicQuestionSetGUI extends ilTestPlayerAbstractGUI
 			return;
 		}
 		
-		if( $this->getQuestionIdParameter() )
+		if( $this->testSequence->getQuestionSet()->getSelectionQuestionList()->isInList($this->getQuestionIdParameter()) )
 		{
 			$this->testSession->setCurrentQuestionId($this->getQuestionIdParameter());
+		}
+		else
+		{
+			$this->resetQuestionIdParameter();
 		}
 		
 		if( !$this->testSession->getCurrentQuestionId() )
@@ -1097,6 +1101,11 @@ class ilTestPlayerDynamicQuestionSetGUI extends ilTestPlayerAbstractGUI
 		$this->ctrl->setParameterByClass('ilTestEvaluationGUI', 'pass', $this->testSession->getPass());
 
 		return $this->ctrl->getLinkTargetByClass('ilTestEvaluationGUI', 'confirmDeletePass');
+	}
+	
+	protected function resetQuestionIdParameter()
+	{
+		$this->resetSequenceElementParameter();
 	}
 	
 	protected function getQuestionIdParameter()

--- a/Modules/Test/classes/class.ilTestQuestionSideListGUI.php
+++ b/Modules/Test/classes/class.ilTestQuestionSideListGUI.php
@@ -178,6 +178,21 @@ class ilTestQuestionSideListGUI
 				$row['worked_through'] ? 'answered'.$active : 'unanswered'.$active
 			);
 			
+			if( isset($row['answerstatus']) )
+			{
+				require_once 'Modules/TestQuestionPool/classes/class.ilAssQuestionList.php';
+				
+				switch( $row['answerstatus'] )
+				{
+					case ilAssQuestionList::QUESTION_ANSWER_STATUS_CORRECT_ANSWERED:
+						$class .= ' passed';
+						break;
+					case ilAssQuestionList::QUESTION_ANSWER_STATUS_WRONG_ANSWERED:
+						$class .= ' failed';
+						break;
+				}
+			}
+			
 			/*
 			if( $this->isDisabled() )
 			{

--- a/Modules/Test/classes/class.ilTestSequenceDynamicQuestionSet.php
+++ b/Modules/Test/classes/class.ilTestSequenceDynamicQuestionSet.php
@@ -585,16 +585,13 @@ class ilTestSequenceDynamicQuestionSet implements ilTestSequenceSummaryProvider
 	{
 		$i = 0;
 		
-		foreach($this->questionSet->getActualQuestionSequence() as $level => $questions)
+		foreach($this->getSelectionOrderedSequence() as $qId)
 		{
-			foreach($questions as $pos => $qId)
+			$i++;
+			
+			if($qId == $questionId)
 			{
-				$i++;
-				
-				if($qId == $questionId)
-				{
-					return $i;
-				}
+				return $i;
 			}
 		}
 
@@ -603,14 +600,7 @@ class ilTestSequenceDynamicQuestionSet implements ilTestSequenceSummaryProvider
 	
 	public function getLastPositionIndex()
 	{
-		$count = 0;
-		
-		foreach($this->questionSet->getActualQuestionSequence() as $level => $questions)
-		{
-			$count += count($questions);
-		}
-		
-		return $count;
+		return count($this->getSelectionOrderedSequence());
 	}
 	
 	// -----------------------------------------------------------------------------------------------------------------
@@ -876,10 +866,27 @@ class ilTestSequenceDynamicQuestionSet implements ilTestSequenceSummaryProvider
 
 		return $questionOrder;
 	}
+	
+	public function getSelectionOrderedSequence()
+	{
+		$sequence = array();
+		
+		foreach($this->getOrderedSequence() as $qId)
+		{
+			if( !$this->getQuestionSet()->getSelectionQuestionList()->isInList($qId) )
+			{
+				continue;
+			}
+			
+			$sequence[] = $qId;
+		}
+		
+		return $sequence;
+	}
 
 	public function getSequenceSummary($obligationsFilterEnabled = false)
 	{
-		$questionOrder = $this->getOrderedSequence();
+		$questionOrder = $this->getSelectionOrderedSequence();
 
 		$solved_questions = ilObjTest::_getSolvedQuestions($this->getActiveId());
 
@@ -887,11 +894,6 @@ class ilTestSequenceDynamicQuestionSet implements ilTestSequenceSummaryProvider
 
 		foreach ($questionOrder as $qId)
 		{
-			if( !$this->getQuestionSet()->getSelectionQuestionList()->isInList($qId) )
-			{
-				continue;
-			}
-			
 			$question =& ilObjTest::_instanciateQuestion($qId);
 			if(is_object($question))
 			{

--- a/Modules/Test/classes/class.ilTestSequenceDynamicQuestionSet.php
+++ b/Modules/Test/classes/class.ilTestSequenceDynamicQuestionSet.php
@@ -696,7 +696,15 @@ class ilTestSequenceDynamicQuestionSet implements ilTestSequenceSummaryProvider
 	}
 
 	// -----------------------------------------------------------------------------------------------------------------
-
+	
+	/**
+	 * @return ilTestDynamicQuestionSet
+	 */
+	public function getQuestionSet()
+	{
+		return $this->questionSet;
+	}
+	
 	public function getCompleteQuestionsData()
 	{
 		return $this->questionSet->getCompleteQuestionList()->getQuestionDataArray();

--- a/Modules/Test/classes/class.ilTestSequenceDynamicQuestionSet.php
+++ b/Modules/Test/classes/class.ilTestSequenceDynamicQuestionSet.php
@@ -784,7 +784,7 @@ class ilTestSequenceDynamicQuestionSet implements ilTestSequenceSummaryProvider
 		return $orderedSequence;
 	}
 	
-	private function fetchQuestionSequence($nonPostponedQuestions, $nonAnsweredQuestions, $excludeQuestionId)
+	private function fetchQuestionSequence($nonPostponedQuestions, $nonAnsweredQuestions)
 	{
 		$questionSequence = array();
 		
@@ -794,11 +794,6 @@ class ilTestSequenceDynamicQuestionSet implements ilTestSequenceSummaryProvider
 
 			foreach($questions as $pos => $qId)
 			{
-				if( $qId == $excludeQuestionId )
-				{
-					continue;
-				}
-				
 				if( isset($this->correctAnsweredQuestions[$qId]) )
 				{
 					continue;
@@ -835,18 +830,13 @@ class ilTestSequenceDynamicQuestionSet implements ilTestSequenceSummaryProvider
 		return $questionSequence;
 	}
 	
-	private function fetchTrackedCorrectAnsweredSequence($excludeQuestionId)
+	private function fetchTrackedCorrectAnsweredSequence()
 	{
 		$questionSequence = array();
 		
 		foreach($this->questionTracking as $key => $question)
 		{
 			$qId = $question['qid'];
-			
-			if($qId == $excludeQuestionId)
-			{
-				continue;
-			}
 			
 			if( !isset($this->correctAnsweredQuestions[$qId]) )
 			{
@@ -861,28 +851,25 @@ class ilTestSequenceDynamicQuestionSet implements ilTestSequenceSummaryProvider
 
 	private function getOrderedSequence()
 	{
-		$correctAnsweredQuestions = $this->fetchTrackedCorrectAnsweredSequence(
-			$this->getCurrentQuestionId()
-		);
+		$correctAnsweredQuestions = $this->fetchTrackedCorrectAnsweredSequence();
 		
 		$nonAnsweredQuestions = $this->fetchQuestionSequence(
-			true, true, $this->getCurrentQuestionId()
+			true, true
 		);
 		
 		$postponedNonAnsweredQuestions = $this->fetchQuestionSequence(
-			false, true, $this->getCurrentQuestionId()
+			false, true
 		);
 		
 		$wrongAnsweredQuestions = $this->fetchQuestionSequence(
-			true, false, $this->getCurrentQuestionId()
+			true, false
 		);
 		
 		$postponedWrongAnsweredQuestions = $this->fetchQuestionSequence(
-			false, false, $this->getCurrentQuestionId()
+			false, false
 		);
 		
-		$questionOrder = array_merge(
-			$correctAnsweredQuestions, array($this->getCurrentQuestionId()),
+		$questionOrder = array_merge( $correctAnsweredQuestions,
 			$nonAnsweredQuestions, $postponedNonAnsweredQuestions,
 			$wrongAnsweredQuestions, $postponedWrongAnsweredQuestions
 		);
@@ -900,6 +887,11 @@ class ilTestSequenceDynamicQuestionSet implements ilTestSequenceSummaryProvider
 
 		foreach ($questionOrder as $qId)
 		{
+			if( !$this->getQuestionSet()->getSelectionQuestionList()->isInList($qId) )
+			{
+				continue;
+			}
+			
 			$question =& ilObjTest::_instanciateQuestion($qId);
 			if(is_object($question))
 			{

--- a/Modules/Test/classes/class.ilTestSequenceDynamicQuestionSet.php
+++ b/Modules/Test/classes/class.ilTestSequenceDynamicQuestionSet.php
@@ -891,6 +891,8 @@ class ilTestSequenceDynamicQuestionSet implements ilTestSequenceSummaryProvider
 		$solved_questions = ilObjTest::_getSolvedQuestions($this->getActiveId());
 
 		$key = 1;
+		
+		$summary = array();
 
 		foreach ($questionOrder as $qId)
 		{

--- a/Modules/Test/classes/class.ilTestSequenceDynamicQuestionSet.php
+++ b/Modules/Test/classes/class.ilTestSequenceDynamicQuestionSet.php
@@ -911,6 +911,8 @@ class ilTestSequenceDynamicQuestionSet implements ilTestSequenceSummaryProvider
 
 				$row = array("nr" => "$key", "title" => $question->getTitle(), "qid" => $question->getId(), "visited" => $worked_through, "solved" => (($solved) ? "1" : "0"), "description" => $question->getComment(), "points" => $question->getMaximumPoints(), "worked_through" => $worked_through, "postponed" => $is_postponed, "sequence" => $qId, "obligatory" => ilObjTest::isQuestionObligatory($question->getId()), 'isAnswered' => $question->isAnswered($this->getActiveId(), $this->getPass()));
 
+				$row['answerstatus'] = $this->getQuestionAnswerStatus($qId);
+				
 				if(!$obligationsFilterEnabled || $row['obligatory'])
 				{
 					$summary[] = $row;
@@ -921,6 +923,23 @@ class ilTestSequenceDynamicQuestionSet implements ilTestSequenceSummaryProvider
 		}
 
 		return $summary;
+	}
+	
+	protected function getQuestionAnswerStatus($qId)
+	{
+		require_once 'Modules/TestQuestionPool/classes/class.ilAssQuestionList.php';
+		
+		if( isset($this->correctAnsweredQuestions[$qId]) )
+		{
+			return ilAssQuestionList::QUESTION_ANSWER_STATUS_CORRECT_ANSWERED;
+		}
+		
+		if( isset($this->wrongAnsweredQuestions[$qId]) )
+		{
+			return ilAssQuestionList::QUESTION_ANSWER_STATUS_WRONG_ANSWERED;
+		}
+
+		return ilAssQuestionList::QUESTION_ANSWER_STATUS_NON_ANSWERED;
 	}
 
 	public function hasFilteredQuestionListCheckedQuestions()

--- a/Modules/Test/classes/class.ilTestSequenceDynamicQuestionSet.php
+++ b/Modules/Test/classes/class.ilTestSequenceDynamicQuestionSet.php
@@ -702,9 +702,9 @@ class ilTestSequenceDynamicQuestionSet implements ilTestSequenceSummaryProvider
 		return $this->questionSet->getCompleteQuestionList()->getQuestionDataArray();
 	}
 	
-	public function getFilteredQuestionsData()
+	public function getSelectedQuestionsData()
 	{
-		return $this->questionSet->getFilteredQuestionList()->getQuestionDataArray();
+		return $this->questionSet->getSelectionQuestionList()->getQuestionDataArray();
 	}
 
 	// -----------------------------------------------------------------------------------------------------------------

--- a/Modules/Test/classes/class.ilTestService.php
+++ b/Modules/Test/classes/class.ilTestService.php
@@ -297,7 +297,12 @@ class ilTestService
 			}
 
 // fau: testNav - add number parameter for getQuestionTitle()
-			$data[] = array('order' => $value["nr"], 'title' => $this->object->getQuestionTitle($value["title"], $value["nr"]), 'description' => $description, 'worked_through' => $value["worked_through"], 'postponed' => $value["postponed"], 'points' => $points, 'marked' => $marked, 'sequence' => $value["sequence"], 'obligatory' => $value['obligatory'], 'isAnswered' => $value['isAnswered']);
+			$row = array('order' => $value["nr"], 'title' => $this->object->getQuestionTitle($value["title"], $value["nr"]), 'description' => $description, 'worked_through' => $value["worked_through"], 'postponed' => $value["postponed"], 'points' => $points, 'marked' => $marked, 'sequence' => $value["sequence"], 'obligatory' => $value['obligatory'], 'isAnswered' => $value['isAnswered']);
+			if( isset($value['answerstatus']) )
+			{
+				$row['answerstatus'] = $value['answerstatus'];
+			}
+			$data[] = $row;
 // fau.
 		}
 

--- a/Modules/Test/classes/class.ilTestSessionDynamicQuestionSet.php
+++ b/Modules/Test/classes/class.ilTestSessionDynamicQuestionSet.php
@@ -57,8 +57,22 @@ class ilTestSessionDynamicQuestionSet extends ilTestSession
 			$this->tstamp = $row["tstamp"];
 
 			$this->questionSetFilterSelection->setTaxonomySelection(unserialize($row['taxfilter']));
-			$this->questionSetFilterSelection->setAnswerStatusSelection($row['answerstatusfilter']);
-			$this->questionSetFilterSelection->setAnswerStatusActiveId($row['active_id']);
+			
+			if( $row['active_id'] > 0 )
+			{
+				if( strlen($row['answerstatusfilter']) )
+				{
+					$this->questionSetFilterSelection->setAnswerStatusSelection($row['answerstatusfilter']);
+				}
+				else
+				{
+					$this->questionSetFilterSelection->setAnswerStatusSelection(
+						$this->questionSetFilterSelection->getDefaultAnswerStatusSelection()
+					);
+				}
+				
+				$this->questionSetFilterSelection->setAnswerStatusActiveId($row['active_id']);
+			}
 		}
 	}
 	

--- a/Modules/Test/classes/tables/class.ilTestDynamicQuestionSetStatisticTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilTestDynamicQuestionSetStatisticTableGUI.php
@@ -108,7 +108,7 @@ class ilTestDynamicQuestionSetStatisticTableGUI extends ilTable2GUI
 
 				$inp = new ilTaxSelectInputGUI($taxId, $postvar, true);
 				$this->addFilterItem($inp);
-				$inp->readFromSession();
+				#$inp->readFromSession();
 				
 				if( $this->getFilterSelection()->hasSelectedTaxonomy($taxId) )
 				{

--- a/Modules/Test/classes/tables/class.ilTestDynamicQuestionSetStatisticTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilTestDynamicQuestionSetStatisticTableGUI.php
@@ -25,8 +25,6 @@ class ilTestDynamicQuestionSetStatisticTableGUI extends ilTable2GUI
 	
 	private $taxonomyFilterEnabled = false;
 	
-	private $answerStatusFilterEnabled = false;
-	
 	/**
 	 * @var ilTestDynamicQuestionSetFilterSelection
 	 */
@@ -119,28 +117,6 @@ class ilTestDynamicQuestionSetStatisticTableGUI extends ilTable2GUI
 				
 				$this->filter[$postvar] = $inp->getValue();
 			}
-		}
-
-		if( $this->isAnswerStatusFilterEnabled() )
-		{
-			require_once 'Services/Form/classes/class.ilSelectInputGUI.php';
-			require_once 'Services/Form/classes/class.ilRadioOption.php';
-			
-			$inp = new ilSelectInputGUI($this->lng->txt('tst_question_answer_status'), 'question_answer_status');
-			$inp->setOptions(array(
-				ilAssQuestionList::ANSWER_STATUS_FILTER_ALL_NON_CORRECT => $this->lng->txt('tst_question_answer_status_all_non_correct'),
-				ilAssQuestionList::ANSWER_STATUS_FILTER_NON_ANSWERED_ONLY => $this->lng->txt('tst_question_answer_status_non_answered'),
-				ilAssQuestionList::ANSWER_STATUS_FILTER_WRONG_ANSWERED_ONLY => $this->lng->txt('tst_question_answer_status_wrong_answered')
-			));
-			$this->addFilterItem($inp);
-			$inp->readFromSession();
-			
-			if( $this->getFilterSelection()->hasAnswerStatusSelection() )
-			{
-				$inp->setValue($this->getFilterSelection()->getAnswerStatusSelection());
-			}
-			
-			$this->filter['question_answer_status'] = $inp->getValue();
 		}
 	}
 

--- a/Modules/Test/templates/default/ta.css
+++ b/Modules/Test/templates/default/ta.css
@@ -422,6 +422,14 @@ ul.shortlist li.unanswered {
 }
 /* fau. */
 
+ul.shortlist li.passed {
+	background-image: url('../../../../templates/default/images/scorm/passed.svg');
+}
+
+ul.shortlist li.failed {
+	background-image: url('../../../../templates/default/images/scorm/failed.svg');
+}
+
 ul.shortlist li.active {
 	font-weight: bold;
 }

--- a/Services/Calendar/classes/class.ilDateTime.php
+++ b/Services/Calendar/classes/class.ilDateTime.php
@@ -489,7 +489,11 @@ class ilDateTime
 		// internally we always use the default timezone
 		if($this->dt_obj)
 		{
-			$this->dt_obj->setTimeZone(new DateTimeZone($this->default_timezone->getIdentifier()));		
+			#21553
+			if($this->dt_obj->getTimezone() === FALSE) {
+				$this->dt_obj->setTimeZone(new DateTimeZone($this->default_timezone->getIdentifier()));
+			}
+
 		}
 		
 	 	return true;


### PR DESCRIPTION
This pull request is about an usibility fix in the continous testing mode. The answer status filter is moved from within the question selection screen to the working form as a toolbar dropdown button. The selection screen's statistic does not consider the answer status any longer. Confusing reports by the answer statistics does not occur any more.