### PR TITLE
Adding MIME-Type for seb-file

### DIFF
--- a/Services/Utilities/classes/class.ilMimeTypeUtil.php
+++ b/Services/Utilities/classes/class.ilMimeTypeUtil.php
@@ -77,6 +77,7 @@ class ilMimeTypeUtil {
 	const APPLICATION__RTF = 'application/rtf';
 	const APPLICATION__SDP = 'application/sdp';
 	const APPLICATION__SEA = 'application/sea';
+	const APPLICATION__SEB = 'application/seb';
 	const APPLICATION__SET = 'application/set';
 	const APPLICATION__SLA = 'application/sla';
 	const APPLICATION__SMIL = 'application/smil';
@@ -1149,6 +1150,7 @@ class ilMimeTypeUtil {
 			self::APPLICATION__X_SDP,
 		),
 		'sdr' => self::APPLICATION__SOUNDER,
+	    'seb' => self::APPLICATION__SEB,
 		'sea' => array(
 			self::APPLICATION__SEA,
 			self::APPLICATION__X_SEA,


### PR DESCRIPTION
This is a fix for https://mantis.ilias.de/view.php?id=26733
The missing mime-type creates issue with the download of config files for the Safe Exam Browser when the option X-Content-Type-Options: no-sniff is set. This file format is important in BYOD exam settings.

@chfsx and @alex40724 you are the implicit maintainers of this: Do you agree for me to add the type?

If this is ok, I would cherry-pick onto all supported versions.