### PR TITLE
54pr enhance error code reporting

### DIFF
--- a/Services/Init/classes/class.ilErrorHandling.php
+++ b/Services/Init/classes/class.ilErrorHandling.php
@@ -387,7 +387,7 @@ class ilErrorHandling extends PEAR
 				
 				$message .= sprintf($lng->txt('log_error_message_explanation'), $file_name);
 			} else {
-				$message = "Error ".$file_name." occurred.";
+				$message = "An error occurred. The generated error code is: ".$file_name;
 
 				if($logger->mail()) {
 					$message .= ' '.'Please send a mail to <a href="mailto:'.$logger->mail().'?subject=code: '.$file_name.'">'.$logger->mail().'</a>';

--- a/Services/Init/classes/class.ilErrorHandling.php
+++ b/Services/Init/classes/class.ilErrorHandling.php
@@ -384,16 +384,12 @@ class ilErrorHandling extends PEAR
 				if($logger->mail()) {
 					$message .= " ".sprintf($lng->txt("log_error_message_send_mail"), $logger->mail(), $file_name, $logger->mail());
 				}
-				
-				$message .= sprintf($lng->txt('log_error_message_explanation'), $file_name);
 			} else {
-				$message = "An error occurred. The generated error code is: ".$file_name;
+				$message = 'Sorry, an error occured. A logfile has been created which can be identified via the code "'.$file_name.'"';
 
 				if($logger->mail()) {
 					$message .= ' '.'Please send a mail to <a href="mailto:'.$logger->mail().'?subject=code: '.$file_name.'">'.$logger->mail().'</a>';
 				}
-				
-				$message .= '<br /><br /><i>The error has been logged to a logfile that can be identified by the given error code ('.$file_name.').</i>';
 			}
 
 			ilUtil::sendFailure($message, true);

--- a/Services/Init/classes/class.ilErrorHandling.php
+++ b/Services/Init/classes/class.ilErrorHandling.php
@@ -384,12 +384,16 @@ class ilErrorHandling extends PEAR
 				if($logger->mail()) {
 					$message .= " ".sprintf($lng->txt("log_error_message_send_mail"), $logger->mail(), $file_name, $logger->mail());
 				}
+				
+				$message .= sprintf($lng->txt('log_error_message_explanation'), $file_name);
 			} else {
 				$message = "Error ".$file_name." occurred.";
 
 				if($logger->mail()) {
-					$message .= ' '.'Please send a mail to <a href="mailto:'.$logger->mail().'?subject=code: '.$file_name.'">'.$logger->mail().'%s</a>';
+					$message .= ' '.'Please send a mail to <a href="mailto:'.$logger->mail().'?subject=code: '.$file_name.'">'.$logger->mail().'</a>';
 				}
+				
+				$message .= '<br /><br /><i>The error has been logged to a logfile that can be identified by the given error code ('.$file_name.').</i>';
 			}
 
 			ilUtil::sendFailure($message, true);

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -13230,9 +13230,8 @@ copg#:#copg_sec_link_info#:#Wenn Sie einen Link auf den kompletten Block setzen,
 pd#:#pd_sys_msg_own_block#:#Systemnachrichten im eigenen Block anzeigen
 pd#:#pd_sys_msg_mail_block#:#Systemnachrichten im Block "Mail" anzeigen
 pd#:#pd_sys_msg_no_block#:#Keine Systemnachrichten auf Schreibtisch anzeigen
-logging#:#log_error_message#:#Es ist ein Fehler aufgetreten. Der generierte Fehlercode lautet: %s.
+logging#:#log_error_message#:#Entschuldigung, es ist ein Fehler aufgetreten. Eine Logdatei wurde erzeugt, die über den Error Code "%s" identifiziert werden kann.
 logging#:#log_error_message_send_mail#:# Bitte wenden Sie sich an <a href="mailto:%s?subject=code: %s">%s</a>
-logging#:#log_error_message_explanation#:#<br /><br /><i>Der fehler wurde in eine Logdatei protokolliert, welche über den generierten Fehlercode identifiziert werden kann (%s).</i>
 logging#:#log_error_folder#:#Dateipfad
 logging#:#log_error_mail#:#E-Mail-Empfänger
 logging#:#log_error_settings#:#Einstellungen zum Fehlerprotokoll

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -13230,8 +13230,9 @@ copg#:#copg_sec_link_info#:#Wenn Sie einen Link auf den kompletten Block setzen,
 pd#:#pd_sys_msg_own_block#:#Systemnachrichten im eigenen Block anzeigen
 pd#:#pd_sys_msg_mail_block#:#Systemnachrichten im Block "Mail" anzeigen
 pd#:#pd_sys_msg_no_block#:#Keine Systemnachrichten auf Schreibtisch anzeigen
-logging#:#log_error_message#:#Fehler %s ist aufgetreten.
+logging#:#log_error_message#:#Es ist ein Fehler aufgetreten. Der generierte Fehlercode lautet: %s.
 logging#:#log_error_message_send_mail#:# Bitte wenden Sie sich an <a href="mailto:%s?subject=code: %s">%s</a>
+logging#:#log_error_message_explanation#:#<br /><br /><i>Der fehler wurde in eine Logdatei protokolliert, welche über den generierten Fehlercode identifiziert werden kann (%s).</i>
 logging#:#log_error_folder#:#Dateipfad
 logging#:#log_error_mail#:#E-Mail-Empfänger
 logging#:#log_error_settings#:#Einstellungen zum Fehlerprotokoll

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -13210,9 +13210,8 @@ copg#:#copg_sec_link_info#:#If you set a link on the whole section, please ensur
 pd#:#pd_sys_msg_own_block#:#Show system messages in an own block
 pd#:#pd_sys_msg_mail_block#:#Show system messages in the "Mail" block
 pd#:#pd_sys_msg_no_block#:#Don't show any system messages on the personal desktop
-logging#:#log_error_message#:#An error occurred. The generated error code is: %s
+logging#:#log_error_message#:#Sorry, an error occured. A logfile has been created which can be identified via the code "%s".
 logging#:#log_error_message_send_mail#:#Please send a mail to <a href="mailto:%s?subject=code: %s">%s</a>
-logging#:#log_error_message_explanation#:#<br /><br /><i>The error has been logged to a logfile that can be identified by the given error code (%s).</i>
 logging#:#log_error_folder#:#Path
 logging#:#log_error_mail#:#Mail recipient
 logging#:#log_error_settings#:#Error logging settings

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -13210,8 +13210,9 @@ copg#:#copg_sec_link_info#:#If you set a link on the whole section, please ensur
 pd#:#pd_sys_msg_own_block#:#Show system messages in an own block
 pd#:#pd_sys_msg_mail_block#:#Show system messages in the "Mail" block
 pd#:#pd_sys_msg_no_block#:#Don't show any system messages on the personal desktop
-logging#:#log_error_message#:#Error %s occurred.
+logging#:#log_error_message#:#An error occurred. The generated error code is: %s
 logging#:#log_error_message_send_mail#:#Please send a mail to <a href="mailto:%s?subject=code: %s">%s</a>
+logging#:#log_error_message_explanation#:#<br /><br /><i>The error has been logged to a logfile that can be identified by the given error code (%s).</i>
 logging#:#log_error_folder#:#Path
 logging#:#log_error_mail#:#Mail recipient
 logging#:#log_error_settings#:#Error logging settings


### PR DESCRIPTION
Hello,

I did a change to the communication of error codes to the user that sadly experience an error in ilias. Me as a maintainer is experiencing some organisationel overhead in my maintenance load because I need to explain bug reporters that there is no error called xyz_123 and that similar error codes does not relate to similar issues.

Short words: the error code gets more well explained with this pull request.

BTW: Is there any way to enable the admin email on the error screen except editing the client.ini.php directly?

Kind regards, Björn

Before: 
![1](https://user-images.githubusercontent.com/2587908/39620360-351f4588-4f8b-11e8-9694-acab018056ba.png)

After:
![2](https://user-images.githubusercontent.com/2587908/39620369-397cd1cc-4f8b-11e8-915c-f5352bfe9372.png)
![3](https://user-images.githubusercontent.com/2587908/39620371-3ba8930a-4f8b-11e8-99f0-bda84a191dc5.png)

