### PR TITLE
UI: expand usage of notification glyph (#26639)

### DIFF
--- a/src/UI/Component/Symbol/Glyph/Factory.php
+++ b/src/UI/Component/Symbol/Glyph/Factory.php
@@ -407,27 +407,17 @@ interface Factory
      * ---
      * description:
      *   purpose: >
-     *       The Notification Glyph allows users to activate / deactivate the notification service for a specific object or sub-item.
-     *       It is a toggle indicating by colour  whether it is activated or not.
+     *       The Notification Glyph indicates and controls functionality that allows the system to send notifications
+     *       to the user, such as the notification center in the Meta Bar or the notification service at individual
+     *       objects.
      *   composition: >
-     *       The Notification Glyph uses the glyphicon-bell in link-color if notifications are not active or brand-warning color if they are.
-     *   effect: >
-     *       Upon clicking the notification activation is toggled: Clicking the Notification Glyph activates respectively
-     *       deactivates the notification service for the current object or sub-item.
+     *       If used to toggle the notifications at an individual object, the Notification Glyph uses link-color to
+     *       indicate inactivity and the brand-warning color to indicate activity.
      *
      * rules:
-     *   usage:
-     *       1: >
-     *          The Notification Glyph MUST only be used in the Content Top Actions.
-     *   interaction:
-     *       1: >
-     *          Clicking the Notification Glyph MUST toggle the activation of Notifications.
-     *   style:
-     *       1: >
-     *          If notifications are activated the Notification Glyph MUST use the brand-warning color.
      *   accessibility:
-     *       1: >
-     *          The aria-label MUST be ‘Notifications'.
+     *       2: >
+     *          The aria-label MUST be "Notifications".
      * ---
      * @param	string|null	$action
      * @return 	\ILIAS\UI\Component\Symbol\Glyph\Glyph

--- a/src/UI/ROADMAP.md
+++ b/src/UI/ROADMAP.md
@@ -167,6 +167,16 @@ block-element, respectively an UI-Component on its own.
 
 ## Long Term
 
+### Glyphs as Toggle
+
+Currently, the Notification Glyph (and maybe others) is used to toggle the activation
+of the notification service at individual objects. The activity then is indicated
+by color only, which violates the general accessibility rule that ["Color MUST not be
+used as the only visual means of conveying information"](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/docs/development/accessibility.md).
+However, a quick fix seems not to be possible atm, because there also is no other
+means to convey the notion of (in-)activity for a general Glyph, or even only the
+specific Notification Glyph.
+
 ### Tooltips and Tooltippable
 
 Tooltips are currently not yet implemented as UI components. Since 


### PR DESCRIPTION
Dear all!

I was tasked with expanding the description of the Notification Glyph to fit the usage for the Notification Center (https://mantis.ilias.de/view.php?id=26639) together with the notification service. This is the best I could come up with.

Please also note, that this glyph seems to have accessibility issues, which I were out of scope of my task at hand, namely the usage of color to convey information and most probably also the aria label, which does not indicate what happens when the glyph is used. For the former I added a roadmap entry, the latter already seems to be targeted by a rule on `Glyph` but not be implemented actually.

Best regards!