### PR TITLE
UI/Input/Field/Numeric - allow empty strings in optional numeric inputs

### DIFF
--- a/src/UI/Implementation/Component/Input/Field/Numeric.php
+++ b/src/UI/Implementation/Component/Input/Field/Numeric.php
@@ -34,7 +34,14 @@ class Numeric extends Input implements C\Input\Field\Numeric
 
         //TODO: Is there a better way to do this? Note, that "withConstraint" is not
         // usable here (clone).
-        $this->setAdditionalConstraint($this->validation_factory->or([$this->validation_factory->isNumeric(), $this->validation_factory->isNull()]));
+        $this->setAdditionalConstraint(
+            $this->validation_factory->or(
+                [
+                    $this->validation_factory->isNumeric(),
+                    $this->validation_factory->hasMaxLength(0) //allow empty string
+                ]
+            )
+        );
     }
 
 

--- a/src/UI/Implementation/Component/Input/Field/Numeric.php
+++ b/src/UI/Implementation/Component/Input/Field/Numeric.php
@@ -32,13 +32,24 @@ class Numeric extends Input implements C\Input\Field\Numeric
     ) {
         parent::__construct($data_factory, $validation_factory, $transformation_factory, $label, $byline);
 
+        $this->setAdditionalTransformation(
+            $this->transformation_factory->custom(
+                function ($v) {
+                    if (trim($v) === '') {
+                        return null;
+                    }
+                    return $v;
+                }
+            )
+        );
+
         //TODO: Is there a better way to do this? Note, that "withConstraint" is not
         // usable here (clone).
         $this->setAdditionalConstraint(
             $this->validation_factory->or(
                 [
                     $this->validation_factory->isNumeric(),
-                    $this->validation_factory->hasMaxLength(0) //allow empty string
+                    $this->validation_factory->isNull()
                 ]
             )
         );

--- a/src/UI/examples/Input/Field/Numeric/numeric_inputs.php
+++ b/src/UI/examples/Input/Field/Numeric/numeric_inputs.php
@@ -11,20 +11,15 @@ function numeric_inputs()
     $request = $DIC->http()->request();
 
     //Step 1: Declare the numeric input
-    $number_input = $ui->input()->field()->numeric("Some Number", "Put in a number.")->withValue(133);
+    $number_input = $ui->input()->field()
+        ->numeric("Some Number", "Put in a number.")
+        ->withValue(133);
 
-    //Step 2, define form and form actions
-    $DIC->ctrl()->setParameterByClass(
-        'ilsystemstyledocumentationgui',
-        'example_name',
-        'numeric_inputs'
-    );
-    $form_action = $DIC->ctrl()->getFormActionByClass('ilsystemstyledocumentationgui');
-    $form = $ui->input()->container()->form()->standard($form_action, [ $number_input]);
+    //Step 2, define form
+    $form = $ui->input()->container()->form()->standard('#', [ $number_input]);
 
-    //Step 4, implement some form data processing.
-    if ($request->getMethod() == "POST"
-            && $request->getQueryParams()['example_name'] == 'numeric_inputs') {
+    //Step 3, implement some form data processing.
+    if ($request->getMethod() == "POST") {
         $form = $form->withRequest($request);
         $result = $form->getData();
     } else {

--- a/src/UI/examples/Input/Field/Numeric/numeric_inputs.php
+++ b/src/UI/examples/Input/Field/Numeric/numeric_inputs.php
@@ -15,8 +15,13 @@ function numeric_inputs()
         ->numeric("Some Number", "Put in a number.")
         ->withValue(133);
 
+    $number_input2 = $number_input->withRequired(true)->withValue('');
+
     //Step 2, define form
-    $form = $ui->input()->container()->form()->standard('#', [ $number_input]);
+    $form = $ui->input()->container()->form()->standard('#', [
+        'n1' => $number_input,
+        'n2' => $number_input2
+    ]);
 
     //Step 3, implement some form data processing.
     if ($request->getMethod() == "POST") {

--- a/tests/UI/Component/Input/Field/NumericInputTest.php
+++ b/tests/UI/Component/Input/Field/NumericInputTest.php
@@ -116,4 +116,36 @@ class NumericInputTest extends ILIAS_UI_TestBase
                     . "	</div>" . "</div>";
         $this->assertEquals($expected, $html);
     }
+
+    public function testNullValue()
+    {
+        $f = $this->buildFactory();
+        $post_data = new DefPostData(['name_0' => null]);
+        $field = $f->numeric('')->withNameFrom($this->name_source);
+        $field_required = $field->withRequired(true);
+
+        $value = $field->withInput($post_data)->getContent();
+        $this->assertTrue($value->isOk());
+        $this->assertNull($value->value());
+
+        $value = $field_required->withInput($post_data)->getContent();
+        $this->assertTrue($value->isError());
+        return $field;
+    }
+
+    /**
+     * @depends testNullValue
+     */
+    public function testEmptyValue($field)
+    {
+        $post_data = new DefPostData(['name_0' => '']);
+        $field_required = $field->withRequired(true);
+
+        $value = $field->withInput($post_data)->getContent();
+        $this->assertTrue($value->isOk());
+        $this->assertEquals('', $value->value());
+
+        $value = $field_required->withInput($post_data)->getContent();
+        $this->assertTrue($value->isError());
+    }
 }

--- a/tests/UI/Component/Input/Field/NumericInputTest.php
+++ b/tests/UI/Component/Input/Field/NumericInputTest.php
@@ -26,7 +26,7 @@ class NumericInputTest extends ILIAS_UI_TestBase
         return new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new SignalGenerator(),
             $df,
-            new Validation\Factory($df, $this->createMock(\ilLanguage::class)),
+            new Validation\Factory($df, $this->getLanguage()),
             new Transformation\Factory()
         );
     }
@@ -143,7 +143,8 @@ class NumericInputTest extends ILIAS_UI_TestBase
 
         $value = $field->withInput($post_data)->getContent();
         $this->assertTrue($value->isOk());
-        $this->assertEquals('', $value->value());
+        $this->assertNull($value->value());
+        $this->assertFalse($value->value() === '');
 
         $value = $field_required->withInput($post_data)->getContent();
         $this->assertTrue($value->isError());


### PR DESCRIPTION
validation OKs empty string, isNull has no effect;
add tests.

fixes https://mantis.ilias.de/view.php?id=28861
