### PR TITLE
Performance in Learning Progress see #28718

### DIFF
--- a/Services/Tracking/classes/repository_statistics/class.ilLPListOfSettingsGUI.php
+++ b/Services/Tracking/classes/repository_statistics/class.ilLPListOfSettingsGUI.php
@@ -403,56 +403,6 @@ class ilLPListOfSettingsGUI extends ilLearningProgressBaseGUI
                 $node["child"] != $a_ref_id) {
                 $a_res[$node["child"]]["node"]["lp"] = true;
                 $has_lp_parents = true;
-                
-                $parent_obj_id = $node["obj_id"];
-                $parent_obj_lp = ilObjectLP::getInstance($parent_obj_id);
-                
-                // parse LP collection
-                $parent_collection = $parent_obj_lp->getCollectionInstance();
-                if ($parent_collection &&
-                    $parent_collection->hasSelectableItems() &&
-                    $parent_collection->isAssignedEntry($a_ref_id)) {
-                    $a_res[$node["child"]]["node"]["active"] = true;
-
-                    if ($parent_collection instanceof ilLPCollectionOfRepositoryObjects) {
-                        $group = array();
-                        foreach ($parent_collection->getTableGUIData($node["parent"]) as $item) {
-                            $found = false;
-                            $grp_tmp = array();
-                            if ($item["grouped"]) {
-                                // parse grouped items
-                                foreach ($item["grouped"] as $group_item) {
-                                    if ($group_item["ref_id"] == $a_ref_id) {
-                                        $found = true;
-                                    } else {
-                                        $grp_tmp[$group_item["ref_id"]] = array(
-                                            "type" => $group_item["type"]
-                                            ,"title" => $group_item["title"]
-                                            ,"obj_id" => $group_item["obj_id"]
-                                        );
-                                    }
-                                }
-                            }
-                            if (sizeof($grp_tmp) ||
-                                $found) {
-                                if ($item["ref_id"] == $a_ref_id) {
-                                    // group "parent" item is current object
-                                    $group = $grp_tmp;
-                                } elseif ($found) {
-                                    // group "parent" item is not current object
-                                    // add group "parent" to grouped items
-                                    $group = $grp_tmp;
-                                    $group[$item["ref_id"]] = array(
-                                        "type" => $item["type"]
-                                        ,"title" => $item["title"]
-                                        ,"obj_id" => $item["obj_id"]
-                                    );
-                                }
-                            }
-                        }
-                        $a_res[$node["child"]]["group"] = $group;
-                    }
-                }
             }
         }
         
@@ -481,37 +431,6 @@ class ilLPListOfSettingsGUI extends ilLearningProgressBaseGUI
             $margin = 0;
             $has_active = false;
             foreach ($coll as $parent_ref_id => $parts) {
-                /* currently not used
-                if($parts["group"])
-                {
-                    foreach($parts["group"] as $group_item_ref_id => $group_item)
-                    {
-                        if($ilAccess->checkAccess("read", "", $group_item_ref_id))
-                        {
-                            $tpl->setCurrentBlock("group_item_link_bl");
-                            $tpl->setVariable("GROUP_ITEM_LINK_TITLE", $group_item["title"]);
-                            $tpl->setVariable("GROUP_ITEM_URL", ilLink::_getLink($group_item_ref_id, $group_item["type"], array("gotolp" => 1)));
-                            $tpl->parseCurrentBlock();
-                        }
-                        else
-                        {
-                            $tpl->setCurrentBlock("group_item_nolink_bl");
-                            $tpl->setVariable("GROUP_ITEM_NOLINK_TITLE", $group_item["title"]);
-                            $tpl->parseCurrentBlock();
-                        }
-
-                        $tpl->setCurrentBlock("group_item_bl");
-                        $tpl->setVariable("GROUP_ITEM_TYPE_URL", ilUtil::getTypeIconPath($group_item["type"], $group_item["obj_id"]));
-                        $tpl->setVariable("GROUP_ITEM_TYPE_ALT", $lng->txt("obj_".$group_item["type"]));
-                        $tpl->parseCurrentBlock();
-                    }
-
-                    $tpl->setCurrentBlock("group_bl");
-                    $tpl->setVariable("GROUP_INFO", $lng->txt("trac_lp_settings_info_parent_group"));
-                    $tpl->parseCurrentBlock();
-                }
-                */
-                
                 $node = $parts["node"];
                 
                 $params = array();


### PR DESCRIPTION
Note, this is not well tested yet. Please review carefully before merging.

**Background**: On our Production Env. Opening Learning Progress on files with enabled "Ermittlung des Lernfortschritts" is extremely slow (up to several minutes). On the test Env with a weaker DB server, it crashes completely with a timeout. Loggin Queries shows 5000+ queries to the DB by just opening e.g. a file with enabled "Ermittlung des Lernfortschritts".  Even if LP is currently inactive for the file. See: https://mantis.ilias.de/view.php?id=28718

**Impact**: This change reduces the loading time from minutes to < 1 sec as well as a drastic reduction in the queries used.

**Explanation**: Issue is a large part of the function getLPPathInfo, which loads all LP information of all parents which can be a huge amount of data. Interestingly, this data seems to be used nowhere since the respective code is outcommented in handleLPUsageInfo (see removed lines, IMO it is better to delete ouctommented code. It is not lost and stays in the history of the Version Control system but makes the productive source look cleaner). So I would propose to remove the code which looks like not in use anymore in getLPPathInfo as well. Please check if this is really not needed anywhere anymore.


