### PR TITLE
Database updates for new Setup implementation

### DIFF
--- a/Services/Database/classes/Setup/class.ilDatabaseUpdateStep.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseUpdateStep.php
@@ -1,0 +1,56 @@
+<?php
+
+/* Copyright (c) 2019 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+use ILIAS\Setup\CallableObjective;
+use ILIAS\Setup\Objective;
+use ILIAS\Setup\Environment;
+
+
+/**
+ * This encapsulate one database update step which is a method on some
+ * ilDatabaseUpdateSteps-object.
+ *
+ * This is a close collaborator of ilDatabaseUpdateSteps and should most probably
+ * not be used standalone.
+ */
+class ilDatabaseUpdateStep extends CallableObjective {
+	/**
+ 	 * @var	string
+	 */
+	protected $class_name;
+
+	/**
+	 * @var string
+	 */
+	protected $method_name;
+
+	public function __construct(
+		ilDatabaseUpdateSteps $parent,
+		string $method_name,
+		Objective ...$preconditions
+	) {
+		$this->class_name = get_class($parent);
+		$this->method_name = $method_name;
+		parent::__construct(
+			function (Environment $env) use ($parent, $method_name) {
+				$db = $env->getResource(Environment::RESOURCE_DATABASE);
+				call_user_func([$parent, $method_name], $db); 
+			},
+			"Database update step $class_name::$method_name",
+			false,
+			...$preconditions
+		);
+	}
+
+
+	/**
+	 * @inheritdocs 
+	 */
+	public function getHash() : string {
+		return hash(
+			"sha256",
+			$this->class_name."::".$this->method_name
+		);
+	}
+}

--- a/Services/Database/classes/Setup/class.ilDatabaseUpdateStep.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseUpdateStep.php
@@ -37,7 +37,7 @@ class ilDatabaseUpdateStep extends CallableObjective {
 				$db = $env->getResource(Environment::RESOURCE_DATABASE);
 				call_user_func([$parent, $method_name], $db); 
 			},
-			"Database update step $class_name::$method_name",
+			"Database update step {$this->class_name}::{$this->method_name}",
 			false,
 			...$preconditions
 		);

--- a/Services/Database/classes/Setup/class.ilDatabaseUpdateStep.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseUpdateStep.php
@@ -27,15 +27,22 @@ class ilDatabaseUpdateStep extends CallableObjective {
 
 	public function __construct(
 		ilDatabaseUpdateSteps $parent,
-		string $method_name,
+		int $num,
 		Objective ...$preconditions
 	) {
 		$this->class_name = get_class($parent);
-		$this->method_name = $method_name;
+		$this->method_name = \ilDatabaseUpdateSteps::STEP_METHOD_PREFIX.$num;
 		parent::__construct(
-			function (Environment $env) use ($parent, $method_name) {
+			function (Environment $env) use ($parent, $num) {
 				$db = $env->getResource(Environment::RESOURCE_DATABASE);
-				call_user_func([$parent, $method_name], $db); 
+				$log = $env->getResource(\ilDatabaseUpdateStepExecutionLog::class);
+				if ($log) {
+					$log->started($this->class_name, $num);
+				}
+				call_user_func([$parent, $this->method_name], $db); 
+				if ($log) {
+					$log->finished($this->class_name, $num);
+				}
 			},
 			"Database update step {$this->class_name}::{$this->method_name}",
 			false,

--- a/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
@@ -22,8 +22,8 @@ use ILIAS\Setup\Objective;
  * If the class takes care of only one table or a set of related tables it will
  * be easier to maintain.
  *
- * If for some reason you rely on update steps from other db-updated-classes
- * implement `getPreconditionSteps`.
+ * If for some reason you rely on other objectives, e.g. steps from other db-update
+ * classes, implement `getAdditionalPreconditionsForStep`.
  */
 abstract class ilDatabaseUpdateSteps implements Objective {
 	const STEP_METHOD_PREFIX = "step_";
@@ -48,6 +48,18 @@ abstract class ilDatabaseUpdateSteps implements Objective {
 		Objective $base
 	) {
 		$this->base = $base;
+	}
+
+	/**
+	 * Get preconditions for steps.
+	 *
+	 * The previous step will automatically be a precondition of every step but
+	 * will not be returned from this method.
+	 *
+	 * @return Objective[]
+	 */
+	public function getAdditionalPreconditionsForStep(int $num): array {
+		return [];
 	}
 
 	/**
@@ -108,7 +120,7 @@ abstract class ilDatabaseUpdateSteps implements Objective {
 				continue;
 			}
 			else if ($s <= $num) {
-				$cur = new ilDatabaseUpdateStep($this, $s, $cur);
+				$cur = new ilDatabaseUpdateStep($this, $s, $cur, ...$this->getAdditionalPreconditionsForStep($s));
 			}
 			else {
 				break;

--- a/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
@@ -64,10 +64,9 @@ abstract class ilDatabaseUpdateSteps extends ilDatabaseObjective {
 			$pre = new NullObjective();
 		}
 
-		$steps = $this->getSteps();
 		$class = get_class($this);
-		foreach($steps as $k => $s) {
-			$pre = new ilDatabaseUpdateStep($s[0], $s[1], $pre);
+		foreach($this->getSteps() as $s) {
+			$pre = new ilDatabaseUpdateStep($this, $s, $pre);
 		}
 
 		return [$pre];
@@ -97,10 +96,10 @@ abstract class ilDatabaseUpdateSteps extends ilDatabaseObjective {
 				throw new \LogicException("Method $method seems to be a step but has an odd looking number");
 			}
 
-			$steps[(int)$number] = [$this, $method];	
+			$steps[] = $method;
 		}
 
-		ksort($steps);
+		sort($steps);
 
 		return $steps;
 	}

--- a/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
@@ -1,0 +1,99 @@
+<?php
+
+/* Copyright (c) 2019 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+use ILIAS\Setup\Environment;
+
+
+/**
+ * This base-class simplifies the creation of (consecutive) database updates.
+ *
+ * Implement update steps on one or more tables by creating methods that follow
+ * this schema:
+ *
+ * public function step_1(\ilDBInterface $db) { ... }
+ *
+ * The class will figure out which of them haven't been performed yet and need
+ * to be executed.
+ *
+ * If the class takes care of only one table or a set of related tables it will
+ * be easier to maintain.
+ *
+ * If for some reason you rely on update steps from other db-updated-classes
+ * implement `getPreconditionSteps`.
+ */
+abstract class ilDatabaseUpdateSteps extends ilDatabaseObjective {
+	const STEP_METHOD_PREFIX = "step_";
+
+	final public function __construct(\ilDatabaseSetupConfig $config) {
+		parent::__construct($config);
+	}
+
+	/**
+	 * The hash for the objective is calculated over the classname and the steps
+	 * that are contained.
+	 */
+	final public function getHash() : string {
+		throw \LogicException("NYI!");
+	}
+
+	public function getLabel() : string {
+		return "Database update steps in ".static::class;
+	}
+
+	/**
+	 * @inheritdocs
+	 */
+	final public function isNotable() : bool {
+		return true;
+	}
+
+	/**
+	 * @inheritdocs
+	 */
+	final public function getPreconditions(Environment $environment) : array {
+		if ($environment->getResource(Setup\Environment::RESOURCE_DATABASE)) {
+		}
+		return [
+			new \ilDatabaseExistsObjective($this->config)
+		];
+	}
+
+	/**
+	 * @inheritdocs
+	 */
+	final public function achieve(Environment $environment) : Environment {
+		$db = $environment->getResource(Environment::RESOURCE_DATABASE);
+
+		foreach ($this->getSteps() as $num => $method) {
+			call_user_func($method, $db);
+		}
+
+		return $environment;
+	}
+
+	/**
+	 * Get the step functions in this class.
+	 */
+	final protected function getSteps() {
+		$steps = [];
+
+		foreach (get_class_methods(static::class) as $method) {
+			if (stripos($method, self::STEP_METHOD_PREFIX) !== 0) {
+				continue;
+			}
+
+			$number = substr($method, strlen(self::STEP_METHOD_PREFIX));
+
+			if (!preg_match("/^[1-9]\d*$/", $number)) {
+				throw new \LogicException("Method $method seems to be a step but has an odd looking number");
+			}
+
+			$steps[(int)$number] = [$this, $method];	
+		}
+
+		ksort($steps);
+
+		return $steps;
+	}
+}

--- a/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
@@ -25,7 +25,7 @@ use ILIAS\Setup\Objective;
  * If for some reason you rely on update steps from other db-updated-classes
  * implement `getPreconditionSteps`.
  */
-abstract class ilDatabaseUpdateSteps extends ilDatabaseObjective {
+abstract class ilDatabaseUpdateSteps implements Objective {
 	const STEP_METHOD_PREFIX = "step_";
 
 	/**
@@ -45,10 +45,8 @@ abstract class ilDatabaseUpdateSteps extends ilDatabaseObjective {
 	 *                           \ilDatabasePopulatedObjective.
 	 */
 	public function __construct(
-		\ilDatabaseSetupConfig $config,
 		Objective $base
 	) {
-		parent::__construct($config);
 		$this->base = $base;
 	}
 

--- a/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
@@ -92,19 +92,19 @@ abstract class ilDatabaseUpdateSteps implements Objective {
 	 *
 	 * @throws \LogicException if step is unknown
 	 */
-	final public function getStep(string $name) : ilDatabaseUpdateStep {
+	final public function getStep(int $num) : ilDatabaseUpdateStep {
 		return new ilDatabaseUpdateStep(
 			$this,
-			$name,
-			...$this->getPreconditionsOfStep($name)
+			self::STEP_METHOD_PREFIX.$num,
+			...$this->getPreconditionsOfStep($num)
 		);
 	}
 
 	/**
 	 * @return Objective[]
 	 */
-	final protected function getPreconditionsOfStep(string $name) : array {
-		$others = $this->getStepsBefore($name);
+	final protected function getPreconditionsOfStep(int $num) : array {
+		$others = $this->getStepsBefore($num);
 		if (count($others) === 0) {
 			return [$this->base];
 		}
@@ -114,7 +114,7 @@ abstract class ilDatabaseUpdateSteps implements Objective {
 	/**
 	 * Get the names of the step-methods in this class.
 	 *
-	 * @return string[]
+	 * @return int[]
 	 */
 	final protected function getSteps() : array {
 		if (!is_null($this->steps)) {
@@ -134,7 +134,7 @@ abstract class ilDatabaseUpdateSteps implements Objective {
 				throw new \LogicException("Method $method seems to be a step but has an odd looking number");
 			}
 
-			$this->steps[$method] = $method;
+			$this->steps[(int)$number] = (int)$number;
 		}
 
 		asort($this->steps);
@@ -148,20 +148,20 @@ abstract class ilDatabaseUpdateSteps implements Objective {
 	 * ATTENTION: The steps are sorted in ascending order.
 	 *
 	 * @throws \LogicException if step is not known
-	 * @return string[]
+	 * @return int[]
 	 */
-	final protected function getStepsBefore(string $other) {
+	final protected function getStepsBefore(int $num) {
 		$this->getSteps();
-		if (!isset($this->steps[$other])) {
-			throw new \LogicException("Unknown database update step: $other");
+		if (!isset($this->steps[$num])) {
+			throw new \LogicException("Unknown database update step: $num");
 		}
 
 		$res = [];
-		foreach ($this->steps as $method) {
-			if ($method	=== $other) {
+		foreach ($this->steps as $cur) {
+			if ($cur === $num) {
 				break;
 			}
-			$res[$method] = $method;
+			$res[$cur] = $cur;
 		}
 		return $res;
 	}

--- a/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
@@ -41,7 +41,7 @@ abstract class ilDatabaseUpdateSteps implements Objective {
 	/**
 	 * @param \ilObjective $base for the update steps, i.e. the objective that should
 	 *                           have been reached before the steps of this class can
-	 *                           even begin. Most propably this should be
+	 *                           even begin. Most probably this should be
 	 *                           \ilDatabasePopulatedObjective.
 	 */
 	public function __construct(

--- a/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
@@ -63,21 +63,21 @@ abstract class ilDatabaseUpdateSteps extends ilDatabaseObjective {
 		);
 	}
 
-	public function getLabel() : string {
+	final public function getLabel() : string {
 		return "Database update steps in ".get_class($this);
 	}
 
 	/**
 	 * @inheritdocs
 	 */
-	public function isNotable() : bool {
+	final public function isNotable() : bool {
 		return true;
 	}
 
 	/**
 	 * @inheritdocs
 	 */
-	public function getPreconditions(Environment $environment) : array {
+	final public function getPreconditions(Environment $environment) : array {
 		$steps = $this->getSteps();
 		return [$this->getStep(array_pop($steps))];
 	}
@@ -85,7 +85,7 @@ abstract class ilDatabaseUpdateSteps extends ilDatabaseObjective {
 	/**
 	 * @inheritdocs
 	 */
-	public function achieve(Environment $environment) : Environment {
+	final public function achieve(Environment $environment) : Environment {
 		return $environment;
 	}
 
@@ -94,7 +94,7 @@ abstract class ilDatabaseUpdateSteps extends ilDatabaseObjective {
 	 *
 	 * @throws \LogicException if step is unknown
 	 */
-	public function getStep(string $name) : ilDatabaseUpdateStep {
+	final public function getStep(string $name) : ilDatabaseUpdateStep {
 		return new ilDatabaseUpdateStep(
 			$this,
 			$name,
@@ -105,7 +105,7 @@ abstract class ilDatabaseUpdateSteps extends ilDatabaseObjective {
 	/**
 	 * @return Objective[]
 	 */
-	protected function getPreconditionsOfStep(string $name) : array {
+	final protected function getPreconditionsOfStep(string $name) : array {
 		$others = $this->getStepsBefore($name);
 		if (count($others) === 0) {
 			return [$this->base];
@@ -114,11 +114,11 @@ abstract class ilDatabaseUpdateSteps extends ilDatabaseObjective {
 	}
 
 	/**
-	 * Get the step-methods in this class.
+	 * Get the names of the step-methods in this class.
 	 *
 	 * @return string[]
 	 */
-	public function getSteps() : array {
+	final protected function getSteps() : array {
 		if (!is_null($this->steps)) {
 			return $this->steps;
 		}
@@ -145,14 +145,14 @@ abstract class ilDatabaseUpdateSteps extends ilDatabaseObjective {
 	}
 
 	/**
-	 * Get the step-methods before the given step.
+	 * Get the names of the step-methods before the given step.
 	 *
 	 * ATTENTION: The steps are sorted in ascending order.
 	 *
 	 * @throws \LogicException if step is not known
 	 * @return string[]
 	 */
-	public function getStepsBefore(string $other) {
+	final protected function getStepsBefore(string $other) {
 		$this->getSteps();
 		if (!isset($this->steps[$other])) {
 			throw new \LogicException("Unknown database update step: $other");

--- a/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
@@ -95,14 +95,22 @@ abstract class ilDatabaseUpdateSteps extends ilDatabaseObjective {
 	 * @throws \LogicException if step is unknown
 	 */
 	public function getStep(string $name) : ilDatabaseUpdateStep {
+		return new ilDatabaseUpdateStep(
+			$this,
+			$name,
+			...$this->getPreconditionsOfStep($name)
+		);
+	}
+
+	/**
+	 * @return Objective[]
+	 */
+	protected function getPreconditionsOfStep(string $name) : array {
 		$others = $this->getStepsBefore($name);
 		if (count($others) === 0) {
-			$pre = $this->base;
+			return [$this->base];
 		}
-		else {
-			$pre = $this->getStep(array_pop($others));
-		}
-		return new ilDatabaseUpdateStep($this, $name, $pre);
+		return [$this->getStep(array_pop($others))];
 	}
 
 	/**

--- a/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
@@ -27,6 +27,11 @@ use ILIAS\Setup\NullObjective;
 abstract class ilDatabaseUpdateSteps extends ilDatabaseObjective {
 	const STEP_METHOD_PREFIX = "step_";
 
+	/**
+	 * @var	string[]|null
+	 */
+	protected $steps = null;
+
 	final public function __construct(\ilDatabaseSetupConfig $config) {
 		parent::__construct($config);
 	}
@@ -83,7 +88,11 @@ abstract class ilDatabaseUpdateSteps extends ilDatabaseObjective {
 	 * Get the step functions in this class.
 	 */
 	final protected function getSteps() {
-		$steps = [];
+		if (!is_null($this->steps)) {
+			return $this->steps;
+		}
+
+		$this->steps = [];
 
 		foreach (get_class_methods(static::class) as $method) {
 			if (stripos($method, self::STEP_METHOD_PREFIX) !== 0) {
@@ -96,11 +105,11 @@ abstract class ilDatabaseUpdateSteps extends ilDatabaseObjective {
 				throw new \LogicException("Method $method seems to be a step but has an odd looking number");
 			}
 
-			$steps[] = $method;
+			$this->steps[] = $method;
 		}
 
-		sort($steps);
+		sort($this->steps);
 
-		return $steps;
+		return $this->steps;
 	}
 }

--- a/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
@@ -76,7 +76,16 @@ abstract class ilDatabaseUpdateSteps implements Objective {
 	 * @inheritdocs
 	 */
 	final public function getPreconditions(Environment $environment) : array {
-		return [$this->getStep($this->getLatestStepNum())];
+		$log = $environment->getResource(\ilDatabaseUpdateStepExecutionLog::class);
+
+		if ($log) {
+			$finished = $log->getLastFinishedStep(get_class($this));
+		}
+		else {
+			$finished = 0;
+		}
+
+		return [$this->getStep($this->getLatestStepNum(), $finished)];
 	}
 
 	/**

--- a/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
@@ -67,12 +67,7 @@ abstract class ilDatabaseUpdateSteps extends ilDatabaseObjective {
 		$steps = $this->getSteps();
 		$class = get_class($this);
 		foreach($steps as $k => $s) {
-			$pre = new CallableObjective(
-				$s,
-				"Database update step $class::step_$k",
-				false,
-				$pre
-			);
+			$pre = new ilDatabaseUpdateStep($s[0], $s[1], $pre);
 		}
 
 		return [$pre];

--- a/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
@@ -105,11 +105,33 @@ abstract class ilDatabaseUpdateSteps extends ilDatabaseObjective {
 				throw new \LogicException("Method $method seems to be a step but has an odd looking number");
 			}
 
-			$this->steps[] = $method;
+			$this->steps[$method] = $method;
 		}
 
-		sort($this->steps);
+		asort($this->steps);
 
 		return $this->steps;
+	}
+
+	/**
+	 * Get the step-methods before the given step.
+	 *
+	 * @throws \LogicException if step is not known
+	 * @return string[]
+	 */
+	public function getStepsBefore(string $other) {
+		$this->getSteps();
+		if (!isset($this->steps[$other])) {
+			throw new \LogicException("Unknown database update step: $other");
+		}
+
+		$res = [];
+		foreach ($this->steps as $method) {
+			if ($method	=== $other) {
+				break;
+			}
+			$res[$method] = $method;
+		}
+		return $res;
 	}
 }

--- a/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
@@ -76,8 +76,7 @@ abstract class ilDatabaseUpdateSteps implements Objective {
 	 * @inheritdocs
 	 */
 	final public function getPreconditions(Environment $environment) : array {
-		$steps = $this->getSteps();
-		return [$this->getStep(array_pop($steps))];
+		return [$this->getStep($this->getLatestStepNum())];
 	}
 
 	/**
@@ -115,7 +114,15 @@ abstract class ilDatabaseUpdateSteps implements Objective {
 	}
 
 	/**
-	 * Get the names of the step-methods in this class.
+	 * Get the number of latest database step in this class.
+	 */
+	final public function getLatestStepNum() : int {
+		$this->getSteps();
+		return end($this->steps);
+	}
+
+	/**
+	 * Get the numbers of the steps in this class.
 	 *
 	 * @return int[]
 	 */

--- a/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php
@@ -108,11 +108,7 @@ abstract class ilDatabaseUpdateSteps implements Objective {
 				continue;
 			}
 			else if ($s <= $num) {
-				$cur = new ilDatabaseUpdateStep(
-					$this,
-					self::STEP_METHOD_PREFIX.$s,
-					$cur
-				);
+				$cur = new ilDatabaseUpdateStep($this, $s, $cur);
 			}
 			else {
 				break;

--- a/Services/Database/interfaces/Setup/interface.ilDatabaseUpdateStepExecutionLog.php
+++ b/Services/Database/interfaces/Setup/interface.ilDatabaseUpdateStepExecutionLog.php
@@ -1,0 +1,22 @@
+<?php
+
+/* Copyright (c) 2019 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+/**
+ * This logs the execution of database update steps.
+ */
+interface ilDatabaseUpdateStepExecutionLog {
+	/**
+	 * @throws \LogicException	if the previously started step has not finished
+	 */
+	public function start(string $class, int $step): void;
+
+	/**
+	 * @throws \LogicException	if the finished step does not match the previously started step
+	 */
+	public function finish(string $class, int $step): void;
+
+	public function getLastStartedStep(string $class): int;
+	public function getLastFinishedStep(string $class): int;
+}
+

--- a/Services/Database/interfaces/Setup/interface.ilDatabaseUpdateStepExecutionLog.php
+++ b/Services/Database/interfaces/Setup/interface.ilDatabaseUpdateStepExecutionLog.php
@@ -9,12 +9,12 @@ interface ilDatabaseUpdateStepExecutionLog {
 	/**
 	 * @throws \LogicException	if the previously started step has not finished
 	 */
-	public function start(string $class, int $step): void;
+	public function started(string $class, int $step): void;
 
 	/**
 	 * @throws \LogicException	if the finished step does not match the previously started step
 	 */
-	public function finish(string $class, int $step): void;
+	public function finished(string $class, int $step): void;
 
 	public function getLastStartedStep(string $class): int;
 	public function getLastFinishedStep(string $class): int;

--- a/Services/Database/test/Setup/ilDatabaseSetupSuite.php
+++ b/Services/Database/test/Setup/ilDatabaseSetupSuite.php
@@ -1,0 +1,19 @@
+<?php
+
+/* Copyright (c) 2019 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+use PHPUnit\Framework\TestSuite;
+
+class ilDatabaseSetupSuite extends TestSuite {
+	/**
+	 * @return \ilDatabaseSetupSuite
+	 */
+	public static function suite() {
+		$suite = new self();
+
+		require_once(__DIR__."/ilDatabaseUpdateStepsTest.php");
+		$suite->addTestSuite(\ilDatabaseUpdateStepsTest::class);
+
+		return $suite;
+	}
+}

--- a/Services/Database/test/Setup/ilDatabaseSetupSuite.php
+++ b/Services/Database/test/Setup/ilDatabaseSetupSuite.php
@@ -13,6 +13,8 @@ class ilDatabaseSetupSuite extends TestSuite {
 
 		require_once(__DIR__."/ilDatabaseUpdateStepsTest.php");
 		$suite->addTestSuite(\ilDatabaseUpdateStepsTest::class);
+		require_once(__DIR__."/ilDatabaseUpdateStepTest.php");
+		$suite->addTestSuite(\ilDatabaseUpdateStepTest::class);
 
 		return $suite;
 	}

--- a/Services/Database/test/Setup/ilDatabaseUpdateStepTest.php
+++ b/Services/Database/test/Setup/ilDatabaseUpdateStepTest.php
@@ -7,14 +7,19 @@ use PHPUnit\Framework\TestCase;
 use ILIAS\Setup\Environment;
 use ILIAS\Setup\Objective;
 
+class Test_ilDatabaseUpdateStep extends ilDatabaseUpdateSteps {
+	public function step_1(\ilDBInterface $db) {
+	}	
+}
+
 class ilDatabaseUpdateStepTest extends TestCase {
 	protected function setUp(): void {
-		$this->parent = $this->createMock(\ilDatabaseUpdateSteps::class);
+		$this->parent = $this->createMock(Test_ilDatabaseUpdateStep::class);
 		$this->precondition = $this->createMock(Objective::class);
 
 		$this->step = new \ilDatabaseUpdateStep(
 			$this->parent,
-			"some_method",
+			1,
 			$this->precondition,
 			$this->precondition	
 		);
@@ -27,5 +32,50 @@ class ilDatabaseUpdateStepTest extends TestCase {
 			[$this->precondition, $this->precondition],
 			$this->step->getPreconditions($env)
 		);
+	}
+
+	public function testCallsExecutionLog() {
+		$env = $this->createMock(Environment::class);
+		$log = $this->createMock(\ilDatabaseUpdateStepExecutionLog::class);
+		$db = $this->createMock(\ilDBInterface::class);
+
+		$env
+			->method("getResource")
+			->will($this->returnValueMap([
+				[Environment::RESOURCE_DATABASE, $db],
+				[\ilDatabaseUpdateStepExecutionLog::class, $log]
+			]));
+
+		$log
+			->expects($this->once(), $this->at(0))
+			->method("started")
+			->with(get_class($this->parent), 1);
+
+		$log
+			->expects($this->once(), $this->at(1))
+			->method("finished")
+			->with(get_class($this->parent), 1);
+
+		$this->step->achieve($env);
+	}
+
+	public function testCallsMethod() {
+		$env = $this->createMock(Environment::class);
+		$db = $this->createMock(\ilDBInterface::class);
+
+		$env
+			->method("getResource")
+			->will($this->returnValueMap([
+				[Environment::RESOURCE_DATABASE, $db],
+				[\ilDatabaseUpdateStepExecutionLog::class, null]
+			]));
+
+		$this->parent
+			->expects($this->once())
+			->method("step_1")
+			->with($db)
+			->willReturn($null);
+
+		$this->step->achieve($env);
 	}
 }

--- a/Services/Database/test/Setup/ilDatabaseUpdateStepTest.php
+++ b/Services/Database/test/Setup/ilDatabaseUpdateStepTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/* Copyright (c) 2019 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+use PHPUnit\Framework\TestCase;
+
+use ILIAS\Setup\Environment;
+use ILIAS\Setup\Objective;
+
+class ilDatabaseUpdateStepTest extends TestCase {
+	protected function setUp(): void {
+		$this->parent = $this->createMock(\ilDatabaseUpdateSteps::class);
+		$this->precondition = $this->createMock(Objective::class);
+
+		$this->step = new \ilDatabaseUpdateStep(
+			$this->parent,
+			"some_method",
+			$this->precondition,
+			$this->precondition	
+		);
+	}
+
+	public function testGetPreconditions() {
+		$env = $this->createMock(Environment::class);
+
+		$this->assertEquals(
+			[$this->precondition, $this->precondition],
+			$this->step->getPreconditions($env)
+		);
+	}
+}

--- a/Services/Database/test/Setup/ilDatabaseUpdateStepsTest.php
+++ b/Services/Database/test/Setup/ilDatabaseUpdateStepsTest.php
@@ -48,9 +48,9 @@ class ilDatabaseUpdateStepsTest extends TestCase {
 		$steps = $this->test1->_getSteps();
 
 		$expected = [
-			1 => [$this->test1, "step_1"],
-			2 => [$this->test1, "step_2"],
-			4 => [$this->test1, "step_4"],
+			"step_1",
+			"step_2",
+			"step_4",
 		];
 
 		$this->assertEquals($expected, $steps);

--- a/Services/Database/test/Setup/ilDatabaseUpdateStepsTest.php
+++ b/Services/Database/test/Setup/ilDatabaseUpdateStepsTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/* Copyright (c) 2019 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+use PHPUnit\Framework\TestCase;
+
+use ILIAS\Setup\Environment;
+
+class Test_ilDatabaseUpdateSteps extends ilDatabaseUpdateSteps {
+	public $called = [];
+
+	public function step_1(\ilDBInterface $db) {
+		$this->called[] = 1;
+		// Call some function on the interface to check if this step
+		// is really called.
+		$db->connect();
+	}	
+
+	// 4 comes before 2 to check if the class gets the sorting right
+	public function step_4(\ilDBInterface $db) {
+		$this->called[] = 4;
+		// Call some function on the interface to check if this step
+		// is really called.
+		$db->connect();
+	}
+
+	public function step_2(\ilDBInterface $db) {
+		$this->called[] = 2;
+		// Call some function on the interface to check if this step
+		// is really called.
+		$db->connect();
+	}
+
+	public function _getSteps() {
+		return self::getSteps();
+	}
+}
+
+class ilDatabaseUpdateStepsTest extends TestCase {
+	protected function setUp(): void {
+		$this->config = $this->createMock(\ilDatabaseSetupConfig::class);
+
+		$this->test1 = new Test_ilDatabaseUpdateSteps($this->config);
+	}
+
+	public function testGetAllSteps() {
+		$steps = $this->test1->_getSteps();
+
+		$expected = [
+			1 => [$this->test1, "step_1"],
+			2 => [$this->test1, "step_2"],
+			4 => [$this->test1, "step_4"],
+		];
+
+		$this->assertEquals($expected, $steps);
+	}
+
+	public function testAchieveAllSteps() {
+		$env = $this->createMock(Environment::class);
+		$db = $this->createMock(\ilDBInterface::class);
+
+		$env
+			->method("getResource")
+			->with(Environment::RESOURCE_DATABASE)
+			->willReturn($db); 
+
+		$db
+			->expects($this->exactly(3))
+			->method("connect");
+
+		$this->test1->achieve($env);
+
+		$this->assertEquals([1,2,4], $this->test1->called);
+	}
+}

--- a/Services/Database/test/Setup/ilDatabaseUpdateStepsTest.php
+++ b/Services/Database/test/Setup/ilDatabaseUpdateStepsTest.php
@@ -36,10 +36,6 @@ class Test_ilDatabaseUpdateSteps extends ilDatabaseUpdateSteps {
 	public function _getSteps() : array {
 		return $this->getSteps();
 	}
-
-	public function _getStepsBefore(int $other) : array {
-		return $this->getStepsBefore($other);
-	}
 }
 
 class ilDatabaseUpdateStepsTest extends TestCase {
@@ -84,34 +80,45 @@ class ilDatabaseUpdateStepsTest extends TestCase {
 		$this->assertEquals($step1->getHash(), $preconditions[0]->getHash());
 	}
 
+	public function testGetStep4Finished2() {
+		$env = $this->createMock(Environment::class);
+
+		$step4 = $this->test1->getStep(4,2);
+
+		$this->assertInstanceOf(ilDatabaseUpdateStep::class, $step4);
+		$this->assertEquals(
+			hash("sha256", Test_ilDatabaseUpdateSteps::class."::step_4"),
+			$step4->getHash()
+		);
+
+		$preconditions = $step4->getPreconditions($env);
+
+		$this->assertCount(1, $preconditions);
+		$this->assertEquals($this->base, $preconditions[0]);
+	}
+
+	public function testGetStep4Finished1() {
+		$env = $this->createMock(Environment::class);
+
+		$step4 = $this->test1->getStep(4,1);
+		$step2 = $this->test1->getStep(2,1);
+
+		$this->assertInstanceOf(ilDatabaseUpdateStep::class, $step4);
+		$this->assertEquals(
+			hash("sha256", Test_ilDatabaseUpdateSteps::class."::step_4"),
+			$step4->getHash()
+		);
+
+		$preconditions = $step4->getPreconditions($env);
+
+		$this->assertCount(1, $preconditions);
+		$this->assertEquals($step2->getHash(), $preconditions[0]->getHash());
+	}
+
 	public function testGetAllSteps() {
 		$steps = $this->test1->_getSteps();
 
 		$expected = [1,2,4];
-
-		$this->assertEquals($expected, array_values($steps));
-	}
-
-	public function testGetStepsBeforeStep1() {
-		$steps = $this->test1->_getStepsBefore(1);
-
-		$expected = [];
-
-		$this->assertEquals($expected, array_values($steps));
-	}
-
-	public function testGetStepsBeforeStep2() {
-		$steps = $this->test1->_getStepsBefore(2);
-
-		$expected = [1];
-
-		$this->assertEquals($expected, array_values($steps));
-	}
-
-	public function testGetStepsBeforeStep4() {
-		$steps = $this->test1->_getStepsBefore(4);
-
-		$expected = [1,2];
 
 		$this->assertEquals($expected, array_values($steps));
 	}

--- a/Services/Database/test/Setup/ilDatabaseUpdateStepsTest.php
+++ b/Services/Database/test/Setup/ilDatabaseUpdateStepsTest.php
@@ -53,7 +53,17 @@ class ilDatabaseUpdateStepsTest extends TestCase {
 			"step_4",
 		];
 
-		$this->assertEquals($expected, $steps);
+		$this->assertEquals($expected, array_values($steps));
+	}
+
+	public function testGetStepsBefore() {
+		$steps = $this->test1->getStepsBefore("step_2");
+
+		$expected = [
+			"step_1"
+		];
+
+		$this->assertEquals($expected, array_values($steps));
 	}
 
 	public function testAchieveAllSteps() {

--- a/Services/Database/test/Setup/ilDatabaseUpdateStepsTest.php
+++ b/Services/Database/test/Setup/ilDatabaseUpdateStepsTest.php
@@ -37,7 +37,7 @@ class Test_ilDatabaseUpdateSteps extends ilDatabaseUpdateSteps {
 		return $this->getSteps();
 	}
 
-	public function _getStepsBefore(string $other) : array {
+	public function _getStepsBefore(int $other) : array {
 		return $this->getStepsBefore($other);
 	}
 }
@@ -52,7 +52,7 @@ class ilDatabaseUpdateStepsTest extends TestCase {
 	public function testGetStep1() {
 		$env = $this->createMock(Environment::class);
 
-		$step1 = $this->test1->getStep("step_1");
+		$step1 = $this->test1->getStep(1);
 
 		$this->assertInstanceOf(ilDatabaseUpdateStep::class, $step1);
 		$this->assertEquals(
@@ -69,8 +69,8 @@ class ilDatabaseUpdateStepsTest extends TestCase {
 	public function testGetStep2() {
 		$env = $this->createMock(Environment::class);
 
-		$step1 = $this->test1->getStep("step_1");
-		$step2 = $this->test1->getStep("step_2");
+		$step1 = $this->test1->getStep(1);
+		$step2 = $this->test1->getStep(2);
 
 		$this->assertInstanceOf(ilDatabaseUpdateStep::class, $step2);
 		$this->assertEquals(
@@ -87,41 +87,31 @@ class ilDatabaseUpdateStepsTest extends TestCase {
 	public function testGetAllSteps() {
 		$steps = $this->test1->_getSteps();
 
-		$expected = [
-			"step_1",
-			"step_2",
-			"step_4",
-		];
+		$expected = [1,2,4];
 
 		$this->assertEquals($expected, array_values($steps));
 	}
 
 	public function testGetStepsBeforeStep1() {
-		$steps = $this->test1->_getStepsBefore("step_1");
+		$steps = $this->test1->_getStepsBefore(1);
 
-		$expected = [
-		];
+		$expected = [];
 
 		$this->assertEquals($expected, array_values($steps));
 	}
 
 	public function testGetStepsBeforeStep2() {
-		$steps = $this->test1->_getStepsBefore("step_2");
+		$steps = $this->test1->_getStepsBefore(2);
 
-		$expected = [
-			"step_1"
-		];
+		$expected = [1];
 
 		$this->assertEquals($expected, array_values($steps));
 	}
 
 	public function testGetStepsBeforeStep4() {
-		$steps = $this->test1->_getStepsBefore("step_4");
+		$steps = $this->test1->_getStepsBefore(4);
 
-		$expected = [
-			"step_1",
-			"step_2"
-		];
+		$expected = [1,2];
 
 		$this->assertEquals($expected, array_values($steps));
 	}

--- a/Services/Database/test/Setup/ilDatabaseUpdateStepsTest.php
+++ b/Services/Database/test/Setup/ilDatabaseUpdateStepsTest.php
@@ -5,6 +5,7 @@
 use PHPUnit\Framework\TestCase;
 
 use ILIAS\Setup\Environment;
+use ILIAS\Setup\ObjectiveIterator;
 
 class Test_ilDatabaseUpdateSteps extends ilDatabaseUpdateSteps {
 	public $called = [];
@@ -68,7 +69,13 @@ class ilDatabaseUpdateStepsTest extends TestCase {
 			->expects($this->exactly(3))
 			->method("connect");
 
-		$this->test1->achieve($env);
+		$i = new ObjectiveIterator($env, $this->test1);
+		while($i->valid()) {
+			$current = $i->current();
+			$env = $current->achieve($env);
+			$i->setEnvironment($env);
+			$i->next();
+		}
 
 		$this->assertEquals([1,2,4], $this->test1->called);
 	}

--- a/Services/Database/test/Setup/ilDatabaseUpdateStepsTest.php
+++ b/Services/Database/test/Setup/ilDatabaseUpdateStepsTest.php
@@ -32,6 +32,14 @@ class Test_ilDatabaseUpdateSteps extends ilDatabaseUpdateSteps {
 		// is really called.
 		$db->connect();
 	}
+
+	public function _getSteps() : array {
+		return $this->getSteps();
+	}
+
+	public function _getStepsBefore(string $other) : array {
+		return $this->getStepsBefore($other);
+	}
 }
 
 class ilDatabaseUpdateStepsTest extends TestCase {
@@ -78,7 +86,7 @@ class ilDatabaseUpdateStepsTest extends TestCase {
 	}
 
 	public function testGetAllSteps() {
-		$steps = $this->test1->getSteps();
+		$steps = $this->test1->_getSteps();
 
 		$expected = [
 			"step_1",
@@ -90,7 +98,7 @@ class ilDatabaseUpdateStepsTest extends TestCase {
 	}
 
 	public function testGetStepsBeforeStep1() {
-		$steps = $this->test1->getStepsBefore("step_1");
+		$steps = $this->test1->_getStepsBefore("step_1");
 
 		$expected = [
 		];
@@ -99,7 +107,7 @@ class ilDatabaseUpdateStepsTest extends TestCase {
 	}
 
 	public function testGetStepsBeforeStep2() {
-		$steps = $this->test1->getStepsBefore("step_2");
+		$steps = $this->test1->_getStepsBefore("step_2");
 
 		$expected = [
 			"step_1"
@@ -109,7 +117,7 @@ class ilDatabaseUpdateStepsTest extends TestCase {
 	}
 
 	public function testGetStepsBeforeStep4() {
-		$steps = $this->test1->getStepsBefore("step_4");
+		$steps = $this->test1->_getStepsBefore("step_4");
 
 		$expected = [
 			"step_1",

--- a/Services/Database/test/Setup/ilDatabaseUpdateStepsTest.php
+++ b/Services/Database/test/Setup/ilDatabaseUpdateStepsTest.php
@@ -44,10 +44,9 @@ class Test_ilDatabaseUpdateSteps extends ilDatabaseUpdateSteps {
 
 class ilDatabaseUpdateStepsTest extends TestCase {
 	protected function setUp(): void {
-		$this->config = $this->createMock(\ilDatabaseSetupConfig::class);
 		$this->base = $this->createMock(Objective::class);
 
-		$this->test1 = new Test_ilDatabaseUpdateSteps($this->config, $this->base);
+		$this->test1 = new Test_ilDatabaseUpdateSteps($this->base);
 	}
 
 	public function testGetStep1() {

--- a/Services/Database/test/ilServicesDatabaseSuite.php
+++ b/Services/Database/test/ilServicesDatabaseSuite.php
@@ -44,6 +44,9 @@ class ilServicesDatabaseSuite extends TestSuite
         require_once('./Services/Database/test/Atom/ilDatabaseAtomSuite.php'); // This seems to be needed in UnitTests
         $suite->addTestSuite(new ilDatabaseAtomSuite());
 
+        require_once('./Services/Database/test/Setup/ilDatabaseSetupSuite.php'); // This seems to be needed in UnitTests
+        $suite->addTestSuite(ilDatabaseSetupSuite::suite());
+
         return $suite;
     }
 }

--- a/src/Setup/CallableObjective.php
+++ b/src/Setup/CallableObjective.php
@@ -1,0 +1,84 @@
+<?php
+
+/* Copyright (c) 2019 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Setup;
+
+use ILIAS\UI;
+
+/**
+ * A callable objective wraps a callable into an objective. 
+ *
+ * The callable receives the environment as parameter. It may return an updated
+ * version of the environment, other results will be discarded.
+ */
+class CallableObjective implements Objective {
+	/**
+	 * @var callable
+	 */
+	protected $callable; 
+
+	/**
+	 * @var string 
+	 */
+	protected $label;
+
+	/**
+	 * @var bool
+	 */
+	protected $is_notable;
+
+	/**
+	 * @var	Objective[]
+	 */
+	protected $preconditions;
+
+	public function __construct(callable $callable, string $label, bool $is_notable, Objective ...$preconditions) {
+		$this->callable = $callable;
+		$this->label = $label;
+		$this->is_notable = $is_notable;
+		$this->preconditions = $preconditions;
+	}
+
+	/**
+	 * @inheritdocs
+	 */
+	public function getHash() : string {
+		return hash(
+			"sha256",
+			spl_object_hash($this)
+		);
+	}
+
+	/**
+	 * @inheritdocs
+	 */
+	public function getLabel() : string {
+		return $this->label;
+	}
+
+	/**
+	 * @inheritdocs
+	 */
+	public function isNotable() : bool {
+		return $this->is_notable;
+	}
+
+	/**
+	 * @inheritdocs
+	 */
+	public function getPreconditions(Environment $environment) : array {
+		return $this->preconditions;
+	}
+
+	/**
+	 * @inheritdocs
+	 */
+	public function achieve(Environment $environment) : Environment {
+		$res = call_user_func($this->callable, $environment);
+		if ($res instanceof Environment) {
+			return $res;
+		}
+		return $environment;
+	}
+}

--- a/src/Setup/ObjectiveCollection.php
+++ b/src/Setup/ObjectiveCollection.php
@@ -44,6 +44,7 @@ class ObjectiveCollection implements Objective {
 	public function getHash() : string {
 		return hash(
 			"sha256",
+			get_class($this).
 			implode(
 				array_map(
 					function($g) { return $g->getHash(); },

--- a/tests/Setup/CallableObjectiveTest.php
+++ b/tests/Setup/CallableObjectiveTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/* Copyright (c) 2019 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Tests\Setup;
+
+require_once(__DIR__."/Helper.php");
+
+use ILIAS\Setup;
+
+class CallableObjectiveTest extends \PHPUnit\Framework\TestCase {
+	use Helper;
+
+	public function myMethod(Setup\Environment $environment) {
+		$this->env = $environment;
+		return $environment;
+	}
+
+	const NAME = "CALL MY METHOD!";
+
+	public function setUp() : void {
+		$this->p = $this->newObjective();
+
+		$this->o = new Setup\CallableObjective(
+			[$this, "myMethod"],
+		 	self::NAME,
+			false,
+			$this->p
+		);
+	}
+
+	public function testGetHash() {
+		$this->assertIsString($this->o->getHash());
+	}
+
+	public function testGetLabel() {
+		$this->assertEquals(self::NAME, $this->o->getLabel());
+	}
+
+	public function testIsNotable() {
+		$this->assertFalse($this->o->isNotable());
+	}
+
+	public function testGetPreconditions() {
+		$env = $this->createMock(Setup\Environment::class);
+
+		$pre = $this->o->getPreconditions($env);
+		$this->assertEquals([$this->p], $pre);	
+	}
+
+
+	public function testAchieve() {
+		$this->env = null;
+
+		$env = $this->createMock(Setup\Environment::class);
+
+		$res = $this->o->achieve($env);
+		$this->assertSame($env, $res);
+		$this->assertSame($this->env, $env);
+	}
+}


### PR DESCRIPTION
Hi all (and especially @chfsx),

this is my current state of how the database update steps could look like in the [new implementation of the setup mechanics](https://github.com/ILIAS-eLearning/ILIAS/pull/1868). The final db-update steps do look very similar to the current db_update-files, a version for the tests can be viewed [here](https://github.com/klees/ILIAS/blob/trunk_setup/Services/Database/test/Setup/ilDatabaseUpdateStepsTest.php#L12).

They use the mechanism outlined in PR #1868, but make them more explicit (and easier to use) for the db-update case. The main difference is, that the steps are now wrapped in a class and that the available dependency (currently only `\ilDBInterface` is available!) for the steps is passed explicitly.

The possibility to have steps separated per component (as requested in [Setup Revision 2018](https://docu.ilias.de/goto_docu_wiki_wpage_4900_1357.html)) is implied, but the same mechanism could also be used for global steps. Dependencies of DB-update-steps (i.e. "execute this before that") can be expressed via [`ilDatabaseUpdateSteps::getAdditionalPreconditionsForStep`](https://github.com/klees/ILIAS/blob/trunk_setup/Services/Database/classes/Setup/class.ilDatabaseUpdateSteps.php#L61), but I expect most components to only depend on updates within themselves.

Also note, that this proposal only is supposed to deal with database updates (and not with the various other migrations and requests that are currently performed in the db_update-files). I will probably add an `InformUserObjective` (or something similar) for the things that are currently dealed with via `die`, while more complex migrations could simply be implemented as vanilla `Objective`s.

If this generell form for the updates is liked, I will open a PR to move the current db-updates to the new form.

Meanwhile, please have a look into this, ask questions, express doubts or raise concerns so I have feedback to iterate on this.

Thx!