### PR TITLE
Centralize block News configurations in a subtab

### DIFF
--- a/Modules/Category/classes/class.ilObjCategoryGUI.php
+++ b/Modules/Category/classes/class.ilObjCategoryGUI.php
@@ -256,6 +256,7 @@ class ilObjCategoryGUI extends ilContainerGUI
 				$this->setEditTabs();
 				$this->tabs_gui->activateSubTab('obj_news_settings');
 				$news_set_gui = new ilContainerNewsSettingsGUI($this);
+				$news_set_gui->setHideByDate(true);
 				$this->ctrl->forwardCommand($news_set_gui);
 				break;
 

--- a/Modules/Category/classes/class.ilObjCategoryGUI.php
+++ b/Modules/Category/classes/class.ilObjCategoryGUI.php
@@ -252,6 +252,8 @@ class ilObjCategoryGUI extends ilContainerGUI
 
 			case "ilcontainernewssettingsgui":
 				$this->prepareOutput();
+				$this->tabs_gui->setTabActive('settings');
+				$this->setEditTabs();
 				$this->tabs_gui->activateSubTab('obj_news_settings');
 				$news_set_gui = new ilContainerNewsSettingsGUI($this);
 				$this->ctrl->forwardCommand($news_set_gui);

--- a/Modules/Category/classes/class.ilObjCategoryGUI.php
+++ b/Modules/Category/classes/class.ilObjCategoryGUI.php
@@ -250,6 +250,13 @@ class ilObjCategoryGUI extends ilContainerGUI
 				$this->ctrl->forwardCommand($this->getObjectMetadataGUI());
 				break;
 
+			case "ilcontainernewssettingsgui":
+				$this->prepareOutput();
+				$this->tabs_gui->activateSubTab('obj_news_settings');
+				$news_set_gui = new ilContainerNewsSettingsGUI($this);
+				$this->ctrl->forwardCommand($news_set_gui);
+				break;
+
 			default:
 				if ($cmd == "infoScreen")
 				{
@@ -704,6 +711,19 @@ class ilObjCategoryGUI extends ilContainerGUI
 		$this->tabs_gui->addSubTab("settings_trans",
 			$this->lng->txt("obj_multilinguality"),
 			$this->ctrl->getLinkTargetByClass("ilobjecttranslationgui", ""));
+
+		//news tab
+		$news_active = ilContainer::_lookupContainerSetting(
+			$this->object->getId(),
+			ilObjectServiceSettingsGUI::NEWS_VISIBILITY,
+			true);
+
+		if($news_active)
+		{
+			$this->tabs_gui->addSubTab('obj_news_settings',
+				$this->lng->txt("cont_news_settings"),
+				$this->ctrl->getLinkTargetByClass('ilcontainernewssettingsgui'));
+		}
 
 		$this->tabs_gui->activateTab("settings");
 		$this->tabs_gui->activateSubTab($active_tab);

--- a/Modules/Course/classes/class.ilObjCourseGUI.php
+++ b/Modules/Course/classes/class.ilObjCourseGUI.php
@@ -2596,12 +2596,13 @@ class ilObjCourseGUI extends ilContainerGUI
 				break;
 
 			case "ilcontainernewssettingsgui":
-
 				$this->setSubTabs("properties");
 				$this->tabs_gui->activateTab('settings');
 				$this->tabs_gui->activateSubTab('obj_news_settings');
-				include_once("./Services/Container/classes/class.ilContainerNewsSettingsGUI.php");
 				$news_set_gui = new ilContainerNewsSettingsGUI($this);
+				$news_set_gui->setTimeline(true);
+				$news_set_gui->setCronNotifications(true);
+				$news_set_gui->setHideByDate(true);
 				$this->ctrl->forwardCommand($news_set_gui);
 				break;
 

--- a/Modules/Forum/classes/class.ilForumSettingsGUI.php
+++ b/Modules/Forum/classes/class.ilForumSettingsGUI.php
@@ -167,6 +167,10 @@ class ilForumSettingsGUI
 				}
 			}
 		}
+		//news subtab
+		$this->lng->loadLanguageModule('forum');
+		$this->tabs->addSubTab('obj_news_settings', $this->lng->txt("cont_news_settings"), $this->ctrl->getLinkTargetByClass('ilcontainernewssettingsgui'));
+
 		return true;
 	}
 

--- a/Modules/Forum/classes/class.ilObjForumGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumGUI.php
@@ -11,7 +11,7 @@ use ILIAS\UI\Renderer;
  * @ilCtrl_Calls ilObjForumGUI: ilPermissionGUI, ilForumExportGUI, ilInfoScreenGUI
  * @ilCtrl_Calls ilObjForumGUI: ilColumnGUI, ilPublicUserProfileGUI, ilForumModeratorsGUI, ilRepositoryObjectSearchGUI
  * @ilCtrl_Calls ilObjForumGUI: ilObjectCopyGUI, ilExportGUI, ilCommonActionDispatcherGUI, ilRatingGUI
- * @ilCtrl_Calls ilObjForumGUI: ilForumSettingsGUI
+ * @ilCtrl_Calls ilObjForumGUI: ilForumSettingsGUI, ilContainerNewsSettingsGUI
  *
  * @ingroup ModulesForum
  */
@@ -310,6 +310,14 @@ class ilObjForumGUI extends \ilObjectGUI implements \ilDesktopItemHandling
 			case 'ilcommonactiondispatchergui':
 				$gui = ilCommonActionDispatcherGUI::getInstanceFromAjaxCall();
 				$this->ctrl->forwardCommand($gui);
+				break;
+
+			case "ilcontainernewssettingsgui":
+				$this->tabs_gui->setTabActive('settings');
+				$this->tabs_gui->activateSubTab('obj_news_settings');
+				$news_set_gui = new ilContainerNewsSettingsGUI($this);
+				$news_set_gui->setPublicNotification(true);
+				$this->ctrl->forwardCommand($news_set_gui);
 				break;
 
 			default:

--- a/Modules/Forum/classes/class.ilObjForumGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumGUI.php
@@ -316,6 +316,7 @@ class ilObjForumGUI extends \ilObjectGUI implements \ilDesktopItemHandling
 				$this->tabs_gui->setTabActive('settings');
 				$this->tabs_gui->activateSubTab('obj_news_settings');
 				$news_set_gui = new ilContainerNewsSettingsGUI($this);
+				$news_set_gui->setNewsBlockForced(true);
 				$news_set_gui->setPublicNotification(true);
 				$this->ctrl->forwardCommand($news_set_gui);
 				break;

--- a/Services/Container/classes/class.ilContainerNewsSettingsGUI.php
+++ b/Services/Container/classes/class.ilContainerNewsSettingsGUI.php
@@ -57,6 +57,11 @@ class ilContainerNewsSettingsGUI
 	protected $has_hide_by_date;
 
 	/**
+	 * @var
+	 */
+	protected $has_public_notification;
+
+	/**
 	 * Constructor
 	 */
 	function __construct(ilObjectGUI $a_parent_gui)
@@ -109,23 +114,27 @@ class ilContainerNewsSettingsGUI
 	 */
 	public function initForm()
 	{
-		//include_once("./Services/Object/classes/class.ilObjectServiceSettingsGUI.php");
-		//include_once("Services/Form/classes/class.ilPropertyFormGUI.php");
-
 		$form = new ilPropertyFormGUI();
 
-		if($this->setting->get('block_activated_news'))
-		{
+		//from crs/grp/cat settings - additional feature - news
+		//TODO uncomment conditionals.
+		//if($this->setting->get('block_activated_news'))
+		//{
 			// Container tools (calendar, news, ... activation)
-			$news = new ilCheckboxInputGUI($this->lng->txt('news_news_block'), ilObjectServiceSettingsGUI::NEWS_VISIBILITY);
-			$news->setValue(1);
-			$news->setChecked($this->object->getNewsBlockActivated());
-			$news->setInfo($this->lng->txt('obj_tool_setting_news_info'));
+			//TODO THIS METHOD BELONGS TO CONTAINER NOT OBJECTS(forum,wiki) from classes which do not extend ilContainer we should
+			// call another gui class. Or create a new one more generic with the code of this class and remove this ilContainerNewsSettingsGUI class.
 
-			ilNewsForContextBlockGUI::addToSettingsForm($news);
+			//if(method_exists($this->object, 'getNewsBlockActivated')){
+				$news = new ilCheckboxInputGUI($this->lng->txt('news_news_block'), ilObjectServiceSettingsGUI::NEWS_VISIBILITY);
+				$news->setValue(1);
+				//TODO FIX THIS/MOVE THIS SETTING
+				//$news->setChecked($this->object->getNewsBlockActivated());
+				$news->setInfo($this->lng->txt('obj_tool_setting_news_info'));
+				ilNewsForContextBlockGUI::addToSettingsForm($news);
+				$form->addItem($news);
+			//}
 
-			$form->addItem($news);
-		}
+		//}
 
 		// Timeline (courses and groups)
 		if($this->has_timeline)
@@ -173,6 +182,7 @@ class ilContainerNewsSettingsGUI
 			}
 		}
 
+		// Hide news before a date (courses, groups and categories)
 		if($this->has_hide_by_date)
 		{
 			//Hide news per date
@@ -194,6 +204,21 @@ class ilContainerNewsSettingsGUI
 			$hnpd->addSubItem($dt_prop);
 
 			$form->addItem($hnpd);
+		}
+
+		// public notifications (forums)
+		//TODO -> difference with has_cron_notifications (crs,grp)?¿
+		/**
+		 * TODO Working here. Add the logic
+		 */
+		if($this->has_public_notification)
+		{
+			//$public = ilBlockSetting::_lookup($this->getBlockType(), "public_notifications", 0, $this->block_id);
+			$ch = new ilCheckboxInputGUI($this->lng->txt("news_notifications_public"),
+				"notifications_public");
+			$ch->setInfo($this->lng->txt("news_notifications_public_info"));
+			//$ch->setChecked($public);
+			$form->addItem($ch);
 		}
 
 		$form->setTitle($this->lng->txt("cont_news_settings"));
@@ -310,6 +335,24 @@ class ilContainerNewsSettingsGUI
 	public function getHideByDate() : bool
 	{
 		return $this->has_hide_by_date;
+	}
+
+	/**
+	 * Set if this repository object has public notifications
+	 * @param bool $a_value
+	 */
+	public function setPublicNotification(bool $a_value)
+	{
+		$this->has_public_notification = $a_value;
+	}
+
+	/**
+	 * Get if this repository object has public notifications available.
+	 * @return bool
+	 */
+	public function getPublicNotification()
+	{
+		return $this->has_public_notification;
 	}
 
 }

--- a/Services/Container/classes/class.ilContainerNewsSettingsGUI.php
+++ b/Services/Container/classes/class.ilContainerNewsSettingsGUI.php
@@ -289,9 +289,27 @@ class ilContainerNewsSettingsGUI
 	 * Get if the container has a configurable cron job to send notifications.
 	 * @return mixed
 	 */
-	public function getCronNotifications()
+	public function getCronNotifications(): bool
 	{
 		return $this->getCronNotifications();
+	}
+
+	/**
+	 * Set if the container can hide news created before a date
+	 * @param bool $a_value
+	 */
+	public function setHideByDate(bool $a_value)
+	{
+		$this->has_hide_by_date = $a_value;
+	}
+
+	/**
+	 * Get if the container can hide news created before a date.
+	 * @return bool
+	 */
+	public function getHideByDate() : bool
+	{
+		return $this->has_hide_by_date;
 	}
 
 }

--- a/Services/Container/classes/class.ilContainerNewsSettingsGUI.php
+++ b/Services/Container/classes/class.ilContainerNewsSettingsGUI.php
@@ -129,6 +129,7 @@ class ilContainerNewsSettingsGUI
 			$news->setValue(1);
 			if($this->has_block_forced){
 				$news->setChecked(true);
+				$news->setDisabled(true);
 			} else {
 				$news->setChecked($this->object->getNewsBlockActivated());
 			}

--- a/Services/News/classes/class.ilNewsForContextBlockGUI.php
+++ b/Services/News/classes/class.ilNewsForContextBlockGUI.php
@@ -18,6 +18,11 @@ include_once("Services/Block/classes/class.ilBlockGUI.php");
 class ilNewsForContextBlockGUI extends ilBlockGUI
 {
 	/**
+	 * object type names with settings->news settings subtab
+	 */
+	const OBJECTS_WITH_NEWS_SUBTAB = ["category", "course", "group", "forum"];
+
+	/**
 	 * @var ilHelpGUI
 	 */
 	protected $help;
@@ -348,7 +353,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
 
 			$ilCtrl->setParameterByClass("ilcontainernewssettingsgui", "ref_id", $ref_id);
 
-			if (in_array($obj_class, ["category", "course", "group"]))
+			if (in_array($obj_class, ilNewsForContextBlockGUI::OBJECTS_WITH_NEWS_SUBTAB))
 			{
 				$this->addBlockCommand(
 					$ilCtrl->getLinkTargetByClass(array("ilrepositorygui", $parent_gui, "ilcontainernewssettingsgui"), "show"),


### PR DESCRIPTION
This Pull Request wants to provide a solution for this bug report:
https://mantis.ilias.de/view.php?id=23755	

Everything starts with this already implemented feature -> https://docu.ilias.de/ilias.php?ref_id=1357&page=Centralising_News_Settings&cmd=preview&cmdClass=ilwikipagegui&cmdNode=g9:g8:ge&baseClass=ilwikihandlergui

We had to deal with a more complex scenario since not only courses and groups are using the block "news", not all objects which are using it are containers, and some of them don't have the news settings sub-tab

The resulting form will have the specific input fields depending on the GUI object.
Container objects:
	- Courses and Groups had 2 different places to edit the settings. I centralize these options in settings->news settings sub-tab.
    - Categories didn't have this settings sub-tab.

Non Container objects:
	-Forums didn't have this news settings sub-tab and don't extend the class ilContainerGUI like categories,groups and courses.
