### PR TITLE
[WIP] Javascript Modules Guideline

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -1,0 +1,21 @@
+<html>
+<head>
+
+</head>
+<body>
+
+Test
+
+<script type="module">
+  import il from './js/il.js';
+  window.il = il;
+  console.log(il);
+</script>
+<script>
+window.onload = function () {
+  il.component1.public1();
+  il.component2.public1();
+};
+</script>
+</body>
+</html>

--- a/demo.html
+++ b/demo.html
@@ -9,7 +9,6 @@ Test
 <script type="module">
   import il from './js/il.js';
   window.il = il;
-  console.log(il);
 </script>
 <script>
 window.onload = function () {

--- a/docs/js/js-modules.md
+++ b/docs/js/js-modules.md
@@ -82,8 +82,10 @@ window.onload = function () {
 All core and service components SHOULD add their imports to one central il.js file.
 
 ```
+// this first line imports a non-ES6-module version of jquery
 import "../libs/bower/bower_components/jquery/dist/jquery.min.js"
 ...
+// ES6-module import style
 import ui from "./src/UI/js/ui.js"
 import object from "./Services/Object/js/object.js"
 import tagging from "./Servicces/tagging/tagging.js"
@@ -119,12 +121,15 @@ Pros
 - Elimination of problems caused by the wrong sequence scripts are loaded.
 - Optional bundling and minification based on ES6 modules using tools like webpack.
 - Removing `$tpl->addJavascript()` calls from PHP.
-- Necessary refactory would be limited and can be done incrementally.
+- Necessary refactoring would be limited and can be done incrementally.
+- Better readability of the code.
+- Easy way to prevent global scope pollution.
 
 Centralizing the imports in one place instead of adding them to single components keeps the path information (location of the js files) in one place. This makes refactoring easier (e.g. when JS files are moved). This approach shares some similarities with the way less files are currently organised in ILIAS.
 
-It may not be appropriate to include Javascript specialised on one component without any reuse for other contexts in this central file, e.g. forum.js or learning_module.js. But in general the number of scripts separately included in a page could be reduced to two.
+It may not be appropriate to include Javascript specialised on one component without any reuse for other contexts in this central `il.js` file, e.g. forum.js or learning_module.js. But in general the number of scripts separately included in a page could be reduced to two.
 
 Cons
 
 - The approach does not offer a solution for dependenc handling / management yet. All components access other services through the global `il` object.
+- ...?

--- a/docs/js/js-modules.md
+++ b/docs/js/js-modules.md
@@ -134,6 +134,7 @@ Cons
 - The approach does not offer a solution for dependenc handling / management yet. All components access other services through the global `il` object.
 - ...?
 
-## Follow-Up
+## Roadmap
 
-This PR does not discuss a bundle strategy (or any kind of build process). It should be a separate task to investigate the best level of bundling/minification on different levels to optimise performance. The suggested structure however could serve as a starting point for such an investigation.
+- This PR does not discuss a **bundle strategy** (or any kind of build process). It should be a separate task to investigate the best level of bundling/minification on different levels to optimise performance. The suggested structure however could serve as a starting point for such an investigation.
+- `il` services as some kind of global service locator object. We may introduce a proper **DI container** instead together with guidelines on how to manage dependencies on the client side.

--- a/docs/js/js-modules.md
+++ b/docs/js/js-modules.md
@@ -133,3 +133,7 @@ Cons
 
 - The approach does not offer a solution for dependenc handling / management yet. All components access other services through the global `il` object.
 - ...?
+
+## Follow-Up
+
+This PR does not discuss a bundle strategy (or any kind of build process). It should be a separate task to investigate the best level of bundling/minification on different levels to optimise performance. The suggested structure however could serve as a starting point for such an investigation.

--- a/docs/js/js-modules.md
+++ b/docs/js/js-modules.md
@@ -1,0 +1,130 @@
+# JS Modules in ILIAS
+
+## Current State
+
+Currently Javascript code is provided in a larger number of files which are included separately in the header of each HTML page.
+
+```
+<script type="text/javascript" src="./libs/bower/bower_components/jquery/dist/jquery.js"></script>
+...
+<script type="text/javascript" src="./libs/bower/bower_components/moment/min/moment-with-locales.min.js"></script>
+...
+<script type="text/javascript" src="./src/UI/templates/js/Dropdown/dropdown.js"></script>
+``` 
+
+Single scripts are added to this list via PHP code of every component that relies on the javascript by calling `addJavascript()` on the Global Template.
+
+```
+$tpl->addJavascript("./Services/Form/js/ServiceFormMulti.js");
+```
+
+The single components are using (in the best case) a revealing-module pattern to expose their public API in a global `il` object.
+
+```
+il = il || {};
+il.UI = il.UI || {};
+il.UI.button = il.UI.button || {};
+(function($, il) {
+    il.UI.button = (function($) {
+
+        var privateFunction = function (id) {
+            ...
+        };
+
+        // public function
+        var initMonth = function (id) {
+            ...
+        };
+
+        // return public interface
+        return {
+            initMonth: initMonth,
+            ...
+        };
+    })($);
+})($, il);
+
+```
+
+### Issues with the current approach
+
+- The sequence of script-tags is error-prone and relies on addJavascript calls in lots of different PHP components.
+- Ajax calls may result in missing dependencies to unavailable js files.
+- The approach does not allow to bundle and minify at least the core Javascript code.
+
+## Proposal
+
+### Bundle core JS via ES6 modules
+
+Using ES6 modules could greatly reduce the number of scripts being included in ILIAS page HTML.
+
+```
+</tml>
+<head>
+</head>
+<body>
+
+...
+
+<script type="module">
+    import il from './js/il.js';
+    window.il = il;
+</script>
+<script>
+window.onload = function () {
+    ...
+};
+</script>
+</body>
+</html>
+```
+
+All core and service components SHOULD add their imports to one central il.js file.
+
+```
+import "../libs/bower/bower_components/jquery/dist/jquery.min.js"
+...
+import ui from "./src/UI/js/ui.js"
+import object from "./Services/Object/js/object.js"
+import tagging from "./Servicces/tagging/tagging.js"
+...
+
+export default {
+  ui: ui,
+  objects: objects,
+  tagging: tagging,
+  ...
+}
+```
+
+Single components SHOULD export their public API as a single object.
+
+```
+export default {
+
+  public1: function() {
+    ...
+    internal();
+  }
+}
+
+function internal() {
+  console.log("internal called");
+}
+```
+
+Pros
+
+- Availability of all core and service JS code with each request.
+- Elimination of problems caused by the wrong sequence scripts are loaded.
+- Optional bundling and minification based on ES6 modules using tools like webpack.
+- Removing `$tpl->addJavascript()` calls from PHP.
+- Necessary refactory would be limited and can be done incrementally.
+
+Centralizing the imports in one place instead of adding them to single components keeps the path information (location of the js files) in one place. This makes refactoring easier (e.g. when JS files are moved). This approach shares some similarities with the way less files are currently organised in ILIAS.
+
+It may not be appropriate to include Javascript specialised on one component without any reuse for other contexts in this central file, e.g. forum.js or learning_module.js. But in general the number of scripts separately included in a page could be reduced to two.
+
+Cons
+
+- The approach does not offer a solution for dependenc handling / management yet. All components access other services through the global `il` object.

--- a/js/component1.js
+++ b/js/component1.js
@@ -1,0 +1,7 @@
+export default {
+
+  public1: function() {
+    console.log("Component 1, public1()");
+    $("body").append("<div>Component 1, public1()</div>");
+  }
+}

--- a/js/component2.js
+++ b/js/component2.js
@@ -1,0 +1,12 @@
+export default {
+
+  public1: function() {
+    console.log("Component 2, public1()");
+    il.component3.public1();
+    internal();
+  }
+}
+
+function internal() {
+  console.log("internal called");
+}

--- a/js/component3.js
+++ b/js/component3.js
@@ -1,0 +1,7 @@
+export default {
+
+  public1: function() {
+    console.log("Component 3, public1()");
+  }
+
+}

--- a/js/il.js
+++ b/js/il.js
@@ -1,0 +1,10 @@
+import "../libs/bower/bower_components/jquery/dist/jquery.min.js"
+import c1 from "./component1.js"
+import c2 from "./component2.js"
+import c3 from "./component3.js"
+
+export default {
+  component1: c1,
+  component2: c2,
+  component3: c3
+}


### PR DESCRIPTION
This PR is another follow-up of #2445.

It includes some demo files and a main .md file:
https://github.com/ILIAS-eLearning/ILIAS/pull/2477/files?short_path=cc6cbc8#diff-cc6cbc8b8162d939361f872ac45c783c

It tries to document the current state of using JS module patterns in ILIAS and a potential roadmap/guideline to switch to ES6 modules.

Please add your comments and thoughts in the PR. You are also invited to join the ILIAS Offline Group [1].

[1] https://docu.ilias.de/goto_docu_grp_8190.html