### PR TITLE
Fix ternary expression violating: Unparenthesized `a ? b : c ? d : e`…

### DIFF
--- a/Services/Repository/classes/class.ilRepositoryGUI.php
+++ b/Services/Repository/classes/class.ilRepositoryGUI.php
@@ -448,9 +448,9 @@ class ilRepositoryGUI
 
 		$active_node = ($_GET["active_node"] > 1)
 			? $_GET["active_node"]
-			: ($_GET["ref_id"] > 1)
+			: (($_GET["ref_id"] > 1)
 				? $_GET["ref_id"]
-				: 0;
+				: 0);
 		$top_node = 0;
 		if ($ilSetting->get("rep_tree_limit_grp_crs") && $active_node > 0)
 		{

--- a/Services/UIComponent/Glyph/classes/class.ilGlyphGUI.php
+++ b/Services/UIComponent/Glyph/classes/class.ilGlyphGUI.php
@@ -62,9 +62,9 @@ class ilGlyphGUI
 		$html = "";
 		$text = ($a_text == "")
 			? $lng->txt(self::$map[$a_glyph]["txt"])
-			: ($a_text == self::NO_TEXT)
+			: (($a_text == self::NO_TEXT)
 				? ""
-				: $a_text;
+				: $a_text);
 		switch ($a_glyph)
 		{
 			case self::CARET:

--- a/Services/WebAccessChecker/classes/class.ilWACSignedPath.php
+++ b/Services/WebAccessChecker/classes/class.ilWACSignedPath.php
@@ -124,14 +124,14 @@ class ilWACSignedPath {
 		$ttlCookie = $cookieJar->get($name . self::TTL_SUFFIX);
 
 		$defaultToken = '';
-		$tokenCookieValue = is_null($tokenCookie) ? $defaultToken : is_a($tokenCookie->getValue(), Cookie::class) ? $tokenCookie->getValue() : $defaultToken;
+		$tokenCookieValue = is_null($tokenCookie) ? $defaultToken : (is_a($tokenCookie->getValue(), Cookie::class) ? $tokenCookie->getValue() : $defaultToken);
 
 		$defaultTimestamp = 0;
-		$timestampCookieValue = is_null($timestampCookie) ? $defaultTimestamp : is_a($timestampCookie->getValue(), Cookie::class) ? $timestampCookie->getValue() : $defaultTimestamp;
+		$timestampCookieValue = is_null($timestampCookie) ? $defaultTimestamp : (is_a($timestampCookie->getValue(), Cookie::class) ? $timestampCookie->getValue() : $defaultTimestamp);
 		$timestampCookieValue = intval($timestampCookieValue);
 
 		$defaultTtl = 0;
-		$ttlCookieValue = is_null($ttlCookie) ? $defaultTtl : is_a($ttlCookie->getValue(), Cookie::class) ? $ttlCookie->getValue() : $defaultTtl;
+		$ttlCookieValue = is_null($ttlCookie) ? $defaultTtl : (is_a($ttlCookie->getValue(), Cookie::class) ? $ttlCookie->getValue() : $defaultTtl);
 		$ttlCookieValue = intval($ttlCookieValue);
 
 		$this->getPathObject()->setToken($tokenCookieValue);


### PR DESCRIPTION
… is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)` (PHP 7.4 deprecation)