### PR TITLE
UI: Fixed signature of language mock for unit tests

### DIFF
--- a/tests/UI/Base.php
+++ b/tests/UI/Base.php
@@ -72,7 +72,7 @@ class ilLanguageMock extends \ilLanguage {
 		$this->requested[] = $a_topic;
 		return $a_topic;
 	}
-	public function toJS($a_key, ilGlobalTemplate $a_tpl = NULL) {
+	public function toJS($a_lang_key, ilGlobalTemplateInterface $a_tpl = null) {
 	}
 	public $lang_module = 'common';
 	public function loadLanguageModule($lang_module) {}


### PR DESCRIPTION
Fixes the followng issue:

```
PHP Warning:  Declaration of ilLanguageMock::toJS($a_key, ?ilGlobalTemplate $a_tpl = NULL) should be compatible with ilLanguage::toJS($a_lang_key, ?ilGlobalTemplateInterface $a_tpl = NULL) in /home/travis/build/ILIAS-eLearning/ILIAS/tests/UI/Base.php on line 68
PHP Stack trace:
PHP   1. {main}() /home/travis/build/ILIAS-eLearning/ILIAS/libs/composer/vendor/phpunit/phpunit/phpunit:0
PHP   2. PHPUnit\TextUI\Command::main() /home/travis/build/ILIAS-eLearning/ILIAS/libs/composer/vendor/phpunit/phpunit/phpunit:61
PHP   3. PHPUnit\TextUI\Command->run() /home/travis/build/ILIAS-eLearning/ILIAS/libs/composer/vendor/phpunit/phpunit/src/TextUI/Command.php:164
PHP   4. PHPUnit\TextUI\Command->handleArguments() /home/travis/build/ILIAS-eLearning/ILIAS/libs/composer/vendor/phpunit/phpunit/src/TextUI/Command.php:175
PHP   5. PHPUnit\Util\Configuration->getTestSuiteConfiguration() /home/travis/build/ILIAS-eLearning/ILIAS/libs/composer/vendor/phpunit/phpunit/src/TextUI/Command.php:906
PHP   6. PHPUnit\Util\Configuration->getTestSuite() /home/travis/build/ILIAS-eLearning/ILIAS/libs/composer/vendor/phpunit/phpunit/src/Util/Configuration.php:870
PHP   7. PHPUnit\Framework\TestSuite->addTestFile() /home/travis/build/ILIAS-eLearning/ILIAS/libs/composer/vendor/phpunit/phpunit/src/Util/Configuration.php:1043
PHP   8. ReflectionMethod->invoke() /home/travis/build/ILIAS-eLearning/ILIAS/libs/composer/vendor/phpunit/phpunit/src/Framework/TestSuite.php:595
PHP   9. ilGlobalSuite::suite() /home/travis/build/ILIAS-eLearning/ILIAS/libs/composer/vendor/phpunit/phpunit/src/Framework/TestSuite.php:595
PHP  10. ilGlobalSuite::addTestFolderToSuite() /home/travis/build/ILIAS-eLearning/ILIAS/Services/PHPUnit/test/ilGlobalSuite.php:103
PHP  11. require_once() /home/travis/build/ILIAS-eLearning/ILIAS/Services/PHPUnit/test/ilGlobalSuite.php:143
PHP  12. require_once() /home/travis/build/ILIAS-eLearning/ILIAS/tests/UI/Renderer/DefaultRendererTest.php:6
```