### PR TITLE
[Certificates] Replace old Certificate Adapter behavior for clone action

### DIFF
--- a/Modules/Course/classes/class.ilObjCourse.php
+++ b/Modules/Course/classes/class.ilObjCourse.php
@@ -1024,12 +1024,10 @@ class ilObjCourse extends ilContainer implements ilMembershipRegistrationCodes
 		unset($obj_settings);
 		
 		// clone certificate (#11085)
-		$factory = new ilCertificateFactory();
 		$templateRepository = new ilCertificateTemplateRepository($ilDB);
 
 		$cloneAction = new ilCertificateCloneAction(
 			$ilDB,
-			$factory,
 			$templateRepository,
 			$DIC->filesystem()->web(),
 			$certificateLogger,

--- a/Modules/Exercise/classes/class.ilObjExercise.php
+++ b/Modules/Exercise/classes/class.ilObjExercise.php
@@ -270,12 +270,10 @@ class ilObjExercise extends ilObject
 		$obj_settings->cloneSettings($new_obj->getId());
 		unset($obj_settings);
 
-		$factory = new ilCertificateFactory();
 		$templateRepository = new ilCertificateTemplateRepository($ilDB);
 
 		$cloneAction = new ilCertificateCloneAction(
 			$ilDB,
-			$factory,
 			$templateRepository,
 			$this->webFilesystem,
 			$this->log,

--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -7499,12 +7499,10 @@ function getAnswerFeedbackPoints()
 		$newObj->saveToDb();
 		
 		// clone certificate
-		$factory = new ilCertificateFactory();
 		$templateRepository = new ilCertificateTemplateRepository($ilDB);
 
 		$cloneAction = new ilCertificateCloneAction(
 			$ilDB,
-			$factory,
 			$templateRepository,
 			$DIC->filesystem()->web(),
 			$certificateLogger,

--- a/Services/Certificate/classes/File/Template/class.ilCertificatePathFactory.php
+++ b/Services/Certificate/classes/File/Template/class.ilCertificatePathFactory.php
@@ -1,0 +1,31 @@
+<?php
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * @author  Niels Theen <ntheen@databay.de>
+ */
+class ilCertificatePathFactory
+{
+	/**
+	 * @param ilObject $object
+	 * @return string
+	 * @throws ilException
+	 */
+	public function createCertificatePath(ilObject $object)
+	{
+		$type = $object->getType();
+		$objectId = $object->getId();
+
+		if ($type === 'tst') {
+			return ilCertificatePathConstants::TEST_PATH . $objectId . '/';
+		} else if ($type === 'exc') {
+			return ilCertificatePathConstants::EXERCISE_PATH . $objectId . '/';
+		} else if ($type === 'sahs') {
+			return ilCertificatePathConstants::SCORM_PATH . $objectId . '/';
+		} else if ($type === 'crs') {
+			return ilCertificatePathConstants::COURSE_PATH . $objectId . '/';
+		}
+
+		throw new ilException(sprintf('Unknown type "%s" for object (obj_id: "%s")creating certificate path', $type, $objectId));
+	}
+}

--- a/Services/Certificate/classes/Template/Action/Clone/class.ilCertificateCloneAction.php
+++ b/Services/Certificate/classes/Template/Action/Clone/class.ilCertificateCloneAction.php
@@ -14,7 +14,7 @@ class ilCertificateCloneAction
 	/**
 	 * @var ilCertificateFactory
 	 */
-	private $certificateFactory;
+	private $certificatePathFactory;
 
 	/**
 	 * @var ilCertificateTemplateRepository
@@ -41,20 +41,19 @@ class ilCertificateCloneAction
 	 * @param ilCertificateFactory $certificateFactory
 	 * @param ilCertificateTemplateRepository $templateRepository
 	 * @param \ILIAS\Filesystem\Filesystem|null $fileSystem
-	 * @param illLogger $logger
+	 * @param ilLogger $logger
 	 * @param ilCertificateObjectHelper|null $objectHelper
-	 * @param string $rootDirectory
+	 * @param ilCertificatePathFactory|null $certificatePathFactory
 	 */
 	public function __construct(
 		ilDBInterface $database,
-		ilCertificateFactory $certificateFactory,
 		ilCertificateTemplateRepository $templateRepository,
 		\ILIAS\Filesystem\Filesystem $fileSystem = null,
 		ilLogger $logger = null,
-		ilCertificateObjectHelper $objectHelper = null
+		ilCertificateObjectHelper $objectHelper = null,
+		ilCertificatePathFactory $certificatePathFactory = null
 	) {
 		$this->database = $database;
-		$this->certificateFactory = $certificateFactory;
 		$this->templateRepository = $templateRepository;
 
 		if (null === $logger) {
@@ -73,6 +72,11 @@ class ilCertificateCloneAction
 			$objectHelper = new ilCertificateObjectHelper();
 		}
 		$this->objectHelper = $objectHelper;
+
+		if (null === $certificatePathFactory) {
+			$certificatePathFactory = new ilCertificatePathFactory();
+		}
+		$this->certificatePathFactory = $certificatePathFactory;
 	}
 
 	/**
@@ -101,9 +105,8 @@ class ilCertificateCloneAction
 			));
 		}
 
-		$newCertificate = $this->certificateFactory->create($newObject);
-
 		$templates = $this->templateRepository->fetchCertificateTemplatesByObjId($oldObject->getId());
+
 
 		/** @var ilCertificateTemplate $template */
 		foreach ($templates as $template) {
@@ -111,8 +114,8 @@ class ilCertificateCloneAction
 			$backgroundImageFile = basename($backgroundImagePath);
 			$backgroundImageThumbnail = dirname($backgroundImagePath) . '/background.jpg.thumb.jpg';
 
-			$newBackgroundImage = $newCertificate->getBackgroundImageDirectory() . $backgroundImageFile;
-			$newBackgroundImageThumbnail = str_replace(CLIENT_WEB_DIR, '', $newCertificate->getBackgroundImageThumbPath());
+			$newBackgroundImage = $this->certificatePathFactory->createCertificatePath($newObject) . $backgroundImageFile;
+			$newBackgroundImageThumbnail = $this->certificatePathFactory->createCertificatePath($newObject);
 
 			if ($this->fileSystem->has($backgroundImagePath)) {
 				if ($this->fileSystem->has($newBackgroundImage)) {

--- a/Services/Certificate/classes/Template/Action/Clone/class.ilCertificateCloneAction.php
+++ b/Services/Certificate/classes/Template/Action/Clone/class.ilCertificateCloneAction.php
@@ -107,7 +107,6 @@ class ilCertificateCloneAction
 
 		$templates = $this->templateRepository->fetchCertificateTemplatesByObjId($oldObject->getId());
 
-
 		/** @var ilCertificateTemplate $template */
 		foreach ($templates as $template) {
 			$backgroundImagePath = $template->getBackgroundImagePath();
@@ -115,7 +114,7 @@ class ilCertificateCloneAction
 			$backgroundImageThumbnail = dirname($backgroundImagePath) . '/background.jpg.thumb.jpg';
 
 			$newBackgroundImage = $this->certificatePathFactory->createCertificatePath($newObject) . $backgroundImageFile;
-			$newBackgroundImageThumbnail = $this->certificatePathFactory->createCertificatePath($newObject);
+			$newBackgroundImageThumbnail = $this->certificatePathFactory->createCertificatePath($newObject) . '/background.jpg.thumb.jpg';
 
 			if ($this->fileSystem->has($backgroundImagePath)) {
 				if ($this->fileSystem->has($newBackgroundImage)) {

--- a/Services/Certificate/test/ilCertificateCloneActionTest.php
+++ b/Services/Certificate/test/ilCertificateCloneActionTest.php
@@ -25,30 +25,6 @@ class ilCertificateCloneActionTest extends PHPUnit_Framework_TestCase
 			->expects($this->once())
 			->method('replace');
 
-		$certificateFactory = $this->getMockBuilder('ilCertificateFactory')
-			->getMock();
-
-		$oldCertficate = $this->getMockBuilder('ilCertificate')
-			->disableOriginalConstructor()
-			->getMock();
-
-		$oldCertficate->method('getBackgroundImageThumbPath')
-			->willReturn('/some/where/background.jpg');
-
-
-		$newCertficate = $this->getMockBuilder('ilCertificate')
-			->disableOriginalConstructor()
-			->getMock();
-
-		$newCertficate->method('getBackgroundImageThumbPath')
-			->willReturn('/some/where/background.jpg');
-
-		$certificateFactory->method('create')
-			->willReturnOnConsecutiveCalls(
-				$oldCertficate,
-				$newCertficate
-			);
-
 		$templateRepository = $this->getMockBuilder('ilCertificateTemplateRepository')
 			->disableOriginalConstructor()
 			->getMock();
@@ -111,7 +87,6 @@ class ilCertificateCloneActionTest extends PHPUnit_Framework_TestCase
 
 		$cloneAction = new ilCertificateCloneAction(
 			$database,
-			$certificateFactory,
 			$templateRepository,
 			$fileSystem ,
 			$logger,

--- a/Services/Certificate/test/ilCertificatePathFactoryTest.php
+++ b/Services/Certificate/test/ilCertificatePathFactoryTest.php
@@ -1,0 +1,89 @@
+<?php
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * @author  Niels Theen <ntheen@databay.de>
+ */
+class ilCertificatePathFactoryTest extends PHPUnit_Framework_TestCase
+{
+	/**
+	 * @var ilCertificatePathFactory
+	 */
+	private $certificatePathFactory;
+
+	public function setUp()
+	{
+		$this->certificatePathFactory = new ilCertificatePathFactory();
+	}
+
+	public function testCreateTestCertificatePath()
+	{
+		$testObject = $this->getMockBuilder('ilObject')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$testObject->method('getType')->willReturn('tst');
+		$testObject->method('getId')->willReturn(100);
+
+		$certificatePath = $this->certificatePathFactory->createCertificatePath($testObject);
+
+		$this->assertEquals('/assessment/certificates/100/', $certificatePath);
+	}
+
+	public function testCreateCourseCertificatePath()
+	{
+		$courseObject = $this->getMockBuilder('ilObject')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$courseObject->method('getType')->willReturn('crs');
+		$courseObject->method('getId')->willReturn(100);
+
+		$certificatePath = $this->certificatePathFactory->createCertificatePath($courseObject);
+
+		$this->assertEquals('/course/certificates/100/', $certificatePath);
+	}
+
+	public function testCreateScormCertificatePath()
+	{
+		$scormObject = $this->getMockBuilder('ilObject')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$scormObject->method('getType')->willReturn('sahs');
+		$scormObject->method('getId')->willReturn(100);
+
+		$certificatePath = $this->certificatePathFactory->createCertificatePath($scormObject);
+
+		$this->assertEquals('/scorm/certificates/100/', $certificatePath);
+	}
+
+	public function testCreateExerciseCertificatePath()
+	{
+		$excerciseObject = $this->getMockBuilder('ilObject')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$excerciseObject->method('getType')->willReturn('exc');
+		$excerciseObject->method('getId')->willReturn(100);
+
+		$certificatePath = $this->certificatePathFactory->createCertificatePath($excerciseObject);
+
+		$this->assertEquals('/exercise/certificates/100/', $certificatePath);
+	}
+
+	/**
+	 * @expectedException ilException
+	 */
+	public function testUnknownTypeThrowsException()
+	{
+		$unknownObject = $this->getMockBuilder('ilObject')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$unknownObject->method('getType')->willReturn('unknown');
+		$unknownObject->method('getId')->willReturn(100);
+
+		$certificatePath = $this->certificatePathFactory->createCertificatePath($unknownObject);
+	}
+}

--- a/libs/composer/vendor/composer/autoload_classmap.php
+++ b/libs/composer/vendor/composer/autoload_classmap.php
@@ -3543,6 +3543,7 @@ return array(
     'ilCertificateObjectsForUserPreloader' => $baseDir . '/../../Services/Certificate/classes/Preload/class.ilCertificateObjectsForUserPreloader.php',
     'ilCertificateParticipantsHelper' => $baseDir . '/../../Services/Certificate/classes/Helper/ilCertificateParticipantsHelper.php',
     'ilCertificatePathConstants' => $baseDir . '/../../Services/Certificate/classes/File/Template/class.ilCertificatePathConstants.php',
+    'ilCertificatePathFactory' => $baseDir . '/../../Services/Certificate/classes/File/Template/class.ilCertificatePathFactory.php',
     'ilCertificatePdfAction' => $baseDir . '/../../Services/Certificate/classes/User/Action/Pdf/class.ilCertificatePdfAction.php',
     'ilCertificatePdfFileNameFactory' => $baseDir . '/../../Services/Certificate/classes/File/Certificate/Filename/class.ilCertificatePdfFileNameFactory.php',
     'ilCertificatePdfFilename' => $baseDir . '/../../Services/Certificate/classes/File/Certificate/Filename/class.ilCertificatePdfFilename.php',

--- a/libs/composer/vendor/composer/autoload_static.php
+++ b/libs/composer/vendor/composer/autoload_static.php
@@ -3856,6 +3856,7 @@ class ComposerStaticInit2fffdf922cf8fdbf1f62eec345993c83
         'ilCertificateObjectsForUserPreloader' => __DIR__ . '/../..' . '/../../Services/Certificate/classes/Preload/class.ilCertificateObjectsForUserPreloader.php',
         'ilCertificateParticipantsHelper' => __DIR__ . '/../..' . '/../../Services/Certificate/classes/Helper/ilCertificateParticipantsHelper.php',
         'ilCertificatePathConstants' => __DIR__ . '/../..' . '/../../Services/Certificate/classes/File/Template/class.ilCertificatePathConstants.php',
+        'ilCertificatePathFactory' => __DIR__ . '/../..' . '/../../Services/Certificate/classes/File/Template/class.ilCertificatePathFactory.php',
         'ilCertificatePdfAction' => __DIR__ . '/../..' . '/../../Services/Certificate/classes/User/Action/Pdf/class.ilCertificatePdfAction.php',
         'ilCertificatePdfFileNameFactory' => __DIR__ . '/../..' . '/../../Services/Certificate/classes/File/Certificate/Filename/class.ilCertificatePdfFileNameFactory.php',
         'ilCertificatePdfFilename' => __DIR__ . '/../..' . '/../../Services/Certificate/classes/File/Certificate/Filename/class.ilCertificatePdfFilename.php',


### PR DESCRIPTION
This PR removes the need of the Certificate Adapters and the `ilCertificate` class in the current clone action.

