### PR TITLE
add submit caption to standard form

### DIFF
--- a/src/UI/Component/Input/Container/Form/Standard.php
+++ b/src/UI/Component/Input/Container/Form/Standard.php
@@ -16,4 +16,14 @@ interface Standard extends Form
      * @return    string
      */
     public function getPostURL();
+
+    /**
+     * Sets the caption of the submit button of the form
+     */
+    public function withSubmitCaption(string $caption) : Standard;
+
+    /**
+     * Gets the submit caption of the form
+     */
+    public function getSubmitCaption() : ?string;
 }

--- a/src/UI/Implementation/Component/Input/Container/Form/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Container/Form/Renderer.php
@@ -38,7 +38,7 @@ class Renderer extends AbstractComponentRenderer
         }
 
         $f = $this->getUIFactory();
-        $submit_button = $f->button()->standard($this->txt("save"), "");
+        $submit_button = $f->button()->standard($component->getSubmitCaption() ?? $this->txt("save"), "");
 
         $tpl->setVariable("BUTTONS_TOP", $default_renderer->render($submit_button));
         $tpl->setVariable("BUTTONS_BOTTOM", $default_renderer->render($submit_button));

--- a/src/UI/Implementation/Component/Input/Container/Form/Standard.php
+++ b/src/UI/Implementation/Component/Input/Container/Form/Standard.php
@@ -43,7 +43,7 @@ class Standard extends Form implements C\Input\Container\Form\Standard
     /**
      * @inheritDoc
      */
-    public function withSubmitCaption(string $caption) : Standard
+    public function withSubmitCaption(string $caption) : C\Input\Container\Form\Standard
     {
         $clone = clone $this;
         $clone->submit_caption = $caption;

--- a/src/UI/Implementation/Component/Input/Container/Form/Standard.php
+++ b/src/UI/Implementation/Component/Input/Container/Form/Standard.php
@@ -14,6 +14,11 @@ class Standard extends Form implements C\Input\Container\Form\Standard
 {
 
     /**
+     * @var String
+     */
+    protected $submit_caption;
+
+    /**
      * @var string
      */
     protected $post_url;
@@ -33,5 +38,24 @@ class Standard extends Form implements C\Input\Container\Form\Standard
     public function getPostURL()
     {
         return $this->post_url;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withSubmitCaption(string $caption) : Standard
+    {
+        $clone = clone $this;
+        $clone->submit_caption = $caption;
+
+        return $clone;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSubmitCaption() : ?string
+    {
+        return $this->submit_caption;
     }
 }

--- a/src/UI/Implementation/Component/Input/Container/Form/Standard.php
+++ b/src/UI/Implementation/Component/Input/Container/Form/Standard.php
@@ -14,7 +14,7 @@ class Standard extends Form implements C\Input\Container\Form\Standard
 {
 
     /**
-     * @var String
+     * @var ?string
      */
     protected $submit_caption;
 

--- a/tests/UI/Component/Input/Container/Form/StandardFormTest.php
+++ b/tests/UI/Component/Input/Container/Form/StandardFormTest.php
@@ -8,6 +8,7 @@ require_once(__DIR__ . "/FormTest.php");
 
 use ILIAS\UI\Implementation\Component\SignalGenerator;
 use \ILIAS\Data;
+use function PHPUnit\Framework\assertNull;
 
 class WithButtonNoUIFactory extends NoUIFactory
 {
@@ -104,7 +105,24 @@ class StandardFormTest extends ILIAS_UI_TestBase
         $this->assertHTMLEquals($expected, $html);
     }
 
-    public function test_submit_caption()
+    public function test_submit_caption() {
+        $f = $this->buildFactory();
+        $if = $this->buildInputFactory();
+
+        $url = "MY_URL";
+        $form = $f->standard($url, [
+            $if->text("label", "byline"),
+        ]);
+
+        $this->assertNull($form->getSubmitCaption());
+
+        $caption = 'Caption';
+        $form = $form->withSubmitCaption($caption);
+
+        $this->assertEquals($caption, $form->getSubmitCaption());
+    }
+
+    public function test_submit_caption_render()
     {
         $f = $this->buildFactory();
         $if = $this->buildInputFactory();

--- a/tests/UI/Component/Input/Container/Form/StandardFormTest.php
+++ b/tests/UI/Component/Input/Container/Form/StandardFormTest.php
@@ -104,6 +104,39 @@ class StandardFormTest extends ILIAS_UI_TestBase
         $this->assertHTMLEquals($expected, $html);
     }
 
+    public function test_submit_caption()
+    {
+        $f = $this->buildFactory();
+        $if = $this->buildInputFactory();
+
+        $url = "MY_URL";
+        $form = $f->standard($url, [
+            $if->text("label", "byline"),
+        ])->withSubmitCaption('create');
+
+        $r = $this->getDefaultRenderer();
+        $html = $this->brutallyTrimHTML($r->render($form));
+
+        $expected = $this->brutallyTrimHTML('
+<form role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" action="MY_URL" method="post" novalidate="novalidate">
+   <div class="il-standard-form-header clearfix">
+      <div class="il-standard-form-cmd"><button class="btn btn-default" data-action="">create</button></div>
+   </div>
+   <div class="form-group row">
+      <label for="id_1" class="control-label col-sm-3">label</label>
+      <div class="col-sm-9">
+         <input id="id_1" type="text" name="form_input_1" class="form-control form-control-sm"/>
+         <div class="help-block">byline</div>
+      </div>
+   </div>
+   <div class="il-standard-form-footer clearfix">
+      <div class="il-standard-form-cmd"><button class="btn btn-default" data-action="">create</button></div>
+   </div>
+</form>
+        ');
+        $this->assertHTMLEquals($expected, $html);
+    }
+
     public function test_render_no_url()
     {
         $f = $this->buildFactory();


### PR DESCRIPTION
Adding the option to set a custom caption for the submit button in a KitchenSink UI Standard form. I had a Form that Creates something new and 'Create' was much better fitting than save, and i think there is possibility for much diversity in forms that should be supportet