### PR TITLE
Replcaing boolean default value with empty string to avoid exception …

### DIFF
--- a/Services/Mail/classes/class.ilMailOptions.php
+++ b/Services/Mail/classes/class.ilMailOptions.php
@@ -85,8 +85,8 @@ class ilMailOptions
      */
     public function createMailOptionsEntry() : void
     {
-        $incomingMail = strlen($this->settings->get('mail_incoming_mail')) ? (int) $this->settings->get('mail_incoming_mail') : self::INCOMING_LOCAL;
-        $emailAddressOption = strlen($this->settings->get('mail_address_option')) ? (int) $this->settings->get('mail_address_option') : self::FIRST_EMAIL;
+        $incomingMail = strlen($this->settings->get('mail_incoming_mail', '')) ? (int) $this->settings->get('mail_incoming_mail') : self::INCOMING_LOCAL;
+        $emailAddressOption = strlen($this->settings->get('mail_address_option', '')) ? (int) $this->settings->get('mail_address_option') : self::FIRST_EMAIL;
 
         $this->db->replace(
             $this->table_mail_options,


### PR DESCRIPTION
…throw

During user creation this path is used and throws an exception because the default for `ilSettings::get` is a boolean false. `strlen` can only work with strings in PHP 7.2.