### PR TITLE
Accessibility: Add possible fix for missing aria-labels for table fil…

### DIFF
--- a/Services/Form/classes/class.ilCheckboxInputGUI.php
+++ b/Services/Form/classes/class.ilCheckboxInputGUI.php
@@ -217,7 +217,9 @@ class ilCheckboxInputGUI extends ilSubEnabledFormPropertyGUI implements ilToolba
 			// zoom 1; *display:inline for IE6 & 7
 			$tpl->setVariable("STYLE_PAR", 'display: -moz-inline-stack; display:inline-block; zoom: 1; *display:inline;');
 		}
-		
+
+		$tpl->setVariable("ARIA_LABEL", $this->getTitle());
+
 		return $tpl->get();
 	}
 

--- a/Services/Form/classes/class.ilCheckboxInputGUI.php
+++ b/Services/Form/classes/class.ilCheckboxInputGUI.php
@@ -218,7 +218,7 @@ class ilCheckboxInputGUI extends ilSubEnabledFormPropertyGUI implements ilToolba
 			$tpl->setVariable("STYLE_PAR", 'display: -moz-inline-stack; display:inline-block; zoom: 1; *display:inline;');
 		}
 
-		$tpl->setVariable("ARIA_LABEL", $this->getTitle());
+		$tpl->setVariable("ARIA_LABEL", ilUtil::prepareFormOutput($this->getTitle()));
 
 		return $tpl->get();
 	}

--- a/Services/Form/classes/class.ilDateDurationInputGUI.php
+++ b/Services/Form/classes/class.ilDateDurationInputGUI.php
@@ -480,6 +480,7 @@ class ilDateDurationInputGUI extends ilSubEnabledFormPropertyGUI implements ilTa
 		if(trim($start_txt))
 		{
 			$tpl->setVariable('START_LABEL', $start_txt);
+			$tpl->setVariable('START_ARIA_LABEL', $start_txt);
 			$tpl->touchBlock('start_width_bl');
 		}
 		
@@ -491,6 +492,7 @@ class ilDateDurationInputGUI extends ilSubEnabledFormPropertyGUI implements ilTa
 		if(trim($end_txt))
 		{
 			$tpl->setVariable('END_LABEL', $end_txt);
+			$tpl->setVariable('END_ARIA_LABEL', $end_txt);
 			$tpl->touchBlock('end_width_bl');
 		}
 		

--- a/Services/Form/classes/class.ilDateDurationInputGUI.php
+++ b/Services/Form/classes/class.ilDateDurationInputGUI.php
@@ -480,7 +480,7 @@ class ilDateDurationInputGUI extends ilSubEnabledFormPropertyGUI implements ilTa
 		if(trim($start_txt))
 		{
 			$tpl->setVariable('START_LABEL', $start_txt);
-			$tpl->setVariable('START_ARIA_LABEL', $start_txt);
+			$tpl->setVariable('START_ARIA_LABEL', ilUtil::prepareFormOutput($start_txt));
 			$tpl->touchBlock('start_width_bl');
 		}
 		
@@ -492,7 +492,7 @@ class ilDateDurationInputGUI extends ilSubEnabledFormPropertyGUI implements ilTa
 		if(trim($end_txt))
 		{
 			$tpl->setVariable('END_LABEL', $end_txt);
-			$tpl->setVariable('END_ARIA_LABEL', $end_txt);
+			$tpl->setVariable('END_ARIA_LABEL', ilUtil::prepareFormOutput($end_txt));
 			$tpl->touchBlock('end_width_bl');
 		}
 		

--- a/Services/Form/classes/class.ilSelectInputGUI.php
+++ b/Services/Form/classes/class.ilSelectInputGUI.php
@@ -239,6 +239,8 @@ class ilSelectInputGUI extends ilSubEnabledFormPropertyGUI implements ilTableFil
 			$tpl->setVariable("MULTI_ICONS", $this->getMultiIconsHTML());			
 		}
 
+		$tpl->setVariable("ARIA_LABEL", $this->getTitle());
+
 		return $tpl->get();
 	}
 	

--- a/Services/Form/classes/class.ilSelectInputGUI.php
+++ b/Services/Form/classes/class.ilSelectInputGUI.php
@@ -239,7 +239,7 @@ class ilSelectInputGUI extends ilSubEnabledFormPropertyGUI implements ilTableFil
 			$tpl->setVariable("MULTI_ICONS", $this->getMultiIconsHTML());			
 		}
 
-		$tpl->setVariable("ARIA_LABEL", $this->getTitle());
+		$tpl->setVariable("ARIA_LABEL", ilUtil::prepareFormOutput($this->getTitle()));
 
 		return $tpl->get();
 	}

--- a/Services/Form/classes/class.ilTextInputGUI.php
+++ b/Services/Form/classes/class.ilTextInputGUI.php
@@ -546,7 +546,9 @@ class ilTextInputGUI extends ilSubEnabledFormPropertyGUI implements ilTableFilte
 			$tpl->touchBlock("inline_in_bl");
 			$tpl->setVariable("MULTI_ICONS", $this->getMultiIconsHTML());
 		}
-		
+
+		$tpl->setVariable("ARIA_LABEL", $this->getTitle());
+
 		return $tpl->get();
 	}
 	

--- a/Services/Form/classes/class.ilTextInputGUI.php
+++ b/Services/Form/classes/class.ilTextInputGUI.php
@@ -547,7 +547,7 @@ class ilTextInputGUI extends ilSubEnabledFormPropertyGUI implements ilTableFilte
 			$tpl->setVariable("MULTI_ICONS", $this->getMultiIconsHTML());
 		}
 
-		$tpl->setVariable("ARIA_LABEL", $this->getTitle());
+		$tpl->setVariable("ARIA_LABEL", ilUtil::prepareFormOutput($this->getTitle()));
 
 		return $tpl->get();
 	}

--- a/Services/Form/templates/default/tpl.prop_checkbox.html
+++ b/Services/Form/templates/default/tpl.prop_checkbox.html
@@ -1,5 +1,5 @@
 <div class="checkbox">
 <label class="checkbox-inline">
-<input onclick="il.Form.showSubForm('subform_{ID}','il_prop_cont_{ID}', this);" type="checkbox" id="{ID}" name="{POST_VAR}" value="{PROPERTY_VALUE}" {PROPERTY_CHECKED} {DISABLED} {PROP_CHECK_ATTRS} />
+<input aria-label="{ARIA_LABEL}" onclick="il.Form.showSubForm('subform_{ID}','il_prop_cont_{ID}', this);" type="checkbox" id="{ID}" name="{POST_VAR}" value="{PROPERTY_VALUE}" {PROPERTY_CHECKED} {DISABLED} {PROP_CHECK_ATTRS} />
 {OPTION_TITLE}&nbsp;</label>
 </div>

--- a/Services/Form/templates/default/tpl.prop_datetime_duration.html
+++ b/Services/Form/templates/default/tpl.prop_datetime_duration.html
@@ -13,7 +13,7 @@
 		<!-- BEGIN start_label_bl -->
 		<!-- END start_label_bl -->
 		<div class="input-group date<!-- BEGIN start_width_bl --> noop<!-- END start_width_bl -->" id="{DATEPICKER_START_ID}">
-			<input type="text" class="form-control" style="min-width:120px" placeholder="{START_PLACEHOLDER}" value="{DATEPICKER_START_VALUE}" name="{DATE_START_ID}"{DATEPICKER_START_DISABLED} {START_REQUIRED}/>
+			<input aria-label="{START_ARIA_LABEL}" type="text" class="form-control" style="min-width:120px" placeholder="{START_PLACEHOLDER}" value="{DATEPICKER_START_VALUE}" name="{DATE_START_ID}"{DATEPICKER_START_DISABLED} {START_REQUIRED}/>
 			<span class="input-group-addon">
 				<span class="glyphicon glyphicon-calendar"></span>
 			</span>
@@ -26,7 +26,7 @@
 		<!-- BEGIN end_label_bl -->
 		<!-- END end_label_bl -->
 		<div class="input-group date<!-- BEGIN end_width_bl --> noop<!-- END end_width_bl -->" id="{DATEPICKER_END_ID}">
-			<input type="text" class="form-control" style="min-width:120px" placeholder="{END_PLACEHOLDER}" value="{DATEPICKER_END_VALUE}" name="{DATE_END_ID}"{DATEPICKER_END_DISABLED} {END_REQUIRED} />
+			<input aria-label="{END_ARIA_LABEL}" type="text" class="form-control" style="min-width:120px" placeholder="{END_PLACEHOLDER}" value="{DATEPICKER_END_VALUE}" name="{DATE_END_ID}"{DATEPICKER_END_DISABLED} {END_REQUIRED} />
 			<span class="input-group-addon">
 				<span class="glyphicon glyphicon-calendar"></span>
 			</span>

--- a/Services/Form/templates/default/tpl.prop_select.html
+++ b/Services/Form/templates/default/tpl.prop_select.html
@@ -1,7 +1,7 @@
 <!-- BEGIN inline_in_bl -->
 <div class="form-inline">
 <!-- END inline_in_bl -->	
-	<select class="form-control" id="{ID}" name="{POST_VAR}" <!-- BEGIN cust_attr -->{CUSTOM_ATTR}<!-- END cust_attr --> {DISABLED}>
+	<select aria-label="{ARIA_LABEL}" class="form-control" id="{ID}" name="{POST_VAR}" <!-- BEGIN cust_attr -->{CUSTOM_ATTR}<!-- END cust_attr --> {DISABLED}>
 	<!-- BEGIN prop_select_option -->
 	<option value="{VAL_SELECT_OPTION}" {CHK_SEL_OPTION}>{TXT_SELECT_OPTION}</option>
 	<!-- END prop_select_option -->

--- a/Services/Form/templates/default/tpl.prop_textinput.html
+++ b/Services/Form/templates/default/tpl.prop_textinput.html
@@ -1,7 +1,7 @@
 <!-- BEGIN inline_in_bl -->
 <div class="form-inline">
 <!-- END inline_in_bl -->	
-	<input class="form-control" <!-- BEGIN submit_form_on_enter -->onkeypress="return il.Util.submitOnEnter(event, this.form);"<!-- END submit_form_on_enter --> type="{PROP_INPUT_TYPE}" <!-- BEGIN stylecss -->style="{CSS_STYLE}" <!-- END stylecss --> id="{ID}" <!-- BEGIN classcss -->  <!-- END classcss --> maxlength="{MAXLENGTH}" name="{POST_VAR}" <!-- BEGIN prop_text_propval -->value="{PROPERTY_VALUE}" <!-- END prop_text_propval -->{DISABLED} {AUTOCOMPLETE} {REQUIRED}/> {INPUT_SUFFIX}
+	<input aria-label="{ARIA_LABEL}" class="form-control" <!-- BEGIN submit_form_on_enter -->onkeypress="return il.Util.submitOnEnter(event, this.form);"<!-- END submit_form_on_enter --> type="{PROP_INPUT_TYPE}" <!-- BEGIN stylecss -->style="{CSS_STYLE}" <!-- END stylecss --> id="{ID}" <!-- BEGIN classcss -->  <!-- END classcss --> maxlength="{MAXLENGTH}" name="{POST_VAR}" <!-- BEGIN prop_text_propval -->value="{PROPERTY_VALUE}" <!-- END prop_text_propval -->{DISABLED} {AUTOCOMPLETE} {REQUIRED}/> {INPUT_SUFFIX}
 	{HIDDEN_INPUT}
 <!-- BEGIN inline_out_bl -->
 	{MULTI_ICONS}

--- a/Services/Mail/classes/Form/class.ilMailQuickFilterInputGUI.php
+++ b/Services/Mail/classes/Form/class.ilMailQuickFilterInputGUI.php
@@ -80,6 +80,7 @@ class ilMailQuickFilterInputGUI extends ilTextInputGUI
 				$tpl->setVariable('PROP_INPUT_TYPE','text');
 		}
 		$tpl->setVariable("ID", $this->getFieldId());
+		$tpl->setVariable("ARIA_LABEL", $this->getTitle());
 		$tpl->setVariable("SIZE", $this->getSize());
 		if($this->getMaxLength() != null)
 			$tpl->setVariable("MAXLENGTH", $this->getMaxLength());

--- a/Services/Mail/templates/default/tpl.prop_mail_quick_filter_input.html
+++ b/Services/Mail/templates/default/tpl.prop_mail_quick_filter_input.html
@@ -1,5 +1,5 @@
 <div class="iosMailFilter"<!-- BEGIN style --> style="{STYLE_PAR}"<!-- END style -->>
-	<input autocomplete="off" <!-- BEGIN submit_form_on_enter -->onkeypress="return il.Util.submitOnEnter(event, this.form);"<!-- END submit_form_on_enter --> type="{PROP_INPUT_TYPE}" placeholder="{TXT_PLACEHOLDER}" <!-- BEGIN stylecss -->style="{CSS_STYLE}" <!-- END stylecss -->size="{SIZE}" id="{ID}" <!-- BEGIN classcss --> class="{CLASS_CSS}" <!-- END classcss --> maxlength="{MAXLENGTH}" name="{POST_VAR}" <!-- BEGIN prop_text_propval -->value="{PROPERTY_VALUE}" <!-- END prop_text_propval -->{DISABLED}/> {INPUT_SUFFIX}
+	<input aria-label="{ARIA_LABEL}" autocomplete="off" <!-- BEGIN submit_form_on_enter -->onkeypress="return il.Util.submitOnEnter(event, this.form);"<!-- END submit_form_on_enter --> type="{PROP_INPUT_TYPE}" placeholder="{TXT_PLACEHOLDER}" <!-- BEGIN stylecss -->style="{CSS_STYLE}" <!-- END stylecss -->size="{SIZE}" id="{ID}" <!-- BEGIN classcss --> class="{CLASS_CSS}" <!-- END classcss --> maxlength="{MAXLENGTH}" name="{POST_VAR}" <!-- BEGIN prop_text_propval -->value="{PROPERTY_VALUE}" <!-- END prop_text_propval -->{DISABLED}/> {INPUT_SUFFIX}
 	{HIDDEN_INPUT}
 	<!-- BEGIN filter_options -->
 	<div id="filter_options_{FIELD_ID}" style="display:none;margin-top: 5px;position:relative;">


### PR DESCRIPTION
…ter input elements

Mantis Issue: https://mantis.ilias.de/view.php?id=25531

This PR will add `aria-label` attributes for certain legacy form elements. The respective label of the elements is used as value for that attribute.
The concrete Mantis issue addresses form input elements of the `Mail Folder Table` view, so **not all** legacy form elements of our code base are affected with this PR.
Please note that the aria-label is also set for the default form usage of these elements, not only for the usage as a table filter element.