### PR TITLE
UI Signal as a title action for Cards

### DIFF
--- a/src/UI/Component/Card/Card.php
+++ b/src/UI/Component/Card/Card.php
@@ -5,12 +5,15 @@
 namespace ILIAS\UI\Component\Card;
 
 use ILIAS\UI\Component\Component;
+use ILIAS\UI\Component\JavaScriptBindable;
+use ILIAS\UI\Component\Clickable;
+use ILIAS\UI\Component\Signal;
 
 /**
  * Interface Card
  * @package ILIAS\UI\Component\Card
  */
-interface Card extends Component {
+interface Card extends Component, JavaScriptBindable, Clickable {
 
 	/**
 	 * Sets the title in the heading section of the card
@@ -27,14 +30,14 @@ interface Card extends Component {
 
 	/**
 	 * Get a Card like this with a title action
-	 * @param string $url
+	 * @param string|Signal[] $action
 	 * @return Standard
 	 */
-	public function withTitleAction($url);
+	public function withTitleAction($action);
 
 	/**
 	 * Returns the title action if given, otherwise null
-	 * @return string|null
+	 * @return string|Signal[]|null
 	 */
 	public function getTitleAction();
 

--- a/src/UI/Implementation/Component/Card/Card.php
+++ b/src/UI/Implementation/Component/Card/Card.php
@@ -6,9 +6,14 @@ namespace ILIAS\UI\Implementation\Component\Card;
 
 use ILIAS\UI\Component\Card as C;
 use ILIAS\UI\Implementation\Component\ComponentHelper;
+use ILIAS\UI\Component\Signal;
+use ILIAS\UI\Implementation\Component\JavaScriptBindable;
+use ILIAS\UI\Implementation\Component\Triggerer;
 
 class Card implements C\Card {
 	use ComponentHelper;
+	use JavaScriptBindable;
+	use Triggerer;
 
 	/**
 	 * @var string
@@ -31,9 +36,9 @@ class Card implements C\Card {
 	protected $image;
 
 	/**
-	 * @var string
+	 * @var string|Signal[]
 	 */
-	protected $title_url = '';
+	protected $title_action = '';
 
 	/**
 	 * @var boolean
@@ -108,11 +113,17 @@ class Card implements C\Card {
 	/**
 	 * @inheritdoc
 	 */
-	public function withTitleAction($url) {
-		$this->checkStringArg("title_url", $url);
+	public function withTitleAction($action) {
+		$this->checkStringOrSignalArg("title_action", $action);
 
 		$clone = clone $this;
-		$clone->title_url = $url;
+		if (is_string($action)) {
+			$clone->title_action = $action;
+		}
+		else {
+			$clone->title_action = null;
+			$clone->setTriggeredSignal($action, "click");
+		}
 
 		return $clone;
 	}
@@ -121,7 +132,10 @@ class Card implements C\Card {
 	 * @inheritdoc
 	 */
 	public function getTitleAction() {
-		return $this->title_url;
+		if ($this->title_action !== null) {
+			return $this->title_action;
+		}
+		return $this->getTriggeredSignalsFor("click");
 	}
 
 	/**
@@ -139,5 +153,18 @@ class Card implements C\Card {
 	 */
 	public function isHighlighted() {
 		return $this->highlight;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function withOnClick(Signal $signal) {
+		return $this->withTriggeredSignal($signal, 'click');
+	}
+	/**
+	 * @inheritdoc
+	 */
+	public function appendOnClick(Signal $signal) {
+		return $this->appendTriggeredSignal($signal, 'click');
 	}
 }

--- a/src/UI/Implementation/Component/Card/Renderer.php
+++ b/src/UI/Implementation/Component/Card/Renderer.php
@@ -31,15 +31,23 @@ class Renderer extends AbstractComponentRenderer {
 			$tpl->touchBlock("no_highlight");
 		}
 
-		if($component->getTitleAction()) {
-			$tpl->setCurrentBlock("title_action_begin");
-			$tpl->setVariable("HREF",$component->getTitleAction());
-			$tpl->parseCurrentBlock();
+		$id = $this->bindJavaScript($component);
+		if (!empty($component->getTitleAction())) {
+			if (is_string($component->getTitleAction())) {
+				$tpl->setCurrentBlock("title_action_begin");
+				$tpl->setVariable("HREF", $component->getTitleAction());
+				$tpl->parseCurrentBlock();
+			}
+			if (is_array($component->getTitleAction())) {
+				$tpl->setCurrentBlock("title_action_begin");
+				$tpl->setVariable("ID", $id);
+				$tpl->parseCurrentBlock();
+			}
 		}
 
 		$tpl->setVariable("TITLE",$component->getTitle());
 
-		if($component->getTitleAction()) {
+		if(!empty($component->getTitleAction())) {
 			$tpl->touchBlock("title_action_end");
 		}
 

--- a/src/UI/templates/default/Card/tpl.card.html
+++ b/src/UI/templates/default/Card/tpl.card.html
@@ -18,7 +18,7 @@
 	<!-- BEGIN highlight --><div class="card-highlight"></div><!-- END highlight -->
 	<!-- BEGIN no_highlight --><div class="card-no-highlight"></div><!-- END no_highlight -->
 	<div class="caption">
-		<h5 class="card-title"><!-- BEGIN title_action_begin --><a href="{HREF}"><!-- END title_action_begin -->{TITLE}<!-- BEGIN title_action_end --></a><!-- END title_action_end --></h5>
+		<h5 class="card-title"><!-- BEGIN title_action_begin --><a href="{HREF}" id="{ID}"><!-- END title_action_begin -->{TITLE}<!-- BEGIN title_action_end --></a><!-- END title_action_end --></h5>
 	</div>
 	<!-- BEGIN section -->
 	<div class="caption">{SECTION}</div>

--- a/tests/UI/Component/Card/CardTest.php
+++ b/tests/UI/Component/Card/CardTest.php
@@ -73,10 +73,17 @@ class CardTest extends ILIAS_UI_TestBase {
 		$this->assertEquals($c->getTitle(), "Card Title New");
 	}
 
-	public function test_with_title_action() {
+	public function test_with_string_title_action() {
 		$c = $this->getBaseCard();
 		$c = $c->withTitleAction("newAction");
 		$this->assertEquals("newAction", $c->getTitleAction());
+	}
+
+	public function test_with_signal_title_action() {
+		$c = $this->getBaseCard();
+		$signal = $this->createMock(C\Signal::class);
+		$c = $c->withTitleAction($signal);
+		$this->assertEquals([$signal], $c->getTitleAction());
 	}
 
 	public function test_with_highlight() {


### PR DESCRIPTION
Currently, a title action in a Card can only be a string. Signals should be possible, too.
This is very useful when the Image in the Card gets an action, which should be the same like in the title of the Card. Images already accept a string or a signal as an action.