### PR TITLE
Setup: Fix wrong type if 'error_reporting' could not be determined

### DIFF
--- a/setup/include/inc.setup_header.php
+++ b/setup/include/inc.setup_header.php
@@ -33,7 +33,7 @@
 use ILIAS\GlobalScreen\Provider\NullProviderFactory;
 use ILIAS\GlobalScreen\Services;
 
-error_reporting((ini_get("error_reporting") & ~E_NOTICE) & ~E_DEPRECATED);
+error_reporting(((int) (ini_get("error_reporting")) & ~E_NOTICE) & ~E_DEPRECATED);
 
 require_once __DIR__ . "/../../libs/composer/vendor/autoload.php";
 


### PR DESCRIPTION
Mantis Issue: https://mantis.ilias.de/view.php?id=27781

Please cherry-pick to `trunk` as well.