### PR TITLE
possible fix for not canceled link actions 'ilias.php' when selecting…

### DIFF
--- a/Services/UIComponent/Explorer2/js/Explorer2.js
+++ b/Services/UIComponent/Explorer2/js/Explorer2.js
@@ -59,7 +59,7 @@ il.Explorer2 = {
 		$(p).find("a").on("click", function (e) {
 			var href = $(this).attr("href");
 			var target = $(this).attr("target");
-			if (href != "#" && href != "") {
+			if (href != "#" && href != "" && href != "ilias.php") {
 				if (target == "_blank") {
 					window.open(href, '_blank');
 				} else {


### PR DESCRIPTION
… any tax node with ilTaxSelectInputGUI

@alex40724 this PR is about fixing bug. Mantis Tickets:
https://mantis.ilias.de/view.php?id=24241
and child reports:
https://mantis.ilias.de/view.php?id=24049
https://mantis.ilias.de/view.php?id=24239

I dont know if this is the best way to fix this, but I did not get it to invetigate for the actual change with 5.4. In ILIAS 5.3 this bug is NOT present.