### PR TITLE
Fix syntax error in class.ilObjTest.php

### DIFF
--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -11204,7 +11204,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         global $ilDB;
 
         $times = array();
-        $result = $ilDB->query("SELECT tst_times.active_fi, tst_times.started FROM tst_times, tst_active WHERE tst_times.active_fi = tst_active.active_id AND tst_active.test_fi = %s ORDER BY tst_times.tstamp DESC",
+        $result = $ilDB->queryF("SELECT tst_times.active_fi, tst_times.started FROM tst_times, tst_active WHERE tst_times.active_fi = tst_active.active_id AND tst_active.test_fi = %s ORDER BY tst_times.tstamp DESC",
             array('integer'),
             array($this->getTestId())
         );


### PR DESCRIPTION
Fixes syntax error introduced in #2711

Query function does not admit parametrized values, so queryF must be used. This was due to a typo when preparing pull request. Patch must be applied on branch 5.4 too. Sorry for the confusion