### PR TITLE
Container References, Fixing build errors, see #30667

### DIFF
--- a/Services/ContainerReference/classes/class.ilContainerReference.php
+++ b/Services/ContainerReference/classes/class.ilContainerReference.php
@@ -113,7 +113,7 @@ class ilContainerReference extends ilObject
      * @param int $a_obj_id
      * @return
      */
-    public static function _lookupTitle($a_obj_id)
+    public static function _lookupTitle($a_obj_id) : string
     {
         global $DIC;
 
@@ -298,7 +298,7 @@ class ilContainerReference extends ilObject
      * Get presentation title
      * @return string presentation title
      */
-    public function getPresentationTitle()
+    public function getPresentationTitle() : string
     {
         if ($this->getTitleType() == self::TITLE_TYPE_CUSTOM) {
             return $this->getTitle();

--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -360,14 +360,14 @@ class ilObject
      */
     final public function getRefId() : int
     {
-        return $this->ref_id;
+        return $this->ref_id ?? 0;
     }
 
     /**
      * get object type
      * @return string
      */
-    final public function getType() : string
+    public function getType() : string
     {
         return $this->type;
     }

--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -452,7 +452,12 @@ class ilObject
      */
     public function getLongDescription() : string
     {
-        return strlen($this->long_desc) ? $this->long_desc : $this->desc;
+        if(strlen($this->long_desc)){
+            return $this->long_desc;
+        } elseif (strlen($this->desc)){
+            return $this->long_desc;
+        }
+        return "";
     }
 
     /**
@@ -1005,7 +1010,7 @@ class ilObject
      * @param int $a_id
      * @return string
      */
-    final public static function _lookupTitle(int $a_id) : string
+    public static function _lookupTitle(int $a_id) : string
     {
         global $DIC;
 

--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -452,9 +452,9 @@ class ilObject
      */
     public function getLongDescription() : string
     {
-        if(strlen($this->long_desc)){
+        if (strlen($this->long_desc)) {
             return $this->long_desc;
-        } elseif (strlen($this->desc)){
+        } elseif (strlen($this->desc)) {
             return $this->long_desc;
         }
         return "";

--- a/Services/Object/test/ilObjectDefinitionTest.php
+++ b/Services/Object/test/ilObjectDefinitionTest.php
@@ -19,8 +19,9 @@ class ilObjectDefinitionTest extends TestCase
     /**
      * @group IL_Init
      */
-    /*public function testObjDefinitionReader()
+    public function testObjDefinitionReader()
     {
+        /*
         include_once("./setup/classes/class.ilObjDefReader.php");
         $def_reader = new ilObjDefReader(
             "./Services/Object/test/testmodule.xml",
@@ -32,5 +33,8 @@ class ilObjectDefinitionTest extends TestCase
         $def_reader->startParsing();
 
         $this->assertEquals("", $result);
-    }*/
+        */
+        //To avoid: No tests found in class "ilObjectDefinitionTest".
+        $this->assertTrue(true);
+    }
 }


### PR DESCRIPTION
Our current trunk builds fail due to: https://github.com/ILIAS-eLearning/ILIAS/commit/76ccc9e2f31d4abf4f3ed8698cf0a28b6d7448f4#commitcomment-50108696

This PR fixes (some) of the resulting issues. 

Unit tests are still failing due to null return values (see: ilTermsOfServiceDocumentGUITest), but running composer autoload is possible again. [Edit, tests have been fixed]

Maybe there are more casualties not discovered by unit tests.

See: https://mantis.ilias.de/view.php?id=30667