### PR TITLE
Database: Fixed PHP 7.0 issue with is_iterable()

### DIFF
--- a/Services/Database/classes/Atom/class.ilAtomQueryBase.php
+++ b/Services/Database/classes/Atom/class.ilAtomQueryBase.php
@@ -245,7 +245,7 @@ abstract class ilAtomQueryBase implements ilAtomQuery {
 	 * @throws \ilAtomQueryException
 	 */
 	protected function checkQueries() {
-		if (!is_iterable($this->query)) {
+		if ((is_array($this->query) && 0 === count($this->query)) && !($this->query instanceof \Traversable)) {
 			throw new ilAtomQueryException('', ilAtomQueryException::DB_ATOM_CLOSURE_NONE);
 		}
 


### PR DESCRIPTION
`is_iterable()` does not exist in PHP 7.0, so this PR is a fix for 2633037e990fabed173957459af2ec9bf254353b

Should be cherry-picked to `release_5-4` as well.