### PR TITLE
BT-25530: Added labels to calendar selection

### DIFF
--- a/Services/Calendar/templates/default/tpl.cal_selection_block_content.html
+++ b/Services/Calendar/templates/default/tpl.cal_selection_block_content.html
@@ -9,7 +9,7 @@
 		<div>
 			<div class="ilCalColSpan" style="border-color: {BGCOLOR}">
 				<input type="hidden" name="shown_cat_ids[]" value="{VAL_ID}" />
-				<input type="checkbox" name="selected_cat_ids[]" value="{VAL_ID}" {VAL_CHECKED} {VAL_DISABLED}/>
+				<input id="check_{VAL_ID}" type="checkbox" name="selected_cat_ids[]" value="{VAL_ID}" {VAL_CHECKED} {VAL_DISABLED}/>
 			</div>
 			<div>
 				<img src="{IMG_SRC}" alt="{IMG_ALT}" title="{IMG_ALT}" />
@@ -17,7 +17,9 @@
 			<div>
 				<!-- BEGIN linked_title -->
 				<div class="ilCalSelTitle">
-				<a class="small" href="{EDIT_LINK}">{VAL_TITLE}</a>
+				<label for="check_{VAL_ID}" style="margin-bottom: 0px;">
+					<a class="small" href="{EDIT_LINK}">{VAL_TITLE}</a>
+				</label>
 				<!-- END linked_title -->
 				<!-- BEGIN plain_title -->
 				{PLAIN_TITLE}


### PR DESCRIPTION
Also set label bottom-margin to 0 in template, so the standard css for labels won't affect the Calendar Selection visuals.