### PR TITLE
30066 Fix: COPage/MediaObjects: Validation of url and title while creating or editing a media object

### DIFF
--- a/Services/COPage/classes/class.ilPCMediaObjectGUI.php
+++ b/Services/COPage/classes/class.ilPCMediaObjectGUI.php
@@ -575,6 +575,21 @@ class ilPCMediaObjectGUI extends ilPageContentGUI
             $this->insert("edpost", "create_mob", true);
             return;
         }
+
+        if ($_POST['standard_reference'] != "") {
+            try {
+                new \ILIAS\Data\URI($_POST['standard_reference']);
+            } catch (\Throwable $e) {
+                $this->form = $mob_gui->getForm();
+                $this->form->setValuesByPost();
+                $url_field = $this->form->getItemByPostVar('standard_reference');
+                $url_field->setAlert($lng->txt('invalid_url'));
+                $this->tpl->setContent($this->form->getHTML());
+                $this->insert("edpost", "create_mob", true);
+                return;
+            }
+        }
+
         // create dummy object in db (we need an id)
         include_once("./Services/COPage/classes/class.ilPCMediaObject.php");
         if ($a_change_obj_ref != true) {

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -16213,3 +16213,4 @@ common#:#lso_admin_form_byline#:#Allgemeine Einstellungen für Lernsequenzen
 common#:#lso_admin_interval_label#:#Abfrageintervall Lernfortschritt (Sekunden)
 common#:#lso_admin_interval_byline#:#Alle x Sekunden wird der Lernfortschritt für nicht vollständig integrierte Objekte abgefragt. Achtung! Je niedriger der Wert, desto häufiger wird eine Abfrage ausgeführt. Das kann sich sehr negativ auf die Systemlast auswirken; entsprechend sollte der Wert möglichst hoch gewählt werden.
 prg#:#no_srctype_or_id#:#Id und Typ dürfen nicht leer sein.
+content#:#invalid_url#:#Das Format der URL ist nicht korrekt. Es sind keine HTML Tags, Apostrophe oder Anführungszeichen erlaubt.


### PR DESCRIPTION
HTML tags, quotes or single quote marks will be removed from title, if those exist in title.
If the url is invalid an alert message is thrown. A media object won't be saved until the url is valid. 

https://mantis.ilias.de/view.php?id=30066