### PR TITLE
UI/MainBar: give tool-button a more striking color

### DIFF
--- a/src/UI/templates/default/MainControls/mainbar.less
+++ b/src/UI/templates/default/MainControls/mainbar.less
@@ -136,19 +136,19 @@
 .il-mainbar-tools-button {
 	.btn-bulky,
 	.btn-bulky.engaged {
-		background-color: lighten(@brand-primary, 10%);
+		background-color: @il-mainbar-tools-btn-bg;
 		border: 0;
-		color: @il-mainbar-btn-color;
+		color: darken(@il-mainbar-btn-color-engaged, 10%);
 		padding: 0;
 		.icon  {
-			filter: invert(100%);
+			filter: invert(30%);
 		}
 	}
 	.btn-bulky.engaged {
-		background-color: lighten(@brand-primary, 45%);
+		background-color: @il-maincontrols-mainbar-bg-color;
 		color: @il-mainbar-btn-color-engaged;
 		.icon  {
-			filter: invert(35%);
+			filter: invert(30%);
 		}
 	}
 }

--- a/templates/default/less/variables.less
+++ b/templates/default/less/variables.less
@@ -939,6 +939,7 @@
 @il-mainbar-btn-border: 1px solid @il-standard-page-border-light-color;
 @il-mainbar-btn-label-size: .9rem;
 @il-mainbar-bulky-label-margin-top: 5px;
+@il-mainbar-tools-btn-bg: @brand-danger;
 @il-mainbar-tools-bg: @body-bg;
 @il-mainbar-tools-item-gap: 3px;
 


### PR DESCRIPTION
In the [ongoing discussion about the tools in the Main Bar](https://docu.ilias.de/goto_docu_grp_8739.html), the group (or at least parts of the group) came to the conclusion that we could alleviate problems with the tools easily if we would give a more striking color to the tools button. This, by no means, is the final conclusion how we would want to treat tools in ILIAS, but could help people to notice tools (when they are there) with simple means. The change is indeed simple, but IMO should help people already to notice the tools.

![tools_colored](https://user-images.githubusercontent.com/10611082/104484258-60750000-55c9-11eb-9c88-cb3ddb8daf59.png)

This does only help sighted people indeed, but does not make things worse for people that depend on screenreaders. The tool button is already marked with a color, we simply change that color. The contrast ratio from background to foreground should be enough to satisfy WCAG-criteria.

I currently propose this for the trunk only, but we might want to backport it to release_7 or even release_6.
