### PR TITLE
CSS Doc: Updating guideline on compiling by using lessc

### DIFF
--- a/templates/Readme.md
+++ b/templates/Readme.md
@@ -385,3 +385,17 @@ that we handle all mobile cases as special cases and the desktop as the default.
 * You should use: `max-width: @grid-float-breakpoint-max` instead of `min-width:
 @grid-float-breakpoint (or min-width: @screen-sm-min)`. With `max-width`,  the
 mobile version is declared as the special case version (desktop first).
+
+## CSS Guideline
+
+CSS is optained by using a lessc compiler on delos.less, e.g. like so:
+
+```
+lessc templates/default/delos.less templates/default/delos.css
+```
+
+Note that the output heavily depends on the used lessc version. If you observe that 
+there are changed appearing in your css output other than the ones to be expected, 
+please first make sure, that you are using the latest lessc version. If so, please inform
+the current CSS maintainer [amstutz](http://www.ilias.de/docu/goto_docu_usr_26468.html) and only push the changes
+caused by your changes in less.


### PR DESCRIPTION
This is a follow up on #2734 trying to handle the switching of css files due to different lessc versions. I really hope this will be not as frequent in future as they currently seem to appear. 