### PR TITLE
[Setup] Message hint that composers autoloader is missing in the setup an needs to run 'composer install' first

### DIFF
--- a/setup/setup.php
+++ b/setup/setup.php
@@ -34,7 +34,7 @@
  * @package ilias-setup
  */
 if (false === file_exists(__DIR__ . '/../libs/composer/vendor/autoload.php')) {
-	echo'Could not find composers "autoload.php". Try to run "composer install" in the directory ".libs/composer"';
+	echo 'Could not find composers "autoload.php". Try to run "composer install" in the directory ".libs/composer"';
 	exit;
 }
 

--- a/setup/setup.php
+++ b/setup/setup.php
@@ -33,6 +33,10 @@
  *
  * @package ilias-setup
  */
+if (false === file_exists(__DIR__ . '/../libs/composer/vendor/autoload.php')) {
+	echo'Could not find composers "autoload.php". Try to run "composer install" in the directory ".libs/composer"';
+	exit;
+}
 
 if (ini_get('session.save_handler') != 'files') {
 	throw new Exception("session.save_handler in php.ini must be configured to 'files'.");


### PR DESCRIPTION
Because I crossed this "little" issue several times now, I wanted to suggest a little change.

The composer vendor directory were deleted from the source code via #1833 (Which was absolutely necessary!).
Because of this, you land on a **blank** setup page on installing ILIAS initially. Currently I have the problem to identify the problem on installing a new ILIAS, because I may check first the symbolic link or the user rights on the folders etc. .

So I just added an simple `echo` if the `vendor/autoload.php` is missing and echo the solution on the browser.

Feel free to give me feedback on this :+1: 