### PR TITLE
Mail: Improve background task handling

### DIFF
--- a/Modules/Forum/classes/Notification/class.ilForumMailEventNotificationSender.php
+++ b/Modules/Forum/classes/Notification/class.ilForumMailEventNotificationSender.php
@@ -417,7 +417,6 @@ class ilForumMailEventNotificationSender extends ilMailNotification
         $bodyText .= $attachmentText;
 
         $mailObject = new ilMailValueObject(
-            '',
             ilObjUser::_lookupLogin($recipientUserId),
             '',
             '',
@@ -459,7 +458,6 @@ class ilForumMailEventNotificationSender extends ilMailNotification
         );
 
         $mailObject = new ilMailValueObject(
-            '',
             ilObjUser::_lookupLogin($recipientUserId),
             '',
             '',

--- a/Modules/Forum/classes/Notification/class.ilForumMailEventNotificationSender.php
+++ b/Modules/Forum/classes/Notification/class.ilForumMailEventNotificationSender.php
@@ -417,6 +417,7 @@ class ilForumMailEventNotificationSender extends ilMailNotification
         $bodyText .= $attachmentText;
 
         $mailObject = new ilMailValueObject(
+            (int) ANONYMOUS_USER_ID,
             ilObjUser::_lookupLogin($recipientUserId),
             '',
             '',
@@ -458,6 +459,7 @@ class ilForumMailEventNotificationSender extends ilMailNotification
         );
 
         $mailObject = new ilMailValueObject(
+            (int) ANONYMOUS_USER_ID,
             ilObjUser::_lookupLogin($recipientUserId),
             '',
             '',

--- a/Services/Mail/classes/BackgroundTask/class.ilCouldNotFindQueueTaskException.php
+++ b/Services/Mail/classes/BackgroundTask/class.ilCouldNotFindQueueTaskException.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 1998-2021 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * Class ilCouldNotFindQueueTaskException
+ * @author Michael Jansen <mjansen@databay.de>
+ */
+class ilCouldNotFindQueueTaskException extends ilException
+{
+}

--- a/Services/Mail/classes/BackgroundTask/class.ilMailDeliveryJob.php
+++ b/Services/Mail/classes/BackgroundTask/class.ilMailDeliveryJob.php
@@ -11,6 +11,7 @@ use ILIAS\BackgroundTasks\Types\SingleType;
 /**
  * Class ilMailDeliveryJob
  * @author Michael Jansen <mjansen@databay.de>
+ * @deprecated
  */
 class ilMailDeliveryJob extends AbstractJob
 {

--- a/Services/Mail/classes/BackgroundTask/class.ilMailDeliveryQueueJob.php
+++ b/Services/Mail/classes/BackgroundTask/class.ilMailDeliveryQueueJob.php
@@ -1,0 +1,115 @@
+<?php declare(strict_types=1);
+/* Copyright (c) 1998-2021 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+use ILIAS\BackgroundTasks\Implementation\Tasks\AbstractJob;
+use ILIAS\BackgroundTasks\Implementation\Values\ScalarValues\BooleanValue;
+use ILIAS\BackgroundTasks\Implementation\Values\ScalarValues\IntegerValue;
+use ILIAS\BackgroundTasks\Implementation\Values\ScalarValues\StringValue;
+use ILIAS\BackgroundTasks\Observer;
+use ILIAS\BackgroundTasks\Types\SingleType;
+use ILIAS\Data\UUID\Factory as UuidFactory;
+
+/**
+ * Class ilMailDeliveryQueueJob
+ * @author Michael Jansen <mjansen@databay.de>
+ */
+class ilMailDeliveryQueueJob extends AbstractJob
+{
+    /**
+     * @inheritdoc
+     */
+    public function run(array $input, Observer $observer)
+    {
+        global $DIC;
+
+        $arguments = array_map(static function ($value) {
+            return $value->getValue();
+        }, $input);
+
+        $DIC->logger()->mail()->info(sprintf(
+            'Mail delivery background task executed for input: %s',
+            json_encode($arguments, JSON_PRETTY_PRINT)
+        ));
+
+        $queuedTaskId = $input[0]->getValue();
+        $queuedTaskRepo = new ilMailQueuedTaskRepository(
+            $DIC->database(),
+            new UuidFactory()
+        );
+
+        $output = new BooleanValue();
+
+        try {
+            $queuedTask = $queuedTaskRepo->findByUuid($queuedTaskId);
+
+            $mail = new ilMail((int) $queuedTask->getActorUsrId());
+            $mail->setSaveInSentbox($queuedTask->shouldSaveInSentBox());
+            
+            if ($queuedTask->getTemplateContextId()) {
+                $mail = $mail
+                    ->withContextId((string) $queuedTask->getTemplateContextId())
+                    ->withContextParameters((array) $queuedTask->getTemplateContextParams());
+            }
+
+            $mail->sendMail(
+                $queuedTask->getRecipients(),
+                $queuedTask->getRecipientsCC(),
+                $queuedTask->getRecipientsBCC(),
+                $queuedTask->getSubject(),
+                $queuedTask->getBody(),
+                $queuedTask->getAttachments(),
+                $queuedTask->isUsingPlaceholders()
+            );
+
+            $DIC->logger()->mail()->info(sprintf(
+                'Mail delivery background task finished: %s',
+                json_encode($arguments, JSON_PRETTY_PRINT)
+            ));
+
+            $queuedTaskRepo->delete($queuedTaskId);
+            
+            $output->setValue(true);
+        } catch (ilCouldNotFindQueueTaskException $e) {
+            $DIC->logger()->mail()->err($e->getMessage());
+            $DIC->logger()->mail()->err($e->getTraceAsString());
+
+            $output->setValue(false);
+        }
+
+        return $output;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getInputTypes()
+    {
+        return [
+            new SingleType(StringValue::class),
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isStateless()
+    {
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getExpectedTimeOfTaskInSeconds()
+    {
+        return 30;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getOutputType()
+    {
+        return new SingleType(BooleanValue::class);
+    }
+}

--- a/Services/Mail/classes/BackgroundTask/class.ilMailQueuedTaskRepository.php
+++ b/Services/Mail/classes/BackgroundTask/class.ilMailQueuedTaskRepository.php
@@ -70,6 +70,7 @@ class ilMailQueuedTaskRepository
         $row = $this->db->fetchAssoc($result);
 
         $mailObject = new ilMailValueObject(
+            (int) $row['actor_usr_id'],
             (string) $row['rcp_to'],
             (string) $row['rcp_cc'],
             (string) $row['rcp_bcc'],
@@ -82,20 +83,15 @@ class ilMailQueuedTaskRepository
             (bool) $row['use_placeholders'],
             (bool) $row['save_in_sentbox'],
         );
-        
-        if ($row['actor_usr_id']) {
-            $mailObject = $mailObject->withActorUsrId((int) $row['actor_usr_id']);
-        }
 
         if ($row['tpl_ctx_id']) {
             $mailObject = $mailObject->withTemplateContextId((string) $row['tpl_ctx_id']);
-        }
-
-        if ($row['tpl_ctx_params']) {
-            $mailObject = $mailObject->withTemplateContextParams((array) unserialize(
-                $row['tpl_ctx_params'],
-                ['allowed_classes' => false]
-            ));
+            if ($row['tpl_ctx_params']) {
+                $mailObject = $mailObject->withTemplateContextParams((array) unserialize(
+                    $row['tpl_ctx_params'],
+                    ['allowed_classes' => false]
+                ));
+            }
         }
 
         return $mailObject;

--- a/Services/Mail/classes/BackgroundTask/class.ilMailQueuedTaskRepository.php
+++ b/Services/Mail/classes/BackgroundTask/class.ilMailQueuedTaskRepository.php
@@ -70,7 +70,6 @@ class ilMailQueuedTaskRepository
         $row = $this->db->fetchAssoc($result);
 
         $mailObject = new ilMailValueObject(
-            '',
             (string) $row['rcp_to'],
             (string) $row['rcp_cc'],
             (string) $row['rcp_bcc'],

--- a/Services/Mail/classes/BackgroundTask/class.ilMailQueuedTaskRepository.php
+++ b/Services/Mail/classes/BackgroundTask/class.ilMailQueuedTaskRepository.php
@@ -30,7 +30,7 @@ class ilMailQueuedTaskRepository
 
         $this->db->insert(self::TABLE_NAME, [
             'queue_item_id' => ['text', $uuid->toString()],
-            'actor_usr_id' => ['integer', $mailTask],
+            'actor_usr_id' => ['integer', $mailTask->getActorUsrId()],
             'rcp_to' => ['clob', $mailTask->getRecipients()],
             'rcp_cc' => ['clob', $mailTask->getRecipientsCC()],
             'rcp_bcc' => ['clob', $mailTask->getRecipientsBCC()],

--- a/Services/Mail/classes/BackgroundTask/class.ilMailQueuedTaskRepository.php
+++ b/Services/Mail/classes/BackgroundTask/class.ilMailQueuedTaskRepository.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+/* Copyright (c) 1998-2021 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * Class ilMailQueuedTaskRepository
+ * @author Michael Jansen
+ */
+class ilMailQueuedTaskRepository
+{
+    private const TABLE_NAME = 'mail_task_queue';
+    
+    /** @var ilDBInterface */
+    private $db;
+    /** @var \ILIAS\Data\UUID\Factory */
+    private $uuidFactory;
+
+    /**
+     * ilMailQueuedTaskRepository constructor.
+     * @param ilDBInterface $db
+     */
+    public function __construct(ilDBInterface $db, \ILIAS\Data\UUID\Factory $uuidFactory)
+    {
+        $this->db = $db;
+        $this->uuidFactory = $uuidFactory;
+    }
+
+    public function save(ilMailValueObject $mailTask) : \ILIAS\Data\UUID\Uuid
+    {
+        $uuid = $this->uuidFactory->uuid4();
+
+        $this->db->insert(self::TABLE_NAME, [
+            'queue_item_id' => ['text', $uuid->toString()],
+            'actor_usr_id' => ['integer', $mailTask],
+            'rcp_to' => ['clob', $mailTask->getRecipients()],
+            'rcp_cc' => ['clob', $mailTask->getRecipientsCC()],
+            'rcp_bcc' => ['clob', $mailTask->getRecipientsBCC()],
+            'mail_subject' => ['text', $mailTask->getSubject()],
+            'mail_body' => ['clob', $mailTask->getBody()],
+            'attachments' => ['blob', serialize($mailTask->getAttachments())],
+            'use_placeholders' => ['integer', $mailTask->isUsingPlaceholders()],
+            'save_in_sentbox' => ['integer', $mailTask->shouldSaveInSentBox()],
+            'tpl_ctx_id' => ['text', $mailTask->getTemplateContextId()],
+            'tpl_ctx_params' => ['blob', serialize($mailTask->getTemplateContextParams())],
+            'created_ts' => ['integer', time()]
+        ]);
+
+        return $uuid;
+    }
+
+    public function delete(string $uuidString) : void
+    {
+        $this->db->manipulateF(
+            "DELETE FROM " . self::TABLE_NAME . " WHERE queue_item_id = %s",
+            ['text'],
+            [$uuidString]
+        );
+    }
+
+    public function findByUuid(string $uuidString) : ilMailValueObject
+    {
+        $result = $this->db->queryF(
+            "SELECT * FROM " . self::TABLE_NAME . " WHERE queue_item_id = %s",
+            ['text'],
+            [$uuidString]
+        );
+        if (1 !== (int) $this->db->numRows($result)) {
+            throw new ilCouldNotFindQueueTaskException("Could not find mail task by uuid $uuidString");
+        }
+
+        $row = $this->db->fetchAssoc($result);
+
+        $mailObject = new ilMailValueObject(
+            '',
+            (string) $row['rcp_to'],
+            (string) $row['rcp_cc'],
+            (string) $row['rcp_bcc'],
+            (string) $row['mail_subject'],
+            (string) $row['mail_body'],
+            (array) unserialize(
+                $row['attachments'],
+                ['allowed_classes' => false]
+            ),
+            (bool) $row['use_placeholders'],
+            (bool) $row['save_in_sentbox'],
+        );
+        
+        if ($row['actor_usr_id']) {
+            $mailObject = $mailObject->withActorUsrId((int) $row['actor_usr_id']);
+        }
+
+        if ($row['tpl_ctx_id']) {
+            $mailObject = $mailObject->withTemplateContextId((string) $row['tpl_ctx_id']);
+        }
+
+        if ($row['tpl_ctx_params']) {
+            $mailObject = $mailObject->withTemplateContextParams((array) unserialize(
+                $row['tpl_ctx_params'],
+                ['allowed_classes' => false]
+            ));
+        }
+
+        return $mailObject;
+    }
+}

--- a/Services/Mail/classes/BackgroundTask/class.ilMassMailDeliveryJob.php
+++ b/Services/Mail/classes/BackgroundTask/class.ilMassMailDeliveryJob.php
@@ -49,9 +49,12 @@ class ilMassMailDeliveryJob extends AbstractJob
 
             $mail->setSaveInSentbox((bool) $mailValueObject->shouldSaveInSentBox());
             $contextId = $input[2]->getValue();
-            $mail = $mail
-                ->withContextId((string) $contextId)
-                ->withContextParameters((array) unserialize($input[3]->getValue()));
+            
+            if ($contextId) {
+                $mail = $mail
+                    ->withContextId((string) $contextId)
+                    ->withContextParameters((array) unserialize($input[3]->getValue()));
+            }
 
             $recipients = (string) $mailValueObject->getRecipients();
             $recipientsCC = (string) $mailValueObject->getRecipientsCC();

--- a/Services/Mail/classes/Object/class.ilMailQueuedTaskRepository.php
+++ b/Services/Mail/classes/Object/class.ilMailQueuedTaskRepository.php
@@ -8,7 +8,7 @@
 class ilMailQueuedTaskRepository
 {
     private const TABLE_NAME = 'mail_task_queue';
-    
+
     /** @var ilDBInterface */
     private $db;
     /** @var \ILIAS\Data\UUID\Factory */

--- a/Services/Mail/classes/Object/class.ilMailValueObject.php
+++ b/Services/Mail/classes/Object/class.ilMailValueObject.php
@@ -32,6 +32,15 @@ class ilMailValueObject
 
     /** @var string */
     private $from;
+    
+    /** @var null|int */
+    private $actorUsrId;
+
+    /** @var null|string */
+    private $templateContextId;
+
+    /** @var null|array */
+    private $templateContextParams;
 
     /**
      * @param string $from
@@ -136,5 +145,50 @@ class ilMailValueObject
     public function getFrom() : string
     {
         return $this->from;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getActorUsrId() : ?int
+    {
+        return $this->actorUsrId;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getTemplateContextId() : ?string
+    {
+        return $this->templateContextId;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getTemplateContextParams() : ?array
+    {
+        return $this->templateContextParams;
+    }
+
+    public function withActorUsrId(?int $id) : self
+    {
+        $clone = clone $this;
+        $clone->actorUsrId = $id;
+        return $clone;
+    }
+
+    public function withTemplateContextId(?string $id) : self
+    {
+        $clone = clone $this;
+        $clone->templateContextId = $id;
+        return $clone;
+    }
+
+    public function withTemplateContextParams(?array $params) : self
+    {
+        $clone = clone $this;
+        $clone->templateContextParams = $params;
+        return $clone;
     }
 }

--- a/Services/Mail/classes/Object/class.ilMailValueObject.php
+++ b/Services/Mail/classes/Object/class.ilMailValueObject.php
@@ -30,9 +30,6 @@ class ilMailValueObject
     /** @var bool */
     private $saveInSentBox;
 
-    /** @var string */
-    private $from;
-    
     /** @var null|int */
     private $actorUsrId;
 
@@ -43,7 +40,6 @@ class ilMailValueObject
     private $templateContextParams;
 
     /**
-     * @param string $from
      * @param string $recipients
      * @param string $recipientsCC
      * @param string $recipientsBCC
@@ -54,7 +50,6 @@ class ilMailValueObject
      * @param bool $saveInSentBox
      */
     public function __construct(
-        string $from,
         string $recipients,
         string $recipientsCC,
         string $recipientsBCC,
@@ -64,7 +59,6 @@ class ilMailValueObject
         bool $usePlaceholders = false,
         bool $saveInSentBox = false
     ) {
-        $this->from = $from;
         $this->recipients = $recipients;
         $this->recipientsCC = $recipientsCC;
         $this->recipientsBCC = $recipientsBCC;
@@ -75,41 +69,26 @@ class ilMailValueObject
         $this->saveInSentBox = $saveInSentBox;
     }
 
-    /**
-     * @return string
-     */
     public function getRecipients() : string
     {
         return $this->recipients;
     }
 
-    /**
-     * @return string
-     */
     public function getRecipientsCC() : string
     {
         return $this->recipientsCC;
     }
 
-    /**
-     * @return string
-     */
     public function getRecipientsBCC() : string
     {
         return $this->recipientsBCC;
     }
 
-    /**
-     * @return string
-     */
     public function getSubject() : string
     {
         return $this->subject;
     }
 
-    /**
-     * @return string
-     */
     public function getBody() : string
     {
         return $this->body;
@@ -123,49 +102,31 @@ class ilMailValueObject
         return $this->attachments;
     }
 
-    /**
-     * @return bool
-     */
     public function isUsingPlaceholders() : bool
     {
         return $this->usePlaceholders;
     }
 
-    /**
-     * @return bool
-     */
     public function shouldSaveInSentBox() : bool
     {
         return $this->saveInSentBox;
     }
 
-    /**
-     * @return string
-     */
     public function getFrom() : string
     {
         return $this->from;
     }
 
-    /**
-     * @return int|null
-     */
     public function getActorUsrId() : ?int
     {
         return $this->actorUsrId;
     }
 
-    /**
-     * @return string|null
-     */
     public function getTemplateContextId() : ?string
     {
         return $this->templateContextId;
     }
 
-    /**
-     * @return array|null
-     */
     public function getTemplateContextParams() : ?array
     {
         return $this->templateContextParams;

--- a/Services/Mail/classes/Object/class.ilMailValueObject.php
+++ b/Services/Mail/classes/Object/class.ilMailValueObject.php
@@ -1,11 +1,15 @@
-<?php
+<?php declare(strict_types=1);
 /* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 /**
- * @author  Niels Theen <ntheen@databay.de>
+ * @author Niels Theen <ntheen@databay.de>
+ * @author Michael Jansen <mjansen@databay.de>
  */
 class ilMailValueObject
 {
+    /** @var int */
+    private $actorUsrId;
+
     /** @var string */
     private $recipients;
 
@@ -30,9 +34,6 @@ class ilMailValueObject
     /** @var bool */
     private $saveInSentBox;
 
-    /** @var null|int */
-    private $actorUsrId;
-
     /** @var null|string */
     private $templateContextId;
 
@@ -40,6 +41,7 @@ class ilMailValueObject
     private $templateContextParams;
 
     /**
+     * @param int $actorUsrId
      * @param string $recipients
      * @param string $recipientsCC
      * @param string $recipientsBCC
@@ -50,6 +52,7 @@ class ilMailValueObject
      * @param bool $saveInSentBox
      */
     public function __construct(
+        int $actorUsrId,
         string $recipients,
         string $recipientsCC,
         string $recipientsBCC,
@@ -59,6 +62,7 @@ class ilMailValueObject
         bool $usePlaceholders = false,
         bool $saveInSentBox = false
     ) {
+        $this->actorUsrId = $actorUsrId;
         $this->recipients = $recipients;
         $this->recipientsCC = $recipientsCC;
         $this->recipientsBCC = $recipientsBCC;
@@ -67,6 +71,11 @@ class ilMailValueObject
         $this->attachments = array_filter(array_map('trim', $attachments));
         $this->usePlaceholders = $usePlaceholders;
         $this->saveInSentBox = $saveInSentBox;
+    }
+
+    public function getActorUsrId() : int
+    {
+        return $this->actorUsrId;
     }
 
     public function getRecipients() : string
@@ -112,16 +121,6 @@ class ilMailValueObject
         return $this->saveInSentBox;
     }
 
-    public function getFrom() : string
-    {
-        return $this->from;
-    }
-
-    public function getActorUsrId() : ?int
-    {
-        return $this->actorUsrId;
-    }
-
     public function getTemplateContextId() : ?string
     {
         return $this->templateContextId;
@@ -130,13 +129,6 @@ class ilMailValueObject
     public function getTemplateContextParams() : ?array
     {
         return $this->templateContextParams;
-    }
-
-    public function withActorUsrId(?int $id) : self
-    {
-        $clone = clone $this;
-        $clone->actorUsrId = $id;
-        return $clone;
     }
 
     public function withTemplateContextId(?string $id) : self

--- a/Services/Mail/classes/Object/class.ilMailValueObjectJsonService.php
+++ b/Services/Mail/classes/Object/class.ilMailValueObjectJsonService.php
@@ -11,13 +11,12 @@ class ilMailValueObjectJsonService
      * @param ilMailValueObject[] $mailValueObjects
      * @return string
      */
-    public function convertToJson(array $mailValueObjects)
+    public function convertToJson(array $mailValueObjects) : string
     {
-        $mailArray = array();
+        $mailArray = [];
         foreach ($mailValueObjects as $mailValueObject) {
-            $array = array();
+            $array = [];
 
-            $array['from'] = $mailValueObject->getFrom();
             $array['recipients'] = $mailValueObject->getRecipients();
             $array['recipients_cc'] = $mailValueObject->getRecipientsCC();
             $array['recipients_bcc'] = $mailValueObject->getRecipientsBCC();
@@ -37,14 +36,13 @@ class ilMailValueObjectJsonService
      * @param string $json
      * @return ilMailValueObject[]
      */
-    public function convertFromJson(string $json)
+    public function convertFromJson(string $json) : array
     {
-        $result = array();
+        $result = [];
         $array = json_decode($json, true);
 
         foreach ($array as $objectValues) {
             $result[] = new ilMailValueObject(
-                $objectValues['from'],
                 $objectValues['recipients'],
                 $objectValues['recipients_cc'],
                 $objectValues['recipients_bcc'],

--- a/Services/Mail/classes/Object/class.ilMailValueObjectJsonService.php
+++ b/Services/Mail/classes/Object/class.ilMailValueObjectJsonService.php
@@ -17,6 +17,7 @@ class ilMailValueObjectJsonService
         foreach ($mailValueObjects as $mailValueObject) {
             $array = [];
 
+            $array['actor_usr_id'] = $mailValueObject->getActorUsrId();
             $array['recipients'] = $mailValueObject->getRecipients();
             $array['recipients_cc'] = $mailValueObject->getRecipientsCC();
             $array['recipients_bcc'] = $mailValueObject->getRecipientsBCC();
@@ -42,7 +43,13 @@ class ilMailValueObjectJsonService
         $array = json_decode($json, true);
 
         foreach ($array as $objectValues) {
+            $actorId = 0;
+            if (isset($objectValues['actor_usr_id'])) {
+                $actorId = (int) $objectValues['actor_usr_id'];
+            }
+
             $result[] = new ilMailValueObject(
+                $actorId,
                 $objectValues['recipients'],
                 $objectValues['recipients_cc'],
                 $objectValues['recipients_bcc'],

--- a/Services/Mail/classes/class.ilMail.php
+++ b/Services/Mail/classes/class.ilMail.php
@@ -1260,6 +1260,7 @@ class ilMail
         $bucket->setUserId($this->user_id);
 
         $mailObject = new ilMailValueObject(
+            (int) $this->user_id,
             (string) $rcp_to,
             (string) $rcp_cc,
             (string) $rcp_bcc,

--- a/Services/Mail/classes/class.ilMail.php
+++ b/Services/Mail/classes/class.ilMail.php
@@ -1260,7 +1260,6 @@ class ilMail
         $bucket->setUserId($this->user_id);
 
         $mailObject = new ilMailValueObject(
-            '',
             (string) $rcp_to,
             (string) $rcp_cc,
             (string) $rcp_bcc,

--- a/Services/Mail/test/ilMailTaskProcessorTest.php
+++ b/Services/Mail/test/ilMailTaskProcessorTest.php
@@ -12,6 +12,8 @@ use ILIAS\DI\Container;
  */
 class ilMailTaskProcessorTest extends ilMailBaseTest
 {
+    private const ACTOR_USR_ID = 4711;
+
     /** @var ilLanguage */
     private $languageMock;
 
@@ -83,6 +85,7 @@ class ilMailTaskProcessorTest extends ilMailBaseTest
         );
 
         $mailValueObject = new ilMailValueObject(
+            self::ACTOR_USR_ID,
             'somebody@iliase.de',
             '',
             '',
@@ -154,6 +157,7 @@ class ilMailTaskProcessorTest extends ilMailBaseTest
         $mailValueObjects = [];
 
         $mailValueObjects[] = new ilMailValueObject(
+            self::ACTOR_USR_ID,
             'somebody@iliase.de',
             '',
             '',
@@ -163,6 +167,7 @@ class ilMailTaskProcessorTest extends ilMailBaseTest
         );
 
         $mailValueObjects[] = new ilMailValueObject(
+            self::ACTOR_USR_ID,
             'somebodyelse@iliase.de',
             '',
             '',
@@ -230,6 +235,7 @@ class ilMailTaskProcessorTest extends ilMailBaseTest
         $mailValueObjects = [];
 
         $mailValueObjects[] = new ilMailValueObject(
+            self::ACTOR_USR_ID,
             'somebody@iliase.de',
             '',
             '',
@@ -239,6 +245,7 @@ class ilMailTaskProcessorTest extends ilMailBaseTest
         );
 
         $mailValueObjects[] = new ilMailValueObject(
+            self::ACTOR_USR_ID,
             'somebodyelse@iliase.de',
             '',
             '',
@@ -248,6 +255,7 @@ class ilMailTaskProcessorTest extends ilMailBaseTest
         );
 
         $mailValueObjects[] = new ilMailValueObject(
+            self::ACTOR_USR_ID,
             'somebody@iliase.de',
             '',
             '',
@@ -318,6 +326,7 @@ class ilMailTaskProcessorTest extends ilMailBaseTest
         $mailValueObjects = [];
 
         $mailValueObjects[] = new ilMailValueObject(
+            self::ACTOR_USR_ID,
             'somebody@iliase.de',
             '',
             '',
@@ -327,6 +336,7 @@ class ilMailTaskProcessorTest extends ilMailBaseTest
         );
 
         $mailValueObjects[] = new ilMailValueObject(
+            self::ACTOR_USR_ID,
             'somebodyelse@iliase.de',
             '',
             '',

--- a/Services/Mail/test/ilMailTaskProcessorTest.php
+++ b/Services/Mail/test/ilMailTaskProcessorTest.php
@@ -83,7 +83,6 @@ class ilMailTaskProcessorTest extends ilMailBaseTest
         );
 
         $mailValueObject = new ilMailValueObject(
-            'ilias@server.com',
             'somebody@iliase.de',
             '',
             '',
@@ -155,7 +154,6 @@ class ilMailTaskProcessorTest extends ilMailBaseTest
         $mailValueObjects = [];
 
         $mailValueObjects[] = new ilMailValueObject(
-            'ilias@server.com',
             'somebody@iliase.de',
             '',
             '',
@@ -165,7 +163,6 @@ class ilMailTaskProcessorTest extends ilMailBaseTest
         );
 
         $mailValueObjects[] = new ilMailValueObject(
-            'ilias@server.com',
             'somebodyelse@iliase.de',
             '',
             '',
@@ -233,7 +230,6 @@ class ilMailTaskProcessorTest extends ilMailBaseTest
         $mailValueObjects = [];
 
         $mailValueObjects[] = new ilMailValueObject(
-            'ilias@server.com',
             'somebody@iliase.de',
             '',
             '',
@@ -243,7 +239,6 @@ class ilMailTaskProcessorTest extends ilMailBaseTest
         );
 
         $mailValueObjects[] = new ilMailValueObject(
-            'ilias@server.com',
             'somebodyelse@iliase.de',
             '',
             '',
@@ -253,7 +248,6 @@ class ilMailTaskProcessorTest extends ilMailBaseTest
         );
 
         $mailValueObjects[] = new ilMailValueObject(
-            'ilias@server.com',
             'somebody@iliase.de',
             '',
             '',
@@ -324,7 +318,6 @@ class ilMailTaskProcessorTest extends ilMailBaseTest
         $mailValueObjects = [];
 
         $mailValueObjects[] = new ilMailValueObject(
-            'ilias@server.com',
             'somebody@iliase.de',
             '',
             '',
@@ -334,7 +327,6 @@ class ilMailTaskProcessorTest extends ilMailBaseTest
         );
 
         $mailValueObjects[] = new ilMailValueObject(
-            'ilias@server.com',
             'somebodyelse@iliase.de',
             '',
             '',

--- a/setup/sql/dbupdate_05.php
+++ b/setup/sql/dbupdate_05.php
@@ -6554,3 +6554,85 @@ if (!$ilDB->indexExistsByFields('booking_reservation', array('date_to'))) {
     $ilDB->addIndex('booking_reservation', array('date_to'), 'i4');
 }
 ?>
+<#5788>
+<?php
+if (!$ilDB->tableExists('mail_task_queue')) {
+    $ilDB->createTable(
+        'mail_task_queue',
+        [
+            'queue_item_id' => [
+                'type' => 'text',
+                'length' => 100,
+                'notnull' => true
+            ],
+            'actor_usr_id' => [
+                'type' => 'integer',
+                'length' => 8,
+                'notnull' => true,
+                'default' => 0
+            ],
+            'rcp_to' => [
+                'type' => 'clob',
+                'notnull' => false,
+                'default' => null
+            ],
+            'rcp_cc' => [
+                'type' => 'clob',
+                'notnull' => false,
+                'default' => null
+            ],
+            'rcp_bcc' => [
+                'type' => 'clob',
+                'notnull' => false,
+                'default' => null
+            ],
+            'mail_subject' => [
+                'type' => 'text',
+                'length' => 255,
+                'notnull' => false,
+                'default' => null
+            ],
+            'mail_body' => [
+                'type' => 'clob',
+                'notnull' => false,
+                'default' => null
+            ],
+            'attachments' => [
+                'type' => 'blob',
+                'notnull' => false,
+                'default' => null
+            ],
+            'use_placeholders' => [
+                'type' => 'integer',
+                'length' => 1,
+                'notnull' => true,
+                'default' => 0
+            ],
+            'save_in_sentbox' => [
+                'type' => 'integer',
+                'length' => 1,
+                'notnull' => true,
+                'default' => 0
+            ],
+            'tpl_ctx_id' => [
+                'type' => 'text',
+                'length' => 100,
+                'notnull' => false,
+                'default' => null
+            ],
+            'tpl_ctx_params' => [
+                'type' => 'blob',
+                'notnull' => false,
+                'default' => null
+            ],
+            'created_ts' => [
+                'type' => 'integer',
+                'length' => 8,
+                'notnull' => true,
+                'default' => 0
+            ]
+        ]
+    );
+    $ilDB->addPrimaryKey('mail_task_queue', ['queue_item_id']);
+}
+?>


### PR DESCRIPTION
The `Mail` component uses `Background Tasks` internally to process the incoming email delivery tasks (according to the JourFixe decision in 2019). But there could be issues when using `Background Tasks`  with many parameters, like documented in:

- https://mantis.ilias.de/view.php?id=28515
- https://mantis.ilias.de/view.php?id=26888
- https://mantis.ilias.de/view.php?id=24961

These issues are hard (read: impossible) to reproduce and the reason could not be found until now.

Currently the `Mail` component passes all it's parameters (to, cc, bcc, ...) to the `Bucket`/`Task`.

This PR introduces a new  `Background Task` used by the `Mail` component which only passes a `Uuid`. All related data is stored by the `Mail` component in a new database table before running the `Task Manager`. When the concrete `Background Task` gets executed, the mail properties are fetched from database and processed. Afterwards, the processed record will be deleted.