### PR TITLE
Set is_empty on create from XML

### DIFF
--- a/Services/COPage/classes/class.ilPageObject.php
+++ b/Services/COPage/classes/class.ilPageObject.php
@@ -2682,7 +2682,8 @@ abstract class ilPageObject
 			"inactive_elements" => array("integer", $iel),
 			"int_links" => array("integer", $inl),
 			"created" => array("timestamp", ilUtil::now()),
-			"last_change" => array("timestamp", ilUtil::now())
+			"last_change" => array("timestamp", ilUtil::now()),
+			"is_empty" => array("integer", $empty)
 			));
 		
 		// after update event


### PR DESCRIPTION
If there is a new PageObject created from XML, the system checks if there is some code in the xml property or not. The result of this check is not used on the insert statement.
The default value for is_empty in the db is "0". That means created PageObjects are not empty, if they weren't edited directly and the **xml property is empty.** As result, ILIAS shows an undesigned empty page.

In my opinion the created "is_empty" should be equal to the result of the check right before the insert statement. So we have a valid state in the db after creation.