### PR TITLE
Fixed bug #28273

### DIFF
--- a/Services/Membership/classes/class.ilMembershipGUI.php
+++ b/Services/Membership/classes/class.ilMembershipGUI.php
@@ -757,6 +757,8 @@ class ilMembershipGUI
             $participants = (array) $_POST['subscribers'];
         } elseif ($_POST['waiting']) {
             $participants = (array) $_POST['waiting'];
+        } else {
+            $participants = array();
         }
 
         if (!count($participants)) {


### PR DESCRIPTION
Send mail fails with error code if no course members are selected