### PR TITLE
WAC checks if file exists and returns false if it does not

### DIFF
--- a/Services/WebAccessChecker/classes/class.ilWebAccessChecker.php
+++ b/Services/WebAccessChecker/classes/class.ilWebAccessChecker.php
@@ -152,10 +152,17 @@ class ilWebAccessChecker {
 
 			return false;
 		} else {
-			$this->addAppliedCheckingMethod(self::CM_SECFOLDER);
 
-			return true;
-		}
+            if($this->getPathObject()->fileExists()) {
+                $this->addAppliedCheckingMethod(self::CM_SECFOLDER);
+
+                return true;
+            } else {
+                $this->addAppliedCheckingMethod(self::CM_SECFOLDER);
+
+                return false;
+            }
+        }
 	}
 
 


### PR DESCRIPTION
As mentioned in the bugreports below missing files in the data folder structure lead to many redirects resulting in ./data/.../error.php (original path with error.php instead of the filename) which in turn is not found continuing the redirection process.

The WAC module never checks if the file really exists and returns true to delivery.php which tries to immediately deliver the file afterwards. A short check could eliminate the problem as far as I can see.

https://mantis.ilias.de/view.php?id=22832
https://mantis.ilias.de/view.php?id=23170
https://mantis.ilias.de/view.php?id=23545