### PR TITLE
UI Components, Avatar Symbol, fix of #29727

### DIFF
--- a/Services/User/classes/class.ilUserAvatarResolver.php
+++ b/Services/User/classes/class.ilUserAvatarResolver.php
@@ -1,6 +1,7 @@
 <?php
 
 use ILIAS\UI\Component\Symbol\Avatar\Avatar;
+use ILIAS\UI\Factory;
 
 /**
  * Class ilUserAvatarResolver
@@ -48,6 +49,10 @@ class ilUserAvatarResolver
      * @var string
      */
     private $size = 'small';
+    /**
+     * @var Factory
+     */
+    protected $ui;
 
     /**
      *  constructor.
@@ -114,10 +119,10 @@ class ilUserAvatarResolver
     public function getAvatar() : Avatar
     {
         if ($this->useUploadedFile()) {
-            return $this->ui->symbol()->avatar()->picture($this->uploaded_file, $this->abbreviation);
-        } else {
-            return $this->ui->symbol()->avatar()->letter($this->abbreviation);
+            return $this->ui->symbol()->avatar()->picture($this->uploaded_file, $this->login);
         }
+
+        return $this->ui->symbol()->avatar()->letter($this->login);
     }
 
     public function getLegacyPictureURL() : string
@@ -125,7 +130,6 @@ class ilUserAvatarResolver
         global $DIC;
         if ($this->useUploadedFile()) {
             return $this->uploaded_file . '?t=' . rand(1, 99999);
-            ;
         }
         /** @var $avatar ilUserAvatarBase */
 

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -16528,3 +16528,7 @@ content#:#cont_footnote#:#Fußnote
 content#:#cont_Book#:#Buchdruck
 content#:#cont_Numbers#:#Zahlen
 content#:#cont_Verse#:#Lyrik/Strophe
+common#:#user_#:#Zurück zum Kurs
+common#:#user_avatar#:#Profilbild
+common#:#current_user_avatar#:#Ihr Profilbild
+common#:#user_avatar_of#:#Profilbild von

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -16530,3 +16530,6 @@ content#:#cont_footnote#:#Footnote
 content#:#cont_Book#:#Book
 content#:#cont_Numbers#:#Numbers
 content#:#cont_Verse#:#Verse/Stanza
+common#:#user_avatar#:#User Avatar
+common#:#current_user_avatar#:#Your User Avatar
+common#:#user_avatar_of#:#User Avatar of

--- a/src/UI/Component/Symbol/Avatar/Avatar.php
+++ b/src/UI/Component/Symbol/Avatar/Avatar.php
@@ -8,4 +8,8 @@ namespace ILIAS\UI\Component\Symbol\Avatar;
 interface Avatar extends \ILIAS\UI\Component\Symbol\Symbol
 {
     public function getUsername() : string;
+
+    public function withAlternativeText(string $text) : Avatar;
+
+    public function getAlternativeText() : string;
 }

--- a/src/UI/Component/Symbol/Factory.php
+++ b/src/UI/Component/Symbol/Factory.php
@@ -138,7 +138,18 @@ interface Factory
      *     1: Avatars MUST be used to represent a specific user.
      *     2: Avatars MUST be used in combination with the represented username.
      *   accessibility:
-     *     1: Avatars MUST bear an aria-label with the username.
+     *     1:  >
+     *       Avatars MUST bear an aria-label or contain an image with an alt tag with some alternative text. Note,
+     *       that it MUST NOT contain both, a aria-label and an image with a non-empty alt tag.
+     *     2:  >
+     *       If the Avatar is accompanied by the name of the user shown in the image
+     *       (e.g. in the Members Gallery), the alternative text attribute MUST be "User Avatar".
+     *     3:  >
+     *       If the Avatar is not or might not (due to some setting) be accompaniedby the
+     *       name of the user shown in the image, the alternative text MUST be "User Avatar of NameOfUser".
+     *     4:  >
+     *       Avatars that show the currently logged in user outside some list with other users,
+     *       the alternative text MUST be "Your user avatar".
      *   responsiveness:
      *     1: the avatar MUST adjust it's size to the parent container.
      * ---

--- a/src/UI/Implementation/Component/Symbol/Avatar/Avatar.php
+++ b/src/UI/Implementation/Component/Symbol/Avatar/Avatar.php
@@ -16,6 +16,8 @@ abstract class Avatar implements C\Symbol\Avatar\Avatar
      */
     private $username;
 
+    protected $alternative_text = "";
+
     public function __construct(string $username)
     {
         $this->username = $username;
@@ -27,5 +29,17 @@ abstract class Avatar implements C\Symbol\Avatar\Avatar
     public function getUsername() : string
     {
         return $this->username;
+    }
+
+    public function withAlternativeText(string $text) : C\Symbol\Avatar\Avatar
+    {
+        $clone = clone $this;
+        $clone->alternative_text = $text;
+        return $clone;
+    }
+
+    public function getAlternativeText() : string
+    {
+        return $this->alternative_text;
     }
 }

--- a/src/UI/Implementation/Component/Symbol/Avatar/Renderer.php
+++ b/src/UI/Implementation/Component/Symbol/Avatar/Renderer.php
@@ -13,18 +13,24 @@ class Renderer extends AbstractComponentRenderer
     {
         $this->checkComponent($component);
         $tpl = null;
+
+        $alternetive_text = $component->getAlternativeText();
+        if($alternetive_text == ""){
+            $alternetive_text = $this->txt("user_avatar");
+        }
+
         /**
          * @var $component Avatar
          */
         if ($component instanceof Component\Symbol\Avatar\Letter) {
             $tpl = $this->getTemplate('tpl.avatar_letter.html', true, true);
-            $tpl->setVariable('ARIA_LABEL', $component->getUsername());
+            $tpl->setVariable('ARIA_LABEL', $alternetive_text);
             $tpl->setVariable('MODE', 'letter');
             $tpl->setVariable('TEXT', $component->getAbbreviation());
             $tpl->setVariable('COLOR', (string) $component->getBackgroundColorVariant());
         } elseif ($component instanceof Component\Symbol\Avatar\Picture) {
             $tpl = $this->getTemplate('tpl.avatar_picture.html', true, true);
-            $tpl->setVariable('ARIA_LABEL', $component->getUsername());
+            $tpl->setVariable('ARIA_LABEL', $alternetive_text);
             $tpl->setVariable('MODE', 'picture');
             $tpl->setVariable('CUSTOMIMAGE', $component->getPicturePath());
         }

--- a/src/UI/templates/default/Symbol/tpl.avatar_picture.html
+++ b/src/UI/templates/default/Symbol/tpl.avatar_picture.html
@@ -1,3 +1,3 @@
-<div class="il-avatar il-avatar-picture il-avatar-size-large" aria-label="{ARIA_LABEL}">
+<div class="il-avatar il-avatar-picture il-avatar-size-large">
 	<!-- BEGIN image --><img src="{CUSTOMIMAGE}" alt="{ARIA_LABEL}"/><!-- END image -->
 </div>

--- a/src/UI/templates/default/Symbol/tpl.avatar_picture.html
+++ b/src/UI/templates/default/Symbol/tpl.avatar_picture.html
@@ -1,3 +1,3 @@
 <div class="il-avatar il-avatar-picture il-avatar-size-large" aria-label="{ARIA_LABEL}">
-	<!-- BEGIN image --><img src="{CUSTOMIMAGE}"/><!-- END image -->
+	<!-- BEGIN image --><img src="{CUSTOMIMAGE}" alt="{ARIA_LABEL}"/><!-- END image -->
 </div>

--- a/tests/UI/Component/Symbol/Avatar/AvatarTest.php
+++ b/tests/UI/Component/Symbol/Avatar/AvatarTest.php
@@ -117,14 +117,30 @@ class AvatarTest extends ILIAS_UI_TestBase
         }
     }
 
+    public function testAlternativeText() : void
+    {
+        $f = $this->getAvatarFactory();
+        $this->assertEquals("", $f->picture('', 'ro')->getAlternativeText());
+        $this->assertEquals("", $f->letter('', 'ro')->getAlternativeText());
+        $this->assertEquals("alternative", $f->picture('', 'ro')
+                                             ->withAlternativeText("alternative")
+                                             ->getAlternativeText());
+        $this->assertEquals("alternative", $f->letter('', 'ro')
+                                             ->withAlternativeText("alternative")
+                                             ->getAlternativeText());
+    }
+
     public function testRenderingLetter()
     {
         $f = $this->getAvatarFactory();
         $r = $this->getDefaultRenderer();
 
         $letter = $f->letter('ro');
-        $html = $this->normalizeHTML($r->render($letter));
-        $expected = '<div class="il-avatar il-avatar-letter il-avatar-size-large il-avatar-letter-color-1" aria-label="ro">	<span class="abbreviation">ro</span></div>';
+        $html = $this->brutallyTrimHTML($r->render($letter));
+        $expected = $this->brutallyTrimHTML('
+<div class="il-avatar il-avatar-letter il-avatar-size-large il-avatar-letter-color-1" aria-label="user_avatar">	
+    <span class="abbreviation">ro</span>
+</div>');
         $this->assertEquals($expected, $html);
     }
 
@@ -135,11 +151,28 @@ class AvatarTest extends ILIAS_UI_TestBase
 
         $str = '/path/to/picture.jpg';
         $letter = $f->picture($str, 'ro');
-        $html = $this->normalizeHTML($r->render($letter));
-        $expected = '<div class="il-avatar il-avatar-picture il-avatar-size-large" aria-label="ro">	<img src="/path/to/picture.jpg" alt="ro"/></div>';
+        $html = $this->brutallyTrimHTML($r->render($letter));
+        $expected = $this->brutallyTrimHTML('
+<div class="il-avatar il-avatar-picture il-avatar-size-large">	
+    <img src="/path/to/picture.jpg" alt="user_avatar"/>
+</div>');
         $this->assertEquals($expected, $html);
     }
 
+    public function testRenderingPictureWithSomeAlternativeText()
+    {
+        $f = $this->getAvatarFactory();
+        $r = $this->getDefaultRenderer();
+
+        $str = '/path/to/picture.jpg';
+        $letter = $f->picture($str, 'ro')->withAlternativeText("alternative");
+        $html = $this->brutallyTrimHTML($r->render($letter));
+        $expected = $this->brutallyTrimHTML('
+<div class="il-avatar il-avatar-picture il-avatar-size-large">	
+    <img src="/path/to/picture.jpg" alt="alternative"/>
+</div>');
+        $this->assertEquals($expected, $html);
+    }
     /**
      * @param int $color_variants
      * @param int $length

--- a/tests/UI/Component/Symbol/Avatar/AvatarTest.php
+++ b/tests/UI/Component/Symbol/Avatar/AvatarTest.php
@@ -136,7 +136,7 @@ class AvatarTest extends ILIAS_UI_TestBase
         $str = '/path/to/picture.jpg';
         $letter = $f->picture($str, 'ro');
         $html = $this->normalizeHTML($r->render($letter));
-        $expected = '<div class="il-avatar il-avatar-picture il-avatar-size-large" aria-label="ro">	<img src="/path/to/picture.jpg"/></div>';
+        $expected = '<div class="il-avatar il-avatar-picture il-avatar-size-large" aria-label="ro">	<img src="/path/to/picture.jpg" alt="ro"/></div>';
         $this->assertEquals($expected, $html);
     }
 


### PR DESCRIPTION
This an adaptation of PR: https://github.com/ILIAS-eLearning/ILIAS/pull/3254 according to the latest results of the discussion in: https://mantis.ilias.de/view.php?id=29727 . Note that I slightly reworded the ruling to be more consistent with the technical implementation. Due to the change of the rules, we need to discuss this in the next JF.

Language File conflicts will be resolved as soon as this is approved for merging into 7.