### PR TITLE
Correctly lock calls to removeIntermediateSolution.

### DIFF
--- a/Modules/Test/classes/class.ilTestOutputGUI.php
+++ b/Modules/Test/classes/class.ilTestOutputGUI.php
@@ -420,10 +420,8 @@ abstract class ilTestOutputGUI extends ilTestPlayerAbstractGUI
 				$this->getCurrentSequenceElement()
 			);
 
-			$this->getQuestionInstance($questionId)->removeIntermediateSolution(
-				$this->testSession->getActiveId(), $this->testSession->getPass()
-			);
-			
+			$this->removeIntermediateSolution();
+
 			$nextSequenceElement = $this->testSequence->getNextSequence($this->getCurrentSequenceElement());
 
 			if(!$this->isValidSequenceElement($nextSequenceElement))
@@ -448,10 +446,8 @@ abstract class ilTestOutputGUI extends ilTestPlayerAbstractGUI
 			$questionId = $this->testSequence->getQuestionForSequence(
 				$this->getCurrentSequenceElement()
 			);
-			
-			$this->getQuestionInstance($questionId)->removeIntermediateSolution(
-				$this->testSession->getActiveId(), $this->testSession->getPass()
-			);
+
+			$this->removeIntermediateSolution();
 
 			if( $this->object->isForceInstantFeedbackEnabled() )
 			{

--- a/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -176,9 +176,12 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
 	public function removeIntermediateSolution()
 	{
 		$questionId = $this->getCurrentQuestionId();
-		return $this->getQuestionInstance($questionId)->removeIntermediateSolution(
-			$this->testSession->getActiveId(), $this->testSession->getPass()
-		);
+		$question = $this->getQuestionInstance($questionId);
+		$question->getProcessLocker()->executeUserSolutionUpdateLockOperation(function() use ($question) {
+			return $question->removeIntermediateSolution(
+				$this->testSession->getActiveId(), $this->testSession->getPass()
+			);
+		});
 	}
 // fau.
 


### PR DESCRIPTION
In the test module, some UI calls to `removeIntermediateSolution` are sometimes not correctly locked using the test module's process locker strategy, but are instead performed without locking.

For example, look at this stack trace from ILIAS 5.3.10:

```
#12 ilDBPdo:manipulate in /var/www/html/ILIAS/Services/Database/classes/PDO/class.ilDBPdo.php:1044
#11 ilDBPdo:manipulateF in /var/www/html/ILIAS/Modules/TestQuestionPool/classes/class.assQuestion.php:4961
#10 assQuestion:removeCurrentSolution in /var/www/html/ILIAS/Modules/TestQuestionPool/classes/class.assQuestion.php:4920
#9 assQuestion:removeIntermediateSolution in /var/www/html/ILIAS/Modules/Test/classes/class.ilTestOutputGUI.php:447
#8 ilTestOutputGUI:submitSolutionCmd in /var/www/html/ILIAS/Modules/Test/classes/class.ilTestOutputGUI.php:143
#7 ilTestOutputGUI:executeCommand in /var/www/html/ILIAS/Services/UICore/classes/class.ilCtrl.php:197
#6 ilCtrl:forwardCommand in /var/www/html/ILIAS/Modules/Test/classes/class.ilObjTestGUI.php:212
#5 ilObjTestGUI:executeCommand in /var/www/html/ILIAS/Services/UICore/classes/class.ilCtrl.php:197
#4 ilCtrl:forwardCommand in /var/www/html/ILIAS/Services/Repository/classes/class.ilRepositoryGUI.php:402
#3 ilRepositoryGUI:show in /var/www/html/ILIAS/Services/Repository/classes/class.ilRepositoryGUI.php:356
#2 ilRepositoryGUI:executeCommand in /var/www/html/ILIAS/Services/UICore/classes/class.ilCtrl.php:197
#1 ilCtrl:forwardCommand in /var/www/html/ILIAS/Services/UICore/classes/class.ilCtrl.php:159
#0 ilCtrl:callBaseClass in /var/www/html/ILIAS/ilias.php:21
```

In some configurations (like enabling full transactions for the test module, which I'm currently working on), this will lead to various database exceptions. In standard ILIAS installations, this just allows operations on the test tables to run without a lock, even though a lock is configured.

This PR adds a lock to `ilTestPlayerAbstractGUI.removeIntermediateSolution`.

I tested this change using TestILIAS with the standard "use database locks" setting in the test settings and didn't experience any problems (e.g. deadlocks).

