### PR TITLE
Fixed strange grep message in special char checker

### DIFF
--- a/CI/Special-Char-Checker/special-char-checker.sh
+++ b/CI/Special-Char-Checker/special-char-checker.sh
@@ -46,6 +46,10 @@ echo "Found $AMOUNT_OF_FILES files."
 COUNTER=0
 for PHPFILE in $(find . -path ./libs -prune -o -type f -name '*.'"$EXTENSION");
 do
+    if [[ $PHPFILE == "./libs" ]]; then
+      continue
+    fi
+
     COUNTER=$((COUNTER + 1))
     echo -ne "Scanning $COUNTER of $AMOUNT_OF_FILES"'\r';
 


### PR DESCRIPTION
As you can see in this job: https://travis-ci.com/github/ILIAS-eLearning/ILIAS/jobs/305315918#L1150 we usually get a strange grep message (despite libs is excluded):

```
grep: ./libs: Is a directory
grep: ./libs: Is a directory
grep: ./libs: Is a directory
grep: ./libs: Is a directory
grep: ./libs: Is a directory
grep: ./libs: Is a directory
grep: ./libs: Is a directory
grep: ./libs: Is a directory
grep: ./libs: Is a directory
```

So I excluded libs again in the loop.