### PR TITLE
[Fix 24936 and 24045] Booking pool does not show available objects

### DIFF
--- a/Modules/BookingManager/classes/class.ilObjBookingPoolGUI.php
+++ b/Modules/BookingManager/classes/class.ilObjBookingPoolGUI.php
@@ -563,6 +563,8 @@ class ilObjBookingPoolGUI extends ilObjectGUI
 			else
 			{
 				$dates = array();
+
+				//loop for 1 week
 				$has_open_slot = $this->buildDatesBySchedule($week_start, $hours, $schedule, $object_ids, $seed, $dates);
 				
 				// find first open slot
@@ -702,16 +704,21 @@ class ilObjBookingPoolGUI extends ilObjectGUI
 		foreach(ilCalendarUtil::_buildWeekDayList($seed,$week_start)->get() as $date)
 		{
 			$date_info = $date->get(IL_CAL_FKT_GETDATE,'','UTC');
-			
-			if($av_from || 
-				$av_to)
+
+			#24045 and #24936
+			if($av_from || $av_to)
 			{
-				$today = $date->get(IL_CAL_DATE);						
-				if($av_from > $today ||
-					$av_to < $today)
+				$today = $date->get(IL_CAL_DATE);
+
+				if ($av_from && $av_from > $today)
 				{
 					continue;
-				}			
+				}
+
+				if($av_to && $av_to < $today)
+				{
+					continue;
+				}
 			}
 
 			$slots = array();


### PR DESCRIPTION
Booking pool does not show available objects and place us to one year forward.
If these changes fix the problem then this commit has to be cherry-picked to 5.4 and ~~probably~~ 5.3

https://mantis.ilias.de/view.php?id=24936