### PR TITLE
'open_mode' for "Tile View"

### DIFF
--- a/Services/Container/classes/class.ilContainerContentGUI.php
+++ b/Services/Container/classes/class.ilContainerContentGUI.php
@@ -788,6 +788,11 @@ abstract class ilContainerContentGUI
 		$dropdown = $f->dropdown()->standard($actions);
 
 		$def_command = $item_list_gui->getDefaultCommand();
+		
+		# Link 'open_mode'
+		if ( is_array( $def_command ) ){
+			$def_command["link"] = $item_list_gui->modifySAHSlaunch( $def_command["link"], $def_command["frame"] );
+		}
 
 		$img = $DIC->object()->commonSettings()->tileImage()->getByObjId($a_item_data['obj_id']);
 


### PR DESCRIPTION
(scorm) Object's 'open_mode' was ignored if items are shown as 'cards'. 
The link has to be modified with ilObjectListGUI->modifySAHSlaunch() for it to work.