### PR TITLE
Fix logic error in setup_exit hack in CLI setup (trunk)

### DIFF
--- a/setup/cli.php
+++ b/setup/cli.php
@@ -42,7 +42,7 @@ $app->run();
 // the setup for the command line version of the setup. Do not use this.
 function setup_exit($message)
 {
-    if (!defined("ILIAS_SETUP_IGNORE_DB_UPDATE_STEP_MESSAGES") && ILIAS_SETUP_IGNORE_DB_UPDATE_STEP_MESSAGES) {
+    if (!(defined("ILIAS_SETUP_IGNORE_DB_UPDATE_STEP_MESSAGES") && ILIAS_SETUP_IGNORE_DB_UPDATE_STEP_MESSAGES)) {
         throw new \ILIAS\Setup\UnachievableException($message);
     }
 }


### PR DESCRIPTION
Bugfix for <https://mantis.ilias.de/view.php?id=29647>, for trunk.