### PR TITLE
Metadata (PHP 7.2): Fixed get_class() applied on non object value

### DIFF
--- a/Services/MetaData/classes/class.ilMDSaxParser.php
+++ b/Services/MetaData/classes/class.ilMDSaxParser.php
@@ -704,8 +704,8 @@ class ilMDSaxParser extends ilSaxParser
 	function &__popParent()
 	{
 		$class = array_pop($this->md_parent);
+		$this->meta_log->debug(is_object($class) ? get_class($class) : 'null');
 		unset($class);
-		$this->meta_log->debug(get_class($class));
 	}
 	function &__getParent()
 	{


### PR DESCRIPTION
This error occured in the `Personal Workspace` when trying to copy objects.

Please cherry-pick this to `release_5-3` and `release_5-4` as well.