### PR TITLE
Fix of 25460

### DIFF
--- a/src/UI/Implementation/Component/Input/Field/Group.php
+++ b/src/UI/Implementation/Component/Input/Field/Group.php
@@ -41,7 +41,7 @@ class Group extends Input implements C\Input\Field\Group {
 		\ILIAS\Refinery\Factory $refinery,
 		array $inputs,
 		string $label,
-		$byline
+		string $byline = null
 	) {
 		parent::__construct($data_factory, $validation_factory, $transformation_factory, $refinery, $label, $byline);
 		$this->checkArgListElements("inputs", $inputs, InputInternal::class);

--- a/src/UI/Implementation/Component/Input/Field/Group.php
+++ b/src/UI/Implementation/Component/Input/Field/Group.php
@@ -41,7 +41,7 @@ class Group extends Input implements C\Input\Field\Group {
 		\ILIAS\Refinery\Factory $refinery,
 		array $inputs,
 		string $label,
-		string $byline
+		$byline
 	) {
 		parent::__construct($data_factory, $validation_factory, $transformation_factory, $refinery, $label, $byline);
 		$this->checkArgListElements("inputs", $inputs, InputInternal::class);

--- a/tests/UI/Component/Input/Field/FieldFactoryTest.php
+++ b/tests/UI/Component/Input/Field/FieldFactoryTest.php
@@ -61,21 +61,99 @@ class FieldFactoryTest extends AbstractFactoryTest {
 	public function test_implements_factory_interface() {
 		$f = $this->buildFactory();
 
-		$text = $f->text("label", "byline");
-		$this->assertInstanceOf(Field\Input::class, $text);
-		$this->assertInstanceOf(Field\Text::class, $text);
+		$input = $f->text("label", "byline");
+		$this->assertInstanceOf(Field\Input::class, $input);
+		$this->assertInstanceOf(Field\Text::class, $input);
 
-		$text = $f->numeric("label", "byline");
-		$this->assertInstanceOf(Field\Input::class, $text);
-		$this->assertInstanceOf(Field\Numeric::class, $text);
+		$input = $f->numeric("label", "byline");
+		$this->assertInstanceOf(Field\Input::class, $input);
+		$this->assertInstanceOf(Field\Numeric::class, $input);
 
-		$text = $f->section([], "label", "byline");
-		$this->assertInstanceOf(Field\Input::class, $text);
-		$this->assertInstanceOf(Field\Group::class, $text);
-		$this->assertInstanceOf(Field\Section::class, $text);
+		$input = $f->section([], "label", "byline");
+		$this->assertInstanceOf(Field\Input::class, $input);
+		$this->assertInstanceOf(Field\Group::class, $input);
+		$this->assertInstanceOf(Field\Section::class, $input);
 
-		$text = $f->group([]);
-		$this->assertInstanceOf(Field\Input::class, $text);
-		$this->assertInstanceOf(Field\Group::class, $text);
+		$input = $f->group([]);
+		$this->assertInstanceOf(Field\Input::class, $input);
+		$this->assertInstanceOf(Field\Group::class, $input);
+
+		$input = $f->dependantGroup([]);
+		$this->assertInstanceOf(Field\Input::class, $input);
+		$this->assertInstanceOf(Field\Group::class, $input);
+		$this->assertInstanceOf(Field\DependantGroup::class, $input);
+
+		$input = $f->checkbox("label", "byline");
+		$this->assertInstanceOf(Field\Input::class, $input);
+		$this->assertInstanceOf(Field\Checkbox::class, $input);
+
+		$input = $f->tag( "label", [],"byline");
+		$this->assertInstanceOf(Field\Input::class, $input);
+		$this->assertInstanceOf(Field\Tag::class, $input);
+
+		$input = $f->password("label", "byline");
+		$this->assertInstanceOf(Field\Input::class, $input);
+		$this->assertInstanceOf(Field\Password::class, $input);
+
+		$input = $f->select("label",[],  "byline");
+		$this->assertInstanceOf(Field\Input::class, $input);
+		$this->assertInstanceOf(Field\Select::class, $input);
+
+		$input = $f->textarea( "label", "byline");
+		$this->assertInstanceOf(Field\Input::class, $input);
+		$this->assertInstanceOf(Field\Textarea::class, $input);
+
+		$input = $f->radio("label", "byline");
+		$this->assertInstanceOf(Field\Input::class, $input);
+		$this->assertInstanceOf(Field\Radio::class, $input);
+
+		$input = $f->multiSelect("label", [], "byline");
+		$this->assertInstanceOf(Field\Input::class, $input);
+		$this->assertInstanceOf(Field\MultiSelect::class, $input);
+	}
+
+	public function test_implements_factory_no_by_line() {
+		$f = $this->buildFactory();
+
+		$input = $f->text("label");
+		$this->assertInstanceOf(Field\Input::class, $input);
+		$this->assertInstanceOf(Field\Text::class, $input);
+
+		$input = $f->numeric("label");
+		$this->assertInstanceOf(Field\Input::class, $input);
+		$this->assertInstanceOf(Field\Numeric::class, $input);
+
+		$input = $f->section([], "label");
+		$this->assertInstanceOf(Field\Input::class, $input);
+		$this->assertInstanceOf(Field\Group::class, $input);
+		$this->assertInstanceOf(Field\Section::class, $input);
+
+		$input = $f->checkbox("label");
+		$this->assertInstanceOf(Field\Input::class, $input);
+		$this->assertInstanceOf(Field\Checkbox::class, $input);
+
+		$input = $f->tag( "label", []);
+		$this->assertInstanceOf(Field\Input::class, $input);
+		$this->assertInstanceOf(Field\Tag::class, $input);
+
+		$input = $f->password("label");
+		$this->assertInstanceOf(Field\Input::class, $input);
+		$this->assertInstanceOf(Field\Password::class, $input);
+
+		$input = $f->select("label",[]);
+		$this->assertInstanceOf(Field\Input::class, $input);
+		$this->assertInstanceOf(Field\Select::class, $input);
+
+		$input = $f->textarea( "label");
+		$this->assertInstanceOf(Field\Input::class, $input);
+		$this->assertInstanceOf(Field\Textarea::class, $input);
+
+		$input = $f->radio("label");
+		$this->assertInstanceOf(Field\Input::class, $input);
+		$this->assertInstanceOf(Field\Radio::class, $input);
+
+		$input = $f->multiSelect("label", []);
+		$this->assertInstanceOf(Field\Input::class, $input);
+		$this->assertInstanceOf(Field\MultiSelect::class, $input);
 	}
 }


### PR DESCRIPTION
The strict type-hint on string does not match the interface, and so caused an error. We might decide to change the interface in future to enable strict type hints, however currently we set non-existing by-lines to null.

Tests added to make sure, inputs without by-lines do work (if the interface allows it).

See Mantis report: https://mantis.ilias.de/view.php?id=25460