### PR TITLE
ArtifactBuilder/Unicode: Add existence check when defining constants

### DIFF
--- a/Services/Utilities/classes/class.ilMWParserAdapter.php
+++ b/Services/Utilities/classes/class.ilMWParserAdapter.php
@@ -16,7 +16,9 @@ if (!function_exists("wfProfileOut"))
 include_once("./include/Unicode/UtfNormalUtil.php");
 
 // From include/Unicode/UtfNormal.php
-define( 'UTF8_REPLACEMENT', "\xef\xbf\xbd" /*codepointToUtf8( UNICODE_REPLACEMENT )*/ );
+if (!defined('UTF8_REPLACEMENT')) {
+	define('UTF8_REPLACEMENT', "\xef\xbf\xbd" /*codepointToUtf8( UNICODE_REPLACEMENT )*/);
+}
 
 /**
  * Returns a regular expression of url protocols

--- a/include/Unicode/UtfNormal.php
+++ b/include/Unicode/UtfNormal.php
@@ -65,7 +65,9 @@ define( 'UTF8_HANGUL_TEND', "\xe1\x87\x82" /*codepointToUtf8( UNICODE_HANGUL_TEN
 define( 'UTF8_SURROGATE_FIRST', "\xed\xa0\x80" /*codepointToUtf8( UNICODE_SURROGATE_FIRST )*/ );
 define( 'UTF8_SURROGATE_LAST', "\xed\xbf\xbf" /*codepointToUtf8( UNICODE_SURROGATE_LAST )*/ );
 define( 'UTF8_MAX', "\xf4\x8f\xbf\xbf" /*codepointToUtf8( UNICODE_MAX )*/ );
-define( 'UTF8_REPLACEMENT', "\xef\xbf\xbd" /*codepointToUtf8( UNICODE_REPLACEMENT )*/ );
+if (!defined('UTF8_REPLACEMENT')) {
+	define( 'UTF8_REPLACEMENT', "\xef\xbf\xbd" /*codepointToUtf8( UNICODE_REPLACEMENT )*/ );
+}
 #define( 'UTF8_REPLACEMENT', '!' );
 
 define( 'UTF8_OVERLONG_A', "\xc1\xbf" );


### PR DESCRIPTION
This PR will fix the re-declaration of constants. The artifact builder complains abouth this when running our CI builds and produces ugly error messages in the protocol.