### PR TITLE
Fix/6/plugin input renders

### DIFF
--- a/src/UI/Implementation/Render/FSLoader.php
+++ b/src/UI/Implementation/Render/FSLoader.php
@@ -61,7 +61,7 @@ class FSLoader implements Loader
      */
     public function getRendererFactoryFor(Component $component)
     {
-        if (strpos(get_class($component) ,"ILIAS\\") === 0) { // Do not break plugin renderers
+        if (strpos(get_class($component), "ILIAS\\") === 0) { // Do not break plugin renderers
             if ($component instanceof \ILIAS\UI\Implementation\Component\Symbol\Glyph\Glyph) {
                 return $this->glyph_renderer_factory;
             }

--- a/src/UI/Implementation/Render/FSLoader.php
+++ b/src/UI/Implementation/Render/FSLoader.php
@@ -61,11 +61,13 @@ class FSLoader implements Loader
      */
     public function getRendererFactoryFor(Component $component)
     {
-        if ($component instanceof \ILIAS\UI\Implementation\Component\Symbol\Glyph\Glyph) {
-            return $this->glyph_renderer_factory;
-        }
-        if ($component instanceof \ILIAS\UI\Implementation\Component\Input\Field\Input) {
-            return $this->field_renderer_factory;
+        if (strpos(get_class($component) ,"ILIAS\\") === 0) { // Do not break plugin renderers
+            if ($component instanceof \ILIAS\UI\Implementation\Component\Symbol\Glyph\Glyph) {
+                return $this->glyph_renderer_factory;
+            }
+            if ($component instanceof \ILIAS\UI\Implementation\Component\Input\Field\Input) {
+                return $this->field_renderer_factory;
+            }
         }
         return $this->default_renderer_factory;
     }


### PR DESCRIPTION
Hello everybody

due to the implementation of the RendererFactory in the inputs it is unfortunately no longer possible to use own renderers or components with their renderers in plugins. The PR suggests a variant, but this would only work if you use your own namespaces in plugins. Maybe there is a more general way (also generally for the selection of renderers per component)