### PR TITLE
Allow upload of Wolfram Notebook (Player) and Computable Document For…

### DIFF
--- a/Services/Utilities/classes/class.ilFileUtils.php
+++ b/Services/Utilities/classes/class.ilFileUtils.php
@@ -599,6 +599,7 @@ class ilFileUtils
 			'c++', 	// TEXT__PLAIN
 			'cc', 	// TEXT__PLAIN
 			'cct', // scorm wbts
+			'cdf',						// (Wolfram) Computable Document Format
 			'cer', 	// APPLICATION__X_X509_CA_CERT
 			'class', // APPLICATION__X_JAVA_CLASS
 			'conf',	 // TEXT__PLAIN
@@ -692,6 +693,8 @@ class ilFileUtils
 			'mv',   // VIDEO__X_SGI_MOVIE,
 			'mw',
 			'mv4',   // VIDEO__MP4,
+			'nb',						// Wolfram Notebook files
+			'nbp',						// Wolfram Notebook Player files
 			'nef',   // IMAGE__X_NIKON_NEF,
 			'nif',   // IMAGE__X_NIFF,
 			'niff',   // IMAGE__X_NIFF,


### PR DESCRIPTION
…mat files

`.cdf`, `.nb` and `.nbp`

See

https://en.wikipedia.org/wiki/Computable_Document_Format
http://www.wolfram.com/cdf/faq/
http://reference.wolfram.com/language/tutorial/NotebooksAsDocuments.html