### PR TITLE
UI Possible fix for Image accessibility

### DIFF
--- a/src/UI/Implementation/Component/Image/Renderer.php
+++ b/src/UI/Implementation/Component/Image/Renderer.php
@@ -34,6 +34,9 @@ class Renderer extends AbstractComponentRenderer {
 			}
 
 			if (is_array($component->getAction())) {
+				$tpl->setCurrentBlock("with_href");
+				$tpl->setVariable("HREF", "#");
+				$tpl->parseCurrentBlock();
 				$tpl->setCurrentBlock("with_id");
 				$tpl->setVariable("ID", $id);
 				$tpl->parseCurrentBlock();

--- a/tests/UI/Component/Image/ImageTest.php
+++ b/tests/UI/Component/Image/ImageTest.php
@@ -155,7 +155,7 @@ class ImageTest extends ILIAS_UI_TestBase {
 
 		$html = $this->normalizeHTML($r->render($i));
 
-		$expected = "<a id=\"id_1\"><img src=\"source\" class=\"img-standard\" alt=\"alt\" /></a>";
+		$expected = "<a href=\"#\" id=\"id_1\"><img src=\"source\" class=\"img-standard\" alt=\"alt\" /></a>";
 
 		$this->assertEquals($expected, $html);
 	}


### PR DESCRIPTION
Some time ago, I implemented the possibility to give Images a signal action. Now, I found out that they are clickable, but not accessible by keyboard. The reason is that they do not get a "href" attribute in the template like Images which have a string action.
First, I tried to make them accessible by giving them "tabindex=0". But this is not enough, because that makes them only focusable and there is much more to do to make them also clickable (see [here](https://www.456bereastreet.com/archive/201302/making_elements_keyboard_focusable_and_clickable/)). That is why I decided to give them just an empty "href" attribute, what would solve the problem the easiest way IMO.

Mantis [24996](https://mantis.ilias.de/view.php?id=24996)