### PR TITLE
Initialize $new_baseclass to empty string.

### DIFF
--- a/Services/UICore/classes/class.ilCtrl.php
+++ b/Services/UICore/classes/class.ilCtrl.php
@@ -1619,6 +1619,7 @@ class ilCtrl
 		}
 
 		$nr = $this->current_node;
+		$new_baseclass= "";
 		foreach ($a_class as $class)
 		{
 			$class = strtolower($class);


### PR DESCRIPTION
Fixes a "Undefined variable: new_baseclass" warning I see in our logs quite often.