### PR TITLE
Language: Increased 'identifier' database field length

### DIFF
--- a/Services/Language/classes/class.ilLanguageExtTableGUI.php
+++ b/Services/Language/classes/class.ilLanguageExtTableGUI.php
@@ -111,7 +111,7 @@ class ilLanguageExtTableGUI extends ilTable2GUI
             include_once("./Services/Form/classes/class.ilTextInputGUI.php");
             $ti = new ilTextInputGUI($lng->txt("search"), "pattern");
             $ti->setParent($this->parent_obj);
-            $ti->setMaxLength(64);
+            $ti->setMaxLength(200);
             $ti->setSize(20);
             $this->addFilterItem($ti);
             $ti->readFromSession();

--- a/setup/sql/5_4_hotfixes.php
+++ b/setup/sql/5_4_hotfixes.php
@@ -983,3 +983,17 @@ $ilDB->addIndex('read_event', array('usr_id'), 'i1');
 <?php
 $ilCtrlStructureReader->getStructure();
 ?>
+?>
+<#67>
+<?php
+if ($ilDB->tableColumnExists("lng_data", "identifier")) {
+	$field = array(
+		'type'    => 'text',
+		'length'  => 200,
+		'notnull' => true,
+		'default' => ' '
+	);
+
+	$ilDB->modifyTableColumn("lng_data", "identifier", $field);
+}
+?>


### PR DESCRIPTION
This PR increases the length of the `identifier` field of table `lng_data`. The current field size of 60 can be a problem especially for plugins with a long plugin identifier.