### PR TITLE
Support PHP 7.1 with ILIAS 5.2

### DIFF
--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -648,7 +648,7 @@ When you upgrade from rather old versions please make sure that the dependencies
 | ILIAS Version   | PHP Version                           |
 |-----------------|---------------------------------------|
 | 5.3.x           | 5.6.x, 7.0.x, 7.1.x                   |
-| 5.2.x           | 5.5.x - 5.6.x, 7.0.x                  |
+| 5.2.x           | 5.5.x - 5.6.x, 7.0.x, 7.1.x           |
 | 5.0.x - 5.1.x   | 5.3.x - 5.5.x                         |
 | 4.4.x           | 5.3.x - 5.5.x                         |
 | 4.3.x           | 5.2.6 - 5.4.x                         |


### PR DESCRIPTION
See JF Decision:
https://www.ilias.de/mantis/view.php?id=22487

TB can still veto this on its meeting at 7 Feb 2018.