### PR TITLE
Proposal for an Interface for a General Kiosk Mode 

### DIFF
--- a/Services/KioskMode/README.md
+++ b/Services/KioskMode/README.md
@@ -1,9 +1,8 @@
 # Kiosk-Mode
 
-The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”,
-“SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”,
-and “OPTIONAL” in this document are to be interpreted as
-described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”,
+“SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be
+interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
 **Table of Contents**
 * [Purpose](#purpose)
@@ -13,64 +12,8 @@ described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
 ## Purpose
 
-A kiosk mode is understood to be a special mode to display certain applications, or
-in the context of ILIAS, certain views in an application where the user gets less
-control over the application or feature than usual. This is traditionally used for
-the unsupervised operation of the application at public locations like museums or
-train stations, where the user e.g. should not be able to perform otherwise common
-operations like closing a window or shutting down the system.
-
-Similar requirements arise in ILIAS for different objects and different scenarios:
-
-* A Test needs to be displayed in a restricted way for the use in an E-Exam.
-* The LTI-Interface needs the ability to display objects in a Kiosk-Mode when it
-  ILIAS is used as a Tool-Provider.
-* The Learning Sequence requires a kiosk mode to maintain control over the general
-  display and navigation.
-
-This service facilitates the implementation of objects that can be viewed in a kiosk
-mode and of features that display these objects in a kiosk mode. The provided means
-aim to make it possible for objects to implement a kiosk mode only once and then be
-used by all features that need to display objects in that kiosk mode. On the other
-hand, features that require viewing other objects in a kiosk mode should be able to
-use all objects that implement a kiosk mode.
-
-This service does neither implement the kiosk-mode for certain objects, nor implements
-a view on these objects. It rather provides interfaces that describe how consumers
-and providers of a kiosk mode should collaborate and functionality that helps to
-implement both sides of the collaboration.
-
-
-## Architecture
-
-A **provider** of a kiosk mode is an ILIAS-object that may be viewed in in a kiosk
-mode. A **player** is any feature of ILIAS that wants to display ILIAS-objects in
-the reduced way defined by the kiosk mode.
-
-The **player** may request a **view** for a certain **provider** at the kiosk mode
-service. The **view** then is the exclusive way for the **player** and the
-**provider** to communicate.
-
-The **view** implements the following functionality to display and control the
-providing object via the kiosk mode:
-
-* It provides **controls** to the player that can be used to modify the state of
-  the view.
-* It provides a function that **updates** a **state** based on the use of **controls**
-  to track the condition of the view.
-* It provides a function to **render** the **state** to allow the player to display
-  the object in a kiosk mode.
-
-The **player** in turn uses that functions of the view to display and execute the
-kiosk mode of the object:
-
-* It asks the view for **controls** and displays them in an appropriate way.
-* It processes user input for the **controls** and asks the view to **update** the
-  **state**. It makes sure that the state is persisted appropriately.
-* It asks the view to **render** the **state** and displays the result in an
-  appropritate way and visual environment, most possibly in conjunction with the
-  controls.
-
+This provides implementations for the [Kiosk-Mode](../../src/KioskMode/README.md) to
+construct views for certain objects and persist state in the database.
 
 ## Public Interface
 

--- a/Services/KioskMode/README.md
+++ b/Services/KioskMode/README.md
@@ -1,0 +1,77 @@
+# Kiosk-Mode
+
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”,
+“SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”,
+and “OPTIONAL” in this document are to be interpreted as
+described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+**Table of Contents**
+* [Purpose](#purpose)
+* [Architecture](#architecture)
+* [Implementing a Provider](#implementing-a-provider)
+* [Implementing a Player](#implementing-a-player)
+
+## Purpose
+
+A kiosk mode is understood to be a special mode to display certain applications, or
+in the context of ILIAS, certain views in an application where the user gets less
+control over the application or feature than usual. This is traditionally used for
+the unsupervised operation of the application at public locations like museums or
+train stations, where the user e.g. should not be able to perform otherwise common
+operations like closing a window or shutting down the system.
+
+Similar requirements arise in ILIAS for different objects and different scenarios:
+
+* A Test needs to be displayed in a restricted way for the use in an E-Exam.
+* The LTI-Interface needs the ability to display objects in a Kiosk-Mode when it
+  ILIAS is used as a Tool-Provider.
+* The Learning Sequence requires a kiosk mode to maintain control over the general
+  display and navigation.
+
+This service facilitates the implementation of objects that can be viewed in a kiosk
+mode and of features that display these objects in a kiosk mode. The provided means
+aim to make it possible for objects to implement a kiosk mode only once and then be
+used by all features that need to display objects in that kiosk mode. On the other
+hand, features that require viewing other objects in a kiosk mode should be able to
+use all objects that implement a kiosk mode.
+
+This service does neither implement the kiosk-mode for certain objects, nor implements
+a view on these objects. It rather provides interfaces that describe how consumers
+and providers of a kiosk mode should collaborate and functionality that helps to
+implement both sides of the collaboration.
+
+
+## Architecture
+
+A **provider** of a kiosk mode is an ILIAS-object that may be viewed in in a kiosk
+mode. A **player** is any feature of ILIAS that wants to display ILIAS-objects in
+the reduced way defined by the kiosk mode.
+
+The **player** may request a **view** for a certain **provider** at the kiosk mode
+service. The **view** then is the exclusive way for the **player** and the
+**provider** to communicate.
+
+The **view** implements the following functionality to display and control the
+providing object via the kiosk mode:
+
+* It provides **controls** to the player that can be used to modify the state of
+  the view.
+* It provides a function that **updates** a **state** based on the use of **controls**
+  to track the condition of the view.
+* It provides a function to **render** the **state** to allow the player to display
+  the object in a kiosk mode.
+
+The **player** in turn uses that functions of the view to display and execute the
+kiosk mode of the object:
+
+* It asks the view for **controls** and displays them in an appropriate way.
+* It processes user input for the **controls** and asks the view to **update** the
+  **state**. It makes sure that the state is persisted appropriately.
+* It asks the view to **render** the **state** and displays the result in an
+  appropritate way and visual environment, most possibly in conjunction with the
+  controls.
+
+
+## Implementing a Provider
+
+## Implementing a Player

--- a/Services/KioskMode/README.md
+++ b/Services/KioskMode/README.md
@@ -19,4 +19,6 @@ construct views for certain objects and persist state in the database.
 
 * `ilKioskModeService` is the central entry  point for consumers of the service.
 * `ilKioskModeView` MUST be implemented by modules that want to provide a kiosk
-  mode.
+  mode. Implementation MUST be located in the `classes` folder of their respective
+  Module where the implementation is named il$MODULEKioskModeView. Implementations
+  must adhere to the interface `ILIAS\KioskMode\View`.

--- a/Services/KioskMode/README.md
+++ b/Services/KioskMode/README.md
@@ -72,6 +72,6 @@ kiosk mode of the object:
   controls.
 
 
-## Implementing a Provider
+## Public Interface
 
-## Implementing a Player
+* `ilKioskModeService` is the central entry  point for consumers of the service.

--- a/Services/KioskMode/README.md
+++ b/Services/KioskMode/README.md
@@ -18,3 +18,5 @@ construct views for certain objects and persist state in the database.
 ## Public Interface
 
 * `ilKioskModeService` is the central entry  point for consumers of the service.
+* `ilKioskModeView` MUST be implemented by modules that want to provide a kiosk
+  mode.

--- a/Services/KioskMode/classes/class.ilKioskModeService.php
+++ b/Services/KioskMode/classes/class.ilKioskModeService.php
@@ -1,0 +1,23 @@
+<?php
+/* Copyright (c) 2018 - Richard Klees <richard.klees@concepts-and-training.de> - Extended GPL, see LICENSE */
+
+/**
+ * Central entry point for users of the service.
+ */
+final class ilKioskModeService {
+	/**
+	 * Try to get a kiosk mode view for the given object.
+	 *
+	 * @return	ilKioskModeView|null
+	 */
+	public function getViewFor(\ilObject $object) {
+	}
+
+	/**
+	 * Check if objects of a certain type provide kiosk modes in general.
+	 *
+	 * @param	string	$object_type	needs to be a valid object type
+	 */
+	public function hasKioskMode(string $object_type) : bool {
+	}
+}

--- a/Services/KioskMode/classes/class.ilKioskModeView.php
+++ b/Services/KioskMode/classes/class.ilKioskModeView.php
@@ -1,0 +1,73 @@
+<?php
+/* Copyright (c) 2018 - Richard Klees <richard.klees@concepts-and-training.de> - Extended GPL, see LICENSE */
+
+/**
+ * Base class to be implemented and put in class-directory of module with the name
+ * il$MODULEKioskModeView (e.g. ilTestKioskModeView).
+ */
+abstract class ilKioskModeView implements ILIAS\KioskModeView {
+	/**
+	 * @var	\ilCtrl
+	 */
+	protected $ctrl;
+
+	/**
+	 * @var \ilLanguage
+	 */
+	protected $lng;
+
+	/**
+	 * @var	\ilAccessHandler
+	 */
+	protected $access;
+
+	/**
+	 * @throws	\LogicException     if an object was provided that does not fit the module
+	 *							    this view belongs to.	
+	 * @throws	\RuntimeException   if user is not allowed to access the kiosk mode
+	 *                              for the supplied object.
+	 */
+	final public function __construct(
+		\ilObject $object,
+		\ilCtrl $ctrl,
+		\ilLanguage $lng,
+		\ilAccessHandler $access
+	) {
+		$this->ctrl = $ctrl;
+		$this->lng = $lng;
+		$this->access = $access;
+		if (!($object instanceof $this->getObjectClass())) {
+			throw new \LogicException(
+				"Provided object of class '".get_class($object)."' does not ".
+				"fit view for '".$this->getObjectClass()."'"
+			);
+		}
+		$this->setObject($object);
+		if (!$this->hasPermissionToAccessKioskMode()) {
+			throw new \RuntimeException(
+				"User is not allowed to access the kiosk mode for the supplied object."
+			);
+		}
+	}
+
+	/**
+	 * Get the class of objects this view displays.
+	 */
+	abstract protected function getObjectClass() : string;
+
+	/**
+	 * Set the object for this view.
+	 *
+	 * This makes it possible to use an appropriately typehinted member variable to
+	 * allow for static code analysis. Sadly PHP has no generics...
+	 */
+	abstract protected setObject(\ilObject $object) : null;
+
+	/**
+	 * Check if the global user has permission to access the kiosk mode of the
+	 * supplied object.
+	 */
+	abstract protected function hasPermissionToAccessKioskMode() : bool;
+
+	// Note that methods of ILIAS\KioskMode\View need to be implemented as well.
+}

--- a/Services/KioskMode/classes/class.ilKioskModeView.php
+++ b/Services/KioskMode/classes/class.ilKioskModeView.php
@@ -5,7 +5,7 @@
  * Base class to be implemented and put in class-directory of module with the name
  * il$MODULEKioskModeView (e.g. ilTestKioskModeView).
  */
-abstract class ilKioskModeView implements ILIAS\KioskModeView {
+abstract class ilKioskModeView implements ILIAS\KioskMode\View {
 	/**
 	 * @var	\ilCtrl
 	 */

--- a/Services/KioskMode/maintenance.json
+++ b/Services/KioskMode/maintenance.json
@@ -1,0 +1,12 @@
+{
+    "maintenance_model": "Classic",
+    "first_maintainer": "rklees(34047)",
+    "second_maintainer": "",
+    "implicit_maintainers": [],
+    "coordinator": "",
+    "tester": "",
+    "testcase_writer": "",
+    "path": "Services/KioskMode",
+    "belong_to_component": "General Kiosk-Mode",
+    "used_in_components": []
+}

--- a/Services/KioskMode/service.xml
+++ b/Services/KioskMode/service.xml
@@ -1,0 +1,3 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<service xmlns="http://www.w3.org" version="$Id:$"
+</service>

--- a/src/KioskMode/ControlBuilder.php
+++ b/src/KioskMode/ControlBuilder.php
@@ -63,7 +63,7 @@ interface ControlBuilder {
 	 *
 	 * @throws \LogicException if view wants to introduce a second locator.
 	 */
-	public function beginLocator(string $command) : LocatorBuilder;
+	public function locator(string $command) : LocatorBuilder;
 
 	/**
 	 * A table of content allows the user to get an overview over the generally available
@@ -76,6 +76,6 @@ interface ControlBuilder {
 	 * @throws \LogicException if view wants to introduce a second TOC.
 	 * @param	mixed $state one of the STATE_ constants from TOCBuilder
 	 */
-	public function beginTOC(string $command, int $parameter = null, $state = null) : TOCBuilder;
+	public function tableOfContent(string $command, int $parameter = null, $state = null) : TOCBuilder;
 }
 

--- a/src/KioskMode/ControlBuilder.php
+++ b/src/KioskMode/ControlBuilder.php
@@ -31,6 +31,13 @@ interface ControlBuilder {
 	public function previousButton(string $command, int $parameter) : ControlBuilder;
 
 	/**
+	 * Build a done button.
+	 *
+	 * @throws \LogicException if view wants to introduce a second previous button.
+	 */
+	public function doneButton(string $command, int $parameter) : ControlBuilder;
+
+	/**
 	 * Build a generic button.
 	 */
 	public function button(string $label, string $command, int $parameter) : ControlBuilder;

--- a/src/KioskMode/ControlBuilder.php
+++ b/src/KioskMode/ControlBuilder.php
@@ -10,40 +10,41 @@ use ILIAS\UI;
  */
 interface ControlBuilder {
 	/**
-	 * Build an exit button.
+	 * An exit control allows the user to gracefully leave the object providing
+	 * the kiosk mode.
 	 *
 	 * @throws \LogicException if view wants to introduce a second exit button.
 	 */
-	public function exitButton(string $command) : ControlBuilder;
+	public function exit(string $command) : ControlBuilder;
 
-	/*
-	 * Build a next button.
+	/**
+	 * A next control allows the user to progress to the next item in the object.
 	 *
 	 * @throws \LogicException if view wants to introduce a second next button.
 	 */
-	public function nextButton(string $command, int $parameter) : ControlBuilder;
+	public function next(string $command, int $parameter) : ControlBuilder;
 
 	/**
-	 * Build a previous button.
+	 * A previous control allows the user to go back to the previous item in the object.
 	 *
 	 * @throws \LogicException if view wants to introduce a second previous button.
 	 */
-	public function previousButton(string $command, int $parameter) : ControlBuilder;
+	public function previous(string $command, int $parameter) : ControlBuilder;
 
 	/**
-	 * Build a done button.
+	 * A done control allows the user to mark the object as done.
 	 *
 	 * @throws \LogicException if view wants to introduce a second previous button.
 	 */
-	public function doneButton(string $command, int $parameter) : ControlBuilder;
+	public function done(string $command, int $parameter) : ControlBuilder;
 
 	/**
-	 * Build a generic button.
+	 * A generic control needs to have a label that tells what it does.
 	 */
-	public function button(string $label, string $command, int $parameter) : ControlBuilder;
+	public function generic(string $label, string $command, int $parameter) : ControlBuilder;
 
 	/**
-	 * Build a toggle.
+	 * A toggle can be used to switch some behaviour in the view on or of.
 	 */
 	public function toggle(string $label, string $on_command, string $off_command) : ControlBuilder;
 
@@ -65,7 +66,8 @@ interface ControlBuilder {
 	public function beginLocator(string $command) : LocatorBuilder;
 
 	/**
-	 * Build a nested table of contents.
+	 * A table of content allows the user to get an overview over the generally available
+	 * content in the object.
 	 *
 	 * The command will be enhanced with a parameter defined here on in the locator builder.
 	 *

--- a/src/KioskMode/ControlBuilder.php
+++ b/src/KioskMode/ControlBuilder.php
@@ -21,19 +21,19 @@ interface ControlBuilder {
 	 *
 	 * @throws \LogicException if view wants to introduce a second next button.
 	 */
-	public function nextButton(string $command) : ControlBuilder;
+	public function nextButton(string $command, int $parameter) : ControlBuilder;
 
 	/**
 	 * Build a previous button.
 	 *
 	 * @throws \LogicException if view wants to introduce a second previous button.
 	 */
-	public function previousButton(string $command) : ControlBuilder;
+	public function previousButton(string $command, int $parameter) : ControlBuilder;
 
 	/**
 	 * Build a generic button.
 	 */
-	public function button(string $label, string $command) : ControlBuilder;
+	public function button(string $label, string $command, int $parameter) : ControlBuilder;
 
 	/**
 	 * Build a toggle.

--- a/src/KioskMode/ControlBuilder.php
+++ b/src/KioskMode/ControlBuilder.php
@@ -74,7 +74,8 @@ interface ControlBuilder {
 	 * If a parameter is defined here, the view provides an overview-page.
 	 *
 	 * @throws \LogicException if view wants to introduce a second TOC.
+	 * @param	mixed $state one of the STATE_ constants from TOCBuilder
 	 */
-	public function beginTOC(string $command, int $parameter = null) : TOCBuilder;
+	public function beginTOC(string $command, int $parameter = null, $state = null) : TOCBuilder;
 }
 

--- a/src/KioskMode/ControlBuilder.php
+++ b/src/KioskMode/ControlBuilder.php
@@ -48,7 +48,15 @@ interface ControlBuilder {
 	public function toggle(string $label, string $on_command, string $off_command) : ControlBuilder;
 
 	/**
-	 * Build a locator.
+	 * A mode control can be used to switch between different modes in the view.
+	 *
+	 * Uses the indizes of the labels in the array as parameter for the command.
+	 */
+	public function mode(string $command, array $labels) : ControlBuilder;
+
+	/**
+	 * A locator allows the user to see the path leading to her current location and
+	 * jump back to previous items on that path.
 	 *
 	 * The command will be enhanced with a parameter defined in the locator builder.
 	 *

--- a/src/KioskMode/ControlBuilder.php
+++ b/src/KioskMode/ControlBuilder.php
@@ -1,0 +1,63 @@
+<?php
+/* Copyright (c) 2018 - Richard Klees <richard.klees@concepts-and-training.de> - Extended GPL, see LICENSE */
+
+namespace ILIAS\KioskMode;
+
+use ILIAS\UI;
+
+/**
+ * Build controls for the view.
+ */
+interface ControlBuilder {
+	/**
+	 * Build an exit button.
+	 *
+	 * @throws \LogicException if view wants to introduce a second exit button.
+	 */
+	public function exitButton(string $command) : ControlBuilder;
+
+	/*
+	 * Build a next button.
+	 *
+	 * @throws \LogicException if view wants to introduce a second next button.
+	 */
+	public function nextButton(string $command) : ControlBuilder;
+
+	/**
+	 * Build a previous button.
+	 *
+	 * @throws \LogicException if view wants to introduce a second previous button.
+	 */
+	public function previousButton(string $command) : ControlBuilder;
+
+	/**
+	 * Build a generic button.
+	 */
+	public function button(string $label, string $command) : ControlBuilder;
+
+	/**
+	 * Build a toggle.
+	 */
+	public function toggle(string $label, string $on_command, string $off_command) : ControlBuilder;
+
+	/**
+	 * Build a locator.
+	 *
+	 * The command will be enhanced with a parameter defined in the locator builder.
+	 *
+	 * @throws \LogicException if view wants to introduce a second locator.
+	 */
+	public function beginLocator(string $command) : LocatorBuilder;
+
+	/**
+	 * Build a nested table of contents.
+	 *
+	 * The command will be enhanced with a parameter defined here on in the locator builder.
+	 *
+	 * If a parameter is defined here, the view provides an overview-page.
+	 *
+	 * @throws \LogicException if view wants to introduce a second TOC.
+	 */
+	public function beginTOC(string $command, int $parameter = null) : TOCBuilder;
+}
+

--- a/src/KioskMode/LocatorBuilder.php
+++ b/src/KioskMode/LocatorBuilder.php
@@ -15,13 +15,13 @@ interface LocatorBuilder {
 	/**
 	 * Finish building the locator.
 	 */
-	public function endLocator() : ControlBuilder; 
+	public function end() : ControlBuilder;
 
 	/**
 	 * Build an entry in the locator.
 	 *
 	 * The parameter will be appended to the command when updating state.
 	 */
-	public function entry(string $label, int $parameter);
+	public function item(string $label, int $parameter) : LocatorBuilder;
 }
 

--- a/src/KioskMode/LocatorBuilder.php
+++ b/src/KioskMode/LocatorBuilder.php
@@ -1,0 +1,27 @@
+<?php
+/* Copyright (c) 2018 - Richard Klees <richard.klees@concepts-and-training.de> - Extended GPL, see LICENSE */
+
+namespace ILIAS\KioskMode;
+
+use ILIAS\UI;
+
+/**
+ * Build a locator for the view.
+ *
+ * The entries of the locator are understood to be given from general to specific,
+ * e.g. Chapter 1 > Section 1.1 > Paragraph 1.1.a ...
+ */
+interface LocatorBuilder {
+	/**
+	 * Finish building the locator.
+	 */
+	public function endLocator() : ControlBuilder; 
+
+	/**
+	 * Build an entry in the locator.
+	 *
+	 * The parameter will be appended to the command when updating state.
+	 */
+	public function entry(string $label, int $parameter);
+}
+

--- a/src/KioskMode/README.md
+++ b/src/KioskMode/README.md
@@ -1,0 +1,79 @@
+# Kiosk-Mode
+
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”,
+“SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be
+interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+**Table of Contents**
+* [Purpose](#purpose)
+* [Architecture](#architecture)
+* [Implementing a Provider](#implementing-a-provider)
+* [Implementing a Player](#implementing-a-player)
+
+## Purpose
+
+A kiosk mode is understood to be a special mode to display certain applications, or
+in the context of ILIAS, certain views in an application where the user gets less
+control over the application or feature than usual. This is traditionally used for
+the unsupervised operation of the application at public locations like museums or
+train stations, where the user e.g. should not be able to perform otherwise common
+operations like closing a window or shutting down the system.
+
+Similar requirements arise in ILIAS for different objects and different scenarios:
+
+* A Test needs to be displayed in a restricted way for the use in an E-Exam.
+* The LTI-Interface needs the ability to display objects in a Kiosk-Mode when it
+  ILIAS is used as a Tool-Provider.
+* The Learning Sequence requires a kiosk mode to maintain control over the general
+  display and navigation.
+
+This library facilitates the implementation of objects that can be viewed in a kiosk
+mode and of features that display these objects in a kiosk mode. The provided means
+aim to make it possible for objects to implement a kiosk mode only once and then be
+used by all features that need to display objects in that kiosk mode. On the other
+hand, features that require viewing other objects in a kiosk mode should be able to
+use all objects that implement a kiosk mode.
+
+This library does neither implement the kiosk-mode for certain objects, nor implements
+a view on these objects. It rather provides interfaces that describe how consumers
+and providers of a kiosk mode should collaborate and functionality that helps to
+implement both sides of the collaboration.
+
+This library is complemented by the [Kiosk-Mode-Service](../../Services/KioskMode/README.md)
+that provides functionality to construct views for certain objects and concrete
+database functionality.
+
+## Architecture
+
+A **provider** of a kiosk mode is an ILIAS-object that may be viewed in in a kiosk
+mode. A **player** is any feature of ILIAS that wants to display ILIAS-objects in
+the reduced way defined by the kiosk mode.
+
+The **player** may request a **view** for a certain **provider** at the kiosk mode
+service. The **view** then is the exclusive way for the **player** and the
+**provider** to communicate.
+
+The **view** implements the following functionality to display and control the
+providing object via the kiosk mode:
+
+* It provides **controls** to the player that can be used to modify the state of
+  the view.
+* It provides a function that **updates** a **state** based on the use of **controls**
+  to track the condition of the view.
+* It provides a function to **render** the **state** to allow the player to display
+  the object in a kiosk mode.
+
+The **player** in turn uses that functions of the view to display and execute the
+kiosk mode of the object:
+
+* It asks the view for **controls** and displays them in an appropriate way.
+* It processes user input for the **controls** and asks the view to **update** the
+  **state**. It makes sure that the state is persisted appropriately.
+* It asks the view to **render** the **state** and displays the result in an
+  appropritate way and visual environment, most possibly in conjunction with the
+  controls.
+
+
+## Implementing a Provider
+
+## Implementing a Player

--- a/src/KioskMode/README.md
+++ b/src/KioskMode/README.md
@@ -76,10 +76,11 @@ kiosk mode of the object:
 
 ## Implementing a Provider
 
-TODO: finish me!
+Please use `ilKioskModeView` in `Services\KioskMode\classes\` as a base to implement
+this for ILIAS-objects.
 
 * `State` MUST only contain information about the view (not about LP, completion, ...)
-* `View` MUST NOT maintain state of the view internally.
+* `View` MUST NOT maintain state of the view internally but put it into `State`.
 * `View::render` MUST NOT render controls that trigger a page change. It MAY provide
   controls that open new browser windows.
 * `View::render` MAY make asynchronues request and change the displayed HTML on the
@@ -97,3 +98,5 @@ TODO: finish me!
 * The player MUST use the commands and parameters provided by the view via
   `View::buildControls` when updating the View.
 * The player MUST call updateGet on GET-Requests and updatePost on POST-requests.
+* The player MUST ensure that a given `State` is unique per instance of View, i.e.
+  keys and values MUST NOT leak to other instances of View.

--- a/src/KioskMode/README.md
+++ b/src/KioskMode/README.md
@@ -80,6 +80,12 @@ TODO: finish me!
 
 * `State` MUST only contain information about the view (not about LP, completion, ...)
 * `View` MUST NOT maintain state of the view internally.
+* `View::render` MUST NOT render controls that trigger a page change. It MAY provide
+  controls that open new browser windows.
+* `View::render` MAY make asynchronues request and change the displayed HTML on the
+  client-side accordingly.
+* The button-controls provided in `View::buildControls` MUST only be used to change the
+  views status. Changes in the systems status MUST be initiated via a POST-request.
 
 ## Implementing a Player
 
@@ -90,3 +96,4 @@ TODO: finish me!
   entries.
 * The player MUST use the commands and parameters provided by the view via
   `View::buildControls` when updating the View.
+* The player MUST call updateGet on GET-Requests and updatePost on POST-requests.

--- a/src/KioskMode/README.md
+++ b/src/KioskMode/README.md
@@ -76,4 +76,17 @@ kiosk mode of the object:
 
 ## Implementing a Provider
 
+TODO: finish me!
+
+* `State` MUST only contain information about the view (not about LP, completion, ...)
+* `View` MUST NOT maintain state of the view internally.
+
 ## Implementing a Player
+
+TODO: finish me!
+
+* The player SHOULD respect the order in which the view build controls.
+* The player MUST respect the order in which the view builds locator entries and TOC
+  entries.
+* The player MUST use the commands and parameters provided by the view via
+  `View::buildControls` when updating the View.

--- a/src/KioskMode/State.php
+++ b/src/KioskMode/State.php
@@ -1,0 +1,27 @@
+<?php
+/* Copyright (c) 2018 - Richard Klees <richard.klees@concepts-and-training.de> - Extended GPL, see LICENSE */
+
+namespace ILIAS\KioskMode;
+
+/**
+ * Keeps the state of a view in a simple stringly type key-value store.
+ */
+class State {
+	/**
+	 * Set a value for a key of the state.
+	 */
+	public function withValueFor(string $key, string $value) : State {
+	}
+
+	/**
+	 * Remove the key-value-pair.
+	 */
+	public function withoutKey(string $key) : State {
+	}
+
+	/**
+	 * Get the value for the given key.
+	 */
+	public function getValueFor(string $key) : State {
+	}
+}

--- a/src/KioskMode/TOCBuilder.php
+++ b/src/KioskMode/TOCBuilder.php
@@ -1,0 +1,33 @@
+<?php
+/* Copyright (c) 2018 - Richard Klees <richard.klees@concepts-and-training.de> - Extended GPL, see LICENSE */
+
+namespace ILIAS\KioskMode;
+
+use ILIAS\UI;
+
+/**
+ * Build a nested table of contents for the view.
+ */
+interface TOCBuilder {
+	/**
+	 * Finish building the TOC.
+	 *
+	 * @return	ControlBuilder|TOCBuilder depending on the nesting level.
+	 */
+	public function endTOC(string $command);
+
+	/**
+	 * Build a sub tree in the TOC.
+	 *
+	 * If a parameter is provided, the node in the TOC can be accessed itself.
+	 */
+	public function beginTOC($label, int $parameter = null) : TOCBuilder;
+
+	/**
+	 * Build an entry in the TOC.
+	 *
+	 * The parameter will be appended to the command when updating the state.
+	 */
+	public function entry(string $label, int $parameter);
+}
+

--- a/src/KioskMode/TOCBuilder.php
+++ b/src/KioskMode/TOCBuilder.php
@@ -9,10 +9,10 @@ use ILIAS\UI;
  * Build a nested table of contents for the view.
  */
 interface TOCBuilder {
-	const STATE_NOT_STARTED = 0;
-	const STATE_IN_PROGRESS = 1;
-	const STATE_COMPLETED = 2;
-	const STATE_FAILED = 3;
+	const LP_NOT_STARTED = 0;
+	const LP_IN_PROGRESS = 1;
+	const LP_COMPLETED = 2;
+	const LP_FAILED = 3;
 
 	/**
 	 * Finish building the TOC.
@@ -26,16 +26,16 @@ interface TOCBuilder {
 	 *
 	 * If a parameter is provided, the node in the TOC can be accessed itself.
 	 *
-	 * @param	mixed $state one of the STATE_ constants from TOCBuilder
+	 * @param	mixed $state one of the LP_ constants from TOCBuilder
 	 */
-	public function node($label, int $parameter = null, $state = null) : TOCBuilder;
+	public function node($label, int $parameter = null, $lp = null) : TOCBuilder;
 
 	/**
 	 * Build an entry in the TOC.
 	 *
 	 * The parameter will be appended to the command when updating the state.
 	 *
-	 * @param	mixed $state one of the STATE_ constants from TOCBuilder
+	 * @param	mixed $state one of the LP_ constants from TOCBuilder
 	 */
 	public function item(string $label, int $parameter, $state = null) : TOCBuilder;
 }

--- a/src/KioskMode/TOCBuilder.php
+++ b/src/KioskMode/TOCBuilder.php
@@ -19,7 +19,7 @@ interface TOCBuilder {
 	 *
 	 * @return	ControlBuilder|TOCBuilder depending on the nesting level.
 	 */
-	public function endTOC(string $command);
+	public function end(string $command);
 
 	/**
 	 * Build a sub tree in the TOC.
@@ -28,7 +28,7 @@ interface TOCBuilder {
 	 *
 	 * @param	mixed $state one of the STATE_ constants from TOCBuilder
 	 */
-	public function beginTOC($label, int $parameter = null, $state = null) : TOCBuilder;
+	public function node($label, int $parameter = null, $state = null) : TOCBuilder;
 
 	/**
 	 * Build an entry in the TOC.
@@ -37,6 +37,6 @@ interface TOCBuilder {
 	 *
 	 * @param	mixed $state one of the STATE_ constants from TOCBuilder
 	 */
-	public function entry(string $label, int $parameter, $state = null);
+	public function item(string $label, int $parameter, $state = null) : TOCBuilder;
 }
 

--- a/src/KioskMode/TOCBuilder.php
+++ b/src/KioskMode/TOCBuilder.php
@@ -9,6 +9,11 @@ use ILIAS\UI;
  * Build a nested table of contents for the view.
  */
 interface TOCBuilder {
+	const STATE_NOT_STARTED = 0;
+	const STATE_IN_PROGRESS = 1;
+	const STATE_COMPLETED = 2;
+	const STATE_FAILED = 3;
+
 	/**
 	 * Finish building the TOC.
 	 *
@@ -20,14 +25,18 @@ interface TOCBuilder {
 	 * Build a sub tree in the TOC.
 	 *
 	 * If a parameter is provided, the node in the TOC can be accessed itself.
+	 *
+	 * @param	mixed $state one of the STATE_ constants from TOCBuilder
 	 */
-	public function beginTOC($label, int $parameter = null) : TOCBuilder;
+	public function beginTOC($label, int $parameter = null, $state = null) : TOCBuilder;
 
 	/**
 	 * Build an entry in the TOC.
 	 *
 	 * The parameter will be appended to the command when updating the state.
+	 *
+	 * @param	mixed $state one of the STATE_ constants from TOCBuilder
 	 */
-	public function entry(string $label, int $parameter);
+	public function entry(string $label, int $parameter, $state = null);
 }
 

--- a/src/KioskMode/URLBuilder.php
+++ b/src/KioskMode/URLBuilder.php
@@ -1,0 +1,18 @@
+<?php
+/* Copyright (c) 2018 - Richard Klees <richard.klees@concepts-and-training.de> - Extended GPL, see LICENSE */
+
+namespace ILIAS\KioskMode;
+
+use ILIAS\Data;
+
+/**
+ * The URLBuilder allows views to get links that are used somewhere inline in
+ * the content.
+ */
+interface URLBuilder {
+    /**
+     * Get an URL for the provided command and params.
+     */
+    public function getURL(string $command, int $param = null) : Data\URI;
+}
+

--- a/src/KioskMode/View.php
+++ b/src/KioskMode/View.php
@@ -36,14 +36,12 @@ interface View {
 	public function updatePost(State $state, string $command, array $post) : State;
 
 	/**
-	 * Render a state using the ui-factory.
-	 *
-	 * @param	callable $post_link	Provides a link to post data when given a command.
+	 * Render a state using the ui-factory and URLs from the builder.
 	 */
 	public function render(
 		State $state,
 		UI\Factory $factory,
-		callable $post_link,
+		URLBuilder $post_link,
 		array $post = null
 	) : UI\Component\Component;
 }

--- a/src/KioskMode/View.php
+++ b/src/KioskMode/View.php
@@ -6,8 +6,9 @@ namespace ILIAS\KioskMode;
 use ILIAS\UI;
 
 /**
- * A kiosk mode view on a certain object. See README#Architecture for further
- * details.
+ * A kiosk mode view on a certain object. See README/Architecture for further
+ * details and README/Implementing a Provider for further directions about
+ * implementation.
  */
 interface View {
 	/**

--- a/src/KioskMode/View.php
+++ b/src/KioskMode/View.php
@@ -11,6 +11,11 @@ use ILIAS\UI;
  */
 interface View {
 	/**
+	 * Build an initial state based on the Provided empty state.
+	 */
+	public function buildInitialState(State $empty_state) : State;
+
+	/**
 	 * Construct the controls for the view based on the current state.
 	 */
 	public function buildControls(State $state, ControlBuilder $builder) : null;
@@ -20,10 +25,24 @@ interface View {
 	 *
 	 * Commands and parameters are defined by the view in `buildControl`.
 	 */
-	public function update(State $state, string $command, int $param = null) : State;
+	public function updateGet(State $state, string $command, int $param = null) : State;
+
+	/**
+	 * Update the state and the object based on the provided command and post-data.
+	 *
+	 * Commands are defined via the post_link-closure provided to render.
+	 */
+	public function updatePost(State $state, string $command, array $post) : State;
 
 	/**
 	 * Render a state using the ui-factory.
+	 *
+	 * @param	callable $post_link	Provides a link to post data when given a command.
 	 */
-	public function render(State $state, UI\Factory $factory) : UI\Component\Component;
+	public function render(
+		State $state,
+		UI\Factory $factory,
+		callable $post_link,
+		array $post = null
+	) : UI\Component\Component;
 }

--- a/src/KioskMode/View.php
+++ b/src/KioskMode/View.php
@@ -1,0 +1,29 @@
+<?php
+/* Copyright (c) 2018 - Richard Klees <richard.klees@concepts-and-training.de> - Extended GPL, see LICENSE */
+
+namespace ILIAS\KioskMode;
+
+use ILIAS\UI;
+
+/**
+ * A kiosk mode view on a certain object. See README#Architecture for further
+ * details.
+ */
+interface View {
+	/**
+	 * Construct the controls for the view based on the current state.
+	 */
+	public function buildControls(State $state, ControlBuilder $builder) : null;
+
+	/**
+	 * Update the state based on the provided command.
+	 *
+	 * Commands and parameters are defined by the view in `buildControl`.
+	 */
+	public function update(State $state, string $command, int $param = null) : State;
+
+	/**
+	 * Render a state using the ui-factory.
+	 */
+	public function render(State $state, UI\Factory $factory) : UI\Component\Component;
+}

--- a/src/KioskMode/View.php
+++ b/src/KioskMode/View.php
@@ -31,17 +31,24 @@ interface View {
 	/**
 	 * Update the state and the object based on the provided command and post-data.
 	 *
-	 * Commands are defined via the post_link-closure provided to render.
+	 * Commands are defined via the url-builder provided to render.
+	 *
+	 * The POSTed data will be passed via $post.
 	 */
 	public function updatePost(State $state, string $command, array $post) : State;
 
 	/**
 	 * Render a state using the ui-factory and URLs from the builder.
+	 *
+	 * Links inside the content that should lead to kiosk-mode-view again (forms)
+	 * must be created via the URLBuilder.
+	 *
+	 * If data was POSTed to the kiosk-mode-view, it will be passed via $post.
 	 */
 	public function render(
 		State $state,
 		UI\Factory $factory,
-		URLBuilder $post_link,
+		URLBuilder $url_builder,
 		array $post = null
 	) : UI\Component\Component;
 }

--- a/src/KioskMode/maintenance.json
+++ b/src/KioskMode/maintenance.json
@@ -1,0 +1,12 @@
+{
+    "maintenance_model": "Classic",
+    "first_maintainer": "rklees(34047)",
+    "second_maintainer": "",
+    "implicit_maintainers": [],
+    "coordinator": "",
+    "tester": "",
+    "testcase_writer": "",
+    "path": "src/KioskMode",
+    "belong_to_component": "General Kiosk-Mode",
+    "used_in_components": []
+}


### PR DESCRIPTION
This is a proposal for an interface to a General Kiosk Mode as outline [in the feature wiki](https://www.ilias.de/docu/goto_docu_wiki_wpage_5237_1357.html). This currently focuses on the interface that objects need to implement that want to be displayed in a kiosk mode view. Facilities for features that want to use said objects will follow once the view-part is mostly fixed.

This is split into two parts:

* `src\KioskMode` that contains the library-like functionality that consumers of kiosk mode from both perspective (players and view) will require. It also defines the basic structure how the kiosk mode works and different entities cooperate.
* `Service\KioskMode` contains the concrete implementation of the general kiosk mode service for ILIAS. It provides base classes that other components use to participate in the kiosk mode and defines bindings to other services (like database).

When reading this you might want to start with the [description of the architecture](https://github.com/ILIAS-eLearning/ILIAS/pull/1105/files#diff-41ec46747e6b49a84af95a48b7eeeade), then go on the [central interface views must implement](https://github.com/ILIAS-eLearning/ILIAS/pull/1105/files#diff-bccbccfa90ea86924985828467b6381e) and proceed to the [base class that must be used to implement it](https://github.com/ILIAS-eLearning/ILIAS/pull/1105/files#diff-4a7f3aaade4ccea0215d90e6d2e4904e).

Questions and feedback, even more so constructive one, is very much appreciated.
 