### PR TITLE
UI/Mainbar, Accessibility: render as list, focus sub-slates

### DIFF
--- a/Modules/StudyProgramme/classes/class.ilStudyProgrammeDashboardViewGUI.php
+++ b/Modules/StudyProgramme/classes/class.ilStudyProgrammeDashboardViewGUI.php
@@ -84,7 +84,7 @@ class ilStudyProgrammeDashboardViewGUI
             krsort($assignments);
             /** @var ilStudyProgrammeAssignment $current */
             $current = current($assignments);
-            if (!$this->isReadable($current)) {
+            if (true || !$this->isReadable($current)) {
                 continue;
             }
 

--- a/Modules/StudyProgramme/classes/class.ilStudyProgrammeDashboardViewGUI.php
+++ b/Modules/StudyProgramme/classes/class.ilStudyProgrammeDashboardViewGUI.php
@@ -84,7 +84,7 @@ class ilStudyProgrammeDashboardViewGUI
             krsort($assignments);
             /** @var ilStudyProgrammeAssignment $current */
             $current = current($assignments);
-            if (true || !$this->isReadable($current)) {
+            if (!$this->isReadable($current)) {
                 continue;
             }
 

--- a/src/UI/Component/MainControls/Factory.php
+++ b/src/UI/Component/MainControls/Factory.php
@@ -206,6 +206,7 @@ interface Factory
      *     5: Bulky Buttons in the Main Bar MUST bear the "aria-haspopup" attribute.
      *     6: Bulky Buttons in the Main Bar MUST bear the ARIA role "menuitem".
      *     7: Slates in the Main Bar MUST bear the ARIA role "menu".
+     *     8: Top-Level entries of the Main Bar MUST be rendered as a listitems.
      * ----
      * @return  \ILIAS\UI\Component\MainControls\MainBar
      */

--- a/src/UI/ROADMAP.md
+++ b/src/UI/ROADMAP.md
@@ -234,8 +234,13 @@ The UI Inputs do not all have a rendering test.
 Add, where missing, and refine existing.
 
 ### Make date/time input accessible (advanced)
-
 Date/Time pickers are currently implemented using a third party library. The solution suffers from accessibility issues. Even native pickers seem not always to be easy accessible. See https://mantis.ilias.de/view.php?id=29816#bugnotes. We should evaluate different solutions to tackle this.
+
+### Remove wrapping DIVs in Mainbar
+Top items in the mainbar are wrapped in a <div class="il-mainbar-triggers">;
+We should get rid of this wrapper and have <ol>/<li> only for "menu-items",
+directly under the <nav>-tag.
+
 
 ## Long Term
 

--- a/src/UI/examples/Layout/Page/Standard/ui.php
+++ b/src/UI/examples/Layout/Page/Standard/ui.php
@@ -11,8 +11,11 @@ function ui()
     $renderer = $DIC->ui()->renderer();
 
     $url = 'src/UI/examples/Layout/Page/Standard/ui.php?new_ui=1';
-    $btn = $f->button()->standard('See UI in fullscreen-mode', $url);
-    return $renderer->render($btn);
+    $page_demo = $f->button()->primary('See UI in fullscreen-mode', $url);
+
+    return $renderer->render([
+        $page_demo
+    ]);
 }
 
 
@@ -51,11 +54,14 @@ if (isset($_GET['new_ui']) && $_GET['new_ui'] == '1') {
         'UI PAGE DEMO', //page title
         'ILIAS', //short title
         'Std. Page Demo' //view title
-    )->withModeInfo($f->mainControls()->modeInfo("Member View", new URI($_SERVER['HTTP_REFERER'])))
+    )
+        /*
+        ->withModeInfo($f->mainControls()->modeInfo("Member View", new URI($_SERVER['HTTP_REFERER'])))
         ->withSystemInfos(
             [$f->mainControls()->systemInfo('This is an neutral Message!', 'read it, understand it, dismiss it...')
                ->withDismissAction(new URI($_SERVER['HTTP_REFERER']))]
         )
+        */
     ->withUIDemo(true);
 
     echo $renderer->render($page);

--- a/src/UI/examples/Layout/Page/Standard/ui_mainbar.php
+++ b/src/UI/examples/Layout/Page/Standard/ui_mainbar.php
@@ -65,6 +65,22 @@ EOT;
             ->withAdditionalEntry('slate0', $slate0)
             ->withAdditionalEntry('slate1', $slate1);
 
+
+
+        $tools_btn = $f->button()->bulky(
+            $f->symbol()->icon()->custom('./src/UI/examples/Layout/Page/Standard/grid.svg', ''),
+            'Tools',
+            '#'
+        );
+        $mainbar = $mainbar->withToolsButton($tools_btn);
+
+        $symbol = $f->symbol()->icon()->custom('./src/UI/examples/Layout/Page/Standard/question.svg', '')->withSize('small');
+        $slate = $f->maincontrols()->slate()->legacy('Help', $symbol, $f->legacy('<h2>tool 1</h2><p>Some Text for Tool 1 entry</p>'));
+        $tools = ['tool1' => $slate];
+        foreach ($tools as $id => $entry) {
+            $mainbar = $mainbar->withAdditionalToolEntry($id, $entry);
+        }
+
         return $mainbar;
     }
 

--- a/src/UI/examples/Layout/Page/Standard/ui_mainbar.php
+++ b/src/UI/examples/Layout/Page/Standard/ui_mainbar.php
@@ -1,0 +1,226 @@
+<?php
+declare(strict_types=1);
+namespace ILIAS\UI\examples\Layout\Page\Standard;
+
+function getUIMainbar($f, $uri, $condensed = false)
+{
+    $symbol = $f->symbol()->icon()->standard('rcat', 'Fischotter', 'small');
+    $link010 = $f->link()->bulky($symbol, '2021 - Fischotter', $uri->withParameter('c', 1));
+    $symbol = $f->symbol()->icon()->standard('rcat', 'Maulwurf', 'small');
+    $link011 = $f->link()->bulky($symbol, '2020 - Maulwurf', $uri->withParameter('c', 2));
+    $symbol = $f->symbol()->icon()->standard('rcat', 'Reh', 'small');
+    $link012 = $f->link()->bulky($symbol, '2019 - Reh', $uri->withParameter('c', 3));
+
+    $symbol = $f->symbol()->icon()->standard('rcat', 'Bachflohkrebs', 'small');
+    $link020 = $f->link()->bulky($symbol, '2021 - Bachflohkrebs', $uri->withParameter('c', 4));
+    $symbol = $f->symbol()->icon()->standard('rcat', 'Wildkatze', 'small');
+    $link021 = $f->link()->bulky($symbol, '2020 - Wildkatze', $uri->withParameter('c', 5));
+    $symbol = $f->symbol()->icon()->standard('rcat', 'Glühwürmchen', 'small');
+    $link022 = $f->link()->bulky($symbol, '2019 - Glühwürmchen', $uri->withParameter('c', 6));
+
+    $link10 = $f->link()->bulky($symbol, 'Frühbarock', $uri->withParameter('c', 7));
+    $link11 = $f->link()->bulky($symbol, 'Hochbarock', $uri->withParameter('c', 8));
+    $link12 = $f->link()->bulky($symbol, 'Spätbarock', $uri->withParameter('c', 9));
+
+    $symbol = $f->symbol()->icon()->standard('cat', 'Deutschland', 'small');
+    $slate01 = $f->maincontrols()->slate()->combined('Deutschland', $symbol, '')
+        ->withAdditionalEntry($link010)
+        ->withAdditionalEntry($link011)
+        ->withAdditionalEntry($link012);
+
+    $contents = <<<EOT
+    <p>Leider gibt es im Takatuka Land kein Tier des Jahres.
+    <br />
+    <b>Aber:</b> Slates in der Main Bar können andere Inhalte als Links enthalten. </p>
+    <p>Zum Beispiel könnten sich hier Inhalte wie der Magazinbaum oder der
+    Mailbaum, komplexe Elemente wie das Notifikation Center, die Hilfe oder
+    auch dieser Text befinden.</p>
+    <p> Die Main Bar ist ganz bewusst nicht nur als 'Menü' gedacht sondern dient auch dazu,
+    komplexe Bedienelemente darzustellen.</p>
+EOT;
+
+    $symbol = $f->symbol()->icon()->standard('cat', 'Takatuka Land', 'small');
+    $slate02 = $f->maincontrols()->slate()->legacy('Takatuka Land', $symbol, $f->legacy($contents));
+
+    $symbol = $f->symbol()->icon()->standard('cat', 'Schweiz', 'small');
+    $slate03 = $f->maincontrols()->slate()->combined('Schweiz', $symbol, '')
+        ->withAdditionalEntry($link020)
+        ->withAdditionalEntry($link021)
+        ->withAdditionalEntry($link022);
+
+    $symbol = $f->symbol()->icon()->custom('./src/UI/examples/Layout/Page/Standard/layers.svg', '')->withSize('small');
+    $slate0 = $f->maincontrols()->slate()->combined('Tier des Jahres', $symbol, '')
+        ->withAdditionalEntry($slate01)
+        ->withAdditionalEntry($slate02)
+        ->withAdditionalEntry($slate03);
+
+    $slate1 = $f->maincontrols()->slate()->combined('Barock', $symbol, '')
+        ->withAdditionalEntry($link10)
+        ->withAdditionalEntry($link11)
+        ->withAdditionalEntry($link12);
+
+
+    if (!$condensed) {
+        $mainbar = $f->mainControls()->mainbar()
+            ->withAdditionalEntry('slate0', $slate0)
+            ->withAdditionalEntry('slate1', $slate1);
+
+        return $mainbar;
+    }
+
+    $slate_base = $f->maincontrols()->slate()->combined('Menu', $symbol, '')
+        ->withAdditionalEntry($slate0)
+        ->withAdditionalEntry($slate1);
+    $mainbar = $f->mainControls()->mainbar()
+        ->withAdditionalEntry('slate0', $slate_base);
+    return $mainbar;
+}
+
+function getUIContent($f, $request)
+{
+    $params = $request->getQueryParams();
+    $cidx = $params['c'];
+
+    switch ($cidx) {
+        case 1:
+            $t = 'Tier des Jahres: Fischotter3';
+            $c = [
+                $f->legacy('<h1>Fischotter</h1><p>Der Fischotter (Lutra lutra) ist ein an das Wasserleben angepasster Marder, der zu den besten Schwimmern unter den Landraubtieren zählt.</p>')
+                ,$f->link()->standard("Quelle: Wikipedia", "https://de.wikipedia.org/wiki/Tier_des_Jahres")
+            ];
+            break;
+        case 2:
+            $t = 'Tier des Jahres: Maulwurf';
+            $c = [
+                $f->legacy('<h1>Maulwurf</h1><p>Der Europäische Maulwurf ist ein mittelgroßer Vertreter der Eurasischen Maulwürfe (Talpa). Er erreicht eine Kopf-Rumpf-Länge von 11,3 bis 15,9 cm, der Schwanz wird 2,5 bis 4,0 cm lang.</p>')
+                ,$f->link()->standard("Quelle: Wikipedia", "https://de.wikipedia.org/wiki/Tier_des_Jahres")
+            ];
+             break;
+        case 3:
+            $t = 'Tier des Jahres: Reh';
+            $c = [
+                $f->legacy('<h1>Reh</h1><p>Das Reh springt hoch,<br> das Reh springt weit.<br> Warum auch nicht? <br>Es hat ja Zeit.</p>')
+            ];
+            break;
+        case 4:
+            $t = 'Tier des Jahres: Bachflohkrebs';
+            $c = [
+                $f->legacy('<h1>Bachflohkrebs</h1><p>Der Bachflohkrebs (Gammarus fossarum) ist ein Flohkrebs aus der Familie der Gammaridae und ein typischer Bachbewohner. <br> Er reagiert als sogenanntes Zeigertier äußerst empfindlich auf Gewässerverschmutzungen.</p>')
+                ,$f->link()->standard("Quelle: Wikipedia", "https://de.wikipedia.org/wiki/Tier_des_Jahres")
+            ];
+            break;
+        case 5:
+            $t = 'Tier des Jahres: Wildkatze';
+            $c = [
+                $f->legacy('<h1>Wildkatze</h1><p>Die Europäische Wildkatze oder Waldkatze (Felis silvestris) ist eine Kleinkatze, die in Europa von der Iberischen Halbinsel bis Osteuropa (westliche Ukraine), in Italien, auf dem Balkan, in Anatolien, im Kaukasus und in den schottischen Highlands vorkommt.</p>')
+                ,$f->link()->standard("Quelle: Wikipedia", "https://de.wikipedia.org/wiki/Tier_des_Jahres")
+            ];
+            break;
+        case 6:
+            $t = 'Frühbarock';
+            $c = [
+                $f->legacy('<h1>Glühwürmchen</h1><p>Der Große Leuchtkäfer bzw. das Große Glühwürmchen oder Große Johannisglühwürmchen (Lampyris noctiluca) ist ein Käfer aus der Familie Leuchtkäfer (Lampyridae).</p>')
+                ,$f->link()->standard("Quelle: Wikipedia", "https://de.wikipedia.org/wiki/Tier_des_Jahres")
+            ];
+            break;
+     
+        case 7:
+            $t = 'Frühbarock';
+            $c = [
+                $f->legacy('<h1>Frühbarock</h1><p><b>etwa 1600 bis 1650</b><br>unter italienischer Dominanz, mit etwa Monteverdi, Gabrieli.</p>')
+                ,$f->link()->standard("Quelle: Wikipedia", "https://de.wikipedia.org/wiki/Tier_des_Jahres")
+            ];
+            break;
+        case 8:
+            $t = 'Hochbarock';
+            $c = [$f->legacy('<h1>Hochbarock</h1><p><b>etwa 1650 bis 1710</b><br>Das französische Musikleben des späten 17. Jahrhunderts wurde maßgeblich von Jean-Baptiste Lully (1632–1687) am Hofe Ludwigs XIV. geprägt.</p>')];
+            break;
+        case 9:
+            $t = 'Spätbarock';
+            $c = [$f->legacy('<h1>Spätbarock</h1><p><b>etwa 1710 bis 1750</b><br>Entwickelte sich im Hochbarock die Musik noch unabhängig in verschiedenen Regionen Europas, so zeichnete sich der Spätbarock durch eine grenzübergreifende Verbreitung der Stile aus. Im deutschen Raum trieb Georg Philipp Telemann (1681–1767) diese Entwicklung voran und wurde schließlich zur „Ikone“ unter den Tonkünstlern.</p>')];
+            break;
+     
+        default:
+            $t = 'Mainbar-Demo';
+            $c = [$f->legacy('Dies ist ein reduziertes Beispiel für die Mainbar des UI-Frameworks.')];
+    }
+
+    return[$t, $c];
+}
+
+function ui_mainbar()
+{
+    global $DIC;
+    $f = $DIC['ui.factory'];
+    $df = new \ILIAS\Data\Factory();
+    $renderer = $DIC['ui.renderer'];
+    $request = $DIC->http()->request();
+
+    $url = 'src/UI/examples/Layout/Page/Standard/ui_mainbar.php?ui_mainbar=1';
+    $mainbar = $f->button()->standard('Mainbar', $url);
+    $url2 = 'src/UI/examples/Layout/Page/Standard/ui_mainbar.php?ui_mainbar=2';
+    $mainbar2 = $f->button()->standard('Mainbar Combined', $url2);
+
+    return $renderer->render([
+        $mainbar,
+        $mainbar2
+    ]);
+}
+
+if ($_GET['ui_mainbar'] == '1' ||
+    $_GET['ui_mainbar'] == '2'
+) {
+    //init ILIAS
+    chdir(__DIR__ . '/../../../../../..');
+    require_once("Services/Init/classes/class.ilInitialisation.php");
+    \ilInitialisation::initILIAS();
+
+    //get resources
+    global $DIC;
+    $f = $DIC['ui.factory'];
+    $renderer = $DIC['ui.renderer'];
+    $request = $DIC->http()->request();
+    
+    $df = new \ILIAS\Data\Factory();
+    $uri = $df->uri(
+        $_SERVER['REQUEST_SCHEME'] .
+        '://' .
+        $_SERVER['SERVER_NAME'] .
+        ':' .
+        $_SERVER['SERVER_PORT'] .
+        $_SERVER['SCRIPT_NAME'] .
+        '?' .
+        $_SERVER['QUERY_STRING']
+    );
+
+    if ($_GET['ui_mainbar'] == '1') {
+        $mainbar = getUIMainbar($f, $uri);
+    }
+    if ($_GET['ui_mainbar'] == '2') {
+        $mainbar = getUIMainbar($f, $uri, true);
+    }
+    
+    list($page_title, $content) = getUIContent($f, $request);
+
+    $logo = $f->image()->responsive("templates/default/images/HeaderIcon.svg", "ILIAS");
+    $breadcrumbs = null;
+    $metabar = null;
+    $footer = null;
+    $short_title = 'DEMO';
+    $view_title = 'UI Mainbar';
+
+    $page = $f->layout()->page()->standard(
+        $content,
+        $metabar,
+        $mainbar,
+        $breadcrumbs,
+        $logo,
+        $footer,
+        $page_title,
+        $short_title,
+        $view_title
+    )
+    ->withUIDemo(true);
+
+    echo $renderer->render($page);
+}

--- a/src/UI/examples/MainControls/MainBar/mainbar.php
+++ b/src/UI/examples/MainControls/MainBar/mainbar.php
@@ -5,94 +5,14 @@ namespace ILIAS\UI\examples\MainControls\MainBar;
 function mainbar()
 {
     global $DIC;
-    $f = $DIC->ui()->factory();
-    $renderer = $DIC->ui()->renderer();
+    $f = $DIC['ui.factory'];
+    $renderer = $DIC['ui.renderer'];
 
-    $mainbar = buildMainbar($f, $renderer);
-    return $renderer->render($mainbar);
-}
-
-function buildMainbar($f, $r)
-{
-    $tools_btn = $f->button()->bulky(
-        $f->symbol()->icon()->custom('./src/UI/examples/Layout/Page/Standard/grid.svg', ''),
-        'Tools',
-        '#'
-    );
-    $more_btn = $f->button()->bulky(
-        $f->symbol()->icon()->standard('', ''),
-        'more',
-        '#'
-    );
-
-    $mainbar = $f->mainControls()->mainbar()
-        ->withToolsButton($tools_btn);
-
-    $entries = [];
-    $entries['repository'] = getDemoEntryRepository($f);
-    $entries['pws'] = getDemoEntryPersonalWorkspace($f);
-    $entries['achievements'] = getDemoEntryAchievements($f);
-    $entries['communication'] = getDemoEntryCommunication($f);
-    $entries['organisation'] = getDemoEntryOrganisation($f);
-    $entries['administration'] = getDemoEntryAdministration($f);
-
-    foreach ($entries as $id => $entry) {
-        $mainbar = $mainbar->withAdditionalEntry($id, $entry);
-    }
-    $tools = getDemoEntryTools($f);
-    foreach ($tools as $id => $entry) {
-        $mainbar = $mainbar->withAdditionalToolEntry($id, $entry);
-    }
-
-    return $mainbar;
-}
-
-function getDemoEntryRepository($f)
-{
-    $symbol = $f->symbol()->icon()->custom('./src/UI/examples/Layout/Page/Standard/layers.svg', '')->withSize('small');
-    $slate = $f->maincontrols()->slate()->combined('Repository', $symbol, '');
-    return $slate;
-}
-
-function getDemoEntryPersonalWorkspace($f)
-{
-    $symbol = $f->symbol()->icon()->custom('./src/UI/examples/Layout/Page/Standard/user.svg', '')->withSize('small');
-    $slate = $f->maincontrols()->slate()->combined('Personal Workspace', $symbol, '');
-    return $slate;
-}
-
-function getDemoEntryAchievements($f)
-{
-    $symbol = $f->symbol()->icon()->custom('./src/UI/examples/Layout/Page/Standard/achievements.svg', '')->withSize('small');
-    $slate = $f->maincontrols()->slate()->legacy('Achievements', $symbol, $f->legacy('content: Achievements'));
-    return $slate;
-}
-
-function getDemoEntryCommunication($f)
-{
-    $symbol = $f->symbol()->icon()->custom('./src/UI/examples/Layout/Page/Standard/communication.svg', '')->withSize('small');
-    $slate = $f->maincontrols()->slate()->legacy('Communication', $symbol, $f->legacy('content: Communication'));
-    return $slate;
-}
-
-function getDemoEntryOrganisation($f)
-{
-    $symbol = $f->symbol()->icon()->custom('./src/UI/examples/Layout/Page/Standard/organisation.svg', '')->withSize('small');
-    $slate = $f->maincontrols()->slate()->legacy('Organisation', $symbol, $f->legacy('content: Organisation'));
-    return $slate;
-}
-
-function getDemoEntryAdministration($f)
-{
-    $symbol = $f->symbol()->icon()->custom('./src/UI/examples/Layout/Page/Standard/administration.svg', '')->withSize('small');
-    $slate = $f->maincontrols()->slate()->legacy('Administration', $symbol, $f->legacy('content: Administration'));
-    return $slate;
-}
-
-function getDemoEntryTools($f)
-{
-    $symbol = $f->symbol()->icon()->custom('./src/UI/examples/Layout/Page/Standard/question.svg', '')->withSize('small');
-    $slate = $f->maincontrols()->slate()->legacy('Help', $symbol, $f->legacy('<h2>tool 1</h2><p>Some Text for Tool 1 entry</p>'));
-    $tools = ['tool1' => $slate];
-    return $tools;
+    $url = 'src/UI/examples/Layout/Page/Standard/ui_mainbar.php?ui_mainbar=1';
+    $to_page = $f->button()->standard('Mainbar', $url);
+    $txt = $f->legacy('<p>Better head over to a preview of page to see a mainbar in its entire beauty...</p>');
+    return $renderer->render([
+        $txt,
+        $to_page
+    ]);
 }

--- a/src/UI/templates/default/MainControls/mainbar.less
+++ b/src/UI/templates/default/MainControls/mainbar.less
@@ -12,6 +12,7 @@
 		&:focus-visible {
 			border: 2px solid @il-focus-color;
 			outline: none;
+			box-shadow: none;
 		}
 	}
 	.bulky-label {

--- a/src/UI/templates/default/MainControls/mainbar.less
+++ b/src/UI/templates/default/MainControls/mainbar.less
@@ -12,7 +12,6 @@
 		&:focus-visible {
 			border: 2px solid @il-focus-color;
 			outline: none;
-			box-shadow: none;
 		}
 	}
 	.bulky-label {
@@ -128,6 +127,9 @@
 // mainbar entries
 .il-mainbar-entries {
 	min-width: 100%;
+	list-style: none;
+	padding: 0px;
+	margin: 0px;
 }
 
 // mainbar slates

--- a/src/UI/templates/default/MainControls/tpl.mainbar.html
+++ b/src/UI/templates/default/MainControls/tpl.mainbar.html
@@ -7,11 +7,11 @@
 		<!-- END tools_trigger -->
 
 		<div class="il-mainbar-triggers">
-			<ol class="il-mainbar-entries" role="menubar" style="visibility: hidden"><!--if done via class/css-files, visibility is being applied too late -->
+			<ul class="il-mainbar-entries" role="menubar" style="visibility: hidden"><!--if done via class/css-files, visibility is being applied too late -->
 				<!-- BEGIN trigger_item -->
-				<li role="menuitem">{BUTTON}</li>
+				<li role="none">{BUTTON}</li>
 				<!-- END trigger_item -->
-			</ol>
+			</ul>
 		</div>
 	</nav>
 

--- a/src/UI/templates/default/MainControls/tpl.mainbar.html
+++ b/src/UI/templates/default/MainControls/tpl.mainbar.html
@@ -7,11 +7,11 @@
 		<!-- END tools_trigger -->
 
 		<div class="il-mainbar-triggers">
-			<div class="il-mainbar-entries" role="menubar" style="visibility: hidden"><!--if done via class/css-files, visibility is being applied too late -->
+			<ol class="il-mainbar-entries" role="menubar" style="visibility: hidden"><!--if done via class/css-files, visibility is being applied too late -->
 				<!-- BEGIN trigger_item -->
-				{BUTTON}
+				<li role="menuitem">{BUTTON}</li>
 				<!-- END trigger_item -->
-			</div>
+			</ol>
 		</div>
 	</nav>
 

--- a/src/UI/templates/js/MainControls/dist/mainbar.js
+++ b/src/UI/templates/js/MainControls/dist/mainbar.js
@@ -101,6 +101,21 @@ var mainbar = function() {
                                     mb.model.actions.engageEntry(id);
                                 }
                                 mb.model.actions.engageEntry(id);
+
+                                var dom_id = il.UI.maincontrols.mainbar.renderer.dom_references[id];
+                                
+
+                                var first = $('#' + dom_id.slate)
+                                    .children().first()
+                                    .children().first();
+                                                                
+                                //first.css('border', '2px solid green');
+                                window.setTimeout(function() {
+                                    first[0].focus()
+                                }, 200);
+                                
+                                
+
                             }
                         }
                         break;
@@ -707,10 +722,12 @@ var renderer = function($) {
             additional_engage: function(){
                 this.getElement().attr('aria-expanded', true);
                 this.getElement().attr('aria-hidden', false);
+                this.getElement().attr('role', 'region');
             },
             additional_disengage: function(){
                 this.getElement().attr('aria-expanded', false);
                 this.getElement().attr('aria-hidden', true);
+                this.getElement().removeAttr('role'); //? really remove ?
             }
         }),
         remover: Object.assign({}, dom_element, {
@@ -800,6 +817,9 @@ var renderer = function($) {
             var triggerer = parts.triggerer.withHtmlId(dom_references[entry.id].triggerer),
                 slate = parts.slate.withHtmlId(dom_references[entry.id].slate);
 
+                triggerer.getElement().attr('aria-controls', slate.html_id);
+                triggerer.getElement().attr('aria-labelledby', triggerer.html_id);
+
             if(entry.hidden) {
                 triggerer.mb_hide(is_tool);
             } else {
@@ -876,7 +896,8 @@ var renderer = function($) {
     public_interface = {
         addEntry: actions.addEntry,
         calcAmountOfButtons: more.calcAmountOfButtons,
-        render: actions.render
+        render: actions.render,
+        dom_references: dom_references
     };
 
     return public_interface;

--- a/src/UI/templates/js/MainControls/dist/mainbar.js
+++ b/src/UI/templates/js/MainControls/dist/mainbar.js
@@ -89,6 +89,7 @@ var mainbar = function() {
                 switch(action) {
                     case 'trigger_mapped':
                         id = mappings[id]; //no break afterwards!
+
                     case 'trigger':
                         state = mb.model.getState();
                         if(id in state.tools) {
@@ -108,9 +109,11 @@ var mainbar = function() {
                             }
                         }
                         break;
+
                     case 'remove':
                         mb.model.actions.removeTool(id);
                         break;
+
                     case 'disengage_all':
                         mb.model.actions.disengageAll();
                         var state = mb.model.getState();
@@ -123,8 +126,24 @@ var mainbar = function() {
                         state.last_active_top = null;
                         mb.model.setState(state);
                         break;
+
                     case 'toggle_tools':
                         mb.model.actions.toggleTools();
+
+                        var state = mb.model.getState();
+                            id = Object.keys(state.tools)[0];
+
+                        if(state.tools_engaged) {
+                            after_render = function() {
+                                for(idx in state.tools) {
+                                    var tool = state.tools[idx];
+                                    if(tool.engaged) {
+                                        id = tool.id;
+                                    }
+                                }
+                                mb.renderer.focusTopentry(id);
+                            };
+                        }
                         break;
                 }
 
@@ -720,16 +739,13 @@ var renderer = function($) {
             additional_engage: function(){
                 this.getElement().attr('aria-expanded', true);
                 this.getElement().attr('aria-hidden', false);
-                //a11y
+                //https://www.w3.org/TR/wai-aria-practices-1.1/examples/accordion/accordion.html
                 this.getElement().attr('role', 'region');
-                //a11y
             },
             additional_disengage: function(){
                 this.getElement().attr('aria-expanded', false);
                 this.getElement().attr('aria-hidden', true);
-                //a11y
                 this.getElement().removeAttr('role', 'region');
-                //a11y                
             }
         }),
         remover: Object.assign({}, dom_element, {

--- a/src/UI/templates/js/MainControls/src/mainbar.main.js
+++ b/src/UI/templates/js/MainControls/src/mainbar.main.js
@@ -89,6 +89,7 @@ var mainbar = function() {
                 switch(action) {
                     case 'trigger_mapped':
                         id = mappings[id]; //no break afterwards!
+
                     case 'trigger':
                         state = mb.model.getState();
                         if(id in state.tools) {
@@ -108,9 +109,11 @@ var mainbar = function() {
                             }
                         }
                         break;
+
                     case 'remove':
                         mb.model.actions.removeTool(id);
                         break;
+
                     case 'disengage_all':
                         mb.model.actions.disengageAll();
                         var state = mb.model.getState()
@@ -123,8 +126,24 @@ var mainbar = function() {
                         state.last_active_top = null;
                         mb.model.setState(state);
                         break;
+
                     case 'toggle_tools':
                         mb.model.actions.toggleTools();
+
+                        var state = mb.model.getState()
+                            id = Object.keys(state.tools)[0];
+
+                        if(state.tools_engaged) {
+                            after_render = function() {
+                                for(idx in state.tools) {
+                                    var tool = state.tools[idx];
+                                    if(tool.engaged) {
+                                        id = tool.id;
+                                    }
+                                }
+                                mb.renderer.focusTopentry(id);
+                            }
+                        }
                         break;
                 }
 

--- a/src/UI/templates/js/MainControls/src/mainbar.main.js
+++ b/src/UI/templates/js/MainControls/src/mainbar.main.js
@@ -83,7 +83,8 @@ var mainbar = function() {
                 var id = signalData.options.entry_id,
                     action = signalData.options.action,
                     mb = il.UI.maincontrols.mainbar,
-                    state;
+                    state,
+                    after_render;
 
                 switch(action) {
                     case 'trigger_mapped':
@@ -97,10 +98,13 @@ var mainbar = function() {
                             if(state.entries[id].engaged) {
                                 mb.model.actions.disengageEntry(id);
                             } else {
-                                if(state.entries[id].isTopLevel()) {
-                                    mb.model.actions.engageEntry(id);
-                                }
                                 mb.model.actions.engageEntry(id);
+
+                                if(state.entries[id].isTopLevel()) {
+                                    after_render = function() {
+                                        mb.renderer.focusSubentry(id);
+                                    }
+                                }
                             }
                         }
                         break;
@@ -109,7 +113,13 @@ var mainbar = function() {
                         break;
                     case 'disengage_all':
                         mb.model.actions.disengageAll();
-                        var state = mb.model.getState();
+                        var state = mb.model.getState()
+                            last_top_id = state.last_active_top;
+
+                        after_render = function() {
+                            mb.renderer.focusTopentry(last_top_id);
+                        }
+
                         state.last_active_top = null;
                         mb.model.setState(state);
                         break;
@@ -119,6 +129,9 @@ var mainbar = function() {
                 }
 
                 mb.renderer.render(mb.model.getState());
+                if(after_render) {
+                    after_render();
+                }
                 mb.persistence.store(mb.model.getState());
             });
         }

--- a/src/UI/templates/js/MainControls/src/mainbar.renderer.js
+++ b/src/UI/templates/js/MainControls/src/mainbar.renderer.js
@@ -71,16 +71,13 @@ var renderer = function($) {
             additional_engage: function(){
                 this.getElement().attr('aria-expanded', true);
                 this.getElement().attr('aria-hidden', false);
-                //a11y
+                //https://www.w3.org/TR/wai-aria-practices-1.1/examples/accordion/accordion.html
                 this.getElement().attr('role', 'region');
-                //a11y
             },
             additional_disengage: function(){
                 this.getElement().attr('aria-expanded', false);
                 this.getElement().attr('aria-hidden', true);
-                //a11y
                 this.getElement().removeAttr('role', 'region');
-                //a11y                
             }
         }),
         remover: Object.assign({}, dom_element, {

--- a/src/UI/templates/js/MainControls/src/mainbar.renderer.js
+++ b/src/UI/templates/js/MainControls/src/mainbar.renderer.js
@@ -71,10 +71,16 @@ var renderer = function($) {
             additional_engage: function(){
                 this.getElement().attr('aria-expanded', true);
                 this.getElement().attr('aria-hidden', false);
+                //a11y
+                this.getElement().attr('role', 'region');
+                //a11y
             },
             additional_disengage: function(){
                 this.getElement().attr('aria-expanded', false);
                 this.getElement().attr('aria-hidden', true);
+                //a11y
+                this.getElement().removeAttr('role', 'region');
+                //a11y                
             }
         }),
         remover: Object.assign({}, dom_element, {
@@ -163,6 +169,11 @@ var renderer = function($) {
 
             var triggerer = parts.triggerer.withHtmlId(dom_references[entry.id].triggerer),
                 slate = parts.slate.withHtmlId(dom_references[entry.id].slate);
+                
+                //a11y
+                triggerer.getElement().attr('aria-controls', slate.html_id);
+                triggerer.getElement().attr('aria-labelledby', triggerer.html_id);
+                //a11y
 
             if(entry.hidden) {
                 triggerer.mb_hide(is_tool);
@@ -236,12 +247,25 @@ var renderer = function($) {
             }
             //unfortunately, this does not work properly via a class
             $('.' + css.mainbar_entries).css('visibility', 'visible');
+        },
+        focusSubentry: function(triggered_entry_id) {
+            var dom_id = dom_references[triggered_entry_id],
+                first = $('#' + dom_id.slate)
+                    .children().first()
+                    .children().first();
+            first[0].focus();
+        },
+        focusTopentry: function(top_entry_id) {
+            var  triggerer = dom_references[top_entry_id];
+            document.getElementById(triggerer.triggerer).focus();
         }
     },
     public_interface = {
         addEntry: actions.addEntry,
         calcAmountOfButtons: more.calcAmountOfButtons,
-        render: actions.render
+        render: actions.render,
+        focusSubentry: actions.focusSubentry,
+        focusTopentry: actions.focusTopentry
     };
 
     return public_interface;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -9664,6 +9664,7 @@ footer {
 .il-maincontrols-mainbar .il-link.link-bulky:active,
 .il-maincontrols-metabar .il-link.link-bulky:active {
   box-shadow: none;
+  border: 2px solid red;
 }
 .il-maincontrols-mainbar .btn-bulky:focus-visible,
 .il-maincontrols-metabar .btn-bulky:focus-visible,

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -9664,7 +9664,6 @@ footer {
 .il-maincontrols-mainbar .il-link.link-bulky:active,
 .il-maincontrols-metabar .il-link.link-bulky:active {
   box-shadow: none;
-  border: 2px solid red;
 }
 .il-maincontrols-mainbar .btn-bulky:focus-visible,
 .il-maincontrols-metabar .btn-bulky:focus-visible,
@@ -9796,6 +9795,9 @@ footer {
 }
 .il-mainbar-entries {
   min-width: 100%;
+  list-style: none;
+  padding: 0px;
+  margin: 0px;
 }
 .il-mainbar-slates {
   box-shadow: 1px 3px 4px rgba(0, 0, 0, 0.1);

--- a/tests/UI/Component/MainControls/MainBarTest.php
+++ b/tests/UI/Component/MainControls/MainBarTest.php
@@ -226,12 +226,12 @@ class MainBarTest extends ILIAS_UI_TestBase
 			<div class="il-maincontrols-mainbar" id="id_12">
 				<nav class="il-mainbar" aria-label="mainbar_aria_label">
 					<div class="il-mainbar-triggers">
-						<ol class="il-mainbar-entries" role="menubar" style="visibility: hidden">
-							<li role="menuitem"><button class="btn btn-bulky" data-action="#" id="id_1" role="menuitem" ><img class="icon custom small" src="" alt=""/><span class="bulky-label">TestEntry</span></button></li>
-							<li role="menuitem"><button class="btn btn-bulky" data-action="#" id="id_2" role="menuitem" ><img class="icon custom small" src="" alt=""/><span class="bulky-label">TestEntry</span></button></li>
-							<li role="menuitem"><button class="btn btn-bulky" id="id_3" role="menuitem" ><img class="icon custom small" src="" alt=""/><span class="bulky-label">1</span></button></li>
-							<li role="menuitem"><button class="btn btn-bulky" id="id_9" role="menuitem" ><span class="glyph" aria-label="show_more"><span class="glyphicon glyphicon-option-horizontal" aria-hidden="true"></span></span><span class="bulky-label">mainbar_more_label</span></button></li>
-						</ol>
+						<ul class="il-mainbar-entries" role="menubar" style="visibility: hidden">
+							<li role="none"><button class="btn btn-bulky" data-action="#" id="id_1" role="menuitem" ><img class="icon custom small" src="" alt=""/><span class="bulky-label">TestEntry</span></button></li>
+							<li role="none"><button class="btn btn-bulky" data-action="#" id="id_2" role="menuitem" ><img class="icon custom small" src="" alt=""/><span class="bulky-label">TestEntry</span></button></li>
+							<li role="none"><button class="btn btn-bulky" id="id_3" role="menuitem" ><img class="icon custom small" src="" alt=""/><span class="bulky-label">1</span></button></li>
+							<li role="none"><button class="btn btn-bulky" id="id_9" role="menuitem" ><span class="glyph" aria-label="show_more"><span class="glyphicon glyphicon-option-horizontal" aria-hidden="true"></span></span><span class="bulky-label">mainbar_more_label</span></button></li>
+						</ul>
 					</div>
 				</nav>
 

--- a/tests/UI/Component/MainControls/MainBarTest.php
+++ b/tests/UI/Component/MainControls/MainBarTest.php
@@ -226,12 +226,12 @@ class MainBarTest extends ILIAS_UI_TestBase
 			<div class="il-maincontrols-mainbar" id="id_12">
 				<nav class="il-mainbar" aria-label="mainbar_aria_label">
 					<div class="il-mainbar-triggers">
-						<div class="il-mainbar-entries" role="menubar" style="visibility: hidden">
-							<button class="btn btn-bulky" data-action="#" id="id_1" role="menuitem" ><img class="icon custom small" src="" alt=""/><span class="bulky-label">TestEntry</span></button>
-							<button class="btn btn-bulky" data-action="#" id="id_2" role="menuitem" ><img class="icon custom small" src="" alt=""/><span class="bulky-label">TestEntry</span></button>
-							<button class="btn btn-bulky" id="id_3" role="menuitem" ><img class="icon custom small" src="" alt=""/><span class="bulky-label">1</span></button>
-							<button class="btn btn-bulky" id="id_9" role="menuitem" ><span class="glyph" aria-label="show_more"><span class="glyphicon glyphicon-option-horizontal" aria-hidden="true"></span></span><span class="bulky-label">mainbar_more_label</span></button>
-						</div>
+						<ol class="il-mainbar-entries" role="menubar" style="visibility: hidden">
+							<li role="menuitem"><button class="btn btn-bulky" data-action="#" id="id_1" role="menuitem" ><img class="icon custom small" src="" alt=""/><span class="bulky-label">TestEntry</span></button></li>
+							<li role="menuitem"><button class="btn btn-bulky" data-action="#" id="id_2" role="menuitem" ><img class="icon custom small" src="" alt=""/><span class="bulky-label">TestEntry</span></button></li>
+							<li role="menuitem"><button class="btn btn-bulky" id="id_3" role="menuitem" ><img class="icon custom small" src="" alt=""/><span class="bulky-label">1</span></button></li>
+							<li role="menuitem"><button class="btn btn-bulky" id="id_9" role="menuitem" ><span class="glyph" aria-label="show_more"><span class="glyphicon glyphicon-option-horizontal" aria-hidden="true"></span></span><span class="bulky-label">mainbar_more_label</span></button></li>
+						</ol>
 					</div>
 				</nav>
 


### PR DESCRIPTION
As discussed in workshops earlier this year, the mainbar will heavily profit from auto-focussing certain elements.
Also, in terms of a11y, the "main menu",  need to be rendered as list/items.

This PR will:
- render mainbar top entries as list-items within an ordered list. (There's a roadmap-entry for removig the div-wrappers, too)
- add roles menubar/menuitem to those entries
- automativally focus subslates of top-entries
- re-focus the top-entry after closing all slates using the according button (on the bottom of slates)
- include the examples from the workshops

