### PR TITLE
Test module: block illegal pass numbers

### DIFF
--- a/Modules/Test/classes/class.ilTestSession.php
+++ b/Modules/Test/classes/class.ilTestSession.php
@@ -413,8 +413,26 @@ class ilTestSession
 		return $this->pass;
 	}
 
+	private function checkIsValidPass($pass)
+	{
+		// check that the new pass index is actually a valid one.
+		$query = "SELECT nr_of_tries FROM tst_tests WHERE test_fi = %s";
+		global $ilDB;
+		$result = $ilDB->queryF(
+			$query, array('integer'), array($this->getTestId())
+		);
+		$row = $ilDB->fetchAssoc($result);
+		$nr_of_tries = intval($row['nr_of_tries']);
+
+		if ($nr_of_tries > 0 && $pass > $nr_of_tries) {
+			require_once 'Modules/Test/exceptions/class.ilTestException.php';
+			throw new ilTestException('illegal call to increasePass!');
+		}
+	}
+
 	function increasePass()
 	{
+		$this->checkIsValidPass($this->pass + 1);
 		$this->pass += 1;
 	}
 


### PR DESCRIPTION
This is a working and tested fix for a test module anomaly encountered through TestILIAS -  the exact reason for the underlying problem escapes me though.

The fix proposed in this PR is obviously hacky - please read this PR as a documented "hack" that was observed to work. All other places where I tried to fix this (e.g. in `performFinishTasks` and parts of the regular test logic), didn't succeed in preventing the problem.

Observed effect: in rare cases (about 1 in 1000 cases, high server load), ILIAS opens a second test pass in a test that is limited to a maximum of 1 pass. This effectively means losing the results of the first (valid) pass and having an empty result, which is bad.

Attached in the following zip are some very recent samples from test runs where this happens:

[lias-illegal-pass-anomaly.zip](https://github.com/ILIAS-eLearning/ILIAS/files/2647777/lias-illegal-pass-anomaly.zip)

Look at the xls files and observe the apparently empty rows in the "Testergebnisse" tab; indeed they are empty but for one illegal entry "2" in the "Durchlauf" column:

<img width="516" alt="pass-2" src="https://user-images.githubusercontent.com/25431384/49498684-2d010c80-f86c-11e8-9592-c7710ffd7540.png">

I believe this might happen due to autosave triggering an additional save after the test has been finished. This save then opens a new empty pass.