### PR TITLE
0030107: No access to reservations-tab after chosing certain columns

### DIFF
--- a/Modules/BookingManager/classes/class.ilBookingReservationsTableGUI.php
+++ b/Modules/BookingManager/classes/class.ilBookingReservationsTableGUI.php
@@ -534,8 +534,14 @@ class ilBookingReservationsTableGUI extends ilTable2GUI
             if ($odf_ids) {
                 $parent = $this->getParentGroupCourse();
                 $parent_obj_id = ilObject::_lookupObjectId($parent['ref_id']);
+                $parent_obj_type = ilObject::_lookupType($parent_obj_id);
 
-                $user_ids = array_diff($user_ids, ilMemberAgreement::lookupAcceptedAgreements($parent_obj_id));
+                $confirmation_required = ($parent_obj_type == 'crs')
+                    ? ilPrivacySettings::_getInstance()->courseConfirmationRequired()
+                    : ilPrivacySettings::_getInstance()->groupConfirmationRequired();
+                if ($confirmation_required) {
+                    $user_ids = array_diff($user_ids, ilMemberAgreement::lookupAcceptedAgreements($parent_obj_id));
+                }
                 $odf_data = ilCourseUserData::_getValuesByObjId($parent_obj_id);
 
                 $usr_data = [];

--- a/Modules/BookingManager/classes/class.ilBookingReservationsTableGUI.php
+++ b/Modules/BookingManager/classes/class.ilBookingReservationsTableGUI.php
@@ -521,9 +521,7 @@ class ilBookingReservationsTableGUI extends ilTable2GUI
             $usr_data = [];
             foreach ($ud["set"] as $v) {
                 foreach ($user_columns as $c) {
-                    if (isset($usr_data[$v["usr_id"]])) {
-                        $usr_data[$v["usr_id"]][$c] = $v[$c];
-                    }
+                    $usr_data[$v["usr_id"]][$c] = $v[$c];
                 }
             }
             foreach ($data as $key => $v) {


### PR DESCRIPTION
This is a fix for https://mantis.ilias.de/view.php?id=30107 (sorry for the mind the misleading commit message)

Course/group defined user fields are removed from user query and added later with a query of course user data, similar to the way it is done in the list of course members.