### PR TITLE
orgu: get title from plugin lang if context is a plugin

### DIFF
--- a/Modules/OrgUnit/classes/Positions/Permissions/class.ilOrgUnitDefaultPermissionFormGUI.php
+++ b/Modules/OrgUnit/classes/Positions/Permissions/class.ilOrgUnitDefaultPermissionFormGUI.php
@@ -18,20 +18,28 @@ class ilOrgUnitDefaultPermissionFormGUI extends ilPropertyFormGUI
      * @var \ilOrgUnitPermission[]
      */
     protected $ilOrgUnitPermissions = [];
-
+    /**
+     * @var ilObjectDefinition
+     */
+    protected $objectDefinition;
 
     /**
      * ilOrgUnitDefaultPermissionFormGUI constructor.
      *
      * @param \ILIAS\Modules\OrgUnit\ARHelper\BaseCommands $parent_gui
      * @param ilOrgUnitPermission[]                        $ilOrgUnitPermissionsFilter
+     * @param ilObjectDefinition                           $objectDefinition
      */
-    public function __construct(BaseCommands $parent_gui, array $ilOrgUnitPermissionsFilter)
-    {
+    public function __construct(
+        BaseCommands $parent_gui,
+        array $ilOrgUnitPermissionsFilter,
+        ilObjectDefinition $objectDefinition
+    ) {
         $this->parent_gui = $parent_gui;
         $this->ilOrgUnitPermissions = $ilOrgUnitPermissionsFilter;
         $this->dic()->ctrl()->saveParameter($parent_gui, 'arid');
         $this->setFormAction($this->dic()->ctrl()->getFormAction($this->parent_gui));
+        $this->objectDefinition = $objectDefinition;
         $this->initFormElements();
         $this->initButtons();
         $this->setTarget('_top');
@@ -69,12 +77,12 @@ class ilOrgUnitDefaultPermissionFormGUI extends ilPropertyFormGUI
         foreach ($this->ilOrgUnitPermissions as $ilOrgUnitPermission) {
             $header = new ilFormSectionHeaderGUI();
             $context = $ilOrgUnitPermission->getContext()->getContext();
-            $header->setTitle($this->txt("obj_{$context}", false));
+            $header->setTitle($this->getTitleForFormHeaderByContext($context));
             $this->addItem($header);
 
             // Checkboxes
             foreach ($ilOrgUnitPermission->getPossibleOperations() as $operation) {
-                $title = $this->txt("org_op_{$operation->getOperationString()}", false);
+                $title = $this->txt("org_op_{$operation->getOperationString()}");
                 $id = $operation->getOperationId();
                 $cb = new ilCheckboxInputGUI($title, "operations[{$context}][{$id}]");
                 $this->addItem($cb);
@@ -154,5 +162,15 @@ class ilOrgUnitDefaultPermissionFormGUI extends ilPropertyFormGUI
     protected function txt($key)
     {
         return $this->parent_gui->txt($key);
+    }
+
+    protected function getTitleForFormHeaderByContext(string $context)
+    {
+        $lang_code = "obj_{$context}";
+        if ($this->objectDefinition->isPlugin($context)) {
+            return ilObjectPlugin::lookupTxtById($context, $lang_code);
+        }
+
+        return $this->txt($lang_code);
     }
 }

--- a/Modules/OrgUnit/classes/Positions/Permissions/class.ilOrgUnitDefaultPermissionGUI.php
+++ b/Modules/OrgUnit/classes/Positions/Permissions/class.ilOrgUnitDefaultPermissionGUI.php
@@ -16,7 +16,11 @@ class ilOrgUnitDefaultPermissionGUI extends BaseCommands
         $this->getParentGui()->addSubTabs();
         $this->getParentGui()->activeSubTab(ilOrgUnitPositionGUI::SUBTAB_PERMISSIONS);
         $ilOrgUnitPermissions = ilOrgUnitPermissionQueries::getAllTemplateSetsForAllActivedContexts($this->getCurrentPositionId());
-        $ilOrgUnitDefaultPermissionFormGUI = new ilOrgUnitDefaultPermissionFormGUI($this, $ilOrgUnitPermissions);
+        $ilOrgUnitDefaultPermissionFormGUI = new ilOrgUnitDefaultPermissionFormGUI(
+            $this,
+            $ilOrgUnitPermissions,
+            $this->dic()["objDefinition"]
+        );
         $ilOrgUnitDefaultPermissionFormGUI->fillForm();
 
         $this->setContent($ilOrgUnitDefaultPermissionFormGUI->getHTML());
@@ -27,7 +31,11 @@ class ilOrgUnitDefaultPermissionGUI extends BaseCommands
     {
         $this->getParentGui()->addSubTabs();
         $ilOrgUnitPermissions = ilOrgUnitPermissionQueries::getAllTemplateSetsForAllActivedContexts($this->getCurrentPositionId(), true);
-        $ilOrgUnitDefaultPermissionFormGUI = new ilOrgUnitDefaultPermissionFormGUI($this, $ilOrgUnitPermissions);
+        $ilOrgUnitDefaultPermissionFormGUI = new ilOrgUnitDefaultPermissionFormGUI(
+            $this,
+            $ilOrgUnitPermissions,
+            $this->dic()["objDefinition"]
+        );
         if ($ilOrgUnitDefaultPermissionFormGUI->saveObject()) {
             ilUtil::sendSuccess($this->txt('msg_success_permission_saved'), true);
             $this->cancel();


### PR DESCRIPTION
If there are some plugins enabled for position access there is a little problem with the form action header. If we want to translate the title for plugins, we have to insert them into the main language. In my opinion this is wrong. With this PR it will be able to get these translations from the plugin self.