### PR TITLE
DataCollection: Corrected Access-Check for Table

### DIFF
--- a/Modules/DataCollection/classes/class.ilObjDataCollectionAccess.php
+++ b/Modules/DataCollection/classes/class.ilObjDataCollectionAccess.php
@@ -320,13 +320,15 @@ class ilObjDataCollectionAccess extends ilObjectAccess {
 
 		// check access to tableview's datacollection first
 		$collection = $table->getCollectionObject();
+		$has_read_on_dcl = false;
 		foreach (ilObjDataCollection::_getAllReferences($collection->getId()) as $ref_id) {
-			if (!self::hasReadAccess($ref_id)) {
-				return false;
+			if (self::hasReadAccess($ref_id)) {
+				$has_read_on_dcl = true;
+				break;
 			}
 		}
 
-		return $table->getIsVisible() || ($table_id == $collection->getFirstVisibleTableId());
+		return $has_read_on_dcl && ($table->getIsVisible() || ($table_id == $collection->getFirstVisibleTableId()));
 	}
 }
 

--- a/Modules/DataCollection/classes/class.ilObjDataCollectionAccess.php
+++ b/Modules/DataCollection/classes/class.ilObjDataCollectionAccess.php
@@ -287,14 +287,6 @@ class ilObjDataCollectionAccess extends ilObjectAccess {
 			$tableview = ilDclTableView::find($tableview);
 		}
 
-		// check access to tableview's datacollection first
-		$collection = $tableview->getTable()->getCollectionObject();
-		foreach (ilObjDataCollection::_getAllReferences($collection->getId()) as $ref_id) {
-			if (!self::hasReadAccess($ref_id)) {
-				return false;
-			}
-		}
-
 		// check access to table
 		if (!self::hasAccessToTable($tableview->getTableId())) {
 			return false;


### PR DESCRIPTION
The check on the access to the parent DataCollection of a table seems to be too restrictive: I should be allowed to have access to a table if I may read any of the references to its parent DataCollection. Currently I have no access to a table if I cannot read any of the references to its parent DataCollection. Also, the check is duplicated.