### PR TITLE
UI: streamline Field Group

### DIFF
--- a/src/UI/Implementation/Component/ComponentHelper.php
+++ b/src/UI/Implementation/Component/ComponentHelper.php
@@ -203,7 +203,7 @@ trait ComponentHelper {
 	 * @throws	\InvalidArgumentException	if any element is not an instance of $classes
 	 * @return	null
 	 */
-	protected function checkArgListElements($which, array &$values, &$classes) {
+	protected function checkArgListElements($which, array &$values, $classes) {
 		$classes = $this->toArray($classes);
 		$this->checkArgList
 			( $which

--- a/src/UI/Implementation/Component/Input/Field/Group.php
+++ b/src/UI/Implementation/Component/Input/Field/Group.php
@@ -52,4 +52,15 @@ class Group extends Input implements C\Input\Field\Group {
 		$clone->inputs = $inputs;
 		return $clone;
 	}
+
+	public function withRequired($is_required) {
+		$clone = parent::withRequired($is_required);
+		$inputs = [];
+		foreach ($this->inputs as $key => $input)
+		{
+			$inputs[$key] = $input->withRequired($is_required);
+		}
+		$clone->inputs = $inputs;
+		return $clone;
+	}
 }

--- a/src/UI/Implementation/Component/Input/Field/Group.php
+++ b/src/UI/Implementation/Component/Input/Field/Group.php
@@ -9,6 +9,7 @@ use ILIAS\Data\Result;
 use ILIAS\UI\Component as C;
 use ILIAS\UI\Implementation\Component\Input\PostData;
 use ILIAS\UI\Implementation\Component\Input\NameSource;
+use ILIAS\UI\Implementation\Component\ComponentHelper;
 use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Validation\Factory as ValidationFactory;
 use ILIAS\Transformation\Factory as TransformationFactory;
@@ -18,6 +19,7 @@ use ILIAS\Transformation\Factory as TransformationFactory;
  */
 class Group extends Input implements C\Input\Field\Group {
 
+	use ComponentHelper;
 	use GroupHelper;
 
 	/**
@@ -26,7 +28,7 @@ class Group extends Input implements C\Input\Field\Group {
 	 * @param DataFactory           $data_factory
 	 * @param ValidationFactory     $validation_factory
 	 * @param TransformationFactory $transformation_factory
-	 * @param                       $inputs
+	 * @param InputInternal[]       $inputs
 	 * @param                       $label
 	 * @param                       $byline
 	 */
@@ -34,11 +36,12 @@ class Group extends Input implements C\Input\Field\Group {
 		DataFactory $data_factory,
 		ValidationFactory $validation_factory,
 		TransformationFactory $transformation_factory,
-		$inputs,
-		$label,
-		$byline
+		array $inputs,
+		string $label,
+		string $byline
 	) {
 		parent::__construct($data_factory, $validation_factory, $transformation_factory, $label, $byline);
+		$this->checkArgListElements("inputs", $inputs, InputInternal::class);
 		$this->inputs = $inputs;
 	}
 

--- a/tests/UI/Component/Input/Field/GroupInputTest.php
+++ b/tests/UI/Component/Input/Field/GroupInputTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/* Copyright (c) 2018 Nils Haagen <nils.haagen@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+require_once(__DIR__ . "/../../../../../libs/composer/vendor/autoload.php");
+require_once(__DIR__ . "/../../../Base.php");
+
+use ILIAS\UI\Implementation\Component\Input\Field\Group;
+use ILIAS\UI\Component\Input\Field\Input;
+use \ILIAS\Data;
+use \ILIAS\Validation;
+use \ILIAS\Transformation;
+
+interface Input1 extends Input {};
+interface Input2 extends Input {};
+
+class GroupInputTest extends ILIAS_UI_TestBase {
+	public function setUp() {
+		$this->child1 = $this->createMock(Input1::class);
+		$this->child2 = $this->createMock(Input2::class);
+		$this->data_factory = $this->createMock(Data\Factory::class);
+		$this->validation_factory = $this->createMock(Validation\Factory::class);
+		$this->transformation_factory = $this->createMock(Transformation\Factory::class);
+		$this->group = new Group(
+			$this->data_factory,
+			$this->validation_factory,
+			$this->transformation_factory,
+			[$this->child1, $this->child2],
+			"LABEL",
+			"BYLINE"
+		);
+	}
+
+	public function testWithDisabledDisablesChildren() {
+		$this->assertNotSame($this->child1, $this->child2);
+
+		$this->child1
+			->expects($this->once())
+			->method("withDisabled")
+			->with(true)
+			->willReturn($this->child2);
+		$this->child2
+			->expects($this->once())
+			->method("withDisabled")
+			->with(true)
+			->willReturn($this->child1);
+
+		$new_group = $this->group->withDisabled(true);
+
+		$this->assertEquals([$this->child2, $this->child1], $new_group->getInputs());
+	}
+}

--- a/tests/UI/Component/Input/Field/GroupInputTest.php
+++ b/tests/UI/Component/Input/Field/GroupInputTest.php
@@ -6,13 +6,14 @@ require_once(__DIR__ . "/../../../../../libs/composer/vendor/autoload.php");
 require_once(__DIR__ . "/../../../Base.php");
 
 use ILIAS\UI\Implementation\Component\Input\Field\Group;
+use ILIAS\UI\Implementation\Component\Input\Field\InputInternal;
 use ILIAS\UI\Component\Input\Field\Input;
 use \ILIAS\Data;
 use \ILIAS\Validation;
 use \ILIAS\Transformation;
 
-interface Input1 extends Input {};
-interface Input2 extends Input {};
+interface Input1 extends InputInternal {};
+interface Input2 extends InputInternal {};
 
 class GroupInputTest extends ILIAS_UI_TestBase {
 	public function setUp() {
@@ -68,5 +69,17 @@ class GroupInputTest extends ILIAS_UI_TestBase {
 
 		$this->assertEquals([$this->child2, $this->child1], $new_group->getInputs());
 	}
-	
+
+	public function testGroupMayOnlyHaveInputChildren() {
+		$this->expectException(\InvalidArgumentException::class);
+
+		$this->group = new Group(
+			$this->data_factory,
+			$this->validation_factory,
+			$this->transformation_factory,
+			["foo", "bar"],
+			"LABEL",
+			"BYLINE"
+		);
+	}
 }

--- a/tests/UI/Component/Input/Field/GroupInputTest.php
+++ b/tests/UI/Component/Input/Field/GroupInputTest.php
@@ -49,4 +49,24 @@ class GroupInputTest extends ILIAS_UI_TestBase {
 
 		$this->assertEquals([$this->child2, $this->child1], $new_group->getInputs());
 	}
+
+	public function testWithRequiredRequiresChildren() {
+		$this->assertNotSame($this->child1, $this->child2);
+
+		$this->child1
+			->expects($this->once())
+			->method("withRequired")
+			->with(true)
+			->willReturn($this->child2);
+		$this->child2
+			->expects($this->once())
+			->method("withRequired")
+			->with(true)
+			->willReturn($this->child1);
+
+		$new_group = $this->group->withRequired(true);
+
+		$this->assertEquals([$this->child2, $this->child1], $new_group->getInputs());
+	}
+	
 }


### PR DESCRIPTION
This streamlines the behaviour of `Group::withRequired` with `Group::withDisabled` to make the children inherit the property. Thx @tfamula for pointing that out!

Along the way I did some minor improvements:
* added tests for the Group
* check that children are indeed inputs
* improved usability of ComponentHelper::checkArgListElements