### PR TITLE
Marked ilUtil as deprecated

### DIFF
--- a/Services/Utilities/classes/class.ilUtil.php
+++ b/Services/Utilities/classes/class.ilUtil.php
@@ -10,9 +10,14 @@ use ILIAS\FileUpload\DTO\UploadResult;
 /**
  * Util class
  * various functions, usage as namespace
+ * @author     Sascha Hofmann <saschahofmann@gmx.de>
+ * @author     Alex Killing <alex.killing@gmx.de>
  *
- * @author Sascha Hofmann <saschahofmann@gmx.de>
- * @author Alex Killing <alex.killing@gmx.de>
+ * @deprecated The 2021 Technical Board has decided to mark the ilUtil class as deprecated. The ilUtil is a historically
+ * grown helper class with many different UseCases and functions. The class is not under direct maintainership and the
+ * responsibilities are unclear. In this context, the class should no longer be used in the code and existing uses
+ * should be converted to their own service in the medium term. If you need ilUtil for the implementation of a new
+ * function in ILIAS > 7, please contact the Technical Board.
  */
 class ilUtil
 {


### PR DESCRIPTION
The 2021 Technical Board has decided to mark the ilUtil class as deprecated. The ilUtil is a historically grown helper class with many different UseCases and functions. The class is not under direct maintainership and the responsibilities are unclear. In this context, the class should no longer be used in the code and existing uses should be converted to their own service in the medium term. If you need ilUtil for the implementation of a new function in ILIAS > 7, please contact the Technical Board.