### PR TITLE
BT-28641: Removed updateTranslation for cat type in ilSoapObjectAdministration, because it was outdated

### DIFF
--- a/webservice/soap/classes/class.ilSoapObjectAdministration.php
+++ b/webservice/soap/classes/class.ilSoapObjectAdministration.php
@@ -1160,7 +1160,6 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         if (count($object_datas) > 0) {
             foreach ($object_datas as $object_data) {
                 $this->updateReferences($object_data);
-                
                 /**
                  * @var ilObject
                  */
@@ -1171,12 +1170,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
                 if ($objDefinition->supportsOfflineHandling($tmp_obj->getType())) {
                     $tmp_obj->setOfflineStatus($object_data['offline']);
                 }
-
-                switch ($object_data['type']) {
-                    case 'cat':
-                        $tmp_obj->updateTranslation($object_data["title"], $object_data["description"], $lng->getLangKey(), $lng->getLangKey());
-                        break;
-                }
+                
                 $tmp_obj->update();
                 if (strlen($object_data['owner']) && is_numeric($object_data['owner'])) {
                     $tmp_obj->setOwner($object_data['owner']);


### PR DESCRIPTION
After testing the functionality with SOAP while removing the call for updateTranslation and still having the changed title in the Multilanguage subtab, I do believe that it's outdated.
I also could not find a translate call or similar in the save function of ilObjCategoryGui, which further makes me believe that it's outdated at this point.