### PR TITLE
[Fix 25368] Fix copy ilobjects

### DIFF
--- a/Services/Object/classes/class.ilObjectCopyGUI.php
+++ b/Services/Object/classes/class.ilObjectCopyGUI.php
@@ -601,7 +601,7 @@ class ilObjectCopyGUI
 				}
 			}
 		}
-		if(is_array($this->getSource()) && count($this->getSource()) == 1 && $objDefinition->isContainer($this->getType()))
+		if(is_array($this->getSources()) && count($this->getSources()) == 1 && $objDefinition->isContainer($this->getType()))
 		{
 			// check, if object should be copied into itself
 			// begin-patch mc


### PR DESCRIPTION
Fix for this bug report -> https://mantis.ilias.de/view.php?id=25368
Can't copy repository objects.
