### PR TITLE
Allow RAR upload

### DIFF
--- a/Services/Utilities/classes/class.ilFileUtils.php
+++ b/Services/Utilities/classes/class.ilFileUtils.php
@@ -731,9 +731,12 @@ class ilFileUtils
 			'qtc',   // VIDEO__X_QTC,
 			'qti',   // IMAGE__X_QUICKTIME,
 			'qtif',   // IMAGE__X_QUICKTIME,
+			'r\d\d',				// RAR (application/vnd.rar)
 			'ra',   // AUDIO__X_PN_REALAUDIO,
 			'ram',   // AUDIO__X_PN_REALAUDIO,
+			'rar',				// RAR (application/vnd.rar)
 			'rast',   // IMAGE__CMU_RASTER,
+			'rev',				// RAR (application/vnd.rar)
 			'rexx',   // TEXT__X_SCRIPT_REXX,
 			'ris',	// ris
 			'rf',   // IMAGE__VND_RN_REALFLASH,


### PR DESCRIPTION
Add `rar`, `rev`, `r\d\d` to whitelist in accordance with https://en.wikipedia.org/wiki/RAR_(file_format)

(I hope, the “`r00`, `r01` etc problem” can be solved this way … 🙂)