### PR TITLE
Forum: Removed massive code duplication

### DIFF
--- a/Modules/Forum/classes/Actions/class.ilForumAutoSaveAsyncDraftAction.php
+++ b/Modules/Forum/classes/Actions/class.ilForumAutoSaveAsyncDraftAction.php
@@ -1,0 +1,196 @@
+<?php
+/* Copyright (c) 1998-2018 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * Class ilForumSaveAsyncDraftAction
+ * @author Nadia Matuschek <nmatuschek@databay.de>
+ */
+class ilForumAutoSaveAsyncDraftAction
+{
+	/** @var \ilObjUser */
+	private $actor;
+
+	/** @var \ilPropertyFormGUI */
+	private $form;
+
+	/** @var \ilForumProperties */
+	private $forumProperties;
+
+	/** @var \ilForumTopic */
+	private $thread;
+	
+	/** @var callable */
+	private $subjectFormatterCallable;
+
+	/** @var int */
+	private $relatedDraftId = 0;
+
+	/** @var int */
+	private $relatedPostId;
+	
+	/** @var int */
+	private $relatedForumId;
+
+	/** @var string */
+	private $action = '';
+
+	/**
+	 * ilForumAutoSaveAsyncDraftAction constructor.
+	 * @param ilObjUser $actor
+	 * @param ilPropertyFormGUI $form
+	 * @param ilForumProperties $forumProperties
+	 * @param ilForumTopic $thread
+	 * @param callable $subjectFormatterCallable
+	 * @param int $relatedDraftId
+	 * @param int $relatedForumId
+	 * @param int $relatedPostId
+	 * @param string $action
+	 */
+	public function __construct(
+		\ilObjUser $actor,
+		\ilPropertyFormGUI $form,
+		\ilForumProperties $forumProperties,
+		\ilForumTopic $thread,
+		callable $subjectFormatterCallable,
+		int $relatedDraftId,
+		int $relatedForumId,
+		int $relatedPostId,
+		string $action
+	) {
+		$this->actor = $actor;
+		$this->form = $form;
+		$this->forumProperties = $forumProperties;
+		$this->thread = $thread;
+		$this->subjectFormatterCallable = $subjectFormatterCallable;
+
+		$this->relatedDraftId = $relatedDraftId;
+		$this->relatedPostId = $relatedPostId;
+		$this->relatedForumId = $relatedForumId;
+		$this->action = $action;
+	}
+
+	/**
+	 * @return \stdClass
+	 */
+	public function executeAndGetResponseObject(): \stdClass
+	{
+		$response = new \stdClass();
+		$response->draft_id = 0;
+
+		if ($this->actor->isAnonymous() || !($this->actor->getId() > 0)) {
+			return $response;
+		}
+
+		if (!\ilForumPostDraft::isAutoSavePostDraftAllowed()) {
+			return $response;
+		}
+
+		$this->form->checkInput();
+
+		$inputValues = [];
+		$inputValues['subject'] = (string)$this->form->getInput('subject');
+		$inputValues['message'] = (string)$this->form->getInput('message');
+		$inputValues['notify'] = (int)$this->form->getInput('notify');
+		$inputValues['alias'] = (string)$this->form->getInput('alias');
+		$usrAlias = ilForumUtil::getPublicUserAlias($inputValues['alias'], $this->forumProperties->isAnonymized());
+
+		if ($this->relatedDraftId > 0) {
+			$draftId = $this->relatedDraftId;
+		} else {
+			$draftId = (int)$this->form->getInput('draft_id');
+		}
+
+		$subjectFormatterCallback = $this->subjectFormatterCallable;
+
+		if ($draftId > 0) {
+			if ('showreply' === $this->action) {
+				$draftObj = \ilForumPostDraft::newInstanceByDraftId($draftId);
+				$draftObj->setPostSubject($subjectFormatterCallback($inputValues['subject']));
+				$draftObj->setPostMessage(\ilRTE::_replaceMediaObjectImageSrc($inputValues['message'], 0));
+				$draftObj->setPostUserAlias($usrAlias);
+				$draftObj->setNotify($inputValues['notify']);
+				$draftObj->setUpdateUserId($this->actor->getId());
+				$draftObj->setPostAuthorId($this->actor->getId());
+				$draftObj->setPostDisplayUserId(($this->forumProperties->isAnonymized() ? 0 : $this->actor->getId()));
+				$draftObj->updateDraft();
+
+				$uploadedObjects = \ilObjMediaObject::_getMobsOfObject('frm~:html', $this->actor->getId());
+				$oldMediaObjects = \ilObjMediaObject::_getMobsOfObject('frm~d:html', $draftObj->getDraftId());
+				$curMediaObjects = \ilRTE::_getMediaObjects($inputValues['message'], 0);
+
+				$this->handleMedia(
+					\ilForumPostDraft::MEDIAOBJECT_TYPE, $draftObj->getDraftId(),
+					$uploadedObjects, $oldMediaObjects, $curMediaObjects
+				);
+			} else {
+				$draftObj = new \ilForumDraftsHistory();
+				$draftObj->setDraftId($draftId);
+				$draftObj->setPostSubject($subjectFormatterCallback($inputValues['subject']));
+				$draftObj->setPostMessage(\ilRTE::_replaceMediaObjectImageSrc($inputValues['message'], 0));
+				$draftObj->addDraftToHistory();
+
+				$uploadedObjects = \ilObjMediaObject::_getMobsOfObject('frm~:html', $this->actor->getId());
+				$oldMediaObjects = \ilObjMediaObject::_getMobsOfObject('frm~d:html', $draftObj->getDraftId());
+				$curMediaObjects = \ilRTE::_getMediaObjects($inputValues['message'], 0);
+
+				$this->handleMedia(
+					\ilForumDraftsHistory::MEDIAOBJECT_TYPE, $draftObj->getHistoryId(),
+					$uploadedObjects, $oldMediaObjects, $curMediaObjects
+				);
+			}
+		} else {
+			$draftObj = new \ilForumPostDraft();
+			$draftObj->setForumId($this->relatedForumId);
+			$draftObj->setThreadId($this->thread->getId());
+			$draftObj->setPostId($this->relatedPostId);
+			$draftObj->setPostSubject($subjectFormatterCallback($inputValues['subject']));
+			$draftObj->setPostMessage(\ilRTE::_replaceMediaObjectImageSrc($inputValues['message'], 0));
+			$draftObj->setPostUserAlias($usrAlias);
+			$draftObj->setNotify($inputValues['notify']);
+			$draftObj->setPostAuthorId($this->actor->getId());
+			$draftObj->setPostDisplayUserId(($this->forumProperties->isAnonymized() ? 0 : $this->actor->getId()));
+			$draftObj->saveDraft();
+
+			$uploadedObjects = \ilObjMediaObject::_getMobsOfObject('frm~:html', $this->actor->getId());
+			$oldMediaObjects = \ilObjMediaObject::_getMobsOfObject('frm~d:html', $draftObj->getDraftId());
+			$curMediaObjects = \ilRTE::_getMediaObjects($inputValues['message'], 0);
+
+			$this->handleMedia(
+				\ilForumPostDraft::MEDIAOBJECT_TYPE, $draftObj->getDraftId(),
+				$uploadedObjects, $oldMediaObjects, $curMediaObjects
+			);
+		}
+
+		$response->draft_id = $draftObj->getDraftId();
+
+		return $response;
+	}
+
+	/**
+	 * @param string $type
+	 * @param int $draftId
+	 * @param int[] $uploadedObjects
+	 * @param int[] $oldMediaObjects
+	 * @param int[] $curMediaObjects
+	 */
+	protected function handleMedia(
+		string $type,
+		int $draftId,
+		array $uploadedObjects,
+		array $oldMediaObjects,
+		array $curMediaObjects
+	) {
+		foreach ($uploadedObjects as $mob) {
+			\ilObjMediaObject::_removeUsage($mob, 'frm~:html', $this->actor->getId());
+			\ilObjMediaObject::_saveUsage($mob, $type, $draftId);
+		}
+
+		foreach ($oldMediaObjects as $mob) {
+			\ilObjMediaObject::_saveUsage($mob, $type, $draftId);
+		}
+
+		foreach ($curMediaObjects as $mob) {
+			\ilObjMediaObject::_saveUsage($mob, $type, $draftId);
+		}
+	}
+}

--- a/Modules/Forum/classes/Actions/class.ilForumAutoSaveAsyncDraftAction.php
+++ b/Modules/Forum/classes/Actions/class.ilForumAutoSaveAsyncDraftAction.php
@@ -87,12 +87,7 @@ class ilForumAutoSaveAsyncDraftAction
 
 		$this->form->checkInput();
 
-		$inputValues = [];
-		$inputValues['subject'] = (string)$this->form->getInput('subject');
-		$inputValues['message'] = (string)$this->form->getInput('message');
-		$inputValues['notify'] = (int)$this->form->getInput('notify');
-		$inputValues['alias'] = (string)$this->form->getInput('alias');
-		$usrAlias = ilForumUtil::getPublicUserAlias($inputValues['alias'], $this->forumProperties->isAnonymized());
+		$inputValues = $this->getInputValuesFromForm();
 
 		if ($this->relatedDraftId > 0) {
 			$draftId = $this->relatedDraftId;
@@ -107,7 +102,7 @@ class ilForumAutoSaveAsyncDraftAction
 				$draftObj = \ilForumPostDraft::newInstanceByDraftId($draftId);
 				$draftObj->setPostSubject($subjectFormatterCallback($inputValues['subject']));
 				$draftObj->setPostMessage(\ilRTE::_replaceMediaObjectImageSrc($inputValues['message'], 0));
-				$draftObj->setPostUserAlias($usrAlias);
+				$draftObj->setPostUserAlias($inputValues['alias']);
 				$draftObj->setNotify($inputValues['notify']);
 				$draftObj->setUpdateUserId($this->actor->getId());
 				$draftObj->setPostAuthorId($this->actor->getId());
@@ -145,7 +140,7 @@ class ilForumAutoSaveAsyncDraftAction
 			$draftObj->setPostId($this->relatedPostId);
 			$draftObj->setPostSubject($subjectFormatterCallback($inputValues['subject']));
 			$draftObj->setPostMessage(\ilRTE::_replaceMediaObjectImageSrc($inputValues['message'], 0));
-			$draftObj->setPostUserAlias($usrAlias);
+			$draftObj->setPostUserAlias($inputValues['alias']);
 			$draftObj->setNotify($inputValues['notify']);
 			$draftObj->setPostAuthorId($this->actor->getId());
 			$draftObj->setPostDisplayUserId(($this->forumProperties->isAnonymized() ? 0 : $this->actor->getId()));
@@ -192,5 +187,23 @@ class ilForumAutoSaveAsyncDraftAction
 		foreach ($curMediaObjects as $mob) {
 			\ilObjMediaObject::_saveUsage($mob, $type, $draftId);
 		}
+	}
+
+	/**
+	 * @return array
+	 */
+	protected function getInputValuesFromForm(): array
+	{
+		$inputValues = [];
+
+		$inputValues['subject'] = (string)$this->form->getInput('subject');
+		$inputValues['message'] = (string)$this->form->getInput('message');
+		$inputValues['notify'] = (int)$this->form->getInput('notify');
+		$inputValues['alias'] = \ilForumUtil::getPublicUserAlias(
+			(string)$this->form->getInput('alias'),
+			$this->forumProperties->isAnonymized()
+		);
+
+		return $inputValues;
 	}
 }

--- a/Modules/Forum/classes/class.ilObjForumGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumGUI.php
@@ -5297,286 +5297,50 @@ $this->doCaptchaCheck();
 
 	public function autosaveDraftAsyncObject()
 	{
-		
-		if($this->user->isAnonymous() || $_GET['action'] == 'ready_showreply')
-		{
-			exit();
+		if (!isset($_GET['action']) || $_GET['action'] !== 'ready_showreply') {
+			$action = new ilForumAutoSaveAsyncDraftAction(
+				$this->user,
+				$this->getReplyEditForm(),
+				$this->objProperties,
+				$this->objCurrentTopic,
+				function(string $message): string {
+					return $this->handleFormInput($message);
+				},
+				$this->objCurrentPost->getId(),
+				(int)($_GET['draft_id'] ?? 0),
+				(int)\ilObjForum::lookupForumIdByRefId($this->ref_id),
+				$this->objCurrentPost->getId(),
+				$_GET['action'] ?? ''
+			);
+
+			echo json_encode($action->executeAndGetResponseObject());
 		}
-		
-		$reponse           = new stdClass();
-		$reponse->draft_id = 0;
-		
-		if(ilForumPostDraft::isAutoSavePostDraftAllowed())
-		{
-			$replyform = $this->getReplyEditForm();
-			$current_post_id =$this->objCurrentPost->getId();
 
-			$replyform->checkInput();
-
-			$form_autosave_values['subject'] = $replyform->getInput('subject'); 
-			$form_autosave_values['message'] = $replyform->getInput('message');
-			$form_autosave_values['notify']  = $replyform->getInput('notify');
-			$form_autosave_values['alias']   = $replyform->getInput('alias');
-				
-			if(isset($_GET['draft_id']) && (int)$_GET['draft_id'] > 0)
-			{
-				$draft_id = (int)$_GET['draft_id'];
-			}
-			else
-			{
-				$draft_id = $replyform->getInput('draft_id');
-			}
-			$user_alias = ilForumUtil::getPublicUserAlias($form_autosave_values['alias'], $this->objProperties->isAnonymized());
-			
-			if((int)$draft_id > 0)
-			{
-				if($_GET['action'] == 'showreply')
-				{
-					$draftObj = ilForumPostDraft::newInstanceByDraftId((int)$draft_id);
-					$draftObj->setPostSubject($this->handleFormInput($form_autosave_values['subject'], false));
-					$draftObj->setPostMessage(ilRTE::_replaceMediaObjectImageSrc($form_autosave_values['message'], 0));
-					
-					$draftObj->setPostUserAlias($user_alias);
-					$draftObj->setNotify((int)$form_autosave_values['notify']);
-					$draftObj->setUpdateUserId($this->user->getId());
-					$draftObj->setPostAuthorId($this->user->getId());
-					$draftObj->setPostDisplayUserId(($this->objProperties->isAnonymized() ? 0 : $this->user->getId()));
-					
-					$draftObj->updateDraft();
-					
-					$uploadedObjects = ilObjMediaObject::_getMobsOfObject('frm~:html', $this->user->getId());
-					$oldMediaObjects = ilObjMediaObject::_getMobsOfObject('frm~d:html', $draftObj->getDraftId());
-					$curMediaObjects = ilRTE::_getMediaObjects($form_autosave_values['message'], 0);
-					
-					foreach($uploadedObjects as $mob)
-					{
-						ilObjMediaObject::_removeUsage($mob, 'frm~:html', $this->user->getId());
-						ilObjMediaObject::_saveUsage($mob, ilForumPostDraft::MEDIAOBJECT_TYPE, $draftObj->getDraftId());
-					}
-					
-					foreach($oldMediaObjects as $mob)
-					{
-						ilObjMediaObject::_saveUsage($mob, ilForumPostDraft::MEDIAOBJECT_TYPE, $draftObj->getDraftId());
-					}
-					
-					foreach($curMediaObjects as $mob)
-					{
-						ilObjMediaObject::_saveUsage($mob, ilForumPostDraft::MEDIAOBJECT_TYPE, $draftObj->getDraftId());
-					}
-				}	
-				else
-				{
-					$draftObj = new ilForumDraftsHistory();
-					$draftObj->setDraftId((int)$draft_id);
-					$draftObj->setPostSubject($this->handleFormInput($form_autosave_values['subject'], false));
-					$draftObj->setPostMessage(ilRTE::_replaceMediaObjectImageSrc($form_autosave_values['message'], 0));
-					$draftObj->addDraftToHistory();
-					
-					$uploadedObjects = ilObjMediaObject::_getMobsOfObject('frm~:html', $this->user->getId());
-					$oldMediaObjects = ilObjMediaObject::_getMobsOfObject('frm~d:html', $draftObj->getDraftId());
-					$curMediaObjects = ilRTE::_getMediaObjects($form_autosave_values['message'], 0);
-					
-					foreach($uploadedObjects as $mob)
-					{
-						ilObjMediaObject::_removeUsage($mob, 'frm~:html', $this->user->getId());
-						ilObjMediaObject::_saveUsage($mob, ilForumDraftsHistory::MEDIAOBJECT_TYPE, $draftObj->getHistoryId());
-					}
-					
-					foreach($oldMediaObjects as $mob)
-					{
-						ilObjMediaObject::_saveUsage($mob, ilForumDraftsHistory::MEDIAOBJECT_TYPE, $draftObj->getHistoryId());
-					}
-					
-					foreach($curMediaObjects as $mob)
-					{
-						ilObjMediaObject::_saveUsage($mob, ilForumDraftsHistory::MEDIAOBJECT_TYPE, $draftObj->getHistoryId());
-					}
-				}
-			}
-			else
-			{
-				$draftObj = new ilForumPostDraft();
-				$draftObj->setForumId(ilObjForum::lookupForumIdByRefId($this->ref_id));
-				$draftObj->setThreadId($this->objCurrentTopic->getId());
-				$draftObj->setPostId($current_post_id);
-
-				$draftObj->setPostSubject($this->handleFormInput($form_autosave_values['subject'], false));
-				$draftObj->setPostMessage(ilRTE::_replaceMediaObjectImageSrc($form_autosave_values['message'], 0));
-
-				$draftObj->setPostUserAlias($user_alias);
-				$draftObj->setNotify((int)$form_autosave_values['notify']);
-				$draftObj->setPostAuthorId($this->user->getId());
-				$draftObj->setPostDisplayUserId(($this->objProperties->isAnonymized() ? 0 : $this->user->getId()));
-				$draftObj->saveDraft();
-				
-				$uploadedObjects = ilObjMediaObject::_getMobsOfObject('frm~:html', $this->user->getId());
-				$oldMediaObjects = ilObjMediaObject::_getMobsOfObject('frm~d:html', $draftObj->getDraftId());
-				$curMediaObjects = ilRTE::_getMediaObjects($form_autosave_values['message'], 0);
-				
-				foreach($uploadedObjects as $mob)
-				{
-					ilObjMediaObject::_removeUsage($mob, 'frm~:html', $this->user->getId());
-					ilObjMediaObject::_saveUsage($mob, ilForumPostDraft::MEDIAOBJECT_TYPE, $draftObj->getDraftId());
-				}
-				
-				foreach($oldMediaObjects as $mob)
-				{
-					ilObjMediaObject::_saveUsage($mob, ilForumPostDraft::MEDIAOBJECT_TYPE, $draftObj->getDraftId());
-				}
-				
-				foreach($curMediaObjects as $mob)
-				{
-					ilObjMediaObject::_saveUsage($mob, ilForumPostDraft::MEDIAOBJECT_TYPE, $draftObj->getDraftId());
-				}
-			}
-		}
-		
-		$reponse->draft_id = $draftObj->getDraftId();
-		echo json_encode($reponse);
 		exit();
 	}
 	
 	public function autosaveThreadDraftAsyncObject()
 	{
-		
-		if($this->user->isAnonymous() || $_GET['action'] == 'ready_showreply')
-		{
-			exit();
+		if (!isset($_GET['action']) || $_GET['action'] !== 'ready_showreply') {
+			$this->initTopicCreateForm();
+
+			$action = new ilForumAutoSaveAsyncDraftAction(
+				$this->user,
+				$this->create_topic_form_gui,
+				$this->objProperties,
+				$this->objCurrentTopic,
+				function(string $message): string {
+					return $this->handleFormInput($message, false);
+				},
+				(int)($_GET['draft_id'] ?? 0),
+				(int)\ilObjForum::lookupForumIdByRefId($this->ref_id),
+				0,
+				$_GET['action'] ?? ''
+			);
+
+			echo json_encode($action->executeAndGetResponseObject());
 		}
-		
-		$reponse           = new stdClass();
-		$reponse->draft_id = 0;
-		
-		if(ilForumPostDraft::isAutoSavePostDraftAllowed())
-		{
-				$this->initTopicCreateForm();
-				$replyform = $this->create_topic_form_gui;
-				$current_post_id = 0;
-		
-			
-			$replyform->checkInput();
-			
-			$form_autosave_values['subject'] = $replyform->getInput('subject');
-			$form_autosave_values['message'] = $replyform->getInput('message');
-			$form_autosave_values['notify']  = $replyform->getInput('notify');
-			$form_autosave_values['alias']   = $replyform->getInput('alias');
-			
-			if(isset($_GET['draft_id']) && (int)$_GET['draft_id'] > 0)
-			{
-				$draft_id = (int)$_GET['draft_id'];
-			}
-			else
-			{
-				$draft_id = $replyform->getInput('draft_id');
-			}
-			$user_alias = ilForumUtil::getPublicUserAlias($form_autosave_values['alias'], $this->objProperties->isAnonymized());
-			if((int)$draft_id > 0)
-			{
-				if($_GET['action'] == 'showreply')
-				{
-					$draftObj = ilForumPostDraft::newInstanceByDraftId((int)$draft_id);
-					$draftObj->setPostSubject($this->handleFormInput($form_autosave_values['subject'], false));
-					$draftObj->setPostMessage(ilRTE::_replaceMediaObjectImageSrc($form_autosave_values['message'], 0));
-					$draftObj->setPostUserAlias($user_alias);
-					$draftObj->setNotify((int)$form_autosave_values['notify']);
-					$draftObj->setUpdateUserId($this->user->getId());
-					$draftObj->setPostAuthorId($this->user->getId());
-					$draftObj->setPostDisplayUserId(($this->objProperties->isAnonymized() ? 0 : $this->user->getId()));
-					
-					$draftObj->updateDraft();
-					
-					$uploadedObjects = ilObjMediaObject::_getMobsOfObject('frm~:html', $this->user->getId());
-					$oldMediaObjects = ilObjMediaObject::_getMobsOfObject('frm~d:html', $draftObj->getDraftId());
-					$curMediaObjects = ilRTE::_getMediaObjects($form_autosave_values['message'], 0);
-					
-					foreach($uploadedObjects as $mob)
-					{
-						ilObjMediaObject::_removeUsage($mob, 'frm~:html', $this->user->getId());
-						ilObjMediaObject::_saveUsage($mob, ilForumPostDraft::MEDIAOBJECT_TYPE, $draftObj->getDraftId());
-					}
-					
-					foreach($oldMediaObjects as $mob)
-					{
-						ilObjMediaObject::_saveUsage($mob, ilForumPostDraft::MEDIAOBJECT_TYPE, $draftObj->getDraftId());
-					}
-					
-					foreach($curMediaObjects as $mob)
-					{
-						ilObjMediaObject::_saveUsage($mob, ilForumPostDraft::MEDIAOBJECT_TYPE, $draftObj->getDraftId());
-					}
-					
-				}
-				else
-				{
-					$draftObj = new ilForumDraftsHistory();
-					$draftObj->setDraftId((int)$draft_id);
-					$draftObj->setPostSubject($this->handleFormInput($form_autosave_values['subject'], false));
-					$draftObj->setPostMessage(ilRTE::_replaceMediaObjectImageSrc($form_autosave_values['message'], 0));
-					$draftObj->addDraftToHistory();
-					
-					$uploadedObjects = ilObjMediaObject::_getMobsOfObject('frm~:html', $this->user->getId());
-					$oldMediaObjects = ilObjMediaObject::_getMobsOfObject('frm~d:html', $draftObj->getDraftId());
-					$curMediaObjects = ilRTE::_getMediaObjects($form_autosave_values['message'], 0);
-					
-					foreach($uploadedObjects as $mob)
-					{
-						ilObjMediaObject::_removeUsage($mob, 'frm~:html', $this->user->getId());
-						ilObjMediaObject::_saveUsage($mob, ilForumDraftsHistory::MEDIAOBJECT_TYPE, $draftObj->getHistoryId());
-					}
-					
-					foreach($oldMediaObjects as $mob)
-					{
-						ilObjMediaObject::_saveUsage($mob, ilForumDraftsHistory::MEDIAOBJECT_TYPE, $draftObj->getHistoryId());
-					}
-					
-					foreach($curMediaObjects as $mob)
-					{
-						ilObjMediaObject::_saveUsage($mob, ilForumDraftsHistory::MEDIAOBJECT_TYPE, $draftObj->getHistoryId());
-					}
-					
-				}
-			}
-			else
-			{
-				$draftObj = new ilForumPostDraft();
-				$draftObj->setForumId(ilObjForum::lookupForumIdByRefId($this->ref_id));
-				$draftObj->setThreadId($this->objCurrentTopic->getId());
-				$draftObj->setPostId($current_post_id);
-				
-				$draftObj->setPostSubject($this->handleFormInput($form_autosave_values['subject'], false));
-				$draftObj->setPostMessage(ilRTE::_replaceMediaObjectImageSrc($form_autosave_values['message'], 0));
-				
-				$draftObj->setPostUserAlias($user_alias);
-				$draftObj->setNotify((int)$form_autosave_values['notify']);
-				$draftObj->setPostAuthorId($this->user->getId());
-				$draftObj->setPostDisplayUserId(($this->objProperties->isAnonymized() ? 0 : $this->user->getId()));
-				$draftObj->saveDraft();
-				
-				$uploadedObjects = ilObjMediaObject::_getMobsOfObject('frm~:html', $this->user->getId());
-				$oldMediaObjects = ilObjMediaObject::_getMobsOfObject('frm~d:html', $draftObj->getDraftId());
-				$curMediaObjects = ilRTE::_getMediaObjects($form_autosave_values['message'], 0);
-				
-				foreach($uploadedObjects as $mob)
-				{
-					ilObjMediaObject::_removeUsage($mob, 'frm~:html', $this->user->getId());
-					ilObjMediaObject::_saveUsage($mob, ilForumPostDraft::MEDIAOBJECT_TYPE, $draftObj->getDraftId());
-				}
-				
-				foreach($oldMediaObjects as $mob)
-				{
-					ilObjMediaObject::_saveUsage($mob, ilForumPostDraft::MEDIAOBJECT_TYPE, $draftObj->getDraftId());
-				}
-				
-				foreach($curMediaObjects as $mob)
-				{
-					ilObjMediaObject::_saveUsage($mob, ilForumPostDraft::MEDIAOBJECT_TYPE, $draftObj->getDraftId());
-				}
-				
-			}
-		}
-		
-		$reponse->draft_id = $draftObj->getDraftId();
-		echo json_encode($reponse);
+
 		exit();
 	}
 	

--- a/libs/composer/vendor/composer/autoload_classmap.php
+++ b/libs/composer/vendor/composer/autoload_classmap.php
@@ -4363,6 +4363,7 @@ return array(
     'ilForumAppEventListener' => $baseDir . '/../../Modules/Forum/classes/class.ilForumAppEventListener.php',
     'ilForumAuthorInformation' => $baseDir . '/../../Modules/Forum/classes/class.ilForumAuthorInformation.php',
     'ilForumAuthorInformationCache' => $baseDir . '/../../Modules/Forum/classes/class.ilForumAuthorInformationCache.php',
+    'ilForumAutoSaveAsyncDraftAction' => $baseDir . '/../../Modules/Forum/classes/Actions/class.ilForumAutoSaveAsyncDraftAction.php',
     'ilForumCronNotification' => $baseDir . '/../../Modules/Forum/classes/class.ilForumCronNotification.php',
     'ilForumCronNotificationDataProvider' => $baseDir . '/../../Modules/Forum/classes/class.ilForumCronNotificationDataProvider.php',
     'ilForumDraftsHistory' => $baseDir . '/../../Modules/Forum/classes/class.ilForumDraftsHistory.php',

--- a/libs/composer/vendor/composer/autoload_static.php
+++ b/libs/composer/vendor/composer/autoload_static.php
@@ -4671,6 +4671,7 @@ class ComposerStaticInit2fffdf922cf8fdbf1f62eec345993c83
         'ilForumAppEventListener' => __DIR__ . '/../..' . '/../../Modules/Forum/classes/class.ilForumAppEventListener.php',
         'ilForumAuthorInformation' => __DIR__ . '/../..' . '/../../Modules/Forum/classes/class.ilForumAuthorInformation.php',
         'ilForumAuthorInformationCache' => __DIR__ . '/../..' . '/../../Modules/Forum/classes/class.ilForumAuthorInformationCache.php',
+        'ilForumAutoSaveAsyncDraftAction' => __DIR__ . '/../..' . '/../../Modules/Forum/classes/Actions/class.ilForumAutoSaveAsyncDraftAction.php',
         'ilForumCronNotification' => __DIR__ . '/../..' . '/../../Modules/Forum/classes/class.ilForumCronNotification.php',
         'ilForumCronNotificationDataProvider' => __DIR__ . '/../..' . '/../../Modules/Forum/classes/class.ilForumCronNotificationDataProvider.php',
         'ilForumDraftsHistory' => __DIR__ . '/../..' . '/../../Modules/Forum/classes/class.ilForumDraftsHistory.php',


### PR DESCRIPTION
Currently there is a massive code duplication when saving drafts in forums asynchronously (Feature: Autosave).
With this PR I created one central class for the code currently duplicated in two different controller commands/actions. The resulting class is presumably not the best piece of code ever, but a first step for further enhancements.

Duplication Costs: **571** (according to `CPD` in `PhpStorm`)

**If the `release_5-4` branch has already been created, this should be also merged/cherry-picked to `release_5-4`.**