### PR TITLE
GlobalScreen: Scope Notifications

### DIFF
--- a/Services/BackgroundTasks/classes/Provider/BTNotificationProvider.php
+++ b/Services/BackgroundTasks/classes/Provider/BTNotificationProvider.php
@@ -1,0 +1,41 @@
+<?php namespace ILIAS\BackgroundTasks\Provider;
+
+use ILIAS\GlobalScreen\Identification\IdentificationInterface;
+use ILIAS\GlobalScreen\Scope\Notification\Provider\AbstractNotificationProvider;
+use ILIAS\GlobalScreen\Scope\Notification\Provider\NotificationProvider;
+
+/**
+ * Class BTNotificationProvider
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+class BTNotificationProvider extends AbstractNotificationProvider implements NotificationProvider
+{
+
+    /**
+     * @inheritDoc
+     */
+    public function getNotifications() : array
+    {
+        $id = function (string $id) : IdentificationInterface {
+            return $this->if->identifier($id);
+        };
+
+        $factory = $this->globalScreen()->notifications()->factory();
+
+        $group = $factory->standardGroup($id('bg_bucket_group'))->withTitle("Some Notifications");
+
+        for ($x = 1; $x < 10; $x++) {
+            $n = $factory->standard($id('bg_bucket_id_' . $x))
+                ->withTitle("A Notification " . $x)
+                ->withSummary("with a super summary " . $x)
+                ->withAction("#");
+
+            $group->addNotification($n);
+        }
+
+        return [
+            $group,
+        ];
+    }
+}

--- a/Services/GlobalScreen/artifacts/global_screen_providers.php
+++ b/Services/GlobalScreen/artifacts/global_screen_providers.php
@@ -26,8 +26,9 @@
   'ILIAS\\GlobalScreen\\Scope\\MetaBar\\Provider\\StaticMetaBarProvider' => 
   array (
     0 => 'ILIAS\\BackgroundTasks\\Provider\\BackgroundTasksMetaBarProvider',
-    1 => 'ILIAS\\Search\\Provider\\SearchMetaBarProvider',
-    2 => 'ILIAS\\User\\Provider\\UserMetaBarProvider',
+    1 => 'ILIAS\\GlobalScreen\\Scope\\MetaBar\\Provider\\NotificationCenterProvider',
+    2 => 'ILIAS\\Search\\Provider\\SearchMetaBarProvider',
+    3 => 'ILIAS\\User\\Provider\\UserMetaBarProvider',
   ),
   'ILIAS\\GlobalScreen\\Scope\\Tool\\Provider\\DynamicToolProvider' => 
   array (
@@ -37,5 +38,9 @@
   array (
     0 => 'ILIAS\\Container\\Screen\\MemberViewLayoutProvider',
     1 => 'ILIAS\\UICore\\PageContentProvider',
+  ),
+  'ILIAS\\GlobalScreen\\Scope\\Notification\\Provider\\NotificationProvider' => 
+  array (
+    0 => 'ILIAS\\BackgroundTasks\\Provider\\BTNotificationProvider',
   ),
 );

--- a/Services/GlobalScreen/classes/Setup/class.ilGlobalScreenBuildProviderMapObjective.php
+++ b/Services/GlobalScreen/classes/Setup/class.ilGlobalScreenBuildProviderMapObjective.php
@@ -3,6 +3,7 @@
 use ILIAS\GlobalScreen\Scope\Layout\Provider\ModificationProvider;
 use ILIAS\GlobalScreen\Scope\MainMenu\Provider\StaticMainMenuProvider;
 use ILIAS\GlobalScreen\Scope\MetaBar\Provider\StaticMetaBarProvider;
+use ILIAS\GlobalScreen\Scope\Notification\Provider\NotificationProvider;
 use ILIAS\GlobalScreen\Scope\Tool\Provider\DynamicToolProvider;
 use ILIAS\Setup;
 
@@ -28,6 +29,7 @@ class ilGlobalScreenBuildProviderMapObjective extends Setup\BuildArtifactObjecti
             StaticMetaBarProvider::class,
             DynamicToolProvider::class,
             ModificationProvider::class,
+            NotificationProvider::class,
         ];
 
         foreach ($i as $interface) {

--- a/Services/GlobalScreen/classes/class.ilGSProviderFactory.php
+++ b/Services/GlobalScreen/classes/class.ilGSProviderFactory.php
@@ -7,6 +7,7 @@ use ILIAS\GlobalScreen\Scope\Layout\Provider\ModificationProvider;
 use ILIAS\GlobalScreen\Scope\MainMenu\Collector\Information\ItemInformation;
 use ILIAS\GlobalScreen\Scope\MainMenu\Provider\StaticMainMenuProvider;
 use ILIAS\GlobalScreen\Scope\MetaBar\Provider\StaticMetaBarProvider;
+use ILIAS\GlobalScreen\Scope\Notification\Provider\NotificationProvider;
 use ILIAS\GlobalScreen\Scope\Tool\Provider\DynamicToolProvider;
 
 /**
@@ -119,6 +120,21 @@ class ilGSProviderFactory implements ProviderFactory
 
         // Plugins
         $this->appendPlugins($providers, DynamicToolProvider::class);
+
+        $this->registerInternal($providers);
+
+        return $providers;
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getNotificationsProvider() : array
+    {
+        $providers = [];
+        // Core
+        $this->appendCore($providers, NotificationProvider::class);
 
         $this->registerInternal($providers);
 

--- a/src/GlobalScreen/Collector/CollectorFactory.php
+++ b/src/GlobalScreen/Collector/CollectorFactory.php
@@ -4,6 +4,7 @@ use ILIAS\GlobalScreen\Provider\ProviderFactory;
 use ILIAS\GlobalScreen\Scope\Layout\Collector\MainLayoutCollector;
 use ILIAS\GlobalScreen\Scope\MainMenu\Collector\MainMenuMainCollector;
 use ILIAS\GlobalScreen\Scope\MetaBar\Collector\MetaBarMainCollector;
+use ILIAS\GlobalScreen\Scope\Notification\Collector\MainNotificationCollector;
 use ILIAS\GlobalScreen\Scope\Tool\Collector\MainToolCollector;
 use ILIAS\GlobalScreen\SingletonTrait;
 
@@ -82,9 +83,19 @@ class CollectorFactory
 
     /**
      * @return MainLayoutCollector
+     * @throws \ReflectionException
      */
     public function layout() : MainLayoutCollector
     {
-        return $this->getWithArgument(MainLayoutCollector::class, $this->provider_factory->getModificationProvider());
+        return $this->getWithMultipleArguments(MainLayoutCollector::class, [$this->provider_factory->getModificationProvider()]);
+    }
+
+
+    /**
+     * @return MainNotificationCollector
+     */
+    public function notifications() : MainNotificationCollector
+    {
+        return $this->getWithArgument(MainNotificationCollector::class, $this->provider_factory->getNotificationsProvider());
     }
 }

--- a/src/GlobalScreen/Provider/NullProviderFactory.php
+++ b/src/GlobalScreen/Provider/NullProviderFactory.php
@@ -58,6 +58,15 @@ class NullProviderFactory implements ProviderFactory
     /**
      * @inheritDoc
      */
+    public function getNotificationsProvider() : array
+    {
+        return [];
+    }
+
+
+    /**
+     * @inheritDoc
+     */
     public function getProviderByClassName(string $class_name) : Provider
     {
         // return new NullP;

--- a/src/GlobalScreen/Provider/ProviderFactory.php
+++ b/src/GlobalScreen/Provider/ProviderFactory.php
@@ -4,6 +4,7 @@ use ILIAS\GlobalScreen\Scope\Layout\Provider\ModificationProvider;
 use ILIAS\GlobalScreen\Scope\MainMenu\Collector\Information\ItemInformation;
 use ILIAS\GlobalScreen\Scope\MainMenu\Provider\StaticMainMenuProvider;
 use ILIAS\GlobalScreen\Scope\MetaBar\Provider\StaticMetaBarProvider;
+use ILIAS\GlobalScreen\Scope\Notification\Provider\NotificationProvider;
 use ILIAS\GlobalScreen\Scope\Tool\Provider\DynamicToolProvider;
 
 /**
@@ -42,6 +43,12 @@ interface ProviderFactory
      * @return StaticMetaBarProvider[]
      */
     public function getMetaBarProvider() : array;
+
+
+    /**
+     * @return NotificationProvider[]
+     */
+    public function getNotificationsProvider() : array;
 
 
     /**

--- a/src/GlobalScreen/README.md
+++ b/src/GlobalScreen/README.md
@@ -16,6 +16,7 @@ There are several scopes served by the GlobalScreen service. Currently these are
 - MainBar (main menu)
 - MetaBar
 - Tool
+- Notification
 - Layout
 
 A scope refers to an area on an ILIAS page. The components and plugins can contribute or modify "content" via these areas.
@@ -38,6 +39,9 @@ The Scope Tool has a lot to do with the Scope MainBar, since the elements
 can be reproduced in almost the same place. However, both the `Items` and the `Providers` as such are .
 
 For more information see [Scope/Tools/README.md](Scope/Tool/README.md).
+
+# Scope Notifications
+For more information, see [Scope/Notification/README.md](Scope/Notification/README.md).
 
 ## Scope Layout
 This area is the superordinate element and responsible for the entire structure of a page. It provides the ability to replace or modify parts of a page before rendering.

--- a/src/GlobalScreen/Scope/Layout/Collector/MainLayoutCollector.php
+++ b/src/GlobalScreen/Scope/Layout/Collector/MainLayoutCollector.php
@@ -7,6 +7,7 @@ use ILIAS\GlobalScreen\Scope\Layout\Factory\LogoModification;
 use ILIAS\GlobalScreen\Scope\Layout\Factory\MainBarModification;
 use ILIAS\GlobalScreen\Scope\Layout\Factory\MetaBarModification;
 use ILIAS\GlobalScreen\Scope\Layout\Factory\NullModification;
+use ILIAS\GlobalScreen\Scope\Layout\MetaContent\MetaContent;
 use ILIAS\GlobalScreen\Scope\Layout\ModificationHandler;
 use ILIAS\GlobalScreen\Scope\Layout\Provider\ModificationProvider;
 use ILIAS\GlobalScreen\ScreenContext\Stack\CalledContexts;
@@ -36,7 +37,7 @@ class MainLayoutCollector
     /**
      * MainLayoutCollector constructor.
      *
-     * @param ModificationProvider[] $providers
+     * @param array $providers
      */
     public function __construct(array $providers)
     {
@@ -127,5 +128,16 @@ class MainLayoutCollector
         $called_contexts = $DIC->globalScreen()->tool()->context()->stack();
 
         return $called_contexts;
+    }
+
+
+    /**
+     * @return MetaContent
+     */
+    private function getMetaContent() : MetaContent
+    {
+        global $DIC;
+
+        return $DIC->globalScreen()->layout()->meta();
     }
 }

--- a/src/GlobalScreen/Scope/MetaBar/Collector/Renderer/NotificationCenterRenderer.php
+++ b/src/GlobalScreen/Scope/MetaBar/Collector/Renderer/NotificationCenterRenderer.php
@@ -1,0 +1,58 @@
+<?php namespace ILIAS\GlobalScreen\Scope\MetaBar\Collector\Renderer;
+
+use ILIAS\GlobalScreen\Collector\Renderer\isSupportedTrait;
+use ILIAS\GlobalScreen\Scope\MetaBar\Factory\isItem;
+use ILIAS\GlobalScreen\Scope\MetaBar\Factory\NotificationCenter;
+use ILIAS\UI\Component\Component;
+
+/**
+ * Class NotificationCenterRenderer
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+class NotificationCenterRenderer implements MetaBarItemRenderer
+{
+
+    use isSupportedTrait;
+    /**
+     * @var \ILIAS\GlobalScreen\Services
+     */
+    private $ui;
+    /**
+     * @var \ILIAS\GlobalScreen\Services
+     */
+    private $gs;
+
+
+    /**
+     * BaseMetaBarItemRenderer constructor.
+     */
+    public function __construct()
+    {
+        global $DIC;
+        $this->ui = $DIC->ui();
+        $this->gs = $DIC->globalScreen();
+    }
+
+
+    /**
+     * @param NotificationCenter $item
+     *
+     * @return Component
+     */
+    public function getComponentForItem(isItem $item) : Component
+    {
+        $f = $this->ui->factory();
+
+        $combined = $f->mainControls()->slate()->combined("Notification Center", $item->getSymbol());
+
+        foreach ($this->gs->collector()->notifications()->getNotifications() as $notification) {
+            $component = $notification->getRenderer()->getComponentForItem($notification);
+            if ($this->isComponentSupportedForCombinedSlate($component)) {
+                $combined = $combined->withAdditionalEntry($component);
+            }
+        }
+
+        return $combined;
+    }
+}

--- a/src/GlobalScreen/Scope/MetaBar/Factory/MetaBarItemFactory.php
+++ b/src/GlobalScreen/Scope/MetaBar/Factory/MetaBarItemFactory.php
@@ -54,4 +54,21 @@ class MetaBarItemFactory
     {
         return new TopLinkItem($identification);
     }
+
+
+    /**
+     * @param IdentificationInterface $identification
+     *
+     * @return NotificationCenter
+     */
+    public function notificationCenter(IdentificationInterface $identification)
+    {
+        static $created;
+        if ($created === true) {
+            throw new \LogicException("only one NotificationCenter can exist");
+        }
+        $created = true;
+
+        return new NotificationCenter($identification);
+    }
 }

--- a/src/GlobalScreen/Scope/MetaBar/Factory/NotificationCenter.php
+++ b/src/GlobalScreen/Scope/MetaBar/Factory/NotificationCenter.php
@@ -1,0 +1,90 @@
+<?php namespace ILIAS\GlobalScreen\Scope\MetaBar\Factory;
+
+use ILIAS\GlobalScreen\Identification\IdentificationInterface;
+use ILIAS\GlobalScreen\Scope\MetaBar\Collector\Renderer\NotificationCenterRenderer;
+use ILIAS\UI\Component\Symbol\Symbol;
+
+/**
+ * Class NotificationCenter
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+class NotificationCenter extends AbstractBaseItem implements isItem, hasSymbol
+{
+
+    /**
+     * @var isItem[]
+     */
+    private $notifications = [];
+
+
+    /**
+     * @inheritDoc
+     */
+    public function __construct(IdentificationInterface $provider_identification)
+    {
+        parent::__construct($provider_identification);
+        $this->renderer = new NotificationCenterRenderer();
+    }
+
+
+    /**
+     * @param isItem[] $notifications
+     *
+     * @return NotificationCenter
+     */
+    public function withNotifications(array $notifications) : NotificationCenter
+    {
+        $this->notifications = $notifications;
+
+        return $this;
+    }
+
+
+    /**
+     * @return isItem[]
+     */
+    public function getNotifications() : array
+    {
+        return $this->notifications;
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function withSymbol(Symbol $symbol) : hasSymbol
+    {
+        return $this;
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function hasSymbol() : bool
+    {
+        return true;
+    }
+
+
+    /**
+     * @return Symbol
+     */
+    public function getSymbol() : Symbol
+    {
+        global $DIC;
+
+        // TODO implement counter
+        return $DIC->ui()->factory()->symbol()->glyph()->notification();
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getPosition() : int
+    {
+        return 1;
+    }
+}

--- a/src/GlobalScreen/Scope/MetaBar/Provider/NotificationCenterProvider.php
+++ b/src/GlobalScreen/Scope/MetaBar/Provider/NotificationCenterProvider.php
@@ -1,0 +1,38 @@
+<?php namespace ILIAS\GlobalScreen\Scope\MetaBar\Provider;
+
+use ILIAS\GlobalScreen\Identification\IdentificationInterface;
+
+/**
+ * Class NotificationCenterProvider
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+class NotificationCenterProvider extends AbstractStaticMetaBarProvider implements StaticMetaBarProvider
+{
+
+    /**
+     * @inheritDoc
+     */
+    public function getMetaBarItems() : array
+    {
+
+        $mb = $this->globalScreen()->metaBar();
+        $id = function ($id) : IdentificationInterface {
+            return $this->if->identifier($id);
+        };
+        $item = [];
+
+        $item[] = $mb->notificationCenter($id('notification_center'))
+            ->withAvailableCallable(function () {
+                // Check if notifications available
+                return true;
+            })
+            ->withVisibilityCallable(
+                function () {
+                    return !$this->dic->user()->isAnonymous();
+                }
+            );
+
+        return $item;
+    }
+}

--- a/src/GlobalScreen/Scope/Notification/Collector/MainNotificationCollector.php
+++ b/src/GlobalScreen/Scope/Notification/Collector/MainNotificationCollector.php
@@ -1,0 +1,44 @@
+<?php namespace ILIAS\GlobalScreen\Scope\Notification\Collector;
+
+use ILIAS\GlobalScreen\Scope\Notification\Factory\isItem;
+use ILIAS\GlobalScreen\Scope\Notification\Provider\NotificationProvider;
+
+/**
+ * Class MainNotificationCollector
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+class MainNotificationCollector
+{
+
+    /**
+     * @var NotificationProvider[]
+     */
+    private $providers = [];
+
+
+    /**
+     * MetaBarMainCollector constructor.
+     *
+     * @param NotificationProvider[] $providers
+     */
+    public function __construct(array $providers)
+    {
+        $this->providers = $providers;
+    }
+
+
+    /**
+     * @return isItem[]
+     */
+    public function getNotifications() : array
+    {
+        $notifications = [];
+
+        foreach ($this->providers as $provider) {
+            $notifications = array_merge($notifications, $provider->getNotifications());
+        }
+
+        return $notifications;
+    }
+}

--- a/src/GlobalScreen/Scope/Notification/Collector/Renderer/AbstractBaseNotificationRenderer.php
+++ b/src/GlobalScreen/Scope/Notification/Collector/Renderer/AbstractBaseNotificationRenderer.php
@@ -1,0 +1,45 @@
+<?php namespace ILIAS\GlobalScreen\Scope\Notification\Collector\Renderer;
+
+use ILIAS\GlobalScreen\Scope\Notification\Factory\canHaveSymbol;
+use ILIAS\GlobalScreen\Scope\Notification\Factory\isItem;
+use ILIAS\UI\Component\Symbol\Symbol;
+use ILIAS\UI\Factory;
+
+/**
+ * Class AbstractBaseNotificationRenderer
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+abstract class AbstractBaseNotificationRenderer implements NotificationRenderer
+{
+
+    /**
+     * @var Factory
+     */
+    protected $ui_factory;
+
+
+    /**
+     * StandardNotificationRenderer constructor.
+     */
+    public function __construct()
+    {
+        global $DIC;
+        $this->ui_factory = $DIC->ui()->factory();
+    }
+
+
+    /**
+     * @param isItem $item
+     *
+     * @return Symbol
+     */
+    protected function getStandardSymbol(isItem $item) : Symbol
+    {
+        if ($item instanceof canHaveSymbol && $item->hasSymbol()) {
+            return $item->getSymbol();
+        }
+
+        return $this->ui_factory->symbol()->icon()->custom("./src/UI/examples/Layout/Page/Standard/question.svg", 'ILIAS', 'small', true);
+    }
+}

--- a/src/GlobalScreen/Scope/Notification/Collector/Renderer/NotificationRenderer.php
+++ b/src/GlobalScreen/Scope/Notification/Collector/Renderer/NotificationRenderer.php
@@ -1,0 +1,24 @@
+<?php namespace ILIAS\GlobalScreen\Scope\Notification\Collector\Renderer;
+
+use ILIAS\GlobalScreen\Scope\Notification\Factory\isItem;
+use ILIAS\UI\Component\Component;
+
+/**
+ * Interface NotificationRenderer
+ *
+ * Every Notification should have a renderer, if you won't provide on in your
+ * TypeInformation, a StandardNotificationRenderer is used.
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+interface NotificationRenderer
+{
+
+    /**
+     * @param isItem $item
+     *
+     * @return Component
+     */
+    public function getComponentForItem(isItem $item) : Component;
+}
+

--- a/src/GlobalScreen/Scope/Notification/Collector/Renderer/StandardNotificationGroupRenderer.php
+++ b/src/GlobalScreen/Scope/Notification/Collector/Renderer/StandardNotificationGroupRenderer.php
@@ -1,0 +1,45 @@
+<?php namespace ILIAS\GlobalScreen\Scope\Notification\Collector\Renderer;
+
+use ILIAS\GlobalScreen\Collector\Renderer\isSupportedTrait;
+use ILIAS\GlobalScreen\Scope\Notification\Factory\isItem;
+use ILIAS\GlobalScreen\Scope\Notification\Factory\StandardNotificationGroup;
+use ILIAS\UI\Component\Component;
+
+/**
+ * Class StandardNotificationGroupRenderer
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+class StandardNotificationGroupRenderer extends AbstractBaseNotificationRenderer implements NotificationRenderer
+{
+
+    use isSupportedTrait;
+
+
+    /**
+     * @param isItem $item
+     *
+     * @return Component
+     * @throws \Exception
+     */
+    public function getComponentForItem(isItem $item) : Component
+    {
+        if (!$item instanceof StandardNotificationGroup) {
+            throw new \LogicException("item is not a StandardNotificationGroup");
+        }
+        /**
+         * @var $item StandardNotificationGroup
+         */
+
+        $slate = $this->ui_factory->mainControls()->slate()->combined($item->getTitle(), $this->getStandardSymbol($item));
+
+        foreach ($item->getNotifications() as $standard_notification) {
+            $component = $standard_notification->getRenderer()->getComponentForItem($standard_notification);
+            if ($this->isComponentSupportedForCombinedSlate($component)) {
+                $slate = $slate->withAdditionalEntry($component);
+            }
+        }
+
+        return $slate;
+    }
+}

--- a/src/GlobalScreen/Scope/Notification/Collector/Renderer/StandardNotificationRenderer.php
+++ b/src/GlobalScreen/Scope/Notification/Collector/Renderer/StandardNotificationRenderer.php
@@ -1,0 +1,31 @@
+<?php namespace ILIAS\GlobalScreen\Scope\Notification\Collector\Renderer;
+
+use ILIAS\GlobalScreen\Scope\Notification\Factory\canHaveSymbol;
+use ILIAS\GlobalScreen\Scope\Notification\Factory\hasActions;
+use ILIAS\GlobalScreen\Scope\Notification\Factory\hasTitle;
+use ILIAS\GlobalScreen\Scope\Notification\Factory\isItem;
+use ILIAS\UI\Component\Component;
+
+/**
+ * Class StandardNotificationRenderer
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+class StandardNotificationRenderer extends AbstractBaseNotificationRenderer implements NotificationRenderer
+{
+
+    /**
+     * @param isItem|hasActions|canHaveSymbol $item
+     *
+     * @return Component
+     */
+    public function getComponentForItem(isItem $item) : Component
+    {
+
+        $label = $item instanceof hasTitle ? $item->getTitle() : "";
+
+        $action = $item instanceof hasActions ? $item->getAction() : "#";
+
+        return $this->ui_factory->button()->bulky($this->getStandardSymbol($item), $label, $action);
+    }
+}

--- a/src/GlobalScreen/Scope/Notification/Factory/AbstractBaseNotification.php
+++ b/src/GlobalScreen/Scope/Notification/Factory/AbstractBaseNotification.php
@@ -1,0 +1,48 @@
+<?php namespace ILIAS\GlobalScreen\Scope\Notification\Factory;
+
+use ILIAS\GlobalScreen\Identification\IdentificationInterface;
+use ILIAS\GlobalScreen\Scope\Notification\Collector\Renderer\NotificationRenderer;
+use ILIAS\GlobalScreen\Scope\Notification\Collector\Renderer\StandardNotificationRenderer;
+
+/**
+ * Class AbstractBaseNotification
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+abstract class AbstractBaseNotification implements isItem
+{
+
+    /**
+     * @var IdentificationInterface
+     */
+    protected $provider_identification;
+
+
+    /**
+     * StandardNotification constructor.
+     *
+     * @param IdentificationInterface $identification
+     */
+    public function __construct(IdentificationInterface $identification)
+    {
+        $this->provider_identification = $identification;
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getProviderIdentification() : IdentificationInterface
+    {
+        return $this->provider_identification;
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getRenderer() : NotificationRenderer
+    {
+        return new StandardNotificationRenderer();
+    }
+}

--- a/src/GlobalScreen/Scope/Notification/Factory/AbstractTitleNotification.php
+++ b/src/GlobalScreen/Scope/Notification/Factory/AbstractTitleNotification.php
@@ -1,0 +1,57 @@
+<?php namespace ILIAS\GlobalScreen\Scope\Notification\Factory;
+
+/**
+ * Class AbstractTitleNotification
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+abstract class AbstractTitleNotification extends AbstractBaseNotification implements hasTitle, isItem
+{
+
+    /**
+     * @var string
+     */
+    protected $title = "";
+
+
+    /**
+     * @inheritDoc
+     */
+    public function withTitle(string $title) : hasTitle
+    {
+        $clone = clone $this;
+        $clone->title = $title;
+
+        return $clone;
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getTitle() : string
+    {
+        return $this->title;
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function withSummary(string $summary) : isItem
+    {
+        $clone = clone $this;
+        $clone->summary = $summary;
+
+        return $clone;
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getSummary() : string
+    {
+        return $this->summary;
+    }
+}

--- a/src/GlobalScreen/Scope/Notification/Factory/NotificationFactory.php
+++ b/src/GlobalScreen/Scope/Notification/Factory/NotificationFactory.php
@@ -1,0 +1,33 @@
+<?php namespace ILIAS\GlobalScreen\Scope\Notification\Factory;
+
+use ILIAS\GlobalScreen\Identification\IdentificationInterface;
+
+/**
+ * Class NotificationFactory
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+class NotificationFactory
+{
+
+    /**
+     * @param IdentificationInterface $identification
+     *
+     * @return StandardNotification
+     */
+    public function standard(IdentificationInterface $identification) : StandardNotification
+    {
+        return new StandardNotification($identification);
+    }
+
+
+    /**
+     * @param IdentificationInterface $identification
+     *
+     * @return StandardNotificationGroup
+     */
+    public function standardGroup(IdentificationInterface $identification) : StandardNotificationGroup
+    {
+        return new StandardNotificationGroup($identification);
+    }
+}

--- a/src/GlobalScreen/Scope/Notification/Factory/StandardNotification.php
+++ b/src/GlobalScreen/Scope/Notification/Factory/StandardNotification.php
@@ -1,0 +1,196 @@
+<?php namespace ILIAS\GlobalScreen\Scope\Notification\Factory;
+
+use Closure;
+use DateTimeImmutable;
+use ILIAS\UI\Component\Symbol\Symbol;
+
+/**
+ * Class Notification
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+class StandardNotification extends AbstractTitleNotification implements isItem, hasTitle, canHaveSymbol, hasActions
+{
+
+    /**
+     * @var Symbol
+     */
+    private $symbol;
+    /**
+     * @var array
+     */
+    private $additional_actions = [];
+    /**
+     * @var int
+     */
+    private $progress;
+    /**
+     * @var string
+     */
+    private $action;
+    /**
+     * @var DateTimeImmutable
+     */
+    protected $date;
+    /**
+     * @var string
+     */
+    protected $summary;
+    /**
+     * @var Closure
+     */
+    protected $close_action_callback;
+
+
+    /**
+     * @inheritDoc
+     */
+    public function withDate(DateTimeImmutable $date_time_immutable) : isItem
+    {
+        $clone = clone $this;
+        $clone->date = $date_time_immutable;
+
+        return $clone;
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getDate() : DateTimeImmutable
+    {
+        return $this->date;
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function withCloseActionCallback(Closure $callback) : isItem
+    {
+        $clone = clone $this;
+        $clone->close_action_callback = $callback;
+
+        return $clone;
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getCloseActionCallback() : Closure
+    {
+        return $this->close_action_callback;
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function withAction(string $action) : isItem
+    {
+        $clone = clone $this;
+        $clone->action = $action;
+
+        return $clone;
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function hasAction() : bool
+    {
+        return is_string($this->action);
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getAction() : string
+    {
+        return $this->action;
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function withSymbol(Symbol $symbol) : canHaveSymbol
+    {
+        $clone = clone $this;
+        $clone->symbol = $symbol;
+
+        return $clone;
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function hasSymbol() : bool
+    {
+        return ($this->symbol instanceof Symbol);
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getSymbol() : Symbol
+    {
+        return $this->symbol;
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function withAdditionalAction(string $title, string $action) : isItem
+    {
+        $clone = clone $this;
+        $clone->additional_actions[$title] = $action;
+
+        return $clone;
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getAdditionalActions() : array
+    {
+        return $this->additional_actions;
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function withProgress(int $progress) : isItem
+    {
+        $clone = clone $this;
+        $clone->progress = $progress;
+
+        return $clone;
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function hasProgress() : bool
+    {
+        return is_int($this->progress);
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getProgress() : int
+    {
+        return $this->progress;
+    }
+}

--- a/src/GlobalScreen/Scope/Notification/Factory/StandardNotificationGroup.php
+++ b/src/GlobalScreen/Scope/Notification/Factory/StandardNotificationGroup.php
@@ -1,0 +1,49 @@
+<?php namespace ILIAS\GlobalScreen\Scope\Notification\Factory;
+
+use ILIAS\GlobalScreen\Scope\Notification\Collector\Renderer\NotificationRenderer;
+use ILIAS\GlobalScreen\Scope\Notification\Collector\Renderer\StandardNotificationGroupRenderer;
+
+/**
+ * Class StandardNotificationGroup
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+class StandardNotificationGroup extends AbstractTitleNotification implements hasTitle, isItem
+{
+
+    /**
+     * @var StandardNotification[]
+     */
+    private $notifications = [];
+
+
+    /**
+     * @param StandardNotification $notification
+     *
+     * @return StandardNotificationGroup
+     */
+    public function addNotification(StandardNotification $notification) : StandardNotificationGroup
+    {
+        $this->notifications[] = $notification;
+
+        return $this;
+    }
+
+
+    /**
+     * @return StandardNotification[]
+     */
+    public function getNotifications() : array
+    {
+        return $this->notifications;
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getRenderer() : NotificationRenderer
+    {
+        return new StandardNotificationGroupRenderer();
+    }
+}

--- a/src/GlobalScreen/Scope/Notification/Factory/canHaveSymbol.php
+++ b/src/GlobalScreen/Scope/Notification/Factory/canHaveSymbol.php
@@ -1,0 +1,31 @@
+<?php namespace ILIAS\GlobalScreen\Scope\Notification\Factory;
+
+use ILIAS\UI\Component\Symbol\Symbol;
+
+/**
+ * Interface canHaveSymbol
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+interface canHaveSymbol
+{
+
+    /**
+     * @param Symbol $symbol
+     *
+     * @return canHaveSymbol
+     */
+    public function withSymbol(Symbol $symbol) : self;
+
+
+    /**
+     * @return bool
+     */
+    public function hasSymbol() : bool;
+
+
+    /**
+     * @return Symbol
+     */
+    public function getSymbol() : Symbol;
+}

--- a/src/GlobalScreen/Scope/Notification/Factory/hasActions.php
+++ b/src/GlobalScreen/Scope/Notification/Factory/hasActions.php
@@ -1,0 +1,65 @@
+<?php namespace ILIAS\GlobalScreen\Scope\Notification\Factory;
+
+use Closure;
+
+/**
+ * Interface hasActions
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+interface hasActions
+{
+
+    //
+    // TODO
+    // - additional actions ev. auch als callback, beide varianten (auch URl) anbieten
+    //
+
+    /**
+     * @param string $action
+     *
+     * @return isItem
+     */
+    public function withAction(string $action) : isItem;
+
+
+    /**
+     * @return bool
+     */
+    public function hasAction() : bool;
+
+
+    /**
+     * @return string
+     */
+    public function getAction() : string;
+
+
+    /**
+     * @param Closure $callback
+     *
+     * @return isItem
+     */
+    public function withCloseActionCallback(Closure $callback) : isItem;
+
+
+    /**
+     * @return Closure
+     */
+    public function getCloseActionCallback() : Closure;
+
+
+    /**
+     * @param string $title
+     * @param string $action
+     *
+     * @return isItem
+     */
+    public function withAdditionalAction(string $title, string $action) : isItem;
+
+
+    /**
+     * @return array
+     */
+    public function getAdditionalActions() : array;
+}

--- a/src/GlobalScreen/Scope/Notification/Factory/hasTitle.php
+++ b/src/GlobalScreen/Scope/Notification/Factory/hasTitle.php
@@ -1,0 +1,37 @@
+<?php namespace ILIAS\GlobalScreen\Scope\Notification\Factory;
+
+/**
+ * Interface hasTitle
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+interface hasTitle
+{
+
+    /**
+     * @param string $title
+     *
+     * @return hasTitle
+     */
+    public function withTitle(string $title) : hasTitle;
+
+
+    /**
+     * @return string
+     */
+    public function getTitle() : string;
+
+
+    /**
+     * @param string $summary
+     *
+     * @return isItem
+     */
+    public function withSummary(string $summary) : isItem;
+
+
+    /**
+     * @return string
+     */
+    public function getSummary() : string;
+}

--- a/src/GlobalScreen/Scope/Notification/Factory/isItem.php
+++ b/src/GlobalScreen/Scope/Notification/Factory/isItem.php
@@ -1,0 +1,24 @@
+<?php namespace ILIAS\GlobalScreen\Scope\Notification\Factory;
+
+use ILIAS\GlobalScreen\Identification\IdentificationInterface;
+use ILIAS\GlobalScreen\Scope\Notification\Collector\Renderer\NotificationRenderer;
+
+/**
+ * Interface isItem
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+interface isItem
+{
+
+    /**
+     * @return IdentificationInterface
+     */
+    public function getProviderIdentification() : IdentificationInterface;
+
+
+    /**
+     * @return NotificationRenderer
+     */
+    public function getRenderer() : NotificationRenderer;
+}

--- a/src/GlobalScreen/Scope/Notification/NotificationServices.php
+++ b/src/GlobalScreen/Scope/Notification/NotificationServices.php
@@ -1,0 +1,24 @@
+<?php namespace ILIAS\GlobalScreen\Scope\Notification;
+
+use ILIAS\GlobalScreen\Scope\Notification\Factory\NotificationFactory;
+use ILIAS\GlobalScreen\SingletonTrait;
+
+/**
+ * Class NotificationServices
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+class NotificationServices
+{
+
+    use SingletonTrait;
+
+
+    /**
+     * @return NotificationFactory
+     */
+    public function factory() : NotificationFactory
+    {
+        return $this->get(NotificationFactory::class);
+    }
+}

--- a/src/GlobalScreen/Scope/Notification/Provider/AbstractNotificationProvider.php
+++ b/src/GlobalScreen/Scope/Notification/Provider/AbstractNotificationProvider.php
@@ -1,0 +1,39 @@
+<?php namespace ILIAS\GlobalScreen\Scope\Notification\Provider;
+
+use ILIAS\DI\Container;
+use ILIAS\GlobalScreen\Identification\IdentificationProviderInterface;
+use ILIAS\GlobalScreen\Provider\AbstractProvider;
+use ILIAS\GlobalScreen\Scope\Notification\Factory\NotificationFactory;
+
+/**
+ * Interface AbstractNotificationProvider
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+abstract class AbstractNotificationProvider extends AbstractProvider implements NotificationProvider
+{
+
+    /**
+     * @var Container
+     */
+    protected $dic;
+    /**
+     * @var IdentificationProviderInterface
+     */
+    protected $if;
+    /**
+     * @var NotificationFactory
+     */
+    protected $notification_factory;
+
+
+    /**
+     * @inheritDoc
+     */
+    public function __construct(Container $dic)
+    {
+        parent::__construct($dic);
+        $this->notification_factory = $this->globalScreen()->notifications()->factory();
+        $this->if = $this->globalScreen()->identification()->core($this);
+    }
+}

--- a/src/GlobalScreen/Scope/Notification/Provider/NotificationProvider.php
+++ b/src/GlobalScreen/Scope/Notification/Provider/NotificationProvider.php
@@ -1,0 +1,18 @@
+<?php namespace ILIAS\GlobalScreen\Scope\Notification\Provider;
+
+use ILIAS\GlobalScreen\Provider\Provider;
+use ILIAS\GlobalScreen\Scope\Notification\Factory\isItem;
+
+/**
+ * Interface NotificationProvider
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+interface NotificationProvider extends Provider
+{
+
+    /**
+     * @return isItem[]
+     */
+    public function getNotifications() : array;
+}

--- a/src/GlobalScreen/Scope/Notification/README.md
+++ b/src/GlobalScreen/Scope/Notification/README.md
@@ -1,0 +1,61 @@
+Scope Notifications
+===================
+This scope addresses notifications that are displayed to the user in the NotificationCenter (a dedicated item in the MetaBar). Components can - as in all other scopes - via an implementation of a `NotificationProvider` provide the `MainNotificationCollector` with a list of notifications. These are summarized and displayed in the NotificationCenter.
+
+The following types are currently available via the Factory:
+
+- `StandardNotification`
+- `StandardNotificationGroup`
+
+# Provider
+
+An own provider is quickly implemented, e.g:
+
+```php
+<?php declare(strict_types=1);
+
+namespace ILIAS\BackgroundTasks\Provider;
+
+use ILIAS\GlobalScreen\Identification\IdentificationInterface;
+use ILIAS\GlobalScreen\Scope\Notification\Provider\AbstractNotificationProvider;
+use ILIAS\GlobalScreen\Scope\Notification\Provider\NotificationProvider;
+
+/**
+ * Class BTNotificationProvider
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+class BTNotificationProvider extends AbstractNotificationProvider implements NotificationProvider
+{
+
+    /**
+     * @inheritDoc
+     */
+    public function getNotifications() : array
+    {
+        $id = function (string $id) : IdentificationInterface {
+            return $this->if->identifier($id);
+        };
+
+        $factory = $this->globalScreen()->notifications()->factory();
+
+        $group = $factory->standardGroup($id('bg_bucket_group'));
+
+        for ($x = 1; $x < 10; $x++) {
+            $n = $factory->standard($id('bg_bucket_id_' . $x))
+                ->withTitle("A Notification " . $x)
+                ->withSummary("with a super summary " . $x)
+                ->withAction("#");
+
+            $group->addNotification($n);
+        }
+
+        return [
+            $group,
+        ];
+    }
+}
+
+```
+
+In this case, the effective notifications are collected in a NotificationGroup. These can then also be rendered as a group in the NotificationCenter.

--- a/src/GlobalScreen/Services.php
+++ b/src/GlobalScreen/Services.php
@@ -6,6 +6,7 @@ use ILIAS\GlobalScreen\Provider\ProviderFactory;
 use ILIAS\GlobalScreen\Scope\Layout\LayoutServices;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\MainMenuItemFactory;
 use ILIAS\GlobalScreen\Scope\MetaBar\Factory\MetaBarItemFactory;
+use ILIAS\GlobalScreen\Scope\Notification\NotificationServices;
 use ILIAS\GlobalScreen\Scope\Tool\ToolServices;
 
 /**
@@ -89,6 +90,15 @@ class Services
     public function layout() : LayoutServices
     {
         return $this->get(LayoutServices::class);
+    }
+
+
+    /**
+     * @return NotificationServices
+     */
+    public function notifications() : NotificationServices
+    {
+        return $this->get(NotificationServices::class);
     }
 
 


### PR DESCRIPTION
After an exciting developer workshop today, we decided to split this pull request. Now only the server-side extension to the GlobalScreen service is proposed, which takes care of the notifications.

A second PR to the client-side notifications, as they are needed for ILIAS 6 especially from the chat, will be opened here shortly.

Furthermore, this PR does not include the rendering of the notifications, UI components are still required for this. Currently notifications are rendered as Bulky-Buttons and have no special function yet.

A description of the scope can be found here: [src/GlobalScreen/Scope/Notification/README.md](https://github.com/ILIAS-eLearning/ILIAS/blob/d4c222530ea60e7bc46b320d5511768e7bb5c3a7/src/GlobalScreen/Scope/Notification/README.md)