### PR TITLE
Blog (PHP 7.2): Fixed get_class() applied on non object value

### DIFF
--- a/Modules/Blog/classes/class.ilBlogPostingGUI.php
+++ b/Modules/Blog/classes/class.ilBlogPostingGUI.php
@@ -334,7 +334,12 @@ class ilBlogPostingGUI extends ilPageObjectGUI
 	 */
 	protected function isInWorkspace()
 	{
-		return stristr(get_class($this->access_handler), "workspace");
+		$class = '';
+		if (is_object($this->access_handler)) {
+			$class = get_class($this->access_handler);
+		}
+
+		return stristr($class, "workspace");
 	}
 
 	/**


### PR DESCRIPTION
Please cherry-pick this to `release_5-3` and `release_5-4` as well.