### PR TITLE
#29047 - fix for copy of content page object

### DIFF
--- a/Modules/ContentPage/classes/class.ilObjContentPage.php
+++ b/Modules/ContentPage/classes/class.ilObjContentPage.php
@@ -59,12 +59,12 @@ class ilObjContentPage extends \ilObject2 implements \ilContentPageObjectConstan
 
         if (\ilContentPagePage::_exists($this->getType(), $this->getId())) {
             $originalPageObject = new \ilContentPagePage($this->getId());
-            $originalXML = $originalPageObject->getXMLContent();
+            $copiedXML = $originalPageObject->copyXmlContent();
 
             $duplicatePageObject = new \ilContentPagePage();
             $duplicatePageObject->setId($new_obj->getId());
             $duplicatePageObject->setParentId($new_obj->getId());
-            $duplicatePageObject->setXMLContent($originalXML);
+            $duplicatePageObject->setXMLContent($copiedXML);
             $duplicatePageObject->createFromXML();
         }
 


### PR DESCRIPTION
When you copy a content page object that has for example H5P content, then the copied object refers to the same H5P content. If you modify it on the copied object, then the original gets modified, too. If you delete it on the copied page, then the editor in the original shows that that content does not exist anymore. This is fixed by the PR.