### PR TITLE
UI/Footer: Add interface changes to support shy buttons with modals

### DIFF
--- a/src/UI/Component/MainControls/Factory.php
+++ b/src/UI/Component/MainControls/Factory.php
@@ -312,12 +312,13 @@ interface Factory
      * ---
      * description:
      *   purpose: >
-     *     The Footer is a unique page section to accommodate links and shy buttons that
-     *     are not being used on a regular basis, such as links to the pages's
-     *     imprint or a privacy policy document.
+     *     The Footer is a unique page section to accommodate links and shy buttons
+     *     triggering Round Trip Modals that are not being used on a regular basis,
+     *     such as links to the pages's imprint or a privacy policy document.
      *
      *   composition: >
-     *     The Footer is composed of a list of links or shy buttons and an optional text-part.
+     *     The Footer is composed of a list of Links or Shy Buttons triggering
+     *     Round Trip Modals and an optional text-part.
      *
      * context:
      *   - The Footer is used with the Standard Page.
@@ -333,7 +334,7 @@ interface Factory
      *        it SHOULD have attached a permanent URL for the current page/object.
      * ----
      *
-     * @param  \ILIAS\UI\Component\Link\Standard[]|\ILIAS\UI\Component\Button\Shy[] $links
+     * @param  \ILIAS\UI\Component\Link\Standard[] $links
      * @param  string $text
      * @return  \ILIAS\UI\Component\MainControls\Footer
      */

--- a/src/UI/Component/MainControls/Factory.php
+++ b/src/UI/Component/MainControls/Factory.php
@@ -312,12 +312,12 @@ interface Factory
      * ---
      * description:
      *   purpose: >
-     *     The Footer is a unique page section to accomodate links that
+     *     The Footer is a unique page section to accommodate links and shy buttons that
      *     are not being used on a regular basis, such as links to the pages's
      *     imprint or a privacy policy document.
      *
      *   composition: >
-     *     The Footer is composed of a list of links and an optional text-part.
+     *     The Footer is composed of a list of links or shy buttons and an optional text-part.
      *
      * context:
      *   - The Footer is used with the Standard Page.
@@ -333,7 +333,7 @@ interface Factory
      *        it SHOULD have attached a permanent URL for the current page/object.
      * ----
      *
-     * @param  \ILIAS\UI\Component\Link\Standard[] $links
+     * @param  \ILIAS\UI\Component\Link\Standard[]|\ILIAS\UI\Component\Button\Shy[] $links
      * @param  string $text
      * @return  \ILIAS\UI\Component\MainControls\Footer
      */

--- a/src/UI/Component/MainControls/Footer.php
+++ b/src/UI/Component/MainControls/Footer.php
@@ -11,11 +11,22 @@ use ILIAS\UI\Component\Component;
 interface Footer extends Component
 {
     /**
-     * @return \ILIAS\UI\Component\Link\Standard[]
+     * @return \ILIAS\UI\Component\Link\Standard|\ILIAS\UI\Component\Button\Shy[]
      */
     public function getLinks() : array;
 
     public function getText() : string;
+
+    /**
+     * @return \ILIAS\UI\Component\Modal\Modal[]
+     */
+    public function getModals() : array;
+
+    /**
+     * @param \ILIAS\UI\Component\Modal\Modal[] $modals
+     * @return Footer
+     */
+    public function withModals(array $modals) : Footer;
 
     /**
      * @return \ILIAS\Data\URI | null

--- a/src/UI/Component/MainControls/Footer.php
+++ b/src/UI/Component/MainControls/Footer.php
@@ -3,7 +3,11 @@
 
 namespace ILIAS\UI\Component\MainControls;
 
+use ILIAS\Data\URI;
 use ILIAS\UI\Component\Component;
+use ILIAS\UI\Component\Button;
+use ILIAS\UI\Component\Link;
+use ILIAS\UI\Component\Modal;
 
 /**
  * This describes the Footer.
@@ -11,27 +15,31 @@ use ILIAS\UI\Component\Component;
 interface Footer extends Component
 {
     /**
-     * @return \ILIAS\UI\Component\Link\Standard|\ILIAS\UI\Component\Button\Shy[]
+     * @return Link\Standard[]
      */
     public function getLinks() : array;
 
     public function getText() : string;
 
     /**
-     * @return \ILIAS\UI\Component\Modal\Modal[]
+     * @return array<Modal\RoundTrip, Button\Shy>[]
      */
     public function getModals() : array;
 
     /**
-     * @param \ILIAS\UI\Component\Modal\Modal[] $modals
+     * @param Modal\RoundTrip $roundTripModal
+     * @param Button\Shy $shyButton
      * @return Footer
      */
-    public function withModals(array $modals) : Footer;
+    public function withAdditionalModalAndTrigger(
+        Modal\RoundTrip $roundTripModal,
+        Button\Shy $shyButton
+    ) : Footer;
 
     /**
-     * @return \ILIAS\Data\URI | null
+     * @return URI|null
      */
     public function getPermanentURL();
 
-    public function withPermanentURL(\ILIAS\Data\URI $url) : Footer;
+    public function withPermanentURL(URI $url) : Footer;
 }

--- a/src/UI/Implementation/Component/MainControls/Footer.php
+++ b/src/UI/Implementation/Component/MainControls/Footer.php
@@ -67,8 +67,6 @@ class Footer implements MainControls\Footer
         Modal\RoundTrip $roundTripModal,
         Button\Shy $shyButton
     ) : \ILIAS\UI\Component\MainControls\Footer {
-        $shyButton->withOnClick($roundTripModal->getShowSignal());
-
         $clone = clone $this;
         $clone->modalsWithTriggers[] = [$roundTripModal, $shyButton];
         return $clone;

--- a/src/UI/Implementation/Component/MainControls/Footer.php
+++ b/src/UI/Implementation/Component/MainControls/Footer.php
@@ -67,6 +67,8 @@ class Footer implements MainControls\Footer
         Modal\RoundTrip $roundTripModal,
         Button\Shy $shyButton
     ) : \ILIAS\UI\Component\MainControls\Footer {
+        $shyButton = $shyButton->withOnClick($roundTripModal->getShowSignal());
+
         $clone = clone $this;
         $clone->modalsWithTriggers[] = [$roundTripModal, $shyButton];
         return $clone;

--- a/src/UI/Implementation/Component/MainControls/Footer.php
+++ b/src/UI/Implementation/Component/MainControls/Footer.php
@@ -69,6 +69,8 @@ class Footer implements MainControls\Footer
     ) : \ILIAS\UI\Component\MainControls\Footer {
         $shyButton->withOnClick($roundTripModal->getShowSignal());
 
-        $this->modalsWithTriggers[] = [$roundTripModal, $shyButton];
+        $clone = clone $this;
+        $clone->modalsWithTriggers[] = [$roundTripModal, $shyButton];
+        return $clone;
     }
 }

--- a/src/UI/Implementation/Component/MainControls/Footer.php
+++ b/src/UI/Implementation/Component/MainControls/Footer.php
@@ -7,6 +7,7 @@ namespace ILIAS\UI\Implementation\Component\MainControls;
 use ILIAS\UI\Component\MainControls;
 use ILIAS\UI\Implementation\Component\ComponentHelper;
 use ILIAS\UI\Component\Link;
+use ILIAS\UI\NotImplementedException;
 
 /**
  * Footer
@@ -15,6 +16,12 @@ class Footer implements MainControls\Footer
 {
     use ComponentHelper;
 
+    private $text = '';
+
+    private $links = [];
+
+    private $modals = [];
+
     /**
      * @var string
      */
@@ -22,7 +29,7 @@ class Footer implements MainControls\Footer
 
     public function __construct(array $links, string $text = '')
     {
-        $types = [\ILIAS\UI\Component\Link\Link::class];
+        $types = [\ILIAS\UI\Component\Link\Link::class, \ILIAS\UI\Component\Button\Shy::class,];
         $this->checkArgListElements('links', $links, $types);
         $this->links = $links;
         $this->text = $text;
@@ -48,5 +55,20 @@ class Footer implements MainControls\Footer
     public function getPermanentURL()
     {
         return $this->permanent_url;
+    }
+
+    public function getModals() : array
+    {
+        return $this->modals;
+    }
+
+    public function withModals(array $modals) : MainControls\Footer
+    {
+        $types = [\ILIAS\UI\Component\Modal\Modal::class,];
+        $this->checkArgListElements('modals', $modals, $types);
+
+        $clone = clone $this;
+        $clone->modals = $modals;
+        return $clone;
     }
 }

--- a/src/UI/Implementation/Component/MainControls/Footer.php
+++ b/src/UI/Implementation/Component/MainControls/Footer.php
@@ -5,9 +5,9 @@
 namespace ILIAS\UI\Implementation\Component\MainControls;
 
 use ILIAS\UI\Component\MainControls;
+use ILIAS\UI\Component\Modal;
 use ILIAS\UI\Implementation\Component\ComponentHelper;
-use ILIAS\UI\Component\Link;
-use ILIAS\UI\NotImplementedException;
+use ILIAS\UI\Component\Button;
 
 /**
  * Footer
@@ -20,7 +20,8 @@ class Footer implements MainControls\Footer
 
     private $links = [];
 
-    private $modals = [];
+    /** @var array<Modal\RoundTrip, Button\Shy>[] */
+    private $modalsWithTriggers = [];
 
     /**
      * @var string
@@ -29,7 +30,7 @@ class Footer implements MainControls\Footer
 
     public function __construct(array $links, string $text = '')
     {
-        $types = [\ILIAS\UI\Component\Link\Link::class, \ILIAS\UI\Component\Button\Shy::class,];
+        $types = [\ILIAS\UI\Component\Link\Link::class,];
         $this->checkArgListElements('links', $links, $types);
         $this->links = $links;
         $this->text = $text;
@@ -59,16 +60,15 @@ class Footer implements MainControls\Footer
 
     public function getModals() : array
     {
-        return $this->modals;
+        return $this->modalsWithTriggers;
     }
 
-    public function withModals(array $modals) : MainControls\Footer
-    {
-        $types = [\ILIAS\UI\Component\Modal\Modal::class,];
-        $this->checkArgListElements('modals', $modals, $types);
+    public function withAdditionalModalAndTrigger(
+        Modal\RoundTrip $roundTripModal,
+        Button\Shy $shyButton
+    ) : \ILIAS\UI\Component\MainControls\Footer {
+        $shyButton->withOnClick($roundTripModal->getShowSignal());
 
-        $clone = clone $this;
-        $clone->modals = $modals;
-        return $clone;
+        $this->modalsWithTriggers[] = [$roundTripModal, $shyButton];
     }
 }

--- a/src/UI/Implementation/Component/MainControls/Renderer.php
+++ b/src/UI/Implementation/Component/MainControls/Renderer.php
@@ -367,6 +367,11 @@ class Renderer extends AbstractComponentRenderer
             $tpl->setVariable('LINKS', $default_renderer->render($link_list));
         }
 
+        $modals = $component->getModals();
+        if ($modals) {
+            $tpl->setVariable('MODALS', $default_renderer->render($modals));
+        }
+
         $tpl->setVariable('TEXT', $component->getText());
 
         $perm_url = $component->getPermanentURL();

--- a/src/UI/Implementation/Component/MainControls/Renderer.php
+++ b/src/UI/Implementation/Component/MainControls/Renderer.php
@@ -362,15 +362,17 @@ class Renderer extends AbstractComponentRenderer
     {
         $tpl = $this->getTemplate("tpl.footer.html", true, true);
         $links = $component->getLinks();
+        $modalsWithTriggers = $component->getModals();
+        $links = array_merge($links, array_column($modalsWithTriggers, 1));
+
         if ($links) {
             $link_list = $this->getUIFactory()->listing()->unordered($links);
             $tpl->setVariable('LINKS', $default_renderer->render($link_list));
         }
 
-        $modals = $component->getModals();
-        if ($modals) {
+        if ($modalsWithTriggers !== []) {
             $tpl->setVariable('MODALS', $default_renderer->render(
-                array_merge(...$modals)
+                array_column($modalsWithTriggers, 0)
             ));
         }
 

--- a/src/UI/Implementation/Component/MainControls/Renderer.php
+++ b/src/UI/Implementation/Component/MainControls/Renderer.php
@@ -369,7 +369,9 @@ class Renderer extends AbstractComponentRenderer
 
         $modals = $component->getModals();
         if ($modals) {
-            $tpl->setVariable('MODALS', $default_renderer->render($modals));
+            $tpl->setVariable('MODALS', $default_renderer->render(
+                array_merge(...$modals)
+            ));
         }
 
         $tpl->setVariable('TEXT', $component->getText());

--- a/src/UI/examples/MainControls/Footer/footer_with_modals.php
+++ b/src/UI/examples/MainControls/Footer/footer_with_modals.php
@@ -1,0 +1,21 @@
+<?php
+function footer_with_modals()
+{
+    global $DIC;
+    $f = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $text = 'Additional info:';
+    $links = [];
+    $links[] = $f->link()->standard("Goto ILIAS", "http://www.ilias.de");
+
+    $footer = $f->mainControls()->footer($links, $text);
+
+    $roundTripModal = $f->modal()->roundtrip('Withdrawal of Consent', $f->legacy('Withdrawal of Consent ...'));
+    $shyButton = $f->button()->shy('Terms Of Service', '#');
+    $shyButton = $shyButton->withOnClick($roundTripModal->getShowSignal());
+
+    $footer = $footer->withAdditionalModalAndTrigger($roundTripModal, $shyButton);
+
+    return $renderer->render($footer);
+}

--- a/src/UI/examples/MainControls/Footer/footer_with_modals.php
+++ b/src/UI/examples/MainControls/Footer/footer_with_modals.php
@@ -13,8 +13,6 @@ function footer_with_modals()
 
     $roundTripModal = $f->modal()->roundtrip('Withdrawal of Consent', $f->legacy('Withdrawal of Consent ...'));
     $shyButton = $f->button()->shy('Terms Of Service', '#');
-    $shyButton = $shyButton->withOnClick($roundTripModal->getShowSignal());
-
     $footer = $footer->withAdditionalModalAndTrigger($roundTripModal, $shyButton);
 
     return $renderer->render($footer);

--- a/src/UI/examples/Modal/RoundTrip/show_a_modal_which_cannot_be_closed_with_the_keyboard.php
+++ b/src/UI/examples/Modal/RoundTrip/show_a_modal_which_cannot_be_closed_with_the_keyboard.php
@@ -7,7 +7,7 @@ function show_a_modal_which_cannot_be_closed_with_the_keyboard()
 
     $modal = $factory->modal()->roundtrip('My Modal 1', $factory->legacy('You cannot close this modal with the ESC key'));
     $modal = $modal->withCloseWithKeyboard(false);
-    $button1 = $factory->button()->standard('Open Modal 1', '#')
+    $button1 = $factory->button()->shy('Open Modal 1', '#')
         ->withOnClick($modal->getShowSignal());
 
     return $renderer->render([$button1, $modal]);

--- a/src/UI/examples/Modal/RoundTrip/show_a_modal_which_cannot_be_closed_with_the_keyboard.php
+++ b/src/UI/examples/Modal/RoundTrip/show_a_modal_which_cannot_be_closed_with_the_keyboard.php
@@ -7,7 +7,7 @@ function show_a_modal_which_cannot_be_closed_with_the_keyboard()
 
     $modal = $factory->modal()->roundtrip('My Modal 1', $factory->legacy('You cannot close this modal with the ESC key'));
     $modal = $modal->withCloseWithKeyboard(false);
-    $button1 = $factory->button()->shy('Open Modal 1', '#')
+    $button1 = $factory->button()->standard('Open Modal 1', '#')
         ->withOnClick($modal->getShowSignal());
 
     return $renderer->render([$button1, $modal]);

--- a/src/UI/templates/default/MainControls/footer.less
+++ b/src/UI/templates/default/MainControls/footer.less
@@ -16,8 +16,11 @@
 		li {
 			display: inline-block;
 			margin-right: 5px;
-			a {
+			a, button {
 				color: white;
+			}
+			button {
+				vertical-align: baseline;
 			}
 		}
 		li:first-child:before {

--- a/src/UI/templates/default/MainControls/tpl.footer.html
+++ b/src/UI/templates/default/MainControls/tpl.footer.html
@@ -16,11 +16,10 @@
 			{LINKS}
 		</div>
 		<!-- END footer_links -->
-
-		<!-- BEGIN footer_modals -->
-		<div class="il-footer-modals">
-			{MODALS}
-		</div>
-		<!-- END footer_modals -->
 	</div>
+	<!-- BEGIN footer_modals -->
+	<div class="il-footer-modals">
+		{MODALS}
+	</div>
+	<!-- END footer_modals -->
 </div>

--- a/src/UI/templates/default/MainControls/tpl.footer.html
+++ b/src/UI/templates/default/MainControls/tpl.footer.html
@@ -17,5 +17,10 @@
 		</div>
 		<!-- END footer_links -->
 
+		<!-- BEGIN footer_modals -->
+		<div class="il-footer-modals">
+			{MODALS}
+		</div>
+		<!-- END footer_modals -->
 	</div>
 </div>

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -1320,7 +1320,7 @@ small,
 mark,
 .mark {
   background-color: #fcf8e3;
-  padding: 0.2em;
+  padding: .2em;
 }
 .text-left {
   text-align: left;
@@ -1623,71 +1623,13 @@ pre code {
   margin-left: -15px;
   margin-right: -15px;
 }
-.col-xs-1,
-.col-sm-1,
-.col-md-1,
-.col-lg-1,
-.col-xs-2,
-.col-sm-2,
-.col-md-2,
-.col-lg-2,
-.col-xs-3,
-.col-sm-3,
-.col-md-3,
-.col-lg-3,
-.col-xs-4,
-.col-sm-4,
-.col-md-4,
-.col-lg-4,
-.col-xs-5,
-.col-sm-5,
-.col-md-5,
-.col-lg-5,
-.col-xs-6,
-.col-sm-6,
-.col-md-6,
-.col-lg-6,
-.col-xs-7,
-.col-sm-7,
-.col-md-7,
-.col-lg-7,
-.col-xs-8,
-.col-sm-8,
-.col-md-8,
-.col-lg-8,
-.col-xs-9,
-.col-sm-9,
-.col-md-9,
-.col-lg-9,
-.col-xs-10,
-.col-sm-10,
-.col-md-10,
-.col-lg-10,
-.col-xs-11,
-.col-sm-11,
-.col-md-11,
-.col-lg-11,
-.col-xs-12,
-.col-sm-12,
-.col-md-12,
-.col-lg-12 {
+.col-xs-1, .col-sm-1, .col-md-1, .col-lg-1, .col-xs-2, .col-sm-2, .col-md-2, .col-lg-2, .col-xs-3, .col-sm-3, .col-md-3, .col-lg-3, .col-xs-4, .col-sm-4, .col-md-4, .col-lg-4, .col-xs-5, .col-sm-5, .col-md-5, .col-lg-5, .col-xs-6, .col-sm-6, .col-md-6, .col-lg-6, .col-xs-7, .col-sm-7, .col-md-7, .col-lg-7, .col-xs-8, .col-sm-8, .col-md-8, .col-lg-8, .col-xs-9, .col-sm-9, .col-md-9, .col-lg-9, .col-xs-10, .col-sm-10, .col-md-10, .col-lg-10, .col-xs-11, .col-sm-11, .col-md-11, .col-lg-11, .col-xs-12, .col-sm-12, .col-md-12, .col-lg-12 {
   position: relative;
   min-height: 1px;
   padding-left: 15px;
   padding-right: 15px;
 }
-.col-xs-1,
-.col-xs-2,
-.col-xs-3,
-.col-xs-4,
-.col-xs-5,
-.col-xs-6,
-.col-xs-7,
-.col-xs-8,
-.col-xs-9,
-.col-xs-10,
-.col-xs-11,
-.col-xs-12 {
+.col-xs-1, .col-xs-2, .col-xs-3, .col-xs-4, .col-xs-5, .col-xs-6, .col-xs-7, .col-xs-8, .col-xs-9, .col-xs-10, .col-xs-11, .col-xs-12 {
   float: left;
 }
 .col-xs-12 {
@@ -1844,18 +1786,7 @@ pre code {
   margin-left: 0%;
 }
 @media (min-width: 768px) {
-  .col-sm-1,
-  .col-sm-2,
-  .col-sm-3,
-  .col-sm-4,
-  .col-sm-5,
-  .col-sm-6,
-  .col-sm-7,
-  .col-sm-8,
-  .col-sm-9,
-  .col-sm-10,
-  .col-sm-11,
-  .col-sm-12 {
+  .col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12 {
     float: left;
   }
   .col-sm-12 {
@@ -2013,18 +1944,7 @@ pre code {
   }
 }
 @media (min-width: 992px) {
-  .col-md-1,
-  .col-md-2,
-  .col-md-3,
-  .col-md-4,
-  .col-md-5,
-  .col-md-6,
-  .col-md-7,
-  .col-md-8,
-  .col-md-9,
-  .col-md-10,
-  .col-md-11,
-  .col-md-12 {
+  .col-md-1, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9, .col-md-10, .col-md-11, .col-md-12 {
     float: left;
   }
   .col-md-12 {
@@ -2182,18 +2102,7 @@ pre code {
   }
 }
 @media (min-width: 1200px) {
-  .col-lg-1,
-  .col-lg-2,
-  .col-lg-3,
-  .col-lg-4,
-  .col-lg-5,
-  .col-lg-6,
-  .col-lg-7,
-  .col-lg-8,
-  .col-lg-9,
-  .col-lg-10,
-  .col-lg-11,
-  .col-lg-12 {
+  .col-lg-1, .col-lg-2, .col-lg-3, .col-lg-4, .col-lg-5, .col-lg-6, .col-lg-7, .col-lg-8, .col-lg-9, .col-lg-10, .col-lg-11, .col-lg-12 {
     float: left;
   }
   .col-lg-12 {
@@ -4939,7 +4848,7 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
 }
 .label {
   display: inline;
-  padding: 0.2em 0.6em 0.3em;
+  padding: .2em .6em .3em;
   font-size: 75%;
   font-weight: bold;
   line-height: 1;
@@ -4947,7 +4856,7 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
   text-align: center;
   white-space: nowrap;
   vertical-align: baseline;
-  border-radius: 0.25em;
+  border-radius: .25em;
 }
 a.label:hover,
 a.label:focus {
@@ -8575,7 +8484,7 @@ fieldset[disabled] .il-table-presentation-viewcontrols .btn-default:not(.disable
 .il-workflow-container .not-available.in-progress .text span,
 .il-workflow-container .no-longer-available.in-progress .text span {
   color: #434343;
-  opacity: 0.5;
+  opacity: .5;
 }
 .il-workflow-container .not-available .text,
 .il-workflow-container .no-longer-available .text {
@@ -9888,8 +9797,12 @@ footer {
   display: inline-block;
   margin-right: 5px;
 }
-.il-maincontrols-footer .il-footer-links li a {
+.il-maincontrols-footer .il-footer-links li a,
+.il-maincontrols-footer .il-footer-links li button {
   color: white;
+}
+.il-maincontrols-footer .il-footer-links li button {
+  vertical-align: baseline;
 }
 .il-maincontrols-footer .il-footer-links li:first-child:before {
   content: "\00b7";
@@ -11041,20 +10954,20 @@ footer {
 .il-avatar.il-avatar-letter span.abbreviation {
   font-weight: lighter;
   text-transform: inherit;
-  font-size: calc(41px / 2);
+  font-size: calc(20.5px);
   line-height: 1;
   position: relative;
-  top: calc(41px / 4);
+  top: calc(10.25px);
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-1 {
   background-color: #1abc9c;
-  border-color: #aef4e6;
-  color: #aef4e6;
+  border-color: #0e6252;
+  color: #0e6252;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-2 {
   background-color: #16a085;
-  border-color: #92f0de;
-  color: #92f0de;
+  border-color: #0a463a;
+  color: #0a463a;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-3 {
   background-color: #f1c40f;
@@ -11063,8 +10976,8 @@ footer {
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-4 {
   background-color: #f39c12;
-  border-color: #fdedd4;
-  color: #fdedd4;
+  border-color: #976008;
+  color: #976008;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-5 {
   background-color: #2ecc71;
@@ -11073,8 +10986,8 @@ footer {
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-6 {
   background-color: #27ae60;
-  border-color: #b3eecc;
-  color: #b3eecc;
+  border-color: #145b32;
+  color: #145b32;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-7 {
   background-color: #e67e22;
@@ -11153,8 +11066,8 @@ footer {
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-22 {
   background-color: #f69785;
-  border-color: #ef4626;
-  color: #ef4626;
+  border-color: #ffffff;
+  color: #ffffff;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-23 {
   background-color: #9ba37e;
@@ -11188,8 +11101,8 @@ footer {
     width: 22.5px;
   }
   .il-avatar.il-avatar-letter span.abbreviation {
-    font-size: calc(22.5px / 2);
-    top: calc(22.5px / 4);
+    font-size: calc(11.25px);
+    top: calc(5.625px);
   }
 }
 .il-link:focus {
@@ -12270,7 +12183,7 @@ div.ilFrame {
 ul,
 ol,
 p {
-  margin: 0.8em 0;
+  margin: .8em 0;
 }
 ol,
 ul {
@@ -12292,7 +12205,7 @@ ol ol {
 small,
 sub,
 sup {
-  font-size: 0.8em;
+  font-size: .8em;
 }
 em,
 i {
@@ -12331,7 +12244,7 @@ a:hover {
   text-decoration: underline;
 }
 hr {
-  margin-bottom: 0.8em;
+  margin-bottom: .8em;
   border: none;
   border-top: 1px solid #ddd;
 }
@@ -15894,7 +15807,7 @@ td > img[src$="icon_custom.svg"] {
     max-width: 94vw;
   }
 }
-@media (min-width: 769px) {
+@media (min-width: 768px+1px) {
   .table-responsive {
     overflow: visible;
   }
@@ -16089,7 +16002,7 @@ table.ilSkill {
 }
 td.ilSkill,
 th.ilSkill {
-  font-size: 0.8em;
+  font-size: .8em;
   padding: 4px;
   min-width: 50px;
 }
@@ -18213,7 +18126,7 @@ body.ilPrtfPdfBody .ilPCMyCoursesToggle img {
   cursor: pointer;
 }
 [data-onscreenchat-inact-userid] {
-  opacity: 0.3 !important;
+  opacity: .3 !important;
 }
 .ilOnScreenChatWindowHeaderTooltip ul {
   text-align: left;
@@ -18292,7 +18205,7 @@ body.ilPrtfPdfBody .ilPCMyCoursesToggle img {
   z-index: 0;
   border: 0 none !important;
   background-color: transparent;
-  opacity: 0.5;
+  opacity: .5;
 }
 #onscreenchat-container .chat-window-wrapper .iosOnScreenChatMessageContainer .iosOnScreenChatMessage {
   background-color: transparent;
@@ -18369,7 +18282,7 @@ body.ilPrtfPdfBody .ilPCMyCoursesToggle img {
   background-color: #f5f5f5;
 }
 #onscreenchat-container .chat-window-wrapper .chat li.separator p {
-  font-size: 0.9em;
+  font-size: .9em;
 }
 #onscreenchat-container .chat-window-wrapper .chat li.header,
 #onscreenchat-container .chat-window-wrapper .chat li.message {
@@ -18386,12 +18299,12 @@ body.ilPrtfPdfBody .ilPCMyCoursesToggle img {
   width: 85%;
 }
 #onscreenchat-container .chat-window-wrapper .chat li .chat-body .header strong {
-  font-size: 0.8em;
+  font-size: .8em;
 }
 #onscreenchat-container .chat-window-wrapper .chat li .chat-body p {
   margin: 0;
   color: #777;
-  font-size: 0.9em;
+  font-size: .9em;
 }
 #onscreenchat-container .chat-window-wrapper .panel {
   pointer-events: auto;
@@ -18832,7 +18745,7 @@ span.ilProfileBadge .modal .img-responsive {
   width: 54px;
 }
 .bootstrap-datetimepicker-widget table td.cw {
-  font-size: 0.8em;
+  font-size: .8em;
   height: 20px;
   line-height: 20px;
   color: #777777;
@@ -19373,7 +19286,7 @@ table.mceToolbar td {
   opacity: 0;
   max-height: 0;
   font-size: 0;
-  transition: 0.25s ease;
+  transition: .25s ease;
 }
 .read-more-state:checked ~ .read-more-wrap .read-more-target {
   opacity: 1;
@@ -19389,10 +19302,10 @@ table.mceToolbar td {
 .read-more-trigger {
   cursor: pointer;
   display: inline-block;
-  padding: 0 0.5em;
+  padding: 0 .5em;
   color: #666;
-  font-size: 0.9em;
+  font-size: .9em;
   line-height: 2;
   border: 1px solid #ddd;
-  border-radius: 0.25em;
+  border-radius: .25em;
 }

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -1320,7 +1320,7 @@ small,
 mark,
 .mark {
   background-color: #fcf8e3;
-  padding: .2em;
+  padding: 0.2em;
 }
 .text-left {
   text-align: left;
@@ -1623,13 +1623,71 @@ pre code {
   margin-left: -15px;
   margin-right: -15px;
 }
-.col-xs-1, .col-sm-1, .col-md-1, .col-lg-1, .col-xs-2, .col-sm-2, .col-md-2, .col-lg-2, .col-xs-3, .col-sm-3, .col-md-3, .col-lg-3, .col-xs-4, .col-sm-4, .col-md-4, .col-lg-4, .col-xs-5, .col-sm-5, .col-md-5, .col-lg-5, .col-xs-6, .col-sm-6, .col-md-6, .col-lg-6, .col-xs-7, .col-sm-7, .col-md-7, .col-lg-7, .col-xs-8, .col-sm-8, .col-md-8, .col-lg-8, .col-xs-9, .col-sm-9, .col-md-9, .col-lg-9, .col-xs-10, .col-sm-10, .col-md-10, .col-lg-10, .col-xs-11, .col-sm-11, .col-md-11, .col-lg-11, .col-xs-12, .col-sm-12, .col-md-12, .col-lg-12 {
+.col-xs-1,
+.col-sm-1,
+.col-md-1,
+.col-lg-1,
+.col-xs-2,
+.col-sm-2,
+.col-md-2,
+.col-lg-2,
+.col-xs-3,
+.col-sm-3,
+.col-md-3,
+.col-lg-3,
+.col-xs-4,
+.col-sm-4,
+.col-md-4,
+.col-lg-4,
+.col-xs-5,
+.col-sm-5,
+.col-md-5,
+.col-lg-5,
+.col-xs-6,
+.col-sm-6,
+.col-md-6,
+.col-lg-6,
+.col-xs-7,
+.col-sm-7,
+.col-md-7,
+.col-lg-7,
+.col-xs-8,
+.col-sm-8,
+.col-md-8,
+.col-lg-8,
+.col-xs-9,
+.col-sm-9,
+.col-md-9,
+.col-lg-9,
+.col-xs-10,
+.col-sm-10,
+.col-md-10,
+.col-lg-10,
+.col-xs-11,
+.col-sm-11,
+.col-md-11,
+.col-lg-11,
+.col-xs-12,
+.col-sm-12,
+.col-md-12,
+.col-lg-12 {
   position: relative;
   min-height: 1px;
   padding-left: 15px;
   padding-right: 15px;
 }
-.col-xs-1, .col-xs-2, .col-xs-3, .col-xs-4, .col-xs-5, .col-xs-6, .col-xs-7, .col-xs-8, .col-xs-9, .col-xs-10, .col-xs-11, .col-xs-12 {
+.col-xs-1,
+.col-xs-2,
+.col-xs-3,
+.col-xs-4,
+.col-xs-5,
+.col-xs-6,
+.col-xs-7,
+.col-xs-8,
+.col-xs-9,
+.col-xs-10,
+.col-xs-11,
+.col-xs-12 {
   float: left;
 }
 .col-xs-12 {
@@ -1786,7 +1844,18 @@ pre code {
   margin-left: 0%;
 }
 @media (min-width: 768px) {
-  .col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12 {
+  .col-sm-1,
+  .col-sm-2,
+  .col-sm-3,
+  .col-sm-4,
+  .col-sm-5,
+  .col-sm-6,
+  .col-sm-7,
+  .col-sm-8,
+  .col-sm-9,
+  .col-sm-10,
+  .col-sm-11,
+  .col-sm-12 {
     float: left;
   }
   .col-sm-12 {
@@ -1944,7 +2013,18 @@ pre code {
   }
 }
 @media (min-width: 992px) {
-  .col-md-1, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9, .col-md-10, .col-md-11, .col-md-12 {
+  .col-md-1,
+  .col-md-2,
+  .col-md-3,
+  .col-md-4,
+  .col-md-5,
+  .col-md-6,
+  .col-md-7,
+  .col-md-8,
+  .col-md-9,
+  .col-md-10,
+  .col-md-11,
+  .col-md-12 {
     float: left;
   }
   .col-md-12 {
@@ -2102,7 +2182,18 @@ pre code {
   }
 }
 @media (min-width: 1200px) {
-  .col-lg-1, .col-lg-2, .col-lg-3, .col-lg-4, .col-lg-5, .col-lg-6, .col-lg-7, .col-lg-8, .col-lg-9, .col-lg-10, .col-lg-11, .col-lg-12 {
+  .col-lg-1,
+  .col-lg-2,
+  .col-lg-3,
+  .col-lg-4,
+  .col-lg-5,
+  .col-lg-6,
+  .col-lg-7,
+  .col-lg-8,
+  .col-lg-9,
+  .col-lg-10,
+  .col-lg-11,
+  .col-lg-12 {
     float: left;
   }
   .col-lg-12 {
@@ -4848,7 +4939,7 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
 }
 .label {
   display: inline;
-  padding: .2em .6em .3em;
+  padding: 0.2em 0.6em 0.3em;
   font-size: 75%;
   font-weight: bold;
   line-height: 1;
@@ -4856,7 +4947,7 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
   text-align: center;
   white-space: nowrap;
   vertical-align: baseline;
-  border-radius: .25em;
+  border-radius: 0.25em;
 }
 a.label:hover,
 a.label:focus {
@@ -8484,7 +8575,7 @@ fieldset[disabled] .il-table-presentation-viewcontrols .btn-default:not(.disable
 .il-workflow-container .not-available.in-progress .text span,
 .il-workflow-container .no-longer-available.in-progress .text span {
   color: #434343;
-  opacity: .5;
+  opacity: 0.5;
 }
 .il-workflow-container .not-available .text,
 .il-workflow-container .no-longer-available .text {
@@ -10954,20 +11045,20 @@ footer {
 .il-avatar.il-avatar-letter span.abbreviation {
   font-weight: lighter;
   text-transform: inherit;
-  font-size: calc(20.5px);
+  font-size: calc(41px / 2);
   line-height: 1;
   position: relative;
-  top: calc(10.25px);
+  top: calc(41px / 4);
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-1 {
   background-color: #1abc9c;
-  border-color: #0e6252;
-  color: #0e6252;
+  border-color: #aef4e6;
+  color: #aef4e6;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-2 {
   background-color: #16a085;
-  border-color: #0a463a;
-  color: #0a463a;
+  border-color: #92f0de;
+  color: #92f0de;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-3 {
   background-color: #f1c40f;
@@ -10976,8 +11067,8 @@ footer {
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-4 {
   background-color: #f39c12;
-  border-color: #976008;
-  color: #976008;
+  border-color: #fdedd4;
+  color: #fdedd4;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-5 {
   background-color: #2ecc71;
@@ -10986,8 +11077,8 @@ footer {
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-6 {
   background-color: #27ae60;
-  border-color: #145b32;
-  color: #145b32;
+  border-color: #b3eecc;
+  color: #b3eecc;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-7 {
   background-color: #e67e22;
@@ -11066,8 +11157,8 @@ footer {
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-22 {
   background-color: #f69785;
-  border-color: #ffffff;
-  color: #ffffff;
+  border-color: #ef4626;
+  color: #ef4626;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-23 {
   background-color: #9ba37e;
@@ -11101,8 +11192,8 @@ footer {
     width: 22.5px;
   }
   .il-avatar.il-avatar-letter span.abbreviation {
-    font-size: calc(11.25px);
-    top: calc(5.625px);
+    font-size: calc(22.5px / 2);
+    top: calc(22.5px / 4);
   }
 }
 .il-link:focus {
@@ -12183,7 +12274,7 @@ div.ilFrame {
 ul,
 ol,
 p {
-  margin: .8em 0;
+  margin: 0.8em 0;
 }
 ol,
 ul {
@@ -12205,7 +12296,7 @@ ol ol {
 small,
 sub,
 sup {
-  font-size: .8em;
+  font-size: 0.8em;
 }
 em,
 i {
@@ -12244,7 +12335,7 @@ a:hover {
   text-decoration: underline;
 }
 hr {
-  margin-bottom: .8em;
+  margin-bottom: 0.8em;
   border: none;
   border-top: 1px solid #ddd;
 }
@@ -15807,7 +15898,7 @@ td > img[src$="icon_custom.svg"] {
     max-width: 94vw;
   }
 }
-@media (min-width: 768px+1px) {
+@media (min-width: 769px) {
   .table-responsive {
     overflow: visible;
   }
@@ -16002,7 +16093,7 @@ table.ilSkill {
 }
 td.ilSkill,
 th.ilSkill {
-  font-size: .8em;
+  font-size: 0.8em;
   padding: 4px;
   min-width: 50px;
 }
@@ -18126,7 +18217,7 @@ body.ilPrtfPdfBody .ilPCMyCoursesToggle img {
   cursor: pointer;
 }
 [data-onscreenchat-inact-userid] {
-  opacity: .3 !important;
+  opacity: 0.3 !important;
 }
 .ilOnScreenChatWindowHeaderTooltip ul {
   text-align: left;
@@ -18205,7 +18296,7 @@ body.ilPrtfPdfBody .ilPCMyCoursesToggle img {
   z-index: 0;
   border: 0 none !important;
   background-color: transparent;
-  opacity: .5;
+  opacity: 0.5;
 }
 #onscreenchat-container .chat-window-wrapper .iosOnScreenChatMessageContainer .iosOnScreenChatMessage {
   background-color: transparent;
@@ -18282,7 +18373,7 @@ body.ilPrtfPdfBody .ilPCMyCoursesToggle img {
   background-color: #f5f5f5;
 }
 #onscreenchat-container .chat-window-wrapper .chat li.separator p {
-  font-size: .9em;
+  font-size: 0.9em;
 }
 #onscreenchat-container .chat-window-wrapper .chat li.header,
 #onscreenchat-container .chat-window-wrapper .chat li.message {
@@ -18299,12 +18390,12 @@ body.ilPrtfPdfBody .ilPCMyCoursesToggle img {
   width: 85%;
 }
 #onscreenchat-container .chat-window-wrapper .chat li .chat-body .header strong {
-  font-size: .8em;
+  font-size: 0.8em;
 }
 #onscreenchat-container .chat-window-wrapper .chat li .chat-body p {
   margin: 0;
   color: #777;
-  font-size: .9em;
+  font-size: 0.9em;
 }
 #onscreenchat-container .chat-window-wrapper .panel {
   pointer-events: auto;
@@ -18745,7 +18836,7 @@ span.ilProfileBadge .modal .img-responsive {
   width: 54px;
 }
 .bootstrap-datetimepicker-widget table td.cw {
-  font-size: .8em;
+  font-size: 0.8em;
   height: 20px;
   line-height: 20px;
   color: #777777;
@@ -19286,7 +19377,7 @@ table.mceToolbar td {
   opacity: 0;
   max-height: 0;
   font-size: 0;
-  transition: .25s ease;
+  transition: 0.25s ease;
 }
 .read-more-state:checked ~ .read-more-wrap .read-more-target {
   opacity: 1;
@@ -19302,10 +19393,10 @@ table.mceToolbar td {
 .read-more-trigger {
   cursor: pointer;
   display: inline-block;
-  padding: 0 .5em;
+  padding: 0 0.5em;
   color: #666;
-  font-size: .9em;
+  font-size: 0.9em;
   line-height: 2;
   border: 1px solid #ddd;
-  border-radius: .25em;
+  border-radius: 0.25em;
 }

--- a/tests/UI/Component/MainControls/FooterTest.php
+++ b/tests/UI/Component/MainControls/FooterTest.php
@@ -104,16 +104,11 @@ class FooterTest extends ILIAS_UI_TestBase
         $modal1 = $mf->roundtrip('Modal1', $legacy);
         $modal2 = $mf->roundtrip('Modal2', $legacy);
 
-        $shyButton1 = $shyButton1->withOnClick($modal1->getShowSignal());
-        $shyButton2 = $shyButton2->withOnClick($modal2->getShowSignal());
-
         $footer = $footer
             ->withAdditionalModalAndTrigger($modal1, $shyButton1)
             ->withAdditionalModalAndTrigger($modal2, $shyButton2);
 
         $this->assertCount(2, $footer->getModals());
-        $this->assertEquals([$modal1, $shyButton1], $footer->getModals()[0]);
-        $this->assertEquals([$modal2, $shyButton2], $footer->getModals()[1]);
 
         return $footer;
     }

--- a/tests/UI/Component/MainControls/FooterTest.php
+++ b/tests/UI/Component/MainControls/FooterTest.php
@@ -94,19 +94,18 @@ class FooterTest extends ILIAS_UI_TestBase
     public function testGetAndSetModalsWithTrigger(C\MainControls\Footer $footer)
     {
         $bf = new I\Button\Factory();
-        $mf = new I\Modal\Factory(new SignalGenerator());
-        $dummyComponent = new class() implements \ILIAS\UI\Component\Component {
-            public function getCanonicalName()
-            {
-                return 'dummy';
-            }
-        };
+        $signalGenerator = new SignalGenerator();
+        $mf = new I\Modal\Factory($signalGenerator);
+        $legacy = new ILIAS\UI\Implementation\Component\Legacy\Legacy('PhpUnit', $signalGenerator);
 
         $shyButton1 = $bf->shy('Button1', '#');
         $shyButton2 = $bf->shy('Button2', '#');
 
-        $modal1 = $mf->roundtrip('Modal1', $dummyComponent);
-        $modal2 = $mf->roundtrip('Modal2', $dummyComponent);
+        $modal1 = $mf->roundtrip('Modal1', $legacy);
+        $modal2 = $mf->roundtrip('Modal2', $legacy);
+
+        $shyButton1 = $shyButton1->withOnClick($modal1->getShowSignal());
+        $shyButton2 = $shyButton2->withOnClick($modal2->getShowSignal());
 
         $footer = $footer
             ->withAdditionalModalAndTrigger($modal1, $shyButton1)
@@ -115,6 +114,8 @@ class FooterTest extends ILIAS_UI_TestBase
         $this->assertCount(2, $footer->getModals());
         $this->assertEquals([$modal1, $shyButton1], $footer->getModals()[0]);
         $this->assertEquals([$modal2, $shyButton2], $footer->getModals()[1]);
+
+        return $footer;
     }
 
     /**
@@ -220,6 +221,71 @@ EOT;
                         <li><a href="http://www.ilias.de" >Goto ILIAS</a></li>
                         <li><a href="#" >go up</a></li>
                     </ul>
+                </div>
+            </div>
+        </div>
+EOT;
+
+        $this->assertEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($html)
+        );
+    }
+
+    /**
+     * @depends testGetAndSetModalsWithTrigger
+     */
+    public function testRenderingModalsWithTriggers(C\MainControls\Footer $footer)
+    {
+        $r = $this->getDefaultRenderer();
+        $html = $r->render($footer);
+
+        $expected = <<<EOT
+        <div class="il-maincontrols-footer">
+            <div class="il-footer-content">
+                <div class="il-footer-text">footer text</div>
+
+                <div class="il-footer-links">
+                    <ul>
+                        <li><a href="http://www.ilias.de" >Goto ILIAS</a></li>
+                        <li><a href="#" >go up</a></li>
+                        <li><button class="btn btn-link" id="id_1" >Button1</button></li>
+                        <li><button class="btn btn-link" id="id_2">Button2</button></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="il-footer-modals">
+                <div class="modal fade il-modal-roundtrip" tabindex="-1" role="dialog" id="id_3">
+                    <div class="modal-dialog" role="document" data-replace-marker="component">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                    <span aria-hidden="true">&times;</span>
+                                </button>
+                                <h4 class="modal-title">Modal1</h4>
+                            </div>
+                            <div class="modal-body">PhpUnit</div>
+                            <div class="modal-footer">
+                                <a class="btn btn-default" data-dismiss="modal" aria-label="Close">cancel</a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal fade il-modal-roundtrip" tabindex="-1" role="dialog" id="id_5">
+                    <div class="modal-dialog" role="document" data-replace-marker="component">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                    <span aria-hidden="true">&times;</span>
+                                </button>
+                                <h4 class="modal-title">Modal2</h4>
+                            </div>
+                            <div class="modal-body">PhpUnit</div>
+                            <div class="modal-footer">
+                                <a class="btn btn-default" data-dismiss="modal" aria-label="Close">cancel</a>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/tests/UI/Component/MainControls/FooterTest.php
+++ b/tests/UI/Component/MainControls/FooterTest.php
@@ -7,12 +7,17 @@ require_once(__DIR__ . "/../../Base.php");
 
 use \ILIAS\UI\Component as C;
 use \ILIAS\UI\Implementation\Component as I;
+use ILIAS\UI\Implementation\Component\SignalGenerator;
 
 /**
  * Tests for the Footer.
  */
 class FooterTest extends ILIAS_UI_TestBase
 {
+    private $links = [];
+    private $text = '';
+    private $perm_url = '';
+
     public function setUp() : void
     {
         $f = new I\Link\Factory();
@@ -26,7 +31,6 @@ class FooterTest extends ILIAS_UI_TestBase
 
     protected function getFactory()
     {
-        $sig_gen = new I\SignalGenerator();
         $sig_gen = new I\SignalGenerator();
         $counter_factory = new I\Counter\Factory();
         $slate_factory = new I\MainControls\Slate\Factory(
@@ -82,6 +86,35 @@ class FooterTest extends ILIAS_UI_TestBase
             $this->text,
             $footer->getText()
         );
+    }
+
+    /**
+     * @depends testConstruction
+     */
+    public function testGetAndSetModalsWithTrigger(C\MainControls\Footer $footer)
+    {
+        $bf = new I\Button\Factory();
+        $mf = new I\Modal\Factory(new SignalGenerator());
+        $dummyComponent = new class() implements \ILIAS\UI\Component\Component {
+            public function getCanonicalName()
+            {
+                return 'dummy';
+            }
+        };
+
+        $shyButton1 = $bf->shy('Button1', '#');
+        $shyButton2 = $bf->shy('Button2', '#');
+
+        $modal1 = $mf->roundtrip('Modal1', $dummyComponent);
+        $modal2 = $mf->roundtrip('Modal2', $dummyComponent);
+
+        $footer = $footer
+            ->withAdditionalModalAndTrigger($modal1, $shyButton1)
+            ->withAdditionalModalAndTrigger($modal2, $shyButton2);
+
+        $this->assertCount(2, $footer->getModals());
+        $this->assertEquals([$modal1, $shyButton1], $footer->getModals()[0]);
+        $this->assertEquals([$modal2, $shyButton2], $footer->getModals()[1]);
     }
 
     /**


### PR DESCRIPTION
This PR suggests interface changes for the `UI Footer` component to support `Shy Buttons` with `Modals` being opened when a button is clicked.

Feature Request: https://docu.ilias.de/goto_docu_wiki_wpage_5120_1357.html

Alternatives:
* Enable `Shy Buttons` to receive a `Modal`, which is rendered when the shy button is rendered:
  1. How many optional `Modal` elements should a shy button support? 1, more than 1?
  2. What about the binding mechanisms of `Button` and `Modal`, which is currently always solved/implemented in the consuming code. `Modal` elements support multiple signals (`Show`, `Close`), so an implicit binding when adding the `Modal` to the `Button` is so easy and maybe not desired by the consumer.
  3. Should the passed `Modal` element(s) be rendered if the `Button` is rendered? I am not sure if rendering the modal in the `Button` renderer is a good idea, because `Modal` elements sometimes include `<form>` elements, and `Buttons` are sometimes rendered within `<form>` elements as well. Nested form elements are not supported by HTML standard. This is already/currently an issue with `Modal` elements because a correct rendering (to avoid forms in forms) totally relies on the consuming code.