### PR TITLE
.gitignore: Added '/Customizing/clients'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 # Directories
 /data
 /Customizing/global
+/Customizing/clients
 /setup/sql/ilDBTemplate
 virtual-data
 


### PR DESCRIPTION
This tiny change improves the possibility to build a hash based on the 'git status' output of an ILIAS installation.