### PR TITLE
Declare and initialize $main_content to empty string.

### DIFF
--- a/Services/UICore/classes/class.ilTemplate.php
+++ b/Services/UICore/classes/class.ilTemplate.php
@@ -72,6 +72,7 @@ class ilTemplate extends HTML_Template_ITX
 	protected $page_actions = array();
 	protected $permanent_link = false;
 	protected $content_style_sheet = "";
+	protected $main_content = "";
 	
 	protected $title_alerts = array();
 	protected $header_action;


### PR DESCRIPTION
Fixes a "Undefined property: ilTemplate::$main_content" warning I see in our logs quite often.