### PR TITLE
ArtifactBuilder/ExternalFeed: Fix usage of undefined constants

### DIFF
--- a/Services/Feeds/classes/class.ilExternalFeed.php
+++ b/Services/Feeds/classes/class.ilExternalFeed.php
@@ -5,7 +5,9 @@ require_once './Services/Http/classes/class.ilProxySettings.php';
 
 define("MAGPIE_DIR", "./Services/Feeds/magpierss/");
 define("MAGPIE_CACHE_ON", true);
-define("MAGPIE_CACHE_DIR", "./".ILIAS_WEB_DIR."/".CLIENT_ID."/magpie_cache");
+if (defined('ILIAS_WEB_DIR') && defined('CLIENT_ID')) {
+	define("MAGPIE_CACHE_DIR", "./" . ILIAS_WEB_DIR . "/" . CLIENT_ID . "/magpie_cache");
+}
 define('MAGPIE_OUTPUT_ENCODING', "UTF-8");
 define('MAGPIE_CACHE_AGE', 900);			// 900 seconds = 15 minutes
 include_once(MAGPIE_DIR."/rss_fetch.inc");


### PR DESCRIPTION
This PR will fix the usage of undefined constants when the file is included by the artifact builder. The artifact builder complains abouth this when running our CI builds and produces ugly error messages in the protocol.