### PR TITLE
Fix ilDBGenerator output script (use of globals accidentially removed)

### DIFF
--- a/Services/Database/classes/class.ilDBGenerator.php
+++ b/Services/Database/classes/class.ilDBGenerator.php
@@ -238,11 +238,9 @@ class ilDBGenerator {
 
 
 	protected function openFile($a_path) {
-		global $DIC;
-		$ilDB = $DIC->database();
 		if (1) {
 			$file = fopen($a_path, "w");
-			$start .= "\t" . $ilDB . "\n\n";
+			$start .= "\t" . 'global $ilDB;' . "\n\n";
 			fwrite($file, $start);
 
 			return $file;
@@ -250,7 +248,7 @@ class ilDBGenerator {
 
 		$file = fopen($a_path, "w");
 		$start = '<?php' . "\n" . 'function setupILIASDatabase()' . "\n{\n";
-		$start .= "\t" . $ilDB . "\n\n";
+		$start .= "\t" . 'global $ilDB;' . "\n\n";
 		fwrite($file, $start);
 
 		return $file;
@@ -290,9 +288,7 @@ class ilDBGenerator {
 			$file = fopen($a_filename, "w");
 
 			$start = '<?php' . "\n" . 'function setupILIASDatabase()' . "\n{\n";
-			global $DIC;
-			$ilDB = $DIC->database();
-			$start .= "\t" . $ilDB . "\n\n";
+			$start .= "\t" . 'global $ilDB;' . "\n\n";
 			fwrite($file, $start);
 		} elseif ($isDirectory) {
 			;


### PR DESCRIPTION
The use of the string 'global $ilDB;' got accidentially removed in 843aee99725. This commit reverts these changes.