### PR TITLE
[Mantis:28923]: remove events without start-time from ical export

### DIFF
--- a/Services/Calendar/classes/Export/class.ilCalendarExport.php
+++ b/Services/Calendar/classes/Export/class.ilCalendarExport.php
@@ -186,9 +186,10 @@ class ilCalendarExport
         global $DIC;
 
         $ilUser = $DIC['ilUser'];
-        
-        if (!$app->getStart() instanceof ilDateTime) {
+
+        if (!$app->getStart()||$app->getStart()==""||$app->getStart()=="<br>" ) {
             $this->logger->notice('Cannot create appointment for app_id: ' . $app->getEntryId());
+            return;
         }
 
         $this->writer->addLine('BEGIN:VEVENT');


### PR DESCRIPTION
Sometimes there is no starting date set for a course. The constructor of ilCalendarEntry will still create an instance of ilDateTime.
This would solve the problem by checking if getStart() returns nothing, an empty string or "<br>"
https://mantis.ilias.de/view.php?id=28923