### PR TITLE
Setup 30373: store default inst_id during installation

### DIFF
--- a/setup/classes/class.ilInstIdDefaultStoredObjective.php
+++ b/setup/classes/class.ilInstIdDefaultStoredObjective.php
@@ -1,0 +1,51 @@
+<?php
+
+/* Copyright (c) 2021 Daniel Weise <daniel.weise@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+use ILIAS\Setup;
+
+class ilInstIdDefaultStoredObjective extends ilSetupObjective
+{
+    public function getHash() : string
+    {
+        return hash("sha256", self::class);
+    }
+
+    public function getLabel() : string
+    {
+        return "Store default installation id.";
+    }
+
+    public function isNotable() : bool
+    {
+        return false;
+    }
+
+    public function getPreconditions(Setup\Environment $environment) : array
+    {
+        return [
+            new \ilSettingsFactoryExistsObjective()
+        ];
+    }
+
+    public function achieve(Setup\Environment $environment) : Setup\Environment
+    {
+        $factory = $environment->getResource(Setup\Environment::RESOURCE_SETTINGS_FACTORY);
+        $settings = $factory->settingsFor("common");
+
+        $settings->set("inst_id", "0");
+
+        return $environment;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isApplicable(Setup\Environment $environment) : bool
+    {
+        $factory = $environment->getResource(Setup\Environment::RESOURCE_SETTINGS_FACTORY);
+        $settings = $factory->settingsFor("common");
+
+        return !(bool) $settings->get("inst_id");
+    }
+}

--- a/setup/classes/class.ilSetupAgent.php
+++ b/setup/classes/class.ilSetupAgent.php
@@ -76,7 +76,12 @@ class ilSetupAgent implements Setup\Agent
                 new ilSetupConfigStoredObjective($config, true),
                 $config->getRegisterNIC()
                         ? new ilNICKeyRegisteredObjective($config)
-                        : new ilNICKeyStoredObjective($config)
+                        : new Setup\ObjectiveCollection(
+                            "",
+                            false,
+                            new ilNICKeyStoredObjective($config),
+                            new ilInstIdDefaultStoredObjective($config)
+                        )
             )
         );
     }


### PR DESCRIPTION
- 'update lucence index' fails if inst_id equals to '', so set inst_id
  to '0'

https://mantis.ilias.de/view.php?id=30373