### PR TITLE
LSO, Legacy LP checks, fix #28840

### DIFF
--- a/Modules/LearningSequence/classes/Player/LSControlBuilder.php
+++ b/Modules/LearningSequence/classes/Player/LSControlBuilder.php
@@ -16,7 +16,8 @@ class LSControlBuilder implements ControlBuilder
 {
     const CMD_START_OBJECT = 'start_legacy_obj';
     const CMD_CHECK_CURRENT_ITEM_LP = 'ccilp';
-    const UPDATE_LEGACY_OBJECT_LP_INTERVAL = 2000;
+    const PARAM_LP_CURRENT_ITEM_OBJID = 'ccilpobjid';
+    const UPDATE_LEGACY_OBJECT_LP_INTERVAL = 4000;
 
 
     /**
@@ -290,14 +291,18 @@ class LSControlBuilder implements ControlBuilder
         if ($this->start) {
             throw new \LogicException("Only one start-control per view...", 1);
         }
-        $this_cmd = $this->url_builder->getHref(self::CMD_START_OBJECT, $parameter);
+
+        $this_cmd = $this->url_builder->getHref(self::CMD_START_OBJECT, 0);
         $lp_cmd = str_replace(
             '&cmd=view&',
             '&cmd=' . self::CMD_CHECK_CURRENT_ITEM_LP . '&',
             $this_cmd
         );
-        $signal = $this->getStartSignal();
 
+        $current_obj_id = $parameter;
+        $lp_cmd .= '&' . self::PARAM_LP_CURRENT_ITEM_OBJID . '=' . $current_obj_id;
+
+        $signal = $this->getStartSignal();
         $this->setListenerJS($signal->getId(), $url, $lp_cmd, $this_cmd);
 
         $this->start = $this->ui_factory->button()

--- a/Modules/LearningSequence/classes/Player/class.ilLegacyKioskModeView.php
+++ b/Modules/LearningSequence/classes/Player/class.ilLegacyKioskModeView.php
@@ -74,6 +74,7 @@ class ilLegacyKioskModeView implements ILIAS\KioskMode\View
         $label = $this->lng->txt('lso_start_item') . ' ' . $this->getTitleByType($this->getType());
 
         $ref_id = $this->object->getRefId();
+        $obj_id = (int) $this->object->getId();
         $type = $this->object->getType();
 
         $url = \ilLink::_getStaticLink(
@@ -84,7 +85,6 @@ class ilLegacyKioskModeView implements ILIAS\KioskMode\View
         );
 
         if (in_array($type, self::GET_VIEW_CMD_FROM_LIST_GUI_FOR)) {
-            $obj_id = $this->object->getId();
             $item_list_gui = \ilObjectListGUIFactory::_getListGUIByType($type);
             $item_list_gui->initItem($ref_id, $obj_id);
             $view_link = $item_list_gui->getCommandLink('view');
@@ -93,7 +93,7 @@ class ilLegacyKioskModeView implements ILIAS\KioskMode\View
             $url = $view_link;
         }
 
-        $builder->start($label, $url, 0);
+        $builder->start($label, $url, $obj_id);
         //return $this->debugBuildAllControls($builder);
         return $builder;
     }

--- a/Modules/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
+++ b/Modules/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
@@ -156,6 +156,19 @@ class ilObjLearningSequenceGUI extends ilContainerGUI
 
         //exit real early for LP-checking.
         if ($cmd === LSControlBuilder::CMD_CHECK_CURRENT_ITEM_LP) {
+            if (isset($_GET[LSControlBuilder::PARAM_LP_CURRENT_ITEM_OBJID])) {
+                $current_obj_obj_id = (int) $_GET[LSControlBuilder::PARAM_LP_CURRENT_ITEM_OBJID];
+
+                print (int) ilLPStatus::_lookupStatus(
+                    $current_obj_obj_id,
+                    $this->user->getId(),
+                    true
+                );
+                exit;
+            }
+
+            //this is the previous way (before #28840)
+            //with iteration over learner items.
             print $this->getCurrentItemLearningProgress();
             exit;
         }


### PR DESCRIPTION
Constantly pulling LP of legacy objects takes its toll on resources; 
this relays the current object's obj_id to the RPC and thus avoids looping over all learner items.
That should reduce load quite a bit, especially in LSOs with many objects.
Also, the default interval is now set to 4000.

https://mantis.ilias.de/view.php?id=28840