### PR TITLE
UI/Mainbar: fix #27821

### DIFF
--- a/src/UI/templates/js/MainControls/mainbar.js
+++ b/src/UI/templates/js/MainControls/mainbar.js
@@ -539,8 +539,10 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 			},
 			readStates = function() {
 				cs = storage();
-				cs.items.entries = decompressEntries(cs.items.entries);
-				cs.items.tools = decompressEntries(cs.items.tools);
+				if (("entries" in cs.items) && ("tools" in cs.items)) {
+					cs.items.entries = decompressEntries(cs.items.entries);
+					cs.items.tools = decompressEntries(cs.items.tools);
+				}
 				return cs.items;
 			},
 			/**


### PR DESCRIPTION
The return value of `readStates` (renamed as `read`) is used in `init_desktop` in l.156 as an indicator to check, if we already have a cookie for the state. Before the change in 6a250bc323be17b423c910d045a47594695a9cf6, the unmodified and empty `cs.items` were returned, causing `cookie_state` to have a length = 0. After the introduction of compression, the `cookie_state` always has two keys, because they were set to `{}` even if they didn't exist in the first place. This fix reintroduces the behaviour by checking if the two keys exist before attempting to decompress them.

https://mantis.ilias.de/view.php?id=27281