### PR TITLE
Composer: Delete directories by PHP code, not by OS specific code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,16 @@
 			"php setup/cli.php build-artifacts --yes"
 		],
 		"post-install-cmd": [
-		  "rm -rf libs/composer/vendor/geshi/geshi/contrib"
+			"php libs/composer/rmdirs.php"
 		],
 		"post-update-cmd": [
-		  "rm -rf libs/composer/vendor/geshi/geshi/contrib"
+			"php libs/composer/rmdirs.php"
 		],
 		"test-php-all": [
-		  "./libs/composer/vendor/bin/phpunit -c ./Services/PHPUnit/config/PhpUnitConfig.xml --colors=always --disallow-todo-tests"
+			"./libs/composer/vendor/bin/phpunit -c ./Services/PHPUnit/config/PhpUnitConfig.xml --colors=always --disallow-todo-tests"
 		],
 		"test-php": [
-		  "./CI/PHPUnit/run_tests.sh"
+			"./CI/PHPUnit/run_tests.sh"
 		]
 	},
 	"require": {

--- a/libs/composer/rmdirs.php
+++ b/libs/composer/rmdirs.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+/* Copyright (c) 2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * @author Michael Jansen <mjansen@databay.de
+ */
+
+if (php_sapi_name() !== 'cli') {
+    exit();
+}
+
+$dirsToDeleted = [
+    __DIR__ . '/vendor/geshi/geshi/contrib',
+];
+
+foreach ($dirsToDeleted as $directoryPath) {
+    try {
+        if (!is_dir($directoryPath)) {
+            continue;
+        }
+
+        $recursiveDirIter = new RecursiveDirectoryIterator($directoryPath, FilesystemIterator::SKIP_DOTS);
+        $resourceIter = new RecursiveIteratorIterator($recursiveDirIter, RecursiveIteratorIterator::CHILD_FIRST);
+        foreach ($resourceIter as $resource) {
+            /** @var $resource SplFileInfo */
+            if ($resource->isDir()) {
+                rmdir($resource->getPathname());
+            } else {
+                unlink($resource->getPathname());
+            }
+            echo "Deleted " . $resource->getPathname() . "\n";
+        }
+        rmdir($directoryPath);
+        echo "Deleted " . $directoryPath . "\n";
+    } catch (Exception $e) {
+        echo $e->getMessage() . "\n";
+    }
+}


### PR DESCRIPTION
This PR changes the approach to delete directories from the composer dependency folders on `post-install-cmd` or `post-update-cmd`. Instead of using OS specific code I use PHP to recursively delete folders.

Currently ILIAS does not work on Microsoft Windows (I am aware that MS will drop the official support for PHP on Windows).

I guess this PR makes @mbecker-databay happy ;-).