### PR TITLE
UI: Numeric Input only supports integers (#29646)

### DIFF
--- a/src/UI/Component/Input/Field/Factory.php
+++ b/src/UI/Component/Input/Field/Factory.php
@@ -52,7 +52,7 @@ interface Factory
      * ---
      * description:
      *   purpose: >
-     *      A numeric field is used to retrieve numeric values from the user.
+     *      A numeric field is used to retrieve integer values from the user.
      *   composition: >
      *      Numeric inputs will render an input-tag with type="number".
      *   effect: >

--- a/src/UI/Implementation/Component/Input/Field/Numeric.php
+++ b/src/UI/Implementation/Component/Input/Field/Numeric.php
@@ -33,7 +33,7 @@ class Numeric extends Input implements C\Input\Field\Numeric
 
         $trafo_numericOrNull = $this->refinery->byTrying([
             $this->refinery->kindlyTo()->null(),
-            $this->refinery->numeric()->isNumeric()
+            $this->refinery->kindlyTo()->int()
         ])
         ->withProblemBuilder(function ($txt, $value) {
             return $txt("ui_numeric_only");
@@ -55,7 +55,7 @@ class Numeric extends Input implements C\Input\Field\Numeric
      */
     protected function getConstraintForRequirement()
     {
-        return $this->refinery->numeric()->isNumeric();
+        return $this->refinery->kindlyTo()->int();
     }
 
     /**


### PR DESCRIPTION
This clarifies that Numeric Input currently indeed only support integers, as documented in https://mantis.ilias.de/view.php?id=29646 To back this behaviour, the Numeric Input now uses the new kind transformations to integer.