### PR TITLE
UI Components, Close Button: Fixing #28950

### DIFF
--- a/src/UI/Implementation/Component/Button/Renderer.php
+++ b/src/UI/Implementation/Component/Button/Renderer.php
@@ -142,6 +142,7 @@ class Renderer extends AbstractComponentRenderer
         // This is required as the rendering seems to only create any output at all
         // if any var was set or block was touched.
         $tpl->setVariable("FORCE_RENDERING", "");
+        $tpl->setVariable("ARIA_LABEL", $this->txt("close"));
         $this->maybeRenderId($component, $tpl);
         return $tpl->get();
     }

--- a/src/UI/templates/default/Button/tpl.close.html
+++ b/src/UI/templates/default/Button/tpl.close.html
@@ -1,4 +1,3 @@
-<button type="button" class="close" data-dismiss="modal"<!-- BEGIN with_id --> id="{ID}"<!-- END with_id -->{FORCE_RENDERING}>
+<button type="button" class="close" aria-label="{ARIA_LABEL}"<!-- BEGIN with_id --> id="{ID}"<!-- END with_id -->{FORCE_RENDERING}>
 	<span aria-hidden="true">&times;</span>
-	<span class="sr-only">Close</span>
 </button>

--- a/tests/UI/Component/Button/ButtonTest.php
+++ b/tests/UI/Component/Button/ButtonTest.php
@@ -193,9 +193,8 @@ class ButtonTest extends ILIAS_UI_TestBase
 
         $html = $this->normalizeHTML($r->render($b));
 
-        $expected = "<button type=\"button\" class=\"close\" data-dismiss=\"modal\">" .
+        $expected = "<button type=\"button\" class=\"close\" aria-label=\"close\">" .
                     "	<span aria-hidden=\"true\">&times;</span>" .
-                    "	<span class=\"sr-only\">Close</span>" .
                     "</button>";
         $this->assertEquals($expected, $html);
     }
@@ -243,9 +242,8 @@ class ButtonTest extends ILIAS_UI_TestBase
         $this->assertCount(1, $ids);
 
         $id = $ids[0];
-        $expected = "<button type=\"button\" class=\"close\" data-dismiss=\"modal\" id=\"$id\">" .
+        $expected = "<button type=\"button\" class=\"close\" aria-label=\"close\" id=\"$id\">" .
                     "	<span aria-hidden=\"true\">&times;</span>" .
-                    "	<span class=\"sr-only\">Close</span>" .
                     "</button>";
         $this->assertEquals($expected, $html);
     }

--- a/tests/UI/Component/Dropzone/File/DropzoneRendererTest.php
+++ b/tests/UI/Component/Dropzone/File/DropzoneRendererTest.php
@@ -42,12 +42,65 @@ class DropzoneRendererTest extends ILIAS_UI_TestBase
     {
 
         // setup expected objects
-        $expectedHtml = '<div id="id_1" class="il-dropzone-base"><div class="clearfix hidden-sm-up"></div><div class="il-upload-file-list" ><div class="container-fluid il-upload-file-items"><div class="error-messages" style="display: none;"><div class="alert alert-danger" role="alert"><!-- General error messages are inserted here with javascript --></div></div><!-- rows from templates are cloned here with javascript --></div><!-- Templates --><div class="container-fluid" ><!-- hidden Template --><div class="il-upload-file-item il-upload-file-item-template clearfix row standard hidden"><div class="col-xs-12 col-no-padding"><!-- Display Filename--><span class="file-info filename">FILENAME<!-- File name is inserted with javascript here --></span><!-- Display Filesize--><span class="file-info filesize">100KB<!-- File size is inserted with javascript here --></span><!-- Dropdown with actions--><span class="pull-right remove"><!--<div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"  aria-label="actions" aria-haspopup="true" aria-expanded="false" > <span class="caret"></span></button><ul class="dropdown-menu"><li><button class="btn btn-link" aria-label="delete_file" data-action="">remove</button></li></ul></div>--><button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button></span><!-- Progress Bar--><div class="progress" style="margin: 10px 0; display: none;"><div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="0"aria-valuemin="0"aria-valuemax="100"></div></div><!-- Error Messages --><div class="file-error-message alert alert-danger" role="alert" style="display: none;"><!-- Error message for file is inserted with javascript here --></div><div class="file-success-message alert alert-success" role="alert" style="display: none;"><!-- Success message for file is inserted with javascript here --></div></div></div><!-- li from templates are cloned here with javascript --></div></div><div class="container-fluid"><div class="il-dropzone standard clearfix row" data-upload-id="id_1"><div class="col-xs-12 col-md-3 col-sm-12 col-lg-3 dz-default dz-message il-dropzone-standard-select-files-wrapper "> <!--col-no-padding--><a href="#" >select_files_from_computer</a></div><div class="col-xs-12 col-md-9 col-sm-12 col-lg-9 col-no-padding"><span class="pull-right dz-default dz-message">drag_files_here</span></div></div><div class="clearfix hidden-sm-up"></div></div></div>';
+        $expectedHtml = $this->brutallyTrimHTML('
+<div id="id_1" class="il-dropzone-base">
+   <div class="clearfix hidden-sm-up"></div>
+   <div class="il-upload-file-list" >
+      <div class="container-fluid il-upload-file-items">
+         <div class="error-messages" style="display: none;">
+            <div class="alert alert-danger" role="alert">
+               <!-- General error messages are inserted here with javascript -->
+            </div>
+         </div>
+         <!-- rows from templates are cloned here with javascript -->
+      </div>
+      <!-- Templates -->
+      <div class="container-fluid" >
+         <!-- hidden Template -->
+         <div class="il-upload-file-item il-upload-file-item-template clearfix row standard hidden">
+            <div class="col-xs-12 col-no-padding">
+               <!-- Display Filename-->
+               <span class="file-info filename">FILENAME<!-- File name is inserted with javascript here -->
+               </span>
+               <!-- Display Filesize-->
+               <span class="file-info filesize">100KB<!-- File size is inserted with javascript here -->
+               </span>
+               <!-- Dropdown with actions-->
+               <span class="pull-right remove">
+                  <!--<div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"  aria-label="actions" aria-haspopup="true" aria-expanded="false" > <span class="caret"></span></button><ul class="dropdown-menu"><li><button class="btn btn-link" aria-label="delete_file" data-action="">remove</button></li></ul></div>-->
+                  <button type="button" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button>
+               </span>
+               <!-- Progress Bar-->
+               <div class="progress" style="margin: 10px 0; display: none;">
+                  <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="0"aria-valuemin="0"aria-valuemax="100"></div>
+               </div>
+               <!-- Error Messages -->
+               <div class="file-error-message alert alert-danger" role="alert" style="display: none;">
+                  <!-- Error message for file is inserted with javascript here -->
+               </div>
+               <div class="file-success-message alert alert-success" role="alert" style="display: none;">
+                  <!-- Success message for file is inserted with javascript here -->
+               </div>
+            </div>
+         </div>
+         <!-- li from templates are cloned here with javascript -->
+      </div>
+   </div>
+   <div class="container-fluid">
+      <div class="il-dropzone standard clearfix row" data-upload-id="id_1">
+         <div class="col-xs-12 col-md-3 col-sm-12 col-lg-3 dz-default dz-message il-dropzone-standard-select-files-wrapper ">
+            <!--col-no-padding--><a href="#" >select_files_from_computer</a>
+         </div>
+         <div class="col-xs-12 col-md-9 col-sm-12 col-lg-9 col-no-padding"><span class="pull-right dz-default dz-message">drag_files_here</span></div>
+      </div>
+      <div class="clearfix hidden-sm-up"></div>
+   </div>
+</div>');
 
         // start test
         $standardDropzone = $this->dropzone()->standard('');
 
-        $html = $this->normalizeHTML($this->getDefaultRenderer()->render($standardDropzone));
+        $html = $this->brutallyTrimHTML($this->getDefaultRenderer()->render($standardDropzone));
 
         $this->assertEquals($expectedHtml, $html);
     }
@@ -61,12 +114,12 @@ class DropzoneRendererTest extends ILIAS_UI_TestBase
     {
 
         // setup expected objects
-        $expectedHtml = '<div id="id_1" class="il-dropzone-base"><div class="clearfix hidden-sm-up"></div><div class="il-upload-file-list" ><div class="container-fluid il-upload-file-items"><div class="error-messages" style="display: none;"><div class="alert alert-danger" role="alert"><!-- General error messages are inserted here with javascript --></div></div><!-- rows from templates are cloned here with javascript --></div><!-- Templates --><div class="container-fluid" ><!-- hidden Template --><div class="il-upload-file-item il-upload-file-item-template clearfix row standard hidden"><div class="col-xs-12 col-no-padding"><!-- Display Filename--><span class="file-info filename">FILENAME<!-- File name is inserted with javascript here --></span><!-- Display Filesize--><span class="file-info filesize">100KB<!-- File size is inserted with javascript here --></span><!-- Dropdown with actions--><span class="pull-right remove"><!--<div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"  aria-label="actions" aria-haspopup="true" aria-expanded="false" > <span class="caret"></span></button><ul class="dropdown-menu"><li><button class="btn btn-link" aria-label="delete_file" data-action="">remove</button></li></ul></div>--><button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button></span><!-- Progress Bar--><div class="progress" style="margin: 10px 0; display: none;"><div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="0"aria-valuemin="0"aria-valuemax="100"></div></div><!-- Error Messages --><div class="file-error-message alert alert-danger" role="alert" style="display: none;"><!-- Error message for file is inserted with javascript here --></div><div class="file-success-message alert alert-success" role="alert" style="display: none;"><!-- Success message for file is inserted with javascript here --></div></div></div><!-- li from templates are cloned here with javascript --></div></div><div class="container-fluid"><div class="il-dropzone standard clearfix row" data-upload-id="id_1"><div class="col-xs-12 col-md-3 col-sm-12 col-lg-3 dz-default dz-message il-dropzone-standard-select-files-wrapper "> <!--col-no-padding--><a href="#" >select_files_from_computer</a></div><div class="col-xs-12 col-md-9 col-sm-12 col-lg-9 col-no-padding"><span class="pull-right dz-default dz-message">message</span></div></div><div class="clearfix hidden-sm-up"></div></div></div>';
+        $expectedHtml = $this->brutallyTrimHTML('<div id="id_1" class="il-dropzone-base"><div class="clearfix hidden-sm-up"></div><div class="il-upload-file-list" ><div class="container-fluid il-upload-file-items"><div class="error-messages" style="display: none;"><div class="alert alert-danger" role="alert"><!-- General error messages are inserted here with javascript --></div></div><!-- rows from templates are cloned here with javascript --></div><!-- Templates --><div class="container-fluid" ><!-- hidden Template --><div class="il-upload-file-item il-upload-file-item-template clearfix row standard hidden"><div class="col-xs-12 col-no-padding"><!-- Display Filename--><span class="file-info filename">FILENAME<!-- File name is inserted with javascript here --></span><!-- Display Filesize--><span class="file-info filesize">100KB<!-- File size is inserted with javascript here --></span><!-- Dropdown with actions--><span class="pull-right remove"><!--<div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"  aria-label="actions" aria-haspopup="true" aria-expanded="false" > <span class="caret"></span></button><ul class="dropdown-menu"><li><button class="btn btn-link" aria-label="delete_file" data-action="">remove</button></li></ul></div>--><button type="button" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button></span><!-- Progress Bar--><div class="progress" style="margin: 10px 0; display: none;"><div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="0"aria-valuemin="0"aria-valuemax="100"></div></div><!-- Error Messages --><div class="file-error-message alert alert-danger" role="alert" style="display: none;"><!-- Error message for file is inserted with javascript here --></div><div class="file-success-message alert alert-success" role="alert" style="display: none;"><!-- Success message for file is inserted with javascript here --></div></div></div><!-- li from templates are cloned here with javascript --></div></div><div class="container-fluid"><div class="il-dropzone standard clearfix row" data-upload-id="id_1"><div class="col-xs-12 col-md-3 col-sm-12 col-lg-3 dz-default dz-message il-dropzone-standard-select-files-wrapper "> <!--col-no-padding--><a href="#" >select_files_from_computer</a></div><div class="col-xs-12 col-md-9 col-sm-12 col-lg-9 col-no-padding"><span class="pull-right dz-default dz-message">message</span></div></div><div class="clearfix hidden-sm-up"></div></div></div>');
 
         // start test
         $standardDropzone = $this->dropzone()->standard('')->withMessage('message');
 
-        $html = $this->normalizeHTML($this->getDefaultRenderer()->render($standardDropzone));
+        $html = $this->brutallyTrimHTML($this->getDefaultRenderer()->render($standardDropzone));
 
         $this->assertEquals($expectedHtml, $html);
     }
@@ -83,7 +136,67 @@ class DropzoneRendererTest extends ILIAS_UI_TestBase
     public function testRenderWrapperDropzone()
     {
         // setup expected objects
-        $expectedHtml = '<div id="id_1" class="il-dropzone-base"><div class="il-dropzone wrapper" data-upload-id="id_1"><p>Pretty smart, isn\'t it?</p><p>Yeah, this is really smart.</p></div><div class="modal fade il-modal-roundtrip" tabindex="-1" role="dialog" id="id_4"><div class="modal-dialog" role="document" data-replace-marker="component"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button><h4 class="modal-title">upload</h4></div><div class="modal-body"><div class="il-upload-file-list" ><div class="container-fluid il-upload-file-items"><div class="error-messages" style="display: none;"><div class="alert alert-danger" role="alert"><!-- General error messages are inserted here with javascript --></div></div><!-- rows from templates are cloned here with javascript --></div><!-- Templates --><div class="container-fluid" ><!-- hidden Template --><div class="il-upload-file-item il-upload-file-item-template clearfix row standard hidden"><div class="col-xs-12 col-no-padding"><!-- Display Filename--><span class="file-info filename">FILENAME<!-- File name is inserted with javascript here --></span><!-- Display Filesize--><span class="file-info filesize">100KB<!-- File size is inserted with javascript here --></span><!-- Dropdown with actions--><span class="pull-right remove"><!--<div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"  aria-label="actions" aria-haspopup="true" aria-expanded="false" > <span class="caret"></span></button><ul class="dropdown-menu"><li><button class="btn btn-link" aria-label="delete_file" data-action="">remove</button></li></ul></div>--><button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button></span><!-- Progress Bar--><div class="progress" style="margin: 10px 0; display: none;"><div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="0"aria-valuemin="0"aria-valuemax="100"></div></div><!-- Error Messages --><div class="file-error-message alert alert-danger" role="alert" style="display: none;"><!-- Error message for file is inserted with javascript here --></div><div class="file-success-message alert alert-success" role="alert" style="display: none;"><!-- Success message for file is inserted with javascript here --></div></div></div><!-- li from templates are cloned here with javascript --></div></div></div><div class="modal-footer"><button class="btn btn-default btn-primary" data-action="" disabled="disabled">upload</button><a class="btn btn-default" data-dismiss="modal" aria-label="Close">cancel</a></div></div></div></div></div>';
+        $expectedHtml = $this->brutallyTrimHTML('
+<div id="id_1" class="il-dropzone-base">
+   <div class="il-dropzone wrapper" data-upload-id="id_1">
+      <p>Pretty smart, isn\'t it?</p>
+      <p>Yeah, this is really smart.</p>
+   </div>
+   <div class="modal fade il-modal-roundtrip" tabindex="-1" role="dialog" id="id_4">
+      <div class="modal-dialog" role="document" data-replace-marker="component">
+         <div class="modal-content">
+            <div class="modal-header">
+               <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+               <h4 class="modal-title">upload</h4>
+            </div>
+            <div class="modal-body">
+               <div class="il-upload-file-list" >
+                  <div class="container-fluid il-upload-file-items">
+                     <div class="error-messages" style="display: none;">
+                        <div class="alert alert-danger" role="alert">
+                           <!-- General error messages are inserted here with javascript -->
+                        </div>
+                     </div>
+                     <!-- rows from templates are cloned here with javascript -->
+                  </div>
+                  <!-- Templates -->
+                  <div class="container-fluid" >
+                     <!-- hidden Template -->
+                     <div class="il-upload-file-item il-upload-file-item-template clearfix row standard hidden">
+                        <div class="col-xs-12 col-no-padding">
+                           <!-- Display Filename-->
+                           <span class="file-info filename">FILENAME<!-- File name is inserted with javascript here -->
+                           </span>
+                           <!-- Display Filesize-->
+                           <span class="file-info filesize">100KB<!-- File size is inserted with javascript here -->
+                           </span>
+                           <!-- Dropdown with actions-->
+                           <span class="pull-right remove">
+                              <!--<div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"  aria-label="actions" aria-haspopup="true" aria-expanded="false" > <span class="caret"></span></button><ul class="dropdown-menu"><li><button class="btn btn-link" aria-label="delete_file" data-action="">remove</button></li></ul></div>-->
+                              <button type="button" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button>
+                           </span>
+                           <!-- Progress Bar-->
+                           <div class="progress" style="margin: 10px 0; display: none;">
+                              <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="0"aria-valuemin="0"aria-valuemax="100"></div>
+                           </div>
+                           <!-- Error Messages -->
+                           <div class="file-error-message alert alert-danger" role="alert" style="display: none;">
+                              <!-- Error message for file is inserted with javascript here -->
+                           </div>
+                           <div class="file-success-message alert alert-success" role="alert" style="display: none;">
+                              <!-- Success message for file is inserted with javascript here -->
+                           </div>
+                        </div>
+                     </div>
+                     <!-- li from templates are cloned here with javascript -->
+                  </div>
+               </div>
+            </div>
+            <div class="modal-footer"><button class="btn btn-default btn-primary" data-action="" disabled="disabled">upload</button><a class="btn btn-default" data-dismiss="modal" aria-label="Close">cancel</a></div>
+         </div>
+      </div>
+   </div>
+</div>');
 
         // start test
         $exampleTextQuestion = $this->legacy_factory->legacy("<p>Pretty smart, isn't it?</p>");
@@ -93,7 +206,7 @@ class DropzoneRendererTest extends ILIAS_UI_TestBase
             $exampleTextAnswer,
         ]);
 
-        $html = $this->normalizeHTML($this->getDefaultRenderer()->render($wrapperDropzone));
+        $html = $this->brutallyTrimHTML($this->getDefaultRenderer()->render($wrapperDropzone));
 
         $this->assertEquals($expectedHtml, $html);
     }
@@ -101,27 +214,211 @@ class DropzoneRendererTest extends ILIAS_UI_TestBase
 
     public function testRenderMetadata()
     {
-        $with_user_defined_names_html = '<div id="id_1" class="il-dropzone-base"><div class="clearfix hidden-sm-up"></div><div class="il-upload-file-list" ><div class="container-fluid il-upload-file-items"><div class="error-messages" style="display: none;"><div class="alert alert-danger" role="alert"><!-- General error messages are inserted here with javascript --></div></div><!-- rows from templates are cloned here with javascript --></div><!-- Templates --><div class="container-fluid" ><!-- hidden Template --><div class="il-upload-file-item il-upload-file-item-template clearfix row standard hidden"><div class="col-xs-12 col-no-padding"><span class="file-info  toggle"><a class="glyph" aria-label="collapse_content"><span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span></a><a class="glyph" aria-label="expand_content"><span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span></a></span><!-- Display Filename--><span class="file-info filename">FILENAME<!-- File name is inserted with javascript here --></span><!-- Display Filesize--><span class="file-info filesize">100KB<!-- File size is inserted with javascript here --></span><!-- Dropdown with actions--><span class="pull-right remove"><!--<div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"  aria-label="actions" aria-haspopup="true" aria-expanded="false" > <span class="caret"></span></button><ul class="dropdown-menu"><li><button class="btn btn-link" aria-label="delete_file" data-action="">remove</button></li><li><button class="btn btn-link" aria-label="edit_metadata" data-action="">edit_metadata</button></li></ul></div>--><button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button></span><!-- Progress Bar--><div class="progress" style="margin: 10px 0; display: none;"><div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="0"aria-valuemin="0"aria-valuemax="100"></div></div><!-- Error Messages --><div class="file-error-message alert alert-danger" role="alert" style="display: none;"><!-- Error message for file is inserted with javascript here --></div><div class="file-success-message alert alert-success" role="alert" style="display: none;"><!-- Success message for file is inserted with javascript here --></div><br><div class="form-horizontal metadata" style="display: none;"><div class="form-group"><label class="col-sm-3 control-label">filename</label><div class="col-sm-9"><input type="text" class="form-control filename-input"></div></div></div></div></div><!-- li from templates are cloned here with javascript --></div></div><div class="container-fluid"><div class="il-dropzone standard clearfix row" data-upload-id="id_1"><div class="col-xs-12 col-md-3 col-sm-12 col-lg-3 dz-default dz-message il-dropzone-standard-select-files-wrapper "> <!--col-no-padding--><a href="#" >select_files_from_computer</a></div><div class="col-xs-12 col-md-9 col-sm-12 col-lg-9 col-no-padding"><span class="pull-right dz-default dz-message">drag_files_here</span></div></div><div class="clearfix hidden-sm-up"></div></div></div>';
+        $with_user_defined_names_html = $this->brutallyTrimHTML('<div id="id_1" class="il-dropzone-base">
+   <div class="clearfix hidden-sm-up"></div>
+   <div class="il-upload-file-list" >
+      <div class="container-fluid il-upload-file-items">
+         <div class="error-messages" style="display: none;">
+            <div class="alert alert-danger" role="alert">
+               <!-- General error messages are inserted here with javascript -->
+            </div>
+         </div>
+         <!-- rows from templates are cloned here with javascript -->
+      </div>
+      <!-- Templates -->
+      <div class="container-fluid" >
+         <!-- hidden Template -->
+         <div class="il-upload-file-item il-upload-file-item-template clearfix row standard hidden">
+            <div class="col-xs-12 col-no-padding">
+               <span class="file-info  toggle"><a class="glyph" aria-label="collapse_content"><span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span></a><a class="glyph" aria-label="expand_content"><span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span></a></span><!-- Display Filename-->
+               <span class="file-info filename">FILENAME<!-- File name is inserted with javascript here -->
+               </span>
+               <!-- Display Filesize-->
+               <span class="file-info filesize">100KB<!-- File size is inserted with javascript here -->
+               </span>
+               <!-- Dropdown with actions-->
+               <span class="pull-right remove">
+                  <!--<div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"  aria-label="actions" aria-haspopup="true" aria-expanded="false" > <span class="caret"></span></button><ul class="dropdown-menu"><li><button class="btn btn-link" aria-label="delete_file" data-action="">remove</button></li><li><button class="btn btn-link" aria-label="edit_metadata" data-action="">edit_metadata</button></li></ul></div>-->
+                  <button type="button" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button>
+               </span>
+               <!-- Progress Bar-->
+               <div class="progress" style="margin: 10px 0; display: none;">
+                  <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="0"aria-valuemin="0"aria-valuemax="100"></div>
+               </div>
+               <!-- Error Messages -->
+               <div class="file-error-message alert alert-danger" role="alert" style="display: none;">
+                  <!-- Error message for file is inserted with javascript here -->
+               </div>
+               <div class="file-success-message alert alert-success" role="alert" style="display: none;">
+                  <!-- Success message for file is inserted with javascript here -->
+               </div>
+               <br>
+               <div class="form-horizontal metadata" style="display: none;">
+                  <div class="form-group">
+                     <label class="col-sm-3 control-label">filename</label>
+                     <div class="col-sm-9"><input type="text" class="form-control filename-input"></div>
+                  </div>
+               </div>
+            </div>
+         </div>
+         <!-- li from templates are cloned here with javascript -->
+      </div>
+   </div>
+   <div class="container-fluid">
+      <div class="il-dropzone standard clearfix row" data-upload-id="id_1">
+         <div class="col-xs-12 col-md-3 col-sm-12 col-lg-3 dz-default dz-message il-dropzone-standard-select-files-wrapper ">
+            <!--col-no-padding--><a href="#" >select_files_from_computer</a>
+         </div>
+         <div class="col-xs-12 col-md-9 col-sm-12 col-lg-9 col-no-padding"><span class="pull-right dz-default dz-message">drag_files_here</span></div>
+      </div>
+      <div class="clearfix hidden-sm-up"></div>
+   </div>
+</div>');
+
         $with_user_defined_names = $this->dropzone()
                                         ->standard('https://ilias.de/ilias.php')
                                         ->withUserDefinedFileNamesEnabled(true);
-        $html = $this->normalizeHTML($this->getDefaultRenderer()->render($with_user_defined_names));
+        $html = $this->brutallyTrimHTML($this->getDefaultRenderer()->render($with_user_defined_names));
         $this->assertEquals($with_user_defined_names_html, $html);
 
-        $with_user_defined_descriptions_html = '<div id="id_1" class="il-dropzone-base"><div class="clearfix hidden-sm-up"></div><div class="il-upload-file-list" ><div class="container-fluid il-upload-file-items"><div class="error-messages" style="display: none;"><div class="alert alert-danger" role="alert"><!-- General error messages are inserted here with javascript --></div></div><!-- rows from templates are cloned here with javascript --></div><!-- Templates --><div class="container-fluid" ><!-- hidden Template --><div class="il-upload-file-item il-upload-file-item-template clearfix row standard hidden"><div class="col-xs-12 col-no-padding"><span class="file-info  toggle"><a class="glyph" aria-label="collapse_content"><span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span></a><a class="glyph" aria-label="expand_content"><span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span></a></span><!-- Display Filename--><span class="file-info filename">FILENAME<!-- File name is inserted with javascript here --></span><!-- Display Filesize--><span class="file-info filesize">100KB<!-- File size is inserted with javascript here --></span><!-- Dropdown with actions--><span class="pull-right remove"><!--<div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"  aria-label="actions" aria-haspopup="true" aria-expanded="false" > <span class="caret"></span></button><ul class="dropdown-menu"><li><button class="btn btn-link" aria-label="delete_file" data-action="">remove</button></li><li><button class="btn btn-link" aria-label="edit_metadata" data-action="">edit_metadata</button></li></ul></div>--><button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button></span><!-- Progress Bar--><div class="progress" style="margin: 10px 0; display: none;"><div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="0"aria-valuemin="0"aria-valuemax="100"></div></div><!-- Error Messages --><div class="file-error-message alert alert-danger" role="alert" style="display: none;"><!-- Error message for file is inserted with javascript here --></div><div class="file-success-message alert alert-success" role="alert" style="display: none;"><!-- Success message for file is inserted with javascript here --></div><br><div class="form-horizontal metadata" style="display: none;"><div class="form-group"><label class="col-sm-3 control-label" for="description-input">description</label><div class="col-sm-9"><textarea class="form-control description-input" id="description-input" rows="3"></textarea></div></div></div></div></div><!-- li from templates are cloned here with javascript --></div></div><div class="container-fluid"><div class="il-dropzone standard clearfix row" data-upload-id="id_1"><div class="col-xs-12 col-md-3 col-sm-12 col-lg-3 dz-default dz-message il-dropzone-standard-select-files-wrapper "> <!--col-no-padding--><a href="#" >select_files_from_computer</a></div><div class="col-xs-12 col-md-9 col-sm-12 col-lg-9 col-no-padding"><span class="pull-right dz-default dz-message">drag_files_here</span></div></div><div class="clearfix hidden-sm-up"></div></div></div>';
+        $with_user_defined_descriptions_html = $this->brutallyTrimHTML('
+        <div id="id_1" class="il-dropzone-base">
+   <div class="clearfix hidden-sm-up"></div>
+   <div class="il-upload-file-list" >
+      <div class="container-fluid il-upload-file-items">
+         <div class="error-messages" style="display: none;">
+            <div class="alert alert-danger" role="alert">
+               <!-- General error messages are inserted here with javascript -->
+            </div>
+         </div>
+         <!-- rows from templates are cloned here with javascript -->
+      </div>
+      <!-- Templates -->
+      <div class="container-fluid" >
+         <!-- hidden Template -->
+         <div class="il-upload-file-item il-upload-file-item-template clearfix row standard hidden">
+            <div class="col-xs-12 col-no-padding">
+               <span class="file-info  toggle"><a class="glyph" aria-label="collapse_content"><span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span></a><a class="glyph" aria-label="expand_content"><span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span></a></span><!-- Display Filename-->
+               <span class="file-info filename">FILENAME<!-- File name is inserted with javascript here -->
+               </span>
+               <!-- Display Filesize-->
+               <span class="file-info filesize">100KB<!-- File size is inserted with javascript here -->
+               </span>
+               <!-- Dropdown with actions-->
+               <span class="pull-right remove">
+                  <!--<div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"  aria-label="actions" aria-haspopup="true" aria-expanded="false" > <span class="caret"></span></button><ul class="dropdown-menu"><li><button class="btn btn-link" aria-label="delete_file" data-action="">remove</button></li><li><button class="btn btn-link" aria-label="edit_metadata" data-action="">edit_metadata</button></li></ul></div>-->
+                  <button type="button" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button>
+               </span>
+               <!-- Progress Bar-->
+               <div class="progress" style="margin: 10px 0; display: none;">
+                  <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="0"aria-valuemin="0"aria-valuemax="100"></div>
+               </div>
+               <!-- Error Messages -->
+               <div class="file-error-message alert alert-danger" role="alert" style="display: none;">
+                  <!-- Error message for file is inserted with javascript here -->
+               </div>
+               <div class="file-success-message alert alert-success" role="alert" style="display: none;">
+                  <!-- Success message for file is inserted with javascript here -->
+               </div>
+               <br>
+               <div class="form-horizontal metadata" style="display: none;">
+                  <div class="form-group">
+                     <label class="col-sm-3 control-label" for="description-input">description</label>
+                     <div class="col-sm-9"><textarea class="form-control description-input" id="description-input" rows="3"></textarea></div>
+                  </div>
+               </div>
+            </div>
+         </div>
+         <!-- li from templates are cloned here with javascript -->
+      </div>
+   </div>
+   <div class="container-fluid">
+      <div class="il-dropzone standard clearfix row" data-upload-id="id_1">
+         <div class="col-xs-12 col-md-3 col-sm-12 col-lg-3 dz-default dz-message il-dropzone-standard-select-files-wrapper ">
+            <!--col-no-padding--><a href="#" >select_files_from_computer</a>
+         </div>
+         <div class="col-xs-12 col-md-9 col-sm-12 col-lg-9 col-no-padding"><span class="pull-right dz-default dz-message">drag_files_here</span></div>
+      </div>
+      <div class="clearfix hidden-sm-up"></div>
+   </div>
+</div>');
         $with_user_defined_descriptions = $this->dropzone()
                                                ->standard('https://ilias.de/ilias.php')
                                                ->withUserDefinedDescriptionEnabled(true);
-        $html = $this->normalizeHTML($this->getDefaultRenderer()
+        $html = $this->brutallyTrimHTML($this->getDefaultRenderer()
                                           ->render($with_user_defined_descriptions));
         $this->assertEquals($with_user_defined_descriptions_html, $html);
 
-        $with_user_defined_names_and_descriptions_html = '<div id="id_1" class="il-dropzone-base"><div class="clearfix hidden-sm-up"></div><div class="il-upload-file-list" ><div class="container-fluid il-upload-file-items"><div class="error-messages" style="display: none;"><div class="alert alert-danger" role="alert"><!-- General error messages are inserted here with javascript --></div></div><!-- rows from templates are cloned here with javascript --></div><!-- Templates --><div class="container-fluid" ><!-- hidden Template --><div class="il-upload-file-item il-upload-file-item-template clearfix row standard hidden"><div class="col-xs-12 col-no-padding"><span class="file-info  toggle"><a class="glyph" aria-label="collapse_content"><span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span></a><a class="glyph" aria-label="expand_content"><span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span></a></span><!-- Display Filename--><span class="file-info filename">FILENAME<!-- File name is inserted with javascript here --></span><!-- Display Filesize--><span class="file-info filesize">100KB<!-- File size is inserted with javascript here --></span><!-- Dropdown with actions--><span class="pull-right remove"><!--<div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"  aria-label="actions" aria-haspopup="true" aria-expanded="false" > <span class="caret"></span></button><ul class="dropdown-menu"><li><button class="btn btn-link" aria-label="delete_file" data-action="">remove</button></li><li><button class="btn btn-link" aria-label="edit_metadata" data-action="">edit_metadata</button></li></ul></div>--><button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button></span><!-- Progress Bar--><div class="progress" style="margin: 10px 0; display: none;"><div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="0"aria-valuemin="0"aria-valuemax="100"></div></div><!-- Error Messages --><div class="file-error-message alert alert-danger" role="alert" style="display: none;"><!-- Error message for file is inserted with javascript here --></div><div class="file-success-message alert alert-success" role="alert" style="display: none;"><!-- Success message for file is inserted with javascript here --></div><br><div class="form-horizontal metadata" style="display: none;"><div class="form-group"><label class="col-sm-3 control-label">filename</label><div class="col-sm-9"><input type="text" class="form-control filename-input"></div></div><div class="form-group"><label class="col-sm-3 control-label" for="description-input">description</label><div class="col-sm-9"><textarea class="form-control description-input" id="description-input" rows="3"></textarea></div></div></div></div></div><!-- li from templates are cloned here with javascript --></div></div><div class="container-fluid"><div class="il-dropzone standard clearfix row" data-upload-id="id_1"><div class="col-xs-12 col-md-3 col-sm-12 col-lg-3 dz-default dz-message il-dropzone-standard-select-files-wrapper "> <!--col-no-padding--><a href="#" >select_files_from_computer</a></div><div class="col-xs-12 col-md-9 col-sm-12 col-lg-9 col-no-padding"><span class="pull-right dz-default dz-message">drag_files_here</span></div></div><div class="clearfix hidden-sm-up"></div></div></div>';
+        $with_user_defined_names_and_descriptions_html = $this->brutallyTrimHTML('
+        <div id="id_1" class="il-dropzone-base">
+   <div class="clearfix hidden-sm-up"></div>
+   <div class="il-upload-file-list" >
+      <div class="container-fluid il-upload-file-items">
+         <div class="error-messages" style="display: none;">
+            <div class="alert alert-danger" role="alert">
+               <!-- General error messages are inserted here with javascript -->
+            </div>
+         </div>
+         <!-- rows from templates are cloned here with javascript -->
+      </div>
+      <!-- Templates -->
+      <div class="container-fluid" >
+         <!-- hidden Template -->
+         <div class="il-upload-file-item il-upload-file-item-template clearfix row standard hidden">
+            <div class="col-xs-12 col-no-padding">
+               <span class="file-info  toggle"><a class="glyph" aria-label="collapse_content"><span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span></a><a class="glyph" aria-label="expand_content"><span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span></a></span><!-- Display Filename-->
+               <span class="file-info filename">FILENAME<!-- File name is inserted with javascript here -->
+               </span>
+               <!-- Display Filesize-->
+               <span class="file-info filesize">100KB<!-- File size is inserted with javascript here -->
+               </span>
+               <!-- Dropdown with actions-->
+               <span class="pull-right remove">
+                  <!--<div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"  aria-label="actions" aria-haspopup="true" aria-expanded="false" > <span class="caret"></span></button><ul class="dropdown-menu"><li><button class="btn btn-link" aria-label="delete_file" data-action="">remove</button></li><li><button class="btn btn-link" aria-label="edit_metadata" data-action="">edit_metadata</button></li></ul></div>-->
+                  <button type="button" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button>
+               </span>
+               <!-- Progress Bar-->
+               <div class="progress" style="margin: 10px 0; display: none;">
+                  <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="0"aria-valuemin="0"aria-valuemax="100"></div>
+               </div>
+               <!-- Error Messages -->
+               <div class="file-error-message alert alert-danger" role="alert" style="display: none;">
+                  <!-- Error message for file is inserted with javascript here -->
+               </div>
+               <div class="file-success-message alert alert-success" role="alert" style="display: none;">
+                  <!-- Success message for file is inserted with javascript here -->
+               </div>
+               <br>
+               <div class="form-horizontal metadata" style="display: none;">
+                  <div class="form-group">
+                     <label class="col-sm-3 control-label">filename</label>
+                     <div class="col-sm-9"><input type="text" class="form-control filename-input"></div>
+                  </div>
+                  <div class="form-group">
+                     <label class="col-sm-3 control-label" for="description-input">description</label>
+                     <div class="col-sm-9"><textarea class="form-control description-input" id="description-input" rows="3"></textarea></div>
+                  </div>
+               </div>
+            </div>
+         </div>
+         <!-- li from templates are cloned here with javascript -->
+      </div>
+   </div>
+   <div class="container-fluid">
+      <div class="il-dropzone standard clearfix row" data-upload-id="id_1">
+         <div class="col-xs-12 col-md-3 col-sm-12 col-lg-3 dz-default dz-message il-dropzone-standard-select-files-wrapper ">
+            <!--col-no-padding--><a href="#" >select_files_from_computer</a>
+         </div>
+         <div class="col-xs-12 col-md-9 col-sm-12 col-lg-9 col-no-padding"><span class="pull-right dz-default dz-message">drag_files_here</span></div>
+      </div>
+      <div class="clearfix hidden-sm-up"></div>
+   </div>
+</div>');
         $with_user_defined_names_and_descriptions = $this->dropzone()
                                                          ->standard('https://ilias.de/ilias.php')
                                                          ->withUserDefinedDescriptionEnabled(true)
                                                          ->withUserDefinedFileNamesEnabled(true);
-        $html = $this->normalizeHTML($this->getDefaultRenderer()
+        $html = $this->brutallyTrimHTML($this->getDefaultRenderer()
                                           ->render($with_user_defined_names_and_descriptions));
         $this->assertEquals($with_user_defined_names_and_descriptions_html, $html);
     }
@@ -129,10 +426,64 @@ class DropzoneRendererTest extends ILIAS_UI_TestBase
 
     public function testWithButton()
     {
-        $expected_html = '<div id="id_1" class="il-dropzone-base"><div class="clearfix hidden-sm-up"></div><div class="il-upload-file-list" ><div class="container-fluid il-upload-file-items"><div class="error-messages" style="display: none;"><div class="alert alert-danger" role="alert"><!-- General error messages are inserted here with javascript --></div></div><!-- rows from templates are cloned here with javascript --></div><!-- Templates --><div class="container-fluid" ><!-- hidden Template --><div class="il-upload-file-item il-upload-file-item-template clearfix row standard hidden"><div class="col-xs-12 col-no-padding"><!-- Display Filename--><span class="file-info filename">FILENAME<!-- File name is inserted with javascript here --></span><!-- Display Filesize--><span class="file-info filesize">100KB<!-- File size is inserted with javascript here --></span><!-- Dropdown with actions--><span class="pull-right remove"><!--<div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"  aria-label="actions" aria-haspopup="true" aria-expanded="false" > <span class="caret"></span></button><ul class="dropdown-menu"><li><button class="btn btn-link" aria-label="delete_file" data-action="">remove</button></li></ul></div>--><button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button></span><!-- Progress Bar--><div class="progress" style="margin: 10px 0; display: none;"><div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="0"aria-valuemin="0"aria-valuemax="100"></div></div><!-- Error Messages --><div class="file-error-message alert alert-danger" role="alert" style="display: none;"><!-- Error message for file is inserted with javascript here --></div><div class="file-success-message alert alert-success" role="alert" style="display: none;"><!-- Success message for file is inserted with javascript here --></div></div></div><!-- li from templates are cloned here with javascript --></div></div><div class="container-fluid"><div class="il-dropzone standard clearfix row" data-upload-id="id_1"><div class="col-xs-12 col-md-3 col-sm-12 col-lg-3 dz-default dz-message il-dropzone-standard-select-files-wrapper "> <!--col-no-padding--><a href="#" >select_files_from_computer</a></div><div class="col-xs-12 col-md-9 col-sm-12 col-lg-9 col-no-padding"><span class="pull-right dz-default dz-message">drag_files_here</span></div></div><div class="clearfix hidden-sm-up"></div></div><button class="btn btn-default"   data-action="#" id="id_2" disabled="disabled">Label</button></div>';
+        $expected_html = $this->brutallyTrimHTML('
+        <div id="id_1" class="il-dropzone-base">
+   <div class="clearfix hidden-sm-up"></div>
+   <div class="il-upload-file-list" >
+      <div class="container-fluid il-upload-file-items">
+         <div class="error-messages" style="display: none;">
+            <div class="alert alert-danger" role="alert">
+               <!-- General error messages are inserted here with javascript -->
+            </div>
+         </div>
+         <!-- rows from templates are cloned here with javascript -->
+      </div>
+      <!-- Templates -->
+      <div class="container-fluid" >
+         <!-- hidden Template -->
+         <div class="il-upload-file-item il-upload-file-item-template clearfix row standard hidden">
+            <div class="col-xs-12 col-no-padding">
+               <!-- Display Filename-->
+               <span class="file-info filename">FILENAME<!-- File name is inserted with javascript here -->
+               </span>
+               <!-- Display Filesize-->
+               <span class="file-info filesize">100KB<!-- File size is inserted with javascript here -->
+               </span>
+               <!-- Dropdown with actions-->
+               <span class="pull-right remove">
+                  <!--<div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"  aria-label="actions" aria-haspopup="true" aria-expanded="false" > <span class="caret"></span></button><ul class="dropdown-menu"><li><button class="btn btn-link" aria-label="delete_file" data-action="">remove</button></li></ul></div>-->
+                  <button type="button" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button>
+               </span>
+               <!-- Progress Bar-->
+               <div class="progress" style="margin: 10px 0; display: none;">
+                  <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="0"aria-valuemin="0"aria-valuemax="100"></div>
+               </div>
+               <!-- Error Messages -->
+               <div class="file-error-message alert alert-danger" role="alert" style="display: none;">
+                  <!-- Error message for file is inserted with javascript here -->
+               </div>
+               <div class="file-success-message alert alert-success" role="alert" style="display: none;">
+                  <!-- Success message for file is inserted with javascript here -->
+               </div>
+            </div>
+         </div>
+         <!-- li from templates are cloned here with javascript -->
+      </div>
+   </div>
+   <div class="container-fluid">
+      <div class="il-dropzone standard clearfix row" data-upload-id="id_1">
+         <div class="col-xs-12 col-md-3 col-sm-12 col-lg-3 dz-default dz-message il-dropzone-standard-select-files-wrapper ">
+            <!--col-no-padding--><a href="#" >select_files_from_computer</a>
+         </div>
+         <div class="col-xs-12 col-md-9 col-sm-12 col-lg-9 col-no-padding"><span class="pull-right dz-default dz-message">drag_files_here</span></div>
+      </div>
+      <div class="clearfix hidden-sm-up"></div>
+   </div>
+   <button class="btn btn-default"   data-action="#" id="id_2" disabled="disabled">Label</button>
+</div>');
         $button = new I\Component\Button\Standard('Label', '#');
         $with_button = $this->dropzone()->standard('')->withUploadButton($button);
-        $html = $this->normalizeHTML($this->getDefaultRenderer()->render($with_button));
+        $html = $this->brutallyTrimHTML($this->getDefaultRenderer()->render($with_button));
         $this->assertEquals($expected_html, $html);
         $this->assertEquals($button, $with_button->getUploadButton());
     }
@@ -198,14 +549,6 @@ class DropzoneRendererTest extends ILIAS_UI_TestBase
         };
         return $factory;
     }
-
-    public function normalizeHTML($html)
-    {
-        $html = trim(str_replace("\t", "", $html));
-
-        return parent::normalizeHTML($html);
-    }
-
 
     protected function dropzone()
     {

--- a/tests/UI/Component/Item/ItemNotificationTest.php
+++ b/tests/UI/Component/Item/ItemNotificationTest.php
@@ -209,9 +209,8 @@ class ItemNotificationTest extends ILIAS_UI_TestBase
 				<h4 class="il-item-notification-title">
 					<a href="">TestLink</a>
 				</h4>
-				<button type="button" class="close" data-dismiss="modal" id="id">
+				<button type="button" class="close" aria-label="close" id="id">
 					<span aria-hidden="true">&times;</span>
-					<span class="sr-only">Close</span>
 				</button>
 				<div class="il-item-description">description</div>
 				<div class="dropdown">


### PR DESCRIPTION
Fix of https://mantis.ilias.de/view_all_bug_page.php?filter=5f9a8ebc76b8a .

Note I: I switch from rs-only to aria-label. IMO the DOM looks cleaner this way. 
Note II: There was some weird data-dismiss="modal" in the DOM of the close button. I guess this got wrongly copied over from bootstrap 3. I removed it. It's plain wrong.
Note III: In tests/UI/Component/Dropzone/File/DropzoneRendererTest.php are some extremely long one liners for html testing. They are almost impossible to read. I took the liberty to change those affected by my change to formated html and brutally trim them afterwards. IMO this improves the readability a lot.

