### PR TITLE
[Mantis:27968] Add index to tax_tree.child

### DIFF
--- a/setup/sql/dbupdate_05.php
+++ b/setup/sql/dbupdate_05.php
@@ -4451,3 +4451,10 @@ if (!$ilDB->tableColumnExists('skl_user_has_level', 'next_level_fulfilment')) {
     ));
 }
 ?>
+<#5678>
+<?php
+// Add new index
+if (!$ilDB->indexExistsByFields('tax_tree', ['child'])) {
+    $ilDB->addIndex('tax_tree', ['child'], 'ttc');
+}
+?>


### PR DESCRIPTION
This will speed-up queries like

```sql
SELECT
 s.child
FROM
 tax_tree s, tax_tree t
WHERE
 t.child = 8385
AND
 s.lft > t.lft
AND
 s.rgt < t.rgt
AND
 s.tax_tree_id = 18710;
```

in ILIAS instances with a large tax_tree.

-> https://mantis.ilias.de/view.php?id=27968

Performance considerations: While one person usually authors
the question (INSERT/UPDATE), many people in parallel are
accessing the test (SELECT). Many reads, few writes ->
use index.