### PR TITLE
Refinery: add interface to kindlyTo-transformation

### DIFF
--- a/src/Refinery/Factory.php
+++ b/src/Refinery/Factory.php
@@ -48,6 +48,22 @@ class Factory
     }
 
     /**
+     * Combined validations and transformations for primitive data types that
+     * establish a baseline for further constraints and more complex transformations.
+     *
+     * Other then the `to`-group, the `kindlyTo` transformation attempts to implement
+     * [Postels Law](https://en.wikipedia.org/wiki/Robustness_principle) by being
+     * reasonably liberal when interpreting data. Look into the various transformations
+     * in the group for detailed information what works exactly.
+     *
+     * @return KindlyTo\Group
+     */
+    public function kindlyTo() : To\Group
+    {
+        return new KindlyTo\Group($this->dataFactory);
+    }
+
+    /**
      * Creates a factory object to create a transformation object, that
      * can be used to execute other transformation objects in a desired
      * order.

--- a/src/Refinery/KindlyTo/Group.php
+++ b/src/Refinery/KindlyTo/Group.php
@@ -1,0 +1,190 @@
+<?php
+declare(strict_types=1);
+
+/* Copyright (c) 2020 Richard Klees, Extended GPL, see docs/LICENSE */
+
+
+namespace ILIAS\Refinery\KindlyTo;
+
+use ILIAS\Refinery\Transformation;
+
+/**
+ * Transformations in this group transform data to primitive types to establish
+ * a baseline for more complex transformation. They use [Postels Law of robustness](https://en.wikipedia.org/wiki/Robustness_principle)
+ * and thus will be useful when communicating with other systems. Look into the
+ * single transformations for more information about the exact behaviour.
+ *
+ * They don't try to mimic PHPs type cast, but instead follow more sophisticated
+ * rules devised in a series of workshops with interested developers from the
+ * community. Thanks Michael Jansen, Fabian Schmid, Alex Killing, Stephan Winiker,
+ * Timon Amstutz and Nils Haagen.
+ */
+class Group
+{
+    /**
+     * Get a kind transformation to an `int`.
+     *
+     * This supports:
+     *   - strings matching \s*(0|(-?[1-9]\d*))\s*, trimming is supported
+     *   - floats, which will be rounded naturally
+     *   - bools, where true maps to 1 and false to 0
+     * This doesn't support:
+     *   - "" will be discarded, as well as null, because null or empty are not 0
+     *   - delimiters per mill, like 1'000, because these depend on locales
+     *   - written variants of "true", "false" or "null", because these definitely
+     *     aren't ints
+     *   - no leading zeros, because these sometimes are used to mark octals
+     *   - no strings in various encodings, like octal/hex/binary/floating point,
+     *     because there are so many possible formats and interpretations
+     *   - strings containing numbers bigger than PHP_INT_MAX, because what would
+     *     we do with them
+     *
+     * All other data will be discarded.
+     */
+    public function int() : Transformation
+    {
+        throw new \LogicException("Not implemented yet.");
+    }
+
+    /**
+     * Get a kind transformation to a `float`.
+     *
+     * This supports:
+     *   - strings in natural notation matching \s*(0|(-?[1-9]\d*([.,]\d+)?))\s*,
+     *     trimming is supported
+     *   - strings in floating point representation matching \s*-?\d+[eE]-?\d+\s*,
+     *     trimming is supported
+     *   - ints, which will be typecasted to float
+     *   - bools, where true maps to 1.0 and false to 0.0
+     * This doesn't support:
+     *   - "" will be discarded, as well as null, because null or empty are not 0
+     *   - delimiters per mill, like 1'000, because they can't reliably be told from
+     *     the decimal delimiter
+     *   - written variants of "true", "false" or "null", because these definitely are
+     *     no floats
+     *   - "NaN", NaN, "INF" and INF, because these will be introducing problems in
+     *     subsequent calculations. Do you really want to do math with floats?
+     *
+     * All other data will be discarded.
+     */
+    public function float() : Transformation
+    {
+        throw new \LogicException("Not implemented yet.");
+    }
+
+    /**
+     * Get a kind transformation to a `string`.
+     *
+     * This supports:
+     *   - ints, which will be serialized naturally to string
+     *   - bool, where true maps to "true" and false to "false"
+     *   - float, which will be serialized to the floating point representation
+     *   - All other data will be transformed using __toString.
+     *
+     * Regarding the usage of __toString: Transformations in this group are not
+     * meant to provide ways to reliably serialize data. For these type of
+     * transformations, two new groups `serializeTo` and `serializeFrom` would
+     * be a better fit and could deal with intricacies of various serialization
+     * formats way better. Instead, these transformations try to offer a forgiving
+     * way to treat incoming data. So by using kindlyTo()->string(), I tell the
+     * Refinery that I expect a certain piece of data to be some string, and expect
+     * that the Refinery tries to produce one. A transformation to string is a
+     * lossy transformation most of the time anyway, if we don't talk about e.g.
+     * serialization formats. So we don't loose much if we, e.g., transform an
+     * array to "Array".
+     */
+    public function string() : Transformation
+    {
+        throw new \LogicException("Not implemented yet.");
+    }
+
+
+    /**
+     * Get a kind transformation to a `bool`.
+     *
+     * This supports:
+     *   - "true" and "false" in all kinds of capitalization
+     *   - 0 and "0", mapping to false, as well as 1 and "1", mapping to true
+     * This doesn't support:
+     *   - "null" or null, since the absence of some data is something else then
+     *     true or false
+     *   - 1.0 or 0.0, because we don't expect that someone really wants to transmit
+     *     booleans disguised as floats.
+     *
+     * All other data will be discarded. We could have decided to use a much more
+     * liberal approach by e.g. interpreting "existence of data" as true and absence
+     * of data as false. However, these transformations here are not meant to
+     * interpret incoming data as desired at all costs, but instead try to be
+     * forgiving regarding various quirks in encoding when different systems talk
+     * to each other. There seem to be some more or less sane ways to encode bools,
+     * but writing "some data" to represent true, or an empty list to represent
+     * is something else. Also, being more liberal introduces a various odd places
+     * in the mapping. If, e.g., we'd map a null to false, an empty list to false
+     * as well, would we map [null] to false or to true? Why? All this problems
+     * seem to introduce more problems than they solve, so we decided to not be
+     * very liberal here.
+     */
+    public function bool() : Transformation
+    {
+        throw new \LogicException("Not implemented yet.");
+    }
+
+    /**
+     * Get a kind transformation to a `DateTimeImmutable`.
+     *
+     * This supports:
+     *   - all formats mentioned in DateTimeInterface, which are probed in a
+     *     sensible order
+     *   - integers, which will be interpreted as Unix timestamps.
+     *
+     * All other data will be discarded.
+     */
+    public function dateTime() : DateTimeTransformation
+    {
+        throw new \LogicException("Not implemented yet.");
+    }
+
+    /**
+     * Get a kind transformation to a list.
+     *
+     * This supports all data represented as PHP array, which will be used via
+     * array_values($v). Non-arrays will be wrapped in one.
+     */
+    public function listOf(Transformation $transformation) : Transformation
+    {
+        throw new \LogicException("Not implemented yet.");
+    }
+
+    /**
+     * Get a kind transformation to a dictionary.
+     *
+     * This supports all data represented as PHP array. Non-arrays will be wrapped
+     * in one.
+     */
+    public function dictOf(Transformation $transformation) : Transformation
+    {
+        throw new \LogicException("Not implemented yet.");
+    }
+
+    /**
+     * Get a kind transformation to a tuple.
+     *
+     * This supports all data represented as PHP array, which will be used via
+     * array_values($V). Non-arrays will be wrapped in one.
+     */
+    public function tupleOf(array $transformation) : Transformation
+    {
+        throw new \LogicException("Not implemented yet.");
+    }
+
+    /**
+     * Get a kind transformation to a record.
+     *
+     * This supports all data represented as PHP array. Non-arrays will be wrapped
+     * in one.
+     */
+    public function recordOf(array $transformations) : Transformation
+    {
+        throw new \LogicException("Not implemented yet.");
+    }
+}

--- a/src/Refinery/KindlyTo/Group.php
+++ b/src/Refinery/KindlyTo/Group.php
@@ -177,8 +177,7 @@ class Group
     /**
      * Get a kind transformation to a dictionary.
      *
-     * This supports all data represented as PHP array. Non-arrays will be wrapped
-     * in one.
+     * This supports all data represented as PHP array.
      */
     public function dictOf(Transformation $transformation) : Transformation
     {

--- a/src/Refinery/KindlyTo/Group.php
+++ b/src/Refinery/KindlyTo/Group.php
@@ -154,7 +154,7 @@ class Group
      * This supports:
      *   - all formats mentioned in DateTimeInterface, which are probed in a
      *     sensible order
-     *   - integers, which will be interpreted as Unix timestamps.
+     *   - integers and float, which will be interpreted as Unix timestamps.
      *
      * All other data will be discarded.
      */

--- a/src/Refinery/KindlyTo/Group.php
+++ b/src/Refinery/KindlyTo/Group.php
@@ -2,10 +2,19 @@
 declare(strict_types=1);
 
 /* Copyright (c) 2020 Richard Klees, Extended GPL, see docs/LICENSE */
-
+/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
 
 namespace ILIAS\Refinery\KindlyTo;
 
+use ILIAS\Refinery\KindlyTo\Transformation\StringTransformation;
+use ILIAS\Refinery\KindlyTo\Transformation\BooleanTransformation;
+use ILIAS\Refinery\KindlyTo\Transformation\DateTimeTransformation;
+use ILIAS\Refinery\KindlyTo\Transformation\IntegerTransformation;
+use ILIAS\Refinery\KindlyTo\Transformation\FloatTransformation;
+use ILIAS\Refinery\KindlyTo\Transformation\ListTransformation;
+use ILIAS\Refinery\KindlyTo\Transformation\RecordTransformation;
+use ILIAS\Refinery\KindlyTo\Transformation\TupleTransformation;
+use ILIAS\Refinery\KindlyTo\Transformation\DictionaryTransformation;
 use ILIAS\Refinery\Transformation;
 
 /**
@@ -21,6 +30,16 @@ use ILIAS\Refinery\Transformation;
  */
 class Group
 {
+    /**
+     * @var \ILIAS\Data\Factory
+     */
+    private $dataFactory;
+
+    public function __construct(\ILIAS\Data\Factory $dataFactory)
+    {
+        $this->dataFactory = $dataFactory;
+    }
+
     /**
      * Get a kind transformation to an `int`.
      *
@@ -43,7 +62,7 @@ class Group
      */
     public function int() : Transformation
     {
-        throw new \LogicException("Not implemented yet.");
+        return new IntegerTransformation();
     }
 
     /**
@@ -69,7 +88,7 @@ class Group
      */
     public function float() : Transformation
     {
-        throw new \LogicException("Not implemented yet.");
+        return new FloatTransformation();
     }
 
     /**
@@ -95,7 +114,7 @@ class Group
      */
     public function string() : Transformation
     {
-        throw new \LogicException("Not implemented yet.");
+        return new StringTransformation();
     }
 
 
@@ -126,7 +145,7 @@ class Group
      */
     public function bool() : Transformation
     {
-        throw new \LogicException("Not implemented yet.");
+        return new BooleanTransformation();
     }
 
     /**
@@ -139,9 +158,9 @@ class Group
      *
      * All other data will be discarded.
      */
-    public function dateTime() : DateTimeTransformation
+    public function dateTime() : Transformation
     {
-        throw new \LogicException("Not implemented yet.");
+        return new DateTimeTransformation();
     }
 
     /**
@@ -152,7 +171,7 @@ class Group
      */
     public function listOf(Transformation $transformation) : Transformation
     {
-        throw new \LogicException("Not implemented yet.");
+        return new ListTransformation($transformation);
     }
 
     /**
@@ -163,7 +182,7 @@ class Group
      */
     public function dictOf(Transformation $transformation) : Transformation
     {
-        throw new \LogicException("Not implemented yet.");
+        return new DictionaryTransformation($transformation);
     }
 
     /**
@@ -171,20 +190,25 @@ class Group
      *
      * This supports all data represented as PHP array, which will be used via
      * array_values($V). Non-arrays will be wrapped in one.
+     * This will accept array with more fields than expected, but drop the extra fields.
+     *
+     * @param Transformation[] $transformation
      */
     public function tupleOf(array $transformation) : Transformation
     {
-        throw new \LogicException("Not implemented yet.");
+        return new TupleTransformation($transformation);
     }
 
     /**
      * Get a kind transformation to a record.
      *
-     * This supports all data represented as PHP array. Non-arrays will be wrapped
-     * in one.
+     * This supports all data represented as PHP array.
+     * This will accept array with more fields than expected, but drop the extra fields.
+     *
+     * @param array<string,Transformation> $transformations
      */
     public function recordOf(array $transformations) : Transformation
     {
-        throw new \LogicException("Not implemented yet.");
+        return new RecordTransformation($transformations);
     }
 }

--- a/src/Refinery/KindlyTo/Transformation/BooleanTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/BooleanTransformation.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Refinery\KindlyTo\Transformation;
+
+use ILIAS\Refinery\DeriveApplyToFromTransform;
+use ILIAS\Refinery\Transformation;
+use ILIAS\Refinery\ConstraintViolationException;
+
+class BooleanTransformation implements Transformation
+{
+    const BOOL_TRUE_STRING = 'true';
+    const BOOL_FALSE_STRING = 'false';
+    const BOOL_TRUE_NUMBER = 1;
+    const BOOL_FALSE_NUMBER = 0;
+    const BOOL_TRUE_NUMBER_STRING = '1';
+    const BOOL_FALSE_NUMBER_STRING = '0';
+
+    use DeriveApplyToFromTransform;
+
+    /**
+     * @inheritdoc
+     */
+    public function transform($from)
+    {
+        if (is_bool($from)) {
+            return $from;
+        }
+
+        if (
+            $from === self::BOOL_TRUE_NUMBER
+            || $from === self::BOOL_TRUE_NUMBER_STRING
+            || (is_string($from) && mb_strtolower($from) === self::BOOL_TRUE_STRING)
+        ) {
+            return true;
+        }
+
+        if (
+            $from === self::BOOL_FALSE_NUMBER
+            || $from === self::BOOL_FALSE_NUMBER_STRING
+            || (is_string($from) && mb_strtolower($from) === self::BOOL_FALSE_STRING)
+        ) {
+            return false;
+        }
+
+        throw new ConstraintViolationException(
+            sprintf('The value "%s" could not be transformed into boolean.', $from),
+            'not_boolean',
+            $from
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function __invoke($from)
+    {
+        return $this->transform($from);
+    }
+}

--- a/src/Refinery/KindlyTo/Transformation/DateTimeTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/DateTimeTransformation.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Refinery\KindlyTo\Transformation;
+
+use ILIAS\Refinery\ConstraintViolationException;
+use ILIAS\Refinery\DeriveApplyToFromTransform;
+use ILIAS\Refinery\Transformation;
+
+/**
+ * Transform date format to DateTimeImmutable
+ * Please note:
+ * - RFC3339 & W3C format output on screen is the same as Atom
+ * - RFC850 format output on screen is the same as Cookie
+ * - RFC1036, RFC1123, RFC2822 & RSS format output on screen is the same as RFC822
+ */
+class DateTimeTransformation implements Transformation
+{
+    use DeriveApplyToFromTransform;
+
+    /**
+     * @inheritdoc
+     */
+    public function transform($from)
+    {
+        if ($from instanceof \DateTimeImmutable) {
+            return $from;
+        }
+
+        $formats = [
+            \DateTimeImmutable::ATOM,
+            \DateTimeImmutable::COOKIE,
+            \DateTimeImmutable::ISO8601,
+            \DateTimeImmutable::RFC822,
+            \DateTimeImmutable::RFC7231,
+            \DateTimeImmutable::RFC3339_EXTENDED
+        ];
+
+        if (is_string($from)) {
+            foreach ($formats as $format) {
+                $res = \DateTimeImmutable::createFromFormat($format, $from);
+                if ($res instanceof \DateTimeImmutable) {
+                    return $res;
+                }
+            }
+        }
+
+        if (is_int($from) || is_float($from)) {
+            return new \DateTimeImmutable("@" . round($from));
+        }
+
+        throw new ConstraintViolationException(
+            sprintf('Value "%s" could not be transformed.', $from),
+            'no_valid_datetime',
+            $from
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function __invoke($from)
+    {
+        return $this->transform($from);
+    }
+}

--- a/src/Refinery/KindlyTo/Transformation/DictionaryTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/DictionaryTransformation.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Refinery\KindlyTo\Transformation;
+
+use ILIAS\Refinery\DeriveApplyToFromTransform;
+use ILIAS\Refinery\Transformation;
+use ILIAS\Refinery\ConstraintViolationException;
+
+class DictionaryTransformation implements Transformation
+{
+    use DeriveApplyToFromTransform;
+
+    private $transformation;
+
+    public function __construct(Transformation $transformation)
+    {
+        $this->transformation = $transformation;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function transform($from)
+    {
+        if (!is_array($from)) {
+            throw new ConstraintViolationException(
+                sprintf('The value "%s" is no array.', $from),
+                'value_is_no_array',
+                $from
+            );
+        }
+
+        $result = [];
+        foreach ($from as $key => $value) {
+            if (!is_string($key)) {
+                throw new ConstraintViolationException(
+                    'Key is not a string',
+                    'key_is_no_string'
+                );
+            }
+            $transformedValue = $this->transformation->transform($value);
+            $result[$key] = $transformedValue;
+        }
+        return $result;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function __invoke($from)
+    {
+        return $this->transform($from);
+    }
+}

--- a/src/Refinery/KindlyTo/Transformation/FloatTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/FloatTransformation.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Refinery\KindlyTo\Transformation;
+
+use ILIAS\Refinery\DeriveApplyToFromTransform;
+use ILIAS\Refinery\Transformation;
+use ILIAS\Refinery\ConstraintViolationException;
+
+class FloatTransformation implements Transformation
+{
+    const REG_STRING = '/^\s*(0|(-?[1-9]\d*([.,]\d+)?))\s*$/';
+    const REG_STRING_FLOATING = '/^\s*-?\d+[eE]-?\d+\s*$/';
+
+    use DeriveApplyToFromTransform;
+
+    /**
+     * @inheritdoc
+     */
+    public function transform($from)
+    {
+        if (is_float($from) && !is_nan($from) && $from !== INF && $from !== -INF) {
+            return $from;
+        }
+
+        if (is_int($from)) {
+            return (float) $from;
+        }
+
+        if (is_bool($from)) {
+            return floatval($from);
+        }
+
+        if (is_string($from)) {
+            $preg_match_string = preg_match(self::REG_STRING, $from, $RegMatch);
+            if ($preg_match_string) {
+                return floatval(str_replace(',', '.', $from));
+            }
+
+            $preg_match_floating_string = preg_match(self::REG_STRING_FLOATING, $from, $RegMatch);
+            if ($preg_match_floating_string) {
+                return floatval($from);
+            }
+
+            throw new ConstraintViolationException(
+                sprintf('The value "%s" could not be transformed into an float', $from),
+                'not_float',
+                $from
+            );
+        }
+
+        throw new ConstraintViolationException(
+            sprintf('The value "%s" could not be transformed into an float', $from),
+            'not_float',
+            $from
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function __invoke($from)
+    {
+        return $this->transform($from);
+    }
+}

--- a/src/Refinery/KindlyTo/Transformation/IntegerTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/IntegerTransformation.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Refinery\KindlyTo\Transformation;
+
+use ILIAS\Refinery\DeriveApplyToFromTransform;
+use ILIAS\Refinery\Transformation;
+use ILIAS\Refinery\ConstraintViolationException;
+
+class IntegerTransformation implements Transformation
+{
+    const REG_INT = '/^\s*(0|(-?[1-9]\d*))\s*$/';
+
+    use DeriveApplyToFromTransform;
+
+    /**
+     * @inheritdoc
+     */
+    public function transform($from)
+    {
+        if (is_int($from)) {
+            return $from;
+        }
+
+        if (is_float($from) && !is_nan($from) && $from !== INF && $from !== -INF) {
+            $from = round($from);
+            return intval($from);
+        }
+
+        if (is_bool($from)) {
+            return (int) $from;
+        }
+
+        if (is_string($from) && preg_match(self::REG_INT, $from)) {
+            $int = intval($from);
+            // This is supposed to guard against PHP_MIN_INT and PHP_MAX_INT.
+            // We only return the value if it looks the same when transforming it
+            // back to string. This won't be the case for too big or too small
+            // values.
+            if (trim($from) === (string) $int) {
+                return $int;
+            }
+        }
+
+        throw new ConstraintViolationException(
+            sprintf('The value "%s" can not be transformed into an integer', $from),
+            'not_integer',
+            $from
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function __invoke($from)
+    {
+        return $this->transform($from);
+    }
+}

--- a/src/Refinery/KindlyTo/Transformation/ListTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/ListTransformation.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 1998-2020 Luka Kai Alexander Stocker, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Refinery\KindlyTo\Transformation;
+
+use ILIAS\Refinery\ConstraintViolationException;
+use ILIAS\Refinery\DeriveApplyToFromTransform;
+use ILIAS\Refinery\Transformation;
+
+class ListTransformation implements Transformation
+{
+    use DeriveApplyToFromTransform;
+
+    private $transformation;
+
+    public function __construct(Transformation $transformation)
+    {
+        $this->transformation = $transformation;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function transform($from)
+    {
+        if (!is_array($from)) {
+            $from = [$from];
+        }
+
+        $result = [];
+        foreach ($from as $val) {
+            $transformedVal = $this->transformation->transform($val);
+            $result[] = $transformedVal;
+        }
+        return $result;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function __invoke($from)
+    {
+        return $this->transform($from);
+    }
+}

--- a/src/Refinery/KindlyTo/Transformation/RecordTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/RecordTransformation.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Refinery\KindlyTo\Transformation;
+
+use ILIAS\Refinery\DeriveApplyToFromTransform;
+use ILIAS\Refinery\Transformation;
+use ILIAS\Refinery\ConstraintViolationException;
+
+class RecordTransformation implements Transformation
+{
+    use DeriveApplyToFromTransform;
+
+    private $transformations;
+
+    /**
+     *@param Transformation[] $transformations
+     */
+    public function __construct(array $transformations)
+    {
+        foreach ($transformations as $key => $transformation) {
+            if (!$transformation instanceof Transformation) {
+                $transformationClassName = Transformation::class;
+
+                throw new ConstraintViolationException(
+                    sprintf('The array must contain only "%s" instances', $transformationClassName),
+                    'not_a_transformation',
+                    $transformationClassName
+                );
+            }
+
+            if (!is_string($key)) {
+                throw new ConstraintViolationException(
+                    sprintf('The array key "%s" must be a string', $key),
+                    'key_is_not_a_string',
+                    $key
+                );
+            }
+        }
+        $this->transformations = $transformations;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function transform($from)
+    {
+        if (!is_array($from)) {
+            throw new ConstraintViolationException(
+                sprintf('The value "%s" is no array.', $from),
+                'value_is_no_array',
+                $from
+            );
+        }
+
+        $result = [];
+        foreach ($this->transformations as $key => $transformation) {
+            if (!array_key_exists($key, $from)) {
+                throw new ConstraintViolationException(
+                    sprintf('Could not find value for key "%s"', $key),
+                    'no_array_key_existing',
+                    $key
+                );
+            }
+            $result[$key] = $transformation->transform($from[$key]);
+        }
+        return $result;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function __invoke($from)
+    {
+        return $this->transform($from);
+    }
+}

--- a/src/Refinery/KindlyTo/Transformation/StringTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/StringTransformation.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Refinery\KindlyTo\Transformation;
+
+use ILIAS\Refinery\DeriveApplyToFromTransform;
+use ILIAS\Refinery\Transformation;
+use ILIAS\Refinery\ConstraintViolationException;
+
+class StringTransformation implements Transformation
+{
+    const BOOL_TRUE = true;
+    const BOOL_FALSE = false;
+    const BOOL_TRUE_NUMBER = 1;
+    const BOOL_FALSE_NUMBER = 0;
+    const BOOL_TRUE_STRING = 'true';
+    const BOOL_FALSE_STRING = 'false';
+
+    use DeriveApplyToFromTransform;
+
+    /**
+     * @inheritdoc
+     */
+    public function transform($from)
+    {
+        if (is_int($from) || is_float($from) || is_double($from)) {
+            return strval($from);
+        }
+
+        if (is_bool($from) || $from === self::BOOL_TRUE_NUMBER || $from === self::BOOL_FALSE_NUMBER) {
+            if ($from === self::BOOL_TRUE || $from === self::BOOL_TRUE_NUMBER) {
+                return self::BOOL_TRUE_STRING;
+            }
+            if ($from === self::BOOL_FALSE || $from === self::BOOL_FALSE_NUMBER) {
+                return self::BOOL_FALSE_STRING;
+            }
+        }
+
+        if (is_string($from)) {
+            return $from;
+        }
+
+        if (is_object($from) && method_exists($from, '__toString')) {
+            return (string) $from;
+        }
+
+        throw new ConstraintViolationException(
+            sprintf('The value "%s" could not be transformed into a string', $from),
+            'not_string',
+            $from
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function __invoke($from)
+    {
+        return $this->transform($from);
+    }
+}

--- a/src/Refinery/KindlyTo/Transformation/TupleTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/TupleTransformation.php
@@ -1,0 +1,91 @@
+<?php
+declare(strict_types=1);
+/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Refinery\KindlyTo\Transformation;
+
+use ILIAS\Refinery\DeriveApplyToFromTransform;
+use ILIAS\Refinery\Transformation;
+use ILIAS\Refinery\ConstraintViolationException;
+
+class TupleTransformation implements Transformation
+{
+    use DeriveApplyToFromTransform;
+
+    private $transformations;
+
+    /**
+     * @param Transformation[] $transformations;
+     */
+    public function __construct(array $transformations)
+    {
+        foreach ($transformations as $transformation) {
+            if (!$transformation instanceof Transformation) {
+                $transformationClassName = Transformation::class;
+
+                throw new ConstraintViolationException(
+                    sprintf('The array must contain only "%s" instances', $transformationClassName),
+                    'not_a_transformation',
+                    $transformationClassName
+                );
+            }
+        }
+        $this->transformations = $transformations;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function transform($from)
+    {
+        if (!is_array($from)) {
+            $from = [$from];
+        }
+
+        if ([] === $from) {
+            throw new ConstraintViolationException(
+                sprintf('The array "%s" ist empty', $from),
+                'value_array_is_empty',
+                $from
+            ) ;
+        }
+
+        $this->testLengthOf($from);
+
+        $result = [];
+        foreach ($from as $key => $value) {
+            if (!array_key_exists($key, $this->transformations)) {
+                throw new ConstraintViolationException(
+                    sprintf('Matching value "%s" not found', $value),
+                    'matching_values_not_found',
+                    $value
+                );
+            }
+            $transformedValue = $this->transformations[$key]->transform($value);
+            $result[] = $transformedValue;
+        }
+        return $result;
+    }
+
+    private function testLengthOf(array $values) : void
+    {
+        $countOfValues = count($values);
+        $countOfTransformations = count($this->transformations);
+
+        if ($countOfValues !== $countOfTransformations) {
+            throw new ConstraintViolationException(
+                sprintf('The length of given value "%s" does not match with the given transformations', $countOfValues),
+                'given_values_',
+                $countOfValues
+            );
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function __invoke($from)
+    {
+        return $this->transform($from);
+    }
+}

--- a/tests/Refinery/KindlyTo/GroupTest.php
+++ b/tests/Refinery/KindlyTo/GroupTest.php
@@ -1,0 +1,73 @@
+<?php
+/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Tests\Refinery\KindlyTo;
+
+use ILIAS\Refinery\KindlyTo\Group;
+use ILIAS\Refinery\KindlyTo\Transformation\FloatTransformation;
+use ILIAS\Refinery\KindlyTo\Transformation\StringTransformation;
+use ILIAS\Refinery\KindlyTo\Transformation\BooleanTransformation;
+use ILIAS\Refinery\KindlyTo\Transformation\DateTimeTransformation;
+use ILIAS\Refinery\KindlyTo\Transformation\IntegerTransformation;
+use ILIAS\Refinery\KindlyTo\Transformation\RecordTransformation;
+use ILIAS\Refinery\KindlyTo\Transformation\TupleTransformation;
+use ILIAS\Refinery\KindlyTo\Transformation\DictionaryTransformation;
+use ILIAS\Tests\Refinery\TestCase;
+
+class GroupTest extends TestCase
+{
+    private $basicGroup;
+
+    public function setUp() : void
+    {
+        $this->basicGroup = new Group(new \ILIAS\Data\Factory());
+    }
+
+    public function testIsStringTransformationInstance()
+    {
+        $transformation = $this->basicGroup->string();
+        $this->assertInstanceOf(StringTransformation::class, $transformation);
+    }
+
+    public function testIsBooleanTransformationInstance()
+    {
+        $transformation = $this->basicGroup->bool();
+        $this->assertInstanceOf(BooleanTransformation::class, $transformation);
+    }
+
+    public function testIsDateTimeTransformationInterface()
+    {
+        $transformation = $this->basicGroup->dateTime();
+        $this->assertInstanceOf(DateTimeTransformation::class, $transformation);
+    }
+
+    public function testIsIntegerTransformationInterface()
+    {
+        $transformation = $this->basicGroup->int();
+        $this->assertInstanceOf(IntegerTransformation::class, $transformation);
+    }
+
+    public function testIsFloatTransformationInterface()
+    {
+        $transformation = $this->basicGroup->float();
+        $this->assertInstanceOf(FloatTransformation::class, $transformation);
+    }
+
+    public function testIsRecordTransformationInterface()
+    {
+        $transformation = $this->basicGroup->recordOf(array('tostring' => new StringTransformation()));
+        $this->assertInstanceOf(RecordTransformation::class, $transformation);
+    }
+
+    public function testIsTupleTransformationInterface()
+    {
+        $transformation = $this->basicGroup->tupleOf(array(new StringTransformation()));
+        $this->assertInstanceOf(TupleTransformation::class, $transformation);
+    }
+
+    public function testNewDictionaryTransformation()
+    {
+        $transformation = $this->basicGroup->dictOf(new StringTransformation());
+        $this->assertInstanceOf(DictionaryTransformation::class, $transformation);
+    }
+}

--- a/tests/Refinery/KindlyTo/Transformation/BooleanTransformationTest.php
+++ b/tests/Refinery/KindlyTo/Transformation/BooleanTransformationTest.php
@@ -1,0 +1,78 @@
+<?php
+/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Tests\Refinery\KindlyTo\Transformation;
+
+use ILIAS\Refinery\KindlyTo\Transformation\BooleanTransformation;
+use ILIAS\Tests\Refinery\TestCase;
+use ILIAS\Refinery\ConstraintViolationException;
+
+/**
+ * Test transformations in this Group
+ */
+class BooleanTransformationTest extends TestCase
+{
+    private $transformation;
+
+    public function setUp() : void
+    {
+        $this->transformation = new BooleanTransformation();
+    }
+
+    /**
+     * @dataProvider BooleanTestDataProvider
+     * @param $originVal
+     * @param bool $expectedVal
+     */
+    public function testBooleanTransformation($originVal, $expectedVal)
+    {
+        $transformedValue = $this->transformation->transform($originVal);
+        $this->assertIsBool($transformedValue);
+        $this->assertSame($expectedVal, $transformedValue);
+    }
+
+    /**
+     * @dataProvider TransformationFailureDataProvider
+     * @param $failingValue
+     */
+    public function testTransformIsInvalid($failingValue)
+    {
+        $this->expectException(ConstraintViolationException::class);
+        $this->transformation->transform($failingValue);
+    }
+
+    public function BooleanTestDataProvider()
+    {
+        return [
+            'true' => [true, true],
+            'false' => [false, false],
+            'pos_boolean1' => ['true', true],
+            'pos_boolean2' => ['TRUE', true],
+            'pos_boolean3' => ['True', true],
+            'pos_boolean4' => ['tRuE', true],
+            'pos_boolean_number' => [1, true],
+            'pos_boolean_number_string' => ['1', true],
+            'neg_boolean1' => ['false', false],
+            'neg_boolean2' => ['FALSE', false],
+            'neg_boolean3' => ['False', false],
+            'neg_boolean4' => ['fAlSe', false],
+            'neg_boolean_number' => [0, false],
+            'neg_boolean_number_string' => ['0', false]
+        ];
+    }
+
+
+    public function TransformationFailureDataProvider()
+    {
+        return [
+            'null' => [null],
+            'null_as_string' => ["null"],
+            'float_zero' => [0.0],
+            'float_one' => [1.0],
+            'two' => [2],
+            'two_as_string' => ["2"],
+            'some_array' => [[]],
+            'some_string' => [""]
+        ];
+    }
+}

--- a/tests/Refinery/KindlyTo/Transformation/DateTimeTransformationTest.php
+++ b/tests/Refinery/KindlyTo/Transformation/DateTimeTransformationTest.php
@@ -1,0 +1,70 @@
+<?php
+/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Tests\Refinery\KindlyTo\Transformation;
+
+require_once('./libs/composer/vendor/autoload.php');
+
+use ILIAS\Refinery\ConstraintViolationException;
+use ILIAS\Refinery\KindlyTo\Transformation\DateTimeTransformation;
+use ILIAS\Tests\Refinery\TestCase;
+
+/**
+ * Tests for DateTimeImmutable and Unix Timetable transformation
+ */
+
+class DateTimeTransformationTest extends TestCase
+{
+    private $transformation;
+
+    public function setUp() : void
+    {
+        $this->transformation = new DateTimeTransformation();
+    }
+
+    /**
+     * @dataProvider DateTimeTransformationDataProvider
+     * @param $originVal
+     * @param $expectedVal
+     */
+    public function testDateTimeISOTransformation($originVal, $expectedVal)
+    {
+        $transformedValue = $this->transformation->transform($originVal);
+        $this->assertIsObject($transformedValue);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $transformedValue);
+        $this->assertEquals($expectedVal, $transformedValue);
+    }
+
+    /**
+     * @dataProvider TransformationFailureDataProvider
+     * @param $failingValue
+     */
+    public function testTransformIsInvalid($failingValue)
+    {
+        $this->expectException(ConstraintViolationException::class);
+        $this->transformation->transform($failingValue);
+    }
+
+    public function DateTimeTransformationDataProvider()
+    {
+        $now = new \DateTimeImmutable();
+        return [
+            'datetime' => [$now, $now],
+            'iso8601' => ['2020-07-06T12:23:05+0000',\DateTimeImmutable::createFromFormat(\DateTimeImmutable::ISO8601, '2020-07-06T12:23:05+0000')],
+            'atom' => ['2020-07-06T12:23:05+00:00',\DateTimeImmutable::createFromFormat(\DateTimeImmutable::ATOM, '2020-07-06T12:23:05+00:00')],
+            'rfc3339_ext' => ['2020-07-06T12:23:05.000+00:00',\DateTimeImmutable::createFromFormat(\DateTimeImmutable::RFC3339_EXTENDED, '2020-07-06T12:23:05.000+00:00')],
+            'cookie' => ['Monday, 06-Jul-2020 12:23:05 GMT+0000',\DateTimeImmutable::createFromFormat(\DateTimeImmutable::COOKIE, 'Monday, 06-Jul-2020 12:23:05 GMT+0000')],
+            'rfc822' => ['Mon, 06 Jul 20 12:23:05 +0000',\DateTimeImmutable::createFromFormat(\DateTimeImmutable::RFC822, 'Mon, 06 Jul 20 12:23:05 +0000')],
+            'rfc7231' => ['Mon, 06 Jul 2020 12:23:05 GMT',\DateTimeImmutable::createFromFormat(\DateTimeImmutable::RFC7231, 'Mon, 06 Jul 2020 12:23:05 GMT')],
+            'unix_timestamp' => [481556262, \DateTimeImmutable::createFromFormat(\DateTimeImmutable::ISO8601, '1985-04-05T13:37:42+0000')],
+            'unix_timestamp_float' => [481556262.4, \DateTimeImmutable::createFromFormat(\DateTimeImmutable::ISO8601, '1985-04-05T13:37:42+0000')]
+        ];
+    }
+
+    public function TransformationFailureDataProvider()
+    {
+        return [
+            'no_matching_string_format' => ['hello']
+        ];
+    }
+}

--- a/tests/Refinery/KindlyTo/Transformation/DictionaryTransformationTest.php
+++ b/tests/Refinery/KindlyTo/Transformation/DictionaryTransformationTest.php
@@ -1,0 +1,53 @@
+<?php
+/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Tests\Refinery\KindlyTo\Transformation;
+
+use ILIAS\Refinery\KindlyTo\Transformation\DictionaryTransformation;
+use ILIAS\Refinery\KindlyTo\Transformation\StringTransformation;
+use ILIAS\Refinery\ConstraintViolationException;
+use ILIAS\Tests\Refinery\TestCase;
+
+class DictionaryTransformationTest extends TestCase
+{
+    /**
+     * @dataProvider DictionaryTransformationDataProvider
+     * @param $originVal
+     * @param $expectedVal
+     */
+    public function testDictionaryTransformation($originVal, $expectedVal)
+    {
+        $transformation = new DictionaryTransformation(new StringTransformation());
+        $transformedValue = $transformation->transform($originVal);
+        $this->assertIsArray($transformedValue);
+        $this->assertEquals($expectedVal, $transformedValue);
+    }
+
+    /**
+     * @dataProvider TransformationFailingDataProvider
+     * @param $failingVal
+     */
+    public function testTransformationFailures($failingVal)
+    {
+        $this->expectException(ConstraintViolationException::class);
+        $transformation = new DictionaryTransformation(new StringTransformation());
+        $result = $transformation->transform($failingVal);
+    }
+
+    public function TransformationFailingDataProvider()
+    {
+        return [
+            'key_not_a_string' => ['hello'],
+            'value_not_a_string' => ['hello' => 1]
+        ];
+    }
+
+    public function DictionaryTransformationDataProvider()
+    {
+        return [
+            'first_arr' => [['hello' => 'world'], ['hello' => 'world'] ],
+            'second_arr' => [['hi' => 'earth', 'goodbye' => 'world'], ['hi' => 'earth', 'goodbye' => 'world']],
+            'empty_array' => [[], []]
+        ];
+    }
+}

--- a/tests/Refinery/KindlyTo/Transformation/FloatTransformationTest.php
+++ b/tests/Refinery/KindlyTo/Transformation/FloatTransformationTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Tests\Refinery\KindlyTo\Transformation;
+
+require_once('./libs/composer/vendor/autoload.php');
+
+use ILIAS\Refinery\ConstraintViolationException;
+use ILIAS\Refinery\KindlyTo\Transformation\FloatTransformation;
+use ILIAS\Tests\Refinery\TestCase;
+
+/**
+ * Test transformations in this Group
+ */
+class FloatTransformationTest extends TestCase
+{
+    private $transformation;
+
+    public function setUp() : void
+    {
+        $this->transformation = new FloatTransformation();
+    }
+
+    /**
+     * @dataProvider FloatTestDataProvider
+     * @param $originVal
+     * @param $expectedVal
+     */
+    public function testFloatTransformation($originVal, $expectedVal)
+    {
+        $transformedValue = $this->transformation->transform($originVal);
+        $this->assertIsFloat($transformedValue);
+        $this->assertEquals($expectedVal, $transformedValue);
+    }
+
+    /**
+     * @dataProvider FailingTransformationDataProvider
+     * @param $failingVal
+     */
+    public function testFailingTransformations($failingVal)
+    {
+        $this->expectNotToPerformAssertions();
+        try {
+            $transformedValue = $this->transformation->transform($failingVal);
+        } catch (ConstraintViolationException $exception) {
+            return;
+        }
+        $this->fail();
+    }
+
+    public function FailingTransformationDataProvider()
+    {
+        return [
+            'null' => [null],
+            'empty' => [""],
+            'written_false' => ['false'],
+            'written_null' => ['null'],
+            'NaN' => [NAN],
+            'written_NaN' => ['NaN'],
+            'INF' => [INF],
+            'neg_INF' => [-INF],
+            'written_INF' => ['INF'],
+            'written_neg_INF' => ['-INF'],
+            'weird_notation1' => ["01"],
+            'weird_notation2' => ["-01"],
+            'mill_delim' => ["1'000"]
+        ];
+    }
+
+    public function FloatTestDataProvider()
+    {
+        return [
+            'some_float' => [1.0, 1.0],
+            'pos_bool' => [true, 1.0],
+            'neg_bool' => [false, 0.0],
+            'string_comma' => ['234,23', 234.23],
+            'neg_string_comma' => ['-234,23', -234.23],
+            'neg_string_comma_trimming' => [' -234,23 ', -234.23],
+            'string_point' => ['234.23', 234.23],
+            'neg_string_point' => ['-234.23', -234.23],
+            'neg_string_point_trimming' => [' -234.23 ', -234.23],
+            'string_e_notation' => ['7E10', 70000000000],
+            'string_e_notation_trimming' => [' 7E10 ', 70000000000],
+            'neg_string_e_notation' => ['-7E10', -70000000000],
+            'neg_string_e_notation_trimming' => [' -7E10 ', -70000000000],
+            'int_val' => [23, 23.0],
+            'neg_int_val' => [-2, -2.0],
+            'zero_int' => [0, 0.0]
+        ];
+    }
+}

--- a/tests/Refinery/KindlyTo/Transformation/IntegerTransformationTest.php
+++ b/tests/Refinery/KindlyTo/Transformation/IntegerTransformationTest.php
@@ -1,0 +1,80 @@
+<?php
+/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Tests\Refinery\KindlyTo\Transformation;
+
+use ILIAS\Refinery\ConstraintViolationException;
+use ILIAS\Refinery\KindlyTo\Transformation\IntegerTransformation;
+use ILIAS\Tests\Refinery\TestCase;
+
+/**
+ * Test transformations in this Group
+ */
+class IntegerTransformationTest extends TestCase
+{
+    private $transformation;
+
+    public function setUp() : void
+    {
+        $this->transformation = new IntegerTransformation();
+    }
+
+    /**
+     * @dataProvider IntegerTestDataProvider
+     * @param $originVal
+     * @param $expectedVal
+     */
+    public function testIntegerTransformation($originVal, $expectedVal)
+    {
+        $transformedValue = $this->transformation->transform($originVal);
+        $this->assertIsInt($transformedValue);
+        $this->assertEquals($expectedVal, $transformedValue);
+    }
+
+    /**
+     * @dataProvider TransformationFailureDataProvider
+     * @param $failingValue
+     */
+    public function testTransformIsInvalid($failingValue)
+    {
+        $this->expectException(ConstraintViolationException::class);
+        $this->transformation->transform($failingValue);
+    }
+
+    public function IntegerTestDataProvider()
+    {
+        return [
+            'pos_bool' => [true, (int) 1],
+            'neg_bool' => [false, (int) 0],
+            'float_val' => [20.5, 21],
+            'float_val_round_up' => [0.51, 1],
+            'float_val_round_down' => [0.49, 0],
+            'string_zero' => ['0', 0],
+            'string_val' => ['4947642', 4947642],
+            'neg_string_val' => ['-4947642', -4947642],
+            'string_val_trimming' => [' 4947642 ', 4947642],
+            'neg_string_val_trimming' => [' -4947642 ', -4947642],
+        ];
+    }
+
+    public function TransformationFailureDataProvider()
+    {
+        return [
+            'bigger_than_int_max' => ["9223372036854775808"],
+            'smaller_than_int_min' => ["-9223372036854775809"],
+            'weird_notation' => ["01"],
+            'some_array' => [[]],
+            'mill_delim' => ["1'000"],
+            'null' => [null],
+            'empty' => [""],
+            'written_false' => ['false'],
+            'written_null' => ['null'],
+            'NaN' => [NAN],
+            'written_NaN' => ['NaN'],
+            'INF' => [INF],
+            'neg_INF' => [-INF],
+            'written_INF' => ['INF'],
+            'written_neg_INF' => ['-INF'],
+        ];
+    }
+}

--- a/tests/Refinery/KindlyTo/Transformation/ListTransformationTest.php
+++ b/tests/Refinery/KindlyTo/Transformation/ListTransformationTest.php
@@ -1,0 +1,59 @@
+<?php
+/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Tests\Refinery\KindlyTo\Transformation;
+
+require_once('./libs/composer/vendor/autoload.php');
+
+use ILIAS\Refinery\ConstraintViolationException;
+use ILIAS\Refinery\KindlyTo\Transformation\ListTransformation;
+use ILIAS\Refinery\To\Transformation\StringTransformation;
+use ILIAS\Tests\Refinery\TestCase;
+
+/**
+ * Test transformations in this Group
+ */
+class ListTransformationTest extends TestCase
+{
+    /**
+     * @dataProvider ArrayToListTransformationDataProvider
+     * @param $originValue
+     * @param $expectedValue
+     */
+    public function testListTransformation($originValue, $expectedValue)
+    {
+        $transformList = new ListTransformation(new StringTransformation());
+        $transformedValue = $transformList->transform($originValue);
+        $this->assertIsArray($transformedValue);
+        $this->assertEquals($expectedValue, $transformedValue);
+    }
+
+    /**
+     * @dataProvider ArrayFailureDataProvider
+     * @param $origValue
+     */
+    public function testFailingTransformations($origValue)
+    {
+        $this->expectException(ConstraintViolationException::class);
+        $transformList = new ListTransformation(new StringTransformation());
+        $transformList->transform($origValue);
+    }
+
+    public function ArrayToListTransformationDataProvider()
+    {
+        return [
+            'first_arr' => [['hello', 'world'], ['hello', 'world']],
+            'second_arr' => [['hello2','world2'], ['hello2', 'world2']],
+            'string_val' => ['hello world',['hello world']],
+            'empty_array' => [[], []]
+        ];
+    }
+
+    public function ArrayFailureDataProvider()
+    {
+        return [
+            'null_array' => [[null]],
+            'value_is_no_string' => [['hello', 2]]
+        ];
+    }
+}

--- a/tests/Refinery/KindlyTo/Transformation/RecordTransformationTest.php
+++ b/tests/Refinery/KindlyTo/Transformation/RecordTransformationTest.php
@@ -1,0 +1,122 @@
+<?php
+/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Tests\Refinery\KindlyTo\Transformation;
+
+use ILIAS\Refinery\ConstraintViolationException;
+use ILIAS\Refinery\KindlyTo\Transformation\IntegerTransformation;
+use ILIAS\Refinery\KindlyTo\Transformation\RecordTransformation;
+use ILIAS\Refinery\KindlyTo\Transformation\StringTransformation;
+use ILIAS\Tests\Refinery\TestCase;
+
+require_once('./libs/composer/vendor/autoload.php');
+
+class RecordTransformationTest extends TestCase
+{
+    const STRING_KEY = 'stringKey';
+    const INT_KEY = 'integerKey';
+    const SECOND_INT_KEY = 'integerKey2';
+
+    /**
+     * @dataProvider RecordTransformationDataProvider
+     * @param $originVal
+     * @param $expectedVal
+     */
+    public function testRecordTransformationIsValid($originVal, $expectedVal)
+    {
+        $recTransform = new RecordTransformation(
+            [
+                self::STRING_KEY => new StringTransformation(),
+                self::INT_KEY => new IntegerTransformation()
+            ]
+        );
+        $transformedValue = $recTransform->transform($originVal);
+        $this->assertIsArray($transformedValue);
+        $this->assertEquals($expectedVal, $transformedValue);
+    }
+
+    /**
+     * @dataProvider RecordFailureDataProvider
+     * @param $origVal
+     */
+    public function testRecordTransformationFailures($origVal)
+    {
+        $this->expectNotToPerformAssertions();
+        $recTransformation = new RecordTransformation(
+            array(
+                self::STRING_KEY => new StringTransformation(),
+                self::INT_KEY => new IntegerTransformation()
+            )
+        );
+
+        try {
+            $result = $recTransformation->transform($origVal);
+        } catch (ConstraintViolationException $exception) {
+            return;
+        }
+        $this->fail();
+    }
+
+    public function testInvalidArray()
+    {
+        $this->expectNotToPerformAssertions();
+        try {
+            $recTransformation = new RecordTransformation(
+                [
+                    new StringTransformation(),
+                    new IntegerTransformation()
+                ]
+            );
+        } catch (ConstraintViolationException $exception) {
+            return;
+        }
+        $this->fail();
+    }
+
+    /**
+     * @dataProvider RecordValueInvalidDataProvider
+     * @param $originalValue
+     */
+    public function testInvalidValueDoesNotMatch($originalValue)
+    {
+        $this->expectNotToPerformAssertions();
+        $recTransformation = new RecordTransformation(
+            [
+                self::INT_KEY => new IntegerTransformation(),
+                self::SECOND_INT_KEY => new IntegerTransformation()
+            ]
+        );
+
+        try {
+            $result = $recTransformation->transform($originalValue);
+        } catch (ConstraintViolationException $exception) {
+            return;
+        }
+        $this->fail();
+    }
+
+    public function RecordTransformationDataProvider()
+    {
+        return [
+            "exact_form" => [['stringKey' => 'hello', 'integerKey' => 1], ['stringKey' => 'hello', 'integerKey' => 1]],
+
+            'too_many_values' => [['stringKey' => 'hello', 'integerKey' => 1, 'secondIntKey' => 1],['stringKey' => 'hello', 'integerKey' => 1]]
+        ];
+    }
+
+    public function RecordFailureDataProvider()
+    {
+        return [
+            'too_little_values' => [['stringKey' => 'hello']],
+            'key_is_not_a_string' => [['testKey' => 'hello', ]],
+            'key_value_is_invalid' => [['stringKey' => 'hello', 'integerKey2' => 1]]
+        ];
+    }
+
+    public function RecordValueInvalidDataProvider()
+    {
+        return [
+            'invalid_value' => [array('stringKey' => 'hello', 'integerKey2' => 1)]
+        ];
+    }
+}

--- a/tests/Refinery/KindlyTo/Transformation/StringTransformationTest.php
+++ b/tests/Refinery/KindlyTo/Transformation/StringTransformationTest.php
@@ -1,0 +1,54 @@
+<?php
+/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Tests\Refinery\KindlyTo\Transformation;
+
+require_once('./libs/composer/vendor/autoload.php');
+
+use ILIAS\Refinery\KindlyTo\Transformation\StringTransformation;
+use ILIAS\Tests\Refinery\TestCase;
+
+/**
+ * Test transformations in this Group
+ */
+class StringTransformationTest extends TestCase
+{
+    private $transformation;
+
+    public function setUp() : void
+    {
+        $this->transformation = new StringTransformation();
+    }
+
+    /**
+     * @dataProvider StringTestDataProvider
+     * @param $originVal
+     * @param string $expectedVal
+     */
+    public function testStringTransformation($originVal, $expectedVal)
+    {
+        $transformedValue = $this->transformation->transform($originVal);
+        $this->assertIsString($transformedValue);
+        $this->assertEquals($expectedVal, $transformedValue);
+    }
+
+    public function StringTestDataProvider()
+    {
+        $obj = new class extends \StdClass {
+            public function __toString()
+            {
+                return 'an object';
+            }
+        };
+        return [
+            'string_val' => ['hello', 'hello'],
+            'int_val' => [300, '300'],
+            'neg_int_val' => [-300, '-300'],
+            'zero_int_val' => [0, '0'],
+            'pos_bool' => [true, 'true'],
+            'neg_bool' => [false, 'false'],
+            'float_val' => [20.5, '20.5'],
+            'object_val' => [$obj, 'an object']
+        ];
+    }
+}

--- a/tests/Refinery/KindlyTo/Transformation/TupleTransformationTest.php
+++ b/tests/Refinery/KindlyTo/Transformation/TupleTransformationTest.php
@@ -1,0 +1,91 @@
+<?php
+/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Tests\Refinery\KindlyTo\Transformation;
+
+use ILIAS\Refinery\ConstraintViolationException;
+use ILIAS\Refinery\KindlyTo\Transformation\IntegerTransformation;
+use ILIAS\Refinery\KindlyTo\Transformation\TupleTransformation;
+use ILIAS\Tests\Refinery\TestCase;
+
+require_once ('./libs/composer/vendor/autoload.php');
+
+class TupleTransformationTest extends TestCase {
+    const TUPLE_KEY = 'hello';
+    /**
+     * @dataProvider TupleTransformationDataProvider
+     * @param $originVal
+     * @param $expectedVal
+     */
+    public function testTupleTransformation($originVal, $expectedVal) {
+        $transformation = new TupleTransformation(
+            [
+                new IntegerTransformation(),
+                new IntegerTransformation()
+            ]
+        );
+        $transformedValue = $transformation->transform($originVal);
+        $this->assertIsArray($transformedValue);
+        $this->assertEquals($expectedVal, $transformedValue);
+    }
+
+    /**
+     * @dataProvider TupleFailingTransformationDataProvider
+     * @param $failingVal
+     */
+    public function testNewTupleIsIncorrect($failingVal) {
+        $this->expectNotToPerformAssertions();
+        $transformation = new TupleTransformation(
+            [
+                new IntegerTransformation(),
+                self::TUPLE_KEY => new IntegerTransformation()
+            ]
+        );
+
+        try {
+            $result = $transformation->transform($failingVal);
+        } catch (ConstraintViolationException $exception) {
+            return;
+        }
+        $this->fail();
+    }
+
+    /**
+     * @dataProvider TupleTooManyValuesDataProvider
+     * @param $tooManyValues
+     */
+    public function testTupleTooManyValues($tooManyValues) {
+        $this->expectNotToPerformAssertions();
+        $transformation = new TupleTransformation(
+            [
+                new IntegerTransformation(),
+                new IntegerTransformation()
+            ]
+        );
+
+        try {
+            $result = $transformation->transform($tooManyValues);
+        } catch (ConstraintViolationException $exception) {
+            return;
+        }
+        $this->fail();
+    }
+
+    public function TupleTooManyValuesDataProvider() {
+        return [
+            'too_many_values' => [array(1,2,3)]
+        ];
+    }
+
+    public function TupleFailingTransformationDataProvider() {
+        return [
+            'incorrect_tuple' => [array(1, 2)]
+        ];
+    }
+
+    public function TupleTransformationDataProvider() {
+        return [
+            'array_test01' => [array(1, 2), [1, 2]]
+        ];
+    }
+}


### PR DESCRIPTION
Hi everybody,

this proposes a missing piece from our `Refinery` input validation framework, which are the `kindlyTo` transformation to implement [Postels Law of robustness](https://en.wikipedia.org/wiki/Robustness_principle) when dealing with input from other systems.

We had three workshops of round about 4 hours to [discuss the details](https://docu.ilias.de/goto_docu_xpdl_7929.html). Thanks @mjansenDatabay, @chfsx, @alex40724, @swiniker, @Amstutz and @nhaagen. This is what we came up with, and we all thought it would be helpful to see our results in a collected form to see if they are internally coherent.

We also found that we would want to have `optionalInt`, `optionalBool`, ... to match the `null or int`, `null or bool`, ... cases. To keep this digestible I did not include these here.

Since this will be something every ILIAS developer will need to work with at some point I invite everybody to ask questions, express (dis-)agreement or give feedback in general.

Thanks and best regards!