### PR TITLE
Fix and Improve OpenID Connect integration

### DIFF
--- a/Services/OpenIdConnect/classes/class.ilAuthProviderOpenIdConnect.php
+++ b/Services/OpenIdConnect/classes/class.ilAuthProviderOpenIdConnect.php
@@ -1,7 +1,7 @@
 <?php
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-use Jumbojett\OpenIDConnectClient;
+use JuliusPC\OpenIDConnectClient;
 
 /**
  * Class ilAuthProviderOpenIdConnect
@@ -37,14 +37,14 @@ class ilAuthProviderOpenIdConnect extends ilAuthProvider implements ilAuthProvid
             return false;
         }
 
-        $auth_token = ilSession::get('oidc_auth_token');
-        $this->getLogger()->debug('Using token: ' . $auth_token);
+        $idtoken = ilSession::get('oidc_auth_idtoken');
+        $this->getLogger()->debug('Using token: ' . $idtoken);
 
-        if (strlen($auth_token)) {
-            ilSession::set('oidc_auth_token', '');
+        if (strlen($idtoken)) {
+            ilSession::set('oidc_auth_idtoken', '');
             $oidc = $this->initClient();
             $oidc->signOut(
-                $auth_token,
+                $idtoken,
                 ILIAS_HTTP_PATH . '/logout.php'
             );
         }
@@ -95,8 +95,7 @@ class ilAuthProviderOpenIdConnect extends ilAuthProvider implements ilAuthProvid
             $_GET['target'] = (string) $this->getCredentials()->getRedirectionTarget();
 
             if ($this->settings->getLogoutScope() == ilOpenIdConnectSettings::LOGOUT_SCOPE_GLOBAL) {
-                $token = $oidc->requestClientCredentialsToken();
-                ilSession::set('oidc_auth_token', $token->access_token);
+                ilSession::set('oidc_auth_idtoken', $oidc->getIdToken());
             }
             return true;
         } catch (Exception $e) {

--- a/Services/OpenIdConnect/classes/class.ilAuthProviderOpenIdConnect.php
+++ b/Services/OpenIdConnect/classes/class.ilAuthProviderOpenIdConnect.php
@@ -76,27 +76,18 @@ class ilAuthProviderOpenIdConnect extends ilAuthProvider implements ilAuthProvid
                 $oidc->getRedirectURL()
             );
 
-            $oidc->setResponseTypes(
-                [
-                    'id_token'
-                ]
-            );
-
-
             $oidc->addScope($this->settings->getAllScopes());
-            $oidc->addAuthParam(['response_mode' => 'form_post']);
             switch ($this->settings->getLoginPromptType()) {
                 case ilOpenIdConnectSettings::LOGIN_ENFORCE:
                     $oidc->addAuthParam(['prompt' => 'login']);
                     break;
             }
-            $oidc->setAllowImplicitFlow(true);
 
             $oidc->authenticate();
             // user is authenticated, otherwise redirected to authorization endpoint or exception
             $this->getLogger()->dump($_REQUEST, \ilLogLevel::DEBUG);
 
-            $claims = $oidc->getVerifiedClaims(null);
+            $claims = $oidc->requestUserInfo();
             $this->getLogger()->dump($claims, \ilLogLevel::DEBUG);
             $status = $this->handleUpdate($status, $claims);
 

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
 		"league/flysystem": "^1.0",
 		"james-heinrich/getid3": "^1.9",
 		"phpoffice/phpspreadsheet": "^1.9.0",
-		"jumbojett/openid-connect-php": "^0.9.2",
 		"sabre/dav": "~3.2.2",
 		"symfony/console" : "^4.2",
 		"slim/slim": "^3.11",
@@ -52,7 +51,8 @@
 		"enshrined/svg-sanitize": "^0.13.0",
 		"guzzlehttp/guzzle": "^6.3",
 		"zendframework/zend-httphandlerrunner": "^1.1.0",
-		"simplesamlphp/simplesamlphp": "^1.18"
+		"simplesamlphp/simplesamlphp": "^1.18",
+		"juliuspc/openid-connect-php": "^1.1"
 	},
 	"require-dev": {
 		"mikey179/vfsstream": "^1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc75e3cfc35397fba8b388f84307c8da",
+    "content-hash": "52a21e56383a3e76fa58af6477afa5cd",
     "packages": [
         {
             "name": "cweagans/composer-patches",
@@ -716,17 +716,17 @@
             "time": "2020-06-30T18:43:34+00:00"
         },
         {
-            "name": "jumbojett/openid-connect-php",
-            "version": "v0.9.2",
+            "name": "juliuspc/openid-connect-php",
+            "version": "v1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/jumbojett/OpenID-Connect-PHP.git",
-                "reference": "4f95102af87f86c43e8191ec6e90d9f35ed1ce5f"
+                "url": "https://github.com/JuliusPC/OpenID-Connect-PHP.git",
+                "reference": "24a4ee0ba5776f7a119824946ab7bdf9e4d02fd0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jumbojett/OpenID-Connect-PHP/zipball/4f95102af87f86c43e8191ec6e90d9f35ed1ce5f",
-                "reference": "4f95102af87f86c43e8191ec6e90d9f35ed1ce5f",
+                "url": "https://api.github.com/repos/JuliusPC/OpenID-Connect-PHP/zipball/24a4ee0ba5776f7a119824946ab7bdf9e4d02fd0",
+                "reference": "24a4ee0ba5776f7a119824946ab7bdf9e4d02fd0",
                 "shasum": ""
             },
             "require": {
@@ -750,8 +750,23 @@
             "license": [
                 "Apache-2.0"
             ],
-            "description": "Bare-bones OpenID Connect client",
-            "time": "2020-11-16T14:48:22+00:00"
+            "description": "OpenID Connect client",
+            "keywords": [
+                "OpenID Connect",
+                "RFC7009",
+                "RFC7662",
+                "SSO",
+                "client",
+                "oauth 2",
+                "oidc",
+                "rfc6749",
+                "rfc7636"
+            ],
+            "support": {
+                "issues": "https://github.com/JuliusPC/OpenID-Connect-PHP/issues",
+                "source": "https://github.com/JuliusPC/OpenID-Connect-PHP/tree/v1.1.1"
+            },
+            "time": "2021-05-14T12:47:35+00:00"
         },
         {
             "name": "league/flysystem",
@@ -1557,16 +1572,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "2.0.1",
+            "version": "2.0.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "ba6fb78f727cd09f2a649113b95468019e490585"
+                "reference": "233a920cb38636a43b18d428f9a8db1f0a1a08f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/ba6fb78f727cd09f2a649113b95468019e490585",
-                "reference": "ba6fb78f727cd09f2a649113b95468019e490585",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/233a920cb38636a43b18d428f9a8db1f0a1a08f4",
+                "reference": "233a920cb38636a43b18d428f9a8db1f0a1a08f4",
                 "shasum": ""
             },
             "require": {
@@ -1574,8 +1589,7 @@
             },
             "require-dev": {
                 "phing/phing": "~2.7",
-                "phpunit/phpunit": "~4.0",
-                "sami/sami": "~2.0",
+                "phpunit/phpunit": "^4.8.35|^5.7|^6.0|^9.4",
                 "squizlabs/php_codesniffer": "~2.0"
             },
             "suggest": {
@@ -1586,6 +1600,9 @@
             },
             "type": "library",
             "autoload": {
+                "files": [
+                    "phpseclib/bootstrap.php"
+                ],
                 "psr-4": {
                     "phpseclib\\": "phpseclib/"
                 }
@@ -1642,7 +1659,25 @@
                 "x.509",
                 "x509"
             ],
-            "time": "2016-01-18T17:07:21+00:00"
+            "support": {
+                "issues": "https://github.com/phpseclib/phpseclib/issues",
+                "source": "https://github.com/phpseclib/phpseclib/tree/2.0.31"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/terrafrost",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpseclib",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpseclib/phpseclib",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-04-06T13:56:45+00:00"
         },
         {
             "name": "pimple/pimple",
@@ -8691,5 +8726,6 @@
     "platform": {
         "php": "^7.3"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
The current OIDC integration has three major flaws:

1. It uses the Implicit Flow instead of the Code Flow. The Implicit Flow should be considered deprecated (and will be in OAuth 2.1) and provides no relevant advantages over using the Code Flow, especially when the application is a confidential client (which ILIAS is, since the code is run on the server and not on the client). Since I couldn't find any comment why Implicit Flow is used, I think it was introduced by copying example code from the library's documentation.
2. The Logout is totally broken and likely never worked. There is no need to pass any Access Token to the Endsession Endpoint. Instead, you just need to provide the ID Token. This may be caused by [incorrect parameter naming in the used library](https://github.com/JuliusPC/OpenID-Connect-PHP/commit/b4eacdb384bc39fedf04c4dd16faedf3ba1668f3).
3. The used library is poorly maintained and has [multiple flaws](https://github.com/JuliusPC/OpenID-Connect-PHP/wiki/Progress-on-fixing-upstream-issues). Therefore, I forked the library and included it in this PR.

All points above are fixed by this PR.

The first and the last change allow to use PKCE if the OpenID Provider supports it.