### PR TITLE
tree explorer: open root node when async

### DIFF
--- a/Services/UIComponent/Explorer2/classes/class.ilExplorerBaseGUI.php
+++ b/Services/UIComponent/Explorer2/classes/class.ilExplorerBaseGUI.php
@@ -590,6 +590,12 @@ abstract class ilExplorerBaseGUI
 
 		$etpl = new ilTemplate("tpl.explorer2.html", true, true, "Services/UIComponent/Explorer2");
 
+		$root = $this->getNodeId($this->getRootNode());
+		if (!in_array($root, $this->open_nodes))
+		{
+			$this->open_nodes[] = $root;
+		}
+
 		if ($_GET["node_id"] != "")
 		{
 			$id = $this->getNodeIdForDomNodeId($_GET["node_id"]);


### PR DESCRIPTION
Hey @alex40724 

This is more of a practical improvement for developers than a bugfix (and not urgent). 

The root node of a tree explorer GUI should be opened automatically if the tree is rendered asynchronously, because: If it's not opened, the GUI doesn't work - the root node is shown, but without an arrow to open it.

So the actual bug would be, that the arrow button is missing if the root node is not opened - but until that is fixed, this workaround here prevents developers from running into this bug and losing a lot of time (what just happened to me :D).

Should I open a ticket for the missing arrow bug? I think it's not really occurring anywhere yet, it's only an issue if someone wants to leave the root node closed.

Notes: 
* This issues only occur in Versions >5.4.
* For the fix, I just copied the bit of code from the synchronous getHTML method

Thanks
Theo