### PR TITLE
BT 0027895: Fixed individual assessment always having 0 accesses in usage intensity statistics

### DIFF
--- a/Modules/IndividualAssessment/classes/class.ilObjIndividualAssessmentGUI.php
+++ b/Modules/IndividualAssessment/classes/class.ilObjIndividualAssessmentGUI.php
@@ -156,6 +156,13 @@ class ilObjIndividualAssessmentGUI extends ilObjectGUI
         $this->ctrl->setCmdClass('ilinfoscreengui');
         $info = $this->buildInfoScreen();
         $this->ctrl->forwardCommand($info);
+
+        ilChangeEvent::_recordReadEvent(
+            $this->object->getType(),
+            $this->object->getRefId(),
+            $this->object->getId(),
+            $this->usr->getId()
+        );
     }
 
     public function membersObject()

--- a/Modules/IndividualAssessment/classes/class.ilObjIndividualAssessmentGUI.php
+++ b/Modules/IndividualAssessment/classes/class.ilObjIndividualAssessmentGUI.php
@@ -76,6 +76,17 @@ class ilObjIndividualAssessmentGUI extends ilObjectGUI
         }
     }
 
+    protected function recordIndividualAssessmentRead() {
+
+        ilChangeEvent::_recordReadEvent(
+            $this->object->getType(),
+            $this->object->getRefId(),
+            $this->object->getId(),
+            $this->usr->getId()
+        );
+
+    }
+
     public function executeCommand()
     {
         $next_class = $this->ctrl->getNextClass($this);
@@ -156,13 +167,7 @@ class ilObjIndividualAssessmentGUI extends ilObjectGUI
         $this->ctrl->setCmdClass('ilinfoscreengui');
         $info = $this->buildInfoScreen();
         $this->ctrl->forwardCommand($info);
-
-        ilChangeEvent::_recordReadEvent(
-            $this->object->getType(),
-            $this->object->getRefId(),
-            $this->object->getId(),
-            $this->usr->getId()
-        );
+        $this->recordIndividualAssessmentRead();
     }
 
     public function membersObject()


### PR DESCRIPTION
I added a call to to recordreadevent on the info screen of individual assessments, which is the only page a normal user is able to see.
So now it shows up correctly in the statistics when checking these.