### PR TITLE
Setup 30245: --plugin option gets ist own install procedure

### DIFF
--- a/Services/Component/classes/Setup/class.ilComponentActivatePluginsObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentActivatePluginsObjective.php
@@ -95,7 +95,7 @@ class ilComponentActivatePluginsObjective implements Setup\Objective
         return $plugin['activation_possible'];
     }
 
-    protected function initEnvironment(Setup\Environment $environment) : ILIAS\DI\Container
+    protected function initEnvironment(Setup\Environment $environment) : ?ILIAS\DI\Container
     {
         $db = $environment->getResource(Setup\Environment::RESOURCE_DATABASE);
         $plugin_admin = $environment->getResource(Setup\Environment::RESOURCE_PLUGIN_ADMIN);

--- a/Services/Component/classes/Setup/class.ilComponentInstallPluginObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentInstallPluginObjective.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 use ILIAS\Setup;
 use ILIAS\DI;
+use ILIAS\Setup\Objective\ClientIdReadObjective;
 
 class ilComponentInstallPluginObjective implements Setup\Objective
 {
@@ -47,12 +48,10 @@ class ilComponentInstallPluginObjective implements Setup\Objective
      */
     public function getPreconditions(Setup\Environment $environment) : array
     {
-        $setup_config = $environment->getConfigFor('common');
-        $db_config = $environment->getConfigFor('database');
-
         return [
-            new \ilIniFilesPopulatedObjective($setup_config),
-            new \ilDatabasePopulatedObjective($db_config),
+            new ClientIdReadObjective(),
+            new \ilIniFilesPopulatedObjective(),
+            new \ilDatabaseUpdatedObjective(),
             new \ilComponentPluginAdminInitObjective()
         ];
     }

--- a/src/Setup/AgentCollection.php
+++ b/src/Setup/AgentCollection.php
@@ -96,7 +96,9 @@ class AgentCollection implements Agent
      */
     public function getInstallObjective(Config $config = null) : Objective
     {
-        $this->checkConfig($config);
+        if (!is_null($config)) {
+            $this->checkConfig($config);
+        }
 
         return new ObjectiveCollection(
             "Collected Install Objectives",

--- a/src/Setup/CLI/HasConfigReader.php
+++ b/src/Setup/CLI/HasConfigReader.php
@@ -25,6 +25,10 @@ trait HasConfigReader
             throw new \LogicException("\$this->config_reader not properly initialized.");
         }
 
+        if (!$agent->hasConfig()) {
+            return null;
+        }
+
         $config_file = $input->getArgument("config");
         $config_overwrites_raw = $input->getOption("config");
         $config_overwrites = [];
@@ -35,7 +39,9 @@ trait HasConfigReader
             }
             $config_overwrites[$vs[0]] = $vs[1];
         }
+
         $config_content = $this->config_reader->readConfigFile($config_file, $config_overwrites);
+
         $trafo = $agent->getArrayToConfigTransformation();
         return $trafo->transform($config_content);
     }

--- a/src/Setup/CLI/InstallCommand.php
+++ b/src/Setup/CLI/InstallCommand.php
@@ -46,7 +46,7 @@ class InstallCommand extends Command
     public function configure()
     {
         $this->setDescription("Creates a fresh ILIAS installation based on the config");
-        $this->addArgument("config", InputArgument::REQUIRED, "Configuration file for the installation");
+        $this->addArgument("config", InputArgument::OPTIONAL, "Configuration file for the installation");
         $this->addOption("config", null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, "Define fields in the configuration file that should be overwritten, e.g. \"a.b.c=foo\"", []);
         $this->addOption("yes", "y", InputOption::VALUE_NONE, "Confirm every message of the installation.");
         $this->configureCommandForPlugins();
@@ -58,6 +58,23 @@ class InstallCommand extends Command
         // the setup for the command line version of the setup. Do not use this.
         define("ILIAS_SETUP_IGNORE_DB_UPDATE_STEP_MESSAGES", true);
 
+        if ($input->hasOption('plugin') && $input->getOption('plugin') != "") {
+            list($objective, $environment, $io) = $this->preparePluginInstallation($input, $output);
+        } else {
+            list($objective, $environment, $io) = $this->prepareILIASInstallation($input, $output);
+        }
+
+        try {
+            $this->achieveObjective($objective, $environment, $io);
+            $io->success("Installation complete. Thanks and have fun!");
+        } catch (NoConfirmationException $e) {
+            $io->error("Aborting Installation, a necessary confirmation is missing:\n\n" . $e->getRequestedConfirmation());
+        }
+
+    }
+
+    protected function prepareILIASInstallation(InputInterface $input, OutputInterface $output) : array
+    {
         $io = new IOWrapper($input, $output);
         $io->printLicenseMessage();
         $io->title("Install ILIAS");
@@ -93,11 +110,40 @@ class InstallCommand extends Command
             $common_config->getClientId()
         );
 
-        try {
-            $this->achieveObjective($objective, $environment, $io);
-            $io->success("Installation complete. Thanks and have fun!");
-        } catch (NoConfirmationException $e) {
-            $io->error("Aborting Installation, a necessary confirmation is missing:\n\n" . $e->getRequestedConfirmation());
+        return [$objective, $environment, $io];
+    }
+
+    protected function preparePluginInstallation(InputInterface $input, OutputInterface $output) : array
+    {
+        $io = new IOWrapper($input, $output);
+        $io->printLicenseMessage();
+        $io->title("Install ILIAS Plugin");
+
+        $agent = $this->getRelevantAgent($input);
+
+        $config = $this->readAgentConfig($agent, $input);
+
+        $objective = new ObjectiveCollection(
+            "Install and Update ILIAS Plugin",
+            false,
+            $agent->getInstallObjective($config),
+            $agent->getUpdateObjective($config)
+        );
+        if (count($this->preconditions) > 0) {
+            $objective = new ObjectiveWithPreconditions(
+                $objective,
+                ...$this->preconditions
+            );
         }
+
+        $environment = new ArrayEnvironment([
+            Environment::RESOURCE_ADMIN_INTERACTION => $io
+        ]);
+
+        if (!is_null($config)) {
+            $environment = $this->addAgentConfigsToEnvironment($agent, $config, $environment);
+        }
+
+       return [$objective, $environment, $io];
     }
 }

--- a/src/Setup/ImplementationOfAgentFinder.php
+++ b/src/Setup/ImplementationOfAgentFinder.php
@@ -142,8 +142,7 @@ class ImplementationOfAgentFinder implements AgentFinder
         ));
 
         if (count($agent_classes) === 0) {
-            return new class($name) extends \ilPluginDefaultAgent {
-            };
+            return new class($name) extends \ilPluginDefaultAgent {};
         }
 
         $agents = [];

--- a/src/Setup/Objective/ClientIdReadObjective.php
+++ b/src/Setup/Objective/ClientIdReadObjective.php
@@ -57,10 +57,6 @@ class ClientIdReadObjective implements Setup\Objective
      */
     public function achieve(Setup\Environment $environment) : Setup\Environment
     {
-        if ($environment->getResource(Setup\Environment::RESOURCE_CLIENT_ID) !== null) {
-            return $environment;
-        }
-
         $dir = $this->getDataDirectoryPath();
         $candidates = array_filter(
             $this->scanDirectory($dir),

--- a/tests/Setup/CLI/HasConfigReaderTest.php
+++ b/tests/Setup/CLI/HasConfigReaderTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/* Copyright (c) 2019 Daniel Weise <daniel.weise@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\Tests\Setup\CLI;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\InputInterface;
+use ILIAS\Setup\CLI\ConfigReader;
+use ILIAS\Setup\CLI\HasConfigReader;
+use ILIAS\Setup\Config;
+use ILIAS\Setup\Agent;
+
+class HasConfigReaderTest extends TestCase
+{
+    protected $has_config_reader;
+
+    public function setUp() : void
+    {
+        $this->config_reader = $this->createMock(ConfigReader::class);
+        $this->has_config_reader = new class($this->config_reader) {
+            use HasConfigReader;
+            public function __construct($cr)
+            {
+                $this->config_reader = $cr;
+            }
+
+            public function _readAgentConfig(Agent $agent, InputInterface $input) : ?Config
+            {
+                return $this->readAgentConfig($agent, $input);
+            }
+        };
+    }
+
+    public function testReadAgentConfigWithoutConfig()
+    {
+        $agent = $this->createMock(Agent::class);
+        $ii = $this->createMock(InputInterface::class);
+
+        $agent
+            ->method("hasConfig")
+            ->willReturn(false)
+        ;
+
+        $this->assertNull($this->has_config_reader->_readAgentConfig($agent, $ii));
+    }
+}

--- a/tests/Setup/CLI/UpdateCommandTest.php
+++ b/tests/Setup/CLI/UpdateCommandTest.php
@@ -53,6 +53,11 @@ class UpdateCommandTest extends TestCase
 
         $agent
             ->expects($this->once())
+            ->method("hasConfig")
+            ->willReturn(true);
+
+        $agent
+            ->expects($this->once())
             ->method("getArrayToConfigTransformation")
             ->with()
             ->willReturn($refinery->custom()->transformation(function ($v) use ($config_file_content, $config) {


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=30245

- getInstallObjective in AgentCollection now checks for is_null($config) before checkConfig
- readAgentConfig in HasConfigReader now returns null if agent has no config
- config is now an optional argument for install command, due to call --plugin without a config