### PR TITLE
Fix/0023674/trunk/wrong language for error message bug

### DIFF
--- a/Services/Form/classes/class.ilFileStandardDropzoneInputGUI.php
+++ b/Services/Form/classes/class.ilFileStandardDropzoneInputGUI.php
@@ -57,9 +57,9 @@ class ilFileStandardDropzoneInputGUI extends ilFileInputGUI implements ilToolbar
 	 */
 	protected $dropzone_message = '';
 	/**
-	 * @var string The error message which will be rendered if an upload error occurs.
+	 * @var string The type error message which will be rendered if a file with not allowed suffix gets uploaded.
 	 */
-	protected $error_message = '';
+	protected $type_error_message = '';
 
 	/**
 	 * @return string the URL where the form will be sent to.
@@ -137,18 +137,18 @@ class ilFileStandardDropzoneInputGUI extends ilFileInputGUI implements ilToolbar
 
 
 	/**
-	 * @return string The error message which will be rendered if an upload error occurs.
+	 * @return string The type error message which will be rendered if a file with not allowed suffix gets uploaded.
 	 */
-	public function getErrorMessage() {
-		return $this->error_message;
+	public function getTypeErrorMessage() {
+		return $this->type_error_message;
 	}
 
 
 	/**
-	 * @param string $error_message The error message which will be rendered if an upload error occurs.
+	 * @param string $type_error_message The type error message which will be rendered if a file with not allowed suffix gets uploaded.
 	 */
-	public function setErrorMessage($error_message) {
-		$this->error_message = $error_message;
+	public function setTypeErrorMessage($type_error_message) {
+		$this->type_error_message = $type_error_message;
 	}
 
 	/**
@@ -170,7 +170,7 @@ class ilFileStandardDropzoneInputGUI extends ilFileInputGUI implements ilToolbar
 		              ->withMaxFiles($this->getMaxFiles())
 		              ->withMessage($this->getDropzoneMessage())
 		              ->withAllowedFileTypes($this->getSuffixes())
-		              ->withErrorMessage($this->getErrorMessage());
+		              ->withTypeErrorMessage($this->getTypeErrorMessage());
 		$dropzone = $this->handleMaxFileSize($dropzone);
 		if ($this->isFileNameSelectionEnabled()) {
 			$dropzone = $dropzone->withUserDefinedFileNamesEnabled(true);

--- a/Services/Form/classes/class.ilFileStandardDropzoneInputGUI.php
+++ b/Services/Form/classes/class.ilFileStandardDropzoneInputGUI.php
@@ -56,7 +56,10 @@ class ilFileStandardDropzoneInputGUI extends ilFileInputGUI implements ilToolbar
 	 * @var string The message which will be rendered within the dropzone.
 	 */
 	protected $dropzone_message = '';
-
+	/**
+	 * @var string The error message which will be rendered if an upload error occurs.
+	 */
+	protected $error_message = '';
 
 	/**
 	 * @return string the URL where the form will be sent to.
@@ -134,6 +137,21 @@ class ilFileStandardDropzoneInputGUI extends ilFileInputGUI implements ilToolbar
 
 
 	/**
+	 * @return string The error message which will be rendered if an upload error occurs.
+	 */
+	public function getErrorMessage() {
+		return $this->error_message;
+	}
+
+
+	/**
+	 * @param string $error_message The error message which will be rendered if an upload error occurs.
+	 */
+	public function setErrorMessage($error_message) {
+		$this->error_message = $error_message;
+	}
+
+	/**
 	 * @inheritdoc
 	 */
 	public function render($a_mode = "") {
@@ -151,7 +169,8 @@ class ilFileStandardDropzoneInputGUI extends ilFileInputGUI implements ilToolbar
 		              ->withParameterName($this->getPostVar())
 		              ->withMaxFiles($this->getMaxFiles())
 		              ->withMessage($this->getDropzoneMessage())
-		              ->withAllowedFileTypes($this->getSuffixes());
+		              ->withAllowedFileTypes($this->getSuffixes())
+		              ->withErrorMessage($this->getErrorMessage());
 		$dropzone = $this->handleMaxFileSize($dropzone);
 		if ($this->isFileNameSelectionEnabled()) {
 			$dropzone = $dropzone->withUserDefinedFileNamesEnabled(true);

--- a/src/UI/Component/Dropzone/File/File.php
+++ b/src/UI/Component/Dropzone/File/File.php
@@ -131,20 +131,20 @@ interface File extends Component, Droppable {
 
 
 	/**
-	 * Get a dropzone like this, displaying the given error message on failure.
+	 * Get a dropzone like this, displaying the given type error message if a file with not allowed suffix gets uploaded.
 	 *
-	 * @param string $error_message
+	 * @param string $type_error_message
 	 *
 	 * @return $this
 	 */
-	public function withErrorMessage($error_message);
+	public function withTypeErrorMessage($type_error_message);
 
 
 	/**
-	 * Get error message of of this dropzone.
+	 * Get type error message of of this dropzone.
 	 *
 	 * @return string
 	 */
-	public function getErrorMessage();
+	public function getTypeErrorMessage();
 
 }

--- a/src/UI/Component/Dropzone/File/File.php
+++ b/src/UI/Component/Dropzone/File/File.php
@@ -129,4 +129,22 @@ interface File extends Component, Droppable {
 	 */
 	public function getParametername();
 
+
+	/**
+	 * Get a dropzone like this, displaying the given error message on failure.
+	 *
+	 * @param string $error_message
+	 *
+	 * @return $this
+	 */
+	public function withErrorMessage($error_message);
+
+
+	/**
+	 * Get error message of of this dropzone.
+	 *
+	 * @return string
+	 */
+	public function getErrorMessage();
+
 }

--- a/src/UI/Implementation/Component/Dropzone/File/File.php
+++ b/src/UI/Implementation/Component/Dropzone/File/File.php
@@ -52,6 +52,10 @@ abstract class File implements \ILIAS\UI\Component\Dropzone\File\File {
 	 * @var string
 	 */
 	protected $parameter_name = 'files';
+	/**
+	 * @var string
+	 */
+	protected $error_message = "";
 
 
 	/**
@@ -213,5 +217,25 @@ abstract class File implements \ILIAS\UI\Component\Dropzone\File\File {
 	 */
 	public function withAdditionalDrop(Signal $signal) {
 		return $this->appendTriggeredSignal($signal, self::DROP_EVENT);
+	}
+
+
+	/**
+	 * @inheritdoc
+	 */
+	public function withErrorMessage($error_message) {
+		$this->checkStringArg("error_message", $error_message);
+		$clone = clone $this;
+		$clone->error_message = $error_message;
+
+		return $clone;
+	}
+
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getErrorMessage() {
+		return $this->error_message;
 	}
 }

--- a/src/UI/Implementation/Component/Dropzone/File/File.php
+++ b/src/UI/Implementation/Component/Dropzone/File/File.php
@@ -55,7 +55,7 @@ abstract class File implements \ILIAS\UI\Component\Dropzone\File\File {
 	/**
 	 * @var string
 	 */
-	protected $error_message = "";
+	protected $type_error_message = "";
 
 
 	/**
@@ -223,10 +223,10 @@ abstract class File implements \ILIAS\UI\Component\Dropzone\File\File {
 	/**
 	 * @inheritdoc
 	 */
-	public function withErrorMessage($error_message) {
-		$this->checkStringArg("error_message", $error_message);
+	public function withTypeErrorMessage($type_error_message) {
+		$this->checkStringArg("error_message", $type_error_message);
 		$clone = clone $this;
-		$clone->error_message = $error_message;
+		$clone->type_error_message = $type_error_message;
 
 		return $clone;
 	}
@@ -235,7 +235,7 @@ abstract class File implements \ILIAS\UI\Component\Dropzone\File\File {
 	/**
 	 * @inheritdoc
 	 */
-	public function getErrorMessage() {
-		return $this->error_message;
+	public function getTypeErrorMessage() {
+		return $this->type_error_message;
 	}
 }

--- a/src/UI/Implementation/Component/Dropzone/File/Renderer.php
+++ b/src/UI/Implementation/Component/Dropzone/File/Renderer.php
@@ -160,7 +160,7 @@ class Renderer extends AbstractComponentRenderer {
 				                                                       * $dropzone->getFileSizeLimit()->getUnit() : 0,
 				'maxFiles'          => $dropzone->getMaxFiles(),
 				'identifier'        => $dropzone->getParametername(),
-				'typeError'         => $dropzone->getErrorMessage(),
+				'typeError'         => $dropzone->getTypeErrorMessage(),
 			]);
 			$reflect = new \ReflectionClass($dropzone);
 			$type = $reflect->getShortName();

--- a/src/UI/Implementation/Component/Dropzone/File/Renderer.php
+++ b/src/UI/Implementation/Component/Dropzone/File/Renderer.php
@@ -160,6 +160,7 @@ class Renderer extends AbstractComponentRenderer {
 				                                                       * $dropzone->getFileSizeLimit()->getUnit() : 0,
 				'maxFiles'          => $dropzone->getMaxFiles(),
 				'identifier'        => $dropzone->getParametername(),
+				'typeError'         => $dropzone->getErrorMessage(),
 			]);
 			$reflect = new \ReflectionClass($dropzone);
 			$type = $reflect->getShortName();

--- a/src/UI/templates/js/Dropzone/File/uploader.js
+++ b/src/UI/templates/js/Dropzone/File/uploader.js
@@ -220,6 +220,9 @@ il.UI = il.UI || {};
                     sizeLimit: options.fileSizeLimit,
                     itemLimit: options.maxFiles
                 },
+	            messages: {
+		            typeError: options.typeError
+	            },
                 callbacks: {
                     onUpload: function (fileId, name) {
                         // Register additional name + description parameters for the upload request


### PR DESCRIPTION
Hi @Amstutz 
Due to https://mantis.ilias.de/view.php?id=23700 we need to adjust the interface of the Dropzone and added `withTypeErrorMessage` and `getTypeErrorMessage`