### PR TITLE
Fix reimport of KPrim's partial solution setting.

### DIFF
--- a/Modules/TestQuestionPool/classes/import/qti12/class.assKprimChoiceImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assKprimChoiceImport.php
@@ -112,10 +112,14 @@ class assKprimChoiceImport extends assQuestionImport
 				if( $decvar->getVarname() == 'SCORE' )
 				{
 					$this->object->setPoints($decvar->getMaxvalue());
-					
+
 					if( $decvar->getMinvalue() > 0 )
 					{
 						$this->object->setScorePartialSolutionEnabled(true);
+					}
+					else
+					{
+						$this->object->setScorePartialSolutionEnabled(false);
 					}
 				}
 			}


### PR DESCRIPTION
Fixes https://mantis.ilias.de/view.php?id=25091

Note that kprim's constructor always initializes this flag to `true`, so the importer has to explicitly set it to `false` as done in this PR:

https://github.com/ILIAS-eLearning/ILIAS/blob/b8f5e2662a9ad30e8312cae213ca26c4261b792b/Modules/TestQuestionPool/classes/class.assKprimChoice.php#L58
