### PR TITLE
Database/Setup: password in config is optional

### DIFF
--- a/Services/Database/classes/Setup/class.ilDatabaseServerIsConnectableObjective.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseServerIsConnectableObjective.php
@@ -8,12 +8,13 @@ class ilDatabaseServerIsConnectableObjective extends \ilDatabaseObjective
 {
     public function getHash() : string
     {
+        $pw = $this->config->getPassword();
         return hash("sha256", implode("-", [
             self::class,
             $this->config->getHost(),
             $this->config->getPort(),
             $this->config->getUser(),
-            $this->config->getPassword()->toString()
+            $pw ? $pw->toString() : ""
         ]));
     }
 

--- a/Services/Database/classes/Setup/class.ilDatabaseSetupConfig.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseSetupConfig.php
@@ -160,7 +160,8 @@ class ilDatabaseSetupConfig implements Setup\Config
                     case "port":
                         return $this->config->getPort();
                     case "pass":
-                        return $this->config->getPassword()->toString();
+                        $pw = $this->config->getPassword();
+                        return $pw ? $pw->toString() : null;
                     case "name":
                         return $this->config->getDatabase();
                     case "type":


### PR DESCRIPTION
Hi @chfsx,

I discovered this bug when debugging some other problem: the `ilDatabaseSetupConfig` says that `password` might be null, but these two locations did not respect that and explode when people do in fact set no database password.

This should fix the issue and would be required in the trunk as well.

Best regards!