### PR TITLE
[Composer] Remove duplicate package reference

### DIFF
--- a/libs/composer/composer.json
+++ b/libs/composer/composer.json
@@ -35,7 +35,6 @@
 		"sabre/dav": "~3.2.2",
 		"symfony/console" : "^4.2",
 		"slim/slim": "^3.11",
-		"symfony/console" : "^4.2",
 		"ramsey/uuid": "^3.8"
 	},
 	"require-dev": {


### PR DESCRIPTION
`"symfony/console"` is already listed on line 36, this leads to an warning during installation of composer.