### PR TITLE
Return configured http_path if it is set in ilUtil::_getHttpPath

### DIFF
--- a/Services/Utilities/classes/class.ilUtil.php
+++ b/Services/Utilities/classes/class.ilUtil.php
@@ -5040,6 +5040,9 @@ class ilUtil
 		}
 		else
 		{
+			if (strlen($ilIliasIniFile->readVariable('server', 'http_path')) > 0) {
+				return $ilIliasIniFile->readVariable('server', 'http_path');
+			}
 			return ILIAS_HTTP_PATH;
 		}
 	}


### PR DESCRIPTION
Because the constant ILIAS_HTTP_PATH is not set correctly i fixed the return value of the ilUtil::_getHttpPath Method.

The ilUtil::_getHttpPath will now return the path confiured in the ilias.ini.php. (If its set and this schould be mandatory)

ILIAS_HTTP_PATH is not correctly set to the dir containing the standard ilias php files (e.g. index.php goto.php ilias.php). Nevertheless, the source code assumes that ILIAS_HTTP_PATH is always pointing to the docroot.

I think this pull request dont comply with the development processes. Feel free to close or convert this pull request.