### PR TITLE
ErrorHandling: DEVMODE may not be defined.

### DIFF
--- a/Services/Init/classes/class.ilErrorHandling.php
+++ b/Services/Init/classes/class.ilErrorHandling.php
@@ -350,7 +350,7 @@ class ilErrorHandling extends PEAR
 	 * @return bool
 	 */
 	protected function isDevmodeActive() {
-		return DEVMODE == 1;
+		return defined("DEVMODE") && (int)DEVMODE === 1;
 	}
 
 	/**


### PR DESCRIPTION
... according to a [suggestion](https://github.com/ILIAS-eLearning/ILIAS/commit/c2db938b3e240e10dcfee1f955d1acfef845a5df#commitcomment-28271092) from @mjansenDatabay. Thx!