### PR TITLE
CI: Implemented tests on push, changed badge on readme

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,5 +1,5 @@
 name: checks
-on: [pull_request]
+on: [pull_request, push]
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://api.travis-ci.com/ILIAS-eLearning/ILIAS.svg?branch=trunk)](https://travis-ci.com/ILIAS-eLearning/ILIAS)
+[![checks](https://github.com/ILIAS-eLearning/ILIAS/actions/workflows/checks.yml/badge.svg)](https://github.com/ILIAS-eLearning/ILIAS/actions/workflows/checks.yml)
 [![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%207.2-8892BF.svg)](https://php.net/)
 
 # ILIAS


### PR DESCRIPTION
According to recent conversation with @mjansenDatabay I've implemented the tests and checks on a push commit. This will add a badge for success/failure on the commits itself (even though it uses more precious usage time from github actions). I've also changed the README.md badge to the github actions status.

* [x] Tests now available for push commits
* [x] Failure/Success-Badge on commits
* [x] Status badge in README.md

If this PR gets approved I'll implement the changes to release_7 and trunk aswell.

Best, Laura