### PR TITLE
UI Component Item, Listing Panel: Fixing Title, see #29616

### DIFF
--- a/src/UI/templates/default/Item/item.less
+++ b/src/UI/templates/default/Item/item.less
@@ -8,12 +8,8 @@
 	padding: @il-item-padding;
 	.clearfix();
 
-	h4 {
-		padding-top: 0;
-		margin: 0;
+	.il-item-title {
 		font-size: @font-size-base;
-		float: left;
-
 		.btn-link, a {
 			font-size: inherit;
 			line-height: @line-height-base;

--- a/src/UI/templates/default/Item/tpl.item_standard.html
+++ b/src/UI/templates/default/Item/tpl.item_standard.html
@@ -14,7 +14,7 @@
 		</div>
 		<div class="media-body">
 			<!-- END lead_start_icon -->
-			<!-- BEGIN title_link_start --><a href="{TITLE_HREF}"><!-- END title_link_start -->{TITLE}<!-- BEGIN title_link_end --></a><!-- END title_link_end -->
+			<div class="il-item-title">{TITLE}</div>
 			{ACTIONS}
 			<!-- BEGIN desc -->
 			<div class="il-item-description">{DESC}</div><!-- END desc -->

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -7655,14 +7655,11 @@ ul.dropdown-menu > li > .btn:focus {
 .il-item:after {
   clear: both;
 }
-.il-item h4 {
-  padding-top: 0;
-  margin: 0;
+.il-item .il-item-title {
   font-size: 14px;
-  float: left;
 }
-.il-item h4 .btn-link,
-.il-item h4 a {
+.il-item .il-item-title .btn-link,
+.il-item .il-item-title a {
   font-size: inherit;
   line-height: 1.42857143;
 }

--- a/tests/UI/Component/Item/ItemGroupTest.php
+++ b/tests/UI/Component/Item/ItemGroupTest.php
@@ -96,9 +96,9 @@ class ItemGroupTest extends ILIAS_UI_TestBase
 	<h3>group</h3>
 		<div class="il-item-group-items">
 		<div class="il-std-item-container"><div class="il-item il-std-item ">
-			title1
+            <div class="il-item-title">title1</div>
 		</div></div><div class="il-std-item-container"><div class="il-item il-std-item ">
-			title2
+            <div class="il-item-title">title2</div>
 		</div></div>
 	</div>
 </div>
@@ -137,9 +137,9 @@ EOT;
 	</div>
 	<div class="il-item-group-items">
 		<div class="il-std-item-container"><div class="il-item il-std-item ">
-			title1
+            <div class="il-item-title">title1</div>
 	</div></div><div class="il-std-item-container"><div class="il-item il-std-item ">
-			title2
+            <div class="il-item-title">title2</div>
 	</div></div>
 	</div>
 </div>

--- a/tests/UI/Component/Item/ItemTest.php
+++ b/tests/UI/Component/Item/ItemTest.php
@@ -142,7 +142,7 @@ class ItemTest extends ILIAS_UI_TestBase
 
         $expected = <<<EOT
 <div class="il-item il-std-item ">
-			Item Title
+            <div class="il-item-title">Item Title</div>
 			<div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"  aria-label="actions" aria-haspopup="true" aria-expanded="false" > <span class="caret"></span></button>
 <ul class="dropdown-menu">
 	<li><button class="btn btn-link" data-action="https://www.ilias.de" id="id_1"  >ILIAS</button>
@@ -207,7 +207,7 @@ EOT;
 			<img src="src" class="img-standard" alt="str" />
 		</div>
 		<div class="col-sm-9">
-			title
+            <div class="il-item-title">title</div>
 		</div>
 	</div>
 </div>
@@ -235,7 +235,7 @@ EOT;
 		<div class="media-left">
 			<div class="icon name small" aria-label="aria_label"></div></div>
 		<div class="media-body">
-			title
+            <div class="il-item-title">title</div>
 		</div>
 	</div>
 </div>
@@ -266,7 +266,7 @@ EOT;
 			lead
 		</div>
 		<div class="col-sm-9">
-			title
+            <div class="il-item-title">title</div>
 		</div>
 	</div>
 </div>
@@ -292,7 +292,7 @@ EOT;
         $html = $r->render($c);
         $expected = <<<EOT
 <div class="il-item il-std-item ">
-			<button class="btn btn-link" data-action="https://www.ilias.de" id="id_1"  >ILIAS</button>
+			<div class="il-item-title"><button class="btn btn-link" data-action="https://www.ilias.de" id="id_1"  >ILIAS</button></div>
 
 			<hr class="il-item-divider" />
 			<div class="row">
@@ -324,7 +324,7 @@ EOT;
         $html = $r->render($c);
 
         $expected = <<<EOT
-<div class="il-item il-std-item "><a href="https://www.ilias.de">ILIAS</a></div>
+<div class="il-item il-std-item "><div class="il-item-title"><a href="https://www.ilias.de">ILIAS</a></div></div>
 EOT;
 
         $this->assertHTMLEquals($expected, $html);

--- a/tests/UI/Component/Panel/PanelListingTest.php
+++ b/tests/UI/Component/Panel/PanelListingTest.php
@@ -102,16 +102,16 @@ class PanelListingTest extends ILIAS_UI_TestBase
 		<h3>Subtitle 1</h3>
 		<div class="il-item-group-items">
 			<div class="il-std-item-container"><div class="il-item il-std-item ">	
-				title1
+                <div class="il-item-title">title1</div>
 			</div></div><div class="il-std-item-container"><div class="il-item il-std-item ">
-				title2
+                <div class="il-item-title">title2</div>
 			</div></div>
 		</div>
 	</div><div class="il-item-group">
 		<h3>Subtitle 2</h3>
 	<div class="il-item-group-items">
 	<div class="il-std-item-container"><div class="il-item il-std-item ">
-			title3
+            <div class="il-item-title">title3</div>
 		</div></div>
 	</div>
 </div>

--- a/tests/UI/Component/Panel/PanelSecondaryListingTest.php
+++ b/tests/UI/Component/Panel/PanelSecondaryListingTest.php
@@ -311,11 +311,11 @@ EOT;
 <div class="il-item-group-items">\n
 <div class="il-std-item-container">
 <div class="il-item il-std-item ">
-title1
-</div><
-/div>\n
+<div class="il-item-title">title1</div>
+</div></div>\n
 <div class="il-std-item-container">
-<div class="il-item il-std-item ">title2
+<div class="il-item il-std-item ">
+<div class="il-item-title">title2</div>
 </div>
 </div>\n
 </div>\n


### PR DESCRIPTION
Proposal to fix: https://mantis.ilias.de/view.php?id=29616 .

This was a casualty of: https://github.com/ILIAS-eLearning/ILIAS/commit/c182f875521fa7ccca24e280cb59ea11dad0d60b , removing, changing the headline schema. This had impact on the CSS. To still identify the title as title by CSS, I surrounded it with a div.

I propose to push this to 6,7 and trunk. However, note the slight change in the tpl, skins could be affected.