### PR TITLE
Fix: #28888 - decouple focussing of main-container 

### DIFF
--- a/src/UI/templates/js/Page/stdpage.js
+++ b/src/UI/templates/js/Page/stdpage.js
@@ -71,5 +71,9 @@ il.UI = il.UI || {};
 	})($);
 })($, il.UI);
 il.Util.addOnLoad(function() {
-    $("main").attr("tabindex", -1).focus();
+	window.setTimeout(
+		function(){
+			$("main").attr("tabindex", -1).focus();
+		}, 10
+	);
 });


### PR DESCRIPTION
Fixes https://mantis.ilias.de/view.php?id=28888,
mainbar adjustments broken in Chrome.

Should also go down to 6.
