### PR TITLE
Adding Guidelines for Screenshots in Docs

### DIFF
--- a/docs/development/docs-guidelines.md
+++ b/docs/development/docs-guidelines.md
@@ -51,6 +51,11 @@ with "You SHOULD").
 * If contend from other files is referenced an internal link to this document
 SHOULD be provided.
 * Line wrap after around 80 chars per line to improve readability SHOULD be used.
+* Screenshots and Images SHOULD be avoided in the documentation if possible. Use
+abstractions instead. If there is no way around using an image, it MUST be included
+by referencing a resource in the [screenshots folder](https://ilias-elearning.github.io/screenshots)
+on https://ilias-elearning.github.io.
+
 
 ### Table of Contents (Markdown)
 


### PR DESCRIPTION
The Technical Board would like to propose a small addition to the guideline to clarify the use of screenshots in the docs folder of ILIAS.