### PR TITLE
Changed version number pattern for ILIAS 6 and ff.

### DIFF
--- a/include/inc.ilias_version.php
+++ b/include/inc.ilias_version.php
@@ -1,5 +1,5 @@
 <?php
-/* Copyright (c) 1998-2018 ILIAS open source e-Learning e.V., Extended GPL, see docs/LICENSE */
+/* Copyright (c) 1998-2019 ILIAS open source e-Learning e.V., Extended GPL, see docs/LICENSE */
 
 /**
 * sets ILIAS version (this file shouldn't be merged between cvs branches)
@@ -9,5 +9,5 @@
 *
 * @package ilias-core
 */
-define("ILIAS_VERSION", "6.0.0 alpha");
-define("ILIAS_VERSION_NUMERIC", "6.0.0");			// must be always x.y.z: x, y and z are numbers
+define("ILIAS_VERSION", "6.0 alpha");
+define("ILIAS_VERSION_NUMERIC", "6.0");			// since version ILIAS 6 this must be always x.y: x and y are numbers


### PR DESCRIPTION
According to decision communicated at Jour Fixe at July 29, ILIAS will get a modified version numbering with ILIAS 6. The new pattern consists no longer of three but of two numbers: one for the major and one for minor release. 6.0 is the first stable release of version 6. 6.1 will be the first bugfix release of version 6. New features will come with ILIAS 7. This PR is adapting this decision to inc.ilias_version.php .