### PR TITLE
ArtifactBuilder/News/Feeds: Add existence check when defining constants

### DIFF
--- a/Modules/ExternalFeed/classes/class.ilExternalFeedBlockGUI.php
+++ b/Modules/ExternalFeed/classes/class.ilExternalFeedBlockGUI.php
@@ -2,10 +2,18 @@
 
 /* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-define("IL_FORM_EDIT", 0);
-define("IL_FORM_CREATE", 1);
-define("IL_FORM_RE_EDIT", 2);
-define("IL_FORM_RE_CREATE", 3);
+if (!defined('IL_FORM_EDIT')) {
+	define("IL_FORM_EDIT", 0);
+}
+if (!defined('IL_FORM_CREATE')) {
+	define("IL_FORM_CREATE", 1);
+}
+if (!defined('IL_FORM_RE_EDIT')) {
+	define("IL_FORM_RE_EDIT", 2);
+}
+if (!defined('IL_FORM_RE_CREATE')) {
+	define("IL_FORM_RE_CREATE", 3);
+}
 
 /**
 * BlockGUI class for external feed block. This is the one that is used

--- a/Services/News/classes/class.ilNewsItemGUI.php
+++ b/Services/News/classes/class.ilNewsItemGUI.php
@@ -4,10 +4,18 @@
 
 include_once("./Services/News/classes/class.ilNewsItem.php");
 
-define("IL_FORM_EDIT", 0);
-define("IL_FORM_CREATE", 1);
-define("IL_FORM_RE_EDIT", 2);
-define("IL_FORM_RE_CREATE", 3);
+if (!defined('IL_FORM_EDIT')) {
+	define("IL_FORM_EDIT", 0);
+}
+if (!defined('IL_FORM_CREATE')) {
+	define("IL_FORM_CREATE", 1);
+}
+if (!defined('IL_FORM_RE_EDIT')) {
+	define("IL_FORM_RE_EDIT", 2);
+}
+if (!defined('IL_FORM_RE_CREATE')) {
+	define("IL_FORM_RE_CREATE", 3);
+}
 
 /**
  * User Interface for NewsItem entities.


### PR DESCRIPTION
This PR will fix the re-declaration of constants. The artifact builder complains abouth this when running our CI builds and produces ugly error messages in the protocol.