### PR TITLE
UI, Mainbar: initially activate a tool

### DIFF
--- a/src/UI/examples/Layout/Page/Standard/ui.php
+++ b/src/UI/examples/Layout/Page/Standard/ui.php
@@ -184,7 +184,17 @@ function getDemoEntryRepository($f)
 		'./src/UI/examples/Layout/Page/Standard/ui.php?new_ui=1'
 	);
 
-	$url = './src/UI/examples/Layout/Page/Standard/ui.php?new_ui=1';
+	$df = new \ILIAS\Data\Factory();
+	$url = $df->uri(
+		$_SERVER['REQUEST_SCHEME'].
+		'://'.
+		$_SERVER['SERVER_NAME'].
+		':'.
+		$_SERVER['SERVER_PORT'].
+		$_SERVER['SCRIPT_NAME'].
+		'?'.
+		$_SERVER['QUERY_STRING']
+	);
 	$link1 = $f->link()->bulky($icon, 'Favorites (Link)', $url);
 	$link2 = $f->link()->bulky($icon, 'Courses (Link2)', $url);
 	$link3 = $f->link()->bulky($icon, 'Groups (Link)', $url);

--- a/src/UI/examples/Layout/Page/Standard/ui.php
+++ b/src/UI/examples/Layout/Page/Standard/ui.php
@@ -23,7 +23,12 @@ if ($_GET['new_ui'] == '1') {
 	$content = pagedemoContent($f);
 	$metabar = pagedemoMetabar($f);
 	$mainbar = pagedemoMainbar($f, $renderer)
-		->withActive("pws");
+		->withActive("pws")
+		/**
+		 * You can also activate a tool initially, e.g.:
+		 * ->withActive("tool2")
+		 */
+		;
 
 	$footer = pagedemoFooter($f);
 

--- a/src/UI/templates/js/MainControls/mainbar.js
+++ b/src/UI/templates/js/MainControls/mainbar.js
@@ -53,8 +53,11 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 			id = component_id;
 			var btn = _getAllButtons()
 				.filter('.' + _cls_btn_engaged);
+			if(btn.length == 0) {
+				 btn = _getAllToolButtons()
+					.filter('.' + _cls_btn_engaged);
+			}
 			_disengageButton(btn);
-
 			if(!il.UI.page.isSmallScreen()) {
 				btn.click();
 			}


### PR DESCRIPTION
You can render a page/mainbar with an active entry, as long as it's not a tool.
This will also enable an initially active tool-entry.