### PR TITLE
Test/Export: Make ref_id injectable to avoid dependency to global …

### DIFF
--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -10437,7 +10437,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
     {
         include_once "./Modules/Test/classes/class.ilObjTestGUI.php";
         include_once "./Modules/Test/classes/tables/class.ilEvaluationAllTableGUI.php";
-        $table_gui = new ilEvaluationAllTableGUI(new ilObjTestGUI(''), 'outEvaluation', $this->getAnonymity());
+        $table_gui = new ilEvaluationAllTableGUI(new ilObjTestGUI($this->getRefId()), 'outEvaluation', $this->getAnonymity());
         return $table_gui->getSelectedColumns();
     }
 

--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -88,8 +88,9 @@ class ilObjTestGUI extends ilObjectGUI
     /**
      * Constructor
      * @access public
+     * @param mixed|null $refId
      */
-    public function __construct()
+    public function __construct($refId = null)
     {
         global $DIC;
         $lng = $DIC['lng'];
@@ -101,7 +102,10 @@ class ilObjTestGUI extends ilObjectGUI
         $this->type = "tst";
         $this->ctrl = $ilCtrl;
         $this->ctrl->saveParameter($this, array("ref_id", "test_ref_id", "calling_test", "test_express_mode", "q_id"));
-        parent::__construct("", $_GET["ref_id"], true, false);
+        if (isset($_GET['ref_id']) && is_numeric($_GET['ref_id'])) {
+            $refId = (int) $_GET['ref_id'];
+        }
+        parent::__construct("", (int) $refId, true, false);
 
         if ($this->object instanceof ilObjTest) {
             require_once 'Modules/Test/classes/class.ilTestQuestionSetConfigFactory.php';


### PR DESCRIPTION
…HTTP state

Background: The test exporter factory and the concrete export strategies for the different test modes depend on ilObjTestGUI when calling `ilObjTest::getEvaluationAdditionalFields`. With this change, the export classes could be used in other endpoints (SOAP, REST, you name it ...), where no $_GET['ref_id'] is given.