### PR TITLE
Setup/File/Database: guard definition of constants

### DIFF
--- a/Modules/File/classes/Setup/class.ilFileObjectToStorageMigration.php
+++ b/Modules/File/classes/Setup/class.ilFileObjectToStorageMigration.php
@@ -143,5 +143,4 @@ class ilFileObjectToStorageMigration implements Setup\Migration
 
         return $this->helper->getAmountOfItems();
     }
-
 }


### PR DESCRIPTION
Hi @chfsx,

I added some guards to the definition of constants in the setup of `Services/Database` and `Services/File` to prevent according notices.

Please also merge to trunk, if you decide to use this.

Best regards!