### PR TITLE
Make deliverPDFFromHTMLString return generated file path

### DIFF
--- a/Modules/Test/classes/class.ilTestPDFGenerator.php
+++ b/Modules/Test/classes/class.ilTestPDFGenerator.php
@@ -112,7 +112,7 @@ class ilTestPDFGenerator
 		}
 		$filename = ilUtil::getASCIIFilename($filename);
 		$pdf_factory = new ilHtmlToPdfTransformerFactory();
-		$pdf_factory->deliverPDFFromHTMLString($pdf_output, $filename, $output_mode, self::service, $purpose);
+		return $pdf_factory->deliverPDFFromHTMLString($pdf_output, $filename, $output_mode, self::service, $purpose);
 
 	}
 

--- a/Services/PDFGeneration/classes/factory/class.ilHtmlToPdfTransformerFactory.php
+++ b/Services/PDFGeneration/classes/factory/class.ilHtmlToPdfTransformerFactory.php
@@ -71,7 +71,7 @@ class ilHtmlToPdfTransformerFactory
 
 		/** @var ilPDFRenderer $renderer */
 		$renderer->generatePDF($service, $purpose, $config, $job);
-		$this->deliverPDF($output, $delivery_type);
+		return $this->deliverPDF($output, $delivery_type);
 	}
 
 


### PR DESCRIPTION
A recent addition in `ilHtmlToPdfTransformerFactory::deliverPDFFromHTMLString`, namely `$output = $this->generateTempPath($output);` which was added on 2018-09-11, changed the logic of the method when `$delivery_type == PDF_OUTPUT_FILE`.

Whereas before `$output` was understood to be the (absolute) target file path, where the PDF file should get written, `deliverPDFFromHTMLString` now generates a private temporary path (using `tempnam()`) that is unknown to the caller (e.g. `/var/ilias/data/ilias/temp/tmp4Bug8E/mytest.pdf`).

With this behaviour, there's no way for a caller to determine where a file has been saved when `$delivery_type == PDF_OUTPUT_FILE`.

I therefore suggest simply returning the resulting file path.


Note: `ilHtmlToPdfTransformerFactory::deliverPDFFromHTMLString` is currently called with absolute paths from various pieces of code related to the old PDF archive function - all that code is currently broken anyway.
