### PR TITLE
Study Programme/Dashboard: Render block as panel

### DIFF
--- a/Modules/StudyProgramme/classes/class.ilPDStudyProgrammeSimpleListGUI.php
+++ b/Modules/StudyProgramme/classes/class.ilPDStudyProgrammeSimpleListGUI.php
@@ -211,4 +211,15 @@ class ilPDStudyProgrammeSimpleListGUI extends ilBlockGUI {
 		$progress_gui->setOnlyRelevant(true);
 		return $progress_gui;
 	}
+
+    /**
+     * Get legacy content
+     *
+     * @return string
+     */
+    protected function getLegacyContent(): string
+    {
+        return $this->getDataSectionContent();
+    }
+
 }

--- a/Services/Block/classes/class.ilBlockGUI.php
+++ b/Services/Block/classes/class.ilBlockGUI.php
@@ -908,7 +908,7 @@ abstract class ilBlockGUI
 	//
 
 	// temporary flag
-	protected $new_rendering = false;
+	protected $new_rendering = true;
 
 
 	/**


### PR DESCRIPTION
This renders the study programme block in a KS panel.

The ilBlockGUI change is due to the migration from the old to the new rendering and will be handled/removed from me afterwards.