### PR TITLE
Forum: Convert 'Datetime' to 'Unix Timestamp'

### DIFF
--- a/Modules/Forum/classes/Notification/class.ilMailEventNotificationSender.php
+++ b/Modules/Forum/classes/Notification/class.ilMailEventNotificationSender.php
@@ -189,14 +189,13 @@ class ilMailEventNotificationSender extends ilMailNotification
                         $this->provider->getPostUpdateUserName($this->getLanguage()),
                         $this->provider->getForumTitle()
                     );
-                    $date       = $this->provider->getPostUpdate();
 
                     $mailObjects[] = $this->createMailValueObjectsWithAttachments(
                         'frm_noti_subject_upt_post',
                         (int) $rcp,
                         (string) $customText,
                         'content_post_updated',
-                        $date
+                        $this->provider->getPostModificationTimestamp()
                     );
                 }
                 break;
@@ -209,14 +208,13 @@ class ilMailEventNotificationSender extends ilMailNotification
                         $this->provider->getPostUpdateUserName($this->getLanguage()),
                         $this->provider->getForumTitle()
                     );
-                    $date       = $this->provider->getPostCensoredDate();
 
                     $mailObjects[] = $this->createMailValueObjectsWithAttachments(
                         'frm_noti_subject_cens_post',
                         (int) $rcp,
                         (string) $customText,
                         'content_censored_post',
-                        $date
+                        $this->provider->getPostCensorshipTimestamp()
                     );
                 }
                 break;
@@ -228,14 +226,13 @@ class ilMailEventNotificationSender extends ilMailNotification
                         $this->getLanguageText('post_uncensored_by'),
                         $this->provider->getPostUpdateUserName($this->getLanguage())
                     );
-                    $date       = $this->provider->getPostCensoredDate();
 
                     $mailObjects[] = $this->createMailValueObjectsWithAttachments(
                         'frm_noti_subject_uncens_post',
                         (int) $rcp,
                         (string) $customText,
                         'forums_the_post',
-                        $date
+                        $this->provider->getPostCensorshipTimestamp()
                     );
                 }
                 break;
@@ -388,7 +385,7 @@ class ilMailEventNotificationSender extends ilMailNotification
      * @param int         $recipientUserId   - id of the user recipient of the mail
      * @param string      $customText        - mail text after salutation
      * @param string      $action            - Language id of action
-     * @param string|null $date              - date to be added in mail
+     * @param int         $timestamp         - timestamp to be added in mail
      * @return ilMailValueObject
      */
     private function createMailValueObjectsWithAttachments(
@@ -396,7 +393,7 @@ class ilMailEventNotificationSender extends ilMailNotification
         int $recipientUserId,
         string $customText,
         string $action,
-        string $date = ''
+        int $timestamp = 0
     ) {
         $subjectText = $this->createSubjectText($subjectLanguageId);
 
@@ -405,7 +402,7 @@ class ilMailEventNotificationSender extends ilMailNotification
             $recipientUserId,
             $customText,
             $action,
-            $date
+            $timestamp
         );
 
         $attachmentText = $this->createAttachmentText();
@@ -436,7 +433,7 @@ class ilMailEventNotificationSender extends ilMailNotification
      * @param int         $recipientUserId
      * @param string      $customText        - mail text after salutation
      * @param string      $action            - Language id of action
-     * @param string|null $date              - date to be added in mail
+     * @param int         $timestamp        - date to be added in mail
      * @return ilMailValueObject
      */
     private function createMailValueObjectWithoutAttachments(
@@ -444,7 +441,7 @@ class ilMailEventNotificationSender extends ilMailNotification
         int $recipientUserId,
         string $customText,
         string $action,
-        string $date = ''
+        int $timestamp = 0
     ) {
         $subjectText = $this->createSubjectText($subjectLanguageId);
 
@@ -453,7 +450,7 @@ class ilMailEventNotificationSender extends ilMailNotification
             $recipientUserId,
             $customText,
             $action,
-            $date
+            $timestamp
         );
 
         $mailObject = new ilMailValueObject(
@@ -476,9 +473,9 @@ class ilMailEventNotificationSender extends ilMailNotification
         int $userId,
         string $customText,
         string $action,
-        string $date
+        int $timestamp
     ) {
-        $date = $this->createMailDate($date);
+        $date = $this->createMailDate($timestamp);
 
         $this->addMailSubject($subject);
 
@@ -548,21 +545,21 @@ class ilMailEventNotificationSender extends ilMailNotification
     }
 
     /**
-     * @param string $date
+     * @param int $timestamp
      * @return string
      * @throws ilDateTimeException
      * @internal
      *
      */
-    private function createMailDate(string $date) : string
+    private function createMailDate(int $timestamp) : string
     {
         ilDatePresentation::setLanguage($this->language);
 
-        if ($date === '') {
-            $date = $this->provider->getPostDate();
+        if (0 === $timestamp) {
+            $timestamp = $this->provider->getPostCreationTimestamp();
         }
 
-        $date = ilDatePresentation::formatDate(new ilDateTime($date, IL_CAL_DATETIME));
+        $date = ilDatePresentation::formatDate(new ilDateTime($timestamp, IL_CAL_UNIX));
 
         return $date;
     }

--- a/Modules/Forum/classes/Tasks/class.ilForumDraftsDerivedTaskProvider.php
+++ b/Modules/Forum/classes/Tasks/class.ilForumDraftsDerivedTaskProvider.php
@@ -71,7 +71,7 @@ class ilForumDraftsDerivedTaskProvider implements \ilDerivedTaskProvider
                 $title,
                 $refId,
                 0,
-                strtotime($draft->getPostDate())
+                $draft->getPostCreationTimestamp()
             );
 
             $isThread = false;

--- a/Modules/Forum/classes/class.ilFileDataForum.php
+++ b/Modules/Forum/classes/class.ilFileDataForum.php
@@ -92,13 +92,13 @@ class ilFileDataForum extends ilFileData
 
             list($obj_id, $rest) = explode('_', $file->getFilename(), 2);
             if ($obj_id == $this->obj_id) {
-                $files[] = array(
+                $files[] = [
                     'path'  => $file->getPathname(),
                     'md5'   => md5($this->obj_id . '_' . $this->pos_id . '_' . $rest),
                     'name'  => $rest,
                     'size'  => $file->getSize(),
-                    'ctime' => date('Y-m-d H:i:s', $file->getCTime())
-                );
+                    'ctime' => $file->getCTime()
+                ];
             }
         }
 
@@ -125,13 +125,13 @@ class ilFileDataForum extends ilFileData
             if ($obj_id == $this->obj_id) {
                 list($pos_id, $rest) = explode('_', $rest, 2);
                 if ($pos_id == $this->getPosId()) {
-                    $files[$rest] = array(
+                    $files[$rest] = [
                         'path'  => $file->getPathname(),
                         'md5'   => md5($this->obj_id . '_' . $this->pos_id . '_' . $rest),
                         'name'  => $rest,
                         'size'  => $file->getSize(),
-                        'ctime' => date('Y-m-d H:i:s', $file->getCTime())
-                    );
+                        'ctime' => $file->getCTime()
+                    ];
                 }
             }
         }

--- a/Modules/Forum/classes/class.ilFileDataForumDrafts.php
+++ b/Modules/Forum/classes/class.ilFileDataForumDrafts.php
@@ -92,13 +92,13 @@ class ilFileDataForumDrafts extends ilFileData
                 continue;
             }
 
-            $files[] = array(
+            $files[] = [
                 'path'  => $file->getPathname(),
                 'md5'   => md5($file->getFilename()),
                 'name'  => $file->getFilename(),
                 'size'  => $file->getSize(),
-                'ctime' => date('Y-m-d H:i:s', $file->getCTime())
-            );
+                'ctime' => $file->getCTime()
+            ];
         }
         
         return $files;
@@ -120,13 +120,13 @@ class ilFileDataForumDrafts extends ilFileData
                 continue;
             }
 
-            $files[$file->getFilename()] = array(
+            $files[$file->getFilename()] = [
                 'path'  => $file->getPathname(),
                 'md5'   => md5($file->getFilename()),
                 'name'  => $file->getFilename(),
                 'size'  => $file->getSize(),
-                'ctime' => date('Y-m-d H:i:s', $file->getCTime())
-            );
+                'ctime' => $file->getCTime()
+            ];
         }
         
         return $files;

--- a/Modules/Forum/classes/class.ilForum.php
+++ b/Modules/Forum/classes/class.ilForum.php
@@ -1121,7 +1121,7 @@ class ilForum
 						LEFT JOIN frm_thread_access iacc ON (iacc.thread_id = ipos.pos_thr_fk AND iacc.usr_id = %s)
 						WHERE ipos.pos_thr_fk = thr_pk
 						 
-						AND (ipos.pos_update > iacc.access_old_ts
+						AND (ipos.pos_update > iacc.access_old
 							OR
 							(iacc.access_old IS NULL AND (ipos.pos_update > " . $this->db->quote(NEW_DEADLINE, 'integer') . "))
 							)

--- a/Modules/Forum/classes/class.ilForumCronNotificationDataProvider.php
+++ b/Modules/Forum/classes/class.ilForumCronNotificationDataProvider.php
@@ -56,22 +56,22 @@ class ilForumCronNotificationDataProvider implements ilForumNotificationMailData
      */
     protected $post_message = '';
     /**
-     * @var null
+     * @var int
      */
-    protected $post_date = null;
+    protected $post_creation_timestamp = 0;
     /**
-     * @var null
+     * @var int
      */
-    protected $post_update = null;
+    protected $post_modification_timestamp = 0;
 
     /**
      * @var bool
      */
     protected $post_censored = false;
     /**
-     * @var null
+     * @var int
      */
-    protected $post_censored_date = null;
+    protected $post_censorship_timestamp = 0;
     /**
      * @var string
      */
@@ -159,12 +159,12 @@ class ilForumCronNotificationDataProvider implements ilForumNotificationMailData
         $this->post_id     = $row['pos_pk'];
         $this->post_title  = $row['pos_subject'];
         $this->post_message  = $row['pos_message'];
-        $this->post_date   = $row['pos_date'];
-        $this->post_update = $row['pos_update'];
+        $this->post_creation_timestamp   = (int) $row['pos_date'];
+        $this->post_modification_timestamp = (int) $row['pos_update'];
         $this->post_update_user_id = $row['update_user'];
 
         $this->post_censored         = $row['pos_cens'];
-        $this->post_censored_date    = $row['pos_cens_date'];
+        $this->post_censorship_timestamp    = (int) $row['pos_cens_date'];
         $this->post_censored_comment = $row['pos_cens_com'];
 
         $this->pos_usr_alias       = $row['pos_usr_alias'];
@@ -303,19 +303,19 @@ class ilForumCronNotificationDataProvider implements ilForumNotificationMailData
     }
 
     /**
-     * @return string frm_posts.pos_date
+     * @inheritDoc
      */
-    public function getPostDate()
+    public function getPostCreationTimestamp() : int
     {
-        return $this->post_date;
+        return $this->post_creation_timestamp;
     }
 
     /**
-     * @return string frm_posts.pos_update
+     * @inheritDoc
      */
-    public function getPostUpdate()
+    public function getPostModificationTimestamp() : int
     {
-        return $this->post_update;
+        return $this->post_modification_timestamp;
     }
 
     /**
@@ -327,11 +327,11 @@ class ilForumCronNotificationDataProvider implements ilForumNotificationMailData
     }
 
     /**
-     * @return string frm_posts.pos_cens_date
+     * @inheritDoc
      */
-    public function getPostCensoredDate()
+    public function getPostCensorshipTimestamp() : int
     {
-        return $this->post_censored_date;
+        return $this->post_censorship_timestamp;
     }
 
     /**

--- a/Modules/Forum/classes/class.ilForumDraftsHistory.php
+++ b/Modules/Forum/classes/class.ilForumDraftsHistory.php
@@ -26,9 +26,9 @@ class ilForumDraftsHistory
     protected $post_message = '';
     
     /**
-     * @var string
+     * @var int
      */
-    protected $draft_date = '0000-00-00 00:00:00';
+    protected $draft_creation_timestamp = 0;
     
     public $db;
     
@@ -97,19 +97,19 @@ class ilForumDraftsHistory
     }
     
     /**
-     * @return string
+     * @return int
      */
-    public function getDraftDate()
+    public function getDraftCreationTimestamp() : int
     {
-        return $this->draft_date;
+        return $this->draft_creation_timestamp;
     }
     
     /**
-     * @param string $draft_date
+     * @param int $timestamp
      */
-    public function setDraftDate($draft_date)
+    public function setDraftCreationTimestamp(int $timestamp)
     {
-        $this->draft_date = $draft_date;
+        $this->draft_creation_timestamp = $timestamp;
     }
     
     /**
@@ -143,7 +143,7 @@ class ilForumDraftsHistory
             $this->setDraftId($row['draft_id']);
             $this->setPostMessage($row['post_message']);
             $this->setPostSubject($row['post_subject']);
-            $this->setDraftDate($row['draft_date']);
+            $this->setDraftCreationTimestamp((int) $row['draft_date']);
         }
     }
     
@@ -179,7 +179,7 @@ class ilForumDraftsHistory
         $history_draft->setDraftId($row['draft_id']);
         $history_draft->setPostMessage($row['post_message']);
         $history_draft->setPostSubject($row['post_subject']);
-        $history_draft->setDraftDate($row['draft_date']);
+        $history_draft->setDraftCreationTimestamp((int) $row['draft_date']);
         
         return $history_draft;
     }
@@ -237,12 +237,13 @@ class ilForumDraftsHistory
         $next_id = $this->db->nextId('frm_drafts_history');
         $this->db->insert(
             'frm_drafts_history',
-            array('history_id'   => array('integer', $next_id),
-                  'draft_id'     => array('integer', $this->getDraftId()),
-                  'post_subject' => array('text', $this->getPostSubject()),
-                  'post_message' => array('text', $this->getPostMessage()),
-                  'draft_date'   => array('timestamp', date("Y-m-d H:i:s"))
-            )
+            [
+                'history_id' => ['integer', $next_id],
+                'draft_id' => ['integer', $this->getDraftId()],
+                'post_subject' => ['text', $this->getPostSubject()],
+                'post_message' => ['text', $this->getPostMessage()],
+                'draft_date' => ['integer', time()]
+            ]
         );
         $this->setHistoryId($next_id);
     }

--- a/Modules/Forum/classes/class.ilForumDraftsTableGUI.php
+++ b/Modules/Forum/classes/class.ilForumDraftsTableGUI.php
@@ -55,7 +55,7 @@ class ilForumDraftsTableGUI extends ilTable2GUI
             $this->tpl->setVariable('VAL_UNLINKED_SUBJECT', $draft['subject']);
         }
 
-        $date = ilDatePresentation::formatDate(new ilDateTime($draft['post_update'], IL_CAL_DATETIME));
+        $date = ilDatePresentation::formatDate(new ilDateTime($draft['post_update'], IL_CAL_UNIX));
         $this->tpl->setVariable('VAL_DATE', $date);
     }
 }

--- a/Modules/Forum/classes/class.ilForumExplorerGUI.php
+++ b/Modules/Forum/classes/class.ilForumExplorerGUI.php
@@ -131,7 +131,7 @@ class ilForumExplorerGUI extends ilTreeExplorerGUI
                 'pos_author_id' => $this->root_node->getPosAuthorId(),
                 'pos_display_user_id' => $this->root_node->getDisplayUserId(),
                 'pos_usr_alias' => $this->root_node->getUserAlias(),
-                'pos_date' => $this->root_node->getCreateDate(),
+                'pos_date' => $this->root_node->getCreationTimestamp(),
                 'import_name' => $this->root_node->getImportName(),
                 'post_read' => $this->root_node->isPostRead()
             ]
@@ -167,7 +167,7 @@ class ilForumExplorerGUI extends ilTreeExplorerGUI
             $node = $factory->simple($this->getNodeContent($record), $icon);
         } else {
             $authorInfo = $this->getAuthorInformationByNode($record);
-            $creationDate = ilDatePresentation::formatDate(new ilDateTime($record['pos_date'], IL_CAL_DATETIME));
+            $creationDate = ilDatePresentation::formatDate(new ilDateTime($record['pos_date'], IL_CAL_UNIX));
             $bylineString = $authorInfo->getAuthorShortName() . ', ' . $creationDate;
 
             $node = $factory->bylined($this->getNodeContent($record), $bylineString, $icon);

--- a/Modules/Forum/classes/class.ilForumExportGUI.php
+++ b/Modules/Forum/classes/class.ilForumExportGUI.php
@@ -193,7 +193,7 @@ class ilForumExportGUI
                 $tpl->setVariable('TXT_REGISTERED', $this->lng->txt('registered_since'));
                 $tpl->setVariable(
                     'REGISTERED_SINCE',
-                    $this->frm->convertDate($authorinfo->getAuthor()->getCreateDate())
+                    $this->frm->formatTimestamp(strtotime($authorinfo->getAuthor()->getCreateDate()))
                 );
             }
 
@@ -233,7 +233,7 @@ class ilForumExportGUI
                 $spanClass = 'moderator_small';
             }
 
-            $post->setChangeDate($post->getChangeDate());
+            $post->setModificationTimestamp($post->getModificationTimestamp());
 
             $authorinfo = new ilForumAuthorInformation(
                 $post->getPosAuthorId(),
@@ -244,7 +244,7 @@ class ilForumExportGUI
 
             $tpl->setVariable(
                 'POST_UPDATE_TXT',
-                $this->lng->txt('edited_on') . ': ' . $this->frm->convertDate($post->getChangeDate()) . ' - ' . strtolower($this->lng->txt('by'))
+                $this->lng->txt('edited_on') . ': ' . $this->frm->formatTimestamp($post->getModificationTimestamp()) . ' - ' . strtolower($this->lng->txt('by'))
             );
             $tpl->setVariable('UPDATE_AUTHOR', $authorinfo->getLinkedAuthorShortName());
             if ($authorinfo->getAuthorName(true) && !$this->objProperties->isAnonymized()) {
@@ -254,7 +254,7 @@ class ilForumExportGUI
 
         // prepare post
         $post->setMessage($this->frm->prepareText($post->getMessage()));
-        $tpl->setVariable('POST_DATE', $this->frm->convertDate($post->getCreateDate()));
+        $tpl->setVariable('POST_DATE', $this->frm->formatTimestamp($post->getCreationTimestamp()));
         $tpl->setVariable('SUBJECT', $post->getSubject());
 
         if (!$post->isCensored()) {

--- a/Modules/Forum/classes/class.ilForumExporter.php
+++ b/Modules/Forum/classes/class.ilForumExporter.php
@@ -53,28 +53,35 @@ class ilForumExporter extends ilXmlExporter
      */
     public function getValidSchemaVersions($a_entity)
     {
-        return array(
-            "4.1.0" => array(
+        return [
+            "4.1.0" => [
                 "namespace"    => "http://www.ilias.de/Modules/Forum/frm/4_1",
                 "xsd_file"     => "ilias_frm_4_1.xsd",
                 "uses_dataset" => false,
                 "min"          => "4.1.0",
                 "max"          => "4.4.999"
-            ),
-            "4.5.0" => array(
+            ],
+            "4.5.0" => [
                 "namespace"    => "http://www.ilias.de/Modules/Forum/frm/4_5",
                 "xsd_file"     => "ilias_frm_4_5.xsd",
                 "uses_dataset" => false,
                 "min"          => "4.5.0",
                 "max"          => "5.0.999"
-            ),
-            "5.1.0" => array(
+            ],
+            "5.1.0" => [
                 "namespace"    => "http://www.ilias.de/Modules/Forum/frm/5_1",
                 "xsd_file"     => "ilias_frm_5_1.xsd",
                 "uses_dataset" => false,
                 "min"          => "5.1.0",
                 "max"          => ""
-            )
-        );
+            ],
+            "6.0" => [
+                "namespace"    => "http://www.ilias.de/Modules/Forum/frm/6",
+                "xsd_file"     => "ilias_frm_6.xsd",
+                "uses_dataset" => false,
+                "min"          => "6.0",
+                "max"          => ""
+            ]
+        ];
     }
 }

--- a/Modules/Forum/classes/class.ilForumPost.php
+++ b/Modules/Forum/classes/class.ilForumPost.php
@@ -23,9 +23,9 @@ class ilForumPost
     
     private $message = '';
     
-    private $createdate = '0000-00-00 00:00:00';
+    private $creation_timestamp = 0;
     
-    private $changedate = '0000-00-00 00:00:00';
+    private $modification_timestamp = 0;
     
     private $user_id_update = 0;
     
@@ -33,7 +33,7 @@ class ilForumPost
     
     private $censorship_comment = '';
     
-    private $censored_date = '0000-00-00 00:00:00';
+    private $censorship_timestamp = 0;
     
     private $notification = 0;
     
@@ -79,7 +79,7 @@ class ilForumPost
     
     private $pos_author_id = 0;
     
-    private $post_activation_date = null;
+    private $post_activation_timestamp = 0;
     
     /**
      * ilForumPost constructor.
@@ -110,27 +110,27 @@ class ilForumPost
     {
         if ($this->forum_id && $this->thread_id) {
             $this->id = $this->db->nextId('frm_posts');
-            
-            $this->db->insert('frm_posts', array(
-                'pos_pk'		=> array('integer', $this->id),
-                'pos_top_fk'	=> array('integer', $this->forum_id),
-                'pos_thr_fk'	=> array('integer', $this->thread_id),
-                'pos_display_user_id'	=> array('integer', $this->display_user_id),
-                'pos_usr_alias'	=> array('text', $this->user_alias),
-                'pos_subject'	=> array('text', $this->subject),
-                'pos_message'	=> array('clob', $this->message),
-                'pos_date'		=> array('timestamp', $this->createdate),
-                'pos_update'	=> array('timestamp', $this->createdate),
-                'update_user'	=> array('integer', $this->user_id_update),
-                'pos_cens'		=> array('integer', $this->censored),
-                'notify'		=> array('integer', (int) $this->notification),
-                'import_name'	=> array('text', (string) $this->import_name),
-                'pos_status'	=> array('integer', (int) $this->status),
-                'pos_author_id' => array('integer', (int) $this->pos_author_id),
-                'is_author_moderator' => array('integer', $this->is_author_moderator),
-                'pos_activation_date' => array('timestamp', $this->createdate)
-            ));
-            
+
+            $this->db->insert('frm_posts', [
+                'pos_pk' => ['integer', $this->id],
+                'pos_top_fk' => ['integer', $this->forum_id],
+                'pos_thr_fk' => ['integer', $this->thread_id],
+                'pos_display_user_id' => ['integer', $this->display_user_id],
+                'pos_usr_alias' => ['text', $this->user_alias],
+                'pos_subject' => ['text', $this->subject],
+                'pos_message' => ['clob', $this->message],
+                'pos_date' => ['integer', $this->creation_timestamp],
+                'pos_update' => ['integer', $this->creation_timestamp],
+                'update_user' => ['integer', $this->user_id_update],
+                'pos_cens' => ['integer', $this->censored],
+                'notify' => ['integer', (int) $this->notification],
+                'import_name' => ['text', (string) $this->import_name],
+                'pos_status' => ['integer', (int) $this->status],
+                'pos_author_id' => ['integer', (int) $this->pos_author_id],
+                'is_author_moderator' => ['integer', $this->is_author_moderator],
+                'pos_activation_date' => ['integer', $this->creation_timestamp]
+            ]);
+
             return true;
         }
         
@@ -142,22 +142,22 @@ class ilForumPost
         if ($this->id) {
             $this->db->update(
                 'frm_posts',
-                array(
-                    'pos_top_fk'	=> array('integer', $this->forum_id),
-                    'pos_thr_fk'	=> array('integer', $this->thread_id),
-                    'pos_subject'	=> array('text', $this->subject),
-                    'pos_message'	=> array('clob', $this->message),
-                    'pos_update'	=> array('timestamp', $this->changedate),
-                    'update_user'	=> array('integer', $this->user_id_update),
-                    'pos_cens'		=> array('integer', $this->censored),
-                    'pos_cens_date' => array('timestamp', $this->censored_date),
-                    'pos_cens_com'	=> array('text', $this->censorship_comment),
-                    'notify'		=> array('integer', (int) $this->notification),
-                    'pos_status'	=> array('integer', (int) $this->status)
-                ),
-                array(
-                    'pos_pk'		=> array('integer', (int) $this->id)
-                )
+                [
+                    'pos_top_fk' => ['integer', $this->forum_id],
+                    'pos_thr_fk' => ['integer', $this->thread_id],
+                    'pos_subject' => ['text', $this->subject],
+                    'pos_message' => ['clob', $this->message],
+                    'pos_update' => ['integer', $this->modification_timestamp],
+                    'update_user' => ['integer', $this->user_id_update],
+                    'pos_cens' => ['integer', $this->censored],
+                    'pos_cens_date' => ['integer', $this->censorship_timestamp],
+                    'pos_cens_com' => ['text', $this->censorship_comment],
+                    'notify' => ['integer', (int) $this->notification],
+                    'pos_status' => ['integer', (int) $this->status]
+                ],
+                [
+                    'pos_pk' => ['integer', (int) $this->id]
+                ]
             );
             
             if ($this->objThread->getFirstPostId() == $this->id) {
@@ -184,32 +184,32 @@ class ilForumPost
                 array($this->id)
             );
             $row = $this->db->fetchObject($res);
-            
+
             if (is_object($row)) {
-                $this->id                 = $row->pos_pk;
-                $this->forum_id           = $row->pos_top_fk;
-                $this->thread_id          = $row->pos_thr_fk;
-                $this->display_user_id    = $row->pos_display_user_id;
-                $this->user_alias         = $row->pos_usr_alias;
-                $this->subject            = $row->pos_subject;
-                $this->message            = $row->pos_message;
-                $this->createdate         = $row->pos_date;
-                $this->changedate         = $row->pos_update;
-                $this->user_id_update     = $row->update_user;
-                $this->censored           = $row->pos_cens;
-                $this->censored_date      = $row->pos_cens_date;
+                $this->id = $row->pos_pk;
+                $this->forum_id = $row->pos_top_fk;
+                $this->thread_id = $row->pos_thr_fk;
+                $this->display_user_id = $row->pos_display_user_id;
+                $this->user_alias = $row->pos_usr_alias;
+                $this->subject = $row->pos_subject;
+                $this->message = $row->pos_message;
+                $this->creation_timestamp = (int) $row->pos_date;
+                $this->modification_timestamp = (int) $row->pos_update;
+                $this->user_id_update = $row->update_user;
+                $this->censored = $row->pos_cens;
+                $this->censorship_timestamp = (int) $row->pos_cens_date;
                 $this->censorship_comment = $row->pos_cens_com;
-                $this->notification       = $row->notify;
-                $this->import_name        = $row->import_name;
-                $this->status             = $row->pos_status;
-                $this->tree_id            = $row->fpt_pk;
-                $this->parent_id          = $row->parent_pos;
-                $this->lft                = $row->lft;
-                $this->rgt                = $row->rgt;
-                $this->depth              = $row->depth;
-                $this->pos_author_id      = $row->pos_author_id;
+                $this->notification = $row->notify;
+                $this->import_name = $row->import_name;
+                $this->status = $row->pos_status;
+                $this->tree_id = $row->fpt_pk;
+                $this->parent_id = $row->parent_pos;
+                $this->lft = $row->lft;
+                $this->rgt = $row->rgt;
+                $this->depth = $row->depth;
+                $this->pos_author_id = $row->pos_author_id;
                 $this->is_author_moderator = $row->is_author_moderator;
-                $this->post_activation_date = $row->pos_activation_date;
+                $this->post_activation_timestamp = (int) $row->pos_activation_date;
                 $this->getUserData();
                 
                 $this->objThread = new ilForumTopic($this->thread_id, $this->is_moderator);
@@ -302,16 +302,18 @@ class ilForumPost
     public function activatePost()
     {
         if ($this->id) {
-            $now = date("Y-m-d H:i:s");
+            $current_timestamp = time();
             $this->db->update(
                 'frm_posts',
-                array('pos_status'	=>	array('integer', 1),
-                      'pos_activation_date' => array('timestamp', $now)),
-                array('pos_pk'		=>	array('integer', $this->id))
+                [
+                    'pos_status' => ['integer', 1],
+                    'pos_activation_date' => ['integer', $current_timestamp]
+                ],
+                ['pos_pk' => ['integer', $this->id]]
             );
 
             $this->activateParentPosts();
-            $this->setPostActivationDate($now);
+            $this->setPostActivationTimestamp($current_timestamp);
             $this->setStatus(1);
             return true;
         }
@@ -329,17 +331,18 @@ class ilForumPost
                    . "WHERE treea.pos_fk = %s";
             $result = $this->db->queryF(
                 $query,
-                array('integer'),
-                array($this->id)
+                ['integer'],
+                [$this->id]
             );
 
-            $now = date("Y-m-d H:i:s");
             while ($row = $this->db->fetchAssoc($result)) {
                 $this->db->update(
                     'frm_posts',
-                    array('pos_status'	=>	array('integer', 1),
-                          'pos_activation_date' => array('timestamp', $now)),
-                    array('pos_pk'		=>	array('integer', $row['pos_pk']))
+                    [
+                        'pos_status' => ['integer', 1],
+                        'pos_activation_date' => ['integer', time()]
+                    ],
+                    ['pos_pk' => ['integer', $row['pos_pk']]]
                 );
             }
             
@@ -359,17 +362,18 @@ class ilForumPost
                    . "WHERE lft < %s AND rgt > %s AND thr_fk = %s";
             $result = $this->db->queryF(
                 $query,
-                array('integer', 'integer', 'integer'),
-                array($this->lft, $this->rgt, $this->thread_id)
+                ['integer', 'integer', 'integer'],
+                [$this->lft, $this->rgt, $this->thread_id]
             );
-            
-            $now = date("Y-m-d H:i:s");
+
             while ($row = $this->db->fetchAssoc($result)) {
                 $this->db->update(
                     'frm_posts',
-                    array('pos_status'	=>	array('integer', 1),
-                          'pos_activation_date' => array('timestamp', $now)),
-                    array('pos_pk'		=>	array('integer', $row['pos_pk']))
+                    [
+                        'pos_status' => ['integer', 1],
+                        'pos_activation_date' => ['integer', time()]
+                    ],
+                    ['pos_pk' => ['integer', $row['pos_pk']]]
                 );
             }
             
@@ -487,21 +491,21 @@ class ilForumPost
     {
         return $this->message;
     }
-    public function setCreateDate($a_createdate)
+    public function setCreationTimestamp(int $timestamp)
     {
-        $this->createdate = $a_createdate;
+        $this->creation_timestamp = $timestamp;
     }
-    public function getCreateDate()
+    public function getCreationTimestamp() : int
     {
-        return $this->createdate;
+        return $this->creation_timestamp;
     }
-    public function setChangeDate($a_changedate)
+    public function setModificationTimestamp(int $timestamp)
     {
-        $this->changedate = $a_changedate;
+        $this->modification_timestamp = $timestamp;
     }
-    public function getChangeDate()
+    public function getModificationTimestamp() : int
     {
-        return $this->changedate;
+        return $this->modification_timestamp;
     }
     public function setUpdateUserId($a_user_id_update)
     {
@@ -643,35 +647,35 @@ class ilForumPost
     }
 
     /**
-     * @return string
+     * @return int
      */
-    public function getCensoredDate()
+    public function getCensorshipTimestamp() : int
     {
-        return $this->censored_date;
+        return $this->censorship_timestamp;
     }
     
     /**
-     * @return string
+     * @return int
      */
-    public function getPostActivationDate()
+    public function getPostActivationTimestamp() : int
     {
-        return $this->post_activation_date;
+        return $this->post_activation_timestamp;
     }
     
     /**
-     * @param string $post_activation_date
+     * @param int $timestamp
      */
-    public function setPostActivationDate($post_activation_date)
+    public function setPostActivationTimestamp(int $timestamp)
     {
-        $this->post_activation_date = $post_activation_date;
+        $this->post_activation_timestamp = $timestamp;
     }
 
     /**
-     * @param string $censored_date
+     * @param int $timestamp
      */
-    public function setCensoredDate($censored_date)
+    public function setCensorshipTimestamp(int $timestamp)
     {
-        $this->censored_date = $censored_date;
+        $this->censorship_timestamp = $timestamp;
     }
     
     /**
@@ -681,14 +685,14 @@ class ilForumPost
     {
         $this->setUserAlias($row['pos_usr_alias']);
         $this->setSubject($row['pos_subject']);
-        $this->setCreateDate($row['pos_date']);
+        $this->setCreationTimestamp((int) $row['pos_date']);
         $this->setMessage($row['pos_message']);
         $this->setForumId($row['pos_top_fk']);
         $this->setThreadId($row['pos_thr_fk']);
-        $this->setChangeDate($row['pos_update']);
+        $this->setModificationTimestamp((int) $row['pos_update']);
         $this->setUpdateUserId($row['update_user']);
         $this->setCensorship($row['pos_cens']);
-        $this->setCensoredDate($row['pos_cens_date']);
+        $this->setCensorshipTimestamp((int) $row['pos_cens_date']);
         $this->setCensorshipComment($row['pos_cens_com']);
         $this->setNotification($row['notify']);
         $this->setImportName($row['import_name']);
@@ -702,6 +706,7 @@ class ilForumPost
         $this->setDisplayUserId($row['pos_display_user_id']);
         $this->setPosAuthorId($row['pos_author_id']);
         $this->setIsAuthorModerator($row['is_author_moderator']);
+        $this->setPostActivationTimestamp((int) $row['pos_activation_date']);
         $this->buildUserRelatedData($row);
     }
     

--- a/Modules/Forum/classes/class.ilForumPostDraft.php
+++ b/Modules/Forum/classes/class.ilForumPostDraft.php
@@ -32,13 +32,13 @@ class ilForumPostDraft
      */
     protected $post_message = '';
     /**
-     * @var string
+     * @var int
      */
-    protected $post_date = '0000-00-00 00:00:00';
+    protected $post_creation_timestamp = 0;
     /**
-     * @var string
+     * @var int
      */
-    protected $post_update = '0000-00-00 00:00:00';
+    protected $post_modification_timestamp = 0;
     /**
      * @var int
      */
@@ -87,12 +87,12 @@ class ilForumPostDraft
         $draft->setDraftId($row['draft_id']);
         $draft->setForumId($row['forum_id']);
         $draft->setPostAuthorId($row['post_author_id']);
-        $draft->setPostDate($row['post_date']);
+        $draft->setPostCreationTimestamp((int) $row['post_date']);
         $draft->setPostDisplayUserId($row['pos_display_usr_id']);
         $draft->setPostId($row['post_id']);
         $draft->setPostMessage($row['post_message']);
         $draft->setPostSubject($row['post_subject']);
-        $draft->setPostUpdate($row['post_update']);
+        $draft->setPostModificationTimestamp((int) $row['post_update']);
         $draft->setPostUserAlias($row['post_user_alias']);
         $draft->setThreadId($row['thread_id']);
         $draft->setUpdateUserId($row['update_user_id']);
@@ -213,35 +213,35 @@ class ilForumPostDraft
     }
     
     /**
-     * @return string
+     * @return int
      */
-    public function getPostDate()
+    public function getPostCreationTimestamp() : int
     {
-        return $this->post_date;
+        return $this->post_creation_timestamp;
     }
     
     /**
-     * @param string $post_date
+     * @param int $timestamp
      */
-    public function setPostDate($post_date)
+    public function setPostCreationTimestamp(int $timestamp)
     {
-        $this->post_date = $post_date;
+        $this->post_creation_timestamp = $timestamp;
     }
     
     /**
-     * @return string
+     * @return int
      */
-    public function getPostUpdate()
+    public function getPostModificationTimestamp() : int
     {
-        return $this->post_update;
+        return $this->post_modification_timestamp;
     }
     
     /**
-     * @param string $post_update
+     * @param int $timestamp
      */
-    public function setPostUpdate($post_update)
+    public function setPostModificationTimestamp(int $timestamp)
     {
-        $this->post_update = $post_update;
+        $this->post_modification_timestamp = $timestamp;
     }
     
     /**
@@ -466,24 +466,23 @@ class ilForumPostDraft
     public function saveDraft()
     {
         $draft_id = $this->db->nextId('frm_posts_drafts');
-        $post_date = date("Y-m-d H:i:s");
-        
-        $this->db->insert('frm_posts_drafts', array(
-            'draft_id' => array('integer', $draft_id),
-            'post_id' => array('integer', $this->getPostId()),
-            'thread_id' => array('integer', $this->getThreadId()),
-            'forum_id' => array('integer', $this->getForumId()),
-            'post_author_id' => array('integer', $this->getPostAuthorId()),
-            'post_subject' => array('text', $this->getPostSubject()),
-            'post_message' => array('clob', $this->getPostMessage()),
-            'notify' => array('integer', $this->getNotify()),
-            'post_notify' => array('integer', $this->getPostNotify()),
-            'post_date' => array('timestamp', $post_date),
-            'post_update' => array('timestamp', $post_date),
-//			'update_user_id' => array('integer', $this->getUpdateUserId()),
-            'post_user_alias' => array('text', $this->getPostUserAlias()),
-            'pos_display_usr_id' => array('integer', $this->getPostDisplayUserId())
-        ));
+        $current_timestamp = time();
+
+        $this->db->insert('frm_posts_drafts', [
+            'draft_id' => ['integer', $draft_id],
+            'post_id' => ['integer', $this->getPostId()],
+            'thread_id' => ['integer', $this->getThreadId()],
+            'forum_id' => ['integer', $this->getForumId()],
+            'post_author_id' => ['integer', $this->getPostAuthorId()],
+            'post_subject' => ['text', $this->getPostSubject()],
+            'post_message' => ['clob', $this->getPostMessage()],
+            'notify' => ['integer', $this->getNotify()],
+            'post_notify' => ['integer', $this->getPostNotify()],
+            'post_date' => ['integer', $current_timestamp],
+            'post_update' => ['integer', $current_timestamp],
+            'post_user_alias' => ['text', $this->getPostUserAlias()],
+            'pos_display_usr_id' => ['integer', $this->getPostDisplayUserId()]
+        ]);
         $this->setDraftId($draft_id);
         return $draft_id;
     }
@@ -492,17 +491,17 @@ class ilForumPostDraft
     {
         $this->db->update(
             'frm_posts_drafts',
-            array(
-            'post_subject' => array('text', $this->getPostSubject()),
-            'post_message' => array('clob', $this->getPostMessage()),
-            'notify' => array('integer', $this->getNotify()),
-            'post_notify' => array('integer', $this->getPostNotify()),
-            'post_update' => array('timestamp', date("Y-m-d H:i:s")),
-            'update_user_id' => array('integer', $this->getUpdateUserId()),
-            'post_user_alias' => array('text', $this->getPostUserAlias()),
-            'pos_display_usr_id' => array('integer', $this->getPostDisplayUserId())
-        ),
-            array('draft_id' => array('integer', $this->getDraftId()))
+            [
+                'post_subject' => ['text', $this->getPostSubject()],
+                'post_message' => ['clob', $this->getPostMessage()],
+                'notify' => ['integer', $this->getNotify()],
+                'post_notify' => ['integer', $this->getPostNotify()],
+                'post_update' => ['integer', time()],
+                'update_user_id' => ['integer', $this->getUpdateUserId()],
+                'post_user_alias' => ['text', $this->getPostUserAlias()],
+                'pos_display_usr_id' => ['integer', $this->getPostDisplayUserId()]
+            ],
+            ['draft_id' => ['integer', $this->getDraftId()]]
         );
     }
     
@@ -740,7 +739,7 @@ class ilForumPostDraft
         while ($row = $ilDB->fetchAssoc($res)) {
             $tmp_obj = new self;
             self::populateWithDatabaseRecord($tmp_obj, $row);
-            $draft_data[] = array('subject'=> $tmp_obj->getPostSubject(), 'post_update' => $tmp_obj->getPostUpdate(), 'draft_id' => $tmp_obj->getDraftId());
+            $draft_data[] = array('subject'=> $tmp_obj->getPostSubject(), 'post_update' => $tmp_obj->getPostModificationTimestamp(), 'draft_id' => $tmp_obj->getDraftId());
         }
         return $draft_data;
     }

--- a/Modules/Forum/classes/class.ilForumPostsDeleted.php
+++ b/Modules/Forum/classes/class.ilForumPostsDeleted.php
@@ -12,9 +12,9 @@ class ilForumPostsDeleted
      */
     protected $deleted_id = 0;
     /**
-     * @var null
+     * @var int
      */
-    protected $deleted_date = null;
+    protected $deletion_timestamp = 0;
     /**
      * @var string
      */
@@ -39,9 +39,9 @@ class ilForumPostsDeleted
     protected $post_message = '';
 
     /**
-     * @var string
+     * @var int
      */
-    protected $post_date = '';
+    protected $post_creation_timestamp = 0;
 
     /**
      * @var int
@@ -95,7 +95,7 @@ class ilForumPostsDeleted
                 $this->setDeletedBy($this->user->getLogin());
             }
             
-            $this->setDeletedDate(date('Y-m-d H:i:s'));
+            $this->setDeletionTimestamp(time());
             $this->setForumTitle($provider->getForumTitle());
             $this->setThreadTitle($provider->getThreadTitle());
             $this->setPostTitle($provider->getPostTitle());
@@ -106,7 +106,7 @@ class ilForumPostsDeleted
                 $this->setPostMessage($provider->getPostMessage());
             }
             
-            $this->setPostDate($provider->getPostDate());
+            $this->setPostCreationTimestamp($provider->getPostCreationTimestamp());
             $this->setObjId($provider->getObjId());
             $this->setRefId($provider->getRefId());
             $this->setThreadId($provider->getThreadId());
@@ -123,24 +123,23 @@ class ilForumPostsDeleted
     {
         $next_id = $this->db->nextId('frm_posts_deleted');
 
-        $this->db->insert('frm_posts_deleted', array(
-            'deleted_id'   => array('integer', $next_id),
-            'deleted_date' => array('timestamp', $this->getDeletedDate()),
-            'deleted_by'   => array('text', $this->getDeletedBy()),
-            'forum_title'  => array('text', $this->getForumTitle()),
-            'thread_title' => array('text', $this->getThreadTitle()),
-            'post_title'   => array('text', $this->getPostTitle()),
-            'post_message' => array('text', $this->getPostMessage()),
-
-            'post_date'    => array('timestamp', $this->getPostDate()),
-            'obj_id'       => array('integer', $this->getObjId()),
-            'ref_id'       => array('integer', $this->getRefId()),
-            'thread_id'    => array('integer', $this->getThreadId()),
-            'forum_id'	   => array('integer', $this->getForumId()),
-            'pos_display_user_id' => array('integer', $this->getPosDisplayUserId()),
-            'pos_usr_alias'		=> array('text', $this->getPosUserAlias()),
-            'is_thread_deleted'	=> array('integer', $this->isThreadDeleted())
-        ));
+        $this->db->insert('frm_posts_deleted', [
+            'deleted_id' => ['integer', $next_id],
+            'deleted_date' => ['integer', $this->getDeletionTimestamp()],
+            'deleted_by' => ['text', $this->getDeletedBy()],
+            'forum_title' => ['text', $this->getForumTitle()],
+            'thread_title' => ['text', $this->getThreadTitle()],
+            'post_title' => ['text', $this->getPostTitle()],
+            'post_message' => ['text', $this->getPostMessage()],
+            'post_date' => ['integer', $this->getPostCreationTimestamp()],
+            'obj_id' => ['integer', $this->getObjId()],
+            'ref_id' => ['integer', $this->getRefId()],
+            'thread_id' => ['integer', $this->getThreadId()],
+            'forum_id' => ['integer', $this->getForumId()],
+            'pos_display_user_id' => ['integer', $this->getPosDisplayUserId()],
+            'pos_usr_alias' => ['text', $this->getPosUserAlias()],
+            'is_thread_deleted' => ['integer', $this->isThreadDeleted()]
+        ]);
     }
 
     /**
@@ -170,19 +169,19 @@ class ilForumPostsDeleted
     }
 
     /**
-     * @return null
+     * @return int
      */
-    public function getDeletedDate()
+    public function getDeletionTimestamp() : int
     {
-        return $this->deleted_date;
+        return $this->deletion_timestamp;
     }
 
     /**
-     * @param null $deleted_date
+     * @param int $timestamp
      */
-    public function setDeletedDate($deleted_date)
+    public function setDeletionTimestamp(int $timestamp)
     {
-        $this->deleted_date = $deleted_date;
+        $this->deletion_timestamp = $timestamp;
     }
 
     /**
@@ -266,19 +265,19 @@ class ilForumPostsDeleted
     }
 
     /**
-     * @return string
+     * @return int
      */
-    public function getPostDate()
+    public function getPostCreationTimestamp(): int
     {
-        return $this->post_date;
+        return $this->post_creation_timestamp;
     }
 
     /**
-     * @param string $post_date
+     * @param int $timestamp
      */
-    public function setPostDate($post_date)
+    public function setPostCreationTimestamp(int $timestamp)
     {
-        $this->post_date = $post_date;
+        $this->post_creation_timestamp = $timestamp;
     }
 
     /**

--- a/Modules/Forum/classes/class.ilForumTopic.php
+++ b/Modules/Forum/classes/class.ilForumTopic.php
@@ -21,9 +21,9 @@ class ilForumTopic
     
     private $subject = '';
     
-    private $createdate = null;
+    private $creation_timestamp = 0;
     
-    private $changedate = null;
+    private $modification_timestamp = 0;
     
     private $num_posts = 0;
     
@@ -94,8 +94,8 @@ class ilForumTopic
         $this->setDisplayUserId((int) $data['thr_display_user_id']);
         $this->setUserAlias($data['thr_usr_alias']);
         $this->setLastPostString($data['last_post_string']);
-        $this->setCreateDate($data['thr_date']);
-        $this->setChangeDate($data['thr_update']);
+        $this->setCreationTimestamp((int) $data['thr_date']);
+        $this->setModificationTimestamp((int) $data['thr_update']);
         $this->setVisits((int) $data['visits']);
         $this->setImportName($data['import_name']);
         $this->setSticky((int) $data['is_sticky']);
@@ -120,25 +120,25 @@ class ilForumTopic
     {
         if ($this->forum_id) {
             $nextId = $this->db->nextId('frm_threads');
-                        
+
             $this->db->insert(
                 'frm_threads',
-                array(
-                'thr_pk'        => array('integer', $nextId),
-                'thr_top_fk'    => array('integer', $this->forum_id),
-                'thr_subject'   => array('text', $this->subject),
-                'thr_display_user_id'    => array('integer', $this->display_user_id),
-                'thr_usr_alias' => array('text', $this->user_alias),
-                'thr_num_posts' => array('integer', $this->num_posts),
-                'thr_last_post' => array('text', $this->last_post_string),
-                'thr_date'      => array('timestamp', $this->createdate),
-                'thr_update'    => array('timestamp', null),
-                'import_name'   => array('text', $this->import_name),
-                'is_sticky'     => array('integer', $this->is_sticky),
-                'is_closed'     => array('integer', $this->is_closed),
-                'avg_rating'    => array('float', $this->average_rating),
-                'thr_author_id' => array('integer', $this->thr_author_id)
-            )
+                [
+                    'thr_pk' => ['integer', $nextId],
+                    'thr_top_fk' => ['integer', $this->forum_id],
+                    'thr_subject' => ['text', $this->subject],
+                    'thr_display_user_id' => ['integer', $this->display_user_id],
+                    'thr_usr_alias' => ['text', $this->user_alias],
+                    'thr_num_posts' => ['integer', $this->num_posts],
+                    'thr_last_post' => ['text', $this->last_post_string],
+                    'thr_date' => ['integer', $this->creation_timestamp],
+                    'thr_update' => ['integer', 0],
+                    'import_name' => ['text', $this->import_name],
+                    'is_sticky' => ['integer', $this->is_sticky],
+                    'is_closed' => ['integer', $this->is_closed],
+                    'avg_rating' => ['float', $this->average_rating],
+                    'thr_author_id' => ['integer', $this->thr_author_id]
+                ]
             );
 
             $this->id = $nextId;
@@ -168,21 +168,21 @@ class ilForumTopic
 					thr_last_post = %s,
 					avg_rating = %s
 				WHERE thr_pk = %s',
-                array('integer', 'text','timestamp', 'integer', 'text', 'float', 'integer'),
-                array(	$this->forum_id,
-                        $this->subject,
-            /*			$this->changedate, */
-                        date('Y-m-d H:i:s'),
-                        $this->num_posts,
-                        $this->last_post_string,
-                        $this->average_rating,
-                        $this->id
-            )
+                ['integer', 'text', 'integer', 'integer', 'text', 'float', 'integer'],
+                [
+                    $this->forum_id,
+                    $this->subject,
+                    time(),
+                    $this->num_posts,
+                    $this->last_post_string,
+                    $this->average_rating,
+                    $this->id
+                ]
             );
-            
+
             return true;
         }
-        
+
         return false;
     }
     
@@ -209,23 +209,23 @@ class ilForumTopic
             $row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT);
 
             if (is_object($row)) {
-                $this->thr_pk           = $row->pos_pk;   // thr_pk = pos_pk ??!??!
-                $this->forum_id         = $row->thr_top_fk;
-                $this->display_user_id  = $row->thr_display_user_id;
-                $this->user_alias       = $row->thr_usr_alias;
-                $this->subject          = html_entity_decode($row->thr_subject);
-                $this->createdate       = $row->thr_date;
-                $this->changedate       = $row->thr_update;
-                $this->import_name      = $row->import_name;
-                $this->num_posts        = $row->thr_num_posts;
+                $this->thr_pk = $row->pos_pk;   // thr_pk = pos_pk ??!??!
+                $this->forum_id = $row->thr_top_fk;
+                $this->display_user_id = $row->thr_display_user_id;
+                $this->user_alias = $row->thr_usr_alias;
+                $this->subject = html_entity_decode($row->thr_subject);
+                $this->creation_timestamp = (int) $row->thr_date;
+                $this->modification_timestamp = (int) $row->thr_update;
+                $this->import_name = $row->import_name;
+                $this->num_posts = $row->thr_num_posts;
                 $this->last_post_string = $row->thr_last_post;
-                $this->visits           = $row->visits;
-                $this->is_sticky        = $row->is_sticky;
-                $this->is_closed        = $row->is_closed;
-                $this->frm_obj_id       = $row->frm_obj_id;
-                $this->average_rating   = $row->avg_rating;
-                $this->thr_author_id    = $row->thr_author_id;
-                
+                $this->visits = $row->visits;
+                $this->is_sticky = $row->is_sticky;
+                $this->is_closed = $row->is_closed;
+                $this->frm_obj_id = $row->frm_obj_id;
+                $this->average_rating = $row->avg_rating;
+                $this->thr_author_id = $row->thr_author_id;
+
                 return true;
             }
             $this->id = 0;
@@ -465,7 +465,7 @@ class ilForumTopic
         $query = '
 			SELECT 			is_author_moderator, pos_author_id, pos_pk, fpt_date, rgt, pos_top_fk, pos_thr_fk, 
 							pos_display_user_id, pos_usr_alias, pos_subject,
-							pos_status, pos_message, pos_date, pos_update,
+							pos_status, pos_message, pos_date, pos_update, pos_activation_date,
 							update_user, pos_cens, pos_cens_com, notify,
 							import_name, fpt_pk, parent_pos, lft, depth,
 							(CASE
@@ -1041,25 +1041,21 @@ class ilForumTopic
     {
         return $this->subject;
     }
-    public function setCreateDate($a_createdate)
+    public function setCreationTimestamp(int $creation_timestamp)
     {
-        $this->createdate = $a_createdate;
+        $this->creation_timestamp = $creation_timestamp;
     }
-    public function getCreateDate()
+    public function getCreationTimestamp() : int
     {
-        return $this->createdate;
+        return $this->creation_timestamp;
     }
-    public function setChangeDate($a_changedate)
+    public function setModificationTimestamp(int $modification_timestamp)
     {
-        if ($a_changedate == '0000-00-00 00:00:00') {
-            $this->changedate = null;
-        } else {
-            $this->changedate = $a_changedate;
-        }
+        $this->modification_timestamp = $modification_timestamp;
     }
-    public function getChangeDate()
+    public function getModificationTimestamp() : int
     {
-        return $this->changedate;
+        return $this->modification_timestamp;
     }
     public function setImportName($a_import_name)
     {
@@ -1303,23 +1299,24 @@ class ilForumTopic
     }
 
     /**
-     * @param integer $thread_id
-     * @return string datetime
+     * @param int $thread_id
+     * @return int 
      */
-    public static function _lookupDate($thread_id)
+    public static function lookupCreationTimestamp($thread_id) : int
     {
         global $DIC;
+
         $ilDB = $DIC->database();
-        
+
         $res = $ilDB->queryF(
             'SELECT thr_date FROM frm_threads WHERE thr_pk = %s',
             array('integer'),
             array((int) $thread_id)
         );
-        
+
         $row = $ilDB->fetchAssoc($res);
-        
-        return $row['thr_date'] ? $row['thr_date'] : '0000-00-00 00:00:00';
+
+        return (int) $row['thr_date'];
     }
 
     /**

--- a/Modules/Forum/classes/class.ilForumTopicTableGUI.php
+++ b/Modules/Forum/classes/class.ilForumTopicTableGUI.php
@@ -311,7 +311,7 @@ class ilForumTopicTableGUI extends ilTable2GUI
 
                 $this->tpl->setVariable(
                     'VAL_LP_DATE',
-                    '<div class="ilWhiteSpaceNowrap">' . ilDatePresentation::formatDate(new ilDateTime($objLastPost->getCreateDate(), IL_CAL_DATETIME)) . '</div>' .
+                    '<div class="ilWhiteSpaceNowrap">' . ilDatePresentation::formatDate(new ilDateTime($objLastPost->getCreationTimestamp(), IL_CAL_UNIX)) . '</div>' .
                     '<div class="ilWhiteSpaceNowrap">' . $this->lng->txt('from') . ' ' . $authorinfo->getLinkedAuthorName() . '</div>'
                 );
             }

--- a/Modules/Forum/classes/class.ilForumXMLParser.php
+++ b/Modules/Forum/classes/class.ilForumXMLParser.php
@@ -251,6 +251,14 @@ class ilForumXMLParser extends ilSaxParser
                 $x['UpdateDate'] = $this->cdata;
                 break;
 
+            case 'CreateDateTs':
+                $x['CreateDateTs'] = $this->cdata;
+                break;
+
+            case 'UpdateDateTs':
+                $x['UpdateDateTs'] = $this->cdata;
+                break;
+
             case 'FileUpload':
                 $x['FileUpload'] = $this->cdata;
                 break;
@@ -361,8 +369,19 @@ class ilForumXMLParser extends ilSaxParser
                     $this->forumThread->setSubject($this->threadArray['Subject']);
                     $this->forumThread->setSticky($this->threadArray['Sticky']);
                     $this->forumThread->setClosed($this->threadArray['Closed']);
-                    $this->forumThread->setCreateDate($this->threadArray['CreateDate']);
-                    $this->forumThread->setChangeDate($this->threadArray['UpdateDate']);
+                    if (isset($this->threadArray['CreateDate'])) {
+                        // TODO: Implement migration depending on JF decision
+                        $this->forumThread->setCreationTimestamp(strtotime($this->threadArray['CreateDate']));
+                    } else {
+                        $this->forumThread->setCreationTimestamp((int) $this->threadArray['CreateDateTs']);
+                    }
+
+                    if (isset($this->threadArray['UpdateDateTs'])) {
+                        // TODO: Implement migration depending on JF decision
+                        $this->forumThread->setModificationTimestamp(strtotime($this->threadArray['UpdateDate']));
+                    } else {
+                        $this->forumThread->setModificationTimestamp((int) $this->threadArray['UpdateDateTs']);
+                    }
                     $this->forumThread->setImportName($this->threadArray['ImportName']);
                     
                     $usr_data = $this->getUserIdAndAlias(
@@ -451,8 +470,19 @@ class ilForumXMLParser extends ilSaxParser
                     $this->forumPost->setThread($this->forumThread);
                     $this->forumPost->setThreadId($this->lastHandledThreadId);
                     $this->forumPost->setForumId($this->lastHandledForumId);
-                    $this->forumPost->setCreateDate($this->postArray['CreateDate']);
-                    $this->forumPost->setChangeDate($this->postArray['UpdateDate']);
+                    if (isset($this->threadArray['CreateDate'])) {
+                        // TODO: Implement migration depending on JF decision
+                        $this->forumPost->setCreationTimestamp(strtotime($this->postArray['CreateDate']));
+                    } else {
+                        $this->forumPost->setCreationTimestamp((int) $this->postArray['CreateDateTs']);
+                    }
+
+                    if (isset($this->threadArray['UpdateDate'])) {
+                        // TODO: Implement migration depending on JF decision
+                        $this->forumPost->setModificationTimestamp(strtotime($this->postArray['UpdateDate']));
+                    } else {
+                        $this->forumPost->setModificationTimestamp((int) $this->postArray['UpdateDateTs']);
+                    }
 
                     $usr_data = $this->getUserIdAndAlias(
                         $this->postArray['UserId'],
@@ -488,16 +518,16 @@ class ilForumXMLParser extends ilSaxParser
                     }
 
                     $postTreeNodeId = $this->db->nextId('frm_posts_tree');
-                    $this->db->insert('frm_posts_tree', array(
-                        'fpt_pk'		=> array('integer', $postTreeNodeId),
-                        'thr_fk'		=> array('integer', $this->lastHandledThreadId),
-                        'pos_fk'		=> array('integer', $this->forumPost->getId()),
-                        'parent_pos'	=> array('integer', $parentId),
-                        'lft'			=> array('integer', $this->postArray['Lft']),
-                        'rgt'			=> array('integer', $this->postArray['Rgt']),
-                        'depth'			=> array('integer', $this->postArray['Depth']),
-                        'fpt_date'		=> array('timestamp', date('Y-m-d H:i:s'))
-                    ));
+                    $this->db->insert('frm_posts_tree', [
+                        'fpt_pk' => ['integer', $postTreeNodeId],
+                        'thr_fk' => ['integer', $this->lastHandledThreadId],
+                        'pos_fk' => ['integer', $this->forumPost->getId()],
+                        'parent_pos' => ['integer', $parentId],
+                        'lft' => ['integer', $this->postArray['Lft']],
+                        'rgt' => ['integer', $this->postArray['Rgt']],
+                        'depth' => ['integer', $this->postArray['Depth']],
+                        'fpt_date' => ['integer', time()]
+                    ]);
 
                     $this->mapping['pos'][$this->postArray['Id']] = $this->forumPost->getId();
                     $this->lastHandledPostId = $this->forumPost->getId();

--- a/Modules/Forum/classes/class.ilForumXMLWriter.php
+++ b/Modules/Forum/classes/class.ilForumXMLWriter.php
@@ -89,8 +89,8 @@ class ilForumXMLWriter extends ilXmlWriter
         $this->xmlElement("ToggleNotification", null, (int) $row->user_toggle_noti);
         $this->xmlElement("LastPost", null, $row->top_last_post);
         $this->xmlElement("Moderator", null, (int) $row->top_mods);
-        $this->xmlElement("CreateDate", null, $row->top_date);
-        $this->xmlElement("UpdateDate", null, $row->top_update);
+        $this->xmlElement("CreateDateTs", null, (int) $row->top_date);
+        $this->xmlElement("UpdateDateTs", null, (int) $row->top_update);
         $this->xmlElement("FileUpload", null, (int) $row->file_upload_allowed);
         $this->xmlElement("UpdateUserId", null, $row->update_user);
         $this->xmlElement("UserId", null, (int) $row->top_usr_id);
@@ -112,8 +112,8 @@ class ilForumXMLWriter extends ilXmlWriter
             $this->xmlElement("AuthorId", null, (int) $row->thr_author_id);
             $this->xmlElement("Alias", null, $row->thr_usr_alias);
             $this->xmlElement("LastPost", null, $row->thr_last_post);
-            $this->xmlElement("CreateDate", null, $row->thr_date);
-            $this->xmlElement("UpdateDate", null, $row->thr_date);
+            $this->xmlElement("CreateDateTs", null, (int) $row->thr_date);
+            $this->xmlElement("UpdateDateTs", null, (int) $row->thr_update);
             $this->xmlElement("ImportName", null, $row->import_name);
             $this->xmlElement("Sticky", null, (int) $row->is_sticky);
             $this->xmlElement("Closed", null, (int) $row->is_closed);
@@ -146,8 +146,8 @@ class ilForumXMLWriter extends ilXmlWriter
                 $this->xmlElement("AuthorId", null, (int) $rowPost->pos_author_id);
                 $this->xmlElement("Alias", null, $rowPost->pos_usr_alias);
                 $this->xmlElement("Subject", null, $rowPost->pos_subject);
-                $this->xmlElement("CreateDate", null, $rowPost->pos_date);
-                $this->xmlElement("UpdateDate", null, $rowPost->pos_update);
+                $this->xmlElement("CreateDateTs", null, (int) $rowPost->pos_date);
+                $this->xmlElement("UpdateDateTs", null, (int) $rowPost->pos_update);
                 $this->xmlElement("UpdateUserId", null, (int) $rowPost->update_user);
                 $this->xmlElement("Censorship", null, (int) $rowPost->pos_cens);
                 $this->xmlElement("CensorshipMessage", null, $rowPost->pos_cens_com);

--- a/Modules/Forum/classes/class.ilObjForum.php
+++ b/Modules/Forum/classes/class.ilObjForum.php
@@ -353,16 +353,15 @@ class ilObjForum extends ilObject
 
         $this->db->replace(
             'frm_thread_access',
-            array(
-                'usr_id'    => array('integer', $a_usr_id),
-                'obj_id'    => array('integer', $this->getId()),
-                'thread_id' => array('integer', $a_thread_id)
-            ),
-            array(
-                'access_last'   => array('integer', time()),
-                'access_old'    => array('integer', isset($data['access_old']) ? (int) $data['access_old'] : 0),
-                'access_old_ts' => array('integer', (int) $data['access_old_ts'])
-            )
+            [
+                'usr_id'    => ['integer', $a_usr_id],
+                'obj_id'    => ['integer', $this->getId()],
+                'thread_id' => ['integer', $a_thread_id]
+            ],
+            [
+                'access_last'   => ['integer', time()],
+                'access_old'    => ['integer', (int) $data['access_old']]
+            ]
         );
 
         return true;
@@ -385,20 +384,6 @@ class ilObjForum extends ilObject
             array('integer'),
             array($a_usr_id)
         );
-
-        $set = $ilDB->query(
-            "SELECT * FROM frm_thread_access " .
-                " WHERE usr_id = " . $ilDB->quote($a_usr_id, "integer")
-        );
-        while ($rec = $ilDB->fetchAssoc($set)) {
-            $ilDB->manipulate(
-                "UPDATE frm_thread_access SET " .
-                    " access_old_ts = " . $ilDB->quote($rec["access_old"], "integer") .
-                    " WHERE usr_id = " . $ilDB->quote($rec["usr_id"], "integer") .
-                    " AND obj_id = " . $ilDB->quote($rec["obj_id"], "integer") .
-                    " AND thread_id = " . $ilDB->quote($rec["thread_id"], "integer")
-            );
-        }
 
         $new_deadline = time() - 60 * 60 * 24 * 7 * ($DIC->settings()->get('frm_store_new') ?
             $DIC->settings()->get('frm_store_new') :
@@ -1026,7 +1011,7 @@ class ilObjForum extends ilObject
 				LEFT JOIN frm_user_read ON (post_id = frm_posts.pos_pk AND frm_user_read.usr_id = %s)
 				LEFT JOIN frm_thread_access ON (frm_thread_access.thread_id = frm_posts.pos_thr_fk AND frm_thread_access.usr_id = %s)
 				WHERE frm_posts.pos_top_fk = %s
-				AND ( (frm_posts.pos_update > frm_thread_access.access_old_ts)
+				AND ( (frm_posts.pos_update > frm_thread_access.access_old)
 						OR (frm_thread_access.access_old IS NULL AND frm_posts.pos_update > %s)
 					)
 				AND frm_posts.pos_author_id != %s 

--- a/Modules/Forum/classes/class.ilObjForumGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumGUI.php
@@ -894,7 +894,7 @@ class ilObjForumGUI extends \ilObjectGUI implements \ilDesktopItemHandling
                         $spanClass = 'moderator_small';
                     }
 
-                    $draft->setPostUpdate($draft->getPostUpdate());
+                    $draft->setPostModificationTimestamp($draft->getPostModificationTimestamp());
 
                     $this->ctrl->setParameter($this, 'backurl', $backurl);
                     $this->ctrl->setParameter($this, 'thr_pk', $node->getThreadId());
@@ -915,7 +915,7 @@ class ilObjForumGUI extends \ilObjectGUI implements \ilDesktopItemHandling
 
                     $tpl->setVariable(
                         'POST_UPDATE_TXT',
-                        $this->lng->txt('edited_on') . ': ' . $frm->convertDate($draft->getPostUpdate()) . ' - ' . strtolower($this->lng->txt('by'))
+                        $this->lng->txt('edited_on') . ': ' . $frm->formatTimestamp($draft->getPostModificationTimestamp()) . ' - ' . strtolower($this->lng->txt('by'))
                     );
                     $tpl->setVariable('UPDATE_AUTHOR', $authorinfo->getLinkedAuthorShortName());
                     if ($authorinfo->getAuthorName(true) && !$this->objProperties->isAnonymized() && !$authorinfo->hasSuffix()) {
@@ -928,7 +928,7 @@ class ilObjForumGUI extends \ilObjectGUI implements \ilDesktopItemHandling
                 $draft->setPostMessage($frm->prepareText($draft->getPostMessage()));
 
                 $tpl->setVariable('SUBJECT', $draft->getPostSubject());
-                $tpl->setVariable('POST_DATE', $frm->convertDate($draft->getPostDate()));
+                $tpl->setVariable('POST_DATE', $frm->formatTimestamp($draft->getPostCreationTimestamp()));
 
                 if (!$node->isCensored() || ($this->objCurrentPost->getId() == $node->getId() && $action === 'censor')) {
                     $spanClass = "";
@@ -1105,7 +1105,7 @@ class ilObjForumGUI extends \ilObjectGUI implements \ilDesktopItemHandling
         }
 
         if ($node->getUpdateUserId() > 0) {
-            $node->setChangeDate($node->getChangeDate());
+            $node->setModificationTimestamp($node->getModificationTimestamp());
 
             $this->ctrl->setParameter($this, 'backurl', $backurl);
             $this->ctrl->setParameter($this, 'thr_pk', $node->getThreadId());
@@ -1127,7 +1127,7 @@ class ilObjForumGUI extends \ilObjectGUI implements \ilDesktopItemHandling
 
             $tpl->setVariable(
                 'POST_UPDATE_TXT',
-                $this->lng->txt('edited_on') . ': ' . $frm->convertDate($node->getChangeDate()) . ' - ' . strtolower($this->lng->txt('by'))
+                $this->lng->txt('edited_on') . ': ' . $frm->formatTimestamp($node->getModificationTimestamp()) . ' - ' . strtolower($this->lng->txt('by'))
             );
             $tpl->setVariable('UPDATE_AUTHOR', $authorinfo->getLinkedAuthorShortName());
             if ($authorinfo->getAuthorName(true) && !$this->objProperties->isAnonymized() && !$authorinfo->hasSuffix()) {
@@ -1157,7 +1157,7 @@ class ilObjForumGUI extends \ilObjectGUI implements \ilDesktopItemHandling
             );
         }
 
-        $tpl->setVariable('POST_DATE', $frm->convertDate($node->getCreateDate()));
+        $tpl->setVariable('POST_DATE', $frm->formatTimestamp($node->getCreationTimestamp()));
 
         if (!$node->isCensored() || ($this->objCurrentPost->getId() == $node->getId() && $action === 'censor')) {
             $spanClass = "";
@@ -2556,7 +2556,7 @@ class ilObjForumGUI extends \ilObjectGUI implements \ilDesktopItemHandling
                     0
                 ));
                 $this->objCurrentPost->setNotification((int) $oReplyEditForm->getInput('notify'));
-                $this->objCurrentPost->setChangeDate(date('Y-m-d H:i:s'));
+                $this->objCurrentPost->setModificationTimestamp(time());
                 $this->objCurrentPost->setUpdateUserId($this->user->getId());
 
                 // edit: update post
@@ -4214,7 +4214,7 @@ class ilObjForumGUI extends \ilObjectGUI implements \ilDesktopItemHandling
             return;
         }
 
-        if (\ilForumTopic::_lookupDate($sourceThreadId) < ilForumTopic::_lookupDate($targetThreadId)) {
+        if (\ilForumTopic::lookupCreationTimestamp($sourceThreadId) < ilForumTopic::lookupCreationTimestamp($targetThreadId)) {
             \ilUtil::sendInfo($this->lng->txt('switch_threads_for_merge'));
         }
 
@@ -5289,7 +5289,7 @@ class ilObjForumGUI extends \ilObjectGUI implements \ilDesktopItemHandling
 
                 $history_date = ilDatePresentation::formatDate(new ilDateTime(
                     $history_instance->getDraftDate(),
-                    IL_CAL_DATETIME
+                    IL_CAL_UNIX
                 ));
                 $this->ctrl->setParameter($this, 'history_id', $history_instance->getHistoryId());
                 $header = $history_date . ' - ' . $history_instance->getPostSubject();

--- a/Modules/Forum/classes/class.ilObjForumListGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumListGUI.php
@@ -157,7 +157,7 @@ class ilObjForumListGUI extends ilObjectListGUI
             );
 
             $lpCont .= $authorinfo->getLinkedAuthorName();
-            $lpCont .= ', ' . ilDatePresentation::formatDate(new ilDateTime($last_post['pos_date'], IL_CAL_DATETIME));
+            $lpCont .= ', ' . ilDatePresentation::formatDate(new ilDateTime($last_post['pos_date'], IL_CAL_UNIX));
 
             $props[] = array(
                 'alert'	=> false,

--- a/Modules/Forum/classes/class.ilObjForumNotificationDataProvider.php
+++ b/Modules/Forum/classes/class.ilObjForumNotificationDataProvider.php
@@ -169,19 +169,19 @@ class ilObjForumNotificationDataProvider implements ilForumNotificationMailData
     }
 
     /**
-     * @return string frm_posts.pos_date
+     * @inheritDoc
      */
-    public function getPostDate()
+    public function getPostCreationTimestamp() : int
     {
-        return $this->objPost->getCreateDate();
+        return $this->objPost->getCreationTimestamp();
     }
 
     /**
-     * @return string frm_posts.pos_update
+     * @inheritDoc
      */
-    public function getPostUpdate()
+    public function getPostModificationTimestamp() : int 
     {
-        return $this->objPost->getChangeDate();
+        return $this->objPost->getModificationTimestamp();
     }
     /**
      * @return bool frm_posts.pos_cens
@@ -192,11 +192,11 @@ class ilObjForumNotificationDataProvider implements ilForumNotificationMailData
     }
 
     /**
-     * @return string frm_posts.pos_cens_date
+     * @inheritDoc
      */
-    public function getPostCensoredDate()
+    public function getPostCensorshipTimestamp() : int
     {
-        return $this->objPost->getCensoredDate();
+        return $this->objPost->getCensorshipTimestamp();
     }
 
     public function getCensorshipComment()

--- a/Modules/Forum/interfaces/interface.ilForumNotificationMailData.php
+++ b/Modules/Forum/interfaces/interface.ilForumNotificationMailData.php
@@ -79,14 +79,14 @@ interface ilForumNotificationMailData
     public function getPostUserName(\ilLanguage $user_lang);
 
     /**
-     * @return string frm_posts.pos_date
+     * @return int
      */
-    public function getPostDate();
+    public function getPostCreationTimestamp() : int;
 
     /**
-     * @return string frm_posts.pos_update
+     * @return int
      */
-    public function getPostUpdate();
+    public function getPostModificationTimestamp() : int;
 
     /**
      * @param \ilLanguage $user_lang
@@ -100,9 +100,9 @@ interface ilForumNotificationMailData
     public function getPostCensored();
 
     /**
-     * @return string frm_posts.pos_cens_date
+     * @return int
      */
-    public function getPostCensoredDate();
+    public function getPostCensorshipTimestamp() : int;
 
     /**
      * @return string

--- a/setup/sql/6_0_hotfixes.php
+++ b/setup/sql/6_0_hotfixes.php
@@ -27,3 +27,87 @@ while ($rec = $ilDB->fetchAssoc($set))
     );
 }
 ?>
+<#3>
+<?php
+// TODO: Implement migration depending on JF decision
+if ($ilDB->tableColumnExists('frm_data', 'top_date')) {
+    
+}
+
+if ($ilDB->tableColumnExists('frm_data', 'top_update')) {
+
+}
+?>
+<#4>
+<?php
+// TODO: Implement migration depending on JF decision
+if ($ilDB->tableColumnExists('frm_drafts_history', 'draft_date')) {
+
+}
+?>
+<#5>
+<?php
+// TODO: Implement migration depending on JF decision
+if ($ilDB->tableColumnExists('frm_posts', 'pos_date')) {
+
+}
+
+if ($ilDB->tableColumnExists('frm_posts', 'pos_update')) {
+
+}
+
+if ($ilDB->tableColumnExists('frm_posts', 'pos_cens_date')) {
+
+}
+
+if ($ilDB->tableColumnExists('frm_posts', 'pos_activation_date')) {
+
+}
+?>
+<#6>
+<?php
+// TODO: Implement migration depending on JF decision
+if ($ilDB->tableColumnExists('frm_posts_deleted', 'deleted_date')) {
+
+}
+
+if ($ilDB->tableColumnExists('frm_posts_deleted', 'post_date')) {
+
+}
+?>
+<#7>
+<?php
+// TODO: Implement migration depending on JF decision
+if ($ilDB->tableColumnExists('frm_posts_drafts', 'post_date')) {
+
+}
+
+if ($ilDB->tableColumnExists('frm_posts_drafts', 'post_update')) {
+
+}
+?>
+<#8>
+<?php
+// TODO: Implement migration depending on JF decision
+if ($ilDB->tableColumnExists('frm_posts_tree', 'fpt_date')) {
+
+}
+?>
+<#9>
+<?php
+// TODO: Implement migration depending on JF decision
+if ($ilDB->tableColumnExists('frm_thread_access', 'access_old_ts')) {
+
+}
+?>
+<#10>
+<?php
+// TODO: Implement migration depending on JF decision
+if ($ilDB->tableColumnExists('frm_threads', 'thr_date')) {
+
+}
+
+if ($ilDB->tableColumnExists('frm_threads', 'thr_update')) {
+
+}
+?>

--- a/setup/sql/6_0_hotfixes.php
+++ b/setup/sql/6_0_hotfixes.php
@@ -95,9 +95,8 @@ if ($ilDB->tableColumnExists('frm_posts_tree', 'fpt_date')) {
 ?>
 <#9>
 <?php
-// TODO: Implement migration depending on JF decision
 if ($ilDB->tableColumnExists('frm_thread_access', 'access_old_ts')) {
-
+    $ilDB->dropTableColumn('frm_thread_access', 'access_old_ts');
 }
 ?>
 <#10>

--- a/xml/ilias_frm_6.xsd
+++ b/xml/ilias_frm_6.xsd
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns = "http://www.w3.org/2001/XMLSchema"
+		targetNamespace = "http://www.ilias.de/Modules/Forum/frm/6"
+		xmlns:t = "http://www.ilias.de/Modules/Forum/frm/6"
+		elementFormDefault = "qualified">
+
+	<element name="Forum">
+		<complexType>
+			<sequence>
+				<element name="Id" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="ObjId" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="Title" type="string" minOccurs="1" maxOccurs="1" />
+				<element name="Description" type="string" minOccurs="1" maxOccurs="1" />
+				<element name="DefaultView" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="Pseudonyms" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="Statistics" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="ThreadRatings" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="Sorting" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="MarkModeratorPosts" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="PostingActivation" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="PresetSubject" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="PresetRe" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="NotificationType" type="string" minOccurs="1" maxOccurs="1" />
+				<element name="ForceNotification" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="ToggleNotification" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="LastPost" type="string" minOccurs="1" maxOccurs="1" />
+				<element name="Moderator" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="CreateDateTs" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="UpdateDateTs" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="FileUpload" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="UpdateUserId" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="UserId" type="integer" minOccurs="1" maxOccurs="1" />				
+				<element ref="t:Thread" minOccurs="0" maxOccurs="unbounded" />
+			</sequence>
+		</complexType>
+	</element>
+
+	<element name="Thread">
+		<complexType>
+			<sequence>
+				<element name="Id" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="Subject" type="string" minOccurs="1" maxOccurs="1" />				
+				<element name="UserId" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="AuthorId" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="Alias" type="string" minOccurs="1" maxOccurs="1" />
+				<element name="LastPost" type="string" minOccurs="1" maxOccurs="1" />
+				<element name="CreateDateTs" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="UpdateDateTs" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="ImportName" type="string" minOccurs="1" maxOccurs="1" />
+				<element name="Sticky" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="Closed" type="integer" minOccurs="1" maxOccurs="1" />
+				<element ref="t:Post" minOccurs="1" maxOccurs="unbounded" />
+			</sequence>
+		</complexType>
+	</element>
+
+	<element name="Post">
+		<complexType>
+			<sequence>
+				<element name="Id" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="UserId" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="AuthorId" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="Alias" type="string" minOccurs="1" maxOccurs="1" />
+				<element name="Subject" type="string" minOccurs="1" maxOccurs="1" />
+				<element name="CreateDateTs" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="UpdateDateTs" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="UpdateUserId" type="integer" minOccurs="1" maxOccurs="1" />				
+				<element name="Censorship" type="boolean" minOccurs="1" maxOccurs="1" />
+				<element name="CensorshipMessage" type="string" minOccurs="1" maxOccurs="1" />
+				<element name="Notification" type="boolean" minOccurs="1" maxOccurs="1" />
+				<element name="ImportName" type="string" minOccurs="1" maxOccurs="1" />
+				<element name="Status" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="Message" type="string" minOccurs="1" maxOccurs="1" />
+				<element ref="t:MessageMediaObjects" minOccurs="0" maxOccurs="1" />
+				<element name="Lft" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="Rgt" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="Depth" type="integer" minOccurs="1" maxOccurs="1" />
+				<element name="ParentId" type="integer" minOccurs="1" maxOccurs="1" />
+				<element ref="t:Attachment" minOccurs="0" maxOccurs="unbounded" />
+			</sequence>
+		</complexType>
+	</element>
+
+	<element name="Attachment">
+		<complexType>
+			<sequence>
+				<element name="Content" type="string" minOccurs="1" maxOccurs="unbounded" />
+			</sequence>
+		</complexType>
+	</element>
+
+	<element name="MessageMediaObjects">
+		<complexType>
+			<sequence>
+				<element name="MediaObject" minOccurs="1" maxOccurs="unbounded" />
+			</sequence>
+		</complexType>
+	</element>
+
+	<element name="MediaObject">
+		<complexType>
+			<attribute name="label" use="required" type="string" />
+			<attribute name="uri" use="required" type="string" />
+		</complexType>
+	</element>
+
+</schema>


### PR DESCRIPTION
This PR migrates all `timestamp` (SQL: datetime) fields of the `Modules/Forum` component to `integer`.

Reason: Storing `Y-m-d H:i:s` information for system events is totally wrong (IMO), because we have no timezone/offset information and it is impossible to determine the exact point in time when the respective events happened.

Related to: https://github.com/ILIAS-eLearning/ILIAS/pull/2423