### PR TITLE
Init/Contexts: Extract special cases to concrete contexts when buildi…

### DIFF
--- a/Services/Context/classes/class.ilContext.php
+++ b/Services/Context/classes/class.ilContext.php
@@ -70,16 +70,17 @@ class ilContext
 
     /**
      * Call current content
-     *
      * @param string $a_method
-     * @return bool
+     * @param array $args
+     * @return mixed
      */
-    protected static function callContext($a_method)
+    protected static function callContext($a_method, array $args = [])
     {
         if (!self::$class_name) {
             self::init(self::CONTEXT_WEB);
         }
-        return call_user_func(array(self::$class_name, $a_method));
+
+        return call_user_func_array([self::$class_name, $a_method], $args);
     }
     
     /**
@@ -204,5 +205,14 @@ class ilContext
     public static function isSessionMainContext()
     {
         return (bool) self::callContext('isSessionMainContext');
+    }
+
+    /**
+     * @param string $httpPath
+     * @return string
+     */
+    public static function modifyHttpPath(string $httpPath) : string
+    {
+        return self::callContext('modifyHttpPath', [$httpPath]);
     }
 }

--- a/Services/Context/classes/class.ilContextApacheSSO.php
+++ b/Services/Context/classes/class.ilContextApacheSSO.php
@@ -110,4 +110,12 @@ class ilContextApacheSSO implements ilContextTemplate
     {
         return false;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public static function modifyHttpPath(string $httpPath) : string
+    {
+        return dirname($httpPath);
+    }
 }

--- a/Services/Context/classes/class.ilContextCron.php
+++ b/Services/Context/classes/class.ilContextCron.php
@@ -110,4 +110,12 @@ class ilContextCron implements ilContextTemplate
     {
         return true;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public static function modifyHttpPath(string $httpPath) : string
+    {
+        return $httpPath;
+    }
 }

--- a/Services/Context/classes/class.ilContextIcal.php
+++ b/Services/Context/classes/class.ilContextIcal.php
@@ -110,4 +110,12 @@ class ilContextIcal implements ilContextTemplate
     {
         return true;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public static function modifyHttpPath(string $httpPath) : string
+    {
+        return $httpPath;
+    }
 }

--- a/Services/Context/classes/class.ilContextLTIProvider.php
+++ b/Services/Context/classes/class.ilContextLTIProvider.php
@@ -96,4 +96,12 @@ class ilContextLTIProvider implements ilContextTemplate
     {
         return false;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public static function modifyHttpPath(string $httpPath) : string
+    {
+        return $httpPath;
+    }
 }

--- a/Services/Context/classes/class.ilContextRest.php
+++ b/Services/Context/classes/class.ilContextRest.php
@@ -111,4 +111,12 @@ class ilContextRest implements ilContextTemplate
     {
         return true;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public static function modifyHttpPath(string $httpPath) : string
+    {
+        return $httpPath;
+    }
 }

--- a/Services/Context/classes/class.ilContextRss.php
+++ b/Services/Context/classes/class.ilContextRss.php
@@ -111,4 +111,12 @@ class ilContextRss implements ilContextTemplate
     {
         return true;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public static function modifyHttpPath(string $httpPath) : string
+    {
+        return $httpPath;
+    }
 }

--- a/Services/Context/classes/class.ilContextRssAuth.php
+++ b/Services/Context/classes/class.ilContextRssAuth.php
@@ -111,4 +111,12 @@ class ilContextRssAuth implements ilContextTemplate
     {
         return true;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public static function modifyHttpPath(string $httpPath) : string
+    {
+        return $httpPath;
+    }
 }

--- a/Services/Context/classes/class.ilContextSaml.php
+++ b/Services/Context/classes/class.ilContextSaml.php
@@ -89,4 +89,16 @@ class ilContextSaml implements ilContextTemplate
     {
         return false;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public static function modifyHttpPath(string $httpPath) : string
+    {
+        if (strpos($httpPath, '/Services/Saml/lib/') !== false && strpos($httpPath, '/metadata.php') === false) {
+            return substr($httpPath, 0, strpos($httpPath, '/Services/Saml/lib/'));
+        }
+
+        return $httpPath;
+    }
 }

--- a/Services/Context/classes/class.ilContextScorm.php
+++ b/Services/Context/classes/class.ilContextScorm.php
@@ -110,4 +110,12 @@ class ilContextScorm implements ilContextTemplate
     {
         return false;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public static function modifyHttpPath(string $httpPath) : string
+    {
+        return $httpPath;
+    }
 }

--- a/Services/Context/classes/class.ilContextSessionReminder.php
+++ b/Services/Context/classes/class.ilContextSessionReminder.php
@@ -110,4 +110,12 @@ class ilContextSessionReminder implements ilContextTemplate
     {
         return false;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public static function modifyHttpPath(string $httpPath) : string
+    {
+        return $httpPath;
+    }
 }

--- a/Services/Context/classes/class.ilContextShibboleth.php
+++ b/Services/Context/classes/class.ilContextShibboleth.php
@@ -110,4 +110,12 @@ class ilContextShibboleth implements ilContextTemplate
     {
         return false;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public static function modifyHttpPath(string $httpPath) : string
+    {
+        return $httpPath;
+    }
 }

--- a/Services/Context/classes/class.ilContextSoap.php
+++ b/Services/Context/classes/class.ilContextSoap.php
@@ -110,4 +110,12 @@ class ilContextSoap implements ilContextTemplate
     {
         return true;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public static function modifyHttpPath(string $httpPath) : string
+    {
+        return $httpPath;
+    }
 }

--- a/Services/Context/classes/class.ilContextSoapNoAuth.php
+++ b/Services/Context/classes/class.ilContextSoapNoAuth.php
@@ -89,4 +89,12 @@ class ilContextSoapNoAuth implements ilContextTemplate
     {
         return true;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public static function modifyHttpPath(string $httpPath) : string
+    {
+        return $httpPath;
+    }
 }

--- a/Services/Context/classes/class.ilContextSoapWithoutClient.php
+++ b/Services/Context/classes/class.ilContextSoapWithoutClient.php
@@ -110,4 +110,12 @@ class ilContextSoapWithoutClient implements ilContextTemplate
     {
         return true;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public static function modifyHttpPath(string $httpPath) : string
+    {
+        return $httpPath;
+    }
 }

--- a/Services/Context/classes/class.ilContextUnitTest.php
+++ b/Services/Context/classes/class.ilContextUnitTest.php
@@ -110,4 +110,12 @@ class ilContextUnitTest implements ilContextTemplate
     {
         return true;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public static function modifyHttpPath(string $httpPath) : string
+    {
+        return $httpPath;
+    }
 }

--- a/Services/Context/classes/class.ilContextWAC.php
+++ b/Services/Context/classes/class.ilContextWAC.php
@@ -100,4 +100,12 @@ class ilContextWAC implements ilContextTemplate
     {
         return false;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public static function modifyHttpPath(string $httpPath) : string
+    {
+        return $httpPath;
+    }
 }

--- a/Services/Context/classes/class.ilContextWeb.php
+++ b/Services/Context/classes/class.ilContextWeb.php
@@ -110,4 +110,12 @@ class ilContextWeb implements ilContextTemplate
     {
         return true;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public static function modifyHttpPath(string $httpPath) : string
+    {
+        return $httpPath;
+    }
 }

--- a/Services/Context/classes/class.ilContextWebdav.php
+++ b/Services/Context/classes/class.ilContextWebdav.php
@@ -110,4 +110,12 @@ class ilContextWebdav implements ilContextTemplate
     {
         return true;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public static function modifyHttpPath(string $httpPath) : string
+    {
+        return $httpPath;
+    }
 }

--- a/Services/Context/interfaces/interface.ilContextTemplate.php
+++ b/Services/Context/interfaces/interface.ilContextTemplate.php
@@ -76,4 +76,12 @@ interface ilContextTemplate
      * @return bool
      */
     public static function isSessionMainContext();
+
+    /**
+     * A context might modify the ILIAS http path
+     * @see \ilInitialisation::buildHTTPPath 
+     * @param string $httpPath
+     * @return string
+     */
+    public static function modifyHttpPath(string $httpPath) : string;
 }

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -342,14 +342,7 @@ class ilInitialisation
             }
         }
 
-        $iliasHttpPath = implode('', [$protocol, $host, $uri]);
-        if (ilContext::getType() == ilContext::CONTEXT_APACHE_SSO) {
-            $iliasHttpPath = dirname($iliasHttpPath);
-        } elseif (ilContext::getType() === ilContext::CONTEXT_SAML) {
-            if (strpos($iliasHttpPath, '/Services/Saml/lib/') !== false && strpos($iliasHttpPath, '/metadata.php') === false) {
-                $iliasHttpPath = substr($iliasHttpPath, 0, strpos($iliasHttpPath, '/Services/Saml/lib/'));
-            }
-        }
+        $iliasHttpPath = ilContext::modifyHttpPath(implode('', [$protocol, $host, $uri]));
 
         $f = new \ILIAS\Data\Factory();
         $uri = $f->uri(ilUtil::removeTrailingPathSeparators($iliasHttpPath));


### PR DESCRIPTION
…ng **global ILIAS_HTTP_PATH constant**

Depending on the given `ilContext`, the determined HTTP path in `\ilInitialisation::buildHTTPPath` is modified. This PR extracts these cases (I added one of them recently) and moves them to the specific `ilContextTemplate` implementation.

In the past there were already discussions regarding the `ILIAS HTTP Path` where we talked about topics like `Document Root HTTP` / `ILIAS Root HTTP Path` and `Request URI HTTP Path`. This PR does **not** address the (big) topic in general.