### PR TITLE
Enable OrgUnit Permissions for Plugins

### DIFF
--- a/Services/Object/classes/class.ilObjectDefinition.php
+++ b/Services/Object/classes/class.ilObjectDefinition.php
@@ -1237,7 +1237,8 @@ class ilObjectDefinition// extends ilSaxParser
 					'administration' => $isInAdministration?'1':'0',
 					"sideblock" => "0",
 					'export' => $ilPluginAdmin->supportsExport($component, $slotName, $slotId, $pl_name),
-					'offline_handling' => '0'
+					'offline_handling' => '0',
+					'orgunit_permissions' => $pl->useOrguPermissions() ? '1' : '0'
 				);
 				$parent_types = $pl->getParentTypes();
 				foreach($parent_types as $parent_type) {

--- a/Services/Repository/classes/class.ilRepositoryObjectPlugin.php
+++ b/Services/Repository/classes/class.ilRepositoryObjectPlugin.php
@@ -262,5 +262,16 @@ abstract class ilRepositoryObjectPlugin extends ilPlugin
 	{
 		return false;
 	}
+
+	/**
+	* Decide if this repository plugin uses OrgUnit Permissions
+	*
+	* @return bool
+	*/
+	public function useOrguPermissions(): bool
+	{
+		return false;
+	}
+
 }
 ?>


### PR DESCRIPTION
To enable OrgUnit-permissions for plugins, the according setting has to be in ObjectDefinition.
Default is "false".