### PR TITLE
lso fix wrong tpl type hints

### DIFF
--- a/Modules/LearningSequence/classes/Content/class.ilObjLearningSequenceContentGUI.php
+++ b/Modules/LearningSequence/classes/Content/class.ilObjLearningSequenceContentGUI.php
@@ -23,7 +23,7 @@ class ilObjLearningSequenceContentGUI
 	public function __construct(
 		ilObjLearningSequenceGUI $parent_gui,
 		ilCtrl $ctrl,
-		ilGlobalTemplate $tpl,
+		ilGlobalTemplateInterface $tpl,
 		ilLanguage $lng,
 		ilAccess $access,
 		ilConfirmationGUI $confirmation_gui,

--- a/Modules/LearningSequence/classes/Player/class.ilObjLearningSequenceLearnerGUI.php
+++ b/Modules/LearningSequence/classes/Player/class.ilObjLearningSequenceLearnerGUI.php
@@ -31,7 +31,7 @@ class ilObjLearningSequenceLearnerGUI
 		int $current_item,
 		ilCtrl $ctrl,
 		ilLanguage $lng,
-		ilGlobalTemplate $tpl,
+		ilGlobalTemplateInterface $tpl,
 		ilToolbarGUI $toolbar,
 		ilKioskModeService $kiosk_mode_service,
 		ilAccess $access,

--- a/Modules/LearningSequence/classes/Settings/class.ilObjLearningSequenceSettingsGUI.php
+++ b/Modules/LearningSequence/classes/Settings/class.ilObjLearningSequenceSettingsGUI.php
@@ -45,7 +45,7 @@ class ilObjLearningSequenceSettingsGUI
 		ilObjLearningSequence $obj,
 		ilCtrl $il_ctrl,
 		ilLanguage $il_language,
-		ilGlobalTemplate $il_template,
+		ilGlobalTemplateInterface $il_template,
 		ilObjectService $obj_service
 	) {
 		$this->obj = $obj;


### PR DESCRIPTION
This pull request does fix wrong type hintings within the learning sequence object. There is no bug report. I just stumbled over the error message when trying some things with the LSO.