### PR TITLE
KS: Lead icon in list item

### DIFF
--- a/src/UI/Component/Item/Factory.php
+++ b/src/UI/Component/Item/Factory.php
@@ -12,7 +12,7 @@ interface Factory {
  	 *   composition: >
 	 *       A list item consists of a title and the following optional elements:
 	 *       description, action drop down, properties (name/value), a text or
-	 *       image lead and a color. Property values MAY be interactive by using
+	 *       image or icon lead and a color. Property values MAY be interactive by using
 	 *       Shy Buttons.
  	 * rules:
 	 *    accessibility:

--- a/src/UI/Component/Item/Item.php
+++ b/src/UI/Component/Item/Item.php
@@ -83,6 +83,14 @@ interface Item extends \ILIAS\UI\Component\Component {
 	public function withLeadImage(\ILIAS\UI\Component\Image\Image $image);
 
 	/**
+	 * Set icon as lead
+	 *
+	 * @param \ILIAS\UI\Component\Icon\Icon $icon lead icon
+	 * @return Icon
+	 */
+	public function withLeadIcon(\ILIAS\UI\Component\Icon\Icon $icon);
+
+	/**
 	 * Set image as lead
 	 *
 	 * @param string $text lead text

--- a/src/UI/Component/Item/Item.php
+++ b/src/UI/Component/Item/Item.php
@@ -105,7 +105,7 @@ interface Item extends \ILIAS\UI\Component\Component {
 	public function withNoLead();
 
 	/**
-	 * @return null|string|\ILIAS\UI\Component\Image\Image
+	 * @return null|string|\ILIAS\UI\Component\Image\Image|\ILIAS\UI\Component\Icon\Icon
 	 */
 	public function getLead();
 


### PR DESCRIPTION
A new optional element for list items.

Example:
[Improve Usability of List of Portfolios](https://www.ilias.de/docu/goto.php?target=wiki_1357_Improve_Usability_of_List_of_Portfolios)