### PR TITLE
DIC Additions

### DIFF
--- a/dicto/rules
+++ b/dicto/rules
@@ -32,6 +32,7 @@ SetErrorHandler = Functions with name:"set_error_handler"
 SetExceptionHandler = Functions with name:"set_exception_handler"
 SetErrorOrExceptionHandler = {SetExceptionHandler, SetErrorHandler}
 IliasTemplateFiles = Files with name:"tpl[.].*[.]html"
+IsDependencyAvailableMethod = Methods with name:"isDependencyAvailable"
 
 
 /**
@@ -134,3 +135,10 @@ IliasTemplateFiles cannot contain text: "on(blur|change|click|dblclick|focus|key
  * Decision by JF 2015-08-03: http://www.ilias.de/docu/goto.php?target=wiki_1357_JourFixe-2015-08-03#ilPageTocA123
  */
 WholeIliasCodebaseExceptInitialisation cannot depend on: GlobalsExceptDIC
+
+/**
+ * isDependencyAvailable of Container is only to be used if strictly required. The need for this,
+ * mostly points to some underlying problem needing to be solved instead of using this.
+ * This was introduced as temporary workaround. See: https://github.com/ILIAS-eLearning/ILIAS/pull/1064
+ */
+WholeIliasCodebase cannot depend on: IsDependencyAvailableMethod

--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -203,11 +203,7 @@ class Container extends \Pimple\Container {
 	 *
 	 * //This is better, since the client just needs to know the name defined in the
 	 * //interface of the component
-	 * $DIC->methodInitialized("systemStyle")
-	 *
-	 * //Note that the following is no better, than the bad example above (same problem)
-	 * $style = $DIC->styleDefinition
-	 * if(is_object($style)){...}
+	 * $DIC->isDependencyAvailable("systemStyle")
 	 *
 	 * @param $name
 	 * @return bool

--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -163,4 +163,61 @@ class Container extends \Pimple\Container {
 	public function event() {
 		return $this['ilAppEventHandler'];
 	}
+
+	/**
+	 * @return \ilIniFile
+	 */
+	public function iliasIni() {
+		return $this['ilIliasIniFile'];
+	}
+
+	/**
+	 * @return \ilIniFile
+	 */
+	public function clientIni() {
+		return $this['ilClientIniFile'];
+	}
+
+	/**
+	 *  @return \ilStyleDefinition
+	 */
+	public function systemStyle(){
+		return $this['styleDefinition'];
+	}
+
+	/**
+	 *  @return \ilHelpGUI
+	 */
+	public function help(){
+		return $this['ilHelp'];
+	}
+
+	/**
+	 * This is syntactic sugar for executing the try catch statement in the clients code.
+	 * Note that the use of the offsetSet code of the default container should be avoided,
+	 * since knowledge about the containers internal mechanism is injected.
+	 *
+	 * Example:
+	 * //This is bad since the client should not need to know about the id's name
+	 * $DIC->offsetSet("styleDefinition")
+	 *
+	 * //This is better, since the client just needs to know the name defined in the
+	 * //interface of the component
+	 * $DIC->methodInitialized("systemStyle")
+	 *
+	 * //Note that the following is no better, than the bad example above (same problem)
+	 * $style = $DIC->styleDefinition
+	 * if(is_object($style)){...}
+	 *
+	 * @param $name
+	 * @return bool
+	 */
+	public function isDependencyAvailable($name){
+		try{
+			$this->$name();
+		}catch(\InvalidArgumentException $e){
+			return false;
+		}
+		return true;
+	}
 }

--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -193,6 +193,10 @@ class Container extends \Pimple\Container {
 	}
 
 	/**
+	 * Note: Only use isDependencyAvailable if strictly required. The need for this,
+	 * mostly points to some underlying problem needing to be solved instead of using this.
+	 * This was introduced as temporary workaround. See: https://github.com/ILIAS-eLearning/ILIAS/pull/1064
+	 *
 	 * This is syntactic sugar for executing the try catch statement in the clients code.
 	 * Note that the use of the offsetSet code of the default container should be avoided,
 	 * since knowledge about the containers internal mechanism is injected.

--- a/tests/DI/DIContainerTest.php
+++ b/tests/DI/DIContainerTest.php
@@ -1,0 +1,28 @@
+<?php
+namespace ILIAS\DI;
+
+require_once('./libs/composer/vendor/autoload.php');
+
+/**
+ * Class DIContainerTest
+ */
+class DIContainerTest extends \PHPUnit_Framework_TestCase {
+
+    /**
+     * @var Container
+     */
+    protected $DIC;
+
+    protected function setUp() {
+        $this->DIC = new Container();
+    }
+
+    public function testIsDependencyAvailableIfNotAvailable(){
+        $this->assertFalse($this->DIC->isDependencyAvailable("notAvailable"));
+    }
+
+    public function testIsDependencyAvailableIfAvailable(){
+        $DIC["available"] = function (){};
+        $this->assertTrue($this->DIC->isDependencyAvailable("available"));
+    }
+}

--- a/tests/DI/DIContainerTest.php
+++ b/tests/DI/DIContainerTest.php
@@ -18,11 +18,11 @@ class DIContainerTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testIsDependencyAvailableIfNotAvailable(){
-        $this->assertFalse($this->DIC->isDependencyAvailable("notAvailable"));
+        $this->assertFalse($this->DIC->isDependencyAvailable("ctrl"));
     }
 
     public function testIsDependencyAvailableIfAvailable(){
-        $DIC["available"] = function (){};
-        $this->assertTrue($this->DIC->isDependencyAvailable("available"));
+        $this->DIC["ilCtrl"] = function (){};
+        $this->assertTrue($this->DIC->isDependencyAvailable("ctrl"));
     }
 }


### PR DESCRIPTION
While fixing [0022885](https://www.ilias.de/mantis/view.php?id=22885) (Fix "WholeIliasCodebaseExceptInitialisation cannot depend on GlobalsExceptDIC " violations) I stumbled across several needed dependencies that are missing on the interface of the DIContainer. 

I am well aware, that I could use them by just accessing them directly through key on the array. In some cases this makes somehow sense, since we do not want to advertise them too much on the interface, since we believe them to be depracated soon (as probably "tpl"). In other cases (e.g. like help) I think this pattern is bad and injects far too much inside knowledge of the container all over the place. I guess we just suggest additional needed once like those as "improvement", correct?

Related, I believe the $DIC->offsetSet("styleDefinition") pattern to be wrong for the same reason (see also comment in the code) and proposed an alternative.

Note: Why is the "HTTPServicesTest" Class in tests/D? This seems odd. I did not tackle this in this PR since it is not directly related.