### PR TITLE
[Mantis 28727] Remove reference to deleted block_top.png

### DIFF
--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -15735,7 +15735,6 @@ div.ilTableHeaderTitleBlock {
   padding: 3px;
   font-size: 90%;
   color: #404040;
-  background: url("images/block_top.png") repeat-x #f8f8f8;
   border-bottom: 1px solid #e9e9e9;
 }
 div.ilTableHeaderTitle {

--- a/templates/default/less/Services/Table/delos.less
+++ b/templates/default/less/Services/Table/delos.less
@@ -46,7 +46,6 @@ div.ilTableHeaderTitleBlock {
 	padding: 3px;
 	font-size: 90%;
 	color: #404040;
-	background: url("@{background-images-path}block_top.png") repeat-x #f8f8f8;
 	border-bottom: 1px solid #e9e9e9;
 }
 


### PR DESCRIPTION
`block_top.png` has been deleted in commit f1f472c798f. This commit removes the rules from less and css because the reference is causing 404s in server logs which may trigger false alerts to app admins.