### PR TITLE
minimal namespace rules for modules / services

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -15,6 +15,7 @@ A general overview on our processes can be found in the [development guide](http
 ## Coding
 
 - [Coding Guidelines](http://www.ilias.de/docu/goto_docu_pg_202_42.html) (WIP): We are on the way to adapt PSR-2
+- [Namespaces](namespaces.md): Guidelines for using namespaces.
 - [Basic Architecture](https://docu.ilias.de/goto_docu_pg_199_42.html): Slightly outdated, but still relevant. Additionally code is going into our core libraries in the [src directory](../../src/README.md).
 - [GIT introduction](https://docu.ilias.de/goto_docu_pg_15604_42.html)
 - [Unit Tests](../../tests/README.md): How to write unit tests

--- a/docs/development/namespaces.md
+++ b/docs/development/namespaces.md
@@ -1,0 +1,8 @@
+# Namespaces
+
+ILIAS is using PSR-4 namespaces in its [src directory](../../src/README.md).
+
+You MAY also use namespaces in the `Modules` or `Services` directories. You SHOULD use `ILIAS\ModuleName` or `ILIAS\ServiceName`, e.g. `ILIAS\Course` or `ILIAS\ActiveRecord` in these cases.
+
+* Please be informed that we might introduce a PSR-4 based autoloading for these components in the future, too, and revise our directory structure accordingly. **You MAY only make use of these namespaces if you are willing to support these necessary future refactorings**.
+* If you are using namespaces, you SHOULD omit the il-prefix from class names.


### PR DESCRIPTION
We recently had a discussion about how to move forward with namespaces in the TB. This PR is a suggested next step.

Any feedback is appreciated.