### PR TITLE
UI/Button: allow buttons to change the view's status

### DIFF
--- a/src/UI/Factory.php
+++ b/src/UI/Factory.php
@@ -220,6 +220,8 @@ interface Factory {
 	 * description:
 	 *   purpose: >
 	 *      Buttons trigger interactions that change the system’s or view's status.
+	 *      Acceptable changes to the current view are those that do not result in
+	 *      a complete replacement of the overall screen (e.g. modals).
 	 *   composition: >
 	 *      Button is a clickable, graphically obtrusive control element. It can
 	 *      bear text.

--- a/src/UI/Factory.php
+++ b/src/UI/Factory.php
@@ -219,10 +219,7 @@ interface Factory {
 	 * ---
 	 * description:
 	 *   purpose: >
-	 *      Buttons trigger interactions that change the system’s status. Usually
-	 *      Buttons are contained in an Input Collection. The Toolbar is the main
-	 *      exception to this rule, since buttons in the Toolbar might also perform
-	 *      view changes.
+	 *      Buttons trigger interactions that change the system’s or view's status.
 	 *   composition: >
 	 *      Button is a clickable, graphically obtrusive control element. It can
 	 *      bear text.
@@ -249,8 +246,8 @@ interface Factory {
 	 *           Buttons MUST NOT be used inside a Textual Paragraph.
 	 *   interaction:
 	 *      1: >
-	 *           A Button SHOULD trigger an action. Only in Toolbars, Buttons MAY also
-	 *           change the view.
+	 *           A Button SHOULD trigger an action that either changes the status of the
+	 *           system or the view.
 	 *      2: >
 	 *           If an action is temporarily not available, Buttons MUST be disabled by
 	 *           setting as type 'disabled'.

--- a/src/UI/Factory.php
+++ b/src/UI/Factory.php
@@ -245,12 +245,11 @@ interface Factory {
 	 *      1: >
 	 *           Buttons MUST NOT be used inside a Textual Paragraph.
 	 *   interaction:
-	 *      1: >
-	 *           A Button SHOULD trigger an action that either changes the status of the
-	 *           system or the view.
 	 *      2: >
 	 *           If an action is temporarily not available, Buttons MUST be disabled by
 	 *           setting as type 'disabled'.
+	 *      3: >
+	 *           A button MUST NOT be used for navigational purpose.
 	 *   style:
 	 *      1: >
 	 *           If Text is used inside a Button, the Button MUST be at least six characters


### PR DESCRIPTION
The current rules of the KS state, that buttons change the system's status, expect for buttons in Toolbars. IMO this neither reflects the state of the art when it comes to buttons, nor it is desireable in general. I therefore suggest to change the button-rules accordingly, so also changes in the view are allowed to be attached to buttons.

The reasons why the current rules of the button seem to be to narrow:

* The disallow attaching Modals etc. to Buttons. This is already done in the calendar, as far as i know. Also, attaching a Modal to a Button seem to be highly desireable and also the only way to display a Modal at all atm.
* Buttons are already used in the View Control Mode for other purpose than triggering changes of the systems status.
* It could be doubted that buttons only trigger state changes in the system even if modals are disregarded. In the standard "save" -> "confirm" workflow in ILIAS only the "confirm"-Button really triggers the change of the systems status. 
* It seems quite normal in general (not only in ILIAS) that buttons also trigger view changes. 