### PR TITLE
Less, Cleanup work from the CSS Squad, see: #30120

### DIFF
--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -18551,22 +18551,6 @@ span.ilProfileBadge .modal .img-responsive {
   cursor: default !important;
   text-decoration: none !important;
 }
-.ilLSOKioskMode #mainspacekeeper {
-  padding-top: 25px;
-}
-.ilLSOKioskMode .ilLeftNav {
-  top: 40px;
-  margin-left: 0px;
-  bottom: 5px !important;
-}
-.ilLSOKioskMode .ilLeftNav.disabled {
-  display: none;
-}
-.ilLSOKioskMode #il_right_col {
-  background-color: #e0e0e0;
-  margin-top: 20px;
-  padding: 5px;
-}
 .ilLSOKioskModeObjectHeader .il_HeaderInner {
   padding-bottom: 5px;
 }
@@ -18577,38 +18561,8 @@ span.ilProfileBadge .modal .img-responsive {
 .ilLSOKioskModeNavigation .navbar-form {
   line-height: 25px;
 }
-.ilLSOKioskTopBarControls {
-  float: left;
-  display: block;
-  line-height: 40px;
-}
-.ilLSOKioskTopBarControls .btn-link {
-  color: #f5f5f5;
-  font-size: 1em;
-  font-weight: 600;
-  margin-left: 15px;
-}
-.ilLSOKioskTopBarControls .btn-link:before {
-  content: "« ";
-}
-.ilLSOKioskTopBarControls .btn-link:hover {
-  text-decoration: underline;
-}
-.ilLSOKioskTopBarTitle {
-  text-align: center;
-}
-.ilLSOKioskTopBarTitle .ilTopTitle {
-  float: none;
-  padding: none;
-}
 .ilLSOKioskModeContent .panel-primary .panel-heading {
   display: none;
-}
-.ilLSOKioskModeCurriculum {
-  background-color: #f9f9f9;
-}
-.ilLSOKioskModeCurriculum .il-workflow-container {
-  padding: 5px;
 }
 .ilLearningHistoryShowMore {
   text-align: center;

--- a/templates/default/less/Modules/LearningSequence/delos.less
+++ b/templates/default/less/Modules/LearningSequence/delos.less
@@ -3,30 +3,10 @@
 .ilLSOLearnerView { /*ILIAS-GUI, "startpage" of LSO*/
 
 	.il-workflow-step-label,
-	.il-workflow-step-label .btn, {
+	.il-workflow-step-label .btn {
 		color: @text-color !important;
 		cursor: default !important;
 		text-decoration: none !important;
-	}
-}
-
-.ilLSOKioskMode {
-	#mainspacekeeper {
-		padding-top: 25px;
-	}
-
-	.ilLeftNav {
-		top: @navbar-height;
-		margin-left: 0px;
-		bottom: 5px !important;
-		&.disabled {
-			display: none;
-		}
-	}
-	#il_right_col {
-		background-color: @lso-dark-bg;
-		margin-top: 20px;
-		padding: 5px;
 	}
 }
 
@@ -43,42 +23,10 @@
 	}
 }
 
-.ilLSOKioskTopBarControls {
-	float: left;
-	display: block;
-	line-height: @navbar-height;
-	.btn-link {
-		color: @panel-footer-bg;
-		font-size: 1em;
-		font-weight: 600;
-		margin-left: 15px;
-		&:before {
-			content: "« ";
-		}
-		&:hover {
-			text-decoration: underline;
-		}
-	}
-}
-.ilLSOKioskTopBarTitle {
-	text-align: center;
-	.ilTopTitle {
-		float: none;
-		padding: none;
-	}
-}
 .ilLSOKioskModeContent {
 	.panel-primary {
 		.panel-heading {
 			display: none;
 		}
-	}
-}
-
-.ilLSOKioskModeCurriculum {
-	background-color: @il-secondary-container-bg;
-
-	.il-workflow-container {
-		padding: 5px;
 	}
 }


### PR DESCRIPTION
hi @nhaagen and @klees 

We perform some less/css cleanup work atm. In this process we observed, that some Less logic seems not to be in use anymore. See also: https://mantis.ilias.de/view.php?id=30120

- [ ] Can you look over the change and merge to trunk and 7 if really not used anymore?

Note: If possible also try to get a rid of the !important statements in the less. Further, note that we will remove the custom color assignment in here in the process of unifying the varying shades of grey used in ILIAS. This will be done in an upcoming PR of the CSS_Squad. If possible for 7, if not hopefully sometime soon ;)

Thx.
