### PR TITLE
Setup FileSystem: 30122 precondition respects update and install

### DIFF
--- a/Services/FileSystem/classes/Setup/class.ilFileSystemComponentDataDirectoryCreatedObjective.php
+++ b/Services/FileSystem/classes/Setup/class.ilFileSystemComponentDataDirectoryCreatedObjective.php
@@ -62,11 +62,17 @@ class ilFileSystemComponentDataDirectoryCreatedObjective extends Setup\Objective
 
     public function getPreconditions(Setup\Environment $environment) : array
     {
-        $ini = $environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI);
-        $data_dir = $ini->readVariable('clients', 'datadir');
+        // case if it is a fresh ILIAS installation
+        if ($environment->hasConfigFor("filesystem")) {
+            $config = $environment->getConfigFor("filesystem");
+            return [
+                new ilFileSystemDirectoriesCreatedObjective($config)
+            ];
+        }
 
+        // case if ILIAS is already installed
         return [
-            new ilFileSystemDirectoriesCreatedObjective(new ilFileSystemSetupConfig($data_dir))
+            new ilIniFilesLoadedObjective()
         ];
     }
 

--- a/Services/FileSystem/classes/Setup/class.ilFileSystemDirectoriesCreatedObjective.php
+++ b/Services/FileSystem/classes/Setup/class.ilFileSystemDirectoriesCreatedObjective.php
@@ -35,10 +35,8 @@ class ilFileSystemDirectoriesCreatedObjective implements Setup\Objective
 
     public function getPreconditions(Setup\Environment $environment) : array
     {
-        $ini = $environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI);
         $client_id = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_ID);
-
-        $data_dir = $ini->readVariable('clients', 'datadir');
+        $data_dir = $this->config->getDataDir();
         $web_dir = dirname(__DIR__, 4) . "/data";
 
         $client_data_dir = $data_dir . '/' . $client_id;


### PR DESCRIPTION
Hello @chfsx,

after the first PR for [#30122](https://mantis.ilias.de/view.php?id=30122) we now noticed that a fresh installation would run into an error 'Path is empty'. This depends on a missing environment resource at this point, that is used in a precondition of ilFileSystemComponentDataDirectoryCreatedObjective. So we have to distinguish between a fresh ILIAS installation and an
already existing ILIAS installation at this precondition.

In case of a fresh installation we have to ensure all file system directories are created. We use the config for file system from the
environment.

In case of an already installed ILIAS we can use the ini files.

If you have questions or need to discuss anything, feel free to contact us.

Best regards.