### PR TITLE
Remove unkown expression for old chat versions

### DIFF
--- a/Modules/Chatroom/chat/Persistence/Database.js
+++ b/Modules/Chatroom/chat/Persistence/Database.js
@@ -537,7 +537,9 @@ var Database = function Database(config) {
 		if (typeof Object.values === "function") {
 			return Object.values(participantsJson);
 		} else {
-			return Object.keys(participantsJson).map((k) => participantsJson[k]);
+			return Object.keys(participantsJson).map(function(k) {
+				return participantsJson[k]
+			});
 		}
 	}
 


### PR DESCRIPTION
Based on the bug: https://www.ilias.de/mantis/view.php?id=22647

Old versions of node.js can't handle the `k => a[k]` expression and will lead to an error during the runtime.

This PR will fix this.