### PR TITLE
ui-ks - add withAction method to ui element glyph

### DIFF
--- a/src/UI/Component/Symbol/Glyph/Glyph.php
+++ b/src/UI/Component/Symbol/Glyph/Glyph.php
@@ -118,4 +118,12 @@ interface Glyph extends \ILIAS\UI\Component\Symbol\Symbol, Clickable
      * @return Glyph
      */
     public function withUnavailableAction();
+
+    /**
+    * Get a Glyph like this with an action.
+    *
+    * @param string $action
+    * @return mixed
+    */
+    public function withAction($action);
 }

--- a/src/UI/Implementation/Component/Symbol/Glyph/Glyph.php
+++ b/src/UI/Implementation/Component/Symbol/Glyph/Glyph.php
@@ -202,4 +202,14 @@ class Glyph implements C\Symbol\Glyph\Glyph
     {
         return $this->appendTriggeredSignal($signal, 'click');
     }
+
+    /**
+    * @inheritdoc
+    */
+    public function withAction($action)
+    {
+        $clone = clone $this;
+        $clone->action = $action;
+        return $clone;
+    }
 }

--- a/tests/UI/Component/Symbol/Glyph/GlyphTest.php
+++ b/tests/UI/Component/Symbol/Glyph/GlyphTest.php
@@ -456,4 +456,23 @@ class GlyphTest extends ILIAS_UI_TestBase
         $expected = "<a class=\"glyph\" href=\"http://www.ilias.de\" aria-label=\"$aria_label\" id=\"$id\"><span class=\"$css_classes\" aria-hidden=\"true\"></span></a>";
         $this->assertEquals($expected, $html);
     }
+
+    /**
+     * @dataProvider glyph_type_provider
+     */
+    public function test_render_with_action($type)
+    {
+        $f = $this->getGlyphFactory();
+        $r = $this->getDefaultRenderer();
+        $c = $f->$type("http://www.ilias.de");
+        $c = $c->withAction("http://www.ilias.de/open-source-lms-ilias/");
+
+        $html = $this->normalizeHTML($r->render($c));
+
+        $css_classes = self::$canonical_css_classes[$type];
+        $aria_label = self::$aria_labels[$type];
+
+        $expected = "<a class=\"glyph\" href=\"http://www.ilias.de/open-source-lms-ilias/\" aria-label=\"$aria_label\"><span class=\"$css_classes\" aria-hidden=\"true\"></span></a>";
+        $this->assertEquals($expected, $html);
+    }
 }


### PR DESCRIPTION
Sometimes it's useful to add a personalized action to a glyph. In our case it comes handy  to customize pagination. I think this should help in other cases too.