### PR TITLE
Introduce PSR-2 (+ some X)

### DIFF
--- a/docs/documentation/coding-style.md
+++ b/docs/documentation/coding-style.md
@@ -1,0 +1,161 @@
+# ILIAS Coding Standard
+This coding standard is for the [ILIAS project](https://github.com/ILIAS-eLearning/ILIAS)
+
+
+**Table of Contents**
+* [PSR-2](#psr-2)
+* [Additions](#additions)
+  * [Indention](#indention)
+  * [Exceptions](#exceptions)
+  * [Abstract](#abstract)
+  * [Interfaces](#interfaces)
+  * [Operators](#operators)
+  * [Type cast](#type-cast)
+  * [Return Type Declaration](#return-type-declaration)
+  * [Strings](#strings)
+  * [Comparison](#comparison)
+  * [Comments](#comments)
+  * [Early return](#early-return)
+  * [Native Types](#native-types)
+  * [Conditions](#conditions)
+  * [Arrays](#arrays)
+
+# PSR-2 
+
+The ILIAS coding standard is aligned to the widely used and established
+[PSR-2 standard](https://www.php-fig.org/psr/psr-2/)
+of the [PHP Interop Group (PHP-FIG)](https://www.php-fig.org/).
+
+_Info: Please be aware of the [additions](#additions)
+defined for the ILIAS project that MUST be used on top of PSR-2_
+
+# Additions
+
+This document is an addition to PSR-2 Standard used in the ILIAS project.
+This section was inspired by the
+[Doctrine Coding Standards](https://github.com/doctrine/coding-standard).
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
+
+## Indention
+
+Divergent from the PSR-2 indentation, the code
+MUST be indent by tabs and NOT spaces.
+
+## Exceptions
+
+Abstract exception class names and exception interface names SHOULD be
+suffixed with `Exception`.
+
+## Abstract
+
+Abstract classes SHOULD NOT be prefixed or suffixed with Abstract.
+
+## Interfaces
+
+Interfaces SHOULD NOT be prefixed or suffixed with Interface.
+
+## Operators
+
+Operators MUST have a space before and after the operator.
+
+Mathematical Operators:
+
+```php
+$result = 1 + $value;
+```
+
+Comparsion Operators:
+
+```php
+if ($size > 0) {
+    // ...
+}
+```
+
+Concatenation Operator:
+
+```php
+$test = 'hello ' . $name . '!';
+```
+
+## Type cast
+
+Spaces MUST be added after a type cast.
+
+```php
+$foo = (int) '12345';
+```
+
+## Return Type Declaration
+
+Spaces MUST be added around a colon in return type declaration.
+
+```php
+function () : void {}
+```
+
+## Strings
+
+Strings MUST use single quotes(apostrophes) for enclosing tags.
+Double quotes MUST NOT be used for enclosing tags.
+
+```php
+$text = 'hello world!';
+```
+
+## Comparison
+
+Strict comparisons MUST be used.
+
+```php
+if (3 === $value) {
+   // ...
+}
+```
+## Comments
+`@author`, `@since` and similar annotations that duplicate Git information MUST NOT be used.
+phpDoc for parameters/returns with native types SHOULD BE omitted, unless adding description.
+
+## Early return
+
+Prefer early exit/return over nesting conditions or using else.
+
+## Native Types
+
+Native types MUST be used where possible.
+
+## Conditions
+
+Assignment in condition MUST NOT be used.
+
+## Arrays
+
+An array that consisting of maximum `3` elements
+MAY be written in one line.
+
+```php
+$fruits = array('apple', 'banana', 'kiwi');
+```
+
+If the elements within the array exceeds 80
+characters the elements MUST be separated
+to an array with 1 element per line.
+The single elements of such arrays MUST be indented.
+
+Arrays that consist of more than `3` elements
+MUST be separated to an array with `1` element
+per line.
+The single elements of such arrays MUST be indented.
+
+```php
+$fruits = array(
+    'apple',
+    'banana',
+    'kiwi',
+    'ananas',
+    'plum'
+);
+```

--- a/docs/documentation/coding-style.md
+++ b/docs/documentation/coding-style.md
@@ -1,63 +1,14 @@
-# ILIAS Coding Standard
-This coding standard is for the [ILIAS project](https://github.com/ILIAS-eLearning/ILIAS)
+# ILIAS Coding Style
 
+This is the coding style for the [ILIAS project](https://github.com/ILIAS-eLearning/ILIAS).
 
-**Table of Contents**
-* [PSR-2](#psr-2)
-* [Additions](#additions)
-  * [Indention](#indention)
-  * [Exceptions](#exceptions)
-  * [Abstract](#abstract)
-  * [Interfaces](#interfaces)
-  * [Operators](#operators)
-  * [Type cast](#type-cast)
-  * [Return Type Declaration](#return-type-declaration)
-  * [Strings](#strings)
-  * [Comparison](#comparison)
-  * [Comments](#comments)
-  * [Early return](#early-return)
-  * [Native Types](#native-types)
-  * [Conditions](#conditions)
-  * [Arrays](#arrays)
+## PSR-2 and additions
 
-# PSR-2 
+The ILIAS coding standard is aligned to the widely used and established [PSR-2 standard](https://www.php-fig.org/psr/psr-2/)
+of the [PHP Interop Group (PHP-FIG)](https://www.php-fig.org/), extended by the
+following additions:
 
-The ILIAS coding standard is aligned to the widely used and established
-[PSR-2 standard](https://www.php-fig.org/psr/psr-2/)
-of the [PHP Interop Group (PHP-FIG)](https://www.php-fig.org/).
-
-_Info: Please be aware of the [additions](#additions)
-defined for the ILIAS project that MUST be used on top of PSR-2_
-
-# Additions
-
-This document is an addition to PSR-2 Standard used in the ILIAS project.
-This section was inspired by the
-[Doctrine Coding Standards](https://github.com/doctrine/coding-standard).
-
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
-interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
-
-## Indention
-
-Divergent from the PSR-2 indentation, the code
-MUST be indent by tabs and NOT spaces.
-
-## Exceptions
-
-Abstract exception class names and exception interface names SHOULD be
-suffixed with `Exception`.
-
-## Abstract
-
-Abstract classes SHOULD NOT be prefixed or suffixed with Abstract.
-
-## Interfaces
-
-Interfaces SHOULD NOT be prefixed or suffixed with Interface.
-
-## Operators
+### Operators
 
 Operators MUST have a space before and after the operator.
 
@@ -81,7 +32,7 @@ Concatenation Operator:
 $test = 'hello ' . $name . '!';
 ```
 
-## Type cast
+### Type cast
 
 Spaces MUST be added after a type cast.
 
@@ -89,73 +40,10 @@ Spaces MUST be added after a type cast.
 $foo = (int) '12345';
 ```
 
-## Return Type Declaration
+### Return Type Declaration
 
 Spaces MUST be added around a colon in return type declaration.
 
 ```php
 function () : void {}
-```
-
-## Strings
-
-Strings MUST use single quotes(apostrophes) for enclosing tags.
-Double quotes MUST NOT be used for enclosing tags.
-
-```php
-$text = 'hello world!';
-```
-
-## Comparison
-
-Strict comparisons MUST be used.
-
-```php
-if (3 === $value) {
-   // ...
-}
-```
-## Comments
-`@author`, `@since` and similar annotations that duplicate Git information MUST NOT be used.
-phpDoc for parameters/returns with native types SHOULD BE omitted, unless adding description.
-
-## Early return
-
-Prefer early exit/return over nesting conditions or using else.
-
-## Native Types
-
-Native types MUST be used where possible.
-
-## Conditions
-
-Assignment in condition MUST NOT be used.
-
-## Arrays
-
-An array that consisting of maximum `3` elements
-MAY be written in one line.
-
-```php
-$fruits = array('apple', 'banana', 'kiwi');
-```
-
-If the elements within the array exceeds 80
-characters the elements MUST be separated
-to an array with 1 element per line.
-The single elements of such arrays MUST be indented.
-
-Arrays that consist of more than `3` elements
-MUST be separated to an array with `1` element
-per line.
-The single elements of such arrays MUST be indented.
-
-```php
-$fruits = array(
-    'apple',
-    'banana',
-    'kiwi',
-    'ananas',
-    'plum'
-);
 ```


### PR DESCRIPTION
Dear developers,

the @ILIAS-eLearning/technical-board  hereby proposes to introduce PSR-2 (with some additions) as the coding style for ILIAS. Thx to @legionth for his substantial contribution to this proposal!

This proposes to add the coding-style to our documentation, but it seems to be even more important how we would want to perform this move. We propose to make this move in three phases:

* Starting in ~June 2019, every change in the maintained ILIAS-versions and the trunk must be made after the coding style is fixed in the changed file. Maintainers may also move their components to the new style at their own discretion. Tools to make this move will be provided.
* With the creation of the beta-branch for 6.0 in Oktober 2019, the rest of the code-base in the trunk, beta and maintained branches will be moved as well.
* Afterwards the CI-server will care that new code adheres to the style. We are looking into the details of this currently. We will also provide means for developers (configuration for PHP-storm, possibly code for a git pre-commit hook, ...) that will make it easy to follow the style-guideline.

We intentionally only included directions regarding the formatting of code. We feel that questions like "How to name interfaces or classes?" or "When to use early return?" require a lot more effort in discussions and thus try to pick low hanging fruits with this proposal first.

This will also make [this page in the dev-guide](https://docu.ilias.de/goto_docu_pg_202_42.html) obsolete.

Feel free to ask questions or give feedback via this PR or on the JF.

Best regards!