### PR TITLE
Allow "defaults" as config instead of full json in rasterize.js

### DIFF
--- a/Services/PDFGeneration/js/rasterize.js
+++ b/Services/PDFGeneration/js/rasterize.js
@@ -189,13 +189,27 @@ var ilPhantomJsHelper =  (function () {
 
 	pub.Init = function(src_file, out_file, json)
 	{
-		try{
-			pro.json = JSON.parse(json);
+		if (json == 'defaults') {
+			pro.json = {
+				page_size: "A4",
+				orientation: "Portrait",
+				margin: "1cm",
+				delay: "200",
+				viewport: "",
+				header: null,
+				footer: null,
+				page_type: "0"
+			}
+		} else {
+			try {
+				pro.json = JSON.parse(json);
+			}
+			catch(error){
+				console.log('Config error no valid JSON given: ' + error);
+				ilPhantomJsWrapper.exitPhantom(1);
+			}
 		}
-		catch(error){
-			console.log('Config error no valid JSON given: ' + error);
-			ilPhantomJsWrapper.exitPhantom(1);
-		}
+
 		pro.src_file = src_file;
 		pro.out_file = out_file;
 		ilPhantomJsWrapper.initWebPageObject();


### PR DESCRIPTION
Debugging `Services/PDFGeneration/js/rasterize.js` is quite cumbersome at the moment as it expects a full config json in its command line (fully escaped for the shell, of course). For example, this is a minimal call to get it to work (scroll to right, please):

```
phantomjs /path/to/rasterize.js demo.html demo.pdf "{\"page_size\":\"A4\",\"orientation\":\"Portrait\",\"margin\":\"1cm\",\"delay\":\"200\",\"viewport\":\"\",\"header\":null,\"footer\":null,\"page_type\":\"0\"}"
```

As this is unnerving (doubly so for someone not initiated with this tool), I suggest adding a simple `defaults` option that makes `rasterizer.js` operate in some mode, suitable for basic debugging from the command line; the following call would be valid then:

```
phantomjs /path/to/rasterize.js demo.html demo.pdf defaults
```


