### PR TITLE
Workaround to order calendar events by time in the Month view.

### DIFF
--- a/Services/Calendar/classes/class.ilCalendarSchedule.php
+++ b/Services/Calendar/classes/class.ilCalendarSchedule.php
@@ -213,6 +213,7 @@ class ilCalendarSchedule
 		
 		$tmp_date = new ilDateTime($unix_start,IL_CAL_UNIX,$this->timezone);
 		$tmp_schedule = array();
+		$tmp_schedule_fullday = array();
 	 	foreach($this->schedule as $schedule)
 	 	{
 	 		if($schedule['fullday'])
@@ -221,7 +222,7 @@ class ilCalendarSchedule
 		 			$f_unix_start == $schedule['dend'] or
 		 			($f_unix_start > $schedule['dstart'] and $f_unix_end <= $schedule['dend']))
 	 			{
-		 			$tmp_schedule[] = $schedule;
+		 			$tmp_schedule_fullday[] = $schedule;
 	 			}
 	 		}
 	 		elseif(($schedule['dstart'] == $unix_start) or
@@ -231,7 +232,16 @@ class ilCalendarSchedule
 	 			$tmp_schedule[] = $schedule;
 	 		}
 	 	}
-	 	return $tmp_schedule;
+
+	 	//order non full day events by starting date;
+		usort($tmp_schedule,function($a, $b){
+			return $a['dstart'] <=> $b['dstart'];
+		});
+
+		//merge both arrays keeping the full day events first and then rest ordered by starting date.
+	 	$schedules = array_merge($tmp_schedule_fullday,$tmp_schedule);
+
+	 	return $schedules;
 	}
 
 	


### PR DESCRIPTION
Workaround for this bug: https://mantis.ilias.de/view.php?id=24909
Month view will show first "full day" events and then the rest ordered by time.
The problem was with recursive events were placed before the other events.