### PR TITLE
[Mantis 15366] Test: Reliably calc. time remaining

### DIFF
--- a/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -1483,6 +1483,9 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
         $this->tpl->setVariable("USER_REMAINING_TIME", sprintf($this->lng->txt("tst_time_already_spent_left"), $str_time_left));
         $this->tpl->parseCurrentBlock();
 
+        // jQuery is required by tpl.workingtime.js
+        require_once "./Services/jQuery/classes/class.iljQueryUtil.php";
+        iljQueryUtil::initjQuery();
         $template = new ilTemplate("tpl.workingtime.js", true, true, 'Modules/Test');
         $template->setVariable("STRING_MINUTE", $this->lng->txt("minute"));
         $template->setVariable("STRING_MINUTES", $this->lng->txt("minutes"));

--- a/Modules/Test/templates/default/tpl.workingtime.js
+++ b/Modules/Test/templates/default/tpl.workingtime.js
@@ -1,45 +1,104 @@
-	var serverdate = -1;
-	var unsaved = true;
-	
-	function setWorkingTime()
-	{
-		if (serverdate == -1) 
-		{
-			var n = new Date({YEAR}, {MONTHNOW}, {DAYNOW}, {HOURNOW}, {MINUTENOW}, {SECONDNOW});
-			serverdate = n.getTime() / 1000;
+/*global il:false, jQuery:false*/
+(function(w, $) {
+
+	var test_end = -1,
+		local_timer_start = -1,
+		unsaved = true,
+		interval = 0;
+
+	if (w.performance) {
+	  local_timer_start = performance.now();
+	}
+
+	var server_date = (new Date({YEAR}, {MONTHNOW}, {DAYNOW}, {HOURNOW}, {MINUTENOW}, {SECONDNOW})).getTime() / 1000,
+		// first tick happens immediately, and older browser use tick-based
+		// counter which increments as soon as jQuery fires $(document).ready
+		now = server_date - 1,
+		test_start = (new Date({YEAR}, {MONTH}, {DAY}, {HOUR}, {MINUTE}, {SECOND})).getTime() / 1000,
+		test_time_min = {PTIME_M},
+		test_time_sec = {PTIME_S},
+		minute = "{STRING_MINUTE}",
+		minutes = "{STRING_MINUTES}",
+		second = "{STRING_SECOND}",
+		seconds = "{STRING_SECONDS}",
+		timeleft = "{STRING_TIMELEFT}",
+		redirectUrl = "{REDIRECT_URL}",
+		and = "{AND}",
+		time_left_span;
+
+		<!-- BEGIN enddate -->
+			test_end = (new Date({ENDYEAR}, {ENDMONTH}, {ENDDAY}, {ENDHOUR}, {ENDMINUTE}, {ENDSECOND})).getTime() / 1000;
+		<!-- END enddate -->
+
+	/**
+	 * invoke test player's auto-save if available
+	 */
+	function autoSave() {
+		unsaved = false;
+		if (typeof il.TestPlayerQuestionEditControl !== 'undefined') {
+			il.TestPlayerQuestionEditControl.saveOnTimeReached();
 		}
-		else
-		{
-			serverdate++;
+	}
+
+	/**
+	 * submit form to redirectUrl
+	 */
+	function redirect() {
+		$("#listofquestions").attr('action', redirectUrl).submit();
+	}
+
+	/**
+	 * Format a "time left" string from parameters provided.
+	 * @param {Number}  avail Time available in full seconds.
+	 * @param {Number}  avail_m Full minutes available.
+	 * @param {Number}  avail_s Seconds available subtracted by full minutes (i.e. avail mod 60).
+	 * @return {String} Text telling how much time is left to finish the test in user's language
+	 */
+	function formatString(avail, avail_m, avail_s) {
+		var output = avail_m + " ";
+		if (avail_m === 1) {
+			output += minute;
+		} else {
+			output += minutes;
 		}
-		var startd = new Date({YEAR}, {MONTH}, {DAY}, {HOUR}, {MINUTE}, {SECOND});
-		var enddtime = -1;
-<!-- BEGIN enddate -->		
-		var endd = new Date({ENDYEAR}, {ENDMONTH}, {ENDDAY}, {ENDHOUR}, {ENDMINUTE}, {ENDSECOND});
-		enddtime = endd.getTime() / 1000;
-<!-- END enddate -->		
-		var ptime_m = {PTIME_M};
-		var ptime_s = {PTIME_S};
-		var minute = "{STRING_MINUTE}";
-		var minutes = "{STRING_MINUTES}";
-		var second = "{STRING_SECOND}";
-		var seconds = "{STRING_SECONDS}";
-		var timeleft = "{STRING_TIMELEFT}";
-		var redirectUrl = "{REDIRECT_URL}";
-		var and = "{AND}";
-		var now = serverdate;
-		var then = startd.getTime() / 1000;
+		// show seconds if less than 5min (300s) left
+		if (avail < 300) {
+			if (avail_s < 10) {
+				output += " " + and + " 0" + avail_s + " ";
+			} else {
+				output += " " + and + " " + avail_s + " ";
+			}
+			if (avail_m == 0) {
+				if (avail_s < 10) {
+					output = "0" + avail_s + " ";
+				} else {
+					output = avail_s + " ";
+				}
+			}
+			if (avail_s == 1) {
+				output += second;
+			} else {
+				output += seconds;
+			}
+		}
+		return output;
+	}
+
+	/**
+	 * Calculate remaining working time and dispatch actions based on that
+	 */
+	function setWorkingTime() {
 		// time since start in seconds
-		var diff = Math.floor(now - then);
-		// available time
-		var avail = ptime_m * 60 + ptime_s - diff;
-		if (avail < 0)
-		{
+		var diff = Math.floor(now - test_start),
+			// available time
+			avail = test_time_min * 60 + test_time_sec - diff,
+			avail_m, avail_s, output;
+
+		if (avail < 0) {
 			avail = 0;
 		}
-		if (enddtime > -1)
-		{
-			var diffToEnd = Math.floor(enddtime - now);
+		if (test_end > -1) {
+			var diffToEnd = Math.floor(test_end - now);
 			if ((diffToEnd > 0) && (diffToEnd < avail))
 			{
 				avail = diffToEnd;
@@ -49,64 +108,49 @@
 				avail = 0;
 			}
 		}
-		if ((avail <= 0) && unsaved)
-		{
-			unsaved = false;
-// fau: testNav - call saveOnTimeReached in the new control script
-            if (typeof il.TestPlayerQuestionEditControl != 'undefined')
-            {
-                il.TestPlayerQuestionEditControl.saveOnTimeReached();
-            }
-// fau.
+		if ((avail <= 0) && unsaved) {
+			autoSave();
 		}
-		if((avail <= 0) && redirectUrl != "") {
-			$("#listofquestions").attr('action', redirectUrl).submit();
+		if((avail <= 0) && redirectUrl !== "") {
+			redirect();
 		}
 
-		var avail_m = Math.floor(avail / 60);
-		var avail_s = avail - (avail_m * 60);
-		var output = avail_m + " ";
-		if (avail_m == 1)
-		{
-			output += minute;
-		}
-		else
-		{
-			output += minutes;
-		}
-		if (avail < 300)
-		{
-			if (avail_s < 10)
-			{
-				output += " " + and + " 0" + avail_s + " ";
-			}
-			else
-			{
-				output += " " + and + " " + avail_s + " ";
-			}
-			if (avail_m == 0)
-			{
-				if (avail_s < 10)
-				{
-					output = "0" + avail_s + " ";
-				}
-				else
-				{
-					output = avail_s + " ";
-				}
-			}
-			if (avail_s == 1)
-			{
-				output += second;
-			}
-			else
-			{
-				output += seconds;
-			}
-		}
-		var span = document.getElementById("timeleft");
-		span.innerHTML = timeleft.replace(/%s/, output);
+		avail_m = Math.floor(avail / 60);
+		avail_s = avail - (avail_m * 60);
+		output = formatString(avail, avail_m, avail_s);
+
+		time_left_span.html( timeleft.replace(/%s/, output) );
 	}
-	window.setWorkingTime = setWorkingTime;
-	
-	window.setInterval('setWorkingTime()',1000);
+
+	/**
+	 * MUST be invoked every 1000ms in older browsers
+	 * (SHOULD for those that support window.performance)
+	 */
+	function tick() {
+		if (local_timer_start >= 0) {
+			// use performance API
+			var local_timer_now = performance.now();
+			if (local_timer_now >= local_timer_start) {
+				// floor in order to ensure the test is not submitted before end
+				// in which case ILIAS would display "autosave [failed|succeeded]"
+				// and not "the test ended ..."
+				now = Math.floor(server_date + (local_timer_now - local_timer_start) / 1000);
+			} else {
+				// result by performance API does not make sense, maybe it's broken
+				// in this browser/version or blocked by a privacy plugin
+				now++;
+			}
+		} else {
+			// performance API unsupported by client
+			now++;
+		}
+		setWorkingTime();
+	}
+
+	$(function() {
+		time_left_span = $('#timeleft');
+		tick();
+		interval = w.setInterval(tick, 1000);
+	});
+
+}(window, jQuery));


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2311611/89765797-52d9bc80-daf7-11ea-9354-9106ab4ccd8b.png)


- The implementation before this fix used an incremented counter based
  approach for calculating time remaining: Every 1000ms add one to
  your counter and assume the counter is the time passed since page
  load in s.
- Modern browsers de-prioritize inactive tabs in order to safe CPU
  and energy.
- This causes `setInterval()` fire less frequently than expected.
- The clock is slow.
- Instead, we use the browser's performance API to calculate the time
  passed since test start. The performance API is supported by all
  modern browsers and does not suffer from above issues, not even from
  time zone or clock changes.
  https://developer.mozilla.org/en-US/docs/Web/API/Performance/now
  https://www.w3.org/TR/hr-time-2/#dom-performance-now
- This is similar to how frames in (3D) games are calculated.
- Additional changes:
    - prevent pollution of global scope wrapping the code in an IIFE
    - begin sort the code units into functions
    - use more strict comparison operators
    - make jshint happy declaring global dependencies