### PR TITLE
Allow empty mail subject prefixes

### DIFF
--- a/Services/Mail/classes/class.ilMail.php
+++ b/Services/Mail/classes/class.ilMail.php
@@ -13,6 +13,8 @@ class ilMail
 	/** @var string */
 	const ILIAS_HOST = 'ilias';
 
+	const MAIL_SUBJECT_PREFIX = '[ILIAS]';
+
 	/** @var ilLanguage */
 	protected $lng;
 
@@ -1636,7 +1638,12 @@ class ilMail
 	{
 		global $DIC;
 
-		return $DIC->settings()->get('mail_subject_prefix', '');
+		$subjectPrefix = $DIC->settings()->get('mail_subject_prefix');
+		if (false === $subjectPrefix) {
+			$subjectPrefix = self::MAIL_SUBJECT_PREFIX;
+		}
+
+		return $subjectPrefix;
 	}
 
 	/**

--- a/Services/Mail/classes/class.ilMail.php
+++ b/Services/Mail/classes/class.ilMail.php
@@ -1414,7 +1414,13 @@ class ilMail
 	 */
 	public function sendMimeMail($a_rcp_to, $a_rcp_cc, $a_rcp_bcc, $a_m_subject, $a_m_message, $a_attachments)
 	{
-		$a_m_subject = self::getSubjectPrefix() . ' ' . $a_m_subject;
+		$subjectPrefix = self::getSubjectPrefix();
+
+		if ('' !== $subjectPrefix) {
+			$subjectPrefix = $subjectPrefix . ' ';
+		}
+
+		$a_m_subject = $subjectPrefix . $a_m_subject;
 
 		/** @var \ilMailMimeSenderFactory $senderFactory */
 		$senderFactory = $GLOBALS["DIC"]["mail.mime.sender.factory"];

--- a/Services/Mail/classes/class.ilObjMailGUI.php
+++ b/Services/Mail/classes/class.ilObjMailGUI.php
@@ -539,9 +539,9 @@ class ilObjMailGUI extends ilObjectGUI
 	 */
 	protected function populateExternalSettingsForm(ilPropertyFormGUI $form)
 	{
-		$subject = $this->settings->get('mail_subject_prefix');
-		if (false === $subject) {
-			$subject = '[ILIAS]';
+		$subjectPrefix = $this->settings->get('mail_subject_prefix');
+		if (false === $subjectPrefix) {
+			$subjectPrefix = '[ILIAS]';
 		}
 
 		$form->setValuesByArray(array(
@@ -551,7 +551,7 @@ class ilObjMailGUI extends ilObjectGUI
 			'mail_smtp_user'                => $this->settings->get('mail_smtp_user'),
 			'mail_smtp_password'            => strlen($this->settings->get('mail_smtp_password')) > 0 ? self::PASSWORD_PLACE_HOLDER : '',
 			'mail_smtp_encryption'          => $this->settings->get('mail_smtp_encryption'),
-			'mail_subject_prefix'           => $subject,
+			'mail_subject_prefix'           => $subjectPrefix,
 			'mail_send_html'                => (int)$this->settings->get('mail_send_html'),
 			'mail_system_usr_from_addr'     => $this->settings->get('mail_system_usr_from_addr'),
 			'mail_system_usr_from_name'     => $this->settings->get('mail_system_usr_from_name'),

--- a/Services/Mail/classes/class.ilObjMailGUI.php
+++ b/Services/Mail/classes/class.ilObjMailGUI.php
@@ -541,7 +541,7 @@ class ilObjMailGUI extends ilObjectGUI
 	{
 		$subjectPrefix = $this->settings->get('mail_subject_prefix');
 		if (false === $subjectPrefix) {
-			$subjectPrefix = '[ILIAS]';
+			$subjectPrefix = ilMail::MAIL_SUBJECT_PREFIX;
 		}
 
 		$form->setValuesByArray(array(

--- a/Services/Mail/classes/class.ilObjMailGUI.php
+++ b/Services/Mail/classes/class.ilObjMailGUI.php
@@ -539,6 +539,11 @@ class ilObjMailGUI extends ilObjectGUI
 	 */
 	protected function populateExternalSettingsForm(ilPropertyFormGUI $form)
 	{
+		$subject = $this->settings->get('mail_subject_prefix');
+		if (false === $subject) {
+			$subject = '[ILIAS]';
+		}
+
 		$form->setValuesByArray(array(
 			'mail_smtp_status'              => (bool)$this->settings->get('mail_smtp_status'),
 			'mail_smtp_host'                => $this->settings->get('mail_smtp_host'),
@@ -546,7 +551,7 @@ class ilObjMailGUI extends ilObjectGUI
 			'mail_smtp_user'                => $this->settings->get('mail_smtp_user'),
 			'mail_smtp_password'            => strlen($this->settings->get('mail_smtp_password')) > 0 ? self::PASSWORD_PLACE_HOLDER : '',
 			'mail_smtp_encryption'          => $this->settings->get('mail_smtp_encryption'),
-			'mail_subject_prefix'           => $this->settings->get('mail_subject_prefix') ? $this->settings->get('mail_subject_prefix') : '[ILIAS]',
+			'mail_subject_prefix'           => $subject,
 			'mail_send_html'                => (int)$this->settings->get('mail_send_html'),
 			'mail_system_usr_from_addr'     => $this->settings->get('mail_system_usr_from_addr'),
 			'mail_system_usr_from_name'     => $this->settings->get('mail_system_usr_from_name'),

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -6745,7 +6745,7 @@ mail#:#mail_select_one_entry#:#Sie müssen mindestens einen Eintrag auswählen
 mail#:#mail_select_one_file#:#Sie müssen mindestens eine Datei auswählen
 mail#:#mail_settings_incoming_type_see_also#:#Eine weitere Möglichkeit, die Empfangsart für die Benutzer zu ändern, haben Sie <a href="%s">hier</a>.
 mail#:#mail_subject_prefix#:#Mail-Betreff
-mail#:#mail_subject_prefix_info#:#Sie können hier einen Text eingeben, der der Betreffzeile ausgehender, automatisch generierter E-Mails vorangestellt wird.
+mail#:#mail_subject_prefix_info#:#Sie können hier einen Text eingeben, der der Betreffzeile ausgehender, automatisch generierter E-Mails vorangestellt wird. Es wird empfohlen einen Präfix anzugeben, um Nutzern das Filtern der Nachrichten zu vereinfachen.
 mail#:#mail_sure_delete#:#Sind Sie sicher, dass die markierten Mails gelöscht werden sollen?
 mail#:#mail_sure_delete_entry#:#Sind Sie sicher, dass die markierten Einträge gelöscht werden sollen?
 mail#:#mail_sure_delete_file#:#Sind Sie sicher, dass die ausgewählten Dateien gelöscht werden sollen?

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -5747,7 +5747,7 @@ mail#:#mail_select_group#:#Please select at least one group.
 mail#:#mail_select_one_entry#:#You must select one entry
 mail#:#mail_select_one_file#:#You must select one file
 mail#:#mail_settings_incoming_type_see_also#:#You can find a further possibility to modify the incoming type of e-mails for users <a href="%s">here</a>.
-mail#:#mail_subject_prefix_info#:#Enter a text, which will be prepended to the subject line of outgoing auto generated e-mails.
+mail#:#mail_subject_prefix_info#:#Enter a text, which will be prepended to the subject line of outgoing auto generated e-mails. It is recommended the usage of a prefix for supporting message filtering by users.
 mail#:#mail_subject_prefix#:#Mail Subject
 mail#:#mail_sure_delete_entry#:#Are you sure you want to delete the following entries?
 mail#:#mail_sure_delete_file#:#Are you sure you want to delete the selected files?


### PR DESCRIPTION
This PR will allow empty prefixes on save.

The save type check of the `mail_subject_prefix` settings allows to check if the setting was saved ever in the settings table. That ensures that on the first opening of this form the default prefix is `ILIAS`.

Mantis: https://mantis.ilias.de/view.php?id=24946