### PR TITLE
#25480: withUnavailableAction for Pagination's Nav Controls

### DIFF
--- a/src/UI/Implementation/Component/ViewControl/Renderer.php
+++ b/src/UI/Implementation/Component/ViewControl/Renderer.php
@@ -328,12 +328,11 @@ class Renderer extends AbstractComponentRenderer
 			$forward = $f->symbol()->glyph()->next($url_next);
 		}
 
-		//2do: unavailable action for glyphs
 		if($component->getCurrentPage() === 0) {
-			//$back = $back->WithUnavailableAction();
+			$back = $back->withUnavailableAction();
 		}
 		if($component->getCurrentPage() >= $component->getNumberOfPages()-1) {
-			//$forward = $forward->WithUnavailableAction();
+			$forward = $forward->withUnavailableAction();
 		}
 
 		$tpl->setVariable('PREVIOUS', $default_renderer->render($back));

--- a/tests/UI/Component/ViewControl/PaginationTest.php
+++ b/tests/UI/Component/ViewControl/PaginationTest.php
@@ -83,11 +83,11 @@ class PaginationTest extends ILIAS_UI_TestBase {
 			->withPageSize(1);
 
 		//two entries, first one inactive
-		//rocker left disabled
+		//browse-left disabled
 		$expected_html = <<<EOT
 <div class="il-viewcontrol-pagination">
 	<span class="browse previous">
-		<a class="glyph" href="?pagination_offset=0" aria-label="back">
+		<a class="glyph disabled" aria-label="back" aria-disabled="true">
 			<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 		</a>
 	</span>
@@ -114,7 +114,7 @@ EOT;
 			->withCurrentPage(1);
 
 		//two entries, second one inactive
-		//rocker right disabled
+		//browse-right disabled
 		$expected_html = <<<EOT
 <div class="il-viewcontrol-pagination">
 	<span class="browse previous">
@@ -127,7 +127,7 @@ EOT;
 	<button class="btn btn-link ilSubmitInactive disabled" data-action="?pagination_offset=1">2</button>
 
 	<span class="browse next">
-		<a class="glyph" href="?pagination_offset=2" aria-label="next">
+		<a class="glyph disabled" aria-label="next" aria-disabled="true">
 			<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
 		</a>
 	</span>
@@ -145,12 +145,12 @@ EOT;
 			->withMaxPaginationButtons(1);
 
 		//one entry,
-		//rocker left disabled
+		//browse-left disabled
 		//boundary-button right
 		$expected_html = <<<EOT
 <div class="il-viewcontrol-pagination">
 	<span class="browse previous">
-		<a class="glyph" href="?pagination_offset=0" aria-label="back">
+		<a class="glyph disabled" aria-label="back" aria-disabled="true">
 			<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 		</a>
 	</span>
@@ -219,7 +219,7 @@ EOT;
 			->withCurrentPage(2);
 
 		//one entry,
-		//rocker right disabled
+		//browse-right disabled
 		//boundary-button left only
 		$expected_html = <<<EOT
 <div class="il-viewcontrol-pagination">
@@ -235,7 +235,7 @@ EOT;
 	<button class="btn btn-link ilSubmitInactive disabled" data-action="?pagination_offset=2">3</button>
 
 	<span class="browse next">
-		<a class="glyph" href="?pagination_offset=3" aria-label="next">
+		<a class="glyph disabled" aria-label="next" aria-disabled="true">
 			<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
 		</a>
 	</span>
@@ -256,7 +256,7 @@ EOT;
 		$expected_html = <<<EOT
 <div class="il-viewcontrol-pagination">
 	<span class="browse previous">
-		<a class="glyph" href="?pagination_offset=0" aria-label="back">
+		<a class="glyph disabled" aria-label="back" aria-disabled="true">
 			<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 		</a>
 	</span>


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=25480

It is currently possible to forward pagination beyond the last page index. 
This disables forward/backward controls if the result would be wrong.