### PR TITLE
[fix 0022914] ALT 1: starting a test fails in pg-installation

### DIFF
--- a/Services/Database/classes/Atom/class.ilAtomQueryLock.php
+++ b/Services/Database/classes/Atom/class.ilAtomQueryLock.php
@@ -62,7 +62,7 @@ class ilAtomQueryLock extends ilAtomQueryBase implements ilAtomQuery {
 			if (!in_array($table->getTableName(), $this->locked_table_names)) {
 				$locks[] = array( 'name' => $table->getTableName(), 'type' => $table->getLockLevel() );
 				$this->locked_table_names[] = $table->getTableName();
-				if ($table->isLockSequence() && $this->ilDBInstance->sequenceExists($table->getTableName())) {
+				if ($table->isLockSequence() && !$this->ilDBInstance->supportsSequences() && $this->ilDBInstance->sequenceExists($table->getTableName())) {
 					$locks[] = array( 'name' => $this->ilDBInstance->getSequenceName($table->getTableName()), 'type' => $table->getLockLevel() );
 				}
 			}

--- a/Services/Database/classes/MDB2/class.ilDB.php
+++ b/Services/Database/classes/MDB2/class.ilDB.php
@@ -385,6 +385,8 @@ abstract class ilDB extends PEAR implements ilDBInterface
 				return $this->supportsFulltext();
 			case 'slave':
 				return $this->supportsSlave();
+			case 'sequences':
+				return $this->supportsSequences();
 			default:
 				return false;
 		}
@@ -396,6 +398,13 @@ abstract class ilDB extends PEAR implements ilDBInterface
 	 */
 	public function supportsTransactions() {
 		// we generally do not want ilDB to support transactions, only PDO-instances
+		return false;
+	}
+	
+	/**
+	 * @return bool
+	 */
+	public function supportsSequences() {
 		return false;
 	}
 

--- a/Services/Database/classes/MDB2/class.ilDBPostgreSQL.php
+++ b/Services/Database/classes/MDB2/class.ilDBPostgreSQL.php
@@ -114,6 +114,13 @@ class ilDBPostgreSQL extends ilDB
 	}
 	
 	/**
+	 * @return bool
+	 */
+	function supportsSequences() {
+		return true;
+	}
+	
+	/**
 	* Replace into method.
 	*
 	* @param	string		table name

--- a/Services/Database/classes/PDO/class.ilDBPdo.php
+++ b/Services/Database/classes/PDO/class.ilDBPdo.php
@@ -20,6 +20,7 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface {
 	const FEATURE_TRANSACTIONS = 'transactions';
 	const FEATURE_FULLTEXT = 'fulltext';
 	const FEATURE_SLAVE = 'slave';
+	const FEATURE_SEQUENCES = 'sequence';
 	/**
 	 * @var string
 	 */
@@ -1375,6 +1376,14 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface {
 	public function supportsTransactions() {
 		return false;
 	}
+	
+	
+	/**
+	 * @return bool
+	 */
+	public function supportsSequences() {
+		return false;
+	}
 
 
 	/**
@@ -1389,6 +1398,8 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface {
 				return $this->supportsFulltext();
 			case self::FEATURE_SLAVE:
 				return $this->supportsSlave();
+			case self::FEATURE_SEQUENCES:
+				return $this->supportsSequences();
 			default:
 				return false;
 		}

--- a/Services/Database/classes/PDO/class.ilDBPdoPostgreSQL.php
+++ b/Services/Database/classes/PDO/class.ilDBPdoPostgreSQL.php
@@ -94,6 +94,13 @@ class ilDBPdoPostgreSQL extends ilDBPdo implements ilDBInterface {
 	public function supportsTransactions() {
 		return true;
 	}
+	
+	/**
+	 * @return bool
+	 */
+	public function supportsSequences() {
+		return true;
+	}
 
 
 	/**

--- a/Services/Database/interfaces/interface.ilDBInterface.php
+++ b/Services/Database/interfaces/interface.ilDBInterface.php
@@ -487,6 +487,11 @@ interface ilDBInterface {
 	 * @return bool
 	 */
 	public function supportsTransactions();
+	
+	/**
+	 * @return bool
+	 */
+	public function supportsSequences();
 
 	//
 	//

--- a/Services/Tracking/classes/status/class.ilLPStatusTestPassed.php
+++ b/Services/Tracking/classes/status/class.ilLPStatusTestPassed.php
@@ -138,7 +138,7 @@ class ilLPStatusTestPassed extends ilLPStatus
 		$status = self::LP_STATUS_NOT_ATTEMPTED_NUM;
 		require_once 'Modules/Test/classes/class.ilObjTestAccess.php';
 		$res = $ilDB->query("
-			SELECT tst_active.active_id, tst_active.tries, count(tst_sequence.active_fi) sequences, tst_active.last_finished_pass,
+			SELECT tst_active.active_id, tst_active.tries, count(tst_sequence.active_fi) " . $ilDB->quoteIdentifier("sequences") . ", tst_active.last_finished_pass,
 				CASE WHEN
 					(tst_tests.nr_of_tries - 1) = tst_active.last_finished_pass
 				THEN '1'
@@ -151,7 +151,7 @@ class ilLPStatusTestPassed extends ilLPStatus
 			ON tst_tests.test_id = tst_active.test_fi
 			WHERE tst_active.user_fi = {$ilDB->quote($a_user_id, "integer")}
 			AND tst_active.test_fi = {$ilDB->quote(ilObjTestAccess::_getTestIDFromObjectID($a_obj_id))}
-			GROUP BY tst_active.active_id, tst_active.tries
+			GROUP BY tst_active.active_id, tst_active.tries, is_last_pass
 		");
 
 		if ($rec = $ilDB->fetchAssoc($res))


### PR DESCRIPTION
_**DEPRICATED! Do NOT merge!**_

fixing https://www.ilias.de/mantis/view.php?id=22914
- in postgresql you cannot lock sequences, because rather than in mysql, sequences are not tables
- also fix a query (reserved word / missing field in group-by-clause)

_this is an alternate PR for bugfix 22914. This should be discussed in conjunction with PR #1037 on next JF_