### PR TITLE
RepositoryPlugins: Use permanent link for navigation history

### DIFF
--- a/Services/Repository/classes/class.ilObjectPluginGUI.php
+++ b/Services/Repository/classes/class.ilObjectPluginGUI.php
@@ -80,12 +80,11 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
                 $this->setAdminTabs();
             }
             
-            // add entry to navigation history
-            if ($ilAccess->checkAccess("read", "", $_GET["ref_id"])) {
+            if ($ilAccess->checkAccess('read', '', $this->object->getRefId())) {
                 $ilNavigationHistory->addItem(
-                    $_GET["ref_id"],
-                    $ilCtrl->getLinkTarget($this, $this->getStandardCmd()),
-                    $this->getType()
+                    $this->object->getRefId(),
+                    ilLink::_getLink($this->object->getRefId(), $this->object->getType()),
+                    $this->object->getType()
                 );
             }
         } else {


### PR DESCRIPTION
Instead of using an unstable ilCtrl link this PR changes
the storage of navigation history items by using
a permanent link instead.