### PR TITLE
Better error reporting if createDirectory() did not succeeded

### DIFF
--- a/Services/MediaObjects/classes/class.ilObjMediaObject.php
+++ b/Services/MediaObjects/classes/class.ilObjMediaObject.php
@@ -671,7 +671,11 @@ class ilObjMediaObject extends ilObject
 	 */
 	function createDirectory()
 	{
-		ilUtil::createDirectory(ilObjMediaObject::_getDirectory($this->getId()));
+		$path = ilObjMediaObject::_getDirectory($this->getId());
+		ilUtil::createDirectory($path);
+		if (!is_dir($path)) {
+			$this->ilias->raiseError("Failed to create directory $path.", $this->ilias->error_obj->FATAL);
+		}
 	}
 
 	/**


### PR DESCRIPTION
I have no Mantis ticket for this, yet this is a problem that seems to happen again and again on some of my installations:

When importing ILIAS items with media objects (e.g. tests), the import can fail if the `mobs` directory has the wrong access rights and does not allow for the creation of sub directories (which might happen due to unzipping the ILIAS source tree on some platforms).

In case the `mobs` directory is not writable, ILIAS gives the following cryptic log entry that won't help the admin in locating the actual problem (I myself originally thought that something might be wrong with the imported xml file, for example, when I first came across this error):

```
Whoops\Exception\ErrorException thrown with message "copy(./data/ilias/mobs/mm_1045/apostroph.jpg): failed to open stream: No such file or directory"

Stacktrace:
#16 Whoops\Exception\ErrorException in /var/www/html/ILIAS/Services/MediaObjects/classes/class.ilObjMediaObject.php:1745
#15 copy in /var/www/html/ILIAS/Services/MediaObjects/classes/class.ilObjMediaObject.php:1745
#14 ilObjMediaObject:_saveTempFileAsMediaObject in /var/www/html/ILIAS/Modules/Test/classes/class.ilObjTest.php:6331
#13 ilObjTest:fromXML in /var/www/html/ILIAS/Services/QTI/classes/class.ilQTIParser.php:1097
#12 ilQTIParser:handlerParseEndTag in /var/www/html/ILIAS/Services/QTI/classes/class.ilQTIParser.php:1078
#11 ilQTIParser:handlerEndTag in [internal]:0
#10 xml_parse in /var/www/html/ILIAS/Services/Xml/classes/class.ilSaxParser.php:191
#9 ilSaxParser:parse in /var/www/html/ILIAS/Services/Xml/classes/class.ilSaxParser.php:115
#8 ilSaxParser:startParsing in /var/www/html/ILIAS/Services/QTI/classes/class.ilQTIParser.php:259
#7 ilQTIParser:startParsing in /var/www/html/ILIAS/Modules/Test/classes/class.ilObjTestGUI.php:1251
#6 ilObjTestGUI:importVerifiedFileObject in /var/www/html/ILIAS/Modules/Test/classes/class.ilObjTestGUI.php:699
#5 ilObjTestGUI:executeCommand in /var/www/html/ILIAS/Services/UICore/classes/class.ilCtrl.php:215
#4 ilCtrl:forwardCommand in /var/www/html/ILIAS/Services/Repository/classes/class.ilRepositoryGUI.php:402
#3 ilRepositoryGUI:show in /var/www/html/ILIAS/Services/Repository/classes/class.ilRepositoryGUI.php:356
#2 ilRepositoryGUI:executeCommand in /var/www/html/ILIAS/Services/UICore/classes/class.ilCtrl.php:215
#1 ilCtrl:forwardCommand in /var/www/html/ILIAS/Services/UICore/classes/class.ilCtrl.php:179
#0 ilCtrl:callBaseClass in /var/www/html/ILIAS/ilias.php:20
```

This PR adds a much better log entry by checking if the creation of the sub directory (`./data/ilias/mobs/mm_1045` in the example above) has succeeded - if not, it will stop there and give an error. This will allow admins to easily track the problem down to `./data/ilias/mobs`.