### PR TITLE
Fix replacement of old replacement behavior

### DIFF
--- a/Services/Certificate/classes/Placeholder/Replacement/class.ilCertificateValueReplacement.php
+++ b/Services/Certificate/classes/Placeholder/Replacement/class.ilCertificateValueReplacement.php
@@ -18,7 +18,7 @@ class ilCertificateValueReplacement
 	 */
 	public function __construct(string $clientWebDirectory = '')
 	{
-		if ('' === $clientWebDirectory && true === defined(CLIENT_WEB_DIR)) {
+		if ('' === $clientWebDirectory && true === defined('CLIENT_WEB_DIR')) {
 			$clientWebDirectory = CLIENT_WEB_DIR;
 		}
 		$this->clientWebDirectory = $clientWebDirectory;

--- a/Services/Certificate/classes/Placeholder/Replacement/class.ilCertificateValueReplacement.php
+++ b/Services/Certificate/classes/Placeholder/Replacement/class.ilCertificateValueReplacement.php
@@ -6,6 +6,15 @@
  */
 class ilCertificateValueReplacement
 {
+	/**
+	 * @var string
+	 */
+	private $clientWebDirectory;
+
+	public function __construct(string $clientWebDirectory = CLIENT_WEB_DIR)
+	{
+		$this->clientWebDirectory = $clientWebDirectory;
+	}
 
 	/**
 	 * Replaces placeholder in the certificate content with actual values
@@ -23,7 +32,7 @@ class ilCertificateValueReplacement
 		}
 
 		$certificateContent = str_replace('[BACKGROUND_IMAGE]',  $backgroundPath, $certificateContent);
-
+		$certificateContent = str_replace('[CLIENT_WEB_DIR]',  $this->clientWebDirectory, $certificateContent);
 
 		$certificateContent = preg_replace("/<\?xml[^>]+?>/", "", $certificateContent);
 		$certificateContent = str_replace("&#xA0;", "<br />", $certificateContent);

--- a/Services/Certificate/classes/Placeholder/Replacement/class.ilCertificateValueReplacement.php
+++ b/Services/Certificate/classes/Placeholder/Replacement/class.ilCertificateValueReplacement.php
@@ -11,8 +11,16 @@ class ilCertificateValueReplacement
 	 */
 	private $clientWebDirectory;
 
-	public function __construct(string $clientWebDirectory = CLIENT_WEB_DIR)
+	/**
+	 * @param string $clientWebDirectory - Replacement for the placeholder [CLIENT_WEB_DIR], if the string is empty
+	 *                                     the constant CLIENT_WEB_DIR will be tried as default value.
+	 *                                     If CLIENT_WEB_DIR is not defined the default value will be an empty string.
+	 */
+	public function __construct(string $clientWebDirectory = '')
 	{
+		if ('' === $clientWebDirectory && true === defined(CLIENT_WEB_DIR)) {
+			$clientWebDirectory = CLIENT_WEB_DIR;
+		}
 		$this->clientWebDirectory = $clientWebDirectory;
 	}
 

--- a/Services/Certificate/test/ilCertificateValueReplacementTest.php
+++ b/Services/Certificate/test/ilCertificateValueReplacementTest.php
@@ -8,7 +8,7 @@ class ilCertificateValueReplacementTest extends \PHPUnit_Framework_TestCase
 {
 	public function testReplace()
 	{
-		$replacement = new ilCertificateValueReplacement();
+		$replacement = new ilCertificateValueReplacement('/some/where');
 
 		$placeholderValues = array('NAME' => 'Peter', 'PRIZE' => 'a fantastic prize');
 
@@ -23,6 +23,31 @@ Hurray [NAME] you have received [PRIZE]
 
 		$expected = '<xml> 
 /some/where/path/background.jpg
+Hurray Peter you have received a fantastic prize
+</xml>';
+
+		$this->assertEquals($expected, $replacedContent);
+	}
+
+	public function testReplaceClientWebDir()
+	{
+		$replacement = new ilCertificateValueReplacement('/some/where');
+
+		$placeholderValues = array('NAME' => 'Peter', 'PRIZE' => 'a fantastic prize');
+
+		$certificateContent = '<xml> 
+[BACKGROUND_IMAGE]
+[CLIENT_WEB_DIR]/background.jpg
+Hurray [NAME] you have received [PRIZE]
+</xml>';
+
+		$backgroundPath = '/some/where/path/background.jpg';
+
+		$replacedContent = $replacement->replace($placeholderValues, $certificateContent, $backgroundPath);
+
+		$expected = '<xml> 
+/some/where/path/background.jpg
+/some/where/background.jpg
 Hurray Peter you have received a fantastic prize
 </xml>';
 


### PR DESCRIPTION
Migrated certificate templates with the old placeholder `[CLIENT_WEB_DIR]` currently won't be replaced. So new created user certificates with this old template may occur with an empty background image. 

New template will always have the `[BACKGROUND_IMAGE]` placeholder in the templates. So this behavior only appears for systems where the template was never touched.

