### PR TITLE
Hotfix/trunk/join implode

### DIFF
--- a/Modules/Exercise/classes/class.ilExSubmission.php
+++ b/Modules/Exercise/classes/class.ilExSubmission.php
@@ -951,7 +951,7 @@ class ilExSubmission
         }
         
         chdir($tmpdir);
-        $zipcmd = $zip . " " . ilUtil::escapeShellArg($tmpzipfile) . " " . join($parsed_files, " ");
+        $zipcmd = $zip . " " . ilUtil::escapeShellArg($tmpzipfile) . " " . join(" ", $parsed_files);
 
         exec($zipcmd);
         ilUtil::delDir($tmpdir);

--- a/Modules/Scorm2004/classes/class.ilObjSCORM2004LearningModuleGUI.php
+++ b/Modules/Scorm2004/classes/class.ilObjSCORM2004LearningModuleGUI.php
@@ -2010,7 +2010,7 @@ class ilObjSCORM2004LearningModuleGUI extends ilObjSCORMLearningModuleGUI
             $chap_ids[] = $chap->getId();
         }
         $chap_ids = array_reverse($chap_ids);
-        $chap_ids = implode($chap_ids, ":");
+        $chap_ids = implode(":", $chap_ids);
 
         if ($a_redirect) {
             $ilCtrl->setParameter($this, "highlight", $chap_ids);
@@ -2057,7 +2057,7 @@ class ilObjSCORM2004LearningModuleGUI extends ilObjSCORMLearningModuleGUI
             $sco_ids[] = $sco->getId();
         }
         $sco_ids = array_reverse($sco_ids);
-        $sco_ids = implode($sco_ids, ":");
+        $sco_ids = implode(":", $sco_ids);
 
         if ($a_redirect) {
             $ilCtrl->setParameter($this, "highlight", $sco_ids);
@@ -2104,7 +2104,7 @@ class ilObjSCORM2004LearningModuleGUI extends ilObjSCORMLearningModuleGUI
             $ass_ids[] = $ass->getId();
         }
         $ass_ids = array_reverse($ass_ids);
-        $ass_ids = implode($ass_ids, ":");
+        $ass_ids = implode(":", $ass_ids);
 
         if ($a_redirect) {
             $ilCtrl->setParameter($this, "highlight", $ass_ids);
@@ -2150,7 +2150,7 @@ class ilObjSCORM2004LearningModuleGUI extends ilObjSCORMLearningModuleGUI
             $page_ids[] = $page->getId();
         }
         $page_ids = array_reverse($page_ids);
-        $page_ids = implode($page_ids, ":");
+        $page_ids = implode(":", $page_ids);
 
         if ($a_redirect) {
             $ilCtrl->setParameter($this, "highlight", $page_ids);
@@ -2403,7 +2403,7 @@ class ilObjSCORM2004LearningModuleGUI extends ilObjSCORMLearningModuleGUI
             $page_ids[] = $page->getId();
         }
         $page_ids = array_reverse($page_ids);
-        $page_ids = implode($page_ids, ":");
+        $page_ids = implode(":", $page_ids);
 
         if ($a_redirect) {
             if ($_GET["obj_id"] != "") {

--- a/Modules/Survey/Evaluation/class.ilSurveyEvaluationGUI.php
+++ b/Modules/Survey/Evaluation/class.ilSurveyEvaluationGUI.php
@@ -455,7 +455,7 @@ class ilSurveyEvaluationGUI
                 $separator = ";";
                 foreach ($csvfile as $csvrow) {
                     $csvrow = $this->processCSVRow($csvrow, true, $separator);
-                    $csv .= join($csvrow, $separator) . "\n";
+                    $csv .= join($separator, $csvrow) . "\n";
                 }
                 ilUtil::deliverData($csv, $surveyname . ".csv");
                 exit();
@@ -1378,7 +1378,7 @@ class ilSurveyEvaluationGUI
                 $separator = ";";
                 foreach ($rows as $csvrow) {
                     $csvrow = str_replace("\n", " ", $this->processCSVRow($csvrow, true, $separator));
-                    $csv .= join($csvrow, $separator) . "\n";
+                    $csv .= join($separator, $csvrow) . "\n";
                 }
                 ilUtil::deliverData($csv, "$surveyname.csv");
                 exit();

--- a/Modules/Survey/Mail/FormMailCodesGUI.php
+++ b/Modules/Survey/Mail/FormMailCodesGUI.php
@@ -74,7 +74,7 @@ class FormMailCodesGUI extends ilPropertyFormGUI
         $this->mailmessage->setRequired(true);
         $this->mailmessage->setCols(80);
         $this->mailmessage->setRows(10);
-        $this->mailmessage->setInfo(sprintf($this->lng->txt('message_content_info'), join($existingcolumns, ', ')));
+        $this->mailmessage->setInfo(sprintf($this->lng->txt('message_content_info'), join(', ', $existingcolumns)));
         $this->addItem($this->mailmessage);
 
         // save message

--- a/Modules/Survey/Participants/class.ilSurveyParticipantsGUI.php
+++ b/Modules/Survey/Participants/class.ilSurveyParticipantsGUI.php
@@ -1470,7 +1470,7 @@ class ilSurveyParticipantsGUI
         $mailmessage_a->setRequired(true);
         $mailmessage_a->setCols(80);
         $mailmessage_a->setRows(10);
-        $mailmessage_a->setInfo(sprintf($this->lng->txt('message_content_info'), join($existingcolumns, ', ')));
+        $mailmessage_a->setInfo(sprintf($this->lng->txt('message_content_info'), join(', ', $existingcolumns)));
         $form->addItem($mailmessage_a);
         
         $recf = new ilHiddenInputGUI("rtr_id");

--- a/Modules/Survey/classes/class.SurveySearch.php
+++ b/Modules/Survey/classes/class.SurveySearch.php
@@ -156,13 +156,13 @@ class SurveySearch
         }
         $cumulated_fields = array();
         foreach ($fields as $params) {
-            array_push($cumulated_fields, "(" . join($params, " OR ") . ")");
+            array_push($cumulated_fields, "(" . join(" OR ", $params) . ")");
         }
         $str_where = "";
         if ($this->concatenation == self::CONCAT_AND) {
-            $str_where = "(" . join($cumulated_fields, " AND ") . ")";
+            $str_where = "(" . join(" AND ", $cumulated_fields) . ")";
         } else {
-            $str_where = "(" . join($cumulated_fields, " OR ") . ")";
+            $str_where = "(" . join(" OR ", $cumulated_fields) . ")";
         }
         if ($str_where) {
             $str_where = " AND $str_where";

--- a/Modules/Survey/classes/class.ilObjSurvey.php
+++ b/Modules/Survey/classes/class.ilObjSurvey.php
@@ -1324,7 +1324,7 @@ class ilObjSurvey extends ilObject
                 }
             }
         }
-        return join($author, ",");
+        return join(",", $author);
     }
 
     /**
@@ -3225,7 +3225,7 @@ class ilObjSurvey extends ilObject
                         "questionblock_id" => $row["questionblock_id"],
                         "title" => $row["title"],
                         "svy" => $surveytitles[$row["obj_fi"]],
-                        "contains" => join($questions_array, ", "),
+                        "contains" => join(", ", $questions_array),
                         "owner" => $row["owner_fi"]
                     );
                 }

--- a/Modules/SurveyQuestionPool/Phrases/class.ilSurveyPhrasesGUI.php
+++ b/Modules/SurveyQuestionPool/Phrases/class.ilSurveyPhrasesGUI.php
@@ -150,7 +150,7 @@ class ilSurveyPhrasesGUI
             $data = array();
             foreach ($phrases as $phrase_id => $phrase_array) {
                 $categories = &ilSurveyPhrases::_getCategoriesForPhrase($phrase_id);
-                array_push($data, array('phrase_id' => $phrase_id, 'phrase' => $phrase_array["title"], 'answers' => join($categories, ", ")));
+                array_push($data, array('phrase_id' => $phrase_id, 'phrase' => $phrase_array["title"], 'answers' => join(", ", $categories)));
             }
             $table_gui->setData($data);
             $this->tpl->setContent($table_gui->getHTML());
@@ -225,7 +225,7 @@ class ilSurveyPhrasesGUI
         foreach ($checked_phrases as $phrase_id) {
             $phrase_array = $phrases[$phrase_id];
             $categories = &ilSurveyPhrases::_getCategoriesForPhrase($phrase_id);
-            array_push($data, array('phrase_id' => $phrase_id, 'phrase' => $phrase_array["title"], 'answers' => join($categories, ", ")));
+            array_push($data, array('phrase_id' => $phrase_id, 'phrase' => $phrase_array["title"], 'answers' => join(", ", $categories)));
         }
         $table_gui->setData($data);
         $this->tpl->setVariable('ADM_CONTENT', $table_gui->getHTML());

--- a/Modules/SurveyQuestionPool/Questions/class.SurveyQuestionGUI.php
+++ b/Modules/SurveyQuestionPool/Questions/class.SurveyQuestionGUI.php
@@ -902,7 +902,7 @@ abstract class SurveyQuestionGUI
             $categories = ilSurveyPhrases::_getCategoriesForPhrase($phrase_id);
                 
             $opt = new ilRadioOption($phrase_array["title"], $phrase_id);
-            $opt->setInfo(join($categories, ","));
+            $opt->setInfo(join(",", $categories));
             $group->addOption($opt);
             
             if ($phrase_array["org_title"] == "dp_standard_numbers") {

--- a/Modules/Test/classes/class.assMarkSchema.php
+++ b/Modules/Test/classes/class.assMarkSchema.php
@@ -164,7 +164,7 @@ class ASS_MarkSchema
                         }
                     }
                     if (count($difffields)) {
-                        $this->logAction($test_id, $lng->txtlng("assessment", "log_mark_changed", ilObjAssessmentFolder::_getLogLanguage()) . ": " . join($difffields, ", "));
+                        $this->logAction($test_id, $lng->txtlng("assessment", "log_mark_changed", ilObjAssessmentFolder::_getLogLanguage()) . ": " . join(", ", $difffields));
                     }
                 } else {
                     $this->logAction($test_id, $lng->txtlng("assessment", "log_mark_removed", ilObjAssessmentFolder::_getLogLanguage()) . ": " .

--- a/Modules/Test/classes/class.ilObjAssessmentFolder.php
+++ b/Modules/Test/classes/class.ilObjAssessmentFolder.php
@@ -229,7 +229,7 @@ class ilObjAssessmentFolder extends ilObject
         if ((!is_array($type_ids)) || (count($type_ids) == 0)) {
             $setting->delete("assessment_manual_scoring");
         } else {
-            $setting->set("assessment_manual_scoring", implode($type_ids, ","));
+            $setting->set("assessment_manual_scoring", implode(",", $type_ids));
         }
     }
 
@@ -247,7 +247,7 @@ class ilObjAssessmentFolder extends ilObject
         if ((!is_array($type_ids)) || (count($type_ids) == 0)) {
             $setting->delete("assessment_scoring_adjustment");
         } else {
-            $setting->set("assessment_scoring_adjustment", implode($type_ids, ","));
+            $setting->set("assessment_scoring_adjustment", implode(",", $type_ids));
         }
     }
 

--- a/Modules/Test/classes/class.ilObjAssessmentFolderGUI.php
+++ b/Modules/Test/classes/class.ilObjAssessmentFolderGUI.php
@@ -384,7 +384,7 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
         }
         $csvoutput = "";
         foreach ($csv as $row) {
-            $csvoutput .= join($row, $separator) . "\n";
+            $csvoutput .= join($separator, $row) . "\n";
         }
         ilUtil::deliverData($csvoutput, str_replace(" ", "_", "log_" . $from . "_" . $until . "_" . $available_tests[$test]) . ".csv");
     }

--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -1487,7 +1487,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
                         array_push($changed_fields, "$key: " . $oldrow[$key] . " => " . $newrow[$key]);
                     }
                 }
-                $changes = join($changed_fields, ", ");
+                $changes = join(", ", $changed_fields);
                 if (count($changed_fields) > 0) {
                     $this->logAction($this->lng->txtlng("assessment", "log_modified_test", ilObjAssessmentFolder::_getLogLanguage()) . " [" . $changes . "]");
                 }
@@ -7041,7 +7041,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
                 }
             }
         }
-        return join($author, ",");
+        return join(",", $author);
     }
 
     /**
@@ -7070,7 +7070,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
                 }
             }
         }
-        return join($author, ",");
+        return join(",", $author);
     }
 
     /**

--- a/Modules/Test/classes/class.ilTestExport.php
+++ b/Modules/Test/classes/class.ilTestExport.php
@@ -307,7 +307,7 @@ abstract class ilTestExport
         $separator = ";";
         foreach ($rows as $evalrow) {
             $csvrow = &$this->test_obj->processCSVRow($evalrow, true, $separator);
-            $csv .= join($csvrow, $separator) . "\n";
+            $csv .= join($separator, $csvrow) . "\n";
         }
         if ($deliver) {
             ilUtil::deliverData($csv, ilUtil::getASCIIFilename($this->test_obj->getTitle() . "_aggregated.csv"));
@@ -923,7 +923,7 @@ abstract class ilTestExport
         $separator = ";";
         foreach ($rows as $evalrow) {
             $csvrow = &$this->test_obj->processCSVRow($evalrow, true, $separator);
-            $csv .= join($csvrow, $separator) . "\n";
+            $csv .= join($separator, $csvrow) . "\n";
         }
         if ($deliver) {
             ilUtil::deliverData($csv, ilUtil::getASCIIFilename($this->test_obj->getTitle() . "_results.csv"));

--- a/Modules/TestQuestionPool/classes/class.assErrorText.php
+++ b/Modules/TestQuestionPool/classes/class.assErrorText.php
@@ -814,9 +814,9 @@ class assErrorText extends assQuestion implements ilObjQuestionScoringAdjustable
                 $items[$idx] = $word;
                 $counter++;
             }
-            $textarray[$textidx] = join($items, " ");
+            $textarray[$textidx] = join(" ", $items);
         }
-        return join($textarray, "\n");
+        return join("\n", $textarray);
     }
 
     public function getBestSelection($withPositivePointsOnly = true)

--- a/Modules/TestQuestionPool/classes/class.assFlashQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assFlashQuestionGUI.php
@@ -272,10 +272,10 @@ class assFlashQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoring
 
         if (count($params)) {
             $template->setCurrentBlock("flash_vars");
-            $template->setVariable("FLASH_VARS", join($params, "&"));
+            $template->setVariable("FLASH_VARS", join("&", $params));
             $template->parseCurrentBlock();
             $template->setCurrentBlock("applet_parameters");
-            $template->setVariable("PARAM_VALUE", join($params, "&"));
+            $template->setVariable("PARAM_VALUE", join("&", $params));
             $template->parseCurrentBlock();
         }
         if ($show_question_text == true) {
@@ -309,10 +309,10 @@ class assFlashQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoring
         }
         if (count($params)) {
             $template->setCurrentBlock("flash_vars");
-            $template->setVariable("FLASH_VARS", join($params, "&"));
+            $template->setVariable("FLASH_VARS", join("&", $params));
             $template->parseCurrentBlock();
             $template->setCurrentBlock("applet_parameters");
-            $template->setVariable("PARAM_VALUE", join($params, "&"));
+            $template->setVariable("PARAM_VALUE", join("&", $params));
             $template->parseCurrentBlock();
         }
         $template->setVariable("QUESTIONTEXT", $this->object->prepareTextareaOutput($this->object->getQuestion(), true));
@@ -359,10 +359,10 @@ class assFlashQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoring
 
         if (count($params)) {
             $template->setCurrentBlock("flash_vars");
-            $template->setVariable("FLASH_VARS", join($params, "&"));
+            $template->setVariable("FLASH_VARS", join("&", $params));
             $template->parseCurrentBlock();
             $template->setCurrentBlock("applet_parameters");
-            $template->setVariable("PARAM_VALUE", join($params, "&"));
+            $template->setVariable("PARAM_VALUE", join("&", $params));
             $template->parseCurrentBlock();
         }
         $template->setVariable("QUESTIONTEXT", $this->object->prepareTextareaOutput($this->object->getQuestion(), true));

--- a/Modules/TestQuestionPool/classes/class.assImagemapQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assImagemapQuestionGUI.php
@@ -240,7 +240,7 @@ class assImagemapQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         $coords = "";
         switch ($_POST["shape"]) {
             case "rect":
-                $coords = join($_POST['image']['mapcoords'], ",");
+                $coords = join(",", $_POST['image']['mapcoords']);
                 ilUtil::sendSuccess($this->lng->txt('msg_rect_added'), true);
                 break;
             case "circle":
@@ -250,7 +250,7 @@ class assImagemapQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
                 ilUtil::sendSuccess($this->lng->txt('msg_circle_added'), true);
                 break;
             case "poly":
-                $coords = join($_POST['image']['mapcoords'], ",");
+                $coords = join(",", $_POST['image']['mapcoords']);
                 ilUtil::sendSuccess($this->lng->txt('msg_poly_added'), true);
                 break;
         }
@@ -301,9 +301,9 @@ class assImagemapQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
                     ilUtil::sendInfo($this->lng->txt("rectangle_click_tl_corner"));
                 } elseif (count($coords) == 1) {
                     ilUtil::sendInfo($this->lng->txt("rectangle_click_br_corner"));
-                    $preview->addPoint($preview->getAreaCount(), join($coords, ","), true, "blue");
+                    $preview->addPoint($preview->getAreaCount(), join(",", $coords), true, "blue");
                 } elseif (count($coords) == 2) {
-                    $c = join($coords, ",");
+                    $c = join(",", $coords);
                     $hidearea = true;
                     $disabled_save = "";
                 }
@@ -313,7 +313,7 @@ class assImagemapQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
                     ilUtil::sendInfo($this->lng->txt("circle_click_center"));
                 } elseif (count($coords) == 1) {
                     ilUtil::sendInfo($this->lng->txt("circle_click_circle"));
-                    $preview->addPoint($preview->getAreaCount(), join($coords, ","), true, "blue");
+                    $preview->addPoint($preview->getAreaCount(), join(",", $coords), true, "blue");
                 } elseif (count($coords) == 2) {
                     if (preg_match("/(\d+)\s*,\s*(\d+)\s+(\d+)\s*,\s*(\d+)/", $coords[0] . " " . $coords[1], $matches)) {
                         $c = "$matches[1],$matches[2]," . (int) sqrt((($matches[3] - $matches[1]) * ($matches[3] - $matches[1])) + (($matches[4] - $matches[2]) * ($matches[4] - $matches[2])));
@@ -327,11 +327,11 @@ class assImagemapQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
                     ilUtil::sendInfo($this->lng->txt("polygon_click_starting_point"));
                 } elseif (count($coords) == 1) {
                     ilUtil::sendInfo($this->lng->txt("polygon_click_next_point"));
-                    $preview->addPoint($preview->getAreaCount(), join($coords, ","), true, "blue");
+                    $preview->addPoint($preview->getAreaCount(), join(",", $coords), true, "blue");
                 } elseif (count($coords) > 1) {
                     ilUtil::sendInfo($this->lng->txt("polygon_click_next_or_save"));
                     $disabled_save = "";
-                    $c = join($coords, ",");
+                    $c = join(",". $coords);
                 }
                 break;
         }

--- a/Modules/TestQuestionPool/classes/class.assJavaApplet.php
+++ b/Modules/TestQuestionPool/classes/class.assJavaApplet.php
@@ -181,7 +181,7 @@ class assJavaApplet extends assQuestion implements ilObjQuestionScoringAdjustabl
             array_push($params_array, "param_value_$key=" . $value["value"]);
         }
         
-        return join($params_array, "<separator>");
+        return join("<separator>", $params_array);
     }
 
     /**
@@ -201,7 +201,7 @@ class assJavaApplet extends assQuestion implements ilObjQuestionScoringAdjustabl
             array_push($params_array, "param_name_$key=" . $value["name"]);
             array_push($params_array, "param_value_$key=" . $value["value"]);
         }
-        return join($params_array, "<separator>");
+        return join("<separator>", $params_array);
     }
 
     /**

--- a/Modules/TestQuestionPool/classes/class.assOrderingHorizontal.php
+++ b/Modules/TestQuestionPool/classes/class.assOrderingHorizontal.php
@@ -785,8 +785,8 @@ class assOrderingHorizontal extends assQuestion implements ilObjQuestionScoringA
     protected function calculateReachedPointsForSolution($value)
     {
         $value = $this->splitAndTrimOrderElementText($value, $this->answer_separator);
-        $value = join($value, $this->answer_separator);
-        if (strcmp($value, join($this->getOrderingElements(), $this->answer_separator)) == 0) {
+        $value = join($this->answer_separator, $value);
+        if (strcmp($value, join($this->answer_separator, $this->getOrderingElements())) == 0) {
             $points = $this->getPoints();
             return $points;
         }

--- a/Modules/TestQuestionPool/classes/class.assOrderingHorizontalGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assOrderingHorizontalGUI.php
@@ -255,7 +255,7 @@ class assOrderingHorizontalGUI extends assQuestionGUI implements ilGuiQuestionSc
             $template->parseCurrentBlock();
         }
         $template->setVariable("QUESTION_ID", $this->object->getId());
-        $template->setVariable("VALUE_ORDERRESULT", ' value="' . join($elements, '{::}') . '"');
+        $template->setVariable("VALUE_ORDERRESULT", ' value="' . join('{::}', $elements) . '"');
         if ($this->object->textsize >= 10) {
             $template->setVariable("STYLE", " style=\"font-size: " . $this->object->textsize . "%;\"");
         }
@@ -314,7 +314,7 @@ class assOrderingHorizontalGUI extends assQuestionGUI implements ilGuiQuestionSc
         if ($this->object->textsize >= 10) {
             $template->setVariable("STYLE", " style=\"font-size: " . $this->object->textsize . "%;\"");
         }
-        $template->setVariable("VALUE_ORDERRESULT", ' value="' . join($elements, '{::}') . '"');
+        $template->setVariable("VALUE_ORDERRESULT", ' value="' . join('{::}', $elements) . '"');
         $template->setVariable("QUESTIONTEXT", $this->object->prepareTextareaOutput($this->object->getQuestion(), true));
         $questionoutput = $template->get();
         if (!$show_question_only) {

--- a/Modules/TestQuestionPool/classes/class.assQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assQuestion.php
@@ -1065,7 +1065,7 @@ abstract class assQuestion
                     break;
             }
         }
-        return join($output, "<br />");
+        return join("<br />", $output);
     }
 
     /**

--- a/Modules/TestQuestionPool/classes/class.ilMatchingPairWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilMatchingPairWizardInputGUI.php
@@ -248,7 +248,7 @@ class ilMatchingPairWizardInputGUI extends ilTextInputGUI
             array_push($ids, $term->identifier);
         }
         $tpl->setVariable("POST_VAR", $this->getPostVar());
-        $tpl->setVariable("TERM_IDS", join($ids, ","));
+        $tpl->setVariable("TERM_IDS", join(",", $ids));
         $tpl->parseCurrentBlock();
         
         $tpl->setCurrentBlock('definition_ids');
@@ -257,7 +257,7 @@ class ilMatchingPairWizardInputGUI extends ilTextInputGUI
             array_push($ids, $definition->identifier);
         }
         $tpl->setVariable("POST_VAR", $this->getPostVar());
-        $tpl->setVariable("DEFINITION_IDS", join($ids, ","));
+        $tpl->setVariable("DEFINITION_IDS", join(",", $ids));
         $tpl->parseCurrentBlock();
         
         $tpl->setVariable("ELEMENT_ID", $this->getPostVar());

--- a/Modules/TestQuestionPool/classes/export/qti12/class.assMatchingQuestionExport.php
+++ b/Modules/TestQuestionPool/classes/export/qti12/class.assMatchingQuestionExport.php
@@ -137,7 +137,7 @@ class assMatchingQuestionExport extends assQuestionExport
             $attrs = array(
                 "ident" => $definition->identifier,
                 "match_max" => "1",
-                "match_group" => join($termids, ",")
+                "match_group" => join(",", $termids)
             );
             $a_xml_writer->xmlStartTag("response_label", $attrs);
             $a_xml_writer->xmlStartTag("material");

--- a/Modules/TestQuestionPool/classes/forms/class.ilAssMatchingPairCorrectionsInputGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilAssMatchingPairCorrectionsInputGUI.php
@@ -101,7 +101,7 @@ class ilAssMatchingPairCorrectionsInputGUI extends ilMatchingPairWizardInputGUI
             array_push($ids, $term->identifier);
         }
         $tpl->setVariable("POST_VAR", $this->getPostVar());
-        $tpl->setVariable("TERM_IDS", join($ids, ","));
+        $tpl->setVariable("TERM_IDS", join(",", $ids));
         $tpl->parseCurrentBlock();
         
         $tpl->setCurrentBlock('definition_ids');
@@ -110,7 +110,7 @@ class ilAssMatchingPairCorrectionsInputGUI extends ilMatchingPairWizardInputGUI
             array_push($ids, $definition->identifier);
         }
         $tpl->setVariable("POST_VAR", $this->getPostVar());
-        $tpl->setVariable("DEFINITION_IDS", join($ids, ","));
+        $tpl->setVariable("DEFINITION_IDS", join(",", $ids));
         $tpl->parseCurrentBlock();
         
         $tpl->setVariable("ELEMENT_ID", $this->getPostVar());

--- a/Services/Container/classes/class.ilContainerGUI.php
+++ b/Services/Container/classes/class.ilContainerGUI.php
@@ -1603,7 +1603,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             $ilCtrl->setParameterByClass("ilobjectcopygui", "source_id", $_POST["id"][0]);
             $ilCtrl->redirectByClass("ilobjectcopygui", "initTargetSelection");
         } else {
-            $ilCtrl->setParameterByClass("ilobjectcopygui", "source_ids", implode($_POST["id"], "_"));
+            $ilCtrl->setParameterByClass("ilobjectcopygui", "source_ids", implode("_", $_POST["id"]));
             $ilCtrl->redirectByClass("ilobjectcopygui", "initTargetSelection");
         }
 
@@ -2290,7 +2290,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 $ilCtrl->redirectByClass("ilobjectcopygui", "saveTarget");
             } else {
                 $ilCtrl->setParameterByClass("ilobjectcopygui", "target", $this->object->getRefId());
-                $ilCtrl->setParameterByClass("ilobjectcopygui", "source_ids", implode($ref_ids, "_"));
+                $ilCtrl->setParameterByClass("ilobjectcopygui", "source_ids", implode("_", $ref_ids));
                 $ilCtrl->redirectByClass("ilobjectcopygui", "saveTarget");
             }
 

--- a/Services/Database/classes/PDO/class.ilDBPdo.php
+++ b/Services/Database/classes/PDO/class.ilDBPdo.php
@@ -883,7 +883,7 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface
     public function addFulltextIndex($a_table, $a_fields, $a_name = "in")
     {
         $i_name = $this->constraintName($a_table, $a_name) . "_idx";
-        $f_str = implode($a_fields, ",");
+        $f_str = implode(",", $a_fields);
         $q = "ALTER TABLE $a_table ADD FULLTEXT $i_name ($f_str)";
         $this->query($q);
     }

--- a/Services/Database/classes/PDO/class.ilDBPdoPostgreSQL.php
+++ b/Services/Database/classes/PDO/class.ilDBPdoPostgreSQL.php
@@ -173,7 +173,7 @@ class ilDBPdoPostgreSQL extends ilDBPdo implements ilDBInterface
         }
         //		if ($lobs)	// lobs -> use prepare execute (autoexecute broken in PEAR 2.4.1)
         //		{
-        $this->manipulate("DELETE FROM " . $a_table . " WHERE " . implode($delwhere, " AND "));
+        $this->manipulate("DELETE FROM " . $a_table . " WHERE " . implode(" AND ", $delwhere));
         $this->insert($a_table, $a_columns);
 
         return true;

--- a/Services/Database/classes/class.ilDBGenerator.php
+++ b/Services/Database/classes/class.ilDBGenerator.php
@@ -698,11 +698,11 @@ class ilDBGenerator
                 $values[] = "'" . str_replace("'", "\'", $v) . "'";
                 $i_str[] = "'" . $f . "' => array('" . $this->fields[$f]["type"] . "', '" . str_replace("'", "\'", $v) . "')";
             }
-            $fields_str = "(" . implode($fields, ",") . ")";
-            $types_str = "array(" . implode($types, ",") . ")";
-            $values_str = "array(" . implode($values, ",") . ")";
+            $fields_str = "(" . implode(",", $fields) . ")";
+            $types_str = "array(" . implode(",", $types) . ")";
+            $values_str = "array(" . implode(",", $values) . ")";
             $ins_st = "\n" . '$ilDB->insert("' . $a_table . '", array(' . "\n";
-            $ins_st .= implode($i_str, ", ") . "));\n";
+            $ins_st .= implode(", ", $i_str) . "));\n";
             //$ins_st.= "\t".$fields_str."\n";
             //$ins_st.= "\t".'VALUES '."(%s".str_repeat(",%s", count($fields) - 1).')"'.",\n";
             //$ins_st.= "\t".$types_str.','.$values_str.');'."\n";
@@ -776,7 +776,7 @@ class ilDBGenerator
                 }
                 $a_tpl->setCurrentBlock("index");
                 $a_tpl->setVariable("VAL_INDEX", $def["name"]);
-                $a_tpl->setVariable("VAL_FIELDS", implode($f2, ", "));
+                $a_tpl->setVariable("VAL_FIELDS", implode(", ", $f2));
                 $a_tpl->parseCurrentBlock();
                 $indices_output = true;
             }
@@ -795,7 +795,7 @@ class ilDBGenerator
                 $a_tpl->setCurrentBlock("constraint");
                 $a_tpl->setVariable("VAL_CONSTRAINT", $def["name"]);
                 $a_tpl->setVariable("VAL_CTYPE", $def["type"]);
-                $a_tpl->setVariable("VAL_CFIELDS", implode($f2, ", "));
+                $a_tpl->setVariable("VAL_CFIELDS", implode(", ", $f2));
                 $a_tpl->parseCurrentBlock();
                 $constraints_output = true;
             }

--- a/Services/FileSystem/classes/class.ilFileSystemTableGUI.php
+++ b/Services/FileSystem/classes/class.ilFileSystemTableGUI.php
@@ -118,7 +118,7 @@ class ilFileSystemTableGUI extends ilTable2GUI
                 
             if ($this->label_enable) {
                 $label = (is_array($this->file_labels[$cfile]))
-                    ? implode($this->file_labels[$cfile], ", ")
+                    ? implode(", ", $this->file_labels[$cfile])
                     : "";
             }
 

--- a/Services/Form/classes/class.ilFlashFileInputGUI.php
+++ b/Services/Form/classes/class.ilFlashFileInputGUI.php
@@ -333,10 +333,10 @@ class ilFlashFileInputGUI extends ilFileInputGUI
                     $index++;
                 }
                 $template->setCurrentBlock("applet_parameter");
-                $template->setVariable("PARAM_VALUE", join($params, "&"));
+                $template->setVariable("PARAM_VALUE", join("&", $params));
                 $template->parseCurrentBlock();
                 $template->setCurrentBlock("flash_vars");
-                $template->setVariable("PARAM_VALUE", join($params, "&"));
+                $template->setVariable("PARAM_VALUE", join("&", $params));
                 $template->parseCurrentBlock();
             }
             $template->setCurrentBlock("applet");

--- a/Services/Init/classes/class.ilPasswordAssistanceGUI.php
+++ b/Services/Init/classes/class.ilPasswordAssistanceGUI.php
@@ -669,7 +669,7 @@ class ilPasswordAssistanceGUI
                 array("\n", "\t"),
                 sprintf(
                     $this->lng->txt('pwassist_username_mail_body'),
-                    join($logins, ",\n"),
+                    join(",\n", $logins),
                     $this->getBaseUrl() . '/',
                     $_SERVER['REMOTE_ADDR'],
                     $email,

--- a/Services/MetaData/classes/class.ilMDEditorGUI.php
+++ b/Services/MetaData/classes/class.ilMDEditorGUI.php
@@ -222,7 +222,7 @@ class ilMDEditorGUI
 
             $this->tpl->setCurrentBlock("keyword_loop");
             $this->tpl->setVariable("KEYWORD_LOOP_VAL", ilUtil::prepareFormOutput(
-                implode($keyword_set, ", ")
+                implode(", ", $keyword_set)
             ));
             $this->tpl->setVariable("LANG", $lang);
             $this->tpl->setVariable("KEYWORD_LOOP_VAL_LANGUAGE", $this->__showLanguageSelect(

--- a/Services/Tracking/classes/class.ilLPXmlWriter.php
+++ b/Services/Tracking/classes/class.ilLPXmlWriter.php
@@ -164,7 +164,7 @@ class ilLPXmlWriter extends ilXmlWriter
                     array(
                         'UserId' => $rec["usr_id"],
                         'ObjId' => $rec["obj_id"],
-                        'RefIds' => implode($ref_ids, ","),
+                        'RefIds' => implode(",", $ref_ids),
                         'Timestamp' => $rec["status_changed"],
                         'LPStatus' => $rec["status"]
                         )

--- a/webservice/soap/classes/class.ilSoapLearningProgressAdministration.php
+++ b/webservice/soap/classes/class.ilSoapLearningProgressAdministration.php
@@ -491,7 +491,7 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
         // check administrator
         $types = "";
         if (is_array($type_filter)) {
-            $types = implode($type_filter, ",");
+            $types = implode(",", $type_filter);
         }
         
         // output lp changes as xml


### PR DESCRIPTION
This PR fixes wrong `join()` and `implode()` calls.

This is similar to #2819 , but without distracted code formatting changes and higher coverage.