### PR TITLE
Refinery: Add fix for Mantis issue 27935

### DIFF
--- a/src/Refinery/To/Transformation/ListTransformation.php
+++ b/src/Refinery/To/Transformation/ListTransformation.php
@@ -39,20 +39,12 @@ class ListTransformation implements Transformation
                 'must_be_array'
             );
         }
-        if (array() === $from) {
-            throw new ConstraintViolationException(
-                'Value array is empty',
-                'value_array_is_empty'
-            );
-        }
 
-        $result = array();
+        $result = [];
         foreach ($from as $value) {
             $transformedValue = $this->transformation->transform($value);
             $result[] = $transformedValue;
         }
-
-
 
         return $result;
     }

--- a/src/UI/Implementation/Component/Input/Field/Tag.php
+++ b/src/UI/Implementation/Component/Input/Field/Tag.php
@@ -281,7 +281,27 @@ class Tag extends Input implements C\Input\Field\Tag
      */
     public function withInput(InputData $input)
     {
-        return parent::withInput($input);
+        // ATTENTION: This is a slightly modified copy of parent::withInput, which
+        // fixes #27909 but makes the Tag Input unusable in Filter Containers.
+        if ($this->getName() === null) {
+            throw new \LogicException("Can only collect if input has a name.");
+        }
+
+        //TODO: Discuss, is this correct here. If there is no input contained in this post
+        //We assign null. Note that unset checkboxes are not contained in POST.
+        if (!$this->isDisabled()) {
+            $value = $input->getOr($this->getName(), null);
+            $clone = $this->withValue($value);
+        } else {
+            $clone = $this;
+        }
+
+        $clone->content = $this->applyOperationsTo($clone->getValue());
+        if ($clone->content->isError()) {
+            return $clone->withError("" . $clone->content->error());
+        }
+
+        return $clone;
     }
 
 

--- a/tests/Refinery/To/Transformation/ListTransformationTest.php
+++ b/tests/Refinery/To/Transformation/ListTransformationTest.php
@@ -29,25 +29,17 @@ class ListTransformationTest extends TestCase
         $this->assertEquals(array('hello', 'world'), $result);
     }
 
-    public function testTransformOnEmptyArrayFails()
+    public function testTransformOnEmptyArrayReturnsEmptyList()
     {
-        $this->expectNotToPerformAssertions();
-
         $listTransformation = new ListTransformation(new StringTransformation());
-        try {
-            $result = $listTransformation->transform(array());
-        } catch (ConstraintViolationException $exception) {
-            return;
-        }
-
-        $this->fail();
+        $this->assertSame([], $listTransformation->transform([]));
     }
 
-    public function testApplyToOnEmptyArrayFails()
+    public function testApplyToOnEmptyArrayDoesNotFail()
     {
         $listTransformation = new ListTransformation(new StringTransformation());
         $result = $listTransformation->applyTo(new Ok(array()));
-        $this->assertTrue($result->isError());
+        $this->assertFalse($result->isError());
     }
 
     public function testTransformOnNullFails()

--- a/tests/UI/Component/Input/Field/TagInputTest.php
+++ b/tests/UI/Component/Input/Field/TagInputTest.php
@@ -180,8 +180,6 @@ class TagInputTest extends ILIAS_UI_TestBase
 
     public function test_empty_array_as_input_lead_to_exception()
     {
-        $this->expectNotToPerformAssertions();
-
         $f = $this->buildFactory();
         $label = "label";
         $name = "name_0";
@@ -189,12 +187,10 @@ class TagInputTest extends ILIAS_UI_TestBase
         /** @var \ILIAS\UI\Implementation\Component\Input\Field\Tag $tag */
         $tag = $f->tag($label, $tags)->withNameFrom($this->name_source)->withRequired(true);
 
-        try {
-            $tag2 = $tag->withInput(new DefInputData([$name => []]));
-        } catch (\Exception $exception) {
-            return;
-        }
-        $this->fail();
+        $tag2 = $tag->withInput(new DefInputData([$name => []]));
+        $result = $tag2->getContent();
+        $this->assertTrue($result->isOk());
+        $this->assertEquals([], $result->value());
     }
 
     public function test_null_value_leads_to_exception()


### PR DESCRIPTION
This commit applies a change to the `listOf` transformation (in the `to` group) regarding empty arrays. Where an empty array was **not** accepted in the past and resulted in a `ConstraintViolationException`, the transformation **now** returns an empty array.

@klees Both failing tests belong to the `TagInput` element in _./src/UI_.