### PR TITLE
UI, Mainbar: fix behavior of mainbar tools (see 27876, 26589, 27465)

### DIFF
--- a/src/UI/Implementation/Component/MainControls/Renderer.php
+++ b/src/UI/Implementation/Component/MainControls/Renderer.php
@@ -93,7 +93,7 @@ class Renderer extends AbstractComponentRenderer
 
         $is_removeable = $is_removeable ? 'true':'false';
         $is_hidden = $is_hidden ? 'true':'false';
-        return "il.UI.maincontrols.mainbar.addToolEntry('{$mb_id}', {$is_removeable}, {$is_hidden});";
+        return "il.UI.maincontrols.mainbar.addToolEntry('{$mb_id}', {$is_removeable}, {$is_hidden}, '{$entry_id}');";
     }
 
     protected function renderMainbarEntry(

--- a/src/UI/templates/js/MainControls/mainbar.js
+++ b/src/UI/templates/js/MainControls/mainbar.js
@@ -504,34 +504,27 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 				}
 				return hash;
 			},
-			compressEntries = function(entries, is_tools) {
+			compressEntries = function(entries) {
 				var k, v, ret = {}, key;
 				for(k in entries) {
 					v = entries[k];
-					key = is_tools ? v.gs_id : k;
-					ret[key] = [
+					ret[k] = [
 						v.removeable ? 1:0,
 						v.engaged ? 1:0,
 						v.hidden ? 1:0
 					];
-					if(is_tools) {
-						ret[key].push(k);
-					}
 				}
 				return ret;
 			},
-			decompressEntries = function(entries, is_tools) {
+			decompressEntries = function(entries) {
 				var k, v, ret = {}, id, gs_id;
 				for(k in entries) {
 					v = entries[k];
-					id = is_tools ? v[3] : k;
-					gs_id = is_tools ? k : null;
 					ret[id] = {
-						"id": id,
+						"id": k,
 						"removeable": !!v[0],
 						"engaged": !!v[1],
-						"hidden": !!v[2],
-						"gs_id": gs_id
+						"hidden": !!v[2]
 					};
 				}
 				return ret;

--- a/src/UI/templates/js/MainControls/mainbar.js
+++ b/src/UI/templates/js/MainControls/mainbar.js
@@ -364,7 +364,6 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 				},
 				addTool: function (entry_id, removeable, hidden, gs_id) {
 					var tool = factories.entry(entry_id);
-					//var tool = factories.entry(gs_id);
 					tool.removeable = removeable ? true : false;
 					tool.hidden = hidden ? true : false;
 					tool.gs_id = gs_id;

--- a/src/UI/templates/js/MainControls/mainbar.js
+++ b/src/UI/templates/js/MainControls/mainbar.js
@@ -537,9 +537,37 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 				}
 				return ret;
 			},
+			compressTools = function(entries) {
+				var k, v, ret = {};
+				for(k in entries) {
+					v = entries[k];
+					ret[v.gs_id] = [
+						v.removeable ? 1:0,
+						v.engaged ? 1:0,
+						v.hidden ? 1:0,
+						k
+					];
+				}
+				return ret;
+			},
+			decompressTools = function(entries) {
+				var k, v, ret = {}, id;
+				for(k in entries) {
+					v = entries[k];
+					id = v[3];
+					ret[id] = {
+						"id": id,
+						"removeable": !!v[0],
+						"engaged": !!v[1],
+						"hidden": !!v[2],
+						"gs_id": k
+					};
+				}
+				return ret;
+			},
 			storeStates = function(state) {
-				state.entries = compressEntries(state.entries, false);
-				state.tools = compressEntries(state.tools, true);
+				state.entries = compressEntries(state.entries);
+				state.tools = compressTools(state.tools);
 				cs = storage();
 				for(idx in state) {
 					cs.add(idx, state[idx]);
@@ -550,8 +578,8 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 			readStates = function() {
 				cs = storage();
 				if (("entries" in cs.items) && ("tools" in cs.items)) {
-					cs.items.entries = decompressEntries(cs.items.entries, false);
-					cs.items.tools = decompressEntries(cs.items.tools, true);
+					cs.items.entries = decompressEntries(cs.items.entries);
+					cs.items.tools = decompressTools(cs.items.tools);
 				}
 				return cs.items;
 			},


### PR DESCRIPTION
While the JS certainly does not become more beautiful or maintainable, these adjustments will transport engange/hidden states of tools by the GS-id rather than enumaration.

As background: Tools (=their states) where stored with ids generated by counting all tools in the mainbar. However, tools vary in their amount, and so wrong states were occasionally applied to the current tools. 

Related bugs are 
https://mantis.ilias.de/view.php?id=27465
https://mantis.ilias.de/view.php?id=26589
https://mantis.ilias.de/view.php?id=27876

