### PR TITLE
UI/Node: Introduction of new 'Bylined' node type

### DIFF
--- a/src/UI/Component/Tree/Node/Bylined.php
+++ b/src/UI/Component/Tree/Node/Bylined.php
@@ -16,5 +16,5 @@ interface Bylined extends Simple
      * information to the current node
      * @return string
      */
-    public function getBylined() : string;
+    public function getByline() : string;
 }

--- a/src/UI/Component/Tree/Node/Bylined.php
+++ b/src/UI/Component/Tree/Node/Bylined.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\UI\Component\Tree\Node;
+
+/**
+ * This describes a tree node with an byline providing additional information
+ * about this node
+ */
+interface Bylined extends Simple
+{
+    /**
+     * The byline string that will be displayed as additional
+     * information to the current node
+     * @return string
+     */
+    public function getBylined() : string;
+}

--- a/src/UI/Component/Tree/Node/Factory.php
+++ b/src/UI/Component/Tree/Node/Factory.php
@@ -58,9 +58,9 @@ interface Factory
      *        byline of additional information to a tree node.
      * ---
      * @param string                                    $label
-     * @param string                                    $bylined
+     * @param string                                    $byline
      * @param \ILIAS\UI\Component\Symbol\Icon\Icon|null $icon
      * @return Bylined
      */
-    public function bylined(string $label, string $bylined, Icon $icon=null): Bylined;
+    public function bylined(string $label, string $byline, Icon $icon=null): Bylined;
 }

--- a/src/UI/Component/Tree/Node/Factory.php
+++ b/src/UI/Component/Tree/Node/Factory.php
@@ -41,4 +41,26 @@ interface Factory
 	 */
 	public function simple(string $label, Icon $icon=null): Simple;
 
+    /**
+     * ---
+     * description:
+     *   purpose: >
+     *     The Bylined Node is an entry containing additional information about
+     *     the node.
+     *   composition: >
+     *     It consists of a string-label, a byline and an optional Icon.
+     *   effect: >
+     *     This node is a simple node with an additional string-byline.
+     * rules:
+     *   usage:
+     *      1: >
+     *        A Byline Node SHOULD be used when there is a need to display a
+     *        byline of additional information to a tree node.
+     * ---
+     * @param string                                    $label
+     * @param string                                    $bylined
+     * @param \ILIAS\UI\Component\Symbol\Icon\Icon|null $icon
+     * @return Bylined
+     */
+    public function bylined(string $label, string $bylined, Icon $icon=null): Bylined;
 }

--- a/src/UI/Component/Tree/Node/Factory.php
+++ b/src/UI/Component/Tree/Node/Factory.php
@@ -41,26 +41,26 @@ interface Factory
 	 */
 	public function simple(string $label, Icon $icon=null): Simple;
 
-    /**
-     * ---
-     * description:
-     *   purpose: >
-     *     The Bylined Node is an entry containing additional information about
-     *     the node.
-     *   composition: >
-     *     It consists of a string-label, a byline and an optional Icon.
-     *   effect: >
-     *     This node is a simple node with an additional string-byline.
-     * rules:
-     *   usage:
-     *      1: >
-     *        A Byline Node SHOULD be used when there is a need to display a
-     *        byline of additional information to a tree node.
-     * ---
-     * @param string                                    $label
-     * @param string                                    $byline
-     * @param \ILIAS\UI\Component\Symbol\Icon\Icon|null $icon
-     * @return Bylined
-     */
-    public function bylined(string $label, string $byline, Icon $icon=null): Bylined;
+	/**
+	 * ---
+	 * description:
+	 *   purpose: >
+	 *     The Bylined Node is an entry containing additional information about
+	 *     the node.
+	 *   composition: >
+	 *     It consists of a string-label, a byline and an optional Icon.
+	 *   effect: >
+	 *     This node is a simple node with an additional string-byline.
+	 * rules:
+	 *   usage:
+	 *      1: >
+	 *        A Byline Node SHOULD be used when there is a need to display a
+	 *        byline of additional information to a tree node.
+	 * ---
+	 * @param string                                    $label
+	 * @param string                                    $byline
+	 * @param \ILIAS\UI\Component\Symbol\Icon\Icon|null $icon
+	 * @return Bylined
+	 */
+	public function bylined(string $label, string $byline, Icon $icon = null) : Bylined;
 }

--- a/src/UI/Implementation/Component/Tree/Node/Bylined.php
+++ b/src/UI/Implementation/Component/Tree/Node/Bylined.php
@@ -12,20 +12,20 @@ use ILIAS\UI\Component\Tree\Node\Icon;
 
 class Bylined extends \ILIAS\UI\Implementation\Component\Tree\Node\Simple implements BylinedInterface
 {
-    /**
-     * @var string
-     */
-    private $byline;
+	/**
+	 * @var string
+	 */
+	private $byline;
 
-    public function __construct(string $label, string $byline, \ILIAS\UI\Component\Symbol\Icon\Icon $icon = null)
-    {
-        parent::__construct($label, $icon);
+	public function __construct(string $label, string $byline, \ILIAS\UI\Component\Symbol\Icon\Icon $icon = null)
+	{
+		parent::__construct($label, $icon);
 
-        $this->byline = $byline;
-    }
+		$this->byline = $byline;
+	}
 
-    public function getByline() : string
-    {
-        return $this->byline;
-    }
+	public function getByline() : string
+	{
+		return $this->byline;
+	}
 }

--- a/src/UI/Implementation/Component/Tree/Node/Bylined.php
+++ b/src/UI/Implementation/Component/Tree/Node/Bylined.php
@@ -1,0 +1,31 @@
+<?php
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * @author  Niels Theen <ntheen@databay.de>
+ */
+
+namespace ILIAS\UI\Implementation\Component\Tree\Node;
+
+use ILIAS\UI\Component\Tree\Node\Bylined as BylinedInterface;
+use ILIAS\UI\Component\Tree\Node\Icon;
+
+class Bylined extends \ILIAS\UI\Implementation\Component\Tree\Node\Simple implements BylinedInterface
+{
+    /**
+     * @var string
+     */
+    private $byline;
+
+    public function __construct(string $label, string $byline, \ILIAS\UI\Component\Symbol\Icon\Icon $icon = null)
+    {
+        parent::__construct($label, $icon);
+
+        $this->byline = $byline;
+    }
+
+    public function getByline() : string
+    {
+        return $this->byline;
+    }
+}

--- a/src/UI/Implementation/Component/Tree/Node/Factory.php
+++ b/src/UI/Implementation/Component/Tree/Node/Factory.php
@@ -5,6 +5,8 @@ namespace ILIAS\UI\Implementation\Component\Tree\Node;
 
 use ILIAS\UI\Component\Tree\Node as INode;
 use ILIAS\UI\Component\Symbol\Icon\Icon as IIcon;
+use ILIAS\UI\Component\Tree\Node\Bylined as IByline;
+use \ILIAS\UI\Implementation\Component\Tree\Node\Bylined;
 
 class Factory implements INode\Factory
 {
@@ -16,4 +18,8 @@ class Factory implements INode\Factory
 		return new Simple($label, $icon);
 	}
 
+    public function bylined(string $label, string $byline, IIcon $icon = null) : IByline
+    {
+        return new Bylined($label, $byline, $icon);
+    }
 }

--- a/src/UI/Implementation/Component/Tree/Node/Factory.php
+++ b/src/UI/Implementation/Component/Tree/Node/Factory.php
@@ -18,8 +18,8 @@ class Factory implements INode\Factory
 		return new Simple($label, $icon);
 	}
 
-    public function bylined(string $label, string $byline, IIcon $icon = null) : IByline
-    {
-        return new Bylined($label, $byline, $icon);
-    }
+	public function bylined(string $label, string $byline, IIcon $icon = null) : IByline
+	{
+		return new Bylined($label, $byline, $icon);
+	}
 }

--- a/src/UI/Implementation/Component/Tree/Node/Renderer.php
+++ b/src/UI/Implementation/Component/Tree/Node/Renderer.php
@@ -28,6 +28,10 @@ class Renderer extends AbstractComponentRenderer {
 			$async = true;
 		}
 
+		if ($component instanceof Node\Bylined && null !== $component->getByline()) {
+            $tpl->setVariable('BYLINE', $component->getByline());
+        }
+
 		$tpl->setVariable("LABEL", $component->getLabel());
 
 		$icon = $component->getIcon();
@@ -102,7 +106,8 @@ class Renderer extends AbstractComponentRenderer {
 	 */
 	protected function getComponentInterfaceName() {
 		return array(
-			Node\Simple::class
+			Node\Simple::class,
+            Node\Bylined::class
 		);
 	}
 }

--- a/src/UI/Implementation/Component/Tree/Node/Renderer.php
+++ b/src/UI/Implementation/Component/Tree/Node/Renderer.php
@@ -29,8 +29,8 @@ class Renderer extends AbstractComponentRenderer {
 		}
 
 		if ($component instanceof Node\Bylined && null !== $component->getByline()) {
-            $tpl->setVariable('BYLINE', $component->getByline());
-        }
+			$tpl->setVariable('BYLINE', $component->getByline());
+		}
 
 		$tpl->setVariable("LABEL", $component->getLabel());
 
@@ -107,7 +107,7 @@ class Renderer extends AbstractComponentRenderer {
 	protected function getComponentInterfaceName() {
 		return array(
 			Node\Simple::class,
-            Node\Bylined::class
+			Node\Bylined::class
 		);
 	}
 }

--- a/src/UI/examples/Tree/Node/Bylined/bylined.php
+++ b/src/UI/examples/Tree/Node/Bylined/bylined.php
@@ -1,0 +1,13 @@
+<?php
+function bylined() {
+	global $DIC;
+	$f = $DIC->ui()->factory();
+	$renderer = $DIC->ui()->renderer();
+
+	$icon=$f->symbol()->icon()->standard("crs", 'Example');
+
+	$node = $f->tree()->node()->bylined('label', 'byline');
+	$node2 = $f->tree()->node()->bylined('label', 'byline', $icon);
+
+	return $renderer->render([$node, $node2]);
+}

--- a/src/UI/templates/default/Tree/tpl.node.html
+++ b/src/UI/templates/default/Tree/tpl.node.html
@@ -2,8 +2,16 @@
 	class="il-tree-node node-simple<!-- BEGIN expandable --> expandable<!-- END expandable --><!-- BEGIN expanded --> expanded<!-- END expanded --><!-- BEGIN highlighted --> highlighted<!-- END highlighted -->"
 	<!-- BEGIN async_loading --> data-async_url="{ASYNCURL}" data-async_loaded="false"<!-- END async_loading -->
 	>
-	<span class="node-line">{ICON}<span class="node-label">{LABEL}</span></span>
-	<!-- BEGIN subnodes -->
+	<span class="node-line">
+		{ICON}<span class="node-label">{LABEL}</span>
+		<!-- BEGIN byline -->
+		<span class="node-byline">{BYLINE}</span>
+		<!-- END byline -->
+	</span>
+
+
+
+<!-- BEGIN subnodes -->
 	<ul>
 		{SUBNODES}
 	</ul>

--- a/tests/UI/Component/Tree/Node/BylineNodeTest.php
+++ b/tests/UI/Component/Tree/Node/BylineNodeTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/* Copyright (c) 2019 Nils Haagen <nils.haagen@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+require_once("libs/composer/vendor/autoload.php");
+require_once(__DIR__."../../../../Base.php");
+
+use \ILIAS\UI\Component as C;
+use \ILIAS\UI\Implementation\Component as I;
+
+/**
+ * Tests for the SimpleNode.
+ */
+class BylineNodeTest extends ILIAS_UI_TestBase
+{
+    /**
+     * @var I\Tree\Node\Factory
+     */
+    private $node_factory;
+
+    /**
+     * @var C\Symbol\Icon\Standard|I\Symbol\Icon\Standard
+     */
+    private $icon;
+
+    public function setUp(): void
+	{
+		$this->node_factory = new I\Tree\Node\Factory();
+		$icon_factory = new I\Symbol\Icon\Factory();
+		$this->icon = $icon_factory->standard("", '');
+	}
+
+	public function createBylineNode()
+    {
+        $node = $this->node_factory->bylined('My Label', 'This is my byline', $this->icon);
+        $this->assertEquals('My Label', $node->getBylined());
+        $this->assertEquals('This is my byline', $node->getBylined());
+        $this->assertEquals($this->icon, $node->getIcon());
+    }
+
+}

--- a/tests/UI/Component/Tree/Node/BylineNodeTest.php
+++ b/tests/UI/Component/Tree/Node/BylineNodeTest.php
@@ -7,6 +7,10 @@ require_once(__DIR__."../../../../Base.php");
 
 use \ILIAS\UI\Component as C;
 use \ILIAS\UI\Implementation\Component as I;
+use ILIAS\UI\Implementation\Component\Input\Field\FieldRendererFactory;
+use ILIAS\UI\Implementation\Component\Symbol\Glyph\GlyphRendererFactory;
+use ILIAS\UI\Implementation\Render\DefaultRendererFactory;
+use ILIAS\UI\Implementation\Render\JavaScriptBinding;
 
 /**
  * Tests for the SimpleNode.
@@ -30,12 +34,135 @@ class BylineNodeTest extends ILIAS_UI_TestBase
 		$this->icon = $icon_factory->standard("", '');
 	}
 
-	public function createBylineNode()
-    {
-        $node = $this->node_factory->bylined('My Label', 'This is my byline', $this->icon);
-        $this->assertEquals('My Label', $node->getBylined());
-        $this->assertEquals('This is my byline', $node->getBylined());
-        $this->assertEquals($this->icon, $node->getIcon());
-    }
+	public function testCreateBylineNode()
+	{
+		$node = $this->node_factory->bylined('My Label', 'This is my byline', $this->icon);
+		$this->assertEquals('My Label', $node->getLabel());
+		$this->assertEquals('This is my byline', $node->getByline());
+		$this->assertEquals($this->icon, $node->getIcon());
+	}
 
+	public function testRendering()
+	{
+		$node = $this->node_factory->bylined('My Label', 'This is my byline');
+
+		$r = $this->getDefaultRenderer();
+		$html = $r->render($node);
+
+		$expected = <<<EOT
+			<li id=""class="il-tree-node node-simple">
+				<span class="node-line">
+					<span class="node-label">My Label</span>
+					<span class="node-byline">This is my byline</span>
+				</span>
+			</li>
+EOT;
+
+		$this->assertEquals(
+			$this->brutallyTrimHTML($expected),
+			$this->brutallyTrimHTML($html)
+		);
+	}
+
+	public function testRenderingWithIcon()
+	{
+		$node = $this->node_factory->bylined('My Label', 'This is my byline', $this->icon);
+
+		$r = $this->getDefaultRenderer();
+		$html = $r->render($node);
+
+		$expected = <<<EOT
+			<li id=""class="il-tree-node node-simple">
+				<span class="node-line">
+					<div class="icon small" aria-label=""></div>
+					<span class="node-label">My Label</span>
+					<span class="node-byline">This is my byline</span>
+				</span>
+			</li>
+EOT;
+
+		$this->assertEquals(
+			$this->brutallyTrimHTML($expected),
+			$this->brutallyTrimHTML($html)
+		);
+	}
+
+	public function testRenderingWithAsync()
+	{
+		$node = $this->node_factory->bylined('My Label', 'This is my byline');
+		$node = $node->withAsyncURL('something.de');
+
+		$r = $this->getDefaultRenderer();
+		$html = $r->render($node);
+
+		$expected = <<<EOT
+			<li id=""
+				class="il-tree-node node-simple expandable" data-async_url="something.de" data-async_loaded="false">
+				<span class="node-line">
+					<span class="node-label">My Label</span>
+					<span class="node-byline">This is my byline</span>
+				</span>
+			</li>
+EOT;
+
+		$this->assertEquals(
+			$this->brutallyTrimHTML($expected),
+			$this->brutallyTrimHTML($html)
+		);
+	}
+
+	public function getDefaultRenderer(JavaScriptBinding $js_binding = null) {
+		$ui_factory = $this->getUIFactory();
+		$tpl_factory = $this->getTemplateFactory();
+		$resource_registry = $this->getResourceRegistry();
+		$lng = $this->getLanguage();
+		if(!$js_binding){
+			$js_binding = $this->getJavaScriptBinding();
+		}
+
+		$defaultRendererFactory = new DefaultRendererFactory(
+			$ui_factory,
+			$tpl_factory,
+			$lng,
+			$js_binding
+		);
+
+		$glyphRendererFactory   = new GlyphRendererFactory(
+			$ui_factory,
+			$tpl_factory,
+			$lng,
+			$js_binding
+		);
+
+		$fieldRendererFactory = new FieldRendererFactory(
+			$ui_factory,
+			$tpl_factory,
+			$lng,
+			$js_binding
+		);
+
+		$fsLoader               = new \ILIAS\UI\Implementation\Render\FSLoader(
+			$defaultRendererFactory,
+			$glyphRendererFactory,
+			$fieldRendererFactory
+		);
+
+		$loaderResourceRegistryWrapper = new \ILIAS\UI\Implementation\Render\LoaderResourceRegistryWrapper(
+			$resource_registry,
+			$fsLoader
+		);
+
+		$component_renderer_loader
+		                               = new \ILIAS\UI\Implementation\Render\LoaderCachingWrapper(
+			$loaderResourceRegistryWrapper
+		);
+		return new TestDefaultRenderer($component_renderer_loader);
+	}
+
+	private function brutallyTrimHTML($html)
+	{
+		$html = str_replace(["\n", "\r", "\t"], "", $html);
+		$html = preg_replace('# {2,}#', " ", $html);
+		return trim($html);
+	}
 }


### PR DESCRIPTION
This PR adds a new type of node that will display a byline beneath the actual label.

This component was developed during the process of a feature described in the feature wiki: https://docu.ilias.de/goto_docu_wiki_wpage_5737_1357.html

An example can be seen on this screenshot:
![Screenshot_2019-08-07 Screenshot(1)](https://user-images.githubusercontent.com/1578709/62624223-e4ca4a80-b922-11e9-8c80-21dd94665eb0.png)

We will provide the implementation to this component once the interfaces are accepted :+1: 