### PR TITLE
QuestionPool/Math: Restored PHP <= 7.0.x behaviour if one operand is …

### DIFF
--- a/Services/Math/classes/class.ilMathPhpAdapter.php
+++ b/Services/Math/classes/class.ilMathPhpAdapter.php
@@ -49,9 +49,20 @@ class ilMathPhpAdapter extends ilMathBaseAdapter
             throw new ilMathDivisionByZeroException(sprintf("Division of %s by %s not possible!", $left_operand, $right_operand));
         }
 
-        $res = $this->normalize($left_operand) / $this->normalize($right_operand);
+        // This ensures the old PHP <= 7.0.x behaviour, see: #27785 / #26361
+        try {
+            $res = $this->normalize($left_operand) / $this->normalize($right_operand);
 
-        return $this->applyScale($res, $this->normalize($scale));
+            $division = $this->applyScale($res, $this->normalize($scale));
+        } catch (Throwable $e) {
+            if  (strpos($e->getMessage(), 'A non-numeric value encountered') !== false) {
+                $division = 0;
+            } else {
+                throw $e;
+            }
+        }
+
+        return $division;
     }
 
     /**

--- a/Services/Math/test/ilMathBaseAdapterTest.php
+++ b/Services/Math/test/ilMathBaseAdapterTest.php
@@ -179,7 +179,8 @@ abstract class ilMathBaseAdapterTest extends TestCase
     public function divData()
     {
         return [
-            ['1', '2', '0.5', self::DEFAULT_SCALE]
+            ['1', '2', '0.5', self::DEFAULT_SCALE],
+            ['', '2', '0', self::DEFAULT_SCALE],
         ];
     }
 


### PR DESCRIPTION
…non numeric in a division (27785 / 26361)

## Problem

In **PHP <= 7.0.x** a mathematical division with a **left operand being an empty string** resulted in **0**.
In **PHP >= 7.1.x** this results in a `Throwable` with message `A non-numeric value encountered`.

See: https://3v4l.org/eaVak

## Suggestion
To guarantee the same behaviour for all supported PHP versions I suggest to catch this error and return 0 as result.

Additionally I covered this (weird) behaviour with a **unit test**.

## Mantis Issues

* https://mantis.ilias.de/view.php?id=27785
* https://mantis.ilias.de/view.php?id=26361
* https://mantis.ilias.de/view.php?id=27726

If accepted, please cherry-pick this to `trunk`,  `release_5-3` and `release_5-4`.