### PR TITLE
UI Head Info

### DIFF
--- a/src/UI/Component/Layout/Page/Standard.php
+++ b/src/UI/Component/Layout/Page/Standard.php
@@ -6,6 +6,7 @@ namespace ILIAS\UI\Component\Layout\Page;
 use ILIAS\UI\Component\Breadcrumbs\Breadcrumbs;
 use ILIAS\UI\Component\Image\Image;
 use ILIAS\UI\Component\JavaScriptBindable;
+use ILIAS\UI\Component\MainControls\SystemInfo;
 use ILIAS\UI\Component\MainControls\Mainbar;
 use ILIAS\UI\Component\MainControls\Metabar;
 use ILIAS\UI\Component\MainControls\ModeInfo;
@@ -97,4 +98,18 @@ interface Standard extends Page, JavaScriptBindable
 
 
     public function hasModeInfo() : bool;
+
+    /**
+     * @param SystemInfo[] $system_infos
+     * @return Standard
+     */
+    public function withSystemInfos(array $system_infos) : Standard;
+
+    /**
+     * @return SystemInfo[]
+     */
+    public function getSystemInfos() : array;
+
+
+    public function hasSystemInfos() : bool;
 }

--- a/src/UI/Component/MainControls/Factory.php
+++ b/src/UI/Component/MainControls/Factory.php
@@ -425,10 +425,10 @@ interface Factory
      *        provides such an interaction. In this case the user MUST be able to
      *        close the info in its context by clicking on the Close Glyph.
      *   accessibility:
-     *     1: >
-     *         The System Info informs about an important circumstance, which must be
-     *         recognizable in particular also for persons with a handicap. A
-     *         role="alert" MUST be added to a System Info.
+     *     1: Breaking System Infos MUST have a role="alert".
+     *     2: Important and neutral System Infos MUST have an aria-live="polite".
+     *     3: The headline MUST be referenced by aria-labelledby
+     *     4: The information MUST be referenced by aria-describedby
      * ----
      * @return \ILIAS\UI\Component\MainControls\SystemInfo
      */

--- a/src/UI/Component/MainControls/Factory.php
+++ b/src/UI/Component/MainControls/Factory.php
@@ -347,7 +347,6 @@ interface Factory
      *   purpose: >
      *     The Mode Info is a section on a page that informs the user that he is
      *     in a certain mode (e.g. in the preview as a member of a course).
-     *
      *   composition: >
      *     The Mode Info MUST contain a title explaining the mode.
      *     The Mode Info MUST contain a Close Button to leave the
@@ -355,10 +354,11 @@ interface Factory
      *   effect: >
      *      By clicking the Close Button, the user leaves the current
      *      (application wide) mode.
-     *
+     *   rivals:
+     *      System Info: >
+     *         use ModeInfo to indicate a certain state in a user context. The SystemInfo on the other hand informs about system-wide information.
      * context:
      *   - The Mode Info is used with the Standard Page.
-     *
      * rules:
      *   usage:
      *     1: The Mode Info is unique for the page - there MUST be not more than one.
@@ -368,10 +368,55 @@ interface Factory
      *     1: >
      *         The Mode Info informs about an important circumstance, which must be
      *         recognizable in particular also for persons with a handicap.
-     *
      * ----
-     *
      * @return \ILIAS\UI\Component\MainControls\ModeInfo
      */
     public function modeInfo(string $title, URI $close_action) : ModeInfo;
+
+    /**
+     * ---
+     * description:
+     *   purpose: >
+     *     The System Info is a section on the page that informs the user about
+     *     information about the ILIAS system. This information can be of
+     *     different relevance, from neutral to breaking (see rules).
+     *   composition: >
+     *     A system info is a horizontally arranged sequence of a headline, an information text and, if applicable, a close button.
+     *
+     *     It can appear in three different colors, depending on its denotation:
+     *     - neutral: indicates a System Info that has only a neutral relevance for the users, e.g. that the installation is a test installation.
+     *     - important: indicates a System Info that should be seen by the users, but does not require immediate action by the user. For example "in 30 days your account will expire".
+     *     - breaking: indicates a system info that should be seen by the user immediately and usually requires quick action or indicates upcoming events such as "ILIAS will not be available tomorrow due to maintenance" or "Your account expires in 3 days".
+     *
+     *   effect: >
+     *     By clicking (if there is one) the Close button, the user accepts the facts and does not wish to be informed further. The System Info containing the clicked Button
+     *
+     *     If the information text is longer than the available space on the page allows, it will be hidden and a More Glyph will be displayed. A click on this More Glyph displays the message in full, with the System Info automatically adjusting in height to match the content.
+     *   rivals:
+     *     Mode Info: >
+     *        use System Infos to output system-wide information. The Mode Info
+     *        only informs about a state the user is in.
+     * context:
+     *   - The System Info is only used within the Standard Page.
+     * rules:
+     *   usage:
+     *     1: There MAY be multiple System Infos on the page.
+     *     2: The System Info MUST contain a headline summarize the information.
+     *     3: The System Info MUST contain an information text with additional information.
+     *     4: The System Info MAY contain a Close Button to dismiss and accept the notification.
+     *     5: If there is a Close Button in a System Info, clicking the Button MUST permanently close this System Info for the user.
+     *     6:
+     *   interaction:
+     *     1: An interaction with the user is not mandatory, unless the System Info
+     *        provides such an interaction. In this case the user MUST be able to
+     *        close the info in its context by clicking on the Close Glyph.
+     *   accessibility:
+     *     1: >
+     *         The System Info informs about an important circumstance, which must be
+     *         recognizable in particular also for persons with a handicap. A
+     *         role="alert" MUST be added to a System Info.
+     * ----
+     * @return \ILIAS\UI\Component\MainControls\SystemInfo
+     */
+    public function systemInfo(string $headline, string $information_text) : SystemInfo;
 }

--- a/src/UI/Component/MainControls/Factory.php
+++ b/src/UI/Component/MainControls/Factory.php
@@ -377,21 +377,30 @@ interface Factory
      * ---
      * description:
      *   purpose: >
-     *     The System Info is a section on the page that informs the user about
-     *     information about the ILIAS system. This information can be of
-     *     different relevance, from neutral to breaking (see rules).
+     *     The System Info is a section of the standard page that informs the user
+     *     about information of the ILIAS system. This information can be of
+     *     different relevance (denotation), from neutral to breaking (see rules).
      *   composition: >
-     *     A system info is a horizontally arranged sequence of a headline, an information text and, if applicable, a close button.
-     *
+     *     A system info is a horizontally arranged sequence of a headline, an
+     *     information text and, if applicable, a close button.
      *     It can appear in three different colors, depending on its denotation:
-     *     - neutral: indicates a System Info that has only a neutral relevance for the users, e.g. that the installation is a test installation.
-     *     - important: indicates a System Info that should be seen by the users, but does not require immediate action by the user. For example "in 30 days your account will expire".
-     *     - breaking: indicates a system info that should be seen by the user immediately and usually requires quick action or indicates upcoming events such as "ILIAS will not be available tomorrow due to maintenance" or "Your account expires in 3 days".
-     *
+     *     - neutral: indicates a System Info that has only a neutral relevance
+     *       for the users, e.g. that the installation is a test installation.
+     *     - important: indicates a System Info that should be seen by the users,
+     *       but does not require immediate action by the user. For example
+     *       "in 30 days your account will expire".
+     *     - breaking: indicates a system info that should be seen by the user
+     *       immediately and usually requires quick action or indicates upcoming
+     *       events such as "ILIAS will not be available tomorrow due to
+     *       maintenance" or "Your account expires in 3 days".
      *   effect: >
-     *     By clicking (if there is one) the Close button, the user accepts the facts and does not wish to be informed further. The System Info containing the clicked Button
-     *
-     *     If the information text is longer than the available space on the page allows, it will be hidden and a More Glyph will be displayed. A click on this More Glyph displays the message in full, with the System Info automatically adjusting in height to match the content.
+     *     By clicking (if there is one) the Close button, the user accepts the
+     *     facts and does not wish to be informed further. The System Info
+     *     containing the clicked Button
+     *     If the information text is longer than the available space on the page
+     *     allows, it will be hidden and a More Glyph will be displayed. Clicking
+     *     the More Glyph displays the whole message, with the System Info
+     *     automatically adjusting in height to match the content.
      *   rivals:
      *     Mode Info: >
      *        use System Infos to output system-wide information. The Mode Info
@@ -402,10 +411,15 @@ interface Factory
      *   usage:
      *     1: There MAY be multiple System Infos on the page.
      *     2: The System Info MUST contain a headline summarize the information.
-     *     3: The System Info MUST contain an information text with additional information.
-     *     4: The System Info MAY contain a Close Button to dismiss and accept the notification.
-     *     5: If there is a Close Button in a System Info, clicking the Button MUST permanently close this System Info for the user.
-     *     6:
+     *     3: >
+     *         The System Info MUST contain an information text with additional
+     *         information.
+     *     4: >
+     *         The System Info MAY contain a Close Button to dismiss and accept
+     *         the notification.
+     *     5: >
+     *         If there is a Close Button in a System Info, clicking the Button
+     *         MUST permanently close this System Info for the user.
      *   interaction:
      *     1: An interaction with the user is not mandatory, unless the System Info
      *        provides such an interaction. In this case the user MUST be able to

--- a/src/UI/Component/MainControls/SystemInfo.php
+++ b/src/UI/Component/MainControls/SystemInfo.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace ILIAS\UI\Component\MainControls;
+
+use ILIAS\Data\URI;
+use ILIAS\UI\Component\Component;
+use ILIAS\UI\Component\Signal;
+use ILIAS\UI\Component\Triggerable;
+
+/**
+ * Interface SystemInfo
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+interface SystemInfo extends Component, \ILIAS\UI\Component\JavaScriptBindable, Triggerable
+{
+
+    public const DENOTATION_NEUTRAL = 'neutral';
+    public const DENOTATION_IMPORTANT = 'important';
+    public const DENOTATION_BREAKING = 'breaking';
+
+    public function getHeadLine() : string;
+
+    public function getInformtationText() : string;
+
+    public function withIsDismissable(bool $is_dismissable) : SystemInfo;
+
+    public function withDismissAction(URI $uri) : SystemInfo;
+
+    public function isDismissable() : bool;
+
+    public function getDismissAction() : URI;
+
+    /**
+     * Must be one of
+     * - SystemInfo::DENOTATION_NEUTRAL
+     * - SystemInfo::DENOTATION_IMPORTANT
+     * - SystemInfo::DENOTATION_BREAKING
+     * @param string $denotation
+     * @return SystemInfo
+     */
+    public function withDenotation(string $denotation) : SystemInfo;
+
+    public function getDenotation() : string;
+
+    public function getCloseSignal() : Signal;
+}

--- a/src/UI/Implementation/Component/Layout/Page/Renderer.php
+++ b/src/UI/Implementation/Component/Layout/Page/Renderer.php
@@ -40,6 +40,9 @@ class Renderer extends AbstractComponentRenderer
         if ($component->hasModeInfo()) {
             $tpl->setVariable('MODEINFO', $default_renderer->render($component->getModeInfo()));
         }
+        if ($component->hasSystemInfos()) {
+            $tpl->setVariable('SYSTEMINFOS', $default_renderer->render($component->getSystemInfos()));
+        }
 
         $breadcrumbs = $component->getBreadcrumbs();
         if ($breadcrumbs && $breadcrumbs->getItems()) {

--- a/src/UI/Implementation/Component/Layout/Page/Standard.php
+++ b/src/UI/Implementation/Component/Layout/Page/Standard.php
@@ -3,15 +3,17 @@
 
 namespace ILIAS\UI\Implementation\Component\Layout\Page;
 
-use ILIAS\UI\Component\Layout\Page;
-use ILIAS\UI\Component\MainControls\ModeInfo;
-use ILIAS\UI\Implementation\Component\ComponentHelper;
-use ILIAS\UI\Implementation\Component\JavaScriptBindable;
-use ILIAS\UI\Component\MainControls\MetaBar;
-use ILIAS\UI\Component\MainControls\MainBar;
 use ILIAS\UI\Component\Breadcrumbs\Breadcrumbs;
 use ILIAS\UI\Component\Image\Image;
+use ILIAS\UI\Component\Layout\Page;
 use ILIAS\UI\Component\MainControls\Footer;
+use ILIAS\UI\Component\MainControls\HeadInfo;
+use ILIAS\UI\Component\MainControls\MainBar;
+use ILIAS\UI\Component\MainControls\MetaBar;
+use ILIAS\UI\Component\MainControls\ModeInfo;
+use ILIAS\UI\Component\MainControls\SystemInfo;
+use ILIAS\UI\Implementation\Component\ComponentHelper;
+use ILIAS\UI\Implementation\Component\JavaScriptBindable;
 
 /**
  * Page
@@ -20,6 +22,7 @@ class Standard implements Page\Standard
 {
     use ComponentHelper;
     use JavaScriptBindable;
+
     /**
      * @var ModeInfo|null
      */
@@ -33,11 +36,11 @@ class Standard implements Page\Standard
      */
     private $metabar;
     /**
-     * @var	MainBar|null
+     * @var    MainBar|null
      */
     private $mainbar;
     /**
-     * @var	Breadcrumbs|null
+     * @var    Breadcrumbs|null
      */
     private $breadcrumbs;
     /**
@@ -45,7 +48,7 @@ class Standard implements Page\Standard
      */
     private $logo;
     /**
-     * @var	footer|null
+     * @var    footer|null
      */
     private $footer;
     /**
@@ -57,21 +60,21 @@ class Standard implements Page\Standard
      */
     private $view_title;
     /**
-     * @var	string
+     * @var    string
      */
     private $title;
     /**
-     * @var	bool
+     * @var    bool
      */
     private $with_headers = true;
     /**
      * @var    bool
      */
     private $ui_demo = false;
+    protected $system_infos = [];
 
     /**
      * Standard constructor.
-     *
      * @param array            $content
      * @param MetaBar|null     $metabar
      * @param MainBar|null     $mainbar
@@ -93,15 +96,15 @@ class Standard implements Page\Standard
         $allowed = [\ILIAS\UI\Component\Component::class];
         $this->checkArgListElements("content", $content, $allowed);
 
-        $this->content = $content;
-        $this->metabar = $metabar;
-        $this->mainbar = $mainbar;
+        $this->content     = $content;
+        $this->metabar     = $metabar;
+        $this->mainbar     = $mainbar;
         $this->breadcrumbs = $locator;
-        $this->logo = $logo;
-        $this->footer = $footer;
-        $this->title = $title;
+        $this->logo        = $logo;
+        $this->footer      = $footer;
+        $this->title       = $title;
         $this->short_title = $short_title;
-        $this->view_title = $view_title;
+        $this->view_title  = $view_title;
     }
 
     /**
@@ -109,7 +112,7 @@ class Standard implements Page\Standard
      */
     public function withMetabar(Metabar $meta_bar) : Page\Standard
     {
-        $clone = clone $this;
+        $clone          = clone $this;
         $clone->metabar = $meta_bar;
         return $clone;
     }
@@ -119,18 +122,17 @@ class Standard implements Page\Standard
      */
     public function withMainbar(Mainbar $main_bar) : Page\Standard
     {
-        $clone = clone $this;
+        $clone          = clone $this;
         $clone->mainbar = $main_bar;
         return $clone;
     }
-
 
     /**
      * @inheritDoc
      */
     public function withLogo(Image $logo) : Page\Standard
     {
-        $clone = clone $this;
+        $clone       = clone $this;
         $clone->logo = $logo;
         return $clone;
     }
@@ -140,11 +142,10 @@ class Standard implements Page\Standard
      */
     public function withFooter(Footer $footer) : Page\Standard
     {
-        $clone = clone $this;
+        $clone         = clone $this;
         $clone->footer = $footer;
         return $clone;
     }
-
 
     /**
      * @inheritDoc
@@ -154,7 +155,6 @@ class Standard implements Page\Standard
         return ($this->metabar instanceof MetaBar);
     }
 
-
     /**
      * @inheritDoc
      */
@@ -162,7 +162,6 @@ class Standard implements Page\Standard
     {
         return ($this->mainbar instanceof MainBar);
     }
-
 
     /**
      * @inheritDoc
@@ -188,7 +187,6 @@ class Standard implements Page\Standard
         return $this->content;
     }
 
-
     /**
      * @inheritdoc
      */
@@ -196,7 +194,6 @@ class Standard implements Page\Standard
     {
         return $this->metabar;
     }
-
 
     /**
      * @inheritdoc
@@ -206,7 +203,6 @@ class Standard implements Page\Standard
         return $this->mainbar;
     }
 
-
     /**
      * @inheritdoc
      */
@@ -214,7 +210,6 @@ class Standard implements Page\Standard
     {
         return $this->breadcrumbs;
     }
-
 
     /**
      * @inheritdoc
@@ -233,17 +228,15 @@ class Standard implements Page\Standard
     }
 
     /**
-     * @param    bool $use_headers
-     *
+     * @param bool $use_headers
      * @return    Page
      */
     public function withHeaders($use_headers) : Page
     {
-        $clone = clone $this;
+        $clone               = clone $this;
         $clone->with_headers = $use_headers;
         return $clone;
     }
-
 
     /**
      * @return    bool
@@ -266,14 +259,14 @@ class Standard implements Page\Standard
      */
     public function withUIDemo(bool $switch = true) : Standard
     {
-        $clone = clone $this;
+        $clone          = clone $this;
         $clone->ui_demo = $switch;
         return $clone;
     }
 
     public function withTitle(string $title) : Page\Standard
     {
-        $clone = clone $this;
+        $clone        = clone $this;
         $clone->title = $title;
         return $clone;
     }
@@ -285,7 +278,7 @@ class Standard implements Page\Standard
 
     public function withShortTitle(string $title) : Page\Standard
     {
-        $clone = clone $this;
+        $clone              = clone $this;
         $clone->short_title = $title;
         return $clone;
     }
@@ -295,10 +288,9 @@ class Standard implements Page\Standard
         return $this->short_title;
     }
 
-
     public function withViewTitle(string $title) : Page\Standard
     {
-        $clone = clone $this;
+        $clone             = clone $this;
         $clone->view_title = $title;
         return $clone;
     }
@@ -308,10 +300,9 @@ class Standard implements Page\Standard
         return $this->view_title;
     }
 
-
     public function withModeInfo(ModeInfo $mode_info) : \ILIAS\UI\Component\Layout\Page\Standard
     {
-        $clone = clone $this;
+        $clone            = clone $this;
         $clone->mode_info = $mode_info;
         return $clone;
     }
@@ -321,7 +312,6 @@ class Standard implements Page\Standard
         return $this->mode_info;
     }
 
-
     public function hasModeInfo() : bool
     {
         return $this->mode_info instanceof ModeInfo;
@@ -329,8 +319,27 @@ class Standard implements Page\Standard
 
     public function withNoFooter() : Standard
     {
-        $clone = clone $this;
+        $clone         = clone $this;
         $clone->footer = null;
         return $clone;
     }
+
+    public function withSystemInfos(array $system_infos) : \ILIAS\UI\Component\Layout\Page\Standard
+    {
+        $this->checkArgListElements("system_infos", $system_infos, [SystemInfo::class]);
+        $clone               = clone $this;
+        $clone->system_infos = $system_infos;
+        return $clone;
+    }
+
+    public function getSystemInfos() : array
+    {
+        return $this->system_infos;
+    }
+
+    public function hasSystemInfos() : bool
+    {
+        return count($this->system_infos) > 0;
+    }
+
 }

--- a/src/UI/Implementation/Component/MainControls/Factory.php
+++ b/src/UI/Implementation/Component/MainControls/Factory.php
@@ -5,6 +5,7 @@ namespace ILIAS\UI\Implementation\Component\MainControls;
 
 use ILIAS\Data\URI;
 use ILIAS\UI\Component\MainControls as IMainControls;
+use ILIAS\UI\Component\MainControls\SystemInfo;
 use ILIAS\UI\Component\MainControls\ModeInfo;
 use ILIAS\UI\Implementation\Component\SignalGeneratorInterface;
 
@@ -71,4 +72,13 @@ class Factory implements IMainControls\Factory
     {
         return new \ILIAS\UI\Implementation\Component\MainControls\ModeInfo($title, $close_action);
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function systemInfo(string $headline, string $information_text) : SystemInfo
+    {
+        return new \ILIAS\UI\Implementation\Component\MainControls\SystemInfo($this->signal_generator, $headline, $information_text);
+    }
+
 }

--- a/src/UI/Implementation/Component/MainControls/Renderer.php
+++ b/src/UI/Implementation/Component/MainControls/Renderer.php
@@ -4,17 +4,17 @@
 
 namespace ILIAS\UI\Implementation\Component\MainControls;
 
-use ILIAS\UI\Implementation\Render\AbstractComponentRenderer;
-use ILIAS\UI\Renderer as RendererInterface;
 use ILIAS\UI\Component;
-use ILIAS\UI\Component\Signal;
+use ILIAS\UI\Component\MainControls\Footer;
 use ILIAS\UI\Component\MainControls\MainBar;
 use ILIAS\UI\Component\MainControls\MetaBar;
 use ILIAS\UI\Component\MainControls\Slate\Slate;
-use ILIAS\UI\Component\MainControls\Footer;
+use ILIAS\UI\Component\Signal;
 use ILIAS\UI\Implementation\Component\Button\Bulky as IBulky;
 use ILIAS\UI\Implementation\Component\MainControls\Slate\Slate as ISlate;
+use ILIAS\UI\Implementation\Render\AbstractComponentRenderer;
 use ILIAS\UI\Implementation\Render\Template as UITemplateWrapper;
+use ILIAS\UI\Renderer as RendererInterface;
 
 class Renderer extends AbstractComponentRenderer
 {
@@ -43,6 +43,9 @@ class Renderer extends AbstractComponentRenderer
         }
         if ($component instanceof ModeInfo) {
             return $this->renderModeInfo($component, $default_renderer);
+        }
+        if ($component instanceof Component\MainControls\SystemInfo) {
+            return $this->renderSystemInfo($component, $default_renderer);
         }
     }
 
@@ -274,6 +277,39 @@ class Renderer extends AbstractComponentRenderer
         return $tpl->get();
     }
 
+    protected function renderSystemInfo(Component\MainControls\SystemInfo $component, RendererInterface $default_renderer) : string
+    {
+        $tpl = $this->getTemplate("tpl.system_info.html", true, true);
+        $tpl->setVariable('HEADLINE', $component->getHeadLine());
+        $tpl->setVariable('BODY', $component->getInformtationText());
+        $tpl->setVariable('DENOTATION', $component->getDenotation());
+        if ($component->isDismissable()) {
+            $close  = $this->getUIFactory()->symbol()->glyph()->close("#");
+            $signal = $component->getCloseSignal();
+            $close  = $close->withOnClick($signal);
+            $tpl->setVariable('CLOSE_BUTTON', $default_renderer->render($close));
+            $close_uri = (($component->getDismissAction()->getBaseURI() . '?' . $component->getDismissAction()->getQuery()));
+            $tpl->setVariable('CLOSE_URI', $close_uri);
+            $component = $component->withAdditionalOnLoadCode(function ($id) use ($signal) {
+                return "$(document).on('{$signal}', function() { il.UI.maincontrols.system_info.close('{$id}'); });";
+            });
+        }
+
+        $more    = $this->getUIFactory()->symbol()->glyph()->more("#"); //->withAdditionalOnLoadCode()
+        $tpl->setVariable('MORE_BUTTON', $default_renderer->render($more));
+
+        $component = $component->withAdditionalOnLoadCode(function ($id) {
+            return "il.UI.maincontrols.system_info.init('{$id}')";
+        });
+
+
+        $id = $this->bindJavaScript($component);
+        $tpl->setVariable('ID', $id);
+
+
+        return $tpl->get();
+    }
+
 
     protected function renderTriggerButtonsAndSlates(
         UITemplateWrapper $tpl,
@@ -395,6 +431,7 @@ class Renderer extends AbstractComponentRenderer
         $registry->register('./src/UI/templates/js/MainControls/metabar.js');
         $registry->register('./src/GlobalScreen/Client/dist/GS.js');
         $registry->register('./src/UI/templates/js/MainControls/footer.js');
+        $registry->register('./src/UI/templates/js/MainControls/system_info.js');
     }
 
     /**
@@ -406,7 +443,8 @@ class Renderer extends AbstractComponentRenderer
             MetaBar::class,
             MainBar::class,
             Footer::class,
-            ModeInfo::class
+            ModeInfo::class,
+            Component\MainControls\SystemInfo::class
         );
     }
 }

--- a/src/UI/Implementation/Component/MainControls/Renderer.php
+++ b/src/UI/Implementation/Component/MainControls/Renderer.php
@@ -283,6 +283,15 @@ class Renderer extends AbstractComponentRenderer
         $tpl->setVariable('HEADLINE', $component->getHeadLine());
         $tpl->setVariable('BODY', $component->getInformtationText());
         $tpl->setVariable('DENOTATION', $component->getDenotation());
+        switch ($component->getDenotation()) {
+            case Component\MainControls\SystemInfo::DENOTATION_NEUTRAL:
+            case Component\MainControls\SystemInfo::DENOTATION_IMPORTANT:
+                $tpl->setVariable('LIVE', 'aria-live="polite"');
+                break;
+            case Component\MainControls\SystemInfo::DENOTATION_BREAKING:
+                $tpl->setVariable('ROLE', 'role="alert"');
+                break;
+        }
         if ($component->isDismissable()) {
             $close  = $this->getUIFactory()->symbol()->glyph()->close("#");
             $signal = $component->getCloseSignal();

--- a/src/UI/Implementation/Component/MainControls/SystemInfo.php
+++ b/src/UI/Implementation/Component/MainControls/SystemInfo.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace ILIAS\UI\Implementation\Component\MainControls;
+
+use ILIAS\Data\URI;
+use ILIAS\UI\Component\MainControls;
+use ILIAS\UI\Component\Signal;
+use ILIAS\UI\Implementation\Component\ComponentHelper;
+use ILIAS\UI\Implementation\Component\JavaScriptBindable;
+use ILIAS\UI\Implementation\Component\SignalGeneratorInterface;
+
+/**
+ * Class SystemInfo
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+class SystemInfo implements MainControls\SystemInfo
+{
+    use ComponentHelper;
+    use JavaScriptBindable;
+
+    /**
+     * @var string
+     */
+    protected $head_line;
+    /**
+     * @var string
+     */
+    protected $information_text;
+    /**
+     * @var bool
+     */
+    protected $dismissable = false;
+    /**
+     * @var URI
+     */
+    protected $dismiss_action;
+    /**
+     * @var string
+     */
+    protected $denotation = self::DENOTATION_NEUTRAL;
+    /**
+     * @var Signal
+     */
+    protected $close_signal;
+    /**
+     * @var SignalGeneratorInterface
+     */
+    protected $signal_generator;
+
+    /**
+     * SystemInfo constructor.
+     * @param SignalGeneratorInterface $signal_generator
+     * @param string                   $head_line
+     * @param string                   $information_text
+     */
+    public function __construct(SignalGeneratorInterface $signal_generator, string $head_line, string $information_text)
+    {
+        $this->signal_generator = $signal_generator;
+        $this->head_line        = $head_line;
+        $this->information_text = $information_text;
+        $this->initSignals();
+    }
+
+    protected function initSignals() : void
+    {
+        $this->close_signal = $this->signal_generator->create();
+    }
+
+    public function getHeadLine() : string
+    {
+        return $this->head_line;
+    }
+
+    public function getInformtationText() : string
+    {
+        return $this->information_text;
+    }
+
+    public function isDismissable() : bool
+    {
+        return $this->dismissable;
+    }
+
+    public function getDismissAction() : URI
+    {
+        return $this->dismiss_action;
+    }
+
+    public function withIsDismissable(bool $is_dismissable) : \ILIAS\UI\Component\MainControls\SystemInfo
+    {
+        $clone              = clone $this;
+        $clone->dismissable = $is_dismissable;
+        return $clone;
+    }
+
+    public function withDismissAction(URI $uri) : \ILIAS\UI\Component\MainControls\SystemInfo
+    {
+        $clone                 = clone $this;
+        $clone->dismiss_action = $uri;
+        return $clone;
+    }
+
+    public function withDenotation(string $denotation) : \ILIAS\UI\Component\MainControls\SystemInfo
+    {
+        $clone             = clone $this;
+        $clone->denotation = $denotation;
+        return $clone;
+    }
+
+    public function getDenotation() : string
+    {
+        return $this->denotation;
+    }
+
+    /**
+     * @return Signal
+     */
+    public function getCloseSignal() : Signal
+    {
+        return $this->close_signal;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withResetSignals()
+    {
+        $clone = clone $this;
+        $clone->initSignals();
+        return $clone;
+    }
+
+}

--- a/src/UI/examples/Layout/Page/Standard/ui.php
+++ b/src/UI/examples/Layout/Page/Standard/ui.php
@@ -50,7 +50,7 @@ if ($_GET['new_ui'] == '1') {
         'ILIAS', //short title
         'Std. Page Demo' //view title
     )->withModeInfo($f->mainControls()->modeInfo("Member View", new URI($_SERVER['HTTP_REFERER'])))
-        ->withHeadInfos(
+        ->withSystemInfos(
             [$f->mainControls()->headInfo('This is an neutral Message!', 'read it, understand it, dismiss it...')
                ->withIsDismissable(true)
                ->withDismissAction(new URI($_SERVER['HTTP_REFERER']))]

--- a/src/UI/examples/Layout/Page/Standard/ui.php
+++ b/src/UI/examples/Layout/Page/Standard/ui.php
@@ -50,6 +50,11 @@ if ($_GET['new_ui'] == '1') {
         'ILIAS', //short title
         'Std. Page Demo' //view title
     )->withModeInfo($f->mainControls()->modeInfo("Member View", new URI($_SERVER['HTTP_REFERER'])))
+        ->withHeadInfos(
+            [$f->mainControls()->headInfo('This is an neutral Message!', 'read it, understand it, dismiss it...')
+               ->withIsDismissable(true)
+               ->withDismissAction(new URI($_SERVER['HTTP_REFERER']))]
+        )
     ->withUIDemo(true);
 
     echo $renderer->render($page);

--- a/src/UI/examples/MainControls/SystemInfo/long_text.php
+++ b/src/UI/examples/MainControls/SystemInfo/long_text.php
@@ -1,0 +1,19 @@
+<?php
+
+use ILIAS\UI\Component\MainControls\HeadInfo;
+
+function long_text()
+{
+    //
+    // This example show how the UI-Elements itself looks like. For a full
+    // example use the example of the UI-Component Layout\Page\Standard.
+    //
+
+    global $DIC;
+    $f        = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $long_text  = $f->mainControls()->systemInfo('This Message has a long body', 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.');
+
+    return $renderer->render([$long_text]);
+}

--- a/src/UI/examples/MainControls/SystemInfo/multiple.php
+++ b/src/UI/examples/MainControls/SystemInfo/multiple.php
@@ -1,0 +1,21 @@
+<?php
+
+use ILIAS\UI\Component\MainControls\SystemInfo;
+
+function multiple()
+{
+    //
+    // This example show how the UI-Elements itself looks like. For a full
+    // example use the example of the UI-Component Layout\Page\Standard.
+    //
+
+    global $DIC;
+    $f        = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $first  = $f->mainControls()->systemInfo('This is the first Message!', 'content of the first message...')->withDenotation(SystemInfo::DENOTATION_BREAKING);
+    $second = $f->mainControls()->systemInfo('This is the second Message!', 'content of the second message...')->withDenotation(SystemInfo::DENOTATION_IMPORTANT);
+    $third  = $f->mainControls()->systemInfo('This is the third Message!', 'content of the third message...');
+
+    return $renderer->render([$first, $second, $third]);
+}

--- a/src/UI/examples/MainControls/SystemInfo/simple.php
+++ b/src/UI/examples/MainControls/SystemInfo/simple.php
@@ -1,0 +1,21 @@
+<?php
+
+use ILIAS\Data\URI;
+
+function simple()
+{
+    //
+    // This example show how the UI-Elements itself looks like. For a full
+    // example use the example of the UI-Component Layout\Page\Standard.
+    //
+
+    global $DIC;
+    $f        = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $systemInfo = $f->mainControls()->systemInfo('This is an neutral Message!', 'read it, understand it, dismiss it...')
+                  ->withIsDismissable(true)
+                  ->withDismissAction(new URI($_SERVER['HTTP_REFERER']));
+
+    return $renderer->render([$systemInfo]);
+}

--- a/src/UI/templates/default/Breadcrumbs/breadcrumbs.less
+++ b/src/UI/templates/default/Breadcrumbs/breadcrumbs.less
@@ -10,10 +10,10 @@
 	flex-direction: row;
 	-ms-grid-column: 1;
 	-ms-grid-column-span: 2;
-	-ms-grid-row: 2;
+	-ms-grid-row: 3;
 	grid-column-start: 1;
 	grid-column-end: 3;
-	grid-row: 2;
+	grid-row: 3;
 	z-index: @il-standard-page-zindex-breadcrumbs;
 	.shadow-bottom();
 

--- a/src/UI/templates/default/Layout/standardpage.less
+++ b/src/UI/templates/default/Layout/standardpage.less
@@ -65,8 +65,8 @@ grid-based layout
 	grid-gap: 0px;
 	-ms-grid-columns: auto 1fr;
     grid-template-columns: auto 1fr;
-	-ms-grid-rows: @il-standard-page-header-height @il-standard-page-breadcrumbs-height auto 1fr;
-    grid-template-rows: @il-standard-page-header-height @il-standard-page-breadcrumbs-height auto 1fr;
+	-ms-grid-rows: @il-standard-page-header-height auto @il-standard-page-breadcrumbs-height 1fr;
+    grid-template-rows: @il-standard-page-header-height auto @il-standard-page-breadcrumbs-height 1fr;
     height: 100%;
 	overflow: hidden;
 	width: 100%;
@@ -115,14 +115,14 @@ header {
 	z-index: @il-standard-page-zindex-header;
 }
 
-// headinfos
-div.il-head-infos {
+// system-infos
+div.il-system-infos {
 	-ms-grid-column: 1;
 	-ms-grid-column-span: 2;
-	-ms-grid-row: 3;
+	-ms-grid-row: 2;
 	grid-column-start: 1;
 	grid-column-end: 3;
-	grid-row: 3;
+	grid-row: 2;
 	z-index: @il-standard-page-zindex-header;
 }
 
@@ -390,11 +390,12 @@ footer {
 	}
 
 	div.il-head-infos {
-		-ms-grid-column: 1;
-		-ms-grid-row: 2;
-		grid-column: 1;
-		grid-row: 2;
-		z-index: @il-standard-page-zindex-header;
+		//grid-column-end: 3;
+		//-ms-grid-column: 1;
+		//-ms-grid-row: 3;
+		//grid-column: 1;
+		//grid-row: 3;
+		//z-index: @il-standard-page-zindex-header;
 	}
 
 	// head-container with logo and metabar
@@ -556,9 +557,9 @@ footer {
 	}
 
 	.il-layout-page-content {
-		-ms-grid-column: 1;
+		-ms-grid-column: 2;
 		-ms-grid-row: 3;
-		grid-column: 1;
+		grid-column: 2;
 		grid-row: 3;
 		overflow: auto;
 	}

--- a/src/UI/templates/default/Layout/standardpage.less
+++ b/src/UI/templates/default/Layout/standardpage.less
@@ -65,8 +65,8 @@ grid-based layout
 	grid-gap: 0px;
 	-ms-grid-columns: auto 1fr;
     grid-template-columns: auto 1fr;
-	-ms-grid-rows: @il-standard-page-header-height @il-standard-page-breadcrumbs-height 1fr;
-    grid-template-rows: @il-standard-page-header-height @il-standard-page-breadcrumbs-height 1fr;
+	-ms-grid-rows: @il-standard-page-header-height @il-standard-page-breadcrumbs-height auto 1fr;
+    grid-template-rows: @il-standard-page-header-height @il-standard-page-breadcrumbs-height auto 1fr;
     height: 100%;
 	overflow: hidden;
 	width: 100%;
@@ -115,6 +115,17 @@ header {
 	z-index: @il-standard-page-zindex-header;
 }
 
+// headinfos
+div.il-head-infos {
+	-ms-grid-column: 1;
+	-ms-grid-column-span: 2;
+	-ms-grid-row: 3;
+	grid-column-start: 1;
+	grid-column-end: 3;
+	grid-row: 3;
+	z-index: @il-standard-page-zindex-header;
+}
+
 // head-container with logo pagetitle and metabar
 .header-inner {
 	-ms-flex-align: center;
@@ -152,9 +163,9 @@ header {
 // mainbar
 nav.il-maincontrols {
 	-ms-grid-column: 1;
-	-ms-grid-row: 3;
+	-ms-grid-row: 4;
 	grid-column: 1;
-	grid-row: 3;
+	grid-row: 4;
 	z-index: @il-standard-page-zindex-maincontrols;
 }
 
@@ -235,9 +246,9 @@ main {
 	-ms-grid-rows: 1fr auto;
 	grid-template-rows: 1fr auto;
 	-ms-grid-column: 2;
-	-ms-grid-row: 3;
+	-ms-grid-row: 4;
 	grid-column: 2;
-	grid-row: 3;
+	grid-row: 4;
 	overflow: auto;
 }
 
@@ -293,8 +304,8 @@ footer {
 		grid-gap: 0px;
 		-ms-grid-columns: 1fr;
 	    grid-template-columns: 1fr;
-		-ms-grid-rows: @il-standard-page-small-header-height 1fr;
-	    grid-template-rows: @il-standard-page-small-header-height 1fr;
+		-ms-grid-rows: @il-standard-page-small-header-height auto 1fr;
+	    grid-template-rows: @il-standard-page-small-header-height auto 1fr;
 	    height: 100%;
 		overflow: hidden;
 		width: 100%;
@@ -330,9 +341,9 @@ footer {
 			grid-template-columns: 1fr;
 			.nav.il-maincontrols {
 				-ms-grid-column: 1;
-				-ms-grid-row: 2;
+				-ms-grid-row: 3;
 				grid-column: 1;
-				grid-row: 2;
+				grid-row: 3;
 				height: 100%; // calc(100% - (@il-standard-page-small-header-height + @il-standard-page-breadcrumbs-height);
 				.il-maincontrols-mainbar {
 					-ms-grid-columns: 1fr;
@@ -375,6 +386,14 @@ footer {
 		-ms-grid-row: 1;
 		grid-column: 1;
 		grid-row: 1;
+		z-index: @il-standard-page-zindex-header;
+	}
+
+	div.il-head-infos {
+		-ms-grid-column: 1;
+		-ms-grid-row: 2;
+		grid-column: 1;
+		grid-row: 2;
 		z-index: @il-standard-page-zindex-header;
 	}
 
@@ -538,9 +557,9 @@ footer {
 
 	.il-layout-page-content {
 		-ms-grid-column: 1;
-		-ms-grid-row: 2;
+		-ms-grid-row: 3;
 		grid-column: 1;
-		grid-row: 2;
+		grid-row: 3;
 		overflow: auto;
 	}
 }

--- a/src/UI/templates/default/Layout/tpl.standardpage.html
+++ b/src/UI/templates/default/Layout/tpl.standardpage.html
@@ -54,7 +54,7 @@
 			{MAINBAR}
 		</div>
 
-		<div class="il-head-infos">
+		<div class="il-system-infos">
 			{SYSTEMINFOS}
 		</div>
 

--- a/src/UI/templates/default/Layout/tpl.standardpage.html
+++ b/src/UI/templates/default/Layout/tpl.standardpage.html
@@ -54,6 +54,10 @@
 			{MAINBAR}
 		</div>
 
+		<div class="il-head-infos">
+			{SYSTEMINFOS}
+		</div>
+
 		<!-- html5 main-tag is not supported in IE / div is needed -->
 		<main class="il-layout-page-content">
 			<div>

--- a/src/UI/templates/default/MainControls/maincontrols.less
+++ b/src/UI/templates/default/MainControls/maincontrols.less
@@ -6,3 +6,4 @@
 @import "mainbar.less";
 @import "footer.less";
 @import "mode_info.less";
+@import "system_info.less";

--- a/src/UI/templates/default/MainControls/system_info.less
+++ b/src/UI/templates/default/MainControls/system_info.less
@@ -1,0 +1,109 @@
+/*
+**************************************************************
+	System Infos
+	change the rule for &.full to
+
+		height: 100%;
+		position: fixed;
+		padding: 100px;
+		top: 0;
+		left: 0;
+		font-size: 2em;
+		line-height: 1.2em;
+
+	to show a fullscreen info
+**************************************************************
+*/
+.il-system-info {
+
+	.head-info-color-variant(@variant_name, @base-color) {
+		@contrast-color: contrast(greyscale(@base-color), darken(@base-color, @il-standard-page-system-info-contrast), lighten(@base-color, @il-standard-page-system-info-contrast), @il-standard-page-system-info-contrast-threshold);
+		&.il-system-info-@{variant_name} {
+			// Shadow
+			-webkit-box-shadow: @il-standard-page-system-info-shadow;
+			-moz-box-shadow: @il-standard-page-system-info-shadow;
+			box-shadow: @il-standard-page-system-info-shadow;
+			background-color: @base-color;
+			// Border
+			border-top: @il-standard-page-system-info-border-color @il-standard-page-system-info-border-top-and-bottom;
+			border-bottom: @il-standard-page-system-info-border-color @il-standard-page-system-info-border-top-and-bottom;
+			border-left: @il-standard-page-system-info-border-color @il-standard-page-system-info-border-left-and-right;
+			border-right: @il-standard-page-system-info-border-color @il-standard-page-system-info-border-left-and-right;
+			// Colors
+			color: @contrast-color;
+
+			a.glyph {
+				color: @contrast-color;
+			}
+		}
+
+	}
+	// 3 Color Variants
+	.head-info-color-variant(neutral, @il-standard-page-system-info-color-variant-neutral);
+	.head-info-color-variant(important, @il-standard-page-system-info-color-variant-important);
+	.head-info-color-variant(breaking, @il-standard-page-system-info-color-variant-breaking);
+
+	// General Sizes
+	width: 100%;
+	line-height: @line-height-computed;
+	padding-top: @padding-base-vertical;
+	padding-bottom: @padding-base-vertical;
+	height: calc(@padding-base-vertical + @padding-base-vertical + @line-height-computed);
+	z-index: 1;
+
+	// Flex
+	display: flex;
+	flex-wrap: nowrap;
+	flex-direction: row;
+	justify-content: flex-start;
+
+	// Show full message
+	&.full {
+		height: auto;
+	}
+
+	div.il-system-info-content {
+		flex-grow: 4;
+		flex-shrink: 1;
+		flex-basis: auto;
+		overflow-y: hidden;
+
+		span {
+			display: inline-block;
+		}
+
+		span.il-system-info-headline {
+			text-transform: @il-standard-page-system-info-headline-transform;
+			font-weight: @il-standard-page-system-info-headline-font-weight;
+			margin-right: @padding-base-horizontal;
+		}
+
+		span.il-system-info-more {
+			display: none;
+		}
+	}
+
+	div.il-system-info-actions {
+		flex-grow: 0;
+		flex-shrink: 0;
+		flex-basis: 60px;
+		align-self: flex-end;
+		text-align: right;
+	}
+
+	&:not(:first-child) {
+		border-top: none;
+	}
+}
+
+/*
+**************************************************************
+	Mobile Layout for System Info
+**************************************************************
+*/
+
+@media only screen and (max-width: @grid-float-breakpoint-max) {
+	.il-system_info {
+		border-top: none;
+	}
+}

--- a/src/UI/templates/default/MainControls/tpl.system_info.html
+++ b/src/UI/templates/default/MainControls/tpl.system_info.html
@@ -1,4 +1,4 @@
-<div id="{ID}" class="container-fluid il-system-info il-system-info-{DENOTATION}" data-close-uri="{CLOSE_URI}">
+<div id="{ID}" class="container-fluid il-system-info il-system-info-{DENOTATION}" data-close-uri="{CLOSE_URI}" {ROLE} {LIVE} aria-labelledby="il-system-info-headline" aria-describedby="il-system-info-more">
 	<div class="il-system-info-content">
 		<span class="il-system-info-headline">{HEADLINE}</span>
 		<span class="il-system-info-more">{MORE_BUTTON}</span>

--- a/src/UI/templates/default/MainControls/tpl.system_info.html
+++ b/src/UI/templates/default/MainControls/tpl.system_info.html
@@ -1,0 +1,10 @@
+<div id="{ID}" class="container-fluid il-system-info il-system-info-{DENOTATION}" data-close-uri="{CLOSE_URI}">
+	<div class="il-system-info-content">
+		<span class="il-system-info-headline">{HEADLINE}</span>
+		<span class="il-system-info-more">{MORE_BUTTON}</span>
+		<span class="il-system-info-body">{BODY}</span>
+	</div>
+	<div class="il-system-info-actions">
+		<span class="il-system-info-close">{CLOSE_BUTTON}</span>
+	</div>
+</div>

--- a/src/UI/templates/js/MainControls/system_info.js
+++ b/src/UI/templates/js/MainControls/system_info.js
@@ -1,0 +1,54 @@
+$(document).ready(function () {
+
+});
+
+
+il = il || {};
+il.UI = il.UI || {};
+il.UI.maincontrols = il.UI.maincontrols || {};
+
+(function ($, maincontrols) {
+	maincontrols.system_info = (function ($) {
+		// alert($(this));
+		/**
+		 * decide and init condensed/wide version
+		 */
+		var init = function (id) {
+			let body = $('#' + id).find('.il-system-info-body');
+			let item_height = body.prop('scrollHeight');
+			let container = body.closest('.il-system-info');
+			let container_height = container.height() + 4;
+			if (item_height > container_height) {
+				let more_button = container.find('.il-system-info-more');
+				more_button.show();
+				more_button.click(function () {
+					container.toggleClass('full');
+					more_button.hide();
+				});
+			}
+			// });
+
+			// $('.il-system-info:not(:first-child)');
+		};
+
+		var close = function (id) {
+			let element = $('#' + id);
+			let close_uri = decodeURI(element.data('closeUri'));
+			$.ajax({
+				async: false,
+				type: 'GET',
+				url: close_uri,
+				success: function(data) {
+					element.slideUp(500);
+				}
+			});
+		};
+
+		return {
+			init: init,
+			close: close,
+		}
+
+	})($);
+})($, il.UI.maincontrols);
+

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -1320,7 +1320,7 @@ small,
 mark,
 .mark {
   background-color: #fcf8e3;
-  padding: 0.2em;
+  padding: .2em;
 }
 .text-left {
   text-align: left;
@@ -1623,125 +1623,20 @@ pre code {
   margin-left: -15px;
   margin-right: -15px;
 }
-.col-xs-1,
-.col-sm-1,
-.col-md-1,
-.col-lg-1,
-.col-xs-2,
-.col-sm-2,
-.col-md-2,
-.col-lg-2,
-.col-xs-3,
-.col-sm-3,
-.col-md-3,
-.col-lg-3,
-.col-xs-4,
-.col-sm-4,
-.col-md-4,
-.col-lg-4,
-.col-xs-5,
-.col-sm-5,
-.col-md-5,
-.col-lg-5,
-.col-xs-6,
-.col-sm-6,
-.col-md-6,
-.col-lg-6,
-.col-xs-7,
-.col-sm-7,
-.col-md-7,
-.col-lg-7,
-.col-xs-8,
-.col-sm-8,
-.col-md-8,
-.col-lg-8,
-.col-xs-9,
-.col-sm-9,
-.col-md-9,
-.col-lg-9,
-.col-xs-10,
-.col-sm-10,
-.col-md-10,
-.col-lg-10,
-.col-xs-11,
-.col-sm-11,
-.col-md-11,
-.col-lg-11,
-.col-xs-12,
-.col-sm-12,
-.col-md-12,
-.col-lg-12 {
+.col-xs-1, .col-sm-1, .col-md-1, .col-lg-1, .col-xs-2, .col-sm-2, .col-md-2, .col-lg-2, .col-xs-3, .col-sm-3, .col-md-3, .col-lg-3, .col-xs-4, .col-sm-4, .col-md-4, .col-lg-4, .col-xs-5, .col-sm-5, .col-md-5, .col-lg-5, .col-xs-6, .col-sm-6, .col-md-6, .col-lg-6, .col-xs-7, .col-sm-7, .col-md-7, .col-lg-7, .col-xs-8, .col-sm-8, .col-md-8, .col-lg-8, .col-xs-9, .col-sm-9, .col-md-9, .col-lg-9, .col-xs-10, .col-sm-10, .col-md-10, .col-lg-10, .col-xs-11, .col-sm-11, .col-md-11, .col-lg-11, .col-xs-12, .col-sm-12, .col-md-12, .col-lg-12 {
   position: relative;
   min-height: 1px;
   padding-left: 15px;
   padding-right: 15px;
 }
-.col-xs-1,
-.col-sm-1,
-.col-md-1,
-.col-lg-1,
-.col-xs-2,
-.col-sm-2,
-.col-md-2,
-.col-lg-2,
-.col-xs-3,
-.col-sm-3,
-.col-md-3,
-.col-lg-3,
-.col-xs-4,
-.col-sm-4,
-.col-md-4,
-.col-lg-4,
-.col-xs-5,
-.col-sm-5,
-.col-md-5,
-.col-lg-5,
-.col-xs-6,
-.col-sm-6,
-.col-md-6,
-.col-lg-6,
-.col-xs-7,
-.col-sm-7,
-.col-md-7,
-.col-lg-7,
-.col-xs-8,
-.col-sm-8,
-.col-md-8,
-.col-lg-8,
-.col-xs-9,
-.col-sm-9,
-.col-md-9,
-.col-lg-9,
-.col-xs-10,
-.col-sm-10,
-.col-md-10,
-.col-lg-10,
-.col-xs-11,
-.col-sm-11,
-.col-md-11,
-.col-lg-11,
-.col-xs-12,
-.col-sm-12,
-.col-md-12,
-.col-lg-12 {
+.col-xs-1, .col-sm-1, .col-md-1, .col-lg-1, .col-xs-2, .col-sm-2, .col-md-2, .col-lg-2, .col-xs-3, .col-sm-3, .col-md-3, .col-lg-3, .col-xs-4, .col-sm-4, .col-md-4, .col-lg-4, .col-xs-5, .col-sm-5, .col-md-5, .col-lg-5, .col-xs-6, .col-sm-6, .col-md-6, .col-lg-6, .col-xs-7, .col-sm-7, .col-md-7, .col-lg-7, .col-xs-8, .col-sm-8, .col-md-8, .col-lg-8, .col-xs-9, .col-sm-9, .col-md-9, .col-lg-9, .col-xs-10, .col-sm-10, .col-md-10, .col-lg-10, .col-xs-11, .col-sm-11, .col-md-11, .col-lg-11, .col-xs-12, .col-sm-12, .col-md-12, .col-lg-12 {
   position: relative;
   min-height: 1px;
   padding-left: 15px;
   padding-right: 15px;
   width: 100%;
 }
-.col-xs-1,
-.col-xs-2,
-.col-xs-3,
-.col-xs-4,
-.col-xs-5,
-.col-xs-6,
-.col-xs-7,
-.col-xs-8,
-.col-xs-9,
-.col-xs-10,
-.col-xs-11,
-.col-xs-12 {
+.col-xs-1, .col-xs-2, .col-xs-3, .col-xs-4, .col-xs-5, .col-xs-6, .col-xs-7, .col-xs-8, .col-xs-9, .col-xs-10, .col-xs-11, .col-xs-12 {
   float: left;
 }
 .col-xs-12 {
@@ -1898,18 +1793,7 @@ pre code {
   margin-left: 0%;
 }
 @media (min-width: 768px) {
-  .col-sm-1,
-  .col-sm-2,
-  .col-sm-3,
-  .col-sm-4,
-  .col-sm-5,
-  .col-sm-6,
-  .col-sm-7,
-  .col-sm-8,
-  .col-sm-9,
-  .col-sm-10,
-  .col-sm-11,
-  .col-sm-12 {
+  .col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12 {
     float: left;
   }
   .col-sm-12 {
@@ -2067,18 +1951,7 @@ pre code {
   }
 }
 @media (min-width: 992px) {
-  .col-md-1,
-  .col-md-2,
-  .col-md-3,
-  .col-md-4,
-  .col-md-5,
-  .col-md-6,
-  .col-md-7,
-  .col-md-8,
-  .col-md-9,
-  .col-md-10,
-  .col-md-11,
-  .col-md-12 {
+  .col-md-1, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9, .col-md-10, .col-md-11, .col-md-12 {
     float: left;
   }
   .col-md-12 {
@@ -2236,18 +2109,7 @@ pre code {
   }
 }
 @media (min-width: 1200px) {
-  .col-lg-1,
-  .col-lg-2,
-  .col-lg-3,
-  .col-lg-4,
-  .col-lg-5,
-  .col-lg-6,
-  .col-lg-7,
-  .col-lg-8,
-  .col-lg-9,
-  .col-lg-10,
-  .col-lg-11,
-  .col-lg-12 {
+  .col-lg-1, .col-lg-2, .col-lg-3, .col-lg-4, .col-lg-5, .col-lg-6, .col-lg-7, .col-lg-8, .col-lg-9, .col-lg-10, .col-lg-11, .col-lg-12 {
     float: left;
   }
   .col-lg-12 {
@@ -4993,7 +4855,7 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
 }
 .label {
   display: inline;
-  padding: 0.2em 0.6em 0.3em;
+  padding: .2em .6em .3em;
   font-size: 75%;
   font-weight: bold;
   line-height: 1;
@@ -5001,7 +4863,7 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
   text-align: center;
   white-space: nowrap;
   vertical-align: baseline;
-  border-radius: 0.25em;
+  border-radius: .25em;
 }
 a.label:hover,
 a.label:focus {
@@ -7883,10 +7745,10 @@ ul.dropdown-menu > li > .btn:focus {
   flex-direction: row;
   -ms-grid-column: 1;
   -ms-grid-column-span: 2;
-  -ms-grid-row: 2;
+  -ms-grid-row: 3;
   grid-column-start: 1;
   grid-column-end: 3;
-  grid-row: 2;
+  grid-row: 3;
   z-index: 998;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
@@ -8647,7 +8509,7 @@ fieldset[disabled] .il-table-presentation-viewcontrols .btn-default:not(.disable
 .il-workflow-container .not-available.in-progress .text span,
 .il-workflow-container .no-longer-available.in-progress .text span {
   color: #434343;
-  opacity: 0.5;
+  opacity: .5;
 }
 .il-workflow-container .not-available .text,
 .il-workflow-container .no-longer-available .text {
@@ -8892,8 +8754,8 @@ grid-based layout
   grid-gap: 0px;
   -ms-grid-columns: auto 1fr;
   grid-template-columns: auto 1fr;
-  -ms-grid-rows: 60px 33px auto 1fr;
-  grid-template-rows: 60px 33px auto 1fr;
+  -ms-grid-rows: 60px auto 33px 1fr;
+  grid-template-rows: 60px auto 33px 1fr;
   height: 100%;
   overflow: hidden;
   width: 100%;
@@ -8933,13 +8795,13 @@ header {
   grid-row: 1;
   z-index: 999;
 }
-div.il-head-infos {
+div.il-system-infos {
   -ms-grid-column: 1;
   -ms-grid-column-span: 2;
-  -ms-grid-row: 3;
+  -ms-grid-row: 2;
   grid-column-start: 1;
   grid-column-end: 3;
-  grid-row: 3;
+  grid-row: 2;
   z-index: 999;
 }
 .header-inner {
@@ -9154,13 +9016,6 @@ footer {
     grid-row: 1;
     z-index: 999;
   }
-  div.il-head-infos {
-    -ms-grid-column: 1;
-    -ms-grid-row: 2;
-    grid-column: 1;
-    grid-row: 2;
-    z-index: 999;
-  }
   .header-inner {
     height: 45px;
     padding: 0;
@@ -9276,9 +9131,9 @@ footer {
     display: block;
   }
   .il-layout-page-content {
-    -ms-grid-column: 1;
+    -ms-grid-column: 2;
     -ms-grid-row: 3;
-    grid-column: 1;
+    grid-column: 2;
     grid-row: 3;
     overflow: auto;
   }
@@ -10060,96 +9915,114 @@ footer {
     width: 100%;
   }
 }
-.il-head-info {
+/*
+**************************************************************
+	System Infos
+	change the rule for &.full to
+
+		height: 100%;
+		position: fixed;
+		padding: 100px;
+		top: 0;
+		left: 0;
+		font-size: 2em;
+		line-height: 1.2em;
+
+	to show a fullscreen info
+**************************************************************
+*/
+.il-system-info {
   width: 100%;
-  font-size: 1em;
-  line-height: 1.4em;
-  height: 2em;
-  padding-top: 0.3em;
-  padding-bottom: 0.3em;
+  line-height: 20px;
+  padding-top: 3px;
+  padding-bottom: 3px;
+  height: calc(26px);
+  z-index: 1;
   display: flex;
   flex-wrap: nowrap;
   flex-direction: row;
   justify-content: flex-start;
 }
-.il-head-info.il-head-info-neutral {
-  -webkit-box-shadow: inset 0 0 0px 0 #708bae;
-  -moz-box-shadow: inset 0 0 0px 0 #708bae;
-  box-shadow: inset 0 0 0px 0 #708bae;
-  background-color: #e2e8ef;
-  border: #708bae 1px solid;
-  color: #708bae;
+.il-system-info.il-system-info-neutral {
+  -webkit-box-shadow: inset 0px -10px 4px -10px rgba(0, 0, 0, 0.25);
+  -moz-box-shadow: inset 0px -10px 4px -10px rgba(0, 0, 0, 0.25);
+  box-shadow: inset 0px -10px 4px -10px rgba(0, 0, 0, 0.25);
+  background-color: #d2dae5;
+  border-top: #ddd none;
+  border-bottom: #ddd none;
+  border-left: #ddd none;
+  border-right: #ddd none;
+  color: #4c6586;
 }
-.il-head-info.il-head-info-neutral a.glyph {
-  color: #708bae !important;
+.il-system-info.il-system-info-neutral a.glyph {
+  color: #4c6586;
 }
-.il-head-info.il-head-info-important {
-  -webkit-box-shadow: inset 0 0 0px 0 #f9740f;
-  -moz-box-shadow: inset 0 0 0px 0 #f9740f;
-  box-shadow: inset 0 0 0px 0 #f9740f;
+.il-system-info.il-system-info-important {
+  -webkit-box-shadow: inset 0px -10px 4px -10px rgba(0, 0, 0, 0.25);
+  -moz-box-shadow: inset 0px -10px 4px -10px rgba(0, 0, 0, 0.25);
+  box-shadow: inset 0px -10px 4px -10px rgba(0, 0, 0, 0.25);
   background-color: #fdd9be;
-  border: #f9740f 1px solid;
-  color: #f9740f;
+  border-top: #ddd none;
+  border-bottom: #ddd none;
+  border-left: #ddd none;
+  border-right: #ddd none;
+  color: #d15c05;
 }
-.il-head-info.il-head-info-important a.glyph {
-  color: #f9740f !important;
+.il-system-info.il-system-info-important a.glyph {
+  color: #d15c05;
 }
-.il-head-info.il-head-info-breaking {
-  -webkit-box-shadow: inset 0 0 0px 0 #9f4604;
-  -moz-box-shadow: inset 0 0 0px 0 #9f4604;
-  box-shadow: inset 0 0 0px 0 #9f4604;
-  background-color: #fb9f5a;
-  border: #9f4604 1px solid;
-  color: #9f4604;
+.il-system-info.il-system-info-breaking {
+  -webkit-box-shadow: inset 0px -10px 4px -10px rgba(0, 0, 0, 0.25);
+  -moz-box-shadow: inset 0px -10px 4px -10px rgba(0, 0, 0, 0.25);
+  box-shadow: inset 0px -10px 4px -10px rgba(0, 0, 0, 0.25);
+  background-color: #ec675e;
+  border-top: #ddd none;
+  border-bottom: #ddd none;
+  border-left: #ddd none;
+  border-right: #ddd none;
+  color: #ffffff;
 }
-.il-head-info.il-head-info-breaking a.glyph {
-  color: #9f4604 !important;
+.il-system-info.il-system-info-breaking a.glyph {
+  color: #ffffff;
 }
-.il-head-info.full {
+.il-system-info.full {
   height: auto;
 }
-.il-head-info div.il-head-info-content {
+.il-system-info div.il-system-info-content {
   flex-grow: 4;
   flex-shrink: 1;
   flex-basis: auto;
   overflow-y: hidden;
-  text-overflow: clip;
 }
-.il-head-info div.il-head-info-content span {
+.il-system-info div.il-system-info-content span {
   display: inline-block;
 }
-.il-head-info div.il-head-info-content span.il-head-info-headline {
+.il-system-info div.il-system-info-content span.il-system-info-headline {
   text-transform: uppercase;
   font-weight: bold;
-  margin-right: 1em;
+  margin-right: 8px;
 }
-.il-head-info div.il-head-info-content span.il-head_info-more {
+.il-system-info div.il-system-info-content span.il-system-info-more {
   display: none;
 }
-.il-head-info div.il-head-info-actions {
+.il-system-info div.il-system-info-actions {
   flex-grow: 0;
   flex-shrink: 0;
   flex-basis: 60px;
   align-self: flex-end;
+  text-align: right;
 }
-.il-head-info div.il-head-info-actions span.il-head_info-close,
-.il-head-info div.il-head-info-actions span.il-head_info-more {
-  float: right;
-}
-.il-head-info:not(:first-child) {
+.il-system-info:not(:first-child) {
   border-top: none;
 }
 /*
 **************************************************************
-       mobile Layout
+	Mobile Layout for System Info
 **************************************************************
 */
 @media only screen and (max-width: 768px) {
-  .il-head_info {
+  .il-system_info {
     border-top: none;
-  }
-  .il-head_info p {
-    display: none;
   }
 }
 .il-drilldown ul {
@@ -11253,10 +11126,10 @@ footer {
 .il-avatar.il-avatar-letter span.abbreviation {
   font-weight: lighter;
   text-transform: inherit;
-  font-size: calc(41px / 2);
+  font-size: calc(20.5px);
   line-height: 1;
   position: relative;
-  top: calc(41px / 4);
+  top: calc(10.25px);
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-1 {
   background-color: #1abc9c;
@@ -11400,8 +11273,8 @@ footer {
     width: 22.5px;
   }
   .il-avatar.il-avatar-letter span.abbreviation {
-    font-size: calc(22.5px / 2);
-    top: calc(22.5px / 4);
+    font-size: calc(11.25px);
+    top: calc(5.625px);
   }
 }
 .il-link:focus {
@@ -11447,6 +11320,12 @@ footer {
 /* @il-highlight-bg: lighten(@brand-secondary, 44%); */
 /* @il-highlight-bg: lighten(#21c5d8, 40%); */
 /* @nav-tabs-link-hover-border-color: @brand-primary; */
+/** headline text transform **/
+/** inline shadow of a message container **/
+/** border configuration, the color is automatically computed from the three color variants **/
+/** nagtive or positive contrast color for text and glyph **/
+/** contrast threshold for contrast color **/
+/** three color variants for neutral, important, breaking Head Infos **/
 .webui-popover-content {
   display: none;
 }
@@ -12460,7 +12339,7 @@ div.ilFrame {
 ul,
 ol,
 p {
-  margin: 0.8em 0;
+  margin: .8em 0;
 }
 ol,
 ul {
@@ -12482,7 +12361,7 @@ ol ol {
 small,
 sub,
 sup {
-  font-size: 0.8em;
+  font-size: .8em;
 }
 em,
 i {
@@ -12521,7 +12400,7 @@ a:hover {
   text-decoration: underline;
 }
 hr {
-  margin-bottom: 0.8em;
+  margin-bottom: .8em;
   border: none;
   border-top: 1px solid #ddd;
 }
@@ -16286,7 +16165,7 @@ table.ilSkill {
 }
 td.ilSkill,
 th.ilSkill {
-  font-size: 0.8em;
+  font-size: .8em;
   padding: 4px;
   min-width: 50px;
 }
@@ -18425,7 +18304,7 @@ body.ilPrtfPdfBody .ilPCMyCoursesToggle img {
   cursor: pointer;
 }
 [data-onscreenchat-inact-userid] {
-  opacity: 0.3 !important;
+  opacity: .3 !important;
 }
 .ilOnScreenChatWindowHeaderTooltip ul {
   text-align: left;
@@ -18504,7 +18383,7 @@ body.ilPrtfPdfBody .ilPCMyCoursesToggle img {
   z-index: 0;
   border: 0 none !important;
   background-color: transparent;
-  opacity: 0.5;
+  opacity: .5;
 }
 #onscreenchat-container .chat-window-wrapper .iosOnScreenChatMessageContainer .iosOnScreenChatMessage {
   background-color: transparent;
@@ -18581,7 +18460,7 @@ body.ilPrtfPdfBody .ilPCMyCoursesToggle img {
   background-color: #f5f5f5;
 }
 #onscreenchat-container .chat-window-wrapper .chat li.separator p {
-  font-size: 0.9em;
+  font-size: .9em;
 }
 #onscreenchat-container .chat-window-wrapper .chat li.header,
 #onscreenchat-container .chat-window-wrapper .chat li.message {
@@ -18598,12 +18477,12 @@ body.ilPrtfPdfBody .ilPCMyCoursesToggle img {
   width: 85%;
 }
 #onscreenchat-container .chat-window-wrapper .chat li .chat-body .header strong {
-  font-size: 0.8em;
+  font-size: .8em;
 }
 #onscreenchat-container .chat-window-wrapper .chat li .chat-body p {
   margin: 0;
   color: #777;
-  font-size: 0.9em;
+  font-size: .9em;
 }
 #onscreenchat-container .chat-window-wrapper .panel {
   pointer-events: auto;
@@ -19044,7 +18923,7 @@ span.ilProfileBadge .modal .img-responsive {
   width: 54px;
 }
 .bootstrap-datetimepicker-widget table td.cw {
-  font-size: 0.8em;
+  font-size: .8em;
   height: 20px;
   line-height: 20px;
   color: #777777;
@@ -19588,7 +19467,7 @@ table.mceToolbar td {
   opacity: 0;
   max-height: 0;
   font-size: 0;
-  transition: 0.25s ease;
+  transition: .25s ease;
 }
 .read-more-state:checked ~ .read-more-wrap .read-more-target {
   opacity: 1;
@@ -19604,10 +19483,10 @@ table.mceToolbar td {
 .read-more-trigger {
   cursor: pointer;
   display: inline-block;
-  padding: 0 0.5em;
+  padding: 0 .5em;
   color: #666;
-  font-size: 0.9em;
+  font-size: .9em;
   line-height: 2;
   border: 1px solid #ddd;
-  border-radius: 0.25em;
+  border-radius: .25em;
 }

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -8892,8 +8892,8 @@ grid-based layout
   grid-gap: 0px;
   -ms-grid-columns: auto 1fr;
   grid-template-columns: auto 1fr;
-  -ms-grid-rows: 60px 33px 1fr;
-  grid-template-rows: 60px 33px 1fr;
+  -ms-grid-rows: 60px 33px auto 1fr;
+  grid-template-rows: 60px 33px auto 1fr;
   height: 100%;
   overflow: hidden;
   width: 100%;
@@ -8933,6 +8933,15 @@ header {
   grid-row: 1;
   z-index: 999;
 }
+div.il-head-infos {
+  -ms-grid-column: 1;
+  -ms-grid-column-span: 2;
+  -ms-grid-row: 3;
+  grid-column-start: 1;
+  grid-column-end: 3;
+  grid-row: 3;
+  z-index: 999;
+}
 .header-inner {
   -ms-flex-align: center;
   align-items: center;
@@ -8964,9 +8973,9 @@ header {
 }
 nav.il-maincontrols {
   -ms-grid-column: 1;
-  -ms-grid-row: 3;
+  -ms-grid-row: 4;
   grid-column: 1;
-  grid-row: 3;
+  grid-row: 4;
   z-index: 997;
 }
 .il-maincontrols-mainbar {
@@ -9024,9 +9033,9 @@ main {
   -ms-grid-rows: 1fr auto;
   grid-template-rows: 1fr auto;
   -ms-grid-column: 2;
-  -ms-grid-row: 3;
+  -ms-grid-row: 4;
   grid-column: 2;
-  grid-row: 3;
+  grid-row: 4;
   overflow: auto;
 }
 /* Footer */
@@ -9069,8 +9078,8 @@ footer {
     grid-gap: 0px;
     -ms-grid-columns: 1fr;
     grid-template-columns: 1fr;
-    -ms-grid-rows: 45px 1fr;
-    grid-template-rows: 45px 1fr;
+    -ms-grid-rows: 45px auto 1fr;
+    grid-template-rows: 45px auto 1fr;
     height: 100%;
     overflow: hidden;
     width: 100%;
@@ -9105,9 +9114,9 @@ footer {
   }
   .il-layout-page.with-mainbar-slates-engaged .nav.il-maincontrols {
     -ms-grid-column: 1;
-    -ms-grid-row: 2;
+    -ms-grid-row: 3;
     grid-column: 1;
-    grid-row: 2;
+    grid-row: 3;
     height: 100%;
   }
   .il-layout-page.with-mainbar-slates-engaged .nav.il-maincontrols .il-maincontrols-mainbar {
@@ -9143,6 +9152,13 @@ footer {
     -ms-grid-row: 1;
     grid-column: 1;
     grid-row: 1;
+    z-index: 999;
+  }
+  div.il-head-infos {
+    -ms-grid-column: 1;
+    -ms-grid-row: 2;
+    grid-column: 1;
+    grid-row: 2;
     z-index: 999;
   }
   .header-inner {
@@ -9261,9 +9277,9 @@ footer {
   }
   .il-layout-page-content {
     -ms-grid-column: 1;
-    -ms-grid-row: 2;
+    -ms-grid-row: 3;
     grid-column: 1;
-    grid-row: 2;
+    grid-row: 3;
     overflow: auto;
   }
 }
@@ -10042,6 +10058,98 @@ footer {
   span.il-mode-info-content {
     display: block;
     width: 100%;
+  }
+}
+.il-head-info {
+  width: 100%;
+  font-size: 1em;
+  line-height: 1.4em;
+  height: 2em;
+  padding-top: 0.3em;
+  padding-bottom: 0.3em;
+  display: flex;
+  flex-wrap: nowrap;
+  flex-direction: row;
+  justify-content: flex-start;
+}
+.il-head-info.il-head-info-neutral {
+  -webkit-box-shadow: inset 0 0 0px 0 #708bae;
+  -moz-box-shadow: inset 0 0 0px 0 #708bae;
+  box-shadow: inset 0 0 0px 0 #708bae;
+  background-color: #e2e8ef;
+  border: #708bae 1px solid;
+  color: #708bae;
+}
+.il-head-info.il-head-info-neutral a.glyph {
+  color: #708bae !important;
+}
+.il-head-info.il-head-info-important {
+  -webkit-box-shadow: inset 0 0 0px 0 #f9740f;
+  -moz-box-shadow: inset 0 0 0px 0 #f9740f;
+  box-shadow: inset 0 0 0px 0 #f9740f;
+  background-color: #fdd9be;
+  border: #f9740f 1px solid;
+  color: #f9740f;
+}
+.il-head-info.il-head-info-important a.glyph {
+  color: #f9740f !important;
+}
+.il-head-info.il-head-info-breaking {
+  -webkit-box-shadow: inset 0 0 0px 0 #9f4604;
+  -moz-box-shadow: inset 0 0 0px 0 #9f4604;
+  box-shadow: inset 0 0 0px 0 #9f4604;
+  background-color: #fb9f5a;
+  border: #9f4604 1px solid;
+  color: #9f4604;
+}
+.il-head-info.il-head-info-breaking a.glyph {
+  color: #9f4604 !important;
+}
+.il-head-info.full {
+  height: auto;
+}
+.il-head-info div.il-head-info-content {
+  flex-grow: 4;
+  flex-shrink: 1;
+  flex-basis: auto;
+  overflow-y: hidden;
+  text-overflow: clip;
+}
+.il-head-info div.il-head-info-content span {
+  display: inline-block;
+}
+.il-head-info div.il-head-info-content span.il-head-info-headline {
+  text-transform: uppercase;
+  font-weight: bold;
+  margin-right: 1em;
+}
+.il-head-info div.il-head-info-content span.il-head_info-more {
+  display: none;
+}
+.il-head-info div.il-head-info-actions {
+  flex-grow: 0;
+  flex-shrink: 0;
+  flex-basis: 60px;
+  align-self: flex-end;
+}
+.il-head-info div.il-head-info-actions span.il-head_info-close,
+.il-head-info div.il-head-info-actions span.il-head_info-more {
+  float: right;
+}
+.il-head-info:not(:first-child) {
+  border-top: none;
+}
+/*
+**************************************************************
+       mobile Layout
+**************************************************************
+*/
+@media only screen and (max-width: 768px) {
+  .il-head_info {
+    border-top: none;
+  }
+  .il-head_info p {
+    display: none;
   }
 }
 .il-drilldown ul {

--- a/templates/default/less/variables.less
+++ b/templates/default/less/variables.less
@@ -831,6 +831,27 @@
 @avatar-letter-color-variants: #1abc9c, #16a085, #f1c40f, #f39c12, #2ecc71, #27ae60, #e67e22, #d35400, #3498db, #2980b9, #e74c3c, #c0392b, #9b59b6, #8e44ad, #bdc3c7, #34495e, #2c3e50, #95a5a6, #7f8c8d, #ec87bf, #d870ad, #f69785, #9ba37e, #b49255, #b49255, #a94136;
 
 
+//== System Info
+//
+//##
+/** headline text transform **/
+@il-standard-page-system-info-headline-transform: uppercase;
+@il-standard-page-system-info-headline-font-weight: bold;
+/** inline shadow of a message container **/
+@il-standard-page-system-info-shadow: inset 0px -10px 4px -10px rgba(0, 0, 0, 0.25);
+/** border configuration, the color is automatically computed from the three color variants **/
+@il-standard-page-system-info-border-color: #ddd;
+@il-standard-page-system-info-border-top-and-bottom: none;
+@il-standard-page-system-info-border-left-and-right: none;
+/** nagtive or positive contrast color for text and glyph **/
+@il-standard-page-system-info-contrast: 45%;
+/** contrast threshold for contrast color **/
+@il-standard-page-system-info-contrast-threshold: 43%;
+/** three color variants for neutral, important, breaking Head Infos **/
+@il-standard-page-system-info-color-variant-neutral: lighten(@brand-primary, 45%); // looks nice with @il-mainbar-btn-bg-color as well
+@il-standard-page-system-info-color-variant-important: lighten(@brand-danger, 30%);
+@il-standard-page-system-info-color-variant-breaking: rgb(236, 103, 94);
+
 //== View Control
 //
 //##

--- a/tests/UI/Component/MainControls/SystemInfoTest.php
+++ b/tests/UI/Component/MainControls/SystemInfoTest.php
@@ -1,0 +1,150 @@
+<?php
+
+use ILIAS\Data\URI;
+use ILIAS\UI\Implementation\Component\MainControls\SystemInfo;
+use ILIAS\UI\Implementation\Component\SignalGenerator;
+use ILIAS\UI\Implementation\Component\Symbol\Factory;
+use ILIAS\UI\Implementation\Render\JavaScriptBinding;
+
+require_once("libs/composer/vendor/autoload.php");
+require_once(__DIR__ . "/../../Base.php");
+
+/**
+ * Class SystemInfoTest
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+class SystemInfoTest extends ILIAS_UI_TestBase
+{
+
+    /**
+     * @var SignalGenerator
+     */
+    private $sig_gen;
+
+    public function setUp() : void
+    {
+        parent::setUp();
+        $this->sig_gen = new SignalGenerator();
+    }
+
+    public function testRendering()
+    {
+        $headline    = 'That\'s one small step for [a] man';
+        $information = 'Lorem IPsum dolor sit amet';
+        $r           = $this->getDefaultRenderer();
+        $system_info = new SystemInfo($this->sig_gen, $headline, $information);
+
+        // Neutral
+        $expected = <<<EOT
+		<div id="id" class="container-fluid il-system-info il-system-info-neutral" data-close-uri=""><div class="il-system-info-content"><span class="il-system-info-headline">$headline</span><span class="il-system-info-more"><a class="glyph" href="#" aria-label="show_more"><span class="glyphicon glyphicon-option-horizontal" aria-hidden="true"></span></a></span><span class="il-system-info-body">$information</span></div><div class="il-system-info-actions"><span class="il-system-info-close"></span></div></div>
+EOT;
+        $actual   = $r->render($system_info);
+
+        $this->assertEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($actual)
+        );
+
+        // Neutral explicit
+        $system_info = $system_info->withDenotation(SystemInfo::DENOTATION_NEUTRAL);
+        $actual      = $r->render($system_info);
+        $this->assertEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($actual)
+        );
+
+        // Important
+        $system_info = $system_info->withDenotation(SystemInfo::DENOTATION_IMPORTANT);
+        $actual      = $r->render($system_info);
+        $expected    = <<<EOT
+		<div id="id" class="container-fluid il-system-info il-system-info-important" data-close-uri=""><div class="il-system-info-content"><span class="il-system-info-headline">$headline</span><span class="il-system-info-more"><a class="glyph" href="#" aria-label="show_more"><span class="glyphicon glyphicon-option-horizontal" aria-hidden="true"></span></a></span><span class="il-system-info-body">$information</span></div><div class="il-system-info-actions"><span class="il-system-info-close"></span></div></div>
+EOT;
+        $this->assertEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($actual)
+        );
+
+        // Breaking
+        $system_info = $system_info->withDenotation(SystemInfo::DENOTATION_BREAKING);
+        $actual      = $r->render($system_info);
+        $expected    = <<<EOT
+	<div id="id" class="container-fluid il-system-info il-system-info-breaking" data-close-uri=""><div class="il-system-info-content"><span class="il-system-info-headline">$headline</span><span class="il-system-info-more"><a class="glyph" href="#" aria-label="show_more"><span class="glyphicon glyphicon-option-horizontal" aria-hidden="true"></span></a></span><span class="il-system-info-body">$information</span></div><div class="il-system-info-actions"><span class="il-system-info-close"></span></div></div>
+EOT;
+        $this->assertEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($actual)
+        );
+
+        // Close Action
+        $uri_string  = 'http://one_giant_leap?for=mankind';
+        $action      = new URI($uri_string);
+        $system_info = $system_info->withIsDismissable(true)->withDismissAction($action)->withDenotation(SystemInfo::DENOTATION_NEUTRAL);
+        $actual      = $r->render($system_info);
+        $expected    = <<<EOT
+<div id="id" class="container-fluid il-system-info il-system-info-neutral" data-close-uri="$uri_string"><div class="il-system-info-content"><span class="il-system-info-headline">$headline</span><span class="il-system-info-more"><a class="glyph" href="#" aria-label="show_more"><span class="glyphicon glyphicon-option-horizontal" aria-hidden="true"></span></a></span><span class="il-system-info-body">$information</span></div><div class="il-system-info-actions"><span class="il-system-info-close"><a class="glyph" href="#" aria-label="close" id="id"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a></span></div></div>
+EOT;
+        $this->assertEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($actual)
+        );
+    }
+
+    public function getDefaultRenderer(JavaScriptBinding $js_binding = null)
+    {
+        return parent::getDefaultRenderer(new class implements \ILIAS\UI\Implementation\Render\JavaScriptBinding {
+            public function createId()
+            {
+                return "id";
+            }
+
+            public $on_load_code = array();
+
+            public function addOnLoadCode($code)
+            {
+                $this->on_load_code[] = $code;
+            }
+
+            public function getOnLoadCodeAsync()
+            {
+            }
+        });
+    }
+
+    public function getUIFactory()
+    {
+        $factory          = new class() extends NoUIFactory {
+
+            /**
+             * @inheritDoc
+             */
+            public function __construct()
+            {
+                $this->sig_gen = new SignalGenerator();
+            }
+
+            public function symbol() : ILIAS\UI\Component\Symbol\Factory
+            {
+                return new Factory(
+                    new \ILIAS\UI\Implementation\Component\Symbol\Icon\Factory(),
+                    new \ILIAS\UI\Implementation\Component\Symbol\Glyph\Factory(),
+                    new \ILIAS\UI\Implementation\Component\Symbol\Avatar\Factory()
+                );
+            }
+
+            public function mainControls() : \ILIAS\UI\Component\MainControls\Factory
+            {
+                return new \ILIAS\UI\Implementation\Component\MainControls\Factory(
+                    $this->sig_gen,
+                    new \ILIAS\UI\Implementation\Component\MainControls\Slate\Factory(
+                        $this->sig_gen,
+                        new \ILIAS\UI\Implementation\Component\Counter\Factory(),
+                        $this->symbol()
+                    )
+                );
+            }
+        };
+        $factory->sig_gen = $this->sig_gen;
+
+        return $factory;
+    }
+}

--- a/tests/UI/Component/MainControls/SystemInfoTest.php
+++ b/tests/UI/Component/MainControls/SystemInfoTest.php
@@ -36,7 +36,7 @@ class SystemInfoTest extends ILIAS_UI_TestBase
 
         // Neutral
         $expected = <<<EOT
-		<div id="id" class="container-fluid il-system-info il-system-info-neutral" data-close-uri=""><div class="il-system-info-content"><span class="il-system-info-headline">$headline</span><span class="il-system-info-more"><a class="glyph" href="#" aria-label="show_more"><span class="glyphicon glyphicon-option-horizontal" aria-hidden="true"></span></a></span><span class="il-system-info-body">$information</span></div><div class="il-system-info-actions"><span class="il-system-info-close"></span></div></div>
+		<div id="id" class="container-fluid il-system-info il-system-info-neutral" data-close-uri="" aria-live="polite" aria-labelledby="il-system-info-headline" aria-describedby="il-system-info-more"><div class="il-system-info-content"><span class="il-system-info-headline">$headline</span><span class="il-system-info-more"><a class="glyph" href="#" aria-label="show_more"><span class="glyphicon glyphicon-option-horizontal" aria-hidden="true"></span></a></span><span class="il-system-info-body">$information</span></div><div class="il-system-info-actions"><span class="il-system-info-close"></span></div></div>
 EOT;
         $actual   = $r->render($system_info);
 
@@ -57,7 +57,7 @@ EOT;
         $system_info = $system_info->withDenotation(SystemInfo::DENOTATION_IMPORTANT);
         $actual      = $r->render($system_info);
         $expected    = <<<EOT
-		<div id="id" class="container-fluid il-system-info il-system-info-important" data-close-uri=""><div class="il-system-info-content"><span class="il-system-info-headline">$headline</span><span class="il-system-info-more"><a class="glyph" href="#" aria-label="show_more"><span class="glyphicon glyphicon-option-horizontal" aria-hidden="true"></span></a></span><span class="il-system-info-body">$information</span></div><div class="il-system-info-actions"><span class="il-system-info-close"></span></div></div>
+		<div id="id" class="container-fluid il-system-info il-system-info-important" data-close-uri="" aria-live="polite" aria-labelledby="il-system-info-headline" aria-describedby="il-system-info-more"><div class="il-system-info-content"><span class="il-system-info-headline">$headline</span><span class="il-system-info-more"><a class="glyph" href="#" aria-label="show_more"><span class="glyphicon glyphicon-option-horizontal" aria-hidden="true"></span></a></span><span class="il-system-info-body">$information</span></div><div class="il-system-info-actions"><span class="il-system-info-close"></span></div></div>
 EOT;
         $this->assertEquals(
             $this->brutallyTrimHTML($expected),
@@ -68,7 +68,7 @@ EOT;
         $system_info = $system_info->withDenotation(SystemInfo::DENOTATION_BREAKING);
         $actual      = $r->render($system_info);
         $expected    = <<<EOT
-	<div id="id" class="container-fluid il-system-info il-system-info-breaking" data-close-uri=""><div class="il-system-info-content"><span class="il-system-info-headline">$headline</span><span class="il-system-info-more"><a class="glyph" href="#" aria-label="show_more"><span class="glyphicon glyphicon-option-horizontal" aria-hidden="true"></span></a></span><span class="il-system-info-body">$information</span></div><div class="il-system-info-actions"><span class="il-system-info-close"></span></div></div>
+	<div id="id" class="container-fluid il-system-info il-system-info-breaking" data-close-uri="" role="alert" aria-labelledby="il-system-info-headline" aria-describedby="il-system-info-more"><div class="il-system-info-content"><span class="il-system-info-headline">$headline</span><span class="il-system-info-more"><a class="glyph" href="#" aria-label="show_more"><span class="glyphicon glyphicon-option-horizontal" aria-hidden="true"></span></a></span><span class="il-system-info-body">$information</span></div><div class="il-system-info-actions"><span class="il-system-info-close"></span></div></div>
 EOT;
         $this->assertEquals(
             $this->brutallyTrimHTML($expected),
@@ -81,7 +81,7 @@ EOT;
         $system_info = $system_info->withIsDismissable(true)->withDismissAction($action)->withDenotation(SystemInfo::DENOTATION_NEUTRAL);
         $actual      = $r->render($system_info);
         $expected    = <<<EOT
-<div id="id" class="container-fluid il-system-info il-system-info-neutral" data-close-uri="$uri_string"><div class="il-system-info-content"><span class="il-system-info-headline">$headline</span><span class="il-system-info-more"><a class="glyph" href="#" aria-label="show_more"><span class="glyphicon glyphicon-option-horizontal" aria-hidden="true"></span></a></span><span class="il-system-info-body">$information</span></div><div class="il-system-info-actions"><span class="il-system-info-close"><a class="glyph" href="#" aria-label="close" id="id"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a></span></div></div>
+<div id="id" class="container-fluid il-system-info il-system-info-neutral" data-close-uri="$uri_string" aria-live="polite" aria-labelledby="il-system-info-headline" aria-describedby="il-system-info-more"><div class="il-system-info-content"><span class="il-system-info-headline">$headline</span><span class="il-system-info-more"><a class="glyph" href="#" aria-label="show_more"><span class="glyphicon glyphicon-option-horizontal" aria-hidden="true"></span></a></span><span class="il-system-info-body">$information</span></div><div class="il-system-info-actions"><span class="il-system-info-close"><a class="glyph" href="#" aria-label="close" id="id"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a></span></div></div>
 EOT;
         $this->assertEquals(
             $this->brutallyTrimHTML($expected),


### PR DESCRIPTION
This pull request suggests the announced UI component "Head Info".

A "Head Info" is currently being developed for the feature "Introduction of Administrative Notification", see https://docu.ilias.de/goto_docu_wiki_wpage_6359_1357.html

Summary:
- The rules can be found at https://github.com/ILIAS-eLearning/ILIAS/compare/trunk...studer-raimann:feature/7/ui-head-info-interfaces#diff-c8e66b8889d5aadf79a14acee5586c8c204a4629ed1a79f457dcba7dc3c91eb5R375
- New read variables can be found at https://github.com/ILIAS-eLearning/ILIAS/compare/trunk...studer-raimann:feature/7/ui-head-info-interfaces#diff-c8e66b8889d5aadf79a14acee5586c8c204a4629ed1a79f457dcba7dc3c91eb5R375
- Several adjustments to the standard page are needed, because the Head Infos are added in the upper part of the page. This PR contains the adjustments to the interface, less and the HTML file

If you want to see more or less, I can adapt the PR. An implementation is already done, so here are some screenshots. I would be happy to receive your feedback and work it into this PR.
