### PR TITLE
fixed #27776: Missing Form Label in Permalink in Footer

### DIFF
--- a/src/UI/templates/default/MainControls/tpl.footer.html
+++ b/src/UI/templates/default/MainControls/tpl.footer.html
@@ -3,7 +3,7 @@
 
 		<!-- BEGIN footer_perm_url -->
 		<div class="il-footer-permanent-url">
-			{PERMA_LINK_LABEL}
+			<label for="current_perma_link">{PERMA_LINK_LABEL}</label>
 			<input id="current_perma_link" type="text" value="{PERMANENT_URL}" readonly="readOnly">
 		</div>
 		<!-- END footer_perm_url -->

--- a/tests/UI/Component/MainControls/FooterTest.php
+++ b/tests/UI/Component/MainControls/FooterTest.php
@@ -177,7 +177,7 @@ EOT;
         $expected = <<<EOT
         <div class="il-maincontrols-footer">
             <div class="il-footer-content">
-                <div class="il-footer-permanent-url">perma_link<input id="current_perma_link" type="text" value="http://www.ilias.de/goto.php?target=xxx_123" readonly="readOnly">
+                <div class="il-footer-permanent-url"><label for="current_perma_link">perma_link</label><input id="current_perma_link" type="text" value="http://www.ilias.de/goto.php?target=xxx_123" readonly="readOnly">
                 </div>
 
                 <div class="il-footer-text">footer text</div>


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=27776