### PR TITLE
[UI/Renderer] Add dependency to refinery to UI renderer

### DIFF
--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1639,19 +1639,22 @@ class ilInitialisation
 							, $c["ui.template_factory"]
 							, $c["lng"]
 							, $c["ui.javascript_binding"]
+							, $c["refinery"]
 							),
 						  new ILIAS\UI\Implementation\Component\Symbol\Glyph\GlyphRendererFactory
 							($c["ui.factory"]
 							, $c["ui.template_factory"]
 							, $c["lng"]
 							, $c["ui.javascript_binding"]
-							),
+							, $c["refinery"]
+						  ),
 						  new ILIAS\UI\Implementation\Component\Input\Field\FieldRendererFactory
 						  	($c["ui.factory"]
 						  	, $c["ui.template_factory"]
 						  	, $c["lng"]
 						  	, $c["ui.javascript_binding"]
-							)
+							, $c["refinery"]
+						  )
 						)
 					)
 				);

--- a/src/UI/Implementation/Component/Input/Field/FieldRendererFactory.php
+++ b/src/UI/Implementation/Component/Input/Field/FieldRendererFactory.php
@@ -10,8 +10,20 @@ class FieldRendererFactory extends Render\DefaultRendererFactory {
 
 	public function getRendererInContext(Component\Component $component, array $contexts) {
 		if( in_array('StandardFilterContainerInput', $contexts)) {
-			return new FilterContextRenderer($this->ui_factory, $this->tpl_factory, $this->lng, $this->js_binding);
+			return new FilterContextRenderer(
+				$this->ui_factory,
+				$this->tpl_factory,
+				$this->lng,
+				$this->js_binding,
+				$this->refinery
+			);
 		}
-		return new Renderer($this->ui_factory, $this->tpl_factory, $this->lng, $this->js_binding);
+		return new Renderer(
+			$this->ui_factory,
+			$this->tpl_factory,
+			$this->lng,
+			$this->js_binding,
+			$this->refinery
+		);
 	}
 }

--- a/src/UI/Implementation/Component/Symbol/Glyph/GlyphRendererFactory.php
+++ b/src/UI/Implementation/Component/Symbol/Glyph/GlyphRendererFactory.php
@@ -10,8 +10,20 @@ class GlyphRendererFactory extends Render\DefaultRendererFactory {
 
 	public function getRendererInContext(Component\Component $component, array $contexts) {
 		if( in_array('BulkyButton', $contexts)) {
-			return new ButtonContextRenderer($this->ui_factory, $this->tpl_factory, $this->lng, $this->js_binding);
+			return new ButtonContextRenderer(
+				$this->ui_factory,
+				$this->tpl_factory,
+				$this->lng,
+				$this->js_binding,
+				$this->refinery
+			);
 		}
-		return new Renderer($this->ui_factory, $this->tpl_factory, $this->lng, $this->js_binding);
+		return new Renderer(
+			$this->ui_factory,
+			$this->tpl_factory,
+			$this->lng,
+			$this->js_binding,
+			$this->refinery
+		);
 	}
 }

--- a/src/UI/Implementation/Render/AbstractComponentRenderer.php
+++ b/src/UI/Implementation/Render/AbstractComponentRenderer.php
@@ -42,13 +42,25 @@ abstract class AbstractComponentRenderer implements ComponentRenderer {
 	private static $component_storage = [];
 
 	/**
+	 * @var \ILIAS\Refinery\Factory
+	 */
+	private $refinery;
+
+	/**
 	 * Component renderers must only depend on a UI-Factory and a Template Factory.
 	 */
-	final public function __construct(Factory $ui_factory, TemplateFactory $tpl_factory, \ilLanguage $lng, JavaScriptBinding $js_binding) {
+	final public function __construct(
+		Factory $ui_factory,
+		TemplateFactory $tpl_factory,
+		\ilLanguage $lng,
+		JavaScriptBinding $js_binding,
+		\ILIAS\Refinery\Factory $refinery
+	) {
 		$this->ui_factory = $ui_factory;
 		$this->tpl_factory = $tpl_factory;
 		$this->lng = $lng;
 		$this->js_binding = $js_binding;
+		$this->refinery = $refinery;
 	}
 
 	/**
@@ -67,6 +79,13 @@ abstract class AbstractComponentRenderer implements ComponentRenderer {
 	 */
 	final protected function getUIFactory() {
 		return $this->ui_factory;
+	}
+
+	/**
+	 * @return \ILIAS\Refinery\Factory
+	 */
+	final protected function getRefinery() : \ILIAS\Refinery\Factory{
+		return $this->refinery;
 	}
 
 	/**

--- a/src/UI/Implementation/Render/DefaultRendererFactory.php
+++ b/src/UI/Implementation/Render/DefaultRendererFactory.php
@@ -4,6 +4,7 @@
 
 namespace ILIAS\UI\Implementation\Render;
 
+use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\UI\Component\Component;
 use ILIAS\UI\Factory as RootFactory;
 
@@ -29,11 +30,23 @@ class DefaultRendererFactory implements RendererFactory {
 	 */
 	protected $js_binding;
 
-	public function __construct(RootFactory $ui_factory, TemplateFactory $tpl_factory, \ilLanguage $lng, JavaScriptBinding $js_binding) {
+	/**
+	 * @var Refinery
+	 */
+	protected $refinery;
+
+	public function __construct(
+		RootFactory $ui_factory,
+		TemplateFactory $tpl_factory,
+		\ilLanguage $lng,
+		JavaScriptBinding $js_binding,
+		Refinery $refinery
+	) {
 		$this->ui_factory = $ui_factory;
 		$this->tpl_factory = $tpl_factory;
 		$this->lng = $lng;
 		$this->js_binding = $js_binding;
+		$this->refinery = $refinery;
 	}
 
 	/**
@@ -42,7 +55,13 @@ class DefaultRendererFactory implements RendererFactory {
 	public function getRendererInContext(Component $component, array $contexts) {
 		$name = $this->getRendererNameFor($component);
 		$this->lng->loadLanguageModule("ui");
-		return new $name($this->ui_factory, $this->tpl_factory, $this->lng, $this->js_binding);
+		return new $name(
+			$this->ui_factory,
+			$this->tpl_factory,
+			$this->lng,
+			$this->js_binding,
+			$this->refinery
+		);
 	}
 
 

--- a/tests/UI/Base.php
+++ b/tests/UI/Base.php
@@ -153,6 +153,12 @@ abstract class ILIAS_UI_TestBase extends TestCase {
 		return new LoggingJavaScriptBinding();
 	}
 
+	public function getRefinery() {
+		return $this->getMockBuilder(\ILIAS\Refinery\Factory::class)
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
 	public function getDefaultRenderer(JavaScriptBinding $js_binding = null) {
 		$ui_factory = $this->getUIFactory();
 		$tpl_factory = $this->getTemplateFactory();
@@ -161,6 +167,8 @@ abstract class ILIAS_UI_TestBase extends TestCase {
 		if(!$js_binding){
 			$js_binding = $this->getJavaScriptBinding();
 		}
+
+		$refinery = $this->getRefinery();
 
 		$component_renderer_loader
 			= new Render\LoaderCachingWrapper
@@ -172,19 +180,22 @@ abstract class ILIAS_UI_TestBase extends TestCase {
 							, $tpl_factory
 							, $lng
 							, $js_binding
+							, $refinery
 							),
 						  new GlyphRendererFactory
 							( $ui_factory
 							, $tpl_factory
 							, $lng
 							, $js_binding
-							),
+							, $refinery
+						  ),
 						  new FieldRendererFactory
 							( $ui_factory
 							, $tpl_factory
 							, $lng
 							, $js_binding
-							)
+							, $refinery
+						  )
 						)
 					)
 				);

--- a/tests/UI/Component/Symbol/Glyph/GlyphTest.php
+++ b/tests/UI/Component/Symbol/Glyph/GlyphTest.php
@@ -382,7 +382,13 @@ class GlyphTest extends ILIAS_UI_TestBase {
 
 	public function test_dont_render_counter() {
 		$this->expectException(\LogicException::class);
-		$r = new \ILIAS\UI\Implementation\Component\Symbol\Glyph\Renderer($this->getUIFactory(), $this->getTemplateFactory(),$this->getLanguage(), $this->getJavaScriptBinding());
+		$r = new \ILIAS\UI\Implementation\Component\Symbol\Glyph\Renderer(
+			$this->getUIFactory(),
+			$this->getTemplateFactory(),
+			$this->getLanguage(),
+			$this->getJavaScriptBinding(),
+			$this->getRefinery()
+		);
 		$f = $this->getCounterFactory();
 
 		$r->render($f->status(0), $this->getDefaultRenderer());

--- a/tests/UI/Renderer/AbstractRendererTest.php
+++ b/tests/UI/Renderer/AbstractRendererTest.php
@@ -99,7 +99,13 @@ namespace {
 		}
 
 		public function test_getTemplate_successfull() {
-			$r = new \ILIAS\UI\Implementation\Component\Symbol\Glyph\GlyphNonAbstractRenderer($this->ui_factory, $this->tpl_factory, $this->lng, $this->js_binding);
+			$r = new \ILIAS\UI\Implementation\Component\Symbol\Glyph\GlyphNonAbstractRenderer(
+				$this->ui_factory,
+				$this->tpl_factory,
+				$this->lng,
+				$this->js_binding,
+				$this->getRefinery()
+			);
 			$tpl = $r->_getTemplate("tpl.glyph.html", true, false);
 
 			$expected = array
@@ -111,7 +117,13 @@ namespace {
 		}
 
 		public function test_getTemplate_unsuccessfull() {
-			$r = new \ILIAS\UI\Implementation\Component\Counter\CounterNonAbstractRenderer($this->ui_factory, $this->tpl_factory, $this->lng, $this->js_binding);
+			$r = new \ILIAS\UI\Implementation\Component\Counter\CounterNonAbstractRenderer(
+				$this->ui_factory,
+				$this->tpl_factory,
+				$this->lng,
+				$this->js_binding,
+				$this->getRefinery()
+			);
 
 			try {
 				$tpl = $r->_getTemplate("tpl.counter_foo.html", true, false);
@@ -126,7 +138,13 @@ namespace {
 		}
 
 		public function test_bindJavaScript_successfull() {
-			$r = new \ILIAS\UI\Implementation\Component\Symbol\Glyph\GlyphNonAbstractRendererWithJS($this->ui_factory, $this->tpl_factory, $this->lng, $this->js_binding);
+			$r = new \ILIAS\UI\Implementation\Component\Symbol\Glyph\GlyphNonAbstractRendererWithJS(
+				$this->ui_factory,
+				$this->tpl_factory,
+				$this->lng,
+				$this->js_binding,
+				$this->getRefinery()
+			);
 
 			$g = new \ILIAS\UI\Implementation\Component\Symbol\Glyph\Glyph(\ILIAS\UI\Component\Symbol\Glyph\Glyph::SETTINGS, "aria_label");
 
@@ -143,7 +161,13 @@ namespace {
 		}
 
 		public function test_bindJavaScript_no_string() {
-			$r = new \ILIAS\UI\Implementation\Component\Symbol\Glyph\GlyphNonAbstractRendererWithJS($this->ui_factory, $this->tpl_factory, $this->lng, $this->js_binding);
+			$r = new \ILIAS\UI\Implementation\Component\Symbol\Glyph\GlyphNonAbstractRendererWithJS(
+				$this->ui_factory,
+				$this->tpl_factory,
+				$this->lng,
+				$this->js_binding,
+				$this->getRefinery()
+			);
 
 			$g = new \ILIAS\UI\Implementation\Component\Symbol\Glyph\Glyph(\ILIAS\UI\Component\Symbol\Glyph\Glyph::SETTINGS, "aria_label");
 

--- a/tests/UI/Renderer/ComponentRendererFSLoaderTest.php
+++ b/tests/UI/Renderer/ComponentRendererFSLoaderTest.php
@@ -21,7 +21,7 @@ class ComponentRendererFSLoaderTest extends TestCase {
 		$js_binding = $this->getMockBuilder(I\Render\JavaScriptBinding::class)->getMock();
 		$refinery_mock = $this->getMockBuilder(\ILIAS\Refinery\Factory::class)
 			->disableOriginalConstructor()
-            ->getMock();
+			->getMock();
 
 		$default_renderer_factory = new I\Render\DefaultRendererFactory(
 			$ui_factory,

--- a/tests/UI/Renderer/ComponentRendererFSLoaderTest.php
+++ b/tests/UI/Renderer/ComponentRendererFSLoaderTest.php
@@ -20,7 +20,7 @@ class ComponentRendererFSLoaderTest extends TestCase {
 		$lng = $this->getMockBuilder(\ilLanguage::class)->disableOriginalConstructor()->getMock();
 		$js_binding = $this->getMockBuilder(I\Render\JavaScriptBinding::class)->getMock();
 		$refinery_mock = $this->getMockBuilder(\ILIAS\Refinery\Factory::class)
-            ->disableOriginalConstructor()
+			->disableOriginalConstructor()
             ->getMock();
 
 		$default_renderer_factory = new I\Render\DefaultRendererFactory(

--- a/tests/UI/Renderer/ComponentRendererFSLoaderTest.php
+++ b/tests/UI/Renderer/ComponentRendererFSLoaderTest.php
@@ -19,7 +19,17 @@ class ComponentRendererFSLoaderTest extends TestCase {
 		$tpl_factory = $this->getMockBuilder(I\Render\TemplateFactory::class)->getMock();
 		$lng = $this->getMockBuilder(\ilLanguage::class)->disableOriginalConstructor()->getMock();
 		$js_binding = $this->getMockBuilder(I\Render\JavaScriptBinding::class)->getMock();
-		$default_renderer_factory = new I\Render\DefaultRendererFactory($ui_factory, $tpl_factory, $lng, $js_binding);
+		$refinery_mock = $this->getMockBuilder(\ILIAS\Refinery\Factory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+		$default_renderer_factory = new I\Render\DefaultRendererFactory(
+			$ui_factory,
+			$tpl_factory,
+			$lng,
+			$js_binding,
+			$refinery_mock
+		);
 		$this->glyph_renderer = $this->createMock(I\Render\RendererFactory::class);
 		$this->field_renderer = $this->createMock(I\Render\RendererFactory::class);
 		return new ComponentRendererFSLoaderTesting($default_renderer_factory, $this->glyph_renderer, $this->field_renderer);


### PR DESCRIPTION
As mentioned in #2042 we need the dependency to the refinery in the UI renderers.

This will open the possibility to perform transformations on the renderer itself like an URI object: See: https://github.com/ILIAS-eLearning/ILIAS/pull/2042/files#diff-2265bd27bb95d394abca54b061ed26d7R37