### PR TITLE
Ignore config.json to make updates more easy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 # Generated Files
 /ilias.ini.php
 /ilias.log
+/config.json
 /db_template_writer.php
 /setup/sql/dbupdate_custom.php
 /install_client.php


### PR DESCRIPTION
To make the update process more easy i added the config.json to the .gitignore.

The installation process describes that the user creates the file in the docroot of ilias so this is constantly blocking a user from pulling a new version (or patch) if its not committed in a fork.


But there is a flaw in the docs. If the json file is public reachable an attacker would be able to read the DB access data from it. Probably it shouldnt even allowed to use a config.json inside the public directory. You decide. 