### PR TITLE
Docs: Add PHP 7.4 as supported version

### DIFF
--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -105,7 +105,7 @@ Please note that different configurations SHOULD be possible, but it might be ha
   * Server OS: Linux
   * Web Server: Apache 2.4 (mod_php, php-fpm)
   * Databases: MySQL/MariaDB 5.6 and 5.7 and Galera (experimental), PostgreSQL 9.x
-  * PHP: Version 7.2 and 7.3 are supported
+  * PHP: Version 7.2, 7.3 and 7.4 are supported
   * zip: 3.0+
   * unzip: 6.0+
   * Imagemagick: 6.8.9-9+
@@ -595,7 +595,7 @@ When you upgrade from rather old versions please make sure that the dependencies
 
 | ILIAS Version   | PHP Version                           |
 |-----------------|---------------------------------------|
-| 6.0.x           | 7.2.x, 7.3.x                          |
+| 6.0.x           | 7.2.x, 7.3.x, 7.4                     |
 | 5.4.x           | 7.0.x, 7.1.x, 7.2.x, 7.3.x            |
 | 5.3.x           | 5.6.x, 7.0.x, 7.1.x                   |
 | 5.2.x           | 5.5.x - 5.6.x, 7.0.x, 7.1.x           |


### PR DESCRIPTION
This PR updates our installation documentation in regards of the max. supported PHP version.

As decided in our Technical Board meeting we'd like to support PHP 7.4 in ILIAS 6. There is already a [PHP 7.4 TravisCI build](https://github.com/ILIAS-eLearning/ILIAS/blob/c6f6ffe7b3ccb00056690ced2da1be71b66a35ec/.travis.yml#L6) so all of our unit tests pass the PHP 7.4 execution.
