### PR TITLE
Fix stripped tags in XLS cloze texts exports

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assClozeTest.php
+++ b/Modules/TestQuestionPool/classes/class.assClozeTest.php
@@ -1600,15 +1600,23 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
 			{
 				if ($gap_index == $solutionvalue["value1"])
 				{
-					switch ($gap->getType())
-					{
-						case CLOZE_SELECT:
-							$worksheet->setCell($startrow + $i, 1, $gap->getItem($solutionvalue["value2"])->getAnswertext());
-							break;
-						case CLOZE_NUMERIC:
-						case CLOZE_TEXT:
-							$worksheet->setCell($startrow + $i, 1, $solutionvalue["value2"]);
-							break;
+					$string_escaping_org_value = $worksheet->getStringEscaping();
+					try {
+						$worksheet->setStringEscaping(false);
+
+						switch ($gap->getType())
+						{
+							case CLOZE_SELECT:
+								$worksheet->setCell($startrow + $i, 1, $gap->getItem($solutionvalue["value2"])->getAnswertext());
+								break;
+							case CLOZE_NUMERIC:
+							case CLOZE_TEXT:
+								$worksheet->setCell($startrow + $i, 1, $solutionvalue["value2"]);
+								break;
+						}
+
+					} finally {
+						$worksheet->setStringEscaping($string_escaping_org_value);
 					}
 				}
 			}


### PR DESCRIPTION
Currently, the occurence of characters like '<' in cloze texts leads to wrong answers being saved in the exported xls file.

For example, enter `F<t>z<l` as solution into a cloze text field. This answer is preserved during the test.

In the XLS export file however, only `Fz` will show up, with `<t>` and `<l` having been lost:

![xls-sample](https://user-images.githubusercontent.com/25431384/40980296-4e41c57a-68d8-11e8-9dc9-c6886d8b3306.png)

This is due to html stripping happening when saving the result to the xls file. While there is an option to prevent this for essay questions ("Exportiere Freitext-Frage mit HTML Code"), there is no such option for cloze texts. As there is no option, I believe it should never get stripped by default.

This PR removes the stripping by setting the worksheet string escaping mode to `false` during saving the cloze text answers.