### PR TITLE
UI, Footer: add label and input for perma-link

### DIFF
--- a/src/UI/Implementation/Component/MainControls/Renderer.php
+++ b/src/UI/Implementation/Component/MainControls/Renderer.php
@@ -357,10 +357,9 @@ class Renderer extends AbstractComponentRenderer
 
         $perm_url = $component->getPermanentURL();
         if ($perm_url) {
-            $tpl->setVariable(
-                'PERMANENT_URL',
-                $perm_url->getBaseURI() . '?' . $perm_url->getQuery()
-            );
+            $url = $perm_url->getBaseURI() . '?' . $perm_url->getQuery();
+            $tpl->setVariable('PERMA_LINK_LABEL', $this->txt('perma_link'));
+            $tpl->setVariable('PERMANENT_URL', $url);
         }
         return $tpl->get();
     }

--- a/src/UI/ROADMAP.md
+++ b/src/UI/ROADMAP.md
@@ -159,6 +159,12 @@ See also: https://github.com/ILIAS-eLearning/ILIAS/pull/2299
 In some cases (e.g. see Item Slate aggregates) it would be good for slate titles
 to also accept buttons. We should extend that.
 
+### Footer should not use an input (beginner)
+
+In the footer's template, an input-tag in cconunction with some inline-js is 
+used to display the perma-link. This should be substituted by a non-input 
+block-element, respectively an UI-Component on its own.
+
 ## Long Term
 
 ### Remove special case for UI-demo in `Implement\Layout\Page\Renderer::setHeaderVars`

--- a/src/UI/templates/default/MainControls/tpl.footer.html
+++ b/src/UI/templates/default/MainControls/tpl.footer.html
@@ -3,7 +3,14 @@
 
 		<!-- BEGIN footer_perm_url -->
 		<div class="il-footer-permanent-url">
-			<span>{PERMANENT_URL}</span>
+			{PERMA_LINK_LABEL}
+			<input
+				id="current_perma_link"
+				type="text"
+				value="{PERMANENT_URL}"
+				onclick="this.select();document.execCommand('copy'); return false;"
+				readonly="readOnly"
+			>
 		</div>
 		<!-- END footer_perm_url -->
 

--- a/src/UI/templates/default/MainControls/tpl.footer.html
+++ b/src/UI/templates/default/MainControls/tpl.footer.html
@@ -4,13 +4,7 @@
 		<!-- BEGIN footer_perm_url -->
 		<div class="il-footer-permanent-url">
 			{PERMA_LINK_LABEL}
-			<input
-				id="current_perma_link"
-				type="text"
-				value="{PERMANENT_URL}"
-				onclick="this.select();document.execCommand('copy'); return false;"
-				readonly="readOnly"
-			>
+			<input id="current_perma_link" type="text" value="{PERMANENT_URL}" onclick="this.select();document.execCommand('copy'); return false;" readonly="readOnly">
 		</div>
 		<!-- END footer_perm_url -->
 

--- a/tests/UI/Component/MainControls/FooterTest.php
+++ b/tests/UI/Component/MainControls/FooterTest.php
@@ -170,25 +170,21 @@ EOT;
         $html = $r->render($footer);
 
         $expected = <<<EOT
-		<div class="il-maincontrols-footer">
-			<div class="il-footer-content">
-				<div class="il-footer-permanent-url">
-					<span>
-						http://www.ilias.de/goto.php?target=xxx_123
-					</span>
-				</div>
-				<div class="il-footer-text">
-					footer text
-				</div>
+        <div class="il-maincontrols-footer">
+            <div class="il-footer-content">
+                <div class="il-footer-permanent-url">perma_link<input id="current_perma_link" type="text" value="http://www.ilias.de/goto.php?target=xxx_123" onclick="this.select();document.execCommand('copy'); return false;" readonly="readOnly">
+                </div>
 
-				<div class="il-footer-links">
-					<ul>
-						<li><a href="http://www.ilias.de" >Goto ILIAS</a></li>
-						<li><a href="#" >go up</a></li>
-					</ul>
-				</div>
-			</div>
-		</div>
+                <div class="il-footer-text">footer text</div>
+
+                <div class="il-footer-links">
+                    <ul>
+                        <li><a href="http://www.ilias.de" >Goto ILIAS</a></li>
+                        <li><a href="#" >go up</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
 EOT;
 
         $this->assertEquals(


### PR DESCRIPTION
This in response to 
https://mantis.ilias.de/view.php?id=26588 and 
https://mantis.ilias.de/view.php?id=26260

![Bildschirmfoto_2019-12-02_17-06-45](https://user-images.githubusercontent.com/3328364/69974761-31ffa700-1526-11ea-9f07-993dbf8847da.png)

@ckrahl: can dividers between the elements be done with CSS? "Impressum" and "Übersetzung" are part of a UI-Linklist...
