### PR TITLE
#26625 / PrivacySecurity: be humble with missing export implementations for specific types

### DIFF
--- a/Services/PrivacySecurity/classes/class.ilExportFieldsInfo.php
+++ b/Services/PrivacySecurity/classes/class.ilExportFieldsInfo.php
@@ -287,7 +287,7 @@ class ilExportFieldsInfo
 		
 		foreach($settings_all as $key => $value)
 		{
-			if(stristr($key,$field_prefix) and $value)
+			if($field_prefix && stristr($key,$field_prefix) and $value)
 			{
 				// added limit for mantis 11096
 				$field_parts = explode('_',$key,$field_part_limit);


### PR DESCRIPTION
This should fix the acute problem, but not the underlying cause.

The acute problem is the error that is thrown because the second parameter to `stristr` is `null`. This should be solved by this.

The underlying cause is, that there currently  is no privacy implementation for the Learning Sequence. I currently can't follow up on this (time is scarce), but I will file a bug and take it to the JF some times soon.

@smeyer-ilias: Please have a look here, so we can move on with the Learning Sequence. Currently the members tab is blocked by this. Thx!