### PR TITLE
Docs: Coordinator Update

### DIFF
--- a/docs/documentation/maintenance-coordinator.md
+++ b/docs/documentation/maintenance-coordinator.md
@@ -28,9 +28,10 @@ probably the most attractive contractor for clients aiming to change
 aspects of the component due to the very indepth know how and the 
 listing as coordinator. 
 
-The PM and the TB appoint or replace coordinators. The coordinator role belongs to the person, 
-not the company, since the role builds on social capital in the community and a 
-vision of the component it will be near impossible to leave that role at a company. 
+The PM and the TB appoint or replace coordinators. The coordinator role belongs to
+the person, not the company, since the role builds on social capital in the community
+and a vision of the component it will be near impossible to leave that role at a
+company.
 
 It is encouraged that two people share the role of the coordinator for one
 component to enhance it's [Bus factor](https://en.wikipedia.org/wiki/Bus_factor).
@@ -38,35 +39,37 @@ component to enhance it's [Bus factor](https://en.wikipedia.org/wiki/Bus_factor)
 <a name="change-management"></a>
 ## Change Management
 Everybody may contribute to any aspect of the component. Such contributions 
-are handed in by pull requests or some other source of data if declared so in the components guidelines.
-Note that the general [contribution guideline](https://github.com/ILIAS-eLearning/ILIAS/blob/release_5-3/docs/documentation/contributing.md) also apply for components managed by the coordinator 
-model. The coordinator is called upon to define additional criteria and processes 
-for the component (e.g. UI-components). This is the gain of this model: PRs cannot be rejected arbitrarily. 
-This allows other developers to build an expectation about the chances of their PR. Pull requests 
-on the public interface must be accepted by the JF. The coordinator gives a recommendation to the 
-JF on whether to accept or decline the PR. The decision of the JF may 
-be implicit if no objections to the recommendation of the coordinator is made. If no agreement 
-is achieved in the JF, the Technical Board will decide upon the request.
-Further note in case two people sharing the role of the coordinator, that the feedback of one
-coordinator is enough for a request to be processed further. If both give
-feedback, the points of both coordinators must be respected. If the coordinators
-give contradictory feedback, the coordinators must resolve their differences 
-before further processing.
+are handed in by pull requests or some other source of data if declared so in
+the components guidelines. Note that the general
+[contribution guideline](https://github.com/ILIAS-eLearning/ILIAS/blob/release_5-3/docs/documentation/contributing.md)
+also apply for components managed by the coordinator model. The coordinator is
+called upon to define additional criteria and processes for the component (e.g.
+UI-components). This is the gain of this model: PRs cannot be rejected arbitrarily.
+This allows other developers to build an expectation about the chances of their PR.
+Pull requests on the public interface must be accepted by the JF. The coordinator
+gives a recommendation to the JF on whether to accept or decline the PR. The
+decision of the JF may be implicit if no objections to the recommendation of the
+coordinator is made. If no agreement is achieved in the JF, the Technical Board
+will decide upon the request. Further note in case two people sharing the role of
+the coordinator, that the feedback of one coordinator is enough for a request to
+be processed further. If both give feedback, the points of both coordinators must
+be respected. If the coordinators give contradictory feedback, the coordinators
+must resolve their differences before further processing.
 
-Final implementations without further changes on the interface do not need 
-formal approval by the JF. The merge of the implementation is performed 
-by the coordinator or the coordinator may assign somebody to do so.
+Final implementations without further changes on the interface do not need formal
+approval by the JF. The merge of the implementation is performed by the coordinator
+or the coordinator may assign somebody to do so.
 
-Note that the general process for feature requests must be respected. However,
-this process is currently under review. The respective document will be linked as soon
+Note that the general process for feature requests must be respected. However, this
+process is currently under review. The respective document will be linked as soon
 as available.
 
 <a name="issue-management"></a>
 ## Issue Management
 Everybody is invited to make proposals on how to tackle any issue by proposing 
 a respective PR. Issues of the component must be reported as bugs. The coordinators 
-are responsible to assign the developer in charge on solving the bug. Due to the focus 
-on code quality, a low amount of bugs should be expected.
+are responsible to assign the developer in charge on solving the bug. Due to the
+focus on code quality, a low amount of bugs should be expected.
 
 <a name="scenarios"></a>
 ## Scenarios

--- a/docs/documentation/maintenance-coordinator.md
+++ b/docs/documentation/maintenance-coordinator.md
@@ -32,6 +32,9 @@ The PM and the TB appoint or replace coordinators. The coordinator role belongs 
 not the company, since the role builds on social capital in the community and a 
 vision of the component it will be near impossible to leave that role at a company. 
 
+It is encouraged that two people share the role of the coordinator for one
+component to enhance it's [Bus factor](https://en.wikipedia.org/wiki/Bus_factor).
+
 <a name="change-management"></a>
 ## Change Management
 Everybody may contribute to any aspect of the component. Such contributions 
@@ -44,6 +47,11 @@ on the public interface must be accepted by the JF. The coordinator gives a reco
 JF on whether to accept or decline the PR. The decision of the JF may 
 be implicit if no objections to the recommendation of the coordinator is made. If no agreement 
 is achieved in the JF, the Technical Board will decide upon the request.
+Further note in case two people sharing the role of the coordinator, that the feedback of one
+coordinator is enough for a request to be processed further. If both give
+feedback, the points of both coordinators must be respected. If the coordinators
+give contradictory feedback, the coordinators must resolve their differences 
+before further processing.
 
 Final implementations without further changes on the interface do not need 
 formal approval by the JF. The merge of the implementation is performed 
@@ -76,6 +84,12 @@ a collaborative development of the vision for such a key aspect.
 the development of the component.
 * The coordinator MUST give recommendations to the JF whether to accept 
 or decline changes.
+* If two people share the role of the coordinator and give contradictory 
+feedback for a change request, they MUST resolve the conflict as quickly
+as possible and publish a new feedback without contradictions. 
+* If two people share the role of the coordinator they MAY give feedback
+the different aspects of a change request. In such a case, both feedbacks
+MUST be considered.
 * The coordinator MUST accept decisions of the Technical Board on change 
 requests in case of disagreement on the JF.
 * The coordinator MUST review final implementation of some accepted 

--- a/docs/documentation/maintenance-coordinator.md
+++ b/docs/documentation/maintenance-coordinator.md
@@ -90,6 +90,9 @@ or decline changes.
 * If two people share the role of the coordinator and give contradictory 
 feedback for a change request, they MUST resolve the conflict as quickly
 as possible and publish a new feedback without contradictions. 
+* If two people share the role of the coordinator they MUST define whom of
+them is contact person for Mantis bug reports as well as for other applicationsi
+that do not support more than one contact.
 * If two people share the role of the coordinator they MAY give feedback
 the different aspects of a change request. In such a case, both feedbacks
 MUST be considered.

--- a/docs/documentation/maintenance.md
+++ b/docs/documentation/maintenance.md
@@ -565,7 +565,7 @@ The code base is deviced in several components:
 
 Components in the Coordinator Model [Coordinator Model](maintenance-coordinator.md):
 * **UI-Service**
-	* Coordinators: [amstutz](http://www.ilias.de/docu/goto_docu_usr_26468.html), 
+	* Coordinators: [amstutz](http://www.ilias.de/docu/goto_docu_usr_26468.html), [rklees](http://www.ilias.de/docu/goto_docu_usr_34047.html)
 	* Used in Directories: src/UI, 
 
 


### PR DESCRIPTION
This PR contains to parts to be discussed in the upcoming JF:
- @klees is not yet listed to be a coordinator of the UI-Components. We believe this to be wrong. In our understanding, he always was one of the two coordinators of the UI-Components. He was simply not listed in the according json.
- Since it is not explicitly described in the maintainance-coordinator.md file that it is possible to have two coordinators sharing the role for one component, we updated it, among with some clarifications.