### PR TITLE
UI, Breadcrumbs: left-side ellipsis (#26424)

### DIFF
--- a/Modules/LearningSequence/test/LSLocatorBuilderTest.php
+++ b/Modules/LearningSequence/test/LSLocatorBuilderTest.php
@@ -83,12 +83,12 @@ class LSLocatorBuilderTest extends ILIAS_UI_TestBase
         $this->assertInstanceOf(Breadcrumbs::class, $out);
 
         $expected = $this->stripHTML(
-            '<nav role="navigation" aria-label="breadcrumbs"> ' .
-            '	<ul class="breadcrumb"> ' .
-            '		<li class="crumb"> ' .
+            '<nav role="navigation" aria-label="breadcrumbs" class="breadcrumb_wrapper"> ' .
+            '	<div class="breadcrumb"> ' .
+            '		<span class="crumb"> ' .
             '			<a href="http://ilias.de/somepath?lsocmd=cmd&lsov=1" >item 1</a>' .
-            '		</li> ' .
-            '	</ul>' .
+            '		</span> ' .
+            '	</div>' .
             '</nav>'
         );
 

--- a/src/UI/templates/default/Breadcrumbs/breadcrumbs.less
+++ b/src/UI/templates/default/Breadcrumbs/breadcrumbs.less
@@ -40,12 +40,12 @@
 				color: @breadcrumb-active-color;
 			}
 		}
-	}
-}
 
-.breadcrumb>span+span:before {
-	content: " \e606";
-	color: @il-standard-page-breadcrumbs-divider-color;
-	padding: 8px 10px;
-	font-family: "il-icons";
+		&>span+span:before {
+			content: " \e606";
+			color: @il-standard-page-breadcrumbs-divider-color;
+			padding: 8px 10px;
+			font-family: "il-icons";
+		}
+	}
 }

--- a/src/UI/templates/default/Breadcrumbs/breadcrumbs.less
+++ b/src/UI/templates/default/Breadcrumbs/breadcrumbs.less
@@ -19,6 +19,7 @@
 
 	.breadcrumb_wrapper {
 		width: 100%;
+		display: inline-grid;
 	}
 
 	.breadcrumb {

--- a/src/UI/templates/default/Breadcrumbs/breadcrumbs.less
+++ b/src/UI/templates/default/Breadcrumbs/breadcrumbs.less
@@ -17,8 +17,6 @@
 	z-index: @il-standard-page-zindex-breadcrumbs;
 	.shadow-bottom();
 
-
-
 	.breadcrumb_wrapper {
 		width: 100%;
 	}

--- a/src/UI/templates/default/Breadcrumbs/breadcrumbs.less
+++ b/src/UI/templates/default/Breadcrumbs/breadcrumbs.less
@@ -16,24 +16,36 @@
 	grid-row: 2;
 	z-index: @il-standard-page-zindex-breadcrumbs;
 	.shadow-bottom();
-	ul.breadcrumb {
+
+
+
+	.breadcrumb_wrapper {
+		width: 100%;
+	}
+
+	.breadcrumb {
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		direction: rtl;
+		text-align: left;
 		margin: 0;
 		font-weight: @breadcrumb-font-weight;
 		font-size: @font-size-small;
 		padding-left: @il-mainbar-btn-width + @il-standard-page-content-padding;
 
-		li {
+		span.crumb {
 			color: @breadcrumb-color;
 			&:hover {
 				color: @breadcrumb-active-color;
 			}
 		}
-
-		&>li+li:before {
-			content: " \e606";
-			color: @il-standard-page-breadcrumbs-divider-color;
-			padding: 8px 10px;
-			font-family: "il-icons";
-		}
 	}
+}
+
+.breadcrumb>span+span:before {
+	content: " \e606";
+	color: @il-standard-page-breadcrumbs-divider-color;
+	padding: 8px 10px;
+	font-family: "il-icons";
 }

--- a/src/UI/templates/default/Breadcrumbs/tpl.breadcrumbs.html
+++ b/src/UI/templates/default/Breadcrumbs/tpl.breadcrumbs.html
@@ -1,35 +1,9 @@
-
-<style type="text/css">
-.bc_wrap {
-	width: 100%;
-
-}
-.breadcrumb{
-
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    direction: rtl;
-    text-align: left;
-
-    padding-left: 100px;
-}
-
-		span.crumb:before {
-			content: " \e606";
-			padding: 8px 10px;
-			font-family: "il-icons";
-		}
-
-</style>
-
-
-<nav role="navigation" aria-label="breadcrumbs" class="bc_wrap">
-	<p class="breadcrumb">
+<nav role="navigation" aria-label="breadcrumbs" class="breadcrumb_wrapper">
+	<div class="breadcrumb">
 		<!-- BEGIN crumbs -->
 		<span class="crumb">
 			{CRUMB}
 		</span>
 		<!-- END crumbs -->
-	</p>
+	</div>
 </nav>

--- a/src/UI/templates/default/Breadcrumbs/tpl.breadcrumbs.html
+++ b/src/UI/templates/default/Breadcrumbs/tpl.breadcrumbs.html
@@ -1,9 +1,35 @@
-<nav role="navigation" aria-label="breadcrumbs">
-	<ul class="breadcrumb">
+
+<style type="text/css">
+.bc_wrap {
+	width: 100%;
+
+}
+.breadcrumb{
+
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    direction: rtl;
+    text-align: left;
+
+    padding-left: 100px;
+}
+
+		span.crumb:before {
+			content: " \e606";
+			padding: 8px 10px;
+			font-family: "il-icons";
+		}
+
+</style>
+
+
+<nav role="navigation" aria-label="breadcrumbs" class="bc_wrap">
+	<p class="breadcrumb">
 		<!-- BEGIN crumbs -->
-		<li class="crumb">
+		<span class="crumb">
 			{CRUMB}
-		</li>
+		</span>
 		<!-- END crumbs -->
-	</ul>
+	</p>
 </nav>

--- a/tests/UI/Component/Breadcrumbs/BreadcrumbsTest.php
+++ b/tests/UI/Component/Breadcrumbs/BreadcrumbsTest.php
@@ -69,15 +69,15 @@ class BreadcrumbsTest extends ILIAS_UI_TestBase
         $c = $f->Breadcrumbs($crumbs);
 
         $html = $this->normalizeHTML($r->render($c));
-        $expected = '<nav role="navigation" aria-label="breadcrumbs">'
-            . '	<ul class="breadcrumb">'
-            . '		<li class="crumb">'
+        $expected = '<nav role="navigation" aria-label="breadcrumbs" class="breadcrumb_wrapper">'
+            . '	<div class="breadcrumb">'
+            . '		<span class="crumb">'
             . '			<a href="#">label</a>'
-            . '		</li>'
-            . '		<li class="crumb">'
+            . '		</span>'
+            . '		<span class="crumb">'
             . '			<a href="#">label2</a>'
-            . '		</li>'
-            . '	</ul>'
+            . '		</span>'
+            . '	</div>'
             . '</nav>';
 
         $this->assertHTMLEquals($expected, $html);


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=26424

Hi all,
this is a suggestion for breadcrumbs with left-side ellipsis.
There is no JS involved - I think that's good.
However, this does not work with ul/li, so we lose the list in favor of div/spans.
Furthermore, I see no gain in having "Repository" as the fixed first entry, but that could be changed back quite easily.

![Screenshot_BC_2020-05-04 15-21-22](https://user-images.githubusercontent.com/3328364/80973166-4f130b80-8e1f-11ea-97e5-c97d9981b38c.png)
