### PR TITLE
Refinery: Handled punctuation when counting words in a string

### DIFF
--- a/src/Refinery/String/EstimatedReadingTime.php
+++ b/src/Refinery/String/EstimatedReadingTime.php
@@ -66,6 +66,10 @@ class EstimatedReadingTime implements Transformation
             foreach ($textNodes as $textNode) {
                 /** @var \DOMText $textNode */
                 $wordsInContent = array_filter(preg_split('/\s+/', $textNode->textContent));
+
+                $wordsInContent = array_filter($wordsInContent, function (string $word) {
+                    return preg_replace('/^\pP$/', '', $word) !== '';
+                });
                 
                 $numberOfWords += count($wordsInContent);
             }

--- a/tests/Refinery/String/Transformation/EstimatedReadingTimeTest.php
+++ b/tests/Refinery/String/Transformation/EstimatedReadingTimeTest.php
@@ -90,4 +90,26 @@ EOT;
             $onlyTextReadingTimeInfo->transform($text)
         );
     }
+
+    /**
+     * 
+     */
+    public function testSolitaryPunctuationCharactersMustNotEffectReadingTime() : void
+    {
+        $textSegmentWithPunctuation = 'Lorem ipsum <img src="#" />, and some other text... ';
+        $repetitions = 300; // 275 repetitions result in an additional minute, if the `,` would be considered
+        
+        $readingTimeTrafo = $this->refinery->string()->estimatedReadingTime(true);
+        
+        $text = str_repeat($textSegmentWithPunctuation, $repetitions);
+
+        $timeInMinutes = $readingTimeTrafo->transform($text);
+        $this->assertEquals(23, $timeInMinutes);
+
+        $textSegment = 'Lorem ipsum <img src="#" /> and some other text... ';
+        $text = str_repeat($textSegment, $repetitions);
+
+        $timeInMinutes = $readingTimeTrafo->transform($text);
+        $this->assertEquals(23, $timeInMinutes);
+    }
 }

--- a/tests/Refinery/String/Transformation/EstimatedReadingTimeTest.php
+++ b/tests/Refinery/String/Transformation/EstimatedReadingTimeTest.php
@@ -106,8 +106,8 @@ EOT;
         $timeInMinutes = $readingTimeTrafo->transform($text);
         $this->assertEquals(23, $timeInMinutes);
 
-        $textSegment = 'Lorem ipsum <img src="#" /> and some other text... ';
-        $text = str_repeat($textSegment, $repetitions);
+        $textSegmentWithoutPunctuation = 'Lorem ipsum <img src="#" /> and some other text... ';
+        $text = str_repeat($textSegmentWithoutPunctuation, $repetitions);
 
         $timeInMinutes = $readingTimeTrafo->transform($text);
         $this->assertEquals(23, $timeInMinutes);


### PR DESCRIPTION
This PR fixes the 'words in a string' determination by removing that elements from the collection of words, which only contain a punctuation character. This can be valid if a consumer provides an input string like:

```php
$input = 'Lorem upsum <img src="#" />, and some other text...';
```
When splitting the XHTML string by only respecting nodes of type `\DOMText` and using a `\s` as pattern, a single `,` can be left as single character depending on the predecessor and successor.

Mantis Ticket: https://mantis.ilias.de/view.php?id=25846