### PR TITLE
[Certificates] Remove placeholder tags from preview object (Release 5-4)

### DIFF
--- a/Services/Certificate/classes/Template/Action/Preview/ilCertificateTemplatePreviewAction.php
+++ b/Services/Certificate/classes/Template/Action/Preview/ilCertificateTemplatePreviewAction.php
@@ -162,8 +162,8 @@ class ilCertificateTemplatePreviewAction
 			$insert_tags[$value['ph']] = $this->utilHelper->prepareFormOutput($value['name']);
 		}
 
-		foreach ($insert_tags as $var => $value) {
-			$certificate_text = str_replace($var, $value, $certificate_text);
+		foreach ($insert_tags as $placeholderVariable => $value) {
+			$certificate_text = str_replace('[' . $placeholderVariable . ']', $value, $certificate_text);
 		}
 
 		$certificate_text = str_replace(


### PR DESCRIPTION
This will replace the Placholder tags `[` and `]` in the preview certificate.

Mantis Ticket: https://mantis.ilias.de/view.php?id=24628#c59034