### PR TITLE
UI, #27281, #27282 - resize dropdown/datepicker after opening

### DIFF
--- a/src/UI/templates/js/Dropdown/dropdown.js
+++ b/src/UI/templates/js/Dropdown/dropdown.js
@@ -1,14 +1,13 @@
 (function($) {
 	$(document).on('shown.bs.dropdown', function(event) {
 		var dropdown = $(event.target);
-
 		dropdown.find('.dropdown-toggle').attr('aria-expanded', true);
+		il.UI.page.fit(dropdown.find('.dropdown-menu'));
 	});
 
 	// on close
 	$(document).on('hidden.bs.dropdown', function(event) {
 		var dropdown = $(event.target);
-
 		dropdown.find('.dropdown-toggle').attr('aria-expanded', false);
 	});
 })($);

--- a/src/UI/templates/js/Input/Field/duration.js
+++ b/src/UI/templates/js/Input/Field/duration.js
@@ -30,3 +30,7 @@ il.UI.Input = il.UI.Input || {};
 
 	})($);
 })($, il.UI.Input);
+
+$(document).on('dp.show', function(event) {
+	il.UI.page.fit($('.bootstrap-datetimepicker-widget'));
+});

--- a/src/UI/templates/js/Page/stdpage.js
+++ b/src/UI/templates/js/Page/stdpage.js
@@ -4,6 +4,7 @@ il.UI = il.UI || {};
 	ui.page = (function($) {
 
 		var breakpoint_max_width = 768, //this corresponds to @grid-float-breakpoint-max, see mainbar.less/metabar.less
+			resized_poppers_margin = 25, //dropdown, date-picker
 			mq_orientation = window.matchMedia("(orientation: portrait)");
 
 		var isSmallScreen = function() {
@@ -22,11 +23,31 @@ il.UI = il.UI || {};
 			return isPortrait() ? 'portrait' : 'landscape';
 		};
 
+		var fitContainerToContent = function(target_container) {
+			var content_container = $('.il-layout-page-content'),
+				margin = resized_poppers_margin,
+				max_width = content_container.width() - 2 * margin,
+				target_left = content_container.offset().left - target_container.parent().offset().left + margin;
+
+			if( target_container.width() < max_width &&
+				target_container.offset().left > content_container.offset().left
+			) {
+				return;
+			}
+			window.setTimeout(function(){
+				target_container.css({
+					'left': target_left,
+					'max-width': max_width
+				});
+			}, 100)
+		}
+
 		return {
 			isSmallScreen: isSmallScreen,
 			getOrientation: getOrientation,
 			isPortrait: isPortrait,
 			isLandscape: isLandscape,
+			fit: fitContainerToContent
 		};
 
 	})($);


### PR DESCRIPTION
This resizes and positions the dropdown-menu and the datetimepicker widget.
I did not take care of the little triangles of the picker to match the triggerer-element or the no-wrapping list elements of the dropdown.
The latter could be solved by removing line 29 from dropdown.less, but I'm unsure what this would break: "white-space: nowrap; // prevent links from randomly breaking onto new lines".
