### PR TITLE
UI: Revision of Mainbar

### DIFF
--- a/src/UI/Component/MainControls/MainBar.php
+++ b/src/UI/Component/MainControls/MainBar.php
@@ -118,4 +118,9 @@ interface MainBar extends \ILIAS\UI\Component\Component, JavaScriptBindable
      * Get a copy of this Mainbar without any entries.
      */
     public function withClearedEntries() : MainBar;
+
+    /**
+     * Signal to toggle the tools-section.
+     */
+    public function getToggleToolsSignal() : Signal;
 }

--- a/src/UI/Component/MainControls/Slate/Slate.php
+++ b/src/UI/Component/MainControls/Slate/Slate.php
@@ -56,6 +56,17 @@ interface Slate extends Component, JavaScriptBindable, Triggerer
      */
     public function getReplaceSignal() : ReplaceSignal;
 
-
+    /**
+     * A Signal that is triggered when the slate "comes into view", i.e. is being engaged.
+     */
     public function appendOnInView(Signal $signal) : Slate;
+
+    /**
+     * Slates in the mainbar need to be adressable via JS, a.o. for storing
+     * current activation states or triggering them from the outside.
+     */
+    public function withMainBarTreePosition(string $tree_pos);
+
+    public function getMainBarTreePosition();
+
 }

--- a/src/UI/Implementation/Component/MainControls/MainBar.php
+++ b/src/UI/Implementation/Component/MainControls/MainBar.php
@@ -21,6 +21,13 @@ class MainBar implements MainControls\MainBar
     use ComponentHelper;
     use JavaScriptBindable;
 
+    const ENTRY_ACTION_TRIGGER = 'trigger';
+    const ENTRY_ACTION_REMOVE = 'remove';
+    const ENTRY_ACTION_TRIGGER_MAPPED = 'trigger_mapped';
+    const ENTRY_ACTION_TOGGLE_TOOLS = 'toggle_tools';
+    const ENTRY_ACTION_DISENGAGE_ALL = 'disengage_all';
+    const NONE_ACTIVE = '_none';
+
     /**
      * @var SignalGeneratorInterface
      */
@@ -86,6 +93,11 @@ class MainBar implements MainControls\MainBar
      */
     private $close_buttons = [];
 
+    /**
+     * @var string
+     */
+     private $mainbar_tree_position;
+
     public function __construct(SignalGeneratorInterface $signal_generator)
     {
         $this->signal_generator = $signal_generator;
@@ -150,7 +162,10 @@ class MainBar implements MainControls\MainBar
 
         $clone = clone $this;
         $clone->tool_entries[$id] = $entry;
-        $clone->tool_signals[$id] = $this->signal_generator->create();
+        $signal = $this->signal_generator->create();
+        $signal->addOption('entry_id', $id);
+        $signal->addOption('action', self::ENTRY_ACTION_TRIGGER_MAPPED);
+        $clone->tool_signals[$id] = $signal;
 
         if($initially_hidden) {
             $clone->initially_hidden_ids[] = $id;
@@ -231,6 +246,14 @@ class MainBar implements MainControls\MainBar
     }
 
     /**
+     * @inheritdoc
+     */
+    public function getToggleToolsSignal() : Signal
+    {
+        return $this->toggle_tools_signal;
+    }
+
+    /**
      * Set the signals for this component
      */
     protected function initSignals()
@@ -239,6 +262,9 @@ class MainBar implements MainControls\MainBar
         $this->tools_click_signal = $this->signal_generator->create();
         $this->tools_removal_signal = $this->signal_generator->create();
         $this->disengage_all_signal = $this->signal_generator->create();
+        $this->disengage_all_signal->addOption('action', self::ENTRY_ACTION_DISENGAGE_ALL);
+        $this->toggle_tools_signal = $this->signal_generator->create();
+        $this->toggle_tools_signal->addOption('action', self::ENTRY_ACTION_TOGGLE_TOOLS);
     }
 
     public function withResetSignals() : MainControls\MainBar
@@ -266,7 +292,8 @@ class MainBar implements MainControls\MainBar
     {
         $valid_entries = array_merge(
             array_keys($this->entries),
-            array_keys($this->tool_entries)
+            array_keys($this->tool_entries),
+            [self::NONE_ACTIVE]
         );
         if (!in_array($active, $valid_entries)) {
             throw new \InvalidArgumentException("Invalid entry to activate: $active", 1);
@@ -310,4 +337,42 @@ class MainBar implements MainControls\MainBar
         return $clone;
     }
 
+    public function getTriggerSignal(
+        string $entry_id,
+        string $action
+    ): Signal {
+        if(! in_array($action, [self::ENTRY_ACTION_TRIGGER, self::ENTRY_ACTION_REMOVE])) {
+            throw new InvalidArgumentException("invalid action for mainbar entry: $action", 1);
+        }
+        $signal = $this->signal_generator->create();
+        $signal->addOption('entry_id', $entry_id);
+        $signal->addOption('action', $action);
+        return $signal;
+    }
+
+    public function withMainBarTreePosition(string $tree_pos): MainBar
+    {
+        $clone = clone $this;
+        $clone->mainbar_tree_position = $tree_pos;
+        return $clone;
+    }
+
+    public function withMappedSubNodes(callable $f): MainBar
+    {
+        $clone = clone $this;
+
+        $counter = 0;
+        foreach ($clone->getEntries() as $k => $v) {
+            $clone->entries[$k] = $f($counter, $v, false);
+            $counter++;
+        }
+
+        $counter = 0;
+        foreach ($clone->getToolEntries() as $k => $v) {
+            $clone->tool_entries[$k] = $f($counter, $v, true);
+            $counter++;
+        }
+
+        return $clone;
+    }
 }

--- a/src/UI/Implementation/Component/MainControls/Renderer.php
+++ b/src/UI/Implementation/Component/MainControls/Renderer.php
@@ -18,10 +18,10 @@ class Renderer extends AbstractComponentRenderer
 {
     const BLOCK_MAINBAR_ENTRIES = 'trigger_item';
     const BLOCK_MAINBAR_TOOLS = 'tool_trigger_item';
-    const BLOCK_MAINBAR_TOOLS_HIDDEN = 'tool_trigger_item_hidden';
     const BLOCK_METABAR_ENTRIES = 'meta_element';
 
     private $signals_for_tools = [];
+    private $trigger_signals = [];
 
     /**
      * @inheritdoc
@@ -44,79 +44,194 @@ class Renderer extends AbstractComponentRenderer
         }
     }
 
+    protected function calculateMainBarTreePosition($pos, $slate)
+    {
+         if (!$slate instanceof Slate && !$slate instanceof MainBar) {
+            return $slate;
+        }
+        return $slate
+            ->withMainBarTreePosition($pos)
+            ->withMappedSubNodes(
+                function($num, $slate, $is_tool=false) use ($pos) {
+                    if($is_tool) {
+                        $pos = 'T';
+                    }
+                    return $this->calculateMainBarTreePosition("$pos:$num", $slate, $is_tool);
+                }
+            );
+    }
+
+
+
+
+
+    protected function renderToolEntry(
+        Slate $entry,
+        string $entry_id,
+        string $mb_id,
+        MainBar $component,
+        UITemplateWrapper $tpl,
+        RendererInterface $default_renderer
+    ): string {
+        $hidden = $component->getInitiallyHiddenToolIds();
+        $close_buttons = $component->getCloseButtons();
+
+        $is_removeable = array_key_exists($entry_id, $close_buttons);
+        $is_hidden = in_array($entry_id, $hidden);
+
+        if($is_removeable) {
+            $trigger_signal = $component->getTriggerSignal($mb_id, $component::ENTRY_ACTION_REMOVE);
+            $this->trigger_signals[] = $trigger_signal;
+            $btn_removetool = $close_buttons[$entry_id]
+               ->withAdditionalOnloadCode(
+                    function ($id) use ($mb_id) {
+                        return "il.UI.maincontrols.mainbar.addPartIdAndEntry('{$mb_id}', 'remover', '{$id}', true);";
+                    }
+                )
+                ->withOnClick($trigger_signal);
+
+            $tpl->setCurrentBlock("tool_removal");
+            $tpl->setVariable("REMOVE_TOOL", $default_renderer->render($btn_removetool));
+            $tpl->parseCurrentBlock();
+        }
+
+        $is_removeable = $is_removeable ? 'true':'false';
+        $is_hidden = $is_hidden ? 'true':'false';
+        return "il.UI.maincontrols.mainbar.addToolEntry('{$mb_id}', {$is_removeable}, {$is_hidden});";
+    }
+
+
+
+
+    protected function renderMainbarEntry(
+        array $entries,
+        string $block,
+        MainBar $component,
+        UITemplateWrapper $tpl,
+        RendererInterface $default_renderer
+    ) {
+        $f = $this->getUIFactory();
+        foreach ($entries as $k => $entry) {
+            $button = $entry;
+            $slate = null;
+
+            if ($entry instanceof Slate) {
+                $slate = $entry;
+                $mb_id = $entry->getMainBarTreePosition();
+
+                $is_tool = $block === static::BLOCK_MAINBAR_TOOLS;
+                $js = '';
+                if($is_tool) {
+                    $js = $this->renderToolEntry($entry, $k, $mb_id, $component, $tpl, $default_renderer);
+                }
+
+                $trigger_signal = $component->getTriggerSignal($mb_id, $component::ENTRY_ACTION_TRIGGER);
+                $this->trigger_signals[] = $trigger_signal;
+                $button = $f->button()->bulky($entry->getSymbol(), $entry->getName(), '#')
+                    ->withOnClick($trigger_signal)
+                    ->withAdditionalOnLoadCode(
+                        function ($id) use ($js, $mb_id, $k, $is_tool) {
+                            $add_as_tool = $is_tool ? 'true':'false';
+                            $js .= "
+                                il.UI.maincontrols.mainbar.addPartIdAndEntry('{$mb_id}', 'triggerer', '{$id}', {$add_as_tool});
+                                il.UI.maincontrols.mainbar.addMapping('{$k}','{$mb_id}');
+                            ";
+                            return $js;
+                        }
+                    );
+            }
+
+            $tpl->setCurrentBlock($block);
+            $tpl->setVariable("BUTTON", $default_renderer->render($button));
+            $tpl->parseCurrentBlock();
+
+            if($slate) {
+                $tpl->setCurrentBlock("slate_item");
+                $tpl->setVariable("SLATE", $default_renderer->render($entry));
+                $tpl->parseCurrentBlock();
+            }
+        }
+    }
+
     protected function renderMainbar(MainBar $component, RendererInterface $default_renderer)
     {
+        $f = $this->getUIFactory();
         $tpl = $this->getTemplate("tpl.mainbar.html", true, true);
-        $active =  $component->getActive();
-        $tools = $component->getToolEntries();
-        $signals = [
-            'entry' => $component->getEntryClickSignal(),
-            'tools' => $component->getToolsClickSignal(),
-            'close_slates' => $component->getDisengageAllSignal(),
-            'tools_removal' => $component->getToolsRemovalSignal()
-        ];
 
-
-        $this->renderTriggerButtonsAndSlates(
-            $tpl,
-            $default_renderer,
-            $signals['entry'],
-            static::BLOCK_MAINBAR_ENTRIES,
-            $component->getEntries(),
-            $active
+        //add "more"-slate
+        $more_button = $component->getMoreButton();
+        $more_slate = $f->maincontrols()->slate()->combined(
+            $more_button->getLabel(),
+            $more_button->getIconOrGlyph()
+        );
+        $component = $component->withAdditionalEntry(
+            '_mb_more_entry',
+             $more_slate
         );
 
-        if (count($tools) > 0) {
-            $tools_button = $component->getToolsButton();
-            $initially_hidden_ids = $component->getInitiallyHiddenToolIds();
-            $close_buttons = $component->getCloseButtons();
-            $this->addTools(
-                $tpl,
-                $default_renderer,
-                $tools_button,
-                $tools,
-                $signals,
-                $active,
-                $initially_hidden_ids,
-                $close_buttons
+        $component = $this->calculateMainBarTreePosition("0", $component);
+
+        $mb_entries = [
+            static::BLOCK_MAINBAR_ENTRIES => $component->getEntries(),
+            static::BLOCK_MAINBAR_TOOLS => $component->getToolEntries()
+        ];
+
+        foreach ($mb_entries as $block => $entries) {
+            $this->renderMainbarEntry(
+                $entries,
+                $block,
+                $component, $tpl, $default_renderer
             );
         }
 
-        $more_button = $component->getMoreButton();
-        $this->addMoreSlate($tpl, $default_renderer, static::BLOCK_MAINBAR_ENTRIES, $more_button, $signals, $active);
-        $this->addCloseSlateButton($tpl, $default_renderer, $signals);
-        $this->addMainbarJS($tpl, $component, $signals, $active);
+        //tools-section trigger
+        if(count($component->getToolEntries()) > 0) {
+            $btn_tools = $component->getToolsButton()
+                ->withOnClick($component->getToggleToolsSignal());
+
+            $tpl->setCurrentBlock("tools_trigger");
+            $tpl->setVariable("BUTTON", $default_renderer->render($btn_tools));
+            $tpl->parseCurrentBlock();
+        }
+
+        //disengage all, close slates
+        $btn_disengage = $f->button()->bulky($f->symbol()->glyph()->back("#"), "close", "#")
+            ->withOnClick($component->getDisengageAllSignal());
+        $tpl->setVariable("CLOSE_SLATES", $default_renderer->render($btn_disengage));
+
+
+        $id = $this->bindMainbarJS($component);
+        $tpl->setVariable('ID', $id);
 
         return $tpl->get();
     }
 
     protected function renderMetabar(MetaBar $component, RendererInterface $default_renderer)
     {
+        $f = $this->getUIFactory();
         $tpl = $this->getTemplate("tpl.metabar.html", true, true);
         $active = '';
         $signals = [
             'entry' => $component->getEntryClickSignal(),
             'close_slates' => $component->getDisengageAllSignal()
         ];
+        $entries = $component->getEntries();
+
+        $more_label = 'more';
+        $more_symbol = $f->symbol()->glyph()->more()
+            ->withCounter($f->counter()->novelty(0))
+            ->withCounter($f->counter()->status(0));
+        $more_slate = $f->maincontrols()->slate()->combined($more_label, $more_symbol, $f->legacy(''));
+        $entries[] = $more_slate;
 
         $this->renderTriggerButtonsAndSlates(
             $tpl,
             $default_renderer,
             $signals['entry'],
             static::BLOCK_METABAR_ENTRIES,
-            $component->getEntries(),
+            $entries,
             $active
         );
-
-        $more_button = $this->getUIFactory()->button()->bulky(
-            $this->getUIFactory()->symbol()->glyph()->more()
-                 ->withCounter($this->getUIFactory()->counter()->novelty(0))
-                 ->withCounter($this->getUIFactory()->counter()->status(0)),
-            'more',
-            '#'
-        );
-
-        $this->addMoreSlate($tpl, $default_renderer, static::BLOCK_METABAR_ENTRIES, $more_button, $signals, $active);
 
         $component = $component->withOnLoadCode(
             function ($id) use ($signals) {
@@ -170,50 +285,18 @@ class Renderer extends AbstractComponentRenderer
             if ($entry instanceof Slate) {
                 $f = $this->getUIFactory();
                 $secondary_signal = $entry->getToggleSignal();
-                if ($block === static::BLOCK_MAINBAR_TOOLS) {
-                    $secondary_signal = $entry->getEngageSignal();
-                }
                 $button = $f->button()->bulky($entry->getSymbol(), $entry->getName(), '#')
                     ->withOnClick($entry_signal)
                     ->appendOnClick($secondary_signal)
                     ->withEngagedState($engaged);
 
                 $slate = $entry;
-                $slate = $slate->withEngaged(false); //init disengaged, onLoadCode will "click" the button
             } else {
                 $button = $entry;
                 $slate = null;
             }
 
-            if ($block === static::BLOCK_MAINBAR_TOOLS) {
-                $this->button_id = null;
-                $button = $button->withAdditionalOnLoadCode(
-                    function ($id) use ($button_id) {
-                        $this->button_id = $id;
-                    }
-                );
-                $button_html = $default_renderer->render($button);
-                $button_id = $this->button_id;
-
-                //closeable tool
-                if(array_key_exists($id, $close_buttons)) {
-                    $btn_removetool = $close_buttons[$id]
-                        ->appendOnClick($tool_removal_signal);
-                    $tpl->setCurrentBlock("tool_removal");
-                    $tpl->setVariable("REMOVE_TOOL_ID", $button_id);
-                    $tpl->setVariable("REMOVE_TOOL", $default_renderer->render($btn_removetool));
-                    $tpl->parseCurrentBlock();
-                }
-
-                //initially hidden
-                if(in_array($id, $initially_hidden_ids)) {
-                    $this->signals_for_tools[$id] = $button_id;
-                    $use_block = static::BLOCK_MAINBAR_TOOLS_HIDDEN;
-                }
-
-            } else {
-                $button_html = $default_renderer->render($button);
-            }
+            $button_html = $default_renderer->render($button);
 
             $tpl->setCurrentBlock($use_block);
             $tpl->setVariable("BUTTON", $button_html);
@@ -227,121 +310,39 @@ class Renderer extends AbstractComponentRenderer
         }
     }
 
-    protected function addCloseSlateButton(
-        UITemplateWrapper $tpl,
-        RendererInterface $default_renderer,
-        array $signals
-    ) {
-        $f = $this->getUIFactory();
-        $btn_disengage = $f->button()->bulky($f->symbol()->glyph()->back("#"), "close", "#")
-            ->withOnClick($signals['close_slates']);
-        $tpl->setVariable("CLOSE_SLATES", $default_renderer->render($btn_disengage));
-    }
+    protected function bindMainbarJS(MainBar $component): string
+    {
+        $trigger_signals = $this->trigger_signals;
 
-    protected function addTools(
-        UITemplateWrapper $tpl,
-        RendererInterface $default_renderer,
-        Component\Button\Bulky $tools_button,
-        array $tools,
-        array $signals,
-        string $active = null,
-        array $initially_hidden_ids = [],
-        array $close_buttons
-    ) {
-        $f = $this->getUIFactory();
+        $inititally_active = $component->getActive();
 
-        $btn_tools = $tools_button
-            ->withOnClick($signals['tools'])
-            ->withEngagedState(false); //if a tool-entry is active, onLoadCode will "click" the button
-
-        $tpl->setCurrentBlock("tools_trigger");
-        $tpl->setVariable("BUTTON", $default_renderer->render($btn_tools));
-        $tpl->parseCurrentBlock();
-
-        $this->renderTriggerButtonsAndSlates(
-            $tpl,
-            $default_renderer,
-            $signals['entry'],
-            static::BLOCK_MAINBAR_TOOLS,
-            $tools,
-            $active,
-            $initially_hidden_ids,
-            $close_buttons,
-            $signals['tools_removal']
-        );
-    }
-
-    protected function addMoreSlate(
-        UITemplateWrapper $tpl,
-        RendererInterface $default_renderer,
-        string $block,
-        Component\Button\Bulky $more_button,
-        array $signals,
-        string $active = null
-    ) {
-        $f = $this->getUIFactory();
-        $more_label = $more_button->getLabel();
-        $more_symbol = $more_button->getIconOrGlyph();
-        $more_slate = $f->maincontrols()->slate()->combined($more_label, $more_symbol, $f->legacy(''));
-        $this->renderTriggerButtonsAndSlates(
-            $tpl,
-            $default_renderer,
-            $signals['entry'],
-            $block,
-            [$more_slate],
-            $active
-        );
-    }
-
-    protected function addMainbarJS(
-        UITemplateWrapper $tpl,
-        MainBar $component,
-        array $signals,
-        string $active = null
-    ) {
-        $ext_signals =  $this->signals_for_tools;
         $component = $component->withOnLoadCode(
-            function ($id) use ($signals, $ext_signals, $component) {
-                $entry_signal = $signals['entry'];
-                $tools_signal = $signals['tools'];
-                $close_slates_signal = $signals['close_slates'];
-                $tool_removal_signal = $signals['tools_removal'];
-                $js = "
-                    il.UI.maincontrols.mainbar.registerSignals(
-                        '{$id}',
-                        '{$entry_signal}',
-                        '{$close_slates_signal}',
-                        '{$tools_signal}',
-                        '{$tool_removal_signal}'
-                    );
-                    il.UI.maincontrols.mainbar.initMore();
-                    $(window).resize(il.UI.maincontrols.mainbar.initMore);
-				";
+            function ($id) use ($component, $trigger_signals, $inititally_active)  {
+                $disengage_all_signal = $component->getDisengageAllSignal();
+                $tools_toggle_signal = $component->getToggleToolsSignal();
 
-                foreach ($ext_signals as $key => $btn_id) {
-                    $ext_signal = $component->getEngageToolSignal($key);
-                    $js .= "
-                        il.UI.maincontrols.mainbar.addExternalSignals(
-                            '{$id}',
-                            '{$ext_signal}',
-                            '{$btn_id}'
-                        );
-                    ";
+                $js .= "il.UI.maincontrols.mainbar.addTriggerSignal('{$disengage_all_signal}');";
+                $js .= "il.UI.maincontrols.mainbar.addTriggerSignal('{$tools_toggle_signal}');";
+
+                foreach ($trigger_signals as $signal) {
+                    $js .= "il.UI.maincontrols.mainbar.addTriggerSignal('{$signal}');";
                 }
+
+                foreach ($component->getToolEntries() as $k => $tool) {
+                    $signal = $component->getEngageToolSignal($k);
+                    $js .= "il.UI.maincontrols.mainbar.addTriggerSignal('{$signal}');";
+                }
+
+                $js .= "
+                    $(window).resize(il.UI.maincontrols.mainbar.adjustToScreenSize);
+                    il.UI.maincontrols.mainbar.init('{$inititally_active}');
+                ";
                 return $js;
             }
         );
 
-        if ($active) {
-            $component = $component->withAdditionalOnLoadCode(
-                function ($id) {
-                    return "il.UI.maincontrols.mainbar.initActive('{$id}');";
-                }
-            );
-        }
-
         $id = $this->bindJavaScript($component);
-        $tpl->setVariable('ID', $id);
+        return $id;
     }
 
     protected function renderFooter(Footer $component, RendererInterface $default_renderer)
@@ -373,6 +374,7 @@ class Renderer extends AbstractComponentRenderer
         parent::registerResources($registry);
         $registry->register('./src/UI/templates/js/MainControls/mainbar.js');
         $registry->register('./src/UI/templates/js/MainControls/metabar.js');
+        $registry->register('./src/GlobalScreen/Client/dist/GS.js');
     }
 
     /**

--- a/src/UI/Implementation/Component/MainControls/Slate/Combined.php
+++ b/src/UI/Implementation/Component/MainControls/Slate/Combined.php
@@ -9,13 +9,16 @@ namespace ILIAS\UI\Implementation\Component\MainControls\Slate;
 use ILIAS\UI\Component\MainControls\Slate as ISlate;
 use ILIAS\UI\Component\Button\Bulky as IBulkyButton;
 use ILIAS\UI\Component\Link\Bulky as IBulkyLink;
-use ILIAS\UI\Implementation\Component\SignalGeneratorInterface;
+use ILIAS\UI\Component\Signal;
+
 
 /**
  * Combined Slate
  */
 class Combined extends Slate implements ISlate\Combined
 {
+    const ENTRY_ACTION_TRIGGER = 'trigger';
+
     /**
      * @var array<Slate|BulkyButton|BulkyLink>
      */
@@ -45,5 +48,26 @@ class Combined extends Slate implements ISlate\Combined
     public function getContents() : array
     {
         return $this->contents;
+    }
+
+
+    public function getTriggerSignal(string $entry_id) : Signal
+    {
+        $signal = $this->signal_generator->create();
+        $signal->addOption('entry_id', $entry_id);
+        $signal->addOption('action', self::ENTRY_ACTION_TRIGGER);
+        $this->$trigger_signals[] = $signal;
+        return $signal;
+    }
+
+    public function withMappedSubNodes(callable $f)
+    {
+        $clone = clone $this;
+        $new_contents = [];
+        foreach ($clone->getContents() as $k => $v) {
+            $new_contents[$k] = $f($k, $v);
+        }
+        $clone->contents = $new_contents;
+        return $clone;
     }
 }

--- a/src/UI/Implementation/Component/MainControls/Slate/Legacy.php
+++ b/src/UI/Implementation/Component/MainControls/Slate/Legacy.php
@@ -34,4 +34,8 @@ class Legacy extends Slate implements ISlate\Legacy
     {
         return $this->contents;
     }
+
+    public function withMappedSubNodes(callable $f) {
+        return $this;
+    }
 }

--- a/src/UI/Implementation/Component/MainControls/Slate/Notification.php
+++ b/src/UI/Implementation/Component/MainControls/Slate/Notification.php
@@ -47,4 +47,8 @@ class Notification extends Slate implements ISlate\Notification
     {
         return $this->contents;
     }
+
+    public function withMappedSubNodes(callable $f) {
+        return $this;
+    }
 }

--- a/src/UI/Implementation/Component/MainControls/Slate/Renderer.php
+++ b/src/UI/Implementation/Component/MainControls/Slate/Renderer.php
@@ -35,18 +35,25 @@ class Renderer extends AbstractComponentRenderer
         $contents = [];
         foreach ($component->getContents() as $entry) {
             if ($entry instanceof ISlate\Slate && !$entry instanceof ISlate\Notification) {
-                $init_state = 'disengaged';
-                if ($entry->getEngaged()) {
-                    $init_state = 'engaged';
-                }
-                $triggerer = $f->button()->bulky($entry->getSymbol(), $entry->getName(), '#')
-                    ->withOnClick($entry->getToggleSignal())
-                    ->withAdditionalOnloadCode(
-                        function ($id) use ($init_state) {
-                            return "$('#{$id}').addClass('{$init_state}');";
-                        }
-                    );
 
+                $trigger_signal = $entry->getToggleSignal();
+                $triggerer = $f->button()->bulky($entry->getSymbol(), $entry->getName(), '#')
+                    ->withOnClick($trigger_signal);
+
+                $mb_id = $entry->getMainBarTreePosition();
+                if($mb_id) {
+                    $trigger_signal = $component->getTriggerSignal($mb_id);
+                    $triggerer = $triggerer
+                        ->withOnClick($trigger_signal)
+                        ->withAdditionalOnloadCode(
+                            function ($id) use ($mb_id, $trigger_signal) {
+                                return "
+                                    il.UI.maincontrols.mainbar.addTriggerSignal('{$trigger_signal}');
+                                    il.UI.maincontrols.mainbar.addPartIdAndEntry('{$mb_id}', 'triggerer', '{$id}');
+                                ";
+                            }
+                        );
+                }
                 $contents[] = $triggerer;
             }
             $contents[] = $entry;
@@ -75,14 +82,23 @@ class Renderer extends AbstractComponentRenderer
             'engage'  => $component->getEngageSignal(),
             'replace' => $component->getReplaceSignal()
         ];
-        $component     = $component->withAdditionalOnLoadCode(function ($id) use ($slate_signals) {
-            $js = "fn = il.UI.maincontrols.slate.onSignal;";
-            foreach ($slate_signals as $key => $signal) {
-                $js .= "$(document).on('{$signal}', function(event, signalData) { fn('{$key}', event, signalData, '{$id}'); return false;});";
-            }
-            return $js;
-        });
-        $id            = $this->bindJavaScript($component);
+
+        $mb_id = $component->getMainBarTreePosition();
+        $component = $component->withAdditionalOnLoadCode(
+            function ($id) use ($slate_signals, $mb_id) {
+                $js = "fn = il.UI.maincontrols.slate.onSignal;";
+                foreach ($slate_signals as $key => $signal) {
+                    $js .= "$(document).on('{$signal}', function(event, signalData) { fn('{$key}', event, signalData, '{$id}'); return false;});";
+                }
+
+                if($mb_id) {
+                    $js .= "il.UI.maincontrols.mainbar.addPartIdAndEntry('{$mb_id}', 'slate', '{$id}');";
+                }
+
+
+                return $js;
+            });
+        $id = $this->bindJavaScript($component);
         $tpl->setVariable('ID', $id);
 
         return $tpl->get();

--- a/src/UI/Implementation/Component/MainControls/Slate/Slate.php
+++ b/src/UI/Implementation/Component/MainControls/Slate/Slate.php
@@ -54,6 +54,11 @@ abstract class Slate implements ISlate\Slate
     protected $engaged = false;
 
     /**
+     * @var string
+     */
+    protected $mainbar_tree_position;
+
+    /**
      * @param string 	$name 	name of the slate, also used as label
      * @param Symbol	$symbol
      */
@@ -142,9 +147,32 @@ abstract class Slate implements ISlate\Slate
         return $this->replace_signal;
     }
 
-
+    /**
+     * @inheritdoc
+     */
     public function appendOnInView(Signal $signal) : \ILIAS\UI\Component\MainControls\Slate\Slate
     {
         return $this->appendTriggeredSignal($signal, 'in_view');
+    }
+
+
+    abstract public function withMappedSubNodes(callable $f);
+
+    /**
+     * @inheritdoc
+     */
+    public function withMainBarTreePosition(string $tree_pos)
+    {
+        $clone = clone $this;
+        $clone->mainbar_tree_position = $tree_pos;
+        return $clone;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getMainBarTreePosition()
+    {
+        return $this->mainbar_tree_position;
     }
 }

--- a/src/UI/Implementation/Component/Signal.php
+++ b/src/UI/Implementation/Component/Signal.php
@@ -49,7 +49,7 @@ class Signal implements \ILIAS\UI\Component\Signal
      * @param string $key
      * @param mixed $value
      */
-    protected function addOption($key, $value)
+    public function addOption($key, $value)
     {
         $this->options[$key] = $value;
     }

--- a/src/UI/examples/Layout/Page/Standard/ui.php
+++ b/src/UI/examples/Layout/Page/Standard/ui.php
@@ -19,17 +19,20 @@ if ($_GET['new_ui'] == '1') {
 
     $f = $DIC->ui()->factory();
     $renderer = $DIC->ui()->renderer();
-
-    $logo = $f->image()->responsive("src/UI/examples/Image/HeaderIconLarge.svg", "ILIAS");
+    $logo = $f->image()->responsive("templates/default/images/HeaderIcon.svg", "ILIAS");
     $breadcrumbs = pagedemoCrumbs($f);
     $metabar = pagedemoMetabar($f);
-    $mainbar = pagedemoMainbar($f, $renderer)
-        ->withActive("pws")
+    $mainbar = pagedemoMainbar($f, $renderer);
+    $mainbar = $mainbar
+        //->withActive("pws")
         /**
-         * You can also activate a tool initially, e.g.:
-         * ->withActive("tool2")
+         * You can also activate a tool initially
+         * or remove all active states:
          */
+         //->withActive("tool2")
+         //->withActive($mainbar::NONE_ACTIVE)
         ;
+
     $footer = pagedemoFooter($f);
 
     $entries = $mainbar->getEntries();
@@ -344,11 +347,27 @@ function getDemoEntryOrganisation($f)
     $symbol = $f->symbol()->icon()
         ->custom('./src/UI/examples/Layout/Page/Standard/organisation.svg', '')
         ->withSize('small');
-    $slate = $f->maincontrols()->slate()->legacy(
-        'Organisation',
-        $symbol,
-        $f->legacy('content: Organisation')
-    );
+
+    $sf = $f->maincontrols()->slate();
+    $slate = $sf->combined('Organisation', $symbol, '')
+        ->withAdditionalEntry(
+            $sf->combined('1', $symbol, '')
+                ->withAdditionalEntry($sf->combined('1.1', $symbol, ''))
+                ->withAdditionalEntry(
+                    $sf->combined('1.2', $symbol, '')
+                        ->withAdditionalEntry($sf->combined('1.2.1', $symbol, ''))
+                        ->withAdditionalEntry($sf->combined('1.2.2', $symbol, ''))
+                )
+        )
+        ->withAdditionalEntry(
+            $sf->combined('2', $symbol, '')
+                ->withAdditionalEntry($sf->combined('2.1', $symbol, ''))
+        )
+        ->withAdditionalEntry($sf->combined('3', $symbol, ''))
+        ->withAdditionalEntry($sf->combined('4', $symbol, ''))
+    ;
+
+
     return $slate;
 }
 

--- a/src/UI/templates/default/MainControls/tpl.mainbar.html
+++ b/src/UI/templates/default/MainControls/tpl.mainbar.html
@@ -23,14 +23,9 @@
 					{BUTTON}
 				</div>
 				<!-- END tool_trigger_item -->
-				<!-- BEGIN tool_trigger_item_hidden -->
-				<div class="il-mainbar-tool-trigger-item hidden">
-					{BUTTON}
-				</div>
-				<!-- END tool_trigger_item_hidden -->
 			</div>
 			<!-- BEGIN tool_removal -->
-			<div class="il-mainbar-remove-tool {REMOVE_TOOL_ID}">
+			<div class="il-mainbar-remove-tool">
 				{REMOVE_TOOL}
 			</div>
 			<!-- END tool_removal -->

--- a/src/UI/templates/js/MainControls/mainbar.js
+++ b/src/UI/templates/js/MainControls/mainbar.js
@@ -4,327 +4,629 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 
 (function($, maincontrols) {
 	maincontrols.mainbar = (function($) {
-
-		var id
-			,_cls_btn_engaged = 'engaged'
-			,_cls_page_active_slates = 'with-mainbar-slates-engaged' //set on _page_div
-			,_cls_entries_wrapper = 'il-mainbar-entries' //encapsulating div of all entries
-			,_cls_toolentries_wrapper = 'il-mainbar-tools-entries' //tools (within  _cls_entries_wrapper)
-			,_cls_tools_wrapper = 'il-mainbar-tools-entries-bg' //encapsulating div of all tool-entries
-			,_cls_tools_btn = 'il-mainbar-tools-button' //encapsulating div of the tools-button
-			,_cls_page_div = 'il-layout-page' //encapsulating div of the page
-			,_cls_slates_wrapper = 'il-mainbar-slates' //encapsulating div of mainbar's slates
-			,_cls_single_slate = false //class of one single slate, will be set on registerSignals
-			,_cls_slate_engaged = false //engaged class of a slate, will be set on registerSignals
-			,_cls_mainbar = 'il-mainbar';
-		;
-
-		var registerSignals = function (
-			component_id,
-			entry_signal,
-			close_slates_signal,
-			tools_signal,
-			tools_removal_signal
-		) {
-			id = component_id;
-			_cls_single_slate = il.UI.maincontrols.slate._cls_single_slate;
-			_cls_slate_engaged = il.UI.maincontrols.slate._cls_engaged;
-
-			$(document).on(entry_signal, function(event, signalData) {
-				onClickEntry(event, signalData);
-				return false;
-			});
-			$(document).on(close_slates_signal, function(event, signalData) {
-				onClickDisengageAll(event, signalData);
-				return false;
-			});
-			$(document).on(tools_signal, function(event, signalData) {
-				onClickToolsEntry(event, signalData);
-				return false;
-			});
-			$(document).on(tools_removal_signal, function(event, signalData) {
-				onClickToolRemoval(event, signalData);
-				initMore();
-				return false;
-			});
-		};
-
-		var addExternalSignals = function(component_id, signal, triggerer_id) {
-			console.log(signal);
-			$(document).on(signal, function(event, signalData) {
-				var btn = $('#' + triggerer_id);
-				btn.click();
-				btn.parent().removeClass('hidden');
-			});
-
-		}
-
-		var initActive = function(component_id) {
-			id = component_id;
-			var btn = _getAllButtons()
-				.filter('.' + _cls_btn_engaged);
-			if(btn.length == 0) {
-				 btn = _getAllToolButtons()
-					.filter('.' + _cls_btn_engaged);
-			}
-			_disengageButton(btn);
-			if(!il.UI.page.isSmallScreen()) {
-				btn.click();
-			}
-
-		}
-
-		var onClickEntry = function(event, signalData) {
-			var btn = signalData.triggerer;
-			if(_isEngaged(btn)) {
-				if(! _isToolButton(btn)) {
-					_disengageButton(btn);
-					_setPageSlatesActive(false);
+		var mappings = {},
+			external_commands = {
+				/**
+				 * Engage a certain tool
+				 */
+				engageTool: function(mapping_id) {
+					var tool_id = mappings[mapping_id];
+					this.model.actions.engageTool(tool_id);
+					this.renderer.render(this.model.getState());
+				},
+				/**
+				 * Just open the tools, activate last one
+				 */
+				engageTools: function() {
+					var tool_id = Object.keys(mappings).slice(-1)[0];
+					this.engageTool(tool_id);
 				}
-			} else {
-				_disengageAllButtons(); //reset, so that only _one_ is active
-				if(_isToolButton(btn)) {
-					_disengageAllToolButtons();
+			},
+			construction = {
+				/**
+				 * Add an entry to the model representing a tool.
+				 * A tool, other than a regular entry, may be removeable by a user
+				 * or may be invisible at first.
+				 * This only adds to the model, the html-parts still need to be registered.
+				 */
+				addToolEntry: function (position_id, removeable = true, hidden = false) {
+					this.model.actions.addTool(position_id, removeable, hidden);
+				},
+				/**
+				 * An entry consists of several visible parts: the button, the slate and
+				 * the close-button (remover).
+				 * All these parts are summed up in the model via the position_id;
+				 * however, when it comes to rendering, the individual parts are needed.
+				 * The function also adds an entry to the model if there is none already.
+				 */
+				addPartIdAndEntry: function (position_id, part, html_id, is_tool = false) {
+					this.renderer.addEntry(position_id, part, html_id);
+					if( !is_tool
+						&& (position_id in this.model.getState().tools == false)
+					) {
+						this.model.actions.addEntry(position_id);
+					}
+				},
+				/**
+				 * Toplevel entries and tools are being given to the mainbar with an
+				 * id; this mapps the id to the position_id calculated during rendering of
+				 * the mainbar.
+				 */
+				addMapping: function(name, position_id) {
+					mappings[name] = position_id;
+				},
+				/**
+				 * Register signals. Signals will have an id (=position_id) and an action
+				 * in their options,
+				 */
+				addTriggerSignal: function(signal) {
+					$(document).on(signal, function(event, signalData) {
+						var id = signalData.options.entry_id,
+							action = signalData.options.action,
+							mb = il.UI.maincontrols.mainbar,
+							state;
+
+						switch(action) {
+							case 'trigger_mapped':
+								id = mappings[id]; //no break afterwards!
+							case 'trigger':
+								state = mb.model.getState();
+								if(id in state.tools) {
+									mb.model.actions.engageTool(id);
+								}
+								if(id in state.entries) { //toggle
+									if(state.entries[id].engaged) {
+										mb.model.actions.disengageEntry(id);
+									} else {
+										mb.model.actions.engageEntry(id);
+									}
+								}
+								break;
+							case 'remove':
+								mb.model.actions.removeTool(id);
+								break;
+							case 'disengage_all':
+								mb.model.actions.disengageAll();
+								break;
+							case 'toggle_tools':
+								mb.model.actions.toggleTools();
+								break;
+						}
+
+						mb.renderer.render(mb.model.getState());
+						mb.persistence.store(mb.model.getState());
+					});
 				}
-				_disengageAllSlates();
-				_engageButton(btn);
-				_setPageSlatesActive(true);
-				if(_isToolButton(btn)) {
-					_setToolsActive(true);
-					_engageButton(_getToolsButton());
+			},
+			adjustToScreenSize = function() {
+				var mb = il.UI.maincontrols.mainbar,
+					amount = mb.renderer.calcAmountOfButtons();
 
-					var search = '.il-mainbar-remove-tool.' + btn.attr('id');
-					$('.il-mainbar-remove-tool').hide();
-					$(search).show();
-				} else {
-					_setToolsActive(false);
-					_disengageButton(_getToolsButton());
-				}
-			}
-		};
+				mb.model.actions.initMoreButton(amount);
+				mb.renderer.render(mb.model.getState());
+			},
+			init = function(inititally_active) {
+				var mb = il.UI.maincontrols.mainbar,
+					cookie_state = mb.persistence.read();
 
-		var onClickDisengageAll = function(event, signalData) {
-			_disengageAllButtons();
-			_disengageAllSlates();
-			_setPageSlatesActive(false);
-			_setToolsActive(false);
-		};
+				if(Object.keys(cookie_state).length > 0) {
+					mb.model.setState(cookie_state);
 
-		var onClickToolsEntry = function(event, signalData) {
-			var btn = signalData.triggerer,
-				active_tool_button;
+					if(inititally_active) {
 
-				console.log(btn);
-			if(_isEngaged(btn)) {
-				_setPageSlatesActive(false);
-				_setToolsActive(false);
-				_disengageButton(btn);
-			} else {
-				_disengageAllButtons();
-				_setPageSlatesActive(true);
-				_setToolsActive(true);
-				_engageButton(btn);
-				_disengageAllSlates();
-
-				if(_isAnyToolActive()) {
-					active_tool_btn = _getAllToolButtons()
-						.filter('.' + _cls_btn_engaged)[0];
-				} else {
-					active_tool_btn = _getAllToolButtons()[0];
-				}
-				active_tool_btn.click();
-			}
-		};
-
-		var onClickToolRemoval = function(event, signalData) {
-			var inst_id = '#' + id,
-				search = [inst_id, _cls_toolentries_wrapper, 'btn'].join(' .'),
-				active_tool_btn = $(search).filter(' .' + _cls_btn_engaged),
-				remaining;
-
-			active_tool_btn.remove();
-			remaining = $(search);
-
-			if(remaining.length > 0) {
-				$(remaining[0]).click();
-			} else {
-				_disengageAllSlates();
-				_setPageSlatesActive(false);
-				_setToolsActive(false);
-				_getToolsButton().remove();
-			}
-		};
-
-		var _getToolsButton = function() {
-			return $('#' + id + ' .' + _cls_tools_btn + ' .btn');
-		};
-
-		var _isToolButton = function(btn) {
-			return btn.parent().parent().hasClass(_cls_tools_wrapper);
-		};
-
-		var _isAnyToolActive = function(btn) {
-			return _getAllToolButtons()
-				.filter('.' + _cls_btn_engaged)
-				.length > 0;
-		};
-
-		var _getAllToolButtons = function() {
-			var search = '#' + id + ' .' + _cls_tools_wrapper + ' .btn';
-			return $(search);
-		};
-
-		var _getAllButtons = function() {
-			var search = '#' + id + ' .' + _cls_entries_wrapper + ' .btn';
-			return $(search);
-		};
-
-		/**
-		 * If any slates are active in the mainbar,
-		 * the overall template has to be alerted
-		 * in order to make room for the slate.
-		 */
-		var _setPageSlatesActive = function(active) {
-			var page_div = $('.' + _cls_page_div);
-			if(active) {
-				page_div.addClass(_cls_page_active_slates);
-			} else {
-				page_div.removeClass(_cls_page_active_slates);
-			}
-		};
-
-		var _setToolsActive = function(active) {
-			var tools_area = $('#' + id +' .' + _cls_toolentries_wrapper);
-			if(active) {
-				tools_area.addClass(_cls_btn_engaged);
-			} else {
-				tools_area.removeClass(_cls_btn_engaged);
-				_disengageButton(_getToolsButton());
-			}
-		};
-
-		var _engageButton = function(btn) {
-			btn.addClass(_cls_btn_engaged);
-			btn.attr('aria-pressed', true);
-		};
-
-		var _disengageButton = function(btn) {
-			btn.removeClass(_cls_btn_engaged);
-			btn.attr('aria-pressed', false);
-		};
-
-		var _isEngaged = function(btn) {
-			return btn.hasClass(_cls_btn_engaged);
-		};
-
-		var _toggleButton = function(btn) {
-			_isEngaged(btn)? _disengageButton(btn) : _engageButton(btn);
-		};
-
-		var _disengageAllButtons = function() {
-			var f = function(i, btn) {
-					_disengageButton($(btn));
-				}
-			_getAllButtons().filter('.' + _cls_btn_engaged).each(f);
-			_getMoreSlate().find('.' + _cls_btn_engaged).each(f);
-
-		};
-
-		var _disengageAllToolButtons = function() {
-			_getAllToolButtons().filter('.' + _cls_btn_engaged).each(
-				function(i, btn) {
-					_disengageButton($(btn));
-				}
-			);
-		};
-
-		var _disengageAllSlates = function() {
-			$('#' + id + ' .' + _cls_slates_wrapper)
-			.children('.' + _cls_single_slate + '.' + _cls_slate_engaged)
-			.each(
-				function(i, slate) {
-					il.UI.maincontrols.slate.disengage($(slate));
-				}
-			);
-		};
-
-
-		/**
-		  * "more" button
-		  */
-		var _isCompletelyOnScreen = function(btn) {
-			var window_height = $(window).height(),
-				window_width = $(window).width(),
-				btn_offset_top = $(btn).offset().top,
-				btn_offset_left = $(btn).offset().left,
-				btn_height = $(btn).height(),
-				btn_width = $(btn).width(),
-				vertically_visible = (btn_offset_top + btn_height) <= window_height,
-				horizontally_visible = (btn_offset_left + btn_width) <= window_width;
-			return (vertically_visible && horizontally_visible);
-		};
-
-		var _getInvisibleButtons = function() {
-			var all_buttons = _getAllButtons(),
-				buttons = all_buttons.slice(0, -1),
-				last_visible = buttons.length,
-				invisible_buttons;
-
-			buttons.each(
-				function(index, btn) {
-					if(!_isCompletelyOnScreen(btn)) {
-						last_visible = index - 1; //make room for the more-button
-						return false;
+						if(inititally_active === '_none') {
+							mb.model.actions.disengageAll();
+						} else if(cookie_state.entries[mappings[inititally_active]]) {
+							mb.model.actions.engageEntry(mappings[inititally_active]);
+						} else if(cookie_state.tools[mappings[inititally_active]]) {
+							mb.model.actions.engageTool(mappings[inititally_active]);
+						}
 					}
 				}
-			);
 
-			if(last_visible == buttons.length) {
-				return [];
-			}
-			return buttons.slice(last_visible);
-		};
+				mb.model.actions.initMoreButton(mb.renderer.calcAmountOfButtons());
+				mb.renderer.render(mb.model.getState());
+			},
+			public_interface = {
+				addToolEntry: construction.addToolEntry,
+				addPartIdAndEntry: construction.addPartIdAndEntry,
+				addMapping: construction.addMapping,
+				addTriggerSignal: construction.addTriggerSignal,
+				adjustToScreenSize: adjustToScreenSize,
+				init: init,
+				engageTool: external_commands.engageTool,
+				engageTools: external_commands.engageTools
+			};
 
-		var _getMoreButton = function() {
-			var buttons = _getAllButtons();
-			return $(buttons[buttons.length - 1]);
-		}
-
-		var _getMoreSlate = function() {
-			var slates = $('#' + id + ' .' + _cls_slates_wrapper)
-				.children('.' + _cls_single_slate);
-			return $(slates[slates.length - 1]);
-		}
-
-		var initMore = function() {
-			var more_button = _getMoreButton(),
-				more_slate = _getMoreSlate(),
-				invisible;
-
-			//reset:
-			more_slate.find('.btn-bulky').insertBefore(more_button);
-
-			invisible = _getInvisibleButtons();
-			if(invisible.length > 0) {
-				invisible.appendTo(more_slate.children('.il-maincontrols-slate-content'));
-				more_button.show();
-			} else {
-				more_button.hide();
-				if(_isEngaged(more_slate)) {
-					_setPageSlatesActive(false);
-					_disengageButton(more_button);
-					il.UI.maincontrols.slate.disengage(more_slate);
-				}
-			}
-		}
-
-		return {
-			registerSignals: registerSignals,
-			initActive: initActive,
-			initMore: initMore,
-			addExternalSignals: addExternalSignals
-		}
-
+		return public_interface;
 	})($);
 })($, il.UI.maincontrols);
 
+
+/**
+ * The Mainbar holds a collection of entries that each consist of some triggerer
+ * and an according slate; in case of Tools, these entries might be hidden at first
+ * or may be removed by the users.
+ * There is a redux-like model of the moving parts of the mainbar: All entries and tools
+ * are stored in a state.
+ * Whenever something changes, i.e. the engagement and thus visibility of elements
+ * should change, these changes are applied to the model first, so that calculations
+ * of dependencies can be done _before_ rendering.
+  */
+(function($, mainbar) {
+	mainbar.model = (function($) {
+		var state,
+			classes = {
+				bar: {
+					any_entry_engaged : false,
+					tools_engaged: false,
+					more_available: false,
+					any_tools_visible: function() {
+						for(idx in this.tools) {
+							if(!this.tools[idx].hidden) {
+								return true;
+							}
+						}
+						return false;
+					},
+					tools: {},
+					entries: {}
+				},
+				entry: {
+					id: null,
+					removeable: false,
+					engaged: false,
+					hidden: false,
+					isTopLevel: function() {return this.id.split(':').length === 2;}
+				}
+			},
+			factories = {
+				entry: (id) => factories.cloned(classes.entry, {id: id}),
+				cloned: (state, params) => Object.assign({}, state, params),
+				state: function(nu_state) {
+					var tmp_state = factories.cloned(state, nu_state);
+					for(idx in tmp_state.entries) {
+						tmp_state.entries[idx].isTopLevel = classes.entry.isTopLevel;
+					}
+					for(idx in tmp_state.tools) {
+						tmp_state.tools[idx].isTopLevel = classes.entry.isTopLevel;
+					}
+					state = tmp_state;
+				}
+			},
+			reducers = {
+				entry: {
+					engage: (entry) => {
+						entry.engaged = true;
+						entry.hidden = false;
+						return entry;
+					},
+					disengage: (entry) => {entry.engaged = false; return entry;},
+					mb_show: (entry) => {entry.hidden = false; return entry;},
+					mb_hide: (entry) => {
+						entry.hidden = true;
+						entry.engaged = false;
+						return entry;
+					}
+				},
+				bar:  {
+					engageTools: (bar) => {bar.tools_engaged = true; return bar;},
+					disengageTools: (bar) => {bar.tools_engaged = false; return bar;},
+					anySlates: (bar) => {bar.any_entry_engaged = true; return bar;},
+					noSlates: (bar) => {bar.any_entry_engaged = false; return bar;},
+					withMoreButton: (bar) => {bar.more_available = true; return bar;},
+					withoutMoreButton: (bar) => {bar.more_available = false; return bar;}
+				},
+				entries: {
+					disengageTopLevel: function(entries) {
+						for(id in entries) {
+							if(entries[id].isTopLevel()) {
+								entries[id] = reducers.entry.disengage(entries[id]);
+							}
+						}
+						return entries;
+					},
+					engageEntryPath: function(entries, entry_id) {
+						var hops = entry_id.split(':');
+						hops.map(function(v, idx, hops) {
+							var id = hops.slice(0, idx+1).join(':');
+							if(id && id != '0') {
+								entries[id] = reducers.entry.engage(entries[id]);
+							}
+						});
+						return entries;
+					}
+				}
+			},
+			helpers = {
+				getTopLevelEntries: function() {
+					var ret = [];
+					for(id in state.entries) {
+						if(state.entries[id].isTopLevel()) {
+							ret.push(state.entries[id]);
+						}
+					}
+					return ret;
+				}
+			},
+			actions = {
+				addEntry: function (entry_id) {
+					state.entries[entry_id] = factories.entry(entry_id);
+				},
+				addTool: function (entry_id, removeable, hidden) {
+					var tool = factories.entry(entry_id);
+					tool.removeable = removeable ? true : false;
+					tool.hidden = hidden ? true : false;
+					state.tools[entry_id] = tool;
+				},
+				engageEntry: function (entry_id) {
+					state.tools = reducers.entries.disengageTopLevel(state.tools);
+					state.entries = reducers.entries.disengageTopLevel(state.entries);
+					state.entries = reducers.entries.engageEntryPath(state.entries, entry_id);
+					state = reducers.bar.disengageTools(state);
+					state = reducers.bar.anySlates(state);
+
+				},
+				disengageEntry: function (entry_id) {
+					state.entries[entry_id] = reducers.entry.disengage(state.entries[entry_id]);
+					if(state.entries[entry_id].isTopLevel()) {
+						state = reducers.bar.noSlates(state);
+					}
+				},
+				hideEntry: function (entry_id) {
+					state.entries[entry_id] = reducers.entry.mb_hide(state.entries[entry_id]);
+				},
+				showEntry: function (entry_id) {
+					state.entries[entry_id] = reducers.entry.mb_show(state.entries[entry_id]);
+				},
+				engageTool: function (entry_id) {
+					state.entries = reducers.entries.disengageTopLevel(state.entries);
+					state.tools = reducers.entries.disengageTopLevel(state.tools);
+					state.tools[entry_id] = reducers.entry.engage(state.tools[entry_id]);
+					state = reducers.bar.engageTools(state);
+					state = reducers.bar.anySlates(state);
+				},
+				removeTool: function (entry_id) {
+					state.tools[entry_id] = reducers.entry.mb_hide(state.tools[entry_id]);
+					for(idx in state.tools) {
+						tool = state.tools[idx];
+						if(!tool.hidden) {
+							state.tools[tool.id] = reducers.entry.engage(tool);
+							break;
+						}
+					}
+					if(!state.any_tools_visible()) {
+						actions.disengageAll();
+					}
+				},
+				toggleTools: function() {
+					if(state.tools_engaged) {
+						state.entries = reducers.entries.disengageTopLevel(state.entries)
+						state = reducers.bar.disengageTools(state);
+						state = reducers.bar.noSlates(state);
+					} else {
+						for(idx in state.tools) {
+							var tool = state.tools[idx];
+							if(tool.engaged) {
+								actions.engageTool(tool.id);
+								return;
+							}
+						}
+						var tool_id = Object.keys(state.tools)[0];
+						actions.engageTool(tool_id);
+					}
+				},
+				disengageAll: function () {
+					state.entries = reducers.entries.disengageTopLevel(state.entries)
+					state.tools = reducers.entries.disengageTopLevel(state.tools)
+					state = reducers.bar.noSlates(state);
+					state = reducers.bar.disengageTools(state);
+				},
+				initMoreButton: function(max_buttons) {
+					var entry_ids = Object.keys(state.entries),
+						last_entry_id = entry_ids[entry_ids.length - 1],
+						more = state.entries[last_entry_id];
+
+					if(state.any_tools_visible()) {
+						max_buttons--
+					};
+
+					//get length of top-level entries (w/o) more-button
+					amount_toplevel = helpers.getTopLevelEntries().length - 1;
+
+					if(amount_toplevel > max_buttons) {
+						state.entries[more.id] = reducers.entry.mb_show(more);
+						state = reducers.bar.withMoreButton(state);
+					} else {
+						state.entries[more.id] = reducers.entry.mb_hide(more);
+						state = reducers.bar.withoutMoreButton(state);
+					}
+				}
+			},
+			public_interface = {
+				actions: actions,
+				getState: () => factories.cloned(state),
+				setState: factories.state,
+				getTopLevelEntries: helpers.getTopLevelEntries
+			},
+			init = function() {
+				state = factories.cloned(classes.bar);
+			};
+
+		init();
+		return public_interface;
+	})($);
+})($, il.UI.maincontrols.mainbar);
+
+
+(function($, mainbar) {
+	mainbar.persistence = (function($) {
+		var cs,
+			storage = function() {
+				if(cs) { return cs; }
+				cookie_name = hash(entry_ids());
+				return new il.Utilities.CookieStorage(cookie_name);
+			},
+			model_state = function() {
+				return il.UI.maincontrols.mainbar.model.getState();
+			},
+			entry_ids = function() {
+				var entries = model_state().entries,
+					base = '';
+				for(idx in entries) {
+					base = base + idx;
+				}
+				return base;
+			},
+			hash = function(str) {
+				var hash = 0,
+					len = str.length,
+					i, chr;
+
+				for (i = 0; i < len; i = i + 1) {
+					chr = str.charCodeAt(i);
+					hash  = ((hash << 5) - hash) + chr;
+					hash |= 0; // Convert to 32bit integer
+				}
+				return hash;
+			},
+			storeStates = function(state) {
+				cs = storage();
+				for(idx in state) {
+					cs.add(idx, state[idx]);
+				}
+				cs.store();
+			},
+			readStates = function() {
+				cs = storage();
+				return cs.items;
+			},
+			public_interface = {
+				read: readStates,
+				store: storeStates
+			};
+
+		return public_interface;
+	})($);
+})($, il.UI.maincontrols.mainbar);
+
+
+
+(function($, mainbar) {
+	mainbar.renderer = (function($) {
+		var css = {
+				engaged: 'engaged'
+				,disengaged: 'disengaged'
+				,hidden: 'hidden'
+				,page_div: 'il-layout-page'
+				,page_has_engaged_slated: 'with-mainbar-slates-engaged'
+				,tools_btn: 'il-mainbar-tools-button'
+				,toolentries_wrapper: 'il-mainbar-tools-entries'
+				,remover_class: 'il-mainbar-remove-tool'
+				,mainbar: 'il-mainbar'
+				,mainbar_buttons: '.il-mainbar .il-mainbar-entries .btn-bulky'
+			},
+
+			dom_references = {},
+			dom_element = {
+				withHtmlId: function (html_id) {
+					return Object.assign({}, this, {html_id: html_id});
+				},
+				getElement: function(){
+					return $('#' + this.html_id);
+				},
+				engage: function() {
+					this.getElement().addClass(css.engaged);
+					this.getElement().removeClass(css.disengaged);
+					this.getElement().trigger('in_view'); //this is most important for async loading of slates,
+														  //it triggers the GlobalScreen-Service.
+				},
+				disengage: function() {
+					this.getElement().addClass(css.disengaged);
+					this.getElement().removeClass(css.engaged);
+				},
+				mb_hide: function(on_parent) {
+					var element = this.getElement();
+					if(on_parent) {
+						element = element.parent();
+					}
+					element.addClass(css.hidden);
+				},
+				mb_show: function(on_parent) {
+					var element = this.getElement();
+					if(on_parent) {
+						element = element.parent();
+					}
+					element.removeClass(css.hidden);
+				}
+			},
+			parts = {
+				triggerer: Object.assign({}, dom_element, {
+					remove: function() {}
+				}),
+				slate: Object.assign({}, dom_element, {
+					remove: null,
+					mb_hide: null,
+					mb_show: null
+				}),
+				remover: Object.assign({}, dom_element, {
+					engage: null,
+					disengage:null,
+					mb_show: function(){this.getElement().parent().show();}
+				}),
+				page: {
+					getElement: function(){
+						return $('.' + css.page_div);
+					},
+					slatesEngaged: function(engaged) {
+						if(engaged) {
+							this.getElement().addClass(css.page_has_engaged_slated);
+						} else {
+							this.getElement().removeClass(css.page_has_engaged_slated);
+						}
+					}
+				},
+				removers: {
+					getElement: function(){
+						return $('.' + css.remover_class);
+					},
+					mb_hide: function() {
+						this.getElement().hide();
+					}
+
+				},
+				tools_area: Object.assign({}, dom_element, {
+					getElement: function(){
+						return $(' .' + css.toolentries_wrapper);
+					}
+				}),
+				tools_button: Object.assign({}, dom_element, {
+					getElement: function(){
+						return $('.' + css.tools_btn + ' .btn');
+					},
+					remove: null
+				}),
+				mainbar: {
+					getElement: function(){
+						return $('.' + css.mainbar);
+					},
+					getOffsetTop: function() {
+						return this.getElement().offset().top;
+					}
+				}
+			},
+
+			//more-slate
+			more = {
+				calcAmountOfButtons: function() {
+					var window_height = $(window).height(),
+						window_width = $(window).width(),
+						horizontal = il.UI.page.isSmallScreen(),
+						btn = $(css.mainbar_buttons).first()
+						btn_height = btn.height(),
+						btn_width = btn.width(),
+						amount_buttons = Math.floor(
+							(window_height - parts.mainbar.getOffsetTop()) / btn_height
+						);
+
+					if(horizontal) {
+						amount_buttons = Math.floor(window_width / btn_width);
+					}
+					return amount_buttons - 1;
+				}
+			},
+
+			actions = {
+				addEntry: function (entry_id, part, html_id) {
+					dom_references[entry_id] = dom_references[entry_id] || {};
+					dom_references[entry_id][part] = html_id;
+				},
+				renderEntry: function (entry, is_tool) {
+					if(!dom_references[entry.id]){
+						return;
+					}
+
+					var triggerer = parts.triggerer.withHtmlId(dom_references[entry.id].triggerer),
+						slate = parts.slate.withHtmlId(dom_references[entry.id].slate);
+
+					if(entry.hidden) {
+						triggerer.mb_hide(is_tool);
+					} else {
+						triggerer.mb_show(is_tool);
+					}
+
+					if(entry.engaged) {
+						triggerer.engage();
+						slate.engage();
+						if(entry.removeable) {
+							remover = parts.remover.withHtmlId(dom_references[entry.id].remover);
+							remover.mb_show(true);
+						}
+					} else {
+						triggerer.disengage();
+						slate.disengage();
+					}
+				},
+
+				moveToplevelTriggerersToMore: function (model_state) {
+					var entry_ids = Object.keys(model_state.entries),
+						last_entry_id = entry_ids[entry_ids.length - 1],
+						more_entry = model_state.entries[last_entry_id],
+						more_slate = parts.slate.withHtmlId(dom_references[more_entry.id].slate),
+						root_entries = il.UI.maincontrols.mainbar.model.getTopLevelEntries(),
+						root_entries_length = root_entries.length - 1,
+						max_buttons = more.calcAmountOfButtons() - 1; //room for the more-button
+
+					if(model_state.any_tools_visible()) { max_buttons--};
+
+					for(i = max_buttons; i < root_entries_length; i++) {
+						btn = parts.triggerer.withHtmlId(dom_references[root_entries[i].id].triggerer);
+						btn.getElement().appendTo(more_slate.getElement().children('.il-maincontrols-slate-content'));
+					}
+				},
+				render: function (model_state) {
+					var entry_ids = Object.keys(model_state.entries),
+						last_entry_id = entry_ids[entry_ids.length - 1],
+						more_entry = model_state.entries[last_entry_id],
+						more_button = parts.triggerer.withHtmlId(dom_references[more_entry.id].triggerer),
+						more_slate = parts.slate.withHtmlId(dom_references[more_entry.id].slate);
+						//reset
+						more_slate.getElement().find('.btn-bulky').insertBefore(more_button.getElement());
+
+					if(model_state.more_available) {
+						actions.moveToplevelTriggerersToMore(model_state);
+					}
+
+					parts.page.slatesEngaged(model_state.any_entry_engaged || model_state.tools_engaged);
+
+					if(model_state.tools_engaged){
+						parts.tools_button.engage();
+						parts.tools_area.engage();
+						parts.removers.mb_hide();
+					} else {
+						if(model_state.any_tools_visible()) {
+							parts.tools_button.mb_show(true); //hide on parent
+							parts.tools_button.disengage();
+							parts.tools_area.disengage();
+						} else {
+							parts.tools_button.mb_hide();
+						}
+					}
+
+					for(idx in model_state.entries) {
+						actions.renderEntry(model_state.entries[idx], false);
+					}
+					for(idx in model_state.tools) {
+						actions.renderEntry(model_state.tools[idx], true);
+					}
+				}
+			},
+			public_interface = {
+				addEntry: actions.addEntry,
+				calcAmountOfButtons: more.calcAmountOfButtons,
+				render: actions.render
+			};
+
+		return public_interface;
+	})($);
+})($, il.UI.maincontrols.mainbar);

--- a/tests/UI/Component/MainControls/MainBarTest.php
+++ b/tests/UI/Component/MainControls/MainBarTest.php
@@ -225,7 +225,7 @@ class MainBarTest extends ILIAS_UI_TestBase
 							<span class="bulky-label">TestEntry</span>
 						</button>
 
-						<button class="btn btn-bulky" id="id_3" aria-pressed="false" >
+						<button class="btn btn-bulky" id="id_3" >
 							<div class="icon custom small" aria-label="">
 								<img src="" />
 							</div>

--- a/tests/UI/Component/MainControls/Slate/SlateTest.php
+++ b/tests/UI/Component/MainControls/Slate/SlateTest.php
@@ -20,6 +20,9 @@ class TestGenericSlate extends Slate implements C\MainControls\Slate\Slate
     {
         return [];
     }
+    public function withMappedSubNodes(callable $f) {
+        return $this;
+    }
 }
 
 /**


### PR DESCRIPTION
This is a first (working) example on how states for the mainbar-entries might be stored in a cookie.
It feels like there is still quite a bit room for improvement, but I could use some comments if this is going in the desired direction at all (@chfsx ?).

Thanks a bunch,
Nils

- enumerate entries and sub-slates
- internal data (JS) to group triggerer, slate and close-button
- revise JS to not operate directly on DOM but do calculations first.
- use ilUtilities from GS to store cookie
- ... still to be improved