### PR TITLE
Use maxlength in TextQuestion's textarea to limit input length.

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assTextQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assTextQuestionGUI.php
@@ -420,6 +420,15 @@ class assTextQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringA
 			$template->setVariable("TEXTBOXSIZE", strlen($this->object->getMaxNumOfChars()));
 			$template->setVariable("CHARACTERS", $this->lng->txt("characters"));
 			$template->parseCurrentBlock();
+			$template->setCurrentBlock();
+			$template->setVariable("MAXCHARS", $this->object->getMaxNumOfChars());
+			$template->parseCurrentBlock();
+		}
+		else
+		{
+			$template->setCurrentBlock();
+			$template->setVariable("MAXCHARS", 1024 * 1024);
+			$template->parseCurrentBlock();
 		}
 		$template->setVariable("ESSAY", ilUtil::prepareFormOutput($user_solution));
 		$questiontext = $this->object->getQuestion();

--- a/Modules/TestQuestionPool/templates/default/tpl.il_as_qpl_text_question_output.html
+++ b/Modules/TestQuestionPool/templates/default/tpl.il_as_qpl_text_question_output.html
@@ -4,7 +4,7 @@
 <!-- BEGIN maximum_char_hint -->
 	<p class="quote">{MAXIMUM_CHAR_HINT}</p>
 <!-- END maximum_char_hint -->
-<textarea class="ilc_qlinput_LongTextInput fullwidth textinput" spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off" cols="40" rows="10" name="TEXT" id="TEXT" onKeyUp="return taCount(this,'myCounter')">{ESSAY}</textarea>
+<textarea class="ilc_qlinput_LongTextInput fullwidth textinput" spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off" cols="40" rows="10" name="TEXT" id="TEXT" onKeyUp="return taCount(this,'myCounter')" maxlength="{MAXCHARS}">{ESSAY}</textarea>
 <!-- BEGIN maxchars_counter -->
 <p id="charcounter" style="visibility: hidden;">(<input type="text" spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off" readonly="readonly" id="myCounter" style="border: 0; background: transparent;" size="{TEXTBOXSIZE}" value="{MAXCHARS}" /> {CHARACTERS})</p>
 <!-- END maxchars_counter -->


### PR DESCRIPTION
Möchte auf diesem Weg intensiv anregen, für Essayfragen die HTML5 property `maxlength` in `textarea` zu nutzen, falls eine Längenbeschränkung vom Fragenersteller vorliegt.

Die momentane Implementierung wirft ja im Zweifel den Text am Ende einfach weg. Ein solches Verhalten des Systems ist aus unserer Sicht im Prüfungskontext - trotz Warnhinweis auf der Fragenanzeige - unter allen Umständen zu vermeiden.