### PR TITLE
UI/Form - Improvements: Cancel-Button 

### DIFF
--- a/src/UI/Component/Input/Container/Form/Factory.php
+++ b/src/UI/Component/Input/Container/Form/Factory.php
@@ -9,7 +9,6 @@ namespace ILIAS\UI\Component\Input\Container\Form;
  */
 interface Factory
 {
-
     /**
      * ---
      * description:
@@ -18,10 +17,13 @@ interface Factory
      *      configuring objects or services.
      *   composition: >
      *      Standard forms provide a submit-button.
+     *      Additionally, they MAY provide a cancel-button.
      *   effect: >
      *      The users manipulates input-values and saves the form to apply the
      *      settings to the object or service or create new entities in the
      *      system.
+     *      Operating the cancel-button will take the user back to the situation
+     *      before calling the form.
      *
      * rules:
      *   usage:
@@ -39,10 +41,16 @@ interface Factory
      *        changed, then you MUST propose it to the JF.
      *     4: >
      *        On top and bottom of a standard form there SHOULD be the “Save” button for the form.
-     *     5: >
-     *        In some rare exceptions the Buttons MAY be named differently: if “Save” is
-     *        clearly a misleading since the action is more than storing
+     *        When the form is very small (e.g. accepting Terms of Condition, or username/password only,
+     *        the upper button MAY be omitted.
+     *   interaction:
+     *     1: Operating the cancel button MUST NOT change the system in any way.
+     *   wording:
+     *     1: >
+     *        In some rare exceptions the Buttons MAY be named differently, e.g.
+     *        if “Save” is clearly a misleading since the action is more than storing
      *        the data into the database. “Send Mail” would be an example of this.
+     *     2: The cancel-button, however, MUST NOT be labelled other than “Cancel”.
      *
      * ---
      *

--- a/src/UI/Component/Input/Container/Form/Standard.php
+++ b/src/UI/Component/Input/Container/Form/Standard.php
@@ -1,19 +1,56 @@
-<?php
+<?php declare(strict_types=1);
 
 /* Copyright (c) 2017 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
 
 namespace ILIAS\UI\Component\Input\Container\Form;
+
+use ILIAS\Data\URI;
 
 /**
  * This describes a standard form.
  */
 interface Standard extends Form
 {
-
     /**
      * Get the URL this form posts its result to.
      *
      * @return    string
      */
     public function getPostURL();
+
+    /**
+     * Set the URL that is called when the user clicks 'cancel'.
+     * Setting an cancel-url will enable an accroding button in the form.
+     *
+     * @return    Standard
+     */
+    public function withCancelURL(URI $url) : Standard;
+
+    /**
+     * Get the URL that is called when the user clicks 'cancel'.
+     */
+    public function getCancelURL() : ?URI;
+
+    /**
+     * Labels the submit-button of the form.
+     *
+     * @return    Standard
+     */
+    public function withSubmitLabel(string $label) : Standard;
+
+    /**
+     * Get the label of the submit-button.
+     */
+    public function getSubmitLabel() : string;
+
+    /**
+     * Do not render buttons at the top of the form.
+     */
+    public function withBottomButtonsOnly(bool $flag = true) : Standard;
+
+    /**
+     * Should the top-buttons be rendered?
+     * Defaults to false.
+     */
+    public function hasBottomButtonsOnly() : bool;
 }

--- a/src/UI/Implementation/Component/Input/Container/Form/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Container/Form/Renderer.php
@@ -42,12 +42,9 @@ class Renderer extends AbstractComponentRenderer
             $f->button()->standard($this->txt($component->getSubmitLabel()), '')
         ];
         if (!is_null($component->getCancelURL())) {
-            array_unshift(
-                $buttons,
-                $f->button()->standard(
-                    $this->txt('cancel'),
-                    (string) $component->getCancelURL()
-                )
+            $buttons[] = $f->button()->standard(
+                $this->txt('cancel'),
+                (string) $component->getCancelURL()
             );
         }
 

--- a/src/UI/Implementation/Component/Input/Container/Form/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Container/Form/Renderer.php
@@ -38,11 +38,23 @@ class Renderer extends AbstractComponentRenderer
         }
 
         $f = $this->getUIFactory();
-        $submit_button = $f->button()->standard($this->txt("save"), "");
+        $buttons = [
+            $f->button()->standard($this->txt($component->getSubmitLabel()), '')
+        ];
+        if (!is_null($component->getCancelURL())) {
+            array_unshift(
+                $buttons,
+                $f->button()->standard(
+                    $this->txt('cancel'),
+                    (string) $component->getCancelURL()
+                )
+            );
+        }
 
-        $tpl->setVariable("BUTTONS_TOP", $default_renderer->render($submit_button));
-        $tpl->setVariable("BUTTONS_BOTTOM", $default_renderer->render($submit_button));
-
+        if (!$component->hasBottomButtonsOnly()) {
+            $tpl->setVariable("BUTTONS_TOP", $default_renderer->render($buttons));
+        }
+        $tpl->setVariable("BUTTONS_BOTTOM", $default_renderer->render($buttons));
         $tpl->setVariable("INPUTS", $default_renderer->render($component->getInputGroup()));
 
         return $tpl->get();

--- a/src/UI/Implementation/Component/Input/Container/Form/Standard.php
+++ b/src/UI/Implementation/Component/Input/Container/Form/Standard.php
@@ -1,16 +1,17 @@
-<?php
+<?php declare(strict_types=1);
 
 /* Copyright (c) 2017 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
 
 namespace ILIAS\UI\Implementation\Component\Input\Container\Form;
 
-use ILIAS\UI\Component as C;
+use ILIAS\UI\Component\Input\Container\Form as C;
 use ILIAS\UI\Implementation\Component\Input;
+use ILIAS\Data\URI;
 
 /**
  * This implements a standard form.
  */
-class Standard extends Form implements C\Input\Container\Form\Standard
+class Standard extends Form implements C\Standard
 {
 
     /**
@@ -18,6 +19,20 @@ class Standard extends Form implements C\Input\Container\Form\Standard
      */
     protected $post_url;
 
+    /**
+     * @var URI
+     */
+    protected $cancel_url;
+
+    /**
+     * @var string
+     */
+    protected $label_submit = 'save';
+
+    /**
+     * @var bool
+     */
+    protected $bottom_buttons_only = false;
 
     public function __construct(Input\Field\Factory $input_factory, $post_url, array $inputs)
     {
@@ -26,12 +41,65 @@ class Standard extends Form implements C\Input\Container\Form\Standard
         $this->post_url = $post_url;
     }
 
-
     /**
      * @inheritdoc
      */
     public function getPostURL()
     {
         return $this->post_url;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function withCancelURL(URI $url) : C\Standard
+    {
+        $clone = clone $this;
+        $clone->cancel_url = $url;
+        return $clone;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getCancelURL() : ?URI
+    {
+        return $this->cancel_url;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function withSubmitLabel(string $label) : C\Standard
+    {
+        $clone = clone $this;
+        $clone->label_submit = $label;
+        return $clone;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSubmitLabel() : string
+    {
+        return $this->label_submit;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function withBottomButtonsOnly(bool $flag = true) : C\Standard
+    {
+        $clone = clone $this;
+        $clone->bottom_buttons_only = $flag;
+        return $clone;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function hasBottomButtonsOnly() : bool
+    {
+        return $this->bottom_buttons_only;
     }
 }

--- a/src/UI/examples/Input/Container/Form/Standard/modifications.php
+++ b/src/UI/examples/Input/Container/Form/Standard/modifications.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This examples modifies a standard form:
+ * - add a cancel-button
+ * - hide the buttons above the form
+ * - customize the submit-label
+ */
+function modifications()
+{
+    global $DIC;
+    $ui = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+    $text_input = $ui->input()->field()->text("Basic Input", "Just some basic input");
+    $section1 = $ui->input()->field()->section([$text_input], "Section 1", "Description of Section 1");
+
+    //Define the form and attach the section.
+    $form = $ui->input()->container()->form()->standard("", [$section1]);
+
+    //Enable a cancel-button:
+    $data_factory = new \ILIAS\Data\Factory();
+    $url = $data_factory->uri('http://www.ilias.de');
+    $form = $form->withCancelURL($url);
+
+    //Hide/remove top-buttons for short forms:
+    $form = $form->withBottomButtonsOnly(true);
+
+    //Re-label the save-button (do not regularly do that!)
+    //The string will still be translated.
+    $form = $form->withSubmitLabel('ok');
+
+    //Render the form
+    return $renderer->render($form);
+}

--- a/src/UI/templates/default/Input/tpl.standard.html
+++ b/src/UI/templates/default/Input/tpl.standard.html
@@ -1,8 +1,12 @@
 <form role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" <!-- BEGIN action --> action="{URL}"<!-- END action --> method="post" novalidate="novalidate">
+	<!-- BEGIN topbuttons -->
 	<div class="il-standard-form-header clearfix">
 		<div class="il-standard-form-cmd">{BUTTONS_TOP}</div>
 	</div>
+	<!-- END topbuttons -->
+
 	{INPUTS}
+	
 	<div class="il-standard-form-footer clearfix">
 		<div class="il-standard-form-cmd">{BUTTONS_BOTTOM}</div>
 	</div>

--- a/tests/UI/Component/Input/Container/Form/StandardFormTest.php
+++ b/tests/UI/Component/Input/Container/Form/StandardFormTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /* Copyright (c) 2016 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
 
@@ -8,6 +8,7 @@ require_once(__DIR__ . "/FormTest.php");
 
 use ILIAS\UI\Implementation\Component\SignalGenerator;
 use \ILIAS\Data;
+use \ILIAS\UI\Component\Input\Container\Form\Form;
 
 class WithButtonNoUIFactory extends NoUIFactory
 {
@@ -61,13 +62,14 @@ class StandardFormTest extends ILIAS_UI_TestBase
     }
 
 
-    public function test_getPostURL()
+    public function test_getPostURL() : Form
     {
         $f = $this->buildFactory();
         $if = $this->buildInputFactory();
         $url = "MY_URL";
         $form = $f->standard($url, [$if->text("label")]);
         $this->assertEquals($url, $form->getPostURL());
+        return $form;
     }
 
 
@@ -103,5 +105,112 @@ class StandardFormTest extends ILIAS_UI_TestBase
 
         $expected = "<form role=\"form\" class=\"il-standard-form form-horizontal\" enctype=\"multipart/form-data\" method=\"post\" novalidate=\"novalidate\">        <div class=\"il-standard-form-header clearfix\">          <div class=\"il-standard-form-cmd\"><button class=\"btn btn-default\" data-action=\"\">save</button></div>        </div>  <div class=\"form-group row\">     <label for=\"form_input_1\" class=\"control-label col-sm-3\">label</label>  <div class=\"col-sm-9\">          <input type=\"text\" name=\"form_input_1\" class=\"form-control form-control-sm\" />          <div class=\"help-block\">byline</div>                    </div></div>    <div class=\"il-standard-form-footer clearfix\">          <div class=\"il-standard-form-cmd\"><button class=\"btn btn-default\" data-action=\"\">save</button></div> </div></form>";
         $this->assertHTMLEquals($expected, $html);
+    }
+
+    /**
+     * @depends test_getPostURL
+     */
+    public function testSubmitLabel(Form $form)
+    {
+        $this->assertEquals('save', $form->getSubmitLabel());
+
+        $label = 'someothersubmitlabel';
+        $form = $form->withSubmitLabel($label);
+        $this->assertEquals($label, $form->getSubmitLabel());
+    }
+
+    /**
+     * @depends test_getPostURL
+     */
+    public function testCancelButton(Form $form) : Form
+    {
+        $this->assertNull($form->getCancelURL());
+        $data = new Data\Factory();
+        $url = $data->uri('http://www.ilias.de');
+        $form = $form->withCancelURL($url);
+        $this->assertEquals($url, $form->getCancelURL());
+        return $form;
+    }
+
+    /**
+     * @depends testCancelButton
+     */
+    public function testCancelButtonRender(Form $form)
+    {
+        $expected = <<<EOT
+<form role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" action="MY_URL" method="post" novalidate="novalidate">
+
+    <div class="il-standard-form-header clearfix">
+        <div class="il-standard-form-cmd">
+            <button class="btn btn-default" data-action="http://www.ilias.de" id="id_1">cancel</button>
+            <button class="btn btn-default" data-action="">save</button>
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <label for="form_input_1" class="control-label col-sm-3">label</label>
+        <div class="col-sm-9">
+            <input type="text" name="form_input_1" class="form-control form-control-sm" />
+        </div>
+    </div>
+
+    <div class="il-standard-form-footer clearfix">
+        <div class="il-standard-form-cmd">
+            <button class="btn btn-default" data-action="http://www.ilias.de" id="id_2">cancel</button>
+            <button class="btn btn-default" data-action="">save</button>
+        </div>
+    </div>
+
+</form>
+EOT;
+        $r = $this->getDefaultRenderer();
+        $html = $r->render($form);
+        $this->assertEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($html)
+        );
+    }
+
+    /**
+     * @depends test_getPostURL
+     */
+    public function testBottomButtonOnly(Form $form)
+    {
+        $this->assertFalse($form->hasBottomButtonsOnly());
+        $form = $form->withBottomButtonsOnly();
+        $this->assertTrue($form->hasBottomButtonsOnly());
+        $form = $form->withBottomButtonsOnly(false);
+        $this->assertFalse($form->hasBottomButtonsOnly());
+    }
+
+    /**
+     * @depends test_getPostURL
+     */
+    public function testBottomButtonRender(Form $form)
+    {
+        $form = $form->withBottomButtonsOnly(true);
+        $expected = <<<EOT
+<form role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" action="MY_URL" method="post" novalidate="novalidate">
+
+    <div class="form-group row">
+        <label for="form_input_1" class="control-label col-sm-3">label</label>
+        <div class="col-sm-9">
+            <input type="text" name="form_input_1" class="form-control form-control-sm" />
+        </div>
+    </div>
+
+    <div class="il-standard-form-footer clearfix">
+        <div class="il-standard-form-cmd">
+            <button class="btn btn-default" data-action="">save</button>
+        </div>
+    </div>
+</form>
+EOT;
+        $r = $this->getDefaultRenderer();
+        $html = $r->render($form);
+        $this->assertEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($html)
+        );
     }
 }

--- a/tests/UI/Component/Input/Container/Form/StandardFormTest.php
+++ b/tests/UI/Component/Input/Container/Form/StandardFormTest.php
@@ -142,8 +142,8 @@ class StandardFormTest extends ILIAS_UI_TestBase
 
     <div class="il-standard-form-header clearfix">
         <div class="il-standard-form-cmd">
-            <button class="btn btn-default" data-action="http://www.ilias.de" id="id_1">cancel</button>
             <button class="btn btn-default" data-action="">save</button>
+            <button class="btn btn-default" data-action="http://www.ilias.de" id="id_1">cancel</button>
         </div>
     </div>
 
@@ -156,8 +156,8 @@ class StandardFormTest extends ILIAS_UI_TestBase
 
     <div class="il-standard-form-footer clearfix">
         <div class="il-standard-form-cmd">
-            <button class="btn btn-default" data-action="http://www.ilias.de" id="id_2">cancel</button>
             <button class="btn btn-default" data-action="">save</button>
+            <button class="btn btn-default" data-action="http://www.ilias.de" id="id_2">cancel</button>
         </div>
     </div>
 


### PR DESCRIPTION
Dear All,
this PR  features 

- **a custom-label for submit**
   As mentioned in the rules already, it is OK to re-label the submit button. 
   There was no way to do that, though.
- **optional cancel-button**
   With a form embedded in some workflow, or the explicit rule to avoid top-bars, a "cancel" gets handy to get back 
   without submitting
- **optional top-buttons**
   For very short forms (such as login, accept ToC,..), it looks sort of exaggerated to have a submit at the top as well...

We adjusted the [rules](https://github.com/ILIAS-eLearning/ILIAS/pull/2926/files#diff-239223547575f8840330e9efc4ead806) accordingly.
This is a standard form with all mentioned additions:

![Screenshot from 2020-10-06 16-22-19](https://user-images.githubusercontent.com/3328364/95214722-7c118300-07f0-11eb-8fa0-acdae643174b.png)

Please kindly consider.
Best regards,
Nils and Oli