### PR TITLE
Extended Maintainer Documentation

### DIFF
--- a/docs/development/maintenance.md
+++ b/docs/development/maintenance.md
@@ -33,7 +33,11 @@ Responsibilities of a component maintainer:
 - Component maintainer are responsible for bug fixing of their component and get assigned related bugs automatically by the [Issue-Tracker](http://mantis.ilias.de).
 
 
-The code base is deviced in several components:
+## Becoming a Maintainer
+
+Applications for maintainerships can be handed in to the product manager. The product manager together with the technical board decide on who becomes a maintainer. Maintainerships are listed with the name of the maintainer. In addition the company the maintainer is working for can be listed, too. In this second case the company can suggest a new maintainer to the product manager, if the employee leaves the company.
+
+## Current Maintainerships
 
 <!-- REMOVE -->
 * **ActiveRecord**

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -18933,3 +18933,4 @@ table.mceToolbar td {
   border: 1px solid #ddd;
   border-radius: .25em;
 }
+/*# sourceMappingURL=delos.css.map */

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -18933,4 +18933,3 @@ table.mceToolbar td {
   border: 1px solid #ddd;
   border-radius: .25em;
 }
-/*# sourceMappingURL=delos.css.map */


### PR DESCRIPTION
This PR extends to maintainance documentation to clarify the process of becoming a maintainer and how companies can be mentioned in maintainerships.