### PR TITLE
Performance Participant: Only count total amount if necessary

### DIFF
--- a/Services/Membership/classes/class.ilParticipant.php
+++ b/Services/Membership/classes/class.ilParticipant.php
@@ -293,7 +293,7 @@ abstract class ilParticipant
 
         $rbacreview = $DIC['rbacreview'];
 
-        if(!$this->numMembers){
+        if (!$this->numMembers) {
             $this->numMembers = $rbacreview->getNumberOfAssignedUsers($this->member_roles);
         }
         return $this->numMembers;
@@ -316,6 +316,7 @@ abstract class ilParticipant
         $users = array();
         $this->participants = array();
         $this->members = $this->admins = $this->tutors = array();
+        $this->member_roles = [];
 
         foreach ($this->roles as $role_id) {
             $title = $ilObjDataCache->lookupTitle($role_id);

--- a/Services/Membership/classes/class.ilParticipant.php
+++ b/Services/Membership/classes/class.ilParticipant.php
@@ -50,7 +50,9 @@ abstract class ilParticipant
     private $tutors = false;
     private $members = false;
     
-    private $numMembers = 0;
+    private $numMembers;
+
+    private $member_roles = [];
 
     private $participants_status = array();
 
@@ -287,6 +289,13 @@ abstract class ilParticipant
     
     public function getNumberOfMembers()
     {
+        global $DIC;
+
+        $rbacreview = $DIC['rbacreview'];
+
+        if(!$this->numMembers){
+            $this->numMembers = $rbacreview->getNumberOfAssignedUsers($this->member_roles);
+        }
         return $this->numMembers;
     }
     
@@ -307,14 +316,12 @@ abstract class ilParticipant
         $users = array();
         $this->participants = array();
         $this->members = $this->admins = $this->tutors = array();
-        
-        $member_roles = array();
 
         foreach ($this->roles as $role_id) {
             $title = $ilObjDataCache->lookupTitle($role_id);
             switch (substr($title, 0, 8)) {
                 case 'il_crs_m':
-                    $member_roles[] = $role_id;
+                    $this->member_roles[] = $role_id;
                     $this->role_data[IL_CRS_MEMBER] = $role_id;
                     if ($rbacreview->isAssigned($this->getUserId(), $role_id)) {
                         $this->participants = true;
@@ -347,7 +354,7 @@ abstract class ilParticipant
                     break;
 
                 case 'il_grp_m':
-                    $member_roles[] = $role_id;
+                    $this->member_roles[] = $role_id;
                     $this->role_data[IL_GRP_MEMBER] = $role_id;
                     if ($rbacreview->isAssigned($this->getUserId(), $role_id)) {
                         $this->participants = true;
@@ -356,8 +363,8 @@ abstract class ilParticipant
                     break;
 
                 default:
-                    
-                    $member_roles[] = $role_id;
+
+                    $this->member_roles[] = $role_id;
                     if ($rbacreview->isAssigned($this->getUserId(), $role_id)) {
                         $this->participants = true;
                         $this->members = true;
@@ -365,7 +372,6 @@ abstract class ilParticipant
                     break;
             }
         }
-        $this->numMembers = $rbacreview->getNumberOfAssignedUsers((array) $member_roles);
     }
 
     /**


### PR DESCRIPTION
Hi 

Inspired by the nice move from the colleagues from databay see @mjansenDatabay in e.g. https://github.com/ILIAS-eLearning/ILIAS/pull/2674 in invested some time yesterday with Perf. and Slow Query Logs and some Code Analysis and believe to be also able to contribute some parts to improve the situations of some installations during the corona madness.

This first tries to remove some issue in the participants class. Some background:
- I stumbled over this while logging some queries on some very simple screens in ILIAS and observed, the I had some queries taking quite some time counting members of seemingly random courses:

`select count(distinct(ua.usr_id)) as num from rbac_ua ua join object_data on ua.usr_id = obj_id join usr_data ud on ua.usr_id = ud.usr_id where rol_id IN (...)`

- First I suspected the Who is Online Tool, but no luck. Trigger was the Main Main Menu with a Repository Link. Such entries perform an access check:

`$DIC->access()->checkAccess('visible', '', $ref_id);`

- If the entry is a course, this will __CheckAccess of a course and instatiate a participant. 

`$participants = ilCourseParticipant::_getInstanceByObjId($a_obj_id, $a_user_id);`

- This finally read the participants and at the end of this function calls for some reason:

`$this->numMembers = $rbacreview->getNumberOfAssignedUsers((array) $member_roles);`

Note this is done each time ilParticpant is instantiated (and therefore also when __checkAccess e.g. in Course is called). Further note that the query for counting participants can take some time for large courses, in our case 1000+ Members -> 10ms. 

The numMembers variable is private with a getter. The only instance using the getter I found was lookupRegistrationInfo in ilObjCourseAccess.

What I did is "lazy load" a chash this variable. I hope this is fine. 

