### PR TITLE
Calendar (PHP 7.2): Fixed returning 'void' instead of array, results in countin…

### DIFF
--- a/Services/Calendar/classes/class.ilCalendarSchedule.php
+++ b/Services/Calendar/classes/class.ilCalendarSchedule.php
@@ -365,7 +365,7 @@ class ilCalendarSchedule
 	{
 		if(!sizeof($a_cats))
 		{
-			return;
+			return $a_cats;
 		}
 		
 		foreach($this->filters as $filter)


### PR DESCRIPTION
…g a non array in consumer

Please cherry-pick this to `trunk` and `release_5-4` as well.