### PR TITLE
UI Components, Meta Bar Dom Structure, see #29717 and #28735

### DIFF
--- a/Services/LTI/templates/default/lti.css
+++ b/Services/LTI/templates/default/lti.css
@@ -6,6 +6,6 @@
     top: 18px;
 }
 
-.il-maincontrols-metabar .il-metabar-entries .btn-bulky .bulky-label {
+.il-maincontrols-metabar .btn-bulky .bulky-label {
 	display: block !important;
 }

--- a/src/UI/Implementation/Component/MainControls/Renderer.php
+++ b/src/UI/Implementation/Component/MainControls/Renderer.php
@@ -359,10 +359,6 @@ class Renderer extends AbstractComponentRenderer
 
             $button_html = $default_renderer->render($button);
 
-            $tpl->setCurrentBlock($use_block);
-            $tpl->setVariable("BUTTON", $button_html);
-            $tpl->parseCurrentBlock();
-
             if ($slate) {
                 $slate = $slate->withAriaRole(ISlate::MENU);
 
@@ -370,6 +366,10 @@ class Renderer extends AbstractComponentRenderer
                 $tpl->setVariable("SLATE", $default_renderer->render($slate));
                 $tpl->parseCurrentBlock();
             }
+
+            $tpl->setCurrentBlock($use_block);
+            $tpl->setVariable("BUTTON", $button_html);
+            $tpl->parseCurrentBlock();
         }
     }
 

--- a/src/UI/templates/default/Layout/standardpage.less
+++ b/src/UI/templates/default/Layout/standardpage.less
@@ -185,6 +185,9 @@ div.il-system-infos {
 	padding-left: 35px; // dynamic value desirable
 }
 
+.il-header-locator{
+	display: none;
+}
 // mainbar
 nav.il-maincontrols {
 	-ms-grid-column: 1;
@@ -440,6 +443,8 @@ footer {
 	}
 
 	.il-header-locator {
+		display: block;
+
 		.dropdown {
 			position: static;
 		}

--- a/src/UI/templates/default/MainControls/metabar.less
+++ b/src/UI/templates/default/MainControls/metabar.less
@@ -2,15 +2,14 @@
 	display: flex;
     justify-content: space-between;
     align-items: center;
-	.il-metabar-entries {
-		align-items: center;
-		display: flex;
-		height: @il-standard-page-header-height;
-		.il-metabar-entry,
-		.il-logout {
-			padding-left: 10px;
-		}
+
+	list-style-type: none; /* Remove bullets */
+
+	// no display labels in metabar level 1
+	>li >.btn-bulky > .bulky-label {
+		display: none;
 	}
+
 	.glyphicon {
 		filter: invert(50%);
 		font-family: 'il-icons';
@@ -18,44 +17,37 @@
 		margin-right: @il-slate-bulky-glyph-margin-right;
 		position: relative;
 	}
+
 	.input-group {
 		display: block;
 	}
+
 	p {
 		padding: 0;
 	}
+
 	form#mm_search_form {
 		padding: 20px;
 	}
 
-	.bulky-label {
-		white-space: normal;
-		margin-top: @il-mainbar-bulky-label-margin-top;
-		display: block;
-	}
-}
-
-.il-metabar-entries {
-	list-style-type: none; /* Remove bullets */
-
 	.badge {
 		position: absolute;
 	}
+
 	.btn {
 		position: relative;
 	}
+
 	.il-counter-novelty {
 		margin-top: 0;
 		top: 17px;
 	}
+
 	.il-counter-status {
 		margin-top: 0;
 		top: 32px;
 	}
-	// no display labels in metabar level 1
-	>li >.btn-bulky > .bulky-label {
-		display: none;
-	}
+
 	.btn-bulky {
 		background-color: transparent;
 		height: @il-metabar-entry-height;
@@ -82,7 +74,19 @@
 		}
 	}
 
+	.bulky-label {
+		white-space: normal;
+		margin-top: @il-mainbar-bulky-label-margin-top;
+		display: block;
+	}
+
 	@media only screen and (max-width: @grid-float-breakpoint-max) {
+		.il-counter-novelty {
+			top: 7px;
+		}
+		.il-counter-status {
+			top: 22px;
+		}
 
 		.il-metabar-more-button {
 			padding-right: 20px;
@@ -125,38 +129,7 @@
 		width: 100%;
 		top: @il-metabar-small-entry-height;
 		right: 0;
-	}
-	/*TODO: remove hack*/
-	.il-maincontrols-slate {
-		@media only screen and (max-width: @grid-float-breakpoint-max) {
-			min-width: 260px;
-		}
-	}
-	/*end of hack*/
 
-	.il-maincontrols-slate-content {
-		// padding: 10px;
-	}
-}
-
-
-.il-header-locator {
-	display: none;
-}
-
-@media only screen and (max-width: @grid-float-breakpoint-max) {
-	.il-header-locator {
-		display: block;
-	}
-	.il-metabar-entries {
-		.il-counter-novelty {
-			top: 7px;
-		}
-		.il-counter-status {
-			top: 22px;
-		}
-	}
-	.il-metabar-slates {
 		.glyphicon {
 			color: @il-metabar-glyph-color;
 			font-size: @il-metabar-small-glyph-size;
@@ -172,17 +145,21 @@
 		.il-counter-spacer {
 			margin-left: -18px;
 		}
-	}
-	.il-metabar-more-slate{
-		.btn-bulky:after {
-			content: "\e606";
 
-			font-family: "il-icons";
-			font-size: @il-slate-bulky-glyph-size * 0.85;
-			position: absolute;
-			right: 10px;
-			top: 20px;
+		.il-metabar-more-slate{
+			.btn-bulky:after {
+				content: "\e606";
+
+				font-family: "il-icons";
+				font-size: @il-slate-bulky-glyph-size * 0.85;
+				position: absolute;
+				right: 10px;
+				top: 20px;
+			}
+		}
+
+		.il-maincontrols-slate {
+			min-width: 260px;
 		}
 	}
 }
-/*end of hack*/

--- a/src/UI/templates/default/MainControls/metabar.less
+++ b/src/UI/templates/default/MainControls/metabar.less
@@ -36,6 +36,8 @@
 }
 
 .il-metabar-entries {
+	list-style-type: none; /* Remove bullets */
+
 	.badge {
 		position: absolute;
 	}
@@ -51,7 +53,7 @@
 		top: 32px;
 	}
 	// no display labels in metabar level 1
-	> .btn-bulky > .bulky-label {
+	>li >.btn-bulky > .bulky-label {
 		display: none;
 	}
 	.btn-bulky {

--- a/src/UI/templates/default/MainControls/tpl.metabar.html
+++ b/src/UI/templates/default/MainControls/tpl.metabar.html
@@ -1,14 +1,12 @@
-<nav class="il-maincontrols-metabar" id="{ID}" aria-label="{ARIA_LABEL}">
-	<ul class="il-metabar-entries" role="menubar" style="visibility: hidden"><!--if done via class/css-files, visibility is being applied too late -->
-		<!-- BEGIN meta_element -->
-		<li role="none">
-			{BUTTON}
-			<!-- BEGIN slate_item -->
-			<div class="il-metabar-slates">
-				{SLATE}
-			</div>
-			<!-- END slate_item -->
-		</li>
-		<!-- END meta_element -->
-	</ul>
-</nav>
+<ul class="il-maincontrols-metabar il-metabar-entries" role="menubar" style="visibility: hidden" aria-label="{ARIA_LABEL}" id="{ID}" ><!--if done via class/css-files, visibility is being applied too late -->
+	<!-- BEGIN meta_element -->
+	<li role="none">
+		{BUTTON}
+		<!-- BEGIN slate_item -->
+		<div class="il-metabar-slates">
+			{SLATE}
+		</div>
+		<!-- END slate_item -->
+	</li>
+	<!-- END meta_element -->
+</ul>

--- a/src/UI/templates/default/MainControls/tpl.metabar.html
+++ b/src/UI/templates/default/MainControls/tpl.metabar.html
@@ -1,12 +1,14 @@
-<div class="il-maincontrols-metabar" id="{ID}" role="menubar" aria-label="{ARIA_LABEL}">
-	<div class="il-metabar-entries" style="visibility: hidden"><!--if done via class/css-files, visibility is being applied too late -->
+<nav class="il-maincontrols-metabar" id="{ID}" aria-label="{ARIA_LABEL}">
+	<ul class="il-metabar-entries" role="menubar" style="visibility: hidden"><!--if done via class/css-files, visibility is being applied too late -->
 		<!-- BEGIN meta_element -->
+		<li role="none">
 			{BUTTON}
+			<!-- BEGIN slate_item -->
+			<div class="il-metabar-slates">
+				{SLATE}
+			</div>
+			<!-- END slate_item -->
+		</li>
 		<!-- END meta_element -->
-	</div>
-	<div class="il-metabar-slates">
-		<!-- BEGIN slate_item -->
-		{SLATE}
-		<!-- END slate_item -->
-	</div>
-</div>
+	</ul>
+</nav>

--- a/src/UI/templates/default/MainControls/tpl.metabar.html
+++ b/src/UI/templates/default/MainControls/tpl.metabar.html
@@ -1,4 +1,4 @@
-<ul class="il-maincontrols-metabar il-metabar-entries" role="menubar" style="visibility: hidden" aria-label="{ARIA_LABEL}" id="{ID}" ><!--if done via class/css-files, visibility is being applied too late -->
+<ul class="il-maincontrols-metabar" role="menubar" style="visibility: hidden" aria-label="{ARIA_LABEL}" id="{ID}" ><!--if done via class/css-files, visibility is being applied too late -->
 	<!-- BEGIN meta_element -->
 	<li role="none">
 		{BUTTON}

--- a/src/UI/templates/js/Item/notification.js
+++ b/src/UI/templates/js/Item/notification.js
@@ -501,7 +501,7 @@ il.UI.item = il.UI.item || {};
 			var getNotificationsTriggererIfAny = function(){
 				var $meta_bar = getMetaBarOfItemIfIsInOne();
 				if($meta_bar.length){
-					var $notification_glyph = $meta_bar.find('.il-metabar-entries > .btn-bulky .glyphicon-bell');
+					var $notification_glyph = $meta_bar.find('.il-maincontrols-metabar > .btn-bulky .glyphicon-bell');
 					return $notification_glyph.parents('.btn-bulky');
 				}
 			}

--- a/src/UI/templates/js/MainControls/metabar.js
+++ b/src/UI/templates/js/MainControls/metabar.js
@@ -86,7 +86,7 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 		};
 		var _disengageAllButtons = function() {
 			$('#' + id +' .' + _cls_entries)
-			.find('li > .btn.' + _cls_btn_engaged)
+			.children('li').children('.btn.' + _cls_btn_engaged)
 			.each(
 				function(i, btn) {
 					_disengageButton($(btn));
@@ -164,7 +164,7 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 
 		var _getMetabarEntries = function() {
 			return $('#' + id +' .' + _cls_entries)
-				.find('li > .btn')
+				.children('li').children('.btn')
 				.not('.' + _cls_more_btn);
 		}
 

--- a/src/UI/templates/js/MainControls/metabar.js
+++ b/src/UI/templates/js/MainControls/metabar.js
@@ -86,7 +86,7 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 		};
 		var _disengageAllButtons = function() {
 			$('#' + id +' .' + _cls_entries)
-			.children('.btn.' + _cls_btn_engaged)
+			.find('li > .btn.' + _cls_btn_engaged)
 			.each(
 				function(i, btn) {
 					_disengageButton($(btn));
@@ -164,7 +164,7 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 
 		var _getMetabarEntries = function() {
 			return $('#' + id +' .' + _cls_entries)
-				.children('.btn')
+				.find('li > .btn')
 				.not('.' + _cls_more_btn);
 		}
 

--- a/src/UI/templates/js/MainControls/metabar.js
+++ b/src/UI/templates/js/MainControls/metabar.js
@@ -7,7 +7,7 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 
 		var id
 			,_cls_btn_engaged = 'engaged'
-			,_cls_entries = 'il-metabar-entries'
+			,_cls_entries = 'il-maincontrols-metabar'
 			,_cls_slates = 'il-metabar-slates'
 			,_cls_more_btn = 'il-metabar-more-button'
 			,_cls_more_slate = 'il-metabar-more-slate'

--- a/src/UI/templates/js/MainControls/metabar.js
+++ b/src/UI/templates/js/MainControls/metabar.js
@@ -85,7 +85,7 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 			return btn.hasClass(_cls_btn_engaged);
 		};
 		var _disengageAllButtons = function() {
-			$('#' + id +' .' + _cls_entries)
+			$('#' + id +'.' + _cls_entries)
 			.children('li').children('.btn.' + _cls_btn_engaged)
 			.each(
 				function(i, btn) {
@@ -140,7 +140,7 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 
 		var _tagMoreButton = function() {
 			if(_getMoreButton().length === 0) {
-				var entries = $('#' + id +' .' + _cls_entries).find('.btn'),
+				var entries = $('#' + id +'.' + _cls_entries).find('.btn'),
 					more = entries.last();
 				$(more).addClass(_cls_more_btn);
 			}
@@ -163,7 +163,7 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 		}
 
 		var _getMetabarEntries = function() {
-			return $('#' + id +' .' + _cls_entries)
+			return $('#' + id +'.' + _cls_entries)
 				.children('li').children('.btn')
 				.not('.' + _cls_more_btn);
 		}

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -8991,6 +8991,9 @@ div.il-system-infos {
   align-items: flex-end;
   padding-left: 35px;
 }
+.il-header-locator {
+  display: none;
+}
 nav.il-maincontrols {
   -ms-grid-column: 1;
   -ms-grid-row: 4;
@@ -9192,6 +9195,9 @@ footer {
   }
   .breadcrumbs {
     display: none;
+  }
+  .il-header-locator {
+    display: block;
   }
   .il-header-locator .dropdown {
     position: static;
@@ -9510,15 +9516,11 @@ footer {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  list-style-type: none;
+  /* Remove bullets */
 }
-.il-maincontrols-metabar .il-metabar-entries {
-  align-items: center;
-  display: flex;
-  height: 60px;
-}
-.il-maincontrols-metabar .il-metabar-entries .il-metabar-entry,
-.il-maincontrols-metabar .il-metabar-entries .il-logout {
-  padding-left: 10px;
+.il-maincontrols-metabar > li > .btn-bulky > .bulky-label {
+  display: none;
 }
 .il-maincontrols-metabar .glyphicon {
   filter: invert(50%);
@@ -9536,76 +9538,75 @@ footer {
 .il-maincontrols-metabar form#mm_search_form {
   padding: 20px;
 }
-.il-maincontrols-metabar .bulky-label {
-  white-space: normal;
-  margin-top: 5px;
-  display: block;
-}
-.il-metabar-entries {
-  list-style-type: none;
-  /* Remove bullets */
-}
-.il-metabar-entries .badge {
+.il-maincontrols-metabar .badge {
   position: absolute;
 }
-.il-metabar-entries .btn {
+.il-maincontrols-metabar .btn {
   position: relative;
 }
-.il-metabar-entries .il-counter-novelty {
+.il-maincontrols-metabar .il-counter-novelty {
   margin-top: 0;
   top: 17px;
 }
-.il-metabar-entries .il-counter-status {
+.il-maincontrols-metabar .il-counter-status {
   margin-top: 0;
   top: 32px;
 }
-.il-metabar-entries > li > .btn-bulky > .bulky-label {
-  display: none;
-}
-.il-metabar-entries .btn-bulky {
+.il-maincontrols-metabar .btn-bulky {
   background-color: transparent;
   height: 60px;
   min-width: 60px;
 }
 @media only screen and (max-width: 768px) {
-  .il-metabar-entries .btn-bulky {
+  .il-maincontrols-metabar .btn-bulky {
     height: 45px;
     min-width: 45px;
   }
 }
-.il-metabar-entries .btn-bulky:focus,
-.il-metabar-entries .btn-bulky:active {
+.il-maincontrols-metabar .btn-bulky:focus,
+.il-maincontrols-metabar .btn-bulky:active {
   box-shadow: none;
 }
-.il-metabar-entries .btn-bulky.engaged {
+.il-maincontrols-metabar .btn-bulky.engaged {
   box-shadow: 1px 3px 4px rgba(0, 0, 0, 0.1);
   background-color: #fafafa;
   border: none;
   color: initial;
   outline-color: transparent;
 }
-.il-metabar-entries .btn-bulky .glyphicon {
+.il-maincontrols-metabar .btn-bulky .glyphicon {
   color: #757575;
   font-size: 2.3rem;
 }
+.il-maincontrols-metabar .bulky-label {
+  white-space: normal;
+  margin-top: 5px;
+  display: block;
+}
 @media only screen and (max-width: 768px) {
-  .il-metabar-entries .il-metabar-more-button {
+  .il-maincontrols-metabar .il-counter-novelty {
+    top: 7px;
+  }
+  .il-maincontrols-metabar .il-counter-status {
+    top: 22px;
+  }
+  .il-maincontrols-metabar .il-metabar-more-button {
     padding-right: 20px;
   }
-  .il-metabar-entries .il-metabar-more-button .icon.custom {
+  .il-maincontrols-metabar .il-metabar-more-button .icon.custom {
     position: relative;
   }
-  .il-metabar-entries .il-metabar-more-button .icon.custom img {
+  .il-maincontrols-metabar .il-metabar-more-button .icon.custom img {
     margin-right: 5px;
   }
-  .il-metabar-entries .il-metabar-more-button .icon.custom .badge {
+  .il-maincontrols-metabar .il-metabar-more-button .icon.custom .badge {
     position: absolute;
     margin-right: 3px;
   }
-  .il-metabar-entries .il-metabar-more-button .icon.custom .badge.il-counter-novelty {
+  .il-maincontrols-metabar .il-metabar-more-button .icon.custom .badge.il-counter-novelty {
     margin-top: -5px;
   }
-  .il-metabar-entries .il-metabar-more-button .icon.custom .badge.il-counter-status {
+  .il-maincontrols-metabar .il-metabar-more-button .icon.custom .badge.il-counter-status {
     margin-top: 10px;
   }
 }
@@ -9618,8 +9619,6 @@ footer {
   overflow-y: auto;
   right: 0;
   top: 60px;
-  /*TODO: remove hack*/
-  /*end of hack*/
 }
 .il-metabar-slates .il-maincontrols-slate {
   min-width: 500px;
@@ -9629,25 +9628,6 @@ footer {
     width: 100%;
     top: 45px;
     right: 0;
-  }
-}
-@media only screen and (max-width: 768px) {
-  .il-metabar-slates .il-maincontrols-slate {
-    min-width: 260px;
-  }
-}
-.il-header-locator {
-  display: none;
-}
-@media only screen and (max-width: 768px) {
-  .il-header-locator {
-    display: block;
-  }
-  .il-metabar-entries .il-counter-novelty {
-    top: 7px;
-  }
-  .il-metabar-entries .il-counter-status {
-    top: 22px;
   }
   .il-metabar-slates .glyphicon {
     color: #757575;
@@ -9664,7 +9644,7 @@ footer {
   .il-metabar-slates .il-counter-spacer {
     margin-left: -18px;
   }
-  .il-metabar-more-slate .btn-bulky:after {
+  .il-metabar-slates .il-metabar-more-slate .btn-bulky:after {
     content: "\e606";
     font-family: "il-icons";
     font-size: 1.7rem;
@@ -9672,8 +9652,10 @@ footer {
     right: 10px;
     top: 20px;
   }
+  .il-metabar-slates .il-maincontrols-slate {
+    min-width: 260px;
+  }
 }
-/*end of hack*/
 .il-maincontrols-mainbar .btn-bulky,
 .il-maincontrols-metabar .btn-bulky,
 .il-maincontrols-mainbar .link-bulky,

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -9541,6 +9541,10 @@ footer {
   margin-top: 5px;
   display: block;
 }
+.il-metabar-entries {
+  list-style-type: none;
+  /* Remove bullets */
+}
 .il-metabar-entries .badge {
   position: absolute;
 }
@@ -9555,7 +9559,7 @@ footer {
   margin-top: 0;
   top: 32px;
 }
-.il-metabar-entries > .btn-bulky > .bulky-label {
+.il-metabar-entries > li > .btn-bulky > .bulky-label {
   display: none;
 }
 .il-metabar-entries .btn-bulky {

--- a/tests/UI/Component/MainControls/MetaBarTest.php
+++ b/tests/UI/Component/MainControls/MetaBarTest.php
@@ -119,6 +119,7 @@ class MetaBarTest extends ILIAS_UI_TestBase
         $html = str_replace(["\n", "\r", "\t"], "", $html);
         $html = preg_replace('# {2,}#', " ", $html);
         $html = preg_replace('/<!--(.|\s)*?-->/', '', $html);
+        $html = str_replace('> <', '><', $html);
         return trim($html);
     }
 
@@ -134,37 +135,37 @@ class MetaBarTest extends ILIAS_UI_TestBase
 
         $html = $r->render($mb);
 
-        $expected = <<<EOT
-<div class="il-maincontrols-metabar" id="id_5" role="menubar" aria-label="metabar_aria_label">
-	<div class="il-metabar-entries" style="visibility: hidden">
-		<button class="btn btn-bulky" data-action="#" id="id_1" role="menuitem" >
-			<img class="icon custom small" src="" alt=""/>
-			<span class="bulky-label">TestEntry</span>
-		</button>
-		<button class="btn btn-bulky" data-action="#" id="id_2" role="menuitem" >
-			<img class="icon custom small" src="" alt=""/>
-			<span class="bulky-label">TestEntry</span>
-		</button>
-		<button class="btn btn-bulky" id="id_3" role="menuitem" aria-haspopup="true" >
-			<span class="glyph" aria-label="disclose">
-				<span class="glyphicon glyphicon-option-vertical" aria-hidden="true"></span>
-				<span class="il-counter">
-					<span class="badge badge-notify il-counter-status" style="display:none">0</span>
-				</span>
-				<span class="il-counter">
-					<span class="badge badge-notify il-counter-novelty" style="display:none">0</span>
-				</span>
-			</span>
-			<span class="bulky-label">more</span>
-		</button>
-	</div>
-	<div class="il-metabar-slates">
-		<div class="il-maincontrols-slate disengaged" id="id_4" role="menu">
-			<div class="il-maincontrols-slate-content" data-replace-marker="content"></div>
-		</div>
-	</div>
-</div>
-EOT;
+        $expected = '
+<nav class="il-maincontrols-metabar" id="id_5" aria-label="metabar_aria_label">
+   <ul class="il-metabar-entries" role="menubar" style="visibility: hidden">
+      <li role="none">
+        <button class="btn btn-bulky" data-action="#" id="id_1" role="menuitem" >
+            <img class="icon custom small" src="" alt=""/><span class="bulky-label">TestEntry</span>
+        </button>
+      </li>
+      <li role="none">
+        <button class="btn btn-bulky" data-action="#" id="id_2" role="menuitem" >
+            <img class="icon custom small" src="" alt=""/><span class="bulky-label">TestEntry</span>
+        </button>
+      </li>
+      <li role="none">
+         <button class="btn btn-bulky" id="id_3" role="menuitem" aria-haspopup="true" >
+             <span class="glyph" aria-label="disclose">
+                <span class="glyphicon glyphicon-option-vertical" aria-hidden="true"></span>
+                <span class="il-counter"><span class="badge badge-notify il-counter-status" style="display:none">0</span></span>
+                <span class="il-counter"><span class="badge badge-notify il-counter-novelty" style="display:none">0</span></span>
+             </span>
+             <span class="bulky-label">more</span>
+         </button>
+         <div class="il-metabar-slates">
+            <div class="il-maincontrols-slate disengaged" id="id_4" role="menu">
+               <div class="il-maincontrols-slate-content" data-replace-marker="content"></div>
+            </div>
+         </div>
+      </li>
+   </ul>
+</nav>
+';
 
         $this->assertEquals(
             $this->brutallyTrimHTML($expected),

--- a/tests/UI/Component/MainControls/MetaBarTest.php
+++ b/tests/UI/Component/MainControls/MetaBarTest.php
@@ -136,7 +136,7 @@ class MetaBarTest extends ILIAS_UI_TestBase
         $html = $r->render($mb);
 
         $expected = '
-   <ul class="il-maincontrols-metabar il-metabar-entries" role="menubar" style="visibility: hidden" aria-label="metabar_aria_label" id="id_5" >
+   <ul class="il-maincontrols-metabar" role="menubar" style="visibility: hidden" aria-label="metabar_aria_label" id="id_5" >
       <li role="none">
         <button class="btn btn-bulky" data-action="#" id="id_1" role="menuitem" >
             <img class="icon custom small" src="" alt=""/><span class="bulky-label">TestEntry</span>

--- a/tests/UI/Component/MainControls/MetaBarTest.php
+++ b/tests/UI/Component/MainControls/MetaBarTest.php
@@ -136,8 +136,7 @@ class MetaBarTest extends ILIAS_UI_TestBase
         $html = $r->render($mb);
 
         $expected = '
-<nav class="il-maincontrols-metabar" id="id_5" aria-label="metabar_aria_label">
-   <ul class="il-metabar-entries" role="menubar" style="visibility: hidden">
+   <ul class="il-maincontrols-metabar il-metabar-entries" role="menubar" style="visibility: hidden" aria-label="metabar_aria_label" id="id_5" >
       <li role="none">
         <button class="btn btn-bulky" data-action="#" id="id_1" role="menuitem" >
             <img class="icon custom small" src="" alt=""/><span class="bulky-label">TestEntry</span>
@@ -164,7 +163,6 @@ class MetaBarTest extends ILIAS_UI_TestBase
          </div>
       </li>
    </ul>
-</nav>
 ';
 
         $this->assertEquals(


### PR DESCRIPTION
Currently we have issues with the Tabbing order in the Meta Bar, see: https://mantis.ilias.de/view.php?id=29717 and https://mantis.ilias.de/view.php?id=28735 . They are caused by the order of the html elements in the DOM. A similar thing is going on in the Main Bar. However, while the solution for the Main Bar is not clear and not easily changeable (e.g. due to the responsive view). A nested solution is possible for the Meta Bar, which is provided here.

I tried to implement as closely to the WCAG example as possible, see: https://www.w3.org/TR/wai-aria-practices/examples/menubar/menubar-1/menubar-1.html . Maybe I missed some point, if so point me to them ;-). Not that I did NOT change the content of the Slate. The structure now looks as follows (some attributes are left out, see the provided rendering test for more detail):

```
<nav class="il-maincontrols-metabar" aria-label="Metaleiste">
   <ul class="il-metabar-entries" role="menubar">
      <li role="none">
        <button class="btn btn-bulky" role="menuitem" ></button>
        SlateWithContent
      </li>
      <li role="none">
        <button class="btn btn-bulky" role="menuitem" ></button>
        SlateWithContent
      </li>
     ....
   </ul>
</nav>
```


This means, that the tabbing order is now as requested in the ticket (jumping inside the slates when opened).

There should be no visual change or any change in behavior while operating with the mouse on large and small displays.