### PR TITLE
23908: Refine auto save fail message

### DIFF
--- a/Modules/Test/js/ilTestPlayerQuestionEditControl.js
+++ b/Modules/Test/js/ilTestPlayerQuestionEditControl.js
@@ -322,7 +322,7 @@ il.TestPlayerQuestionEditControl = new function() {
      * @param jqXHR
      */
     function detectBackgroundChangesFailure(jqXHR) {
-        $('#autosavemessage').text(jqXHR.responseText)
+        $('#autosavemessage').text(jqXHR.responseText || ('Autosave error: ' + jqXHR.statusText))
             .fadeIn(500, function(){
                 $('#autosavemessage').fadeOut(5000)
             });
@@ -627,7 +627,7 @@ il.TestPlayerQuestionEditControl = new function() {
      */
     function autoSaveFailure(jqXHR) {
 
-        $('#autosavemessage').text(jqXHR.responseText)
+        $('#autosavemessage').text(jqXHR.responseText || ('Autosave error: ' + jqXHR.statusText))
             .fadeIn(500, function(){
                 $('#autosavemessage').fadeOut(5000)
         });


### PR DESCRIPTION
When an XHR is sent while offline, the `jqXHR.responseText`
is undefined but there might be more cases, for instance if
the server experiences a fatal error or the connection is reset.
An `undefined` response text causes that the existing text
does not change so ILIAS reports "successfully saved".

Mantis: https://mantis.ilias.de/view.php?id=23908