### PR TITLE
[Refinery] Fix usages of integer constraints in unit tests + consumer code

### DIFF
--- a/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeSettingsGUI.php
+++ b/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeSettingsGUI.php
@@ -81,6 +81,11 @@ class ilObjStudyProgrammeSettingsGUI {
 	 */
 	protected $trafo_factory;
 
+	/**
+	 * @var \ILIAS\Refinery\Factory
+	 */
+	private $refinery;
+
 	public function __construct($a_parent_gui, $a_ref_id) {
 		global $DIC;
 		$tpl = $DIC['tpl'];
@@ -92,6 +97,7 @@ class ilObjStudyProgrammeSettingsGUI {
 		$lng = $DIC['lng'];
 		$ilLog = $DIC['ilLog'];
 		$ilias = $DIC['ilias'];
+		$refinery = $DIC->refinery();
 
 		$this->parent_gui = $a_parent_gui;
 		$this->ref_id = $a_ref_id;
@@ -112,6 +118,7 @@ class ilObjStudyProgrammeSettingsGUI {
 		$this->trafo_factory = new \ILIAS\Refinery\Transformation\Factory(); // TODO: replace this with the version from the DIC once available
 		$this->data = new \ILIAS\Data\Factory();
 		$this->validation = new \ILIAS\Refinery\Validation\Factory($this->data, $this->lng);
+		$this->refinery = $refinery;
 		
 		$this->object = null;
 
@@ -259,7 +266,7 @@ class ilObjStudyProgrammeSettingsGUI {
 						self::PROP_POINTS =>
 							$ff->numeric($txt("prg_points"))
 								->withValue((string)$prg->getPoints())
-								->withAdditionalConstraint($this->validation->greaterThan(-1)),
+								->withAdditionalConstraint($this->refinery->int()->isGreaterThan(-1)),
 						self::PROP_STATUS =>
 							$ff->select($txt("prg_status"), $status_options)
 								->withValue((string)$prg->getStatus())

--- a/tests/Validation/Constraints/LogicalOrTest.php
+++ b/tests/Validation/Constraints/LogicalOrTest.php
@@ -4,6 +4,8 @@
 require_once 'libs/composer/vendor/autoload.php';
 
 use ILIAS\Data;
+use ILIAS\Refinery\Integer\Constraints\GreaterThan;
+use ILIAS\Refinery\Integer\Constraints\LessThan;
 use ILIAS\Refinery\Validation;
 use ILIAS\Refinery\Validation\Constraints\LogicalOr;
 use PHPUnit\Framework\TestCase;
@@ -109,11 +111,12 @@ class LogicalOrTest extends TestCase
 	public function constraintsProvider(): array
 	{
 		$mock = $this->getMockBuilder(\ilLanguage::class)->disableOriginalConstructor()->getMock();
-		$f = new Validation\Factory(new Data\Factory(), $mock);
+		$data_factory = new Data\Factory();
+		$f = new Validation\Factory($data_factory, $mock);
 
 		return [
 			[$f->or([$f->isInt(), $f->isString()]), '5', []],
-			[$f->or([$f->greaterThan(5), $f->lessThan(2)]), 7, 3]
+			[$f->or([new GreaterThan(5, $data_factory, $mock), new LessThan(2, $data_factory, $mock)]), 7, 3]
 		];
 	}
 }

--- a/tests/Validation/ValidationFactoryTest.php
+++ b/tests/Validation/ValidationFactoryTest.php
@@ -37,16 +37,6 @@ class ValidationFactoryTest extends TestCase {
 		$this->assertInstanceOf(Validation\Constraint::class, $is_int);
 	}
 
-	public function testGreaterThan() {
-		$gt = $this->f->greaterThan(5);
-		$this->assertInstanceOf(Validation\Constraint::class, $gt);
-	}
-
-	public function testLessThan() {
-		$lt = $this->f->lessThan(5);
-		$this->assertInstanceOf(Validation\Constraint::class, $lt);
-	}
-
 	public function testHasMinLength() {
 		$min = $this->f->hasMinLength(1);
 		$this->assertInstanceOf(Validation\Constraint::class, $min);
@@ -59,8 +49,8 @@ class ValidationFactoryTest extends TestCase {
 
 	public function testSequential() {
 		$constraints = array(
-				$this->f->greaterThan(5),
-				$this->f->lessThan(15)
+				$this->f->hasMinLength(5),
+				$this->f->hasMaxLength(15)
 			);
 
 		$sequential = $this->f->sequential($constraints);
@@ -69,8 +59,8 @@ class ValidationFactoryTest extends TestCase {
 
 	public function testParallel() {
 		$constraints = array(
-				$this->f->greaterThan(5),
-				$this->f->lessThan(15)
+				$this->f->hasMinLength(5),
+				$this->f->hasMaxLength(15)
 			);
 
 		$parallel = $this->f->parallel($constraints);
@@ -78,7 +68,7 @@ class ValidationFactoryTest extends TestCase {
 	}
 
 	public function testNot() {
-		$constraint = $this->f->greaterThan(5);
+		$constraint = $this->f->hasMinLength(5);
 		$not = $this->f->not($constraint);
 		$this->assertInstanceOf(Validation\Constraint::class, $not);
 	}


### PR DESCRIPTION
Addition to the recent changes of #1825 

I didn't recognize the failing unittests because the script for PRs in travis didn't seem to work.