### PR TITLE
BT-29425: Fixed wrong language variable in mobile search view

### DIFF
--- a/Services/Search/classes/Provider/SearchMetaBarProvider.php
+++ b/Services/Search/classes/Provider/SearchMetaBarProvider.php
@@ -63,7 +63,7 @@ class SearchMetaBarProvider extends AbstractStaticMetaBarProvider implements Sta
             ->topLegacyItem($this->getId())
             ->withLegacyContent($content())
             ->withSymbol($this->dic->ui()->factory()->symbol()->glyph()->search())
-            ->withTitle($this->dic->language()->txt("Search"))
+            ->withTitle($this->dic->language()->txt("search"))
             ->withPosition(1)
             ->withAvailableCallable(
                 function () {


### PR DESCRIPTION
Link to Mantis-Report:
https://mantis.ilias.de/view.php?id=29425