### PR TITLE
Secondary panels with footer

### DIFF
--- a/Modules/Blog/classes/class.ilObjBlogGUI.php
+++ b/Modules/Blog/classes/class.ilObjBlogGUI.php
@@ -2495,12 +2495,14 @@ class ilObjBlogGUI extends ilObject2GUI implements ilDesktopItemHandling
 				$title = $block[0];
 
 				$content = $block[1];
-				if(isset($block[2]) && is_array($block[2]))
-				{
-					$content .= "<a href='".$block[2][0]."'>".$block[2][1]."</a>";
-				}
 
 				$secondary_panel = $ui_factory->panel()->secondary()->legacy($title, $ui_factory->legacy($content));
+
+				if(isset($block[2]) && is_array($block[2]))
+				{
+					$link = $ui_factory->link()->standard($block[2][1], $block[2][0]);
+					$secondary_panel = $secondary_panel->withFooter($link);
+				}
 
 				$wtpl->setCurrentBlock("block_bl");
 				$wtpl->setVariable("BLOCK", $ui_renderer->render($secondary_panel));

--- a/Modules/Blog/classes/class.ilObjBlogGUI.php
+++ b/Modules/Blog/classes/class.ilObjBlogGUI.php
@@ -2500,7 +2500,7 @@ class ilObjBlogGUI extends ilObject2GUI implements ilDesktopItemHandling
 
 				if(isset($block[2]) && is_array($block[2]))
 				{
-					$link = $ui_factory->link()->standard($block[2][1], $block[2][0]);
+					$link = $ui_factory->button()->shy($block[2][1], $block[2][0]);
 					$secondary_panel = $secondary_panel->withFooter($link);
 				}
 

--- a/Services/Excel/classes/class.ilExcel.php
+++ b/Services/Excel/classes/class.ilExcel.php
@@ -589,7 +589,7 @@ class ilExcel
 	 * @param int $pRow
 	 * @return string
 	 */
-	function getCoordByColumnAndRow($pColumn = 1, $pRow = 1)
+	function getCoordByColumnAndRow($pColumn = 0, $pRow = 1)
 	{
 		$col = $this->columnIndexAdjustment($pColumn);
 		$columnLetter = Coordinate::stringFromColumnIndex($col);

--- a/Services/Excel/classes/class.ilExcel.php
+++ b/Services/Excel/classes/class.ilExcel.php
@@ -589,7 +589,7 @@ class ilExcel
 	 * @param int $pRow
 	 * @return string
 	 */
-	function getCoordByColumnAndRow($pColumn = 0, $pRow = 1)
+	function getCoordByColumnAndRow($pColumn = 1, $pRow = 1)
 	{
 		$col = $this->columnIndexAdjustment($pColumn);
 		$columnLetter = Coordinate::stringFromColumnIndex($col);

--- a/src/UI/Component/Panel/Secondary/Factory.php
+++ b/src/UI/Component/Panel/Secondary/Factory.php
@@ -35,10 +35,13 @@ interface Factory {
 	 *   purpose: >
 	 *      Secondary Legacy Panel present content from a Legacy component.
 	 *   composition: >
-	 *      Secondary Legacy Panel is composed of title and a Legacy component.
+	 *      The Secondary Legacy Panel is composed of title and a Legacy component. Additionally, it
+	 *      may have an optional footer area containing a Shy Button.
 	 *
 	 * context:
 	 *   - Marginal Grid Calendar.
+	 *   - Marginal Blog section.
+	 *   - Marginal Poll section.
 	 *
 	 * ---
 	 * @param string $title

--- a/src/UI/Component/Panel/Secondary/Secondary.php
+++ b/src/UI/Component/Panel/Secondary/Secondary.php
@@ -26,4 +26,17 @@ interface Secondary extends C\Component
 	 */
 	public function getViewControls(): ?array;
 
+	/**
+	 * Sets a Component being displayed below the content
+	 * @param \ILIAS\UI\Component\Component $component
+	 * @return \ILIAS\UI\Component\Panel\Secondary\Secondary
+	 */
+	public function withFooter(C\Component $component) : Secondary;
+
+	/**
+	 * Gets the Component being displayed below the content
+	 * @return \ILIAS\UI\Component\Component | null
+	 */
+	public function getFooter() : ?C\Component;
+
 }

--- a/src/UI/Component/Panel/Secondary/Secondary.php
+++ b/src/UI/Component/Panel/Secondary/Secondary.php
@@ -28,15 +28,15 @@ interface Secondary extends C\Component
 
 	/**
 	 * Sets a Component being displayed below the content
-	 * @param \ILIAS\UI\Component\Component $component
+	 * @param \ILIAS\UI\Component\Button\Shy $component
 	 * @return \ILIAS\UI\Component\Panel\Secondary\Secondary
 	 */
-	public function withFooter(C\Component $component) : Secondary;
+	public function withFooter(C\Button\Shy $component) : Secondary;
 
 	/**
 	 * Gets the Component being displayed below the content
-	 * @return \ILIAS\UI\Component\Component | null
+	 * @return \ILIAS\UI\Component\Button\Shy | null
 	 */
-	public function getFooter() : ?C\Component;
+	public function getFooter() : ?C\Button\Shy;
 
 }

--- a/src/UI/Implementation/Component/Panel/Secondary/Renderer.php
+++ b/src/UI/Implementation/Component/Panel/Secondary/Renderer.php
@@ -95,6 +95,13 @@ class Renderer extends AbstractComponentRenderer
 
 		$tpl->setVariable("BODY_LEGACY", $default_renderer->render($component->getLegacyComponent()));
 
+		$footer = $component->getFooter();
+		if($footer) {
+			$tpl->setCurrentBlock("footer");
+			$tpl->setVariable("FOOTER", $default_renderer->render($footer));
+			$tpl->parseCurrentBlock();
+		}
+
 		return $tpl->get();
 	}
 

--- a/src/UI/Implementation/Component/Panel/Secondary/Secondary.php
+++ b/src/UI/Implementation/Component/Panel/Secondary/Secondary.php
@@ -88,7 +88,7 @@ abstract class Secondary implements C\Panel\Secondary\Secondary
 	/**
 	 * @inheritdoc
 	 */
-	public function withFooter(C\Component $component) : C\Panel\Secondary\Secondary
+	public function withFooter(C\Button\Shy $component) : C\Panel\Secondary\Secondary
 	{
 		$clone = clone $this;
 		$clone->footer_component = $component;
@@ -98,7 +98,7 @@ abstract class Secondary implements C\Panel\Secondary\Secondary
 	/**
 	 * @inheritdoc
 	 */
-	public function getFooter(): ?C\Component
+	public function getFooter(): ?C\Button\Shy
 	{
 		return $this->footer_component;
 	}

--- a/src/UI/Implementation/Component/Panel/Secondary/Secondary.php
+++ b/src/UI/Implementation/Component/Panel/Secondary/Secondary.php
@@ -31,7 +31,7 @@ abstract class Secondary implements C\Panel\Secondary\Secondary
 	protected $view_controls;
 
 	/**
-	 * @var null \ILIAS\UI\Component\Component
+	 * @var null|\ILIAS\UI\Component\Button\Shy
 	 */
 	protected $footer_component = null;
 

--- a/src/UI/Implementation/Component/Panel/Secondary/Secondary.php
+++ b/src/UI/Implementation/Component/Panel/Secondary/Secondary.php
@@ -31,6 +31,11 @@ abstract class Secondary implements C\Panel\Secondary\Secondary
 	protected $view_controls;
 
 	/**
+	 * @var null \ILIAS\UI\Component\Component
+	 */
+	protected $footer_component = null;
+
+	/**
 	 * Gets the secondary panel title
 	 *
 	 * @return string
@@ -78,6 +83,24 @@ abstract class Secondary implements C\Panel\Secondary\Secondary
 	public function getViewControls(): ?array
 	{
 		return $this->view_controls;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function withFooter(C\Component $component) : C\Panel\Secondary\Secondary
+	{
+		$clone = clone $this;
+		$clone->footer_component = $component;
+		return $clone;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getFooter(): ?C\Component
+	{
+		return $this->footer_component;
 	}
 }
 ?>

--- a/src/UI/examples/Panel/Secondary/Legacy/with_footer.php
+++ b/src/UI/examples/Panel/Secondary/Legacy/with_footer.php
@@ -15,7 +15,7 @@ function with_footer()
 	}
 
 	$legacy = $factory->legacy($html);
-	$link = $factory->link()->standard("Edit Keywords", "");
+	$link = $factory->button()->Shy("Edit Keywords", "");
 
 	$panel = $factory->panel()->secondary()->legacy("panel title", $legacy)->withFooter($link);
 

--- a/src/UI/examples/Panel/Secondary/Legacy/with_footer.php
+++ b/src/UI/examples/Panel/Secondary/Legacy/with_footer.php
@@ -1,0 +1,23 @@
+<?php
+
+function with_footer()
+{
+	global $DIC;
+
+	$factory = $DIC->ui()->factory();
+	$renderer = $DIC->ui()->renderer();
+
+	$tags = ["PHP", "ILIAS", "Sofware", "SOLID", "Domain Driven"];
+
+	$html = "";
+	foreach ($tags as $tag) {
+		$html .= $renderer->render($factory->button()->tag($tag, ""));
+	}
+
+	$legacy = $factory->legacy($html);
+	$link = $factory->link()->standard("Edit Keywords", "");
+
+	$panel = $factory->panel()->secondary()->legacy("panel title", $legacy)->withFooter($link);
+
+	return $renderer->render($panel);
+}

--- a/src/UI/templates/default/Panel/tpl.secondary.html
+++ b/src/UI/templates/default/Panel/tpl.secondary.html
@@ -13,4 +13,9 @@
 		<!-- END group -->
 		{BODY_LEGACY}
 	</div>
+	<!-- BEGIN footer -->
+	<div class="panel-footer ilBlockInfo">
+		{FOOTER}
+	</div>
+	<!-- END footer -->
 </div>

--- a/tests/UI/Component/Panel/PanelSecondaryLegacyTest.php
+++ b/tests/UI/Component/Panel/PanelSecondaryLegacyTest.php
@@ -298,4 +298,32 @@ EOT;
 
 	}
 
+	public function test_render_with_footer() {
+		$legacy = $this->getUIFactory()->legacy("Legacy content");
+
+		$secondary_panel = $this->getUIFactory()->legacyPanel("Title", $legacy)
+			->withFooter($legacy);
+
+		$html = $this->getDefaultRenderer()->render($secondary_panel);
+
+		$expected_html = <<<EOT
+<div class="panel panel-secondary">
+	<div class="panel-heading ilHeader clearfix">
+		<h3 class="ilHeader panel-secondary-title">Title</h3>
+	</div>
+	<div class="panel-body">
+		Legacy content
+	</div>
+	<div class="panel-footer ilBlockInfo">
+		Legacy content
+	</div>
+</div>
+EOT;
+		$this->assertHTMLEquals(
+			$this->cleanHTML($expected_html),
+			$this->cleanHTML($html)
+		);
+
+	}
+
 }

--- a/tests/UI/Component/Panel/PanelSecondaryLegacyTest.php
+++ b/tests/UI/Component/Panel/PanelSecondaryLegacyTest.php
@@ -300,9 +300,10 @@ EOT;
 
 	public function test_render_with_footer() {
 		$legacy = $this->getUIFactory()->legacy("Legacy content");
+		$footer_shy_button = $this->getUIFactory()->button()->shy("Action","");
 
 		$secondary_panel = $this->getUIFactory()->legacyPanel("Title", $legacy)
-			->withFooter($legacy);
+			->withFooter($footer_shy_button);
 
 		$html = $this->getDefaultRenderer()->render($secondary_panel);
 
@@ -315,7 +316,7 @@ EOT;
 		Legacy content
 	</div>
 	<div class="panel-footer ilBlockInfo">
-		Legacy content
+		<button class="btn btn-link" data-action="">Action</button>
 	</div>
 </div>
 EOT;


### PR DESCRIPTION
Secondary panels do not have the "footer" space like the old side blocks, therefore some actions/features are not available in the new implementation.
When I was migrating old blocks to panels I wrote some code to test functionalities (e.g. edit keywords when editing a blog post) I decided to polish the code and create this Draft to continue the discussion.

Blocks using footers:
- Poll (comments)
- Calendar (iCal)
- Blog (Edit Keywords)
...

Here a few questions/thoughts:
- Should we put this one step up and allow footers in other panels?
- Where will be these actions located? footers, action buttons ... Do we need these actions at all?
- In this PR, Footers accept only one UI Component. It can be changed to an array of components if necessary.

![old_blocks](https://user-images.githubusercontent.com/588312/59112660-bee4f180-8943-11e9-9be3-6fd70afc9446.png)

![new_panels](https://user-images.githubusercontent.com/588312/59112643-b5f42000-8943-11e9-9464-89ce98679ffb.png)

Edit: More screenshots about former blocks.

![side_calendar_ical](https://user-images.githubusercontent.com/588312/60432663-1f91e200-9c03-11e9-803a-63ec85201389.png)

![side_poll](https://user-images.githubusercontent.com/588312/60432668-24569600-9c03-11e9-91eb-0db58a5401c3.png)

