### PR TITLE
#29020 fix linkify export

### DIFF
--- a/Modules/LearningModule/classes/class.ilObjContentObject.php
+++ b/Modules/LearningModule/classes/class.ilObjContentObject.php
@@ -2486,10 +2486,15 @@ class ilObjContentObject extends ilObject
                     "target" => $a_target_dir . '/js/ilExtLink.js',
                     "type" => "js");
             }
-            if (is_int(strpos($p, "linkify"))) {
+            if (is_int(strpos($p, "linkify.min.js"))) {
                 $scripts[] = array("source" => $p,
-                    "target" => $a_target_dir . '/js/linkify.js',
+                    "target" => $a_target_dir . '/js/linkify.min.js',
                     "type" => "js");
+            }
+            if (is_int(strpos($p, "linkify-jquery.min.js"))) {
+                $scripts[] = array("source" => $p,
+                                   "target" => $a_target_dir . '/js/linkify-jquery.min.js',
+                                   "type" => "js");
             }
         }
 

--- a/Services/COPage/classes/class.ilCOPageHTMLExport.php
+++ b/Services/COPage/classes/class.ilCOPageHTMLExport.php
@@ -262,8 +262,11 @@ class ilCOPageHTMLExport
             if (is_int(strpos($p, "ExtLink"))) {
                 copy($p, $this->js_dir . '/ilExtLink.js');
             }
-            if (is_int(strpos($p, "linkify"))) {
-                copy($p, $this->js_dir . '/linkify.js');
+            if (is_int(strpos($p, "linkify.min.js"))) {
+                copy($p, $this->js_dir . '/linkify.min.js');
+            }
+            if (is_int(strpos($p, "linkify-jquery.min.js"))) {
+                copy($p, $this->js_dir . '/linkify-jquery.min.js');
             }
         }
 


### PR DESCRIPTION
Since  our last update to ILIAS 5.4.17 an HTML export of a learning module  does not longer show the table of contents. This is caused by a js error  in the initialisation of the page, regarding the linkify library. With  the new version of the library,  two files with different names are  needed. The change is not yet supported by the HTML export of the  module.

https://mantis.ilias.de/view.php?id=29020




