### PR TITLE
#0030243: Failed test: TeX im PDF-Export anzeigen

### DIFF
--- a/Modules/Survey/xml/question2fo.xsl
+++ b/Modules/Survey/xml/question2fo.xsl
@@ -66,6 +66,9 @@
 					<xsl:apply-templates/>
 				</fo:inline>			
 			</xsl:when>
+			<xsl:otherwise>
+				<xsl:apply-templates/>
+			</xsl:otherwise>
 		</xsl:choose>
 	</xsl:template>
 	


### PR DESCRIPTION
In https://test7.ilias.de/goto_test7_svy_36510.html a survey question is created with TeX code in the RTE editor. If you look to the HTML view you see that the TeX is included in a span tag. When the PDF is rendered the TeX formula is not shown because the span tag is not processed by XSL if it does not have the class "solutionbox" or "questionlabel". 