### PR TITLE
UI/Tree: Rectify Aria-Labels and According Rules

### DIFF
--- a/src/UI/Component/Tree/Factory.php
+++ b/src/UI/Component/Tree/Factory.php
@@ -29,12 +29,6 @@ interface Factory
      *       Nodes MUST restrict themselves to a minimal presentation, i.e.
      *       they MUST solely display information supportive and relevant for
      *       the intended task.
-     *   accessibility:
-     *     1: Nodes with further subnodes MUST bear the "aria-expanded" attribute.
-     *     2: Nodes with further subnodes MUST bear the ARIA role "treeitem".
-     *     3: Nodes without further subnodes MUST bear the ARIA role "none".
-     *     4: A group of subnodes MUST bear the ARIA role "group".
-     *
      * ---
      * @return \ILIAS\UI\Component\Tree\Node\Factory
      */

--- a/src/UI/Factory.php
+++ b/src/UI/Factory.php
@@ -762,6 +762,16 @@ interface Factory
      *     2: >
      *       A Tree SHOULD NOT mix different kind of nodes, i.e.
      *       all nodes in the same Tree SHOULD be identical in structure.
+     *   accessibility:
+     *     1: All tree nodes are contained in or owned by an element with role "tree".
+     *     2: Each element serving as a tree node has role "treeitem".
+     *     3: Each root node is contained in the element with role "tree".
+     *     4: >
+     *       Each parent node contains an an element with role "group" that contains
+     *       the subnodes of that parent.
+     *     5: >
+     *       Each parent node uses "aria-expanded" (with values "true" or "false") to
+     *       indicate if it is expanded or not.
      *
      * ---
      * @return \ILIAS\UI\Component\Tree\Factory

--- a/src/UI/Implementation/Component/Tree/Node/Renderer.php
+++ b/src/UI/Implementation/Component/Tree/Node/Renderer.php
@@ -79,7 +79,6 @@ class Renderer extends AbstractComponentRenderer
 
         if (count($subnodes) > 0 || $async) {
             $tpl->touchBlock("expandable");
-            $tpl->setVariable("ARIA_ROLE", "treeitem");
             $tpl->setCurrentBlock("aria_expanded");
             if ($component->isExpanded()) {
                 $tpl->touchBlock("expanded");
@@ -88,8 +87,6 @@ class Renderer extends AbstractComponentRenderer
                 $tpl->setVariable("ARIA_EXPANDED", "false");
             }
             $tpl->parseCurrentBlock();
-        } else {
-            $tpl->setVariable("ARIA_ROLE", "none");
         }
 
         if (count($subnodes) > 0) {

--- a/src/UI/templates/default/Tree/tpl.node.html
+++ b/src/UI/templates/default/Tree/tpl.node.html
@@ -1,6 +1,6 @@
 <li id="{ID}"
 	 class="il-tree-node node-simple<!-- BEGIN expandable --> expandable<!-- END expandable --><!-- BEGIN expanded --> expanded<!-- END expanded --><!-- BEGIN highlighted --> highlighted<!-- END highlighted -->"
-	 role="{ARIA_ROLE}"
+	 role="treeitem"
 <!-- BEGIN aria_expanded --> aria-expanded="{ARIA_EXPANDED}"<!-- END aria_expanded -->
 <!-- BEGIN async_loading --> data-async_url="{ASYNCURL}" data-async_loaded="false"<!-- END async_loading -->
 >

--- a/tests/UI/Component/Tree/ExpandableTreeTest.php
+++ b/tests/UI/Component/Tree/ExpandableTreeTest.php
@@ -90,21 +90,21 @@ class ExpandableTreeTest extends ILIAS_UI_TestBase
 				<span class="node-line"><span class="node-label">1</span></span>
 
 				<ul role="group">
-					<li id="" class="il-tree-node node-simple" role="none">
+					<li id="" class="il-tree-node node-simple" role="treeitem">
 						<span class="node-line"><span class="node-label">1.1</span></span>
 					</li>
 					<li id="" class="il-tree-node node-simple expandable" role="treeitem" aria-expanded="false">
 						<span class="node-line"><span class="node-label">1.2</span></span>
 
 						<ul role="group">
-							<li id="" class="il-tree-node node-simple" role="none">
+							<li id="" class="il-tree-node node-simple" role="treeitem">
 								<span class="node-line"><span class="node-label">1.2.1</span></span>
 							</li>
 						</ul>
 					</li>
 				</ul>
 			</li>
-			<li id="" class="il-tree-node node-simple" role="none">
+			<li id="" class="il-tree-node node-simple" role="treeitem">
 				<span class="node-line"><span class="node-label">2</span></span>
 			</li>
 		</ul>

--- a/tests/UI/Component/Tree/Node/BylineNodeTest.php
+++ b/tests/UI/Component/Tree/Node/BylineNodeTest.php
@@ -50,7 +50,7 @@ class BylineNodeTest extends ILIAS_UI_TestBase
         $html = $r->render($node);
 
         $expected = <<<EOT
-			<li id="" class="il-tree-node node-simple" role="none">
+			<li id="" class="il-tree-node node-simple" role="treeitem">
 				<span class="node-line">
 					<span class="node-label">My Label</span>
 					<span class="node-byline">This is my byline</span>
@@ -72,7 +72,7 @@ EOT;
         $html = $r->render($node);
 
         $expected = <<<EOT
-			<li id="" class="il-tree-node node-simple" role="none">
+			<li id="" class="il-tree-node node-simple" role="treeitem">
 				<span class="node-line">
 					<span class="node-label">
 						<img class="icon small" src="./templates/default/images/icon_default.svg" alt=""/>

--- a/tests/UI/Component/Tree/Node/SimpleNodeTest.php
+++ b/tests/UI/Component/Tree/Node/SimpleNodeTest.php
@@ -112,7 +112,7 @@ class SimpleNodeTest extends ILIAS_UI_TestBase
         $html = $r->render($node);
 
         $expected = <<<EOT
-			<li id="" class="il-tree-node node-simple" role="none">
+			<li id="" class="il-tree-node node-simple" role="treeitem">
 				<span class="node-line">
 					<span class="node-label">simple</span>
 				</span>
@@ -159,7 +159,7 @@ EOT;
         $html = $r->render($node);
 
         $expected = <<<EOT
-			<li id="" class="il-tree-node node-simple" role="none">
+			<li id="" class="il-tree-node node-simple" role="treeitem">
 				<span class="node-line">
 					<span class="node-label">
 						<img class="icon small" src="./templates/default/images/icon_default.svg" alt=""/>


### PR DESCRIPTION
Hi everyone!

This is supposed to improve the accessibility of the UI-component `Tree`, as documented in [#29851](https://mantis.ilias.de/view.php?id=29851). Thanks Kristina from HSLU for looking into this and pointing out the fix. I also improved the accessibility-rules according to [the WAI aria practices](https://www.w3.org/TR/wai-aria-practices/#tree_roles_states_props).

Best regards!