### PR TITLE
Travis/CI: Remove 'snapshot' suffix for PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ matrix:
   include:
   - php: 7.2
   - php: 7.3
-  - php: 7.4snapshot
+  - php: 7.4
 script:
 - ./CI/PHPUnit/run_tests_with_reporting.sh;
 - if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then travis_wait 60 ./CI/PHP-CS-Fixer/run_check.sh; fi


### PR DESCRIPTION
This commit removes the `snapshot` suffix for PHP 7.4 in our Travis CI configuration file.