### PR TITLE
fixed required php-soap

### DIFF
--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -254,7 +254,7 @@ systemctl restart httpd.service
 
 On Debian/Ubuntu 14.04 or 16.04 execute:
 ```
-apt-get install libapache2-mod-php7.1 php7.1-gd php7.1-mysql php7.1-mbstring php7.1-curl php7.1-dom php7.1-zip php-xml
+apt-get install libapache2-mod-php7.1 php7.1-gd php7.1-mysql php7.1-mbstring php7.1-curl php7.1-dom php7.1-zip php7.1-xml php7.1-soap
 ```
 
 On RHEL/CentOS execute:
@@ -449,7 +449,6 @@ Depending on your use case, you MAY want to install further dependencies (exact 
 
 * php-curl
 * php-xmlrpc
-* php-soap
 * php-ldap
 * ffmpeg
 * mimetex


### PR DESCRIPTION
Added php-soap as required package to avoid installation errors as in https://mantis.ilias.de/view.php?id=29618
Changed  php-xml to named version php7.1-xml as for other php packages.