### PR TITLE
Error Handling: Editor Support

### DIFF
--- a/Services/Init/classes/class.ilErrorHandling.php
+++ b/Services/Init/classes/class.ilErrorHandling.php
@@ -399,7 +399,7 @@ class ilErrorHandling extends PEAR
 
 	/**
 	 * Get the handler to be used in DEVMODE.
-	 * @return Whoops\Handler
+	 * @return Whoops\Handler\HandlerInterface
 	 */
 	protected function devmodeHandler() {
 		global $ilLog;
@@ -413,30 +413,34 @@ class ilErrorHandling extends PEAR
 				// fallthrough
 			default:
 				if ((!defined('ERROR_HANDLER') || ERROR_HANDLER != 'PRETTY_PAGE') && $ilLog) {
-					$ilLog->write("Unknown or undefined error handler '".ERROR_HANDLER."'. "
-						."Falling back to PrettyPageHandler.");
-				}
-			$prettyPageHandler = new PrettyPageHandler();
-			if (defined('ERROR_EDITOR_URL')) {
-				$pathTranslations = [];
-
-				if (defined('ERROR_EDITOR_PATH_TRANSLATIONS')) {
-					$mappings = explode('|', ERROR_EDITOR_PATH_TRANSLATIONS);
-					foreach ($mappings as $mapping) {
-						$parts = explode(',', $mapping);
-						$pathTranslations[$parts[0]] = $parts[1];
-					}
+					$ilLog->write(
+						"Unknown or undefined error handler '".ERROR_HANDLER."'. " .
+						"Falling back to PrettyPageHandler."
+					);
 				}
 
-				$prettyPageHandler->setEditor(function ($file, $line) use ($pathTranslations) {
-					foreach ($pathTranslations as $from => $to) {
-						$file = preg_replace('@' . $from . '@' , $to, $file);
+				$prettyPageHandler = new PrettyPageHandler();
+				if (defined('ERROR_EDITOR_URL')) {
+					$pathTranslations = [];
+
+					if (defined('ERROR_EDITOR_PATH_TRANSLATIONS')) {
+						$mappings = explode('|', ERROR_EDITOR_PATH_TRANSLATIONS);
+						foreach ($mappings as $mapping) {
+							$parts = explode(',', $mapping);
+							$pathTranslations[$parts[0]] = $parts[1];
+						}
 					}
 
-					return str_ireplace(['[FILE]', '[LINE]'], [$file, $line], ERROR_EDITOR_URL);
-				});
-			}
-			return $prettyPageHandler;
+					$prettyPageHandler->setEditor(function ($file, $line) use ($pathTranslations) {
+						foreach ($pathTranslations as $from => $to) {
+							$file = preg_replace('@' . $from . '@' , $to, $file);
+						}
+
+						return str_ireplace(['[FILE]', '[LINE]'], [$file, $line], ERROR_EDITOR_URL);
+					});
+				}
+
+				return $prettyPageHandler;
 		}
 	}
 	

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -139,6 +139,16 @@ class ilInitialisation
 		define ("PATH_TO_LESSC",$ilIliasIniFile->readVariable("tools","lessc"));
 		define ("PATH_TO_PHANTOMJS",$ilIliasIniFile->readVariable("tools","phantomjs"));
 
+		if ($ilIliasIniFile->groupExists('error')) {
+			if ($ilIliasIniFile->variableExists('error', 'editor_url')) {
+				define("ERROR_EDITOR_URL", $ilIliasIniFile->readVariable('error','editor_url'));
+			}
+
+			if ($ilIliasIniFile->variableExists('error', 'editor_path_translations')) {
+				define("ERROR_EDITOR_PATH_TRANSLATIONS", $ilIliasIniFile->readVariable('error','editor_path_translations'));
+			}
+		}
+
 		// read virus scanner settings
 		switch ($ilIliasIniFile->readVariable("tools", "vscantype"))
 		{


### PR DESCRIPTION
Allows IDE url handlers for the pretty page handler output.

Configuration could be done in the *ilias.ini.php* file (Example: ILIAS running on a Vagrant Ubuntu guest VM, files are located on a Windows 10 host):

```
[error]
editor_url = "phpstorm://open?file=[FILE]&line=[LINE]"
editor_path_translations = "/var/www/ilias/htdocs,C:/xampp/htdocs/ilias"
```

See also: https://github.com/filp/whoops/blob/master/docs/Open%20Files%20In%20An%20Editor.md