### PR TITLE
ilPluginAdmin: Change include_once to include for multiple method calls

### DIFF
--- a/Services/Component/classes/class.ilPluginAdmin.php
+++ b/Services/Component/classes/class.ilPluginAdmin.php
@@ -234,7 +234,7 @@ class ilPluginAdmin
      */
     protected function parsePluginPhp($plugin_php_file)
     {
-        include_once($plugin_php_file);
+        include($plugin_php_file);
 
         $values = [
             "version"           => $version,


### PR DESCRIPTION
The plugin.php defines some variables which are passed into a config array. If this method is called twice the values are all null. This results in fatal errors since release_5-4 because it now enforces parameter types here in class.ilPlugin.php :
`private function setVersion(**string** $a_version)`

Eventually this solves Bug #0026803 (https://mantis.ilias.de/view.php?id=26803)