### PR TITLE
Setup: Workaround for Mantis issue 23876

### DIFF
--- a/Services/Cron/classes/class.ilCronManager.php
+++ b/Services/Cron/classes/class.ilCronManager.php
@@ -321,12 +321,15 @@ class ilCronManager implements \ilCronManagerInterface
 		{										
 			include_once $class_file;
 			if(class_exists($a_class))
-			{				
-				$job = new $a_class();				
-				if($job instanceof ilCronJob)
-				{
-					if($job->getId() == $a_id)
-					{
+			{
+				$refl = new \ReflectionClass($a_class);
+				if ($refl->isSubclassOf(\ilCronJob::class)) {
+					$job = $refl->newInstanceWithoutConstructor();
+					if (0 === strlen($job->getId())) {
+						$job = new $a_class;
+					}
+
+					if ($job->getId() === $a_id) {
 						return $job;
 					}
 					else

--- a/Services/Cron/classes/class.ilCronManager.php
+++ b/Services/Cron/classes/class.ilCronManager.php
@@ -323,8 +323,8 @@ class ilCronManager implements \ilCronManagerInterface
 			if(class_exists($a_class))
 			{
 				$refl = new \ReflectionClass($a_class);
+				$job = $refl->newInstanceWithoutConstructor();
 				if ($refl->isSubclassOf(\ilCronJob::class)) {
-					$job = $refl->newInstanceWithoutConstructor();
 					if (0 === strlen($job->getId())) {
 						$job = new $a_class;
 					}


### PR DESCRIPTION
Currently ILIAS components register provided `ilCronJob` derivatives in the `service.xml` or `module.xml` file. This information is read from the XML files during setup, triggered by ` \ilSetupGUI::reloadControlStructure`.

For each found job an instance of the respective PHP class will be created. If the constructor of a class makes use of certain dependencies retrieved from the global `$DIC`, missing dependencies in the `Setup Context` can result in a crash.

Stack:
1. \ilSetupGUI::reloadControlStructure
2. \ilObjDefReader::handlerBeginTag
3. \ilCronManager::updateFromXML
4. \ilCronManager::getJobInstance

Mantis issue: https://mantis.ilias.de/view.php?id=23876