### PR TITLE
Bt files lucene

### DIFF
--- a/Modules/File/LuceneObjectDefinition.xml
+++ b/Modules/File/LuceneObjectDefinition.xml
@@ -9,6 +9,7 @@
 				SELECT MAX(version) version, file_name
 				FROM file_data
 				WHERE file_id IN (?)
+				AND rid IS NULL
 				GROUP BY file_id,file_name
 			</Query>
 			<Param format="list" type="int" value="objId" />
@@ -20,6 +21,28 @@
 			</Field>
 			<DataSource type="File" action="append">
 				<PathCreator name="FileObjectPathCreator41" />
+				<Field store="YES" index="ANALYZED" name="content">
+					<Transformer name="LinefeedSanitizer" />
+				</Field>
+			</DataSource>
+		</DataSource>
+		<DataSource type="JDBC" action="append">
+			<Query>
+				SELECT MAX(version) version, file_name, rid
+				FROM file_data
+				WHERE file_id IN (?)
+				AND rid IS NOT NULL
+				GROUP BY file_id,file_name
+			</Query>
+			<Param format="list" type="int" value="objId" />
+			<Field store="YES" index="ANALYZED" column="file_name" type="text" name="propertyHigh">
+				<Transformer name="FilenameExtractor" />
+			</Field>
+			<Field store="YES" index="ANALYZED" column="file_name" type="text" name="mimeType">
+				<Transformer name="MimeTypeExtractor" />
+			</Field>
+			<DataSource type="File" action="append">
+				<PathCreator name="FileObjectPathCreator7" />
 				<Field store="YES" index="ANALYZED" name="content">
 					<Transformer name="LinefeedSanitizer" />
 				</Field>

--- a/Services/WebServices/RPC/lib/src/de/ilias/services/lucene/index/file/ExtensionFileHandler.java
+++ b/Services/WebServices/RPC/lib/src/de/ilias/services/lucene/index/file/ExtensionFileHandler.java
@@ -56,7 +56,7 @@ public class ExtensionFileHandler {
      * @return
      * @throws FileHandlerException
      */
-    public String getContent(File file) throws FileHandlerException {
+    public String getContent(File file, String extension) throws FileHandlerException {
 
     	// Stop here if no read permission is given
         if(!file.canRead()) {
@@ -69,87 +69,89 @@ public class ExtensionFileHandler {
 		}
 		
        	logger.info("Current file is: " + file.getAbsolutePath());
-		
-       
-    	try {
-	        String fname = file.getName();
-	        int dotIndex = fname.lastIndexOf(".");
-	        if((dotIndex > 0) && (dotIndex < fname.length())) {
-	            String extension = fname.substring(dotIndex + 1, fname.length());
-				
-				
-				// Do not index xslx
-				if(extension.equalsIgnoreCase("xlsx")) {
-					logger.info("Ignoring xslx: " + file.getName());
-					return "";
-				}
-	            // Handled extensions are: html,pdf,txt
-	            if(extension.equalsIgnoreCase("pdf")) {
-	                logger.info("Using getPDFDocument() for " + file.getName());
-	                return getPDFDocument(file);
-	            }
-	            // HTML
-	            if(extension.equalsIgnoreCase("html") || extension.equalsIgnoreCase("htm")) {
-	                logger.info("Using getHTMLDocument() for " + file.getName());
-	                return getHTMLDocument(file);
-	            }
-	            if(extension.equalsIgnoreCase("txt") || extension.length() == 0) {
-	                logger.info("Using getTextDocument() for: " + file.getName() );
-	                return getTextDocument(file);
-	            }
-	            // Open office
-	            if(extension.equalsIgnoreCase("odt")) {
-	            	logger.info("Using getOpenOfficeDocument() for " + file.getName());
-	            	return getOpenOfficeDocument(file);
-	            }
-	            if(extension.equalsIgnoreCase("ott")) {
-	            	logger.info("Using getOpenOfficeDocument() for " + file.getName());
-	            	return getOpenOfficeDocument(file);
-	            }
-	            if(extension.equalsIgnoreCase("stw")) {
-	            	logger.info("Using getOpenOfficeDocument() for " + file.getName());
-	            	return getOpenOfficeDocument(file);
-	            }
-	            if(extension.equalsIgnoreCase("sxw")) {
-	            	logger.info("Using getOpenOfficeDocument() for " + file.getName());
-	            	return getOpenOfficeDocument(file);
-	            }
-	            if(extension.equalsIgnoreCase("odg")) {
-	            	logger.info("Using getOpenOfficeDocument() for " + file.getName());
-	            	return getOpenOfficeDocument(file);
-	            }
-	            if(extension.equalsIgnoreCase("odp")) {
-	            	logger.info("Using getOpenOfficeDocument() for " + file.getName());
-	            	return getOpenOfficeDocument(file);
-	            }
-	            if(extension.equalsIgnoreCase("sti")) {
-	            	logger.info("Using getOpenOfficeDocument() for " + file.getName());
-	            	return getOpenOfficeDocument(file);
-	            }
-	            if(extension.equalsIgnoreCase("sxd")) {
-	            	logger.info("Using getOpenOfficeDocument() for " + file.getName());
-	            	return getOpenOfficeDocument(file);
-	            }
-	            if(extension.equalsIgnoreCase("sxw")) {
-	            	logger.info("Using getOpenOfficeDocument() for " + file.getName());
-	            	return getOpenOfficeDocument(file);
-	            }
-	            // Flat XML OO documents
-	            if(extension.equalsIgnoreCase("fodt")) {
-	            	logger.info("Using getOpenOfficeDocument() for " + file.getName());
-	            	return getFlatOpenOfficeDocument(file);
-	            }
-	            if(extension.equalsIgnoreCase("fodp")) {
-	            	logger.info("Using getOpenOfficeDocument() for " + file.getName());
-	            	return getFlatOpenOfficeDocument(file);
-	            }
-	            
-	            // RTF
-	            if(extension.equalsIgnoreCase("rtf")) {
-	            	logger.info("Using getRTFDocument() for " + file.getName());
-	            	return getRTFDocument(file);
-	            }
-	        }
+		try {
+			String fname = file.getName();
+			int dotIndex = fname.lastIndexOf(".");
+			if ((extension.length() == 0)
+				&& (dotIndex > 0)
+				&& (dotIndex < fname.length())) {
+				extension = fname.substring(dotIndex + 1, fname.length());
+			}
+			if (extension.equalsIgnoreCase("")) {
+				logger.warn("no valid extension found for: " + file.getName());
+				return "";
+			}
+			// Do not index xslx
+			if (extension.equalsIgnoreCase("xlsx")) {
+				logger.info("Ignoring xslx: " + file.getName());
+				return "";
+			}
+			// Handled extensions are: html,pdf,txt
+			if (extension.equalsIgnoreCase("pdf")) {
+				logger.info("Using getPDFDocument() for " + file.getName());
+				return getPDFDocument(file);
+			}
+			// HTML
+			if (extension.equalsIgnoreCase("html") || extension.equalsIgnoreCase("htm")) {
+				logger.info("Using getHTMLDocument() for " + file.getName());
+				return getHTMLDocument(file);
+			}
+			if (extension.equalsIgnoreCase("txt") || extension.length() == 0) {
+				logger.info("Using getTextDocument() for: " + file.getName());
+				return getTextDocument(file);
+			}
+			// Open office
+			if (extension.equalsIgnoreCase("odt")) {
+				logger.info("Using getOpenOfficeDocument() for " + file.getName());
+				return getOpenOfficeDocument(file);
+			}
+			if (extension.equalsIgnoreCase("ott")) {
+				logger.info("Using getOpenOfficeDocument() for " + file.getName());
+				return getOpenOfficeDocument(file);
+			}
+			if (extension.equalsIgnoreCase("stw")) {
+				logger.info("Using getOpenOfficeDocument() for " + file.getName());
+				return getOpenOfficeDocument(file);
+			}
+			if (extension.equalsIgnoreCase("sxw")) {
+				logger.info("Using getOpenOfficeDocument() for " + file.getName());
+				return getOpenOfficeDocument(file);
+			}
+			if (extension.equalsIgnoreCase("odg")) {
+				logger.info("Using getOpenOfficeDocument() for " + file.getName());
+				return getOpenOfficeDocument(file);
+			}
+			if (extension.equalsIgnoreCase("odp")) {
+				logger.info("Using getOpenOfficeDocument() for " + file.getName());
+				return getOpenOfficeDocument(file);
+			}
+			if (extension.equalsIgnoreCase("sti")) {
+				logger.info("Using getOpenOfficeDocument() for " + file.getName());
+				return getOpenOfficeDocument(file);
+			}
+			if (extension.equalsIgnoreCase("sxd")) {
+				logger.info("Using getOpenOfficeDocument() for " + file.getName());
+				return getOpenOfficeDocument(file);
+			}
+			if (extension.equalsIgnoreCase("sxw")) {
+				logger.info("Using getOpenOfficeDocument() for " + file.getName());
+				return getOpenOfficeDocument(file);
+			}
+			// Flat XML OO documents
+			if (extension.equalsIgnoreCase("fodt")) {
+				logger.info("Using getOpenOfficeDocument() for " + file.getName());
+				return getFlatOpenOfficeDocument(file);
+			}
+			if (extension.equalsIgnoreCase("fodp")) {
+				logger.info("Using getOpenOfficeDocument() for " + file.getName());
+				return getFlatOpenOfficeDocument(file);
+			}
+
+			// RTF
+			if (extension.equalsIgnoreCase("rtf")) {
+				logger.info("Using getRTFDocument() for " + file.getName());
+				return getRTFDocument(file);
+			}
         }
     	catch (FileHandlerException e) {
         	logger.warn("Parsing failed with message: " + e);

--- a/Services/WebServices/RPC/lib/src/de/ilias/services/lucene/index/file/path/ExerciseAssignmentPathCreator.java
+++ b/Services/WebServices/RPC/lib/src/de/ilias/services/lucene/index/file/path/ExerciseAssignmentPathCreator.java
@@ -70,4 +70,9 @@ public class ExerciseAssignmentPathCreator implements PathCreator {
 		return buildFile(el, null);
 	}
 
+	@Override
+	public String getExtension(CommandQueueElement el, ResultSet res) {
+		return "";
+	}
+
 }

--- a/Services/WebServices/RPC/lib/src/de/ilias/services/lucene/index/file/path/FileListPathCreator.java
+++ b/Services/WebServices/RPC/lib/src/de/ilias/services/lucene/index/file/path/FileListPathCreator.java
@@ -141,4 +141,22 @@ public class FileListPathCreator implements PathCreator {
 
 		return buildFile(el, null);
 	}
+	
+	@Override
+	public String getExtension(CommandQueueElement el, ResultSet res) {
+		
+		StringBuilder extension = new StringBuilder();
+		try {
+			String fileName = res.getString("file_name");
+	        int dotIndex = fileName.lastIndexOf(".");
+	        if((dotIndex > 0) && (dotIndex < fileName.length())) {
+	            extension.append(fileName.substring(dotIndex + 1, fileName.length()));
+			}
+
+		} catch (SQLException ex) {
+			logger.error(ex.toString());
+		}
+		return extension.toString();
+	}
+	
 }

--- a/Services/WebServices/RPC/lib/src/de/ilias/services/lucene/index/file/path/FileObjectPathCreator.java
+++ b/Services/WebServices/RPC/lib/src/de/ilias/services/lucene/index/file/path/FileObjectPathCreator.java
@@ -142,4 +142,9 @@ public class FileObjectPathCreator implements PathCreator {
 
 		return buildFile(el, null);
 	}
+
+	@Override
+	public String getExtension(CommandQueueElement el, ResultSet res) {
+		throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+	}
 }

--- a/Services/WebServices/RPC/lib/src/de/ilias/services/lucene/index/file/path/FileObjectPathCreator7.java
+++ b/Services/WebServices/RPC/lib/src/de/ilias/services/lucene/index/file/path/FileObjectPathCreator7.java
@@ -1,0 +1,138 @@
+/* Copyright (c) 1998-2016 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+package de.ilias.services.lucene.index.file.path;
+
+import de.ilias.services.db.DBFactory;
+import de.ilias.services.lucene.index.CommandQueueElement;
+import de.ilias.services.settings.ClientSettings;
+import de.ilias.services.settings.ConfigurationException;
+import de.ilias.services.settings.LocalSettings;
+import java.io.File;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.logging.Level;
+import org.apache.log4j.Logger;
+
+/**
+ *
+ * @author Stefan Meyer <smeyer.ilias@gmx.de>
+ */
+public class FileObjectPathCreator7  implements PathCreator
+{
+	private static final Logger logger = Logger.getLogger(FileObjectPathCreator.class);
+	
+	protected String basePath = "storage";
+	protected static final String BIN_NAME = "data";
+
+	/**
+	 * Default constructor
+	 */
+	public FileObjectPathCreator7() {
+
+	}
+	
+	/**
+	 * Set bas path
+	 * @param bp
+	 */
+	public void setBasePath(String bp) {
+		
+		this.basePath = bp;
+	}
+	
+
+	/**
+	 * Get base path
+	 * 
+	 * @return String basePath
+	 */
+	public String getBasePath() {
+		
+		return this.basePath;
+	}
+	
+	
+	/**
+	 * @see de.ilias.services.lucene.index.file.path.PathCreator#buildPath(de.ilias.services.lucene.index.CommandQueueElement, java.sql.ResultSet)
+	 */
+	public File buildFile(CommandQueueElement el, ResultSet res)
+			throws PathCreatorException {
+
+		
+		int objId = el.getObjId();
+		
+		
+		
+		StringBuilder fullPath = new StringBuilder();
+		StringBuilder versionPath = new StringBuilder();
+		
+		File file;
+		
+		try {
+			int versionCode = 1;
+			int resVersion = res.getInt("version");
+			if (resVersion > 0) {
+				versionCode = resVersion;
+			}
+			String rid = res.getString("rid");
+			String resourcePath = "";
+
+			fullPath.append(ClientSettings.getInstance(LocalSettings.getClientKey()).getDataDirectory().getAbsolutePath());
+			fullPath.append(System.getProperty("file.separator"));
+			fullPath.append(ClientSettings.getInstance(LocalSettings.getClientKey()).getClient());
+			fullPath.append(System.getProperty("file.separator"));
+			fullPath.append(getBasePath());
+			fullPath.append(System.getProperty("file.separator"));
+			fullPath.append(rid.replaceAll("-", System.getProperty("file.separator")));
+			
+			versionPath.append(fullPath);
+			versionPath.append(System.getProperty("file.separator"));
+			versionPath.append(String.valueOf(versionCode));
+			versionPath.append(System.getProperty("file.separator"));
+			versionPath.append(BIN_NAME);
+			
+			logger.info("Detected file object path is: " + versionPath.toString());
+
+			file = new File(versionPath.toString());
+			if(file.exists() && file.canRead()) {
+				return file;
+			}
+			return null;
+		} 
+		catch (ConfigurationException e) {
+			throw new PathCreatorException(e);
+		}
+		catch (SQLException e) {
+			throw new PathCreatorException(e);
+		}
+		catch (NullPointerException e) {
+			throw new PathCreatorException(e);
+		} 
+	}
+
+	/**
+	 * @see de.ilias.services.lucene.index.file.path.PathCreator#buildPath(de.ilias.services.lucene.index.CommandQueueElement)
+	 */
+	public File buildFile(CommandQueueElement el) throws PathCreatorException {
+
+		return buildFile(el, null);
+	}
+
+	@Override
+	public String getExtension(CommandQueueElement el, ResultSet res) {
+		
+		StringBuilder extension = new StringBuilder();
+		try {
+			String fileName = res.getString("file_name");
+	        int dotIndex = fileName.lastIndexOf(".");
+	        if((dotIndex > 0) && (dotIndex < fileName.length())) {
+	            extension.append(fileName.substring(dotIndex + 1, fileName.length()));
+			}
+			logger.info("Extraced extension: " + extension.toString() + " from file name: " + fileName);
+
+		} catch (SQLException ex) {
+			logger.error(ex.toString());
+		}
+		return extension.toString();
+	}
+}

--- a/Services/WebServices/RPC/lib/src/de/ilias/services/lucene/index/file/path/HTLMObjectPathCreator.java
+++ b/Services/WebServices/RPC/lib/src/de/ilias/services/lucene/index/file/path/HTLMObjectPathCreator.java
@@ -79,4 +79,9 @@ public class HTLMObjectPathCreator implements PathCreator {
 		return buildFile(el, null);
 	}
 
+	@Override
+	public String getExtension(CommandQueueElement el, ResultSet res) {
+		return "";
+	}
+
 }

--- a/Services/WebServices/RPC/lib/src/de/ilias/services/lucene/index/file/path/MailAttachmentPathCreator.java
+++ b/Services/WebServices/RPC/lib/src/de/ilias/services/lucene/index/file/path/MailAttachmentPathCreator.java
@@ -70,5 +70,10 @@ public class MailAttachmentPathCreator implements PathCreator {
 		return this.buildFile(el, null);
 		
 	}
+
+	@Override
+	public String getExtension(CommandQueueElement el, ResultSet res) {
+		return "";
+	}
 	
 }

--- a/Services/WebServices/RPC/lib/src/de/ilias/services/lucene/index/file/path/PathCreator.java
+++ b/Services/WebServices/RPC/lib/src/de/ilias/services/lucene/index/file/path/PathCreator.java
@@ -56,4 +56,13 @@ public interface PathCreator {
 	 * @throws PathCreatorException
 	 */
 	public File buildFile(CommandQueueElement el) throws PathCreatorException;
+	
+	
+	/**
+	 * 
+	 * @param el
+	 * @param res
+	 * @return String
+	 */
+	public String getExtension(CommandQueueElement el, ResultSet res);
 }

--- a/Services/WebServices/RPC/lib/src/de/ilias/services/lucene/index/file/path/PathCreatorFactory.java
+++ b/Services/WebServices/RPC/lib/src/de/ilias/services/lucene/index/file/path/PathCreatorFactory.java
@@ -59,6 +59,9 @@ public class PathCreatorFactory {
 		if(name.equalsIgnoreCase("MailAttachmentPathCreator")) {
 			return (PathCreator) new MailAttachmentPathCreator();
 		}
+		if(name.equalsIgnoreCase("FileObjectPathCreator7")) {
+			return (PathCreator) new FileObjectPathCreator7();
+		}
 		
 		throw new ObjectDefinitionException("Invalid path creator name given: " + name);
 	}

--- a/Services/WebServices/RPC/lib/src/de/ilias/services/object/DirectoryDataSource.java
+++ b/Services/WebServices/RPC/lib/src/de/ilias/services/object/DirectoryDataSource.java
@@ -81,7 +81,7 @@ public class DirectoryDataSource extends FileDataSource {
 				// Analyze encoding (transfer encoding), parse file extension
 				// and finally read content
 				try {
-					content.append(" " + handler.getContent(files.get(i)));
+					content.append(" " + handler.getContent(files.get(i), ""));
 				} 
 				catch (FileHandlerException e) {
 					logger.warn("Cannot parse file " + files.get(i).getAbsolutePath());

--- a/Services/WebServices/RPC/lib/src/de/ilias/services/object/FileDataSource.java
+++ b/Services/WebServices/RPC/lib/src/de/ilias/services/object/FileDataSource.java
@@ -68,10 +68,11 @@ public class FileDataSource extends DataSource {
 				return;
 			}
 			file = getPathCreator().buildFile(el, res);
+			String extension = getPathCreator().getExtension(el, res);
 			
 			// Analyze encoding (transfer encoding), parse file extension and finally read content
 			for(Object field : getFields()) {
-				((FieldDefinition) field).writeDocument(handler.getContent(file));
+				((FieldDefinition) field).writeDocument(handler.getContent(file, extension));
 			}
 			logger.debug("File path is: " + file.getAbsolutePath());
 			return;


### PR DESCRIPTION
This adds support for the new storage of file objects with the following assumptions:

- file_data.rid is null => no migration is done
- a part of the path to the file can constructed by replacing "_" by "/" or "\"
- version directory is always 1 or higher
- filename is "data"

A switch for the old and new structure is done in Module/File/LuceneObjectDefinition.xml by querying rid against NULL