### PR TITLE
Feature/6/ui inline icon

### DIFF
--- a/src/UI/Component/Symbol/Icon/Factory.php
+++ b/src/UI/Component/Symbol/Icon/Factory.php
@@ -75,4 +75,30 @@ interface Factory
      * @return 	\ILIAS\UI\Component\Symbol\Icon\Custom
      **/
     public function custom($icon_path, $aria_label, $size='small', $is_disabled = false);
+
+    /**
+     * ---
+     * description:
+     *   purpose: >
+     *     ILIAS allows users to upload icons e.g. for Main bar items.
+     *     Those, in opposite to the standard icons, can be delivered inline as base64.
+     *   composition: >
+     *     Instead of setting a background image via CSS-class, an image-tag is
+     *     contained in the icons's div.
+     *   rivals:
+     *     Standard Icon: Standard Icons MUST be used for core-objects.
+     * rules:
+     *   style:
+     *     1: Inline Icons MUST use SVG as graphic, encoses as base64.
+     *     2: >
+     *       Icons MUST have a transparent background so they could be put on
+     *       all kinds of backgrounds.
+     *     3: >
+     *       Images used for Inline Icons SHOULD have equal width and height
+     *       (=be quadratic) in order not to be distorted.
+     * ---
+     *
+     * @return 	\ILIAS\UI\Component\Symbol\Icon\Inline
+     **/
+    public function inline(string $base_64_data, string $mime_type, string $aria_label, string $size = 'small', bool $is_disabled = false);
 }

--- a/src/UI/Component/Symbol/Icon/Inline.php
+++ b/src/UI/Component/Symbol/Icon/Inline.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ILIAS\UI\Component\Symbol\Icon;
+
+/**
+ * This describes the behavior of an inline icon.
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+interface Inline extends Icon
+{
+
+    /**
+     * Return the base64 content of the icon
+     */
+    public function getBase64Data() : string;
+
+
+    public function getMimeType() : string;
+}

--- a/src/UI/Implementation/Component/Symbol/Icon/Factory.php
+++ b/src/UI/Implementation/Component/Symbol/Icon/Factory.php
@@ -22,4 +22,10 @@ class Factory implements I\Factory
     {
         return new Custom($icon_path, $aria_label, $size, $is_disabled);
     }
+
+
+    public function inline(string $base_64_data, string $mime_type, string $aria_label, string $size = 'small', bool $is_disabled = false)
+    {
+        return new Inline($base_64_data, $aria_label, $size, $is_disabled, $mime_type);
+    }
 }

--- a/src/UI/Implementation/Component/Symbol/Icon/Inline.php
+++ b/src/UI/Implementation/Component/Symbol/Icon/Inline.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace ILIAS\UI\Implementation\Component\Symbol\Icon;
+
+use ILIAS\UI\Component as C;
+
+/**
+ * Class Inline
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+class Inline extends Icon implements C\Symbol\Icon\Inline
+{
+
+    /**
+     * @var    string
+     */
+    private $base_64;
+    /**
+     * @var string
+     */
+    private $mime_type;
+
+
+    public function __construct(string $base_64, string $aria_label, string $size, bool $is_disabled, string $mime_type)
+    {
+        $this->checkArgIsElement(
+            'size',
+            $size,
+            self::$possible_sizes,
+            implode('/', self::$possible_sizes)
+        );
+        $this->name = 'inline';
+        $this->mime_type = $mime_type;
+        $this->base_64 = $base_64;
+        $this->aria_label = $aria_label;
+        $this->size = $size;
+        $this->is_disabled = $is_disabled;
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getBase64Data() : string
+    {
+        //src="data:image/gif;base64,R0lGOD...
+        return $this->base_64;
+    }
+
+
+    public function getMimeType() : string
+    {
+        return $this->mime_type;
+    }
+}

--- a/src/UI/Implementation/Component/Symbol/Icon/Renderer.php
+++ b/src/UI/Implementation/Component/Symbol/Icon/Renderer.php
@@ -4,9 +4,9 @@
 
 namespace ILIAS\UI\Implementation\Component\Symbol\Icon;
 
+use ILIAS\UI\Component;
 use ILIAS\UI\Implementation\Render\AbstractComponentRenderer;
 use ILIAS\UI\Renderer as RendererInterface;
-use ILIAS\UI\Component;
 
 class Renderer extends AbstractComponentRenderer
 {
@@ -27,7 +27,11 @@ class Renderer extends AbstractComponentRenderer
 
         if ($component instanceof Component\Symbol\Icon\Custom) {
             $tpl->setVariable("CUSTOMIMAGE", $component->getIconPath());
-        } else {
+        } elseif ($component instanceof Component\Symbol\Icon\Inline) {
+            $value = 'data:' . $component->getMimeType() . ';base64,' . $component->getBase64Data();
+            $tpl->setVariable("BASE64", $value);
+        }
+        else {
             if ($component->isOutlined()) {
                 $tpl->setVariable("OUTLINED", " outlined");
             }

--- a/src/UI/examples/Symbol/Icon/Inline/inline_icon.php
+++ b/src/UI/examples/Symbol/Icon/Inline/inline_icon.php
@@ -1,0 +1,28 @@
+<?php
+function inline_icon()
+{
+    global $DIC;
+    $f = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $raw_icon_data = '<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Icons" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 32 32" style="enable-background:new 0 0 32 32;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
+</style>
+<rect x="6" y="15" class="st0" width="20" height="13"/>
+<rect x="5" y="10" class="st0" width="22" height="5"/>
+<rect x="12" y="10" class="st0" width="8" height="5"/>
+<rect x="13" y="15" class="st0" width="6" height="13"/>
+<path class="st0" d="M23.7,5.4c-1-2-3.8-1.9-5,0.2L16,10l4.8,0C23.1,9.9,24.7,7.4,23.7,5.4z"/>
+<path class="st0" d="M8.3,5.4c1-2,3.8-1.9,5,0.2L16,10l-4.8,0C8.9,9.9,7.3,7.4,8.3,5.4z"/>
+</svg>
+';
+
+    $base_64_encode = base64_encode($raw_icon_data);
+    $ico = $f->symbol()->icon()->inline($base_64_encode, 'image/svg+xml', 'Example');
+
+    return $renderer->render($ico);
+}

--- a/src/UI/templates/default/Symbol/icon.less
+++ b/src/UI/templates/default/Symbol/icon.less
@@ -71,7 +71,7 @@
 	}
 
 	/* the custom-icon is rendered with an image contained in the div */
-	&.custom {
+	&.custom, &.inline {
 		background-image: none;
 	}
 

--- a/src/UI/templates/default/Symbol/tpl.icon.html
+++ b/src/UI/templates/default/Symbol/tpl.icon.html
@@ -1,4 +1,7 @@
 <div class="icon {NAME} {SIZE}{DISABLED}{OUTLINED}" aria-label="{ARIA_LABEL}">
+<!-- BEGIN base64image -->
+	<img src="{BASE64}" />
+<!-- END base64image -->
 <!-- BEGIN customimage -->
 	<img src="{CUSTOMIMAGE}" />
 <!-- END customimage -->

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -9704,7 +9704,8 @@ footer {
   /* Safari 6.0 - 9.0 */
   filter: grayscale(100%);
 }
-.icon.custom {
+.icon.custom,
+.icon.inline {
   background-image: none;
 }
 .icon.grp .abbreviation,

--- a/tests/UI/Component/Symbol/Icon/IconTest.php
+++ b/tests/UI/Component/Symbol/Icon/IconTest.php
@@ -29,6 +29,9 @@ class IconTest extends ILIAS_UI_TestBase
 
         $ci = $f->custom('course', 'Kurs');
         $this->assertInstanceOf("ILIAS\\UI\\Component\\Symbol\\Icon\\Custom", $ci);
+
+        $ci = $f->inline('course', 'image/svg+xml', 'Kurs');
+        $this->assertInstanceOf("ILIAS\\UI\\Component\\Symbol\\Icon\\Inline", $ci);
     }
 
     public function testAttributes()
@@ -117,6 +120,32 @@ class IconTest extends ILIAS_UI_TestBase
 
         $ico = $f->custom('/some/path/', 'Custom Icon');
         $this->assertEquals('/some/path/', $ico->getIconPath());
+    }
+
+
+    public function testInlineData()
+    {
+        $f = $this->getIconFactory();
+
+        $content = 'raw_content';
+
+        $ico = $f->inline(base64_encode($content), 'image/svg+xml', 'Test');
+        $this->assertEquals(base64_encode($content), $ico->getBase64Data());
+    }
+
+
+    public function testRenderingInline()
+    {
+        $f = $this->getIconFactory();
+        $r = $this->getDefaultRenderer();
+        $content = 'raw_content';
+        $mime_type = 'image/svg+xml';
+        $aria_label = 'Test';
+        $ico = $f->inline(base64_encode($content), $mime_type, $aria_label);
+        $html = $this->normalizeHTML($r->render($ico));
+        $expected = '<div class="icon inline small" aria-label="' . $aria_label . '">	<img src="data:' . $mime_type . ';base64,' . base64_encode($content) . '" /></div>';
+
+        $this->assertEquals($expected, $html);
     }
 
     public function testRenderingStandard()


### PR DESCRIPTION
ILIAS 6 now allows to upload custom svg-icons for the mainbar items. since it need a separate roundtrip to ILIAS di display them, an Inline-icon would must help improve the performance of this feature.

this PR contains the interfaces and it's implementation and tests. It is a very small change since it fits nice into the already existing icon.

Interface and description:
- https://github.com/studer-raimann/ILIAS/blob/363325ff2853497d7d7c66da96c7b905171478fc/src/UI/Component/Symbol/Icon/Factory.php#L103
- https://github.com/studer-raimann/ILIAS/blob/363325ff2853497d7d7c66da96c7b905171478fc/src/UI/Component/Symbol/Icon/Inline.php