### PR TITLE
fixed #30563: mediaobject fixed height

### DIFF
--- a/Services/COPage/xsl/page.xsl
+++ b/Services/COPage/xsl/page.xsl
@@ -2958,7 +2958,7 @@
 				</xsl:if>
 				<!-- see #bug22632 -->
 				<xsl:if test="$width = '' and $height = ''">
-					<xsl:attribute name="style">max-width: 100%; width: 100%;</xsl:attribute>
+					<xsl:attribute name="style">max-width: 100%; width: 100%; max-height: 100%;</xsl:attribute>
 				</xsl:if>
 				<xsl:if test="$mode != 'edit' and
 					(../MediaAliasItem[@Purpose = $curPurpose]/Parameter[@Name = 'autostart']/@Value = 'true' or


### PR DESCRIPTION
fixed an issue where a mediaobject without fixed height would make content beneath it unclickable, due to an invisible video container. (see https://mantis.ilias.de/view.php?id=30563)