### PR TITLE
Fixed typo in Survey Question Pool

### DIFF
--- a/Modules/SurveyQuestionPool/classes/class.ilObjSurveyQuestionPoolListGUI.php
+++ b/Modules/SurveyQuestionPool/classes/class.ilObjSurveyQuestionPoolListGUI.php
@@ -25,7 +25,7 @@ class ilObjSurveyQuestionPoolListGUI extends ilObjectListGUI
         $this->gui_class_name = "ilobjsurveyquestionpoolgui";
 
         // general commands array
-        $this->commands = ilObjSurveyQUestionPoolAccess::_getCommands();
+        $this->commands = ilObjSurveyQuestionPoolAccess::_getCommands();
     }
 
 


### PR DESCRIPTION
This commit just fixes a very small typo. For a call to `ilObjSurveyQUestionPoolAccess`, the U is written uppercase instead of lowercase. Even though class names in PHP seem to be case insensitive, our installation throws an exception for this.