### PR TITLE
[Certificate] SCORM certificate template GUI throws exception because an undefined variables is used in the constructor

### DIFF
--- a/Services/Certificate/classes/Form/Repository/class.ilCertificateSettingsScormFormRepository.php
+++ b/Services/Certificate/classes/Form/Repository/class.ilCertificateSettingsScormFormRepository.php
@@ -57,7 +57,6 @@ class ilCertificateSettingsScormFormRepository implements ilCertificateFormRepos
 				$object->getId(),
 				$certificatePath,
 				$language,
-				$template,
 				$controller,
 				$access,
 				$toolbar,


### PR DESCRIPTION
This is only relevant for the current trunk, `release-5-4` has slightly different structure.