### PR TITLE
UI: factored out FormInput(Internal)

### DIFF
--- a/src/UI/Component/Input/Container/Form/Factory.php
+++ b/src/UI/Component/Input/Container/Form/Factory.php
@@ -47,7 +47,7 @@ interface Factory
      * ---
      *
      * @param    string $post_url
-     * @param    array<mixed,\ILIAS\UI\Component\Input\Input>    $inputs
+     * @param    array<mixed,\ILIAS\UI\Component\Input\FormInput>    $inputs
      *
      * @return    \ILIAS\UI\Component\Input\Container\Form\Standard
      */

--- a/src/UI/Component/Input/Container/Form/Form.php
+++ b/src/UI/Component/Input/Container/Form/Form.php
@@ -18,7 +18,7 @@ interface Form extends Component
     /**
      * Get the inputs contained in the form.
      *
-     * @return    array<mixed,\ILIAS\UI\Component\Input\Input>
+     * @return    array<mixed,\ILIAS\UI\Component\Input\FormInput>
      */
     public function getInputs();
 

--- a/src/UI/Component/Input/Field/Checkbox.php
+++ b/src/UI/Component/Input/Field/Checkbox.php
@@ -10,6 +10,6 @@ use ILIAS\UI\Component\Component;
 /**
  * This describes checkbox inputs.
  */
-interface Checkbox extends Component
+interface Checkbox extends Component, FormInput
 {
 }

--- a/src/UI/Component/Input/Field/DateTime.php
+++ b/src/UI/Component/Input/Field/DateTime.php
@@ -5,11 +5,12 @@
 namespace ILIAS\UI\Component\Input\Field;
 
 use ILIAS\Data\DateFormat\DateFormat;
+use ILIAS\UI\Component\Component;
 
 /**
  * This describes the datetime-field.
  */
-interface DateTime extends Input
+interface DateTime extends Component, FormInput
 {
     /**
      * Get an input like this using the given format.

--- a/src/UI/Component/Input/Field/Factory.php
+++ b/src/UI/Component/Input/Field/Factory.php
@@ -96,7 +96,7 @@ interface Factory
      *
      * ---
      *
-     * @param    array<mixed,\ILIAS\UI\Component\Input\Field\Input>    $inputs
+     * @param    array<mixed,\ILIAS\UI\Component\Input\Field\FormInput>    $inputs
      * @param    string    $label
      *
      * @return    \ILIAS\UI\Component\Input\Field\Group
@@ -126,7 +126,7 @@ interface Factory
      *      accepted by the Jour Fixe.
      *
      * ---
-     * @param    array<mixed,\ILIAS\UI\Component\Input\Field\Input>    $inputs
+     * @param    array<mixed,\ILIAS\UI\Component\Input\Field\FormInput>    $inputs
      * @return	\ILIAS\UI\Component\Input\Field\OptionalGroup
      */
     public function optionalGroup(array $inputs, string $label, string $byline = null) : OptionalGroup;
@@ -154,7 +154,7 @@ interface Factory
      *      accepted by the Jour Fixe.
      *
      * ---
-     * @param    array<mixed,\ILIAS\UI\Component\Input\Field\Input\Group>    $inputs
+     * @param    array<mixed,\ILIAS\UI\Component\Input\Field\Input\FormInput>    $input
      * @return	\ILIAS\UI\Component\Input\Field\SwitchableGroup
      */
     public function switchableGroup(array $inputs, string $label, string $byline = null) : SwitchableGroup;
@@ -196,7 +196,7 @@ interface Factory
      *
      * ---
      *
-     * @param    array<mixed,\ILIAS\UI\Component\Input\Field\Input>    $inputs
+     * @param    array<mixed,\ILIAS\UI\Component\Input\Field\FormInput>    $inputs
      * @param    string|null $label
      * @param    string      $byline
      *

--- a/src/UI/Component/Input/Field/File.php
+++ b/src/UI/Component/Input/Field/File.php
@@ -5,7 +5,7 @@ namespace ILIAS\UI\Component\Input\Field;
 /**
  * This describes file field.
  */
-interface File extends Input
+interface File extends FormInput
 {
     public function withAcceptedMimeTypes(array $mime_types) : File;
 

--- a/src/UI/Component/Input/Field/FilterInput.php
+++ b/src/UI/Component/Input/Field/FilterInput.php
@@ -14,6 +14,6 @@ namespace ILIAS\UI\Component\Input\Field;
  *
  * @author killing@leifos.de
  */
-interface FilterInput extends Input
+interface FilterInput extends FormInput
 {
 }

--- a/src/UI/Component/Input/Field/FormInput.php
+++ b/src/UI/Component/Input/Field/FormInput.php
@@ -1,0 +1,110 @@
+<?php
+
+/* Copyright (c) 2017 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\UI\Component\Input\Field;
+
+use ILIAS\UI\Component\Component;
+use ILIAS\Refinery\Transformation;
+use ILIAS\UI\Component\JavaScriptBindable;
+use ILIAS\UI\Component\OnUpdateable;
+
+/**
+ * This describes inputs that can be used in forms.
+ */
+interface FormInput extends Component, Input, JavaScriptBindable, OnUpdateable
+{
+    /**
+     * Get the label of the input.
+     *
+     * @return    string
+     */
+    public function getLabel();
+
+    /**
+     * Get an input like this, but with a replaced label.
+     *
+     * @param    string $label
+     *
+     * @return    Input
+     */
+    public function withLabel($label);
+
+    /**
+     * Get the byline of the input.
+     *
+     * @return    string|null
+     */
+    public function getByline();
+
+    /**
+     * Get an input like this, but with an additional/replaced label.
+     *
+     * @param    string|null $byline
+     *
+     * @return    Input
+     */
+    public function withByline($byline);
+
+    /**
+     * Is this field required?
+     *
+     * @return    bool
+     */
+    public function isRequired();
+
+    /**
+     * Get an input like this, but set the field to be required (or not).
+     *
+     * @param    bool $is_required
+     *
+     * @return    Input
+     */
+    public function withRequired($is_required);
+
+    /**
+     * Is this input disabled?
+     *
+     * @return    bool
+     */
+    public function isDisabled();
+
+    /**
+     * Get an input like this, but set it to a disabled state.
+     *
+     * @param    bool $is_disabled
+     *
+     * @return    Input
+     */
+    public function withDisabled($is_disabled);
+
+    /**
+     * The error of the input as used in HTML.
+     *
+     * @return string|null
+     */
+    public function getError();
+
+    /**
+     * Get an input like this one, with a different error.
+     *
+     * @param    string
+     *
+     * @return    Input
+     */
+    public function withError($error);
+
+    /**
+     * Get update code
+     *
+     * This method has to return JS code that calls
+     * il.UI.filter.onFieldUpdate(event, '$id', string_value);
+     * - initially "onload" and
+     * - on every input change.
+     * It must pass a readable string representation of its value in parameter 'string_value'.
+     *
+     * @param \Closure $binder
+     * @return string
+     */
+    public function getUpdateOnLoadCode() : \Closure;
+}

--- a/src/UI/Component/Input/Field/Group.php
+++ b/src/UI/Component/Input/Field/Group.php
@@ -5,9 +5,11 @@ docs/LICENSE */
 
 namespace ILIAS\UI\Component\Input\Field;
 
+use ILIAS\UI\Component\Component;
+
 /**
  * This describes a group of inputs.
  */
-interface Group extends Input
+interface Group extends Component, FormInput
 {
 }

--- a/src/UI/Component/Input/Field/Input.php
+++ b/src/UI/Component/Input/Field/Input.php
@@ -28,81 +28,8 @@ use ILIAS\UI\Component\OnUpdateable;
  * into other types of data. This means, that e.g. the value of an input could
  * be some id, while the content could be some object referenced by that id.
  */
-interface Input extends Component, JavaScriptBindable, OnUpdateable
+interface Input
 {
-
-    /**
-     * Get the label of the input.
-     *
-     * @return    string
-     */
-    public function getLabel();
-
-
-    /**
-     * Get an input like this, but with a replaced label.
-     *
-     * @param    string $label
-     *
-     * @return    Input
-     */
-    public function withLabel($label);
-
-
-    /**
-     * Get the byline of the input.
-     *
-     * @return    string|null
-     */
-    public function getByline();
-
-
-    /**
-     * Get an input like this, but with an additional/replaced label.
-     *
-     * @param    string|null $byline
-     *
-     * @return    Input
-     */
-    public function withByline($byline);
-
-
-    /**
-     * Is this field required?
-     *
-     * @return    bool
-     */
-    public function isRequired();
-
-
-    /**
-     * Get an input like this, but set the field to be required (or not).
-     *
-     * @param    bool $is_required
-     *
-     * @return    Input
-     */
-    public function withRequired($is_required);
-
-
-    /**
-     * Is this input disabled?
-     *
-     * @return    bool
-     */
-    public function isDisabled();
-
-
-    /**
-     * Get an input like this, but set it to a disabled state.
-     *
-     * @param    bool $is_disabled
-     *
-     * @return    Input
-     */
-    public function withDisabled($is_disabled);
-
-
     /**
      * Get the value that is displayed in the input client side.
      *
@@ -124,24 +51,6 @@ interface Input extends Component, JavaScriptBindable, OnUpdateable
 
 
     /**
-     * The error of the input as used in HTML.
-     *
-     * @return string|null
-     */
-    public function getError();
-
-
-    /**
-     * Get an input like this one, with a different error.
-     *
-     * @param    string
-     *
-     * @return    Input
-     */
-    public function withError($error);
-
-
-    /**
      * Apply a transformation to the content of the input.
      *
      * @param    Transformation $trafo
@@ -149,19 +58,4 @@ interface Input extends Component, JavaScriptBindable, OnUpdateable
      * @return    Input
      */
     public function withAdditionalTransformation(Transformation $trafo);
-
-
-    /**
-     * Get update code
-     *
-     * This method has to return JS code that calls
-     * il.UI.filter.onFieldUpdate(event, '$id', string_value);
-     * - initially "onload" and
-     * - on every input change.
-     * It must pass a readable string representation of its value in parameter 'string_value'.
-     *
-     * @param \Closure $binder
-     * @return string
-     */
-    public function getUpdateOnLoadCode() : \Closure;
 }

--- a/src/UI/Component/Input/Field/Password.php
+++ b/src/UI/Component/Input/Field/Password.php
@@ -4,11 +4,9 @@
 
 namespace ILIAS\UI\Component\Input\Field;
 
-use ILIAS\Data\Password as PWD;
-
 /**
  * This describes password inputs.
  */
-interface Password extends Input
+interface Password extends FormInput
 {
 }

--- a/src/UI/Component/Input/Field/Radio.php
+++ b/src/UI/Component/Input/Field/Radio.php
@@ -7,7 +7,7 @@ namespace ILIAS\UI\Component\Input\Field;
 /**
  * This is what a radio-input looks like.
  */
-interface Radio extends Input
+interface Radio extends FormInput
 {
 
     /**

--- a/src/UI/Component/Input/Field/Section.php
+++ b/src/UI/Component/Input/Field/Section.php
@@ -8,6 +8,6 @@ namespace ILIAS\UI\Component\Input\Field;
 /**
  * This describes section inputs.
  */
-interface Section extends Input
+interface Section extends FormInput
 {
 }

--- a/src/UI/Component/Input/Field/Tag.php
+++ b/src/UI/Component/Input/Field/Tag.php
@@ -5,7 +5,7 @@ namespace ILIAS\UI\Component\Input\Field;
 
 use ILIAS\UI\Component\JavaScriptBindable;
 use ILIAS\UI\Component\Signal;
-use ILIAS\UI\Implementation\Component\Input\Field\InputInternal;
+use ILIAS\UI\Implementation\Component\Input\Field\FormInputInternal;
 
 /**
  * Interface Tag
@@ -14,7 +14,7 @@ use ILIAS\UI\Implementation\Component\Input\Field\InputInternal;
  *
  * @package ILIAS\UI\Component\Input\Field
  */
-interface Tag extends FilterInput, InputInternal
+interface Tag extends FilterInput, FormInputInternal
 {
 
     /**

--- a/src/UI/Component/Input/Field/Textarea.php
+++ b/src/UI/Component/Input/Field/Textarea.php
@@ -9,7 +9,7 @@ use ILIAS\UI\Component\JavaScriptBindable;
 /**
  * This describes Textarea inputs.
  */
-interface Textarea extends Input
+interface Textarea extends FormInput
 {
 
     /**

--- a/src/UI/Implementation/Component/Input/Field/FormInputInternal.php
+++ b/src/UI/Implementation/Component/Input/Field/FormInputInternal.php
@@ -4,13 +4,13 @@
 
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
-use ILIAS\UI\Component\Input\Field\Input;
+use ILIAS\UI\Component\Input\Field\FormInput;
 use ILIAS\UI\Implementation\Component\Input\NameSource;
 
 /**
  * This type of input is required by forms.
  */
-interface FormInputInternal extends InputInternal, Input
+interface FormInputInternal extends InputInternal, FormInput
 {
     /**
      * Get an input like this one, with a different name.

--- a/src/UI/Implementation/Component/Input/Field/FormInputInternal.php
+++ b/src/UI/Implementation/Component/Input/Field/FormInputInternal.php
@@ -1,0 +1,23 @@
+<?php
+
+/* Copyright (c) 2017 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\UI\Implementation\Component\Input\Field;
+
+use ILIAS\UI\Component\Input\Field\Input;
+use ILIAS\UI\Implementation\Component\Input\NameSource;
+
+/**
+ * This type of input is required by forms.
+ */
+interface FormInputInternal extends InputInternal, Input
+{
+    /**
+     * Get an input like this one, with a different name.
+     *
+     * @param    NameSource $source
+     *
+     * @return    Input
+     */
+    public function withNameFrom(NameSource $source);
+}

--- a/src/UI/Implementation/Component/Input/Field/Group.php
+++ b/src/UI/Implementation/Component/Input/Field/Group.php
@@ -37,7 +37,7 @@ class Group extends Input implements C\Input\Field\Group
      *
      * @param DataFactory           $data_factory
      * @param \ILIAS\Refinery\Factory $refinery
-     * @param InputInternal[]       $inputs
+     * @param FormInputInternal[]   $inputs
      * @param                       $label
      * @param                       $byline
      */
@@ -49,7 +49,7 @@ class Group extends Input implements C\Input\Field\Group
         string $byline = null
     ) {
         parent::__construct($data_factory, $refinery, $label, $byline);
-        $this->checkArgListElements("inputs", $inputs, InputInternal::class);
+        $this->checkArgListElements("inputs", $inputs, FormInputInternal::class);
         $this->inputs = $inputs;
     }
 

--- a/src/UI/Implementation/Component/Input/Field/Group.php
+++ b/src/UI/Implementation/Component/Input/Field/Group.php
@@ -23,7 +23,7 @@ class Group extends Input implements C\Input\Field\Group
     /**
      * Inputs that are contained by this group
      *
-     * @var    Input[]
+     * @var    FormInput[]
      */
     protected $inputs = [];
 
@@ -201,7 +201,7 @@ class Group extends Input implements C\Input\Field\Group
     }
 
     /**
-     * @return Input[]
+     * @return FormInput[]
      */
     public function getInputs()
     {

--- a/src/UI/Implementation/Component/Input/Field/Input.php
+++ b/src/UI/Implementation/Component/Input/Field/Input.php
@@ -20,7 +20,7 @@ use ILIAS\UI\Implementation\Component\Triggerer;
 /**
  * This implements commonalities between inputs.
  */
-abstract class Input implements C\Input\Field\Input, InputInternal
+abstract class Input implements C\Input\Field\Input, FormInputInternal
 {
     use ComponentHelper;
     use JavaScriptBindable;
@@ -324,7 +324,7 @@ abstract class Input implements C\Input\Field\Input, InputInternal
         }
     }
 
-    // Implementation of InputInternal
+    // Implementation of FormInputInternal
 
     // This is the machinery to be used to process the input from the client side.
     // This should not be exposed to the consumers of the inputs. These methods

--- a/src/UI/Implementation/Component/Input/Field/InputInternal.php
+++ b/src/UI/Implementation/Component/Input/Field/InputInternal.php
@@ -13,7 +13,7 @@ use ILIAS\Data\Result;
  * Describes the interface of inputs that is used for internal
  * processing of data from the client.
  */
-interface InputInternal 
+interface InputInternal extends Input
 {
     /**
      * The name of the input as used in HTML.

--- a/src/UI/Implementation/Component/Input/Field/InputInternal.php
+++ b/src/UI/Implementation/Component/Input/Field/InputInternal.php
@@ -13,25 +13,14 @@ use ILIAS\Data\Result;
  * Describes the interface of inputs that is used for internal
  * processing of data from the client.
  */
-interface InputInternal extends Input
+interface InputInternal 
 {
-
     /**
      * The name of the input as used in HTML.
      *
      * @return string
      */
     public function getName();
-
-
-    /**
-     * Get an input like this one, with a different name.
-     *
-     * @param    NameSource $source
-     *
-     * @return    Input
-     */
-    public function withNameFrom(NameSource $source);
 
 
     /**

--- a/src/UI/Implementation/Component/Input/Field/SwitchableGroup.php
+++ b/src/UI/Implementation/Component/Input/Field/SwitchableGroup.php
@@ -27,7 +27,7 @@ class SwitchableGroup extends Group implements Field\SwitchableGroup
      *
      * @param DataFactory           $data_factory
      * @param \ILIAS\Refinery\Factory $refinery
-     * @param InputInternal[]       $inputs
+     * @param FormInputInternal[]     $inputs
      * @param                       $label
      * @param                       $byline
      */

--- a/src/UI/Implementation/Component/Input/Field/Tag.php
+++ b/src/UI/Implementation/Component/Input/Field/Tag.php
@@ -16,7 +16,7 @@ use ILIAS\UI\Implementation\Component\Triggerer;
  *
  * @author Fabian Schmid <fs@studer-raimann.ch>
  */
-class Tag extends Input implements C\Input\Field\Tag
+class Tag extends Input implements FormInputInternal, C\Input\Field\Tag
 {
     const EVENT_ITEM_ADDED = 'itemAdded';
     const EVENT_BEFORE_ITEM_REMOVE = 'beforeItemRemove';

--- a/tests/UI/Component/Input/Container/Filter/FilterTest.php
+++ b/tests/UI/Component/Input/Container/Filter/FilterTest.php
@@ -5,7 +5,7 @@
 require_once(__DIR__ . "/../../../../Base.php");
 
 use ILIAS\UI\Implementation\Component\Input;
-use \ILIAS\UI\Implementation\Component\Input\Field\InputInternal;
+use \ILIAS\UI\Implementation\Component\Input\Field\FormInputInternal;
 use \ILIAS\UI\Implementation\Component\Input\NameSource;
 use \ILIAS\UI\Implementation\Component\Input\InputData;
 use \ILIAS\UI\Implementation\Component\Input\Container\Filter\Filter;
@@ -408,7 +408,7 @@ class FilterTest extends ILIAS_UI_TestBase
     {
         static $no = 2000;
         $config = $this
-            ->getMockBuilder(InputInternal::class)
+            ->getMockBuilder(FormInputInternal::class)
             ->setMethods(["getName", "withNameFrom", "withInput", "getContent", "getLabel", "withLabel", "getByline", "withByline", "isRequired", "withRequired", "isDisabled", "withDisabled", "getValue", "withValue", "getError", "withError", "withAdditionalTransformation", "withAdditionalConstraint", "getUpdateOnLoadCode", "getCanonicalName", "withOnLoadCode", "withAdditionalOnLoadCode", "getOnLoadCode", "withOnUpdate", "appendOnUpdate", "withResetTriggeredSignals", "getTriggeredSignals"])
             ->setMockClassName("Mock_InputNo" . ($no++))
             ->getMock();

--- a/tests/UI/Component/Input/Container/Form/FormTest.php
+++ b/tests/UI/Component/Input/Container/Form/FormTest.php
@@ -5,7 +5,7 @@
 require_once(__DIR__ . "/../../../../Base.php");
 
 use ILIAS\UI\Implementation\Component\Input;
-use \ILIAS\UI\Implementation\Component\Input\Field\InputInternal;
+use \ILIAS\UI\Implementation\Component\Input\Field\FormInputInternal;
 use \ILIAS\UI\Implementation\Component\Input\NameSource;
 use \ILIAS\UI\Implementation\Component\Input\InputData;
 use \ILIAS\UI\Implementation\Component\Input\Container\Form\Form;
@@ -412,7 +412,7 @@ class FormTest extends ILIAS_UI_TestBase
     {
         static $no = 1000;
         $config = $this
-            ->getMockBuilder(InputInternal::class)
+            ->getMockBuilder(FormInputInternal::class)
             ->setMethods(["getName", "withNameFrom", "withInput", "getContent", "getLabel", "withLabel", "getByline", "withByline", "isRequired", "withRequired", "isDisabled", "withDisabled", "getValue", "withValue", "getError", "withError", "withAdditionalTransformation", "withAdditionalConstraint", "getUpdateOnLoadCode", "getCanonicalName", "withOnLoadCode", "withAdditionalOnLoadCode", "getOnLoadCode", "withOnUpdate", "appendOnUpdate", "withResetTriggeredSignals", "getTriggeredSignals"])
             ->setMockClassName("Mock_InputNo" . ($no++))
             ->getMock();

--- a/tests/UI/Component/Input/Field/GroupInputTest.php
+++ b/tests/UI/Component/Input/Field/GroupInputTest.php
@@ -7,7 +7,6 @@ require_once(__DIR__ . "/../../../Base.php");
 
 use ILIAS\UI\Implementation\Component\Input\Field\Group;
 use ILIAS\UI\Implementation\Component\Input\Field\Input;
-use ILIAS\UI\Implementation\Component\Input\Field\InputInternal;
 use ILIAS\UI\Implementation\Component\Input\InputData;
 use \ILIAS\Data;
 


### PR DESCRIPTION
Hi @Amstutz, @tfamula,

as a preparation to improve input handling in the `ViewControl`s I factored out some interface stuff that I deem applicable to the `Input Field`s as well as the`ViewControl`s. Maybe we would want to perform a similar move for the `FilterInput`s.

The goal is to establish a mechanism for input handling for the `ViewControl`s which is similar to the ones we use for forms and filters. This refactoring in interfaces most likely will be followed by some refactoring of the actual input processing code to make it applicable for `ViewControl`s as well. Also we will try to make the `ViewControl`s obey the interfaces `Input` and `InputInternal`. Stay tuned.

Best regards!