### PR TITLE
[Refinery] Create URI to string transformation, to get the origin string to create e.g. a href element from the URI object

### DIFF
--- a/src/Refinery/Factory.php
+++ b/src/Refinery/Factory.php
@@ -147,4 +147,14 @@ class Factory
 	{
 		return new DateTime\Group();
 	}
+
+	/**
+	 * Contains transformations for Data\URI
+	 *
+	 * @return URI\Group
+	 */
+	public function uri()
+	{
+		return new URI\Group();
+	}
 }

--- a/src/Refinery/Factory.php
+++ b/src/Refinery/Factory.php
@@ -153,7 +153,7 @@ class Factory
 	 *
 	 * @return URI\Group
 	 */
-	public function uri()
+	public function uri() : URI\Group
 	{
 		return new URI\Group();
 	}

--- a/src/Refinery/URI/Group.php
+++ b/src/Refinery/URI/Group.php
@@ -1,0 +1,16 @@
+<?php
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * @author  Niels Theen <ntheen@databay.de>
+ */
+
+namespace ILIAS\Refinery\URI;
+
+class Group
+{
+    public function string()
+    {
+        return new StringTransformation();
+    }
+}

--- a/src/Refinery/URI/Group.php
+++ b/src/Refinery/URI/Group.php
@@ -9,7 +9,7 @@ namespace ILIAS\Refinery\URI;
 
 class Group
 {
-    public function string()
+    public function toString()
     {
         return new StringTransformation();
     }

--- a/src/Refinery/URI/Group.php
+++ b/src/Refinery/URI/Group.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 /**

--- a/src/Refinery/URI/Group.php
+++ b/src/Refinery/URI/Group.php
@@ -9,7 +9,7 @@ namespace ILIAS\Refinery\URI;
 
 class Group
 {
-    public function toString()
+    public function toString() : StringTransformation
     {
         return new StringTransformation();
     }

--- a/src/Refinery/URI/StringTransformation.php
+++ b/src/Refinery/URI/StringTransformation.php
@@ -1,0 +1,56 @@
+<?php
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * @author  Niels Theen <ntheen@databay.de>
+ */
+
+namespace ILIAS\Refinery\URI;
+
+use ILIAS\Data\URI;
+use ILIAS\Refinery\ConstraintViolationException;
+use ILIAS\Refinery\DeriveApplyToFromTransform;
+use ILIAS\Refinery\Transformation;
+
+class StringTransformation  implements Transformation
+{
+    use DeriveApplyToFromTransform;
+
+    /**
+     * @inheritdoc
+     */
+    public function transform($from)
+    {
+        if (false === $from instanceof URI) {
+            throw new ConstraintViolationException(
+                sprintf('The value MUST be of type "%s"', URI::class),
+                'not_uri_object'
+            );
+        }
+
+        /** @var URI $from */
+        $result = $from->getBaseURI();
+
+        $query  = $from->getQuery();
+        if (null !== $query) {
+            $query = '?' . $query;
+        }
+        $result .= $query;
+
+        $fragment = $from->getFragment();
+        if (null !== $fragment) {
+            $fragment = '#' . $fragment;
+        }
+        $result   .= $fragment;
+
+        return $result;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function __invoke($from)
+    {
+        return $this->transform($from);
+    }
+}

--- a/src/Refinery/URI/StringTransformation.php
+++ b/src/Refinery/URI/StringTransformation.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 /**

--- a/tests/Refinery/FactoryTest.php
+++ b/tests/Refinery/FactoryTest.php
@@ -97,4 +97,10 @@ class FactoryTest extends TestCase
 		$this->assertInstanceOf(\ILIAS\Refinery\DateTime\Group::class, $group);
 	}
 
+    public function testCreateUriGrouo()
+    {
+        $group = $this->basicFactory->uri();
+        $this->assertInstanceOf(\ILIAS\Refinery\URI\Group::class, $group);
+    }
+
 }

--- a/tests/Refinery/URI/GroupTest.php
+++ b/tests/Refinery/URI/GroupTest.php
@@ -1,0 +1,26 @@
+<?php
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * @author  Niels Theen <ntheen@databay.de>
+ */
+
+namespace ILIAS\Tests\Refinery\URI;
+
+require_once('./libs/composer/vendor/autoload.php');
+
+namespace ILIAS\Tests\Refinery\URI;
+
+use ILIAS\Refinery\URI\Group;
+use ILIAS\Refinery\URI\StringTransformation;
+use ILIAS\Tests\Refinery\TestCase;
+
+class GroupTest extends TestCase
+{
+    public function testStringTransformationInstance()
+    {
+        $group = new Group();
+        $transformation = $group->string();
+        $this->assertInstanceOf(StringTransformation::class, $transformation);
+    }
+}

--- a/tests/Refinery/URI/GroupTest.php
+++ b/tests/Refinery/URI/GroupTest.php
@@ -20,7 +20,7 @@ class GroupTest extends TestCase
     public function testStringTransformationInstance()
     {
         $group = new Group();
-        $transformation = $group->string();
+        $transformation = $group->toString();
         $this->assertInstanceOf(StringTransformation::class, $transformation);
     }
 }

--- a/tests/Refinery/URI/StringTransformationTest.php
+++ b/tests/Refinery/URI/StringTransformationTest.php
@@ -1,0 +1,76 @@
+<?php
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * @author  Niels Theen <ntheen@databay.de>
+ */
+
+namespace ILIAS\Tests\Refinery\URI;
+
+require_once('./libs/composer/vendor/autoload.php');
+
+use ILIAS\Data\URI;
+use ILIAS\Refinery\ConstraintViolationException;
+use ILIAS\Refinery\URI\StringTransformation;
+use ILIAS\Tests\Refinery\TestCase;
+
+class StringTransformationTest extends TestCase
+{
+    /**
+     * @var StringTransformation
+     */
+    private $transformation;
+
+    public function setUp() : void
+    {
+        $this->transformation = new StringTransformation();
+    }
+
+    public function testSimpleUri()
+    {
+        $uri              = new URI('http://ilias.de');
+        $transformedValue = $this->transformation->transform($uri);
+
+        $this->assertEquals('http://ilias.de', $transformedValue);
+    }
+
+    public function testUriWithPath()
+    {
+        $uri              = new URI('http://ilias.de/with/path');
+        $transformedValue = $this->transformation->transform($uri);
+
+        $this->assertEquals('http://ilias.de/with/path', $transformedValue);
+    }
+
+    public function testUriWithFragment()
+    {
+        $uri              = new URI('http://ilias.de/test.php#title');
+        $transformedValue = $this->transformation->transform($uri);
+
+        $this->assertEquals('http://ilias.de/test.php#title', $transformedValue);
+    }
+
+    public function testSimpleUriWithQueryParameter()
+    {
+        $uri              = new URI('http://ilias.de?test=something&further=1');
+        $transformedValue = $this->transformation->transform($uri);
+
+        $this->assertEquals('http://ilias.de?test=something&further=1', $transformedValue);
+    }
+
+    public function testUriWithQueryPathAndParameter()
+    {
+        $uri              = new URI('http://ilias.de/with/path?test=something&further=1');
+        $transformedValue = $this->transformation->transform($uri);
+
+        $this->assertEquals('http://ilias.de/with/path?test=something&further=1', $transformedValue);
+    }
+
+    public function testTransformNotURIObjectFails()
+    {
+        $this->expectException(ConstraintViolationException::class);
+        $transformedValue = $this->transformation->transform('http://ilias.de');
+
+        $this->assertEquals('http://ilias.de', $transformedValue);
+    }
+}


### PR DESCRIPTION
This PR as proposal to create a transformation to transform an `Data\URI` object into a `string`.

The original idea was born during the development of #2042 , because there was no actual functionality to pass an `Data\URI` object around and be able to get the origin entered string back

Tell me what you think :+1: 