### PR TITLE
add lang pd_personal_workspace

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -16426,3 +16426,4 @@ adn#:#msg_dismissable_info#:#Benutzer können Ankündigung schließen und sehen 
 adn#:#msg_form_button_updateAndStay#:#Sichern und bleiben
 adn#:#common_actions#:#Aktionen
 adn#:#common_add_msg#:#Ankündigung hinzufügen
+pd#:#pd_personal_workspace#:#Persönlicher Arbeitsraum

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -16435,3 +16435,4 @@ mob#:#mob_external_url#:#External URL
 mob#:#mob_choose_from_pool#:#Choose from Media Pool
 mob#:#mob_url#:#URL
 mob#:#mob_url_info#:#Externe URL, z.B. Youtube oder Vimeo URL.
+pd#:#pd_personal_workspace#:#Personal Workspace


### PR DESCRIPTION
pd_personal_workspace is missing here in ILIAS 6:
- Personal Workspace -> Portfolio -> Add Portfolio
![Screenshot_2020-11-26 DEV ILIAS Next Portfolio](https://user-images.githubusercontent.com/29703577/100327548-b961e800-2fcb-11eb-992d-c9ac93ae5da2.png)
