### PR TITLE
#28500 - init Explorer2-JS for category selection

### DIFF
--- a/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeGUI.php
+++ b/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeGUI.php
@@ -226,6 +226,7 @@ class ilObjStudyProgrammeGUI extends ilContainerGUI
                 $this->tabs_gui->activateTab(self::TAB_SETTINGS);
                 $this->tabs_gui->activateSubTab('auto_content');
                 $this->autocategories_gui->setRefId($this->ref_id);
+                $this->initTreeJS();
                 $this->ctrl->forwardCommand($this->autocategories_gui);
                 break;
 
@@ -601,7 +602,7 @@ class ilObjStudyProgrammeGUI extends ilContainerGUI
                 self::TAB_INFO,
                 $this->lng->txt("info_short"),
                 $this->getLinkTarget("info_short")
-                                   );
+            );
         }
 
         if ($this->checkAccess("write")) {
@@ -609,7 +610,7 @@ class ilObjStudyProgrammeGUI extends ilContainerGUI
                 self::TAB_SETTINGS,
                 $this->lng->txt("settings"),
                 $this->getLinkTarget("settings")
-                                   );
+            );
         }
 
         if (
@@ -862,5 +863,10 @@ class ilObjStudyProgrammeGUI extends ilContainerGUI
             $this->lng->txt('error_creating_certificate_pdf')
         );
         $pdf_action->downloadPdf($user_id, $obj_id);
+    }
+
+    protected function initTreeJS() : void
+    {
+        ilExplorerBaseGUI::init();
     }
 }


### PR DESCRIPTION
fix for https://mantis.ilias.de/view.php?id=28500;
ilExplorerBaseGUI::init() adds JS to the template that is needed for the tree/category selection.
This is commonly done by components in the MainBar, but if those are deactivated, the JS is missing.