### PR TITLE
Fixed implode() argument order to remove PHP 7.4 depreciated warnings

### DIFF
--- a/Services/Accordion/classes/class.ilAccordionPropertiesStorage.php
+++ b/Services/Accordion/classes/class.ilAccordionPropertiesStorage.php
@@ -42,7 +42,7 @@ class ilAccordionPropertiesStorage
     public $properties = array(
         "opened" => array("storage" => "session")
         );
-    
+
     /**
     * execute command
     */
@@ -50,20 +50,20 @@ class ilAccordionPropertiesStorage
     {
         $ilUser = $this->user;
         $ilCtrl = $this->ctrl;
-        
+
         $cmd = $ilCtrl->getCmd();
         //		$next_class = $this->ctrl->getNextClass($this);
 
         $this->$cmd();
     }
-    
+
     /**
      * Show Filter
      */
     public function setOpenedTab()
     {
         $ilUser = $this->user;
-        
+
         if ($_GET["user_id"] == $ilUser->getId()) {
             switch ($_GET["act"]) {
 
@@ -81,7 +81,7 @@ class ilAccordionPropertiesStorage
                         $_GET["accordion_id"],
                         (int) $_GET["user_id"],
                         "opened",
-                        implode($cur_arr, ";")
+                        implode(";", $cur_arr)
                     );
                     break;
 
@@ -99,7 +99,7 @@ class ilAccordionPropertiesStorage
                         $_GET["accordion_id"],
                         (int) $_GET["user_id"],
                         "opened",
-                        implode($cur_arr, ";")
+                        implode(";", $cur_arr)
                     );
                     break;
 
@@ -124,7 +124,7 @@ class ilAccordionPropertiesStorage
             }
         }
     }
-    
+
     /**
     * Store property in session or db
     */
@@ -141,7 +141,7 @@ class ilAccordionPropertiesStorage
                 $_SESSION["accordion"][$a_table_id][$a_user_id][$a_property]
                     = $a_value;
                 break;
-                
+
             case "db":
 /*
                 $ilDB->replace("table_properties", array(
@@ -154,7 +154,7 @@ class ilAccordionPropertiesStorage
 */
         }
     }
-    
+
     /**
     * Get property in session or db
     */
@@ -168,7 +168,7 @@ class ilAccordionPropertiesStorage
 //echo "<br><br><br><br><br><br><br><br>get-".$r;
                 return $r;
                 break;
-                
+
             case "db":
 /*
                 $set = $ilDB->query("SELECT value FROM table_properties ".

--- a/Services/COPage/classes/class.ilMediaAliasItem.php
+++ b/Services/COPage/classes/class.ilMediaAliasItem.php
@@ -57,7 +57,7 @@ class ilMediaAliasItem
                 return $res->nodeset[0];
             }
         }
-        
+
         $xpc = xpath_new_context($this->dom);
         $path = "//PageContent[@HierId = '" . $a_hier_id . "']/" . $this->parent_node_name . "/MediaAliasItem[@Purpose='$a_purpose']" . $a_sub_element;
         $res = xpath_eval($xpc, $path);
@@ -65,7 +65,7 @@ class ilMediaAliasItem
             return $res->nodeset[0];
         }
     }
-    
+
     public function getParameterNodes($a_hier_id, $a_purpose, $a_pc_id = "")
     {
         if ($a_pc_id != "") {
@@ -77,7 +77,7 @@ class ilMediaAliasItem
             }
             return array();
         }
-        
+
         $xpc = xpath_new_context($this->dom);
         $path = "//PageContent[@HierId = '" . $a_hier_id . "']/" . $this->parent_node_name . "/MediaAliasItem[@Purpose='$a_purpose']/Parameter";
         $res = xpath_eval($xpc, $path);
@@ -97,7 +97,7 @@ class ilMediaAliasItem
             }
             return array();
         }
-        
+
         $xpc = xpath_new_context($this->dom);
         $path = "//PageContent[@HierId = '" . $a_hier_id . "']/" . $this->parent_node_name . "/MediaAliasItem[@Purpose='$a_purpose']/MapArea";
         $res = xpath_eval($xpc, $path);
@@ -473,7 +473,7 @@ class ilMediaAliasItem
             $par_node = $par_nodes[$i];
             $par_arr[] = $par_node->get_attribute("Name") . "=\"" . $par_node->get_attribute("Value") . "\"";
         }
-        return implode($par_arr, ", ");
+        return implode(", ", $par_arr);
     }
 
     /**
@@ -538,7 +538,7 @@ class ilMediaAliasItem
         }
     }
 
-    
+
     /**
     * Get all map areas
     */
@@ -575,10 +575,10 @@ class ilMediaAliasItem
                 "Id" => $maparea_node->get_attribute("Id"),
                 "Link" => $link);
         }
-        
+
         return $maparea_arr;
     }
-    
+
     /**
     * Set title of area
     */
@@ -597,7 +597,7 @@ class ilMediaAliasItem
             }
         }
     }
-    
+
     /**
     * Set link of area to an internal one
     */
@@ -623,7 +623,7 @@ class ilMediaAliasItem
             );
         }
     }
-    
+
     /**
     * Set link of area to an external one
     */
@@ -742,7 +742,7 @@ class ilMediaAliasItem
             );
         }
     }
-    
+
     /**
      * Delete a sinlge map area
      */
@@ -758,7 +758,7 @@ class ilMediaAliasItem
             $ma_nodes[$a_nr - 1]->unlink_node($ma_nodes[$a_nr - 1]);
         }
     }
-    
+
     /**
      * Delete map areas by id
      */
@@ -899,7 +899,7 @@ class ilMediaAliasItem
             $this->item_node->unlink_node($this->item_node);
         }
     }
-    
+
     /**
     * make map work copy of image
     *
@@ -915,12 +915,12 @@ class ilMediaAliasItem
         $a_coords
     ) {
         $lng = $this->lng;
-        
+
         if (!$a_st_item->copyOriginal()) {
             return false;
         }
         $a_st_item->buildMapWorkImage();
-        
+
         // determine ratios (first see whether the instance has w/h defined)
         $width = $this->getWidth();
         $height = $this->getHeight();
@@ -960,7 +960,7 @@ class ilMediaAliasItem
                 );
             }
         }
-        
+
         if ($a_output_new_area) {
             $area = new ilMapArea();
             $area->setShape($a_area_type);
@@ -976,7 +976,7 @@ class ilMediaAliasItem
         }
 
         $a_st_item->saveMapWorkImage();
-        
+
         return true;
     }
 }

--- a/Services/COPage/classes/class.ilPCParagraph.php
+++ b/Services/COPage/classes/class.ilPCParagraph.php
@@ -637,7 +637,7 @@ class ilPCParagraph extends ilPageContent
         // internal links
         //$any = "[^\]]*";	// this doesn't work :-(
         $ws = "[ \t\r\f\v\n]*";
-        $ltypes = "page|chap|term|media|obj|dfile|sess|wpage|ppage|" . implode($rtypes, "|");
+        $ltypes = "page|chap|term|media|obj|dfile|sess|wpage|ppage|" . implode("|", $rtypes);
         // empty internal links
         while (preg_match('~\[(iln' . $ws . '((inst' . $ws . '=' . $ws . '([\"0-9])*)?' . $ws .
             "((" . $ltypes . ")$ws=$ws([\"0-9])*)$ws" .

--- a/Services/COPage/classes/class.ilPageContent.php
+++ b/Services/COPage/classes/class.ilPageContent.php
@@ -58,7 +58,7 @@ abstract class ilPageContent
             die("Error: ilPageContent::init() did not set type");
         }
     }
-    
+
     /**
      * Set page
      *
@@ -68,7 +68,7 @@ abstract class ilPageContent
     {
         $this->pg_obj = $a_val;
     }
-    
+
     /**
      * Get page
      *
@@ -78,7 +78,7 @@ abstract class ilPageContent
     {
         return $this->pg_obj;
     }
-    
+
     /**
     * Init object. This function must be overwritten and at least set
     * the content type.
@@ -114,7 +114,7 @@ abstract class ilPageContent
     {
         $this->node = $a_node;
     }
-    
+
 
     /**
     * Get xml node of page content.
@@ -167,8 +167,8 @@ abstract class ilPageContent
     {
         return $this->hier_id;
     }
-    
-    
+
+
     /**
     * Get hierarchical id from dom
     */
@@ -303,8 +303,8 @@ abstract class ilPageContent
     {
         $id = explode("_", $ed_id);
         $id[count($id) - 1]++;
-        
-        return implode($id, "_");
+
+        return implode("_", $id);
     }
 
     /**
@@ -319,7 +319,7 @@ abstract class ilPageContent
         $id = explode("_", $ed_id);
         $id[count($id) - 1]--;
 
-        return implode($id, "_");
+        return implode("_", $id);
     }
 
     /**
@@ -353,10 +353,10 @@ abstract class ilPageContent
     public static function sortHierIds($a_array)
     {
         uasort($a_array, array("ilPageContent", "isGreaterHierId"));
-        
+
         return $a_array;
     }
-    
+
     /**
     * Check whether Hier ID $a is greater than Hier ID $b
     */
@@ -373,7 +373,7 @@ abstract class ilPageContent
         }
         return false;
     }
-    
+
     /**
     * Set Enabled value for page content component.
     *
@@ -386,7 +386,7 @@ abstract class ilPageContent
             $this->node->set_attribute("Enabled", $value);
         }
     }
-     
+
     /**
     * Enable page content.
     */
@@ -394,7 +394,7 @@ abstract class ilPageContent
     {
         $this->setEnabled("True");
     }
-      
+
     /**
     * Disable page content.
     */
@@ -415,10 +415,10 @@ abstract class ilPageContent
         } else {
             $compare = "True";
         }
-        
+
         return strcasecmp($compare, "true") == 0;
     }
-    
+
     /**
     * Create page content node (always use this method first when adding a new element)
     */
@@ -430,7 +430,7 @@ abstract class ilPageContent
         }
         return $node;
     }
-    
+
     /**
      * Get lang vars needed for editing
      * @return array array of lang var keys
@@ -449,7 +449,7 @@ abstract class ilPageContent
     public static function handleCopiedContent(DOMDocument $a_domdoc, $a_self_ass = true, $a_clone_mobs = false)
     {
     }
-    
+
     /**
      * Modify page content after xsl
      *
@@ -472,7 +472,7 @@ abstract class ilPageContent
     public static function afterPageUpdate($a_page, DOMDocument $a_domdoc, $a_xml, $a_creation)
     {
     }
-    
+
     /**
      * Before page is being deleted
      *

--- a/Services/COPage/classes/class.ilPageContentGUI.php
+++ b/Services/COPage/classes/class.ilPageContentGUI.php
@@ -88,7 +88,7 @@ class ilPageContentGUI
     {
         $this->content_obj = $a_val;
     }
-    
+
     /**
      * Get content object
      *
@@ -98,7 +98,7 @@ class ilPageContentGUI
     {
         return $this->content_obj;
     }
-    
+
     /**
      * Set page
      *
@@ -108,7 +108,7 @@ class ilPageContentGUI
     {
         $this->pg_obj = $a_val;
     }
-    
+
     /**
      * Get page
      *
@@ -179,10 +179,10 @@ class ilPageContentGUI
                 $this->style = new ilObjStyleSheet($this->getStyleId());
             }
         }
-        
+
         return $this->style;
     }
-    
+
     /**
     * Get characteristics of current style
     */
@@ -255,9 +255,9 @@ class ilPageContentGUI
     {
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-        
+
         include_once("./Services/COPage/classes/class.ilPageEditorSettings.php");
-        
+
         $btpl = new ilTemplate("tpl.bb_menu.html", true, true, "Services/COPage");
 
         // not nice, should be set by context per method
@@ -268,7 +268,7 @@ class ilPageContentGUI
                 $this->ctrl->getLinkTargetByClass("ilInternalLinkGUI", "showLinkHelp")
             );
             $btpl->parseCurrentBlock();
-            
+
             // add int link parts
             include_once("./Services/Link/classes/class.ilInternalLinkGUI.php");
             $btpl->setCurrentBlock("int_link_prep");
@@ -313,7 +313,7 @@ class ilPageContentGUI
                 }
             }
         }
-        
+
         if ($this->getPageConfig()->getEnableAnchors()) {
             $btpl->touchBlock("bb_anc_button");
             $btpl->setVariable("TXT_ANC", $lng->txt("cont_anchor") . ":");
@@ -322,10 +322,10 @@ class ilPageContentGUI
 
         include_once("./Services/COPage/classes/class.ilPCParagraphGUI.php");
         $btpl->setVariable("CHAR_STYLE_SELECT", ilPCParagraphGUI::getCharStyleSelector($this->pg_obj->getParentType(), "il.COPageBB.setCharacterClass", $this->getStyleId()));
-        
+
         // footnote
         //		$btpl->setVariable("TXT_FN", $this->lng->txt("cont_text_fn"));
-        
+
         //		$btpl->setVariable("TXT_CODE", $this->lng->txt("cont_text_code"));
         $btpl->setVariable("TXT_ILN", $this->lng->txt("cont_text_iln"));
         $lng->toJS("cont_text_iln");
@@ -334,9 +334,9 @@ class ilPageContentGUI
         $btpl->setVariable("TXT_BB_TIP", $this->lng->txt("cont_bb_tip"));
         $btpl->setVariable("TXT_WLN", $lng->txt("wiki_wiki_page"));
         $lng->toJS("wiki_wiki_page");
-        
+
         $btpl->setVariable("PAR_TA_NAME", $a_ta_name);
-        
+
         return $btpl->get();
     }
 
@@ -427,7 +427,7 @@ class ilPageContentGUI
         }
 
         $a_hid = explode(":", $_POST["target"][0]);
-        
+
         // check if target is within source
         if ($this->hier_id == substr($a_hid[0], 0, strlen($this->hier_id))) {
             $ilErr->raiseError($this->lng->txt("cont_target_within_source"), $ilErr->MESSAGE);
@@ -461,15 +461,15 @@ class ilPageContentGUI
         }
         $this->ctrl->returnToParent($this, "jump" . $this->hier_id);
     }
-    
-    
+
+
     /**
     * split page to new page at specified position
     */
     public function splitPage()
     {
         $ilErr = $this->error;
-        
+
         if ($this->pg_obj->getParentType() != "lm") {
             $ilErr->raiseError("Split method called for wrong parent type (" .
             $this->pg_obj->getParentType() . ")", $ilErr->FATAL);
@@ -479,12 +479,12 @@ class ilPageContentGUI
                 $this->pg_obj->getParentType(),
                 $this->hier_id
             );
-                
+
             // jump to new page
             $this->ctrl->setParameterByClass("illmpageobjectgui", "obj_id", $lm_page->getId());
             $this->ctrl->redirectByClass("illmpageobjectgui", "edit");
         }
-        
+
         $this->ctrl->returnToParent($this, "jump" . ($this->hier_id - 1));
     }
 
@@ -494,7 +494,7 @@ class ilPageContentGUI
     public function splitPageNext()
     {
         $ilErr = $this->error;
-        
+
         if ($this->pg_obj->getParentType() != "lm") {
             $ilErr->raiseError("Split method called for wrong parent type (" .
             $this->pg_obj->getParentType() . ")", $ilErr->FATAL);
@@ -504,7 +504,7 @@ class ilPageContentGUI
                 $this->pg_obj->getParentType(),
                 $this->hier_id
             );
-            
+
             // jump to successor page
             if ($succ_id > 0) {
                 $this->ctrl->setParameterByClass("illmpageobjectgui", "obj_id", $succ_id);
@@ -522,7 +522,7 @@ class ilPageContentGUI
         if (is_array($this->updated)) {
             $error_str = "<b>Error(s):</b><br>";
             foreach ($this->updated as $error) {
-                $err_mess = implode($error, " - ");
+                $err_mess = implode(" - ", $error);
                 if (!is_int(strpos($err_mess, ":0:"))) {
                     $error_str .= htmlentities($err_mess) . "<br />";
                 }
@@ -533,7 +533,7 @@ class ilPageContentGUI
                 $this->updated);
         }
     }
-    
+
     /**
     * cancel creating page content
     */
@@ -565,20 +565,20 @@ class ilPageContentGUI
     public function deactivate()
     {
         $obj = &$this->content_obj;
-        
+
         if ($obj->isEnabled()) {
             $obj->disable();
         } else {
             $obj->enable();
         }
-        
+
         $updated = $this->pg_obj->update($this->hier_id);
         if ($updated !== true) {
             $_SESSION["il_pg_error"] = $updated;
         } else {
             unset($_SESSION["il_pg_error"]);
         }
-    
+
         $this->ctrl->returnToParent($this, "jump" . $this->hier_id);
     }
 
@@ -588,16 +588,16 @@ class ilPageContentGUI
     public function cut()
     {
         $lng = $this->lng;
-        
+
         $obj = $this->content_obj;
-        
+
         $updated = $this->pg_obj->cutContents(array($this->hier_id . ":" . $this->pc_id));
         if ($updated !== true) {
             $_SESSION["il_pg_error"] = $updated;
         } else {
             unset($_SESSION["il_pg_error"]);
         }
-    
+
         //ilUtil::sendSuccess($lng->txt("cont_sel_el_cut_use_paste"), true);
         $this->log->debug("return to parent jump" . $this->hier_id);
         $this->ctrl->returnToParent($this, "jump" . $this->hier_id);
@@ -609,12 +609,12 @@ class ilPageContentGUI
     public function copy()
     {
         $lng = $this->lng;
-        
+
         $obj = $this->content_obj;
-        
+
         //ilUtil::sendSuccess($lng->txt("cont_sel_el_copied_use_paste"), true);
         $this->pg_obj->copyContents(array($this->hier_id . ":" . $this->pc_id));
-  
+
         $this->ctrl->returnToParent($this, "jump" . $this->hier_id);
     }
 

--- a/Services/COPage/classes/class.ilPageEditorGUI.php
+++ b/Services/COPage/classes/class.ilPageEditorGUI.php
@@ -141,7 +141,7 @@ class ilPageEditorGUI
         $this->int_link_return = $a_return;
     }
 
-    
+
     public function setPageBackTitle($a_title)
     {
         $this->page_back_title = $a_title;
@@ -182,7 +182,7 @@ class ilPageEditorGUI
             $pc_id = $pca[1];
             $cmd = explode("_", $pca[0]);
             unset($cmd[0]);
-            $hier_id = implode($cmd, "_");
+            $hier_id = implode("_", $cmd);
             $cmd = $_POST["command" . $hier_id];
         }
         $this->log->debug("step EC: cmd:$cmd, hier_id: $hier_id, pc_id: $pc_id");
@@ -392,7 +392,7 @@ class ilPageEditorGUI
                     $this->ctrl->redirectByClass(array("ilobjquestionpoolgui", get_class($cont_obj)), "editQuestion");
                 }
                 break;
-                    
+
             // Plugged Component
             case "ilpcpluggedgui":
                 $this->tabs_gui->clearTargets();
@@ -408,7 +408,7 @@ class ilPageEditorGUI
                 break;
 
             default:
-                
+
                 // generic calls to gui classes
                 include_once("./Services/COPage/classes/class.ilCOPagePCDef.php");
                 if (ilCOPagePCDef::isPCGUIClassName($next_class, true)) {
@@ -431,7 +431,7 @@ class ilPageEditorGUI
                 } else {
                     $this->log->debug("Call ilPageEditorGUI command.");
                     // cmd belongs to ilPageEditorGUI
-                    
+
                     if ($cmd == "pasteFromClipboard") {
                         $ret = $this->pasteFromClipboard($hier_id);
                     } elseif ($cmd == "paste") {
@@ -448,7 +448,7 @@ class ilPageEditorGUI
 
         return $ret;
     }
-    
+
     /**
     * checks if current user has activated js editing and
     * if browser is js capable
@@ -500,7 +500,7 @@ class ilPageEditorGUI
             }
         }
         $ilUser->writePref("ilPageEditor_JavaScript", $_POST["js_mode"]);
-        
+
         // again not so nice...
         if ($this->page->getParentType() == "lm") {
             $this->ctrl->redirectByClass("illmpageobjectgui", "edit");
@@ -508,14 +508,14 @@ class ilPageEditorGUI
             $this->ctrl->returnToParent($this);
         }
     }
-    
+
     /**
     * copy linked media object to clipboard
     */
     public function copyLinkedMediaToClipboard()
     {
         $ilUser = $this->user;
-        
+
         ilUtil::sendSuccess($this->lng->txt("copied_to_clipboard"), true);
         $ilUser->addObjectToClipboard($_POST["mob_id"], "mob", ilObject::_lookupTitle($_POST["mob_id"]));
         $this->ctrl->returnToParent($this);
@@ -527,11 +527,11 @@ class ilPageEditorGUI
     public function copyLinkedMediaToMediaPool()
     {
         $ilUser = $this->user;
-        
+
         $this->ctrl->setParameterByClass("ilmediapooltargetselector", "mob_id", $_POST["mob_id"]);
         $this->ctrl->redirectByClass("ilmediapooltargetselector", "listPools");
     }
-    
+
     /**
     * add change comment to history
     */
@@ -616,7 +616,7 @@ class ilPageEditorGUI
     public function copySelected()
     {
         $lng = $this->lng;
-        
+
         if (is_int(strpos($_POST["target"][0], ";"))) {
             $_POST["target"] = explode(";", $_POST["target"][0]);
         }
@@ -633,7 +633,7 @@ class ilPageEditorGUI
     public function cutSelected()
     {
         $lng = $this->lng;
-        
+
         if (is_int(strpos($_POST["target"][0], ";"))) {
             $_POST["target"] = explode(";", $_POST["target"][0]);
         }
@@ -691,13 +691,13 @@ class ilPageEditorGUI
     {
         $tpl = $this->tpl;
         $lng = $this->lng;
-        
+
         if (is_int(strpos($_POST["target"][0], ";"))) {
             $_POST["target"] = explode(";", $_POST["target"][0]);
         }
         if (is_array($_POST["target"])) {
             $types = array();
-            
+
             // check what content element types have been selected
             foreach ($_POST["target"] as $t) {
                 $tarr = explode(":", $t);
@@ -709,7 +709,7 @@ class ilPageEditorGUI
                     $types["sec"] = "sec";
                 }
             }
-        
+
             if (count($types) == 0) {
                 ilUtil::sendFailure($lng->txt("cont_select_par_or_section"), true);
                 $this->ctrl->returnToParent($this);
@@ -729,13 +729,13 @@ class ilPageEditorGUI
     {
         $ilCtrl = $this->ctrl;
         $lng = $this->lng;
-        
-        
+
+
         // edit form
         include_once("./Services/Form/classes/class.ilPropertyFormGUI.php");
         $this->form = new ilPropertyFormGUI();
         $this->form->setTitle($this->lng->txt("cont_choose_characteristic"));
-        
+
         if ($a_types["par"] == "par") {
             $select_prop = new ilSelectInputGUI(
                 $this->lng->txt("cont_choose_characteristic_text"),
@@ -756,7 +756,7 @@ class ilPageEditorGUI
             $select_prop->setOptions($options);
             $this->form->addItem($select_prop);
         }
-        
+
         foreach ($a_target as $t) {
             $hidden = new ilHiddenInputGUI("target[]");
             $hidden->setValue($t);
@@ -858,7 +858,7 @@ class ilPageEditorGUI
     {
         $this->ctrl->returnToParent($this);
     }
-    
+
     /**
     * display locator
     */
@@ -879,9 +879,9 @@ class ilPageEditorGUI
         $lng = $this->lng;
         $ilAccess = $this->access;
         $ilCtrl = $this->ctrl;
-        
+
         $stpl = new ilTemplate("tpl.snippet_info.html", true, true, "Services/COPage");
-        
+
         include_once("./Modules/MediaPool/classes/class.ilMediaPoolItem.php");
         $mep_pools = ilMediaPoolItem::getPoolForItemId($_POST["ci_id"]);
         foreach ($mep_pools as $mep_id) {
@@ -903,7 +903,7 @@ class ilPageEditorGUI
             $stpl->setVariable("VAL_MEDIA_POOL", ilObject::_lookupTitle($mep_id));
             $stpl->parseCurrentBlock();
         }
-        
+
         include_once("./Modules/MediaPool/classes/class.ilMediaPoolPage.php");
         $stpl->setVariable("TXT_TITLE", $lng->txt("title"));
         $stpl->setVariable("VAL_TITLE", ilMediaPoolPage::lookupTitle($_POST["ci_id"]));

--- a/Services/COPage/classes/class.ilPageObject.php
+++ b/Services/COPage/classes/class.ilPageObject.php
@@ -33,7 +33,7 @@ define("IL_NO_HEADER", "none");
        main xslt file
 
 */
- 
+
 /**
  * Class ilPageObject
  *
@@ -159,24 +159,24 @@ abstract class ilPageObject
                 "Section", "Tab", "ContentPopup", "GridCell");
         $this->setActive(true);
         $this->show_page_act_info = false;
-        
+
         if ($a_id != 0) {
             $this->read();
         }
-        
+
         $this->initPageConfig();
-        
+
         $this->afterConstructor();
     }
-    
+
     /**
      * After constructor
      */
     public function afterConstructor()
     {
     }
-    
-    
+
+
     /**
      * Get parent type
      *
@@ -194,7 +194,7 @@ abstract class ilPageObject
         $cfg = ilPageObjectFactory::getConfigInstance($this->getParentType());
         $this->setPageConfig($cfg);
     }
-    
+
     /**
      * Set language
      *
@@ -204,7 +204,7 @@ abstract class ilPageObject
     {
         $this->language = $a_val;
     }
-    
+
     /**
      * Get language
      *
@@ -214,7 +214,7 @@ abstract class ilPageObject
     {
         return $this->language;
     }
-    
+
     /**
      * Set page config object
      *
@@ -224,7 +224,7 @@ abstract class ilPageObject
     {
         $this->page_config = $a_val;
     }
-    
+
     /**
      * Get page config object
      *
@@ -314,7 +314,7 @@ abstract class ilPageObject
     {
         return $this->lastchange;
     }
-    
+
     /**
      * Set last change user
      *
@@ -334,7 +334,7 @@ abstract class ilPageObject
     {
         return $this->last_change_user;
     }
-    
+
     /**
      * Set show page activation info
      *
@@ -344,7 +344,7 @@ abstract class ilPageObject
     {
         $this->show_page_act_info = $a_val;
     }
-    
+
     /**
      * Get show page activation info
      *
@@ -396,7 +396,7 @@ abstract class ilPageObject
         $this->setRenderedTime($this->page_record["rendered_time"]);
         $this->setLastChange($this->page_record["last_change"]);
     }
-    
+
     /**
      * Checks whether page exists
      *
@@ -413,12 +413,12 @@ abstract class ilPageObject
         if (!$a_no_cache && isset(self::$exists[$a_parent_type . ":" . $a_id . ":" . $a_lang])) {
             return self::$exists[$a_parent_type . ":" . $a_id . ":" . $a_lang];
         }
-        
+
         $and_lang = "";
         if ($a_lang != "") {
             $and_lang = " AND lang = " . $db->quote($a_lang, "text");
         }
-        
+
         $query = "SELECT page_id FROM page_object WHERE page_id = " . $db->quote($a_id, "integer") . " " .
             "AND parent_type = " . $db->quote($a_parent_type, "text") . $and_lang;
         $set = $db->query($query);
@@ -489,7 +489,7 @@ abstract class ilPageObject
     {
         return $this->dom;
     }
-    
+
     /**
      * Get dom doc (php5 dom document)
      *
@@ -501,10 +501,10 @@ abstract class ilPageObject
         if ($this->dom instanceof php4DOMDocument) {
             return $this->dom->myDOMDocument;
         }
-        
+
         return $this->dom;
     }
-    
+
 
     /**
     * set id
@@ -605,7 +605,7 @@ abstract class ilPageObject
         global $DIC;
 
         $db = $DIC->database();
-        
+
         // language must be set at least to "-"
         if ($a_lang == "") {
             $a_lang = "-";
@@ -632,7 +632,7 @@ abstract class ilPageObject
                 return true;
             }
         }
-        
+
         return $rec["active"];
     }
 
@@ -644,7 +644,7 @@ abstract class ilPageObject
         global $DIC;
 
         $db = $DIC->database();
-        
+
         // language must be set at least to "-"
         if ($a_lang == "") {
             $a_lang = "-";
@@ -667,7 +667,7 @@ abstract class ilPageObject
         if (!$rec["active"] && $rec["activation_start"] != "") {
             return true;
         }
-        
+
         return false;
     }
 
@@ -679,7 +679,7 @@ abstract class ilPageObject
         global $DIC;
 
         $db = $DIC->database();
-        
+
         // language must be set at least to "-"
         if ($a_lang == "") {
             $a_lang = "-";
@@ -728,11 +728,11 @@ abstract class ilPageObject
             );
             $rec = $db->fetchAssoc($set);
         }
-        
+
         return $rec;
     }
 
-    
+
     /**
     * Lookup parent id
     */
@@ -741,13 +741,13 @@ abstract class ilPageObject
         global $DIC;
 
         $db = $DIC->database();
-        
+
         $res = $db->query("SELECT parent_id FROM page_object WHERE page_id = " . $db->quote($a_id, "integer") . " " .
                 "AND parent_type=" . $db->quote($a_type, "text"));
         $rec = $db->fetchAssoc($res);
         return $rec["parent_id"];
     }
-    
+
     /**
      * Write parent id
      */
@@ -763,7 +763,7 @@ abstract class ilPageObject
             array($a_par_id, $a_pg_id, $a_parent_type)
         );
     }
-    
+
     /**
     * Set Activation Start.
     *
@@ -833,7 +833,7 @@ abstract class ilPageObject
             $child_node = $cont_node->first_child();
             $node_name = $child_node->node_name();
         }
-        
+
         // table extra handling (@todo: get rid of it)
         if ($node_name == "Table") {
             if ($child_node->get_attribute("DataTable") == "y") {
@@ -860,12 +860,12 @@ abstract class ilPageObject
 
             //require_once("./Services/MediaObjects/classes/class.ilObjMediaObject.php");
             require_once("./Services/COPage/classes/class.ilPCMediaObject.php");
-            
+
             $mal_node = $child_node->first_child();
             //echo "ilPageObject::getContentObject:nodename:".$mal_node->node_name().":<br>";
             $id_arr = explode("_", $mal_node->get_attribute("OriginId"));
             $mob_id = $id_arr[count($id_arr) - 1];
-            
+
             // allow deletion of non-existing media objects
             if (!ilObject::_exists($mob_id) && in_array("delete", $_POST)) {
                 $mob_id = 0;
@@ -874,7 +874,7 @@ abstract class ilPageObject
             //$mob = new ilObjMediaObject($mob_id);
             $mob = new ilPCMediaObject($this);
             $mob->readMediaObject($mob_id);
-            
+
             //$mob->setDom($this->dom);
             $mob->setNode($cont_node);
             $mob->setHierId($a_hier_id);
@@ -885,9 +885,9 @@ abstract class ilPageObject
         //
         // generic procedure
         //
-        
+
         $pc_def = ilCOPagePCDef::getPCDefinitionByName($node_name);
-        
+
         // check if pc definition has been found
         if (!is_array($pc_def)) {
             include_once("./Services/COPage/exceptions/class.ilCOPageUnknownPCTypeException.php");
@@ -924,7 +924,7 @@ abstract class ilPageObject
                     return $cont_node;
                 }
             }
-            
+
             // fall back to hier id
             $path = "//*[@HierId = '$a_hier_id']";
             $res = xpath_eval($xpc, $path);
@@ -952,7 +952,7 @@ abstract class ilPageObject
                 return true;
             }
         }
-        
+
         // fall back to hier id
         $path = "//*[@HierId = '$a_hier_id']//" . $a_content_tag;
         $res = xpath_eval($xpc, $path);
@@ -961,7 +961,7 @@ abstract class ilPageObject
         }
         return false;
     }
-    
+
     // only for test purposes
     public function lookforhier($a_hier_id)
     {
@@ -1027,7 +1027,7 @@ abstract class ilPageObject
             return $this->xml;
         }
     }
-    
+
     /**
     * Copy content of page; replace page components with copies
     * where necessary (e.g. questions)
@@ -1072,10 +1072,10 @@ abstract class ilPageObject
         } else {
             $this->removeQuestions($a_dom);
         }
-        
+
         // handle interactive images
         $this->newIIMCopies($a_dom);
-        
+
         // handle media objects
         if ($a_clone_mobs) {
             $this->newMobCopies($a_dom);
@@ -1143,7 +1143,7 @@ abstract class ilPageObject
         include_once("./Services/Link/classes/class.ilInternalLink.php");
         for ($i = 0; $i < count($res->nodeset); $i++) {
             $or_id = $res->nodeset[$i]->get_attribute("OriginId");
-            
+
             $inst_id = ilInternalLink::_extractInstOfTarget($or_id);
             $mob_id = ilInternalLink::_extractObjIdOfTarget($or_id);
 
@@ -1155,13 +1155,13 @@ abstract class ilPageObject
                     // now copy this question and change reference to
                     // new question id
                     $new_mob = $media_object->duplicate();
-                    
+
                     $res->nodeset[$i]->set_attribute("OriginId", "il__mob_" . $new_mob->getId());
                 }
             }
         }
     }
-    
+
     /**
      * Replaces media objects with copies
      */
@@ -1176,7 +1176,7 @@ abstract class ilPageObject
         include_once("./Services/Link/classes/class.ilInternalLink.php");
         for ($i = 0; $i < count($res->nodeset); $i++) {
             $or_id = $res->nodeset[$i]->get_attribute("OriginId");
-            
+
             $inst_id = ilInternalLink::_extractInstOfTarget($or_id);
             $mob_id = ilInternalLink::_extractObjIdOfTarget($or_id);
 
@@ -1188,13 +1188,13 @@ abstract class ilPageObject
                     // now copy this question and change reference to
                     // new question id
                     $new_mob = $media_object->duplicate();
-                    
+
                     $res->nodeset[$i]->set_attribute("OriginId", "il__mob_" . $new_mob->getId());
                 }
             }
         }
     }
-    
+
     /**
      * Replaces existing question content elements with
      * new copies
@@ -1210,7 +1210,7 @@ abstract class ilPageObject
         include_once("./Services/Link/classes/class.ilInternalLink.php");
         for ($i = 0; $i < count($res->nodeset); $i++) {
             $qref = $res->nodeset[$i]->get_attribute("QRef");
-            
+
             $inst_id = ilInternalLink::_extractInstOfTarget($qref);
             $q_id = ilInternalLink::_extractObjIdOfTarget($qref);
 
@@ -1235,7 +1235,7 @@ abstract class ilPageObject
             }
         }
     }
-    
+
     /**
      * Remove questions from document
      *
@@ -1253,9 +1253,9 @@ abstract class ilPageObject
             $parent_node->unlink_node($parent_node);
         }
     }
-    
+
     // @todo: end
-    
+
     /**
      * Remove questions from document
      *
@@ -1271,7 +1271,7 @@ abstract class ilPageObject
         $res = &xpath_eval($xpc, $path);
         return count($res->nodeset);
     }
-    
+
     /**
     * get xml content of page from dom
     * (use this, if any changes are made to the document)
@@ -1341,14 +1341,14 @@ abstract class ilPageObject
             "ed_item_up", "ed_item_down", "ed_split_page_next","ed_enable",
             "de_activate", "ed_paste", "ed_edit_multiple", "ed_cut", "ed_copy", "ed_insert_templ",
             "ed_click_to_add_pg", "download");
-        
+
         // collect lang vars from pc elements
         include_once("./Services/COPage/classes/class.ilCOPagePCDef.php");
         $defs = ilCOPagePCDef::getPCDefinitions();
         foreach ($defs as $def) {
             $lang_vars[] = "pc_" . $def["pc_type"];
             $lang_vars[] = "ed_insert_" . $def["pc_type"];
-            
+
             ilCOPagePCDef::requirePCClassByName($def["name"]);
             $cl = $def["pc_class"];
             $lvs = call_user_func($def["pc_class"] . '::getLangVars');
@@ -1409,7 +1409,7 @@ abstract class ilPageObject
 
     // @todo end
 
-    
+
     /**
     * lm parser set this flag to true, if the page contains intern links
     * (this method should only be called by the import parser)
@@ -1433,7 +1433,7 @@ abstract class ilPageObject
     {
         return $this->contains_int_link;
     }
-    
+
     /**
      * Set import mode
      *
@@ -1443,7 +1443,7 @@ abstract class ilPageObject
     {
         $this->import_mode = $a_val;
     }
-    
+
     /**
      * Get import mode
      *
@@ -1565,13 +1565,13 @@ abstract class ilPageObject
             $links[$target . ":" . $type . ":" . $targetframe . ":" . $anchor . $add] =
                 array("Target" => $target, "Type" => $type,
                     "TargetFrame" => $targetframe, "Anchor" => $anchor);
-                    
+
             // get links (image map areas) for inline media objects
             if ($type == "MediaObject" && $targetframe == "") {
                 if (substr($target, 0, 4) == "il__") {
                     $id_arr = explode("_", $target);
                     $id = $id_arr[count($id_arr) - 1];
-    
+
                     $med_links = ilMediaItem::_getMapAreasIntLinks($id);
                     foreach ($med_links as $key => $med_link) {
                         $links[$key] = $med_link;
@@ -1687,7 +1687,7 @@ abstract class ilPageObject
         // set hierarchical ids for Paragraphs, Tables, TableRows and TableData elements
         $xpc = xpath_new_context($this->dom);
         //$path = "//Paragraph | //Table | //TableRow | //TableData";
-        
+
         $sep = $path = "";
         foreach ($this->id_elements as $el) {
             $path .= $sep . "//" . $el;
@@ -1790,7 +1790,7 @@ abstract class ilPageObject
     {
         return $this->first_row_ids;
     }
-    
+
     /**
     * get ids of all first table columns
     */
@@ -1799,7 +1799,7 @@ abstract class ilPageObject
     {
         return $this->first_col_ids;
     }
-    
+
     /**
     * get ids of all list items
     */
@@ -1808,7 +1808,7 @@ abstract class ilPageObject
     {
         return $this->list_item_ids;
     }
-    
+
     /**
     * get ids of all file items
     */
@@ -1817,7 +1817,7 @@ abstract class ilPageObject
     {
         return $this->file_item_ids;
     }
-    
+
     /**
     * strip all hierarchical id attributes out of the dom tree
     */
@@ -1903,7 +1903,7 @@ abstract class ilPageObject
     public function resolveIntLinks($a_link_map = null)
     {
         $changed = false;
-        
+
         $this->log->debug("start");
 
         // resolve normal internal links
@@ -2100,9 +2100,9 @@ abstract class ilPageObject
     public function moveIntLinks($a_from_to)
     {
         $this->buildDom();
-        
+
         $changed = false;
-        
+
         // resolve normal internal links
         $xpc = xpath_new_context($this->dom);
         $path = "//IntLink";
@@ -2127,13 +2127,13 @@ abstract class ilPageObject
             }
         }
         unset($xpc);
-        
+
         // map areas
         $this->addHierIDs();
         $xpc = xpath_new_context($this->dom);
         $path = "//MediaAlias";
         $res = xpath_eval($xpc, $path);
-        
+
         require_once("Services/MediaObjects/classes/class.ilMediaItem.php");
         require_once("Services/COPage/classes/class.ilMediaAliasItem.php");
 
@@ -2171,7 +2171,7 @@ abstract class ilPageObject
                 if (substr($oid, 0, 4) == "il__") {
                     $id_arr = explode("_", $oid);
                     $id = $id_arr[count($id_arr) - 1];
-    
+
                     $mob = new ilObjMediaObject($id);
                     $med_item = $mob->getMediaItem("Standard");
                     $med_areas = $med_item->getMapAreas();
@@ -2180,7 +2180,7 @@ abstract class ilPageObject
                         $link_type = ($area->getLinkType() == "int")
                             ? "IntLink"
                             : "ExtLink";
-                        
+
                         $areas[] = array(
                             "Nr" => $area->getNr(),
                             "Shape" => $area->getShape(),
@@ -2207,7 +2207,7 @@ abstract class ilPageObject
                     }
                 }
             }
-            
+
             // correct map area links
             if ($correction_needed) {
                 $changed = true;
@@ -2226,7 +2226,7 @@ abstract class ilPageObject
                             }
                         }
                     }
-                    
+
                     $std_alias_item->addMapArea(
                         $area["Shape"],
                         $area["Coords"],
@@ -2255,7 +2255,7 @@ abstract class ilPageObject
     public static function _handleImportRepositoryLinks($a_rep_import_id, $a_rep_type, $a_rep_ref_id)
     {
         include_once("./Services/Link/classes/class.ilInternalLink.php");
-        
+
         //echo "-".$a_rep_import_id."-".$a_rep_ref_id."-";
         $sources = ilInternalLink::_getSourcesOfTarget(
             "obj",
@@ -2283,12 +2283,12 @@ abstract class ilPageObject
             }
         }
     }
-        
+
     // @todo: generalize, internal links usage info
     public function handleImportRepositoryLink($a_rep_import_id, $a_rep_type, $a_rep_ref_id)
     {
         $this->buildDom();
-        
+
         // resolve normal internal links
         $xpc = xpath_new_context($this->dom);
         $path = "//IntLink";
@@ -2452,14 +2452,14 @@ abstract class ilPageObject
             $this->setXMLContent("<PageObject></PageObject>");
             $empty = true;
         }
-        
+
         $content = $this->getXMLContent();
         $this->buildDom(true);
         $dom_doc = $this->getDomDoc();
-        
+
         $iel = $this->containsDeactivatedElements($content);
         $inl = $this->containsIntLinks($content);
-                
+
         // create object
         $this->db->insert("page_object", array(
             "page_id" => array("integer", $this->getId()),
@@ -2478,7 +2478,7 @@ abstract class ilPageObject
             "created" => array("timestamp", ilUtil::now()),
             "last_change" => array("timestamp", ilUtil::now())
             ));
-        
+
         // after update event
         $this->__afterUpdate($dom_doc, $content, true, $empty);
     }
@@ -2529,7 +2529,7 @@ abstract class ilPageObject
 
         return true;
     }
-    
+
     /**
      * After update event handler (internal). The hooks are e.g. for
      * storing any dependent relations/references in the database.
@@ -2557,14 +2557,14 @@ abstract class ilPageObject
                 call_user_func($def["pc_class"] . '::afterPageUpdate', $this, $a_domdoc, $a_xml, $a_creation);
             }
         }
-                
+
         // call page hook
         $this->afterUpdate($a_domdoc, $a_xml);
-        
+
         // call update listeners
         $this->callUpdateListeners();
     }
-    
+
     /**
      * After update
      *
@@ -2574,7 +2574,7 @@ abstract class ilPageObject
     public function afterUpdate()
     {
     }
-    
+
 
     /**
      * update complete page content in db (dom xml content is used)
@@ -2617,11 +2617,11 @@ abstract class ilPageObject
             // @todo 1: is this page type or pc content type
             // related -> plugins should be able to hook in!?
             $this->performAutomaticModifications();
-            
+
             // get xml content
             $content = $this->getXMLFromDom();
             $dom_doc = $this->getDomDoc();
-            
+
             // this needs to be locked
 
             // write history entry
@@ -2665,7 +2665,7 @@ abstract class ilPageObject
                             "ilias_version" => array("text", ILIAS_VERSION_NUMERIC),
                             "nr" => array("integer", (int) $last_nr["mnr"] + 1)
                             ));
-                        
+
                         $old_content = $old_rec["content"];
                         $old_domdoc = new DOMDocument();
                         $old_nr = $last_nr["mnr"] + 1;
@@ -2673,7 +2673,7 @@ abstract class ilPageObject
 
                         // after history entry creation event
                         $this->__afterHistoryEntry($old_domdoc, $old_content, $old_nr);
-                        
+
                         $this->history_saved = true;		// only save one time
                     } else {
                         $this->history_saved = true;		// do not save on first change
@@ -2684,7 +2684,7 @@ abstract class ilPageObject
             $em = (trim($content) == "<PageObject/>")
                 ? 1
                 : 0;
-            
+
             // @todo: pass dom instead?
             $iel = $this->containsDeactivatedElements($content);
             $inl = $this->containsIntLinks($content);
@@ -2706,7 +2706,7 @@ abstract class ilPageObject
                 "parent_type" => array("text", $this->getParentType()),
                 "lang" => array("text", $this->getLanguage())
                 ));
-                        
+
             // after update event
             $this->__afterUpdate($dom_doc, $content);
 
@@ -2719,7 +2719,7 @@ abstract class ilPageObject
         }
     }
 
-    
+
 
     /**
      * delete page object
@@ -2736,7 +2736,7 @@ abstract class ilPageObject
 
         $mobs = array();
         $files = array();
-        
+
         if (!$this->page_not_found) {
             $this->buildDom();
             $mobs = $this->collectMediaObjects(false);
@@ -2787,7 +2787,7 @@ abstract class ilPageObject
                 $copg_logger->debug("ilPageObject: ... type mismatch. Ignoring mob " . $mob_id . ".");
                 continue;
             }
-            
+
             if (ilObject::_exists($mob_id)) {
                 $copg_logger->debug("ilPageObject: ... delete mob " . $mob_id . ".");
 
@@ -2815,7 +2815,7 @@ abstract class ilPageObject
             call_user_func($def["pc_class"] . '::beforePageDelete', $this);
         }
     }
-    
+
     /**
      * Before deletion handler (internal).
      *
@@ -2825,7 +2825,7 @@ abstract class ilPageObject
     {
         // save style usage
         $this->saveStyleUsage($a_old_domdoc, $a_old_nr);
-        
+
         // pc classes hook
         include_once("./Services/COPage/classes/class.ilCOPagePCDef.php");
         $defs = ilCOPagePCDef::getPCDefinitions();
@@ -2905,7 +2905,7 @@ abstract class ilPageObject
                     }
                     $template = 1;
                     break;
-                
+
                 case "List":
                     $sname = $node->getAttribute("Class");
                     if ($node->getAttribute("Type") == "Ordered") {
@@ -2921,10 +2921,10 @@ abstract class ilPageObject
                     "stype" => $stype, "template" => $template);
             }
         }
-        
-        
+
+
         $this->deleteStyleUsages($a_old_nr);
-        
+
         foreach ($usages as $u) {
             $id = $this->db->nextId('page_style_usage');
 
@@ -2941,7 +2941,7 @@ abstract class ilPageObject
                 ")");
         }
     }
-    
+
     /**
      * Delete style usages
      *
@@ -2962,7 +2962,7 @@ abstract class ilPageObject
             $and_old_nr
         );
     }
-    
+
 
     /**
     * Get last update of included elements (media objects and files).
@@ -3000,8 +3000,8 @@ abstract class ilPageObject
             $this->getLanguage()
         );
     }
-    
-    
+
+
     /**
      * save internal links of page
      *
@@ -3104,7 +3104,7 @@ abstract class ilPageObject
             return $this->update();
         }
     }
-    
+
 
     /**
      * Delete multiple content objects
@@ -3121,7 +3121,7 @@ abstract class ilPageObject
         foreach ($a_hids as $a_hid) {
             $a_hid = explode(":", $a_hid);
             //echo "-".$a_hid[0]."-".$a_hid[1]."-";
-            
+
             // @todo 1: hook
             // do not delete question nodes in assessment pages
             if (!$this->checkForTag("Question", $a_hid[0], $a_hid[1]) || $a_self_ass) {
@@ -3139,7 +3139,7 @@ abstract class ilPageObject
             return $this->update();
         }
     }
-    
+
     /**
      * Copy contents to clipboard and cut them from the page
      *
@@ -3150,7 +3150,7 @@ abstract class ilPageObject
         $this->copyContents($a_hids);
         return $this->deleteContents($a_hids, true, $this->getPageConfig()->getEnableSelfAssessment());
     }
-    
+
     /**
      * Copy contents to clipboard
      *
@@ -3165,7 +3165,7 @@ abstract class ilPageObject
         }
 
         $time = date("Y-m-d H:i:s", time());
-        
+
         $hier_ids = array();
         $skip = array();
         foreach ($a_hids as $a_hid) {
@@ -3173,7 +3173,7 @@ abstract class ilPageObject
                 continue;
             }
             $a_hid = explode(":", $a_hid);
-            
+
             // check, whether new hid is child of existing one or vice versa
             reset($hier_ids);
             foreach ($hier_ids as $h) {
@@ -3203,7 +3203,7 @@ abstract class ilPageObject
                     // remove pc and hier ids
                     $content = preg_replace('/PCID=\"[a-z0-9]*\"/i', "", $content);
                     $content = preg_replace('/HierId=\"[a-z0-9_]*\"/i', "", $content);
-                    
+
                     $user->addToPCClipboard($content, $time, $nr);
                     $nr++;
                 }
@@ -3219,10 +3219,10 @@ abstract class ilPageObject
     public function pasteContents($a_hier_id, $a_self_ass = false)
     {
         $user = $this->user;
-        
+
         $a_hid = explode(":", $a_hier_id);
         $content = $user->getPCClipboardContent();
-        
+
         // we insert from last to first, because we insert all at the
         // same hier_id
         for ($i = count($content) - 1; $i >= 0; $i--) {
@@ -3255,7 +3255,7 @@ abstract class ilPageObject
         $e = $this->update();
         //var_dump($e);
     }
-    
+
     /**
      * (De-)activate elements
      */
@@ -3265,7 +3265,7 @@ abstract class ilPageObject
             return;
         }
         $obj = &$this->content_obj;
-        
+
         foreach ($a_hids as $a_hid) {
             $a_hid = explode(":", $a_hid);
             $curr_node = $this->getContentNode($a_hid[0], $a_hid[1]);
@@ -3283,7 +3283,7 @@ abstract class ilPageObject
                 }
             }
         }
-        
+
         if ($a_update) {
             return $this->update();
         }
@@ -3300,7 +3300,7 @@ abstract class ilPageObject
     public function deleteContentFromHierId($a_hid, $a_update = true)
     {
         $hier_ids = $this->getHierIds();
-        
+
         // iterate all hierarchical ids
         foreach ($hier_ids as $hier_id) {
             // delete top level nodes only
@@ -3327,7 +3327,7 @@ abstract class ilPageObject
     public function deleteContentBeforeHierId($a_hid, $a_update = true)
     {
         $hier_ids = $this->getHierIds();
-        
+
         // iterate all hierarchical ids
         foreach ($hier_ids as $hier_id) {
             // delete top level nodes only
@@ -3343,8 +3343,8 @@ abstract class ilPageObject
             return $this->update();
         }
     }
-    
-    
+
+
     /**
     * move content of hierarchical id >= $a_hid to other page
     *
@@ -3407,7 +3407,7 @@ abstract class ilPageObject
         // move mode into container elements is always INSERT_CHILD
         $curr_node = $this->getContentNode($a_pos, $a_pcid);
         $curr_name = $curr_node->node_name();
-        
+
         // @todo: try to generalize this
         if (($curr_name == "TableData") || ($curr_name == "PageObject") ||
             ($curr_name == "ListItem") || ($curr_name == "Section")
@@ -3421,12 +3421,12 @@ abstract class ilPageObject
             //echo "-".$a_pos."-".$hid."-";
             $a_pos = $hid;
         }
-        
+
         if ($a_mode != IL_INSERT_CHILD) {			// determine parent hierarchical id
             // of sibling at $a_pos
             $pos = explode("_", $a_pos);
             $target_pos = array_pop($pos);
-            $parent_pos = implode($pos, "_");
+            $parent_pos = implode("_", $pos);
         } else {		// if we should insert a child, $a_pos is alreade the hierarchical id
             // of the parent node
             $parent_pos = $a_pos;
@@ -3480,7 +3480,7 @@ abstract class ilPageObject
 //echo "PP";
                 break;
         }
-                
+
         //check for PlaceHolder to remove in EditMode-keep in Layout Mode
         if (!$this->getPageConfig()->getEnablePCType("PlaceHolder")) {
             $sub_nodes = $curr_node->child_nodes() ;
@@ -3500,7 +3500,7 @@ abstract class ilPageObject
         // move mode into container elements is always INSERT_CHILD
         $curr_node = $this->getContentNode($a_pos, $a_pcid);
         $curr_name = $curr_node->node_name();
-        
+
         // @todo: try to generalize
         if (($curr_name == "TableData") || ($curr_name == "PageObject") ||
             ($curr_name == "ListItem") || ($curr_name == "Section")
@@ -3513,12 +3513,12 @@ abstract class ilPageObject
         if ($hid != "") {
             $a_pos = $hid;
         }
-        
+
         if ($a_mode != IL_INSERT_CHILD) {			// determine parent hierarchical id
             // of sibling at $a_pos
             $pos = explode("_", $a_pos);
             $target_pos = array_pop($pos);
-            $parent_pos = implode($pos, "_");
+            $parent_pos = implode("_", $pos);
         } else {		// if we should insert a child, $a_pos is alreade the hierarchical id
             // of the parent node
             $parent_pos = $a_pos;
@@ -3645,16 +3645,16 @@ abstract class ilPageObject
 
             if (substr($target, 0, 4) == "il__") {
                 $id = substr($target, 4, strlen($target) - 4);
-                
+
                 // convert repository links obj_<ref_id> to <type>_<obj_id>
                 // this leads to bug 6685.
                 if ($a_res_ref_to_obj_id && $type == "RepositoryItem") {
                     $id_arr = explode("_", $id);
-                    
+
                     // changed due to bug 6685
                     $ref_id = $id_arr[1];
                     $obj_id = ilObject::_lookupObjId($id_arr[1]);
-                    
+
                     $otype = ilObject::_lookupType($obj_id);
                     if ($obj_id > 0) {
                         // changed due to bug 6685
@@ -3674,7 +3674,7 @@ abstract class ilPageObject
         unset($xpc);
 
         // @todo: move to media/fileitems/questions, ...
-        
+
         // insert inst id into media aliases
         $xpc = xpath_new_context($this->dom);
         $path = "//MediaAlias";
@@ -3700,7 +3700,7 @@ abstract class ilPageObject
             }
         }
         unset($xpc);
-        
+
         // insert inst id into question references
         $xpc = xpath_new_context($this->dom);
         $path = "//Question";
@@ -3736,14 +3736,14 @@ abstract class ilPageObject
     {
         $this->builddom();
         $mydom = $this->dom;
-        
+
         $sep = $path = "";
         foreach ($this->id_elements as $el) {
             $path .= $sep . "//" . $el . "[not(@PCID)]";
             $sep = " | ";
             $path .= $sep . "//" . $el . "[@PCID='']";
         }
-        
+
         $xpc = xpath_new_context($mydom);
         $res = &xpath_eval($xpc, $path);
 
@@ -3763,7 +3763,7 @@ abstract class ilPageObject
     {
         $this->builddom();
         $mydom = $this->dom;
-        
+
         $pcids = array();
 
         $sep = $path = "";
@@ -3771,7 +3771,7 @@ abstract class ilPageObject
             $path .= $sep . "//" . $el . "[@PCID]";
             $sep = " | ";
         }
-        
+
         // get existing ids
         $xpc = xpath_new_context($mydom);
         $res = &xpath_eval($xpc, $path);
@@ -3782,7 +3782,7 @@ abstract class ilPageObject
         }
         return $pcids;
     }
-    
+
     /**
      * existsPCId
      *
@@ -3793,7 +3793,7 @@ abstract class ilPageObject
     {
         $this->builddom();
         $mydom = $this->dom;
-        
+
         $pcids = array();
 
         $sep = $path = "";
@@ -3801,7 +3801,7 @@ abstract class ilPageObject
             $path .= $sep . "//" . $el . "[@PCID='" . $a_pc_id . "']";
             $sep = " | ";
         }
-        
+
         // get existing ids
         $xpc = xpath_new_context($mydom);
         $res = &xpath_eval($xpc, $path);
@@ -3822,8 +3822,8 @@ abstract class ilPageObject
         $id = ilUtil::randomHash(10, $a_pc_ids);
         return $id;
     }
-    
-    
+
+
     /**
      * Insert Page Content IDs
      */
@@ -3831,7 +3831,7 @@ abstract class ilPageObject
     {
         $this->builddom();
         $mydom = $this->dom;
-        
+
         $pcids = $this->getAllPCIds();
 
         // add missing ones
@@ -3853,7 +3853,7 @@ abstract class ilPageObject
             $res->nodeset[$i]->set_attribute("PCID", $id);
         }
     }
-    
+
     /**
     * Get page contents hashes
     */
@@ -3862,7 +3862,7 @@ abstract class ilPageObject
         $this->builddom();
         $this->addHierIds();
         $mydom = $this->dom;
-        
+
         // get existing ids
         $path = "//PageContent";
         $xpc = xpath_new_context($mydom);
@@ -3878,7 +3878,7 @@ abstract class ilPageObject
                 $dump = substr($dump, 0, $hpos) .
                     substr($dump, $hpos + strlen(' HierId="' . $hier_id . '"'));
             }
-            
+
             $childs = $res->nodeset[$i]->child_nodes();
             $content = "";
             if ($childs[0] && $childs[0]->node_name() == "Paragraph") {
@@ -3897,10 +3897,10 @@ abstract class ilPageObject
             $hashes[$pc_id] =
                 array("hier_id" => $hier_id, "hash" => md5($dump), "content" => $content);
         }
-        
+
         return $hashes;
     }
-    
+
     /**
     * Get question ids
     */
@@ -3919,7 +3919,7 @@ abstract class ilPageObject
         include_once("./Services/Link/classes/class.ilInternalLink.php");
         for ($i = 0; $i < count($res->nodeset); $i++) {
             $qref = $res->nodeset[$i]->get_attribute("QRef");
-            
+
             $inst_id = ilInternalLink::_extractInstOfTarget($qref);
             $obj_id = ilInternalLink::_extractObjIdOfTarget($qref);
 
@@ -3946,7 +3946,7 @@ abstract class ilPageObject
         $path = "/descendant::Paragraph[position() = $par_id]";
 
         $res = &xpath_eval($xpc, $path);
-        
+
         if (count($res->nodeset) != 1) {
             die("Should not happen");
         }
@@ -4003,7 +4003,7 @@ abstract class ilPageObject
         //echo "<br><b>fo:</b><br>".htmlentities($fo); flush();
         return $fo;
     }
-    
+
     public function registerOfflineHandler($handler)
     {
         $this->offline_handler = $handler;
@@ -4020,7 +4020,7 @@ abstract class ilPageObject
         return $this->offline_handler;
     }
 
-    
+
     /**
     * lookup whether page contains deactivated elements
     */
@@ -4029,7 +4029,7 @@ abstract class ilPageObject
         global $DIC;
 
         $db = $DIC->database();
-        
+
         if ($a_lang == "") {
             $a_lang = "-";
         }
@@ -4040,7 +4040,7 @@ abstract class ilPageObject
             " lang = " . $db->quote($a_lang, "text") . " AND " .
             " inactive_elements = " . $db->quote(1, "integer");
         $obj_set = $db->query($query);
-        
+
         if ($obj_rec = $obj_set->fetchRow(ilDBConstants::FETCHMODE_ASSOC)) {
             return true;
         }
@@ -4068,13 +4068,13 @@ abstract class ilPageObject
     public function getHistoryEntries()
     {
         $db = $this->db;
-        
+
         $h_query = "SELECT * FROM page_history " .
             " WHERE page_id = " . $db->quote($this->getId(), "integer") .
             " AND parent_type = " . $db->quote($this->getParentType(), "text") .
             " AND lang = " . $db->quote($this->getLanguage(), "text") .
             " ORDER BY hdate DESC";
-        
+
         $hset = $db->query($h_query);
         $hentries = array();
 
@@ -4086,14 +4086,14 @@ abstract class ilPageObject
         //var_dump($hentries);
         return $hentries;
     }
-    
+
     /**
     * Get History Entry
     */
     public function getHistoryEntry($a_old_nr)
     {
         $db = $this->db;
-        
+
         $res = $db->queryF(
             "SELECT * FROM page_history " .
             " WHERE page_id = %s " .
@@ -4106,11 +4106,11 @@ abstract class ilPageObject
         if ($hrec = $db->fetchAssoc($res)) {
             return $hrec;
         }
-        
+
         return false;
     }
 
-    
+
     /**
     * Get information about a history entry, its predecessor and
     * its successor.
@@ -4120,7 +4120,7 @@ abstract class ilPageObject
     public function getHistoryInfo($a_nr)
     {
         $db = $this->db;
-        
+
         // determine previous entry
         $and_nr = ($a_nr > 0)
             ? " AND nr < " . $db->quote((int) $a_nr, "integer")
@@ -4140,7 +4140,7 @@ abstract class ilPageObject
             $row = $db->fetchAssoc($res);
             $ret["previous"] = $row;
         }
-        
+
         // determine next entry
         $res = $db->query("SELECT MIN(nr) mnr FROM page_history " .
             " WHERE page_id = " . $db->quote($this->getId(), "integer") .
@@ -4177,7 +4177,7 @@ abstract class ilPageObject
 
         return $ret;
     }
-    
+
     public function addChangeDivClasses($a_hashes)
     {
         $xpc = xpath_new_context($this->dom);
@@ -4197,7 +4197,7 @@ abstract class ilPageObject
         }
         //echo "<br><br><br><br><br><br>".htmlentities($this->getXMLFromDom());
     }
-    
+
     /**
      * Compares to revisions of the page
      *
@@ -4221,7 +4221,7 @@ abstract class ilPageObject
                 if ($l_hashes[$pc_id]["hash"] != $r_hashes[$pc_id]["hash"]) {
                     $l_hashes[$pc_id]["change"] = "Modified";
                     $r_hashes[$pc_id]["change"] = "Modified";
-                    
+
                     include_once("./Services/COPage/mediawikidiff/class.WordLevelDiff.php");
                     // if modified element is a paragraph, highlight changes
                     if ($l_hashes[$pc_id]["content"] != "" &&
@@ -4240,7 +4240,7 @@ abstract class ilPageObject
                 }
             }
         }
-        
+
         // determine all new paragraphs
         foreach ($r_hashes as $pc_id => $h) {
             if (!isset($l_hashes[$pc_id])) {
@@ -4253,7 +4253,7 @@ abstract class ilPageObject
         return array("l_page" => $l_page, "r_page" => $r_page,
             "l_changes" => $l_hashes, "r_changes" => $r_hashes);
     }
-    
+
     /**
      * Increase view cnt
      */
@@ -4267,7 +4267,7 @@ abstract class ilPageObject
             " AND parent_type = " . $db->quote($this->getParentType(), "text") .
             " AND lang = " . $db->quote($this->getLanguage(), "text"));
     }
-    
+
     /**
     * Get recent pages changes for parent object.
     *
@@ -4280,12 +4280,12 @@ abstract class ilPageObject
         global $DIC;
 
         $db = $DIC->database();
-        
+
         $and_lang = "";
         if ($a_lang != "") {
             $and_lang = " AND lang = " . $db->quote($a_lang, "text");
         }
-        
+
         $page_changes = array();
         $limit_ts = date('Y-m-d H:i:s', time() - ($a_period * 24 * 60 * 60));
         $q = "SELECT * FROM page_object " .
@@ -4323,12 +4323,12 @@ abstract class ilPageObject
                 "nr" => $page["nr"],
                 "user" => $page["user_id"]);
         }
-        
+
         $page_changes = ilUtil::sortArray($page_changes, "date", "desc");
-        
+
         return $page_changes;
     }
-    
+
     /**
      * Get all pages for parent object
      *
@@ -4342,7 +4342,7 @@ abstract class ilPageObject
         global $DIC;
 
         $db = $DIC->database();
-        
+
         $and_lang = "";
         if ($a_lang != "") {
             $and_lang = " AND lang = " . $db->quote($a_lang, "text");
@@ -4378,14 +4378,14 @@ abstract class ilPageObject
         global $DIC;
 
         $db = $DIC->database();
-        
+
         $and_lang = "";
         if ($a_lang != "") {
             $and_lang = " AND lang = " . $db->quote($a_lang, "text");
         }
 
         $pages = array();
-        
+
         $q = "SELECT * FROM page_object " .
             " WHERE parent_id = " . $db->quote($a_parent_id, "integer") .
             " AND parent_type = " . $db->quote($a_parent_type, "text") . $and_lang .
@@ -4416,12 +4416,12 @@ abstract class ilPageObject
         global $DIC;
 
         $db = $DIC->database();
-        
+
         $and_lang = "";
         if ($a_lang != "") {
             $and_lang = " AND lang = " . $db->quote($a_lang, "text");
         }
-        
+
         $contributors = array();
         $set = $db->queryF(
             "SELECT last_change_user, lang, page_id FROM page_object " .
@@ -4455,7 +4455,7 @@ abstract class ilPageObject
                     $contributors[$hpage["user_id"]][$hpage["page_id"]] + $hpage["cnt"];
             }
         }
-        
+
         $c = array();
         foreach ($contributors as $k => $co) {
             if (ilObject::_lookupType($k) == "usr") {
@@ -4464,7 +4464,7 @@ abstract class ilPageObject
                     "lastname" => $name["lastname"], "firstname" => $name["firstname"]);
             }
         }
-        
+
         return $c;
     }
 
@@ -4479,7 +4479,7 @@ abstract class ilPageObject
         global $DIC;
 
         $db = $DIC->database();
-        
+
         $and_lang = "";
         if ($a_lang != "") {
             $and_lang = " AND lang = " . $db->quote($a_lang, "text");
@@ -4518,7 +4518,7 @@ abstract class ilPageObject
                     $contributors[$hpage["user_id"]] + $hpage["cnt"];
             }
         }
-        
+
         $c = array();
         foreach ($contributors as $k => $co) {
             include_once "Services/User/classes/class.ilObjUser.php";
@@ -4526,7 +4526,7 @@ abstract class ilPageObject
             $c[] = array("user_id" => $k, "pages" => $co,
                 "lastname" => $name["lastname"], "firstname" => $name["firstname"]);
         }
-        
+
         return $c;
     }
 
@@ -4562,7 +4562,7 @@ abstract class ilPageObject
         global $DIC;
 
         $db = $DIC->database();
-        
+
         $and_lang = "";
         if ($a_lang != "") {
             $and_lang = " AND lang = " . $db->quote($a_lang, "text");
@@ -4608,7 +4608,7 @@ abstract class ilPageObject
     public function performAutomaticModifications()
     {
     }
-    
+
     /**
      * Save initial opened content
      *
@@ -4626,12 +4626,12 @@ abstract class ilPageObject
                 $link_type = "MediaObject";
                 $a_id = "il__mob_" . $a_id;
                 break;
-                
+
             case "page":
                 $link_type = "PageObject";
                 $a_id = "il__pg_" . $a_id;
                 break;
-                
+
             case "term":
                 $link_type = "GlossaryItem";
                 $a_id = "il__git_" . $a_id;
@@ -4675,8 +4675,8 @@ abstract class ilPageObject
 
         $this->update();
     }
-    
-    
+
+
     /**
      * Get initial opened content
      *
@@ -4703,16 +4703,16 @@ abstract class ilPageObject
             $id = $il_node->get_attribute("Target");
             $link_type = $il_node->get_attribute("Type");
             $target = $il_node->get_attribute("TargetFrame");
-            
+
             switch ($link_type) {
                 case "MediaObject":
                     $type = "media";
                     break;
-                    
+
                 case "PageObject":
                     $type = "page";
                     break;
-                    
+
                 case "GlossaryItem":
                     $type = "term";
                     break;
@@ -4721,11 +4721,11 @@ abstract class ilPageObject
             $id = ilInternalLink::_extractObjIdOfTarget($id);
             return array("id" => $id, "type" => $type, "target" => $target);
         }
-        
+
         return array();
     }
     // @todo end
-    
+
     /**
      * Before page content update
      *
@@ -4793,7 +4793,7 @@ abstract class ilPageObject
         global $DIC;
 
         $db = $DIC->database();
-        
+
         $set = $db->query(
             "SELECT lang FROM page_object " .
             " WHERE page_id = " . $db->quote($a_id, "integer") .
@@ -4805,7 +4805,7 @@ abstract class ilPageObject
         }
         return $langs;
     }
-    
+
 
     /**
      * Copy page to translation
@@ -4828,11 +4828,11 @@ abstract class ilPageObject
         $transl_page->setActivationEnd($this->getActivationEnd());
         $transl_page->create();
     }
-    
+
     ////
     //// Page locking
     ////
-    
+
     /**
      * Get page lock
      */
@@ -4840,7 +4840,7 @@ abstract class ilPageObject
     {
         $db = $this->db;
         $user = $this->user;
-        
+
         $min = (int) $this->getEffectiveEditLockTime();
         if ($min > 0) {
             // try to set the lock for the user
@@ -4854,7 +4854,7 @@ abstract class ilPageObject
                 " AND page_id = " . $db->quote($this->getId(), "integer") .
                 " AND parent_type = " . $db->quote($this->getParentType(), "text")
             );
-            
+
             $set = $db->query(
                 "SELECT edit_lock_user FROM page_object " .
                 " WHERE page_id = " . $db->quote($this->getId(), "integer") .
@@ -4865,7 +4865,7 @@ abstract class ilPageObject
                 return false;
             }
         }
-        
+
         return true;
     }
 
@@ -4916,7 +4916,7 @@ abstract class ilPageObject
 
         $aset = new ilSetting("adve");
         $min = (int) $aset->get("block_mode_minutes");
-        
+
         $set = $db->query(
             "SELECT edit_lock_user, edit_lock_ts FROM page_object " .
             " WHERE page_id = " . $db->quote($this->getId(), "integer") .
@@ -4924,10 +4924,10 @@ abstract class ilPageObject
         );
         $rec = $db->fetchAssoc($set);
         $rec["edit_lock_until"] = $rec["edit_lock_ts"] + $min * 60;
-        
+
         return $rec;
     }
-    
+
     /**
      * Truncate (html) string
      *
@@ -4943,13 +4943,13 @@ abstract class ilPageObject
     public static function truncateHTML($a_text, $a_length = 100, $a_ending = '...', $a_exact = false, $a_consider_html = true)
     {
         include_once "Services/Utilities/classes/class.ilStr.php";
-                    
+
         if ($a_consider_html) {
             // if the plain text is shorter than the maximum length, return the whole text
             if (strlen(preg_replace('/<.*?>/', '', $a_text)) <= $a_length) {
                 return $a_text;
             }
-            
+
             // splits all html-tags to scanable lines
             $total_length = strlen($a_ending);
             $open_tags = array();
@@ -4978,7 +4978,7 @@ abstract class ilPageObject
                     // add html-tag to $truncate'd text
                     $truncate .= $line_matchings[1];
                 }
-                
+
                 // calculate the length of the plain text part of the line; handle entities as one character
                 $content_length = strlen(preg_replace('/&[0-9a-z]{2,8};|&#[0-9]{1,7};|[0-9a-f]{1,6};/i', ' ', $line_matchings[2]));
                 if ($total_length + $content_length > $a_length) {
@@ -5001,14 +5001,14 @@ abstract class ilPageObject
 
                     // $truncate .= substr($line_matchings[2], 0, $left+$entities_length);
                     $truncate .= ilStr::shortenText($line_matchings[2], 0, $left + $entities_length);
-                    
+
                     // maximum lenght is reached, so get off the loop
                     break;
                 } else {
                     $truncate .= $line_matchings[2];
                     $total_length += $content_length;
                 }
-                
+
                 // if the maximum length is reached, get off the loop
                 if ($total_length >= $a_length) {
                     break;
@@ -5022,7 +5022,7 @@ abstract class ilPageObject
                 $truncate = ilStr::shortenText($a_text, 0, $a_length - strlen($a_ending));
             }
         }
-        
+
         // THIS IS BUGGY AS IT MIGHT BREAK AN OPEN TAG AT THE END
         if (!sizeof($open_tags)) {
             // if the words shouldn't be cut in the middle...
@@ -5036,20 +5036,20 @@ abstract class ilPageObject
                 }
             }
         }
-                
+
         // add the defined ending to the text
         $truncate .= $a_ending;
-        
+
         if ($a_consider_html) {
             // close all unclosed html-tags
             foreach ($open_tags as $tag) {
                 $truncate .= '</' . $tag . '>';
             }
         }
-        
+
         return $truncate;
     }
-    
+
     /**
      * Get content templates
      *
@@ -5095,7 +5095,7 @@ abstract class ilPageObject
         if ($this->getPageConfig()->getEditLockSupport() == false) {
             return 0;
         }
-        
+
         $aset = new ilSetting("adve");
         $min = (int) $aset->get("block_mode_minutes") ;
 

--- a/Services/COPage/classes/class.ilPageObjectGUI.php
+++ b/Services/COPage/classes/class.ilPageObjectGUI.php
@@ -119,7 +119,7 @@ class ilPageObjectGUI
      * @var \ILIAS\DI\UIServices
      */
     protected $ui;
-    
+
     /**
      * Constructor
      *
@@ -155,7 +155,7 @@ class ilPageObjectGUI
             $a_old_nr = $_GET["old_nr"];
         }
         $this->setOldNr($a_old_nr);
-        
+
         if ($a_lang == "" && $_GET["transl"] != "") {
             $this->setLanguage($_GET["transl"]);
         } else {
@@ -164,7 +164,7 @@ class ilPageObjectGUI
             }
             $this->setLanguage($a_lang);
         }
-        
+
 
         $this->setOutputMode(IL_PAGE_PRESENTATION);
         $this->setEnabledPageFocus(true);
@@ -180,21 +180,21 @@ class ilPageObjectGUI
         $this->page_back_title = $this->lng->txt("page");
         $this->lng->loadLanguageModule("content");
         $this->lng->loadLanguageModule("copg");
-        
+
         $this->setTemplateOutput(false);
 
         $this->ctrl->saveParameter($this, "transl");
-        
+
         $this->afterConstructor();
     }
-    
+
     /**
      * After constructor
      */
     public function afterConstructor()
     {
     }
-    
+
 
     /**
      * Init page object
@@ -210,7 +210,7 @@ class ilPageObjectGUI
         );
         $this->setPageObject($page);
     }
-    
+
     /**
      * Set parent type
      *
@@ -220,7 +220,7 @@ class ilPageObjectGUI
     {
         $this->parent_type = $a_val;
     }
-    
+
     /**
      * Get parent type
      *
@@ -230,7 +230,7 @@ class ilPageObjectGUI
     {
         return $this->parent_type;
     }
-    
+
     /**
      * Set ID
      *
@@ -240,7 +240,7 @@ class ilPageObjectGUI
     {
         $this->id = $a_val;
     }
-    
+
     /**
      * Get ID
      *
@@ -250,7 +250,7 @@ class ilPageObjectGUI
     {
         return $this->id;
     }
-    
+
     /**
      * Set old nr (historic page)
      *
@@ -260,7 +260,7 @@ class ilPageObjectGUI
     {
         $this->old_nr = $a_val;
     }
-    
+
     /**
      * Get old nr (historic page)
      *
@@ -270,7 +270,7 @@ class ilPageObjectGUI
     {
         return $this->old_nr;
     }
-    
+
     /**
      * Set language
      *
@@ -280,7 +280,7 @@ class ilPageObjectGUI
     {
         $this->language = $a_val;
     }
-    
+
     /**
      * Get language
      *
@@ -291,10 +291,10 @@ class ilPageObjectGUI
         if ($this->language == "") {
             return "-";
         }
-        
+
         return $this->language;
     }
-    
+
     /**
      * Set enable pc type
      *
@@ -304,7 +304,7 @@ class ilPageObjectGUI
     {
         $this->getPageConfig()->setEnablePCType($a_pc_type, $a_val);
     }
-    
+
     /**
      * Get enable pc type
      *
@@ -314,7 +314,7 @@ class ilPageObjectGUI
     {
         return $this->getPageConfig()->getEnablePCType($a_pc_type);
     }
-    
+
     /**
      * Set page config object
      *
@@ -324,7 +324,7 @@ class ilPageObjectGUI
     {
         $this->page_config = $a_val;
     }
-    
+
     /**
      * Get page config object
      *
@@ -334,7 +334,7 @@ class ilPageObjectGUI
     {
         return $this->page_config;
     }
-    
+
     /**
      * Set Page Object
      *
@@ -666,7 +666,7 @@ class ilPageObjectGUI
     {
         $this->tab_hook = array("obj" => $a_object, "func" => $a_function);
     }
-        
+
     /**
     * Set Display first Edit tab, then Preview tab, instead of Page and Edit.
     *
@@ -829,7 +829,7 @@ class ilPageObjectGUI
     {
         $this->compare_mode = $a_val;
     }
-    
+
     /**
     * Get compare mode
     *
@@ -839,7 +839,7 @@ class ilPageObjectGUI
     {
         return $this->compare_mode;
     }
-    
+
     /**
      * Set abstract only
      *
@@ -849,7 +849,7 @@ class ilPageObjectGUI
     {
         $this->abstract_only = $a_val;
     }
-    
+
     /**
      * Get abstract only
      *
@@ -859,7 +859,7 @@ class ilPageObjectGUI
     {
         return $this->abstract_only;
     }
-    
+
     /**
      * Set render page container
      *
@@ -869,7 +869,7 @@ class ilPageObjectGUI
     {
         $this->render_page_container = $a_val;
     }
-    
+
     /**
      * Get render page container
      *
@@ -988,8 +988,8 @@ class ilPageObjectGUI
         }
         return $xml;
     }
-    
-    
+
+
     /**
     * execute command
     */
@@ -1015,13 +1015,13 @@ class ilPageObjectGUI
                 }
                 $this->ctrl->forwardCommand($md_gui);
                 break;
-            
+
             case "ileditclipboardgui":
                 $clip_gui = new ilEditClipboardGUI();
                 $clip_gui->setPageBackTitle($this->page_back_title);
                 $ret = $this->ctrl->forwardCommand($clip_gui);
                 break;
-                
+
             // notes
             case "ilnotegui":
                 switch ($_GET["notes_mode"]) {
@@ -1031,7 +1031,7 @@ class ilPageObjectGUI
                         return $html;
                 }
                 break;
-                
+
             case 'ilpublicuserprofilegui':
                 require_once './Services/User/classes/class.ilPublicUserProfileGUI.php';
                 $profile_gui = new ilPublicUserProfileGUI($_GET["user"]);
@@ -1073,7 +1073,7 @@ class ilPageObjectGUI
                 $form = $this->initOpenedContentForm();
                 $this->ctrl->forwardCommand($form);
                 break;
-                
+
             case "ilinternallinkgui":
                 $this->lng->loadLanguageModule("content");
                 require_once("./Services/Link/classes/class.ilInternalLinkGUI.php");
@@ -1083,7 +1083,7 @@ class ilPageObjectGUI
                 $link_gui->filterLinkType("GlossaryItem");
                 $link_gui->filterLinkType("Media_Media");
                 $link_gui->filterLinkType("Media_FAQ");
-                
+
                 $link_gui->setFilterWhiteList(true);
                 $this->ctrl->forwardCommand($link_gui);
                 break;
@@ -1105,7 +1105,7 @@ class ilPageObjectGUI
 
                 // set tabs
                 $this->setQEditTabs("feedback");
-                
+
                 // load required lang mods
                 $this->lng->loadLanguageModule("assessment");
 
@@ -1162,7 +1162,7 @@ class ilPageObjectGUI
     public function setQEditTabs($a_active)
     {
         include_once("./Modules/TestQuestionPool/classes/class.assQuestion.php");
-        
+
         $this->tabs_gui->clearTargets();
 
         $this->tabs_gui->setBackTarget(
@@ -1187,15 +1187,15 @@ class ilPageObjectGUI
 
         $this->tabs_gui->activateTab($a_active);
     }
-    
+
     /**
      * On feedback editing forwarding
      */
     public function onFeedbackEditingForwarding()
     {
     }
-    
-    
+
+
     public function deactivatePage()
     {
         $this->getPageObject()->setActivationStart(null);
@@ -1225,7 +1225,7 @@ class ilPageObjectGUI
         iljQueryUtil::initjQueryUI();
 
         //		$this->initSelfAssessmentRendering();
-        
+
         include_once("./Services/MediaObjects/classes/class.ilObjMediaObjectGUI.php");
         ilObjMediaObjectGUI::includePresentationJS($GLOBALS["tpl"]);
 
@@ -1234,10 +1234,10 @@ class ilPageObjectGUI
         // needed for overlays in iim
         include_once("./Services/UIComponent/Overlay/classes/class.ilOverlayGUI.php");
         ilOverlayGUI::initJavascript();
-        
+
         include_once("./Services/MediaObjects/classes/class.ilPlayerUtil.php");
         ilPlayerUtil::initMediaElementJs($GLOBALS["tpl"]);
-        
+
         // init template
         //if($this->outputToTemplate())
         //{
@@ -1344,7 +1344,7 @@ class ilPageObjectGUI
                         $cfg->getEnableUserLinks()
                     )
                 );
-                    
+
                 // add int link parts
                 include_once("./Services/Link/classes/class.ilInternalLinkGUI.php");
                 $tpl->setCurrentBlock("int_link_prep");
@@ -1388,14 +1388,14 @@ class ilPageObjectGUI
             }
         } else {
             // presentation or preview here
-                
+
             $tpl = new ilTemplate("tpl.page.html", true, true, "Services/COPage");
             if ($this->getEnabledPageFocus()) {
                 $tpl->touchBlock("page_focus");
             }
-                
+
             include_once("./Services/User/classes/class.ilUserUtil.php");
-                
+
             // presentation
             if ($this->isPageContainerToBeRendered()) {
                 $tpl->touchBlock("page_container_1");
@@ -1427,7 +1427,7 @@ class ilPageObjectGUI
                         $tpl->setVariable("TXT_PREV_REV", $this->lng->txt("cont_previous_rev"));
                         $tpl->parseCurrentBlock();
                     }
-                        
+
                     // next revision
                     if ($c_old_nr > 0) {
                         $tpl->setCurrentBlock("next_rev");
@@ -1468,7 +1468,7 @@ class ilPageObjectGUI
                         $tpl->parseCurrentBlock();
                     }
                 }
-                    
+
                 $tpl->setCurrentBlock("hist_nav");
                 $tpl->setVariable("TXT_REVISION", $this->lng->txt("cont_revision"));
                 $tpl->setVariable(
@@ -1518,7 +1518,7 @@ class ilPageObjectGUI
                 //$this->tpl->setVariable("TXT_COPY_TO_POOL", $this->lng->txt("cont_copy_to_mediapool"));
                 $tpl->parseCurrentBlock();
             }
-                
+
             // content snippets used
             include_once("./Services/COPage/classes/class.ilPCContentInclude.php");
             $snippets = ilPCContentInclude::collectContentIncludes(
@@ -1539,7 +1539,7 @@ class ilPageObjectGUI
                 $tpl->setVariable("TXT_SHOW_INFO", $this->lng->txt("cont_show_info"));
                 $tpl->parseCurrentBlock();
             }
-                
+
             // scheduled activation?
             if (!$this->getPageObject()->getActive() &&
                     $this->getPageObject()->getActivationStart() != "" &&
@@ -1582,13 +1582,13 @@ class ilPageObjectGUI
 
         // manage hierarchical ids
         if ($this->getOutputMode() == "edit") {
-            
+
             // add pc ids, if necessary
             if (!$this->obj->checkPCIds()) {
                 $this->obj->insertPCIds();
                 $this->obj->update(true, true);
             }
-            
+
             $this->obj->addFileSizes();
             $this->obj->addHierIDs();
 
@@ -1724,7 +1724,7 @@ class ilPageObjectGUI
 
         $img_path = ilUtil::getImagePath("", false, $this->getOutputMode(), $this->getOutputMode() == "offline");
 
-        
+
         if ($this->getPageConfig()->getEnablePCType("Tabs")) {
             //include_once("./Services/YUI/classes/class.ilYuiUtil.php");
             //ilYuiUtil::initTabView();
@@ -1736,7 +1736,7 @@ class ilPageObjectGUI
         $file_download_link = $this->determineFileDownloadLink();
         $fullscreen_link = $this->determineFullscreenLink();
         $this->sourcecode_download_script = $this->determineSourcecodeDownloadScript();
-        
+
         // default values for various parameters (should be used by
         // all instances in the future)
         $media_mode = ($this->getOutputMode() == "edit")
@@ -1746,13 +1746,13 @@ class ilPageObjectGUI
         include_once("./Modules/LearningModule/classes/class.ilEditClipboard.php");
         $paste = (ilEditClipboard::getAction() == "copy" &&
             $this->getOutputMode() == "edit");
-        
+
         include_once("./Services/MediaObjects/classes/class.ilPlayerUtil.php");
 
         $flv_video_player = ($this->getOutputMode() != "offline")
             ? ilPlayerUtil::getFlashVideoPlayerFilename(true)
             : ilPlayerUtil::getFlashVideoPlayerFilename(true);
-            
+
         $cfg = $this->getPageConfig();
 
         $current_ts = time();
@@ -1811,7 +1811,7 @@ class ilPageObjectGUI
         }
 
         //$content = str_replace("&nbsp;", "", $content);
-        
+
         // this ensures that cache is emptied with every update
         $params["version"] = ILIAS_VERSION;
         // ensure no cache hit, if included files/media objects have been changed
@@ -1824,9 +1824,9 @@ class ilPageObjectGUI
 
         // run xslt
         $md5 = md5(serialize($params) . $link_xml . $template_xml . $md5_adds);
-        
+
         //$a = microtime();
-        
+
         // check cache (same parameters, non-edit mode and rendered time
         // > last change
         if (($this->getOutputMode() == "preview" || $this->getOutputMode() == "presentation") &&
@@ -1845,7 +1845,7 @@ class ilPageObjectGUI
             $args = array( '/_xml' => $content, '/_xsl' => $xsl );
             $xh = xslt_create();
             $output = xslt_process($xh, "arg:/_xml", "arg:/_xsl", null, $args, $params);
-            
+
             if (($this->getOutputMode() == "presentation" || $this->getOutputMode() == "preview")
                 && !$this->getAbstractOnly()
                 && $this->obj->old_nr == 0) {
@@ -1862,7 +1862,7 @@ class ilPageObjectGUI
             $output = str_replace("&gt;", ">", $output);
         }
         $output = str_replace("&amp;", "&", $output);
-        
+
         include_once './Services/MathJax/classes/class.ilMathJax.php';
         $output = ilMathJax::getInstance()->insertLatexImages($output);
 
@@ -1895,7 +1895,7 @@ class ilPageObjectGUI
             !$this->getPageObject()->getActive($this->getPageConfig()->getEnableScheduledActivation())) {
             $output = '<div class="il_editarea_disabled"><div class="ilCopgDisabledText">' . $this->getDisabledText() . '</div>' . $output . '</div>';
         }
-        
+
         // for all page components...
         include_once("./Services/COPage/classes/class.ilCOPagePCDef.php");
         $defs = ilCOPagePCDef::getPCDefinitions();
@@ -1909,7 +1909,7 @@ class ilPageObjectGUI
 
             // post xsl page content modification by pc elements
             $output = $pc_obj->modifyPageContentPostXsl($output, $this->getOutputMode());
-            
+
             // javascript files
             $js_files = $pc_obj->getJavascriptFiles($this->getOutputMode());
             foreach ($js_files as $js) {
@@ -1928,7 +1928,7 @@ class ilPageObjectGUI
                 $GLOBALS["tpl"]->addOnloadCode($code);
             }
         }
-        
+
         //		$output = $this->selfAssessmentRendering($output);
 
         // output
@@ -1967,7 +1967,7 @@ class ilPageObjectGUI
     public function replaceCurlyBrackets($output)
     {
         //echo "<br><br>".htmlentities($output);
-        
+
         while (is_int($start = strpos($output, "<!--ParStart-->")) &&
             is_int($end = strpos($output, "<!--ParEnd-->", $start))) {
             $output = substr($output, 0, $start) .
@@ -1984,7 +1984,7 @@ class ilPageObjectGUI
         //echo "<br><br>".htmlentities($output);
         return $output;
     }
-    
+
     /**
      * Get captions for activation action menu entries
      */
@@ -1993,16 +1993,16 @@ class ilPageObjectGUI
         return array("deactivatePage" => $this->lng->txt("cont_deactivate_page"),
                 "activatePage" => $this->lng->txt("cont_activate_page"));
     }
-    
+
     /**
      * Add actions menu
      */
     public function addActionsMenu($a_tpl, $sel_media_mode, $sel_html_mode, $sel_js_mode)
     {
         global $DIC;
-        
+
         $ui = $DIC->ui();
-        
+
         // actions
         include_once("./Services/UIComponent/AdvancedSelectionList/classes/class.ilAdvancedSelectionListGUI.php");
 
@@ -2028,7 +2028,7 @@ class ilPageObjectGUI
                     $this->ctrl->getLinkTarget($this, "activatePage")
                 );
             }
-            
+
             $a_tpl->setVariable("PAGE_ACTIONS", $list->getHTML());
         }
 
@@ -2041,12 +2041,12 @@ class ilPageObjectGUI
                 $this->ctrl->getLinkTarget($this, "initialOpenedContent")
             );
         }
-        
+
         // multi-lang actions
         if ($this->addMultiLangActionsAndInfo($list, $a_tpl)) {
             $entries = true;
         }
-        
+
         if ($entries) {
             $items = $list->getItems();
             if (count($items) > 1) {
@@ -2130,9 +2130,9 @@ class ilPageObjectGUI
     public function addMultiLangActionsAndInfo($a_list, $a_tpl)
     {
         $any_items = false;
-        
+
         $cfg = $this->getPageConfig();
-        
+
         // general multi lang support and single page mode?
         if ($cfg->getMultiLangSupport()) {
             //include_once("./Services/COPage/classes/class.ilPageMultiLang.php");
@@ -2141,7 +2141,7 @@ class ilPageObjectGUI
 
             include_once("./Services/Object/classes/class.ilObjectTranslation.php");
             $ot = ilObjectTranslation::getInstance($this->getPageObject()->getParentId());
-            
+
             if (!$ot->getContentActivated()) {
                 /*				if ($cfg->getSinglePageMode())
                                 {
@@ -2193,10 +2193,10 @@ class ilPageObjectGUI
                 $any_items = true;
             }
         }
-        
+
         return $any_items;
     }
-    
+
 
     /**
      * Set edit mode
@@ -2250,13 +2250,13 @@ class ilPageObjectGUI
         $ctrl = $DIC->ctrl();
 
         $mathJaxSetting = new ilSetting("MathJax");
-        
+
         include_once("./Services/COPage/classes/class.ilPageEditorSettings.php");
 
         include_once("./Services/UIComponent/Tooltip/classes/class.ilTooltipGUI.php");
-        
+
         $btpl = new ilTemplate("tpl.tiny_menu.html", true, true, "Services/COPage");
-        
+
         // debug ghost element
         if (DEVMODE == 1) {
             $btpl->touchBlock("debug_ghost");
@@ -2330,7 +2330,7 @@ class ilPageObjectGUI
                 $lng->txt("cont_insert_new_paragraph"),
                 "iltinymenu_bd"
             );
-            
+
             $btpl->setCurrentBlock("par_edit");
             $btpl->setVariable("TXT_PAR_FORMAT", $lng->txt("cont_par_format"));
             include_once("./Services/COPage/classes/class.ilPCParagraphGUI.php");
@@ -2339,7 +2339,7 @@ class ilPageObjectGUI
                 ilPCParagraphGUI::_getCharacteristics($a_style_id),
                 true
             ));
-            
+
             ilTooltipGUI::addTooltip(
                 "ilAdvSelListAnchorText_style_selection",
                 $lng->txt("cont_paragraph_styles"),
@@ -2382,7 +2382,7 @@ class ilPageObjectGUI
         }
 
         $aset = new ilSetting("adve");
-        
+
         include_once("./Services/COPage/classes/class.ilPageContentGUI.php");
         foreach (ilPageContentGUI::_getCommonBBButtons() as $c => $st) {
             // these are handled via drop down now...
@@ -2398,7 +2398,7 @@ class ilPageObjectGUI
                 if ($aset->get("use_physical")) {
                     $cc_code = str_replace(array("str", "emp", "imp"), array("B", "I", "U"), $cc_code);
                 }
-                
+
                 if ($c != "tex" || $mathJaxSetting->get("enable") || defined("URL_TO_LATEX")) {
                     $btpl->setCurrentBlock("bb_" . $c . "_button");
                     $btpl->setVariable("CC_" . strtoupper($c), $cc_code);
@@ -2413,7 +2413,7 @@ class ilPageObjectGUI
                 }
             }
         }
-        
+
         if ($mathJaxSetting->get("enable") || defined("URL_TO_LATEX")) {
             ilTooltipGUI::addTooltip(
                 "il_edm_tex",
@@ -2477,7 +2477,7 @@ class ilPageObjectGUI
         $btpl->setVariable("TXT_LINKS", $lng->txt("cont_links"));
         $btpl->setVariable("TXT_MORE_FUNCTIONS", $lng->txt("cont_more_functions"));
         $btpl->setVariable("TXT_SAVING", $lng->txt("cont_saving"));
-        
+
         include_once("./Services/COPage/classes/class.ilPCParagraphGUI.php");
 
         $btpl->setVariable("CHAR_STYLE_SELECTOR", ilPCParagraphGUI::getCharStyleSelector($a_par_type, true, $a_style_id));
@@ -2613,7 +2613,7 @@ class ilPageObjectGUI
         return $this->ctrl->getLinkTargetByClass(strtolower(get_class($this)), "preview");
     }
 
-    
+
     /**
      * Download file of file lists
      */
@@ -2654,7 +2654,7 @@ class ilPageObjectGUI
             exit;
         }
     }
-    
+
     /**
      * Show media in fullscreen mode
      */
@@ -2675,10 +2675,10 @@ class ilPageObjectGUI
 
         //$int_links = $page_object->getInternalLinks();
         $med_links = ilMediaItem::_getMapAreasIntLinks($_GET["mob_id"]);
-        
+
         // @todo
         //$link_xml = $this->getLinkXML($med_links, $this->getLayoutLinkTargets());
-        
+
         require_once("./Services/MediaObjects/classes/class.ilObjMediaObject.php");
         $media_obj = new ilObjMediaObject($_GET["mob_id"]);
         require_once("./Services/COPage/classes/class.ilPageObject.php");
@@ -2864,7 +2864,7 @@ class ilPageObjectGUI
 
         return $a_output;
     }
-    
+
     /**
      * Insert resources
      *
@@ -2874,7 +2874,7 @@ class ilPageObjectGUI
     public function insertResources($a_output)
     {
         // this is edit mode only
-        
+
         if ($this->getEnablePCType("Resources") &&
             ($this->getOutputMode() == "edit" || $this->getOutputMode() == "preview")) {
             include_once("./Services/COPage/classes/class.ilPCResourcesGUI.php");
@@ -2882,9 +2882,9 @@ class ilPageObjectGUI
         }
         return $a_output;
     }
-    
-    
-    
+
+
+
     /**
      * Insert adv content trigger
      *
@@ -2916,11 +2916,11 @@ class ilPageObjectGUI
                 $a_output
             );
         }
-        
+
         return $a_output;
     }
-    
-    
+
+
     /**
      * Finalizing output processing. Maybe overwritten in derived
      * classes, e.g. in wiki module.
@@ -2929,7 +2929,7 @@ class ilPageObjectGUI
     {
         return $a_output;
     }
-    
+
     /**
     * Insert help texts
     */
@@ -2993,7 +2993,7 @@ class ilPageObjectGUI
                 return $form->getHTML();
             }
         }
-        
+
         // edit lock
         if (!$this->getPageObject()->getEditLock()) {
             include_once("./Services/User/classes/class.ilUserUtil.php");
@@ -3015,15 +3015,15 @@ class ilPageObjectGUI
                 $mess = $this->getBlockingInfoMessage();
             }
         }
-        
+
         $this->setOutputMode(IL_PAGE_EDIT);
 
         $html = $this->showPage();
-        
+
         if ($this->isEnabledNotes()) {
             $html .= "<br /><br />" . $this->getNotesHTML();
         }
-    
+
         return $mess . $html;
     }
 
@@ -3047,7 +3047,7 @@ class ilPageObjectGUI
         return $ui->renderer()->render($mbox);
     }
 
-    
+
     /**
      * InsertJS at placeholder
      *
@@ -3057,14 +3057,14 @@ class ilPageObjectGUI
     public function insertJSAtPlaceholder()
     {
         $tpl = $this->tpl;
-        
+
         if ($_GET["pl_hier_id"] == "") {
             $this->obj->buildDom();
             $this->obj->addHierIDs();
             $hid = $this->obj->getHierIdsForPCIds(array($_GET["pl_pc_id"]));
             $_GET["pl_hier_id"] = $hid[$_GET["pl_pc_id"]];
         }
-        
+
         //		  'pl_hier_id' => string '2_1_1_1' (length=7)
         //  'pl_pc_id' => string '1f77eb1d8a478497d69b99d938fda8f' (length=31)
         $html = $this->edit();
@@ -3075,7 +3075,7 @@ class ilPageObjectGUI
 
         return $html;
     }
-    
+
     /**
      * Init captcha form.
      */
@@ -3083,17 +3083,17 @@ class ilPageObjectGUI
     {
         require_once  'Services/Form/classes/class.ilPropertyFormGUI.php';
         $form = new ilPropertyFormGUI();
-        
+
         require_once 'Services/Captcha/classes/class.ilCaptchaInputGUI.php';
         $ci = new ilCaptchaInputGUI($this->lng->txt('cont_captcha_code'), 'captcha_code');
         $ci->setRequired(true);
         $form->addItem($ci);
 
         $form->addCommandButton('edit', $this->lng->txt('ok'));
-        
+
         $form->setTitle($this->lng->txt('cont_captcha_verification'));
         $form->setFormAction($this->ctrl->getFormAction($this));
-        
+
         return $form;
     }
 
@@ -3112,7 +3112,7 @@ class ilPageObjectGUI
         $this->getTabs("preview");
         return $this->showPage();
     }
-    
+
     /**
     * show fullscreen view of media object
     */
@@ -3177,7 +3177,7 @@ class ilPageObjectGUI
         if (is_array($a_error)) {
             $error_str = "<b>Error(s):</b><br>";
             foreach ($a_error as $error) {
-                $err_mess = implode($error, " - ");
+                $err_mess = implode(" - ", $error);
                 if (!is_int(strpos($err_mess, ":0:"))) {
                     $error_str .= htmlentities($err_mess) . "<br />";
                 }
@@ -3194,9 +3194,9 @@ class ilPageObjectGUI
         if (!$this->getEnableEditing()) {
             return;
         }
-        
+
         $this->tpl->addJavaScript("./Services/COPage/js/page_history.js");
-        
+
         include_once("./Services/COPage/classes/class.ilPageHistoryTableGUI.php");
         $table_gui = new ilPageHistoryTableGUI($this, "history");
         $table_gui->setId("hist_table");
@@ -3220,10 +3220,10 @@ class ilPageObjectGUI
         if (!$this->getEnableEditing()) {
             return;
         }
-        
+
         include_once("Services/Utilities/classes/class.ilConfirmationGUI.php");
         $c_gui = new ilConfirmationGUI();
-        
+
         // set confirm/cancel commands
         $this->ctrl->setParameter($this, "rollback_nr", $_GET["old_nr"]);
         $c_gui->setFormAction($this->ctrl->getFormAction($this, "rollback"));
@@ -3232,16 +3232,16 @@ class ilPageObjectGUI
         $c_gui->setConfirm($this->lng->txt("confirm"), "rollback");
 
         $hentry = $this->obj->getHistoryEntry($_GET["old_nr"]);
-            
+
         $c_gui->addItem(
             "id[]",
             $_GET["old_nr"],
             ilDatePresentation::formatDate(new ilDateTime($hentry["hdate"], IL_CAL_DATETIME))
         );
-        
+
         $this->tpl->setContent($c_gui->getHTML());
     }
-    
+
     /**
     * Rollback to a previous version
     */
@@ -3262,7 +3262,7 @@ class ilPageObjectGUI
         }
         $this->ctrl->redirect($this, "history");
     }
-    
+
     /**
      * Set screen id component
      *
@@ -3282,7 +3282,7 @@ class ilPageObjectGUI
     public function getTabs($a_activate = "")
     {
         $this->setScreenIdComponent();
-        
+
         if (!$this->getEnabledTabs()) {
             return;
         }
@@ -3290,7 +3290,7 @@ class ilPageObjectGUI
         // back to upper context
         if (!$this->getEditPreview()) {
             $this->tabs_gui->addTarget("pg", $this->ctrl->getLinkTarget($this, "preview"), array("", "preview"));
-    
+
             if ($this->getEnableEditing()) {
                 $this->tabs_gui->addTarget("edit", $this->ctrl->getLinkTarget($this, "edit"), array("", "edit"));
             }
@@ -3301,7 +3301,7 @@ class ilPageObjectGUI
 
             $this->tabs_gui->addTarget("cont_preview", $this->ctrl->getLinkTarget($this, "preview"), array("", "preview"));
         }
-            
+
         //$tabs_gui->addTarget("properties", $this->ctrl->getLinkTarget($this, "properties")
         //	, "properties", get_class($this));
 
@@ -3324,7 +3324,7 @@ class ilPageObjectGUI
         }
 
         $lm_set = new ilSetting("lm");
-        
+
         if ($this->getEnableEditing() && $lm_set->get("page_history", 1)) {
             $this->tabs_gui->addTarget("history", $this->ctrl->getLinkTarget($this, "history"), "history", get_class($this));
             if ($_GET["history_mode"] == "1" || $this->ctrl->getCmd() == "compareVersion") {
@@ -3380,7 +3380,7 @@ class ilPageObjectGUI
 
         $tpl = new ilTemplate("tpl.page_compare.html", true, true, "Services/COPage");
         $compare = $this->obj->compareVersion((int) $_POST["left"], (int) $_POST["right"]);
-        
+
         // left page
         $lpage = $compare["l_page"];
         $cfg = $this->getPageConfig();
@@ -3395,7 +3395,7 @@ class ilPageObjectGUI
         $lhtml = $this->replaceDiffTags($lhtml);
         $lhtml = str_replace("&lt;br /&gt;", "<br />", $lhtml);
         $tpl->setVariable("LEFT", $lhtml);
-        
+
         // right page
         $rpage = $compare["r_page"];
         $this->setPageObject($rpage);
@@ -3407,7 +3407,7 @@ class ilPageObjectGUI
         $rhtml = $this->replaceDiffTags($rhtml);
         $rhtml = str_replace("&lt;br /&gt;", "<br />", $rhtml);
         $tpl->setVariable("RIGHT", $rhtml);
-        
+
         $tpl->setVariable("TXT_NEW", $this->lng->txt("cont_pc_new"));
         $tpl->setVariable("TXT_MODIFIED", $this->lng->txt("cont_pc_modified"));
         $tpl->setVariable("TXT_DELETED", $this->lng->txt("cont_pc_deleted"));
@@ -3417,7 +3417,7 @@ class ilPageObjectGUI
 
         return $tpl->get();
     }
-    
+
     public function replaceDiffTags($a_html)
     {
         $a_html = str_replace("[ilDiffInsStart]", '<span class="ilDiffIns">', $a_html);
@@ -3427,7 +3427,7 @@ class ilPageObjectGUI
 
         return $a_html;
     }
-    
+
     /**
     * Edit activation (only, if scheduled page activation is activated in administration)
     */
@@ -3444,7 +3444,7 @@ class ilPageObjectGUI
         $atpl->parseCurrentBlock();
         $this->tpl->setContent($atpl->get());
     }
-    
+
     /**
     * Init activation form
     */
@@ -3454,7 +3454,7 @@ class ilPageObjectGUI
         $this->form = new ilPropertyFormGUI();
         $this->form->setFormAction($this->ctrl->getFormAction($this));
         $this->form->setTitle($this->lng->txt("cont_page_activation"));
-        
+
         // activation type radio
         $rad = new ilRadioGroupInputGUI($this->lng->txt("cont_activation"), "activation");
         $rad_op1 = new ilRadioOption($this->lng->txt("cont_activated"), "activated");
@@ -3463,7 +3463,7 @@ class ilPageObjectGUI
         $rad_op2 = new ilRadioOption($this->lng->txt("cont_deactivated"), "deactivated");
         $rad->addOption($rad_op2);
         $rad_op3 = new ilRadioOption($this->lng->txt("cont_scheduled_activation"), "scheduled");
-        
+
         $dt_prop = new ilDateTimeInputGUI($this->lng->txt("cont_start"), "start");
         $dt_prop->setRequired(true);
         $dt_prop->setShowTime(true);
@@ -3472,20 +3472,20 @@ class ilPageObjectGUI
         $dt_prop2->setRequired(true);
         $dt_prop2->setShowTime(true);
         $rad_op3->addSubItem($dt_prop2);
-            
+
         // show activation information
         $cb = new ilCheckboxInputGUI($this->lng->txt("cont_show_activation_info"), "show_activation_info");
         $cb->setInfo($this->lng->txt("cont_show_activation_info_info"));
         $rad_op3->addSubItem($cb);
-            
-        
+
+
         $rad->addOption($rad_op3);
 
         $this->form->addCommandButton("saveActivation", $this->lng->txt("save"));
-        
+
         $this->form->addItem($rad);
     }
-    
+
     /**
     * Get values for activation form
     */
@@ -3495,7 +3495,7 @@ class ilPageObjectGUI
         if ($this->getPageObject()->getActive()) {
             $activation = "activated";
         }
-        
+
         $dt_prop = $this->form->getItemByPostVar("start");
         if ($this->getPageObject()->getActivationStart() != "") {
             $activation = "scheduled";
@@ -3512,18 +3512,18 @@ class ilPageObjectGUI
                 IL_CAL_DATETIME
             ));
         }
-        
+
         $this->form->getItemByPostVar("activation")->setValue($activation);
         $this->form->getItemByPostVar("show_activation_info")->setChecked($this->getPageObject()->getShowActivationInfo());
     }
-    
+
     /**
     * Save Activation
     */
     public function saveActivation()
     {
         $this->initActivationForm();
-        
+
         if ($this->form->checkInput()) {
             $this->getPageObject()->setActive(true);
             $this->getPageObject()->setActivationStart(null);
@@ -3582,7 +3582,7 @@ class ilPageObjectGUI
                 $a_content_object->getParentType()
             );
         }
-    
+
         if ($a_enable_private_notes) {
             $notes_gui->enablePrivateNotes();
         }
@@ -3592,7 +3592,7 @@ class ilPageObjectGUI
                 $notes_gui->enablePublicNotesDeletion(true);
             }
         }
-        
+
         if ($a_callback) {
             $notes_gui->addObserver($a_callback);
         }
@@ -3636,10 +3636,10 @@ class ilPageObjectGUI
     {
         $this->tabs_gui->activateTab("edit");
         $form = $this->initOpenedContentForm();
-        
+
         $this->tpl->setContent($form->getHTML());
     }
-    
+
     /**
      * Init form for initially opened content
      *
@@ -3650,7 +3650,7 @@ class ilPageObjectGUI
     {
         include_once("Services/Form/classes/class.ilPropertyFormGUI.php");
         $form = new ilPropertyFormGUI();
-        
+
         // link input
         include_once 'Services/Form/classes/class.ilLinkInputGUI.php';
         $ac = new ilLinkInputGUI($this->lng->txt('cont_resource'), 'opened_content');
@@ -3661,17 +3661,17 @@ class ilPageObjectGUI
         if ($val["id"] != "" && $val["type"] != "") {
             $ac->setValue($val["type"] . "|" . $val["id"] . "|" . $val["target"]);
         }
-        
+
         $form->addItem($ac);
-        
+
         $form->addCommandButton("saveInitialOpenedContent", $this->lng->txt("save"));
         $form->addCommandButton("edit", $this->lng->txt("cancel"));
         $form->setTitle($this->lng->txt("cont_initial_attached_content"));
         $form->setFormAction($this->ctrl->getFormAction($this));
-        
+
         return $form;
     }
-    
+
     /**
      * Save initial opened content
      *
@@ -3685,16 +3685,16 @@ class ilPageObjectGUI
             ilUtil::stripSlashes($_POST["opened_content_ajax_id"]),
             ilUtil::stripSlashes($_POST["opened_content_ajax_target"])
         );
-        
+
         ilUtil::sendSuccess($this->lng->txt("msg_obj_modified"));
         $this->ctrl->redirect($this, "edit");
     }
-    
+
     ////
     //// Multilinguality functions
     ////
-        
-    
+
+
     /**
      * Switch to language
      */
@@ -3709,7 +3709,7 @@ class ilPageObjectGUI
         $this->ctrl->setParameter($this, "transl", $_GET["totransl"]);
         $this->ctrl->redirect($this, "edit");
     }
-    
+
     /**
      * Confirm page translation creation
      */
@@ -3718,7 +3718,7 @@ class ilPageObjectGUI
         $l = ilUtil::stripSlashes($_GET["totransl"]);
         $this->ctrl->setParameter($this, "totransl", $l);
         $this->lng->loadLanguageModule("meta");
-        
+
         include_once("./Services/Utilities/classes/class.ilConfirmationGUI.php");
         $cgui = new ilConfirmationGUI();
         $cgui->setFormAction($this->ctrl->getFormAction($this));
@@ -3728,7 +3728,7 @@ class ilPageObjectGUI
         $cgui->setConfirm($this->lng->txt("confirm"), "createPageTranslation");
         $this->tpl->setContent($cgui->getHTML());
     }
-    
+
     /**
      * Edit master language
      */
@@ -3737,7 +3737,7 @@ class ilPageObjectGUI
         $this->ctrl->setParameter($this, "transl", "");
         $this->ctrl->redirect($this, "edit");
     }
-    
+
     /**
      * Create page translation
      */
@@ -3766,7 +3766,7 @@ class ilPageObjectGUI
         ilUtil::sendSuccess($this->lng->txt("cont_page_lock_released"), true);
         $this->ctrl->redirect($this, "preview");
     }
-    
+
     protected function isPageContainerToBeRendered()
     {
         return (

--- a/Services/Container/classes/class.ilContainerGUI.php
+++ b/Services/Container/classes/class.ilContainerGUI.php
@@ -103,7 +103,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
      * @var \ILIAS\DI\UIServices
      */
     protected $ui;
-    
+
     /**
     * Constructor
     * @access public
@@ -135,7 +135,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $lng = $DIC->language();
 
         $this->rbacsystem = $rbacsystem;
-        
+
         $lng->loadLanguageModule("cntr");
         $lng->loadLanguageModule('cont');
 
@@ -151,7 +151,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     public function executeCommand()
     {
         $tpl = $this->tpl;
-        
+
         $next_class = $this->ctrl->getNextClass();
         $cmd = $this->ctrl->getCmd("render");
 
@@ -166,11 +166,11 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                     return "";
                 }
                 break;
-                
+
             case "ilobjstylesheetgui":
                 $this->forwardToStyleSheet();
                 break;
-            
+
             default:
                 $this->prepareOutput();
                 $cmd .= "Object";
@@ -210,7 +210,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
         if ($new_tpl_id != $current_tpl_id) {
             $_REQUEST['tplid'] = $new_tpl_id;
-            
+
             // redirect to didactic template confirmation
             include_once './Services/DidacticTemplate/classes/class.ilDidacticTemplateGUI.php';
             $this->ctrl->setReturn($this, 'edit');
@@ -230,9 +230,9 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     {
         $ilCtrl = $this->ctrl;
         $ilTabs = $this->tabs;
-        
+
         $ilTabs->clearTargets();
-        
+
         $cmd = $ilCtrl->getCmd();
         include_once("./Services/Style/Content/classes/class.ilObjStyleSheetGUI.php");
         $this->ctrl->setReturn($this, "editStyleProperties");
@@ -256,8 +256,8 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             $this->ctrl->redirectByClass("ilobjstylesheetgui", "edit");
         }
     }
-    
-    
+
+
     /**
     * forward command to page object
     */
@@ -274,7 +274,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         } else {
             $this->checkPermission("write");
         }
-        
+
         $ilTabs->clearTargets();
 
         if ($_GET["redirectSource"] == "ilinternallinkgui") {
@@ -301,7 +301,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         include_once("./Services/Container/classes/class.ilContainerPageGUI.php");
 
         $lng->loadLanguageModule("content");
-        
+
         include_once("./Services/Style/Content/classes/class.ilObjStyleSheet.php");
         $this->tpl->setVariable(
             "LOCATION_CONTENT_STYLESHEET",
@@ -324,7 +324,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             $new_page_object->setId($this->object->getId());
             $new_page_object->createFromXML();
         }
-        
+
         // get page object
         $this->ctrl->setReturnByClass("ilcontainerpagegui", "edit");
         $page_gui = new ilContainerPageGUI($this->object->getId());
@@ -370,16 +370,16 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             );
             $page_gui->setPrependingHtml($wtpl->get());
         }
-        
+
         // style tab
         $page_gui->setTabHook($this, "addPageTabs");
-        
+
         $ret = $this->ctrl->forwardCommand($page_gui);
 
         //$ret =& $page_gui->executeCommand();
         return $ret;
     }
-    
+
     /**
     * Add page tabs
     */
@@ -387,7 +387,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     {
         $ilTabs = $this->tabs;
         $ilCtrl = $this->ctrl;
-        
+
         $ilTabs->addTarget(
             "obj_sty",
             $ilCtrl->getLinkTarget($this, 'editStyleProperties'),
@@ -402,11 +402,11 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     {
         $ilSetting = $this->settings;
         $ilUser = $this->user;
-        
+
         if (!$ilSetting->get("enable_cat_page_edit")) {
             return;
         }
-        
+
         // old page editor content
         $xpage_id = ilContainer::_lookupContainerSetting(
             $this->object->getId(),
@@ -418,9 +418,9 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             return $xpage->getContent();
         }
 
-        
+
         // page object
-        
+
 
         // if page does not exist, return nothing
         include_once("./Services/COPage/classes/class.ilPageUtil.php");
@@ -432,7 +432,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         }
         include_once("./Services/Container/classes/class.ilContainerPage.php");
         include_once("./Services/Container/classes/class.ilContainerPageGUI.php");
-        
+
         include_once("./Services/Style/Content/classes/class.ilObjStyleSheet.php");
         $this->tpl->setVariable(
             "LOCATION_CONTENT_STYLESHEET",
@@ -466,7 +466,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         //$ret =& $page_gui->executeCommand();
         return $ret;
     }
-    
+
     /**
      * prepare output
      */
@@ -477,18 +477,18 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 // This method is called directly from ilContainerGUI::renderObject
                 #$this->showPossibleSubObjects();
                 $this->showTreeFlatIcon();
-                
+
                 // Member view
                 include_once './Services/Container/classes/class.ilMemberViewGUI.php';
                 ilMemberViewGUI::showMemberViewSwitch($this->object->getRefId());
             }
         }
     }
-    
+
     public function showTreeFlatIcon()
     {
         $tpl = $this->tpl;
-        
+
         // dont show icon, if role (permission gui->rolegui) is edited
         if ($_GET["obj_id"] != "") {
             return;
@@ -498,14 +498,14 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         if (ilMemberViewSettings::getInstance()->isActive()) {
             return;
         }
-        
+
         $mode = ($_SESSION["il_rep_mode"] == "flat")
             ? "tree"
             : "flat";
         $link = "ilias.php?baseClass=ilRepositoryGUI&amp;cmd=frameset&amp;set_mode=" . $mode . "&amp;ref_id=" . $this->object->getRefId();
         $tpl->setTreeFlatIcon($link, $mode);
     }
-    
+
     /**
     * called by prepare output
     */
@@ -514,18 +514,18 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         if (!ilContainer::_lookupContainerSetting($this->object->getId(), "hide_header_icon_and_title")) {
             $this->tpl->setTitle($this->object->getTitle());
             $this->tpl->setDescription($this->object->getLongDescription());
-    
+
             // set tile icon
             $icon = ilObject::_getIcon($this->object->getId(), "big", $this->object->getType());
             $this->tpl->setTitleIcon($icon, $this->lng->txt("obj_" . $this->object->getType()));
-                        
+
             include_once './Services/Object/classes/class.ilObjectListGUIFactory.php';
             $lgui = ilObjectListGUIFactory::_getListGUIByType($this->object->getType());
             $lgui->initItem($this->object->getRefId(), $this->object->getId());
             $this->tpl->setAlertProperties($lgui->getAlertProperties());
         }
     }
-        
+
     /**
     * show possible sub objects selection list
     */
@@ -535,7 +535,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $gui = new ilObjectAddNewItemGUI($this->object->getRefId());
         $gui->render();
     }
-    
+
     /**
      * Get content gui object
      *
@@ -550,7 +550,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 include_once("./Services/Container/classes/class.ilContainerSimpleContentGUI.php");
                 $container_view = new ilContainerSimpleContentGUI($this);
                 break;
-                
+
             case ilContainer::VIEW_OBJECTIVE:
                 include_once('./Services/Container/classes/class.ilContainerObjectiveGUI.php');
                 $container_view = new ilContainerObjectiveGUI($this);
@@ -562,7 +562,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 include_once("./Services/Container/classes/class.ilContainerSessionsContentGUI.php");
                 $container_view = new ilContainerSessionsContentGUI($this);
                 break;
-                
+
             // all items in one block
             case ilContainer::VIEW_BY_TYPE:
             default:
@@ -573,9 +573,9 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
         return $container_view;
     }
-    
-    
-    
+
+
+
     /**
     * render the object
     */
@@ -586,27 +586,27 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $ilTabs = $this->tabs;
         $ilCtrl = $this->ctrl;
         $ilSetting = $this->settings;
-        
+
         $container_view = $this->getContentGUI();
-        
+
         $this->setContentSubTabs();
         if ($this->isActiveAdministrationPanel()) {
             $ilTabs->activateSubTab("manage");
         } else {
             $ilTabs->activateSubTab("view_content");
         }
-        
+
         $container_view->setOutput();
 
         $this->adminCommands = $container_view->adminCommands;
-        
+
         // it is important not to show the subobjects/admin panel here, since
         // we will create nested forms in case, e.g. a news/calendar item is added
         if ($ilCtrl->getNextClass() != "ilcolumngui") {
             $this->showAdministrationPanel();
             $this->showPossibleSubObjects();
         }
-        
+
         $this->showPermanentLink();
 
         // add tree updater javascript
@@ -671,7 +671,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         } elseif ($this->isActiveAdministrationPanel()) {
             // #11545
             $main_tpl->setPageFormAction($this->ctrl->getFormAction($this));
-            
+
             include_once './Services/UIComponent/Toolbar/classes/class.ilToolbarGUI.php';
             $toolbar = new ilToolbarGUI();
             $this->ctrl->setParameter($this, "type", "");
@@ -711,7 +711,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 if ($this->object->gotItems()) {
                     $toolbar->addSeparator();
                 }
-                    
+
                 $toolbar->addButton(
                     $this->lng->txt('cntr_adopt_content'),
                     $this->ctrl->getLinkTargetByClass(
@@ -752,7 +752,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                     if ($this->isActiveOrdering()) {
                         // #11843
                         $main_tpl->setPageFormAction($this->ctrl->getFormAction($this));
-                        
+
                         include_once './Services/UIComponent/Toolbar/classes/class.ilToolbarGUI.php';
                         $toolbar = new ilToolbarGUI();
                         $this->ctrl->setParameter($this, "type", "");
@@ -856,18 +856,18 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     public function switchToStdEditorObject()
     {
         $ilCtrl = $this->ctrl;
-        
+
         $_SESSION["il_cntr_editor"] = "std";
         $ilCtrl->redirect($this, "editPageFrame");
     }
-    
+
     /**
     * Switch to old page editor
     */
     public function switchToOldEditorObject()
     {
         $ilCtrl = $this->ctrl;
-        
+
         $_SESSION["il_cntr_editor"] = "old";
         $ilCtrl->redirect($this, "editPageFrame");
     }
@@ -881,7 +881,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $ilAccess = $this->access;
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-        
+
         if ($ilAccess->checkAccess("write", "", $this->object->getRefId())) {
             include_once("./Services/XHTMLPage/classes/class.ilXHTMLPage.php");
 
@@ -902,7 +902,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
             ilUtil::sendSuccess($lng->txt("cntr_switched_editor"), true);
         }
-        
+
         $ilCtrl->redirect($this, "editPageFrame");
     }
 
@@ -939,7 +939,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         if (!$rbacsystem->checkAccess("write", $this->ref_id)) {
             $ilErr->raiseError($this->lng->txt("msg_no_perm_write"), $ilErr->MESSAGE);
         }
-        
+
         $xpage_id = ilContainer::_lookupContainerSetting(
             $this->object->getId(),
             "xhtml_page"
@@ -949,7 +949,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             $xpage = new ilXHTMLPage($xpage_id);
             $content = $xpage->getContent();
         }
-        
+
         // get template
         $tpl->addBlockFile(
             "ADM_CONTENT",
@@ -970,12 +970,12 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $tpl->setVariable("IMG_WARNING", ilUtil::getImagePath("icon_alert.svg"));
         $tpl->setVariable("HREF_OPEN_STD_EDITOR", $ilCtrl->getLinkTarget($this, "switchToStdEditor"));
         $tpl->setVariable("ALT_WARNING", $lng->txt("warning"));
-        
+
         include_once("./Services/Form/classes/class.ilFormPropertyGUI.php");
         include_once("./Services/Form/classes/class.ilTextAreaInputGUI.php");
         //$ta = new ilTextAreaInputGUI();
         //$tags = $ta->getRteTagSet("extended_table_img");
-        
+
         // add rte support
         include_once "./Services/RTE/classes/class.ilRTE.php";
         $rtestring = ilRTE::_getRTEClassname();
@@ -989,7 +989,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         //$rte->setStyleSelect(true);
         //$rte->addCustomRTESupport($obj_id, $obj_type, $tags);
     }
-    
+
     public function savePageContentObject()
     {
         include_once("Services/XHTMLPage/classes/class.ilXHTMLPage.php");
@@ -998,7 +998,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             $this->object->getId(),
             "xhtml_page"
         );
-        
+
         /*include_once("./Services/Form/classes/class.ilFormPropertyGUI.php");
         include_once("./Services/Form/classes/class.ilTextAreaInputGUI.php");
         $ta = new ilTextAreaInputGUI();
@@ -1008,7 +1008,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         //$text = ilUtil::stripSlashes($_POST["page_content"],
         //		true,
         //		$tags);
-                
+
         $text = ilUtil::stripSlashes(
             $_POST["page_content"],
             true,
@@ -1028,7 +1028,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 $xpage->getId()
             );
         }
-        
+
         include_once("Services/RTE/classes/class.ilRTE.php");
         ilRTE::_cleanupMediaObjectUsage(
             $text,
@@ -1039,7 +1039,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         ilUtil::sendSuccess($this->lng->txt("msg_obj_modified"), true);
         $this->ctrl->redirect($this, "");
     }
-    
+
     public function cancelPageContentObject()
     {
         $this->ctrl->redirect($this, "");
@@ -1049,19 +1049,19 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     {
         $lng = $this->lng;
         $tree = $this->tree;
-        
+
         $tpl = new ilTemplate(
             "tpl.container_link_help.html",
             true,
             true,
             "Services/Container"
         );
-        
+
         $type_ordering = array(
             "cat", "fold", "crs", "grp", "chat", "frm", "lres",
             "glo", "webr", "file", "exc",
             "tst", "svy", "mep", "qpl", "spl");
-            
+
         $childs = $tree->getChilds($_GET["ref_id"]);
         foreach ($childs as $child) {
             if (in_array($child["type"], array("lm", "sahs", "htlm"))) {
@@ -1070,7 +1070,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 $cnt[$child["type"]]++;
             }
         }
-            
+
         $tpl->setVariable("LOCATION_STYLESHEET", ilUtil::getStyleSheetLocation());
         $tpl->setVariable("TXT_HELP_HEADER", $lng->txt("help"));
         foreach ($type_ordering as $type) {
@@ -1097,7 +1097,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     {
         $this->adminCommands = false;
     }
-    
+
     /**
     * determin admin commands
     */
@@ -1156,7 +1156,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         } else {
             $a_tpl->setCurrentBlock("container_header_row");
         }
-        
+
         $a_tpl->setVariable("BLOCK_HEADER_CONTENT", $title);
         $a_tpl->parseCurrentBlock();
         //$a_tpl->touchBlock("container_row");
@@ -1183,7 +1183,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             : "row_type_1";
 
         $a_tpl->touchBlock($this->cur_row_type);
-        
+
         $nbsp = true;
         if ($ilSetting->get("icon_position_in_lists") == "item_rows") {
             $icon = ilUtil::getImagePath("icon_" . $a_image_type . ".svg");
@@ -1241,10 +1241,10 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             : "row_type_1";
 
         $a_tpl->touchBlock($this->cur_row_type);
-        
+
         $type = $this->lng->txt("obj_" . $a_type);
         $a_message = str_replace("[type]", $type, $a_message);
-        
+
         $a_tpl->setVariable("ROW_NBSP", "&nbsp;");
 
         $a_tpl->setCurrentBlock("container_standard_row");
@@ -1261,14 +1261,14 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $this->cur_row_type = "";
     }
 
-    
+
     /**
     * Add page editor tabs
     */
     public function setPageEditorTabs()
     {
         $lng = $this->lng;
-        
+
         if (!$this->isActiveAdministrationPanel()
             || strtolower($this->ctrl->getCmdClass()) != "ilcontainerpagegui") {
             return;
@@ -1277,7 +1277,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $lng->loadLanguageModule("content");
         //$tabs_gui = new ilTabsGUI();
         //$tabs_gui->setSubTabs();
-        
+
         // back to upper context
         $this->tabs_gui->setBackTarget(
             $this->lng->txt("obj_cat"),
@@ -1305,7 +1305,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         if (!is_object($this->object)) {
             return;
         }
-        
+
         if ($a_include_view && $ilAccess->checkAccess("read", "", $this->object->getRefId())) {
             if (!$this->isActiveAdministrationPanel()) {
                 $ilTabs->addSubTab("view_content", $lng->txt("view"), $ilCtrl->getLinkTarget($this, "view"));
@@ -1313,7 +1313,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 $ilTabs->addSubTab("view_content", $lng->txt("view"), $ilCtrl->getLinkTarget($this, "disableAdministrationPanel"));
             }
         }
-        
+
         if ($ilUser->getId() != ANONYMOUS_USER_ID &&
                 (
                     $this->adminCommands ||
@@ -1352,7 +1352,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             }
         }
     }
-    
+
 
     /**
     * common tabs for all container objects (should be called
@@ -1416,14 +1416,14 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     public function editOrderObject()
     {
         $ilTabs = $this->tabs;
-        
+
         $this->edit_order = true;
         $_SESSION["il_cont_admin_panel"] = false;
         $this->renderObject();
-        
+
         $ilTabs->activateSubTab("ordering");
     }
-    
+
     /**
      * Check if ordering is enabled
      * @return  bool
@@ -1432,7 +1432,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     {
         return $this->edit_order ? true : false;
     }
-    
+
     /**
      * Check if item ordering is enabled
      * @return bool
@@ -1444,7 +1444,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         }
         return false;
     }
-            
+
     /**
      * @see ilDesktopItemHandling::addToDesk()
      */
@@ -1452,17 +1452,17 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     {
         $ilSetting = $this->settings;
         $lng = $this->lng;
-        
+
         if ((int) $ilSetting->get('disable_my_offers')) {
             return $this->renderObject();
         }
-        
+
         include_once './Services/PersonalDesktop/classes/class.ilDesktopItemGUI.php';
         ilDesktopItemGUI::addToDesktop();
         ilUtil::sendSuccess($lng->txt("added_to_desktop"));
         $this->renderObject();
     }
-    
+
     /**
      * @see ilDesktopItemHandling::removeFromDesk()
      */
@@ -1470,11 +1470,11 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     {
         $ilSetting = $this->settings;
         $lng = $this->lng;
-        
+
         if ((int) $ilSetting->get('disable_my_offers')) {
             return $this->renderObject();
         }
-        
+
         include_once './Services/PersonalDesktop/classes/class.ilDesktopItemGUI.php';
         ilDesktopItemGUI::removeFromDesktop();
         ilUtil::sendSuccess($lng->txt("removed_from_desktop"));
@@ -1494,7 +1494,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     {
         return $this->multi_download_enabled;
     }
-    
+
     /**
     * cut object(s) out from a container and write the information to clipboard
     *
@@ -1531,7 +1531,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 if ($node['type'] == 'rolf') {
                     continue;
                 }
-                
+
                 if (!$rbacsystem->checkAccess('delete', $node["ref_id"])) {
                     $no_cut[] = $node["ref_id"];
                 }
@@ -1602,7 +1602,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 if ($node['type'] == 'rolf') {
                     continue;
                 }
-                
+
                 if (!$rbacsystem->checkAccess('visible,read,copy', $node["ref_id"])) {
                     $no_copy[] = $node["ref_id"];
                 }
@@ -1630,7 +1630,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             $ilCtrl->setParameterByClass("ilobjectcopygui", "source_id", $_POST["id"][0]);
             $ilCtrl->redirectByClass("ilobjectcopygui", "initTargetSelection");
         } else {
-            $ilCtrl->setParameterByClass("ilobjectcopygui", "source_ids", implode($_POST["id"], "_"));
+            $ilCtrl->setParameterByClass("ilobjectcopygui", "source_ids", implode("_", $_POST["id"]));
             $ilCtrl->redirectByClass("ilobjectcopygui", "initTargetSelection");
         }
 
@@ -1642,7 +1642,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
         return $this->initAndDisplayCopyIntoMultipleObjectsObject();
     } // END COPY
-    
+
     public function downloadObject()
     {
         $rbacsystem = $this->rbacsystem;
@@ -1669,7 +1669,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 $no_perm[] = $ref_id;
             }
         }
-        
+
         // IF THERE IS ANY OBJECT THAT CANNOT BE DOWNLOADED
         if (count($no_download)) {
             $no_download = array_unique($no_download);
@@ -1678,7 +1678,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             }
             $ilErr->raiseError(implode(', ', $txt_objs) . " " . $this->lng->txt("msg_obj_no_download"), $ilErr->MESSAGE);
         }
-        
+
         // NO ACCESS
         if (count($no_perm)) {
             $ilErr->raiseError(
@@ -1686,37 +1686,37 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 $ilErr->MESSAGE
             );
         }
-        
+
         // download the objects
         $this->downloadMultipleObjects($_POST["id"]);
     }
-    
+
     private function downloadMultipleObjects($a_ref_ids)
     {
         $lng = $this->lng;
         $rbacsystem = $this->rbacsystem;
         $ilAccess = $this->access;
-        
+
         include_once 'Modules/Folder/classes/class.ilObjFolder.php';
         include_once 'Modules/File/classes/class.ilObjFile.php';
         include_once 'Modules/File/classes/class.ilFileException.php';
-        
+
         // create temporary file to download
         $zip = PATH_TO_ZIP;
         $tmpdir = ilUtil::ilTempnam();
         ilUtil::makeDir($tmpdir);
-        
+
         try {
             // copy each selected object
             foreach ($a_ref_ids as $ref_id) {
                 if (!$ilAccess->checkAccess("read", "", $ref_id)) {
                     continue;
                 }
-                
+
                 if (ilObject::_isInTrash($ref_id)) {
                     continue;
                 }
-                
+
                 // get object
                 $object = ilObjectFactory::getInstanceByRefId($ref_id);
                 $obj_type = $object->getType();
@@ -1739,7 +1739,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             ilUtil::sendInfo($e->getMessage(), true);
         }
     }
-    
+
     /**
      * private functions which iterates through all folders and files
      * and create an according file structure in a temporary directory. This function works recursive.
@@ -1755,12 +1755,12 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $rbacsystem = $DIC->rbac()->system();
         $tree = $DIC->repositoryTree();
         $ilAccess = $DIC->access();
-        
+
         $tmpdir = $tmpdir . DIRECTORY_SEPARATOR . ilUtil::getASCIIFilename($title);
         ilUtil::makeDir($tmpdir);
-        
+
         $subtree = $tree->getChildsByTypeFilter($refid, array("fold","file"));
-        
+
         foreach ($subtree as $child) {
             if (!$ilAccess->checkAccess("read", "", $child["ref_id"])) {
                 continue;
@@ -1777,18 +1777,18 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             }
         }
     }
-    
+
     private static function copyFile($obj_id, $title, $tmpdir)
     {
         $newFilename = $tmpdir . DIRECTORY_SEPARATOR . ilUtil::getASCIIFilename($title);
-        
+
         // copy to temporary directory
         $oldFilename = ilObjFile::_lookupAbsolutePath($obj_id);
 
         if (!copy($oldFilename, $newFilename)) {
             throw new ilFileException("Could not copy " . $oldFilename . " to " . $newFilename);
         }
-        
+
         touch($newFilename, filectime($oldFilename));
     }
 
@@ -1868,7 +1868,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     {
         unset($_SESSION["clipboard"]);
         unset($_SESSION["il_rep_clipboard"]);
-        
+
         //var_dump($this->getReturnLocation("clear",$this->ctrl->getLinkTarget($this)),get_class($this));
 
         // only redirect if clipboard was cleared
@@ -1878,7 +1878,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             $this->ctrl->redirect($this, 'render');
         }
     }
-    
+
     public function performPasteIntoMultipleObjectsObject()
     {
         $rbacsystem = $this->rbacsystem;
@@ -1903,7 +1903,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             $message = __METHOD__ . ": cmd was neither 'cut', 'link' nor 'copy'; may be a hack attempt!";
             $ilErr->raiseError($message, $ilErr->WARNING);
         }
-        
+
         if ($command == 'cut') {
             if (isset($_POST['node']) && (int) $_POST['node']) {
                 $_POST['nodes'] = array($_POST['node']);
@@ -1931,7 +1931,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         foreach ($_SESSION['clipboard']['ref_ids'] as $ref_id) {
             $obj_data = ilObjectFactory::getInstanceByRefId($ref_id);
             $current_parent_id = $tree->getParentId($obj_data->getRefId());
-            
+
             foreach ($_POST['nodes'] as $folder_ref_id) {
                 if (!array_key_exists($folder_ref_id, $folder_objects_cache)) {
                     $folder_objects_cache[$folder_ref_id] = ilObjectFactory::getInstanceByRefId($folder_ref_id);
@@ -1941,18 +1941,18 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 if (!$rbacsystem->checkAccess('create', $folder_ref_id, $obj_data->getType())) {
                     $no_paste[] = sprintf($this->lng->txt('msg_no_perm_paste_object_in_folder'), $obj_data->getTitle() . ' [' . $obj_data->getRefId() . ']', $folder_objects_cache[$folder_ref_id]->getTitle() . ' [' . $folder_objects_cache[$folder_ref_id]->getRefId() . ']');
                 }
-                
+
                 // CHECK IF REFERENCE ALREADY EXISTS
                 if ($folder_ref_id == $current_parent_id) {
                     $exists[] = sprintf($this->lng->txt('msg_obj_exists_in_folder'), $obj_data->getTitle() . ' [' . $obj_data->getRefId() . ']', $folder_objects_cache[$folder_ref_id]->getTitle() . ' [' . $folder_objects_cache[$folder_ref_id]->getRefId() . ']');
                 }
-    
+
                 // CHECK IF PASTE OBJECT SHALL BE CHILD OF ITSELF
                 if ($tree->isGrandChild($ref_id, $folder_ref_id) ||
                     $ref_id == $folder_ref_id) {
                     $is_child[] = sprintf($this->lng->txt('msg_paste_object_not_in_itself'), $obj_data->getTitle() . ' [' . $obj_data->getRefId() . ']');
                 }
-    
+
                 // CHECK IF OBJECT IS ALLOWED TO CONTAIN PASTED OBJECT AS SUBOBJECT
                 if (!in_array($obj_data->getType(), array_keys($folder_objects_cache[$folder_ref_id]->getPossibleSubObjects()))) {
                     $not_allowed_subobject[] = sprintf(
@@ -1963,7 +1963,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 }
             }
         }
-        
+
         ////////////////////////////
         // process checking results
         if (count($exists) && $command != "copy") {
@@ -1984,7 +1984,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             $error .= $error != '' ? '<br />' : '';
             $error .= implode('<br />', $no_paste);
         }
-        
+
         if ($error != '') {
             ilUtil::sendFailure($error);
             switch ($command) {
@@ -2010,17 +2010,17 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         // to prevent multiple actions via back/reload button
         $ref_ids = $_SESSION['clipboard']['ref_ids'];
         unset($_SESSION['clipboard']['ref_ids']);
-        
+
         // BEGIN ChangeEvent: Record paste event.
         require_once('Services/Tracking/classes/class.ilChangeEvent.php');
         // END ChangeEvent: Record paste event.
-        
+
         // process COPY command
         if ($command == 'copy') {
             foreach ($_POST['nodes'] as $folder_ref_id) {
                 foreach ($ref_ids as $ref_id) {
                     $revIdMapping = array();
-                    
+
                     $oldNode_data = $tree->getNodeData($ref_id);
                     if ($oldNode_data['parent'] == $folder_ref_id) {
                         require_once 'Modules/File/classes/class.ilObjFileAccess.php';
@@ -2029,7 +2029,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                     } else {
                         $newRef = $this->cloneNodes($ref_id, $folder_ref_id, $refIdMapping, null);
                     }
-                    
+
                     // BEGIN ChangeEvent: Record copy event.
                     $old_parent_data = $tree->getParentNodeData($ref_id);
                     $newNode_data = $tree->getNodeData($newRef);
@@ -2049,10 +2049,10 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                     // END PATCH ChangeEvent: Record cut event.
                 }
             }
-            
+
             ilUtil::sendSuccess($this->lng->txt('msg_cloned'), true);
         } // END COPY
-        
+
         // process CUT command
         if ($command == 'cut') {
             foreach ($_POST['nodes'] as $folder_ref_id) {
@@ -2061,10 +2061,10 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                     $old_parent = $tree->getParentId($ref_id);
                     $tree->moveTree($ref_id, $folder_ref_id);
                     $rbacadmin->adjustMovedObjectPermissions($ref_id, $old_parent);
-                    
+
                     include_once('./Services/Conditions/classes/class.ilConditionHandler.php');
                     ilConditionHandler::_adjustMovedObjectConditions($ref_id);
-    
+
                     // BEGIN ChangeEvent: Record cut event.
                     $node_data = $tree->getNodeData($ref_id);
                     $old_parent_data = $tree->getNodeData($old_parent);
@@ -2083,32 +2083,32 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                     ilChangeEvent::_catchupWriteEvents($node_data['obj_id'], $ilUser->getId());
                     // END PATCH ChangeEvent: Record cut event.
                 }
-                
+
                 // prevent multiple iterations for cut cmommand
                 break;
             }
-            
+
             ilUtil::sendSuccess($this->lng->txt('msg_cut_copied'), true);
         } // END CUT
-        
+
         // process LINK command
         if ($command == 'link') {
             $linked_to_folders = array();
 
             include_once "Services/AccessControl/classes/class.ilRbacLog.php";
             $rbac_log_active = ilRbacLog::isActive();
-            
+
             foreach ($_POST['nodes'] as $folder_ref_id) {
                 $linked_to_folders[$folder_ref_id] = $ilObjDataCache->lookupTitle($ilObjDataCache->lookupObjId($folder_ref_id));
-                        
+
                 foreach ($ref_ids as $ref_id) {
                     // get node data
                     $top_node = $tree->getNodeData($ref_id);
-    
+
                     // get subnodes of top nodes
                     $subnodes[$ref_id] = $tree->getSubtree($top_node);
                 }
-    
+
                 // now move all subtrees to new location
                 foreach ($subnodes as $key => $subnode) {
                     // first paste top_node....
@@ -2116,14 +2116,14 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                     $new_ref_id = $obj_data->createReference();
                     $obj_data->putInTree($folder_ref_id);
                     $obj_data->setPermissions($folder_ref_id);
-                    
+
                     // rbac log
                     if ($rbac_log_active) {
                         $rbac_log_roles = $rbacreview->getParentRoleIds($new_ref_id, false);
                         $rbac_log = ilRbacLog::gatherFaPa($new_ref_id, array_keys($rbac_log_roles), true);
                         ilRbacLog::add(ilRbacLog::LINK_OBJECT, $new_ref_id, $rbac_log, $key);
                     }
-    
+
                     // BEGIN ChangeEvent: Record link event.
                     $node_data = $tree->getNodeData($new_ref_id);
                     ilChangeEvent::_recordWriteEvent(
@@ -2135,7 +2135,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                     ilChangeEvent::_catchupWriteEvents($node_data['obj_id'], $ilUser->getId());
                     // END PATCH ChangeEvent: Record link event.
                 }
-    
+
                 $ilLog->write(__METHOD__ . ', link finished');
             }
 
@@ -2153,10 +2153,10 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             if (count($ref_ids) == 1) {
                 $suffix = 's';
             }
-            
+
             $mbox = $ui->factory()->messageBox()->success($this->lng->txt('mgs_objects_linked_to_the_following_folders_' . $suffix))
                 ->withLinks($links);
-            
+
             ilUtil::sendSuccess($ui->renderer()->render($mbox), true);
         } // END LINK
 
@@ -2165,17 +2165,17 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
         $this->ctrl->returnToParent($this);
     }
-    
+
     public function initAndDisplayLinkIntoMultipleObjectsObject()
     {
         $tree = $this->tree;
-        
+
         // empty session on init
         $_SESSION['paste_linked_repexpand'] = array();
-        
+
         // copy opend nodes from repository explorer
         $_SESSION['paste_linked_repexpand'] = is_array($_SESSION['repexpand']) ? $_SESSION['repexpand'] : array();
-        
+
         // open current position
         $path = $tree->getPathId((int) $_GET['ref_id']);
         foreach ((array) $path as $node_id) {
@@ -2183,7 +2183,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 $_SESSION['paste_linked_repexpand'][] = $node_id;
             }
         }
-        
+
         return $this->showPasteTreeObject();
     }
 
@@ -2267,17 +2267,17 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $ilCtrl->returnToParent($this);
     }
 
-    
+
     public function initAndDisplayCopyIntoMultipleObjectsObject()
     {
         $tree = $this->tree;
 
         // empty session on init
         $_SESSION['paste_copy_repexpand'] = array();
-        
+
         // copy opend nodes from repository explorer
         $_SESSION['paste_copy_repexpand'] = is_array($_SESSION['repexpand']) ? $_SESSION['repexpand'] : array();
-        
+
         // open current position
         $path = $tree->getPathId((int) $_GET['ref_id']);
         foreach ((array) $path as $node_id) {
@@ -2285,21 +2285,21 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 $_SESSION['paste_copy_repexpand'][] = $node_id;
             }
         }
-        
+
         return $this->showPasteTreeObject();
     }
-    
+
 
     public function initAndDisplayMoveIntoObjectObject()
     {
         $tree = $this->tree;
-        
+
         // empty session on init
         $_SESSION['paste_cut_repexpand'] = array();
-        
+
         // copy opend nodes from repository explorer
         $_SESSION['paste_cut_repexpand'] = is_array($_SESSION['repexpand']) ? $_SESSION['repexpand'] : array();
-        
+
         // open current position
         $path = $tree->getPathId((int) $_GET['ref_id']);
         foreach ((array) $path as $node_id) {
@@ -2307,10 +2307,10 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 $_SESSION['paste_cut_repexpand'][] = $node_id;
             }
         }
-        
+
         return $this->showPasteTreeObject();
     }
-    
+
 
     /**
     * paste object from clipboard to current place
@@ -2425,7 +2425,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 $ilCtrl->redirectByClass("ilobjectcopygui", "saveTarget");
             } else {
                 $ilCtrl->setParameterByClass("ilobjectcopygui", "target", $this->object->getRefId());
-                $ilCtrl->setParameterByClass("ilobjectcopygui", "source_ids", implode($ref_ids, "_"));
+                $ilCtrl->setParameterByClass("ilobjectcopygui", "source_ids", implode("_", $ref_ids));
                 $ilCtrl->redirectByClass("ilobjectcopygui", "saveTarget");
             }
 
@@ -2471,7 +2471,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 $old_parent = $tree->getParentId($ref_id);
                 $this->tree->moveTree($ref_id, $this->object->getRefId());
                 $rbacadmin->adjustMovedObjectPermissions($ref_id, $old_parent);
-                
+
                 include_once('./Services/Conditions/classes/class.ilConditionHandler.php');
                 ilConditionHandler::_adjustMovedObjectConditions($ref_id);
 
@@ -2548,7 +2548,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
         $this->ctrl->returnToParent($this);
     } // END PASTE
-    
+
 
     /**
     * show clipboard
@@ -2613,17 +2613,17 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     public function isActiveAdministrationPanel()
     {
         $ilAccess = $this->access;
-        
+
         // #10081
         if ($_SESSION["il_cont_admin_panel"] &&
             $this->object->getRefId() &&
             !$ilAccess->checkAccess("write", "", $this->object->getRefId())) {
             return false;
         }
-        
+
         return $_SESSION["il_cont_admin_panel"];
     }
-    
+
     /**
     * May be overwritten in subclasses.
     */
@@ -2637,11 +2637,11 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             $this->allowBlocksMoving()) {
             $column_gui->setEnableMovement(true);
         }
-        
+
         $column_gui->setRepositoryItems(
             $this->object->getSubItems($this->isActiveAdministrationPanel(), true)
         );
-        
+
         //if ($ilAccess->checkAccess("write", "", $this->object->getRefId())
         //	&& $this->allowBlocksConfigure())
         if ($ilAccess->checkAccess("write", "", $this->object->getRefId())) {
@@ -2650,12 +2650,12 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             $column_gui->setBlockProperty("news", "default_visibility_option", true);
             $column_gui->setBlockProperty("news", "hide_news_block_option", true);
         }
-        
+
         if ($this->isActiveAdministrationPanel()) {
             $column_gui->setAdminCommands(true);
         }
     }
-    
+
     /**
     * Standard is to allow blocks moving
     */
@@ -2671,7 +2671,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     {
         return true;
     }
-    
+
     /**
     *
     *
@@ -2683,7 +2683,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     {
         $this->cloneWizardPageObject(true);
     }
-    
+
     /**
      *
      *
@@ -2695,7 +2695,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     {
         $this->cloneWizardPageObject(false);
     }
-    
+
     /**
      * Show clone wizard page for container objects
      *
@@ -2705,10 +2705,10 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     public function cloneWizardPageObject($a_tree_view = true)
     {
         include_once('Services/CopyWizard/classes/class.ilCopyWizardPageFactory.php');
-        
+
         $ilObjDataCache = $this->obj_data_cache;
         $tree = $this->tree;
-        
+
         if (!$_REQUEST['clone_source']) {
             ilUtil::sendFailure($this->lng->txt('select_one'));
             if (isset($_SESSION['wizard_search_title'])) {
@@ -2722,13 +2722,13 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $new_type = $_REQUEST['new_type'];
         $this->ctrl->setParameter($this, 'clone_source', (int) $_REQUEST['clone_source']);
         $this->ctrl->setParameter($this, 'new_type', $new_type);
-        
+
 
         // Generell JavaScript
         $this->tpl->addJavaScript('./Services/CopyWizard/js/ilContainer.js');
         $this->tpl->setVariable('BODY_ATTRIBUTES', 'onload="ilDisableChilds(\'cmd\');"');
 
-        
+
         $this->tpl->addBlockFile(
             'ADM_CONTENT',
             'adm_content',
@@ -2747,7 +2747,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         } else {
             $this->tpl->setVariable('CMD_BACK', 'create');
         }
-        
+
         $this->tpl->setVariable('BTN_TREE', $this->lng->txt('treeview'));
         $this->tpl->setVariable('BTN_LIST', $this->lng->txt('flatview'));
 
@@ -2761,11 +2761,11 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                     $first = false;
                     continue;
                 }
-                
+
                 if ($node['type'] == 'rolf') {
                     continue;
                 }
-                
+
                 $has_items = true;
 
                 for ($i = $source_node['depth'];$i < $node['depth']; $i++) {
@@ -2775,7 +2775,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 // fill options
                 $copy_wizard_page = ilCopyWizardPageFactory::_getInstanceByType($source_id, $node['type']);
                 $copy_wizard_page->fillTreeSelection($node['ref_id'], $node['type'], $node['depth']);
-                
+
                 $this->tpl->setCurrentBlock('tree_row');
                 $this->tpl->setVariable('TREE_IMG', ilUtil::getImagePath('icon_' . $node['type'] . '.svg'));
                 $this->tpl->setVariable('TREE_ALT_IMG', $this->lng->txt('obj_' . $node['type']));
@@ -2804,7 +2804,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             }
         }
     }
-    
+
     /**
      * Clone all object
      * Overwritten method for copying container objects
@@ -2816,20 +2816,20 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     {
         $ilLog = $this->log;
         $ilCtrl = $this->ctrl;
-        
+
         include_once('./Services/Link/classes/class.ilLink.php');
         include_once('Services/CopyWizard/classes/class.ilCopyWizardOptions.php');
-        
+
         $ilAccess = $this->access;
         $ilErr = $this->error;
         $rbacsystem = $this->rbacsystem;
         $tree = $this->tree;
         $ilUser = $this->user;
-        
+
         $new_type = $_REQUEST['new_type'];
         $ref_id = (int) $_GET['ref_id'];
         $clone_source = (int) $_REQUEST['clone_source'];
-        
+
         if (!$rbacsystem->checkAccess('create', $ref_id, $new_type)) {
             $ilErr->raiseError($this->lng->txt('permission_denied'));
         }
@@ -2845,7 +2845,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $options = $_POST['cp_options'] ? $_POST['cp_options'] : array();
         $orig = ilObjectFactory::getInstanceByRefId($clone_source);
         $result = $orig->cloneAllObject($_COOKIE[session_name()], $_COOKIE['ilClientId'], $new_type, $ref_id, $clone_source, $options);
-        
+
         include_once './Services/CopyWizard/classes/class.ilCopyWizardOptions.php';
         if (ilCopyWizardOptions::_isFinished($result['copy_id'])) {
             ilUtil::sendSuccess($this->lng->txt("object_duplicated"), true);
@@ -2858,7 +2858,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         }
     }
 
-    
+
     /**
      * Save Sorting
      *
@@ -2878,7 +2878,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         ilUtil::sendSuccess($this->lng->txt('cntr_saved_sorting'), true);
         $this->ctrl->redirect($this, "editOrder");
     }
-    
+
     // BEGIN WebDAV: Support a copy command in the repository
     /**
     * Recursively clones all nodes of the RBAC tree.
@@ -2899,7 +2899,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         error_log(__METHOD__ . ' cloning srcRef=' . $srcRef . ' dstRef=' . $dstRef . '...');
         $newRef = $srcObj->cloneObject($dstRef)->getRefId();
         error_log(__METHOD__ . ' ...cloning... newRef=' . $newRef . '...');
-        
+
         // We must immediately apply a new name to the object, to
         // prevent confusion of WebDAV clients about having two objects with identical
         // name in the repository.
@@ -2939,7 +2939,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     public function modifyItemGUI($a_item_list_gui, $a_item_data, $a_show_path)
     {
         $lng = $this->lng;
-        
+
         if ($a_show_path) {
             $a_item_list_gui->addCustomProperty(
                 $lng->txt('path'),
@@ -2949,7 +2949,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             );
         }
     }
-    
+
     /**
     * build path
     */
@@ -2974,7 +2974,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     //
     // Style editing
     //
-    
+
     /**
     * Edit style properties
     */
@@ -2982,15 +2982,15 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     {
         $ilTabs = $this->tabs;
         $tpl = $this->tpl;
-        
+
         $this->checkPermission("write");
-        
+
         $this->initStylePropertiesForm();
         $tpl->setContent($this->form->getHTML());
-        
+
         $ilTabs->activateTab("obj_sty");
     }
-    
+
     /**
     * Init style properties form
     */
@@ -3001,7 +3001,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $ilTabs = $this->tabs;
         $ilSetting = $this->settings;
         $tpl = $this->tpl;
-        
+
         $tpl->setTreeFlatIcon("", "");
         $ilTabs->clearTargets();
         $xpage_id = ilContainer::_lookupContainerSetting(
@@ -3030,13 +3030,13 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $page_gui->setTabHook($this, "addPageTabs");
         $ilCtrl->getHTML($page_gui);
         $ilTabs->setTabActive("obj_sty");
-        
+
         include_once("./Services/Style/Content/classes/class.ilObjStyleSheet.php");
         $lng->loadLanguageModule("style");
 
         include_once("./Services/Form/classes/class.ilPropertyFormGUI.php");
         $this->form = new ilPropertyFormGUI();
-        
+
         $fixed_style = $ilSetting->get("fixed_content_style_id");
         //		$style_id = $this->object->getStyleSheetId();
 
@@ -3113,7 +3113,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
         $ilCtrl->redirectByClass("ilobjstylesheetgui", "create");
     }
-    
+
     /**
     * Edit Style
     */
@@ -3140,7 +3140,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     public function saveStyleSettingsObject()
     {
         $ilSetting = $this->settings;
-    
+
         include_once("./Services/Style/Content/classes/class.ilObjStyleSheet.php");
         if ($ilSetting->get("fixed_content_style_id") <= 0 &&
             (ilObjStyleSheet::_lookupStandard($this->object->getStyleSheetId())
@@ -3158,22 +3158,22 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     public function getAsynchItemListObject()
     {
         $ilCtrl = $this->ctrl;
-        
+
         $ref_id = $_GET["cmdrefid"];
         $obj_id = ilObject::_lookupObjId($ref_id);
         $type = ilObject::_lookupType($obj_id);
-        
+
         // this should be done via container-object->getSubItem in the future
         $data = array("child" => $ref_id, "ref_id" => $ref_id, "obj_id" => $obj_id,
             "type" => $type);
         include_once 'Services/Object/classes/class.ilObjectListGUIFactory.php';
         $item_list_gui = ilObjectListGUIFactory::_getListGUIByType($type);
         $item_list_gui->setContainerObject($this);
-        
+
         $item_list_gui->enableComments(true);
         $item_list_gui->enableNotes(true);
         $item_list_gui->enableTags(true);
-        
+
         $this->modifyItemGUI($item_list_gui, $data, false);
         $html = $item_list_gui->getListItemHTML(
             $ref_id,
@@ -3195,7 +3195,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 $html = $gui_class->modifyHTML($html, $resp);
             }
         }
-        
+
         echo $html;
         exit;
     }
@@ -3208,12 +3208,12 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     {
         $tpl = $this->tpl;
         $ilToolbar = $this->toolbar;
-        
+
         if ($a_init) {
             ilUtil::sendInfo($this->lng->txt('webdav_pwd_instruction'));
             $this->initFormPasswordInstruction();
         }
-        
+
         include_once('Services/WebDAV/classes/class.ilWebDAVUtil.php');
         $dav_util = ilWebDAVUtil::getInstance();
         $ilToolbar->addButton(
@@ -3227,7 +3227,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
         $tpl->setContent($this->form->getHTML());
     }
-    
+
     /**
      * Init password form
      * @return
@@ -3237,7 +3237,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         include_once("Services/Form/classes/class.ilPropertyFormGUI.php");
         $this->form = new ilPropertyFormGUI();
         $this->form->setFormAction($this->ctrl->getFormAction($this));
-    
+
         // new password
         $ipass = new ilPasswordInputGUI($this->lng->txt("desired_password"), "new_password");
         $ipass->setRequired(true);
@@ -3245,13 +3245,13 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $this->form->addItem($ipass);
         $this->form->addCommandButton("savePassword", $this->lng->txt("save"));
         $this->form->addCommandButton('cancel', $this->lng->txt('cancel'));
-        
+
         $this->form->setTitle($this->lng->txt("chg_ilias_and_webfolder_password"));
         $this->form->setFormAction($this->ctrl->getFormAction($this));
-        
+
         return $this->form;
     }
-    
+
     /**
      * Save password
      * @return
@@ -3259,7 +3259,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     protected function savePasswordObject()
     {
         $ilUser = $this->user;
-        
+
         $form = $this->initFormPasswordInstruction();
         if ($form->checkInput()) {
             $ilUser->resetPassword($this->form->getInput('new_password'), $this->form->getInput('new_password'));
@@ -3270,7 +3270,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $form->setValuesByPost();
         $this->showPasswordInstructionObject();
     }
-    
+
     /**
      * Redraw a list item (ajax)
      *
@@ -3280,12 +3280,12 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     public function redrawListItemObject()
     {
         $tpl = $this->tpl;
-        
+
         $html = null;
-        
+
         $item_data = $this->object->getSubItems(false, false, (int) $_GET["child_ref_id"]);
         $container_view = $this->getContentGUI();
-        
+
         // list item is session material (not part of "_all"-items - see below)
         include_once './Modules/Session/classes/class.ilEventItems.php';
         $event_items = ilEventItems::_getItemsOfContainer($this->object->getRefId());
@@ -3304,7 +3304,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 }
             }
         }
-            
+
         // "normal" list item
         if (!$html) {
             foreach ($this->object->items["_all"] as $id) {
@@ -3313,14 +3313,14 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 }
             }
         }
-        
+
         if ($html) {
             echo $html;
-            
+
             // we need to add onload code manually (rating, comments, etc.)
             echo $tpl->getOnLoadCodeForAsynch();
         }
-                        
+
         exit;
     }
 
@@ -3352,7 +3352,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     protected function fileManagerLaunchObject()
     {
         $ilUser = $this->user;
-        
+
         $tpl = new ilTemplate('tpl.fm_launch_ws.html', false, false, 'Services/WebServices/FileManager');
         $tpl->setVariable('JNLP_URL', ILIAS_HTTP_PATH . '/Services/WebServices/FileManager/lib/dist/FileManager.jnlp');
         $tpl->setVariable('SESSION_ID', $_COOKIE[session_name()] . '::' . CLIENT_ID);
@@ -3371,7 +3371,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         exit;
     }
     // begin-patch fm
-        
+
     /**
      * Show tree
      */
@@ -3381,7 +3381,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $ilUser = $this->user;
         $ilSetting = $this->settings;
         $ilCtrl = $this->ctrl;
-        
+
         // set current repository view mode
         if (!empty($_GET["set_mode"])) {
             $_SESSION["il_rep_mode"] = $_GET["set_mode"];
@@ -3401,7 +3401,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         if ($_SESSION["il_rep_mode"] == "") {
             $_SESSION["il_rep_mode"] = $ilSetting->get("default_repository_view");
         }
-        
+
         $mode = ($_SESSION["il_rep_mode"] != "")
             ? $_SESSION["il_rep_mode"]
             : "flat";
@@ -3504,10 +3504,10 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     {
         include_once('Services/Container/classes/class.ilContainerSortingSettings.php');
         include_once './Services/Container/classes/class.ilContainer.php';
-        
+
         $settings = new ilContainerSortingSettings($this->object->getId());
         $sort = new ilRadioGroupInputGUI($this->lng->txt('sorting_header'), "sorting");
-        
+
         if (in_array(ilContainer::SORT_INHERIT, $a_sorting_settings)) {
             $sort_inherit = new ilRadioOption();
             $sort_inherit->setTitle(
@@ -3528,7 +3528,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 ilContainer::SORT_TITLE
             );
             $sort_title->setInfo($this->lng->txt('sorting_info_title'));
-            
+
             $this->initSortingDirectionForm($settings, $sort_title, 'title');
             $sort->addOption($sort_title);
         }
@@ -3561,7 +3561,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             $sort->setValue(ilContainer::SORT_TITLE);
         }
         $form->addItem($sort);
-        
+
         return $form;
     }
 
@@ -3615,11 +3615,11 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         } else {
             $txt = $this->lng->txt('sorting_direction');
         }
-        
+
         $direction = new ilRadioGroupInputGUI($txt, $a_prefix . '_sorting_direction');
         $direction->setValue($sorting_settings->getSortDirection());
         $direction->setRequired(true);
-        
+
         // asc
         $asc = new ilRadioOption(
             $this->lng->txt('sorting_asc'),
@@ -3633,9 +3633,9 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             ilContainer::SORT_DIRECTION_DESC
         );
         $direction->addOption($desc);
-        
+
         $element->addSubItem($direction);
-        
+
         return $element;
     }
 
@@ -3722,7 +3722,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         include_once('Services/Container/classes/class.ilContainerSortingSettings.php');
         $settings = new ilContainerSortingSettings($this->object->getId());
         $settings->setSortMode($form->getInput("sorting"));
-        
+
         switch ($form->getInput('sorting')) {
             case ilContainer::SORT_TITLE:
                 $settings->setSortDirection($form->getInput('title_sorting_direction'));
@@ -3739,7 +3739,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 $settings->setSortDirection($form->getInput('manual_sorting_direction'));
                 break;
         }
-        
+
         $settings->update();
     }
 

--- a/Services/Database/classes/PDO/class.ilDBPdo.php
+++ b/Services/Database/classes/PDO/class.ilDBPdo.php
@@ -907,7 +907,7 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface
     public function addFulltextIndex($a_table, $a_fields, $a_name = "in")
     {
         $i_name = $this->constraintName($a_table, $a_name) . "_idx";
-        $f_str = implode($a_fields, ",");
+        $f_str = implode(",", $a_fields);
         $q = "ALTER TABLE $a_table ADD FULLTEXT $i_name ($f_str)";
         $this->query($q);
     }
@@ -1179,7 +1179,7 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface
             $field_values[$k] = $col[1];
         }
 
-        $q = "REPLACE INTO " . $table . " (" . implode($fields, ",") . ") VALUES (" . implode($placeholders, ",") . ")";
+        $q = "REPLACE INTO " . $table . " (" . implode(",", $fields) . ") VALUES (" . implode(",", $placeholders) . ")";
 
         $r = $this->manipulateF($q, $types, $values);
 

--- a/Services/Database/classes/PDO/class.ilDBPdoPostgreSQL.php
+++ b/Services/Database/classes/PDO/class.ilDBPdoPostgreSQL.php
@@ -178,7 +178,7 @@ class ilDBPdoPostgreSQL extends ilDBPdo implements ilDBInterface
         }
         //		if ($lobs)	// lobs -> use prepare execute (autoexecute broken in PEAR 2.4.1)
         //		{
-        $this->manipulate("DELETE FROM " . $a_table . " WHERE " . implode($delwhere, " AND "));
+        $this->manipulate("DELETE FROM " . $a_table . " WHERE " . implode(" AND ", $delwhere));
         $this->insert($a_table, $a_columns);
 
         return true;

--- a/Services/Database/classes/class.ilDBGenerator.php
+++ b/Services/Database/classes/class.ilDBGenerator.php
@@ -700,11 +700,11 @@ class ilDBGenerator
                 $values[] = "'" . str_replace("'", "\'", $v) . "'";
                 $i_str[] = "'" . $f . "' => array('" . $this->fields[$f]["type"] . "', '" . str_replace("'", "\'", $v) . "')";
             }
-            $fields_str = "(" . implode($fields, ",") . ")";
-            $types_str = "array(" . implode($types, ",") . ")";
-            $values_str = "array(" . implode($values, ",") . ")";
+            $fields_str = "(" . implode(",", $fields) . ")";
+            $types_str = "array(" . implode(",", $types) . ")";
+            $values_str = "array(" . implode(",", $values) . ")";
             $ins_st = "\n" . '$ilDB->insert("' . $a_table . '", array(' . "\n";
-            $ins_st .= implode($i_str, ", ") . "));\n";
+            $ins_st .= implode(", ", $i_str) . "));\n";
             //$ins_st.= "\t".$fields_str."\n";
             //$ins_st.= "\t".'VALUES '."(%s".str_repeat(",%s", count($fields) - 1).')"'.",\n";
             //$ins_st.= "\t".$types_str.','.$values_str.');'."\n";
@@ -778,7 +778,7 @@ class ilDBGenerator
                 }
                 $a_tpl->setCurrentBlock("index");
                 $a_tpl->setVariable("VAL_INDEX", $def["name"]);
-                $a_tpl->setVariable("VAL_FIELDS", implode($f2, ", "));
+                $a_tpl->setVariable("VAL_FIELDS", implode(", ", $f2));
                 $a_tpl->parseCurrentBlock();
                 $indices_output = true;
             }
@@ -797,7 +797,7 @@ class ilDBGenerator
                 $a_tpl->setCurrentBlock("constraint");
                 $a_tpl->setVariable("VAL_CONSTRAINT", $def["name"]);
                 $a_tpl->setVariable("VAL_CTYPE", $def["type"]);
-                $a_tpl->setVariable("VAL_CFIELDS", implode($f2, ", "));
+                $a_tpl->setVariable("VAL_CFIELDS", implode(", ", $f2));
                 $a_tpl->parseCurrentBlock();
                 $constraints_output = true;
             }

--- a/Services/FileSystem/classes/class.ilFileSystemTableGUI.php
+++ b/Services/FileSystem/classes/class.ilFileSystemTableGUI.php
@@ -15,7 +15,7 @@ class ilFileSystemTableGUI extends ilTable2GUI
 {
     protected $has_multi; // [bool]
     protected $row_commands = array();
-    
+
     /**
     * Constructor
     */
@@ -45,10 +45,10 @@ class ilFileSystemTableGUI extends ilTable2GUI
         $this->file_labels = $a_file_labels;
         $this->post_dir_path = $a_post_dir_path;
         $this->lng = $lng;
-        
+
         parent::__construct($a_parent_obj, $a_parent_cmd);
         $this->setTitle($lng->txt("cont_files") . " " . $this->cur_subdir);
-        
+
         $this->has_multi = false;
         for ($i = 0; $i < count($a_commands); $i++) {
             if (!$a_commands[$i]["single"]) {
@@ -68,7 +68,7 @@ class ilFileSystemTableGUI extends ilTable2GUI
 
         $this->setDefaultOrderField("name");
         $this->setDefaultOrderDirection("asc");
-        
+
         $this->setEnableHeader(true);
         $this->setFormAction($ilCtrl->getFormAction($a_parent_obj));
         $this->setRowTemplate(
@@ -77,7 +77,7 @@ class ilFileSystemTableGUI extends ilTable2GUI
         );
         $this->setEnableTitle(true);
     }
-    
+
     public function numericOrdering($a_field)
     {
         if ($a_field == "size") {
@@ -94,8 +94,8 @@ class ilFileSystemTableGUI extends ilTable2GUI
         $this->determineOffsetAndOrder(true);
         $this->setData($this->getEntries());
     }
-    
-    
+
+
     /**
     * Get entries
     */
@@ -115,10 +115,10 @@ class ilFileSystemTableGUI extends ilTable2GUI
             $cfile = (!empty($this->cur_subdir))
                 ? $this->cur_subdir . "/" . $e["entry"]
                 : $e["entry"];
-                
+
             if ($this->label_enable) {
                 $label = (is_array($this->file_labels[$cfile]))
-                    ? implode($this->file_labels[$cfile], ", ")
+                    ? implode(", ", $this->file_labels[$cfile])
                     : "";
             }
 
@@ -169,7 +169,7 @@ class ilFileSystemTableGUI extends ilTable2GUI
     {
         global $DIC;
         $ilCtrl = $DIC['ilCtrl'];
-        
+
         $hash = $this->post_dir_path
             ? md5($a_set["file"])
             : md5($a_set["entry"]);
@@ -188,7 +188,7 @@ class ilFileSystemTableGUI extends ilTable2GUI
             $this->tpl->setVariable("TXT_LABEL", $a_set["label"]);
             $this->tpl->parseCurrentBlock();
         }
-        
+
         $ilCtrl->setParameter($this->parent_obj, "cdir", $this->cur_subdir);
 
         //$this->tpl->setVariable("ICON", $obj["title"]);
@@ -212,7 +212,7 @@ class ilFileSystemTableGUI extends ilTable2GUI
             $this->tpl->setVariable("TXT_FILENAME2", $a_set["entry"]);
             $this->tpl->parseCurrentBlock();
         }
-        
+
         if ($a_set["type"] != "dir") {
             $this->tpl->setVariable("TXT_SIZE", ilUtil::formatSize($a_set["size"]));
         }

--- a/Services/InfoScreen/classes/class.ilInfoScreenGUI.php
+++ b/Services/InfoScreen/classes/class.ilInfoScreenGUI.php
@@ -124,12 +124,12 @@ class ilInfoScreenGUI
         $rbacsystem = $this->rbacsystem;
         $tpl = $this->tpl;
         $ilAccess = $this->access;
-        
+
         $next_class = $this->ctrl->getNextClass($this);
 
         $cmd = $this->ctrl->getCmd("showSummary");
         $this->ctrl->setReturn($this, "showSummary");
-        
+
         $this->setTabs();
 
         switch ($next_class) {
@@ -148,13 +148,13 @@ class ilInfoScreenGUI
                 $html = $this->ctrl->forwardCommand($user_profile);
                 $tpl->setContent($html);
                 break;
-            
+
             case "ilcommonactiondispatchergui":
                 include_once("Services/Object/classes/class.ilCommonActionDispatcherGUI.php");
                 $gui = ilCommonActionDispatcherGUI::getInstanceFromAjaxCall();
                 $this->ctrl->forwardCommand($gui);
                 break;
-                
+
             default:
                 return $this->$cmd();
                 break;
@@ -171,7 +171,7 @@ class ilInfoScreenGUI
     {
         $this->table_class = $a_val;
     }
-    
+
     /**
      * Get table class
      *
@@ -181,7 +181,7 @@ class ilInfoScreenGUI
     {
         return $this->table_class;
     }
-    
+
     /**
     * enable notes
     */
@@ -234,7 +234,7 @@ class ilInfoScreenGUI
     {
         $this->block_property[$a_block_type][$a_property] = $a_value;
     }
-    
+
     public function getAllBlockProperties()
     {
         return $this->block_property;
@@ -382,7 +382,7 @@ class ilInfoScreenGUI
                     $langs[] = $lng->txt("meta_l_" . $md_lan->getLanguageCode());
                 }
             }
-            $langs = implode($langs, ", ");
+            $langs = implode(", ", $langs);
 
             // keywords
             $keywords = array();
@@ -390,7 +390,7 @@ class ilInfoScreenGUI
                 $md_key = $md_gen->getKeyword($id);
                 $keywords[] = $md_key->getKeyword();
             }
-            $keywords = implode($keywords, ", ");
+            $keywords = implode(", ", $keywords);
         }
 
         // authors
@@ -483,13 +483,13 @@ class ilInfoScreenGUI
 
         $this->addSection($lng->txt("additional_info"));
         $a_obj = $this->gui_object->object;
-                
+
         // links to the object
         if (is_object($a_obj)) {
             // permanent link
             $type = $a_obj->getType();
             $ref_id = $a_obj->getRefId();
-            
+
             if ($ref_id) {
                 include_once 'Services/WebServices/ECS/classes/class.ilECSServerSettings.php';
                 if (ilECSServerSettings::getInstance()->activeServerExists()) {
@@ -508,7 +508,7 @@ class ilInfoScreenGUI
                     $pm->getHTML(),
                     ""
                 );
-            
+
                 // bookmarks
 
                 // links to resource
@@ -539,8 +539,8 @@ class ilInfoScreenGUI
                 }
             }
         }
-                
-                
+
+
         // creation date
         $this->addProperty(
             $lng->txt("create_date"),
@@ -551,7 +551,7 @@ class ilInfoScreenGUI
         if ($ilUser->getId() != ANONYMOUS_USER_ID and $a_obj->getOwner()) {
             include_once './Services/Object/classes/class.ilObjectFactory.php';
             include_once './Services/User/classes/class.ilObjUser.php';
-            
+
             if (ilObjUser::userExists(array($a_obj->getOwner()))) {
                 $ownerObj = ilObjectFactory::getInstanceByObjId($a_obj->getOwner(), false);
             } else {
@@ -652,7 +652,7 @@ class ilInfoScreenGUI
     public function getCenterColumnHTML()
     {
         $ilCtrl = $this->ctrl;
-        
+
         include_once("Services/Block/classes/class.ilColumnGUI.php");
         $column_gui = new ilColumnGUI("info", IL_COL_CENTER);
         $this->setColumnSettings($column_gui);
@@ -675,7 +675,7 @@ class ilInfoScreenGUI
                 $html = $this->getHTML();
             }
         }
-        
+
         return $html;
     }
 
@@ -687,7 +687,7 @@ class ilInfoScreenGUI
         $ilUser = $this->user;
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-        
+
         include_once("Services/Block/classes/class.ilColumnGUI.php");
         $column_gui = new ilColumnGUI("info", IL_COL_RIGHT);
         $this->setColumnSettings($column_gui);
@@ -719,7 +719,7 @@ class ilInfoScreenGUI
         $column_gui->setRepositoryMode(true);
         $column_gui->setAllBlockProperties($this->getAllBlockProperties());
     }
-    
+
     public function setOpenFormTag($a_val)
     {
         $this->open_form_tag = $a_val;
@@ -741,14 +741,14 @@ class ilInfoScreenGUI
         $ilAccess = $this->access;
         $ilCtrl = $this->ctrl;
         $ilUser = $this->user;
-        
+
         $tpl = new ilTemplate("tpl.infoscreen.html", true, true, "Services/InfoScreen");
 
         // other class handles form action (@todo: this is not implemented/tested)
         if ($this->form_action == "") {
             $this->setFormAction($ilCtrl->getFormAction($this));
         }
-        
+
         require_once 'Services/jQuery/classes/class.iljQueryUtil.php';
         iljQueryUtil::initjQuery();
 
@@ -758,10 +758,10 @@ class ilInfoScreenGUI
                 $this->addButton($lng->txt("show_hidden_sections"), "JavaScript:toggleSections(this, '" . $lng->txt("show_hidden_sections") . "', '" . $lng->txt("hide_visible_sections") . "');");
             }
         }
-        
-        
+
+
         // DEPRECATED - use ilToolbarGUI
-        
+
         // add top buttons
         if (count($this->top_buttons) > 0) {
             $tpl->addBlockfile("TOP_BUTTONS", "top_buttons", "tpl.buttons.html");
@@ -799,7 +799,7 @@ class ilInfoScreenGUI
                 $tpl->setVariable("FORMACTION", $this->form_action);
                 $tpl->parseCurrentBlock();
             }
-            
+
             if ($this->close_form_tag) {
                 $tpl->touchBlock("formbottom");
             }
@@ -962,7 +962,7 @@ class ilInfoScreenGUI
         if (!ilObjUserTracking::_enabledLearningProgress()) {
             return false;
         }
-            
+
         include_once './Services/Object/classes/class.ilObjectLP.php';
         $olp = ilObjectLP::getInstance($this->getContextObjId());
         if ($olp->getCurrentMode() != ilLPObjSettings::LP_MODE_MANUAL) {
@@ -1058,7 +1058,7 @@ class ilInfoScreenGUI
                 // $a_tpl->touchBlock("row");
             }
         }
-        
+
         // #10493
         $a_tpl->touchBlock("row");
     }
@@ -1092,7 +1092,7 @@ class ilInfoScreenGUI
     {
         $ilAccess = $this->access;
         $ilSetting = $this->settings;
-        
+
         $next_class = $this->ctrl->getNextClass($this);
         include_once("Services/Notes/classes/class.ilNoteGUI.php");
         $notes_gui = new ilNoteGUI(
@@ -1100,18 +1100,18 @@ class ilInfoScreenGUI
             0,
             $this->gui_object->object->getType()
         );
-        
+
         // global switch
         if ($ilSetting->get("disable_comments")) {
             $notes_gui->enablePublicNotes(false);
         } else {
             $ref_id = $this->gui_object->object->getRefId();
             $has_write = $ilAccess->checkAccess("write", "", $ref_id);
-            
+
             if ($has_write && $ilSetting->get("comments_del_tutor", 1)) {
                 $notes_gui->enablePublicNotesDeletion(true);
             }
-            
+
             /* should probably be discussed further
             for now this will only work properly with comments settings
             (see ilNoteGUI constructor)
@@ -1195,7 +1195,7 @@ class ilInfoScreenGUI
         );
     }
 
-    
+
     /**
     * Add tagging
     */
@@ -1203,7 +1203,7 @@ class ilInfoScreenGUI
     {
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-        
+
         $lng->loadLanguageModule("tagging");
         $tags_set = new ilSetting("tags");
 
@@ -1213,22 +1213,22 @@ class ilInfoScreenGUI
             $this->gui_object->object->getId(),
             $this->gui_object->object->getType()
         );
-        
+
         $this->addSection($lng->txt("tagging_tags"));
-        
+
         if ($tags_set->get("enable_all_users")) {
             $this->addProperty(
                 $lng->txt("tagging_all_users"),
                 $tagging_gui->getAllUserTagsForObjectHTML()
             );
         }
-        
+
         $this->addProperty(
             $lng->txt("tagging_my_tags"),
             $tagging_gui->getTaggingInputHTML()
         );
     }
-    
+
     public function saveTags()
     {
         include_once("Services/Tagging/classes/class.ilTaggingGUI.php");
@@ -1238,10 +1238,10 @@ class ilInfoScreenGUI
             $this->gui_object->object->getType()
         );
         $tagging_gui->saveInput();
-        
+
         ilUtil::sendSuccess($this->lng->txt('msg_obj_modified'), true);
         $this->ctrl->redirect($this, ""); // #14993
-        
+
         // return $this->showSummary();
     }
 
@@ -1254,7 +1254,7 @@ class ilInfoScreenGUI
     public function getHiddenToggleButton()
     {
         $lng = $this->lng;
-        
+
         return "<a onClick=\"toggleSections(this, '" . $lng->txt("show_hidden_sections") . "', '" . $lng->txt("hide_visible_sections") . "'); return false;\" href=\"#\">" . $lng->txt("show_hidden_sections") . "</a>";
     }
 

--- a/Services/MediaObjects/classes/class.ilMediaItem.php
+++ b/Services/MediaObjects/classes/class.ilMediaItem.php
@@ -126,7 +126,7 @@ class ilMediaItem
     {
         $this->text_representation = $a_val;
     }
-    
+
     /**
      * Get text representation
      *
@@ -136,7 +136,7 @@ class ilMediaItem
     {
         return $this->text_representation;
     }
-    
+
     /**
      * Set upload hash
      *
@@ -185,7 +185,7 @@ class ilMediaItem
             $ilDB->quote($this->getUploadHash(), "text") .
             ")";
         $ilDB->manipulate($query);
-        
+
         $this->setId($item_id);
 
         // create mob parameters
@@ -317,18 +317,18 @@ class ilMediaItem
             }
         }
     }
-    
+
     /**
     * write thumbnail creation try data ("y"/"n")
     */
     public function writeThumbTried($a_tried)
     {
         $ilDB = $this->db;
-        
+
         $q = "UPDATE media_item SET tried_thumb = " .
             $ilDB->quote($a_tried, "text") .
             " WHERE id = " . $ilDB->quote($this->getId(), "integer");
-            
+
         $ilDB->manipulate($q);
     }
 
@@ -343,7 +343,7 @@ class ilMediaItem
         global $DIC;
 
         $ilDB = $DIC->database();
-        
+
         // read media_object record
         $query = "SELECT * FROM media_item WHERE mob_id = " .
             $ilDB->quote($a_mob_id, "integer") . " " .
@@ -366,7 +366,7 @@ class ilMediaItem
         global $DIC;
 
         $ilDB = $DIC->database();
-        
+
         // read media_object record
         $query = "SELECT * FROM media_item WHERE id = " .
             $ilDB->quote($a_med_id, "integer");
@@ -389,19 +389,19 @@ class ilMediaItem
         global $DIC;
 
         $ilDB = $DIC->database();
-        
+
         // read media_object record
         $query = "SELECT * FROM media_item WHERE mob_id = " .
             $ilDB->quote($a_mobId, "integer") . " " .
             "AND purpose=" . $ilDB->quote($a_purpose, "text") . " ORDER BY nr";
         $item_set = $ilDB->query($query);
-        
+
         while ($item_rec = $ilDB->fetchAssoc($item_set)) {
             return $item_rec;
         }
         return false;
     }
-    
+
     /**
     * read media items into media objects (static)
     *
@@ -412,7 +412,7 @@ class ilMediaItem
         global $DIC;
 
         $ilDB = $DIC->database();
-        
+
         // read media_object record
         $query = "SELECT * FROM media_item WHERE mob_id = " .
             $ilDB->quote($a_mob->getId(), "integer") . " " .
@@ -465,7 +465,7 @@ class ilMediaItem
         global $DIC;
 
         $ilDB = $DIC->database();
-        
+
         // iterate all media items ob mob
         $query = "SELECT * FROM media_item WHERE mob_id = " .
             $ilDB->quote($a_mob_id, "integer");
@@ -806,7 +806,7 @@ class ilMediaItem
         $o_file = $file_arr[count($file_arr) - 1];
         $file_arr = explode(".", $o_file);
         unset($file_arr[count($file_arr) - 1]);
-        $file = implode($file_arr, ".");
+        $file = implode(".", $file_arr);
 
         if (!$a_reference_copy) {
             return $this->getWorkDirectory() . "/" . $file . "." . $this->getMapWorkCopyType();
@@ -918,7 +918,7 @@ class ilMediaItem
                 @fclose($lcopy);
                 @fclose($handle);
             }
-            
+
             // now, create working copy
             ilUtil::convertImage(
                 $this->getMapWorkCopyName(true),
@@ -934,7 +934,7 @@ class ilMediaItem
         }
         return true;
     }
-    
+
     /**
     * make map work copy of image
     *
@@ -944,12 +944,12 @@ class ilMediaItem
     public function makeMapWorkCopy($a_area_nr = 0, $a_exclude = false)
     {
         $lng = $this->lng;
-        
+
         if (!$this->copyOriginal()) {
             return false;
         }
         $this->buildMapWorkImage();
-        
+
         // determine ratios
         $size = @getimagesize($this->getMapWorkCopyName());
         $x_ratio = 1;
@@ -980,7 +980,7 @@ class ilMediaItem
         }
 
         $this->saveMapWorkImage();
-        
+
         return true;
     }
 
@@ -1113,7 +1113,7 @@ class ilMediaItem
         // build xml of map areas
         for ($i = 0; $i < count($this->mapareas); $i++) {
             $area = $this->mapareas[$i];
-            
+
             // highlight mode
             $hm = "";
             if ($area->getHighlightMode() != "") {
@@ -1123,7 +1123,7 @@ class ilMediaItem
                     : "Accented";
                 $hm .= 'HighlightClass="' . $hcl . '" ';
             }
-            
+
             $xml .= "<MapArea Shape=\"" . $area->getShape() . "\" Coords=\"" . $area->getCoords() . "\" " . $hm . ">";
             if ($area->getLinkType() == IL_INT_LINK) {
                 $target_frame = $area->getTargetFrame();
@@ -1135,7 +1135,7 @@ class ilMediaItem
                 $tf_str = ($target_frame == "")
                     ? ""
                     : "TargetFrame=\"" . $target_frame . "\"";
-                
+
                 $xml .= "<IntLink Target=\"" . $area->getTarget($a_insert_inst, $a_inst) . "\" Type=\"" .
                     $area->getType() . "\" $tf_str>";
                 // see bug 17893 and http://stackoverflow.com/questions/4026502/xml-error-at-ampersand
@@ -1163,7 +1163,7 @@ class ilMediaItem
         global $DIC;
 
         $ilDB = $DIC->database();
-        
+
         //echo "mediaItems::resolve<br>";
         // read media_object record
         $query = "SELECT * FROM media_item WHERE mob_id = " .
@@ -1185,7 +1185,7 @@ class ilMediaItem
         global $DIC;
 
         $ilDB = $DIC->database();
-        
+
         // read media_items records
         $query = "SELECT * FROM media_item WHERE mob_id = " .
             $ilDB->quote($a_mob_id, "integer") . " ORDER BY nr";

--- a/Services/MediaObjects/classes/class.ilObjMediaObjectGUI.php
+++ b/Services/MediaObjects/classes/class.ilObjMediaObjectGUI.php
@@ -89,7 +89,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
         $this->lng = $lng;
         $this->back_title = "";
         $this->type = "mob";
-        
+
         $lng->loadLanguageModule("mob");
     }
 
@@ -148,7 +148,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
     {
         return $this->enabledmapareas;
     }
-    
+
     /**
     * Set width preset
     *
@@ -158,7 +158,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
     {
         $this->width_preset = $a_val;
     }
-    
+
     /**
     * Get width preset
     *
@@ -178,7 +178,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
     {
         $this->height_preset = $a_val;
     }
-    
+
     /**
     * Get height preset
     *
@@ -210,7 +210,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
     {
         $this->ctrl->returnToParent($this);
     }
-    
+
 
     /**
      * Execute current command
@@ -222,7 +222,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
         $tpl = $this->tpl;
         $ilAccess = $this->access;
         $ilErr = $this->error;
-        
+
         $next_class = $this->ctrl->getNextClass($this);
         $cmd = $this->ctrl->getCmd();
 
@@ -240,7 +240,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
 
                 $this->ctrl->forwardCommand($md_gui);
                 break;
-                
+
             case "ilimagemapeditorgui":
                 require_once("./Services/MediaObjects/classes/class.ilImageMapEditorGUI.php");
                 $image_map_edit = new ilImageMapEditorGUI($this->object);
@@ -248,7 +248,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
                 $tpl->setContent($ret);
                 $this->checkFixSize();
                 break;
-                
+
             case "ilfilesystemgui":
                 include_once("./Services/FileSystem/classes/class.ilFileSystemGUI.php");
                 $fs_gui = new ilFileSystemGUI(ilUtil::getWebspaceDir() . "/mobs/mm_" . $this->object->getId());
@@ -297,7 +297,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
     {
         $this->back_title = $a_title;
     }
-    
+
     /**
     * create new media object form
     */
@@ -305,7 +305,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
     {
         $tpl = $this->tpl;
         $ilHelp = $this->help;
-        
+
         $ilHelp->setScreenId("create");
         $this->initForm();
         $tpl->setContent($this->form_gui->getHTML());
@@ -318,15 +318,15 @@ class ilObjMediaObjectGUI extends ilObjectGUI
     {
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-        
+
         include_once("Services/Form/classes/class.ilPropertyFormGUI.php");
-        
+
         if ($a_mode == "edit") {
             $std_item = $this->object->getMediaItem("Standard");
         }
 
         $this->form_gui = new ilPropertyFormGUI();
-        
+
         // standard view resource
         $title = new ilTextInputGUI($lng->txt("title"), "standard_title");
         $title->setSize(40);
@@ -351,14 +351,14 @@ class ilObjMediaObjectGUI extends ilObjectGUI
         $radio_prop->addOption($op2);
         $radio_prop->setValue("File");
         $this->form_gui->addItem($radio_prop);
-        
+
         // standard format
         if ($a_mode == "edit") {
             $format = new ilNonEditableValueGUI($lng->txt("cont_format"), "standard_format");
             $format->setValue($std_item->getFormat());
             $this->form_gui->addItem($format);
         }
-        
+
         // standard size
         $radio_size = new ilRadioGroupInputGUI($lng->txt("size"), "standard_size");
         if ($a_mode == "edit") {
@@ -374,14 +374,14 @@ class ilObjMediaObjectGUI extends ilObjectGUI
             $op2 = new ilRadioOption($lng->txt("cont_adjust_size"), "selected");
         }
         $radio_size->addOption($op1);
-        
+
         // width height
         include_once("./Services/MediaObjects/classes/class.ilWidthHeightInputGUI.php");
         $width_height = new ilWidthHeightInputGUI($lng->txt("cont_width") .
                 " / " . $lng->txt("cont_height"), "standard_width_height");
         $width_height->setConstrainProportions(true);
         $op2->addSubItem($width_height);
-            
+
         // resize image
         if ($a_mode == "edit") {
             $std_item = $this->object->getMediaItem("Standard");
@@ -391,7 +391,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
                 $op2->addSubItem($resize);
             }
         }
-            
+
         $radio_size->setValue("original");
         if ($a_mode == "create" && ($this->getHeightPreset() > 0 || $this->getWidthPreset() > 0)) {
             $radio_size->setValue("selected");
@@ -400,7 +400,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
         }
         $radio_size->addOption($op2);
         $this->form_gui->addItem($radio_size);
-        
+
         // standard caption
         $caption = new ilTextAreaInputGUI($lng->txt("cont_caption"), "standard_caption");
         $caption->setCols(30);
@@ -411,7 +411,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
         $caption->setSize(40);
         $caption->setMaxLength(200);
         $this->form_gui->addItem($caption);*/
-        
+
         // text representation (alt text)
         if ($a_mode == "edit" && is_int(strpos($std_item->getFormat(), "image"))) {
             $ta = new ilTextAreaInputGUI($lng->txt("text_repr"), "text_representation");
@@ -441,12 +441,12 @@ class ilObjMediaObjectGUI extends ilObjectGUI
         if ($a_mode == "edit") {
             $full_item = $this->object->getMediaItem("Fullscreen");
         }
-        
+
         // fullscreen view resource
         $fs_sec = new ilFormSectionHeaderGUI();
         $fs_sec->setTitle($lng->txt("cont_fullscreen"));
         $this->form_gui->addItem($fs_sec);
-        
+
         $radio_prop2 = new ilRadioGroupInputGUI($lng->txt("cont_resource"), "full_type");
         $op1 = new ilRadioOption($lng->txt("cont_none"), "None");
         $radio_prop2->addOption($op1);
@@ -479,7 +479,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
                 $this->form_gui->addItem($format);
             }
         }
-        
+
         // fullscreen size
         $radio_size = new ilRadioGroupInputGUI($lng->txt("size"), "full_size");
         if ($a_mode == "edit") {
@@ -496,13 +496,13 @@ class ilObjMediaObjectGUI extends ilObjectGUI
             $op2 = new ilRadioOption($lng->txt("cont_adjust_size"), "selected");
         }
         $radio_size->addOption($op1);
-        
+
         // width/height
         $width_height = new ilWidthHeightInputGUI($lng->txt("cont_width") .
                 " / " . $lng->txt("cont_height"), "full_width_height");
         $width_height->setConstrainProportions(true);
         $op2->addSubItem($width_height);
-            
+
         // resize image
         if ($a_mode == "edit") {
             $full_item = $this->object->getMediaItem("Fullscreen");
@@ -520,7 +520,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
         $radio_size->setValue("original");
         $radio_size->addOption($op2);
         $this->form_gui->addItem($radio_size);
-        
+
         // fullscreen caption
         $caption = new ilTextAreaInputGUI($lng->txt("cont_caption"), "full_caption");
         $caption->setCols(30);
@@ -531,7 +531,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
         $caption->setSize(40);
         $caption->setMaxLength(200);
         $this->form_gui->addItem($caption);*/
-        
+
         // text representation (alt text)
         if ($a_mode == "edit" && $this->object->hasFullscreenItem() && is_int(strpos($std_item->getFormat(), "image"))) {
             $ta = new ilTextAreaInputGUI($lng->txt("text_repr"), "full_text_representation");
@@ -541,7 +541,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
             $this->form_gui->addItem($ta);
         }
 
-        
+
         // fullscreen parameters
         if ($a_mode == "edit" && $this->object->hasFullscreenItem() &&
             !in_array($full_item->getFormat(), ilObjMediaObject::_getSimpleMimeTypes())) {
@@ -583,7 +583,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
         }
     }
 
-    
+
     /**
     * Get values for form
     *
@@ -591,9 +591,9 @@ class ilObjMediaObjectGUI extends ilObjectGUI
     public function getValues()
     {
         $values = array();
-        
+
         $values["standard_title"] = $this->object->getTitle();
-        
+
         $std_item = $this->object->getMediaItem("Standard");
         if ($std_item->getLocationType() == "LocalFile") {
             $values["standard_type"] = "File";
@@ -606,7 +606,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
         $values["standard_width_height"]["width"] = $std_item->getWidth();
         $values["standard_width_height"]["height"] = $std_item->getHeight();
         $values["standard_width_height"]["constr_prop"] = true;
-        
+
         $values["standard_size"] = "selected";
 
         $orig_size = $std_item->getOriginalSize();
@@ -629,7 +629,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
         } else {
             $values["standard_parameters"] = $std_item->getParameterString();
         }
-        
+
         $values["full_type"] = "None";
         $values["full_size"] = "original";
         if ($this->object->hasFullScreenItem()) {
@@ -647,7 +647,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
             $values["full_width_height"]["constr_prop"] = true;
 
             $values["full_size"] = "selected";
-    
+
             $orig_size = $full_item->getOriginalSize();
             if ($full_item->getWidth() == "" &&
                 $full_item->getHeight() == "") {
@@ -669,7 +669,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
             }
             $values["full_text_representation"] = $full_item->getTextRepresentation();
         }
-        
+
         $this->form_gui->setValuesByArray($values);
     }
 
@@ -693,7 +693,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
             return false;
         }
     }
-    
+
     /**
      * chechInputForm
      *
@@ -708,8 +708,8 @@ class ilObjMediaObjectGUI extends ilObjectGUI
         }
         return true;
     }
-    
-    
+
+
     /**
     * Set media object values from creation form
     */
@@ -822,7 +822,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
             } elseif ($_POST["full_type"] == "Standard" && $_POST["standard_type"] == "File") {
                 $location = $file_name;
             }
-            
+
             // resize file
             if ($_POST["full_type"] == "File" ||
                 ($_POST["full_type"] == "Standard" && $_POST["standard_type"] == "File")) {
@@ -836,13 +836,13 @@ class ilObjMediaObjectGUI extends ilObjectGUI
                         (boolean) $_POST["full_width_height"]["constr_prop"]
                     );
                 }
-    
+
                 $media_item2->setFormat($format);
                 $media_item2->setLocation($location);
                 $media_item2->setLocationType("LocalFile");
                 $type = "File";
             }
-            
+
             if ($_POST["full_type"] == "Reference") {
                 $format = $location = "";
                 if ($_POST["full_reference"] != "") {
@@ -850,7 +850,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
                     $location = ilUtil::stripSlashes($_POST["full_reference"]);
                 }
             }
-            
+
             if ($_POST["full_type"] == "Reference" ||
                 ($_POST["full_type"] == "Standard" && $_POST["standard_type"] == "Reference")) {
                 $media_item2->setFormat($format);
@@ -878,14 +878,14 @@ class ilObjMediaObjectGUI extends ilObjectGUI
                 $media_item2->setCaption(ilUtil::stripSlashes($_POST["full_caption"]));
             }
         }
-    
+
         ilObjMediaObject::renameExecutables($mob_dir);
         include_once("./Services/MediaObjects/classes/class.ilMediaSvgSanitizer.php");
         ilMediaSvgSanitizer::sanitizeDir($mob_dir);	// see #20339
         $a_mob->update();
     }
-    
-    
+
+
     /**
     * Cancel saving
     */
@@ -900,7 +900,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
     public function editObject()
     {
         $tpl = $this->tpl;
-        
+
         $this->setPropertiesSubTabs("general");
 
         $this->initForm("edit");
@@ -1001,12 +1001,12 @@ class ilObjMediaObjectGUI extends ilObjectGUI
     {
         $lng = $this->lng;
         $tpl = $this->tpl;
-        
+
         $this->initForm("edit");
         if ($this->form_gui->checkInput()) {
             $title = trim($_POST["standard_title"]);
             $this->object->setTitle($title);
-            
+
             $std_item = $this->object->getMediaItem("Standard");
             $location = $std_item->getLocation();
             $format = $std_item->getFormat();
@@ -1027,17 +1027,17 @@ class ilObjMediaObjectGUI extends ilObjectGUI
                         $file_name,
                         $file
                     );
-    
+
                     // get mime type
                     $format = ilObjMediaObject::getMimeType($file);
                     $location = $file_name;
-                    
+
                     $resize = true;
                 } elseif ($_POST["standard_resize"]) {
                     $file = $mob_dir . "/" . $location;
                     $resize = true;
                 }
-                
+
                 // resize
                 if ($resize) {
                     if ($_POST["standard_size"] != "original" &&
@@ -1052,7 +1052,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
                     $std_item->setFormat($format);
                     $std_item->setLocation($location);
                 }
-                
+
                 $std_item->setLocationType("LocalFile");
             }
             $this->object->setDescription($format);
@@ -1075,10 +1075,10 @@ class ilObjMediaObjectGUI extends ilObjectGUI
 
             // set caption
             $std_item->setCaption(ilUtil::stripSlashes($_POST["standard_caption"]));
-            
+
             // text representation
             $std_item->setTextRepresentation(ilUtil::stripSlashes($_POST["text_representation"]));
-            
+
             // set parameters
             if (!in_array($std_item->getFormat(), ilObjMediaObject::_getSimpleMimeTypes())) {
                 if (ilObjMediaObject::_useAutoStartParameterOnly(
@@ -1094,7 +1094,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
                     $std_item->setParameters(ilUtil::stripSlashes(utf8_decode($_POST["standard_parameters"])));
                 }
             }
-    
+
             // "None" selected
             if ($_POST["full_type"] == "None") {
                 if ($this->object->hasFullscreenItem()) {		// delete existing
@@ -1128,16 +1128,16 @@ class ilObjMediaObjectGUI extends ilObjectGUI
                             $full_file_name,
                             $file
                         );
-    
+
                         $format = ilObjMediaObject::getMimeType($file);
                         $location = $full_file_name;
-                        
+
                         $resize = true;
                     } elseif ($_POST["full_resize"]) {
                         $file = $mob_dir . "/" . $location;
                         $resize = true;
                     }
-                    
+
                     // resize
                     if ($resize) {
                         if ($_POST["full_size"] != "original" &&
@@ -1180,7 +1180,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
                         );
                     }
                 }
-                
+
                 // determine width and height of known image types
                 $wh = ilObjMediaObject::_determineWidthHeight(
                     $format,
@@ -1199,13 +1199,13 @@ class ilObjMediaObjectGUI extends ilObjectGUI
                 $full_item->setWidth($wh["width"]);
                 $full_item->setHeight($wh["height"]);
                 $full_item->setLocation($location);
-                
+
                 $full_item->setCaption(ilUtil::stripSlashes($_POST["full_caption"]));
-                
+
                 // text representation
                 $full_item->setTextRepresentation(ilUtil::stripSlashes($_POST["full_text_representation"]));
 
-                
+
                 // set parameters
                 if (!in_array($std_item->getFormat(), ilObjMediaObject::_getSimpleMimeTypes())) {
                     if (ilObjMediaObject::_useAutoStartParameterOnly(
@@ -1389,7 +1389,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
                         $purpose[] = $this->lng->txt("cont_fullscreen");
                     }
                 }
-                $this->tpl->setVariable("TXT_PURPOSE", implode($purpose, ", "));
+                $this->tpl->setVariable("TXT_PURPOSE", implode(", ", $purpose));
 
                 $this->tpl->parseCurrentBlock();
             }
@@ -1637,8 +1637,8 @@ class ilObjMediaObjectGUI extends ilObjectGUI
     {
         $this->showUsagesObject(true);
     }
-    
-    
+
+
     /**
      * show all usages of mob
      */
@@ -1649,19 +1649,19 @@ class ilObjMediaObjectGUI extends ilObjectGUI
         $ilTabs = $this->tabs;
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-        
+
         $ilTabs->addSubTab(
             "current_usages",
             $lng->txt("cont_current_usages"),
             $ilCtrl->getLinkTarget($this, "showUsages")
         );
-        
+
         $ilTabs->addSubTab(
             "all_usages",
             $lng->txt("cont_all_usages"),
             $ilCtrl->getLinkTarget($this, "showAllUsages")
         );
-        
+
         if ($a_all) {
             $ilTabs->activateSubTab("all_usages");
             $cmd = "showAllUsages";
@@ -1785,7 +1785,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
         }
     }
 
-    
+
     /**
     * Get Tabs
     */
@@ -1794,7 +1794,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
         $ilHelp = $this->help;
 
         $ilHelp->setScreenIdComponent("mob");
-        
+
         if (is_object($this->object) && strtolower(get_class($this->object)) == "ilobjmediaobject"
             && $this->object->getId() > 0) {
             // object properties
@@ -1804,11 +1804,11 @@ class ilObjMediaObjectGUI extends ilObjectGUI
                 "edit",
                 get_class($this)
             );
-            
+
             $st_item = $this->object->getMediaItem("Standard");
 
             // link areas
-            
+
             if (is_object($st_item) && $this->getEnabledMapAreas()) {
                 $format = $st_item->getFormat();
                 if (substr($format, 0, 5) == "image" && !is_int(strpos($format, "svg"))) {
@@ -1843,7 +1843,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
                 //				$ilTabs->addTarget("cont_files",
                 //					$this->ctrl->getLinkTarget($this, "editFiles"), "editFiles",
                 //					get_class($this));
-                    
+
                 $this->tabs_gui->addTarget(
                     "cont_files",
                     $this->ctrl->getLinkTargetByClass(
@@ -1876,7 +1876,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
             );
         }
     }
-    
+
     /**
      * Show video tools
      *
@@ -1890,14 +1890,14 @@ class ilObjMediaObjectGUI extends ilObjectGUI
         include_once("./Services/MediaObjects/classes/class.ilFFmpeg.php");
 
         /*$codecs = ilFFmpeg::getSupportedCodecsInfo();
-        $codec_str = implode($codecs, "<br />");
+        $codec_str = implode("<br />", $codecs);
         $tpl->setContent($codec_str);*/
-        
+
         $formats = ilFFmpeg::getSupportedFormatsInfo();
-        $formats_str = implode($formats, "<br />");
+        $formats_str = implode("<br />", $formats);
         $tpl->setContent($formats_str);
     }
-    
+
 
     /**
      * Include media object presentation JS
@@ -1911,17 +1911,17 @@ class ilObjMediaObjectGUI extends ilObjectGUI
         if ($a_tpl == null) {
             $a_tpl = $tpl;
         }
-        
+
         include_once("./Services/jQuery/classes/class.iljQueryUtil.php");
         iljQueryUtil::initjQUery($a_tpl);
         include_once("./Services/jQuery/classes/class.iljQueryUtil.php");
         $a_tpl->addJavascript(iljQueryUtil::getLocalMaphilightPath());
         $a_tpl->addJavascript("./Services/COPage/js/ilCOPagePres.js");
-        
+
         include_once("./Services/MediaObjects/classes/class.ilPlayerUtil.php");
         ilPlayerUtil::initMediaElementJs($a_tpl);
     }
-    
+
     /**
      * Set subtabs for properties
      *
@@ -1934,13 +1934,13 @@ class ilObjMediaObjectGUI extends ilObjectGUI
         $lng = $this->lng;
 
         $ilTabs->activateTab("cont_mob_def_prop");
-        
+
         $ilTabs->addSubTab(
             "general",
             $lng->txt("mob_general"),
             $ilCtrl->getLinkTarget($this, "edit")
         );
-        
+
         if ($this->object->getMediaItem("Standard")->getFormat() == "video/webm" ||
             $this->object->getMediaItem("Standard")->getFormat() == "video/mp4") {
             $ilTabs->addSubTab(
@@ -1949,10 +1949,10 @@ class ilObjMediaObjectGUI extends ilObjectGUI
                 $ilCtrl->getLinkTarget($this, "listSubtitleFiles")
             );
         }
-        
+
         $ilTabs->activateSubTab($a_active);
     }
-    
+
     /**
      * List subtitls files
      *
@@ -1966,16 +1966,16 @@ class ilObjMediaObjectGUI extends ilObjectGUI
         $ilCtrl = $this->ctrl;
         $lng = $this->lng;
         $ilUser = $this->user;
-        
+
         $this->setPropertiesSubTabs("subtitles");
-        
+
         // upload file
         $ilToolbar->setFormAction($ilCtrl->getFormAction($this), true);
         include_once("./Services/Form/classes/class.ilFileInputGUI.php");
         $fi = new ilFileInputGUI($lng->txt("mob_subtitle_file") . " (.srt)", "subtitle_file");
         $fi->setSuffixes(array("srt"));
         $ilToolbar->addInputItem($fi, true);
-        
+
         // language
         include_once("./Services/Form/classes/class.ilSelectInputGUI.php");
         include_once("./Services/MetaData/classes/class.ilMDLanguageItem.php");
@@ -1989,13 +1989,13 @@ class ilObjMediaObjectGUI extends ilObjectGUI
 
         $ilToolbar->addSeparator();
         $ilToolbar->addFormButton($lng->txt("mob_upload_multi_srt"), "uploadMultipleSubtitleFileForm");
-        
+
         include_once("./Services/MediaObjects/classes/class.ilMobSubtitleTableGUI.php");
         $tab = new ilMobSubtitleTableGUI($this, "listSubtitleFiles", $this->object);
-            
+
         $tpl->setContent($tab->getHTML());
     }
-    
+
     /**
      * Upload srt file
      *
@@ -2006,13 +2006,13 @@ class ilObjMediaObjectGUI extends ilObjectGUI
     {
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-        
+
         if ($this->object->uploadSrtFile($_FILES["subtitle_file"]["tmp_name"], ilUtil::stripSlashes($_POST["language"]))) {
             ilUtil::sendSuccess($lng->txt("msg_obj_modified"), true);
         }
         $ilCtrl->redirect($this, "listSubtitleFiles");
     }
-    
+
     /**
      * Confirm srt file deletion
      */
@@ -2021,9 +2021,9 @@ class ilObjMediaObjectGUI extends ilObjectGUI
         $ilCtrl = $this->ctrl;
         $tpl = $this->tpl;
         $lng = $this->lng;
-            
+
         $lng->loadLanguageModule("meta");
-        
+
         if (!is_array($_POST["srt"]) || count($_POST["srt"]) == 0) {
             ilUtil::sendInfo($lng->txt("no_checkbox"), true);
             $ilCtrl->redirect($this, "listSubtitleFiles");
@@ -2034,15 +2034,15 @@ class ilObjMediaObjectGUI extends ilObjectGUI
             $cgui->setHeaderText($lng->txt("mob_really_delete_srt"));
             $cgui->setCancel($lng->txt("cancel"), "listSubtitleFiles");
             $cgui->setConfirm($lng->txt("delete"), "deleteSrtFiles");
-            
+
             foreach ($_POST["srt"] as $i) {
                 $cgui->addItem("srt[]", $i, "subtitle_" . $i . ".srt (" . $lng->txt("meta_l_" . $i) . ")");
             }
-            
+
             $tpl->setContent($cgui->getHTML());
         }
     }
-    
+
     /**
      * Delete srt files
      */
@@ -2050,7 +2050,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
     {
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-        
+
         foreach ($_POST["srt"] as $i) {
             if (strlen($i) == 2 && !is_int(strpos($i, "."))) {
                 $this->object->removeAdditionalFile("srt/subtitle_" . $i . ".srt");

--- a/Services/MetaData/classes/class.ilMDEditorGUI.php
+++ b/Services/MetaData/classes/class.ilMDEditorGUI.php
@@ -42,7 +42,7 @@ class ilMDEditorGUI
         $this->md_obj = new ilMD($a_rbac_id, $a_obj_id, $a_obj_type);
 
         $this->lng->loadLanguageModule('meta');
-        
+
         include_once('Services/MetaData/classes/class.ilMDSettings.php');
         $this->md_settings = ilMDSettings::_getInstance();
     }
@@ -65,7 +65,7 @@ class ilMDEditorGUI
                 $item = $this->getFilterItemByPostVar($_GET["postvar"]);
                 $form_prop_dispatch->setItem($item);
                 return $this->ctrl->forwardCommand($form_prop_dispatch);
-            
+
             default:
                 if (!$cmd) {
                     $cmd = "listSection";
@@ -86,7 +86,7 @@ class ilMDEditorGUI
         $xml_writer->startExport();
 
         $this->tpl->addBlockFile('ADM_CONTENT', 'adm_content', 'tpl.md_editor.html', 'Services/MetaData');
-        
+
         $this->__setTabs('meta_general');
 
         $this->tpl->setVariable("MD_CONTENT", htmlentities($xml_writer->getXML()));
@@ -108,7 +108,7 @@ class ilMDEditorGUI
         }
 
         $this->tpl->addBlockFile('ADM_CONTENT', 'adm_content', 'tpl.md_editor.html', 'Services/MetaData');
-        
+
         $this->__setTabs('meta_quickedit');
 
         $this->tpl->addBlockFile('MD_CONTENT', 'md_content', 'tpl.md_quick_edit_scorm.html', 'Services/MetaData');
@@ -127,7 +127,7 @@ class ilMDEditorGUI
         $first = true;
         foreach ($ids = $this->md_section->getLanguageIds() as $id) {
             $md_lan = $this->md_section->getLanguage($id);
-            
+
             if ($first) {
                 $this->tpl->setCurrentBlock("language_head");
                 $this->tpl->setVariable("ROWSPAN_LANG", count($ids));
@@ -209,7 +209,7 @@ class ilMDEditorGUI
             $keywords[$md_key->getKeywordLanguageCode()][]
                 = $md_key->getKeyword();
         }
-        
+
         foreach ($keywords as $lang => $keyword_set) {
             if ($first) {
                 $this->tpl->setCurrentBlock("keyword_head");
@@ -222,7 +222,7 @@ class ilMDEditorGUI
 
             $this->tpl->setCurrentBlock("keyword_loop");
             $this->tpl->setVariable("KEYWORD_LOOP_VAL", ilUtil::prepareFormOutput(
-                implode($keyword_set, ", ")
+                implode(", ", $keyword_set)
             ));
             $this->tpl->setVariable("LANG", $lang);
             $this->tpl->setVariable("KEYWORD_LOOP_VAL_LANGUAGE", $this->__showLanguageSelect(
@@ -244,7 +244,7 @@ class ilMDEditorGUI
                 $lang
             ));
         }
-        
+
         // Lifecycle...
         // experts
         $this->tpl->setVariable("TXT_EXPERTS", $lng->txt('meta_subjectmatterexpert'));
@@ -298,7 +298,7 @@ class ilMDEditorGUI
             }
             $this->tpl->setVariable("POC_VAL", ilUtil::prepareFormOutput($ent_str));
         }
-        
+
         $this->tpl->setVariable("TXT_STATUS", $this->lng->txt('meta_status'));
         if (!is_object($this->md_section = $this->md_obj->getLifecycle())) {
             $this->md_section = $this->md_obj->addLifecycle();
@@ -320,7 +320,7 @@ class ilMDEditorGUI
         $valid = true;
         if (is_object($this->md_section = $this->md_obj->getEducational())) {
             include_once 'Services/MetaData/classes/class.ilMDUtils.php';
-            
+
             if (!$tlt = ilMDUtils::_LOMDurationToArray($this->md_section->getTypicalLearningTime())) {
                 if (strlen($this->md_section->getTypicalLearningTime())) {
                     $tlt = array(0,0,0,0,0);
@@ -331,7 +331,7 @@ class ilMDEditorGUI
         $this->tpl->setVariable("TXT_MONTH", $this->lng->txt('md_months'));
         $this->tpl->setVariable("SEL_MONTHS", $this->__buildMonthsSelect($tlt[0]));
         $this->tpl->setVariable("SEL_DAYS", $this->__buildDaysSelect($tlt[1]));
-        
+
         $this->tpl->setVariable("TXT_DAYS", $this->lng->txt('md_days'));
         $this->tpl->setVariable("TXT_TIME", $this->lng->txt('md_time'));
 
@@ -353,11 +353,11 @@ class ilMDEditorGUI
             $this->tpl->setVariable("INFO_TLT_NOT_VALID", $this->lng->txt('meta_info_tlt_not_valid'));
             $this->tpl->parseCurrentBlock();
         }
-        
-    
+
+
         $this->tpl->setVariable("TXT_SAVE", $this->lng->txt('save'));
     }
-    
+
     public function listQuickEdit()
     {
         global $DIC;
@@ -368,7 +368,7 @@ class ilMDEditorGUI
             $this->md_section = $this->md_obj->addGeneral();
             $this->md_section->save();
         }
-        
+
         $this->__setTabs('meta_quickedit');
 
 
@@ -396,12 +396,12 @@ class ilMDEditorGUI
         $lng = $DIC['lng'];
         $ilCtrl = $DIC['ilCtrl'];
         $tree = $DIC['tree'];
-    
+
         include_once("Services/Form/classes/class.ilPropertyFormGUI.php");
         $this->form = new ilPropertyFormGUI();
         $this->form->setId('ilquickeditform');
         $this->form->setShowTopButtons(false);
-    
+
         // title
         $ti = new ilTextInputGUI($this->lng->txt("title"), "gen_title");
         $ti->setMaxLength(200);
@@ -411,11 +411,11 @@ class ilMDEditorGUI
         }
         $ti->setValue($this->md_section->getTitle());
         $this->form->addItem($ti);
-        
+
         // description(s)
         foreach ($ids = $this->md_section->getDescriptionIds() as $id) {
             $md_des = $this->md_section->getDescription($id);
-            
+
             $ta = new ilTextAreaInputGUI($this->lng->txt("meta_description"), "gen_description[" . $id . "][description]");
             $ta->setCols(50);
             $ta->setRows(4);
@@ -444,7 +444,7 @@ class ilMDEditorGUI
             $si->setOptions($options);
             $this->form->addItem($si);
         }
-        
+
         // keyword(s)
         $first = true;
         $keywords = array();
@@ -643,7 +643,7 @@ class ilMDEditorGUI
             $this->md_obj->getObjType(),
             $this->md_obj->getRBACId()
         );
-        
+
         $result = array();
         $cnt = 0;
         foreach ($res as $r) {
@@ -660,8 +660,8 @@ class ilMDEditorGUI
         echo ilJsonUtil::encode($result);
         exit;
     }
-    
-    
+
+
     /**
     * update quick edit properties
     */
@@ -707,14 +707,14 @@ class ilMDEditorGUI
                 $md_des->update();
             }
         }
-        
+
         // Keyword
         if (is_array($_POST["keywords"]["value"])) {
             include_once("./Services/MetaData/classes/class.ilMDKeyword.php");
             ilMDKeyword::updateKeywords($this->md_section, $_POST["keywords"]["value"]);
         }
         $this->callListeners('General');
-        
+
         // Copyright
         if ($_POST['copyright'] || $_POST['copyright_text']) {
             if (!is_object($this->md_section = $this->md_obj->getRights())) {
@@ -779,22 +779,22 @@ class ilMDEditorGUI
                 $this->md_section = $this->md_obj->addLifecycle();
                 $this->md_section->save();
             }
-            
+
             // determine all entered authors
             $auth_arr = explode($this->md_settings->getDelimiter(), $_POST["life_authors"]);
             for ($i = 0; $i < count($auth_arr); $i++) {
                 $auth_arr[$i] = trim($auth_arr[$i]);
             }
-            
+
             $md_con_author = "";
-            
+
             // update existing author entries (delete if not entered)
             foreach (($ids = $this->md_section->getContributeIds()) as $con_id) {
                 $md_con = $this->md_section->getContribute($con_id);
                 if ($md_con->getRole() == "Author") {
                     foreach ($ent_ids = $md_con->getEntityIds() as $ent_id) {
                         $md_ent = $md_con->getEntity($ent_id);
-                        
+
                         // entered author already exists
                         if (in_array($md_ent->getEntity(), $auth_arr)) {
                             unset($auth_arr[array_search($md_ent->getEntity(), $auth_arr)]);
@@ -805,7 +805,7 @@ class ilMDEditorGUI
                     $md_con_author = $md_con;
                 }
             }
-            
+
             // insert enterd, but not existing authors
             if (count($auth_arr) > 0) {
                 if (!is_object($md_con_author)) {
@@ -830,7 +830,7 @@ class ilMDEditorGUI
             }
         }
         $this->callListeners('Lifecycle');
-        
+
         // #18563
         /*
         if(!$_REQUEST["wsp_id"])
@@ -840,7 +840,7 @@ class ilMDEditorGUI
             $tax_gui = new ilTaxMDGUI($this->md_obj->getRBACId(),$this->md_obj->getObjId(),$this->md_obj->getObjType());
             $tax_gui->updateFromMDForm();
         }*/
-        
+
         // Redirect here to read new title and description
         // Otherwise ('Lifecycle' 'technical' ...) simply call listSection()
         ilUtil::sendSuccess($this->lng->txt("saved_successfully"), true);
@@ -869,16 +869,16 @@ class ilMDEditorGUI
                 for ($i = 0; $i < count($auth_arr); $i++) {
                     $auth_arr[$i] = trim($auth_arr[$i]);
                 }
-                
+
                 $md_con_author = "";
-                    
+
                 // update existing author entries (delete if not entered)
                 foreach (($ids = $sco_md_section->getContributeIds()) as $con_id) {
                     $md_con = $sco_md_section->getContribute($con_id);
                     if ($md_con->getRole() == $type) {
                         foreach ($ent_ids = $md_con->getEntityIds() as $ent_id) {
                             $md_ent = $md_con->getEntity($ent_id);
-    
+
                             // entered author already exists
                             if (in_array($md_ent->getEntity(), $auth_arr)) {
                                 unset($auth_arr[array_search($md_ent->getEntity(), $auth_arr)]);
@@ -889,7 +889,7 @@ class ilMDEditorGUI
                         $md_con_author = $md_con;
                     }
                 }
-                
+
                 // insert enterd, but not existing authors
                 if (count($auth_arr) > 0) {
                     if (!is_object($md_con_author)) {
@@ -917,7 +917,7 @@ class ilMDEditorGUI
         }
         $this->updateQuickEdit_scorm();
     }
-    
+
     public function updateQuickEdit_scorm_prop_expert()
     {
         $this->updateQuickEdit_scorm_propagate("life_experts", "SubjectMatterExpert");
@@ -966,8 +966,8 @@ class ilMDEditorGUI
                 $md_des->update();
             }
         }
-        
-        
+
+
         // Keyword
         if (is_array($_POST["keywords"]["value"])) {
             $new_keywords = array();
@@ -978,13 +978,13 @@ class ilMDEditorGUI
                     $new_keywords[$language][] = trim($keyword);
                 }
             }
-            
+
             // update existing author entries (delete if not entered)
             foreach ($ids = $this->md_section->getKeywordIds() as $id) {
                 $md_key = $this->md_section->getKeyword($id);
 
                 $lang = $md_key->getKeywordLanguageCode();
-                
+
                 // entered keyword already exists
                 if (is_array($new_keywords[$lang]) &&
                     in_array($md_key->getKeyword(), $new_keywords[$lang])) {
@@ -994,7 +994,7 @@ class ilMDEditorGUI
                     $md_key->delete();
                 }
             }
-            
+
             // insert entered, but not existing keywords
             foreach ($new_keywords as $lang => $key_arr) {
                 foreach ($key_arr as $keyword) {
@@ -1008,7 +1008,7 @@ class ilMDEditorGUI
             }
         }
         $this->callListeners('General');
-        
+
         // Copyright
         if ($_POST['copyright_id'] or $_POST['rights_copyright']) {
             if (!is_object($this->md_section = $this->md_obj->getRights())) {
@@ -1062,22 +1062,22 @@ class ilMDEditorGUI
                 $this->md_section = $this->md_obj->addLifecycle();
                 $this->md_section->save();
             }
-            
+
             // determine all entered authors
             $auth_arr = explode(",", $_POST["life_experts"]);
             for ($i = 0; $i < count($auth_arr); $i++) {
                 $auth_arr[$i] = trim($auth_arr[$i]);
             }
-            
+
             $md_con_author = "";
-            
+
             // update existing author entries (delete if not entered)
             foreach (($ids = $this->md_section->getContributeIds()) as $con_id) {
                 $md_con = $this->md_section->getContribute($con_id);
                 if ($md_con->getRole() == "SubjectMatterExpert") {
                     foreach ($ent_ids = $md_con->getEntityIds() as $ent_id) {
                         $md_ent = $md_con->getEntity($ent_id);
-                        
+
                         // entered author already exists
                         if (in_array($md_ent->getEntity(), $auth_arr)) {
                             unset($auth_arr[array_search($md_ent->getEntity(), $auth_arr)]);
@@ -1088,7 +1088,7 @@ class ilMDEditorGUI
                     $md_con_author = $md_con;
                 }
             }
-            
+
             // insert enterd, but not existing authors
             if (count($auth_arr) > 0) {
                 if (!is_object($md_con_author)) {
@@ -1112,29 +1112,29 @@ class ilMDEditorGUI
                 }
             }
         }
-        
+
         // InstructionalDesigner
         if ($_POST["life_designers"] != "") {
             if (!is_object($this->md_section = $this->md_obj->getLifecycle())) {
                 $this->md_section = $this->md_obj->addLifecycle();
                 $this->md_section->save();
             }
-            
+
             // determine all entered authors
             $auth_arr = explode(",", $_POST["life_designers"]);
             for ($i = 0; $i < count($auth_arr); $i++) {
                 $auth_arr[$i] = trim($auth_arr[$i]);
             }
-            
+
             $md_con_author = "";
-            
+
             // update existing author entries (delete if not entered)
             foreach (($ids = $this->md_section->getContributeIds()) as $con_id) {
                 $md_con = $this->md_section->getContribute($con_id);
                 if ($md_con->getRole() == "InstructionalDesigner") {
                     foreach ($ent_ids = $md_con->getEntityIds() as $ent_id) {
                         $md_ent = $md_con->getEntity($ent_id);
-                        
+
                         // entered author already exists
                         if (in_array($md_ent->getEntity(), $auth_arr)) {
                             unset($auth_arr[array_search($md_ent->getEntity(), $auth_arr)]);
@@ -1145,7 +1145,7 @@ class ilMDEditorGUI
                     $md_con_author = $md_con;
                 }
             }
-            
+
             // insert enterd, but not existing authors
             if (count($auth_arr) > 0) {
                 if (!is_object($md_con_author)) {
@@ -1169,29 +1169,29 @@ class ilMDEditorGUI
                 }
             }
         }
-        
+
         // Point of Contact
         if ($_POST["life_poc"] != "") {
             if (!is_object($this->md_section = $this->md_obj->getLifecycle())) {
                 $this->md_section = $this->md_obj->addLifecycle();
                 $this->md_section->save();
             }
-            
+
             // determine all entered authors
             $auth_arr = explode(",", $_POST["life_poc"]);
             for ($i = 0; $i < count($auth_arr); $i++) {
                 $auth_arr[$i] = trim($auth_arr[$i]);
             }
-            
+
             $md_con_author = "";
-            
+
             // update existing author entries (delete if not entered)
             foreach (($ids = $this->md_section->getContributeIds()) as $con_id) {
                 $md_con = $this->md_section->getContribute($con_id);
                 if ($md_con->getRole() == "PointOfContact") {
                     foreach ($ent_ids = $md_con->getEntityIds() as $ent_id) {
                         $md_ent = $md_con->getEntity($ent_id);
-                        
+
                         // entered author already exists
                         if (in_array($md_ent->getEntity(), $auth_arr)) {
                             unset($auth_arr[array_search($md_ent->getEntity(), $auth_arr)]);
@@ -1202,7 +1202,7 @@ class ilMDEditorGUI
                     $md_con_author = $md_con;
                 }
             }
-            
+
             // insert enterd, but not existing authors
             if (count($auth_arr) > 0) {
                 if (!is_object($md_con_author)) {
@@ -1226,22 +1226,22 @@ class ilMDEditorGUI
                 }
             }
         }
-        
+
         $this->md_section = $this->md_obj->getLifecycle();
         $this->md_section->setVersionLanguage(new ilMDLanguageItem($_POST['lif_language']));
         $this->md_section->setVersion(ilUtil::stripSlashes($_POST['lif_version']));
         $this->md_section->setStatus($_POST['lif_status']);
         $this->md_section->update();
 
-        
+
         $this->callListeners('Lifecycle');
-        
+
         // Redirect here to read new title and description
         // Otherwise ('Lifecycle' 'technical' ...) simply call listSection()
         ilUtil::sendSuccess($this->lng->txt("saved_successfully"), true);
         $this->ctrl->redirect($this, 'listSection');
     }
-    
+
     /*
      * list general sections
      */
@@ -1253,7 +1253,7 @@ class ilMDEditorGUI
         }
 
         $this->tpl->addBlockFile('ADM_CONTENT', 'adm_content', 'tpl.md_editor.html', 'Services/MetaData');
-        
+
         $this->__setTabs('meta_general');
 
         $this->tpl->addBlockFile('MD_CONTENT', 'md_content', 'tpl.md_general.html', 'Services/MetaData');
@@ -1263,7 +1263,7 @@ class ilMDEditorGUI
         $this->tpl->setVariable("EDIT_ACTION", $this->ctrl->getFormAction($this));
 
         $this->__fillSubelements();
-        
+
         $this->tpl->setVariable("TXT_GENERAL", $this->lng->txt("meta_general"));
         $this->tpl->setVariable("TXT_IDENTIFIER", $this->lng->txt("meta_identifier"));
         $this->tpl->setVariable("TXT_LANGUAGE", $this->lng->txt("meta_language"));
@@ -1295,7 +1295,7 @@ class ilMDEditorGUI
                 $this->tpl->parseCurrentBlock();
                 $first = false;
             }
-            
+
             if (count($ids) > 1) {
                 $this->ctrl->setParameter($this, 'meta_index', $id);
                 $this->ctrl->setParameter($this, 'meta_path', 'meta_identifier');
@@ -1329,7 +1329,7 @@ class ilMDEditorGUI
         $first = true;
         foreach ($ids = $this->md_section->getLanguageIds() as $id) {
             $md_lan = $this->md_section->getLanguage($id);
-            
+
             if ($first) {
                 $this->tpl->setCurrentBlock("language_head");
                 $this->tpl->setVariable("ROWSPAN_LANG", count($ids));
@@ -1395,7 +1395,7 @@ class ilMDEditorGUI
         $first = true;
         foreach ($ids = $this->md_section->getKeywordIds() as $id) {
             $md_key = $this->md_section->getKeyword($id);
-            
+
             if ($first) {
                 $this->tpl->setCurrentBlock("keyword_head");
                 $this->tpl->setVariable("ROWSPAN_KEYWORD", count($ids));
@@ -1414,7 +1414,7 @@ class ilMDEditorGUI
                 $this->tpl->setVariable("KEYWORD_LOOP_TXT_DELETE", $this->lng->txt("meta_delete"));
                 $this->tpl->parseCurrentBlock();
             }
-            
+
             $this->tpl->setCurrentBlock("keyword_loop");
             $this->tpl->setVariable("KEYWORD_LOOP_NO", $id);
             $this->tpl->setVariable("KEYWORD_LOOP_TXT_VALUE", $this->lng->txt("meta_value"));
@@ -1446,7 +1446,7 @@ class ilMDEditorGUI
     public function updateGeneral()
     {
         include_once 'Services/MetaData/classes/class.ilMDLanguageItem.php';
-        
+
         if (!strlen(trim($_POST['gen_title']))) {
             if ($this->md_obj->getObjType() != 'sess') {
                 ilUtil::sendFailure($this->lng->txt('title_required'));
@@ -1454,7 +1454,7 @@ class ilMDEditorGUI
                 return false;
             }
         }
-        
+
         // General values
         $this->md_section = $this->md_obj->getGeneral();
         $this->md_section->setStructure($_POST['gen_structure']);
@@ -1559,7 +1559,7 @@ class ilMDEditorGUI
         $this->listSection();
         return true;
     }
-        
+
 
 
     public function listTechnical()
@@ -1683,7 +1683,7 @@ class ilMDEditorGUI
                 "REQUIREMENT_LOOP_VAL_OPERATINGSYSTEM_MINIMUMVERSION",
                 ilUtil::prepareFormOutput($md_re->getOperatingSystemMinimumVersion())
             );
-            
+
             $this->tpl->setVariable(
                 "REQUIREMENT_LOOP_VAL_OPERATINGSYSTEM_MAXIMUMVERSION",
                 ilUtil::prepareFormOutput($md_re->getOperatingSystemMaximumVersion())
@@ -1693,7 +1693,7 @@ class ilMDEditorGUI
                 "REQUIREMENT_LOOP_VAL_BROWSER_MINIMUMVERSION",
                 ilUtil::prepareFormOutput($md_re->getBrowserMinimumVersion())
             );
-            
+
             $this->tpl->setVariable(
                 "REQUIREMENT_LOOP_VAL_BROWSER_MAXIMUMVERSION",
                 ilUtil::prepareFormOutput($md_re->getBrowserMaximumVersion())
@@ -1743,7 +1743,7 @@ class ilMDEditorGUI
                     "ORREQUIREMENT_LOOP_VAL_OPERATINGSYSTEM_MINIMUMVERSION",
                     ilUtil::prepareFormOutput($md_re->getOperatingSystemMinimumVersion())
                 );
-            
+
                 $this->tpl->setVariable(
                     "ORREQUIREMENT_LOOP_VAL_OPERATINGSYSTEM_MAXIMUMVERSION",
                     ilUtil::prepareFormOutput($md_re->getOperatingSystemMaximumVersion())
@@ -1753,7 +1753,7 @@ class ilMDEditorGUI
                     "ORREQUIREMENT_LOOP_VAL_BROWSER_MINIMUMVERSION",
                     ilUtil::prepareFormOutput($md_re->getBrowserMinimumVersion())
                 );
-            
+
                 $this->tpl->setVariable(
                     "ORREQUIREMENT_LOOP_VAL_BROWSER_MAXIMUMVERSION",
                     ilUtil::prepareFormOutput($md_re->getBrowserMaximumVersion())
@@ -1812,7 +1812,7 @@ class ilMDEditorGUI
         $this->tpl->setVariable("TXT_SAVE", $this->lng->txt('save'));
         $this->tpl->parseCurrentBlock();
     }
-    
+
 
 
     public function listLifecycle()
@@ -1872,7 +1872,7 @@ class ilMDEditorGUI
             if (count($ids) > 1) {
                 $this->ctrl->setParameter($this, 'meta_index', $con_id);
                 $this->ctrl->setParameter($this, 'meta_path', 'meta_contribute');
-                
+
                 $this->tpl->setCurrentBlock("contribute_delete");
                 $this->tpl->setVariable("CONTRIBUTE_LOOP_ACTION_DELETE", $this->ctrl->getLinkTarget($this, 'deleteElement'));
                 $this->tpl->setVariable("CONTRIBUTE_LOOP_TXT_DELETE", $this->lng->txt('delete'));
@@ -1881,18 +1881,18 @@ class ilMDEditorGUI
             // Entities
             foreach ($ent_ids = $md_con->getEntityIds() as $ent_id) {
                 $md_ent = $md_con->getEntity($ent_id);
-                
+
                 $this->ctrl->setParameter($this, 'meta_path', 'meta_entity');
-                
+
                 if (count($ent_ids) > 1) {
                     $this->tpl->setCurrentBlock("contribute_entity_delete");
-                    
+
                     $this->ctrl->setParameter($this, 'meta_index', $ent_id);
                     $this->tpl->setVariable("CONTRIBUTE_ENTITY_LOOP_ACTION_DELETE", $this->ctrl->getLinkTarget($this, 'deleteElement'));
                     $this->tpl->setVariable("CONTRIBUTE_ENTITY_LOOP_TXT_DELETE", $this->lng->txt('delete'));
                     $this->tpl->parseCurrentBlock();
                 }
-                
+
                 $this->tpl->setCurrentBlock("contribute_entity_loop");
 
                 $this->tpl->setVariable("CONTRIBUTE_ENTITY_LOOP_CONTRIBUTE_NO", $con_id);
@@ -1902,7 +1902,7 @@ class ilMDEditorGUI
                 $this->tpl->parseCurrentBlock();
             }
             $this->tpl->setCurrentBlock("contribute_loop");
-            
+
             $this->ctrl->setParameter($this, 'section_element', 'meta_entity');
             $this->ctrl->setParameter($this, 'meta_index', $con_id);
             $this->tpl->setVariable("CONTRIBUTE_ENTITY_LOOP_ACTION_ADD", $this->ctrl->getLinkTarget($this, 'addSectionElement'));
@@ -1922,7 +1922,7 @@ class ilMDEditorGUI
             $this->tpl->setVariable("CONTRIBUTE_LOOP_TXT_DATE", $this->lng->txt('meta_date'));
             $this->tpl->setVariable("CONTRIBUTE_LOOP_NO", $con_id);
             $this->tpl->setVariable("CONTRIBUTE_LOOP_VAL_DATE", ilUtil::prepareFormOutput($md_con->getDate()));
-            
+
             $this->tpl->parseCurrentBlock();
         }
         $this->tpl->setVariable("TXT_SAVE", $this->lng->txt('save'));
@@ -2022,7 +2022,7 @@ class ilMDEditorGUI
             if (count($ids) > 1) {
                 $this->ctrl->setParameter($this, 'meta_index', $id);
                 $this->ctrl->setParameter($this, 'meta_path', 'meta_identifier');
-                
+
                 $this->tpl->setCurrentBlock("identifier_delete");
                 $this->tpl->setVariable("IDENTIFIER_LOOP_ACTION_DELETE", $this->ctrl->getLinkTarget($this, 'deleteElement'));
                 $this->tpl->setVariable("IDENTIFIER_LOOP_TXT_DELETE", $this->lng->txt('delete'));
@@ -2052,7 +2052,7 @@ class ilMDEditorGUI
             if (count($ids) > 1) {
                 $this->ctrl->setParameter($this, 'meta_index', $con_id);
                 $this->ctrl->setParameter($this, 'meta_path', 'meta_contribute');
-                
+
                 $this->tpl->setCurrentBlock("contribute_delete");
                 $this->tpl->setVariable("CONTRIBUTE_LOOP_ACTION_DELETE", $this->ctrl->getLinkTarget($this, 'deleteElement'));
                 $this->tpl->setVariable("CONTRIBUTE_LOOP_TXT_DELETE", $this->lng->txt('delete'));
@@ -2061,18 +2061,18 @@ class ilMDEditorGUI
             // Entities
             foreach ($ent_ids = $md_con->getEntityIds() as $ent_id) {
                 $md_ent = $md_con->getEntity($ent_id);
-                
+
                 $this->ctrl->setParameter($this, 'meta_path', 'meta_entity');
-                
+
                 if (count($ent_ids) > 1) {
                     $this->tpl->setCurrentBlock("contribute_entity_delete");
-                    
+
                     $this->ctrl->setParameter($this, 'meta_index', $ent_id);
                     $this->tpl->setVariable("CONTRIBUTE_ENTITY_LOOP_ACTION_DELETE", $this->ctrl->getLinkTarget($this, 'deleteElement'));
                     $this->tpl->setVariable("CONTRIBUTE_ENTITY_LOOP_TXT_DELETE", $this->lng->txt('delete'));
                     $this->tpl->parseCurrentBlock();
                 }
-                
+
                 $this->tpl->setCurrentBlock("contribute_entity_loop");
 
                 $this->ctrl->setParameter($this, 'section_element', 'meta_entity');
@@ -2099,7 +2099,7 @@ class ilMDEditorGUI
             $this->tpl->setVariable("CONTRIBUTE_LOOP_TXT_DATE", $this->lng->txt('meta_date'));
             $this->tpl->setVariable("CONTRIBUTE_LOOP_NO", $con_id);
             $this->tpl->setVariable("CONTRIBUTE_LOOP_VAL_DATE", ilUtil::prepareFormOutput($md_con->getDate()));
-            
+
             $this->tpl->parseCurrentBlock();
         }
         $this->tpl->setVariable("TXT_SAVE", $this->lng->txt('save'));
@@ -2205,7 +2205,7 @@ class ilMDEditorGUI
             );
 
             $this->tpl->setVariable("TXT_SAVE", $this->lng->txt("save"));
-    
+
             $this->tpl->setCurrentBlock("rights");
             $this->tpl->parseCurrentBlock();
         }
@@ -2222,7 +2222,7 @@ class ilMDEditorGUI
         $this->md_section->setDescriptionLanguage(new ilMDLanguageItem($_POST['rights']['DescriptionLanguage']));
         $this->md_section->setDescription(ilUtil::stripSlashes($_POST['rights']['Description']));
         $this->md_section->update();
-        
+
         $this->callListeners('Rights');
         ilUtil::sendSuccess($this->lng->txt("saved_successfully"));
         $this->listSection();
@@ -2274,7 +2274,7 @@ class ilMDEditorGUI
             $this->tpl->setVariable("TXT_INTENDEDENDUSERROLE", $this->lng->txt("meta_intended_end_user_role"));
             $this->tpl->setVariable("TXT_CONTEXT", $this->lng->txt("meta_context"));
             $this->tpl->setVariable("TXT_DIFFICULTY", $this->lng->txt("meta_difficulty"));
-            
+
             $this->tpl->setVariable("VAL_INTERACTIVITYTYPE_" . strtoupper($this->md_section->getInteractivityType()), " selected");
             $this->tpl->setVariable("VAL_LEARNINGRESOURCETYPE_" . strtoupper($this->md_section->getLearningResourceType()), " selected");
             $this->tpl->setVariable("VAL_INTERACTIVITYLEVEL_" . strtoupper($this->md_section->getInteractivityLevel()), " selected");
@@ -2283,7 +2283,7 @@ class ilMDEditorGUI
             $this->tpl->setVariable("VAL_CONTEXT_" . strtoupper($this->md_section->getContext()), " selected");
             $this->tpl->setVariable("VAL_DIFFICULTY_" . strtoupper($this->md_section->getDifficulty()), " selected");
             #$this->tpl->setVariable("VAL_TYPICALLEARNINGTIME", ilUtil::prepareFormOutput($this->md_section->getTypicalLearningTime()));
-            
+
             $this->tpl->setVariable("TXT_ACTIVE", $this->lng->txt("meta_active"));
             $this->tpl->setVariable("TXT_EXPOSITIVE", $this->lng->txt("meta_expositive"));
             $this->tpl->setVariable("TXT_MIXED", $this->lng->txt("meta_mixed"));
@@ -2327,7 +2327,7 @@ class ilMDEditorGUI
             $valid = true;
 
             include_once 'Services/MetaData/classes/class.ilMDUtils.php';
-            
+
             if (!$tlt = ilMDUtils::_LOMDurationToArray($this->md_section->getTypicalLearningTime())) {
                 if (strlen($this->md_section->getTypicalLearningTime())) {
                     $tlt = array(0,0,0,0,0);
@@ -2338,7 +2338,7 @@ class ilMDEditorGUI
             $this->tpl->setVariable("TXT_MONTH", $this->lng->txt('md_months'));
             $this->tpl->setVariable("SEL_MONTHS", $this->__buildMonthsSelect($tlt[0]));
             $this->tpl->setVariable("SEL_DAYS", $this->__buildDaysSelect($tlt[1]));
-        
+
             $this->tpl->setVariable("TXT_DAYS", $this->lng->txt('md_days'));
             $this->tpl->setVariable("TXT_TIME", $this->lng->txt('md_time'));
 
@@ -2366,7 +2366,7 @@ class ilMDEditorGUI
             $first = true;
             foreach ($ids = $this->md_section->getTypicalAgeRangeIds() as $id) {
                 $md_age = $this->md_section->getTypicalAgeRange($id);
-                
+
                 // extra test due to bug 5316 (may be due to eLaix import)
                 if (is_object($md_age)) {
                     if ($first) {
@@ -2379,11 +2379,11 @@ class ilMDEditorGUI
                         $this->tpl->parseCurrentBlock();
                         $first = false;
                     }
-                        
-                    
+
+
                     $this->ctrl->setParameter($this, 'meta_index', $id);
                     $this->ctrl->setParameter($this, 'meta_path', 'educational_typical_age_range');
-        
+
                     $this->tpl->setCurrentBlock("typicalagerange_delete");
                     $this->tpl->setVariable(
                         "TYPICALAGERANGE_LOOP_ACTION_DELETE",
@@ -2391,7 +2391,7 @@ class ilMDEditorGUI
                     );
                     $this->tpl->setVariable("TYPICALAGERANGE_LOOP_TXT_DELETE", $this->lng->txt("meta_delete"));
                     $this->tpl->parseCurrentBlock();
-    
+
                     $this->tpl->setCurrentBlock("typicalagerange_loop");
                     $this->tpl->setVariable("TYPICALAGERANGE_LOOP_TXT_VALUE", $this->lng->txt("meta_value"));
                     $this->tpl->setVariable("TYPICALAGERANGE_LOOP_VAL", ilUtil::prepareFormOutput($md_age->getTypicalAgeRange()));
@@ -2426,10 +2426,10 @@ class ilMDEditorGUI
                 }
 
                 $md_des = $this->md_section->getDescription($id);
-                
+
                 $this->ctrl->setParameter($this, 'meta_index', $id);
                 $this->ctrl->setParameter($this, 'meta_path', 'educational_description');
-                
+
                 $this->tpl->setCurrentBlock("description_loop");
                 $this->tpl->setVariable("DESCRIPTION_LOOP_NO", $id);
                 $this->tpl->setVariable("DESCRIPTION_LOOP_TXT_VALUE", $this->lng->txt("meta_value"));
@@ -2467,9 +2467,9 @@ class ilMDEditorGUI
                     $this->tpl->parseCurrentBlock();
                     $first = false;
                 }
-                
+
                 $md_lang = $this->md_section->getLanguage($id);
-                
+
                 $this->ctrl->setParameter($this, 'meta_index', $id);
                 $this->ctrl->setParameter($this, 'meta_path', 'educational_language');
 
@@ -2519,7 +2519,7 @@ class ilMDEditorGUI
 
 
         // TLT
-        
+
         if ($_POST['tlt']['mo'] or $_POST['tlt']['d'] or
            $_POST['tlt']['h'] or $_POST['tlt']['m'] or $_POST['tlt']['s']) {
             $this->md_section->setPhysicalTypicalLearningTime(
@@ -2563,9 +2563,9 @@ class ilMDEditorGUI
             );
             $md_lang->update();
         }
-        
+
         $this->md_section->update();
-        
+
         $this->callListeners('Educational');
         ilUtil::sendSuccess($this->lng->txt("saved_successfully"));
         $this->listSection();
@@ -2594,10 +2594,10 @@ class ilMDEditorGUI
         } else {
             foreach ($rel_ids as $rel_id) {
                 $this->md_section = $this->md_obj->getRelation($rel_id);
-                
+
                 $this->ctrl->setParameter($this, 'meta_index', $rel_id);
                 $this->ctrl->setParameter($this, "section", "meta_relation");
-                
+
                 /* Identifier_ */
                 $res_ids = $this->md_section->getIdentifier_Ids();
                 foreach ($res_ids as $res_id) {
@@ -2638,7 +2638,7 @@ class ilMDEditorGUI
                     );
                     $this->tpl->parseCurrentBlock();
                 }
-    
+
                 /* Description */
                 $res_dess = $this->md_section->getDescriptionIds();
                 foreach ($res_dess as $res_des) {
@@ -2655,7 +2655,7 @@ class ilMDEditorGUI
                         $this->tpl->setVariable("DESCRIPTION_LOOP_TXT_DELETE", $this->lng->txt("meta_delete"));
                         $this->tpl->parseCurrentBlock();
                     }
-    
+
                     $this->tpl->setCurrentBlock("description_loop");
                     $this->tpl->setVariable("DESCRIPTION_LOOP_NO", $res_des);
                     $this->tpl->setVariable("DESCRIPTION_LOOP_TXT_DESCRIPTION", $this->lng->txt("meta_description"));
@@ -2681,7 +2681,7 @@ class ilMDEditorGUI
                     );
                     $this->tpl->parseCurrentBlock();
                 }
-                
+
                 $this->tpl->setCurrentBlock("relation_loop");
                 $this->tpl->setVariable("REL_ID", $rel_id);
                 $this->tpl->setVariable("TXT_RELATION", $this->lng->txt("meta_relation"));
@@ -2716,7 +2716,7 @@ class ilMDEditorGUI
                 $this->tpl->setVariable("VAL_KIND_" . strtoupper($this->md_section->getKind()), " selected");
                 $this->tpl->parseCurrentBlock();
             }
-            
+
             $this->tpl->setCurrentBlock("relation");
             $this->tpl->setVariable("EDIT_ACTION", $this->ctrl->getFormAction($this));
             $this->tpl->setVariable("TXT_SAVE", $this->lng->txt("save"));
@@ -2733,9 +2733,9 @@ class ilMDEditorGUI
             // kind
             $relation = $this->md_obj->getRelation($id);
             $relation->setKind($_POST['relation'][$id]['Kind']);
-            
+
             $relation->update();
-            
+
             // identifiers
             $res_idents = $relation->getIdentifier_Ids();
             foreach ($res_idents as $res_id) {
@@ -2744,7 +2744,7 @@ class ilMDEditorGUI
                 $ident->setEntry(ilUtil::stripSlashes($_POST['relation']['Resource']['Identifier'][$res_id]['Entry']));
                 $ident->update();
             }
-            
+
             // descriptions
             $res_dess = $relation->getDescriptionIds();
             foreach ($res_dess as $res_des) {
@@ -2756,7 +2756,7 @@ class ilMDEditorGUI
                 $des->update();
             }
         }
-        
+
         $this->callListeners('Relation');
         ilUtil::sendSuccess($this->lng->txt("saved_successfully"));
         $this->listSection();
@@ -2788,7 +2788,7 @@ class ilMDEditorGUI
                 $this->ctrl->setParameter($this, "section", "meta_annotation");
 
                 $this->md_section = $this->md_obj->getAnnotation($anno_id);
-                                
+
                 $this->tpl->setCurrentBlock("annotation_loop");
                 $this->tpl->setVariable("ANNOTATION_ID", $anno_id);
                 $this->tpl->setVariable("TXT_ANNOTATION", $this->lng->txt("meta_annotation"));
@@ -2804,12 +2804,12 @@ class ilMDEditorGUI
                 );
                 $this->tpl->setVariable("TXT_DELETE", $this->lng->txt("meta_delete"));
                 $this->tpl->setVariable("TXT_ADD", $this->lng->txt("meta_add"));
-                
+
                 $this->tpl->setVariable("TXT_ENTITY", $this->lng->txt("meta_entity"));
                 $this->tpl->setVariable("VAL_ENTITY", ilUtil::prepareFormOutput($this->md_section->getEntity()));
                 $this->tpl->setVariable("TXT_DATE", $this->lng->txt("meta_date"));
                 $this->tpl->setVariable("VAL_DATE", ilUtil::prepareFormOutput($this->md_section->getDate()));
-    
+
                 /* Description */
                 $this->tpl->setVariable("TXT_DESCRIPTION", $this->lng->txt("meta_description"));
                 $this->tpl->setVariable("TXT_VALUE", $this->lng->txt("meta_value"));
@@ -2822,10 +2822,10 @@ class ilMDEditorGUI
                         $this->md_section->getDescriptionLanguageCode()
                     )
                 );
-                
+
                 $this->tpl->parseCurrentBlock();
             }
-            
+
             $this->tpl->setCurrentBlock("annotation");
             $this->tpl->setVariable("EDIT_ACTION", $this->ctrl->getFormAction($this));
             $this->tpl->setVariable("TXT_SAVE", $this->lng->txt("save"));
@@ -2850,12 +2850,12 @@ class ilMDEditorGUI
 
             $annotation->update();
         }
-        
+
         $this->callListeners('Annotation');
         ilUtil::sendSuccess($this->lng->txt("saved_successfully"));
         $this->listSection();
     }
-    
+
     /*
      * list classification section
      */
@@ -2880,17 +2880,17 @@ class ilMDEditorGUI
             foreach ($class_ids as $class_id) {
                 $this->md_section = $this->md_obj->getClassification($class_id);
                 $this->ctrl->setParameter($this, "section", "meta_classification");
-                
+
                 /* TaxonPath */
                 $tp_ids = $this->md_section->getTaxonPathIds();
                 foreach ($tp_ids as $tp_id) {
                     $tax_path = $this->md_section->getTaxonPath($tp_id);
-                    
+
                     $tax_ids = $tax_path->getTaxonIds();
-                    
+
                     foreach ($tax_ids as $tax_id) {
                         $taxon = $tax_path->getTaxon($tax_id);
-                        
+
                         if (count($tax_ids) > 1) {
                             $this->tpl->setCurrentBlock("taxon_delete");
                             $this->ctrl->setParameter($this, "meta_index", $tax_id);
@@ -2997,7 +2997,7 @@ class ilMDEditorGUI
                         $this->tpl->setVariable("KEYWORD_LOOP_TXT_DELETE", $this->lng->txt("meta_delete"));
                         $this->tpl->parseCurrentBlock();
                     }
-                    
+
                     $keyword = $this->md_section->getKeyword($key_id);
                     $this->tpl->setCurrentBlock("keyword_loop");
                     $this->tpl->setVariable("KEYWORD_LOOP_NO", $key_id);
@@ -3024,7 +3024,7 @@ class ilMDEditorGUI
                     $this->tpl->setVariable("KEYWORD_LOOP_TXT_ADD", $this->lng->txt("meta_add"));
                     $this->tpl->parseCurrentBlock();
                 }
-                
+
                 $this->tpl->setCurrentBlock("classification_loop");
                 $this->tpl->setVariable("TXT_CLASSIFICATION", $this->lng->txt("meta_classification"));
                 $this->ctrl->setParameter($this, "meta_index", $class_id);
@@ -3038,12 +3038,12 @@ class ilMDEditorGUI
                     $this->ctrl->getLinkTarget($this, "addSection")
                 );
                 $this->tpl->setVariable("TXT_ADD", $this->lng->txt("meta_add"));
-    
+
                 $this->tpl->setVariable("TXT_NEW_ELEMENT", $this->lng->txt("meta_new_element"));
                 $this->tpl->setVariable("TXT_TAXONPATH", $this->lng->txt("meta_taxon_path"));
                 $this->tpl->setVariable("TXT_KEYWORD", $this->lng->txt("meta_keyword"));
                 $this->tpl->setVariable("TXT_ADD", $this->lng->txt("meta_add"));
-                
+
                 $this->tpl->setVariable("TXT_PLEASE_SELECT", $this->lng->txt("meta_please_select"));
                 $this->tpl->setVariable("CLASS_ID", $class_id);
                 $this->tpl->setVariable("TXT_PURPOSE", $this->lng->txt("meta_purpose"));
@@ -3059,7 +3059,7 @@ class ilMDEditorGUI
                 $this->tpl->setVariable("VAL_PURPOSE_" . strtoupper($this->md_section->getPurpose()), " selected");
                 $this->tpl->parseCurrentBlock();
             }
-            
+
             $this->tpl->setCurrentBlock("classification");
             $this->tpl->setVariable(
                 "EDIT_ACTION",
@@ -3079,14 +3079,14 @@ class ilMDEditorGUI
             // entity
             $classification = $this->md_obj->getClassification($id);
             $classification->setPurpose($_POST['classification'][$id]['Purpose']);
-            
+
             $classification->setDescription(ilUtil::stripSlashes($_POST['classification'][$id]['Description']));
             $classification->setDescriptionLanguage(
                 new ilMDLanguageItem($_POST['classification'][$id]['Language'])
             );
 
             $classification->update();
-            
+
             $key_ids = $classification->getKeywordIds();
             foreach ($key_ids as $key_id) {
                 $keyword = $classification->getKeyword($key_id);
@@ -3096,7 +3096,7 @@ class ilMDEditorGUI
                 );
                 $keyword->update();
             }
-            
+
             $tp_ids = $classification->getTaxonPathIds();
             foreach ($tp_ids as $tp_id) {
                 $tax_path = $classification->getTaxonPath($tp_id);
@@ -3107,7 +3107,7 @@ class ilMDEditorGUI
                 $tax_path->update();
 
                 $tax_ids = $tax_path->getTaxonIds();
-                    
+
                 foreach ($tax_ids as $tax_id) {
                     $taxon = $tax_path->getTaxon($tax_id);
                     $taxon->setTaxon(ilUtil::stripSlashes($_POST['classification']['TaxonPath']['Taxon'][$tax_id]['Value']));
@@ -3119,7 +3119,7 @@ class ilMDEditorGUI
                 }
             }
         }
-        
+
         $this->callListeners('Classification');
         ilUtil::sendSuccess($this->lng->txt("saved_successfully"));
         $this->listSection();
@@ -3131,24 +3131,24 @@ class ilMDEditorGUI
 
         $md_element = ilMDFactory::_getInstance($_GET['meta_path'], $_GET['meta_index'], $_GET['meta_technical']);
         $md_element->delete();
-        
+
         $this->listSection();
 
         return true;
     }
-    
+
     public function deleteSection()
     {
         include_once 'Services/MetaData/classes/class.ilMDFactory.php';
 
         $md_element = ilMDFactory::_getInstance($_GET['section'], $_GET['meta_index']);
         $md_element->delete();
-        
+
         $this->listSection();
 
         return true;
     }
-    
+
     public function addSection()
     {
         // Switch section
@@ -3187,12 +3187,12 @@ class ilMDEditorGUI
                 $this->md_section = $this->md_obj->addRights();
                 $this->md_section->save();
                 break;
-                
+
             case 'meta_educational':
                 $this->md_section = $this->md_obj->addEducational();
                 $this->md_section->save();
                 break;
-                
+
             case 'meta_relation':
                 $this->md_section = $this->md_obj->addRelation();
                 $this->md_section->save();
@@ -3201,7 +3201,7 @@ class ilMDEditorGUI
                 $des = $this->md_section->addDescription();
                 $des->save();
                 break;
-                
+
             case 'meta_annotation':
                 $this->md_section = $this->md_obj->addAnnotation();
                 $this->md_section->save();
@@ -3222,7 +3222,7 @@ class ilMDEditorGUI
                 break;
 
         }
-        
+
         $this->listSection();
         return true;
     }
@@ -3232,7 +3232,7 @@ class ilMDEditorGUI
         $section_element = (empty($_POST['section_element']))
             ? $_GET['section_element']
             : $_POST['section_element'];
-            
+
 
         // Switch section
         switch ($_GET['section']) {
@@ -3251,7 +3251,7 @@ class ilMDEditorGUI
             case 'meta_general':
                 $this->md_section = $this->md_obj->getGeneral();
                 break;
-                
+
             case 'meta_educational':
                 $this->md_section = $this->md_obj->getEducational();
                 break;
@@ -3315,23 +3315,23 @@ class ilMDEditorGUI
             case 'educational_typical_age_range':
                 $md_new = $this->md_section->addTypicalAgeRange();
                 break;
-                
+
             case 'relation_resource_identifier':
                 $rel = $this->md_obj->getRelation($_GET['meta_index']);
                 $md_new = $rel->addIdentifier_();
                 break;
-                
+
             case 'relation_resource_description':
                 $rel = $this->md_obj->getRelation($_GET['meta_index']);
                 $md_new = $rel->addDescription();
                 break;
-                
+
             case 'TaxonPath':
                 $md_new = $this->md_section->addTaxonPath();
                 $md_new->save();
                 $md_new = $md_new->addTaxon();
                 break;
-                
+
             case 'Taxon':
                 $tax_path = $this->md_section->getTaxonPath($_GET['meta_index']);
                 $md_new = $tax_path->addTaxon();
@@ -3359,13 +3359,13 @@ class ilMDEditorGUI
 
             case 'meta_meta_metadata':
                 return $this->listMetaMetadata();
-                
+
             case 'debug':
                 return $this->debug();
-                
+
             case 'meta_rights':
                 return $this->listRights();
-                
+
             case 'meta_educational':
                 return $this->listEducational();
 
@@ -3411,7 +3411,7 @@ class ilMDEditorGUI
         global $DIC;
 
         $ilToolbar = $DIC['ilToolbar'];
-        
+
         $tabs = array('meta_quickedit' => 'listQuickEdit',
                       'meta_general' => 'listGeneral',
                       'meta_lifecycle' => 'listLifecycle',
@@ -3438,13 +3438,13 @@ class ilMDEditorGUI
         $section->setValue($a_active);
 
         $ilToolbar->addStickyItem($section, true);
-        
+
         include_once "Services/UIComponent/Button/classes/class.ilSubmitButton.php";
         $button = ilSubmitButton::getInstance();
         $button->setCaption("show");
         $button->setCommand("listSection");
         $ilToolbar->addStickyItem($button);
-                
+
         $ilToolbar->setFormAction($this->ctrl->getFormAction($this, "listSection"));
 
         return true;
@@ -3502,8 +3502,8 @@ class ilMDEditorGUI
         }
         return ilUtil::formSelect($sel_day, 'tlt[d]', $options, false, true);
     }
-                
-        
+
+
 
     // Observer methods
     public function addObserver(&$a_class, $a_method, $a_element)

--- a/Services/Repository/classes/class.ilObjRepositorySettingsGUI.php
+++ b/Services/Repository/classes/class.ilObjRepositorySettingsGUI.php
@@ -41,7 +41,7 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
         $this->lng->loadLanguageModule('rep');
         $this->lng->loadLanguageModule('cmps');
     }
-    
+
     public function executeCommand()
     {
         $ilErr = $this->error;
@@ -70,29 +70,29 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
         }
         return true;
     }
-    
+
     public function getAdminTabs()
     {
         $rbacsystem = $this->rbacsystem;
-        
+
         $this->tabs_gui->addTab(
             "settings",
             $this->lng->txt("settings"),
             $this->ctrl->getLinkTarget($this, "view")
         );
-        
+
         $this->tabs_gui->addTab(
             "icons",
             $this->lng->txt("rep_custom_icons"),
             $this->ctrl->getLinkTarget($this, "customIcons")
         );
-        
+
         $this->tabs_gui->addTab(
             "modules",
             $this->lng->txt("cmps_repository_object_types"),
             $this->ctrl->getLinkTarget($this, "listModules")
         );
-        
+
         if ($rbacsystem->checkAccess('edit_permission', $this->object->getRefId())) {
             $this->tabs_gui->addTab(
                 "perm_settings",
@@ -101,28 +101,28 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
             );
         }
     }
-    
+
     public function view(ilPropertyFormGUI $a_form = null)
     {
         $this->tabs_gui->activateTab("settings");
-        
+
         if (!$a_form) {
             $a_form = $this->initSettingsForm();
         }
-        
+
         $this->tpl->setContent($a_form->getHTML());
     }
-    
+
     protected function initSettingsForm()
     {
         $ilSetting = $this->settings;
         $ilAccess = $this->access;
-        
+
         include_once('Services/Form/classes/class.ilPropertyFormGUI.php');
         $form = new ilPropertyFormGUI();
         $form->setTitle($this->lng->txt("settings"));
         $form->setFormAction($this->ctrl->getFormAction($this, 'saveSettings'));
-        
+
         // default repository view
         $options = array(
             "flat" => $this->lng->txt("flatview"),
@@ -213,7 +213,7 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
             $cb->setChecked(true);
         }
         $form->addItem($cb);
-    
+
         // change event
         require_once 'Services/Tracking/classes/class.ilChangeEvent.php';
         $this->lng->loadLanguageModule("trac");
@@ -221,69 +221,69 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
         $event->setInfo($this->lng->txt("trac_show_repository_views_info"));
         $event->setChecked(ilChangeEvent::_isActive());
         $form->addItem($event);
-        
-        
+
+
         include_once "Services/Administration/classes/class.ilAdministrationSettingsFormHandler.php";
         ilAdministrationSettingsFormHandler::addFieldsToForm(
             ilAdministrationSettingsFormHandler::FORM_REPOSITORY,
             $form,
             $this
         );
-        
-        
+
+
         // object lists
-        
+
         $lists = new ilFormSectionHeaderGUI();
         $lists->setTitle($this->lng->txt("rep_object_lists"));
         $form->addItem($lists);
-            
+
         $sdesc = new ilCheckboxInputGUI($this->lng->txt("adm_rep_shorten_description"), "rep_shorten_description");
         $sdesc->setInfo($this->lng->txt("adm_rep_shorten_description_info"));
         $sdesc->setChecked($ilSetting->get("rep_shorten_description"));
         $form->addItem($sdesc);
-        
+
         $sdesclen = new ilNumberInputGUI($this->lng->txt("adm_rep_shorten_description_length"), "rep_shorten_description_length");
         $sdesclen->setValue($ilSetting->get("rep_shorten_description_length"));
         $sdesclen->setSize(3);
         $sdesc->addSubItem($sdesclen);
-            
+
         // load action commands asynchronously
         $cb = new ilCheckboxInputGUI($this->lng->txt("adm_item_cmd_asynch"), "item_cmd_asynch");
         $cb->setInfo($this->lng->txt("adm_item_cmd_asynch_info"));
         $cb->setChecked($ilSetting->get("item_cmd_asynch"));
         $form->addItem($cb);
-        
+
         // notes/comments/tagging
         $pl = new ilCheckboxInputGUI($this->lng->txt('adm_show_comments_tagging_in_lists'), 'comments_tagging_in_lists');
         $pl->setValue(1);
         $pl->setChecked($ilSetting->get('comments_tagging_in_lists'));
         $form->addItem($pl);
-        
+
         $pltags = new ilCheckboxInputGUI($this->lng->txt('adm_show_comments_tagging_in_lists_tags'), 'comments_tagging_in_lists_tags');
         $pltags->setValue(1);
         $pltags->setChecked($ilSetting->get('comments_tagging_in_lists_tags'));
         $pl->addSubItem($pltags);
-                
+
         if ($ilAccess->checkAccess('write', '', $this->object->getRefId())) {
             $form->addCommandButton('saveSettings', $this->lng->txt('save'));
         }
-        
+
         return $form;
     }
-    
+
     public function saveSettings()
     {
         $ilSetting = $this->settings;
         $ilAccess = $this->access;
-        
+
         if (!$ilAccess->checkAccess('write', '', $this->object->getRefId())) {
             $this->ctrl->redirect($this, "view");
         }
-    
+
         $form = $this->initSettingsForm();
         if ($form->checkInput()) {
             $ilSetting->set("default_repository_view", $_POST["default_rep_view"]);
-                        
+
             $ilSetting->set("repository_tree_pres", $_POST["tree_pres"]);
             if ($_POST["tree_pres"] == "") {
                 $_POST["rep_tree_limit_grp_crs"] = "";
@@ -294,10 +294,10 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
                 $_POST["rep_tree_limit_grp_crs"] = false;
             }
             $ilSetting->set("rep_tree_limit_grp_crs", $_POST["rep_tree_limit_grp_crs"]);
-                        
+
             // $ilSetting->set('rep_cache',(int) $_POST['rep_cache']);
             // $ilSetting->set("rep_tree_synchronize", $_POST["rep_tree_synchronize"]);
-            
+
             $ilSetting->set("enable_trash", $_POST["enable_trash"]);
 
 
@@ -324,37 +324,37 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
             } else {
                 ilChangeEvent::_deactivate();
             }
-                        
+
             ilUtil::sendSuccess($this->lng->txt("msg_obj_modified"), true);
             $this->ctrl->redirect($this, "view");
         }
-        
+
         $form->setValuesByPost();
         $this->view($form);
     }
-    
+
     public function customIcons(ilPropertyFormGUI $a_form = null)
     {
         $this->tabs_gui->activateTab("icons");
-        
+
         if (!$a_form) {
             $a_form = $this->initCustomIconsForm();
         }
-        
+
         $this->tpl->setContent($a_form->getHTML());
     }
-    
+
     protected function initCustomIconsForm()
     {
         $ilSetting = $this->settings;
         $ilAccess = $this->access;
-        
+
         include_once "Services/Form/classes/class.ilPropertyFormGUI.php";
         include_once "Services/Form/classes/class.ilCombinationInputGUI.php";
         $form = new ilPropertyFormGUI();
         $form->setTitle($this->lng->txt("rep_custom_icons"));
         $form->setFormAction($this->ctrl->getFormAction($this, 'saveCustomIcons'));
-                
+
         $cb = new ilCheckboxInputGUI($this->lng->txt("enable_custom_icons"), "custom_icons");
         $cb->setInfo($this->lng->txt("enable_custom_icons_info"));
         $cb->setChecked($ilSetting->get("custom_icons"));
@@ -363,94 +363,94 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
         if ($ilAccess->checkAccess('write', '', $this->object->getRefId())) {
             $form->addCommandButton('saveCustomIcons', $this->lng->txt('save'));
         }
-        
+
         return $form;
     }
-    
+
     public function saveCustomIcons()
     {
         $ilSetting = $this->settings;
         $ilAccess = $this->access;
-        
+
         if (!$ilAccess->checkAccess('write', '', $this->object->getRefId())) {
             $this->ctrl->redirect($this, "customIcons");
         }
-    
+
         $form = $this->initCustomIconsForm();
         if ($form->checkInput()) {
             $ilSetting->set("custom_icons", (int) $form->getInput("custom_icons"));
             ilUtil::sendSuccess($this->lng->txt("msg_obj_modified"), true);
             $this->ctrl->redirect($this, "customIcons");
         }
-        
+
         $form->setValuesByPost();
         $this->customIcons($form);
     }
-    
+
     protected function setModuleSubTabs($a_active)
     {
         $this->tabs_gui->activateTab('modules');
-        
+
         $this->tabs_gui->addSubTab(
             "list_mods",
             $this->lng->txt("rep_new_item_menu"),
             $this->ctrl->getLinkTarget($this, "listModules")
         );
-        
+
         $this->tabs_gui->addSubTab(
             "new_item_groups",
             $this->lng->txt("rep_new_item_groups"),
             $this->ctrl->getLinkTarget($this, "listNewItemGroups")
         );
-        
+
         $this->tabs_gui->activateSubTab($a_active);
     }
-    
+
     protected function listModules()
     {
         $ilAccess = $this->access;
-        
+
         $this->setModuleSubTabs("list_mods");
-                
+
         $has_write = $ilAccess->checkAccess('write', '', $this->object->getRefId());
-        
+
         include_once("./Services/Repository/classes/class.ilModulesTableGUI.php");
         $comp_table = new ilModulesTableGUI($this, "listModules", $has_write);
-                
+
         $this->tpl->setContent($comp_table->getHTML());
     }
-    
+
     protected function saveModules()
     {
         $ilSetting = $this->settings;
         $ilCtrl = $this->ctrl;
         $lng = $this->lng;
         $ilAccess = $this->access;
-        
+
         if (!is_array($_POST["obj_grp"]) ||
             !is_array($_POST["obj_pos"]) ||
             !$ilAccess->checkAccess('write', '', $this->object->getRefId())) {
             $ilCtrl->redirect($this, "listModules");
         }
-        
+
         $grp_pos_map = array(0 => 9999);
         include_once("Services/Repository/classes/class.ilObjRepositorySettings.php");
         foreach (ilObjRepositorySettings::getNewItemGroups() as $item) {
             $grp_pos_map[$item["id"]] = $item["pos"];
         }
-        
+
         $type_pos_map = array();
         foreach ($_POST["obj_pos"] as $obj_type => $pos) {
             $grp_id = (int) $_POST["obj_grp"][$obj_type];
             $type_pos_map[$grp_id][$obj_type] = $pos;
-            
+
             // enable creation?
             $ilSetting->set("obj_dis_creation_" . $obj_type, !(int) $_POST["obj_enbl_creation"][$obj_type]);
         }
-        
+
         foreach ($type_pos_map as $grp_id => $obj_types) {
             $grp_pos = str_pad($grp_pos_map[$grp_id], 4, "0", STR_PAD_LEFT);
-        
+
             asort($obj_types);
             $pos = 0;
             foreach (array_keys($obj_types) as $obj_type) {
@@ -468,57 +468,57 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
         }
         else
         {
-            ilUtil::sendInfo($lng->txt("cmps_duplicate_positions")." ".implode($double, ", "), true);
+            ilUtil::sendInfo($lng->txt("cmps_duplicate_positions")." ".implode(", ", $double), true);
         }
         */
-        
+
         ilUtil::sendSuccess($lng->txt("msg_obj_modified"), true);
         $ilCtrl->redirect($this, "listModules");
     }
-    
+
     protected function listNewItemGroups()
     {
         $ilToolbar = $this->toolbar;
         $ilAccess = $this->access;
-        
+
         $this->setModuleSubTabs("new_item_groups");
-        
+
         $has_write = $ilAccess->checkAccess('write', '', $this->object->getRefId());
-        
+
         if ($has_write) {
             $ilToolbar->addButton(
                 $this->lng->txt("rep_new_item_group_add"),
                 $this->ctrl->getLinkTarget($this, "addNewItemGroup")
             );
-        
+
             $ilToolbar->addButton(
                 $this->lng->txt("rep_new_item_group_add_separator"),
                 $this->ctrl->getLinkTarget($this, "addNewItemGroupSeparator")
             );
         }
-        
+
         include_once("./Services/Repository/classes/class.ilNewItemGroupTableGUI.php");
         $grp_table = new ilNewItemGroupTableGUI($this, "listNewItemGroups", $has_write);
-                
+
         $this->tpl->setContent($grp_table->getHTML());
     }
-    
+
     protected function initNewItemGroupForm($a_grp_id = false)
     {
         $this->setModuleSubTabs("new_item_groups");
-        
+
         include_once "Services/Form/classes/class.ilPropertyFormGUI.php";
         $form = new ilPropertyFormGUI();
-        
+
         $this->lng->loadLanguageModule("meta");
         $def_lng = $this->lng->getDefaultLanguage();
-    
+
         $title = new ilTextInputGUI($this->lng->txt("title"), "title_" . $def_lng);
         $title->setInfo($this->lng->txt("meta_l_" . $def_lng) .
             " (" . $this->lng->txt("default_language") . ")");
         $title->setRequired(true);
         $form->addItem($title);
-        
+
         foreach ($this->lng->getInstalledLanguages() as $lang_id) {
             if ($lang_id != $def_lng) {
                 $title = new ilTextInputGUI($this->lng->txt("translation"), "title_" . $lang_id);
@@ -526,43 +526,43 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
                 $form->addItem($title);
             }
         }
-                                        
+
         if (!$a_grp_id) {
             $form->setTitle($this->lng->txt("rep_new_item_group_add"));
             $form->setFormAction($this->ctrl->getFormAction($this, "saveNewItemGroup"));
-            
+
             $form->addCommandButton("saveNewItemGroup", $this->lng->txt("save"));
         } else {
             $form->setTitle($this->lng->txt("rep_new_item_group_edit"));
             $form->setFormAction($this->ctrl->getFormAction($this, "updateNewItemGroup"));
-            
+
             include_once("Services/Repository/classes/class.ilObjRepositorySettings.php");
             $grp = ilObjRepositorySettings::getNewItemGroups();
             $grp = $grp[$a_grp_id];
-            
+
             foreach ($grp["titles"] as $id => $value) {
                 $field = $form->getItemByPostVar("title_" . $id);
                 if ($field) {
                     $field->setValue($value);
                 }
             }
-            
+
             $form->addCommandButton("updateNewItemGroup", $this->lng->txt("save"));
         }
         $form->addCommandButton("listNewItemGroups", $this->lng->txt("cancel"));
-        
+
         return $form;
     }
-    
+
     protected function addNewItemGroup(ilPropertyFormGUI $a_form = null)
     {
         if (!$a_form) {
             $a_form = $this->initNewItemGroupForm();
         }
-        
+
         $this->tpl->setContent($a_form->getHTML());
     }
-    
+
     protected function saveNewItemGroup()
     {
         $form = $this->initNewItemGroupForm();
@@ -571,60 +571,60 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
             foreach ($this->lng->getInstalledLanguages() as $lang_id) {
                 $titles[$lang_id] = $form->getInput("title_" . $lang_id);
             }
-            
+
             include_once("Services/Repository/classes/class.ilObjRepositorySettings.php");
             if (ilObjRepositorySettings::addNewItemGroup($titles)) {
                 ilUtil::sendSuccess($this->lng->txt("settings_saved"), true);
                 $this->ctrl->redirect($this, "listNewItemGroups");
             }
         }
-        
+
         $form->setValuesByPost();
         $this->addNewItemGroup($form);
     }
-    
+
     protected function editNewItemGroup(ilPropertyFormGUI $a_form = null)
     {
         $grp_id = (int) $_GET["grp_id"];
         if (!$grp_id) {
             $this->ctrl->redirect($this, "listNewItemGroups");
         }
-        
+
         if (!$a_form) {
             $this->ctrl->setParameter($this, "grp_id", $grp_id);
             $a_form = $this->initNewItemGroupForm($grp_id);
         }
-        
+
         $this->tpl->setContent($a_form->getHTML());
     }
-    
+
     protected function updateNewItemGroup()
     {
         $grp_id = (int) $_GET["grp_id"];
         if (!$grp_id) {
             $this->ctrl->redirect($this, "listNewItemGroups");
         }
-        
+
         $this->ctrl->setParameter($this, "grp_id", $grp_id);
-        
+
         $form = $this->initNewItemGroupForm($grp_id);
         if ($form->checkInput()) {
             $titles = array();
             foreach ($this->lng->getInstalledLanguages() as $lang_id) {
                 $titles[$lang_id] = $form->getInput("title_" . $lang_id);
             }
-            
+
             include_once("Services/Repository/classes/class.ilObjRepositorySettings.php");
             if (ilObjRepositorySettings::updateNewItemGroup($grp_id, $titles)) {
                 ilUtil::sendSuccess($this->lng->txt("settings_saved"), true);
                 $this->ctrl->redirect($this, "listNewItemGroups");
             }
         }
-        
+
         $form->setValuesByPost();
         $this->addNewItemGroup($form);
     }
-    
+
     protected function addNewItemGroupSeparator()
     {
         include_once("Services/Repository/classes/class.ilObjRepositorySettings.php");
@@ -633,21 +633,21 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
         }
         $this->ctrl->redirect($this, "listNewItemGroups");
     }
-    
+
     protected function saveNewItemGroupOrder()
     {
         $ilSetting = $this->settings;
-        
+
         if (is_array($_POST["grp_order"])) {
             include_once("Services/Repository/classes/class.ilObjRepositorySettings.php");
             ilObjRepositorySettings::updateNewItemGroupOrder($_POST["grp_order"]);
-                                    
+
             $grp_pos_map = array();
             include_once("Services/Repository/classes/class.ilObjRepositorySettings.php");
             foreach (ilObjRepositorySettings::getNewItemGroups() as $item) {
                 $grp_pos_map[$item["id"]] = str_pad($item["pos"], 4, "0", STR_PAD_LEFT);
             }
-        
+
             // update order of assigned objects
             foreach (ilObjRepositorySettings::getNewItemGroupSubItems() as $grp_id => $subitems) {
                 // unassigned objects will always be last
@@ -661,21 +661,21 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
                     }
                 }
             }
-            
+
             ilUtil::sendSuccess($this->lng->txt("settings_saved"), true);
         }
         $this->ctrl->redirect($this, "listNewItemGroups");
     }
-    
+
     protected function confirmDeleteNewItemGroup()
     {
         if (!is_array($_POST["grp_id"])) {
             ilUtil::sendFailure($this->lng->txt("select_one"));
             return $this->listNewItemGroups();
         }
-        
+
         $this->setModuleSubTabs("new_item_groups");
-        
+
         include_once("./Services/Utilities/classes/class.ilConfirmationGUI.php");
         $cgui = new ilConfirmationGUI();
         $cgui->setHeaderText($this->lng->txt("rep_new_item_group_delete_sure"));
@@ -683,52 +683,52 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
         $cgui->setFormAction($this->ctrl->getFormAction($this));
         $cgui->setCancel($this->lng->txt("cancel"), "listNewItemGroups");
         $cgui->setConfirm($this->lng->txt("confirm"), "deleteNewItemGroup");
-        
+
         include_once("Services/Repository/classes/class.ilObjRepositorySettings.php");
         $groups = ilObjRepositorySettings::getNewItemGroups();
 
         foreach ($_POST["grp_id"] as $grp_id) {
             $cgui->addItem("grp_id[]", $grp_id, $groups[$grp_id]["title"]);
         }
-        
+
         $this->tpl->setContent($cgui->getHTML());
     }
-    
+
     protected function deleteNewItemGroup()
     {
         if (!is_array($_POST["grp_id"])) {
             return $this->listNewItemGroups();
         }
-        
+
         include_once("Services/Repository/classes/class.ilObjRepositorySettings.php");
         foreach ($_POST["grp_id"] as $grp_id) {
             ilObjRepositorySettings::deleteNewItemGroup($grp_id);
         }
-        
+
         ilUtil::sendSuccess($this->lng->txt("settings_saved"), true);
         $this->ctrl->redirect($this, "listNewItemGroups");
     }
-    
+
     public function addToExternalSettingsForm($a_form_id)
     {
         $ilSetting = $this->settings;
-        
+
         switch ($a_form_id) {
             case ilAdministrationSettingsFormHandler::FORM_LP:
-                
+
                 require_once 'Services/Tracking/classes/class.ilChangeEvent.php';
                 $fields = array('trac_show_repository_views' => array(ilChangeEvent::_isActive(), ilAdministrationSettingsFormHandler::VALUE_BOOL));
-                                                
+
                 return array(array("view", $fields));
-                
-                
+
+
             case ilAdministrationSettingsFormHandler::FORM_TAGGING:
-                
+
                 $fields = array(
                     'adm_show_comments_tagging_in_lists' => array($ilSetting->get('comments_tagging_in_lists'), ilAdministrationSettingsFormHandler::VALUE_BOOL,
                         array('adm_show_comments_tagging_in_lists_tags' => array($ilSetting->get('comments_tagging_in_lists_tags'), ilAdministrationSettingsFormHandler::VALUE_BOOL))
                 ));
-                
+
                 return array(array("view", $fields));
         }
     }

--- a/Services/Skill/classes/class.ilSkillLevelResourcesTableGUI.php
+++ b/Services/Skill/classes/class.ilSkillLevelResourcesTableGUI.php
@@ -49,23 +49,23 @@ class ilSkillLevelResourcesTableGUI extends ilTable2GUI
 
         $ilCtrl = $DIC->ctrl();
         $lng = $DIC->language();
-        
+
         $this->level_id = $a_level_id;
-        
+
         include_once("./Services/Skill/classes/class.ilSkillResources.php");
         $this->resources = new ilSkillResources($a_skill_id, $a_tref_id);
-        
+
         parent::__construct($a_parent_obj, $a_parent_cmd);
         $this->setData($this->resources->getResourcesOfLevel($a_level_id));
         $this->setTitle($lng->txt("resources"));
-        
+
         $this->addColumn("", "", "1px", true);
         $this->addColumn($this->lng->txt("type"), "", "1px");
         $this->addColumn($this->lng->txt("title"), "");
         $this->addColumn($this->lng->txt("path"));
         $this->addColumn($this->lng->txt("skmg_suggested"));
         $this->addColumn($this->lng->txt("skmg_lp_triggers_level"));
-        
+
         $this->setFormAction($ilCtrl->getFormAction($a_parent_obj));
         $this->setRowTemplate("tpl.level_resources_row.html", "Services/Skill");
 
@@ -74,7 +74,7 @@ class ilSkillLevelResourcesTableGUI extends ilTable2GUI
             $this->addCommandButton("saveResourceSettings", $lng->txt("skmg_save_settings"));
         }
     }
-    
+
     /**
      * Fill table row
      */
@@ -104,7 +104,7 @@ class ilSkillLevelResourcesTableGUI extends ilTable2GUI
         $this->tpl->setVariable("TITLE", ilObject::_lookupTitle($obj_id));
         $this->tpl->setVariable("IMG", ilUtil::img(ilObject::_getIcon($obj_id, "tiny")));
         $this->tpl->setVariable("ID", $ref_id);
-        
+
         $path = $tree->getPathFull($ref_id);
         $path_items = array();
         foreach ($path as $p) {
@@ -112,6 +112,6 @@ class ilSkillLevelResourcesTableGUI extends ilTable2GUI
                 $path_items[] = $p["title"];
             }
         }
-        $this->tpl->setVariable("PATH", implode($path_items, " > "));
+        $this->tpl->setVariable("PATH", implode(" > ", $path_items));
     }
 }

--- a/Services/Skill/classes/class.ilSkillProfileLevelsTableGUI.php
+++ b/Services/Skill/classes/class.ilSkillProfileLevelsTableGUI.php
@@ -38,21 +38,21 @@ class ilSkillProfileLevelsTableGUI extends ilTable2GUI
         $lng = $DIC->language();
         $ilAccess = $DIC->access();
         $lng = $DIC->language();
-        
+
         include_once("./Services/Skill/classes/class.ilBasicSkill.php");
         include_once("./Services/Skill/classes/class.ilSkillTree.php");
         $this->tree = new ilSkillTree();
-        
+
         $this->profile = $a_profile;
         parent::__construct($a_parent_obj, $a_parent_cmd);
 
         $this->setData($this->profile->getSkillLevels());
         $this->setTitle($lng->txt("skmg_skill_levels"));
-        
+
         $this->addColumn("", "", "1", true);
         $this->addColumn($this->lng->txt("skmg_skill"));
         $this->addColumn($this->lng->txt("skmg_level"));
-        
+
         $this->setFormAction($ilCtrl->getFormAction($a_parent_obj));
         $this->setRowTemplate("tpl.skill_profile_level_row.html", "Services/Skill");
 
@@ -61,7 +61,7 @@ class ilSkillProfileLevelsTableGUI extends ilTable2GUI
         }
         //$this->addCommandButton("", $lng->txt(""));
     }
-    
+
     /**
      * Fill table row
      */
@@ -79,11 +79,11 @@ class ilSkillProfileLevelsTableGUI extends ilTable2GUI
         }
         $this->tpl->setVariable(
             "SKILL_TITLE",
-            implode($path_items, " > ")
+            implode(" > ", $path_items)
         );
-        
+
         $this->tpl->setVariable("LEVEL_TITLE", ilBasicSkill::lookupLevelTitle($a_set["level_id"]));
-        
+
         $this->tpl->setVariable(
             "ID",
             ((int) $a_set["base_skill_id"]) . ":" . ((int) $a_set["tref_id"]) . ":" . ((int) $a_set["level_id"])

--- a/Services/Tagging/classes/class.ilObjTaggingSettingsGUI.php
+++ b/Services/Tagging/classes/class.ilObjTaggingSettingsGUI.php
@@ -133,7 +133,7 @@ class ilObjTaggingSettingsGUI extends ilObjectGUI
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
         $ilAccess = $this->access;
-        
+
         $tags_set = new ilSetting("tags");
         if ($tags_set->get("enable")) {
             $ilTabs->addSubTab(
@@ -148,7 +148,7 @@ class ilObjTaggingSettingsGUI extends ilObjectGUI
                     $lng->txt("tagging_forbidden_tags"),
                     $ilCtrl->getLinkTarget($this, "editForbiddenTags")
                 );
-    
+
                 $ilTabs->addSubTab(
                     "users",
                     $lng->txt("users"),
@@ -157,15 +157,15 @@ class ilObjTaggingSettingsGUI extends ilObjectGUI
             }
         }
     }
-    
-    
+
+
     /**
     * Edit mediacast settings.
     */
     public function editSettings()
     {
         $ilTabs = $this->tabs;
-        
+
         $this->tabs_gui->setTabActive('tagging_edit_settings');
         $this->addSubTabs();
         $ilTabs->activateSubTab("settings");
@@ -180,7 +180,7 @@ class ilObjTaggingSettingsGUI extends ilObjectGUI
     {
         $ilCtrl = $this->ctrl;
         $ilSetting = $this->settings;
-        
+
         $this->checkPermission("write");
 
         $tags_set = new ilSetting("tags");
@@ -198,10 +198,10 @@ class ilObjTaggingSettingsGUI extends ilObjectGUI
     public function cancel()
     {
         $ilCtrl = $this->ctrl;
-        
+
         $ilCtrl->redirect($this, "view");
     }
-        
+
     /**
      * Init settings property form
      *
@@ -211,15 +211,15 @@ class ilObjTaggingSettingsGUI extends ilObjectGUI
     {
         $lng = $this->lng;
         $ilAccess = $this->access;
-        
+
         $tags_set = new ilSetting("tags");
-        
-        
+
+
         include_once('Services/Form/classes/class.ilPropertyFormGUI.php');
         $form = new ilPropertyFormGUI();
         $form->setFormAction($this->ctrl->getFormAction($this));
         $form->setTitle($this->lng->txt('tagging_settings'));
-        
+
         if ($ilAccess->checkAccess("write", "", $this->object->getRefId())) {
             $form->addCommandButton('saveSettings', $this->lng->txt('save'));
             $form->addCommandButton('cancel', $this->lng->txt('cancel'));
@@ -232,7 +232,7 @@ class ilObjTaggingSettingsGUI extends ilObjectGUI
         );
         $cb_prop->setValue("1");
         $cb_prop->setChecked($tags_set->get("enable"));
-        
+
         // enable all users info
         $cb_prop2 = new ilCheckboxInputGUI(
             $lng->txt("tagging_enable_all_users"),
@@ -243,23 +243,23 @@ class ilObjTaggingSettingsGUI extends ilObjectGUI
         $cb_prop->addSubItem($cb_prop2);
 
         $form->addItem($cb_prop);
-                
+
         include_once "Services/Administration/classes/class.ilAdministrationSettingsFormHandler.php";
         ilAdministrationSettingsFormHandler::addFieldsToForm(
             ilAdministrationSettingsFormHandler::FORM_TAGGING,
             $form,
             $this
         );
-        
+
         $this->tpl->setContent($form->getHTML());
     }
-    
+
     //
     //
     // FORBIDDEN TAGS
     //
     //
-    
+
     /**
      * Edit forbidden tags
      */
@@ -267,15 +267,15 @@ class ilObjTaggingSettingsGUI extends ilObjectGUI
     {
         $ilTabs = $this->tabs;
         $tpl = $this->tpl;
-        
+
         $this->addSubTabs();
         $ilTabs->activateSubTab("forbidden_tags");
         $ilTabs->activateTab("tagging_edit_settings");
         $this->initForbiddenTagsForm();
-        
+
         $tpl->setContent($this->form->getHTML());
     }
-    
+
     /**
      * Init forbidden tags form.
      */
@@ -283,31 +283,31 @@ class ilObjTaggingSettingsGUI extends ilObjectGUI
     {
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-    
+
         $tags_set = new ilSetting("tags");
         $forbidden = $tags_set->get("forbidden_tags");
 
         if ($forbidden != "") {
             $tags_array = unserialize($forbidden);
-            $forb_str = implode($tags_array, " ");
+            $forb_str = implode(" ", $tags_array);
         }
-        
+
         include_once("Services/Form/classes/class.ilPropertyFormGUI.php");
         $this->form = new ilPropertyFormGUI();
-        
+
         // tags
         $ta = new ilTextAreaInputGUI($this->lng->txt("tagging_tags"), "forbidden_tags");
         $ta->setCols(50);
         $ta->setRows(10);
         $ta->setValue($forb_str);
         $this->form->addItem($ta);
-    
+
         $this->form->addCommandButton("saveForbiddenTags", $lng->txt("save"));
-                    
+
         $this->form->setTitle($lng->txt("tagging_forbidden_tags"));
         $this->form->setFormAction($ilCtrl->getFormAction($this));
     }
-    
+
     /**
     * Save forbidden tags
     */
@@ -319,9 +319,9 @@ class ilObjTaggingSettingsGUI extends ilObjectGUI
 
         $this->initForbiddenTagsForm();
         $this->form->checkInput();
-        
+
         $this->checkPermission("write");
-        
+
         $tags = str_replace(",", " ", $_POST["forbidden_tags"]);
         $tags = explode(" ", $tags);
         $tags_array = array();
@@ -331,17 +331,17 @@ class ilObjTaggingSettingsGUI extends ilObjectGUI
                 $tags_array[$t] = $t;
             }
         }
-        
+
         asort($tags_array);
-        
+
         $tags_set = new ilSetting("tags");
-        
+
         $tags_set->set("forbidden_tags", serialize($tags_array));
-        
+
         ilUtil::sendSuccess($lng->txt("msg_obj_modified"), true);
         $ilCtrl->redirect($this, "editForbiddenTags");
     }
-    
+
     //
     //
     // USER INFO
@@ -358,9 +358,9 @@ class ilObjTaggingSettingsGUI extends ilObjectGUI
         $ilToolbar = $this->toolbar;
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-        
+
         $this->checkPermission("write");
-        
+
         $this->addSubTabs();
         $ilTabs->activateTab("tagging_edit_settings");
         $ilTabs->activateSubTab("users");
@@ -368,17 +368,17 @@ class ilObjTaggingSettingsGUI extends ilObjectGUI
         $tag = ($_POST["tag"] != "")
             ? ilUtil::stripSlashes($_POST["tag"])
             : $_GET["tag"];
-        
+
         // tag input
         include_once("./Services/Form/classes/class.ilTextInputGUI.php");
         $ti = new ilTextInputGUI($lng->txt("tagging_tag"), "tag");
         $ti->setSize(15);
         $ti->setValue($tag);
         $ilToolbar->addInputItem($ti, true);
-        
+
         $ilToolbar->addFormButton($lng->txt("tagging_search_users"), "searchUsersForTag");
         $ilToolbar->setFormAction($ilCtrl->getFormAction($this, "searchUsersForTag"));
-        
+
         if ($a_search) {
             include_once("./Services/Tagging/classes/class.ilUserForTagTableGUI.php");
             $ilCtrl->setParameter($this, "tag", $tag);
@@ -390,8 +390,8 @@ class ilObjTaggingSettingsGUI extends ilObjectGUI
             $tpl->setContent($table->getHTML());
         }
     }
-    
-    
+
+
     /**
      * Search users for tag
      */

--- a/Services/Tagging/classes/class.ilTaggingGUI.php
+++ b/Services/Tagging/classes/class.ilTaggingGUI.php
@@ -42,7 +42,7 @@ class ilTaggingGUI
         $this->lng = $DIC->language();
     }
 
-    
+
     /**
      * Execute command
      *
@@ -52,7 +52,7 @@ class ilTaggingGUI
     public function executeCommand()
     {
         $ilCtrl = $this->ctrl;
-        
+
         $next_class = $ilCtrl->getNextClass();
         switch ($next_class) {
             default:
@@ -61,8 +61,8 @@ class ilTaggingGUI
                 break;
         }
     }
-    
-    
+
+
     /**
     * Set Object.
     *
@@ -79,11 +79,11 @@ class ilTaggingGUI
         $this->obj_type = $a_obj_type;
         $this->sub_obj_id = $a_sub_obj_id;
         $this->sub_obj_type = $a_sub_obj_type;
-        
+
         $this->setSaveCmd("saveTags");
         $this->setUserId($ilUser->getId());
         $this->setInputFieldName("il_tags");
-        
+
         $tags_set = new ilSetting("tags");
         $forbidden = $tags_set->get("forbidden_tags");
         if ($forbidden != "") {
@@ -92,7 +92,7 @@ class ilTaggingGUI
             $this->forbidden = array();
         }
     }
-    
+
     /**
     * Set User ID.
     *
@@ -160,7 +160,7 @@ class ilTaggingGUI
     {
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-        
+
         $ttpl = new ilTemplate("tpl.tags_input.html", true, true, "Services/Tagging");
         $tags = ilTagging::getTagsForUserAndObject(
             $this->obj_id,
@@ -171,23 +171,23 @@ class ilTaggingGUI
         );
         $ttpl->setVariable(
             "VAL_TAGS",
-            ilUtil::prepareFormOutput(implode($tags, ", "))
+            ilUtil::prepareFormOutput(implode(", ", $tags))
         );
         $ttpl->setVariable("TXT_SAVE", $lng->txt("save"));
         $ttpl->setVariable("TXT_COMMA_SEPARATED", $lng->txt("comma_separated"));
         $ttpl->setVariable("CMD_SAVE", $this->savecmd);
         $ttpl->setVariable("NAME_TAGS", $this->getInputFieldName());
-        
+
         return $ttpl->get();
     }
-    
+
     /**
     * Save Input
     */
     public function saveInput()
     {
         $lng = $this->lng;
-        
+
         $input = ilUtil::stripSlashes($_POST[$this->getInputFieldName()]);
         $input = str_replace("\r", "\n", $input);
         $input = str_replace("\n\n", "\n", $input);
@@ -213,7 +213,7 @@ class ilTaggingGUI
         );
         ilUtil::sendSuccess($lng->txt('msg_obj_modified'));
     }
-    
+
     /**
     * Check whether a tag is forbiddens
     */
@@ -229,7 +229,7 @@ class ilTaggingGUI
         }
         return false;
     }
-    
+
     /**
     * Get Input HTML for Tagging of an object (and a user)
     */
@@ -237,7 +237,7 @@ class ilTaggingGUI
     {
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-        
+
         $ttpl = new ilTemplate("tpl.tag_cloud.html", true, true, "Services/Tagging");
         $tags = ilTagging::getTagsForObject(
             $this->obj_id,
@@ -262,15 +262,15 @@ class ilTaggingGUI
                 $ttpl->parseCurrentBlock();
             }
         }
-        
+
         return $ttpl->get();
     }
 
-    
+
     ////
     //// Ajax related methods
     ////
-    
+
     /**
      * Init javascript
      */
@@ -294,10 +294,10 @@ class ilTaggingGUI
         include_once("./Services/jQuery/classes/class.iljQueryUtil.php");
         iljQueryUtil::initjQuery($tpl);
         $tpl->addJavascript("./Services/Tagging/js/ilTagging.js");
-        
+
         $tpl->addOnLoadCode("ilTagging.setAjaxUrl('" . $a_ajax_url . "');");
     }
-    
+
     /**
      * Get tagging js call
      *
@@ -310,7 +310,7 @@ class ilTaggingGUI
         global $DIC;
 
         $tpl = $DIC["tpl"];
-        
+
         if ($a_update_code === null) {
             $a_update_code = "null";
         } else {
@@ -330,11 +330,11 @@ class ilTaggingGUI
     {
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-        
+
         $lng->loadLanguageModule("tagging");
         $tpl = new ilTemplate("tpl.edit_tags.html", true, true, "Services/Tagging");
         $tpl->setVariable("TXT_TAGS", $lng->txt("tagging_tags"));
-    
+
         switch ($_GET["mess"] != "" ? $_GET["mess"] : $this->mess) {
             case "mod":
                 $mtype = "success";
@@ -358,21 +358,21 @@ class ilTaggingGUI
         );
         $tpl->setVariable(
             "VAL_TAGS",
-            ilUtil::prepareFormOutput(implode($tags, ", "))
+            ilUtil::prepareFormOutput(implode(", ", $tags))
         );
         $tpl->setVariable("TXT_SAVE", $lng->txt("save"));
         $tpl->setVariable("TXT_COMMA_SEPARATED", $lng->txt("comma_separated"));
         $tpl->setVariable("CMD_SAVE", "saveJS");
-        
+
         $os = "ilTagging.cmdAjaxForm(event, '" .
             $ilCtrl->getFormActionByClass("iltagginggui", "", "", true) .
             "');";
         $tpl->setVariable("ON_SUBMIT", $os);
-        
+
         $tags_set = new ilSetting("tags");
         if ($tags_set->get("enable_all_users")) {
             $tpl->setVariable("TAGS_TITLE", $lng->txt("tagging_my_tags"));
-            
+
             $all_obj_tags = ilTagging::_getListTagsForObjects(array($this->obj_id));
             $all_obj_tags = $all_obj_tags[$this->obj_id];
             if (is_array($all_obj_tags) &&
@@ -387,11 +387,11 @@ class ilTaggingGUI
                 }
             }
         }
-        
+
         echo $tpl->get();
         exit;
     }
-    
+
     /**
      * Save JS
      */
@@ -420,9 +420,9 @@ class ilTaggingGUI
             $this->getUserId(),
             $tags
         );
-        
+
         $this->mess = "mod";
-        
+
         $this->getHTML();
     }
 }

--- a/Services/Taxonomy/classes/class.ilObjTaxonomyGUI.php
+++ b/Services/Taxonomy/classes/class.ilObjTaxonomyGUI.php
@@ -29,7 +29,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
 
     protected $multiple = false;
     protected $assigned_item_sorting = false;
-    
+
     /**
      * Execute command
      */
@@ -46,15 +46,15 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $this->help = $DIC["ilHelp"];
         $ilCtrl = $DIC->ctrl();
         $lng = $DIC->language();
-        
+
         parent::__construct($a_id, ilObject2GUI::OBJECT_ID);
-        
+
         $ilCtrl->saveParameter($this, "tax_node");
         $ilCtrl->saveParameter($this, "tax_id");
-        
+
         $lng->loadLanguageModule("tax");
     }
-    
+
     /**
      * Get type
      *
@@ -74,7 +74,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
     {
         $this->assigned_object_id = $a_val;
     }
-    
+
     /**
      * Get assigned object
      *
@@ -84,7 +84,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
     {
         return $this->assigned_object_id;
     }
-    
+
     /**
      * Set multiple
      *
@@ -94,7 +94,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
     {
         $this->multiple = $a_val;
     }
-    
+
     /**
      * Get multiple
      *
@@ -104,7 +104,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
     {
         return $this->multiple;
     }
-    
+
     /**
      * Set list info
      *
@@ -114,7 +114,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
     {
         $this->list_info = trim($a_val);
     }
-    
+
     /**
      * Get list info
      *
@@ -124,7 +124,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
     {
         return $this->list_info;
     }
-    
+
     /**
      * Activate sorting mode of assigned objects
      *
@@ -138,8 +138,8 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $this->assigned_item_obj_id = $a_obj_id;
         $this->assigned_item_type = $a_item_type;
     }
-    
-    
+
+
     /**
      * Execute command
      */
@@ -148,7 +148,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $ilCtrl = $this->ctrl;
         $ilUser = $this->user;
         $ilTabs = $this->tabs;
-        
+
         $next_class = $ilCtrl->getNextClass();
 
         switch ($next_class) {
@@ -158,7 +158,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
                 break;
         }
     }
-    
+
     /**
      * Init creation forms
      */
@@ -167,15 +167,15 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $forms = array(
             self::CFORM_NEW => $this->initCreateForm("tax")
             );
-        
+
         return $forms;
     }
 
-    
+
     ////
     //// Features that work on the base of an assigend object (AO)
     ////
-    
+
     /**
      *
      *
@@ -187,8 +187,8 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $ilToolbar = $this->toolbar;
         $ilCtrl = $this->ctrl;
         $lng = $this->lng;
-        
-        
+
+
         //		if (count($tax_ids) != 0 && !$this->getMultiple())
         //		{
         //			$this->listNodes();
@@ -197,11 +197,11 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         //		{
         $this->listTaxonomies();
         //		}
-        
+
         // currently we support only one taxonomy, otherwise we may need to provide
         // a list here
     }
-    
+
     /**
      * Get current taxonomy id
      *
@@ -217,8 +217,8 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         }
         return false;
     }
-    
-    
+
+
     /**
      * Get current taxonomy
      *
@@ -232,11 +232,11 @@ class ilObjTaxonomyGUI extends ilObject2GUI
             $tax = new ilObjTaxonomy($tax_id);
             return $tax;
         }
-        
+
         return false;
     }
-    
-    
+
+
     /**
      * List items
      *
@@ -249,21 +249,21 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $ilToolbar = $this->toolbar;
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-        
+
         $tax = $this->getCurrentTaxonomy();
-        
+
         $this->setTabs("list_items");
-        
+
         // show toolbar
         $ilToolbar->setFormAction($ilCtrl->getFormAction($this));
         $ilToolbar->addFormButton($lng->txt("tax_create_node"), "createTaxNode");
-        
+
         $ilToolbar->setCloseFormTag(false);
-        
-        
+
+
         // show tree
         $this->showTree();
-        
+
         // show subitems
         include_once("./Services/Taxonomy/classes/class.ilTaxonomyTableGUI.php");
         $table = new ilTaxonomyTableGUI(
@@ -277,8 +277,8 @@ class ilObjTaxonomyGUI extends ilObject2GUI
 
         $tpl->setContent($table->getHTML());
     }
-    
-    
+
+
     /**
      * Create assigned taxonomy
      *
@@ -289,8 +289,8 @@ class ilObjTaxonomyGUI extends ilObject2GUI
     {
         $this->create();
     }
-    
-    
+
+
     /**
      * If we run under an assigned object, the permission should be checked on
      * the upper level
@@ -303,7 +303,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
             return parent::checkPermissionBool($a_perm, $a_cmd, $a_type, $a_node_id);
         }
     }
-    
+
     /**
      * Cancel creation
      *
@@ -313,14 +313,14 @@ class ilObjTaxonomyGUI extends ilObject2GUI
     public function cancel()
     {
         $ilCtrl = $this->ctrl;
-        
+
         if ($this->getAssignedObject() > 0) {
             $ilCtrl->redirect($this, "listTaxonomies");
         }
-        
+
         return parent::cancel();
     }
-    
+
     /**
      * Save taxonomy
      *
@@ -330,14 +330,14 @@ class ilObjTaxonomyGUI extends ilObject2GUI
     public function save()
     {
         $ilCtrl = $this->ctrl;
-        
+
         if ($this->getAssignedObject() > 0) {
             $_REQUEST["new_type"] = "tax";
         }
-        
+
         parent::saveObject();
     }
-    
+
     /**
      * After saving,
      *
@@ -371,7 +371,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $lng = $this->lng;
 
         $tax = $this->getCurrentTaxonomy();
-        
+
         include_once("./Services/Taxonomy/classes/class.ilTaxonomyExplorerGUI.php");
         $cmd = $a_ass_items
             ? "listAssignedItems"
@@ -389,7 +389,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         }
         return;
     }
-    
+
     /**
      * Get tree html
      *
@@ -418,7 +418,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         }
         return;
     }
-    
+
 
     /**
      * Create tax node
@@ -433,12 +433,12 @@ class ilObjTaxonomyGUI extends ilObject2GUI
 
         $this->setTabs("list_items");
         $ilHelp->setSubScreenId("create_node");
-        
+
         $this->initTaxNodeForm("create");
         $tpl->setContent($this->form->getHTML());
     }
-    
-    
+
+
     /**
      * Init tax node form
      *
@@ -448,14 +448,14 @@ class ilObjTaxonomyGUI extends ilObject2GUI
     {
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-    
+
         include_once("Services/Form/classes/class.ilPropertyFormGUI.php");
         $this->form = new ilPropertyFormGUI();
 
         // title
         $ti = new ilTextInputGUI($this->lng->txt("title"), "title");
         $this->form->addItem($ti);
-        
+
         // order nr
         $tax = $this->getCurrentTaxonomy();
         if ($tax->getSortingMode() == ilObjTaxonomy::SORT_MANUAL) {
@@ -464,13 +464,13 @@ class ilObjTaxonomyGUI extends ilObject2GUI
             $or->setSize(5);
             $this->form->addItem($or);
         }
-        
+
         if ($a_mode == "edit") {
             $node = new ilTaxonomyNode((int) $_GET["tax_node"]);
             $ti->setValue($node->getTitle());
             $or->setValue($node->getOrderNr());
         }
-        
+
         // save and cancel commands
         if ($a_mode == "create") {
             $this->form->addCommandButton("saveTaxNode", $lng->txt("save"));
@@ -481,10 +481,10 @@ class ilObjTaxonomyGUI extends ilObject2GUI
             $this->form->addCommandButton("listNodes", $lng->txt("cancel"));
             $this->form->setTitle($lng->txt("tax_edit_tax_node"));
         }
-                    
+
         $this->form->setFormAction($ilCtrl->getFormAction($this));
     }
-    
+
     /**
      * Save tax node form
      *
@@ -494,16 +494,16 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $tpl = $this->tpl;
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-    
+
         $this->initTaxNodeForm("create");
         if ($this->form->checkInput()) {
             $tax = $this->getCurrentTaxonomy();
-            
+
             // create node
             include_once("./Services/Taxonomy/classes/class.ilTaxonomyNode.php");
             $node = new ilTaxonomyNode();
             $node->setTitle($this->form->getInput("title"));
-            
+
             $tax = $this->getCurrentTaxonomy();
             if ($tax->getSortingMode() == ilObjTaxonomy::SORT_MANUAL) {
                 $order_nr = $this->form->getInput("order_nr");
@@ -515,12 +515,12 @@ class ilObjTaxonomyGUI extends ilObject2GUI
             $node->setOrderNr($order_nr);
             $node->setTaxonomyId($tax->getId());
             $node->create();
-            
+
             // put in tree
             ilTaxonomyNode::putInTree($tax->getId(), $node, (int) $_GET["tax_node"]);
-            
+
             ilTaxonomyNode::fixOrderNumbers($tax->getId(), (int) $_GET["tax_node"]);
-            
+
             ilUtil::sendSuccess($lng->txt("msg_obj_modified"), true);
             $ilCtrl->redirect($this, "listNodes");
         } else {
@@ -528,8 +528,8 @@ class ilObjTaxonomyGUI extends ilObject2GUI
             $tpl->setContent($this->form->getHtml());
         }
     }
-    
-    
+
+
     /**
      * Update tax node
      */
@@ -538,7 +538,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
         $tpl = $this->tpl;
-        
+
         $this->initTaxNodeForm("edit");
         if ($this->form->checkInput()) {
             // create node
@@ -559,7 +559,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
             $tpl->setContent($this->form->getHtml());
         }
     }
-    
+
     /**
      * Confirm deletion screen for items
      */
@@ -580,7 +580,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $ilHelp->setSubScreenId("del_items");
 
         //		$ilTabs->clearTargets();
-        
+
         include_once("./Services/Utilities/classes/class.ilConfirmationGUI.php");
         $confirmation_gui = new ilConfirmationGUI();
 
@@ -609,7 +609,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
     public function confirmedDelete()
     {
         $ilCtrl = $this->ctrl;
-        
+
         include_once("./Services/Taxonomy/classes/class.ilTaxonomyNode.php");
 
         // delete all selected objects
@@ -629,7 +629,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
 
         // feedback
         ilUtil::sendInfo($this->lng->txt("info_deleted"), true);
-        
+
         $ilCtrl->redirect($this, "listNodes");
     }
 
@@ -643,7 +643,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
     {
         $ilCtrl = $this->ctrl;
         $lng = $this->lng;
-        
+
         // save sorting
         include_once("./Services/Taxonomy/classes/class.ilTaxonomyNode.php");
         if (is_array($_POST["order"])) {
@@ -654,7 +654,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
             }
             ilTaxonomyNode::fixOrderNumbers($this->getCurrentTaxonomyId(), (int) $_GET["tax_node"]);
         }
-        
+
         // save titles
         if (is_array($_POST["title"])) {
             foreach ($_POST["title"] as $k => $v) {
@@ -665,11 +665,11 @@ class ilObjTaxonomyGUI extends ilObject2GUI
             }
         }
 
-        
+
         ilUtil::sendSuccess($lng->txt("msg_obj_modified"));
         $ilCtrl->redirect($this, "listNodes");
     }
-    
+
     /**
      * Move items
      */
@@ -693,12 +693,12 @@ class ilObjTaxonomyGUI extends ilObject2GUI
             $lng->txt("cancel"),
             $ilCtrl->getLinkTarget($this, "listNodes")
         );
-        
+
         ilUtil::sendInfo($lng->txt("tax_please_select_target"));
-        
+
         if (is_array($_POST["id"])) {
-            $ilCtrl->setParameter($this, "move_ids", implode($_POST["id"], ","));
-            
+            $ilCtrl->setParameter($this, "move_ids", implode(",", $_POST["id"]));
+
             $ilUser = $this->user;
             $tpl = $this->tpl;
             $ilCtrl = $this->ctrl;
@@ -718,7 +718,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
             }
         }
     }
-    
+
     /**
      * Paste items (move operation)
      */
@@ -732,7 +732,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
             $move_ids = explode(",", $_GET["move_ids"]);
             $tax = $this->getCurrentTaxonomy();
             $tree = $tax->getTree();
-            
+
             include_once("./Services/Taxonomy/classes/class.ilTaxonomyNode.php");
             $target_node = new ilTaxonomyNode((int) $_GET["tax_node"]);
             foreach ($move_ids as $m_id) {
@@ -746,7 +746,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
                         ilUtil::sendFailure($lng->txt("tax_target_within_nodes"), true);
                         $this->ctrl->redirect($this, "listNodes");
                     }
-                    
+
                     // if target is not current place, move
                     $parent_id = $tree->getParentId((int) $m_id);
                     if ($parent_id != $target_node->getId()) {
@@ -761,7 +761,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         ilUtil::sendSuccess($lng->txt("msg_obj_modified"), true);
         $ilCtrl->redirect($this, "listNodes");
     }
-    
+
     /**
      * Confirm taxonomy deletion
      */
@@ -772,19 +772,19 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $lng = $this->lng;
 
         $tax = $this->getCurrentTaxonomy();
-        
+
         include_once("./Services/Utilities/classes/class.ilConfirmationGUI.php");
         $cgui = new ilConfirmationGUI();
         $cgui->setFormAction($ilCtrl->getFormAction($this));
         $cgui->setHeaderText($lng->txt("tax_confirm_deletion"));
         $cgui->setCancel($lng->txt("cancel"), "listTaxonomies");
         $cgui->setConfirm($lng->txt("delete"), "deleteTaxonomy");
-        
+
         $cgui->addItem("id[]", $i, $tax->getTitle());
-        
+
         $tpl->setContent($cgui->getHTML());
     }
-    
+
     /**
      * Delete taxonomy
      *
@@ -795,10 +795,10 @@ class ilObjTaxonomyGUI extends ilObject2GUI
     {
         $ilCtrl = $this->ctrl;
         $lng = $this->lng;
-        
+
         $tax = $this->getCurrentTaxonomy();
         $tax->delete();
-        
+
         ilUtil::sendSuccess($lng->txt("tax_tax_deleted"), true);
         $ilCtrl->redirect($this, "listTaxonomies");
     }
@@ -815,7 +815,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $ilToolbar = $this->toolbar;
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-        
+
         $tax_ids = ilObjTaxonomy::getUsageOfObject($this->getAssignedObject());
         if (count($tax_ids) == 0 || $this->getMultiple()) {
             $ilToolbar->addButton(
@@ -825,19 +825,19 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         } else {
             ilUtil::sendInfo($lng->txt("tax_max_one_tax"));
         }
-        
+
         include_once("./Services/Taxonomy/classes/class.ilTaxonomyListTableGUI.php");
-        
+
         $tab = new ilTaxonomyListTableGUI(
             $this,
             "listTaxonomies",
             $this->getAssignedObject(),
             $this->getListInfo()
         );
-        
+
         $tpl->setContent($tab->getHTML());
     }
-    
+
     /**
      * Set tabs
      *
@@ -850,7 +850,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $tpl = $this->tpl;
         $lng = $this->lng;
         $ilHelp = $this->help;
-        
+
         $ilTabs->clearTargets();
 
         $ilHelp->setScreenIdComponent("tax");
@@ -859,12 +859,12 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $tpl->setTitle(ilObject::_lookupTitle($this->getCurrentTaxonomyId()));
         $tpl->setDescription(ilObject::_lookupDescription($this->getCurrentTaxonomyId()));
         $tpl->setTitleIcon(ilUtil::getImagePath("icon_tax.svg"));
-        
+
         $ilTabs->setBackTarget(
             $lng->txt("back"),
             $ilCtrl->getLinkTarget($this, "listTaxonomies")
         );
-        
+
         $ilTabs->addTab(
             "list_items",
             $lng->txt("tax_nodes"),
@@ -882,10 +882,10 @@ class ilObjTaxonomyGUI extends ilObject2GUI
             $lng->txt("settings"),
             $ilCtrl->getLinkTarget($this, "editSettings")
         );
-        
+
         $ilTabs->activateTab($a_id);
     }
-    
+
     /**
      * Edit settings
      *
@@ -895,13 +895,13 @@ class ilObjTaxonomyGUI extends ilObject2GUI
     public function editSettings()
     {
         $tpl = $this->tpl;
-        
+
         $this->setTabs("settings");
-        
+
         $form = $this->initSettingsForm();
         $tpl->setContent($form->getHTML());
     }
-    
+
     /**
      * Init  form.
      */
@@ -909,18 +909,18 @@ class ilObjTaxonomyGUI extends ilObject2GUI
     {
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-    
+
         $tax = $this->getCurrentTaxonomy();
-        
+
         include_once("Services/Form/classes/class.ilPropertyFormGUI.php");
         $form = new ilPropertyFormGUI();
-    
+
         // title
         $ti = new ilTextInputGUI($lng->txt("title"), "title");
         $ti->setMaxLength(200);
         $form->addItem($ti);
         $ti->setValue($tax->getTitle());
-        
+
         // description
         $ta = new ilTextAreaInputGUI($lng->txt("description"), "description");
         //$ta->setCols();
@@ -937,22 +937,22 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $si->setOptions($options);
         $form->addItem($si);
         $si->setValue($tax->getSortingMode());
-        
+
         // assigned item sorting
         if ($this->assigned_item_sorting) {
             $cb = new ilCheckboxInputGUI($lng->txt("tax_item_sorting"), "item_sorting");
             $cb->setChecked($tax->getItemSorting());
             $form->addItem($cb);
         }
-    
+
         $form->addCommandButton("updateSettings", $lng->txt("save"));
-                    
+
         $form->setTitle($lng->txt("settings"));
         $form->setFormAction($ilCtrl->getFormAction($this));
-        
+
         return $form;
     }
-    
+
     /**
      * Update taxonomy settings
      */
@@ -961,7 +961,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $tpl = $this->tpl;
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-    
+
         $form = $this->initSettingsForm();
         if ($form->checkInput()) {
             $tax = $this->getCurrentTaxonomy();
@@ -978,7 +978,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
             $tpl->setContent($form->getHtml());
         }
     }
-    
+
     /**
      * List assigned items
      *
@@ -991,14 +991,14 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $ilToolbar = $this->toolbar;
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-        
+
         $tax = $this->getCurrentTaxonomy();
-        
+
         $this->setTabs("ass_items");
-                
+
         // show tree
         $this->showTree(true);
-        
+
         // list assigned items
         include_once("./Services/Taxonomy/classes/class.ilTaxAssignedItemsTableGUI.php");
         $table = new ilTaxAssignedItemsTableGUI(
@@ -1025,7 +1025,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
     {
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-        
+
         include_once("./Services/Taxonomy/classes/class.ilTaxNodeAssignment.php");
         if (is_array($_POST["order"])) {
             $order = $_POST["order"];

--- a/Services/Tracking/classes/class.ilLPXmlWriter.php
+++ b/Services/Tracking/classes/class.ilLPXmlWriter.php
@@ -14,7 +14,7 @@ include_once "./Services/Xml/classes/class.ilXmlWriter.php";
 class ilLPXmlWriter extends ilXmlWriter
 {
     private $add_header = true;
-    
+
     private $timestamp = "";
     private $include_ref_ids = false;
     private $type_filter = array();
@@ -27,7 +27,7 @@ class ilLPXmlWriter extends ilXmlWriter
         $this->add_header = $a_add_header;
         parent::__construct();
     }
-    
+
     /**
      * Set timestamp
      *
@@ -37,7 +37,7 @@ class ilLPXmlWriter extends ilXmlWriter
     {
         $this->timestamp = $a_val;
     }
-    
+
     /**
      * Get timestamp
      *
@@ -47,7 +47,7 @@ class ilLPXmlWriter extends ilXmlWriter
     {
         return $this->timestamp;
     }
-    
+
     /**
      * Set include ref ids
      *
@@ -57,7 +57,7 @@ class ilLPXmlWriter extends ilXmlWriter
     {
         $this->include_ref_ids = $a_val;
     }
-    
+
     /**
      * Get include ref ids
      *
@@ -67,7 +67,7 @@ class ilLPXmlWriter extends ilXmlWriter
     {
         return $this->include_ref_ids;
     }
-    
+
     /**
      * Set type filter
      *
@@ -77,7 +77,7 @@ class ilLPXmlWriter extends ilXmlWriter
     {
         $this->type_filter = $a_val;
     }
-    
+
     /**
      * Get type filter
      *
@@ -87,7 +87,7 @@ class ilLPXmlWriter extends ilXmlWriter
     {
         return $this->type_filter;
     }
-    
+
     /**
      * Write XML
      * @return
@@ -101,7 +101,7 @@ class ilLPXmlWriter extends ilXmlWriter
         }
         $this->addLPInformation();
     }
-    
+
     /**
      * Build XML header
      * @return
@@ -114,8 +114,8 @@ class ilLPXmlWriter extends ilXmlWriter
 
         return true;
     }
-    
-    
+
+
     /**
      * Init xml writer
      * @return bool
@@ -124,13 +124,13 @@ class ilLPXmlWriter extends ilXmlWriter
     protected function init()
     {
         $this->xmlClear();
-        
+
         /*		if(!$this->obj_id)
                 {
                     throw new UnexpectedValueException('No obj_id given: ');
                 }*/
     }
-    
+
     /**
      * Add lp information as xml
      *
@@ -142,9 +142,9 @@ class ilLPXmlWriter extends ilXmlWriter
         global $DIC;
 
         $ilDB = $DIC['ilDB'];
-        
+
         $this->xmlStartTag('LPData', array());
-        
+
         $set = $ilDB->query(
             $q = "SELECT * FROM ut_lp_marks " .
             " WHERE status_changed >= " . $ilDB->quote($this->getTimestamp(), "timestamp")
@@ -155,7 +155,7 @@ class ilLPXmlWriter extends ilXmlWriter
             if ($this->getIncludeRefIds()) {
                 $ref_ids = ilObject::_getAllReferences($rec["obj_id"]);
             }
-            
+
             if (!is_array($this->getTypeFilter()) ||
                 (count($this->getTypeFilter()) == 0) ||
                 in_array(ilObject::_lookupType($rec["obj_id"]), $this->getTypeFilter())) {
@@ -164,14 +164,14 @@ class ilLPXmlWriter extends ilXmlWriter
                     array(
                         'UserId' => $rec["usr_id"],
                         'ObjId' => $rec["obj_id"],
-                        'RefIds' => implode($ref_ids, ","),
+                        'RefIds' => implode(",", $ref_ids),
                         'Timestamp' => $rec["status_changed"],
                         'LPStatus' => $rec["status"]
                         )
                 );
             }
         }
-        
+
         $this->xmlEndTag('LPData');
     }
 }

--- a/Services/UICore/lib/html-it/IT.php
+++ b/Services/UICore/lib/html-it/IT.php
@@ -911,7 +911,7 @@ class HTML_Template_IT
      */
     public function getFile($filename)
     {
-        if ($filename{0} == '/' && substr($this->fileRoot, -1) == '/') {
+        if ($filename[0] == '/' && substr($this->fileRoot, -1) == '/') {
             $filename = substr($filename, 1);
         }
 

--- a/Services/UICore/lib/html-it/ITX.php
+++ b/Services/UICore/lib/html-it/ITX.php
@@ -613,7 +613,7 @@ class HTML_Template_ITX extends HTML_Template_IT
 
             while ($head != '' && $args2 = $this->getValue($head, ',')) {
                 $arg2 = trim($args2);
-                $args[] = ('"' == $arg2{0} || "'" == $arg2{0}) ?
+                $args[] = ('"' == $arg2[0] || "'" == $arg2[0]) ?
                                     substr($arg2, 1, -1) : $arg2;
                 if ($arg2 == $head) {
                     break;

--- a/Services/User/classes/class.ilUserQuery.php
+++ b/Services/User/classes/class.ilUserQuery.php
@@ -55,7 +55,7 @@ class ilUserQuery
         "last_login",
         "active"
     );
-    
+
     /**
      * Constructor
      */
@@ -84,7 +84,7 @@ class ilUserQuery
         }
         $this->udf_filter = $valid_udfs;
     }
-    
+
     /**
      * Get udf filter
      *
@@ -94,7 +94,7 @@ class ilUserQuery
     {
         return $this->udf_filter;
     }
-    
+
     /**
      * Set order field (column in usr_data)
      * Default order is 'login'
@@ -104,7 +104,7 @@ class ilUserQuery
     {
         $this->order_field = $a_order;
     }
-    
+
     /**
      * Set order direction
      * 'asc' or 'desc'
@@ -115,7 +115,7 @@ class ilUserQuery
     {
         $this->order_dir = $a_dir;
     }
-    
+
     /**
      * Set offset
      * @param int $a_offset
@@ -124,7 +124,7 @@ class ilUserQuery
     {
         $this->offset = $a_offset;
     }
-    
+
     /**
      * Set result limit
      * Default is 50
@@ -134,7 +134,7 @@ class ilUserQuery
     {
         $this->limit = $a_limit;
     }
-    
+
     /**
      * Text (like) filter in login, firstname, lastname or email
      * @param string filter
@@ -143,7 +143,7 @@ class ilUserQuery
     {
         $this->text_filter = $a_filter;
     }
-    
+
     /**
      * Set activation filter
      * 'active' or 'inactive' or empty
@@ -153,7 +153,7 @@ class ilUserQuery
     {
         $this->activation = $a_activation;
     }
-    
+
     /**
      * Set last login filter
      * @param ilDateTime $dt
@@ -162,7 +162,7 @@ class ilUserQuery
     {
         $this->last_login = $dt;
     }
-    
+
     /**
      * Enable limited access filter
      * @param bool
@@ -171,7 +171,7 @@ class ilUserQuery
     {
         $this->limited_access = $a_status;
     }
-    
+
     /**
      * Enable no course filter
      * @param bool $a_no_course
@@ -180,7 +180,7 @@ class ilUserQuery
     {
         $this->no_courses = $a_no_course;
     }
-    
+
     /**
      * Enable no group filter
      * @param bool $a_no_group
@@ -189,7 +189,7 @@ class ilUserQuery
     {
         $this->no_groups = $a_no_group;
     }
-    
+
     /**
      * Set course / group filter
      * object_id of course or group
@@ -199,7 +199,7 @@ class ilUserQuery
     {
         $this->crs_grp = $a_cg_id;
     }
-    
+
     /**
      * Set role filter
      * obj_id of role
@@ -209,7 +209,7 @@ class ilUserQuery
     {
         $this->role = $a_role_id;
     }
-    
+
     /**
      * Set user folder filter
      * reference id of user folder or category (local user administration)
@@ -219,7 +219,7 @@ class ilUserQuery
     {
         $this->user_folder = $a_fold_id;
     }
-    
+
     /**
      * Set additional fields (columns in usr_data or 'online_time')
      * @param array $additional_fields
@@ -228,7 +228,7 @@ class ilUserQuery
     {
         $this->additional_fields = (array) $a_add;
     }
-    
+
     /**
      * Array with user ids to query against
      * @param array $a_filter
@@ -237,7 +237,7 @@ class ilUserQuery
     {
         $this->users = $a_filter;
     }
-    
+
     /**
      * set first letter lastname filter
      * @param string $a_fll
@@ -266,7 +266,7 @@ class ilUserQuery
     {
         $this->authentication_method = $a_authentication;
     }
-    
+
     /**
      * Query usr_data
      * @return array ('cnt', 'set')
@@ -315,16 +315,16 @@ class ilUserQuery
         // count query
         $count_query = "SELECT count(usr_data.usr_id) cnt" .
             " FROM usr_data";
-        
+
         $all_multi_fields = array("interests_general", "interests_help_offered", "interests_help_looking");
         $multi_fields = array();
-        
+
         $sql_fields = array();
         foreach ($this->default_fields as $idx => $field) {
             if (!$field) {
                 continue;
             }
-            
+
             if (in_array($field, $all_multi_fields)) {
                 $multi_fields[] = $field;
             } elseif (!stristr($field, ".")) {
@@ -340,7 +340,7 @@ class ilUserQuery
         }
 
         // basic query
-        $query = "SELECT " . implode($sql_fields, ",") .
+        $query = "SELECT " . implode(",", $sql_fields) .
             " FROM usr_data" .
             $join;
 
@@ -367,7 +367,7 @@ class ilUserQuery
             $count_query .= $add;
             $where = " AND";
         }
-        
+
         if ($this->text_filter != "") {		// email, name, login
             $add = $where . " (" . $ilDB->like("usr_data.login", "text", "%" . $this->text_filter . "%") . " " .
                 "OR " . $ilDB->like("usr_data.firstname", "text", "%" . $this->text_filter . "%") . " " .
@@ -378,7 +378,7 @@ class ilUserQuery
             $count_query .= $add;
             $where = " AND";
         }
-        
+
         if ($this->activation != "") {		// activation
             if ($this->activation == "inactive") {
                 $add = $where . " usr_data.active = " . $ilDB->quote(0, "integer") . " ";
@@ -471,7 +471,7 @@ class ilUserQuery
             $count_query .= $add;
             $where = " AND";
         }
-        
+
         if ($this->user_folder) {
             $add = $where . " " . $ilDB->in('usr_data.time_limit_owner', $this->user_folder, false, 'integer');
             $query .= $add;
@@ -495,7 +495,7 @@ class ilUserQuery
                     $query .= " ORDER BY usr_data.active ASC, usr_data.time_limit_unlimited ASC, usr_data.time_limit_until ASC";
                 }
                 break;
-                
+
             case "online_time":
                 if ($this->order_dir == "desc") {
                     $query .= " ORDER BY ut_online.online_time DESC";
@@ -503,7 +503,7 @@ class ilUserQuery
                     $query .= " ORDER BY ut_online.online_time ASC";
                 }
                 break;
-                
+
             default:
                 if ($this->order_dir != "asc" && $this->order_dir != "desc") {
                     $this->order_dir = "asc";
@@ -533,18 +533,18 @@ class ilUserQuery
 
         $offset = (int) $this->offset;
         $limit = (int) $this->limit;
-        
+
         // #9866: validate offset against rowcount
         if ($offset >= $cnt) {
             $offset = 0;
         }
-        
+
         $ilDB->setLimit($limit, $offset);
-        
+
         if (sizeof($multi_fields)) {
             $usr_ids = array();
         }
-        
+
         // set query
         $set = $ilDB->query($query);
         $result = array();
@@ -572,8 +572,8 @@ class ilUserQuery
         }
         return array("cnt" => $cnt, "set" => $result);
     }
-    
-    
+
+
     /**
      * Get data for user administration list.
      * @deprecated

--- a/Services/Utilities/classes/class.ilUtil.php
+++ b/Services/Utilities/classes/class.ilUtil.php
@@ -99,7 +99,7 @@ class ilUtil
         require_once("./Services/Style/System/classes/class.ilStyleDefinition.php");
         $current_skin = ilStyleDefinition::getCurrentSkin();
         $current_style = ilStyleDefinition::getCurrentStyle();
-        
+
         if (is_object($styleDefinition)) {
             $image_dir = $styleDefinition->getImageDirectory($current_style);
         }
@@ -176,7 +176,7 @@ class ilUtil
         global $DIC;
 
         $ilSetting = $DIC->settings();
-        
+
         // add version as parameter to force reload for new releases
         // use ilStyleDefinition instead of account to get the current style
         require_once("./Services/Style/System/classes/class.ilStyleDefinition.php");
@@ -378,7 +378,7 @@ class ilUtil
             $sty = ($style != "")
                 ? ' style="' . $style . '" '
                 : "";
-                
+
             if ($direct_text) {
                 $str .= " <option $sty value=\"" . $key . "\"";
             } else {
@@ -509,7 +509,7 @@ class ilUtil
         if ($onclick) {
             $str .= ('onclick="' . $onclick . '"');
         }
-        
+
         $str .= (" type=\"radio\" name=\"" . $varname . "\"");
         if ($checked == 1) {
             $str .= " checked=\"checked\"";
@@ -769,7 +769,7 @@ class ilUtil
 
         // mask existing image tags
         $ret = str_replace('src="http://', '"***masked_im_start***', $ret);
-        
+
         include_once("./Services/Utilities/classes/class.ilMWParserAdapter.php");
         $parser = new ilMWParserAdapter();
         $ret = $parser->replaceFreeExternalLinks($ret);
@@ -884,9 +884,9 @@ class ilUtil
                 $sel_day .= ($name . '="' . $value . '" ');
             }
         }
-        
+
         $sel_day .= $disabled . "name=\"" . $prefix . "[d]\" id=\"" . $prefix . "_d\">\n";
-        
+
         if ($emptyoption) {
             $sel_day .= "<option value=\"0\">--</option>\n";
         }
@@ -1103,7 +1103,7 @@ class ilUtil
         global $DIC;
 
         $lng = $DIC->language();
-        
+
         include_once('./Services/PrivacySecurity/classes/class.ilSecuritySettings.php');
         $security = ilSecuritySettings::_getInstance();
 
@@ -1112,16 +1112,16 @@ class ilUtil
             $customError = $lng->txt('password_empty');
             return false;
         }
-        
+
         $isPassword = true;
         $errors = array();
-        
+
         // check if password to short
         if ($security->getPasswordMinLength() > 0 && strlen($a_passwd) < $security->getPasswordMinLength()) {
             $errors[] = sprintf($lng->txt('password_to_short'), $security->getPasswordMinLength());
             $isPassword = false;
         }
-        
+
         // check if password not to long
         // Hmmmmm, maybe we should discuss this limitation. In my opinion it is stupid to limit the password length ;-). There should only be a technical limitation (field size in database).
         if ($security->getPasswordMaxLength() > 0 && strlen($a_passwd) > $security->getPasswordMaxLength()) {
@@ -1172,13 +1172,13 @@ class ilUtil
                 $isPassword = false;
             }
         }
-        
+
         // ensure password matches the positive list of chars/special-chars
         if (!preg_match(self::getPasswordValidChars(), $a_passwd)) {
             $errors[] = $lng->txt('password_contains_invalid_chars');
             $isPassword = false;
         }
-        
+
         // build custom error message
         if (count($errors) == 1) {
             $customError = $errors[0];
@@ -1261,14 +1261,14 @@ class ilUtil
 
         include_once('./Services/PrivacySecurity/classes/class.ilSecuritySettings.php');
         $security = ilSecuritySettings::_getInstance();
-        
+
         $infos = array(sprintf($lng->txt('password_allow_chars'), self::getPasswordValidChars(false)));
-                
+
         // check if password to short
         if ($security->getPasswordMinLength() > 0) {
             $infos[] = sprintf($lng->txt('password_to_short'), $security->getPasswordMinLength());
         }
-        
+
         // check if password not to long
         if ($security->getPasswordMaxLength() > 0) {
             $infos[] = sprintf($lng->txt('password_to_long'), $security->getPasswordMaxLength());
@@ -1390,7 +1390,7 @@ class ilUtil
     {
         include_once("./Services/Utilities/classes/class.ilStr.php");
         $str_arr = explode(" ", $a_str);
-        
+
         for ($i = 0; $i < count($str_arr); $i++) {
             if (ilStr::strLen($str_arr[$i]) > $a_len) {
                 $str_arr[$i] = ilStr::subStr($str_arr[$i], 0, $a_len);
@@ -1399,8 +1399,8 @@ class ilUtil
                 }
             }
         }
-        
-        return implode($str_arr, " ");
+
+        return implode(" ", $str_arr);
     }
 
     /**
@@ -1601,7 +1601,7 @@ class ilUtil
         if (!is_file($a_file)) {
             return;
         }
-        
+
         // if flat, move file to temp directory first
         if ($a_flat) {
             $tmpdir = ilUtil::ilTempnam();
@@ -1611,7 +1611,7 @@ class ilUtil
             $a_file = $tmpdir . DIRECTORY_SEPARATOR . basename($a_file);
             $origpathinfo = pathinfo($orig_file);
         }
-        
+
         $pathinfo = pathinfo($a_file);
         $dir = $pathinfo["dirname"];
         $file = $pathinfo["basename"];
@@ -1712,7 +1712,7 @@ class ilUtil
             $pathinfo = pathinfo($a_dir);
             chdir($pathinfo["dirname"]);
         }
-        
+
         $pathinfo = pathinfo($a_file);
         $dir = $pathinfo["dirname"];
         $file = $pathinfo["basename"];
@@ -1722,7 +1722,7 @@ class ilUtil
         }
 
         $zip = PATH_TO_ZIP;
-        
+
         if (!$zip) {
             chdir($cdir);
             return false;
@@ -1755,7 +1755,7 @@ class ilUtil
 
         $pathinfo = pathinfo($a_dir);
         chdir($pathinfo["dirname"]);
-        
+
         $pathinfo = pathinfo($a_file);
         $dir = $pathinfo["dirname"];
         $file = $pathinfo["basename"];
@@ -1766,7 +1766,7 @@ class ilUtil
             chdir($cdir);
             return false;
         }
-        
+
         $name = basename($a_dir);
         $source = ilUtil::escapeShellArg($name);
 
@@ -1775,7 +1775,7 @@ class ilUtil
         chdir($cdir);
         return true;
     }
-    
+
     /**
     * get convert command
     *
@@ -1788,7 +1788,7 @@ class ilUtil
     {
         return PATH_TO_CONVERT;
     }
-    
+
     /**
      * execute convert command
      *
@@ -1800,7 +1800,7 @@ class ilUtil
     {
         ilUtil::execQuoted(PATH_TO_CONVERT, $args);
     }
-    
+
     /**
      * Compare convert version numbers
      *
@@ -1817,7 +1817,7 @@ class ilUtil
         }
         return false;
     }
-    
+
     /**
      * Parse convert version string, e.g. 6.3.8-3, into integer
      *
@@ -1862,7 +1862,7 @@ class ilUtil
                 $geometry = " -geometry " . $a_geometry . "x" . $a_geometry . " ";
             }
         }
-        
+
         $bg_color = ($a_background_color != "")
             ? " -background color " . $a_background_color . " "
             : "";
@@ -1892,7 +1892,7 @@ class ilUtil
 
         ilUtil::execConvert($convert_cmd);
     }
-    
+
     /**
     * Build img tag
     *
@@ -1934,7 +1934,7 @@ class ilUtil
         //		$mime = "application/octet-stream"; // or whatever the mime type is
 
         include_once './Services/Http/classes/class.ilHTTPS.php';
-        
+
         //if($_SERVER['HTTPS'])
         if (ilHTTPS::getInstance()->isDetected()) {
 
@@ -2066,18 +2066,18 @@ class ilUtil
 
         /// $ascii_filename = mb_convert_encoding($a_filename,'US-ASCII','UTF-8');
         /// $ascii_filename = preg_replace('/\&(.)[^;]*;/','\\1', $ascii_filename);
-                
+
         // #15914 - try to fix german umlauts
         $umlauts = array("Ä" => "Ae", "Ö" => "Oe", "Ü" => "Ue",
             "ä" => "ae", "ö" => "oe", "ü" => "ue", "ß" => "ss");
         foreach ($umlauts as $src => $tgt) {
             $a_filename = str_replace($src, $tgt, $a_filename);
         }
-        
+
         $ascii_filename = htmlentities($a_filename, ENT_NOQUOTES, 'UTF-8');
         $ascii_filename = preg_replace('/\&(.)[^;]*;/', '\\1', $ascii_filename);
         $ascii_filename = preg_replace('/[\x7f-\xff]/', '_', $ascii_filename);
-        
+
         // OS do not allow the following characters in filenames: \/:*?"<>|
         $ascii_filename = preg_replace('/[:\x5c\/\*\?\"<>\|]/', '_', $ascii_filename);
         return $ascii_filename;
@@ -2137,7 +2137,7 @@ class ilUtil
         $amp = $xml_style
             ? "&amp;"
             : "&";
-        
+
         $url = (is_int(strpos($a_url, "?")))
             ? $a_url . $amp . $a_par
             : $a_url . "?" . $a_par;
@@ -2372,7 +2372,7 @@ class ilUtil
 
         return $df->clientId($clientId);
     }
-    
+
     /**
     * Strip slashes from array and sub-arrays
     *
@@ -2412,7 +2412,7 @@ class ilUtil
         //echo "<br>-".htmlentities(ilUtil::secureString($a_str, $a_strip_html, $a_allow));
         return ilUtil::secureString($a_str, $a_strip_html, $a_allow);
     }
-    
+
     /**
     * strip slashes if magic qoutes is enabled
     *
@@ -3022,7 +3022,7 @@ class ilUtil
             // occured in: setup -> new client -> install languages -> sorting of languages
             $array_sortby = 0;
         }
-        
+
         // this comparison should give optimal results if
         // locale is provided and mb string functions are supported
         if ($array_sortorder == "asc") {
@@ -3077,7 +3077,7 @@ class ilUtil
         $a_keep_keys = false
     ) {
         include_once("./Services/Utilities/classes/class.ilStr.php");
-        
+
         // BEGIN WebDAV: Provide a 'stable' sort algorithm
         if (!$a_keep_keys) {
             return self::stableSortArray($array, $a_array_sortby, $a_array_sortorder, $a_numeric, $a_keep_keys);
@@ -3437,7 +3437,7 @@ class ilUtil
         setlocale(LC_CTYPE, "UTF8", "en_US.UTF-8"); // fix for PHP escapeshellcmd bug. See: http://bugs.php.net/bug.php?id=45132
         return escapeshellcmd($a_arg);
     }
-    
+
     /**
      * exec command and fix spaces on windows
      *
@@ -3450,7 +3450,7 @@ class ilUtil
     public static function execQuoted($cmd, $args = null)
     {
         global $DIC;
-        
+
         if (ilUtil::isWindows() && strpos($cmd, " ") !== false && substr($cmd, 0, 1) !== '"') {
             // cmd won't work without quotes
             $cmd = '"' . $cmd . '"';
@@ -3514,7 +3514,7 @@ class ilUtil
         $difference = $target_time - $starting_time;
         $days = (($difference - ($difference % 86400)) / 86400);
         $difference = $difference - ($days * 86400) + 3600;
-        
+
         // #15343 - using a global locale leads to , instead of . for (implicit) floats
         return str_replace(",", ".", ($days + 25570 + ($difference / 86400)));
     }
@@ -3663,7 +3663,7 @@ class ilUtil
     {
         $ret = array();
         srand((double) microtime() * 1000000);
-        
+
         include_once('./Services/PrivacySecurity/classes/class.ilSecuritySettings.php');
         $security = ilSecuritySettings::_getInstance();
 
@@ -3687,7 +3687,7 @@ class ilUtil
             $numbers = "1234567890";
             $special = "_.+?#-*@!$%~";
             $pw = "";
-            
+
             if ($security->getPasswordNumberOfUppercaseChars() > 0) {
                 for ($j = 0; $j < $security->getPasswordNumberOfUppercaseChars(); $j++) {
                     switch ($next) {
@@ -3695,7 +3695,7 @@ class ilUtil
                             $pw.= $consonants_uc[$random->int(0, strlen($consonants_uc) - 1)];
                             $next = 2;
                             break;
-                        
+
                         case 2:
                             $pw.= $vowels_uc[$random->int(0, strlen($vowels_uc) - 1)];
                             $next = 1;
@@ -3719,7 +3719,7 @@ class ilUtil
                         $pw.= $consonants[$random->int(0, strlen($consonants) - 1)];
                         $next = 2;
                         break;
-                    
+
                     case 2:
                         $pw.= $vowels[$random->int(0, strlen($vowels) - 1)];
                         $next = 1;
@@ -3728,7 +3728,7 @@ class ilUtil
             }
 
             $pw = str_shuffle($pw);
-        
+
             $ret[] = $pw;
         }
         return $ret;
@@ -3890,7 +3890,7 @@ class ilUtil
         list($std, $min, $sec) = explode(":", $uhrzeit);
         return mktime((int) $std, (int) $min, (int) $sec, (int) $monat, (int) $tag, (int) $jahr);
     }
-     
+
     /**
     * Return current timestamp in Y-m-d H:i:s format
     *
@@ -4076,12 +4076,12 @@ class ilUtil
             if ($counter >= $limit) {
                 break;
             }
-            
+
             // Filter objects in recovery folder
             if ($tree->isGrandChild(RECOVERY_FOLDER_ID, $row->ref_id)) {
                 continue;
             }
-            
+
             // Check deleted, hierarchical access ...
             if ($ilAccess->checkAccessOfUser($a_usr_id, $a_operation, '', $row->ref_id, $row->type, $row->obj_id)) {
                 $counter++;
@@ -4187,7 +4187,7 @@ class ilUtil
                 }
             }
         }
-        
+
         // since server side mathjax rendering does include svg-xml structures that indeed have linebreaks,
         // do latex conversion AFTER replacing linebreaks with <br>. <svg> tag MUST NOT contain any <br> tags.
         if ($prepare_for_latex_output) {
@@ -4203,7 +4203,7 @@ class ilUtil
             $result = str_replace("}", "&#125;", $result);
             $result = str_replace("\\", "&#92;", $result);
         }
-        
+
         return $result;
     }
 
@@ -4238,15 +4238,15 @@ class ilUtil
         global $DIC;
 
         $lng = $DIC->language();
-        
+
         if (!$a_to) {
             $a_to = new ilDateTime(time(), IL_CAL_UNIX);
         }
-        
+
         $from = new DateTime($a_from->get(IL_CAL_DATETIME));
         $to = new DateTime($a_to->get(IL_CAL_DATETIME));
         $diff = $to->diff($from);
-        
+
         $periods = array();
         $periods["years"] = $diff->format("%y");
         $periods["months"] = $diff->format("%m");
@@ -4267,7 +4267,7 @@ class ilUtil
                 $array[] = $value . ' ' . $lng->txt($segment_name);
             }
         }
-        
+
         $len = sizeof($array);
         if ($len > 3) {
             $array = array_slice($array, 0, (3 - $len));
@@ -4281,7 +4281,7 @@ class ilUtil
         $max_filesize = self::formatBytes(
             self::getUploadSizeLimitBytes()
         );
-        
+
         global $DIC;
 
         $lng = $DIC->language();
@@ -4308,17 +4308,17 @@ class ilUtil
 
         return round($size, $decimals) . $unit[$i];
     }
-    
+
     public static function getUploadSizeLimitBytes()
     {
         $uploadSizeLimitBytes = min(
             self::convertPhpIniSizeValueToBytes(ini_get('post_max_size')),
             self::convertPhpIniSizeValueToBytes(ini_get('upload_max_filesize'))
         );
-        
+
         return $uploadSizeLimitBytes;
     }
-    
+
     public static function convertPhpIniSizeValueToBytes($phpIniSizeValue)
     {
         if (is_numeric($phpIniSizeValue)) {
@@ -4327,7 +4327,7 @@ class ilUtil
 
         $suffix = substr($phpIniSizeValue, -1);
         $value = substr($phpIniSizeValue, 0, -1);
-        
+
         switch (strtoupper($suffix)) {
             case 'P':
                 $value *= 1024;
@@ -4345,7 +4345,7 @@ class ilUtil
                 $value *= 1024;
                 break;
         }
-        
+
         return $value;
     }
 
@@ -4628,7 +4628,7 @@ class ilUtil
         $random = new \ilRandom();
         return md5($random->int(1, 9999999) + str_replace(" ", "", (string) microtime()));
     }
-    
+
     public static function setCookie($a_cookie_name, $a_cookie_value = '', $a_also_set_super_global = true, $a_set_cookie_invalid = false)
     {
         /*
@@ -4661,23 +4661,23 @@ class ilUtil
             $secure,
             IL_COOKIE_HTTPONLY
         );
-                    
+
         if ((bool) $a_also_set_super_global) {
             $_COOKIE[$a_cookie_name] = $a_cookie_value;
         }
     }
-    
+
     public static function _sanitizeFilemame($a_filename)
     {
         return strip_tags(self::stripSlashes($a_filename));
     }
-    
+
     public static function _getHttpPath()
     {
         global $DIC;
 
         $ilIliasIniFile = $DIC["ilIliasIniFile"];
-        
+
         if ($_SERVER['SHELL'] || php_sapi_name() == 'cli' ||
             // fallback for windows systems, useful in crons
             (class_exists("ilContext") && !ilContext::usesHTTP())) {
@@ -4686,7 +4686,7 @@ class ilUtil
             return ILIAS_HTTP_PATH;
         }
     }
-    
+
     /**
      * printBacktrace
      *
@@ -4865,12 +4865,12 @@ class ilUtil
 
         fclose($fp);
     }
-    
-    
+
+
     //
     //  used to be in ilFormat
     //
-    
+
     /**
      * Returns the magnitude used for size units.
      *
@@ -4887,7 +4887,7 @@ class ilUtil
     {
         return 1024;
     }
-    
+
     /**
     * format a float
     *
@@ -4937,7 +4937,7 @@ class ilUtil
 
         return $txt;
     }
-    
+
     /**
      * Returns the specified file size value in a human friendly form.
      * <p>
@@ -4993,17 +4993,17 @@ class ilUtil
 
         return $result;
     }
-    
-    
+
+
     //
     // used for disk quotas
     //
-    
+
     public static function MB2Bytes($a_value)
     {
         return  ((int) $a_value) * pow(self::_getSizeMagnitude(), 2);
     }
-    
+
     public static function Bytes2MB($a_value)
     {
         return  ((int) $a_value) / (pow(self::_getSizeMagnitude(), 2));


### PR DESCRIPTION
implode ( string $glue , array $pieces )

implode() akzeptiert die Parameter aus historischen Gründen in beiden 
Reihenfolgen. Aufgrund der Konsistenz zu explode(), ist die nicht 
dokumentierte Reihenfolge allerdings missbilligt.

Fixed "Array and string offset access syntax with curly braces is 
deprecated", so $string{0} became $string[0]