### PR TITLE
Revert "UI/CombinedSlate: Add optional entry id for menu sub entries (ILIAS 6)"

### DIFF
--- a/src/GlobalScreen/Scope/MainMenu/Collector/Renderer/TopParentItemRenderer.php
+++ b/src/GlobalScreen/Scope/MainMenu/Collector/Renderer/TopParentItemRenderer.php
@@ -31,7 +31,7 @@ class TopParentItemRenderer extends BaseTypeRenderer
         foreach ($item->getChildren() as $child) {
             $component = $child->getTypeInformation()->getRenderer()->getComponentForItem($child, false);
             if ($this->isComponentSupportedForCombinedSlate($component)) {
-                $slate = $slate->withAdditionalEntry($component, $this->hash($child->getProviderIdentification()->serialize()));
+                $slate = $slate->withAdditionalEntry($component);
             }
         }
 

--- a/src/UI/Component/MainControls/Slate/Combined.php
+++ b/src/UI/Component/MainControls/Slate/Combined.php
@@ -5,7 +5,6 @@
 namespace ILIAS\UI\Component\MainControls\Slate;
 
 use ILIAS\UI\Component\Divider\Horizontal;
-use ILIAS\UI\Component\Link\Bulky;
 
 /**
  * This describes the Combined Slate
@@ -15,5 +14,5 @@ interface Combined extends Slate
     /**
      * @param Slate|Bulky|Horizontal $entry
      */
-    public function withAdditionalEntry($entry, ?string $id = null) : Combined;
+    public function withAdditionalEntry($entry) : Combined;
 }

--- a/src/UI/Implementation/Component/MainControls/Slate/Combined.php
+++ b/src/UI/Implementation/Component/MainControls/Slate/Combined.php
@@ -11,7 +11,6 @@ use ILIAS\UI\Component\MainControls\Slate as ISlate;
 use ILIAS\UI\Component\Button\Bulky as IBulkyButton;
 use ILIAS\UI\Component\Link\Bulky as IBulkyLink;
 use ILIAS\UI\Component\Signal;
-use InvalidArgumentException;
 
 /**
  * Combined Slate
@@ -21,14 +20,14 @@ class Combined extends Slate implements ISlate\Combined
     const ENTRY_ACTION_TRIGGER = 'trigger';
 
     /**
-     * @var array<Slate|IBulkyButton|IBulkyLink>
+     * @var array<Slate|BulkyButton|BulkyLink>
      */
     protected $contents = [];
 
     /**
      * @inheritdoc
      */
-    public function withAdditionalEntry($entry, ?string $id = null) : ISlate\Combined
+    public function withAdditionalEntry($entry) : ISlate\Combined
     {
         $classes = [
             IBulkyButton::class,
@@ -40,16 +39,7 @@ class Combined extends Slate implements ISlate\Combined
         $this->checkArgListElements("Slate, Bulky -Button or -Link", $check, $classes);
 
         $clone = clone $this;
-        if ($id) {
-            if (key_exists($id, $clone->contents)) {
-                throw new InvalidArgumentException(
-                    "Identifier $id already exists in component " . $clone->getName())
-                ;
-            }
-            $clone->contents[$id] = $entry;
-        } else {
-            $clone->contents[] = $entry;
-        }
+        $clone->contents[] = $entry;
         return $clone;
     }
 

--- a/tests/UI/Component/MainControls/Slate/CombinedSlateTest.php
+++ b/tests/UI/Component/MainControls/Slate/CombinedSlateTest.php
@@ -161,34 +161,4 @@ EOT;
             $this->brutallyTrimHTML($html)
         );
     }
-
-    public function testIdWithSubslate()
-    {
-        $identifier = 'test_identifier';
-        $name = 'name';
-        $icon = $this->icon_factory->custom('', '');
-        $subslate = new Combined($this->sig_gen, $name, $icon);
-        $slate = new Combined($this->sig_gen, $name, $icon);
-        $slate = $slate->withAdditionalEntry($subslate, $identifier);
-
-        $this->assertArrayHasKey($identifier, $slate->getContents());
-    }
-
-    public function testIdsWithSubslate()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Identifier test_identifier already exists in component name');
-
-        $identifier = 'test_identifier';
-        $name = 'name';
-        $name1 = 'name1';
-        $name2 = 'name2';
-        $icon = $this->icon_factory->custom('', '');
-        $subslate1 = new Combined($this->sig_gen, $name1, $icon);
-        $subslate2 = new Combined($this->sig_gen, $name2, $icon);
-        $slate = new Combined($this->sig_gen, $name, $icon);
-        $slate
-            ->withAdditionalEntry($subslate1, $identifier)
-            ->withAdditionalEntry($subslate2, $identifier);
-    }
 }


### PR DESCRIPTION
Reverts ILIAS-eLearning/ILIAS#3278

The changes seem to have major impact on the length of mainbar-cookie, since enumaration is now supecseeded by longish globalscreen-ids. We reverted changes for now, an will have to think about better/other/bypassing solutions.

please see: https://mantis.ilias.de/view.php?id=30638