### PR TITLE
Fix/0012860/5 4/filtering mbstrings

### DIFF
--- a/Services/Database/classes/MDB2/class.ilDB.php
+++ b/Services/Database/classes/MDB2/class.ilDB.php
@@ -2510,9 +2510,11 @@ abstract class ilDB extends PEAR implements ilDBInterface
 
 	/**
 	 * @param string $engine
+	 *
 	 * @return array
 	 */
-	public function migrateAllTablesToEngine($engine = ilDBConstants::MYSQL_ENGINE_INNODB) {
+	public function migrateAllTablesToEngine($engine = ilDBConstants::MYSQL_ENGINE_INNODB)
+	{
 		return array();
 	}
 
@@ -2520,10 +2522,12 @@ abstract class ilDB extends PEAR implements ilDBInterface
 	/**
 	 * @return bool
 	 */
-	public function supportsEngineMigration() {
+	public function supportsEngineMigration()
+	{
 		return false;
 	}
 
+	
 	/**
 	 * @param $table_name
 	 * @return string
@@ -2540,5 +2544,28 @@ abstract class ilDB extends PEAR implements ilDBInterface
 		require_once('./Services/Database/classes/Atom/class.ilAtomQueryLock.php');
 
 		return new ilAtomQueryLock($this);
+	}
+
+
+	/**
+	 * @inheritdoc
+	 */
+	public function sanitizeMB4StringIfNotSupported($query)
+	{
+		if (!$this->doesCollationSupportMB4Strings()) {
+			$query = preg_replace(
+				'/[\x{10000}-\x{10FFFF}]/u', ilDBConstants::MB4_REPLACEMENT, $query
+			);
+		}
+
+		return $query;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function doesCollationSupportMB4Strings()
+	{
+		return false;
 	}
 }

--- a/Services/Database/classes/MDB2/class.ilDBInnoDB.php
+++ b/Services/Database/classes/MDB2/class.ilDBInnoDB.php
@@ -63,4 +63,3 @@ class ilDBInnoDB extends ilDBMySQL {
 	}
 }
 
-?>

--- a/Services/Database/classes/MDB2/class.ilDBMySQL.php
+++ b/Services/Database/classes/MDB2/class.ilDBMySQL.php
@@ -661,4 +661,4 @@ class ilDBMySQL extends ilDB
 		return 'MyISAM';
 	}
 }
-?>
+

--- a/Services/Database/classes/MDB2/class.ilDBOracle.php
+++ b/Services/Database/classes/MDB2/class.ilDBOracle.php
@@ -503,4 +503,3 @@ class ilDBOracle extends ilDB
 		return false;
 	}
 }
-?>

--- a/Services/Database/classes/MDB2/class.ilDBPostgreSQL.php
+++ b/Services/Database/classes/MDB2/class.ilDBPostgreSQL.php
@@ -264,19 +264,4 @@ class ilDBPostgreSQL extends ilDB
 	public function setStorageEngine($storage_engine) {
 		return false;
 	}
-
-
-	public function getServerVersion($native = false) {
-		// TODO: Implement getServerVersion() method.
-	}
-
-
-	public function queryCol($query, $type = ilDBConstants::FETCHMODE_DEFAULT, $colnum = 0) {
-		
-	}
-
-
-	public function queryRow($query, $types = null, $fetchmode = ilDBConstants::FETCHMODE_DEFAULT) {
-		// TODO: Implement queryRow() method.
-	}
 }

--- a/Services/Database/classes/PDO/class.ilDBPdo.php
+++ b/Services/Database/classes/PDO/class.ilDBPdo.php
@@ -614,6 +614,8 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface {
 		$fields = implode("`,`", $fields);
 		$query = "INSERT INTO " . $table_name . " (`" . $fields . "`) VALUES (" . $values . ")";
 
+		$query = $this->sanitizeMB4StringIfNotSupported($query);
+
 		return $this->pdo->exec($query);
 	}
 
@@ -651,18 +653,23 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface {
 		$lobs = false;
 		$lob = array();
 		foreach ($columns as $k => $col) {
+			$field_value = $col[1];
 			$fields[] = $k;
 			$placeholders[] = "%s";
 			$placeholders_full[] = ":$k";
 			$types[] = $col[0];
 
-			// integer auto-typecast (this casts bool values to integer)
-			if ($col[0] == 'integer' && !is_null($col[1])) {
-				$col[1] = (int)$col[1];
+			if ($col[0] == "blob" || $col[0] == "clob" || $col[0] == 'text') {
+				$field_value = $this->sanitizeMB4StringIfNotSupported($field_value);
 			}
 
-			$values[] = $col[1];
-			$field_values[$k] = $col[1];
+			// integer auto-typecast (this casts bool values to integer)
+			if ($col[0] == 'integer' && !is_null($field_value)) {
+				$field_value = (int)$field_value;
+			}
+
+			$values[] = $field_value;
+			$field_values[$k] = $field_value;
 			if ($col[0] == "blob" || $col[0] == "clob") {
 				$lobs = true;
 				$lob[$k] = $k;
@@ -712,6 +719,7 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface {
 	}
 
 
+
 	/**
 	 * @param string $query
 	 * @return bool|int
@@ -721,6 +729,7 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface {
 		global $DIC;
 		$ilBench = $DIC['ilBench'];
 		try {
+			$query = $this->sanitizeMB4StringIfNotSupported($query);
 			if ($ilBench instanceof ilBenchmark) {
 				$ilBench->startDbBench($query);
 			}
@@ -1729,6 +1738,22 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface {
 
 
 	/**
+	 * @inheritDoc
+	 */
+	public function migrateAllTablesToCollation($collation = ilDBConstants::MYSQL_COLLATION_UTF8MB4) {
+		return array();
+	}
+
+
+	/**
+	 * @inheritDoc
+	 */
+	public function supportsCollationMigration() {
+		return false;
+	}
+
+
+	/**
 	 * @return bool
 	 */
 	public function supportsEngineMigration() {
@@ -2015,10 +2040,34 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface {
 
 	/**
 	 * @return string
+	 * @throws ilDatabaseException
 	 */
 	public function getDBVersion() {
 		$d = $this->fetchObject($this->query("SELECT VERSION() AS version"));
 
 		return ($d->version ? $d->version : 'Unknown');
+	}
+
+
+	/**
+	 * @inheritdoc
+	 */
+	public function sanitizeMB4StringIfNotSupported($query)
+	{
+		if (!$this->doesCollationSupportMB4Strings()) {
+			$query = preg_replace(
+				'/[\x{10000}-\x{10FFFF}]/u', ilDBConstants::MB4_REPLACEMENT, $query
+			);
+		}
+
+		return $query;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function doesCollationSupportMB4Strings()
+	{
+		return false;
 	}
 }

--- a/Services/Database/classes/PDO/class.ilDBPdoMySQL.php
+++ b/Services/Database/classes/PDO/class.ilDBPdoMySQL.php
@@ -73,6 +73,35 @@ abstract class ilDBPdoMySQL extends ilDBPdo implements ilDBInterface {
 
 
 	/**
+	 * @inheritDoc
+	 */
+	public function migrateAllTablesToCollation($collation = ilDBConstants::MYSQL_COLLATION_UTF8MB4)
+	{
+		$ilDBPdoManager = $this->loadModule(ilDBConstants::MODULE_MANAGER);
+		$errors = array();
+		foreach ($ilDBPdoManager->listTables() as $table_name) {
+			$q = "ALTER TABLE {$this->quoteIdentifier($table_name)} CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;";
+			try {
+				$this->pdo->exec($q);
+			} catch (PDOException $e) {
+				$errors[] = $table_name;
+			}
+		}
+
+		return $errors;
+	}
+
+
+	/**
+	 * @inheritDoc
+	 */
+	public function supportsCollationMigration()
+	{
+		return true;
+	}
+
+
+	/**
 	 * @param string $table_name
 	 * @return int
 	 */
@@ -95,6 +124,29 @@ abstract class ilDBPdoMySQL extends ilDBPdo implements ilDBInterface {
 		}
 
 		return $value;
+	}
+
+
+	/**
+	 * @inheritDoc
+	 */
+	public function doesCollationSupportMB4Strings()
+	{
+		// Currently ILIAS does not support utf8mb4, after that ilDB could check like this:
+		//		static $supported;
+		//		if (!isset($supported)) {
+		//			$q = "SELECT default_character_set_name FROM information_schema.SCHEMATA WHERE schema_name = %s;";
+		//			$res = $this->queryF($q, ['text'], [$this->getDbname()]);
+		//			$data = $this->fetchObject($res);
+		//			$supported = ($data->default_character_set_name === 'utf8mb4');
+		//		}
+
+		$q = "SHOW VARIABLES LIKE '%vers%'";
+		$res = $this->query($q);
+					$data = $this->fetchObject($res);
+		//			$supported = ($data->default_character_set_name === 'utf8mb4');
+
+		return false;
 	}
 }
 

--- a/Services/Database/classes/PDO/class.ilDBPdoPostgreSQL.php
+++ b/Services/Database/classes/PDO/class.ilDBPdoPostgreSQL.php
@@ -436,5 +436,6 @@ class ilDBPdoPostgreSQL extends ilDBPdo implements ilDBInterface {
 	public function dropPrimaryKey($table_name) {
 		return $this->manager->dropConstraint($table_name, "pk", true);
 	}
+
 }
 

--- a/Services/Database/classes/class.ilDBAnalyzer.php
+++ b/Services/Database/classes/class.ilDBAnalyzer.php
@@ -24,7 +24,7 @@ class ilDBAnalyzer {
 	 */
 	protected $reverse;
 	/**
-	 * @var \ilDB|\ilDBInterface
+	 * @var \ilDBInterface
 	 */
 	protected $il_db;
 	/**

--- a/Services/Database/classes/class.ilDBConstants.php
+++ b/Services/Database/classes/class.ilDBConstants.php
@@ -49,12 +49,20 @@ class ilDBConstants {
 	// Engines
 	const MYSQL_ENGINE_INNODB = 'InnoDB';
 	const MYSQL_ENGINE_MYISAM = 'MyISAM';
+	// Characters
+	const MYSQL_CHARACTER_UTF8 = 'utf8';
+	const MYSQL_CHARACTER_UTF8MB4 = 'utf8mb4';
+	// Collations
+	const MYSQL_COLLATION_UTF8 = 'utf8_general_ci';
+	const MYSQL_COLLATION_UTF8MB4 = 'utf8mb4_general_ci';
 	// Mapping AutoExec
 	const MDB2_AUTOQUERY_INSERT = 1;
 	const MDB2_AUTOQUERY_UPDATE = 2;
 	const MDB2_AUTOQUERY_DELETE = 3;
 	const MDB2_AUTOQUERY_SELECT = 4;
 	const MDB2_PREPARE_MANIP = false;
+	// Other
+	const MB4_REPLACEMENT = "?";
 	/**
 	 * @var array
 	 */

--- a/Services/Database/interfaces/interface.ilDBInterface.php
+++ b/Services/Database/interfaces/interface.ilDBInterface.php
@@ -9,6 +9,18 @@
 interface ilDBInterface {
 
 	/**
+	 * @return bool
+	 */
+	public function doesCollationSupportMB4Strings();
+
+	/**
+	 * @param $query string to sanitize, all MB4-Characters like emojis will re replaced with ???
+	 *
+	 * @return string sanitized query
+	 */
+	public function sanitizeMB4StringIfNotSupported($query);
+
+	/**
 	 * Get reserved words. This must be overwritten in DBMS specific class.
 	 * This is mainly used to check whether a new identifier can be problematic
 	 * because it is a reserved word. So createTable / alterTable usually check
@@ -662,7 +674,7 @@ interface ilDBInterface {
 /**
  * Interface ilDBPdoInterface
  */
-interface ilDBPdoInterface {
+interface ilDBPdoInterface extends ilDBInterface {
 
 	/**
 	 * @param bool $native
@@ -706,6 +718,7 @@ interface ilDBPdoInterface {
 
 	/**
 	 * @param string $engine
+	 *
 	 * @return array of failed tables
 	 */
 	public function migrateAllTablesToEngine($engine = ilDBConstants::MYSQL_ENGINE_INNODB);
@@ -715,6 +728,20 @@ interface ilDBPdoInterface {
 	 * @return bool
 	 */
 	public function supportsEngineMigration();
+
+
+	/**
+	 * @param string $collation
+	 *
+	 * @return array of failed tables
+	 */
+	public function migrateAllTablesToCollation($collation = ilDBConstants::MYSQL_COLLATION_UTF8MB4);
+
+
+	/**
+	 * @return bool
+	 */
+	public function supportsCollationMigration();
 
 
 	/**


### PR DESCRIPTION
This is the filter in ilDB wich will filter all mb4-strings and replace them by `?` . This does not fix already broken PageEditorPages or other broken content, it will just prevent ILIAS from storing more broken data to database.

This is an interface-change of a defined internal interface in ilDBInterface, therefore this has to be accepted in JF.