### PR TITLE
0028831: Learning Progress Performance -> SCORM

### DIFF
--- a/Modules/ScormAicc/classes/class.ilScormLP.php
+++ b/Modules/ScormAicc/classes/class.ilScormLP.php
@@ -13,6 +13,11 @@ include_once "Services/Object/classes/class.ilObjectLP.php";
  */
 class ilScormLP extends ilObjectLP
 {
+    /**
+     * @var null | bool
+     */
+    protected $precondition_cache = null;
+
     public static function getDefaultModes($a_lp_active)
     {
         return array(
@@ -68,14 +73,24 @@ class ilScormLP extends ilObjectLP
         }
         return parent::getCurrentMode();
     }
-    
+
+    /**
+     * @return bool
+     * @throws ilDatabaseException
+     */
     protected function checkSCORMPreconditions()
     {
-        include_once('./Services/AccessControl/classes/class.ilConditionHandler.php');
-        if (count(ilConditionHandler::_getConditionsOfTrigger('sahs', $this->obj_id))) {
-            return true;
+        static $counter;
+
+        if (!is_null($this->precondition_cache)) {
+            return $this->precondition_cache;
         }
-        return false;
+
+        $this->precondition_cache =
+            ilConditionHandler::getNumberOfConditionsOfTrigger('sahs', $this->obj_id) > 0 ?
+                true :
+                false;
+        return $this->precondition_cache;
     }
     
     protected static function isLPMember(array &$a_res, $a_usr_id, $a_obj_ids)

--- a/Modules/ScormAicc/classes/class.ilScormLP.php
+++ b/Modules/ScormAicc/classes/class.ilScormLP.php
@@ -80,8 +80,6 @@ class ilScormLP extends ilObjectLP
      */
     protected function checkSCORMPreconditions()
     {
-        static $counter;
-
         if (!is_null($this->precondition_cache)) {
             return $this->precondition_cache;
         }


### PR DESCRIPTION
This improves the performance of the LP matrix view, if SCORM objects are part of a collection.
Without this static cache the method checkScormPreconditions() performs NUMBER_OF_USERS * NUMBER_SCORM_ITEMS database queries.