### PR TITLE
Documentation: Changed supported PHP versions

### DIFF
--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -672,7 +672,7 @@ When you upgrade from rather old versions please make sure that the dependencies
 
 | ILIAS Version   | PHP Version                           |
 |-----------------|---------------------------------------|
-| 5.4.x           | 7.0.x, 7.1.x, 7.2.x                   |
+| 5.4.x           | 7.0.x, 7.1.x, 7.2.x, 7.3.x            |
 | 5.3.x           | 5.6.x, 7.0.x, 7.1.x                   |
 | 5.2.x           | 5.5.x - 5.6.x, 7.0.x, 7.1.x           |
 | 5.0.x - 5.1.x   | 5.3.x - 5.5.x                         |


### PR DESCRIPTION
Added Support of `PHP 7.3` according to https://docu.ilias.de/goto_docu_wiki_wpage_5692_1357.html