### PR TITLE
Component/Setup: always reload component definitions (#30109)

### DIFF
--- a/Services/Component/classes/Setup/class.ilComponentsSetupAgent.php
+++ b/Services/Component/classes/Setup/class.ilComponentsSetupAgent.php
@@ -35,10 +35,7 @@ class ilComponentsSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        if ($config !== null) {
-            return new \ilComponentDefinitionsStoredObjective(false);
-        }
-        return new Setup\Objective\NullObjective();
+        return new \ilComponentDefinitionsStoredObjective(false);
     }
 
     /**


### PR DESCRIPTION
Fix https://mantis.ilias.de/view.php?id=30109

Always reload the component definitions, no matter if there is a configuration or not.