### PR TITLE
[Certificates] Fix usage of object helpers for usage of PHP 7.2

### DIFF
--- a/Services/Certificate/classes/Form/Repository/class.ilCertificateSettingsCourseFormRepository.php
+++ b/Services/Certificate/classes/Form/Repository/class.ilCertificateSettingsCourseFormRepository.php
@@ -170,7 +170,7 @@ class ilCertificateSettingsCourseFormRepository implements ilCertificateFormRepo
                 if (null === $id) {
                     return '';
                 }
-                $obj_id = $objectHelper->lookupObjId($id);
+                $obj_id = $objectHelper->lookupObjId((int) $id);
                 $olp = $lpHelper->getInstance($obj_id);
 
                 $invalid_modes = $this->getInvalidLPModes();
@@ -180,7 +180,7 @@ class ilCertificateSettingsCourseFormRepository implements ilCertificateFormRepo
                 if (in_array($olp->getCurrentMode(), $invalid_modes)) {
                     $mode = '<strong>' . $mode . '</strong>';
                 }
-                return $objectHelper->lookupTitle($objectHelper->lookupObjId($id)) . ' (' . $mode . ')';
+                return $objectHelper->lookupTitle($objectHelper->lookupObjId((int) $id)) . ' (' . $mode . ')';
             });
 
             $subitems->setRequired(true);
@@ -204,7 +204,7 @@ class ilCertificateSettingsCourseFormRepository implements ilCertificateFormRepo
         }
 
         foreach ($refIds as $refId) {
-            $objectId = $this->objectHelper->lookupObjId($refId);
+            $objectId = $this->objectHelper->lookupObjId((int) $refId);
             $learningProgressObject = $this->lpHelper->getInstance($objectId);
             $currentMode = $learningProgressObject->getCurrentMode();
             if (in_array($currentMode, $invalidModes)) {

--- a/Services/Certificate/classes/Helper/ilCertificateObjectHelper.php
+++ b/Services/Certificate/classes/Helper/ilCertificateObjectHelper.php
@@ -41,6 +41,6 @@ class ilCertificateObjectHelper
      */
     public function lookupTitle(int $objectId) : string
     {
-        return ilObject::_lookupTitle($objectId);
+        return (string) ilObject::_lookupTitle($objectId);
     }
 }

--- a/Services/Certificate/classes/Template/Action/Clone/class.ilCertificateCloneAction.php
+++ b/Services/Certificate/classes/Template/Action/Clone/class.ilCertificateCloneAction.php
@@ -139,7 +139,7 @@ class ilCertificateCloneAction
 
             $newTemplate = new ilCertificateTemplate(
                 $newObject->getId(),
-                $this->objectHelper->lookupObjId($newObject->getId()),
+                $this->objectHelper->lookupObjId((int) $newObject->getId()),
                 $template->getCertificateContent(),
                 $template->getCertificateHash(),
                 $template->getTemplateValues(),


### PR DESCRIPTION
The call of object helpers can fail on the current trunk using strict type hint declaration.

This should fix this.