### PR TITLE
Imprint: get rid of template in method renderFullScreen (#28716)

### DIFF
--- a/Services/Imprint/classes/class.ilImprintGUI.php
+++ b/Services/Imprint/classes/class.ilImprintGUI.php
@@ -113,31 +113,22 @@ class ilImprintGUI extends ilPageObjectGUI
         
         return $a_output;
     }
-    
+
     protected function renderFullscreen()
     {
         $tpl = $this->tpl;
         $lng = $this->lng;
-        $ilMainMenu = $this->main_menu;
-        
+
         if (!ilImprint::isActive()) {
             ilUtil::redirect("ilias.php?baseClass=ilDashboardGUI");
         }
-        
+        $tpl->setTitle($lng->txt("imprint"));
         $tpl->loadStandardTemplate();
-        
+
         $this->setRawPageContent(true);
         $html = $this->showPage();
-        
-        $itpl = new ilTemplate("tpl.imprint.html", true, true, "Services/Imprint");
-        $itpl->setVariable("PAGE_TITLE", $lng->txt("imprint"));
-        $itpl->setVariable("IMPRINT", $html);
-        unset($html);
-        
-        $tpl->setContent($itpl->get());
-        
-        $ilMainMenu->showLogoOnly(true);
-        
+        $tpl->setContent($html);
+
         $tpl->printToStdout("DEFAULT", true, false);
         exit();
     }

--- a/Services/Imprint/templates/default/tpl.imprint.html
+++ b/Services/Imprint/templates/default/tpl.imprint.html
@@ -1,2 +1,0 @@
-<h1 class="ilc_page_title_PageTitle">{PAGE_TITLE}</h1>
-{IMPRINT}


### PR DESCRIPTION
If one opens the "Imprint" in the footer in ILIAS 6 (e.g. on test6.ilias.de) the title of the browser tab goes missing. This fixes that issue and also removes an outdated template.

https://mantis.ilias.de/view.php?id=28716