### PR TITLE
0024494: Failed test: Kurs mit SCORM Lernmodul exportieren

### DIFF
--- a/Modules/ScormAicc/classes/class.ilSAHSEditGUI.php
+++ b/Modules/ScormAicc/classes/class.ilSAHSEditGUI.php
@@ -103,7 +103,7 @@ class ilSAHSEditGUI
 			{
 				require_once("Modules/ScormAicc/classes/class.ilScormAiccExporter.php");
 				$exporter = new ilScormAiccExporter();
-				$xml = $exporter->getXmlRepresentation("sahs", "5.1.0", $_GET["ref_id"]);
+				$xml = $exporter->getXmlRepresentation("sahs", "5.1.0", ilObject::_lookupObjectId($_GET["ref_id"]));
 			}
 			else if ($cmd == "download")
 			{

--- a/Modules/ScormAicc/classes/class.ilScormAiccDataSet.php
+++ b/Modules/ScormAicc/classes/class.ilScormAiccDataSet.php
@@ -65,7 +65,7 @@ class ilScormAiccDataSet extends ilDataSet
 	{
 		global $ilDB;
 
-		$obj_id = ilObject::_lookupObjectId ($a_id);
+		$obj_id = $a_id;
 		$columns = [];
 		foreach ($this->properties as $property)
 			array_push ($columns, $property["db_col"]);
@@ -148,14 +148,21 @@ class ilScormAiccDataSet extends ilDataSet
 		return $this->element_db_mapping[$db_col_name];
 	}
 
-	/* own getXmlRepresentation function to embed zipfile in xml
-	 *
-	 */
+    /**
+     * own getXmlRepresentation function to embed zipfile in xml
+     *
+     * @param $a_entity
+     * @param $a_schema_version
+     * @param $a_ids (obj_id)
+     * @param string $a_field
+     * @param bool $a_omit_header
+     * @param bool $a_omit_types
+     * @return string
+     */
 	public function getExtendedXmlRepresentation($a_entity, $a_schema_version, $a_ids, $a_field = "", $a_omit_header = false, $a_omit_types = false)
 	{
 		$GLOBALS["ilLog"]->write(json_encode($this->getTypes("sahs", "5.1.0"), JSON_PRETTY_PRINT));
 
-		global $ilCtrl, $ilDB;
 		$this->dircnt = 1;
 
 		$this->readData($a_entity, $a_schema_version, $a_ids, $a_field = "");

--- a/Modules/ScormAicc/classes/class.ilScormAiccExporter.php
+++ b/Modules/ScormAicc/classes/class.ilScormAiccExporter.php
@@ -17,7 +17,7 @@ class ilScormAiccExporter extends ilXmlExporter
 	{
 
 		include_once './Modules/ScormAicc/classes/class.ilObjSAHSLearningModule.php';
-		$lm = new ilObjSAHSLearningModule(ilObject::_lookupObjectId($a_id),false);
+		$lm = new ilObjSAHSLearningModule($a_id, false);
 		if ($lm->getEditable())		// fix #0022063 (export authoring scorm lm)
 		{
 			include_once("./Modules/Scorm2004/classes/class.ilScorm2004DataSet.php");


### PR DESCRIPTION
Possible fix for: https://mantis.ilias.de/view.php?id=24494

There was a mix up with ref_ids and obj_ids.