### PR TITLE
LSO: space between lines in Kiosk-navbar; fixes #28783

### DIFF
--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -19022,6 +19022,9 @@ span.ilProfileBadge .modal .img-responsive {
   margin-bottom: 10px;
   background-color: #e0e0e0;
 }
+.ilLSOKioskModeNavigation .navbar-form {
+  line-height: 25px;
+}
 .ilLSOKioskTopBarControls {
   float: left;
   display: block;

--- a/templates/default/less/Modules/LearningSequence/delos.less
+++ b/templates/default/less/Modules/LearningSequence/delos.less
@@ -38,6 +38,9 @@
 .ilLSOKioskModeNavigation {
 	margin-bottom: 10px;
 	background-color: @lso-dark-bg;
+	.navbar-form {
+		line-height: 25px;
+	}
 }
 
 .ilLSOKioskTopBarControls {


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=28783
"As soon as there are two lines due to too many custom menu entries there is no padding between the lines."