### PR TITLE
Component/Setup: use generalized objectives for plugin updates (#29169)

### DIFF
--- a/Services/Component/classes/Setup/class.ilComponentActivatePluginsObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentActivatePluginsObjective.php
@@ -47,13 +47,8 @@ class ilComponentActivatePluginsObjective implements Setup\Objective
      */
     public function getPreconditions(Setup\Environment $environment) : array
     {
-        $setup_config = $environment->getConfigFor('common');
-        $db_config = $environment->getConfigFor('database');
-
         return [
-            new \ilIniFilesPopulatedObjective($setup_config),
-            new \ilDatabasePopulatedObjective($db_config),
-            new \ilComponentPluginAdminInitObjective()
+            new \ilComponentUpdatePluginObjective($this->plugin_name)
         ];
     }
 

--- a/Services/Component/classes/Setup/class.ilComponentPluginAdminInitObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentPluginAdminInitObjective.php
@@ -34,6 +34,10 @@ class ilComponentPluginAdminInitObjective implements Setup\Objective
      */
     public function getPreconditions(Setup\Environment $environment) : array
     {
+        if (!$environment->hasConfigFor('language')) {
+            return [];
+        }
+
         $config = $environment->getConfigFor('language');
         return [
             new \ilLanguagesInstalledObjective($config, new ilSetupLanguage('en'))

--- a/Services/Component/classes/Setup/class.ilComponentUpdatePluginObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentUpdatePluginObjective.php
@@ -47,12 +47,9 @@ class ilComponentUpdatePluginObjective implements Setup\Objective
      */
     public function getPreconditions(Setup\Environment $environment) : array
     {
-        $setup_config = $environment->getConfigFor('common');
-        $db_config = $environment->getConfigFor('database');
-
         return [
-            new \ilIniFilesPopulatedObjective($setup_config),
-            new \ilDatabasePopulatedObjective($db_config),
+            new \ilIniFilesLoadedObjective(),
+            new \ilDatabaseInitializedObjective(),
             new \ilComponentPluginAdminInitObjective()
         ];
     }


### PR DESCRIPTION
This fixes [#29169](https://mantis.ilias.de/view.php?id=29169) by using objectives that do not depend on configs.

