### PR TITLE
fix 26459, 26462 - flickering of bar-buttons

### DIFF
--- a/src/UI/Implementation/Component/Layout/Page/Renderer.php
+++ b/src/UI/Implementation/Component/Layout/Page/Renderer.php
@@ -13,7 +13,7 @@ use ILIAS\UI\Component\Image\Image;
 
 class Renderer extends AbstractComponentRenderer
 {
-
+    const COOKIE_NAME_SLATES_ENGAGED = 'il_mb_slates';
     /**
      * @inheritdoc
      */
@@ -53,6 +53,11 @@ class Renderer extends AbstractComponentRenderer
             if ($logo) {
                 $tpl->setVariable("LOGO", $default_renderer->render($logo));
             }
+        }
+
+        $slates_cookie = $_COOKIE[self::COOKIE_NAME_SLATES_ENGAGED];
+        if($slates_cookie && json_decode($slates_cookie,true)['engaged']) {
+            $tpl->touchBlock('slates_engaged');
         }
 
         $tpl->setVariable("TITLE", $component->getTitle());

--- a/src/UI/templates/default/Layout/tpl.standardpage.html
+++ b/src/UI/templates/default/Layout/tpl.standardpage.html
@@ -26,7 +26,7 @@
 
 <body>
 
-	<section class="il-layout-page">
+	<section class="il-layout-page<!-- BEGIN slates_engaged --> with-mainbar-slates-engaged<!-- END slates_engaged -->">
 
 		<header>
 			<div class="header-inner">
@@ -36,8 +36,6 @@
 						{TITLE}
 					</div>
 				</div>
-
-
 
 				<!-- BEGIN header_locator -->
 				<nav class="il-header-locator">

--- a/src/UI/templates/default/MainControls/tpl.mainbar.html
+++ b/src/UI/templates/default/MainControls/tpl.mainbar.html
@@ -7,7 +7,7 @@
 		<!-- END tools_trigger -->
 
 		<div class="il-mainbar-triggers">
-			<div class="il-mainbar-entries">
+			<div class="il-mainbar-entries" style="visibility: hidden"><!--if done via class/css-files, visibility is being applied too late -->
 				<!-- BEGIN trigger_item -->
 				{BUTTON}
 				<!-- END trigger_item -->

--- a/src/UI/templates/default/MainControls/tpl.metabar.html
+++ b/src/UI/templates/default/MainControls/tpl.metabar.html
@@ -1,5 +1,5 @@
 <div class="il-maincontrols-metabar" id="{ID}">
-	<div class="il-metabar-entries">
+	<div class="il-metabar-entries" style="visibility: hidden"><!--if done via class/css-files, visibility is being applied too late -->
 		<!-- BEGIN meta_element -->
 			{BUTTON}
 		<!-- END meta_element -->

--- a/src/UI/templates/js/MainControls/mainbar.js
+++ b/src/UI/templates/js/MainControls/mainbar.js
@@ -483,11 +483,22 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 					cs.add(idx, state[idx]);
 				}
 				cs.store();
+				storePageState(state.any_entry_engaged || state.tools_engaged);
 			},
 			readStates = function() {
 				cs = storage();
 				return cs.items;
 			},
+			/**
+			 * The information wether slates are engaged or not is shared
+			 * with the page's renderer, so the space can be reserverd very early.
+			 */
+			storePageState = function(engaged) {
+				var shared = new il.Utilities.CookieStorage('il_mb_slates');
+				shared.add('engaged', engaged);
+				shared.store();
+			},
+
 			public_interface = {
 				read: readStates,
 				store: storeStates
@@ -512,6 +523,7 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 				,remover_class: 'il-mainbar-remove-tool'
 				,mainbar: 'il-mainbar'
 				,mainbar_buttons: '.il-mainbar .il-mainbar-entries .btn-bulky'
+				,mainbar_entries: 'il-mainbar-entries'
 			},
 
 			dom_references = {},
@@ -709,6 +721,8 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 					for(idx in model_state.tools) {
 						actions.renderEntry(model_state.tools[idx], true);
 					}
+					//unfortunately, this does not work properly via a class
+					$('.' + css.mainbar_entries).css('visibility', 'visible');
 				}
 			},
 			public_interface = {

--- a/src/UI/templates/js/MainControls/metabar.js
+++ b/src/UI/templates/js/MainControls/metabar.js
@@ -112,6 +112,8 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 			_tagMoreButton();
 			_tagMoreSlate();
 			il.UI.page.isSmallScreen() ? _initCondensed() : _initWide();
+			//unfortunately, this does not work properly via a class
+			$('.' + _cls_entries).css("visibility","visible");
 		};
 
 		var _initCondensed = function () {

--- a/tests/UI/Component/MainControls/MainBarTest.php
+++ b/tests/UI/Component/MainControls/MainBarTest.php
@@ -193,6 +193,7 @@ class MainBarTest extends ILIAS_UI_TestBase
     {
         $html = str_replace(["\n", "\r", "\t"], "", $html);
         $html = preg_replace('# {2,}#', " ", $html);
+        $html = preg_replace('/<!--(.|\s)*?-->/', '', $html);
         return trim($html);
     }
 
@@ -224,7 +225,7 @@ class MainBarTest extends ILIAS_UI_TestBase
 			<div class="il-maincontrols-mainbar" id="id_12">
 				<div class="il-mainbar">
 					<div class="il-mainbar-triggers">
-						<div class="il-mainbar-entries">
+						<div class="il-mainbar-entries" style="visibility: hidden">
 							<button class="btn btn-bulky" data-action="#" id="id_1" ><div class="icon custom small" aria-label=""><img src="" /></div><span class="bulky-label">TestEntry</span></button>
 							<button class="btn btn-bulky" data-action="#" id="id_2" ><div class="icon custom small" aria-label=""><img src="" /></div><span class="bulky-label">TestEntry</span></button>
 							<button class="btn btn-bulky" id="id_3" ><div class="icon custom small" aria-label=""><img src="" /></div><span class="bulky-label">1</span></button>

--- a/tests/UI/Component/MainControls/MetaBarTest.php
+++ b/tests/UI/Component/MainControls/MetaBarTest.php
@@ -112,6 +112,14 @@ class MetaBarTest extends ILIAS_UI_TestBase
         return $factory;
     }
 
+    public function brutallyTrimHTML($html)
+    {
+        $html = str_replace(["\n", "\r", "\t"], "", $html);
+        $html = preg_replace('# {2,}#', " ", $html);
+        $html = preg_replace('/<!--(.|\s)*?-->/', '', $html);
+        return trim($html);
+    }
+
     public function testRendering()
     {
         $r = $this->getDefaultRenderer();
@@ -126,20 +134,20 @@ class MetaBarTest extends ILIAS_UI_TestBase
 
         $expected = <<<EOT
 <div class="il-maincontrols-metabar" id="id_5">
-	<div class="il-metabar-entries">
-		<button class="btn btn-bulky" data-action="#" id="id_1">
+	<div class="il-metabar-entries" style="visibility: hidden">
+		<button class="btn btn-bulky" data-action="#" id="id_1" >
 			<div class="icon custom small" aria-label="">
 				<img src="" />
 			</div>
 			<span class="bulky-label">TestEntry</span>
 		</button>
-		<button class="btn btn-bulky" data-action="#" id="id_2">
+		<button class="btn btn-bulky" data-action="#" id="id_2" >
 			<div class="icon custom small" aria-label="">
 				<img src="" />
 			</div>
 			<span class="bulky-label">TestEntry</span>
 		</button>
-		<button class="btn btn-bulky" id="id_3" aria-pressed="false">
+		<button class="btn btn-bulky" id="id_3" aria-pressed="false" >
 			<span class="glyph" aria-label="more">
 				<span class="glyphicon glyphicon-option-horizontal" aria-hidden="true"></span>
 				<span class="il-counter">


### PR DESCRIPTION
The page's (re-)load ist still visible, but way more unobstrusive.
Buttons of meta- and mainbar are set to invisible first and shown after calculations are done.
Also, Mainbar shares a cookie with the page's renderer to acknowledge slates being engaed(or not) at an early point of time.
Thanks to @klees  for patience and focus.

https://mantis.ilias.de/view.php?id=26462
https://mantis.ilias.de/view.php?id=26459