### PR TITLE
omit synchronous loading for async tree guis

### DIFF
--- a/Services/UIComponent/Explorer2/classes/class.ilExplorerBaseGUI.php
+++ b/Services/UIComponent/Explorer2/classes/class.ilExplorerBaseGUI.php
@@ -761,39 +761,42 @@ abstract class ilExplorerBaseGUI
 
 		$etpl = new ilTemplate("tpl.explorer2.html", true, true, "Services/UIComponent/Explorer2");
 
-		// render childs
-		$root_node = $this->getRootNode();
-		
-		if (!$this->getSkipRootNode() &&
-			$this->isNodeVisible($this->getRootNode()))
-		{
-			$this->listStart($etpl);
-			$this->renderNode($this->getRootNode(), $etpl);
-			$this->listEnd($etpl);
-		}
-		else
-		{		
-			$childs = $this->getChildsOfNode($this->getNodeId($root_node));
-			$childs = $this->sortChilds($childs, $this->getNodeId($root_node));
-			$any = false;
-			foreach ($childs as $child_node)
+		if (!$this->ajax) {
+			// render childs
+			$root_node = $this->getRootNode();
+
+			if (!$this->getSkipRootNode() &&
+				$this->isNodeVisible($this->getRootNode()))
 			{
-				if ($this->isNodeVisible($child_node))
-				{
-					if (!$any)
-					{
-						$this->listStart($etpl);
-						$any = true;
-					}
-					$this->renderNode($child_node, $etpl);
-				}
-			}
-			if ($any)
-			{
+				$this->listStart($etpl);
+				$this->renderNode($this->getRootNode(), $etpl);
 				$this->listEnd($etpl);
 			}
+			else
+			{
+				$childs = $this->getChildsOfNode($this->getNodeId($root_node));
+				$childs = $this->sortChilds($childs, $this->getNodeId($root_node));
+				$any = false;
+				foreach ($childs as $child_node)
+				{
+					if ($this->isNodeVisible($child_node))
+					{
+						if (!$any)
+						{
+							$this->listStart($etpl);
+							$any = true;
+						}
+						$this->renderNode($child_node, $etpl);
+					}
+				}
+				if ($any)
+				{
+					$this->listEnd($etpl);
+				}
+			}
+
 		}
-		
+
 		$etpl->setVariable("CONTAINER_ID", $container_id);
 		$etpl->setVariable("CONTAINER_OUTER_ID", $container_outer_id);
 


### PR DESCRIPTION
Hey @alex40724 

I noticed some strange behavior in the ExplorerGUI code: When a tree is configured to load asynchronously ($this->ajax = true), the getHTML method still renders the whole tree synchronously. 
The synchronously loaded html is not used though and gets overwritten by an asynchronous call of getNodeAsync (it's not even shown in the small time frame between the synchronous and asynchronous call).

This fix simply adds an if-clause around the synchronous part (the diff below just looks more complicated).

I tested it only with the repository tree (seems to work the same but a bit faster). You know the ExplorerGUI better than me - should it be tested somewhere else?

I guess the same issue exists in all maintained releases and could be cherry-picked to those, haven't tested it though.

Thanks!
Theo