### PR TITLE
UI Presentation of Standard Listing Panels in Side Panels and Slates

### DIFF
--- a/src/UI/Component/Panel/Factory.php
+++ b/src/UI/Component/Panel/Factory.php
@@ -106,7 +106,8 @@ interface Factory {
 	 *       single template.
 	 *   composition: >
 	 *       Listing Panels are composed of several titled Item Groups.
-	 *       They further may contain a filter.
+	 *       They further may contain a filter. Listing Panels provide a condensed presentation when beind used
+	 *       inside of Side Panels and Slates.
 	 *   effect: >
 	 *       The List Items of Listing Panels may contain a dropdown
 	 *       offering options to interact with the item. Further Listing Panels

--- a/src/UI/Factory.php
+++ b/src/UI/Factory.php
@@ -561,7 +561,10 @@ interface Factory {
 	 *      a Shy Button. The item contains three
 	 *      sections, where one section contains important information about the item,
 	 *      the second section shows the content of the item and another section shows
-	 *      metadata about the entity.
+	 *      metadata about the entity. Items provide a condensed presentation when being used inside of
+	 *      Side Panels and Slates. Metadata will be omitted in the condensed presentation.
+	 *      ALTERNATIVE: In the condensed presentation metadata will be presented in a Popover being triggered
+	 *      by a Magnifier Glyph.
 	 *   effect: >
 	 *      Items may contain Interaction Triggers such as Glyphs, Buttons or Tags.
 	 *   rivals:


### PR DESCRIPTION
This suggestion works together with the current proposals of the Page Layout revision and the Personal Desktop revision.

Side Panels are discussed here: https://docu.ilias.de/goto_docu_wiki_wpage_5592_1357.html
Slates are part of this PR: https://github.com/ILIAS-eLearning/ILIAS/pull/1335

This suggestion continues the idea of the current "Example 3: With lead image in narrow container" which can be found in the KS documentation (Panel > Listing > Standard).

Use Cases: Who-Is-Online list in Slates. Lists of News, Mails, Bookmarks in Side Panels (and similar lists currently presented in side blocks).

This PR does not make any interface changes yet. It makes the following suggestions for the future Slate and Side Panel interface:

- Slates and Side Panels provide a way to embed Standard Listing Panels
- Standard Listing Panels will provide a condensed presentation in these contexts

See https://github.com/ILIAS-eLearning/ILIAS/pull/1414/files for the proposed changes in the KS documentation.

As soon as the Slate / Side Panel components are accepted in the trunk, this PR will suggest API changes to embed Standard Listing Panels within these components (if not possible already).

Condensed Presentation:
![bildschirmfoto 2019-01-11 um 09 21 43](https://user-images.githubusercontent.com/1221841/51022272-17c28080-1584-11e9-92e6-fe431e515abd.png)

Actions:
![bildschirmfoto 2019-01-11 um 09 28 02](https://user-images.githubusercontent.com/1221841/51022236-01b4c000-1584-11e9-9802-d55f7022f1f3.png)

Lead Text:
![bildschirmfoto 2019-01-11 um 09 30 09](https://user-images.githubusercontent.com/1221841/51022214-f6fa2b00-1583-11e9-9d88-125071ef68e2.png)

Embedded in Side Panel Proposal using more appropriate Heading size:

![bildschirmfoto 2019-01-11 um 09 23 00](https://user-images.githubusercontent.com/1221841/51021840-f3b26f80-1582-11e9-9034-d32b0a70736c.png)

