### PR TITLE
#0030242: Failed test: TeX im Forum anzeigen

### DIFF
--- a/Modules/Forum/classes/class.ilForum.php
+++ b/Modules/Forum/classes/class.ilForum.php
@@ -499,7 +499,7 @@ class ilForum
             $news_item->setPriority(NEWS_NOTICE);
             $news_item->setTitle($objNewPost->getSubject());
             $news_item->setContent(ilRTE::_replaceMediaObjectImageSrc($this->prepareText($objNewPost->getMessage(), 0), 1));
-            if ($objNewPost->getMessage() != strip_tags($objNewPost->getMessage())) {
+            if ($news_item->getContent() != strip_tags($news_item->getContent())) {
                 $news_item->setContentHtml(true);
             }
             
@@ -746,7 +746,7 @@ class ilForum
                 $news_item = new ilNewsItem($news_id);
                 //$news_item->setTitle($subject);
                 $news_item->setContent(nl2br($this->prepareText($message, 0)));
-                if ($message != strip_tags($message)) {
+                if ($news_item->getContent() != strip_tags($news_item->getContent())) {
                     $news_item->setContentHtml(true);
                 } else {
                     $news_item->setContentHtml(false);
@@ -768,7 +768,7 @@ class ilForum
                 $news_item = new ilNewsItem($news_id);
                 //$news_item->setTitle($subject);
                 $news_item->setContent(nl2br($this->prepareText($rec["pos_message"], 0)));
-                if ($rec["pos_message"] != strip_tags($rec["pos_message"])) {
+                if ($news_item->getContent() != strip_tags($news_item->getContent())) {
                     $news_item->setContentHtml(true);
                 } else {
                     $news_item->setContentHtml(false);

--- a/Modules/Forum/classes/class.ilObjForumGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumGUI.php
@@ -2549,7 +2549,7 @@ class ilObjForumGUI extends \ilObjectGUI implements \ilDesktopItemHandling
                             ), 1)
                         );
 
-                        if ($this->objCurrentPost->getMessage() != strip_tags($this->objCurrentPost->getMessage())) {
+                        if ($news_item->getContent() != strip_tags($news_item->getContent())) {
                             $news_item->setContentHtml(true);
                         } else {
                             $news_item->setContentHtml(false);

--- a/Services/News/classes/class.ilNewsDefaultRendererGUI.php
+++ b/Services/News/classes/class.ilNewsDefaultRendererGUI.php
@@ -132,6 +132,12 @@ class ilNewsDefaultRendererGUI implements ilNewsRendererGUI
             return $a_str;
         }
 
+        // this fixes bug 30242.
+        // server side mathjax creates svg code which may include links
+        if (is_int(strpos($a_str, "</svg>")) && is_int(strpos($a_str, "<svg"))) {
+            return $a_str;
+        }
+
         return ilUtil::makeClickable($a_str);
     }
 


### PR DESCRIPTION
This a fix for Mantis bug 30242.
If RTE ist not enabled for the forum, the authors still can add TeX code with the delimiters [tex] and [/tex]. This is correctly displayed in the forum if the servier-side rendering of mathjax is enabled for the browser. The detail view of generated news items however looks strange because a post-processing in ilNewsDefaultRendererGUI::getDetailContent corrupts the svg code. This should not be done if ilNewsItem::getContentHtml indicates that the content is already HTML. The creation of the news item in the forum code, however checked that with the original message but not with the content after processing by ilMathJax.
Additionally ilNewsDefaultRendererGUI::makeClickable should not replace URLs in SVG code.