### PR TITLE
Draft for the legacy component to return custom js code

### DIFF
--- a/src/UI/Component/Legacy/Legacy.php
+++ b/src/UI/Component/Legacy/Legacy.php
@@ -22,6 +22,7 @@ interface Legacy extends \ILIAS\UI\Component\Component
     /**
      * Get a legacy component like this, but with an additional signal with custom JavaScript code
      *
+     * @deprecated Should only be used to connect legacy components. Will be removed in the future. Use at your own risk
      * @param $signal_name
      * @param $js_code
      * @return Legacy
@@ -31,6 +32,7 @@ interface Legacy extends \ILIAS\UI\Component\Component
     /**
      * Get signal with custom JavaScript code
      *
+     * @deprecated Should only be used to connect legacy components. Will be removed in the future. Use at your own risk
      * @param $signal_name
      * @throws \InvalidArgumentException
      * @return Signal

--- a/src/UI/Component/Legacy/Legacy.php
+++ b/src/UI/Component/Legacy/Legacy.php
@@ -16,4 +16,21 @@ interface Legacy extends \ILIAS\UI\Component\Component
      * @return	string
      */
     public function getContent();
+
+    /**
+     * Get a legacy component like this, but with an additional signal with custom JavaScript code
+     *
+     * @param $signal_name
+     * @param $js_code
+     * @return Legacy
+     */
+    public function withCustomSignal(string $signal_name, string $js_code) : Legacy;
+
+    /**
+     * Get signal with custom JavaScript code
+     *
+     * @param $signal_name
+     * @return \ILIAS\UI\Component\Signal
+     */
+    public function getCustomSignal(string $signal_name) : \ILIAS\UI\Component\Signal;
 }

--- a/src/UI/Component/Legacy/Legacy.php
+++ b/src/UI/Component/Legacy/Legacy.php
@@ -32,7 +32,8 @@ interface Legacy extends \ILIAS\UI\Component\Component
      * Get signal with custom JavaScript code
      *
      * @param $signal_name
-     * @return Signal|null
+     * @throws \InvalidArgumentException
+     * @return Signal
      */
     public function getCustomSignal(string $signal_name);
 }

--- a/src/UI/Component/Legacy/Legacy.php
+++ b/src/UI/Component/Legacy/Legacy.php
@@ -4,6 +4,8 @@
 
 namespace ILIAS\UI\Component\Legacy;
 
+use ILIAS\UI\Component\Signal;
+
 /**
  * Interface Legacy
  * @package ILIAS\UI\Component\Legacy
@@ -30,7 +32,7 @@ interface Legacy extends \ILIAS\UI\Component\Component
      * Get signal with custom JavaScript code
      *
      * @param $signal_name
-     * @return \ILIAS\UI\Component\Signal
+     * @return Signal|null
      */
-    public function getCustomSignal(string $signal_name) : \ILIAS\UI\Component\Signal;
+    public function getCustomSignal(string $signal_name);
 }

--- a/src/UI/Implementation/Component/Legacy/Legacy.php
+++ b/src/UI/Implementation/Component/Legacy/Legacy.php
@@ -5,7 +5,9 @@
 namespace ILIAS\UI\Implementation\Component\Legacy;
 
 use ILIAS\UI\Component as C;
+use ILIAS\UI\Component\Signal;
 use ILIAS\UI\Implementation\Component\ComponentHelper;
+use ILIAS\UI\NotImplementedException;
 
 /**
  * Class Legacy
@@ -38,5 +40,21 @@ class Legacy implements C\Legacy\Legacy
     public function getContent()
     {
         return $this->content;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function withCustomSignal(string $signal_name, string $js_code) : \ILIAS\UI\Component\Legacy\Legacy
+    {
+        throw new NotImplementedException("withCustomSignal is not implemented yet");
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getCustomSignal(string $signal_name) : Signal
+    {
+        throw new NotImplementedException("getCustomSignal is not implemented yet");
     }
 }


### PR DESCRIPTION
With this PR, I suggest to add the ability to the legacy component to return custom signals.

To add a custom signal to a legacy component, call `withCustomSignal($signal_name, $js_code)`. Since there can be multiple custom signals in one legacy component, give each signal an id, which is unique in this component. The second parameter is the JavaScript-Code, which should be executed when the signal is triggered.

`getCustomSignal($signal_name)` returns a signal with the custom JavaScript-code in it. If there is no custom signal with the given name, `null` will be returned.