### PR TITLE
Language: fixed DB-usage in ilLanguage::__destruct

### DIFF
--- a/Services/Language/classes/class.ilLanguage.php
+++ b/Services/Language/classes/class.ilLanguage.php
@@ -636,13 +636,14 @@ class ilLanguage
 	function __destruct()
 	{
 		global $DIC;
-		$ilDB = $DIC->database();
 
 		//case $ilDB not existing should not happen but if something went wrong it shouldn't leads to any failures
-		if(!$this->usage_log_enabled || !(($ilDB instanceof ilDBMySQL) || ($ilDB instanceof ilDBPdoMySQLMyISAM)))
+		if(!$this->usage_log_enabled || !$DIC->isDependencyAvailable("database"))
 		{
 			return;
 		}
+
+		$ilDB = $DIC->database();
 
 		foreach((array)self::$lng_log as $identifier => $module)
 		{


### PR DESCRIPTION
The usage of the database-dependency in the __destruct-method implicitely introduces this dependency to all users of ilLanguage, even if they do not use any method of ilLanguage in some (test-)scenario. This broke automated tests.

To fix this, the a (deprecated) check for said dependency was introduced. This will lead to a new dicto-violation. The underlying problem should thus be fixed by a proper solution, e.g. removing the language-log-functionality or moving it to a decorator for the ilLanguage class which only is wrapped around ilLanguage in the initialisation when language logging is activated.