### PR TITLE
LSO 29944: fix type 'extor' to 'extro'

### DIFF
--- a/Modules/LearningSequence/classes/Xml/class.ilLearningSequenceXMLParser.php
+++ b/Modules/LearningSequence/classes/Xml/class.ilLearningSequenceXMLParser.php
@@ -97,7 +97,7 @@ class ilLearningSequenceXMLParser extends ilSaxParser
             case "abstract_img":
                 $this->settings["abstract_img"] = trim($this->cdata);
                 break;
-            case "extor_img":
+            case "extro_img":
                 $this->settings["extro_img"] = trim($this->cdata);
                 break;
             case "abstract_img_data":

--- a/Modules/LearningSequence/classes/class.ilLearningSequenceImporter.php
+++ b/Modules/LearningSequence/classes/class.ilLearningSequenceImporter.php
@@ -58,7 +58,6 @@ class ilLearningSequenceImporter extends ilXmlImporter
             (int) $this->user->getId(),
             $roles->getDefaultAdminRole()
         );
-        return $new_obj;
     }
 
     protected function updateRefId(ilImportMapping $mapping)


### PR DESCRIPTION
- also remove return statement that returns an non existing object