### PR TITLE
Standard Layout, Introduce Text Direction and Rendering Tests, see: #30532 and #29426

### DIFF
--- a/src/UI/Component/Layout/Page/Standard.php
+++ b/src/UI/Component/Layout/Page/Standard.php
@@ -17,6 +17,9 @@ use ILIAS\UI\Component\MainControls\Footer;
  */
 interface Standard extends Page, JavaScriptBindable
 {
+    //Possible Text Directions
+    public const LTR = 'ltr';
+    public const RTL = 'rtl';
 
     /**
      * @param MetaBar $meta_bar
@@ -112,4 +115,16 @@ interface Standard extends Page, JavaScriptBindable
 
 
     public function hasSystemInfos() : bool;
+
+    /**
+     * Set the direction of the text. This is used in CSS.
+     * Note that in the default skin, rtl is only partly supported.
+     */
+    public function withTextDirection(string $text_direction) : Standard;
+
+    /**
+     * Get the direction of the text. This is used in CSS.
+     * Note that in the default skin, rtl is only partly supported.
+     */
+    public function getTextDirection() : string;
 }

--- a/src/UI/Implementation/Component/Layout/Page/Renderer.php
+++ b/src/UI/Implementation/Component/Layout/Page/Renderer.php
@@ -67,6 +67,7 @@ class Renderer extends AbstractComponentRenderer
         $tpl->setVariable("SHORT_TITLE", $component->getShortTitle());
         $tpl->setVariable("VIEW_TITLE", $component->getViewTitle());
         $tpl->setVariable("LANGUAGE", $this->getLangKey());
+        $tpl->setVariable("TEXT_DIRECTION", $component->getTextDirection());
         $tpl->setVariable('CONTENT', $default_renderer->render($component->getContent()));
 
         if ($component->hasFooter()) {

--- a/src/UI/Implementation/Component/Layout/Page/Standard.php
+++ b/src/UI/Implementation/Component/Layout/Page/Standard.php
@@ -70,7 +70,14 @@ class Standard implements Page\Standard
      * @var    bool
      */
     private $ui_demo = false;
+    /**
+     * @var array
+     */
     protected $system_infos = [];
+    /**
+     * @var string
+     */
+    protected $text_direction = "ltr";
 
     /**
      * Standard constructor.
@@ -339,5 +346,24 @@ class Standard implements Page\Standard
     public function hasSystemInfos() : bool
     {
         return count($this->system_infos) > 0;
+    }
+
+
+    public function withTextDirection(string $text_direction) : \ILIAS\UI\Component\Layout\Page\Standard
+    {
+        $this->checkArgIsElement(
+            "Text Direction",
+            $text_direction,
+            [self::LTR,self::RTL],
+            implode('/', [self::LTR,self::RTL])
+        );
+        $clone = clone $this;
+        $clone->text_direction = $text_direction;
+        return $clone;
+    }
+
+    public function getTextDirection() : string
+    {
+        return $this->text_direction;
     }
 }

--- a/src/UI/templates/default/Layout/tpl.standardpage.html
+++ b/src/UI/templates/default/Layout/tpl.standardpage.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{LANGUAGE}" dir="ltr">
+<html lang="{LANGUAGE}" dir="{TEXT_DIRECTION}">
 <head>
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/tests/UI/Component/Input/Field/FileInputTest.php
+++ b/tests/UI/Component/Input/Field/FileInputTest.php
@@ -372,7 +372,7 @@ class FileInputTest extends ILIAS_UI_TestBase
         return new WithSomeButtonNoUIFactory($this->buildButtonFactory());
     }
 
-    public function getDefaultRenderer(JavaScriptBinding $js_binding = null)
+    public function getDefaultRenderer(JavaScriptBinding $js_binding = null, $with_stub_renderings = [])
     {
         $ui_factory = $this->getUIFactory();
         $tpl_factory = $this->getTemplateFactory();

--- a/tests/UI/Component/Layout/Page/StandardPageTest.php
+++ b/tests/UI/Component/Layout/Page/StandardPageTest.php
@@ -18,13 +18,47 @@ use \ILIAS\UI\Implementation\Component\Legacy\Legacy;
  */
 class StandardPageTest extends ILIAS_UI_TestBase
 {
+    /**
+     * @var Page\Standard
+     */
+    protected $stdpage;
+
+    /**
+     * @var Page\Factory
+     */
+    protected $factory;
+
+    /**
+     * @var MainBar
+     */
+    protected $mainbar;
+
+    /**
+     * @var MetaBar
+     */
+    protected $metabar;
+
+    /**
+     * @var Breadcrumbs
+     */
+    protected $crumbs;
+
+    /**
+     * @var Image
+     */
+    protected $logo;
+
     public function setUp() : void
     {
         $sig_gen = new \ILIAS\UI\Implementation\Component\SignalGenerator();
         $this->metabar = $this->createMock(MetaBar::class);
+        $this->metabar->method("getCanonicalName")->willReturn("MetaBar Stub");
         $this->mainbar = $this->createMock(MainBar::class);
+        $this->mainbar->method("getCanonicalName")->willReturn("MainBar Stub");
         $this->crumbs = $this->createMock(Breadcrumbs::class);
+        $this->crumbs->method("getCanonicalName")->willReturn("Breadcrumbs Stub");
         $this->logo = $this->createMock(Image::class);
+        $this->logo->method("getCanonicalName")->willReturn("Logo Stub");
         $this->contents = array(new Legacy('some content', $sig_gen));
         $this->title = 'pagetitle';
 
@@ -131,5 +165,93 @@ class StandardPageTest extends ILIAS_UI_TestBase
             $title,
             $this->stdpage->withViewTitle($title)->getViewTitle()
         );
+    }
+
+    public function testWithTextDirection()
+    {
+        $this->assertEquals("ltr", $this->stdpage->getTextDirection());
+        $this->assertEquals(
+            "rtl",
+            $this->stdpage
+            ->withTextDirection($this->stdpage::RTL)
+            ->getTextDirection()
+        );
+    }
+
+    public function testRenderingWithTitle()
+    {
+        $this->stdpage = $this->stdpage
+            ->withTitle("Title")
+            ->withViewTitle("View Title")
+            ->withShortTitle("Short Title");
+
+        $r = $this->getDefaultRenderer(null, [$this->metabar, $this->mainbar, $this->crumbs, $this->logo]);
+        $html = $this->brutallyTrimHTML($r->render($this->stdpage));
+
+        $exptected = $this->brutallyTrimHTML('
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+   <head>
+      <meta charset="utf-8" />
+      <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+      <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+      <title>Short Title: View Title</title>
+      <style type="text/css"></style>
+   </head>
+   <body>
+      <div class="il-layout-page">
+         <header>
+            <div class="header-inner">
+               <div class="il-logo">Logo Stub<div class="il-pagetitle">Title</div></div>MetaBar Stub</div>
+         </header>
+         <div class="breadcrumbs"></div>
+         <div class="il-system-infos"></div>
+         <div class="nav il-maincontrols">MainBar Stub</div>
+         <!-- html5 main-tag is not supported in IE / div is needed -->
+         <main class="il-layout-page-content">
+            <div>some content</div>
+         </main>
+      </div>
+      <script type="text/javascript">il.Util.addOnLoad(function() {});</script>
+   </body>
+</html>');
+        $this->assertEquals($exptected, $html);
+    }
+
+    public function testRenderingWithRtlLanguage()
+    {
+        $this->stdpage = $this->stdpage->withTextDirection($this->stdpage::RTL);
+
+        $r = $this->getDefaultRenderer(null, [$this->metabar, $this->mainbar, $this->crumbs, $this->logo]);
+        $html = $this->brutallyTrimHTML($r->render($this->stdpage));
+
+        $exptected = $this->brutallyTrimHTML('
+<!DOCTYPE html>
+<html lang="en" dir="rtl">
+   <head>
+      <meta charset="utf-8" />
+      <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+      <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+      <title>: </title>
+      <style type="text/css"></style>
+   </head>
+   <body>
+      <div class="il-layout-page">
+         <header>
+            <div class="header-inner">
+               <div class="il-logo">Logo Stub<div class="il-pagetitle">pagetitle</div></div>MetaBar Stub</div>
+         </header>
+         <div class="breadcrumbs"></div>
+         <div class="il-system-infos"></div>
+         <div class="nav il-maincontrols">MainBar Stub</div>
+         <!-- html5 main-tag is not supported in IE / div is needed -->
+         <main class="il-layout-page-content">
+            <div>some content</div>
+         </main>
+      </div>
+      <script type="text/javascript">il.Util.addOnLoad(function() {});</script>
+   </body>
+</html>');
+        $this->assertEquals($exptected, $html);
     }
 }

--- a/tests/UI/Component/MainControls/SystemInfoTest.php
+++ b/tests/UI/Component/MainControls/SystemInfoTest.php
@@ -192,7 +192,7 @@ EOT;
         );
     }
 
-    public function getDefaultRenderer(JavaScriptBinding $js_binding = null)
+    public function getDefaultRenderer(JavaScriptBinding $js_binding = null, $with_stub_renderings = [])
     {
         return parent::getDefaultRenderer(new class implements \ILIAS\UI\Implementation\Render\JavaScriptBinding {
             public function createId()


### PR DESCRIPTION
This PR is the first part in tackling the issue reported in: https://mantis.ilias.de/view.php?id=29426 by adding mutators for the text direction. A second part will be the correct usage of those mutators by global screen. I did not want to bundle the two to keep the complexity manageable. 

By providing the necessary tests, I got reminded that we did not have rendering tests for the standard layout. This PR also contains a fix for this, by adding an option to render parts of a component as "Stub". E.g. one can now render the as Mock Provided Main Bar in the Page Layout as simple string just displaying the Canonical Name of the Component. This could be useful for other components as well, featuring many sub components in their default version. Since I believe the missing of rendering tests for a component to be an issue, I created a ticket for this as well, which is hereby adressed: https://mantis.ilias.de/view.php?id=30532