### PR TITLE
fixed bug #30572: ilMailSearchGroupsGUI verwechselt Kurse und Gruppen

### DIFF
--- a/Services/Contact/classes/class.ilMailSearchGroupsGUI.php
+++ b/Services/Contact/classes/class.ilMailSearchGroupsGUI.php
@@ -480,7 +480,7 @@ class ilMailSearchGroupsGUI
             if (is_array($ids) && count($ids)) {
                 $this->addPermission($ids);
             } else {
-                ilUtil::sendInfo($this->lng->txt("mail_select_course"));
+                ilUtil::sendInfo($this->lng->txt("mail_select_group"));
                 $this->showMyGroups();
             }
         } elseif ($_GET["view"] == "grp_members") {


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=30572