### PR TITLE
CI: Fixed PHP-CS-Fixer and Special-Char-Checker, Improved speed of Tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,14 +11,14 @@ jobs:
         php: [7.3, 7.4]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, gd, json, readline, xsl
-          tools: composer:v2
+          tools: composer:v1
           coverage: none
 
       - name: Install dependencies

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,10 +3,12 @@ on: [pull_request]
 jobs:
   tests:
     runs-on: ubuntu-latest
+    outputs:
+      all: ${{ steps.changes.outputs.all }}
     strategy:
       fail-fast: false
       matrix:
-        php: [7.2, 7.3, 7.4]
+        php: [7.3, 7.4]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -16,7 +18,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, gd, json, readline, xsl
-          tools: composer:v1
+          tools: composer:v2
           coverage: none
 
       - name: Install dependencies
@@ -30,6 +32,10 @@ jobs:
 
       - name: PHP CS Fixer
         run: CI/PHP-CS-Fixer/run_check.sh
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
 
       - name: Special Char Checker
         run: CI/Special-Char-Checker/special-char-checker.sh
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,7 +11,7 @@ jobs:
         php: [7.3, 7.4]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v1
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.3, 7.4]
+        php: [7.2, 7.3, 7.4]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/CI/Import/Functions.sh
+++ b/CI/Import/Functions.sh
@@ -3,3 +3,9 @@
 function printLn() {
 	echo -e "$PRE $1"
 }
+
+function get_changed_files() {
+  URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files"
+  CHANGED_FILES=$(curl -s -X GET -G $URL | jq -r '.[] | .filename' | grep '.php')
+  echo ${CHANGED_FILES}
+}

--- a/CI/PHP-CS-Fixer/run_check.sh
+++ b/CI/PHP-CS-Fixer/run_check.sh
@@ -1,30 +1,16 @@
 #!/bin/bash
-source CI/Import/Functions.sh
-source CI/Import/Variables.sh
 
-if [[ -x "$PHP_CS_FIXER" ]]
-  then
-  	$PHP_CS_FIXER fix --config=./CI/PHP-CS-Fixer/code-format.php_cs --dry-run -vvv > "$PHP_CS_FIXER_RESULTS_PATH"
-	
-	PIPE_EXIT_CODE=`echo ${PIPESTATUS[0]}`
-	
-	printLn "Command exited with code: $PIPE_EXIT_CODE"
+URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files"
+CHANGED_FILES=$(curl -s -X GET -G $URL | jq -r '.[] | .filename' | grep '.php')
 
-	# We disabled reporting because we can't implement it right now
-	# Priority has the base function so that the tests work
-	#printLn "Cloning results repository, copy results file."
-	#if [ -d "$TRAVIS_RESULTS_DIRECTORY" ]; then
-	#	printLn "Starting to remove old temp directory"
-	#	rm -rf "$TRAVIS_RESULTS_DIRECTORY"
-	#fi
-
-	#cd tmp && git clone $CI_RESULTS_REPO
-
-	#printLn "Switching directory and run results handling."
-	#cp "$PHP_CS_FIXER_RESULTS_PATH" "$TRAVIS_RESULTS_DIRECTORY/data/"
-	#cd "$TRAVIS_RESULTS_DIRECTORY" && ./run.sh
-	
-else
-	printLn "No php-cs-fixer found, please install it with the following command:"
-	printLn "\tcomposer require friendsofphp/php-cs-fixer"
-fi
+for FILE in ${CHANGED_FILES}
+do
+	echo "Check file: ${FILE}"
+	RUNCSFIXER=$(libs/composer/vendor/bin/php-cs-fixer fix --using-cache=no --diff --config=./CI/PHP-CS-Fixer/code-format.php_cs ${FILE})
+	RESULT=$?
+	if [[ ${RESULT} -ne 0 ]]
+	then
+		exit ${RESULT}
+  fi
+done
+exit 0

--- a/CI/PHP-CS-Fixer/run_check.sh
+++ b/CI/PHP-CS-Fixer/run_check.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files"
-CHANGED_FILES=$(curl -s -X GET -G $URL | jq -r '.[] | .filename' | grep '.php')
+source CI/Import/Functions.sh
 
+CHANGED_FILES=$(get_changed_files)
 for FILE in ${CHANGED_FILES}
 do
 	echo "Check file: ${FILE}"

--- a/CI/Special-Char-Checker/special-char-checker.sh
+++ b/CI/Special-Char-Checker/special-char-checker.sh
@@ -12,13 +12,14 @@
 
 
 # get the files from this PR to the last head
-GITFILES=$(git --no-pager diff --name-only FETCH_HEAD $(git merge-base FETCH_HEAD ${TRAVIS_BRANCH}))
+URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files"
+CHANGED_FILES=$(curl -s -X GET -G $URL | jq -r '.[] | .filename' | grep '.php')
 
 echo "Scanning changed files for special chars ..."
 
 FILES=()
 COUNTER=0
-for PHPFILE in $GITFILES;
+for PHPFILE in $CHANGED_FILES;
 do
   FELONE="$(pwd)/$PHPFILE"
 

--- a/CI/Special-Char-Checker/special-char-checker.sh
+++ b/CI/Special-Char-Checker/special-char-checker.sh
@@ -10,10 +10,10 @@
 # which are usually used by old printers. Sometimes these hidden characters
 # like hidden spaces, tabs or newlines are added to the code accidentally.
 
+source CI/Import/Functions.sh
 
 # get the files from this PR to the last head
-URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files"
-CHANGED_FILES=$(curl -s -X GET -G $URL | jq -r '.[] | .filename' | grep '.php')
+CHANGED_FILES=$(get_changed_files)
 
 echo "Scanning changed files for special chars ..."
 


### PR DESCRIPTION
I once again improved our CI process. With this PR we are implementing and fixed several issues regarding our PHP-CS-Fixer and the Special-Char-Checker which both were broken in the first update. These changes were made:

1. The PHP-CS-Fixer and the Special-Char-Checker are only checking the PHP files which are changed within a pull request
2. The PHP-CS-Fixer now bailes if something is wrong and the checks fail with a certain message.
3. The Special-Char-Checker now works. Basically in the same way

This reduced the amount of time for a check by a lot. If this improvement is accepted for the branch release_6 I'll open a PR for release_7 and the trunk.