### PR TITLE
[fix 0022914] ALT 2: starting a test fails in pg-installation

### DIFF
--- a/Services/Database/classes/PDO/class.ilDBPdoPostgreSQL.php
+++ b/Services/Database/classes/PDO/class.ilDBPdoPostgreSQL.php
@@ -241,9 +241,11 @@ class ilDBPdoPostgreSQL extends ilDBPdo implements ilDBInterface {
 	 * @throws \ilDatabaseException
 	 */
 	public function nextId($table_name) {
-		$sequence_name = $table_name . '_seq';
-		$query = "SELECT NEXTVAL('$sequence_name')";
-		$result = $this->query($query, 'integer');
+		$sequence_name = $this->manager->getDBInstance()->quoteIdentifier($this->manager->getDBInstance()->getSequenceName($table_name));
+		$seqcol_name = $this->manager->getDBInstance()->quoteIdentifier(ilDBConstants::SEQUENCE_COLUMNS_NAME);
+
+		$query = "UPDATE $sequence_name set $seqcol_name = $seqcol_name + 1 RETURNING $seqcol_name as nextval";
+		$result = $this->query($query);
 		$data = $result->fetchObject();
 
 		return $data->nextval;

--- a/Services/Tracking/classes/status/class.ilLPStatusTestPassed.php
+++ b/Services/Tracking/classes/status/class.ilLPStatusTestPassed.php
@@ -138,7 +138,7 @@ class ilLPStatusTestPassed extends ilLPStatus
 		$status = self::LP_STATUS_NOT_ATTEMPTED_NUM;
 		require_once 'Modules/Test/classes/class.ilObjTestAccess.php';
 		$res = $ilDB->query("
-			SELECT tst_active.active_id, tst_active.tries, count(tst_sequence.active_fi) sequences, tst_active.last_finished_pass,
+			SELECT tst_active.active_id, tst_active.tries, count(tst_sequence.active_fi) " . $ilDB->quoteIdentifier("sequences") . ", tst_active.last_finished_pass,
 				CASE WHEN
 					(tst_tests.nr_of_tries - 1) = tst_active.last_finished_pass
 				THEN '1'
@@ -151,7 +151,7 @@ class ilLPStatusTestPassed extends ilLPStatus
 			ON tst_tests.test_id = tst_active.test_fi
 			WHERE tst_active.user_fi = {$ilDB->quote($a_user_id, "integer")}
 			AND tst_active.test_fi = {$ilDB->quote(ilObjTestAccess::_getTestIDFromObjectID($a_obj_id))}
-			GROUP BY tst_active.active_id, tst_active.tries
+			GROUP BY tst_active.active_id, tst_active.tries, is_last_pass
 		");
 
 		if ($rec = $ilDB->fetchAssoc($res))


### PR DESCRIPTION
fixing https://www.ilias.de/mantis/view.php?id=22914

- in postgresql you cannot lock sequences, because rather than in mysql, sequences are not tables
- also fix a query (reserved word / missing field in group-by-clause)

_this is an alternate PR for bugfix 22914. This should be discussed in conjunction with PR #1042  on next JF_