### PR TITLE
GitHubActions: Add possible fix for php-cs-fixer version when executi…

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -30,7 +30,7 @@ jobs:
           GHRUN: "yes"
 
       - name: Install PHP CS Fixer
-        run: composer require friendsofphp/php-cs-fixer --no-interaction --no-progress
+        run: composer require "friendsofphp/php-cs-fixer:^2.19" --no-interaction --no-progress
 
       - name: PHP CS Fixer
         run: CI/PHP-CS-Fixer/run_check.sh

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,9 +29,6 @@ jobs:
         env:
           GHRUN: "yes"
 
-      - name: Install PHP CS Fixer
-        run: composer require "friendsofphp/php-cs-fixer:^2.19" --no-interaction --no-progress
-
       - name: PHP CS Fixer
         run: CI/PHP-CS-Fixer/run_check.sh
         env:


### PR DESCRIPTION
…ng GitHub actions

This PR fixes an issue with the latest v. 3.0 release of `php-cs-fixer`, which is installed by the `GitHub Actions` step `Install PHP CS Fixer` and causes our builds to fail (even for PHP 7.4).

```bash
Run composer require friendsofphp/php-cs-fixer --no-interaction --no-progress
Using version ^3.0 for friendsofphp/php-cs-fixer
./composer.json has been updated
Running composer update friendsofphp/php-cs-fixer
Gathering patches for root package.
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires friendsofphp/php-cs-fixer ^3.0 -> satisfiable by friendsofphp/php-cs-fixer[v3.0.0].
    - friendsofphp/php-cs-fixer v3.0.0 requires php-cs-fixer/diff ^2.0 -> found php-cs-fixer/diff[v2.0.0, v2.0.1, v2.0.2] but the package is fixed to v1.3.1 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
Error: Your requirements could not be resolved to an installable set of packages.
```

CC @lauraquellmalz 