### PR TITLE
Optimize filtering of test participants info

### DIFF
--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -11204,8 +11204,11 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         global $ilDB;
 
         $times = array();
-        $result = $ilDB->query("SELECT tst_times.active_fi, tst_times.started FROM tst_times, tst_active WHERE tst_times.active_fi = tst_active.active_id ORDER BY tst_times.tstamp DESC");
-        while ($row = $ilDB->fetchAssoc($result)) {
+        $result = $ilDB->query("SELECT tst_times.active_fi, tst_times.started FROM tst_times, tst_active WHERE tst_times.active_fi = tst_active.active_id AND tst_active.test_fi = %s ORDER BY tst_times.tstamp DESC",
+            array('integer'),
+            array($this->getTestId())
+        );
+	while ($row = $ilDB->fetchAssoc($result)) {
             $times[$row['active_fi']] = $row['started'];
         }
         return $times;


### PR DESCRIPTION
 **Description of the problem**

``getStartingTimeOfParticipants()`` method retrieves a full join, with no filtering for current test, of two massive data tables in big installations: tst_times and tst_active. However, ``getTimeExtensionsOfParticipants()`` method does a similar operations filtering for current test only as expected. 

**Problem observed**

Slow query when using option: Test-> Participants > extra time on a big installation.

```
 #Query_time: 19.270230  Lock_time: 0.000084 Rows_sent: 7665070  Rows_examined: 23243108
 SET timestamp=1589538109;
 SELECT tst_times.active_fi, tst_times.started FROM tst_times, tst_active WHERE tst_times.active_fi = tst_active.active_id ORDER BY tst_times.tstamp DESC
```

**Solution proposed**

Filtering query for active test only: tst_active.active_id, as in ``getTimeExtensionsOfParticipants()``

**Patch for same problem in version 5.4**

```
--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -11526,7 +11526,11 @@
         $ilDB = $DIC['ilDB'];
 
         $times = array();
-        $result = $ilDB->query("SELECT tst_times.active_fi, tst_times.started FROM tst_times, tst_active WHERE tst_times.active_fi = tst_active.active_id ORDER BY tst_times.tstamp DESC");
+        $result = $ilDB->queryF(
+                "SELECT tst_times.active_fi, tst_times.started FROM tst_times, tst_active WHERE tst_times.active_fi = tst_active.active_id AND tst_active.test_fi = %s ORDER BY tst_times.tstamp DESC",
+                 array('integer'),
+                 array($this->getTestId())
+        );
        while ($row = $ilDB->fetchAssoc($result)) {
             $times[$row['active_fi']] = $row['started'];
         }
```