### PR TITLE
fix_28737: use il-footer-bg-color in default layout

### DIFF
--- a/src/UI/templates/default/Layout/standardpage.less
+++ b/src/UI/templates/default/Layout/standardpage.less
@@ -243,7 +243,7 @@ main {
 
 /* Footer */
 footer {
-	background-color: @brand-primary;
+	background-color: @il-footer-bg-color;
 	min-height: auto;
 	padding: @il-footer-padding;
 	text-align: center;


### PR DESCRIPTION
In case #28737 is classified as a bug and wasn't an intentional change for ILIAS 6.