### PR TITLE
#28495 - MainMenu Subitems

### DIFF
--- a/Services/MainMenu/classes/Administration/class.ilMMSubItemTableGUI.php
+++ b/Services/MainMenu/classes/Administration/class.ilMMSubItemTableGUI.php
@@ -43,7 +43,7 @@ class ilMMSubItemTableGUI extends ilTable2GUI
         $this->setExternalSegmentation(true);
         parent::__construct($a_parent_obj);
         $this->item_repository = $item_repository;
-        $this->lng             = $this->parent_obj->lng;
+        $this->lng = $this->parent_obj->lng;
         $this->addFilterItems();
         $this->setData($this->resolveData());
         $this->setFormAction($this->ctrl->getFormAction($this->parent_obj));
@@ -59,8 +59,8 @@ class ilMMSubItemTableGUI extends ilTable2GUI
         $table_entry_status = new ilSelectInputGUI($this->lng->txt(self::F_TABLE_ENTRY_STATUS), self::F_TABLE_ENTRY_STATUS);
         $table_entry_status->setOptions(
             array(
-                self::F_TABLE_ALL_VALUE           => $this->lng->txt("all"),
-                self::F_TABLE_ONLY_ACTIVE_VALUE   => $this->lng->txt("only_active"),
+                self::F_TABLE_ALL_VALUE => $this->lng->txt("all"),
+                self::F_TABLE_ONLY_ACTIVE_VALUE => $this->lng->txt("only_active"),
                 self::F_TABLE_ONLY_INACTIVE_VALUE => $this->lng->txt("only_inactive"),
             )
         );
@@ -104,18 +104,19 @@ class ilMMSubItemTableGUI extends ilTable2GUI
         global $DIC;
 
         $renderer = $DIC->ui()->renderer();
-        $factory  = $DIC->ui()->factory();
+        $factory = $DIC->ui()->factory();
         /**
          * @var $item_facade ilMMItemFacadeInterface
          */
         $item_facade = $a_set['facade'];
+
         if ($item_facade->isChild()) {
-            if (!$current_parent || $current_parent->getProviderIdentification() !== $item_facade->item()->getParent()) {
+            if (!$current_parent ||
+                $current_parent->getProviderIdentification()->serialize() !== $item_facade->getParentIdentificationString()) {
                 $current_parent = $this->item_repository->getSingleItem($item_facade->item()->getParent());
                 if ($current_parent instanceof Lost) {
-
                 }
-                $this->tpl->setVariable("PARENT_TITLE", $current_parent->getTitle()); //  ." ({$current_parent->getProviderIdentification()->getInternalIdentifier()})"
+                $this->tpl->setVariable("PARENT_TITLE", $current_parent->getTitle());
                 $position = 1;
             }
         }
@@ -144,9 +145,9 @@ class ilMMSubItemTableGUI extends ilTable2GUI
 
             $rendered_modal = "";
             if ($item_facade->isCustom()) {
-                $ditem  = $factory->modal()->interruptiveItem($this->hash($a_set['identification']), $item_facade->getDefaultTitle());
+                $ditem = $factory->modal()->interruptiveItem($this->hash($a_set['identification']), $item_facade->getDefaultTitle());
                 $action = $this->ctrl->getFormActionByClass(ilMMSubItemGUI::class, ilMMSubItemGUI::CMD_DELETE);
-                $m      = $factory->modal()
+                $m = $factory->modal()
                                   ->interruptive($this->lng->txt(ilMMSubItemGUI::CMD_DELETE), $this->lng->txt(ilMMSubItemGUI::CMD_CONFIRM_DELETE), $action)
                                   ->withAffectedItems([$ditem]);
 
@@ -191,7 +192,11 @@ class ilMMSubItemTableGUI extends ilTable2GUI
         $sub_items_for_table = $this->item_repository->getSubItemsForTable();
 
         foreach ($sub_items_for_table as $k => $item) {
-            $item_facade                       = $this->item_repository->repository()->getItemFacade($DIC->globalScreen()->identification()->fromSerializedIdentification($item['identification']));
+            $item_ident = $DIC->globalScreen()->identification()->fromSerializedIdentification($item['identification']);
+            $item_facade = $this->item_repository->repository()->getItemFacade($item_ident);
+            $parent_id = $item['parent_identification'];
+            $parent_id_calculated = $item_facade->getParentIdentificationString();
+
             $sub_items_for_table[$k]['facade'] = $item_facade;
             if (isset($this->filter[self::F_TABLE_ENTRY_STATUS]) && $this->filter[self::F_TABLE_ENTRY_STATUS] !== self::F_TABLE_ALL_VALUE) {
                 if (($this->filter[self::F_TABLE_ENTRY_STATUS] == self::F_TABLE_ONLY_ACTIVE_VALUE && !$item_facade->isActivated())
@@ -201,7 +206,6 @@ class ilMMSubItemTableGUI extends ilTable2GUI
                 }
             }
         }
-
         return $sub_items_for_table;
     }
 }

--- a/Services/MainMenu/classes/Items/Facade/class.ilMMAbstractItemFacade.php
+++ b/Services/MainMenu/classes/Items/Facade/class.ilMMAbstractItemFacade.php
@@ -51,10 +51,10 @@ abstract class ilMMAbstractItemFacade implements ilMMItemFacadeInterface
      */
     public function __construct(\ILIAS\GlobalScreen\Identification\IdentificationInterface $identification, Main $collector)
     {
-        $this->identification   = $identification;
-        $this->gs_item          = $collector->getSingleItemFromRaw($identification);
+        $this->identification = $identification;
+        $this->gs_item = $collector->getSingleItemFromRaw($identification);
         $this->type_information = $collector->getTypeInformationCollection()->get(get_class($this->gs_item));
-        $this->mm_item          = ilMMItemStorage::register($this->gs_item);
+        $this->mm_item = ilMMItemStorage::register($this->gs_item);
     }
 
     public function getId() : string
@@ -190,6 +190,11 @@ abstract class ilMMAbstractItemFacade implements ilMMItemFacadeInterface
     {
         if ($this->gs_item instanceof isChild) {
             $provider_name_for_presentation = $this->gs_item->getParent()->serialize();
+
+            $storage_parent = $this->mm_item->getParentIdentification();
+            if ($storage_parent !== $provider_name_for_presentation) {
+                return $storage_parent;
+            }
 
             return $provider_name_for_presentation;
         }
@@ -327,7 +332,7 @@ abstract class ilMMAbstractItemFacade implements ilMMItemFacadeInterface
     {
         if ($this->isDeletable()) {
             $serialize = $this->identification->serialize();
-            $mm        = ilMMItemStorage::find($serialize);
+            $mm = ilMMItemStorage::find($serialize);
             if ($mm instanceof ilMMItemStorage) {
                 $mm->delete();
             }


### PR DESCRIPTION
Use storage-item's parent over gs-item's.
This fixes https://mantis.ilias.de/view.php?id=28495 to the extend that tests are still passing and the described behavior is no longer observable.

However, especially the modifications in class.ilMMAbstractItemFacade.php do not feel too right - so please correct me and maybe point out better ways?
Thanks a lot.