### PR TITLE
Didactic Templates: Fixed returning 'void' explicitly (PHP 7.2)

### DIFF
--- a/Services/DidacticTemplate/classes/class.ilDidacticTemplateFilterPattern.php
+++ b/Services/DidacticTemplate/classes/class.ilDidacticTemplateFilterPattern.php
@@ -247,7 +247,6 @@ abstract class ilDidacticTemplateFilterPattern
 			$this->setPatternSubType($row->pattern_sub_type);
 			$this->setPattern($row->pattern);
 		}
-		return void;
 	}
 }
 ?>


### PR DESCRIPTION
Mantis Issue: https://mantis.ilias.de/view.php?id=25286