### PR TITLE
[Test] ilAuth is not a valid argument for DIC + is not used anywhere in the method

### DIFF
--- a/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -748,9 +748,6 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
 
 	function finishTestCmd($requires_confirmation = true)
 	{
-		global $DIC;
-		$ilAuth = $DIC['ilAuth'];
-
 		unset($_SESSION["tst_next"]);
 
 		$active_id = $this->testSession->getActiveId();


### PR DESCRIPTION
This leads to an exception.

See Mantis reference: https://mantis.ilias.de/view.php?id=24000