### PR TITLE
0023511 - Check flock return value for test file locking.

### DIFF
--- a/Modules/Test/classes/class.ilTestProcessLockerFile.php
+++ b/Modules/Test/classes/class.ilTestProcessLockerFile.php
@@ -74,7 +74,12 @@ class ilTestProcessLockerFile extends ilTestProcessLocker
 	{
 		$lockFilePath = $this->getLockFilePath($processName);
 		$this->lockFileHandles[$processName] = fopen($lockFilePath, 'w');
-		flock($this->lockFileHandles[$processName], LOCK_EX);
+		if ($this->lockFileHandles[$processName] === false) {
+			throw new ilTestException("could not open lock file");
+		}
+		if (flock($this->lockFileHandles[$processName], LOCK_EX) !== true) {
+			throw new ilTestException("could not acquire file lock");
+		}
 	}
 	
 	private function getLockFilePath($processName)


### PR DESCRIPTION
A minor point, but in the current test file locker, the result of `flock` is not checked. Now, as `flock` is blocking (doesn't pass `LOCK_NB`), it should never fail. But still, we should check if it fails for some obscure reason and then not continue under the assumption that a lock was obtained.

https://mantis.ilias.de/view.php?id=23511