### PR TITLE
fix #26924: Translation-Link does not work

### DIFF
--- a/Modules/DataCollection/classes/class.ilDataCollectionGlobalTemplate.php
+++ b/Modules/DataCollection/classes/class.ilDataCollectionGlobalTemplate.php
@@ -18,7 +18,6 @@ class ilDataCollectionGlobalTemplate implements ilGlobalTemplateInterface
     protected $permanent_link = false;
     protected $lightbox = array();
     protected $standard_template_loaded = false;
-    protected $translation_linked = false; // fix #9992: remember if a translation link is added
     /**
      * @var    \ilTemplate
      */
@@ -133,8 +132,6 @@ class ilDataCollectionGlobalTemplate implements ilGlobalTemplateInterface
         // output translation link
         include_once("Services/Language/classes/class.ilObjLanguageAccess.php");
         if (ilObjLanguageAccess::_checkTranslate() and !ilObjLanguageAccess::_isPageTranslation()) {
-            // fix #9992: remember linked translation instead of saving language usages here
-            $this->translation_linked = true;
             $link_items[ilObjLanguageAccess::_getTranslationLink()] = array($lng->txt('translation'), true);
         }
 
@@ -1418,10 +1415,8 @@ class ilDataCollectionGlobalTemplate implements ilGlobalTemplateInterface
             $html = $this->template->get($part);
         }
 
-        // fix #9992: save language usages as late as possible
-        if ($this->translation_linked) {
-            ilObjLanguageAccess::_saveUsages();
-        }
+        // save language usages as late as possible
+        ilObjLanguageAccess::_saveUsages();
 
         return $html;
     }
@@ -1541,10 +1536,8 @@ class ilDataCollectionGlobalTemplate implements ilGlobalTemplateInterface
                     }
                 }
 
-                // fix #9992: save language usages as late as possible
-                if ($this->translation_linked) {
-                    ilObjLanguageAccess::_saveUsages();
-                }
+                // save language usages as late as possible
+                ilObjLanguageAccess::_saveUsages();
 
                 print $html;
 

--- a/Services/COPage/classes/class.ilCOPageGlobalTemplate.php
+++ b/Services/COPage/classes/class.ilCOPageGlobalTemplate.php
@@ -19,8 +19,6 @@ class ilCOPageGlobalTemplate implements ilGlobalTemplateInterface
     protected $lightbox = array();
     protected $standard_template_loaded = false;
 
-    protected $translation_linked = false; // fix #9992: remember if a translation link is added
-
     /**
      * @var	\ilTemplate
      */
@@ -130,8 +128,6 @@ class ilCOPageGlobalTemplate implements ilGlobalTemplateInterface
         // output translation link
         include_once("Services/Language/classes/class.ilObjLanguageAccess.php");
         if (ilObjLanguageAccess::_checkTranslate() and !ilObjLanguageAccess::_isPageTranslation()) {
-            // fix #9992: remember linked translation instead of saving language usages here
-            $this->translation_linked = true;
             $link_items[ilObjLanguageAccess::_getTranslationLink()] = array($lng->txt('translation'), true);
         }
 
@@ -1360,10 +1356,8 @@ class ilCOPageGlobalTemplate implements ilGlobalTemplateInterface
             $html = $this->template->get($part);
         }
 
-        // fix #9992: save language usages as late as possible
-        if ($this->translation_linked) {
-            ilObjLanguageAccess::_saveUsages();
-        }
+        // save language usages as late as possible
+        ilObjLanguageAccess::_saveUsages();
 
         return $html;
     }
@@ -1482,10 +1476,8 @@ class ilCOPageGlobalTemplate implements ilGlobalTemplateInterface
                     }
                 }
 
-                // fix #9992: save language usages as late as possible
-                if ($this->translation_linked) {
-                    ilObjLanguageAccess::_saveUsages();
-                }
+                // save language usages as late as possible
+                ilObjLanguageAccess::_saveUsages();
 
                 print $html;
 

--- a/Services/RTE/classes/class.ilRTEGlobalTemplate.php
+++ b/Services/RTE/classes/class.ilRTEGlobalTemplate.php
@@ -19,8 +19,6 @@ class ilRTEGlobalTemplate implements ilGlobalTemplateInterface
     protected $lightbox = array();
     protected $standard_template_loaded = false;
 
-    protected $translation_linked = false; // fix #9992: remember if a translation link is added
-
     /**
      * @var	\ilTemplate
      */
@@ -130,8 +128,6 @@ class ilRTEGlobalTemplate implements ilGlobalTemplateInterface
         // output translation link
         include_once("Services/Language/classes/class.ilObjLanguageAccess.php");
         if (ilObjLanguageAccess::_checkTranslate() and !ilObjLanguageAccess::_isPageTranslation()) {
-            // fix #9992: remember linked translation instead of saving language usages here
-            $this->translation_linked = true;
             $link_items[ilObjLanguageAccess::_getTranslationLink()] = array($lng->txt('translation'), true);
         }
 
@@ -1363,10 +1359,8 @@ class ilRTEGlobalTemplate implements ilGlobalTemplateInterface
             $html = $this->template->get($part);
         }
 
-        // fix #9992: save language usages as late as possible
-        if ($this->translation_linked) {
-            ilObjLanguageAccess::_saveUsages();
-        }
+        // save language usages as late as possible
+        ilObjLanguageAccess::_saveUsages();
 
         return $html;
     }
@@ -1485,10 +1479,8 @@ class ilRTEGlobalTemplate implements ilGlobalTemplateInterface
                     }
                 }
 
-                // fix #9992: save language usages as late as possible
-                if ($this->translation_linked) {
-                    ilObjLanguageAccess::_saveUsages();
-                }
+                // save language usages as late as possible
+                ilObjLanguageAccess::_saveUsages();
 
                 print $html;
 

--- a/Services/UICore/classes/MetaTemplate/PageContentGUI.php
+++ b/Services/UICore/classes/MetaTemplate/PageContentGUI.php
@@ -491,10 +491,8 @@ class PageContentGUI
             }
         }
 
-        // fix #9992: save language usages as late as possible
-        if ($this->translation_linked) {
-            \ilObjLanguageAccess::_saveUsages();
-        }
+        // save language usages as late as possible
+        \ilObjLanguageAccess::_saveUsages();
 
         return $html;
     }

--- a/Services/UICore/classes/class.ilGlobalPageTemplate.php
+++ b/Services/UICore/classes/class.ilGlobalPageTemplate.php
@@ -111,6 +111,9 @@ class ilGlobalPageTemplate implements ilGlobalTemplateInterface
         PageContentProvider::setContent($this->legacy_content_template->renderPage("DEFAULT", true, false));
         print $this->ui->renderer()->render($this->gs->collector()->layout()->getFinalPage());
 
+        // save language usages as late as possible
+        \ilObjLanguageAccess::_saveUsages();
+
         // see #26968
         $this->handleReferer();
     }

--- a/Services/UICore/classes/class.ilGlobalTemplate.php
+++ b/Services/UICore/classes/class.ilGlobalTemplate.php
@@ -20,8 +20,6 @@ class ilGlobalTemplate implements ilGlobalTemplateInterface
     protected $lightbox = array();
     protected $standard_template_loaded = false;
 
-    protected $translation_linked = false; // fix #9992: remember if a translation link is added
-
     /**
      * @var	\ilTemplate
      */
@@ -137,8 +135,6 @@ class ilGlobalTemplate implements ilGlobalTemplateInterface
         // output translation link
         include_once("Services/Language/classes/class.ilObjLanguageAccess.php");
         if (ilObjLanguageAccess::_checkTranslate() and !ilObjLanguageAccess::_isPageTranslation()) {
-            // fix #9992: remember linked translation instead of saving language usages here
-            $this->translation_linked = true;
             $link_items[ilObjLanguageAccess::_getTranslationLink()] = array($lng->txt('translation'), true);
         }
 
@@ -765,10 +761,8 @@ class ilGlobalTemplate implements ilGlobalTemplateInterface
             }
         }
 
-        // fix #9992: save language usages as late as possible
-        if ($this->translation_linked) {
-            ilObjLanguageAccess::_saveUsages();
-        }
+        // save language usages as late as possible
+        \ilObjLanguageAccess::_saveUsages();
 
         return $html;
     }
@@ -1471,10 +1465,8 @@ class ilGlobalTemplate implements ilGlobalTemplateInterface
             $html = $this->template->get($part);
         }
 
-        // fix #9992: save language usages as late as possible
-        if ($this->translation_linked) {
-            ilObjLanguageAccess::_saveUsages();
-        }
+        // save language usages as late as possible
+        \ilObjLanguageAccess::_saveUsages();
 
         return $html;
     }


### PR DESCRIPTION
This PR fixes https://mantis.ilias.de/view.php?id=26924 for ILIAS 6.

Essentially it adds a missing call of ilObjLanguageAccess::_saveUsages() in ilGlobalPageTemplate.

Additionaly it decouples the calls of ilObjLanguageAccess::_getTranslationLink() and ilObjLanguageAccess::_saveUsages() and therefore it removes the state variables $translation_linked from the implementations of ilGlobalTemplateInterface.

ilObjLanguageAccess::_saveUsages() now checks internally, whether the collected usages of language variables should be saved in the session. To avoid multipe database queries, the result of ilObjLanguageAccess::_checkTranslate() is cached for that purpose.