### PR TITLE
UI: an internal input also is an input

### DIFF
--- a/src/UI/Implementation/Component/Input/Field/InputInternal.php
+++ b/src/UI/Implementation/Component/Input/Field/InputInternal.php
@@ -5,6 +5,7 @@
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
 use ILIAS\UI\Implementation\Component\Input\PostData;
+use ILIAS\UI\Component\Input\Field\Input;
 use ILIAS\UI\Implementation\Component\Input\NameSource;
 use ILIAS\Data\Result;
 
@@ -12,7 +13,7 @@ use ILIAS\Data\Result;
  * Describes the interface of inputs that is used for internal
  * processing of data from the client.
  */
-interface InputInternal {
+interface InputInternal extends Input {
 
 	/**
 	 * The name of the input as used in HTML.


### PR DESCRIPTION
This is a minor rectification that is supposed to fix two warnings in the tests:

1) GroupInputTest::testWithDisabledDisablesChildren
Trying to configure method "withDisabled" which cannot be configured because it does not exist, has not been specified, is final, or is static

2) GroupInputTest::testWithRequiredRequiresChildren
Trying to configure method "withRequired" which cannot be configured because it does not exist, has not been specified, is final, or is static

This also just seems to be correct.