### PR TITLE
WebDAV: Added versioning to 5.4. This adds a new 'modification date' as well

### DIFF
--- a/Services/WebDAV/classes/dav/class.ilObjContainerDAV.php
+++ b/Services/WebDAV/classes/dav/class.ilObjContainerDAV.php
@@ -73,6 +73,7 @@ abstract class ilObjContainerDAV extends ilObjectDAV implements Sabre\DAV\IColle
                     $file_obj->setTitle($name);
                     $file_obj->setFileName($name);
                     $file_obj->setVersion(1);
+                    $file_obj->setMaxVersion(1);
                     $file_obj->createDirectory();
                     $file_obj->create();
 

--- a/Services/WebDAV/classes/dav/class.ilObjFileDAV.php
+++ b/Services/WebDAV/classes/dav/class.ilObjFileDAV.php
@@ -66,6 +66,12 @@ class ilObjFileDAV extends ilObjectDAV implements Sabre\DAV\IFile
     {        
         if($this->repo_helper->checkAccess('write', $this->getRefId()))
         {
+            // Stolen from ilObjFile->addFileVersion
+            $this->obj->setVersion($this->obj->getMaxVersion() + 1);
+            $this->obj->setMaxVersion($this->obj->getMaxVersion() + 1);
+            ilHistory::_createEntry($this->obj->getId(), "new_version", $this->obj->getTitle() . "," . $this->obj->getVersion() . "," . $this->obj->getMaxVersion());
+            $this->obj->addNewsNotification("file_updated");
+
             $this->handleFileUpload($data);
             return $this->getETag();
         }


### PR DESCRIPTION
According to mantis 0026171, I added the Versioning for already existing files on a WebDAV file-upload. This solves as well the "date modified is not updated on upload"-problem.

This PR contains part of the code of the commit https://github.com/ILIAS-eLearning/ILIAS/commit/d733f5070b994789cf08f33b3e3ecc3f6c3874a4 for Ilias6. Just without the "Versioning"-Settings (this is a feature introduced with Ilias6).