### PR TITLE
25635: Check TinyMCE contextmenu plugin is loaded

### DIFF
--- a/Services/RTE/templates/default/tpl.usereditor.html
+++ b/Services/RTE/templates/default/tpl.usereditor.html
@@ -5,7 +5,7 @@
 	function ilTinyMceInitCallback(ed) {
 		// Add hook for onContextMenu so that Insert Image can be removed
 		<!-- BEGIN remove_img_context_menu_item -->
-		ed.plugins.contextmenu.onContextMenu.add(function(sender, menu) {
+		if (ed.plugins.contextmenu) ed.plugins.contextmenu.onContextMenu.add(function(sender, menu) {
 			// create a new object
 			var otherItems = {};
 			var lastItem = null;


### PR DESCRIPTION
before attempting to modify it

Just a proposal as the code modifying the context menu might be removed altogether from tpl.usereditor.html. Also not sure about the truthy test (or better compare to undefined) and the missing curly braces. Please advice if comfortable.