### PR TITLE
LearningSequence, adapt to GlobalScreen

### DIFF
--- a/Modules/LearningSequence/GlobalScreen/classes/class.ilLSViewLayoutProvider.php
+++ b/Modules/LearningSequence/GlobalScreen/classes/class.ilLSViewLayoutProvider.php
@@ -1,0 +1,132 @@
+<?php
+//namespace ILIAS\LTI\Screen;
+
+use ILIAS\GlobalScreen\Scope\Layout\Provider\AbstractModificationProvider;
+use ILIAS\GlobalScreen\Scope\Layout\Provider\ModificationProvider;
+use ILIAS\GlobalScreen\ScreenContext\Stack\ContextCollection;
+use ILIAS\GlobalScreen\ScreenContext\Stack\CalledContexts;
+
+use ILIAS\GlobalScreen\Scope\Layout\Factory\MainBarModification;
+use ILIAS\UI\Component\MainControls\MainBar;
+use ILIAS\GlobalScreen\Scope\Layout\Factory\MetaBarModification;
+use ILIAS\UI\Component\MainControls\MetaBar;
+use ILIAS\GlobalScreen\Scope\Layout\Factory\FooterModification;
+use ILIAS\UI\Component\MainControls\Footer;
+use ILIAS\GlobalScreen\Scope\Layout\Factory\BreadCrumbsModification;
+use ILIAS\UI\Component\Breadcrumbs\Breadcrumbs;
+use ILIAS\GlobalScreen\Scope\Layout\Factory\ContentModification;
+use ILIAS\UI\Component\Legacy\Legacy;
+
+/**
+ * Class ilLSViewLayoutProvider
+ *
+ * @author Nils Haagen <nils.haagen@concepts-and-training.de>
+ */
+class ilLSViewLayoutProvider extends AbstractModificationProvider implements ModificationProvider
+{
+
+    /**
+     * @var Collection | null
+     */
+    protected $data_collection;
+
+    /**
+     * @inheritDoc
+     */
+    public function isInterestedInContexts() : ContextCollection
+    {
+        //return $this->context_collection->kiosk();
+        return $this->context_collection->main();
+        return $this->context_collection->repository();
+    }
+
+    /**
+     * @param CalledContexts $calledContexts
+     *
+     * @return bool
+     */
+    protected function isKioskModeEnabled(CalledContexts $screen_context_stack) : bool
+    {
+        $this->data_collection = $screen_context_stack->current()->getAdditionalData();
+        return $this->data_collection->is(\ilLSPlayer::GS_DATA_LS_KIOSK_MODE, true);
+    }
+
+    public function getMainBarModification(CalledContexts $screen_context_stack) : ?MainBarModification
+    {
+        if($this->isKioskModeEnabled($screen_context_stack)) {
+            return $this->globalScreen()->layout()->factory()->mainbar()
+                ->withModification(
+                    function(MainBar $mainbar) : ?MainBar {
+                        $mainbar = $mainbar->withClearedEntries();
+                        foreach ($this->data_collection->get(\ilLSPlayer::GS_DATA_LS_MAINBARCONTROLS) as $key => $entry) {
+                            $mainbar = $mainbar->withAdditionalEntry($key, $entry);
+                        }
+                        return $mainbar;
+                    }
+                )->withHighPriority();
+        }
+        return null;
+    }
+
+    public function getMetaBarModification(CalledContexts $screen_context_stack) : ?MetaBarModification
+    {
+
+        if($this->isKioskModeEnabled($screen_context_stack)) {
+            return $this->globalScreen()->layout()->factory()->metabar()
+                ->withModification(
+                    function(MetaBar $metabar) {
+                        $metabar = $metabar->withClearedEntries();
+                        foreach ($this->data_collection->get(\ilLSPlayer::GS_DATA_LS_METABARCONTROLS) as $key => $entry) {
+                            $metabar = $metabar->withAdditionalEntry($key, $entry);
+                        }
+                        return $metabar;
+                    }
+                )
+                ->withHighPriority();
+        }
+        return null;
+    }
+
+    public function getFooterModification(CalledContexts $screen_context_stack) : ?FooterModification
+    {
+        if($this->isKioskModeEnabled($screen_context_stack)) {
+            return $this->globalScreen()->layout()->factory()->footer()
+                ->withModification(
+                    function(Footer $current) {
+                        return null;
+                    }
+                )->withHighPriority();
+        }
+        return null;
+    }
+
+    public function getBreadCrumbsModification(CalledContexts $screen_context_stack) : ?BreadCrumbsModification
+    {
+        if($this->isKioskModeEnabled($screen_context_stack)) {
+            return $this->globalScreen()->layout()->factory()->breadcrumbs()
+                ->withModification(
+                    function(Breadcrumbs $current) {
+                        return null;
+                    }
+                )
+                ->withHighPriority();
+        }
+        return null;
+    }
+
+    public function getContentModification(CalledContexts $screen_context_stack) : ?ContentModification
+    {
+        if($this->isKioskModeEnabled($screen_context_stack)) {
+            $html = $this->data_collection->get(\ilLSPlayer::GS_DATA_LS_CONTENT);
+            return $this->globalScreen()->layout()->factory()->content()
+                ->withModification(
+                    function (Legacy $content) use ($html): Legacy {
+                        $ui = $this->dic->ui();
+                        return $ui->factory()->legacy($html);
+                    }
+                )
+                ->withHighPriority();
+        }
+        return null;
+    }
+}

--- a/Modules/LearningSequence/GlobalScreen/classes/class.ilLSViewLayoutProvider.php
+++ b/Modules/LearningSequence/GlobalScreen/classes/class.ilLSViewLayoutProvider.php
@@ -1,11 +1,8 @@
 <?php
-//namespace ILIAS\LTI\Screen;
-
 use ILIAS\GlobalScreen\Scope\Layout\Provider\AbstractModificationProvider;
 use ILIAS\GlobalScreen\Scope\Layout\Provider\ModificationProvider;
 use ILIAS\GlobalScreen\ScreenContext\Stack\ContextCollection;
 use ILIAS\GlobalScreen\ScreenContext\Stack\CalledContexts;
-
 use ILIAS\GlobalScreen\Scope\Layout\Factory\MainBarModification;
 use ILIAS\UI\Component\MainControls\MainBar;
 use ILIAS\GlobalScreen\Scope\Layout\Factory\MetaBarModification;
@@ -35,9 +32,7 @@ class ilLSViewLayoutProvider extends AbstractModificationProvider implements Mod
      */
     public function isInterestedInContexts() : ContextCollection
     {
-        //return $this->context_collection->kiosk();
         return $this->context_collection->main();
-        return $this->context_collection->repository();
     }
 
     /**
@@ -53,80 +48,80 @@ class ilLSViewLayoutProvider extends AbstractModificationProvider implements Mod
 
     public function getMainBarModification(CalledContexts $screen_context_stack) : ?MainBarModification
     {
-        if($this->isKioskModeEnabled($screen_context_stack)) {
-            return $this->globalScreen()->layout()->factory()->mainbar()
-                ->withModification(
-                    function(MainBar $mainbar) : ?MainBar {
-                        $mainbar = $mainbar->withClearedEntries();
-                        foreach ($this->data_collection->get(\ilLSPlayer::GS_DATA_LS_MAINBARCONTROLS) as $key => $entry) {
-                            $mainbar = $mainbar->withAdditionalEntry($key, $entry);
-                        }
-                        return $mainbar;
-                    }
-                )->withHighPriority();
+        if(! $this->isKioskModeEnabled($screen_context_stack)) {
+            return null;
         }
-        return null;
+        return $this->globalScreen()->layout()->factory()->mainbar()
+            ->withModification(
+                function(MainBar $mainbar) : ?MainBar {
+                    $mainbar = $mainbar->withClearedEntries();
+                    foreach ($this->data_collection->get(\ilLSPlayer::GS_DATA_LS_MAINBARCONTROLS) as $key => $entry) {
+                        $mainbar = $mainbar->withAdditionalEntry($key, $entry);
+                    }
+                    return $mainbar;
+                }
+            )->withHighPriority();
     }
 
     public function getMetaBarModification(CalledContexts $screen_context_stack) : ?MetaBarModification
     {
-
-        if($this->isKioskModeEnabled($screen_context_stack)) {
-            return $this->globalScreen()->layout()->factory()->metabar()
-                ->withModification(
-                    function(MetaBar $metabar) {
-                        $metabar = $metabar->withClearedEntries();
-                        foreach ($this->data_collection->get(\ilLSPlayer::GS_DATA_LS_METABARCONTROLS) as $key => $entry) {
-                            $metabar = $metabar->withAdditionalEntry($key, $entry);
-                        }
-                        return $metabar;
-                    }
-                )
-                ->withHighPriority();
+        if(! $this->isKioskModeEnabled($screen_context_stack)) {
+            return null;
         }
-        return null;
+        return $this->globalScreen()->layout()->factory()->metabar()
+            ->withModification(
+                function(MetaBar $metabar) {
+                    $metabar = $metabar->withClearedEntries();
+                    foreach ($this->data_collection->get(\ilLSPlayer::GS_DATA_LS_METABARCONTROLS) as $key => $entry) {
+                        $metabar = $metabar->withAdditionalEntry($key, $entry);
+                    }
+                    return $metabar;
+                }
+            )
+            ->withHighPriority();
     }
 
     public function getFooterModification(CalledContexts $screen_context_stack) : ?FooterModification
     {
-        if($this->isKioskModeEnabled($screen_context_stack)) {
-            return $this->globalScreen()->layout()->factory()->footer()
-                ->withModification(
-                    function(Footer $current) {
-                        return null;
-                    }
-                )->withHighPriority();
+        if(! $this->isKioskModeEnabled($screen_context_stack)) {
+            return null;
         }
-        return null;
+        return $this->globalScreen()->layout()->factory()->footer()
+            ->withModification(
+                function(Footer $current) {
+                    return null;
+                }
+            )->withHighPriority();
     }
 
     public function getBreadCrumbsModification(CalledContexts $screen_context_stack) : ?BreadCrumbsModification
     {
-        if($this->isKioskModeEnabled($screen_context_stack)) {
-            return $this->globalScreen()->layout()->factory()->breadcrumbs()
-                ->withModification(
-                    function(Breadcrumbs $current) {
-                        return null;
-                    }
-                )
-                ->withHighPriority();
+        if(! $this->isKioskModeEnabled($screen_context_stack)) {
+            return null;
         }
-        return null;
+
+        return $this->globalScreen()->layout()->factory()->breadcrumbs()
+            ->withModification(
+                function(Breadcrumbs $current) {
+                    return null;
+                }
+            )
+            ->withHighPriority();
     }
 
     public function getContentModification(CalledContexts $screen_context_stack) : ?ContentModification
     {
-        if($this->isKioskModeEnabled($screen_context_stack)) {
-            $html = $this->data_collection->get(\ilLSPlayer::GS_DATA_LS_CONTENT);
-            return $this->globalScreen()->layout()->factory()->content()
-                ->withModification(
-                    function (Legacy $content) use ($html): Legacy {
-                        $ui = $this->dic->ui();
-                        return $ui->factory()->legacy($html);
-                    }
-                )
-                ->withHighPriority();
+        if(! $this->isKioskModeEnabled($screen_context_stack)) {
+            return null;
         }
-        return null;
+        $html = $this->data_collection->get(\ilLSPlayer::GS_DATA_LS_CONTENT);
+        return $this->globalScreen()->layout()->factory()->content()
+            ->withModification(
+                function (Legacy $content) use ($html): Legacy {
+                    $ui = $this->dic->ui();
+                    return $ui->factory()->legacy($html);
+                }
+            )
+            ->withHighPriority();
     }
 }

--- a/Modules/LearningSequence/classes/Player/LSControlBuilder.php
+++ b/Modules/LearningSequence/classes/Player/LSControlBuilder.php
@@ -154,7 +154,8 @@ class LSControlBuilder implements ControlBuilder
 			$label = 'lso_player_finish';
 		}
 
-		$exit_button = $this->ui_factory->button()->shy(
+		$exit_button = $this->ui_factory->button()->bulky(
+			$this->ui_factory->symbol()->glyph()->close(),
 			$this->lng->txt($label),
 			$cmd
 		);

--- a/Modules/LearningSequence/classes/Player/class.ilKioskPageRenderer.php
+++ b/Modules/LearningSequence/classes/Player/class.ilKioskPageRenderer.php
@@ -3,8 +3,10 @@
 declare(strict_types=1);
 
 use ILIAS\UI\Renderer;
+use ILIAS\UI\Factory;
 use ILIAS\UI\Component\Component;
 use ILIAS\UI\Component\Listing\Workflow\Workflow;
+use ILIAS\UI\Component\MainControls\Slate\Slate;
 use ILIAS\GlobalScreen\Scope\Layout\LayoutServices;
 use ILIAS\GlobalScreen\Scope\Layout\MetaContent\MetaContent;
 
@@ -16,6 +18,7 @@ class ilKioskPageRenderer
 	public function __construct(
 		ilGlobalPageTemplate $il_global_template,
 		MetaContent $layout_meta_content,
+		Factory $ui_factory,
 		Renderer $ui_renderer,
 		ilTemplate $kiosk_template,
 		ilLSTOCGUI $toc_gui,
@@ -24,6 +27,7 @@ class ilKioskPageRenderer
 	) {
 		$this->il_tpl = $il_global_template;
 		$this->layout_meta_content = $layout_meta_content;
+		$this->ui_factory = $ui_factory;
 		$this->ui_renderer = $ui_renderer;
 		$this->tpl = $kiosk_template;
 		$this->toc_gui = $toc_gui;
@@ -31,24 +35,46 @@ class ilKioskPageRenderer
 		$this->window_base_title = $window_base_title;
 	}
 
+	public function buildCurriculumSlate(Workflow $curriculum): Slate
+	{
+		return $this->ui_factory->maincontrols()->slate()->legacy(
+			'Curriculum',
+			$this->ui_factory->symbol()->glyph()->briefcase(),
+			$this->ui_factory->legacy(
+				$this->ui_renderer->render($curriculum)
+			)
+		);
+	}
+
+
+	public function buildToCSlate($toc): Slate
+	{
+		/* ilExplorerBaseGUI has changed and seems to be broken.
+		TODO: fix ToC-building
+		$html = $this->toc_gui
+			->withStructure($toc->toJSON())
+			->getHTML();
+		*/
+		$html = "ToC";
+		return $this->ui_factory->maincontrols()->slate()->legacy(
+			'ToC',
+			$this->ui_factory->symbol()->glyph()->user(),
+			$this->ui_factory->legacy($html)
+		);
+	}
+
+
 	public function render(
 		string $lso_title,
 		LSControlBuilder $control_builder,
 		string $obj_title,
 		Component $icon,
-		array $content,
-		Workflow $curriculum
+		array $content
 	): string {
 
 		$this->tpl->setVariable("HTML_PAGE_TITLE",
 			$this->window_base_title .' - ' .$lso_title
 		);
-
-		$this->tpl->setVariable("TOPBAR_CONTROLS",
-			$this->ui_renderer->render($control_builder->getExitControl())
-		);
-
-		$this->tpl->setVariable("TOPBAR_TITLE", $lso_title);
 
 		$this->tpl->setVariable("OBJECT_ICON",
 			$this->ui_renderer->render($icon)
@@ -74,7 +100,6 @@ class ilKioskPageRenderer
 			$this->tpl->setVariable("JS_INLINE", $control_builder->getAdditionalJS());
 		}
 
-
 		//TODO: insert toggles
 
 		$this->tpl->setVariable("OBJ_NAVIGATION",
@@ -99,98 +124,7 @@ class ilKioskPageRenderer
 		$this->tpl->setVariable('CONTENT',
 			$this->ui_renderer->render($content)
 		);
-		$this->tpl->setVariable('CURRICULUM',
-			$this->ui_renderer->render($curriculum)
-		);
 
-		if($control_builder->getToc()) {
-			$this->tpl->touchBlock("sidebar_space");
-			$this->tpl->setVariable("SIDEBAR",
-				$this->toc_gui
-					->withStructure($control_builder->getToc()->toJSON())
-					->getHTML()
-			);
-		} else {
-			$this->tpl->touchBlock("sidebar_disabled");
-		}
-
-		$tpl = $this->setHeaderVars($this->tpl);
-		return $tpl->get();
+		return $this->tpl->get();
 	}
-
-	protected function setHeaderVars(ilTemplate $tpl)
-	{
-		$js_files = $this->getJsFiles();
-		$js_olc = $this->getOnLoadCode();
-		$css_files = $this->getCSSFiles();
-		$css_inline = $this->getInlineCSS();
-
-		foreach ($js_files as $js_file) {
-			$tpl->setCurrentBlock("js_file");
-			$tpl->setVariable("JS_FILE", $js_file);
-			$tpl->parseCurrentBlock();
-		}
-
-		foreach ($css_files as $css_file) {
-			$tpl->setCurrentBlock("css_file");
-			$tpl->setVariable("CSS_FILE", $css_file);
-			$tpl->parseCurrentBlock();
-		}
-
-		$tpl->setVariable("CSS_INLINE", $css_inline);
-		$tpl->setVariable("OLCODE", $js_olc);
-
-		return $tpl;
-	}
-
-	protected function getJsFiles(): array
-	{
-		$js_files = [];
-		$basic = './Services/JavaScript/js/Basic.js';
-		foreach ($this->layout_meta_content->getJs()->getItemsInOrderOfDelivery() as $js_file) {
-			$file = $js_file->getContent();
-			if(strpos($file, 'Services/FileUpload/js')) {
-				continue;
-			}
-			if(! strpos($file, '/jquery') && ! in_array($basic, $js_files)) {
-				$js_files[] = $basic;
-			}
-			$js_files[] = $file;
-		}
-		return $js_files;
-	}
-
-	protected function getOnLoadCode(): string
-	{
-		$js_inline = [];
-		foreach ($this->layout_meta_content->getOnloadCode()->getItemsInOrderOfDelivery() as $on_load_code) {
-			$js_inline[] = $on_load_code->getContent();
-		}
-		return implode(PHP_EOL, $js_inline);
-	}
-
-	protected function getCSSFiles(): array
-	{
-		$css_files = $this->layout_meta_content->getCSS()->getItemsInOrderOfDelivery();
-		$css_files = array_map(
-			function($css_file) {
-				return $css_file->getContent();
-			}
-			,$css_files
-		);
-		$css_files[] = \ilUtil::getStyleSheetLocation("filesystem", "delos.css");
-		$css_files[] = \ilUtil::getStyleSheetLocation();
-		$css_files[] = \ilUtil::getNewContentStyleSheetLocation();
-		return $css_files;
-	}
-
-	protected function getInlineCSS(): string
-	{
-		$css_inline = [];
-		foreach ($this->layout_meta_content->getInlineCss()->getItemsInOrderOfDelivery() as $inline_css) {
-			$css_inline[] = $inline_css->getContent();
-		}
-		return implode(PHP_EOL, $css_inline);
-	}
-
 }

--- a/Modules/LearningSequence/classes/Player/class.ilKioskPageRenderer.php
+++ b/Modules/LearningSequence/classes/Player/class.ilKioskPageRenderer.php
@@ -20,6 +20,7 @@ class ilKioskPageRenderer
 		MetaContent $layout_meta_content,
 		Factory $ui_factory,
 		Renderer $ui_renderer,
+		ilLanguage $lng,
 		ilTemplate $kiosk_template,
 		ilLSTOCGUI $toc_gui,
 		ilLSLocatorGUI $loc_gui,
@@ -29,6 +30,7 @@ class ilKioskPageRenderer
 		$this->layout_meta_content = $layout_meta_content;
 		$this->ui_factory = $ui_factory;
 		$this->ui_renderer = $ui_renderer;
+		$this->lng = $lng;
 		$this->tpl = $kiosk_template;
 		$this->toc_gui = $toc_gui;
 		$this->loc_gui = $loc_gui;
@@ -38,7 +40,7 @@ class ilKioskPageRenderer
 	public function buildCurriculumSlate(Workflow $curriculum): Slate
 	{
 		return $this->ui_factory->maincontrols()->slate()->legacy(
-			'Curriculum',
+			$this->lng->txt('lso_mainbar_button_label_curriculum'),
 			$this->ui_factory->symbol()->glyph()->briefcase(),
 			$this->ui_factory->legacy(
 				$this->ui_renderer->render($curriculum)
@@ -57,7 +59,7 @@ class ilKioskPageRenderer
 		*/
 		$html = "ToC";
 		return $this->ui_factory->maincontrols()->slate()->legacy(
-			'ToC',
+			$this->lng->txt('lso_mainbar_button_label_toc'),
 			$this->ui_factory->symbol()->glyph()->user(),
 			$this->ui_factory->legacy($html)
 		);

--- a/Modules/LearningSequence/classes/Player/class.ilLSPlayer.php
+++ b/Modules/LearningSequence/classes/Player/class.ilLSPlayer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use ILIAS\KioskMode\ControlBuilder;
 use ILIAS\UI\Component\Listing\Workflow\Step;
+use ILIAS\GlobalScreen\ScreenContext\ScreenContext;
 
 /**
  * Implementation of KioskMode Player
@@ -21,6 +22,11 @@ class ilLSPlayer
 	const LSO_CMD_FINISH = 'lsofinish';
 
 
+	const GS_DATA_LS_KIOSK_MODE = 'ls_kiosk_mode';
+	const GS_DATA_LS_CONTENT = 'ls_content';
+	const GS_DATA_LS_MAINBARCONTROLS = 'ls_mainbar_controls';
+	const GS_DATA_LS_METABARCONTROLS = 'ls_metabar_controls';
+
 	public function __construct(
 		string $lso_title,
 		ilLSLearnerItemsQueries $ls_items,
@@ -29,7 +35,8 @@ class ilLSPlayer
 		ilLSCurriculumBuilder $curriculum_builder,
 		ilLSViewFactory $view_factory,
 		ilKioskPageRenderer $renderer,
-		ILIAS\UI\Factory $ui_factory
+		ILIAS\UI\Factory $ui_factory,
+		ScreenContext $current_context
 	) {
 		$this->lso_title = $lso_title;
 		$this->ls_items = $ls_items;
@@ -40,9 +47,10 @@ class ilLSPlayer
 		$this->view_factory = $view_factory;
 		$this->page_renderer = $renderer;
 		$this->ui_factory = $ui_factory;
+		$this->current_context = $current_context;
 	}
 
-	public function render(array $get, array $post=null)
+	public function play(array $get, array $post=null)
 	{
 		//init state and current item
 		$current_item = $this->getCurrentItem();
@@ -83,32 +91,59 @@ class ilLSPlayer
 		//have the view build controls
 		$control_builder = $this->control_builder;
 		$view->buildControls($state, $control_builder);
+
 		//amend controls not set by the view
-		$this->buildDefaultControls($control_builder, $item, $item_position);
+		$control_builder = $this->buildDefaultControls($control_builder, $item, $item_position);
 
 		//content
 		$obj_title = $next_item->getTitle();
 		$icon = $this->ui_factory->symbol()->icon()
 			->standard($next_item->getType(), $next_item->getType(), 'medium');
 
-		$curriculum = $this->curriculum_builder->getLearnerCurriculum(true)
-			->withActive($item_position);
-
 		$content = $this->renderComponentView($state, $view);
+
 		$panel = $this->ui_factory->panel()->standard(
 			'', //panel_title
 			$content
 		);
 		$content = [$panel];
 
-		return $this->page_renderer->render(
+
+		$rendered_body  = $this->page_renderer->render(
 			$this->lso_title,
 			$control_builder,
 			$obj_title,
 			$icon,
-			$content,
-			$curriculum
+			$content
 		);
+
+		$metabar_controls = [
+			'exit' => $control_builder->getExitControl()
+		];
+
+		//curriculum
+		$curriculum_slate = $this->page_renderer->buildCurriculumSlate(
+			$this->curriculum_builder
+				->getLearnerCurriculum(true)
+				->withActive($item_position)
+		);
+		$mainbar_controls = [
+			'curriculum' => $curriculum_slate
+		];
+
+		//ToC
+		$toc = $control_builder->getToc();
+		if($toc) {
+			$toc_slate = $this->page_renderer->buildToCSlate($toc);
+			$mainbar_controls['toc'] = $toc_slate;
+		}
+
+		$cc = $this->current_context;
+		$cc->addAdditionalData(self::GS_DATA_LS_KIOSK_MODE, true);
+		$cc->addAdditionalData(self::GS_DATA_LS_METABARCONTROLS, $metabar_controls);
+		$cc->addAdditionalData(self::GS_DATA_LS_MAINBARCONTROLS, $mainbar_controls);
+		$cc->addAdditionalData(self::GS_DATA_LS_CONTENT, $rendered_body);
+		return;
 	}
 
 	protected function getCurrentItem() {

--- a/Modules/LearningSequence/classes/Player/class.ilLegacyKioskModeView.php
+++ b/Modules/LearningSequence/classes/Player/class.ilLegacyKioskModeView.php
@@ -94,7 +94,8 @@ class ilLegacyKioskModeView implements ILIAS\KioskMode\View
 		}
 
 		$builder->start($label,	$url, 0);
-		//return $this->debugBuildAllControls($builder);
+
+//		return $this->debugBuildAllControls($builder);
 		return $builder;
 	}
 

--- a/Modules/LearningSequence/classes/Player/class.ilObjLearningSequenceLearnerGUI.php
+++ b/Modules/LearningSequence/classes/Player/class.ilObjLearningSequenceLearnerGUI.php
@@ -212,36 +212,26 @@ class ilObjLearningSequenceLearnerGUI
 
 	protected function play()
 	{
-		//enforce tree is visible/active for ToC
-		//(this does not work for first item, since there is no page-change)
-		//how is this done?
+		$response = $this->player->play($_GET, $_POST);
 
-		if(!$_SESSION["lso_old_il_rep_mode"]) {
-			$_SESSION["lso_old_il_rep_mode"] = $_SESSION["il_rep_mode"];
-		}
-		$_SESSION["il_rep_mode"] = 'tree';
+		switch ($response) {
+			case null:
+				//render the page
+				$this->tpl->enableDragDropFileUpload(null);
+				$this->tpl->setContent('THIS SHOULD NOT SHOW');
+				return;
 
-		$html = $this->player->render($_GET, $_POST);
+			case 'EXIT::' .$this->player::LSO_CMD_FINISH:
+				$cmd = self::CMD_EXTRO;
+				break;
 
-		if($html === 'EXIT::' .$this->player::LSO_CMD_SUSPEND) {
-			$cmd = self::CMD_STANDARD;
+			case 'EXIT::' .$this->player::LSO_CMD_SUSPEND:
+			default:
+				$cmd = self::CMD_STANDARD;
+				break;
 		}
-		if($html === 'EXIT::' .$this->player::LSO_CMD_FINISH) {
-			$cmd = self::CMD_EXTRO;
-		}
-		if(is_null($html)) {
-			$cmd = self::CMD_STANDARD;
-		}
-
-		if(is_null($cmd)){
-			print $html;
-			exit();
-		} else {
-			$_SESSION["il_rep_mode"] = $_SESSION["lso_old_il_rep_mode"];
-
-			$href = $this->ctrl->getLinkTarget($this, $cmd, '', false, false);
-			\ilUtil::redirect($href);
-		}
+		$href = $this->ctrl->getLinkTarget($this, $cmd, '', false, false);
+		\ilUtil::redirect($href);
 	}
 
 	protected function getCurrentItemLearningProgress()

--- a/Modules/LearningSequence/classes/class.ilLSDI.php
+++ b/Modules/LearningSequence/classes/class.ilLSDI.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
 use Pimple\Container;
+use ILIAS\GlobalScreen\ScreenContext\ScreenContext;
 
 
 /**
@@ -41,5 +42,11 @@ class ilLSDI extends Container
 		{
 			return new ilLSPostConditionDB($dic["ilDB"]);
 		};
+
+		$this["gs.current_context"] = function($c) use ($dic): ScreenContext
+		{
+			return $dic->globalScreen()->tool()->context()->current();
+		};
+
 	}
 }

--- a/Modules/LearningSequence/classes/class.ilLSLocalDI.php
+++ b/Modules/LearningSequence/classes/class.ilLSLocalDI.php
@@ -150,6 +150,7 @@ class ilLSLocalDI extends Container
 				$dic["global_screen"]->layout()->meta(),
 				$dic["ui.factory"],
 				$dic["ui.renderer"],
+				$dic['lng'],
 				$kiosk_template,
 				$c["gui.toc"],
 				$c["gui.loc"],

--- a/Modules/LearningSequence/classes/class.ilLSLocalDI.php
+++ b/Modules/LearningSequence/classes/class.ilLSLocalDI.php
@@ -148,6 +148,7 @@ class ilLSLocalDI extends Container
 			return new ilKioskPageRenderer(
 				$dic["tpl"],
 				$dic["global_screen"]->layout()->meta(),
+				$dic["ui.factory"],
 				$dic["ui.renderer"],
 				$kiosk_template,
 				$c["gui.toc"],
@@ -177,7 +178,9 @@ class ilLSLocalDI extends Container
 				$c["player.curriculumbuilder"],
 				$c["player.viewfactory"],
 				$c["player.kioskrenderer"],
-				$dic["ui.factory"]
+				$dic["ui.factory"],
+				$dic["gs.current_context"]
+
 			);
 		};
 

--- a/Modules/LearningSequence/templates/default/tpl.kioskpage.html
+++ b/Modules/LearningSequence/templates/default/tpl.kioskpage.html
@@ -1,130 +1,39 @@
+<div id="il_center_col" class="col-sm-9">
 
-<!DOCTYPE html>
-<html lang="de" dir="ltr">
-<head>
-	<meta charset="utf-8" />
-	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
-	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
+	<div class="ilLSOKioskModeObjectHeader">
+		<div class="media il_HeaderInner">
+			<div id="headerimage" class="media-object">
+				{OBJECT_ICON}
+			</div>
+			<h1 class="media-heading ilHeader">
+				<a class="ilAccAnchor" id="il_mhead_t_focus">
+					{OBJECT_TITLE}
+				</a>
+			</h1>
+		</div>
+	</div>
 
-	<title>{HTML_PAGE_TITLE}</title>
+	<nav class="ilToolbar navbar-default ilLSOKioskModeNavigation" role="navigation" id="2">
+		<div class="container-fluid">
+			<div class="navbar-header">
+				<div class="navbar-form">
+					{PLAYER_NAVIGATION} | {OBJ_NAVIGATION}
+				</div>
 
-	<base href="{BASE}" />
-
-	<style type="text/css">
-		{CSS_INLINE}
-	</style>
-
-	<!-- BEGIN css_file -->
-	<link rel="stylesheet" type="text/css" href="{CSS_FILE}" />
-	<!-- END css_file -->
-
-	<!-- BEGIN js_file -->
-	<script type="text/javascript" src="{JS_FILE}"></script>
-	<!-- END js_file -->
-	<script type="text/javascript">
-		{JS_INLINE}
-	</script>
-</head>
-
-<body class="std">
-	<div class="ilAll ilLSOKioskMode">
-
-		<div id="ilTopBar" class="ilTopBar ilTopFixed hidden-print">
-			<div class="container-fluid ilContainerWidth">
-				<div class="row">
-					<div class="ilLSOKioskTopBarControls">{TOPBAR_CONTROLS}</div>
-					<div class="ilLSOKioskTopBarTitle">
-						<div class="ilTopTitle">{TOPBAR_TITLE}</div>
-					</div>
+				<div class="ilLSOKioskModeViewModes">
+					{VIEW_MODES}
 				</div>
 			</div>
+
 		</div>
+	</nav>
 
-		<div id="mainspacekeeper" class="container-fluid ilContainerWidth">
-			<div class="row" style="position: relative;">
+	<div class="ilLSOKioskModeLocator">
+		{LOCATOR}
+	</div>
 
-				<div id="left_nav" class="ilLeftNav hidden-print<!-- BEGIN sidebar_disabled --> disabled<!-- END sidebar_disabled -->">
-					{SIDEBAR}
-				</div>
+	<div class="ilLSOKioskModeContent">
+		{CONTENT}
+	</div>
 
-				<div id="fixed_content" class="<!-- BEGIN sidebar_space -->ilLeftNavSpace <!-- END sidebar_space -->ilContentFixed">
-					<div id="mainscrolldiv">
-
-						<div class="ilClearFloat"></div>
-
-						<div class="container-fluid" id="ilContentContainer">
-							<div class="row">
-								<div id="il_center_col" class="col-sm-9">
-
-									<div class="ilLSOKioskModeObjectHeader">
-										<div class="media il_HeaderInner">
-											<div id="headerimage" class="media-object">
-												{OBJECT_ICON}
-											</div>
-											<h1 class="media-heading ilHeader">
-												<a class="ilAccAnchor" id="il_mhead_t_focus">
-													{OBJECT_TITLE}
-												</a>
-											</h1>
-										</div>
-									</div>
-
-									<nav class="ilToolbar navbar-default ilLSOKioskModeNavigation" role="navigation" id="2">
-										<div class="container-fluid">
-											<div class="navbar-header">
-													<div class="navbar-form">
-														{PLAYER_NAVIGATION} | {OBJ_NAVIGATION}
-													</div>
-
-													<div class="ilLSOKioskModeViewModes">
-														{VIEW_MODES}
-													</div>
-											</div>
-
-
-										</div>
-									</nav>
-
-									<div class="ilLSOKioskModeLocator">
-										{LOCATOR}
-									</div>
-
-									<div class="ilLSOKioskModeContent">
-										{CONTENT}
-									</div>
-
-								</div> <!-- il_center_col -->
-
-								<div id="il_right_col" class="col-sm-3">
-
-									<div class="ilLSOKioskModeCurriculum">
-										{CURRICULUM}
-									</div>
-
-								</div> <!-- il_right_col -->
-
-							</div>
-						</div><!-- #ilContentContainer -->
-
-					</div><!--mainscrolldiv -->
-				</div><!--fixed_content -->
-
-			</div><!-- row -->
-		</div><!-- mainspacekeeper -->
-
-	</div> <!-- ilAll -->
-
-	<!-- BEGIN on_load_code -->
-	<script type="text/javascript">
-		<!-- BEGIN on_load_code_inner -->
-			il.Util.addOnLoad(function() {
-				{OLCODE}
-			});
-		<!-- END on_load_code_inner -->
-	</script>
-	<!-- END on_load_code -->
-
-</body>
-</html>
-
+</div> <!-- il_center_col -->

--- a/Services/GlobalScreen/artifacts/global_screen_providers.php
+++ b/Services/GlobalScreen/artifacts/global_screen_providers.php
@@ -64,7 +64,8 @@
     3 => 'ILIAS\\LTI\\Screen\\LtiViewLayoutProvider',
     4 => 'ILIAS\\UICore\\PageContentProvider',
     5 => 'ilHTMLExportViewLayoutProvider',
-    6 => 'ilTestPlayerLayoutProvider',
+    6 => 'ilLSViewLayoutProvider',
+    7 => 'ilTestPlayerLayoutProvider',
   ),
   'ILIAS\\GlobalScreen\\Scope\\Notification\\Provider\\NotificationProvider' => 
   array (

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -15727,3 +15727,5 @@ cmix#:#highscore_top_num_unit#:#Platzierungen
 cmix#:#download_certificate#:#Zertifikat herunterladen
 dash#:#dash_info_sure_remove_from_favs#:#Sollen die folgenden Objekte wirklich aus Ihren Favoriten entfernt werden?
 mmbr#:#mmbr_unsubscribed_from_objs#:#Sie wurden von den ausgewählten Objekten abgemeldet.
+lso#:#lso_mainbar_button_label_toc#:#Inhalte
+lso#:#lso_mainbar_button_label_curriculum#:#Curriculum

--- a/src/GlobalScreen/Scope/Layout/Factory/FooterModification.php
+++ b/src/GlobalScreen/Scope/Layout/Factory/FooterModification.php
@@ -51,7 +51,7 @@ class FooterModification extends AbstractLayoutModification implements LayoutMod
      */
     public function returnTypeAllowsNull() : bool
     {
-        return false;
+        return true;
     }
 }
 

--- a/src/UI/Component/MainControls/MainBar.php
+++ b/src/UI/Component/MainControls/MainBar.php
@@ -114,4 +114,8 @@ interface MainBar extends \ILIAS\UI\Component\Component, JavaScriptBindable
      */
     public function getCloseButtons() : array;
 
+    /**
+     * Get a copy of this Mainbar without any entries.
+     */
+    public function withClearedEntries() : MainBar;
 }

--- a/src/UI/Component/MainControls/MetaBar.php
+++ b/src/UI/Component/MainControls/MetaBar.php
@@ -36,4 +36,9 @@ interface MetaBar extends Component, JavaScriptBindable
      * This signal disengages all slates when triggered.
      */
     public function getDisengageAllSignal() : Signal;
+
+    /**
+     * Get a copy of this Metabar without any entries.
+     */
+    public function withClearedEntries() : MetaBar;
 }

--- a/src/UI/Implementation/Component/MainControls/MainBar.php
+++ b/src/UI/Implementation/Component/MainControls/MainBar.php
@@ -300,4 +300,14 @@ class MainBar implements MainControls\MainBar
     {
         return $this->close_buttons;
     }
+
+
+    public function withClearedEntries() : MainControls\MainBar
+    {
+        $clone = clone $this;
+        $clone->entries = [];
+        $clone->tool_entries = [];
+        return $clone;
+    }
+
 }

--- a/src/UI/Implementation/Component/MainControls/MetaBar.php
+++ b/src/UI/Implementation/Component/MainControls/MetaBar.php
@@ -93,4 +93,11 @@ class MetaBar implements MainControls\MetaBar
         $this->entry_click_signal = $this->signal_generator->create();
         $this->disengage_all_signal = $this->signal_generator->create();
     }
+
+    public function withClearedEntries() : MainControls\MetaBar
+    {
+        $clone = clone $this;
+        $clone->entries = [];
+        return $clone;
+    }
 }


### PR DESCRIPTION
- extend Mainbar/Metabar with "withClearedEntries" to remove all entries
- move curriculum into slate
- move exit-control into metabar
- render content using layoutprovider/modifications
- cleanup template

https://docu.ilias.de/goto_docu_wiki_wpage_6070_1357.html