### PR TITLE
Fix Unit tests in relying on language

### DIFF
--- a/Services/Language/classes/class.ilLanguage.php
+++ b/Services/Language/classes/class.ilLanguage.php
@@ -636,7 +636,10 @@ class ilLanguage
 	function __destruct()
 	{
 		global $DIC;
-		$ilDB = $DIC->database();
+		if($DIC){
+			$ilDB = $DIC->database();
+		}
+
 
 		//case $ilDB not existing should not happen but if something went wrong it shouldn't leads to any failures
 		if(!$this->usage_log_enabled || !(($ilDB instanceof ilDBMySQL) || ($ilDB instanceof ilDBPdoMySQLMyISAM)))

--- a/Services/Language/classes/class.ilLanguage.php
+++ b/Services/Language/classes/class.ilLanguage.php
@@ -636,7 +636,7 @@ class ilLanguage
 	function __destruct()
 	{
 		global $DIC;
-		if($DIC){
+		if($DIC && $DIC->isDependencyAvailable("database")){
 			$ilDB = $DIC->database();
 		}else{
 			return;

--- a/Services/Language/classes/class.ilLanguage.php
+++ b/Services/Language/classes/class.ilLanguage.php
@@ -638,6 +638,8 @@ class ilLanguage
 		global $DIC;
 		if($DIC){
 			$ilDB = $DIC->database();
+		}else{
+			return;
 		}
 
 


### PR DESCRIPTION
Hi @fneumann 

Currently the UI tests fail due to the following commit: "Fix "WholeIliasCodebaseExceptInitialisation cannot depend on GlobalsExceptDIC " violations". I did not check what else will fail as well. This PR resolves the issue for the UI tests. Thx for merging quickly or resolving otherwise.