### PR TITLE
TinyMCE/SOAP: Fixed #25243 / Use of undefined constant (PHP 7.2)

### DIFF
--- a/webservice/soap/classes/class.ilSoapAdministration.php
+++ b/webservice/soap/classes/class.ilSoapAdministration.php
@@ -66,15 +66,15 @@ class ilSoapAdministration
 		define('NUSOAP',1);
 		define('PHP5',2);
 
-		if(IL_SOAPMODE == IL_SOAPMODE_NUSOAP)
-		{
+		if (
+			defined('IL_SOAPMODE') && defined('IL_SOAPMODE_NUSOAP') &&
+			IL_SOAPMODE == IL_SOAPMODE_NUSOAP
+		) {
 			$this->error_method = NUSOAP;
-		} 
-		else
-		{ 
+		} else { 
 			$this->error_method = PHP5;
 		}
-		#echo ("SOAP: using soap mode ".IL_SOAPMODE == IL_SOAPMODE_NUSOAP ? "NUSOAP": "PHP5");
+
 		$this->__initAuthenticationObject();
 	}
 


### PR DESCRIPTION
Mantis Ticket: https://mantis.ilias.de/view.php?id=25243