### PR TITLE
Init/ErrorReporting: Use -1 in DEVMODE if PHP 8 or SHOWNOTICES = true

### DIFF
--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1063,12 +1063,8 @@ class ilInitialisation
      */
     protected static function handleDevMode()
     {
-        if (defined(SHOWNOTICES) && SHOWNOTICES) {
-            // no further differentiating of php version regarding to 5.4 neccessary
-            // when the error reporting is set to E_ALL anyway
-
-            // add notices to error reporting
-            error_reporting(E_ALL);
+        if ((defined(SHOWNOTICES) && SHOWNOTICES) || version_compare(PHP_VERSION, '8.0', '>=')) {
+            error_reporting(-1);
         }
 
         if (defined('DEBUGTOOLS') && DEBUGTOOLS) {


### PR DESCRIPTION
With this PR I suggest to set the error_reporting to -1 in DEVMODE when using PHP 8 or if SHOWNOTICES evaluates to true.

Reason: Because the PHP policy regarding notices and deprecations has changed in the last years, I highly recommend to report as much errors as possible.