### PR TITLE
fixed 0029641: Consultation Hours Error: colon vs ctrl regex

### DIFF
--- a/Services/Calendar/classes/ConsultationHours/class.ilConsultationHoursGUI.php
+++ b/Services/Calendar/classes/ConsultationHours/class.ilConsultationHoursGUI.php
@@ -29,7 +29,7 @@ include_once './Services/Calendar/classes/ConsultationHours/class.ilConsultation
  * Consultation hours editor
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
  *
- * @ilCtrl_Calls: ilConsultationHoursGUI: ilPublicUserProfileGUI, ilRepositorySearchGUI
+ * @ilCtrl_Calls ilConsultationHoursGUI: ilPublicUserProfileGUI, ilRepositorySearchGUI
  */
 class ilConsultationHoursGUI
 {

--- a/Services/Certificate/classes/class.ilCertificateGUI.php
+++ b/Services/Certificate/classes/class.ilCertificateGUI.php
@@ -27,7 +27,7 @@
 * @author		Helmut Schottmüller <helmut.schottmueller@mac.com>
 * @version	$Id$
 * @ingroup Services
-* @ilCtrl_Calls: ilCertificateGUI: ilPropertyFormGUI
+* @ilCtrl_Calls ilCertificateGUI: ilPropertyFormGUI
 */
 class ilCertificateGUI
 {

--- a/setup/sql/7_hotfixes.php
+++ b/setup/sql/7_hotfixes.php
@@ -411,3 +411,7 @@ if (!$ilDB->tableColumnExists('adv_md_values_ltext', 'disabled')) {
 }
 ?>
 
+<#21>
+<?php
+$ilCtrlStructureReader->getStructure();
+?>


### PR DESCRIPTION
This is a fix for https://mantis.ilias.de/view.php?id=29641
The ctrl class declartion has an invalid colin after the parent class definition. 

While grepping through the project, I found a similar problem in ilCertificateGUI
