### PR TITLE
[Certificate] Fix diappearing certificate button in tests if test results were deleted

### DIFF
--- a/Modules/Test/classes/class.ilTestResultsGUI.php
+++ b/Modules/Test/classes/class.ilTestResultsGUI.php
@@ -316,11 +316,9 @@ class ilTestResultsGUI
 		$toolbar = $DIC->toolbar();
 		$validator = new ilCertificateDownloadValidator();
 		if($validator->isCertificateDownloadable($DIC->user()->getId(), $this->getTestObj()->getId())) {
-			$toolbar->setFormAction($DIC->ctrl()->getFormActionByClass(ilTestEvaluationGUI::class, 'outCertificate'));
-
-			$button = ilSubmitButton::getInstance();
+			$button = ilLinkButton::getInstance();
 			$button->setCaption('certificate');
-			$button->setCommand('outCertificate');
+			$button->setUrl($DIC->ctrl()->getFormActionByClass(ilTestEvaluationGUI::class, 'outCertificate'));
 			$toolbar->addButtonInstance($button);
 		}
 

--- a/Modules/Test/classes/class.ilTestResultsGUI.php
+++ b/Modules/Test/classes/class.ilTestResultsGUI.php
@@ -312,8 +312,20 @@ class ilTestResultsGUI
 
 			$DIC->ctrl()->redirectByClass(array('ilMyTestResultsGUI', 'ilTestEvaluationGUI'));
 		}
-		
+
+		$toolbar = $DIC->toolbar();
+		$validator = new ilCertificateDownloadValidator();
+		if($validator->isCertificateDownloadable($DIC->user()->getId(), $this->getTestObj()->getId())) {
+			$toolbar->setFormAction($DIC->ctrl()->getFormActionByClass(ilTestEvaluationGUI::class, 'outCertificate'));
+
+			$button = ilSubmitButton::getInstance();
+			$button->setCaption('certificate');
+			$button->setCommand('outCertificate');
+			$toolbar->addButtonInstance($button);
+		}
+
 		$this->showNoResultsReportingMessage();
+
 	}
 	
 	protected function showNoResultsReportingMessage()


### PR DESCRIPTION
Mantis: https://mantis.ilias.de/view.php?id=25287

SCORM and exercises seems ok, the download is still available even if the data is reset.