### PR TITLE
CoPage: Added undefined constant DOMXML_LOAD_PARSING

### DIFF
--- a/include/inc.xml5compliance.php
+++ b/include/inc.xml5compliance.php
@@ -37,6 +37,8 @@ function domxml_open_file($filename)
 	return new php4DOMDocument($filename);
 }
 
+define('DOMXML_LOAD_PARSING', 0);
+
 /*
 * ##added
 */


### PR DESCRIPTION
Please cherry-pick this to `release_5-3` and `release_5-4` as well.