### PR TITLE
fix duplicate html escaping in TA text xls export

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assTextQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assTextQuestion.php
@@ -830,7 +830,7 @@ class assTextQuestion extends assQuestion implements ilObjQuestionScoringAdjusta
 
 		if (strlen($solutions[0]["value1"]))
 		{
-			$worksheet->setCell($startrow + $i, 1, $solutions[0]["value1"]);
+			$worksheet->setCell($startrow + $i, 1, html_entity_decode($solutions[0]["value1"]));
 		}
 		$i++;
 


### PR DESCRIPTION
With the latest changes regarding purifying all input html (and maybe even before that), some characters in the essay XLS export end up doubly encoded; also the setting "export essay question as html code" does not work as expected.

Here's an image that shows what currently happens for one input (see left top) without this fix and with this fix:

![ilias-xls-export](https://user-images.githubusercontent.com/25431384/41463517-0cefcbbe-7097-11e8-8224-8f5ed1887357.png)

The fix is undoing the html encoding currently done by default before exporting to xls.

I've tested that this fix works reliably using my automated test tool (https://github.com/lieblb/testilias) against randomly generated text sequences (only the "export essay question as html code is enabled" case was tested).
