### PR TITLE
Checks for existence of $tree in container in the initialisation

### DIFF
--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -878,7 +878,7 @@ class ilInitialisation
         } else {
             self::initGlobal('lng', ilLanguage::getFallbackInstance());
         }
-        if (is_object($rbacsystem)) {
+        if (is_object($rbacsystem) && $DIC->offsetExists('tree')) {
             $rbacsystem->initMemberView();
         }
     }


### PR DESCRIPTION
Hello!

This PR is not fixing any bug in the ILIAS core but makes the initialization process more stable if it is called from outside.

@iszmais explained some details here https://mantis.ilias.de/view.php?id=27760 its not easy to replicate because it needs a complicated setup to get it working.

I could imagine that the people who found the bug (#2458) merge worthy are also interested in this PR.

