### PR TITLE
Easier way to get the export tab and functionality for Plugins

### DIFF
--- a/Services/Repository/classes/class.ilObjectPluginGUI.php
+++ b/Services/Repository/classes/class.ilObjectPluginGUI.php
@@ -49,27 +49,27 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 		parent::__construct($a_ref_id, $a_id_type, $a_parent_node_id);
 		$this->plugin = $this->getPlugin();
 	}
-
+	
 	/**
 	* execute command
 	*/
 	function executeCommand()
 	{
-		$this->ctrl = $this->ctrl;
-		$this->tpl = $this->tpl;
-		$this->access = $this->access;
-		$this->lng = $this->lng;
-		$this->nav_history = $this->nav_history;
-		$this->tabs = $this->tabs;
+		$ilCtrl = $this->ctrl;
+		$tpl = $this->tpl;
+		$ilAccess = $this->access;
+		$lng = $this->lng;
+		$ilNavigationHistory = $this->nav_history;
+		$ilTabs = $this->tabs;
 
 		// get standard template (includes main menu and general layout)
-		$this->tpl->getStandardTemplate();
+		$tpl->getStandardTemplate();
 
 		// set title
 		if (!$this->getCreationMode())
 		{
-			$this->tpl->setTitle($this->object->getTitle());
-			$this->tpl->setTitleIcon(ilObject::_getIcon($this->object->getId()));
+			$tpl->setTitle($this->object->getTitle());
+			$tpl->setTitleIcon(ilObject::_getIcon($this->object->getId()));
 
 			// set tabs
 			if (strtolower($_GET["baseClass"]) != "iladministrationgui")
@@ -80,24 +80,27 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 			else
 			{
 				$this->addAdminLocatorItems();
-				$this->tpl->setLocator();
+				$tpl->setLocator();
 				$this->setAdminTabs();
 			}
+			
 			// add entry to navigation history
-			if ($this->access->checkAccess("read", "", $_GET["ref_id"]))
+			if ($ilAccess->checkAccess("read", "", $_GET["ref_id"]))
 			{
-				$this->nav_history->addItem($_GET["ref_id"],
-					$this->ctrl->getLinkTarget($this, $this->getStandardCmd()), $this->getType());
+				$ilNavigationHistory->addItem($_GET["ref_id"],
+					$ilCtrl->getLinkTarget($this, $this->getStandardCmd()), $this->getType());
 			}
+
 		}
 		else
 		{
 			// show info of parent
-			$this->tpl->setTitle($this->lookupParentTitleInCreationMode());
-			$this->tpl->setTitleIcon(
+			$tpl->setTitle($this->lookupParentTitleInCreationMode());
+			$tpl->setTitleIcon(
 				ilObject::_getIcon(ilObject::_lookupObjId($_GET["ref_id"]), "big"),
-				$this->lng->txt("obj_".ilObject::_lookupType($_GET["ref_id"], true)));
+				$lng->txt("obj_".ilObject::_lookupType($_GET["ref_id"], true)));
 			$this->setLocator();
+
 		}
 
 		$next_class = $this->ctrl->getNextClass($this);
@@ -109,28 +112,32 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 				$this->checkPermission("visible");
 				$this->infoScreen();	// forwards command
 				break;
+
 			case 'ilpermissiongui':
 				include_once("Services/AccessControl/classes/class.ilPermissionGUI.php");
 				$perm_gui = new ilPermissionGUI($this);
-				$this->tabs->setTabActive("perm_settings");
-				$this->ctrl->forwardCommand($perm_gui);
+				$ilTabs->setTabActive("perm_settings");
+				$ilCtrl->forwardCommand($perm_gui);
 				break;
+		
 			case 'ilobjectcopygui':
 				include_once './Services/Object/classes/class.ilObjectCopyGUI.php';
 				$cp = new ilObjectCopyGUI($this);
 				$cp->setType($this->getType());
 				$this->ctrl->forwardCommand($cp);
 				break;
+			
 			case 'ilexportgui':
 				// only if plugin supports it?
 				$this->tabs->setTabActive("export");
 				include_once './Services/Export/classes/class.ilExportGUI.php';
-				$exp = new ilExportGUI($this);
+				$exp = new ilExportGUI($this);		
 				$exp->addFormat('xml');
 				$this->ctrl->forwardCommand($exp);
 				break;
+						
 			case 'illearningprogressgui':
-				$this->tabs->setTabActive("learning_progress");
+				$ilTabs->setTabActive("learning_progress");
 				include_once './Services/Tracking/classes/class.ilLearningProgressGUI.php';
 				$new_gui = new ilLearningProgressGUI(ilLearningProgressGUI::LP_CONTEXT_REPOSITORY,
 													  $this->object->getRefId(),
@@ -159,8 +166,8 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 				}
 				if ($cmd == "infoScreen")
 				{
-					$this->ctrl->setCmd("showSummary");
-					$this->ctrl->setCmdClass("ilinfoscreengui");
+					$ilCtrl->setCmd("showSummary");
+					$ilCtrl->setCmdClass("ilinfoscreengui");
 					$this->infoScreen();
 				}
 				else
@@ -172,7 +179,7 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 
 		if (!$this->getCreationMode())
 		{
-			$this->tpl->show();
+			$tpl->show();
 		}
 	}
 
@@ -181,11 +188,11 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	*/
 	function addLocatorItems()
 	{
-		$this->locator = $this->locator;
+		$ilLocator = $this->locator;
 
 		if (!$this->getCreationMode())
 		{
-			$this->locator->addItem($this->object->getTitle(),
+			$ilLocator->addItem($this->object->getTitle(),
 				$this->ctrl->getLinkTarget($this, $this->getStandardCmd()), "", $_GET["ref_id"]);
 		}
 	}
@@ -207,7 +214,7 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 		}
 		return $this->plugin;
 	}
-
+	
 	/**
 	* Wrapper for txt function
 	*/
@@ -215,7 +222,7 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	{
 		return $this->getPlugin()->txt($a_var);
 	}
-
+	
 	/**
 	 * Use custom creation form titles
 	 * 
@@ -228,13 +235,15 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 		{
 			case self::CFORM_NEW:
 				return $this->txt($this->getType()."_new");
+				
 			case self::CFORM_IMPORT:
 				return $this->lng->txt("import");
+				
 			case self::CFORM_CLONE:
 				return $this->txt("objs_".$this->getType()."_duplicate");
 		}
 	}
-
+	
 	/**
 	 * Init creation froms
 	 *
@@ -245,13 +254,15 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	 */
 	protected function initCreationForms($a_new_type)
 	{
+		$ilPluginAdmin = $this->plugin_admin;
+		
 		$forms = array();
 		$forms[self::CFORM_NEW] = $this->initCreateForm($a_new_type);
 
 		if($this->supportsExport())
 		{
 			$forms[self::CFORM_IMPORT] = $this->initImportForm($a_new_type);
-		}
+		}		
 		if($this->supportsCloning()) {
 			$forms[self::CFORM_CLONE] = $this->fillCloneTemplate(null, $a_new_type);
 		}
@@ -265,7 +276,7 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	protected function supportsCloning() {
 		return true;
 	}
-
+	
 	/**
 	* Init object creation form
 	* 
@@ -296,9 +307,9 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 		$form->addCommandButton("save", $this->txt($a_new_type."_add"));
 		$form->addCommandButton("cancel", $this->lng->txt("cancel"));
 
-		return $form;
+		return $form;		
 	}
-
+	
 	/**
 	* Init object update form
 	* 
@@ -306,34 +317,34 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	*/
 	public function initEditForm()
 	{
-		$this->lng = $this->lng;
-		$this->ctrl = $this->ctrl;
-
+		$lng = $this->lng;
+		$ilCtrl = $this->ctrl;
+	
 		include_once("Services/Form/classes/class.ilPropertyFormGUI.php");
 		$form = new ilPropertyFormGUI();
 		$form->setTarget("_top");
-		$form->setFormAction($this->ctrl->getFormAction($this, "update"));
-		$form->setTitle($this->lng->txt("edit"));
-
+		$form->setFormAction($ilCtrl->getFormAction($this, "update"));	 
+		$form->setTitle($lng->txt("edit"));
+	
 		// title
-		$ti = new ilTextInputGUI($this->lng->txt("title"), "title");
+		$ti = new ilTextInputGUI($lng->txt("title"), "title");
 		$ti->setSize(min(40, ilObject::TITLE_LENGTH));
 		$ti->setMaxLength(ilObject::TITLE_LENGTH);
 		$ti->setRequired(true);
 		$form->addItem($ti);
-
+		
 		// description
-		$ta = new ilTextAreaInputGUI($this->lng->txt("description"), "desc");
+		$ta = new ilTextAreaInputGUI($lng->txt("description"), "desc");
 		$ta->setCols(40);
 		$ta->setRows(2);
 		$form->addItem($ta);
-
-		$form->addCommandButton("update", $this->lng->txt("save"));
-		// $this->form->addCommandButton("cancelUpdate", $this->lng->txt("cancel"));	  
+	
+		$form->addCommandButton("update", $lng->txt("save"));
+		// $this->form->addCommandButton("cancelUpdate", $lng->txt("cancel"));	  
 		
 		return $form;
 	}
-
+	
 	/**
 	 * Init object import form
 	 *
@@ -356,7 +367,7 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 
 		$form->addCommandButton("importFile", $this->lng->txt("import"));
 		$form->addCommandButton("cancel", $this->lng->txt("cancel"));
-
+	
 		return $form;
 	}
 
@@ -366,44 +377,44 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	*/
 	function afterSave(ilObject $newObj)
 	{
-		$this->ctrl = $this->ctrl;
+		$ilCtrl = $this->ctrl;
 		// always send a message
 		ilUtil::sendSuccess($this->lng->txt("object_added"),true);
 
-		$this->ctrl->initBaseClass("ilObjPluginDispatchGUI");
-		$this->ctrl->setTargetScript("ilias.php");
-		$this->ctrl->getCallStructure(strtolower("ilObjPluginDispatchGUI"));
+		$ilCtrl->initBaseClass("ilObjPluginDispatchGUI");
+		$ilCtrl->setTargetScript("ilias.php");
+		$ilCtrl->getCallStructure(strtolower("ilObjPluginDispatchGUI"));
+		
+//var_dump($ilCtrl->call_node);
+//var_dump($ilCtrl->forward);
+//var_dump($ilCtrl->parent);
+//var_dump($ilCtrl->root_class);
 
-//var_dump($this->ctrl->call_node);
-//var_dump($this->ctrl->forward);
-//var_dump($this->ctrl->parent);
-//var_dump($this->ctrl->root_class);
-
-		$this->ctrl->setParameterByClass(get_class($this), "ref_id", $newObj->getRefId());
-		$this->ctrl->redirectByClass(array("ilobjplugindispatchgui", get_class($this)), $this->getAfterCreationCmd());
+		$ilCtrl->setParameterByClass(get_class($this), "ref_id", $newObj->getRefId());
+		$ilCtrl->redirectByClass(array("ilobjplugindispatchgui", get_class($this)), $this->getAfterCreationCmd());
 	}
-
+	
 	/**
 	* Cmd that will be redirected to after creation of a new object.
 	*/
 	abstract function getAfterCreationCmd();
-
+	
 	abstract function getStandardCmd();
-
+	
 //	abstract function performCommand();
-
+	
 	/**
 	* Add info screen tab
 	*/
 	function addInfoTab()
 	{
-		$this->access = $this->access;
-		$this->tabs = $this->tabs;
-
+		$ilAccess = $this->access;
+		$ilTabs = $this->tabs;
+		
 		// info screen
-		if ($this->access->checkAccess('visible', "", $this->object->getRefId()))
+		if ($ilAccess->checkAccess('visible', "", $this->object->getRefId()))
 		{
-			$this->tabs->addTarget("info_short",
+			$ilTabs->addTarget("info_short",
 				$this->ctrl->getLinkTargetByClass(
 				"ilinfoscreengui", "showSummary"),
 				"showSummary");
@@ -415,19 +426,20 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	*/
 	function addPermissionTab()
 	{
-		$this->access = $this->access;
-		$this->tabs = $this->tabs;
-		$this->ctrl = $this->ctrl;
-
+		$ilAccess = $this->access;
+		$ilTabs = $this->tabs;
+		$ilCtrl = $this->ctrl;
+		
 		// edit permissions
-		if($this->access->checkAccess('edit_permission', "", $this->object->getRefId()))
+		if($ilAccess->checkAccess('edit_permission', "", $this->object->getRefId()))
 		{
-			$this->tabs->addTarget("perm_settings",
-				$this->ctrl->getLinkTargetByClass("ilpermissiongui", "perm"),
+			$ilTabs->addTarget("perm_settings",
+				$ilCtrl->getLinkTargetByClass("ilpermissiongui", "perm"),
 				array("perm","info","owner"), 'ilpermissiongui');
 		}
 	}
-
+	
+	
 	/**
 	* Add export tab
 	*/
@@ -450,14 +462,14 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	*/
 	function infoScreen()
 	{
-		$this->access = $this->access;
-		$this->user = $this->user;
-		$this->lng = $this->lng;
-		$this->ctrl = $this->ctrl;
-		$this->tpl = $this->tpl;
-		$this->tabs = $this->tabs;
-
-		$this->tabs->setTabActive("info_short");
+		$ilAccess = $this->access;
+		$ilUser = $this->user;
+		$lng = $this->lng;
+		$ilCtrl = $this->ctrl;
+		$tpl = $this->tpl;
+		$ilTabs = $this->tabs;
+		
+		$ilTabs->setTabActive("info_short");
 		
 		$this->checkPermission("visible");
 
@@ -466,13 +478,13 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 		$info->enablePrivateNotes();
 
 		// general information
-		$this->lng->loadLanguageModule("meta");
+		$lng->loadLanguageModule("meta");
 
 		$this->addInfoItems($info);
 
 		// forward the command
-		$ret = $this->ctrl->forwardCommand($info);
-		//$this->tpl->setContent($ret);
+		$ret = $ilCtrl->forwardCommand($info);
+		//$tpl->setContent($ret);
 	}
 
 	/**
@@ -492,11 +504,11 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 		$ilCtrl = $DIC->ctrl();
 		$ilAccess = $DIC->access();
 		$lng = $DIC->language();
-
+		
 		$t = explode("_", $a_target[0]);
 		$ref_id = (int) $t[0];
 		$class_name = $a_target[1];
-
+		
 		if ($ilAccess->checkAccess("read", "", $ref_id))
 		{
 			$ilCtrl->initBaseClass("ilObjPluginDispatchGUI");
@@ -522,13 +534,14 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 		}
 	}
 
+
 	/**
 	 * @return bool
 	 */
 	protected function supportsExport() {
-		$this->plugin_admin = $this->plugin_admin;
+		$ilPluginAdmin = $this->plugin_admin;
 
-		return $this->plugin_admin->supportsExport(IL_COMP_SERVICE, "Repository", "robj", $this->getPlugin()->getPluginName());
+		return $ilPluginAdmin->supportsExport(IL_COMP_SERVICE, "Repository", "robj", $this->getPlugin()->getPluginName());
 	}
 
 

--- a/Services/Repository/classes/class.ilObjectPluginGUI.php
+++ b/Services/Repository/classes/class.ilObjectPluginGUI.php
@@ -409,6 +409,23 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	}
 
 	/**
+	* Add export tab
+	*/
+	function addExportTab()
+	{
+		// write
+		if($this->access->checkAccess('write', "", $this->object->getRefId()))
+		{
+			$this->tabs->addTarget(
+				'export',
+				$this->ctrl->getLinkTargetByClass("ilexportgui",''),
+				'export',
+				'ilexportgui'
+			);
+		}
+	}
+
+	/**
 	* show information screen
 	*/
 	function infoScreen()

--- a/Services/Repository/classes/class.ilObjectPluginGUI.php
+++ b/Services/Repository/classes/class.ilObjectPluginGUI.php
@@ -55,13 +55,6 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	*/
 	function executeCommand()
 	{
-		$this->ctrl = $this->ctrl;
-		$this->tpl = $this->tpl;
-		$this->access = $this->access;
-		$this->lng = $this->lng;
-		$this->nav_history = $this->nav_history;
-		$this->tabs = $this->tabs;
-
 		// get standard template (includes main menu and general layout)
 		$this->tpl->getStandardTemplate();
 
@@ -180,8 +173,6 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	*/
 	function addLocatorItems()
 	{
-		$this->locator = $this->locator;
-
 		if (!$this->getCreationMode())
 		{
 			$this->locator->addItem($this->object->getTitle(),
@@ -305,9 +296,6 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	*/
 	public function initEditForm()
 	{
-		$this->lng = $this->lng;
-		$this->ctrl = $this->ctrl;
-
 		include_once("Services/Form/classes/class.ilPropertyFormGUI.php");
 		$form = new ilPropertyFormGUI();
 		$form->setTarget("_top");
@@ -365,7 +353,6 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	*/
 	function afterSave(ilObject $newObj)
 	{
-		$this->ctrl = $this->ctrl;
 		// always send a message
 		ilUtil::sendSuccess($this->lng->txt("object_added"),true);
 
@@ -396,9 +383,6 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	*/
 	function addInfoTab()
 	{
-		$this->access = $this->access;
-		$this->tabs = $this->tabs;
-
 		// info screen
 		if ($this->access->checkAccess('visible', "", $this->object->getRefId()))
 		{
@@ -414,10 +398,6 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	*/
 	function addPermissionTab()
 	{
-		$this->access = $this->access;
-		$this->tabs = $this->tabs;
-		$this->ctrl = $this->ctrl;
-
 		// edit permissions
 		if($this->access->checkAccess('edit_permission', "", $this->object->getRefId()))
 		{
@@ -432,15 +412,8 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	*/
 	function infoScreen()
 	{
-		$this->access = $this->access;
-		$this->user = $this->user;
-		$this->lng = $this->lng;
-		$this->ctrl = $this->ctrl;
-		$this->tpl = $this->tpl;
-		$this->tabs = $this->tabs;
-
 		$this->tabs->setTabActive("info_short");
-		
+
 		$this->checkPermission("visible");
 
 		include_once("./Services/InfoScreen/classes/class.ilInfoScreenGUI.php");
@@ -508,8 +481,6 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	 * @return bool
 	 */
 	protected function supportsExport() {
-		$this->plugin_admin = $this->plugin_admin;
-
 		return $this->plugin_admin->supportsExport(IL_COMP_SERVICE, "Repository", "robj", $this->getPlugin()->getPluginName());
 	}
 

--- a/Services/Repository/classes/class.ilObjectPluginGUI.php
+++ b/Services/Repository/classes/class.ilObjectPluginGUI.php
@@ -116,6 +116,7 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 				break;
 			case 'ilexportgui':
 				// only if plugin supports it?
+				$this->tabs->setTabActive("export");
 				include_once './Services/Export/classes/class.ilExportGUI.php';
 				$exp = new ilExportGUI($this);
 				$exp->addFormat('xml');

--- a/Services/Repository/classes/class.ilObjectPluginGUI.php
+++ b/Services/Repository/classes/class.ilObjectPluginGUI.php
@@ -49,27 +49,27 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 		parent::__construct($a_ref_id, $a_id_type, $a_parent_node_id);
 		$this->plugin = $this->getPlugin();
 	}
-	
+
 	/**
 	* execute command
 	*/
 	function executeCommand()
 	{
-		$ilCtrl = $this->ctrl;
-		$tpl = $this->tpl;
-		$ilAccess = $this->access;
-		$lng = $this->lng;
-		$ilNavigationHistory = $this->nav_history;
-		$ilTabs = $this->tabs;
+		$this->ctrl = $this->ctrl;
+		$this->tpl = $this->tpl;
+		$this->access = $this->access;
+		$this->lng = $this->lng;
+		$this->nav_history = $this->nav_history;
+		$this->tabs = $this->tabs;
 
 		// get standard template (includes main menu and general layout)
-		$tpl->getStandardTemplate();
+		$this->tpl->getStandardTemplate();
 
 		// set title
 		if (!$this->getCreationMode())
 		{
-			$tpl->setTitle($this->object->getTitle());
-			$tpl->setTitleIcon(ilObject::_getIcon($this->object->getId()));
+			$this->tpl->setTitle($this->object->getTitle());
+			$this->tpl->setTitleIcon(ilObject::_getIcon($this->object->getId()));
 
 			// set tabs
 			if (strtolower($_GET["baseClass"]) != "iladministrationgui")
@@ -80,27 +80,24 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 			else
 			{
 				$this->addAdminLocatorItems();
-				$tpl->setLocator();
+				$this->tpl->setLocator();
 				$this->setAdminTabs();
 			}
-			
 			// add entry to navigation history
-			if ($ilAccess->checkAccess("read", "", $_GET["ref_id"]))
+			if ($this->access->checkAccess("read", "", $_GET["ref_id"]))
 			{
-				$ilNavigationHistory->addItem($_GET["ref_id"],
-					$ilCtrl->getLinkTarget($this, $this->getStandardCmd()), $this->getType());
+				$this->nav_history->addItem($_GET["ref_id"],
+					$this->ctrl->getLinkTarget($this, $this->getStandardCmd()), $this->getType());
 			}
-
 		}
 		else
 		{
 			// show info of parent
-			$tpl->setTitle($this->lookupParentTitleInCreationMode());
-			$tpl->setTitleIcon(
+			$this->tpl->setTitle($this->lookupParentTitleInCreationMode());
+			$this->tpl->setTitleIcon(
 				ilObject::_getIcon(ilObject::_lookupObjId($_GET["ref_id"]), "big"),
-				$lng->txt("obj_".ilObject::_lookupType($_GET["ref_id"], true)));
+				$this->lng->txt("obj_".ilObject::_lookupType($_GET["ref_id"], true)));
 			$this->setLocator();
-
 		}
 
 		$next_class = $this->ctrl->getNextClass($this);
@@ -112,31 +109,27 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 				$this->checkPermission("visible");
 				$this->infoScreen();	// forwards command
 				break;
-
 			case 'ilpermissiongui':
 				include_once("Services/AccessControl/classes/class.ilPermissionGUI.php");
 				$perm_gui = new ilPermissionGUI($this);
-				$ilTabs->setTabActive("perm_settings");
-				$ilCtrl->forwardCommand($perm_gui);
+				$this->tabs->setTabActive("perm_settings");
+				$this->ctrl->forwardCommand($perm_gui);
 				break;
-		
 			case 'ilobjectcopygui':
 				include_once './Services/Object/classes/class.ilObjectCopyGUI.php';
 				$cp = new ilObjectCopyGUI($this);
 				$cp->setType($this->getType());
 				$this->ctrl->forwardCommand($cp);
 				break;
-			
 			case 'ilexportgui':
 				// only if plugin supports it?
 				include_once './Services/Export/classes/class.ilExportGUI.php';
-				$exp = new ilExportGUI($this);		
+				$exp = new ilExportGUI($this);
 				$exp->addFormat('xml');
 				$this->ctrl->forwardCommand($exp);
 				break;
-						
 			case 'illearningprogressgui':
-				$ilTabs->setTabActive("learning_progress");
+				$this->tabs->setTabActive("learning_progress");
 				include_once './Services/Tracking/classes/class.ilLearningProgressGUI.php';
 				$new_gui = new ilLearningProgressGUI(ilLearningProgressGUI::LP_CONTEXT_REPOSITORY,
 													  $this->object->getRefId(),
@@ -165,8 +158,8 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 				}
 				if ($cmd == "infoScreen")
 				{
-					$ilCtrl->setCmd("showSummary");
-					$ilCtrl->setCmdClass("ilinfoscreengui");
+					$this->ctrl->setCmd("showSummary");
+					$this->ctrl->setCmdClass("ilinfoscreengui");
 					$this->infoScreen();
 				}
 				else
@@ -178,7 +171,7 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 
 		if (!$this->getCreationMode())
 		{
-			$tpl->show();
+			$this->tpl->show();
 		}
 	}
 
@@ -187,11 +180,11 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	*/
 	function addLocatorItems()
 	{
-		$ilLocator = $this->locator;
+		$this->locator = $this->locator;
 
 		if (!$this->getCreationMode())
 		{
-			$ilLocator->addItem($this->object->getTitle(),
+			$this->locator->addItem($this->object->getTitle(),
 				$this->ctrl->getLinkTarget($this, $this->getStandardCmd()), "", $_GET["ref_id"]);
 		}
 	}
@@ -213,7 +206,7 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 		}
 		return $this->plugin;
 	}
-	
+
 	/**
 	* Wrapper for txt function
 	*/
@@ -221,7 +214,7 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	{
 		return $this->getPlugin()->txt($a_var);
 	}
-	
+
 	/**
 	 * Use custom creation form titles
 	 * 
@@ -234,15 +227,13 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 		{
 			case self::CFORM_NEW:
 				return $this->txt($this->getType()."_new");
-				
 			case self::CFORM_IMPORT:
 				return $this->lng->txt("import");
-				
 			case self::CFORM_CLONE:
 				return $this->txt("objs_".$this->getType()."_duplicate");
 		}
 	}
-	
+
 	/**
 	 * Init creation froms
 	 *
@@ -253,15 +244,13 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	 */
 	protected function initCreationForms($a_new_type)
 	{
-		$ilPluginAdmin = $this->plugin_admin;
-		
 		$forms = array();
 		$forms[self::CFORM_NEW] = $this->initCreateForm($a_new_type);
 
 		if($this->supportsExport())
 		{
 			$forms[self::CFORM_IMPORT] = $this->initImportForm($a_new_type);
-		}		
+		}
 		if($this->supportsCloning()) {
 			$forms[self::CFORM_CLONE] = $this->fillCloneTemplate(null, $a_new_type);
 		}
@@ -275,7 +264,7 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	protected function supportsCloning() {
 		return true;
 	}
-	
+
 	/**
 	* Init object creation form
 	* 
@@ -306,9 +295,9 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 		$form->addCommandButton("save", $this->txt($a_new_type."_add"));
 		$form->addCommandButton("cancel", $this->lng->txt("cancel"));
 
-		return $form;		
+		return $form;
 	}
-	
+
 	/**
 	* Init object update form
 	* 
@@ -316,34 +305,34 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	*/
 	public function initEditForm()
 	{
-		$lng = $this->lng;
-		$ilCtrl = $this->ctrl;
-	
+		$this->lng = $this->lng;
+		$this->ctrl = $this->ctrl;
+
 		include_once("Services/Form/classes/class.ilPropertyFormGUI.php");
 		$form = new ilPropertyFormGUI();
 		$form->setTarget("_top");
-		$form->setFormAction($ilCtrl->getFormAction($this, "update"));	 
-		$form->setTitle($lng->txt("edit"));
-	
+		$form->setFormAction($this->ctrl->getFormAction($this, "update"));
+		$form->setTitle($this->lng->txt("edit"));
+
 		// title
-		$ti = new ilTextInputGUI($lng->txt("title"), "title");
+		$ti = new ilTextInputGUI($this->lng->txt("title"), "title");
 		$ti->setSize(min(40, ilObject::TITLE_LENGTH));
 		$ti->setMaxLength(ilObject::TITLE_LENGTH);
 		$ti->setRequired(true);
 		$form->addItem($ti);
-		
+
 		// description
-		$ta = new ilTextAreaInputGUI($lng->txt("description"), "desc");
+		$ta = new ilTextAreaInputGUI($this->lng->txt("description"), "desc");
 		$ta->setCols(40);
 		$ta->setRows(2);
 		$form->addItem($ta);
-	
-		$form->addCommandButton("update", $lng->txt("save"));
-		// $this->form->addCommandButton("cancelUpdate", $lng->txt("cancel"));	  
+
+		$form->addCommandButton("update", $this->lng->txt("save"));
+		// $this->form->addCommandButton("cancelUpdate", $this->lng->txt("cancel"));	  
 		
 		return $form;
 	}
-	
+
 	/**
 	 * Init object import form
 	 *
@@ -366,7 +355,7 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 
 		$form->addCommandButton("importFile", $this->lng->txt("import"));
 		$form->addCommandButton("cancel", $this->lng->txt("cancel"));
-	
+
 		return $form;
 	}
 
@@ -376,44 +365,44 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	*/
 	function afterSave(ilObject $newObj)
 	{
-		$ilCtrl = $this->ctrl;
+		$this->ctrl = $this->ctrl;
 		// always send a message
 		ilUtil::sendSuccess($this->lng->txt("object_added"),true);
 
-		$ilCtrl->initBaseClass("ilObjPluginDispatchGUI");
-		$ilCtrl->setTargetScript("ilias.php");
-		$ilCtrl->getCallStructure(strtolower("ilObjPluginDispatchGUI"));
-		
-//var_dump($ilCtrl->call_node);
-//var_dump($ilCtrl->forward);
-//var_dump($ilCtrl->parent);
-//var_dump($ilCtrl->root_class);
+		$this->ctrl->initBaseClass("ilObjPluginDispatchGUI");
+		$this->ctrl->setTargetScript("ilias.php");
+		$this->ctrl->getCallStructure(strtolower("ilObjPluginDispatchGUI"));
 
-		$ilCtrl->setParameterByClass(get_class($this), "ref_id", $newObj->getRefId());
-		$ilCtrl->redirectByClass(array("ilobjplugindispatchgui", get_class($this)), $this->getAfterCreationCmd());
+//var_dump($this->ctrl->call_node);
+//var_dump($this->ctrl->forward);
+//var_dump($this->ctrl->parent);
+//var_dump($this->ctrl->root_class);
+
+		$this->ctrl->setParameterByClass(get_class($this), "ref_id", $newObj->getRefId());
+		$this->ctrl->redirectByClass(array("ilobjplugindispatchgui", get_class($this)), $this->getAfterCreationCmd());
 	}
-	
+
 	/**
 	* Cmd that will be redirected to after creation of a new object.
 	*/
 	abstract function getAfterCreationCmd();
-	
+
 	abstract function getStandardCmd();
-	
+
 //	abstract function performCommand();
-	
+
 	/**
 	* Add info screen tab
 	*/
 	function addInfoTab()
 	{
-		$ilAccess = $this->access;
-		$ilTabs = $this->tabs;
-		
+		$this->access = $this->access;
+		$this->tabs = $this->tabs;
+
 		// info screen
-		if ($ilAccess->checkAccess('visible', "", $this->object->getRefId()))
+		if ($this->access->checkAccess('visible', "", $this->object->getRefId()))
 		{
-			$ilTabs->addTarget("info_short",
+			$this->tabs->addTarget("info_short",
 				$this->ctrl->getLinkTargetByClass(
 				"ilinfoscreengui", "showSummary"),
 				"showSummary");
@@ -425,33 +414,32 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	*/
 	function addPermissionTab()
 	{
-		$ilAccess = $this->access;
-		$ilTabs = $this->tabs;
-		$ilCtrl = $this->ctrl;
-		
+		$this->access = $this->access;
+		$this->tabs = $this->tabs;
+		$this->ctrl = $this->ctrl;
+
 		// edit permissions
-		if($ilAccess->checkAccess('edit_permission', "", $this->object->getRefId()))
+		if($this->access->checkAccess('edit_permission', "", $this->object->getRefId()))
 		{
-			$ilTabs->addTarget("perm_settings",
-				$ilCtrl->getLinkTargetByClass("ilpermissiongui", "perm"),
+			$this->tabs->addTarget("perm_settings",
+				$this->ctrl->getLinkTargetByClass("ilpermissiongui", "perm"),
 				array("perm","info","owner"), 'ilpermissiongui');
 		}
 	}
-	
-	
+
 	/**
 	* show information screen
 	*/
 	function infoScreen()
 	{
-		$ilAccess = $this->access;
-		$ilUser = $this->user;
-		$lng = $this->lng;
-		$ilCtrl = $this->ctrl;
-		$tpl = $this->tpl;
-		$ilTabs = $this->tabs;
-		
-		$ilTabs->setTabActive("info_short");
+		$this->access = $this->access;
+		$this->user = $this->user;
+		$this->lng = $this->lng;
+		$this->ctrl = $this->ctrl;
+		$this->tpl = $this->tpl;
+		$this->tabs = $this->tabs;
+
+		$this->tabs->setTabActive("info_short");
 		
 		$this->checkPermission("visible");
 
@@ -460,13 +448,13 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 		$info->enablePrivateNotes();
 
 		// general information
-		$lng->loadLanguageModule("meta");
+		$this->lng->loadLanguageModule("meta");
 
 		$this->addInfoItems($info);
 
 		// forward the command
-		$ret = $ilCtrl->forwardCommand($info);
-		//$tpl->setContent($ret);
+		$ret = $this->ctrl->forwardCommand($info);
+		//$this->tpl->setContent($ret);
 	}
 
 	/**
@@ -486,11 +474,11 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 		$ilCtrl = $DIC->ctrl();
 		$ilAccess = $DIC->access();
 		$lng = $DIC->language();
-		
+
 		$t = explode("_", $a_target[0]);
 		$ref_id = (int) $t[0];
 		$class_name = $a_target[1];
-		
+
 		if ($ilAccess->checkAccess("read", "", $ref_id))
 		{
 			$ilCtrl->initBaseClass("ilObjPluginDispatchGUI");
@@ -516,14 +504,13 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 		}
 	}
 
-
 	/**
 	 * @return bool
 	 */
 	protected function supportsExport() {
-		$ilPluginAdmin = $this->plugin_admin;
+		$this->plugin_admin = $this->plugin_admin;
 
-		return $ilPluginAdmin->supportsExport(IL_COMP_SERVICE, "Repository", "robj", $this->getPlugin()->getPluginName());
+		return $this->plugin_admin->supportsExport(IL_COMP_SERVICE, "Repository", "robj", $this->getPlugin()->getPluginName());
 	}
 
 

--- a/Services/Repository/classes/class.ilObjectPluginGUI.php
+++ b/Services/Repository/classes/class.ilObjectPluginGUI.php
@@ -55,6 +55,13 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	*/
 	function executeCommand()
 	{
+		$this->ctrl = $this->ctrl;
+		$this->tpl = $this->tpl;
+		$this->access = $this->access;
+		$this->lng = $this->lng;
+		$this->nav_history = $this->nav_history;
+		$this->tabs = $this->tabs;
+
 		// get standard template (includes main menu and general layout)
 		$this->tpl->getStandardTemplate();
 
@@ -174,6 +181,8 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	*/
 	function addLocatorItems()
 	{
+		$this->locator = $this->locator;
+
 		if (!$this->getCreationMode())
 		{
 			$this->locator->addItem($this->object->getTitle(),
@@ -297,6 +306,9 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	*/
 	public function initEditForm()
 	{
+		$this->lng = $this->lng;
+		$this->ctrl = $this->ctrl;
+
 		include_once("Services/Form/classes/class.ilPropertyFormGUI.php");
 		$form = new ilPropertyFormGUI();
 		$form->setTarget("_top");
@@ -354,6 +366,7 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	*/
 	function afterSave(ilObject $newObj)
 	{
+		$this->ctrl = $this->ctrl;
 		// always send a message
 		ilUtil::sendSuccess($this->lng->txt("object_added"),true);
 
@@ -384,6 +397,9 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	*/
 	function addInfoTab()
 	{
+		$this->access = $this->access;
+		$this->tabs = $this->tabs;
+
 		// info screen
 		if ($this->access->checkAccess('visible', "", $this->object->getRefId()))
 		{
@@ -399,6 +415,10 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	*/
 	function addPermissionTab()
 	{
+		$this->access = $this->access;
+		$this->tabs = $this->tabs;
+		$this->ctrl = $this->ctrl;
+
 		// edit permissions
 		if($this->access->checkAccess('edit_permission', "", $this->object->getRefId()))
 		{
@@ -430,8 +450,15 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	*/
 	function infoScreen()
 	{
-		$this->tabs->setTabActive("info_short");
+		$this->access = $this->access;
+		$this->user = $this->user;
+		$this->lng = $this->lng;
+		$this->ctrl = $this->ctrl;
+		$this->tpl = $this->tpl;
+		$this->tabs = $this->tabs;
 
+		$this->tabs->setTabActive("info_short");
+		
 		$this->checkPermission("visible");
 
 		include_once("./Services/InfoScreen/classes/class.ilInfoScreenGUI.php");
@@ -499,6 +526,8 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 	 * @return bool
 	 */
 	protected function supportsExport() {
+		$this->plugin_admin = $this->plugin_admin;
+
 		return $this->plugin_admin->supportsExport(IL_COMP_SERVICE, "Repository", "robj", $this->getPlugin()->getPluginName());
 	}
 


### PR DESCRIPTION
I tried to get the export function in our plugins. As example we looked at the TestRepositoryObject where the export is enabled. The used way is in my opinion a litte unhappy.

The plugin has to overwrite the executeCommand to get an active export tab and handle the showExport command as well. I think this is not necessary, because the parent has implemented the forwarding on nextClass to the export gui.

After a quick look i think it will be more comfortable, if the export is handle equal as the permission tab. The tab is created within a function of ilObjectPluginGUI and the tab gets active if we enter the nextClass forward.

This changes are more viewable in this commit:
https://github.com/ILIAS-eLearning/ILIAS/commit/1bb82c153c40f245270055ce8587be3b7b9420aa
https://github.com/ILIAS-eLearning/ILIAS/commit/6475972161b09c061cb439aa8c40dee094dce250

I create a PR for TestRepositoryObject too, where i displayed the changes and advantages. This PR is here: https://github.com/ILIAS-eLearning/TestRepositoryObject/pull/8

The other changes are only a correct usage of class properties.