### PR TITLE
Added file type .vsdx for VISEO files to list of valid file extensions

### DIFF
--- a/Services/Utilities/classes/class.ilFileUtils.php
+++ b/Services/Utilities/classes/class.ilFileUtils.php
@@ -795,6 +795,7 @@ class ilFileUtils
 			'viv',   // VIDEO__VIMEO,
 			'vivo',   // VIDEO__VIVO,
 			'vrml',   // APPLICATION__X_VRML,
+            'vsdx',   // viseo
 			'wav',		// wav
 			'webm',   // VIDEO__WEBM,
 			'wmv',   // VIDEO__X_MS_WMV,


### PR DESCRIPTION
Added file type for VISEO application to whitelist. Related bug report is #22658