### PR TITLE
[WIP] Password: Add Argon2id hashing support (req. PHP >= 7.3.x)

### DIFF
--- a/Services/Password/classes/class.ilBasePasswordEncoder.php
+++ b/Services/Password/classes/class.ilBasePasswordEncoder.php
@@ -9,7 +9,7 @@
 abstract class ilBasePasswordEncoder implements ilPasswordEncoder
 {
     /** @var int Maximum password length */
-    const MAX_PASSWORD_LENGTH = 4096;
+    private const MAX_PASSWORD_LENGTH = 4096;
 
     /**
      * Compares two passwords.

--- a/Services/Password/classes/class.ilBasePasswordEncoder.php
+++ b/Services/Password/classes/class.ilBasePasswordEncoder.php
@@ -34,7 +34,6 @@ abstract class ilBasePasswordEncoder implements ilPasswordEncoder
             $result |= (ord($knownString[$i % $known_string_length]) ^ ord($userString[$i]));
         }
 
-        // They are only identical strings if $result is exactly 0...
         return 0 === $result;
     }
 

--- a/Services/Password/classes/class.ilPasswordUtils.php
+++ b/Services/Password/classes/class.ilPasswordUtils.php
@@ -23,7 +23,6 @@ class ilPasswordUtils
             }
         }
 
-        // Default random string generation
         $rand = '';
         for ($i = 0; $i < $length; $i++) {
             $rand .= chr(mt_rand(0, 255));

--- a/Services/Password/classes/encoders/class.ilArgon2IdPasswordEncoder.php
+++ b/Services/Password/classes/encoders/class.ilArgon2IdPasswordEncoder.php
@@ -1,0 +1,167 @@
+<?php declare(strict_types=1);
+/* Copyright (c) 1998-2016 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * Class ilArgon2idPasswordEncoder
+ * @author  Michael Jansen <mjansen@databay.de>
+ * @package ServicesPassword
+ */
+class ilArgon2idPasswordEncoder extends ilBasePasswordEncoder
+{
+    /** @var int */
+    private $memory_cost;
+    /** @var int */
+    private $time_cost;
+    /** @var int */
+    private $threads;
+
+    /**
+     * @param array $config
+     */
+    public function __construct(array $config = [])
+    {
+        if (!empty($config)) {
+            foreach ($config as $key => $value) {
+                switch (strtolower($key)) {
+                    case 'memory_cost':
+                        $this->setMemoryCost($value);
+                        break;
+
+                    case 'time_cost':
+                        $this->setTimeCost($value);
+                        break;
+
+                    case 'threads':
+                        $this->setThreads($value);
+                        break;
+                }
+            }
+        }
+
+        if ($this->isSupportedByRuntime() && static::class == self::class) {
+            if (!isset($config['memory_cost'])) {
+                $this->setMemoryCost(PASSWORD_ARGON2_DEFAULT_MEMORY_COST);
+            }
+            if (!isset($config['time_cost'])) {
+                $this->setTimeCost(PASSWORD_ARGON2_DEFAULT_TIME_COST);
+            }
+            if (!isset($config['threads'])) {
+                $this->setThreads(PASSWORD_ARGON2_DEFAULT_THREADS);
+            }
+        }
+
+        $this->init();
+    }
+
+    /**
+     *
+     */
+    protected function init() : void
+    {
+    }
+
+    /**
+     * @return int
+     */
+    public function getMemoryCost() : int
+    {
+        return $this->memory_cost;
+    }
+
+    /**
+     * @param int $memory_costs
+     */
+    public function setMemoryCost(int $memory_costs) : void
+    {
+        $this->memory_cost = $memory_costs;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTimeCost() : int
+    {
+        return $this->time_cost;
+    }
+
+    /**
+     * @param int $time_cost
+     */
+    public function setTimeCost(int $time_cost) : void
+    {
+        $this->time_cost = $time_cost;
+    }
+
+    /**
+     * @return int
+     */
+    public function getThreads() : int
+    {
+        return $this->threads;
+    }
+
+    /**
+     * @param int $threads
+     */
+    public function setThreads(int $threads) : void
+    {
+        $this->threads = $threads;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName() : string
+    {
+        return 'argon2id';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isSupportedByRuntime() : bool
+    {
+        return (
+            parent::isSupportedByRuntime() &&
+            version_compare(phpversion(), '7.3.0', '>=') &&
+            defined('PASSWORD_ARGON2ID')
+        );
+    }
+
+    /**
+     * @inheritDoc
+     * @throws ilPasswordException
+     */
+    public function encodePassword(string $raw, string $salt) : string
+    {
+        if ($this->isPasswordTooLong($raw)) {
+            throw new ilPasswordException('Invalid password.');
+        }
+
+        return password_hash($raw, PASSWORD_ARGON2ID, [
+            'memory_cost' => $this->getMemoryCost(),
+            'time_cost' => $this->getTimeCost(),
+            'threads' => $this->getThreads(),
+        ]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isPasswordValid(string $encoded, string $raw, string $salt) : bool
+    {
+        return password_verify($raw, $encoded);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function requiresReencoding(string $encoded) : bool
+    {
+        return password_needs_rehash($encoded, PASSWORD_ARGON2ID, [
+            'memory_cost' => $this->getMemoryCost(),
+            'time_cost' => $this->getTimeCost(),
+            'threads' => $this->getThreads(),
+        ]);
+    }
+}

--- a/Services/Password/classes/encoders/class.ilArgon2IdPasswordEncoder.php
+++ b/Services/Password/classes/encoders/class.ilArgon2IdPasswordEncoder.php
@@ -16,7 +16,7 @@ class ilArgon2idPasswordEncoder extends ilBasePasswordEncoder
     private $threads;
 
     /**
-     * @param array $config
+     * @param array<string, mixed> $config
      */
     public function __construct(array $config = [])
     {

--- a/Services/Password/classes/encoders/class.ilBcryptPasswordEncoder.php
+++ b/Services/Password/classes/encoders/class.ilBcryptPasswordEncoder.php
@@ -12,6 +12,7 @@ class ilBcryptPasswordEncoder extends ilBcryptPhpPasswordEncoder
     private const MIN_SALT_SIZE = 16;
     /** @var string */
     public const SALT_STORAGE_FILENAME = 'pwsalt.txt';
+
     /** @var string|null */
     private $client_salt = null;
     /** @var bool */
@@ -22,7 +23,7 @@ class ilBcryptPasswordEncoder extends ilBcryptPhpPasswordEncoder
     private $data_directory = '';
 
     /**
-     * @param array $config
+     * @param array<string, mixed> $config
      * @throws ilPasswordException
      */
     public function __construct(array $config = [])

--- a/Services/Password/classes/encoders/class.ilBcryptPasswordEncoder.php
+++ b/Services/Password/classes/encoders/class.ilBcryptPasswordEncoder.php
@@ -1,8 +1,6 @@
 <?php declare(strict_types=1);
 /* Copyright (c) 1998-2014 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/Password/classes/encoders/class.ilBcryptPhpPasswordEncoder.php';
-
 /**
  * Class ilBcryptPasswordEncoder
  * @author  Michael Jansen <mjansen@databay.de>
@@ -11,20 +9,15 @@ require_once 'Services/Password/classes/encoders/class.ilBcryptPhpPasswordEncode
 class ilBcryptPasswordEncoder extends ilBcryptPhpPasswordEncoder
 {
     /** @var int */
-    const MIN_SALT_SIZE = 16;
-
+    private const MIN_SALT_SIZE = 16;
     /** @var string */
-    const SALT_STORAGE_FILENAME = 'pwsalt.txt';
-
+    public const SALT_STORAGE_FILENAME = 'pwsalt.txt';
     /** @var string|null */
     private $client_salt = null;
-
     /** @var bool */
     private $is_security_flaw_ignored = false;
-
     /** @var bool */
     private $backward_compatibility = false;
-
     /** @var string */
     private $data_directory = '';
 

--- a/Services/Password/classes/encoders/class.ilBcryptPhpPasswordEncoder.php
+++ b/Services/Password/classes/encoders/class.ilBcryptPhpPasswordEncoder.php
@@ -1,8 +1,6 @@
 <?php declare(strict_types=1);
 /* Copyright (c) 1998-2016 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/Password/classes/class.ilBasePasswordEncoder.php';
-
 /**
  * Class ilBcryptPhpPasswordEncoder
  * @author  Michael Jansen <mjansen@databay.de>
@@ -10,9 +8,7 @@ require_once 'Services/Password/classes/class.ilBasePasswordEncoder.php';
  */
 class ilBcryptPhpPasswordEncoder extends ilBasePasswordEncoder
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $costs = '08';
 
     /**
@@ -47,43 +43,6 @@ class ilBcryptPhpPasswordEncoder extends ilBasePasswordEncoder
     }
 
     /**
-     * @see http://php.net/manual/en/function.password-hash.php#example-984
-     * @param float $time_target
-     * @return int
-     * @throws ilPasswordException
-     */
-    public function benchmarkCost(float $time_target = 0.05) : int
-    {
-        $cost = 8;
-
-        do {
-            $cost++;
-            $start = microtime(true);
-            $encoder = new self(['cost' => (string) $cost]);
-            $encoder->encodePassword('test', '');
-            $end = microtime(true);
-        } while (($end - $start) < $time_target && $cost < 32);
-
-        return $cost;
-    }
-
-    /**
-     * @return string
-     */
-    public function getName() : string
-    {
-        return 'bcryptphp';
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function isSupportedByRuntime() : bool
-    {
-        return parent::isSupportedByRuntime() && version_compare(phpversion(), '5.5.0', '>=');
-    }
-
-    /**
      * @return string
      */
     public function getCosts() : string
@@ -107,6 +66,43 @@ class ilBcryptPhpPasswordEncoder extends ilBasePasswordEncoder
     }
 
     /**
+     * @see http://php.net/manual/en/function.password-hash.php#example-984
+     * @param float $time_target
+     * @return int
+     * @throws ilPasswordException
+     */
+    public function benchmarkCost(float $time_target = 0.05) : int
+    {
+        $cost = 8;
+
+        do {
+            $cost++;
+            $start = microtime(true);
+            $encoder = new self(['cost' => (string) $cost]);
+            $encoder->encodePassword('test', '');
+            $end = microtime(true);
+        } while (($end - $start) < $time_target && $cost < 31);
+
+        return $cost;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName() : string
+    {
+        return 'bcryptphp';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isSupportedByRuntime() : bool
+    {
+        return parent::isSupportedByRuntime() && version_compare(phpversion(), '5.5.0', '>=');
+    }
+
+    /**
      * @inheritDoc
      * @throws ilPasswordException
      */
@@ -117,7 +113,7 @@ class ilBcryptPhpPasswordEncoder extends ilBasePasswordEncoder
         }
 
         return password_hash($raw, PASSWORD_BCRYPT, [
-            'cost' => $this->getCosts()
+            'cost' => $this->getCosts(),
         ]);
     }
 
@@ -135,7 +131,7 @@ class ilBcryptPhpPasswordEncoder extends ilBasePasswordEncoder
     public function requiresReencoding(string $encoded) : bool
     {
         return password_needs_rehash($encoded, PASSWORD_BCRYPT, [
-            'cost' => $this->getCosts()
+            'cost' => $this->getCosts(),
         ]);
     }
 }

--- a/Services/Password/classes/encoders/class.ilBcryptPhpPasswordEncoder.php
+++ b/Services/Password/classes/encoders/class.ilBcryptPhpPasswordEncoder.php
@@ -12,7 +12,7 @@ class ilBcryptPhpPasswordEncoder extends ilBasePasswordEncoder
     protected $costs = '08';
 
     /**
-     * @param array $config
+     * @param array<string, mixed> $config
      * @throws ilPasswordException
      */
     public function __construct(array $config = [])
@@ -28,7 +28,6 @@ class ilBcryptPhpPasswordEncoder extends ilBasePasswordEncoder
         }
 
         if (!isset($config['cost']) && static::class == self::class) {
-            // Determine the costs only if they are not passed in constructor
             $this->setCosts((string) $this->benchmarkCost(0.05));
         }
 

--- a/Services/Password/classes/encoders/class.ilMd5PasswordEncoder.php
+++ b/Services/Password/classes/encoders/class.ilMd5PasswordEncoder.php
@@ -1,8 +1,6 @@
 <?php declare(strict_types=1);
 /* Copyright (c) 1998-2014 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/Password/classes/class.ilBasePasswordEncoder.php';
-
 /**
  * Class ilMd5PasswordEncoder
  * This class implements the ILIAS password encryption mechanism used in ILIAS3/ILIAS4
@@ -13,6 +11,13 @@ require_once 'Services/Password/classes/class.ilBasePasswordEncoder.php';
  */
 class ilMd5PasswordEncoder extends ilBasePasswordEncoder
 {
+    /**
+     * @param array $config
+     */
+    public function __construct(array $config = [])
+    {
+    }
+
     /**
      * @inheritDoc
      * @throws ilPasswordException

--- a/Services/Password/classes/encoders/class.ilMd5PasswordEncoder.php
+++ b/Services/Password/classes/encoders/class.ilMd5PasswordEncoder.php
@@ -12,7 +12,7 @@
 class ilMd5PasswordEncoder extends ilBasePasswordEncoder
 {
     /**
-     * @param array $config
+     * @param array<string, mixed> $config
      */
     public function __construct(array $config = [])
     {

--- a/Services/Password/exceptions/class.ilPasswordException.php
+++ b/Services/Password/exceptions/class.ilPasswordException.php
@@ -1,8 +1,6 @@
 <?php declare(strict_types=1);
 /* Copyright (c) 1998-2014 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/Exceptions/classes/class.ilException.php';
-
 /**
  * Class for user password exception handling in ILIAS.
  * @author  Michael Jansen <mjansen@databay.de>

--- a/Services/Password/test/encoders/ilArgon2IdPasswordEncoderTest.php
+++ b/Services/Password/test/encoders/ilArgon2IdPasswordEncoderTest.php
@@ -1,0 +1,132 @@
+<?php declare(strict_types=1);
+/* Copyright (c) 1998-2014 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+require_once 'Services/Password/test/ilPasswordBaseTest.php';
+
+/**
+ * Class ilArgon2IdPasswordEncoderTest
+ * @author  Michael Jansen <mjansen@databay.de>
+ * @package ServicesPassword
+ */
+class ilArgon2IdPasswordEncoderTest extends ilPasswordBaseTest
+{
+    /** @var string */
+    const PASSWORD = 'password';
+
+    /** @var string */
+    const WRONG_PASSWORD = 'wrong_password';
+
+    /**
+     *
+     */
+    private function skipIfPhpVersionIsNotSupported() : void
+    {
+        if (version_compare(phpversion(), '7.2.0', '<')) {
+            $this->markTestSkipped('Requires PHP >= 7.2.0');
+        }
+    }
+
+    /**
+     * @return ilArgon2idPasswordEncoder
+     * @throws ilPasswordException
+     */
+    public function testInstanceCanBeCreated() : ilArgon2idPasswordEncoder
+    {
+        $this->skipIfPhpVersionIsNotSupported();
+
+        $encoder = new ilArgon2idPasswordEncoder();
+        $this->assertInstanceOf(ilArgon2idPasswordEncoder::class, $encoder);
+        return $encoder;
+    }
+
+    /**
+     * @depends testInstanceCanBeCreated
+     * @param ilArgon2idPasswordEncoder $encoder
+     * @return ilArgon2idPasswordEncoder
+     * @throws ilPasswordException
+     */
+    public function testPasswordShouldBeCorrectlyEncodedAndVerified(
+        ilArgon2idPasswordEncoder $encoder
+    ) : ilArgon2idPasswordEncoder {
+        $encoded_password = $encoder->encodePassword(self::PASSWORD, '');
+        $this->assertTrue($encoder->isPasswordValid($encoded_password, self::PASSWORD, ''));
+        $this->assertFalse($encoder->isPasswordValid($encoded_password, self::WRONG_PASSWORD, ''));
+        return $encoder;
+    }
+
+    /**
+     * @depends testInstanceCanBeCreated
+     * @param ilArgon2idPasswordEncoder $encoder
+     * @throws ilPasswordException
+     */
+    public function testExceptionIsRaisedIfThePasswordExceedsTheSupportedLengthOnEncoding(
+        ilArgon2idPasswordEncoder $encoder
+    ) : void {
+        $this->expectException(ilPasswordException::class);
+        $encoder->encodePassword(str_repeat('a', 5000), '');
+    }
+
+    /**
+     * @depends testInstanceCanBeCreated
+     * @param ilArgon2idPasswordEncoder $encoder
+     * @throws ilPasswordException
+     */
+    public function testPasswordVerificationShouldFailIfTheRawPasswordExceedsTheSupportedLength(
+        ilArgon2idPasswordEncoder $encoder
+    ) : void {
+        $this->assertFalse($encoder->isPasswordValid('encoded', str_repeat('a', 5000), ''));
+    }
+
+    /**
+     * @depends testInstanceCanBeCreated
+     * @param ilArgon2idPasswordEncoder $encoder
+     */
+    public function testNameShouldBeArgon2id(ilArgon2idPasswordEncoder $encoder) : void
+    {
+        $this->assertEquals('argon2id', $encoder->getName());
+    }
+
+    /**
+     * @depends testInstanceCanBeCreated
+     * @param ilArgon2idPasswordEncoder $encoder
+     */
+    public function testEncoderDoesNotRelyOnSalts(ilArgon2idPasswordEncoder $encoder) : void
+    {
+        $this->assertFalse($encoder->requiresSalt());
+    }
+
+    /**
+     * @depends testInstanceCanBeCreated
+     * @param ilArgon2idPasswordEncoder $encoder
+     * @throws ilPasswordException
+     */
+    public function testReencodingIsDetectedWhenNecessary(ilArgon2idPasswordEncoder $encoder) : void
+    {
+        $raw = self::PASSWORD;
+
+        $encoder->setThreads(2);
+        $encoder->setMemoryCost(4096);
+        $encoder->setTimeCost(8);
+        $encoded = $encoder->encodePassword($raw, '');
+
+        $encoder->setThreads(2);
+        $encoder->setMemoryCost(4096);
+        $encoder->setTimeCost(8);
+        $this->assertFalse($encoder->requiresReencoding($encoded));
+
+        $encoder->setThreads(2);
+        $encoder->setMemoryCost(4096);
+        $encoder->setTimeCost(4);
+        $this->assertTrue($encoder->requiresReencoding($encoded));
+
+        $encoder->setThreads(1);
+        $encoder->setMemoryCost(4096);
+        $encoder->setTimeCost(8);
+        $this->assertTrue($encoder->requiresReencoding($encoded));
+
+        $encoder->setThreads(2);
+        $encoder->setMemoryCost(2048);
+        $encoder->setTimeCost(8);
+        $this->assertTrue($encoder->requiresReencoding($encoded));
+    }
+}

--- a/Services/Password/test/encoders/ilArgon2IdPasswordEncoderTest.php
+++ b/Services/Password/test/encoders/ilArgon2IdPasswordEncoderTest.php
@@ -1,8 +1,6 @@
 <?php declare(strict_types=1);
 /* Copyright (c) 1998-2014 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/Password/test/ilPasswordBaseTest.php';
-
 /**
  * Class ilArgon2IdPasswordEncoderTest
  * @author  Michael Jansen <mjansen@databay.de>
@@ -11,10 +9,9 @@ require_once 'Services/Password/test/ilPasswordBaseTest.php';
 class ilArgon2IdPasswordEncoderTest extends ilPasswordBaseTest
 {
     /** @var string */
-    const PASSWORD = 'password';
-
+    private const PASSWORD = 'password';
     /** @var string */
-    const WRONG_PASSWORD = 'wrong_password';
+    private const WRONG_PASSWORD = 'wrong_password';
 
     /**
      *

--- a/Services/Password/test/encoders/ilBcryptPasswordEncoderTest.php
+++ b/Services/Password/test/encoders/ilBcryptPasswordEncoderTest.php
@@ -1,8 +1,6 @@
 <?php declare(strict_types=1);
 /* Copyright (c) 1998-2014 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/Password/test/ilPasswordBaseTest.php';
-
 use org\bovigo\vfs;
 
 /**
@@ -13,15 +11,15 @@ use org\bovigo\vfs;
 class ilBcryptPasswordEncoderTest extends ilPasswordBaseTest
 {
     /** @var string */
-    const VALID_COSTS = '08';
+    private const VALID_COSTS = '08';
     /** @var string */
-    const PASSWORD = 'password';
+    private const PASSWORD = 'password';
     /** @var string */
-    const WRONG_PASSWORD = 'wrong_password';
+    private const WRONG_PASSWORD = 'wrong_password';
     /** @var string */
-    const CLIENT_SALT = 'homer!12345_/';
+    private const CLIENT_SALT = 'homer!12345_/';
     /** @var string */
-    const PASSWORD_SALT = 'salt';
+    private const PASSWORD_SALT = 'salt';
 
     /** @var vfs\vfsStreamDirectory */
     protected $testDirectory;

--- a/Services/Password/test/encoders/ilBcryptPasswordEncoderTest.php
+++ b/Services/Password/test/encoders/ilBcryptPasswordEncoderTest.php
@@ -1,7 +1,6 @@
 <?php declare(strict_types=1);
 /* Copyright (c) 1998-2014 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/Password/classes/encoders/class.ilBcryptPasswordEncoder.php';
 require_once 'Services/Password/test/ilPasswordBaseTest.php';
 
 use org\bovigo\vfs;
@@ -15,22 +14,17 @@ class ilBcryptPasswordEncoderTest extends ilPasswordBaseTest
 {
     /** @var string */
     const VALID_COSTS = '08';
-
     /** @var string */
     const PASSWORD = 'password';
-
     /** @var string */
     const WRONG_PASSWORD = 'wrong_password';
-
     /** @var string */
     const CLIENT_SALT = 'homer!12345_/';
-
     /** @var string */
     const PASSWORD_SALT = 'salt';
 
     /** @var vfs\vfsStreamDirectory */
     protected $testDirectory;
-
     /** @var string */
     protected $testDirectoryUrl;
 
@@ -148,7 +142,7 @@ class ilBcryptPasswordEncoderTest extends ilPasswordBaseTest
             'cost' => self::VALID_COSTS,
             'data_directory' => $this->getTestDirectoryUrl()
         ]);
-        $this->assertInstanceOf('ilBcryptPasswordEncoder', $encoder);
+        $this->assertInstanceOf(ilBcryptPasswordEncoder::class, $encoder);
         $this->assertEquals(self::VALID_COSTS, $encoder->getCosts());
         $this->assertFalse($encoder->isSecurityFlawIgnored());
         $encoder->setClientSalt(self::CLIENT_SALT);

--- a/Services/Password/test/encoders/ilBcryptPhpPasswordEncoderTest.php
+++ b/Services/Password/test/encoders/ilBcryptPhpPasswordEncoderTest.php
@@ -1,7 +1,6 @@
 <?php declare(strict_types=1);
 /* Copyright (c) 1998-2016 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/Password/classes/encoders/class.ilBcryptPhpPasswordEncoder.php';
 require_once 'Services/Password/test/ilPasswordBaseTest.php';
 
 /**
@@ -13,10 +12,8 @@ class ilBcryptPhpPasswordEncoderTest extends ilPasswordBaseTest
 {
     /** @var string */
     const VALID_COSTS = '08';
-
     /** @var string */
     const PASSWORD = 'password';
-
     /** @var string */
     const WRONG_PASSWORD = 'wrong_password';
 
@@ -57,7 +54,7 @@ class ilBcryptPhpPasswordEncoderTest extends ilPasswordBaseTest
         $encoder = new ilBcryptPhpPasswordEncoder([
             'cost' => self::VALID_COSTS
         ]);
-        $this->assertInstanceOf('ilBcryptPhpPasswordEncoder', $encoder);
+        $this->assertInstanceOf(ilBcryptPhpPasswordEncoder::class, $encoder);
         $this->assertEquals(self::VALID_COSTS, $encoder->getCosts());
         return $encoder;
     }
@@ -174,7 +171,7 @@ class ilBcryptPhpPasswordEncoderTest extends ilPasswordBaseTest
         $this->assertTrue($costs_target > 4 && $costs_target < 32);
         $this->assertIsInt($costs_default);
         $this->assertIsInt($costs_target);
-        $this->assertNotEquals($costs_default, $costs_target);
+        $this->assertGreaterThanOrEqual($costs_default, $costs_target);
     }
 
     /**

--- a/Services/Password/test/encoders/ilBcryptPhpPasswordEncoderTest.php
+++ b/Services/Password/test/encoders/ilBcryptPhpPasswordEncoderTest.php
@@ -1,8 +1,6 @@
 <?php declare(strict_types=1);
 /* Copyright (c) 1998-2016 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/Password/test/ilPasswordBaseTest.php';
-
 /**
  * Class ilBcryptPhpPasswordEncoderTest
  * @author  Michael Jansen <mjansen@databay.de>
@@ -11,11 +9,11 @@ require_once 'Services/Password/test/ilPasswordBaseTest.php';
 class ilBcryptPhpPasswordEncoderTest extends ilPasswordBaseTest
 {
     /** @var string */
-    const VALID_COSTS = '08';
+    private const VALID_COSTS = '08';
     /** @var string */
-    const PASSWORD = 'password';
+    private const PASSWORD = 'password';
     /** @var string */
-    const WRONG_PASSWORD = 'wrong_password';
+    private const WRONG_PASSWORD = 'wrong_password';
 
     /**
      *
@@ -56,6 +54,7 @@ class ilBcryptPhpPasswordEncoderTest extends ilPasswordBaseTest
         ]);
         $this->assertInstanceOf(ilBcryptPhpPasswordEncoder::class, $encoder);
         $this->assertEquals(self::VALID_COSTS, $encoder->getCosts());
+
         return $encoder;
     }
 
@@ -120,6 +119,7 @@ class ilBcryptPhpPasswordEncoderTest extends ilPasswordBaseTest
         $encoded_password = $encoder->encodePassword(self::PASSWORD, '');
         $this->assertTrue($encoder->isPasswordValid($encoded_password, self::PASSWORD, ''));
         $this->assertFalse($encoder->isPasswordValid($encoded_password, self::WRONG_PASSWORD, ''));
+
         return $encoder;
     }
 
@@ -165,7 +165,7 @@ class ilBcryptPhpPasswordEncoderTest extends ilPasswordBaseTest
     public function testCostsCanBeDeterminedDynamically(ilBcryptPhpPasswordEncoder $encoder) : void
     {
         $costs_default = $encoder->benchmarkCost();
-        $costs_target = $encoder->benchmarkCost(0.5);
+        $costs_target  = $encoder->benchmarkCost(0.5);
 
         $this->assertTrue($costs_default > 4 && $costs_default < 32);
         $this->assertTrue($costs_target > 4 && $costs_target < 32);

--- a/Services/Password/test/encoders/ilMd5PasswordEncoderTest.php
+++ b/Services/Password/test/encoders/ilMd5PasswordEncoderTest.php
@@ -1,7 +1,6 @@
 <?php declare(strict_types=1);
 /* Copyright (c) 1998-2014 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/Password/classes/encoders/class.ilMd5PasswordEncoder.php';
 require_once 'Services/Password/test/ilPasswordBaseTest.php';
 
 /**
@@ -17,7 +16,7 @@ class ilMd5PasswordEncoderTest extends ilPasswordBaseTest
     public function testInstanceCanBeCreated() : ilMd5PasswordEncoder
     {
         $encoder = new ilMd5PasswordEncoder();
-        $this->assertInstanceOf('ilMd5PasswordEncoder', $encoder);
+        $this->assertInstanceOf(ilMd5PasswordEncoder::class, $encoder);
         return $encoder;
     }
 

--- a/Services/Password/test/encoders/ilMd5PasswordEncoderTest.php
+++ b/Services/Password/test/encoders/ilMd5PasswordEncoderTest.php
@@ -1,8 +1,6 @@
 <?php declare(strict_types=1);
 /* Copyright (c) 1998-2014 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/Password/test/ilPasswordBaseTest.php';
-
 /**
  * Class ilMd5PasswordEncoderTest
  * @author  Michael Jansen <mjansen@databay.de>

--- a/Services/User/classes/class.ilUserImportParser.php
+++ b/Services/User/classes/class.ilUserImportParser.php
@@ -527,6 +527,9 @@ class ilUserImportParser extends ilSaxParser
 
             case 'Password':
                 $this->currPasswordType = $a_attribs['Type'];
+				if (is_string($this->currPasswordType) && 'bcrypt' === strtolower($this->currPasswordType)) {
+					$this->currPasswordType = 'bcryptphp';
+				}
                 break;
             case "AuthMode":
                 if (array_key_exists("type", $a_attribs)) {
@@ -666,6 +669,9 @@ class ilUserImportParser extends ilSaxParser
 
             case 'Password':
                 $this->currPasswordType = $a_attribs['Type'];
+				if (is_string($this->currPasswordType) && 'bcrypt' === strtolower($this->currPasswordType)) {
+					$this->currPasswordType = 'bcryptphp';
+				}
                 break;
             case "AuthMode":
                 if (array_key_exists("type", $a_attribs)) {
@@ -1073,14 +1079,15 @@ class ilUserImportParser extends ilSaxParser
                             $this->logFailure($this->userObj->getLogin(), $lng->txt("usrimport_cant_insert"));
                         } else {
                             if (!strlen($this->currPassword) == 0) {
-                                switch (strtoupper($this->currPasswordType)) {
-                                    case "BCRYPT":
+                                switch (strtolower($this->currPasswordType)) {
+                                    case "argon2id":
+                                    case "bcryptphp":
                                         $this->userObj->setPasswd($this->currPassword, IL_PASSWD_CRYPTED);
-                                        $this->userObj->setPasswordEncodingType('bcryptphp');
+                                        $this->userObj->setPasswordEncodingType(strtolower($this->currPasswordType));
                                         $this->userObj->setPasswordSalt(null);
                                         break;
 
-                                    case "PLAIN":
+                                    case "plain":
                                         $this->userObj->setPasswd($this->currPassword, IL_PASSWD_PLAIN);
                                         $this->acc_mail->setUserPassword($this->currPassword);
                                         break;
@@ -1204,14 +1211,15 @@ class ilUserImportParser extends ilSaxParser
                             $updateUser->read();
                             $updateUser->readPrefs();
                             if ($this->currPassword != null) {
-                                switch (strtoupper($this->currPasswordType)) {
-                                    case "BCRYPT":
+                                switch (strtolower($this->currPasswordType)) {
+                                    case "argon2id":
+                                    case "bcryptphp":
                                         $updateUser->setPasswd($this->currPassword, IL_PASSWD_CRYPTED);
-                                        $updateUser->setPasswordEncodingType('bcryptphp');
+                                        $updateUser->setPasswordEncodingType(strtolower($this->currPasswordType));
                                         $updateUser->setPasswordSalt(null);
                                         break;
 
-                                    case "PLAIN":
+                                    case "plain":
                                         $updateUser->setPasswd($this->currPassword, IL_PASSWD_PLAIN);
                                         $this->acc_mail->setUserPassword($this->currPassword);
                                         break;
@@ -1779,14 +1787,15 @@ class ilUserImportParser extends ilSaxParser
                 break;
 
             case "Password":
-                switch ($this->currPasswordType) {
-                    case "BCRYPT":
+                switch (strtolower($this->currPasswordType)) {
+                    case "argon2id":
+                    case "bcryptphp":
                         $this->userObj->setPasswd($this->cdata, IL_PASSWD_CRYPTED);
-                        $this->userObj->setPasswordEncodingType('bcryptphp');
+                        $this->userObj->setPasswordEncodingType(strtolower($this->currPasswordType));
                         $this->userObj->setPasswordSalt(null);
                         break;
 
-                    case "PLAIN":
+                    case "plain":
                         $this->userObj->setPasswd($this->cdata, IL_PASSWD_PLAIN);
                         $this->acc_mail->setUserPassword($this->currPassword);
                         break;

--- a/Services/User/classes/class.ilUserPasswordEncoderFactory.php
+++ b/Services/User/classes/class.ilUserPasswordEncoderFactory.php
@@ -1,8 +1,6 @@
 <?php declare(strict_types=1);
 /* Copyright (c) 1998-2014 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/User/exceptions/class.ilUserException.php';
-
 /**
  * Class ilUserPasswordEncoderFactory
  * @author  Michael Jansen <mjansen@databay.de>
@@ -45,6 +43,7 @@ class ilUserPasswordEncoderFactory
     protected function getValidEncoders($config) : array
     {
         return [
+            new ilArgon2idPasswordEncoder($config),
             new ilBcryptPhpPasswordEncoder($config),
             new ilBcryptPasswordEncoder($config),
             new ilMd5PasswordEncoder($config),

--- a/Services/User/classes/class.ilUserPasswordManager.php
+++ b/Services/User/classes/class.ilUserPasswordManager.php
@@ -86,12 +86,12 @@ class ilUserPasswordManager
             [
                 'encoder_factory' => new ilUserPasswordEncoderFactory(
                     [
-                        'default_password_encoder' => 'bcryptphp',
+                        'default_password_encoder' => 'argon2id',
                         'ignore_security_flaw' => true,
                         'data_directory' => ilUtil::getDataDir()
                     ]
                 ),
-                'password_encoder' => 'bcryptphp',
+                'password_encoder' => 'argon2id',
                 'settings' => $DIC->isDependencyAvailable('settings') ? $DIC->settings() : null,
                 'db' => $DIC->database(),
             ]

--- a/Services/User/test/ilObjUserPasswordTest.php
+++ b/Services/User/test/ilObjUserPasswordTest.php
@@ -4,12 +4,6 @@
 use org\bovigo\vfs;
 
 require_once 'libs/composer/vendor/autoload.php';
-require_once 'Services/User/classes/class.ilUserPasswordManager.php';
-require_once 'Services/User/classes/class.ilUserPasswordEncoderFactory.php';
-require_once 'Services/Password/classes/class.ilBasePasswordEncoder.php';
-require_once 'Services/Utilities/classes/class.ilUtil.php';
-require_once 'Services/User/classes/class.ilObjUser.php';
-require_once 'Services/User/exceptions/class.ilUserException.php';
 require_once 'Services/User/test/ilUserBaseTest.php';
 
 /**

--- a/Services/User/test/ilObjUserPasswordTest.php
+++ b/Services/User/test/ilObjUserPasswordTest.php
@@ -394,8 +394,8 @@ class ilObjUserPasswordTest extends ilUserBaseTest
         $second_mockencoder = $this->getMockBuilder(ilBasePasswordEncoder::class)->disableOriginalConstructor()->getMock();
         $second_mockencoder->expects($this->atLeastOnce())->method('getName')->will($this->returnValue('second_mockencoder'));
 
-        $factory->setEncoders([$encoder, $second_mockencoder]);
-        $this->assertCount(2, $factory->getEncoders());
+        $factory->setSupportedEncoders([$encoder, $second_mockencoder]);
+        $this->assertCount(2, $factory->getSupportedEncoders());
         $this->assertCount(2, $factory->getSupportedEncoderNames());
         $this->assertCount(
             0,
@@ -417,7 +417,7 @@ class ilObjUserPasswordTest extends ilUserBaseTest
         $factory = new ilUserPasswordEncoderFactory([
             'data_directory' => $this->getTestDirectoryUrl()
         ]);
-        $factory->setEncoders(['phpunit']);
+        $factory->setSupportedEncoders(['phpunit']);
     }
 
     /**
@@ -475,7 +475,7 @@ class ilObjUserPasswordTest extends ilUserBaseTest
             'default_password_encoder' => $encoder->getName(),
             'data_directory' => $this->getTestDirectoryUrl()
         ]);
-        $factory->setEncoders([$encoder]);
+        $factory->setSupportedEncoders([$encoder]);
         $this->assertEquals($encoder, $factory->getEncoderByName('phpunit', true));
     }
 
@@ -493,7 +493,7 @@ class ilObjUserPasswordTest extends ilUserBaseTest
             'default_password_encoder' => $encoder->getName(),
             'data_directory' => $this->getTestDirectoryUrl()
         ]);
-        $factory->setEncoders([$encoder]);
+        $factory->setSupportedEncoders([$encoder]);
         $this->assertEquals($encoder, $factory->getEncoderByName('mockencoder', true));
     }
 }

--- a/setup/classes/class.ilSetupPasswordEncoderFactory.php
+++ b/setup/classes/class.ilSetupPasswordEncoderFactory.php
@@ -1,13 +1,11 @@
 <?php declare(strict_types=1);
 /* Copyright (c) 1998-2018 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/User/classes/class.ilUserPasswordEncoderFactory.php';
-
 /**
  * Class ilSetupPasswordManager
  * @author Michael Jansen <mjansen@databay.de>
  */
-class ilSetupPasswordEncoderFactory extends \ilUserPasswordEncoderFactory
+class ilSetupPasswordEncoderFactory extends ilUserPasswordEncoderFactory
 {
     /**
      * @inheritdoc
@@ -15,6 +13,7 @@ class ilSetupPasswordEncoderFactory extends \ilUserPasswordEncoderFactory
     protected function getValidEncoders($config) : array
     {
         return [
+            new ilArgon2idPasswordEncoder($config),
             new ilBcryptPhpPasswordEncoder($config),
             new ilMd5PasswordEncoder($config),
         ];

--- a/setup/classes/class.ilSetupPasswordManager.php
+++ b/setup/classes/class.ilSetupPasswordManager.php
@@ -110,7 +110,10 @@ class ilSetupPasswordManager
                 },
                 'bcryptphp' => function ($encoded) {
                     return is_string($encoded) && substr($encoded, 0, 4) === '$2y$' && strlen($encoded) === 60;
-                }
+                },
+                'argon2id'   => function ($encoded) {
+                    return is_string($encoded) && substr($encoded, 0, 10) === '$argon2id$' && strlen($encoded) === 96;
+                },
             ]
         );
 

--- a/setup/sql/dbupdate_05.php
+++ b/setup/sql/dbupdate_05.php
@@ -4312,4 +4312,13 @@ if (!$idx) {
     $ilDB->addIndex('frm_user_read', ['usr_id', 'post_id'], 'i1');
     $setting->set('ilfrmreadidx1', 1);
 }
-?> 
+?>
+<#5666>
+<?php
+$ilDB->modifyTableColumn('usr_data', 'passwd', array(
+    'type'    => 'text',
+    'length'  => 100,
+    'notnull' => false,
+    'default' => null
+));
+?>


### PR DESCRIPTION
This PR will add Argon2id support for password hashing in ILIAS. 

To discuss: PHP needs to be compiled with Argon2 support, so further documentation (and maybe additional compatibility checks in the setup) will be maybe required if this PR gets approved.
This will maybe also affect the PHP binary for the `Travis CI` builds.

Feature Wiki Page: https://docu.ilias.de/goto_docu_wiki_wpage_6330_1357.html