### PR TITLE
UIComponent/GlyphGUI: Fix ternary operator

### DIFF
--- a/Services/UIComponent/Glyph/classes/class.ilGlyphGUI.php
+++ b/Services/UIComponent/Glyph/classes/class.ilGlyphGUI.php
@@ -62,9 +62,9 @@ class ilGlyphGUI
         $html = "";
         $text = ($a_text == "")
             ? $lng->txt(self::$map[$a_glyph]["txt"])
-            : ($a_text == self::NO_TEXT)
+            : (($a_text == self::NO_TEXT)
                 ? ""
-                : $a_text;
+                : $a_text);
         switch ($a_glyph) {
             case self::CARET:
                 $html = '<span class="caret"></span>';


### PR DESCRIPTION
You don't need to cherry-pick this to ILIAS >= 6.x

Mantis Issue: https://mantis.ilias.de/view.php?id=30511