### PR TITLE
UI: More carefully select acceptable client side values in Select-Field

### DIFF
--- a/src/UI/Implementation/Component/Input/Field/Select.php
+++ b/src/UI/Implementation/Component/Input/Field/Select.php
@@ -52,7 +52,9 @@ class Select extends Input implements C\Input\Field\Select {
 	 * @inheritdoc
 	 */
 	protected function isClientSideValueOk($value) {
-		return in_array($value, array_keys($this->options));
+		return 
+			in_array($value, array_keys($this->options))
+			|| (!$this->isRequired() && $value == "");
 	}
 
 	/**

--- a/src/UI/Implementation/Component/Input/Field/Select.php
+++ b/src/UI/Implementation/Component/Input/Field/Select.php
@@ -52,7 +52,7 @@ class Select extends Input implements C\Input\Field\Select {
 	 * @inheritdoc
 	 */
 	protected function isClientSideValueOk($value) {
-		return is_string($value);
+		return in_array($value, array_keys($this->options));
 	}
 
 	/**

--- a/tests/UI/Component/Input/Field/SelectTest.php
+++ b/tests/UI/Component/Input/Field/SelectTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/* Copyright (c) 2018 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+require_once(__DIR__ . "/../../../Base.php");
+
+class SelectForTest extends ILIAS\UI\Implementation\Component\Input\Field\Select {
+	public function _isClientSideValueOk($value) {
+		return $this->isClientSideValueOk($value);
+	}
+}
+
+class SelectInputTest extends ILIAS_UI_TestBase {
+	public function testOnlyValuesFromOptionsAreAcceptableClientSideValues() {
+		$options = ["one" => "Eins", "two" => "Zwei", "three" => "Drei"];
+		$select = new SelectForTest(
+			$this->createMock(ILIAS\Data\Factory::class),
+			$this->createMock(ILIAS\Validation\Factory::class),
+			$this->createMock(ILIAS\Transformation\Factory::class),
+			"",
+			$options,
+			""
+		);
+
+		$this->assertTrue($select->_isClientSideValueOk("one"));
+		$this->assertTrue($select->_isClientSideValueOk("two"));
+		$this->assertTrue($select->_isClientSideValueOk("three"));
+		$this->assertFalse($select->_isClientSideValueOk("four"));
+	}
+}

--- a/tests/UI/Component/Input/Field/SelectTest.php
+++ b/tests/UI/Component/Input/Field/SelectTest.php
@@ -27,4 +27,32 @@ class SelectInputTest extends ILIAS_UI_TestBase {
 		$this->assertTrue($select->_isClientSideValueOk("three"));
 		$this->assertFalse($select->_isClientSideValueOk("four"));
 	}
+
+	public function testEmptyStringIsAcceptableClientSideValueIfSelectIsNotRequired() {
+		$options = [];
+		$select = new SelectForTest(
+			$this->createMock(ILIAS\Data\Factory::class),
+			$this->createMock(ILIAS\Validation\Factory::class),
+			$this->createMock(ILIAS\Transformation\Factory::class),
+			"",
+			$options,
+			""
+		);
+
+		$this->assertTrue($select->_isClientSideValueOk(""));
+	}
+
+	public function testEmptyStringIsNoAcceptableClientSideValueIfSelectIsRequired() {
+		$options = [];
+		$select = (new SelectForTest(
+			$this->createMock(ILIAS\Data\Factory::class),
+			$this->createMock(ILIAS\Validation\Factory::class),
+			$this->createMock(ILIAS\Transformation\Factory::class),
+			"",
+			$options,
+			""
+		))->withRequired(true);
+
+		$this->assertFalse($select->_isClientSideValueOk(""));
+	}
 }


### PR DESCRIPTION
The current implementation of the `Select Field` allows the clients to pass a rather broad set of values (all strings). This is not correct, as only keys of known options will ever be retrieved from a benign client. This PR restricts the acceptable client values accordingly and tests the behaviour.