### PR TITLE
Mime Type Detection: Added tests for Youtube/Vimeo URLs

### DIFF
--- a/Services/Utilities/test/ilMimeTypeTest.php
+++ b/Services/Utilities/test/ilMimeTypeTest.php
@@ -1,0 +1,38 @@
+<?php
+/* Copyright (c) 1998-2018 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+require_once 'libs/composer/vendor/autoload.php';
+
+/**
+ * Class ilMimeTypeTest
+ */
+class ilMimeTypeTest extends \PHPUnit_Framework_TestCase
+{
+	/**
+	 *
+	 */
+	public function testMimeTypeForYoutubeUrlCouldBeCorrectlyDetected()
+	{
+		$expected = 'video/youtube';
+		$actual   = \ilMimeTypeUtil::lookupMimeType(
+			'https://www.youtube.com/watch?v=WSgP85kr6eU',
+			ilMimeTypeUtil::APPLICATION__OCTET_STREAM
+		);
+
+		$this->assertEquals($expected,  $actual);
+	}
+
+	/**
+	 *
+	 */
+	public function testMimeTypeForVimeoUrlCouldBeCorrectlyDetected()
+	{
+		$expected = 'video/vimeo';
+		$actual   = \ilMimeTypeUtil::lookupMimeType(
+			'https://vimeo.com/180157999',
+			ilMimeTypeUtil::APPLICATION__OCTET_STREAM
+		);
+
+		$this->assertEquals($expected,  $actual);
+	}
+}

--- a/Services/Utilities/test/ilMimeTypeTest.php
+++ b/Services/Utilities/test/ilMimeTypeTest.php
@@ -14,7 +14,7 @@ class ilMimeTypeTest extends \PHPUnit_Framework_TestCase
 		$expected = 'video/youtube';
 		$actual   = \ilMimeTypeUtil::lookupMimeType(
 			'https://www.youtube.com/watch?v=WSgP85kr6eU',
-			ilMimeTypeUtil::APPLICATION__OCTET_STREAM
+			\ilMimeTypeUtil::APPLICATION__OCTET_STREAM
 		);
 
 		$this->assertEquals($expected,  $actual);
@@ -28,7 +28,7 @@ class ilMimeTypeTest extends \PHPUnit_Framework_TestCase
 		$expected = 'video/vimeo';
 		$actual   = \ilMimeTypeUtil::lookupMimeType(
 			'https://vimeo.com/180157999',
-			ilMimeTypeUtil::APPLICATION__OCTET_STREAM
+			\ilMimeTypeUtil::APPLICATION__OCTET_STREAM
 		);
 
 		$this->assertEquals($expected,  $actual);

--- a/Services/Utilities/test/ilMimeTypeTest.php
+++ b/Services/Utilities/test/ilMimeTypeTest.php
@@ -1,8 +1,6 @@
 <?php
 /* Copyright (c) 1998-2018 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'libs/composer/vendor/autoload.php';
-
 /**
  * Class ilMimeTypeTest
  */

--- a/Services/Utilities/test/ilServicesUtilitiesSuite.php
+++ b/Services/Utilities/test/ilServicesUtilitiesSuite.php
@@ -1,6 +1,8 @@
 <?php
 /* Copyright (c) 1998-2018 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+require_once 'libs/composer/vendor/autoload.php';
+
 /**
  * Class ilServicesUtilitiesSuite
  */

--- a/Services/Utilities/test/ilServicesUtilitiesSuite.php
+++ b/Services/Utilities/test/ilServicesUtilitiesSuite.php
@@ -1,0 +1,21 @@
+<?php
+/* Copyright (c) 1998-2018 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * Class ilServicesUtilitiesSuite
+ */
+class ilServicesUtilitiesSuite extends \PHPUnit_Framework_TestSuite
+{
+	/**
+	 * @return \PHPUnit_Framework_TestSuite
+	 */
+	public static function suite()
+	{
+		$suite = new self();
+
+		require 'Services/Utilities/test/ilMimeTypeTest.php';
+		$suite->addTestSuite('ilMimeTypeTest');
+
+		return $suite;
+	}
+}


### PR DESCRIPTION
These tests will currently fail because the 3rd parameter of `\ilMimeTypeUtil::lookupMimeType` is not set explicitly to `true`.