### PR TITLE
Fix Use of undefined constant AUTH_SHIB

### DIFF
--- a/Services/Authentication/classes/class.ilObjAuthSettingsGUI.php
+++ b/Services/Authentication/classes/class.ilObjAuthSettingsGUI.php
@@ -265,7 +265,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
             $this->ilias->raiseError($this->lng->txt("auth_err_no_mode_selected"), $this->ilias->error_obj->MESSAGE);
         }
 
-        $current_auth_mode = $ilSetting->get('auth_mode', '');
+        $current_auth_mode = $ilSetting->get('auth_mode','');
         if ($_POST["auth_mode"] == $current_auth_mode) {
             ilUtil::sendInfo($this->lng->txt("auth_mode") . ": " . $this->getAuthModeTitle() . " " . $this->lng->txt("auth_mode_not_changed"), true);
             $this->ctrl->redirect($this, 'authSettings');
@@ -286,7 +286,8 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
                 */
                 break;
                 
-                case AUTH_SHIB:
+				// @fix changed from AUTH_SHIB > is not defined
+                case AUTH_SHIBBOLETH:
                 if ($this->object->checkAuthSHIB() !== true) {
                     ilUtil::sendFailure($this->lng->txt("auth_shib_not_configured"), true);
                     ilUtil::redirect($this->getReturnLocation("authSettings", $this->ctrl->getLinkTarget($this, "editSHIB", "", false, false)));
@@ -869,7 +870,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
             
                 include_once("Services/AccessControl/classes/class.ilPermissionGUI.php");
                 $perm_gui = new ilPermissionGUI($this);
-                $ret = &$this->ctrl->forwardCommand($perm_gui);
+                $ret =&$this->ctrl->forwardCommand($perm_gui);
                 break;
                 
             case 'illdapsettingsgui':


### PR DESCRIPTION
Used constant AUTH_SHIB is curently not defined, use AUTH_SHIBBOLETH instead. Error by setting default authentication mode.

ERROR-LOG:

Whoops\Exception\ErrorException thrown with message "Use of undefined constant AUTH_SHIB - assumed 'AUTH_SHIB' (this will throw an Error in a future version of PHP)"

Stacktrace:
#7 Whoops\Exception\ErrorException in ILIAS_PATH/htdocs/Services/Authentication/classes/class.ilObjAuthSettingsGUI.php:289
#6 ilErrorHandling:handlePreWhoops in ILIAS_PATH/htdocs/Services/Authentication/classes/class.ilObjAuthSettingsGUI.php:289
#5 ilObjAuthSettingsGUI:setAuthModeObject in ILIAS_PATH/htdocs/Services/Authentication/classes/class.ilObjAuthSettingsGUI.php:926
#4 ilObjAuthSettingsGUI:executeCommand in ILIAS_PATH/htdocs/Services/UICore/classes/class.ilCtrl.php:210
#3 ilCtrl:forwardCommand in ILIAS_PATH/htdocs/Services/Administration/classes/class.ilAdministrationGUI.php:250
#2 ilAdministrationGUI:executeCommand in ILIAS_PATH/htdocs/Services/UICore/classes/class.ilCtrl.php:210
#1 ilCtrl:forwardCommand in ILIAS_PATH/htdocs/Services/UICore/classes/class.ilCtrl.php:175
#0 ilCtrl:callBaseClass in ILIAS_PATH/htdocs/ilias.php:20