### PR TITLE
DateTime: Remove manipulations of global default timezone (except in …

### DIFF
--- a/Services/WorkflowEngine/test/parser/002_StartEvent/StartEvent_MultiStart.bpmn2
+++ b/Services/WorkflowEngine/test/parser/002_StartEvent/StartEvent_MultiStart.bpmn2
@@ -3,7 +3,7 @@
     <bpmn2:process id="StartEvent_Multistart" isExecutable="false">
         <bpmn2:startEvent id="StartEvent_1">
             <bpmn2:timerEventDefinition id="TimerEventDefinition_1">
-                <bpmn2:timeDate xsi:type="bpmn2:tFormalExpression">2014-05-12T12:13:14</bpmn2:timeDate>
+                <bpmn2:timeDate xsi:type="bpmn2:tFormalExpression">2014-05-12T12:13:14Z</bpmn2:timeDate>
             </bpmn2:timerEventDefinition>
         </bpmn2:startEvent>
         <bpmn2:startEvent id="StartEvent_2">

--- a/Services/WorkflowEngine/test/parser/002_StartEvent/StartEvent_MultiStart_goldsample.php
+++ b/Services/WorkflowEngine/test/parser/002_StartEvent/StartEvent_MultiStart_goldsample.php
@@ -43,7 +43,7 @@ require_once './Services/WorkflowEngine/classes/detectors/class.ilEventDetector.
 			$_v_StartEvent_1_detector->setEvent(			"time_passed", 			"time_passed");
 			$_v_StartEvent_1_detector->setEventSubject(	"none", 	"0");
 			$_v_StartEvent_1_detector->setEventContext(	"none", 	"0");
-			$_v_StartEvent_1_detector->setListeningTimeframe(1399889594, 0);
+			$_v_StartEvent_1_detector->setListeningTimeframe(1399896794, 0);
 			$_v_StartEvent_2 = new ilBasicNode($this);
 			$this->addNode($_v_StartEvent_2);
 			$_v_StartEvent_2->setName('$_v_StartEvent_2');

--- a/Services/WorkflowEngine/test/parser/002_StartEvent/StartEvent_Timer_Date.bpmn2
+++ b/Services/WorkflowEngine/test/parser/002_StartEvent/StartEvent_Timer_Date.bpmn2
@@ -3,7 +3,7 @@
     <bpmn2:process id="StartEvent_Timer_Date" isExecutable="false">
         <bpmn2:startEvent id="StartEvent_1">
             <bpmn2:timerEventDefinition id="TimerEventDefinition_1">
-                <bpmn2:timeDate xsi:type="bpmn2:tFormalExpression">2014-05-12T12:13:14</bpmn2:timeDate>
+                <bpmn2:timeDate xsi:type="bpmn2:tFormalExpression">2014-05-12T12:13:14Z</bpmn2:timeDate>
             </bpmn2:timerEventDefinition>
         </bpmn2:startEvent>
     </bpmn2:process>

--- a/Services/WorkflowEngine/test/parser/002_StartEvent/StartEvent_Timer_Date_goldsample.php
+++ b/Services/WorkflowEngine/test/parser/002_StartEvent/StartEvent_Timer_Date_goldsample.php
@@ -34,7 +34,7 @@ require_once './Services/WorkflowEngine/classes/detectors/class.ilEventDetector.
 			$_v_StartEvent_1_detector->setEvent(			"time_passed", 			"time_passed");
 			$_v_StartEvent_1_detector->setEventSubject(	"none", 	"0");
 			$_v_StartEvent_1_detector->setEventContext(	"none", 	"0");
-			$_v_StartEvent_1_detector->setListeningTimeframe(1399889594, 0);
+			$_v_StartEvent_1_detector->setListeningTimeframe(1399896794, 0);
 			}
 		}
 		

--- a/Services/WorkflowEngine/test/parser/002_StartEvent/class.test_002_StartEvent.php
+++ b/Services/WorkflowEngine/test/parser/002_StartEvent/class.test_002_StartEvent.php
@@ -18,8 +18,6 @@ class test_002_StartEvent extends ilWorkflowEngineBaseTest
 
         parent::setUp();
 
-        date_default_timezone_set('Europe/Berlin');
-
         require_once './Services/WorkflowEngine/classes/parser/class.ilBPMN2Parser.php';
     }
 

--- a/Services/WorkflowEngine/test/parser/007_IntermediateCatchEvent/IntermediateCatchEvent_Timer_Simple.bpmn2
+++ b/Services/WorkflowEngine/test/parser/007_IntermediateCatchEvent/IntermediateCatchEvent_Timer_Simple.bpmn2
@@ -11,7 +11,7 @@
             <bpmn2:incoming>SequenceFlow_3</bpmn2:incoming>
             <bpmn2:outgoing>SequenceFlow_4</bpmn2:outgoing>
             <bpmn2:timerEventDefinition id="TimerEventDefinition_1">
-                <bpmn2:timeDate xsi:type="bpmn2:tFormalExpression">2011-03-11T12:13:14</bpmn2:timeDate>
+                <bpmn2:timeDate xsi:type="bpmn2:tFormalExpression">2011-03-11T12:13:14Z</bpmn2:timeDate>
             </bpmn2:timerEventDefinition>
         </bpmn2:intermediateCatchEvent>
         <bpmn2:sequenceFlow id="SequenceFlow_3" name="" sourceRef="StartEvent_1" targetRef="IntermediateCatchEvent_2"/>

--- a/Services/WorkflowEngine/test/parser/007_IntermediateCatchEvent/IntermediateCatchEvent_Timer_Simple_goldsample.php
+++ b/Services/WorkflowEngine/test/parser/007_IntermediateCatchEvent/IntermediateCatchEvent_Timer_Simple_goldsample.php
@@ -32,7 +32,7 @@ require_once './Services/WorkflowEngine/classes/detectors/class.ilSimpleDetector
 			$_v_IntermediateCatchEvent_2_detector->setEvent(			"time_passed", 			"time_passed");
 			$_v_IntermediateCatchEvent_2_detector->setEventSubject(	"none", 	"0");
 			$_v_IntermediateCatchEvent_2_detector->setEventContext(	"none", 	"0");
-			$_v_IntermediateCatchEvent_2_detector->setListeningTimeframe(1299841994, 0);
+			$_v_IntermediateCatchEvent_2_detector->setListeningTimeframe(1299845594, 0);
 			$_v_IntermediateCatchEvent_2->addDetector($_v_IntermediateCatchEvent_2_detector);
 			
 			$_v_IntermediateCatchEvent_2_detector = new ilSimpleDetector($_v_IntermediateCatchEvent_2);

--- a/src/BackgroundTasks/Implementation/Bucket/BasicBucket.php
+++ b/src/BackgroundTasks/Implementation/Bucket/BasicBucket.php
@@ -312,9 +312,7 @@ class BasicBucket implements Bucket
      */
     public function heartbeat()
     {
-        $timezone_identifier = ini_get('date.timezone');
-        date_default_timezone_set($timezone_identifier ? $timezone_identifier : 'UTC');
-        $now = new \DateTime();
+        $now = new \DateTime('now', new \DateTimeZone('UTC'));
         $this->lastHeartbeat = $now->getTimestamp();
     }
 

--- a/tests/Filesystem/Finder/FinderTest.php
+++ b/tests/Filesystem/Finder/FinderTest.php
@@ -195,11 +195,7 @@ class FinderTest extends TestCase
      */
     public function testFinderWillFilterFilesAndFoldersByCreationTimestamp() : Filesystem\Filesystem
     {
-        $timezone = date_default_timezone_get();
-        date_default_timezone_set("Europe/Berlin");
-
-        // 30.03.2019 13:00:00 Europe/Berlin
-        $now = 1553947200;
+        $now = new \DateTimeImmutable('2019-03-30 13:00:00');
 
         $fs = $this->getNestedFileSystemStructure();
         $fs
@@ -211,25 +207,25 @@ class FinderTest extends TestCase
             ->will($this->returnCallback(function ($path) use ($now) {
                 switch ($path) {
                     case'file_1.txt':
-                        return new \DateTimeImmutable('@' . $now);
+                        return $now;
 
                     case 'file_2.mp3':
-                        return new \DateTimeImmutable('@' . ($now + 60 * 60 * 1));
+                        return $now->modify('+1 hour');
 
                     case 'dir_1/file_3.log':
-                        return new \DateTimeImmutable('@' . ($now + 60 * 60 * 2));
+                        return $now->modify('+2 hour');
 
                     case 'dir_1/file_4.php':
-                        return new \DateTimeImmutable('@' . ($now + 60 * 60 * 3));
+                        return $now->modify('+3 hour');
 
                     case 'dir_1/dir_1_1/file_5.cpp':
-                        return new \DateTimeImmutable('@' . ($now + 60 * 60 * 4));
+                        return $now->modify('+4 hour');
 
                     case 'dir_1/dir_1_2/file_6.py':
-                        return new \DateTimeImmutable('@' . ($now + 60 * 60 * 5));
+                        return $now->modify('+5 hour');
 
                     case 'dir_1/dir_1_2/file_7.cpp':
-                        return new \DateTimeImmutable('@' . ($now + 60 * 60 * 6));
+                        return $now->modify('+6 hour');
 
                     default:
                         return new \DateTimeImmutable('now');
@@ -247,8 +243,6 @@ class FinderTest extends TestCase
         $this->assertCount(2, $finder->date('< 2019-03-30 15:00')->files());
         $this->assertCount(3, $finder->date('<= 2019-03-30 15:00')->files());
         $this->assertCount(2, $finder->date('<= 2019-03-30 15:00 - 1minute')->files());
-
-        date_default_timezone_set($timezone);
 
         return $fs;
     }

--- a/tests/Filesystem/Provider/FlySystem/FlySystemFileAccessTest.php
+++ b/tests/Filesystem/Provider/FlySystem/FlySystemFileAccessTest.php
@@ -47,7 +47,7 @@ class FlySystemFileAccessTest extends TestCase
     protected function setUp() : void
     {
         parent::setUp();
-        date_default_timezone_set('Africa/Lagos');
+
         $this->filesystemMock = Mockery::mock(FilesystemInterface::class);
         $this->subject = new FlySystemFileAccess($this->filesystemMock);
     }


### PR DESCRIPTION
…Services/Calendar)

This PR removes all global/default timezone manipulations (except those in `Services/Calendar`) from our code base.

It is related to https://mantis.ilias.de/view.php?id=26951