### PR TITLE
[FIX] 0029643: UI Modal: Change in Modal renderer breaks existing usa…

### DIFF
--- a/src/UI/Implementation/Component/Modal/Renderer.php
+++ b/src/UI/Implementation/Component/Modal/Renderer.php
@@ -117,8 +117,7 @@ class Renderer extends AbstractComponentRenderer
         $modal = $this->registerSignals($modal);
         $id = $this->bindJavaScript($modal);
         $tpl->setVariable('ID', $id);
-        $value = $modal->getFormAction();
-        $tpl->setVariable('FORM_ACTION', $value);
+        $tpl->setVariable('FORM_ACTION', $modal->getFormAction());
         $tpl->setVariable('TITLE', $modal->getTitle());
         $tpl->setVariable('MESSAGE', $modal->getMessage());
         if (count($modal->getAffectedItems())) {
@@ -135,7 +134,6 @@ class Renderer extends AbstractComponentRenderer
             }
         }
         $tpl->setVariable('ACTION_BUTTON_LABEL', $this->txt($modal->getActionButtonLabel()));
-        $tpl->setVariable('ACTION_BUTTON', $modal->getActionButtonLabel());
         $tpl->setVariable('CANCEL_BUTTON_LABEL', $this->txt($modal->getCancelButtonLabel()));
         return $tpl->get();
     }

--- a/src/UI/templates/default/Modal/tpl.interruptive.html
+++ b/src/UI/templates/default/Modal/tpl.interruptive.html
@@ -31,7 +31,7 @@
 					<!-- END with_items -->
 				</div>
 				<div class="modal-footer">
-					<input type="submit" class="btn btn-primary" value="{ACTION_BUTTON_LABEL}" name="cmd[{ACTION_BUTTON}]">
+					<input type="submit" class="btn btn-primary" value="{ACTION_BUTTON_LABEL}">
 					<a class="btn btn-default" data-dismiss="modal" aria-label="Close">{CANCEL_BUTTON_LABEL}</a>
 				</div>
 			</div>

--- a/tests/UI/Component/Modal/InterruptiveTest.php
+++ b/tests/UI/Component/Modal/InterruptiveTest.php
@@ -82,7 +82,7 @@ class InterruptiveTest extends ModalBase
 					<div class="alert alert-warning il-modal-interruptive-message" role="alert">Message</div>
 				</div>
 				<div class="modal-footer">
-					<input type="submit" class="btn btn-primary" value="delete" name="cmd[delete]">
+					<input type="submit" class="btn btn-primary" value="delete">
 					<a class="btn btn-default" data-dismiss="modal" aria-label="Close">cancel</a>
 				</div>
 			</div>


### PR DESCRIPTION
…ges of interruptive modals

@mjansenDatabay / @Amstutz 
This is basically a revert of the commit https://github.com/ILIAS-eLearning/ILIAS/commit/a63a4a07b68bf6e8d8c4c51942c97c96e9f2f26e which I made and which is quite nonsense...

The interruptive Modal can be used with the "fallback" command of ilCtrl.

see https://mantis.ilias.de/view.php?id=29643