### PR TITLE
LDAP: Add option for ldap_escape DN

### DIFF
--- a/Services/LDAP/classes/class.ilLDAPQuery.php
+++ b/Services/LDAP/classes/class.ilLDAPQuery.php
@@ -290,7 +290,14 @@ class ilLDAPQuery
         foreach ($group_names as $group) {
             $user = $a_ldap_user_name;
             if ($this->getServer()->enabledGroupMemberIsDN()) {
-                $user = $ldap_user_data['dn'];
+				// Start patch Escape DN
+				if($this->getServer()->enabledEscapeDN()){					
+					$user = ldap_escape($ldap_user_data['dn'], "",  LDAP_ESCAPE_DN);
+				}
+				else{
+					$user = $ldap_user_data['dn'];
+				}
+				// End Patch Escape DN
             }
             
             $filter = sprintf(

--- a/Services/LDAP/classes/class.ilLDAPRoleAssignmentRule.php
+++ b/Services/LDAP/classes/class.ilLDAPRoleAssignmentRule.php
@@ -139,16 +139,25 @@ class ilLDAPRoleAssignmentRule
      */
     private function isGroupMember($a_user_data)
     {
-        if ($this->isMemberAttributeDN()) {
-            $user_cmp = $a_user_data['dn'];
-        } else {
-            $user_cmp = $a_user_data['ilExternalAccount'];
-        }
-        
         include_once('Services/LDAP/classes/class.ilLDAPQuery.php');
         include_once('Services/LDAP/classes/class.ilLDAPServer.php');
                 
         $server = ilLDAPServer::getInstanceByServerId($this->getServerId());
+        
+       if ($this->isMemberAttributeDN()) {
+ 			// start Patch Escape DN
+            if($server->enabledEscapeDN()) 
+            {
+				$user_cmp = ldap_escape($a_user_data['dn'], "",  LDAP_ESCAPE_DN );
+			}
+            else 
+            {
+				$user_cmp = $a_user_data['dn'];
+			}
+			// End Patch Escape DN
+        } else {
+            $user_cmp = $a_user_data['ilExternalAccount'];
+        }
         
         try {
             $query = new ilLDAPQuery($server);

--- a/Services/LDAP/classes/class.ilLDAPSettingsGUI.php
+++ b/Services/LDAP/classes/class.ilLDAPSettingsGUI.php
@@ -672,8 +672,11 @@ class ilLDAPSettingsGUI
             'global_role' => ilLDAPAttributeMapping::_lookupGlobalRole($this->server->getServerId()),
             'migration' => (int) $this->server->isAccountMigrationEnabled(),
             // start Patch Name Filter
-            "name_filter" => $this->server->getUsernameFilter()
+            "name_filter" => $this->server->getUsernameFilter(),
             // end Patch Name Filter
+			// start Patch Escape DN
+			'escape_dn' => $this->server->enabledEscapeDN()
+			// end Patch Escape DN            
         ));
     }
     
@@ -726,6 +729,13 @@ class ilLDAPSettingsGUI
         $basedsn->setSize(64);
         $basedsn->setMaxLength(255);
         $this->form_gui->addItem($basedsn);
+
+        // Start Patch Escape DN
+		$escapedn = new ilCheckboxInputGUI($this->lng->txt('ldap_escapedn'), 'escape_dn');	// ADD LANG VAR	
+		$escapedn->setValue(1);
+		$escapedn->setInfo($this->lng->txt('ldap_escapedn_info'));
+		$this->form_gui->addItem($escapedn);
+        // End Patch Escape DN
         
         $referrals = new ilCheckboxInputGUI($this->lng->txt('ldap_referrals'), 'referrals');
         $referrals->setValue(1);
@@ -924,6 +934,9 @@ class ilLDAPSettingsGUI
             // start Patch Name Filter
             $this->server->setUsernameFilter($this->form_gui->getInput("name_filter"));
             // end Patch Name Filter
+			// start Patch Escape DN
+			$this->server->enableEscapeDN((int) $this->form_gui->getInput('escape_dn'));
+			// end Patch Escape DN
             if (!$this->server->validate()) {
                 ilUtil::sendFailure($ilErr->getMessage());
                 $this->form_gui->setValuesByPost();

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -9204,6 +9204,8 @@ ldap#:#ldap_dn_info#:#Wählen Sie hier den kompletten DN der LDAP-Gruppe.
 ldap#:#ldap_edit_role_ass_rule#:#Regel zur Rollenzuordnung bearbeiten
 ldap#:#ldap_edit_role_assignment#:#Zuordnung bearbeiten
 ldap#:#ldap_err_missing_plugin_id#:#Bitte geben Sie eine gültige Plugin-Id ein.
+ldap#:#ldap_escapedn#:#DN Escapen
+ldap#:#ldap_escapedn_info#:#Legt fest, ob reservierte Zeichen im Distinguished Name escaped werden vor der LDAP Abfrage oder nicht.
 ldap#:#ldap_filter_info#:#Filter, der dem Suchfilter folgendermaßen hinzugefügt wird: (&(userattr=username)<strong>(userfilter)</strong>)
 ldap#:#ldap_global_role#:#Globale Rolle
 ldap#:#ldap_global_role_assignment#:#Rollenzuordnung

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -5566,6 +5566,8 @@ ldap#:#ldap_deleted_rule#:#Deleted selected role assignments.
 ldap#:#ldap_dn_info#:#Enter the distinguished name of the LDAP group.
 ldap#:#ldap_edit_role_ass_rule#:#Edit Role Assignment Rule
 ldap#:#ldap_err_missing_plugin_id#:#Please enter a valid plugin id.
+ldap#:#ldap_escapedn#:#Escape DN
+ldap#:#ldap_escapedn_info#:#Specifiy if speical characters in the Distinguished Name must be escaped for the LDPA query or not.
 ldap#:#ldap_filter_info#:#Filter that will be added to the search filter this way: (&(userattr=username)<strong>(userfilter)</strong>).
 ldap#:#ldap_global_role_assignment#:#ILIAS-Role Assignment
 ldap#:#ldap_global_role_info#:#Please choose an ILIAS Role new users will be assigned to. <span class="asterisk">*</span> The role selection is <b>required</b> in case you chose a type of synchronisation.


### PR DESCRIPTION
This patch implements an option to escape the User DN for use inside LDAP queries/filter for Active Directory Compability. The current implementation breaks with Active Directory if the user DN is of the format "Lastname, Firstname".