### PR TITLE
Implemented automatic packaging for ILIAS releases (CI)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,16 @@ addons:
     - unzip
 install:
 - composer install
+deploy:
+  edge: true
+  provider: script
+  script: CI/Packaging/Packaging.sh
+  skip_cleanup: true
+  on:
+    php: 7.3
+    tags: true
+    repo: ILIAS-eLearning/ILIAS
+    branch: trunk
 env:
   global:
     secure: c43mDcrMbH53mAGZdASJ8HkVpjxbEi388HTegyFGFhVLWk6/srrWUGJtYPkVGvhv2/5s5VQiHelXpjT9vi9iKi9wQCZcudBALjvywPY+OuMdDSs8priMpedRWYcR+l8DGNxfubgp8hb2tcZJh2IwzlOlPRvYhOPoCZZHp9i2AoEHEMmpIMagtBSg7jg7kchQSDcnMB9BUplmDJsQwWY46Yom+8G0KQM84Hcn24SwYq6qGjFCwwdFVLhIDmKGubkKBdYpF06kOftZ8hOBwpYgjzhGhCDSIT6qj/RSgH9i4Bn2b/QzzoxlSJFW5pldiYUXWiwf4qBBisG8EnHSc/pCpTbEeXnCr9fJ8aWyakK4Fm8EjBR5Ll8hmIKR9sAboS13btr2fRMpoS1VrdbjGbFmuSNgL6rrnlbPvRSMR6smmHPRQJ7iLP8/q8jBxiPnhVG/yGeZm8Oe38ONfRAlJwfa0bfxh8ifRHSK9e9yyi2HYPejoFpIUHRzr6j/4WevQShlwaGOzEFbrCawKPJkcFuyVY2gd0sYSJQLXnefMwAGSjhtOAS4YSypL2bX75WcKXodALZRyzU6OSFlGYfPT0rdbz7scV6US0zA/T1ltlsjO6yzqlc0WuVBkZPdF270sldOluGGrwEj+9nVqsRftgC9ZdlecxeE4blCzT1cx8eUSUU=

--- a/CI/Packaging/Packaging.sh
+++ b/CI/Packaging/Packaging.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source ./CI/Packaging/build.sh
+source ./CI/Packaging/pack.sh
+source ./CI/Packaging/deploy.sh

--- a/CI/Packaging/build.sh
+++ b/CI/Packaging/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+NOW=$(date +'%d.%m.%Y %I:%M:%S')
+echo "[$NOW] Building ILIAS"
+
+# copy data
+rsync -av --progress -q ./ "./CI/Packaging/package" --exclude .git --exclude CI --exclude Customizing --exclude packaging --exclude 'tests*' --exclude 'test*'
+
+# clean
+rm ./CI/Packaging/package/.travis.yml
+rm ./CI/Packaging/package/.gitignore
+rm ./CI/Packaging/package/.gitkeep
+
+NOW=$(date +'%d.%m.%Y %I:%M:%S')
+echo "[$NOW] Finished building ILIAS"

--- a/CI/Packaging/deploy.sh
+++ b/CI/Packaging/deploy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+NOW=$(date +'%d.%m.%Y %I:%M:%S')
+echo "[$NOW] Deploying ILIAS"
+
+./CI/Packaging/upload-asset.sh github_api_token=$ILIAS_GITHUB_TOKEN owner=ILIAS-eLearning repo=ILIAS tag=LATEST filename="./CI/Packaging/package/ilias.tar.gz"
+
+NOW=$(date +'%d.%m.%Y %I:%M:%S')
+echo "[$NOW] Finished deploying ILIAS"

--- a/CI/Packaging/pack.sh
+++ b/CI/Packaging/pack.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+NOW=$(date +'%d.%m.%Y %I:%M:%S')
+echo "[$NOW] Packing ILIAS"
+
+DIR=$(pwd)
+
+cd "./CI/Packaging/package/"
+tar -zcf "ilias.tar.gz" *
+cd $DIR
+
+NOW=$(date +'%d.%m.%Y %I:%M:%S')
+echo "[$NOW] Finished packing ILIAS"

--- a/CI/Packaging/upload-asset.sh
+++ b/CI/Packaging/upload-asset.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Author: Stefan Buck
+# License: MIT
+# https://gist.github.com/stefanbuck/ce788fee19ab6eb0b4447a85fc99f447
+#
+#
+# This script accepts the following parameters:
+#
+# * owner
+# * repo
+# * tag
+# * filename
+# * github_api_token
+#
+# Script to upload a release asset using the GitHub API v3.
+#
+# Example:
+#
+# upload-github-release-asset.sh github_api_token=TOKEN owner=stefanbuck repo=playground tag=v0.1.0 filename=./build.zip
+#
+
+# Check dependencies.
+set -e
+xargs=$(which gxargs || which xargs)
+
+# Validate settings.
+[ "$TRACE" ] && set -x
+
+CONFIG=$@
+
+for line in $CONFIG; do
+  eval "$line"
+done
+
+# Define variables.
+GH_API="https://api.github.com"
+GH_REPO="$GH_API/repos/$owner/$repo"
+GH_TAGS="$GH_REPO/releases/tags/$tag"
+AUTH="Authorization: token $github_api_token"
+WGET_ARGS="--content-disposition --auth-no-challenge --no-cookie"
+CURL_ARGS="-LJO#"
+
+if [[ "$tag" == 'LATEST' ]]; then
+  GH_TAGS="$GH_REPO/releases/latest"
+fi
+
+# Validate token.
+curl -o /dev/null -sH "$AUTH" $GH_REPO || { echo "Error: Invalid repo, token or network issue!";  exit 1; }
+
+# Read asset tags.
+response=$(curl -sH "$AUTH" $GH_TAGS)
+
+# Get ID of the asset based on given filename.
+eval $(echo "$response" | grep -m 1 "id.:" | grep -w id | tr : = | tr -cd '[[:alnum:]]=')
+[ "$id" ] || { echo "Error: Failed to get release id for tag: $tag"; echo "$response" | awk 'length($0)<100' >&2; exit 1; }
+
+# Construct url
+GH_ASSET="https://uploads.github.com/repos/$owner/$repo/releases/$id/assets?name=$(basename $filename)"
+
+echo "$GITHUB_OAUTH_BASIC" --data-binary @"$filename" -H "Authorization: token $github_api_token" -H "Content-Type: application/octet-stream" $GH_ASSET


### PR DESCRIPTION
As mentioned in the jour fix by @klees we are introducing the start of the automatic packaging of ILIAS. The goal for this project is to relieve some work from @fwolf-ilias which could be automated.

In this very first step the script packs ILIAS on a release (currently of the trunk as base with PHP7.3, if this needs adjustment, comment) after the composer installed all the needed libraries. The archive will be added automatically to the release/tag.

Next steps:
1. In order to get this script to work we need a new env in the `.travis.yml`. It should be called "ILIAS_GITHUB_TOKEN" which contains the github authorization token for the organization "ILIAS-eLearning". @fwolf-ilias wanted to organize this.
2. We can automate a lot of things within the release todos. As soon as this script is stable we go further. @fwolf-ilias is introduced in all the steps.

If there are any questions feel free to comment or contact me directly.