### PR TITLE
changes in BGT to skip UserInteractions

### DIFF
--- a/src/BackgroundTasks/Implementation/Persistence/BasicPersistence.php
+++ b/src/BackgroundTasks/Implementation/Persistence/BasicPersistence.php
@@ -390,6 +390,7 @@ class BasicPersistence implements Persistence {
 
 		// Bugfix 0023775
 		// Added additional orderBy for the id to ensure that the items are returned in the right order.
+
 		/** @var ValueToTaskContainer $valueToTask */
 		$valueToTasks = ValueToTaskContainer::where([ 'task_id' => $taskContainerId ])->orderBy('task_id')->orderBy('id')->get();
 		$inputs = [];

--- a/src/BackgroundTasks/Implementation/TaskManager/BasicTaskManager.php
+++ b/src/BackgroundTasks/Implementation/TaskManager/BasicTaskManager.php
@@ -2,11 +2,11 @@
 
 namespace ILIAS\BackgroundTasks\Implementation\TaskManager;
 
+use ILIAS\BackgroundTasks\Bucket;
 use ILIAS\BackgroundTasks\Exceptions\Exception;
 use ILIAS\BackgroundTasks\Implementation\Bucket\State;
 use ILIAS\BackgroundTasks\Implementation\Tasks\UserInteraction\UserInteractionRequiredException;
 use ILIAS\BackgroundTasks\Implementation\Values\ThunkValue;
-use ILIAS\BackgroundTasks\Bucket;
 use ILIAS\BackgroundTasks\Observer;
 use ILIAS\BackgroundTasks\Persistence;
 use ILIAS\BackgroundTasks\Task;
@@ -87,9 +87,15 @@ abstract class BasicTaskManager implements TaskManager {
 		if (is_a($task, Task\UserInteraction::class)) {
 			/** @var Task\UserInteraction $userInteraction */
 			$userInteraction = $task;
-			$observer->notifyCurrentTask($userInteraction);
-			$observer->notifyState(State::USER_INTERACTION);
-			throw new UserInteractionRequiredException("User interaction required.");
+
+			if ($userInteraction->canBeSkipped($final_values)) {
+				return $userInteraction->getSkippedValue($final_values);
+				//
+			} else {
+				$observer->notifyCurrentTask($userInteraction);
+				$observer->notifyState(State::USER_INTERACTION);
+				throw new UserInteractionRequiredException("User interaction required.");
+			}
 		}
 
 		throw new Exception("You need to execute a Job or a UserInteraction.");

--- a/src/BackgroundTasks/Implementation/Tasks/AbstractUserInteraction.php
+++ b/src/BackgroundTasks/Implementation/Tasks/AbstractUserInteraction.php
@@ -2,9 +2,40 @@
 
 namespace ILIAS\BackgroundTasks\Implementation\Tasks;
 
-use ILIAS\BackgroundTasks\Implementation\Tasks\UserInteraction\UserInteractionOption;
 use ILIAS\BackgroundTasks\Task\UserInteraction;
+use ILIAS\BackgroundTasks\Value;
 
+/**
+ * Class AbstractUserInteraction
+ *
+ * @package ILIAS\BackgroundTasks\Implementation\Tasks
+ *
+ * @author  Fabian Schmid <fs@studer-raimann.ch>
+ */
 abstract class AbstractUserInteraction extends AbstractTask implements UserInteraction {
 
+	/**
+	 * @inheritDoc
+	 */
+	public function getMessage(array $input) {
+		return $message = "";
+	}
+
+
+	/**
+	 * @inheritDoc
+	 */
+	public function canBeSkipped(array $input): bool {
+		return false;
+	}
+
+
+	/**
+	 * @param array $input
+	 *
+	 * @return Value
+	 */
+	public function getSkippedValue(array $input): Value {
+		return $input[0];
+	}
 }

--- a/src/BackgroundTasks/Task/UserInteraction.php
+++ b/src/BackgroundTasks/Task/UserInteraction.php
@@ -2,10 +2,10 @@
 
 namespace ILIAS\BackgroundTasks\Task;
 
-use ILIAS\BackgroundTasks\Task\UserInteraction\Option;
-use ILIAS\BackgroundTasks\Value;
 use ILIAS\BackgroundTasks\Bucket;
 use ILIAS\BackgroundTasks\Task;
+use ILIAS\BackgroundTasks\Task\UserInteraction\Option;
+use ILIAS\BackgroundTasks\Value;
 
 /**
  * Interface UserInteraction
@@ -25,6 +25,29 @@ interface UserInteraction extends Task {
 
 
 	/**
+	 * Decide whether the UserInteraction is presented to the user and he has to decide
+	 * or user UserInteraction is skipped by the TaskManager. You must return a valid
+	 * Value then, @see getSkippedValue.
+	 *
+	 * @param Value[] $input The input value of this task.
+	 *
+	 * @return bool
+	 */
+	public function canBeSkipped(array $input): bool;
+
+
+	/**
+	 * @see canBeSkipped, whenever you decide to skip the UserInteraction, you have to
+	 *                             return a valid Value to proceed.
+	 *
+	 * @param Value[] $input
+	 *
+	 * @return Value
+	 */
+	public function getSkippedValue(array $input): Value;
+
+
+	/**
 	 * @param \ILIAS\BackgroundTasks\Value[] $input                The input value of this task.
 	 * @param Option                         $user_selected_option The Option the user chose.
 	 * @param Bucket                         $bucket               Notify the bucket about your
@@ -33,4 +56,13 @@ interface UserInteraction extends Task {
 	 * @return Value
 	 */
 	public function interaction(array $input, Option $user_selected_option, Bucket $bucket);
+
+
+	/**
+	 * @param Value[] $input The input value of this task.
+	 *
+	 * @return string $message enables the UserInteraction to be used as a notification (for example when a bucket fails due to an
+	 *                expected condition not being met)
+	 */
+	public function getMessage(array $input);
 }


### PR DESCRIPTION
@mjansenDatabay you asked to have BGT which disappear automatically after they have finished. with these changes you can have a simple UserInteraction at the and of your Task-Chain and define it to skip automatically.

JF: this is an announcement of an interface change in /src.