### PR TITLE
UI Components, Bulky Buttons: Fragments for Button, see: #28849

### DIFF
--- a/src/UI/Implementation/Component/Link/Bulky.php
+++ b/src/UI/Implementation/Component/Link/Bulky.php
@@ -30,6 +30,9 @@ class Bulky extends Link implements C\Link\Bulky
         if ($target->getQuery()) {
             $action .= '?' . $target->getQuery();
         }
+        if($target->getFragment()){
+            $action .= '#' .$target->getFragment();
+        }
         parent::__construct($action);
         $this->label = $label;
         $this->symbol = $symbol;

--- a/src/UI/Implementation/Component/Link/Bulky.php
+++ b/src/UI/Implementation/Component/Link/Bulky.php
@@ -26,14 +26,7 @@ class Bulky extends Link implements C\Link\Bulky
 
     public function __construct(C\Symbol\Symbol $symbol, string $label, \ILIAS\Data\URI $target)
     {
-        $action = $target->getBaseURI();
-        if ($target->getQuery()) {
-            $action .= '?' . $target->getQuery();
-        }
-        if($target->getFragment()){
-            $action .= '#' .$target->getFragment();
-        }
-        parent::__construct($action);
+        parent::__construct($target->__toString());
         $this->label = $label;
         $this->symbol = $symbol;
     }

--- a/tests/UI/Component/Link/BulkyLinkTest.php
+++ b/tests/UI/Component/Link/BulkyLinkTest.php
@@ -13,6 +13,11 @@ use \ILIAS\UI\Implementation\Component as I;
  */
 class BulkyLinkTest extends ILIAS_UI_TestBase
 {
+    /**
+     * @var I\Link\Factory
+     */
+    protected $factory;
+
     public function setUp() : void
     {
         $this->factory = new I\Link\Factory();
@@ -47,6 +52,27 @@ class BulkyLinkTest extends ILIAS_UI_TestBase
         $this->assertEquals($this->glyph, $link->getSymbol());
         $link = $this->factory->bulky($this->icon, "label", $this->target);
         $this->assertEquals($this->icon, $link->getSymbol());
+    }
+
+    public function testGetAction()
+    {
+        $plain = "http://www.ilias.de";
+        $with_query = $plain."?query1=1";
+        $with_multi_query = $with_query."&query2=2";
+        $with_fragment = $plain."#fragment";
+        $with_multi_query_and_fragment_uri = $with_multi_query.$with_fragment;
+
+        $plain_uri = new \ILIAS\Data\URI($plain);
+        $with_query_uri = new \ILIAS\Data\URI($with_query);
+        $with_multi_query_uri = new \ILIAS\Data\URI($with_multi_query);
+        $with_fragment_uri = new \ILIAS\Data\URI($with_fragment);
+        $with_multi_query_and_fragment_uri = new \ILIAS\Data\URI($with_multi_query_and_fragment_uri);
+
+        $this->assertEquals($plain, $this->factory->bulky($this->glyph, "label", $plain_uri)->getAction());
+        $this->assertEquals($with_query, $this->factory->bulky($this->glyph, "label", $with_query_uri)->getAction());
+        $this->assertEquals($with_multi_query, $this->factory->bulky($this->glyph, "label", $with_multi_query_uri)->getAction());
+        $this->assertEquals($with_fragment_uri, $this->factory->bulky($this->glyph, "label", $with_fragment_uri)->getAction());
+        $this->assertEquals($with_multi_query_and_fragment_uri, $this->factory->bulky($this->glyph, "label", $with_multi_query_and_fragment_uri)->getAction());
     }
 
     public function testRenderingGlyph()


### PR DESCRIPTION
We ignore fragments for Bulky Buttons, see: https://mantis.ilias.de/view.php?id=28849

This fixes the missing fragments for Bulky Buttons and adds some tests to make sure we process the Action as URI properly. However, IMO we should think about centralizing actions from URIs somewhat more. Having this in Bulkys seems wrong in the long run. If we use URI more widely we have such issues all over the place. Maybe add an according helper on the URI itself? 

However, maybe merge this before implementing the general fix. This needs to be merged down to 6,7 and trunk.