### PR TITLE
Add missing property to remove notice

### DIFF
--- a/Services/Component/classes/class.ilPluginSlot.php
+++ b/Services/Component/classes/class.ilPluginSlot.php
@@ -18,7 +18,12 @@ include_once("./Services/Component/classes/class.ilPlugin.php");
 */
 class ilPluginSlot
 {
-    
+
+    /**
+     * @var string
+     */
+    private $prefix = '';
+
     /**
     * Constructor
     */


### PR DESCRIPTION
This PR adds just a missing property which results in a notice/info with php 7.2 since ilias 5.4.

