### PR TITLE
Table: Fix of scrolling in responsive view, see #27833

### DIFF
--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -15719,9 +15719,10 @@ tr.tblheader {
 td > img[src$="icon_custom.svg"] {
   max-width: 32px;
 }
-@media (min-width: 768px) {
+@media (max-width: 768px) {
   .table-responsive {
-    overflow: visible;
+    overflow-x: auto;
+    max-width: 94vw;
   }
 }
 /* Services/Notes */

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -12352,6 +12352,10 @@ body#tinymce {
   margin: 5px auto 0;
   width: 700px;
 }
+div#mainspacekeeper {
+  overflow: auto;
+  max-width: 100%;
+}
 .fullwidth {
   width: 100%;
 }
@@ -15719,10 +15723,9 @@ tr.tblheader {
 td > img[src$="icon_custom.svg"] {
   max-width: 32px;
 }
-@media (max-width: 768px) {
+@media (min-width: 768px) {
   .table-responsive {
-    overflow-x: auto;
-    max-width: 94vw;
+    overflow: visible;
   }
 }
 /* Services/Notes */

--- a/templates/default/delos.less
+++ b/templates/default/delos.less
@@ -693,6 +693,8 @@ body#tinymce {
 }
 
 div#mainspacekeeper {
+	overflow: auto;
+	max-width: 100%;
 }
 
 div#mainscrolldiv {

--- a/templates/default/less/Services/Table/delos.less
+++ b/templates/default/less/Services/Table/delos.less
@@ -253,8 +253,12 @@ td > img[src$="icon_custom.svg"] {
   }
 }
 
-@media (min-width: 768px) {
-  .table-responsive {
-	overflow: visible;
-  }
+//Note this is fixes the responsive view for the legacy table. In future we should rather move to truly responsive tables.
+//See #27833
+@media (max-width: @grid-float-breakpoint-max) {
+	.table-responsive{
+		overflow-x: auto;
+		max-width: 94vw;
+	}
 }
+

--- a/templates/default/less/Services/Table/delos.less
+++ b/templates/default/less/Services/Table/delos.less
@@ -252,13 +252,3 @@ td > img[src$="icon_custom.svg"] {
 	//position: static !important; // Removed due to https://mantis.ilias.de/view.php?id=22175
   }
 }
-
-//Note this is fixes the responsive view for the legacy table. In future we should rather move to truly responsive tables.
-//See #27833
-@media (max-width: @grid-float-breakpoint-max) {
-	.table-responsive{
-		overflow-x: auto;
-		max-width: 94vw;
-	}
-}
-


### PR DESCRIPTION
Proposal for (partly) fixing: https://mantis.ilias.de/view.php?id=27833

<del>I am not proud to propose this in this manner. However this could be a pragmatic way forward for fixing the linked issue in the responsive view for the legacy table.

<del>Note the CSS only kicks bellow our @grid-float-breakpoint-max  (768px) above that we still scroll the complete page content (which is often the case of the Main Bar has it's Slates opened).

[Edit] Thx for @klees for pointing me towards a superior solution.
