### PR TITLE
UI: mark error in group in i18n (#28352)

### DIFF
--- a/Modules/IndividualAssessment/test/ilIndividualAssessmentSettingsTest.php
+++ b/Modules/IndividualAssessment/test/ilIndividualAssessmentSettingsTest.php
@@ -51,7 +51,8 @@ class ilIndividualAssessmentSettingsTest extends TestCase
         $f = new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new ILIAS\UI\Implementation\Component\SignalGenerator(),
             $df,
-            $refinery
+            $refinery,
+            $lng
         );
 
         $obj_id = 10;

--- a/Modules/IndividualAssessment/test/ilIndividualAssessmentUserGradingTest.php
+++ b/Modules/IndividualAssessment/test/ilIndividualAssessmentUserGradingTest.php
@@ -113,7 +113,8 @@ class ilIndividualAssessmentUserGradingTest extends TestCase
         $f = new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new ILIAS\UI\Implementation\Component\SignalGenerator(),
             $df,
-            $refinery
+            $refinery,
+            $lng
         );
 
         $name = 'Hans Günther';

--- a/Modules/StudyProgramme/test/ilStudyProgrammeAssessmentSettingsTest.php
+++ b/Modules/StudyProgramme/test/ilStudyProgrammeAssessmentSettingsTest.php
@@ -106,7 +106,8 @@ class ilStudyProgrammeAssessmentSettingsTest extends TestCase
         $f = new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new ILIAS\UI\Implementation\Component\SignalGenerator(),
             $df,
-            $refinery
+            $refinery,
+            $lng
         );
 
         $obj = new ilStudyProgrammeAssessmentSettings(self::VALID_POINTS_1, self::VALID_STATUS_1);

--- a/Modules/StudyProgramme/test/ilStudyProgrammeAutoMailSettingsTest.php
+++ b/Modules/StudyProgramme/test/ilStudyProgrammeAutoMailSettingsTest.php
@@ -179,7 +179,8 @@ class ilStudyProgrammeAutoMailSettingsTest extends TestCase
         $f = new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new ILIAS\UI\Implementation\Component\SignalGenerator(),
             $df,
-            $refinery
+            $refinery,
+            $lng
         );
 
         $obj = new ilStudyProgrammeAutoMailSettings(

--- a/Modules/StudyProgramme/test/ilStudyProgrammeDeadlineSettingsTest.php
+++ b/Modules/StudyProgramme/test/ilStudyProgrammeDeadlineSettingsTest.php
@@ -74,7 +74,8 @@ class ilStudyProgrammeDeadlineSettingsTest extends TestCase
         $f = new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new ILIAS\UI\Implementation\Component\SignalGenerator(),
             $df,
-            $refinery
+            $refinery,
+            $lng
         );
 
         $obj = new ilStudyProgrammeDeadlineSettings(

--- a/Modules/StudyProgramme/test/ilStudyProgrammeTypeSettingsTest.php
+++ b/Modules/StudyProgramme/test/ilStudyProgrammeTypeSettingsTest.php
@@ -37,7 +37,8 @@ class ilStudyProgrammeTypeSettingsTest extends TestCase
         $f = new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new ILIAS\UI\Implementation\Component\SignalGenerator(),
             $df,
-            $refinery
+            $refinery,
+            $lng
         );
 
         $obj = new ilStudyProgrammeTypeSettings(self::VALID_TYPE_1);

--- a/Modules/StudyProgramme/test/ilStudyProgrammeValidityOfAchievedQualificationSettingsTest.php
+++ b/Modules/StudyProgramme/test/ilStudyProgrammeValidityOfAchievedQualificationSettingsTest.php
@@ -129,7 +129,8 @@ class ilStudyProgrammeValidityOfAchievedQualificationSettingsTest extends TestCa
         $f = new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new ILIAS\UI\Implementation\Component\SignalGenerator(),
             $df,
-            $refinery
+            $refinery,
+            $lng
         );
 
         $obj = new ilStudyProgrammeValidityOfAchievedQualificationSettings(

--- a/Modules/StudyProgramme/test/types/ilStudyProgrammeTypeInfoTest.php
+++ b/Modules/StudyProgramme/test/types/ilStudyProgrammeTypeInfoTest.php
@@ -115,7 +115,8 @@ class ilStudyProgrammeTypeInfoTest extends TestCase
         $f = new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new ILIAS\UI\Implementation\Component\SignalGenerator(),
             $df,
-            $refinery
+            $refinery,
+            $lng
         );
 
         $obj = new ilStudyProgrammeTypeInfo(

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -16174,3 +16174,4 @@ rbac#:#prgr_write#:#Einstellungen der Links zu Studienprogrammen bearbeiten
 rbac#:#rbac_create_prgr#:#Link zu Studienprogramm anlegen
 common#:#eyeopened#:#Eye Open - Click to reveal the input's contents###18 05 2020 new variable
 rbac#:#prgr#:#User can copy link to study programme###18 05 2020 new variable
+ui#:#ui_error_in_group#:#Es gibt einen Fehler in diesem Bereich.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -16174,3 +16174,4 @@ rbac#:#prgr_edit_permission#:#User can change permission settings
 rbac#:#prgr_visible#:#Links to study programmes are visible and can be used
 rbac#:#prgr_write#:#User can edit settings of links to study programmes
 rbac#:#rbac_create_prgr#:#Create link to study programme
+ui#:#ui_error_in_group#:#There is some error in this part.

--- a/src/UI/Implementation/Component/Input/Field/Duration.php
+++ b/src/UI/Implementation/Component/Input/Field/Duration.php
@@ -66,6 +66,7 @@ class Duration extends Group implements C\Input\Field\Duration, JSBindabale
     public function __construct(
         DataFactory $data_factory,
         \ILIAS\Refinery\Factory $refinery,
+        \ilLanguage $lng,
         Factory $field_factory,
         $label,
         $byline
@@ -75,7 +76,7 @@ class Duration extends Group implements C\Input\Field\Duration, JSBindabale
             $field_factory->dateTime('end')
         ];
 
-        parent::__construct($data_factory, $refinery, $inputs, $label, $byline);
+        parent::__construct($data_factory, $refinery, $lng, $inputs, $label, $byline);
 
         $this->addTransformation();
         $this->addValidation();

--- a/src/UI/Implementation/Component/Input/Field/Factory.php
+++ b/src/UI/Implementation/Component/Input/Field/Factory.php
@@ -19,24 +19,30 @@ use ILIAS\UI\Implementation\Component\SignalGeneratorInterface;
  */
 class Factory implements Field\Factory
 {
-
     /**
      * @var    Data\Factory
      */
     protected $data_factory;
+
     /**
      * @var Validation\Factory
      */
     protected $validation_factory;
+
     /**
      * @var SignalGeneratorInterface
      */
     protected $signal_generator;
+
     /**
      * @var \ILIAS\Refinery\Factory
      */
     private $refinery;
 
+    /**
+     * @var	\ilLanguage
+     */
+    protected $lng;
 
     /**
      * Factory constructor.
@@ -48,11 +54,13 @@ class Factory implements Field\Factory
     public function __construct(
         SignalGeneratorInterface $signal_generator,
         Data\Factory $data_factory,
-        \ILIAS\Refinery\Factory $refinery
+        \ILIAS\Refinery\Factory $refinery,
+        \ilLanguage $lng
     ) {
         $this->signal_generator = $signal_generator;
         $this->data_factory = $data_factory;
         $this->refinery = $refinery;
+        $this->lng = $lng;
     }
 
     /**
@@ -76,7 +84,7 @@ class Factory implements Field\Factory
      */
     public function group(array $inputs, string $label = '')
     {
-        return new Group($this->data_factory, $this->refinery, $inputs, $label, null);
+        return new Group($this->data_factory, $this->refinery, $this->lng, $inputs, $label, null);
     }
 
     /**
@@ -84,7 +92,7 @@ class Factory implements Field\Factory
      */
     public function optionalGroup(array $inputs, string $label, string $byline = null) : Field\OptionalGroup
     {
-        return new OptionalGroup($this->data_factory, $this->refinery, $inputs, $label, $byline);
+        return new OptionalGroup($this->data_factory, $this->refinery, $this->lng, $inputs, $label, $byline);
     }
 
     /**
@@ -92,7 +100,7 @@ class Factory implements Field\Factory
      */
     public function switchableGroup(array $inputs, string $label, string $byline = null) : Field\SwitchableGroup
     {
-        return new SwitchableGroup($this->data_factory, $this->refinery, $inputs, $label, $byline);
+        return new SwitchableGroup($this->data_factory, $this->refinery, $this->lng, $inputs, $label, $byline);
     }
 
     /**
@@ -100,7 +108,7 @@ class Factory implements Field\Factory
      */
     public function section(array $inputs, $label, $byline = null)
     {
-        return new Section($this->data_factory, $this->refinery, $inputs, $label, $byline);
+        return new Section($this->data_factory, $this->refinery, $this->lng, $inputs, $label, $byline);
     }
 
     /**
@@ -172,7 +180,7 @@ class Factory implements Field\Factory
      */
     public function duration($label, $byline = null)
     {
-        return new Duration($this->data_factory, $this->refinery, $this, $label, $byline);
+        return new Duration($this->data_factory, $this->refinery, $this->lng, $this, $label, $byline);
     }
 
 

--- a/src/UI/Implementation/Component/Input/Field/Group.php
+++ b/src/UI/Implementation/Component/Input/Field/Group.php
@@ -35,15 +35,17 @@ class Group extends Input implements C\Input\Field\Group
     /**
      * Group constructor.
      *
-     * @param DataFactory           $data_factory
+     * @param DataFactory             $data_factory
      * @param \ILIAS\Refinery\Factory $refinery
-     * @param InputInternal[]       $inputs
-     * @param                       $label
-     * @param                       $byline
+     * @param \ilLanguage             $lng
+     * @param InputInternal[]         $inputs
+     * @param                         $label
+     * @param                         $byline
      */
     public function __construct(
         DataFactory $data_factory,
         \ILIAS\Refinery\Factory $refinery,
+        \ilLanguage $lng,
         array $inputs,
         string $label,
         string $byline = null
@@ -51,6 +53,7 @@ class Group extends Input implements C\Input\Field\Group
         parent::__construct($data_factory, $refinery, $label, $byline);
         $this->checkArgListElements("inputs", $inputs, InputInternal::class);
         $this->inputs = $inputs;
+        $this->lng = $lng;
     }
 
     public function withDisabled($is_disabled)
@@ -168,8 +171,7 @@ class Group extends Input implements C\Input\Field\Group
 
         $clone->inputs = $inputs;
         if ($error) {
-            // TODO: use lng here
-            $clone->content = $clone->data_factory->error("error_in_group");
+            $clone->content = $clone->data_factory->error($this->lng->txt("ui_error_in_group"));
         } else {
             $clone->content = $clone->applyOperationsTo($contents);
         }

--- a/src/UI/Implementation/Component/Input/Field/SwitchableGroup.php
+++ b/src/UI/Implementation/Component/Input/Field/SwitchableGroup.php
@@ -25,21 +25,23 @@ class SwitchableGroup extends Group implements Field\SwitchableGroup
     /**
      * Only adds a check to the original group-constructor.
      *
-     * @param DataFactory           $data_factory
+     * @param DataFactory             $data_factory
      * @param \ILIAS\Refinery\Factory $refinery
-     * @param InputInternal[]       $inputs
-     * @param                       $label
-     * @param                       $byline
+     * @param \ilLanguage             $lng
+     * @param InputInternal[]         $inputs
+     * @param                         $label
+     * @param                         $byline
      */
     public function __construct(
         DataFactory $data_factory,
         \ILIAS\Refinery\Factory $refinery,
+        \ilLanguage $lng,
         array $inputs,
         string $label,
         string $byline = null
     ) {
         $this->checkArgListElements("inputs", $inputs, Group::class);
-        parent::__construct($data_factory, $refinery, $inputs, $label, $byline);
+        parent::__construct($data_factory, $refinery, $lng, $inputs, $label, $byline);
     }
 
     /**
@@ -116,8 +118,7 @@ class SwitchableGroup extends Group implements Field\SwitchableGroup
         }
 
         if ($clone->inputs[$key]->getContent()->isError()) {
-            // TODO: use lng here
-            $clone->content = $clone->data_factory->error("error_in_group");
+            $clone->content = $clone->data_factory->error($this->lng->txt("ui_error_in_group"));
         } else {
             $clone->content = $this->applyOperationsTo($clone->getValue());
             if ($clone->content->isError()) {

--- a/tests/UI/Component/Input/Container/Filter/FilterFactoryTest.php
+++ b/tests/UI/Component/Input/Container/Filter/FilterFactoryTest.php
@@ -26,7 +26,8 @@ class FilterFactoryTest extends AbstractFactoryTest
             new \ILIAS\UI\Implementation\Component\Input\Field\Factory(
                 new SignalGenerator(),
                 $df,
-                new ILIAS\Refinery\Factory($df, $language)
+                new ILIAS\Refinery\Factory($df, $language),
+                $language
             )
         );
     }

--- a/tests/UI/Component/Input/Container/Filter/FilterTest.php
+++ b/tests/UI/Component/Input/Container/Filter/FilterTest.php
@@ -88,7 +88,8 @@ class FilterTest extends ILIAS_UI_TestBase
         return new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new SignalGenerator(),
             $df,
-            new ILIAS\Refinery\Factory($df, $language)
+            new ILIAS\Refinery\Factory($df, $language),
+            $language
         );
     }
 

--- a/tests/UI/Component/Input/Container/Filter/StandardFilterTest.php
+++ b/tests/UI/Component/Input/Container/Filter/StandardFilterTest.php
@@ -76,7 +76,8 @@ class StandardFilterTest extends ILIAS_UI_TestBase
         return new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new SignalGenerator(),
             $df,
-            new ILIAS\Refinery\Factory($df, $language)
+            new ILIAS\Refinery\Factory($df, $language),
+            $language
         );
     }
 

--- a/tests/UI/Component/Input/Container/Form/FormFactoryTest.php
+++ b/tests/UI/Component/Input/Container/Form/FormFactoryTest.php
@@ -25,7 +25,8 @@ class FormFactoryTest extends AbstractFactoryTest
             new \ILIAS\UI\Implementation\Component\Input\Field\Factory(
                 new SignalGenerator(),
                 $df,
-                new \ILIAS\Refinery\Factory($df, $language)
+                new \ILIAS\Refinery\Factory($df, $language),
+                $language
             )
         );
     }

--- a/tests/UI/Component/Input/Container/Form/FormTest.php
+++ b/tests/UI/Component/Input/Container/Form/FormTest.php
@@ -79,11 +79,12 @@ class FormTest extends ILIAS_UI_TestBase
     protected function buildInputFactory()
     {
         $df = new Data\Factory();
-        $language = $this->createMock(\ilLanguage::class);
+        $this->language = $this->createMock(\ilLanguage::class);
         return new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new SignalGenerator(),
             $df,
-            new \ILIAS\Refinery\Factory($df, $language)
+            new \ILIAS\Refinery\Factory($df, $this->language),
+            $this->language
         );
     }
 
@@ -343,6 +344,13 @@ class FormTest extends ILIAS_UI_TestBase
 
         $form = new ConcreteForm($this->buildInputFactory(), []);
         $form->setInputs(["foo" => $input_1, "bar" => $input_2]);
+
+        $i18n = "THERE IS SOME ERROR IN THIS GROUP";
+        $this->language
+            ->expects($this->once())
+            ->method("txt")
+            ->with("ui_error_in_group")
+            ->willReturn($i18n);
 
         //Todo: This is not good, this should throw an error or similar.
         $form = $form->withRequest($request);

--- a/tests/UI/Component/Input/Container/Form/StandardFormTest.php
+++ b/tests/UI/Component/Input/Container/Form/StandardFormTest.php
@@ -44,7 +44,8 @@ class StandardFormTest extends ILIAS_UI_TestBase
         return new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new SignalGenerator(),
             $df,
-            new \ILIAS\Refinery\Factory($df, $language)
+            new \ILIAS\Refinery\Factory($df, $language),
+            $language
         );
     }
 

--- a/tests/UI/Component/Input/Field/CheckboxInputTest.php
+++ b/tests/UI/Component/Input/Field/CheckboxInputTest.php
@@ -28,7 +28,8 @@ class CheckboxInputTest extends ILIAS_UI_TestBase
         return new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new SignalGenerator(),
             $df,
-            new \ILIAS\Refinery\Factory($df, $language)
+            new \ILIAS\Refinery\Factory($df, $language),
+            $language
         );
     }
 

--- a/tests/UI/Component/Input/Field/DateTimeInputTest.php
+++ b/tests/UI/Component/Input/Field/DateTimeInputTest.php
@@ -30,7 +30,8 @@ class DateTimeInputTest extends ILIAS_UI_TestBase
         return new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new SignalGenerator(),
             $this->data_factory,
-            new \ILIAS\Refinery\Factory($df, $language)
+            new \ILIAS\Refinery\Factory($df, $language),
+            $language
         );
     }
  

--- a/tests/UI/Component/Input/Field/DurationInputTest.php
+++ b/tests/UI/Component/Input/Field/DurationInputTest.php
@@ -22,10 +22,17 @@ class DurationInputTest extends ILIAS_UI_TestBase
         $this->factory = $this->buildFactory();
     }
 
+    protected function buildLanguage()
+    {
+        if (!isset($this->lng)) {
+            $this->lng = $this->createMock(\ilLanguage::class);
+        }
+        return $this->lng;
+    }
+
     protected function buildRefinery()
     {
-        $language = $this->createMock(\ilLanguage::class);
-        return new \ILIAS\Refinery\Factory($this->data_factory, $language);
+        return new \ILIAS\Refinery\Factory($this->data_factory, $this->buildLanguage());
     }
 
     protected function buildFactory()
@@ -33,7 +40,8 @@ class DurationInputTest extends ILIAS_UI_TestBase
         return new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new SignalGenerator(),
             $this->data_factory,
-            $this->buildRefinery()
+            $this->buildRefinery(),
+            $this->buildLanguage()
         );
     }
     public function getUIFactory()

--- a/tests/UI/Component/Input/Field/FieldFactoryTest.php
+++ b/tests/UI/Component/Input/Field/FieldFactoryTest.php
@@ -54,7 +54,8 @@ class FieldFactoryTest extends AbstractFactoryTest
         return new \ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new SignalGenerator(),
             $df,
-            new \ILIAS\Refinery\Factory($df, $language)
+            new \ILIAS\Refinery\Factory($df, $language),
+            $language
         );
     }
 

--- a/tests/UI/Component/Input/Field/FileInputTest.php
+++ b/tests/UI/Component/Input/Field/FileInputTest.php
@@ -50,7 +50,8 @@ class FileInputTest extends ILIAS_UI_TestBase
         return new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new SignalGenerator(),
             $df,
-            new ILIAS\Refinery\Factory($df, $language)
+            new ILIAS\Refinery\Factory($df, $language),
+            $language
         );
     }
 
@@ -240,21 +241,21 @@ class FileInputTest extends ILIAS_UI_TestBase
                 new LoaderResourceRegistryWrapper(
                     $resource_registry,
                     new FSLoader(
-                    new DefaultRendererFactory(
+                        new DefaultRendererFactory(
                         $ui_factory,
                         $tpl_factory,
                         $lng,
                         $js_binding,
                         $refinery
                     ),
-                    new GlyphRendererFactory(
+                        new GlyphRendererFactory(
                         $ui_factory,
                         $tpl_factory,
                         $lng,
                         $js_binding,
                         $refinery
                     ),
-                    new FieldRendererFactory(
+                        new FieldRendererFactory(
                         $ui_factory,
                         $tpl_factory,
                         $lng,

--- a/tests/UI/Component/Input/Field/MultiSelectInputTest.php
+++ b/tests/UI/Component/Input/Field/MultiSelectInputTest.php
@@ -26,7 +26,8 @@ class MultiSelectInputTest extends ILIAS_UI_TestBase
         return new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new SignalGenerator(),
             $df,
-            new \ILIAS\Refinery\Factory($df, $language)
+            new \ILIAS\Refinery\Factory($df, $language),
+            $language
         );
     }
 

--- a/tests/UI/Component/Input/Field/NumericInputTest.php
+++ b/tests/UI/Component/Input/Field/NumericInputTest.php
@@ -26,7 +26,8 @@ class NumericInputTest extends ILIAS_UI_TestBase
         return new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new SignalGenerator(),
             $df,
-            new \ILIAS\Refinery\Factory($df, $language)
+            new \ILIAS\Refinery\Factory($df, $language),
+            $language
         );
     }
 

--- a/tests/UI/Component/Input/Field/OptionalGroupInputTest.php
+++ b/tests/UI/Component/Input/Field/OptionalGroupInputTest.php
@@ -30,7 +30,8 @@ class OptionalGroupInputTest extends ILIAS_UI_TestBase
         $this->child1 = $this->createMock(Input11::class);
         $this->child2 = $this->createMock(Input12::class);
         $this->data_factory = new Data\Factory();
-        $this->refinery = new ILIAS\Refinery\Factory($this->data_factory, $this->createMock(\ilLanguage::class));
+        $this->language = $this->createMock(\ilLanguage::class);
+        $this->refinery = new ILIAS\Refinery\Factory($this->data_factory, $this->language);
 
         $this->child1
             ->method("withNameFrom")
@@ -42,6 +43,7 @@ class OptionalGroupInputTest extends ILIAS_UI_TestBase
         $this->optional_group = (new OptionalGroup(
             $this->data_factory,
             $this->refinery,
+            $this->language,
             [$this->child1, $this->child2],
             "LABEL",
             "BYLINE"
@@ -100,6 +102,7 @@ class OptionalGroupInputTest extends ILIAS_UI_TestBase
         $this->group = new OptionalGroup(
             $this->data_factory,
             $this->refinery,
+            $this->language,
             ["foo", "bar"],
             "LABEL",
             "BYLINE"
@@ -276,6 +279,13 @@ class OptionalGroupInputTest extends ILIAS_UI_TestBase
             ->expects($this->once())
             ->method("getContent")
             ->willReturn($this->data_factory->ok("two"));
+
+        $i18n = "THERE IS SOME ERROR IN THIS GROUP";
+        $this->language
+            ->expects($this->once())
+            ->method("txt")
+            ->with("ui_error_in_group")
+            ->willReturn($i18n);
 
         $new_group = $this->optional_group
             ->withAdditionalTransformation($this->refinery->custom()->transformation(function ($v) {

--- a/tests/UI/Component/Input/Field/PasswordInputTest.php
+++ b/tests/UI/Component/Input/Field/PasswordInputTest.php
@@ -39,7 +39,8 @@ class PasswordInputTest extends ILIAS_UI_TestBase
         return new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new SignalGenerator(),
             $df,
-            new \ILIAS\Refinery\Factory($df, $language)
+            new \ILIAS\Refinery\Factory($df, $language),
+            $language
         );
     }
 

--- a/tests/UI/Component/Input/Field/RadioInputTest.php
+++ b/tests/UI/Component/Input/Field/RadioInputTest.php
@@ -25,7 +25,8 @@ class RadioInputTest extends ILIAS_UI_TestBase
         return new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new SignalGenerator(),
             $df,
-            new \ILIAS\Refinery\Factory($df, $language)
+            new \ILIAS\Refinery\Factory($df, $language),
+            $language
         );
     }
 

--- a/tests/UI/Component/Input/Field/SwitchableGroupInputTest.php
+++ b/tests/UI/Component/Input/Field/SwitchableGroupInputTest.php
@@ -33,6 +33,7 @@ class SwitchableGroupInputTest extends ILIAS_UI_TestBase
         $this->child2 = $this->createMock(Group2::class);
         $this->data_factory = new Data\Factory();
         $this->refinery = new ILIAS\Refinery\Factory($this->data_factory, $this->createMock(\ilLanguage::class));
+        $this->lng = $this->createMock(\ilLanguage::class);
 
         $this->child1
             ->method("withNameFrom")
@@ -44,6 +45,7 @@ class SwitchableGroupInputTest extends ILIAS_UI_TestBase
         $this->switchable_group = (new SwitchableGroup(
             $this->data_factory,
             $this->refinery,
+            $this->lng,
             ["child1" => $this->child1, "child2" => $this->child2],
             "LABEL",
             "BYLINE"
@@ -60,7 +62,8 @@ class SwitchableGroupInputTest extends ILIAS_UI_TestBase
         return new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new SignalGenerator(),
             $this->data_factory,
-            $this->refinery
+            $this->refinery,
+            $this->lng
         );
     }
 
@@ -111,6 +114,7 @@ class SwitchableGroupInputTest extends ILIAS_UI_TestBase
         $this->group = new SwitchableGroup(
             $this->data_factory,
             $this->refinery,
+            $this->lng,
             [$this->createMock(Input::class)],
             "LABEL",
             "BYLINE"
@@ -262,6 +266,13 @@ class SwitchableGroupInputTest extends ILIAS_UI_TestBase
             ->method("getContent")
             ->willReturn($this->data_factory->error(""));
 
+        $i18n = "THERE IS SOME ERROR IN THIS GROUP";
+        $this->lng
+            ->expects($this->once())
+            ->method("txt")
+            ->with("ui_error_in_group")
+            ->willReturn($i18n);
+
         $new_group = $this->switchable_group
             ->withAdditionalTransformation($this->refinery->custom()->transformation(function ($v) {
                 $this->assertFalse(true, "This should not happen.");
@@ -273,6 +284,40 @@ class SwitchableGroupInputTest extends ILIAS_UI_TestBase
         $this->assertNotSame($this->switchable_group, $new_group);
         $this->assertTrue($new_group->getContent()->isError());
     }
+
+    public function testErrorIsI18NOnError()
+    {
+        $this->assertNotSame($this->child1, $this->child2);
+
+        $input_data = $this->createMock(InputData::class);
+
+        $input_data
+            ->expects($this->once())
+            ->method("get")
+            ->with("name0")
+            ->willReturn("child2");
+
+        $this->child2
+            ->method("withInput")
+            ->willReturn($this->child2);
+        $this->child2
+            ->method("getContent")
+            ->willReturn($this->data_factory->error(""));
+
+        $i18n = "THERE IS SOME ERROR IN THIS GROUP";
+        $this->lng
+            ->expects($this->once())
+            ->method("txt")
+            ->with("ui_error_in_group")
+            ->willReturn($i18n);
+
+        $switchable_group = $this->switchable_group
+            ->withInput($input_data);
+
+        $this->assertTrue($switchable_group->getContent()->isError());
+        $this->assertEquals($i18n, $switchable_group->getContent()->error());
+    }
+
 
     public function testWithInputDoesNotAcceptUnknownKeys()
     {

--- a/tests/UI/Component/Input/Field/TagInputTest.php
+++ b/tests/UI/Component/Input/Field/TagInputTest.php
@@ -37,7 +37,8 @@ class TagInputTest extends ILIAS_UI_TestBase
         return new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new SignalGenerator(),
             $df,
-            new \ILIAS\Refinery\Factory($df, $language)
+            new \ILIAS\Refinery\Factory($df, $language),
+            $language
         );
     }
 

--- a/tests/UI/Component/Input/Field/TextInputTest.php
+++ b/tests/UI/Component/Input/Field/TextInputTest.php
@@ -26,7 +26,8 @@ class TextInputTest extends ILIAS_UI_TestBase
         return new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new SignalGenerator(),
             $df,
-            new ILIAS\Refinery\Factory($df, $language)
+            new ILIAS\Refinery\Factory($df, $language),
+            $language
         );
     }
 

--- a/tests/UI/Component/Input/Field/TextareaTest.php
+++ b/tests/UI/Component/Input/Field/TextareaTest.php
@@ -32,7 +32,8 @@ class TextareaTest extends ILIAS_UI_TestBase
         return new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new SignalGenerator(),
             $df,
-            new ILIAS\Refinery\Factory($df, $language)
+            new ILIAS\Refinery\Factory($df, $language),
+            $language
         );
     }
 


### PR DESCRIPTION
This fixes [#28352](https://mantis.ilias.de/view.php?id=28352). I needed to introduce a new dependency on `\ilLanguage` to `UI\Implementation\Component\Input\Field`, this in turn led to some busywork in various tests. The actual change is also covered by tests.

We definitely should look how we could improve the tests at some point, I found a lot of duplicated code to build UI factories. Maybe I'll have someone looking into there sometime soon, but if anyone has some spare time I'll won't be unhappy either.