### PR TITLE
[fix 0022914] ALT 3: starting a test fails in pg-installation

### DIFF
--- a/Services/Database/classes/Atom/class.ilAtomQueryLock.php
+++ b/Services/Database/classes/Atom/class.ilAtomQueryLock.php
@@ -63,7 +63,7 @@ class ilAtomQueryLock extends ilAtomQueryBase implements ilAtomQuery {
 				$locks[] = array( 'name' => $table->getTableName(), 'type' => $table->getLockLevel() );
 				$this->locked_table_names[] = $table->getTableName();
 				if ($table->isLockSequence() && $this->ilDBInstance->sequenceExists($table->getTableName())) {
-					$locks[] = array( 'name' => $this->ilDBInstance->getSequenceName($table->getTableName()), 'type' => $table->getLockLevel() );
+					$locks[] = array( 'name' => $table->getTableName(), 'type' => $table->getLockLevel(), 'sequence' => true );
 				}
 			}
 			if ($table->getAlias()) {

--- a/Services/Database/classes/PDO/class.ilDBPdoPostgreSQL.php
+++ b/Services/Database/classes/PDO/class.ilDBPdoPostgreSQL.php
@@ -186,21 +186,21 @@ class ilDBPdoPostgreSQL extends ilDBPdo implements ilDBInterface {
 
 		$counter = 0;
 		foreach ($a_tables as $table) {
-			$lock = 'LOCK TABLE ';
+			if (!isset($table['sequence']) && $table['sequence']) {
+				$lock = 'LOCK TABLE ' . $table['name'];
 
-			$lock .= ($table['name'] . ' ');
+				switch ($table['type']) {
+					case ilDBConstants::LOCK_READ:
+						$lock .= ' IN SHARE MODE ';
+						break;
 
-			switch ($table['type']) {
-				case ilDBConstants::LOCK_READ:
-					$lock .= ' IN SHARE MODE ';
-					break;
+					case ilDBConstants::LOCK_WRITE:
+						$lock .= ' IN EXCLUSIVE MODE ';
+						break;
+				}
 
-				case ilDBConstants::LOCK_WRITE:
-					$lock .= ' IN EXCLUSIVE MODE ';
-					break;
+				$locks[] = $lock;
 			}
-
-			$locks[] = $lock;
 		}
 
 		// @TODO use and store a unique identifier to allow nested lock/unlocks

--- a/Services/Tracking/classes/status/class.ilLPStatusTestPassed.php
+++ b/Services/Tracking/classes/status/class.ilLPStatusTestPassed.php
@@ -138,7 +138,7 @@ class ilLPStatusTestPassed extends ilLPStatus
 		$status = self::LP_STATUS_NOT_ATTEMPTED_NUM;
 		require_once 'Modules/Test/classes/class.ilObjTestAccess.php';
 		$res = $ilDB->query("
-			SELECT tst_active.active_id, tst_active.tries, count(tst_sequence.active_fi) sequences, tst_active.last_finished_pass,
+			SELECT tst_active.active_id, tst_active.tries, count(tst_sequence.active_fi) " . $ilDB->quoteIdentifier("sequences") . ", tst_active.last_finished_pass,
 				CASE WHEN
 					(tst_tests.nr_of_tries - 1) = tst_active.last_finished_pass
 				THEN '1'
@@ -151,7 +151,7 @@ class ilLPStatusTestPassed extends ilLPStatus
 			ON tst_tests.test_id = tst_active.test_fi
 			WHERE tst_active.user_fi = {$ilDB->quote($a_user_id, "integer")}
 			AND tst_active.test_fi = {$ilDB->quote(ilObjTestAccess::_getTestIDFromObjectID($a_obj_id))}
-			GROUP BY tst_active.active_id, tst_active.tries
+			GROUP BY tst_active.active_id, tst_active.tries, is_last_pass
 		");
 
 		if ($rec = $ilDB->fetchAssoc($res))


### PR DESCRIPTION
fixing https://www.ilias.de/mantis/view.php?id=22914
- in postgresql you cannot lock sequences, because rather than in mysql, sequences are not tables
- also fix a query (reserved word / missing field in group-by-clause)

_this is an alternate PR for bugfix 22914. This should be discussed in conjunction with PR #1037 on next JF_