### PR TITLE
Init: remove unsafe characters from  recursively

### DIFF
--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -43,6 +43,7 @@ class ilInitialisation
 	protected static function recursivelyRemoveUnsafeCharacters(&$var) {
 		if (is_array($var)) {
 			foreach ($var as $k => $v) {
+				$k = $this->recursivelyRemoveUnsafeCharacters($k);
 				$var[$k] = self::recursivelyRemoveUnsafeCharacters($v);
 			}
 			return $var;

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -43,6 +43,7 @@ class ilInitialisation
 	protected static function recursivelyRemoveUnsafeCharacters(&$var) {
 		if (is_array($var)) {
 			foreach ($var as $k => $v) {
+				unset($var[$k]);
 				$k = $this->recursivelyRemoveUnsafeCharacters($k);
 				$var[$k] = self::recursivelyRemoveUnsafeCharacters($v);
 			}

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -37,18 +37,23 @@ class ilInitialisation
 		// We do not need this characters in any case, so it is
 		// feasible to filter them everytime. POST parameters
 		// need attention through ilUtil::stripSlashes() and similar functions)
-		if (is_array($_GET))
-		{
-			foreach($_GET as $k => $v)
-			{
-				// \r\n used for IMAP MX Injection
-				// ' used for SQL Injection
-				$_GET[$k] = str_replace(array("\x00", "\n", "\r", "\\", "'", '"', "\x1a"), "", $v);
+		self::recursivelyRemoveUnsafeCharacters($_GET);
+	}
 
-				// this one is for XSS of any kind
-				$_GET[$k] = strip_tags($_GET[$k]);
+	protected static function recursivelyRemoveUnsafeCharacters(&$var) {
+		if (is_array($var)) {
+			foreach ($var as $k => $v) {
+				$var[$k] = self::recursivelyRemoveUnsafeCharacters($v);
 			}
+			return $var;
 		}
+		return strip_tags(
+			str_replace(
+				array("\x00", "\n", "\r", "\\", "'", '"', "\x1a"),
+				"",
+				$var
+			)
+		);
 	}
 	
 	/**


### PR DESCRIPTION
This allows $_GET-parameters to be nested more then one level.