### PR TITLE
Performance Session Access: Do not load all participants to check access of only one

### DIFF
--- a/Modules/Session/classes/class.ilObjSessionAccess.php
+++ b/Modules/Session/classes/class.ilObjSessionAccess.php
@@ -86,9 +86,7 @@ class ilObjSessionAccess extends ilObjectAccess
         if (!$a_user_id) {
             $a_user_id = $ilUser->getId();
         }
-        include_once './Modules/Session/classes/class.ilSessionParticipants.php';
-        $part = ilSessionParticipants::getInstance($a_ref_id);
-        
+
         switch ($a_cmd) {
             case 'register':
                 
@@ -98,10 +96,12 @@ class ilObjSessionAccess extends ilObjectAccess
                 if ($ilUser->isAnonymous()) {
                     return false;
                 }
-                if ($part->isAssigned($a_user_id)) {
+                
+                include_once './Modules/Session/classes/class.ilSessionParticipants.php';
+                if(ilSessionParticipants::_isParticipant($a_ref_id,$a_user_id)) {
                     return false;
                 }
-                if ($part->isSubscriber($a_user_id)) {
+                if (ilSessionParticipants::_isSubscriber($a_obj_id,$a_user_id)) {
                     return false;
                 }
                 include_once './Modules/Session/classes/class.ilSessionWaitingList.php';


### PR DESCRIPTION
Hi 

Inspired by the nice move from the colleagues from databay see @mjansenDatabay in e.g. https://github.com/ILIAS-eLearning/ILIAS/pull/2674 in invested some time yesterday with Perf. and Slow Query Logs and some Code Analysis and believe to be also able to contribute some parts to improve the situations of some installations during the corona madness.

This second removes a rather large issue in the access class of sessions. Some background:
- I stumbled over this while logging some queries in a course with a large list of session, each session containing a very large list of participants (50+, 100+ participants). This content took VERY long time to load a caused a lot of load on the DB. After doing some digging, I found the cause in the ilObjSessionAccess class. __checkAccess there loads for every command to be checked ALL participants of each session:

`$part = ilSessionParticipants::getInstance($a_ref_id);`
        
Some results are cached, but still the amount of data loaded is enormous (everything about every participant), compared with the actual information needed (nothing, or if command "register" then is logged in user participant or subscriber). Note that this is done in our case for all 50+ Sessions in a container. We have a very powerful system at hand, but if many users look at the content, even our system does lose some sweat over this.

@smeyer-ilias plz check if the used static methods are truly equivalent to the other ones. I am quite positive for _isSubscriber. However, somewhat unsure for _isParticipant. 

Thx. 