### PR TITLE
[Forum] Remove requires *Forum because composer autloader is already in use 

### DIFF
--- a/Modules/Forum/classes/class.ilFileDataForum.php
+++ b/Modules/Forum/classes/class.ilFileDataForum.php
@@ -1,9 +1,6 @@
 <?php
 /* Copyright (c) 1998-2012 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once("./Services/FileSystem/classes/class.ilFileData.php");
-require_once("./Services/Utilities/classes/class.ilFileUtils.php");
-
 /**
 * This class handles all operations on files for the forum object.
 *  

--- a/Modules/Forum/classes/class.ilFileDataForumDrafts.php
+++ b/Modules/Forum/classes/class.ilFileDataForumDrafts.php
@@ -1,9 +1,6 @@
 <?php
 /* Copyright (c) 1998-2016 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once("./Services/FileSystem/classes/class.ilFileData.php");
-require_once("./Services/Utilities/classes/class.ilFileUtils.php");
-
 /**
  * This class handles all operations on files for the drafts of a forum object.
  *

--- a/Modules/Forum/classes/class.ilForum.php
+++ b/Modules/Forum/classes/class.ilForum.php
@@ -698,7 +698,6 @@ class ilForum
 			array($message, $cens_date, $cens, $GLOBALS['DIC']['ilUser']->getId(), $pos_pk));
 		
 		// Change news item accordingly
-		include_once("./Services/News/classes/class.ilNewsItem.php");
 		$news_id = ilNewsItem::getFirstNewsIdForContext($this->id,
 			"frm", $pos_pk, "pos");
 		if ($news_id > 0)
@@ -765,8 +764,6 @@ class ilForum
 	*/
 	public function deletePost($post)
 	{
-		include_once "./Modules/Forum/classes/class.ilObjForum.php";
-
 		$p_node = $this->getPostNode($post);
 
 		$GLOBALS['ilAppEventHandler']->raise(
@@ -805,8 +802,6 @@ class ilForum
 		if ($p_node["parent"] == 0)
 		{
 			// delete thread access data
-			include_once './Modules/Forum/classes/class.ilObjForum.php';
-
 			ilObjForum::_deleteAccessEntries($p_node['tree']);
 
 			// delete thread
@@ -832,7 +827,6 @@ class ilForum
 			
 			while ($posrec = $this->db->fetchAssoc($posset))
 			{
-				include_once("./Services/News/classes/class.ilNewsItem.php");
 				$news_id = ilNewsItem::getFirstNewsIdForContext($this->id,
 					"frm", $posrec["pos_pk"], "pos");
 				if ($news_id > 0)
@@ -843,7 +837,6 @@ class ilForum
 				
 				try
 				{
-					include_once 'Services/MediaObjects/classes/class.ilObjMediaObject.php';
 					$mobs = ilObjMediaObject::_getMobsOfObject('frm:html', $posrec['pos_pk']);
 					foreach($mobs as $mob)
 					{						
@@ -877,7 +870,6 @@ class ilForum
 					array('integer'), array($del_id[$i]));
 				
 				// delete related news item
-				include_once("./Services/News/classes/class.ilNewsItem.php");
 				$news_id = ilNewsItem::getFirstNewsIdForContext($this->id,
 					"frm", $del_id[$i], "pos");
 				if ($news_id > 0)
@@ -888,7 +880,6 @@ class ilForum
 				
 				try
 				{
-					include_once 'Services/MediaObjects/classes/class.ilObjMediaObject.php';
 					$mobs = ilObjMediaObject::_getMobsOfObject('frm:html', $del_id[$i]);
 					foreach($mobs as $mob)
 					{						
@@ -1825,7 +1816,6 @@ class ilForum
 		{
 			if($edit == 0)
 			{
-				include_once './Services/MathJax/classes/class.ilMathJax.php';
 				$text = ilMathJax::getInstance()->insertLatexImages($text, "\<span class\=\"latex\">", "\<\/span>");
 				$text = ilMathJax::getInstance()->insertLatexImages($text, "\[tex\]", "\[\/tex\]");
 			}
@@ -1846,8 +1836,7 @@ class ilForum
 		{
 			return false;
 		}
-		include_once "./Modules/Forum/classes/class.ilFileDataForum.php";
-		
+
 		$tmp_file_obj = new ilFileDataForum($this->getForumId());
 		foreach($a_ids as $pos_id)
 		{
@@ -2175,8 +2164,6 @@ class ilForum
 		$add_difference = $target_root_node->getRgt();
 
 // update target root node rgt
-		include_once 'Modules/Forum/classes/class.ilForumPostsTree.php';
-//		$new_target_rgt = ($target_root_node->getRgt() + $source_root_node->getRgt() + 1);
 		$new_target_rgt = ($target_root_node->getRgt() + $source_root_node->getRgt());
 		ilForumPostsTree::updateTargetRootRgt($target_root_node->getId(), $new_target_rgt);
 
@@ -2221,15 +2208,12 @@ class ilForum
 		}
 
 // update frm_posts pos_thr_fk = target_thr_id
-		include_once 'Modules/Forum/classes/class.ilForumPost.php';
 		ilForumPost::mergePosts($merge_thread_source->getId(), $merge_thread_target->getId());
 
 // check notifications
-		include_once 'Modules/Forum/classes/class.ilForumNotification.php';
 		ilForumNotification::mergeThreadNotificiations($merge_thread_source->getId(), $merge_thread_target->getId());
 
 // delete frm_thread_access entries
-		include_once './Modules/Forum/classes/class.ilObjForum.php';
 		ilObjForum::_deleteAccessEntries($merge_thread_source->getId());
 
 // update frm_user_read  

--- a/Modules/Forum/classes/class.ilForum.php
+++ b/Modules/Forum/classes/class.ilForum.php
@@ -512,8 +512,6 @@ class ilForum
 		// Add Notification to news
 		if($status)
 		{
-			require_once 'Services/RTE/classes/class.ilRTE.php';
-			include_once("./Services/News/classes/class.ilNewsItem.php");
 			$news_item = new ilNewsItem();
 			$news_item->setContext($forum_obj->getId(), 'frm', $objNewPost->getId(), 'pos');
 			$news_item->setPriority(NEWS_NOTICE);
@@ -1616,8 +1614,6 @@ class ilForum
 	*/
 	public function fetchPostNodeData($a_row)
 	{
-		require_once('./Services/User/classes/class.ilObjUser.php');
-		
 		if (ilObject::_exists($a_row->pos_display_user_id))
 		{
 			$tmp_user = new ilObjUser($a_row->pos_display_user_id);

--- a/Modules/Forum/classes/class.ilForum.php
+++ b/Modules/Forum/classes/class.ilForum.php
@@ -1,11 +1,6 @@
 <?php
 /* Copyright (c) 1998-2012 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once './Modules/Forum/classes/class.ilForumProperties.php';
-require_once './Modules/Forum/classes/class.ilObjForum.php';
-require_once './Modules/Forum/classes/class.ilForumTopic.php';
-require_once './Modules/Forum/classes/class.ilForumPost.php';
-
 /**
 * Class Forum
 * core functions for forum
@@ -752,7 +747,6 @@ class ilForum
 			}
 		}
 
-		require_once 'Modules/Forum/classes/class.ilForumPost.php';
 		$GLOBALS['ilAppEventHandler']->raise(
 			'Modules/Forum',
 			'censoredPost',

--- a/Modules/Forum/classes/class.ilForumAppEventListener.php
+++ b/Modules/Forum/classes/class.ilForumAppEventListener.php
@@ -46,8 +46,6 @@ class ilForumAppEventListener implements ilAppEventListener
 						ilForumPostDraft::moveDraftsByMovedThread($a_parameter['thread_ids'], $a_parameter['source_ref_id'], $a_parameter['target_ref_id']);
 						break;
 					case 'createdPost':
-						require_once 'Modules/Forum/classes/class.ilForumMailNotification.php';
-						require_once 'Modules/Forum/classes/class.ilObjForumNotificationDataProvider.php';
 						require_once 'Services/Cron/classes/class.ilCronManager.php';
 
 						$post              = $a_parameter['post'];
@@ -93,8 +91,6 @@ class ilForumAppEventListener implements ilAppEventListener
 						break;
 
 					case 'activatedPost':
-						require_once 'Modules/Forum/classes/class.ilForumMailNotification.php';
-						require_once 'Modules/Forum/classes/class.ilObjForumNotificationDataProvider.php';
 						require_once 'Services/Cron/classes/class.ilCronManager.php';
 						
 						$post = $a_parameter['post'];
@@ -110,9 +106,6 @@ class ilForumAppEventListener implements ilAppEventListener
 						break;
 
 					case 'updatedPost':
-						require_once 'Modules/Forum/classes/class.ilForumMailNotification.php';
-						require_once 'Modules/Forum/classes/class.ilObjForumNotificationDataProvider.php';
-						
 						if(!$a_parameter['old_status_was_active'])
 						{
 							return;
@@ -143,9 +136,6 @@ class ilForumAppEventListener implements ilAppEventListener
 						break;
 
 					case 'censoredPost':
-						require_once 'Modules/Forum/classes/class.ilForumMailNotification.php';
-						require_once 'Modules/Forum/classes/class.ilObjForumNotificationDataProvider.php';
-
 						$post = $a_parameter['post'];
 
 						if($immediate_notifications_enabled)
@@ -171,8 +161,6 @@ class ilForumAppEventListener implements ilAppEventListener
 						break;
 
 					case 'deletedPost':
-						require_once 'Modules/Forum/classes/class.ilForumMailNotification.php';
-						require_once 'Modules/Forum/classes/class.ilObjForumNotificationDataProvider.php';
 						require_once 'Services/Cron/classes/class.ilCronManager.php';
 						
 						$post = $a_parameter['post'];
@@ -185,7 +173,6 @@ class ilForumAppEventListener implements ilAppEventListener
 						{
 							if(ilCronManager::isJobActive('frm_notification'))
 							{
-								require_once 'Modules/Forum/classes/class.ilForumPostsDeleted.php';
 								$delObj = new ilForumPostsDeleted($provider);
 								$delObj->setThreadDeleted($thread_deleted);
 								$delObj->insert();
@@ -209,8 +196,6 @@ class ilForumAppEventListener implements ilAppEventListener
 					case 'savedAsDraft':
 					case 'updatedDraft':
 					case 'deletedDraft':
-						require_once './Modules/Forum/classes/class.ilForumDraftsHistory.php';
-						
 						/**
 						 * var $draftObj ilForumPostDraft
 						 */
@@ -221,8 +206,6 @@ class ilForumAppEventListener implements ilAppEventListener
 						
 						break;
 					case 'publishedDraft':
-						require_once './Modules/Forum/classes/class.ilForumDraftsHistory.php';
-						require_once './Modules/Forum/classes/class.ilForumPostDraft.php';
 						/**
 						 * var $draftObj ilForumPostDraft
 						 */

--- a/Modules/Forum/classes/class.ilForumAppEventListener.php
+++ b/Modules/Forum/classes/class.ilForumAppEventListener.php
@@ -37,7 +37,6 @@ class ilForumAppEventListener implements ilAppEventListener
 				switch($a_event)
 				{
 					case 'mergedThreads':
-						include_once './Modules/Forum/classes/class.ilForumPostDraft.php';
 						ilForumPostDraft::moveDraftsByMergedThreads($a_parameter['source_thread_id'], $a_parameter['target_thread_id']);
 						break;
 					case 'movedThreads':
@@ -225,7 +224,6 @@ class ilForumAppEventListener implements ilAppEventListener
 				switch ($a_event)
 				{
 					case "moveTree":
-						include_once './Modules/Forum/classes/class.ilForumNotification.php';
 						ilForumNotification::_clearForcedForumNotifications($a_parameter);
 						break;
 				}
@@ -235,8 +233,6 @@ class ilForumAppEventListener implements ilAppEventListener
 				switch($a_event)
 				{
 					case "addParticipant":
-						include_once './Modules/Forum/classes/class.ilForumNotification.php';
-						
 						$ref_ids = self::getCachedReferences($a_parameter['obj_id']);
 
 						foreach($ref_ids as $ref_id)
@@ -247,8 +243,6 @@ class ilForumAppEventListener implements ilAppEventListener
 						
 						break;
 					case 'deleteParticipant':
-						include_once './Modules/Forum/classes/class.ilForumNotification.php';
-
 						$ref_ids = self::getCachedReferences($a_parameter['obj_id']);
 
 						foreach($ref_ids as $ref_id)
@@ -263,8 +257,6 @@ class ilForumAppEventListener implements ilAppEventListener
 				switch($a_event)
 				{
 					case "addParticipant":
-						include_once './Modules/Forum/classes/class.ilForumNotification.php';
-
 						$ref_ids = self::getCachedReferences($a_parameter['obj_id']);
 
 						foreach($ref_ids as $ref_id)
@@ -275,8 +267,6 @@ class ilForumAppEventListener implements ilAppEventListener
 
 						break;
 					case 'deleteParticipant':
-						include_once './Modules/Forum/classes/class.ilForumNotification.php';
-
 						$ref_ids = self::getCachedReferences($a_parameter['obj_id']);
 
 						foreach($ref_ids as $ref_id)
@@ -291,7 +281,6 @@ class ilForumAppEventListener implements ilAppEventListener
 				switch($a_event)
 				{
 					case 'deleteUser':  
-						include_once './Modules/Forum/classes/class.ilForumPostDraft.php';
 						ilForumPostDraft::deleteDraftsByUserId($a_parameter['usr_id']);
 						break;
 				}

--- a/Modules/Forum/classes/class.ilForumAppEventListener.php
+++ b/Modules/Forum/classes/class.ilForumAppEventListener.php
@@ -1,8 +1,6 @@
 <?php
 /* Copyright (c) 1998-2012 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/EventHandling/interfaces/interface.ilAppEventListener.php';
-
 /**
 * Forum listener. Listens to events of other components.
 *
@@ -46,8 +44,6 @@ class ilForumAppEventListener implements ilAppEventListener
 						ilForumPostDraft::moveDraftsByMovedThread($a_parameter['thread_ids'], $a_parameter['source_ref_id'], $a_parameter['target_ref_id']);
 						break;
 					case 'createdPost':
-						require_once 'Services/Cron/classes/class.ilCronManager.php';
-
 						$post              = $a_parameter['post'];
 						$notify_moderators = $a_parameter['notify_moderators'];
 
@@ -91,8 +87,6 @@ class ilForumAppEventListener implements ilAppEventListener
 						break;
 
 					case 'activatedPost':
-						require_once 'Services/Cron/classes/class.ilCronManager.php';
-						
 						$post = $a_parameter['post'];
 						if($immediate_notifications_enabled && $post->isActivated())
 						{
@@ -161,8 +155,6 @@ class ilForumAppEventListener implements ilAppEventListener
 						break;
 
 					case 'deletedPost':
-						require_once 'Services/Cron/classes/class.ilCronManager.php';
-						
 						$post = $a_parameter['post'];
 
 						$thread_deleted = $a_parameter['thread_deleted'];

--- a/Modules/Forum/classes/class.ilForumAuthorInformation.php
+++ b/Modules/Forum/classes/class.ilForumAuthorInformation.php
@@ -200,8 +200,6 @@ class ilForumAuthorInformation
 	 */
 	protected function init()
 	{
-		include_once 'Modules/Forum/classes/class.ilObjForumAccess.php';
-
 		$translationLanguage = $this->globalLng;
 		if ($this->lng instanceof \ilLanguage) {
 			$translationLanguage = $this->lng;

--- a/Modules/Forum/classes/class.ilForumAuthorInformation.php
+++ b/Modules/Forum/classes/class.ilForumAuthorInformation.php
@@ -1,9 +1,6 @@
 <?php
 /* Copyright (c) 1998-2012 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Modules/Forum/classes/class.ilObjForumAccess.php';
-require_once 'Modules/Forum/classes/class.ilForumAuthorInformationCache.php';
-
 /**
  * ilForumAuthorInformation
  * @author  Michael Jansen <mjansen@databay.de>

--- a/Modules/Forum/classes/class.ilForumCronNotification.php
+++ b/Modules/Forum/classes/class.ilForumCronNotification.php
@@ -303,7 +303,6 @@ class ilForumCronNotification extends ilCronJob
 			}
 		}
 
-		require_once 'Modules/Forum/classes/class.ilForumAuthorInformationCache.php';
 		ilForumAuthorInformationCache::preloadUserObjects(array_unique($usrIdsToPreload));
 
 		$i = 0;

--- a/Modules/Forum/classes/class.ilForumCronNotification.php
+++ b/Modules/Forum/classes/class.ilForumCronNotification.php
@@ -1,9 +1,6 @@
 <?php
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-include_once "Services/Cron/classes/class.ilCronJob.php";
-include_once "./Modules/Forum/classes/class.ilForumMailNotification.php";
-
 /**
  * Forum notifications
  *
@@ -255,9 +252,6 @@ class ilForumCronNotification extends ilCronJob
 	{
 		global $DIC; 
 		$ilDB = $DIC->database();
-
-		include_once './Modules/Forum/classes/class.ilForumCronNotificationDataProvider.php';
-		include_once './Modules/Forum/classes/class.ilForumMailNotification.php';
 
 		while($row = $ilDB->fetchAssoc($res))
 		{

--- a/Modules/Forum/classes/class.ilForumCronNotificationDataProvider.php
+++ b/Modules/Forum/classes/class.ilForumCronNotificationDataProvider.php
@@ -1,10 +1,6 @@
 <?php
 /* Copyright (c) 1998-2015 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-include_once './Modules/Forum/interfaces/interface.ilForumNotificationMailData.php';
-include_once './Modules/Forum/classes/class.ilForumProperties.php';
-require_once 'Modules/Forum/classes/class.ilForumAuthorInformation.php';
-
 /**
  * Class ilForumCronNotificationDataProvider
  *

--- a/Modules/Forum/classes/class.ilForumCronNotificationDataProvider.php
+++ b/Modules/Forum/classes/class.ilForumCronNotificationDataProvider.php
@@ -209,7 +209,6 @@ class ilForumCronNotificationDataProvider implements ilForumNotificationMailData
 		if(ilForumProperties::isSendAttachmentsByMailEnabled())
 		{
 			// get attachments
-			include_once "./Modules/Forum/classes/class.ilFileDataForum.php";
 			$fileDataForum = new ilFileDataForum($this->getObjId(), $this->getPostId());
 			$filesOfPost   = $fileDataForum->getFilesOfPost();
 

--- a/Modules/Forum/classes/class.ilForumDraftsHistory.php
+++ b/Modules/Forum/classes/class.ilForumDraftsHistory.php
@@ -259,7 +259,6 @@ class ilForumDraftsHistory
 	
 	public function deleteMobs()
 	{
-		require_once 'Services/MediaObjects/classes/class.ilObjMediaObject.php';
 		// delete mobs of draft history
 		$oldMediaObjects = ilObjMediaObject::_getMobsOfObject('frm~h:html',  $this->getHistoryId());
 		foreach($oldMediaObjects as $oldMob)

--- a/Modules/Forum/classes/class.ilForumDraftsHistory.php
+++ b/Modules/Forum/classes/class.ilForumDraftsHistory.php
@@ -238,7 +238,6 @@ class ilForumDraftsHistory
 	public function addMobsToDraftsHistory($message)
 	{
 		// copy temporary media objects (frm~)
-		include_once 'Services/MediaObjects/classes/class.ilObjMediaObject.php';
 		$mediaObjects = ilRTE::_getMediaObjects($this->getPostMessage(), 0);
 		
 		$myMediaObjects = ilObjMediaObject::_getMobsOfObject('frm~h:html', $this->getHistoryId());

--- a/Modules/Forum/classes/class.ilForumDraftsTableGUI.php
+++ b/Modules/Forum/classes/class.ilForumDraftsTableGUI.php
@@ -1,7 +1,5 @@
 <?php
 /* Copyright (c) 1998-2012 ILIAS open source, Extended GPL, see docs/LICENSE */
-require_once 'Services/Table/classes/class.ilTable2GUI.php';
-require_once 'Services/Calendar/classes/class.ilDatePresentation.php';
 
 /**
  * Class ilForumDraftsTableGUI

--- a/Modules/Forum/classes/class.ilForumExplorerGUI.php
+++ b/Modules/Forum/classes/class.ilForumExplorerGUI.php
@@ -1,8 +1,6 @@
 <?php
 /* Copyright (c) 1998-2016 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/UIComponent/Explorer2/classes/class.ilExplorerBaseGUI.php';
-
 /**
  * Class ilForumExplorerGUI
  * @author Michael Jansen <mjansen@databay.de>

--- a/Modules/Forum/classes/class.ilForumExplorerGUI.php
+++ b/Modules/Forum/classes/class.ilForumExplorerGUI.php
@@ -169,7 +169,6 @@ class ilForumExplorerGUI extends ilExplorerBaseGUI
 		$tpl->setVariable('TITLE_CLASSES', implode(' ', $this->getNodeTitleClasses($a_node)));
 		$tpl->parseCurrentBlock();
 
-		require_once 'Modules/Forum/classes/class.ilForumAuthorInformation.php';
 		$authorinfo = new ilForumAuthorInformation(
 			$a_node['pos_author_id'],
 			$a_node['pos_display_user_id'],

--- a/Modules/Forum/classes/class.ilForumExportGUI.php
+++ b/Modules/Forum/classes/class.ilForumExportGUI.php
@@ -1,10 +1,7 @@
 <?php
 /* Copyright (c) 1998-2012 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Modules/Forum/classes/class.ilForumProperties.php';
 require_once 'Services/RTE/classes/class.ilRTE.php';
-require_once 'Modules/Forum/classes/class.ilForumAuthorInformation.php';
-require_once 'Modules/Forum/classes/class.ilForum.php';
 
 /**
 * Forum export to HTML and Print.
@@ -342,7 +339,6 @@ class ilForumExportGUI
 
 			$post->setChangeDate($post->getChangeDate());
 
-			require_once 'Modules/Forum/classes/class.ilForumAuthorInformation.php';
 			$authorinfo = new ilForumAuthorInformation(
 				$post->getPosAuthorId(),
 				$post->getDisplayUserId(),

--- a/Modules/Forum/classes/class.ilForumExportGUI.php
+++ b/Modules/Forum/classes/class.ilForumExportGUI.php
@@ -1,8 +1,6 @@
 <?php
 /* Copyright (c) 1998-2012 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/RTE/classes/class.ilRTE.php';
-
 /**
 * Forum export to HTML and Print.
 *
@@ -89,7 +87,6 @@ class ilForumExportGUI
 		$location_stylesheet = ilUtil::getStyleSheetLocation();
 		$tpl->setVariable('LOCATION_STYLESHEET', $location_stylesheet);
 
-		require_once 'Services/jQuery/classes/class.iljQueryUtil.php';
 		iljQueryUtil::initjQuery();
 
 		$this->frm->setMDB2WhereCondition('top_pk = %s ', array('integer'), array((int)$_GET['thr_top_fk']));
@@ -134,7 +131,6 @@ class ilForumExportGUI
 		$location_stylesheet = ilUtil::getStyleSheetLocation();
 		$tpl->setVariable('LOCATION_STYLESHEET', $location_stylesheet);
 
-		require_once 'Services/jQuery/classes/class.iljQueryUtil.php';
 		iljQueryUtil::initjQuery();
 
 		$this->frm->setMDB2WhereCondition('top_pk = %s ', array('integer'), array((int)$_GET['top_pk']));

--- a/Modules/Forum/classes/class.ilForumExportGUI.php
+++ b/Modules/Forum/classes/class.ilForumExportGUI.php
@@ -392,7 +392,6 @@ class ilForumExportGUI
 	 */
 	protected function prepare()
 	{
-		include_once './Services/MathJax/classes/class.ilMathJax.php';
 		ilMathJax::getInstance()
 			->init(ilMathJax::PURPOSE_EXPORT)
 			->setZoomFactor(10);

--- a/Modules/Forum/classes/class.ilForumExporter.php
+++ b/Modules/Forum/classes/class.ilForumExporter.php
@@ -1,8 +1,6 @@
 <?php
 /* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-include_once("./Services/Export/classes/class.ilXmlExporter.php");
-
 /**
  * Exporter class for sessions
  *
@@ -35,7 +33,6 @@ class ilForumExporter extends ilXmlExporter
 	{
 		$xml = '';
 
-		include_once 'Modules/Forum/classes/class.ilForumXMLWriter.php';
 		if(ilObject::_lookupType($a_id) == 'frm')
 		{
 			$writer = new ilForumXMLWriter();

--- a/Modules/Forum/classes/class.ilForumImporter.php
+++ b/Modules/Forum/classes/class.ilForumImporter.php
@@ -1,8 +1,6 @@
 <?php
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-include_once("./Services/Export/classes/class.ilXmlImporter.php");
-
 /**
  * Importer class for forums
  *
@@ -20,8 +18,6 @@ class ilForumImporter extends ilXmlImporter
 	 */
 	public function importXmlRepresentation($a_entity, $a_id, $a_xml, $a_mapping)
 	{
-		include_once 'Modules/Forum/classes/class.ilObjForum.php';
-
 		// case i container
 		if($new_id = $a_mapping->getMapping('Services/Container','objs',$a_id))
 		{
@@ -34,7 +30,6 @@ class ilForumImporter extends ilXmlImporter
 			$newObj->create();
 		}
 
-		include_once 'Modules/Forum/classes/class.ilForumXMLParser.php';
 		$parser = new ilForumXMLParser($newObj, $a_xml);
 		$parser->setImportDirectory($this->getImportDirectory());
 		$parser->setImportInstallId($this->getInstallId());

--- a/Modules/Forum/classes/class.ilForumMailNotification.php
+++ b/Modules/Forum/classes/class.ilForumMailNotification.php
@@ -1,8 +1,6 @@
 <?php
 /* Copyright (c) 1998-2015 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-include_once './Services/Mail/classes/class.ilMailNotification.php';
-
 /**
  * @author Nadia Matuschek <nmatuschek@databay.de>
  * @version $Id$

--- a/Modules/Forum/classes/class.ilForumModeratorsGUI.php
+++ b/Modules/Forum/classes/class.ilForumModeratorsGUI.php
@@ -186,7 +186,6 @@ class ilForumModeratorsGUI
 			)
 		);
 
-		require_once 'Modules/Forum/classes/class.ilForumModeratorsTableGUI.php';
 		$tbl = new ilForumModeratorsTableGUI($this, 'showModerators', '', (int)$_GET['ref_id']);
 
 		$entries = $this->oForumModerators->getCurrentModerators();

--- a/Modules/Forum/classes/class.ilForumModeratorsGUI.php
+++ b/Modules/Forum/classes/class.ilForumModeratorsGUI.php
@@ -1,12 +1,6 @@
 <?php
 /* Copyright (c) 1998-2012 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-include_once 'Modules/Forum/classes/class.ilForumModerators.php';
-include_once 'Services/Form/classes/class.ilPropertyFormGUI.php';
-include_once 'Services/Table/classes/class.ilTable2GUI.php';
-include_once 'Services/Search/classes/class.ilQueryParser.php';
-include_once 'Services/Search/classes/class.ilObjectSearchFactory.php';
-
 /**
  * Class ilForumModeratorsGUI
  * @author Nadia Matuschek <nmatuschek@databay.de>
@@ -65,7 +59,6 @@ class ilForumModeratorsGUI
 		switch($next_class)
 		{
 			case 'ilrepositorysearchgui':
-				include_once 'Services/Search/classes/class.ilRepositorySearchGUI.php';
 				$rep_search = new ilRepositorySearchGUI();
 				$rep_search->setCallback($this, 'addModerator');
 				$this->ctrl->setReturn($this, 'showModerators');
@@ -93,9 +86,7 @@ class ilForumModeratorsGUI
 			return;
 		}
 
-		include_once "Modules/Forum/classes/class.ilForumNotification.php";
 		$isCrsGrp = ilForumNotification::_isParentNodeGrpCrs($this->ref_id);
-		include_once "Modules/Forum/classes/class.ilForumProperties.php";
 		$objFrmProps = ilForumProperties::getInstance(ilObject::_lookupObjId($this->ref_id));
 		$frm_noti_type = $objFrmProps->getNotificationType();
 		
@@ -136,15 +127,8 @@ class ilForumModeratorsGUI
 			return $this->showModerators();
 		}
 
-		include_once "Modules/Forum/classes/class.ilForumNotification.php";
 		$isCrsGrp = ilForumNotification::_isParentNodeGrpCrs($this->ref_id);
 
-		if($isCrsGrp)
-		{
-			include_once "Services/Membership/classes/class.ilParticipants.php";
-		}
-
-		include_once "Modules/Forum/classes/class.ilForumProperties.php";
 		$objFrmProps = ilForumProperties::getInstance(ilObject::_lookupObjId($this->ref_id));
 		$frm_noti_type = $objFrmProps->getNotificationType();
 		
@@ -174,7 +158,6 @@ class ilForumModeratorsGUI
 	 */
 	public function showModerators()
 	{
-		include_once './Services/Search/classes/class.ilRepositorySearchGUI.php';
 		ilRepositorySearchGUI::fillAutoCompleteToolbar(
 			$this,
 			$this->toolbar,

--- a/Modules/Forum/classes/class.ilForumModeratorsTableGUI.php
+++ b/Modules/Forum/classes/class.ilForumModeratorsTableGUI.php
@@ -1,8 +1,6 @@
 <?php
 /* Copyright (c) 1998-2015 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/Table/classes/class.ilTable2GUI.php';
-
 /**
  * Class ilForumModeratorsTableGUI
  * @author	Michael Jansen <mjansen@databay.de>

--- a/Modules/Forum/classes/class.ilForumMoveTopicsExplorer.php
+++ b/Modules/Forum/classes/class.ilForumMoveTopicsExplorer.php
@@ -1,8 +1,6 @@
 <?php
 /* Copyright (c) 1998-2015 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/Repository/classes/class.ilRepositorySelectorExplorerGUI.php';
-
 /**
  * ilForumMoveTopicsExplorer
  * @author Michael Jansen <mjansen@databay.de>

--- a/Modules/Forum/classes/class.ilForumNewsRendererGUI.php
+++ b/Modules/Forum/classes/class.ilForumNewsRendererGUI.php
@@ -2,7 +2,6 @@
 
 /* Copyright (c) 1998-2016 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-include_once("./Services/News/classes/class.ilNewsDefaultRendererGUI.php");
 /**
  * Forum news renderer
  *
@@ -19,12 +18,10 @@ class ilForumNewsRendererGUI extends ilNewsDefaultRendererGUI
 	 */
 	function getObjectLink()
 	{
-		include_once("./Services/Link/classes/class.ilLink.php");
 		$n = $this->getNewsItem();
 		if ($n->getContextSubObjType() == "pos"
 			&& $n->getContextSubObjId() > 0)
 		{
-			include_once("./Modules/Forum/classes/class.ilObjForumAccess.php");
 			$pos = $n->getContextSubObjId();
 			$thread = ilObjForumAccess::_getThreadForPosting($pos);
 			if ($thread > 0)

--- a/Modules/Forum/classes/class.ilForumNotification.php
+++ b/Modules/Forum/classes/class.ilForumNotification.php
@@ -203,9 +203,7 @@ class ilForumNotification
 	{
 		global $DIC; 
 		$ilUser = $DIC->user();
-			
-		include_once 'Modules/Forum/classes/class.ilForumProperties.php';
-		
+
 		$node_data = self::getCachedNodeData($ref_id);
 		
 		foreach($node_data as $data)
@@ -242,9 +240,7 @@ class ilForumNotification
 		$ilUser = $DIC->user();
 
 		$node_data = self::getCachedNodeData($ref_id);
-		
-		include_once 'Modules/Forum/classes/class.ilForumModerators.php';
-		
+
 		foreach($node_data as $data)
 		{
 			//check frm_properties if frm_noti is enabled
@@ -341,12 +337,10 @@ class ilForumNotification
 
 		if($parent_obj->getType() == 'crs')
 		{
-			include_once 'Modules/Course/classes/class.ilCourseParticipants.php';
-			$oParticipants = ilCourseParticipants::_getInstanceByObjId($parent_obj->getId());				
+			$oParticipants = ilCourseParticipants::_getInstanceByObjId($parent_obj->getId());
 		}
 		else if($parent_obj->getType() == 'grp')
 		{
-			include_once 'Modules/Group/classes/class.ilGroupParticipants.php';
 			$oParticipants = ilGroupParticipants::_getInstanceByObjId($parent_obj->getId());
 		}
 		

--- a/Modules/Forum/classes/class.ilForumNotification.php
+++ b/Modules/Forum/classes/class.ilForumNotification.php
@@ -1,9 +1,6 @@
 <?php
 /* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Modules/Forum/classes/class.ilObjForum.php';
-require_once 'Modules/Forum/classes/class.ilForum.php';
-
 /**
 * Class ilForumNotification
 *

--- a/Modules/Forum/classes/class.ilForumPost.php
+++ b/Modules/Forum/classes/class.ilForumPost.php
@@ -1,8 +1,6 @@
 <?php
 /* Copyright (c) 1998-2012 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once './Modules/Forum/classes/class.ilForumTopic.php';
-
 /**
 * @author Michael Jansen <mjansen@databay.de>
 * @version $Id$

--- a/Modules/Forum/classes/class.ilForumPost.php
+++ b/Modules/Forum/classes/class.ilForumPost.php
@@ -248,7 +248,6 @@ class ilForumPost
 	{
 		if ($row['pos_display_user_id'] && $row['pos_pk'])
 		{
-			require_once 'Services/User/classes/class.ilObjUser.php';
 			$tmp_user = new ilObjUser();
 			$tmp_user->setFirstname($row['firstname']);
 			$tmp_user->setLastname($row['lastname']);

--- a/Modules/Forum/classes/class.ilForumPostDraft.php
+++ b/Modules/Forum/classes/class.ilForumPostDraft.php
@@ -515,7 +515,6 @@ class ilForumPostDraft
 	 */
 	public static function deleteMobsOfDraft($draft_id)
 	{
-		require_once 'Services/MediaObjects/classes/class.ilObjMediaObject.php';
 		// delete mobs of draft
 		$oldMediaObjects = ilObjMediaObject::_getMobsOfObject('frm~d:html', $draft_id);
 		foreach($oldMediaObjects as $oldMob)

--- a/Modules/Forum/classes/class.ilForumPostDraft.php
+++ b/Modules/Forum/classes/class.ilForumPostDraft.php
@@ -1,6 +1,5 @@
 <?php
 /* Copyright (c) 1998-2016 ILIAS open source, Extended GPL, see docs/LICENSE */
-require_once './Modules/Forum/classes/class.ilFileDataForumDrafts.php';
 /**
  * Class ilForumPostDraft
  * @author Nadia Matuschek <nmatuschek@databay.de>

--- a/Modules/Forum/classes/class.ilForumPostingDraftsBlockGUI.php
+++ b/Modules/Forum/classes/class.ilForumPostingDraftsBlockGUI.php
@@ -2,7 +2,6 @@
 /* Copyright (c) 1998-2016 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 require_once 'Services/Block/classes/class.ilBlockGUI.php';
-require_once './Modules/Forum/classes/class.ilForum.php';
 
 /**
  * Class ilForumPostingDraftsBlockGUI
@@ -101,8 +100,6 @@ class ilForumPostingDraftsBlockGUI extends ilBlockGUI
 	 */
 	public function fillDataSection()
 	{
-		require_once './Modules/Forum/classes/class.ilForumPostDraft.php';
-		require_once './Modules/Forum/classes/class.ilForumUtil.php';
 		require_once './Services/Link/classes/class.ilLink.php';
 		
 		$drafts_instances = ilForumPostDraft::getDraftInstancesByUserId($this->user->getId());

--- a/Modules/Forum/classes/class.ilForumPostingDraftsBlockGUI.php
+++ b/Modules/Forum/classes/class.ilForumPostingDraftsBlockGUI.php
@@ -1,8 +1,6 @@
 <?php
 /* Copyright (c) 1998-2016 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/Block/classes/class.ilBlockGUI.php';
-
 /**
  * Class ilForumPostingDraftsBlockGUI
  * @author Michael Jansen <mjansen@databay.de>
@@ -100,8 +98,6 @@ class ilForumPostingDraftsBlockGUI extends ilBlockGUI
 	 */
 	public function fillDataSection()
 	{
-		require_once './Services/Link/classes/class.ilLink.php';
-		
 		$drafts_instances = ilForumPostDraft::getDraftInstancesByUserId($this->user->getId());
 		
 		$draft_as_array = array();

--- a/Modules/Forum/classes/class.ilForumSettingsGUI.php
+++ b/Modules/Forum/classes/class.ilForumSettingsGUI.php
@@ -263,9 +263,6 @@ class ilForumSettingsGUI
 		// set form html into template
 		$this->tpl->setVariable('NOTIFICATIONS_SETTINGS_FORM', $this->notificationSettingsForm->getHTML());
 
-		include_once 'Modules/Forum/classes/class.ilForumNotification.php';
-		include_once 'Modules/Forum/classes/class.ilObjForum.php';
-
 		$frm_noti = new ilForumNotification($this->parent_obj->object->getRefId());
 		$oParticipants = $this->getParticipants();
 
@@ -278,7 +275,6 @@ class ilForumSettingsGUI
 		if($this->parent_obj->objProperties->getNotificationType() == 'default')
 		{
 			// update forum_notification table
-			include_once 'Modules/Forum/classes/class.ilForumNotification.php';
 			$forum_noti = new ilForumNotification($this->parent_obj->object->getRefId());
 			$forum_noti->setAdminForce($this->parent_obj->objProperties->isAdminForceNoti());
 			$forum_noti->setUserToggle($this->parent_obj->objProperties->isUserToggleNoti());
@@ -369,7 +365,6 @@ class ilForumSettingsGUI
 		}
 		else
 		{
-			include_once 'Modules/Forum/classes/class.ilForumNotification.php';
 			$frm_noti = new ilForumNotification($this->parent_obj->object->getRefId());
 
 			foreach($_POST['user_id'] as $user_id)
@@ -404,7 +399,6 @@ class ilForumSettingsGUI
 		}
 		else
 		{
-			include_once 'Modules/Forum/classes/class.ilForumNotification.php';
 			$frm_noti = new ilForumNotification($this->parent_obj->object->getRefId());
 
 			foreach($_POST['user_id'] as $user_id)
@@ -436,7 +430,6 @@ class ilForumSettingsGUI
 		}
 		else
 		{
-			include_once 'Modules/Forum/classes/class.ilForumNotification.php';
 			$frm_noti = new ilForumNotification($this->parent_obj->object->getRefId());
 
 			foreach($_POST['user_id'] as $user_id)
@@ -475,7 +468,6 @@ class ilForumSettingsGUI
 		}
 		else
 		{
-			include_once 'Modules/Forum/classes/class.ilForumNotification.php';
 			$frm_noti = new ilForumNotification($this->parent_obj->object->getRefId());
 
 			foreach($_POST['user_id'] as $user_id)
@@ -522,7 +514,6 @@ class ilForumSettingsGUI
 		if($grp_ref_id > 0)
 		{
 			$parent_obj = ilObjectFactory::getInstanceByRefId($grp_ref_id);
-			include_once 'Modules/Group/classes/class.ilGroupParticipants.php';
 			$oParticipants = ilGroupParticipants::_getInstanceByObjId($parent_obj->getId());
 			return $oParticipants;
 		}
@@ -530,7 +521,6 @@ class ilForumSettingsGUI
 		{
 			$parent_obj = ilObjectFactory::getInstanceByRefId($crs_ref_id);
 
-			include_once 'Modules/Course/classes/class.ilCourseParticipants.php';
 			$oParticipants = ilCourseParticipants::_getInstanceByObjId($parent_obj->getId());
 			return $oParticipants;
 		}
@@ -542,8 +532,6 @@ class ilForumSettingsGUI
 
 	private function updateUserNotifications($update_all_users = false)
 	{
-		include_once 'Modules/Forum/classes/class.ilForumNotification.php';
-
 		$oParticipants = $this->getParticipants();
 
 		$frm_noti = new ilForumNotification($this->parent_obj->object->getRefId());
@@ -644,7 +632,6 @@ class ilForumSettingsGUI
 				$this->parent_obj->objProperties->setNotificationType('default');
 				$this->parent_obj->objProperties->setAdminForceNoti(0);
 				$this->parent_obj->objProperties->setUserToggleNoti(0);
-				include_once 'Modules/Forum/classes/class.ilForumNotification.php';
 				$frm_noti = new ilForumNotification($this->parent_obj->object->getRefId());
 				$frm_noti->deleteNotificationAllUsers();
 			}

--- a/Modules/Forum/classes/class.ilForumStatisticsTableGUI.php
+++ b/Modules/Forum/classes/class.ilForumStatisticsTableGUI.php
@@ -1,8 +1,6 @@
 <?php
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/Table/classes/class.ilTable2GUI.php';
-
 /**
  * Class ilForumStatisticsTableGUI
  *

--- a/Modules/Forum/classes/class.ilForumTopic.php
+++ b/Modules/Forum/classes/class.ilForumTopic.php
@@ -1,8 +1,6 @@
 <?php
 /* Copyright (c) 1998-2012 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once './Modules/Forum/classes/class.ilForumPost.php';
-
 /**
 * @author Michael Jansen <mjansen@databay.de>
 * @version $Id:$
@@ -525,7 +523,6 @@ class ilForumTopic
 			unset($tmp_object);
 		}
 
-		require_once 'Modules/Forum/classes/class.ilForumAuthorInformationCache.php';
 		ilForumAuthorInformationCache::preloadUserObjects(array_unique($usr_ids));
 
 		return $posts;
@@ -760,7 +757,6 @@ class ilForumTopic
 			$children[] = $row;
 		}
 
-		require_once 'Modules/Forum/classes/class.ilForumAuthorInformationCache.php';
 		ilForumAuthorInformationCache::preloadUserObjects(array_unique($usr_ids));
 
 		return $children;

--- a/Modules/Forum/classes/class.ilForumTopic.php
+++ b/Modules/Forum/classes/class.ilForumTopic.php
@@ -608,7 +608,6 @@ class ilForumTopic
 
 			while($post = $posts->fetchRow(ilDBConstants::FETCHMODE_ASSOC))
 			{ 
-				include_once("./Services/News/classes/class.ilNewsItem.php");
 				$news_id = ilNewsItem::getFirstNewsIdForContext($old_obj_id,
 					"frm", $post["pos_pk"], "pos");
 				$news_item = new ilNewsItem($news_id);

--- a/Modules/Forum/classes/class.ilForumTopicTableGUI.php
+++ b/Modules/Forum/classes/class.ilForumTopicTableGUI.php
@@ -1,9 +1,6 @@
 <?php
 /* Copyright (c) 1998-2012 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/Table/classes/class.ilTable2GUI.php';
-require_once 'Services/Rating/classes/class.ilRatingGUI.php';
-
 /**
  * Class ilForumTopicTableGUI
  * @author  Nadia Matuschek <nmatuschek@databay.de>

--- a/Modules/Forum/classes/class.ilForumTopicTableGUI.php
+++ b/Modules/Forum/classes/class.ilForumTopicTableGUI.php
@@ -2,8 +2,6 @@
 /* Copyright (c) 1998-2012 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 require_once 'Services/Table/classes/class.ilTable2GUI.php';
-require_once 'Modules/Forum/classes/class.ilForumAuthorInformation.php';
-require_once 'Modules/Forum/classes/class.ilForumAuthorInformationCache.php';
 require_once 'Services/Rating/classes/class.ilRatingGUI.php';
 
 /**

--- a/Modules/Forum/classes/class.ilForumUtil.php
+++ b/Modules/Forum/classes/class.ilForumUtil.php
@@ -61,7 +61,6 @@ class ilForumUtil
 	 */
 	public static function moveMediaObjects($post_message, $source_type, $source_id, $target_type, $target_id, $direction = 0)
 	{
-		include_once 'Services/MediaObjects/classes/class.ilObjMediaObject.php';
 		$mediaObjects = ilRTE::_getMediaObjects($post_message, $direction);
 		$myMediaObjects = ilObjMediaObject::_getMobsOfObject($source_type, $source_id);
 		foreach($mediaObjects as $mob)
@@ -86,7 +85,6 @@ class ilForumUtil
 	 */
 	public static function saveMediaObjects($post_message, $target_type, $target_id, $direction = 0)
 	{
-		include_once 'Services/MediaObjects/classes/class.ilObjMediaObject.php';
 		$mediaObjects = ilRTE::_getMediaObjects($post_message, $direction);
 		
 		foreach($mediaObjects as $mob)

--- a/Modules/Forum/classes/class.ilForumXMLParser.php
+++ b/Modules/Forum/classes/class.ilForumXMLParser.php
@@ -1,9 +1,6 @@
 <?php
 /* Copyright (c) 1998-2012 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-include_once './Services/Xml/classes/class.ilSaxParser.php';
-include_once "./Services/MediaObjects/classes/class.ilObjMediaObject.php";
-
 class ilForumXMLParser extends ilSaxParser
 {
 	/**

--- a/Modules/Forum/classes/class.ilForumXMLParser.php
+++ b/Modules/Forum/classes/class.ilForumXMLParser.php
@@ -2,7 +2,6 @@
 /* Copyright (c) 1998-2012 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 include_once './Services/Xml/classes/class.ilSaxParser.php';
-require_once 'Modules/Forum/classes/class.ilForumProperties.php';
 include_once "./Services/MediaObjects/classes/class.ilObjMediaObject.php";
 
 class ilForumXMLParser extends ilSaxParser
@@ -357,8 +356,6 @@ class ilForumXMLParser extends ilSaxParser
 
 				if($this->entity == 'thread' && $this->threadArray)
 				{
-					require_once 'Modules/Forum/classes/class.ilForumTopic.php';
-
 					$this->forumThread = new ilForumTopic();
 					$this->forumThread->setId($this->threadArray['Id']);
 					$this->forumThread->setForumId( $this->lastHandledForumId );
@@ -440,8 +437,6 @@ class ilForumXMLParser extends ilSaxParser
 
 				if($this->entity == 'post' && $this->postArray)
 				{
-					require_once 'Modules/Forum/classes/class.ilForumPost.php';
-
 					$this->forumPost = new ilForumPost();
 					$this->forumPost->setId($this->postArray['Id']);
 					$this->forumPost->setCensorship($this->postArray['Censorship']);

--- a/Modules/Forum/classes/class.ilForumXMLWriter.php
+++ b/Modules/Forum/classes/class.ilForumXMLWriter.php
@@ -2,11 +2,6 @@
 
 /* Copyright (c) 1998-2011 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-include_once "./Services/Xml/classes/class.ilXmlWriter.php";
-include_once "./Modules/Forum/classes/class.ilFileDataForum.php";
-include_once "Services/MediaObjects/classes/class.ilObjMediaObject.php";
-include_once "Services/RTE/classes/class.ilRTE.php";
-
 /**
 * XML writer class
 *

--- a/Modules/Forum/classes/class.ilObjForum.php
+++ b/Modules/Forum/classes/class.ilObjForum.php
@@ -2,9 +2,6 @@
 /* Copyright (c) 1998-2012 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 require_once 'Services/Object/classes/class.ilObject.php';
-require_once 'Modules/Forum/classes/class.ilForum.php';
-require_once 'Modules/Forum/classes/class.ilFileDataForum.php';
-require_once 'Modules/Forum/classes/class.ilForumProperties.php';
 
 /** @defgroup ModulesForum Modules/Forum
  */
@@ -97,7 +94,6 @@ class ilObjForum extends ilObject
 	{
 		$id = parent::create();
 
-		require_once 'Modules/Forum/classes/class.ilForumProperties.php';
 		$properties = ilForumProperties::getInstance($this->getId());
 		$properties->setDefaultView(1);
 		$properties->setAnonymisation(0);
@@ -668,11 +664,9 @@ class ilObjForum extends ilObject
 
 		if(count($draft_ids) > 0)
 		{
-			require_once 'Modules/Forum/classes/class.ilForumDraftsHistory.php';
 			$historyObj = new ilForumDraftsHistory();
 			$historyObj->deleteHistoryByDraftIds($draft_ids);
 			
-			require_once 'Modules/Forum/classes/class.ilForumPostDraft.php';
 			$draftObj = new ilForumPostDraft();
 			$draftObj->deleteDraftsByDraftIds($draft_ids);
 		}

--- a/Modules/Forum/classes/class.ilObjForum.php
+++ b/Modules/Forum/classes/class.ilObjForum.php
@@ -1,8 +1,6 @@
 <?php
 /* Copyright (c) 1998-2012 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/Object/classes/class.ilObject.php';
-
 /** @defgroup ModulesForum Modules/Forum
  */
 
@@ -137,7 +135,6 @@ class ilObjForum extends ilObject
 	 */
 	function getDiskUsage()
 	{
-		require_once("./Modules/File/classes/class.ilObjFileAccess.php");
 		return ilObjForumAccess::_lookupDiskUsage($this->id);
 	}
 

--- a/Modules/Forum/classes/class.ilObjForum.php
+++ b/Modules/Forum/classes/class.ilObjForum.php
@@ -494,16 +494,12 @@ class ilObjForum extends ilObject
 		));
 
 		// read options
-		include_once('Services/CopyWizard/classes/class.ilCopyWizardOptions.php');
-
 		$cwo     = ilCopyWizardOptions::_getInstance($a_copy_id);
 		$options = $cwo->getOptions($this->getRefId());
 
 		$options['threads'] = $this->Forum->_getThreads($this->getId());
 
 		// Generate starting threads
-		include_once('Modules/Forum/classes/class.ilFileDataForum.php');
-
 		$new_frm = $new_obj->Forum;
 		$new_frm->setMDB2WhereCondition('top_frm_fk = %s ', array('integer'), array($new_obj->getId()));
 
@@ -561,7 +557,6 @@ class ilObjForum extends ilObject
 		$this->rbac->admin()->copyRolePermissions($moderator, $this->getRefId(), $new_obj->getRefId(), $new_moderator, true);
 		$this->logger->write(__METHOD__ . ' : Finished copying of role il_frm_moderator.');
 
-		include_once './Modules/Forum/classes/class.ilForumModerators.php';
 		$obj_mods = new ilForumModerators($this->getRefId());
 
 		$old_mods = $obj_mods->getCurrentModerators();
@@ -676,7 +671,6 @@ class ilObjForum extends ilObject
 	 */
 	public function initDefaultRoles()
 	{
-		include_once './Services/AccessControl/classes/class.ilObjRole.php';
 		$role = ilObjRole::createDefaultRole(
 				'il_frm_moderator_'.$this->getRefId(),
 				"Moderator of forum obj_no.".$this->getId(),
@@ -715,7 +709,6 @@ class ilObjForum extends ilObject
 	public function createSettings()
 	{
 		// news settings (public notifications yes/no)
-		include_once("./Services/News/classes/class.ilNewsItem.php");
 		$default_visibility = ilNewsItem::_getDefaultVisibilityForRefId($_GET["ref_id"]);
 		if($default_visibility == "public")
 		{

--- a/Modules/Forum/classes/class.ilObjForumAccess.php
+++ b/Modules/Forum/classes/class.ilObjForumAccess.php
@@ -1,9 +1,6 @@
 <?php
 /* Copyright (c) 1998-2012 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-include_once 'Services/Object/classes/class.ilObjectAccess.php';
-include_once 'Modules/Forum/classes/class.ilObjForum.php';
-
 /**
  * Class ilObjForumAccess
  * @author  Alex Killing <alex.killing@gmx.de>
@@ -140,8 +137,6 @@ class ilObjForumAccess extends ilObjectAccess
 	 */
 	public static function prepareMessageForLists($text)
 	{
-		include_once 'Services/Utilities/classes/class.ilStr.php';
-
 		$text = strip_tags($text);
 		$text = preg_replace('/\[(\/)?quote\]/', '', $text);
 		if(ilStr::strLen($text) > 40)

--- a/Modules/Forum/classes/class.ilObjForumAccess.php
+++ b/Modules/Forum/classes/class.ilObjForumAccess.php
@@ -108,8 +108,6 @@ class ilObjForumAccess extends ilObjectAccess
 		global $DIC;
 		$ilDB = $DIC->database();
 
-		require_once 'Modules/Forum/classes/class.ilFileDataForum.php';
-
 		$res = $ilDB->queryf(
 			'SELECT top_frm_fk, pos_pk FROM frm_posts p
 			JOIN frm_data d ON d.top_pk = p.pos_top_fk

--- a/Modules/Forum/classes/class.ilObjForumAdministration.php
+++ b/Modules/Forum/classes/class.ilObjForumAdministration.php
@@ -11,8 +11,6 @@
 * @package ilias-core
 */
 
-require_once "./Services/Object/classes/class.ilObject.php";
-
 class ilObjForumAdministration extends ilObject
 {
 	/**

--- a/Modules/Forum/classes/class.ilObjForumAdministrationAccess.php
+++ b/Modules/Forum/classes/class.ilObjForumAdministrationAccess.php
@@ -1,8 +1,6 @@
 <?php
 /* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-include_once("./Services/Object/classes/class.ilObjectAccess.php");
-
 /**
 * Class ilObjForumAdministrationAccess
 *

--- a/Modules/Forum/classes/class.ilObjForumAdministrationGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumAdministrationGUI.php
@@ -2,7 +2,6 @@
 /* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 require_once 'Services/Object/classes/class.ilObjectGUI.php';
-require_once 'Modules/Forum/classes/class.ilForumProperties.php';
 
 /**
  * Forum Administration Settings.

--- a/Modules/Forum/classes/class.ilObjForumAdministrationGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumAdministrationGUI.php
@@ -1,7 +1,6 @@
 <?php
 /* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/Object/classes/class.ilObjectGUI.php';
 
 /**
  * Forum Administration Settings.
@@ -43,7 +42,6 @@ class ilObjForumAdministrationGUI extends ilObjectGUI
 		{
 			case 'ilpermissiongui':
 				$this->tabs_gui->setTabActive('perm_settings');
-				require_once 'Services/AccessControl/classes/class.ilPermissionGUI.php';
 				$this->ctrl->forwardCommand(new ilPermissionGUI($this));
 				break;
 
@@ -117,13 +115,11 @@ class ilObjForumAdministrationGUI extends ilObjectGUI
 		$this->settings->set('enable_fora_statistics', (int)$form->getInput('fora_statistics'));
 		$this->settings->set('enable_anonymous_fora', (int)$form->getInput('anonymous_fora'));
 
-		require_once 'Services/Cron/classes/class.ilCronManager.php';
 		if(!ilCronManager::isJobActive('frm_notification'))
 		{
 			$this->settings->set('forum_notification', (int)$form->getInput('forum_notification'));
 		}
 
-		require_once 'Services/Captcha/classes/class.ilCaptchaUtil.php';
 		ilCaptchaUtil::setActiveForForum((bool)$form->getInput('activate_captcha_anonym'));
 
 		$this->settings->set('save_post_drafts', (int)$form->getInput('save_post_drafts'));
@@ -140,8 +136,6 @@ class ilObjForumAdministrationGUI extends ilObjectGUI
 	 */
 	protected function populateForm(ilPropertyFormGUI $form)
 	{
-		require_once 'Services/Captcha/classes/class.ilCaptchaUtil.php';
-
 		$frma_set = new ilSetting('frma');
 
 		$form->setValuesByArray(array(
@@ -163,7 +157,6 @@ class ilObjForumAdministrationGUI extends ilObjectGUI
 	 */
 	protected function getSettingsForm()
 	{
-		require_once 'Services/Form/classes/class.ilPropertyFormGUI.php';
 		$form = new ilPropertyFormGUI();
 		$form->setFormAction($this->ctrl->getFormAction($this, 'saveSettings'));
 		$form->setTitle($this->lng->txt('settings'));
@@ -188,10 +181,8 @@ class ilObjForumAdministrationGUI extends ilObjectGUI
 		$file_upload->setInfo($this->lng->txt('file_upload_allowed_fora_desc'));
 		$form->addItem($file_upload);
 
-		require_once 'Services/Cron/classes/class.ilCronManager.php';
 		if(ilCronManager::isJobActive('frm_notification'))
 		{
-			require_once 'Services/Administration/classes/class.ilAdministrationSettingsFormHandler.php';
 			ilAdministrationSettingsFormHandler::addFieldsToForm(
 				ilAdministrationSettingsFormHandler::FORM_FORUM,
 				$form,
@@ -211,7 +202,6 @@ class ilObjForumAdministrationGUI extends ilObjectGUI
 		$check->setValue(1);
 		$form->addItem($check);
 
-		require_once 'Services/Captcha/classes/class.ilCaptchaUtil.php';
 		$cap = new ilCheckboxInputGUI($this->lng->txt('adm_captcha_anonymous_short'), 'activate_captcha_anonym');
 		$cap->setInfo($this->lng->txt('adm_captcha_anonymous_frm'));
 		$cap->setValue(1);
@@ -264,7 +254,6 @@ class ilObjForumAdministrationGUI extends ilObjectGUI
 				return array(array("editSettings", $fields));
 
 			case ilAdministrationSettingsFormHandler::FORM_ACCESSIBILITY:
-				require_once 'Services/Captcha/classes/class.ilCaptchaUtil.php';
 				$fields = array(
 					'adm_captcha_anonymous_short' => array(ilCaptchaUtil::isActiveForForum(), ilAdministrationSettingsFormHandler::VALUE_BOOL)
 				);

--- a/Modules/Forum/classes/class.ilObjForumGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumGUI.php
@@ -1,14 +1,6 @@
 <?php
 /* Copyright (c) 1998-2012 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/Object/classes/class.ilObjectGUI.php';
-require_once 'Services/Table/classes/class.ilTable2GUI.php';
-require_once 'Services/Form/classes/class.ilPropertyFormGUI.php';
-require_once 'Services/RTE/classes/class.ilRTE.php';
-require_once 'Services/PersonalDesktop/interfaces/interface.ilDesktopItemHandling.php';
-require_once 'Services/UIComponent/SplitButton/classes/class.ilSplitButtonGUI.php';
-require_once 'Services/MediaObjects/classes/class.ilObjMediaObject.php';
-
 /**
  * Class ilObjForumGUI
  *
@@ -280,7 +272,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 				break;
 
 			case 'ilpermissiongui':
-				require_once 'Services/AccessControl/classes/class.ilPermissionGUI.php';
 				$perm_gui = new ilPermissionGUI($this);
 				$this->ctrl->forwardCommand($perm_gui);
 				break;
@@ -334,7 +325,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 					$this->error->raiseError($this->lng->txt('msg_no_perm_read'), $this->error->MESSAGE);
 				}
 
-				require_once 'Services/Rating/classes/class.ilRatingGUI.php';
 				$rating_gui = new ilRatingGUI();
 				$rating_gui->setObject($this->object->getId(), $this->object->getType(), $this->objCurrentTopic->getId(), 'thread');
 
@@ -349,7 +339,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 				break;
 			
 			case 'ilcommonactiondispatchergui':
-				include_once 'Services/Object/classes/class.ilCommonActionDispatcherGUI.php';
 				$gui = ilCommonActionDispatcherGUI::getInstanceFromAjaxCall();
 				$this->ctrl->forwardCommand($gui);
 				break;
@@ -562,7 +551,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 		// Create topic button
 		if($this->access->checkAccess('add_thread', '', $this->object->getRefId()) && !$this->hideToolbar())
 		{
-			require_once 'Services/UIComponent/Button/classes/class.ilLinkButton.php';
 			$btn = ilLinkButton::getInstance();
 			$btn->setUrl($this->ctrl->getLinkTarget($this, 'createThread'));
 			$btn->setCaption('forums_new_thread');
@@ -1738,7 +1726,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 		$frm = $oForumObjects['frm'];
 		$oFDForum = $oForumObjects['file_obj'];
 
-		require_once 'Services/Form/classes/class.ilPropertyFormGUI.php';
 		$this->replyEditForm = new ilPropertyFormGUI();
 		$this->replyEditForm->setId('id_showreply');
 		$this->replyEditForm->setTableWidth('100%');
@@ -1856,8 +1843,7 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 			$oPostGUI->setRTESupport($this->objCurrentPost->getId(), 'frm', 'frm_post', 'tpl.tinymce_frm_post.html', false, '3.5.11');
 		}
 		// purifier
-		require_once 'Services/Html/classes/class.ilHtmlPurifierFactory.php';
-		$oPostGUI->setPurifier(ilHtmlPurifierFactory::_getInstanceByType('frm_post'));		
+		$oPostGUI->setPurifier(ilHtmlPurifierFactory::_getInstanceByType('frm_post'));
 
 		$this->replyEditForm->addItem($oPostGUI);
 
@@ -1881,14 +1867,12 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 			$this->replyEditForm->addItem($oFileUploadGUI);
 		}
 
-		require_once 'Services/Captcha/classes/class.ilCaptchaUtil.php';
 		if(
 			$this->user->isAnonymous() &&
 			!$this->user->isCaptchaVerified() &&
 			ilCaptchaUtil::isActiveForForum()
 		)
 		{
-			require_once 'Services/Captcha/classes/class.ilCaptchaInputGUI.php';
 			$captcha = new ilCaptchaInputGUI($this->lng->txt('cont_captcha_code'), 'captcha_code');
 			$captcha->setRequired(true);		
 			$this->replyEditForm->addItem($captcha);
@@ -2586,7 +2570,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 		$bottom_toolbar                    = clone $this->toolbar;
 		$bottom_toolbar_split_button_items = array();
 		
-		require_once 'Services/UIComponent/Button/classes/class.ilLinkButton.php';
 		$this->tpl->addCss('./Modules/Forum/css/forum_tree.css');
 		if(!isset($_SESSION['viewmode']))
 		{
@@ -3693,7 +3676,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 		));
 		
 		// purifier
-		require_once 'Services/Html/classes/class.ilHtmlPurifierFactory.php';
 		$post_gui->setPurifier(ilHtmlPurifierFactory::_getInstanceByType('frm_post'));
 		$this->create_topic_form_gui->addItem($post_gui);
 		
@@ -3741,14 +3723,12 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 			$this->create_topic_form_gui->addItem($dir_notification_gui);
 		}
 		
-		require_once 'Services/Captcha/classes/class.ilCaptchaUtil.php';
 		if(
 			$this->user->isAnonymous() &&
 			!$this->user->isCaptchaVerified() &&
 			ilCaptchaUtil::isActiveForForum()
 		)
 		{
-			require_once 'Services/Captcha/classes/class.ilCaptchaInputGUI.php';
 			$captcha = new ilCaptchaInputGUI($this->lng->txt('cont_captcha_code'), 'captcha_code');
 			$captcha->setRequired(true);
 			$this->create_topic_form_gui->addItem($captcha);
@@ -4692,7 +4672,6 @@ $this->doCaptchaCheck();
 		$rgt_content = '';
 		if(!$GLOBALS['ilCtrl']->isAsynch())
 		{
-			require_once 'Services/Search/classes/class.ilRepositoryObjectSearchGUI.php';
 			$rgt_content = ilRepositoryObjectSearchGUI::getSearchBlockHTML($this->lng->txt('frm_search'));
 		}
 		$this->tpl->setRightContent($rgt_content . $this->getRightColumnHTML());
@@ -5778,7 +5757,6 @@ $this->doCaptchaCheck();
 		$this->tpl->setCurrentBlock('posts_row');
 		if(count($actions) > 0)
 		{
-			require_once 'Services/UIComponent/Button/classes/class.ilLinkButton.php';
 			$action_button = ilSplitButtonGUI::getInstance();
 			
 			$i = 0;
@@ -5840,7 +5818,6 @@ $this->doCaptchaCheck();
 	public function doHistoryCheck($draft_id)
 	{
 	
-		require_once './Services/jQuery/classes/class.iljQueryUtil.php';
 		iljQueryUtil::initjQuery();
 		
 		$modal = '';
@@ -5849,7 +5826,6 @@ $this->doCaptchaCheck();
 			$history_instances = ilForumDraftsHistory::getInstancesByDraftId($draft_id);
 			if(is_array($history_instances) && sizeof($history_instances) > 0)
 			{
-				require_once 'Services/UIComponent/Modal/classes/class.ilModalGUI.php';
 				$modal = ilModalGUI::getInstance();
 				$modal->setHeading($this->lng->txt('restore_draft_from_autosave'));
 				$modal->setId('frm_autosave_restore');
@@ -5891,8 +5867,7 @@ $this->doCaptchaCheck();
 	
 	public function doCaptchaCheck()
 	{
-		require_once 'Services/Captcha/classes/class.ilCaptchaUtil.php';
-		if($this->user->isAnonymous() 
+		if($this->user->isAnonymous()
 			&& !$this->user->isCaptchaVerified() 
 			&& ilCaptchaUtil::isActiveForForum())
 		{

--- a/Modules/Forum/classes/class.ilObjForumGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumGUI.php
@@ -262,7 +262,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 				$this->setSideBlocks();
 				$this->tabs->activateTab("forums_threads");
 				$this->ctrl->setReturn($this,'view');
-				include_once './Services/Search/classes/class.ilRepositoryObjectSearchGUI.php';
 				$search_gui = new ilRepositoryObjectSearchGUI(
 					$this->object->getRefId(),
 					$this,
@@ -296,7 +295,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 				break;
 
 			case 'ilpublicuserprofilegui':				
-				include_once 'Services/User/classes/class.ilPublicUserProfileGUI.php';
 				$profile_gui = new ilPublicUserProfileGUI((int)$_GET['user']);
 				$add = $this->getUserProfileAdditional((int)$_GET['ref_id'], (int)$_GET['user']);
 				$profile_gui->setAdditional($add);
@@ -305,7 +303,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 				break;
 				
 			case 'ilobjectcopygui':
-				include_once 'Services/Object/classes/class.ilObjectCopyGUI.php';
 				$cp = new ilObjectCopyGUI($this);
 				$cp->setType('frm');
 				$this->ctrl->forwardCommand($cp);
@@ -313,7 +310,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 
 			case 'ilexportgui':
 				$this->tabs->activateTab('export');
-				include_once 'Services/Export/classes/class.ilExportGUI.php';
 				$exp = new ilExportGUI($this);
 				$exp->addFormat('xml');
 				$this->ctrl->forwardCommand($exp);
@@ -558,7 +554,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 		}
 
 		// Mark all topics as read button
-		include_once 'Services/Accessibility/classes/class.ilAccessKeyGUI.php';
 		if($this->user->getId() != ANONYMOUS_USER_ID && !(int)strlen($this->confirmation_gui_html))
 		{
 			$this->toolbar->addButton(
@@ -572,7 +567,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 
 		if(ilForumPostDraft::isSavePostDraftAllowed())
 		{
-			include_once './Modules/Forum/classes/class.ilForumDraftsTableGUI.php';
 			$drafts_tbl = new ilForumDraftsTableGUI($this, $cmd, '');
 			$draft_instances = ilForumPostDraft::getThreadDraftData($this->user->getId(), ilObjForum::lookupForumIdByObjId($this->object->getId()));
 			if(count($draft_instances)> 0)
@@ -595,7 +589,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 			$frm->setMDB2WhereCondition('top_pk = %s ', array('integer'), array($topicData['top_pk']));
 			$frm->updateVisits($topicData['top_pk']);
 
-			include_once 'Modules/Forum/classes/class.ilForumTopicTableGUI.php';
 			if(!in_array($cmd, array('showThreads', 'sortThreads') ))
 			{
 				$cmd = 'showThreads';
@@ -608,7 +601,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 		}
 
 		// Permanent link
-		include_once 'Services/PermanentLink/classes/class.ilPermanentLinkGUI.php';
 		$permalink = new ilPermanentLinkGUI('frm', $this->object->getRefId());
 		$this->tpl->setVariable('PRMLINK', $permalink->getHTML());
 	}
@@ -663,7 +655,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 						
 						$this->tpl->setCurrentBlock('attachments');
 						$this->tpl->setVariable('TXT_ATTACHMENTS_DOWNLOAD', $this->lng->txt('forums_attachments'));
-						include_once("./Services/UIComponent/Glyph/classes/class.ilGlyphGUI.php");
 						$this->tpl->setVariable('DOWNLOAD_IMG', ilGlyphGUI::get(ilGlyphGUI::ATTACHMENT, $this->lng->txt('forums_download_attachment')));
 						if(count($filesOfDraft) > 1)
 						{
@@ -862,7 +853,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 				}
 				$this->tpl->setCurrentBlock('attachments');
 				$this->tpl->setVariable('TXT_ATTACHMENTS_DOWNLOAD', $this->lng->txt('forums_attachments'));
-				include_once("./Services/UIComponent/Glyph/classes/class.ilGlyphGUI.php");
 				$this->tpl->setVariable('DOWNLOAD_IMG', ilGlyphGUI::get(ilGlyphGUI::ATTACHMENT, $this->lng->txt('forums_download_attachment')));
 				if(count($filesOfPost) > 1)
 				{
@@ -1328,14 +1318,12 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 				$_GET['cmd'] = 'viewThread';
 				$_GET['baseClass'] = 'ilRepositoryGUI';
 
-				include_once('ilias.php');
 				exit();
 			}
 			else
 			{
 				$_GET['ref_id'] = $a_target;
 				$_GET['baseClass'] = 'ilRepositoryGUI';
-				include_once('ilias.php');
 				exit();
 			}
 		}
@@ -1346,7 +1334,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 			ilUtil::sendInfo(sprintf($lng->txt('msg_no_perm_read_item'),
 				ilObject::_lookupTitle(ilObject::_lookupObjId($a_target))), true);
 			$_GET['baseClass'] = 'ilRepositoryGUI';
-			include('ilias.php');
 			exit();
 		}
 
@@ -1417,7 +1404,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 			return $this->showThreadsObject();
 		}
 	 	
-	 	include_once('Services/Utilities/classes/class.ilConfirmationGUI.php');
 		$c_gui = new ilConfirmationGUI();
 		
 		$c_gui->setFormAction($this->ctrl->getFormAction($this, 'performDeleteThreads'));
@@ -1445,7 +1431,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 			return $this->showThreadsObject();
 		}
 		
-		include_once('Services/Utilities/classes/class.ilConfirmationGUI.php');
 		$c_gui = new ilConfirmationGUI();
 		
 		$c_gui->setFormAction($this->ctrl->getFormAction($this, 'deleteThreadDrafts'));
@@ -1848,7 +1833,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 		$this->replyEditForm->addItem($oPostGUI);
 
 		// notification only if gen. notification is disabled and forum isn't anonymous
-		include_once 'Services/Mail/classes/class.ilMail.php';
 		$umail = new ilMail($this->user->getId());
 		if($this->rbac->system()->checkAccess('internal_mail', $umail->getMailObjectReferenceId()) &&
 		   !$frm->isThreadNotificationEnabled($this->user->getId(), $this->objCurrentPost->getThreadId()) &&
@@ -1947,7 +1931,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 
 		if($_GET['action'] == 'showreply' || $_GET['action'] == 'ready_showreply' || $_GET['action'] == 'editdraft')
 		{
-			include_once 'Services/RTE/classes/class.ilRTE.php';
 			$rtestring = ilRTE::_getRTEClassname();
 			
 			if(array_key_exists('show_rte', $_POST))
@@ -2364,7 +2347,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 				}				
 
 				// remove usage of deleted media objects
-				include_once 'Services/MediaObjects/classes/class.ilObjMediaObject.php';
 				$oldMediaObjects = ilObjMediaObject::_getMobsOfObject('frm:html', $this->objCurrentPost->getId());
 				$curMediaObjects = ilRTE::_getMediaObjects($oReplyEditForm->getInput('message'), 0);
 				foreach($oldMediaObjects as $oldMob)
@@ -2422,7 +2404,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 					$this->objCurrentPost->reload();
 					
 					// Change news item accordingly
-					include_once 'Services/News/classes/class.ilNewsItem.php';
 					// note: $this->objCurrentPost->getForumId() does not give us the forum ID here (why?)
 					$news_id = ilNewsItem::getFirstNewsIdForContext($forumObj->getId(),
 						'frm', $this->objCurrentPost->getId(), 'pos');
@@ -2650,7 +2631,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 		{
 			try
 			{
-				include_once 'Services/MediaObjects/classes/class.ilObjMediaObject.php';
 				$mobs = ilObjMediaObject::_getMobsOfObject('frm~:html', $this->user->getId());
 				foreach($mobs as $mob)
 				{					
@@ -2733,8 +2713,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 			/** @var $menutpl ilTemplate */
 			$menutpl = new ilTemplate('tpl.forums_threads_menu.html', true, true, 'Modules/Forum');
 
-			include_once("./Services/Accessibility/classes/class.ilAccessKeyGUI.php");
-			
 			// mark all as read
 			if($this->user->getId() != ANONYMOUS_USER_ID &&
 				$forumObj->getCountUnread($this->user->getId(), (int) $this->objCurrentTopic->getId())
@@ -3209,8 +3187,7 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 		$bottom_toolbar->addButtonInstance($to_top_button);
 		$this->tpl->setVariable('TOOLBAR_BOTTOM', $bottom_toolbar->getHTML());
 
-		include_once 'Services/PermanentLink/classes/class.ilPermanentLinkGUI.php';
-		$permalink = new ilPermanentLinkGUI('frm', $this->object->getRefId(), '_'.$this->objCurrentTopic->getId());		
+		$permalink = new ilPermanentLinkGUI('frm', $this->object->getRefId(), '_'.$this->objCurrentTopic->getId());
 		$this->tpl->setVariable('PRMLINK', $permalink->getHTML());
 
 		$this->tpl->addOnLoadCode('$(".ilFrmPostContent img").each(function() {
@@ -3283,7 +3260,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 	
 	public function showUserObject()
 	{
-		include_once 'Services/User/classes/class.ilPublicUserProfileGUI.php';
 		$profile_gui = new ilPublicUserProfileGUI($_GET['user']);
 		$add = $this->getUserProfileAdditional($_GET['ref_id'], $_GET['user']);
 		$profile_gui->setAdditional($add);
@@ -3708,8 +3684,7 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 				}
 			}
 		}
-		
-		include_once 'Services/Mail/classes/class.ilMail.php';
+
 		$umail = new ilMail($this->user->getId());
 		// catch hack attempts
 		if($this->rbac->system()->checkAccess('internal_mail', $umail->getMailObjectReferenceId()) &&
@@ -4055,7 +4030,6 @@ $this->doCaptchaCheck();
 										array('integer', 'text'), array($topicData['top_pk'], $this->create_topic_form_gui->getInput('subject')));
 			
 			// copy temporary media objects (frm~)
-			include_once 'Services/MediaObjects/classes/class.ilObjMediaObject.php';
 			$mediaObjects = ilRTE::_getMediaObjects($this->create_topic_form_gui->getInput('message'), 0);
 			foreach($mediaObjects as $mob)
 			{
@@ -4288,7 +4262,6 @@ $this->doCaptchaCheck();
 			$this->error->raiseError($this->lng->txt('msg_no_perm_read'), $this->error->MESSAGE);
 		}
 
-		include_once 'Services/InfoScreen/classes/class.ilInfoScreenGUI.php';
 		$info = new ilInfoScreenGUI($this);
 
 		$info->enablePrivateNotes();
@@ -4421,9 +4394,7 @@ $this->doCaptchaCheck();
 		}
 		
 		if($this->isParentObjectCrsOrGrp())
-		{	
-
-			include_once 'Modules/Forum/classes/class.ilForumNotification.php';
+		{
 
 			$frm_noti = new ilForumNotification((int) $_GET['ref_id']);
 			$frm_noti->setUserId($this->user->getId());
@@ -4462,7 +4433,6 @@ $this->doCaptchaCheck();
 			return;
 		}
 
-		include_once './Services/PersonalDesktop/classes/class.ilDesktopItemGUI.php';
 		ilDesktopItemGUI::addToDesktop();
 		ilUtil::sendSuccess($this->lng->txt("added_to_desktop"));
 		$this->showThreadsObject();
@@ -4479,7 +4449,6 @@ $this->doCaptchaCheck();
 			return;
 		}
 
-		include_once './Services/PersonalDesktop/classes/class.ilDesktopItemGUI.php';
 		ilDesktopItemGUI::removeFromDesktop();
 		ilUtil::sendSuccess($this->lng->txt("removed_from_desktop"));
 		$this->showThreadsObject();
@@ -4548,7 +4517,6 @@ $this->doCaptchaCheck();
 			$topicData = $frm->getOneTopic();
 			if($topicData)
 			{
-				include_once 'Modules/Forum/classes/class.ilForumTopicTableGUI.php';
 				$this->ctrl->setParameter($this, 'merge_thread_id', $selected_thread_id);
 				$tbl = new ilForumTopicTableGUI($this, 'mergeThreads', '', (int)$_GET['ref_id'], $topicData, $this->is_moderator, $this->forum_overview_setting);
 				$tbl->setSelectedThread($selected_thread_obj);
@@ -4603,9 +4571,8 @@ $this->doCaptchaCheck();
 		if(ilForumTopic::_lookupDate($source_thread_id) < ilForumTopic::_lookupDate($target_thread_id))
 		{
 			ilUtil::sendInfo($this->lng->txt('switch_threads_for_merge'));
-		}	
-		
-		include_once 'Services/Utilities/classes/class.ilConfirmationGUI.php';
+		}
+
 		$c_gui = new ilConfirmationGUI();
 
 		$c_gui->setFormAction($this->ctrl->getFormAction($this, 'performMergeThreads'));
@@ -5190,7 +5157,6 @@ $this->doCaptchaCheck();
 	protected function deleteMobsOfDraft($draft_id, $message)
 	{
 		// remove usage of deleted media objects
-		include_once 'Services/MediaObjects/classes/class.ilObjMediaObject.php';
 		$oldMediaObjects = ilObjMediaObject::_getMobsOfObject('frm~d:html', $draft_id);
 		$curMediaObjects = ilRTE::_getMediaObjects($message, 0);
 		foreach($oldMediaObjects as $oldMob)
@@ -5830,7 +5796,6 @@ $this->doCaptchaCheck();
 				$modal->setHeading($this->lng->txt('restore_draft_from_autosave'));
 				$modal->setId('frm_autosave_restore');
 				$form_tpl = new ilTemplate('tpl.restore_thread_draft.html', true, true, 'Modules/Forum');
-				include_once  './Services/Accordion/classes/class.ilAccordionGUI.php';
 
 				foreach($history_instances as $key => $history_instance)
 				{

--- a/Modules/Forum/classes/class.ilObjForumGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumGUI.php
@@ -1,22 +1,12 @@
 <?php
 /* Copyright (c) 1998-2012 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Modules/Forum/classes/class.ilForumSettingsGUI.php';
 require_once 'Services/Object/classes/class.ilObjectGUI.php';
 require_once 'Services/Table/classes/class.ilTable2GUI.php';
-require_once 'Modules/Forum/classes/class.ilForumProperties.php';
 require_once 'Services/Form/classes/class.ilPropertyFormGUI.php';
-require_once 'Modules/Forum/classes/class.ilForumPost.php';
-require_once 'Modules/Forum/classes/class.ilForum.php';
-require_once 'Modules/Forum/classes/class.ilForumTopic.php';
 require_once 'Services/RTE/classes/class.ilRTE.php';
 require_once 'Services/PersonalDesktop/interfaces/interface.ilDesktopItemHandling.php';
-require_once 'Modules/Forum/classes/class.ilForumMailNotification.php';
 require_once 'Services/UIComponent/SplitButton/classes/class.ilSplitButtonGUI.php';
-require_once 'Modules/Forum/classes/class.ilForumPostDraft.php';
-require_once './Modules/Forum/classes/class.ilFileDataForumDrafts.php';
-require_once './Modules/Forum/classes/class.ilForumUtil.php';
-require_once './Modules/Forum/classes/class.ilForumDraftsHistory.php';
 require_once 'Services/MediaObjects/classes/class.ilObjMediaObject.php';
 
 /**
@@ -296,14 +286,12 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 				break;
 
 			case 'ilforumexportgui':
-				require_once 'Modules/Forum/classes/class.ilForumExportGUI.php';
 				$fex_gui = new ilForumExportGUI();
 				$this->ctrl->forwardCommand($fex_gui);
 				exit();
 				break;
 			
 			case 'ilforummoderatorsgui':
-				require_once 'Modules/Forum/classes/class.ilForumModeratorsGUI.php';
 				$fm_gui = new ilForumModeratorsGUI();
 				$this->ctrl->forwardCommand($fm_gui);
 				break;
@@ -723,7 +711,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 				$this->ctrl->setParameter($this, 'thr_pk', $node->getThreadId());
 				$this->ctrl->setParameter($this, 'user', $draft->getPostDisplayUserId());
 				
-				require_once 'Modules/Forum/classes/class.ilForumAuthorInformation.php';
 				$authorinfo = new ilForumAuthorInformation(
 					$draft->getPostAuthorId(),
 					$draft->getPostDisplayUserId(),
@@ -780,7 +767,7 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 					$this->ctrl->setParameter($this, 'thr_pk', $node->getThreadId());
 					$this->ctrl->setParameter($this, 'user', $node->getUpdateUserId());
 					$this->ctrl->setParameter($this, 'draft_id', $draft->getDraftId());
-					require_once 'Modules/Forum/classes/class.ilForumAuthorInformation.php';
+
 					$authorinfo = new ilForumAuthorInformation(
 						$draft->getPostAuthorId(),
 						$draft->getUpdateUserId(),
@@ -974,7 +961,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 		$this->ctrl->setParameter($this, 'thr_pk', $node->getThreadId());
 		$this->ctrl->setParameter($this, 'user', $node->getDisplayUserId());
 		
-		require_once 'Modules/Forum/classes/class.ilForumAuthorInformation.php';
 		$authorinfo = new ilForumAuthorInformation(
 			$node->getPosAuthorId(),
 			$node->getDisplayUserId(),
@@ -1035,8 +1021,8 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 			&& $node->getDisplayUserId() == 0)
 			{
 				$update_user_id = $node->getDisplayUserId();
-			}	
-			require_once 'Modules/Forum/classes/class.ilForumAuthorInformation.php';
+			}
+
 			$authorinfo = new ilForumAuthorInformation(
 				$node->getPosAuthorId(),
 				$update_user_id,
@@ -1292,9 +1278,7 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 		}
 		
 		$this->object->Forum->setForumId($this->object->getId());
-		
-		require_once 'Modules/Forum/classes/class.ilForumStatisticsTableGUI.php';
-		
+
 		$tbl = new ilForumStatisticsTableGUI($this, 'showStatistics');
 		$tbl->setId('il_frm_statistic_table_'.(int) $_GET['ref_id']);
 		$tbl->setTitle($this->lng->txt('statistic'), 'icon_usr.svg', $this->lng->txt('obj_'.$this->object->getType()));
@@ -1394,8 +1378,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 	 		ilUtil::sendInfo($this->lng->txt('select_at_least_one_thread'));
 	 		return $this->showThreadsObject();
 	 	}	
-
-		require_once 'Modules/Forum/classes/class.ilObjForum.php';
 
 		$forumObj = new ilObjForum($_GET['ref_id']);
 		
@@ -2569,7 +2551,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 		 */
 		$frm = $oForumObjects['frm'];
 
-		require_once 'Modules/Forum/classes/class.ilForumAuthorInformation.php';
 		$authorinfo = new ilForumAuthorInformation(
 			$this->objCurrentPost->getPosAuthorId(),
 			$this->objCurrentPost->getDisplayUserId(),
@@ -2705,7 +2686,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 
 		if($this->isHierarchicalView())
 		{
-			require_once 'Modules/Forum/classes/class.ilForumExplorerGUI.php';
 			$exp = new ilForumExplorerGUI('frm_exp_' . $this->objCurrentTopic->getId(), $this, 'viewThread');
 			$exp->setThread($this->objCurrentTopic);
 			if(!$exp->handleCommand())
@@ -2714,9 +2694,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 			}
 		}
 
-		require_once './Modules/Forum/classes/class.ilObjForum.php';
-		require_once './Modules/Forum/classes/class.ilFileDataForum.php';		
-		
 		$this->lng->loadLanguageModule('forum');
 
 		// add entry to navigation history
@@ -3041,7 +3018,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 										}										
 										else if($this->ctrl->getCmd() == 'quotePost')
 										{
-											require_once 'Modules/Forum/classes/class.ilForumAuthorInformation.php';
 											$authorinfo = new ilForumAuthorInformation(
 												$node->getPosAuthorId(),
 												$node->getDisplayUserId(),
@@ -3188,7 +3164,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 				}
 				else if($this->ctrl->getCmd() == 'quoteTopLevelPost')
 				{
-					require_once 'Modules/Forum/classes/class.ilForumAuthorInformation.php';
 					$authorinfo = new ilForumAuthorInformation(
 						$first_node->getPosAuthorId(),
 						$first_node->getDisplayUserId(),
@@ -3585,7 +3560,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling
 			$this->ctrl->redirect($this, 'showThreads');
 		}
 
-		require_once 'Modules/Forum/classes/class.ilForumMoveTopicsExplorer.php';
 		$exp = new ilForumMoveTopicsExplorer($this, 'moveThreads');
 		$exp->setPathOpen($this->object->getRefId());
 		$exp->setNodeSelected(isset($_POST['frm_ref_id']) && (int)$_POST['frm_ref_id'] ? (int)$_POST['frm_ref_id'] : 0);

--- a/Modules/Forum/classes/class.ilObjForumListGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumListGUI.php
@@ -164,7 +164,6 @@ class ilObjForumListGUI extends ilObjectListGUI
 				ilObjForumAccess::prepareMessageForLists($last_post['pos_message']) . "</a> " .
 				strtolower($this->lng->txt('from')) . "&nbsp;";
 
-			require_once 'Modules/Forum/classes/class.ilForumAuthorInformation.php';
 			$authorinfo = new ilForumAuthorInformation(
 				$last_post['pos_author_id'],
 				$last_post['pos_display_user_id'],

--- a/Modules/Forum/classes/class.ilObjForumListGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumListGUI.php
@@ -1,8 +1,6 @@
 <?php
 /* Copyright (c) 1998-2012 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-include_once 'Services/Object/classes/class.ilObjectListGUI.php';
-
 /**
  * Class ilObjForumListGUI
  * @author  Alex Killing <alex.killing@gmx.de>
@@ -59,7 +57,6 @@ class ilObjForumListGUI extends ilObjectListGUI
 		$this->gui_class_name      = 'ilobjforumgui';
 
 		// general commands array
-		include_once 'Modules/Forum/classes/class.ilObjForumAccess.php';
 		$this->commands = ilObjForumAccess::_getCommands();
 	}
 
@@ -77,12 +74,10 @@ class ilObjForumListGUI extends ilObjectListGUI
 
 		$props = array();
 
-		include_once 'Modules/Forum/classes/class.ilObjForumAccess.php';
 		$properties       = ilObjForumAccess::getStatisticsByRefId($this->ref_id);
 		$num_posts_total  = $properties['num_posts'];
 		$num_unread_total = $properties['num_unread_posts'];
 
-		include_once 'Modules/Forum/classes/class.ilForumPostDraft.php';
 		$num_drafts_total = 0;
 		if(ilForumPostDraft::isSavePostDraftAllowed())
 		{
@@ -140,7 +135,6 @@ class ilObjForumListGUI extends ilObjectListGUI
 			);
 		}
 
-		include_once 'Modules/Forum/classes/class.ilForumProperties.php';
 		if($this->getDetailsLevel() == ilObjectListGUI::DETAILS_ALL)
 		{
 			if(ilForumProperties::getInstance($this->obj_id)->isAnonymized())

--- a/Modules/Forum/classes/class.ilObjForumNotificationDataProvider.php
+++ b/Modules/Forum/classes/class.ilObjForumNotificationDataProvider.php
@@ -1,9 +1,6 @@
 <?php
 /* Copyright (c) 1998-2015 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-include_once './Modules/Forum/interfaces/interface.ilForumNotificationMailData.php';
-include_once './Modules/Forum/classes/class.ilForumProperties.php';
-
 /**
  * Class ilObjForumNotificationDataProvider
  * @author Nadia Matuschek <nmatuschek@databay.de>
@@ -462,7 +459,6 @@ class ilObjForumNotificationDataProvider implements ilForumNotificationMailData
 		));
 
 		if (false === $this->notificationCache->exists($cacheKey)) {
-			include_once './Modules/Forum/classes/class.ilForumPost.php';
 			$parent_objPost = new ilForumPost($this->objPost->getParentId());
 
 			$this->notificationCache->store($cacheKey, $parent_objPost);
@@ -486,7 +482,6 @@ class ilObjForumNotificationDataProvider implements ilForumNotificationMailData
 		));
 
 		if (false === $this->notificationCache->exists($cacheKey)) {
-			include_once './Modules/Forum/classes/class.ilForum.php';
 			// get moderators to notify about needed activation
 			$rcps = ilForum::_getModerators($this->getRefId());
 			$this->notificationCache->store($cacheKey, $rcps);

--- a/Modules/Forum/classes/class.ilObjForumNotificationDataProvider.php
+++ b/Modules/Forum/classes/class.ilObjForumNotificationDataProvider.php
@@ -382,7 +382,6 @@ class ilObjForumNotificationDataProvider implements ilForumNotificationMailData
 			$fileDataForum = new ilFileDataForum($this->getObjId(), $this->objPost->getId());
 			$filesOfPost   = $fileDataForum->getFilesOfPost();
 			
-			require_once 'Services/Mail/classes/class.ilFileDataMail.php';
 			$fileDataMail = new ilFileDataMail(ANONYMOUS_USER_ID);
 			
 			foreach($filesOfPost as $attachment)

--- a/Modules/Forum/classes/class.ilObjForumNotificationDataProvider.php
+++ b/Modules/Forum/classes/class.ilObjForumNotificationDataProvider.php
@@ -379,7 +379,6 @@ class ilObjForumNotificationDataProvider implements ilForumNotificationMailData
 	{
 		if(ilForumProperties::isSendAttachmentsByMailEnabled())
 		{
-			require_once 'Modules/Forum/classes/class.ilFileDataForum.php';
 			$fileDataForum = new ilFileDataForum($this->getObjId(), $this->objPost->getId());
 			$filesOfPost   = $fileDataForum->getFilesOfPost();
 			

--- a/Modules/Forum/classes/class.ilObjForumSearchResultTableGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumSearchResultTableGUI.php
@@ -1,8 +1,6 @@
 <?php
 /* Copyright (c) 1998-2015 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/Search/classes/class.ilRepositoryObjectSearchResultTableGUI.php';
-
 /**
  * Class ilObjForumSearchResultTableGUI
  */

--- a/Modules/Forum/classes/class.ilObjForumSubItemListGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumSubItemListGUI.php
@@ -1,8 +1,6 @@
 <?php
 /* Copyright (c) 1998-2012 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-include_once './Services/Object/classes/class.ilSubItemListGUI.php';
-
 /** 
 * Show forum threads
 * 
@@ -37,7 +35,6 @@ class ilObjForumSubItemListGUI extends ilSubItemListGUI
 			$this->getItemListGUI()->setChildId($sub_item);
 			$this->tpl->setVariable('LINK',$this->getItemListGUI()->getCommandLink('thread'));
 			$this->tpl->setVariable('TARGET',$this->getItemListGUI()->getCommandFrame(''));
-			include_once './Modules/Forum/classes/class.ilObjForum.php';
 			$this->tpl->setVariable('TITLE',ilObjForum::_lookupThreadSubject($sub_item));
 			
 			// begin-patch mime_filter

--- a/Services/WebDAV/classes/class.ilDiskQuotaChecker.php
+++ b/Services/WebDAV/classes/class.ilDiskQuotaChecker.php
@@ -345,7 +345,6 @@ class ilDiskQuotaChecker
 		require_once 'Modules/File/classes/class.ilObjFileAccess.php';
 		self::__updateDiskUsageReportOfType(new ilObjFileAccess(), 'file');
 
-		require_once 'Modules/Forum/classes/class.ilObjForumAccess.php';
 		self::__updateDiskUsageReportOfType(new ilObjForumAccess(), 'frm');
 
 		require_once 'Modules/HTMLLearningModule/classes/class.ilObjFileBasedLMAccess.php';


### PR DESCRIPTION
"Why this PR" you may ask? Good question.

1. We are using the composer autoloader that takes care of loading the files.
2. I wanted to add subfolders to create a better overview over the classes and its purposes
3. It reduces the code \o/