### PR TITLE
Language: Increased 'identifier' database field length

### DIFF
--- a/Services/Language/classes/class.ilLanguageExtTableGUI.php
+++ b/Services/Language/classes/class.ilLanguageExtTableGUI.php
@@ -140,7 +140,7 @@ class ilLanguageExtTableGUI extends ilTable2GUI
             include_once("./Services/Form/classes/class.ilTextInputGUI.php");
             $ti = new ilTextInputGUI(ucfirst($lng->txt("identifier")), "identifier");
             $ti->setParent($this->parent_obj);
-            $ti->setMaxLength(64);
+            $ti->setMaxLength(200);
             $ti->setSize(20);
             $this->addFilterItem($ti);
             $ti->readFromSession();

--- a/setup/sql/dbupdate_05.php
+++ b/setup/sql/dbupdate_05.php
@@ -1231,4 +1231,16 @@ if (!$ilDB->tableColumnExists('tst_manual_fb', 'finalized_by_usr_id')) {
 <?php
 $ilCtrlStructureReader->getStructure();
 ?>
+<#5513>
+<?php
+if ($ilDB->tableColumnExists("lng_data", "identifier")) {
+	$field = array(
+		'type'    => 'text',
+		'length'  => 200,
+		'notnull' => true,
+		'default' => ' '
+	);
 
+	$ilDB->modifyTableColumn("lng_data", "identifier", $field);
+}
+?>


### PR DESCRIPTION
This PR increases the length of the `identifier` field of table `lng_data`. The current field size of 60 can be a problem especially for plugins with a long plugin identifier.