### PR TITLE
Migrate WebDAV Settings to DB for ILIAS7

### DIFF
--- a/Services/WebDAV/classes/class.ilObjWebDAV.php
+++ b/Services/WebDAV/classes/class.ilObjWebDAV.php
@@ -92,28 +92,6 @@ class ilObjWebDAV extends ilObject
     }
 
     /**
-     * Sets the webdavActionsVisible property.
-     *
-     * @param boolean    new value
-     *
-     * @return    void
-     */
-    public function setWebdavActionsVisible($newValue)
-    {
-        $this->webdavActionsVisible = $newValue;
-    }
-
-    /**
-     * Gets the webdavActionsVisible property.
-     *
-     * @return    boolean    value
-     */
-    public function isWebdavActionsVisible()
-    {
-        return $this->webdavActionsVisible;
-    }
-
-    /**
      * Gets the defaultWebfolderInstructions property.
      * This is a read only property. The text is retrieved from $lng.
      *
@@ -180,25 +158,10 @@ class ilObjWebDAV extends ilObject
     private function write()
     {
         global $DIC;
-        $ilClientIniFile = $DIC['ilClientIniFile'];
         $settings = new ilSetting('webdav');
 
-        // Clear any old error messages
-        $ilClientIniFile->error(null);
-
-        if (!$ilClientIniFile->groupExists('file_access')) {
-            $ilClientIniFile->addGroup('file_access');
-        }
         $settings->set('webdav_enabled', $this->webdavEnabled ? '1' : '0');
         $settings->set('webdav_versioning_enabled', $this->webdavVersioningEnabled ? '1' : '0');
-        $ilClientIniFile->setVariable('file_access', 'webdav_actions_visible', $this->webdavActionsVisible ? '1' : '0');
-        $ilClientIniFile->write();
-
-        if ($ilClientIniFile->getError()) {
-            global $DIC;
-            $ilErr = $DIC['ilErr'];
-            $ilErr->raiseError($ilClientIniFile->getError(), $ilErr->WARNING);
-        }
     }
 
     /**
@@ -210,30 +173,8 @@ class ilObjWebDAV extends ilObject
 
         global $DIC;
         $settings = new ilSetting('webdav');
-        $ilClientIniFile = $DIC['ilClientIniFile'];
         $this->webdavEnabled = $settings->get('webdav_enabled', '0') == '1';
         // default_value = 1 for versionigEnabled because it was already standard before ilias5.4
         $this->webdavVersioningEnabled = $settings->get('webdav_versioning_enabled', '1') == '1';
-        $this->webdavActionsVisible = $ilClientIniFile->readVariable('file_access', 'webdav_actions_visible') == '1';
-        $ilClientIniFile->ERROR = false;
     }
-
-    /**
-     * Gets instructions for the usage of webfolders.
-     *
-     * The instructions consist of HTML text with placeholders.
-     * See _getWebfolderInstructionsFor for a description of the supported
-     * placeholders.
-     *
-     * @return String HTML text with placeholders.
-     */
-    public static function _getDefaultWebfolderInstructions()
-    {
-        global $lng;
-
-        return $lng->txt('webfolder_instructions_text');
-    }
-
-
-
 }

--- a/Services/WebDAV/classes/class.ilObjWebDAV.php
+++ b/Services/WebDAV/classes/class.ilObjWebDAV.php
@@ -92,40 +92,6 @@ class ilObjWebDAV extends ilObject
     }
 
     /**
-     * Gets the defaultWebfolderInstructions property.
-     * This is a read only property. The text is retrieved from $lng.
-     *
-     * @return    String    value
-     */
-    public function getDefaultWebfolderInstructions()
-    {
-        return self::_getDefaultWebfolderInstructions();
-    }
-
-    /**
-     * Gets the customWebfolderInstructionsEnabled property.
-     *
-     * @return    boolean    value
-     */
-    public function isCustomWebfolderInstructionsEnabled()
-    {
-        return $this->customWebfolderInstructionsEnabled;
-    }
-
-    /**
-     * Sets the customWebfolderInstructionsEnabled property.
-     *
-     * @param boolean new value.
-     *
-     * @return    void
-     */
-    public function setCustomWebfolderInstructionsEnabled($newValue)
-    {
-        $this->customWebfolderInstructionsEnabled = $newValue;
-    }
-
-
-    /**
      * create
      *
      * note: title, description and type should be set when this function is called

--- a/Services/WebDAV/classes/class.ilObjWebDAV.php
+++ b/Services/WebDAV/classes/class.ilObjWebDAV.php
@@ -189,7 +189,7 @@ class ilObjWebDAV extends ilObject
         if (!$ilClientIniFile->groupExists('file_access')) {
             $ilClientIniFile->addGroup('file_access');
         }
-        $ilClientIniFile->setVariable('file_access', 'webdav_enabled', $this->webdavEnabled ? '1' : '0');
+        $settings->set('webdav_enabled', $this->webdavEnabled ? '1' : '0');
         $settings->set('webdav_versioning_enabled', $this->webdavVersioningEnabled ? '1' : '0');
         $ilClientIniFile->setVariable('file_access', 'webdav_actions_visible', $this->webdavActionsVisible ? '1' : '0');
         $ilClientIniFile->write();
@@ -211,7 +211,7 @@ class ilObjWebDAV extends ilObject
         global $DIC;
         $settings = new ilSetting('webdav');
         $ilClientIniFile = $DIC['ilClientIniFile'];
-        $this->webdavEnabled = $ilClientIniFile->readVariable('file_access', 'webdav_enabled') == '1';
+        $this->webdavEnabled = $settings->get('webdav_enabled', '0') == '1';
         // default_value = 1 for versionigEnabled because it was already standard before ilias5.4
         $this->webdavVersioningEnabled = $settings->get('webdav_versioning_enabled', '1') == '1';
         $this->webdavActionsVisible = $ilClientIniFile->readVariable('file_access', 'webdav_actions_visible') == '1';

--- a/Services/WebDAV/classes/class.ilObjWebDAVGUI.php
+++ b/Services/WebDAV/classes/class.ilObjWebDAVGUI.php
@@ -87,21 +87,21 @@ class ilObjWebDAVGUI extends ilObjectGUI
         $this->type = "wbdv";
         parent::__construct($a_data, $a_id, $a_call_by_reference, false);
 
-        $this->ctrl             = $DIC['ilCtrl'];
-        $this->db               = $DIC->database();
-        $this->error_handling   = $DIC["ilErr"];
-        $this->filesystem       = $DIC->filesystem();
-        $this->http             = $DIC->http();
-        $this->lng              = $DIC->language();
-        $this->logger           = $DIC->logger()->root();
-        $this->rbacsystem       = $DIC['rbacsystem'];
-        $this->settings         = $DIC['ilSetting'];
-        $this->tabs             = $DIC['ilTabs'];
-        $this->tpl              = $DIC['tpl'];
-        $this->tree             = $DIC['tree'];
-        $this->ui_factory       = $DIC->ui()->factory();
-        $this->ui_renderer      = $DIC->ui()->renderer();
-        $this->upload           = $DIC->upload();
+        $this->ctrl = $DIC['ilCtrl'];
+        $this->db = $DIC->database();
+        $this->error_handling = $DIC["ilErr"];
+        $this->filesystem = $DIC->filesystem();
+        $this->http = $DIC->http();
+        $this->lng = $DIC->language();
+        $this->logger = $DIC->logger()->root();
+        $this->rbacsystem = $DIC['rbacsystem'];
+        $this->settings = $DIC['ilSetting'];
+        $this->tabs = $DIC['ilTabs'];
+        $this->tpl = $DIC['tpl'];
+        $this->tree = $DIC['tree'];
+        $this->ui_factory = $DIC->ui()->factory();
+        $this->ui_renderer = $DIC->ui()->renderer();
+        $this->upload = $DIC->upload();
     }
 
 

--- a/Services/WebDAV/classes/dav/class.ilObjFileDAV.php
+++ b/Services/WebDAV/classes/dav/class.ilObjFileDAV.php
@@ -150,7 +150,7 @@ class ilObjFileDAV extends ilObjectDAV implements Sabre\DAV\IFile
                 fileinode($path) .
                 filesize($path) .
                 filemtime($path)
-                ) . '"';
+            ) . '"';
         }
         
         return null;

--- a/Services/WebDAV/test/mount_instructions/ilWebDAVMountInstructionsDocumentProcessorBaseTest.php
+++ b/Services/WebDAV/test/mount_instructions/ilWebDAVMountInstructionsDocumentProcessorBaseTest.php
@@ -5,11 +5,9 @@ use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 
 class ilWebDAVMountInstructionsDocumentProcessorBaseTest extends TestCase
 {
-
     private function createDocumentProcessorBaseObject()
     {
-        return new class extends ilWebDAVMountInstructionsDocumentProcessorBase
-        {
+        return new class extends ilWebDAVMountInstructionsDocumentProcessorBase {
             public function processMountInstructions(string $a_raw_mount_instructions) : array
             {
                 return null;

--- a/setup/sql/dbupdate_05.php
+++ b/setup/sql/dbupdate_05.php
@@ -5465,7 +5465,7 @@ if ($ilDB->tableExists('pdfgen_renderer')) {
 $disk_quota_settings = new ilSetting('disk_quota');
 $disk_quota_settings->deleteAll();
 ?>
-<#5732>
+<#5733>
 <?php
 // Get settings
 $settings = new ilSetting('webdav');

--- a/setup/sql/dbupdate_05.php
+++ b/setup/sql/dbupdate_05.php
@@ -5424,7 +5424,6 @@ $ilDB->update('settings',
         'keyword' => ['text', 'webdav_versioning_enabled']
     ]);
 ?>
-
 <#5728>
 <?php
 if (!$ilDB->tableColumnExists('didactic_tpl_settings','icon_ide')) {
@@ -5465,4 +5464,18 @@ if ($ilDB->tableExists('pdfgen_renderer')) {
 <?php
 $disk_quota_settings = new ilSetting('disk_quota');
 $disk_quota_settings->deleteAll();
+?>
+<#5732>
+<?php
+// Get settings
+$settings = new ilSetting('webdav');
+
+// Get client ini
+$ini_file = CLIENT_WEB_DIR . "/client.ini.php";
+$ilClientIniFile = new ilIniFile($ini_file);
+$ilClientIniFile->read();
+
+// Migrate value 'webdav_enabled from client.ini to database
+$webdav_enabled = $ilClientIniFile->readVariable('file_access', 'webdav_enabled') == '1';
+$settings->set('webdav_enabled', $webdav_enabled ? '1' : '0');
 ?>


### PR DESCRIPTION
With this PR, I moved the settings if WebDAV is enabled from the client.ini file to the database. (1. commit)

Additionally, there is some cleanup of unused settings and methods in the new ilObjWebDAV file. (2. commit)

@klees I'm not sure about the DB-Update part. My idea was to migrate the existing setting `webdav_enabled` from the client.ini file to the database. But the reading of the client.ini file looks kind of hacky to me in the database migrations. What is your opinion about it?