### PR TITLE
UI: Secondary Panel in Sub Panel

### DIFF
--- a/Modules/Exercise/classes/class.ilExerciseManagementGUI.php
+++ b/Modules/Exercise/classes/class.ilExerciseManagementGUI.php
@@ -659,7 +659,7 @@ class ilExerciseManagementGUI
         }
 
         $main_panel = $this->ui_factory->panel()->sub($a_data['uname'], $this->ui_factory->legacy($a_data['utext']))
-            ->withCard($this->ui_factory->card()->standard($this->lng->txt('text_assignment'))->withSections(array($this->ui_factory->legacy($card_tpl->get()))))->withActions($actions_dropdown);
+            ->withFurtherInformation($this->ui_factory->card()->standard($this->lng->txt('text_assignment'))->withSections(array($this->ui_factory->legacy($card_tpl->get()))))->withActions($actions_dropdown);
 
         $feedback_tpl = new ilTemplate("tpl.exc_report_feedback.html", true, true, "Modules/Exercise");
         //if no feedback filter the feedback is displayed. Can be list submissions or compare submissions.

--- a/Modules/Survey/Evaluation/class.ilSurveyEvaluationGUI.php
+++ b/Modules/Survey/Evaluation/class.ilSurveyEvaluationGUI.php
@@ -1038,12 +1038,12 @@ class ilSurveyEvaluationGUI
         $anchor_id = "svyrdq" . $question->getId();
         $title = "<span id='$anchor_id'>$qst_title</span>";
         $panel_qst_card = $ui_factory->panel()->sub($title, $ui_factory->legacy($svy_text))
-            ->withCard($ui_factory->card()->standard($svy_type_title)->withSections(array($ui_factory->legacy($card_table_tpl->get()))));
+            ->FurtherInformation($ui_factory->card()->standard($svy_type_title)->withSections(array($ui_factory->legacy($card_table_tpl->get()))));
 
         //commit 715c28815 from phantom patch
         //$anchor = "<a name='".$anchor_id."'></a>";
         //$panel_qst_card = $ui_factory->panel()->sub($anchor.$qst_title, $ui_factory->legacy($svy_text))
-        //->withCard($ui_factory->card($svy_type_title)->withSections(array($ui_factory->legacy($card_table_tpl->get()))));
+        //->withFurtherInformation($ui_factory->card($svy_type_title)->withSections(array($ui_factory->legacy($card_table_tpl->get()))));
         
         array_push($this->array_panels, $panel_qst_card);
 

--- a/src/UI/Component/Panel/Factory.php
+++ b/src/UI/Component/Panel/Factory.php
@@ -48,14 +48,15 @@ interface Factory
      *   purpose: >
      *       Sub Panels are used to structure the content of Standard panels further into titled sections.
      *   composition: >
-     *       Sub Panels consist of a title and a content section. They may contain a Card on their right side to display
-     *       meta information about the content displayed.
+     *       Sub Panels consist of a title and a content section. They may contain either a Card or a Secondary Panel on
+     *       their right side to display meta information about the content displayed.
      *   rivals:
      *      Standard Panel: >
      *        The Standard Panel might contain a Sub Panel.
      *      Card: >
      *        The Sub Panels may contain one Card.
-     *
+     *      Secondary Panel: >
+     *        The Sub Panels may contain one Secondary Panel.
      * rules:
      *   usage:
      *      1: Sub Panels MUST only be inside Standard Panels

--- a/src/UI/Component/Panel/Sub.php
+++ b/src/UI/Component/Panel/Sub.php
@@ -21,4 +21,17 @@ interface Sub extends Panel
      * @return \ILIAS\UI\Component\Card\Card | null
      */
     public function getCard();
+
+    /**
+     * Sets the Secondary Panel to be displayed on the right of the Sub Panel
+     * @param \ILIAS\UI\Component\Panel\Secondary\Secondary $secondary
+     * @return Sub
+     */
+    public function withSecondaryPanel(\ILIAS\UI\Component\Panel\Secondary\Secondary $secondary);
+
+    /**
+     * Gets the Secondary Panel to be displayed on the right of the Sub Panel
+     * @return \ILIAS\UI\Component\Panel\Secondary\Secondary | null
+     */
+    public function getSecondaryPanel();
 }

--- a/src/UI/Component/Panel/Sub.php
+++ b/src/UI/Component/Panel/Sub.php
@@ -10,28 +10,15 @@ namespace ILIAS\UI\Component\Panel;
 interface Sub extends Panel
 {
     /**
-     * Sets the card to be displayed on the right of the Sub Panel
-     * @param \ILIAS\UI\Component\Card\Card $card
+     * Sets the component to be displayed on the right of the Sub Panel
+     * @param \ILIAS\UI\Component\Card\Card | \ILIAS\UI\Component\Panel\Secondary\Secondary $component
      * @return Sub
      */
-    public function withCard(\ILIAS\UI\Component\Card\Card $card);
+    public function withFurtherInformation($component);
 
     /**
-     * Gets the card to be displayed on the right of the Sub Panel
-     * @return \ILIAS\UI\Component\Card\Card | null
+     * Gets the component to be displayed on the right of the Sub Panel
+     * @return \ILIAS\UI\Component\Card\Card | \ILIAS\UI\Component\Panel\Secondary\Secondary | null
      */
-    public function getCard();
-
-    /**
-     * Sets the Secondary Panel to be displayed on the right of the Sub Panel
-     * @param \ILIAS\UI\Component\Panel\Secondary\Secondary $secondary
-     * @return Sub
-     */
-    public function withSecondaryPanel(\ILIAS\UI\Component\Panel\Secondary\Secondary $secondary);
-
-    /**
-     * Gets the Secondary Panel to be displayed on the right of the Sub Panel
-     * @return \ILIAS\UI\Component\Panel\Secondary\Secondary | null
-     */
-    public function getSecondaryPanel();
+    public function getFurtherInformation();
 }

--- a/src/UI/Implementation/Component/Panel/Renderer.php
+++ b/src/UI/Implementation/Component/Panel/Renderer.php
@@ -108,18 +108,13 @@ class Renderer extends AbstractComponentRenderer
             $tpl->parseCurrentBlock();
         }
 
-        if ($component->getCard()) {
-            $tpl->setCurrentBlock("with_card");
+        if ($component->getFurtherInformation()) {
+            $tpl->setCurrentBlock("with_further_information");
             $tpl->setVariable("BODY", $this->getContentAsString($component, $default_renderer));
-            $tpl->setVariable("CARD", $default_renderer->render($component->getCard()));
-            $tpl->parseCurrentBlock();
-        } elseif ($component->getSecondaryPanel()) {
-            $tpl->setCurrentBlock("with_secondary_panel");
-            $tpl->setVariable("BODY", $this->getContentAsString($component, $default_renderer));
-            $tpl->setVariable("SECONDARY", $default_renderer->render($component->getSecondaryPanel()));
+            $tpl->setVariable("INFO", $default_renderer->render($component->getFurtherInformation()));
             $tpl->parseCurrentBlock();
         }else {
-            $tpl->setCurrentBlock("no_right_side");
+            $tpl->setCurrentBlock("no_further_information");
             $tpl->setVariable("BODY", $this->getContentAsString($component, $default_renderer));
             $tpl->parseCurrentBlock();
         }

--- a/src/UI/Implementation/Component/Panel/Renderer.php
+++ b/src/UI/Implementation/Component/Panel/Renderer.php
@@ -113,8 +113,13 @@ class Renderer extends AbstractComponentRenderer
             $tpl->setVariable("BODY", $this->getContentAsString($component, $default_renderer));
             $tpl->setVariable("CARD", $default_renderer->render($component->getCard()));
             $tpl->parseCurrentBlock();
-        } else {
-            $tpl->setCurrentBlock("no_card");
+        } elseif ($component->getSecondaryPanel()) {
+            $tpl->setCurrentBlock("with_secondary_panel");
+            $tpl->setVariable("BODY", $this->getContentAsString($component, $default_renderer));
+            $tpl->setVariable("SECONDARY", $default_renderer->render($component->getSecondaryPanel()));
+            $tpl->parseCurrentBlock();
+        }else {
+            $tpl->setCurrentBlock("no_right_side");
             $tpl->setVariable("BODY", $this->getContentAsString($component, $default_renderer));
             $tpl->parseCurrentBlock();
         }

--- a/src/UI/Implementation/Component/Panel/Sub.php
+++ b/src/UI/Implementation/Component/Panel/Sub.php
@@ -16,50 +16,26 @@ class Sub extends Panel implements C\Panel\Sub
     use ComponentHelper;
 
     /**
-     * Card to be displayed on the right of the Sub Panel
-     * @var C\Card\Card
+     * Component to be displayed on the right of the Sub Panel
+     * @var C\Card\Card | C\Panel\Secondary\Secondary
      */
-    private $card = null;
-
-    /**
-     * Secondary panel to be displayed on the right of the Sub Panel
-     * @var C\Panel\Secondary\Secondary
-     */
-    private $secondary = null;
+    private $component = null;
 
     /**
      * @inheritdoc
      */
-    public function withCard(C\Card\Card $card)
+    public function withFurtherInformation($component)
     {
         $clone = clone $this;
-        $clone->card = $card;
+        $clone->component = $component;
         return $clone;
     }
 
     /**
      * @inheritdoc
      */
-    public function getCard()
+    public function getFurtherInformation()
     {
-        return $this->card;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function withSecondaryPanel(C\Panel\Secondary\Secondary $secondary)
-    {
-        $clone = clone $this;
-        $clone->secondary = $secondary;
-        return $clone;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getSecondaryPanel()
-    {
-        return $this->secondary;
+        return $this->component;
     }
 }

--- a/src/UI/Implementation/Component/Panel/Sub.php
+++ b/src/UI/Implementation/Component/Panel/Sub.php
@@ -22,6 +22,12 @@ class Sub extends Panel implements C\Panel\Sub
     private $card = null;
 
     /**
+     * Secondary panel to be displayed on the right of the Sub Panel
+     * @var C\Panel\Secondary\Secondary
+     */
+    private $secondary = null;
+
+    /**
      * @inheritdoc
      */
     public function withCard(C\Card\Card $card)
@@ -37,5 +43,23 @@ class Sub extends Panel implements C\Panel\Sub
     public function getCard()
     {
         return $this->card;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function withSecondaryPanel(C\Panel\Secondary\Secondary $secondary)
+    {
+        $clone = clone $this;
+        $clone->secondary = $secondary;
+        return $clone;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSecondaryPanel()
+    {
+        return $this->secondary;
     }
 }

--- a/src/UI/examples/Panel/Report/base.php
+++ b/src/UI/examples/Panel/Report/base.php
@@ -9,7 +9,7 @@ function base()
     $renderer = $DIC->ui()->renderer();
 
     $sub1 = $f->panel()->sub("Sub Panel Title 1", $f->legacy("Some Content"))
-            ->withCard($f->card()->standard("Card Heading")->withSections(array($f->legacy("Card Content"))));
+            ->withFurtherInformation($f->card()->standard("Card Heading")->withSections(array($f->legacy("Card Content"))));
     $sub2 = $f->panel()->sub("Sub Panel Title 2", $f->legacy("Some Content"));
 
     $block = $f->panel()->report("Report Title", array($sub1,$sub2));

--- a/src/UI/examples/Panel/Sub/with_card.php
+++ b/src/UI/examples/Panel/Sub/with_card.php
@@ -11,7 +11,7 @@ function with_card()
     $block = $f->panel()->standard(
         "Panel Title",
         $f->panel()->sub("Sub Panel Title", $f->legacy("Some Content"))
-            ->withCard($f->card()->standard("Card Heading")->withSections(array($f->legacy("Card Content"))))
+            ->withFurtherInformation($f->card()->standard("Card Heading")->withSections(array($f->legacy("Card Content"))))
     );
 
     return $renderer->render($block);

--- a/src/UI/examples/Panel/Sub/with_secondary_panel.php
+++ b/src/UI/examples/Panel/Sub/with_secondary_panel.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+namespace ILIAS\UI\Examples\Panel\Sub;
 
 function with_secondary_panel()
 {

--- a/src/UI/examples/Panel/Sub/with_secondary_panel.php
+++ b/src/UI/examples/Panel/Sub/with_secondary_panel.php
@@ -1,0 +1,48 @@
+<?php
+
+function with_secondary_panel()
+{
+    global $DIC;
+    $f = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $actions = $f->dropdown()->standard(array(
+        $f->button()->shy("ILIAS", "https://www.ilias.de"),
+        $f->button()->shy("GitHub", "https://www.github.com")
+    ));
+
+    $list_item1 = $f->item()->standard("Item Title")
+                          ->withActions($actions)
+                          ->withProperties(array(
+                              "Origin" => "Course Title 1",
+                              "Last Update" => "24.11.2011",
+                              "Location" => "Room 123, Main Street 44, 3012 Bern"))
+                          ->withDescription("Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.");
+
+    $list_item2 = $f->item()->standard("Item 2 Title")
+                          ->withActions($actions)
+                          ->withDescription("Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.");
+
+    $list_item3 = $f->item()->standard("Item 3 Title")
+                          ->withActions($actions)
+                          ->withDescription("Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.");
+
+    $items = array(
+        $f->item()->group("Listing Subtitle 1", array(
+            $list_item1,
+            $list_item2
+        )),
+        $f->item()->group("Listing Subtitle 2", array(
+            $list_item3
+        )));
+
+    $panel = $f->panel()->secondary()->listing("Listing panel Title", $items)->withActions($actions);
+
+    $block = $f->panel()->standard(
+        "Panel Title",
+        $f->panel()->sub("Sub Panel Title", $f->legacy("Some Content"))
+          ->withSecondaryPanel($panel)
+    );
+
+    return $renderer->render($block);
+}

--- a/src/UI/examples/Panel/Sub/with_secondary_panel.php
+++ b/src/UI/examples/Panel/Sub/with_secondary_panel.php
@@ -43,7 +43,7 @@ function with_secondary_panel()
     $block = $f->panel()->standard(
         "Panel Title",
         $f->panel()->sub("Sub Panel Title", $f->legacy("Some Content"))
-          ->withSecondaryPanel($panel)
+          ->withFurtherInformation($panel)
     );
 
     return $renderer->render($block);

--- a/src/UI/templates/default/Panel/tpl.sub.html
+++ b/src/UI/templates/default/Panel/tpl.sub.html
@@ -11,6 +11,12 @@
 			<div class="col-sm-4">{CARD}</div>
 		</div>
 		<!-- END with_card -->
-		<!-- BEGIN no_card -->{BODY}<!-- END no_card -->
+		<!-- BEGIN with_secondary_panel -->
+		<div class="row">
+			<div class="col-sm-8">{BODY}</div>
+			<div class="col-sm-4">{SECONDARY}</div>
+		</div>
+		<!-- END with_secondary_panel -->
+		<!-- BEGIN no_right_side -->{BODY}<!-- END no_right_side -->
 	</div>
 </div>

--- a/src/UI/templates/default/Panel/tpl.sub.html
+++ b/src/UI/templates/default/Panel/tpl.sub.html
@@ -5,18 +5,12 @@
 	</div>
 	<!-- END title -->
 	<div class="panel-body">
-		<!-- BEGIN with_card -->
+		<!-- BEGIN with_further_information -->
 		<div class="row">
 			<div class="col-sm-8">{BODY}</div>
-			<div class="col-sm-4">{CARD}</div>
+			<div class="col-sm-4">{INFO}</div>
 		</div>
-		<!-- END with_card -->
-		<!-- BEGIN with_secondary_panel -->
-		<div class="row">
-			<div class="col-sm-8">{BODY}</div>
-			<div class="col-sm-4">{SECONDARY}</div>
-		</div>
-		<!-- END with_secondary_panel -->
-		<!-- BEGIN no_right_side -->{BODY}<!-- END no_right_side -->
+		<!-- END with_further_information -->
+		<!-- BEGIN no_further_information -->{BODY}<!-- END no_further_information -->
 	</div>
 </div>

--- a/tests/UI/Component/Panel/PanelTest.php
+++ b/tests/UI/Component/Panel/PanelTest.php
@@ -148,6 +148,20 @@ class PanelTest extends ILIAS_UI_TestBase
         $this->assertEquals($p->getCard(), $card);
     }
 
+    public function test_sub_with_secondary_panel()
+    {
+        $fp = $this->getPanelFactory();
+
+        $p = $fp->sub("Title", array(new ComponentDummy()));
+
+        $legacy = new I\Component\Legacy\Legacy("Legacy content", new SignalGenerator());
+        $secondary = new I\Component\Panel\Secondary\Legacy("Legacy panel title", $legacy);
+
+        $p = $p->withSecondaryPanel($secondary);
+
+        $this->assertEquals($p->getSecondaryPanel(), $secondary);
+    }
+
     public function test_report_get_title()
     {
         $f = $this->getPanelFactory();
@@ -239,6 +253,44 @@ EOT;
 EOT;
 
         $this->assertHTMLEquals($expected_html, $html);
+    }
+
+    public function test_render_sub_with_secondary_panel()
+    {
+        $fp = $this->getPanelFactory();
+        $r = $this->getDefaultRenderer();
+
+        $p = $fp->sub("Title", array());
+        $legacy = new I\Component\Legacy\Legacy("Legacy content", new SignalGenerator());
+        $secondary = new I\Component\Panel\Secondary\Legacy("Legacy panel title", $legacy);
+        $p = $p->withSecondaryPanel($secondary);
+        $html = $r->render($p);
+
+        $expected_html = <<<EOT
+<div class="panel panel-sub panel-flex">
+	<div class="panel-heading ilBlockHeader clearfix">
+		<h3>Title</h3>
+	</div>
+	<div class="panel-body">
+		<div class="row">
+			<div class="col-sm-8"></div>
+			<div class="col-sm-4">
+				<div class="panel panel-secondary panel-flex">
+					<div class="panel-heading ilHeader clearfix">
+					    <h4 class="ilHeader">Legacy panel title</h4>
+                    </div>
+                    <div class="panel-body">Legacy content</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+EOT;
+
+        $this->assertHTMLEquals(
+            $this->brutallyTrimHTML($expected_html),
+            $this->brutallyTrimHTML($html)
+        );
     }
 
     public function test_render_report()

--- a/tests/UI/Component/Panel/PanelTest.php
+++ b/tests/UI/Component/Panel/PanelTest.php
@@ -143,9 +143,9 @@ class PanelTest extends ILIAS_UI_TestBase
 
         $card = new I\Component\Card\Card("Card Title");
 
-        $p = $p->withCard($card);
+        $p = $p->withFurtherInformation($card);
 
-        $this->assertEquals($p->getCard(), $card);
+        $this->assertEquals($p->getFurtherInformation(), $card);
     }
 
     public function test_sub_with_secondary_panel()
@@ -157,9 +157,9 @@ class PanelTest extends ILIAS_UI_TestBase
         $legacy = new I\Component\Legacy\Legacy("Legacy content", new SignalGenerator());
         $secondary = new I\Component\Panel\Secondary\Legacy("Legacy panel title", $legacy);
 
-        $p = $p->withSecondaryPanel($secondary);
+        $p = $p->withFurtherInformation($secondary);
 
-        $this->assertEquals($p->getSecondaryPanel(), $secondary);
+        $this->assertEquals($p->getFurtherInformation(), $secondary);
     }
 
     public function test_report_get_title()
@@ -222,7 +222,7 @@ EOT;
 
         $p = $fp->sub("Title", array())->withActions($actions);
         $card = new I\Component\Card\Card("Card Title");
-        $p = $p->withCard($card);
+        $p = $p->withFurtherInformation($card);
         $html = $r->render($p);
 
         $expected_html = <<<EOT
@@ -263,7 +263,7 @@ EOT;
         $p = $fp->sub("Title", array());
         $legacy = new I\Component\Legacy\Legacy("Legacy content", new SignalGenerator());
         $secondary = new I\Component\Panel\Secondary\Legacy("Legacy panel title", $legacy);
-        $p = $p->withSecondaryPanel($secondary);
+        $p = $p->withFurtherInformation($secondary);
         $html = $r->render($p);
 
         $expected_html = <<<EOT
@@ -299,7 +299,7 @@ EOT;
         $r = $this->getDefaultRenderer();
         $sub = $fp->sub("Title", array());
         $card = new I\Component\Card\Card("Card Title");
-        $sub = $sub->withCard($card);
+        $sub = $sub->withFurtherInformation($card);
         $report = $fp->report("Title", $sub);
 
         $html = $r->render($report);


### PR DESCRIPTION
This PR adds the possibility to create Sub Panels not only with a Card on the right side, but also with a Secondary Panel.

- [x] There is one technical problem I could not found a solution for. With these changes, it would be possible to use withCard() and withSecondaryPanel() at the same time. This must not be possible. How can we prevent mixing two mutators in the UI Framework?

Related FR: https://docu.ilias.de/goto_docu_wiki_wpage_5999_1357.html