### PR TITLE
Add cpp header file types to default whitelist

### DIFF
--- a/Services/Utilities/classes/class.ilFileUtils.php
+++ b/Services/Utilities/classes/class.ilFileUtils.php
@@ -634,6 +634,8 @@ class ilFileUtils
 			'gtar',   // APPLICATION__X_GTAR,
 			'gz',   // APPLICATION__X_GZIP,
 			'gzip',   // APPLICATION__X_GZIP,
+			'h',	// TEXT__X_C
+			'hpp',	// TEXT__X_C
 			'htm',   // TEXT__HTML,
 			'html',   // TEXT__HTML,
 			'htmls',   // TEXT__HTML,


### PR DESCRIPTION
.cpp files were allowed already and since .h and .hpp files can have identical contents, it makes little sense to not allow them too.  Due to the triviality of this change, I have decided to not go through the bug tracker or feature request, but decided to fix this directly.