### PR TITLE
 fix 26748 - activate first tool, if tools are actually engaged, but …

### DIFF
--- a/src/UI/templates/js/MainControls/mainbar.js
+++ b/src/UI/templates/js/MainControls/mainbar.js
@@ -179,12 +179,17 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 				 */
 				if(first_tool_id) {
 					mb.model.actions.engageTool(first_tool_id);
+				} else {
+					//tools engaged, but none active: take the first one:
+					if(mb.model.getState().tools_engaged) {
+						mb.model.actions.engageTool(Object.keys(init_state.tools).shift());
+					}
 				}
 
 				mb.model.actions.initMoreButton(mb.renderer.calcAmountOfButtons());
 				mb.renderer.render(mb.model.getState());
 			},
-			init_mobile = function(initially_active) {
+			init_mobile = function() {
 				var mb = il.UI.maincontrols.mainbar;
 				mb.model.actions.disengageAll();
 				mb.model.actions.initMoreButton(mb.renderer.calcAmountOfButtons());


### PR DESCRIPTION
…the former tool went away
(same as https://github.com/ILIAS-eLearning/ILIAS/pull/2402)

https://mantis.ilias.de/view.php?id=26748