### PR TITLE
[Certificate] ObjectHelper::getInstanceByObjId can also return boolean

### DIFF
--- a/Services/Certificate/classes/Helper/ilCertificateObjectHelper.php
+++ b/Services/Certificate/classes/Helper/ilCertificateObjectHelper.php
@@ -11,7 +11,7 @@ class ilCertificateObjectHelper
 	 * @param bool $stop_on_error
 	 * @return ilObject
 	 */
-	public function getInstanceByObjId($objectId, bool $stop_on_error = true): ilObject
+	public function getInstanceByObjId($objectId, bool $stop_on_error = true)
 	{
 		return ilObjectFactory::getInstanceByObjId($objectId, $stop_on_error);
 	}

--- a/Services/Certificate/classes/class.ilCertificateCron.php
+++ b/Services/Certificate/classes/class.ilCertificateCron.php
@@ -165,6 +165,10 @@ class ilCertificateCron extends \ilCronJob
 				$template = $this->templateRepository->fetchTemplate($templateId);
 
 				$object = $this->objectHelper->getInstanceByObjId($objId, false);
+				if (!$object instanceof ilObject) {
+					throw new ilException(sprintf('The given object id: "%s"  could not be referred to an actual object', $objId));
+				}
+
 				$type = $object->getType();
 
 				$userObject = $this->objectHelper->getInstanceByObjId($userId, false);


### PR DESCRIPTION
`ilObjectFactory` can also return a boolean which can result into a PHP Error in some cases