### PR TITLE
No action behind glyph, if there is no next or previous page

### DIFF
--- a/src/UI/Component/Glyph/Glyph.php
+++ b/src/UI/Component/Glyph/Glyph.php
@@ -90,4 +90,12 @@ interface Glyph extends \ILIAS\UI\Component\Component, \ILIAS\UI\Component\JavaS
 	 * @return mixed
 	 */
 	public function withHighlight();
+
+	/**
+	 * Get a Glyph like this with an action.
+	 *
+	 * @param string $action
+	 * @return mixed
+	 */
+	public function withAction($action);
 }

--- a/src/UI/Implementation/Component/Glyph/Glyph.php
+++ b/src/UI/Implementation/Component/Glyph/Glyph.php
@@ -158,4 +158,13 @@ class Glyph implements C\Glyph\Glyph {
 	public function appendOnClick(Signal $signal) {
 		return $this->appendTriggeredSignal($signal, 'click');
 	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function withAction($action) {
+		$clone = clone $this;
+		$clone->action = $action;
+		return $clone;
+	}
 }

--- a/src/UI/Implementation/Component/ViewControl/Renderer.php
+++ b/src/UI/Implementation/Component/ViewControl/Renderer.php
@@ -306,11 +306,15 @@ class Renderer extends AbstractComponentRenderer
 		$forward = $f->glyph()->next();
 
 		if($component->getTriggeredSignals()) {
-			if($prev != 0) {
+			if($prev >= 0
+				&& $component->getCurrentPage() > 0
+			) {
 				$back = $back->withOnClick($component->getInternalSignal());
 			}
 
-			if($next <= $max_pages) {
+			if($next <= $component->getNumberOfPages() - 1
+				&& $component->getCurrentPage() < $component->getNumberOfPages() - 1
+			) {
 				$forward = $forward->withOnClick($component->getInternalSignal());
 			}
 		} else {
@@ -329,11 +333,15 @@ class Renderer extends AbstractComponentRenderer
 				$url_next = $base .http_build_query($params);
 			}
 
-			if($prev > 0) {
+			if($prev >= 0
+				&& $component->getCurrentPage() > 0
+			) {
 				$back = $back->withAction($url_prev);
 			}
 
-			if($next <= $max_pages) {
+			if($next <= $component->getNumberOfPages() - 1
+				&& $component->getCurrentPage() < $component->getNumberOfPages() - 1
+			) {
 				$forward = $forward->withAction($url_next);
 			}
 		}

--- a/src/UI/Implementation/Component/ViewControl/Renderer.php
+++ b/src/UI/Implementation/Component/ViewControl/Renderer.php
@@ -295,15 +295,24 @@ class Renderer extends AbstractComponentRenderer
 	 */
 	protected function setPaginationBrowseControls(Component\ViewControl\Pagination $component, RendererInterface $default_renderer, &$tpl) {
 		$prev = max(0, $component->getCurrentPage() - 1);
-		$next = $component->getCurrentPage() + 1;
+		$max_pages = $component->getNumberOfPages() - 1;
+		$next = min($component->getCurrentPage() + 1, $max_pages);
 
 		$f = new \ILIAS\UI\Implementation\Factory(
 			new \ILIAS\UI\Implementation\Component\SignalGenerator()
 		);
 
+		$back = $f->glyph()->back();
+		$forward = $f->glyph()->next();
+
 		if($component->getTriggeredSignals()) {
-			$back = $f->glyph()->back('')->withOnClick($component->getInternalSignal());
-			$forward = $f->glyph()->next('')->withOnClick($component->getInternalSignal());
+			if($prev != 0) {
+				$back = $back->withOnClick($component->getInternalSignal());
+			}
+
+			if($next < $max_pages) {
+				$forward = $forward->withOnClick($component->getInternalSignal());
+			}
 		} else {
 			$url = $component->getTargetURL();
 			if(strpos($url, '?') === false) {
@@ -320,8 +329,13 @@ class Renderer extends AbstractComponentRenderer
 				$url_next = $base .http_build_query($params);
 			}
 
-			$back = $f->glyph()->back($url_prev);
-			$forward = $f->glyph()->next($url_next);
+			if($prev > 0) {
+				$back = $back->withAction($url_prev);
+			}
+
+			if($next < $max_pages) {
+				$forward = $forward->withAction($url_next);
+			}
 		}
 
 		//2do: unavailable action for glyphs

--- a/src/UI/Implementation/Component/ViewControl/Renderer.php
+++ b/src/UI/Implementation/Component/ViewControl/Renderer.php
@@ -310,7 +310,7 @@ class Renderer extends AbstractComponentRenderer
 				$back = $back->withOnClick($component->getInternalSignal());
 			}
 
-			if($next < $max_pages) {
+			if($next <= $max_pages) {
 				$forward = $forward->withOnClick($component->getInternalSignal());
 			}
 		} else {
@@ -333,7 +333,7 @@ class Renderer extends AbstractComponentRenderer
 				$back = $back->withAction($url_prev);
 			}
 
-			if($next < $max_pages) {
+			if($next <= $max_pages) {
 				$forward = $forward->withAction($url_next);
 			}
 		}


### PR DESCRIPTION
The pagination control renders glyphs for navigation between pages. At the moment it is possible to get on empty pages with click on the next glyph.

With this improvement there will be no link behind the glyph if first or last page is current. To get these functionality the glyph should get a new method "withActions" to set the action after the creation. This is needed because there is no disabled back or next glyph.