### PR TITLE
bugfix for #29733 (allow image format 'svg' for tiles)

### DIFF
--- a/Services/Object/CommonSettings/TileImage/classes/class.ilObjectTileImageFactory.php
+++ b/Services/Object/CommonSettings/TileImage/classes/class.ilObjectTileImageFactory.php
@@ -29,7 +29,7 @@ class ilObjectTileImageFactory implements ilObjectTileImageFactoryInterface
      */
     public function getSupportedFileExtensions() : array
     {
-        return ["png", "jpg", "jpeg"];
+        return ["png", "jpg", "jpeg", "svg"];
     }
 
     /**


### PR DESCRIPTION
Added image format 'svg' for uploading a tile image.
See bugreport:  https://mantis.ilias.de/view.php?id=29733