### PR TITLE
Bugfix: Remove include to invalid path

### DIFF
--- a/Modules/Survey/classes/class.ilObjSurvey.php
+++ b/Modules/Survey/classes/class.ilObjSurvey.php
@@ -6127,7 +6127,6 @@ class ilObjSurvey extends ilObject
 
         $ilCtrl->setParameterByClass("ilSurveyEvaluationGUI", "ref_id", $this->getRefId());
             
-        include_once "./Modules/Survey/classes/class.ilSurveyEvaluationGUI.php";
         $gui = new ilSurveyEvaluationGUI($this);
         $url = $ilCtrl->getLinkTargetByClass(array("ilObjSurveyGUI", "ilSurveyEvaluationGUI"), "evaluationdetails", "", false, false);
 


### PR DESCRIPTION
The cron-job "survey_notification" crashes on our instance (and others probably as well). The reason is an `include_once` to a class which was moved to another folder for ILIAS6. `ilSurveyEvaluationGUI` is now in the folder "Evaluation" instead of "classes".

Since we use autoloading and the class is included in the class map, I just removed the `include_once`-Statement. If you want me to do some more cleanup, I will remove the other includes in this method as well.