### PR TITLE
Setup/Chatroom: use null-object for config instead (#29226)

### DIFF
--- a/Modules/Chatroom/classes/Setup/class.ilChatroomSetupAgent.php
+++ b/Modules/Chatroom/classes/Setup/class.ilChatroomSetupAgent.php
@@ -66,7 +66,7 @@ class ilChatroomSetupAgent implements Setup\Agent
         // TODO: clean this up
         return $this->refinery->custom()->transformation(function ($data) use ($levels, $intervals) {
             if (is_null($data)) {
-                return null;
+                return new Setup\NullConfig();
             }
 
             $protocol = 'http://';
@@ -149,7 +149,9 @@ class ilChatroomSetupAgent implements Setup\Agent
      */
     public function getInstallObjective(Setup\Config $config = null) : Setup\Objective
     {
-        if ($config === null) {
+        // null would not be valid here, because this agents strictly wants to have
+        // a config.
+        if ($config instanceof Setup\NullConfig) {
             return new Setup\Objective\NullObjective();
         }
 
@@ -161,7 +163,9 @@ class ilChatroomSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        if ($config === null) {
+        // null would be valid here, because our user might just not have passed
+        // one during update.
+        if ($config === null || $config instanceof Setup\NullConfig) {
             return new Setup\Objective\NullObjective();
         }
 

--- a/src/Setup/NullConfig.php
+++ b/src/Setup/NullConfig.php
@@ -1,0 +1,12 @@
+<?php
+
+/* Copyright (c) 2019 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Setup;
+
+/**
+ * A configuration with no content.
+ */
+class NullConfig implements Config
+{
+}


### PR DESCRIPTION
Using a null object allows to distinguish better between "simply not there" and "intentionally not set".

Please be so kind and pick this into trunk as well, if you are fine with the change. Thx!