### PR TITLE
Fix behavior if il-variable is undefined

### DIFF
--- a/Services/JavaScript/js/Basic.js
+++ b/Services/JavaScript/js/Basic.js
@@ -19,7 +19,9 @@ if (!window.console) {
 }
 
 // global il namespace, additional objects usually should be added to this one
-il = il || {};
+if (typeof il === 'undefined') {
+	il = {}
+}
 
 // utility functions
 il.Util = {


### PR DESCRIPTION
The latest PR #2136 seems to break the current JavaScript bindings on several pages.

This is a more old school fix, but it seems to work on the pages that just broke.