### PR TITLE
Fixes Use of undefined constant TIMING_NEVER error.

### DIFF
--- a/Modules/Scorm2004/classes/adlparser/SeqActivity.php
+++ b/Modules/Scorm2004/classes/adlparser/SeqActivity.php
@@ -55,7 +55,7 @@
    define("TIMING_ONCE", "once");
    define("TIMING_EACHNEW", "onEachNewAttempt");
    define("TER_EXITALL", "_EXITALL_");
-
+   define("TIMING_NEVER", "never");
 
 class SeqActivity
 {


### PR DESCRIPTION
defines sequencing subsystem constant that was not defined.