### PR TITLE
Setup: implement ability to handle plugins during cli setup

### DIFF
--- a/Services/Component/classes/Setup/class.ilComponentActivatePluginsObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentActivatePluginsObjective.php
@@ -1,0 +1,150 @@
+<?php
+/* Copyright (c) 2020 Daniel Weise <daniel.weise@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+declare(strict_types=1);
+
+use ILIAS\Setup;
+use ILIAS\DI;
+
+class ilComponentActivatePluginsObjective implements Setup\Objective
+{
+    /**
+     * @var string
+     */
+    protected $plugin_name;
+
+    public function __construct(string $plugin_name)
+    {
+        $this->plugin_name = $plugin_name;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getHash() : string
+    {
+        return hash("sha256", self::class . $this->plugin_name);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getLabel() : string
+    {
+        return "Activate plugin $this->plugin_name.";
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isNotable() : bool
+    {
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPreconditions(Setup\Environment $environment) : array
+    {
+        $setup_config = $environment->getConfigFor('common');
+        $db_config = $environment->getConfigFor('database');
+
+        return [
+            new \ilIniFilesPopulatedObjective($setup_config),
+            new \ilDatabasePopulatedObjective($db_config),
+            new \ilComponentPluginAdminInitObjective()
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function achieve(Setup\Environment $environment) : Setup\Environment
+    {
+        $ORIG_DIC = $this->initEnvironment($environment);
+
+        $plugin = $GLOBALS["DIC"]["ilPluginAdmin"]->getRawPluginDataFor($this->plugin_name);
+
+        if (!is_null($plugin) && $plugin['activation_possible'] && $plugin['supports_cli_setup']) {
+            $pl = ilPlugin::getPluginObject(
+                $plugin['component_type'],
+                $plugin['component_name'],
+                $plugin['slot_id'],
+                $plugin['name']
+            );
+
+            $pl->activate();
+        }
+
+        $GLOBALS["DIC"] = $ORIG_DIC;
+
+        return $environment;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isApplicable(Setup\Environment $environment) : bool
+    {
+        $ORIG_DIC = $this->initEnvironment($environment);
+
+        $plugin = $GLOBALS["DIC"]["ilPluginAdmin"]->getRawPluginDataFor($this->plugin_name);
+
+        if (is_null($plugin) || !$plugin['supports_cli_setup']) {
+            return false;
+        }
+
+        $GLOBALS["DIC"] = $ORIG_DIC;
+
+        return $plugin['activation_possible'];
+    }
+
+    protected function initEnvironment(Setup\Environment $environment) : ILIAS\DI\Container
+    {
+        $db = $environment->getResource(Setup\Environment::RESOURCE_DATABASE);
+        $plugin_admin = $environment->getResource(Setup\Environment::RESOURCE_PLUGIN_ADMIN);
+        $ini = $environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI);
+        $client_ini = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_INI);
+
+
+        // ATTENTION: This is a total abomination. It only exists to allow various
+        // sub components of the various readers to run. This is a memento to the
+        // fact, that dependency injection is something we want. Currently, every
+        // component could just service locate the whole world via the global $DIC.
+        $DIC = $GLOBALS["DIC"];
+        $GLOBALS["DIC"] = new DI\Container();
+        $GLOBALS["DIC"]["ilDB"] = $db;
+        $GLOBALS["DIC"]["ilIliasIniFile"] = $ini;
+        $GLOBALS["DIC"]["ilClientIniFile"] = $client_ini;
+        $GLOBALS["DIC"]["ilLoggerFactory"] = new class() {
+            public function getLogger()
+            {
+            }
+        };
+        $GLOBALS["DIC"]["ilBench"] = null;
+        $GLOBALS["DIC"]["lng"] = new ilLanguage('en');
+        $GLOBALS["DIC"]["ilPluginAdmin"] = $plugin_admin;
+        $GLOBALS["DIC"]["ilCtrl"] = new ilCtrl();
+        $GLOBALS["DIC"]["ilias"] = null;
+        $GLOBALS["DIC"]["ilLog"] = null;
+        $GLOBALS["DIC"]["ilErr"] = null;
+        $GLOBALS["DIC"]["tree"] = null;
+        $GLOBALS["DIC"]["ilAppEventHandler"] = null;
+        $GLOBALS["DIC"]["ilSetting"] = new ilSetting();
+        $GLOBALS["DIC"]["objDefinition"] = new ilObjectDefinition();
+        $GLOBALS["DIC"]["ilUser"] = new class() {
+            public $prefs = [];
+            public function __construct()
+            {
+                $this->prefs['language'] = 'en';
+            }
+        };
+
+        if (!defined('DEBUG')) {
+            define('DEBUG', false);
+        }
+
+        return $DIC;
+    }
+}

--- a/Services/Component/classes/Setup/class.ilComponentDefinitionsStoredObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentDefinitionsStoredObjective.php
@@ -68,7 +68,7 @@ class ilComponentDefinitionsStoredObjective implements Setup\Objective
         $GLOBALS["DIC"] = new DI\Container();
         $GLOBALS["DIC"]["ilDB"] = $db;
         $GLOBALS["DIC"]["ilIliasIniFile"] = $ini;
-        $GLOBALS["DIC"]["ilClientIniFile"] = $ini;
+        $GLOBALS["DIC"]["ilClientIniFile"] = $client_ini;
         $GLOBALS["DIC"]["ilBench"] = null;
         $GLOBALS["DIC"]["ilObjDataCache"] = null;
         $GLOBALS["DIC"]["lng"] = new class() {

--- a/Services/Component/classes/Setup/class.ilComponentInstallPluginObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentInstallPluginObjective.php
@@ -1,0 +1,150 @@
+<?php
+/* Copyright (c) 2020 Daniel Weise <daniel.weise@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+declare(strict_types=1);
+
+use ILIAS\Setup;
+use ILIAS\DI;
+
+class ilComponentInstallPluginObjective implements Setup\Objective
+{
+    /**
+     * @var string
+     */
+    protected $plugin_name;
+
+    public function __construct(string $plugin_name)
+    {
+        $this->plugin_name = $plugin_name;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getHash() : string
+    {
+        return hash("sha256", self::class . $this->plugin_name);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getLabel() : string
+    {
+        return "Install plugin $this->plugin_name.";
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isNotable() : bool
+    {
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPreconditions(Setup\Environment $environment) : array
+    {
+        $setup_config = $environment->getConfigFor('common');
+        $db_config = $environment->getConfigFor('database');
+
+        return [
+            new \ilIniFilesPopulatedObjective($setup_config),
+            new \ilDatabasePopulatedObjective($db_config),
+            new \ilComponentPluginAdminInitObjective()
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function achieve(Setup\Environment $environment) : Setup\Environment
+    {
+        $ORIG_DIC = $this->initEnvironment($environment);
+
+        $plugin = $GLOBALS["DIC"]["ilPluginAdmin"]->getRawPluginDataFor($this->plugin_name);
+
+        if (!is_null($plugin) && $plugin['must_install'] && $plugin['supports_cli_setup']) {
+            $pl = ilPlugin::getPluginObject(
+                $plugin['component_type'],
+                $plugin['component_name'],
+                $plugin['slot_id'],
+                $plugin['name']
+            );
+
+            $pl->install();
+        }
+
+        $GLOBALS["DIC"] = $ORIG_DIC;
+
+        return $environment;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isApplicable(Setup\Environment $environment) : bool
+    {
+        $ORIG_DIC = $this->initEnvironment($environment);
+
+        $plugin = $GLOBALS["DIC"]["ilPluginAdmin"]->getRawPluginDataFor($this->plugin_name);
+
+        if (is_null($plugin) || !$plugin['supports_cli_setup']) {
+            return false;
+        }
+
+        $GLOBALS["DIC"] = $ORIG_DIC;
+
+        return $plugin['must_install'];
+    }
+
+    protected function initEnvironment(Setup\Environment $environment) : ILIAS\DI\Container
+    {
+        $db = $environment->getResource(Setup\Environment::RESOURCE_DATABASE);
+        $plugin_admin = $environment->getResource(Setup\Environment::RESOURCE_PLUGIN_ADMIN);
+        $ini = $environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI);
+        $client_ini = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_INI);
+
+
+        // ATTENTION: This is a total abomination. It only exists to allow various
+        // sub components of the various readers to run. This is a memento to the
+        // fact, that dependency injection is something we want. Currently, every
+        // component could just service locate the whole world via the global $DIC.
+        $DIC = $GLOBALS["DIC"];
+        $GLOBALS["DIC"] = new DI\Container();
+        $GLOBALS["DIC"]["ilDB"] = $db;
+        $GLOBALS["DIC"]["ilIliasIniFile"] = $ini;
+        $GLOBALS["DIC"]["ilClientIniFile"] = $client_ini;
+        $GLOBALS["DIC"]["ilLoggerFactory"] = new class() {
+            public function getLogger()
+            {
+            }
+        };
+        $GLOBALS["DIC"]["ilBench"] = null;
+        $GLOBALS["DIC"]["lng"] = new ilLanguage('en');
+        $GLOBALS["DIC"]["ilPluginAdmin"] = $plugin_admin;
+        $GLOBALS["DIC"]["ilCtrl"] = new ilCtrl();
+        $GLOBALS["DIC"]["ilias"] = null;
+        $GLOBALS["DIC"]["ilLog"] = null;
+        $GLOBALS["DIC"]["ilErr"] = null;
+        $GLOBALS["DIC"]["tree"] = null;
+        $GLOBALS["DIC"]["ilAppEventHandler"] = null;
+        $GLOBALS["DIC"]["ilSetting"] = new ilSetting();
+        $GLOBALS["DIC"]["objDefinition"] = new ilObjectDefinition();
+        $GLOBALS["DIC"]["ilUser"] = new class() {
+            public $prefs = [];
+            public function __construct()
+            {
+                $this->prefs['language'] = 'en';
+            }
+        };
+
+        if (!defined('DEBUG')) {
+            define('DEBUG', false);
+        }
+
+        return $DIC;
+    }
+}

--- a/Services/Component/classes/Setup/class.ilComponentPluginAdminInitObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentPluginAdminInitObjective.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+use ILIAS\Setup;
+use ILIAS\DI;
+
+class ilComponentPluginAdminInitObjective implements Setup\Objective
+{
+    /**
+     * @inheritdoc
+     */
+    public function getHash() : string
+    {
+        return hash("sha256", self::class);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getLabel() : string
+    {
+        return "ilPluginAdmin is initialized and stored into the environment.";
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isNotable() : bool
+    {
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPreconditions(Setup\Environment $environment) : array
+    {
+        $config = $environment->getConfigFor('language');
+        return [
+            new \ilLanguagesInstalledObjective($config, new ilSetupLanguage('en'))
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function achieve(Setup\Environment $environment) : Setup\Environment
+    {
+        // ATTENTION: This is a total abomination. It only exists to allow various
+        // sub components of the various readers to run. This is a memento to the
+        // fact, that dependency injection is something we want. Currently, every
+        // component could just service locate the whole world via the global $DIC.
+        $DIC = $GLOBALS["DIC"];
+        $GLOBALS["DIC"] = new DI\Container();
+        $GLOBALS["DIC"]["lng"] = new class() {
+            public function loadLanguageModule()
+            {
+            }
+        };
+
+        $environment = $environment->withResource(
+            Setup\Environment::RESOURCE_PLUGIN_ADMIN,
+            new ilPluginAdmin()
+        );
+
+        $GLOBALS["DIC"] = $DIC;
+
+        return $environment;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isApplicable(Setup\Environment $environment) : bool
+    {
+        return is_null($environment->getResource(Setup\Environment::RESOURCE_PLUGIN_ADMIN));
+    }
+}

--- a/Services/Component/classes/Setup/class.ilComponentUpdatePluginObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentUpdatePluginObjective.php
@@ -1,0 +1,150 @@
+<?php
+/* Copyright (c) 2020 Daniel Weise <daniel.weise@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+declare(strict_types=1);
+
+use ILIAS\Setup;
+use ILIAS\DI;
+
+class ilComponentUpdatePluginObjective implements Setup\Objective
+{
+    /**
+     * @var string
+     */
+    protected $plugin_name;
+
+    public function __construct(string $plugin_name)
+    {
+        $this->plugin_name = $plugin_name;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getHash() : string
+    {
+        return hash("sha256", self::class . $this->plugin_name);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getLabel() : string
+    {
+        return "Update plugin $this->plugin_name.";
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isNotable() : bool
+    {
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPreconditions(Setup\Environment $environment) : array
+    {
+        $setup_config = $environment->getConfigFor('common');
+        $db_config = $environment->getConfigFor('database');
+
+        return [
+            new \ilIniFilesPopulatedObjective($setup_config),
+            new \ilDatabasePopulatedObjective($db_config),
+            new \ilComponentPluginAdminInitObjective()
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function achieve(Setup\Environment $environment) : Setup\Environment
+    {
+        $ORIG_DIC = $this->initEnvironment($environment);
+
+        $plugin = $GLOBALS["DIC"]["ilPluginAdmin"]->getRawPluginDataFor($this->plugin_name);
+
+        if (!is_null($plugin) && $plugin['needs_update'] && $plugin['supports_cli_setup']) {
+            $pl = ilPlugin::getPluginObject(
+                $plugin['component_type'],
+                $plugin['component_name'],
+                $plugin['slot_id'],
+                $plugin['name']
+            );
+
+            $pl->update();
+        }
+
+        $GLOBALS["DIC"] = $ORIG_DIC;
+
+        return $environment;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isApplicable(Setup\Environment $environment) : bool
+    {
+        $ORIG_DIC = $this->initEnvironment($environment);
+
+        $plugin = $GLOBALS["DIC"]["ilPluginAdmin"]->getRawPluginDataFor($this->plugin_name);
+
+        if (is_null($plugin) || !$plugin['supports_cli_setup']) {
+            return false;
+        }
+
+        $GLOBALS["DIC"] = $ORIG_DIC;
+
+        return $plugin['needs_update'];
+    }
+
+    protected function initEnvironment(Setup\Environment $environment) : ILIAS\DI\Container
+    {
+        $db = $environment->getResource(Setup\Environment::RESOURCE_DATABASE);
+        $plugin_admin = $environment->getResource(Setup\Environment::RESOURCE_PLUGIN_ADMIN);
+        $ini = $environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI);
+        $client_ini = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_INI);
+
+
+        // ATTENTION: This is a total abomination. It only exists to allow various
+        // sub components of the various readers to run. This is a memento to the
+        // fact, that dependency injection is something we want. Currently, every
+        // component could just service locate the whole world via the global $DIC.
+        $DIC = $GLOBALS["DIC"];
+        $GLOBALS["DIC"] = new DI\Container();
+        $GLOBALS["DIC"]["ilDB"] = $db;
+        $GLOBALS["DIC"]["ilIliasIniFile"] = $ini;
+        $GLOBALS["DIC"]["ilClientIniFile"] = $client_ini;
+        $GLOBALS["DIC"]["ilLoggerFactory"] = new class() {
+            public function getLogger()
+            {
+            }
+        };
+        $GLOBALS["DIC"]["ilBench"] = null;
+        $GLOBALS["DIC"]["lng"] = new ilLanguage('en');
+        $GLOBALS["DIC"]["ilPluginAdmin"] = $plugin_admin;
+        $GLOBALS["DIC"]["ilCtrl"] = new ilCtrl();
+        $GLOBALS["DIC"]["ilias"] = null;
+        $GLOBALS["DIC"]["ilLog"] = null;
+        $GLOBALS["DIC"]["ilErr"] = null;
+        $GLOBALS["DIC"]["tree"] = null;
+        $GLOBALS["DIC"]["ilAppEventHandler"] = null;
+        $GLOBALS["DIC"]["ilSetting"] = new ilSetting();
+        $GLOBALS["DIC"]["objDefinition"] = new ilObjectDefinition();
+        $GLOBALS["DIC"]["ilUser"] = new class() {
+            public $prefs = [];
+            public function __construct()
+            {
+                $this->prefs['language'] = 'en';
+            }
+        };
+
+        if (!defined('DEBUG')) {
+            define('DEBUG', false);
+        }
+
+        return $DIC;
+    }
+}

--- a/Services/Component/classes/Setup/class.ilPluginDefaultAgent.php
+++ b/Services/Component/classes/Setup/class.ilPluginDefaultAgent.php
@@ -1,0 +1,80 @@
+<?php
+/* Copyright (c) 2020 Daniel Weise <daniel.weise@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+declare(strict_types=1);
+
+use ILIAS\Setup;
+use \ILIAS\Refinery\Transformation;
+use ILIAS\UI\Component\Input\Field\Input;
+
+abstract class ilPluginDefaultAgent implements Setup\Agent
+{
+    /**
+     * @var string
+     */
+    protected $plugin_name;
+
+    public function __construct(string $plugin_name)
+    {
+        $this->plugin_name = $plugin_name;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function hasConfig() : bool
+    {
+        return false;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getArrayToConfigTransformation() : Transformation
+    {
+        throw new \LogicException(self::class . " has no Config.");
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getInstallObjective(Setup\Config $config = null) : Setup\Objective
+    {
+        return new Setup\ObjectiveCollection(
+            'Complete objectives from Services/Component',
+            false,
+            new \ilComponentInstallPluginObjective($this->plugin_name),
+            new \ilComponentUpdatePluginObjective($this->plugin_name),
+            new \ilComponentActivatePluginsObjective($this->plugin_name)
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
+    {
+        return new Setup\ObjectiveCollection(
+            'Complete objectives from Services/Component',
+            false,
+            new \ilComponentUpdatePluginObjective($this->plugin_name),
+            new \ilComponentActivatePluginsObjective($this->plugin_name)
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getBuildArtifactObjective() : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
+}

--- a/Services/Component/classes/class.ilCachedComponentData.php
+++ b/Services/Component/classes/class.ilCachedComponentData.php
@@ -467,7 +467,7 @@ class ilCachedComponentData
      */
     public function lookupActivePluginsBySlotId($slot_id)
     {
-        if (is_array($this->il_plugin_active[$slot_id])) {
+        if (isset($this->il_plugin_active[$slot_id]) && is_array($this->il_plugin_active[$slot_id])) {
             return $this->il_plugin_active[$slot_id];
         } else {
             return array();
@@ -590,7 +590,7 @@ class ilCachedComponentData
      */
     public function lookupPluginSlotByComponent($component)
     {
-        if (is_array($this->il_pluginslot_by_comp[$component])) {
+        if (isset($this->il_pluginslot_by_comp[$component]) && is_array($this->il_pluginslot_by_comp[$component])) {
             return $this->il_pluginslot_by_comp[$component];
         }
 

--- a/Services/Component/classes/class.ilPlugin.php
+++ b/Services/Component/classes/class.ilPlugin.php
@@ -54,6 +54,10 @@ abstract class ilPlugin
      * @var ProviderCollection
      */
     protected $provider_collection;
+    /**
+     * @var string
+     */
+    protected $message;
 
 
     public function __construct()

--- a/Services/Component/classes/class.ilPluginRawReader.php
+++ b/Services/Component/classes/class.ilPluginRawReader.php
@@ -8,7 +8,7 @@ class ilPluginRawReader
     const BASE_PLUGIN_PATH = 'Customizing/global/plugins';
     const SEARCH_PATTERN = 'plugin.php';
 
-    public function getPluginNames() : \Iterator
+    public function getPluginNames() : ?\Iterator
     {
         if (!@is_dir(self::BASE_PLUGIN_PATH)) {
             throw new LogicException('Path not found: ' . self::BASE_PLUGIN_PATH);

--- a/Services/Component/classes/class.ilPluginRawReader.php
+++ b/Services/Component/classes/class.ilPluginRawReader.php
@@ -1,0 +1,25 @@
+<?php
+/* Copyright (c) 2020 Daniel Weise <daniel.weise@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+declare(strict_types=1);
+
+class ilPluginRawReader
+{
+    const BASE_PLUGIN_PATH = 'Customizing/global/plugins';
+    const SEARCH_PATTERN = 'plugin.php';
+
+    public function getPluginNames() : \Iterator
+    {
+        if (!@is_dir(self::BASE_PLUGIN_PATH)) {
+            throw new LogicException('Path not found: ' . self::BASE_PLUGIN_PATH);
+        }
+
+        $it = new RecursiveDirectoryIterator(self::BASE_PLUGIN_PATH);
+        foreach (new RecursiveIteratorIterator($it) as $file) {
+            $path = $file->getPathName();
+            if (is_file($path) && basename($path) === self::SEARCH_PATTERN) {
+                yield basename(dirname($path));
+            }
+        }
+    }
+}

--- a/Services/Cron/classes/class.ilCronManager.php
+++ b/Services/Cron/classes/class.ilCronManager.php
@@ -371,8 +371,9 @@ class ilCronManager implements \ilCronManagerInterface
             " WHERE job_id = " . $ilDB->quote($a_job->getId(), "text");
         $set = $ilDB->query($sql);
         $row = $ilDB->fetchAssoc($set);
-        $job_exists = ($row["job_id"] == $a_job->getId());
-        $schedule_type = $row["schedule_type"];
+        $job_id = $row['job_id'] ?? null;
+        $job_exists = ($job_id == $a_job->getId());
+        $schedule_type = $row["schedule_type"] ?? null;
 
         if ($job_exists && (
             $row['component'] != $a_component ||

--- a/Services/Database/classes/PDO/class.ilDBPdo.php
+++ b/Services/Database/classes/PDO/class.ilDBPdo.php
@@ -494,7 +494,7 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface
     public function query($query)
     {
         global $DIC;
-        $ilBench = $DIC['ilBench'];
+        $ilBench = $DIC['ilBench'] ?? null;
 
         $query = $this->appendLimit($query);
 
@@ -735,7 +735,7 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface
     public function manipulate($query)
     {
         global $DIC;
-        $ilBench = $DIC['ilBench'];
+        $ilBench = $DIC['ilBench'] ?? null;
         try {
             $query = $this->sanitizeMB4StringIfNotSupported($query);
             if ($ilBench instanceof ilBenchmark) {

--- a/Services/Database/classes/Setup/class.ilDatabaseSetupConfig.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseSetupConfig.php
@@ -36,7 +36,7 @@ class ilDatabaseSetupConfig implements Setup\Config
     protected $create_database;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $collation;
 
@@ -51,7 +51,7 @@ class ilDatabaseSetupConfig implements Setup\Config
     protected $password;
 
     /**
-     * @var	string
+     * @var	string|null
      */
     protected $path_to_db_dump;
 

--- a/Services/Database/classes/class.ilDBUpdate.php
+++ b/Services/Database/classes/class.ilDBUpdate.php
@@ -32,6 +32,14 @@ class ilDBUpdate
      * @var string
      */
     public $updateMsg;
+    /**
+     * @var ilIniFile|null
+     */
+    protected $client_ini;
+
+    protected $custom_updates_current_version;
+    protected $custom_updates_file_version;
+    protected $custom_updates_info_read;
 
 
     /**
@@ -211,6 +219,7 @@ class ilDBUpdate
         //go through filecontent and search for last occurence of <#x>
         reset($this->lastfilecontent);
         $regs = array();
+        $version = 0;
         foreach ($this->lastfilecontent as $row) {
             if (preg_match('/^\<\#([0-9]+)>/', $row, $regs)) {
                 $version = $regs[1];
@@ -322,7 +331,6 @@ class ilDBUpdate
         }
 
         $GLOBALS['ilMySQLAbstraction'] = $ilMySQLAbstraction;
-
         if ($this->client_ini) {
             $ilCtrlStructureReader->setIniFile($this->client_ini);
         }

--- a/Services/FileSystem/classes/Setup/class.ilFileSystemComponentDataDirectoryCreatedObjective.php
+++ b/Services/FileSystem/classes/Setup/class.ilFileSystemComponentDataDirectoryCreatedObjective.php
@@ -70,4 +70,13 @@ class ilFileSystemComponentDataDirectoryCreatedObjective extends Setup\Objective
         $this->path = $this->buildPath($environment);
         return parent::achieve($environment);
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function isApplicable(Setup\Environment $environment) : bool
+    {
+        $this->path = $this->buildPath($environment);
+        return parent::isApplicable($environment);
+    }
 }

--- a/Services/FileSystem/classes/Setup/class.ilFileSystemComponentDataDirectoryCreatedObjective.php
+++ b/Services/FileSystem/classes/Setup/class.ilFileSystemComponentDataDirectoryCreatedObjective.php
@@ -29,6 +29,8 @@ class ilFileSystemComponentDataDirectoryCreatedObjective extends Setup\Objective
         string $component_dir,
         int $base_location = self::DATADIR
     ) {
+        parent::__construct($component_dir);
+
         $this->component_dir = $component_dir;
         $this->base_location = $base_location;
     }

--- a/Services/GlobalScreen/classes/Setup/class.ilGlobalScreenBuildProviderMapObjective.php
+++ b/Services/GlobalScreen/classes/Setup/class.ilGlobalScreenBuildProviderMapObjective.php
@@ -31,9 +31,11 @@ class ilGlobalScreenBuildProviderMapObjective extends Setup\Artifact\BuildArtifa
             NotificationProvider::class,
         ];
 
+        $finder = new Setup\ImplementationOfInterfaceFinder();
         foreach ($i as $interface) {
-            $i = new Setup\ImplementationOfInterfaceFinder($interface);
-            $class_names[$interface] = iterator_to_array($i->getMatchingClassNames());
+            $class_names[$interface] = iterator_to_array(
+                $finder->getMatchingClassNames($interface)
+            );
         }
 
         return new Setup\Artifact\ArrayArtifact($class_names);

--- a/Services/Language/classes/class.ilLanguage.php
+++ b/Services/Language/classes/class.ilLanguage.php
@@ -311,7 +311,7 @@ class ilLanguage
             $lang_key = $this->lang_user;
         }
 
-        if (is_array($this->cached_modules[$a_module])) {
+        if (isset($this->cached_modules[$a_module]) && is_array($this->cached_modules[$a_module])) {
             $this->text = array_merge($this->text, $this->cached_modules[$a_module]);
 
             if ($this->usage_log_enabled) {
@@ -328,7 +328,11 @@ class ilLanguage
                 $ilDB->quote($a_module, "text");
         $r = $ilDB->query($q);
         $row = $r->fetchRow(ilDBConstants::FETCHMODE_ASSOC);
-        
+
+        if ($row === false) {
+            return;
+        }
+
         $new_text = unserialize($row["lang_array"]);
         if (is_array($new_text)) {
             $this->text = array_merge($this->text, $new_text);

--- a/Services/Language/classes/class.ilObjLanguage.php
+++ b/Services/Language/classes/class.ilObjLanguage.php
@@ -633,14 +633,14 @@ class ilObjLanguage extends ilObject
             $a_remarks = substr($a_remarks, 0, 250);
         }
         if ($a_remarks == '') {
-            unset($a_remarks);
+            $a_remarks = null;
         }
 
         if (isset($a_value)) {
             $a_value = substr($a_value, 0, 4000);
         }
         if ($a_value == '') {
-            unset($a_value);
+            $a_value = null;
         }
 
         $ilDB->replace(

--- a/Services/Mail/classes/class.ilMailTemplateContextService.php
+++ b/Services/Mail/classes/class.ilMailTemplateContextService.php
@@ -174,7 +174,8 @@ class ilMailTemplateContextService
         $query = "SELECT id FROM mail_tpl_ctx WHERE id = %s";
         $res = $DIC->database()->queryF($query, array('text'), array($a_context->getId()));
         $row = $DIC->database()->fetchAssoc($res);
-        $context_exists = ($row['id'] == $a_context->getId());
+        $row_id = $row['id'] ?? null;
+        $context_exists = ($row_id == $a_context->getId());
 
         if (!$context_exists) {
             $DIC->database()->insert('mail_tpl_ctx', array(

--- a/Services/Migration/DBUpdate_3560/classes/class.ilDBUpdateNewObjectType.php
+++ b/Services/Migration/DBUpdate_3560/classes/class.ilDBUpdateNewObjectType.php
@@ -304,7 +304,7 @@ class ilDBUpdateNewObjectType
             ' WHERE operation = ' . $ilDB->quote($a_operation, 'text');
         $res = $ilDB->query($sql);
         $row = $ilDB->fetchAssoc($res);
-        return $row['ops_id'];
+        return $row['ops_id'] ?? null;
     }
     
     /**
@@ -362,7 +362,7 @@ class ilDBUpdateNewObjectType
             ' AND title = ' . $ilDB->quote($a_type, 'text');
         $res = $ilDB->query($sql);
         $row = $ilDB->fetchAssoc($res);
-        return $row['obj_id'];
+        return $row['obj_id'] ?? null;
     }
     
     /**

--- a/Services/Repository/classes/class.ilObjectPlugin.php
+++ b/Services/Repository/classes/class.ilObjectPlugin.php
@@ -42,7 +42,7 @@ abstract class ilObjectPlugin extends ilObject2
      */
     public static function getPluginObjectByType($type)
     {
-        if (!self::$plugin_by_type[$type]) {
+        if (!isset(self::$plugin_by_type[$type]) || !self::$plugin_by_type[$type]) {
             list($component, $component_name) = ilPlugin::lookupTypeInformationsForId($type);
             if (
                 $component == IL_COMP_SERVICE &&

--- a/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
+++ b/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
@@ -14,6 +14,7 @@ class ilCtrlStructureReader
 {
     public $executed;
     public $db = null;
+    protected $read_plugins = false;
 
     public function __construct($a_ini_file = null)
     {
@@ -72,6 +73,10 @@ class ilCtrlStructureReader
 
         // plugin path
         $this->plugin_path = $a_plugin_path;
+
+        if ($this->plugin_path != "" && $this->comp_prefix != "") {
+            $this->read_plugins = true;
+        }
 
         if ($a_dir == "") {
             $a_dir = $this->getILIASAbsolutePath();
@@ -158,7 +163,11 @@ class ilCtrlStructureReader
         $il_absolute_path = $this->getILIASAbsolutePath();
         $data_dir = $this->normalizePath($il_absolute_path . "/data");
         $customizing_dir = $this->normalizePath($il_absolute_path . "/Customizing");
+
         $dir = $this->normalizePath($dir);
+        if ($this->read_plugins) {
+            return $dir != $data_dir;
+        }
         return $dir != $customizing_dir && $dir != $data_dir;
     }
 
@@ -239,7 +248,6 @@ class ilCtrlStructureReader
 
         foreach ($ctrl_structure->getClassScripts() as $class => $script) {
             $file = substr($script, strlen($start_dir) + 1);
-            
             // store class to file assignment
             $ilDB->manipulate(sprintf(
                 "INSERT INTO ctrl_classfile (class, filename, comp_prefix, plugin_path) " .

--- a/setup/README.md
+++ b/setup/README.md
@@ -1,13 +1,19 @@
 # Use the Command Line to Manage ILIAS
 
-The ILIAS command line app can be called via `php setup\setup.php`. It contains three
-commands to manage ILIAS installations:
+The ILIAS command line app can be called via `php setup\setup.php`. It contains four
+main commands to manage ILIAS installations:
 
 * `install` will [set an installation up](#install-ilias)
 * `update` will [update an installation](#update-ilias)
 * `status` will [report status of an installation](#report-status-of-ilias)
 * `build-artifacts` [recreates static assets](#build-ilias-artifacts) of an installation
 * `reload-control-structure` [rebuilds structure information](#build-ilias-artifacts) of an installation
+
+`install` and `update` also supply switches and options for a granular control of the inclusion of plugins:
+
+* `--skip <plugin name>` will exclude the named plugin from the command
+* `--no-plugins` will exclude all plugins from the command
+* `install <plugin name>` (or `update <plugin name>` respectively) will update or install the specified plugin
 
 `install` and `update` both require a [configuration file](#about-the-config-file)
 to do their job. The app also supports a `help` command that lists arguments and
@@ -16,7 +22,7 @@ options of the available commands.
 
 ## Install ILIAS
 
-To install ILIAS from the command line, call `php setup/setup.php install config.json"
+To install ILIAS with all plugins from the command line, call `php setup/setup.php install config.json`
 from within the ILIAS folder you checked out from GitHub (or downloaded from elsewhere).
 `config.json` can be the path to some [configuration file](#about-the-config-file)
 which does not need to reside in the ILIAS folder. Also, `setup/setup.php` could be
@@ -44,6 +50,13 @@ from the original config will be overwritten with `XYZ`. This allows to use one
 configuration for multiple setups and overwrite it from the CLI or even share
 configs without secrets.
 
+The setup will also install plugins of the installation, unless the plugin explicitely
+defines that it cannot be installed via CLI setup. If you still want to skip a plugin
+for installation, use the skip-option: `php setup/setup.php install --skip <plugin name> config.json`.
+The option can be repeated to cover multiple plugins. If you want to skip plugins
+alltogether, use the `--no-plugins` option. If you only want to install a specific
+plugin, use `php setup/setup.php install config.json <plugin name>`.
+
 
 ## Update ILIAS
 
@@ -52,12 +65,14 @@ from within your ILIAS folder. This will update the configuration of ILIAS accor
 to the provided configuration as well as update the database of the installation or
 do other necessary task for the update. This does not update the source code.
 
+Plugins are updated just as the core of ILIAS (if the plugin does not exclude itself),
+where the plugins can be controlled with the same options as for `install`.
+
 Sometimes it might happen that the database update steps detect some edge case
 or warn about a possible loss of data. In this case the update is aborted with
 a message and can be resumed after the messages was read carefully and acted
 upon. You may use the `--ignore-db-update-messages` at your own risk if you want
 to silence the messages.
-
 
 ## Report Status of ILIAS
 
@@ -72,6 +87,9 @@ The output of the command is formatted as YAML to be easily readable by people a
 machines. So we encourage you to use this command for monitoring your system and
 also request status information via our feature process that you are interested in.
 
+Like for `install` and `update`, plugins are included here, but can be controlled
+via options.
+
 
 ## Build ILIAS Artifacts
 
@@ -82,6 +100,9 @@ filesystem permissions later on, because the webserver will need to access the
 generated files. Please do not invoke this function unless it is explicitly stated
 in update or patch instructions or you know what you are doing.
 
+Like for `install` and `update`, plugins are included here, but can be controlled
+via options.
+
 
 ## Reload ILIAS Control Structure
 
@@ -89,7 +110,6 @@ The control structure captures information about components and GUIs of ILIAS
 in the database. Sometimes it might be necessary to refresh that information.
 Please do not invoke this function unless it is explicitly stated in update
 or patch instructions or you know what you are doing.
-
 
 ## About the Config File
 

--- a/setup/cli.php
+++ b/setup/cli.php
@@ -38,17 +38,6 @@ $c = build_container_for_setup($executed_in_directory);
 $app = $c["app"];
 $app->run();
 
-function get_agent_name_by_class(string $class_name) : string
-{
-    // We assume that the name of an agent in the class ilXYZSetupAgent really
-    // is XYZ. If that does not fit we just use the class name.
-    $match = [];
-    if (preg_match("/il(\w+)SetupAgent/", $class_name, $match)) {
-        return $match[1];
-    }
-    return $class_name;
-}
-
 // ATTENTION: This is a hack to get around the usage of the echo/exit pattern in
 // the setup for the command line version of the setup. Do not use this.
 function setup_exit($message)
@@ -73,21 +62,21 @@ function build_container_for_setup(string $executed_in_directory)
     };
     $c["command.install"] = function ($c) {
         return new \ILIAS\Setup\CLI\InstallCommand(
-            $c["agent"],
+            $c["agent_finder"],
             $c["config_reader"],
             $c["common_preconditions"]
         );
     };
     $c["command.update"] = function ($c) {
         return new \ILIAS\Setup\CLI\UpdateCommand(
-            $c["agent"],
+            $c["agent_finder"],
             $c["config_reader"],
             $c["common_preconditions"]
         );
     };
     $c["command.build-artifacts"] = function ($c) {
         return new \ILIAS\Setup\CLI\BuildArtifactsCommand(
-            $c["agent"]
+            $c["agent_finder"]
         );
     };
     $c["command.reload-control-structure"] = function ($c) {
@@ -97,7 +86,7 @@ function build_container_for_setup(string $executed_in_directory)
     };
     $c["command.status"] = function ($c) {
         return new \ILIAS\Setup\CLI\StatusCommand(
-            $c["agent"]
+            $c["agent_finder"]
         );
     };
 
@@ -108,21 +97,6 @@ function build_container_for_setup(string $executed_in_directory)
         ];
     };
 
-    $c["agent"] = function ($c) {
-        return function () use ($c) {
-            return new ILIAS\Setup\AgentCollection(
-                $c["refinery"],
-                $c["agents"]
-            );
-        };
-    };
-
-    $c["agent_finder"] = function ($c) {
-        return new ILIAS\Setup\ImplementationOfInterfaceFinder(
-            ILIAS\Setup\Agent::class
-        );
-    };
-
     $c["common_agent"] = function ($c) {
         return new \ilSetupAgent(
             $c["refinery"],
@@ -130,25 +104,16 @@ function build_container_for_setup(string $executed_in_directory)
         );
     };
 
-    $c["agents"] = function ($c) {
-        $agents["common"] = $c["common_agent"];
-        foreach ($c["agent_finder"]->getMatchingClassNames() as $cls) {
-            if (preg_match("/ILIAS\\\\Setup\\\\.*/", $cls)) {
-                continue;
-            }
-            $name = get_agent_name_by_class($cls);
-            if (isset($agents[$name])) {
-                throw new \RuntimeException(
-                    "Encountered duplicate agent $name in $cls"
-                );
-            }
-            $agents[strtolower($name)] = new $cls(
-                $c["refinery"],
-                $c["data_factory"],
-                $c["lng"]
-            );
-        };
-        return $agents;
+    $c["agent_finder"] = function ($c) {
+        return new ILIAS\Setup\ImplementationOfAgentFinder(
+            $c["refinery"],
+            $c["data_factory"],
+            $c["lng"],
+            $c["interface_finder"],
+            [
+                "common" => $c["common_agent"]
+            ]
+        );
     };
 
     $c["refinery"] = function ($c) {
@@ -170,6 +135,10 @@ function build_container_for_setup(string $executed_in_directory)
         return new \ILIAS\Setup\CLI\ConfigReader(
             $executed_in_directory
         );
+    };
+
+    $c["interface_finder"] = function ($c) {
+        return new \ILIAS\Setup\ImplementationOfInterfaceFinder();
     };
 
     return $c;

--- a/setup/cli.php
+++ b/setup/cli.php
@@ -110,6 +110,7 @@ function build_container_for_setup(string $executed_in_directory)
             $c["data_factory"],
             $c["lng"],
             $c["interface_finder"],
+            $c["plugin_raw_reader"],
             [
                 "common" => $c["common_agent"]
             ]
@@ -139,6 +140,10 @@ function build_container_for_setup(string $executed_in_directory)
 
     $c["interface_finder"] = function ($c) {
         return new \ILIAS\Setup\ImplementationOfInterfaceFinder();
+    };
+
+    $c["plugin_raw_reader"] = function ($c) {
+        return new \ilPluginRawReader();
     };
 
     return $c;

--- a/src/Setup/AgentCollection.php
+++ b/src/Setup/AgentCollection.php
@@ -45,6 +45,16 @@ class AgentCollection implements Agent
         return $clone;
     }
 
+    public function withAdditionalAgent(string $key, Agent $agent) : AgentCollection
+    {
+        if (isset($this->agents[$key])) {
+            throw new \LogicException("An agent with the name '$name' already exists.");
+        }
+        $clone = clone $this;
+        $clone->agents[$key] = $agent;
+        return $clone;
+    }
+
     /**
      * @inheritdocs
      */

--- a/src/Setup/AgentCollection.php
+++ b/src/Setup/AgentCollection.php
@@ -8,6 +8,7 @@ use ILIAS\UI\Component\Input\Field\Factory as FieldFactory;
 use ILIAS\UI\Component\Input\Field\Input as Input;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Refinery\Transformation;
+use Symfony\Component\Mime\Exception\LogicException;
 
 /**
  * An agent that is just a collection of some other agents.
@@ -35,6 +36,13 @@ class AgentCollection implements Agent
     public function getAgent(string $key) : ?Agent
     {
         return $this->agents[$key] ?? null;
+    }
+
+    public function withRemovedAgent(string $key) : AgentCollection
+    {
+        $clone = clone $this;
+        unset($clone->agents[$key]);
+        return $clone;
     }
 
     /**
@@ -167,15 +175,6 @@ class AgentCollection implements Agent
             throw new \InvalidArgumentException(
                 "Expected ConfigCollection for configuration."
             );
-        }
-    }
-
-    protected function getAgentsWithConfig() : \Traversable
-    {
-        foreach ($this->agents as $k => $c) {
-            if ($c->hasConfig()) {
-                yield $k => $c;
-            }
         }
     }
 }

--- a/src/Setup/AgentFinder.php
+++ b/src/Setup/AgentFinder.php
@@ -1,0 +1,29 @@
+<?php
+/* Copyright (c) 2020 Daniel Weise <daniel.weise@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+declare(strict_types=1);
+
+namespace ILIAS\Setup;
+
+interface AgentFinder
+{
+    /**
+     * Collect all agents from the system, core and plugin, bundled in a collection.
+     */
+    public function getAgents() : AgentCollection;
+
+    /**
+     * Collect core agents from the system bundled in a collection.
+     */
+    public function getCoreAgents() : AgentCollection;
+    
+    /**
+     * Get a agent from a specific plugin.
+     *
+     * If there is no plugin agent, this would the default agent.
+     * If the plugin contains multiple agents, these will be collected.
+     *
+     * @param string $name of the plugin to get the agent from
+     */
+    public function getPluginAgent(string $name) : Agent;
+}

--- a/src/Setup/CLI/BuildArtifactsCommand.php
+++ b/src/Setup/CLI/BuildArtifactsCommand.php
@@ -6,16 +6,11 @@ namespace ILIAS\Setup\CLI;
 use ILIAS\Setup\Agent;
 use ILIAS\Setup\AgentFinder;
 use ILIAS\Setup\ArrayEnvironment;
-use ILIAS\Setup\Config;
 use ILIAS\Setup\Environment;
-use ILIAS\Setup\Objective;
-use ILIAS\Setup\ObjectiveCollection;
-use ILIAS\Setup\ObjectiveWithPreconditions;
 use ILIAS\Setup\NoConfirmationException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
 /**

--- a/src/Setup/CLI/BuildArtifactsCommand.php
+++ b/src/Setup/CLI/BuildArtifactsCommand.php
@@ -4,6 +4,7 @@
 namespace ILIAS\Setup\CLI;
 
 use ILIAS\Setup\Agent;
+use ILIAS\Setup\AgentFinder;
 use ILIAS\Setup\ArrayEnvironment;
 use ILIAS\Setup\Config;
 use ILIAS\Setup\Environment;
@@ -27,19 +28,17 @@ class BuildArtifactsCommand extends Command
 
     protected static $defaultName = "build-artifacts";
 
-    /**
-     * @var callable $lazy_agent must return a Setup\Agent
-     */
-    public function __construct(callable $lazy_agent)
+    public function __construct(AgentFinder $agent_finder)
     {
         parent::__construct();
-        $this->lazy_agent = $lazy_agent;
+        $this->agent_finder = $agent_finder;
     }
 
     public function configure()
     {
         $this->setDescription("Build static artifacts from source");
         $this->addOption("yes", "y", InputOption::VALUE_NONE, "Confirm every message of the setup.");
+        $this->configureCommandForPlugins();
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
@@ -48,7 +47,7 @@ class BuildArtifactsCommand extends Command
         $io->printLicenseMessage();
         $io->title("Building Static Artifacts for ILIAS");
 
-        $agent = $this->getAgent();
+        $agent = $this->getRelevantAgent($input);
 
         $objective = $agent->getBuildArtifactObjective();
 

--- a/src/Setup/CLI/ObjectiveHelper.php
+++ b/src/Setup/CLI/ObjectiveHelper.php
@@ -6,6 +6,7 @@ namespace ILIAS\Setup\CLI;
 use ILIAS\Setup\Objective;
 use ILIAS\Setup\Environment;
 use ILIAS\Setup\ObjectiveIterator;
+use ILIAS\Setup\UnachievableException;
 
 /**
  * Add this to an Command that has wants to achieve objectives.
@@ -31,14 +32,14 @@ trait ObjectiveHelper
             try {
                 $environment = $current->achieve($environment);
                 if ($io) {
-                    $io->finishedLastObjective($current->getLabel(), $current->isNotable());
+                    $io->finishedLastObjective();
                 }
                 $iterator->setEnvironment($environment);
             } catch (UnachievableException $e) {
                 $iterator->markAsFailed($current);
                 if ($io) {
                     $io->error($e->getMessage());
-                    $io->failedLastObjective($current->getLabel());
+                    $io->failedLastObjective();
                 }
             }
             $iterator->next();

--- a/src/Setup/CLI/StatusCommand.php
+++ b/src/Setup/CLI/StatusCommand.php
@@ -3,7 +3,7 @@
 
 namespace ILIAS\Setup\CLI;
 
-use ILIAS\Setup\Agent;
+use ILIAS\Setup\AgentFinder;
 use ILIAS\Setup\ArrayEnvironment;
 use ILIAS\Setup\Config;
 use ILIAS\Setup\Environment;
@@ -28,18 +28,16 @@ class StatusCommand extends Command
 
     protected static $defaultName = "status";
 
-    /**
-     * @var callable $lazy_agent must return a Setup\Agent
-     */
-    public function __construct(callable $lazy_agent)
+    public function __construct(AgentFinder $agent_finder)
     {
         parent::__construct();
-        $this->lazy_agent = $lazy_agent;
+        $this->agent_finder = $agent_finder;
     }
 
     public function configure()
     {
         $this->setDescription("Collect and show status information about the installation.");
+        $this->configureCommandForPlugins();
     }
 
 
@@ -51,8 +49,9 @@ class StatusCommand extends Command
 
         $environment = new ArrayEnvironment([]);
         $storage = new Metrics\ArrayStorage();
+        $agent = $this->getRelevantAgent($input);
         $objective = new Tentatively(
-            $this->getAgent()->getStatusObjective($storage)
+            $agent->getStatusObjective($storage)
         );
 
         $this->achieveObjective($objective, $environment);

--- a/src/Setup/CLI/UpdateCommand.php
+++ b/src/Setup/CLI/UpdateCommand.php
@@ -1,9 +1,11 @@
-<?php
+<?php declare(strict_types=1);
+
 /* Copyright (c) 2016 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
 
 namespace ILIAS\Setup\CLI;
 
 use ILIAS\Setup\Agent;
+use ILIAS\Setup\AgentFinder;
 use ILIAS\Setup\ArrayEnvironment;
 use ILIAS\Setup\Config;
 use ILIAS\Setup\Environment;
@@ -34,13 +36,12 @@ class UpdateCommand extends Command
     protected $preconditions;
 
     /**
-     * @var callable $lazy_agent must return a Setup\Agent
      * @var Objective[] $preconditions will be achieved before command invocation
      */
-    public function __construct(callable $lazy_agent, ConfigReader $config_reader, array $preconditions)
+    public function __construct(AgentFinder $agent_finder, ConfigReader $config_reader, array $preconditions)
     {
         parent::__construct();
-        $this->lazy_agent = $lazy_agent;
+        $this->agent_finder = $agent_finder;
         $this->config_reader = $config_reader;
         $this->preconditions = $preconditions;
     }
@@ -52,6 +53,7 @@ class UpdateCommand extends Command
         $this->addOption("config", null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, "Define fields in the configuration file that should be overwritten, e.g. \"a.b.c=foo\"", []);
         $this->addOption("ignore-db-update-messages", null, InputOption::VALUE_NONE, "Ignore messages from the database update steps.");
         $this->addOption("yes", "y", InputOption::VALUE_NONE, "Confirm every message of the update.");
+        $this->configureCommandForPlugins();
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
@@ -66,7 +68,7 @@ class UpdateCommand extends Command
         $io->printLicenseMessage();
         $io->title("Update ILIAS");
 
-        $agent = $this->getAgent();
+        $agent = $this->getRelevantAgent($input);
 
         if ($input->getArgument("config")) {
             $config = $this->readAgentConfig($agent, $input);

--- a/src/Setup/CLI/UpdateCommand.php
+++ b/src/Setup/CLI/UpdateCommand.php
@@ -4,13 +4,10 @@
 
 namespace ILIAS\Setup\CLI;
 
-use ILIAS\Setup\Agent;
 use ILIAS\Setup\AgentFinder;
 use ILIAS\Setup\ArrayEnvironment;
-use ILIAS\Setup\Config;
 use ILIAS\Setup\Environment;
 use ILIAS\Setup\Objective;
-use ILIAS\Setup\ObjectiveCollection;
 use ILIAS\Setup\Objective\ObjectiveWithPreconditions;
 use ILIAS\Setup\NoConfirmationException;
 use Symfony\Component\Console\Command\Command;

--- a/src/Setup/Environment.php
+++ b/src/Setup/Environment.php
@@ -18,6 +18,7 @@ interface Environment
     const RESOURCE_CLIENT_INI = "resource_client_ini";
     const RESOURCE_SETTINGS_FACTORY = "resource_settings_factory";
     const RESOURCE_CLIENT_ID = "resource_client_id";
+    const RESOURCE_PLUGIN_ADMIN = "resource_plugin_admin";
 
     /**
      * Consumers of this method should check if the result is what they expect,

--- a/src/Setup/ImplementationOfAgentFinder.php
+++ b/src/Setup/ImplementationOfAgentFinder.php
@@ -1,0 +1,144 @@
+<?php
+
+/* Copyright (c) 2020 Daniel Weise <daniel.weise@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+declare(strict_types=1);
+
+namespace ILIAS\Setup;
+
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Data;
+use ILIAS\UI\Component\Input\Field\Factory as FieldFactory;
+use ilSetupLanguage;
+
+class ImplementationOfAgentFinder implements AgentFinder
+{
+    /**
+     * @var Refinery|null
+     */
+    protected $refinery;
+
+    /**
+     * @var Data\Factory|null
+     */
+    protected $data_factory;
+
+    /**
+     * @var \ilSetupLanguage
+     */
+    protected $lng;
+
+    /**
+     * @var \ilPluginRawReader|null
+     */
+    //protected $plugin_raw_reader;
+
+    /**
+     * @var ImplementationOfInterfaceFinder|null
+     */
+    protected $interface_finder;
+
+    /**
+     * @var array<string, Setup\Agent> $predefined_agents
+     */
+    protected $predefined_agents;
+    
+    /**
+     * @var array<string, Setup\Agent> $predefined_agents
+     */
+    public function __construct(
+        Refinery $refinery,
+        Data\Factory $data_factory,
+        \ilSetupLanguage $lng,
+        ImplementationOfInterfaceFinder $interface_finder,
+        //\ilPluginRawReader $plugin_raw_reader,
+        array $predefined_agents = []
+    ) {
+        $this->refinery = $refinery;
+        $this->data_factory = $data_factory;
+        $this->lng = $lng;
+        $this->interface_finder = $interface_finder;
+        //$this->plugin_raw_reader = $plugin_raw_reader;
+        $this->predefined_agents = $predefined_agents;
+    }
+
+    /**
+     * Collect all agents from the system, core and plugin, bundled in a collection.
+     *
+     * @param string[]  $ignore folders to be ignored.
+     */
+    public function getAgents() : AgentCollection
+    {
+        $agents = $this->getCoreAgents();
+
+        // Get a list of existing plugins in the system.
+        $plugins = [];
+
+        foreach ($plugins as $plugin_name) {
+            $agents = $agents->withAdditionalAgent(
+                strtolower($plugin_name),
+                $this->getPluginAgent($plugin_name)
+            );
+        }
+
+        return $agents;
+    }
+
+
+    /**
+     * Collect core agents from the system bundled in a collection.
+     */
+    public function getCoreAgents() : AgentCollection
+    {
+        // Initialize the agents.
+        $agents = new AgentCollection(
+            $this->refinery,
+            $this->predefined_agents
+        );
+
+        // This is a list of all agent classes in the system (which we don't want to ignore).
+        $agent_classes = $this->interface_finder->getMatchingClassNames(
+            Agent::class,
+            ["[/]Customizing/.*]"]
+        );
+        foreach ($agent_classes as $class_name) {
+            $agents = $agents->withAdditionalAgent(
+                $this->getAgentNameByClassName($class_name),
+                new $class_name(
+                    $this->refinery,
+                    $this->data_factory,
+                    $this->lng
+                )
+            );
+        }
+
+        return $agents;
+    }
+    
+    /**
+     * Get a agent from a specific plugin.
+     *
+     * If there is no plugin agent, this would the default agent.
+     * If the plugin contains multiple agents, these will be collected.
+     *
+     * @param string $name of the plugin to get the agent from
+     */
+    public function getPluginAgent(string $name) : Agent
+    {
+        throw new \LogicException("Not yet implemented.");
+    }
+
+    /**
+     * Derive a name for the agent based on a class name.
+     */
+    protected function getAgentNameByClassName(string $class_name) : string
+    {
+        // We assume that the name of an agent in the class ilXYZSetupAgent really
+        // is XYZ. If that does not fit we just use the class name.
+        $match = [];
+        if (preg_match("/il(\w+)SetupAgent/", $class_name, $match)) {
+            return strtolower($match[1]);
+        }
+        return $class_name;
+    }
+}

--- a/src/Setup/ImplementationOfInterfaceFinder.php
+++ b/src/Setup/ImplementationOfInterfaceFinder.php
@@ -9,42 +9,67 @@ namespace ILIAS\Setup;
  */
 class ImplementationOfInterfaceFinder
 {
-
     /**
      * @var string
      */
-    private $interface = "";
+    protected $root;
+
     /**
-     * @var array
+     * @var string[]
      */
-    private $ignore
-        = [
-            '.*/Customizing/',
-            '.*/libs/',
-            '.*/test/',
-            '.*/tests/',
-            '.*/setup/',
-            // Classes using removed Auth-class from PEAR
-            '.*ilSOAPAuth.*',
-            // Classes using unknown
-            '.*ilPDExternalFeedBlockGUI.*',
-        ];
+    protected $ignore = [
+        '.*/libs/',
+        '.*/test/',
+        '.*/tests/',
+        '.*/setup/',
+        // Classes using removed Auth-class from PEAR
+        '.*ilSOAPAuth.*',
+        // Classes using unknown
+        '.*ilPDExternalFeedBlockGUI.*',
+    ];
 
+    /**
+     * @var string[]|null
+     */
+    protected $classmap = null;
 
-    public function __construct(string $interface)
+    public function __construct()
     {
-        $this->interface = $interface;
-        $this->getAllClassNames();
+        $this->root = substr(__FILE__, 0, strpos(__FILE__, "/src"));
+        $this->classmap = include "./libs/composer/vendor/composer/autoload_classmap.php";
     }
 
-
-    protected function getAllClassNames() : \Iterator
+    /**
+     * The matcher finds the class names implementing the given interface, while
+     * ignoring paths in self::$ignore and and the additional patterns provided.
+     *
+     * Patterns are regexps (without delimiters) to define complete paths on the
+     * filesystem to be ignored.
+     *
+     * @param   string[] $additional_ignore
+     */
+    public function getMatchingClassNames(string $interface, array $additional_ignore = []) : \Iterator
     {
-        // We use the composer classmap ATM
-        $composer_classmap = include "./libs/composer/vendor/composer/autoload_classmap.php";
-        $root = substr(__FILE__, 0, strpos(__FILE__, "/src"));
+        foreach ($this->getAllClassNames($additional_ignore) as $class_name) {
+            try {
+                $r = new \ReflectionClass($class_name);
+                if ($r->isInstantiable() && $r->implementsInterface($interface)) {
+                    yield $class_name;
+                }
+            } catch (\Throwable $e) {
+                // noting to do here
+            }
+        }
+    }
 
-        if (!is_array($composer_classmap)) {
+    /**
+     * @param   string[] $additional_ignore
+     */
+    protected function getAllClassNames(array $additional_ignore) : \Iterator
+    {
+        $ignore = array_merge($this->ignore, $additional_ignore);
+
+        if (!is_array($this->classmap)) {
             throw new \LogicException("Composer ClassMap not loaded");
         }
 
@@ -55,29 +80,14 @@ class ImplementationOfInterfaceFinder
                 function ($v) {
                     return "(" . str_replace('/', '(/|\\\\)', $v) . ")";
                 },
-                $this->ignore
+                $ignore
             )
         );
 
-        foreach ($composer_classmap as $class_name => $file_path) {
-            $path = str_replace($root, "", realpath($file_path));
+        foreach ($this->classmap as $class_name => $file_path) {
+            $path = str_replace($this->root, "", realpath($file_path));
             if (!preg_match("#^" . $regexp . "$#", $path)) {
                 yield $class_name;
-            }
-        }
-    }
-
-
-    public function getMatchingClassNames() : \Iterator
-    {
-        foreach ($this->getAllClassNames() as $class_name) {
-            try {
-                $r = new \ReflectionClass($class_name);
-                if ($r->isInstantiable() && $r->implementsInterface($this->interface)) {
-                    yield $class_name;
-                }
-            } catch (\Throwable $e) {
-                // noting to do here
             }
         }
     }

--- a/src/Setup/ImplementationOfInterfaceFinder.php
+++ b/src/Setup/ImplementationOfInterfaceFinder.php
@@ -18,6 +18,7 @@ class ImplementationOfInterfaceFinder
      * @var string[]
      */
     protected $ignore = [
+        '.*/src/',
         '.*/libs/',
         '.*/test/',
         '.*/tests/',
@@ -83,6 +84,7 @@ class ImplementationOfInterfaceFinder
                 $ignore
             )
         );
+
 
         foreach ($this->classmap as $class_name => $file_path) {
             $path = str_replace($this->root, "", realpath($file_path));

--- a/src/Setup/Objective.php
+++ b/src/Setup/Objective.php
@@ -58,7 +58,8 @@ interface Objective
     /**
      * Get to know whether the objective is applicable.
      *
-     * Don't change the environment or act on services in the environment.
+     * Don't change the environment or cause changes on services in the environment.
+     * Just check if this objective needs to be achieved, either currently or at all.
      * In case of doubt whether the objective is applicable or not return true.
      */
     public function isApplicable(Environment $environment) : bool;

--- a/tests/Setup/AgentCollectionTest.php
+++ b/tests/Setup/AgentCollectionTest.php
@@ -303,4 +303,34 @@ class AgentCollectionTest extends TestCase
         $this->assertSame($c4, $cb->getAgent("c4"));
         $this->assertNull($cb->getAgent("c5"));
     }
+
+    public function testWithAdditionalAgent()
+    {
+        $refinery = $this->createMock(Refinery::class);
+
+        $c1 = $this->newAgent();
+        $c2 = $this->newAgent();
+        $c3 = $this->newAgent();
+        $c4 = $this->newAgent();
+
+        $ca = new Setup\AgentCollection(
+            $refinery,
+            ["c1" => $c1, "c2" => $c2, "c3" => $c3]
+        );
+        $cb = $ca->withAdditionalAgent("c4", $c4);
+
+        $this->assertNotSame($ca, $cb);
+
+        $this->assertSame($c1, $ca->getAgent("c1"));
+        $this->assertSame($c2, $ca->getAgent("c2"));
+        $this->assertSame($c3, $ca->getAgent("c3"));
+        $this->assertNull($ca->getAgent("c4"));
+        $this->assertNull($ca->getAgent("c5"));
+
+        $this->assertSame($c1, $cb->getAgent("c1"));
+        $this->assertSame($c2, $cb->getAgent("c2"));
+        $this->assertSame($c3, $cb->getAgent("c3"));
+        $this->assertSame($c4, $cb->getAgent("c4"));
+        $this->assertNull($cb->getAgent("c5"));
+    }
 }

--- a/tests/Setup/AgentCollectionTest.php
+++ b/tests/Setup/AgentCollectionTest.php
@@ -146,7 +146,6 @@ class AgentCollectionTest extends TestCase
         $this->assertEquals($conf3, $conf->getConfig("c3"));
     }
 
-
     public function testGetInstallObjective() : void
     {
         $refinery = new Refinery($this->createMock(DataFactory::class), $this->createMock(\ilLanguage::class));
@@ -273,5 +272,35 @@ class AgentCollectionTest extends TestCase
         $this->assertSame($c3, $c->getAgent("c3"));
         $this->assertSame($c4, $c->getAgent("c4"));
         $this->assertNull($c->getAgent("c5"));
+    }
+
+    public function testWithRemovedAgent()
+    {
+        $refinery = $this->createMock(Refinery::class);
+
+        $c1 = $this->newAgent();
+        $c2 = $this->newAgent();
+        $c3 = $this->newAgent();
+        $c4 = $this->newAgent();
+
+        $ca = new Setup\AgentCollection(
+            $refinery,
+            ["c1" => $c1, "c2" => $c2, "c3" => $c3, "c4" => $c4]
+        );
+        $cb = $ca->withRemovedAgent("c2");
+
+        $this->assertNotSame($ca, $cb);
+
+        $this->assertSame($c1, $ca->getAgent("c1"));
+        $this->assertSame($c2, $ca->getAgent("c2"));
+        $this->assertSame($c3, $ca->getAgent("c3"));
+        $this->assertSame($c4, $ca->getAgent("c4"));
+        $this->assertNull($ca->getAgent("c5"));
+
+        $this->assertSame($c1, $cb->getAgent("c1"));
+        $this->assertNull($cb->getAgent("c2"));
+        $this->assertSame($c3, $cb->getAgent("c3"));
+        $this->assertSame($c4, $cb->getAgent("c4"));
+        $this->assertNull($cb->getAgent("c5"));
     }
 }

--- a/tests/Setup/CLI/BuildArtifactsCommandTest.php
+++ b/tests/Setup/CLI/BuildArtifactsCommandTest.php
@@ -12,17 +12,16 @@ class BuildArtifactsCommandTest extends TestCase
 {
     public function testBasicFunctionality() : void
     {
-        $agent = $this->createMock(Setup\Agent::class);
-        $config_reader = $this->createMock(Setup\CLI\ConfigReader::class);
-        $command = new Setup\CLI\BuildArtifactsCommand(function () use ($agent) {
-            return $agent;
-        });
+        $agent_finder = $this->createMock(Setup\AgentFinder::class);
 
-        $tester = new CommandTester($command);
+        $agent = $this->createMock(Setup\AgentCollection::class);
+        $agent_finder
+            ->expects($this->once())
+            ->method("getAgents")
+            ->with()
+            ->willReturn($agent);
 
         $objective = $this->createMock(Setup\Objective::class);
-        $env = $this->createMock(Setup\Environment::class);
-
         $agent
             ->expects($this->once())
             ->method("getBuildArtifactObjective")
@@ -37,14 +36,17 @@ class BuildArtifactsCommandTest extends TestCase
         $objective
             ->expects($this->once())
             ->method("achieve")
-            ->willReturn($env);
+            ->will($this->returnCallback(function (Setup\Environment $e) {
+                return $e;
+            }));
 
         $objective
             ->expects($this->once())
             ->method("isApplicable")
             ->willReturn(true);
 
-        $tester->execute([
-        ]);
+        $command = new Setup\CLI\BuildArtifactsCommand($agent_finder);
+        $tester = new CommandTester($command);
+        $tester->execute([]);
     }
 }

--- a/tests/Setup/CLI/HasAgentTest.php
+++ b/tests/Setup/CLI/HasAgentTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/* Copyright (c) 2019 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Tests\Setup\CLI;
+
+use ILIAS\Setup\AgentFinder;
+use ILIAS\Setup\AgentCollection;
+use ILIAS\Setup\CLI\HasAgent;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\InputInterface;
+
+class HasAgentTest extends TestCase
+{
+    public function setUp() : void
+    {
+        $this->agent_finder = $this->createMock(AgentFinder::class);
+        $this->has_agent = new class($this->agent_finder) {
+            use HasAgent;
+            public function __construct($af)
+            {
+                $this->agent_finder = $af;
+            }
+
+            public function _getRelevantAgent($i)
+            {
+                return $this->getRelevantAgent($i);
+            }
+        };
+    }
+
+    public function testGetRelevantAgentWithoutOption()
+    {
+        $ii = $this->createMock(InputInterface::class);
+        $ac = $this->createMock(AgentCollection::class);
+
+        $ii
+            ->method("getOption")
+            ->willReturn(null);
+
+        $this->agent_finder
+            ->expects($this->once())
+            ->method("getAgents")
+            ->with()
+            ->willReturn($ac);
+
+        $agent = $this->has_agent->_getRelevantAgent($ii);
+
+        $this->assertEquals($ac, $agent);
+    }
+
+    public function testGetRelevantAgentWithNoPluginOption()
+    {
+        $ii = $this->createMock(InputInterface::class);
+        $ac = $this->createMock(AgentCollection::class);
+
+        $ii
+            ->method("getOption")
+            ->will($this->returnValueMap([
+                ["no-plugins", true],
+                ["skip", null]
+            ]));
+
+        $this->agent_finder
+            ->expects($this->once())
+            ->method("getCoreAgents")
+            ->with()
+            ->willReturn($ac);
+
+        $agent = $this->has_agent->_getRelevantAgent($ii);
+
+        $this->assertEquals($ac, $agent);
+    }
+
+    public function testGetRelevantAgentWithPluginNameOptions()
+    {
+        $ii = $this->createMock(InputInterface::class);
+        $ac = $this->createMock(AgentCollection::class);
+
+        $ii
+            ->method("getOption")
+            ->will($this->returnValueMap([
+                ["no-plugins", null],
+                ["skip", null]
+            ]));
+
+        $ii
+            ->method("getArgument")
+            ->with("plugin-name")
+            ->willReturn("foobar");
+
+        $this->agent_finder
+            ->expects($this->once())
+            ->method("getPluginAgent")
+            ->with("foobar")
+            ->willReturn($ac);
+
+        $agent = $this->has_agent->_getRelevantAgent($ii);
+
+        $this->assertEquals($ac, $agent);
+    }
+}

--- a/tests/Setup/CLI/InstallCommandTest.php
+++ b/tests/Setup/CLI/InstallCommandTest.php
@@ -26,11 +26,10 @@ class InstallCommandTest extends TestCase
     {
         $refinery = new Refinery($this->createMock(DataFactory::class), $this->createMock(\ilLanguage::class));
 
-        $agent = $this->createMock(Setup\Agent::class);
+        $agent = $this->createMock(Setup\AgentCollection::class);
         $config_reader = $this->createMock(Setup\CLI\ConfigReader::class);
-        $command = new Setup\CLI\InstallCommand(function () use ($agent) {
-            return $agent;
-        }, $config_reader, []);
+        $agent_finder = $this->createMock(Setup\AgentFinder::class);
+        $command = new Setup\CLI\InstallCommand($agent_finder, $config_reader, []);
 
         $tester = new CommandTester($command);
 
@@ -62,6 +61,12 @@ class InstallCommandTest extends TestCase
                     return "client_id";
                 }
             });
+
+        $agent_finder
+            ->expects($this->once())
+            ->method("getAgents")
+            ->with()
+            ->willReturn($agent);
 
         $agent
             ->expects($this->once())

--- a/tests/Setup/CLI/UpdateCommandTest.php
+++ b/tests/Setup/CLI/UpdateCommandTest.php
@@ -25,15 +25,14 @@ class UpdateCommandTest extends TestCase
     {
         $refinery = new Refinery($this->createMock(DataFactory::class), $this->createMock(\ilLanguage::class));
 
-        $agent = $this->createMock(Setup\Agent::class);
+        $agent = $this->createMock(Setup\AgentCollection::class);
         $config_reader = $this->createMock(Setup\CLI\ConfigReader::class);
-        $command = new Setup\CLI\UpdateCommand(function () use ($agent) {
-            return $agent;
-        }, $config_reader, []);
+        $agent_finder = $this->createMock(Setup\AgentFinder::class);
+        $command = new Setup\CLI\UpdateCommand($agent_finder, $config_reader, []);
 
         $tester = new CommandTester($command);
 
-        $config = $this->createMock(Setup\Config::class);
+        $config = $this->createMock(Setup\ConfigCollection::class);
         $config_file = "config_file";
         $config_file_content = ["config_file"];
 
@@ -45,6 +44,12 @@ class UpdateCommandTest extends TestCase
             ->method("readConfigFile")
             ->with($config_file)
             ->willReturn($config_file_content);
+
+        $agent_finder
+            ->expects($this->once())
+            ->method("getAgents")
+            ->with()
+            ->willReturn($agent);
 
         $agent
             ->expects($this->once())

--- a/tests/Setup/ImplementationOfInterfaceFinderTest.php
+++ b/tests/Setup/ImplementationOfInterfaceFinderTest.php
@@ -11,7 +11,7 @@ class ImplementationOfInterfaceFinderForTest extends ImplementationOfInterfaceFi
 {
     public $class_names = [];
 
-    protected function getAllClassNames() : \Iterator
+    protected function getAllClassNames(array $additional_ignore) : \Iterator
     {
         foreach ($this->class_names as $name) {
             yield $name;
@@ -42,40 +42,40 @@ class ImplementationOfInterfaceFinderTest extends TestCase
 {
     public function testWithTestInterface1()
     {
-        $finder = new ImplementationOfInterfaceFinderForTest(TestInterface1::class);
+        $finder = new ImplementationOfInterfaceFinderForTest();
         $finder->class_names = [
             TestClass1::class,
             TestClass2::class,
             TestClass3::class
         ];
         $expected = [TestClass1::class, TestClass3::class];
-        $result = iterator_to_array($finder->getMatchingClassNames());
+        $result = iterator_to_array($finder->getMatchingClassNames(TestInterface1::class));
         $this->assertEquals($expected, $result);
     }
 
     public function testWithTestInterface2()
     {
-        $finder = new ImplementationOfInterfaceFinderForTest(TestInterface2::class);
+        $finder = new ImplementationOfInterfaceFinderForTest();
         $finder->class_names = [
             TestClass1::class,
             TestClass2::class,
             TestClass3::class
         ];
         $expected = [TestClass2::class, TestClass3::class];
-        $result = iterator_to_array($finder->getMatchingClassNames());
+        $result = iterator_to_array($finder->getMatchingClassNames(TestInterface2::class));
         $this->assertEquals($expected, $result);
     }
 
     public function testWithTestInterface3()
     {
-        $finder = new ImplementationOfInterfaceFinderForTest(TestInterface3::class);
+        $finder = new ImplementationOfInterfaceFinderForTest();
         $finder->class_names = [
             TestClass1::class,
             TestClass2::class,
             TestClass3::class
         ];
         $expected = [];
-        $result = iterator_to_array($finder->getMatchingClassNames());
+        $result = iterator_to_array($finder->getMatchingClassNames(TestInterface3::class));
         $this->assertEquals($expected, $result);
     }
 }


### PR DESCRIPTION
Add new options and arguments for the commands install and update:

- install                          -> will setup an ILIAS-Instance including plugins
- install --no_plugins     -> will setup an ILIAS-Instance without plugins
- install plugin_name    -> will setup the plugin plugin_name

- update                          -> will update an ILIAS-Instance including plugins
- update --no_plugins     -> will update an ILIAS-Instance without plugins
- update plugin_name    -> will update the plugin plugin_name

Add option and functionality depending on [JourFix Discusion Point 9](https://docu.ilias.de/goto.php?target=wiki_1357_Setup_-_Update_Plugins_via_Setup):

- install --skip plugin_name    -> will setup an ILIAS-Instance excluding selected plugin/s
- update --skip plugin_name  -> will update an ILIAS-Instance excluding selected plugin/s

- add a flag for plugin.php  'ignore_cli_setup'. Default or not set in plugin.php results in value false.