### PR TITLE
Notification Center Glyph

### DIFF
--- a/src/UI/Component/Symbol/Glyph/Factory.php
+++ b/src/UI/Component/Symbol/Glyph/Factory.php
@@ -414,12 +414,15 @@ interface Factory
      *   effect: >
      *       Upon clicking the notification activation is toggled: Clicking the Notification Glyph activates respectively
      *       deactivates the notification service for the current object or sub-item.
-     * context:
-     *       - Activate Mail Notification in Forum
      *   rivals:
      *      Notification Center Glyph: >
      *         The Notification Center Glyph is not used to activate Notification, but to trigger their display in the
      *         Meta Bar.
+     *
+     *
+     *
+     * context:
+     *       - Activate Mail Notification in Forum
      *
      * rules:
      *   usage:
@@ -471,7 +474,7 @@ interface Factory
      *          "you have no new messages" do also not count towards this number.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be ‘Notifications'.
+     *          The aria-label MUST be ‘Notification Center'.
      * ---
      * @param	string|null	$action
      * @return 	\ILIAS\UI\Component\Symbol\Glyph\Glyph

--- a/src/UI/Component/Symbol/Glyph/Factory.php
+++ b/src/UI/Component/Symbol/Glyph/Factory.php
@@ -438,6 +438,39 @@ interface Factory
      * ---
      * description:
      *   purpose: >
+     *         The Notification Center Glyph is used to trigger the Slate displaying
+     *         the Notification Items in the Meta Bar.
+     *   composition: >
+     *       The Notification Glyph uses the glyphicon-bell. A Novelty Counter
+     *       displays the number of Notification Items carrying any type of news.
+     *   effect: >
+     *       Upon clicking the Slate displaying all Notification Items is displayed.
+     *   rivals:
+     *      Notification Glyph: >
+     *         The Disclosure Glyph hides t
+     *
+     * rules:
+     *   usage:
+     *       1: >
+     *          The Notification Center Glyph MUST always be visible in the Meta Bar
+     *          as long as the user is logged in.
+     *   composition:
+     *       1: >
+     *          The Novelty Counter MUST display the number of Notification Items
+     *          carrying any type of news.
+     *   accessibility:
+     *       1: >
+     *          The aria-label MUST be ‘Notifications'.
+     * ---
+     * @param	string|null	$action
+     * @return 	\ILIAS\UI\Component\Symbol\Glyph\Glyph
+     */
+    public function notificationCenter(string $action = null) : Glyph;
+
+    /**
+     * ---
+     * description:
+     *   purpose: >
      *       The Tag Glyph is used to indicate the possibility of adding tags to an object.
      *   composition: >
      *       The Tag Glyph uses the glyphicon-tag.

--- a/src/UI/Component/Symbol/Glyph/Factory.php
+++ b/src/UI/Component/Symbol/Glyph/Factory.php
@@ -457,7 +457,7 @@ interface Factory
      *   rivals:
      *      Notification Glyph: >
      *         The Notification Glyph serves as trigger for activating e.g. Mail Notification
-     *         in the Forum and also indicates by it's state, whether does notifications are activated.
+     *         in the Forum and also indicates by it's state, whether those notifications are activated.
      * context:
      *       - Trigger the display of Notifications in the Meta Bar.
      *

--- a/src/UI/Component/Symbol/Glyph/Factory.php
+++ b/src/UI/Component/Symbol/Glyph/Factory.php
@@ -414,6 +414,12 @@ interface Factory
      *   effect: >
      *       Upon clicking the notification activation is toggled: Clicking the Notification Glyph activates respectively
      *       deactivates the notification service for the current object or sub-item.
+     * context:
+     *       - Activate Mail Notification in Forum
+     *   rivals:
+     *      Notification Center Glyph: >
+     *         The Notification Center Glyph is not used to activate Notification, but to trigger their display in the
+     *         Meta Bar.
      *
      * rules:
      *   usage:
@@ -438,8 +444,8 @@ interface Factory
      * ---
      * description:
      *   purpose: >
-     *         The Notification Center Glyph is used to trigger the Slate displaying
-     *         the Notification Items in the Meta Bar.
+     *       The Notification Center Glyph is used to trigger the Slate displaying
+     *       the Notification Items in the Meta Bar.
      *   composition: >
      *       The Notification Glyph uses the glyphicon-bell. A Novelty Counter
      *       displays the number of Notification Items carrying any type of news.
@@ -447,7 +453,10 @@ interface Factory
      *       Upon clicking the Slate displaying all Notification Items is displayed.
      *   rivals:
      *      Notification Glyph: >
-     *         The Disclosure Glyph hides t
+     *         The Notification Glyph serves as trigger for activating e.g. Mail Notification
+     *         in the Forum and also indicates by it's state, whether does notifications are activated.
+     * context:
+     *       - Trigger the display of Notifications in the Meta Bar.
      *
      * rules:
      *   usage:
@@ -457,7 +466,9 @@ interface Factory
      *   composition:
      *       1: >
      *          The Novelty Counter MUST display the number of Notification Items
-     *          carrying any type of news.
+     *          carrying any type of news. Note that aggregates do note count to this
+     *          number. Further note, that Items, that tell the user something like
+     *          "you have no new messages" do also not count towards this number.
      *   accessibility:
      *       1: >
      *          The aria-label MUST be ‘Notifications'.

--- a/src/UI/Component/Symbol/Glyph/Glyph.php
+++ b/src/UI/Component/Symbol/Glyph/Glyph.php
@@ -28,7 +28,7 @@ interface Glyph extends \ILIAS\UI\Component\Symbol\Symbol, \ILIAS\UI\Component\J
     const USER = "user";
     const MAIL = "mail";
     const NOTIFICATION = "notification";
-    const NOTIFICATION_CENTER = "notification_center";
+    const NOTIFICATION_CENTER = "notificationCenter";
     const TAG = "tag";
     const NOTE = "note";
     const COMMENT = "comment";

--- a/src/UI/Component/Symbol/Glyph/Glyph.php
+++ b/src/UI/Component/Symbol/Glyph/Glyph.php
@@ -28,6 +28,7 @@ interface Glyph extends \ILIAS\UI\Component\Symbol\Symbol, \ILIAS\UI\Component\J
     const USER = "user";
     const MAIL = "mail";
     const NOTIFICATION = "notification";
+    const NOTIFICATION_CENTER = "notification_center";
     const TAG = "tag";
     const NOTE = "note";
     const COMMENT = "comment";

--- a/src/UI/Implementation/Component/Symbol/Glyph/Factory.php
+++ b/src/UI/Implementation/Component/Symbol/Glyph/Factory.php
@@ -141,6 +141,14 @@ class Factory implements G\Factory
     /**
      * @inheritdoc
      */
+    public function notificationCenter(string $action = null) : G\Glyph
+    {
+        return new Glyph(G\Glyph::NOTIFICATION, "notification center", $action);
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function tag(string $action = null) : G\Glyph
     {
         return new Glyph(G\Glyph::TAG, "tags", $action);

--- a/src/UI/Implementation/Component/Symbol/Glyph/Glyph.php
+++ b/src/UI/Implementation/Component/Symbol/Glyph/Glyph.php
@@ -62,6 +62,7 @@ class Glyph implements C\Symbol\Glyph\Glyph
         , self::USER
         , self::MAIL
         , self::NOTIFICATION
+        , self::NOTIFICATION_CENTER
         , self::TAG
         , self::NOTE
         , self::COMMENT

--- a/src/UI/examples/Symbol/Glyph/NotificationCenter/notification.php
+++ b/src/UI/examples/Symbol/Glyph/NotificationCenter/notification.php
@@ -1,0 +1,18 @@
+<?php
+function notification()
+{
+    global $DIC;
+    $f = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $glyph = $f->symbol()->glyph()->notification("#");
+
+    //Showcase the various states of this Glyph
+    $list = $f->listing()->descriptive([
+        "Active"=>$glyph,
+        "Inactive"=>$glyph->withUnavailableAction(),
+        "Highlighted"=>$glyph->withHighlight()
+    ]);
+
+    return $renderer->render($list);
+}

--- a/src/UI/examples/Symbol/Glyph/NotificationCenter/notification_center.php
+++ b/src/UI/examples/Symbol/Glyph/NotificationCenter/notification_center.php
@@ -1,0 +1,18 @@
+<?php
+function notification_center()
+{
+    global $DIC;
+    $f = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $glyph = $f->symbol()->glyph()->notificationCenter("#");
+
+    //Showcase the various states of this Glyph
+    $list = $f->listing()->descriptive([
+        "Active"=>$glyph,
+        "Inactive"=>$glyph->withUnavailableAction(),
+        "Highlighted"=>$glyph->withHighlight()
+    ]);
+
+    return $renderer->render($list);
+}

--- a/src/UI/templates/default/Symbol/glyph.less
+++ b/src/UI/templates/default/Symbol/glyph.less
@@ -70,6 +70,7 @@
 	content: "\e04b";
 }
 .glyphicon-bell:before {
+	font-family: il-icons;
 	content: "\e027";
 }
 .glyphicon-comment:before {

--- a/src/UI/templates/default/Symbol/tpl.glyph.html
+++ b/src/UI/templates/default/Symbol/tpl.glyph.html
@@ -13,6 +13,7 @@
 <!-- BEGIN user --> glyphicon-user<!-- END user -->
 <!-- BEGIN mail --> glyphicon-envelope<!-- END mail -->
 <!-- BEGIN notification --> glyphicon-bell<!-- END notification -->
+<!-- BEGIN notification_center --> glyphicon-bell<!-- END notification_center -->
 <!-- BEGIN tag --> glyphicon-tag<!-- END tag -->
 <!-- BEGIN note --> glyphicon-pushpin<!-- END note -->
 <!-- BEGIN comment --> glyphicon-comment<!-- END comment -->

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -10540,6 +10540,7 @@ footer {
   content: "\e04b";
 }
 .glyphicon-bell:before {
+  font-family: il-icons;
   content: "\e027";
 }
 .glyphicon-comment:before {

--- a/tests/UI/Component/Symbol/Glyph/GlyphTest.php
+++ b/tests/UI/Component/Symbol/Glyph/GlyphTest.php
@@ -74,7 +74,7 @@ class GlyphTest extends ILIAS_UI_TestBase
         , G\Glyph::USER				=> "show_who_is_online"
         , G\Glyph::MAIL 			=> "mail"
         , G\Glyph::NOTIFICATION		=> "notifications"
-        , G\Glyph::NOTIFICATION_CENTER => "notifications_center"
+        , G\Glyph::NOTIFICATION_CENTER => "notification center"
         , G\Glyph::TAG				=> "tags"
         , G\Glyph::NOTE				=> "notes"
         , G\Glyph::COMMENT			=> "comments"

--- a/tests/UI/Component/Symbol/Glyph/GlyphTest.php
+++ b/tests/UI/Component/Symbol/Glyph/GlyphTest.php
@@ -1,4 +1,4 @@
-<?php
+f<?php
 
 /* Copyright (c) 2016 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
 
@@ -36,6 +36,7 @@ class GlyphTest extends ILIAS_UI_TestBase
         , G\Glyph::USER				=> "glyphicon glyphicon-user"
         , G\Glyph::MAIL 			=> "glyphicon glyphicon-envelope"
         , G\Glyph::NOTIFICATION		=> "glyphicon glyphicon-bell"
+        , G\Glyph::NOTIFICATION_CENTER => "glyphicon glyphicon-bell"
         , G\Glyph::TAG				=> "glyphicon glyphicon-tag"
         , G\Glyph::NOTE				=> "glyphicon glyphicon-pushpin"
         , G\Glyph::COMMENT			=> "glyphicon glyphicon-comment"
@@ -73,6 +74,7 @@ class GlyphTest extends ILIAS_UI_TestBase
         , G\Glyph::USER				=> "show_who_is_online"
         , G\Glyph::MAIL 			=> "mail"
         , G\Glyph::NOTIFICATION		=> "notifications"
+        , G\Glyph::NOTIFICATION_CENTER => "notifications_center"
         , G\Glyph::TAG				=> "tags"
         , G\Glyph::NOTE				=> "notes"
         , G\Glyph::COMMENT			=> "comments"
@@ -295,6 +297,7 @@ class GlyphTest extends ILIAS_UI_TestBase
             , array(G\Glyph::USER)
             , array(G\Glyph::MAIL)
             , array(G\Glyph::NOTIFICATION)
+            , array(G\Glyph::NOTIFICATION_CENTER)
             , array(G\Glyph::TAG)
             , array(G\Glyph::NOTE)
             , array(G\Glyph::COMMENT)


### PR DESCRIPTION
Fix of: https://mantis.ilias.de/view.php?id=26639.

This the proposal to introduce the necessary semenatics for the Notification Center Glyph opening the Notification Items in ILIAS 6. Note that for the moment, this uses the same visual output as the already existing notifications do, however this might easily be changed now, or in future if needed/asked for.

![image](https://user-images.githubusercontent.com/1866896/69900773-0a6adc00-1378-11ea-8ff0-5bcdc661a2cc.png)
