### PR TITLE
Presentation table should render only one element or nothing as action

### DIFF
--- a/src/UI/Component/Table/PresentationRow.php
+++ b/src/UI/Component/Table/PresentationRow.php
@@ -64,10 +64,10 @@ interface PresentationRow extends \ILIAS\UI\Component\Component, Triggerable {
 	/**
 	 * Get a row like this with a button or a dropdown for actions in the expanded row.
 	 *
-	 * @param ILIAS\UI\Component\Button\Button|ILIAS\UI\Component\Dropdown\Dropdown 	$actions
+	 * @param ILIAS\UI\Component\Button\Button|ILIAS\UI\Component\Dropdown\Dropdown 	$action
 	 * @return \ILIAS\UI\Component\Table\PresentationRow
 	 */
-	public function withActions($actions);
+	public function withAction($action);
 
 	/**
 	 * Get the signal to expand the row.

--- a/src/UI/Implementation/Component/Table/PresentationRow.php
+++ b/src/UI/Implementation/Component/Table/PresentationRow.php
@@ -40,7 +40,7 @@ class PresentationRow implements T\PresentationRow {
 	/**
 	 * @var	ILIAS\UI\Component\Button\Button|ILIAS\UI\Component\Dropdown\Dropdown|null
 	 */
-	private $actions;
+	private $action;
 
 	/**
 	 * @var	array
@@ -219,16 +219,27 @@ class PresentationRow implements T\PresentationRow {
 	/**
 	 * @inheritdoc
 	 */
-	public function withActions($actions) {
+	public function withAction($action) {
+		$check =
+			is_null($action)
+			|| $action instanceof \ILIAS\UI\Component\Button\Button
+			|| $action instanceof \ILIAS\UI\Component\Dropdown\Dropdown;
+
+		$expected =
+			" NULL or ".
+			" \ILIAS\UI\Component\Button\Button or ".
+			" \ILIAS\UI\Component\ropdown\Dropdown";
+
+		$this->checkArg("action", $check, $this->wrongTypeMessage($expected, $action));
 		$clone = clone $this;
-		$clone->actions = $actions;
+		$clone->action = $action;
 		return $clone;
 	}
 
 	/**
 	 * @inheritdoc
 	 */
-	public function getActions() {
-		return $this->actions;
+	public function getAction() {
+		return $this->action;
 	}
 }

--- a/src/UI/Implementation/Component/Table/Renderer.php
+++ b/src/UI/Implementation/Component/Table/Renderer.php
@@ -127,9 +127,10 @@ class Renderer extends AbstractComponentRenderer {
 			$tpl->parseCurrentBlock();
 		}
 
-		foreach ($component->getActions() as $button) {
+		$action = $component->getAction();
+		if(!is_null($action)) {
 			$tpl->setCurrentBlock("button");
-			$tpl->setVariable("BUTTON", $default_renderer->render($button));
+			$tpl->setVariable("BUTTON", $default_renderer->render($action));
 			$tpl->parseCurrentBlock();
 		}
 

--- a/src/UI/examples/Table/Presentation/base.php
+++ b/src/UI/examples/Table/Presentation/base.php
@@ -47,7 +47,7 @@ function base() {
 						'Fee: ' => $record['fee']
 					)
 				)
-				->withActions(
+				->withAction(
 					$ui_factory->button()->standard('book course', '#')
 				);
 		}

--- a/src/UI/examples/Table/Presentation/base1.php
+++ b/src/UI/examples/Table/Presentation/base1.php
@@ -41,7 +41,7 @@ function base1() {
 				'Median: ' => $record['answers'][$record['stats']['median']]['title']
 			)
 		)
-		->withActions($ui_factory->button()->standard('zur Frage', '#'));
+		->withAction($ui_factory->button()->standard('zur Frage', '#'));
 
 	};
 


### PR DESCRIPTION
This fixes a bug that was introduced when JF demanded an action-dropdown instead of a list of buttons. The renderer wasn't adjusted accordingly.