### PR TITLE
UI/Node: Fix some rendering problems with bylined nodes and bylined linked nodes

### DIFF
--- a/src/UI/Implementation/Component/Tree/Node/Renderer.php
+++ b/src/UI/Implementation/Component/Tree/Node/Renderer.php
@@ -43,6 +43,9 @@ class Renderer extends AbstractComponentRenderer {
 			if($icon){
 				$tpl->setVariable("ICON_LINKED", $default_renderer->render($icon));
 			}
+			if ($component instanceof Node\Bylined && null !== $component->getByline()) {
+				$tpl->setVariable('BYLINE_LINKED', $component->getByline());
+			}
 		}
 		else {
 			$tpl->setCurrentBlock("node_without_link");
@@ -50,12 +53,10 @@ class Renderer extends AbstractComponentRenderer {
 			if($icon){
 				$tpl->setVariable("ICON", $default_renderer->render($icon));
 			}
+			if ($component instanceof Node\Bylined && null !== $component->getByline()) {
+				$tpl->setVariable('BYLINE', $component->getByline());
+			}
 		}
-
-		if ($component instanceof Node\Bylined && null !== $component->getByline()) {
-			$tpl->setVariable('BYLINE', $component->getByline());
-		}
-
 
 		if($component->isHighlighted()){
 			$tpl->touchBlock("highlighted");

--- a/src/UI/templates/default/Tree/tpl.node.html
+++ b/src/UI/templates/default/Tree/tpl.node.html
@@ -14,7 +14,7 @@
 	<!-- BEGIN node_with_link -->
 	<span class="node-line">{ICON_LINKED}<span class="node-label"><a href="{LINK}">{LABEL_LINKED}</a></span>
 	<!-- BEGIN byline_link -->
-		<span class="node-byline">{BYLINE}</span>
+		<span class="node-byline">{BYLINE_LINKED}</span>
 	<!-- END byline_link -->
 	</span>
 	<!-- END node_with_link -->


### PR DESCRIPTION
Seems like the template can't handle multiple definitions of the same variable in different blocks.
This problem occurred during the testing of #2138.

I now added now a second template variable with the same purpose: to add the byline.

