### PR TITLE
[WIP] [Certificates] Fix: Certificate not downloadable in Exercise

### DIFF
--- a/Modules/Exercise/classes/class.ilExerciseCertificateAdapter.php
+++ b/Modules/Exercise/classes/class.ilExerciseCertificateAdapter.php
@@ -182,6 +182,37 @@ class ilExerciseCertificateAdapter extends ilCertificateAdapter
 	{
 		return $this->object->getId();
 	}
+
+	/**
+	 * This code was orignaly located in `ilObjExercise` and has been moved
+	 * here for `ilCertificateMigrationJob`
+	 *
+	 * @param int $objectId
+	 * @param int $userId
+	 * @return bool
+	 */
+	public function hasUserCertificate(int $userId)
+	{
+		// show certificate?
+		if(ilCertificate::isActive() && ilCertificate::isObjectActive($this->object->getId())) {
+			$certificate_visible = $this->object->getCertificateVisibility();
+			// if not never
+			if($certificate_visible != 2) {
+				// if passed only
+				$status = ilExerciseMembers::_lookupStatus($this->object->getId(), $userId);
+				if($certificate_visible == 1 && $status == "passed") {
+					return true;
+				}
+
+				// always (excluding notgraded)
+				else if($certificate_visible == 0 && $status != "notgraded") {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
 }
 
 ?>

--- a/Modules/Exercise/classes/class.ilObjExercise.php
+++ b/Modules/Exercise/classes/class.ilObjExercise.php
@@ -869,21 +869,6 @@ class ilObjExercise extends ilObject
 	}
 
 	/**
-	 * Check if given user has certificate to show/download
-	 * 
-	 * @param int $a_user_id
-	 * @return bool 
-	 */
-	function hasUserCertificate($a_user_id)
-	{
-		$validator = new ilCertificateDownloadValidator();
-		if($validator->isCertificateDownloadable($a_user_id, $this->getId())) {
-			return true;
-		}
-		return false;
-	}
-	
-	/**
 	 * Add to desktop after hand-in
 	 * 
 	 * @return bool

--- a/Modules/Exercise/classes/class.ilObjExercise.php
+++ b/Modules/Exercise/classes/class.ilObjExercise.php
@@ -867,7 +867,7 @@ class ilObjExercise extends ilObject
 			array($a_value, $this->getId())
 		);
 	}
-	
+
 	/**
 	 * Check if given user has certificate to show/download
 	 * 

--- a/Services/Certificate/classes/BackgroundTasks/class.ilCertificateMigrationJob.php
+++ b/Services/Certificate/classes/BackgroundTasks/class.ilCertificateMigrationJob.php
@@ -463,9 +463,9 @@ class ilCertificateMigrationJob extends AbstractJob
 				continue;
 			}
 
-			if ($object->hasUserCertificate($this->user_id))
+			$adapter = new \ilExerciseCertificateAdapter($object);
+			if ($adapter->hasUserCertificate($this->user_id))
 			{
-				$adapter = new \ilExerciseCertificateAdapter($object);
 				$data = $this->createCertificateData($objectId, $adapter, $object, $data);
 			}
 		}


### PR DESCRIPTION
This should take care of the changes made in: https://mantis.ilias.de/view.php?id=24113
I don't think that the changes made in https://github.com/ILIAS-eLearning/ILIAS/commit/df2579d5ea0acbf2ddef75fa914e95f1338f2492 are a fix for this. 

Why do I think this?

Let's have a look into `ilObjExerciseGUI` line 882:
```php
	function outCertificateObject()
	{
		global $DIC;

		$database = $DIC->database();
		$logger = $DIC->logger()->root();

		$ilUser = $this->user;
	
		if($this->object->hasUserCertificate($ilUser->getId()))
		{	
			ilUtil::sendFailure($this->lng->txt("msg_failed"));
			$this->showOverviewObject();			
		}

		$ilUserCertificateRepository = new ilUserCertificateRepository($database, $logger);
		$pdfGenerator = new ilPdfGenerator($ilUserCertificateRepository, $logger);

		$pdfAction = new ilCertificatePdfAction(
			$logger,
			$pdfGenerator,
			new ilCertificateUtilHelper(),
			$this->lng->txt('error_creating_certificate_pdf')
		);

		$pdfAction->downloadPdf((int) $ilUser->getId(), (int)$this->object->getId());
	}
```

The method `outCertificateObject` is used for the actual download button. As we see in the mantis ticket, the button isn't even shown. See we would need to know where the button is added to execute this method.

See line 825 in `ilObjExerciseGUI`

```php
		$validator = new ilCertificateDownloadValidator();
		if($validator->isCertificateDownloadable($ilUser->getId(), $this->object->getId())) {
			$ilToolbar->addButton($this->lng->txt("certificate"),
			$this->ctrl->getLinkTarget($this, "outCertificate"));
		}
```
The `ilCertificateDownloadValidator`` checks with an user certificate is existing in the database, if the certificates are globally set to `active` and if the RPC server is active.

So my suggestion about this bug is: **The LP is not set to passed OR the cron-job for the certificates wasn't completed at that time.** 