### PR TITLE
Setup: Fix usage of undefined variable in exception message

### DIFF
--- a/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
+++ b/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
@@ -98,7 +98,7 @@ class ilCtrlStructureReader
     {
         // check wether $a_cdir is a directory
         if (!@is_dir($a_cdir)) {
-            throw new \LogicException("'$c_dir' is not a directory.");
+            throw new \LogicException("'$a_cdir' is not a directory.");
         }
 
         foreach ($this->getFilesIn($a_cdir) as list($file, $full_path)) {


### PR DESCRIPTION
Mantis Issue: https://mantis.ilias.de/view.php?id=28382