### PR TITLE
contrib_27275: re-enable perma-link

### DIFF
--- a/Services/Registration/classes/class.ilAccountRegistrationGUI.php
+++ b/Services/Registration/classes/class.ilAccountRegistrationGUI.php
@@ -66,9 +66,8 @@ class ilAccountRegistrationGUI
     {
         global $DIC;
 
-        $ilErr = $DIC['ilErr'];
-
         if ($this->registration_settings->getRegistrationType() == IL_REG_DISABLED) {
+            $ilErr = $DIC['ilErr'];
             $ilErr->raiseError($this->lng->txt('reg_disabled'), $ilErr->FATAL);
         }
 
@@ -81,7 +80,8 @@ class ilAccountRegistrationGUI
                 $tpl = $this->displayForm();
         }
 
-        //$tpl->setPermanentLink('usr', null, 'registration');
+        $gtpl = $DIC['tpl'];
+        $gtpl->setPermanentLink('usr', null, 'registration');
         ilStartUpGUI::printToGlobalTemplate($tpl);
     }
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=27275

This re-enables the perma-link on the registration-page.
However, using the link does not lead to the registation-page anymore ;(