### PR TITLE
Legacy Forms, UI Components Forms: Fix of #28696

### DIFF
--- a/Services/Form/templates/default/tpl.property_form.html
+++ b/Services/Form/templates/default/tpl.property_form.html
@@ -35,6 +35,9 @@
 	<label {FOR_ID} class="col-sm-3 control-label {PROPERTY_CLASS}">{PROPERTY_TITLE}<!-- BEGIN sub_hid_title --> <span class="ilAccHeadingHidden">{SPHID_TITLE}</span><!-- END sub_hid_title --><!-- BEGIN sub_required --> <span class="asterisk">*</span><!-- END sub_required --></label>
 	<div class="col-sm-9 {PROPERTY_CLASS}">
 <!-- END sub_prop_start -->
+<!-- BEGIN alert -->
+		<div class="help-block alert alert-danger" role="alert">{TXT_ALERT}</div>
+<!-- END alert -->
 <!-- BEGIN cssrect -->
 		<label for="{ID}[top]">{TEXT_TOP}</label>
 		<input type="text" size="{SIZE}" id="{ID}[top]" name="{POST_VAR}[top]" <!-- BEGIN cssrect_value_top -->value="{CSSRECT_VALUE}" <!-- END cssrect_value_top -->{DISABLED} />
@@ -81,9 +84,6 @@
 <!-- BEGIN description -->
 		<div class="help-block">{PROPERTY_DESCRIPTION}</div>
 <!-- END description -->
-<!-- BEGIN alert -->
-		<div class="help-block alert alert-danger" role="alert"><img src="{IMG_ALERT}" alt="{ALT_ALERT}" /> {TXT_ALERT}</div>
-<!-- END alert -->
 <!-- BEGIN sub_form -->
 		<div class="ilSubForm" id="subform_{SFID}">{PROP_SUB_FORM}</div>
 		<!-- BEGIN sub_form_hide --><script>

--- a/src/UI/templates/default/Input/input.less
+++ b/src/UI/templates/default/Input/input.less
@@ -68,7 +68,29 @@
 	background-color: @il-main-dark-bg;
 	border: 1px solid lighten(@il-neutral-light-color,20%);
 	border-radius: 0;
+}
+
+.form-horizontal .help-block {
+  color: @il-standard-form-color;
+  font-size: @il-standard-form-byline-font-size;
+
+  margin: 2px 0 4px;
+  padding: 0;
+
+  clear: both;
+  &:last-child {
+    margin: 2px 0 10px;
   }
+
+  &.alert-danger {
+    margin: @padding-small-vertical 0 0;
+    padding: 0 @padding-small-vertical 0 @padding-small-vertical;
+
+    color: @alert-danger-text;
+    background-color: @alert-danger-bg;
+    border-color: @alert-danger-border;
+  }
+}
 
 //== Specific Inputs
 //

--- a/src/UI/templates/default/Input/tpl.context_form.html
+++ b/src/UI/templates/default/Input/tpl.context_form.html
@@ -1,11 +1,9 @@
 <div class="form-group row">
 	<label for="{ID}" class="control-label col-sm-3">{LABEL}<!-- BEGIN required --><span class="asterisk">*</span><!-- END required --></label>
 	<div class="col-sm-9">
+		<!-- BEGIN error --><div class="help-block alert alert-danger" role="alert">{ERROR}</div><!-- END error -->
 		{INPUT}
 		<!-- BEGIN byline --><div class="help-block">{BYLINE}</div><!-- END byline -->
-		<!-- BEGIN error --><div class="help-block alert alert-danger" role="alert">
-			<img border="0" src="./templates/default/images/icon_alert.svg" alt="alert" />
-			{ERROR}
-		</div><!-- END error -->{DEPENDANT_GROUP}
+		{DEPENDANT_GROUP}
 	</div>
 </div>

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -8097,6 +8097,23 @@ ul.dropdown-menu > li > .btn:focus {
   border: 1px solid #a8a8a8;
   border-radius: 0;
 }
+.form-horizontal .help-block {
+  color: #434343;
+  font-size: 85%;
+  margin: 2px 0 4px;
+  padding: 0;
+  clear: both;
+}
+.form-horizontal .help-block:last-child {
+  margin: 2px 0 10px;
+}
+.form-horizontal .help-block.alert-danger {
+  margin: 3px 0 0;
+  padding: 0 3px 0 3px;
+  color: #a94442;
+  background-color: #f2dede;
+  border-color: #ebccd1;
+}
 .il-input-tag {
   height: auto;
   min-height: 1.42857143;
@@ -12889,9 +12906,6 @@ select.form-control {
   padding-top: 0;
   line-height: normal;
 }
-.form-horizontal .help-block {
-  line-height: normal;
-}
 .form-horizontal div.radio label.radio-inline {
   line-height: 25px;
 }
@@ -12919,16 +12933,6 @@ select.form-control {
 }
 label {
   font-weight: normal;
-}
-.form-horizontal .help-block {
-  color: #434343;
-  margin: 2px 0 4px;
-  padding: 0;
-  font-size: 85%;
-  clear: both;
-}
-.form-horizontal .help-block:last-child {
-  margin: 2px 0 10px;
 }
 td.form-inline > div.form-group {
   display: block;

--- a/templates/default/less/Services/Form/delos.less
+++ b/templates/default/less/Services/Form/delos.less
@@ -84,9 +84,6 @@ select.form-control {
 		padding-top: 0;
 		line-height: normal;
 	}
-	.help-block {
-		line-height: normal;
-	}
 	div.radio label.radio-inline {
 		line-height: @input-height-base;
 	}
@@ -113,17 +110,6 @@ select.form-control {
 
 label {
 	font-weight: normal;
-}
-
-.form-horizontal .help-block {
-	color: @il-standard-form-color;
-	margin: 2px 0 4px;
-	padding: 0;
-	font-size: @il-standard-form-byline-font-size;
-	clear: both;
-	&:last-child {
-		margin: 2px 0 10px;
-	}
 }
 
 td.form-inline > div.form-group {

--- a/tests/UI/Component/Input/Field/CheckboxInputTest.php
+++ b/tests/UI/Component/Input/Field/CheckboxInputTest.php
@@ -82,9 +82,9 @@ class CheckboxInputTest extends ILIAS_UI_TestBase
         <div class="form-group row">
            <label for="id_1" class="control-label col-sm-3">label</label>
            <div class="col-sm-9">
+              <div class="help-block alert alert-danger" role="alert">an_error</div>
               <input type="checkbox" id="id_1" value="checked" name="name_0" class="form-control form-control-sm"/>
               <div class="help-block">byline</div>
-              <div class="help-block alert alert-danger" role="alert"><img border="0" src="./templates/default/images/icon_alert.svg" alt="alert"/>an_error</div>
            </div>
         </div>
         ');

--- a/tests/UI/Component/Input/Field/FileInputTest.php
+++ b/tests/UI/Component/Input/Field/FileInputTest.php
@@ -164,6 +164,7 @@ class FileInputTest extends ILIAS_UI_TestBase
         <div class="form-group row">
             <label for="id_1" class="control-label col-sm-3">label</label>
             <div class="col-sm-9">
+                <div class="help-block alert alert-danger" role="alert">an_error</div>
                 <div class="il-input-file" id="id_1">
                     <div class="il-input-file-dropzone"><button class="btn btn-link" data-action="#" id="id_2">select_files_from_computer</button></div>
                     <div class="il-input-file-filelist">
@@ -186,7 +187,6 @@ class FileInputTest extends ILIAS_UI_TestBase
                     <input class="input-template" type="hidden" name="name_0[]" value="" data-file-id="" />
                 </div>
                 <div class="help-block">byline</div>
-                <div class="help-block alert alert-danger" role="alert"><img border="0" src="./templates/default/images/icon_alert.svg" alt="alert" />an_error</div>
             </div>
         </div>
         ');

--- a/tests/UI/Component/Input/Field/NumericInputTest.php
+++ b/tests/UI/Component/Input/Field/NumericInputTest.php
@@ -52,11 +52,18 @@ class NumericInputTest extends ILIAS_UI_TestBase
         $numeric = $f->numeric($label, $byline)->withNameFrom($this->name_source);
 
         $r = $this->getDefaultRenderer();
-        $html = $this->normalizeHTML($r->render($numeric));
+        $html = $this->brutallyTrimHTML($r->render($numeric));
 
-        $expected = "<div class=\"form-group row\">" . "	<label for=\"id_1\" class=\"control-label col-sm-3\">$label</label>"
-                    . "	<div class=\"col-sm-9\">" . "		<input id=\"id_1\" type=\"number\" name=\"$name\" class=\"form-control form-control-sm\" />"
-                    . "		<div class=\"help-block\">$byline</div>" . "		" . "	</div>" . "</div>";
+        $expected = $this->brutallyTrimHTML('
+<div class="form-group row">
+   <label for="id_1" class="control-label col-sm-3">label</label>
+   <div class="col-sm-9">
+      <input id="id_1" type="number" name="name_0" class="form-control form-control-sm" />
+      <div class="help-block">byline</div>
+   </div>
+</div>
+');
+        $this->brutallyTrimHTML($expected, $html);
         $this->assertEquals($expected, $html);
     }
 
@@ -71,13 +78,17 @@ class NumericInputTest extends ILIAS_UI_TestBase
         $numeric = $f->numeric($label, $byline)->withNameFrom($this->name_source)->withError($error);
 
         $r = $this->getDefaultRenderer();
-        $html = $this->normalizeHTML($r->render($numeric));
+        $html = $this->brutallyTrimHTML($r->render($numeric));
 
-        $expected = "<div class=\"form-group row\">" . "	<label for=\"id_1\" class=\"control-label col-sm-3\">$label</label>"
-                    . "	<div class=\"col-sm-9\">" . "		<input id=\"id_1\" type=\"number\" name=\"$name\" class=\"form-control form-control-sm\" />"
-                    . "		<div class=\"help-block\">$byline</div>" . "		<div class=\"help-block alert alert-danger\" role=\"alert\">"
-                    . "			<img border=\"0\" src=\"./templates/default/images/icon_alert.svg\" alt=\"alert\" />" . "			$error"
-                    . "		</div>" . "	</div>" . "</div>";
+        $expected = $this->brutallyTrimHTML('
+<div class="form-group row">
+   <label for="id_1" class="control-label col-sm-3">label</label>	
+   <div class="col-sm-9">
+      <div class="help-block alert alert-danger" role="alert">an_error</div>
+      <input id="id_1" type="number" name="name_0" class="form-control form-control-sm" />		
+      <div class="help-block">byline</div>
+   </div>
+</div>');
         $this->assertEquals($expected, $html);
     }
 
@@ -90,11 +101,14 @@ class NumericInputTest extends ILIAS_UI_TestBase
         $numeric = $f->numeric($label)->withNameFrom($this->name_source);
 
         $r = $this->getDefaultRenderer();
-        $html = $this->normalizeHTML($r->render($numeric));
+        $html = $this->brutallyTrimHTML($r->render($numeric));
 
-        $expected = "<div class=\"form-group row\">" . "	<label for=\"id_1\" class=\"control-label col-sm-3\">$label</label>"
-                    . "	<div class=\"col-sm-9\">" . "		<input id=\"id_1\" type=\"number\" name=\"$name\" class=\"form-control form-control-sm\" />"
-                    . "		" . "		" . "	</div>" . "</div>";
+        $expected = $this->brutallyTrimHTML('
+<div class="form-group row">
+   <label for="id_1" class="control-label col-sm-3">label</label>	
+   <div class="col-sm-9">		<input id="id_1" type="number" name="name_0" class="form-control form-control-sm" />					</div>
+</div>
+');
         $this->assertEquals($expected, $html);
     }
 
@@ -108,12 +122,14 @@ class NumericInputTest extends ILIAS_UI_TestBase
         $numeric = $f->numeric($label)->withValue($value)->withNameFrom($this->name_source);
 
         $r = $this->getDefaultRenderer();
-        $html = $this->normalizeHTML($r->render($numeric));
+        $html = $this->brutallyTrimHTML($r->render($numeric));
 
-        $expected = "<div class=\"form-group row\">" . "	<label for=\"id_1\" class=\"control-label col-sm-3\">$label</label>"
-                    . "	<div class=\"col-sm-9\">"
-                    . "		<input id=\"id_1\" type=\"number\" value=\"$value\" name=\"$name\" class=\"form-control form-control-sm\" />" . "		" . "		"
-                    . "	</div>" . "</div>";
+        $expected = $this->brutallyTrimHTML('
+<div class="form-group row">
+   <label for="id_1" class="control-label col-sm-3">label</label>	
+   <div class="col-sm-9">		<input id="id_1" type="number" value="10" name="name_0" class="form-control form-control-sm" />					</div>
+</div>
+');
         $this->assertEquals($expected, $html);
     }
 
@@ -125,11 +141,13 @@ class NumericInputTest extends ILIAS_UI_TestBase
         $numeric = $f->numeric($label)->withNameFrom($this->name_source)->withDisabled(true);
 
         $r = $this->getDefaultRenderer();
-        $html = $this->normalizeHTML($r->render($numeric));
+        $html = $this->brutallyTrimHTML($r->render($numeric));
 
-        $expected = "<div class=\"form-group row\">" . "	<label for=\"id_1\" class=\"control-label col-sm-3\">$label</label>"
-                    . "	<div class=\"col-sm-9\">" . "		<input id=\"id_1\" type=\"number\" name=\"$name\" disabled=\"disabled\" class=\"form-control form-control-sm\" />"
-                    . "		" . "		" . "	</div>" . "</div>";
+        $expected = $this->brutallyTrimHTML('
+<div class="form-group row">
+   <label for="id_1" class="control-label col-sm-3">label</label>	
+   <div class="col-sm-9">		<input id="id_1" type="number" name="name_0" disabled="disabled" class="form-control form-control-sm" />					</div>
+</div>');
         $this->assertEquals($expected, $html);
     }
 

--- a/tests/UI/Component/Input/Field/PasswordInputTest.php
+++ b/tests/UI/Component/Input/Field/PasswordInputTest.php
@@ -87,26 +87,17 @@ class PasswordInputTest extends ILIAS_UI_TestBase
         $pwd = $f->password($label, $byline)->withNameFrom($this->name_source)->withError($error);
 
         $r = $this->getDefaultRenderer();
-        $html = $this->normalizeHTML($r->render($pwd));
-        $expected = ""
-            . "<div class=\"form-group row\">"
-                . " <label for=\"id_1\" class=\"control-label col-sm-3\">$label</label>"
-                . " <div class=\"col-sm-9\">"
-                    . " <div class=\"il-input-password\" id=\"id_1\">"
-                        . " <input type=\"password\" name=\"$name\" class=\"form-control form-control-sm\" />"
-                    . " </div>"
-                    . " <div class=\"help-block\">$byline</div>"
-                    . " <div class=\"help-block alert alert-danger\" role=\"alert\">"
-                        . " <img border=\"0\" src=\"./templates/default/images/icon_alert.svg\" alt=\"alert\" />"
-                        . " $error"
-                    . " </div>"
-                . " </div>"
-            . "</div>";
+        $html = $this->brutallyTrimHTML($r->render($pwd));
+        $expected = $this->brutallyTrimHTML('
+<div class="form-group row">
+   <label for="id_1" class="control-label col-sm-3">label</label>
+   <div class="col-sm-9">
+      <div class="help-block alert alert-danger" role="alert">an_error</div>
+      <div class="il-input-password" id="id_1"><input type="password" name="name_0" class="form-control form-control-sm" /></div>
+      <div class="help-block">byline</div>
+   </div>
+</div>');
 
-        $html = preg_replace('!\s+!', ' ', $html);
-        $expected = preg_replace('!\s+!', ' ', $expected);
-        $html = explode(' ', $html); //so you can actually _see_ the difference...
-        $expected = explode(' ', $expected);
         $this->assertEquals($expected, $html);
     }
 

--- a/tests/UI/Component/Input/Field/TagInputTest.php
+++ b/tests/UI/Component/Input/Field/TagInputTest.php
@@ -99,9 +99,9 @@ class TagInputTest extends ILIAS_UI_TestBase
            <div class="form-group row">
             <label for="id_1" class="control-label col-sm-3">label</label>
             <div class="col-sm-9">
+                <div class="help-block alert alert-danger" role="alert">an_error</div>
                 <div id="container-id_1" class="form-control form-control-sm il-input-tag"><input type="text" id="id_1" value="" class="form-control form-control-sm"/> <input type="hidden" id="template-id_1" value="name_0[]"/></div>
                 <div class="help-block">byline</div>
-                <div class="help-block alert alert-danger" role="alert"><img border="0" src="./templates/default/images/icon_alert.svg" alt="alert" />an_error</div>
             </div>
         </div>     
         ');

--- a/tests/UI/Component/Input/Field/TextInputTest.php
+++ b/tests/UI/Component/Input/Field/TextInputTest.php
@@ -52,11 +52,17 @@ class TextInputTest extends ILIAS_UI_TestBase
         $text = $f->text($label, $byline)->withNameFrom($this->name_source);
 
         $r = $this->getDefaultRenderer();
-        $html = $this->normalizeHTML($r->render($text));
+        $html = $this->brutallyTrimHTML($r->render($text));
 
-        $expected = "<div class=\"form-group row\">" . "	<label for=\"id_1\" class=\"control-label col-sm-3\">$label</label>"
-                    . "	<div class=\"col-sm-9\">" . "		<input id=\"id_1\" type=\"text\" name=\"$name\" class=\"form-control form-control-sm\" />"
-                    . "		<div class=\"help-block\">$byline</div>" . "		" . "	</div>" . "</div>";
+        $expected = $this->brutallyTrimHTML('
+<div class="form-group row">
+   <label for="id_1" class="control-label col-sm-3">label</label>	
+   <div class="col-sm-9">
+      <input id="id_1" type="text" name="name_0" class="form-control form-control-sm" />		
+      <div class="help-block">byline</div>
+   </div>
+</div>
+');
         $this->assertEquals($expected, $html);
     }
 
@@ -71,13 +77,18 @@ class TextInputTest extends ILIAS_UI_TestBase
         $text = $f->text($label, $byline)->withNameFrom($this->name_source)->withError($error);
 
         $r = $this->getDefaultRenderer();
-        $html = $this->normalizeHTML($r->render($text));
+        $html = $this->brutallyTrimHTML($r->render($text));
 
-        $expected = "<div class=\"form-group row\">" . "	<label for=\"id_1\" class=\"control-label col-sm-3\">$label</label>"
-                    . "	<div class=\"col-sm-9\">" . "		<input id=\"id_1\" type=\"text\" name=\"$name\" class=\"form-control form-control-sm\" />"
-                    . "		<div class=\"help-block\">$byline</div>" . "		<div class=\"help-block alert alert-danger\" role=\"alert\">"
-                    . "			<img border=\"0\" src=\"./templates/default/images/icon_alert.svg\" alt=\"alert\" />" . "			$error"
-                    . "		</div>" . "	</div>" . "</div>";
+        $expected = $this->brutallyTrimHTML('
+<div class="form-group row">
+   <label for="id_1" class="control-label col-sm-3">label</label>
+   <div class="col-sm-9">
+      <div class="help-block alert alert-danger" role="alert">an_error</div>
+      <input id="id_1" type="text" name="name_0" class="form-control form-control-sm" />
+      <div class="help-block">byline</div>
+   </div>
+</div>
+');
         $this->assertEquals($expected, $html);
     }
 
@@ -90,11 +101,14 @@ class TextInputTest extends ILIAS_UI_TestBase
         $text = $f->text($label)->withNameFrom($this->name_source);
 
         $r = $this->getDefaultRenderer();
-        $html = $this->normalizeHTML($r->render($text));
+        $html = $this->brutallyTrimHTML($r->render($text));
 
-        $expected = "<div class=\"form-group row\">" . "	<label for=\"id_1\" class=\"control-label col-sm-3\">$label</label>"
-                    . "	<div class=\"col-sm-9\">" . "		<input id=\"id_1\" type=\"text\" name=\"$name\" class=\"form-control form-control-sm\" />" . "		"
-                    . "		" . "	</div>" . "</div>";
+        $expected = $this->brutallyTrimHTML('
+<div class="form-group row">
+   <label for="id_1" class="control-label col-sm-3">label</label>	
+   <div class="col-sm-9"><input id="id_1" type="text" name="name_0" class="form-control form-control-sm" /></div>
+</div>
+');
         $this->assertEquals($expected, $html);
     }
 
@@ -108,12 +122,14 @@ class TextInputTest extends ILIAS_UI_TestBase
         $text = $f->text($label)->withValue($value)->withNameFrom($this->name_source);
 
         $r = $this->getDefaultRenderer();
-        $html = $this->normalizeHTML($r->render($text));
+        $html = $this->brutallyTrimHTML($r->render($text));
 
-        $expected = "<div class=\"form-group row\">" . "	<label for=\"id_1\" class=\"control-label col-sm-3\">$label</label>"
-                    . "	<div class=\"col-sm-9\">"
-                    . "		<input id=\"id_1\" type=\"text\" value=\"$value\" name=\"$name\" class=\"form-control form-control-sm\" />" . "		" . "		"
-                    . "	</div>" . "</div>";
+        $expected = $this->brutallyTrimHTML('
+<div class="form-group row">
+   <label for="id_1" class="control-label col-sm-3">label</label>	
+   <div class="col-sm-9"><input id="id_1" type="text" value="value" name="name_0" class="form-control form-control-sm" /></div>
+</div>
+');
         $this->assertEquals($expected, $html);
     }
 
@@ -126,12 +142,14 @@ class TextInputTest extends ILIAS_UI_TestBase
         $text = $f->text($label)->withNameFrom($this->name_source)->withRequired(true);
 
         $r = $this->getDefaultRenderer();
-        $html = $this->normalizeHTML($r->render($text));
+        $html = $this->brutallyTrimHTML($r->render($text));
 
-        $expected = "<div class=\"form-group row\">" . "	<label for=\"id_1\" class=\"control-label col-sm-3\">" . "$label"
-                    . "<span class=\"asterisk\">*</span>" . "</label>" . "	<div class=\"col-sm-9\">"
-                    . "		<input id=\"id_1\" type=\"text\" name=\"$name\" class=\"form-control form-control-sm\" />" . "		" . "		" . "	</div>"
-                    . "</div>";
+        $expected = $this->brutallyTrimHTML('
+<div class="form-group row">
+   <label for="id_1" class="control-label col-sm-3">label<span class="asterisk">*</span></label>	
+   <div class="col-sm-9"><input id="id_1" type="text" name="name_0" class="form-control form-control-sm" /></div>
+</div>
+');
         $this->assertEquals($expected, $html);
     }
 
@@ -143,12 +161,14 @@ class TextInputTest extends ILIAS_UI_TestBase
         $text = $f->text($label)->withNameFrom($this->name_source)->withDisabled(true);
 
         $r = $this->getDefaultRenderer();
-        $html = $this->normalizeHTML($r->render($text));
+        $html = $this->brutallyTrimHTML($r->render($text));
 
-        $expected = "<div class=\"form-group row\">" . "	<label for=\"id_1\" class=\"control-label col-sm-3\">$label</label>"
-                    . "	<div class=\"col-sm-9\">" . "		<input id=\"id_1\" type=\"text\" name=\"$name\" disabled=\"disabled\" class=\"form-control form-control-sm\" />" . "		"
-                    . "		" . "	</div>" . "</div>";
-
+        $expected = $this->brutallyTrimHTML('
+<div class="form-group row">
+   <label for="id_1" class="control-label col-sm-3">label</label>	
+   <div class="col-sm-9"><input id="id_1" type="text" name="name_0" disabled="disabled" class="form-control form-control-sm" /></div>
+</div>
+');
         $this->assertEquals($expected, $html);
     }
 

--- a/tests/UI/Component/Input/Field/TextareaTest.php
+++ b/tests/UI/Component/Input/Field/TextareaTest.php
@@ -247,18 +247,18 @@ class TextareaTest extends ILIAS_UI_TestBase
         $error = "an_error";
         $textarea = $f->textarea($label, $byline)->withNameFrom($this->name_source)->withError($error);
 
-        $expected = "<div class=\"form-group row\">"
-            . "<label for=\"id_1\" class=\"control-label col-sm-3\">$label</label>"
-            . "<div class=\"col-sm-9\">"
-            . "<textarea id=\"id_1\" name=\"$name\" class=\"form-control form-control-sm\"></textarea>"
-            . "<div class=\"help-block\">$byline</div>"
-            . "<div class=\"help-block alert alert-danger\" role=\"alert\">"
-            . "<img border=\"0\" src=\"./templates/default/images/icon_alert.svg\" alt=\"alert\" />"
-            . "$error</div></div></div>";
+        $expected = $this->brutallyTrimHTML('
+<div class="form-group row">
+   <label for="id_1" class="control-label col-sm-3">label</label>
+   <div class="col-sm-9">
+      <div class="help-block alert alert-danger" role="alert">an_error</div>
+      <textarea id="id_1" name="name_0" class="form-control form-control-sm"></textarea>
+      <div class="help-block">This is just a byline Min: 5</div>
+   </div>
+</div>
+');
 
-        $html = $this->normalizeHTML($r->render($textarea));
-        $html = trim(preg_replace('/\t+/', '', $html));
-        $expected = trim(preg_replace('/\t+/', '', $expected));
+        $html = $this->brutallyTrimHTML($r->render($textarea));
         $this->assertEquals($expected, $html);
     }
 


### PR DESCRIPTION
Hi 

This is the proposed fix for: https://mantis.ilias.de/view.php?id=28696

Main change: Error message is now above input. 

In Legacy Forms:
![image](https://user-images.githubusercontent.com/1866896/112873671-3c05cb80-90c2-11eb-99c3-b8df04a3a527.png)



In UI Components:
![image](https://user-images.githubusercontent.com/1866896/112873650-34462700-90c2-11eb-9b75-dbafea16dbb4.png)


@akill, short review on the changes on the legacy forms would be highly appreciated.

Thx.