### PR TITLE
UI - Panel - Data

### DIFF
--- a/Services/Authentication/classes/class.ilSessionReminderCheck.php
+++ b/Services/Authentication/classes/class.ilSessionReminderCheck.php
@@ -16,14 +16,12 @@ class ilSessionReminderCheck
 	{
 		/**
 		 * @var $ilDB            ilDB
-		 * @var $ilUser          ilObjUser
 		 * @var $ilClientIniFile ilIniFile
 		 * @var $lng             ilLanguage
 		 */
 		global $DIC;
 
 		$ilDB = $DIC['ilDB'];
-		$ilUser = $DIC['ilUser'];
 		$lng = $DIC['lng'];
 		$ilClientIniFile = $DIC['ilClientIniFile'];
 
@@ -77,12 +75,7 @@ class ilSessionReminderCheck
 			$response['message'] = 'The session is already expired. The client should have received a remind command before.';
 			return ilJsonUtil::encode($response);
 		}
-		
-		/**
-		 * @var $user ilObjUser
-		 */
-		$ilUser = ilObjectFactory::getInstanceByObjId($data['user_id']);
-		
+
 		if(null === $expiretime)
 		{
 			$response['message'] = 'ILIAS could not determine the expire time from the session data.';

--- a/Services/Object/classes/class.ilObjectCopyGUI.php
+++ b/Services/Object/classes/class.ilObjectCopyGUI.php
@@ -449,9 +449,7 @@ class ilObjectCopyGUI
 		include_once("./Services/Repository/classes/class.ilRepositorySelectorExplorerGUI.php");
 		$exp = new ilRepositorySelectorExplorerGUI($this, "showTargetSelectionTree");
 		$exp->setTypeWhiteList(array("root", "cat", "grp", "crs", "fold", "lso"));
-		// begin-patch mc
 		$exp->setSelectMode("target", TRUE);
-		// end-patch multi copy
 		if ($exp->handleCommand())
 		{
 			return;

--- a/Services/Taxonomy/classes/class.ilTaxonomyExplorerGUI.php
+++ b/Services/Taxonomy/classes/class.ilTaxonomyExplorerGUI.php
@@ -86,7 +86,7 @@ class ilTaxonomyExplorerGUI extends ilTreeExplorerGUI
 	{
 		$ilCtrl = $this->ctrl;
 		
-		if(!$this->onclick)
+		if(!$this->onclick && $this->target_gui != "")
 		{
 			$ilCtrl->setParameterByClass($this->target_gui, "tax_node", $a_node["child"]);
 			$href = $ilCtrl->getLinkTargetByClass($this->target_gui, $this->target_cmd);

--- a/Services/Tree/classes/class.ilTree.php
+++ b/Services/Tree/classes/class.ilTree.php
@@ -293,16 +293,12 @@ class ilTree
 	{
 		global $DIC;
 
-		$ilUser = $DIC['ilUser'];
-		
-		// lang_code is only required in $this->fetchnodedata
-		if (!is_object($ilUser))
-		{
-			$this->lang_code = "en";
-		}
-		else
-		{
+		// lang_code is only required in $this->fetchnodedata 
+		try {
+			$ilUser = $DIC['ilUser'];
 			$this->lang_code = $ilUser->getCurrentLanguage();
+		} catch (\InvalidArgumentException $e) {
+			$this->lang_code = "en";
 		}
 	}
 	

--- a/src/UI/Component/Panel/Data.php
+++ b/src/UI/Component/Panel/Data.php
@@ -1,0 +1,43 @@
+<?php
+
+/* Copyright (c) 2019 Björn Heyser <info@bjoernheyser.de> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\UI\Component\Panel;
+
+use ILIAS\UI\Component\Component;
+
+/**
+ * This describes how a data-panel could be modified during construction of UI.
+ */
+interface Data extends \ILIAS\UI\Component\Component {
+	
+	/**
+	 * Gets the title of the panel
+	 *
+	 * @return string $title Title of the Data-Panel
+	 */
+	public function getTitle();
+	
+	/**
+	 * Gets the content to be displayed inside the data-panel
+	 *
+	 * @return Component[]|Component
+	 */
+	public function getContent();
+	
+	/**
+	 * Adds data entry to be displayed within the data-panel
+	 *
+	 * @param Component $dataLabel
+	 * @param Component $dataValue
+	 * @return \ILIAS\UI\Component\Panel\Data
+	 */
+	public function withAdditionalEntry(Component $dataLabel, Component $dataValue);
+	
+	/**
+	 * Returns the entries as array (Entries[ Entry[ Label, Value ] ])
+	 *
+	 * @return array
+	 */
+	public function getEntries();
+}

--- a/src/UI/Component/Panel/Factory.php
+++ b/src/UI/Component/Panel/Factory.php
@@ -97,6 +97,39 @@ interface Factory {
 	 * @return \ILIAS\UI\Component\Panel\Report
 	 */
 	public function report($title,$sub_panels);
+	
+	/**
+	 * ---
+	 * description:
+	 *   purpose: >
+	 *       Data panels are used to present any data structured by entries having a label and a value.
+	 *       This can be used for e.g. showing up any statistic. A general rule is that the data must not have
+	 *       more than one value per label. (Data tables e.g. have multiple values per label)
+	 *   composition: >
+	 *       They are composed of a Standard Panel and a list of entries having a label and a value component each.
+	 *   effect: >
+	 *       Data Panels are predominantly used for displaying data structured as label/value pairs.
+	 *   rivals:
+	 *      Standard Panels: >
+	 *        The Report Panels contains sub panels used to structure information.
+	 *      Presentation Table: >
+	 *        Presentation Tables display only a subset of the data at first glance;
+	 *        their entries can then be expanded to show detailed information.
+	 *
+	 * context:
+	 *   - why do i need a context? no other component comes with this entry here!?
+	 *   - without this entry here the unit tests fails with a hint to add a context entry!?
+	 *
+	 * rules:
+	 *   usage:
+	 *      1: >
+	 *         Data panels MUST be used when a report like presentation is required
+	 *         and the information to be shown is a kind of label/value structure.
+	 * ---
+	 * @param string $title
+	 * @return \ILIAS\UI\Component\Panel\Data
+	 */
+	public function data($title);
 
 	/**
 	 * ---

--- a/src/UI/Implementation/Component/Panel/Data.php
+++ b/src/UI/Implementation/Component/Panel/Data.php
@@ -1,0 +1,47 @@
+<?php
+
+/* Copyright (c) 2019 Björn Heyser <info@bjoernheyser.de> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\UI\Implementation\Component\Panel;
+
+use ILIAS\UI\Component\Component;
+
+/**
+ * Class Panel
+ * @package ILIAS\UI\Implementation\Component\Panel
+ */
+class Data extends Panel implements \ILIAS\UI\Component\Panel\Data {
+	
+	/**
+	 * @var array
+	 */
+	protected $entries;
+	
+	/**
+	 * @param string $title
+	 */
+	public function __construct($title) {
+		$this->entries = array();
+		parent::__construct($title, array());
+	}
+	
+	/**
+	 * @param Component $dataLabel
+	 * @param Component $dataValue
+	 * @return \ILIAS\UI\Component\Panel\Data|Data
+	 */
+	public function withAdditionalEntry(Component $dataLabel, Component $dataValue)
+	{
+		$this->entries[] = array($dataLabel, $dataValue);
+		
+		return clone $this;
+	}
+	
+	/**
+	 * @return array
+	 */
+	public function getEntries()
+	{
+		return $this->entries;
+	}
+}

--- a/src/UI/Implementation/Component/Panel/Factory.php
+++ b/src/UI/Implementation/Component/Panel/Factory.php
@@ -41,6 +41,13 @@ class Factory implements \ILIAS\UI\Component\Panel\Factory {
 	public function report($title,$sub_panels) {
 		return new Report($title,$sub_panels);
 	}
+	
+	/**
+	 * @inheritdoc
+	 */
+	public function data($title) {
+		return new Data($title);
+	}
 
 	/**
 	 * @inheritdoc

--- a/src/UI/Implementation/Component/Panel/Renderer.php
+++ b/src/UI/Implementation/Component/Panel/Renderer.php
@@ -32,6 +32,11 @@ class Renderer extends AbstractComponentRenderer {
 			 * @var Component\Panel\Sub $component
 			 */
 			return $this->renderSub($component, $default_renderer);
+		} else if($component instanceof Component\Panel\Data) {
+			/**
+			 * @var Component\Panel\Data $component
+			 */
+			return $this->renderData($component, $default_renderer);
 		}
 		/**
 		 * @var Component\Panel\Report $component
@@ -110,6 +115,45 @@ class Renderer extends AbstractComponentRenderer {
 			$tpl->parseCurrentBlock();
 		}
 
+		return $tpl->get();
+	}
+	
+	/**
+	 * @param Component\Panel\Data $component
+	 * @param RendererInterface $default_renderer
+	 * @return string
+	 */
+	protected function renderData(Component\Panel\Data $component, RendererInterface $default_renderer)
+	{
+		global $DIC;
+		
+		$divider = $DIC->ui()->factory()->divider()->horizontal();
+		
+		$tpl = $this->getTemplate("tpl.data.html", true, true);
+		
+		$first = true;
+		
+		foreach($component->getEntries() as $entry)
+		{
+			if( $first )
+			{
+				$first = false;
+			}
+			else
+			{
+				$tpl->setCurrentBlock('data-row-divider');
+				$tpl->setVariable('DIVIDER', $default_renderer->render($divider));
+				$tpl->parseCurrentBlock();
+			}
+
+			$tpl->setCurrentBlock('data-row');
+			$tpl->setVariable('LABEL', $default_renderer->render($entry[0]));
+			$tpl->setVariable('VALUE', $default_renderer->render($entry[1]));
+			$tpl->parseCurrentBlock();
+		}
+		
+		$tpl->setVariable("TITLE", $component->getTitle());
+		
 		return $tpl->get();
 	}
 

--- a/src/UI/examples/Panel/Data/base.php
+++ b/src/UI/examples/Panel/Data/base.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Only serving as Example
+ */
+function base() {
+	
+	global $DIC;
+	
+	$factory = $DIC->ui()->factory();
+	$renderer = $DIC->ui()->renderer();
+	
+	$dataPanel = $factory->panel()->data('Any Label/Value Statistic');
+	
+	$dataPanel->withAdditionalEntry(
+		$factory->legacy('First Label'),
+		$factory->legacy('Good Value')
+	);
+	
+	$dataPanel->withAdditionalEntry(
+		$factory->legacy('Second Label'),
+		$factory->legacy('More Well Value')
+	);
+	
+	$dataPanel->withAdditionalEntry(
+		$factory->legacy('A Last Label'),
+		$factory->legacy('Any Last Value')
+	);
+	
+	$html = $renderer->render($dataPanel);
+	
+	return $html;
+}

--- a/src/UI/templates/default/Panel/tpl.data.html
+++ b/src/UI/templates/default/Panel/tpl.data.html
@@ -1,8 +1,8 @@
 <div class="panel panel-primary il-panel-data">
-    <div class="panel-heading ilHeader">
+    <div class="panel-heading ilHeader clearfix">
         <h3 class="ilHeader">{TITLE}</h3>
     </div>
-    <div class="panel-body">
+    <div class="panel-body ilClearFloat">
         <!-- BEGIN data-row -->
         <!-- BEGIN data-row-divider -->{DIVIDER}<!-- END data-row-divider -->
         <div class="il-panel-data-row clearfix">

--- a/src/UI/templates/default/Panel/tpl.data.html
+++ b/src/UI/templates/default/Panel/tpl.data.html
@@ -1,0 +1,14 @@
+<div class="panel panel-primary il-panel-data">
+    <div class="panel-heading ilHeader">
+        <h3 class="ilHeader">{TITLE}</h3>
+    </div>
+    <div class="panel-body">
+        <!-- BEGIN data-row -->
+        <!-- BEGIN data-row-divider -->{DIVIDER}<!-- END data-row-divider -->
+        <div class="il-panel-data-row clearfix">
+            <div class="il-panel-data-label col-md-4">{LABEL}</div>
+            <div class="il-panel-data-value col-md-8">{VALUE}</div>
+        </div>
+        <!-- END data-row -->
+    </div>
+</div>

--- a/tests/UI/Base.php
+++ b/tests/UI/Base.php
@@ -49,6 +49,7 @@ class NoUIFactory implements Factory {
 	public function input() {}
 	public function table() {}
 	public function messageBox() {}
+	public function data() {}
 }
 
 class LoggingRegistry implements ResourceRegistry {


### PR DESCRIPTION
This PR introduces a new UI component to be used when any kind of information is to be shown that follows a label/value structure. This UI component can avoid the use of tables to show just a single data row. Also the abuse of a form to present non editable data will be past having this new UI component.

`function base() {
	
	global $DIC;
	
	$factory = $DIC->ui()->factory();
	$renderer = $DIC->ui()->renderer();
	
	$dataPanel = $factory->panel()->data('Any Label/Value Statistic');
	
	$dataPanel->withAdditionalEntry(
		$factory->legacy('First Label'),
		$factory->legacy('Good Value')
	);
	
	$dataPanel->withAdditionalEntry(
		$factory->legacy('Second Label'),
		$factory->legacy('More Well Value')
	);
	
	$dataPanel->withAdditionalEntry(
		$factory->legacy('A Last Label'),
		$factory->legacy('Any Last Value')
	);
	
	$html = $renderer->render($dataPanel);
	
	return $html;
}`

![image](https://user-images.githubusercontent.com/2587908/50739436-a5971800-11e0-11e9-8f67-ec862e5da6d7.png)

The new UI component is located at `UI > Panel > Data` within the UI component taxonomy.