### PR TITLE
Don't save default image path on certificate template save. To avoid empty exports and similiar issues

### DIFF
--- a/Services/Certificate/classes/Template/Action/Export/class.ilCertificateTemplateExportAction.php
+++ b/Services/Certificate/classes/Template/Action/Export/class.ilCertificateTemplateExportAction.php
@@ -97,21 +97,15 @@ class ilCertificateTemplateExportAction
 
         $backgroundImagePath = $template->getBackgroundImagePath();
         if ($backgroundImagePath !== null && $backgroundImagePath !== '') {
-            try {
+            if (true === $this->filesystem->has($backgroundImagePath)) {
                 $this->filesystem->copy($backgroundImagePath, $exportPath . 'background.jpg');
-            } catch (\ILIAS\Filesystem\Exception\FileAlreadyExistsException $e) {
-            } catch (\ILIAS\Filesystem\Exception\FileNotFoundException $e) {
-            } catch (\ILIAS\Filesystem\Exception\IOException $e) {
             }
         }
 
         $thumbnailImagePath = $template->getThumbnailImagePath();
         if ($thumbnailImagePath !== null && $thumbnailImagePath !== '') {
-            try {
+            if (true === $this->filesystem->has($backgroundImagePath)) {
                 $this->filesystem->copy($thumbnailImagePath, $exportPath . 'thumbnail.svg');
-            } catch (\ILIAS\Filesystem\Exception\FileAlreadyExistsException $e) {
-            } catch (\ILIAS\Filesystem\Exception\FileNotFoundException $e) {
-            } catch (\ILIAS\Filesystem\Exception\IOException $e) {
             }
         }
 

--- a/Services/Certificate/classes/Template/Action/Export/class.ilCertificateTemplateExportAction.php
+++ b/Services/Certificate/classes/Template/Action/Export/class.ilCertificateTemplateExportAction.php
@@ -97,19 +97,27 @@ class ilCertificateTemplateExportAction
 
         $backgroundImagePath = $template->getBackgroundImagePath();
         if ($backgroundImagePath !== null && $backgroundImagePath !== '') {
-            $this->filesystem->copy($backgroundImagePath, $exportPath . 'background.jpg');
+            try {
+                $this->filesystem->copy($backgroundImagePath, $exportPath . 'background.jpg');
+            } catch (\ILIAS\Filesystem\Exception\FileAlreadyExistsException $e) {
+            } catch (\ILIAS\Filesystem\Exception\FileNotFoundException $e) {
+            } catch (\ILIAS\Filesystem\Exception\IOException $e) {
+            }
         }
 
         $thumbnailImagePath = $template->getThumbnailImagePath();
         if ($thumbnailImagePath !== null && $thumbnailImagePath !== '') {
-            $this->filesystem->copy($thumbnailImagePath, $exportPath . 'thumbnail.svg');
+            try {
+                $this->filesystem->copy($thumbnailImagePath, $exportPath . 'thumbnail.svg');
+            } catch (\ILIAS\Filesystem\Exception\FileAlreadyExistsException $e) {
+            } catch (\ILIAS\Filesystem\Exception\FileNotFoundException $e) {
+            } catch (\ILIAS\Filesystem\Exception\IOException $e) {
+            }
         }
-
 
         $objectType = $this->objectHelper->lookupType($this->objectId);
 
         $zipFileName = $time . '__' . $installationId . '__' . $objectType . '__' . $this->objectId . '__certificate.zip';
-
 
         $zipPath = $rootDir . $this->certificatePath . $zipFileName;
         $this->utilHelper->zip($exportPath, $zipPath);

--- a/Services/Certificate/classes/class.ilCertificateGUI.php
+++ b/Services/Certificate/classes/class.ilCertificateGUI.php
@@ -542,7 +542,7 @@ class ilCertificateGUI
 
                 $backgroundImagePath = $previousCertificateTemplate->getBackgroundImagePath();
 
-                if ($backgroundImagePath === '' && $backgroundImagePath !== null) {
+                if ($backgroundImagePath === '') {
                     $globalRelativeBackgroundImagePath = ilObjCertificateSettingsAccess::getBackgroundImagePath(true);
                     $globalRelativeBackgroundImagePath = str_replace('[CLIENT_WEB_DIR]', '', $globalRelativeBackgroundImagePath);
                     $backgroundImagePath = $globalRelativeBackgroundImagePath;

--- a/Services/Certificate/classes/class.ilCertificateGUI.php
+++ b/Services/Certificate/classes/class.ilCertificateGUI.php
@@ -34,6 +34,11 @@ include_once("./Services/Certificate/classes/class.ilCertificate.php");
 class ilCertificateGUI
 {
     /**
+     * @var \ILIAS\Filesystem\Filesystem
+     */
+    private $fileSystem;
+
+    /**
      * ilCertificate object reference
      * @var ilCertificate
      */
@@ -207,7 +212,8 @@ class ilCertificateGUI
         ilCertificateBackgroundImageUpload $upload = null,
         ilCertificateTemplatePreviewAction $previewAction = null,
         \ILIAS\FileUpload\FileUpload $fileUpload = null,
-        ilSetting $settings = null
+        ilSetting $settings = null,
+        \ILIAS\Filesystem\Filesystem $fileSystem = null
     ) {
         global $DIC;
 
@@ -319,6 +325,11 @@ class ilCertificateGUI
             $settings = new ilSetting('certificate');
         }
         $this->settings = $settings;
+
+        if (null === $fileSystem) {
+            $fileSystem = $DIC->filesystem()->web();
+        }
+        $this->fileSystem = $fileSystem;
     }
 
     /**
@@ -537,7 +548,7 @@ class ilCertificateGUI
                     $backgroundImagePath = $globalRelativeBackgroundImagePath;
                 }
 
-                if (!file_exists(CLIENT_WEB_DIR . $backgroundImagePath)) {
+                if (false === $this->fileSystem->has($backgroundImagePath)) {
                     $backgroundImagePath = '';
                 }
 

--- a/Services/Certificate/classes/class.ilCertificateGUI.php
+++ b/Services/Certificate/classes/class.ilCertificateGUI.php
@@ -532,8 +532,13 @@ class ilCertificateGUI
                 $backgroundImagePath = $previousCertificateTemplate->getBackgroundImagePath();
 
                 if ($backgroundImagePath === '' && $backgroundImagePath !== null) {
-                    $backgroundImagePath = ilObjCertificateSettingsAccess::getBackgroundImagePath(true);
-                    $backgroundImagePath = str_replace('[CLIENT_WEB_DIR]', '', $backgroundImagePath);
+                    $globalRelativeBackgroundImagePath = ilObjCertificateSettingsAccess::getBackgroundImagePath(true);
+                    $globalRelativeBackgroundImagePath = str_replace('[CLIENT_WEB_DIR]', '', $globalRelativeBackgroundImagePath);
+                    $backgroundImagePath = $globalRelativeBackgroundImagePath;
+                }
+
+                if (!file_exists(CLIENT_WEB_DIR . $backgroundImagePath)) {
+                    $backgroundImagePath = '';
                 }
 
                 $cardThumbnailImagePath = $previousCertificateTemplate->getThumbnailImagePath();


### PR DESCRIPTION
Mantis: https://mantis.ilias.de/view.php?id=24731

This PR sets the background image path to an empty string if no file. could by found on the file system.
The exception occurred, because the origin code base didn't care at all, if a background image existed or not. Because we now use the filesystem component of the `src` libraries, this issue came up for the first time.
This was probably a issue in previous versions too, but didn't have such an impact.