### PR TITLE
Setup: make `update` change config and implement `status`

### DIFF
--- a/Modules/Forum/classes/Setup/class.ilForumSetupAgent.php
+++ b/Modules/Forum/classes/Setup/class.ilForumSetupAgent.php
@@ -19,14 +19,6 @@ class ilForumSetupAgent implements Setup\Agent
     /**
      * @inheritdoc
      */
-    public function getConfigInput(Setup\Config $config = null) : UI\Component\Input\Field\Input
-    {
-        throw new \LogicException("Agent has no config.");
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getArrayToConfigTransformation() : Refinery\Transformation
     {
         throw new \LogicException("Agent has no config.");

--- a/Modules/Forum/classes/Setup/class.ilForumSetupAgent.php
+++ b/Modules/Forum/classes/Setup/class.ilForumSetupAgent.php
@@ -29,15 +29,9 @@ class ilForumSetupAgent implements Setup\Agent
      */
     public function getInstallObjective(Setup\Config $config = null) : Setup\Objective
     {
-        $dir_objective = new ilFileSystemComponentDataDirectoryCreatedObjective(
+        return new ilFileSystemComponentDataDirectoryCreatedObjective(
             'forum',
             ilFileSystemComponentDataDirectoryCreatedObjective::DATADIR
-        );
-
-        return new Setup\ObjectiveCollection(
-            "Complete objectives from Modules/Forum",
-            false,
-            $dir_objective
         );
     }
 

--- a/Modules/Forum/classes/Setup/class.ilForumSetupAgent.php
+++ b/Modules/Forum/classes/Setup/class.ilForumSetupAgent.php
@@ -56,4 +56,12 @@ class ilForumSetupAgent implements Setup\Agent
     {
         return new Setup\Objective\NullObjective();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
 }

--- a/Modules/LearningModule/classes/Setup/class.ilLearningModuleSetupAgent.php
+++ b/Modules/LearningModule/classes/Setup/class.ilLearningModuleSetupAgent.php
@@ -19,14 +19,6 @@ class ilLearningModuleSetupAgent implements Setup\Agent
     /**
      * @inheritdoc
      */
-    public function getConfigInput(Setup\Config $config = null) : UI\Component\Input\Field\Input
-    {
-        throw new \LogicException("Agent has no config.");
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getArrayToConfigTransformation() : Refinery\Transformation
     {
         throw new \LogicException("Agent has no config.");

--- a/Modules/LearningModule/classes/Setup/class.ilLearningModuleSetupAgent.php
+++ b/Modules/LearningModule/classes/Setup/class.ilLearningModuleSetupAgent.php
@@ -29,14 +29,9 @@ class ilLearningModuleSetupAgent implements Setup\Agent
      */
     public function getInstallObjective(Setup\Config $config = null) : Setup\Objective
     {
-        $dir_objective = new ilFileSystemComponentDataDirectoryCreatedObjective(
+        return new ilFileSystemComponentDataDirectoryCreatedObjective(
             'lm_data',
             ilFileSystemComponentDataDirectoryCreatedObjective::WEBDIR
-        );
-        return new Setup\ObjectiveCollection(
-            "Complete objectives from Modules/LearningModule",
-            false,
-            $dir_objective
         );
     }
 

--- a/Modules/LearningModule/classes/Setup/class.ilLearningModuleSetupAgent.php
+++ b/Modules/LearningModule/classes/Setup/class.ilLearningModuleSetupAgent.php
@@ -55,4 +55,12 @@ class ilLearningModuleSetupAgent implements Setup\Agent
     {
         return new Setup\Objective\NullObjective();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
 }

--- a/Modules/LearningSequence/classes/Setup/class.ilLearningSequenceSetupAgent.php
+++ b/Modules/LearningSequence/classes/Setup/class.ilLearningSequenceSetupAgent.php
@@ -55,4 +55,12 @@ class ilLearningSequenceSetupAgent implements Setup\Agent
     {
         return new Setup\Objective\NullObjective();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
 }

--- a/Modules/LearningSequence/classes/Setup/class.ilLearningSequenceSetupAgent.php
+++ b/Modules/LearningSequence/classes/Setup/class.ilLearningSequenceSetupAgent.php
@@ -29,14 +29,9 @@ class ilLearningSequenceSetupAgent implements Setup\Agent
      */
     public function getInstallObjective(Setup\Config $config = null) : Setup\Objective
     {
-        $dir_objective = new ilFileSystemComponentDataDirectoryCreatedObjective(
+        return new ilFileSystemComponentDataDirectoryCreatedObjective(
             ilLearningSequenceFilesystem::PATH_PRE,
             ilFileSystemComponentDataDirectoryCreatedObjective::WEBDIR
-        );
-        return new Setup\ObjectiveCollection(
-            "Complete objectives from Modules/LearningSequence",
-            false,
-            $dir_objective
         );
     }
 

--- a/Modules/LearningSequence/classes/Setup/class.ilLearningSequenceSetupAgent.php
+++ b/Modules/LearningSequence/classes/Setup/class.ilLearningSequenceSetupAgent.php
@@ -19,14 +19,6 @@ class ilLearningSequenceSetupAgent implements Setup\Agent
     /**
      * @inheritdoc
      */
-    public function getConfigInput(Setup\Config $config = null) : UI\Component\Input\Field\Input
-    {
-        throw new \LogicException("Agent has no config.");
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getArrayToConfigTransformation() : Refinery\Transformation
     {
         throw new \LogicException("Agent has no config.");

--- a/Modules/SystemFolder/classes/Setup/class.ilInstallationInformationStoredObjective.php
+++ b/Modules/SystemFolder/classes/Setup/class.ilInstallationInformationStoredObjective.php
@@ -38,9 +38,8 @@ class ilInstallationInformationStoredObjective implements Setup\Objective
 
     public function getPreconditions(Setup\Environment $environment) : array
     {
-        $common_config = $environment->getConfigFor("common");
         return [
-            new \ilIniFilesPopulatedObjective($common_config),
+            new \ilIniFilesLoadedObjective(),
             new \ilSettingsFactoryExistsObjective()
         ];
     }

--- a/Modules/SystemFolder/classes/Setup/class.ilSystemFolderMetricsCollectedObjective.php
+++ b/Modules/SystemFolder/classes/Setup/class.ilSystemFolderMetricsCollectedObjective.php
@@ -1,0 +1,50 @@
+<?php
+
+/* Copyright (c) 2020 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+use ILIAS\Setup;
+
+class ilSystemFolderMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
+{
+    public function getTentativePreconditions(Setup\Environment $environment) : array
+    {
+        return [
+            new \ilSettingsFactoryExistsObjective()
+        ];
+    }
+
+    public function collectFrom(Setup\Environment $environment, Setup\Metrics\Storage $storage) : void
+    {
+        $factory = $environment->getResource(Setup\Environment::RESOURCE_SETTINGS_FACTORY);
+        if (!$factory) {
+            return;
+        }
+        $settings = $factory->settingsFor("common");
+        $firstname = new Setup\Metrics\Metric(
+            Setup\Metrics\Metric::STABILITY_CONFIG,
+            Setup\Metrics\Metric::TYPE_TEXT,
+            $settings->get("admin_firstname")
+        );
+        $lastname = new Setup\Metrics\Metric(
+            Setup\Metrics\Metric::STABILITY_CONFIG,
+            Setup\Metrics\Metric::TYPE_TEXT,
+            $settings->get("admin_lastname")
+        );
+        $email = new Setup\Metrics\Metric(
+            Setup\Metrics\Metric::STABILITY_CONFIG,
+            Setup\Metrics\Metric::TYPE_TEXT,
+            $settings->get("admin_email")
+        );
+        $contact = new Setup\Metrics\Metric(
+            Setup\Metrics\Metric::STABILITY_CONFIG,
+            Setup\Metrics\Metric::TYPE_COLLECTION,
+            [
+                "firstname" => $firstname,
+                "lastname" => $lastname,
+                "email" => $email
+            ],
+            "Contact information for this installation."
+        );
+        $storage->store("contact", $contact);
+    }
+}

--- a/Modules/SystemFolder/classes/Setup/class.ilSystemFolderSetupAgent.php
+++ b/Modules/SystemFolder/classes/Setup/class.ilSystemFolderSetupAgent.php
@@ -35,7 +35,7 @@ class ilSystemFolderSetupAgent implements Setup\Agent
     {
         return $this->refinery->custom()->transformation(function ($data) {
             return new \ilSystemFolderSetupConfig(
-                $data["client"]["name"],
+                $data["client"]["name"] ?? null,
                 $data["client"]["description"] ?? null,
                 $data["client"]["institution"] ?? null,
                 $data["contact"]["firstname"],
@@ -58,11 +58,7 @@ class ilSystemFolderSetupAgent implements Setup\Agent
      */
     public function getInstallObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\ObjectiveCollection(
-            "Complete objectives from Modules/SystemFolder",
-            false,
-            new ilInstallationInformationStoredObjective($config)
-        );
+        return new ilInstallationInformationStoredObjective($config);
     }
 
     /**
@@ -70,7 +66,7 @@ class ilSystemFolderSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilInstallationInformationStoredObjective($config);
     }
 
     /**

--- a/Modules/SystemFolder/classes/Setup/class.ilSystemFolderSetupAgent.php
+++ b/Modules/SystemFolder/classes/Setup/class.ilSystemFolderSetupAgent.php
@@ -66,7 +66,10 @@ class ilSystemFolderSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new ilInstallationInformationStoredObjective($config);
+        if ($config !== null) {
+            return new ilInstallationInformationStoredObjective($config);
+        }
+        return new Setup\Objective\NullObjective();
     }
 
     /**

--- a/Modules/SystemFolder/classes/Setup/class.ilSystemFolderSetupAgent.php
+++ b/Modules/SystemFolder/classes/Setup/class.ilSystemFolderSetupAgent.php
@@ -76,4 +76,12 @@ class ilSystemFolderSetupAgent implements Setup\Agent
     {
         return new Setup\Objective\NullObjective();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
 }

--- a/Modules/SystemFolder/classes/Setup/class.ilSystemFolderSetupAgent.php
+++ b/Modules/SystemFolder/classes/Setup/class.ilSystemFolderSetupAgent.php
@@ -85,6 +85,6 @@ class ilSystemFolderSetupAgent implements Setup\Agent
      */
     public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilSystemFolderMetricsCollectedObjective($storage);
     }
 }

--- a/Modules/SystemFolder/classes/Setup/class.ilSystemFolderSetupAgent.php
+++ b/Modules/SystemFolder/classes/Setup/class.ilSystemFolderSetupAgent.php
@@ -31,14 +31,6 @@ class ilSystemFolderSetupAgent implements Setup\Agent
     /**
      * @inheritdoc
      */
-    public function getConfigInput(Setup\Config $config = null) : UI\Component\Input\Field\Input
-    {
-        throw new \LogicException("Not yet implemented.");
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getArrayToConfigTransformation() : Refinery\Transformation
     {
         return $this->refinery->custom()->transformation(function ($data) {

--- a/Services/Administration/classes/Setup/class.ilSettingsFactoryExistsObjective.php
+++ b/Services/Administration/classes/Setup/class.ilSettingsFactoryExistsObjective.php
@@ -23,9 +23,8 @@ class ilSettingsFactoryExistsObjective implements Setup\Objective
 
     public function getPreconditions(Setup\Environment $environment) : array
     {
-        $db_config = $environment->getConfigFor("database");
         return [
-            new ilDatabasePopulatedObjective($db_config)
+            new ilDatabaseInitializedObjective()
         ];
     }
 

--- a/Services/BackgroundTasks/classes/Setup/class.ilBackgroundTasksConfigStoredObjective.php
+++ b/Services/BackgroundTasks/classes/Setup/class.ilBackgroundTasksConfigStoredObjective.php
@@ -34,9 +34,8 @@ class ilBackgroundTasksConfigStoredObjective implements Setup\Objective
 
     public function getPreconditions(Setup\Environment $environment) : array
     {
-        $common_config = $environment->getConfigFor("common");
         return [
-            new ilIniFilesPopulatedObjective($common_config)
+            new ilIniFilesLoadedObjective()
         ];
     }
 

--- a/Services/BackgroundTasks/classes/Setup/class.ilBackgroundTasksMetricsCollectedObjective.php
+++ b/Services/BackgroundTasks/classes/Setup/class.ilBackgroundTasksMetricsCollectedObjective.php
@@ -1,0 +1,34 @@
+<?php
+
+/* Copyright (c) 2020 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+use ILIAS\Setup;
+
+class ilBackgroundTasksMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
+{
+    public function getTentativePreconditions(Setup\Environment $environment) : array
+    {
+        return [
+            new ilIniFilesLoadedObjective()
+        ];
+    }
+
+    public function collectFrom(Setup\Environment $environment, Setup\Metrics\Storage $storage) : void
+    {
+        $ini = $environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI);
+        if (!$ini) {
+            return;
+        }
+
+        $storage->storeConfigText(
+            "type",
+            $ini->readVariable("background_tasks", "concurrency"),
+            "The type of execution used for background tasks"
+        );
+        $storage->storeConfigGauge(
+            "max_number_of_concurrent_tasks",
+            (int)$ini->readVariable("background_tasks", "number_of_concurrent_tasks"),
+            "The maximum amount of concurrent tasks used to run background tasks."
+        );
+    }
+}

--- a/Services/BackgroundTasks/classes/Setup/class.ilBackgroundTasksSetupAgent.php
+++ b/Services/BackgroundTasks/classes/Setup/class.ilBackgroundTasksSetupAgent.php
@@ -64,4 +64,12 @@ class ilBackgroundTasksSetupAgent implements Setup\Agent
     {
         return new Setup\Objective\NullObjective();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
 }

--- a/Services/BackgroundTasks/classes/Setup/class.ilBackgroundTasksSetupAgent.php
+++ b/Services/BackgroundTasks/classes/Setup/class.ilBackgroundTasksSetupAgent.php
@@ -31,14 +31,6 @@ class ilBackgroundTasksSetupAgent implements Setup\Agent
     /**
      * @inheritdoc
      */
-    public function getConfigInput(Setup\Config $config = null) : UI\Component\Input\Field\Input
-    {
-        throw new \LogicException("Not yet implemented.");
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getArrayToConfigTransformation() : Refinery\Transformation
     {
         return $this->refinery->custom()->transformation(function ($data) {

--- a/Services/BackgroundTasks/classes/Setup/class.ilBackgroundTasksSetupAgent.php
+++ b/Services/BackgroundTasks/classes/Setup/class.ilBackgroundTasksSetupAgent.php
@@ -54,7 +54,10 @@ class ilBackgroundTasksSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new ilBackgroundTasksConfigStoredObjective($config);
+        if ($config !== null) {
+            return new ilBackgroundTasksConfigStoredObjective($config);
+        }
+        return new Setup\Objective\NullObjective();
     }
 
     /**

--- a/Services/BackgroundTasks/classes/Setup/class.ilBackgroundTasksSetupAgent.php
+++ b/Services/BackgroundTasks/classes/Setup/class.ilBackgroundTasksSetupAgent.php
@@ -73,6 +73,6 @@ class ilBackgroundTasksSetupAgent implements Setup\Agent
      */
     public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilBackgroundTasksMetricsCollectedObjective($storage);
     }
 }

--- a/Services/BackgroundTasks/classes/Setup/class.ilBackgroundTasksSetupAgent.php
+++ b/Services/BackgroundTasks/classes/Setup/class.ilBackgroundTasksSetupAgent.php
@@ -46,11 +46,7 @@ class ilBackgroundTasksSetupAgent implements Setup\Agent
      */
     public function getInstallObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\ObjectiveCollection(
-            "Complete objectives from Services/BackgroundTasks",
-            false,
-            new ilBackgroundTasksConfigStoredObjective($config)
-        );
+        return new ilBackgroundTasksConfigStoredObjective($config);
     }
 
     /**
@@ -58,7 +54,7 @@ class ilBackgroundTasksSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilBackgroundTasksConfigStoredObjective($config);
     }
 
     /**

--- a/Services/Component/classes/Setup/class.ilComponentsSetupAgent.php
+++ b/Services/Component/classes/Setup/class.ilComponentsSetupAgent.php
@@ -45,4 +45,12 @@ class ilComponentsSetupAgent implements Setup\Agent
     {
         return new Setup\Objective\NullObjective();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
 }

--- a/Services/Component/classes/Setup/class.ilComponentsSetupAgent.php
+++ b/Services/Component/classes/Setup/class.ilComponentsSetupAgent.php
@@ -35,7 +35,10 @@ class ilComponentsSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new \ilComponentDefinitionsStoredObjective(false);
+        if ($config !== null) {
+            return new \ilComponentDefinitionsStoredObjective(false);
+        }
+        return new Setup\Objective\NullObjective();
     }
 
     /**

--- a/Services/Component/classes/Setup/class.ilComponentsSetupAgent.php
+++ b/Services/Component/classes/Setup/class.ilComponentsSetupAgent.php
@@ -17,14 +17,6 @@ class ilComponentsSetupAgent implements Setup\Agent
     /**
      * @inheritdoc
      */
-    public function getConfigInput(Setup\Config $config = null) : ILIAS\UI\Component\Input\Field\Input
-    {
-        throw new \LogicException(self::class . " has no Config.");
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getArrayToConfigTransformation() : Transformation
     {
         throw new \LogicException(self::class . " has no Config.");

--- a/Services/Database/classes/Setup/class.ilDatabaseConfigStoredObjective.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseConfigStoredObjective.php
@@ -24,9 +24,8 @@ class ilDatabaseConfigStoredObjective extends ilDatabaseObjective
 
     public function getPreconditions(Setup\Environment $environment) : array
     {
-        $common_config = $environment->getConfigFor("common");
         return [
-            new ilIniFilesPopulatedObjective($common_config),
+            new ilIniFilesLoadedObjective(),
             new ilDatabaseExistsObjective($this->config)
         ];
     }

--- a/Services/Database/classes/Setup/class.ilDatabaseInitializedObjective.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseInitializedObjective.php
@@ -1,0 +1,62 @@
+<?php
+
+/* Copyright (c) 2019 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+use ILIAS\Setup;
+
+class ilDatabaseInitializedObjective implements Setup\Objective
+{
+    public function getHash() : string
+    {
+        return hash("sha256", self::class);
+    }
+
+    public function getLabel() : string
+    {
+        return "The database object is initialized.";
+    }
+
+    public function isNotable() : bool
+    {
+        return true;
+    }
+
+    public function getPreconditions(Setup\Environment $environment) : array
+    {
+        return [
+            new ilIniFilesLoadedObjective()
+        ];
+    }
+
+    public function achieve(Setup\Environment $environment) : Setup\Environment
+    {
+        if ($environment->getResource(Setup\Environment::RESOURCE_DATABASE)) {
+            return $environment;
+        }
+
+        $client_ini = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_INI);
+
+        $type = $client_ini->readVariable("db", "type");
+        if ($type == "") {
+            $type = "mysql";
+        }
+
+        $db = \ilDBWrapperFactory::getWrapper($type);
+        $db->initFromIniFile($client_ini);
+        $connect = $db->connect(true);
+        if (!$connect) {
+            throw new Setup\UnachievableException(
+                "Database cannot be connected."
+            );
+        }
+        return $environment->withResource(Setup\Environment::RESOURCE_DATABASE, $db);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isApplicable(Setup\Environment $environment) : bool
+    {
+        return $environment->getResource(Setup\Environment::RESOURCE_CLIENT_INI) !== null;
+    }
+}

--- a/Services/Database/classes/Setup/class.ilDatabaseMetricsCollectedObjective.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseMetricsCollectedObjective.php
@@ -1,0 +1,170 @@
+<?php
+
+/* Copyright (c) 2020 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+use ILIAS\Setup;
+use ILIAS\DI;
+
+class ilDatabaseMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
+{
+    public function getTentativePreconditions(Setup\Environment $environment) : array
+    {
+        return [
+            new \ilIniFilesLoadedObjective(),
+            new \ilDatabaseInitializedObjective()
+        ];
+    }
+
+    public function collectFrom(Setup\Environment $environment, Setup\Metrics\Storage $storage) : void
+    {
+        $client_ini = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_INI);
+        if ($client_ini) {
+            $storage->storeConfigText(
+                "type",
+                $client_ini->readVariable("db", "type") ?? "mysql",
+                "The storage backend that is used for the database."
+            );
+            $storage->storeConfigText(
+                "host",
+                $client_ini->readVariable("db", "host"),
+                "The host where the storage backend is located."
+            );
+            $storage->storeConfigText(
+                "port",
+                $client_ini->readVariable("db", "host"),
+                "The port where the storage backend is located at the host."
+            );
+            $storage->storeConfigText(
+                "name",
+                $client_ini->readVariable("db", "name"),
+                "The name of the database in the storage backend."
+            );
+            $storage->storeConfigText(
+                "user",
+                $client_ini->readVariable("db", "user"),
+                "The user to be used for the storage backend."
+            );
+            $storage->storeConfigText(
+                "pass",
+                $client_ini->readVariable("db", "pass"),
+                "The password for the user for the storage backend."
+            );
+        }
+
+
+        $db = $environment->getResource(Setup\Environment::RESOURCE_DATABASE);
+        $ini = $environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI);
+        if (!$db && !$ini) {
+            return;
+        }
+        $client_id = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_ID);
+
+        // ATTENTION: This is a total abomination. It only exists to allow the db-
+        // update to run. This is a memento to the fact, that dependency injection
+        // is something we want. Currently, every component could just service
+        // locate the whole world via the global $DIC.
+        $DIC = $GLOBALS["DIC"] ?? [];
+        $GLOBALS["DIC"] = new DI\Container();
+        $GLOBALS["DIC"]["ilDB"] = $db;
+        $GLOBALS["ilDB"] = $db;
+        $GLOBALS["DIC"]["ilBench"] = null;
+        $GLOBALS["DIC"]["ilLog"] = new class() {
+            public function write()
+            {
+            }
+            public function info()
+            {
+            }
+            public function warning($msg)
+            {
+            }
+            public function error($msg)
+            {
+            }
+        };
+        $GLOBALS["ilLog"] = $GLOBALS["DIC"]["ilLog"];
+        $GLOBALS["DIC"]["ilLoggerFactory"] = new class() {
+            public function getRootLogger()
+            {
+                return new class() {
+                    public function write()
+                    {
+                    }
+                };
+            }
+        };
+        $GLOBALS["ilCtrlStructureReader"] = new class() {
+            public function getStructure()
+            {
+            }
+            public function setIniFile()
+            {
+            }
+        };
+        define("CLIENT_DATA_DIR", $ini->readVariable("clients", "datadir") . "/" . $client_id);
+        define("CLIENT_WEB_DIR", dirname(__DIR__, 4) . "/data/" . $client_id);
+        if (!defined("ILIAS_ABSOLUTE_PATH")) {
+            define("ILIAS_ABSOLUTE_PATH", dirname(__FILE__, 5));
+        }
+        if (!defined("ILIAS_LOG_ENABLED")) {
+            define("ILIAS_LOG_ENABLED", false);
+        }
+        define("ROOT_FOLDER_ID", $client_ini->readVariable("system", "ROOT_FOLDER_ID"));
+        define("ROLE_FOLDER_ID", $client_ini->readVariable("system", "ROLE_FOLDER_ID"));
+        define("SYSTEM_FOLDER_ID", $client_ini->readVariable("system", "SYSTEM_FOLDER_ID"));
+
+
+        $db_update = new class($db, $client_ini) extends ilDBUpdate {
+            public function loadXMLInfo()
+            {
+            }
+        };
+        $db_update->readCustomUpdatesInfo(true);
+
+        $storage->storeStableCounter(
+            "version",
+            $db_update->getCurrentVersion(),
+            "The version of the database schema that is currently installed."
+        );
+        $storage->storeStableCounter(
+            "available_version",
+            $db_update->getFileVersion(),
+            "The version of the database schema that is available in the current source."
+        );
+        $storage->storeStableBool(
+            "update_required",
+            !$db_update->getDBVersionStatus(),
+            "Does the database require an update?"
+        );
+        $storage->storeStableCounter(
+            "hotfix_version",
+            $db_update->getHotfixCurrentVersion() ?? 0,
+            "The version of the hotfix database schema that is currently installed."
+        );
+        $storage->storeStableCounter(
+            "available_hotfix_version",
+            $db_update->getHotfixFileVersion() ?? 0,
+            "The version of the hotfix database schema that is available in the current source."
+        );
+        $storage->storeStableBool(
+            "hotfix_required",
+            $db_update->hotfixAvailable(),
+            "Does the database require a hotfix update?"
+        );
+        $storage->storeStableCounter(
+            "custom_version",
+            $db_update->getCustomUpdatesCurrentVersion() ?? 0,
+            "The version of the custom database schema that is currently installed."
+        );
+        $storage->storeStableCounter(
+            "available_custom_version",
+            $db_update->getCustomUpdatesFileVersion() ?? 0,
+            "The version of the custom database schema that is available in the current source."
+        );
+        $storage->storeStableBool(
+            "custom_update_required",
+            $db_update->customUpdatesAvailable(),
+            "Does the database require a custom update?"
+        );
+    }
+}

--- a/Services/Database/classes/Setup/class.ilDatabaseSetupAgent.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseSetupAgent.php
@@ -30,14 +30,6 @@ class ilDatabaseSetupAgent implements Setup\Agent
     /**
      * @inheritdocs
      */
-    public function getConfigInput(Setup\Config $config = null) : ILIAS\UI\Component\Input\Field\Input
-    {
-        throw new \LogicException("NYI!");
-    }
-
-    /**
-     * @inheritdocs
-     */
     public function getArrayToConfigTransformation() : Transformation
     {
         // TODO: Migrate this to refinery-methods once possible.

--- a/Services/Database/classes/Setup/class.ilDatabaseSetupAgent.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseSetupAgent.php
@@ -82,4 +82,12 @@ class ilDatabaseSetupAgent implements Setup\Agent
     {
         return new Setup\Objective\NullObjective();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
 }

--- a/Services/Database/classes/Setup/class.ilDatabaseSetupAgent.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseSetupAgent.php
@@ -67,7 +67,12 @@ class ilDatabaseSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new \ilDatabaseUpdatedObjective($config, false);
+        return new Setup\ObjectiveCollection(
+            "Complete objectives from Services\Database",
+            false,
+            new \ilDatabaseConfigStoredObjective($config),
+            new \ilDatabaseUpdatedObjective($config, false)
+        );
     }
 
     /**

--- a/Services/Database/classes/Setup/class.ilDatabaseSetupAgent.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseSetupAgent.php
@@ -58,7 +58,8 @@ class ilDatabaseSetupAgent implements Setup\Agent
             "Complete objectives from Services\Database",
             false,
             new ilDatabaseConfigStoredObjective($config),
-            new \ilDatabaseUpdatedObjective($config)
+            new \ilDatabasePopulatedObjective($config),
+            new \ilDatabaseUpdatedObjective()
         );
     }
 
@@ -67,11 +68,15 @@ class ilDatabaseSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
+        $p = [];
+        if ($config !== null) {
+            $p[] = new \ilDatabaseConfigStoredObjective($config);
+        }
+        $p[] = new \ilDatabaseUpdatedObjective();
         return new Setup\ObjectiveCollection(
             "Complete objectives from Services\Database",
             false,
-            new \ilDatabaseConfigStoredObjective($config),
-            new \ilDatabaseUpdatedObjective($config, false)
+            ...$p
         );
     }
 

--- a/Services/Database/classes/Setup/class.ilDatabaseSetupAgent.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseSetupAgent.php
@@ -93,6 +93,6 @@ class ilDatabaseSetupAgent implements Setup\Agent
      */
     public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilDatabaseMetricsCollectedObjective($storage);
     }
 }

--- a/Services/Database/classes/Setup/class.ilDatabaseUpdatedObjective.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseUpdatedObjective.php
@@ -5,32 +5,11 @@
 use ILIAS\Setup;
 use ILIAS\DI;
 
-class ilDatabaseUpdatedObjective extends \ilDatabaseObjective
+class ilDatabaseUpdatedObjective implements Setup\Objective
 {
-    /**
-     * @var	ilDatabaseSetupConfig
-     */
-    protected $config;
-
-    /**
-     * @var	bool
-     */
-    protected $populate_before;
-
-    public function __construct(\ilDatabaseSetupConfig $config, bool $populate_before = false)
-    {
-        parent::__construct($config);
-        $this->populate_before = $populate_before;
-    }
-
     public function getHash() : string
     {
-        return hash("sha256", implode("-", [
-            self::class,
-            $this->config->getHost(),
-            $this->config->getPort(),
-            $this->config->getDatabase()
-        ]));
+        return hash("sha256", self::class);
     }
 
     public function getLabel() : string
@@ -45,16 +24,8 @@ class ilDatabaseUpdatedObjective extends \ilDatabaseObjective
 
     public function getPreconditions(Setup\Environment $environment) : array
     {
-        if (!$this->populate_before) {
-            return [
-                new \ilIniFilesLoadedObjective(),
-                new \ilDatabaseExistsObjective($this->config)
-            ];
-        }
-
         return [
-            new \ilIniFilesLoadedObjective(),
-            new \ilDatabasePopulatedObjective($this->config)
+            new \ilDatabaseInitializedObjective()
         ];
     }
 

--- a/Services/Database/classes/Setup/class.ilDatabaseUpdatedObjective.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseUpdatedObjective.php
@@ -52,9 +52,8 @@ class ilDatabaseUpdatedObjective extends \ilDatabaseObjective
             ];
         }
 
-        $common_config = $environment->getConfigFor("common");
         return [
-            new \ilIniFilesPopulatedObjective($common_config),
+            new \ilIniFilesLoadedObjective(),
             new \ilDatabasePopulatedObjective($this->config)
         ];
     }

--- a/Services/Database/classes/Setup/class.ilDatabaseUpdatedObjective.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseUpdatedObjective.php
@@ -25,6 +25,8 @@ class ilDatabaseUpdatedObjective implements Setup\Objective
     public function getPreconditions(Setup\Environment $environment) : array
     {
         return [
+            new Setup\Objective\ClientIdReadObjective(),
+            new ilIniFilesPopulatedObjective(),
             new \ilDatabaseInitializedObjective()
         ];
     }
@@ -33,9 +35,9 @@ class ilDatabaseUpdatedObjective implements Setup\Objective
     {
         $db = $environment->getResource(Setup\Environment::RESOURCE_DATABASE);
         $io = $environment->getResource(Setup\Environment::RESOURCE_ADMIN_INTERACTION);
+        $ini = $environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI);
         $client_ini = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_INI);
-        $common_config = $environment->getConfigFor("common");
-        $filesystem_config = $environment->getConfigFor("filesystem");
+        $client_id = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_ID);
 
         // ATTENTION: This is a total abomination. It only exists to allow the db-
         // update to run. This is a memento to the fact, that dependency injection
@@ -87,8 +89,8 @@ class ilDatabaseUpdatedObjective implements Setup\Objective
             {
             }
         };
-        define("CLIENT_DATA_DIR", $filesystem_config->getDataDir() . "/" . $common_config->getClientId());
-        define("CLIENT_WEB_DIR", $filesystem_config->getWebDir() . "/" . $common_config->getClientId());
+        define("CLIENT_DATA_DIR", $ini->readVariable("clients", "datadir") . "/" . $client_id);
+        define("CLIENT_WEB_DIR", dirname(__DIR__, 4) . "/data/" . $client_id);
         if (!defined("ILIAS_ABSOLUTE_PATH")) {
             define("ILIAS_ABSOLUTE_PATH", dirname(__FILE__, 5));
         }

--- a/Services/FileSystem/classes/Setup/class.ilFileSystemMetricsCollectedObjective.php
+++ b/Services/FileSystem/classes/Setup/class.ilFileSystemMetricsCollectedObjective.php
@@ -1,0 +1,28 @@
+<?php
+
+/* Copyright (c) 2020 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+use ILIAS\Setup;
+use ILIAS\Setup\Metrics\Storage;
+
+class ilFileSystemMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
+{
+    public function getTentativePreconditions(Setup\Environment $environment) : array
+    {
+        return [
+            new ilIniFilesLoadedObjective()
+        ];
+    }
+
+    protected function collectFrom(Setup\Environment $environment, Storage $storage) : void
+    {
+        $ini = $environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI);
+        if ($ini) {
+            $storage->storeConfigText(
+                "data_dir",
+                $ini->readVariable("client", "datadir"),
+                "Filesystem location where ILIAS stores data outside of direct web access."
+            );
+        }
+    }
+}

--- a/Services/FileSystem/classes/Setup/class.ilFileSystemSetupAgent.php
+++ b/Services/FileSystem/classes/Setup/class.ilFileSystemSetupAgent.php
@@ -63,4 +63,12 @@ class ilFileSystemSetupAgent implements Setup\Agent
     {
         return new Setup\Objective\NullObjective();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
 }

--- a/Services/FileSystem/classes/Setup/class.ilFileSystemSetupAgent.php
+++ b/Services/FileSystem/classes/Setup/class.ilFileSystemSetupAgent.php
@@ -31,14 +31,6 @@ class ilFileSystemSetupAgent implements Setup\Agent
     /**
      * @inheritdoc
      */
-    public function getConfigInput(Setup\Config $config = null) : UI\Component\Input\Field\Input
-    {
-        throw new \LogicException("Not yet implemented.");
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getArrayToConfigTransformation() : Refinery\Transformation
     {
         return $this->refinery->custom()->transformation(function ($data) {

--- a/Services/FileSystem/classes/Setup/class.ilFileSystemSetupAgent.php
+++ b/Services/FileSystem/classes/Setup/class.ilFileSystemSetupAgent.php
@@ -45,11 +45,7 @@ class ilFileSystemSetupAgent implements Setup\Agent
      */
     public function getInstallObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\ObjectiveCollection(
-            "Complete objetives from Services/FileSystem",
-            false,
-            new ilFileSystemDirectoriesCreatedObjective($config)
-        );
+        return new ilFileSystemDirectoriesCreatedObjective($config);
     }
 
     /**
@@ -57,7 +53,7 @@ class ilFileSystemSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilFileSystemConfigNotChangedObjective($config);
     }
 
     /**

--- a/Services/FileSystem/classes/Setup/class.ilFileSystemSetupAgent.php
+++ b/Services/FileSystem/classes/Setup/class.ilFileSystemSetupAgent.php
@@ -53,7 +53,10 @@ class ilFileSystemSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new ilFileSystemConfigNotChangedObjective($config);
+        if ($config) {
+            return new ilFileSystemConfigNotChangedObjective($config);
+        }
+        return new Setup\Objective\NullObjective();
     }
 
     /**

--- a/Services/FileSystem/classes/Setup/class.ilFileSystemSetupAgent.php
+++ b/Services/FileSystem/classes/Setup/class.ilFileSystemSetupAgent.php
@@ -72,6 +72,6 @@ class ilFileSystemSetupAgent implements Setup\Agent
      */
     public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilFileSystemMetricsCollectedObjective($storage);
     }
 }

--- a/Services/GlobalCache/classes/Setup/class.ilGlobalCacheConfigStoredObjective.php
+++ b/Services/GlobalCache/classes/Setup/class.ilGlobalCacheConfigStoredObjective.php
@@ -34,9 +34,8 @@ class ilGlobalCacheConfigStoredObjective implements Setup\Objective
 
     public function getPreconditions(Setup\Environment $environment) : array
     {
-        $common_config = $environment->getConfigFor("common");
         return [
-            new ilIniFilesPopulatedObjective($common_config),
+            new ilIniFilesLoadedObjective()
         ];
     }
 
@@ -58,7 +57,7 @@ class ilGlobalCacheConfigStoredObjective implements Setup\Objective
      */
     public function isApplicable(Setup\Environment $environment) : bool
     {
-        // The effort to check the hole ini file is here to big.
+        // The effort to check the whole ini file is too big here.
         return true;
     }
 }

--- a/Services/GlobalCache/classes/Setup/class.ilGlobalCacheMetricsCollectedObjective.php
+++ b/Services/GlobalCache/classes/Setup/class.ilGlobalCacheMetricsCollectedObjective.php
@@ -1,0 +1,49 @@
+<?php
+
+/* Copyright (c) 2020 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+use ILIAS\Setup;
+
+class ilGlobalCacheMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
+{
+    public function getTentativePreconditions(Setup\Environment $environment) : array
+    {
+        return [
+            new ilIniFilesLoadedObjective()
+        ];
+    }
+
+    public function collectFrom(Setup\Environment $environment, Setup\Metrics\Storage $storage) : void
+    {
+        $client_ini = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_INI);
+        if (!$client_ini) {
+            return;
+        }
+
+        $settings = new ilGlobalCacheSettings();
+        $settings->readFromIniFile($client_ini);
+        $storage->storeConfigText(
+            "service",
+            $settings->getService(),
+            "The backend that is used for the ILIAS cache."
+        );
+        $component_activation = [];
+        foreach (ilGlobalCache::getAvailableComponents() as $component) {
+            $component_activation[$component] = new Setup\Metrics\Metric(
+                Setup\Metrics\Metric::STABILITY_CONFIG,
+                Setup\Metrics\Metric::TYPE_BOOL,
+                $settings->isComponentActivated($component)
+            );
+        }
+        $component_activation = new Setup\Metrics\Metric(
+            Setup\Metrics\Metric::STABILITY_CONFIG,
+            Setup\Metrics\Metric::TYPE_COLLECTION,
+            $component_activation,
+            "Which components are activated to use caching?"
+        );
+        $storage->store(
+            "component_activation",
+            $component_activation
+        );
+    }
+}

--- a/Services/GlobalCache/classes/Setup/class.ilGlobalCacheSetupAgent.php
+++ b/Services/GlobalCache/classes/Setup/class.ilGlobalCacheSetupAgent.php
@@ -92,4 +92,12 @@ class ilGlobalCacheSetupAgent implements Setup\Agent
     {
         return new Setup\Objective\NullObjective();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
 }

--- a/Services/GlobalCache/classes/Setup/class.ilGlobalCacheSetupAgent.php
+++ b/Services/GlobalCache/classes/Setup/class.ilGlobalCacheSetupAgent.php
@@ -74,11 +74,7 @@ class ilGlobalCacheSetupAgent implements Setup\Agent
      */
     public function getInstallObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\ObjectiveCollection(
-            "Complete objectives from Services/GlobalCache",
-            false,
-            new ilGlobalCacheConfigStoredObjective($config)
-        );
+        return new ilGlobalCacheConfigStoredObjective($config);
     }
 
     /**
@@ -86,7 +82,7 @@ class ilGlobalCacheSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilGlobalCacheConfigStoredObjective($config);
     }
 
     /**

--- a/Services/GlobalCache/classes/Setup/class.ilGlobalCacheSetupAgent.php
+++ b/Services/GlobalCache/classes/Setup/class.ilGlobalCacheSetupAgent.php
@@ -30,14 +30,6 @@ class ilGlobalCacheSetupAgent implements Setup\Agent
     /**
      * @inheritdoc
      */
-    public function getConfigInput(Setup\Config $config = null) : UI\Component\Input\Field\Input
-    {
-        throw new \LogicException("Not yet implemented.");
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getArrayToConfigTransformation() : Refinery\Transformation
     {
         return $this->refinery->custom()->transformation(function ($data) {

--- a/Services/GlobalCache/classes/Setup/class.ilGlobalCacheSetupAgent.php
+++ b/Services/GlobalCache/classes/Setup/class.ilGlobalCacheSetupAgent.php
@@ -82,7 +82,10 @@ class ilGlobalCacheSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new ilGlobalCacheConfigStoredObjective($config);
+        if ($config !== null) {
+            return new ilGlobalCacheConfigStoredObjective($config);
+        }
+        return new Setup\Objective\NullObjective();
     }
 
     /**

--- a/Services/GlobalCache/classes/Setup/class.ilGlobalCacheSetupAgent.php
+++ b/Services/GlobalCache/classes/Setup/class.ilGlobalCacheSetupAgent.php
@@ -101,6 +101,6 @@ class ilGlobalCacheSetupAgent implements Setup\Agent
      */
     public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilGlobalCacheMetricsCollectedObjective($storage);
     }
 }

--- a/Services/GlobalScreen/classes/Setup/class.ilGlobalScreenSetupAgent.php
+++ b/Services/GlobalScreen/classes/Setup/class.ilGlobalScreenSetupAgent.php
@@ -30,14 +30,6 @@ class ilGlobalScreenSetupAgent implements Setup\Agent
     /**
      * @inheritdocs
      */
-    public function getConfigInput(Setup\Config $config = null) : ILIAS\UI\Component\Input\Field\Input
-    {
-        throw new \LogicException(self::class . " has no Config.");
-    }
-
-    /**
-     * @inheritdocs
-     */
     public function getArrayToConfigTransformation() : Transformation
     {
         throw new \LogicException(self::class . " has no Config.");

--- a/Services/GlobalScreen/classes/Setup/class.ilGlobalScreenSetupAgent.php
+++ b/Services/GlobalScreen/classes/Setup/class.ilGlobalScreenSetupAgent.php
@@ -58,4 +58,12 @@ class ilGlobalScreenSetupAgent implements Setup\Agent
     {
         return new \ilGlobalScreenBuildProviderMapObjective();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
 }

--- a/Services/Http/classes/Setup/class.ilHttpConfigStoredObjective.php
+++ b/Services/Http/classes/Setup/class.ilHttpConfigStoredObjective.php
@@ -34,9 +34,8 @@ class ilHttpConfigStoredObjective implements Setup\Objective
 
     public function getPreconditions(Setup\Environment $environment) : array
     {
-        $common_config = $environment->getConfigFor("common");
         return [
-            new ilIniFilesPopulatedObjective($common_config),
+            new ilIniFilesLoadedObjective(),
             new \ilSettingsFactoryExistsObjective()
         ];
     }

--- a/Services/Http/classes/Setup/class.ilHttpMetricsCollectedObjective.php
+++ b/Services/Http/classes/Setup/class.ilHttpMetricsCollectedObjective.php
@@ -1,0 +1,96 @@
+<?php
+
+/* Copyright (c) 2020 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+use ILIAS\Setup;
+
+class ilHttpMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
+{
+    public function getTentativePreconditions(Setup\Environment $environment) : array
+    {
+        return [
+            new ilIniFilesLoadedObjective(),
+            new \ilSettingsFactoryExistsObjective()
+        ];
+    }
+
+    public function collectFrom(Setup\Environment $environment, Setup\Metrics\Storage $storage) : void
+    {
+        $ini = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_INI);
+        if ($ini) {
+            $storage->storeConfigText(
+                "http_path",
+                $ini->readVariable("server", "http_path"),
+                "URL of the server."
+            );
+
+            if ($ini->readVariable("https", "auto_https_detect_enabled")) {
+                $header_name = new Setup\Metrics\Metric(
+                    Setup\Metrics\Metric::STABILITY_CONFIG,
+                    Setup\Metrics\Metric::TYPE_TEXT,
+                    $ini->readVariable("https", "auto_https_detect_header_name"),
+                    "The name of the header used for https detection in requests."
+                );
+                $header_value = new Setup\Metrics\Metric(
+                    Setup\Metrics\Metric::STABILITY_CONFIG,
+                    Setup\Metrics\Metric::TYPE_TEXT,
+                    $ini->readVariable("https", "auto_https_detect_header_value"),
+                    "The value in the named header that indicates usage of https in requests."
+                );
+                $https_metrics = new Setup\Metrics\Metric(
+                    Setup\Metrics\Metric::STABILITY_CONFIG,
+                    Setup\Metrics\Metric::TYPE_COLLECTION,
+                    [
+                        "header_name" => $header_name,
+                        "header_value" => $header_value
+                    ],
+                    "The properties of a request used for https detection."
+                );
+                $storage->store("https_autodetection", $https_metrics);
+            } else {
+                $storage->storeConfigBool(
+                    "https_autodetection",
+                    false,
+                    "Does the server attempt to detect https in incoming requests?"
+                );
+            }
+        }
+
+        $factory = $environment->getResource(Setup\Environment::RESOURCE_SETTINGS_FACTORY);
+        if (!$factory) {
+            return;
+        }
+        $settings = $factory->settingsFor("common");
+
+        if ($settings->get("proxy_status")) {
+            $host = new Setup\Metrics\Metric(
+                Setup\Metrics\Metric::STABILITY_CONFIG,
+                Setup\Metrics\Metric::TYPE_TEXT,
+                $ini->get("proxy_host"),
+                "The host of the proxy."
+            );
+            $host = new Setup\Metrics\Metric(
+                Setup\Metrics\Metric::STABILITY_CONFIG,
+                Setup\Metrics\Metric::TYPE_TEXT,
+                $ini->get("proxy_host"),
+                "The port of the proxy."
+            );
+            $proxy = new Setup\Metrics\Metric(
+                Setup\Metrics\Metric::STABILITY_CONFIG,
+                Setup\Metrics\Metric::TYPE_COLLECTION,
+                [
+                    "host" => $host,
+                    "port" => $port
+                ],
+                "The proxy that is used for outgoing connections."
+            );
+            $storage->store("proxy", $proxy);
+        } else {
+            $storage->storeConfigBool(
+                "proxy",
+                false,
+                "Does the server use a proxy for outgoing connections?"
+            );
+        }
+    }
+}

--- a/Services/Http/classes/Setup/class.ilHttpSetupAgent.php
+++ b/Services/Http/classes/Setup/class.ilHttpSetupAgent.php
@@ -63,11 +63,7 @@ class ilHttpSetupAgent implements Setup\Agent
      */
     public function getInstallObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\ObjectiveCollection(
-            "Complete objectives from Services/Http",
-            false,
-            new ilHttpConfigStoredObjective($config)
-        );
+        return new ilHttpConfigStoredObjective($config);
     }
 
     /**
@@ -75,7 +71,7 @@ class ilHttpSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilHttpConfigStoredObjective($config);
     }
 
     /**

--- a/Services/Http/classes/Setup/class.ilHttpSetupAgent.php
+++ b/Services/Http/classes/Setup/class.ilHttpSetupAgent.php
@@ -81,4 +81,12 @@ class ilHttpSetupAgent implements Setup\Agent
     {
         return new Setup\Objective\NullObjective();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
 }

--- a/Services/Http/classes/Setup/class.ilHttpSetupAgent.php
+++ b/Services/Http/classes/Setup/class.ilHttpSetupAgent.php
@@ -71,7 +71,10 @@ class ilHttpSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new ilHttpConfigStoredObjective($config);
+        if ($config !== null) {
+            return new ilHttpConfigStoredObjective($config);
+        }
+        return new Setup\Objective\NullObjective();
     }
 
     /**

--- a/Services/Http/classes/Setup/class.ilHttpSetupAgent.php
+++ b/Services/Http/classes/Setup/class.ilHttpSetupAgent.php
@@ -90,6 +90,6 @@ class ilHttpSetupAgent implements Setup\Agent
      */
     public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilHttpMetricsCollectedObjective($storage);
     }
 }

--- a/Services/Http/classes/Setup/class.ilHttpSetupAgent.php
+++ b/Services/Http/classes/Setup/class.ilHttpSetupAgent.php
@@ -31,14 +31,6 @@ class ilHttpSetupAgent implements Setup\Agent
     /**
      * @inheritdoc
      */
-    public function getConfigInput(Setup\Config $config = null) : UI\Component\Input\Field\Input
-    {
-        throw new \LogicException("Not yet implemented.");
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getArrayToConfigTransformation() : Refinery\Transformation
     {
         return $this->refinery->custom()->transformation(function ($data) {

--- a/Services/Language/classes/Setup/class.ilDefaultLanguageSetObjective.php
+++ b/Services/Language/classes/Setup/class.ilDefaultLanguageSetObjective.php
@@ -27,9 +27,8 @@ class ilDefaultLanguageSetObjective extends ilLanguageObjective
 
     public function getPreconditions(Setup\Environment $environment) : array
     {
-        $common_config = $environment->getConfigFor("common");
         return [
-            new \ilIniFilesPopulatedObjective($common_config),
+            new \ilIniFilesLoadedObjective(),
             new \ilSettingsFactoryExistsObjective()
         ];
     }

--- a/Services/Language/classes/Setup/class.ilLanguageConfigStoredObjective.php
+++ b/Services/Language/classes/Setup/class.ilLanguageConfigStoredObjective.php
@@ -23,9 +23,8 @@ class ilLanguageConfigStoredObjective extends ilLanguageObjective
 
     public function getPreconditions(Setup\Environment $environment) : array
     {
-        $common_config = $environment->getConfigFor("common");
         return [
-            new ilIniFilesPopulatedObjective($common_config)
+            new ilIniFilesLoadedObjective()
         ];
     }
 

--- a/Services/Language/classes/Setup/class.ilLanguageMetricsCollectedObjective.php
+++ b/Services/Language/classes/Setup/class.ilLanguageMetricsCollectedObjective.php
@@ -1,0 +1,83 @@
+<?php
+
+/* Copyright (c) 2020 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+use ILIAS\Setup;
+
+class ilLanguageMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
+{
+    /**
+     * @var \ilSetupLanguage
+     */
+    protected $il_setup_language;
+
+    public function __construct(
+        Setup\Metrics\Storage $storage,
+        \ilSetupLanguage $il_setup_language
+    ) {
+        parent::__construct($storage);
+        $this->il_setup_language = $il_setup_language;
+    }
+        
+
+    public function getTentativePreconditions(Setup\Environment $environment) : array
+    {
+        return [
+            new ilIniFilesLoadedObjective(),
+            new ilDatabaseInitializedObjective()
+        ];
+    }
+
+    public function collectFrom(Setup\Environment $environment, Setup\Metrics\Storage $storage) : void
+    {
+        $client_ini = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_INI);
+        if ($client_ini) {
+            $storage->storeConfigText(
+                "default_language",
+                $client_ini->readVariable("language", "default"),
+                "The language that is used by default."
+            );
+        }
+
+        $db = $environment->getResource(Setup\Environment::RESOURCE_DATABASE);
+        $this->il_setup_language->setDbHandler($db);
+
+        // TODO: Remove this once ilSetupLanguage (or a successor) supports proper
+        // DI for all methods.
+        $GLOBALS["ilDB"] = $db;
+
+        $installed_languages = [];
+        $local_languages = $this->il_setup_language->getLocalLanguages();
+        foreach ($this->il_setup_language->getInstalledLanguages() as $lang) {
+            $local_file = new Setup\Metrics\Metric(
+                Setup\Metrics\Metric::STABILITY_STABLE,
+                Setup\Metrics\Metric::TYPE_BOOL,
+                in_array($lang, $local_languages),
+                "Is there a local language file for the language?"
+            );
+            $local_changes = new Setup\Metrics\Metric(
+                Setup\Metrics\Metric::STABILITY_STABLE,
+                Setup\Metrics\Metric::TYPE_BOOL,
+                count($this->il_setup_language->getLocalChanges($lang)) > 0,
+                "Are there local changes for the language?"
+            );
+            $installed_languages[$lang] = new Setup\Metrics\Metric(
+                Setup\Metrics\Metric::STABILITY_STABLE,
+                Setup\Metrics\Metric::TYPE_COLLECTION,
+                [
+                    "local_file" => $local_file,
+                    "local_changes" => $local_changes
+                ]
+            );
+        };
+        $installed_languages = new Setup\Metrics\Metric(
+            Setup\Metrics\Metric::STABILITY_STABLE,
+            Setup\Metrics\Metric::TYPE_COLLECTION,
+            $installed_languages
+        );
+        $storage->store(
+            "installed_languages",
+            $installed_languages
+        );
+    }
+}

--- a/Services/Language/classes/Setup/class.ilLanguageSetupAgent.php
+++ b/Services/Language/classes/Setup/class.ilLanguageSetupAgent.php
@@ -71,7 +71,13 @@ class ilLanguageSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new Setup\ObjectiveCollection(
+            "Complete objectives from Services/Language",
+            false,
+            new ilLanguageConfigStoredObjective($config),
+            new ilLanguagesInstalledObjective($config, $this->il_setup_language),
+            new ilDefaultLanguageSetObjective($config)
+        );
     }
 
     /**

--- a/Services/Language/classes/Setup/class.ilLanguageSetupAgent.php
+++ b/Services/Language/classes/Setup/class.ilLanguageSetupAgent.php
@@ -71,13 +71,16 @@ class ilLanguageSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\ObjectiveCollection(
-            "Complete objectives from Services/Language",
-            false,
-            new ilLanguageConfigStoredObjective($config),
-            new ilLanguagesInstalledObjective($config, $this->il_setup_language),
-            new ilDefaultLanguageSetObjective($config)
-        );
+        if ($config !== null) {
+            return new Setup\ObjectiveCollection(
+                "Complete objectives from Services/Language",
+                false,
+                new ilLanguageConfigStoredObjective($config),
+                new ilLanguagesInstalledObjective($config, $this->il_setup_language),
+                new ilDefaultLanguageSetObjective($config)
+            );
+        }
+        return new Setup\Objective\NullObjective();
     }
 
     /**

--- a/Services/Language/classes/Setup/class.ilLanguageSetupAgent.php
+++ b/Services/Language/classes/Setup/class.ilLanguageSetupAgent.php
@@ -38,14 +38,6 @@ class ilLanguageSetupAgent implements Setup\Agent
     /**
      * @inheritdoc
      */
-    public function getConfigInput(Setup\Config $config = null) : UI\Component\Input\Field\Input
-    {
-        throw new \LogicException("Not yet implemented.");
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getArrayToConfigTransformation() : Refinery\Transformation
     {
         return $this->refinery->custom()->transformation(function ($data) {

--- a/Services/Language/classes/Setup/class.ilLanguageSetupAgent.php
+++ b/Services/Language/classes/Setup/class.ilLanguageSetupAgent.php
@@ -87,4 +87,12 @@ class ilLanguageSetupAgent implements Setup\Agent
     {
         return new Setup\Objective\NullObjective();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
 }

--- a/Services/Language/classes/Setup/class.ilLanguageSetupAgent.php
+++ b/Services/Language/classes/Setup/class.ilLanguageSetupAgent.php
@@ -96,6 +96,6 @@ class ilLanguageSetupAgent implements Setup\Agent
      */
     public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilLanguageMetricsCollectedObjective($storage, $this->il_setup_language);
     }
 }

--- a/Services/Language/classes/Setup/class.ilSetupLanguage.php
+++ b/Services/Language/classes/Setup/class.ilSetupLanguage.php
@@ -494,7 +494,7 @@ class ilSetupLanguage extends ilLanguage
     * @param    string  	maximum change date "yyyy-mm-dd hh:mm:ss"
     * @return   array       [module][identifier] => value
     */
-    protected function getLocalChanges($a_lang_key, $a_min_date = "", $a_max_date = "")
+    public function getLocalChanges($a_lang_key, $a_min_date = "", $a_max_date = "")
     {
         $ilDB = $this->db;
         

--- a/Services/Logging/classes/Setup/class.ilLoggingConfigStoredObjective.php
+++ b/Services/Logging/classes/Setup/class.ilLoggingConfigStoredObjective.php
@@ -35,9 +35,8 @@ class ilLoggingConfigStoredObjective implements Setup\Objective
 
     public function getPreconditions(Setup\Environment $environment) : array
     {
-        $common_config = $environment->getConfigFor("common");
         return [
-            new ilIniFilesPopulatedObjective($common_config)
+            new ilIniFilesLoadedObjective()
         ];
     }
 

--- a/Services/Logging/classes/Setup/class.ilLoggingMetricsCollectedObjective.php
+++ b/Services/Logging/classes/Setup/class.ilLoggingMetricsCollectedObjective.php
@@ -1,0 +1,39 @@
+<?php
+
+/* Copyright (c) 2020 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+use ILIAS\Setup;
+
+class ilLoggingMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
+{
+    public function getTentativePreconditions(Setup\Environment $environment) : array
+    {
+        return [
+            new ilIniFilesLoadedObjective()
+        ];
+    }
+
+    public function collectFrom(Setup\Environment $environment, Setup\Metrics\Storage $storage) : void
+    {
+        $ini = $environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI);
+        if (!$ini) {
+            return;
+        }
+
+        $storage->storeConfigBool(
+            "enable",
+            $ini->readVariable("log", "enabled"),
+            "Is the logging enabled on the installation?"
+        );
+        $storage->storeConfigText(
+            "path_to_logfile",
+            $ini->readVariable("log", "path") . "/" . $ini->readVariable("log", "file"),
+            "The path to the logfile."
+        );
+        $storage->storeConfigText(
+            "errorlog_dir",
+            $ini->readVariable("log", "error_path"),
+            "The path to the directory where error protocols are stored."
+        );
+    }
+}

--- a/Services/Logging/classes/Setup/class.ilLoggingSetupAgent.php
+++ b/Services/Logging/classes/Setup/class.ilLoggingSetupAgent.php
@@ -64,4 +64,12 @@ class ilLoggingSetupAgent implements Setup\Agent
     {
         return new Setup\Objective\NullObjective();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
 }

--- a/Services/Logging/classes/Setup/class.ilLoggingSetupAgent.php
+++ b/Services/Logging/classes/Setup/class.ilLoggingSetupAgent.php
@@ -54,7 +54,10 @@ class ilLoggingSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new ilLoggingConfigStoredObjective($config);
+        if ($config !== null) {
+            return new ilLoggingConfigStoredObjective($config);
+        }
+        return new Setup\Objective\NullObjective();
     }
 
     /**

--- a/Services/Logging/classes/Setup/class.ilLoggingSetupAgent.php
+++ b/Services/Logging/classes/Setup/class.ilLoggingSetupAgent.php
@@ -46,11 +46,7 @@ class ilLoggingSetupAgent implements Setup\Agent
      */
     public function getInstallObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\ObjectiveCollection(
-            "Complete objectives from Services/Logging",
-            false,
-            new ilLoggingConfigStoredObjective($config)
-        );
+        return new ilLoggingConfigStoredObjective($config);
     }
 
     /**
@@ -58,7 +54,7 @@ class ilLoggingSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilLoggingConfigStoredObjective($config);
     }
 
     /**

--- a/Services/Logging/classes/Setup/class.ilLoggingSetupAgent.php
+++ b/Services/Logging/classes/Setup/class.ilLoggingSetupAgent.php
@@ -30,14 +30,6 @@ class ilLoggingSetupAgent implements Setup\Agent
     /**
      * @inheritdoc
      */
-    public function getConfigInput(Setup\Config $config = null) : UI\Component\Input\Field\Input
-    {
-        throw new \LogicException("Not yet implemented.");
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getArrayToConfigTransformation() : Refinery\Transformation
     {
         return $this->refinery->custom()->transformation(function ($data) {

--- a/Services/Logging/classes/Setup/class.ilLoggingSetupAgent.php
+++ b/Services/Logging/classes/Setup/class.ilLoggingSetupAgent.php
@@ -73,6 +73,6 @@ class ilLoggingSetupAgent implements Setup\Agent
      */
     public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilLoggingMetricsCollectedObjective($storage);
     }
 }

--- a/Services/Mail/classes/Setup/class.ilMailSetupAgent.php
+++ b/Services/Mail/classes/Setup/class.ilMailSetupAgent.php
@@ -19,14 +19,6 @@ class ilMailSetupAgent implements Setup\Agent
     /**
      * @inheritdoc
      */
-    public function getConfigInput(Setup\Config $config = null) : UI\Component\Input\Field\Input
-    {
-        throw new \LogicException("Agent has no config.");
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getArrayToConfigTransformation() : Refinery\Transformation
     {
         throw new \LogicException("Agent has no config.");

--- a/Services/Mail/classes/Setup/class.ilMailSetupAgent.php
+++ b/Services/Mail/classes/Setup/class.ilMailSetupAgent.php
@@ -29,15 +29,9 @@ class ilMailSetupAgent implements Setup\Agent
      */
     public function getInstallObjective(Setup\Config $config = null) : Setup\Objective
     {
-        $dir_objective = new ilFileSystemComponentDataDirectoryCreatedObjective(
+        return new ilFileSystemComponentDataDirectoryCreatedObjective(
             'mail',
             ilFileSystemComponentDataDirectoryCreatedObjective::DATADIR
-        );
-
-        return new Setup\ObjectiveCollection(
-            "Complete objectives from Services/Mail",
-            false,
-            $dir_objective
         );
     }
 

--- a/Services/Mail/classes/Setup/class.ilMailSetupAgent.php
+++ b/Services/Mail/classes/Setup/class.ilMailSetupAgent.php
@@ -50,4 +50,12 @@ class ilMailSetupAgent implements Setup\Agent
     {
         return new Setup\Objective\NullObjective();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
 }

--- a/Services/MathJax/classes/Setup/class.ilMathJaxConfigStoredObjective.php
+++ b/Services/MathJax/classes/Setup/class.ilMathJaxConfigStoredObjective.php
@@ -34,9 +34,8 @@ class ilMathJaxConfigStoredObjective implements Setup\Objective
 
     public function getPreconditions(Setup\Environment $environment) : array
     {
-        $common_config = $environment->getConfigFor("common");
         return [
-            new ilIniFilesPopulatedObjective($common_config)
+            new ilIniFilesLoadedObjective()
         ];
     }
 

--- a/Services/MathJax/classes/Setup/class.ilMathJaxMetricsCollectedObjective.php
+++ b/Services/MathJax/classes/Setup/class.ilMathJaxMetricsCollectedObjective.php
@@ -1,0 +1,29 @@
+<?php
+
+/* Copyright (c) 2020 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+use ILIAS\Setup;
+
+class ilMathJaxMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
+{
+    public function getTentativePreconditions(Setup\Environment $environment) : array
+    {
+        return [
+            new ilIniFilesLoadedObjective()
+        ];
+    }
+
+    public function collectFrom(Setup\Environment $environment, Setup\Metrics\Storage $storage) : void
+    {
+        $ini = $environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI);
+        if (!$ini) {
+            return;
+        }
+
+        $storage->storeConfigText(
+            "path_to_latex_cgi",
+            $ini->readVariable("tools", "latex"),
+            "The path to the binary used to render latex via CGI."
+        );
+    }
+}

--- a/Services/MathJax/classes/Setup/class.ilMathJaxSetupAgent.php
+++ b/Services/MathJax/classes/Setup/class.ilMathJaxSetupAgent.php
@@ -63,4 +63,12 @@ class ilMathJaxSetupAgent implements Setup\Agent
     {
         return new Setup\Objective\NullObjective();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
 }

--- a/Services/MathJax/classes/Setup/class.ilMathJaxSetupAgent.php
+++ b/Services/MathJax/classes/Setup/class.ilMathJaxSetupAgent.php
@@ -53,7 +53,10 @@ class ilMathJaxSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new ilMathJaxConfigStoredObjective($config);
+        if ($config !== null) {
+            return new ilMathJaxConfigStoredObjective($config);
+        }
+        return new Setup\Objective\NullObjective();
     }
 
     /**

--- a/Services/MathJax/classes/Setup/class.ilMathJaxSetupAgent.php
+++ b/Services/MathJax/classes/Setup/class.ilMathJaxSetupAgent.php
@@ -45,11 +45,7 @@ class ilMathJaxSetupAgent implements Setup\Agent
      */
     public function getInstallObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\ObjectiveCollection(
-            "Complete objectives from Services/MathJax",
-            false,
-            new ilMathJaxConfigStoredObjective($config)
-        );
+        return new ilMathJaxConfigStoredObjective($config);
     }
 
     /**
@@ -57,7 +53,7 @@ class ilMathJaxSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilMathJaxConfigStoredObjective($config);
     }
 
     /**

--- a/Services/MathJax/classes/Setup/class.ilMathJaxSetupAgent.php
+++ b/Services/MathJax/classes/Setup/class.ilMathJaxSetupAgent.php
@@ -31,14 +31,6 @@ class ilMathJaxSetupAgent implements Setup\Agent
     /**
      * @inheritdoc
      */
-    public function getConfigInput(Setup\Config $config = null) : UI\Component\Input\Field\Input
-    {
-        throw new \LogicException("Not yet implemented.");
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getArrayToConfigTransformation() : Refinery\Transformation
     {
         return $this->refinery->custom()->transformation(function ($data) {

--- a/Services/MathJax/classes/Setup/class.ilMathJaxSetupAgent.php
+++ b/Services/MathJax/classes/Setup/class.ilMathJaxSetupAgent.php
@@ -72,6 +72,6 @@ class ilMathJaxSetupAgent implements Setup\Agent
      */
     public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilMathJaxMetricsCollectedObjective($storage);
     }
 }

--- a/Services/MediaObjects/classes/Setup/class.ilMediaObjectMetricsCollectedObjective.php
+++ b/Services/MediaObjects/classes/Setup/class.ilMediaObjectMetricsCollectedObjective.php
@@ -1,0 +1,29 @@
+<?php
+
+/* Copyright (c) 2020 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+use ILIAS\Setup;
+
+class ilMediaObjectMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
+{
+    public function getTentativePreconditions(Setup\Environment $environment) : array
+    {
+        return [
+            new ilIniFilesLoadedObjective()
+        ];
+    }
+
+    public function collectFrom(Setup\Environment $environment, Setup\Metrics\Storage $storage) : void
+    {
+        $ini = $environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI);
+        if (!$ini) {
+            return;
+        }
+
+        $storage->storeConfigText(
+            "path_to_ffmpeg",
+            $ini->readVariable("tools", "ffmpeg"),
+            "The path to the binary of ffmpeg to convert videos."
+        );
+    }
+}

--- a/Services/MediaObjects/classes/Setup/class.ilMediaObjectSetupAgent.php
+++ b/Services/MediaObjects/classes/Setup/class.ilMediaObjectSetupAgent.php
@@ -63,7 +63,10 @@ class ilMediaObjectSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new ilMediaObjectConfigStoredObjective($config);
+        if ($config !== null) {
+            return new ilMediaObjectConfigStoredObjective($config);
+        }
+        return new Setup\Objective\NullObjective();
     }
 
     /**

--- a/Services/MediaObjects/classes/Setup/class.ilMediaObjectSetupAgent.php
+++ b/Services/MediaObjects/classes/Setup/class.ilMediaObjectSetupAgent.php
@@ -31,14 +31,6 @@ class ilMediaObjectSetupAgent implements Setup\Agent
     /**
      * @inheritdoc
      */
-    public function getConfigInput(Setup\Config $config = null) : UI\Component\Input\Field\Input
-    {
-        throw new \LogicException("Not yet implemented.");
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getArrayToConfigTransformation() : Refinery\Transformation
     {
         return $this->refinery->custom()->transformation(function ($data) {

--- a/Services/MediaObjects/classes/Setup/class.ilMediaObjectSetupAgent.php
+++ b/Services/MediaObjects/classes/Setup/class.ilMediaObjectSetupAgent.php
@@ -82,6 +82,6 @@ class ilMediaObjectSetupAgent implements Setup\Agent
      */
     public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilMediaObjectMetricsCollectedObjective($storage);
     }
 }

--- a/Services/MediaObjects/classes/Setup/class.ilMediaObjectSetupAgent.php
+++ b/Services/MediaObjects/classes/Setup/class.ilMediaObjectSetupAgent.php
@@ -73,4 +73,12 @@ class ilMediaObjectSetupAgent implements Setup\Agent
     {
         return new Setup\Objective\NullObjective();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
 }

--- a/Services/MediaObjects/classes/Setup/class.ilMediaObjectSetupAgent.php
+++ b/Services/MediaObjects/classes/Setup/class.ilMediaObjectSetupAgent.php
@@ -63,7 +63,7 @@ class ilMediaObjectSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilMediaObjectConfigStoredObjective($config);
     }
 
     /**

--- a/Services/PDFGeneration/classes/Setup/class.ilPDFGenerationConfigStoredObjective.php
+++ b/Services/PDFGeneration/classes/Setup/class.ilPDFGenerationConfigStoredObjective.php
@@ -34,9 +34,8 @@ class ilPDFGenerationConfigStoredObjective implements Setup\Objective
 
     public function getPreconditions(Setup\Environment $environment) : array
     {
-        $common_config = $environment->getConfigFor("common");
         return [
-            new ilIniFilesPopulatedObjective($common_config)
+            new ilIniFilesLoadedObjective()
         ];
     }
 

--- a/Services/PDFGeneration/classes/Setup/class.ilPDFGenerationMetricsCollectedObjective.php
+++ b/Services/PDFGeneration/classes/Setup/class.ilPDFGenerationMetricsCollectedObjective.php
@@ -1,0 +1,29 @@
+<?php
+
+/* Copyright (c) 2020 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+use ILIAS\Setup;
+
+class ilPDFGenerationMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
+{
+    public function getTentativePreconditions(Setup\Environment $environment) : array
+    {
+        return [
+            new ilIniFilesLoadedObjective()
+        ];
+    }
+
+    public function collectFrom(Setup\Environment $environment, Setup\Metrics\Storage $storage) : void
+    {
+        $ini = $environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI);
+        if (!$ini) {
+            return;
+        }
+
+        $storage->storeConfigText(
+            "path_to_phantom_js",
+            $ini->readVariable("tools", "phantomjs"),
+            "The path to the phantom js binary that is used for pdf generation."
+        );
+    }
+}

--- a/Services/PDFGeneration/classes/Setup/class.ilPDFGenerationSetupAgent.php
+++ b/Services/PDFGeneration/classes/Setup/class.ilPDFGenerationSetupAgent.php
@@ -53,7 +53,10 @@ class ilPDFGenerationSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new ilPDFGenerationConfigStoredObjective($config);
+        if ($config !== null) {
+            return new ilPDFGenerationConfigStoredObjective($config);
+        }
+        return new Setup\Objective\NullObjective();
     }
 
     /**

--- a/Services/PDFGeneration/classes/Setup/class.ilPDFGenerationSetupAgent.php
+++ b/Services/PDFGeneration/classes/Setup/class.ilPDFGenerationSetupAgent.php
@@ -63,4 +63,12 @@ class ilPDFGenerationSetupAgent implements Setup\Agent
     {
         return new Setup\Objective\NullObjective();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
 }

--- a/Services/PDFGeneration/classes/Setup/class.ilPDFGenerationSetupAgent.php
+++ b/Services/PDFGeneration/classes/Setup/class.ilPDFGenerationSetupAgent.php
@@ -72,6 +72,6 @@ class ilPDFGenerationSetupAgent implements Setup\Agent
      */
     public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilPDFGenerationMetricsCollectedObjective($storage);
     }
 }

--- a/Services/PDFGeneration/classes/Setup/class.ilPDFGenerationSetupAgent.php
+++ b/Services/PDFGeneration/classes/Setup/class.ilPDFGenerationSetupAgent.php
@@ -45,11 +45,7 @@ class ilPDFGenerationSetupAgent implements Setup\Agent
      */
     public function getInstallObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\ObjectiveCollection(
-            "Complete objectives from Services/PDFGeneration",
-            false,
-            new ilPDFGenerationConfigStoredObjective($config)
-        );
+        return new ilPDFGenerationConfigStoredObjective($config);
     }
 
     /**
@@ -57,7 +53,7 @@ class ilPDFGenerationSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilPDFGenerationConfigStoredObjective($config);
     }
 
     /**

--- a/Services/PDFGeneration/classes/Setup/class.ilPDFGenerationSetupAgent.php
+++ b/Services/PDFGeneration/classes/Setup/class.ilPDFGenerationSetupAgent.php
@@ -31,14 +31,6 @@ class ilPDFGenerationSetupAgent implements Setup\Agent
     /**
      * @inheritdoc
      */
-    public function getConfigInput(Setup\Config $config = null) : UI\Component\Input\Field\Input
-    {
-        throw new \LogicException("Not yet implemented.");
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getArrayToConfigTransformation() : Refinery\Transformation
     {
         return $this->refinery->custom()->transformation(function ($data) {

--- a/Services/Preview/classes/Setup/class.ilPreviewConfigStoredObjective.php
+++ b/Services/Preview/classes/Setup/class.ilPreviewConfigStoredObjective.php
@@ -34,9 +34,8 @@ class ilPreviewConfigStoredObjective implements Setup\Objective
 
     public function getPreconditions(Setup\Environment $environment) : array
     {
-        $common_config = $environment->getConfigFor("common");
         return [
-            new ilIniFilesPopulatedObjective($common_config)
+            new ilIniFilesLoadedObjective()
         ];
     }
 

--- a/Services/Preview/classes/Setup/class.ilPreviewMetricsCollectedObjective.php
+++ b/Services/Preview/classes/Setup/class.ilPreviewMetricsCollectedObjective.php
@@ -1,0 +1,29 @@
+<?php
+
+/* Copyright (c) 2020 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+use ILIAS\Setup;
+
+class ilPreviewMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
+{
+    public function getTentativePreconditions(Setup\Environment $environment) : array
+    {
+        return [
+            new ilIniFilesLoadedObjective()
+        ];
+    }
+
+    public function collectFrom(Setup\Environment $environment, Setup\Metrics\Storage $storage) : void
+    {
+        $ini = $environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI);
+        if (!$ini) {
+            return;
+        }
+
+        $storage->storeConfigText(
+            "path_to_ghostscript",
+            $ini->readVariable("tools", "ghostscript"),
+            "The path to the binary of ghostscripts that is used to render previews."
+        );
+    }
+}

--- a/Services/Preview/classes/Setup/class.ilPreviewSetupAgent.php
+++ b/Services/Preview/classes/Setup/class.ilPreviewSetupAgent.php
@@ -45,11 +45,7 @@ class ilPreviewSetupAgent implements Setup\Agent
      */
     public function getInstallObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\ObjectiveCollection(
-            "Complete objectives from Services/Preview",
-            false,
-            new ilPreviewConfigStoredObjective($config)
-        );
+        return new ilPreviewConfigStoredObjective($config);
     }
 
     /**
@@ -57,7 +53,7 @@ class ilPreviewSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilPreviewConfigStoredObjective($config);
     }
 
     /**

--- a/Services/Preview/classes/Setup/class.ilPreviewSetupAgent.php
+++ b/Services/Preview/classes/Setup/class.ilPreviewSetupAgent.php
@@ -31,14 +31,6 @@ class ilPreviewSetupAgent implements Setup\Agent
     /**
      * @inheritdoc
      */
-    public function getConfigInput(Setup\Config $config = null) : UI\Component\Input\Field\Input
-    {
-        throw new \LogicException("Not yet implemented.");
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getArrayToConfigTransformation() : Refinery\Transformation
     {
         return $this->refinery->custom()->transformation(function ($data) {

--- a/Services/Preview/classes/Setup/class.ilPreviewSetupAgent.php
+++ b/Services/Preview/classes/Setup/class.ilPreviewSetupAgent.php
@@ -63,4 +63,12 @@ class ilPreviewSetupAgent implements Setup\Agent
     {
         return new Setup\Objective\NullObjective();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
 }

--- a/Services/Preview/classes/Setup/class.ilPreviewSetupAgent.php
+++ b/Services/Preview/classes/Setup/class.ilPreviewSetupAgent.php
@@ -72,6 +72,6 @@ class ilPreviewSetupAgent implements Setup\Agent
      */
     public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilPreviewMetricsCollectedObjective($storage);
     }
 }

--- a/Services/Preview/classes/Setup/class.ilPreviewSetupAgent.php
+++ b/Services/Preview/classes/Setup/class.ilPreviewSetupAgent.php
@@ -53,7 +53,10 @@ class ilPreviewSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new ilPreviewConfigStoredObjective($config);
+        if ($config !== null) {
+            return new ilPreviewConfigStoredObjective($config);
+        }
+        return new Setup\Objective\NullObjective();
     }
 
     /**

--- a/Services/Style/classes/Setup/class.ilStyleConfigStoredObjective.php
+++ b/Services/Style/classes/Setup/class.ilStyleConfigStoredObjective.php
@@ -35,9 +35,8 @@ class ilStyleConfigStoredObjective implements Setup\Objective
 
     public function getPreconditions(Setup\Environment $environment) : array
     {
-        $common_config = $environment->getConfigFor("common");
         return [
-            new ilIniFilesPopulatedObjective($common_config)
+            new ilIniFilesLoadedObjective()
         ];
     }
 

--- a/Services/Style/classes/Setup/class.ilStyleMetricsCollectedObjective.php
+++ b/Services/Style/classes/Setup/class.ilStyleMetricsCollectedObjective.php
@@ -1,0 +1,34 @@
+<?php
+
+/* Copyright (c) 2020 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+use ILIAS\Setup;
+
+class ilStyleMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
+{
+    public function getTentativePreconditions(Setup\Environment $environment) : array
+    {
+        return [
+            new ilIniFilesLoadedObjective()
+        ];
+    }
+
+    public function collectFrom(Setup\Environment $environment, Setup\Metrics\Storage $storage) : void
+    {
+        $ini = $environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI);
+        if (!$ini) {
+            return;
+        }
+
+        $storage->storeConfigBool(
+            "manage_system_styles",
+            $ini->readVariable("tools", "enable_system_styles_management"),
+            "Can users manage system styles from within the installation?"
+        );
+        $storage->storeConfigText(
+            "path_to_lessc",
+            $ini->readVariable("tools", "lessc"),
+            "The path to the binary that is used for compiling less."
+        );
+    }
+}

--- a/Services/Style/classes/Setup/class.ilStyleSetupAgent.php
+++ b/Services/Style/classes/Setup/class.ilStyleSetupAgent.php
@@ -73,6 +73,6 @@ class ilStyleSetupAgent implements Setup\Agent
      */
     public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilStyleMetricsCollectedObjective($storage);
     }
 }

--- a/Services/Style/classes/Setup/class.ilStyleSetupAgent.php
+++ b/Services/Style/classes/Setup/class.ilStyleSetupAgent.php
@@ -31,14 +31,6 @@ class ilStyleSetupAgent implements Setup\Agent
     /**
      * @inheritdoc
      */
-    public function getConfigInput(Setup\Config $config = null) : UI\Component\Input\Field\Input
-    {
-        throw new \LogicException("Not yet implemented.");
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getArrayToConfigTransformation() : Refinery\Transformation
     {
         return $this->refinery->custom()->transformation(function ($data) {

--- a/Services/Style/classes/Setup/class.ilStyleSetupAgent.php
+++ b/Services/Style/classes/Setup/class.ilStyleSetupAgent.php
@@ -54,7 +54,10 @@ class ilStyleSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new ilStyleConfigStoredObjective($config);
+        if ($config !== null) {
+            return new ilStyleConfigStoredObjective($config);
+        }
+        return new Setup\Objective\NullObjective();
     }
 
     /**

--- a/Services/Style/classes/Setup/class.ilStyleSetupAgent.php
+++ b/Services/Style/classes/Setup/class.ilStyleSetupAgent.php
@@ -64,4 +64,12 @@ class ilStyleSetupAgent implements Setup\Agent
     {
         return new ilKitchenSinkDataCollectedObjective();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
 }

--- a/Services/Style/classes/Setup/class.ilStyleSetupAgent.php
+++ b/Services/Style/classes/Setup/class.ilStyleSetupAgent.php
@@ -46,11 +46,7 @@ class ilStyleSetupAgent implements Setup\Agent
      */
     public function getInstallObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\ObjectiveCollection(
-            "Complete objectives from Services/Style",
-            false,
-            new ilStyleConfigStoredObjective($config)
-        );
+        return new ilStyleConfigStoredObjective($config);
     }
 
     /**
@@ -58,7 +54,7 @@ class ilStyleSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilStyleConfigStoredObjective($config);
     }
 
     /**

--- a/Services/UICore/classes/Setup/class.ilCtrlStructureStoredObjective.php
+++ b/Services/UICore/classes/Setup/class.ilCtrlStructureStoredObjective.php
@@ -52,9 +52,8 @@ class ilCtrlStructureStoredObjective implements Setup\Objective
      */
     public function getPreconditions(Setup\Environment $environment) : array
     {
-        $config = $environment->getConfigFor('database');
         return [
-            new \ilDatabaseUpdatedObjective($config, $this->populate_before)
+            new \ilDatabaseInitializedObjective()
         ];
     }
 

--- a/Services/UICore/classes/Setup/class.ilUICoreSetupAgent.php
+++ b/Services/UICore/classes/Setup/class.ilUICoreSetupAgent.php
@@ -54,4 +54,12 @@ class ilUICoreSetupAgent implements Setup\Agent
     {
         return new Setup\Objective\NullObjective();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
 }

--- a/Services/UICore/classes/Setup/class.ilUICoreSetupAgent.php
+++ b/Services/UICore/classes/Setup/class.ilUICoreSetupAgent.php
@@ -26,14 +26,6 @@ class ilUICoreSetupAgent implements Setup\Agent
     /**
      * @inheritdoc
      */
-    public function getConfigInput(Setup\Config $config = null) : ILIAS\UI\Component\Input\Field\Input
-    {
-        throw new \LogicException(self::class . " has no Config.");
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getArrayToConfigTransformation() : Transformation
     {
         throw new \LogicException(self::class . " has no Config.");

--- a/Services/User/classes/Setup/class.ilUserSetupAgent.php
+++ b/Services/User/classes/Setup/class.ilUserSetupAgent.php
@@ -56,4 +56,12 @@ class ilUserSetupAgent implements Setup\Agent
     {
         return new Setup\Objective\NullObjective();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
 }

--- a/Services/User/classes/Setup/class.ilUserSetupAgent.php
+++ b/Services/User/classes/Setup/class.ilUserSetupAgent.php
@@ -19,14 +19,6 @@ class ilUserSetupAgent implements Setup\Agent
     /**
      * @inheritdoc
      */
-    public function getConfigInput(Setup\Config $config = null) : UI\Component\Input\Field\Input
-    {
-        throw new \LogicException("Agent has no config.");
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getArrayToConfigTransformation() : Refinery\Transformation
     {
         throw new \LogicException("Agent has no config.");

--- a/Services/Utilities/classes/Setup/class.ilUtilitiesConfigStoredObjective.php
+++ b/Services/Utilities/classes/Setup/class.ilUtilitiesConfigStoredObjective.php
@@ -38,9 +38,8 @@ class ilUtilitiesConfigStoredObjective implements Setup\Objective
 
     public function getPreconditions(Setup\Environment $environment) : array
     {
-        $common_config = $environment->getConfigFor("common");
         return [
-            new ilIniFilesPopulatedObjective($common_config)
+            new ilIniFilesLoadedObjective()
         ];
     }
 

--- a/Services/Utilities/classes/Setup/class.ilUtilitiesMetricsCollectedObjective.php
+++ b/Services/Utilities/classes/Setup/class.ilUtilitiesMetricsCollectedObjective.php
@@ -1,0 +1,39 @@
+<?php
+
+/* Copyright (c) 2020 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+use ILIAS\Setup;
+
+class ilUtilitiesMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
+{
+    public function getTentativePreconditions(Setup\Environment $environment) : array
+    {
+        return [
+            new ilIniFilesLoadedObjective()
+        ];
+    }
+
+    public function collectFrom(Setup\Environment $environment, Setup\Metrics\Storage $storage) : void
+    {
+        $ini = $environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI);
+        if (!$ini) {
+            return;
+        }
+
+        $storage->storeConfigText(
+            "path_to_convert",
+            $ini->readVariable("tools", "convert"),
+            "The path to the binary from imagemagick that is used to convert images."
+        );
+        $storage->storeConfigText(
+            "path_to_zip",
+            $ini->readVariable("tools", "zip"),
+            "The path to the binary that is used for zipping files."
+        );
+        $storage->storeConfigText(
+            "path_to_unzip",
+            $ini->readVariable("tools", "unzip"),
+            "The path to the binary that is used for unzipping files."
+        );
+    }
+}

--- a/Services/Utilities/classes/Setup/class.ilUtilitiesSetupAgent.php
+++ b/Services/Utilities/classes/Setup/class.ilUtilitiesSetupAgent.php
@@ -55,7 +55,10 @@ class ilUtilitiesSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return  new ilUtilitiesConfigStoredObjective($config);
+        if ($config !== null) {
+            return  new ilUtilitiesConfigStoredObjective($config);
+        }
+        return new Setup\Objective\NullObjective();
     }
 
     /**

--- a/Services/Utilities/classes/Setup/class.ilUtilitiesSetupAgent.php
+++ b/Services/Utilities/classes/Setup/class.ilUtilitiesSetupAgent.php
@@ -65,4 +65,12 @@ class ilUtilitiesSetupAgent implements Setup\Agent
     {
         return new Setup\Objective\NullObjective();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
 }

--- a/Services/Utilities/classes/Setup/class.ilUtilitiesSetupAgent.php
+++ b/Services/Utilities/classes/Setup/class.ilUtilitiesSetupAgent.php
@@ -47,11 +47,7 @@ class ilUtilitiesSetupAgent implements Setup\Agent
      */
     public function getInstallObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\ObjectiveCollection(
-            "Complete objectives from Services/Utilities",
-            false,
-            new ilUtilitiesConfigStoredObjective($config)
-        );
+        return  new ilUtilitiesConfigStoredObjective($config);
     }
 
     /**
@@ -59,7 +55,7 @@ class ilUtilitiesSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return  new ilUtilitiesConfigStoredObjective($config);
     }
 
     /**

--- a/Services/Utilities/classes/Setup/class.ilUtilitiesSetupAgent.php
+++ b/Services/Utilities/classes/Setup/class.ilUtilitiesSetupAgent.php
@@ -31,14 +31,6 @@ class ilUtilitiesSetupAgent implements Setup\Agent
     /**
      * @inheritdoc
      */
-    public function getConfigInput(Setup\Config $config = null) : UI\Component\Input\Field\Input
-    {
-        throw new \LogicException("Not yet implemented.");
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getArrayToConfigTransformation() : Refinery\Transformation
     {
         return $this->refinery->custom()->transformation(function ($data) {

--- a/Services/Utilities/classes/Setup/class.ilUtilitiesSetupAgent.php
+++ b/Services/Utilities/classes/Setup/class.ilUtilitiesSetupAgent.php
@@ -74,6 +74,6 @@ class ilUtilitiesSetupAgent implements Setup\Agent
      */
     public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilUtilitiesMetricsCollectedObjective($storage);
     }
 }

--- a/Services/VirusScanner/classes/Setup/class.ilVirusScannerConfigStoredObjective.php
+++ b/Services/VirusScanner/classes/Setup/class.ilVirusScannerConfigStoredObjective.php
@@ -34,9 +34,8 @@ class ilVirusScannerConfigStoredObjective implements Setup\Objective
 
     public function getPreconditions(Setup\Environment $environment) : array
     {
-        $common_config = $environment->getConfigFor("common");
         return [
-            new ilIniFilesPopulatedObjective($common_config)
+            new ilIniFilesLoadedObjective()
         ];
     }
 

--- a/Services/VirusScanner/classes/Setup/class.ilVirusScannerMetricsCollectedObjective.php
+++ b/Services/VirusScanner/classes/Setup/class.ilVirusScannerMetricsCollectedObjective.php
@@ -1,0 +1,39 @@
+<?php
+
+/* Copyright (c) 2020 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+use ILIAS\Setup;
+
+class ilVirusScannerMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
+{
+    public function getTentativePreconditions(Setup\Environment $environment) : array
+    {
+        return [
+            new ilIniFilesLoadedObjective()
+        ];
+    }
+
+    public function collectFrom(Setup\Environment $environment, Setup\Metrics\Storage $storage) : void
+    {
+        $ini = $environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI);
+        if (!$ini) {
+            return;
+        }
+
+        $storage->storeConfigText(
+            "virusscanner",
+            $ini->readVariable("tools", "vscantype"),
+            "The engine that is used for virus scanning."
+        );
+        $storage->storeConfigText(
+            "path_to_scan",
+            $ini->readVariable("tools", "scancommand"),
+            "The path to the binary that is used for virus scanning."
+        );
+        $storage->storeConfigText(
+            "path_to_clean",
+            $ini->readVariable("tools", "cleancommand"),
+            "The path to the binary that is used for cleaning up after virus scanning."
+        );
+    }
+}

--- a/Services/VirusScanner/classes/Setup/class.ilVirusScannerSetupAgent.php
+++ b/Services/VirusScanner/classes/Setup/class.ilVirusScannerSetupAgent.php
@@ -65,4 +65,12 @@ class ilVirusScannerSetupAgent implements Setup\Agent
     {
         return new Setup\Objective\NullObjective();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
 }

--- a/Services/VirusScanner/classes/Setup/class.ilVirusScannerSetupAgent.php
+++ b/Services/VirusScanner/classes/Setup/class.ilVirusScannerSetupAgent.php
@@ -47,11 +47,7 @@ class ilVirusScannerSetupAgent implements Setup\Agent
      */
     public function getInstallObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\ObjectiveCollection(
-            "Complete objectives from Services/VirusScanner",
-            false,
-            new ilVirusScannerConfigStoredObjective($config)
-        );
+        return new ilVirusScannerConfigStoredObjective($config);
     }
 
     /**
@@ -59,7 +55,7 @@ class ilVirusScannerSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilVirusScannerConfigStoredObjective($config);
     }
 
     /**

--- a/Services/VirusScanner/classes/Setup/class.ilVirusScannerSetupAgent.php
+++ b/Services/VirusScanner/classes/Setup/class.ilVirusScannerSetupAgent.php
@@ -55,7 +55,10 @@ class ilVirusScannerSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new ilVirusScannerConfigStoredObjective($config);
+        if ($config !== null) {
+            return new ilVirusScannerConfigStoredObjective($config);
+        }
+        return new Setup\Objective\NullObjective();
     }
 
     /**

--- a/Services/VirusScanner/classes/Setup/class.ilVirusScannerSetupAgent.php
+++ b/Services/VirusScanner/classes/Setup/class.ilVirusScannerSetupAgent.php
@@ -31,14 +31,6 @@ class ilVirusScannerSetupAgent implements Setup\Agent
     /**
      * @inheritdoc
      */
-    public function getConfigInput(Setup\Config $config = null) : UI\Component\Input\Field\Input
-    {
-        throw new \LogicException("Not yet implemented.");
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getArrayToConfigTransformation() : Refinery\Transformation
     {
         return $this->refinery->custom()->transformation(function ($data) {

--- a/Services/VirusScanner/classes/Setup/class.ilVirusScannerSetupAgent.php
+++ b/Services/VirusScanner/classes/Setup/class.ilVirusScannerSetupAgent.php
@@ -74,6 +74,6 @@ class ilVirusScannerSetupAgent implements Setup\Agent
      */
     public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilVirusScannerMetricsCollectedObjective($storage);
     }
 }

--- a/setup/README.md
+++ b/setup/README.md
@@ -5,6 +5,7 @@ commands to manage ILIAS installations:
 
 * `install` will [set an installation up](#install-ilias)
 * `update` will [update an installation](#update-ilias)
+* `status` will [report status of an installation](#report-status-of-ilias)
 * `build-artifacts` [recreates static assets](#build-ilias-artifacts) of an installation
 * `reload-control-structure` [rebuilds structure information](#build-ilias-artifacts) of an installation
 
@@ -48,13 +49,28 @@ configs without secrets.
 
 To update ILIAS from the command line, call `php setup/setup.php update config.json`
 from within your ILIAS folder. This will update the configuration of ILIAS according
-to the provided configuration as well as update the database of the installation.
+to the provided configuration as well as update the database of the installation or
+do other necessary task for the update. This does not update the source code.
 
 Sometimes it might happen that the database update steps detect some edge case
 or warn about a possible loss of data. In this case the update is aborted with
 a message and can be resumed after the messages was read carefully and acted
 upon. You may use the `--ignore-db-update-messages` at your own risk if you want
 to silence the messages.
+
+
+## Report Status of ILIAS
+
+Via `php setup/setup.php status` you can get a status of your ILIAS instalaltion.
+The command uses a best effort approach, so according to the status of your
+system the output might contain more or less fields. When calling this for an
+system where ILIAS was not installed, for example, the output only contains the
+information that ilias is not installed. The command also reports on the configuration
+of the installation.
+
+The output of the command is formatted as YAML to be easily readable by people and
+machines. So we encourage you to use this command for monitoring your system and
+also request status information via our feature process that you are interested in.
 
 
 ## Build ILIAS Artifacts

--- a/setup/README.md
+++ b/setup/README.md
@@ -47,9 +47,8 @@ configs without secrets.
 ## Update ILIAS
 
 To update ILIAS from the command line, call `php setup/setup.php update config.json`
-from within your ILIAS folder. Make sure you use the same config to update your
-installation as you have used for the [installation](#install-ilias). The remarks
-for the [installation](#install-ilias) in this README also apply for the update.
+from within your ILIAS folder. This will update the configuration of ILIAS according
+to the provided configuration as well as update the database of the installation.
 
 Sometimes it might happen that the database update steps detect some edge case
 or warn about a possible loss of data. In this case the update is aborted with

--- a/setup/classes/class.ilIniFilesLoadedObjective.php
+++ b/setup/classes/class.ilIniFilesLoadedObjective.php
@@ -24,7 +24,8 @@ class ilIniFilesLoadedObjective implements Setup\Objective
     public function getPreconditions(Setup\Environment $environment) : array
     {
         return [
-            new ClientIdReadObjective()
+            new Setup\Objective\ClientIdReadObjective(),
+            new ilIniFilesPopulatedObjective()
         ];
     }
 
@@ -41,13 +42,15 @@ class ilIniFilesLoadedObjective implements Setup\Objective
         if ($environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI) == null) {
             $path = dirname(__DIR__, 2) . "/ilias.ini.php";
             $ini = new ilIniFile($path);
+            $ini->read();
             $environment = $environment
                 ->withResource(Setup\Environment::RESOURCE_ILIAS_INI, $ini);
         }
 
         if ($environment->getResource(Setup\Environment::RESOURCE_CLIENT_INI) == null) {
-            $path = $this->getClientDir() . "/client.ini.php";
+            $path = $this->getClientDir($client_id) . "/client.ini.php";
             $client_ini = new ilIniFile($path);
+            $client_ini->read();
             $environment = $environment
                 ->withResource(Setup\Environment::RESOURCE_CLIENT_INI, $client_ini);
         }

--- a/setup/classes/class.ilIniFilesPopulatedObjective.php
+++ b/setup/classes/class.ilIniFilesPopulatedObjective.php
@@ -4,7 +4,7 @@
 
 use ILIAS\Setup;
 
-class ilIniFilesPopulatedObjective extends ilSetupObjective
+class ilIniFilesPopulatedObjective implements Setup\Objective
 {
     public function getHash() : string
     {
@@ -23,33 +23,48 @@ class ilIniFilesPopulatedObjective extends ilSetupObjective
 
     public function getPreconditions(Setup\Environment $environment) : array
     {
+        $client_id = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_ID);
+        if ($client_id === null) {
+            throw new \LogicException(
+                "Expected a client_id in the environment."
+            );
+        }
+        $client_dir = $this->getClientDir($client_id);
+
         // TODO: This shows an unfortunate connection between the webdir and the
-        // client.ini.php. Why does the client in reside in the webdir? If we
+        // client.ini.php. Why does the client.ini reside in the webdir? If we
         // remove the client-feature, the client-ini will go away...
         return [
-            new \ilOverwritesExistingInstallationConfirmed($this->config),
             new Setup\Objective\DirectoryCreatedObjective(dirname(__DIR__, 2) . "/data"),
-            new Setup\Objective\DirectoryCreatedObjective($this->getClientDir()),
-            new Setup\Condition\CanCreateFilesInDirectoryCondition($this->getClientDir()),
-            new Setup\Condition\CanCreateFilesInDirectoryCondition(dirname(__DIR__, 2)),
+            new Setup\Objective\DirectoryCreatedObjective($client_dir),
+            new Setup\Condition\CanCreateFilesInDirectoryCondition($client_dir),
+            new Setup\Condition\CanCreateFilesInDirectoryCondition(dirname(__DIR__, 2))
         ];
     }
 
     public function achieve(Setup\Environment $environment) : Setup\Environment
     {
-        $path = dirname(__DIR__, 2) . "/ilias.ini.php";
-        $ini = new ilIniFile($path);
-        $ini->GROUPS = parse_ini_file(__DIR__ . "/../ilias.master.ini.php", true);
-        $ini->write();
+        $client_id = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_ID);
 
-        $path = $this->getClientDir() . "/client.ini.php";
-        $client_ini = new ilIniFile($path);
-        $client_ini->GROUPS = parse_ini_file(__DIR__ . "/../client.master.ini.php", true);
-        $client_ini->write();
+        $path = $this->getILIASIniPath();
+        if (!file_exists($path)) {
+            $ini = new ilIniFile($path);
+            $ini->GROUPS = parse_ini_file(__DIR__ . "/../ilias.master.ini.php", true);
+            $ini->write();
+            $environment = $environment
+                ->withResource(Setup\Environment::RESOURCE_ILIAS_INI, $ini);
+        }
 
-        return $environment
-            ->withResource(Setup\Environment::RESOURCE_ILIAS_INI, $ini)
-            ->withResource(Setup\Environment::RESOURCE_CLIENT_INI, $client_ini);
+        $path = $this->getClientIniPath($client_id);
+        if (!file_exists($path)) {
+            $client_ini = new ilIniFile($path);
+            $client_ini->GROUPS = parse_ini_file(__DIR__ . "/../client.master.ini.php", true);
+            $client_ini->write();
+            $environment = $environment
+                ->withResource(Setup\Environment::RESOURCE_CLIENT_INI, $client_ini);
+        }
+
+        return $environment;
     }
 
     /**
@@ -57,15 +72,24 @@ class ilIniFilesPopulatedObjective extends ilSetupObjective
      */
     public function isApplicable(Setup\Environment $environment) : bool
     {
-        // if ini file exists we assume that there is some relevant content
-        $ini = $environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI);
-        $client_ini = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_INI);
+        $client_id = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_ID);
 
-        return is_null($ini) || is_null($client_ini);
+        return !file_exists($this->getILIASIniPath())
+            || !file_exists($this->getClientIniPath($client_id));
     }
 
-    protected function getClientDir() : string
+    protected function getClientDir(string $client_id) : string
     {
-        return dirname(__DIR__, 2) . "/data/" . $this->config->getClientId();
+        return dirname(__DIR__, 2) . "/data/" . $client_id;
+    }
+
+    protected function getClientIniPath(string $client_id) : string
+    {
+        return $this->getClientDir($client_id) . "/client.ini.php";
+    }
+
+    protected function getILIASIniPath() : string
+    {
+        return dirname(__DIR__, 2) . "/ilias.ini.php";
     }
 }

--- a/setup/classes/class.ilSetupAgent.php
+++ b/setup/classes/class.ilSetupAgent.php
@@ -45,14 +45,6 @@ class ilSetupAgent implements Setup\Agent
     /**
      * @inheritdoc
      */
-    public function getConfigInput(Setup\Config $config = null) : UI\Component\Input\Field\Input
-    {
-        throw new \LogicException("Not yet implemented.");
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getArrayToConfigTransformation() : Refinery\Transformation
     {
         return $this->refinery->custom()->transformation(function ($data) {

--- a/setup/classes/class.ilSetupAgent.php
+++ b/setup/classes/class.ilSetupAgent.php
@@ -73,7 +73,7 @@ class ilSetupAgent implements Setup\Agent
                 new Setup\Condition\PHPExtensionLoadedCondition("xsl"),
                 new Setup\Condition\PHPExtensionLoadedCondition("gd"),
                 $this->getPHPMemoryLimitCondition(),
-                new ilSetupConfigStoredObjective($config),
+                new ilSetupConfigStoredObjective($config, true),
                 $config->getRegisterNIC()
                         ? new ilNICKeyRegisteredObjective($config)
                         : new ilNICKeyStoredObjective($config)
@@ -103,7 +103,7 @@ class ilSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilSetupConfigStoredObjective($config);
     }
 
     /**

--- a/setup/classes/class.ilSetupAgent.php
+++ b/setup/classes/class.ilSetupAgent.php
@@ -119,6 +119,6 @@ class ilSetupAgent implements Setup\Agent
      */
     public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilSetupMetricsCollectedObjective($storage);
     }
 }

--- a/setup/classes/class.ilSetupAgent.php
+++ b/setup/classes/class.ilSetupAgent.php
@@ -103,7 +103,10 @@ class ilSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new ilSetupConfigStoredObjective($config);
+        if ($config !== null) {
+            return new ilSetupConfigStoredObjective($config);
+        }
+        return new Setup\Objective\NullObjective();
     }
 
     /**

--- a/setup/classes/class.ilSetupAgent.php
+++ b/setup/classes/class.ilSetupAgent.php
@@ -113,4 +113,12 @@ class ilSetupAgent implements Setup\Agent
     {
         return new Setup\Objective\NullObjective();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
 }

--- a/setup/classes/class.ilSetupConfigStoredObjective.php
+++ b/setup/classes/class.ilSetupConfigStoredObjective.php
@@ -31,7 +31,7 @@ class ilSetupConfigStoredObjective extends ilSetupObjective
     public function getPreconditions(Setup\Environment $environment) : array
     {
         return [
-            new ilIniFilesPopulatedObjective($this->config)
+            new ilIniFilesLoadedObjective()
         ];
     }
 

--- a/setup/classes/class.ilSetupMetricsCollectedObjective.php
+++ b/setup/classes/class.ilSetupMetricsCollectedObjective.php
@@ -1,0 +1,60 @@
+<?php
+
+/* Copyright (c) 2019 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+use ILIAS\Setup;
+
+class ilSetupMetricsCollectedObjective implements Setup\Objective
+{
+    /**
+     * @var Setup\Metrics\Storage
+     */
+    protected $storage;
+
+    public function __construct(Setup\Metrics\Storage $storage)
+    {
+        $this->storage = $storage;
+    }
+
+    public function getHash() : string
+    {
+        return hash("sha256", self::class);
+    }
+
+    public function getLabel() : string
+    {
+        return "Collect common metrics for the ILIAS installation.";
+    }
+
+    public function isNotable() : bool
+    {
+        return true;
+    }
+
+    public function getPreconditions(Setup\Environment $environment) : array
+    {
+        return [
+            new ilIniFilesLoadedObjective()
+        ];
+    }
+
+    public function achieve(Setup\Environment $environment) : Setup\Environment
+    {
+        $ini = $environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI);
+        $client_ini = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_INI);
+        $this->storage->storeStableBool(
+            "is_installed",
+            $ini !== null && $client_ini !== null
+        );
+
+        return $environment;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isApplicable(Setup\Environment $environment) : bool
+    {
+        return true;
+    }
+}

--- a/setup/classes/class.ilSetupMetricsCollectedObjective.php
+++ b/setup/classes/class.ilSetupMetricsCollectedObjective.php
@@ -4,57 +4,27 @@
 
 use ILIAS\Setup;
 
-class ilSetupMetricsCollectedObjective implements Setup\Objective
+class ilSetupMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
 {
-    /**
-     * @var Setup\Metrics\Storage
-     */
-    protected $storage;
-
-    public function __construct(Setup\Metrics\Storage $storage)
-    {
-        $this->storage = $storage;
-    }
-
-    public function getHash() : string
-    {
-        return hash("sha256", self::class);
-    }
-
     public function getLabel() : string
     {
         return "Collect common metrics for the ILIAS installation.";
     }
 
-    public function isNotable() : bool
-    {
-        return true;
-    }
-
-    public function getPreconditions(Setup\Environment $environment) : array
+    public function getTentativePreconditions(Setup\Environment $environment) : array
     {
         return [
             new ilIniFilesLoadedObjective()
         ];
     }
 
-    public function achieve(Setup\Environment $environment) : Setup\Environment
+    public function collectFrom(Setup\Environment $environment, Setup\Metrics\Storage $storage) : void
     {
         $ini = $environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI);
         $client_ini = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_INI);
-        $this->storage->storeStableBool(
+        $storage->storeStableBool(
             "is_installed",
             $ini !== null && $client_ini !== null
         );
-
-        return $environment;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function isApplicable(Setup\Environment $environment) : bool
-    {
-        return true;
     }
 }

--- a/setup/classes/class.ilSetupMetricsCollectedObjective.php
+++ b/setup/classes/class.ilSetupMetricsCollectedObjective.php
@@ -24,7 +24,16 @@ class ilSetupMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
         $client_ini = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_INI);
         $storage->storeStableBool(
             "is_installed",
-            $ini !== null && $client_ini !== null
+            $ini !== null && $client_ini !== null,
+            "Are there any indications an installation was performed?"
         );
+        $client_id = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_ID);
+        if ($client_id) {
+            $storage->storeConfigText(
+                "client_id",
+                $client_id,
+                "Id of the ILIAS client."
+            );
+        }
     }
 }

--- a/setup/cli.php
+++ b/setup/cli.php
@@ -26,6 +26,7 @@ require_once(__DIR__ . "/classes/class.ilIniFilesLoadedObjective.php");
 require_once(__DIR__ . "/classes/class.ilNICKeyRegisteredObjective.php");
 require_once(__DIR__ . "/classes/class.ilNICKeyStoredObjective.php");
 require_once(__DIR__ . "/classes/class.ilSetupConfigStoredObjective.php");
+require_once(__DIR__ . "/classes/class.ilSetupMetricsCollectedObjective.php");
 
 use ILIAS\UI\Component\Input\Field\Factory as FieldFactory;
 use ILIAS\UI\Component\Input\Field\File;
@@ -66,7 +67,8 @@ function build_container_for_setup(string $executed_in_directory)
             $c["command.install"],
             $c["command.update"],
             $c["command.build-artifacts"],
-            $c["command.reload-control-structure"]
+            $c["command.reload-control-structure"],
+            $c["command.status"]
         );
     };
     $c["command.install"] = function ($c) {
@@ -91,6 +93,11 @@ function build_container_for_setup(string $executed_in_directory)
     $c["command.reload-control-structure"] = function ($c) {
         return new \ILIAS\Setup\CLI\ReloadControlStructureCommand(
             $c["common_preconditions"]
+        );
+    };
+    $c["command.status"] = function ($c) {
+        return new \ILIAS\Setup\CLI\StatusCommand(
+            $c["agent"]
         );
     };
 

--- a/setup/cli.php
+++ b/setup/cli.php
@@ -104,7 +104,6 @@ function build_container_for_setup(string $executed_in_directory)
     $c["agent"] = function ($c) {
         return function () use ($c) {
             return new ILIAS\Setup\AgentCollection(
-                $c["ui.field_factory"],
                 $c["refinery"],
                 $c["agents"]
             );
@@ -143,83 +142,6 @@ function build_container_for_setup(string $executed_in_directory)
             );
         };
         return $agents;
-    };
-
-    $c["ui.field_factory"] = function ($c) {
-        return new class implements FieldFactory {
-            public function text($label, $byline = null)
-            {
-                throw new \LogicException("The CLI-setup does not support the UI-Framework.");
-            }
-            public function numeric($label, $byline = null)
-            {
-                throw new \LogicException("The CLI-setup does not support the UI-Framework.");
-            }
-            public function group(array $inputs, string $label = '')
-            {
-                throw new \LogicException("The CLI-setup does not support the UI-Framework.");
-            }
-            public function section(array $inputs, $label, $byline = null)
-            {
-                throw new \LogicException("The CLI-setup does not support the UI-Framework.");
-            }
-            public function dependantGroup(array $inputs)
-            {
-                throw new \LogicException("The CLI-setup does not support the UI-Framework.");
-            }
-            public function optionalGroup(array $inputs, string $label, string $byline = null) : \ILIAS\UI\Component\Input\Field\OptionalGroup
-            {
-                throw new \LogicException("The CLI-setup does not support the UI-Framework.");
-            }
-            public function switchableGroup(array $inputs, string $label, string $byline = null) : \ILIAS\UI\Component\Input\Field\SwitchableGroup
-            {
-                throw new \LogicException("The CLI-setup does not support the UI-Framework.");
-            }
-            public function checkbox($label, $byline = null)
-            {
-                throw new \LogicException("The CLI-setup does not support the UI-Framework.");
-            }
-            public function tag(string $label, array $tags, $byline = null) : Tag
-            {
-                throw new \LogicException("The CLI-setup does not support the UI-Framework.");
-            }
-            public function password($label, $byline = null)
-            {
-                throw new \LogicException("The CLI-setup does not support the UI-Framework.");
-            }
-            public function select($label, array $options, $byline = null)
-            {
-                throw new \LogicException("The CLI-setup does not support the UI-Framework.");
-            }
-            public function textarea($label, $byline = null)
-            {
-                throw new \LogicException("The CLI-setup does not support the UI-Framework.");
-            }
-            public function radio($label, $byline = null)
-            {
-                throw new \LogicException("The CLI-setup does not support the UI-Framework.");
-            }
-            public function multiSelect($label, array $options, $byline = null)
-            {
-                throw new \LogicException("The CLI-setup does not support the UI-Framework.");
-            }
-            public function dateTime($label, $byline = null)
-            {
-                throw new \LogicException("The CLI-setup does not support the UI-Framework.");
-            }
-            public function duration($label, $byline = null)
-            {
-                throw new \LogicException("The CLI-setup does not support the UI-Framework.");
-            }
-            public function file(UploadHandler $handler, string $label, string $byline = null) : File
-            {
-                throw new \LogicException("The CLI-setup does not support the UI-Framework.");
-            }
-            public function viewControl() : ViewControlFactory
-            {
-                throw new \LogicException("The CLI-setup does not support the UI-Framework.");
-            }
-        };
     };
 
     $c["refinery"] = function ($c) {

--- a/src/Setup/Agent.php
+++ b/src/Setup/Agent.php
@@ -41,9 +41,13 @@ interface Agent
      * The provided configuration is to be used to change according configuration
      * values in the installation. If this is not possible for some reason, an
      * according UnachievableException needs to be thrown in the according objective.
+     *
      * The configuration is not to be used to initialize the required environment
      * for the objectives. This must be done via ClientIdReadObjective and depending
      * objectives like ilIniFilesLoadedObjective.
+     *
+     * If no configuration is provided the configuration of the component should
+     * stay as is.
      *
      * @throw InvalidArgumentException if Config does not match the Agent..
      */

--- a/src/Setup/Agent.php
+++ b/src/Setup/Agent.php
@@ -28,12 +28,22 @@ interface Agent
     /**
      * Get the goals the agent wants to achieve on setup.
      *
+     * The provided configuration is to be used to set according configuration
+     * values in the installation.
+     *
      * @throw InvalidArgumentException if Config does not match the Agent..
      */
     public function getInstallObjective(Config $config = null) : Objective;
 
     /**
      * Get the goal the agent wants to achieve on update.
+     *
+     * The provided configuration is to be used to change according configuration
+     * values in the installation. If this is not possible for some reason, an
+     * according UnachievableException needs to be thrown in the according objective.
+     * The configuration is not to be used to initialize the required environment
+     * for the objectives. This must be done via ClientIdReadObjective and depending
+     * objectives like ilIniFilesLoadedObjective.
      *
      * @throw InvalidArgumentException if Config does not match the Agent..
      */

--- a/src/Setup/Agent.php
+++ b/src/Setup/Agent.php
@@ -18,15 +18,6 @@ interface Agent
     public function hasConfig() : bool;
 
     /**
-     * Agents must provide an input to set the configuration if they have a
-     * configuration.
-     *
-     * @throw InvalidArgumentException if Config does not match the Agent..
-     * @throw LogicException if Agent has no Config
-     */
-    public function getConfigInput(Config $config = null) : UI\Component\Input\Field\Input;
-
-    /**
      * Agents must be able to tell how to create a configuration from a
      * nested array.
      *

--- a/src/Setup/Agent.php
+++ b/src/Setup/Agent.php
@@ -61,8 +61,12 @@ interface Agent
     public function getBuildArtifactObjective() : Objective;
 
     /**
-     * Get the objective to collect metrics about the component the agent belongs
-     * to.
+     * Get the objective to be achieved when status is requested.
+     *
+     * Make sure that this runs in a reasonable time and also uses a reasonable
+     * amount of ressources, since the command fed by this objective is meant to
+     * be called by monitoring systems in short intervalls. So no expansive queries,
+     * complicated calculations or long lasting network requests.
      *
      * This is supposed to inform about any kind of metrics regarding the component.
      */

--- a/src/Setup/Agent.php
+++ b/src/Setup/Agent.php
@@ -55,4 +55,12 @@ interface Agent
      * @throw InvalidArgumentException if Config does not match the Agent.
      */
     public function getBuildArtifactObjective() : Objective;
+
+    /**
+     * Get the objective to collect metrics about the component the agent belongs
+     * to.
+     *
+     * This is supposed to inform about any kind of metrics regarding the component.
+     */
+    public function getStatusObjective(Metrics\Storage $storage) : Objective;
 }

--- a/src/Setup/AgentCollection.php
+++ b/src/Setup/AgentCollection.php
@@ -103,6 +103,19 @@ class AgentCollection implements Agent
         return new ObjectiveCollection("Collected Build Artifact Objectives", false, ...$gs);
     }
 
+    /**
+     * @inheritdocs
+     */
+    public function getStatusObjective(Metrics\Storage $storage) : Objective
+    {
+        $os = [];
+        foreach ($this->agents as $k => $a) {
+            $s = new Metrics\StorageOnPathWrapper($k, $storage);
+            $os[] = $a->getStatusObjective($s);
+        }
+        return new ObjectiveCollection("Collected Status Objectives", false, ...$os);
+    }
+
     protected function getXObjective(string $which, Config $config = null) : Objective
     {
         $this->checkConfig($config);

--- a/src/Setup/AgentCollection.php
+++ b/src/Setup/AgentCollection.php
@@ -15,11 +15,6 @@ use ILIAS\Refinery\Transformation;
 class AgentCollection implements Agent
 {
     /**
-     * @var FieldFactory
-     */
-    protected $field_factory;
-
-    /**
      * @var Refinery
      */
     protected $refinery;
@@ -30,11 +25,9 @@ class AgentCollection implements Agent
     protected $agents;
 
     public function __construct(
-        FieldFactory $field_factory,
         Refinery $refinery,
         array $agents
     ) {
-        $this->field_factory = $field_factory;
         $this->refinery = $refinery;
         $this->agents = $agents;
     }
@@ -55,35 +48,6 @@ class AgentCollection implements Agent
             }
         }
         return false;
-    }
-
-    /**
-     * @inheritdocs
-     */
-    public function getConfigInput(Config $config = null) : Input
-    {
-        if ($config !== null) {
-            $this->checkConfig($config);
-        }
-
-        $inputs = [];
-        foreach ($this->getAgentsWithConfig() as $k => $c) {
-            if ($config) {
-                $inputs[$k] = $c->getConfigInput($config->getConfig($k));
-            } else {
-                $inputs[$k] = $c->getConfigInput();
-            }
-        }
-
-        return $this->field_factory->group($inputs)
-            ->withAdditionalTransformation(
-                $this->refinery->in()->series([
-                    $this->refinery->custom()->transformation(function ($v) {
-                        return [$v];
-                    }),
-                    $this->refinery->to()->toNew(ConfigCollection::class)
-                ])
-            );
     }
 
     /**

--- a/src/Setup/CLI/StatusCommand.php
+++ b/src/Setup/CLI/StatusCommand.php
@@ -1,0 +1,64 @@
+<?php
+/* Copyright (c) 2016 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Setup\CLI;
+
+use ILIAS\Setup\Agent;
+use ILIAS\Setup\ArrayEnvironment;
+use ILIAS\Setup\Config;
+use ILIAS\Setup\Environment;
+use ILIAS\Setup\Objective;
+use ILIAS\Setup\ObjectiveCollection;
+use ILIAS\Setup\Objective\Tentatively;
+use ILIAS\Setup\Metrics;
+use ILIAS\Setup\NoConfirmationException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+/**
+ * Command to output status information about the installation.
+ */
+class StatusCommand extends Command
+{
+    use HasAgent;
+    use ObjectiveHelper;
+
+    protected static $defaultName = "status";
+
+    /**
+     * @var callable $lazy_agent must return a Setup\Agent
+     */
+    public function __construct(callable $lazy_agent)
+    {
+        parent::__construct();
+        $this->lazy_agent = $lazy_agent;
+    }
+
+    public function configure()
+    {
+        $this->setDescription("Collect and show status information about the installation.");
+    }
+
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        // ATTENTION: Don't do this (in general), please have a look at the comment
+        // in ilIniFilesLoadedObjective.
+        \ilIniFilesLoadedObjective::$might_populate_ini_files_as_well = false;
+
+        $environment = new ArrayEnvironment([]);
+        $storage = new Metrics\ArrayStorage();
+        $objective = new Tentatively(
+            $this->getAgent()->getStatusObjective($storage)
+        );
+
+        $this->achieveObjective($objective, $environment);
+
+        $metric = $storage->asMetric();
+
+        $output->write($metric->toYAML() . "\n");
+    }
+}

--- a/src/Setup/CLI/StatusCommand.php
+++ b/src/Setup/CLI/StatusCommand.php
@@ -58,6 +58,18 @@ class StatusCommand extends Command
         $this->achieveObjective($objective, $environment);
 
         $metric = $storage->asMetric();
+        list($config, $other) = $metric->extractByStability(Metrics\Metric::STABILITY_CONFIG);
+        if ($other) {
+            $values = $other->getValue();
+        } else {
+            $values = [];
+        }
+        $values["config"] = $config;
+        $metric = new Metrics\Metric(
+            Metrics\Metric::STABILITY_MIXED,
+            Metrics\Metric::TYPE_COLLECTION,
+            $values
+        );
 
         $output->write($metric->toYAML() . "\n");
     }

--- a/src/Setup/CLI/UpdateCommand.php
+++ b/src/Setup/CLI/UpdateCommand.php
@@ -68,7 +68,11 @@ class UpdateCommand extends Command
 
         $agent = $this->getAgent();
 
-        $config = $this->readAgentConfig($agent, $input);
+        if ($input->getArgument("config")) {
+            $config = $this->readAgentConfig($agent, $input);
+        } else {
+            $config = null;
+        }
 
         $objective = $agent->getUpdateObjective($config);
         if (count($this->preconditions) > 0) {
@@ -81,7 +85,9 @@ class UpdateCommand extends Command
         $environment = new ArrayEnvironment([
             Environment::RESOURCE_ADMIN_INTERACTION => $io
         ]);
-        $environment = $this->addAgentConfigsToEnvironment($agent, $config, $environment);
+        if ($config) {
+            $environment = $this->addAgentConfigsToEnvironment($agent, $config, $environment);
+        }
 
         try {
             $this->achieveObjective($objective, $environment, $io);

--- a/src/Setup/Metrics/CollectedObjective.php
+++ b/src/Setup/Metrics/CollectedObjective.php
@@ -1,0 +1,85 @@
+<?php
+
+/* Copyright (c) 2020 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Setup\Metrics;
+
+use ILIAS\Setup;
+
+/**
+ * Base class to simplify collection of metrics.
+ */
+abstract class CollectedObjective implements Setup\Objective
+{
+    /**
+     * @var Storage
+     */
+    protected $storage;
+
+    public function __construct(Storage $storage)
+    {
+        $this->storage = $storage;
+    }
+
+    /**
+     * Attempt to gather metrics based on the provided environment.
+     *
+     * Make sure to be very cautious regarding expectations towards the environment.
+     * It might only be initialized partially or not be initialized at all, since
+     * preconditions might not have been met. This should be implemented with a
+     * best effort approach to gather as much metrics as possible even when the
+     * installation is damaged.
+     */
+    abstract protected function collectFrom(Setup\Environment $environment, Storage $storage) : void;
+
+    /**
+     * Give preconditions that might or might not be fullfilled.
+     *
+     * Since collection of metrics should also work in (partially) broken installations
+     * the preconditions given here will only be tentatively fullfilled when collectFrom
+     * is called.
+     *
+     * @return Setup\Objective[]
+     */
+    abstract protected function getTentativePreconditions(Setup\Environment $environment) : array;
+
+    public function getHash() : string
+    {
+        return hash("sha256", static::class);
+    }
+
+    public function getLabel() : string
+    {
+        return "Collect metrics.";
+    }
+
+    public function isNotable() : bool
+    {
+        return false;
+    }
+
+    public function getPreconditions(Setup\Environment $environment) : array
+    {
+        return array_map(
+            function (Setup\Objective $o) {
+                return new Setup\Objective\Tentatively($o);
+            },
+            $this->getTentativePreconditions($environment)
+        );
+    }
+
+    public function achieve(Setup\Environment $environment) : Setup\Environment
+    {
+        $this->collectFrom($environment, $this->storage);
+        return $environment;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isApplicable(Setup\Environment $environment) : bool
+    {
+        // We want to always collect fresh metrics.
+        return true;
+    }
+}

--- a/src/Setup/Metrics/Metric.php
+++ b/src/Setup/Metrics/Metric.php
@@ -154,7 +154,7 @@ final class Metric
         return $this->value;
     }
 
-    public function getDescription() : string
+    public function getDescription() : ?string
     {
         return $this->description;
     }

--- a/src/Setup/Metrics/README.md
+++ b/src/Setup/Metrics/README.md
@@ -1,0 +1,61 @@
+# Little Framework for Metrics
+
+To implement the `status` command of the setup, this little framework for metrics
+was introduced. This might evolve to some stand alone library within the ILIAS core
+sometime and become the base for more elaborate monitoring requirements or
+telemetrics.
+
+## Metrics
+
+The metrics are designed to be a common format for output of values to other
+systems such as time series databases. Also, the surrounding facilities are meant
+to be expanded some time in the future. This is designed as a data sink and not meant
+to be used in internal processing in ILIAS or as a source for data. Hence no
+connection to the `Refinery` (so far).
+
+The central class in the framework is the [`Metric`](./Metric.php), which is
+understood to be some quantity that can be measured about the system. It has
+one of five predefined (and not expandable) types or is a key/value collection
+of some other metrics. The decision to design this as a closed type is explained
+below.
+
+A metric can have three different stabilities (config, stable, volatile) which are
+meant to make transparent how and when we expect changes in that metric to happen.
+This could be used in the future to, e.g., improve the `status` command, so that
+only volatile metrics can be queried frequently. A collection of metrics can be
+of mixed stability.
+
+Then, of course, a metric has a value according to its type and an optional (but
+highly recommended!) description that should explain what it is that is measured.
+
+## Storage
+
+A storage is the actual sink for the metrics. It has one cental `store` method
+and a bulk of convenience methods for quicker use. These could be moved to some
+factory or builder for metrics some time in the future, but this seems to be
+overkill atm. In general, since a `Metric` is designed as a closed sum type, we
+do not expect it to be necessary that factories for `Metric`s need to be abstracted,
+creation via `new` seems to be enough.
+
+Currently there is one simple and naive implementation for a storage as a nested
+array, and a wrapper `StorageOnPath` to modify the key that is used to store
+metrics in an underlying storage. In the future, we expect other implementations
+to arise, e.g. over the ILIAS DB or some telemetry system.
+
+## Design Considerations
+
+The `Metric` is designed as a closed sum type. `Closed` here means, that the type
+is not open for new members, as we would expect in an OOP system. `Sum` means,
+that there are certain variations in the type (the various value types for the
+metric and the stabilities). This is implemented like this to make it possible
+that consumers of metrics know every possible type of metric instead of only
+accessing it via an interface.
+
+We do not expect the types of metrics need to expand dynamically according to
+the scenario. There will be various producers inside the system that can stick
+to the formats of `Metric`s that are provided here. What will expand, maybe
+even dynamically, are the `Storage`s where the metrics will be send. These would
+be impossible to build with an open type without a defined interface. Designing
+an interface would be prudent if we would expect dynamicism on both sides of
+the problems, metrics and storage. Designing an interface, though, is hard and
+seems to be overkill here, at least at the moment.

--- a/src/Setup/Objective/ClientIdReadObjective.php
+++ b/src/Setup/Objective/ClientIdReadObjective.php
@@ -57,6 +57,10 @@ class ClientIdReadObjective implements Setup\Objective
      */
     public function achieve(Setup\Environment $environment) : Setup\Environment
     {
+        if ($environment->getResource(Setup\Environment::RESOURCE_CLIENT_ID) !== null) {
+            return $environment;
+        }
+
         $dir = $this->getDataDirectoryPath();
         $candidates = array_filter(
             $this->scanDirectory($dir),
@@ -108,6 +112,6 @@ class ClientIdReadObjective implements Setup\Objective
      */
     public function isApplicable(Setup\Environment $environment) : bool
     {
-        return $environment->getResource(Setup\Environment::RESOURCE_CLIENT_ID) !== null;
+        return $environment->getResource(Setup\Environment::RESOURCE_CLIENT_ID) === null;
     }
 }

--- a/src/Setup/README.md
+++ b/src/Setup/README.md
@@ -24,6 +24,11 @@ There are special kinds of `Objective`s tailored to match certain use cases.
 [`Artifact`](./Artifact.php) somewhere. Look into the [according section](#on-artifacts)
 to find out how to use them.
 
+For the `status` command of the setup, the kernel of a framework for metrics is
+[included](./Metrics/README.md) here. This is kept a little separate from the rest
+of the setup, because we might want to detach this some day.
+
+
 ## More Details, Please!
 
 ### On Config

--- a/tests/Language/Setup/ilLanguageSetupAgentTest.php
+++ b/tests/Language/Setup/ilLanguageSetupAgentTest.php
@@ -71,15 +71,18 @@ class ilLanguageSetupAgentTest extends TestCase
 
     public function testGetUpdateObjective() : void
     {
-        $result = $this->obj->getUpdateObjective();
+        $setup_conf_mock = $this->createMock(\ilLanguageSetupConfig::class);
+        $objective_collection = $this->obj->getInstallObjective($setup_conf_mock);
 
-        $this->assertInstanceOf(NullObjective::class, $result);
+        $this->assertEquals('Complete objectives from Services/Language', $objective_collection->getLabel());
+        $this->assertFalse($objective_collection->isNotable());
+        $this->assertEquals(3, count($objective_collection->getObjectives()));
     }
 
 
     public function testGetBuildArtifactObjective() : void
     {
-        $result = $this->obj->getUpdateObjective();
+        $result = $this->obj->getBuildArtifactObjective();
 
         $this->assertInstanceOf(NullObjective::class, $result);
     }

--- a/tests/Language/Setup/ilLanguageSetupAgentTest.php
+++ b/tests/Language/Setup/ilLanguageSetupAgentTest.php
@@ -34,12 +34,6 @@ class ilLanguageSetupAgentTest extends TestCase
         $this->assertTrue($this->obj->hasConfig());
     }
 
-    public function testGetConfigInput() : void
-    {
-        $this->expectException(\LogicException::class);
-        $this->obj->getConfigInput();
-    }
-
     public function testGetArrayToConfigTransformationWithDefaultLanguage() : void
     {
         $fnc = $this->obj->getArrayToConfigTransformation();

--- a/tests/Setup/AgentCollectionTest.php
+++ b/tests/Setup/AgentCollectionTest.php
@@ -236,15 +236,6 @@ class AgentCollectionTest extends TestCase
 
         $c1
             ->expects($this->once())
-            ->method("hasConfig")
-            ->willReturn(true);
-        $c2
-            ->expects($this->once())
-            ->method("hasConfig")
-            ->willReturn(false);
-
-        $c1
-            ->expects($this->once())
             ->method("getUpdateObjective")
             ->with($conf1)
             ->willReturn($g1);

--- a/tests/Setup/AgentCollectionTest.php
+++ b/tests/Setup/AgentCollectionTest.php
@@ -191,6 +191,40 @@ class AgentCollectionTest extends TestCase
     public function testGetUpdateObjective() : void
     {
         $refinery = new Refinery($this->createMock(DataFactory::class), $this->createMock(\ilLanguage::class));
+        $storage = $this->createMock(Setup\Metrics\Storage::class);
+
+        $c1 = $this->newAgent();
+        $c2 = $this->newAgent();
+
+        $g1 = $this->newObjective();
+        $g2 = $this->newObjective();
+
+        $s1 = new Setup\Metrics\StorageOnPathWrapper("c1", $storage);
+        $s2 = new Setup\Metrics\StorageOnPathWrapper("c2", $storage);
+
+        $c1
+            ->expects($this->once())
+            ->method("getStatusObjective")
+            ->with($s1)
+            ->willReturn($g1);
+        $c2
+            ->expects($this->once())
+            ->method("getStatusObjective")
+            ->with($s2)
+            ->willReturn($g2);
+
+        $col = new Setup\AgentCollection($refinery, ["c1" => $c1,"c2" => $c2]);
+        $conf = new Setup\ConfigCollection(["c1" => $conf1]);
+
+        $g = $col->getStatusObjective($storage);
+
+        $this->assertInstanceOf(Setup\ObjectiveCollection::class, $g);
+        $this->assertEquals([$g1, $g2], $g->getObjectives());
+    }
+
+    public function testGetCollectMetricsObjective() : void
+    {
+        $refinery = new Refinery($this->createMock(DataFactory::class), $this->createMock(\ilLanguage::class));
 
         $c1 = $this->newAgent();
         $c2 = $this->newAgent();

--- a/tests/Setup/Helper.php
+++ b/tests/Setup/Helper.php
@@ -15,7 +15,7 @@ trait Helper
 
         $consumer = $this
             ->getMockBuilder(Setup\Agent::class)
-            ->setMethods(["hasConfig", "getDefaultConfig", "getConfigInput", "getArrayToConfigTransformation", "getInstallObjective", "getUpdateObjective", "getBuildArtifactObjective"])
+            ->setMethods(["hasConfig", "getDefaultConfig", "getConfigInput", "getArrayToConfigTransformation", "getInstallObjective", "getUpdateObjective", "getBuildArtifactObjective", "getStatusObjective"])
             ->setMockClassName("Mock_AgentNo" . ($no++))
             ->getMock();
 

--- a/tests/Setup/Metrics/MetricTest.php
+++ b/tests/Setup/Metrics/MetricTest.php
@@ -156,4 +156,54 @@ METRIC;
 
         $this->assertEquals($expected, $metrics->toYAML());
     }
+
+    public function testExtractBySeverity()
+    {
+        $metrics = new M(M::STABILITY_MIXED, M::TYPE_COLLECTION, [
+            "a" => new M(M::STABILITY_MIXED, M::TYPE_COLLECTION, [
+                "h" => new M(M::STABILITY_CONFIG, M::TYPE_TEXT, "a_h"),
+                "c" => new M(M::STABILITY_MIXED, M::TYPE_COLLECTION, [
+                    "d" => new M(M::STABILITY_MIXED, M::TYPE_COLLECTION, [
+                        "e" => new M(M::STABILITY_STABLE, M::TYPE_TEXT, "a_c_d_e"),
+                        "f" => new M(M::STABILITY_VOLATILE, M::TYPE_TEXT, "a_c_d_f")
+                    ]),
+                    "g" => new M(M::STABILITY_CONFIG, M::TYPE_TEXT, "a_c_g")
+                ]),
+                "i" => new M(M::STABILITY_STABLE, M::TYPE_TEXT, "a_i\na_i")
+            ]),
+            "b" => new M(M::STABILITY_MIXED, M::TYPE_COLLECTION, [
+                "j" => new M(M::STABILITY_VOLATILE, M::TYPE_TEXT, "b_j")
+            ]),
+            "k" => new M(M::STABILITY_CONFIG, M::TYPE_TEXT, "k")
+        ]);
+
+        $expected_extracted = new M(M::STABILITY_CONFIG, M::TYPE_COLLECTION, [
+            "a" => new M(M::STABILITY_CONFIG, M::TYPE_COLLECTION, [
+                "h" => new M(M::STABILITY_CONFIG, M::TYPE_TEXT, "a_h"),
+                "c" => new M(M::STABILITY_CONFIG, M::TYPE_COLLECTION, [
+                    "g" => new M(M::STABILITY_CONFIG, M::TYPE_TEXT, "a_c_g")
+                ]),
+            ]),
+            "k" => new M(M::STABILITY_CONFIG, M::TYPE_TEXT, "k")
+        ]);
+        $expected_rest = new M(M::STABILITY_MIXED, M::TYPE_COLLECTION, [
+            "a" => new M(M::STABILITY_MIXED, M::TYPE_COLLECTION, [
+                "c" => new M(M::STABILITY_MIXED, M::TYPE_COLLECTION, [
+                    "d" => new M(M::STABILITY_MIXED, M::TYPE_COLLECTION, [
+                        "e" => new M(M::STABILITY_STABLE, M::TYPE_TEXT, "a_c_d_e"),
+                        "f" => new M(M::STABILITY_VOLATILE, M::TYPE_TEXT, "a_c_d_f")
+                    ])
+                ]),
+                "i" => new M(M::STABILITY_STABLE, M::TYPE_TEXT, "a_i\na_i")
+            ]),
+            "b" => new M(M::STABILITY_MIXED, M::TYPE_COLLECTION, [
+                "j" => new M(M::STABILITY_VOLATILE, M::TYPE_TEXT, "b_j")
+            ])
+        ]);
+
+        list($extracted, $rest) = $metrics->extractByStability(M::STABILITY_CONFIG);
+
+        $this->assertEquals($expected_extracted, $extracted);
+        $this->assertEquals($expected_rest, $rest);
+    }
 }


### PR DESCRIPTION
Dear colleagues,

this implements two feature requests for the setup: [Add `status` Command](https://docu.ilias.de/goto.php?target=wiki_1357_Setup_-_Add_status_Command) and [Let `update` Command Change Configs](https://docu.ilias.de/goto.php?target=wiki_1357_Setup_-_Let_update-Command_change_configs) and also cleans up some things a little. Although we advice to create small PRs I hope it is easier for every individual maintainer to look through changes in their components in bulk. Changes regarding components of other maintainers should be mostly repetitive and contain little logic.

This is what happened in general:

* I removed `Agent::getConfigInput`. When building the setup initially I though we would need this for the webbased GUI, but this will be removed soon. Anyway, it was never really implemented anywhere.
* I introduced [some infrastructure for metrics](https://github.com/ILIAS-eLearning/ILIAS/tree/trunk/src/Setup/Metrics) before that is put to use now to implement the status command. `Agent`s can now provide an `Objective` for the status command via `getStatusObjective`. That `Objective` is supposed to collect metrics and store them to a `Storage` for metrics. I have provided a base class that should make it fairly easy and obvious how to implement an appropriate `Objective`. This was exercised for various components, mostly to collect the current configuration from the installation.
* I decoupled two widely used `Objective`s from configs provided by agents to make them more easily usable. These are `ilIniFilesLoadedObjective` and `ilDatabaseInitializedObjective`. These lead to some simplifications in various `Objective`s.
* This also made it possible to remove the hard dependency on a configuration for the `update` command (or `Agent::getUpdateObjective`, respectively). Although the signature for `Agent::getUpdateObjective` did not change, `Agent`s now need to update their config when one is provided (and do other stuff even without config if necessary on update). I implemented that for all components where this is required. To make this work I needed to drop the dependency on the config in various places.
* This in turn made it possible to make the `config` option for the `update` command optional.

I will go into a little bit more detail for some of the involved maintainers.

I will improve on two points in this PR, which is documentation for the metrics and sorting the output for `status` to separate configs and other metrics. I still already open this PR to give involved maintainers a chance to have a look already.

As always, feel free to ask questions, give feedback or request changes. And hopefully, click "Approve", of course.

Best regards!
