### PR TITLE
Setup: Read ILIAS version from constant

### DIFF
--- a/src/Setup/Condition/PHPExtensionLoadedCondition.php
+++ b/src/Setup/Condition/PHPExtensionLoadedCondition.php
@@ -10,12 +10,14 @@ class PHPExtensionLoadedCondition extends ExternalConditionObjective
 {
     public function __construct($which)
     {
+        $ilias_version = ILIAS_VERSION_NUMERIC;
+
         return parent::__construct(
             "PHP extension \"$which\" loaded",
             function (Setup\Environment $env) use ($which) : bool {
                 return in_array($which, get_loaded_extensions());
             },
-            "ILIAS 7 requires the PHP extension $which."
+            "ILIAS $ilias_version requires the PHP extension $which."
         );
     }
 }

--- a/src/Setup/Objective/ClientIdReadObjective.php
+++ b/src/Setup/Objective/ClientIdReadObjective.php
@@ -80,10 +80,12 @@ class ClientIdReadObjective implements Setup\Objective
         }
 
         if (count($candidates) != 1) {
+            $ilias_version = ILIAS_VERSION_NUMERIC;
+
             throw new Setup\UnachievableException(
                 "There is more than one directory in the webdata-dir at '$dir'. " .
                 "Probably this is an ILIAS installation that uses clients. Clients " .
-                "are not supported anymore since ILIAS 7. " .
+                "are not supported anymore since ILIAS $ilias_version " .
                 "(see: https://docu.ilias.de/goto.php?target=wiki_1357_Setup_-_Abandon_Multi_Client)"
             );
         }


### PR DESCRIPTION
This PR replaces the statically defined version number in src/Setup with the ILIAS_VERSION_NUMERIC constant.
This constant is defined in the include/inc.ilias_version.php file and bumped by the release manager.

Of course this introduces a dependency on this global constant.