### PR TITLE
UI/Standard Page: focus content area on page load (#27270)

### DIFF
--- a/src/UI/Component/Layout/Page/Factory.php
+++ b/src/UI/Component/Layout/Page/Factory.php
@@ -49,6 +49,8 @@ interface Factory
      *     1: >
      *        Scrollable areas of the Standard Page MUST be scrollable by only using
      *        the keyboard.
+     *     2: >
+     *        The content area of the Standard Page MUST be focused on page load.
      * ----
      *
      * @param  \ILIAS\UI\Component\Component[] $content

--- a/src/UI/templates/js/Page/stdpage.js
+++ b/src/UI/templates/js/Page/stdpage.js
@@ -31,3 +31,6 @@ il.UI = il.UI || {};
 
 	})($);
 })($, il.UI);
+il.Util.addOnLoad(function() {
+    $("main").focus();
+});


### PR DESCRIPTION
This fixes hopefully helps with [#27279](https://mantis.ilias.de/view.php?id=27270) by focusing the content area on page load and also adds an according rule. This seems to fit the semantics of html `<main>` as well.