### PR TITLE
[fix-25247] initial values for lucene_prefix_wildcard & lucene_sub_relevance

### DIFF
--- a/setup/sql/ilDBTemplate.php
+++ b/setup/sql/ilDBTemplate.php
@@ -50482,13 +50482,13 @@ $ilDB->insert("settings", array(
 'module' => array('text', 'common'), 'keyword' => array('text', 'lucene_offline_filter'), 'value' => array('clob', '0')));
 
 $ilDB->insert("settings", array(
-'module' => array('text', 'common'), 'keyword' => array('text', 'lucene_prefix_wildcard'), 'value' => array('clob', '')));
+'module' => array('text', 'common'), 'keyword' => array('text', 'lucene_prefix_wildcard'), 'value' => array('clob', '0')));
 
 $ilDB->insert("settings", array(
 'module' => array('text', 'common'), 'keyword' => array('text', 'lucene_show_relevance'), 'value' => array('clob', '1')));
 
 $ilDB->insert("settings", array(
-'module' => array('text', 'common'), 'keyword' => array('text', 'lucene_sub_relevance'), 'value' => array('clob', '')));
+'module' => array('text', 'common'), 'keyword' => array('text', 'lucene_sub_relevance'), 'value' => array('clob', '0')));
 
 $ilDB->insert("settings", array(
 'module' => array('text', 'common'), 'keyword' => array('text', 'lucene_user_search'), 'value' => array('clob', '1')));


### PR DESCRIPTION
This PR provides initial values for entries
- lucene_prefix_wildcard    and
- lucene_sub_relevance
in table [settings].

See mantis: https://mantis.ilias.de/view.php?id=25247