### PR TITLE
exclude plugin vendor directories from autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,8 @@
 		"exclude-from-classmap": [
 			"./Services/Migration",
 			"./*/*/lib", "./*/*/test",
-			"./Services/CAS/phpcas"
+			"./Services/CAS/phpcas",
+			"./Customizing/**/vendor"
 		]
 	},
 	"extra": {


### PR DESCRIPTION
Change to PR #2758 to prevent conflicts in duplicate composer libraries (see https://github.com/ILIAS-eLearning/ILIAS/pull/2758#issuecomment-704917682).