### PR TITLE
Fix condition for .htaccess restriction

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -12,7 +12,8 @@
 	RewriteCond %{HTTP_USER_AGENT} ^(DavClnt)$
 	RewriteCond %{REQUEST_METHOD} ^(OPTIONS)$
 	RewriteRule .* "-" [R=401,L]
-
+</IfModule>
+<IfModule mod_alias.c>
 	RedirectMatch 404 /\.git
 </IfModule>
 <IfModule mod_xsendfile.c>


### PR DESCRIPTION
RedirectMatch is provided by mod_alias, not by mod_rewrite, see
<https://httpd.apache.org/docs/2.4/en/mod/mod_alias.html#redirectmatch>.

This properly blocks access to version-control files in deployments
where the web server has mod_alias enabled, but not mod_redirect.

This is the fix for release_6.