### PR TITLE
Namespace for custom icon has changed

### DIFF
--- a/Services/LearningHistory/classes/class.ilLearningHistoryTimelineItem.php
+++ b/Services/LearningHistory/classes/class.ilLearningHistoryTimelineItem.php
@@ -75,7 +75,7 @@ class ilLearningHistoryTimelineItem implements ilTimelineItemInt
 		$f = $this->ui->factory();
 		$r = $this->ui->renderer();
 
-		$ico = $f->symbol()->icon()->custom($this->lh_entry->getIconPath(), '')->withSize(\ILIAS\UI\Component\Icon\Custom::MEDIUM);
+		$ico = $f->symbol()->icon()->custom($this->lh_entry->getIconPath(), '')->withSize(\ILIAS\UI\Component\Symbol\Icon\Icon::MEDIUM);
 
 		$obj_id = $this->lh_entry->getObjId();
 		$title = ilObject::_lookupTitle($obj_id);


### PR DESCRIPTION
The namespace changed recently, this PR will just fix the current call so the gui element won't throw an error.