### PR TITLE
Fixing Disk-Quota for ILIAS >= 6

### DIFF
--- a/Modules/File/classes/class.ilObjFileAccessSettingsGUI.php
+++ b/Modules/File/classes/class.ilObjFileAccessSettingsGUI.php
@@ -25,7 +25,6 @@ use ILIAS\BackgroundTasks\Implementation\Bucket\BasicBucket;
 use ILIAS\File\Sanitation\DownloadSanitationReportUserInteraction;
 use ILIAS\File\Sanitation\SanitationReportJob;
 
-include_once "./Services/Object/classes/class.ilObjectGUI.php";
 
 /**
  * Class ilObjFileAccessSettingsGUI
@@ -99,21 +98,17 @@ class ilObjFileAccessSettingsGUI extends ilObjectGUI
         switch ($next_class) {
             case 'ilpermissiongui':
                 $this->tabs_gui->setTabActive('perm_settings');
-                include_once("Services/AccessControl/classes/class.ilPermissionGUI.php");
                 $perm_gui = new ilPermissionGUI($this);
                 $ret =& $this->ctrl->forwardCommand($perm_gui);
                 break;
 
             case 'ilfmsettingsgui':
                 $this->tabs_gui->setTabActive('fm_settings_tab');
-                include_once './Services/WebServices/FileManager/classes/class.ilFMSettingsGUI.php';
                 $fmg = new ilFMSettingsGUI($this);
                 $this->ctrl->forwardCommand($fmg);
                 break;
 
             case 'ilwebdavmountinstructionsuploadgui':
-                include_once './Services/WebDAV/classes/mount_instructions/class.ilWebDAVMountInstructionsUploadGUI.php';
-                include_once './Services/WebDAV/classes/mount_instructions/class.ilWebDAVMountInstructionsTableDataProvider.php';
                 $document_gui = new ilWebDAVMountInstructionsUploadGUI(
                         $this->object,
                         $this->tpl,
@@ -450,8 +445,6 @@ class ilObjFileAccessSettingsGUI extends ilObjectGUI
         $ilCtrl = $DIC['ilCtrl'];
         $ilTabs = $DIC['ilTabs'];
 
-        include_once("./Services/COPage/classes/class.ilPageEditorSettings.php");
-
         $ilTabs->addSubTabTarget("settings", $ilCtrl->getLinkTarget($this, "editDiskQuotaSettings"), array("editDiskQuotaSettings"));
 
         if (ilDiskQuotaActivationChecker::_isActive()) {
@@ -577,7 +570,7 @@ class ilObjFileAccessSettingsGUI extends ilObjectGUI
         $select_usage_filter = ilUtil::formSelect($_SESSION['quota_usage_filter'], "usage_filter", $usage_action, false, true);
         $select_access_filter = ilUtil::formSelect($_SESSION['quota_access_filter'], "access_filter", $access_action, false, true);
 
-        $this->tpl->setCurrentBlock("filter");
+        $this->tpl->setCurrentBlock("filter_section");
         $this->tpl->setVariable("FILTER_TXT_FILTER", $lng->txt('filter'));
         $this->tpl->setVariable("SELECT_USAGE_FILTER", $select_usage_filter);
         $this->tpl->setVariable("SELECT_ACCESS_FILTER", $select_access_filter);
@@ -593,6 +586,7 @@ class ilObjFileAccessSettingsGUI extends ilObjectGUI
         // create table
         require_once './Services/Table/classes/class.ilTableGUI.php';
         $tbl = new ilTableGUI(0, false);
+        $tbl->setTitle('');
 
         // title & header columns
         $header_vars = array('login', 'firstname', 'lastname', 'email', 'access_until', 'last_login', 'disk_quota', 'disk_usage', 'last_reminder');
@@ -691,25 +685,17 @@ class ilObjFileAccessSettingsGUI extends ilObjectGUI
                     default :
                         $tbl_content_cell = htmlspecialchars($row[$key]);
                 }
-                /*
-                if (is_array($tbl_content_cell))
-                {
-                    $tbl->tpl->setCurrentBlock("tbl_cell_subtitle");
-                    $tbl->tpl->setVariable("TBL_CELL_SUBTITLE",$tbl_content_cell[1]);
-                    $tbl->tpl->parseCurrentBlock();
-                    $tbl_content_cell = "<b>".$tbl_content_cell[0]."</b>";
-                }*/
 
-                $tbl->tpl->setCurrentBlock("tbl_content_cell");
-                $tbl->tpl->setVariable("TBL_CONTENT_CELL", $tbl_content_cell);
+                $tbl->getTemplateObject()->setCurrentBlock("tbl_content_cell");
+                $tbl->getTemplateObject()->setVariable("TBL_CONTENT_CELL", $tbl_content_cell);
 
-                $tbl->tpl->parseCurrentBlock();
+                $tbl->getTemplateObject()->parseCurrentBlock();
             }
 
-            $tbl->tpl->setCurrentBlock("tbl_content_row");
+            $tbl->getTemplateObject()->setCurrentBlock("tbl_content_row");
             $rowcolor = ilUtil::switchColor($count, "tblrow1", "tblrow2");
-            $tbl->tpl->setVariable("ROWCOLOR", $rowcolor);
-            $tbl->tpl->parseCurrentBlock();
+            $tbl->getTemplateObject()->setVariable("ROWCOLOR", $rowcolor);
+            $tbl->getTemplateObject()->parseCurrentBlock();
 
             $count++;
         }
@@ -728,7 +714,6 @@ class ilObjFileAccessSettingsGUI extends ilObjectGUI
         $lng->loadLanguageModule("meta");
         $lng->loadLanguageModule("mail");
 
-        include_once "Services/Form/classes/class.ilPropertyFormGUI.php";
         $form = new ilPropertyFormGUI();
         $form->setFormAction($this->ctrl->getFormAction($this));
 
@@ -814,7 +799,6 @@ class ilObjFileAccessSettingsGUI extends ilObjectGUI
         $tpl->setVariable("TXT_ILIAS_URL", $lng->txt("mail_nacc_ilias_url"));
         $tpl->setVariable("TXT_CLIENT_NAME", $lng->txt("mail_nacc_client_name"));
 
-        include_once "Services/UIComponent/Panel/classes/class.ilPanelGUI.php";
         $legend = ilPanelGUI::getInstance();
         $legend->setHeadingStyle(ilPanelGUI::HEADING_STYLE_BLOCK);
         $legend->setHeading($lng->txt("mail_nacc_use_placeholder"));
@@ -888,8 +872,6 @@ class ilObjFileAccessSettingsGUI extends ilObjectGUI
         $num_prop->setValue(ilFileUploadSettings::getConcurrentUploads());
         $num_prop->setInfo($lng->txt('concurrent_uploads_info'));
         $chk_enabled->addSubItem($num_prop);
-
-        include_once("./Services/Utilities/classes/class.ilFileUtils.php");
 
         // default white list
         $ne = new ilNonEditableValueGUI($this->lng->txt("file_suffix_default_white"), "");
@@ -1067,7 +1049,6 @@ class ilObjFileAccessSettingsGUI extends ilObjectGUI
         }
 
         // set warning if ghostscript not installed
-        include_once("./Services/Preview/classes/class.ilGhostscriptRenderer.php");
         if (!ilGhostscriptRenderer::isGhostscriptInstalled()) {
             ilUtil::sendInfo($lng->txt("ghostscript_not_configured"));
         }

--- a/Services/Administration/classes/class.ilAdministrationSettingsFormHandler.php
+++ b/Services/Administration/classes/class.ilAdministrationSettingsFormHandler.php
@@ -35,7 +35,7 @@ class ilAdministrationSettingsFormHandler
     const SETTINGS_FORUM                = "frma";
     const SETTINGS_LRES                 = "lrss";
     const SETTINGS_REPOSITORY           = "reps";
-    const SETTINGS_PD                   = "dshs";
+    const SETTINGS_PR                   = "prss";
     const SETTINGS_COURSE               = "crss";
     const SETTINGS_GROUP                = "grps";
     const SETTINGS_PRIVACY_SECURITY     = "ps";
@@ -107,7 +107,7 @@ class ilAdministrationSettingsFormHandler
                 break;
             
             case self::FORM_FILES_QUOTA:
-                $types = array(self::SETTINGS_PD);
+                $types = array(self::SETTINGS_PR);
                 break;
             
             case self::FORM_LP:

--- a/Services/DiskQuota/templates/default/tpl.disk_quota_report.html
+++ b/Services/DiskQuota/templates/default/tpl.disk_quota_report.html
@@ -1,8 +1,8 @@
-<!-- BEGIN filter -->
+<!-- BEGIN filter_section -->
 <form action="{FILTER_ACTION}" method="post">
 	<b>{FILTER_TXT_FILTER}</b>&nbsp;{SELECT_USAGE_FILTER}&nbsp;{SELECT_ACCESS_FILTER}&nbsp;<input class="submit" type="submit" name="cmd[{FILTER_NAME}]" value="{FILTER_VALUE}"/>&nbsp;
 </form>
-<!-- END filter -->
+<!-- END filter_section -->
 {USER_TABLE}
 
 <div class="help-block">{LAST_UPDATE_TEXT}</div>


### PR DESCRIPTION
This ports the bug-fixes for mantis #26346 to ILIAS 6 and fixes a few
follow-up issues with the Disk Quota settings.

As the abandonment of the Disk Quota in the Repository was not scheduled for ILIAS 6, I think we should fix this. I didn't test anything deeper, just made the table in the settings work. The renaming of the template block from filter to filter_section is a workaround as otherwise I was receiving exceptions about having two blocks with the same name "filter".

I can then cherry-pick this to ILIAS 6, if you want me to.