### PR TITLE
Make ilDBPdo.nextId() abstract.

### DIFF
--- a/Services/Database/classes/PDO/class.ilDBPdo.php
+++ b/Services/Database/classes/PDO/class.ilDBPdo.php
@@ -235,30 +235,7 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface {
 	 *
 	 * @return int
 	 */
-	public function nextId($table_name) {
-		$sequence_table_name = $table_name . '_seq';
-
-		$last_insert_id = $this->pdo->lastInsertId($table_name);
-		if ($last_insert_id) {
-			//			return $last_insert_id;
-		}
-
-		if ($this->tableExists($sequence_table_name)) {
-			$stmt = $this->pdo->prepare("SELECT sequence FROM $sequence_table_name");
-			$stmt->execute();
-			$rows = $stmt->fetch(PDO::FETCH_ASSOC);
-			$stmt->closeCursor();
-			$next_id = $rows['sequence'] + 1;
-			$stmt = $this->pdo->prepare("DELETE FROM $sequence_table_name");
-			$stmt->execute(array("next_id" => $next_id));
-			$stmt = $this->pdo->prepare("INSERT INTO $sequence_table_name (sequence) VALUES (:next_id)");
-			$stmt->execute(array("next_id" => $next_id));
-
-			return $next_id;
-		}
-
-		return 1;
-	}
+	abstract public function nextId($table_name);
 
 
 	/**


### PR DESCRIPTION
I'm currently working on transaction safety for the test module and came across this by accident.

`ilDBPdo.nextId()` offers an implementation to get a sequence number, even though all inheritants (`ilDBPdoMySQL`, `ilDBPdoPostgreSQL`) implement their custom, better `nextId` methods. Furthermore:

(1) the code in `ilDBPdo.nextId()` seems unfinished, as there's a call to `lastInsertId` that isn't used.
(2) the code is highly inefficient as `DELETE FROM` will cause a full table lock that will cause a lot of transactions to deadlock (once transactions are used)

Instead, `ilDBPdoMySQL` and `ilDBPdoPostgreSQL` should implement highly optimized versions of sequence getters that use specific features of their databases in order to work around transaction deadlocks.