### PR TITLE
UI Signal as an action for Images

### DIFF
--- a/src/UI/Component/Image/Image.php
+++ b/src/UI/Component/Image/Image.php
@@ -4,13 +4,17 @@
 
 namespace ILIAS\UI\Component\Image;
 
+use ILIAS\UI\Component\JavaScriptBindable;
+use ILIAS\UI\Component\Clickable;
+use ILIAS\UI\Component\Signal;
+
 /**
  * This describes how a glyph could be modified during construction of UI.
  *
  * Interface Image
  * @package ILIAS\UI\Component\Image
  */
-interface Image extends \ILIAS\UI\Component\Component {
+interface Image extends \ILIAS\UI\Component\Component, JavaScriptBindable, Clickable {
 	/**
 	 * Types of images
 	 */
@@ -52,14 +56,14 @@ interface Image extends \ILIAS\UI\Component\Component {
 
 	/**
 	 * Get an image like this with an action
-	 * @param string $url
+	 * @param string|Signal[] $action
 	 * @return \ILIAS\UI\Component\Image\Image
 	 */
-	public function withAction($url);
+	public function withAction($action);
 
 	/**
 	 * Get the action of the image
-	 * @return string|null
+	 * @return string|Signal[]
 	 */
 	public function getAction();
 }

--- a/src/UI/Factory.php
+++ b/src/UI/Factory.php
@@ -93,13 +93,14 @@ interface Factory {
 	 * description:
 	 *   purpose: The Image component is used to display images of various sources.
 	 *   composition: An Image is composed of the image and an alternative text for screen readers.
-	 *   effect: >
-	 *     Images may be included in interacted components. Images may also be interactive on their own. Clicking on
-	 *     an Image can e.g. provide navigation to another screen or showing a Modal on the same screen. The usage of
-	 *     an interactive Image MUST be confirmed by the JF to make sure that interactive Images will only be used
-	 *     in meaningful cases.
 	 *
 	 * rules:
+	 *   interaction:
+	 *     1: >
+	 *        Images MAY be included in interacted components. Images MAY also be interactive on their own. Clicking on
+	 *        an Image can e.g. provide navigation to another screen or showing a Modal on the same screen. The usage
+	 *        of an interactive Image MUST be confirmed by the JF to make sure that interactive Images will only be
+	 *        used in meaningful cases.
 	 *   accessibility:
 	 *     1: >
 	 *        Images MUST contain the alt attribute. This attribute MAY be left empty (alt="") if the image is of

--- a/src/UI/Factory.php
+++ b/src/UI/Factory.php
@@ -97,7 +97,7 @@ interface Factory {
 	 * rules:
 	 *   interaction:
 	 *     1: >
-	 *        Images MAY be included in interacted components. Images MAY also be interactive on their own. Clicking on
+	 *        Images MAY be included in interactive components. Images MAY also be interactive on their own. Clicking on
 	 *        an Image can e.g. provide navigation to another screen or showing a Modal on the same screen. The usage
 	 *        of an interactive Image MUST be confirmed by the JF to make sure that interactive Images will only be
 	 *        used in meaningful cases.

--- a/src/UI/Factory.php
+++ b/src/UI/Factory.php
@@ -93,7 +93,11 @@ interface Factory {
 	 * description:
 	 *   purpose: The Image component is used to display images of various sources.
 	 *   composition: An Image is composed of the image and an alternative text for screen readers.
-	 *   effect: Images may be included in interacted components but not interactive on their own.
+	 *   effect: >
+	 *     Images may be included in interacted components. Images may also be interactive on their own. Clicking on
+	 *     an Image can e.g. provide navigation to another screen or showing a Modal on the same screen. The usage of
+	 *     an interactive Image MUST be confirmed by the JF to make sure that interactive Images will only be used
+	 *     in meaningful cases.
 	 *
 	 * rules:
 	 *   accessibility:

--- a/src/UI/Implementation/Component/Image/Image.php
+++ b/src/UI/Implementation/Component/Image/Image.php
@@ -6,6 +6,9 @@ namespace ILIAS\UI\Implementation\Component\Image;
 
 use ILIAS\UI\Component as C;
 use ILIAS\UI\Implementation\Component\ComponentHelper;
+use ILIAS\UI\Component\Signal;
+use ILIAS\UI\Implementation\Component\JavaScriptBindable;
+use ILIAS\UI\Implementation\Component\Triggerer;
 
 /**
  * Class Image
@@ -13,6 +16,8 @@ use ILIAS\UI\Implementation\Component\ComponentHelper;
  */
 class Image implements C\Image\Image {
 	use ComponentHelper;
+	use JavaScriptBindable;
+	use Triggerer;
 
 	/**
 	 * @var	string
@@ -32,7 +37,7 @@ class Image implements C\Image\Image {
 	/**
 	 * @var string
 	 */
-	protected $url = '';
+	protected $action = '';
 
 	/**
 	 * @var []
@@ -102,11 +107,16 @@ class Image implements C\Image\Image {
 	/**
 	 * @inheritdoc
 	 */
-	public function withAction($url) {
-		$this->checkStringArg("url", $url);
-
+	public function withAction($action) {
+		$this->checkStringOrSignalArg("action", $action);
 		$clone = clone $this;
-		$clone->url = $url;
+		if (is_string($action)) {
+			$clone->action = $action;
+		}
+		else {
+			$clone->action = null;
+			$clone->setTriggeredSignal($action, "click");
+		}
 
 		return $clone;
 	}
@@ -115,6 +125,23 @@ class Image implements C\Image\Image {
 	 * @inheritdoc
 	 */
 	public function getAction() {
-		return $this->url;
+		if ($this->action !== null) {
+			return $this->action;
+		}
+		return $this->getTriggeredSignalsFor("click");
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function withOnClick(Signal $signal) {
+		return $this->withTriggeredSignal($signal, 'click');
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function appendOnClick(Signal $signal) {
+		return $this->appendTriggeredSignal($signal, 'click');
 	}
 }

--- a/src/UI/Implementation/Component/Image/Renderer.php
+++ b/src/UI/Implementation/Component/Image/Renderer.php
@@ -23,10 +23,21 @@ class Renderer extends AbstractComponentRenderer {
 		$this->checkComponent($component);
 		$tpl = $this->getTemplate("tpl.image.html", true, true);
 
-		if($component->getAction()) {
-			$tpl->setCurrentBlock("action_begin");
-			$tpl->setVariable("HREF",$component->getAction());
-			$tpl->parseCurrentBlock();
+		$id = $this->bindJavaScript($component);
+		if (!empty($component->getAction())) {
+			$tpl->touchBlock("action_begin");
+
+			if (is_string($component->getAction())) {
+				$tpl->setCurrentBlock("with_href");
+				$tpl->setVariable("HREF", $component->getAction());
+				$tpl->parseCurrentBlock();
+			}
+
+			if (is_array($component->getAction())) {
+				$tpl->setCurrentBlock("with_id");
+				$tpl->setVariable("ID", $id);
+				$tpl->parseCurrentBlock();
+			}
 		}
 
 		$tpl->setCurrentBlock($component->getType());
@@ -34,7 +45,7 @@ class Renderer extends AbstractComponentRenderer {
 		$tpl->setVariable("ALT",htmlspecialchars($component->getAlt()));
 		$tpl->parseCurrentBlock();
 
-		if($component->getAction()) {
+		if (!empty($component->getAction())) {
 			$tpl->touchBlock("action_end");
 		}
 

--- a/src/UI/examples/Image/Standard/with_signal_action.php
+++ b/src/UI/examples/Image/Standard/with_signal_action.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Example for rendering an Image with a signal as action
+ */
+function with_signal_action() {
+	//Loading factories
+	global $DIC;
+	$f = $DIC->ui()->factory();
+	$renderer = $DIC->ui()->renderer();
+
+	//Genarating and rendering the image and modal
+	$image_in_modal = $f->image()->standard(
+		"src/UI/examples/Image/mountains.jpg",
+		"");
+	$page = $f->modal()->lightboxImagePage($image_in_modal, "Nice view");
+	$modal = $f->modal()->lightbox($page);
+
+	$image = $f->image()->standard(
+		"src/UI/examples/Image/HeaderIconLarge.svg",
+		"Thumbnail Example")->withAction($modal->getShowSignal());
+
+	$html = $renderer->render([$image, $modal]);
+
+	return $html;
+}

--- a/src/UI/examples/Image/Standard/with_string_action.php
+++ b/src/UI/examples/Image/Standard/with_string_action.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Example for rendering an Image with a string as action
+ */
+function with_string_action() {
+	//Loading factories
+	global $DIC;
+	$f = $DIC->ui()->factory();
+	$renderer = $DIC->ui()->renderer();
+
+	//Genarating and rendering the image and modal
+	$image = $f->image()->standard(
+		"src/UI/examples/Image/HeaderIconLarge.svg",
+		"Thumbnail Example")->withAction("https://www.ilias.de");
+
+	$html = $renderer->render($image);
+
+	return $html;
+}

--- a/src/UI/templates/default/Image/tpl.image.html
+++ b/src/UI/templates/default/Image/tpl.image.html
@@ -1,5 +1,5 @@
 <!-- BEGIN action_begin -->
-<a href="{HREF}">
+<a<!-- BEGIN with_href --> href="{HREF}"<!-- END with_href --><!-- BEGIN with_id --> id="{ID}"<!-- END with_id -->>
 <!-- END action_begin -->
 
 <!-- BEGIN standard -->

--- a/tests/UI/Component/Image/ImageTest.php
+++ b/tests/UI/Component/Image/ImageTest.php
@@ -6,6 +6,7 @@ require_once(__DIR__."/../../../../libs/composer/vendor/autoload.php");
 require_once(__DIR__."/../../Base.php");
 
 use \ILIAS\UI\Component as C;
+use \ILIAS\UI\Implementation\Component\Signal;
 
 /**
  * Test on button implementation.
@@ -64,11 +65,19 @@ class ImageTest extends ILIAS_UI_TestBase {
 		$this->assertEquals("newAlt", $i->getAlt());
 	}
 
-	public function test_set_action() {
+	public function test_set_string_action() {
 		$f = $this->getImageFactory();
 		$i = $f->standard("source","alt");
 		$i = $i->withAction("newAction");
 		$this->assertEquals("newAction", $i->getAction());
+	}
+
+	public function test_set_signal_action() {
+		$f = $this->getImageFactory();
+		$signal = $this->createMock(C\Signal::class);
+		$i = $f->standard("source","alt");
+		$i = $i->withAction($signal);
+		$this->assertEquals([$signal], $i->getAction());
 	}
 
 	public function test_invalid_source(){
@@ -125,7 +134,7 @@ class ImageTest extends ILIAS_UI_TestBase {
 		$this->assertEquals($expected, $html);
 	}
 
-	public function test_render_with_action() {
+	public function test_render_with_string_action() {
 		$f = $this->getImageFactory();
 		$r = $this->getDefaultRenderer();
 		$i = $f->standard("source", "alt")->withAction("action");
@@ -133,6 +142,20 @@ class ImageTest extends ILIAS_UI_TestBase {
 		$html = $this->normalizeHTML($r->render($i));
 
 		$expected = "<a href=\"action\"><img src=\"source\" class=\"img-standard\" alt=\"alt\" /></a>";
+
+		$this->assertEquals($expected, $html);
+	}
+
+	public function test_render_with_signal_action() {
+		$f = $this->getImageFactory();
+		$r = $this->getDefaultRenderer();
+		$signal = $this->createMock(Signal::class);
+
+		$i = $f->standard("source", "alt")->withAction($signal);
+
+		$html = $this->normalizeHTML($r->render($i));
+
+		$expected = "<a id=\"id_1\"><img src=\"source\" class=\"img-standard\" alt=\"alt\" /></a>";
 
 		$this->assertEquals($expected, $html);
 	}


### PR DESCRIPTION
This adds the option to give an Image a Signal as an action. At the moment, only strings are allowed.
See also this [Feature Request](https://docu.ilias.de/goto_docu_wiki_wpage_5561_1357.html): Badges will be represented in a Deck of Cards. Clicking on one Card respectively the Image in the Card must open a Modal. A similar case has been added as an [example](https://github.com/ILIAS-eLearning/ILIAS/pull/1337/files#diff-3f2a0c6bf8dfd42e7396a3fac2c98c15).