### PR TITLE
Fix for upcoming composer version

### DIFF
--- a/libs/composer/composer.json
+++ b/libs/composer/composer.json
@@ -10,7 +10,7 @@
 		"cweagans/composer-patches": "~1.0",
 		"filp/whoops": "^2.1.13",
 		"monolog/monolog": "^1.23.0",
-		"technosophos/LibRIS": "^2.0.2",
+		"technosophos/libris": "^2.0.2",
 		"ezyang/htmlpurifier": "4.10.0",
 		"phpmailer/phpmailer": "^6.0.6",
 		"geshi/geshi": "dev-master#5861c58981244ab6ee0dd337f096ff14bf15b1eb",
@@ -31,7 +31,7 @@
 		"slim/slim": "^3.11"
 	},
 	"require-dev": {
-		"mikey179/vfsStream": "^1.6",
+		"mikey179/vfsstream": "^1.6",
 		"phpunit/phpunit": "^8.0",
 		"phpunit/php-code-coverage": "^7.0",
 		"mockery/mockery": "^1.2",
@@ -54,7 +54,7 @@
 			"approved-by": "Jour Fixe",
 			"approved-date": "YYYY-MM-DD"
 		},
-		"technosophos/LibRIS" : {
+		"technosophos/libris" : {
 			"source" : "github.com/filp/whoops",
 			"used_version" : "v2.0.2",
 			"wrapped_by" : "Modules/Bibliographic/classes/Types/Ris/class.ilRisWrapper.php",
@@ -156,7 +156,7 @@
 			"approved-by": "Jour Fixe",
 			"approved-date": "YYYY-MM-DD"
 		},
-		"mikey179/vfsStream" : {
+		"mikey179/vfsstream" : {
 			"source": "https://github.com/mikey179/vfsStream",
 			"used_version": "v1.6.4",
 			"added_by": "Michael Jansen <mjansen@databay.de>",


### PR DESCRIPTION
Using the current version of composer `Composer version 1.8.5 2019-04-09 17:46:47
` you will receive the following warning:

```
Deprecation warning: require.technosophos/LibRIS is invalid, it should not contain uppercase characters. Please use technosophos/libris instead. Make sure you fix this as Composer 2.0 will error.
Deprecation warning: require-dev.mikey179/vfsStream is invalid, it should not contain uppercase characters. Please use mikey179/vfsstream instead. Make sure you fix this as Composer 2.0 will error.
```
So uppercase won't be supported in the future.
