### PR TITLE
LSO: starting the sequence crashes in 5.4

### DIFF
--- a/Modules/LearningSequence/classes/Player/LSUrlBuilder.php
+++ b/Modules/LearningSequence/classes/Player/LSUrlBuilder.php
@@ -18,11 +18,11 @@ class LSUrlBuilder implements URLBuilder
 
 	public function getURL(string $command, int $param = null): ILIAS\Data\URI
 	{
-		$query = $this->base_url->getQuery();
+		$query = $this->base_url->query();
 		if(!$query) {
 			$params = [];
 		} else {
-			parse_str($this->base_url->getQuery(), $params);
+			parse_str($this->base_url->query(), $params);
 		}
 
 		$params[self::PARAM_LSO_COMMAND] = $command;
@@ -38,6 +38,6 @@ class LSUrlBuilder implements URLBuilder
 	public function getHref(string $command, int $param = null): string
 	{
 		$url = $this->getURL($command, $param);
-		return $url->getBaseURI().'?'.$url->getQuery();
+		return $url->baseURI().'?'.$url->query();
 	}
 }


### PR DESCRIPTION
use this version for 5.4, there was an erroneous update from trunk.