### PR TITLE
[FIX] 0030122: Can't create missing directory during update command

### DIFF
--- a/Modules/File/classes/Setup/class.ilFileObjectMigrationAgent.php
+++ b/Modules/File/classes/Setup/class.ilFileObjectMigrationAgent.php
@@ -45,7 +45,10 @@ class ilFileObjectMigrationAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-       return new Setup\Objective\NullObjective();
+        return new ilFileSystemComponentDataDirectoryCreatedObjective(
+            'storage',
+            ilFileSystemComponentDataDirectoryCreatedObjective::DATADIR
+        );
     }
 
     /**

--- a/Services/FileSystem/classes/Setup/class.ilFileSystemDirectoriesCreatedObjective.php
+++ b/Services/FileSystem/classes/Setup/class.ilFileSystemDirectoriesCreatedObjective.php
@@ -35,16 +35,24 @@ class ilFileSystemDirectoriesCreatedObjective implements Setup\Objective
 
     public function getPreconditions(Setup\Environment $environment) : array
     {
-        $common_config = $environment->getConfigFor("common");
+        $ini = $environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI);
+        $client_id = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_ID);
+
+        $data_dir = $ini->readVariable('clients', 'datadir');
+        $web_dir = dirname(__DIR__, 4) . "/data";
+
+        $client_data_dir = $data_dir . '/' . $client_id;
+        $client_web_dir = $web_dir . '/' . $client_id;
+
         return [
-            new ilIniFilesPopulatedObjective($common_config),
-            new Setup\Objective\DirectoryCreatedObjective($this->config->getDataDir()),
-            new Setup\Objective\DirectoryCreatedObjective($this->config->getWebDir()),
+            new ilIniFilesPopulatedObjective(),
+            new Setup\Objective\DirectoryCreatedObjective($data_dir),
+            new Setup\Objective\DirectoryCreatedObjective($web_dir),
             new Setup\Objective\DirectoryCreatedObjective(
-                $this->config->getWebDir() . "/" . $common_config->getClientId()
+                $client_web_dir
             ),
             new Setup\Objective\DirectoryCreatedObjective(
-                $this->config->getDataDir() . "/" . $common_config->getClientId()
+                $client_data_dir
             )
         ];
     }


### PR DESCRIPTION
The PR #3199 almost did the thing, there still some change missing to create directories during the update process. may you have a look at this please? thanks a lot!

https://mantis.ilias.de/view.php?id=30122