### PR TITLE
ilCtrl: Add cheap option to enable CSRF token verification for HTTP GE…

### DIFF
--- a/Modules/LearningModule/Presentation/classes/class.ilLMPresentationGUI.php
+++ b/Modules/LearningModule/Presentation/classes/class.ilLMPresentationGUI.php
@@ -376,8 +376,17 @@ class ilLMPresentationGUI
         }
         
         $next_class = $this->ctrl->getNextClass($this);
-        $cmd = $this->ctrl->getCmd("layout", array("showPrintView"));
+        $cmd = $this->ctrl->getCmd("layout", new class implements ilCtrlCommandSecurity {
+            public function getSafePostCommands() : array
+            {
+                return ['showPrintView'];
+            }
 
+            public function getUnsafeGetCommands() : array
+            {
+                return [];
+            }
+        });
 
         $obj_id = $this->requested_obj_id;
         $this->ctrl->setParameter($this, "obj_id", $this->requested_obj_id);

--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -94,7 +94,17 @@ class ilStartUpGUI
      */
     public function executeCommand()
     {
-        $cmd = $this->ctrl->getCmd("processIndexPHP", array('processIndexPHP','showLoginPage'));
+        $cmd = $this->ctrl->getCmd("processIndexPHP", new class implements ilCtrlCommandSecurity {
+            public function getSafePostCommands() : array
+            {
+                return ['processIndexPHP','showLoginPage'];
+            }
+
+            public function getUnsafeGetCommands() : array
+            {
+                return [];
+            }
+        });
         $next_class = $this->ctrl->getNextClass($this);
 
         switch ($next_class) {

--- a/Services/UICore/classes/class.ilCtrl.php
+++ b/Services/UICore/classes/class.ilCtrl.php
@@ -1383,14 +1383,16 @@ class ilCtrl
         $a_cmd = "",
         $a_anchor = "",
         $a_asynch = false,
-        $xml_style = false
+        $xml_style = false,
+        bool $append_csrf_token = false
     ) {
         $script = $this->getLinkTargetByClass(
             strtolower(get_class($a_gui_obj)),
             $a_cmd,
             $a_anchor,
             $a_asynch,
-            $xml_style
+            $xml_style,
+            $append_csrf_token
         );
         return $script;
     }
@@ -1412,7 +1414,8 @@ class ilCtrl
         $a_cmd = "",
         $a_anchor = "",
         $a_asynch = false,
-        $xml_style = false
+        $xml_style = false,
+        bool $append_csrf_token = false
     ) {
         if ($a_asynch) {
             $xml_style = false;
@@ -1426,11 +1429,13 @@ class ilCtrl
             $script .= $amp . "cmdMode=asynch";
         }
 
-        $script = ilUtil::appendUrlParameterString(
-            $script,
-            self::IL_RTOKEN_NAME . '=' . $this->getRequestToken(),
-            $xml_style
-        );
+        if ($append_csrf_token) {
+            $script = ilUtil::appendUrlParameterString(
+                $script,
+                self::IL_RTOKEN_NAME . '=' . $this->getRequestToken(),
+                $xml_style
+            );
+        }
 
         if ($a_anchor != "") {
             $script = $script . "#" . $a_anchor;

--- a/Services/UICore/classes/class.ilCtrl.php
+++ b/Services/UICore/classes/class.ilCtrl.php
@@ -936,7 +936,7 @@ class ilCtrl
         $cmd = "";
         if (isset($_GET['cmd'])) {
             $cmd = $_GET['cmd'];
-            if ($unsafeGetCommands !== [] && in_array($cmd, $unsafeGetCommands)) {
+            if (in_array($cmd, $unsafeGetCommands)) {
                 if ($this->verified_cmd !== '') {
                     return $this->verified_cmd;
                 } elseif (!$this->verifyToken()) {

--- a/Services/UICore/classes/class.ilCtrl.php
+++ b/Services/UICore/classes/class.ilCtrl.php
@@ -939,11 +939,10 @@ class ilCtrl
             if ($unsafeGetCommands !== [] && in_array($cmd, $unsafeGetCommands)) {
                 if ($this->verified_cmd !== '') {
                     return $this->verified_cmd;
-                } else {
-                    if (!$this->verifyToken()) {
-                        return $a_default_cmd;
-                    }
+                } elseif (!$this->verifyToken()) {
+                    return $a_default_cmd;
                 }
+
                 $this->verified_cmd = $cmd;
             }
         }
@@ -954,16 +953,12 @@ class ilCtrl
             }
             $cmd = isset($_POST["cmd"]) && is_array($_POST["cmd"]) ? key($_POST["cmd"]) : '';
 
-            // verify command
             if ($this->verified_cmd != "") {
                 return $this->verified_cmd;
-            } else {
-                if (!$this->verifyToken() &&
-                    (!is_array($safePostCommands) || !in_array($cmd, $safePostCommands))) {
-                    return $a_default_cmd;
-                }
+            } elseif (!in_array($cmd, $safePostCommands) && !$this->verifyToken()) {
+                return $a_default_cmd;
             }
-            
+
             $this->verified_cmd = $cmd;
             if ($cmd == "" && isset($_POST["table_top_cmd"])) {		// selected command in multi-list (table2)
                 $cmd = key($_POST["table_top_cmd"]);

--- a/Services/UICore/interfaces/interface.ilCtrlCommandSecurity.php
+++ b/Services/UICore/interfaces/interface.ilCtrlCommandSecurity.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+/**
+ * @author Michael Jansen <mjansen@databay.de>
+ */
+interface ilCtrlCommandSecurity
+{
+    /**
+     * Returns a list of command strings provided in the HTTP POST body, where a CSRF token is not verified by ilCtrl
+     * @return string[]
+     */
+    public function getSafePostCommands() : array;
+
+    /**
+     * Returns a list of command strings provided in the HTTP query string, where a CSRF token MUST be verified by ilCtrl
+     * @return string[]
+     */
+    public function getUnsafeGetCommands() : array;
+}


### PR DESCRIPTION
…T request commands

Maybe these changes could be a 'cheap' approach to support CSRF tokens for command strings passed in HTTP GET requests.

I did a regex based search for `->getCmd\([^\)]+?,(.+?)\)` and only found 2 usages where `Safe POST commands` were passed, with this PR we instead introduced some `configuration object`.

## Consumer Code

### Link Creation

In this example case, we offer a link to the user in a listing of forum postings. If the user clicks on the link, the system state will be modified (here: mark a posting as read):

```php
$this->ctrl->setParameterByClass(ilObjForumGUI::class, 'pos_pk', 4711);

$link = $this->ctrl->getLinkTarget(
    ilObjForumGUI::class,
    'markPostRead',
    'posting-4711',
    false,
    false,
    true // Yes, this is (unfortunately) another parameter beingt introduced with this PR ...
);
```
The CSRF token is appended to this URL only, not to other URLs contained in the HTML response being send to the browser.

### Command Retrieval from `ilCtrl`

If we wan't to process this request, we'll have to retrieve the command from `ilCtrl`. We'll have to tell `ilCtrl` that `markPostUnread` is a state modifying command where a CSRF token has to be checked in consequence.

```php
        $cmd = $this->ctrl->getCmd('showContent', new class implements ilCtrlCommandSecurity {
            public function getSafePostCommands() : array
            {
                return [];
            }

            public function getUnsafeGetCommands() : array
            {
                return ['markPostUnread'];
            }

        });
```

Result: If the command `markPostUnread` is given in a HTTP GET request, the CSRF token will be verified. If the verification fails, the default command will be returned by `ilCtrl`. This is the same behaviour already implemented for failed CSRF token verifications in HTTP POST requests.

----

This approach could be a way to handle security issues being reported for the internal views (user is logged in), where system state is currently modified by HTTP GET requests.