### PR TITLE
Proposal for a `roadmap`-tag for PRs

### DIFF
--- a/docs/documentation/contributing.md
+++ b/docs/documentation/contributing.md
@@ -87,7 +87,7 @@ be assigned by the Technical Board or Maintainers:
 |-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | bugfix          | PRs with the label `bugfix` propose a solution for a reported bug in the official Bugtracker https://mantis.ilias.de                                                      |
 | improvement     | The label `improvement` is used for PRs which propose a general improvement of code or documentation which is not related to a bug.                                       |
-| roadmap         | The label `roadmap` is assigned to PRs that contain strategical or tactical discussions regarding the future of a component.                                              |
+| roadmap         | The label `roadmap` is assigned to PRs that contain strategical or tactical discussions of technical topics regarding the future of a component.                          |
 | jour fixe       | PRs which should be discussed during the next Jour Fixe are labeled with this `jour fixe`. Please set this label at least 2 days before the envisaged date of Jour Fixe.  |
 | kitchen sink    | All contributions to the Kitchen Sink Project are labeled accordingly.                                                                                                    |
 | technical board | This label is given for PRs which will be discussed in a meeting of the Technical Board. The label will be removed after the discussion.                                  |

--- a/docs/documentation/contributing.md
+++ b/docs/documentation/contributing.md
@@ -93,7 +93,7 @@ be assigned by the Technical Board or Maintainers:
 | technical board | This label is given for PRs which will be discussed in a meeting of the Technical Board. The label will be removed after the discussion.                                  |
 
 <a name="rules-for-maintainers-assigned-to-prs"></a>
-#### Rules for Maintainers assigned to PRs
+#### Rules for Maintainers and Coordinators assigned to PRs
 
 As an FOSS community we should be glad that people want to contribute code to
 our project as this reflects usage of our project. To show this when handling

--- a/docs/documentation/contributing.md
+++ b/docs/documentation/contributing.md
@@ -87,6 +87,7 @@ be assigned by the Technical Board or Maintainers:
 |-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | bugfix          | PRs with the label `bugfix` propose a solution for a reported bug in the official Bugtracker https://mantis.ilias.de                                                      |
 | improvement     | The label `improvement` is used for PRs which propose a general improvement of code or documentation which is not related to a bug.                                       |
+| roadmap         | The label `roadmap` is assigned to PRs that contain strategical or tactical discussions regarding the future of a component.                                              |
 | jour fixe       | PRs which should be discussed during the next Jour Fixe are labeled with this `jour fixe`. Please set this label at least 2 days before the envisaged date of Jour Fixe.  |
 | kitchen sink    | All contributions to the Kitchen Sink Project are labeled accordingly.                                                                                                    |
 | technical board | This label is given for PRs which will be discussed in a meeting of the Technical Board. The label will be removed after the discussion.                                  |

--- a/docs/documentation/maintenance-coordinator.md
+++ b/docs/documentation/maintenance-coordinator.md
@@ -74,7 +74,8 @@ a collaborative development of the vision for such a key aspect.
 ## What can be expected of a coordinator?
 * The coordinator MUST moderate the discussion on finding a vision on 
 the development of the component. The coordinator SHOULD document that
-vision publicly and close to the code.
+vision publicly in a file called `ROADMAP.md` in the root of the
+components directory.
 * The coordinator MUST give recommendations to the JF whether to accept 
 or decline changes.
 * The coordinator MUST accept decisions of the Technical Board on change 

--- a/docs/documentation/maintenance-coordinator.md
+++ b/docs/documentation/maintenance-coordinator.md
@@ -73,7 +73,8 @@ a collaborative development of the vision for such a key aspect.
 <a name="expectations"></a>
 ## What can be expected of a coordinator?
 * The coordinator MUST moderate the discussion on finding a vision on 
-the development of the component.
+the development of the component. The coordinator SHOULD document that
+vision publicly and close to the code.
 * The coordinator MUST give recommendations to the JF whether to accept 
 or decline changes.
 * The coordinator MUST accept decisions of the Technical Board on change 


### PR DESCRIPTION
With the [introduction of the coordinator-model](https://github.com/ILIAS-eLearning/ILIAS/pull/1096) for the maintenance of components, the coordinators for components are called to moderate a discussion on finding the vision for a component. For the UI-framework, we decided to introduce a [roadmap](https://github.com/ILIAS-eLearning/ILIAS/pull/1138) to document that vision and be able to discuss it via PRs. The idea to have a roadmap was also already discussed in the original coordinator-PR, but not pursued at that point.

This PR attempts to elaborate on that documentation by:
* adding the soft requirement to document the components vision to the coordinator rules
* proposing a tag for PRs that allows people to specifically get involved with strategical and tactical decisions regarding specific components