### PR TITLE
bug #23082: fix style export for html export

### DIFF
--- a/Services/Style/System/classes/class.ilSystemStyleHTMLExport.php
+++ b/Services/Style/System/classes/class.ilSystemStyleHTMLExport.php
@@ -45,7 +45,6 @@ class ilSystemStyleHTMLExport
 	function createDirectories()
 	{
 		ilUtil::makeDir($this->style_dir);
-		ilUtil::makeDir($this->style_img_dir);
 		ilUtil::makeDir($this->img_dir);
 		ilUtil::makeDir($this->img_browser_dir);
 	}
@@ -70,24 +69,21 @@ class ilSystemStyleHTMLExport
 		global $ilUser;
 		
 		$this->createDirectories();
-		
+
 		// export system style sheet
 		$location_stylesheet = ilUtil::getStyleSheetLocation("filesystem");
-		$style_name = $ilUser->prefs["style"].".css";
-		copy($location_stylesheet, $this->style_dir."/".$style_name);
-		$fh = fopen($location_stylesheet, "r");
-		$css = fread($fh, filesize($location_stylesheet));
-		preg_match_all("/url\(([^\)]*)\)/",$css,$files);
-		foreach (array_unique($files[1]) as $fileref)
-		{
-			$fileref = dirname($location_stylesheet)."/".$fileref;
-			if (is_file($fileref))
-			{
-				copy($fileref, $this->style_img_dir."/".basename($fileref));
+		foreach (
+			$iterator = new \RecursiveIteratorIterator(
+				new \RecursiveDirectoryIterator(dirname($location_stylesheet), \RecursiveDirectoryIterator::SKIP_DOTS),
+				\RecursiveIteratorIterator::SELF_FIRST) as $item
+		) {
+			if ($item->isDir()) {
+				mkdir($this->style_dir . DIRECTORY_SEPARATOR . $iterator->getSubPathName());
+			} else {
+				copy($item, $this->style_dir . DIRECTORY_SEPARATOR . $iterator->getSubPathName());
 			}
 		}
-		fclose($fh);
-		
+
 		// export (icon) images
 		foreach ($this->images as $im)
 		{


### PR DESCRIPTION
This fixes part of bug https://mantis.ilias.de/view.php?id=23083 (woff files). This export needs some revision in general. It tried to read resources from the css. The new routine just copies the folder completely.

Since the system style folder is not a valid source for copying yet, the file service cannot be used yet. So this should only be a temporary workaround (however PHP copy has been used in the old solution, too).