### PR TITLE
Introduce `info.php` for Composer-Dependencies

### DIFF
--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -517,12 +517,29 @@ All the other files and directories should be owned by ```root```, but readable 
 It is highly RECOMMENDED to place your data directory outside of the web server docroot, as pointed out by the ILIAS Installation Wizard.
 
 <a name="secure-installation-files"></a>
-### Secure Installation Files
+### Secure Installation Files and Dependencies
 
 The access to the ILIAS Installation Wizard (```/setup/setup.php```) MAY be restricted:
 
 ```
 <Location /setup>
+  <IfVersion < 2.3>
+    Order Deny,Allow
+    Deny From All
+    Allow from 127.0.0.1
+  </IfVersion>
+
+  <IfVersion > 2.3>
+    Require all denied
+    Require ip 127.0.0.1
+  </IfVersion>
+</Location>
+```
+
+The access to the dependencies folder MAY be restricted:
+
+```
+<Location /libs>
   <IfVersion < 2.3>
     Order Deny,Allow
     Deny From All

--- a/libs/composer/info.php
+++ b/libs/composer/info.php
@@ -27,21 +27,23 @@ function vendor_hash() {
 	if(!file_exists(VENDOR_PATH)) {
 		return "vendor directory does not exist";
 	}
-	return hash_directory(HASH_ALGO, VENDOR_PATH);
+	return hash_directory(HASH_ALGO, VENDOR_PATH, [VENDOR_PATH."/autoload.php", VENDOR_PATH."/composer"]);
 }
 
-function hash_directory($algo, $path) {
+function hash_directory($algo, $path, $exclude = []) {
+	$content = scandir($path);
+	sort($content);
 	return hash(
 		HASH_ALGO,
 		implode(
 			"",
 			array_map(
-				function($o) use ($algo, $path) {
-					if ($o === "." || $o === "..") {
+				function($o) use ($algo, $path, $exclude) {
+					if ($o === "." || $o === ".." || $o === ".git") {
 						return "";
 					}
 					$o = "$path/$o";
-					if (is_link($o)) {
+					if (is_link($o) || in_array($o, $exclude)) {
 						return "";
 					}
 					if (is_dir($o)) {
@@ -49,7 +51,7 @@ function hash_directory($algo, $path) {
 					}
 					return hash_file($algo, $o);
 				},
-				scandir($path)
+				$content
 			)
 		)
 	);

--- a/libs/composer/info.php
+++ b/libs/composer/info.php
@@ -1,0 +1,56 @@
+<?php
+/* Copyright (c) 2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * This script can be used to quickly compare the state of the vendor directory
+ * with some reference. It simply outputs a hash of the composer lock and a
+ * combined hash of all files in vendor.
+ */
+
+define("HASH_ALGO", "sha1");
+define("COMPOSER_LOCK_PATH", __DIR__."/composer.lock");
+define("VENDOR_PATH", __DIR__."/vendor");
+
+header("Content-Type: text/plain");
+
+echo "composer.lock: ".composer_lock_hash()."\n";
+echo "vendor:        ".vendor_hash()."\n";
+
+function composer_lock_hash() {
+	if (!file_exists(COMPOSER_LOCK_PATH)) {
+		return "composer.lock does not exist";
+	}
+	return hash_file(HASH_ALGO, COMPOSER_LOCK_PATH);
+}
+
+function vendor_hash() {
+	if(!file_exists(VENDOR_PATH)) {
+		return "vendor directory does not exist";
+	}
+	return hash_directory(HASH_ALGO, VENDOR_PATH);
+}
+
+function hash_directory($algo, $path) {
+	return hash(
+		HASH_ALGO,
+		implode(
+			"",
+			array_map(
+				function($o) use ($algo, $path) {
+					if ($o === "." || $o === "..") {
+						return "";
+					}
+					$o = "$path/$o";
+					if (is_link($o)) {
+						return "";
+					}
+					if (is_dir($o)) {
+						return hash_directory($algo, $o);
+					}
+					return hash_file($algo, $o);
+				},
+				scandir($path)
+			)
+		)
+	);
+}


### PR DESCRIPTION
This is a follow up for #1833. It adds the following changes:

* An `info.php` in `libs\composer` that calculates a hash over the composer.lock and the vendor directory. This can be used to quickly check if some installation has the correct composer-dependencies.
* An addition to the installation guide that advises people to close `libs/composer` for internet access, which imo is a good advise anyway.

On the current branch (klees/trunk_check_vendor), the algorithm calculates this:

* **composer.lock:** cf0639a636b395d7a5e22ea0d164d63ed2aaab21
* **vendor:** 4666fb4f2bfe5f86ad0c57eb770fed1c397db6f4

Maybe someone could crosscheck this on her own machine, this would be even better if this was a windows machine or some linux (I am Mac OS, currently).