### PR TITLE
Fix for 0022820

### DIFF
--- a/Services/AccessControl/classes/class.ilConditionHandler.php
+++ b/Services/AccessControl/classes/class.ilConditionHandler.php
@@ -1049,8 +1049,8 @@ class ilConditionHandler
 
 
 		$query = "SELECT * FROM conditions WHERE ".
-			"trigger_ref_id = ".$ilDB->quote($trigger_obj->getId(),'integer')." ".
-			"AND target_ref_id = ".$ilDB->quote($target_obj->getId(),'integer');
+			"trigger_ref_id = ".$ilDB->quote($trigger_obj->getRefId(),'integer')." ".
+			"AND target_ref_id = ".$ilDB->quote($target_obj->getRefId(),'integer');
 
 		$res = $this->db->query($query);
 		if($res->numRows() > 1)

--- a/Services/AccessControl/classes/class.ilConditionHandler.php
+++ b/Services/AccessControl/classes/class.ilConditionHandler.php
@@ -1049,8 +1049,8 @@ class ilConditionHandler
 
 
 		$query = "SELECT * FROM conditions WHERE ".
-			"trigger_ref_id = ".$ilDB->quote($trigger_obj->getRefId(),'integer')." ".
-			"AND target_ref_id = ".$ilDB->quote($target_obj->getRefId(),'integer');
+			"trigger_ref_id = ".$ilDB->quote($trigger_obj->getId(),'integer')." ".
+			"AND target_ref_id = ".$ilDB->quote($target_obj->getId(),'integer');
 
 		$res = $this->db->query($query);
 		if($res->numRows() > 1)

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -854,7 +854,7 @@ class ilInitialisation
 	/**
 	 * $lng initialisation
 	 */
-	protected static function initLanguage($a_use_user_language = true)
+	protected static function initLanguage()
 	{
 		/**
 		 * @var $rbacsystem ilRbacSystem
@@ -862,15 +862,7 @@ class ilInitialisation
 		global $rbacsystem;
 
 		require_once 'Services/Language/classes/class.ilLanguage.php';
-
-		if($a_use_user_language)
-		{
-			self::initGlobal('lng', ilLanguage::getGlobalInstance());
-		}
-		else
-		{
-			self::initGlobal('lng', ilLanguage::getGlobalDefaultInstance());
-		}
+		self::initGlobal('lng', ilLanguage::getGlobalInstance());
 		if(is_object($rbacsystem))
 		{
 			$rbacsystem->initMemberView();
@@ -930,11 +922,6 @@ class ilInitialisation
 		else
 		{
 			$GLOBALS[$a_name] = $a_class;
-		}
-
-		if($DIC->offsetExists($a_name))
-		{
-			$DIC->offsetUnset($a_name);
 		}
 
 		$DIC[$a_name] = function ($c) use ($a_name) {
@@ -1041,7 +1028,7 @@ class ilInitialisation
 			self::includePhp5Compliance();
 			
 			// language may depend on user setting
-			self::initLanguage(true);
+			self::initLanguage();
 			$GLOBALS['DIC']['tree']->initLangCode();
 
 			self::initInjector($GLOBALS['DIC']);
@@ -1154,9 +1141,6 @@ class ilInitialisation
 		self::handleMaintenanceMode();
 
 		self::initDatabase();
-
-		// init dafault language
-		self::initLanguage(false);
 		
 		// moved after databases 
 		self::initLog();		
@@ -1242,9 +1226,8 @@ class ilInitialisation
 	public static function resumeUserSession()
 	{
 		include_once './Services/Authentication/classes/class.ilAuthUtils.php';
-		if(ilAuthUtils::isAuthenticationForced())
+		if(ilAuthUtils::handleForcedAuthentication())
 		{
-			ilAuthUtils::handleForcedAuthentication();
 		}
 		
 		if(

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -856,6 +856,8 @@ class ilInitialisation
 	 */
 	protected static function initLanguage($a_use_user_language = true)
 	{
+		global $DIC;
+
 		/**
 		 * @var $rbacsystem ilRbacSystem
 		 */
@@ -865,11 +867,15 @@ class ilInitialisation
 
 		if($a_use_user_language)
 		{
+			if($DIC->offsetExists('lng'))
+			{
+				$DIC->offsetUnset('lng');
+			}
 			self::initGlobal('lng', ilLanguage::getGlobalInstance());
 		}
 		else
 		{
-			self::initGlobal('lng', ilLanguage::getGlobalDefaultInstance());
+			self::initGlobal('lng', ilLanguage::getFallbackInstance());
 		}
 		if(is_object($rbacsystem))
 		{
@@ -930,11 +936,6 @@ class ilInitialisation
 		else
 		{
 			$GLOBALS[$a_name] = $a_class;
-		}
-
-		if($DIC->offsetExists($a_name))
-		{
-			$DIC->offsetUnset($a_name);
 		}
 
 		$DIC[$a_name] = function ($c) use ($a_name) {

--- a/Services/Language/classes/class.ilLanguage.php
+++ b/Services/Language/classes/class.ilLanguage.php
@@ -473,7 +473,7 @@ class ilLanguage
 	 * Builds a global default language instance
 	 * @return \ilLanguage
 	 */
-	public static function getGlobalDefaultInstance()
+	public static function getFallbackInstance()
 	{
 		return new self('en');
 	}

--- a/Services/Language/classes/class.ilLanguage.php
+++ b/Services/Language/classes/class.ilLanguage.php
@@ -470,6 +470,15 @@ class ilLanguage
 	}
 
 	/**
+	 * Builds a global default language instance
+	 * @return \ilLanguage
+	 */
+	public static function getGlobalDefaultInstance()
+	{
+		return new self('en');
+	}
+
+	/**
 	 * Builds the global language object
 	 * @return self
 	 */

--- a/Services/Language/classes/class.ilLanguage.php
+++ b/Services/Language/classes/class.ilLanguage.php
@@ -470,15 +470,6 @@ class ilLanguage
 	}
 
 	/**
-	 * Builds a global default language instance
-	 * @return \ilLanguage
-	 */
-	public static function getGlobalDefaultInstance()
-	{
-		return new self('en');
-	}
-
-	/**
 	 * Builds the global language object
 	 * @return self
 	 */


### PR DESCRIPTION
This fixed different issues regarding the language initialisation for ECS authentication request and SOAP webservice failures. 

The global language object is initialised with the default language directly after the databases initialisation and reinitialised after user authentication or session resuming with the user language.

[1] https://www.ilias.de/mantis/view.php?id=22820