### PR TITLE
Fix mantis 22320 - no access to uploaded file(s) during manual correction in "Scoring by Question"-mode

### DIFF
--- a/Modules/Test/classes/class.ilTestScoringByQuestionsGUI.php
+++ b/Modules/Test/classes/class.ilTestScoringByQuestionsGUI.php
@@ -351,7 +351,7 @@ class ilTestScoringByQuestionsGUI extends ilTestScoringGUI
 		$question_gui = $this->object->createQuestionGUI('', $question_id);
 
 		$tmp_tpl = new ilTemplate('tpl.il_as_tst_correct_solution_output.html', TRUE, TRUE, 'Modules/Test');
-		$result_output = $question_gui->getSolutionOutput($active_id, $pass, FALSE, FALSE, FALSE, $this->object->getShowSolutionFeedback());
+		$result_output = $question_gui->getSolutionOutput($active_id, $pass, FALSE, FALSE, FALSE, $this->object->getShowSolutionFeedback(), FALSE, TRUE);
 		$tmp_tpl->setVariable('TEXT_YOUR_SOLUTION', $this->lng->txt('answers_of') .' '. $participant->getName());
 		$maxpoints = $question_gui->object->getMaximumPoints();
 


### PR DESCRIPTION
The upload question is not to be blamed for this issue. Instead the calling class (class.ilTestScoringByQuestionsGUI.php) did not set the parameter "show_manual_scoring = TRUE" for "getSolutionOutput()". So in the ScoringByQuestionGUI the version for the participant in "Detailed Results" was always shown and not the version for manual correction. 

The other correction mode "Scoring by participants" is correct and the parameter "show_manual_scoring = TRUE" is set as expected (class.ilTestScoringGUI.php, line 394).

As with this fix, the parameter is finally correctly set for manual correction in both modes, I expect nothing to be broken by this change.