### PR TITLE
mantis 25426: Group export / import does not export several settings

### DIFF
--- a/Modules/Group/classes/class.ilGroupXMLParser.php
+++ b/Modules/Group/classes/class.ilGroupXMLParser.php
@@ -556,6 +556,16 @@ class ilGroupXMLParser extends ilMDSaxParser implements ilSaxSubsetParser
 		$this->group_obj->setRegistrationAccessCode($this->group_data['registration_access_code'] ? $this->group_data['registration_access_code'] : '');
 		$this->group_obj->setViewMode($this->group_data['view_mode'] ? $this->group_data['view_mode'] : ilContainer::VIEW_DEFAULT);
 		$this->group_obj->setMailToMembersType((int) $this->group_data['mail_members_type']);
+
+		// add container settings to group_obj, so they do not get overwritten by the ilContainer::update; see mantis 25426
+		$group_container_settings = ilContainer::_getContainerSettings($this->group_obj->getId());
+		$this->group_obj->setNewsTimeline($group_container_settings["news_timeline"]);
+		$this->group_obj->setNewsTimelineAutoEntries($group_container_settings["news_timeline_incl_auto"]);
+		$this->group_obj->setNewsTimelineLandingPage($group_container_settings["news_timeline_landing_page"]);
+		include_once("./Services/Object/classes/class.ilObjectServiceSettingsGUI.php");
+		$this->group_obj->setNewsBlockActivated($group_container_settings[ilObjectServiceSettingsGUI::NEWS_VISIBILITY]);
+		$this->group_obj->setUseNews($group_container_settings[ilObjectServiceSettingsGUI::USE_NEWS]);
+
 		$this->group_obj->update();
 
 		// ASSIGN ADMINS/MEMBERS

--- a/Modules/Group/classes/class.ilGroupXMLParser.php
+++ b/Modules/Group/classes/class.ilGroupXMLParser.php
@@ -225,6 +225,10 @@ class ilGroupXMLParser extends ilMDSaxParser implements ilSaxSubsetParser
 				$this->group_data['waiting_list_enabled'] = $a_attribs['waitingList'] == 'Yes' ? true : false;
 				break;
 			
+			case 'AccessCode':
+				$this->group_data['registration_access_code_enabled'] = $a_attribs['enabled'] == 'Yes' ? true : false;
+				break;
+
 			case 'period':
 				$this->in_period = true;
 				break;
@@ -264,7 +268,7 @@ class ilGroupXMLParser extends ilMDSaxParser implements ilSaxSubsetParser
 				break;
 
 			case 'ContainerSetting':
-				$this->current_container_setting = $a_attribs['id'];				
+				$this->current_container_setting = $a_attribs['id'];
 				break;
 
 			case 'Sort':
@@ -354,6 +358,10 @@ class ilGroupXMLParser extends ilMDSaxParser implements ilSaxSubsetParser
 				$this->in_period = false;
 				break;
 
+			case 'AccessCode':
+				$this->group_data['registration_access_code'] = $this->cdata;
+				break;
+
 			case "group":
 				// NOW SAVE THE NEW OBJECT (if it hasn't been imported)
 				$this->__save();
@@ -397,7 +405,14 @@ class ilGroupXMLParser extends ilMDSaxParser implements ilSaxSubsetParser
 			case 'mailMembersType':
 				$this->group_data['mail_members_type'] = (int) $this->cdata;
 				break;
-				
+
+			case 'viewMode':
+				if((int) $this->cdata)
+				{
+					$this->group_data['view_mode'] = (int) $this->cdata;
+				}
+				break;
+
 		}
 		$this->cdata = '';
 	}
@@ -513,13 +528,13 @@ class ilGroupXMLParser extends ilMDSaxParser implements ilSaxSubsetParser
 		}
 		$this->group_obj->setRegistrationType($flag);
 		
-		$end = new ilDateTime(time(),IL_CAL_UNIX);
+		$end = NULL;
 		if($this->group_data['expiration_end'])
 		{
 			$end = new ilDateTime($this->group_data['expiration_end'],IL_CAL_UNIX);
 		}
 
-		$start = clone $end;
+		$start = NULL;
 		if($this->group_data['expiration_start'])
 		{
 			$start = new ilDateTime($this->group_data['expiration_start'],IL_CAL_UNIX);
@@ -537,6 +552,9 @@ class ilGroupXMLParser extends ilMDSaxParser implements ilSaxSubsetParser
 		$this->group_obj->setCancellationEnd($this->group_data['cancel_end']);
 		$this->group_obj->setMinMembers($this->group_data['min_members']);
 		$this->group_obj->setShowMembers($this->group_data['show_members'] ? $this->group_data['show_members'] : 0);
+		$this->group_obj->enableRegistrationAccessCode($this->group_data['registration_access_code_enabled'] ? $this->group_data['registration_access_code_enabled'] : 0);
+		$this->group_obj->setRegistrationAccessCode($this->group_data['registration_access_code'] ? $this->group_data['registration_access_code'] : '');
+		$this->group_obj->setViewMode($this->group_data['view_mode'] ? $this->group_data['view_mode'] : ilContainer::VIEW_DEFAULT);
 		$this->group_obj->setMailToMembersType((int) $this->group_data['mail_members_type']);
 		$this->group_obj->update();
 

--- a/Modules/Group/classes/class.ilGroupXMLWriter.php
+++ b/Modules/Group/classes/class.ilGroupXMLWriter.php
@@ -91,6 +91,7 @@ class ilGroupXMLWriter extends ilXmlWriter
 			$this->__buildTitleDescription();
 			$this->__buildRegistration();
 			$this->__buildExtraSettings();
+			$this->__buildPeriod();
 			if ($this->attach_users) 
 			{
 				$this->__buildAdmin();
@@ -245,8 +246,10 @@ class ilGroupXMLWriter extends ilXmlWriter
 		{
 			$this->xmlElement('password',null,$pwd);
 		}
+		$accessCodeAttrs = array();
+		$accessCodeAttrs['enabled'] = $this->group_obj->isRegistrationAccessCodeEnabled() ? 'Yes' : 'No';
+		$this->xmlElement("AccessCode", $accessCodeAttrs, $this->group_obj->getRegistrationAccessCode());
 
-		
 		// limited registration period
 		if(!$this->group_obj->isRegistrationUnlimited())
 		{
@@ -275,6 +278,7 @@ class ilGroupXMLWriter extends ilXmlWriter
 	function __buildExtraSettings()
 	{
 		$this->xmlElement('showMembers',null,$this->group_obj->getShowMembers());
+		$this->xmlElement('viewMode',null,$this->group_obj->getViewMode());
 	}
 
 	function __buildAdmin()


### PR DESCRIPTION
Pull request for https://mantis.ilias.de/view.php?id=25426

Please see details about the exact settings affected in the mantis issue.
I am not overly happy with the part loading the container settings from the DB and writing them back in the group object, but the alternative would have been a large switch (or nested if) statement inside an already big switch statement in the ``ilGroupXMLParser::handlerEndTag``. However I can change the code to call the ``group_obj->setNewsWhatever`` in the ``handlerEndTag``, if you prefer.

Please review and give me advise how to imporve the pull request where you see room for improvement. 