### PR TITLE
Refinery: Fix language mock in unit tests (see Mantis 29247)

### DIFF
--- a/tests/Refinery/ConstraintViolationExceptionTest.php
+++ b/tests/Refinery/ConstraintViolationExceptionTest.php
@@ -1,7 +1,7 @@
 <?php
 /* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-use PHPUnit\Framework\TestCase;
+namespace ILIAS\Tests\Refinery;
 
 /**
  * @author  Niels Theen <ntheen@databay.de>

--- a/tests/Refinery/TestCase.php
+++ b/tests/Refinery/TestCase.php
@@ -7,6 +7,7 @@
 
 namespace ILIAS\Tests\Refinery;
 
+use ilGlobalTemplateInterface;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 
 require_once('./libs/composer/vendor/autoload.php');


### PR DESCRIPTION
Mantis Issue: https://mantis.ilias.de/view.php?id=29247

This has to be cherry-picked to all stable release branches.