### PR TITLE
GlobalScreen/PluginProviderHelper: Make plugin property protected

### DIFF
--- a/src/GlobalScreen/Provider/PluginProviderHelper.php
+++ b/src/GlobalScreen/Provider/PluginProviderHelper.php
@@ -17,7 +17,7 @@ trait PluginProviderHelper
     /**
      * @var ilPlugin
      */
-    private $plugin;
+    protected $plugin;
     /**
      * @var PluginIdentificationProvider
      */


### PR DESCRIPTION
This commit changes the access modifier for the 'plugin' property. If the access is restricted to private, a derived (from `AbstractStaticPluginMainMenuProvider`) plugin provider has to create a new plugin instance if the plugin is required to provide main bar entries.