### PR TITLE
 [Certificates] Set default option to cron for certificates

### DIFF
--- a/Services/Certificate/classes/class.ilCertificateAppEventListener.php
+++ b/Services/Certificate/classes/class.ilCertificateAppEventListener.php
@@ -390,7 +390,7 @@ class ilCertificateAppEventListener implements ilAppEventListener
             time()
         );
 
-        $mode = $settings->get('persistent_certificate_mode', '');
+        $mode = $settings->get('persistent_certificate_mode', 'persistent_certificate_mode_cron');
         if ($mode === 'persistent_certificate_mode_instant') {
             $cronjob = new ilCertificateCron();
             $cronjob->init();

--- a/Services/Certificate/classes/class.ilCertificateCron.php
+++ b/Services/Certificate/classes/class.ilCertificateCron.php
@@ -143,12 +143,10 @@ class ilCertificateCron extends \ilCronJob
     {
         $this->init();
 
-        $this->init();
-
         $result = new ilCronJobResult();
         $result->setStatus(ilCronJobResult::STATUS_NO_ACTION);
 
-        $currentMode = $this->settings->get('persistent_certificate_mode', 'persistent_certificate_mode_instant');
+        $currentMode = $this->settings->get('persistent_certificate_mode', 'persistent_certificate_mode_cron');
         if ($currentMode !== 'persistent_certificate_mode_cron') {
             $this->logger->warning(sprintf('Will not start cron job, because the mode is not set as cron job. Current Mode in settings: "%s"',
                 $currentMode));

--- a/Services/Certificate/classes/class.ilObjCertificateSettingsGUI.php
+++ b/Services/Certificate/classes/class.ilObjCertificateSettingsGUI.php
@@ -230,7 +230,7 @@ class ilObjCertificateSettingsGUI extends ilObjectGUI
         $form_settings = new ilSetting("certificate");
 
         $mode = $_POST["persistent_certificate_mode"];
-        $previousMode = $form_settings->get('persistent_certificate_mode', 'persistent_certificate_mode_instant');
+        $previousMode = $form_settings->get('persistent_certificate_mode', 'persistent_certificate_mode_cron');
         if ($mode !== $previousMode && $mode === 'persistent_certificate_mode_instant') {
             $cron = new ilCertificateCron();
             $cron->init();


### PR DESCRIPTION
There was difference between options, when you never saved the form of general certificate settings and came from an old system.

This led to a confusing behavior, that a certificate queue entry was generated but the cron could never be executed.

This PR will fix this behavior. 