### PR TITLE
Init: Use URI data type to set global ILIAS_HTTP_PATH constant

### DIFF
--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -354,12 +354,16 @@ class ilInitialisation
 				$uri = dirname($uri);
 			}
 		}
-		if(ilContext::getType() == ilContext::CONTEXT_APACHE_SSO)
-		{
-			return define('ILIAS_HTTP_PATH',ilUtil::removeTrailingPathSeparators(dirname($protocol.$host.$uri)));
 
+		$iliasHttpPath = implode('', [$protocol, $host, $uri]);
+		if (ilContext::getType() == ilContext::CONTEXT_APACHE_SSO) {
+			$iliasHttpPath = dirname($iliasHttpPath);
 		}
-		return define('ILIAS_HTTP_PATH',ilUtil::removeTrailingPathSeparators($protocol.$host.$uri));
+
+		$f = new \ILIAS\Data\Factory();
+		$uri = $f->uri(ilUtil::removeTrailingPathSeparators($iliasHttpPath));
+
+		return define('ILIAS_HTTP_PATH', $uri->getBaseURI());
 	}
 
 	/**


### PR DESCRIPTION
This PR adds the usage of the `URI` data type to the end of the `ILIAS_HTTP_PATH` build process.

I suggest to merge this ASAP to the `trunk` to gather some experience with the myriad different ILIAS requests. If we do not notice any issues we SHOULD merge this to all stable branches.

If the passed string contains ill-formatted segments when creating the `URI` instance, the raised exception results in a `Whoops` page (which should be okay for unexpected request URIs :smile:).

Feedback is highly appreciated.