### PR TITLE
Make invalid ref_id FATAL instead of WARNING

### DIFF
--- a/Services/Object/classes/class.ilObjectFactory.php
+++ b/Services/Object/classes/class.ilObjectFactory.php
@@ -159,7 +159,7 @@ class ilObjectFactory
 			if ($stop_on_error === true)
 			{
 				$message = "ilObjectFactory::getInstanceByRefId(): No ref_id given!";
-				$ilErr->raiseError($message, $ilErr->WARNING);
+				$ilErr->raiseError($message, $ilErr->FATAL);
 				exit();
 			}
 			
@@ -179,7 +179,7 @@ class ilObjectFactory
 			if ($stop_on_error === true)
 			{
 				$message = "ilObjectFactory::getInstanceByRefId(): Object with ref_id ".$a_ref_id." not found!";
-				$ilErr->raiseError($message, $ilErr->WARNING);
+				$ilErr->raiseError($message, $ilErr->FATAL);
 				exit();
 			}
 			


### PR DESCRIPTION
Came across this error this morning while trying to import old (unsupported) tests.

Current trunk behavior is displaying this message without writing any logs:
<img width="883" alt="warning" src="https://user-images.githubusercontent.com/25431384/58308680-8e10a280-7e02-11e9-8ac4-d1aea33d07ea.png">

This is unfortunate, as there is no indication for developers where this thing is originating.

Since the thing is fatal anyway (see following `exit()`), I suggest using `$ilErr->FATAL`. With PR, an error log gets written:

<img width="874" alt="fatal" src="https://user-images.githubusercontent.com/25431384/58308761-bdbfaa80-7e02-11e9-9d6f-a219fa2cffa2.png">
