### PR TITLE
Preparation for Mantis 19682 - Add log entry if solution is willingly deleted

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assQuestion.php
@@ -5316,6 +5316,8 @@ abstract class assQuestion
 		$this->removeExistingSolutions($activeId, $pass);
 		$this->removeResultRecord($activeId, $pass);
 
+		assQuestion::log($activeId, "log_user_solution_willingly_deleted");
+		
 		self::_updateTestPassResults(
 			$activeId, $pass, $this->areObligationsToBeConsidered(), $this->getProcessLocker(), $this->getTestId()
 		);

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -824,6 +824,7 @@ assessment#:#log_user_answered_question#:#Ein Benutzer beantwortet eine Frage un
 assessment#:#log_user_data_removed#:#Die Testdaten aller Benutzer wurden entfernt###deprecated
 assessment#:#log_user_entered_values#:#Der Benutzer hat Werte eingetragen
 assessment#:#log_user_not_entered_values#:#Der Benutzer hat keine Werte eingetragen
+assessment#:#log_user_solution_willingly_deleted#:#Der Benutzer hat seine Antwort entfernt.
 assessment#:#mailnottype#:#Ein Versand findet auch beim Beenden einzelner Testdurchläufe statt
 assessment#:#maintenance#:#Wartung
 assessment#:#manscoring#:#Manuelle Bewertung

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -714,6 +714,7 @@ assessment#:#log_user_answered_question#:#User answered a question and received 
 assessment#:#log_user_data_removed#:#Removed all user data###deprecated
 assessment#:#log_user_entered_values#:#User entered values
 assessment#:#log_user_not_entered_values#:#User did not enter values
+assessment#:#log_user_solution_willingly_deleted#:#User deleted the answer.
 assessment#:#maintenance#:#Maintenance
 assessment#:#manscoring_done#:#Scored Participants
 assessment#:#manscoring_hint#:#You have added at least one question which may require manual scoring. To avoid that participants get already access to the test results before you finished manual scoring, please define a suitable date for the access to the test results.


### PR DESCRIPTION
Since ILIAS 5.1 users can delete answers during a test but this is not logged. We can't distinguish between a somehow lost answer and a willingly deleted answer anymore.

To enable us to better understand the issue in Mantis 19682, we need this log.