### PR TITLE
#25166 - Setup: fixed odd missing database error

### DIFF
--- a/setup/classes/class.ilClient.php
+++ b/setup/classes/class.ilClient.php
@@ -34,6 +34,11 @@ class ilClient
 	 */
 	public $ini;
 
+	/**
+	 * @var ilDbSetup|null
+	 */
+	protected $db_setup = null;
+
 
 	/**
 	 * ilClient constructor.
@@ -63,11 +68,15 @@ class ilClient
 	public function getDBSetup($cached = true) {
 		require_once('./setup/classes/class.ilDbSetup.php');
 
-		if (!$cached) {
-			return \ilDbSetup::getNewInstanceForClient($this);
+		if ($cached) {
+			if (is_null($this->db_setup)) {
+				$this->db_setup = \ilDbSetup::getNewInstanceForClient($this);
+			}
+			return $this->db_setup;
 		}
 
-		return ilDbSetup::getInstanceForClient($this);
+
+		return \ilDbSetup::getNewInstanceForClient($this);
 	}
 
 	/**


### PR DESCRIPTION
The reason for this problem is some very chaotic handling of new instances of ilClient, caching in ilDbSetup and initialisation and distribution of database instances. ilClient::getDbSetup uses static methods from ilDbSetup that cache instances via client_id. The DBSetup instance is tied to the ilClient it was created for. ilSetup produces two instances of ilClient, one for querying the status and one for actual actions on the client. The second instance is the one that is used to attempt login. Since ilDbSetup doesn't take into account that two instances for the same client might have been created, it returns a cached instance for the client id. This in fact is bound to the first ilClient instance and sets the db on that one (in provideGlobalDB) instead of setting the db on the second ilClient-instance which is the one that is in fact used afterwards.

The problem at hand was solved by moving the caching of ilDbSetup instances to the ilClient. The root-cause was not solved here and the setup remains in its generally messy state for now.