### PR TITLE
fixed assertion

### DIFF
--- a/Services/UICore/classes/class.ilGlobalTemplate.php
+++ b/Services/UICore/classes/class.ilGlobalTemplate.php
@@ -1821,7 +1821,7 @@ class ilGlobalTemplate
 		}
 
 		$toolb = $this->admin_panel_commands_toolbar;
-		assert($toolbar instanceof \ilToolbarGUI);
+		assert($toolb instanceof \ilToolbarGUI);
 
 		// Add arrow if desired.
 		if($this->admin_panel_arrow)


### PR DESCRIPTION
This assertion seems to be wrong in trunk (wrong variable name), in some cases this leads to a warning.