### PR TITLE
Update class.ilObjMailGUI.php

### DIFF
--- a/Services/Mail/classes/class.ilObjMailGUI.php
+++ b/Services/Mail/classes/class.ilObjMailGUI.php
@@ -457,12 +457,14 @@ class ilObjMailGUI extends ilObjectGUI
 
         $user = new ilTextInputGUI($this->lng->txt('mail_smtp_user'), 'mail_smtp_user');
         $user->setDisabled(!$this->isEditingAllowed());
+        $user->setDisableHtmlAutoComplete(true);
         $smtp->addSubItem($user);
 
         $password = new ilPasswordInputGUI($this->lng->txt('mail_smtp_password'), 'mail_smtp_password');
         $password->setRetype(false);
         $password->setSkipSyntaxCheck(true);
         $password->setDisabled(!$this->isEditingAllowed());
+        $password->setDisableHtmlAutoComplete(true);
         $smtp->addSubItem($password);
 
         $pre = new ilTextInputGUI($this->lng->txt('mail_subject_prefix'), 'mail_subject_prefix');


### PR DESCRIPTION
Added autocomplete-disabling on mail_smtp_user and mail_smtp_password to avoid a pitfall.
If an user has saved his credientials for Ilias and those fields are supposed to be empty, the browser autocompletion will fill in the saved user-credentials and will set this data as mail-credentials on saving the settings. This will result in smtp connection errors.