### PR TITLE
Patch lti lib

### DIFF
--- a/libs/composer/composer.json
+++ b/libs/composer/composer.json
@@ -25,7 +25,7 @@
 		"tecnickcom/tcpdf": "^6.2.12",
 		"pimple/pimple" : "^3.0",
 		"symfony/yaml": "^3.1",
-		"imsglobal/lti": "^3.0",
+		"imsglobal/lti": "^3.0.2",
 		"guzzlehttp/psr7": "^1.4",
 		"psr/http-message": "^1.0",
 		"dflydev/fig-cookies": "^1.0",
@@ -180,7 +180,7 @@
 		},                
 		"imsglobal/lti" : {
 			"source": "https://github.com/ILIAS-eLearning/LTI-Tool-Provider-Library-PHP",
-			"used_version": "v3.0.0",
+			"used_version": "v3.0.2",
 			"added_by": "Stefan Meyer <smeyer.ilias@gmx.de>",
 			"wrapped_by": "",
 			"last_update": "2016-11-24",
@@ -357,6 +357,9 @@
 			},
 			"simplesamlphp/simplesamlphp": {
 				"ILIAS SimpleSAMLphp Patches": "patches/simplesamlphp.patch"
+			},
+			"imsglobal/lti": {
+				"ILIAS LTI Patches": "patches/lti.patch"
 			}
 		}
 	}

--- a/libs/composer/patches/lti.patch
+++ b/libs/composer/patches/lti.patch
@@ -1,0 +1,42 @@
+diff --git a/src/HTTPMessage.php b/src/HTTPMessage.php
+index 3c043bb..9dc3f69 100644
+--- a/src/HTTPMessage.php
++++ b/src/HTTPMessage.php
+@@ -132,8 +132,10 @@ class HTTPMessage
+             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+             curl_setopt($ch, CURLINFO_HEADER_OUT, true);
+             curl_setopt($ch, CURLOPT_HEADER, true);
+-            curl_setopt($ch, CURLOPT_SSLVERSION,3);
++            #curl_setopt($ch, CURLOPT_SSLVERSION,3);
+             $chResp = curl_exec($ch);
++            \ilLoggerFactory::getLogger('lti')->dump(curl_getinfo($ch), \ilLogLevel::DEBUG);
++            \ilLoggerFactory::getLogger('lti')->dump(curl_error($ch), \ilLogLevel::DEBUG);
+             $this->ok = $chResp !== false;
+             if ($this->ok) {
+                 $chResp = str_replace("\r\n", "\n", $chResp);
+diff --git a/src/OAuth/OAuthRequest.php b/src/OAuth/OAuthRequest.php
+index b7498f8..6e13262 100644
+--- a/src/OAuth/OAuthRequest.php
++++ b/src/OAuth/OAuthRequest.php
+@@ -39,7 +39,7 @@ class OAuthRequest {
+                 ? 'http'
+                 : 'https';
+       $http_url = ($http_url) ? $http_url : $scheme .
+-                                '://' . $_SERVER['SERVER_NAME'] .
++                                '://' . $_SERVER['HTTP_HOST'] .
+                                 ':' .
+                                 $_SERVER['SERVER_PORT'] .
+                                 $_SERVER['REQUEST_URI'];
+diff --git a/src/ToolProvider/ResourceLink.php b/src/ToolProvider/ResourceLink.php
+index f08f11c..5006230 100644
+--- a/src/ToolProvider/ResourceLink.php
++++ b/src/ToolProvider/ResourceLink.php
+@@ -282,7 +282,7 @@ class ResourceLink
+     {
+ 
+         if (is_null($this->consumer)) {
+-            if (!is_null($this->context) || !is_null($this->contextId)) {
++            if($this->context || $this->contextId) {
+                 $this->consumer = $this->getContext()->getConsumer();
+             } else {
+                 $this->consumer = ToolConsumer::fromRecordId($this->consumerId, $this->getDataConnector());


### PR DESCRIPTION
- move inline patches of composer lib imsglobal/lti to regular patch file.
- stick version to 3.0.2 (i think we should always pin the exact version of a patched library)
- added another patch to the lib: replaced SERVER_NAME with HTTP_HOST because it seems to be more valid. SERVER_NAMEs are sometimes empty or misconfigured and HTTP_HOST represents always the domain of the requested urls. An empty SERVER_NAME will crash the creation of the lti signatur.