### PR TITLE
UI Components: Interface for Notification Item and Notification Slate

### DIFF
--- a/src/UI/Component/Item/Factory.php
+++ b/src/UI/Component/Item/Factory.php
@@ -39,4 +39,55 @@ interface Factory {
 	 * @return \ILIAS\UI\Component\Item\Group
 	 */
 	public function group($title, $items);
+
+
+	/**
+	 * ---
+	 * description:
+	 *   purpose: >
+	 *     Notifications in this context are messages from the system published to the user.
+	 *     Notification Items are used to bundle information (such as title and description)
+	 *     about such notifications and possible interactions with them (such as opening the mail folder
+	 *     containing a new mail).
+	 *   composition: >
+	 *     Notification Items always contain a title and an icon, which indicates the service or module
+	 *     triggering the notification. They also contain a close button. They might contain meta data
+	 *     such as various properties or a description and they further contain a set of interactions
+	 *     allowing the user to react in various ways. The first of those interaction is placed on the title
+	 *     of the Notification Item. Notification Items might also aggregate information about
+	 *     a set of related notifications and display them in the form of such an aggregate.
+	 *   effect: >
+	 *     The main interaction of the item is placed on the title and will be fired by clicking on the Notification Items title.
+	 *     If more than one is passed, they will be listed in a dropdown. The interaction fired by clicking
+	 *     on the Notification Item's title directs in most cases to
+	 *     some repository holding the entry which fired the notification. Clicking on the close button
+	 *     removes the Notification permanently. Exceptions are Notification Items displaying aggregated
+	 *     information. In such a case, Clicking on the title displays the list of the Notifications
+	 *     being aggregated and it will only be closed if all Notifications being aggregated are closed.
+	 *
+	 * rules:
+	 *   interaction:
+	 *     1: >
+	 *       The main interaction offered by clicking on the Notification Items title SHOULD open to
+	 *       some repository holding the entry which fired the notification (e.g. Mailbox in case of new Mail).
+	 *     2: >
+	 *       Clicking on the title of a Notification Item displaying aggregated information of other Notification
+	 *       Items will open a Notification Slate displaying those Notification Items.
+	 *     3: >
+	 *        Clicking on the Close Button MUST remove the Notification Item permanently from the list of
+	 *        Notification Items.
+	 *     4: >
+	 *        If the Notification Item aggregates information on other Notification Items, closing all the
+	 *        aggregates MUST close the aggregating Notification Item as well.
+	 *   accessibility:
+	 *     1: >
+	 *       All interactions offered by a notification item MUST be accessible by only using the keyboard.
+	 *     2: >
+	 *       The purpose of each interaction MUST be clearly labeled by text.
+	 * ---
+	 * @param string|\ILIAS\UI\Component\Button\Shy|\ILIAS\UI\Component\Link\Standard $title Title of the item holding the main interaction
+	 * @param \ILIAS\UI\Component\Symbol\Icon\Icon $icon lead icon
+	 * @return \ILIAS\UI\Component\Item\Notification
+	 */
+	public function notification($title, \ILIAS\UI\Component\Symbol\Icon\Icon $icon);
 }

--- a/src/UI/Component/Item/Notification.php
+++ b/src/UI/Component/Item/Notification.php
@@ -1,0 +1,72 @@
+<?php
+
+/* Copyright (c) 2019 Timon Amstutz <timon.amstutz@ilub.unibe.ch> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\UI\Component\Item;
+
+use ILIAS\UI\Component\Signal;
+
+/**
+ * Interface Notification
+ * @package ILIAS\UI\Component\Item
+ */
+interface Notification extends Item {
+
+	/**
+	 * Get a Notification Item like this but with additional content bellow
+	 * the description
+	 *
+	 * @param \ILIAS\UI\Component\Component $component
+	 * @return self
+	 */
+	public function withAdditionalContent(\ILIAS\UI\Component\Component $component): Notification;
+
+	/**
+	 * Get the additional content of the item or null.
+	 *
+	 * @return \ILIAS\UI\Component\Component|null $component
+	 */
+	public function getAdditionalContent();
+
+	/**
+	 * Get an Item like this to be fired async, when to close button is pressed.
+	 * With this interaction, information may be stored persistently in the DB without interrupting the workflow
+	 * of the user (e.g. setting a flag, that the message was consulted).
+	 *
+	 * @param string|Signal		$action
+	 * @return self
+	 */
+	public function withCloseAction($action): Notification;
+
+	/**
+	 * Get the signal attached to this Notification Item
+	 *
+	 * @return self
+	 */
+	public function getCloseAction();
+
+	/**
+	 * Get an Notification Item like this, but with a set of
+	 * Notifications, this Notification Item will aggregate.
+	 *
+	 * @param Notification[] $sub
+	 * @return self
+	 */
+	public function withAggregateNotification($sub): Notification;
+
+	/**
+	 * Get the list of Notification Items, this Notification Item
+	 * aggregates or an empty list.
+	 *
+	 * @return Notification[] $sub
+	 */
+	public function getAggregateNotification(): array;
+
+	/**
+	 * Get icon as lead. Note that Notifications only accept Icons as lead,
+	 * this is different from the standard Item.
+	 *
+	 * @return \ILIAS\UI\Component\Symbol\Icon\Icon
+	 */
+	public function getLeadIcon():\ILIAS\UI\Component\Symbol\Icon\Icon;
+}

--- a/src/UI/Component/MainControls/Slate/Factory.php
+++ b/src/UI/Component/MainControls/Slate/Factory.php
@@ -70,4 +70,58 @@ interface Factory
 		\ILIAS\UI\Component\Symbol\Symbol $symbol
 	): Combined;
 
+	/**
+	 * ---
+	 * description:
+	 *   purpose: >
+	 *     Notifications Slates are used by the system to publish information to the user in the form of Notification Items.
+	 *     The aim of the Notification Slates and the Notification Items they contain, is to make notifications
+	 *     visible and quickly accessible. They form a centralized channel into which notifications are bundled into.
+	 *     Note that the Notification Slates and Items do not replace the short-lived message displayed on the screen without
+	 *     page loading (like "You have received 1 Contact Request") currently called "toasts".
+	 *
+	 *   composition: >
+	 *     Notifications Slates hold Notification Items, displaying information on and possible interactions
+	 *     with the displayed Notifications. They display the Notification Items chronological order (with the latest on top).
+	 *     Each Notification Slate bundles Notification Items of one specific type of source (service, e.g. Mail).
+	 *
+	 *   effect: >
+	 *     By default Notification Slates are engaged, meaning, they display there content to the user.
+	 *
+	 *   rivals:
+	 *      Combined Slates: >
+	 *          Combined Slates can hold Bulky Links and other Slates, Notification Slates may only contain
+	 *          Notification Items. Further Combined Slates always require an icon and the contained slates are by
+	 *          default dis-engaged.
+	 *      Item Group: >
+	 *          Item Groups bundle any kind of Items, may hold actions on those Items and do not feature an disengaged State.
+	 *
+	 * context:
+	 *   - Notifications in the Meta Bar
+	 *
+	 * rules:
+	 *   usage:
+	 *     1: >
+	 *       Every service that can send a notification SHOULD add an entry in the Notification Center.
+	 *     2: >
+	 *       The displayed Notifications also SHOULD have a permanent place (mainly in Main Bar),
+	 *       somewhere where old messages shown as Notification Item can still be viewed, even if they are removed
+	 *       from the Notification Slate. Exceptions to this are the chat and the Background Tasks.
+	 *   composition:
+	 *     1: >
+	 *          Each Notification Slate MUST bundle Notification Items of one specific type of source (service, e.g. Mail).
+	 *     2: >
+	 *          Notification Slates MUST NOT be empty.
+	 *   ordering:
+	 *       1: >
+	 *          Notification Items displayed inside the Notification Slate MUST be displayed in chronological
+	 *          order where the newest item MUST be the topmost.
+	 *
+	 * ----
+	 *
+	 * @param string $name
+	 * @param \ILIAS\UI\Component\Item\Notification[] $notification_items
+	 * @return \ILIAS\UI\Component\MainControls\Slate\Notification
+	 */
+	public function notification(string $name, array $notification_items): Notification;
 }

--- a/src/UI/Component/MainControls/Slate/Notification.php
+++ b/src/UI/Component/MainControls/Slate/Notification.php
@@ -1,0 +1,19 @@
+<?php
+
+/* Copyright (c) 2019 Timon Amstutz Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\UI\Component\MainControls\Slate;
+
+use \ILIAS\UI\Component\Item\Notification as ItemNotification;
+/**
+ * Notifications Slates are Slates restricted to only containing Notification Items
+ */
+interface Notification extends Slate{
+	/**
+	 * Get a Notification Slate like this, but with one additional Notification Item entry.
+	 *
+	 * @param ItemNotification $entry
+	 * @return Notification
+	 */
+	public function withAdditionalEntry(ItemNotification $entry): Notification;
+}

--- a/src/UI/Implementation/Component/Item/Factory.php
+++ b/src/UI/Implementation/Component/Item/Factory.php
@@ -5,6 +5,7 @@
 namespace ILIAS\UI\Implementation\Component\Item;
 
 use ILIAS\UI\Component\Item as I;
+use ILIAS\UI\NotImplementedException;
 
 class Factory implements I\Factory {
 
@@ -22,4 +23,11 @@ class Factory implements I\Factory {
 		return new Group($title, $items);
 	}
 
+	/**
+	 * @inheritdoc
+	 */
+	public function notification($title, \ILIAS\UI\Component\Symbol\Icon\Icon $icon) {
+		throw new NotImplementedException();
+		//return new Notification($title,$icon);
+	}
 }

--- a/src/UI/Implementation/Component/MainControls/Slate/Factory.php
+++ b/src/UI/Implementation/Component/MainControls/Slate/Factory.php
@@ -9,6 +9,7 @@ use ILIAS\UI\Component\Legacy\Legacy as ILegacy;
 use ILIAS\UI\Implementation\Component\SignalGeneratorInterface;
 use ILIAS\UI\Component\Counter\Factory as CounterFactory;
 use ILIAS\UI\Component\Symbol\Symbol;
+use ILIAS\UI\NotImplementedException;
 
 class Factory implements ISlate\Factory
 {
@@ -38,5 +39,12 @@ class Factory implements ISlate\Factory
 	public function combined(string $name, Symbol $symbol): ISlate\Combined
 	{
 		return new Combined($this->signal_generator, $name, $symbol);
+	}
+
+
+	public function notification(string $name,  array $notification_items): ISlate\Notification
+	{
+		throw new NotImplementedException();
+		//return new Notification($name, $notification_items);
 	}
 }


### PR DESCRIPTION
This PR proposes to introduce the required UI-Components for implementing: [FR](https://docu.ilias.de/goto_docu_wiki_wpage_5118_1357.html).

I propose the following two new components:

**Item -> Notification**:
As proposed already in the FR we implement a specialized version of the Item to display notifications in the list as shown in the mockups. The difference between the standard item as used e.g. in the Calendar List view is shown in the interface description. Most notably is the feature to aggregate Multiple Notification Items into one. Note that the behavior when clicking on the aggregate is very similar to the Dilldown Menu. However we did consider the drilldown behaviour here not as key characteristic here, but rather as implementation detail, that could change in the future or mix drilldown with regular List behavior (see e.g. nice to have note in linke FR).

**Main Controls -> Slate -> Notification**:
The Slate presenting the Notification is an already existing combined slate. The slates this Combined Slates Contains however are Notification Slates. They differ from Combination Slate in that they are accepting Notification Items as entries and in that they do not require an Icon.

Note that there are some slight differences from the mockup in the linked FR to the mockup bellow generated by using this interface. E.g. there are no links in the description (would be technically possible though), but directly on the title, to be more aligned with existing Items.

Further please have a close look an the following rule of the notification slates:
-  Every service that can send a notification SHOULD add an entry in the Notification Center.
- The displayed Notifications also SHOULD have a permanent place (mainly in Main Bar), somewhere where old messages shown as Notification Item can still be viewed, even if they are removed from the Notification Slate. Exceptions to this are the chat and the Background Tasks.

They are taken from the accepted [FR](https://docu.ilias.de/goto_docu_wiki_wpage_5118_1357.html), but might still be worth to be noted once more.

Further note, that if this FR does not contain the clientside logic for adding notifications such as provided in chat, see: src/GlobalScreen/Client

The following snippet provides an example using this interface and providing the mockup shown bellow:
```
public function getNotifications() : array
{
   //Creating a mail Notification Item
   $mail_icon = $this->ui_factory->symbol()->icon()->standard("mail","mail");
   $mail_title = $this->ui_factory->link()->standard("Inbox", "link_to_inbox");
   $mail_notification_item = $this->ui_factory->item()->notification($mail_title,$mail_icon)
      ->withDescription("You have 23 unread mails in your inbox")
      ->withProperties(["Time"=>"3 days ago"]);

   //Creating a badge Notification Item
   $badge_icon = $this->ui_factory->symbol()->icon()->standard("bdga","mail");
   $badge_title = $this->ui_factory->link()->standard("Badges", "link_to_achievement_badges");
   $badge_notification_item = $this->ui_factory->item()->notification($badge_title,$badge_icon)
      ->withDescription("You received 1 Badge.")
      ->withProperties(["Time"=>"2 days ago"]);

   //Some generic notification Items
   $generic_icon1 = $this->ui_factory->symbol()->icon()->standard("cal","generic");
   $generic_title1 = $this->ui_factory->link()->standard("Generic 1", "link_to_generic_repo");
   $generic_item1 = $this->ui_factory->item()->notification($generic_title1,$generic_icon1)
      ->withDescription("Some description.")
      ->withProperties(["Property 1"=>"Content 1","Property 2"=>"Content 2"])
      ->withActions(
         $this->ui_factory->dropdown()->standard([
            $this->ui_factory->button()->shy("Possible Action of this Item", "https://www.ilias.de"),
            $this->ui_factory->button()->shy("Other Possible Action of this Item", "https://www.github.com")
         ])
      );
   $generic_title2 = $this->ui_factory->link()->standard("Generic 2", "just_opens_the_list_of_aggregates");
   $generic_item2 = $this->ui_factory->item()->notification($generic_title2,$generic_icon1)
      ->withDescription("Some description describing the aggregates attached.")
      ->withProperties(["Property 1"=>"Content 1","Property 2"=>"Content 2"])
      ->withAggregateNotification([$generic_item1,$generic_item1]);

   $factory = $this->globalScreen()->notifications()->factory();
   $id = function (string $id) : IdentificationInterface {
      return $this->if->identifier($id);
   };

   //Now, one could fill the Notification Slates for those 3 Services (normally done by global screen)
   $mail_slate =  $this->ui_factory->mainControls()->slate()->notification("Mail",[$mail_notification_item]);
   $badge_slate =  $this->ui_factory->mainControls()->slate()->notification("Badge",[$badge_notification_item]);
   $generic_slate =  $this->ui_factory->mainControls()->slate()->notification("Generic",[
      $generic_item1,$generic_item2
   ]);

   //Add them to the center which is added to the top bar.
   $notification_center =  $this->ui_factory->mainControls()->slate()->combined("Notification Center",
      $this->ui_factory->symbol()->icon()->standard("notification","notification"))
      ->withAdditionalEntry($mail_slate)->withAdditionalEntry($badge_slate)->withAdditionalEntry($generic_slate);


   //Note that generating the slates is something, a developer does not need to take care of.
   //This is done by the global screen, see: src/GlobalScreen/Scope/Notification/README.md
   //So if one would need to offer those three new types of notification, one would need to
   //Offer a class implementing NotificationProvider by e.g. extending AbstractNotificationProvider and
   //implementing getNotifications like so (note slightly different from the version currently in trunk):
   $mail_group = $factory->standardGroup($id('mail_bucket_group'))->withTitle("Mail")
      ->addNotification($factory->standard($id('mail_bucket'))->withNotificationItem($mail_notification_item));

   $badge_group = $factory->standardGroup($id('badge_bucket_group'))->withTitle("Badges")
      ->addNotification($factory->standard($id('badge_bucket'))->withNotificationItem($badge_notification_item));

   $generic_group = $factory->standardGroup($id('generic_bucket_group'))->withTitle("Generic")
      ->addNotification($factory->standard($id('generic_bucket1'))->withNotificationItem($generic_item1))
      ->addNotification($factory->standard($id('generic_bucket2'))->withNotificationItem($generic_item2));

   return [
      $mail_group,
      $badge_group,
      $generic_group
   ];
}

```
![image](https://user-images.githubusercontent.com/1866896/65869448-c741bc00-e37a-11e9-843e-e35a1031587b.png)

