### PR TITLE
Update install.md > Abandoned IE 11

### DIFF
--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -117,7 +117,7 @@ Please note that different configurations SHOULD be possible, but it might be ha
 ### Client
 
   * Desktop: Windows 7+, MacOS X 10.7+, Linux
-  * Web Browser: IE11+, Microsoft Edge, Firefox 14+, Chrome 18+, Safari 7+
+  * Web Browser: Microsoft Edge, Firefox 14+, Chrome 18+, Safari 7+
 
 <a name="database-recommendations"></a>
 ## Database Recommendations


### PR DESCRIPTION
IE11 support has been abandoned according to the Feature Wiki https://docu.ilias.de/goto_docu_wiki_wpage_5457_1357.html