### PR TITLE
Add whitespaces instead of line brakes for latest article view in forum

### DIFF
--- a/Modules/Forum/classes/class.ilObjForumAccess.php
+++ b/Modules/Forum/classes/class.ilObjForumAccess.php
@@ -135,6 +135,7 @@ class ilObjForumAccess extends ilObjectAccess
      */
     public static function prepareMessageForLists($text)
     {
+        $text = str_replace('<br />', ' ', $text);
         $text = strip_tags($text);
         $text = preg_replace('/\[(\/)?quote\]/', '', $text);
         if (ilStr::strLen($text) > 40) {


### PR DESCRIPTION
This is a very small usability improvement fixing an edge case in the list view of a forum. It ensures a white space is shown in the "last posting" line when a new line is in the posting part to be shown.

If accepted this should probably be cherry-picked to all maintained versions (I can do this, if you want).