### PR TITLE
Fix/0023166/trunk/iliasinifile and ilclientinifile are not available in setup via dic bug

### DIFF
--- a/setup/include/inc.setup_header.php
+++ b/setup/include/inc.setup_header.php
@@ -180,7 +180,7 @@ $DIC["http"] = function ($c) {
 $DIC['ilCtrl'] = new ilCtrl();
 
 $DIC["ilIliasIniFile"] = function($c) { return $GLOBALS["ilIliasIniFile"]; };
-+
-+$DIC["ilClientIniFile"] = function($c) { return $GLOBALS["ilClientIniFile"]; };
+
+$DIC["ilClientIniFile"] = function($c) { return $GLOBALS["ilClientIniFile"]; };
 
 ?>

--- a/setup/include/inc.setup_header.php
+++ b/setup/include/inc.setup_header.php
@@ -178,4 +178,9 @@ $DIC["http"] = function ($c) {
 	);
 };
 $DIC['ilCtrl'] = new ilCtrl();
+
+$DIC["ilIliasIniFile"] = function($c) { return $GLOBALS["ilIliasIniFile"]; };
++
++$DIC["ilClientIniFile"] = function($c) { return $GLOBALS["ilClientIniFile"]; };
+
 ?>


### PR DESCRIPTION
Hi @alex40724   
@bseglias used the following workaround to avoid the error mentioned in 0023166 (missing globals during structure-reload).