### PR TITLE
UI, Close Glyph: use X to close an overlay or leave a view

### DIFF
--- a/src/UI/Component/Symbol/Glyph/Factory.php
+++ b/src/UI/Component/Symbol/Glyph/Factory.php
@@ -934,18 +934,17 @@ interface Factory {
 	 * ---
 	 * description:
 	 *   purpose: >
-	 *      The Close Glyph is used to symbolize an action that closes somthing
+	 *      The Close Glyph is used to symbolize an action that closes something
 	 *      or leaves a previously initiated context.
 	 *   composition: >
 	 *      The Close Glyph uses the glyphicon-remove.
 	 *   effect: >
-	 *       Clicking the Close Glyph will close an overlay, remove an element
-	 *       from the page or change the view entirely.
+	 *       Clicking the Close Glyph will close an overlay or change the view.
 	 *
 	 * rules:
 	 *   accessibility:
 	 *       1: >
-	 *          The aria-label SHOULD be 'Close' or 'Remove'.
+	 *          The aria-label MUST be 'Close'.
 	 * ---
 	 * @param string|null	$action
 	 * @return \ILIAS\UI\Component\Symbol\Glyph\Glyph

--- a/src/UI/Component/Symbol/Glyph/Factory.php
+++ b/src/UI/Component/Symbol/Glyph/Factory.php
@@ -929,4 +929,26 @@ interface Factory {
 	 * @return \ILIAS\UI\Component\Symbol\Glyph\Glyph
 	 */
 	public function time($action = null);
+
+	/**
+	 * ---
+	 * description:
+	 *   purpose: >
+	 *      The Close Glyph is used to symbolize an action that closes somthing
+	 *      or leaves a previously initiated context.
+	 *   composition: >
+	 *      The Close Glyph uses the glyphicon-remove.
+	 *   effect: >
+	 *       Clicking the Close Glyph will close an overlay, remove an element
+	 *       from the page or change the view entirely.
+	 *
+	 * rules:
+	 *   accessibility:
+	 *       1: >
+	 *          The aria-label SHOULD be 'Close' or 'Remove'.
+	 * ---
+	 * @param string|null	$action
+	 * @return \ILIAS\UI\Component\Symbol\Glyph\Glyph
+	 */
+	public function close($action = null);
 }

--- a/src/UI/Component/Symbol/Glyph/Glyph.php
+++ b/src/UI/Component/Symbol/Glyph/Glyph.php
@@ -47,6 +47,7 @@ interface Glyph extends \ILIAS\UI\Component\Symbol\Symbol, \ILIAS\UI\Component\J
 	const HELP = "help";
 	const CALENDAR = "calendar";
 	const TIME = "time";
+	const CLOSE = "close";
 
 	/**
 	 * Get the type of the glyph.

--- a/src/UI/Implementation/Component/Symbol/Glyph/Factory.php
+++ b/src/UI/Implementation/Component/Symbol/Glyph/Factory.php
@@ -288,4 +288,12 @@ class Factory implements G\Factory {
 	{
 		return new Glyph(G\Glyph::TIME, "time", $action);
 	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function close($action = null): G\Glyph
+	{
+		return new Glyph(G\Glyph::CLOSE, "close", $action);
+	}
 }

--- a/src/UI/Implementation/Component/Symbol/Glyph/Glyph.php
+++ b/src/UI/Implementation/Component/Symbol/Glyph/Glyph.php
@@ -82,6 +82,7 @@ class Glyph implements C\Symbol\Glyph\Glyph {
 		, self::HELP
 		, self::CALENDAR
 		, self::TIME
+		, self::CLOSE
 		);
 
 

--- a/src/UI/examples/Symbol/Glyph/Close/close.php
+++ b/src/UI/examples/Symbol/Glyph/Close/close.php
@@ -1,0 +1,17 @@
+<?php
+function close() {
+	global $DIC;
+	$f = $DIC->ui()->factory();
+	$renderer = $DIC->ui()->renderer();
+
+	$glyph = $f->symbol()->glyph()->close("#");
+
+	//Showcase the various states of this Glyph
+	$list = $f->listing()->descriptive([
+		"Active"=>$glyph,
+		"Inactive"=>$glyph->withUnavailableAction(),
+		"Highlighted"=>$glyph->withHighlight()
+	]);
+
+	return $renderer->render($list);
+}

--- a/src/UI/templates/default/Symbol/tpl.glyph.html
+++ b/src/UI/templates/default/Symbol/tpl.glyph.html
@@ -33,6 +33,7 @@
 <!-- BEGIN help --> glyphicon-question-sign<!-- END help -->
 <!-- BEGIN calendar --> glyphicon-calendar<!-- END calendar -->
 <!-- BEGIN time --> glyphicon-time<!-- END time -->
+<!-- BEGIN close --> glyphicon-remove<!-- END close -->
 " aria-hidden="true"></span>
 
 <!-- BEGIN counter_status -->

--- a/tests/UI/Component/Symbol/Glyph/GlyphFactoryTest.php
+++ b/tests/UI/Component/Symbol/Glyph/GlyphFactoryTest.php
@@ -23,6 +23,7 @@ class GlyphFactoryTest extends AbstractFactoryTest {
 		, "help"			=> array("context" => false)
 		, "calendar"		=> array("context" => false)
 		, "time"			=> array("context" => false)
+		, "close"			=> array("context" => false)
 		);
 
 	public $factory_title = 'ILIAS\\UI\\Component\\Symbol\\Glyph\\Factory';


### PR DESCRIPTION
This introduces the X-Glyph. I'm not shure about the name, though.
![close-glyph](https://user-images.githubusercontent.com/3328364/66055532-f9e3e400-e535-11e9-93c8-b11e39798344.png)
