### PR TITLE
Settings Templates (PHP 7.2): Fixed usage of undefined constant (instead of str…

### DIFF
--- a/Services/Administration/classes/class.ilSettingsTemplateGUI.php
+++ b/Services/Administration/classes/class.ilSettingsTemplateGUI.php
@@ -97,10 +97,10 @@ class ilSettingsTemplateGUI
 	function readSettingsTemplate()
 	{
 	    if ($this->getConfig()) {
-		$this->settings_template = new ilSettingsTemplate((int) $_GET[templ_id], $this->getConfig());
+		$this->settings_template = new ilSettingsTemplate((int) $_GET["templ_id"], $this->getConfig());
 	    }
 	    else {
-		$this->settings_template = new ilSettingsTemplate((int) $_GET[templ_id]);
+		$this->settings_template = new ilSettingsTemplate((int) $_GET["templ_id"]);
 	    }
 	}
 


### PR DESCRIPTION
…ing)

Please cherry-pick this to `trunk` and `release_5-4` as well.