### PR TITLE
Check session.save_handler in setup.php

### DIFF
--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -271,6 +271,7 @@ session.gc_divisor = 100
 session.gc_maxlifetime = 14400
 session.hash_function = 0
 session.cookie_httponly = On
+session.save_handler = files ; for ILIAS setup, ILIAS installations override this
 ; If you installation is served via HTTPS also use:
 session.cookie_secure = On
  

--- a/setup/setup.php
+++ b/setup/setup.php
@@ -34,6 +34,10 @@
  * @package ilias-setup
  */
 
+if (ini_get('session.save_handler') != 'files') {
+	throw new Exception("session.save_handler in php.ini must be configured to 'files'.");
+}
+
 chdir("..");
 define('IL_INITIAL_WD', getcwd());
 require_once "./setup/include/inc.setup_header.php";


### PR DESCRIPTION
Follow up of https://github.com/ILIAS-eLearning/ILIAS/pull/1149.

This throws an exception if `session.save_handler` is not configured to `files` in `setup.php`.

For the docs, I imagine something like this?

```
session.save_handler=files ; for ILIAS setup, ILIAS installations override this
```

I'm not sure how to update the php.ini under "PHP Installation/Configuration" in  https://docu.ilias.de/goto_docu_lm_367.html though.
