### PR TITLE
UI/ModeInfo: extend ModeInfo (Maincontrol) to surround the entire page

### DIFF
--- a/src/UI/Implementation/Component/Layout/Page/Renderer.php
+++ b/src/UI/Implementation/Component/Layout/Page/Renderer.php
@@ -148,6 +148,7 @@ class Renderer extends AbstractComponentRenderer
             include_once("./Services/jQuery/classes/class.iljQueryUtil.php");
             array_unshift($js_files, './libs/bower/bower_components/jquery-migrate/jquery-migrate.min.js');
             array_unshift($js_files, \iljQueryUtil::getLocaljQueryPath());
+            $css_files[] = ['file' => './templates/default/delos.css'];
         }
 
         foreach ($js_files as $js_file) {

--- a/src/UI/examples/Layout/Page/Standard/ui.php
+++ b/src/UI/examples/Layout/Page/Standard/ui.php
@@ -51,7 +51,7 @@ if ($_GET['new_ui'] == '1') {
         'Std. Page Demo' //view title
     )->withModeInfo($f->mainControls()->modeInfo("Member View", new URI($_SERVER['HTTP_REFERER'])))
         ->withSystemInfos(
-            [$f->mainControls()->headInfo('This is an neutral Message!', 'read it, understand it, dismiss it...')
+            [$f->mainControls()->systemInfo('This is an neutral Message!', 'read it, understand it, dismiss it...')
                ->withDismissAction(new URI($_SERVER['HTTP_REFERER']))]
         )
     ->withUIDemo(true);

--- a/src/UI/templates/default/Layout/tpl.standardpage.html
+++ b/src/UI/templates/default/Layout/tpl.standardpage.html
@@ -23,11 +23,12 @@
 	<script type="text/javascript" src="{JS_FILE}"></script>
 	<!-- END js_file -->
 </head>
-
 <body>
+	<!-- BEGIN mode_info -->
+	{MODEINFO}
+	<!-- END mode_info -->
 
 	<div class="il-layout-page<!-- BEGIN slates_engaged --> with-mainbar-slates-engaged<!-- END slates_engaged -->">
-
 		<header>
 			<div class="header-inner">
 				<div class="il-logo">
@@ -61,9 +62,6 @@
 		<!-- html5 main-tag is not supported in IE / div is needed -->
 		<main class="il-layout-page-content">
 			<div>
-				<!-- BEGIN mode_info -->
-				{MODEINFO}
-				<!-- END mode_info -->
 				{CONTENT}
 			</div>
 

--- a/src/UI/templates/default/MainControls/mode_info.less
+++ b/src/UI/templates/default/MainControls/mode_info.less
@@ -4,10 +4,12 @@
   border-left: @il-mode-info-border;
   border-right: @il-mode-info-border;
   text-align: center;
-  height: @il-mode-info-height;
-  margin-bottom: -@il-mode-info-height;
-  z-index: 2;
-  position: static;
+
+  z-index: 10000;
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  pointer-events: none;
 }
 
 .il-mode-info + div {
@@ -30,13 +32,14 @@
   -webkit-box-shadow: @il-mode-info-shadow;
   -moz-box-shadow: @il-mode-info-shadow;
   box-shadow: @il-mode-info-shadow;
+
+   pointer-events: all;
 }
 
 .il-mode-info span {
   color: @il-mode-info-text-color;
   font-size: @font-size-large;
 }
-
 
 @media only screen and (max-width: @grid-float-breakpoint-max) {
   .il-mode-info {

--- a/src/UI/templates/default/MainControls/mode_info.less
+++ b/src/UI/templates/default/MainControls/mode_info.less
@@ -5,7 +5,7 @@
   border-right: @il-mode-info-border;
   text-align: center;
 
-  z-index: 10000;
+  z-index: @il-mode-info-zindex;
   position: absolute;
   height: 100%;
   width: 100%;
@@ -15,7 +15,13 @@
 .il-mode-info + div {
   border: @il-mode-info-border;
   border-top: 0 none;
+  
+  @media only screen and (max-width: @grid-float-breakpoint-max) {
+    padding-top: @il-mode-info-height;
+  }
 }
+
+
 //
 // This is needed to break the current grid from the page
 //

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -9998,7 +9998,7 @@ footer {
   border-left: 3px solid #fa8228;
   border-right: 3px solid #fa8228;
   text-align: center;
-  z-index: 10000;
+  z-index: 1010;
   position: absolute;
   height: 100%;
   width: 100%;
@@ -10007,6 +10007,11 @@ footer {
 .il-mode-info + div {
   border: 3px solid #fa8228;
   border-top: 0 none;
+}
+@media only screen and (max-width: 768px) {
+  .il-mode-info + div {
+    padding-top: 30px;
+  }
 }
 .il-layout-page-content > div {
   display: grid;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -9998,10 +9998,11 @@ footer {
   border-left: 3px solid #fa8228;
   border-right: 3px solid #fa8228;
   text-align: center;
-  height: 30px;
-  margin-bottom: -30px;
-  z-index: 2;
-  position: static;
+  z-index: 10000;
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  pointer-events: none;
 }
 .il-mode-info + div {
   border: 3px solid #fa8228;
@@ -10018,6 +10019,7 @@ footer {
   -webkit-box-shadow: 0px 2px 2px 0px #808080;
   -moz-box-shadow: 0px 2px 2px 0px #808080;
   box-shadow: 0px 2px 2px 0px #808080;
+  pointer-events: all;
 }
 .il-mode-info span {
   color: white;

--- a/templates/default/less/variables.less
+++ b/templates/default/less/variables.less
@@ -952,6 +952,8 @@
 @il-mode-info-height: 30px;
 @il-mode-info-shadow: 0px 2px 2px 0px rgba(128, 128, 128, 1);
 @il-mode-info-text-color: white;
+@il-mode-info-zindex: 1010;
+
 
 //** slates
 @il-slate-bulky-bg-color: #f2f2f2;


### PR DESCRIPTION
This suggests the ModeInfo maincontrol to surround the entire page,
taking into account that some modes may also modify other parts than the content.

![ModeInfoAroundPage](https://user-images.githubusercontent.com/3328364/107013814-27304a00-679b-11eb-93e9-6cabc5bfdaf6.png)

