### PR TITLE
BT-28825: Fixed missing screen IDs for calendar views

### DIFF
--- a/Services/Calendar/classes/class.ilCalendarPresentationGUI.php
+++ b/Services/Calendar/classes/class.ilCalendarPresentationGUI.php
@@ -190,6 +190,8 @@ class ilCalendarPresentationGUI
 
         $this->initSeed();
         $this->prepareOutput();
+
+        $this->help->setScreenIdComponent("cal");
         
         switch ($cmd) {
             case 'selectCHCalendarOfUser':
@@ -707,9 +709,6 @@ class ilCalendarPresentationGUI
         global $DIC;
 
         $tpl = $DIC->ui()->mainTemplate();
-        $ilHelp = $this->help;
-
-        $ilHelp->setScreenIdComponent("cal");
 
         if ($this->category_id) {
             $this->addCategoryTabs();


### PR DESCRIPTION
Well, turns out all that was needed was to move the setScreenComponent function to a more central location to fix the whole calendar view