### PR TITLE
Trim each entry of valid email domains

### DIFF
--- a/Services/Registration/classes/class.ilRegistrationSettings.php
+++ b/Services/Registration/classes/class.ilRegistrationSettings.php
@@ -191,10 +191,16 @@ class ilRegistrationSettings
     {
         return $this->reg_allow_codes;
     }
-    
+
     public function setAllowedDomains($a_value)
     {
-        $a_value = explode(";", trim($a_value));
+        $a_value = array_map(
+            function ($value) {
+                return trim($value);
+            },
+            explode(";", trim($a_value))
+        );
+
         $this->allowed_domains = $a_value;
     }
     


### PR DESCRIPTION
There is an option to prevent the registration with invalid email domains. It can be a problem, if the administrator uses space after each separating semicolon. In this case it will be nice if we trim each entry to get rid of these spaces.