### PR TITLE
File System GUI: Fixed rendering of checkbox for '..' entries

### DIFF
--- a/Services/FileSystem/classes/class.ilFileSystemTableGUI.php
+++ b/Services/FileSystem/classes/class.ilFileSystemTableGUI.php
@@ -156,6 +156,14 @@ class ilFileSystemTableGUI extends ilTable2GUI
 		}
 	}
 
+	/**
+	 * @param array $entry
+	 * @return bool
+	 */
+	private function isDoubleDotDirectory(array $entry)
+	{
+		return $entry['entry'] === '..';
+	}
 
 	/**
 	* Fill table row
@@ -169,9 +177,12 @@ class ilFileSystemTableGUI extends ilTable2GUI
 			? md5($a_set["file"])
 			: md5($a_set["entry"]);
 
-		if($this->has_multi)
-		{			
-			$this->tpl->setVariable("CHECKBOX_ID", $hash);
+		if ($this->has_multi) {
+			if ($this->isDoubleDotDirectory($a_set)) {
+				$this->tpl->touchBlock('no_checkbox');
+			} else {
+				$this->tpl->setVariable("CHECKBOX_ID", $hash);
+			}
 		}
 
 		// label

--- a/Services/FileSystem/templates/default/tpl.directory_row.html
+++ b/Services/FileSystem/templates/default/tpl.directory_row.html
@@ -2,6 +2,7 @@
 	<!-- BEGIN select_bl -->
 	<td class="std" valign="top">
 		<!-- BEGIN checkbox --><input type="checkbox" name="file[{CHECKBOX_ORDER_ID}]" value="{CHECKBOX_ID}" {CHECKED}/><!-- END checkbox -->
+		<!-- BEGIN no_checkbox -->&nbsp;<!-- END no_checkbox -->
 	</td>
 	<!-- END select_bl -->
 	<!-- BEGIN Order -->


### PR DESCRIPTION
This PR fixes an issue with double dot directories (`..`) listed in the table rendered by `ilFileSystemGUI`. Selecting a `..` directory and executing a `multi command` (e.g. `Delete`) does not have any effect for this type of record, so the checkbox should not be rendered.

Mantis Issue: https://mantis.ilias.de/view.php?id=25274