### PR TITLE
Declare DIC for autocomplete in IDEs

### DIFF
--- a/ilias.php
+++ b/ilias.php
@@ -15,7 +15,10 @@
 require_once("Services/Init/classes/class.ilInitialisation.php");
 ilInitialisation::initILIAS();
 
-global $ilCtrl, $ilBench;
+/**
+ * @var $DIC \ILIAS\DI\Container
+ */
+global $DIC, $ilBench;
 
-$ilCtrl->callBaseClass();
+$DIC->ctrl()->callBaseClass();
 $ilBench->save();


### PR DESCRIPTION
Hi @alex40724 

Currently I have the issue, that autocomplete often fails me for $DIC in PHPStorms. This change here improves this, by declaring the nature of $DIC in a central place. Maybe others suffer from the same Issues or other IDE's might profit as well from this declaration. Not sure if this is the ideal place. If there are strong opinions on some alternative, I am happy to adapt.

Thx, for considering.