### PR TITLE
Error handling PDO exception output

### DIFF
--- a/error.php
+++ b/error.php
@@ -32,5 +32,7 @@ catch(Exception $e)
 		throw $e;
 	}
 
-	die($e->getMessage());
+	if (!($e instanceof \PDOException)) {
+		die($e->getMessage());
+	}
 }


### PR DESCRIPTION
Mantis issue: 22904

If accepted, this should be merged to 5.3.x and 5.2.x as well.