### PR TITLE
Travis CI: removed classmap spam, from composer process

### DIFF
--- a/src/Setup/ImplementationOfInterfaceFinder.php
+++ b/src/Setup/ImplementationOfInterfaceFinder.php
@@ -71,7 +71,6 @@ class ImplementationOfInterfaceFinder
         foreach ($composer_classmap as $class_name => $file_path) {
             $path = str_replace($root, "", realpath($file_path));
             if (!preg_match("#^" . $regexp . "$#", $path)) {
-                echo $path . " => " . $class_name . "\n";
                 yield $class_name;
             }
         }


### PR DESCRIPTION
This `echo` spams the composer build, which results in locking the process log for a short period of time and I don't see the necessity for this behavior.