### PR TITLE
Fix of: #22531

### DIFF
--- a/Services/Utilities/classes/class.ilUtil.php
+++ b/Services/Utilities/classes/class.ilUtil.php
@@ -4895,7 +4895,7 @@ class ilUtil
 	{
 		global $DIC;
 
-		$tpl = $DIC["tpl"];
+		$tpl = $DIC->tpl;
 		if(is_object($tpl))
 		{
 			$tpl->setMessage("failure", $a_info, $a_keep);


### PR DESCRIPTION
Fix of https://ilias.de/mantis/view.php?id=22531. Note that Whoops\Exception\ErrorException thrown with message "Uncaught InvalidArgumentException: Identifier "tpl" is not defined. in ./libs/composer/vendor/pimple/pimple/src/Pimple/Container.php:96 is thrown if accessed by array index. 

If fine with you, also propagate to 5.3.