### PR TITLE
fixed 26538: KS Filter: Pressing Enter

### DIFF
--- a/src/UI/Implementation/Component/Input/Container/Filter/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Container/Filter/Renderer.php
@@ -153,7 +153,14 @@ class Renderer extends AbstractComponentRenderer
                 $code = "$('#$id').on('click', function(event) {
 							il.UI.filter.onCmd(event, '$id', 'apply');
 							return false; // stop event propagation
-					});";
+					});
+					$('#$id').closest('.il-filter').find(':text').on('keypress', function(ev) {
+						if (typeof ev != 'undefined' && typeof ev.keyCode != 'undefined' && ev.keyCode == 13) {
+							il.UI.filter.onCmd(event, '$id', 'apply');
+							return false; // stop event propagation
+						}
+					});
+					";
                 return $code;
             });
 


### PR DESCRIPTION
Fix for:
https://mantis.ilias.de/view.php?id=26538

Note: This fix assumes, that it is ok that the filter "makes the decision" to apply the filter on enter for all HTML text inputs appearing withing the filter.

I think this is ok for now. Might be improved in the future, but the current behaviour is very distracting.