### PR TITLE
Aria-label for UI Tree

### DIFF
--- a/Modules/Forum/classes/class.ilForumExplorerGUI.php
+++ b/Modules/Forum/classes/class.ilForumExplorerGUI.php
@@ -134,6 +134,14 @@ class ilForumExplorerGUI extends ilTreeExplorerGUI
     }
 
     /**
+     * @return string
+     */
+    public function getTreeLabel()
+    {
+        return $this->lng->txt("frm_posts");
+    }
+
+    /**
      * @inheritDoc
      */
     public function getTreeComponent() : Tree
@@ -152,7 +160,7 @@ class ilForumExplorerGUI extends ilTreeExplorerGUI
         ];
 
         $tree = $this->ui->factory()->tree()
-            ->expandable($this)
+            ->expandable($this->getTreeLabel(), $this)
             ->withData($rootNode)
             ->withHighlightOnNodeClick(false);
 

--- a/Modules/OrgUnit/classes/Provider/OrgUnitToolProvider.php
+++ b/Modules/OrgUnit/classes/Provider/OrgUnitToolProvider.php
@@ -57,11 +57,13 @@ class OrgUnitToolProvider extends AbstractDynamicToolProvider
     private function getTree() : Tree
     {
         global $DIC;
+        $lng = $DIC->language();
         $tree = $this->getTreeRecursion();
 
         $parent_node_id = $DIC->repositoryTree()->getParentId(ilObjOrgUnit::getRootOrgRefId());
 
-        return $this->dic->ui()->factory()->tree()->expandable($tree)->withData($tree->getChildsOfNode($parent_node_id));
+        return $this->dic->ui()->factory()->tree()->expandable($lng->txt("org_units"), $tree)
+            ->withData($tree->getChildsOfNode($parent_node_id));
     }
 
     private function getTreeRecursion() : TreeRecursion

--- a/Services/Mail/classes/class.ilMailExplorer.php
+++ b/Services/Mail/classes/class.ilMailExplorer.php
@@ -54,6 +54,14 @@ class ilMailExplorer extends ilTreeExplorerGUI
     }
 
     /**
+     * @return string
+     */
+    public function getTreeLabel()
+    {
+        return $this->lng->txt("mail_folders");
+    }
+
+    /**
      * @inheritDoc
      */
     public function getTreeComponent() : Tree
@@ -61,7 +69,7 @@ class ilMailExplorer extends ilTreeExplorerGUI
         $f = $this->ui->factory();
 
         $tree = $f->tree()
-            ->expandable($this)
+            ->expandable($this->getTreeLabel(), $this)
             ->withData($this->tree->getChilds((int) $this->tree->readRootId()))
             ->withHighlightOnNodeClick(false);
 

--- a/Services/UIComponent/Explorer2/classes/class.ilTreeExplorerGUI.php
+++ b/Services/UIComponent/Explorer2/classes/class.ilTreeExplorerGUI.php
@@ -20,6 +20,7 @@ abstract class ilTreeExplorerGUI extends ilExplorerBaseGUI implements \ILIAS\UI\
     protected $httpRequest;
 
     protected $tree = null;
+    protected $tree_label = "";
     protected $order_field = "";
     protected $order_field_numeric = false;
     protected $type_white_list = array();
@@ -440,6 +441,14 @@ abstract class ilTreeExplorerGUI extends ilExplorerBaseGUI implements \ILIAS\UI\
     }
 
     /**
+     * @return string
+     */
+    public function getTreeLabel()
+    {
+        return $this->tree_label;
+    }
+
+    /**
      * Get Tree UI
      *
      * @return \ILIAS\UI\Component\Tree\Tree|object
@@ -453,7 +462,12 @@ abstract class ilTreeExplorerGUI extends ilExplorerBaseGUI implements \ILIAS\UI\
             $tree->getNodeData($tree->readRootId())
         );
 
-        $tree = $f->tree()->expandable($this)
+        $label = $this->getTreeLabel();
+        if ($this->getTreeLabel() == "" && $this->getNodeContent($this->getRootNode())) {
+            $label = $this->getNodeContent($this->getRootNode());
+        }
+
+        $tree = $f->tree()->expandable($label, $this)
             ->withData($data)
             ->withHighlightOnNodeClick(true);
 

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -6554,6 +6554,7 @@ forum#:#frm_moderators_not_exist_yet#:#Bitte wählen Sie einen Moderator aus.
 forum#:#frm_moderators_select_at_least_one#:#Bitte wählen Sie mindestens einen Moderator aus.
 forum#:#frm_moderators_select_one#:#Bitte wählen Sie einen Benutzer, dem Sie die Moderatorenrolle zuweisen möchten.
 forum#:#frm_post_not_activated_yet#:#Der Beitrag wurde noch nicht aktiviert.
+forum#:#frm_posts#:#Forenbeiträge
 forum#:#frm_pseudonym#:#Pseudonym
 forum#:#frm_purifier_not_implemented_for_type_x#:#Es ist noch kein Reiniger für den Typ %s implementiert.
 forum#:#frm_statistics#:#Statistik

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -5591,6 +5591,7 @@ forum#:#frm_moderators_select_at_least_one#:#Please choose at least one moderato
 forum#:#frm_moderators_select_one#:#Please choose one user.
 forum#:#frm_moderators#:#Moderators
 forum#:#frm_post_not_activated_yet#:#Not activated yet.
+forum#:#frm_posts#:#Forum Posts
 forum#:#frm_pseudonym#:#Pseudonym
 forum#:#frm_purifier_not_implemented_for_type_x#:#Purifier for type %s not implemented yet.
 forum#:#frm_statistics_disabled_for_participants#:#Statistics are disabled for forum members.

--- a/src/UI/Component/Tree/Factory.php
+++ b/src/UI/Component/Tree/Factory.php
@@ -58,7 +58,6 @@ interface Factory
      *   effect: >
      *     When clicking a Node, it will expand or collapse, thus showing or hiding
      *     its sub-Nodes.
-     *
      * rules:
      *   usage:
      *     1: >
@@ -70,14 +69,16 @@ interface Factory
      *        object and its properties as individual nodes.
      *   accessibility:
      *     1: Expandable Trees MUST bear the ARIA role "tree".
-     *     2: > The "aria-label" attribute MUST be set for Expandable Trees,
-     *          which MUST be language-dependant.
-     *
-     *
+     *     2: The "aria-label" attribute MUST be set for Expandable Trees.
+     *     3: The "aria-label" attribute MUST be language-dependant.
+     *     4: >
+     *        The "aria-label" attribute MUST describe the content of the Tree as
+     *        precisely as possible. "Tree" MUST NOT be set as label, labels like
+     *        "Forum Posts" or "Mail Folders" are much more helpful.
+     *        (Note that "Tree" is already set by the ARIA role attribute.)
      * ---
      * @param string $label
      * @param TreeRecursion $recursion
-     *
      * @return \ILIAS\UI\Component\Tree\Expandable
      */
     public function expandable(string $label, TreeRecursion $recursion) : Expandable;

--- a/src/UI/Component/Tree/Factory.php
+++ b/src/UI/Component/Tree/Factory.php
@@ -70,11 +70,15 @@ interface Factory
      *        object and its properties as individual nodes.
      *   accessibility:
      *     1: Expandable Trees MUST bear the ARIA role "tree".
+     *     2: > The "aria-label" attribute MUST be set for Expandable Trees,
+     *          which MUST be language-dependant.
+     *
      *
      * ---
+     * @param string $label
      * @param TreeRecursion $recursion
      *
      * @return \ILIAS\UI\Component\Tree\Expandable
      */
-    public function expandable(TreeRecursion $recursion) : Expandable;
+    public function expandable(string $label, TreeRecursion $recursion) : Expandable;
 }

--- a/src/UI/Component/Tree/Tree.php
+++ b/src/UI/Component/Tree/Tree.php
@@ -19,6 +19,13 @@ interface Tree extends Component
     public function withEnvironment($environment) : Tree;
 
     /**
+     * Get the (aria-)label
+     *
+     * @return string
+     */
+    public function getLabel() : string;
+
+    /**
      * Apply data to the Tree.
      */
     public function withData($data) : Tree;

--- a/src/UI/Implementation/Component/Tree/Factory.php
+++ b/src/UI/Implementation/Component/Tree/Factory.php
@@ -19,8 +19,8 @@ class Factory implements ITree\Factory
     /**
      * @inheritdoc
      */
-    public function expandable(ITree\TreeRecursion $recursion) : ITree\Expandable
+    public function expandable(string $label, ITree\TreeRecursion $recursion) : ITree\Expandable
     {
-        return new Expandable($recursion);
+        return new Expandable($label, $recursion);
     }
 }

--- a/src/UI/Implementation/Component/Tree/Renderer.php
+++ b/src/UI/Implementation/Component/Tree/Renderer.php
@@ -23,6 +23,8 @@ class Renderer extends AbstractComponentRenderer
         $tpl_name = "tpl.tree.html";
         $tpl = $this->getTemplate($tpl_name, true, true);
 
+        $tpl->setVariable("ARIA_LABEL", $component->getLabel());
+
         $recursion =
         $environment = $component->getEnvironment();
 

--- a/src/UI/Implementation/Component/Tree/Tree.php
+++ b/src/UI/Implementation/Component/Tree/Tree.php
@@ -26,6 +26,11 @@ abstract class Tree implements ITree\Tree
     protected $data;
 
     /**
+     * @var string
+     */
+    protected $label;
+
+    /**
      * @var TreeRecursion
      */
     protected $recursion;
@@ -36,9 +41,18 @@ abstract class Tree implements ITree\Tree
     protected $highlight_nodes_on_click = false;
 
 
-    public function __construct(ITree\TreeRecursion $recursion)
+    public function __construct(string $label, ITree\TreeRecursion $recursion)
     {
+        $this->label = $label;
         $this->recursion = $recursion;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getLabel() : string
+    {
+        return $this->label;
     }
 
     /**

--- a/src/UI/examples/Tree/Expandable/expandable.php
+++ b/src/UI/examples/Tree/Expandable/expandable.php
@@ -65,7 +65,7 @@ function expandable()
         'modal' => $modal
     ];
 
-    $tree = $f->tree()->expandable($recursion)
+    $tree = $f->tree()->expandable("Label", $recursion)
         ->withEnvironment($environment)
         ->withData($data)
         ->withHighlightOnNodeClick(true);

--- a/src/UI/examples/Tree/Expandable/expandable2.php
+++ b/src/UI/examples/Tree/Expandable/expandable2.php
@@ -45,7 +45,7 @@ function expandable2()
         }
     };
 
-    $tree = $f->tree()->expandable($recursion)
+    $tree = $f->tree()->expandable("Label", $recursion)
         ->withData($data);
 
     return $renderer->render($tree);

--- a/src/UI/examples/Tree/Expandable/expandable_async_repo.php
+++ b/src/UI/examples/Tree/Expandable/expandable_async_repo.php
@@ -81,7 +81,7 @@ function expandable_async_repo($ref = null)
         'icon_factory' => $f->symbol()->icon()
     ];
 
-    $tree = $f->tree()->expandable($recursion)
+    $tree = $f->tree()->expandable("Label", $recursion)
         ->withEnvironment($environment)
         ->withData($data);
 

--- a/src/UI/templates/default/Tree/tpl.tree.html
+++ b/src/UI/templates/default/Tree/tpl.tree.html
@@ -1,3 +1,3 @@
-<ul id="{ID}" class="il-tree" role="tree">
+<ul id="{ID}" class="il-tree" role="tree" aria-label="{ARIA_LABEL}">
 	{NODES}
 </ul>

--- a/tests/UI/Component/Tree/ExpandableTreeTest.php
+++ b/tests/UI/Component/Tree/ExpandableTreeTest.php
@@ -65,9 +65,10 @@ class ExpandableTreeTest extends ILIAS_UI_TestBase
         $n2 = new DataNode('2');
         $data = [$n1, $n2];
 
+        $label = "label";
         $recursion = new Recursion();
         $f = $this->getUIFactory();
-        $this->tree = $f->tree()->expandable($recursion)
+        $this->tree = $f->tree()->expandable($label, $recursion)
             ->withData($data);
     }
 
@@ -84,7 +85,7 @@ class ExpandableTreeTest extends ILIAS_UI_TestBase
         $html = $r->render($this->tree);
 
         $expected = <<<EOT
-		<ul id="id_1" class="il-tree" role="tree">
+		<ul id="id_1" class="il-tree" role="tree" aria-label="label">
 			<li id="" class="il-tree-node node-simple expandable" role="treeitem" aria-expanded="false">
 				<span class="node-line"><span class="node-label">1</span></span>
 

--- a/tests/UI/Component/Tree/TreeTest.php
+++ b/tests/UI/Component/Tree/TreeTest.php
@@ -33,6 +33,7 @@ class TreeTest extends ILIAS_UI_TestBase
 
     public function testConstruction()
     {
+        $label = "label";
         $recursion = new class implements \ILIAS\UI\Component\Tree\TreeRecursion {
             public function getChildren($record, $environment = null) : array
             {
@@ -47,13 +48,24 @@ class TreeTest extends ILIAS_UI_TestBase
             }
         };
 
-        $tree = new TestingTree($recursion);
+        $tree = new TestingTree($label, $recursion);
         $this->assertInstanceOf(
             "ILIAS\\UI\\Component\\Tree\\Tree",
             $tree
         );
 
         return $tree;
+    }
+
+    /**
+     * @depends testConstruction
+     */
+    public function testGetLabel($tree)
+    {
+        $this->assertEquals(
+            "label",
+            $tree->getLabel()
+        );
     }
 
     /**


### PR DESCRIPTION
This is a follow-up of one open task, which was discussed in https://github.com/ILIAS-eLearning/ILIAS/pull/2500. 
It tackles the UI Tree, which should get a new (aria-)label to improve accessibility. Because the UI Tree is already used in a few places, this PR includes also suggestions for existing Trees, where the labels have to be added retroactively.