### PR TITLE
 KioskMode: enhanced docu (#23574) and fixed param to TOCBuilder

### DIFF
--- a/src/KioskMode/ControlBuilder.php
+++ b/src/KioskMode/ControlBuilder.php
@@ -20,28 +20,40 @@ interface ControlBuilder {
 	/**
 	 * A next control allows the user to progress to the next item in the object.
 	 *
+	 * The $parameter can be used to pass additional information to View::updateGet
+	 * if required, e.g. about a chapter in the content.
+	 *
 	 * @throws \LogicException if view wants to introduce a second next button.
 	 */
-	public function next(string $command, int $parameter) : ControlBuilder;
+	public function next(string $command, int $parameter = null) : ControlBuilder;
 
 	/**
 	 * A previous control allows the user to go back to the previous item in the object.
 	 *
+	 * The $parameter can be used to pass additional information to View::updateGet
+	 * if required, e.g. about a chapter in the content.
+	 *
 	 * @throws \LogicException if view wants to introduce a second previous button.
 	 */
-	public function previous(string $command, int $parameter) : ControlBuilder;
+	public function previous(string $command, int $parameter = null) : ControlBuilder;
 
 	/**
 	 * A done control allows the user to mark the object as done.
 	 *
+	 * The $parameter can be used to pass additional information to View::updateGet
+	 * if required, e.g. about a chapter in the content.
+	 *
 	 * @throws \LogicException if view wants to introduce a second previous button.
 	 */
-	public function done(string $command, int $parameter) : ControlBuilder;
+	public function done(string $command, int $parameter = null) : ControlBuilder;
 
 	/**
 	 * A generic control needs to have a label that tells what it does.
+	 *
+	 * The $parameter can be used to pass additional information to View::updateGet
+	 * if required, e.g. about a chapter in the content.
 	 */
-	public function generic(string $label, string $command, int $parameter) : ControlBuilder;
+	public function generic(string $label, string $command, int $parameter = null) : ControlBuilder;
 
 	/**
 	 * A toggle can be used to switch some behaviour in the view on or of.

--- a/src/KioskMode/README.md
+++ b/src/KioskMode/README.md
@@ -90,13 +90,11 @@ this for ILIAS-objects.
 
 ## Implementing a Player
 
-TODO: finish me!
-
 * The player SHOULD respect the order in which the view build controls.
 * The player MUST respect the order in which the view builds locator entries and TOC
   entries.
 * The player MUST use the commands and parameters provided by the view via
   `View::buildControls` when updating the View.
-* The player MUST call updateGet on GET-Requests and updatePost on POST-requests.
+* The player MUST call `updateGet` on GET-Requests and `updatePost` on POST-requests.
 * The player MUST ensure that a given `State` is unique per instance of View, i.e.
   keys and values MUST NOT leak to other instances of View.

--- a/src/KioskMode/TOCBuilder.php
+++ b/src/KioskMode/TOCBuilder.php
@@ -19,7 +19,7 @@ interface TOCBuilder {
 	 *
 	 * @return	ControlBuilder|TOCBuilder depending on the nesting level.
 	 */
-	public function end(string $command);
+	public function end();
 
 	/**
 	 * Build a sub tree in the TOC.

--- a/src/KioskMode/TOCBuilder.php
+++ b/src/KioskMode/TOCBuilder.php
@@ -26,6 +26,9 @@ interface TOCBuilder {
 	 *
 	 * If a parameter is provided, the node in the TOC can be accessed itself.
 	 *
+	 * The $parameter can be used to pass additional information to View::updateGet
+	 * if required, e.g. about a chapter in the content.
+	 *
 	 * @param	mixed $state one of the LP_ constants from TOCBuilder
 	 */
 	public function node($label, int $parameter = null, $lp = null) : TOCBuilder;
@@ -34,6 +37,9 @@ interface TOCBuilder {
 	 * Build an entry in the TOC.
 	 *
 	 * The parameter will be appended to the command when updating the state.
+	 *
+	 * The $parameter can be used to pass additional information to View::updateGet
+	 * if required, e.g. about a chapter in the content.
 	 *
 	 * @param	mixed $state one of the LP_ constants from TOCBuilder
 	 */

--- a/src/KioskMode/View.php
+++ b/src/KioskMode/View.php
@@ -18,15 +18,21 @@ interface View {
 
 	/**
 	 * Construct the controls for the view based on the current state.
+	 *
+	 * The interaction with the controls build via the ControlBuilder will always
+	 * be delegated to updateGet.
 	 */
 	public function buildControls(State $state, ControlBuilder $builder);
 
 	/**
 	 * Update the state based on the provided command.
 	 *
+	 * If the update was caused by a control with a $parameter (see ControlBuilder)
+	 * that value is passed to $parameter here.
+	 *
 	 * Commands and parameters are defined by the view in `buildControl`.
 	 */
-	public function updateGet(State $state, string $command, int $param = null) : State;
+	public function updateGet(State $state, string $command, int $parameter = null) : State;
 
 	/**
 	 * Update the state and the object based on the provided command and post-data.


### PR DESCRIPTION
Some clarifications in the docu according to https://mantis.ilias.de/view.php?id=23574.

I also removed a bogus parameter to `TOCBuilder::end`. Although this change is minor, this is also a breaking change, thus I'll add this to JF-agenda.