### PR TITLE
UI Component, Update Roadmap, removed Bootstrap Entry

### DIFF
--- a/src/UI/ROADMAP.md
+++ b/src/UI/ROADMAP.md
@@ -328,21 +328,6 @@ We need patterns or even a framework for client-side code that gives clear
 guidelines how interactive components should be build for the UI-framework and
 that integrates with the mechanism we use on the server-side to compose GUIs.
 
-
-### Introduce Bootstrap 4 and Create a System for SASS-Variables
-
-Currently ILIAS (and hence the UI-Framework) uses Bootstrap 3 as CSS-framework.
-In the meantime, [Bootstrap 4](https://getbootstrap.com/docs/4.0/getting-started/introduction/)
-was published. It comes with a new language for writing stylesheets (SASS) and
-a new system for its SASS-variables.
-
-The UI-Framework should switch to using Bootstrap 4. In this process, a system
-to use Bootraps new set of variables together with a possible set of special
-variables should be designed, documented and implemented. The switch to Bootstrap 4
-needs to be coordinated with the components of ILIAS that currently do use features
-of Bootstrap but do not use the UI-Framework.
-
-
 ### Page-Layout and ilTemplate, CSS/JS Header
 
 When rendering the whole page, all needed resources like CSS and JS must be included.


### PR DESCRIPTION
Removed an entry from the Roadmap. Bootstrap 4 is no longer a goal. See also: https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/src/UI/docu/sass-guidelines.md