### PR TITLE
Modules - StudyProgramme: set permissions for auto content references 

### DIFF
--- a/Modules/StudyProgramme/classes/class.ilObjStudyProgramme.php
+++ b/Modules/StudyProgramme/classes/class.ilObjStudyProgramme.php
@@ -1539,6 +1539,7 @@ class ilObjStudyProgramme extends ilContainer
             $course_ref->create();
             $course_ref->createReference();
             $course_ref->putInTree($prg->getRefId());
+            $course_ref->setPermissions($crs_ref_id);
             $course_ref->setTargetId(ilObject::_lookupObjectId($crs_ref_id));
             $course_ref->update();
         }


### PR DESCRIPTION
If permissions are not disabled and the course is online, auto content references can now be seen in the StudyProgramme overview.

https://mantis.ilias.de/view.php?id=28562