### PR TITLE
Auth/Session: Fix Mantis issue 28305

### DIFF
--- a/Services/Authentication/classes/class.ilSessionDBHandler.php
+++ b/Services/Authentication/classes/class.ilSessionDBHandler.php
@@ -20,6 +20,10 @@ class ilSessionDBHandler
     public function setSaveHandler()
     {
         // register save handler functions
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            return true;
+        }
+
         if (ini_get("session.save_handler") == "user" || version_compare(PHP_VERSION, '7.2.0', '>=')) {
             session_set_save_handler(
                 array($this, "open"),


### PR DESCRIPTION
This PR fixes Mantis issue https://mantis.ilias.de/view.php?id=28305 . If a session is already active, `session_set_save_handler` MUST NOT be changed again.