### PR TITLE
SPRG 29358, 29529, 29522: fixes writing/update of individual plan from program

### DIFF
--- a/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeIndividualPlanGUI.php
+++ b/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeIndividualPlanGUI.php
@@ -174,34 +174,8 @@ class ilObjStudyProgrammeIndividualPlanGUI
             );
         }
         $ass->updateFromProgram();
-
-        $prg = $ass->getStudyProgramme();
-        $prgrs = $ass->getRootProgress();
-        $status = $prgrs->getStatus();
-        if (
-            $status == ilStudyProgrammeProgress::STATUS_COMPLETED ||
-            $status == ilStudyProgrammeProgress::STATUS_ACCREDITED
-        ) {
-            $validity_settings = $prg->getValidityOfQualificationSettings();
-            $period = $validity_settings->getQualificationPeriod();
-            $date = $validity_settings->getQualificationDate();
-            if ($period) {
-                $date = $prgrs->getCompletionDate();
-                $date->add(new DateInterval('P' . $period . 'D'));
-            }
-            $prgrs->setValidityOfQualification($date);
-            $prgrs->storeProgress();
-        } else { //not completed/accredited
-            $deadline_settings = $prg->getDeadlineSettings();
-            $period = $deadline_settings->getDeadlinePeriod();
-            $date = $deadline_settings->getDeadlineDate();
-            if ($period) {
-                $date = $prgrs->getAssignmentDate();
-                $date->add(new DateInterval('P' . $period . 'D'));
-            }
-            $prgrs->setDeadline($date);
-            $prgrs->storeProgress();
-        }
+        $ass->updateValidityFromProgram();
+        $ass->updateDeadlineFromProgram();
 
         $this->ctrl->setParameter($this, "ass_id", $ass->getId());
         $this->showSuccessMessage("update_from_plan_successful");

--- a/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeMembersGUI.php
+++ b/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeMembersGUI.php
@@ -658,8 +658,27 @@ class ilObjStudyProgrammeMembersGUI
                     }
                     $prgrs->setValidityOfQualification($date);
                 }
+                $prgrs->storeProgress();
             }
             /** 29529 end ----------- */
+
+            /** 29358 --------------- */
+            else { //not completed/accredited
+                $deadline_settings = $prg->getDeadlineSettings();
+                $period = $deadline_settings->getDeadlinePeriod();
+                $date = $deadline_settings->getDeadlineDate();
+                if (!$period && !$date) {
+                    $prgrs->setDeadline(null);
+                } else {
+                    if ($period) {
+                        $date = $prgrs->getAssignmentDate();
+                        $date->add(new DateInterval('P' . $period . 'D'));
+                    }
+                    $prgrs->setDeadline($date);
+                }
+                $prgrs->storeProgress();
+            }
+            /** 29358 end ----------- */
         }
 
         if (count($not_updated) == count($prgrs_ids)) {

--- a/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeMembersGUI.php
+++ b/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeMembersGUI.php
@@ -639,32 +639,8 @@ class ilObjStudyProgrammeMembersGUI
             }
 
             $ass->updateFromProgram();
-
-            $status = $prgrs->getStatus();
-            if (
-                $status == ilStudyProgrammeProgress::STATUS_COMPLETED ||
-                $status == ilStudyProgrammeProgress::STATUS_ACCREDITED
-            ) {
-                $validity_settings = $prg->getValidityOfQualificationSettings();
-                $period = $validity_settings->getQualificationPeriod();
-                $date = $validity_settings->getQualificationDate();
-                if ($period) {
-                    $date = $prgrs->getCompletionDate();
-                    $date->add(new DateInterval('P' . $period . 'D'));
-                }
-                $prgrs->setValidityOfQualification($date);
-                $prgrs->storeProgress();
-            } else { //not completed/accredited
-                $deadline_settings = $prg->getDeadlineSettings();
-                $period = $deadline_settings->getDeadlinePeriod();
-                $date = $deadline_settings->getDeadlineDate();
-                if ($period) {
-                    $date = $prgrs->getAssignmentDate();
-                    $date->add(new DateInterval('P' . $period . 'D'));
-                }
-                $prgrs->setDeadline($date);
-                $prgrs->storeProgress();
-            }
+            $ass->updateValidityFromProgram();
+            $ass->updateDeadlineFromProgram();
         }
 
         if (count($not_updated) == count($prgrs_ids)) {

--- a/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeMembersGUI.php
+++ b/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeMembersGUI.php
@@ -628,6 +628,7 @@ class ilObjStudyProgrammeMembersGUI
 
 
         foreach ($prgrs_ids as $key => $prgrs_id) {
+            //** ilStudyProgrammeUserProgress */
             $prgrs = $this->getProgressObject((int) $prgrs_id);
             //** ilStudyProgrammeUserAssignment */
             $ass = $this->sp_user_assignment_db->getInstanceById($prgrs->getAssignmentId());
@@ -639,7 +640,6 @@ class ilObjStudyProgrammeMembersGUI
 
             $ass->updateFromProgram();
 
-            /** 29529 --------------- */
             $status = $prgrs->getStatus();
             if (
                 $status == ilStudyProgrammeProgress::STATUS_COMPLETED ||
@@ -648,37 +648,23 @@ class ilObjStudyProgrammeMembersGUI
                 $validity_settings = $prg->getValidityOfQualificationSettings();
                 $period = $validity_settings->getQualificationPeriod();
                 $date = $validity_settings->getQualificationDate();
-
-                if (!$period && !$date) {
-                    $prgrs->setValidityOfQualification(null);
-                } else {
-                    if ($period) {
-                        $date = $prgrs->getCompletionDate();
-                        $date->add(new DateInterval('P' . $period . 'D'));
-                    }
-                    $prgrs->setValidityOfQualification($date);
+                if ($period) {
+                    $date = $prgrs->getCompletionDate();
+                    $date->add(new DateInterval('P' . $period . 'D'));
                 }
+                $prgrs->setValidityOfQualification($date);
                 $prgrs->storeProgress();
-            }
-            /** 29529 end ----------- */
-
-            /** 29358 --------------- */
-            else { //not completed/accredited
+            } else { //not completed/accredited
                 $deadline_settings = $prg->getDeadlineSettings();
                 $period = $deadline_settings->getDeadlinePeriod();
                 $date = $deadline_settings->getDeadlineDate();
-                if (!$period && !$date) {
-                    $prgrs->setDeadline(null);
-                } else {
-                    if ($period) {
-                        $date = $prgrs->getAssignmentDate();
-                        $date->add(new DateInterval('P' . $period . 'D'));
-                    }
-                    $prgrs->setDeadline($date);
+                if ($period) {
+                    $date = $prgrs->getAssignmentDate();
+                    $date->add(new DateInterval('P' . $period . 'D'));
                 }
+                $prgrs->setDeadline($date);
                 $prgrs->storeProgress();
             }
-            /** 29358 end ----------- */
         }
 
         if (count($not_updated) == count($prgrs_ids)) {

--- a/Modules/StudyProgramme/classes/class.ilStudyProgrammeUserAssignment.php
+++ b/Modules/StudyProgramme/classes/class.ilStudyProgrammeUserAssignment.php
@@ -185,6 +185,44 @@ class ilStudyProgrammeUserAssignment
         return $this;
     }
 
+    public function updateValidityFromProgram() : void
+    {
+        $prg = $this->getStudyProgramme();
+        $progress = $this->getRootProgress();
+        if (!$progress->hasValidStatus()) {
+            return;
+        }
+
+        $validity_settings = $prg->getValidityOfQualificationSettings();
+        $period = $validity_settings->getQualificationPeriod();
+        $date = $validity_settings->getQualificationDate();
+        if ($period) {
+            $date = $progress->getCompletionDate();
+            $date->add(new DateInterval('P' . $period . 'D'));
+        }
+        $progress->setValidityOfQualification($date);
+        $progress->storeProgress();
+    }
+
+    public function updateDeadlineFromProgram() : void
+    {
+        $prg = $this->getStudyProgramme();
+        $progress = $this->getRootProgress();
+        if ($progress->hasValidStatus()) {
+            return;
+        }
+
+        $deadline_settings = $prg->getDeadlineSettings();
+        $period = $deadline_settings->getDeadlinePeriod();
+        $date = $deadline_settings->getDeadlineDate();
+        if ($period) {
+            $date = $progress->getAssignmentDate();
+            $date->add(new DateInterval('P' . $period . 'D'));
+        }
+        $progress->setDeadline($date);
+        $progress->storeProgress();
+    }
+
     /**
      * Add missing progresses for new nodes in the programm.
      *

--- a/Modules/StudyProgramme/classes/class.ilStudyProgrammeUserProgress.php
+++ b/Modules/StudyProgramme/classes/class.ilStudyProgrammeUserProgress.php
@@ -211,10 +211,14 @@ class ilStudyProgrammeUserProgress
     public function setValidityOfQualification(DateTime $date = null) : void
     {
         $this->progress->setValidityOfQualification($date);
-        /** 29529 --------------- */
-        $this->progress_repository->update($this->progress);
-        /** 29529 end ----------- */
     }
+
+    /** 29529 --------------- */
+    public function storeProgress() : void
+    {
+        $this->progress_repository->update($this->progress);
+    }
+    /** 29529 end ----------- */
 
     /**
      * Delete the assignment from database.

--- a/Modules/StudyProgramme/classes/class.ilStudyProgrammeUserProgress.php
+++ b/Modules/StudyProgramme/classes/class.ilStudyProgrammeUserProgress.php
@@ -211,6 +211,9 @@ class ilStudyProgrammeUserProgress
     public function setValidityOfQualification(DateTime $date = null) : void
     {
         $this->progress->setValidityOfQualification($date);
+        /** 29529 --------------- */
+        $this->progress_repository->update($this->progress);
+        /** 29529 end ----------- */
     }
 
     /**

--- a/Modules/StudyProgramme/classes/class.ilStudyProgrammeUserProgress.php
+++ b/Modules/StudyProgramme/classes/class.ilStudyProgrammeUserProgress.php
@@ -213,12 +213,10 @@ class ilStudyProgrammeUserProgress
         $this->progress->setValidityOfQualification($date);
     }
 
-    /** 29529 --------------- */
     public function storeProgress() : void
     {
         $this->progress_repository->update($this->progress);
     }
-    /** 29529 end ----------- */
 
     /**
      * Delete the assignment from database.

--- a/Modules/StudyProgramme/classes/class.ilStudyProgrammeUserProgress.php
+++ b/Modules/StudyProgramme/classes/class.ilStudyProgrammeUserProgress.php
@@ -1006,4 +1006,15 @@ class ilStudyProgrammeUserProgress
             $usr_progress_db->reminderSendFor($usr_progress->getId());
         }
     }
+
+    public function hasValidStatus() : bool
+    {
+        return in_array(
+            $this->getStatus(),
+            [
+                ilStudyProgrammeProgress::STATUS_COMPLETED,
+                ilStudyProgrammeProgress::STATUS_ACCREDITED
+            ]
+        );
+    }
 }


### PR DESCRIPTION

https://mantis.ilias.de/view.php?id=29358
https://mantis.ilias.de/view.php?id=29522
https://mantis.ilias.de/view.php?id=29529

There were several issues with updating individual plans based on program-settings.
I did not want to hook into ilStudyProgrammeUserAssignment::updateFromProgram because this is used quite often throughout the prg-code, so I separated updateValidityFromProgram/updateDeadlineFromProgram.