### PR TITLE
Refactoring in ilCtrlStructureReader

### DIFF
--- a/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
+++ b/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
@@ -112,16 +112,20 @@ class ilCtrlStructureReader
                 if ($parent) {
                     $cs = $cs->withClassScript($parent, $full_path);
                 }
-                foreach ($children as $child) {
-                    $cs = $cs->withClassChild($parent, $child);
+                if ($children) {
+                    foreach ($children as $child) {
+                        $cs = $cs->withClassChild($parent, $child);
+                    }
                 }
 
                 list($child, $parents) = $this->getIlCtrlIsCalledBy($content);
                 if ($child) {
                     $cs = $cs->withClassScript($child, $full_path);
                 }
-                foreach ($parents as $parent) {
-                    $cs = $cs->withClassChild($parent, $child);
+                if ($parents) {
+                    foreach ($parents as $parent) {
+                        $cs = $cs->withClassChild($parent, $child);
+                    }
                 }
 
                 $cl = $this->getGUIClassNameFromClassPath($full_path);
@@ -135,7 +139,11 @@ class ilCtrlStructureReader
                 if (!isset($e->class) || !isset($e->file_path)) {
                     throw $e;
                 }
-                $this->panicOnDuplicateClass($e->file_path, $e->class);
+                $this->panicOnDuplicateClass(
+                    $e->file_path,
+                    $cs->getClassScriptOf($e->class),
+                    $e->class
+                );
             }
         }
 
@@ -194,7 +202,7 @@ class ilCtrlStructureReader
     // RESULT STORAGE
     // ----------------------
 
-    protected function panicOnDuplicateClass(string $full_path, string $parent) : void
+    protected function panicOnDuplicateClass(string $full_path, string $other_path, string $parent) : void
     {
         $ilDB = $this->getDB();
 
@@ -226,7 +234,7 @@ class ilCtrlStructureReader
             sprintf(
                 $msg,
                 $parent,
-                $this->class_script[$parent],
+                $other_path,
                 $full_path
             )
         );

--- a/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
+++ b/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
@@ -133,24 +133,15 @@ class ilCtrlStructureReader
                 foreach ($parents as $parent) {
                     $this->addClassChild($parent, $child);
                 }
+
+                $cl = $this->getGUIClassNameFromClassFileName($file);
+                if ($this->containsClassDefinitionFor($cl, $content)) {
+                    $this->addClassScript($cl, $full_path);
+                }
             } catch (\LogicException $e) {
                 $e->setMessage("In file \"$full_path\": " . $e->getMessage());
                 throw $e;
             }
-
-            $handle = fopen($full_path, "r");
-            while (!feof($handle)) {
-                $line = fgets($handle, 4096);
-
-                $cl = $this->getGUIClassNameFromClassFileName($file);
-                if ($cl) {
-                    $pos = strpos(strtolower($line), "class " . $cl);
-                    if (is_int($pos)) {
-                        $this->addClassScript($cl, $full_path);
-                    }
-                }
-            }
-            fclose($handle);
         }
     }
 
@@ -205,6 +196,12 @@ class ilCtrlStructureReader
         if (!in_array($child, $this->class_childs[$parent])) {
             $this->class_childs[$parent][] = $child;
         }
+    }
+
+    protected function containsClassDefinitionFor(string $class, string $content) : bool
+    {
+        $regexp = "~.*class\s+$class~mi";
+        return preg_match($regexp, $content) != 0;
     }
 
     const IL_CTRL_DECLARATION_REGEXP = '~^.*@{WHICH}\s+(\w+)\s*:\s*(\w+(\s*,\s*\w+)*)\s*$~mi';

--- a/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
+++ b/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
@@ -113,99 +113,100 @@ class ilCtrlStructureReader
         }
 
         foreach ($this->getFilesIn($il_absolute_path, $a_cdir) as list($file, $full_path)) {
-            // files
-            if (preg_match("~^class.*php$~i", $file) || preg_match("~^ilSCORM13Player.php$~i", $file)) {
-                $handle = fopen($full_path, "r");
-                while (!feof($handle)) {
-                    $line = fgets($handle, 4096);
+            if (!$this->isInterestingFile($file)) {
+                continue;
+            }
 
-                    // handle @ilctrl_calls
-                    $pos = strpos(strtolower($line), "@ilctrl_calls");
-                    if (is_int($pos)) {
-                        $com = substr($line, $pos + 14);
-                        $pos2 = strpos($com, ":");
-                        if (is_int($pos2)) {
-                            $com_arr = explode(":", $com);
-                            $parent = strtolower(trim($com_arr[0]));
+            $handle = fopen($full_path, "r");
+            while (!feof($handle)) {
+                $line = fgets($handle, 4096);
 
-                            // check file duplicates
-                            if ($parent != "" && isset($this->class_script[$parent]) &&
-                                $this->class_script[$parent] != $full_path) {
-                                // delete all class to file assignments
-                                $ilDB->manipulate("DELETE FROM ctrl_classfile WHERE comp_prefix = " .
-                                    $ilDB->quote($this->comp_prefix, "text"));
-                                if ($this->comp_prefix == "") {
-                                    $ilDB->manipulate($q = "DELETE FROM ctrl_classfile WHERE " .
-                                        $ilDB->equals("comp_prefix", "", "text", true));
-                                }
+                // handle @ilctrl_calls
+                $pos = strpos(strtolower($line), "@ilctrl_calls");
+                if (is_int($pos)) {
+                    $com = substr($line, $pos + 14);
+                    $pos2 = strpos($com, ":");
+                    if (is_int($pos2)) {
+                        $com_arr = explode(":", $com);
+                        $parent = strtolower(trim($com_arr[0]));
 
-                                // delete all call entries
-                                $ilDB->manipulate("DELETE FROM ctrl_calls WHERE comp_prefix = " .
-                                    $ilDB->quote($this->comp_prefix, "text"));
-                                if ($this->comp_prefix == "") {
-                                    $ilDB->manipulate("DELETE FROM ctrl_calls WHERE comp_prefix IS NULL");
-                                }
-
-                                $msg = implode("\n", [
-                                    "Error: Duplicate call structure definition found (Class %s) in files:",
-                                    "- %s",
-                                    "- %s",
-                                    "",
-                                    "Please remove the file, that does not belong to the official ILIAS distribution.",
-                                    "After that invoke 'Tools' -> 'Reload Control Structure' in the ILIAS Setup."
-                                ]);
-
-                                throw new \Exception(
-                                    sprintf(
-                                        $msg,
-                                        $parent,
-                                        $this->class_script[$parent],
-                                        $full_path
-                                    )
-                                );
+                        // check file duplicates
+                        if ($parent != "" && isset($this->class_script[$parent]) &&
+                            $this->class_script[$parent] != $full_path) {
+                            // delete all class to file assignments
+                            $ilDB->manipulate("DELETE FROM ctrl_classfile WHERE comp_prefix = " .
+                                $ilDB->quote($this->comp_prefix, "text"));
+                            if ($this->comp_prefix == "") {
+                                $ilDB->manipulate($q = "DELETE FROM ctrl_classfile WHERE " .
+                                    $ilDB->equals("comp_prefix", "", "text", true));
                             }
 
-                            $this->class_script[$parent] = $full_path;
-                            $childs = explode(",", $com_arr[1]);
-                            foreach ($childs as $child) {
-                                $child = trim(strtolower($child));
-                                if (!isset($this->class_childs[$parent]) || !is_array($this->class_childs[$parent]) || !in_array($child, $this->class_childs[$parent])) {
-                                    $this->class_childs[$parent][] = $child;
-                                }
+                            // delete all call entries
+                            $ilDB->manipulate("DELETE FROM ctrl_calls WHERE comp_prefix = " .
+                                $ilDB->quote($this->comp_prefix, "text"));
+                            if ($this->comp_prefix == "") {
+                                $ilDB->manipulate("DELETE FROM ctrl_calls WHERE comp_prefix IS NULL");
                             }
+
+                            $msg = implode("\n", [
+                                "Error: Duplicate call structure definition found (Class %s) in files:",
+                                "- %s",
+                                "- %s",
+                                "",
+                                "Please remove the file, that does not belong to the official ILIAS distribution.",
+                                "After that invoke 'Tools' -> 'Reload Control Structure' in the ILIAS Setup."
+                            ]);
+
+                            throw new \Exception(
+                                sprintf(
+                                    $msg,
+                                    $parent,
+                                    $this->class_script[$parent],
+                                    $full_path
+                                )
+                            );
                         }
-                    }
 
-                    // handle isCalledBy comments
-                    $pos = strpos(strtolower($line), "@ilctrl_iscalledby");
-                    if (is_int($pos)) {
-                        $com = substr($line, $pos + 19);
-                        $pos2 = strpos($com, ":");
-                        if (is_int($pos2)) {
-                            $com_arr = explode(":", $com);
-                            $child = strtolower(trim($com_arr[0]));
-                            $this->class_script[$child] = $full_path;
-
-                            $parents = explode(",", $com_arr[1]);
-                            foreach ($parents as $parent) {
-                                $parent = trim(strtolower($parent));
-                                if (!isset($this->class_childs[$parent]) || !is_array($this->class_childs[$parent]) || !in_array($child, $this->class_childs[$parent])) {
-                                    $this->class_childs[$parent][] = $child;
-                                }
+                        $this->class_script[$parent] = $full_path;
+                        $childs = explode(",", $com_arr[1]);
+                        foreach ($childs as $child) {
+                            $child = trim(strtolower($child));
+                            if (!isset($this->class_childs[$parent]) || !is_array($this->class_childs[$parent]) || !in_array($child, $this->class_childs[$parent])) {
+                                $this->class_childs[$parent][] = $child;
                             }
-                        }
-                    }
-
-                    if (preg_match("~^class\.(.*GUI)\.php$~i", $file, $res)) {
-                        $cl = strtolower($res[1]);
-                        $pos = strpos(strtolower($line), "class " . $cl);
-                        if (is_int($pos) && (!isset($this->class_script[$cl]) || $this->class_script[$cl] == "")) {
-                            $this->class_script[$cl] = $full_path;
                         }
                     }
                 }
-                fclose($handle);
+
+                // handle isCalledBy comments
+                $pos = strpos(strtolower($line), "@ilctrl_iscalledby");
+                if (is_int($pos)) {
+                    $com = substr($line, $pos + 19);
+                    $pos2 = strpos($com, ":");
+                    if (is_int($pos2)) {
+                        $com_arr = explode(":", $com);
+                        $child = strtolower(trim($com_arr[0]));
+                        $this->class_script[$child] = $full_path;
+
+                        $parents = explode(",", $com_arr[1]);
+                        foreach ($parents as $parent) {
+                            $parent = trim(strtolower($parent));
+                            if (!isset($this->class_childs[$parent]) || !is_array($this->class_childs[$parent]) || !in_array($child, $this->class_childs[$parent])) {
+                                $this->class_childs[$parent][] = $child;
+                            }
+                        }
+                    }
+                }
+
+                if (preg_match("~^class\.(.*GUI)\.php$~i", $file, $res)) {
+                    $cl = strtolower($res[1]);
+                    $pos = strpos(strtolower($line), "class " . $cl);
+                    if (is_int($pos) && (!isset($this->class_script[$cl]) || $this->class_script[$cl] == "")) {
+                        $this->class_script[$cl] = $full_path;
+                    }
+                }
             }
+            fclose($handle);
         }
     }
 
@@ -241,6 +242,13 @@ class ilCtrlStructureReader
     private function normalizePath(string $path) : string
     {
         return str_replace(['//'], ['/'], $path);
+    }
+
+    const INTERESTING_FILES_REGEXP = "~^(class\..*\.php)|(ilSCORM13Player\.php)$~i";
+
+    protected function isInterestingFile(string $file) : bool
+    {
+        return preg_match(self::INTERESTING_FILES_REGEXP, $file);
     }
 
     /**

--- a/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
+++ b/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
@@ -198,8 +198,8 @@ class ilCtrlStructureReader
                     }
                 }
 
-                if (preg_match("~^class\.(.*GUI)\.php$~i", $file, $res)) {
-                    $cl = strtolower($res[1]);
+                $cl = $this->getGUIClassNameFromClassFileName($file);
+                if ($cl) {
                     $pos = strpos(strtolower($line), "class " . $cl);
                     if (is_int($pos) && (!isset($this->class_script[$cl]) || $this->class_script[$cl] == "")) {
                         $this->class_script[$cl] = $full_path;
@@ -249,6 +249,17 @@ class ilCtrlStructureReader
     protected function isInterestingFile(string $file) : bool
     {
         return preg_match(self::INTERESTING_FILES_REGEXP, $file);
+    }
+
+    const GUI_CLASS_FILE_REGEXP = "~^class\.(.*GUI)\.php$~i";
+
+    protected function getGUIClassNameFromClassFileName(string $file) : ?string
+    {
+        $res = [];
+        if (preg_match(self::GUI_CLASS_FILE_REGEXP, $file, $res)) {
+            return strtolower($res[1]);
+        }
+        return null;
     }
 
     /**

--- a/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
+++ b/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
@@ -297,6 +297,10 @@ class ilCtrlStructureReader
     // PARSING
     // ----------------------
 
+    /**
+     * @throw \LogicException if some file declares control structure for multiple classes
+     * @throw \RuntimeException if there are different locations defined for some class.
+     */
     protected function parseFileTo(\ilCtrlStructure $cs, string $full_path, string $content) : \ilCtrlStructure
     {
         list($parent, $children) = $this->getIlCtrlCalls($content);

--- a/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
+++ b/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
@@ -134,8 +134,8 @@ class ilCtrlStructureReader
                     $this->addClassChild($parent, $child);
                 }
 
-                $cl = $this->getGUIClassNameFromClassFileName($file);
-                if ($this->containsClassDefinitionFor($cl, $content)) {
+                $cl = $this->getGUIClassNameFromClassPath($full_path);
+                if ($cl && $this->containsClassDefinitionFor($cl, $content)) {
                     $this->addClassScript($cl, $full_path);
                 }
             } catch (\LogicException $e) {
@@ -270,12 +270,12 @@ class ilCtrlStructureReader
         return preg_match(self::INTERESTING_FILES_REGEXP, $file);
     }
 
-    const GUI_CLASS_FILE_REGEXP = "~^class\.(.*GUI)\.php$~i";
+    const GUI_CLASS_FILE_REGEXP = "~^.*/class\.(.*GUI)\.php$~i";
 
-    protected function getGUIClassNameFromClassFileName(string $file) : ?string
+    protected function getGUIClassNameFromClassPath(string $path) : ?string
     {
         $res = [];
-        if (preg_match(self::GUI_CLASS_FILE_REGEXP, $file, $res)) {
+        if (preg_match(self::GUI_CLASS_FILE_REGEXP, $path, $res)) {
             return strtolower($res[1]);
         }
         return null;

--- a/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
+++ b/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
@@ -132,7 +132,7 @@ class ilCtrlStructureReader
     // DIRECTORY TRAVERSAL
     // ----------------------
 
-    protected function getFilesIn(string $dir)
+    protected function getFilesIn(string $dir) : \Generator
     {
         foreach (scandir($dir) as $e) {
             if ($e == "." || $e == "..") {
@@ -153,7 +153,7 @@ class ilCtrlStructureReader
         }
     }
 
-    protected function shouldDescendToDirectory(string $dir)
+    protected function shouldDescendToDirectory(string $dir) : bool
     {
         $il_absolute_path = $this->getILIASAbsolutePath();
         $data_dir = $this->normalizePath($il_absolute_path . "/data");

--- a/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
+++ b/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
@@ -110,7 +110,7 @@ class ilCtrlStructureReader
     public function read($a_cdir)
     {
         $ilDB = $this->getDB();
-        if (defined(ILIAS_ABSOLUTE_PATH)) {
+        if (defined("ILIAS_ABSOLUTE_PATH")) {
             $il_absolute_path = ILIAS_ABSOLUTE_PATH;
         } else {
             $il_absolute_path = dirname(__FILE__, 5);

--- a/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
+++ b/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
@@ -140,7 +140,7 @@ class ilCtrlStructureReader
             $full_path = "$a_cdir/$file";
 
             // directories
-            if (@is_dir($full_path) && $this->shouldDescendToDirectory($full_path)) {
+            if (@is_dir($full_path) && $this->shouldDescendToDirectory($il_absolute_path, $full_path)) {
                 $this->read($full_path);
                 continue;
             }
@@ -243,6 +243,10 @@ class ilCtrlStructureReader
                 fclose($handle);
             }
         }
+    }
+
+    protected function getFilesIn(string $dir)
+    {
     }
 
     /**

--- a/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
+++ b/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
@@ -1,5 +1,5 @@
 <?php
-/* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
+/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 /**
 * Class ilCtrlStructureReader

--- a/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
+++ b/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
@@ -60,10 +60,7 @@ class ilCtrlStructureReader
             return;
         }
 
-        require_once('./Services/UICore/classes/class.ilCachedCtrl.php');
-        ilCachedCtrl::flush();
-        require_once('./Services/GlobalCache/classes/class.ilGlobalCache.php');
-        ilGlobalCache::flushAll();
+        $this->flushCaches();
     
         // prefix for component
         $this->comp_prefix = $a_comp_prefix;
@@ -88,6 +85,12 @@ class ilCtrlStructureReader
                 $this->ini->write();
             }
         }
+    }
+
+    protected function flushCaches()
+    {
+        ilCachedCtrl::flush();
+        ilGlobalCache::flushAll();
     }
 
     /**

--- a/Services/UICore/classes/class.ilCtrlStructure.php
+++ b/Services/UICore/classes/class.ilCtrlStructure.php
@@ -1,0 +1,106 @@
+<?php
+/* Copyright (c) 2020 Richard Klees, Extended GPL, see docs/LICENSE */
+
+/**
+ * The CtrlStructure knows how GUIs call each other and where the code of the
+ * guis is located.
+ */
+class ilCtrlStructure
+{
+    /**
+     * @var array<string, string>
+     */
+    protected $class_scripts;
+
+    /**
+     * @var array<string, string[]>
+     */
+    protected $class_children;
+
+    public function __construct(array $class_scripts = [], array $class_children = [])
+    {
+        $this->class_scripts = [];
+        $this->class_children = [];
+        foreach ($class_scripts as $k => $v) {
+            $this->addClassScript($k, $v);
+        }
+        foreach ($class_children as $k => $vs) {
+            foreach ($vs as $v) {
+                $this->addClassChild($k, $v);
+            }
+        }
+    }
+
+    public function withClassScript(string $class, string $file_path) : \ilCtrlStructure
+    {
+        $clone = clone $this;
+        $clone->addClassScript($class, $file_path);
+        return $clone;
+    }
+
+    public function withClassChild(string $parent, string $child) : \ilCtrlStructure
+    {
+        $clone = clone $this;
+        $clone->addClassChild($parent, $child);
+        return $clone;
+    }
+
+    public function getClassScripts() : \Generator
+    {
+        foreach ($this->class_scripts as $k => $v) {
+            yield $k => $v;
+        }
+    }
+
+    public function getClassChildren() : \Generator
+    {
+        foreach ($this->class_children as $k => $v) {
+            yield $k => $v;
+        }
+    }
+
+    public function getClassScriptOf(string $class) : ?string
+    {
+        if (!isset($this->class_scripts[$class])) {
+            return null;
+        }
+        return $this->class_scripts[$class];
+    }
+
+    protected function addClassScript(string $class, string $file_path) : void
+    {
+        if ($class == "") {
+            throw new \InvalidArgumentException(
+                "Can't add class script for an empty class."
+            );
+        }
+
+        if (isset($this->class_scripts[$class]) && $this->class_scripts[$class] != $file_path) {
+            $e = new \RuntimeException(
+                "Can't add script '$file_path' for class '$class', a script for that class already exists."
+            );
+            $e->file_path = $file_path;
+            $e->class = $class;
+            throw $e;
+        }
+
+        $this->class_scripts[$class] = $file_path;
+    }
+
+    protected function addClassChild(string $parent, string $child) : void
+    {
+        if ($parent == "") {
+            throw new \InvalidArgumentException(
+                "Can't add class child for an empty parent."
+            );
+        }
+
+        if (!isset($this->class_children[$parent])) {
+            $this->class_children[$parent] = [];
+        }
+
+        if (!in_array($child, $this->class_children[$parent])) {
+            $this->class_children[$parent][] = $child;
+        }
+    }
+}

--- a/Services/UICore/test/ilCtrlStructureReaderTest.php
+++ b/Services/UICore/test/ilCtrlStructureReaderTest.php
@@ -19,8 +19,35 @@ class ilCtrlStructureReaderTest extends TestCase
 
     public function testReadSmoke()
     {
-        $dir = __DIR__ . "/test_dir/";
+        $dir = __DIR__ . "/test_dir";
         $result = $this->reader->read($dir);
         $this->assertTrue($result === false || is_null($result));
+    }
+
+    public function testReadClassScriptIsAsExpected()
+    {
+        $dir = __DIR__ . "/test_dir/";
+        $result = $this->reader->read($dir);
+
+        $expected_class_script = [
+           "ilmytestinggui" => "$dir/class.ilMyTestingGUI.php"
+        ];
+        $this->assertEquals($this->reader->class_script, $expected_class_script);
+    }
+
+    public function testReadClassChildsIsAsExpected()
+    {
+        $dir = __DIR__ . "/test_dir/";
+        $result = $this->reader->read($dir);
+
+        $expected_class_childs= [
+           "ilmytestinggui" => [
+                "ilmyothertestinggui"
+            ],
+            "ilmythirdtestinggui" => [
+                "ilmytestinggui"
+            ]
+        ];
+        $this->assertEquals($this->reader->class_childs, $expected_class_childs);
     }
 }

--- a/Services/UICore/test/ilCtrlStructureReaderTest.php
+++ b/Services/UICore/test/ilCtrlStructureReaderTest.php
@@ -17,6 +17,10 @@ class ilCtrlStructureReaderTest extends TestCase
             {
                 return $this->getFilesIn($il_absolute_path, $dir);
             }
+            public function _isInterestingFile(string $file)
+            {
+                return $this->isInterestingFile($file);
+            }
         })
             ->withDB($this->db);
     }
@@ -142,5 +146,15 @@ class ilCtrlStructureReaderTest extends TestCase
         sort($expected);
         sort($result);
         $this->assertEquals($expected, $result);
+    }
+
+    public function testIsInterestingFile()
+    {
+        $this->assertTrue($this->reader->_isInterestingFile("ilSCORM13Player.php"));
+        $this->assertTrue($this->reader->_isInterestingFile("class.ilMyTestingGUI.php"));
+        $this->assertFalse($this->reader->_isInterestingFile("foo.php"));
+        $this->assertFalse($this->reader->_isInterestingFile("picture.png"));
+        $this->assertFalse($this->reader->_isInterestingFile("icon.svg"));
+        $this->assertFalse($this->reader->_isInterestingFile("data.json"));
     }
 }

--- a/Services/UICore/test/ilCtrlStructureReaderTest.php
+++ b/Services/UICore/test/ilCtrlStructureReaderTest.php
@@ -21,6 +21,10 @@ class ilCtrlStructureReaderTest extends TestCase
             {
                 return $this->isInterestingFile($file);
             }
+            public function _getGUIClassNameFromClassFileName(string $file)
+            {
+                return $this->getGUIClassNameFromClassFileName($file);
+            }
         })
             ->withDB($this->db);
     }
@@ -156,5 +160,15 @@ class ilCtrlStructureReaderTest extends TestCase
         $this->assertFalse($this->reader->_isInterestingFile("picture.png"));
         $this->assertFalse($this->reader->_isInterestingFile("icon.svg"));
         $this->assertFalse($this->reader->_isInterestingFile("data.json"));
+    }
+
+    public function testGetGUIClassNameFromClassFileName()
+    {
+        $this->assertNull($this->reader->_getGUIClassNameFromClassFileName("ilSCORM13Player.php"));
+        $this->assertEquals("ilmytestinggui", $this->reader->_getGUIClassNameFromClassFileName("class.ilMyTestingGUI.php"));
+        $this->assertNull($this->reader->_getGUIClassNameFromClassFileName("foo.php"));
+        $this->assertNull($this->reader->_getGUIClassNameFromClassFileName("picture.png"));
+        $this->assertNull($this->reader->_getGUIClassNameFromClassFileName("icon.svg"));
+        $this->assertNull($this->reader->_getGUIClassNameFromClassFileName("data.json"));
     }
 }

--- a/Services/UICore/test/ilCtrlStructureReaderTest.php
+++ b/Services/UICore/test/ilCtrlStructureReaderTest.php
@@ -13,6 +13,10 @@ class ilCtrlStructureReaderTest extends TestCase
             {
                 return $this->shouldDescendToDirectory($il_absolute_path, $dir);
             }
+            public function _getFilesIn(string $il_absolute_path, string $dir)
+            {
+                return $this->getFilesIn($il_absolute_path, $dir);
+            }
         })
             ->withDB($this->db);
     }
@@ -125,5 +129,18 @@ class ilCtrlStructureReaderTest extends TestCase
         $this->assertTrue($this->reader->_shouldDescendToDirectory("", "/bar"));
         $this->assertFalse($this->reader->_shouldDescendToDirectory("", "/data"));
         $this->assertFalse($this->reader->_shouldDescendToDirectory("", "/Customizing"));
+    }
+
+    public function testFilesInDir()
+    {
+        $dir = __DIR__ . "/test_dir/";
+        $expected = [
+            ["class.ilMyTestingGUI.php", "$dir/class.ilMyTestingGUI.php"],
+            ["test_file", "$dir/sub_test_dir/test_file"]
+        ];
+        $result = iterator_to_array($this->reader->_getFilesIn("", $dir));
+        sort($expected);
+        sort($result);
+        $this->assertEquals($expected, $result);
     }
 }

--- a/Services/UICore/test/ilCtrlStructureReaderTest.php
+++ b/Services/UICore/test/ilCtrlStructureReaderTest.php
@@ -7,11 +7,20 @@ class ilCtrlStructureReaderTest extends TestCase
 {
     protected function setUp() : void
     {
-        $this->reader = new ilCtrlStructureReader();
+        $this->db = $this->createMock(\ilDBInterface::class);
+        $this->reader = (new ilCtrlStructureReader())
+            ->withDB($this->db);
     }
 
     public function testSmoke()
     {
         $this->assertInstanceOf(ilCtrlStructureReader::class, $this->reader);
+    }
+
+    public function testReadSmoke()
+    {
+        $dir = __DIR__ . "/test_dir/";
+        $result = $this->reader->read($dir);
+        $this->assertTrue($result === false || is_null($result));
     }
 }

--- a/Services/UICore/test/ilCtrlStructureReaderTest.php
+++ b/Services/UICore/test/ilCtrlStructureReaderTest.php
@@ -37,6 +37,10 @@ class ilCtrlStructureReaderTest extends TestCase
             {
                 return $this->getIlCtrlCalls($content);
             }
+            public function _getIlCtrlIsCalledBy(string $content)
+            {
+                return $this->getIlCtrlIsCalledBy($content);
+            }
         })
             ->withDB($this->db);
     }
@@ -252,6 +256,61 @@ require_once "./Services/Container/classes/class.ilContainerGUI.php";
  * @ilCtrl_Calls ilObjCourseGUI: ilCourseRegistrationGUI, ilCourseObjectivesGUI
  * @ilCtrl_Calls ilObjCourseGUI: ilObjCourseGroupingGUI, ilInfoScreenGUI, ilLearningProgressGUI, ilPermissionGUI
  * @ilCtrl_Calls ilObjCourseGUI: ilRepositorySearchGUI
+ *
+ * @extends ilContainerGUI
+ */
+class ilObjCourseGUI extends ilContainerGUI
+{
+}
+PHP
+        );
+        $expected = [
+            "ilcourseregistrationgui",
+            "ilcourseobjectivesgui",
+            "ilobjcoursegroupinggui",
+            "ilinfoscreengui",
+            "illearningprogressgui",
+            "ilpermissiongui",
+            "ilrepositorysearchgui"
+        ];
+
+        sort($expected);
+        sort($children);
+
+        $this->assertEquals("ilobjcoursegui", $parent);
+        $this->assertEquals($expected, $children);
+    }
+
+    public function testGetIlCtrlIsCalledByNoContent()
+    {
+        $gen = $this->reader->_getIlCtrlIsCalledBy(
+            <<<"PHP"
+class SomeRandomClass {
+}
+PHP
+        );
+        $this->assertNull($gen);
+    }
+
+    public function testGetIlCtrlIsCalledByWithContent()
+    {
+        list($parent, $children) = $this->reader->_getIlCtrlIsCalledBy(
+            <<<"PHP"
+<?php
+/* Copyright (c) 2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+
+require_once "./Services/Container/classes/class.ilContainerGUI.php";
+
+/**
+ * Class ilObjCourseGUI
+ *
+ * @author Stefan Meyer <smeyer.ilias@gmx.de>
+ * $Id$
+ *
+ * @ilCtrl_IsCalledBy ilObjCourseGUI: ilCourseRegistrationGUI, ilCourseObjectivesGUI
+ * @ilCtrl_IsCalledBy ilObjCourseGUI: ilObjCourseGroupingGUI, ilInfoScreenGUI, ilLearningProgressGUI, ilPermissionGUI
+ * @ilCtrl_IsCalledBy ilObjCourseGUI: ilRepositorySearchGUI
  *
  * @extends ilContainerGUI
  */

--- a/Services/UICore/test/ilCtrlStructureReaderTest.php
+++ b/Services/UICore/test/ilCtrlStructureReaderTest.php
@@ -21,9 +21,9 @@ class ilCtrlStructureReaderTest extends TestCase
             {
                 return $this->isInterestingFile($file);
             }
-            public function _getGUIClassNameFromClassFileName(string $file)
+            public function _getGUIClassNameFromClassPath(string $file)
             {
-                return $this->getGUIClassNameFromClassFileName($file);
+                return $this->getGUIClassNameFromClassPath($file);
             }
             public function _addClassScript(string $class, string $file_path)
             {
@@ -182,14 +182,14 @@ class ilCtrlStructureReaderTest extends TestCase
         $this->assertFalse($this->reader->_isInterestingFile("data.json"));
     }
 
-    public function testGetGUIClassNameFromClassFileName()
+    public function testGetGUIClassNameFromClassPath()
     {
-        $this->assertNull($this->reader->_getGUIClassNameFromClassFileName("ilSCORM13Player.php"));
-        $this->assertEquals("ilmytestinggui", $this->reader->_getGUIClassNameFromClassFileName("class.ilMyTestingGUI.php"));
-        $this->assertNull($this->reader->_getGUIClassNameFromClassFileName("foo.php"));
-        $this->assertNull($this->reader->_getGUIClassNameFromClassFileName("picture.png"));
-        $this->assertNull($this->reader->_getGUIClassNameFromClassFileName("icon.svg"));
-        $this->assertNull($this->reader->_getGUIClassNameFromClassFileName("data.json"));
+        $this->assertNull($this->reader->_getGUIClassNameFromClassPath("/my/dir/ilSCORM13Player.php"));
+        $this->assertEquals("ilmytestinggui", $this->reader->_getGUIClassNameFromClassPath("/my/dir/class.ilMyTestingGUI.php"));
+        $this->assertNull($this->reader->_getGUIClassNameFromClassPath("/my/dir/foo.php"));
+        $this->assertNull($this->reader->_getGUIClassNameFromClassPath("/my/dir/picture.png"));
+        $this->assertNull($this->reader->_getGUIClassNameFromClassPath("/my/dir/icon.svg"));
+        $this->assertNull($this->reader->_getGUIClassNameFromClassPath("/my/dir/data.json"));
     }
 
     public function testAddClassScript()

--- a/Services/UICore/test/ilCtrlStructureReaderTest.php
+++ b/Services/UICore/test/ilCtrlStructureReaderTest.php
@@ -8,7 +8,12 @@ class ilCtrlStructureReaderTest extends TestCase
     protected function setUp() : void
     {
         $this->db = $this->createMock(\ilDBInterface::class);
-        $this->reader = (new ilCtrlStructureReader())
+        $this->reader = (new class() extends ilCtrlStructureReader {
+            public function _shouldDescendToDirectory(string $il_absolute_path, string $dir)
+            {
+                return $this->shouldDescendToDirectory($il_absolute_path, $dir);
+            }
+        })
             ->withDB($this->db);
     }
 
@@ -112,5 +117,13 @@ class ilCtrlStructureReaderTest extends TestCase
             );
 
         $result = $this->reader->read($dir);
+    }
+
+    public function testShouldDescendToDirectory()
+    {
+        $this->assertTrue($this->reader->_shouldDescendToDirectory("", "/foo"));
+        $this->assertTrue($this->reader->_shouldDescendToDirectory("", "/bar"));
+        $this->assertFalse($this->reader->_shouldDescendToDirectory("", "/data"));
+        $this->assertFalse($this->reader->_shouldDescendToDirectory("", "/Customizing"));
     }
 }

--- a/Services/UICore/test/ilCtrlStructureReaderTest.php
+++ b/Services/UICore/test/ilCtrlStructureReaderTest.php
@@ -151,7 +151,7 @@ class ilCtrlStructureReaderTest extends TestCase
             ->method("manipulate")
             ->withConsecutive(
                 ["DELETE FROM ctrl_classfile WHERE comp_prefix = \"$my_comp_prefix\""],
-                ["DELETE FROM ctrl_calls WHERE comp_prefix = \"$my_comp_prefix\""],
+                ["DELETE FROM ctrl_calls WHERE comp_prefix = \"$my_comp_prefix\""]
             );
 
         $result = $this->reader->_readDirTo($dir, $ctrl_structure);

--- a/Services/UICore/test/ilCtrlStructureReaderTest.php
+++ b/Services/UICore/test/ilCtrlStructureReaderTest.php
@@ -49,6 +49,10 @@ class ilCtrlStructureReaderTest extends TestCase
             {
                 return "";
             }
+            public function _read(string $a_cdir) : bool
+            {
+                return $this->read($a_cdir);
+            }
         })
             ->withDB($this->db);
     }
@@ -61,14 +65,14 @@ class ilCtrlStructureReaderTest extends TestCase
     public function testReadSmoke()
     {
         $dir = __DIR__ . "/test_dir";
-        $result = $this->reader->read($dir);
-        $this->assertTrue($result === false || is_null($result));
+        $result = $this->reader->_read($dir);
+        $this->assertTrue(is_bool($result));
     }
 
     public function testReadClassScriptIsAsExpected()
     {
         $dir = __DIR__ . "/test_dir";
-        $result = $this->reader->read($dir);
+        $result = $this->reader->_read($dir);
 
         $expected_class_script = [
            "ilmytestinggui" => "$dir/class.ilMyTestingGUI.php"
@@ -79,7 +83,7 @@ class ilCtrlStructureReaderTest extends TestCase
     public function testReadClassChildsIsAsExpected()
     {
         $dir = __DIR__ . "/test_dir/";
-        $result = $this->reader->read($dir);
+        $result = $this->reader->_read($dir);
 
         $expected_class_childs= [
            "ilmytestinggui" => [
@@ -121,7 +125,7 @@ class ilCtrlStructureReaderTest extends TestCase
                 ["DELETE FROM ctrl_calls WHERE comp_prefix IS NULL"]
             );
 
-        $result = $this->reader->read($dir);
+        $result = $this->reader->_read($dir);
     }
 
     public function testReadRemovesDuplicateFilesInDatabaseIfCompPrefixIsSet()
@@ -152,7 +156,7 @@ class ilCtrlStructureReaderTest extends TestCase
                 ["DELETE FROM ctrl_calls WHERE comp_prefix = \"$my_comp_prefix\""],
             );
 
-        $result = $this->reader->read($dir);
+        $result = $this->reader->_read($dir);
     }
 
     public function testShouldDescendToDirectory()

--- a/Services/UICore/test/ilCtrlStructureReaderTest.php
+++ b/Services/UICore/test/ilCtrlStructureReaderTest.php
@@ -1,0 +1,17 @@
+<?php
+/* Copyright (c) 2020 Richard Klees <richard.klees@concepts-and-training.de>, Extended GPL, see docs/LICENSE */
+
+use PHPUnit\Framework\TestCase;
+
+class ilCtrlStructureReaderTest extends TestCase
+{
+    protected function setUp() : void
+    {
+        $this->reader = new ilCtrlStructureReader();
+    }
+
+    public function testSmoke()
+    {
+        $this->assertInstanceOf(ilCtrlStructureReader::class, $this->reader);
+    }
+}

--- a/Services/UICore/test/ilCtrlStructureReaderTest.php
+++ b/Services/UICore/test/ilCtrlStructureReaderTest.php
@@ -9,13 +9,13 @@ class ilCtrlStructureReaderTest extends TestCase
     {
         $this->db = $this->createMock(\ilDBInterface::class);
         $this->reader = (new class() extends ilCtrlStructureReader {
-            public function _shouldDescendToDirectory(string $il_absolute_path, string $dir)
+            public function _shouldDescendToDirectory(string $dir)
             {
-                return $this->shouldDescendToDirectory($il_absolute_path, $dir);
+                return $this->shouldDescendToDirectory($dir);
             }
-            public function _getFilesIn(string $il_absolute_path, string $dir)
+            public function _getFilesIn(string $dir)
             {
-                return $this->getFilesIn($il_absolute_path, $dir);
+                return $this->getFilesIn($dir);
             }
             public function _isInterestingFile(string $file)
             {
@@ -44,6 +44,10 @@ class ilCtrlStructureReaderTest extends TestCase
             public function _containsClassDefinitionFor(string $class, string $content)
             {
                 return $this->containsClassDefinitionFor($class, $content);
+            }
+            protected function getILIASAbsolutePath() : string
+            {
+                return "";
             }
         })
             ->withDB($this->db);
@@ -153,10 +157,10 @@ class ilCtrlStructureReaderTest extends TestCase
 
     public function testShouldDescendToDirectory()
     {
-        $this->assertTrue($this->reader->_shouldDescendToDirectory("", "/foo"));
-        $this->assertTrue($this->reader->_shouldDescendToDirectory("", "/bar"));
-        $this->assertFalse($this->reader->_shouldDescendToDirectory("", "/data"));
-        $this->assertFalse($this->reader->_shouldDescendToDirectory("", "/Customizing"));
+        $this->assertTrue($this->reader->_shouldDescendToDirectory("/foo"));
+        $this->assertTrue($this->reader->_shouldDescendToDirectory("/bar"));
+        $this->assertFalse($this->reader->_shouldDescendToDirectory("/data"));
+        $this->assertFalse($this->reader->_shouldDescendToDirectory("/Customizing"));
     }
 
     public function testFilesInDir()
@@ -166,7 +170,7 @@ class ilCtrlStructureReaderTest extends TestCase
             ["class.ilMyTestingGUI.php", "$dir/class.ilMyTestingGUI.php"],
             ["test_file", "$dir/sub_test_dir/test_file"]
         ];
-        $result = iterator_to_array($this->reader->_getFilesIn("", $dir));
+        $result = iterator_to_array($this->reader->_getFilesIn($dir));
         sort($expected);
         sort($result);
         $this->assertEquals($expected, $result);

--- a/Services/UICore/test/ilCtrlStructureReaderTest.php
+++ b/Services/UICore/test/ilCtrlStructureReaderTest.php
@@ -41,6 +41,10 @@ class ilCtrlStructureReaderTest extends TestCase
             {
                 return $this->getIlCtrlIsCalledBy($content);
             }
+            public function _containsClassDefinitionFor(string $class, string $content)
+            {
+                return $this->containsClassDefinitionFor($class, $content);
+            }
         })
             ->withDB($this->db);
     }
@@ -334,5 +338,29 @@ PHP
 
         $this->assertEquals("ilobjcoursegui", $parent);
         $this->assertEquals($expected, $children);
+    }
+
+    public function testContainsClassDefinitionFor()
+    {
+        $res = $this->reader->_containsClassDefinitionFor(
+            "SomeRandomClass",
+            <<<"PHP"
+class SomeRandomClass {
+}
+PHP
+        );
+        $this->assertTrue($res);
+    }
+
+    public function testDoesNotContainClassDefinitionFor()
+    {
+        $res = $this->reader->_containsClassDefinitionFor(
+            "SomeRandomClass",
+            <<<"PHP"
+class fooSomeRandomClass {
+}
+PHP
+        );
+        $this->assertFalse($res);
     }
 }

--- a/Services/UICore/test/ilCtrlStructureTest.php
+++ b/Services/UICore/test/ilCtrlStructureTest.php
@@ -1,0 +1,101 @@
+<?php
+/* Copyright (c) 2020 Richard Klees <richard.klees@concepts-and-training.de>, Extended GPL, see docs/LICENSE */
+
+use PHPUnit\Framework\TestCase;
+
+class ilCtrlStructureTest extends TestCase
+{
+    protected function setUp() : void
+    {
+        $this->ctrl_structure = new \ilCtrlStructure();
+    }
+
+    public function testAddClassScript()
+    {
+        $this->ctrl_structure =$this->ctrl_structure
+            ->withClassScript("class1", "file1")
+            ->withClassScript("class2", "file2")
+            ->withClassScript("class3", "file3")
+            ->withClassScript("class2", "file2");
+
+        $expected = [
+            "class1" => "file1",
+            "class2" => "file2",
+            "class3" => "file3",
+        ];
+
+        $this->assertEquals(
+            $expected,
+            iterator_to_array($this->ctrl_structure->getClassScripts())
+        );
+    }
+
+    public function testAddClassScriptPanicsOnDuplicate()
+    {
+        $this->expectException(\RuntimeException::class);
+
+        $this->ctrl_structure
+            ->withClassScript("class1", "file1")
+            ->withClassScript("class1", "file2");
+    }
+
+    public function testAddClassChild()
+    {
+        $this->ctrl_structure = $this->ctrl_structure
+            ->withClassChild("parent1", "child1")
+            ->withClassChild("parent2", "child2")
+            ->withClassChild("parent1", "child3");
+
+        $expected = [
+            "parent1" => ["child1", "child3"],
+            "parent2" => ["child2"]
+        ];
+
+        $this->assertEquals(
+            $expected,
+            iterator_to_array($this->ctrl_structure->getClassChildren())
+        );
+    }
+
+    public function testConstructor()
+    {
+        $scripts = [
+            "class1" => "file1",
+            "class2" => "file2",
+            "class3" => "file3",
+        ];
+
+        $children = [
+            "parent1" => ["child1", "child3"],
+            "parent2" => ["child2"]
+        ];
+
+        $ctrl_structure = new \ilCtrlStructure($scripts, $children);
+    
+        $this->assertEquals(
+            $scripts,
+            iterator_to_array($ctrl_structure->getClassScripts())
+        );
+
+        $this->assertEquals(
+            $children,
+            iterator_to_array($ctrl_structure->getClassChildren())
+        );
+    }
+
+    public function testGetClassScriptOf()
+    {
+        $scripts = [
+            "class1" => "file1",
+            "class2" => "file2",
+            "class3" => "file3",
+        ];
+
+        $ctrl_structure = new \ilCtrlStructure($scripts, []);
+
+        $this->assertEquals("file1", $ctrl_structure->getClassScriptOf("class1"));
+        $this->assertEquals("file2", $ctrl_structure->getClassScriptOf("class2"));
+        $this->assertEquals("file3", $ctrl_structure->getClassScriptOf("class3"));
+        $this->assertSame(null, $ctrl_structure->getClassScriptOf("class4"));
+    }
+}

--- a/Services/UICore/test/ilServicesUICoreSuite.php
+++ b/Services/UICore/test/ilServicesUICoreSuite.php
@@ -21,6 +21,8 @@ class ilServicesUICoreSuite extends TestSuite
         $suite->addTestSuite("ilTemplateTest");
         include_once("./Services/UICore/test/ilCtrlStructureReaderTest.php");
         $suite->addTestSuite("ilCtrlStructureReaderTest");
+        include_once("./Services/UICore/test/ilCtrlStructureTest.php");
+        $suite->addTestSuite("ilCtrlStructureTest");
 
         return $suite;
     }

--- a/Services/UICore/test/ilServicesUICoreSuite.php
+++ b/Services/UICore/test/ilServicesUICoreSuite.php
@@ -19,6 +19,8 @@ class ilServicesUICoreSuite extends TestSuite
     
         include_once("./Services/UICore/test/ilTemplateTest.php");
         $suite->addTestSuite("ilTemplateTest");
+        include_once("./Services/UICore/test/ilCtrlStructureReaderTest.php");
+        $suite->addTestSuite("ilCtrlStructureReaderTest");
 
         return $suite;
     }

--- a/Services/UICore/test/test_dir/class.ilMyTestingGUI.php
+++ b/Services/UICore/test/test_dir/class.ilMyTestingGUI.php
@@ -1,0 +1,10 @@
+<?php
+/* Copyright (c) 2020 Richard Klees <richard.klees@concepts-and-training.de>, Extended GPL, see docs/LICENSE */
+
+/**
+ * @ilCtrl_Calls ilMyTestingGUI: ilMyOtherTestingGUI
+ * @ilCtrl_IsCalledBy ilMyTestingGUI: ilMyThirdTestingGUI
+ */
+class ilMyTestingGUI
+{
+}


### PR DESCRIPTION
Hi @alex40724,

I did some refactoring in the `ilCtrlStructureReader` in an attempt to prepare it to be moved to an artifact. I think we are not quite there yet, but I also think this is a good point to show my work and (hopefully) get this merged.

What I did so far:
* I restructured the parsing process in `ilCtrlStructureReader` and broke it apart in several pieces. I wrote unit tests in that process where possible.
* I introduced `ilCtrlStructure` to hold the actual control structure instead of using plain arrays and wrote unit tests for this too.

The end result might be looking fairly different then the state from where I started, but I think it should be possible to follow my moves via the various commits and see that they are quite digestible 
when viewed individually.

There still are some more things I would do before introducing the `ilCtrlStructure` as artifact (roughly):
* Move creation of node-ids out of the database.
* Introduce a repository interface for `ilCtrlStructure` and implement it for the DB-version.
* Enhance `ilCtrlStructure` and use it together with the repository class in `ilCtrl`.
* Implement the repository for the artifact case.

I'm looking forward to your feedback!

Best regards!
