### PR TITLE
Show tests in Assigned Objects tab of competences

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assQuestion.php
@@ -2134,6 +2134,16 @@ abstract class assQuestion
         foreach ($assignmentList->getAssignmentsByQuestionId($question_id) as $assignment) {
             /* @var ilAssQuestionSkillAssignment $assignment */
             $assignment->deleteFromDb();
+
+            // remove skill usage
+            if (!$assignment->isSkillUsed()) {
+                ilSkillUsage::setUsage(
+                    $assignment->getParentObjId(),
+                    $assignment->getSkillBaseId(),
+                    $assignment->getSkillTrefId(),
+                    false
+                );
+            }
         }
 
         $this->deleteTaxonomyAssignments();
@@ -4475,6 +4485,13 @@ abstract class assQuestion
             $assignment->setParentObjId($trgParentId);
             $assignment->setQuestionId($trgQuestionId);
             $assignment->saveToDb();
+
+            // add skill usage
+            ilSkillUsage::setUsage(
+                $trgParentId,
+                $assignment->getSkillBaseId(),
+                $assignment->getSkillTrefId()
+            );
         }
     }
 
@@ -4493,6 +4510,16 @@ abstract class assQuestion
             /* @var ilAssQuestionSkillAssignment $assignment */
 
             $assignment->deleteFromDb();
+
+            // remove skill usage
+            if (!$assignment->isSkillUsed()) {
+                ilSkillUsage::setUsage(
+                    $assignment->getParentObjId(),
+                    $assignment->getSkillBaseId(),
+                    $assignment->getSkillTrefId(),
+                    false
+                );
+            }
         }
         
         $this->duplicateSkillAssignments($srcParentId, $srcQuestionId, $trgParentId, $trgQuestionId);

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionSkillAssignment.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionSkillAssignment.php
@@ -194,6 +194,27 @@ class ilAssQuestionSkillAssignment
         return $row['cnt'] > 0;
     }
 
+    public function isSkillUsed()
+    {
+        $query = "
+			SELECT COUNT(*) cnt
+			FROM qpl_qst_skl_assigns
+			WHERE obj_fi = %s
+			AND skill_base_fi = %s
+			AND skill_tref_fi = %s
+		";
+
+        $res = $this->db->queryF(
+            $query,
+            array('integer', 'integer', 'integer'),
+            array($this->getParentObjId(), $this->getSkillBaseId(), $this->getSkillTrefId())
+        );
+
+        $row = $this->db->fetchAssoc($res);
+
+        return $row['cnt'] > 0;
+    }
+
     /**
      * @param int $skillPoints
      */

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
@@ -245,6 +245,9 @@ class ilAssQuestionSkillAssignmentsGUI
                             if (!$assignment->hasEvalModeBySolution()) {
                                 $assignment->setSkillPoints((int) $skillPoints);
                                 $assignment->saveToDb();
+
+                                // add skill usage
+                                ilSkillUsage::setUsage($this->getQuestionContainerId(), $skillBaseId, $skillTrefId);
                             }
                         }
                     }
@@ -293,6 +296,9 @@ class ilAssQuestionSkillAssignmentsGUI
                         $assignment->setSkillPoints(ilAssQuestionSkillAssignment::DEFAULT_COMPETENCE_POINTS);
                         $assignment->setEvalMode(ilAssQuestionSkillAssignment::EVAL_MODE_BY_QUESTION_RESULT);
                         $assignment->saveToDb();
+
+                        // add skill usage
+                        ilSkillUsage::setUsage($this->getQuestionContainerId(), $skillBaseId, $skillTrefId);
                     }
                     
                     $handledSkills[$skillId] = $skill;
@@ -305,6 +311,15 @@ class ilAssQuestionSkillAssignmentsGUI
                 }
 
                 $assignment->deleteFromDb();
+
+                // remove skill usage
+                if (!$assignment->isSkillUsed()) {
+                    ilSkillUsage::setUsage(
+                        $assignment->getParentObjId(),
+                        $assignment->getSkillBaseId(),
+                        $assignment->getSkillTrefId(),
+                        false);
+                }
             }
 
             ilUtil::sendSuccess($this->lng->txt('qpl_qst_skl_assigns_updated'), true);
@@ -432,6 +447,13 @@ class ilAssQuestionSkillAssignmentsGUI
             }
             
             $assignment->saveToDb();
+
+            // add skill usage
+            ilSkillUsage::setUsage(
+                $this->getQuestionContainerId(),
+                (int) $_GET['skill_base_id'],
+                (int) $_GET['skill_tref_id']
+            );
             
             ilUtil::sendSuccess($this->lng->txt('qpl_qst_skl_assign_properties_modified'), true);
 

--- a/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionSkillAssignmentImporter.php
+++ b/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionSkillAssignmentImporter.php
@@ -215,6 +215,9 @@ class ilAssQuestionSkillAssignmentImporter
             
             $importableAssignment->saveToDb();
             $importableAssignment->saveComparisonExpressions();
+
+            // add skill usage
+            ilSkillUsage::setUsage($this->getTargetParentObjId(), $foundSkillId['skill_id'], $foundSkillId['tref_id']);
             
             $this->getSuccessImportAssignmentList()->addAssignment($importableAssignment);
         }


### PR DESCRIPTION
This should fix [30014](https://mantis.ilias.de/view.php?id=30014).
In ILIAS 7 an [Assigned Objects](https://docu.ilias.de/goto_docu_wiki_wpage_5720_1357.html) tab was added for competences. For tests, this means: When a competence was added to a question, the corresponding tests must be shown there. Technically this means, an entry in the `skl_usage` table in the database has to be added.

I had to add a new method `isSkillUsed()` to remove the entry in `skl_usage` table only if the competence is removed from all questions of the test. The method is similar to `dbRecordExists()`, but the `$questionId` must not be checked here, only the `$parentObjId`. I know this is not nicely placed, but no better alternative came to my mind. I you have one, I would appreciate it!