### PR TITLE
Create new path factory to avoid usage of constant in actual code 

### DIFF
--- a/Modules/Course/classes/class.ilObjCourse.php
+++ b/Modules/Course/classes/class.ilObjCourse.php
@@ -1036,7 +1036,7 @@ class ilObjCourse extends ilContainer implements ilMembershipRegistrationCodes
 		unset($obj_settings);
 		
 		// clone certificate (#11085)
-		$factory = new ilCertificateFactory();
+		$factory = new ilCertificateFactory(new ilCertificatePathFactory());
 		$templateRepository = new ilCertificateTemplateRepository($ilDB);
 
 		$cloneAction = new ilCertificateCloneAction(

--- a/Modules/Exercise/classes/class.ilObjExercise.php
+++ b/Modules/Exercise/classes/class.ilObjExercise.php
@@ -269,7 +269,7 @@ class ilObjExercise extends ilObject
 		$obj_settings->cloneSettings($new_obj->getId());
 		unset($obj_settings);
 
-		$factory = new ilCertificateFactory();
+		$factory = new ilCertificateFactory(new ilCertificatePathFactory());
 		$templateRepository = new ilCertificateTemplateRepository($ilDB);
 
 		$cloneAction = new ilCertificateCloneAction(

--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -7560,7 +7560,7 @@ function getAnswerFeedbackPoints()
 		$newObj->saveToDb();
 		
 		// clone certificate
-		$factory = new ilCertificateFactory();
+		$factory = new ilCertificateFactory(new ilCertificatePathFactory());
 		$templateRepository = new ilCertificateTemplateRepository($ilDB);
 
 		$cloneAction = new ilCertificateCloneAction(
@@ -10928,7 +10928,7 @@ function getAnswerFeedbackPoints()
 	{
 		if ($this->canShowTestResults($testSession))
 		{
-			$factory = new ilCertificateFactory();
+			$factory = new ilCertificateFactory(new ilCertificatePathFactory());
 
 			$cert = $factory->create($this);
 

--- a/Modules/Test/classes/class.ilTestEvaluationGUI.php
+++ b/Modules/Test/classes/class.ilTestEvaluationGUI.php
@@ -354,7 +354,7 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
 			);
 			
 			if(!$this->object->getAnonymity()) {
-				$factory = new ilCertificateFactory();
+				$factory = new ilCertificateFactory(new ilCertificatePathFactory());
 
 				$certificate = $factory->create($this->object);
 

--- a/Modules/Test/classes/class.ilTestEvaluationGUI.php
+++ b/Modules/Test/classes/class.ilTestEvaluationGUI.php
@@ -875,10 +875,11 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
 		$database = $DIC->database();
 		$logger = $DIC->logger()->root();
 
+		$pathFactory = new ilCertificatePathFactory();
 		$objectId    = $this->object->getId();
 		$zipAction = new ilUserCertificateZip(
 			$objectId,
-			ilCertificatePathConstants::TEST_PATH . $objectId . '/'
+			$pathFactory->create($this->object)
 		);
 
 		$archive_dir = $zipAction->createArchiveDirectory();

--- a/Services/Certificate/classes/File/Template/Path/class.ilCertificatePathFactory.php
+++ b/Services/Certificate/classes/File/Template/Path/class.ilCertificatePathFactory.php
@@ -17,9 +17,6 @@ class ilCertificatePathFactory
             case 'crs':
                 $certificatePath = ilCertificatePathConstants::COURSE_PATH . $object->getId() . '/';
                 break;
-            case 'scrm':
-                $certificatePath = ilCertificatePathConstants::SCORM_PATH . $object->getId() . '/';
-                break;
             case 'sahs':
                 $certificatePath = ilCertificatePathConstants::SCORM_PATH . $object->getId() . '/';
                 break;

--- a/Services/Certificate/classes/File/Template/Path/class.ilCertificatePathFactory.php
+++ b/Services/Certificate/classes/File/Template/Path/class.ilCertificatePathFactory.php
@@ -1,0 +1,36 @@
+<?php
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * @author  Niels Theen <ntheen@databay.de>
+ */
+class ilCertificatePathFactory
+{
+    public function create(ilObject $object)
+    {
+        $type = $object->getType();
+
+        switch ($type) {
+            case 'tst':
+                $certificatePath = ilCertificatePathConstants::TEST_PATH . $object->getId() . '/';
+                break;
+            case 'crs':
+                $certificatePath = ilCertificatePathConstants::COURSE_PATH . $object->getId() . '/';
+                break;
+            case 'scrm':
+                $certificatePath = ilCertificatePathConstants::SCORM_PATH . $object->getId() . '/';
+                break;
+            case 'exc':
+                $certificatePath = ilCertificatePathConstants::EXERCISE_PATH . $object->getId() . '/';
+                break;
+            default:
+                throw new ilException(sprintf(
+                    'The type "%s" is currently not supported for certificates',
+                    $type
+                ));
+                break;
+        }
+
+        return $certificatePath;
+    }
+}

--- a/Services/Certificate/classes/File/Template/Path/class.ilCertificatePathFactory.php
+++ b/Services/Certificate/classes/File/Template/Path/class.ilCertificatePathFactory.php
@@ -20,6 +20,9 @@ class ilCertificatePathFactory
             case 'scrm':
                 $certificatePath = ilCertificatePathConstants::SCORM_PATH . $object->getId() . '/';
                 break;
+            case 'sahs':
+                $certificatePath = ilCertificatePathConstants::SCORM_PATH . $object->getId() . '/';
+                break;
             case 'exc':
                 $certificatePath = ilCertificatePathConstants::EXERCISE_PATH . $object->getId() . '/';
                 break;

--- a/Services/Certificate/classes/Gui/class.ilCertificateFactory.php
+++ b/Services/Certificate/classes/Gui/class.ilCertificateFactory.php
@@ -7,6 +7,16 @@
 class ilCertificateFactory
 {
     /**
+     * @var ilCertificatePathFactory
+     */
+    private $pathFactory;
+
+    public function __construct(ilCertificatePathFactory $pathFactory)
+    {
+        $this->pathFactory = $pathFactory;
+    }
+
+    /**
      * @param ilObject $object
      * @return ilCertificate
      * @throws ilException
@@ -20,25 +30,21 @@ class ilCertificateFactory
                 $adapter = new ilTestCertificateAdapter($object);
                 $placeholderDescriptionObject = new ilTestPlaceholderDescription();
                 $placeholderValuesObject = new ilTestPlaceHolderValues();
-                $certificatePath = ilCertificatePathConstants::TEST_PATH . $object->getId() . '/';
                 break;
             case 'crs':
                 $adapter = new ilCourseCertificateAdapter($object);
                 $placeholderDescriptionObject = new ilCoursePlaceholderDescription();
                 $placeholderValuesObject = new ilCoursePlaceholderValues();
-                $certificatePath = ilCertificatePathConstants::COURSE_PATH . $object->getId() . '/';
                 break;
             case 'scrm':
                 $adapter = new ilSCORMCertificateAdapter($object);
                 $placeholderDescriptionObject = new ilScormPlaceholderDescription($object);
                 $placeholderValuesObject = new ilScormPlaceholderValues();
-                $certificatePath = ilCertificatePathConstants::SCORM_PATH . $object->getId() . '/';
                 break;
             case 'exc':
                 $adapter = new ilExerciseCertificateAdapter($object);
                 $placeholderDescriptionObject = new ilExercisePlaceholderDescription();
                 $placeholderValuesObject = new ilExercisePlaceHolderValues();
-                $certificatePath = ilCertificatePathConstants::EXERCISE_PATH . $object->getId() . '/';
                 break;
             default:
                 throw new ilException(sprintf(
@@ -47,6 +53,8 @@ class ilCertificateFactory
                 ));
                 break;
         }
+
+        $certificatePath = $this->pathFactory->create($object);
 
         $certificate = new ilCertificate(
             $adapter,

--- a/Services/Certificate/classes/Gui/class.ilCertificateGUIFactory.php
+++ b/Services/Certificate/classes/Gui/class.ilCertificateGUIFactory.php
@@ -39,14 +39,15 @@ class ilCertificateGUIFactory
 
         $templateRepository = new ilCertificateTemplateRepository($this->dic->database(), $logger);
         $deleteAction = new ilCertificateTemplateDeleteAction($templateRepository);
+        $pathFactory = new ilCertificatePathFactory();
+
+        $certificatePath = $pathFactory->create($object);
 
         switch ($type) {
             case 'tst':
                 $placeholderDescriptionObject = new ilTestPlaceholderDescription();
                 $placeholderValuesObject = new ilTestPlaceHolderValues();
                 $adapter = new ilTestCertificateAdapter($object);
-
-                $certificatePath = ilCertificatePathConstants::TEST_PATH . $objectId . '/';
 
                 $formFactory = new ilCertificateSettingsTestFormRepository(
                     $objectId,
@@ -59,8 +60,6 @@ class ilCertificateGUIFactory
                     $DIC->toolbar(),
                     $placeholderDescriptionObject
                 );
-
-                $certificatePath = ilCertificatePathConstants::TEST_PATH . $objectId . '/';
 
                 $deleteAction = new ilCertificateTestTemplateDeleteAction(
                     $deleteAction,
@@ -75,7 +74,6 @@ class ilCertificateGUIFactory
                 $placeholderDescriptionObject = new ilCoursePlaceholderDescription();
                 $placeholderValuesObject = new ilCoursePlaceholderValues();
 
-                $certificatePath = ilCertificatePathConstants::COURSE_PATH . $objectId . '/';
 
                 $formFactory = new ilCertificateSettingsCourseFormRepository(
                     $object,
@@ -88,14 +86,11 @@ class ilCertificateGUIFactory
                     $placeholderDescriptionObject
                 );
 
-                $certificatePath = ilCertificatePathConstants::COURSE_PATH . $objectId . '/';
                 break;
             case 'exc':
                 $adapter = new ilExerciseCertificateAdapter($object);
                 $placeholderDescriptionObject = new ilExercisePlaceholderDescription();
                 $placeholderValuesObject = new ilExercisePlaceHolderValues();
-
-                $certificatePath = ilCertificatePathConstants::EXERCISE_PATH . $objectId . '/';
 
                 $formFactory = new ilCertificateSettingsExerciseRepository(
                     $object,
@@ -108,14 +103,11 @@ class ilCertificateGUIFactory
                     $placeholderDescriptionObject
                 );
 
-                $certificatePath = ilCertificatePathConstants::EXERCISE_PATH . $objectId . '/';
                 break;
             case 'sahs':
                 $adapter = new ilSCORMCertificateAdapter($object);
                 $placeholderDescriptionObject = new ilScormPlaceholderDescription($object);
                 $placeholderValuesObject = new ilScormPlaceholderValues();
-
-                $certificatePath = ilCertificatePathConstants::SCORM_PATH . $objectId . '/';
 
                 $formFactory = new ilCertificateSettingsScormFormRepository(
                     $object,
@@ -127,8 +119,6 @@ class ilCertificateGUIFactory
                     $DIC->toolbar(),
                     $placeholderDescriptionObject
                 );
-
-                $certificatePath = ilCertificatePathConstants::SCORM_PATH . $objectId . '/';
 
                 break;
             default:

--- a/Services/Certificate/test/ilCertificateCloneActionTest.php
+++ b/Services/Certificate/test/ilCertificateCloneActionTest.php
@@ -26,6 +26,7 @@ class ilCertificateCloneActionTest extends ilCertificateBaseTestCase
             ->method('replace');
 
         $certificateFactory = $this->getMockBuilder('ilCertificateFactory')
+            ->disableOriginalConstructor()
             ->getMock();
 
         $oldCertficate = $this->getMockBuilder('ilCertificate')

--- a/Services/Certificate/test/ilCertificateFactoryTest.php
+++ b/Services/Certificate/test/ilCertificateFactoryTest.php
@@ -20,7 +20,7 @@ class ilCertificateFactoryTest extends ilCertificateBaseTestCase
         $object->method('getType')
             ->willReturn('something');
 
-        $factory = new ilCertificateFactory();
+        $factory = new ilCertificateFactory(new ilCertificatePathFactory());
 
         $factory->create($object);
 


### PR DESCRIPTION
This will remove the need to create your own paths via the constants of the certificate.
Just enter the object you want the path for an there you go! :+1: 