### PR TITLE
Setup/Artifact Builder: Fix testing blacklisted folders against regex…

### DIFF
--- a/src/Setup/ImplementationOfInterfaceFinder.php
+++ b/src/Setup/ImplementationOfInterfaceFinder.php
@@ -19,10 +19,10 @@ class ImplementationOfInterfaceFinder
      */
     private $ignore
         = [
-            '/libs/',
-            '/test/',
-            '/tests/',
-            '/setup/',
+            '.*/libs/',
+            '.*/test/',
+            '.*/tests/',
+            '.*/setup/',
             // Classes using removed Auth-class from PEAR
             '.*ilSOAPAuth.*',
             // Classes using unknown


### PR DESCRIPTION
… (did not work because of ^....$ in regex)

Mantis Issue: https://mantis.ilias.de/view.php?id=26220