### PR TITLE
UI/Numeric Input Field: fix #27555

### DIFF
--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1416,6 +1416,7 @@ class ilInitialisation
     public static function initUIFramework(\ILIAS\DI\Container $c)
     {
         $c["ui.factory"] = function ($c) {
+            $c["lng"]->loadLanguageModule("ui");
             return new ILIAS\UI\Implementation\Factory(
                 $c["ui.factory.counter"],
                 $c["ui.factory.button"],

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -16087,3 +16087,4 @@ impr#:#impr_page_type_impr#:#Impressum
 prg#:#prg_additional_settings#:#Zusätzliche Funktionen
 prg#:#prg_access_by_orgu#:#Zugriffsregelungen nach Organisationseinheiten
 prg#:#prg_access_by_orgu_byline#:#Wenn aktiviert, können zusätzliche Zugriffsregelungen über Positionen in Organisationseinheiten vergeben werden.
+ui#:#ui_numeric_only#:#Bitte geben sie eine ganze Zahl ein.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -16087,3 +16087,4 @@ impr#:#impr_page_type_impr#:#Imprint
 prg#:#prg_additional_settings#:#Additional Features
 prg#:#prg_access_by_orgu#:#Access Control by Organisation Unit Positions
 prg#:#prg_access_by_orgu_byline#:#If enabled, additional access control rules can be defined by positions in organisational units.
+ui#:#ui_numeric_only#:#Please insert a whole number.

--- a/src/UI/Implementation/Component/Input/Field/Numeric.php
+++ b/src/UI/Implementation/Component/Input/Field/Numeric.php
@@ -36,6 +36,9 @@ class Numeric extends Input implements C\Input\Field\Numeric
                 $this->refinery->numeric()->isNumeric(),
                 $this->refinery->null()
             ])
+            ->withProblemBuilder(function($txt, $value) {
+                return $txt("ui_numeric_only");
+            })
         );
     }
 

--- a/src/UI/Implementation/Render/DefaultRendererFactory.php
+++ b/src/UI/Implementation/Render/DefaultRendererFactory.php
@@ -55,7 +55,6 @@ class DefaultRendererFactory implements RendererFactory
     public function getRendererInContext(Component $component, array $contexts)
     {
         $name = $this->getRendererNameFor($component);
-        $this->lng->loadLanguageModule("ui");
         return new $name(
             $this->ui_factory,
             $this->tpl_factory,


### PR DESCRIPTION
Before this commit we used the default error message for the constraint in the Numeric Input Field, which isn't really helpful to users, as pointed out in [#27666](https://mantis.ilias.de/view.php?id=27555). The default message is replaced by a custom message. The message is created early in the processing and the language module 'ui' isn't already loaded then, if the module is loaded in the renderer. Thus, the loading of the language module is moved to the initialisation of the UI framework. We assume, that we need the module when someone requires the UI factory.