### PR TITLE
Fixes: Course Icons are blocked for a regular user (#23308)

### DIFF
--- a/Services/Container/classes/class.ilContainerAccess.php
+++ b/Services/Container/classes/class.ilContainerAccess.php
@@ -23,7 +23,7 @@ class ilContainerAccess
 
 		preg_match("/\\/obj_([\\d]*)\\//uism", $ilWACPath->getPath(), $results);
 		foreach (ilObject2::_getAllReferences($results[1]) as $ref_id) {
-			if ($ilAccess->checkAccess('read', '', $ref_id)) {
+			if ($ilAccess->checkAccess('visible', '', $ref_id)) {
 				return true;
 			}
 		}


### PR DESCRIPTION
Custom icons are blocked since containerAccess checks "read" permission of the courses. A user, that has no access to the course should still see the icon though. It has been reported on mantis.

https://ilias.de/mantis/view.php?id=23308
