### PR TITLE
LSO: Performance Issues (#28160)

### DIFF
--- a/Modules/LearningSequence/classes/LSItems/LSItemOnlineStatus.php
+++ b/Modules/LearningSequence/classes/LSItems/LSItemOnlineStatus.php
@@ -24,15 +24,17 @@ class LSItemOnlineStatus
 
     public function setOnlineStatus(int $ref_id, bool $status)
     {
-        $obj = $this->getObjectFor($ref_id);
+        $obj = \ilObjectFactory::getInstanceByRefId($ref_id);
         $obj->setOfflineStatus(!$status);
         $obj->update();
     }
 
     public function getOnlineStatus(int $ref_id) : bool
     {
-        $obj = $this->getObjectFor($ref_id);
-        return !$obj->getOfflineStatus();
+        if(!$this->hasOnlineStatus($ref_id)) {
+            return true;
+        }
+        return !\ilObject::lookupOfflineStatus(\ilObject::_lookupObjId($ref_id));
     }
 
     public function hasOnlineStatus(int $ref_id) : bool
@@ -45,13 +47,8 @@ class LSItemOnlineStatus
         return false;
     }
 
-    protected function getObjectFor(int $ref_id) : ilObject
-    {
-        return ilObjectFactory::getInstanceByRefId($ref_id);
-    }
-
     protected function getObjectTypeFor(int $ref_id) : string
     {
-        return ilObject::_lookupType($ref_id, true);
+        return \ilObject::_lookupType($ref_id, true);
     }
 }

--- a/Modules/LearningSequence/classes/Player/class.ilObjLearningSequenceLearnerGUI.php
+++ b/Modules/LearningSequence/classes/Player/class.ilObjLearningSequenceLearnerGUI.php
@@ -69,9 +69,7 @@ class ilObjLearningSequenceLearnerGUI
             case self::CMD_VIEW:
                 $this->play();
                 break;
-            case LSControlBuilder::CMD_CHECK_CURRENT_ITEM_LP:
-                $this->getCurrentItemLearningProgress();
-                // no break
+
             default:
                 throw new ilException(
                     "ilObjLearningSequenceLearnerGUI: " .
@@ -261,16 +259,5 @@ class ilObjLearningSequenceLearnerGUI
             $href = $this->ctrl->getLinkTarget($this, $cmd, '', false, false);
             \ilUtil::redirect($href);
         }
-    }
-
-
-    protected function getCurrentItemLearningProgress()
-    {
-        foreach ($this->ls_learner_items as $index => $item) {
-            if ($item->getRefId() === $this->current_item) {
-                print $item->getLearningProgressStatus();
-            }
-        }
-        exit;
     }
 }

--- a/Modules/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
+++ b/Modules/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
@@ -127,12 +127,30 @@ class ilObjLearningSequenceGUI extends ilContainerGUI
         $this->object = $this->getObject();
     }
 
+    protected function getCurrentItemLearningProgress()
+    {
+        $usr_id = (int) $this->user->getId();
+        $items = $this->getLearnerItems($usr_id);
+        $current_item_ref_id = $this->getCurrentItemForLearner($usr_id);
+        foreach ($items as $index => $item) {
+            if ($item->getRefId() === $current_item_ref_id) {
+                return $item->getLearningProgressStatus();
+            }
+        }
+    }
+
     public function executeCommand()
     {
         $next_class = $this->ctrl->getNextClass($this);
         $cmd = $this->ctrl->getCmd();
-        $tpl = $this->tpl;
 
+        //exit real early for LP-checking.
+        if($cmd === LSControlBuilder::CMD_CHECK_CURRENT_ITEM_LP) {
+            print $this->getCurrentItemLearningProgress();
+            exit;
+        }
+
+        $tpl = $this->tpl;
         parent::prepareOutput();
         $this->addToNavigationHistory();
         //showRepTree is from containerGUI;


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=28160

Accessing Items would determine the items' online status by instantiating the whole object. This also happenend during LP or PostCondition checks as well as for the curriculum.
It is way less load on the DB to use the static lookups from ilObject. 

This PR additionally moves the async LP-check for legacy objects up one GUI.