### PR TITLE
PHP 7.2/Setup: Fixed "Warning: count(): Parameter must be an array or an ob…

### DIFF
--- a/setup/classes/class.ilSetup.php
+++ b/setup/classes/class.ilSetup.php
@@ -2133,7 +2133,7 @@ class ilSetup
 				$row = array();
 				while($row = $db->fetchAssoc($res)) break;
 
-				if( count($row) > 0 )
+				if( is_array($row) && count($row) > 0 )
 				{
 					$db->update(
 						'settings',


### PR DESCRIPTION
…ject that implements Countable"

Mantis Ticket: https://mantis.ilias.de/view.php?id=24916