### PR TITLE
WebDAV instruction for Windows Explorer bugfix

### DIFF
--- a/Modules/File/classes/class.ilObjFileAccessSettingsGUI.php
+++ b/Modules/File/classes/class.ilObjFileAccessSettingsGUI.php
@@ -36,7 +36,7 @@ include_once "./Services/Object/classes/class.ilObjectGUI.php";
  */
 class ilObjFileAccessSettingsGUI extends ilObjectGUI {
 
-    const INSTALL_README_PATH = '/docs/configuration/install.md';
+	const INSTALL_README_PATH = '/docs/configuration/install.md';
 	const CMD_EDIT_DOWNLOADING_SETTINGS = 'editDownloadingSettings';
 	const CMD_EDIT_WEBDAV_SETTINGS = 'editWebDAVSettings';
 	
@@ -363,7 +363,7 @@ class ilObjFileAccessSettingsGUI extends ilObjectGUI {
 		}
 
 		$form = $this->initWebDAVSettingsForm();
-        $tpl->setContent($form->getHTML());
+		$tpl->setContent($form->getHTML());
 	}
 
 
@@ -374,7 +374,7 @@ class ilObjFileAccessSettingsGUI extends ilObjectGUI {
 	    global $DIC;
 		$rbacsystem = $DIC['rbacsystem'];
 		$ilErr = $DIC['ilErr'];
-        $tpl = $DIC['tpl'];
+		$tpl = $DIC['tpl'];
 		$ilCtrl = $DIC['ilCtrl'];
 		$lng = $DIC['lng'];
 
@@ -397,16 +397,16 @@ class ilObjFileAccessSettingsGUI extends ilObjectGUI {
 		else 
 		{
 		    $form->setValuesByPost();
-            $tpl->setContent($form->getHTML());
-        }
+		    $tpl->setContent($form->getHTML());
+		}
     }
 
     public function getAdditionalWebDAVInformation() {
-        global $DIC;
-        $lng = $DIC->language();
+	    global $DIC;
+	    $lng = $DIC->language();
 
-        return $furtherInformation = sprintf($lng->txt('webdav_additional_information'), $this->getInstallationDocsLink());
-    }
+	    return $furtherInformation = sprintf($lng->txt('webdav_additional_information'), $this->getInstallationDocsLink());
+	}
 
     public function getInstallationDocsLink()
     {

--- a/Modules/File/classes/class.ilObjFileAccessSettingsGUI.php
+++ b/Modules/File/classes/class.ilObjFileAccessSettingsGUI.php
@@ -371,7 +371,7 @@ class ilObjFileAccessSettingsGUI extends ilObjectGUI {
 	 * Save settings
 	 */
 	public function saveWebDAVSettings()  {
-	    global $DIC;
+		global $DIC;
 		$rbacsystem = $DIC['rbacsystem'];
 		$ilErr = $DIC['ilErr'];
 		$tpl = $DIC['tpl'];
@@ -399,19 +399,19 @@ class ilObjFileAccessSettingsGUI extends ilObjectGUI {
 		    $form->setValuesByPost();
 		    $tpl->setContent($form->getHTML());
 		}
-    }
-
-    public function getAdditionalWebDAVInformation() {
-	    global $DIC;
-	    $lng = $DIC->language();
-
-	    return $furtherInformation = sprintf($lng->txt('webdav_additional_information'), $this->getInstallationDocsLink());
 	}
 
-    public function getInstallationDocsLink()
-    {
-        return ilUtil::_getHttpPath() . self::INSTALL_README_PATH;
-    }
+	public function getAdditionalWebDAVInformation() {
+		global $DIC;
+		$lng = $DIC->language();
+
+		return $furtherInformation = sprintf($lng->txt('webdav_additional_information'), $this->getInstallationDocsLink());
+	}
+
+	public function getInstallationDocsLink()
+	{
+		return ilUtil::_getHttpPath() . self::INSTALL_README_PATH;
+	}
 
 	/**
 	 * called by prepare output

--- a/Modules/File/classes/class.ilObjFileAccessSettingsGUI.php
+++ b/Modules/File/classes/class.ilObjFileAccessSettingsGUI.php
@@ -36,6 +36,7 @@ include_once "./Services/Object/classes/class.ilObjectGUI.php";
  */
 class ilObjFileAccessSettingsGUI extends ilObjectGUI {
 
+    const INSTALL_README_PATH = '/docs/configuration/install.md';
 	const CMD_EDIT_DOWNLOADING_SETTINGS = 'editDownloadingSettings';
 	const CMD_EDIT_WEBDAV_SETTINGS = 'editWebDAVSettings';
 	
@@ -322,6 +323,7 @@ class ilObjFileAccessSettingsGUI extends ilObjectGUI {
 	    $cb_prop = new ilCheckboxInputGUI($lng->txt("enable_webdav"), "enable_webdav");
 	    $cb_prop->setValue('1');
 	    $cb_prop->setChecked($this->object->isWebdavEnabled());
+	    $cb_prop->setInfo($this->getAdditionalWebDAVInformation());
 	    $form->addItem($cb_prop);
 	    
 	    $rgi_prop = new ilRadioGroupInputGUI($lng->txt('webfolder_instructions'), 'custom_webfolder_instructions_choice');
@@ -361,8 +363,7 @@ class ilObjFileAccessSettingsGUI extends ilObjectGUI {
 		}
 
 		$form = $this->initWebDAVSettingsForm();
-
-		$tpl->setContent($form->getHTML());
+        $tpl->setContent($form->getHTML());
 	}
 
 
@@ -373,6 +374,7 @@ class ilObjFileAccessSettingsGUI extends ilObjectGUI {
 	    global $DIC;
 		$rbacsystem = $DIC['rbacsystem'];
 		$ilErr = $DIC['ilErr'];
+        $tpl = $DIC['tpl'];
 		$ilCtrl = $DIC['ilCtrl'];
 		$lng = $DIC['lng'];
 
@@ -395,10 +397,21 @@ class ilObjFileAccessSettingsGUI extends ilObjectGUI {
 		else 
 		{
 		    $form->setValuesByPost();
-		    $tpl->setContent($form->getHTML());
-		}
-	}
+            $tpl->setContent($form->getHTML());
+        }
+    }
 
+    public function getAdditionalWebDAVInformation() {
+        global $DIC;
+        $lng = $DIC->language();
+
+        return $furtherInformation = sprintf($lng->txt('webdav_additional_information'), $this->getInstallationDocsLink());
+    }
+
+    public function getInstallationDocsLink()
+    {
+        return ilUtil::_getHttpPath() . self::INSTALL_README_PATH;
+    }
 
 	/**
 	 * called by prepare output

--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -393,9 +393,9 @@ FromLineOverride=YES
 <a name="webdav-configuration-optional"></a>
 ## WebDAV Configuration (OPTIONAL)
 
-Because of an error in the Windows Explorer, it sometimes fails to add a WebDAV connection with the error code "0x80070043 The Network Name Cannot Be Found".
+Because of a special behaviour in the Windows Explorer, it sometimes fails to add a WebDAV connection with the error code "0x80070043 The Network Name Cannot Be Found".
 
-To prevent this error, add following rewrite rules to the root of your website:
+To prevent this behaviour, add the following rewrite rules to a .htaccess file in your webroot or to the corresponding section of the configuration of your webserver:
 ```
 RewriteCond %{HTTP_USER_AGENT} ^(DavClnt)$
 RewriteCond %{REQUEST_METHOD} ^(OPTIONS)$

--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -27,6 +27,7 @@ ILIAS is a powerful Open Source Learning Management System for developing and re
       1. [MySQL Strict Mode \(5.6+\)](#mysql-strict-mode-56)
       1. [MySQL Perfomance tuning \(OPTIONAL\)](#mysql-perfomance-tuning-optional)
    1. [E-Mail Configuration \(OPTIONAL\)](#e-mail-configuration-optional)
+   1. [WebDAV Configuration \(OPTIONAL\)](#webdav-configuration-optional)
    1. [Install other Depedencies](#install-other-depedencies)
       1. [Optional Dependencies](#optional-dependencies)
    1. [Installation Wizard](#installation-wizard)
@@ -387,6 +388,18 @@ hostname=yourserver.example.com
 # YES - Allow the user to specify their own From: address
 # NO - Use the system generated From: address
 FromLineOverride=YES
+```
+
+<a name="webdav-configuration-optional"></a>
+## WebDAV Configuration (OPTIONAL)
+
+Because of an error in the Windows Explorer, it sometimes fails to add a WebDAV connection with the error code "0x80070043 The Network Name Cannot Be Found".
+
+To prevent this error, add following rewrite rules to the root of your website:
+```
+RewriteCond %{HTTP_USER_AGENT} ^(DavClnt)$
+RewriteCond %{REQUEST_METHOD} ^(OPTIONS)$
+RewriteRule .* "-" [R=401,L]
 ```
 
 <a name="install-other-depedencies"></a>

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -4381,7 +4381,7 @@ common#:#visits#:#Besuche
 common#:#web_resources#:#Weblinks
 common#:#webdav#:#WebDAV
 common#:#edit_metadata#:#Metadaten bearbeiten
-common#:#webdav_additional_information#:#Aufgrund eines Fehlers in Windows, treten beim Windows Explorer unter gewissen Umständen Probleme auf wenn er versucht eine WebDAV Verbindung hinzuzufügen. Lesen Sie mehr dazu in der Installationsanleitung <a href="%s" target="_blank">install.md</a> Kapitel: "WebDAV Configuration (OPTIONAL)"
+common#:#webdav_additional_information#:#Um sicher zu gehen, dass der Windows Explorer erfolgreich eine Verbindung über WebDAV herstellen kan, lesen in der Installationsanleitung "<a href="%s" target="_blank">install.md</a>" das Kapitel: "WebDAV Configuration (OPTIONAL)"
 common#:#webdav_pwd_instruction#:#Um das ILIAS-Magazin als Webordner außerhalb der aktuellen Sitzung als Webordner zu öffnen, empfehlen wir ein lokales Passwort anzulegen.<br />Dieses Passwort wird nur für die Webordner-Funktionalitäten benötigt, die ILIAS-Anmeldung erfolgt weiterhin mit Ihrem gewohnten Passwort.
 common#:#webdav_pwd_instruction_success#:#Ein neues lokales Passwort wurde angelegt. Sie können nun das Magazin als Webordner öffnen.
 common#:#webfolder_dir_info#:#Sie sind hierher gelangt, weil Ihr Browser keine Webordner öffnen kann. Lesen Sie die <a href="%1$s">Anleitung zum Öffnen dieses Webordners</a>.

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -4381,6 +4381,7 @@ common#:#visits#:#Besuche
 common#:#web_resources#:#Weblinks
 common#:#webdav#:#WebDAV
 common#:#edit_metadata#:#Metadaten bearbeiten
+common#:#webdav_additional_information#:#Aufgrund eines Fehlers in Windows, treten beim Windows Explorer unter gewissen Umständen Probleme auf wenn er versucht eine WebDAV Verbindung hinzuzufügen. Lesen Sie mehr dazu in der Installationsanleitung <a href="%s" target="_blank">install.md</a> Kapitel: "WebDAV Configuration (OPTIONAL)"
 common#:#webdav_pwd_instruction#:#Um das ILIAS-Magazin als Webordner außerhalb der aktuellen Sitzung als Webordner zu öffnen, empfehlen wir ein lokales Passwort anzulegen.<br />Dieses Passwort wird nur für die Webordner-Funktionalitäten benötigt, die ILIAS-Anmeldung erfolgt weiterhin mit Ihrem gewohnten Passwort.
 common#:#webdav_pwd_instruction_success#:#Ein neues lokales Passwort wurde angelegt. Sie können nun das Magazin als Webordner öffnen.
 common#:#webfolder_dir_info#:#Sie sind hierher gelangt, weil Ihr Browser keine Webordner öffnen kann. Lesen Sie die <a href="%1$s">Anleitung zum Öffnen dieses Webordners</a>.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -8272,6 +8272,7 @@ administration#:#language_remove_local_file#:#Delete the custom language file
 rbac#:#export_member_data#:#Access User Data
 rbac#:#rbac_change_existing_objects_desc_new_role#:#The permission settings of this role will be adopted to ALL existing objects.
 forum#:#frm_edit_title#:#Edit Title
+common#:#webdav_additional_information#:#Due to an error in Windows, the Windows Explorer has sometimes problems to add a new WebDAV connection. Read more in the installation instructions file <a href="%s" target="_blank">install.md</a> chapter: "WebDAV Configuration (OPTIONAL)"
 common#:#webdav_pwd_instruction#:#We suggest to create a local password for opening the repository as webfolder.<br />This password is only required for the webfolder functionality.
 common#:#webdav_pwd_instruction_success#:#A new local password has been created. You can now open the repository as webfolder.
 administration#:#language_merged_global#:#The local changes were merged into the standard language file.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -8272,7 +8272,7 @@ administration#:#language_remove_local_file#:#Delete the custom language file
 rbac#:#export_member_data#:#Access User Data
 rbac#:#rbac_change_existing_objects_desc_new_role#:#The permission settings of this role will be adopted to ALL existing objects.
 forum#:#frm_edit_title#:#Edit Title
-common#:#webdav_additional_information#:#Due to an error in Windows, the Windows Explorer has sometimes problems to add a new WebDAV connection. Read more in the installation instructions file <a href="%s" target="_blank">install.md</a> chapter: "WebDAV Configuration (OPTIONAL)"
+common#:#webdav_additional_information#:#To be sure, that the Windows Explorer can can add a WebDAV connection, read the installation instruction file <a href="%s" target="_blank">install.md</a> chapter: "WebDAV Configuration (OPTIONAL)"
 common#:#webdav_pwd_instruction#:#We suggest to create a local password for opening the repository as webfolder.<br />This password is only required for the webfolder functionality.
 common#:#webdav_pwd_instruction_success#:#A new local password has been created. You can now open the repository as webfolder.
 administration#:#language_merged_global#:#The local changes were merged into the standard language file.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -8272,7 +8272,7 @@ administration#:#language_remove_local_file#:#Delete the custom language file
 rbac#:#export_member_data#:#Access User Data
 rbac#:#rbac_change_existing_objects_desc_new_role#:#The permission settings of this role will be adopted to ALL existing objects.
 forum#:#frm_edit_title#:#Edit Title
-common#:#webdav_additional_information#:#To be sure, that the Windows Explorer can can add a WebDAV connection, read the installation instruction file <a href="%s" target="_blank">install.md</a> chapter: "WebDAV Configuration (OPTIONAL)"
+common#:#webdav_additional_information#:#To be sure, that Windows Explorer can add a WebDAV connection, read the installation instruction file <a href="%s" target="_blank">install.md</a> chapter: "WebDAV Configuration (OPTIONAL)"
 common#:#webdav_pwd_instruction#:#We suggest to create a local password for opening the repository as webfolder.<br />This password is only required for the webfolder functionality.
 common#:#webdav_pwd_instruction_success#:#A new local password has been created. You can now open the repository as webfolder.
 administration#:#language_merged_global#:#The local changes were merged into the standard language file.


### PR DESCRIPTION
As discussed at JF on 25. FEB 2019, I added a short WebDAV instruction for the exotic beaviour of Windows Explorer to the `install.md`-file.

The text with the link is added as "info" by the "Activate WebDAV"-Checkbox.

If this PR is ok for you, I will also add the same text in release 5.3 and 5.2.