### PR TITLE
Test module: partial fix for race condition during test JS initialization

### DIFF
--- a/Modules/Test/js/ilTestPlayerQuestionEditControl.js
+++ b/Modules/Test/js/ilTestPlayerQuestionEditControl.js
@@ -104,6 +104,14 @@ il.TestPlayerQuestionEditControl = new function() {
 	 */
 	this.init = function(configParam) {
 
+	    // make sure users do not change answers until we are set up properly
+        $('body').css('pointer-events', 'none');
+        $(document).keydown(function(e) {
+            if (origData === '') { // not initialized yet?
+                e.preventDefault();
+            }
+        });
+
         // save the configuration parameters provided by ILIAS
         config = configParam;
 
@@ -228,6 +236,9 @@ il.TestPlayerQuestionEditControl = new function() {
         if (typeof tinyMCE != 'undefined') {
             activateMceSaveHandler();
         }
+
+        // we are set up now, user may change answer now.
+        $('body').css('pointer-events', '');
     }
 
     /**


### PR DESCRIPTION
Observe the following race condition (the JavaScript code refers to `Modules/Test/js/ilTestPlayerQuestionEditControl.js`):

(1) During test playback, a new question page is loaded in the browser
(2) from inside `this.init()`, `setTimeout(startTimers, START_TIMERS_DELAY);` gets called
(3) user changes current answer to a new solution.
(4) `startTimers` runs and sets `origData` to the current answer.
(5) save is triggered. It is detected that `origData == newData`, which means the answer is not saved.

(5) obviously is bad, since the answer (and the user's change) in (3) is lost.

Effect was observed in TestILIAS in about 1 in 1000 (high server load). On a real client, it's extremely improbable that (3) will happen before (4), as `START_TIMERS_DELAY` is 100 ms. With this change, the problem can no longer be reproduced in TestILIAS.

This fix works by injecting a `pointer-events: none` style in the `body` tag, thereby blocking all mouse events until initialization has finished. A similar approach is taken for `keydown` events. This approach works for various question types (tested using Firefox), however for TinyMCE it does not work - I did not find a good and simple fix here (the problem did not seem to occur there however).

