### PR TITLE
[Certificates] Add missing date completion placeholder for previews

### DIFF
--- a/Services/Certificate/classes/Placeholder/Values/class.ilDefaultPlaceholderValues.php
+++ b/Services/Certificate/classes/Placeholder/Values/class.ilDefaultPlaceholderValues.php
@@ -183,7 +183,9 @@ class ilDefaultPlaceholderValues implements ilCertificatePlaceholderValues
 			"USER_COUNTRY" => $this->utilHelper->prepareFormOutput($this->language->txt("certificate_var_user_country")),
 			"USER_MATRICULATION" => $this->utilHelper->prepareFormOutput($this->language->txt("certificate_var_user_matriculation")),
 			'DATE' => $this->utilHelper->prepareFormOutput((trim($this->dateHelper->formatDate(time(), $this->dateFormat)))),
-			'DATETIME' => $this->utilHelper->prepareFormOutput((trim($this->dateHelper->formatDatetime(time(), $this->dateFormat))))
+			'DATETIME' => $this->utilHelper->prepareFormOutput((trim($this->dateHelper->formatDatetime(time(), $this->dateFormat)))),
+			'DATE_COMPLETED' => $this->utilHelper->prepareFormOutput((trim($this->dateHelper->formatDate(time(), $this->dateFormat)))),
+			'DATETIME_COMPLETED' => $this->utilHelper->prepareFormOutput((trim($this->dateHelper->formatDatetime(time(), $this->dateFormat))))
 		);
 
 		return array_merge($previewPlacholderValues, $this->userDefinedFieldsPlaceholderValues->getPlaceholderValuesForPreview($userId, $objId));

--- a/Services/Certificate/test/ilDefaultPlaceholderValuesTest.php
+++ b/Services/Certificate/test/ilDefaultPlaceholderValuesTest.php
@@ -240,7 +240,9 @@ class ilDefaultPlaceholderValuesTest extends PHPUnit_Framework_TestCase
 				'USER_COUNTRY'       => 'Something',
 				'USER_MATRICULATION' => 'Something',
 				'DATE'               => '2018-09-09',
-				'DATETIME'           => '2018-09-09 14:00:30'
+				'DATETIME'           => '2018-09-09 14:00:30',
+				'DATE_COMPLETED'     => '2018-09-09',
+				'DATETIME_COMPLETED' => '2018-09-09 14:00:30'
 			),
 			$result
 		);


### PR DESCRIPTION
This PR adds the missing placeholders for the user certificate create by the preview action.

For the timestamp the current system timestamp is used. This behavior is analog to the old adapter behavior.

Mantis Ticket: https://mantis.ilias.de/view.php?id=25024 