### PR TITLE
fixed login max length

### DIFF
--- a/Services/Form/classes/class.ilUserLoginInputGUI.php
+++ b/Services/Form/classes/class.ilUserLoginInputGUI.php
@@ -150,7 +150,7 @@ class ilUserLoginInputGUI extends ilFormPropertyGUI
 		$a_tpl->setVariable("ID", $this->getFieldId());
 		$a_tpl->setVariable("PROPERTY_VALUE", ilUtil::prepareFormOutput($this->getValue()));
 		$a_tpl->setVariable("SIZE", $this->size);
-		$a_tpl->setVariable("MAXLENGTH", $this->maxlength);
+		$a_tpl->setVariable("MAXLENGTH", $this->max_length);
 		if ($this->getDisabled())
 		{
 			$a_tpl->setVariable("DISABLED",


### PR DESCRIPTION
For ilUserLoginInputGUI is a default max length set of 80 chars. This was never applied due to an typo in the responsible function.

https://mantis.ilias.de/view.php?id=25584