### PR TITLE
fixed 24950: Error when create portfolios

### DIFF
--- a/Services/MainMenu/classes/class.ilMainMenuGUI.php
+++ b/Services/MainMenu/classes/class.ilMainMenuGUI.php
@@ -611,7 +611,7 @@ class ilMainMenuGUI {
 	 * @param \ilTemplate $mainTpl
 	 * @param \ilLanguage $lng
 	 */
-	private function renderOnScreenNotifications(\ilObjUser $user, \ilGlobalTemplate $mainTpl, \ilLanguage $lng) {
+	private function renderOnScreenNotifications(\ilObjUser $user, $mainTpl, \ilLanguage $lng) {
 		if ($this->getMode() != self::MODE_TOPBAR_REDUCED && !$user->isAnonymous()) {
 			$this->tpl->touchBlock('osd_container');
 

--- a/Services/Notifications/classes/class.ilNotificationOSDGUI.php
+++ b/Services/Notifications/classes/class.ilNotificationOSDGUI.php
@@ -26,7 +26,7 @@ class ilNotificationOSDGUI
 	 * @param \ilGlobalTemplate $mainTemplate
 	 * @param \ilLanguage $lng
 	 */
-	public function __construct(\ilObjUser $user, \ilGlobalTemplate $mainTemplate, \ilLanguage $lng)
+	public function __construct(\ilObjUser $user, $mainTemplate, \ilLanguage $lng)
 	{
 		$this->user         = $user;
 		$this->mainTemplate = $mainTemplate;

--- a/Services/User/Actions/classes/class.ilUserActionGUI.php
+++ b/Services/User/Actions/classes/class.ilUserActionGUI.php
@@ -38,7 +38,7 @@ class ilUserActionGUI
 	 * @param ilTemplate $a_global_tpl
 	 * @param int $a_current_user_id
 	 */
-	protected function __construct(ilUserActionContext $a_user_action_context, ilGlobalTemplate $a_global_tpl,
+	protected function __construct(ilUserActionContext $a_user_action_context, $a_global_tpl,
 		$a_current_user_id)
 	{
 		$this->tpl = $a_global_tpl;
@@ -54,7 +54,7 @@ class ilUserActionGUI
 	 * @param int $a_current_user_id
 	 * @return ilUserActionGUI
 	 */
-	static function getInstance(ilUserActionContext $a_user_action_context, ilGlobalTemplate $a_global_tpl, $a_current_user_id)
+	static function getInstance(ilUserActionContext $a_user_action_context, $a_global_tpl, $a_current_user_id)
 	{
 		return new ilUserActionGUI($a_user_action_context, $a_global_tpl, $a_current_user_id);
 	}

--- a/Services/YUI/classes/class.ilYuiUtil.php
+++ b/Services/YUI/classes/class.ilYuiUtil.php
@@ -14,8 +14,11 @@ class ilYuiUtil {
 
 	/**
 	 * Init YUI Connection module
+	 * ilGlobalTemplate type hint is removed here, since currently (Apr 2019)
+	 * other global templates (e.g. ilPortfolioGlobalTemplate) are being passed
+	 * (see ilInitialisation initHTML()).
 	 */
-	static function initConnection(ilGlobalTemplate $a_main_tpl = null) {
+	static function initConnection($a_main_tpl = null) {
 		global $DIC;
 
 		if ($a_main_tpl == null)
@@ -159,8 +162,12 @@ class ilYuiUtil {
 
 	/**
 	 * Init YUI Overlay module
+	 *
+	 * ilGlobalTemplate type hint is removed here, since currently (Apr 2019)
+	 * other global templates (e.g. ilPortfolioGlobalTemplate) are being passed
+	 * (see ilInitialisation initHTML()).
 	 */
-	static function initOverlay(ilGlobalTemplate $a_main_tpl = null) {
+	static function initOverlay($a_main_tpl = null) {
 		global $DIC;
 
 		if ($a_main_tpl == null)
@@ -507,8 +514,11 @@ class ilYuiUtil {
 
 	/**
 	 * Add container css
+	 * ilGlobalTemplate type hint is removed here, since currently (Apr 2019)
+	 * other global templates (e.g. ilPortfolioGlobalTemplate) are being passed
+	 * (see ilInitialisation initHTML()).
 	 */
-	protected static function addContainerCss(ilGlobalTemplate $a_main_tpl = null) {
+	protected static function addContainerCss($a_main_tpl = null) {
 		global $DIC;
 
 		if ($a_main_tpl == null)

--- a/src/UI/Implementation/Render/ilJavaScriptBinding.php
+++ b/src/UI/Implementation/Render/ilJavaScriptBinding.php
@@ -22,7 +22,14 @@ class ilJavaScriptBinding implements JavaScriptBinding {
 	 */
 	protected $code = array();
 
-	public function __construct(\ilGlobalTemplate $global_tpl) {
+	/**
+	 * ilJavaScriptBinding constructor.
+	 * ilGlobalTemplate type hint is removed here, since currently (Apr 2019)
+	 * other global templates (e.g. ilPortfolioGlobalTemplate) are being passed
+	 * (see ilInitialisation initHTML()).
+	 * @param $il_template
+	 */
+	public function __construct($global_tpl) {
 		$this->global_tpl = $global_tpl;
 	}
 

--- a/src/UI/Implementation/Render/ilResourceRegistry.php
+++ b/src/UI/Implementation/Render/ilResourceRegistry.php
@@ -14,7 +14,14 @@ class ilResourceRegistry implements ResourceRegistry {
 	 */
 	protected $il_template;
 
-	public function __construct(\ilGlobalTemplate $il_template) {
+	/**
+	 * ilResourceRegistry constructor.
+ 	 * ilGlobalTemplate type hint is removed here, since currently (Apr 2019)
+	 * other global templates (e.g. ilPortfolioGlobalTemplate) are being passed
+	 * (see ilInitialisation initHTML()).
+	 * @param $il_template
+	 */
+	public function __construct($il_template) {
 		$this->il_template = $il_template;
 	}
 

--- a/src/UI/Implementation/Render/ilTemplateWrapper.php
+++ b/src/UI/Implementation/Render/ilTemplateWrapper.php
@@ -18,7 +18,14 @@ class ilTemplateWrapper implements Template {
 	 */
 	private $tpl;
 
-	final public function __construct(\ilGlobalTemplate $global_tpl, \ilTemplate $tpl) {
+	/**
+	 * ilTemplateWrapper constructor.
+	 * ilGlobalTemplate type hint is removed here, since currently (Apr 2019)
+	 * other global templates (e.g. ilPortfolioGlobalTemplate) are being passed
+	 * (see ilInitialisation initHTML()).
+	 * @param $il_template
+	 */
+	final public function __construct($global_tpl, \ilTemplate $tpl) {
 		$this->global_tpl = $global_tpl;
 		$this->tpl = $tpl;
 	}

--- a/src/UI/Implementation/Render/ilTemplateWrapperFactory.php
+++ b/src/UI/Implementation/Render/ilTemplateWrapperFactory.php
@@ -13,7 +13,14 @@ class ilTemplateWrapperFactory implements TemplateFactory {
 	 */
 	protected $global_tpl;
 
-	public function __construct(\ilGlobalTemplate $global_tpl) {
+	/**
+	 * ilTemplateWrapperFactory constructor.
+	 * ilGlobalTemplate type hint is removed here, since currently (Apr 2019)
+	 * other global templates (e.g. ilPortfolioGlobalTemplate) are being passed
+	 * (see ilInitialisation initHTML()).
+	 * @param $il_template
+	 */
+	public function __construct($global_tpl) {
 		$this->global_tpl = $global_tpl;
 	}
 


### PR DESCRIPTION
Bug: https://mantis.ilias.de/view.php?id=24950

This is due to the global template refactoring.

ilInitialisation::initHTML() creates different kind of global templates now, but several common functions do only accept ilGlobalTemplate.

If I remember correctly one option was to remove these type hints until we found a way to get rid of the several ilGlobalTemplate derivates.

Is this ok?