### PR TITLE
Backport fix for deprecation of array/string index in curly braces in PHP 7.4 to ILIAS 5.4

### DIFF
--- a/Modules/Chatroom/classes/class.ilChatroomUser.php
+++ b/Modules/Chatroom/classes/class.ilChatroomUser.php
@@ -143,7 +143,7 @@ class ilChatroomUser
     {
         $firstname = $this->user->getFirstname();
 
-        return $firstname{0} . '. ' . $this->user->getLastname();
+        return $firstname[0] . '. ' . $this->user->getLastname();
     }
 
     /**

--- a/Modules/TestQuestionPool/classes/class.assErrorText.php
+++ b/Modules/TestQuestionPool/classes/class.assErrorText.php
@@ -789,7 +789,7 @@ class assErrorText extends assQuestion implements ilObjQuestionScoringAdjustable
                         }
                     } else {
                         $appendComma = "";
-                        if ($item{$posClosingBrackets + 2} == ',') {
+                        if ($item[$posClosingBrackets + 2] == ',') {
                             $appendComma = ",";
                         }
 

--- a/Modules/Wiki/mediawiki/Title.php
+++ b/Modules/Wiki/mediawiki/Title.php
@@ -1784,7 +1784,7 @@ class Title
 
         # Initial colon indicates main namespace rather than specified default
         # but should not create invalid {ns,title} pairs such as {0,Project:Foo}
-        if (':' == $dbkey{0}) {
+        if (':' == $dbkey[0]) {
             $this->mNamespace = NS_MAIN;
             $dbkey = substr($dbkey, 1); # remove the colon but continue processing
             $dbkey = trim($dbkey, '_'); # remove any subsequent whitespace
@@ -1913,7 +1913,7 @@ class Title
         }
 
         // Any remaining initial :s are illegal.
-        if ($dbkey !== '' && ':' == $dbkey{0}) {
+        if ($dbkey !== '' && ':' == $dbkey[0]) {
             return false;
         }
         

--- a/Services/AuthApache/classes/class.ilWhiteListUrlValidator.php
+++ b/Services/AuthApache/classes/class.ilWhiteListUrlValidator.php
@@ -38,7 +38,7 @@ class ilWhiteListUrlValidator
                 return true;
             }
 
-            $firstChar = $validDomain{0};
+            $firstChar = $validDomain[0];
             if ('.' !== $firstChar) {
                 $validDomain = '.' . $validDomain;
             }

--- a/Services/Feeds/classes/class.ilExternalFeed.php
+++ b/Services/Feeds/classes/class.ilExternalFeed.php
@@ -285,7 +285,7 @@ class ilExternalFeed
                             if (isset($url_parts['port'])) {
                                 $full_url .= ":$url_parts[port]";
                             }
-                            if ($href{0} != '/') { #it's a relative link on the domain
+                            if ($href[0] != '/') { #it's a relative link on the domain
                                 $full_url .= dirname($url_parts['path']);
                                 if (substr($full_url, -1) != '/') {
                                     #if the last character isn't a '/', add it

--- a/Services/FileDelivery/classes/FileDeliveryTypes/PHPChunked.php
+++ b/Services/FileDelivery/classes/FileDeliveryTypes/PHPChunked.php
@@ -104,7 +104,7 @@ final class PHPChunked implements ilFileDeliveryType
             // If the range starts with an '-' we start from the beginning
             // If not, we forward the file pointer
             // And make sure to get the end byte if spesified
-            if ($range{0} == '-') {
+            if ($range[0] == '-') {
                 // The n-number of the last bytes is requested
                 $c_start = $size - substr($range, 1);
             } else {

--- a/Services/FileUpload/classes/class.ilFileUploadGUI.php
+++ b/Services/FileUpload/classes/class.ilFileUploadGUI.php
@@ -404,7 +404,7 @@ class ilFileUploadGUI
      */
     private function makeJqueryId($a_id)
     {
-        if (is_string($a_id) && strlen($a_id) > 0 && $a_id{0} !== '#') {
+        if (is_string($a_id) && strlen($a_id) > 0 && $a_id[0] !== '#') {
             return '#' . $a_id;
         }
 

--- a/Services/Mail/classes/Address/Type/class.ilRoleMailboxSearch.php
+++ b/Services/Mail/classes/Address/Type/class.ilRoleMailboxSearch.php
@@ -85,7 +85,7 @@ class ilRoleMailboxSearch
         $role_ids = array();
         foreach ($parsedList as $address) {
             $local_part = $address->getMailbox();
-            if (strpos($local_part, '#') !== 0 && !($local_part{0} == '"' && $local_part{1} == "#")) {
+            if (strpos($local_part, '#') !== 0 && !($local_part[0] == '"' && $local_part[1] == "#")) {
                 // A local-part which doesn't start with a '#' doesn't denote a role.
                 // Therefore we can skip it.
                 continue;
@@ -94,7 +94,7 @@ class ilRoleMailboxSearch
             $local_part = substr($local_part, 1);
 
             /* If role contains spaces, eg. 'foo role', double quotes are added which have to be removed here.*/
-            if ($local_part{0} == '#' && $local_part{strlen($local_part) - 1} == '"') {
+            if ($local_part[0] == '#' && $local_part[strlen($local_part) - 1] == '"') {
                 $local_part = substr($local_part, 1);
                 $local_part = substr($local_part, 0, strlen($local_part) - 1);
             }

--- a/Services/RTE/classes/class.ilTinyMCE.php
+++ b/Services/RTE/classes/class.ilTinyMCE.php
@@ -1111,11 +1111,11 @@ class ilTinyMCE extends ilRTE
             $a_string = str_replace(',,', ',', $a_string);
         }
 
-        if ($a_string{0} == ',') {
+        if ($a_string[0] == ',') {
             $a_string = (string) substr($a_string, 1);
         }
 
-        if (strlen($a_string) && $a_string{strlen($a_string) - 1} == ',') {
+        if (strlen($a_string) && $a_string[strlen($a_string) - 1] == ',') {
             $a_string = substr($a_string, 0, strlen($a_string) - 1);
         }
 

--- a/Services/UICore/lib/html-it/IT.php
+++ b/Services/UICore/lib/html-it/IT.php
@@ -911,7 +911,7 @@ class HTML_Template_IT
      */
     public function getFile($filename)
     {
-        if ($filename{0} == '/' && substr($this->fileRoot, -1) == '/') {
+        if ($filename[0] == '/' && substr($this->fileRoot, -1) == '/') {
             $filename = substr($filename, 1);
         }
 

--- a/Services/UICore/lib/html-it/ITX.php
+++ b/Services/UICore/lib/html-it/ITX.php
@@ -613,7 +613,7 @@ class HTML_Template_ITX extends HTML_Template_IT
 
             while ($head != '' && $args2 = $this->getValue($head, ',')) {
                 $arg2 = trim($args2);
-                $args[] = ('"' == $arg2{0} || "'" == $arg2{0}) ?
+                $args[] = ('"' == $arg2[0] || "'" == $arg2[0]) ?
                                     substr($arg2, 1, -1) : $arg2;
                 if ($arg2 == $head) {
                     break;

--- a/Services/Utilities/classes/Parser.php
+++ b/Services/Utilities/classes/Parser.php
@@ -860,7 +860,7 @@ class Parser
             if ($line == '') { // empty line, go to next line
                 continue;
             }
-            $first_character = $line{0};
+            $first_character = $line[0];
             $matches = array();
 
             if (preg_match('/^(:*)\{\|(.*)$/', $line, $matches)) {
@@ -2024,7 +2024,7 @@ class Parser
         # so only perform processing if subpages are allowed
         if ($this->areSubpagesAllowed()) {
             # Look at the first character
-            if ($target != '' && $target{0} == '/') {
+            if ($target != '' && $target[0] == '/') {
                 # / at end means we don't want the slash to be shown
                 $trailingSlashes = preg_match_all('%(/+)$%', $target, $m);
                 if ($trailingSlashes) {
@@ -2095,7 +2095,7 @@ class Parser
         }
 
         for ($i = 0; $i < $shorter; ++$i) {
-            if ($st1{$i} != $st2{$i}) {
+            if ($st1[$i] != $st2[$i]) {
                 break;
             }
         }
@@ -2232,11 +2232,11 @@ class Parser
                 $paragraphStack = false;
 
                 while ($commonPrefixLength < $lastPrefixLength) {
-                    $output .= $this->closeList($lastPrefix{$lastPrefixLength - 1});
+                    $output .= $this->closeList($lastPrefix[$lastPrefixLength - 1]);
                     --$lastPrefixLength;
                 }
                 if ($prefixLength <= $commonPrefixLength && $commonPrefixLength > 0) {
-                    $output .= $this->nextItem($pref{$commonPrefixLength - 1});
+                    $output .= $this->nextItem($pref[$commonPrefixLength - 1]);
                 }
                 while ($prefixLength > $commonPrefixLength) {
                     $char = substr($pref, $commonPrefixLength, 1);
@@ -2276,7 +2276,7 @@ class Parser
                         $inBlockElem = true;
                     }
                 } elseif (!$inBlockElem && !$this->mInPre) {
-                    if (' ' == $t{0} and ($this->mLastSection == 'pre' or trim($t) != '')) {
+                    if (' ' == $t[0] and ($this->mLastSection == 'pre' or trim($t) != '')) {
                         // pre
                         if ($this->mLastSection != 'pre') {
                             $paragraphStack = false;
@@ -2323,7 +2323,7 @@ class Parser
             }
         }
         while ($prefixLength) {
-            $output .= $this->closeList($pref2{$prefixLength - 1});
+            $output .= $this->closeList($pref2[$prefixLength - 1]);
             --$prefixLength;
         }
         if ('' != $this->mLastSection) {
@@ -2369,7 +2369,7 @@ class Parser
         $stack = 0;
         $len = strlen($str);
         for ($i = 0; $i < $len; $i++) {
-            $c = $str{$i};
+            $c = $str[$i];
 
             switch ($state) {
             // (Using the number is a performance hack for common cases)

--- a/Services/XHTMLValidator/validator/Text_Diff/Renderer.php
+++ b/Services/XHTMLValidator/validator/Text_Diff/Renderer.php
@@ -50,7 +50,7 @@ class Text_Diff_Renderer
     {
         $params = array();
         foreach (get_object_vars($this) as $k => $v) {
-            if ($k{0} == '_') {
+            if ($k[0] == '_') {
                 $params[substr($k, 1)] = $v;
             }
         }

--- a/Services/XHTMLValidator/validator/validator.inc
+++ b/Services/XHTMLValidator/validator/validator.inc
@@ -97,7 +97,7 @@ class validator {
         foreach ($GLOBALS['opts'] as $k => $v) {
 
             /* lock the explanation tip to 90 chars */
-            if (isset($v['explain']{91})) {
+            if (isset($v['explain'][91])) {
                 $title = iconv_substr($v['explain'], 0, 87, 'UTF-8') . '...';
             } else {
                 $title = $v['explain'];
@@ -122,7 +122,7 @@ class validator {
                     $return .= "<select name=\"$k\">\n";
 
                     foreach ($v['values'] as $key => $val) {
-                        if ($val{0} == '$')
+                        if ($val[0] == '$')
                             eval('$val='.$val.';'); // map the var name to its value
 
                         $return .= "<option value=\"$key\"" . ($v['default'] == $key ? ' selected="selected"' :'') .">$val</option>\n";
@@ -321,7 +321,7 @@ class validator {
 
             foreach (explode("\n", $diff) as $line) {
 
-                switch(isset($line{0}) ? $line{0} : '') {
+                switch(isset($line[0]) ? $line[0] : '') {
                     case '-':
                         $text .= '<span class="diffsub">' . $line . "</span><br />\n";
                         break;
@@ -329,7 +329,7 @@ class validator {
                         $text .= '<span class="diffadd">' . $line . "</span><br />\n";
                         break;
                     case '@':
-                        if (isset($line{1}) && $line{1} == '@' && isset($line{2}) && $line{2} == ' ') {
+                        if (isset($line[1]) && $line[1] == '@' && isset($line[2]) && $line[2] == ' ') {
                             $text .= '<span class="diffjmp">' . $line . "</span><br />\n";
                             break;
                         }

--- a/include/Unicode/UtfNormal.php
+++ b/include/Unicode/UtfNormal.php
@@ -374,12 +374,12 @@ class UtfNormal
             $len = $chunk + 1; # Counting down is faster. I'm *so* sorry.
 
             for ($i = -1; --$len;) {
-                if ($remaining = $tailBytes[$c = $str{++$i}]) {
+                if ($remaining = $tailBytes[$c = $str[++$i]]) {
                     # UTF-8 head byte!
                     $sequence = $head = $c;
                     do {
                         # Look for the defined number of tail bytes...
-                        if (--$len && ($c = $str{++$i}) >= "\x80" && $c < "\xc0") {
+                        if (--$len && ($c = $str[++$i]) >= "\x80" && $c < "\xc0") {
                             # Legal tail bytes are nice.
                             $sequence .= $c;
                         } else {

--- a/include/Unicode/UtfNormal.php
+++ b/include/Unicode/UtfNormal.php
@@ -256,7 +256,7 @@ class UtfNormal
         global $utfCheckNFC, $utfCombiningClass;
         $len = strlen($string);
         for ($i = 0; $i < $len; $i++) {
-            $c = $string{$i};
+            $c = $string[$i];
             $n = ord($c);
             if ($n < 0x80) {
                 continue;
@@ -356,7 +356,7 @@ class UtfNormal
         foreach ($matches[1] as $str) {
             $chunk = strlen($str);
 
-            if ($str{0} < "\x80") {
+            if ($str[0] < "\x80") {
                 # ASCII chunk: guaranteed to be valid UTF-8
                 # and in normal form C, so skip over it.
                 $base += $chunk;
@@ -579,7 +579,7 @@ class UtfNormal
         $len = strlen($string);
         $out = '';
         for ($i = 0; $i < $len; $i++) {
-            $c = $string{$i};
+            $c = $string[$i];
             $n = ord($c);
             if ($n < 0x80) {
                 # ASCII chars never decompose
@@ -606,9 +606,9 @@ class UtfNormal
                     # A lookup table would be slightly faster,
                     # but adds a lot of memory & disk needs.
                     #
-                    $index = ((ord($c{0}) & 0x0f) << 12
-                             | (ord($c{1}) & 0x3f) << 6
-                             | (ord($c{2}) & 0x3f))
+                    $index = ((ord($c[0]) & 0x0f) << 12
+                             | (ord($c[1]) & 0x3f) << 6
+                             | (ord($c[2]) & 0x3f))
                            - UNICODE_HANGUL_FIRST;
                     $l = intval($index / UNICODE_HANGUL_NCOUNT);
                     $v = intval(($index % UNICODE_HANGUL_NCOUNT) / UNICODE_HANGUL_TCOUNT);
@@ -644,7 +644,7 @@ class UtfNormal
         $combiners = array();
         $lastClass = -1;
         for ($i = 0; $i < $len; $i++) {
-            $c = $string{$i};
+            $c = $string[$i];
             $n = ord($c);
             if ($n >= 0x80) {
                 if ($n >= 0xf0) {
@@ -703,7 +703,7 @@ class UtfNormal
         $x1 = ord(substr(UTF8_HANGUL_VBASE, 0, 1));
         $x2 = ord(substr(UTF8_HANGUL_TEND, 0, 1));
         for ($i = 0; $i < $len; $i++) {
-            $c = $string{$i};
+            $c = $string[$i];
             $n = ord($c);
             if ($n < 0x80) {
                 # No combining characters here...
@@ -763,8 +763,8 @@ class UtfNormal
                         #
                         #$lIndex = utf8ToCodepoint( $startChar ) - UNICODE_HANGUL_LBASE;
                         #$vIndex = utf8ToCodepoint( $c ) - UNICODE_HANGUL_VBASE;
-                        $lIndex = ord($startChar{2}) - 0x80;
-                        $vIndex = ord($c{2}) - 0xa1;
+                        $lIndex = ord($startChar[2]) - 0x80;
+                        $vIndex = ord($c[2]) - 0xa1;
 
                         $hangulPoint = UNICODE_HANGUL_FIRST +
                             UNICODE_HANGUL_TCOUNT *
@@ -782,25 +782,25 @@ class UtfNormal
                               $startChar <= UTF8_HANGUL_LAST &&
                               !$lastHangul) {
                         # $tIndex = utf8ToCodepoint( $c ) - UNICODE_HANGUL_TBASE;
-                        $tIndex = ord($c{2}) - 0xa7;
+                        $tIndex = ord($c[2]) - 0xa7;
                         if ($tIndex < 0) {
-                            $tIndex = ord($c{2}) - 0x80 + (0x11c0 - 0x11a7);
+                            $tIndex = ord($c[2]) - 0x80 + (0x11c0 - 0x11a7);
                         }
 
                         # Increment the code point by $tIndex, without
                         # the function overhead of decoding and recoding UTF-8
                         #
-                        $tail = ord($startChar{2}) + $tIndex;
+                        $tail = ord($startChar[2]) + $tIndex;
                         if ($tail > 0xbf) {
                             $tail -= 0x40;
-                            $mid = ord($startChar{1}) + 1;
+                            $mid = ord($startChar[1]) + 1;
                             if ($mid > 0xbf) {
-                                $startChar{0} = chr(ord($startChar{0}) + 1);
+                                $startChar[0] = chr(ord($startChar[0]) + 1);
                                 $mid -= 0x40;
                             }
-                            $startChar{1} = chr($mid);
+                            $startChar[1] = chr($mid);
                         }
-                        $startChar{2} = chr($tail);
+                        $startChar[2] = chr($tail);
 
                         # If there's another jamo char after this, *don't* try to merge it.
                         $lastHangul = 1;
@@ -831,7 +831,7 @@ class UtfNormal
         $len = strlen($string);
         $out = '';
         for ($i = 0; $i < $len; $i++) {
-            $out .= $string{$i};
+            $out .= $string[$i];
         }
         return $out;
     }

--- a/include/Unicode/UtfNormalUtil.php
+++ b/include/Unicode/UtfNormalUtil.php
@@ -109,7 +109,7 @@ function utf8ToHexSequence($str)
 function utf8ToCodepoint($char)
 {
     # Find the length
-    $z = ord($char{0});
+    $z = ord($char[0]);
     if ($z & 0x80) {
         $length = 0;
         while ($z & 0x80) {
@@ -134,7 +134,7 @@ function utf8ToCodepoint($char)
     # Add in the free bits from subsequent bytes
     for ($i = 1; $i < $length; $i++) {
         $z <<= 6;
-        $z |= ord($char{$i}) & 0x3f;
+        $z |= ord($char[$i]) & 0x3f;
     }
 
     return $z;

--- a/tests/UI/Renderer/ilIndependentTemplate.php
+++ b/tests/UI/Renderer/ilIndependentTemplate.php
@@ -37,7 +37,7 @@ class ilIndependentTemplate extends ilTemplate implements \ILIAS\UI\Implementati
     */
     public function getFile($filename)
     {
-        if ($filename{0} == '/' && substr($this->fileRoot, -1) == '/') {
+        if ($filename[0] == '/' && substr($this->fileRoot, -1) == '/') {
             $filename = substr($filename, 1);
         }
 

--- a/webservice/soap/classes/class.ilSoapAdministration.php
+++ b/webservice/soap/classes/class.ilSoapAdministration.php
@@ -309,7 +309,7 @@ class ilSoapAdministration
     public static function return_bytes($val)
     {
         $val = trim($val);
-        $last = strtolower($val{strlen($val)-1});
+        $last = strtolower($val[strlen($val)-1]);
         switch ($last) {
         // The 'G' modifier is available since PHP 5.1.0
         case 'g':


### PR DESCRIPTION
Backport changes to address [deprecation of string or array access with curly braces in PHP 7.4](https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.array-string-access-curly-brace) in ILIAS 5.4 code. This may help users to keep their number of patches lower when they are running the ([officially unsupported](https://docu.ilias.de/goto_docu_wiki_wpage_5047_1357.html#ilPageTocA23)) combination of ILIAS 5.4 on PHP 7.4 or later.