### PR TITLE
Missing plural in german Lang-File

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -15337,7 +15337,7 @@ task#:#task_derived_tasks#:#To-Do
 task#:#task_tasks_with_deadline#:#Mit Endtermin
 task#:#task_tasks_without_deadline#:#Ohne Endtermin
 task#:#task_deadline#:#Ende
-task#:#task_no_tasks#:#Sie haben derzeit keine offenen To-Do.
+task#:#task_no_tasks#:#Sie haben derzeit keine offenen To-Dos.
 task#:#task_start#:#Beginn
 task#:#task_task#:#Aufgabe
 task#:#task_details#:#Details


### PR DESCRIPTION
Small language error. Would need to be fixed in all supported Versions.