### PR TITLE
fixed personal skill presentation ...

### DIFF
--- a/Modules/Test/classes/class.ilTestPersonalSkillsGUI.php
+++ b/Modules/Test/classes/class.ilTestPersonalSkillsGUI.php
@@ -45,6 +45,7 @@ class ilTestPersonalSkillsGUI
 
 		$gui->setGapAnalysisActualStatusModePerObject($this->getTestId(), $this->lng->txt('tst_test_result'));
 
+		$gui->setTriggerObjectsFilter(array($this->getTestId()));
 		$gui->setHistoryView(true); // NOT IMPLEMENTED YET
 
 		// this is not required, we have no self evals in the test context,

--- a/Services/Container/Skills/classes/class.ilContSkillPresentationGUI.php
+++ b/Services/Container/Skills/classes/class.ilContSkillPresentationGUI.php
@@ -108,6 +108,7 @@ class ilContSkillPresentationGUI
 		include_once("./Services/Skill/classes/class.ilPersonalSkillsGUI.php");
 		$gui = new ilPersonalSkillsGUI();
 		$gui->setGapAnalysisActualStatusModePerObject($this->container->getId());
+		$gui->setTriggerObjectsFilter($this->getSubtreeObjectIds());
 		$gui->setHistoryView(true); // NOT IMPLEMENTED YET
 		$skills = array_map(function ($v) {
 			return array(
@@ -130,6 +131,28 @@ class ilContSkillPresentationGUI
 		$gui->listProfilesForGap();
 	}
 
+	protected function getSubtreeObjectIds()
+	{
+		global $DIC; /* @var ILIAS\DI\Container $DIC */
+		
+		$nodes = $DIC->repositoryTree()->getSubTree(
+			$DIC->repositoryTree()->getNodeData( $this->container->getRefId() )
+		);
+		
+		$objects = array();
+		
+		foreach($nodes as $node)
+		{
+			if( $node['child'] == $this->container->getRefId() )
+			{
+				continue; // @smeyer: or is any container able to provide competence records itself?
+			}
+
+			$objects[] = ilObject::_lookupObjectId($node['child']);
+		}
+		
+		return $objects;
+	}
 
 }
 

--- a/Services/Skill/classes/class.ilPersonalSkillsGUI.php
+++ b/Services/Skill/classes/class.ilPersonalSkillsGUI.php
@@ -24,6 +24,7 @@ class ilPersonalSkillsGUI
 	protected $gap_self_eval_levels = array();
 	protected $mode = "";
 	protected $history_view = false;
+	protected $trigger_objects_filter = array();
 	protected $intro_text = "";
 	protected $hidden_skills = array();
 
@@ -212,6 +213,22 @@ class ilPersonalSkillsGUI
 	function getHistoryView()
 	{
 		return $this->history_view;
+	}
+	
+	/**
+	 * @return array
+	 */
+	public function getTriggerObjectsFilter()
+	{
+		return $this->trigger_objects_filter;
+	}
+	
+	/**
+	 * @param array $trigger_objects_filter
+	 */
+	public function setTriggerObjectsFilter($trigger_objects_filter)
+	{
+		$this->trigger_objects_filter = $trigger_objects_filter;
 	}
 	
 	/**
@@ -553,6 +570,11 @@ class ilPersonalSkillsGUI
 				// get all object triggered entries and render them
 				foreach ($skill->getAllHistoricLevelEntriesOfUser($bs["tref"] , $user->getId(), ilBasicSkill::EVAL_BY_ALL) as $level_entry)
 				{
+					if( count($this->getTriggerObjectsFilter()) && !in_array($level_entry['trigger_obj_id'], $this->getTriggerObjectsFilter()) )
+					{
+						continue;
+					}
+					
 					// render the self evaluation at the correct position within the list of object triggered entries
 					if ($se_date > $level_entry["status_date"] && !$se_rendered)
 					{


### PR DESCRIPTION
…with filter for relevant trigger objects within container or single provider object context.
---
At the moment the presentation of personal competences within a course or test object context does include the presentation of competence results from all trigger objects that exist in the repository.

This is of course pretty much what the users want when presenting the competence results at the peronal desktop. But for the presentation within a repository container (e.g. course) or a competence record provider object (e.g. test) the results should be filtered for the context.

IMHO Courses should show all competnce records that relate to any of the course's sub objects and test objects should show only records relating to the test itself.

This PR does fix the issue by adding a trigger object filter for the ilPersonalSkillsGUI that gets enabled from test and course objects. The way of integrating the filter might not be the best but should work as a bugfix.

NOTE: This problem does occur since the activation of the history mode. Prior to presenting the complete history of competence records, the presentation DID filter for the relevant object context, at least within test objects. (When disabling the history mode for the ilPersonalSkillsGUI, everthing is fine within a test object, but of course without history then)

The following (T&A) mantis gets solved with this PR:
https://mantis.ilias.de/view.php?id=25660

The following (Course) mantis ticket might be relevant here as well:
https://mantis.ilias.de/view.php?id=24973

The single commit of this PR should be easily mergeable to the other stable branches as well as to the trunk.