### PR TITLE
Switching repository chat message field to textarea and also switched…

### DIFF
--- a/Modules/Chatroom/js/iliaschat.jquery.js
+++ b/Modules/Chatroom/js/iliaschat.jquery.js
@@ -1556,8 +1556,9 @@ var ServerConnector = function ServerConnector(url, scope, user, userManager, gu
 		});
 
 		// when the client hits ENTER on their keyboard
-		$('#submit_message_text').keypress(function(e) {
-			if(e.which == 13) {
+		$('#submit_message_text').keydown(function(e) {
+			var keycode = e.keyCode || e.which;
+			if(keycode === 13) {
 				e.preventDefault();
 				e.stopPropagation();
 

--- a/Modules/Chatroom/js/iliaschat.jquery.js
+++ b/Modules/Chatroom/js/iliaschat.jquery.js
@@ -1558,7 +1558,7 @@ var ServerConnector = function ServerConnector(url, scope, user, userManager, gu
 		// when the client hits ENTER on their keyboard
 		$('#submit_message_text').keydown(function(e) {
 			var keycode = e.keyCode || e.which;
-			if(keycode === 13) {
+			if(keycode === 13 && !e.shiftKey) {
 				e.preventDefault();
 				e.stopPropagation();
 

--- a/Modules/Chatroom/templates/default/style.css
+++ b/Modules/Chatroom/templates/default/style.css
@@ -5,6 +5,7 @@
 .chat.messageLine {
 	margin-top: 5px;
 	margin-bottom: 5px;
+	white-space: pre-line;
 }
 
 .chat.messageLine.private {

--- a/Modules/Chatroom/templates/default/tpl.chatroom.html
+++ b/Modules/Chatroom/templates/default/tpl.chatroom.html
@@ -130,7 +130,7 @@
 						</label>
 					</div>
 					<div id="iosChatInputContainer" class="col-sm-9">
-						<input class="form-control" type="text" name="message" id="submit_message_text"/>
+						<textarea autocomplete="off" class="form-control" name="message" id="submit_message_text"></textarea>
 						<input type="button" class="btn btn-default btn-sm" value="{LBL_SEND}" id="submit_message"/>
 					</div>
 				</div>


### PR DESCRIPTION
… keypress to keydown.

This is a suggested solution to the feature request: [Repository Chat: Message box supports multiple lines](https://docu.ilias.de/goto_docu_wiki_wpage_6782_1357.html)

Keypress is deprecated according to https://developer.mozilla.org/en-US/docs/Web/API/Document/keypress_event