### PR TITLE
UI, Mainbar: Update on Tools- and Slatesbehavior

### DIFF
--- a/Services/Dashboard/GlobalScreen/classes/DashboardLayoutProvider.php
+++ b/Services/Dashboard/GlobalScreen/classes/DashboardLayoutProvider.php
@@ -7,11 +7,11 @@ use ILIAS\GlobalScreen\Scope\Layout\Factory\MainBarModification;
 use ILIAS\UI\Component\MainControls\MainBar;
 
 /**
- * Class PDLayoutProvider
+ * Class DashboardLayoutProvider
  *
  * @author Nils Haagen <nils.haagen@concepts-and-training.de>
  */
-class PDLayoutProvider extends AbstractModificationProvider implements ModificationProvider
+class DashboardLayoutProvider extends AbstractModificationProvider implements ModificationProvider
 {
     /**
      * @var Collection | null

--- a/Services/Dashboard/GlobalScreen/classes/DashboardLayoutProvider.php
+++ b/Services/Dashboard/GlobalScreen/classes/DashboardLayoutProvider.php
@@ -29,7 +29,6 @@ class DashboardLayoutProvider extends AbstractModificationProvider implements Mo
 
     public function getMainBarModification(CalledContexts $screen_context_stack) : ?MainBarModification
     {
-
         $this->data_collection = $screen_context_stack->current()->getAdditionalData();
         if(!$this->data_collection->is(\ilDashboardGUI::DISENGAGE_MAINBAR, true)) {
             return null;

--- a/Services/Dashboard/GlobalScreen/classes/PDLayoutProvider.php
+++ b/Services/Dashboard/GlobalScreen/classes/PDLayoutProvider.php
@@ -1,0 +1,46 @@
+<?php
+use ILIAS\GlobalScreen\Scope\Layout\Provider\AbstractModificationProvider;
+use ILIAS\GlobalScreen\Scope\Layout\Provider\ModificationProvider;
+use ILIAS\GlobalScreen\ScreenContext\Stack\ContextCollection;
+use ILIAS\GlobalScreen\ScreenContext\Stack\CalledContexts;
+use ILIAS\GlobalScreen\Scope\Layout\Factory\MainBarModification;
+use ILIAS\UI\Component\MainControls\MainBar;
+
+/**
+ * Class PDLayoutProvider
+ *
+ * @author Nils Haagen <nils.haagen@concepts-and-training.de>
+ */
+class PDLayoutProvider extends AbstractModificationProvider implements ModificationProvider
+{
+    /**
+     * @var Collection | null
+     */
+    protected $data_collection;
+
+    /**
+     * @inheritDoc
+     */
+    public function isInterestedInContexts() : ContextCollection
+    {
+        return $this->context_collection->desktop();
+
+    }
+
+    public function getMainBarModification(CalledContexts $screen_context_stack) : ?MainBarModification
+    {
+
+        $this->data_collection = $screen_context_stack->current()->getAdditionalData();
+        if(!$this->data_collection->is(\ilDashboardGUI::DISENGAGE_MAINBAR, true)) {
+            return null;
+        }
+
+        return $this->globalScreen()->layout()->factory()->mainbar()
+            ->withModification(
+                function(MainBar $mainbar) : ?MainBar {
+                    return $mainbar->withActive($mainbar::NONE_ACTIVE);
+                }
+            )
+            ->withHighPriority();
+    }
+}

--- a/Services/Dashboard/classes/class.ilDashboardGUI.php
+++ b/Services/Dashboard/classes/class.ilDashboardGUI.php
@@ -26,6 +26,9 @@ include_once 'Services/UIComponent/AdvancedSelectionList/classes/class.ilAdvance
 class ilDashboardGUI
 {
 	const CMD_JUMP_TO_MY_STAFF = "jumpToMyStaff";
+
+	const DISENGAGE_MAINBAR = "dash_mb_disengage";
+
 	/**
 	 * @var ilCtrl
 	 */
@@ -307,6 +310,7 @@ class ilDashboardGUI
 				$this->ctrl->forwardCommand($gui);
 				break;
 			default:
+				$context->current()->addAdditionalData(self::DISENGAGE_MAINBAR, true);
 				$this->getStandardTemplates();
 				$this->setTabs();
 				$cmd = $this->ctrl->getCmd("show");

--- a/src/UI/Implementation/Component/MainControls/Renderer.php
+++ b/src/UI/Implementation/Component/MainControls/Renderer.php
@@ -61,10 +61,6 @@ class Renderer extends AbstractComponentRenderer
             );
     }
 
-
-
-
-
     protected function renderToolEntry(
         Slate $entry,
         string $entry_id,
@@ -99,9 +95,6 @@ class Renderer extends AbstractComponentRenderer
         $is_hidden = $is_hidden ? 'true':'false';
         return "il.UI.maincontrols.mainbar.addToolEntry('{$mb_id}', {$is_removeable}, {$is_hidden});";
     }
-
-
-
 
     protected function renderMainbarEntry(
         array $entries,

--- a/src/UI/templates/js/MainControls/mainbar.js
+++ b/src/UI/templates/js/MainControls/mainbar.js
@@ -17,10 +17,10 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 				/**
 				 * Just open the tools, activate last one
 				 */
-				engageTools: function() {
-					var tool_id = Object.keys(mappings).slice(-1)[0];
-					this.engageTool(tool_id);
-				}
+				disengageAll: function() {
+					this.model.actions.disengageAll();
+					this.renderer.render(this.model.getState());
+				},
 			},
 			construction = {
 				/**
@@ -206,7 +206,7 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 				adjustToScreenSize: adjustToScreenSize,
 				init: init,
 				engageTool: external_commands.engageTool,
-				engageTools: external_commands.engageTools
+				disengageAll: external_commands.disengageAll
 			};
 
 		return public_interface;
@@ -524,6 +524,9 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 					this.getElement().removeClass(css.disengaged);
 					this.getElement().trigger('in_view'); //this is most important for async loading of slates,
 														  //it triggers the GlobalScreen-Service.
+					if(il.UI.page.isSmallScreen() && il.UI.maincontrols.metabar) {
+						il.UI.maincontrols.metabar.disengageAll();
+					}
 				},
 				disengage: function() {
 					this.getElement().addClass(css.disengaged);

--- a/src/UI/templates/js/MainControls/mainbar.js
+++ b/src/UI/templates/js/MainControls/mainbar.js
@@ -109,8 +109,8 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 					}
 					return null;
 				},
-				getLastEngagedToolId: function(tools) {
-					var keys = Object.keys(tools).reverse();
+				getFirstEngagedToolId: function(tools) {
+					var keys = Object.keys(tools);
 					for(var idx in keys) {
 						if(tools[keys[idx]].engaged) {
 							return keys[idx];
@@ -157,7 +157,7 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 				}
 
 				init_state = mb.model.getState();
-				last_tool_id = helper.getLastEngagedToolId(init_state.tools);
+				first_tool_id = helper.getFirstEngagedToolId(init_state.tools);
 
 				/**
 				 * initially active (from mainbar-component) will override everything (but tools)
@@ -175,8 +175,8 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 				/**
 				 * Override potentially active entry, if there are is an active tool.
 				 */
-				if(last_tool_id) {
-					mb.model.actions.engageTool(last_tool_id);
+				if(first_tool_id) {
+					mb.model.actions.engageTool(first_tool_id);
 				}
 
 				mb.model.actions.initMoreButton(mb.renderer.calcAmountOfButtons());

--- a/src/UI/templates/js/MainControls/mainbar.js
+++ b/src/UI/templates/js/MainControls/mainbar.js
@@ -159,10 +159,8 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 				init_state = mb.model.getState();
 				last_tool_id = helper.getLastEngagedToolId(init_state.tools);
 
-
 				/**
-				 * initially active (from mainbar-component)
-				 * will override everything
+				 * initially active (from mainbar-component) will override everything (but tools)
 				 */
 				if(initially_active) {
 					if(initially_active === '_none') {
@@ -175,10 +173,8 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 				}
 
 				/**
-				 * Override potentially active entry, if there are is
-				 * an active tool
+				 * Override potentially active entry, if there are is an active tool.
 				 */
-
 				if(last_tool_id) {
 					mb.model.actions.engageTool(last_tool_id);
 				}

--- a/src/UI/templates/js/MainControls/mainbar.js
+++ b/src/UI/templates/js/MainControls/mainbar.js
@@ -122,11 +122,13 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 			adjustToScreenSize = function() {
 				var mb = il.UI.maincontrols.mainbar,
 					amount = mb.renderer.calcAmountOfButtons();
-
+				if(il.UI.page.isSmallScreen()) {
+					mb.model.actions.disengageAll();
+				}
 				mb.model.actions.initMoreButton(amount);
 				mb.renderer.render(mb.model.getState());
 			},
-			init = function(initially_active) {
+			init_desktop = function(initially_active) {
 				var mb = il.UI.maincontrols.mainbar,
 					cookie_state = mb.persistence.read(),
 					init_state = mb.model.getState();
@@ -182,6 +184,20 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 				mb.model.actions.initMoreButton(mb.renderer.calcAmountOfButtons());
 				mb.renderer.render(mb.model.getState());
 			},
+			init_mobile = function(initially_active) {
+				var mb = il.UI.maincontrols.mainbar;
+				mb.model.actions.disengageAll();
+				mb.model.actions.initMoreButton(mb.renderer.calcAmountOfButtons());
+				mb.renderer.render(mb.model.getState());
+			},
+			init = function(initially_active) {
+				if(il.UI.page.isSmallScreen()) {
+					init_mobile();
+				} else {
+					init_desktop(initially_active);
+				}
+			},
+
 			public_interface = {
 				addToolEntry: construction.addToolEntry,
 				addPartIdAndEntry: construction.addPartIdAndEntry,

--- a/src/UI/templates/js/MainControls/metabar.js
+++ b/src/UI/templates/js/MainControls/metabar.js
@@ -26,6 +26,9 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 
 			$(document).on(entry_signal, function(event, signalData) {
 				onClickEntry(event, signalData);
+				if(il.UI.page.isSmallScreen() && il.UI.maincontrols.mainbar) {
+					il.UI.maincontrols.mainbar.disengageAll();
+				}
 				return false;
 			});
 			$(document).on(close_slates_signal, function(event, signalData) {
@@ -37,11 +40,9 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 		var onClickEntry = function(event, signalData) {
 			var btn = signalData.triggerer;
 
-
 			if(btn.attr('id') === _getMoreButton().attr('id')) {
 				return;
 			}
-
 
 			if(_isEngaged(btn)) {
 				_disengageButton(btn);
@@ -58,21 +59,17 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 			_disengageAllButtons();
 			_disengageAllSlates();
 		};
-
 		var _engageButton = function(btn) {
 			btn.addClass(_cls_btn_engaged);
 			btn.attr('aria-pressed', true);
 		};
-
 		var _disengageButton = function(btn) {
 			btn.removeClass(_cls_btn_engaged);
 			btn.attr('aria-pressed', false);
 		};
-
 		var _isEngaged = function(btn) {
 			return btn.hasClass(_cls_btn_engaged);
 		};
-
 		var _disengageAllButtons = function() {
 			$('#' + id +' .' + _cls_entries)
 			.children('.btn.' + _cls_btn_engaged)
@@ -82,13 +79,16 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 				}
 			)
 		};
-
 		var _disengageAllSlates = function() {
 			getEngagedSlates().each(
 				function(i, slate) {
 					il.UI.maincontrols.slate.disengage($(slate));
 				}
 			)
+		};
+		var disengageAll = function() {
+			_disengageAllSlates();
+			_disengageAllButtons();
 		};
 		var getEngagedSlates = function() {
 			var search = '#' + id
@@ -175,7 +175,8 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 			collectCounters: collectCounters,
 			_getMoreButton: _getMoreButton,
 			getEngagedSlates: getEngagedSlates,
-			_disengageAllSlates: _disengageAllSlates
+			_disengageAllSlates: _disengageAllSlates,
+			disengageAll: disengageAll
 		}
 
 	})($);


### PR DESCRIPTION
This includes #2373; I also lowered the priority in ilHelpViewLayoutProvider due to collisions (@eqsoft might be interested as well).

- Toolstates are persistent (https://mantis.ilias.de/view.php?id=26723)
- Only new/not yet invoked tools push themselves into the foreground
- Active tools are applied _after_ initially active, so that e.g. the Help will stay open even for the Dashboard.




