### PR TITLE
[Certificates] Fix: Card thumbnails are empty on certificate template import

### DIFF
--- a/Services/Certificate/classes/Template/Action/Import/class.ilCertificateTemplateImportAction.php
+++ b/Services/Certificate/classes/Template/Action/Import/class.ilCertificateTemplateImportAction.php
@@ -168,10 +168,10 @@ class ilCertificateTemplateImportAction
 
 		$currentVersion = (int) $certificate->getVersion();
 		$newVersion = $currentVersion;
-		$backgroundImagePath = '';
-		$cardThumbnailImagePath = '';
+		$backgroundImagePath = $certificate->getBackgroundImagePath();
+		$cardThumbnailImagePath = $certificate->getThumbnailImagePath();
 
-		$xsl = '';
+		$xsl = $certificate->getCertificateContent();
 
 		foreach ($directoryInformation as $file) {
 			if (strcmp($file['type'], 'file') == 0) {

--- a/Services/Certificate/classes/Template/Action/Import/class.ilCertificateTemplateImportAction.php
+++ b/Services/Certificate/classes/Template/Action/Import/class.ilCertificateTemplateImportAction.php
@@ -111,6 +111,7 @@ class ilCertificateTemplateImportAction
 	 * @param string $filename
 	 * @param string $rootDir
 	 * @param string $iliasVerision
+	 * @param string $installationID
 	 * @return bool
 	 * @throws \ILIAS\Filesystem\Exception\FileAlreadyExistsException
 	 * @throws \ILIAS\Filesystem\Exception\FileNotFoundException
@@ -168,7 +169,9 @@ class ilCertificateTemplateImportAction
 		$currentVersion = (int) $certificate->getVersion();
 		$newVersion = $currentVersion;
 		$backgroundImagePath = '';
-		$thumbnailImagePath = '';
+		$cardThumbnailImagePath = '';
+
+		$xsl = '';
 
 		foreach ($directoryInformation as $file) {
 			if (strcmp($file['type'], 'file') == 0) {
@@ -183,36 +186,7 @@ class ilCertificateTemplateImportAction
 
 						return 'url(' . $basePath . '/' . $fileName . ')';
 					}, $xsl);
-
-					$jsonEncodedTemplateValues = json_encode($this->placeholderDescriptionObject->getPlaceholderDescriptions());
-
-					$newHashValue = hash(
-						'sha256',
-						implode('', array(
-							$xsl,
-							$backgroundImagePath,
-							$jsonEncodedTemplateValues,
-							$thumbnailImagePath
-						))
-					);
-
-					$template = new ilCertificateTemplate(
-						$this->objectId,
-						$this->objectHelper->lookupType($this->objectId),
-						$xsl,
-						$newHashValue,
-						$jsonEncodedTemplateValues,
-						$newVersion,
-						$iliasVerision,
-						time(),
-						true,
-						$backgroundImagePath,
-						$thumbnailImagePath
-					);
-
-					$this->templateRepository->save($template);
-				}
-				else if (strpos($file['entry'], '.jpg') !== false) {
+				} elseif (strpos($file['entry'], '.jpg') !== false) {
 					$newVersion = $currentVersion + 1;
 					$newBackgroundImageName = 'background_' . $newVersion . '.jpg';
 					$newPath = $this->certificatePath . $newBackgroundImageName;
@@ -232,13 +206,45 @@ class ilCertificateTemplateImportAction
 						'JPEG',
 						100
 					);
+				} elseif (strpos($file['entry'], '.svg') !== false) {
+					$newVersion = $currentVersion + 1;
+					$newCardThumbnailName = 'thumbnail_' . $newVersion . '.svg';
+					$newPath = $this->certificatePath . $newCardThumbnailName;
 
-					$newThumbnailImagePath = 'thumbnail_' . $newVersion . '.svg';
+					$this->filesystem->copy($filePath, $newPath);
 
-					$thumbnailImagePath = $this->certificatePath . $newThumbnailImagePath;
+					$cardThumbnailImagePath = $this->certificatePath . $newCardThumbnailName;
 				}
 			}
 		}
+
+		$jsonEncodedTemplateValues = json_encode($this->placeholderDescriptionObject->getPlaceholderDescriptions());
+
+		$newHashValue = hash(
+			'sha256',
+			implode('', array(
+				$xsl,
+				$backgroundImagePath,
+				$jsonEncodedTemplateValues,
+				$cardThumbnailImagePath
+			))
+		);
+
+		$template = new ilCertificateTemplate(
+			$this->objectId,
+			$this->objectHelper->lookupType($this->objectId),
+			$xsl,
+			$newHashValue,
+			$jsonEncodedTemplateValues,
+			$newVersion,
+			$iliasVerision,
+			time(),
+			true,
+			$backgroundImagePath,
+			$cardThumbnailImagePath
+		);
+
+		$this->templateRepository->save($template);
 
 		$this->utilHelper->delDir($importPath);
 

--- a/Services/Certificate/classes/Template/Action/Import/class.ilCertificateTemplateImportAction.php
+++ b/Services/Certificate/classes/Template/Action/Import/class.ilCertificateTemplateImportAction.php
@@ -167,7 +167,7 @@ class ilCertificateTemplateImportAction
 		$certificate = $this->templateRepository->fetchCurrentlyUsedCertificate($this->objectId);
 
 		$currentVersion = (int) $certificate->getVersion();
-		$newVersion = $currentVersion;
+		$newVersion = $currentVersion + 1;
 		$backgroundImagePath = $certificate->getBackgroundImagePath();
 		$cardThumbnailImagePath = $certificate->getThumbnailImagePath();
 
@@ -187,7 +187,6 @@ class ilCertificateTemplateImportAction
 						return 'url(' . $basePath . '/' . $fileName . ')';
 					}, $xsl);
 				} elseif (strpos($file['entry'], '.jpg') !== false) {
-					$newVersion = $currentVersion + 1;
 					$newBackgroundImageName = 'background_' . $newVersion . '.jpg';
 					$newPath = $this->certificatePath . $newBackgroundImageName;
 					$this->filesystem->copy($filePath, $newPath);
@@ -207,7 +206,6 @@ class ilCertificateTemplateImportAction
 						100
 					);
 				} elseif (strpos($file['entry'], '.svg') !== false) {
-					$newVersion = $currentVersion + 1;
 					$newCardThumbnailName = 'thumbnail_' . $newVersion . '.svg';
 					$newPath = $this->certificatePath . $newCardThumbnailName;
 


### PR DESCRIPTION
The card thumbnails can be empty during certificate template import.
This was caused by wrong handling of mix of file names and file extensions.

Mantis: https://mantis.ilias.de/view.php?id=24731