### PR TITLE
Fix for Mantis 25381

### DIFF
--- a/Services/RTE/classes/class.ilTinyMCE.php
+++ b/Services/RTE/classes/class.ilTinyMCE.php
@@ -314,7 +314,6 @@ class ilTinyMCE extends ilRTE
 		$template = new ilTemplate("tpl.usereditor.html", true, true, "Services/RTE");
 		$this->handleImgContextMenuItem($template);
 		$template->setCurrentBlock("tinymce");
-		$template->setVariable("JAVASCRIPT_LOCATION", "./Services/RTE/tiny_mce".$this->vd."/tiny_mce.js");
 		include_once "./Services/Object/classes/class.ilObject.php";
 		$template->setVariable("SELECTOR", $editor_selector);
 		$template->setVariable("BLOCKFORMATS", "");
@@ -329,9 +328,9 @@ class ilTinyMCE extends ilRTE
 		$template->setVariable("STYLESHEET_LOCATION", ilUtil::getNewContentStyleSheetLocation() . "," . ilUtil::getStyleSheetLocation("output", "delos.css"));
 		$template->setVariable("LANG", $this->_getEditorLanguage());
 		$template->parseCurrentBlock();
-		$this->tpl->setCurrentBlock("HeadContent");
-		$this->tpl->setVariable("CONTENT_BLOCK", $template->get());
-		$this->tpl->parseCurrentBlock();
+		
+		$this->tpl->addJavaScript("./Services/RTE/tiny_mce".$this->vd."/tiny_mce.js");
+		$this->tpl->addOnLoadCode($template->get());
 	}
 
 	/**

--- a/Services/RTE/templates/default/tpl.usereditor.html
+++ b/Services/RTE/templates/default/tpl.usereditor.html
@@ -1,7 +1,4 @@
 <!-- BEGIN tinymce -->
-<script language="javascript" type="text/javascript" src="{JAVASCRIPT_LOCATION}"></script>
-<script language="javascript" type="text/javascript">
-
 	function ilTinyMceInitCallback(ed) {
 		// Add hook for onContextMenu so that Insert Image can be removed
 		<!-- BEGIN remove_img_context_menu_item -->
@@ -62,6 +59,5 @@
 			ed.onInit.add(ilTinyMceInitCallback);
 		}
 	});
-</script>
 <!-- END tinymce -->
 


### PR DESCRIPTION
TinyMCE must not longer add itself as a script block within the html HEAD, but is to be added as onLoadCode instead, since ilGlobalPageTemplate do not offer this tpl block any longer.

Tiny lib file is to be added as a Javascript File to ilGlobalPageTemplate

https://mantis.ilias.de/view.php?id=25381