### PR TITLE
Fixes random question order in participant sheets of XLS export.

### DIFF
--- a/Modules/Test/classes/class.ilTestExport.php
+++ b/Modules/Test/classes/class.ilTestExport.php
@@ -761,7 +761,17 @@ abstract class ilTestExport
 				$row += 2;
 				if(is_object($userdata) && is_array($userdata->getQuestions($pass)))
 				{
-					foreach($userdata->getQuestions($pass) as $question)
+					$order = array();
+					foreach ($this->test_obj->getQuestionsOfPass($active_id, $pass) as $record) {
+						$order[$record["question_fi"]] = $record["sequence"];
+					}
+
+					$questions = array_merge($userdata->getQuestions($pass));
+					usort($questions, function($q1, $q2) use ($order) {
+						return $order[$q1["id"]] - $order[$q2["id"]];
+					});
+
+					foreach($questions as $question)
 					{
 						require_once "./Modules/TestQuestionPool/classes/class.assQuestion.php";
 						$question = assQuestion::_instanciateQuestion($question["id"]);


### PR DESCRIPTION
Momentan werden beim Excel-Export der Ergebnisse die Fragen auf den Detail-Sheets der Teilnehmer in der Reihenfolge gespeichert, die der Präsentationsreihenfolge für den Teilnehmer entspricht.

Das ist aus unserer Sicht etwas ungünstig, da hierdurch für Nachkorrektur u.ä. dieselben Fragen verschiedener Teilnehmer an verschiedenen Positionen stehen (bei randomisierter Fragenreihenfolge).

Dieser PR sortiert die Fragen beim Export immer in die kanonische Erstellungsreihenfolge, so dass bei jedem Teilnehmer dieselbe Reihenfolge exportiert und, unabhängig von der Präsentationsreihenfolge.

Meine Implementierung ist wohl etwas fragwürdig (insbes. die Nutzung der sonst noch nicht genutzten Methode `getQuestionsOfPass`), ich hoffe aber, dass der PR im Zweifel als detaillierter Bug Report/Anregung verstanden werden kann. 