### PR TITLE
WebDAV: Added rewrite rule to .htaccess to prevent problems with windows clients

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -9,6 +9,9 @@
 	RewriteRule ^goto_(.*)_([a-z]+_[0-9]+(.*)).html$ goto.php?client_id=$1&target=$2&lang=%1 [L]
 	RewriteRule ^goto_(.*)_([a-z]+_[0-9]+(.*)).html$ goto.php?client_id=$1&target=$2 [L]
 	RewriteRule ^data/.*/.*/.*$ ./Services/WebAccessChecker/wac.php [L]
+	RewriteCond %{HTTP_USER_AGENT} ^(DavClnt)$
+	RewriteCond %{REQUEST_METHOD} ^(OPTIONS)$
+	RewriteRule .* "-" [R=401,L]
 
 	RedirectMatch 404 /\.git
 </IfModule>


### PR DESCRIPTION
I added the rewrite rules for WebDAV, which are since PR #1677 in the install.md, directly to the .htaccess. If ILIAS is in the webroot, this prevents the problem without the interaction of an admin.