### PR TITLE
Dashboard/Mainbar: No active Slates for the Dashboard

### DIFF
--- a/Services/Dashboard/GlobalScreen/classes/DashboardLayoutProvider.php
+++ b/Services/Dashboard/GlobalScreen/classes/DashboardLayoutProvider.php
@@ -7,11 +7,11 @@ use ILIAS\GlobalScreen\Scope\Layout\Factory\MainBarModification;
 use ILIAS\UI\Component\MainControls\MainBar;
 
 /**
- * Class PDLayoutProvider
+ * Class DashboardLayoutProvider
  *
  * @author Nils Haagen <nils.haagen@concepts-and-training.de>
  */
-class PDLayoutProvider extends AbstractModificationProvider implements ModificationProvider
+class DashboardLayoutProvider extends AbstractModificationProvider implements ModificationProvider
 {
     /**
      * @var Collection | null

--- a/Services/Dashboard/GlobalScreen/classes/PDLayoutProvider.php
+++ b/Services/Dashboard/GlobalScreen/classes/PDLayoutProvider.php
@@ -1,0 +1,46 @@
+<?php
+use ILIAS\GlobalScreen\Scope\Layout\Provider\AbstractModificationProvider;
+use ILIAS\GlobalScreen\Scope\Layout\Provider\ModificationProvider;
+use ILIAS\GlobalScreen\ScreenContext\Stack\ContextCollection;
+use ILIAS\GlobalScreen\ScreenContext\Stack\CalledContexts;
+use ILIAS\GlobalScreen\Scope\Layout\Factory\MainBarModification;
+use ILIAS\UI\Component\MainControls\MainBar;
+
+/**
+ * Class PDLayoutProvider
+ *
+ * @author Nils Haagen <nils.haagen@concepts-and-training.de>
+ */
+class PDLayoutProvider extends AbstractModificationProvider implements ModificationProvider
+{
+    /**
+     * @var Collection | null
+     */
+    protected $data_collection;
+
+    /**
+     * @inheritDoc
+     */
+    public function isInterestedInContexts() : ContextCollection
+    {
+        return $this->context_collection->desktop();
+
+    }
+
+    public function getMainBarModification(CalledContexts $screen_context_stack) : ?MainBarModification
+    {
+
+        $this->data_collection = $screen_context_stack->current()->getAdditionalData();
+        if(!$this->data_collection->is(\ilDashboardGUI::DISENGAGE_MAINBAR, true)) {
+            return null;
+        }
+
+        return $this->globalScreen()->layout()->factory()->mainbar()
+            ->withModification(
+                function(MainBar $mainbar) : ?MainBar {
+                    return $mainbar->withActive($mainbar::NONE_ACTIVE);
+                }
+            )
+            ->withHighPriority();
+    }
+}

--- a/Services/Dashboard/classes/class.ilDashboardGUI.php
+++ b/Services/Dashboard/classes/class.ilDashboardGUI.php
@@ -26,6 +26,9 @@ include_once 'Services/UIComponent/AdvancedSelectionList/classes/class.ilAdvance
 class ilDashboardGUI
 {
 	const CMD_JUMP_TO_MY_STAFF = "jumpToMyStaff";
+
+	const DISENGAGE_MAINBAR = "dash_mb_disengage";
+
 	/**
 	 * @var ilCtrl
 	 */
@@ -305,6 +308,7 @@ class ilDashboardGUI
 				break;
 
 			default:
+				$context->current()->addAdditionalData(self::DISENGAGE_MAINBAR, true);
 				$this->getStandardTemplates();
 				$this->setTabs();
 				$cmd = $this->ctrl->getCmd("show");


### PR DESCRIPTION
According to the rules for mainbar and slates by the UI Weekly from Oct. 18th, all slates should be closed when navigating to the Dashboard.
