### PR TITLE
fix/5-4/ilmmsubitemgui filter param

### DIFF
--- a/Services/MainMenu/classes/Administration/class.ilMMSubItemGUI.php
+++ b/Services/MainMenu/classes/Administration/class.ilMMSubItemGUI.php
@@ -184,7 +184,7 @@ class ilMMSubItemGUI extends ilMMAbstractItemGUI {
 
 
 	private function applyFilter() {
-		$table = new ilMMSubItemTableGUI($this, $this->repository);
+		$table = new ilMMSubItemTableGUI($this, $this->repository,$this->access);
 		$table->writeFilterToSession();
 
 		$this->cancel();
@@ -192,7 +192,7 @@ class ilMMSubItemGUI extends ilMMAbstractItemGUI {
 
 
 	private function resetFilter() {
-		$table = new ilMMSubItemTableGUI($this, $this->repository);
+		$table = new ilMMSubItemTableGUI($this, $this->repository,$this->access);
 		$table->resetFilter();
 		$table->resetOffset();
 

--- a/Services/MainMenu/classes/Administration/class.ilMMSubItemGUI.php
+++ b/Services/MainMenu/classes/Administration/class.ilMMSubItemGUI.php
@@ -184,7 +184,7 @@ class ilMMSubItemGUI extends ilMMAbstractItemGUI {
 
 
 	private function applyFilter() {
-		$table = new ilMMSubItemTableGUI($this, $this->repository,$this->access);
+		$table = new ilMMSubItemTableGUI($this, $this->repository, $this->access);
 		$table->writeFilterToSession();
 
 		$this->cancel();
@@ -192,7 +192,7 @@ class ilMMSubItemGUI extends ilMMAbstractItemGUI {
 
 
 	private function resetFilter() {
-		$table = new ilMMSubItemTableGUI($this, $this->repository,$this->access);
+		$table = new ilMMSubItemTableGUI($this, $this->repository, $this->access);
 		$table->resetFilter();
 		$table->resetOffset();
 


### PR DESCRIPTION
bugfix for ilmmsubitemgui:
TypeError
Argument 3 passed to ilMMSubItemTableGUI::__construct() must be an instance of ilObjMainMenuAccess, none given, called in /var/www/htdocs/test-elearning.fhoev/docroot/Services/MainMenu/classes/Administration/class.ilMMSubItemGUI.php on line 187

