### PR TITLE
BUGFIX[29053]

### DIFF
--- a/Services/Navigation/classes/class.ilNavigationHistoryListMenuGUI.php
+++ b/Services/Navigation/classes/class.ilNavigationHistoryListMenuGUI.php
@@ -1,0 +1,68 @@
+<?php
+
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+use ILIAS\Data\URI;
+use ILIAS\DI\Container;
+
+/**
+ * Favourites UI
+ *
+ * @author killing@leifos.de
+ */
+class ilNavigationHistoryListMenuGUI
+{
+    /**
+     * @var ilPDSelectedItemsBlockViewGUI
+     */
+    protected $block_view;
+
+    /**
+     * @var Container
+     */
+    protected $dic;
+
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        global $DIC;
+        $this->dic = $DIC;
+    }
+
+    /**
+     * Render
+     *
+     * @return string
+     */
+    public function render()
+    {
+        $nav_items = [];
+        if (isset($this->dic['ilNavigationHistory'])) {
+            $nav_items = $this->dic['ilNavigationHistory']->getItems();
+        }
+
+        $items = [];
+        foreach (array_slice($nav_items, 0, 10) as $nav_item) {
+            if (!isset($nav_item["ref_id"]) || !isset($_GET["ref_id"])
+                || ($nav_item["ref_id"] != $_GET["ref_id"])
+            ) {
+                $obj_id = ilObject::_lookupObjectId($nav_item["ref_id"]);
+                $url = $nav_item["link"];
+                if(strpos($nav_item["link"], ilUtil::_getHttpPath()) !== 0) {
+                    $url = ilUtil::_getHttpPath() . '/' . $nav_item["link"];
+                }
+                $items[] = $this->dic->ui()->factory()->link()->bulky(
+                    $this->dic->ui()->factory()->symbol()->icon()->custom(ilObject::_getIcon($obj_id), $nav_item["title"]),
+                    $nav_item["title"],
+                    new URI($url)
+                );
+            }
+        }
+
+
+        return $this->dic->ui()->renderer()->render($items);
+    }
+}

--- a/Services/Repository/GlobalScreen/classes/RepositoryMainBarProvider.php
+++ b/Services/Repository/GlobalScreen/classes/RepositoryMainBarProvider.php
@@ -126,50 +126,6 @@ class RepositoryMainBarProvider extends AbstractStaticMainMenuProvider
             ->withAction($action());
     }
 
-
-
-    /**
-     * Render last visited
-     *
-     * @return string
-     */
-    protected function renderLastVisited()
-    {
-        $nav_items = [];
-        if (isset($this->dic['ilNavigationHistory'])) {
-            $nav_items = $this->dic['ilNavigationHistory']->getItems();
-        }
-        reset($nav_items);
-        $cnt = 0;
-        $first = true;
-        $item_groups = [];
-
-        $f = $this->dic->ui()->factory();
-        foreach ($nav_items as $k => $nav_item) {
-            if ($cnt >= 10) {
-                break;
-            }
-
-            if (!isset($nav_item["ref_id"]) || !isset($_GET["ref_id"])
-                || ($nav_item["ref_id"] != $_GET["ref_id"] || !$first)
-            ) {            // do not list current item
-                $ititle = ilUtil::shortenText(strip_tags($nav_item["title"]), 50, true); // #11023
-                $obj_id = ilObject::_lookupObjectId($nav_item["ref_id"]);
-                $items[] = $f->item()->standard(
-                    $f->link()->standard($ititle, $nav_item["link"])
-                )->withLeadIcon($f->symbol()->icon()->custom(ilObject::_getIcon($obj_id), $ititle));
-            }
-            $first = false;
-        }
-
-        $item_groups[] = $f->item()->group("", $items);
-        $panel = $f->panel()->secondary()->listing("", $item_groups);
-
-        return $this->dic->ui()->renderer()->render([$panel]);
-    }
-
-
-
     /**
      * Render repository tree
      *

--- a/Services/Repository/GlobalScreen/classes/RepositoryMainBarProvider.php
+++ b/Services/Repository/GlobalScreen/classes/RepositoryMainBarProvider.php
@@ -76,7 +76,6 @@ class RepositoryMainBarProvider extends AbstractStaticMainMenuProvider
 
         $icon = $this->dic->ui()->factory()->symbol()->icon()->custom(\ilUtil::getImagePath("outlined/icon_lstv.svg"), $title);
 
-        $p = $this;
         $entries[] = $this->mainmenu
             ->complex($this->if->identifier('last_visited'))
             ->withTitle($this->dic->language()->txt('last_visited'))
@@ -85,8 +84,10 @@ class RepositoryMainBarProvider extends AbstractStaticMainMenuProvider
             ->withPosition(30)
             ->withSymbol($icon)
             ->withParent($top)
-            ->withContentWrapper(function () use ($p) {
-                return $this->dic->ui()->factory()->legacy($p->renderLastVisited());
+            ->withContentWrapper(function () {
+                $history_list = new \ilNavigationHistoryListMenuGUI();
+
+                return $this->dic->ui()->factory()->legacy($history_list->render());
             });
 
 

--- a/src/UI/templates/default/MainControls/Slate/slate.less
+++ b/src/UI/templates/default/MainControls/Slate/slate.less
@@ -42,8 +42,9 @@
 		.icon {
 			margin-top: @padding-small-vertical;
 			margin-right: @il-slate-bulky-glyph-margin-right;
-			filter: invert(50%);
-
+			&.outlined {
+				filter: invert(50%);
+			}
 		}
 		.icon.small {
 			min-width: @icon-size-small;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -9256,6 +9256,9 @@ footer {
 .il-maincontrols-slate .link-bulky .icon {
   margin-top: 3px;
   margin-right: 5px;
+}
+.il-maincontrols-slate .btn-bulky .icon.outlined,
+.il-maincontrols-slate .link-bulky .icon.outlined {
   filter: invert(50%);
 }
 .il-maincontrols-slate .btn-bulky .icon.small,


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=29053

Dieser PR verbessert die Ansicht der Historie im Hauptmenü und steigert die User-Satisfactory und Barrierefreiheit.
Desweiteren abstrahiert er den Renderprozess in eine eigene GUI und behebt einen Fehler zur maximalen Größe der Liste.


Vorher:
![image](https://user-images.githubusercontent.com/45942348/96272165-05357080-0fce-11eb-8852-e85cc14aae77.png)

Nachher:
![image](https://user-images.githubusercontent.com/45942348/96272097-ee8f1980-0fcd-11eb-9364-694908e869e2.png)
