### PR TITLE
[FIX] 0026720: Tooltips in Online Help not working

### DIFF
--- a/Services/Help/GlobalScreen/classes/class.ilHelpViewLayoutProvider.php
+++ b/Services/Help/GlobalScreen/classes/class.ilHelpViewLayoutProvider.php
@@ -3,20 +3,19 @@
 use ILIAS\GlobalScreen\Scope\Layout\Factory\MainBarModification;
 use ILIAS\GlobalScreen\Scope\Layout\Provider\AbstractModificationProvider;
 use ILIAS\GlobalScreen\Scope\Layout\Provider\ModificationProvider;
+use ILIAS\GlobalScreen\Scope\MainMenu\Factory\hasSymbol;
 use ILIAS\GlobalScreen\ScreenContext\Stack\CalledContexts;
 use ILIAS\GlobalScreen\ScreenContext\Stack\ContextCollection;
-use ILIAS\UI\Component\Component;
 use ILIAS\UI\Component\JavaScriptBindable;
+use ILIAS\UI\Component\Symbol\Symbol;
 
 /**
  * HTML export view layout provider, hides main and meta bar
- *
  * @author <killing@leifos.de>
  */
 class ilHelpViewLayoutProvider extends AbstractModificationProvider implements ModificationProvider
 {
     use \ILIAS\GlobalScreen\Scope\MainMenu\Collector\Renderer\Hasher;
-
 
     /**
      * @inheritDoc
@@ -25,7 +24,6 @@ class ilHelpViewLayoutProvider extends AbstractModificationProvider implements M
     {
         return $this->context_collection->main();
     }
-
 
     /**
      * No main bar in HTML exports
@@ -39,15 +37,16 @@ class ilHelpViewLayoutProvider extends AbstractModificationProvider implements M
             $tt_text = ilHelp::getMainMenuTooltip($p->getInternalIdentifier());
             $tt_text = htmlspecialchars(str_replace(array("\n", "\r"), '', $tt_text));
 
-            $item->addComponentDecorator(static function (Component $component) use ($tt_text) : Component {
-                if ($component instanceof JavaScriptBindable) {
-                    return $component->withAdditionalOnLoadCode(static function ($id) use ($tt_text) : string {
-                        return "il.Tooltip.add('$id', { context:'', my:'bottom center', at:'top center', text:'$tt_text' });";
-                    });
-                }
-
-                return $component;
-            });
+            if ($item instanceof hasSymbol && $item->hasSymbol()) {
+                $item->addSymbolDecorator(static function (Symbol $symbol) use ($tt_text) : Symbol {
+                    if ($symbol instanceof JavaScriptBindable) {
+                        return $symbol->withAdditionalOnLoadCode(static function ($id) use ($tt_text) : string {
+                            return "il.Tooltip.addToNearest('$id', 'button,a', { context:'', my:'bottom center', at:'top center', text:'$tt_text' });";
+                        });
+                    }
+                    return $symbol;
+                });
+            }
         }
 
         ilTooltipGUI::init();

--- a/Services/UIComponent/Tooltip/js/ilTooltip.js
+++ b/Services/UIComponent/Tooltip/js/ilTooltip.js
@@ -17,6 +17,16 @@ il.Tooltip = {
 	},
 
 	/**
+	 * Add a tooltip to the nearest element given
+	 *
+	 * @param string el_id element id
+	 * @param object cfg configuration object
+	 */
+	addToNearest: function (el_id, nearest_element_selector, cfg) {
+		this.tooltips.push({el_id: $("#" + el_id).closest(nearest_element_selector), cfg: cfg});
+	},
+
+	/**
 	 * Add a tooltip
 	 *
 	 * @param string selector

--- a/src/GlobalScreen/Scope/MainMenu/Collector/Renderer/BaseTypeRenderer.php
+++ b/src/GlobalScreen/Scope/MainMenu/Collector/Renderer/BaseTypeRenderer.php
@@ -83,7 +83,13 @@ class BaseTypeRenderer implements TypeRenderer
     protected function getStandardSymbol(isItem $item) : Symbol
     {
         if ($item instanceof hasSymbol && $item->hasSymbol()) {
+            $c = $item->getSymbolDecorator();
+            if ($c !== null) {
+                return $c($item->getSymbol());
+            }
+
             return $item->getSymbol();
+
         }
         if ($item instanceof hasTitle) {
             $abbr = strtoupper(substr($item->getTitle(), 0, 1));

--- a/src/GlobalScreen/Scope/MainMenu/Factory/Item/Complex.php
+++ b/src/GlobalScreen/Scope/MainMenu/Factory/Item/Complex.php
@@ -4,21 +4,20 @@ use Closure;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\AbstractChildItem;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\hasContent;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\hasSymbol;
+use ILIAS\GlobalScreen\Scope\MainMenu\Factory\hasSymbolTrait;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\hasTitle;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\supportsAsynchronousLoading;
+use ILIAS\GlobalScreen\Scope\MainMenu\Factory\SymbolDecoratorTrait;
 use ILIAS\UI\Component\Component;
-use ILIAS\UI\Component\Symbol\Glyph;
-use ILIAS\UI\Component\Symbol\Icon;
-use ILIAS\UI\Component\Symbol\Symbol;
 
 /**
  * Class Complex
- *
  * @author Fabian Schmid <fs@studer-raimann.ch>
  */
 class Complex extends AbstractChildItem implements hasContent, hasTitle, hasSymbol, supportsAsynchronousLoading
 {
-
+    use SymbolDecoratorTrait;
+    use hasSymbolTrait;
     /**
      * @var Closure
      */
@@ -32,38 +31,31 @@ class Complex extends AbstractChildItem implements hasContent, hasTitle, hasSymb
      */
     private $title = '';
     /**
-     * @var Symbol
-     */
-    private $symbol;
-    /**
      * @var bool
      */
     private $supports_async_loading = false;
-
 
     /**
      * @inheritDoc
      */
     public function withContentWrapper(Closure $content_wrapper) : hasContent
     {
-        $clone = clone($this);
+        $clone                  = clone($this);
         $clone->content_wrapper = $content_wrapper;
 
         return $clone;
     }
-
 
     /**
      * @inheritDoc
      */
     public function withContent(Component $ui_component) : hasContent
     {
-        $clone = clone($this);
+        $clone          = clone($this);
         $clone->content = $ui_component;
 
         return $clone;
     }
-
 
     /**
      * @inheritDoc
@@ -79,20 +71,17 @@ class Complex extends AbstractChildItem implements hasContent, hasTitle, hasSymb
         return $this->content;
     }
 
-
     /**
      * @param string $title
-     *
      * @return Complex
      */
     public function withTitle(string $title) : hasTitle
     {
-        $clone = clone($this);
+        $clone        = clone($this);
         $clone->title = $title;
 
         return $clone;
     }
-
 
     /**
      * @inheritDoc
@@ -102,55 +91,16 @@ class Complex extends AbstractChildItem implements hasContent, hasTitle, hasSymb
         return $this->title;
     }
 
-
-    /**
-     * @inheritDoc
-     */
-    public function withSymbol(Symbol $symbol) : hasSymbol
-    {
-        // bugfix mantis 25526: make aria labels mandatory
-        if (($symbol instanceof Icon\Icon || $symbol instanceof Glyph\Glyph)
-            && ($symbol->getAriaLabel() === "")
-        ) {
-            throw new \LogicException("the symbol's aria label MUST be set to ensure accessibility");
-        }
-
-        $clone = clone($this);
-        $clone->symbol = $symbol;
-
-        return $clone;
-    }
-
-
-    /**
-     * @inheritDoc
-     */
-    public function getSymbol() : Symbol
-    {
-        return $this->symbol;
-    }
-
-
-    /**
-     * @inheritDoc
-     */
-    public function hasSymbol() : bool
-    {
-        return $this->symbol instanceof Symbol;
-    }
-
-
     /**
      * @inheritDoc
      */
     public function withSupportsAsynchronousLoading(bool $supported) : supportsAsynchronousLoading
     {
-        $clone = clone($this);
+        $clone                         = clone($this);
         $clone->supports_async_loading = $supported;
 
         return $clone;
     }
-
 
     /**
      * @inheritDoc

--- a/src/GlobalScreen/Scope/MainMenu/Factory/Item/Link.php
+++ b/src/GlobalScreen/Scope/MainMenu/Factory/Item/Link.php
@@ -3,26 +3,21 @@
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\AbstractChildItem;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\hasAction;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\hasSymbol;
+use ILIAS\GlobalScreen\Scope\MainMenu\Factory\hasSymbolTrait;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\hasTitle;
-use ILIAS\UI\Component\Symbol\Symbol;
-use ILIAS\UI\Component\Symbol\Glyph;
-use ILIAS\UI\Component\Symbol\Icon;
+use ILIAS\GlobalScreen\Scope\MainMenu\Factory\SymbolDecoratorTrait;
 
 /**
  * Class Link
- *
  * Attention: This is not the same as the \ILIAS\UI\Component\Link\Link. Please
  * read the difference between GlobalScreen and UI in the README.md of the GlobalScreen Service.
- *
  * @author Fabian Schmid <fs@studer-raimann.ch>
  */
 class Link extends AbstractChildItem implements hasTitle, hasAction, hasSymbol
 {
+    use SymbolDecoratorTrait;
+    use hasSymbolTrait;
 
-    /**
-     * @var Symbol
-     */
-    protected $symbol;
     /**
      * @var bool
      */
@@ -40,20 +35,17 @@ class Link extends AbstractChildItem implements hasTitle, hasAction, hasSymbol
      */
     protected $title = '';
 
-
     /**
      * @param string $title
-     *
      * @return Link
      */
     public function withTitle(string $title) : hasTitle
     {
-        $clone = clone($this);
+        $clone        = clone($this);
         $clone->title = $title;
 
         return $clone;
     }
-
 
     /**
      * @return string
@@ -63,20 +55,17 @@ class Link extends AbstractChildItem implements hasTitle, hasAction, hasSymbol
         return $this->title;
     }
 
-
     /**
      * @param string $alt_text
-     *
      * @return Link
      */
     public function withAltText(string $alt_text) : Link
     {
-        $clone = clone($this);
+        $clone           = clone($this);
         $clone->alt_text = $alt_text;
 
         return $clone;
     }
-
 
     /**
      * @return string
@@ -86,20 +75,17 @@ class Link extends AbstractChildItem implements hasTitle, hasAction, hasSymbol
         return $this->alt_text;
     }
 
-
     /**
      * @param string $action
-     *
      * @return Link
      */
     public function withAction(string $action) : hasAction
     {
-        $clone = clone($this);
+        $clone         = clone($this);
         $clone->action = $action;
 
         return $clone;
     }
-
 
     /**
      * @return string
@@ -109,20 +95,17 @@ class Link extends AbstractChildItem implements hasTitle, hasAction, hasSymbol
         return $this->action;
     }
 
-
     /**
      * @param bool $is_external
-     *
      * @return Link
      */
     public function withIsLinkToExternalAction(bool $is_external) : hasAction
     {
-        $clone = clone $this;
+        $clone                     = clone $this;
         $clone->is_external_action = $is_external;
 
         return $clone;
     }
-
 
     /**
      * @return bool
@@ -132,39 +115,4 @@ class Link extends AbstractChildItem implements hasTitle, hasAction, hasSymbol
         return $this->is_external_action;
     }
 
-
-    /**
-     * @inheritDoc
-     */
-    public function withSymbol(Symbol $symbol) : hasSymbol
-    {
-        // bugfix mantis 25526: make aria labels mandatory
-        if (($symbol instanceof Icon\Icon || $symbol instanceof Glyph\Glyph)
-            && ($symbol->getAriaLabel() === "")) {
-            throw new \LogicException("the symbol's aria label MUST be set to ensure accessibility");
-        }
-
-        $clone = clone $this;
-        $clone->symbol = $symbol;
-
-        return $clone;
-    }
-
-
-    /**
-     * @inheritDoc
-     */
-    public function getSymbol() : Symbol
-    {
-        return $this->symbol;
-    }
-
-
-    /**
-     * @inheritDoc
-     */
-    public function hasSymbol() : bool
-    {
-        return ($this->symbol instanceof Symbol);
-    }
 }

--- a/src/GlobalScreen/Scope/MainMenu/Factory/Item/LinkList.php
+++ b/src/GlobalScreen/Scope/MainMenu/Factory/Item/LinkList.php
@@ -2,19 +2,20 @@
 
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\AbstractChildItem;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\hasSymbol;
+use ILIAS\GlobalScreen\Scope\MainMenu\Factory\hasSymbolTrait;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\hasTitle;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\supportsAsynchronousLoading;
-use ILIAS\UI\Component\Symbol\Symbol;
+use ILIAS\GlobalScreen\Scope\MainMenu\Factory\SymbolDecoratorTrait;
 use InvalidArgumentException;
 
 /**
  * Class LinkList
- *
  * @package ILIAS\GlobalScreen\MainMenu\Item
  */
 class LinkList extends AbstractChildItem implements hasTitle, supportsAsynchronousLoading, hasSymbol
 {
-
+    use SymbolDecoratorTrait;
+    use hasSymbolTrait;
     /**
      * @var string
      */
@@ -27,25 +28,18 @@ class LinkList extends AbstractChildItem implements hasTitle, supportsAsynchrono
      * @var bool
      */
     protected $supports_async_loading = false;
-    /**
-     * @var Symbol
-     */
-    private $symbol;
-
 
     /**
      * @param string $title
-     *
      * @return Link
      */
     public function withTitle(string $title) : hasTitle
     {
-        $clone = clone($this);
+        $clone        = clone($this);
         $clone->title = $title;
 
         return $clone;
     }
-
 
     /**
      * @return string
@@ -55,10 +49,8 @@ class LinkList extends AbstractChildItem implements hasTitle, supportsAsynchrono
         return $this->title;
     }
 
-
     /**
      * @param array|callable|\Generator $links
-     *
      * @return LinkList
      */
     public function withLinks($links) : LinkList
@@ -84,12 +76,11 @@ class LinkList extends AbstractChildItem implements hasTitle, supportsAsynchrono
                 throw new InvalidArgumentException("withLinks only accepts arrays of Links or a callable providing them");
             }
         }
-        $clone = clone($this);
+        $clone        = clone($this);
         $clone->links = $links;
 
         return $clone;
     }
-
 
     /**
      * @return Link[]
@@ -99,18 +90,16 @@ class LinkList extends AbstractChildItem implements hasTitle, supportsAsynchrono
         return $this->links;
     }
 
-
     /**
      * @inheritDoc
      */
     public function withSupportsAsynchronousLoading(bool $supported) : supportsAsynchronousLoading
     {
-        $clone = clone($this);
+        $clone                         = clone($this);
         $clone->supports_async_loading = $supported;
 
         return $clone;
     }
-
 
     /**
      * @inheritDoc
@@ -120,33 +109,4 @@ class LinkList extends AbstractChildItem implements hasTitle, supportsAsynchrono
         return $this->supports_async_loading;
     }
 
-
-    /**
-     * @inheritDoc
-     */
-    public function withSymbol(Symbol $symbol) : hasSymbol
-    {
-        $clone = clone($this);
-        $clone->symbol = $symbol;
-
-        return $clone;
-    }
-
-
-    /**
-     * @inheritDoc
-     */
-    public function getSymbol() : Symbol
-    {
-        return $this->symbol;
-    }
-
-
-    /**
-     * @inheritDoc
-     */
-    public function hasSymbol() : bool
-    {
-        return $this->symbol instanceof Symbol;
-    }
 }

--- a/src/GlobalScreen/Scope/MainMenu/Factory/Item/Lost.php
+++ b/src/GlobalScreen/Scope/MainMenu/Factory/Item/Lost.php
@@ -12,17 +12,17 @@ use ILIAS\GlobalScreen\Scope\MainMenu\Factory\isChild;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\isItem;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\isParent;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\isTopItem;
+use ILIAS\GlobalScreen\Scope\MainMenu\Factory\SymbolDecoratorTrait;
 use ILIAS\UI\Component\Component;
 use ILIAS\UI\Component\Symbol\Symbol;
 
 /**
  * Class Lost
- *
  * @author Fabian Schmid <fs@studer-raimann.ch>
  */
 class Lost extends AbstractBaseItem implements hasContent, isTopItem, isParent, isChild, hasTitle, hasAction, hasSymbol
 {
-
+    use SymbolDecoratorTrait;
     /**
      * @var isChild[]
      */
@@ -36,7 +36,6 @@ class Lost extends AbstractBaseItem implements hasContent, isTopItem, isParent, 
      */
     private $title = '';
 
-
     /**
      * @inheritDoc
      */
@@ -45,7 +44,6 @@ class Lost extends AbstractBaseItem implements hasContent, isTopItem, isParent, 
         parent::__construct($provider_identification);
         $this->parent = new NullIdentification();
     }
-
 
     /**
      * @inheritDoc
@@ -57,7 +55,6 @@ class Lost extends AbstractBaseItem implements hasContent, isTopItem, isParent, 
         return $this;
     }
 
-
     /**
      * @inheritDoc
      */
@@ -65,7 +62,6 @@ class Lost extends AbstractBaseItem implements hasContent, isTopItem, isParent, 
     {
         return $this->title;
     }
-
 
     /**
      * @inheritDoc
@@ -75,7 +71,6 @@ class Lost extends AbstractBaseItem implements hasContent, isTopItem, isParent, 
         return $this;
     }
 
-
     /**
      * @inheritDoc
      */
@@ -83,7 +78,6 @@ class Lost extends AbstractBaseItem implements hasContent, isTopItem, isParent, 
     {
         return $this;
     }
-
 
     /**
      * @inheritDoc
@@ -95,7 +89,6 @@ class Lost extends AbstractBaseItem implements hasContent, isTopItem, isParent, 
         return $DIC->ui()->factory()->legacy("");
     }
 
-
     /**
      * @inheritDoc
      */
@@ -106,7 +99,6 @@ class Lost extends AbstractBaseItem implements hasContent, isTopItem, isParent, 
         return $this;
     }
 
-
     /**
      * @inheritDoc
      */
@@ -115,7 +107,6 @@ class Lost extends AbstractBaseItem implements hasContent, isTopItem, isParent, 
         return $this->parent instanceof isParent;
     }
 
-
     /**
      * @inheritDoc
      */
@@ -123,7 +114,6 @@ class Lost extends AbstractBaseItem implements hasContent, isTopItem, isParent, 
     {
         return $this->parent;
     }
-
 
     /**
      * @inheritDoc
@@ -135,7 +125,6 @@ class Lost extends AbstractBaseItem implements hasContent, isTopItem, isParent, 
         return $this;
     }
 
-
     /**
      * @inheritDoc
      */
@@ -143,7 +132,6 @@ class Lost extends AbstractBaseItem implements hasContent, isTopItem, isParent, 
     {
         return $this->children;
     }
-
 
     /**
      * @inheritDoc
@@ -155,7 +143,6 @@ class Lost extends AbstractBaseItem implements hasContent, isTopItem, isParent, 
         return $this;
     }
 
-
     /**
      * @inheritDoc
      */
@@ -166,7 +153,6 @@ class Lost extends AbstractBaseItem implements hasContent, isTopItem, isParent, 
         return $this;
     }
 
-
     /**
      * @inheritDoc
      */
@@ -174,7 +160,6 @@ class Lost extends AbstractBaseItem implements hasContent, isTopItem, isParent, 
     {
         return count($this->children) > 0;
     }
-
 
     /**
      * @inheritDoc
@@ -185,7 +170,6 @@ class Lost extends AbstractBaseItem implements hasContent, isTopItem, isParent, 
         return $this;
     }
 
-
     /**
      * @inheritDoc
      */
@@ -193,7 +177,6 @@ class Lost extends AbstractBaseItem implements hasContent, isTopItem, isParent, 
     {
         return "#";
     }
-
 
     /**
      * @inheritDoc
@@ -204,7 +187,6 @@ class Lost extends AbstractBaseItem implements hasContent, isTopItem, isParent, 
         return $this;
     }
 
-
     /**
      * @inheritDoc
      */
@@ -212,7 +194,6 @@ class Lost extends AbstractBaseItem implements hasContent, isTopItem, isParent, 
     {
         return false;
     }
-
 
     /**
      * @inheritDoc
@@ -222,7 +203,6 @@ class Lost extends AbstractBaseItem implements hasContent, isTopItem, isParent, 
         return $this;
     }
 
-
     /**
      * @inheritDoc
      */
@@ -230,7 +210,6 @@ class Lost extends AbstractBaseItem implements hasContent, isTopItem, isParent, 
     {
         return null;
     }
-
 
     /**
      * @inheritDoc

--- a/src/GlobalScreen/Scope/MainMenu/Factory/Item/RepositoryLink.php
+++ b/src/GlobalScreen/Scope/MainMenu/Factory/Item/RepositoryLink.php
@@ -2,20 +2,24 @@
 
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\AbstractChildItem;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\hasAction;
+use ILIAS\GlobalScreen\Scope\MainMenu\Factory\hasSymbol;
+use ILIAS\GlobalScreen\Scope\MainMenu\Factory\hasSymbolTrait;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\hasTitle;
+use ILIAS\GlobalScreen\Scope\MainMenu\Factory\SymbolDecoratorTrait;
+use ILIAS\UI\Component\Symbol\Symbol;
 use ilLink;
 use ilObject2;
 
 /**
  * Class Link
- *
  * Attention: This is not the same as the \ILIAS\UI\Component\Link\Link. Please
  * read the difference between GlobalScreen and UI in the README.md of the GlobalScreen Service.
- *
  * @author Fabian Schmid <fs@studer-raimann.ch>
  */
-class RepositoryLink extends AbstractChildItem implements hasTitle, hasAction
+class RepositoryLink extends AbstractChildItem implements hasTitle, hasAction, hasSymbol
 {
+    use hasSymbolTrait;
+    use SymbolDecoratorTrait;
 
     /**
      * @var int
@@ -30,20 +34,17 @@ class RepositoryLink extends AbstractChildItem implements hasTitle, hasAction
      */
     protected $title = '';
 
-
     /**
      * @param string $title
-     *
      * @return RepositoryLink
      */
     public function withTitle(string $title) : hasTitle
     {
-        $clone = clone($this);
+        $clone        = clone($this);
         $clone->title = $title;
 
         return $clone;
     }
-
 
     /**
      * @return string
@@ -53,20 +54,17 @@ class RepositoryLink extends AbstractChildItem implements hasTitle, hasAction
         return $this->title !== null ? $this->title : ($this->getRefId() > 0 ? ilObject2::_lookupTitle(ilObject2::_lookupObjectId($this->getRefId())) : "");
     }
 
-
     /**
      * @param string $alt_text
-     *
      * @return RepositoryLink
      */
     public function withAltText(string $alt_text) : RepositoryLink
     {
-        $clone = clone($this);
+        $clone           = clone($this);
         $clone->alt_text = $alt_text;
 
         return $clone;
     }
-
 
     /**
      * @return string
@@ -76,7 +74,6 @@ class RepositoryLink extends AbstractChildItem implements hasTitle, hasAction
         return $this->alt_text;
     }
 
-
     /**
      * @return string
      */
@@ -85,34 +82,34 @@ class RepositoryLink extends AbstractChildItem implements hasTitle, hasAction
         return ilLink::_getLink($this->ref_id);
     }
 
-
     /**
      * @param string $action
-     *
      * @return hasAction
      */
     public function withAction(string $action) : hasAction
     {
-        $clone = clone $this;
+        $clone         = clone $this;
         $clone->ref_id = (int) $action;
 
         return $clone;
     }
 
-
     /**
      * @param int $ref_id
-     *
      * @return RepositoryLink
      */
     public function withRefId(int $ref_id) : RepositoryLink
     {
-        $clone = clone $this;
+        $clone         = clone $this;
         $clone->ref_id = $ref_id;
 
         return $clone;
     }
 
+    public function getSymbol() : Symbol
+    {
+        return $this->symbol;
+    }
 
     /**
      * @return int
@@ -122,7 +119,6 @@ class RepositoryLink extends AbstractChildItem implements hasTitle, hasAction
         return $this->ref_id;
     }
 
-
     /**
      * @inheritDoc
      */
@@ -131,7 +127,6 @@ class RepositoryLink extends AbstractChildItem implements hasTitle, hasAction
         throw new \LogicException("Repository-Links are always internal");
     }
 
-
     /**
      * @inheritDoc
      */
@@ -139,4 +134,5 @@ class RepositoryLink extends AbstractChildItem implements hasTitle, hasAction
     {
         return false;
     }
+
 }

--- a/src/GlobalScreen/Scope/MainMenu/Factory/SymbolDecoratorTrait.php
+++ b/src/GlobalScreen/Scope/MainMenu/Factory/SymbolDecoratorTrait.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types=1);
+
+namespace ILIAS\GlobalScreen\Scope\MainMenu\Factory;
+
+use Closure;
+use ILIAS\UI\Component\Component;
+use ILIAS\UI\Component\Symbol\Symbol;
+use LogicException;
+use ReflectionFunction;
+use ReflectionType;
+
+/**
+ * Trait SymbolDecoratorTrait
+ * @package ILIAS\GlobalScreen\Scope
+ * @author  Fabian Schmid <fs@studer-raimann.ch>
+ */
+trait SymbolDecoratorTrait
+{
+
+    /**
+     * @var Closure
+     */
+    private $symbol_decorator;
+
+    /**
+     * @param Closure $symbol_decorator
+     * @return hasSymbol
+     */
+    public function addSymbolDecorator(Closure $symbol_decorator) : hasSymbol
+    {
+        if (!$this->checkClosure($symbol_decorator)) {
+            throw new LogicException('first argument of closure must be type-hinted to \ILIAS\UI\Component\Symbol\Symbol');
+        }
+        if ($this->symbol_decorator instanceof Closure) {
+            $existing               = $this->symbol_decorator;
+            $this->symbol_decorator = static function (Symbol $c) use ($symbol_decorator, $existing) : Symbol {
+                $component = $existing();
+
+                return $symbol_decorator($component);
+            };
+        } else {
+            $this->symbol_decorator = $symbol_decorator;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Closure|null
+     */
+    public function getSymbolDecorator() : ?Closure
+    {
+        return $this->symbol_decorator;
+    }
+
+    private function checkClosure(Closure $c) : bool
+    {
+        try {
+            $r = new ReflectionFunction($c);
+            if (count($r->getParameters()) !== 1) {
+                return false;
+            }
+            $first_param_type = $r->getParameters()[0]->getType();
+            if ($first_param_type instanceof ReflectionType && $first_param_type->getName() !== Symbol::class) {
+                return false;
+            }
+            $return_type = $r->getReturnType();
+            if ($return_type === null) {
+                return false;
+            }
+            if ($return_type->getName() !== Symbol::class) {
+                return false;
+            }
+
+            return true;
+        } catch (\Throwable $i) {
+            return false;
+        }
+    }
+}

--- a/src/GlobalScreen/Scope/MainMenu/Factory/TopItem/TopLinkItem.php
+++ b/src/GlobalScreen/Scope/MainMenu/Factory/TopItem/TopLinkItem.php
@@ -3,24 +3,20 @@
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\AbstractBaseItem;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\hasAction;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\hasSymbol;
+use ILIAS\GlobalScreen\Scope\MainMenu\Factory\hasSymbolTrait;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\hasTitle;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\isTopItem;
-use ILIAS\UI\Component\Symbol\Symbol;
-use ILIAS\UI\Component\Symbol\Glyph;
-use ILIAS\UI\Component\Symbol\Icon;
+use ILIAS\GlobalScreen\Scope\MainMenu\Factory\SymbolDecoratorTrait;
 
 /**
  * Class TopLinkItem
- *
  * @author Fabian Schmid <fs@studer-raimann.ch>
  */
 class TopLinkItem extends AbstractBaseItem implements hasTitle, hasAction, isTopItem, hasSymbol
 {
+    use SymbolDecoratorTrait;
+    use hasSymbolTrait;
 
-    /**
-     * @var Symbol
-     */
-    protected $symbol;
     /**
      * @var bool
      */
@@ -34,20 +30,17 @@ class TopLinkItem extends AbstractBaseItem implements hasTitle, hasAction, isTop
      */
     protected $action = '';
 
-
     /**
      * @param string $title
-     *
      * @return hasTitle|TopLinkItem
      */
     public function withTitle(string $title) : hasTitle
     {
-        $clone = clone($this);
+        $clone        = clone($this);
         $clone->title = $title;
 
         return $clone;
     }
-
 
     /**
      * @return string
@@ -57,20 +50,17 @@ class TopLinkItem extends AbstractBaseItem implements hasTitle, hasAction, isTop
         return $this->title;
     }
 
-
     /**
      * @param string $action
-     *
      * @return hasAction|TopLinkItem
      */
     public function withAction(string $action) : hasAction
     {
-        $clone = clone($this);
+        $clone         = clone($this);
         $clone->action = $action;
 
         return $clone;
     }
-
 
     /**
      * @return string
@@ -80,20 +70,17 @@ class TopLinkItem extends AbstractBaseItem implements hasTitle, hasAction, isTop
         return $this->action;
     }
 
-
     /**
      * @param bool $is_external
-     *
      * @return TopLinkItem
      */
     public function withIsLinkToExternalAction(bool $is_external) : hasAction
     {
-        $clone = clone $this;
+        $clone                     = clone $this;
         $clone->is_external_action = $is_external;
 
         return $clone;
     }
-
 
     /**
      * @return bool
@@ -103,39 +90,4 @@ class TopLinkItem extends AbstractBaseItem implements hasTitle, hasAction, isTop
         return $this->is_external_action;
     }
 
-
-    /**
-     * @inheritDoc
-     */
-    public function withSymbol(Symbol $symbol) : hasSymbol
-    {
-        // bugfix mantis 25526: make aria labels mandatory
-        if (($symbol instanceof Icon\Icon || $symbol instanceof Glyph\Glyph)
-            && ($symbol->getAriaLabel() === "")) {
-            throw new \LogicException("the symbol's aria label MUST be set to ensure accessibility");
-        }
-
-        $clone = clone $this;
-        $clone->symbol = $symbol;
-
-        return $clone;
-    }
-
-
-    /**
-     * @inheritDoc
-     */
-    public function getSymbol() : Symbol
-    {
-        return $this->symbol;
-    }
-
-
-    /**
-     * @inheritDoc
-     */
-    public function hasSymbol() : bool
-    {
-        return $this->symbol instanceof Symbol;
-    }
 }

--- a/src/GlobalScreen/Scope/MainMenu/Factory/TopItem/TopParentItem.php
+++ b/src/GlobalScreen/Scope/MainMenu/Factory/TopItem/TopParentItem.php
@@ -2,43 +2,35 @@
 
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\AbstractParentItem;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\hasSymbol;
+use ILIAS\GlobalScreen\Scope\MainMenu\Factory\hasSymbolTrait;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\hasTitle;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\isTopItem;
-use ILIAS\UI\Component\Symbol\Glyph;
-use ILIAS\UI\Component\Symbol\Icon;
-use ILIAS\UI\Component\Symbol\Symbol;
+use ILIAS\GlobalScreen\Scope\MainMenu\Factory\SymbolDecoratorTrait;
 
 /**
  * Class TopParentItem
- *
  * @author Fabian Schmid <fs@studer-raimann.ch>
  */
 class TopParentItem extends AbstractParentItem implements isTopItem, hasTitle, hasSymbol
 {
-
+    use SymbolDecoratorTrait;
+    use hasSymbolTrait;
     /**
      * @var string
      */
     protected $title = '';
-    /**
-     * @var Symbol
-     */
-    protected $symbol;
-
 
     /**
      * @param string $title
-     *
      * @return TopParentItem
      */
     public function withTitle(string $title) : hasTitle
     {
-        $clone = clone($this);
+        $clone        = clone($this);
         $clone->title = $title;
 
         return $clone;
     }
-
 
     /**
      * @inheritDoc
@@ -48,40 +40,4 @@ class TopParentItem extends AbstractParentItem implements isTopItem, hasTitle, h
         return $this->title;
     }
 
-
-    /**
-     * @inheritDoc
-     */
-    public function withSymbol(Symbol $symbol) : hasSymbol
-    {
-        // bugfix mantis 25526: make aria labels mandatory
-        if (($symbol instanceof Icon\Icon || $symbol instanceof Glyph\Glyph)
-            && ($symbol->getAriaLabel() === "")
-        ) {
-            throw new \LogicException("the symbol's aria label MUST be set to ensure accessibility");
-        }
-
-        $clone = clone($this);
-        $clone->symbol = $symbol;
-
-        return $clone;
-    }
-
-
-    /**
-     * @inheritDoc
-     */
-    public function getSymbol() : Symbol
-    {
-        return $this->symbol;
-    }
-
-
-    /**
-     * @inheritDoc
-     */
-    public function hasSymbol() : bool
-    {
-        return $this->symbol instanceof Symbol;
-    }
 }

--- a/src/GlobalScreen/Scope/MainMenu/Factory/hasSymbol.php
+++ b/src/GlobalScreen/Scope/MainMenu/Factory/hasSymbol.php
@@ -1,12 +1,11 @@
 <?php namespace ILIAS\GlobalScreen\Scope\MainMenu\Factory;
 
+use Closure;
 use ILIAS\UI\Component\Symbol\Symbol;
 
 /**
  * Interface hasSymbol
- *
  * Methods for Entries with Symbols
- *
  * @author Fabian Schmid <fs@studer-raimann.ch>
  */
 interface hasSymbol extends isItem
@@ -14,20 +13,28 @@ interface hasSymbol extends isItem
 
     /**
      * @param Symbol $symbol
-     *
      * @return hasSymbol
      */
     public function withSymbol(Symbol $symbol) : hasSymbol;
-
 
     /**
      * @return Symbol
      */
     public function getSymbol() : Symbol;
 
-
     /**
      * @return bool
      */
     public function hasSymbol() : bool;
+
+    /**
+     * @param Closure $symbol_decorator
+     * @return hasSymbol
+     */
+    public function addSymbolDecorator(Closure $symbol_decorator) : hasSymbol;
+
+    /**
+     * @return Closure|null
+     */
+    public function getSymbolDecorator() : ?Closure;
 }

--- a/src/GlobalScreen/Scope/MainMenu/Factory/hasSymbolTrait.php
+++ b/src/GlobalScreen/Scope/MainMenu/Factory/hasSymbolTrait.php
@@ -1,0 +1,48 @@
+<?php namespace ILIAS\GlobalScreen\Scope\MainMenu\Factory;
+
+use ILIAS\UI\Component\Symbol\Symbol;
+
+/**
+ * Trait hasSymbolTrait
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+trait hasSymbolTrait
+{
+    /**
+     * @var Symbol
+     */
+    protected $symbol;
+
+    /**
+     * @inheritDoc
+     */
+    public function withSymbol(Symbol $symbol) : hasSymbol
+    {
+        // bugfix mantis 25526: make aria labels mandatory
+        if (($symbol instanceof Icon\Icon || $symbol instanceof Glyph\Glyph)
+            && ($symbol->getAriaLabel() === "")) {
+            throw new \LogicException("the symbol's aria label MUST be set to ensure accessibility");
+        }
+
+        $clone         = clone $this;
+        $clone->symbol = $symbol;
+
+        return $clone;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSymbol() : Symbol
+    {
+        return $this->symbol;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hasSymbol() : bool
+    {
+        return $this->symbol instanceof Symbol;
+    }
+}

--- a/src/GlobalScreen/Scope/Tool/Factory/AbstractBaseTool.php
+++ b/src/GlobalScreen/Scope/Tool/Factory/AbstractBaseTool.php
@@ -4,15 +4,15 @@ namespace ILIAS\GlobalScreen\Scope\Tool\Factory;
 
 use Closure;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\AbstractParentItem;
+use ILIAS\GlobalScreen\Scope\MainMenu\Factory\SymbolDecoratorTrait;
 
 /**
  * Class AbstractBaseTool
- *
  * @author Fabian Schmid <fs@studer-raimann.ch>
  */
 abstract class AbstractBaseTool extends AbstractParentItem implements isToolItem
 {
-
+    use SymbolDecoratorTrait;
     /**
      * @var Closure
      */
@@ -22,18 +22,16 @@ abstract class AbstractBaseTool extends AbstractParentItem implements isToolItem
      */
     protected $initially_hidden = false;
 
-
     /**
      * @inheritDoc
      */
     public function withInitiallyHidden(bool $initially_hidden) : isToolItem
     {
-        $clone = clone($this);
+        $clone                   = clone($this);
         $clone->initially_hidden = $initially_hidden;
 
         return $clone;
     }
-
 
     /**
      * @inheritDoc
@@ -43,18 +41,16 @@ abstract class AbstractBaseTool extends AbstractParentItem implements isToolItem
         return $this->initially_hidden;
     }
 
-
     /**
      * @inheritDoc
      */
     public function withCloseCallback(Closure $close_callback) : isToolItem
     {
-        $clone = clone($this);
+        $clone                 = clone($this);
         $clone->close_callback = $close_callback;
 
         return $clone;
     }
-
 
     /**
      * @inheritDoc
@@ -63,7 +59,6 @@ abstract class AbstractBaseTool extends AbstractParentItem implements isToolItem
     {
         return $this->close_callback;
     }
-
 
     /**
      * @inheritDoc

--- a/src/GlobalScreen/Scope/Tool/Factory/TreeTool.php
+++ b/src/GlobalScreen/Scope/Tool/Factory/TreeTool.php
@@ -5,6 +5,7 @@ namespace ILIAS\GlobalScreen\Scope\Tool\Factory;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\hasSymbol;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\hasTitle;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\isTopItem;
+use ILIAS\GlobalScreen\Scope\MainMenu\Factory\SymbolDecoratorTrait;
 use ILIAS\UI\Component\Symbol\Glyph;
 use ILIAS\UI\Component\Symbol\Icon;
 use ILIAS\UI\Component\Symbol\Symbol;
@@ -12,12 +13,11 @@ use ILIAS\UI\Component\Tree\Tree;
 
 /**
  * Class TreeTool
- *
  * @author Fabian Schmid <fs@studer-raimann.ch>
  */
 class TreeTool extends AbstractBaseTool implements isTopItem, hasSymbol, isToolItem
 {
-
+    use SymbolDecoratorTrait;
     /**
      * @var
      */
@@ -31,20 +31,17 @@ class TreeTool extends AbstractBaseTool implements isTopItem, hasSymbol, isToolI
      */
     protected $title;
 
-
     /**
      * @param string $title
-     *
      * @return TreeTool
      */
     public function withTitle(string $title) : hasTitle
     {
-        $clone = clone($this);
+        $clone        = clone($this);
         $clone->title = $title;
 
         return $clone;
     }
-
 
     /**
      * @return string
@@ -53,7 +50,6 @@ class TreeTool extends AbstractBaseTool implements isTopItem, hasSymbol, isToolI
     {
         return $this->title;
     }
-
 
     /**
      * @inheritDoc
@@ -67,24 +63,22 @@ class TreeTool extends AbstractBaseTool implements isTopItem, hasSymbol, isToolI
             throw new \LogicException("the symbol's aria label MUST be set to ensure accessibility");
         }
 
-        $clone = clone($this);
+        $clone         = clone($this);
         $clone->symbol = $symbol;
 
         return $clone;
     }
-
 
     /**
      * @inheritDoc
      */
     public function withTree(Tree $tree) : TreeTool
     {
-        $clone = clone($this);
+        $clone       = clone($this);
         $clone->tree = $tree;
 
         return $clone;
     }
-
 
     /**
      * @return Tree
@@ -94,7 +88,6 @@ class TreeTool extends AbstractBaseTool implements isTopItem, hasSymbol, isToolI
         return $this->tree;
     }
 
-
     /**
      * @inheritDoc
      */
@@ -102,7 +95,6 @@ class TreeTool extends AbstractBaseTool implements isTopItem, hasSymbol, isToolI
     {
         return $this->symbol;
     }
-
 
     /**
      * @inheritDoc

--- a/src/UI/Component/Symbol/Glyph/Glyph.php
+++ b/src/UI/Component/Symbol/Glyph/Glyph.php
@@ -10,7 +10,7 @@ use ILIAS\UI\Component\Clickable;
 /**
  * This describes how a glyph could be modified during construction of UI.
  */
-interface Glyph extends \ILIAS\UI\Component\Symbol\Symbol, \ILIAS\UI\Component\JavaScriptBindable, Clickable
+interface Glyph extends \ILIAS\UI\Component\Symbol\Symbol, Clickable
 {
     // Types of glyphs:
     const SETTINGS = "settings";

--- a/src/UI/Component/Symbol/Symbol.php
+++ b/src/UI/Component/Symbol/Symbol.php
@@ -3,9 +3,11 @@
 
 namespace ILIAS\UI\Component\Symbol;
 
+use ILIAS\UI\Component\JavaScriptBindable;
+
 /**
  * This describes a symbol.
  */
-interface Symbol extends \ILIAS\UI\Component\Component
+interface Symbol extends \ILIAS\UI\Component\Component, JavaScriptBindable
 {
 }

--- a/src/UI/Implementation/Component/Symbol/Icon/Icon.php
+++ b/src/UI/Implementation/Component/Symbol/Icon/Icon.php
@@ -5,10 +5,12 @@ namespace ILIAS\UI\Implementation\Component\Symbol\Icon;
 
 use ILIAS\UI\Component as C;
 use ILIAS\UI\Implementation\Component\ComponentHelper;
+use ILIAS\UI\Implementation\Component\JavaScriptBindable;
 
 abstract class Icon implements C\Symbol\Icon\Icon
 {
     use ComponentHelper;
+    use JavaScriptBindable;
 
     /**
      * @var	string

--- a/src/UI/Implementation/Component/Symbol/Icon/Renderer.php
+++ b/src/UI/Implementation/Component/Symbol/Icon/Renderer.php
@@ -43,6 +43,14 @@ class Renderer extends AbstractComponentRenderer
             $tpl->setVariable("DISABLED", " disabled");
         }
 
+        $id = $this->bindJavaScript($component);
+
+        if ($id !== null) {
+            $tpl->setCurrentBlock("with_id");
+            $tpl->setVariable("ID", $id);
+            $tpl->parseCurrentBlock();
+        }
+
         return $tpl->get();
     }
 

--- a/src/UI/ROADMAP.md
+++ b/src/UI/ROADMAP.md
@@ -167,6 +167,14 @@ block-element, respectively an UI-Component on its own.
 
 ## Long Term
 
+### Tooltips and Tooltippable
+
+Tooltips are currently not yet implemented as UI components. Since 
+probably many UI components have or will have tooltips, the introduction
+ of a tooltippable interface should be discussed. This interface can
+  easily receive tooltips (either as a UI component or much simpler as
+   text) and can be implemented for all relevant UI components.
+
 ### Remove special case for UI-demo in `Implement\Layout\Page\Renderer::setHeaderVars`
 
 Currently `Implement\Layout\Page\Renderer::setHeaderVars` contains a special

--- a/src/UI/templates/default/Symbol/tpl.icon.html
+++ b/src/UI/templates/default/Symbol/tpl.icon.html
@@ -1,4 +1,4 @@
-<div class="icon {NAME} {SIZE}{DISABLED}{OUTLINED}" aria-label="{ARIA_LABEL}">
+<div class="icon {NAME} {SIZE}{DISABLED}{OUTLINED}" aria-label="{ARIA_LABEL}"<!-- BEGIN with_id --> id="{ID}"<!-- END with_id -->>
 <!-- BEGIN customimage -->
 	<img src="{CUSTOMIMAGE}" />
 <!-- END customimage -->


### PR DESCRIPTION
Hi @alex40724 @Amstutz and @klees 

this is a proposal for (partial) correction of https://mantis.ilias.de/view.php?id=26720. partial, because now the correct tooltip texts should be inserted.

In order to be able to attach tooltips to MainBar items, an extension to the GlobalScreen (introduction to SymbolDecorator) and to the UI component Icon (extension to JavaScriptBindable) as well as to ilTooltip.js/ilHelpViewLayoutProvider is currently required:

- Conversion ilHelpViewLayoutProvider: https://github.com/ILIAS-eLearning/ILIAS/compare/release_6...studer-raimann:fix/0026720/6/tooltips#diff-9aeb11dd1290c52122830e357718c93bR40
- Extension ilTooltip.js: The tooltips should not be attached directly to the glyph/icon, but for example to the button: https://github.com/ILIAS-eLearning/ILIAS/compare/release_6...studer-raimann:fix/0026720/6/tooltips#diff-e17e4660c0787d60502ec7150c4b9cf2R25
- Implementation JavaScriptBindable in icon: https://github.com/ILIAS-eLearning/ILIAS/compare/release_6...studer-raimann:fix/0026720/6/tooltips#diff-975f02c06d3867cc7efdd007eeeceaebR46

Since tooltips should be integrated into the UI components more easily and better in the future, here is an entry in the roadmap of the UI service: https://github.com/ILIAS-eLearning/ILIAS/compare/release_6...studer-raimann:fix/0026720/6/tooltips#diff-03187698ad133a5bd55a354aa296e112R170

