### PR TITLE
 Certificate: removed dislocated str_replace

### DIFF
--- a/Services/Certificate/classes/Placeholder/Replacement/class.ilCertificateValueReplacement.php
+++ b/Services/Certificate/classes/Placeholder/Replacement/class.ilCertificateValueReplacement.php
@@ -41,10 +41,6 @@ class ilCertificateValueReplacement
         $certificateContent = str_replace('[BACKGROUND_IMAGE]', $backgroundPath, $certificateContent);
         $certificateContent = str_replace('[CLIENT_WEB_DIR]', $this->clientWebDirectory, $certificateContent);
 
-        $certificateContent = preg_replace("/<\?xml[^>]+?>/", "", $certificateContent);
-        $certificateContent = str_replace("&#xA0;", "<br />", $certificateContent);
-        $certificateContent = str_replace("&#160;", "<br />", $certificateContent);
-
         return $certificateContent;
     }
 }


### PR DESCRIPTION
This seems to be no security feature, as the commit message tells, but instead was previously located (and marked as "dirty hack") in ilCertificate::getFormFieldsFromFO. In this new location it removes stuff (empty lines, especially) that we will need later.

This most probably also fixes a bug (empty lines get lost). I currently do not have time to write a proper report and kindly ask for forbearance.