### PR TITLE
Membership: Performance on Notification Settings

### DIFF
--- a/Services/Membership/classes/class.ilMembershipNotifications.php
+++ b/Services/Membership/classes/class.ilMembershipNotifications.php
@@ -218,7 +218,7 @@ class ilMembershipNotifications
     {
         global $DIC;
 
-        $ilDB = $DIC['ilDB'];
+        $ilDB = $DIC->database();
         
         $users = $all = array();
         
@@ -235,7 +235,7 @@ class ilMembershipNotifications
             case self::MODE_SELF:
                 $set = $ilDB->query("SELECT usr_id" .
                     " FROM usr_pref" .
-                    " WHERE " . $ilDB->like("keyword", "text", "grpcrs_ntf_" . $this->ref_id) .
+                    " WHERE keyword = " . $ilDB->quote("grpcrs_ntf_".$this->ref_id, "text") .
                     " AND value = " . $ilDB->quote(self::VALUE_ON, "text"));
                 while ($row = $ilDB->fetchAssoc($set)) {
                     $users[] = $row["usr_id"];
@@ -248,7 +248,7 @@ class ilMembershipNotifications
                 $inactive = array();
                 $set = $ilDB->query("SELECT usr_id" .
                     " FROM usr_pref" .
-                    " WHERE " . $ilDB->like("keyword", "text", "grpcrs_ntf_" . $this->ref_id) .
+                    " WHERE keyword = " . $ilDB->quote("grpcrs_ntf_".$this->ref_id, "text") .
                     " AND value = " . $ilDB->quote(self::VALUE_OFF, "text"));
                 while ($row = $ilDB->fetchAssoc($set)) {
                     $inactive[] = $row["usr_id"];


### PR DESCRIPTION
Improves perf. on courses with active notifications, by changing the following query:
`SELECT usr_id FROM usr_pref WHERE UPPER(keyword) LIKE(UPPER('grpcrs_ntf_9999')) AND value = '1'`

To 

`SELECT usr_id FROM usr_pref WHERE keyword = 'grpcrs_ntf_9999' AND value = '1'
`

and thus enabling the use of indices.

See: https://mantis.ilias.de/view.php?id=28416