### PR TITLE
Introducing language.md

### DIFF
--- a/docs/development/language.md
+++ b/docs/development/language.md
@@ -1,26 +1,26 @@
 ILIAS Language Handling
 =======================
-ILIAS offers multi-language support for the interface of ILIAS.
+ILIAS offers multi-language support for the user interface of ILIAS.
 
 # Guidelines
 1.  All language entries are text strings and stored in language files in the 
     subdirectory `/lang`. Each language entry has the format:
 
-        `language_module_ID#:#variable_ID#:#text_content###comment`
+        language_module_ID#:#variable_ID#:#text_content###comment
 
-    The elements `language_module_ID`, `variable_ID` and `variable_ID`  are required, 
-    while `comment` is optional and can be used for additional information about an 
+    The elements `language_module_ID`, `variable_ID` and `text_content`  are REQUIRED, 
+    while `comment` is OPTIONAL and can be used for additional information about an 
     entry, e.g. „`07 02 2020 new variable`“.
     
 2. The `variable_ID` of a language entry MUST be unique within the whole language file. This avoids conflicts in the 
 presentation of language entries because the `language_module_ID` is not taken into consideration when ILIAS inserts 
-language entries into the HTML output.
+language entries into the output.
 
 3. New components MUST use the `object_ID` for the `language_module_ID` as defined in the related module.xml or 
 service.xml. The `language_module_ID` MUST also be used as a prefix for the variable names in this language module, 
 e.g.:
 
-        `frm#:#frm_new_posting#:#New Posting`
+        frm#:#frm_new_posting#:#New Posting
 
 4. Each language file contains one block with language_module_ID `common`. Entries of this block start with 
 `common#:#`. The language_module_ID `common` MUST only be used for language entries that are used by various 
@@ -30,19 +30,22 @@ request, the use of new `common` variables SHOULD be minimised.
 5. To keep the language files maintainable and facilitate translation and creation of new language versions, 
 the amount of language entries should be as low as possible. Therefore, language entries that are no longer 
 used in ILIAS due to refactorings or changes in the code MUST be removed from the English language file. 
-Whenever possible, existing language entries SHOULD be reused and probably moved to the 'common' module to 
+Whenever possible, existing language entries SHOULD be reused and probably moved to the `common` module to 
 avoid multiple entries of the same meaning.
 
 6. The English language file is the master language file. New variables MUST be added at least to this file, 
 since we synchronise the variables when preparing a new ILIAS release. If a variable exists in a file of another 
-language but not in the English one, the entry will be removed from the file.
+language but not in the English one, the entry will be removed from the file during synchronisation.
 
 # Additional Information
-Adding new entries into language files will not make them available automatically in the user interface. You need to 
-refresh the languages by executing Administration » Languages » Refresh Languages in your ILIAS installation.
+Adding new entries into language files will not make them available in the user interface automatically. You need to 
+refresh the languages by executing the `Refresh Languages` action in the global ILIAS language administration
+(`Administration » Languages`).
  
-The global language object `$lng`, an instance of class `ilLanguage`, provides methods to access these strings in the 
-language of the user currently logged in. This is done by using the functions `loadLanguageModule()` and `txt()`.
+The global language object can be retrieved from the dependency injection container by using/calling `$DIC['lng']` or
+`$DIC->language()`. This is an instance of class `ilLanguage` and provides methods to access these strings in the 
+language of the user within the current authentication process. This is done by using the functions
+ `loadLanguageModule()` and `txt()`.
 
         $lng->loadLanguageModule("frm");
         $tpl->setVariable("TEXT", $lng->txt("frm_new_posting"));    
@@ -53,8 +56,8 @@ The language handling process in ILIAS knows four distinct roles:
 * The *First language maintainer* is managing the language handling process and fixing or delegating language bugs. The
 first maintainer has to be notified about newly introduced languages and changes of the language version maintainers.
 * The *Second language maintainer* is responsible for the language component.
-* *Developers* are adding new language entries to their components, modifying them or remove them from the code.
-* *Language version maintainers* are volunteers and take care of a specific language version and translating new entries 
+* *Developers* add new language entries to their components, modify them or remove unused entries from the code.
+* *Language version maintainers* are volunteers, take care of a specific language version and translate new entries 
 to the related language.
 
 # Maintaining Languages

--- a/docs/development/language.md
+++ b/docs/development/language.md
@@ -1,0 +1,68 @@
+ILIAS Language Handling
+=======================
+ILIAS offers multi-language support for the interface of ILIAS.
+
+# Guidelines
+1.  All language entries are text strings and stored in language files in the 
+    subdirectory `/lang`. Each language entry has the format:
+
+        `language_module_ID#:#variable_ID#:#text_content###comment`
+
+    The elements `language_module_ID`, `variable_ID` and `variable_ID`  are required, 
+    while `comment` is optional and can be used for additional information about an 
+    entry, e.g. „`07 02 2020 new variable`“.
+    
+2. The `variable_ID` of a language entry MUST be unique within the whole language file. This avoids conflicts in the 
+presentation of language entries because the `language_module_ID` is not taken into consideration when ILIAS inserts 
+language entries into the HTML output.
+
+3. New components MUST use the `object_ID` for the `language_module_ID` as defined in the related module.xml or 
+service.xml. The `language_module_ID` MUST also be used as a prefix for the variable names in this language module, 
+e.g.:
+
+        `frm#:#frm_new_posting#:#New Posting`
+
+4. Each language file contains one block with language_module_ID `common`. Entries of this block start with 
+`common#:#`. The language_module_ID `common` MUST only be used for language entries that are used by various 
+components and in combined contexts. Because this block is always read from the database into memory for each 
+request, the use of new `common` variables SHOULD be minimised.
+ 
+5. To keep the language files maintainable and facilitate translation and creation of new language versions, 
+the amount of language entries should be as low as possible. Therefore, language entries that are no longer 
+used in ILIAS due to refactorings or changes in the code MUST be removed from the English language file. 
+Whenever possible, existing language entries SHOULD be reused and probably moved to the 'common' module to 
+avoid multiple entries of the same meaning.
+
+6. The English language file is the master language file. New variables MUST be added at least to this file, 
+since we synchronise the variables when preparing a new ILIAS release. If a variable exists in a file of another 
+language but not in the English one, the entry will be removed from the file.
+
+# Additional Information
+Adding new entries into language files will not make them available automatically in the user interface. You need to 
+refresh the languages by executing Administration » Languages » Refresh Languages in your ILIAS installation.
+ 
+The global language object `$lng`, an instance of class `ilLanguage`, provides methods to access these strings in the 
+language of the user currently logged in. This is done by using the functions `loadLanguageModule()` and `txt()`.
+
+        $lng->loadLanguageModule("frm");
+        $tpl->setVariable("TEXT", $lng->txt("frm_new_posting"));    
+
+# Roles
+The language handling process in ILIAS knows four distinct roles:
+
+* The *First language maintainer* is managing the language handling process and fixing or delegating language bugs. The
+first maintainer has to be notified about newly introduced languages and changes of the language version maintainers.
+* The *Second language maintainer* is responsible for the language component.
+* *Developers* are adding new language entries to their components, modifying them or remove them from the code.
+* *Language version maintainers* are volunteers and take care of a specific language version and translating new entries 
+to the related language.
+
+# Maintaining Languages
+The different languages supported by ILIAS are maintained by volunteers. The ILIAS society is offering language 
+maintenance installations for every version. These are clients of the regular testing installations.
+
+* http://lang54.ilias.de is the language maintenance installation for 5.4
+* http://lang6.ilias.de is the language maintenance installation for 6, a.s.o.
+
+You find more information about language maintenance in the document 
+[Language Instructions](https://docu.ilias.de/goto_docu_lm_37.html).


### PR DESCRIPTION
As requested by the Jour Fixe at April 28, Stephan Winiker and I have tried to define a guideline for an improved language handling in ILIAS. We took the opportunity and picked up the information about language handling in the Development Guide, chap. 20 (see https://docu.ilias.de/goto_docu_pg_42472_42.html), edited it and suggest now to move this important and code-relevant information from the DevGuide into the ILIAS code by introducing the following language.md to the /docs/development directory.

While some guidelines are just re-phrased compared to the DevGuide page, we also introduced two new guidelines. No. 2 shall prevent bugs like Mantis #28087 (see https://mantis.ilias.de/view.php?id=28087) and no. 5 shall prevent a useless growth of the language files.

We highly appreciate any comments on this suggestion.