### PR TITLE
UI Possible fix for Disabled Glyph

### DIFF
--- a/src/UI/Implementation/Component/Glyph/Renderer.php
+++ b/src/UI/Implementation/Component/Glyph/Renderer.php
@@ -24,7 +24,7 @@ class Renderer extends AbstractComponentRenderer {
 		$tpl = $this->getTemplate($tpl_file, true, true);
 
 		$action = $component->getAction();
-		if ($action !== null) {
+		if ($component->isActive() && $action !== null) {
 			$tpl->setCurrentBlock("with_action");
 			$tpl->setVariable("ACTION", $component->getAction());
 			$tpl->parseCurrentBlock();

--- a/tests/UI/Component/Glyph/GlyphTest.php
+++ b/tests/UI/Component/Glyph/GlyphTest.php
@@ -323,7 +323,7 @@ class GlyphTest extends ILIAS_UI_TestBase {
 		$css_classes = self::$canonical_css_classes[$type];
 		$aria_label = self::$aria_labels[$type];
 
-		$expected = "<a class=\"glyph disabled\" href=\"http://www.ilias.de\" aria-label=\"$aria_label\" ".
+		$expected = "<a class=\"glyph disabled\" aria-label=\"$aria_label\" ".
 					"aria-disabled=\"true\"><span class=\"$css_classes\" aria-hidden=\"true\"></span></a>";
 		$this->assertEquals($expected, $html);
 	}


### PR DESCRIPTION
Currently, disabled glyphs are rendered with a "href"-attribute and the passed action. This causes a problem when using keyboard instead of mouse. The glyph becomes focusable by tab-key and accessible by return-key, which must not be possible.
This PR solves this problem by only adding the "href"-attribute to active glyphs and not to inactive glyphs. I am not 100% sure if this is the right solution, because Buttons purposely always save the action, even when they are disabled (see [here](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/src/UI/Implementation/Component/Button/Renderer.php#L57)). Maybe this feature could also be useful for Glyphs. In case of Buttons, this is not that problematic. When disabled, they are still focusable by tab-key (which is not nice but tolerable) but they are at least not accessible by return-key. Maybe there is another way to prevent using disabled glyphs by keyboard and still keep the action attribute.

Mantis [24945](https://mantis.ilias.de/view.php?id=24945)