### PR TITLE
Add Documentation for Expert Groups

### DIFF
--- a/docs/development/expert-groups.md
+++ b/docs/development/expert-groups.md
@@ -1,0 +1,39 @@
+# Experts Groups
+
+**Expert Groups support the ILIAS community in improving quality aspects in the
+fields of usability, performance, security, software architecture and the
+development process.** These cross cutting concerns are the responsibility of
+the Technical Board, as assigned by the by-laws of the ILIAS society. Still,
+these fields cannot be treated effectively by the Technical Board alone but
+need broad consideration in all stages of the development process. The expert
+groups are meant to help the community and the Technical Board by providing
+knowledge and insights in various forms.
+
+To do that, **the groups will work on any means that serve the goal to improve
+quality e.g. consultancy, tools, code, concepts, documentation, guideline, process
+definitions.** Depending on the field, the state of the art in that field and the
+problem at hand, different approaches for improvements may be conceivable. The
+expert group are expected to identify and propose means that are effective,
+efficient and appropriate.
+
+To implement them, **the experts use existing processes for decision making, e.g.
+the Jour Fixe**, if required. They are also expected to use other processes and
+tools provided by the ILIAS community, such as the Mantis Issue Tracker, GitHub,
+the ILIAS conference and the development conference. The experts should convince
+other community members by tangible reasoning, just as other community members.
+
+To indicate a special trust of the TB, the **expert groups are appointed by the
+Technical Board**. This also gives the experts a special visibility in the
+community. **The members of the experts groups are appointed for their well-founded
+knowledge in the respective field**. They all are willing and able to
+contribute and share that knowledge. **All members of expert groups will be listed
+publicly.** The TB is looking to include all people with the required expertise
+and the willingness to contribute. **Membership applications can be handed in to
+the various expert groups. The Technical Board will confirm memberships and ensure
+the general working capacity of the groups.**
+
+The TB expects the experts to contribute their insights, opinions and criticism
+as early as possible in the development process. Also, the TB expects all community
+members to seak the experts advice and listen to their feedback. **The Technical
+Board is committed to make the experts opinions heard in the development of ILIAS.
+Recommendations by experts will have a strong impact on the decisions of the TB.** 


### PR DESCRIPTION
Dear community,

in the past year, the [SIG Client](https://docu.ilias.de/goto_docu_grp_4941.html) had a series of workshops, using the technique of a "Zukunftswerkstatt". General goal of the workshops was to generate ideas how to move the client side of ILIAS into the future. One output of the session in [November 2019](https://docu.ilias.de/goto_docu_sess_8042.html) was the idea to create a group of UI/UX experts that were supposed to help on all stages of the development process with their knowledge.

This idea has been adopted by the [Technical Board](https://docu.ilias.de/goto_docu_grp_5089.html). We elaborated it into a general framework for experts in the various fields that are identified as the cross cutting concerns the TB is responsible of. We hereby want to present that general framework.

We expect, that a combined UI/UX/Accessibility expert group will be the first concrete group appointed in this framework and will get back to you soon with new results.

Until then we ask for your feedback regarding this framework and will bring it to the attention of the JF.

Best regards!