### PR TITLE
UI: rules to fence direct Modal usage

### DIFF
--- a/src/UI/Factory.php
+++ b/src/UI/Factory.php
@@ -535,6 +535,9 @@ interface Factory
      *     3: Modals SHOULD not be used to perform complex workflows.
      *     4: Modals MUST be closable by a little “x”-button on the right side of the header.
      *     5: Modals MUST contain a title in the header.
+     *     6: >
+     *       If a Modal contains a form, it MUST NOT be rendered within another form. This
+     *       will break the HTML-engine of the client, since forms in forms are not allowed.
      * ---
      *
      * @return \ILIAS\UI\Component\Modal\Factory


### PR DESCRIPTION
@mjansenDatabay brought problems with the usage of Modals to attention. He observed that it is not very straight forward to use Modals stand alone. It is very easy to misplace them on some page, since they need to be rendered on their own by the consumer currently. This may lead to various problems like <form> in <form> or misassigned CSS-properties, like z-index. The root cause for these issues seems to be, that to use a Modal a consumer needs to know about the resulting DOM of its page, which breaks the assumption that UI-components should be easily combinable.

@Amstutz, @mjansenDatabay and @klees discussed the problem and considered various solutions. A key insight in this discussion was, that a Modal encodes a functional pattern that relies on some specific DOM, instead of a semantic meaning, like
many other components in the UI framework do. Although we won't get rid of the pure functional usage anytime soon, we considered it useful to tease out the semantic patterns by prompting our users to not use the Modal directly. Hence two new rules for the usage of modals.