### PR TITLE
UI Components, Sortation: ID for Soration with Tests, see #29822

### DIFF
--- a/src/UI/Implementation/Component/ViewControl/Renderer.php
+++ b/src/UI/Implementation/Component/ViewControl/Renderer.php
@@ -124,18 +124,20 @@ class Renderer extends AbstractComponentRenderer
         if ($triggeredSignals) {
             $internal_signal = $component->getSelectSignal();
             $signal = $triggeredSignals[0]->getSignal();
-            $options = json_encode($signal->getOptions());
 
-            $component = $component->withOnLoadCode(function ($id) use ($internal_signal, $signal) {
+            $component = $component->withAdditionalOnLoadCode(function ($id) use ($internal_signal, $signal) {
                 return "$(document).on('{$internal_signal}', function(event, signalData) {
 							il.UI.viewcontrol.sortation.onInternalSelect(event, signalData, '{$signal}', '{$id}');
 							return false;
 						})";
             });
+        }
 
-            //maybeRenderId does not return id
+        if($component->getOnLoadCode()){
             $id = $this->bindJavaScript($component);
+            $tpl->setCurrentBlock('id');
             $tpl->setVariable('ID', $id);
+            $tpl->parseCurrentBlock();
         }
 
         //setup entries

--- a/src/UI/templates/default/ViewControl/tpl.sortation.html
+++ b/src/UI/templates/default/ViewControl/tpl.sortation.html
@@ -1,3 +1,3 @@
-<div class="il-viewcontrol-sortation" id="{ID}">
+<div class="il-viewcontrol-sortation" <!-- BEGIN id -->id="{ID}"<!-- END id -->>
 {SORTATION_DROPDOWN}
 </div>

--- a/tests/UI/Component/Panel/PanelSecondaryLegacyTest.php
+++ b/tests/UI/Component/Panel/PanelSecondaryLegacyTest.php
@@ -208,7 +208,7 @@ EOT;
 <div class="panel panel-secondary panel-flex">
 	<div class="panel-heading ilHeader clearfix">
 		<h4 class="ilHeader">Title</h4>
-		<div class="il-viewcontrol-sortation" id="">
+		<div class="il-viewcontrol-sortation">
 			<div class="dropdown">
 				<button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="actions" aria-haspopup="true" aria-expanded="false">
 					<span class="caret"></span>

--- a/tests/UI/Component/Panel/PanelSecondaryListingTest.php
+++ b/tests/UI/Component/Panel/PanelSecondaryListingTest.php
@@ -167,7 +167,7 @@ EOT;
 <div class="panel panel-secondary panel-flex">
 	<div class="panel-heading ilHeader clearfix">
 		<h4 class="ilHeader">Title</h4>
-		<div class="il-viewcontrol-sortation" id="">
+		<div class="il-viewcontrol-sortation">
 			<div class="dropdown">
 				<button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="actions" aria-haspopup="true" aria-expanded="false">
 					<span class="caret"></span>

--- a/tests/UI/Component/Panel/PanelTest.php
+++ b/tests/UI/Component/Panel/PanelTest.php
@@ -313,7 +313,7 @@ EOT;
 <div class="panel panel-primary panel-flex">
 	<div class="panel-heading ilHeader clearfix">
 		<h2 class="ilHeader">Title</h2> 
-		<div class="il-viewcontrol-sortation" id="">
+		<div class="il-viewcontrol-sortation">
 <div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"  aria-label="actions" aria-haspopup="true" aria-expanded="false" > <span class="caret"></span></button>
 <ul class="dropdown-menu">
 	<li><button class="btn btn-link" data-action="?sortation=a" id="id_1">A</button>

--- a/tests/UI/Component/ViewControl/SortationTest.php
+++ b/tests/UI/Component/ViewControl/SortationTest.php
@@ -75,13 +75,37 @@ class SortationTest extends ILIAS_UI_TestBase
         );
     }
 
-    protected function getSortationExpectedHTML()
+    public function testRenderingWithJsBinding(){
+        $f = $this->getFactory();
+        $r = $this->getDefaultRenderer();
+        $s = $f->sortation($this->options)->withAdditionalOnLoadCode(function($id){return "";});
+
+        $html = $this->normalizeHTML($r->render($s));
+        $this->assertEquals(
+            $this->getSortationExpectedHTML(true),
+            $html
+        );
+    }
+
+    protected function getSortationExpectedHTML(bool $with_id = false)
     {
+        $id = "";
+        $button1_id = "id_1";
+        $button2_id = "id_2";
+        $button3_id = "id_3";
+
+        if($with_id){
+            $id = "id=\"id_1\"";
+            $button1_id = "id_2";
+            $button2_id = "id_3";
+            $button3_id = "id_4";
+        }
+
         $expected = <<<EOT
-<div class="il-viewcontrol-sortation" id=""><div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"  aria-label="actions" aria-haspopup="true" aria-expanded="false" > <span class="caret"></span></button><ul class="dropdown-menu">
-	<li><button class="btn btn-link" data-action="?sortation=internal_rating" id="id_1">Best</button></li>
-	<li><button class="btn btn-link" data-action="?sortation=date_desc" id="id_2">Most Recent</button></li>
-	<li><button class="btn btn-link" data-action="?sortation=date_asc" id="id_3">Oldest</button></li></ul></div>
+<div class="il-viewcontrol-sortation" $id><div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"  aria-label="actions" aria-haspopup="true" aria-expanded="false" > <span class="caret"></span></button><ul class="dropdown-menu">
+	<li><button class="btn btn-link" data-action="?sortation=internal_rating" id="$button1_id">Best</button></li>
+	<li><button class="btn btn-link" data-action="?sortation=date_desc" id="$button2_id">Most Recent</button></li>
+	<li><button class="btn btn-link" data-action="?sortation=date_asc" id="$button3_id">Oldest</button></li></ul></div>
 </div>
 EOT;
         return $this->normalizeHTML($expected);


### PR DESCRIPTION
This is one of the trivial fixing of having empty id's in the rendered DOM. Fixed by adding a block only rendering if id is present. However, while adding a unit test, making sure the id is rendered if needed, I observed that there are issue with adding additional onload code without a trigger. This would simply have been ignored. This should be fixed. 

@klees : Since I changed some additional lines in rendering and slightly shuffled the tests around, I would loike you to shortly browse over it and greenlight this, thx