### PR TITLE
Fix usage of $php_errormsg

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assFlashQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assFlashQuestion.php
@@ -437,11 +437,11 @@ class assFlashQuestion extends assQuestion implements ilObjQuestionScoringAdjust
         $ctx = stream_context_create($params);
         $fp = @fopen($url, 'rb', false, $ctx);
         if (!$fp) {
-            throw new Exception("Problem with $url, $php_errormsg");
+            throw new Exception("Problem with $url, " . error_get_last());
         }
         $response = @stream_get_contents($fp);
         if ($response === false) {
-            throw new Exception("Problem reading data from $url, $php_errormsg");
+            throw new Exception("Problem reading data from $url, " . error_get_last());
         }
         return $response;
     }


### PR DESCRIPTION
`$php_errormsg` MUST not be used in future PHP versions, `error_get_last()` MUST be used instead.