### PR TITLE
UI Components, Custom Aria Label for Glyphs: See #28930

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -16301,6 +16301,7 @@ common#:#eyeclosed#:#Geschlossenes Auge - Klicken um den Inhalt des Eingabefelds
 common#:#eyeopen#:#Geöffnetes Auge - Klicken um den Inhalt des Eingabefelds aufzuzeigen
 common#:#show_more#:#Mehr zeigen
 common#:#disclose#:#Aufdecken
+common#:#disclose_cross_sectional_services#:#Zeige Benutzerprofil und Querschnittsdienste
 common#:#switch_language#:#Sprache wechseln
 lti#:#lti_user_role_created#:#Die empfohlene globale Rolle für LTI-User wurde angelegt.
 lti#:#lti_create_lti_user_role#:#Empfohlene globale Rolle für LTI-User anlegen

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -16303,6 +16303,7 @@ common#:#eyeclosed#:#Eye Closed - Click to hide the input's contents
 common#:#eyeopened#:#Eye Open - Click to reveal the input's contents
 common#:#show_more#:#Show More
 common#:#disclose#:#Disclose
+common#:#disclose_cross_sectional_services#:#Disclose profile and cross-sectional services
 common#:#switch_language#:#Switch Language
 lti#:#lti_user_role_created#:#The recommended global role for LTI users has been created.
 lti#:#lti_create_lti_user_role#:#Create recommended global role for LTI users

--- a/src/UI/Component/Symbol/Factory.php
+++ b/src/UI/Component/Symbol/Factory.php
@@ -97,6 +97,9 @@ interface Factory
      *       1: >
      *          The functionality triggered by the Glyph MUST be indicated to
      *          screen readers with the attributes aria-label or aria-labelledby.
+     *       2: >
+     *          The default aria-label MAY be replaced by a custom label, if the default does
+     *          not sufficiently describe the purpose of the glyph in a given context.
      * ---
      * @return  \ILIAS\UI\Component\Symbol\Glyph\Factory
      */

--- a/src/UI/Component/Symbol/Glyph/Factory.php
+++ b/src/UI/Component/Symbol/Glyph/Factory.php
@@ -19,17 +19,16 @@ interface Factory
      *       The Settings Glyph uses the glyphicon-cog.
      *   effect: >
      *      Upon clicking, a settings Dropdown is opened.
-     *
      * context:
      *    - In ILIAS <5.4, blocks on the Personal Desktop feature the Settings Glyph.
-     *
      * rules:
      *   usage:
      *       1: >
      *          The Settings Glyph MUST only be used in Blocks.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be “Settings”.
+     *          The aria-label MUST be “Settings” or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -57,7 +56,8 @@ interface Factory
      *          The Collapse Glyph MUST indicate if the toggled Container Collection is visible or not.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be ‘Collapse Content'.
+     *          The aria-label MUST be ‘Collapse Content' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -85,7 +85,8 @@ interface Factory
      *          The Expand Glyph MUST indicate if the toggled Container Collection is visible or not.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be ‘Expand Content'.
+     *          The aria-label MUST be ‘Expand Content' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -121,7 +122,8 @@ interface Factory
      *       1: Newly added items MUST be placed below the line in which the Add Glyph has been clicked
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be ‘Add'.
+     *          The aria-label MUST be ‘Add' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -155,7 +157,8 @@ interface Factory
      *       3: The Remove Glyph MUST NOT be used to add lines to tables.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be ‘Remove'.
+     *          The aria-label MUST be ‘Remove' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return 	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -192,7 +195,8 @@ interface Factory
      *          column of a form.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be ‘Up'.
+     *          The aria-label MUST be ‘Up' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -229,7 +233,8 @@ interface Factory
      *          column of a form.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be ‘Down'.
+     *          The aria-label MUST be ‘Down' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -260,7 +265,8 @@ interface Factory
      *          If clicking on the Back/Next GLYPH opens a previous view of an object, the Back Glyph MUST be used.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be ‘Back'.
+     *          The aria-label MUST be ‘Back' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return 	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -290,7 +296,8 @@ interface Factory
      *          If clicking on the Back/Next GLYPH opens a previous view of an object, the Back Glyph MUST be used.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be ‘Next'.
+     *          The aria-label MUST be ‘Next' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return 	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -311,7 +318,8 @@ interface Factory
      * rules:
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be ‘Sort Ascending'.
+     *          The aria-label MUST be ‘Sort Ascending' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return 	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -332,7 +340,8 @@ interface Factory
      * rules:
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be ‘Sort Descending'.
+     *          The aria-label MUST be ‘Sort Descending' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return 	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -352,7 +361,8 @@ interface Factory
      * rules:
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be ‘Background Tasks'.
+     *          The aria-label MUST be ‘Background Tasks' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return 	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -374,7 +384,8 @@ interface Factory
      * rules:
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be ‘Show who is online'.
+     *          The aria-label MUST be ‘Show who is online' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return 	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -396,7 +407,8 @@ interface Factory
      * rules:
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be ‘Mail'.
+     *          The aria-label MUST be ‘Mail' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return 	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -417,7 +429,8 @@ interface Factory
      * rules:
      *   accessibility:
      *       2: >
-     *          The aria-label MUST be "Notifications".
+     *          The aria-label MUST be "Notifications" or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return 	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -440,7 +453,8 @@ interface Factory
      *          Novelty and Status Counter MUST show the amount of tags that have been added to a specific object.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be ‘Tags'.
+     *          The aria-label MUST be ‘Tags' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -463,7 +477,8 @@ interface Factory
      *          Novelty and Status Counter MUST show the amount of notes that have been added to a specific object.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be ‘Notes'.
+     *          The aria-label MUST be ‘Notes' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -486,7 +501,8 @@ interface Factory
      *          Novelty and Status Counter MUST show the amount of comments that have been added to a specific object.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be ‘Comments'.
+     *          The aria-label MUST be ‘Comments' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -512,7 +528,8 @@ interface Factory
      *          A Status Counter MUST indicate the overall amount of like expressions.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be 'Like'.
+     *          The aria-label MUST be 'Like' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -538,7 +555,8 @@ interface Factory
      *          A Status Counter MUST indicate the overall amount of love expressions.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be 'Love'.
+     *          The aria-label MUST be 'Love' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -564,7 +582,8 @@ interface Factory
      *          A Status Counter MUST indicate the overall amount of dislike expressions.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be 'Dislike'.
+     *          The aria-label MUST be 'Dislike' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -590,7 +609,8 @@ interface Factory
      *          A Status Counter MUST indicate the overall amount of laugh expressions.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be 'Laugh'.
+     *          The aria-label MUST be 'Laugh' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -616,7 +636,8 @@ interface Factory
      *          A Status Counter MUST indicate the overall amount of astounded expressions.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be 'Astounded'.
+     *          The aria-label MUST be 'Astounded' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -642,7 +663,8 @@ interface Factory
      *          A Status Counter MUST indicate the overall amount of sad expressions.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be 'Sad'.
+     *          The aria-label MUST be 'Sad' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -668,7 +690,8 @@ interface Factory
      *          A Status Counter MUST indicate the overall amount of angry expressions.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be 'Angry'.
+     *          The aria-label MUST be 'Angry' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -696,7 +719,8 @@ interface Factory
      *          The Eye Closed Glyph MUST only be used with Password-Inputs.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be "Eye Closed - Click to hide the input's contents".
+     *          The aria-label MUST be "Eye Closed - Click to hide the input's contents" or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -723,7 +747,8 @@ interface Factory
      *          The Eye Open Glyph MUST only be used with Password-Inputs.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be "Eye Opened - Click to reveal the input's contents".
+     *          The aria-label MUST be "Eye Opened - Click to reveal the input's contents" or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -749,7 +774,8 @@ interface Factory
      *          A Status Counter MAY indicate the overall amount of attachments.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be 'Attachment'.
+     *          The aria-label MUST be 'Attachment' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param string|null	$action
      * @return \ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -783,7 +809,8 @@ interface Factory
      *          greying out the Reset Glyph.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be 'Reset'.
+     *          The aria-label MUST be 'Reset' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param string|null	$action
      * @return \ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -817,7 +844,8 @@ interface Factory
      *          the Apply Glyph.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be 'Apply'.
+     *          The aria-label MUST be 'Apply' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param string|null	$action
      * @return \ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -842,7 +870,8 @@ interface Factory
      * rules:
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be 'Search'.
+     *          The aria-label MUST be 'Search' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -868,7 +897,8 @@ interface Factory
      * rules:
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be 'Help'.
+     *          The aria-label MUST be 'Help' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -891,7 +921,8 @@ interface Factory
      * rules:
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be 'Calendar'.
+     *          The aria-label MUST be 'Calendar' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param string|null	$action
      * @return \ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -914,7 +945,8 @@ interface Factory
      * rules:
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be 'Time'.
+     *          The aria-label MUST be 'Time' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param string|null	$action
      * @return \ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -935,7 +967,8 @@ interface Factory
      * rules:
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be 'Close'.
+     *          The aria-label MUST be 'Close' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param string|null	$action
      * @return \ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -993,7 +1026,8 @@ interface Factory
      *          from the Disclose Glyph.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be 'Show More'.
+     *          The aria-label MUST be 'Show More' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param string|null	$action
      * @return \ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -1049,7 +1083,8 @@ interface Factory
      *          also have a visual similarity, which can be distinguished from the More Glyph.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be „Disclose“.
+     *          The aria-label MUST be „Disclose“ or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param string|null	$action
      * @return \ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -1080,7 +1115,8 @@ interface Factory
      * rules:
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be 'Switch Language'.
+     *          The aria-label MUST be 'Switch Language' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -1110,7 +1146,8 @@ interface Factory
      *       1: The Login Glyph MUST be placed on the very top right.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be 'Login'.
+     *          The aria-label MUST be 'Login' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -1138,7 +1175,8 @@ interface Factory
      *       1: The Logout Glyph MUST be displayed if the user is logged in.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be 'Logout'.
+     *          The aria-label MUST be 'Logout' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -1164,7 +1202,8 @@ interface Factory
      * rules:
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be 'Bullet Point List'.
+     *          The aria-label MUST be 'Bullet Point List' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -1193,7 +1232,8 @@ interface Factory
      *       1: The Logout Glyph MUST be displayed if the user is logged in.
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be 'Numbered List'.
+     *          The aria-label MUST be 'Numbered List' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -1220,7 +1260,8 @@ interface Factory
      * rules:
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be 'Increase Indent'.
+     *          The aria-label MUST be 'Increase Indent' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -1246,7 +1287,8 @@ interface Factory
      * rules:
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be 'Decrease Indent'.
+     *          The aria-label MUST be 'Decrease Indent' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph
@@ -1271,7 +1313,8 @@ interface Factory
      * rules:
      *   accessibility:
      *       1: >
-     *          The aria-label MUST be 'Filter'.
+     *          The aria-label MUST be 'Filter' or some wording describing the purpose of the glyph
+     *          even better.
      * ---
      * @param	string|null	$action
      * @return	\ILIAS\UI\Component\Symbol\Glyph\Glyph

--- a/src/UI/Component/Symbol/Glyph/Glyph.php
+++ b/src/UI/Component/Symbol/Glyph/Glyph.php
@@ -131,4 +131,13 @@ interface Glyph extends \ILIAS\UI\Component\Symbol\Symbol, Clickable
     * @return mixed
     */
     public function withAction($action);
+
+    /**
+     * Get a Glyph like this, but with a custom aria label. Such label are necessary if the default label
+     * does not describe the function of the label in a given context.
+     *
+     * @param string $label
+     * @return mixed
+     */
+    public function withAriaLabel(string $label);
 }

--- a/src/UI/Implementation/Component/MainControls/Renderer.php
+++ b/src/UI/Implementation/Component/MainControls/Renderer.php
@@ -230,7 +230,7 @@ class Renderer extends AbstractComponentRenderer
         $entries = $component->getEntries();
 
         $more_label = 'more';
-        $more_symbol = $f->symbol()->glyph()->disclosure()
+        $more_symbol = $f->symbol()->glyph()->disclosure()->withAriaLabel("disclose_cross_sectional_services")
             ->withCounter($f->counter()->novelty(0))
             ->withCounter($f->counter()->status(0));
         /**

--- a/src/UI/Implementation/Component/Symbol/Glyph/Glyph.php
+++ b/src/UI/Implementation/Component/Symbol/Glyph/Glyph.php
@@ -121,6 +121,17 @@ class Glyph implements C\Symbol\Glyph\Glyph
     {
         return $this->type;
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function withAriaLabel(string $label)
+    {
+        $clone = clone $this;
+        $clone->aria_label = $label;
+        return $clone;
+    }
+
     /**
      * @inheritdoc
      */

--- a/tests/UI/Component/MainControls/MetaBarTest.php
+++ b/tests/UI/Component/MainControls/MetaBarTest.php
@@ -146,7 +146,7 @@ class MetaBarTest extends ILIAS_UI_TestBase
 			<span class="bulky-label">TestEntry</span>
 		</button>
 		<button class="btn btn-bulky" id="id_3" role="menuitem" aria-haspopup="true" >
-			<span class="glyph" aria-label="disclose">
+			<span class="glyph" aria-label="disclose_cross_sectional_services">
 				<span class="glyphicon glyphicon-option-vertical" aria-hidden="true"></span>
 				<span class="il-counter">
 					<span class="badge badge-notify il-counter-status" style="display:none">0</span>

--- a/tests/UI/Component/Symbol/Glyph/GlyphTest.php
+++ b/tests/UI/Component/Symbol/Glyph/GlyphTest.php
@@ -192,6 +192,14 @@ class GlyphTest extends ILIAS_UI_TestBase
         $this->assertTrue($g2->isHighlighted());
     }
 
+    public function test_with_custom_aria()
+    {
+        $gf = $this->getGlyphFactory();
+        $g = $gf->more();
+        $this->assertEquals("show_more",$g->getAriaLabel());
+        $this->assertEquals("Some Custom Label",$g->withAriaLabel("Some Custom Label")->getAriaLabel());
+    }
+
     /**
      * @dataProvider glyph_type_provider
      */

--- a/tests/UI/Component/Symbol/Glyph/GlyphTest.php
+++ b/tests/UI/Component/Symbol/Glyph/GlyphTest.php
@@ -196,8 +196,8 @@ class GlyphTest extends ILIAS_UI_TestBase
     {
         $gf = $this->getGlyphFactory();
         $g = $gf->more();
-        $this->assertEquals("show_more",$g->getAriaLabel());
-        $this->assertEquals("Some Custom Label",$g->withAriaLabel("Some Custom Label")->getAriaLabel());
+        $this->assertEquals("show_more", $g->getAriaLabel());
+        $this->assertEquals("Some Custom Label", $g->withAriaLabel("Some Custom Label")->getAriaLabel());
     }
 
     /**


### PR DESCRIPTION
This PR proposes a fix for: https://mantis.ilias.de/view.php?id=28930

Main insight from the report is, that glyph need to be a bit more flexible in the way devs can set aria-labels. There are situation, where the label needs to have a more context driven label than the one that was derived as default from the purpose description. 