### PR TITLE
Tree: Optimize \ilTree::getPathFull

### DIFF
--- a/Services/Tree/classes/class.ilTree.php
+++ b/Services/Tree/classes/class.ilTree.php
@@ -1063,7 +1063,7 @@ class ilTree
         }
 
         if ($this->__isMainTree() && $this->tree_id == 1) {
-            usort($pathFull, static function(array $leftNode, array $rightNode) {
+            usort($pathFull, static function(array $leftNode, array $rightNode) : int {
                 return strcmp($leftNode['depth'], $rightNode['depth']);
             });
 

--- a/Services/Tree/classes/class.ilTree.php
+++ b/Services/Tree/classes/class.ilTree.php
@@ -1064,7 +1064,7 @@ class ilTree
 
         if ($this->__isMainTree() && $this->tree_id == 1) {
             usort($pathFull, static function(array $leftNode, array $rightNode) : int {
-                return strcmp($leftNode['depth'], $rightNode['depth']);
+                return (int) $leftNode['depth'] <=> (int) $rightNode['depth'];
             });
         }
 

--- a/Services/Tree/classes/class.ilTree.php
+++ b/Services/Tree/classes/class.ilTree.php
@@ -1066,8 +1066,6 @@ class ilTree
             usort($pathFull, static function(array $leftNode, array $rightNode) : int {
                 return strcmp($leftNode['depth'], $rightNode['depth']);
             });
-
-            return $pathFull;
         }
 
         return $pathFull;


### PR DESCRIPTION
This PR optimizes ilTree::getPathFull on (at least) MariaDB installations by applying a tree filter in PHP, not in SQL.

This improves the performance of large installations.

If approved, this should be merged to all maintained ILIAS versions.