### PR TITLE
fixed wrong path (base path for relative t&a path was missing since p…

### DIFF
--- a/Services/Certificate/classes/class.ilCertificate.php
+++ b/Services/Certificate/classes/class.ilCertificate.php
@@ -343,7 +343,7 @@ class ilCertificate
 		$type = ilObject::_lookupType($this->objectId);
 		$certificateId = $this->objectId;
 
-		$dir = $this->certificatePath . time() . "__" . IL_INST_ID . "__" . $type . "__" . $certificateId . "__certificate/";
+		$dir = CLIENT_WEB_DIR . $this->certificatePath . time() . "__" . IL_INST_ID . "__" . $type . "__" . $certificateId . "__certificate/";
 		ilUtil::makeDirParents($dir);
 		return $dir;
 	}

--- a/Services/Certificate/classes/class.ilCertificate.php
+++ b/Services/Certificate/classes/class.ilCertificate.php
@@ -372,12 +372,13 @@ class ilCertificate
 	public function zipCertificatesInArchiveDirectory($dir, $deliver = TRUE)
 	{
 		$zipfile = time() . "__" . IL_INST_ID . "__" . $this->getAdapter()->getAdapterType() . "__" . $this->getAdapter()->getCertificateId() . "__certificates.zip";
-		ilUtil::zip($dir, $this->certificatePath . $zipfile);
+		$zipfilePath = CLIENT_WEB_DIR . $this->certificatePath . $zipfile;
+		ilUtil::zip($dir, $zipfilePath);
 		ilUtil::delDir($dir);
 		if ($deliver) {
-			ilUtil::deliverFile($this->certificatePath . $zipfile, $zipfile, "application/zip");
+			ilUtil::deliverFile($zipfilePath, $zipfile, "application/zip");
 		}
-		return $this->certificatePath . $zipfile;
+		return $zipfilePath;
 	}
 
 	public static function isActive()

--- a/Services/Certificate/classes/class.ilCertificate.php
+++ b/Services/Certificate/classes/class.ilCertificate.php
@@ -376,7 +376,7 @@ class ilCertificate
 		ilUtil::zip($dir, $zipfilePath);
 		ilUtil::delDir($dir);
 		if ($deliver) {
-			ilUtil::deliverFile($zipfilePath, $zipfile, "application/zip");
+			ilUtil::deliverFile($zipfilePath, $zipfile, "application/zip", false, true);
 		}
 		return $zipfilePath;
 	}


### PR DESCRIPTION
…ath constants were changed to relative)

Seit dem die Pfade in ilCertificatePathConstants auf relative Pfade (beginnend mit einem / ;-) umgestellt wurden ist an der Stelle wo das Archiv Dir erzeugt wird ein falscher Pfad. Der relative Pfad wird ohne das CLIENT_WEB_DIR vorangestellt (als absoluter Pfad wegen des beginnenden / ;-) verwendet. Das ist dann definitiv ein Ort an dem nicht geschrieben werden darf.

Das mit dem / war gut, andernfalls irgend ein Dir im Webspace erstellt worden wäre.

Meine Änderung bekämpft einfach das Symptom an Ort und Stelle und stellt dort nun CLIENT_WEB_DIR wieder voran. Die Klassenvariable mit dem relativen Pfad war nun intendiert nur (semi) relativ.