### PR TITLE
UI/Page: add class for "no mainbar", fixes 27012

### DIFF
--- a/src/UI/Implementation/Component/Layout/Page/Renderer.php
+++ b/src/UI/Implementation/Component/Layout/Page/Renderer.php
@@ -55,9 +55,14 @@ class Renderer extends AbstractComponentRenderer
             }
         }
 
-        $slates_cookie = $_COOKIE[self::COOKIE_NAME_SLATES_ENGAGED];
-        if($slates_cookie && json_decode($slates_cookie,true)['engaged']) {
-            $tpl->touchBlock('slates_engaged');
+        if($component->hasMainbar()) {
+            $slates_cookie = $_COOKIE[self::COOKIE_NAME_SLATES_ENGAGED];
+            if($slates_cookie && json_decode($slates_cookie,true)['engaged']) {
+                $tpl->touchBlock('slates_engaged');
+            }
+        } else {
+            $tpl->touchBlock('no_mainbar');
+            $tpl->touchBlock('nav_no_mainbar');
         }
 
         $tpl->setVariable("TITLE", $component->getTitle());

--- a/src/UI/templates/default/Layout/tpl.standardpage.html
+++ b/src/UI/templates/default/Layout/tpl.standardpage.html
@@ -26,7 +26,7 @@
 
 <body>
 
-	<section class="il-layout-page<!-- BEGIN slates_engaged --> with-mainbar-slates-engaged<!-- END slates_engaged -->">
+	<section class="il-layout-page<!-- BEGIN slates_engaged --> with-mainbar-slates-engaged<!-- END slates_engaged --><!-- BEGIN no_mainbar --> without-mainbar<!-- END no_mainbar -->">
 
 		<header>
 			<div class="header-inner">
@@ -50,7 +50,7 @@
 			{BREADCRUMBS}
 		</nav>
 
-		<nav class="nav il-maincontrols">
+		<nav class="nav il-maincontrols<!-- BEGIN nav_no_mainbar --> without-mainbar<!-- END nav_no_mainbar -->">
 			{MAINBAR}
 		</nav>
 


### PR DESCRIPTION
Happy New Year to you all.

This adds a css-class "without-mainbar" to .il-layout-page and .nav.il-maincontrols in case there is no Mainbar present, as, i.e., in then HTML-Export of the Portfolio (see https://mantis.ilias.de/view.php?id=27012).

@catkrahl may I ask you to please add the according css, so that the main-nav grid-column does not take space/exists in this case? 