### PR TITLE
Initialize $pdo_type to PDO::PARAM_STR.

### DIFF
--- a/Services/Database/classes/PDO/class.ilDBPdo.php
+++ b/Services/Database/classes/PDO/class.ilDBPdo.php
@@ -758,6 +758,7 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface {
 			return 'NULL';
 		}
 
+		$pdo_type = PDO::PARAM_STR;
 		switch ($type) {
 			case ilDBConstants::T_TIMESTAMP:
 			case ilDBConstants::T_DATETIME:


### PR DESCRIPTION
For `T_TIMESTAMP` and `T_DATETIME`, `$pdo_type` does not get initialized here currently. This is not good, as it will call `$this->pdo->quote($value, null)` and that call's result is not clearly defined (https://php.net/manual/en/pdo.quote.php).