### PR TITLE
[Certificates] Update certificate roadmap - Show previous user certificates

### DIFF
--- a/Services/Certificate/roadmap.md
+++ b/Services/Certificate/roadmap.md
@@ -33,6 +33,8 @@ of the planned features of this service.
 * Planned for 2018 (?)
 * Alternative concept to queuing and process via
   cron job to avoid idle times
+* Show previous user certificates with filter options
+  in GUI
 
 ### v2.2.0
 


### PR DESCRIPTION
Adds a feature to the roadmap that previous certificates should be shown for the user in the GUI

Discussed in: https://mantis.ilias.de/view.php?id=24372#c58747 