### PR TITLE
UI, fix - set page's base-tag only in example-mode

### DIFF
--- a/src/UI/Implementation/Component/Layout/Page/Renderer.php
+++ b/src/UI/Implementation/Component/Layout/Page/Renderer.php
@@ -120,12 +120,11 @@ class Renderer extends AbstractComponentRenderer {
 			foreach ($layout->meta()->getOnloadCode()->getItemsInOrderOfDelivery() as $on_load_code) {
 				$js_inline[] = $on_load_code->getContent();
 			}
-
-			$base_url = $layout->meta()->getBaseURL();
 		}
 
 		if($for_ui_demo) {
 			$base_url = '../../../../../../';
+			$tpl->setVariable("BASE", $base_url);
 
 			array_unshift($js_files, './Services/JavaScript/js/Basic.js');
 
@@ -155,7 +154,6 @@ class Renderer extends AbstractComponentRenderer {
 		$tpl->setVariable("CSS_INLINE", implode(PHP_EOL, $css_inline));
 		$tpl->setVariable("OLCODE", implode(PHP_EOL, $js_inline));
 
-		$tpl->setVariable("BASE", $base_url);
 
 		return $tpl;
 	}

--- a/src/UI/templates/default/Layout/tpl.standardpage.html
+++ b/src/UI/templates/default/Layout/tpl.standardpage.html
@@ -5,7 +5,9 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 
+	<!-- BEGIN base -->
 	<base href="{BASE}" />
+	<!-- END base -->
 
 	<style type="text/css">
 		{CSS_INLINE}


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=25718

There is no need for a base-tag in the standard page; 
furthermore, when using href="#" with a base-url, this url is used instead of the current one.