### PR TITLE
[Certificates] Use Completion Datetime for Migrated Certificates instead file modified time

### DIFF
--- a/Services/Certificate/classes/BackgroundTasks/class.ilCertificateMigrationJob.php
+++ b/Services/Certificate/classes/BackgroundTasks/class.ilCertificateMigrationJob.php
@@ -662,7 +662,7 @@ class ilCertificateMigrationJob extends AbstractJob
 			'Successful renedered certificate for (type, obj_id, usr_id): ' . $cert_data['certificate_type'] . ', ' . $cert_data['obj_id'] . ', ' . $this->user_id
 		);
 
-		$cert_data['acquired_timestamp'] = 0;
+		$cert_data['acquired_timestamp'] = time();
 		if (true === isset($insert_tags['[DATETIME_COMPLETED_UNIX]'])) {
 			$cert_data['acquired_timestamp'] = $insert_tags['[DATETIME_COMPLETED_UNIX]'];
 		}

--- a/Services/Certificate/classes/BackgroundTasks/class.ilCertificateMigrationJob.php
+++ b/Services/Certificate/classes/BackgroundTasks/class.ilCertificateMigrationJob.php
@@ -556,17 +556,16 @@ class ilCertificateMigrationJob extends AbstractJob
 			$cert_path = $cert_data['certificate_path'] . "certificate.xml";
 			if (file_exists($cert_path) && (filesize($cert_path) > 0))
 			{
-				$cert_data = $this->addContentToCertificateData($cert_data);
-				$cert_data['acquired_timestamp'] = filemtime($cert_path);
+				$cert_data = $this->addContentAndTimestampToCertificateData($cert_data);
 			}
 		}
 	}
 
 	/**
 	 * @param array $cert_data
-	 * @return string
+	 * @return array
 	 */
-	private function addContentToCertificateData(array $cert_data): string
+	private function addContentAndTimestampToCertificateData(array $cert_data): array
 	{
 		$oldDatePresentationStatus = \ilDatePresentation::useRelativeDates();
 		\ilDatePresentation::setUseRelativeDates(false);
@@ -662,6 +661,11 @@ class ilCertificateMigrationJob extends AbstractJob
 		$this->logger->debug(
 			'Successful renedered certificate for (type, obj_id, usr_id): ' . $cert_data['certificate_type'] . ', ' . $cert_data['obj_id'] . ', ' . $this->user_id
 		);
+
+		$cert_data['acquired_timestamp'] = 0;
+		if (true === isset($insert_tags['[DATETIME_COMPLETED_UNIX]'])) {
+			$cert_data['acquired_timestamp'] = $insert_tags['[DATETIME_COMPLETED_UNIX]'];
+		}
 
 		\ilDatePresentation::setUseRelativeDates($oldDatePresentationStatus);
 

--- a/Services/Certificate/classes/BackgroundTasks/class.ilCertificateMigrationJob.php
+++ b/Services/Certificate/classes/BackgroundTasks/class.ilCertificateMigrationJob.php
@@ -556,8 +556,8 @@ class ilCertificateMigrationJob extends AbstractJob
 			$cert_path = $cert_data['certificate_path'] . "certificate.xml";
 			if (file_exists($cert_path) && (filesize($cert_path) > 0))
 			{
+				$cert_data = $this->addContentToCertificateData($cert_data);
 				$cert_data['acquired_timestamp'] = filemtime($cert_path);
-				$cert_data['certificate_content'] = $this->renderCertificate($cert_data);
 			}
 		}
 	}
@@ -566,7 +566,7 @@ class ilCertificateMigrationJob extends AbstractJob
 	 * @param array $cert_data
 	 * @return string
 	 */
-	protected function renderCertificate(array $cert_data): string
+	private function addContentToCertificateData(array $cert_data): string
 	{
 		$oldDatePresentationStatus = \ilDatePresentation::useRelativeDates();
 		\ilDatePresentation::setUseRelativeDates(false);
@@ -665,7 +665,9 @@ class ilCertificateMigrationJob extends AbstractJob
 
 		\ilDatePresentation::setUseRelativeDates($oldDatePresentationStatus);
 
-		return $xslfo;
+		$cert_data['certificate_content'] = $xslfo;
+
+		return $cert_data;
 	}
 
 	/**

--- a/Services/Certificate/classes/class.ilCertificateAdapter.php
+++ b/Services/Certificate/classes/class.ilCertificateAdapter.php
@@ -316,7 +316,10 @@ abstract class ilCertificateAdapter
 		if($a_completion_date)
 		{
 			$vars["DATE_COMPLETED"] = ilDatePresentation::formatDate(new ilDate($a_completion_date, IL_CAL_DATETIME));
-			$vars["DATETIME_COMPLETED"] = ilDatePresentation::formatDate(new ilDateTime($a_completion_date, IL_CAL_DATETIME));
+
+			$dateTime = new ilDateTime($a_completion_date, IL_CAL_DATETIME);
+			$vars["DATETIME_COMPLETED"] = ilDatePresentation::formatDate($dateTime);
+			$vars["DATETIME_COMPLETED_UNIX"] = $dateTime->get(IL_CAL_UNIX);
 		}
 		
 		ilDatePresentation::setUseRelativeDates($old);


### PR DESCRIPTION
This PR uses the actual completion date/time instead of `filemtime()`.

Mantis reference: https://mantis.ilias.de/view.php?id=23865