### PR TITLE
Fix hard to debug fatal error/white page in setup.php

### DIFF
--- a/setup/setup.php
+++ b/setup/setup.php
@@ -34,6 +34,10 @@
  * @package ilias-setup
  */
 
+if(version_compare(PHP_VERSION, '7.1.0', '>=')) {
+	ini_set('session.save_handler', 'files');
+}
+
 chdir("..");
 define('IL_INITIAL_WD', getcwd());
 require_once "./setup/include/inc.setup_header.php";


### PR DESCRIPTION
This fixes a recurring error I see in `setup.php` when running ILIAS in PHP 7 docker containers.

Each time you call `setup.php` in such a configuration, you simply get a white page without any errors in any of the logs. Using `error_reporting` and `ini_set('display_errors', 'On');` won't log anything either. Non-developers are lost.

It takes some debugging to track this down to the following call, which kills PHP 7 silently and completely with a fatal error: https://github.com/ILIAS-eLearning/ILIAS/blob/9d5df1bf52d28a2acd305385d8409fdfa5820bfb/setup/classes/class.Session.php#L61

Here's the error, retrieved through a debug handler for fatal error messages:

```
Fatal error: session_start(): Failed to initialize storage module: user (path: /tmp) in /var/www/html/ILIAS/setup/setup.php on line 37
```

Which makes sense: at this point, no `user` session callbacks were defined. Specifically, `setSaveHandler` is not called in this setup code path.

https://github.com/ILIAS-eLearning/ILIAS/blob/9d5df1bf52d28a2acd305385d8409fdfa5820bfb/Services/Authentication/classes/class.ilSessionDBHandler.php#L20

Setting `session.save_handler` to the PHP default `files` for `setup.php` fixes this.