### PR TITLE
Bugfix: Check if constant AUTH_DEFAULT is defined

### DIFF
--- a/Services/Authentication/classes/class.ilObjAuthSettingsGUI.php
+++ b/Services/Authentication/classes/class.ilObjAuthSettingsGUI.php
@@ -265,7 +265,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
             $this->ilias->raiseError($this->lng->txt("auth_err_no_mode_selected"), $this->ilias->error_obj->MESSAGE);
         }
 
-        if ($_POST["auth_mode"] == AUTH_DEFAULT) {
+        if (defined(AUTH_DEFAULT) && $_POST["auth_mode"] == AUTH_DEFAULT) {
             ilUtil::sendInfo($this->lng->txt("auth_mode") . ": " . $this->getAuthModeTitle() . " " . $this->lng->txt("auth_mode_not_changed"), true);
             $this->ctrl->redirect($this, 'authSettings');
         }


### PR DESCRIPTION
PHP 7.2 does not allow the usage of undefined constants.
Check if it is defined before using it for a comparison.
Otherwise it's not possible to change the default authentication methods in the GUI.