### PR TITLE
[fix 0022839] adapt locate-method for PostgreSQL

### DIFF
--- a/Services/Database/classes/MDB2/class.ilDBPostgreSQL.php
+++ b/Services/Database/classes/MDB2/class.ilDBPostgreSQL.php
@@ -282,4 +282,18 @@ class ilDBPostgreSQL extends ilDB
 		}
 		return $sql;
 	}
+
+
+	/**
+	 * 
+	 * @param string $a_needle
+	 * @param string $a_string
+	 * @param int $a_start_pos
+	 * @return string
+	 */
+	public function locate($a_needle, $a_string, $a_start_pos = 1): string {
+		$manager = $this->db->loadModule('Manager');
+		return $manager->getQueryUtils()->locate($a_needle, $a_string, $a_start_pos);		
+	}
+
 }

--- a/Services/Database/classes/QueryUtils/class.ilPostgresQueryUtils.php
+++ b/Services/Database/classes/QueryUtils/class.ilPostgresQueryUtils.php
@@ -157,7 +157,7 @@ class ilPostgresQueryUtils extends ilQueryUtils {
 		$locate .= '), ';
 		$locate .= $a_needle;
 		$locate .= ') + ';
-		$locate .= $a_start_pos;
+		$locate .= --$a_start_pos;
 
 		return $locate;
 	}

--- a/Services/Database/classes/QueryUtils/class.ilPostgresQueryUtils.php
+++ b/Services/Database/classes/QueryUtils/class.ilPostgresQueryUtils.php
@@ -150,13 +150,14 @@ class ilPostgresQueryUtils extends ilQueryUtils {
 	 * @return string
 	 */
 	public function locate($a_needle, $a_string, $a_start_pos = 1) {
-		$locate = ' LOCATE( ';
-		$locate .= $a_needle;
-		$locate .= ',';
+		$locate = ' STRPOS(SUBSTR(';
 		$locate .= $a_string;
-		$locate .= ',';
+		$locate .= ', ';
 		$locate .= $a_start_pos;
-		$locate .= ') ';
+		$locate .= '), ';
+		$locate .= $a_needle;
+		$locate .= ') + ';
+		$locate .= $a_start_pos;
 
 		return $locate;
 	}


### PR DESCRIPTION
Copying Object failed in PostgreSQL, because PG doesn't have a 'LOCATE'-Method...