### PR TITLE
[Certificates] Remove usage of il certificate in certificate GUI elements

### DIFF
--- a/Services/Certificate/classes/Form/Repository/class.ilCertificateSettingsCourseFormRepository.php
+++ b/Services/Certificate/classes/Form/Repository/class.ilCertificateSettingsCourseFormRepository.php
@@ -136,8 +136,6 @@ class ilCertificateSettingsCourseFormRepository implements ilCertificateFormRepo
 
     /**
      * @param ilCertificateGUI $certificateGUI
-     * @param ilCertificate    $certificateObject
-     * @param string           $certificatePath
      * @return ilPropertyFormGUI
      * @throws \ILIAS\Filesystem\Exception\FileAlreadyExistsException
      * @throws \ILIAS\Filesystem\Exception\FileNotFoundException
@@ -146,9 +144,9 @@ class ilCertificateSettingsCourseFormRepository implements ilCertificateFormRepo
      * @throws ilException
      * @throws ilWACException
      */
-    public function createForm(ilCertificateGUI $certificateGUI, ilCertificate $certificateObject)
+    public function createForm(ilCertificateGUI $certificateGUI)
     {
-        $form = $this->settingsFromFactory->createForm($certificateGUI, $certificateObject);
+        $form = $this->settingsFromFactory->createForm($certificateGUI);
 
         $objectLearningProgressSettings = new ilLPObjSettings($this->object->getId());
 

--- a/Services/Certificate/classes/Form/Repository/class.ilCertificateSettingsCourseFormRepository.php
+++ b/Services/Certificate/classes/Form/Repository/class.ilCertificateSettingsCourseFormRepository.php
@@ -70,6 +70,7 @@ class ilCertificateSettingsCourseFormRepository implements ilCertificateFormRepo
     public function __construct(
         \ilObject $object,
         string $certificatePath,
+        bool $hasAdditionalElements,
         ilLanguage $language,
         ilCtrl $controller,
         ilAccess $access,
@@ -91,6 +92,7 @@ class ilCertificateSettingsCourseFormRepository implements ilCertificateFormRepo
             $settingsFromFactory = new ilCertificateSettingsFormRepository(
                 $object->getId(),
                 $certificatePath,
+                $hasAdditionalElements,
                 $language,
                 $controller,
                 $access,

--- a/Services/Certificate/classes/Form/Repository/class.ilCertificateSettingsExerciseRepository.php
+++ b/Services/Certificate/classes/Form/Repository/class.ilCertificateSettingsExerciseRepository.php
@@ -73,9 +73,9 @@ class ilCertificateSettingsExerciseRepository implements ilCertificateFormReposi
      * @throws ilException
      * @throws ilWACException
      */
-    public function createForm(ilCertificateGUI $certificateGUI, ilCertificate $certificateObject)
+    public function createForm(ilCertificateGUI $certificateGUI)
     {
-        $form = $this->settingsFromFactory->createForm($certificateGUI, $certificateObject);
+        $form = $this->settingsFromFactory->createForm($certificateGUI);
 
         return $form;
     }

--- a/Services/Certificate/classes/Form/Repository/class.ilCertificateSettingsExerciseRepository.php
+++ b/Services/Certificate/classes/Form/Repository/class.ilCertificateSettingsExerciseRepository.php
@@ -34,6 +34,7 @@ class ilCertificateSettingsExerciseRepository implements ilCertificateFormReposi
     public function __construct(
         ilObject $object,
         string $certificatePath,
+        bool $hasAdditionalElements,
         ilLanguage $language,
         ilCtrl $controller,
         ilAccessHandler $access,
@@ -48,6 +49,7 @@ class ilCertificateSettingsExerciseRepository implements ilCertificateFormReposi
             $settingsFormFactory = new ilCertificateSettingsFormRepository(
                 $object->getId(),
                 $certificatePath,
+                $hasAdditionalElements,
                 $language,
                 $controller,
                 $access,

--- a/Services/Certificate/classes/Form/Repository/class.ilCertificateSettingsFormRepository.php
+++ b/Services/Certificate/classes/Form/Repository/class.ilCertificateSettingsFormRepository.php
@@ -62,6 +62,11 @@ class ilCertificateSettingsFormRepository implements ilCertificateFormRepository
     private $certificatePath;
 
     /**
+     * @var bool
+     */
+    private $hasAdditionalElements;
+
+    /**
      * @var ilCertificateBackgroundImageFileService
      */
     private $backGroundImageFileService;
@@ -83,6 +88,7 @@ class ilCertificateSettingsFormRepository implements ilCertificateFormRepository
     public function __construct(
         int $objectId,
         string $certificatePath,
+        bool $hasAdditionalElements,
         ilLanguage $language,
         ilCtrl $controller,
         ilAccess $access,
@@ -105,6 +111,7 @@ class ilCertificateSettingsFormRepository implements ilCertificateFormRepository
         $this->toolbar                      = $toolbar;
         $this->placeholderDescriptionObject = $placeholderDescriptionObject;
         $this->certificatePath              = $certificatePath;
+        $this->hasAdditionalElements        = $hasAdditionalElements;
 
         $database                           = $DIC->database();
 
@@ -325,7 +332,7 @@ class ilCertificateSettingsFormRepository implements ilCertificateFormRepository
 
         $form->addItem($certificate);
 
-        if ($certificateObject->getAdapter()->hasAdditionalFormElements()) {
+        if (true === $this->hasAdditionalElements) {
             $formSection = new \ilFormSectionHeaderGUI();
             $formSection->setTitle($this->language->txt("cert_form_sec_add_features"));
             $form->addItem($formSection);

--- a/Services/Certificate/classes/Form/Repository/class.ilCertificateSettingsFormRepository.php
+++ b/Services/Certificate/classes/Form/Repository/class.ilCertificateSettingsFormRepository.php
@@ -168,10 +168,7 @@ class ilCertificateSettingsFormRepository implements ilCertificateFormRepository
      * @throws ilException
      * @throws ilWACException
      */
-    public function createForm(
-        ilCertificateGUI $certificateGUI,
-        ilCertificate $certificateObject
-    ) {
+    public function createForm(ilCertificateGUI $certificateGUI) {
         $certificateTemplate = $this->templateRepository->fetchCurrentlyUsedCertificate($this->objectId);
 
         $command = $this->controller->getCmd();

--- a/Services/Certificate/classes/Form/Repository/class.ilCertificateSettingsScormFormRepository.php
+++ b/Services/Certificate/classes/Form/Repository/class.ilCertificateSettingsScormFormRepository.php
@@ -40,6 +40,7 @@ class ilCertificateSettingsScormFormRepository implements ilCertificateFormRepos
     public function __construct(
         ilObject $object,
         string $certificatePath,
+        bool $hasAdditionalElements,
         ilLanguage $language,
         ilCtrl $controller,
         ilAccess $access,
@@ -56,6 +57,7 @@ class ilCertificateSettingsScormFormRepository implements ilCertificateFormRepos
             $settingsFormRepository = new ilCertificateSettingsFormRepository(
                 $object->getId(),
                 $certificatePath,
+                $hasAdditionalElements,
                 $language,
                 $controller,
                 $access,

--- a/Services/Certificate/classes/Form/Repository/class.ilCertificateSettingsScormFormRepository.php
+++ b/Services/Certificate/classes/Form/Repository/class.ilCertificateSettingsScormFormRepository.php
@@ -76,7 +76,6 @@ class ilCertificateSettingsScormFormRepository implements ilCertificateFormRepos
 
     /**
      * @param ilCertificateGUI $certificateGUI
-     * @param ilCertificate    $certificateObject
      * @param string           $certificatePath
      * @return ilPropertyFormGUI
      * @throws \ILIAS\Filesystem\Exception\FileAlreadyExistsException
@@ -86,9 +85,9 @@ class ilCertificateSettingsScormFormRepository implements ilCertificateFormRepos
      * @throws ilException
      * @throws ilWACException
      */
-    public function createForm(ilCertificateGUI $certificateGUI, ilCertificate $certificateObject)
+    public function createForm(ilCertificateGUI $certificateGUI)
     {
-        $form = $this->settingsFromFactory->createForm($certificateGUI, $certificateObject);
+        $form = $this->settingsFromFactory->createForm($certificateGUI);
 
         $short_name = new ilTextInputGUI($this->language->txt('certificate_short_name'), 'short_name');
         $short_name->setRequired(true);

--- a/Services/Certificate/classes/Form/Repository/class.ilCertificateSettingsTestFormRepository.php
+++ b/Services/Certificate/classes/Form/Repository/class.ilCertificateSettingsTestFormRepository.php
@@ -75,11 +75,8 @@ class ilCertificateSettingsTestFormRepository implements ilCertificateFormReposi
      * @throws ilException
      * @throws ilWACException
      */
-    public function createForm(
-        ilCertificateGUI $certificateGUI,
-        ilCertificate $certificateObject
-    ) {
-        $form = $this->settingsFromFactory->createForm($certificateGUI, $certificateObject);
+    public function createForm(ilCertificateGUI $certificateGUI) {
+        $form = $this->settingsFromFactory->createForm($certificateGUI);
 
         return $form;
     }

--- a/Services/Certificate/classes/Form/Repository/class.ilCertificateSettingsTestFormRepository.php
+++ b/Services/Certificate/classes/Form/Repository/class.ilCertificateSettingsTestFormRepository.php
@@ -22,19 +22,21 @@ class ilCertificateSettingsTestFormRepository implements ilCertificateFormReposi
     private $testObject;
 
     /**
-     * @param int $objectId
-     * @param string $certificatePath
-     * @param ilObjTest $testObject
-     * @param ilLanguage $language
-     * @param ilCtrl $controller
-     * @param ilAccess $access
-     * @param ilToolbarGUI $toolbar
-     * @param ilCertificatePlaceholderDescription $placeholderDescriptionObject
+     * @param int                                      $objectId
+     * @param string                                   $certificatePath
+     * @param bool                                     $hasAdditionalElements
+     * @param ilObjTest                                $testObject
+     * @param ilLanguage                               $language
+     * @param ilCtrl                                   $controller
+     * @param ilAccess                                 $access
+     * @param ilToolbarGUI                             $toolbar
+     * @param ilCertificatePlaceholderDescription      $placeholderDescriptionObject
      * @param ilCertificateSettingsFormRepository|null $settingsFormRepository
      */
     public function __construct(
         int $objectId,
         string $certificatePath,
+        bool $hasAdditionalElements,
         ilObjTest $testObject,
         ilLanguage $language,
         ilCtrl $controller,
@@ -50,6 +52,7 @@ class ilCertificateSettingsTestFormRepository implements ilCertificateFormReposi
             $settingsFormRepository = new ilCertificateSettingsFormRepository(
                 $objectId,
                 $certificatePath,
+                $hasAdditionalElements,
                 $language,
                 $controller,
                 $access,

--- a/Services/Certificate/classes/Form/Repository/interface.ilCertificateFormRepository.php
+++ b/Services/Certificate/classes/Form/Repository/interface.ilCertificateFormRepository.php
@@ -8,10 +8,9 @@ interface ilCertificateFormRepository
 {
     /**
      * @param ilCertificateGUI $certificateGUI
-     * @param ilCertificate $certificateObject
      * @return ilPropertyFormGUI
      */
-    public function createForm(ilCertificateGUI $certificateGUI, ilCertificate $certificateObject);
+    public function createForm(ilCertificateGUI $certificateGUI);
 
     /**
      * @param array $formFields

--- a/Services/Certificate/classes/Gui/class.ilCertificateGUIFactory.php
+++ b/Services/Certificate/classes/Gui/class.ilCertificateGUIFactory.php
@@ -51,6 +51,7 @@ class ilCertificateGUIFactory
                 $formFactory = new ilCertificateSettingsTestFormRepository(
                     $objectId,
                     $certificatePath,
+                    false,
                     $object,
                     $DIC->language(),
                     $DIC->ctrl(),
@@ -68,6 +69,8 @@ class ilCertificateGUIFactory
 
                 break;
             case 'crs':
+                $hasAdditionalElements = true;
+
                 $adapter = new ilCourseCertificateAdapter($object);
                 $placeholderDescriptionObject = new ilCoursePlaceholderDescription();
                 $placeholderValuesObject = new ilCoursePlaceholderValues();
@@ -77,6 +80,7 @@ class ilCertificateGUIFactory
                 $formFactory = new ilCertificateSettingsCourseFormRepository(
                     $object,
                     $certificatePath,
+                    false,
                     $DIC->language(),
                     $DIC->ctrl(),
                     $DIC->access(),
@@ -96,6 +100,7 @@ class ilCertificateGUIFactory
                 $formFactory = new ilCertificateSettingsExerciseRepository(
                     $object,
                     $certificatePath,
+                    false,
                     $DIC->language(),
                     $DIC->ctrl(),
                     $DIC->access(),
@@ -115,6 +120,7 @@ class ilCertificateGUIFactory
                 $formFactory = new ilCertificateSettingsScormFormRepository(
                     $object,
                     $certificatePath,
+                    true,
                     $DIC->language(),
                     $DIC->ctrl(),
                     $DIC->access(),

--- a/Services/Certificate/test/ilCertificateSettingsCourseFormRepositoryTest.php
+++ b/Services/Certificate/test/ilCertificateSettingsCourseFormRepositoryTest.php
@@ -81,6 +81,7 @@ class ilCertificateSettingsCourseFormRepositoryTest extends ilCertificateBaseTes
         $repository = new ilCertificateSettingsCourseFormRepository(
             $object,
             '/some/where',
+            false,
             $language,
             $controller,
             $access,
@@ -175,6 +176,7 @@ class ilCertificateSettingsCourseFormRepositoryTest extends ilCertificateBaseTes
         $repository = new ilCertificateSettingsCourseFormRepository(
             $object,
             '/some/where',
+            false,
             $language,
             $controller,
             $access,

--- a/Services/Certificate/test/ilCertificateSettingsExerciseRepositoryTest.php
+++ b/Services/Certificate/test/ilCertificateSettingsExerciseRepositoryTest.php
@@ -48,6 +48,7 @@ class ilCertificateSettingsExerciseRepositoryTest extends ilCertificateBaseTestC
         $repository = new ilCertificateSettingsExerciseRepository(
             $object,
             '/some/where/',
+            false,
             $language,
             $controller,
             $access,
@@ -109,6 +110,7 @@ class ilCertificateSettingsExerciseRepositoryTest extends ilCertificateBaseTestC
         $repository = new ilCertificateSettingsExerciseRepository(
             $object,
             '/some/where/',
+            false,
             $language,
             $controller,
             $access,
@@ -162,6 +164,7 @@ class ilCertificateSettingsExerciseRepositoryTest extends ilCertificateBaseTestC
         $repository = new ilCertificateSettingsExerciseRepository(
             $object,
             '/some/where/',
+            false,
             $language,
             $controller,
             $access,

--- a/Services/Certificate/test/ilCertificateSettingsScormFormRepositoryTest.php
+++ b/Services/Certificate/test/ilCertificateSettingsScormFormRepositoryTest.php
@@ -47,6 +47,7 @@ class ilCertificateSettingsScormFormRepositoryTest extends ilCertificateBaseTest
         $repository = new ilCertificateSettingsScormFormRepository(
             $object,
             '/some/where/',
+            false,
             $language,
             $controller,
             $access,
@@ -116,6 +117,7 @@ class ilCertificateSettingsScormFormRepositoryTest extends ilCertificateBaseTest
         $repository = new ilCertificateSettingsScormFormRepository(
             $object,
             '/some/where/',
+            false,
             $language,
             $controller,
             $access,

--- a/Services/Certificate/test/ilCertificateSettingsTestFormRepositoryTest.php
+++ b/Services/Certificate/test/ilCertificateSettingsTestFormRepositoryTest.php
@@ -48,6 +48,7 @@ class ilCertificateSettingsTestFormRepositoryTest extends ilCertificateBaseTestC
         $repository = new ilCertificateSettingsTestFormRepository(
             100,
             '/some/where/',
+            false,
             $object,
             $language,
             $controller,
@@ -110,6 +111,7 @@ class ilCertificateSettingsTestFormRepositoryTest extends ilCertificateBaseTestC
         $repository = new ilCertificateSettingsTestFormRepository(
             100,
             '/some/where/',
+            false,
             $object,
             $language,
             $controller,
@@ -164,6 +166,7 @@ class ilCertificateSettingsTestFormRepositoryTest extends ilCertificateBaseTestC
         $repository = new ilCertificateSettingsTestFormRepository(
             100,
             '/some/where/',
+            false,
             $object,
             $language,
             $controller,


### PR DESCRIPTION
This will remove the dependency of `ilCertificate` of the GUI setting elements, because these are not needed anymore.