### PR TITLE
Setup: added two new objective types

### DIFF
--- a/src/Setup/AchievementTracker.php
+++ b/src/Setup/AchievementTracker.php
@@ -1,0 +1,19 @@
+<?php
+
+/* Copyright (c) 2019 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Setup;
+
+use ILIAS\UI;
+
+/**
+ * Tracks the achievement of objectives.
+ *
+ * Most Objectives should be able to determine themselves if they (still) need
+ * to be achieved or not. For some Objectives this might not be possible, this
+ * is where this helps out.
+ */
+interface AchievementTracker {
+	public function trackAchievementOf(Objective $objective) : void;
+	public function isAchieved(Objective $objective) : bool;
+}

--- a/src/Setup/AdminConfirmedObjective.php
+++ b/src/Setup/AdminConfirmedObjective.php
@@ -54,14 +54,14 @@ class AdminConfirmedObjective implements Objective {
 	 * @inheritdoc
 	 */
 	public function achieve(Environment $environment) : Environment {
-		$confirmation_requester = $environment->getResource(Environment::RESOURCE_CONFIRMATION_REQUESTER);
+		$admin_interaction = $environment->getResource(Environment::RESOURCE_ADMIN_INTERACTION);
 		$achievement_tracker = $environment->getResource(Environment::RESOURCE_ACHIEVEMENT_TRACKER);
 
 		if ($achievement_tracker->isAchieved($this)) {
 			return $environment;
 		}
 
-		if(!$confirmation_requester->confirmOrDeny($this->message)) {
+		if(!$admin_interaction->confirmOrDeny($this->message)) {
 			throw new UnachievableException(
 				"The admin did not confirm the message."
 			);

--- a/src/Setup/AdminConfirmedObjective.php
+++ b/src/Setup/AdminConfirmedObjective.php
@@ -55,12 +55,19 @@ class AdminConfirmedObjective implements Objective {
 	 */
 	public function achieve(Environment $environment) : Environment {
 		$confirmation_requester = $environment->getResource(Environment::RESOURCE_CONFIRMATION_REQUESTER);
+		$achievement_tracker = $environment->getResource(Environment::RESOURCE_ACHIEVEMENT_TRACKER);
+
+		if ($achievement_tracker->isAchieved($this)) {
+			return $environment;
+		}
 
 		if(!$confirmation_requester->confirmOrDeny($this->message)) {
 			throw new UnachievableException(
 				"The admin did not confirm the message."
 			);
 		}
+
+		$achievement_tracker->trackAchievementOf($this);
 
 		return $environment;
 	}

--- a/src/Setup/AdminConfirmedObjective.php
+++ b/src/Setup/AdminConfirmedObjective.php
@@ -1,0 +1,67 @@
+<?php
+
+/* Copyright (c) 2019 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Setup;
+
+use ILIAS\UI;
+
+/**
+ * An admin needs to confirm something to achieve this objective.
+ */
+class AdminConfirmedObjective implements Objective {
+	/**
+	 * @var string
+	 */
+	protected $message;
+
+	public function __construct(string $message) {
+		$this->message = $message;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getHash() : string {
+		return hash(
+			"sha256",
+			get_class($this)."::".$this->message
+		);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getLabel() : string {
+		return "Get a confirmation from admin.";
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function isNotable() : bool {
+		return false;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getPreconditions(Environment $environment) : array {
+		return [];
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function achieve(Environment $environment) : Environment {
+		$confirmation_requester = $environment->getResource(Environment::RESOURCE_CONFIRMATION_REQUESTER);
+
+		if(!$confirmation_requester->confirmOrDeny($this->message)) {
+			throw new UnachievableException(
+				"The admin did not confirm the message."
+			);
+		}
+
+		return $environment;
+	}
+}

--- a/src/Setup/AdminInteraction.php
+++ b/src/Setup/AdminInteraction.php
@@ -5,8 +5,10 @@
 namespace ILIAS\Setup;
 
 /**
- * Prompts a user to confirm or deny a certain message.
+ * This defines ways in which objectives may interact with admins during the
+ * setup.
  */
-interface ConfirmationRequester {
+interface AdminInteraction {
+	public function inform(string $message) : void;
 	public function confirmOrDeny(string $message) : bool;
 }

--- a/src/Setup/CLI/IOWrapper.php
+++ b/src/Setup/CLI/IOWrapper.php
@@ -86,6 +86,17 @@ class IOWrapper implements AdminInteraction {
 		}
 	}
 
+	public function failedLastObjective() {
+		// Always show label of failed objectives.
+		if ($this->output_in_objective || !$this->last_objective_was_notable) {
+			$this->startObjective($this->last_objective_label, true);
+		}
+
+		if ($this->showLastObjectiveLabel()) {
+			$this->style->write("[<fg=red>FAILED</>]\n");
+		}
+	}
+
 	protected function outputInObjective() : void {
 		if (!$this->output_in_objective && $this->showLastObjectiveLabel()) {
 			$this->output_in_objective = true;

--- a/src/Setup/CLI/IOWrapper.php
+++ b/src/Setup/CLI/IOWrapper.php
@@ -1,0 +1,38 @@
+<?php
+
+/* Copyright (c) 2019 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Setup\CLI;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Wrapper around symfonies input and output facilities to provide just the
+ * functionality required for the ILIAS-setup.
+ */
+class IOWrapper {
+	/**
+	 * @var	InputInterface
+	 */
+	protected $in;
+
+	/**
+	 * @var OutputInterface
+	 */
+	protected $out;
+
+	public function __construct(InputInterface $in, OutputInterface $out) {
+		$this->in = $in;
+		$this->out = $out;
+	}
+
+	public function startObjective(string $label, bool $is_notable) {
+		if ($is_notable || $this->out->isVeryVerbose()  || $this->out->isDebug()) {
+			$this->out->writeln($label);
+		}
+	}
+
+	public function finishedLastObjective() {
+	}
+}

--- a/src/Setup/CLI/IOWrapper.php
+++ b/src/Setup/CLI/IOWrapper.php
@@ -4,7 +4,7 @@
 
 namespace ILIAS\Setup\CLI;
 
-use ILIAS\Setup\ConfirmationRequester;
+use ILIAS\Setup\AdminInteraction;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  * Wrapper around symfonies input and output facilities to provide just the
  * functionality required for the ILIAS-setup.
  */
-class IOWrapper implements ConfirmationRequester {
+class IOWrapper implements AdminInteraction {
 	const LABEL_WIDTH = 75;
 	const ELLIPSIS = "...";
 
@@ -53,6 +53,20 @@ class IOWrapper implements ConfirmationRequester {
 		$this->style = new SymfonyStyle($in, $out);
 	}
 
+	// Implementation of AdminInteraction
+
+	public function inform(string $message) : void {
+		$this->outputInObjective();
+		$this->style->note($message);
+	}
+
+	public function confirmOrDeny(string $message) : bool {
+		$this->outputInObjective();
+		return $this->style->confirm($message, false);
+	}
+
+	// For CLI-Setup
+
 	public function startObjective(string $label, bool $is_notable) {
 		$this->last_objective_was_notable = $is_notable;
 		$this->last_objective_label = $label;
@@ -70,11 +84,6 @@ class IOWrapper implements ConfirmationRequester {
 		if ($this->showLastObjectiveLabel()) {
 			$this->style->write("[<fg=green>OK</>]\n");
 		}
-	}
-
-	public function confirmOrDeny(string $message) : bool {
-		$this->outputInObjective();
-		return $this->style->confirm($message, false);
 	}
 
 	protected function outputInObjective() : void {

--- a/src/Setup/CLI/IOWrapper.php
+++ b/src/Setup/CLI/IOWrapper.php
@@ -6,12 +6,16 @@ namespace ILIAS\Setup\CLI;
 
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * Wrapper around symfonies input and output facilities to provide just the
  * functionality required for the ILIAS-setup.
  */
 class IOWrapper {
+	const LABEL_WIDTH = 75;
+	const ELLIPSIS = "...";
+
 	/**
 	 * @var	InputInterface
 	 */
@@ -22,17 +26,38 @@ class IOWrapper {
 	 */
 	protected $out;
 
+	/**
+	 * @var	SymfonyStyle
+	 */
+	protected $style;
+
+	/**
+	 * @var bool
+	 */
+	protected $last_objective_was_notable = false;
+
+	/**
+	 * @var string
+	 */
+	protected $last_objective_label = "";
+
 	public function __construct(InputInterface $in, OutputInterface $out) {
 		$this->in = $in;
 		$this->out = $out;
+		$this->style = new SymfonyStyle($in, $out);
 	}
 
 	public function startObjective(string $label, bool $is_notable) {
+		$this->last_command_was_notable = $is_notable;
+		$this->last_objective_label = $label;
 		if ($is_notable || $this->out->isVeryVerbose()  || $this->out->isDebug()) {
-			$this->out->writeln($label);
+			$this->style->write(str_pad($label."...", self::LABEL_WIDTH));
 		}
 	}
 
 	public function finishedLastObjective() {
+		if ($this->last_command_was_notable || $this->out->isVeryVerbose()  || $this->out->isDebug()) {
+			$this->style->write("[<fg=green>OK</>]\n");
+		}
 	}
 }

--- a/src/Setup/CLI/InstallCommand.php
+++ b/src/Setup/CLI/InstallCommand.php
@@ -57,7 +57,7 @@ class InstallCommand extends Command {
 
 		$goal = $this->agent->getInstallObjective($config);
 		$environment = new ArrayEnvironment([
-			Environment::RESOURCE_CONFIRMATION_REQUESTER => $io,
+			Environment::RESOURCE_ADMIN_INTERACTION => $io,
 			// TODO: This needs to be implemented correctly...
 			Environment::RESOURCE_ACHIEVEMENT_TRACKER => new class implements AchievementTracker {
 				public function trackAchievementOf(Objective $objective) : void {}

--- a/src/Setup/CLI/InstallCommand.php
+++ b/src/Setup/CLI/InstallCommand.php
@@ -3,6 +3,7 @@
 
 namespace ILIAS\Setup\CLI;
 
+use ILIAS\Setup\UnachievableException;
 use ILIAS\Setup\Agent;
 use ILIAS\Setup\AgentCollection;
 use ILIAS\Setup\AchievementTracker;
@@ -75,9 +76,14 @@ class InstallCommand extends Command {
 		while($goals->valid()) {
 			$current = $goals->current();
 			$io->startObjective($current->getLabel(), $current->isNotable());
-			$environment = $current->achieve($environment);
-			$io->finishedLastObjective($current->getLabel(), $current->isNotable());
-			$goals->setEnvironment($environment);
+			try {
+				$environment = $current->achieve($environment);
+				$io->finishedLastObjective($current->getLabel(), $current->isNotable());
+				$goals->setEnvironment($environment);
+			}
+			catch (UnachievableException $e) {
+				$io->failedLastObjective($current->getLabel());
+			}
 			$goals->next();
 		}
 	}

--- a/src/Setup/CLI/InstallCommand.php
+++ b/src/Setup/CLI/InstallCommand.php
@@ -60,12 +60,12 @@ class InstallCommand extends Command {
 		}
 
 		$goals = new ObjectiveIterator($environment, $goal);
+		$io = new IOWrapper($input, $output);
 		while($goals->valid()) {
 			$current = $goals->current();
-			if ($current->isNotable() || $output->isVeryVerbose()  || $output->isDebug()) {
-				$output->writeln($current->getLabel());
-			}
+			$io->startObjective($current->getLabel(), $current->isNotable());
 			$environment = $current->achieve($environment);
+			$io->finishedLastObjective($current->getLabel(), $current->isNotable());
 			$goals->setEnvironment($environment);
 			$goals->next();
 		}

--- a/src/Setup/ConfirmationRequester.php
+++ b/src/Setup/ConfirmationRequester.php
@@ -1,0 +1,12 @@
+<?php
+
+/* Copyright (c) 2019 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Setup;
+
+/**
+ * Prompts a user to confirm or deny a certain message.
+ */
+interface ConfirmationRequester {
+	public function confirmOrDeny(string $message) : bool;
+}

--- a/src/Setup/Environment.php
+++ b/src/Setup/Environment.php
@@ -12,6 +12,7 @@ interface Environment {
 	// We define some resources that will definitely be requried. We allow for
 	// new identifiers, though, to be open for extensions and the future.
 	const RESOURCE_DATABASE = "resource_database";
+	const RESOURCE_CONFIRMATION_REQUESTER = "resource_confirmation_requester";
 
 	/**
 	 * Consumers of this method should check if the result is what they expect,

--- a/src/Setup/Environment.php
+++ b/src/Setup/Environment.php
@@ -13,6 +13,7 @@ interface Environment {
 	// new identifiers, though, to be open for extensions and the future.
 	const RESOURCE_DATABASE = "resource_database";
 	const RESOURCE_CONFIRMATION_REQUESTER = "resource_confirmation_requester";
+	const RESOURCE_ACHIEVEMENT_TRACKER = "resource_achievement_tracker";
 
 	/**
 	 * Consumers of this method should check if the result is what they expect,

--- a/src/Setup/Environment.php
+++ b/src/Setup/Environment.php
@@ -12,7 +12,7 @@ interface Environment {
 	// We define some resources that will definitely be requried. We allow for
 	// new identifiers, though, to be open for extensions and the future.
 	const RESOURCE_DATABASE = "resource_database";
-	const RESOURCE_CONFIRMATION_REQUESTER = "resource_confirmation_requester";
+	const RESOURCE_ADMIN_INTERACTION = "resource_admin_interaction";
 	const RESOURCE_ACHIEVEMENT_TRACKER = "resource_achievement_tracker";
 
 	/**

--- a/src/Setup/ExternalConditionObjective.php
+++ b/src/Setup/ExternalConditionObjective.php
@@ -1,0 +1,89 @@
+<?php
+
+/* Copyright (c) 2019 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Setup;
+
+use ILIAS\UI;
+
+/**
+ * A condition that can't be met by ILIAS itself needs to be met by some external
+ * means.
+ *
+ * ATTENTION: Two ExternalConditionObjectives are considered to be identical if the
+ * label is identical. I.e., getHash does not use the actual condition or the message.
+ */
+class ExternalConditionObjective implements Objective {
+	/**
+	 * @var string
+	 */
+	protected $label;
+
+	/**
+	 * @var callable
+	 */
+	protected $condition;
+
+	/**
+	 * @var string|null
+	 */
+	protected $message;
+
+	/**
+	 * @param callable $condition needs to be function from Environment to bool.
+	 */
+	public function __construct(string $label, callable $condition, string $message = null) {
+		$this->condition = $condition;
+		$this->label = $label;
+		$this->message = $message;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getHash() : string {
+		return hash(
+			"sha256",
+			get_class($this)."::".$this->label
+		);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getLabel() : string {
+		return $this->label;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function isNotable() : bool {
+		return true;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getPreconditions(Environment $environment) : array {
+		return [];
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function achieve(Environment $environment) : Environment {
+		if (($this->condition)($environment)) {
+			return $environment;
+		}
+
+		if ($this->message) {
+			$admin_interaction = $environment->getResource(Environment::RESOURCE_ADMIN_INTERACTION);
+			$admin_interaction->inform($this->message);
+		}
+
+		throw new UnachievableException(
+			"An external condition was not met: {$this->label}"
+		);
+	}
+}

--- a/src/Setup/ObjectiveIterator.php
+++ b/src/Setup/ObjectiveIterator.php
@@ -42,6 +42,11 @@ class ObjectiveIterator implements \Iterator {
 	protected $returned;
 
 	/**
+	 * @var	array<string, bool>
+	 */
+	protected $failed;
+
+	/**
 	 * @var array<string, string[]>
 	 */
 	protected $reverse_dependencies;
@@ -57,10 +62,21 @@ class ObjectiveIterator implements \Iterator {
 		$this->environment = $environment;
 	}
 
+	public function markAsFailed(Objective $objective) {
+		if (!isset($this->returned[$objective->getHash()])) {
+			throw new \LogicException(
+				"You may only mark objectives as failed that have been returned by this iterator."
+			);
+		}
+
+		$this->failed[$objective->getHash()] = true;
+	}
+
 	public function rewind() {
 		$this->stack = [$this->objective];
 		$this->current = null; 
 		$this->returned = [];
+		$this->failed = [];
 		$this->reverse_dependencies = [];
 		$this->next();
 	}
@@ -89,10 +105,27 @@ class ObjectiveIterator implements \Iterator {
 		$preconditions = array_filter(
 			$cur->getPreconditions($this->environment),
 			function ($p) {
-				return !isset($this->returned[$p->getHash()]);
+				$h = $p->getHash();
+				return !isset($this->returned[$h]) || isset($this->failed[$h]);
 			}
 		);
 
+		$failed_preconditions = array_filter(
+			$preconditions,
+			function ($p) {
+				return isset($this->failed[$p->getHash()]);
+			}
+		);
+
+		// We only have preconditions left that we know to have failed.
+		if (count($preconditions) !== 0
+		&& count($preconditions) === count($failed_preconditions)) {
+			throw new UnachievableException(
+				"Objective only has failed preconditions."
+			);
+		}
+
+		// No preconditions open, we can proceed with the objective.
 		if (count($preconditions) === 0) {
 			$this->returned[$hash] = true;
 			$this->current = $cur;

--- a/src/Setup/ObjectiveIterator.php
+++ b/src/Setup/ObjectiveIterator.php
@@ -53,10 +53,7 @@ class ObjectiveIterator implements \Iterator {
 		$this->rewind();
 	}
 
-	/**
-	 * @return void
-	 */
-	public function setEnvironment(Environment $environment) {
+	public function setEnvironment(Environment $environment) : void {
 		$this->environment = $environment;
 	}
 

--- a/tests/Setup/AdminConfirmedObjectiveTest.php
+++ b/tests/Setup/AdminConfirmedObjectiveTest.php
@@ -38,17 +38,17 @@ class AdminConfirmedObjectiveTest extends \PHPUnit\Framework\TestCase {
 
 	public function testAlreadyAchieved() {
 		$env = $this->createMock(Setup\Environment::class);
-		$confirmation_requester = $this->createMock(Setup\ConfirmationRequester::class);
+		$admin_interaction = $this->createMock(Setup\AdminInteraction::class);
 		$achievement_tracker = $this->createMock(Setup\AchievementTracker::class);
 
 		$env
 			->method("getResource")
 			->will($this->returnValueMap([
-				[Setup\Environment::RESOURCE_CONFIRMATION_REQUESTER, $confirmation_requester],
+				[Setup\Environment::RESOURCE_ADMIN_INTERACTION, $admin_interaction],
 				[Setup\Environment::RESOURCE_ACHIEVEMENT_TRACKER, $achievement_tracker]
 			]));
 
-		$confirmation_requester
+		$admin_interaction
 			->expects($this->never())
 			->method("confirmOrDeny");
 
@@ -68,17 +68,17 @@ class AdminConfirmedObjectiveTest extends \PHPUnit\Framework\TestCase {
 
 	public function testAchieveWithConfirmation() {
 		$env = $this->createMock(Setup\Environment::class);
-		$confirmation_requester = $this->createMock(Setup\ConfirmationRequester::class);
+		$admin_interaction = $this->createMock(Setup\AdminInteraction::class);
 		$achievement_tracker = $this->createMock(Setup\AchievementTracker::class);
 
 		$env
 			->method("getResource")
 			->will($this->returnValueMap([
-				[Setup\Environment::RESOURCE_CONFIRMATION_REQUESTER, $confirmation_requester],
+				[Setup\Environment::RESOURCE_ADMIN_INTERACTION, $admin_interaction],
 				[Setup\Environment::RESOURCE_ACHIEVEMENT_TRACKER, $achievement_tracker]
 			]));
 
-		$confirmation_requester
+		$admin_interaction
 			->expects($this->once())
 			->method("confirmOrDeny")
 			->with($this->message)
@@ -103,17 +103,17 @@ class AdminConfirmedObjectiveTest extends \PHPUnit\Framework\TestCase {
 		$this->expectException(Setup\UnachievableException::class);
 
 		$env = $this->createMock(Setup\Environment::class);
-		$confirmation_requester = $this->createMock(Setup\ConfirmationRequester::class);
+		$admin_interaction = $this->createMock(Setup\AdminInteraction::class);
 		$achievement_tracker = $this->createMock(Setup\AchievementTracker::class);
 
 		$env
 			->method("getResource")
 			->will($this->returnValueMap([
-				[Setup\Environment::RESOURCE_CONFIRMATION_REQUESTER, $confirmation_requester],
+				[Setup\Environment::RESOURCE_ADMIN_INTERACTION, $admin_interaction],
 				[Setup\Environment::RESOURCE_ACHIEVEMENT_TRACKER, $achievement_tracker]
 			]));
 
-		$confirmation_requester
+		$admin_interaction
 			->expects($this->once())
 			->method("confirmOrDeny")
 			->with($this->message)

--- a/tests/Setup/AdminConfirmedObjectiveTest.php
+++ b/tests/Setup/AdminConfirmedObjectiveTest.php
@@ -36,21 +36,64 @@ class AdminConfirmedObjectiveTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals([], $pre);	
 	}
 
+	public function testAlreadyAchieved() {
+		$env = $this->createMock(Setup\Environment::class);
+		$confirmation_requester = $this->createMock(Setup\ConfirmationRequester::class);
+		$achievement_tracker = $this->createMock(Setup\AchievementTracker::class);
+
+		$env
+			->method("getResource")
+			->will($this->returnValueMap([
+				[Setup\Environment::RESOURCE_CONFIRMATION_REQUESTER, $confirmation_requester],
+				[Setup\Environment::RESOURCE_ACHIEVEMENT_TRACKER, $achievement_tracker]
+			]));
+
+		$confirmation_requester
+			->expects($this->never())
+			->method("confirmOrDeny");
+
+		$achievement_tracker
+			->expects($this->once())
+			->method("isAchieved")
+			->with($this->o)
+			->willReturn(true);
+
+		$achievement_tracker
+			->expects($this->never())
+			->method("trackAchievementOf");
+
+		$res = $this->o->achieve($env);
+		$this->assertSame($env, $res);
+	}
+
 	public function testAchieveWithConfirmation() {
 		$env = $this->createMock(Setup\Environment::class);
 		$confirmation_requester = $this->createMock(Setup\ConfirmationRequester::class);
+		$achievement_tracker = $this->createMock(Setup\AchievementTracker::class);
 
 		$env
-			->expects($this->once())
 			->method("getResource")
-			->with(Setup\Environment::RESOURCE_CONFIRMATION_REQUESTER)
-			->willReturn($confirmation_requester);
+			->will($this->returnValueMap([
+				[Setup\Environment::RESOURCE_CONFIRMATION_REQUESTER, $confirmation_requester],
+				[Setup\Environment::RESOURCE_ACHIEVEMENT_TRACKER, $achievement_tracker]
+			]));
 
 		$confirmation_requester
 			->expects($this->once())
 			->method("confirmOrDeny")
 			->with($this->message)
 			->willReturn(true);
+
+		$achievement_tracker
+			->expects($this->once())
+			->method("isAchieved")
+			->with($this->o)
+			->willReturn(false);
+
+		$achievement_tracker
+			->expects($this->once())
+			->method("trackAchievementOf")
+			->with($this->o);
 
 		$res = $this->o->achieve($env);
 		$this->assertSame($env, $res);
@@ -61,18 +104,30 @@ class AdminConfirmedObjectiveTest extends \PHPUnit\Framework\TestCase {
 
 		$env = $this->createMock(Setup\Environment::class);
 		$confirmation_requester = $this->createMock(Setup\ConfirmationRequester::class);
+		$achievement_tracker = $this->createMock(Setup\AchievementTracker::class);
 
 		$env
-			->expects($this->once())
 			->method("getResource")
-			->with(Setup\Environment::RESOURCE_CONFIRMATION_REQUESTER)
-			->willReturn($confirmation_requester);
+			->will($this->returnValueMap([
+				[Setup\Environment::RESOURCE_CONFIRMATION_REQUESTER, $confirmation_requester],
+				[Setup\Environment::RESOURCE_ACHIEVEMENT_TRACKER, $achievement_tracker]
+			]));
 
 		$confirmation_requester
 			->expects($this->once())
 			->method("confirmOrDeny")
 			->with($this->message)
 			->willReturn(false);
+
+		$achievement_tracker
+			->expects($this->once())
+			->method("isAchieved")
+			->with($this->o)
+			->willReturn(false);
+
+		$achievement_tracker
+			->expects($this->never())
+			->method("trackAchievementOf");
 
 		$res = $this->o->achieve($env);
 	}

--- a/tests/Setup/AdminConfirmedObjectiveTest.php
+++ b/tests/Setup/AdminConfirmedObjectiveTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/* Copyright (c) 2019 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Tests\Setup;
+
+use ILIAS\Setup;
+
+class AdminConfirmedObjectiveTest extends \PHPUnit\Framework\TestCase {
+	public function setUp() : void {
+		$this->message = "This needs to be confirmed...";
+		$this->o = new Setup\AdminConfirmedObjective($this->message);
+	}
+
+	public function testGetHash() {
+		$this->assertIsString($this->o->getHash());
+	}
+
+	public function testHashIsDifferentForDifferentMessages() {
+		$other = new Setup\AdminConfirmedObjective("");
+		$this->assertNotEquals($this->o->getHash(), $other->getHash());
+	}
+
+	public function testGetLabel() {
+		$this->assertIsString($this->o->getLabel());
+	}
+
+	public function testIsNotable() {
+		$this->assertFalse($this->o->isNotable());
+	}
+
+	public function testGetPreconditions() {
+		$env = $this->createMock(Setup\Environment::class);
+
+		$pre = $this->o->getPreconditions($env);
+		$this->assertEquals([], $pre);	
+	}
+
+	public function testAchieveWithConfirmation() {
+		$env = $this->createMock(Setup\Environment::class);
+		$confirmation_requester = $this->createMock(Setup\ConfirmationRequester::class);
+
+		$env
+			->expects($this->once())
+			->method("getResource")
+			->with(Setup\Environment::RESOURCE_CONFIRMATION_REQUESTER)
+			->willReturn($confirmation_requester);
+
+		$confirmation_requester
+			->expects($this->once())
+			->method("confirmOrDeny")
+			->with($this->message)
+			->willReturn(true);
+
+		$res = $this->o->achieve($env);
+		$this->assertSame($env, $res);
+	}
+
+	public function testAchieveWithDenial() {
+		$this->expectException(Setup\UnachievableException::class);
+
+		$env = $this->createMock(Setup\Environment::class);
+		$confirmation_requester = $this->createMock(Setup\ConfirmationRequester::class);
+
+		$env
+			->expects($this->once())
+			->method("getResource")
+			->with(Setup\Environment::RESOURCE_CONFIRMATION_REQUESTER)
+			->willReturn($confirmation_requester);
+
+		$confirmation_requester
+			->expects($this->once())
+			->method("confirmOrDeny")
+			->with($this->message)
+			->willReturn(false);
+
+		$res = $this->o->achieve($env);
+	}
+}

--- a/tests/Setup/ExternalConditionObjectiveTest.php
+++ b/tests/Setup/ExternalConditionObjectiveTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/* Copyright (c) 2019 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Tests\Setup;
+
+use ILIAS\Setup;
+
+class ExternalConditionObjectiveTest extends \PHPUnit\Framework\TestCase {
+	public function setUp() : void {
+		$this->label_t = "condition_true";
+		$this->t = new Setup\ExternalConditionObjective(
+			$this->label_t,
+			function (Setup\Environment $e) { return true; }
+		);
+		$this->label_f = "condition_false";
+		$this->f = new Setup\ExternalConditionObjective(
+			$this->label_f,
+			function (Setup\Environment $e) { return false; }
+		);
+	}
+
+	public function testGetHash() {
+		$this->assertIsString($this->t->getHash());
+	}
+
+	public function testHashIsDifferentForDifferentMessages() {
+		$this->assertNotEquals($this->t->getHash(), $this->f->getHash());
+	}
+
+	public function testGetLabel() {
+		$this->assertIsString($this->f->getLabel());
+		$this->assertEquals($this->label_f, $this->f->getLabel());
+		$this->assertEquals($this->label_t, $this->t->getLabel());
+	}
+
+	public function testIsNotable() {
+		$this->assertTrue($this->f->isNotable());
+	}
+
+	public function testGetPreconditions() {
+		$env = $this->createMock(Setup\Environment::class);
+
+		$pre = $this->f->getPreconditions($env);
+		$this->assertEquals([], $pre);	
+	}
+
+	public function testAchieveFalse() {
+		$this->expectException(Setup\UnachievableException::class);
+		$env = $this->createMock(Setup\Environment::class);
+		$res = $this->f->achieve($env);
+	}
+
+
+	public function testAchieveTrue() {
+		$env = $this->createMock(Setup\Environment::class);
+		$res = $this->t->achieve($env);
+		$this->assertEquals($env, $res);
+	}
+}

--- a/tests/Setup/ObjectiveIteratorTest.php
+++ b/tests/Setup/ObjectiveIteratorTest.php
@@ -162,6 +162,40 @@ class ObjectiveIteratorTest extends \PHPUnit\Framework\TestCase {
 		$iterator->next();
 	}
 
+	public function testMarkFailed() {
+		$this->expectException(Setup\UnachievableException::class);
+
+		$env = new Setup\ArrayEnvironment([]);
+
+		$objective_fail = $this->newObjective();
+		$objective_1 = $this->newObjective();
+		$objective_2 = $this->newObjective();
+		$objective_3 = $this->newObjective();
+
+		$objective_1
+			->method("getPreconditions")
+			->willReturn([]);
+
+		$objective_2
+			->method("getPreconditions")
+			->willReturn([]);
+
+		$objective_3
+			->method("getPreconditions")
+			->willReturn([$objective_1, $objective_fail, $objective_2]);
+
+		$iterator = new Setup\ObjectiveIterator($env, $objective_3);
+
+
+		$this->assertEquals($objective_1, $iterator->current());
+		$iterator->next();
+		$this->assertEquals($objective_fail, $iterator->current());
+		$iterator->markAsFailed($objective_fail);
+		$iterator->next();
+		$this->assertEquals($objective_2, $iterator->current());
+		$iterator->next();
+	}
+
 	protected function newObjective($hash = null) {
 		static $no = 0;
 


### PR DESCRIPTION
Hello everybody,

just so everybody who is interested can stay tuned regarding the setup:

* I added an `ExternalConditionObjective` that checks some condition and fails if the conditions is not met. This could e.g. be used to warn on problematic database conditions that need to be fixed by some administrator manually.
* I added an `AdminConfirmationObjective` that may only be achieved if an admin says "yes". This could e.g. be used to warn about some potential data loss before doing dangerous stuff.
* The CLI setup looks a bit nicer now and can handle the new objectives.
* The CLI setup does not fail on the first failed objective but only when no objectives without failed preconditions are left.

If you want to have a peak into how the setup in the CLI might look like or want to play with the mechanisms, create a [`setup/cli_test.php`](https://gist.github.com/klees/c27f32c3c756a0795781f7260ff53c84#file-cli_test-php) and run it with `php setup/cli_test.php install some.json` (the json can actually be `{}`). This will do nothing more then sleep, post notes or wait for admin interaction, but should be a good environment to test stuff or understand what is going on in the setup.

As always: If you have questions, doubts, ideas, etc. regarding this I'll be happy to hear them.

@nhaagen: Please have a look into this before I'll merge. Most probably you are the most knowledgeable person regarding the new setup besides me. I would be happy if this would last and you'll find flaws here.

Best regards!