### PR TITLE
Feature/7/splitting up file object/moving folder download action

### DIFF
--- a/Modules/File/classes/class.ilObjFileAccessSettingsGUI.php
+++ b/Modules/File/classes/class.ilObjFileAccessSettingsGUI.php
@@ -198,22 +198,6 @@ class ilObjFileAccessSettingsGUI extends ilObjectGUI
         $dl_prop->setInfo($lng->txt('download_with_uploaded_filename_info'));
         $form->addItem($dl_prop);
 
-        // Show download action for folder
-        $dl_prop = new ilCheckboxInputGUI($lng->txt("enable_download_folder"), "enable_download_folder");
-        $dl_prop->setValue('1');
-        // default value should reflect previous behaviour (-> 0)
-        $dl_prop->setChecked($this->folderSettings->get("enable_download_folder", 0) == 1);
-        $dl_prop->setInfo($lng->txt('enable_download_folder_info'));
-        $form->addItem($dl_prop);
-
-        // multi download
-        $dl_prop = new ilCheckboxInputGUI($lng->txt("enable_multi_download"), "enable_multi_download");
-        $dl_prop->setValue('1');
-        // default value should reflect previous behaviour (-> 0)
-        $dl_prop->setChecked($this->folderSettings->get("enable_multi_download", 0) == 1);
-        $dl_prop->setInfo($lng->txt('enable_multi_download_info'));
-        $form->addItem($dl_prop);
-
         // download limit
         $lng->loadLanguageModule("bgtask");
         $dl_prop = new ilNumberInputGUI($lng->txt("bgtask_setting_limit"), "bg_limit");
@@ -305,8 +289,6 @@ class ilObjFileAccessSettingsGUI extends ilObjectGUI
             $this->object->setInlineFileExtensions(ilUtil::stripSlashes($_POST['inline_file_extensions']));
             $this->object->update();
 
-            $this->folderSettings->set("enable_download_folder", $_POST["enable_download_folder"] == 1);
-            $this->folderSettings->set("enable_multi_download", $_POST["enable_multi_download"] == 1);
             $this->folderSettings->set("bgtask_download_limit", (int) $_POST["bg_limit"]);
 
             require_once("Services/Preview/classes/class.ilPreviewSettings.php");

--- a/Services/Repository/classes/class.ilObjRepositorySettingsGUI.php
+++ b/Services/Repository/classes/class.ilObjRepositorySettingsGUI.php
@@ -23,6 +23,11 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
      */
     protected $rbacsystem;
 
+    /**
+     * @var \ilSetting
+     */
+    protected $folder_settings;
+
     public function __construct($a_data, $a_id, $a_call_by_reference = true, $a_prepare_output = true)
     {
         global $DIC;
@@ -31,6 +36,7 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
         $this->access = $DIC->access();
         $this->rbacsystem = $DIC->rbac()->system();
         $this->settings = $DIC->settings();
+        $this->folder_settings = new ilSetting('fold');
         $this->ctrl = $DIC->ctrl();
         $this->lng = $DIC->language();
         $this->toolbar = $DIC->toolbar();
@@ -252,6 +258,22 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
 
         $form->addItem($exp_limit);
 
+        // Show download action for folder
+        $dl_prop = new ilCheckboxInputGUI($this->lng->txt("enable_download_folder"), "enable_download_folder");
+        $dl_prop->setValue('1');
+        // default value should reflect previous behaviour (-> 0)
+        $dl_prop->setChecked($this->folder_settings->get("enable_download_folder", 0) == 1);
+        $dl_prop->setInfo($this->lng->txt('enable_download_folder_info'));
+        $form->addItem($dl_prop);
+
+        // multi download
+        $dl_prop = new ilCheckboxInputGUI($this->lng->txt("enable_multi_download"), "enable_multi_download");
+        $dl_prop->setValue('1');
+        // default value should reflect previous behaviour (-> 0)
+        $dl_prop->setChecked($this->folder_settings->get("enable_multi_download", 0) == 1);
+        $dl_prop->setInfo($this->lng->txt('enable_multi_download_info'));
+        $form->addItem($dl_prop);
+
         // object lists
         
         $lists = new ilFormSectionHeaderGUI();
@@ -341,6 +363,9 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
                 ? (int) $_POST['rep_tree_limit_number']
                 : 0;
             $ilSetting->set('rep_tree_limit_number', $limit_number);
+
+            $this->folder_settings->set("enable_download_folder", $_POST["enable_download_folder"] == 1);
+            $this->folder_settings->set("enable_multi_download", $_POST["enable_multi_download"] == 1);
 
             require_once 'Services/Tracking/classes/class.ilChangeEvent.php';
             if ($form->getInput('change_event_tracking')) {


### PR DESCRIPTION
Hi @alex40724 

It was discussed in the feature request https://docu.ilias.de/goto_docu_wiki_wpage_6312_1357.html that certain settings are moved to the "Repository" administration area. This pull-request here makes this shift.

Thanks for the review!

Best regards


Fabian