### PR TITLE
0020393: The chatserver replies to a connect from a client with "invalid namespace"

### DIFF
--- a/Modules/Chatroom/classes/gui/class.ilChatroomViewGUI.php
+++ b/Modules/Chatroom/classes/gui/class.ilChatroomViewGUI.php
@@ -145,6 +145,7 @@ class ilChatroomViewGUI extends ilChatroomGUIHandler
 		$initial->profile_image_url     = $ilCtrl->getLinkTarget($this->gui, 'view-getUserProfileImages', '', true, false);
 		$initial->no_profile_image_url  = ilUtil::getImagePath('no_photo_xxsmall.jpg');
 		$initial->private_rooms_enabled = (boolean)$room->getSetting('private_rooms_enabled');
+		$initial->subdirectory          = $settings->getSubDirectory();
 
 		$initial->userinfo = array(
 			'moderator' => ilChatroom::checkUserPermissions('moderate', (int)$_GET['ref_id'], false),

--- a/Modules/Chatroom/js/iliaschat.jquery.js
+++ b/Modules/Chatroom/js/iliaschat.jquery.js
@@ -1155,7 +1155,7 @@ var ILIASConnector = function ILIASConnector(_postUrl, responseHandler) {
  * @param {GUI} gui
  * @constructor
  */
-var ServerConnector = function ServerConnector(url, scope, user, userManager, gui) {
+var ServerConnector = function ServerConnector(url, scope, user, userManager, gui, subdirectory) {
 
 	var _socket;
 
@@ -1163,7 +1163,7 @@ var ServerConnector = function ServerConnector(url, scope, user, userManager, gu
 	 * Setup server connector
 	 */
 	this.init = function() {
-		_socket = io.connect(url);
+		_socket = io.connect(url, {path: subdirectory});
 
 		_socket.on('message', _onMessage);
 		_socket.on('connect', function(){
@@ -1678,7 +1678,7 @@ il.Util.addOnLoad(function () {
 			var userManager		= new UserManager();
 			smileys			= new Smileys(initial.smileys);
 			iliasConnector	= new ILIASConnector(posturl, new ILIASResponseHandler());
-			serverConnector 	= new ServerConnector(baseurl + '/'+instance, scope, user, userManager, gui);
+			serverConnector 	= new ServerConnector(baseurl + '/'+instance, scope, user, userManager, gui, initial.subdirectory);
 			var privateRooms	= new PrivateRooms('#private_rooms', translation, iliasConnector);
 			var chatUsers		= new ChatUsers('#chat_users', translation, iliasConnector);
 			chatActions		= new ChatActions('#chat_actions', translation, iliasConnector, initial.private_rooms_enabled, userManager);


### PR DESCRIPTION
This PR add the possibility to configure a chatserver within a subdirectory.
This feature already works fine for the OnScreenChat but the implementation for chatrooms missed to pass the configuration parameter to the socket.io `connect` funtion.

Example:

```javascript
io.connect(
    'https://my.domain/MY_CLIENT_ID',
    {
          path: '/subdirectory'
    }
);
```
This configuration will connect to an URL like

 `https://my.domain/subdirectory/?EIO=3&transport=polling&sid=<id>`

Ticket: https://www.ilias.de/mantis/view.php?id=20393#c56292
