### PR TITLE
LSO, fix 27144: call isMember on roles, not LSOObj

### DIFF
--- a/Modules/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
+++ b/Modules/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
@@ -513,7 +513,7 @@ class ilObjLearningSequenceGUI extends ilContainerGUI
                 || (
                     $this->getObject()->getLSSettings()->getMembersGallery()
                     &&
-                    $this->object->isMember((int) $this->user->getId())
+                    $this->getObject()->getLSRoles()->isMember((int) $this->user->getId())
                 )
             ) {
                 $this->tabs->addTab(


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=27144