### PR TITLE
Instad of raise an error on multiple calls of the migration method, return an empty string instead

### DIFF
--- a/Services/Certificate/classes/class.ilCertificateMigrationGUI.php
+++ b/Services/Certificate/classes/class.ilCertificateMigrationGUI.php
@@ -10,6 +10,9 @@
  */
 class ilCertificateMigrationGUI
 {
+	/** @var ilLogger|null */
+	private $logger;
+
 	/** @var \ilCtrl|null */
 	protected $ctrl;
 
@@ -48,6 +51,7 @@ class ilCertificateMigrationGUI
 	 * @param ilSetting|null                       $certificateSettings
 	 * @param ilCertificateMigrationValidator|null $migrationValidator
 	 * @param ilErrorHandling|null                 $errorHandler
+	 * @param ilLog|null                           $logger
 	 */
 	public function __construct(
 		\ilCtrl $ctrl = null,
@@ -58,7 +62,8 @@ class ilCertificateMigrationGUI
 		\ilLearningHistoryService $learningHistoryService = null,
 		\ilSetting $certificateSettings = null,
 		\ilCertificateMigrationValidator $migrationValidator = null,
-		\ilErrorHandling $errorHandler = null
+		\ilErrorHandling $errorHandler = null,
+        \ilLog $logger = null
 	) {
 		global $DIC;
 
@@ -94,6 +99,11 @@ class ilCertificateMigrationGUI
 			$errorHandler = $DIC['ilErr'];
 		}
 		$this->errorHandler = $errorHandler;
+
+		if (null === $logger) {
+			$logger = $DIC->logger()->cert();
+		}
+		$this->logger = $logger;
 
 		$this->ctrl = $ctrl;
 		$lng->loadLanguageModule('cert');
@@ -144,6 +154,7 @@ class ilCertificateMigrationGUI
 			$this->user, new \ilCertificateMigration($this->user->getId())
 		);
 		if (false === $isMigrationAvailable) {
+		    $this->logger->error('Tried to execute user certificate migration, but the migration has already been executed');
 			return '';
 		}
 

--- a/Services/Certificate/classes/class.ilCertificateMigrationGUI.php
+++ b/Services/Certificate/classes/class.ilCertificateMigrationGUI.php
@@ -144,7 +144,7 @@ class ilCertificateMigrationGUI
 			$this->user, new \ilCertificateMigration($this->user->getId())
 		);
 		if (false === $isMigrationAvailable) {
-			$this->errorHandler->raiseError($this->lng->txt('permission_denied'), $this->errorHandler->MESSAGE);
+			return '';
 		}
 
 		$factory = $this->backgroundTasks->taskFactory();


### PR DESCRIPTION
Raising an error via an error handler, will lead to an to an weird behavior when trying to delete a background task or just refresh the page.

Because the `Start Migration` button has a link with the command `startMigrationAndReturnMessage` in it, every action that refreshes the page will result in the error handling instead, because the command the command "startMigrationAndReturnMessage" will be executed a second time.

Mantis: https://mantis.ilias.de/view.php?id=25675