### PR TITLE
CI Global Reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ script:
 - ./CI/PHPUnit/run_tests_with_reporting.sh;
 - if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then travis_wait 60 ./CI/PHP-CS-Fixer/run_check.sh; fi
 - ./CI/Special-Char-Checker/special-char-checker.sh ./ php;
+- ./CI/results/report-results.sh
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
 - ./CI/PHPUnit/run_tests_with_reporting.sh;
 - if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then travis_wait 60 ./CI/PHP-CS-Fixer/run_check.sh; fi
 - ./CI/Special-Char-Checker/special-char-checker.sh ./ php;
-- if [[ "$TRAVIS_EVENT_TYPE" == "pull_request" ]]; then travis_wait 60 ./CI/results/report-results.sh; fi
+- if [[ "$TRAVIS_EVENT_TYPE" != "pull_request" ]]; then travis_wait 60 ./CI/results/report-results.sh; fi
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
 - ./CI/PHPUnit/run_tests_with_reporting.sh;
 - if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then travis_wait 60 ./CI/PHP-CS-Fixer/run_check.sh; fi
 - ./CI/Special-Char-Checker/special-char-checker.sh ./ php;
-- if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then travis_wait 60 ./CI/results/report-results.sh; fi
+- if [[ "$TRAVIS_EVENT_TYPE" == "pull_request" ]]; then travis_wait 60 ./CI/results/report-results.sh; fi
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
 - ./CI/PHPUnit/run_tests_with_reporting.sh;
 - if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then travis_wait 60 ./CI/PHP-CS-Fixer/run_check.sh; fi
 - ./CI/Special-Char-Checker/special-char-checker.sh ./ php;
-- ./CI/results/report-results.sh
+- if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then travis_wait 60 ./CI/results/report-results.sh; fi
 addons:
   apt:
     packages:

--- a/CI/Import/Variables.sh
+++ b/CI/Import/Variables.sh
@@ -1,18 +1,26 @@
 #!/bin/bash
-TMP_DIR="/tmp"
 
+# CS fixer (Todo for later)
+TMP_DIR="/tmp"
 PHP_CS_FIXER_RESULTS_PATH="$TMP_DIR/phpfix_results"
 PHP_CS_FIXER="libs/composer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer"
 
-PHPUNIT_PATH="$TMP_DIR/phpunit_latest.csv"
-PHPUNIT_PATH_TMP="$TMP_DIR/phpunit_changed.csv"
-PHPUNIT_RESULTS_PATH="$TMP_DIR/phpunit_results"
+# Setup the results data directories
+RESULTS_DATA_DIRECTORY="CI/results/data"
 
-DICTO_PATH="$TMP_DIR/dicto_latest.csv"
+RESULTS_DATA_DIRECTORY_CSFIXER="$RESULTS_DATA_DIRECTORY/phpfix_results"
 
-TRAVIS_RESULTS_DIRECTORY="$TMP_DIR/CI-Results/"
+RESULTS_DATA_DIRECTORY_PHPUNIT="$RESULTS_DATA_DIRECTORY/phpunit_latest.csv"
+RESULTS_DATA_DIRECTORY_PHPUNIT_RESULTS_PATH="/tmp/phpunit_results"
+RESULTS_DATA_DIRECTORY_PHPUNIT_TMP="$RESULTS_DATA_DIRECTORY/phpunit_changed.csv"
 
+RESULTS_DATA_DIRECTORY_DICTO="$RESULTS_DATA_DIRECTORY/dicto_latest.csv"
+
+TRAVIS_RESULTS_DIRECTORY="/tmp/CI-Results"
+
+# Why???
 DATE=`date '+%Y-%m-%d %H:%M:%S'`
 UNIXDATE=`date '+%s'`
 
+# Why??
 PRE="\t*** "

--- a/CI/Import/Variables.sh
+++ b/CI/Import/Variables.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-# CS fixer (Todo for later)
-TMP_DIR="/tmp"
-PHP_CS_FIXER_RESULTS_PATH="$TMP_DIR/phpfix_results"
-PHP_CS_FIXER="libs/composer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer"
-
 # Setup the results data directories
 RESULTS_DATA_DIRECTORY="CI/results/data"
 
@@ -15,6 +10,10 @@ RESULTS_DATA_DIRECTORY_PHPUNIT_RESULTS_PATH="/tmp/phpunit_results"
 RESULTS_DATA_DIRECTORY_PHPUNIT_TMP="$RESULTS_DATA_DIRECTORY/phpunit_changed.csv"
 
 RESULTS_DATA_DIRECTORY_DICTO="$RESULTS_DATA_DIRECTORY/dicto_latest.csv"
+
+# CS fixer (Todo for later)
+PHP_CS_FIXER_RESULTS_PATH="$RESULTS_DATA_DIRECTORY/phpfix_results"
+PHP_CS_FIXER="libs/composer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer"
 
 TRAVIS_RESULTS_DIRECTORY="/tmp/CI-Results"
 

--- a/CI/PHPUnit/run_tests_with_reporting.sh
+++ b/CI/PHPUnit/run_tests_with_reporting.sh
@@ -76,15 +76,18 @@ if [[ -e "$RESULTS_DATA_DIRECTORY_PHPUNIT_RESULTS_PATH" ]]
 	if [[ "$FAILURE" == "true" || $PIPE_EXIT_CODE -gt 0 ]]
 		then
 			printLn "Errors were found, exiting with error code."
-			export PHP_UNIT_EXIT_CODE="99"
+			touch "$RESULTS_DATA_DIRECTORY/PHPUnitExitCode.tmp"
+			echo "99" >> "$RESULTS_DATA_DIRECTORY/PHPUnitExitCode.tmp"
 			exit 99
 	else
 			printLn "No errors were found."
-			export PHP_UNIT_EXIT_CODE="0"
+			touch "$RESULTS_DATA_DIRECTORY/PHPUnitExitCode.tmp"
+			echo "0" >> "$RESULTS_DATA_DIRECTORY/PHPUnitExitCode.tmp"
 			exit 0
 	fi
 else
 	printLn "No result file found, stopping!"
-	export PHP_UNIT_EXIT_CODE="99"
+	touch "$RESULTS_DATA_DIRECTORY/PHPUnitExitCode.tmp"
+	echo "99" >> "$RESULTS_DATA_DIRECTORY/PHPUnitExitCode.tmp"
 	exit 99
 fi

--- a/CI/PHPUnit/run_tests_with_reporting.sh
+++ b/CI/PHPUnit/run_tests_with_reporting.sh
@@ -5,7 +5,7 @@ source CI/Import/Variables.sh
 
 printLn "Initialize paths variables"
 
-./CI/PHPUnit/run_tests.sh | tee "$PHPUNIT_RESULTS_PATH"
+./CI/PHPUnit/run_tests.sh | tee "$RESULTS_DATA_DIRECTORY_PHPUNIT_RESULTS_PATH"
 
 PIPE_EXIT_CODE=`echo ${PIPESTATUS[0]}`
 
@@ -13,10 +13,10 @@ printLn "Command exited with code: $PIPE_EXIT_CODE"
 
 printLn "Travis: event type ($TRAVIS_EVENT_TYPE), job number ($TRAVIS_JOB_NUMBER), pull request ($TRAVIS_PULL_REQUEST), commit ($TRAVIS_COMMIT) "
 
-if [[ -e "$PHPUNIT_RESULTS_PATH" ]]
+if [[ -e "$RESULTS_DATA_DIRECTORY_PHPUNIT_RESULTS_PATH" ]]
 	then
 		printLn "Collecting data."
-		RESULT=`tail -n1 < "$PHPUNIT_RESULTS_PATH"`
+		RESULT=`tail -n1 < "$RESULTS_DATA_DIRECTORY_PHPUNIT_RESULTS_PATH"`
 		SPLIT_RESULT=(`echo $RESULT | tr ':' ' '`)
 		PHP_VERSION=`php -r "echo PHP_MAJOR_VERSION . '_' . PHP_MINOR_VERSION;"`
 		if [ -e "include/inc.ilias_version.php" ]
@@ -36,16 +36,16 @@ if [[ -e "$PHPUNIT_RESULTS_PATH" ]]
 				CLEANED=(`echo ${PHP_UNIT_RESULT[0]} | tr '( OK (tests)' ' ' | xargs`)
 				RESULTS[Tests]=$CLEANED;
 		else
-			for TYPE in "${!RESULTS[@]}"; 
-				do 
-					for PHP_UNIT_RESULT in "${!SPLIT_RESULT[@]}"; 
-						do 
+			for TYPE in "${!RESULTS[@]}";
+				do
+					for PHP_UNIT_RESULT in "${!SPLIT_RESULT[@]}";
+						do
 							if [ "$TYPE" == "${SPLIT_RESULT[$PHP_UNIT_RESULT]}" ]
 								then
 									CLEANED=(`echo ${SPLIT_RESULT[$PHP_UNIT_RESULT + 1]} | tr ',.' ' '`)
 									RESULTS[$TYPE]=$CLEANED;
 							fi
-						done 
+						done
 				done
 		fi
 
@@ -54,37 +54,25 @@ if [[ -e "$PHPUNIT_RESULTS_PATH" ]]
 				FAILURE=true
 		fi
 
-		if [[ "$TRAVIS_EVENT_TYPE" != "pull_request" ]]
+		if [[ "$TRAVIS_EVENT_TYPE" == "pull_request" ]]
 		then
-			printLn "Cloning results repository, copy results file."
-			if [ -d "$TRAVIS_RESULTS_DIRECTORY" ]; then
-				printLn "Starting to remove old temp directory"
-				rm -rf "$TRAVIS_RESULTS_DIRECTORY"
-			fi
-
-			cd /tmp && git clone https://github.com/ILIAS-eLearning/CI-Results
-			cp "$TRAVIS_RESULTS_DIRECTORY/data/phpunit_latest.csv" "$PHPUNIT_PATH"
+			printLn "Copy results file."
 
 			printLn "Removing old line PHP version $PHP_VERSION and ILIAS version $ILIAS_VERSION"
-			grep -v "$ILIAS_VERSION.*php_$PHP_VERSION" $PHPUNIT_PATH > $PHPUNIT_PATH_TMP 
+			grep -v "$ILIAS_VERSION.*php_$PHP_VERSION" $RESULTS_DATA_DIRECTORY_PHPUNIT > $RESULTS_DATA_DIRECTORY_PHPUNIT_TMP
 
 			NEW_LINE="$JOB_URL,$JOB_ID,$ILIAS_VERSION,php_$PHP_VERSION,PHP $PHP_VERSION,${RESULTS[Warnings]},${RESULTS[Skipped]},${RESULTS[Incomplete]},${RESULTS[Tests]},${RESULTS[Errors]},${RESULTS[Risky]},$FAILURE,$DATE,$UNIXDATE";
 			printLn "Writing line: $NEW_LINE"
-			echo "$NEW_LINE" >> "$PHPUNIT_PATH_TMP";
+			echo "$NEW_LINE" >> "$RESULTS_DATA_DIRECTORY_PHPUNIT_TMP";
 
 			printLn "Handling result."
 
-			if [ -e "$PHPUNIT_PATH_TMP" ]
+			if [ -e "$RESULTS_DATA_DIRECTORY_PHPUNIT_TMP" ]
 				then
-					mv "$PHPUNIT_PATH_TMP" "$PHPUNIT_PATH"
-					rm "$PHPUNIT_RESULTS_PATH"
+					mv "$RESULTS_DATA_DIRECTORY_PHPUNIT_TMP" "$RESULTS_DATA_DIRECTORY_PHPUNIT"
+					rm "$RESULTS_DATA_DIRECTORY_PHPUNIT_RESULTS_PATH"
 			fi
-
-			printLn "Switching directory and run results handling."
-			cp "$PHPUNIT_PATH" "$TRAVIS_RESULTS_DIRECTORY/data/"
-			cd "$TRAVIS_RESULTS_DIRECTORY" && ./run.sh
-
-	fi		
+	fi
 	if [[ "$FAILURE" == "true" || $PIPE_EXIT_CODE -gt 0 ]]
 		then
 			printLn "Errors were found, exiting with error code."
@@ -96,4 +84,4 @@ if [[ -e "$PHPUNIT_RESULTS_PATH" ]]
 else
 	printLn "No result file found, stopping!"
 	exit 99
-fi		
+fi

--- a/CI/PHPUnit/run_tests_with_reporting.sh
+++ b/CI/PHPUnit/run_tests_with_reporting.sh
@@ -76,12 +76,15 @@ if [[ -e "$RESULTS_DATA_DIRECTORY_PHPUNIT_RESULTS_PATH" ]]
 	if [[ "$FAILURE" == "true" || $PIPE_EXIT_CODE -gt 0 ]]
 		then
 			printLn "Errors were found, exiting with error code."
+			export PHP_UNIT_EXIT_CODE="99"
 			exit 99
 	else
 			printLn "No errors were found."
+			export PHP_UNIT_EXIT_CODE="0"
 			exit 0
 	fi
 else
 	printLn "No result file found, stopping!"
+	export PHP_UNIT_EXIT_CODE="99"
 	exit 99
 fi

--- a/CI/PHPUnit/run_tests_with_reporting.sh
+++ b/CI/PHPUnit/run_tests_with_reporting.sh
@@ -54,7 +54,7 @@ if [[ -e "$RESULTS_DATA_DIRECTORY_PHPUNIT_RESULTS_PATH" ]]
 				FAILURE=true
 		fi
 
-		if [[ "$TRAVIS_EVENT_TYPE" == "pull_request" ]]
+		if [[ "$TRAVIS_EVENT_TYPE" != "pull_request" ]]
 		then
 			printLn "Copy results file."
 

--- a/CI/results/report-results.sh
+++ b/CI/results/report-results.sh
@@ -5,7 +5,7 @@ source CI/Import/Functions.sh
 source CI/Import/Variables.sh
 
 echo "-----"
-echo "PHP_UNIT_EXIT_CODE: "
+PHP_UNIT_EXIT_CODE=$(<"$RESULTS_DATA_DIRECTORY/PHPUnitExitCode.tmp")
 echo $PHP_UNIT_EXIT_CODE
 echo "-----"
 exit

--- a/CI/results/report-results.sh
+++ b/CI/results/report-results.sh
@@ -4,6 +4,12 @@
 source CI/Import/Functions.sh
 source CI/Import/Variables.sh
 
+echo "-----"
+echo "PHP_UNIT_EXIT_CODE: "
+echo $PHP_UNIT_EXIT_CODE
+echo "-----"
+exit
+
 # clone the CI repository
 if [ -d "$TRAVIS_RESULTS_DIRECTORY" ]; then
   printLn "Starting to remove old temp directory"

--- a/CI/results/report-results.sh
+++ b/CI/results/report-results.sh
@@ -4,11 +4,11 @@
 source CI/Import/Functions.sh
 source CI/Import/Variables.sh
 
-echo "-----"
 PHP_UNIT_EXIT_CODE=$(<"$RESULTS_DATA_DIRECTORY/PHPUnitExitCode.tmp")
-echo $PHP_UNIT_EXIT_CODE
-echo "-----"
-exit
+if [[ $PHP_UNIT_EXIT_CODE != "0" ]];
+then
+  exit $PHP_UNIT_EXIT_CODE
+fi
 
 # clone the CI repository
 if [ -d "$TRAVIS_RESULTS_DIRECTORY" ]; then

--- a/CI/results/report-results.sh
+++ b/CI/results/report-results.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-# Exit positively if we are on a PR
-if [[ "$TRAVIS_EVENT_TYPE" == "pull_request" ]];
-then
-  exit 0
-fi
-
 # get the dependencies
 source CI/Import/Functions.sh
 source CI/Import/Variables.sh

--- a/CI/results/report-results.sh
+++ b/CI/results/report-results.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# get the dependencies
+source CI/Import/Functions.sh
+source CI/Import/Variables.sh
+
+# clone the CI repository
+if [ -d "$TRAVIS_RESULTS_DIRECTORY" ]; then
+  printLn "Starting to remove old temp directory"
+  rm -rf "$TRAVIS_RESULTS_DIRECTORY"
+fi
+git clone https://github.com/ILIAS-eLearning/CI-Results "$TRAVIS_RESULTS_DIRECTORY"
+
+# Move all the results in data folder to the tmp folder
+cp -r "$RESULTS_DATA_DIRECTORY" "$TRAVIS_RESULTS_DIRECTORY"
+rm "$TRAVIS_RESULTS_DIRECTORY/data/.gitkeep"
+
+ls "$TRAVIS_RESULTS_DIRECTORY/data/"
+
+# run the reporting
+cd "$TRAVIS_RESULTS_DIRECTORY" && ./run.sh

--- a/CI/results/report-results.sh
+++ b/CI/results/report-results.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Exit positively if we are on a PR
+if [[ "$TRAVIS_EVENT_TYPE" == "pull_request" ]];
+then
+  exit 0
+fi
+
 # get the dependencies
 source CI/Import/Functions.sh
 source CI/Import/Variables.sh


### PR DESCRIPTION
Implemented global report scripts for all the report scripts like PHP Unit and PHP CS Fixer. In future there will be a lot of reports implemented through other tools like dicto. So we are going to place every report in one folder which the run.sh-script from CI-Results will grab. This PR is the main iteration for that.