### PR TITLE
Docs: Add PHP 7.4 as supported version for ILIAS 6

### DIFF
--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -596,7 +596,7 @@ When you upgrade from rather old versions please make sure that the dependencies
 | ILIAS Version   | PHP Version                           |
 |-----------------|---------------------------------------|
 | 7.x             | 7.3.x, 7.4.x                          |
-| 6.x             | 7.2.x, 7.3.x                          |
+| 6.x             | 7.2.x, 7.3.x, 7.4.x                   |
 | 5.4.x           | 7.0.x, 7.1.x, 7.2.x, 7.3.x            |
 | 5.3.x           | 5.6.x, 7.0.x, 7.1.x                   |
 | 5.2.x           | 5.5.x - 5.6.x, 7.0.x, 7.1.x           |


### PR DESCRIPTION
Similar to #2725 