### PR TITLE
OpenIdConnect: add maintainer in maintenance.json 

### DIFF
--- a/Services/OpenIdConnect/maintenance.json
+++ b/Services/OpenIdConnect/maintenance.json
@@ -1,6 +1,6 @@
 {
     "maintenance_model": "Classic",
-    "first_maintainer": "",
+    "first_maintainer": "smeyer(191)",
     "second_maintainer": "",
     "implicit_maintainers": [],
     "coordinator": [


### PR DESCRIPTION
Hi @smeyer-ilias,

looking into various files and `git blame` I came to the conclusion that you are the maintainer here. Hence the change in maintenance.json. If this is not the case, please just pass back.

Thanks!