### PR TITLE
Move initalisation of ILIAS into constructor of CronStartUp

### DIFF
--- a/Services/Cron/classes/class.ilCronStartUp.php
+++ b/Services/Cron/classes/class.ilCronStartUp.php
@@ -14,7 +14,7 @@ class ilCronStartUp
 	private $username = '';
 	private $password = '';
 
-	/** @var ilAuthSession|mixed|null */
+	/** @var ilAuthSession */
 	private $authSession;
 
 	/**
@@ -27,34 +27,27 @@ class ilCronStartUp
 		$a_client_id,
 		$a_login,
 		$a_password,
-		\ilAuthSession $authSession = null
+		ilAuthSession $authSession = null
 	) {
 		$this->client = $a_client_id;
 		$this->username = $a_login;
 		$this->password = $a_password;
 
-		if ($authSession) {
+		include_once './Services/Context/classes/class.ilContext.php';
+		ilContext::init(ilContext::CONTEXT_CRON);
+
+		// define client
+		// @see mantis 20371
+		$_GET['client_id'] = $this->client;
+
+		include_once './include/inc.header.php';
+
+		if (null === $authSession) {
 			global $DIC;
 			$authSession = $DIC['ilAuthSession'];
 		}
 		$this->authSession = $authSession;
 	}
-	
-	/** 
-	 * Init ILIAS
-	 */
-	public function initIlias()
-	{
-		include_once './Services/Context/classes/class.ilContext.php';
-		ilContext::init(ilContext::CONTEXT_CRON);
-		
-		// define client
-		// @see mantis 20371
-		$_GET['client_id'] = $this->client;
-		
-		include_once './include/inc.header.php';
-	}
-	
 	
 
 	/**
@@ -65,21 +58,18 @@ class ilCronStartUp
 	 */
 	public function authenticate()
 	{
-		include_once './Services/Authentication/classes/Frontend/class.ilAuthFrontendCredentials.php';
 		$credentials = new ilAuthFrontendCredentials();
 		$credentials->setUsername($this->username);
 		$credentials->setPassword($this->password);
 		
-		include_once './Services/Authentication/classes/Provider/class.ilAuthProviderFactory.php';
 		$provider_factory = new ilAuthProviderFactory();
 		$providers = $provider_factory->getProviders($credentials);
 			
-		include_once './Services/Authentication/classes/class.ilAuthStatus.php';
 		$status = ilAuthStatus::getInstance();
 			
-		include_once './Services/Authentication/classes/Frontend/class.ilAuthFrontendFactory.php';
 		$frontend_factory = new ilAuthFrontendFactory();
 		$frontend_factory->setContext(ilAuthFrontendFactory::CONTEXT_CLI);
+
 		$frontend = $frontend_factory->getFrontend(
 			$this->authSession,
 			$status,
@@ -98,9 +88,8 @@ class ilCronStartUp
 
 			default:
 			case ilAuthStatus::STATUS_AUTHENTICATION_FAILED:
-				include_once './Services/Cron/exceptions/class.ilCronException.php';
 				throw new ilCronException($status->getTranslatedReason());
-		}				
+		}
 		return true;
 	}
 

--- a/cron/cron.php
+++ b/cron/cron.php
@@ -2,7 +2,6 @@
 chdir(dirname(__FILE__));
 chdir('..');
 
-
 include_once './Services/Cron/classes/class.ilCronStartUp.php';
 
 if($_SERVER['argc'] < 4)
@@ -11,10 +10,17 @@ if($_SERVER['argc'] < 4)
 	exit(1);
 }
 
-$cron = new ilCronStartUp($_SERVER['argv'][3], $_SERVER['argv'][1], $_SERVER['argv'][2]);
+$client = $_SERVER['argv'][3];
+$login = $_SERVER['argv'][1];
+$password = $_SERVER['argv'][2];
+
+$cron = new ilCronStartUp(
+	$client,
+	$login,
+	$password
+);
 
 try {
-	$cron->initIlias();
 	$cron->authenticate();
 
 	$cronManager = new ilStrictCliCronManager(


### PR DESCRIPTION
This PR is bugfix to the dependency injection approach I made earlier. Because the CronStartUp is at the very start of the ILIAS callstack the `DIC` and therefore `ilAuthSession` doesn't exist, I moved the initialisation of ILIAS into the constructor of `CronStartUp`.

While I am at this file: I also removed some `includes` because we are already using an autloader, so no need to use them.