### PR TITLE
Fix Parameter must be an array or an counable object

### DIFF
--- a/Services/LDAP/classes/class.ilLDAPQuery.php
+++ b/Services/LDAP/classes/class.ilLDAPQuery.php
@@ -384,8 +384,8 @@ class ilLDAPQuery
         
         // All groups
         foreach ($group_data as $data) {
-            $this->log->debug('Found ' . count($data[$attribute_name]) . ' group members for group ' . $data['dn']);
             if (is_array($data[$attribute_name])) {
+	            $this->log->debug('Found ' . count($data[$attribute_name]) . ' group members for group ' . $data['dn']);
                 foreach ($data[$attribute_name] as $name) {
                     $this->readUserData($name, true, true);
                 }


### PR DESCRIPTION
Fixing error by using ldap-user-sync.

replace debug message after checking for an array

ERROR-LOG:

ilCronManager::runJob:95 count(): Parameter must be an array or an object that implements Countable
ilCronManager::runJob:95 #0 ILIAS_PATH/Services/Init/classes/class.ilErrorHandling.php(461): Whoops\Run->handleError(2, 'count(): Parame...', 'ILIAS_PATH...', 387)
#1 ILIAS_PATH/Services/LDAP/classes/class.ilLDAPQuery.php(387): ilErrorHandling->handlePreWhoops(2, 'count(): Parame...', 'ILIAS_PATH...', 387, Array)
#2 ILIAS_PATH/Services/LDAP/classes/class.ilLDAPQuery.php(131): ilLDAPQuery->fetchGroupMembers()
#3 ILIAS_PATH/Services/LDAP/classes/class.ilLDAPCronSynchronization.php(87): ilLDAPQuery->fetchUsers()
#4 ILIAS_PATH/Services/Cron/classes/class.ilCronManager.php(178): ilLDAPCronSynchronization->run()
#5 ILIAS_PATH/Services/Cron/classes/class.ilCronManager.php(95): ilCronManager::runJob(Object(ilLDAPCronSynchronization), Array, true)
#6 ILIAS_PATH/Services/Cron/classes/class.ilCronManagerGUI.php(282): ilCronManager::runJobManual('ldap_sync')
#7 ILIAS_PATH/Services/Cron/classes/class.ilCronManagerGUI.php(64): ilCronManagerGUI->confirmedRun()
#8 ILIAS_PATH/Services/UICore/classes/class.ilCtrl.php(210): ilCronManagerGUI->executeCommand()
#9 ILIAS_PATH/Modules/SystemFolder/classes/class.ilObjSystemFolderGUI.php(152): ilCtrl->forwardCommand(Object(ilCronManagerGUI))
#10 ILIAS_PATH/Services/UICore/classes/class.ilCtrl.php(210): ilObjSystemFolderGUI->executeCommand()
#11 ILIAS_PATH/Services/Administration/classes/class.ilAdministrationGUI.php(250): ilCtrl->forwardCommand(Object(ilObjSystemFolderGUI))
#12 ILIAS_PATH/Services/UICore/classes/class.ilCtrl.php(210): ilAdministrationGUI->executeCommand()
#13 ILIAS_PATH/Services/UICore/classes/class.ilCtrl.php(175): ilCtrl->forwardCommand(Object(ilAdministrationGUI))
#14 ILIAS_PATH/ilias.php(20): ilCtrl->callBaseClass()
#15 {main}