### PR TITLE
UI/Select Input Field: fix #27837

### DIFF
--- a/src/UI/Implementation/Component/Input/Field/Select.php
+++ b/src/UI/Implementation/Component/Input/Field/Select.php
@@ -52,7 +52,7 @@ class Select extends Input implements C\Input\Field\Select
     {
         return
             in_array($value, array_keys($this->options))
-            || (!$this->isRequired() && $value == "");
+            || $value == "";
     }
 
     /**

--- a/tests/UI/Component/Input/Field/SelectTest.php
+++ b/tests/UI/Component/Input/Field/SelectTest.php
@@ -45,7 +45,7 @@ class SelectInputTest extends ILIAS_UI_TestBase
         $this->assertTrue($select->_isClientSideValueOk(""));
     }
 
-    public function testEmptyStringIsNoAcceptableClientSideValueIfSelectIsRequired()
+    public function testEmptyStringIsAnAcceptableClientSideValueEvenIfSelectIsRequired()
     {
         $options = [];
         $select = (new SelectForTest(
@@ -56,6 +56,6 @@ class SelectInputTest extends ILIAS_UI_TestBase
             ""
         ))->withRequired(true);
 
-        $this->assertFalse($select->_isClientSideValueOk(""));
+        $this->assertTrue($select->_isClientSideValueOk(""));
     }
 }


### PR DESCRIPTION
The trigger here was that there are two forms on the same side, one with an required input, the other without. A change in the first select triggered an error in the second. Still, this should not happen, exceptions should not be thrown at users.

The root cause for this is, that the empty string that is received from the client is indeed a valid client side value, even if the field is required. The "required" condition is evaluated later on.

https://mantis.ilias.de/view.php?id=27837