### PR TITLE
Excel: Added method to merge cells of the passed coordinates

### DIFF
--- a/Services/Excel/classes/class.ilExcel.php
+++ b/Services/Excel/classes/class.ilExcel.php
@@ -619,11 +619,11 @@ class ilExcel
 	}
 
 	/**
-	 * @param string $coordinates A coordinates string like 'A1:B5'
+	 * @param string $coordinatesRange A coordinates range string like 'A1:B5'
 	 * @throws \PhpOffice\PhpSpreadsheet\Exception
 	 */
-	public function mergeCells(string $coordinates) : void
+	public function mergeCells(string $coordinatesRange) : void
 	{
-		$this->workbook->getActiveSheet()->mergeCells($coordinates);
+		$this->workbook->getActiveSheet()->mergeCells($coordinatesRange);
 	}
 }

--- a/Services/Excel/classes/class.ilExcel.php
+++ b/Services/Excel/classes/class.ilExcel.php
@@ -619,7 +619,7 @@ class ilExcel
 	}
 
 	/**
-	 * @param string $coordinates
+	 * @param string $coordinates A coordinates string like 'A1:B5'
 	 * @throws \PhpOffice\PhpSpreadsheet\Exception
 	 */
 	public function mergeCells(string $coordinates) : void

--- a/Services/Excel/classes/class.ilExcel.php
+++ b/Services/Excel/classes/class.ilExcel.php
@@ -618,4 +618,12 @@ class ilExcel
 		return $column++;
 	}
 
+	/**
+	 * @param string $coordinates
+	 * @throws \PhpOffice\PhpSpreadsheet\Exception
+	 */
+	public function mergeCells(string $coordinates) : void
+	{
+		$this->workbook->getActiveSheet()->mergeCells($coordinates);
+	}
 }


### PR DESCRIPTION
This PR adds a new method to the public API of the ILIAS `Excel` writer. I did not find any equivalent method in the current code base and I sometimes need to merge cells in Excel exports of our plugins.