### PR TITLE
UI/Input/Field/Numeric - allow empty strings in optional numeric inputs

### DIFF
--- a/src/UI/Implementation/Component/Input/Field/Numeric.php
+++ b/src/UI/Implementation/Component/Input/Field/Numeric.php
@@ -14,7 +14,6 @@ use ILIAS\UI\Component\Signal;
  */
 class Numeric extends Input implements C\Input\Field\Numeric
 {
-
     /**
      * Numeric constructor.
      *
@@ -31,17 +30,27 @@ class Numeric extends Input implements C\Input\Field\Numeric
         $byline
     ) {
         parent::__construct($data_factory, $refinery, $label, $byline);
-        $this->setAdditionalTransformation(
-            $this->refinery->logical()->logicalOr([
-                $this->refinery->numeric()->isNumeric(),
-                $this->refinery->string()->hasMaxLength(0)
-            ])
-            ->withProblemBuilder(function ($txt, $value) {
-                return $txt("ui_numeric_only");
-            })
-        );
-    }
 
+        $trafo_empty2null = $this->refinery->custom()->transformation(
+            function ($v) {
+                if (trim($v) === '') {
+                    return null;
+                }
+                return $v;
+            },
+            ""
+        );
+        $trafo_numericOrNull = $this->refinery->logical()->logicalOr([
+            $this->refinery->numeric()->isNumeric(),
+            $this->refinery->null()
+        ])
+        ->withProblemBuilder(function ($txt, $value) {
+            return $txt("ui_numeric_only");
+        });
+
+        $this->setAdditionalTransformation($trafo_empty2null);
+        $this->setAdditionalTransformation($trafo_numericOrNull);
+    }
 
     /**
      * @inheritdoc
@@ -51,18 +60,12 @@ class Numeric extends Input implements C\Input\Field\Numeric
         return is_numeric($value) || $value === "" || $value === null;
     }
 
-
     /**
      * @inheritdoc
      */
     protected function getConstraintForRequirement()
     {
-        return $this->refinery->logical()->parallel([
-            $this->refinery->numeric()->isNumeric(),
-            $this->refinery->logical()->not(
-                $this->refinery->null()
-            )
-        ]) ;
+        return $this->refinery->numeric()->isNumeric();
     }
 
     /**

--- a/src/UI/Implementation/Component/Input/Field/Numeric.php
+++ b/src/UI/Implementation/Component/Input/Field/Numeric.php
@@ -34,7 +34,7 @@ class Numeric extends Input implements C\Input\Field\Numeric
         $this->setAdditionalTransformation(
             $this->refinery->logical()->logicalOr([
                 $this->refinery->numeric()->isNumeric(),
-                $this->refinery->null()
+                $this->refinery->string()->hasMaxLength(0)
             ])
             ->withProblemBuilder(function ($txt, $value) {
                 return $txt("ui_numeric_only");
@@ -57,7 +57,12 @@ class Numeric extends Input implements C\Input\Field\Numeric
      */
     protected function getConstraintForRequirement()
     {
-        return $this->refinery->numeric()->isNumeric();
+        return $this->refinery->logical()->parallel([
+            $this->refinery->numeric()->isNumeric(),
+            $this->refinery->logical()->not(
+                $this->refinery->null()
+            )
+        ]) ;
     }
 
     /**

--- a/src/UI/examples/Input/Field/Numeric/numeric_inputs.php
+++ b/src/UI/examples/Input/Field/Numeric/numeric_inputs.php
@@ -15,8 +15,13 @@ function numeric_inputs()
         ->numeric("Some Number", "Put in a number.")
         ->withValue(133);
 
+    $number_input2 = $number_input->withRequired(true)->withValue('');
+
     //Step 2, define form and form actions
-    $form = $ui->input()->container()->form()->standard('#', [ $number_input]);
+    $form = $ui->input()->container()->form()->standard('#', [
+        'n1' => $number_input,
+        'n2' => $number_input2
+    ]);
 
     //Step 3, implement some form data processing.
     if ($request->getMethod() == "POST") {

--- a/src/UI/examples/Input/Field/Numeric/numeric_inputs.php
+++ b/src/UI/examples/Input/Field/Numeric/numeric_inputs.php
@@ -11,12 +11,14 @@ function numeric_inputs()
     $request = $DIC->http()->request();
 
     //Step 1: Declare the numeric input
-    $number_input = $ui->input()->field()->numeric("Some Number", "Put in a number.")->withValue(133);
+    $number_input = $ui->input()->field()
+        ->numeric("Some Number", "Put in a number.")
+        ->withValue(133);
 
     //Step 2, define form and form actions
     $form = $ui->input()->container()->form()->standard('#', [ $number_input]);
 
-    //Step 4, implement some form data processing.
+    //Step 3, implement some form data processing.
     if ($request->getMethod() == "POST") {
         $form = $form->withRequest($request);
         $result = $form->getData();

--- a/tests/UI/Component/Input/Field/NumericInputTest.php
+++ b/tests/UI/Component/Input/Field/NumericInputTest.php
@@ -132,4 +132,53 @@ class NumericInputTest extends ILIAS_UI_TestBase
                     . "		" . "		" . "	</div>" . "</div>";
         $this->assertEquals($expected, $html);
     }
+
+    public function testNullValue()
+    {
+        $f = $this->buildFactory();
+        $post_data = new DefInputData(['name_0' => null]);
+        $field = $f->numeric('')->withNameFrom($this->name_source);
+        $field_required = $field->withRequired(true);
+
+        $value = $field->withInput($post_data)->getContent();
+        $this->assertTrue($value->isOk());
+        $this->assertNull($value->value());
+
+        $value = $field_required->withInput($post_data)->getContent();
+        $this->assertTrue($value->isError());
+        return $field;
+    }
+
+    /**
+     * @depends testNullValue
+     */
+    public function testEmptyValue($field)
+    {
+        $post_data = new DefInputData(['name_0' => '']);
+        $field_required = $field->withRequired(true);
+
+        $value = $field->withInput($post_data)->getContent();
+        $this->assertTrue($value->isOk());
+        $this->assertEquals('', $value->value());
+
+        $value = $field_required->withInput($post_data)->getContent();
+        $this->assertTrue($value->isError());
+    }
+
+    /**
+     * @depends testNullValue
+     */
+    public function testZeroisValidValue($field)
+    {
+        $post_data = new DefInputData(['name_0' => 0]);
+        $field_required = $field->withRequired(true);
+
+        $value = $field->withInput($post_data)->getContent();
+        $this->assertTrue($value->isOk());
+        $this->assertEquals(0, $value->value());
+
+        $value = $field_required->withInput($post_data)->getContent();
+        $this->assertTrue($value->isOK());
+        $this->assertEquals(0, $value->value());
+    }
 }

--- a/tests/UI/Component/Input/Field/NumericInputTest.php
+++ b/tests/UI/Component/Input/Field/NumericInputTest.php
@@ -22,7 +22,7 @@ class NumericInputTest extends ILIAS_UI_TestBase
     protected function buildFactory()
     {
         $df = new Data\Factory();
-        $language = $this->createMock(\ilLanguage::class);
+        $language = $this->getLanguage();
         return new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             new SignalGenerator(),
             $df,
@@ -159,16 +159,17 @@ class NumericInputTest extends ILIAS_UI_TestBase
 
         $value = $field->withInput($post_data)->getContent();
         $this->assertTrue($value->isOk());
-        $this->assertEquals('', $value->value());
+        $this->assertNull($value->value());
 
-        $value = $field_required->withInput($post_data)->getContent();
+        $field_required = $field_required->withInput($post_data);
+        $value = $field_required->getContent();
         $this->assertTrue($value->isError());
     }
 
     /**
      * @depends testNullValue
      */
-    public function testZeroisValidValue($field)
+    public function testZeroIsValidValue($field)
     {
         $post_data = new DefInputData(['name_0' => 0]);
         $field_required = $field->withRequired(true);


### PR DESCRIPTION
fixes https://mantis.ilias.de/view.php?id=28861 for ILIAS 6,
see https://github.com/ILIAS-eLearning/ILIAS/pull/2887