### PR TITLE
possible fix for #24272: Portfolio List: Property Name/Values suffer …

### DIFF
--- a/src/UI/examples/Panel/Listing/Standard/with_lead_icon.php
+++ b/src/UI/examples/Panel/Listing/Standard/with_lead_icon.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * With lead icon
+ */
+function with_lead_icon() {
+	global $DIC;
+	$f = $DIC->ui()->factory();
+	$renderer = $DIC->ui()->renderer();
+
+	$actions = $f->dropdown()->standard(array(
+		$f->button()->shy("ILIAS", "https://www.ilias.de"),
+		$f->button()->shy("GitHub", "https://www.github.com")
+	));
+
+	$list_item1 = $f->item()->standard("ILIAS Beginner Course")
+		->withActions($actions)
+		->withProperties(array(
+			"Origin" => "Course Title 1",
+			"Last Update" => "24.11.2011",
+			"Location" => "Room 123, Main Street 44, 3012 Bern"))
+		->withDescription("Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.")
+		->withLeadIcon($f->icon()->standard('crs', 'Course', 'medium'));
+
+	$list_item2 = $f->item()->standard("ILIAS Advanced Course")
+		->withActions($actions)
+		->withProperties(array(
+			"Origin" => "Course Title 1",
+			"Last Update" => "24.11.2011",
+			"Location" => "Room 123, Main Street 44, 3012 Bern"))
+		->withDescription("Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.")
+		->withLeadIcon($f->icon()->standard('crs', 'Course', 'medium'));
+
+	$list_item3 = $f->item()->standard("ILIAS User Group")
+		->withActions($actions)
+		->withProperties(array(
+			"Origin" => "Course Title 1",
+			"Last Update" => "24.11.2011",
+			"Location" => "Room 123, Main Street 44, 3012 Bern"))
+		->withDescription("Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.")
+		->withLeadIcon($f->icon()->standard('grp', 'Group', 'medium'));
+
+	$std_list = $f->panel()->listing()->standard("Content", array(
+		$f->item()->group("Courses", array(
+			$list_item1,
+			$list_item2
+		)),
+		$f->item()->group("Groups", array(
+			$list_item3
+		))
+	));
+
+
+	return $renderer->render($std_list);
+}

--- a/src/UI/templates/default/Item/item.less
+++ b/src/UI/templates/default/Item/item.less
@@ -75,6 +75,7 @@
 
 .il-item-group-items {
 	clear: both;
+	max-width: @il-item-group-max-width;
 }
 
 /* this is currently experimental, could be removed */

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -7429,6 +7429,7 @@ hr.il-divider-with-label {
 }
 .il-item-group-items {
   clear: both;
+  max-width: 997px;
 }
 /* this is currently experimental, could be removed */
 .il-narrow-content .il-item {

--- a/templates/default/less/variables.less
+++ b/templates/default/less/variables.less
@@ -657,7 +657,7 @@
 @il-item-padding: 20px;
 @il-item-marker-border-left: 5px solid;
 @il-item-h5-margin: 4px 0px 2px 0px;
-
+@il-item-group-max-width: 997px;
 
 //== Listing Panel
 //


### PR DESCRIPTION
…from lots of space; added example for lead icon in item list panels

https://mantis.ilias.de/view.php?id=24272

997px is the max of the center column, if a left or a right column is presented.

This PR contains also an example for the item lists with icons, since this was missing.

Same view as in bug report after PR:

![bildschirmfoto 2018-12-10 um 11 55 19](https://user-images.githubusercontent.com/1221841/49728396-ed269480-fc72-11e8-87e1-a852d4c7727b.png)
