### PR TITLE
WIP: UI, StandardPage: add short- and view-title

### DIFF
--- a/Services/UICore/classes/Screen/PageContentProvider.php
+++ b/Services/UICore/classes/Screen/PageContentProvider.php
@@ -9,6 +9,9 @@ use ILIAS\GlobalScreen\ScreenContext\Stack\CalledContexts;
 use ILIAS\GlobalScreen\ScreenContext\Stack\ContextCollection;
 use ILIAS\UI\Component\Legacy\Legacy;
 use ILIAS\UI\Component\MainControls\Footer;
+use ILIAS\GlobalScreen\Scope\Layout\Factory\TitleModification;
+use ILIAS\GlobalScreen\Scope\Layout\Factory\ShortTitleModification;
+use ILIAS\GlobalScreen\Scope\Layout\Factory\ViewTitleModification;
 
 /**
  * Class ilPageContentProvider
@@ -29,6 +32,10 @@ class PageContentProvider extends AbstractModificationProvider implements Modifi
     /**
      * @var string
      */
+    private static $title = "";
+    /**
+     * @var string
+     */
     private static $short_title = "";
     /**
      * @var string
@@ -41,6 +48,14 @@ class PageContentProvider extends AbstractModificationProvider implements Modifi
     public static function setContent(string $content) : void
     {
         self::$content = $content;
+    }
+
+    /**
+     * @param string $content
+     */
+    public static function setTitle(string $title) : void
+    {
+        self::$title = $title;
     }
 
     /**
@@ -91,16 +106,33 @@ class PageContentProvider extends AbstractModificationProvider implements Modifi
         })->withLowPriority();
     }
 
-    public function getShortTitleModification(CalledContexts $screen_context_stack) : ?ContentModification
+
+    public function getTitleModification(CalledContexts $screen_context_stack) : ?TitleModification
     {
-        //die(self::$short_title);
-        return $this->globalScreen()->layout()->factory()->content()->withModification(function (Legacy $content) : Legacy {
-            //$this->globalScreen()->layout()->factory()->short_title()
-            $ui = $this->dic->ui();
-            return $ui->factory()->legacy(self::$short_title);
-        })->withLowPriority();
+        return $this->globalScreen()->layout()->factory()->title()->withModification(
+            function (string $content) : string {
+                return self::$title;
+            }
+        )->withLowPriority();
     }
 
+    public function getShortTitleModification(CalledContexts $screen_context_stack) : ?ShortTitleModification
+    {
+        return $this->globalScreen()->layout()->factory()->short_title()->withModification(
+            function (string $content) : string {
+                return self::$short_title;
+            }
+        )->withLowPriority();
+    }
+
+    public function getViewTitleModification(CalledContexts $screen_context_stack) : ?ViewTitleModification
+    {
+        return $this->globalScreen()->layout()->factory()->view_title()->withModification(
+            function (string $content) : string {
+                return self::$view_title;
+            }
+        )->withLowPriority();
+    }
 
     /**
      * @inheritDoc

--- a/Services/UICore/classes/Screen/PageContentProvider.php
+++ b/Services/UICore/classes/Screen/PageContentProvider.php
@@ -26,7 +26,14 @@ class PageContentProvider extends AbstractModificationProvider implements Modifi
      * @var string
      */
     private static $perma_link = "";
-
+    /**
+     * @var string
+     */
+    private static $short_title = "";
+    /**
+     * @var string
+     */
+    private static $view_title = "";
 
     /**
      * @param string $content
@@ -34,6 +41,22 @@ class PageContentProvider extends AbstractModificationProvider implements Modifi
     public static function setContent(string $content) : void
     {
         self::$content = $content;
+    }
+
+    /**
+     * @param string $content
+     */
+    public static function setShortTitle(string $short_title) : void
+    {
+        self::$short_title = $short_title;
+    }
+
+    /**
+     * @param string $content
+     */
+    public static function setViewTitle(string $view_title) : void
+    {
+        self::$view_title = $view_title;
     }
 
 
@@ -62,8 +85,19 @@ class PageContentProvider extends AbstractModificationProvider implements Modifi
     {
         return $this->globalScreen()->layout()->factory()->content()->withModification(function (Legacy $content) : Legacy {
             $ui = $this->dic->ui();
+            return $ui->factory()->legacy(
+                $ui->renderer()->render($content) .self::$content
+            );
+        })->withLowPriority();
+    }
 
-            return $ui->factory()->legacy($ui->renderer()->render($content) . self::$content);
+    public function getShortTitleModification(CalledContexts $screen_context_stack) : ?ContentModification
+    {
+        //die(self::$short_title);
+        return $this->globalScreen()->layout()->factory()->content()->withModification(function (Legacy $content) : Legacy {
+            //$this->globalScreen()->layout()->factory()->short_title()
+            $ui = $this->dic->ui();
+            return $ui->factory()->legacy(self::$short_title);
         })->withLowPriority();
     }
 

--- a/Services/UICore/classes/class.ilGlobalPageTemplate.php
+++ b/Services/UICore/classes/class.ilGlobalPageTemplate.php
@@ -107,11 +107,7 @@ class ilGlobalPageTemplate implements ilGlobalTemplateInterface
         $this->prepareBasicCSS();
 
         PageContentProvider::setContent($this->legacy_content_template->renderPage("DEFAULT", true, false));
-        PageContentProvider::setTitle('PAGE-xx');
-        PageContentProvider::setShortTitle('SHORT-xx');
-        PageContentProvider::setViewTitle('VIEW-xx');
-
-
+        PageContentProvider::setShortTitle(CLIENT_NAME);
         print $this->ui->renderer()->render($this->gs->collector()->layout()->getFinalPage());
     }
 
@@ -221,6 +217,8 @@ class ilGlobalPageTemplate implements ilGlobalTemplateInterface
     public function setTitle($a_title)
     {
         $this->legacy_content_template->setTitle($a_title);
+        PageContentProvider::setTitle($a_title);
+        PageContentProvider::setViewTitle($a_title);
     }
 
 

--- a/Services/UICore/classes/class.ilGlobalPageTemplate.php
+++ b/Services/UICore/classes/class.ilGlobalPageTemplate.php
@@ -107,6 +107,9 @@ class ilGlobalPageTemplate implements ilGlobalTemplateInterface
         $this->prepareBasicCSS();
 
         PageContentProvider::setContent($this->legacy_content_template->renderPage("DEFAULT", true, false));
+        PageContentProvider::setShortTitle('SHORT-xx');
+        PageContentProvider::setViewTitle('VIEW-xx');
+
 
         print $this->ui->renderer()->render($this->gs->collector()->layout()->getFinalPage());
     }

--- a/Services/UICore/classes/class.ilGlobalPageTemplate.php
+++ b/Services/UICore/classes/class.ilGlobalPageTemplate.php
@@ -107,6 +107,7 @@ class ilGlobalPageTemplate implements ilGlobalTemplateInterface
         $this->prepareBasicCSS();
 
         PageContentProvider::setContent($this->legacy_content_template->renderPage("DEFAULT", true, false));
+        PageContentProvider::setTitle('PAGE-xx');
         PageContentProvider::setShortTitle('SHORT-xx');
         PageContentProvider::setViewTitle('VIEW-xx');
 

--- a/src/GlobalScreen/Scope/Layout/Builder/StandardPageBuilder.php
+++ b/src/GlobalScreen/Scope/Layout/Builder/StandardPageBuilder.php
@@ -39,7 +39,20 @@ class StandardPageBuilder implements PageBuilder
         $meta_bar = $parts->getMetaBar();
         $bread_crumbs = $parts->getBreadCrumbs();
         $footer = $parts->getFooter();
+        $title = $parts->getTitle();
+        $short_title = $parts->getShortTitle();
+        $view_title = $parts->getViewTitle();
 
-        return $this->ui->factory()->layout()->page()->standard([$parts->getContent()], $meta_bar, $main_bar, $bread_crumbs, $header_image, $footer);
+        return $this->ui->factory()->layout()->page()->standard(
+            [$parts->getContent()],
+            $meta_bar,
+            $main_bar,
+            $bread_crumbs,
+            $header_image,
+            $footer,
+            $title,
+            $short_title,
+            $view_title
+        );
     }
 }

--- a/src/GlobalScreen/Scope/Layout/Collector/MainLayoutCollector.php
+++ b/src/GlobalScreen/Scope/Layout/Collector/MainLayoutCollector.php
@@ -106,7 +106,10 @@ class MainLayoutCollector
         $final_page_modification = new NullModification();
         $final_footer_modification = new NullModification();
 
+//var_dump($this->providers);
         foreach ($this->providers as $provider) {
+            var_dump(get_class($provider));
+
             $context_collection = $provider->isInterestedInContexts();
             if (!$context_collection->hasMatch($called_contexts)) {
                 continue;
@@ -133,6 +136,17 @@ class MainLayoutCollector
             // PAGE
             $page_modification = $provider->getPageBuilderDecorator($called_contexts);
             $this->replaceModification($final_page_modification, $page_modification, PageBuilderModification::class);
+
+            if(get_class($provider) !== "ILIAS\GlobalScreen\Provider\GSModificationProvider") { //TODO: raus
+
+              $short_title_modification = $provider->getShortTitleModification($called_contexts);
+              $this->replaceModification($final_page_modification, $short_title_modification, 'stitle');
+
+//var_dump($final_page_modification);
+//var_dump(get_class($short_title_modification));
+
+            }
+
         }
 
         if ($final_content_modification->hasValidModification()) {
@@ -158,6 +172,7 @@ class MainLayoutCollector
         }
 
         return $this->modification_handler->getPageWithPagePartProviders();
+die('stop');
     }
 
 

--- a/src/GlobalScreen/Scope/Layout/Collector/MainLayoutCollector.php
+++ b/src/GlobalScreen/Scope/Layout/Collector/MainLayoutCollector.php
@@ -19,6 +19,9 @@ use ILIAS\GlobalScreen\Scope\Layout\Provider\ModificationProvider;
 use ILIAS\GlobalScreen\ScreenContext\Stack\CalledContexts;
 use ILIAS\UI\Component\Layout\Page\Page;
 use LogicException;
+use ILIAS\GlobalScreen\Scope\Layout\Factory\TitleModification;
+use ILIAS\GlobalScreen\Scope\Layout\Factory\ShortTitleModification;
+use ILIAS\GlobalScreen\Scope\Layout\Factory\ViewTitleModification;
 
 /**
  * Class MainLayoutCollector
@@ -105,10 +108,12 @@ class MainLayoutCollector
         $final_meta_bar_modification = new NullModification();
         $final_page_modification = new NullModification();
         $final_footer_modification = new NullModification();
+        $final_title_modification = new NullModification();
+        $final_short_title_modification = new NullModification();
+        $final_view_title_modification = new NullModification();
 
-//var_dump($this->providers);
+
         foreach ($this->providers as $provider) {
-            var_dump(get_class($provider));
 
             $context_collection = $provider->isInterestedInContexts();
             if (!$context_collection->hasMatch($called_contexts)) {
@@ -139,12 +144,14 @@ class MainLayoutCollector
 
             if(get_class($provider) !== "ILIAS\GlobalScreen\Provider\GSModificationProvider") { //TODO: raus
 
-              $short_title_modification = $provider->getShortTitleModification($called_contexts);
-              $this->replaceModification($final_page_modification, $short_title_modification, 'stitle');
+                $title_modification = $provider->getTitleModification($called_contexts);
+                $this->replaceModification($final_title_modification, $title_modification, TitleModification::class);
 
-//var_dump($final_page_modification);
-//var_dump(get_class($short_title_modification));
+                $short_title_modification = $provider->getShortTitleModification($called_contexts);
+                $this->replaceModification($final_short_title_modification, $short_title_modification, ShortTitleModification::class);
 
+                $view_title_modification = $provider->getViewTitleModification($called_contexts);
+                $this->replaceModification($final_view_title_modification, $view_title_modification, ViewTitleModification::class);
             }
 
         }
@@ -170,9 +177,17 @@ class MainLayoutCollector
         if ($final_page_modification->hasValidModification()) {
             $this->modification_handler->modifyPageBuilderWithClosure($final_page_modification->getModification());
         }
+        if ($final_title_modification->hasValidModification()) {
+            $this->modification_handler->modifyTitleWithClosure($final_title_modification->getModification());
+        }
+        if ($final_short_title_modification->hasValidModification()) {
+            $this->modification_handler->modifyShortTitleWithClosure($final_short_title_modification->getModification());
+        }
+        if ($final_view_title_modification->hasValidModification()) {
+            $this->modification_handler->modifyViewTitleWithClosure($final_view_title_modification->getModification());
+        }
 
         return $this->modification_handler->getPageWithPagePartProviders();
-die('stop');
     }
 
 

--- a/src/GlobalScreen/Scope/Layout/Collector/MainLayoutCollector.php
+++ b/src/GlobalScreen/Scope/Layout/Collector/MainLayoutCollector.php
@@ -141,19 +141,15 @@ class MainLayoutCollector
             // PAGE
             $page_modification = $provider->getPageBuilderDecorator($called_contexts);
             $this->replaceModification($final_page_modification, $page_modification, PageBuilderModification::class);
+            // Pagetitle
+            $title_modification = $provider->getTitleModification($called_contexts);
+            $this->replaceModification($final_title_modification, $title_modification, TitleModification::class);
 
-            if(get_class($provider) !== "ILIAS\GlobalScreen\Provider\GSModificationProvider") { //TODO: raus
+            $short_title_modification = $provider->getShortTitleModification($called_contexts);
+            $this->replaceModification($final_short_title_modification, $short_title_modification, ShortTitleModification::class);
 
-                $title_modification = $provider->getTitleModification($called_contexts);
-                $this->replaceModification($final_title_modification, $title_modification, TitleModification::class);
-
-                $short_title_modification = $provider->getShortTitleModification($called_contexts);
-                $this->replaceModification($final_short_title_modification, $short_title_modification, ShortTitleModification::class);
-
-                $view_title_modification = $provider->getViewTitleModification($called_contexts);
-                $this->replaceModification($final_view_title_modification, $view_title_modification, ViewTitleModification::class);
-            }
-
+            $view_title_modification = $provider->getViewTitleModification($called_contexts);
+            $this->replaceModification($final_view_title_modification, $view_title_modification, ViewTitleModification::class);
         }
 
         if ($final_content_modification->hasValidModification()) {

--- a/src/GlobalScreen/Scope/Layout/Factory/ModificationFactory.php
+++ b/src/GlobalScreen/Scope/Layout/Factory/ModificationFactory.php
@@ -69,4 +69,18 @@ class ModificationFactory
     {
         return new FooterModification();
     }
+
+    public function title() : TitleModification
+    {
+        return new TitleModification();
+    }
+    public function short_title() : ShortTitleModification
+    {
+        return new ShortTitleModification();
+    }
+    public function view_title() : ViewTitleModification
+    {
+        return new ViewTitleModification();
+    }
+
 }

--- a/src/GlobalScreen/Scope/Layout/Factory/ShortTitleModification.php
+++ b/src/GlobalScreen/Scope/Layout/Factory/ShortTitleModification.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace ILIAS\GlobalScreen\Scope\Layout\Factory;
+
+/**
+ * Class ShortTitleModification
+ *
+ * @author Nils Haagen <nhaagen@concepts-and-training.de>
+ */
+class ShortTitleModification extends TitleModification
+{
+}

--- a/src/GlobalScreen/Scope/Layout/Factory/TitleModification.php
+++ b/src/GlobalScreen/Scope/Layout/Factory/TitleModification.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace ILIAS\GlobalScreen\Scope\Layout\Factory;
+
+/**
+ * Class TitleModification
+ *
+ * @author Nils Haagen <nhaagen@concepts-and-training.de>
+ */
+class TitleModification extends AbstractLayoutModification implements LayoutModification
+{
+
+    /**
+     * @inheritDoc
+     */
+    public function isFinal() : bool
+    {
+        return true;
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getClosureFirstArgumentType() : string
+    {
+        return 'string';
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getClosureReturnType() : string
+    {
+        return 'string';
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function firstArgumentAllowsNull() : bool
+    {
+        return true;
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function returnTypeAllowsNull() : bool
+    {
+        return false;
+    }
+}
+

--- a/src/GlobalScreen/Scope/Layout/Factory/ViewTitleModification.php
+++ b/src/GlobalScreen/Scope/Layout/Factory/ViewTitleModification.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace ILIAS\GlobalScreen\Scope\Layout\Factory;
+
+/**
+ * Class ShortTitleModification
+ *
+ * @author Nils Haagen <nhaagen@concepts-and-training.de>
+ */
+class ViewTitleModification extends TitleModification
+{
+}

--- a/src/GlobalScreen/Scope/Layout/ModificationHandler.php
+++ b/src/GlobalScreen/Scope/Layout/ModificationHandler.php
@@ -148,6 +148,30 @@ class ModificationHandler
     }
 
 
+    public function modifyTitleWithClosure(Closure $closure_returning_title) : void
+    {
+        $this->replaceWithAutoWiredInstance(
+            DecoratedPagePartProvider::PURPOSE_TITLE
+            , $closure_returning_title
+        );
+    }
+    public function modifyShortTitleWithClosure(Closure $closure_returning_short_title) : void
+    {
+        $this->replaceWithAutoWiredInstance(
+            DecoratedPagePartProvider::PURPOSE_SHORTTITLE
+            , $closure_returning_short_title
+        );
+    }
+    public function modifyViewTitleWithClosure(Closure $closure_returning_view_title) : void
+    {
+        $this->replaceWithAutoWiredInstance(
+            DecoratedPagePartProvider::PURPOSE_VIEWTITLE
+            , $closure_returning_view_title
+        );
+    }
+
+
+
     /**
      * @param string  $interface
      * @param Closure $closure

--- a/src/GlobalScreen/Scope/Layout/ModificationHandler.php
+++ b/src/GlobalScreen/Scope/Layout/ModificationHandler.php
@@ -154,6 +154,9 @@ class ModificationHandler
      */
     private function replaceWithAutoWiredInstance(string $interface, Closure $closure) : void
     {
+        //var_dump($closure);
+        //var_dump('--------------------------------------------------');
+
         $this->current_page_part_provider = new DecoratedPagePartProvider($this->current_page_part_provider, $closure, $interface);
     }
 }

--- a/src/GlobalScreen/Scope/Layout/ModificationHandler.php
+++ b/src/GlobalScreen/Scope/Layout/ModificationHandler.php
@@ -178,9 +178,6 @@ class ModificationHandler
      */
     private function replaceWithAutoWiredInstance(string $interface, Closure $closure) : void
     {
-        //var_dump($closure);
-        //var_dump('--------------------------------------------------');
-
         $this->current_page_part_provider = new DecoratedPagePartProvider($this->current_page_part_provider, $closure, $interface);
     }
 }

--- a/src/GlobalScreen/Scope/Layout/Provider/AbstractModificationProvider.php
+++ b/src/GlobalScreen/Scope/Layout/Provider/AbstractModificationProvider.php
@@ -12,6 +12,9 @@ use ILIAS\GlobalScreen\Scope\Layout\Factory\PageBuilderModification;
 use ILIAS\GlobalScreen\Scope\Tool\Factory\ToolFactory;
 use ILIAS\GlobalScreen\ScreenContext\Stack\CalledContexts;
 use ILIAS\GlobalScreen\ScreenContext\Stack\ContextCollection;
+use ILIAS\GlobalScreen\Scope\Layout\Factory\TitleModification;
+use ILIAS\GlobalScreen\Scope\Layout\Factory\ShortTitleModification;
+use ILIAS\GlobalScreen\Scope\Layout\Factory\ViewTitleModification;
 
 /**
  * Class AbstractModificationProvider
@@ -100,6 +103,30 @@ abstract class AbstractModificationProvider extends AbstractProvider implements 
      * @inheritDoc
      */
     public function getPageBuilderDecorator(CalledContexts $screen_context_stack) : ?PageBuilderModification
+    {
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getTitleModification(CalledContexts $screen_context_stack) : ?TitleModification
+    {
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getShortTitleModification(CalledContexts $screen_context_stack) : ?ShortTitleModification
+    {
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getViewTitleModification(CalledContexts $screen_context_stack) : ?ViewTitleModification
     {
         return null;
     }

--- a/src/GlobalScreen/Scope/Layout/Provider/ModificationProvider.php
+++ b/src/GlobalScreen/Scope/Layout/Provider/ModificationProvider.php
@@ -10,6 +10,9 @@ use ILIAS\GlobalScreen\Scope\Layout\Factory\MetaBarModification;
 use ILIAS\GlobalScreen\Scope\Layout\Factory\PageBuilderModification;
 use ILIAS\GlobalScreen\ScreenContext\ScreenContextAwareProvider;
 use ILIAS\GlobalScreen\ScreenContext\Stack\CalledContexts;
+use ILIAS\GlobalScreen\Scope\Layout\Factory\TitleModification;
+use ILIAS\GlobalScreen\Scope\Layout\Factory\ShortTitleModification;
+use ILIAS\GlobalScreen\Scope\Layout\Factory\ViewTitleModification;
 
 /**
  * Interface ModificationProvider
@@ -73,4 +76,26 @@ interface ModificationProvider extends Provider, ScreenContextAwareProvider
      * @return PageBuilderModification|null
      */
     public function getPageBuilderDecorator(CalledContexts $screen_context_stack) : ?PageBuilderModification;
+
+    /**
+     * @param CalledContexts $screen_context_stack
+     *
+     * @return TitleModification|null
+     */
+    public function getTitleModification(CalledContexts $screen_context_stack) : ?TitleModification;
+
+    /**
+     * @param CalledContexts $screen_context_stack
+     *
+     * @return ShortTitleModification|null
+     */
+    public function getShortTitleModification(CalledContexts $screen_context_stack) : ?ShortTitleModification;
+
+    /**
+     * @param CalledContexts $screen_context_stack
+     *
+     * @return ViewTitleModification|null
+     */
+    public function getViewTitleModification(CalledContexts $screen_context_stack) : ?ViewTitleModification;
+
 }

--- a/src/GlobalScreen/Scope/Layout/Provider/PagePart/DecoratedPagePartProvider.php
+++ b/src/GlobalScreen/Scope/Layout/Provider/PagePart/DecoratedPagePartProvider.php
@@ -17,6 +17,9 @@ use ILIAS\UI\Component\MainControls\MetaBar;
  */
 class DecoratedPagePartProvider implements PagePartProvider
 {
+    const PURPOSE_TITLE = 'ptitle';
+    const PURPOSE_SHORTTITLE = 'stitle';
+    const PURPOSE_VIEWTITLE = 'vtitle';
 
     /**
      * @var PagePartProvider
@@ -116,5 +119,29 @@ class DecoratedPagePartProvider implements PagePartProvider
     public function getFooter() : ?Footer
     {
         return $this->getDecoratedOrOriginal(Footer::class, $this->original->getFooter());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getTitle() : string
+    {
+        return $this->getDecoratedOrOriginal(self::PURPOSE_TITLE, $this->original->getTitle());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getShortTitle() : string
+    {
+        return $this->getDecoratedOrOriginal(self::PURPOSE_SHORTTITLE, $this->original->getShortTitle());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getViewTitle() : string
+    {
+        return $this->getDecoratedOrOriginal(self::PURPOSE_VIEWTITLE, $this->original->getViewTitle());
     }
 }

--- a/src/GlobalScreen/Scope/Layout/Provider/PagePart/PagePartProvider.php
+++ b/src/GlobalScreen/Scope/Layout/Provider/PagePart/PagePartProvider.php
@@ -49,4 +49,8 @@ interface PagePartProvider
      * @return Footer|null
      */
     public function getFooter() : ?Footer;
+
+    public function getTitle() : string;
+    public function getShortTitle() : string;
+    public function getViewTitle() : string;
 }

--- a/src/GlobalScreen/Scope/Layout/Provider/PagePart/StandardPagePartProvider.php
+++ b/src/GlobalScreen/Scope/Layout/Provider/PagePart/StandardPagePartProvider.php
@@ -173,4 +173,29 @@ class StandardPagePartProvider implements PagePartProvider
     {
         return $this->ui->factory()->mainControls()->footer([]);
     }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getTitle() : string
+    {
+        return 'title';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getShortTitle() : string
+    {
+        return 'short';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getViewTitle() : string
+    {
+        return 'view';
+    }
 }

--- a/src/UI/Component/Layout/Page/Factory.php
+++ b/src/UI/Component/Layout/Page/Factory.php
@@ -23,7 +23,11 @@ interface Factory
      *     content. "Content" in this case is the part of the page that is
      *     not Mainbar, Metabar, Footer or Locator, but e.g. the Repository-Listing,
      *     an object's view or edit form, etc.
-     *     The locator (in form of breadcrumbs),the logo and title are optional.
+     *     The locator (in form of breadcrumbs), the logo and titles are optional.
+     *     Finally, there are short- and view title. The short title is usually used
+     *     to identify the installation of ILIAS, while the view-title gives a very
+     *     short  reference to the current view. Both short title and view title are
+     *     put into the title-tag of the page so they show up in the browser's tab.
      *
      * featurewiki:
      *   - Desktop: https://docu.ilias.de/goto_docu_wiki_wpage_4563_1357.html
@@ -36,6 +40,9 @@ interface Factory
      *     3: The Standard Page MUST be rendered with a Mainbar.
      *     4: The Standard Page SHOULD be rendered with Breadcrumbs.
      *     5: The Standard Page SHOULD be rendered with a Logo.
+     *     6: The Standard Page SHOULD be rendered with a Title.
+     *     7: The Standard Page's short title SHOULD reference the current ILIAS installation.
+     *     8: The Standard Page's view title SHOULD give a good hint to the current view.
      *
      * ----
      *
@@ -54,6 +61,8 @@ interface Factory
         Breadcrumbs $locator = null,
         Image $logo = null,
         MainControls\Footer $footer = null,
-        string $title = ''
+        string $title = '',
+        string $short_title = '',
+        string $view_title = ''
     ) : Standard;
 }

--- a/src/UI/Component/Layout/Page/Standard.php
+++ b/src/UI/Component/Layout/Page/Standard.php
@@ -79,4 +79,13 @@ interface Standard extends Page, JavaScriptBindable
     public function withTitle(string $title) : Standard;
 
     public function getTitle() : string;
+
+    public function withShortTitle(string $title) : Standard;
+
+    public function getShortTitle() : string;
+
+    public function withViewTitle(string $title) : Standard;
+
+    public function getViewTitle() : string;
+
 }

--- a/src/UI/Implementation/Component/Layout/Page/Factory.php
+++ b/src/UI/Implementation/Component/Layout/Page/Factory.php
@@ -10,7 +10,6 @@ use ILIAS\UI\Component\MainControls;
 
 class Factory implements Page\Factory
 {
-
     /**
      * @inheritdoc
      */
@@ -21,8 +20,20 @@ class Factory implements Page\Factory
         Breadcrumbs $locator = null,
         Image $logo = null,
         MainControls\Footer $footer = null,
-        string $title = ''
+        string $title = '',
+        string $short_title = '',
+        string $view_title = ''
     ) : Page\Standard {
-        return new Standard($content, $metabar, $mainbar, $locator, $logo, $footer, $title);
+        return new Standard(
+            $content,
+            $metabar,
+            $mainbar,
+            $locator,
+            $logo,
+            $footer,
+            $title,
+            $short_title,
+            $view_title
+        );
     }
 }

--- a/src/UI/Implementation/Component/Layout/Page/Renderer.php
+++ b/src/UI/Implementation/Component/Layout/Page/Renderer.php
@@ -53,6 +53,8 @@ class Renderer extends AbstractComponentRenderer
         }
 
         $tpl->setVariable("TITLE", $component->getTitle());
+        $tpl->setVariable("SHORT_TITLE", $component->getShortTitle());
+        $tpl->setVariable("VIEW_TITLE", $component->getViewTitle());
         $tpl->setVariable('CONTENT', $default_renderer->render($component->getContent()));
 
         if ($component->hasFooter()) {

--- a/src/UI/Implementation/Component/Layout/Page/Standard.php
+++ b/src/UI/Implementation/Component/Layout/Page/Standard.php
@@ -45,6 +45,14 @@ class Standard implements Page\Standard
      */
     private $footer;
     /**
+     * @var string
+     */
+    private $short_title;
+    /**
+     * @var string
+     */
+    private $view_title;
+    /**
      * @var	string
      */
     private $title;
@@ -56,7 +64,6 @@ class Standard implements Page\Standard
      * @var    bool
      */
     private $ui_demo = false;
-
 
     /**
      * Standard constructor.
@@ -75,7 +82,9 @@ class Standard implements Page\Standard
         Breadcrumbs $locator = null,
         Image $logo = null,
         Footer $footer = null,
-        string $title = ''
+        string $title = '',
+        string $short_title = '',
+        string $view_title = ''
     ) {
         $allowed = [\ILIAS\UI\Component\Component::class];
         $this->checkArgListElements("content", $content, $allowed);
@@ -87,6 +96,8 @@ class Standard implements Page\Standard
         $this->logo = $logo;
         $this->footer = $footer;
         $this->title = $title;
+        $this->short_title = $short_title;
+        $this->view_title = $view_title;
     }
 
     /**
@@ -266,5 +277,30 @@ class Standard implements Page\Standard
     public function getTitle() : string
     {
         return $this->title;
+    }
+
+    public function withShortTitle(string $title) : Page\Standard
+    {
+        $clone = clone $this;
+        $clone->short_title = $title;
+        return $clone;
+    }
+
+    public function getShortTitle() : string
+    {
+        return $this->short_title;
+    }
+
+
+    public function withViewTitle(string $title) : Page\Standard
+    {
+        $clone = clone $this;
+        $clone->view_title = $title;
+        return $clone;
+    }
+
+    public function getViewTitle() : string
+    {
+        return $this->view_title;
     }
 }

--- a/src/UI/examples/Layout/Page/Standard/ui.php
+++ b/src/UI/examples/Layout/Page/Standard/ui.php
@@ -40,7 +40,9 @@ if ($_GET['new_ui'] == '1') {
         $breadcrumbs,
         $logo,
         $footer,
-        'UI PAGE DEMO'
+        'UI PAGE DEMO', //page title
+        'TRUNK -', //short title
+        'Std. Page Demo' //view title
     )
     ->withUIDemo(true);
     ;

--- a/src/UI/examples/Layout/Page/Standard/ui.php
+++ b/src/UI/examples/Layout/Page/Standard/ui.php
@@ -41,7 +41,7 @@ if ($_GET['new_ui'] == '1') {
         $logo,
         $footer,
         'UI PAGE DEMO', //page title
-        'TRUNK -', //short title
+        'ILIAS', //short title
         'Std. Page Demo' //view title
     )
     ->withUIDemo(true);

--- a/src/UI/templates/default/Layout/tpl.standardpage.html
+++ b/src/UI/templates/default/Layout/tpl.standardpage.html
@@ -9,6 +9,8 @@
 	<base href="{BASE}" />
 	<!-- END base -->
 
+	<title>{SHORT_TITLE} {VIEW_TITLE}</title>
+
 	<style type="text/css">
 		{CSS_INLINE}
 	</style>

--- a/src/UI/templates/default/Layout/tpl.standardpage.html
+++ b/src/UI/templates/default/Layout/tpl.standardpage.html
@@ -9,7 +9,7 @@
 	<base href="{BASE}" />
 	<!-- END base -->
 
-	<title>{SHORT_TITLE} {VIEW_TITLE}</title>
+	<title>{SHORT_TITLE}: {VIEW_TITLE}</title>
 
 	<style type="text/css">
 		{CSS_INLINE}

--- a/tests/UI/Component/Layout/Page/StandardPageTest.php
+++ b/tests/UI/Component/Layout/Page/StandardPageTest.php
@@ -115,4 +115,21 @@ class StandardPageTest extends ILIAS_UI_TestBase
             $this->stdpage->withTitle($title)->getTitle()
         );
     }
+    public function testWithShortTitle()
+    {
+        $title = 'some short title';
+        $this->assertEquals(
+            $title,
+            $this->stdpage->withShortTitle($title)->getShortTitle()
+        );
+    }
+    public function testWithViewTitle()
+    {
+        $title = 'some view title';
+        $this->assertEquals(
+            $title,
+            $this->stdpage->withViewTitle($title)->getViewTitle()
+        );
+    }
+
 }


### PR DESCRIPTION
Add page-, short- and view title to Standard Page.
![Bildschirmfoto_2019-10-16_19-11-09](https://user-images.githubusercontent.com/3328364/66942673-dd719c80-f049-11e9-848b-bb7a29ffd09a.png)
![Bildschirmfoto_2019-10-16_19-10-47](https://user-images.githubusercontent.com/3328364/66942683-e5314100-f049-11e9-8896-ee609da077af.png)

The page title is shown in the content (here, on the metabar), while the actual title-tag is short title + view title.
[Rules are here:](https://github.com/ILIAS-eLearning/ILIAS/pull/2249/files#diff-ddc95be6d038d5279fc6125f12f14745)