### PR TITLE
fixed column index due to new PHPOffice Excel starts from 1 (not 0)

### DIFF
--- a/Services/Excel/classes/class.ilExcel.php
+++ b/Services/Excel/classes/class.ilExcel.php
@@ -351,7 +351,8 @@ class ilExcel
 	 */
 	public function getColumnCoord($a_col)
 	{
-		return Coordinate::stringFromColumnIndex($a_col);
+		$col = ++$a_col;
+		return Coordinate::stringFromColumnIndex($col);
 	}
 	
 	/**
@@ -542,7 +543,8 @@ class ilExcel
 	 */
 	function getCoordByColumnAndRow($pColumn = 0, $pRow = 1)
 	{
-		$columnLetter = Coordinate::stringFromColumnIndex($pColumn);
+		$pColumn = ++$pColumn;
+		$columnLetter = Coordinate::stringFromColumnIndex($pColumn + 1);
 		return $columnLetter . $pRow;
 	}
 


### PR DESCRIPTION
With the introduction of the new PHP Office Library I did experience trouble with the start column index. When I changed to 1 instead of 0 all worked fine again.

I noticed that you @xus did fix a very same issue in ilExcel::setCell() so I did it the same as commited in this PR.

I did fix:

* ilExcel::getColumnCoord()
* ilExcel::getCoordByColumnAndRow()

( Your Commit: https://github.com/ILIAS-eLearning/ILIAS/commit/31509a79ea2223a2f6548a8a1d1bac5a343d390d )