### PR TITLE
UI/MainMenu: 28608 split preparation for ui presentation and filter a…

### DIFF
--- a/Services/MainMenu/classes/TypeHandler/class.ilMMTypeHandlerRepositoryLink.php
+++ b/Services/MainMenu/classes/TypeHandler/class.ilMMTypeHandlerRepositoryLink.php
@@ -33,7 +33,8 @@ class ilMMTypeHandlerRepositoryLink extends ilMMAbstractBaseTypeHandlerAction im
             $item = $item->withRefId($ref_id)
                 ->withVisibilityCallable(
                     function () use ($DIC, $ref_id) {
-                        return (bool) $DIC->access()->checkAccess('visible', '', $ref_id);
+                        return (bool) $DIC->access()->checkAccess('visible', '', $ref_id) &&
+                            $DIC->access()->checkAccess('read', '', $ref_id);
                     }
                 );
             // ->withAvailableCallable(

--- a/src/GlobalScreen/Collector/AbstractBaseCollector.php
+++ b/src/GlobalScreen/Collector/AbstractBaseCollector.php
@@ -35,8 +35,10 @@ abstract class AbstractBaseCollector implements Collector
     {
         if (!$this->hasBeenCollected()) {
             $this->collectStructure();
-            $this->filterItemsByVisibilty(false);
             $this->prepareItemsForUIRepresentation();
+            $this->filterItemsByVisibilty(false);
+            $this->cleanupItemsForUIRepresentation();
+            $this->sortItemsForUIRepresentation();
             $this->setCollected();
         }
     }

--- a/src/GlobalScreen/Scope/Layout/Collector/MainLayoutCollector.php
+++ b/src/GlobalScreen/Scope/Layout/Collector/MainLayoutCollector.php
@@ -161,6 +161,16 @@ class MainLayoutCollector extends AbstractBaseCollector
         // TODO: Implement prepareItemsForUIRepresentation() method.
     }
 
+    public function cleanupItemsForUIRepresentation() : void
+    {
+        // TODO: Implement cleanupItemsForUIRepresentation() method.
+    }
+
+    public function sortItemsForUIRepresentation() : void
+    {
+        // TODO: Implement sortItemsForUIRepresentation() method.
+    }
+
 
     /**
      * @inheritDoc

--- a/src/GlobalScreen/Scope/MainMenu/Collector/MainMenuMainCollector.php
+++ b/src/GlobalScreen/Scope/MainMenu/Collector/MainMenuMainCollector.php
@@ -54,10 +54,10 @@ class MainMenuMainCollector extends AbstractBaseCollector implements ItemCollect
      */
     public function __construct(array $providers, ItemInformation $information = null)
     {
-        $this->information                 = $information;
-        $this->providers                   = $providers;
+        $this->information = $information;
+        $this->providers = $providers;
         $this->type_information_collection = new TypeInformationCollection();
-        $this->map                         = new Map();
+        $this->map = new Map();
     }
 
     /**
@@ -155,7 +155,10 @@ class MainMenuMainCollector extends AbstractBaseCollector implements ItemCollect
             }
             return $item;
         });
+    }
 
+    public function cleanupItemsForUIRepresentation() : void
+    {
         // Remove not visible children
         $this->map->walk(function (isItem &$item) : isItem {
             if ($item instanceof isParent) {
@@ -176,7 +179,10 @@ class MainMenuMainCollector extends AbstractBaseCollector implements ItemCollect
 
             return true;
         });
+    }
 
+    public function sortItemsForUIRepresentation() : void
+    {
         $this->map->sort();
     }
 

--- a/src/GlobalScreen/Scope/MetaBar/Collector/MetaBarMainCollector.php
+++ b/src/GlobalScreen/Scope/MetaBar/Collector/MetaBarMainCollector.php
@@ -54,6 +54,16 @@ class MetaBarMainCollector extends AbstractBaseCollector implements ItemCollecto
 
     public function prepareItemsForUIRepresentation() : void
     {
+        // TODO: Implement prepareItemsForUIRepresentation() method.
+    }
+
+    public function cleanupItemsForUIRepresentation() : void
+    {
+        // TODO: Implement filterItemsByVisibilty() method.
+    }
+
+    public function sortItemsForUIRepresentation() : void
+    {
         $this->sortItems($this->items);
         array_walk($this->items, $this->getChildSorter());
     }

--- a/src/GlobalScreen/Scope/Notification/Collector/MainNotificationCollector.php
+++ b/src/GlobalScreen/Scope/Notification/Collector/MainNotificationCollector.php
@@ -67,6 +67,16 @@ class MainNotificationCollector extends AbstractBaseCollector implements ItemCol
         // TODO: Implement prepareItemsForUIRepresentation() method.
     }
 
+    public function cleanupItemsForUIRepresentation() : void
+    {
+        // TODO: Implement cleanupItemsForUIRepresentation() method.
+    }
+
+    public function sortItemsForUIRepresentation() : void
+    {
+        // TODO: Implement sortItemsForUIRepresentation() method.
+    }
+
 
     /**
      * @inheritDoc

--- a/src/GlobalScreen/Scope/Tool/Collector/MainToolCollector.php
+++ b/src/GlobalScreen/Scope/Tool/Collector/MainToolCollector.php
@@ -93,7 +93,15 @@ class MainToolCollector extends AbstractBaseCollector implements ItemCollector
         array_walk($this->tools, function (isToolItem $tool) {
             $this->applyTypeInformation($tool);
         });
+    }
 
+    public function cleanupItemsForUIRepresentation() : void
+    {
+        // TODO: Implement cleanupItemsForUIRepresentation() method.
+    }
+
+    public function sortItemsForUIRepresentation() : void
+    {
         usort($this->tools, $this->getItemSorter());
     }
 


### PR DESCRIPTION
…fter only prepairing

The closure to filter items by visibility was called only once, so the repository link was never filtered by the defined closure within the preparation for ui presentation.

So i splitted the preparation function in three steps.
1. Preparation: Still configures the items with ref id and new isVisible Closure.
2. Cleanup: Removes all parent items with empty children (Same as now)
3. Sorting: Sorts the items as it was (Same as now)

Complementary i moved the filter action after the preparation to execute all correctly defined Filter closures.