### PR TITLE
Setup: store config in environment

### DIFF
--- a/src/Setup/ArrayEnvironment.php
+++ b/src/Setup/ArrayEnvironment.php
@@ -15,7 +15,7 @@ class ArrayEnvironment implements Environment {
 	 /**
 	  * @var array<string,mixed>
 	  */
-	protected $configs;
+	public $configs;
 
 	public function __construct(array $resources)
 	{
@@ -43,7 +43,7 @@ class ArrayEnvironment implements Environment {
 				"Resource '$id' is already contained in the environment"
 			);
 		}
-		$clone = new ArrayEnvironment($this->resources);
+		$clone = clone $this;
 		$clone->resources[$id] = $resource;
 		return $clone;
 	}
@@ -58,7 +58,7 @@ class ArrayEnvironment implements Environment {
 				"Config for '$component' is already contained in the environment"
 			);
 		}
-		$clone = new ArrayEnvironment($this->resources);
+		$clone = clone $this;
 		$clone->configs[$component] = $config;
 		return $clone;
 	}

--- a/src/Setup/ArrayEnvironment.php
+++ b/src/Setup/ArrayEnvironment.php
@@ -15,7 +15,6 @@ class ArrayEnvironment implements Environment {
 	 /**
 	  * @var array<string,mixed>
 	  */
-
 	protected $configs;
 
 	public function __construct(array $resources)
@@ -52,28 +51,28 @@ class ArrayEnvironment implements Environment {
 	/**
 	 * @inheritdoc
 	 */
-	public function withConfigFor(string $id, $config): Environment
+	public function withConfigFor(string $component, $config): Environment
 	{
-		if (isset($this->configs[$id])) {
+		if (isset($this->configs[$component])) {
 			throw new \RuntimeException(
-				"Config '$id' is already contained in the environment"
+				"Config for '$component' is already contained in the environment"
 			);
 		}
 		$clone = new ArrayEnvironment($this->resources);
-		$clone->configs[$id] = $config;
+		$clone->configs[$component] = $config;
 		return $clone;
 	}
 
 	/**
 	 * @inheritdoc
 	 */
-	public function getConfigFor(string $id)
+	public function getConfigFor(string $component)
 	{
-		if (!isset($this->configs[$id])) {
+		if (!isset($this->configs[$component])) {
 			throw new \RuntimeException(
-				"Config '$id' is not contained in the environment"
+				"Config for '$component' is not contained in the environment"
 			);
 		}
-		return $this->configs[$id];
+		return $this->configs[$component];
 	}
 }

--- a/src/Setup/ArrayEnvironment.php
+++ b/src/Setup/ArrayEnvironment.php
@@ -12,14 +12,22 @@ class ArrayEnvironment implements Environment {
 	 */
 	protected $resources;
 
-	public function __construct(array $resources) {
+	 /**
+	  * @var array<string,mixed>
+	  */
+
+	protected $configs;
+
+	public function __construct(array $resources)
+	{
 		$this->resources = $resources;
 	}
 
 	/**
-	 * @inheritdocs
+	 * @inheritdoc
 	 */
-	public function getResource(string $id) {
+	public function getResource(string $id)
+	{
 		if (!isset($this->resources[$id])) {
 			return null;
 		}
@@ -27,9 +35,10 @@ class ArrayEnvironment implements Environment {
 	}
 
 	/**
-	 * @inheritdocs
+	 * @inheritdoc
 	 */
-	public function withResource(string $id, $resource) : Environment {
+	public function withResource(string $id, $resource): Environment
+	{
 		if (isset($this->resources[$id])) {
 			throw new \RuntimeException(
 				"Resource '$id' is already contained in the environment"
@@ -38,5 +47,33 @@ class ArrayEnvironment implements Environment {
 		$clone = new ArrayEnvironment($this->resources);
 		$clone->resources[$id] = $resource;
 		return $clone;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function withConfigFor(string $id, $config): Environment
+	{
+		if (isset($this->configs[$id])) {
+			throw new \RuntimeException(
+				"Config '$id' is already contained in the environment"
+			);
+		}
+		$clone = new ArrayEnvironment($this->resources);
+		$clone->configs[$id] = $config;
+		return $clone;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getConfigFor(string $id)
+	{
+		if (!isset($this->configs[$id])) {
+			throw new \RuntimeException(
+				"Config '$id' is not contained in the environment"
+			);
+		}
+		return $this->configs[$id];
 	}
 }

--- a/src/Setup/CLI/InstallCommand.php
+++ b/src/Setup/CLI/InstallCommand.php
@@ -4,6 +4,7 @@
 namespace ILIAS\Setup\CLI;
 
 use ILIAS\Setup\Agent;
+use ILIAS\Setup\AgentCollection;
 use ILIAS\Setup\ArrayEnvironment;
 use ILIAS\Setup\ObjectiveIterator;
 use Symfony\Component\Console\Command\Command;
@@ -51,6 +52,12 @@ class InstallCommand extends Command {
 
 		$goal = $this->agent->getInstallObjective($config);
 		$environment = new ArrayEnvironment([]);
+
+		if ($this->agent instanceof AgentCollection && $config) {
+			foreach ($config->getKeys() as $k) {
+				$environment = $environment->withConfigFor($k, $config->getConfig($k));
+			}
+		}
 
 		$goals = new ObjectiveIterator($environment, $goal);
 		while($goals->valid()) {

--- a/src/Setup/Environment.php
+++ b/src/Setup/Environment.php
@@ -31,11 +31,11 @@ interface Environment {
 	  * build an Objective with the respective config.
 	  * @throw \RuntimeException if this config is already in the environment.
 	  */
-	public function withConfigFor(string $id, $config) : Environment;
+	public function withConfigFor(string $component, $config) : Environment;
 
 	/**
 	 * @return array|null
 	 */
-	public function getConfigFor(string $id);
+	public function getConfigFor(string $component);
 
 }

--- a/src/Setup/Environment.php
+++ b/src/Setup/Environment.php
@@ -10,7 +10,7 @@ namespace ILIAS\Setup;
  */
 interface Environment {
 	// We define some resources that will definitely be requried. We allow for
-	// new identifiers, though, to be open for extensions and the future, though.
+	// new identifiers, though, to be open for extensions and the future.
 	const RESOURCE_DATABASE = "resource_database";
 
 	/**
@@ -25,4 +25,17 @@ interface Environment {
 	 * @throw \RuntimeException if this resource is already in the environment.
 	 */
 	public function withResource(string $id, $resource) : Environment;
+
+	 /**
+	  * When using the environment with preconditions, it might become necessary to
+	  * build an Objective with the respective config.
+	  * @throw \RuntimeException if this config is already in the environment.
+	  */
+	public function withConfigFor(string $id, $config) : Environment;
+
+	/**
+	 * @return array|null
+	 */
+	public function getConfigFor(string $id);
+
 }

--- a/src/Setup/Environment.php
+++ b/src/Setup/Environment.php
@@ -27,15 +27,15 @@ interface Environment {
 	public function withResource(string $id, $resource) : Environment;
 
 	 /**
-	  * When using the environment with preconditions, it might become necessary to
-	  * build an Objective with the respective config.
+	  * Stores a config for some component in the environment.
+	  *
 	  * @throw \RuntimeException if this config is already in the environment.
 	  */
 	public function withConfigFor(string $component, $config) : Environment;
 
 	/**
-	 * @return array|null
+	 * @throw \RuntimeException if there is no config for the component
+	 * @return mixed 
 	 */
 	public function getConfigFor(string $component);
-
 }

--- a/tests/Setup/ArrayEnvironmentTest.php
+++ b/tests/Setup/ArrayEnvironmentTest.php
@@ -14,13 +14,15 @@ class ArrayEnvironmentTest extends \PHPUnit\Framework\TestCase {
 		]);
 	}
 
-	public function testGetResource() {
+	public function testGetResource()
+	{
 		$this->assertEquals("FOO", $this->environment->getResource("foo"));
 		$this->assertEquals("BAR", $this->environment->getResource("bar"));
 		$this->assertNull($this->environment->getResource("baz"));
 	}
 
-	public function testWithResource() {
+	public function testWithResource()
+	{
 		$env = $this->environment->withResource("baz", "BAZ");
 
 		$this->assertEquals("FOO", $env->getResource("foo"));
@@ -28,10 +30,33 @@ class ArrayEnvironmentTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals("BAZ", $env->getResource("baz"));
 	}
 
-	public function testSetResourceRejectsDuplicates() {
+	public function testSetResourceRejectsDuplicates()
+	{
 		$this->expectException(\RuntimeException::class);
 
 		$env = $this->environment->withResource("baz", "BAZ");
 		$env->withResource("baz", "BAZ");
-	}	
+	}
+
+	public function testConfigFor()
+	{
+		$env = $this->environment->withConfigFor("foo", "BAR");
+		$this->assertEquals("BAR", $env->getConfigFor("foo"));
+	}
+
+	public function testDuplicateConfigFor()
+	{
+		$this->expectException(\RuntimeException::class);
+		$env = $this->environment
+			->withConfigFor("foo", "BAR")
+			->withConfigFor("foo", "BAZ");
+	}
+
+	public function testWrongConfigId()
+	{
+		$this->expectException(\RuntimeException::class);
+		$env = $this->environment
+			->getConfigFor("foofoo");
+	}
+
 }


### PR DESCRIPTION
When using the environment with preconditions, it might become necessary to build an Objective with the respective config.
This will usually be the case for Objectives writing into the DB, for they should depend on ilDatabaseCreatedObjective.