### PR TITLE
avoid pdf generation services of make an absolute path even more abso…

### DIFF
--- a/Services/PDFGeneration/classes/factory/class.ilHtmlToPdfTransformerFactory.php
+++ b/Services/PDFGeneration/classes/factory/class.ilHtmlToPdfTransformerFactory.php
@@ -59,7 +59,11 @@ class ilHtmlToPdfTransformerFactory
 		$renderer = ilPDFGeneratorUtils::getRendererInstance($map['selected']);
 		$config = ilPDFGeneratorUtils::getRendererConfig($service, $purpose, $map['selected']);
 
-		$output = $this->generateTempPath($output);
+		if( basename($output) == $output )
+		{
+			$output = $this->generateTempPath($output);
+		}
+		
 		$job = new ilPDFGenerationJob();
 		$job->setFilename($output);
 		$job->addPage($src);


### PR DESCRIPTION
…lute by prefixing with a temp path.

Since the fix in the pdf genaration service that prepends a temp path to the filename, it is not possible to pass a valid absolute path as target filename.

The changes in this PR does avoid the pdf generation service from doing this when the filename is a filename having an relative or absolute path.

Simple filenames of course still gets the temp path prepended.

The corresponding bug report (i reopened it): https://mantis.ilias.de/view.php?id=23563#c57842