### PR TITLE
[Fix 0022724] Rebuilding instead of modifying Sequence in Hotfix 12

### DIFF
--- a/setup/sql/5_3_hotfixes.php
+++ b/setup/sql/5_3_hotfixes.php
@@ -196,7 +196,7 @@ $res = $ilDB->query($query);
 while($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT))
 {
 	$ilDB->dropSequence("il_meta_description");
-	$ilDB->createSequence("il_meta_description", $row->desc_id);
+	$ilDB->createSequence("il_meta_description", $row->desc_id + 100);
 }
 ?>
 <#13>

--- a/setup/sql/5_3_hotfixes.php
+++ b/setup/sql/5_3_hotfixes.php
@@ -195,8 +195,8 @@ $query = 'SELECT MAX(meta_description_id) desc_id from il_meta_description ';
 $res = $ilDB->query($query);
 while($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT))
 {
-	$query = 'UPDATE il_meta_description_seq SET sequence = '. $ilDB->quote($row->desc_id + 100);
-	$ilDB->manipulate($query);
+	$ilDB->dropSequence("il_meta_description");
+	$ilDB->createSequence("il_meta_description", $row->desc_id);
 }
 ?>
 <#13>


### PR DESCRIPTION
Due to Compatibility-Problems with PostgreSQL, modifying a sequence is not the preferred way. Instead of this you should recreate a sequence with the new starting-val