### PR TITLE
Notes (in container lists): Fixed usage of undefined constants (PHP 7.2)

### DIFF
--- a/Services/Object/classes/class.ilObjectListGUI.php
+++ b/Services/Object/classes/class.ilObjectListGUI.php
@@ -1807,6 +1807,7 @@ class ilObjectListGUI
 		$redraw_js = "il.Object.redrawListItem(".$note_ref_id.");";
 		
 		// add common properties (comments, notes, tags)
+		require_once 'Services/Notes/classes/class.ilNote.php';
 		if ((self::$cnt_notes[$note_obj_id][IL_NOTE_PRIVATE] > 0 ||
 			self::$cnt_notes[$note_obj_id][IL_NOTE_PUBLIC] > 0 || 
 			self::$cnt_tags[$note_obj_id] > 0 ||


### PR DESCRIPTION
Mantis Ticket: https://mantis.ilias.de/view.php?id=25251