### PR TITLE
Switches redirect targets if there is an init authentication error.

### DIFF
--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1351,13 +1351,12 @@ class ilInitialisation
             ilContext::getType() == ilContext::CONTEXT_WAC) {
             throw new Exception("Authentication failed.");
         }
-        if ($GLOBALS['DIC']['ilAuthSession']->isExpired()) {
-            ilLoggerFactory::getLogger('init')->debug('Expired session found -> redirect to login page');
-            return self::goToLogin();
-        }
         if (ilPublicSectionSettings::getInstance()->isEnabledForDomain($_SERVER['SERVER_NAME'])) {
             ilLoggerFactory::getLogger('init')->debug('Redirect to public section.');
             return self::goToPublicSection();
+        }
+        if ($GLOBALS['DIC']['ilAuthSession']->isExpired()) {
+            ilLoggerFactory::getLogger('init')->debug('Expired session found -> redirect to login page');
         }
         ilLoggerFactory::getLogger('init')->debug('Redirect to login page.');
         return self::goToLogin();


### PR DESCRIPTION
If the public area is enabled the error should be shown in the anonymous area since the login page blockes a user from proceeding any further with an expired session.
The user has to login successfully or has to clear the cookies to escape a redirect loop to the login.php.

Steps to reproduce:
1)Setup ilias with an anonymous area.
2)Login
3)Surf in the anonymous area until the session expires