### PR TITLE
Help: Only attach tooltips if available

### DIFF
--- a/Services/Help/GlobalScreen/classes/class.ilHelpViewLayoutProvider.php
+++ b/Services/Help/GlobalScreen/classes/class.ilHelpViewLayoutProvider.php
@@ -37,7 +37,7 @@ class ilHelpViewLayoutProvider extends AbstractModificationProvider implements M
             $tt_text = ilHelp::getMainMenuTooltip($p->getInternalIdentifier());
             $tt_text = htmlspecialchars(str_replace(array("\n", "\r"), '', $tt_text));
 
-            if ($item instanceof hasSymbol && $item->hasSymbol()) {
+            if ($item instanceof hasSymbol && $item->hasSymbol() && !empty($tt_text)) {
                 $item->addSymbolDecorator(static function (Symbol $symbol) use ($tt_text) : Symbol {
                     if ($symbol instanceof JavaScriptBindable) {
                         return $symbol->withAdditionalOnLoadCode(static function ($id) use ($tt_text) : string {


### PR DESCRIPTION
Hi @chfsx,

I just saw on the test6 that we have a lot of empty tooltips on the main bar. This should fix the problem.

Best regards!