### PR TITLE
UI/Layout/Footer: Remove z-index from footer

### DIFF
--- a/src/UI/templates/default/Layout/standardpage.less
+++ b/src/UI/templates/default/Layout/standardpage.less
@@ -247,7 +247,6 @@ footer {
 	min-height: auto;
 	padding: @il-footer-padding;
 	text-align: center;
-	z-index: 2;
 }
 
 

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -8966,7 +8966,6 @@ footer {
   min-height: auto;
   padding: 20px 0 15px 5px;
   text-align: center;
-  z-index: 2;
 }
 /*
 **************************************************************
@@ -19420,4 +19419,3 @@ table.mceToolbar td {
   border: 1px solid #ddd;
   border-radius: 0.25em;
 }
-/*# sourceMappingURL=delos.css.map */


### PR DESCRIPTION
This PR removes the `z-index` property (currently set to `z-index: 2`) from the `<footer>` HTML element.

Reasons: Because of the set `z-index`, modals rendered in the footer area (see #2803) are hidden **behind** the `Modal Backdrop`.

I did not notice any negative site effect after removing the `z-index` (neither in the desktop view, nor in the mobile view). I also talked to @nhaagen and he has no objections as well.
