### PR TITLE
allow uuid creation from strings

### DIFF
--- a/src/Data/UUID/Factory.php
+++ b/src/Data/UUID/Factory.php
@@ -45,4 +45,13 @@ class Factory
     {
         return $this->uuid4()->toString();
     }
+
+    /**
+     * @param string $uuid
+     * @return Uuid
+     */
+    public function fromString(string $uuid) : Uuid
+    {
+        return new RamseyUuidWrapper($this->uuid_factory->fromString($uuid));
+    }
 }

--- a/tests/Data/UuidTest.php
+++ b/tests/Data/UuidTest.php
@@ -29,7 +29,6 @@ class UuidTest extends TestCase
         $factory = new Factory();
         $uuid = $factory->uuid4();
 
-        $this->assertTrue(get_class($uuid) === RamseyUuidWrapper::class);
         $this->assertEquals(1, preg_match(self::VALID_UUID4, $uuid->toString()));
     }
 
@@ -53,9 +52,8 @@ class UuidTest extends TestCase
         $factory = new Factory();
         $uuid = $factory->fromString(self::UUID4);
 
-        $this->assertTrue(get_class($uuid) === RamseyUuidWrapper::class);
         $this->assertEquals(1, preg_match(self::VALID_UUID4, $uuid->toString()));
-        $this->assertTrue($uuid->toString() === self::UUID4);
+        $this->assertEquals(self::UUID4, $uuid->toString());
     }
 
     /**

--- a/tests/Data/UuidTest.php
+++ b/tests/Data/UuidTest.php
@@ -1,0 +1,71 @@
+<?php
+require_once("libs/composer/vendor/autoload.php");
+
+use PHPUnit\Framework\TestCase;
+use ILIAS\Data\UUID\Factory;
+use ILIAS\Data\UUID\RamseyUuidWrapper;
+use Ramsey\Uuid\Exception\InvalidUuidStringException;
+
+class UuidTest extends TestCase
+{
+    const VALID_UUID4 = '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$/';
+
+    const UUID4 = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+    const NO_UUID = 'lorem ipsum dolor';
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function test_init()
+    {
+        return new Factory();
+    }
+
+    /**
+     * @depends test_init
+     */
+    public function test_uuid4()
+    {
+        $factory = new Factory();
+        $uuid = $factory->uuid4();
+
+        $this->assertTrue(get_class($uuid) === RamseyUuidWrapper::class);
+        $this->assertEquals(1, preg_match(self::VALID_UUID4, $uuid->toString()));
+    }
+
+    /**
+     * @depends test_init
+     */
+    public function test_uuid4_string()
+    {
+        $factory = new Factory();
+        $uuid = $factory->uuid4AsString();
+
+        $this->assertTrue(is_string($uuid));
+        $this->assertEquals(1, preg_match(self::VALID_UUID4, $uuid));
+    }
+
+    /**
+     * @depends test_init
+     */
+    public function test_from_string()
+    {
+        $factory = new Factory();
+        $uuid = $factory->fromString(self::UUID4);
+
+        $this->assertTrue(get_class($uuid) === RamseyUuidWrapper::class);
+        $this->assertEquals(1, preg_match(self::VALID_UUID4, $uuid->toString()));
+        $this->assertTrue($uuid->toString() === self::UUID4);
+    }
+
+    /**
+     * @depends test_init
+     */
+    public function test_from_illegal_string()
+    {
+        $this->expectException(InvalidUuidStringException::class);
+
+        $factory = new Factory();
+        $factory->fromString(self::NO_UUID);
+    }
+}


### PR DESCRIPTION
Allow uuid creation from strings, as it is needed to load Uuids from the Database or to process Uuid query-parameters