### PR TITLE
[Certificates] Extract ZIP methods into separated class

### DIFF
--- a/Modules/Test/classes/class.ilTestEvaluationGUI.php
+++ b/Modules/Test/classes/class.ilTestEvaluationGUI.php
@@ -875,11 +875,13 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
 		$database = $DIC->database();
 		$logger = $DIC->logger()->root();
 
-		$factory = new ilCertificateFactory();
+		$objectId    = $this->object->getId();
+		$zipAction = new ilUserCertificateZip(
+			$objectId,
+			ilCertificatePathConstants::TEST_PATH . $objectId . '/'
+		);
 
-		$certificate = $factory->create($this->object);
-
-		$archive_dir = $certificate->createArchiveDirectory();
+		$archive_dir = $zipAction->createArchiveDirectory();
 		$total_users = array();
 		
 		$this->object->setAccessFilteredParticipantList(
@@ -898,7 +900,7 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
 			{
 				$user_id = $this->object->_getUserIdFromActiveId($active_id);
 				
-				if( !$certValidator->isCertificateDownloadable($user_id, $this->object->getId()) )
+				if( !$certValidator->isCertificateDownloadable($user_id, $objectId) )
 				{
 					continue;
 				}
@@ -910,13 +912,13 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
 					$this->lng->txt('error_creating_certificate_pdf')
 				);
 
-				$pdf = $pdfAction->createPDF($user_id, $this->object->getid());
+				$pdf = $pdfAction->createPDF($user_id, $objectId);
 				if (strlen($pdf))
 				{
-					$certificate->addPDFtoArchiveDirectory($pdf, $archive_dir, $user_id . "_" . str_replace(" ", "_", ilUtil::getASCIIFilename($name)) . ".pdf");
+					$zipAction->addPDFtoArchiveDirectory($pdf, $archive_dir, $user_id . "_" . str_replace(" ", "_", ilUtil::getASCIIFilename($name)) . ".pdf");
 				}
 			}
-			$zipArchive = $certificate->zipCertificatesInArchiveDirectory($archive_dir, TRUE);
+			$zipArchive = $zipAction->zipCertificatesInArchiveDirectory($archive_dir, TRUE);
 		}
 
 	}

--- a/Services/Certificate/classes/User/Action/Zip/class.ilUserCertificateZip.php
+++ b/Services/Certificate/classes/User/Action/Zip/class.ilUserCertificateZip.php
@@ -1,0 +1,115 @@
+<?php
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * @author  Niels Theen <ntheen@databay.de>
+ */
+class ilUserCertificateZip
+{
+
+    /**
+     * @var int
+     */
+    private $objectId;
+
+    /**
+     * @var string
+     */
+    private $webDirectory;
+
+    /**
+     * @var string
+     */
+    private $certificatePath;
+
+    /**
+     * @var string
+     */
+    private $typeInFileName;
+
+    /**
+     * @var string
+     */
+    private $installionId;
+
+    public function __construct(
+        int $objectId,
+        string $certificatePath,
+        string $webDirectory = CLIENT_WEB_DIR,
+        string $installationId = IL_INST_ID
+    ) {
+        $this->objectId = $objectId;
+        $this->certificatePath = $certificatePath;
+        $this->webDirectory = $webDirectory;
+        $this->installionId = $installationId;
+
+        // The mapping to types is made to reflect the old behaviour of
+        // the adapters
+        $iliasType = ilObject::_lookupType($this->objectId);
+
+        $typeInFileName = 'not_defined';
+        if ('crs' === $iliasType) {
+            $typeInFileName = 'course';
+        } elseif ('tst' === $iliasType) {
+            $typeInFileName = 'test';
+        } elseif ('exc' === $iliasType) {
+            $typeInFileName = 'exc';
+        } elseif ('sahs' === $iliasType) {
+            $typeInFileName = 'scorm';
+        }
+
+        $this->typeInFileName = $typeInFileName;
+    }
+
+    /**
+     * Creates a directory for a zip archive containing multiple certificates
+     *
+     * @return string The created archive directory
+     */
+    public function createArchiveDirectory()
+    {
+        $type = ilObject::_lookupType($this->objectId);
+        $certificateId = $this->objectId;
+
+        $directory = $this->webDirectory . $this->certificatePath . time() . '__' . $this->installionId . '__' . $type . '__' . $certificateId . '__certificate/';
+        ilUtil::makeDirParents($directory);
+
+        return $directory;
+    }
+
+    /**
+     * Adds PDF data as a file to a given directory
+     *
+     * @param binary $pdfdata Binary PDF data
+     * @param string $dir Directory to contain the PDF data
+     * @param string $filename The filename to save the PDF data
+     */
+    public function addPDFtoArchiveDirectory($pdfdata, $dir, $filename)
+    {
+        $fh = fopen($dir . $filename, 'wb');
+        fwrite($fh, $pdfdata);
+        fclose($fh);
+    }
+
+    /**
+     * Create a ZIP file from a directory with certificates
+     *
+     * @param string $dir Directory containing the certificates
+     * @param boolean $deliver TRUE to deliver the ZIP file, FALSE to return the filename only
+     * @return string The created ZIP archive path
+     */
+    public function zipCertificatesInArchiveDirectory($dir, $deliver = true)
+    {
+        $zipFile = time() . '__' . $this->installionId . '__' . $this->typeInFileName . '__' . $this->objectId . '__certificates.zip';
+        $zipFilePath = $this->webDirectory . $this->certificatePath . $zipFile;
+
+        ilUtil::zip($dir, $zipFilePath);
+        ilUtil::delDir($dir);
+
+        if ($deliver) {
+            ilUtil::deliverFile($zipFilePath, $zipFile, 'application/zip', false, true);
+        }
+
+        return $zipFilePath;
+    }
+}

--- a/Services/Certificate/classes/class.ilCertificate.php
+++ b/Services/Certificate/classes/class.ilCertificate.php
@@ -255,54 +255,6 @@ class ilCertificate
     /* BULK CERTIFICATE PROCESSING METHODS *
     /***************************************
 
-    /**
-    * Creates a directory for a zip archive containing multiple certificates
-    *
-    * @return string The created archive directory
-    */
-    public function createArchiveDirectory()
-    {
-        $type = ilObject::_lookupType($this->objectId);
-        $certificateId = $this->objectId;
-
-        $dir = CLIENT_WEB_DIR . $this->certificatePath . time() . "__" . IL_INST_ID . "__" . $type . "__" . $certificateId . "__certificate/";
-        ilUtil::makeDirParents($dir);
-        return $dir;
-    }
-
-    /**
-    * Adds PDF data as a file to a given directory
-    *
-    * @param string $pdfdata Binary PDF data
-    * @param string $dir Directory to contain the PDF data
-    * @param string $filename The filename to save the PDF data
-    */
-    public function addPDFtoArchiveDirectory($pdfdata, $dir, $filename)
-    {
-        $fh = fopen($dir . $filename, "wb");
-        fwrite($fh, $pdfdata);
-        fclose($fh);
-    }
-
-    /**
-    * Create a ZIP file from a directory with certificates
-    *
-    * @param string $dir Directory containing the certificates
-    * @param boolean $deliver TRUE to deliver the ZIP file, FALSE to return the filename only
-    * @return string The created ZIP archive path
-    */
-    public function zipCertificatesInArchiveDirectory($dir, $deliver = true)
-    {
-        $zipfile = time() . "__" . IL_INST_ID . "__" . $this->getAdapter()->getAdapterType() . "__" . $this->getAdapter()->getCertificateId() . "__certificates.zip";
-        $zipfilePath = CLIENT_WEB_DIR . $this->certificatePath . $zipfile;
-        ilUtil::zip($dir, $zipfilePath);
-        ilUtil::delDir($dir);
-        if ($deliver) {
-            ilUtil::deliverFile($zipfilePath, $zipfile, "application/zip", false, true);
-        }
-        return $zipfilePath;
-    }
-
     public static function isActive()
     {
         if (self::$is_active === null) {


### PR DESCRIPTION
Extract actions to create ZIP from certificates.

This is currently only used in module test, so the usage here is very limited.