### PR TITLE
Search: Used string instead of constant when defining a constant (PHP…

### DIFF
--- a/Services/Search/classes/class.ilQueryParser.php
+++ b/Services/Search/classes/class.ilQueryParser.php
@@ -59,7 +59,7 @@ class ilQueryParser
 
 		$lng = $DIC['lng'];
 
-		define(MIN_WORD_LENGTH,3);
+		define('MIN_WORD_LENGTH',3);
 
 		$this->lng = $lng;
 


### PR DESCRIPTION
… 7.2)

Please cherry-pick this to `release_5-3` and `release_5-4` as well.