### PR TITLE
PHP 7.2: Fixed usage of undefined constants causing a PHP WARNING

### DIFF
--- a/Services/GlobalCache/classes/class.ilGlobalCache.php
+++ b/Services/GlobalCache/classes/class.ilGlobalCache.php
@@ -185,7 +185,11 @@ class ilGlobalCache {
 	 */
 	protected static function generateServiceId() {
 		if (!isset(self::$unique_service_id)) {
-			self::$unique_service_id = substr(md5('il_' . CLIENT_ID), 0, 6);
+			$rawServiceId = '_';
+			if (defined('CLIENT_ID')) {
+				$rawServiceId .= 'il_' . CLIENT_ID;
+			}
+			self::$unique_service_id = substr(md5($rawServiceId), 0, 6);
 		}
 	}
 

--- a/Services/Logging/classes/public/class.ilLoggerFactory.php
+++ b/Services/Logging/classes/public/class.ilLoggerFactory.php
@@ -164,15 +164,20 @@ class ilLoggerFactory
 		{
 			return $this->loggers[$a_component_id];
 		}
-		
+
+		$loggerNamePrefix = '';
+		if (defined('CLIENT_ID')) {
+			$loggerNamePrefix = CLIENT_ID . '_';
+		}
+
 		switch($a_component_id)
 		{
 			case 'root':
-				$logger = new Logger(CLIENT_ID.'_root');
+				$logger = new Logger($loggerNamePrefix . 'root');
 				break;
 				
 			default:
-				$logger = new Logger(CLIENT_ID.'_'.$a_component_id);
+				$logger = new Logger($loggerNamePrefix . $a_component_id);
 				break;
 				
 		}

--- a/Services/Table/classes/class.ilTable2GUI.php
+++ b/Services/Table/classes/class.ilTable2GUI.php
@@ -595,7 +595,7 @@ class ilTable2GUI extends ilTableGUI
 	final public function setData($a_data)
 	{
 		// check column names against given data (to ensure proper sorting)
-		if(DEVMODE &&
+		if(defined('DEVMODE') && DEVMODE &&
 			$this->enabled["header"] && $this->enabled["sort"] &&
 			$this->columns_determined && is_array($this->column) &&
 			is_array($a_data) && sizeof($a_data) && !$this->getExternalSorting())


### PR DESCRIPTION
Mantis Tickets:
* https://mantis.ilias.de/view.php?id=24918
* https://mantis.ilias.de/view.php?id=24919
* https://mantis.ilias.de/view.php?id=24920

If possible cherry-pick this to `release_5-3` and `release_5-4` as well.