### PR TITLE
Proposal: Add UI Links to UI Dropdowns

### DIFF
--- a/src/UI/Component/Dropdown/Dropdown.php
+++ b/src/UI/Component/Dropdown/Dropdown.php
@@ -17,7 +17,7 @@ interface Dropdown extends Component, JavaScriptBindable, Clickable, Hoverable {
 	/**
 	 * Get the items of the Dropdown.
 	 *
-	 * @return	array<\ILIAS\UI\Component\Button\Shy|\ILIAS\UI\Component\Divider\Horizontal>
+	 * @return	array<\ILIAS\UI\Component\Button\Shy|\ILIAS\UI\Component\Divider\Horizontal|\ILIAS\UI\Component\Link\Standard>
 	 */
 	public function getItems();
 

--- a/src/UI/Component/Dropdown/Factory.php
+++ b/src/UI/Component/Dropdown/Factory.php
@@ -20,7 +20,7 @@ interface Factory {
 	 *          Standard Dropdown MUST be used if there is no good reason using
 	 *          another instance.
 	 * ---
-	 * @param array<\ILIAS\UI\Component\Button\Shy|\ILIAS\UI\Component\Divider\Horizontal> array of action items
+	 * @param array<\ILIAS\UI\Component\Button\Shy|\ILIAS\UI\Component\Divider\Horizontal|\ILIAS\UI\Component\Link\Standard> array of action items
 	 * @return \ILIAS\UI\Component\Dropdown\Standard
 	 */
 	public function standard($items);

--- a/src/UI/Implementation/Component/Dropdown/Dropdown.php
+++ b/src/UI/Implementation/Component/Dropdown/Dropdown.php
@@ -24,13 +24,13 @@ abstract class Dropdown implements C\Dropdown\Dropdown {
 	protected $label;
 
 	/**
-	 * @var array<\ILIAS\UI\Component\Button\Shy|\ILIAS\UI\Component\Divider\Horizontal>
+	 * @var array<\ILIAS\UI\Component\Button\Shy|\ILIAS\UI\Component\Divider\Horizontal|\ILIAS\UI\Component\Link\Standard>
 	 */
 	protected $items;
 
 	/**
 	 * Dropdown constructor.
-	 * @param array<\ILIAS\UI\Component\Button\Shy|\ILIAS\UI\Component\Divider\Horizontal> $items
+	 * @param array<\ILIAS\UI\Component\Button\Shy|\ILIAS\UI\Component\Divider\Horizontal|\ILIAS\UI\Component\Link\Standard> $items
 	 */
 	public function __construct($items) {
 		$this->items = $items;

--- a/src/UI/examples/Dropdown/Standard/with_buttons_and_links.php
+++ b/src/UI/examples/Dropdown/Standard/with_buttons_and_links.php
@@ -1,0 +1,12 @@
+<?php
+function with_buttons_and_links() {
+	global $DIC;
+	$f = $DIC->ui()->factory();
+	$renderer = $DIC->ui()->renderer();
+
+	$items = array(
+		$f->button()->shy("Github", "https://www.ilias.de"),
+		$f->link()->standard("ILIAS", "https://www.ilias.de")->withOpenInNewViewport(true)
+	);
+	return $renderer->render($f->dropdown()->standard($items)->withLabel("Actions"));
+}

--- a/src/UI/examples/Dropdown/Standard/with_buttons_and_links.php
+++ b/src/UI/examples/Dropdown/Standard/with_buttons_and_links.php
@@ -5,7 +5,7 @@ function with_buttons_and_links() {
 	$renderer = $DIC->ui()->renderer();
 
 	$items = array(
-		$f->button()->shy("Github", "https://www.ilias.de"),
+		$f->button()->shy("Github", "https://www.github.com"),
 		$f->link()->standard("ILIAS", "https://www.ilias.de")->withOpenInNewViewport(true)
 	);
 	return $renderer->render($f->dropdown()->standard($items)->withLabel("Actions"));

--- a/tests/UI/Component/Dropdown/DropdownTest.php
+++ b/tests/UI/Component/Dropdown/DropdownTest.php
@@ -34,17 +34,19 @@ class DropdownTest extends ILIAS_UI_TestBase {
 
 	public function test_with_items() {
 		$f = $this->getFactory();
+		$link = new I\Component\Link\Standard("Link to Github", "http://www.github.com");
 		$c = $f->standard(array(
 			new I\Component\Button\Shy("ILIAS", "https://www.ilias.de"),
 			new I\Component\Button\Shy("GitHub", "https://www.github.com"),
-			new I\Component\Divider\Horizontal(),	
-			new I\Component\Button\Shy("GitHub", "https://www.github.com")
+			new I\Component\Divider\Horizontal(),
+			$link->withOpenInNewViewport(true)
 		));
 		$items = $c->getItems();
 
 		$this->assertTrue(is_array($items));
 		$this->assertInstanceOf("ILIAS\\UI\\Component\\Button\\Shy", $items[0]);
 		$this->assertInstanceOf("ILIAS\\UI\\Component\\Divider\\Horizontal", $items[2]);
+		$this->assertInstanceOf("ILIAS\\UI\\Component\\Link\\Standard", $items[3]);
 	}
 
 	public function test_render_empty() {
@@ -105,6 +107,29 @@ EOT;
 					<li><button class="btn btn-link" data-action="https://www.ilias.de" id="id_1">ILIAS</button></li>
 					<li><hr  /></li>
 					<li><button class="btn btn-link" data-action="https://www.github.com" id="id_2">GitHub</button></li>
+				</ul>
+			</div>
+EOT;
+
+		$this->assertHTMLEquals($expected, $html);
+	}
+
+	public function test_render_with_link_new_viewport() {
+		$f = $this->getFactory();
+		$r = $this->getDefaultRenderer();
+
+		$link = new I\Component\Link\Standard("Link to ILIAS", "http://www.ilias.de");
+
+		$c = $f->standard(array(
+			$link->withOpenInNewViewport(true)
+		));
+
+		$html = $r->render($c);
+
+		$expected = <<<EOT
+			<div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"  aria-haspopup="true" aria-expanded="false"><span class="caret"></span></button>
+				<ul class="dropdown-menu">
+					<li><a href="http://www.ilias.de" target="_blank" rel="noopener">Link to ILIAS</a></li>
 				</ul>
 			</div>
 EOT;


### PR DESCRIPTION
This PR proposes to allow UI Dropdowns to accept also UI Links as items.

The main reason for that is that sometimes the items in the dropdown need to open a new browser tab.

This issue came to me when implementing this [ILIAS Feature](https://docu.ilias.de/goto_docu_wiki_wpage_5571_1357.html)