### PR TITLE
Test Additional Time, fix for: 28403

### DIFF
--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -11520,6 +11520,12 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         return (strlen($this->activation_ending_time)) ? $this->activation_ending_time : null;
     }
 
+    /**
+     * Note, this function should only be used if absolutely necessary, since it perform joins on tables that
+     * tend to grow huge and returns vast amount of data. If possible, use getStartingTimeOfUser($active_id) instead
+     *
+     * @return array
+     */
     public function getStartingTimeOfParticipants()
     {
         global $DIC;

--- a/Modules/Test/classes/class.ilTestParticipantsTimeExtensionGUI.php
+++ b/Modules/Test/classes/class.ilTestParticipantsTimeExtensionGUI.php
@@ -116,7 +116,7 @@ class ilTestParticipantsTimeExtensionGUI
             $time = $this->getTestObj()->getStartingTimeOfUser($participant->getActiveId());
             if ($time) {
                 $started = $DIC->language()->txt('tst_started') . ': ' . ilDatePresentation::formatDate(
-                    new ilDateTime($time, IL_CAL_DATETIME)
+                    new ilDateTime($time, IL_CAL_UNIX)
                 );
                 
                 $tblRow['started'] = $started;
@@ -197,7 +197,7 @@ class ilTestParticipantsTimeExtensionGUI
 
             $time = $this->getTestObj()->getStartingTimeOfUser($participant->getActiveId());
             if ($time) {
-                $started = ", " . $DIC->language()->txt('tst_started') . ': ' . ilDatePresentation::formatDate(new ilDateTime($time, IL_CAL_DATETIME));
+                $started = ", " . $DIC->language()->txt('tst_started') . ': ' . ilDatePresentation::formatDate(new ilDateTime($time, IL_CAL_UNIX));
             }
             
             if ($addons[$participant->getActiveId()] > 0) {

--- a/Modules/Test/classes/class.ilTestParticipantsTimeExtensionGUI.php
+++ b/Modules/Test/classes/class.ilTestParticipantsTimeExtensionGUI.php
@@ -106,17 +106,17 @@ class ilTestParticipantsTimeExtensionGUI
         $participantList = $participantList->getAccessFilteredList(
             ilTestParticipantAccessFilter::getManageParticipantsUserFilter($this->getTestObj()->getRefId())
         );
-        
-        $times = $this->getTestObj()->getStartingTimeOfParticipants();
+
         $addons = $this->getTestObj()->getTimeExtensionsOfParticipants();
         
         $tableData = array();
         foreach ($participantList as $participant) {
             $tblRow = array();
-            
-            if ($times[$participant->getActiveId()]) {
+
+            $time = $this->getTestObj()->getStartingTimeOfUser($participant->getActiveId());
+            if ($time) {
                 $started = $DIC->language()->txt('tst_started') . ': ' . ilDatePresentation::formatDate(
-                    new ilDateTime($times[$participant->getActiveId()], IL_CAL_DATETIME)
+                    new ilDateTime($time, IL_CAL_DATETIME)
                 );
                 
                 $tblRow['started'] = $started;
@@ -177,7 +177,6 @@ class ilTestParticipantsTimeExtensionGUI
             ilTestParticipantAccessFilter::getManageParticipantsUserFilter($this->getTestObj()->getRefId())
         );
         
-        $times = $this->getTestObj()->getStartingTimeOfParticipants();
         $addons = $this->getTestObj()->getTimeExtensionsOfParticipants();
         
         $participantslist = new ilSelectInputGUI($DIC->language()->txt('participants'), "participant");
@@ -195,9 +194,10 @@ class ilTestParticipantsTimeExtensionGUI
             } else {
                 $name = $participant->getLastname() . ', ' . $participant->getFirstname();
             }
-            
-            if ($times[$participant->getActiveId()]) {
-                $started = ", " . $DIC->language()->txt('tst_started') . ': ' . ilDatePresentation::formatDate(new ilDateTime($times[$participant->getActiveId()], IL_CAL_DATETIME));
+
+            $time = $this->getTestObj()->getStartingTimeOfUser($participant->getActiveId());
+            if ($time) {
+                $started = ", " . $DIC->language()->txt('tst_started') . ': ' . ilDatePresentation::formatDate(new ilDateTime($time, IL_CAL_DATETIME));
             }
             
             if ($addons[$participant->getActiveId()] > 0) {


### PR DESCRIPTION
Loading time improved from 45s, to <1s for the given screens in Dashboard of the feature. See ticket https://mantis.ilias.de/view.php?id=28403 for more information. Plz, make a special double check on the Formatting time lines before merging. Ill tend to mix things up when it comes to timing:

```
ilDatePresentation::formatDate(  new ilDateTime($time, IL_CAL_UNIX) )
```