### PR TITLE
Disable autosave if running test in kiosk and window gets hidden.

### DIFF
--- a/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -2794,6 +2794,9 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
 		// Forced feedback will change the navigation saving command
 		$config['forcedInstantFeedback'] = $this->object->isForceInstantFeedbackEnabled();
 
+		// Inform EditControl about kiosk mode
+		$config['isInKioskMode'] = $this->object->getKioskMode();
+
 		$this->tpl->addJavascript('./Modules/Test/js/ilTestPlayerQuestionEditControl.js');
 		$this->tpl->addOnLoadCode('il.TestPlayerQuestionEditControl.init('.json_encode($config).')');
 	}


### PR DESCRIPTION
Eine Sicherheitsanpassung für Autospeichern im Kiosk-Modus, die ein Problem behebt, das unter bestimmten Browsern zu Datenverlust bei E-Prüfungen führen kann.

Während die meisten Nutzer von E-Prüfungen ILIAS mit dem SEB betreiben, sind andere Browser und Szenarien denkbar. In diesen Szenarien ist es möglich, dass Nutzer während der Prüfung durch versehentliche Tastenkombinationen - und ohne es zu bemerken - das aktuelle Tab duplizieren und so im Hintergrund weitere Tabs mit demselben Test öffnen.

Ist im Test Autospeichern aktiviert, führt dies dazu, dass die Tabs im Hintergrund immer wieder Fragen mit alten Antworten überspeichern und damit de facto zu einem andauernden Datenverlust führen.

Während ein Fix im Testmodul anhand von Versionsnummern (jede neue Antwort = neue Version) wohl denkbar wäre, nimmt dieser PR einen einfachen Ansatz, der das schlimmste verhindert: wird ein Tab oder Window unsichtbar, wird Autospeichern ausgeschaltet und eine Warnmeldung angezeigt. Dies passiert ausschließlich, wenn der Test im Kioskmodus läuft; ich gehe davon aus, dass im Kioskmodus ein Window oder Tab nicht verschwinden darf.

Hier die Warnmeldung:

![autosave-warning](https://user-images.githubusercontent.com/25431384/38991415-fa0672cc-43dd-11e8-94f1-986c686194e5.png)
