### PR TITLE
LSO: mark view-mode with ModeInfo

### DIFF
--- a/Modules/LearningSequence/classes/GlobalScreen/class.ilLSViewLayoutProvider.php
+++ b/Modules/LearningSequence/classes/GlobalScreen/class.ilLSViewLayoutProvider.php
@@ -16,6 +16,12 @@ use ILIAS\GlobalScreen\Scope\Layout\Factory\ContentModification;
 use ILIAS\UI\Component\Legacy\Legacy;
 use ILIAS\GlobalScreen\ScreenContext\AdditionalData\Collection;
 
+use ILIAS\GlobalScreen\Scope\Layout\Provider\PagePart\PagePartProvider;
+use ILIAS\GlobalScreen\Scope\Layout\Builder\StandardPageBuilder;
+use ILIAS\GlobalScreen\Scope\Layout\Factory\PageBuilderModification;
+use ILIAS\UI\Component\Layout\Page\Page;
+use ILIAS\Data\URI;
+
 /**
  * Class ilLSViewLayoutProvider
  *
@@ -71,11 +77,7 @@ class ilLSViewLayoutProvider extends AbstractModificationProvider implements Mod
         return $this->globalScreen()->layout()->factory()->metabar()
             ->withModification(
                 function (MetaBar $metabar) : ?Metabar {
-                    $metabar = $metabar->withClearedEntries();
-                    foreach ($this->data_collection->get(ilLSPlayer::GS_DATA_LS_METABARCONTROLS) as $key => $entry) {
-                        $metabar = $metabar->withAdditionalEntry($key, $entry);
-                    }
-                    return $metabar;
+                    return $metabar->withClearedEntries();
                 }
             )
             ->withHighPriority();
@@ -110,6 +112,30 @@ class ilLSViewLayoutProvider extends AbstractModificationProvider implements Mod
                 function (Legacy $content) use ($html) : Legacy {
                     $ui = $this->dic->ui();
                     return $ui->factory()->legacy($html);
+                }
+            )
+            ->withHighPriority();
+    }
+
+    public function getPageBuilderDecorator(CalledContexts $screen_context_stack) : ?PageBuilderModification
+    {
+        if (!$this->isKioskModeEnabled($screen_context_stack)) {
+            return null;
+        }
+
+        $exit = $this->data_collection->get(\ilLSPlayer::GS_DATA_LS_METABARCONTROLS)['exit'];
+        $label = $this->dic['lng']->txt('lso_player_viewmodelabel');
+
+        $lnk = new URI($exit->getAction());
+
+        return $this->factory->page()
+            ->withModification(
+                function (PagePartProvider $parts) use ($label, $lnk) : Page {
+                    $p = new StandardPageBuilder();
+                    $f = $this->dic['ui.factory'];
+                    $page = $p->build($parts);
+                    $modeinfo = $f->mainControls()->modeInfo($label, $lnk);
+                    return $page->withModeInfo($modeinfo);
                 }
             )
             ->withHighPriority();

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -10332,11 +10332,11 @@ lso#:#lso_mail_unsubscribe_member_sub#:#Ihre Abmeldung von der Lernsequenz "%s"
 lso#:#lso_mail_wl_bod#:#Sie sind auf die Warteliste der Lernsequenz "%s" gesetzt worden und haben die Position %s auf der Warteliste.  Sie werden per Mail benachrichtigt, sobald Ihr Aufnahmeantrag angenommen bzw. abgelehnt wurde.
 lso#:#lso_mail_wl_sub#:#Ihre Anmeldung für Lernsequenz "%s"
 lso#:#lso_mainbar_button_label_curriculum#:#Curriculum
+lso#:#lso_members_gallery#:#Mitgliedergalerie
 lso#:#lso_mainbar_button_label_toc#:#Inhalte
 lso#:#lso_mem_tbl_header#:#Lernsequenz Teilnehmer
 lso#:#lso_member_administration#:#Teilnehmerverwaltung
 lso#:#lso_members_deleted#:#Das/die Mitglied(er) wurde(n) aus der Lernsequenz ausgetragen
-lso#:#lso_members_gallery#:#Mitgliedergalerie
 lso#:#lso_members_print_title#:#Lernsequenzmitglieder
 lso#:#lso_min_one_admin#:#Dieser Lernsequenz muß mindestens ein Administrator zugeordnet bleiben.
 lso#:#lso_msg_member_assigned#:#Benutzer wurde(n) in die Lernsequenz aufgenommen
@@ -10354,6 +10354,7 @@ lso#:#lso_player_resume#:#Lernsequenz wieder aufnehmen
 lso#:#lso_player_review#:#Lernsequenz überarbeiten
 lso#:#lso_player_start#:#Lernsequenz starten
 lso#:#lso_player_suspend#:#Unterbrechen
+lso#:#lso_player_viewmodelabel#:#Bearbeitung der Lernsequenz 
 lso#:#lso_print_list#:#Liste erstellen
 lso#:#lso_read#:#Lesezugriff auf Learning Sequence
 lso#:#lso_search_users#:#Benutzer suchen

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -10332,11 +10332,11 @@ lso#:#lso_mail_unsubscribe_member_sub#:#Ihre Abmeldung von der Lernsequenz "%s"
 lso#:#lso_mail_wl_bod#:#Sie sind auf die Warteliste der Lernsequenz "%s" gesetzt worden und haben die Position %s auf der Warteliste.  Sie werden per Mail benachrichtigt, sobald Ihr Aufnahmeantrag angenommen bzw. abgelehnt wurde.
 lso#:#lso_mail_wl_sub#:#Ihre Anmeldung für Lernsequenz "%s"
 lso#:#lso_mainbar_button_label_curriculum#:#Curriculum
-lso#:#lso_members_gallery#:#Mitgliedergalerie
 lso#:#lso_mainbar_button_label_toc#:#Inhalte
 lso#:#lso_mem_tbl_header#:#Lernsequenz Teilnehmer
 lso#:#lso_member_administration#:#Teilnehmerverwaltung
 lso#:#lso_members_deleted#:#Das/die Mitglied(er) wurde(n) aus der Lernsequenz ausgetragen
+lso#:#lso_members_gallery#:#Mitgliedergalerie
 lso#:#lso_members_print_title#:#Lernsequenzmitglieder
 lso#:#lso_min_one_admin#:#Dieser Lernsequenz muß mindestens ein Administrator zugeordnet bleiben.
 lso#:#lso_msg_member_assigned#:#Benutzer wurde(n) in die Lernsequenz aufgenommen

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -31,6 +31,7 @@
 <!-- language file start -->
 acc#:#acc_access_key#:#Access Key
 acc#:#acc_access_keys#:#Access Keys
+lso#:#lso_player_viewmodelabel#:#Learning Sequence
 acc#:#acc_add_document_btn_label#:#Add Document
 acc#:#acc_comp_frm#:#Forum
 acc#:#acc_comp_global#:#Global

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -31,7 +31,6 @@
 <!-- language file start -->
 acc#:#acc_access_key#:#Access Key
 acc#:#acc_access_keys#:#Access Keys
-lso#:#lso_player_viewmodelabel#:#Learning Sequence
 acc#:#acc_add_document_btn_label#:#Add Document
 acc#:#acc_comp_frm#:#Forum
 acc#:#acc_comp_global#:#Global
@@ -10330,6 +10329,7 @@ lso#:#lso_player_resume#:#Resume Learning Sequence
 lso#:#lso_player_review#:#Review Learning Sequence
 lso#:#lso_player_start#:#Start Learning Sequence
 lso#:#lso_player_suspend#:#Suspend
+lso#:#lso_player_viewmodelabel#:#Learning Sequence
 lso#:#lso_print_list#:#Generate list
 lso#:#lso_read#:#User has read access to Learning Sequence
 lso#:#lso_search_users#:#Search Users


### PR DESCRIPTION
In conjunction with https://github.com/ILIAS-eLearning/ILIAS/pull/3151,
this visualizes the player-mode / learner view of LSO in a way more prominent way, including very strong hints on where to exit ;)

![ScreenshotLSO1](https://user-images.githubusercontent.com/3328364/107018764-24d0ee80-67a1-11eb-94c2-1801a8d2faf6.png)
![ScreenshotLSO2](https://user-images.githubusercontent.com/3328364/107018772-269ab200-67a1-11eb-9368-4f5c85601768.png)
