### PR TITLE
[FIX] 0029727: Failed test: 1.1.1 Meta Bar bietet Alt-Texte für grafische Bedienelemente

### DIFF
--- a/Services/User/classes/class.ilUserAvatarResolver.php
+++ b/Services/User/classes/class.ilUserAvatarResolver.php
@@ -1,6 +1,7 @@
 <?php
 
 use ILIAS\UI\Component\Symbol\Avatar\Avatar;
+use ILIAS\UI\Factory;
 
 /**
  * Class ilUserAvatarResolver
@@ -48,6 +49,10 @@ class ilUserAvatarResolver
      * @var string
      */
     private $size = 'small';
+    /**
+     * @var Factory
+     */
+    protected $ui;
 
     /**
      *  constructor.
@@ -114,10 +119,10 @@ class ilUserAvatarResolver
     public function getAvatar() : Avatar
     {
         if ($this->useUploadedFile()) {
-            return $this->ui->symbol()->avatar()->picture($this->uploaded_file, $this->abbreviation);
-        } else {
-            return $this->ui->symbol()->avatar()->letter($this->abbreviation);
+            return $this->ui->symbol()->avatar()->picture($this->uploaded_file, $this->login);
         }
+
+        return $this->ui->symbol()->avatar()->letter($this->login);
     }
 
     public function getLegacyPictureURL() : string
@@ -125,7 +130,6 @@ class ilUserAvatarResolver
         global $DIC;
         if ($this->useUploadedFile()) {
             return $this->uploaded_file . '?t=' . rand(1, 99999);
-            ;
         }
         /** @var $avatar ilUserAvatarBase */
 

--- a/src/UI/templates/default/Symbol/tpl.avatar_picture.html
+++ b/src/UI/templates/default/Symbol/tpl.avatar_picture.html
@@ -1,3 +1,3 @@
 <div class="il-avatar il-avatar-picture il-avatar-size-large" aria-label="{ARIA_LABEL}">
-	<!-- BEGIN image --><img src="{CUSTOMIMAGE}"/><!-- END image -->
+	<!-- BEGIN image --><img src="{CUSTOMIMAGE}" alt="{ARIA_LABEL}"/><!-- END image -->
 </div>

--- a/tests/UI/Component/Symbol/Avatar/AvatarTest.php
+++ b/tests/UI/Component/Symbol/Avatar/AvatarTest.php
@@ -136,7 +136,7 @@ class AvatarTest extends ILIAS_UI_TestBase
         $str = '/path/to/picture.jpg';
         $letter = $f->picture($str, 'ro');
         $html = $this->normalizeHTML($r->render($letter));
-        $expected = '<div class="il-avatar il-avatar-picture il-avatar-size-large" aria-label="ro">	<img src="/path/to/picture.jpg"/></div>';
+        $expected = '<div class="il-avatar il-avatar-picture il-avatar-size-large" aria-label="ro">	<img src="/path/to/picture.jpg" alt="ro"/></div>';
         $this->assertEquals($expected, $html);
     }
 


### PR DESCRIPTION
See https://mantis.ilias.de/view.php?id=29727