### PR TITLE
BT-29427: Changed language variable in mobile view of meta bar to refer to user instead of avatar

### DIFF
--- a/Services/User/classes/Provider/UserMetaBarProvider.php
+++ b/Services/User/classes/Provider/UserMetaBarProvider.php
@@ -48,7 +48,7 @@ class UserMetaBarProvider extends AbstractStaticMetaBarProvider
         // "User"-Menu
         $item[] = $mb->topParentItem($id('user'))
             ->withSymbol($this->dic->user()->getAvatar())
-            ->withTitle($this->dic->language()->txt("personal_picture"))
+            ->withTitle($this->dic->language()->txt("info_view_of_user"))
             ->withPosition(4)
             ->withVisibilityCallable(
                 function () {


### PR DESCRIPTION
Link to Mantis-Report:
https://mantis.ilias.de/view.php?id=29427