### PR TITLE
ILIAS 7 Course/Group: Mail Prefix (Part III)

### DIFF
--- a/Modules/Course/classes/class.ilCourseMembershipGUI.php
+++ b/Modules/Course/classes/class.ilCourseMembershipGUI.php
@@ -43,16 +43,19 @@ class ilCourseMembershipGUI extends ilMembershipGUI
     /**
      * @inheritdoc
      */
-    protected function getMailContextOptions()
+    protected function getMailContextOptions() : array
     {
-        $context_options = [];
+        $context_options = [
+            ilMailFormCall::CONTEXT_KEY => ilCourseMailTemplateTutorContext::ID,
+            'ref_id' => $this->getParentObject()->getRefId(),
+            'ts' => time(),
+            ilMail::PROP_CONTEXT_SUBJECT_PREFIX => ilContainer::_lookupContainerSetting(
+                $this->getParentObject()->getId(),
+                ilObjectServiceSettingsGUI::EXTERNAL_MAIL_PREFIX,
+                ''
+            ),
+        ];
 
-        $context_options =
-            [
-                ilMailFormCall::CONTEXT_KEY => ilCourseMailTemplateTutorContext::ID,
-                'ref_id' => $this->getParentObject()->getRefId(),
-                'ts' => time()
-            ];
         return $context_options;
     }
 

--- a/Modules/Course/classes/class.ilCourseMembershipMailNotification.php
+++ b/Modules/Course/classes/class.ilCourseMembershipMailNotification.php
@@ -53,6 +53,23 @@ class ilCourseMembershipMailNotification extends ilMailNotification
     {
         parent::__construct();
     }
+
+    /**
+     * @inheritDoc
+     */
+    protected function initMail() : ilMail
+    {
+        parent::initMail();
+        $this->mail = $this->mail->withContextParameters([
+            ilMail::PROP_CONTEXT_SUBJECT_PREFIX => ilContainer::_lookupContainerSetting(
+                ilObject::_lookupObjId($this->getRefId()),
+                ilObjectServiceSettingsGUI::EXTERNAL_MAIL_PREFIX,
+                ''
+            ),
+        ]);
+
+        return $this->mail;
+    }
     
     /**
      * Force sending mail independent from global setting

--- a/Modules/Forum/classes/Notification/class.ilForumMailEventNotificationSender.php
+++ b/Modules/Forum/classes/Notification/class.ilForumMailEventNotificationSender.php
@@ -56,7 +56,7 @@ class ilForumMailEventNotificationSender extends ilMailNotification
     /**
      * @inheritdoc
      */
-    protected function initMail()
+    protected function initMail() : ilMail
     {
         $mail = parent::initMail();
         $this->logger->debug('Initialized mail service');

--- a/Modules/Forum/classes/class.ilForumMailNotification.php
+++ b/Modules/Forum/classes/class.ilForumMailNotification.php
@@ -51,7 +51,7 @@ class ilForumMailNotification extends ilMailNotification
     /**
      * @inheritdoc
      */
-    protected function initMail()
+    protected function initMail() : ilMail
     {
         $mail = parent::initMail();
         $this->logger->debug('Initialized mail service');

--- a/Modules/Group/classes/class.ilGroupMembershipGUI.php
+++ b/Modules/Group/classes/class.ilGroupMembershipGUI.php
@@ -239,4 +239,20 @@ class ilGroupMembershipGUI extends ilMembershipGUI
         }
         return [];
     }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getMailContextOptions() : array
+    {
+        $context_options = [
+            ilMail::PROP_CONTEXT_SUBJECT_PREFIX => ilContainer::_lookupContainerSetting(
+                $this->getParentObject()->getId(),
+                ilObjectServiceSettingsGUI::EXTERNAL_MAIL_PREFIX,
+                ''
+            ),
+        ];
+
+        return $context_options;
+    }
 }

--- a/Modules/Group/classes/class.ilGroupMembershipMailNotification.php
+++ b/Modules/Group/classes/class.ilGroupMembershipMailNotification.php
@@ -55,6 +55,23 @@ class ilGroupMembershipMailNotification extends ilMailNotification
     {
         parent::__construct();
     }
+
+    /**
+     * @inheritDoc
+     */
+    protected function initMail() : ilMail
+    {
+        parent::initMail();
+        $this->mail = $this->mail->withContextParameters([
+            ilMail::PROP_CONTEXT_SUBJECT_PREFIX => ilContainer::_lookupContainerSetting(
+                ilObject::_lookupObjId($this->getRefId()),
+                ilObjectServiceSettingsGUI::EXTERNAL_MAIL_PREFIX,
+                ''
+            ),
+        ]);
+
+        return $this->mail;
+    }
     
     /**
      * Force sending mail independent from global setting

--- a/Modules/Session/classes/class.ilSessionMembershipGUI.php
+++ b/Modules/Session/classes/class.ilSessionMembershipGUI.php
@@ -266,16 +266,14 @@ class ilSessionMembershipGUI extends ilMembershipGUI
     /**
      * @inheritdoc
      */
-    protected function getMailContextOptions()
+    protected function getMailContextOptions() : array
     {
-        $context_options = [];
+        $context_options = [
+            ilMailFormCall::CONTEXT_KEY => ilSessionMailTemplateParticipantContext::ID,
+            'ref_id' => $this->getParentObject()->getRefId(),
+            'ts' => time()
+        ];
 
-        $context_options =
-            [
-                ilMailFormCall::CONTEXT_KEY => ilSessionMailTemplateParticipantContext::ID,
-                'ref_id' => $this->getParentObject()->getRefId(),
-                'ts' => time()
-            ];
         return $context_options;
     }
 }

--- a/Services/Mail/classes/class.ilMailNotification.php
+++ b/Services/Mail/classes/class.ilMailNotification.php
@@ -371,15 +371,15 @@ abstract class ilMailNotification
     /**
      * @return ilMail
      */
-    protected function initMail()
+    protected function initMail() : ilMail
     {
         return $this->mail = new ilMail($this->getSender());
     }
 
     /**
-     * @return ilMail|null
+     * @return ilMail
      */
-    protected function getMail()
+    protected function getMail() : ilMail
     {
         return is_object($this->mail) ? $this->mail : $this->initMail();
     }

--- a/Services/Membership/classes/class.ilMembershipGUI.php
+++ b/Services/Membership/classes/class.ilMembershipGUI.php
@@ -794,13 +794,11 @@ class ilMembershipGUI
     }
 
     /**
-     * Get mail context options
      * @return array
      */
-    protected function getMailContextOptions()
+    protected function getMailContextOptions() : array
     {
-        $context_options = [];
-        return $context_options;
+        return [];
     }
 
     


### PR DESCRIPTION
This PR provides the configured mail subject prefix of courses and groups for the mail system. This is valid for both, automatically sent mail notifications as well as contexts where the actor is redirected from the crs/grp to the mail system UI and composes a mail to given recipients manually.

Wiki Page: https://docu.ilias.de/goto_docu_wiki_wpage_1717_1357.html