### PR TITLE
KS: new ui report listing component

### DIFF
--- a/src/UI/Component/Listing/Factory.php
+++ b/src/UI/Component/Listing/Factory.php
@@ -83,6 +83,11 @@ interface Factory {
      *        The items for a descriptive listing consists of a key as a title
      *        and a value describing the key. It is to be used whenever the semantics of
      *        a html descriptive listing is required that can be shown underneath.
+     * rules:
+     *   usage:
+     *       1: >
+     *         The Report Listing MUST NOT be used standalone. It MUST be used as content
+     *         for a parent component such as a Panel or similar.
      * ----
      * @return \ILIAS\UI\Component\Listing\Report\Factory
      */

--- a/src/UI/Component/Listing/Factory.php
+++ b/src/UI/Component/Listing/Factory.php
@@ -70,4 +70,22 @@ interface Factory {
 	 */
 	public function workflow();
 
+    /**
+     * ---
+     * description:
+     *   purpose: >
+     *     Report Listings are used to present label-value doubles of textual-information.
+     *   composition: >
+     *     Report Listings are composed of items containing a key labeling the value
+     *     being displayed side by side.
+     *   rivals:
+     *      DescriptiveListing: >
+     *        The items for a descriptive listing consists of a key as a title
+     *        and a value describing the key. It is to be used whenever the semantics of
+     *        a html descriptive listing is required that can be shown underneath.
+     * ----
+     * @return \ILIAS\UI\Component\Listing\Report\Factory
+     */
+	public function report();
+
 }

--- a/src/UI/Component/Listing/Report/Factory.php
+++ b/src/UI/Component/Listing/Report/Factory.php
@@ -25,7 +25,13 @@ interface Factory
      *     of the available space.
      *     A Standard Report Listing SHOULD be used with a divider,
      *     that will be shown between the items.
-     *
+     * rules:
+     *   usage:
+     *       1: >
+     *         The Standard Report Listing MUST NOT be used standalone. It MUST be used as content
+     *         for a parent component such as a Panel or similar.
+     *       2: >
+     *         The Standard Report Listing SHOULD be used as a major ui part such as the main content.
      * ----
      * @param array $items string => Component | string
      *
@@ -47,6 +53,13 @@ interface Factory
      *     The items will be presented underneath, whereby each items' label and value will be presented side by side.
      *     The width of columns for labels and values are not the same, the labels get more space.
      *     For a better optic the values are righ aligned.
+     * rules:
+     *   usage:
+     *       1: >
+     *         The Mini Report Listing MUST NOT be used standalone. It MUST be used as content
+     *         for a parent component such as the Reporting Panel Card or similar.
+     *       2: >
+     *         The Mini Report Listing SHOULD NOT be used as a major ui part such as the main content.
      * ----
      *
      * @param array $items string => Component | string

--- a/src/UI/Component/Listing/Report/Factory.php
+++ b/src/UI/Component/Listing/Report/Factory.php
@@ -1,0 +1,57 @@
+<?php
+
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\UI\Component\Listing\Report;
+
+/**
+ * This is the interface for a report factory.
+ */
+interface Factory
+{
+    /**
+     * ---
+     * description:
+     *   purpose: >
+     *     A Standard Report Listing is the usual choice when label-value doubles
+     *     of textual-information are to be presented as a major part of the ui,
+     *     representing e.g. the main content for any screen.
+     *   composition: >
+     *     Report Listings are composed of items containing a key labeling the value
+     *     being displayed side by side.
+     *   effect: >
+     *     The items will be presented underneath, whereby each items' label and value
+     *     will be presented side by side both left aligned an in columns using the half
+     *     of the available space.
+     *     A Standard Report Listing SHOULD be used with a divider,
+     *     that will be shown between the items.
+     *
+     * ----
+     * @param array $items string => Component | string
+     *
+     * @return \ILIAS\UI\Component\Listing\Report\Standard
+     */
+    public function standard(array $items);
+
+    /**
+     * ---
+     * description:
+     *   purpose: >
+     *     A Mini Report Listing is the choice when label-value doubles of textual-information
+     *     are to be presented as a marginal part in the ui, e.g. when used as a section
+     *     for a card within a reporting panel.
+     *   composition: >
+     *     Report Listings are composed of items containing a key labeling the value
+     *     being displayed side by side.
+     *   effect: >
+     *     The items will be presented underneath, whereby each items' label and value will be presented side by side.
+     *     The width of columns for labels and values are not the same, the labels get more space.
+     *     For a better optic the values are righ aligned.
+     * ----
+     *
+     * @param array $items string => Component | string
+     *
+     * @return \ILIAS\UI\Component\Listing\Report\Mini
+     */
+    public function mini(array $items);
+}

--- a/src/UI/Component/Listing/Report/Mini.php
+++ b/src/UI/Component/Listing/Report/Mini.php
@@ -1,0 +1,13 @@
+<?php
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\UI\Component\Listing\Report;
+
+/**
+ * Interface Mini
+ * @package ILIAS\UI\Component\Listing\Report
+ */
+interface Mini extends Report
+{
+
+}

--- a/src/UI/Component/Listing/Report/Report.php
+++ b/src/UI/Component/Listing/Report/Report.php
@@ -1,0 +1,19 @@
+<?php
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\UI\Component\Listing\Report;
+
+use ILIAS\UI\Component\Component;
+
+/**
+ * Interface Report
+ * @package ILIAS\UI\Component\Listing\Report
+ */
+interface Report extends Component
+{
+    /**
+     * Gets the key value pair as items for the list. Key is used as label for the value.
+     * @return array $items string => Component | string
+     */
+    public function getItems();
+}

--- a/src/UI/Component/Listing/Report/Standard.php
+++ b/src/UI/Component/Listing/Report/Standard.php
@@ -1,0 +1,36 @@
+<?php
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\UI\Component\Listing\Report;
+
+use ILIAS\UI\Component\Component;
+
+/**
+ * Interface Standard
+ * @package ILIAS\UI\Component\Listing\Report
+ */
+interface Standard extends Report
+{
+    /**
+     * Adds a divider to be rendered between the rows of label => item.
+     * Use a \ILIAS\UI\Component\Divider\Horizontal for example.
+     *
+     * @param Component
+     * @return Standard
+     */
+    public function withDivider(Component $component);
+
+    /**
+     * Returns the fact whether a divider component was added or not.
+     *
+     * @return bool
+     */
+    public function hasDivider();
+
+    /**
+     * Returns the divider component if one was added. Returns null otherwise.
+     *
+     * @return Component|null
+     */
+    public function getDivider();
+}

--- a/src/UI/Implementation/Component/Listing/Factory.php
+++ b/src/UI/Implementation/Component/Listing/Factory.php
@@ -37,4 +37,11 @@ class Factory implements \ILIAS\UI\Component\Listing\Factory {
 	public function workflow(){
 		return new Workflow\Factory();
 	}
+
+    /**
+     * @inheritdoc
+     */
+    public function report(){
+        return new Report\Factory();
+    }
 }

--- a/src/UI/Implementation/Component/Listing/Report/Factory.php
+++ b/src/UI/Implementation/Component/Listing/Report/Factory.php
@@ -1,0 +1,29 @@
+<?php
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\UI\Implementation\Component\Listing\Report;
+
+use ILIAS\UI\Component as C;
+
+/**
+ * Factory for report listings
+ * @package ILIAS\UI\Implementation\Component\Listing\Report
+ */
+class Factory implements C\Listing\Report\Factory
+{
+    /**
+     * @inheritdoc
+     */
+    public function standard(array $items)
+    {
+        return new Standard($items);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function mini(array $items)
+    {
+        return new Mini($items);
+    }
+}

--- a/src/UI/Implementation/Component/Listing/Report/Mini.php
+++ b/src/UI/Implementation/Component/Listing/Report/Mini.php
@@ -1,0 +1,16 @@
+<?php
+
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\UI\Implementation\Component\Listing\Report;
+
+use ILIAS\UI\Component as C;
+
+/**
+ * Class Mini
+ * @package ILIAS\UI\Implementation\Component\Listing\Report
+ */
+class Mini extends Report implements C\Listing\Report\Mini
+{
+
+}

--- a/src/UI/Implementation/Component/Listing/Report/Renderer.php
+++ b/src/UI/Implementation/Component/Listing/Report/Renderer.php
@@ -1,0 +1,166 @@
+<?php
+
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\UI\Implementation\Component\Listing\Report;
+
+use ILIAS\UI\Implementation\Render\AbstractComponentRenderer;
+use ILIAS\UI\Renderer as RendererInterface;
+use ILIAS\UI\Component\Component;
+use ILIAS\UI\Implementation\Render\Template;
+use ILIAS\UI\Component\Listing\Report\Report;
+use ILIAS\UI\Component\Listing\Report\Standard;
+use ILIAS\UI\Component\Listing\Report\Mini;
+
+/**
+ * Class Renderer
+ *
+ * @author      Björn Heyser <info@bjoernheyser.de>
+ *
+ * @package     Services/AssessmentQuestion
+ */
+class Renderer extends AbstractComponentRenderer
+{
+    /**
+	 * @inheritdocs
+	 */
+    protected function getComponentInterfaceName()
+    {
+        return [Report::class];
+    }
+
+	/**
+	 * @inheritdocs
+	 */
+    public function render(Component $component, RendererInterface $default_renderer)
+    {
+        $this->checkComponent($component);
+
+        if($component instanceof Standard)
+        {
+            return $this->render_standard($component, $default_renderer);
+        }
+
+        if($component instanceof Mini)
+        {
+            return $this->render_mini($component, $default_renderer);
+        }
+
+        return '';
+    }
+
+
+    /**
+     * @param Standard          $component
+     * @param RendererInterface $default_renderer
+     *
+     * @return string
+     */
+    private function render_standard(Standard $component, RendererInterface $default_renderer)
+    {
+        $tpl = $this->getReportTemplate();
+
+        $first = true;
+
+        foreach ($component->getItems() as $label => $item)
+        {
+            if( $first )
+            {
+                $first = false;
+            }
+            elseif( $component->hasDivider() )
+            {
+                $this->renderDivider(
+                    $tpl, $default_renderer->render($component->getDivider())
+                );
+            }
+
+            $this->renderItem($tpl, 'item_standard', $label,
+                $this->ensureRenderedItemString($default_renderer, $item)
+            );
+
+            $this->renderRow($tpl);
+        }
+
+        return $tpl->get();
+    }
+
+    /**
+     * @param Mini              $component
+     * @param RendererInterface $default_renderer
+     *
+     * @return string
+     */
+    private function render_mini(Mini $component, RendererInterface $default_renderer)
+    {
+        $tpl = $this->getReportTemplate();
+
+        foreach($component->getItems() as $label => $item)
+        {
+            $this->renderItem($tpl, 'item_mini', $label,
+                $this->ensureRenderedItemString($default_renderer, $item)
+            );
+
+            $this->renderRow($tpl);
+        }
+
+        return $tpl->get();
+    }
+
+    /**
+     * @param Template $tpl
+     * @param RendererInterface $default_renderer
+     */
+    private function renderDivider(Template $tpl, $renderedDivider)
+    {
+        $tpl->setCurrentBlock('divider');
+        $tpl->setVariable('DIVIDER', $renderedDivider);
+        $tpl->parseCurrentBlock();
+    }
+
+    /**
+     * @param Template $tpl
+     * @param string $label
+     * @param string $item
+     */
+    private function renderItem(Template $tpl, $block, $label, $item)
+    {
+        $tpl->setCurrentBlock($block);
+        $tpl->setVariable('LABEL', $label);
+        $tpl->setVariable('ITEM', $item);
+        $tpl->parseCurrentBlock();
+    }
+
+    /**
+     * @param Template $tpl
+     */
+    private function renderRow(Template $tpl)
+    {
+        $tpl->setCurrentBlock('row');
+        $tpl->parseCurrentBlock();
+    }
+
+    /**
+     * @return Template
+     */
+    private function getReportTemplate()
+    {
+        return $this->getTemplate('tpl.report.html', true, true);
+    }
+
+    /**
+     * @param RendererInterface $default_renderer
+     * @param Component|string $item
+     *
+     * @return string
+     */
+    private function ensureRenderedItemString(RendererInterface $default_renderer, $item)
+    {
+        if($item instanceof Component)
+        {
+            return $default_renderer->render($item);
+        }
+
+        return $item;
+    }
+}

--- a/src/UI/Implementation/Component/Listing/Report/Report.php
+++ b/src/UI/Implementation/Component/Listing/Report/Report.php
@@ -1,0 +1,82 @@
+<?php
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\UI\Implementation\Component\Listing\Report;
+
+use http\Exception\InvalidArgumentException;
+use ILIAS\UI\Component as C;
+use ILIAS\UI\Implementation\Component\ComponentHelper;
+
+/**
+ * Class Report
+ * @package ILIAS\UI\Implementation\Component\Listing\Report
+ */
+abstract class Report implements C\Listing\Report\Report
+{
+    use ComponentHelper;
+
+    /**
+     * @var	array
+     */
+    protected $items;
+
+    /**
+     * @inheritdoc
+     */
+    public function __construct(array $items)
+    {
+        $this->validateItems($items);
+        $this->items = $items;
+    }
+
+    private function validateItems(array $items)
+    {
+        if( !count($items) )
+        {
+            throw new \InvalidArgumentException('expected non empty array, got empty array');
+        }
+
+        $this->checkArgList("Report List Items", $items,
+            function($k, $v)
+            {
+                if( !is_string($k) || !strlen($k) )
+                {
+                    return false;
+                }
+
+                if( is_string($v) && strlen($v) )
+                {
+                    return true;
+                }
+
+                if( $v instanceof C\Component )
+                {
+                    return true;
+                }
+
+                return false;
+            },
+            function($k, $v)
+            {
+                if( is_object($v) )
+                {
+                    $v = get_class($v);
+                }
+                elseif( $v === null )
+                {
+                    $v = 'NULL';
+                }
+
+                return "expected keys of type string and values of type string|Component, got ($k => $v)";
+            }
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getItems()
+    {
+        return $this->items;
+    }
+}

--- a/src/UI/Implementation/Component/Listing/Report/Standard.php
+++ b/src/UI/Implementation/Component/Listing/Report/Standard.php
@@ -1,0 +1,47 @@
+<?php
+
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\UI\Implementation\Component\Listing\Report;
+
+use ILIAS\UI\Component as C;
+use ILIAS\UI\Component\Component;
+
+/**
+ * Class Standard
+ * @package ILIAS\UI\Implementation\Component\Listing\Report
+ */
+class Standard extends Report implements C\Listing\Report\Standard
+{
+    /**
+     * @var Component|null
+     */
+    protected $divider;
+
+    /**
+     * @inheritdoc
+     */
+    public function withDivider(Component $divider)
+    {
+        $clone = clone $this;
+        $clone->items = $this->items;
+        $clone->divider = $divider;
+        return $clone;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function hasDivider()
+    {
+        return $this->divider instanceof Component;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getDivider()
+    {
+        return $this->divider;
+    }
+}

--- a/src/UI/examples/Listing/Report/Mini/base.php
+++ b/src/UI/examples/Listing/Report/Mini/base.php
@@ -1,0 +1,20 @@
+<?php
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+function base()
+{
+    global $DIC; /* @var \ILIAS\DI\Container $DIC */
+    $f = $DIC->ui()->factory();
+    $r = $DIC->ui()->renderer();
+
+    $items = [
+        'Any Label for the First Item' => 'Item 1',
+        'Another Label for the Second Item' => 'Item 2',
+        'Third Item Comes as Component' => $f->legacy('Item 3'),
+        'Fourth Item Comes as Component' => $f->legacy('Item 4')
+    ];
+
+    $mini = $f->listing()->report()->mini($items);
+
+    return $r->render($mini);
+}

--- a/src/UI/examples/Listing/Report/Standard/base.php
+++ b/src/UI/examples/Listing/Report/Standard/base.php
@@ -1,0 +1,22 @@
+<?php
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+function base()
+{
+    global $DIC; /* @var \ILIAS\DI\Container $DIC */
+    $f = $DIC->ui()->factory();
+    $r = $DIC->ui()->renderer();
+
+    $items = [
+        'Any Label for the First Item' => 'Item 1',
+        'Another Label for the Second Item' => 'Item 2',
+        'Third Item Comes as Component' => $f->legacy('Item 3'),
+        'Fourth Item Comes as Component' => $f->legacy('Item 4')
+    ];
+
+    $standard = $f->listing()->report()->standard($items)->withDivider(
+        $f->divider()->horizontal()
+    );
+
+    return $r->render($standard);
+}

--- a/src/UI/templates/default/Listing/tpl.report.html
+++ b/src/UI/templates/default/Listing/tpl.report.html
@@ -1,0 +1,17 @@
+<div class="row">
+	<!-- BEGIN row -->
+		<!-- BEGIN divider -->
+			<div class="col-md-12">{DIVIDER}</div>
+		<!-- END divider -->
+		<div class="il-listing-report-row clearfix">
+			<!-- BEGIN item_standard -->
+			<div class="il-listing-report-label col-md-6 col-xs-8">{LABEL}</div>
+			<div class="il-listing-report-item col-md-6 col-xs-4">{ITEM}</div>
+			<!-- END item_standard -->
+			<!-- BEGIN item_mini -->
+				<div class="il-listing-report-label col-md-9 col-xs-9">{LABEL}</div>
+				<div class="il-listing-report-item col-md-3 col-xs-3 ilRight">{ITEM}</div>
+			<!-- END item_mini -->
+		</div>
+	<!-- END row -->
+</div>

--- a/tests/UI/Component/Listing/ListingFactoryTest.php
+++ b/tests/UI/Component/Listing/ListingFactoryTest.php
@@ -20,6 +20,10 @@ class ListingFactoryTest extends AbstractFactoryTest {
 			"workflow" => array(
 					"context" => false,
 					"rules" => false
+			),
+			"report" => array(
+					"context" => false,
+					"rules" => false
 			)
 	);
 

--- a/tests/UI/Component/Listing/ListingTest.php
+++ b/tests/UI/Component/Listing/ListingTest.php
@@ -36,6 +36,11 @@ class ListingTest extends ILIAS_UI_TestBase {
 		( "ILIAS\\UI\\Component\\Listing\\Descriptive"
 				, $f->descriptive(array("k1"=>"c1"))
 		);
+
+        $this->assertInstanceOf
+        ( "ILIAS\\UI\\Component\\Listing\\Report\\Factory"
+            , $f->report()
+        );
 	}
 
 

--- a/tests/UI/Component/Listing/Report/ReportFactoryTest.php
+++ b/tests/UI/Component/Listing/Report/ReportFactoryTest.php
@@ -1,0 +1,19 @@
+<?php
+
+require_once 'tests/UI/AbstractFactoryTest.php';
+
+class ReportFactoryTest extends AbstractFactoryTest
+{
+    public $kitchensink_info_settings = [
+        'standard' => array(
+            'context' => false,
+            'rules' => false
+        ),
+        'mini' => array(
+            'context' => false,
+            'rules' => false
+        )
+    ];
+
+    public $factory_title = 'ILIAS\\UI\\Component\\Listing\\Report\\Factory';
+}

--- a/tests/UI/Component/Listing/Report/ReportMiniTest.php
+++ b/tests/UI/Component/Listing/Report/ReportMiniTest.php
@@ -1,0 +1,78 @@
+<?php
+
+require_once(__DIR__ . '/ReportTest.php');
+
+class ReportMiniTest extends ReportTest
+{
+    public function test_getItems()
+    {
+        $f = $this->getReportFactory();
+
+        $items = $this->getStringItemsMock();
+        $standard = $f->mini($items);
+        $this->assertEquals($items, $standard->getItems());
+
+        $items = $this->getComponentItemsMock();
+        $standard = $f->mini($items);
+        $this->assertEquals($items, $standard->getItems());
+    }
+
+    public function test_validation()
+    {
+        $f = $this->getReportFactory();
+
+        foreach($this->getInvalidItemsMocks() as $invalidItemsMock)
+        {
+            try
+            {
+                $f->mini($invalidItemsMock);
+
+                $this->throwException(new Exception(
+                    'expected InvalidArgumentException, catched none'
+                ));
+            }
+            catch(InvalidArgumentException $e)
+            {
+                $this->assertInstanceOf('InvalidArgumentException', $e);
+            }
+        }
+    }
+
+    public function test_rendered()
+    {
+        $f = $this->getReportFactory();
+        $r = $this->getDefaultRenderer();
+
+        $items = $this->getMixedItemsMock();
+        $standard = $f->mini($items);
+        $actualHtml = $r->render($standard);
+
+        $expectedHtml = $this->getExpectedMixedItemsMockHtml();
+
+        $this->assertHTMLEquals($expectedHtml, $actualHtml);
+    }
+
+    private function getExpectedMixedItemsMockHtml()
+    {
+        $html =  '<div class="row">';
+        $html .= '		<div class="il-listing-report-row clearfix">';
+        $html .= '				<div class="il-listing-report-label col-md-9 col-xs-9">label1</div>';
+        $html .= '				<div class="il-listing-report-item col-md-3 col-xs-3 ilRight">item1</div>';
+        $html .= '		</div>';
+        $html .= '		<div class="il-listing-report-row clearfix">';
+        $html .= '				<div class="il-listing-report-label col-md-9 col-xs-9">label2</div>';
+        $html .= '				<div class="il-listing-report-item col-md-3 col-xs-3 ilRight">item2</div>';
+        $html .= '		</div>';
+        $html .= '		<div class="il-listing-report-row clearfix">';
+        $html .= '				<div class="il-listing-report-label col-md-9 col-xs-9">label3</div>';
+        $html .= '				<div class="il-listing-report-item col-md-3 col-xs-3 ilRight">item3</div>';
+        $html .= '		</div>';
+        $html .= '		<div class="il-listing-report-row clearfix">';
+        $html .= '				<div class="il-listing-report-label col-md-9 col-xs-9">label4</div>';
+        $html .= '				<div class="il-listing-report-item col-md-3 col-xs-3 ilRight">item4</div>';
+        $html .= '		</div>';
+        $html .= '</div>';
+
+        return $html;
+    }
+}

--- a/tests/UI/Component/Listing/Report/ReportStandardTest.php
+++ b/tests/UI/Component/Listing/Report/ReportStandardTest.php
@@ -1,0 +1,152 @@
+<?php
+
+require_once(__DIR__ . '/ReportTest.php');
+
+class ReportStandardTest extends ReportTest
+{
+    public function test_getItems()
+    {
+        $f = $this->getReportFactory();
+
+        $items = $this->getStringItemsMock();
+        $standard = $f->standard($items);
+        $this->assertEquals($items, $standard->getItems());
+
+        $items = $this->getComponentItemsMock();
+        $standard = $f->standard($items);
+        $this->assertEquals($items, $standard->getItems());
+    }
+
+    public function test_getDivider()
+    {
+        $f = $this->getReportFactory();
+        $items = $this->getStringItemsMock();
+        $divider = $this->getDividerComponent();
+
+        $standard = $f->standard($items);
+        $this->assertNull($standard->getDivider());
+
+        $standard = $standard->withDivider($divider);
+        $this->assertEquals($divider, $standard->getDivider());
+    }
+
+    public function test_hasDivider()
+    {
+        $f = $this->getReportFactory();
+        $items = $this->getStringItemsMock();
+        $divider = $this->getDividerComponent();
+
+        $standard = $f->standard($items);
+        $this->assertFalse($standard->hasDivider());
+
+        $standard = $standard->withDivider($divider);
+        $this->assertTrue($standard->hasDivider());
+    }
+
+    public function test_withDivider()
+    {
+        $f = $this->getReportFactory();
+        $items = $this->getStringItemsMock();
+        $divider = $this->getDividerComponent();
+
+        $standard = $f->standard($items)->withDivider($divider);
+
+        $this->assertEquals($divider, $standard->getDivider());
+    }
+
+    public function test_validation()
+    {
+        $f = $this->getReportFactory();
+
+        foreach($this->getInvalidItemsMocks() as $invalidItemsMock)
+        {
+            try
+            {
+                $f->standard($invalidItemsMock);
+
+                $this->throwException(new Exception(
+                    'expected InvalidArgumentException, catched none'
+                ));
+            }
+            catch(InvalidArgumentException $e)
+            {
+                $this->assertInstanceOf('InvalidArgumentException', $e);
+            }
+        }
+    }
+
+    public function test_rendered_with_divider()
+    {
+        $f = $this->getReportFactory();
+        $r = $this->getDefaultRenderer();
+
+        $items = $this->getMixedItemsMock();
+        $standard = $f->standard($items)->withDivider($this->getDividerComponent());
+        $actualHtml = $r->render($standard);
+
+        $expectedHtml = $this->getExpectedMixedItemsMockHtml(true);
+
+        $this->assertHTMLEquals($expectedHtml, $actualHtml);
+    }
+
+    public function test_rendered_without_divider()
+    {
+        $f = $this->getReportFactory();
+        $r = $this->getDefaultRenderer();
+
+        $items = $this->getMixedItemsMock();
+        $standard = $f->standard($items);
+        $actualHtml = $r->render($standard);
+
+        $expectedHtml = $this->getExpectedMixedItemsMockHtml(false);
+
+        $this->assertHTMLEquals($expectedHtml, $actualHtml);
+    }
+
+    private function getExpectedMixedItemsMockHtml($withDivider)
+    {
+        $html =  '<div class="row">';
+        $html .= '		<div class="il-listing-report-row clearfix">';
+        $html .= '			<div class="il-listing-report-label col-md-6 col-xs-8">label1</div>';
+        $html .= '			<div class="il-listing-report-item col-md-6 col-xs-4">item1</div>';
+        $html .= '		</div>';
+        if($withDivider)
+        {
+            $html .= '			<div class="col-md-12">';
+            $html .= '<hr  />';
+            $html .= '</div>';
+        }
+        $html .= '		<div class="il-listing-report-row clearfix">';
+        $html .= '			<div class="il-listing-report-label col-md-6 col-xs-8">label2</div>';
+        $html .= '			<div class="il-listing-report-item col-md-6 col-xs-4">item2</div>';
+        $html .= '		</div>';
+        if($withDivider)
+        {
+            $html .= '			<div class="col-md-12">';
+            $html .= '<hr  />';
+            $html .= '</div>';
+        }
+        $html .= '		<div class="il-listing-report-row clearfix">';
+        $html .= '			<div class="il-listing-report-label col-md-6 col-xs-8">label3</div>';
+        $html .= '			<div class="il-listing-report-item col-md-6 col-xs-4">item3</div>';
+        $html .= '		</div>';
+        if($withDivider)
+        {
+            $html .= '			<div class="col-md-12">';
+            $html .= '<hr  />';
+            $html .= '</div>';
+        }
+        $html .= '		<div class="il-listing-report-row clearfix">';
+        $html .= '			<div class="il-listing-report-label col-md-6 col-xs-8">label4</div>';
+        $html .= '			<div class="il-listing-report-item col-md-6 col-xs-4">item4</div>';
+        $html .= '		</div>';
+        $html .= '</div>';
+
+        return $html;
+    }
+
+    private function getDividerComponent()
+    {
+        return new \ILIAS\UI\Implementation\Component\Divider\Horizontal();
+    }
+}

--- a/tests/UI/Component/Listing/Report/ReportTest.php
+++ b/tests/UI/Component/Listing/Report/ReportTest.php
@@ -1,0 +1,70 @@
+<?php
+
+require_once('tests/UI/Base.php');
+
+class ReportTest extends ILIAS_UI_TestBase
+{
+    public function test_interfaces()
+    {
+        $f = $this->getReportFactory();
+
+        $this->assertInstanceOf(
+            'ILIAS\\UI\\Component\\Listing\\Report\\Factory',
+            $f
+        );
+
+        $this->assertInstanceOf(
+            'ILIAS\\UI\\Component\\Listing\\Report\\Standard',
+            $f->standard($this->getStringItemsMock())
+        );
+
+        $this->assertInstanceOf(
+            'ILIAS\\UI\\Component\\Listing\\Report\\Mini',
+            $f->mini($this->getStringItemsMock())
+        );
+    }
+
+    protected function getReportFactory()
+    {
+        return new ILIAS\UI\Implementation\Component\Listing\Report\Factory();
+    }
+
+    protected function getLegacyComponent($content)
+    {
+        return new \ILIAS\UI\Implementation\Component\Legacy\Legacy($content);
+    }
+
+    protected function getComponentItemsMock()
+    {
+        return [
+            'label1' => $this->getLegacyComponent('items1'),
+            'label2' => $this->getLegacyComponent('item2')
+        ];
+    }
+
+    protected function getStringItemsMock()
+    {
+        return [
+            'label1' => 'item1', 'label2' => 'item2', 'label3' => 'item3'
+        ];
+    }
+
+    protected function getMixedItemsMock()
+    {
+        return [
+            'label1' => 'item1',
+            'label2' => $this->getLegacyComponent('item2'),
+            'label3' => 'item3',
+            'label4' => $this->getLegacyComponent('item4')
+        ];
+    }
+
+    protected function getInvalidItemsMocks()
+    {
+        return [
+            ['' => 'item'],
+            ['label' => ''],
+            []
+        ];
+    }
+}


### PR DESCRIPTION
This PR introduces a new ui component called report listing:
UI > Listing > Report > Standard / Mini

It is to be used to present listings of label-value doubles that need to be presented side by side.

It is more about presenting longer labels for short values than a short term that is described with a longer description. This is why we need this report listing as a rival to the descriptive listing.

*Standard Report Listing*

The Standard Report Listing is used for a regular presentation in the main content of a page as a major part of the ui.
```
function base()
{
    global $DIC; /* @var \ILIAS\DI\Container $DIC */
    $f = $DIC->ui()->factory();
    $r = $DIC->ui()->renderer();

    $items = [
        'Any Label for the First Item' => 'Item 1',
        'Another Label for the Second Item' => 'Item 2',
        'Third Item Comes as Component' => $f->legacy('Item 3'),
        'Fourth Item Comes as Component' => $f->legacy('Item 4')
    ];

    $standard = $f->listing()->report()->standard($items)->withDivider(
        $f->divider()->horizontal()
    );

    return $r->render($standard);
}
```
![image](https://user-images.githubusercontent.com/2587908/63017962-eacaa900-be97-11e9-8976-1461c30d5ef1.png)

*Mini Report Listing*

The variant Mini Report Listing is to be used when presenting the information as a mariginal part of the ui, e.g. when using in the card of a reporting panel.
```
function base()
{
    global $DIC; /* @var \ILIAS\DI\Container $DIC */
    $f = $DIC->ui()->factory();
    $r = $DIC->ui()->renderer();

    $items = [
        'Any Label for the First Item' => 'Item 1',
        'Another Label for the Second Item' => 'Item 2',
        'Third Item Comes as Component' => $f->legacy('Item 3'),
        'Fourth Item Comes as Component' => $f->legacy('Item 4')
    ];

    $mini = $f->listing()->report()->mini($items);

    return $r->render($mini);
}
```
![image](https://user-images.githubusercontent.com/2587908/63017922-d2f32500-be97-11e9-9982-9feded014789.png)
