### PR TITLE
Object: Fix return type and incorrect value when requesting long desc…

### DIFF
--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -452,10 +452,10 @@ class ilObject
      */
     public function getLongDescription() : string
     {
-        if (strlen($this->long_desc)) {
+        if (is_string($this->long_desc) && strlen($this->long_desc)) {
             return $this->long_desc;
-        } elseif (strlen($this->desc)) {
-            return $this->long_desc;
+        } elseif (is_string($this->desc) && strlen($this->desc)) {
+            return $this->desc;
         }
         return "";
     }


### PR DESCRIPTION
…ription from an object

This is a fix of the fix @Amstutz provided some days ago. It returns the correct value if a long description is not available and ensures the correct return type as well.

Mantis Issue: https://mantis.ilias.de/view.php?id=30673