### PR TITLE
ScormAICC: fix js-error that breaks loading of wbts

### DIFF
--- a/Modules/ScormAicc/scripts/basisAPI.js
+++ b/Modules/ScormAicc/scripts/basisAPI.js
@@ -78,7 +78,7 @@ function sendRequest (url, data, callback, user, password, headers) {
 	
 	function useSendBeacon() {
 		if (navigator.userAgent.indexOf("Chrome") > -1) {
-			if (typeof(window.sahs_content.event) != "undefined" && (window.sahs_content.event.type=="unload" || window.sahs_content.event.type=="beforeunload")) {
+			if (typeof(window.sahs_content) != "undefined" && typeof(window.sahs_content.event) != "undefined" && (window.sahs_content.event.type=="unload" || window.sahs_content.event.type=="beforeunload")) {
 				var raw = navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
 				var version = raw ? parseInt(raw[2], 10) : false;
 				if (version === false) return false;


### PR DESCRIPTION
Hi @Uwe-Kohnle,

we tested your fix f9bec0286ece536059a02b674b59699044723ece but haven't been able to load any WBT after applying it. We quickly found that loading of WBTs is broken since `window.sahs_content` is not defined at load time, which seems to make the loading process in JS stop.

After applying the attached fix the problem was gone and we found that 3 of 4 tested WBTs now work in Chrome 80+. I will try to find out why the missing WBT does not work and maybe get back with my findings.

Thanks and best regards!