### PR TITLE
GS: allow null as return types for page parts

### DIFF
--- a/src/GlobalScreen/Scope/Layout/Factory/AbstractLayoutModification.php
+++ b/src/GlobalScreen/Scope/Layout/Factory/AbstractLayoutModification.php
@@ -123,14 +123,14 @@ abstract class AbstractLayoutModification implements LayoutModification
             if ($first_argument_type !== null) {
                 if (!isset($r->getParameters()[0])
                     || !$r->getParameters()[0]->hasType()
-                    || $r->getParameters()[0]->getType()->getName() !== $first_argument_type
+                    || ($r->getParameters()[0]->getType()->getName() !== $first_argument_type && $r->getParameters()[0]->getType()->allowsNull())
                 ) {
                     return false;
                 }
             }
 
             if (!$r->hasReturnType()
-                || $r->getReturnType()->getName() !== $return_type
+                || ($r->getReturnType()->getName() !== $return_type && !$r->getReturnType()->allowsNull())
             ) {
                 return false;
             }

--- a/src/GlobalScreen/Scope/Layout/Provider/PagePart/DecoratedPagePartProvider.php
+++ b/src/GlobalScreen/Scope/Layout/Provider/PagePart/DecoratedPagePartProvider.php
@@ -67,7 +67,7 @@ class DecoratedPagePartProvider implements PagePartProvider
     /**
      * @inheritDoc
      */
-    public function getContent() : Legacy
+    public function getContent() : ?Legacy
     {
         return $this->getDecoratedOrOriginal(Legacy::class, $this->original->getContent());
     }
@@ -76,7 +76,7 @@ class DecoratedPagePartProvider implements PagePartProvider
     /**
      * @inheritDoc
      */
-    public function getMetaBar() : MetaBar
+    public function getMetaBar() : ?MetaBar
     {
         return $this->getDecoratedOrOriginal(MetaBar::class, $this->original->getMetaBar());
     }
@@ -85,7 +85,7 @@ class DecoratedPagePartProvider implements PagePartProvider
     /**
      * @inheritDoc
      */
-    public function getMainBar() : MainBar
+    public function getMainBar() : ?MainBar
     {
         return $this->getDecoratedOrOriginal(MainBar::class, $this->original->getMainBar());
     }
@@ -94,7 +94,7 @@ class DecoratedPagePartProvider implements PagePartProvider
     /**
      * @inheritDoc
      */
-    public function getBreadCrumbs() : Breadcrumbs
+    public function getBreadCrumbs() : ?Breadcrumbs
     {
         return $this->getDecoratedOrOriginal(Breadcrumbs::class, $this->original->getBreadCrumbs());
     }
@@ -103,7 +103,7 @@ class DecoratedPagePartProvider implements PagePartProvider
     /**
      * @inheritDoc
      */
-    public function getLogo() : Image
+    public function getLogo() : ?Image
     {
         return $this->getDecoratedOrOriginal(Image::class, $this->original->getLogo());
     }

--- a/src/GlobalScreen/Scope/Layout/Provider/PagePart/PagePartProvider.php
+++ b/src/GlobalScreen/Scope/Layout/Provider/PagePart/PagePartProvider.php
@@ -17,29 +17,29 @@ interface PagePartProvider
     /**
      * @return Legacy
      */
-    public function getContent() : Legacy;
+    public function getContent() : ?Legacy;
 
 
     /**
      * @return MetaBar
      */
-    public function getMetaBar() : MetaBar;
+    public function getMetaBar() : ?MetaBar;
 
 
     /**
      * @return MainBar
      */
-    public function getMainBar() : MainBar;
+    public function getMainBar() : ?MainBar;
 
 
     /**
      * @return Breadcrumbs
      */
-    public function getBreadCrumbs() : Breadcrumbs;
+    public function getBreadCrumbs() : ?Breadcrumbs;
 
 
     /**
      * @return Image
      */
-    public function getLogo() : Image;
+    public function getLogo() : ?Image;
 }

--- a/src/GlobalScreen/Scope/Layout/Provider/PagePart/StandardPagePartProvider.php
+++ b/src/GlobalScreen/Scope/Layout/Provider/PagePart/StandardPagePartProvider.php
@@ -49,7 +49,7 @@ class StandardPagePartProvider implements PagePartProvider
     /**
      * @inheritDoc
      */
-    public function getContent() : Legacy
+    public function getContent() : ?Legacy
     {
         return $this->content ?? new LegacyImplementation("");
     }
@@ -58,7 +58,7 @@ class StandardPagePartProvider implements PagePartProvider
     /**
      * @inheritDoc
      */
-    public function getMetaBar() : MetaBar
+    public function getMetaBar() : ?MetaBar
     {
         $f = $this->ui->factory();
         $meta_bar = $f->mainControls()->metaBar();
@@ -78,7 +78,7 @@ class StandardPagePartProvider implements PagePartProvider
     /**
      * @inheritDoc
      */
-    public function getMainBar() : MainBar
+    public function getMainBar() : ?MainBar
     {
         $f = $this->ui->factory();
         $main_bar = $f->mainControls()->mainBar();
@@ -114,7 +114,7 @@ class StandardPagePartProvider implements PagePartProvider
     /**
      * @inheritDoc
      */
-    public function getBreadCrumbs() : Breadcrumbs
+    public function getBreadCrumbs() : ?Breadcrumbs
     {
         // TODO this currently gets the items from ilLocatorGUI, should that serve be removed with
         // something like GlobalScreen\Scope\Locator\Item
@@ -133,7 +133,7 @@ class StandardPagePartProvider implements PagePartProvider
     /**
      * @inheritDoc
      */
-    public function getLogo() : Image
+    public function getLogo() : ?Image
     {
         return $this->ui->factory()->image()->standard(ilUtil::getImagePath("HeaderIcon.svg"), "ILIAS");
     }


### PR DESCRIPTION
For your information: PageParts and Modifications should allow null as return type since otherwise it's impossible to remove things like the Mainbar completely. This is needed e.g. in Login-Pages (see #2116 )

This is just an interface-change