### PR TITLE
Correct default value for paramter in send mail method

### DIFF
--- a/Modules/Forum/classes/class.ilForumMailNotification.php
+++ b/Modules/Forum/classes/class.ilForumMailNotification.php
@@ -312,7 +312,7 @@ class ilForumMailNotification extends ilMailNotification
 		int $userId,
 		string $customText,
 		string $action,
-		string $date = null
+		string $date = ''
 	) {
 		$this->createMail($subjectLanguageId, $userId, $customText, $action, $date);
 		$this->appendAttachments();


### PR DESCRIPTION
`null` is not a correct default value for type `string`