### PR TITLE
Documentation for “Secure ILIAS” 

### DIFF
--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -32,16 +32,6 @@ ILIAS is a powerful Open Source Learning Management System for developing and re
    1. [Installation Wizard](#installation-wizard)
    1. [Configure ILIAS Java RPC server \(OPTIONAL\)](#configure-ilias-java-rpc-server-optional)
 1. [Hardening and Security Guidance](#hardening-and-security-guidance)
-   1. [Secure Files](#secure-files)
-      1. [File Access Rights](#file-access-rights)
-      1. [Place data directory outside of the web root](#place-data-directory-outside-of-the-web-root)
-      1. [Secure Installation Files](#secure-installation-files)
-   1. [Use HTTPS](#use-https)
-      1. [Redirect all unencrypted traffic to HTTPS](#redirect-all-unencrypted-traffic-to-https)
-      1. [Enable HTTP Strict Transport Security](#enable-http-strict-transport-security)
-      1. [Proper SSL configuration](#proper-ssl-configuration)
-   1. [Serve security related Headers](#serve-security-related-headers)
-   1. [Report security issues](#report-security-issues)
 1. [Customizing ILIAS](#customizing-ilias)
    1. [Plugin Repository](#plugin-repository)
 1. [Upgrading ILIAS](#upgrading-ilias)
@@ -120,7 +110,7 @@ Please note that different configurations SHOULD be possible, but it might be ha
   * PhantomJS: 2.0.0+
   * NodeJS: 8.9.4 (TLS) - 10.15.3 (LTS)
   * Java: Version 7 and 8 are suported
-  
+
 <a name="client"></a>
 ### Client
 
@@ -130,7 +120,7 @@ Please note that different configurations SHOULD be possible, but it might be ha
 <a name="database-recommendations"></a>
 ## Database Recommendations
 
-> Please note that installing ILIAS in utf8mb4-collations is currently not supported! ILIAS supports utf8mb3 only. 
+> Please note that installing ILIAS in utf8mb4-collations is currently not supported! ILIAS supports utf8mb3 only.
 
 We RECOMMEND to use MySQL/MariaDB with the following settings:
 
@@ -170,24 +160,24 @@ cd ilias
 git checkout release_5-2
 chown www-data:www-data /var/www/html/ilias -R
 ```
-The files SHOULD be owned by your webserver user/group (e.g. ```www-data``` or ```apache```) the mode SHOULD be 644 for files and 755 for directories. 
+The files SHOULD be owned by your webserver user/group (e.g. ```www-data``` or ```apache```) the mode SHOULD be 644 for files and 755 for directories.
 
 For more details on file access rights see [File Access Rights](#file-access-rights) in the Security section of this document.
 
 <a name="dependency-installation"></a>
 # Dependency Installation
 
-Depending on your Linux Distribution you have several ways to install the required dependencies. We RECOMMEND to always use your distributions package manager to keep your packages up to date in an easy manner avoiding security issues. 
+Depending on your Linux Distribution you have several ways to install the required dependencies. We RECOMMEND to always use your distributions package manager to keep your packages up to date in an easy manner avoiding security issues.
 
 <a name="apache-installationconfiguration"></a>
 ## Apache Installation/Configuration
 
-On Debian/Ubuntu execute: 
+On Debian/Ubuntu execute:
 ```
-apt-get install apache2 
+apt-get install apache2
 ```
 
-On RHEL/CentOS execute: 
+On RHEL/CentOS execute:
 ```
 yum install httpd
 ```
@@ -221,12 +211,12 @@ security enhancing configuration.
 
 After changing the configuration remember to reload the web server daemon:
 
-On Debian/Ubuntu: 
+On Debian/Ubuntu:
 ```
 systemctl restart apache2.service
 ```
 
-On RHEL/CentOS: 
+On RHEL/CentOS:
 ```
 systemctl restart httpd.service
 ```
@@ -239,7 +229,7 @@ On Debian/Ubuntu 14.04 or 16.04 execute:
 apt-get install libapache2-mod-php7.1 php7.1-gd php7.1-mysql php7.1-mbstring php7.1-curl php7.1-dom php7.1-zip php-xml
 ```
 
-On RHEL/CentOS execute: 
+On RHEL/CentOS execute:
 ```
 yum install php
 systemctl restart httpd.service
@@ -261,10 +251,10 @@ We RECOMMEND the following settings for your php.ini:
 ; you may choose higher values for max_execution_time and memory_limit
 max_execution_time = 600
 memory_limit = 512M
- 
+
 error_reporting = E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT ; PHP 5.4.0 and higher
 display_errors = Off
- 
+
 ; or any higher values for post_max_size and upload_max_filesize
 post_max_size = 256M
 upload_max_filesize = 256M
@@ -278,7 +268,7 @@ session.cookie_httponly = On
 session.save_handler = files ; for ILIAS setup, ILIAS installations override this
 ; If you installation is served via HTTPS also use:
 session.cookie_secure = On
- 
+
 ; for chat server since ILIAS 4.2
 allow_url_fopen = 1
 
@@ -295,12 +285,12 @@ Remember to reload your web server configuration to apply those changes.
 <a name="database-installationconfiguration"></a>
 ## Database Installation/Configuration
 
-On Debian/Ubuntu execute: 
+On Debian/Ubuntu execute:
 ```
 apt-get install mysql-server
 ```
 
-On RHEL/CentOS execute: 
+On RHEL/CentOS execute:
 ```
 yum install mariadb
 ```
@@ -353,12 +343,12 @@ We RECOMMEND to use https://github.com/major/MySQLTuner-perl to optimize your My
 
 You MAY use whatever MTA you like to send E-Mail generated by ILIAS. We RECOMMEND to use an already existing smarthost (mailhub). A very simple way to do so is using ```ssmtp```:
 
-On Debian/Ubuntu execute: 
+On Debian/Ubuntu execute:
 ```
 apt-get install ssmtp
 ```
 
-On RHEL/CentOS execute: 
+On RHEL/CentOS execute:
 ```
 yum install ssmtp
 ```
@@ -373,7 +363,7 @@ The configuration file for SSMTP (e.g. ```/etc/ssmtp/ssmtp.conf ```) MAY look as
 # Make this empty to disable rewriting.
 root=yourmail@mail.com
 
-# The place where the mail goes. The actual machine name is required no 
+# The place where the mail goes. The actual machine name is required no
 # MX records are consulted. Commonly mailhosts are named mail.domain.com
 mailhub=smtp.yourmail.com
 
@@ -402,7 +392,7 @@ On Ubuntu 16.04 execute:
 apt-get install zip unzip imagemagick openjdk-8-jdk
 ```
 
-On RHEL/CentOS execute: 
+On RHEL/CentOS execute:
 ```
 yum install zip unzip libxslt ImageMagick java-1.8.0-openjdk
 ```
@@ -475,149 +465,20 @@ At this point the RPC server will generate PDF certificates, but to use Lucence 
 <a name="hardening-and-security-guidance"></a>
 # Hardening and Security Guidance
 
-<a name="secure-files"></a>
-## Secure Files
+Due the Call for Bids "Documentation for  'Secure ILIAS'", the content is moved to an own file.
 
-In previous versions of ILIAS it might have been possible to access SCORM, Media Files and User Profile Images without beeing logged in by guessing the proper URL and no measures were taken by the admin to deny such access.
-
-Since ILIAS 5.1 a new WebAccessChecker (WAC) is implemented by default. To make use of WAC you MUST enable ```mod_rewrite``` in your Apache configuration.
-
-Please note that this will not work with Nginx as ```.htaccess```-files are not supported. Instead you MAY add the following to your Nginx configuration file (please note that running ILIAS with Nginx isn't officially supported and certain features like Shibboleth won't work):
-
-```
-server {
-    [...]
-    root /var/www/trunk;
-    set $root $document_root;
-    rewrite ^/data/(.*)/(.*)/(.*)$ /Services/WebAccessChecker/wac.php last;
-    location /secured-data {
-        alias $root/data;
-        internal;
-    }
-    [...]
-}
-```
-
-<a name="file-access-rights"></a>
-### File Access Rights
-
-If you're an experienced admin you MAY want to use more strict file access rights that we RECOMMENDED earlier in this document. To make it impossible for an attacker to modify PHP files if he gains control over the web server processes those files SHOULD be owned by ```root``` wherever possible.
-
-The only files and directories that must be owned/writeable by the web user are:
-
-  * ilias.ini.php
-  * data/
-  * ILIAS data dir outside of the webservers docroot
-
-All the other files and directories should be owned by ```root```, but readable by the web user (e.g. 644/755).
-
-<a name="place-data-directory-outside-of-the-web-root"></a>
-### Place data directory outside of the web root
-
-It is highly RECOMMENDED to place your data directory outside of the web server docroot, as pointed out by the ILIAS Installation Wizard.
-
-<a name="secure-installation-files"></a>
-### Secure Installation Files and Dependencies
-
-The access to the ILIAS Installation Wizard (```/setup/setup.php```) MAY be restricted:
-
-```
-<Location /setup>
-  <IfVersion < 2.3>
-    Order Deny,Allow
-    Deny From All
-    Allow from 127.0.0.1
-  </IfVersion>
-
-  <IfVersion > 2.3>
-    Require all denied
-    Require ip 127.0.0.1
-  </IfVersion>
-</Location>
-```
-
-The access to the dependencies folder MAY be restricted:
-
-```
-<Location /libs>
-  <IfVersion < 2.3>
-    Order Deny,Allow
-    Deny From All
-    Allow from 127.0.0.1
-  </IfVersion>
-
-  <IfVersion > 2.3>
-    Require all denied
-    Require ip 127.0.0.1
-  </IfVersion>
-</Location>
-```
-
-<a name="use-https"></a>
-## Use HTTPS
-
-You can get a trusted, free SSL certificate at https://letsencrypt.org
-
-<a name="redirect-all-unencrypted-traffic-to-https"></a>
-### Redirect all unencrypted traffic to HTTPS
-
-To redirect all HTTP traffic to HTTPS you MAY issue a permanent redirect using the 301 status code:
-
-```
-<VirtualHost *:80>
-   ServerName yourservername.org
-   Redirect permanent / https://yourservername.org/
-</VirtualHost>
-```
-
-<a name="enable-http-strict-transport-security"></a>
-### Enable HTTP Strict Transport Security
-
-By adding the following to your Apache SSL VirtualHost configuration you instruct browsers not to allow any connection to your ILIAS instance using HTTP and prevent visitors from bypassing invalid certificate warnings.
-
-```
-<IfModule mod_headers.c>
-    Header always set Strict-Transport-Security "max-age=15768000; includeSubDomains; preload"
-</IfModule>
-```
-
-**Warning:** Before activating the configuration above you MUST make sure that you have a good workflow for maintaining your SSL settings (including certificate renewals) as you will not be able to disable HTTPS access to your site for up to 6 months.
-
-<a name="proper-ssl-configuration"></a>
-### Proper SSL configuration
-
-The default SSL ciphers used by web servers are often not state-of-the-art, so you SHOULD consider to choose your own settings. Which settings should be used depends completely on your environment. Therefore giving a generic recommendation is not really possible.
-
-We RECOMMEND to use the [Mozilla SSL Configuration Generator](https://mozilla.github.io/server-side-tls/ssl-config-generator/) to generate a suitable configuration and the [Qualys SSL Labs Tests](https://www.ssllabs.com/ssltest/) or the [High-Tech Bridge SSL Server Test](https://www.htbridge.com/ssl/) to check your settings.
-
-<a name="serve-security-related-headers"></a>
-## Serve security related Headers
-
-To improve the security of your ILIAS users you SHOULD set the following Headers:
-
-  * X-Content-Type-Options: nosniff
-  * X-XSS-Protection: 1; mode=block
-  * X-Frame-Options: SAMEORIGIN
-
-For Apache on Debian systems you can turn those headers on by editing ```/etc/apache2/conf-enabled/security.conf```. You MUST enable  ```mod_headers``` and ```mod_env``` for this.
-
-For Nginx you can simply add for example ```add_header X-Frame-Options "SAMEORIGIN";``` in your ```server``` configuration.
-
-<a name="report-security-issues"></a>
-## Report security issues
-
-If you think you found an security related issue in ILIAS please refer to http://www.ilias.de/docu/goto_docu_wiki_5307.html#ilPageTocA213 for reporting it.
+See [Hardening and Security Guidance](secure.md)
 
 <a name="customizing-ilias"></a>
 # Customizing ILIAS
 
-If you need to customize your ILIAS installation you MUST NOT edit the core files, otherwise you will not be able to update your installation in a timely manner (e.g. due to security fixes). 
+If you need to customize your ILIAS installation you MUST NOT edit the core files, otherwise you will not be able to update your installation in a timely manner (e.g. due to security fixes).
 
 You can find proper ways to customize ILIAS in the [ILIAS Development Guide](http://www.ilias.de/docu/goto_docu_pg_29964_42.html):
 
   * [Plugins and Plugin Slots - ILIAS Development Guide](http://www.ilias.de/docu/goto.php?target=st_27029)
   * [Custom Styles](/templates/Readme.md#custom-styles)
-  
+
 <a name="plugin-repository"></a>
 ## Plugin Repository
 
@@ -626,7 +487,7 @@ ILIAS can be extended with a lot of Plugins. You find the complete list in the [
 <a name="upgrading-ilias"></a>
 # Upgrading ILIAS
 
-The easiest way to update ILIAS is using Git, please note that this is only possible if you installed ILIAS via git as advised in this document. If Git wasn't used you can always download the ZIP or Tarball in the [release section of the ILIAS GitHub pages](https://github.com/ILIAS-eLearning/ILIAS/releases). 
+The easiest way to update ILIAS is using Git, please note that this is only possible if you installed ILIAS via git as advised in this document. If Git wasn't used you can always download the ZIP or Tarball in the [release section of the ILIAS GitHub pages](https://github.com/ILIAS-eLearning/ILIAS/releases).
 
 Before you start you SHOULD consider to:
 
@@ -662,7 +523,7 @@ git checkout release_5-2
 Replace ```release_5-2``` with the branch or tag you actually want to upgrade to. You can get a list of available branches by executing ```git branch -a``` and a list of all available tags by executing ```git tag```. Never use ```trunk``` or ```*beta``` for production.
 
 In case of merge conflicts refer to [Resolving Conflicts - ILIAS Development Guide](http://www.ilias.de/docu/goto.php?target=pg_15604).
-  
+
 See [Database Update](#database-update) for details on how to complete the Upgrade by updating your database.
 
 As a last step you should log in with a User using your custom skin. If everything works fine change back from Delos to your skin. If not refer to [Customizing ILIAS](#customizing-ilias) to modify your skin to match the new requirements.

--- a/docs/configuration/secure.md
+++ b/docs/configuration/secure.md
@@ -38,7 +38,7 @@ For a better identification, they will describe here:
 |  placeholder |  description |
 |-------|-------|
 | %USERNAME% |  an individual user name or the webserver user based on distribution  |
-| %GROUP% | a choiceable group name or the webserver group based on distribution|
+| %GROUP% | a individual group name or the webserver group based on distribution|
 | %HOSTNAME% | your specific fully qualified domain name of ILIAS  |
 | %IPADDRESS% | ip address in CIDR notation  |
 | %DOCROOT% | directory that forms the main document tree visible from the web |

--- a/docs/configuration/secure.md
+++ b/docs/configuration/secure.md
@@ -1,0 +1,571 @@
+# Table of Contents
+- [Hardening and Security Guidance](#hardening-and-security-guidance)
+  * [Firewalling](#firewalling)
+  * [File Access Rights](#file-access-rights)
+  * [Place data directory outside of the web root](#place-data-directory-outside-of-the-web-root)
+  * [Isolate Docroot](#isolate-docroot)
+  * [OS user handling security](#os-user-handling-security)
+  * [Major security improvement: use HTTPS](#major-security-improvement--use-https)
+    + [Redirect all unencrypted traffic to HTTPS](#redirect-all-unencrypted-traffic-to-https)
+    + [Proper SSL configuration](#proper-ssl-configuration)
+    + [Serve security related Headers](#serve-security-related-headers)
+    + [Enable OCSP stapling (TLS Certificate Status Request)](#enable-ocsp-stapling--tls-certificate-status-request-)
+    + [Enable HTTP Strict Transport Security](#enable-http-strict-transport-security)
+    + [Genrate the ILIAS ```ilClientId``` cookie with ```secure``` attribute](#genrate-the-ilias----ilclientid----cookie-with----secure----attribute)
+  * [Suppress server signature and PHP version information](#suppress-server-signature-and-php-version-information)
+  * [deny access or restrict to several files or locations](#deny-access-or-restrict-to-several-files-or-locations)
+    + [ILIAS setup](#ilias-setup)
+    + [Prevent blacklisted files of beeing served by the webserver](#prevent-blacklisted-files-of-beeing-served-by-the-webserver)
+    + [Prevent execution of PHP-Code in data-directory](#prevent-execution-of-php-code-in-data-directory)
+    + [Deny Access to local Git-Directory](#deny-access-to-local-git-directory)
+  * [Integrity check of ILIAS code in docroot](#integrity-check-of-ilias-code-in-docroot)
+  * [Use WebAccessChecker](#use-webaccesschecker)
+  * [Use secure passwords](#use-secure-passwords)
+  * [Report security issues](#report-security-issues)
+
+# Hardening and Security Guidance
+
+This guideline is going to show you some best practice examples how to improve the security of your ILIAS installation, of the webserver and it's associated components.
+The ILIAS e.V. requested a documentation for a "Secure ILIAS" in march 2019.
+The section "Hardening and Security Guidance" should be removed and the security related instructions have to be mantained in a own document.
+
+## Firewall
+
+Block all traffic by default and explicitly allow only specific traffic to port 443/TCP for HTTPS secured traffic.
+For "quality of life", it is recommend to also permit 80/TCP for a [redirect to HTTPS](#redirect-all-unencrypted-traffic-to-https-1).
+
+## File Access Rights
+
+If you're an experienced admin you MAY want to use more restrictive file access rights that we RECOMMEND in this document. To make it impossible for an attacker to modify PHP files if he gains control over the web server processes, those files SHOULD be owned by ```root``` wherever possible.
+
+The only files and directories that MUST be owned/writeable by the web user are:
+
+  * ilias.ini.php
+  * data/
+  * ILIAS data dir outside of the webservers docroot
+
+All the other files and directories should be owned by ```root```, but readable by the web user (e.g. 644/755).
+
+example of the suggested configuration:
+```
+git clone --single-branch -b release_5-4 https://github.com/ILIAS-eLearning/ILIAS.git \ /var/www/ilias/.
+
+mkdir -p /var/www/ilias;
+mkdir /var/www/ilias_data;
+mkdir /var/www/ilias_log;
+mkdir /var/www/ilias_log/ilias_errors
+
+chown [www-data:www-data|www_ilias_1:www_ilias_1] /var/www/ilias /var/www/ilias/data
+chown [www-data:www-data|www_ilias_1:www_ilias_1] /var/www/ilias_data
+chown [www-data:www-data|www_ilias_1:www_ilias_1] /var/www/ilias_log
+chown [www-data:www-data|www_ilias_1:www_ilias_1] /var/www/ilias_log/ilias_errors
+
+chmod [2]775 /var/www/ilias/data
+chmod [2]775 /var/www/ilias_data
+chmod [2]775 /var/www/ilias_log
+chmod [2]775 /var/www/ilias_log/ilias_errors
+```
+
+After the installation of ILIAS is finished, you SHOULD also revoke write permission for the file ```ilias.ini.php``` (e.g. ```/var/www/ilias/ilias.ini.php```).
+note: for changing base setting via ILIAS setup, you need to grant write permission for the file ```ilias.ini.php``` again.
+
+## Place data directory outside of the web root
+
+It is highly RECOMMENDED to place your data directory outside of the web server docroot, as pointed out by the ILIAS Installation Wizard.
+
+## Isolate Docroot
+You MAY use openbasedir-restriction to avoid malicious software to directory-traverse out of your docroot-directory. This is very important if there are other websites on the same host.
+
+Apache2:
+
+    php_admin_value open_basedir ./:%docroot_dir%:/usr/share/php/:/var/www/lib/:/tmp
+
+Nginx:
+
+    fastcgi_param PHP_VALUE open_basedir="./:%docroot_dir%:/usr/share/php/:/var/www/lib/:/tmp";
+**Hint:** This option will be applied to the PHP-FPM process. If there are multiple websites on your webserver you have to define a single PHP-FPM-pool for each website. Otherwise these other homepages won' t be accessible anymore.
+
+## OS user handling security
+
+If you use PHP-FPM (FastCGI Process Manager), you can increase security by running the PHP-FPM processes as an specific instead ```www-data``` / ```wwwrun``` (depends on linux distribution).
+
+Snippet from a PHP-FPM pool definition:
+```
+; Unix user/group of processes
+; Note: The user is mandatory. If the group is not set, the default user's group
+;       will be used.
+user = www_ilias_1
+group = www_ilias_1
+```
+
+**note:**  
+NGINX and also apache2 is can only run with one user (no multi user multi process model).  
+So it is necessary to put all the "PHP-FPM"-users in the primary group of the webserver user.
+
+## Major security improvement: use HTTPS
+
+You can get a trusted, free SSL certificate at https://letsencrypt.org.
+Or use a SSL certificate from a commercial certificate authority.
+
+### Redirect all unencrypted traffic to HTTPS
+
+To redirect all HTTP traffic to HTTPS you SHOULD issue a permanent redirect using the 301 status code:
+
+#### Apache2
+
+```
+<VirtualHost *:80>
+   ServerName yourservername.org
+   Redirect permanent / https://yourservername.org/
+</VirtualHost>
+```
+
+#### NGINX
+
+```
+server {
+		listen   *:80;
+		listen   [::]:80;
+		server_name yourservername.org;
+
+		location / {
+				return 301 https://yourservername.org$request_uri;				
+		}
+```
+
+### Proper SSL configuration
+
+The default SSL settings (e.g. ciphers & ssl protocol version ) used by web servers are often not state-of-the-art, so you SHOULD consider to choose your own settings.
+
+**Suggestion of modern settings for SSL configuration:**
+
+The following suggestion can only be a recommendation and depends completely on your specific environment (webserver software and version, used OpenSSL version, etc.).
+
+If you use, the following suggestion, please note that the oldest compatible clients will be:
+* Firefox 27
+* Chrome 30
+* IE 11 on Windows 7,
+* Edge
+* Opera 17
+* Safari 9
+* Android 5.0
+* Java 8
+
+Older browser clients will not be able to reach the ILIAS installation!
+
+#### Apache2
+*(Version: 2.4.34,  OpenSSL 1.1.1c)*
+
+Add the following line INSIDE the `` <VirtualHost></VirtualHost> `` block:
+```
+<VirtualHost *:443>
+    ...
+    ServerName yourservername.org
+    ...
+    SSLEngine on
+    SSLCertificateFile       /path/to/signed_cert_plus_intermediates
+    SSLCertificateKeyFile   /path/to/private/key
+```
+
+Add the following line OUTSIDE  the `` <VirtualHost></VirtualHost> `` block:
+```
+SSLProtocol             all -SSLv3 -TLSv1 -TLSv1.1
+SSLCipherSuite          ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
+SSLHonorCipherOrder     on
+SSLCompression          off
+SSLSessionTickets       off
+```
+
+
+#### NGINX
+*(Version: 1.14.0,  OpenSSL 1.1.1c)*
+
+Add the following line INSIDE the server block:
+
+```
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    ...
+    server_name yourservername.org;
+    ...
+    # certs sent to the client in SERVER HELLO are concatenated in ssl_certificate
+    ssl_certificate /path/to/signed_cert_plus_intermediates;
+    ssl_certificate_key /path/to/private_key;
+    ssl_session_timeout 5m;
+    ssl_session_cache shared:SSL:16m;
+    ssl_session_tickets off;
+
+    ssl_protocols TLSv1.2;
+    ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
+    ssl_prefer_server_ciphers on;
+
+    ssl_dhparam /etc/ssl/private/dhparam.pem;
+
+
+```
+
+``ssl_dhparam /etc/ssl/private/dhparam.pem;``:
+
+This specifies a file with DH parameters for EDH (Ephemeral Diffie-Hellman) ciphers.  
+By default, NGINX will use the default DHE paramaters provided by openssl. This uses a weak key that gets lower scores.  
+Run ``openssl dhparam -out /etc/ssl/private/dhparam.pem 4096`` in terminal to generate it.
+
+We RECOMMEND to use the [Mozilla SSL Configuration Generator](https://ssl-config.mozilla.org/) to generate a suitable configuration and the [Qualys SSL Labs Tests](https://www.ssllabs.com/ssltest/) or the [High-Tech Bridge SSL Server Test](https://www.htbridge.com/ssl/) to check your settings. It is recommended, to reach a "A" rating as minimum.
+
+
+### Serve security related Headers
+
+To improve the security of your ILIAS users you SHOULD set the following Headers:
+
+
+```
+    X-Content-Type-Options: nosniff;
+    X-XSS-Protection: 1; mode=block;
+    X-Frame-Options: SAMEORIGIN;
+    Referrer-Policy: strict-origin;
+    Feature-Policy sync-xhr 'self';  
+    add_header Content-Security-Policy "default-src 'self'; connect-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline' data:; img-src 'self' 'unsafe-inline' data:; font-src 'self' 'unsafe-inline' data:; media-src 'self' 'unsafe-inline' data:";  
+```
+
+*Backward compatibility to  Microsoft Internet Explorer 10*:  
+```
+add_header X-Content-Security-Policy "default-src 'self'; connect-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline' data:; img-src 'self' 'unsafe-inline' data:; font-src 'self' 'unsafe-inline' data:; media-src 'self' 'unsafe-inline' data:";
+```
+
+see also: [Browser compatibility of HTTP headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP#Browser_compatibility)
+
+##### Apache
+Add the following line INSIDE the `` <VirtualHost></VirtualHost> `` block:
+
+```
+    <IfModule mod_headers.c>
+        Header set X-Content-Type-Options "nosniff"
+        Header set X-XSS-Protection "1; mode=block"
+        Header set X-Frame-Options "SAMEORIGIN;"
+        Header set Referrer-Policy "strict-origin"
+        Header set Feature-Policy "sync-xhr 'self'"
+
+        # Working with ILIAS in most use cases:
+        Header set Content-Security-Policy "default-src 'self'; connect-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline' data:; img-src 'self' 'unsafe-inline' data:; font-src 'self' 'unsafe-inline' data:; media-src 'self' 'unsafe-inline' data:"
+
+        # Working with ILIAS in most use cases:
+        Header set X-Content-Security-Policy "default-src 'self'; connect-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline' data:; img-src 'self' 'unsafe-inline' data:; font-src 'self' 'unsafe-inline' data:; media-src 'self' 'unsafe-inline' data:"
+    </IfModule>
+```
+
+ ##### NGINX
+ You can simply add this in your ```server``` configuration:
+
+ ```
+  # Content-Security
+         add_header X-Frame-Options "SAMEORIGIN";
+         add_header X-Content-Type-Options nosniff;
+         add_header X-XSS-Protection "1; mode=block";
+         add_header Referrer-Policy "strict-origin";
+         add_header Feature-Policy "sync-xhr 'self';
+
+         # Working with ILIAS in most use cases:
+         add_header Content-Security-Policy "default-src 'self'; connect-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline' data:; img-src 'self' 'unsafe-inline' data:; font-src 'self' 'unsafe-inline' data:; media-src 'self' 'unsafe-inline' data:";
+         #compatibility to  Microsoft Internet Explorer 10:
+         add_header X-Content-Security-Policy "default-src 'self'; connect-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline' data:; img-src 'self' 'unsafe-inline' data:; font-src 'self' 'unsafe-inline' data:; media-src 'self' 'unsafe-inline' data:";
+ ```
+
+note:  
+If you use a proxied [Chat Server](https://github.com/ILIAS-eLearning/ILIAS/blob/release_5-4/Modules/Chatroom/README.md), you MUST add the url to the CSP definition:  
+```connect-src 'self' wss://onscreenchat.yourservername.org https://onscreenchat.yourservername.org;```
+
+#### Validate the header configuration
+It is recommended to validate your configuration with the services from https://securityheaders.com/.  
+Try to reach **A** grade.
+
+### Enable OCSP stapling (TLS Certificate Status Request)
+
+The  TLS/SSL extension [OCSP stapling](https://en.wikipedia.org/wiki/OCSP_stapling) provides a way to improve the performance (cause the webserver is will done this instead of the browser client) of SSL negotiation while maintaining visitor privacy.
+The [Online Certificate Status Protocol (OCSP)](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol) is used for checking the revocation status of a SSL certificate (X.509 certificate). -> https://tools.ietf.org/html/rfc6066
+
+By adding the following to your SSL VirtualHost configuration your webserver will do the check for you and send signatured information regarding to browser client
+
+#### Apache2
+
+Add the following line INSIDE the `` <VirtualHost></VirtualHost> `` block:
+```
+SSLUseStapling on
+SSLStaplingResponderTimeout 5
+SSLStaplingReturnResponderErrors off
+```
+Add the following line OUTSIDE  the ``` <VirtualHost></VirtualHost> ``` block:
+```
+SSLStaplingCache shmcb:/tmp/stapling_cache(128000)
+```
+
+#### NGINX
+
+```
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    ssl_stapling_file ocsp_response;
+    ssl_trusted_certificate /path/to/cert_chain.pem;
+
+    resolver <IP DNS resolver>;
+```
+
+#### Check the OCSP configuration
+
+```
+openssl s_client -connect yourservername.org:443 -servername yourservername.org -status < /dev/null 2>&1 | grep -i "OCSP response"
+```
+
+### Enable HTTP Strict Transport Security
+
+**A word of warning here** *: This is a very effective, but also complex thing to do. It is recommended you do that - but you should totally know what you're doing. If not, please be aware that you may mess up your installation. If you have the slightest doubt you can pull this off, do yourself (and your users) a huge favor by trying this on an unimportant subdomain first. Really.*
+
+The [HTTP Strict Transport Security (HSTS)](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) header allows a host to enforce the use of HTTPS on the client side. The browser will be informed to use HTTPS.
+This protects e.g. from protocol downgrade attacks and cookie hijacking.
+
+By adding the following to your SSL VirtualHost configuration you instruct browsers not to allow any connection to your ILIAS instance using HTTP and prevent visitors from bypassing invalid certificate warnings.
+
+#### Apache2
+
+Ensure you have ```mod_headers.so``` enabled in Apache2:
+
+```
+<IfModule mod_headers.c>
+    Header always set Strict-Transport-Security "max-age=15552000; includeSubDomains; preload"
+</IfModule>
+```
+
+#### NGINX
+
+```
+    add_header Strict-Transport-Security max-age=15552000; includeSubDomains" preload;
+```
+
+**Warning:** Before activating the configuration above you MUST make sure that you have a good workflow for maintaining your SSL settings (including certificate renewals) as you will not be able to disable HTTPS access to your site for up to 6 months.
+
+**Tip:** When you test HSTS, use a very short max-age timeout
+```
+includeSubDomains:       Restrictions also apply to all subdomains of the current domain.
+max-age:                 Duration of cached information (180 days)
+```
+
+### Genrate the ILIAS ```ilClientId``` cookie with ```secure``` attribute
+
+The browser will include the cookie in an HTTP request only if the request is transmitted over a secure channel (HTTPS).  
+https://en.wikipedia.org/wiki/Secure_cookie
+
+##### Apache
+You have to add this to the apache2 configuration.
+```
+Header edit Set-Cookie ^(.*)$ $1;HttpOnly;Secure
+```
+
+note:  
+Apache2 will use this for all cookie, who are beeing created.
+
+##### NGINX
+You can simply add for example ```add_header Set-Cookie``` in your ```server``` configuration.
+
+```
+    add_header Set-Cookie "ilClientId=%client_id%; Path=/; Secure; HttpOnly";
+```
+note:  
+For nginx, you have to generate a specific cookie for your ILIAS client.
+This will overide the cookie deliverd by ILIAS, so it is necessary to generate the whole cookie.
+
+## Suppress server signature and PHP version information
+
+By default, web servers include sensitive server information in http headers and detailed PHP version information.
+It is recommended to suppress these header informations to prevent detection and exploit of version specific security issues of web server and PHP version.
+
+### Remove “server” information from http header
+
+#### Apache2
+* Module mod_headers is needed
+```
+<IfModule mod_headers.c>
+    Headers unset Server
+    Headers always unset Server
+</IfModule>
+```
+
+#### NGINX
+* Module ngx_http_headers_module is needed
+
+```
+    more_set_headers 'Server: ';
+```
+or better
+```
+    more_clear_headers  'Server:*';
+```
+
+### Remove “X-Powered-By” information from http header
+
+This can also be done by unsetting the header in webserver.
+* "Header unset X-Powered-By" for Apache2 or rather
+* "more_clear_headers 'X-Powered-By'" for NGINX.
+
+The suggested solution is to set 'expose_php' to 'off' in your php.ini:
+
+```
+    expose_php = Off
+```
+
+## deny access or restrict to several files or locations
+
+### ILIAS setup
+The access to the ILIAS Installation Wizard ``(/setup/setup.php)`` MAY be restricted:<br/><br/>
+
+Apache2:  
+```
+    <Location /setup>
+        <IfVersion < 2.3>
+         Order Deny,Allow
+         Deny From All
+         Allow from %IP-Address
+        </IfVersion>
+
+        <IfVersion > 2.3>
+            Require all denied
+            Require ip %IP-Address
+        </IfVersion>
+    </Location>
+```
+
+Nginx:  
+
+```
+    location /setup {
+        allow %IP-Address;
+        deny all;
+
+        # add location for PHP processing here
+    }
+    location /setup/setup.php {
+        allow %IP-Address;
+        deny all;
+    }
+
+```
+
+### Prevent blacklisted files of beeing served by the webserver
+If somebody tries to upload a file thats filetype is blacklisted by the upload settings, the upload will take place but the file will be renamed to ``filename.sec``. The webserver MUST not serve this file anymore to it's visitors as the file may consists of maliscious software.
+
+Apache2:
+
+    <FilesMatch "\.(sec)$">
+        Order Deny,Allow
+        Deny from All
+    </FilesMatch>
+
+Nginx:
+
+    location ~ [^/]\.sec {
+        deny all;
+    }
+
+### Prevent execution of PHP-Code in data-directory
+There may be situations where there is no oppurtunity to disallow uploading php-files e.g. in Computer Science courses. In this case you SHOULD disallow these uploaded code to be executed by the webserver.
+
+Apache2:
+```
+    <LocationMatch "/data/.*(?i)\.(php)$">
+        Order Deny,Allow
+        Deny from All
+    </LocationMatch>
+```
+Nginx:
+```
+    location ~* /data/.*\.php {
+        deny all;
+    }
+```
+
+### Deny Access to local Git-Directory
+If you installed ILIAS via git, access the local Git-Directory (.git) SHOULD be denied for visitors via web.
+
+Apache2:
+```
+    <Directorymatch "^/.*/\.git/">
+        Order deny,allow
+        Deny from all
+    </Directorymatch>
+```
+Nginx:
+```
+    location /.git {
+        deny all;
+    }
+```
+
+
+
+## Integrity check of ILIAS code in docroot
+Local changes of the code of ILIAS can indicate a potential intrusion.
+
+To determine local changes of the code of ILIAS use `git status` / `git diff`.
+This will show you the uncommited local changes. 
+(Beware: Committed local changes remain undetected using this method.)
+(If you have conscious code local changes, this can lead to a false positive.)
+
+## Use WebAccessChecker
+In previous versions of ILIAS, it might have been possible to access SCORM, Media Files and User Profile Images without beeing logged in by guessing the proper URL and no measures were taken by the admin to deny such access. Since ILIAS 5.1, a new WebAccessChecker (WAC) is activated by default. To make use of WAC you MUST enable ``mod_rewrite`` in your Apache configuration.
+
+Please note that this will not work with Nginx as ``.htaccess-files`` are not supported. Instead you MUST add the following to your Nginx configuration file (please note that running ILIAS with Nginx isn't officially supported and certain features like Shibboleth won't work):
+
+This is a NGINX recommended configuration. (note: inside the `%docroot_dir%/data` no PHP will be proceed)
+
+
+```
+    server {
+        [...]
+        location ~ /data/ {
+            set $root $document_root;
+            rewrite ^/data/(.*)/(.*)/(.*)$ /Services/WebAccessChecker/wac.php last;
+
+            location ~ [^/]\.php(/|$) { access_log off; log_not_found off; deny all; }
+        }
+
+        location ^~ /secured-data {
+            # Protected, only working for subrequests (X-Accel-Redirect)
+            alias $root/data;
+            internal;
+
+            location ~ [^/]\.php(/|$) { access_log off; log_not_found off; deny all; }
+        }
+         [...]
+    }
+```
+
+
+** [ilFileDelivery](https://github.com/ILIAS-eLearning/ILIAS/blob/release_5-4/Services/FileDelivery/classes/override.php.template)** (concerns NGINX/PHP-FPM):
+> This is needed if you want to use the ilFileDelivery::DELIVERY_METHOD_XACCEL or the ilFileDelivery::DELIVERY_METHOD_XSENDFILE Method since PHP can't figure out whether X-Accel ist installed or not.""
+
+rename the file:  
+     ```%docroot_dir%/Services/FileDelivery/classes/override.php.template```  
+to  
+     ```%docroot_dir%Services/FileDelivery/classes/override.php```  
+
+
+## Use secure passwords
+Please keep in mind, that your plattform might me be accessible to the world wide web. To avoid unauthorized access to your Ilias-Installation, it his highly recommended to use secure passwords. Especially the root password and the Ilias-Master-Password are potentially endangered.
+
+Your passwords should fullfil the following criterias:
+
+* at least 8 characters in length
+* lowercase and uppercase alphabetic characters, numbers and symbols
+* do not consist of information that can easily be associated with the user
+
+You MAY generate a password by using the pwgen-command on your webserver's cli
+* -B: don't include ambiguous characters in the password;
+* -y: include at least one special symbol in the password
+).
+
+```
+    pwgen -By
+```
+
+## Report security issues
+
+If you think you found an security related issue in ILIAS please refer to http://www.ilias.de/docu/goto_docu_wiki_5307.html#ilPageTocA213 for reporting it.

--- a/docs/configuration/secure.md
+++ b/docs/configuration/secure.md
@@ -350,7 +350,7 @@ OCSP Response Data:
     Response Type: Basic OCSP Response
 ```
 
-The [Qualys SSL Labs Tests](https://www.ssllabs.com/ssltest/) will also provided you a working or non-working OCSP configuration:
+The [Qualys SSL Labs Tests](https://www.ssllabs.com/ssltest/) will also show if your OCSP configuration is working:
 ```OCSP stapling 	Yes```
 
 ### Enable HTTP Strict Transport Security

--- a/docs/configuration/secure.md
+++ b/docs/configuration/secure.md
@@ -307,7 +307,7 @@ Try to reach **A** grade.
 
 ### Enable OCSP stapling (TLS Certificate Status Request)
 
-The  TLS/SSL extension [OCSP stapling](https://en.wikipedia.org/wiki/OCSP_stapling) provides a way to improve the performance (cause the webserver is will do this instead of the browser client) of SSL negotiation while maintaining visitor privacy.
+The  TLS/SSL extension [OCSP stapling](https://en.wikipedia.org/wiki/OCSP_stapling) provides a way to improve the performance (as the webserver will fetch the OCS instead of the browser client) of SSL negotiation while maintaining visitor privacy.
 The [Online Certificate Status Protocol (OCSP)](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol) is used for checking the revocation status of a SSL certificate (X.509 certificate). -> https://tools.ietf.org/html/rfc6066
 
 By adding the following to your SSL VirtualHost configuration your webserver will do the check for you and send signatured information regarding to browser client

--- a/docs/configuration/secure.md
+++ b/docs/configuration/secure.md
@@ -37,7 +37,7 @@ For a better identification, they will describe here:
 
 |  placeholder |  description |
 |-------|-------|
-|  %USERNAME% |  a choiceable user name or the webserver user based on distribution  |
+| %USERNAME% |  an individual user name or the webserver user based on distribution  |
 | %GROUP% | a choiceable group name or the webserver group based on distribution|
 | %HOSTNAME% | your specific fully qualified domain name of ILIAS  |
 | %IPADDRESS% | ip address in CIDR notation  |

--- a/docs/configuration/secure.md
+++ b/docs/configuration/secure.md
@@ -236,7 +236,7 @@ In best case, you allways use the latest "Modern" configuration.
 ### Serve security related Headers
 
 To improve the security of your ILIAS users you SHOULD set the following Headers:
-(this is experience based configuration set of headers, may this can differ to your configuration/ usage scenario)
+(this is an experience based configuration set of headers, this may differ from your configuration/usage scenario)
 
 
 ```

--- a/docs/configuration/secure.md
+++ b/docs/configuration/secure.md
@@ -42,6 +42,7 @@ For a better identification, they will describe here:
 | %HOSTNAME% | your specific fully qualified domain name of ILIAS  |
 | %IPADDRESS% | ip address in CIDR notation  |
 | %DOCROOT% | directory that forms the main document tree visible from the web |
+| %EXTERNALDATA% | ILIAS data directory outside of the web documenation root |
 | %CLIENTID% | the client name of the ILIAS installation  |
 
 
@@ -68,18 +69,18 @@ git clone --single-branch -b release_5-4 https://github.com/ILIAS-eLearning/ILIA
 
 mkdir -p /var/www/ilias;
 mkdir /var/www/ilias_data;
-mkdir /var/www/ilias_log;
-mkdir /var/www/ilias_log/ilias_errors
+mkdir /var/log/ilias;
+mkdir /var/log/ilias/ilias_errors
 
 chown %USERNAME%:%GROUP% /var/www/ilias /var/www/ilias/data
 chown %USERNAME%:%GROUP% /var/www/ilias_data
-chown %USERNAME%:%GROUP% /var/www/ilias_log
-chown %USERNAME%:%GROUP% /var/www/ilias_log/ilias_errors
+chown %USERNAME%:%GROUP% /var/log/ilias
+chown %USERNAME%:%GROUP% /var/log/ilias/ilias_errors
 
 chmod 2775 /var/www/ilias/data
 chmod 2775 /var/www/ilias_data
-chmod 2775 /var/www/ilias_log
-chmod 2775 /var/www/ilias_log/ilias_errors
+chmod 2775 /var/log/ilias
+chmod 2775 /var/log/ilias/ilias_errors
 ```
 
 After the installation of ILIAS is finished, you SHOULD also revoke write permission for the file ```ilias.ini.php``` (e.g. ```/var/www/ilias/ilias.ini.php```).
@@ -94,11 +95,11 @@ You MAY use openbasedir-restriction to avoid malicious software to directory-tra
 
 Apache2:
 
-    php_admin_value open_basedir ./:%DOCROOT%:/usr/share/php/:/var/www/lib/:/tmp
+    php_admin_value open_basedir ./:%DOCROOT%:%EXTERNALDATA%:/var/log/ilias:/usr/share/php/:/var/www/lib/:/tmp
 
 Nginx:
 
-    fastcgi_param PHP_VALUE open_basedir="./:%DOCROOT%:/usr/share/php/:/var/www/lib/:/tmp";
+    fastcgi_param PHP_VALUE open_basedir="./:%DOCROOT%:%EXTERNALDATA%:/var/log/ilias:/usr/share/php/:/var/www/lib/:/tmp";
 **Hint:** This option will be applied to the PHP-FPM process. If there are multiple websites on your webserver you have to define a single PHP-FPM-pool for each website. Otherwise these other homepages won' t be accessible anymore.
 
 ## OS user handling security

--- a/docs/configuration/secure.md
+++ b/docs/configuration/secure.md
@@ -488,7 +488,7 @@ Nginx:
 
 ```
 
-Please add here the whitelisted ip address (%IPADDRESS%) to grant access to ILIAS setup here.
+Please add the whitelisted ip address (%IPADDRESS%) to grant access to ILIAS setup here.
 
 ### Prevent blacklisted files of beeing served by the webserver
 If somebody tries to upload a file thats filetype is blacklisted by the upload settings, the upload will take place but the file will be renamed to ``filename.sec``. The webserver should not serve this file anymore to it's visitors as the file may consists of maliscious software.

--- a/docs/configuration/secure.md
+++ b/docs/configuration/secure.md
@@ -491,7 +491,7 @@ Nginx:
 Please add the whitelisted ip address (%IPADDRESS%) to grant access to ILIAS setup here.
 
 ### Prevent blacklisted files of beeing served by the webserver
-If somebody tries to upload a file thats filetype is blacklisted by the upload settings, the upload will take place but the file will be renamed to ``filename.sec``. The webserver should not serve this file anymore to it's visitors as the file may consists of maliscious software.
+If somebody tries to upload a file with a filetype blacklisted by the upload settings, the upload will take place, but the file will be renamed to ``filename.sec``. The webserver should not serve this file anymore to it's visitors as the file may consists of malicious software.
 
 Apache2:
 


### PR DESCRIPTION
This PR is a deliverable of the `Documentation for “Secure ILIAS”-Call for Bids`.

It adds a new [docs/configuration/secure.md](https://github.com/ILIAS-eLearning/ILIAS/pull/1969/files#diff-bc4efbccda9ee8ec8e6ff062a7cc4f44), removes the according paragraphs in [docs/configuration/install.md](https://github.com/ILIAS-eLearning/ILIAS/pull/1969/files#diff-4ffd877b4e4254fa3eb0c5b625bb549f) and links to the new file.

There will be a public workshop: https://docu.ilias.de/goto_docu_grp_6768.html