### PR TITLE
Course/MemberExport: Fix wrong offset in CSV export

### DIFF
--- a/Services/Membership/classes/Export/class.ilMemberExport.php
+++ b/Services/Membership/classes/Export/class.ilMemberExport.php
@@ -620,6 +620,7 @@ class ilMemberExport
         if (substr($a_field, 0, 4) != 'udf_') {
             return false;
         }
+
         if (!$this->privacy->courseConfirmationRequired() or $this->agreement[$udf_data->getUserId()]['accepted']) {
             $field_info = explode('_', $a_field);
             $field_id = $field_info[1];
@@ -628,8 +629,9 @@ class ilMemberExport
             $this->addCol($value, $row, $col);
             return true;
         }
-        #$this->csv->addColumn('');
+
         $this->addCol('', $row, $col);
+        return true;
     }
     
     /**


### PR DESCRIPTION
This commit fixes a wrong offset in the member export CSV file, if the actor selected one (or more) user defined fields and an exported user did not accept the agreement of the course.

Mantis Issue: https://mantis.ilias.de/view.php?id=27490