### PR TITLE
[Certificates] Reduce duplicated code in migration job

### DIFF
--- a/Services/Certificate/classes/BackgroundTasks/class.ilCertificateMigrationJob.php
+++ b/Services/Certificate/classes/BackgroundTasks/class.ilCertificateMigrationJob.php
@@ -719,7 +719,9 @@ class ilCertificateMigrationJob extends AbstractJob
 				$xsl_path = $cert_path . "certificate.xml";
 
 				if (file_exists($xsl_path) && (filesize($xsl_path) > 0)) {
-					$this->logMessage('Found certificate with id: ' . $objectId, 'debug');
+					$type = $object->getType();
+
+					$this->logMessage(sprintf('Found certificate for object id "%s" (type: "%s") and user id "%s"', $objectId, $type, $this->user_id), 'debug');
 
 					$webdir = $cert_path . "background.jpg";
 
@@ -733,7 +735,7 @@ class ilCertificateMigrationJob extends AbstractJob
 						"obj_id" => $objectId,
 						"user_id" => $this->user_id,
 						"certificate_path" => $cert_path,
-						"certificate_type" => $object->getType(),
+						"certificate_type" => $type,
 						"background_image_path" => $background_image_path,
 						"acquired_timestamp" => null,
 						"ilias_version" => ILIAS_VERSION_NUMERIC,

--- a/Services/Certificate/classes/BackgroundTasks/class.ilCertificateMigrationJob.php
+++ b/Services/Certificate/classes/BackgroundTasks/class.ilCertificateMigrationJob.php
@@ -455,44 +455,40 @@ class ilCertificateMigrationJob extends AbstractJob
 			if ($obj_ids)
 			{
 
-				foreach(\ilCertificate::areObjectsActive($obj_ids) as $obj_id => $active)
+				foreach(\ilCertificate::areObjectsActive($obj_ids) as $objectId => $active)
 				{
 					if ($active)
 					{
-						$type = \ilObjSAHSLearningModule::_lookupSubType($obj_id);
+						$type = \ilObjSAHSLearningModule::_lookupSubType($objectId);
 
-						$lm = \ilObjectFactory::getInstanceByObjId($obj_id, false);
-						if (!$lm || !($lm instanceof \ilObjSAHSLearningModule)) {
-							$this->logMessage('Found inconsistent object, skipped migration: ' . $obj_id, 'debug');
+						$object = \ilObjectFactory::getInstanceByObjId($objectId, false);
+						if (!$object || !($object instanceof \ilObjSAHSLearningModule)) {
+							$this->logMessage('Found inconsistent object, skipped migration: ' . $objectId, 'debug');
 							continue;
 						}
-						$lm->setSubType($type);
+						$object->setSubType($type);
 
-						$adapter = new \ilSCORMCertificateAdapter($lm);
+						$adapter = new \ilSCORMCertificateAdapter($object);
 
-						$obj_id = $adapter->getCertificateID();
-						if(\ilCertificate::isActive() && isset($obj_id) && \ilCertificate::isObjectActive($obj_id))
+						if(\ilCertificate::isActive() && \ilCertificate::isObjectActive($objectId))
 						{
 							if (file_exists($adapter->getCertificatePath()))
 							{
 								$cert_path = $adapter->getCertificatePath();
 								$xsl_path = $cert_path . "certificate.xml";
-
 								if (file_exists($xsl_path) && (filesize($xsl_path) > 0))
 								{
-									$this->logMessage('Found scorm certificate with id: ' . $obj_id, 'debug');
+									$this->logMessage('Found certificate with id: ' . $objectId, 'debug');
 									$webdir = $cert_path . "background.jpg";
-
 									$background_image_path = str_replace(
 										\ilUtil::removeTrailingPathSeparators(CLIENT_WEB_DIR),
 										'',
 										$webdir
 									);
-
 									$data[] = array(
-										"obj_id" => $obj_id,
+										"obj_id" => $objectId,
 										"user_id" => $this->user_id,
-										"certificate_type" => 'sahs',
+										"certificate_type" => $object->getType(),
 										"background_image_path" => $background_image_path,
 										"acquired_timestamp" => null,
 										"ilias_version" => ILIAS_VERSION_NUMERIC,
@@ -520,23 +516,22 @@ class ilCertificateMigrationJob extends AbstractJob
 
 		$data = array();
 
-		foreach(\ilObjTest::getTestObjIdsWithActiveForUserId($this->user_id) as $test_id)
+		foreach(\ilObjTest::getTestObjIdsWithActiveForUserId($this->user_id) as $objectId)
 		{
-			$test = \ilObjectFactory::getInstanceByObjId($test_id, false);
-			if (!$test || !($test instanceof \ilObjTest)) {
-				$this->logMessage('Found inconsistent object, skipped migration: ' . $test_id, 'debug');
+			$object = \ilObjectFactory::getInstanceByObjId($objectId, false);
+			if (!$object || !($object instanceof \ilObjTest)) {
+				$this->logMessage('Found inconsistent object, skipped migration: ' . $objectId, 'debug');
 				continue;
 			}
 
-			$session = new \ilTestSessionFactory($test);
+			$session = new \ilTestSessionFactory($object);
 			$session = $session->getSession(null);
-			if ($test->canShowCertificate($session, $session->getUserId(), $session->getActiveId()))
+			if ($object->canShowCertificate($session, $session->getUserId(), $session->getActiveId()))
 			{
 
-				$adapter = new \ilTestCertificateAdapter($test);
+				$adapter = new \ilTestCertificateAdapter($object);
 
-				$obj_id = $adapter->getCertificateID();
-				if(\ilCertificate::isActive() && isset($obj_id) && \ilCertificate::isObjectActive($obj_id))
+				if(\ilCertificate::isActive() && \ilCertificate::isObjectActive($objectId))
 				{
 					if (file_exists($adapter->getCertificatePath()))
 					{
@@ -544,7 +539,7 @@ class ilCertificateMigrationJob extends AbstractJob
 						$xsl_path = $cert_path . "certificate.xml";
 						if (file_exists($xsl_path) && (filesize($xsl_path) > 0))
 						{
-							$this->logMessage('Found test certificate with id: ' . $test_id, 'debug');
+							$this->logMessage('Found certificate with id: ' . $objectId, 'debug');
 							$webdir = $cert_path . "background.jpg";
 							$background_image_path = str_replace(
 								\ilUtil::removeTrailingPathSeparators(CLIENT_WEB_DIR),
@@ -552,10 +547,10 @@ class ilCertificateMigrationJob extends AbstractJob
 								$webdir
 							);
 							$data[] = array(
-								"obj_id" => $test_id,
+								"obj_id" => $objectId,
 								"user_id" => $this->user_id,
 								"certificate_path" => $cert_path,
-								"certificate_type" => 'tst',
+								"certificate_type" => $object->getType(),
 								"background_image_path" => $background_image_path,
 								"acquired_timestamp" => null,
 								"ilias_version" => ILIAS_VERSION_NUMERIC,
@@ -581,20 +576,19 @@ class ilCertificateMigrationJob extends AbstractJob
 
 		$data = array();
 
-		foreach(\ilObjExercise::_lookupFinishedUserExercises($this->user_id) as $exercise_id => $passed)
+		foreach(\ilObjExercise::_lookupFinishedUserExercises($this->user_id) as $objectId => $passed)
 		{
-			$exc = \ilObjectFactory::getInstanceByObjId($exercise_id, false);
-			if (!$exc || !($exc instanceof \ilObjExercise)) {
-				$this->logMessage('Found inconsistent object, skipped migration: ' . $exercise_id, 'debug');
+			$object = \ilObjectFactory::getInstanceByObjId($objectId, false);
+			if (!$object || !($object instanceof \ilObjExercise)) {
+				$this->logMessage('Found inconsistent object, skipped migration: ' . $objectId, 'debug');
 				continue;
 			}
 
-			if ($exc->hasUserCertificate($this->user_id))
+			if ($object->hasUserCertificate($this->user_id))
 			{
-				$adapter = new \ilExerciseCertificateAdapter($exc);
+				$adapter = new \ilExerciseCertificateAdapter($object);
 
-				$obj_id = $adapter->getCertificateID();
-				if(\ilCertificate::isActive() && isset($obj_id) && \ilCertificate::isObjectActive($obj_id))
+				if(\ilCertificate::isActive() && \ilCertificate::isObjectActive($objectId))
 				{
 					if (file_exists($adapter->getCertificatePath()))
 					{
@@ -602,7 +596,7 @@ class ilCertificateMigrationJob extends AbstractJob
 						$xsl_path = $cert_path . "certificate.xml";
 						if (file_exists($xsl_path) && (filesize($xsl_path) > 0))
 						{
-							$this->logMessage('Found exercise certificate with id: ' . $obj_id, 'debug');
+							$this->logMessage('Found certificate with id: ' . $objectId, 'debug');
 							$webdir = $cert_path . "background.jpg";
 							$background_image_path = str_replace(
 								\ilUtil::removeTrailingPathSeparators(CLIENT_WEB_DIR),
@@ -610,10 +604,10 @@ class ilCertificateMigrationJob extends AbstractJob
 								$webdir
 							);
 							$data[] = array(
-								"obj_id" => $exercise_id,
+								"obj_id" => $objectId,
 								"user_id" => $this->user_id,
 								"certificate_path" => $cert_path,
-								"certificate_type" => 'exc',
+								"certificate_type" => $object->getType(),
 								"background_image_path" => $background_image_path,
 								"acquired_timestamp" => null,
 								"ilias_version" => ILIAS_VERSION_NUMERIC,
@@ -644,19 +638,18 @@ class ilCertificateMigrationJob extends AbstractJob
 		{
 			\ilCourseCertificateAdapter::_preloadListData([$this->user_id], $obj_ids);
 
-			foreach($obj_ids as $crs_id)
+			foreach($obj_ids as $objectId)
 			{
-				if (\ilCourseCertificateAdapter::_hasUserCertificate($this->user_id, $crs_id))
+				if (\ilCourseCertificateAdapter::_hasUserCertificate($this->user_id, $objectId))
 				{
-					$crs = \ilObjectFactory::getInstanceByObjId($crs_id, false);
-					if (!$crs || !($crs instanceof \ilObjCourse)) {
-						$this->logMessage('Found inconsistent object, skipped migration: ' . $crs_id, 'debug');
+					$object = \ilObjectFactory::getInstanceByObjId($objectId, false);
+					if (!$object || !($object instanceof \ilObjCourse)) {
+						$this->logMessage('Found inconsistent object, skipped migration: ' . $objectId, 'debug');
 						continue;
 					}
 
-					$adapter = new \ilCourseCertificateAdapter($crs);
-					$obj_id = $adapter->getCertificateID();
-					if(\ilCertificate::isActive() && isset($obj_id) && \ilCertificate::isObjectActive($obj_id))
+					$adapter = new \ilCourseCertificateAdapter($object);
+					if(\ilCertificate::isActive() && \ilCertificate::isObjectActive($objectId))
 					{
 						if (file_exists($adapter->getCertificatePath()))
 						{
@@ -664,7 +657,7 @@ class ilCertificateMigrationJob extends AbstractJob
 							$xsl_path = $cert_path . "certificate.xml";
 							if (file_exists($xsl_path) && (filesize($xsl_path) > 0))
 							{
-								$this->logMessage('Found course certificate with id: ' . $crs_id, 'debug');
+								$this->logMessage('Found certificate with id: ' . $objectId, 'debug');
 								$webdir = $cert_path . "background.jpg";
 								$background_image_path = str_replace(
 									\ilUtil::removeTrailingPathSeparators(CLIENT_WEB_DIR),
@@ -672,10 +665,10 @@ class ilCertificateMigrationJob extends AbstractJob
 									$webdir
 								);
 								$data[] = array(
-									"obj_id" => $crs_id,
+									"obj_id" => $objectId,
 									"user_id" => $this->user_id,
 									"certificate_path" => $cert_path,
-									"certificate_type" => 'crs',
+									"certificate_type" => $object->getType(),
 									"background_image_path" => $background_image_path,
 									"acquired_timestamp" => null,
 									"ilias_version" => ILIAS_VERSION_NUMERIC,

--- a/Services/Certificate/classes/BackgroundTasks/class.ilCertificateMigrationJob.php
+++ b/Services/Certificate/classes/BackgroundTasks/class.ilCertificateMigrationJob.php
@@ -470,34 +470,7 @@ class ilCertificateMigrationJob extends AbstractJob
 
 						$adapter = new \ilSCORMCertificateAdapter($object);
 
-						if(\ilCertificate::isActive() && \ilCertificate::isObjectActive($objectId))
-						{
-							if (file_exists($adapter->getCertificatePath()))
-							{
-								$cert_path = $adapter->getCertificatePath();
-								$xsl_path = $cert_path . "certificate.xml";
-								if (file_exists($xsl_path) && (filesize($xsl_path) > 0))
-								{
-									$this->logMessage('Found certificate with id: ' . $objectId, 'debug');
-									$webdir = $cert_path . "background.jpg";
-									$background_image_path = str_replace(
-										\ilUtil::removeTrailingPathSeparators(CLIENT_WEB_DIR),
-										'',
-										$webdir
-									);
-									$data[] = array(
-										"obj_id" => $objectId,
-										"user_id" => $this->user_id,
-										"certificate_path" => $cert_path,
-										"certificate_type" => $object->getType(),
-										"background_image_path" => $background_image_path,
-										"acquired_timestamp" => null,
-										"ilias_version" => ILIAS_VERSION_NUMERIC,
-										"certificate_content" => null,
-									);
-								}
-							}
-						}
+						$data = $this->createCertificateData($objectId, $adapter, $object, $data);
 					}
 				}
 			}
@@ -532,34 +505,7 @@ class ilCertificateMigrationJob extends AbstractJob
 
 				$adapter = new \ilTestCertificateAdapter($object);
 
-				if(\ilCertificate::isActive() && \ilCertificate::isObjectActive($objectId))
-				{
-					if (file_exists($adapter->getCertificatePath()))
-					{
-						$cert_path = $adapter->getCertificatePath();
-						$xsl_path = $cert_path . "certificate.xml";
-						if (file_exists($xsl_path) && (filesize($xsl_path) > 0))
-						{
-							$this->logMessage('Found certificate with id: ' . $objectId, 'debug');
-							$webdir = $cert_path . "background.jpg";
-							$background_image_path = str_replace(
-								\ilUtil::removeTrailingPathSeparators(CLIENT_WEB_DIR),
-								'',
-								$webdir
-							);
-							$data[] = array(
-								"obj_id" => $objectId,
-								"user_id" => $this->user_id,
-								"certificate_path" => $cert_path,
-								"certificate_type" => $object->getType(),
-								"background_image_path" => $background_image_path,
-								"acquired_timestamp" => null,
-								"ilias_version" => ILIAS_VERSION_NUMERIC,
-								"certificate_content" => null,
-							);
-						}
-					}
-				}
+				$data = $this->createCertificateData($objectId, $adapter, $object, $data);
 			}
 		}
 
@@ -589,34 +535,7 @@ class ilCertificateMigrationJob extends AbstractJob
 			{
 				$adapter = new \ilExerciseCertificateAdapter($object);
 
-				if(\ilCertificate::isActive() && \ilCertificate::isObjectActive($objectId))
-				{
-					if (file_exists($adapter->getCertificatePath()))
-					{
-						$cert_path = $adapter->getCertificatePath();
-						$xsl_path = $cert_path . "certificate.xml";
-						if (file_exists($xsl_path) && (filesize($xsl_path) > 0))
-						{
-							$this->logMessage('Found certificate with id: ' . $objectId, 'debug');
-							$webdir = $cert_path . "background.jpg";
-							$background_image_path = str_replace(
-								\ilUtil::removeTrailingPathSeparators(CLIENT_WEB_DIR),
-								'',
-								$webdir
-							);
-							$data[] = array(
-								"obj_id" => $objectId,
-								"user_id" => $this->user_id,
-								"certificate_path" => $cert_path,
-								"certificate_type" => $object->getType(),
-								"background_image_path" => $background_image_path,
-								"acquired_timestamp" => null,
-								"ilias_version" => ILIAS_VERSION_NUMERIC,
-								"certificate_content" => null,
-							);
-						}
-					}
-				}
+				$data = $this->createCertificateData($objectId, $adapter, $object, $data);
 			}
 		}
 
@@ -650,34 +569,7 @@ class ilCertificateMigrationJob extends AbstractJob
 					}
 
 					$adapter = new \ilCourseCertificateAdapter($object);
-					if(\ilCertificate::isActive() && \ilCertificate::isObjectActive($objectId))
-					{
-						if (file_exists($adapter->getCertificatePath()))
-						{
-							$cert_path = $adapter->getCertificatePath();
-							$xsl_path = $cert_path . "certificate.xml";
-							if (file_exists($xsl_path) && (filesize($xsl_path) > 0))
-							{
-								$this->logMessage('Found certificate with id: ' . $objectId, 'debug');
-								$webdir = $cert_path . "background.jpg";
-								$background_image_path = str_replace(
-									\ilUtil::removeTrailingPathSeparators(CLIENT_WEB_DIR),
-									'',
-									$webdir
-								);
-								$data[] = array(
-									"obj_id" => $objectId,
-									"user_id" => $this->user_id,
-									"certificate_path" => $cert_path,
-									"certificate_type" => $object->getType(),
-									"background_image_path" => $background_image_path,
-									"acquired_timestamp" => null,
-									"ilias_version" => ILIAS_VERSION_NUMERIC,
-									"certificate_content" => null,
-								);
-							}
-						}
-					}
+					$data = $this->createCertificateData($objectId, $adapter, $object, $data);
 				}
 			}
 		}
@@ -809,5 +701,52 @@ class ilCertificateMigrationJob extends AbstractJob
 		\ilDatePresentation::setUseRelativeDates($oldDatePresentationStatus);
 
 		return $xslfo;
+	}
+
+	/**
+	 * @param $objectId
+	 * @param $adapter
+	 * @param $object
+	 * @param $data
+	 * @return array
+	 */
+	protected function createCertificateData(
+		$objectId,
+		\ilCertificateAdapter $adapter,
+		\ilObject $object,
+		array $data
+	): array
+	{
+		if (\ilCertificate::isActive() && \ilCertificate::isObjectActive($objectId)) {
+			if (file_exists($adapter->getCertificatePath())) {
+				$cert_path = $adapter->getCertificatePath();
+				$xsl_path = $cert_path . "certificate.xml";
+
+				if (file_exists($xsl_path) && (filesize($xsl_path) > 0)) {
+					$this->logMessage('Found certificate with id: ' . $objectId, 'debug');
+
+					$webdir = $cert_path . "background.jpg";
+
+					$background_image_path = str_replace(
+						\ilUtil::removeTrailingPathSeparators(CLIENT_WEB_DIR),
+						'',
+						$webdir
+					);
+
+					$data[] = array(
+						"obj_id" => $objectId,
+						"user_id" => $this->user_id,
+						"certificate_path" => $cert_path,
+						"certificate_type" => $object->getType(),
+						"background_image_path" => $background_image_path,
+						"acquired_timestamp" => null,
+						"ilias_version" => ILIAS_VERSION_NUMERIC,
+						"certificate_content" => null,
+					);
+				}
+			}
+		}
+
+		return $data;
 	}
 }

--- a/Services/Certificate/classes/BackgroundTasks/class.ilCertificateMigrationJob.php
+++ b/Services/Certificate/classes/BackgroundTasks/class.ilCertificateMigrationJob.php
@@ -469,7 +469,6 @@ class ilCertificateMigrationJob extends AbstractJob
 						$object->setSubType($type);
 
 						$adapter = new \ilSCORMCertificateAdapter($object);
-
 						$data = $this->createCertificateData($objectId, $adapter, $object, $data);
 					}
 				}
@@ -502,9 +501,7 @@ class ilCertificateMigrationJob extends AbstractJob
 			$session = $session->getSession(null);
 			if ($object->canShowCertificate($session, $session->getUserId(), $session->getActiveId()))
 			{
-
 				$adapter = new \ilTestCertificateAdapter($object);
-
 				$data = $this->createCertificateData($objectId, $adapter, $object, $data);
 			}
 		}
@@ -534,7 +531,6 @@ class ilCertificateMigrationJob extends AbstractJob
 			if ($object->hasUserCertificate($this->user_id))
 			{
 				$adapter = new \ilExerciseCertificateAdapter($object);
-
 				$data = $this->createCertificateData($objectId, $adapter, $object, $data);
 			}
 		}

--- a/Services/Certificate/classes/BackgroundTasks/class.ilCertificateMigrationJob.php
+++ b/Services/Certificate/classes/BackgroundTasks/class.ilCertificateMigrationJob.php
@@ -488,6 +488,7 @@ class ilCertificateMigrationJob extends AbstractJob
 									$data[] = array(
 										"obj_id" => $objectId,
 										"user_id" => $this->user_id,
+										"certificate_path" => $cert_path,
 										"certificate_type" => $object->getType(),
 										"background_image_path" => $background_image_path,
 										"acquired_timestamp" => null,

--- a/Services/Certificate/classes/BackgroundTasks/class.ilCertificateMigrationJob.php
+++ b/Services/Certificate/classes/BackgroundTasks/class.ilCertificateMigrationJob.php
@@ -706,7 +706,7 @@ class ilCertificateMigrationJob extends AbstractJob
 	 * @param $data
 	 * @return array
 	 */
-	protected function createCertificateData(
+	private function createCertificateData(
 		$objectId,
 		\ilCertificateAdapter $adapter,
 		\ilObject $object,


### PR DESCRIPTION
This PR reduces the code duplication in `ilCertificateMigrationJob`.

I recommend to check the single commits to validate the history of changes.