### PR TITLE
Chatserver: Improve error message when files do not exist

### DIFF
--- a/Modules/Chatroom/chat/Validation/Rules/FileExists.js
+++ b/Modules/Chatroom/chat/Validation/Rules/FileExists.js
@@ -15,10 +15,7 @@ module.exports = function FileExists(filename) {
 
 	this.validate = function() {
 		if(!FileSystem.existsSync(_filename)) {
-			/**
-			 * @TODO Change Error
-			 */
-			throw new Error('CHANGE TO SPECIFIC ERROR');
+			throw new Error('File does not exist: ' + _filename);
 		}
 	};
 };


### PR DESCRIPTION
The error message for missing files seems to be a placeholder. This PR fixes this issue by introducing a proper message and including the path of the missing file.