### PR TITLE
UI/Input/Radio - numeric values, fix #28862

### DIFF
--- a/src/UI/Implementation/Component/Input/Field/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Field/Renderer.php
@@ -519,7 +519,7 @@ class Renderer extends AbstractComponentRenderer
             $input_tpl->setVariable("VALUE", $value);
             $input_tpl->setVariable("LABEL", $label);
 
-            if ($input->getValue() !== null && $input->getValue() === $value) {
+            if ($input->getValue() !== null && $input->getValue() == $value) {
                 $input_tpl->setVariable("CHECKED", 'checked="checked"');
             }
 

--- a/src/UI/examples/Input/Field/Radio/base.php
+++ b/src/UI/examples/Input/Field/Radio/base.php
@@ -23,11 +23,17 @@ function base()
         ->withOption('value1', 'label1', 'byline1')
         ->withOption('value2', 'label2', 'byline2', $dependant_fields);
 
+    $radio_num_value = $ui->input()->field()->radio("Numeric Values", "pick one...")
+        ->withOption('1', 'One', '')
+        ->withOption('2', 'Two', '')
+        ->withOption('3', 'Three', '');
+
     //Step 2: define the radio
     $radio = $ui->input()->field()->radio("Radio", "check an option")
         ->withOption('value1', 'label1', 'byline1')
         ->withOption('value2', 'label2', 'byline2', $dependant_fields)
-        ->withOption('value3', 'label3', 'byline3', [$radio_d]);
+        ->withOption('value3', 'label3', 'byline3', [$radio_d])
+        ->withOption('value4', 'numerics', 'test num values', [$radio_num_value]);
 
 
     //Step 3: define form and form actions
@@ -37,12 +43,11 @@ function base()
         'radio'
     );
     $form_action = $DIC->ctrl()->getFormActionByClass('ilsystemstyledocumentationgui');
-    $form = $ui->input()->container()->form()->standard($form_action, ['radio' => $radio]);
+    $form = $ui->input()->container()->form()->standard('#', ['radio' => $radio]);
 
     //Step 4: implement some form data processing. Note, the value of the checkbox will
     // be 'checked' if checked an null if unchecked.
-    if ($request->getMethod() == "POST"
-        && $request->getQueryParams()['example_name'] == 'radio') {
+    if ($request->getMethod() == "POST") {
         $form = $form->withRequest($request);
         $result = $form->getData();
     } else {


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=28862
Value was relayed/handled properly, but not set again on output. I softended the check.

From PHP-docu: 
https://www.php.net/manual/en/language.types.array.php
"""Additionally the following key casts will occur:
Strings containing valid decimal integers, unless the number is preceded by a + sign, will be cast to the integer type. E.g. the key "8" will actually be stored under 8. On the other hand "08" will not be cast, as it isn't a valid decimal integer."""