### PR TITLE
ArtifactBuilder/ExternalFeed/CLI: Add existence check when defining c…

### DIFF
--- a/Services/Feeds/classes/class.ilExternalFeed.php
+++ b/Services/Feeds/classes/class.ilExternalFeed.php
@@ -3,7 +3,9 @@
 
 require_once './Services/Http/classes/class.ilProxySettings.php';
 
-define("MAGPIE_DIR", "./Services/Feeds/magpierss/");
+if (!defined("MAGPIE_DIR")) {
+	define("MAGPIE_DIR", "./Services/Feeds/magpierss/");
+}
 define("MAGPIE_CACHE_ON", true);
 define("MAGPIE_CACHE_DIR", "./".ILIAS_WEB_DIR."/".CLIENT_ID."/magpie_cache");
 define('MAGPIE_OUTPUT_ENCODING', "UTF-8");

--- a/setup/cli.php
+++ b/setup/cli.php
@@ -4,7 +4,9 @@
 
 
 // according to ./Services/Feeds/classes/class.ilExternalFeed.php:
-define("MAGPIE_DIR", "./Services/Feeds/magpierss/");
+if (!defined("MAGPIE_DIR")) {
+	define("MAGPIE_DIR", "./Services/Feeds/magpierss/");
+}
 
 require_once(__DIR__."/classes/class.ilSetupLanguage.php");
 require_once(__DIR__."/classes/class.ilCtrlStructureReader.php");


### PR DESCRIPTION
…onstants

This PR will fix the re-declaration of constants. The artifact builder complains abouth this when running our CI builds and produces ugly error messages in the protocol.