### PR TITLE
Refinery: Fix unit tests and productive code for PHP 8

### DIFF
--- a/src/Refinery/KindlyTo/Transformation/NullTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/NullTransformation.php
@@ -26,7 +26,7 @@ class NullTransformation implements Transformation
             return null;
         }
         throw new ConstraintViolationException(
-            sprintf('The value "%s" could not be transformed into null', $from),
+            sprintf('The value "%s" could not be transformed into null', var_export($from, true)),
             'not_null',
             $from
         );

--- a/src/Refinery/ProblemBuilder.php
+++ b/src/Refinery/ProblemBuilder.php
@@ -58,8 +58,7 @@ trait ProblemBuilder
                 $args[0] = $error;
                 for ($i = 0; $i < count($args); $i++) {
                     $v = $args[$i];
-                    if ((is_array($v) || is_object($v) || is_null($v))
-                    && !method_exists($v, "__toString")) {
+                    if ((is_array($v) || (is_object($v) && !method_exists($v, "__toString")) || is_null($v))) {
                         if (is_array($v)) {
                             $args[$i] = "array";
                         } elseif (is_null($v)) {


### PR DESCRIPTION
This PR fixes the `Refinery` tests for PHP 8

The failing tests are part of the legacy T&A suite, not part of the refinery. There is `random` test which ramdomly fails in this PR.