### PR TITLE
Use actual saved font size to be displayed in editor

### DIFF
--- a/Services/Certificate/xml/fo2xhtml.xsl
+++ b/Services/Certificate/xml/fo2xhtml.xsl
@@ -114,41 +114,8 @@
 							</xsl:choose>
 						</xsl:if>
 						<xsl:if test="@font-size">
-							<xsl:choose>
-								<xsl:when test="@font-size='8pt'">
-									<xsl:text>font-size: 8pt;</xsl:text>
-								</xsl:when>
-								<xsl:when test="@font-size='10pt'">
-
-									<xsl:text>font-size: 10pt;</xsl:text>
-
-								</xsl:when>
-								<xsl:when test="@font-size='12pt'">
-
-									<xsl:text>font-size: 12pt;</xsl:text>
-
-								</xsl:when>
-								<xsl:when test="@font-size='14pt'">
-
-									<xsl:text>font-size: 14pt;</xsl:text>
-
-								</xsl:when>
-								<xsl:when test="@font-size='18pt'">
-
-									<xsl:text>font-size: 18pt;</xsl:text>
-
-								</xsl:when>
-								<xsl:when test="@font-size='24pt'">
-
-									<xsl:text>font-size: 24pt;</xsl:text>
-
-								</xsl:when>
-								<xsl:when test="@font-size='36pt'">
-
-									<xsl:text>font-size: 36pt;</xsl:text>
-
-								</xsl:when>
-							</xsl:choose>
+							<xsl:text>font-size: </xsl:text>
+							<xsl:value-of select="@font-size"/>
 						</xsl:if>
 						<xsl:if test="@padding">
 							<xsl:text>padding: </xsl:text>


### PR DESCRIPTION
Currently there is a mismatch between, saving the certificate template content and displaying it on screen, caused by the XSL definitions (`fo2xhtml.xsl` and `xhtml2fo.xsl`).

While the writing direction (`xhtml2fo.xsl`) would allow any font size the reading site (`fo2xhtml.xsl`) would only allow the font sizes provided by the TinyMCE.

This PR will allow any value for font-size is allowed

Related Mantis Ticket: https://mantis.ilias.de/view.php?id=25815