### PR TITLE
Additional OrgUnit Position Permissions (incl. Langvars)

### DIFF
--- a/Modules/OrgUnit/classes/Positions/Operation/class.ilOrgUnitOperation.php
+++ b/Modules/OrgUnit/classes/Positions/Operation/class.ilOrgUnitOperation.php
@@ -13,6 +13,9 @@ class ilOrgUnitOperation extends ActiveRecord {
 	const OP_ACCESS_RESULTS = 'access_results';
 	const OP_MANAGE_MEMBERS = 'manage_members';
 	const OP_ACCESS_ENROLMENTS = 'access_enrolments';
+	const OP_MANAGE_PARTICIPANTS = 'manage_participants';
+	const OP_SCORE_PARTICIPANTS = 'score_participants';
+
 	/**
 	 * @var int
 	 *

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -11095,6 +11095,10 @@ orgu#:#orgu_enable_my_staff_info#:#Die Ansicht ‘Meine Mitarbeiter’ zeigt die
 orgu#:#org_op_manage_members#:#Mitglieder bearbeiten
 orgu#:#org_op_access_results#:#Zugriff auf Ergebnisse
 rbac#:#org_op_access_results#:#Zugriff auf Ergebnisse untergeordneter Benutzer
+orgu#:#org_op_manage_participants#:#Teilnehmer verwalten
+rbac#:#org_op_manage_participants#:#Untergeordnete Teilnehmer verwalten
+orgu#:#org_op_score_participants#:#Teilnehmer bewerten
+rbac#:#org_op_score_participants#:#Untergeordnete Teilnehmer bewerten
 orgu#:#org_op_read_learning_progress#:#Lernfortschritt von anderen Benutzern einsehen
 orgu#:#org_op_edit_submissions_grades#:#Abgaben von anderen Benutzern bearbeiten
 rbac#:#org_op_edit_submissions_grades#:#Abgaben von anderen Benutzern bearbeiten

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -11093,6 +11093,8 @@ orgu#:#orgu_enable_my_staff#:#‘Ansicht Mitarbeiter’ aktivieren
 orgu#:#orgunit_position_permissions_not_active_for#:#Das Überschreiben der Zugriffsregelung für die Positionen darf nicht lokal vorgenommen werden für den Typ:
 orgu#:#orgu_enable_my_staff_info#:#Die Ansicht ‘Meine Mitarbeiter’ zeigt die Lernfortschritte der eigenen Mitarbeiter an.
 orgu#:#org_op_manage_members#:#Mitglieder bearbeiten
+orgu#:#org_op_access_results#:#Zugriff auf Ergebnisse
+rbac#:#org_op_access_results#:#Zugriff auf Ergebnisse untergeordneter Benutzer
 orgu#:#org_op_read_learning_progress#:#Lernfortschritt von anderen Benutzern einsehen
 orgu#:#org_op_edit_submissions_grades#:#Abgaben von anderen Benutzern bearbeiten
 rbac#:#org_op_edit_submissions_grades#:#Abgaben von anderen Benutzern bearbeiten

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -11116,6 +11116,10 @@ orgu#:#orgu_enable_my_staff_info#:#The View ‘Staff’ shows the Learning Progr
 orgu#:#org_op_manage_members#:#Manage Members
 orgu#:#org_op_access_results#:#Access Results
 rbac#:#org_op_access_results#:#Access Results of Subordinated Users
+orgu#:#org_op_manage_participants#:#Manage Participants
+rbac#:#org_op_manage_participants#:#Manage Subordinated Participants
+orgu#:#org_op_score_participants#:#Score Participants
+rbac#:#org_op_score_participants#:#Score Subordinated Participants
 orgu#:#orgunit_position_permissions_not_active_for#:#You cannot override the position specific permissions for the type:
 orgu#:#org_op_read_learning_progress#:#View learning progress of other users
 orgu#:#org_op_write_learning_progress#:#Set learning progress of other users

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -11114,6 +11114,8 @@ orgu#:#remove_successful#:#User was removed successfully.
 orgu#:#orgu_enable_my_staff#:#Enable View ‘Staff’
 orgu#:#orgu_enable_my_staff_info#:#The View ‘Staff’ shows the Learning Progress of the own Employees.
 orgu#:#org_op_manage_members#:#Manage Members
+orgu#:#org_op_access_results#:#Access Results
+rbac#:#org_op_access_results#:#Access Results of Subordinated Users
 orgu#:#orgunit_position_permissions_not_active_for#:#You cannot override the position specific permissions for the type:
 orgu#:#org_op_read_learning_progress#:#View learning progress of other users
 orgu#:#org_op_write_learning_progress#:#Set learning progress of other users


### PR DESCRIPTION
This PR integrates new OrgUnit Position Permissions to the OrgUnit service. They are used in the context of the test object with additional commits, right after this PR has been merged.

Langvars were completed for allready existing permissions and new ones are integrated for the additional permissions.