### PR TITLE
UI: Strip Tags in New Input Implementation

### DIFF
--- a/src/UI/Implementation/Component/Input/Field/Input.php
+++ b/src/UI/Implementation/Component/Input/Field/Input.php
@@ -427,6 +427,9 @@ abstract class Input implements C\Input\Field\Input, InputInternal {
 	 * @inheritdoc
 	 */
 	final public function getContent() {
+		if (is_null($this->content)) {
+			throw new \LogicException("No content of this field has been evaluated yet. Seems withInput was not called.");
+		}
 		return $this->content;
 	}
 }

--- a/src/UI/Implementation/Component/Input/Field/InputInternal.php
+++ b/src/UI/Implementation/Component/Input/Field/InputInternal.php
@@ -45,7 +45,7 @@ interface InputInternal {
 	/**
 	 * Get the current content of the input.
 	 *
-	 * @return    Result|null
+	 * @return    Result
 	 */
 	public function getContent();
 }

--- a/src/UI/Implementation/Component/Input/Field/Text.php
+++ b/src/UI/Implementation/Component/Input/Field/Text.php
@@ -5,11 +5,29 @@
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
 use ILIAS\UI\Component as C;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Transformation\Factory as TransformationFactory;
+use ILIAS\Validation\Factory as ValidationFactory;
 
 /**
  * This implements the text input.
  */
 class Text extends Input implements C\Input\Field\Text {
+	/**
+	 * @inheritdoc
+	 */
+	public function __construct(
+		DataFactory $data_factory,
+		ValidationFactory $validation_factory,
+		TransformationFactory $transformation_factory,
+		$label,
+		$byline
+	) {
+		parent::__construct($data_factory, $validation_factory, $transformation_factory, $label, $byline);
+		$this->setAdditionalTransformation($transformation_factory->custom(function($v) {
+			return strip_tags($v);
+		}));
+	}
 
 	/**
 	 * @inheritdoc

--- a/src/UI/Implementation/Component/Input/Field/Textarea.php
+++ b/src/UI/Implementation/Component/Input/Field/Textarea.php
@@ -6,16 +6,34 @@ namespace ILIAS\UI\Implementation\Component\Input\Field;
 
 use ILIAS\UI\Component as C;
 use ILIAS\UI\Implementation\Component\JavaScriptBindable;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Transformation\Factory as TransformationFactory;
+use ILIAS\Validation\Factory as ValidationFactory;
 
 /**
  * This implements the textarea input.
  */
 class Textarea extends Input implements C\Input\Field\Textarea {
-
 	use JavaScriptBindable;
 
 	protected $max_limit;
 	protected $min_limit;
+
+	/**
+	 * @inheritdoc
+	 */
+	public function __construct(
+		DataFactory $data_factory,
+		ValidationFactory $validation_factory,
+		TransformationFactory $transformation_factory,
+		$label,
+		$byline
+	) {
+		parent::__construct($data_factory, $validation_factory, $transformation_factory, $label, $byline);
+		$this->setAdditionalTransformation($transformation_factory->custom(function($v) {
+			return strip_tags($v);
+		}));
+	}
 
 	/**
 	 * set maximum number of characters

--- a/tests/UI/Component/Input/Field/InputTest.php
+++ b/tests/UI/Component/Input/Field/InputTest.php
@@ -166,7 +166,9 @@ class InputTest extends ILIAS_UI_TestBase {
 
 
 	public function test_getContent() {
-		$this->assertEquals(null, $this->input->getContent());
+		$this->expectException(\LogicException::class);
+
+		$this->input->getContent();
 	}
 
 

--- a/tests/UI/Component/Input/Field/TextInputTest.php
+++ b/tests/UI/Component/Input/Field/TextInputTest.php
@@ -134,4 +134,15 @@ class TextInputTest extends ILIAS_UI_TestBase {
 		$value2 = $text2->getContent();
 		$this->assertTrue($value2->isError());
 	}
+
+	public function test_stripsTags() {
+		$f = $this->buildFactory();
+		$name = "name_0";
+		$text = $f->text("")
+			->withNameFrom($this->name_source)
+			->withInput(new DefPostData([$name => "<script>alert()</script>"]));
+
+		$content = $text->getContent();
+		$this->assertEquals("alert()", $content->value());
+	}
 }

--- a/tests/UI/Component/Input/Field/TextareaTest.php
+++ b/tests/UI/Component/Input/Field/TextareaTest.php
@@ -245,4 +245,15 @@ class TextareaTest extends ILIAS_UI_TestBase {
 		$expected = trim(preg_replace('/\t+/', '', $expected));
 		$this->assertEquals($expected, $html);
 	}
+
+	public function test_stripsTags() {
+		$f = $this->buildFactory();
+		$name = "name_0";
+		$text = $f->textarea("")
+			->withNameFrom($this->name_source)
+			->withInput(new DefPostData([$name => "<script>alert()</script>"]));
+
+		$content = $text->getContent();
+		$this->assertEquals("alert()", $content->value());
+	}
 }


### PR DESCRIPTION
After discussing the issue of XSS-protection in the new input implementation of the UI-framework in #1189, @Amstutz and I decided to remove tags altogether in the currently available text-input-fields to allow people to use the new input implementation without the burden to think of correctly removing XSS-related input. This will break use-cases, where textarea and text field should actually be used to input HTML, but we prefer bug reports for these cases over XSS-vulnerabilities.

We will look into a proper long term solution for the use-cases that actually need some html-tags for ILIAS 6.0.

Note that this is no breaking change, thus no JF-decision etc. is required. 