### PR TITLE
UI Framework: Deleted MainControls\MainBar::withMoreButton and ::getMoreButton methods - ROADMAP.md updated

### DIFF
--- a/Modules/LearningModule/Export/class.ilLMHtmlExportViewLayoutProvider.php
+++ b/Modules/LearningModule/Export/class.ilLMHtmlExportViewLayoutProvider.php
@@ -69,9 +69,6 @@ class ilLMHtmlExportViewLayoutProvider extends AbstractModificationProvider impl
                         new \ILIAS\UI\Implementation\Component\SignalGenerator()
                     );
                     $grid_icon = $f->symbol()->icon()->custom(\ilUtil::getImagePath("outlined/icon_tool.svg"), $lng->txt("more"));
-                    $offline_main_bar = $offline_main_bar->withMoreButton(
-                        $f->button()->bulky($grid_icon, $lng->txt("more"), "#")
-                    );
                     $tools_button = $f->button()->bulky($grid_icon, $lng->txt("tools"), "#")->withEngagedState(true);
                     $offline_main_bar = $offline_main_bar->withToolsButton($tools_button);
 

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -16180,3 +16180,4 @@ common#:#eyeopened#:#Offenes Auge: Klicken Sie, um den Inhalt der Eingabe anzuze
 rbac#:#prgr_copy#:#Links zu Studienprogrammen kopieren
 ui#:#ui_error_in_group#:#Es gibt einen Fehler in diesem Bereich.
 feed#:#feed_no_local_url#:#Bitte geben sie eine gültige externe Feed URL an.
+common#:#mainbar_more_label#:#Mehr

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -16180,3 +16180,4 @@ rbac#:#prgr_write#:#User can edit settings of links to study programmes
 rbac#:#rbac_create_prgr#:#Create link to study programme
 ui#:#ui_error_in_group#:#There is some error in this part.
 feed#:#feed_no_local_url#:#The URL could not be verified. Please enter a valid external Feed URL.
+common#:#mainbar_more_label#:#More

--- a/src/GlobalScreen/Scope/Layout/Provider/PagePart/StandardPagePartProvider.php
+++ b/src/GlobalScreen/Scope/Layout/Provider/PagePart/StandardPagePartProvider.php
@@ -105,10 +105,6 @@ class StandardPagePartProvider implements PagePartProvider
                 $main_bar = $main_bar->withAdditionalEntry($identifier, $component);
             }
         }
-        $more_glyph = $f->symbol()->glyph()->more("#");
-        $main_bar = $main_bar->withMoreButton(
-            $f->button()->bulky($more_glyph, "More", "#")
-        );
 
         // Tools
         $grid_icon = $f->symbol()->icon()->custom(\ilUtil::getImagePath("outlined/icon_tool.svg"), "More");

--- a/src/UI/Component/MainControls/MainBar.php
+++ b/src/UI/Component/MainControls/MainBar.php
@@ -68,16 +68,6 @@ interface MainBar extends \ILIAS\UI\Component\Component, JavaScriptBindable
     public function getToolsButton() : Button\Bulky;
 
     /**
-     * Set button for further entries that do not fit on the screen.
-     */
-    public function withMoreButton(Button\Bulky $button) : MainBar;
-
-    /**
-     * Returns the button for further entries.
-     */
-    public function getMoreButton() : Button\Bulky;
-
-    /**
      * Get the signal that is triggered when any entry in the bar is clicked.
      */
     public function getEntryClickSignal() : Signal;

--- a/src/UI/Implementation/Component/MainControls/MainBar.php
+++ b/src/UI/Implementation/Component/MainControls/MainBar.php
@@ -197,24 +197,6 @@ class MainBar implements MainControls\MainBar
     /**
      * @inheritdoc
      */
-    public function withMoreButton(Button\Bulky $button) : MainControls\MainBar
-    {
-        $clone = clone $this;
-        $clone->more_button = $button;
-        return $clone;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getMoreButton() : Button\Bulky
-    {
-        return $this->more_button;
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getEntryClickSignal() : Signal
     {
         return $this->entry_click_signal;

--- a/src/UI/Implementation/Component/MainControls/Renderer.php
+++ b/src/UI/Implementation/Component/MainControls/Renderer.php
@@ -162,17 +162,16 @@ class Renderer extends AbstractComponentRenderer
         $tpl = $this->getTemplate("tpl.mainbar.html", true, true);
 
         $tpl->setVariable("ARIA_LABEL", $this->txt('mainbar_aria_label'));
-
+        $more_btn_label = $this->txt('mainbar_more_label');
         //add "more"-slate
         $more_slate = $f->maincontrols()->slate()->combined(
-            $component->getMoreButton()->getLabel(),
+            $more_btn_label,
             $f->symbol()->glyph()->more()
         )->withAriaRole(ISlate::MENU);
         $component = $component->withAdditionalEntry(
             '_mb_more_entry',
             $more_slate
         );
-
         $component = $this->calculateMainBarTreePosition("0", $component);
 
         $mb_entries = [

--- a/src/UI/ROADMAP.md
+++ b/src/UI/ROADMAP.md
@@ -130,18 +130,6 @@ base class and removed on `Field\Select` and `Field\Text`.
 
 New inputs must already implement the methods.
 
-### Remove `MainControl\MainBar::withMoreButton` and `::getMoreButton` (beginner, ~2h)
-
-Currently these two methods offer the possibility for a customization where none
-is required. The more button might be styled via css or exchange of images, but
-we do not need to exchange it programmatically.
-
-### Add symbol for more and use it in the More-Button (beginner, ~2h)
-
-Currently the symbol for the more button is pulled from the examples directory of
-the UI-framework. The image-file should be moved to a proper location and possibly
-become part of the UI-framework as a proper glyph.
-
 ### Create a `Group`-family in `Input\Field` (beginner, ~2h)
 
 Currently `Input\Field` contains various group inputs, where the different inputs

--- a/src/UI/examples/Layout/Page/Standard/ui.php
+++ b/src/UI/examples/Layout/Page/Standard/ui.php
@@ -189,8 +189,7 @@ function pagedemoMainbar($f, $r)
     );
 
     $mainbar = $f->mainControls()->mainbar()
-        ->withToolsButton($tools_btn)
-        ->withMoreButton($more_btn);
+        ->withToolsButton($tools_btn);
 
     $entries = [];
     $entries['repository'] = getDemoEntryRepository($f);

--- a/src/UI/examples/MainControls/MainBar/mainbar.php
+++ b/src/UI/examples/MainControls/MainBar/mainbar.php
@@ -23,8 +23,7 @@ function buildMainbar($f, $r)
     );
 
     $mainbar = $f->mainControls()->mainbar()
-        ->withToolsButton($tools_btn)
-        ->withMoreButton($more_btn);
+        ->withToolsButton($tools_btn);
 
     $entries = [];
     $entries['repository'] = getDemoEntryRepository($f);

--- a/tests/UI/Component/MainControls/MainBarTest.php
+++ b/tests/UI/Component/MainControls/MainBarTest.php
@@ -216,9 +216,6 @@ class MainBarTest extends ILIAS_UI_TestBase
             );
 
         $mb = $this->factory->mainBar()
-            ->withMoreButton(
-                $this->button_factory->bulky($icon, 'more', '')
-            )
             ->withAdditionalEntry('test1', $this->getButton())
             ->withAdditionalEntry('test2', $this->getButton())
             ->withAdditionalEntry('slate', $slate);
@@ -233,7 +230,7 @@ class MainBarTest extends ILIAS_UI_TestBase
 							<button class="btn btn-bulky" data-action="#" id="id_1" ><div class="icon custom small" aria-label=""><img src="" /></div><span class="bulky-label">TestEntry</span></button>
 							<button class="btn btn-bulky" data-action="#" id="id_2" ><div class="icon custom small" aria-label=""><img src="" /></div><span class="bulky-label">TestEntry</span></button>
 							<button class="btn btn-bulky" id="id_3" role="menuitem" aria-haspopup="true" ><div class="icon custom small" aria-label=""><img src="" /></div><span class="bulky-label">1</span></button>
-							<button class="btn btn-bulky" id="id_9" role="menuitem" aria-haspopup="true" ><span class="glyph" aria-label="show_more"><span class="glyphicon glyphicon-option-horizontal" aria-hidden="true"></span></span><span class="bulky-label">more</span></button>
+							<button class="btn btn-bulky" id="id_9" role="menuitem" aria-haspopup="true" ><span class="glyph" aria-label="show_more"><span class="glyphicon glyphicon-option-horizontal" aria-hidden="true"></span></span><span class="bulky-label">mainbar_more_label</span></button>
 						</div>
 					</div>
 				</nav>


### PR DESCRIPTION
https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/src/UI/ROADMAP.md#remove-maincontrolmainbarwithmorebutton-and-getmorebutton-beginner-2h