### PR TITLE
Fix/23384/5 4/delete trash survey

### DIFF
--- a/Modules/Survey/classes/class.ilObjSurvey.php
+++ b/Modules/Survey/classes/class.ilObjSurvey.php
@@ -384,7 +384,7 @@ class ilObjSurvey extends ilObject
 			array('integer'),
 			array($this->getSurveyId())
 		);
-		$this->deleteAllUserData();
+		$this->deleteAllUserData(false);
 
 		$affectedRows = $ilDB->manipulateF("DELETE FROM svy_anonymous WHERE survey_fi = %s",
 			array('integer'),
@@ -412,13 +412,14 @@ class ilObjSurvey extends ilObject
 			$mob_obj->delete();
 		}
 	}
-	
+
 	/**
-	* Deletes all user data of a survey
-	* 
-	* @access	public
-	*/
-	function deleteAllUserData()
+	 * Deletes all user data of a survey
+	 *
+	 * @access    public
+	 * @param bool $reset_LP	notice that the LP can only be reset it the determining components still exist
+	 */
+	function deleteAllUserData($reset_LP = true)
 	{
 		$ilDB = $this->db;
 		
@@ -447,6 +448,12 @@ class ilObjSurvey extends ilObject
 				array('integer'),
 				array($active_fi)
 			);
+		}
+
+		if ($reset_LP) {
+			include_once "Services/Object/classes/class.ilObjectLP.php";
+			$lp_obj = ilObjectLP::getInstance($this->getId());
+			$lp_obj->resetLPDataForCompleteObject();
 		}
 	}
 	

--- a/Modules/Survey/classes/class.ilObjSurvey.php
+++ b/Modules/Survey/classes/class.ilObjSurvey.php
@@ -448,10 +448,6 @@ class ilObjSurvey extends ilObject
 				array($active_fi)
 			);
 		}
-		
-		include_once "Services/Object/classes/class.ilObjectLP.php";
-		$lp_obj = ilObjectLP::getInstance($this->getId());
-		$lp_obj->resetLPDataForCompleteObject();
 	}
 	
 	/**


### PR DESCRIPTION
This should fix https://mantis.ilias.de/view.php?id=23384

The problem is, when deleting a survey from the trash, it tries to 'resetLPDataForCompleteObject', which doesn't delete the LP Status but resets it and determines the new status. But the new status cannot be determined, since the important parts of the survey have already been deleted (thus the error message " 'status' cannot be null ").

Also, it is not necessary for an object to delete the learning progress, since the Tracking Service's EventHandler handles it: https://github.com/ILIAS-eLearning/ILIAS/blob/release_5-4/Services/Tracking/classes/class.ilTrackingAppEventListener.php#L38