### PR TITLE
0024774: Failed test: Einstellungen des OER Harvesters bearbeiten

### DIFF
--- a/Services/Cron/classes/class.ilCronManagerGUI.php
+++ b/Services/Cron/classes/class.ilCronManagerGUI.php
@@ -57,7 +57,7 @@ class ilCronManagerGUI
 		switch($class)
 		{
 			case "ilpropertyformgui":
-				$form = $this->initEditForm();
+				$form = $this->initEditForm($_REQUEST['jid']);
 				$this->ctrl->forwardCommand($form);
 				break;
 		}


### PR DESCRIPTION
This is a fix for https://mantis.ilias.de/view.php?id=24774

Since the propertyform-forwarding is a new 5.4 feature, it needs to be merged only to the trunk.
