### PR TITLE
Add's an ID to this table.

### DIFF
--- a/Modules/Test/classes/tables/class.ilTestSkillLevelThresholdsTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilTestSkillLevelThresholdsTableGUI.php
@@ -48,7 +48,7 @@ class ilTestSkillLevelThresholdsTableGUI extends ilTable2GUI
 
 		$this->lng = $lng;
 		$this->ctrl = $ctrl;
-
+		$this->setId('tstSkillLevelThreshold');
 		$this->lng->loadLanguageModule('form');
 
 		$this->setStyle('table', 'fullwidth');


### PR DESCRIPTION
There's an issue with Thresholds on competencies, if you have multiple pages of them you can't save properly and there's no row selector on this table without the ID. If you have all the competencies on one page and save it works but not otherwise.