### PR TITLE
workaround for mantis 24241

### DIFF
--- a/Services/UIComponent/Explorer2/js/Explorer2.js
+++ b/Services/UIComponent/Explorer2/js/Explorer2.js
@@ -59,7 +59,7 @@ il.Explorer2 = {
 		$(p).find("a").on("click", function (e) {
 			var href = $(this).attr("href");
 			var target = $(this).attr("target");
-			if (href != "#" && href != "") {
+			if (href != "#" && href != "" && href != 'ilias.php') {
 				if (target == "_blank") {
 					window.open(href, '_blank');
 				} else {


### PR DESCRIPTION
This fixed the issues with taxonomy selections anywhere in ilias. The problem should be anywhere else than the fix, but indeed the simple workaround does fix any problems.

I spend some time, but I did not get what has changed between 5.3 and 5.4 ... but this PR does successfully handle the symptoms.

Liebe Grüße, BJörn

https://mantis.ilias.de/view.php?id=24241