### PR TITLE
Update install.md according to new release

### DIFF
--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -154,13 +154,13 @@ We RECOMMEND to clone from GitHub as this will offer some kind of autoupdate for
 <a name="git-clonecheckout"></a>
 ## Git Clone/Checkout
 
-To checkout the ILIAS release 6 in ```/var/www/html/ilias/``` use the following commands:
+To checkout the ILIAS release 7 in ```/var/www/html/ilias/``` use the following commands:
 
 ```
 cd /var/www/html/
 git clone https://github.com/ILIAS-eLearning/ILIAS.git ilias
 cd ilias
-git checkout release_6
+git checkout release_7
 chown www-data:www-data /var/www/html/ilias -R
 ```
 The files SHOULD be owned by your webserver user/group (e.g. ```www-data``` or ```apache```) the mode SHOULD be 644 for files and 755 for directories.
@@ -565,11 +565,11 @@ To apply a major update (e.g. v5.4.0 to 6.0) please check that your OS has the [
 
 ```
 git fetch
-git checkout release_6
+git checkout release_7
 composer install --no-dev
 ```
 
-Replace ```release_6``` with the branch or tag you actually want to upgrade to. You can get a list of available branches by executing ```git branch -a``` and a list of all available tags by executing ```git tag```. Never use ```trunk``` or ```*beta``` for production.
+Replace ```release_7``` with the branch or tag you actually want to upgrade to. You can get a list of available branches by executing ```git branch -a``` and a list of all available tags by executing ```git tag```. Never use ```trunk``` or ```*beta``` for production.
 
 In case of merge conflicts refer to [Resolving Conflicts - ILIAS Development Guide](http://www.ilias.de/docu/goto.php?target=pg_15604).
 
@@ -659,15 +659,15 @@ The ILIAS Testserver (https://test7.ilias.de) is currently configured as follows
 | Package        | Version                     |
 |----------------|-----------------------------|
 | Distribution   | Ubuntu 20.04 LTS            |
-| MariaDB        | 10.3                        |
-| PHP            | 7.4                         |
-| Nginx          | 1.16                        |
+| MariaDB        | 10.0.38                     |
+| PHP            | 7.3                         |
+| Apache2        | 2.4.18                      |
 | zip            | 3.0                         |
 | unzip          | 6.00                        |
-| JDK            | OpenJDK 11                  |
-| Node.js        | 12 LTS                      |
+| JDK            | OpenJDK 8                   |
+| Node.js        | 10.23.0                     |
 | wkhtmltopdf    | 0.12.5                      |
-| Ghostscript    | 9.51                        |
-| Imagemagick    | 6.9.10-23 Q16               |
+| Ghostscript    | 9.26                        |
+| Imagemagick    | 6.8.9-9 Q16                 |
 
 Please note: Shibboleth won't work with Nginx.


### PR DESCRIPTION
Hi @ILIAS-eLearning/technical-board !

I would like to use this Pull request as platform to discuss some changes, which could be made to the installation page. The first commit is just about changing facts like release names and test server configuration.

1. Recommended Setup for Running ILIAS
 - Shouldn't we recommend any more recent OS here? 
 - Set OpenJDK to 8

2. PHP Installation/Configuration
 - This chapter should be moved before chapter "Build PHP-Dependencies and Artifacts"

3. WebDAV Configuration (OPTIONAL)
 - There is an configuration available to use php-fpm aside with webDAV as i remember correctly. An apache configuration could looke like this:
```
<FilesMatch  \.php$>
                        SSLOptions +StdEnvVars
                        SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
                        SetHandler "proxy:unix:/var/run/php/php7.3-fpm.sock|fcgi://localhost/"
</FilesMatch>
```
I don't have any experience with nginx so far. We should ask some nginx experienced admin for an example here.

4. Install other Depedencies
 - Remove Ubuntu 14.04 as it is outdated.

5. Installation Wizard
 - Has to be rewritten completely, as the setup page is not available anymore. My thoughts would be an explanation with an minimal config.json and a reference to the setup pages.

6. Upgrading ILIAS
 - I would like to change the link from github releases to the release page on docu.ilias.de as there are more informations avaiable.

7. Database Update
 - This needs also an rewrite to the new setup CLI. Should I do this or @klees ?

These are my few cents which our install.md could benefit from. If you have some ideas too, feel free to comment and discuss here and I will merge all approved ideas.

Regards,
Fabian Wolf

Systemadministrator
ILIAS open source e-Learning e.V.