### PR TITLE
Add plugin language translation to news feed

### DIFF
--- a/Services/News/classes/class.ilNewsDefaultRendererGUI.php
+++ b/Services/News/classes/class.ilNewsDefaultRendererGUI.php
@@ -23,6 +23,10 @@ class ilNewsDefaultRendererGUI implements ilNewsRendererGUI
 	 * @var ilLanguage
 	 */
 	protected $lng;
+	/**
+	 * @var ilObjectDefinition $obj_dev
+	 */
+	protected $obj_def;
 
 	/**
 	 * @var ilNewsItem
@@ -36,9 +40,6 @@ class ilNewsDefaultRendererGUI implements ilNewsRendererGUI
 
 	/**
 	 * Constructor
-	 *
-	 * @param
-	 * @return
 	 */
 	function __construct()
 	{
@@ -46,6 +47,7 @@ class ilNewsDefaultRendererGUI implements ilNewsRendererGUI
 
 		$this->ctrl = $DIC->ctrl();
 		$this->lng = $DIC->language();
+		$this->obj_def = $DIC['objDefinition'];
 	}
 
 	/**
@@ -102,8 +104,21 @@ class ilNewsDefaultRendererGUI implements ilNewsRendererGUI
 	{
 		if ($this->news_item->getContentTextIsLangVar())
 		{
-			$this->lng->loadLanguageModule($this->news_item->getContextObjType());
-			return $this->lng->txt($this->news_item->getContent());
+			$content = NULL;
+			if ($this->obj_def->isPlugin($this->news_item->getContextObjType()))
+			{
+				$content = ilObjectPlugin::lookupTxtById(
+					$this->news_item->getContextObjType(),
+					$this->news_item->getContent()
+				);
+			}
+			else
+			{
+				$this->lng->loadLanguageModule($this->news_item->getContextObjType());
+				$content = $this->lng->txt($this->news_item->getContent());
+			}
+
+			return $content;
 		}
 
 		$content = $this->makeClickable($this->news_item->getContent());

--- a/Services/News/classes/class.ilNewsForContextBlockGUI.php
+++ b/Services/News/classes/class.ilNewsForContextBlockGUI.php
@@ -390,7 +390,13 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
 	*/
 	function fillRow($news)
 	{
-		global $ilUser, $ilCtrl, $lng;
+		global $DIC;
+		$ilCtrl = $DIC->ctrl();
+		$lng = $DIC->language();
+		/**
+		 * @var ilObjectDefinition $objDefinition
+		 */
+		$objDefinition = $DIC['objDefinition'];
 
 		if ($this->getCurrentDetailLevel() > 2)
 		{
@@ -432,8 +438,14 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
 				? "lres"
 				: "obj_".$type;
 
+			$langTypeTranslation = NULL;
+			if ($objDefinition->isPlugin($news["context_obj_type"]))
+				$langTypeTranslation = ilObjectPlugin::lookupTxtById($news["context_obj_type"], $lang_type);
+			else
+				$langTypeTranslation = $lng->txt($lang_type);
+
 			$this->tpl->setCurrentBlock("news_context");
-			$this->tpl->setVariable("TYPE", $lng->txt($lang_type));
+			$this->tpl->setVariable("TYPE", $langTypeTranslation);
 			$this->tpl->setVariable("IMG_TYPE",
 				ilObject::_getIcon($obj_id, "tiny", $type));
 			$this->tpl->setVariable("TITLE",

--- a/Services/News/classes/class.ilNewsItem.php
+++ b/Services/News/classes/class.ilNewsItem.php
@@ -1680,14 +1680,28 @@ class ilNewsItem
 
 		return $objs;
 	}
-	
+
+
 	/**
 	 * Determine title for news item entry
+	 *
+	 * @param string        $a_context_obj_type
+	 * @param string        $a_title
+	 * @param bool          $a_content_is_lang_var
+	 * @param int           $a_agg_ref_id
+	 * @param string|array  $a_aggregation
+	 *
+	 * @return string
 	 */
 	static function determineNewsTitle($a_context_obj_type, $a_title, $a_content_is_lang_var,
 		$a_agg_ref_id = 0, $a_aggregation = "")
 	{
-		global $lng;
+		global $DIC;
+		$lng = $DIC->language();
+		/**
+		 * @var ilObjectDefinition $objDefinition
+		 */
+		$objDefinition = $DIC['objDefinition'];
 
 		if ($a_agg_ref_id > 0)
 		{
@@ -1745,6 +1759,9 @@ class ilNewsItem
 		{
 			if ($a_content_is_lang_var)
 			{
+				if($objDefinition->isPlugin($a_context_obj_type))
+					return ilObjectPlugin::lookupTxtById($a_context_obj_type, $a_title);
+
 				return $lng->txt($a_title);
 			}
 			else
@@ -1752,8 +1769,6 @@ class ilNewsItem
 				return $a_title;
 			}
 		}
-		
-		return "";
 	}
 
 	/**
@@ -1761,10 +1776,18 @@ class ilNewsItem
 	 */
 	static function determineNewsContent($a_context_obj_type, $a_content, $a_is_lang_var)
 	{
-		global $lng;
+		global $DIC;
+		$lng = $DIC->language();
+		/**
+		 * @var ilObjectDefinition $objDefinition
+		 */
+		$objDefinition = $DIC['objDefinition'];
 
 		if ($a_is_lang_var)
 		{
+			if($objDefinition->isPlugin($a_context_obj_type))
+				return ilObjectPlugin::lookupTxtById($a_context_obj_type, $a_title);
+
 			$lng->loadLanguageModule($a_context_obj_type);
 			return $lng->txt($a_content);
 		}

--- a/Services/News/classes/class.ilNewsTimelineItemGUI.php
+++ b/Services/News/classes/class.ilNewsTimelineItemGUI.php
@@ -209,7 +209,16 @@ class ilNewsTimelineItemGUI implements ilTimelineItemInt
 		}
 		else
 		{
-			$tpl->setVariable("TITLE", $this->lng->txt($i->getTitle()));
+			$title = NULL;
+			if ($this->obj_def->isPlugin($i->getContextObjType()))
+			{
+				$title = ilObjectPlugin::lookupTxtById($i->getContextObjType(), $i->getTitle());
+			}
+			else
+			{
+				$title = $this->lng->txt($i->getTitle());
+			}
+			$tpl->setVariable("TITLE", $title);
 		}
 
 		// content


### PR DESCRIPTION
Proposal to improve the news feed language integration.

The proposal consists of:
* Change of the way the news read a given language variable by object type.

There is also bug report created by my self [0022644](https://www.ilias.de/mantis/view.php?id=22644), which got closed due to the fact that it was never intended to support plugins. 

However I would like to point out that the news feed is  able to use the plugin language files with almost no changes. Due to this fact I would like to propose the change as an improvement instead of a feature request which requires a lot of time. 