### PR TITLE
Introduce PSR-4 namespace for Tests

### DIFF
--- a/libs/composer/composer.json
+++ b/libs/composer/composer.json
@@ -52,8 +52,16 @@
 			"ILIAS\\Tests\\" : "../../tests",
 			"ILIAS\\" : "../../src"
 		},
-		"classmap": ["../../Services/", "../../Modules", "../ilias"],
-		"exclude-from-classmap": ["../../Services/Migration", "../../*/*/lib", "../../*/*/test", "../../Services/CAS/phpcas"]
+		"classmap": [
+			"../../Services/",
+			"../../Modules",
+			"../ilias"
+		],
+		"exclude-from-classmap": [
+			"../../Services/Migration",
+			"../../*/*/lib", "../../*/*/test",
+			"../../Services/CAS/phpcas"
+		]
 	},
 	"extra": {
 		"cweagans/composer-patches" : {

--- a/libs/composer/composer.json
+++ b/libs/composer/composer.json
@@ -48,7 +48,10 @@
 		"friendsofphp/php-cs-fixer": "^2.15"
 	},
 	"autoload": {
-		"psr-4" : { "ILIAS\\" : "../../src" },
+		"psr-4" : {
+			"ILIAS\\Tests\\" : "../../tests",
+			"ILIAS\\" : "../../src"
+		},
 		"classmap": ["../../Services/", "../../Modules", "../ilias"],
 		"exclude-from-classmap": ["../../Services/Migration", "../../*/*/lib", "../../*/*/test", "../../Services/CAS/phpcas"]
 	},

--- a/tests/Setup/AgentCollectionTest.php
+++ b/tests/Setup/AgentCollectionTest.php
@@ -4,8 +4,6 @@
 
 namespace ILIAS\Tests\Setup;
 
-require_once(__DIR__."/Helper.php");
-
 use ILIAS\Setup;
 use ILIAS\UI\Component\Input\Field\Factory as FieldFactory;
 use ILIAS\UI\Component\Input\Field\Input as Input;

--- a/tests/Setup/ConfigCollectionTest.php
+++ b/tests/Setup/ConfigCollectionTest.php
@@ -4,8 +4,6 @@
 
 namespace ILIAS\Tests\Setup;
 
-require_once(__DIR__."/Helper.php");
-
 use ILIAS\Setup;
 
 class ConfigCollectionTest extends \PHPUnit\Framework\TestCase {

--- a/tests/Setup/ObjectiveCollectionTest.php
+++ b/tests/Setup/ObjectiveCollectionTest.php
@@ -4,8 +4,6 @@
 
 namespace ILIAS\Tests\Setup;
 
-require_once(__DIR__."/Helper.php");
-
 use ILIAS\Setup;
 
 class ObjectiveCollectionTest extends \PHPUnit\Framework\TestCase {


### PR DESCRIPTION
I hereby propose to introduce a new namespace `ILIAS\Tests` that is pointed to `./tests` via PSR-4. This will allow use namespaces and autoloading in tests, which should help to keep names local _and_ concise.