### PR TITLE
Fixed 0024192: Mail to members does not filter by position access

### DIFF
--- a/Services/Contact/classes/class.ilMailMemberSearchGUI.php
+++ b/Services/Contact/classes/class.ilMailMemberSearchGUI.php
@@ -247,7 +247,7 @@ class ilMailMemberSearchGUI
 		
 		$this->tpl->getStandardTemplate();
 		$tbl = new ilMailMemberSearchTableGUI($this, 'showSelectableUsers');
-		$provider = new ilMailMemberSearchDataProvider($this->getObjParticipants());
+		$provider = new ilMailMemberSearchDataProvider($this->getObjParticipants(),$this->ref_id);
 		$tbl->setData($provider->getData());
 
 		$this->tpl->setContent($tbl->getHTML());


### PR DESCRIPTION
@mjansenDatabay This fixes issue https://mantis.ilias.de/view.php?id=24192

Selectable users are filtered by position access 'manage_members' in courses and groups if no access via membership (read) is granted.