### PR TITLE
Fix regex for PCT encoding in Data/URI

### DIFF
--- a/src/Data/URI.php
+++ b/src/Data/URI.php
@@ -49,7 +49,7 @@ class URI
     const ALPHA = '[A-Za-z]';
     const DIGIT = '[0-9]';
     const ALPHA_DIGIT = '[A-Za-z0-9]';
-    const HEXDIG = '[0-9A-F]';
+    const HEXDIG = '[0-9A-Fa-f]';
     const PCTENCODED = '%' . self::HEXDIG . self::HEXDIG;
     /**
      * point|minus|plus to be used in schema.


### PR DESCRIPTION
Following [rfc3986](https://tools.ietf.org/html/rfc3986#section-2.1) we should be more tolerant here. I would see this as a bug fix and ask to cherry pick to 5.4 and 6.