### PR TITLE
News: 30396 remove cat from check for use_news and news_timeline

### DIFF
--- a/Services/News/classes/class.ilNewsItem.php
+++ b/Services/News/classes/class.ilNewsItem.php
@@ -875,7 +875,7 @@ class ilNewsItem
 
         // get starting date
         $starting_date = "";
-        if ($obj_type == "grp" || $obj_type == "crs" || $obj_type == "cat") {
+        if ($obj_type == "grp" || $obj_type == "crs") {
             if (!ilContainer::_lookupContainerSetting(
                 $obj_id,
                 'cont_use_news',


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=30396

Hi Alex,

the class ilNewsItem currently checks for categories whether the timeline is switched on and whether the property 'cont_use_news' is set. For the category, however, only the property 'cont_show_news' is set. There is no timeline for categories. As a result, I removed the category from the check. The visibility of the news in the category is only controlled via the property 'cont_show_news'.

Best regards.