### PR TITLE
Bugfix for ilDateTime constructor don't work with IL_CAL_ISO_8601

### DIFF
--- a/Services/Calendar/classes/class.ilDateTime.php
+++ b/Services/Calendar/classes/class.ilDateTime.php
@@ -502,7 +502,7 @@ class ilDateTime
 				$this->dt_obj = DateTime::createFromFormat(
 					DateTime::ISO8601,
 					$a_date,
-					$this->getTimeZoneIdentifier()
+					new DateTimeZone($this->getTimeZoneIdentifier())
 					);
 				break;
 	 	}


### PR DESCRIPTION
fixed `DateTime::createFromFormat` parameter 3 must be a `DateTimeZone`, but string was given.