### PR TITLE
AR: relative require once

### DIFF
--- a/Services/ActiveRecord/Exception/class.arException.php
+++ b/Services/ActiveRecord/Exception/class.arException.php
@@ -1,5 +1,5 @@
 <?php
-require_once('./Services/Exceptions/classes/class.ilException.php');
+require_once(dirname(__FILE__).'/../../../Services/Exceptions/classes/class.ilException.php');
 /**
  * Class arException
  *


### PR DESCRIPTION
Hi there,

We are currently massively expanding our set of unit tests mainly for plugins. We use a lot of AR's. If we mock AR's the with mockery, as proposed in: https://github.com/ILIAS-eLearning/ILIAS/tree/trunk/tests we run in the following issue:

```
Fatal error: main(): Failed opening required './Services/Exceptions/classes/class.ilException.php' 
```

Note that we run test from the plugins directory, therefore ./... does not work. For components with namespaces and autoloading this is not issue. Others we wrap, since this only appears a few times. This however appears very often and makes writing test really a pain. If possible, also merge to 5.3.