### PR TITLE
iass: Fix PHP 8 issues for (Unit Tests)

### DIFF
--- a/Modules/IndividualAssessment/classes/class.ilIndividualAssessmentMemberGUI.php
+++ b/Modules/IndividualAssessment/classes/class.ilIndividualAssessmentMemberGUI.php
@@ -230,7 +230,6 @@ class ilIndividualAssessmentMemberGUI extends AbstractCtrlAwareUploadHandler
 
         ilUtil::sendSuccess($this->lng->txt('iass_membership_saved'), true);
         $this->redirect(self::CMD_EDIT);
-
     }
 
     protected function amend()
@@ -570,7 +569,9 @@ class ilIndividualAssessmentMemberGUI extends AbstractCtrlAwareUploadHandler
             return null;
         }
 
-        return end(explode('/', $path));
+        $array = explode('/', $path);
+
+        return end($array);
     }
 
     protected function getFilePath() : ?string

--- a/Modules/IndividualAssessment/classes/ilIndividualAssessmentUserGrading.php
+++ b/Modules/IndividualAssessment/classes/ilIndividualAssessmentUserGrading.php
@@ -153,9 +153,9 @@ class ilIndividualAssessmentUserGrading
         \ilLanguage $lng,
         Refinery $refinery,
         array $grading_options,
-        bool $may_be_edited = true,
-        bool $place_required = false,
-        bool $amend = false,
+        bool $may_be_edited,
+        bool $place_required,
+        bool $amend,
         ilIndividualAssessmentMemberGUI $file_handler
     ) : Field\Input {
         $name = $input


### PR DESCRIPTION
This PR fixes required parameters after optional parameters.
Furthermore passing a function result directly as an
argument (by ref) is not valid, so this is fixed as well.