### PR TITLE
ilRPCServerSettings: Fatal Error because of null object ilError

### DIFF
--- a/Services/WebServices/RPC/classes/class.ilRPCServerSettings.php
+++ b/Services/WebServices/RPC/classes/class.ilRPCServerSettings.php
@@ -62,7 +62,6 @@ class ilRPCServerSettings
 
 		$this->log =& $ilLog;
 		$this->db =& $ilDB;
-		$this->err =& $ilError;
 		$this->ilias =& $ilias;
 	}
 

--- a/Services/WebServices/RPC/classes/class.ilRPCServerSettings.php
+++ b/Services/WebServices/RPC/classes/class.ilRPCServerSettings.php
@@ -44,7 +44,6 @@ class ilRPCServerSettings
 
 	var $log = null;
 	var $db = null;
-	var $err = null;
 
 	var $settings_obj  = null;
 
@@ -59,7 +58,6 @@ class ilRPCServerSettings
 
 		$ilLog = $DIC['ilLog'];
 		$ilDB = $DIC['ilDB'];
-		$ilError = $DIC['ilError'];
 		$ilias = $DIC['ilias'];
 
 		$this->log =& $ilLog;
@@ -67,7 +65,7 @@ class ilRPCServerSettings
 		$this->err =& $ilError;
 		$this->ilias =& $ilias;
 	}
-	
+
 	/**
 	 * Get singelton instance
 	 * @return object $ilRPCServerSettings


### PR DESCRIPTION
The call of `$DIC['ilError']` leads to an exception on login. Because `ilErrror` is not defined in the DIC.
It seems that `ilError` is not needed here. I couldn't find any calls of this attribute.