### PR TITLE
Http/Setup: collect proxy config from settings (not ini) (#29177)

### DIFF
--- a/Services/Http/classes/Setup/class.ilHttpMetricsCollectedObjective.php
+++ b/Services/Http/classes/Setup/class.ilHttpMetricsCollectedObjective.php
@@ -66,13 +66,13 @@ class ilHttpMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
             $host = new Setup\Metrics\Metric(
                 Setup\Metrics\Metric::STABILITY_CONFIG,
                 Setup\Metrics\Metric::TYPE_TEXT,
-                $ini->get("proxy_host"),
+                $settings->get("proxy_host"),
                 "The host of the proxy."
             );
             $host = new Setup\Metrics\Metric(
                 Setup\Metrics\Metric::STABILITY_CONFIG,
                 Setup\Metrics\Metric::TYPE_TEXT,
-                $ini->get("proxy_host"),
+                $settings->get("proxy_host"),
                 "The port of the proxy."
             );
             $proxy = new Setup\Metrics\Metric(


### PR DESCRIPTION
Hi @smeyer-ilias,

this fixes [#29177](https://mantis.ilias.de/view.php?id=29177) by reading the proxy config from the settings.

Best regards!