### PR TITLE
UI Fix for Glyph context template

### DIFF
--- a/src/UI/templates/default/Glyph/tpl.glyph.context_btn.html
+++ b/src/UI/templates/default/Glyph/tpl.glyph.context_btn.html
@@ -1,3 +1,3 @@
-<span class="glyph<!-- BEGIN highlighted --> highlighted<!-- END highlighted -->"<!-- BEGIN with_action --> href="{ACTION}"<!-- END with_action --> aria-label="{LABEL}"<!-- BEGIN with_id --> id="{ID}"<!-- END with_id -->>
+<span class="glyph<!-- BEGIN highlighted --> highlighted<!-- END highlighted --><!-- BEGIN disabled --> disabled<!-- END disabled -->"<!-- BEGIN with_action --> href="{ACTION}"<!-- END with_action --> aria-label="{LABEL}"<!-- BEGIN with_aria_disabled --> aria-disabled="{ARIA_DISABLED}"<!-- END with_aria_disabled --><!-- BEGIN with_id --> id="{ID}"<!-- END with_id -->>
 {GLYPH}
 </span>


### PR DESCRIPTION
When the disabled state for glyphs was added, it was forgotten to adjust the template of glyphs when they are rendered in bulky buttons.

Mantis [24944](https://mantis.ilias.de/view.php?id=24944)