### PR TITLE
UI Components: Async Notifications

### DIFF
--- a/src/UI/Implementation/Component/Item/Renderer.php
+++ b/src/UI/Implementation/Component/Item/Renderer.php
@@ -106,11 +106,6 @@ class Renderer extends AbstractComponentRenderer
         return $tpl->get();
     }
 
-    /**
-     * @param Component\Item\Notification $component
-     * @param RendererInterface           $default_renderer
-     * @return string
-     */
     protected function renderNotification(Component\Item\Notification $component, RendererInterface $default_renderer)
     {
         $tpl = $this->getTemplate("tpl.item_notification.html", true, true);

--- a/src/UI/Implementation/Component/Item/Renderer.php
+++ b/src/UI/Implementation/Component/Item/Renderer.php
@@ -130,7 +130,7 @@ class Renderer extends AbstractComponentRenderer
         $aggregates_html = "";
 
         // aggregate notification
-        $title           = $this->getUIFactory()->button()->bulky($this->getUIFactory()->symbol()->glyph()->back(), "Back", "");
+        $title           = $this->getUIFactory()->button()->bulky($this->getUIFactory()->symbol()->glyph()->back(), $this->txt("back"), "");
         $aggregates_html = $default_renderer->render(
             $this->getUIFactory()->mainControls()->slate()->notification($default_renderer->render($title), $component->getAggregateNotifications())
         );

--- a/src/UI/Implementation/Component/Item/Renderer.php
+++ b/src/UI/Implementation/Component/Item/Renderer.php
@@ -106,6 +106,11 @@ class Renderer extends AbstractComponentRenderer
         return $tpl->get();
     }
 
+    /**
+     * @param Component\Item\Notification $component
+     * @param RendererInterface           $default_renderer
+     * @return string
+     */
     protected function renderNotification(Component\Item\Notification $component, RendererInterface $default_renderer)
     {
         $tpl = $this->getTemplate("tpl.item_notification.html", true, true);
@@ -119,44 +124,57 @@ class Renderer extends AbstractComponentRenderer
         if ($actions !== null) {
             $tpl->setVariable("ACTIONS", $default_renderer->render($actions));
         }
-        // close action
-        if ($component->getCloseAction()) {
-            $url          = $component->getCloseAction();
-            $close_action = $this->getUIFactory()->button()->close()->withAdditionalOnLoadCode(
-                function ($id) use ($url) {
-                    return "il.UI.item.notification.registerCloseAction('$id','$url');";
-                }
-            );
-            $tpl->setVariable("CLOSE_ACTION", $default_renderer->render($close_action));
-        }
+
         // additional content
         if ($component->getAdditionalContent()) {
             $tpl->setCurrentBlock("additional_content");
             $tpl->setVariable("ADDITIONAL_CONTENT", $default_renderer->render($component->getAdditionalContent()));
             $tpl->parseCurrentBlock();
         }
+
+        $aggregates_html = "";
+
         // aggregate notification
+        $title           = $this->getUIFactory()->button()->bulky($this->getUIFactory()->symbol()->glyph()->back(), "Back", "");
+        $aggregates_html = $default_renderer->render(
+            $this->getUIFactory()->mainControls()->slate()->notification($default_renderer->render($title), $component->getAggregateNotifications())
+        );
+
+        $toggleable = true;
         if (!empty($component->getAggregateNotifications())) {
-            $title           = $this->getUIFactory()->button()->bulky($this->getUIFactory()->symbol()->glyph()->back(), "Back", "");
-            $aggregates_html = $default_renderer->render(
-                $this->getUIFactory()->mainControls()->slate()->notification($default_renderer->render($title), $component->getAggregateNotifications())
-            );
-            $component       = $component->withAdditionalOnLoadCode(
-                function ($id) {
-                    return "il.UI.item.notification.registerAggregatesToggle('$id');";
+            $toggleable = false;
+        }
+
+        $component = $component->withAdditionalOnLoadCode(
+            function ($id) use ($toggleable){
+                return "il.UI.item.notification.getNotificationItemObject($($id)).registerAggregates($toggleable);";
+            }
+        );
+
+        //Bind id
+        $item_id = $this->bindJavaScript($component);
+
+        $tpl->setCurrentBlock("aggregate_notifications");
+        $tpl->setVariable("AGGREGATES", $aggregates_html);
+        $tpl->setVariable("PARENT_ID", $item_id);
+        $tpl->parseCurrentBlock();
+
+        // close action
+        if ($component->getCloseAction()) {
+            $url          = $component->getCloseAction();
+            $close_action = $this->getUIFactory()->button()->close()->withAdditionalOnLoadCode(
+                function ($id) use ($url, $item_id) {
+                    return "il.UI.item.notification.getNotificationItemObject($($id)).registerCloseAction('$url',1);";
                 }
             );
-            $id = $this->bindJavaScript($component);
-
-            $tpl->setCurrentBlock("id");
-            $tpl->setVariable('ID', $id);
-            $tpl->parseCurrentBlock();
-
-            $tpl->setCurrentBlock("aggregate_notifications");
-            $tpl->setVariable("AGGREGATES", $aggregates_html);
-            $tpl->setVariable("PARENT_ID", $id);
-            $tpl->parseCurrentBlock();
+            $tpl->setVariable("CLOSE_ACTION", $default_renderer->render($close_action));
         }
+
+        $tpl->setCurrentBlock("id");
+        $tpl->setVariable('ID', $item_id);
+        $tpl->parseCurrentBlock();
+
+
         return $tpl->get();
     }
 

--- a/src/UI/ROADMAP.md
+++ b/src/UI/ROADMAP.md
@@ -134,6 +134,10 @@ description, factory, renderer, directory...
 There are several tests still using snake cases as function names, remove it.
 See also: https://github.com/ILIAS-eLearning/ILIAS/pull/2299
 
+### Slates only accept string for titles (beginner, ~2h)
+
+In some cases (e.g. see Item Slate aggregates) it would be good for slate titles
+to also accept buttons. We should extend that.
 
 ## Long Term
 

--- a/src/UI/ROADMAP.md
+++ b/src/UI/ROADMAP.md
@@ -129,6 +129,11 @@ are created with methods that share the "group"-suffix. This is a exemplary case
 for the introduction of a new 'Group` family within `Input\Field`, with its own
 description, factory, renderer, directory...
 
+### Remove Snake Cases Functions for Tests (beginner, ~2h)
+
+There are several tests still using snake cases as function names, remove it.
+See also: https://github.com/ILIAS-eLearning/ILIAS/pull/2299
+
 
 ## Long Term
 
@@ -239,6 +244,15 @@ registries for CSS- and JS-resources. These registries could then be passed to
 the page and would turn the aforementioned transportation from ilTemplate obsolete.
 In ultimo, there would be exactly one occurence of a line like
 "echo $renderer->render($page);exit();" to output the complete UI.
+
+### Introduce proper Notification Center (Expert)
+
+The term "Notification Center" has not bee properly defined yet in the ILIAS context. 
+This leads to several issues. E.g. there is no notification center UI Component,
+laying (too much) work on the shoulders of Global Screen, Notification Slate and Items.
+However, just building such a UI Component, would not do the trick. This needs
+to go hand in hand with a proper discussion on what a Notification Center should be
+and do for us. Current state, see: [FR: Notification Center](https://docu.ilias.de/goto_docu_wiki_wpage_5118_1357.html).
 
 
 ## Ideas and Food for Thought

--- a/src/UI/examples/Item/Notification/async.php
+++ b/src/UI/examples/Item/Notification/async.php
@@ -1,0 +1,55 @@
+<?php
+function async()
+{
+    global $DIC;
+    $f        = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $async_close              = $_SERVER['REQUEST_URI'] . '&close_item=true';
+    $async_replace_url               = $_SERVER['REQUEST_URI'] . '&async_load_replace=true';
+    $async_replace_content_load_url               = $_SERVER['REQUEST_URI'] . '&async_load_replace_content=true';
+
+    //Creating a Mail Notification Item
+    $icon              = $f->symbol()->icon()->standard("chtr", "chtr");
+    $title             = $f->link()->standard("Some Title", "#");
+    $item = $f->item()->notification($title, $icon)->withCloseAction($async_close);
+
+    $async_item = $item->withAggregateNotifications([$item->withDescription("Original Item")]);
+
+    if ($_GET['async_load_replace']) {
+        $replacement = $async_item
+            ->withDescription("The Item has been replaced Async.")
+            ->withAggregateNotifications([$item->withDescription("This is a freshly async delivered Item.")
+                                          ,$item->withDescription("And a second one")]);
+        echo $renderer->renderAsync([$replacement]);
+        exit;
+    }
+
+    if ($_GET['async_load_replace_content']) {
+        $replacement = $async_item
+            ->withDescription("The content of the Item has been replaced Async.")
+            ->withAggregateNotifications([$item->withDescription("You will never see this")]);
+        echo $renderer->renderAsync($replacement);
+        exit;
+    }
+
+    $async_replace = $async_item
+        ->withDescription("The complete Item will be replaced Async")
+        ->withAdditionalOnLoadCode(function($id) use ($async_replace_url) {
+                return "
+                    var item = il.UI.item.notification.getNotificationItemObject($($id));
+                    item.replaceByAsyncItem('$async_replace_url',{});
+                ";
+            });
+
+    $async_replace_content = $async_item
+        ->withDescription("The content of the Item will be replaced Async")
+        ->withAdditionalOnLoadCode(function($id) use ($async_replace_content_load_url) {
+            return "
+                    var item = il.UI.item.notification.getNotificationItemObject($($id));
+                    item.replaceContentByAsyncItemContent('$async_replace_content_load_url',{});
+                ";
+        });
+
+    return $renderer->render([$async_replace,$async_replace_content]);
+}

--- a/src/UI/examples/MainControls/MetaBar/extended_notifications.php
+++ b/src/UI/examples/MainControls/MetaBar/extended_notifications.php
@@ -63,10 +63,10 @@ function extended_notifications()
     }
 
     if ($_GET['async_load_replace']==="true") {
-        $remaining = $_POST["remaining"];
-        $added = $_POST["added"];
+        $remaining = $_GET["remaining"];
+        $added = $_GET["added"];
 
-        //We create to amount of aggregates send to us by post and put an according
+        //We create the amount of aggregates send to us by get and put an according
         //description into the newly create Notification Item
         $items = [];
         for($i = 1; $i<$added+1; $i++){
@@ -80,16 +80,16 @@ function extended_notifications()
     }
 
     if ($_GET['async_load_replace_content']==="true") {
-        $remaining = $_POST["remaining"];
-        $added = $_POST["added"];
+        $remaining = $_GET["remaining"];
+        $added = $_GET["added"];
         $replacement = $item->withDescription("Number of Async non-closed Aggregates: ".$remaining.", totally created: ".$added);
         echo $renderer->renderAsync([$replacement]);
         exit;
     }
 
     if ($_GET['async_add_aggregate']==="true") {
-        $remaining = $_POST["remaining"];
-        $added = $_POST["added"];
+        $remaining = $_GET["remaining"];
+        $added = $_GET["added"];
 
         $new_aggregate = $closable_item->withDescription("The item has been added, Nr: ".$added);
 

--- a/src/UI/examples/MainControls/MetaBar/extended_notifications.php
+++ b/src/UI/examples/MainControls/MetaBar/extended_notifications.php
@@ -10,6 +10,20 @@
  *  - DemoScopeItem: Most importantly, the Notification Object for executing all the
  *      Async logic.
  *
+ * The functions of the public interface of interest featured here are:
+ *  - getNotificationItemObject($item_or_object_inside_item): Most importantly, returning
+ *       the Item Object, for access to all other functions of the interface.
+ *
+ *  - replaceByAsyncItem(url,send_data): Replaces the item completely with a new retrieved async.
+ *  - replaceContentByAsyncItemContent(url,send_data): Only replaces the data around the item
+ *       (title, description and such)
+ *  - addAsyncAggregate(url,send_data): Adds one aggregate retrieved async (the sub-like items).
+ *  - getCounterObjectIfAny(): Gets an instance of the counter for manual manipulations.
+ *
+ * Of further Interest could be (not featured here):
+ *  - getCloseButtonOfItem(): Getting a jQuery instance of the close button, e.g. for attaching
+ *     more interactions.
+
  * @return string
  */
 function extended_notifications()

--- a/src/UI/examples/MainControls/MetaBar/extended_notifications.php
+++ b/src/UI/examples/MainControls/MetaBar/extended_notifications.php
@@ -1,0 +1,149 @@
+<?php
+
+function extended_notifications()
+{
+    global $DIC;
+    $f = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+
+    $async_close              = $_SERVER['REQUEST_URI'].'&close_item=true&async_load_replace=false&async_load_replace_content=false&async_add_aggregate=false';
+    $async_replace_url               = $_SERVER['REQUEST_URI'] . '&close_item=false&async_load_replace=true&async_load_replace_content=false&async_add_aggregate=false';
+    $async_replace_content_load_url               = $_SERVER['REQUEST_URI'] . '&close_item=false&async_load_replace=false&async_load_replace_content=true&async_add_aggregate=false';
+    $async_add_aggregate = $_SERVER['REQUEST_URI'] . '&close_item=false&async_load_replace=false&async_load_replace_content=false&async_add_aggregate=true';
+
+    //Creating a Mail Notification Item
+    $icon              = $f->symbol()->icon()->standard("chtr", "chtr");
+    $title             = $f->link()->standard("Some Title", "#");
+    $item = $f->item()->notification($title, $icon);
+    $closable_item = $item->withCloseAction($async_close);
+
+    if ($_GET['async_load_replace']==="true") {
+        $remaining = $_POST["remaining"];
+        $added = $_POST["added"];
+
+        $items = [];
+        for($i = 1; $i<$remaining+1; $i++){
+            $items[] = $closable_item->withDescription("This item is number: ".$i." of a fix set of 10 entries.");
+        }
+        $replacement = $item->withDescription("Number of Async non-closed Aggregates: ".$remaining.", totally created: ".$added)
+            ->withAggregateNotifications($items);
+
+        echo $renderer->renderAsync([$replacement]);
+        exit;
+    }
+
+    if ($_GET['async_load_replace_content']==="true") {
+        $remaining = $_POST["remaining"];
+        $added = $_POST["added"];
+        $replacement = $item->withDescription("Number of Async non-closed Aggregates: ".$remaining.", totally created: ".$added);
+        echo $renderer->renderAsync([$replacement]);
+        exit;
+    }
+
+    if ($_GET['close_item']==="true") {
+        $js = $f->legacy("")->withOnLoadCode(function($id) use($async_replace_content_load_url){
+            return "
+                il.DemoScopeRemaining--;
+                il.DemoScopeItem.replaceContentByAsyncItemContent('$async_replace_content_load_url',{remaining: il.DemoScopeRemaining,added: il.DemoScopeAdded});
+            ";
+        });
+        echo $renderer->renderAsync($js);
+        exit;
+    }
+
+    if ($_GET['async_add_aggregate']==="true") {
+        $remaining = $_POST["remaining"];
+        $added = $_POST["added"];
+
+        $new_aggregate = $closable_item->withDescription("The item has been added, Nr: ".$added);
+
+        echo $renderer->renderAsync([$new_aggregate]);
+        exit;
+    }
+
+    $add_button = $f->button()->standard("Add Chat Notification", "#")
+                    ->withAdditionalOnLoadCode(function($id) use ($async_replace_url,$async_add_aggregate) {
+                        return "
+                            $('#$id').click(function() {
+                                il.DemoScopeItem.getCounterObjectIfAny().incrementNoveltyCount(1);
+                                il.DemoScopeAdded++;
+                                il.DemoScopeRemaining++;
+                                il.DemoScopeItem.addAsyncAggregate('$async_add_aggregate',{remaining: il.DemoScopeAdded,added: il.DemoScopeAdded});
+                                il.DemoScopeItem.replaceContentByAsyncItemContent('$async_replace_url',{remaining: il.DemoScopeAdded,added: il.DemoScopeAdded});
+                            });";
+                    });
+
+    $reset_button = $f->button()->standard("Reset Chat", "#")
+                      ->withAdditionalOnLoadCode(function($id) use ($async_replace_url) {
+                          return "
+                            $('#$id').click(function() {
+                                il.DemoScopeItem.getCounterObjectIfAny().decrementNoveltyCount(il.DemoScopeRemaining);
+                                il.DemoScopeAdded = 0;
+                                il.DemoScopeRemaining = 0;
+                                il.DemoScopeItem.replaceByAsyncItem('$async_replace_url',{remaining: il.DemoScopeAdded,added: il.DemoScopeAdded});
+                            });";
+                      });
+
+    $set_button = $f->button()->standard("Set to 10 chat entries", "#")
+                    ->withAdditionalOnLoadCode(function($id) use ($async_replace_url) {
+                        return "
+                            $('#$id').click(function() {
+                                il.DemoScopeItem.getCounterObjectIfAny().decrementNoveltyCount(il.DemoScopeRemaining);
+                                il.DemoScopeItem.getCounterObjectIfAny().incrementNoveltyCount(10);
+                                il.DemoScopeAdded = 10;
+                                il.DemoScopeRemaining = 10;
+                                il.DemoScopeItem.replaceByAsyncItem('$async_replace_url',{remaining: il.DemoScopeAdded,added: il.DemoScopeAdded});
+                            });";
+                    });
+
+    $async_item = $item
+        ->withDescription("This is the original Version after the Page has loaded. Will be replaced completely.")
+        ->withAdditionalOnLoadCode(function($id) {
+            return "
+                il.DemoScopeAdded = 0;
+                il.DemoScopeRemaining = 0;
+                il.DemoScopeItem = il.UI.item.notification.getNotificationItemObject($($id));
+            ";
+        });
+    $async_slate = $f->mainControls()->slate()->notification("Chat", [$async_item]);
+
+
+    //This item and its group is loaded regularly
+    $mail_icon              = $f->symbol()->icon()->standard("mail", "mail");
+    $mail_title             = $f->link()->standard("Inbox", "link_to_inbox");
+    $mail_notification_item = $f->item()->notification($mail_title, $mail_icon)
+                                ->withDescription("You have 23 unread mails in your inbox")
+                                ->withProperties(["Time" => "3 days ago"]);
+    $mail_slate    = $f->mainControls()->slate()->notification("Mail", [$mail_notification_item]);
+
+
+    $notification_glyph = $f->symbol()->glyph()->notification("notification", "notification")
+                             ->withCounter($f->counter()->novelty(1));
+
+    $notification_center = $f->mainControls()->slate()
+                             ->combined("Notification Center",$notification_glyph )
+                             ->withAdditionalEntry($async_slate)
+                             ->withAdditionalEntry($mail_slate);
+
+    $css_fix = "<style>.panel-primary .il-maincontrols-metabar{flex-direction: column;} .panel-primary .il-metabar-slates{position: relative;top: 0px;}</style>";
+    return $css_fix.$renderer->render([buildMetabarWithNotifications($f,$notification_center),$add_button,$set_button,$reset_button]);
+}
+
+function buildMetabarWithNotifications($f,$notification_center)
+{
+    $help = $f->button()->bulky($f->symbol()->glyph()->help(), 'Help', '#');
+    $search = $f->button()->bulky($f->symbol()->glyph()->search(), 'Search', '#');
+    $user = $f->button()->bulky($f->symbol()->glyph()->user(), 'User', '#');
+
+
+    $metabar = $f->mainControls()->metabar()
+                 ->withAdditionalEntry('search', $search)
+                 ->withAdditionalEntry('help', $help)
+                 ->withAdditionalEntry('notification', $notification_center)
+                 ->withAdditionalEntry('user', $user);
+
+    return $metabar;
+}
+
+

--- a/src/UI/examples/MainControls/Slate/Notification/standard.php
+++ b/src/UI/examples/MainControls/Slate/Notification/standard.php
@@ -4,6 +4,9 @@
  * Notification Items to it. However, note that this task is done by the global
  * screen. Currently, devs. will not come in contact with the Component outside
  * the Global Screen.
+ *
+ * Note, there is an extended example featuring async calls in the Main Controls Meta Bar
+ * Section
  */
 function standard()
 {

--- a/src/UI/templates/default/Item/tpl.item_notification.html
+++ b/src/UI/templates/default/Item/tpl.item_notification.html
@@ -1,44 +1,46 @@
-<div class="il-item il-notification-item" <!-- BEGIN id -->id="{ID}"<!-- END id -->>
-	<div class="media">
-		<div class="media-left">
-			<!-- BEGIN lead_icon -->{LEAD_ICON}<!-- END lead_icon -->
-		</div>
-		<div class="media-body">
-			<h5 class="il-item-notification-title">{TITLE}</h5>
-			{CLOSE_ACTION}
+<span class="il-item-notification-replacement-container">
+	<div class="il-item il-notification-item" <!-- BEGIN id -->id="{ID}"<!-- END id -->>
+		<div class="media">
+			<div class="media-left">
+				<!-- BEGIN lead_icon -->{LEAD_ICON}<!-- END lead_icon -->
+			</div>
+			<div class="media-body">
+				<h5 class="il-item-notification-title">{TITLE}</h5>
+				{CLOSE_ACTION}
 
-			<!-- BEGIN desc -->
-			<div class="il-item-description">{DESC}</div>
-			<!-- END desc -->
-			{ACTIONS}
-			<!-- BEGIN additional_content -->
-			<div class="il-item-additional-content">{ADDITIONAL_CONTENT}</div>
-			<!-- END additional_content -->
+				<!-- BEGIN desc -->
+				<div class="il-item-description">{DESC}</div>
+				<!-- END desc -->
+				{ACTIONS}
+				<!-- BEGIN additional_content -->
+				<div class="il-item-additional-content">{ADDITIONAL_CONTENT}</div>
+				<!-- END additional_content -->
 
-			<!-- BEGIN properties -->
-			<hr class="il-item-divider">
-			<!-- BEGIN property_row -->
-			<div class="row">
-				<div class="col-md-6">
-					<div class="row">
-						<div class="col-sm-5 il-item-property-name">{PROP_NAME_A}</div>
-						<div class="col-sm-7 il-item-property-value il-multi-line-cap-3">{PROP_VAL_A}</div>
+				<!-- BEGIN properties -->
+				<hr class="il-item-divider">
+				<!-- BEGIN property_row -->
+				<div class="row il-item-properties">
+					<div class="col-md-6">
+						<div class="row">
+							<div class="col-sm-5 il-item-property-name">{PROP_NAME_A}</div>
+							<div class="col-sm-7 il-item-property-value il-multi-line-cap-3">{PROP_VAL_A}</div>
+						</div>
+					</div>
+					<div class="col-md-6">
+						<div class="row">
+							<div class="col-sm-5 il-item-property-name">{PROP_NAME_B}</div>
+							<div class="col-sm-7 il-item-property-value il-multi-line-cap-3">{PROP_VAL_B}</div>
+						</div>
 					</div>
 				</div>
-				<div class="col-md-6">
-					<div class="row">
-						<div class="col-sm-5 il-item-property-name">{PROP_NAME_B}</div>
-						<div class="col-sm-7 il-item-property-value il-multi-line-cap-3">{PROP_VAL_B}</div>
-					</div>
+				<!-- END property_row -->
+				<!-- END properties -->
+				<!-- BEGIN aggregate_notifications -->
+				<div class="il-aggregate-notifications" data-aggregatedby="{PARENT_ID}">
+					{AGGREGATES}
 				</div>
+				<!-- END aggregate_notifications -->
 			</div>
-			<!-- END property_row -->
-			<!-- END properties -->
-			<!-- BEGIN aggregate_notifications -->
-			<div class="il-aggregate-notifications" data-aggregatedby="{PARENT_ID}">
-				{AGGREGATES}
-			</div>
-			<!-- END aggregate_notifications -->
 		</div>
 	</div>
-</div>
+</span>

--- a/src/UI/templates/js/Item/notification.js
+++ b/src/UI/templates/js/Item/notification.js
@@ -10,143 +10,312 @@ il.UI.item = il.UI.item || {};
  */
 (function($, item ) {
 	item.notification = (function($) {
+		/**
+		 * Name of the counter class in the DOM
+		 * @private
+		 */
+		var _cls_item_container = 'il-item-notification-replacement-container';
 
 		/**
 		 * See Interface description
-		 * @param id
-		 * @param url
 		 */
-		var registerCloseAction = function(id,url) {
-			var $close_button = $('#'+id);
-			console.log(id);
+		var getNotificationItemObject= function($item_or_object_inside_item){
+			console.assert($item_or_object_inside_item instanceof jQuery,
+				"$item_or_object_inside_item is not a jQuery Object, param: "+$item_or_object_inside_item);
 
-			$close_button.click(function(){
-				removeNotificationItem($close_button);
-				callCloseActionAsync(url);
-			});
+			var $item = $item_or_object_inside_item;
+			if(!$item.hasClass(_cls_item_container)){
+				$item = $item_or_object_inside_item.closest("."+_cls_item_container);
+			}
+			console.assert($item.length > 0, "Passed jQuery Object does not contain a Notification Item");
+
+			//Make sure *this* in generateCounterObject is properly bound.
+			var NotificationItemConstructor = generateNotificationItemObject.bind({});
+			return NotificationItemConstructor($item);
 		};
 
 		/**
-		 * See Interface description
-		 * @param id
+		 * Interface returned by this function for public use (see return statement bellow)
+		 * The contained functions are implemented bellow
 		 */
-		var registerAggregatesToggle = function(id){
-			var $item = $('#'+id);
-			var $title = $item.find(".il-item-notification-title");
-			var $aggregates = $("div[data-aggregatedby="+id+"]").hide();
+		var public_interface = {
 
-			$title.find("a").attr("href", "#");
-			$title.click(function(event){
-				engageAggregatesOfItem($item,$aggregates);
-			});
-
-			$aggregates.find(".il-maincontrols-slate-notification-title").click(function(){
-				disEngageAggregatesOfItem($item,$aggregates)
-			});
-		};
-
-		/**
-		 * Note that the Name "Public Interface" here indicates, that those two functions will be
-		 * used outside of this scope. However, the only consumer currently is the "withAdditionalOnLoadCode"
-		 * function in the renderer of the items.
-		 *
-		 * @type {{registerCloseAction: registerCloseAction, registerAggregatesToggle: registerAggregatesToggle}}
-		 */
-		var public_interface =  {
 			/**
-			 * Used to register the close action on the Item if such an action is given.
-			 * Note that not all items are closable. Close action removes the item
-			 * from the list, and fires a callback to the server to notify the respective
-			 * endpoint on the server, that this item has been closed.
+			 * The argument passed mussed be the jQuery Object of some element containing
+			 * a notification slate. Then, the function searches the jQuery Notification Slate
+			 * object in the DOM and creates an new Notification Slate object by using the
+			 * generateNotificationSlateObject function
+			 */
+
+			getNotificationItemObject: getNotificationItemObject,
+		};
+
+
+
+		/**
+		 * Declaration and implementation of the notification slate object
+		 */
+		var generateNotificationItemObject = function($item){
+			var $item = $item;
+
+			/**
+			 * See Interface description
+			 * @param id
+			 */
+			this.registerAggregates = function(prevent_toggle){
+				var $aggregates = getAggregatesOfItem().hide();
+
+				$aggregates.find(".il-maincontrols-slate-notification-title").click(function(){
+					disEngageAggregatesOfItem($aggregates)
+				});
+
+				if(!prevent_toggle){
+					var $title = $item.find(".il-item-notification-title").first();
+					$title.find("a").attr("href", "#");
+					$title.click(function(event){
+						engageAggregatesOfItem($aggregates);
+					});
+				}
+			};
+
+
+
+			/**
+			 * See Interface description
+			 * @param id
+			 */
+			this.replaceByAsyncItem = function(url,send_data){
+				disEngageAggregatesOfItem(getAggregatesOfItem());
+				getAggregatesOfItem().remove();
+				performAsyncCall(url,send_data,function(data) {
+					getParentSlateOfItem().show();
+					$item.html(data);
+				});
+				return this;
+			};
+
+			this.replaceContentByAsyncItemContent = function(url,send_data){
+				performAsyncCall(url,send_data,function(data) {
+					copyContent($item,$(data),[
+						".il-item-notification-title",
+						".il-item-additional-content",
+						".il-item-properties",
+						".il-item-description"]);
+				});
+				return this;
+			};
+
+			this.addAsyncAggregate = function(url,send_data){
+				var self = this;
+				performAsyncCall(url,send_data,function(data) {
+					var $aggregates = getAggregatesOfItem().append(data);
+					if($aggregates.find(".il-item-notification-replacement-container").length === 1){
+						self.registerAggregates();
+					}
+				});
+				return this;
+			};
+
+			this.getCounterObjectIfAny = function(){
+				var $meta_bar = getMetaBarOfItemIfIsInOne();
+				if($meta_bar.length){
+					return il.UI.counter.getCounterObject(getNotificationsTriggererIfAny());
+				}
+			}
+
+			/**
+			 * See Interface description
+			 * @param id
+			 * @param url
+			 */
+			this.registerCloseAction = function(url,amount) {
+				var self = this;
+				var $close_button = this.getCloseButtonOfItem();
+				if($close_button.length){
+					$close_button.click(function(){
+						var $counter = self.getCounterObjectIfAny();
+						if($counter){
+							$counter.decrementNoveltyCount(amount);
+						}
+						callCloseActionAsync(url);
+						removeNotificationItem();
+					});
+				}
+			};
+
+			this.getCloseButtonOfItem = function () {
+				return $item.find(".close").first();
+			}
+
+			/**
+			 * Interface returned by this function for public use (see return statement bellow)
+			 * The contained functions are implemented bellow
+			 */
+			var public_object_interace = {
+				/**
+				 * Used to register the close action on the Item if such an action is given.
+				 * Note that not all items are closable. Close action removes the item
+				 * from the list, and fires a callback to the server to notify the respective
+				 * endpoint on the server, that this item has been closed.
+				 */
+				registerCloseAction: this.registerCloseAction,
+				/**
+				 * If an item contains aggregate items, they will be shown if the aggregating item
+				 * is clicked. This interaction is registered on the item here.
+				 */
+				registerAggregates: this.registerAggregates,
+				/**
+				 * Checks if there is any Novelty Counter inside the counter the given object
+				 */
+				replaceByAsyncItem: this.replaceByAsyncItem,
+				/**
+				 * Checks if there is any Status Counter inside the counter the given object
+				 */
+				replaceContentByAsyncItemContent: this.replaceContentByAsyncItemContent,
+
+				addAsyncAggregate: this.addAsyncAggregate,
+				/**
+				 * Checks if there is any Status Counter inside the counter the given object
+				 */
+				getCloseButtonOfItem: this.getCloseButtonOfItem,
+
+
+				getCounterObjectIfAny: this.getCounterObjectIfAny
+			};
+
+			var copyContent = function($to,$from, parts){
+				parts.forEach(function (part) {
+					console.log(part);
+					console.log($from.find(part).html());
+
+					$to.find(part).first().html($from.find(part).html());
+				});;
+			}
+
+
+			var performAsyncCall = function(url,send_data,callback){
+				$.ajax({
+					url: url,
+					data: send_data,
+					type: "POST"
+				}).done(function(data) {
+					callback(data);
+				});
+			}
+
+
+
+			/**
+			 * Firing to callback to the endpoint on the server
 			 *
+			 * @private
+			 * @param $item
+			 * @param $aggregates
 			 */
-			registerCloseAction: registerCloseAction,
+			var callCloseActionAsync = function(url){
+				$.ajax({
+					url: url
+				}).done(function(data) {
+					$item.append(data);
+				});
+			};
+
 			/**
-			 * If an item contains aggregate items, they will be shown if the aggregating item
-			 * is clicked. This interaction is registered on the item here.
+			 * Removing the closed item from the list.
+			 *
+			 * @private
+			 * @param $close_button
 			 */
-			registerAggregatesToggle: registerAggregatesToggle
-		}
+			var removeNotificationItem = function () {
+				console.log($item.siblings().children().length);
+				if(!$item.siblings().children(".il-notification-item").length){
+					getParentSlateOfItem().hide();
+					if($item.parents(".il-aggregate-notifications").length) {
+						getParentSlateOfItem().show().siblings().show();
+					}
+				}
+				$item.children().remove();
+			};
 
-		/**
-		 * Showing aggregates if aggregating item is clicked.
-		 *
-		 * @private
-		 * @param $item
-		 * @param $aggregates
-		 */
-		var engageAggregatesOfItem = function($item,$aggregates){
-			$item.hide();
 
-			var $parent_slate = getParentSlateOfItem($item)
 
-			if($parent_slate.length){
-				$parent_slate.siblings().hide();
-				$parent_slate.hide();
-				$aggregates.insertAfter($parent_slate).show();
-			}else{
-				$aggregates.insertAfter($item).show();
+			/**
+			 * Showing aggregates if aggregating item is clicked.
+			 *
+			 * @private
+			 * @param $aggregates
+			 */
+			var engageAggregatesOfItem = function($aggregates){
+
+				var $parent_slate = getParentSlateOfItem();
+
+				if($parent_slate.length){
+					$parent_slate.siblings().hide();
+					$parent_slate.hide();
+					$aggregates.insertAfter($parent_slate).show();
+				}else{
+					$aggregates.insertAfter($item).show();
+					$item.hide();
+				}
+			};
+
+
+			/**
+			 * Hiding aggregates, if the user navigates back to the top level.
+			 *
+			 * @private
+			 * @param $item
+			 * @param $aggregates
+			 */
+			var disEngageAggregatesOfItem = function($aggregates){
+				var $parent_slate = getParentSlateOfItem();
+				if($parent_slate.length){
+					$parent_slate.siblings().show();
+					$parent_slate.show();
+				}
+				$item.show().append($aggregates);
+				$aggregates.hide();
+			};
+
+			var getNotificationsTriggererIfAny = function(){
+				var $meta_bar = getMetaBarOfItemIfIsInOne();
+				if($meta_bar.length){
+					var $notification_glyph = $meta_bar.find('.il-metabar-entries > .btn-bulky .glyphicon-bell');
+					return $notification_glyph.parents('.btn-bulky');
+				}
 			}
-		};
 
-		/**
-		 * Hiding aggregates, if the user navigates back to the top level.
-		 *
-		 * @private
-		 * @param $item
-		 * @param $aggregates
-		 */
-		var disEngageAggregatesOfItem = function($item,$aggregates){
-			$item.show();
-			var $parent_slate = getParentSlateOfItem($item);
-			if($parent_slate.length){
-				$parent_slate.siblings().show();
-				$parent_slate.show();
+			/**
+			 * Gets and returns the Meta Bar if there is one
+			 */
+			var getMetaBarOfItemIfIsInOne = function(){
+				return $item.parents('.il-maincontrols-metabar');
 			}
-			$item.show().append($aggregates);
-			$aggregates.hide();
-		};
 
-		/**
-		 * Firing to callback to the endpoint on the server
-		 *
-		 * @private
-		 * @param $item
-		 * @param $aggregates
-		 */
-		var callCloseActionAsync = function(url){
-			$.ajax({
-				url: url
-			}).done(function(data) {
-				//Nothing to be done here.
-			});
-		};
-
-		/**
-		 * Removing the closed item from the list.
-		 *
-		 * @private
-		 * @param $item
-		 * @param $aggregates
-		 */
-		var removeNotificationItem = function ($close_button) {
-			var $item = $close_button.parents(".il-notification-item");
-			var $item_siblings = $item.siblings(".il-notification-item");
-			if(!$item_siblings.length){
-				getParentSlateOfItem($item).remove();
+			var getAggregatesOfItem = function(){
+				$parent = getParentSlateOfItem().parent();
+				if(!$parent.length){
+					$parent = $('body');
+				}
+				return $parent.find(".il-aggregate-notifications[data-aggregatedby="+getId()+"]");
 			}
-			$item.remove();
-		};
 
-		/**
-		 * Get the slate, that contains the item given
-		 * 
-		 * @private
-		 * @param $item
-		 * @param $aggregates
-		 */
-		var getParentSlateOfItem = function($item){
-			return $item.parents(".il-maincontrols-slate-notification");
+			/**
+			 * Get the slate, that contains the item given
+			 *
+			 * @private
+			 * @param $item
+			 */
+			var getParentSlateOfItem = function(){
+				return $item.parents(".il-maincontrols-slate-notification");
+			};
+
+			var getId = function(){
+				console.log("get id: "+$item.children().attr('id'));
+				return $item.find(".il-notification-item").first().attr('id');
+			}
+
+			return public_object_interace;
 		};
 
 		return public_interface;

--- a/src/UI/templates/js/Item/notification.js
+++ b/src/UI/templates/js/Item/notification.js
@@ -3,21 +3,61 @@ il.UI = il.UI || {};
 il.UI.item = il.UI.item || {};
 
 /**
- * Scope for JS code for the Items in the UI Components.
+ * Scope for JS code for the Notification Items in the UI Components.
  *
- * This Scope offers an interface providing two function for the Notification Items
- * that are currently only used internally while rendering the Notification Items
+ * Note that this scope provides a public interface through which Notification Items can
+ * be accessed and manipulated by the client side. Note that this is the same pattern as is used by
+ * counter.js
+ *
+ * This scope contains only the getNotificationItemObject through which a Notification Item object can
+ * be accessed.
+ *
+ * See the public_object_interface bellow for a list of functions of this object offered
+ * to the public. Also see the extended asyc Main Controls Meta Bar example for a detailed
+ * show case of the provided functionality.
+ *
+ * Note that this can be used
+ *
+ * Example Usage:
+ *
+ * //Step 1: Get the Notification Item Object
+ * var il.MyScoope.myNotificationItem = il.UI.item.notification.getNotificationItemObject($('selector'));
+ *
+ * Note that it is probably best to grap the selector directly from the item itself like so:
+ *
+ * $async_item = $item->withAdditionalOnLoadCode(function($id) {
+ *   return "il.MyScoope.myNotificationItem  = il.UI.item.notification.getNotificationItemObject($($id));";
+ * });
+ *
+ * //Step 2: Do stuff with the Notification Item Object
+ * il.MyScoope.myNotificationItem.replaceByAsyncItem('some_url',{some_data});
+ *
+ * //Step 3: Note that you can also get the counter if the object is placed in the Meta Bar like so:
+ * il.MyScoope.myNotificationItem.getCounterObjectIfAny().incrementNoveltyCount(10);
  */
 (function($, item ) {
 	item.notification = (function($) {
 		/**
-		 * Name of the counter class in the DOM
+		 * Name of the outermost Notification Item class in the DOM. This is
+		 * where our internal $item will point to. Even if the complete
+		 * Notification Item is replaced, this will remain in the DOM to give
+		 * the object a valid access for further actions (e.g. putting something new
+		 * in there), or modifying counters.
+		 *
 		 * @private
 		 */
 		var _cls_item_container = 'il-item-notification-replacement-container';
 
+
 		/**
-		 * See Interface description
+
+		 /**
+		 * The argument passed mussed be the jQuery Object of some element residing inside
+		 * a Notification Item Object. Then, the function searches the jQuery Notification Slate
+		 * object in the DOM and creates an new Notification Slate object by using the
+		 * generateNotificationSlateObject function
+		 *
+		 * @public
 		 */
 		var getNotificationItemObject= function($item_or_object_inside_item){
 			console.assert($item_or_object_inside_item instanceof jQuery,
@@ -29,38 +69,122 @@ il.UI.item = il.UI.item || {};
 			}
 			console.assert($item.length > 0, "Passed jQuery Object does not contain a Notification Item");
 
-			//Make sure *this* in generateCounterObject is properly bound.
+			//Make sure *this* in generateNotificationItemObject is properly bound.
 			var NotificationItemConstructor = generateNotificationItemObject.bind({});
 			return NotificationItemConstructor($item);
 		};
 
 		/**
-		 * Interface returned by this function for public use (see return statement bellow)
-		 * The contained functions are implemented bellow
+		 * Interface returned by this function for public use
 		 */
 		var public_interface = {
-
-			/**
-			 * The argument passed mussed be the jQuery Object of some element containing
-			 * a notification slate. Then, the function searches the jQuery Notification Slate
-			 * object in the DOM and creates an new Notification Slate object by using the
-			 * generateNotificationSlateObject function
-			 */
-
 			getNotificationItemObject: getNotificationItemObject,
 		};
 
 
 
 		/**
-		 * Declaration and implementation of the notification slate object
+		 * Declaration and implementation of the Notification Item object.
+		 * Those functions are available through the object provided by getNotificationItemObject
 		 */
 		var generateNotificationItemObject = function($item){
+			/**
+			 * jQuery object pointing to the outmost il-item-notification-replacement-container
+			 * div.
+			 */
 			var $item = $item;
 
 			/**
-			 * See Interface description
-			 * @param id
+			 * Replaces the complete Notification Item along with its
+			 * aggregates. Note that $item remains valid, since
+			 * it points to an outer container.
+			 *
+			 * Note, POST is used to send large amounts of DATA back here.
+			 *
+			 * @public
+			 * @param url
+			 * @param send_data
+			 * @returns {generateNotificationItemObject}
+			 */
+			this.replaceByAsyncItem = function(url,send_data){
+				disEngageAggregatesOfItem(getAggregatesOfItem());
+				getAggregatesOfItem().remove();
+				performAsyncCall(url,send_data,function(data) {
+					getParentSlateOfItem().show();
+					$item.html(data);
+				});
+				return this;
+			};
+
+			/**
+			 * Replaces only the data of the Notification Item
+			 * not it's aggregates. This can be used, if
+			 * e.g. only a time property or description text has to be
+			 * changed, and not the whole list of aggregates.
+			 *
+			 * Note, POST is used to send large amounts of DATA back here.
+			 *
+			 * @public
+			 * @param url
+			 * @param send_data
+			 * @returns {generateNotificationItemObject}
+			 */
+			this.replaceContentByAsyncItemContent = function(url,send_data){
+				performAsyncCall(url,send_data,function(data) {
+					copyContent($item,$(data),[
+						".il-item-notification-title",
+						".il-item-additional-content",
+						".il-item-properties",
+						".il-item-description"]);
+				});
+				return this;
+			};
+
+			/**
+			 * Adds an additional aggregate to the Notification Item returned
+			 * by the URL called async.
+			 *
+			 * Note, POST is used to send large amounts of DATA back here.
+			 *
+			 * @public
+			 * @param url
+			 * @param send_data
+			 * @returns {generateNotificationItemObject}
+			 */
+			this.addAsyncAggregate = function(url,send_data){
+				var self = this;
+				performAsyncCall(url,send_data,function(data) {
+					var $aggregates = getAggregatesOfItem().append(data);
+					if($aggregates.find(".il-item-notification-replacement-container").length === 1){
+						self.registerAggregates();
+					}
+				});
+				return this;
+			};
+
+			/**
+			 * Returns the Object, if the context the Items resides in provides such an Object.
+			 * Note, that one has to manipulate counters manually, if the async methods are used.
+			 *
+			 * @public
+			 * @returns {generateCounterObject}
+			 */
+			this.getCounterObjectIfAny = function(){
+				var $meta_bar = getMetaBarOfItemIfIsInOne();
+				if($meta_bar.length){
+					return il.UI.counter.getCounterObject(getNotificationsTriggererIfAny());
+				}
+			}
+
+			/**
+			 * Used to register the aggregates section and the necessary actioins.
+			 * All Notification Items have such a section, however, if this section is empty it is not accessible.
+			 *
+			 * Note this is usually only used internally or by the Notification Item renderer.
+			 *
+			 * @public
+			 * @param bool prevent_toggle
+			 * @returns {generateNotificationItemObject}
 			 */
 			this.registerAggregates = function(prevent_toggle){
 				var $aggregates = getAggregatesOfItem().hide();
@@ -76,57 +200,26 @@ il.UI.item = il.UI.item || {};
 						engageAggregatesOfItem($aggregates);
 					});
 				}
+				return this;
 			};
-
-
 
 			/**
-			 * See Interface description
-			 * @param id
-			 */
-			this.replaceByAsyncItem = function(url,send_data){
-				disEngageAggregatesOfItem(getAggregatesOfItem());
-				getAggregatesOfItem().remove();
-				performAsyncCall(url,send_data,function(data) {
-					getParentSlateOfItem().show();
-					$item.html(data);
-				});
-				return this;
-			};
-
-			this.replaceContentByAsyncItemContent = function(url,send_data){
-				performAsyncCall(url,send_data,function(data) {
-					copyContent($item,$(data),[
-						".il-item-notification-title",
-						".il-item-additional-content",
-						".il-item-properties",
-						".il-item-description"]);
-				});
-				return this;
-			};
-
-			this.addAsyncAggregate = function(url,send_data){
-				var self = this;
-				performAsyncCall(url,send_data,function(data) {
-					var $aggregates = getAggregatesOfItem().append(data);
-					if($aggregates.find(".il-item-notification-replacement-container").length === 1){
-						self.registerAggregates();
-					}
-				});
-				return this;
-			};
-
-			this.getCounterObjectIfAny = function(){
-				var $meta_bar = getMetaBarOfItemIfIsInOne();
-				if($meta_bar.length){
-					return il.UI.counter.getCounterObject(getNotificationsTriggererIfAny());
-				}
-			}
-
-			/**
-			 * See Interface description
-			 * @param id
-			 * @param url
+			 * Used to register the close action on the Item if such an action is given.
+			 * Note that not all items are closable. Close action removes the item
+			 * from the list, and fires a callback to the server to notify the respective
+			 * endpoint on the server, that this item has been closed.
+			 *
+			 * Note this is usually only used internally or by the Notification Item renderer.
+			 * Others just provide an URL on the Notification Item Component and work from there.
+			 *
+			 * Note that JS logic might be returned by the server, which would be
+			 * attached to the DOM and executed if properly wrapped. See the extended
+			 * Meta Bar example.
+			 *
+			 * @public
+			 * @param string url
+			 * @param int amount
+			 * @returns {generateNotificationItemObject}
 			 */
 			this.registerCloseAction = function(url,amount) {
 				var self = this;
@@ -137,62 +230,58 @@ il.UI.item = il.UI.item || {};
 						if($counter){
 							$counter.decrementNoveltyCount(amount);
 						}
-						callCloseActionAsync(url);
+						performAsyncCall(url,{},function(data) {
+							$item.append(data);
+						});
 						removeNotificationItem();
 					});
 				}
+				return this;
 			};
 
+			/**
+			 * Return a handle to the close Button, in case
+			 * additional magic needs to be placed on this button.
+			 *
+			 * @public
+			 * @returns jQuery Close Button
+			 */
 			this.getCloseButtonOfItem = function () {
 				return $item.find(".close").first();
 			}
 
 			/**
-			 * Interface returned by this function for public use (see return statement bellow)
+			 * Interface returned by this function for public use
 			 * The contained functions are implemented bellow
 			 */
-			var public_object_interace = {
-				/**
-				 * Used to register the close action on the Item if such an action is given.
-				 * Note that not all items are closable. Close action removes the item
-				 * from the list, and fires a callback to the server to notify the respective
-				 * endpoint on the server, that this item has been closed.
-				 */
+			var public_object_interface = {
 				registerCloseAction: this.registerCloseAction,
-				/**
-				 * If an item contains aggregate items, they will be shown if the aggregating item
-				 * is clicked. This interaction is registered on the item here.
-				 */
 				registerAggregates: this.registerAggregates,
-				/**
-				 * Checks if there is any Novelty Counter inside the counter the given object
-				 */
 				replaceByAsyncItem: this.replaceByAsyncItem,
-				/**
-				 * Checks if there is any Status Counter inside the counter the given object
-				 */
 				replaceContentByAsyncItemContent: this.replaceContentByAsyncItemContent,
-
 				addAsyncAggregate: this.addAsyncAggregate,
-				/**
-				 * Checks if there is any Status Counter inside the counter the given object
-				 */
 				getCloseButtonOfItem: this.getCloseButtonOfItem,
-
-
 				getCounterObjectIfAny: this.getCounterObjectIfAny
 			};
 
-			var copyContent = function($to,$from, parts){
-				parts.forEach(function (part) {
-					console.log(part);
-					console.log($from.find(part).html());
 
-					$to.find(part).first().html($from.find(part).html());
-				});;
-			}
+			/**
+			 * The following function are all internal.
+			 */
 
-
+			/**
+			 * Just some syntactic sugar for the ajax call.
+			 * Note that we send data per POST, in case
+			 * we need to send larger amounts. POST should
+			 * be fine also in a semantical sense, since
+			 * often we really do POST back data here, to be
+			 * stored permanently.
+			 *
+			 * @private
+			 * @param url
+			 * @param send_data
+			 * @param callback
+			 */
 			var performAsyncCall = function(url,send_data,callback){
 				$.ajax({
 					url: url,
@@ -204,40 +293,21 @@ il.UI.item = il.UI.item || {};
 			}
 
 
-
 			/**
-			 * Firing to callback to the endpoint on the server
+			 * Copies a set of divs to another. Used
+			 * to exchange the content of an old to a new
+			 * version of the notification item.
 			 *
 			 * @private
-			 * @param $item
-			 * @param $aggregates
+			 * @param $to
+			 * @param $from
+			 * @param parts
 			 */
-			var callCloseActionAsync = function(url){
-				$.ajax({
-					url: url
-				}).done(function(data) {
-					$item.append(data);
-				});
-			};
-
-			/**
-			 * Removing the closed item from the list.
-			 *
-			 * @private
-			 * @param $close_button
-			 */
-			var removeNotificationItem = function () {
-				console.log($item.siblings().children().length);
-				if(!$item.siblings().children(".il-notification-item").length){
-					getParentSlateOfItem().hide();
-					if($item.parents(".il-aggregate-notifications").length) {
-						getParentSlateOfItem().show().siblings().show();
-					}
-				}
-				$item.children().remove();
-			};
-
-
+			var copyContent = function($to,$from, parts){
+				parts.forEach(function (part) {
+					$to.find(part).first().html($from.find(part).html());
+				});;
+			}
 
 			/**
 			 * Showing aggregates if aggregating item is clicked.
@@ -265,7 +335,6 @@ il.UI.item = il.UI.item || {};
 			 *
 			 * @private
 			 * @param $item
-			 * @param $aggregates
 			 */
 			var disEngageAggregatesOfItem = function($aggregates){
 				var $parent_slate = getParentSlateOfItem();
@@ -276,22 +345,28 @@ il.UI.item = il.UI.item || {};
 				$item.show().append($aggregates);
 				$aggregates.hide();
 			};
-
-			var getNotificationsTriggererIfAny = function(){
-				var $meta_bar = getMetaBarOfItemIfIsInOne();
-				if($meta_bar.length){
-					var $notification_glyph = $meta_bar.find('.il-metabar-entries > .btn-bulky .glyphicon-bell');
-					return $notification_glyph.parents('.btn-bulky');
+			/**
+			 * Removes an Notificaiton Item and the aggretas.
+			 * Note that depending on the state after removing, some
+			 * additional cleaning up needs to be done.
+			 *
+			 * @private
+			 * @param $close_button
+			 */
+			var removeNotificationItem = function () {
+				if(!$item.siblings().children(".il-notification-item").length){
+					getParentSlateOfItem().hide();
+					if($item.parents(".il-aggregate-notifications").length) {
+						getParentSlateOfItem().show().siblings().show();
+					}
 				}
-			}
+				$item.children().remove();
+			};
 
 			/**
-			 * Gets and returns the Meta Bar if there is one
+			 * Get the jQuery Object of the Aggregates of the Item
+			 * @returns jQuery Object of the Aggregates of the Item
 			 */
-			var getMetaBarOfItemIfIsInOne = function(){
-				return $item.parents('.il-maincontrols-metabar');
-			}
-
 			var getAggregatesOfItem = function(){
 				$parent = getParentSlateOfItem().parent();
 				if(!$parent.length){
@@ -302,20 +377,51 @@ il.UI.item = il.UI.item || {};
 
 			/**
 			 * Get the slate, that contains the item given
-			 *
-			 * @private
-			 * @param $item
+			 * @returns {*}
 			 */
 			var getParentSlateOfItem = function(){
 				return $item.parents(".il-maincontrols-slate-notification");
 			};
 
+			/**
+			 * Returns the Id of the Notification Item from the DOM
+			 * @returns sting Id
+			 */
 			var getId = function(){
-				console.log("get id: "+$item.children().attr('id'));
 				return $item.find(".il-notification-item").first().attr('id');
 			}
 
-			return public_object_interace;
+			/**
+			 * Gets and returns the Meta Bar if there is one
+			 *
+			 * @returns jQuery Object of Meta Bar
+			 */
+			var getMetaBarOfItemIfIsInOne = function(){
+				return $item.parents('.il-maincontrols-metabar');
+			}
+
+			/**
+			 * Gets the jQuery Object of the triggerer of the Notifications
+			 * if any.
+			 *
+			 * Personal Note: This is not placed on the very bottom by accident.
+			 * This is the furthest level of doom to be found here and I am not proud
+			 * of it. Hopefully this will never be found. It is a shame and needs to be
+			 * get rid of in the next revision (see also UI Components Roadmap). This
+			 * access to the triggerer feels like waking in the midst of a highway with blindfolds
+			 * on during rush hour.
+			 *
+			 * @returns jQuery Object of the triggerer of the Notifications
+			 */
+			var getNotificationsTriggererIfAny = function(){
+				var $meta_bar = getMetaBarOfItemIfIsInOne();
+				if($meta_bar.length){
+					var $notification_glyph = $meta_bar.find('.il-metabar-entries > .btn-bulky .glyphicon-bell');
+					return $notification_glyph.parents('.btn-bulky');
+				}
+			}
+
+			return public_object_interface;
 		};
 
 		return public_interface;

--- a/src/UI/templates/js/Item/notification.js
+++ b/src/UI/templates/js/Item/notification.js
@@ -12,11 +12,9 @@ il.UI.item = il.UI.item || {};
  * This scope contains only the getNotificationItemObject through which a Notification Item object can
  * be accessed.
  *
- * See the public_object_interface bellow for a list of functions of this object offered
+ * See the public_object_interface below for a list of functions of this object offered
  * to the public. Also see the extended asyc Main Controls Meta Bar example for a detailed
  * show case of the provided functionality.
- *
- * Note that this can be used
  *
  * Example Usage:
  *
@@ -246,7 +244,7 @@ il.UI.item = il.UI.item || {};
 
 			/**
 			 * Interface returned by this function for public use
-			 * The contained functions are implemented bellow
+			 * The contained functions are implemented below
 			 */
 			var public_object_interface = {
 				registerCloseAction: this.registerCloseAction,

--- a/src/UI/templates/js/Item/notification.js
+++ b/src/UI/templates/js/Item/notification.js
@@ -99,8 +99,6 @@ il.UI.item = il.UI.item || {};
 			 * aggregates. Note that $item remains valid, since
 			 * it points to an outer container.
 			 *
-			 * Note, POST is used to send large amounts of DATA back here.
-			 *
 			 * @public
 			 * @param url
 			 * @param send_data
@@ -122,8 +120,6 @@ il.UI.item = il.UI.item || {};
 			 * e.g. only a time property or description text has to be
 			 * changed, and not the whole list of aggregates.
 			 *
-			 * Note, POST is used to send large amounts of DATA back here.
-			 *
 			 * @public
 			 * @param url
 			 * @param send_data
@@ -143,8 +139,6 @@ il.UI.item = il.UI.item || {};
 			/**
 			 * Adds an additional aggregate to the Notification Item returned
 			 * by the URL called async.
-			 *
-			 * Note, POST is used to send large amounts of DATA back here.
 			 *
 			 * @public
 			 * @param url
@@ -271,11 +265,9 @@ il.UI.item = il.UI.item || {};
 
 			/**
 			 * Just some syntactic sugar for the ajax call.
-			 * Note that we send data per POST, in case
-			 * we need to send larger amounts. POST should
-			 * be fine also in a semantical sense, since
-			 * often we really do POST back data here, to be
-			 * stored permanently.
+			 * Note that we send data per GET, due to semantical
+			 * correctness, see discussion in:
+			 * https://github.com/ILIAS-eLearning/ILIAS/pull/2329
 			 *
 			 * @private
 			 * @param url
@@ -286,7 +278,7 @@ il.UI.item = il.UI.item || {};
 				$.ajax({
 					url: url,
 					data: send_data,
-					type: "POST"
+					type: "GET"
 				}).done(function(data) {
 					callback(data);
 				});

--- a/tests/UI/Client/NotificationItem/NotificationItem.html
+++ b/tests/UI/Client/NotificationItem/NotificationItem.html
@@ -1,0 +1,63 @@
+<div class="il-maincontrols-metabar" id="il_ui_fw_5dd2417d74b775_30458766">
+	<div class="il-metabar-entries">
+		<button class="btn btn-bulky" id="il_ui_fw_5dd2417d65f966_35910433" aria-pressed="false">
+         <span class="glyph" href="notification" aria-label="Notifications">
+         <span class="glyphicon
+            glyphicon-bell
+            " aria-hidden="true"></span>
+         <span class="il-counter">
+         <span class="badge badge-notify il-counter-novelty">1</span>
+         </span>
+         <span class="il-counter-spacer">1</span>
+         </span>
+			<div><span class="bulky-label">Notification Center</span></div>
+		</button>
+	</div>
+	<div class="il-metabar-slates">
+		<div class="il-maincontrols-slate disengaged" id="slate_id">
+			<div class="il-maincontrols-slate-content" data-replace-marker="content">
+				<div class="il-maincontrols-slate il-maincontrols-slate-notification">
+					<div class="il-maincontrols-slate-notification-title">
+						Mail
+					</div>
+					<div class="il-maincontrols-slate-content">
+                  <span class="il-item-notification-replacement-container">
+                     <div class="il-item il-notification-item" id="notification_item_id">
+                        <div class="media">
+                           <div class="media-left">
+                              <div class="icon mail small" aria-label="mail">
+                              </div>
+                           </div>
+                           <div class="media-body">
+                              <h5 class="il-item-notification-title"><a href="link_to_inbox">Inbox</a></h5>
+							   <button type="button" class="close" data-dismiss="modal" id="close_button_id">
+									<span aria-hidden="true">×</span>
+									<span class="sr-only">Close</span>
+								</button>
+                              <div class="il-item-description">You have 23 unread mails in your inbox</div>
+                              <hr class="il-item-divider">
+                              <div class="row il-item-properties">
+                                 <div class="col-md-6">
+                                    <div class="row">
+                                       <div class="col-sm-5 il-item-property-name">Time</div>
+                                       <div class="col-sm-7 il-item-property-value il-multi-line-cap-3">3 days ago</div>
+                                    </div>
+                                 </div>
+                                 <div class="col-md-6">
+                                    <div class="row">
+                                       <div class="col-sm-5 il-item-property-name"></div>
+                                       <div class="col-sm-7 il-item-property-value il-multi-line-cap-3"></div>
+                                    </div>
+                                 </div>
+                              </div>
+                           </div>
+                        </div>
+                     </div>
+                  </span>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+

--- a/tests/UI/Client/NotificationItem/NotificationItem.js
+++ b/tests/UI/Client/NotificationItem/NotificationItem.js
@@ -1,0 +1,24 @@
+var NotificationItemTests = {
+	html: "NotificationItem/NotificationItem.html",
+
+	testGetValidObject: function(){
+		return (!(getNotificationItemTest1() instanceof jQuery));
+	},
+	testGetCloseButton1: function(){
+		$button = getNotificationItemTest1().getCloseButtonOfItem();
+		return ($button instanceof jQuery);
+	},
+	testGetCloseButton2: function(){
+		$button = getNotificationItemTest1().getCloseButtonOfItem();
+		return ($button.attr('id') == "close_button_id");
+	},
+	getCounterObjectIfAny1: function(){
+		$counter = getNotificationItemTest1().getCounterObjectIfAny();
+		return $counter.getNoveltyCount() == 1 && $counter.getStatusCount()==0;
+	}
+};
+
+var getNotificationItemTest1 = function(){
+
+	return il.UI.item.notification.getNotificationItemObject($("#notification_item_id"));
+};

--- a/tests/UI/Client/Runner.js
+++ b/tests/UI/Client/Runner.js
@@ -4,6 +4,7 @@
 $( document ).ready(function() {
 	var TestPackage = [
 		CounterTests,
+		NotificationItemTests
 		//Place further test packages here.
 	];
 

--- a/tests/UI/Client/index.html
+++ b/tests/UI/Client/index.html
@@ -5,10 +5,12 @@
 
 	<!-- Add your test sources here-->
 	<script src="Counter/CounterTest.js"></script>
+	<script src="NotificationItem/NotificationItem.js"></script>
+
 
 	<!-- Add all other needed sources here-->
 	<script src="../../../src/UI/templates/js/Counter/counter.js"></script>
-
+	<script src="../../../src/UI/templates/js/Item/notification.js"></script>
 </head>
 
 <body>

--- a/tests/UI/Component/Item/ItemNotificationTest.php
+++ b/tests/UI/Component/Item/ItemNotificationTest.php
@@ -199,65 +199,97 @@ class ItemNotificationTest extends ILIAS_UI_TestBase
 
         $html = $this->brutallyTrimHTML($r->render($c));
         $expected = <<<EOT
-<div class="il-item il-notification-item" id="id">
-    <div class="media">
-        <div class="media-left">
-            <div class="icon name small" aria-label="aria_label"></div>
-        </div>
-        <div class="media-body">
-            <h5 class="il-item-notification-title"><a href="" >TestLink</a></h5>
-            <button type="button" class="close" data-dismiss="modal" id="id"> <span aria-hidden="true">&times;</span> <span class="sr-only">Close</span></button>
-            <div class="il-item-description">description</div>
-            <div class="dropdown">
-                <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"> <span class="caret"></span></button>
-                <ul class="dropdown-menu">
-                    <li>
-                        <button class="btn btn-link" data-action="https://www.ilias.de" id="id">ILIAS</button>
-                    </li>
-                    <li>
-                        <button class="btn btn-link" data-action="https://www.github.com" id="id">GitHub</button>
-                    </li>
-                </ul>
-            </div>
-            <div class="il-item-additional-content">someContent</div>
-            <hr class="il-item-divider">
-            <div class="row">
-                <div class="col-md-6">
-                    <div class="row">
-                        <div class="col-sm-5 il-item-property-name">prop1</div>
-                        <div class="col-sm-7 il-item-property-value il-multi-line-cap-3">val1</div>
-                    </div>
-                </div>
-                <div class="col-md-6">
-                    <div class="row">
-                        <div class="col-sm-5 il-item-property-name">prop2</div>
-                        <div class="col-sm-7 il-item-property-value il-multi-line-cap-3">val2</div>
-                    </div>
-                </div>
-            </div>
-            <div class="il-aggregate-notifications" data-aggregatedby="id">
-                <div class="il-maincontrols-slate il-maincontrols-slate-notification">
-                    <div class="il-maincontrols-slate-notification-title">
-                        <button class="btn btn-bulky" data-action=""><span class="glyph" aria-label="back"><span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span></span>
-                            <div><span class="bulky-label">Back</span></div>
-                        </button>
-                    </div>
-                    <div class="il-maincontrols-slate-content">
-                        <div class="il-item il-notification-item">
-                            <div class="media">
-                                <div class="media-left">
-                                    <div class="icon name small" aria-label="aria_label"></div>
-                                </div>
-                                <div class="media-body">
-                                    <h5 class="il-item-notification-title">title_aggregate</h5> </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
+<span class="il-item-notification-replacement-container">
+	<div class="il-item il-notification-item" id="id">
+		<div class="media">
+			<div class="media-left">
+				<div class="icon name small" aria-label="aria_label"></div>
+			</div>
+			<div class="media-body">
+				<h5 class="il-item-notification-title">
+					<a href="">TestLink</a>
+				</h5>
+				<button type="button" class="close" data-dismiss="modal" id="id">
+					<span aria-hidden="true">&times;</span>
+					<span class="sr-only">Close</span>
+				</button>
+				<div class="il-item-description">description</div>
+				<div class="dropdown">
+					<button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+						<span class="caret"></span>
+					</button>
+					<ul class="dropdown-menu">
+						<li>
+							<button class="btn btn-link" data-action="https://www.ilias.de" id="id">ILIAS</button>
+						</li>
+						<li>
+							<button class="btn btn-link" data-action="https://www.github.com" id="id">GitHub</button>
+						</li>
+					</ul>
+				</div>
+				<div class="il-item-additional-content">someContent</div>
+				<hr class="il-item-divider">
+					<div class="row il-item-properties">
+						<div class="col-md-6">
+							<div class="row">
+								<div class="col-sm-5 il-item-property-name">prop1</div>
+								<div class="col-sm-7 il-item-property-value il-multi-line-cap-3">val1</div>
+							</div>
+						</div>
+						<div class="col-md-6">
+							<div class="row">
+								<div class="col-sm-5 il-item-property-name">prop2</div>
+								<div class="col-sm-7 il-item-property-value il-multi-line-cap-3">val2</div>
+							</div>
+						</div>
+					</div>
+					<div class="il-aggregate-notifications" data-aggregatedby="id">
+						<div class="il-maincontrols-slate il-maincontrols-slate-notification">
+							<div class="il-maincontrols-slate-notification-title">
+								<button class="btn btn-bulky" data-action="">
+									<span class="glyph" aria-label="back">
+										<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
+									</span>
+									<div>
+										<span class="bulky-label">Back</span>
+									</div>
+								</button>
+							</div>
+							<div class="il-maincontrols-slate-content">
+								<span class="il-item-notification-replacement-container">
+									<div class="il-item il-notification-item" id="id">
+										<div class="media">
+											<div class="media-left">
+												<div class="icon name small" aria-label="aria_label"></div>
+											</div>
+											<div class="media-body">
+												<h5 class="il-item-notification-title">title_aggregate</h5>
+												<div class="il-aggregate-notifications" data-aggregatedby="id">
+													<div class="il-maincontrols-slate il-maincontrols-slate-notification">
+														<div class="il-maincontrols-slate-notification-title">
+															<button class="btn btn-bulky" data-action="">
+																<span class="glyph" aria-label="back">
+																	<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
+																</span>
+																<div>
+																	<span class="bulky-label">Back</span>
+																</div>
+															</button>
+														</div>
+														<div class="il-maincontrols-slate-content"></div>
+													</div>
+												</div>
+											</div>
+										</div>
+									</div>
+								</span>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</span>
 EOT;
 
         $this->assertEquals($this->brutallyTrimHTML($expected), $html);

--- a/tests/UI/Component/Item/ItemNotificationTest.php
+++ b/tests/UI/Component/Item/ItemNotificationTest.php
@@ -251,7 +251,7 @@ class ItemNotificationTest extends ILIAS_UI_TestBase
 										<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 									</span>
 									<div>
-										<span class="bulky-label">Back</span>
+										<span class="bulky-label">back</span>
 									</div>
 								</button>
 							</div>
@@ -272,7 +272,7 @@ class ItemNotificationTest extends ILIAS_UI_TestBase
 																	<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 																</span>
 																<div>
-																	<span class="bulky-label">Back</span>
+																	<span class="bulky-label">back</span>
 																</div>
 															</button>
 														</div>

--- a/tests/UI/Component/MainControls/Slate/NotificationSlateTest.php
+++ b/tests/UI/Component/MainControls/Slate/NotificationSlateTest.php
@@ -102,19 +102,36 @@ class NotificationSlateTest extends ILIAS_UI_TestBase
 
         $expected = <<<EOT
 <div class="il-maincontrols-slate il-maincontrols-slate-notification">
-    <div class="il-maincontrols-slate-notification-title">slate title</div>
-    <div class="il-maincontrols-slate-content">
-        <div class="il-item il-notification-item">
-            <div class="media">
-                <div class="media-left">
-                    <div class="icon name small" aria-label="aria_label"></div>
-                </div>
-                <div class="media-body">
-                    <h5 class="il-item-notification-title">item title</h5>
-                </div>
-            </div>
-        </div>
-    </div>
+	<div class="il-maincontrols-slate-notification-title">slate title</div>
+	<div class="il-maincontrols-slate-content">
+		<span class="il-item-notification-replacement-container">
+			<div class="il-item il-notification-item" id="id_1">
+				<div class="media">
+					<div class="media-left">
+						<div class="icon name small" aria-label="aria_label"></div>
+					</div>
+					<div class="media-body">
+						<h5 class="il-item-notification-title">item title</h5>
+						<div class="il-aggregate-notifications" data-aggregatedby="id_1">
+							<div class="il-maincontrols-slate il-maincontrols-slate-notification">
+								<div class="il-maincontrols-slate-notification-title">
+									<button class="btn btn-bulky" data-action="">
+										<span class="glyph" aria-label="back">
+											<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
+										</span>
+										<div>
+											<span class="bulky-label">Back</span>
+										</div>
+									</button>
+								</div>
+								<div class="il-maincontrols-slate-content"></div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</span>
+	</div>
 </div>
 EOT;
         $this->assertEquals(

--- a/tests/UI/Component/MainControls/Slate/NotificationSlateTest.php
+++ b/tests/UI/Component/MainControls/Slate/NotificationSlateTest.php
@@ -120,7 +120,7 @@ class NotificationSlateTest extends ILIAS_UI_TestBase
 											<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 										</span>
 										<div>
-											<span class="bulky-label">Back</span>
+											<span class="bulky-label">back</span>
 										</div>
 									</button>
 								</div>


### PR DESCRIPTION
This is a follow up on: https://github.com/ILIAS-eLearning/ILIAS/pull/2299 and gears up the Notifications to handle async requirements, needed e.g. for the Chat. Important, we need to follow up on this in the next ILIAS Version. In this step it becomes obvious, that we still lack a properly defined notification center, which leeds to quite some jquery blood bath. Also see the hereby contained roadmap entry.

This PR contains the following:
- The revised notification.js enabling async requests, along with some refactorings of the Item renderer and template.
- Comments/explanations on the file above
- An detailed example show-casing this new behaviour in a fully featured Meta Bar.
- Adaptions of existing unit tests.
- JS tests (not quite complete yet)
- A Roadmap entry pointing out the lack of the notification center.
- A Roadmap entry pointing out the ugly snake case in tests (as promised in: https://github.com/ILIAS-eLearning/ILIAS/pull/2299)

The given example features the Notifications in the Meta Bar with 3 Buttons firing async requests, to add and remove notifications, it looks as follows:

![image](https://user-images.githubusercontent.com/1866896/69035034-e821a780-09e2-11ea-860d-15927d3b7c1a.png)

