### PR TITLE
Fix Mantis issue 28651

### DIFF
--- a/Services/Randomization/classes/class.ilRandom.php
+++ b/Services/Randomization/classes/class.ilRandom.php
@@ -41,7 +41,7 @@ class ilRandom
                 return random_int($min, $max);
             } catch (Exception $e) {
                 $this->logger->logStack(\ilLogLevel::ERROR);
-                $this->logger()->error('No suitable random number generator found.');
+                $this->logger->error('No suitable random number generator found.');
                 throw $e;
             } catch (Throwable $e) {
                 $this->logger->logStack(\ilLogLevel::ERROR);

--- a/Services/Randomization/classes/class.ilRandom.php
+++ b/Services/Randomization/classes/class.ilRandom.php
@@ -7,9 +7,9 @@
 class ilRandom
 {
     /**
-     * @var \ilLogger | null
+     * @var ilLogger|null
      */
-    private $logger = null;
+    private $logger;
 
     /**
      * constructor.
@@ -29,14 +29,14 @@ class ilRandom
      */
     public function int($min = null, $max = null)
     {
-        if(is_null($min)) {
+        if (is_null($min)) {
             $min = 0;
         }
-        if(is_null($max)) {
+        if (is_null($max)) {
             $max = mt_getrandmax();
         }
 
-        if($this->supportsRandomInt()) {
+        if ($this->supportsRandomInt()) {
             try {
                 return random_int($min, $max);
             } catch (Exception $e) {
@@ -58,10 +58,9 @@ class ilRandom
      */
     private function supportsRandomInt()
     {
-        if(version_compare(PHP_VERSION , '7.0.0', '>=')) {
+        if (version_compare(PHP_VERSION, '7.0.0', '>=')) {
             return true;
         }
         return false;
     }
-
 }

--- a/libs/composer/vendor/composer/autoload_classmap.php
+++ b/libs/composer/vendor/composer/autoload_classmap.php
@@ -6304,6 +6304,7 @@ return array(
     'ilRadiusAttributeToUser' => $baseDir . '/../../Services/Radius/classes/class.ilRadiusAttributeToUser.php',
     'ilRadiusSettings' => $baseDir . '/../../Services/Radius/classes/class.ilRadiusSettings.php',
     'ilRadiusSettingsGUI' => $baseDir . '/../../Services/Radius/classes/class.ilRadiusSettingsGUI.php',
+    'ilRandom' => $baseDir . '/../../Services/Randomization/classes/class.ilRandom.php',
     'ilRandomTestData' => $baseDir . '/../../Modules/Test/classes/class.ilRandomTestData.php',
     'ilRandomTestROInputGUI' => $baseDir . '/../../Modules/Test/classes/class.ilRandomTestROInputGUI.php',
     'ilRating' => $baseDir . '/../../Services/Rating/classes/class.ilRating.php',

--- a/libs/composer/vendor/composer/autoload_static.php
+++ b/libs/composer/vendor/composer/autoload_static.php
@@ -6670,6 +6670,7 @@ class ComposerStaticInit2fffdf922cf8fdbf1f62eec345993c83
         'ilRadiusAttributeToUser' => __DIR__ . '/../..' . '/../../Services/Radius/classes/class.ilRadiusAttributeToUser.php',
         'ilRadiusSettings' => __DIR__ . '/../..' . '/../../Services/Radius/classes/class.ilRadiusSettings.php',
         'ilRadiusSettingsGUI' => __DIR__ . '/../..' . '/../../Services/Radius/classes/class.ilRadiusSettingsGUI.php',
+        'ilRandom' => __DIR__ . '/../..' . '/../../Services/Randomization/classes/class.ilRandom.php',
         'ilRandomTestData' => __DIR__ . '/../..' . '/../../Modules/Test/classes/class.ilRandomTestData.php',
         'ilRandomTestROInputGUI' => __DIR__ . '/../..' . '/../../Modules/Test/classes/class.ilRandomTestROInputGUI.php',
         'ilRating' => __DIR__ . '/../..' . '/../../Services/Rating/classes/class.ilRating.php',

--- a/setup/sql/5_4_hotfixes.php
+++ b/setup/sql/5_4_hotfixes.php
@@ -1350,3 +1350,7 @@ $ilDB->modifyTableColumn(
     ]
 );
 ?>
+<#92>
+<?php
+$ilCtrlStructureReader->getStructure();
+?>


### PR DESCRIPTION
This PR fixes https://mantis.ilias.de/view.php?id=28651 by ...

1. ... updating the composer autoload files.
2. ... fixing a call to `$this-logger()` where no such method exists.
3. ... adding a new database update step for the introduced `rnd` logger.

Fix 2. and 3. MUST be fixed in `release_6` (see #2808) and `trunk` (see #2809) as well.