### PR TITLE
UI Guideline Update

### DIFF
--- a/src/UI/README.md
+++ b/src/UI/README.md
@@ -405,7 +405,13 @@ If you would like to implement a new component to the framework you should perfo
 
 ### How to Change an Existing Component?
 
-TODO: write me
+1. Create a new branch based on the current trunk.
+2. Implement your changes and create a PR on the current trunk.
+3. Clearly state in the description of the PR, why you believe the change to be necessary.
+If your change fixes a bug, link to the according bugfix. If you need the change for implementing a feature, link
+the Feature Request. If you are changing the interface of a component, your proposal will be discussed in the next JF 
+(see: [rules](./docu/rules) ).
+
 
 ## Abstraction of Javascript in the Framework
 

--- a/src/UI/docu/rules.md
+++ b/src/UI/docu/rules.md
@@ -1,10 +1,9 @@
-# Jour Fixe Proposal to introduce a centralizes UI-Framework for ILIAS.
+# Guideline for Collaboration in the UI-Framework
 
-We suggest the following rules for the ILIAS UI framework. The UI framework
-currently is in a construction phase. The current form of the rules therefore
+The UI framework currently is in a construction phase. The current form of the rules therefore
 represents the best effort for the current state of the framework. It therefore
 is likely that there will be additions to or refinements of the rules in the
-(near) future. Everyone using the rules is invited to critically reflect the
+future. Everyone using the rules is invited to critically reflect the
 rules and propose changes.
 
 ## Basics

--- a/src/UI/docu/rules.md
+++ b/src/UI/docu/rules.md
@@ -28,6 +28,10 @@ rules and propose changes.
   github. The code in the pull request SHOULD obay the rules given in **Interfaces
   to Factories** and **Interfaces to UI components**. The existing unit tests for
   the UI framework SHOULD pass.
+* You SHOULD only propose one component per PR. If it simplifies the discussion
+  and/or makes the PR a lot easier to read and understand, you MAY bundle multiple
+  new components in one PR. Note that this implies, that they can only be accepted, 
+  if every single one is passes the requirements. This might be a potential risk.
 * The new method MUST be backed with a stub implementation down to the methods
   that represent concrete UI components, where said methods MUST raise
   ILIAS\UI\NotImplementedException upon call, if the UI component is not already

--- a/src/UI/docu/rules.md
+++ b/src/UI/docu/rules.md
@@ -28,9 +28,6 @@ rules and propose changes.
   github. The code in the pull request SHOULD obay the rules given in **Interfaces
   to Factories** and **Interfaces to UI components**. The existing unit tests for
   the UI framework SHOULD pass.
-* The pull request MAY be made from the edge branch in the ILIAS-repo. If the new
-  component is already implemented, the edge installation of ILIAS MAY be used
-  for showcasing the component.
 * The new method MUST be backed with a stub implementation down to the methods
   that represent concrete UI components, where said methods MUST raise
   ILIAS\UI\NotImplementedException upon call, if the UI component is not already


### PR DESCRIPTION
We propose to drop one outdated rule involving the edge branch of ILIAS and adding a new one concerning the number of components per PR. This last rule resulted due to the discussion of the rather larger number of components proposed at once in: https://github.com/ILIAS-eLearning/ILIAS/pull/1335

Further: Some improvement of the readme of the UI Components along with some re-wording in the guidelines. 