### PR TITLE
UICore: improve handling of paths in reader

### DIFF
--- a/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
+++ b/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
@@ -96,7 +96,7 @@ class ilCtrlStructureReader
      */
     private function normalizePath(string $path) : string
     {
-        return str_replace(['//'], ['/'], $path);
+        return realpath(str_replace(['//'], ['/'], $path));
     }
 
     /**
@@ -270,7 +270,7 @@ class ilCtrlStructureReader
                 $ilDB->quote($file, "text"),
                 $ilDB->quote($this->comp_prefix, "text"),
                 $ilDB->quote($this->plugin_path, "text")
-                ));
+            ));
         }
         //$this->class_childs[$parent][] = $child;
         foreach ($this->class_childs as $parent => $v) {
@@ -301,7 +301,7 @@ class ilCtrlStructureReader
         $ilDB->manipulate(
             "UPDATE ctrl_classfile SET " .
             " cid = " . $ilDB->quote("", "text")
-            );
+        );
         $set = $ilDB->query("SELECT * FROM ctrl_classfile ");
         $cnt = 1;
         while ($rec = $ilDB->fetchAssoc($set)) {
@@ -310,7 +310,7 @@ class ilCtrlStructureReader
                 "UPDATE ctrl_classfile SET " .
                 " cid = " . $ilDB->quote($cid, "text") .
                 " WHERE class = " . $ilDB->quote($rec["class"], "text")
-                );
+            );
             $cnt++;
         }
     }

--- a/Services/UICore/classes/Setup/class.ilCtrlStructureStoredObjective.php
+++ b/Services/UICore/classes/Setup/class.ilCtrlStructureStoredObjective.php
@@ -74,7 +74,7 @@ class ilCtrlStructureStoredObjective implements Setup\Objective
 
         $reader = $this->ctrl_reader->withDB($db);
         $reader->executed = false;
-        $reader->readStructure(true, ".");
+        $reader->readStructure(true);
         return $environment;
     }
 }


### PR DESCRIPTION
`ilCtrlStructure::normalizePath` did not take into account that the same directory might be referenced by different names, e.g., as in this case a relative vs. an absolute name or via a symlink.

This improves this behaviour by adding `realpath` as a normalization measure for the path. The explicit setting of `"."` as path to be scanned in the setup objective is superfluous too.

This fixes two problems:

https://mantis.ilias.de/view.php?id=28284
https://mantis.ilias.de/view.php?id=28777