### PR TITLE
Fix 25624

### DIFF
--- a/Services/Container/classes/class.ilContainerContentGUI.php
+++ b/Services/Container/classes/class.ilContainerContentGUI.php
@@ -785,9 +785,19 @@ abstract class ilContainerContentGUI
 			$actions[] = $button;
 
 		}
-		$dropdown = $f->dropdown()->standard($actions);
+
 
 		$def_command = $item_list_gui->getDefaultCommand();
+
+		if ($def_command["frame"] != "") {
+			$button =
+				$f->button()->shy("Open", "")->withAdditionalOnLoadCode(function($id) use ($item, $def_command) {
+					return
+						"$('#$id').click(function(e) { window.open('".str_replace("&amp;", "&", $def_command["link"])."', '".$def_command["frame"]."');});";
+				});
+			$actions[] = $button;
+		}
+		$dropdown = $f->dropdown()->standard($actions);
 
 		$img = $DIC->object()->commonSettings()->tileImage()->getByObjId($a_item_data['obj_id']);
 
@@ -809,7 +819,15 @@ abstract class ilContainerContentGUI
 		$image = $f->image()->responsive($path, "");
 		if ($def_command["link"] != "")	// #24256
 		{
-			$image = $image->withAction($def_command["link"]);
+			if ($def_command["frame"] != "") {
+				$image = $image->withAdditionalOnLoadCode(function($id) use ($def_command) {
+					return
+						"$('#$id').click(function(e) { window.open('".str_replace("&amp;", "&", $def_command["link"])."', '".$def_command["frame"]."');});";
+				});
+			}
+			else {
+				$image = $image->withAction($def_command["link"]);
+			}
 		}
 
 		// card

--- a/Services/Container/classes/class.ilContainerContentGUI.php
+++ b/Services/Container/classes/class.ilContainerContentGUI.php
@@ -753,6 +753,7 @@ abstract class ilContainerContentGUI
 	{
 		global $DIC;
 		$f = $DIC->ui()->factory();
+		$r = $DIC->ui()->renderer();
 		$user = $DIC->user();
 
 		$item_list_gui = $this->getItemGUI($a_item_data);
@@ -789,14 +790,6 @@ abstract class ilContainerContentGUI
 
 		$def_command = $item_list_gui->getDefaultCommand();
 
-		if ($def_command["frame"] != "") {
-			$button =
-				$f->button()->shy("Open", "")->withAdditionalOnLoadCode(function($id) use ($item, $def_command) {
-					return
-						"$('#$id').click(function(e) { window.open('".str_replace("&amp;", "&", $def_command["link"])."', '".$def_command["frame"]."');});";
-				});
-			$actions[] = $button;
-		}
 		$dropdown = $f->dropdown()->standard($actions);
 
 		$img = $DIC->object()->commonSettings()->tileImage()->getByObjId($a_item_data['obj_id']);
@@ -815,6 +808,7 @@ abstract class ilContainerContentGUI
 		}
 
 		$sections = [];
+		$title = $a_item_data["title"];
 
 		$image = $f->image()->responsive($path, "");
 		if ($def_command["link"] != "")	// #24256
@@ -824,14 +818,18 @@ abstract class ilContainerContentGUI
 					return
 						"$('#$id').click(function(e) { window.open('".str_replace("&amp;", "&", $def_command["link"])."', '".$def_command["frame"]."');});";
 				});
+
+				$button =
+					$f->button()->shy($title, "")->withAdditionalOnLoadCode(function($id) use ($def_command) {
+						return
+							"$('#$id').click(function(e) { window.open('".str_replace("&amp;", "&", $def_command["link"])."', '".$def_command["frame"]."');});";
+					});
+				$title = $r->render($button);
 			}
 			else {
 				$image = $image->withAction($def_command["link"]);
 			}
 		}
-
-		// card
-		$title = $a_item_data["title"];
 
 		// description, @todo: move to new ks element
 		if ($a_item_data["description"] != "") {
@@ -858,7 +856,7 @@ abstract class ilContainerContentGUI
 		)->withActions($dropdown
 		);
 
-		if ($def_command["link"] != "")	// #24256
+		if ($def_command["link"] != "" && $def_command["frame"] == "")	// #24256
 		{
 			$card = $card->withTitleAction($def_command["link"]);
 		}

--- a/Services/Container/classes/class.ilContainerContentGUI.php
+++ b/Services/Container/classes/class.ilContainerContentGUI.php
@@ -789,7 +789,6 @@ abstract class ilContainerContentGUI
 
 
 		$def_command = $item_list_gui->getDefaultCommand();
-
 		$dropdown = $f->dropdown()->standard($actions);
 
 		$img = $DIC->object()->commonSettings()->tileImage()->getByObjId($a_item_data['obj_id']);
@@ -810,10 +809,15 @@ abstract class ilContainerContentGUI
 		$sections = [];
 		$title = $a_item_data["title"];
 
+		// workaround for scorm
+		$modified_link =
+			$item_list_gui->modifySAHSlaunch($def_command["link"], $def_command["frame"]);
+
+
 		$image = $f->image()->responsive($path, "");
 		if ($def_command["link"] != "")	// #24256
 		{
-			if ($def_command["frame"] != "") {
+			if ($def_command["frame"] != "" && ($modified_link == $def_command["link"])) {
 				$image = $image->withAdditionalOnLoadCode(function($id) use ($def_command) {
 					return
 						"$('#$id').click(function(e) { window.open('".str_replace("&amp;", "&", $def_command["link"])."', '".$def_command["frame"]."');});";
@@ -827,7 +831,7 @@ abstract class ilContainerContentGUI
 				$title = $r->render($button);
 			}
 			else {
-				$image = $image->withAction($def_command["link"]);
+				$image = $image->withAction($modified_link);
 			}
 		}
 
@@ -856,9 +860,9 @@ abstract class ilContainerContentGUI
 		)->withActions($dropdown
 		);
 
-		if ($def_command["link"] != "" && $def_command["frame"] == "")	// #24256
+		if ($def_command["link"] != "" && ($def_command["frame"] == "" || $modified_link != $def_command["link"]))	// #24256
 		{
-			$card = $card->withTitleAction($def_command["link"]);
+			$card = $card->withTitleAction($modified_link);
 		}
 
 		// properties

--- a/src/UI/Component/Card/Card.php
+++ b/src/UI/Component/Card/Card.php
@@ -14,14 +14,14 @@ interface Card extends Component {
 
 	/**
 	 * Sets the title in the heading section of the card
-	 * @param $title
+	 * @param string|\ILIAS\UI\Component\Button\Shy $title
 	 * @return Standard
 	 */
 	public function withTitle($title);
 
 	/**
 	 * Get the title in the heading section of the card
-	 * @return string
+	 * @return string|\ILIAS\UI\Component\Button\Shy
 	 */
 	public function getTitle();
 

--- a/src/UI/Component/Image/Image.php
+++ b/src/UI/Component/Image/Image.php
@@ -4,13 +4,17 @@
 
 namespace ILIAS\UI\Component\Image;
 
+use ILIAS\UI\Component\JavaScriptBindable;
+use ILIAS\UI\Component\Clickable;
+use ILIAS\UI\Component\Signal;
+
 /**
  * This describes how a glyph could be modified during construction of UI.
  *
  * Interface Image
  * @package ILIAS\UI\Component\Image
  */
-interface Image extends \ILIAS\UI\Component\Component {
+interface Image extends \ILIAS\UI\Component\Component, JavaScriptBindable, Clickable {
 	/**
 	 * Types of images
 	 */
@@ -52,14 +56,14 @@ interface Image extends \ILIAS\UI\Component\Component {
 
 	/**
 	 * Get an image like this with an action
-	 * @param string $url
+	 * @param string|Signal[] $action
 	 * @return \ILIAS\UI\Component\Image\Image
 	 */
-	public function withAction($url);
+	public function withAction($action);
 
 	/**
 	 * Get the action of the image
-	 * @return string|null
+	 * @return string|Signal[]
 	 */
 	public function getAction();
 }

--- a/src/UI/Implementation/Component/Card/Card.php
+++ b/src/UI/Implementation/Component/Card/Card.php
@@ -50,7 +50,9 @@ class Card implements C\Card {
 	 * @param \ILIAS\UI\Component\Image\Image|null $image
 	 */
 	public function __construct($title, \ILIAS\UI\Component\Image\Image $image = null){
-		$this->checkStringArg("title", $title);
+		if (! $title instanceof \ILIAS\UI\Component\Button\Shy) {
+			$this->checkStringArg("title", $title);
+		}
 
 		$this->title = $title;
 		$this->image = $image;
@@ -60,7 +62,9 @@ class Card implements C\Card {
 	 * @inheritdoc
 	 */
 	public function withTitle($title){
-		$this->checkStringArg("title", $title);
+		if (! $title instanceof \ILIAS\UI\Component\Button\Shy) {
+			$this->checkStringArg("title", $title);
+		}
 
 		$clone = clone $this;
 		$clone->title = $title;

--- a/src/UI/Implementation/Component/Card/Renderer.php
+++ b/src/UI/Implementation/Component/Card/Renderer.php
@@ -42,13 +42,19 @@ class Renderer extends AbstractComponentRenderer {
 			$tpl->touchBlock("no_highlight");
 		}
 
+		$title = $component->getTitle();
 		if($component->getTitleAction()) {
 			$tpl->setCurrentBlock("title_action_begin");
 			$tpl->setVariable("HREF",$component->getTitleAction());
 			$tpl->parseCurrentBlock();
+		} else {
+			if ($title instanceof \ILIAS\UI\Component\Button\Shy)
+			{
+				$title = $default_renderer->render($title);
+			}
 		}
 
-		$tpl->setVariable("TITLE",$component->getTitle());
+		$tpl->setVariable("TITLE", $title);
 
 		if($component->getTitleAction()) {
 			$tpl->touchBlock("title_action_end");

--- a/src/UI/Implementation/Component/Image/Image.php
+++ b/src/UI/Implementation/Component/Image/Image.php
@@ -6,6 +6,9 @@ namespace ILIAS\UI\Implementation\Component\Image;
 
 use ILIAS\UI\Component as C;
 use ILIAS\UI\Implementation\Component\ComponentHelper;
+use ILIAS\UI\Component\Signal;
+use ILIAS\UI\Implementation\Component\JavaScriptBindable;
+use ILIAS\UI\Implementation\Component\Triggerer;
 
 /**
  * Class Image
@@ -13,6 +16,8 @@ use ILIAS\UI\Implementation\Component\ComponentHelper;
  */
 class Image implements C\Image\Image {
 	use ComponentHelper;
+	use JavaScriptBindable;
+	use Triggerer;
 
 	/**
 	 * @var	string
@@ -32,7 +37,7 @@ class Image implements C\Image\Image {
 	/**
 	 * @var string
 	 */
-	protected $url = '';
+	protected $action = '';
 
 	/**
 	 * @var []
@@ -102,11 +107,16 @@ class Image implements C\Image\Image {
 	/**
 	 * @inheritdoc
 	 */
-	public function withAction($url) {
-		$this->checkStringArg("url", $url);
-
+	public function withAction($action) {
+		$this->checkStringOrSignalArg("action", $action);
 		$clone = clone $this;
-		$clone->url = $url;
+		if (is_string($action)) {
+			$clone->action = $action;
+		}
+		else {
+			$clone->action = null;
+			$clone->setTriggeredSignal($action, "click");
+		}
 
 		return $clone;
 	}
@@ -115,6 +125,23 @@ class Image implements C\Image\Image {
 	 * @inheritdoc
 	 */
 	public function getAction() {
-		return $this->url;
+		if ($this->action !== null) {
+			return $this->action;
+		}
+		return $this->getTriggeredSignalsFor("click");
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function withOnClick(Signal $signal) {
+		return $this->withTriggeredSignal($signal, 'click');
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function appendOnClick(Signal $signal) {
+		return $this->appendTriggeredSignal($signal, 'click');
 	}
 }

--- a/src/UI/Implementation/Component/Image/Renderer.php
+++ b/src/UI/Implementation/Component/Image/Renderer.php
@@ -23,10 +23,21 @@ class Renderer extends AbstractComponentRenderer {
 		$this->checkComponent($component);
 		$tpl = $this->getTemplate("tpl.image.html", true, true);
 
-		if($component->getAction()) {
-			$tpl->setCurrentBlock("action_begin");
-			$tpl->setVariable("HREF",$component->getAction());
-			$tpl->parseCurrentBlock();
+		$id = $this->bindJavaScript($component);
+		if (!empty($component->getAction())) {
+			$tpl->touchBlock("action_begin");
+
+			if (is_string($component->getAction())) {
+				$tpl->setCurrentBlock("with_href");
+				$tpl->setVariable("HREF", $component->getAction());
+				$tpl->parseCurrentBlock();
+			}
+
+			if (is_array($component->getAction())) {
+				$tpl->setCurrentBlock("with_id");
+				$tpl->setVariable("ID", $id);
+				$tpl->parseCurrentBlock();
+			}
 		}
 
 		$tpl->setCurrentBlock($component->getType());
@@ -34,7 +45,7 @@ class Renderer extends AbstractComponentRenderer {
 		$tpl->setVariable("ALT",htmlspecialchars($component->getAlt()));
 		$tpl->parseCurrentBlock();
 
-		if($component->getAction()) {
+		if (!empty($component->getAction())) {
 			$tpl->touchBlock("action_end");
 		}
 

--- a/src/UI/Implementation/Component/Image/Renderer.php
+++ b/src/UI/Implementation/Component/Image/Renderer.php
@@ -43,6 +43,9 @@ class Renderer extends AbstractComponentRenderer {
 		$tpl->setCurrentBlock($component->getType());
 		$tpl->setVariable("SOURCE",$component->getSource());
 		$tpl->setVariable("ALT",htmlspecialchars($component->getAlt()));
+		if (empty($component->getAction()) && $id !== null) {
+			$tpl->setVariable("IMG_ID", " id='".$id."' ");
+		}
 		$tpl->parseCurrentBlock();
 
 		if (!empty($component->getAction())) {

--- a/src/UI/examples/Image/Standard/with_signal_action.php
+++ b/src/UI/examples/Image/Standard/with_signal_action.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Example for rendering an Image with a signal as action
+ */
+function with_signal_action() {
+	//Loading factories
+	global $DIC;
+	$f = $DIC->ui()->factory();
+	$renderer = $DIC->ui()->renderer();
+
+	//Genarating and rendering the image and modal
+	$image_in_modal = $f->image()->standard(
+		"src/UI/examples/Image/mountains.jpg",
+		"");
+	$page = $f->modal()->lightboxImagePage($image_in_modal, "Nice view");
+	$modal = $f->modal()->lightbox($page);
+
+	$image = $f->image()->standard(
+		"src/UI/examples/Image/HeaderIconLarge.svg",
+		"Thumbnail Example")->withAction($modal->getShowSignal());
+
+	$html = $renderer->render([$image, $modal]);
+
+	return $html;
+}

--- a/src/UI/examples/Image/Standard/with_string_action.php
+++ b/src/UI/examples/Image/Standard/with_string_action.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Example for rendering an Image with a string as action
+ */
+function with_string_action() {
+	//Loading factories
+	global $DIC;
+	$f = $DIC->ui()->factory();
+	$renderer = $DIC->ui()->renderer();
+
+	//Genarating and rendering the image and modal
+	$image = $f->image()->standard(
+		"src/UI/examples/Image/HeaderIconLarge.svg",
+		"Thumbnail Example")->withAction("https://www.ilias.de");
+
+	$html = $renderer->render($image);
+
+	return $html;
+}

--- a/src/UI/templates/default/Image/tpl.image.html
+++ b/src/UI/templates/default/Image/tpl.image.html
@@ -3,11 +3,11 @@
 <!-- END action_begin -->
 
 <!-- BEGIN standard -->
-<img src="{SOURCE}" class="img-standard" {IMG_ID} alt="{ALT}" />
+<img src="{SOURCE}" class="img-standard"{IMG_ID} alt="{ALT}" />
 <!-- END standard -->
 
 <!-- BEGIN responsive -->
-<img src="{SOURCE}" class="img-responsive" {IMG_ID} alt="{ALT}" />
+<img src="{SOURCE}" class="img-responsive"{IMG_ID} alt="{ALT}" />
 <!-- END responsive -->
 
 <!-- BEGIN action_end -->

--- a/src/UI/templates/default/Image/tpl.image.html
+++ b/src/UI/templates/default/Image/tpl.image.html
@@ -3,11 +3,11 @@
 <!-- END action_begin -->
 
 <!-- BEGIN standard -->
-<img src="{SOURCE}" class="img-standard" alt="{ALT}" />
+<img src="{SOURCE}" class="img-standard" {IMG_ID} alt="{ALT}" />
 <!-- END standard -->
 
 <!-- BEGIN responsive -->
-<img src="{SOURCE}" class="img-responsive" alt="{ALT}" />
+<img src="{SOURCE}" class="img-responsive" {IMG_ID} alt="{ALT}" />
 <!-- END responsive -->
 
 <!-- BEGIN action_end -->

--- a/src/UI/templates/default/Image/tpl.image.html
+++ b/src/UI/templates/default/Image/tpl.image.html
@@ -1,5 +1,5 @@
 <!-- BEGIN action_begin -->
-<a href="{HREF}">
+<a<!-- BEGIN with_href --> href="{HREF}"<!-- END with_href --><!-- BEGIN with_id --> id="{ID}"<!-- END with_id -->>
 <!-- END action_begin -->
 
 <!-- BEGIN standard -->

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -14681,6 +14681,9 @@ div#ilContRepIntro img {
 .ilContainerTileRows .il-chart-progressmeter-container {
   height: 100%;
 }
+.ilContainerTileRows .il-card h5 button.btn {
+  font-size: inherit;
+}
 .ilContainerShowMore {
   padding: 15px 10px;
   background-color: white;

--- a/templates/default/delos.less
+++ b/templates/default/delos.less
@@ -1051,6 +1051,7 @@ div.il_info {
 	text-align: right;
 }
 
+
 /* ---------------- headlines ------------------ */
 
 a#il_mhead_t_focus {

--- a/templates/default/less/Services/Container/delos.less
+++ b/templates/default/less/Services/Container/delos.less
@@ -239,6 +239,10 @@ div#ilContRepIntro img {
 	height: 100%;
 }
 
+.ilContainerTileRows .il-card h5 button.btn {
+	font-size: inherit;
+}
+
 .ilContainerShowMore {
 	padding: 15px 10px;
 	background-color: @il-primary-container-bg;

--- a/tests/UI/Component/Image/ImageTest.php
+++ b/tests/UI/Component/Image/ImageTest.php
@@ -6,6 +6,7 @@ require_once(__DIR__."/../../../../libs/composer/vendor/autoload.php");
 require_once(__DIR__."/../../Base.php");
 
 use \ILIAS\UI\Component as C;
+use \ILIAS\UI\Implementation\Component\Signal;
 
 /**
  * Test on button implementation.
@@ -64,11 +65,19 @@ class ImageTest extends ILIAS_UI_TestBase {
 		$this->assertEquals("newAlt", $i->getAlt());
 	}
 
-	public function test_set_action() {
+	public function test_set_string_action() {
 		$f = $this->getImageFactory();
 		$i = $f->standard("source","alt");
 		$i = $i->withAction("newAction");
 		$this->assertEquals("newAction", $i->getAction());
+	}
+
+	public function test_set_signal_action() {
+		$f = $this->getImageFactory();
+		$signal = $this->createMock(C\Signal::class);
+		$i = $f->standard("source","alt");
+		$i = $i->withAction($signal);
+		$this->assertEquals([$signal], $i->getAction());
 	}
 
 	public function test_invalid_source(){
@@ -125,7 +134,7 @@ class ImageTest extends ILIAS_UI_TestBase {
 		$this->assertEquals($expected, $html);
 	}
 
-	public function test_render_with_action() {
+	public function test_render_with_string_action() {
 		$f = $this->getImageFactory();
 		$r = $this->getDefaultRenderer();
 		$i = $f->standard("source", "alt")->withAction("action");
@@ -133,6 +142,20 @@ class ImageTest extends ILIAS_UI_TestBase {
 		$html = $this->normalizeHTML($r->render($i));
 
 		$expected = "<a href=\"action\"><img src=\"source\" class=\"img-standard\" alt=\"alt\" /></a>";
+
+		$this->assertEquals($expected, $html);
+	}
+
+	public function test_render_with_signal_action() {
+		$f = $this->getImageFactory();
+		$r = $this->getDefaultRenderer();
+		$signal = $this->createMock(Signal::class);
+
+		$i = $f->standard("source", "alt")->withAction($signal);
+
+		$html = $this->normalizeHTML($r->render($i));
+
+		$expected = "<a id=\"id_1\"><img src=\"source\" class=\"img-standard\" alt=\"alt\" /></a>";
 
 		$this->assertEquals($expected, $html);
 	}


### PR DESCRIPTION
Fix for
https://mantis.ilias.de/view.php?id=25624

@Amstutz 

This makes the following UI changes

- Merge https://github.com/ILIAS-eLearning/ILIAS/commit/e58cc711ba67c2daac6e8c0e56578a7227741e8b from trunk to https://github.com/ILIAS-eLearning/ILIAS/pull/2017/commits/81c7e4e7e73ad1a6b41185e5979a0eff15ca6af8 in 5.4 branch
- Fix output of the ID for images without action: https://github.com/ILIAS-eLearning/ILIAS/pull/2017/commits/ec29bc4b77f8ff96e27a33a43f0132ce19315d29
- Allow shy buttons for card titles, similar to list item titles: d948ab155ec0c2b6f2ff302732d8724b0561f974

If these changes are ok for you, I would merge this (since it will require some manual work in the container code in the trunk).