### PR TITLE
Fix race condition concerning saved to question in autosave.

### DIFF
--- a/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -576,7 +576,22 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
 		$result = "";
 		if (is_array($_POST) && count($_POST) > 0)
 		{
-			if( $this->isParticipantsAnswerFixed($this->getCurrentQuestionId()) )
+			$questionId  = $this->testSequence->getQuestionForSequence(
+				$this->getCurrentSequenceElement()
+			);
+
+			$formQuestionId = $_POST["formquestionid"];
+			if (intval($formQuestionId) != intval($questionId))
+			{
+				// the question id derived from $_GET["sequence"] must always match
+				// the one  encoded in the question answers in $_POST["formquestionid"],
+				// otherwise we'd save one set of answers into the wrong question. happens
+				// on some browsers during autosave ($_GET data - and thus the question
+				// sequence id - is from the question when the autosave was installed,
+				// whereas $_POST data is from a new question the user just switched to).
+				$result = '-IGNORE-';
+			}
+			else if( $this->isParticipantsAnswerFixed($this->getCurrentQuestionId()) )
 			{
 				$result = '-IGNORE-';
 			}
@@ -1201,6 +1216,7 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
 		$this->tpl->setVariable("FORMACTION", $formAction);
 		$this->tpl->setVariable("ENCTYPE", 'enctype="'.$questionGui->getFormEncodingType().'"');
 		$this->tpl->setVariable("FORM_TIMESTAMP", time());
+		$this->tpl->setVariable("FORM_QUESTION_ID", $questionGui->getQuestionId());
 	}
 
 	protected function showQuestionEditable(assQuestionGUI $questionGui, $formAction, $isQuestionWorkedThrough, $instantResponse)

--- a/Modules/Test/templates/default/tpl.il_as_tst_output.html
+++ b/Modules/Test/templates/default/tpl.il_as_tst_output.html
@@ -13,6 +13,7 @@
 </div>
 <!-- END enableprocessingtime -->
 <input type="hidden" name="formtimestamp" value="{FORM_TIMESTAMP}" />
+<input type="hidden" name="formquestionid" value="{FORM_QUESTION_ID}" />
 <!-- BEGIN char_selector -->{CHAR_SELECTOR_TEMPLATE}<!-- END char_selector -->
 <!-- BEGIN test_nav_toolbar -->{TEST_NAV_TOOLBAR}<!-- END test_nav_toolbar -->
 <table class="fullwidth">
@@ -79,6 +80,7 @@
 <!-- END exam_id_footer -->
 <p></p>
 <input type="hidden" name="formtimestamp" value="{FORM_TIMESTAMP}" />
+<input type="hidden" name="formquestionid" value="{FORM_QUESTION_ID}" />
 <!-- BEGIN js_initialize -->
 {JS_INITIALIZE}
 <!-- END js_initialize -->

--- a/Modules/TestQuestionPool/classes/class.assQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assQuestionGUI.php
@@ -384,6 +384,11 @@ abstract class assQuestionGUI
 		return $this->questionActionCmd;
 	}
 
+	public function getQuestionId()
+	{
+		return $this->object->getId();
+	}
+
 	/**
 	 * Evaluates a posted edit form and writes the form data in the question object
 	 * @return integer A positive value, if one of the required fields wasn't set, else 0
@@ -2220,6 +2225,7 @@ abstract class assQuestionGUI
 		$this->tpl->setVariable("FORMACTION", $formaction);
 		$this->tpl->setVariable("ENCTYPE", 'enctype="'.$this->getFormEncodingType().'"');
 		$this->tpl->setVariable("FORM_TIMESTAMP", time());
+		$this->tpl->setVariable("FORM_QUESTION_ID", $this->getQuestionId());
 	}
 	
 	// hey: prevPassSolutions - $pass will be passed always from now on


### PR DESCRIPTION
Diesen Fehler haben wir schon im alten ILIAS EA in der Wildbahn gehabt. Scheint mit dem SEB/Firefox eher nicht aufzutreten, mit Google Chrome aber sehr wohl.

Ursache ist, dass beim Autospeichern zum Zeitpunkt der Installation des Timers eine URL hart kodiert wird, in der die Fragen-Sequence-Id `sequence` steht, z.B. wie hier:

```
"autosaveUrl":"ilias.php?ref_id=73&sequence=3&active_id=102&pmode=edit&cmd=autosave&cmdClass=iltestplayerfixedquestionsetgui&cmdNode=rz:mt:yn&baseClass=ilrepositorygui&cmdMode=asynch"
```

Mit dieser URL wird nun in `ilTestPlayerQuestionEditControl.js` via `setInterval` ein timer installiert, der irgendwann auf diese URL feuert:

```
$.ajax({
    type: 'POST',
    url: url, // falsche URL
    data: newData,
    dataType: 'text',
    timeout: config.autosaveInterval
})
```

Ist zum Zeitpunkt des Feuerns bereits eine andere Frage aufgerufen worden, wird die URL der alten Frage mit den POST-Daten der neuen Frage aufgerufen; dies führt zu einem Überschreiben einer Frage A mit den Ergebnissen aus Frage B.

Der Kern des Problems ist, dass Funktionen wie `getCurrentQuestionId()` die aktuelle Frage aus `$_GET` und nicht aus `$_POST` holen, und damit Ergebnisse auf falsche Fragen gesichert werden können:

```
protected function getCurrentQuestionId()
{
    return $this->testSequence->getQuestionForSequence($_GET["sequence"]);
}
```

Dieser PR prüft daher, zumindest für Autospeichern, ab, dass kein Mismatch vorhanden ist.