### PR TITLE
6.0/ui/fix switchablegroup value

### DIFF
--- a/src/UI/Implementation/Component/Input/Field/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Field/Renderer.php
@@ -592,7 +592,6 @@ class Renderer extends AbstractComponentRenderer
 		}
 		$options_html = $input_tpl->get();
 
-
 		//render with context:
 		$tpl = $this->getTemplate("tpl.context_form.html", true, true);
 		$tpl->setVariable("LABEL", $input->getLabel());

--- a/src/UI/Implementation/Component/Input/Field/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Field/Renderer.php
@@ -576,8 +576,8 @@ class Renderer extends AbstractComponentRenderer
 			$input_tpl->setVariable("VALUE", $key);
 			$input_tpl->setVariable("LABEL", $group->getLabel());
 
-			if ($input->getValue() !== null) {
-				list($index, $subvalues) = $input->getValue();
+			if ($group->getValue() !== null) {
+				list($index, $subvalues) = $group->getValue();
 				if((int)$index === $key) {
 					$input_tpl->setVariable("CHECKED", 'checked="checked"');
 				}
@@ -591,6 +591,7 @@ class Renderer extends AbstractComponentRenderer
 			$input_tpl->parseCurrentBlock();
 		}
 		$options_html = $input_tpl->get();
+
 
 		//render with context:
 		$tpl = $this->getTemplate("tpl.context_form.html", true, true);

--- a/src/UI/Implementation/Component/Input/Field/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Field/Renderer.php
@@ -576,9 +576,9 @@ class Renderer extends AbstractComponentRenderer
 			$input_tpl->setVariable("VALUE", $key);
 			$input_tpl->setVariable("LABEL", $group->getLabel());
 
-			if ($group->getValue() !== null) {
-				list($index, $subvalues) = $group->getValue();
-				if((int)$index === $key) {
+			if ($input->getValue() !== null) {
+				list($index, $subvalues) = $input->getValue();
+				if($index === $key) {
 					$input_tpl->setVariable("CHECKED", 'checked="checked"');
 				}
 			}

--- a/src/UI/Implementation/Component/Input/Field/SwitchableGroup.php
+++ b/src/UI/Implementation/Component/Input/Field/SwitchableGroup.php
@@ -87,7 +87,7 @@ class SwitchableGroup extends Group implements Field\SwitchableGroup {
 	public function getValue() {
 		$key = Input::getValue();
 		if(is_null($key)){
-			return $key;
+			return null;
 		}
 		return [$key, $this->inputs[$key]->getValue()];
 	}

--- a/src/UI/Implementation/Component/Input/Field/SwitchableGroup.php
+++ b/src/UI/Implementation/Component/Input/Field/SwitchableGroup.php
@@ -65,7 +65,6 @@ class SwitchableGroup extends Group implements Field\SwitchableGroup {
 
 	/**
 	 * @inheritdoc
-	 * @return Checkbox
 	 */
 	public function withValue($value) {
 		if (is_string($value) || is_int($value)) {
@@ -87,6 +86,9 @@ class SwitchableGroup extends Group implements Field\SwitchableGroup {
 	 */
 	public function getValue() {
 		$key = Input::getValue();
+		if(is_null($key)){
+			return $key;
+		}
 		return [$key, $this->inputs[$key]->getValue()];
 	}
 

--- a/src/UI/examples/Input/Field/SwitchableGroup/base.php
+++ b/src/UI/examples/Input/Field/SwitchableGroup/base.php
@@ -33,7 +33,7 @@ function base() {
 		],
 		"pick one",
 		"...or the other"
-	)->withValue("g2");
+	);
 
 	//Step 3: define form and form actions
 	$DIC->ctrl()->setParameterByClass(
@@ -45,7 +45,8 @@ function base() {
 	$form = $ui->input()->container()->form()->standard(
 		$form_action,
 		[
-			'switchable_group' => $sg
+			'switchable_group' => $sg,
+			'switchable_group2' => $sg->withValue("g2")
 		]);
 
 	//Step 4: implement some form data processing.

--- a/src/UI/examples/Input/Field/SwitchableGroup/base.php
+++ b/src/UI/examples/Input/Field/SwitchableGroup/base.php
@@ -20,16 +20,20 @@ function base() {
 	$group2 = $ui->input()->field()->group(
 		[
 			"field_2_1"=>$ui->input()->field()->text("Item 2", "Just another field")
+				->withValue('some val')
 		],
 		"switchable group number two"
 	);
 
 	//Step 2: Switchable Group - one or the other:
 	$sg = $ui->input()->field()->switchableGroup(
-		[$group1, $group2],
+		[
+			"g1"=>$group1,
+			"g2"=>$group2
+		],
 		"pick one",
 		"...or the other"
-	);
+	)->withValue("g2");
 
 	//Step 3: define form and form actions
 	$DIC->ctrl()->setParameterByClass(
@@ -38,7 +42,11 @@ function base() {
 		'switchablegroup'
 	);
 	$form_action = $DIC->ctrl()->getFormActionByClass('ilsystemstyledocumentationgui');
-	$form = $ui->input()->container()->form()->standard($form_action, ['switchable_group' => $sg]);
+	$form = $ui->input()->container()->form()->standard(
+		$form_action,
+		[
+			'switchable_group' => $sg
+		]);
 
 	//Step 4: implement some form data processing.
 	if ($request->getMethod() == "POST"


### PR DESCRIPTION
Follow-up to #2225; rendering of Switchable Group used to throw (in examples, e.g.)
The issue is with $value beeing set or not rather than subgroups.