### PR TITLE
Use correct check for a achieved certificate of the user

### DIFF
--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -10928,11 +10928,14 @@ function getAnswerFeedbackPoints()
 	{
 		if ($this->canShowTestResults($testSession))
 		{
-			$factory = new ilCertificateFactory(new ilCertificatePathFactory());
+			$isComplete = false;
+			$userCertificateRepository = new ilUserCertificateRepository($this->db, $this->log);
+			try {
+				$userCertificateRepository->fetchActiveCertificate($user_id, $this->getId());
+				$isComplete = true;
+			} catch (ilException $e) {}
 
-			$cert = $factory->create($this);
-
-			if ($cert->isComplete())
+			if ($isComplete)
 			{
 				$vis = $this->getCertificateVisibility();
 				$showcert = FALSE;

--- a/Modules/Test/classes/class.ilTestEvaluationGUI.php
+++ b/Modules/Test/classes/class.ilTestEvaluationGUI.php
@@ -354,13 +354,11 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
 			);
 			
 			if(!$this->object->getAnonymity()) {
-				$factory = new ilCertificateFactory(new ilCertificatePathFactory());
-
-				$certificate = $factory->create($this->object);
-
-				if($certificate->isComplete(new ilTestCertificateAdapter($this->object))) {
+				$userCertificateRepository = new ilUserCertificateRepository($DIC->database(), $DIC->logger()->cert());
+				try {
+					$userCertificateRepository->fetchActiveCertificate($DIC->user()->getId(), $this->object->getId());
 					$options['certificate'] = $this->lng->txt('exp_type_certificate');
-				}
+				} catch (ilException $e) {}
 			}
 
 			$export_type->setOptions($options);


### PR DESCRIPTION
The checks were done via `ilCertificate` which is not correct to fine an "active" or achieved certificate.