### PR TITLE
UI Components, Layout: Accessibility Rule

### DIFF
--- a/src/UI/Component/Input/Factory.php
+++ b/src/UI/Component/Input/Factory.php
@@ -91,7 +91,9 @@ interface Factory
      *     1: >
      *         All fields visible in a view MUST be accessible by keyboard by using the
      *         ‘Tab’-Key.
-     *
+     *     2: >
+     *         If the Field is carrying the focus (e.g. by tabbing) and is visible it
+     *         MUST always be visibly marked (e.g. by some sort of highlighting).
      * ---
      *
      * @return    \ILIAS\UI\Component\Input\Field\Factory

--- a/src/UI/Component/Layout/Page/Factory.php
+++ b/src/UI/Component/Layout/Page/Factory.php
@@ -49,9 +49,6 @@ interface Factory
      *     1: >
      *        Scrollable areas of the Standard Page MUST be scrollable by only using
      *        the keyboard.
-     *     2: >
-     *        The element carrying the focus (e.g. by tabbing) in the Standard Layout
-     *        MUST always be visibly marked (e.g. by some sort of highlighting).
      * ----
      *
      * @param  \ILIAS\UI\Component\Component[] $content

--- a/src/UI/Component/Layout/Page/Factory.php
+++ b/src/UI/Component/Layout/Page/Factory.php
@@ -44,6 +44,14 @@ interface Factory
      *     7: The Standard Page's short title SHOULD reference the current ILIAS installation.
      *     8: The Standard Page's view title SHOULD give a good hint to the current view.
      *
+     * rules:
+     *   accessibility:
+     *     1: >
+     *        Scrollable areas of the Standard Page MUST be scrollable by only using
+     *        the keyboard.
+     *     2: >
+     *        The element carrying the focus (e.g. by tabbing) in the Standard Layout
+     *        MUST always be visibly marked (e.g. by some sort of highlighting).
      * ----
      *
      * @param  \ILIAS\UI\Component\Component[] $content

--- a/src/UI/Factory.php
+++ b/src/UI/Factory.php
@@ -126,6 +126,12 @@ interface Factory
      *      1: >
      *           DOM elements of type "a" MUST be used to properly identify an
      *           element.
+     *      2: >
+     *           If the Link is carrying the focus (e.g. by tabbing) and is visible it
+     *           MUST always be visibly marked (e.g. by some sort of highlighting).
+     *      3: >
+     *           All Links visible in a view MUST be accessible by keyboard by using the
+     *           ‘Tab’-Key.
      * ---
      * @return  \ILIAS\UI\Component\Link\Factory
      */
@@ -198,6 +204,12 @@ interface Factory
      *           Button DOM elements MUST either be of type "button", of type "a"
      *           accompanied with the aria-role “Button” or input along with the type
      *           attribute “button” or "submit".
+     *      3: >
+     *           If the Button is carrying the focus (e.g. by tabbing) and is visible it
+     *           MUST always be visibly marked (e.g. by some sort of highlighting).
+     *      4: >
+     *           All Buttons visible in a view MUST be accessible by keyboard by using the
+     *           ‘Tab’-Key.
      * ---
      * @return  \ILIAS\UI\Component\Button\Factory
      */


### PR DESCRIPTION
Our ruling an focus and scrolling behaviour by only using keyboard needs to be enhanced and find it's way into testrail. This part covers a clear ruling on visibility and scrollability in our ILIAS Standard Layout. Note this could be further refined by shaping out, which elements MUST be focusable and which not. However, this is a further small iteration towards a more accessible UI.

Note, thx @atoedt and @alex40724 for reporting the respective issues marking those issues in ILIAS 6, see: https://mantis.ilias.de/view.php?id=27270 and https://mantis.ilias.de/view.php?id=25684