### PR TITLE
Refinery/ReadingTime Trafo: Ignore comment nodes in XHTML strings

### DIFF
--- a/src/Refinery/String/EstimatedReadingTime.php
+++ b/src/Refinery/String/EstimatedReadingTime.php
@@ -65,7 +65,11 @@ class EstimatedReadingTime implements Transformation
         $textNodes = $xpath->query('//text()');
         if ($textNodes->length > 0) {
             foreach ($textNodes as $textNode) {
-                /** @var \DOMText $textNode */
+                /** @var \DOMText|\DOMCdataSection $textNode */
+                if ($textNode instanceof \DOMCdataSection) {
+                    continue;
+                }
+
                 $wordsInContent = array_filter(preg_split('/\s+/', $textNode->textContent));
 
                 $wordsInContent = array_filter($wordsInContent, function (string $word) {

--- a/tests/Refinery/String/Transformation/EstimatedReadingTimeTest.php
+++ b/tests/Refinery/String/Transformation/EstimatedReadingTimeTest.php
@@ -4,7 +4,6 @@ namespace ILIAS\Tests\Refinery\String;
 
 use ILIAS\Refinery\Factory;
 use PHPUnit\Framework\TestCase;
-require_once 'libs/composer/vendor/autoload.php';
 
 class EstimatedReadingTimeTest extends TestCase
 {

--- a/tests/Refinery/String/Transformation/EstimatedReadingTimeTest.php
+++ b/tests/Refinery/String/Transformation/EstimatedReadingTimeTest.php
@@ -1,10 +1,10 @@
 <?php declare(strict_types=1);
 /* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
-
 namespace ILIAS\Tests\Refinery\String;
 
 use ILIAS\Refinery\Factory;
 use PHPUnit\Framework\TestCase;
+require_once 'libs/composer/vendor/autoload.php';
 
 class EstimatedReadingTimeTest extends TestCase
 {
@@ -14,7 +14,7 @@ EOT;
     const HTML = <<<EOT
 <div>Lorem ipsum dolor <span style="color: red;">sit amet</span>, <img src="#" /> consetetur sadipscing elitr, sed diam nonumy eirmod <img src="#" />  tempor invidunt <img src="#" />  ut labore et dolore <img src="#" />  magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor <img src="#" />  sit amet. <img src="#" />  Lorem ipsum dolor <img src="#" />  sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, <img src="#" />  sed diam voluptua. <img src="#" />  At vero eos et accusam et justo duo dolores et ea rebum. Stet <img src="#" />  clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</div>
 EOT;
-    
+
     /** @var Factory */
     private $refinery;
     
@@ -60,9 +60,6 @@ EOT;
         $readingTimeTrafo->transform($from);
     }
 
-    /**
-     *
-     */
     public function testReadingTimeForPlainText() : void
     {
         $readingTimeTrafo = $this->refinery->string()->estimatedReadingTime(true);
@@ -72,9 +69,6 @@ EOT;
         );
     }
 
-    /**
-     *
-     */
     public function testReadingTimeForHtmlFragment() : void
     {
         $text = self::HTML;
@@ -92,10 +86,7 @@ EOT;
         );
     }
 
-    /**
-     *
-     */
-    public function testSolitaryPunctuationCharactersMustNotEffectReadingTime() : void
+    public function testSolitaryPunctuationCharactersMustNotAffectReadingTime() : void
     {
         $textSegmentWithPunctuation = 'Lorem ipsum <img src="#" />, and some other text... ';
         $repetitions = 300; // 275 repetitions result in an additional minute, if the `,` would be considered
@@ -112,5 +103,20 @@ EOT;
 
         $timeInMinutes = $readingTimeTrafo->transform($text);
         $this->assertEquals(23, $timeInMinutes);
+    }
+
+    public function testXTHMLCommentsMustNotAffectReadingTime() : void
+    {
+        $text = self::HTML;
+
+        $comment = '<script><!--a comment--></script>';
+        $repetitions = 300;
+        $text = $text . str_repeat($comment, $repetitions);
+
+        $onlyTextReadingTimeInfo = $this->refinery->string()->estimatedReadingTime();
+        $this->assertEquals(
+            1,
+            $onlyTextReadingTimeInfo->transform($text)
+        );
     }
 }


### PR DESCRIPTION
When the reading time is determined by the given
text string, XHTML comments MUST not be considered.
Therefore these document nodes have to be skipped
when counting words of a (XHTML) string.

https://mantis.ilias.de/view.php?id=29038