### PR TITLE
Delay form submit until autosave is finished

### DIFF
--- a/Modules/Test/js/ilTestPlayerQuestionEditControl.js
+++ b/Modules/Test/js/ilTestPlayerQuestionEditControl.js
@@ -258,6 +258,10 @@ il.TestPlayerQuestionEditControl = new function() {
             autoSaver = 0;
         }
 
+        // guard against race condition from delayed startTimers, i.e.
+        // if startTimers is scheduled, but hasn't run at this point.
+        config.autosaveInterval = 0;
+
         if (autoSaveInCommit) {
             onAutoSaveDone = then;
         } else {
@@ -616,6 +620,12 @@ il.TestPlayerQuestionEditControl = new function() {
      * Handle the form submission
      */
     function handleFormSubmit() {
+
+        if (autoSaveInCommit) {
+            alert("Please try again after autosave has finished.");
+            return false;
+        }
+
         //var submitBtn = $(this).find("input[type=submit]:focus"); // perhaps neccessary anytime
         
         // add the 'answer changed' parameter to the url
@@ -684,6 +694,7 @@ il.TestPlayerQuestionEditControl = new function() {
                 })
             .done(function(responseText) {
                 autoSaveInCommit = false;
+                autoSavedData = newData;
                 autoSaveSuccess(responseText);
                 autoSaveDone();
             })
@@ -692,8 +703,6 @@ il.TestPlayerQuestionEditControl = new function() {
                 autoSaveFailure(responseText);
                 autoSaveDone();
             });
-
-            autoSavedData = newData;
         }
     }
 


### PR DESCRIPTION
Vgl. https://github.com/ILIAS-eLearning/ILIAS/pull/1027 und https://www.ilias.de/mantis/view.php?id=23410.

In außerordentlich seltenen Fällen scheint es, nach meiner Meinung durch sehr seltene race conditions in  Browserimplementierungen, möglich zu sein, dass eine definierte Serialisierung zwischen HTTP Post und dem Ajax-XHR von Autosave nicht gewährleistet ist.

Dieser PR erzwingt eine solche Serialisierung, indem kein HTTP Post abgesendet wird, solange ein AutoSave durchgeführt und noch nicht abgeschlossen ist; der HTTP Post wird entsprechend verzögert. Hierbei handelt es sich in der Regel nur um Sekundenbruchteile.

Zur Einordnung: dieser Fall tritt per se sehr selten auf: der Benutzer muss genau in dem Sekundenbruchteil Submit drücken, wenn das System im Autosave ist. Selbst wenn dieser Fall auftritt, ist die Wahrscheinlichkeit, dass etwas schiefgeht, wiederum außerordentlich gering.

Die Formattierung innerhalb der verzögerten `function()`-Blöcke habe ich absichtlich uneingerückt gelassen, um ersichtlich zu machen, dass ich da nicht geändert habe.

