### PR TITLE
add explorer-navigation to sub-panel, move relations into card

### DIFF
--- a/Services/Style/System/classes/Documentation/class.ilKSDocumentationEntryGUI.php
+++ b/Services/Style/System/classes/Documentation/class.ilKSDocumentationEntryGUI.php
@@ -44,16 +44,28 @@ class ilKSDocumentationEntryGUI
 	protected $r = null;
 
 	/**
+	 * @var ilKSDocumentationExplorerGUI
+	 */
+	protected $explorer;
+
+	/**
 	 * ilKSDocumentationEntryGUI constructor.
 	 * @param ilSystemStyleDocumentationGUI $parent
 	 * @param Entry\ComponentEntry $entry
 	 * @param Entry\ComponentEntries $entries
 	 */
-	public function __construct(ilSystemStyleDocumentationGUI $parent, Entry\ComponentEntry $entry, Entry\ComponentEntries $entries) {
+	public function __construct(
+			ilSystemStyleDocumentationGUI $parent,
+			ilKSDocumentationExplorerGUI $explorer,
+			Entry\ComponentEntries $entries
+	) {
 		global $DIC;
 
 		$this->f = $DIC->ui()->factory();
 		$this->r = $DIC->ui()->renderer();
+
+		$this->explorer = $explorer;
+		$entry = $explorer->getCurrentOpenedNode();
 
 		$this->setEntry($entry);
 		$this->setEntries($entries);
@@ -131,8 +143,11 @@ class ilKSDocumentationEntryGUI
 			}
 		}
 
-		$sub_panels[] = $this->f->panel()->sub("Relations",
-			$this->f->listing()->descriptive(
+
+		$relations_card = $this->f->card()
+			->standard('Relations')
+			->withSections([
+				$this->f->listing()->descriptive(
 					array(
 						"Parents" => $this->f->listing()->ordered(
 							$this->entries->getParentsOfEntryTitles($this->entry->getId())
@@ -141,10 +156,19 @@ class ilKSDocumentationEntryGUI
 							$this->entries->getDescendantsOfEntryTitles($this->entry->getId())
 						)
 					)
-			)
-		);
+				)
+			]);
 
-		$report = $this->f->panel()->report($this->entry->getTitle(),$sub_panels);
+
+		$sub_panels[] = $this->f->panel()->sub("Navigation",
+			$this->f->legacy($this->explorer->getHTML())
+		)
+		->withCard($relations_card);
+
+
+
+		$report = $this->f->panel()
+			->report($this->entry->getTitle(),$sub_panels);
 
 		return $this->r->render($report);
 	}

--- a/Services/Style/System/classes/Documentation/class.ilSystemStyleDocumentationGUI.php
+++ b/Services/Style/System/classes/Documentation/class.ilSystemStyleDocumentationGUI.php
@@ -95,10 +95,14 @@ class ilSystemStyleDocumentationGUI
 		}
 
 		$explorer = new ilKSDocumentationExplorerGUI($this, "entries", $entries, $_GET["node_id"]);
-		$this->tpl->setLeftNavContent($explorer->getHTML());
-		$entry_gui = new ilKSDocumentationEntryGUI($this,$explorer->getCurrentOpenedNode(), $entries);
-		$content .= $entry_gui->renderEntry();
 
+		$entry_gui = new ilKSDocumentationEntryGUI(
+			$this,
+			$explorer,
+			$entries
+		);
+
+		$content = $entry_gui->renderEntry();
 		$this->tpl->setContent($content);
 	}
 


### PR DESCRIPTION
With the current state of trunk, there is no navigation through the KitchenSink.
Since the docs are a helpful and quite frequently used tool for developers, I'd like to propose this INTERIM solution.

Explorer-style navigation in the content certainly breaks one or the other rule, and MUST vanish as soon as possible, latest before a beta-release.

![Bildschirmfoto_2019-05-09_11-51-22](https://user-images.githubusercontent.com/3328364/57445507-cb95fd00-7252-11e9-88b7-2238f326d656.png)
