### PR TITLE
0022280: Presentation Settings for Session can not be saved

### DIFF
--- a/Modules/IndividualAssessment/classes/class.ilObjIndividualAssessmentListGUI.php
+++ b/Modules/IndividualAssessment/classes/class.ilObjIndividualAssessmentListGUI.php
@@ -16,7 +16,10 @@ class ilObjIndividualAssessmentListGUI extends ilObjectListGUI {
 		$this->info_screen_enabled = true;
 		$this->type = "iass";
 		$this->gui_class_name = "ilobjIndividualassessmentgui";
-		
+
+		$this->substitutions = ilAdvancedMDSubstitution::_getInstanceByObjectType($this->type);
+		$this->enableSubstitutions($this->substitutions->isActive());
+
 		// general commands array
 		include_once('./Modules/IndividualAssessment/classes/class.ilObjIndividualAssessmentAccess.php');
 		$this->commands = ilObjIndividualAssessmentAccess::_getCommands();


### PR DESCRIPTION
This is a fix for https://mantis.ilias.de/view.php?id=22280

When merged, advanced meta data can optionally be shown in ListGUIs of Invidual Assessment objects.