### PR TITLE
fixed number fomat for cell values in ilExcel (mantis 25340)

### DIFF
--- a/Services/Excel/classes/class.ilExcel.php
+++ b/Services/Excel/classes/class.ilExcel.php
@@ -250,6 +250,15 @@ class ilExcel
 			);
 			$this->setDateFormat($cell, $a_value);
 		}
+		elseif(is_numeric($a_value))
+		{
+			$this->workbook->getActiveSheet()->setCellValueExplicit(
+				$a_coords,
+				$this->prepareValue($a_value),
+				PHPExcel_Cell_DataType::TYPE_NUMERIC,
+				false
+			);
+		}
 		else
 		{
 			$this->workbook->getActiveSheet()->setCellValueExplicit(
@@ -280,6 +289,16 @@ class ilExcel
 				true
 			);
 			$this->setDateFormat($cell, $a_value);
+		}
+		elseif(is_numeric($a_value))
+		{
+			$this->workbook->getActiveSheet()->setCellValueExplicitByColumnAndRow(
+				$a_col,
+				$a_row,
+				$this->prepareValue($a_value),
+				PHPExcel_Cell_DataType::TYPE_NUMERIC,
+				false
+			);
 		}
 		else
 		{


### PR DESCRIPTION
This PR adds a detection for numeric values that causes values to be set by ilExcel::setCell and ilExcel::setCellValueByCoordinates NUMBER_FORMAT datatype.

The default datatype STRING_FORMAT that is used without this improvement, causes two problems otherwise:

integer values gets an aposthroph sign added in front, that tells Excel to handle it as text value
float values are stored with the decimal point BUT as text, so Excel wont present this value with a comma sign in german Excel Software
this PR fixes Mantis 25340: https://mantis.ilias.de/view.php?id=25340