### PR TITLE
UI: Use Unification from Refinery

### DIFF
--- a/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeSettingsGUI.php
+++ b/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeSettingsGUI.php
@@ -258,7 +258,7 @@ class ilObjStudyProgrammeSettingsGUI {
 						self::PROP_POINTS =>
 							$ff->numeric($txt("prg_points"))
 								->withValue((string)$prg->getPoints())
-								->withAdditionalConstraint($this->refinery->int()->isGreaterThan(-1)),
+								->withAdditionalTransformation($this->refinery->int()->isGreaterThan(-1)),
 						self::PROP_STATUS =>
 							$ff->select($txt("prg_status"), $status_options)
 								->withValue((string)$prg->getStatus())

--- a/src/Refinery/Constraint.php
+++ b/src/Refinery/Constraint.php
@@ -11,7 +11,7 @@ use ILIAS\Data\Result;
  *
  * Constraints MUST NOT modify the supplied value.
  */
-interface Constraint {
+interface Constraint extends Transformation {
 	/**
 	 * Checks the provided value.
 	 *
@@ -51,7 +51,7 @@ interface Constraint {
 	 * @param   Result $result
 	 * @return  Result
 	 */
-	public function applyTo(Result $result);
+	public function applyTo(Result $result) : Result;
 
 	/**
 	 * Get a constraint like this one with a builder for a custom error

--- a/src/Refinery/Custom/Constraint.php
+++ b/src/Refinery/Custom/Constraint.php
@@ -4,10 +4,15 @@
 namespace ILIAS\Refinery\Custom;
 
 use ILIAS\Refinery\Constraint as ConstraintInterface;
+use ILIAS\Refinery\DeriveTransformFromApplyTo;
+use ILIAS\Refinery\DeriveInvokeFromTransform;
 use ILIAS\Data;
 use ILIAS\Data\Result;
 
 class Constraint implements ConstraintInterface {
+	use DeriveTransformFromApplyTo;
+	use DeriveInvokeFromTransform;
+
 	/**
 	 * @var ILIAS\Data\Factory
 	 */
@@ -82,7 +87,7 @@ class Constraint implements ConstraintInterface {
 	/**
 	 * @inheritdoc
 	 */
-	final public function applyTo(Result $result) {
+	final public function applyTo(Result $result) : Result {
 		if($result->isError()) {
 			return $result;
 		}

--- a/src/Refinery/Custom/Transformation.php
+++ b/src/Refinery/Custom/Transformation.php
@@ -5,11 +5,14 @@ namespace ILIAS\Refinery\Custom;
 use ILIAS\Data\Factory;
 use ILIAS\Data\Result;
 use ILIAS\Refinery\Transformation as TransformationInterface;
+use ILIAS\Refinery\DeriveApplyToFromTransform;
 
 /**
  * Transform values according to custom configuration
  */
 class Transformation implements TransformationInterface {
+	use DeriveApplyToFromTransform;
+
 	/**
 	 * @var callable
 	 */
@@ -37,19 +40,5 @@ class Transformation implements TransformationInterface {
 	 */
 	public function __invoke($from) {
 		return $this->transform($from);
-	}
-
-	/**
-	 * @inheritdoc
-	 */
-	public function applyTo(Result $data) : Result
-	{
-		$dataValue = $data->value();
-
-		$value = $this->transform($dataValue);
-
-		$result = $this->factory->ok($value);
-
-		return $result;
 	}
 }

--- a/src/Refinery/DeriveApplyToFromTransform.php
+++ b/src/Refinery/DeriveApplyToFromTransform.php
@@ -12,6 +12,13 @@ use ILIAS\Data\Result;
 trait DeriveApplyToFromTransform
 {
 	/**
+	 * @param mixed $from
+	 * @return mixed
+	 * @throws \Exception
+	 */
+	abstract public function transform($from);
+
+	/**
 	 * @param Result $result
 	 * @return Result
 	 */

--- a/src/Refinery/DeriveInvokeFromTransform.php
+++ b/src/Refinery/DeriveInvokeFromTransform.php
@@ -1,0 +1,30 @@
+<?php
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * @author  Richard Klees <richard.klees@concepts-and-training.de>
+ */
+
+namespace ILIAS\Refinery;
+
+
+use ILIAS\Data\Result;
+
+trait DeriveInvokeFromTransform
+{
+	/**
+	 * @param mixed $from
+	 * @return mixed
+	 * @throws \Exception
+	 */
+	abstract public function transform($from);
+
+	/**
+	 * @throws \InvalidArgumentException  if the argument could not be transformed
+	 * @param  mixed  $from
+	 * @return mixed
+	 */
+	public function __invoke($from) {
+		return $this->transform($from);
+	}
+}

--- a/src/Refinery/DeriveTransformFromApplyTo.php
+++ b/src/Refinery/DeriveTransformFromApplyTo.php
@@ -13,8 +13,14 @@ use ILIAS\Data\Result;
 trait DeriveTransformFromApplyTo
 {
 	/**
-	 * @param mixed $from
+	 * @param Result $result
 	 * @return Result
+	 */
+	abstract public function applyTo(Result $result) : Result;
+
+	/**
+	 * @param mixed $from
+	 * @return mixed
 	 * @throws \Exception
 	 */
 	public function transform($from)

--- a/src/Refinery/String/Group.php
+++ b/src/Refinery/String/Group.php
@@ -66,4 +66,14 @@ class Group
 	{
 		return new SplitString($delimiter, $this->dataFactory);
 	}
+
+	/**
+	 * Creates a transformation that strips tags from a string.
+	 *
+	 * Uses php's strip_tags under the hood.
+	 */
+	public function stripTags() : StripTags
+	{
+		return new StripTags();
+	}
 }

--- a/src/Refinery/String/StripTags.php
+++ b/src/Refinery/String/StripTags.php
@@ -1,0 +1,27 @@
+<?php
+/* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Refinery\String;
+
+use ILIAS\Refinery\Transformation;
+use ILIAS\Refinery\DeriveApplyToFromTransform;
+use ILIAS\Refinery\DeriveInvokeFromTransform;
+
+/**
+ * Strip tags from a string.
+ */
+class StripTags implements Transformation {
+	use DeriveApplyToFromTransform;
+	use DeriveInvokeFromTransform;
+
+	/**
+	 * @inheritdoc
+	 */
+	public function transform($from) {
+		if(!is_string($from)) {
+			throw new \InvalidArgumentException(__METHOD__ . " the argument is not a string.");
+		}
+
+		return strip_tags($from);
+	}
+}

--- a/src/UI/Component/Input/Field/Input.php
+++ b/src/UI/Component/Input/Field/Input.php
@@ -6,7 +6,6 @@ namespace ILIAS\UI\Component\Input\Field;
 
 use ILIAS\UI\Component\Component;
 use ILIAS\Refinery\Transformation;
-use ILIAS\Refinery\Constraint;
 use ILIAS\UI\Component\JavaScriptBindable;
 use ILIAS\UI\Component\OnUpdateable;
 
@@ -149,16 +148,6 @@ interface Input extends Component, JavaScriptBindable, OnUpdateable {
 	 * @return    Input
 	 */
 	public function withAdditionalTransformation(Transformation $trafo);
-
-
-	/**
-	 * Apply a constraint to the content of the input.
-	 *
-	 * @param    Constraint $constraint
-	 *
-	 * @return    Input
-	 */
-	public function withAdditionalConstraint(Constraint $constraint);
 
 
 	/**

--- a/src/UI/Implementation/Component/Input/Field/Duration.php
+++ b/src/UI/Implementation/Component/Input/Field/Duration.php
@@ -116,7 +116,7 @@ class Duration extends Group implements C\Input\Field\Duration, JSBindabale {
 		};
 
 		$from_before_until = $this->refinery->custom()->constraint($is_ok, $error);
-		$this->setAdditionalConstraint($from_before_until);
+		$this->setAdditionalTransformation($from_before_until);
 	}
 
 	/**

--- a/src/UI/Implementation/Component/Input/Field/Numeric.php
+++ b/src/UI/Implementation/Component/Input/Field/Numeric.php
@@ -30,10 +30,7 @@ class Numeric extends Input implements C\Input\Field\Numeric {
 	) {
 
 		parent::__construct($data_factory, $refinery, $label, $byline);
-
-		//TODO: Is there a better way to do this? Note, that "withConstraint" is not
-		// usable here (clone).
-		$this->setAdditionalConstraint($this->refinery->numeric()->isNumeric());
+		$this->setAdditionalTransformation($this->refinery->numeric()->isNumeric());
 	}
 
 

--- a/src/UI/Implementation/Component/Input/Field/Password.php
+++ b/src/UI/Implementation/Component/Input/Field/Password.php
@@ -98,7 +98,7 @@ class Password extends Input implements C\Input\Field\Password, Triggerable {
 		if($special) {
 			$constraints[] = $pw_validation->hasSpecialChars();
 		}
-		return $this->withAdditionalConstraint($this->refinery->logical()->parallel($constraints));
+		return $this->withAdditionalTransformation($this->refinery->logical()->parallel($constraints));
 	}
 
 	/**

--- a/src/UI/Implementation/Component/Input/Field/Tag.php
+++ b/src/UI/Implementation/Component/Input/Field/Tag.php
@@ -178,7 +178,7 @@ class Tag extends Input implements C\Input\Field\Tag {
 		/**
 		 * @var $with_constraint C\Input\Field\Tag
 		 */
-		$with_constraint = $clone->withAdditionalConstraint(
+		$with_constraint = $clone->withAdditionalTransformation(
 			$this->refinery->custom()->constraint(
 				function ($value) use ($clone) {
 					return (0 == count(array_diff($value, $clone->getTags())));

--- a/src/UI/Implementation/Component/Input/Field/Textarea.php
+++ b/src/UI/Implementation/Component/Input/Field/Textarea.php
@@ -27,9 +27,9 @@ class Textarea extends Input implements C\Input\Field\Textarea {
 		$byline
 	) {
 		parent::__construct($data_factory, $refinery, $label, $byline);
-		$this->setAdditionalTransformation($refinery->custom()->transformation(function($v) {
-			return strip_tags($v);
-		}));
+		$this->setAdditionalTransformation(
+			$refinery->string()->stripTags()
+		);
 	}
 
 	/**
@@ -39,9 +39,10 @@ class Textarea extends Input implements C\Input\Field\Textarea {
 	 */
 	public function withMaxLimit($max_limit)
 	{
-		$clone = clone $this;
+		$clone = $this->withAdditionalTransformation(
+			$this->refinery->string()->hasMaxLength($max_limit)
+		);
 		$clone->max_limit = $max_limit;
-		$clone->setAdditionalConstraint($this->refinery->string()->hasMaxLength($max_limit));
 		return $clone;
 	}
 
@@ -61,9 +62,10 @@ class Textarea extends Input implements C\Input\Field\Textarea {
 	 */
 	public function withMinLimit($min_limit)
 	{
-		$clone = clone $this;
+		$clone = $this->withAdditionalTransformation(
+			$this->refinery->string()->hasMinLength($min_limit)
+		);
 		$clone->min_limit = $min_limit;
-		$clone->setAdditionalConstraint($this->refinery->string()->hasMinLength($min_limit));
 		return $clone;
 	}
 

--- a/src/UI/examples/Input/Field/Group/base.php
+++ b/src/UI/examples/Input/Field/Group/base.php
@@ -32,7 +32,7 @@ function base() {
     $group = $ui->input()->field()->group(
         [ $number_input->withLabel("Left"), $number_input->withLabel("Right")])
         ->withAdditionalTransformation($sum)
-        ->withAdditionalConstraint($equal_ten);
+        ->withAdditionalTransformation($equal_ten);
 
     //Step 4: define form and form actions, attach the group to the form
     $DIC->ctrl()->setParameterByClass(

--- a/src/UI/examples/Input/Field/Group/disabled.php
+++ b/src/UI/examples/Input/Field/Group/disabled.php
@@ -30,7 +30,7 @@ function disabled() {
 	$group = $ui->input()->field()->group(
 		[ $number_input->withLabel("Left"), $number_input->withLabel("Right")])->withDisabled(true)
 		->withAdditionalTransformation($sum)
-		->withAdditionalConstraint($equal_ten);
+		->withAdditionalTransformation($equal_ten);
 
 	//Step 4: define form and form actions, attach the group to the form
 	$DIC->ctrl()->setParameterByClass(

--- a/src/UI/examples/Input/Field/Password/with_contraints.php
+++ b/src/UI/examples/Input/Field/Password/with_contraints.php
@@ -16,7 +16,7 @@ function with_contraints() {
     //Step 1: Define the input field
     //and add some constraints.
     $pwd_input = $ui->input()->field()->password("Password", "constraints in place.")
-        ->withAdditionalConstraint(
+        ->withAdditionalTransformation(
             $refinery->logical()->parallel([
                 $refinery->string()->hasMinLength(8),
                 $pw_validation->hasLowerChars(),

--- a/src/UI/examples/Input/Field/Section/base.php
+++ b/src/UI/examples/Input/Field/Section/base.php
@@ -32,7 +32,7 @@ function base() {
     $group = $ui->input()->field()->section(
         [ $number_input->withLabel("Left"), $number_input->withLabel("Right")],"Equals 10","Left and Right must equal 10")
         ->withAdditionalTransformation($sum)
-        ->withAdditionalConstraint($equal_ten);
+        ->withAdditionalTransformation($equal_ten);
 
     //Step 3, define form and form actions, attach the group to the form
     $DIC->ctrl()->setParameterByClass(

--- a/src/UI/examples/Input/Field/Section/disabled.php
+++ b/src/UI/examples/Input/Field/Section/disabled.php
@@ -31,7 +31,7 @@ function disabled() {
 	$group = $ui->input()->field()->section(
 		[ $number_input->withLabel("Left"), $number_input->withLabel("Right")],"Equals 10","Left and Right must equal 10")
 		->withAdditionalTransformation($sum)
-		->withAdditionalConstraint($equal_ten)
+		->withAdditionalTransformation($equal_ten)
 		->withDisabled(true);
 
 	//Step 3, define form and form actions, attach the group to the form

--- a/tests/Refinery/String/StripTagsTest.php
+++ b/tests/Refinery/String/StripTagsTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+use ILIAS\Refinery;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * TestCase for SplitString transformations
+ *
+ * @author Stefan Hecken <stefan.hecken@concepts-and-training.de>
+ */
+class StripTagsTest extends TestCase {
+	const STRING_TO_STRIP = "I <script>contain</a> tags.";
+	const EXPECTED_RESULT = "I contain tags.";
+
+	protected function setUp() : void	{
+		$this->f = new \ILIAS\Refinery\Factory(
+			$this->createMock(\ILIAS\Data\Factory::class),
+			$language = $this->createMock('\ilLanguage')
+		);
+		$this->strip_tags = $this->f->string()->stripTags();
+	}
+
+	public function testTransform() {
+		$res = $this->strip_tags->transform(self::STRING_TO_STRIP);
+		$this->assertEquals(self::EXPECTED_RESULT, $res);
+	}
+}

--- a/tests/Refinery/String/StripTagsTest.php
+++ b/tests/Refinery/String/StripTagsTest.php
@@ -26,4 +26,9 @@ class StripTagsTest extends TestCase {
 		$res = $this->strip_tags->transform(self::STRING_TO_STRIP);
 		$this->assertEquals(self::EXPECTED_RESULT, $res);
 	}
+
+	public function testNoString() {
+		$this->expectException(\InvalidArgumentException::class);
+		$this->strip_tags->transform(0);
+	}
 }

--- a/tests/UI/Component/Input/Field/InputTest.php
+++ b/tests/UI/Component/Input/Field/InputTest.php
@@ -275,7 +275,7 @@ class InputTest extends ILIAS_UI_TestBase {
 		$input = $this->input->withNameFrom($this->name_source);
 		$values = new DefInputData([$name => $value]);
 
-		$input2 = $input->withAdditionalConstraint($this->refinery->custom()->constraint(function ($_) { return true; }, $error))->withInput($values);
+		$input2 = $input->withAdditionalTransformation($this->refinery->custom()->constraint(function ($_) { return true; }, $error))->withInput($values);
 		$res = $input2->getContent();
 
 		$this->assertInstanceOf(Result::class, $res);
@@ -295,7 +295,7 @@ class InputTest extends ILIAS_UI_TestBase {
 		$input = $this->input->withNameFrom($this->name_source);
 		$values = new DefInputData([$name => $value]);
 
-		$input2 = $input->withAdditionalConstraint($this->refinery->custom()->constraint(function ($_) { return false; }, $error))->withInput($values);
+		$input2 = $input->withAdditionalTransformation($this->refinery->custom()->constraint(function ($_) { return false; }, $error))->withInput($values);
 		$res = $input2->getContent();
 
 		$this->assertInstanceOf(Result::class, $res);
@@ -309,13 +309,20 @@ class InputTest extends ILIAS_UI_TestBase {
 
 
 	public function test_withInput_and_constraint_fails_different_order() {
+		$rc = $this->refinery->custom();
+
 		$name = "name_0";
 		$value = "value";
 		$error = "an error";
 		$input = $this->input->withNameFrom($this->name_source);
 		$values = new DefInputData([$name => $value]);
 
-		$input2 = $input->withInput($values)->withAdditionalConstraint($this->refinery->custom()->constraint(function ($_) { return false; }, $error));
+		$input2 = $input
+			->withInput($values)
+			->withAdditionalTransformation($rc->constraint(function ($_) {
+				return false;
+			}, $error));
+
 		$res = $input2->getContent();
 
 		$this->assertInstanceOf(Result::class, $res);
@@ -340,7 +347,7 @@ class InputTest extends ILIAS_UI_TestBase {
 				$this->assertEquals($value, $v);
 
 				return $transform_to;
-			}))->withAdditionalConstraint($this->refinery->custom()->constraint(function ($v) use ($transform_to) {
+			}))->withAdditionalTransformation($this->refinery->custom()->constraint(function ($v) use ($transform_to) {
 				$this->assertEquals($transform_to, $v);
 
 				return true;
@@ -372,7 +379,7 @@ class InputTest extends ILIAS_UI_TestBase {
 				$this->assertEquals($value, $v);
 
 				return $transform_to;
-			}))->withAdditionalConstraint($this->refinery->custom()->constraint(function ($v) use ($transform_to) {
+			}))->withAdditionalTransformation($this->refinery->custom()->constraint(function ($v) use ($transform_to) {
 				$this->assertEquals($transform_to, $v);
 
 				return true;
@@ -397,7 +404,7 @@ class InputTest extends ILIAS_UI_TestBase {
 		$input = $this->input->withNameFrom($this->name_source);
 		$values = new DefInputData([$name => $value]);
 
-		$input2 = $input->withAdditionalConstraint($this->refinery->custom()->constraint(function ($v) use ($value) {
+		$input2 = $input->withAdditionalTransformation($this->refinery->custom()->constraint(function ($v) use ($value) {
 				$this->assertEquals($value, $v);
 
 				return true;
@@ -419,6 +426,8 @@ class InputTest extends ILIAS_UI_TestBase {
 
 
 	public function test_withInput_constraint_fails_and_transformation() {
+		$rc = $this->refinery->custom();
+
 		$name = "name_0";
 		$value = "value";
 		$transform_to = "other value";
@@ -426,11 +435,13 @@ class InputTest extends ILIAS_UI_TestBase {
 		$input = $this->input->withNameFrom($this->name_source);
 		$values = new DefInputData([$name => $value]);
 
-		$input2 = $input->withAdditionalConstraint($this->refinery->custom()->constraint(function ($v) use ($value) {
+		$input2 = $input
+			->withAdditionalTransformation($rc->constraint(function ($v) use ($value) {
 				$this->assertEquals($value, $v);
 
 				return false;
-			}, $error))->withAdditionalTransformation($this->refinery->custom()->transformation(function ($v) use ($value, $transform_to) {
+			}, $error))
+			->withAdditionalTransformation($rc->transformation(function ($v) use ($value, $transform_to) {
 				$this->assertFalse("This should not happen");
 
 				return $transform_to;
@@ -455,7 +466,7 @@ class InputTest extends ILIAS_UI_TestBase {
 		$input = $this->input->withNameFrom($this->name_source);
 		$values = new DefInputData([$name => $value]);
 
-		$input2 = $input->withInput($values)->withAdditionalConstraint($this->refinery->custom()->constraint(function ($v) use ($value) {
+		$input2 = $input->withInput($values)->withAdditionalTransformation($this->refinery->custom()->constraint(function ($v) use ($value) {
 				$this->assertEquals($value, $v);
 
 				return false;


### PR DESCRIPTION
This uses the unification from `Transformation` and `Constraint` that was done in the Refinery. This leads to a **breaking change in the UI-Framework:** `withAdditionalConstraint` vanishes, because we only need `withAdditionalTransformation`.

This also includes some improvement in the Refinery (which I kindly ask @mjansenDatabay and @legionth to review):

* actually implement the unification of `Transformation` and `Constraint`
* some improvements in the traits to derive methods for `Transformation`
* a new transformation `String\StripTags`.