### PR TITLE
ilCtrl: fix ctrl structure declarations

### DIFF
--- a/Services/Multilingualism/classes/class.ilMultilingualismGUI.php
+++ b/Services/Multilingualism/classes/class.ilMultilingualismGUI.php
@@ -9,7 +9,7 @@
  * @version $Id$
  * @ingroup ServicesObject
  *
- * @ilCtrl_IsCalledBy ilTranslationGUI: ilDidacticTemplateSettingsGUI
+ * @ilCtrl_IsCalledBy ilMultilingualismeGUI: ilDidacticTemplateSettingsGUI
  */
 class ilMultilingualismGUI
 {

--- a/Services/Repository/classes/class.ilRepositoryGUI.php
+++ b/Services/Repository/classes/class.ilRepositoryGUI.php
@@ -28,6 +28,7 @@ include_once("./Services/Table/classes/class.ilTableGUI.php");
 * @ilCtrl_Calls ilRepositoryGUI: ilObjIndividualAssessmentGUI
 * @ilCtrl_Calls ilRepositoryGUI: ilObjLTIConsumerGUI
 * @ilCtrl_Calls ilRepositoryGUI: ilObjCmiXapiGUI
+* @ilCtrl_Calls ilRepositoryGUI: ilPermissionGUI
 *
 */
 class ilRepositoryGUI

--- a/Services/Skill/classes/class.ilSkillTemplateGUI.php
+++ b/Services/Skill/classes/class.ilSkillTemplateGUI.php
@@ -6,7 +6,7 @@
  * Skill template GUI class
  *
  * @author Alex Killing <alex.killing@gmx.de>
- * @ilCtrl_isCalledBy ilSkillCategoryGUI: ilObjSkillManagementGUI
+ * @ilCtrl_isCalledBy ilSkillTemplateGUI: ilObjSkillManagementGUI
  */
 class ilSkillTemplateGUI extends ilSkillTreeNodeGUI
 {


### PR DESCRIPTION
Hi @alex40724,

after the refactoring the `ilCtrlStructureReader` seems to be a little more picky and thus unearthed two faulty control structure declarations.

Best regards!