### PR TITLE
Possible Fix [23757]: Check if thread_Id is still valid.

### DIFF
--- a/Modules/Forum/classes/class.ilObjForumNotificationDataProvider.php
+++ b/Modules/Forum/classes/class.ilObjForumNotificationDataProvider.php
@@ -404,6 +404,10 @@ class ilObjForumNotificationDataProvider implements ilForumNotificationMailData
 	 */
 	public function getThreadNotificationRecipients()
 	{
+        $rcps = array();
+        if($this->getThreadId() == 0) {
+            return $rcps;
+        }
 		// GET USERS WHO WANT TO BE INFORMED ABOUT NEW POSTS
 		$res = $this->db->queryf('
 			SELECT user_id FROM frm_notification 
@@ -414,7 +418,6 @@ class ilObjForumNotificationDataProvider implements ilForumNotificationMailData
 
 		// get all references of obj_id
 		$frm_references = ilObject::_getAllReferences($this->getObjId());
-		$rcps = array();
 		while($row = $this->db->fetchAssoc($res))
 		{
 			// do rbac check before sending notification


### PR DESCRIPTION
This fix checks if the thread is still present at that specific time. If the thread has been deleted in the meantime getThreadId() returns 0. Requesting all users with thread_id == 0 leads to getting all possible users of all regular forums (in "frm_notification" table if "thread_id" == 0 then "frm_id" != 0). This behaviour is unintended and wrong. If inside the getThreadNotificationRecipients function the thread_id is 0 then return an empty recipients array.