### PR TITLE
#25042, #25037: radio collects, but does not show errors of dependant fields.

### DIFF
--- a/Services/MainMenu/classes/TypeHandler/class.ilMMTypeHandlerRepositoryLink.php
+++ b/Services/MainMenu/classes/TypeHandler/class.ilMMTypeHandlerRepositoryLink.php
@@ -52,7 +52,7 @@ class ilMMTypeHandlerRepositoryLink extends ilMMAbstractBaseTypeHandlerAction im
 	 */
 	public function getAdditionalFieldsForSubForm(IdentificationInterface $identification): array {
 		global $DIC;
-		$url = $DIC->ui()->factory()->input()->field()->numeric($this->getFieldTranslation());
+		$url = $DIC->ui()->factory()->input()->field()->numeric($this->getFieldTranslation())->withRequired(true);
 		if (isset($this->links[$identification->serialize()][self::F_ACTION]) && is_numeric($this->links[$identification->serialize()][self::F_ACTION])) {
 			$url = $url->withValue((int)$this->links[$identification->serialize()][self::F_ACTION]);
 		}

--- a/src/UI/Implementation/Component/Input/Field/Radio.php
+++ b/src/UI/Implementation/Component/Input/Field/Radio.php
@@ -18,6 +18,8 @@ class Radio extends Input implements C\Input\Field\Radio, C\JavaScriptBindable{
 	use JavaScriptBindable;
 	use Triggerer;
 
+	const DEPENDANT_FIELD_ERROR = 'ilradio_dependant_field_error';
+
 	/**
 	 * @var array <string,string> {$value => $label}
 	 */
@@ -136,6 +138,8 @@ class Radio extends Input implements C\Input\Field\Radio, C\JavaScriptBindable{
 
 				if ($content->isOk()) {
 					$values['group_values'][$name] = $content->value();
+				} else {
+					$clone = $clone->withError(self::DEPENDANT_FIELD_ERROR);
 				}
 
 				$clone->dependant_fields[$value][$name] = $filled;

--- a/src/UI/Implementation/Component/Input/Field/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Field/Renderer.php
@@ -526,7 +526,7 @@ class Renderer extends AbstractComponentRenderer {
 		if ($input->isRequired()) {
 			$tpl->touchBlock("required");
 		}
-		if ($input->getError() !== null) {
+		if ($input->getError() !== null && $input->getError() != $input::DEPENDANT_FIELD_ERROR) {
 			$tpl->setCurrentBlock("error");
 			$tpl->setVariable("ERROR", $input->getError());
 			$tpl->parseCurrentBlock();


### PR DESCRIPTION
A radio in put with dependant fields should alert errors, but only once. The fields themselves display error messages, so the radio should not. However, it is important that the radio as the main input does not return an OK-value if there are dependant errors.
If anyone comes up with a better solution, I'm more than happy.
