### PR TITLE
Init: Remove dead authentication code

### DIFF
--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1327,54 +1327,6 @@ class ilInitialisation
 	}
 
 	/**
-	 * Try authentication
-	 *
-	 * This will basically validate the current session
-	 */
-	public static function authenticate()
-	{
-		global $ilAuth, $ilias, $ilErr;
-
-		$current_script = substr(strrchr($_SERVER["PHP_SELF"], "/"), 1);
-
-		if(self::blockedAuthentication($current_script))
-		{
-			return;
-		}
-
-		$oldSid = session_id();
-
-		$ilAuth->start();
-		$ilias->setAuthError($ilErr->getLastError());
-
-		if($ilAuth->getAuth() && $ilAuth->getStatus() == '')
-		{
-			self::initUserAccount();
-
-			self::handleAuthenticationSuccess();
-		}
-		else
-		{
-			if (!self::showingLoginForm($current_script))
-			{
-				// :TODO: should be moved to context?!
-				$mandatory_auth = ($current_script != "shib_login.php"
-						&& $current_script != "shib_logout.php"
-						&& $current_script != "saml.php"
-						&& $current_script != "error.php"
-						&& $current_script != "chat.php"
-						&& $current_script != "wac.php"
-						&& $current_script != "index.php"); // #10316
-
-				if($mandatory_auth)
-				{
-					self::handleAuthenticationFail();
-				}
-			}
-		}
-	}
-
-	/**
 	 * @static
 	 */
 	protected static function handleAuthenticationSuccess()
@@ -1962,27 +1914,6 @@ class ilInitialisation
 		}
 
 		ilLoggerFactory::getLogger('auth')->debug('Authentication required');
-		return false;
-	}
-
-	/**
-	 * Is current view the login form?
-	 *
-	 * @return boolean
-	 */
-	protected static function showingLoginForm($a_current_script)
-	{
-		if($a_current_script == "login.php")
-		{
-			return true;
-		}
-
-		if($_REQUEST["baseClass"] == "ilStartUpGUI" &&
-			self::getCurrentCmd() == "showLoginPage")
-		{
-			return true;
-		}
-
 		return false;
 	}
 


### PR DESCRIPTION
This PR removes some functions from class `ilInitialisation` which are not used anymore since several ILIAS releases.

@smeyer-ilias I did not find any usage of these methods.

Part of https://mantis.ilias.de/view.php?id=25944