### PR TITLE
Remove lng duplicates + wrongly placed translation

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -16406,7 +16406,7 @@ mob#:#mob_upload_file#:#Datei hochladen
 mob#:#mob_external_url#:#Externe URL
 mob#:#mob_choose_from_pool#:#Aus Medienpool
 mob#:#mob_url#:#URL
-mob#:#mob_url_info#:#External resource URL, e.g. Youtube or Vimeo URL.
+mob#:#mob_url_info#:#Externe URL, z.B. Youtube oder Vimeo URL.
 adn#:#administrative_notification#:#Ankündigung
 adn#:#administrative_notification_description#:#Bereitstellen systemweiter Ankündigungen in der Kopfzeile von ILIAS
 common#:#obj_adn#:#Ankündigungen

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -16444,7 +16444,7 @@ mob#:#mob_upload_file#:#Upload File
 mob#:#mob_external_url#:#External URL
 mob#:#mob_choose_from_pool#:#Choose from Media Pool
 mob#:#mob_url#:#URL
-mob#:#mob_url_info#:#Externe URL, z.B. Youtube oder Vimeo URL.
+mob#:#mob_url_info#:#External resource URL, e.g. Youtube or Vimeo URL.
 common#:#objs_prgr#:#Links to Study Programmes
 rbac#:#prgr_copy#:#User can copy links to study programmes.
 rbac#:#prgr_delete#:#User can move or delete links to study programmes.
@@ -16460,10 +16460,6 @@ rbac#:#coms_visible#:#Administration of Comments is visible.
 rbac#:#coms_read#:#User has read access to administration of Comments.
 rbac#:#coms_write#:#User can edit settings of administration of Comments.
 rbac#:#coms_edit_permissions#:#User can change permission settings of administration of Comments.
-rbac#:#coms_visible#:#Administration of Comments is visible.
-rbac#:#coms_read#:#User has read access to administration of Comments.
-rbac#:#coms_write#:#User can edit settings of administration of Comments.
-rbac#:#coms_edit_permissions#:#User can change permission settings of administration of Comments.
 rbac#:#cpad_visible#:#Administration of Content Pages is visible.
 rbac#:#cpad_read#:#User has read access to administration of Content Pages.
 rbac#:#cpad_write#:#User can edit settings of administration of Content Pages.
@@ -16472,10 +16468,6 @@ rbac#:#fils_visible#:#Administration of File Services is visible.
 rbac#:#fils_read#:#User has read access to File Services administration.
 rbac#:#fils_write#:#User can edit and configure File Services.
 rbac#:#fils_edit_permissions#:#User can change permission settings of File Services administration.
-rbac#:#fils_visible#:#Administration der Datei-Services ist sichtbar.
-rbac#:#fils_read#:#Lesezugriff auf Administration für Datei-Services
-rbac#:#fils_write#:#Konfiguration der Datei-Services bearbeiten
-rbac#:#fils_edit_permissions#:#Rechteeinstellungen der Administration für Datei-Services ändern
 rbac#:#lhts_visible#:#Administration of Learning History is visible.
 rbac#:#lhts_read#:#User has read access to Learning History administration.
 rbac#:#lhts_write#:#User can edit settings of Learning History administration.


### PR DESCRIPTION
Hi @matthiaskunkel,
I noticed some discrepancies (e.g. duplicates) in the language files when updating the languages. The Git History tells me that you introduced these variables. Please check and merge if the changes are correct.

The wrong translation for `mob_url_info` also occurs in ILIAS 7. I created a separate PR for this: #3165 