### PR TITLE
WebDAV: Fixed a bug in the versioning of files over webdav

### DIFF
--- a/Modules/File/classes/class.ilObjFileAccessSettings.php
+++ b/Modules/File/classes/class.ilObjFileAccessSettings.php
@@ -342,7 +342,8 @@ class ilObjFileAccessSettings extends ilObject
         $settings = new ilSetting('file_access');
         $ilClientIniFile = $DIC['ilClientIniFile'];
         $this->webdavEnabled = $ilClientIniFile->readVariable('file_access', 'webdav_enabled') == '1';
-        $this->webdavVersioningEnabled = $settings->get('webdav_versioning_enabled', '0') == '1';
+        // default_value = 1 for versionigEnabled because it was already standard before ilias5.4
+        $this->webdavVersioningEnabled = $settings->get('webdav_versioning_enabled', '1') == '1';
         $this->webdavActionsVisible = $ilClientIniFile->readVariable('file_access', 'webdav_actions_visible') == '1';
         $this->downloadWithUploadedFilename = $ilClientIniFile->readVariable('file_access', 'download_with_uploaded_filename') == '1';
         $ilClientIniFile->ERROR = false;

--- a/Modules/File/classes/class.ilObjFileAccessSettingsGUI.php
+++ b/Modules/File/classes/class.ilObjFileAccessSettingsGUI.php
@@ -328,8 +328,9 @@ class ilObjFileAccessSettingsGUI extends ilObjectGUI
         $form->addItem($cb_prop);
 
         // Enable versioning
-        $cb_prop = new ilCheckboxInputGUI($lng->txt("enable_versioning_webdav"), "enable_versioning_webdav");
+        $cb_prop = new ilCheckboxInputGUI($lng->txt("webdav_enable_versioning"), "enable_versioning_webdav");
         $cb_prop->setValue('1');
+        $cb_prop->setInfo($lng->txt("webdav_versioning_info"));
         $cb_prop->setChecked($this->object->isWebdavVersioningEnabled());
         $form->addItem($cb_prop);
 

--- a/Services/WebDAV/classes/dav/class.ilObjContainerDAV.php
+++ b/Services/WebDAV/classes/dav/class.ilObjContainerDAV.php
@@ -67,7 +67,7 @@ abstract class ilObjContainerDAV extends ilObjectDAV implements Sabre\DAV\IColle
             {
                 if ($this->childExists($name)) {
                     $file_dav = $this->getChild($name);
-                    $file_dav->handleFileUpload($data);
+                    $file_dav->put($data);
                 } else {
                     $file_obj = new ilObjFile();
                     $file_obj->setTitle($name);
@@ -83,7 +83,7 @@ abstract class ilObjContainerDAV extends ilObjectDAV implements Sabre\DAV\IColle
                     $file_obj->update();
 
                     $file_dav = new ilObjFileDAV($file_obj, $this->repo_helper, $this->dav_helper);
-                    $file_dav->handleFileUpload($data);
+                    $file_dav->handleFileUpload($data, "create");
                 }
             }
             else

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -4461,6 +4461,8 @@ common#:#visitors#:#Besucher
 common#:#visits#:#Besuche
 common#:#web_resources#:#Weblinks
 common#:#webdav#:#WebDAV
+common#:#webdav_enable_versioning#:#Datei Versionierung
+common#:#webdav_versioning_info#:#Wenn diese Einstellung aktiviert ist, wird für bereits existierende Dateien eine neue Version angelegt. An sonst werden diese überschrieben.
 common#:#edit_metadata#:#Metadaten bearbeiten
 common#:#webdav_pwd_instruction#:#Um das ILIAS-Magazin als Webordner außerhalb der aktuellen Sitzung als Webordner zu öffnen, empfehlen wir ein lokales Passwort anzulegen.<br />Dieses Passwort wird nur für die Webordner-Funktionalitäten benötigt, die ILIAS-Anmeldung erfolgt weiterhin mit Ihrem gewohnten Passwort.
 common#:#webdav_pwd_instruction_success#:#Ein neues lokales Passwort wurde angelegt. Sie können nun das Magazin als Webordner öffnen.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -3914,6 +3914,8 @@ common#:#visitors#:#Visitors
 common#:#visits#:#Visits
 common#:#web_resources#:#Weblinks
 common#:#webdav#:#WebDAV
+common#:#webdav_enable_versioning#:#File Versioning
+common#:#webdav_versioning_info#:#If enabled, already existing files will get a new version instead of beeing overwritten.
 common#:#webfolder_dir_info#:#You got here, because your browser can't open webfolders. Read the <a href="%1$s">instructions for opening webfolders</a>.
 common#:#webfolder_index_of#:#Index of %1$s
 common#:#webfolder_instructions_info#:#The webfolder instructions are shown on browsers, which can not open a webfolder directly. You can use HTML code, and the following placeholders: <b>[WEBFOLDER_TITLE]</b>, <b>[WEBFOLDER_URI]</b>, <b>[WEBFOLDER_URI_IE]</b>, <b>[WEBFOLDER_URI_KONQUEROR]</b>, <b>[WEBFOLDER_URI_NAUTILUS]</b>, <b>[ADMIN_MAIL]</b>, <b>[IF_WINDOWS]</b>...<b>[/IF_WINDOWS]</b>, <b>[IF_MAC]</b>...<b>[/IF_MAC]</b>, <b>[IF_LINUX]</b>...<b>[/IF_LINUX]</b>. Clear the field to get the default instructions.


### PR DESCRIPTION
I made a bugfix and also some small improvements for the file versioning over webdav. Since this is for ilias6 (which is still under development) there is no bug report for this. I just found it by myself. The fix is about, reading the settings for the chosen options and a small improvement, when some methods are called.

Since versioning seems to be the default option for version < 5.4, I changed the default option for it in `ilObjFileAccessSettings` from off ('0') to on ('1').

