### PR TITLE
LM/CoPage/ArtifactBuilder: Add existence check when defining constants

### DIFF
--- a/Modules/LearningModule/classes/class.ilLMPageObject.php
+++ b/Modules/LearningModule/classes/class.ilLMPageObject.php
@@ -1,10 +1,15 @@
 <?php
 
 /* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
-
-define ("IL_CHAPTER_TITLE", "st_title");
-define ("IL_PAGE_TITLE", "pg_title");
-define ("IL_NO_HEADER", "none");
+if (!defined('IL_CHAPTER_TITLE')) {
+	define("IL_CHAPTER_TITLE", "st_title");
+}
+if (!defined('IL_PAGE_TITLE')) {
+	define("IL_PAGE_TITLE", "pg_title");
+}
+if (!defined('IL_NO_HEADER')) {
+	define("IL_NO_HEADER", "none");
+}
 
 /**
 * Class ilLMPageObject

--- a/Services/COPage/classes/class.ilPageObject.php
+++ b/Services/COPage/classes/class.ilPageObject.php
@@ -5,9 +5,15 @@ define("IL_INSERT_BEFORE", 0);
 define("IL_INSERT_AFTER", 1);
 define("IL_INSERT_CHILD", 2);
 
-define ("IL_CHAPTER_TITLE", "st_title");
-define ("IL_PAGE_TITLE", "pg_title");
-define ("IL_NO_HEADER", "none");
+if (!defined('IL_CHAPTER_TITLE')) {
+	define("IL_CHAPTER_TITLE", "st_title");
+}
+if (!defined('IL_PAGE_TITLE')) {
+	define("IL_PAGE_TITLE", "pg_title");
+}
+if (!defined('IL_NO_HEADER')) {
+	define("IL_NO_HEADER", "none");
+}
 
 /** @defgroup ServicesCOPage Services/COPage
  */


### PR DESCRIPTION
This PR will fix the re-declaration of constants. The artifact builder complains abouth this when running our CI builds and produces ugly error messages in the protocol.