### PR TITLE
Modules forum double underscore function name

### DIFF
--- a/Modules/Forum/classes/class.ilFileDataForum.php
+++ b/Modules/Forum/classes/class.ilFileDataForum.php
@@ -367,7 +367,7 @@ class ilFileDataForum extends ilFileData
     * @access	private
     * @return bool
     */
-    public function checkReadWrite()
+    private function checkReadWrite()
     {
         if (is_writable($this->forum_path) && is_readable($this->forum_path)) {
             return true;
@@ -378,10 +378,9 @@ class ilFileDataForum extends ilFileData
     /**
     * init directory
     * overwritten method
-    * @access	public
     * @return string path
     */
-    public function initDirectory()
+    private function initDirectory()
     {
         if (is_writable($this->getPath())) {
             if (mkdir($this->getPath() . '/' . FORUM_PATH)) {
@@ -397,10 +396,9 @@ class ilFileDataForum extends ilFileData
     * rotate files with same name
     * recursive method
     * @param string filename
-    * @access	private
     * @return bool
     */
-    public function rotateFiles($a_path)
+    private function rotateFiles($a_path)
     {
         if (file_exists($a_path)) {
             $this->rotateFiles($a_path . ".old");

--- a/Modules/Forum/classes/class.ilFileDataForum.php
+++ b/Modules/Forum/classes/class.ilFileDataForum.php
@@ -46,7 +46,7 @@ class ilFileDataForum extends ilFileData
         
         // IF DIRECTORY ISN'T CREATED CREATE IT
         if (!$this->__checkPath()) {
-            $this->__initDirectory();
+            $this->initDirectory();
         }
         $this->obj_id = $a_obj_id;
         $this->pos_id = $a_pos_id;
@@ -216,7 +216,7 @@ class ilFileDataForum extends ilFileData
                 if (strlen($filename) && strlen($temp_name) && $error == 0) {
                     $path = $this->getForumPath() . '/' . $this->obj_id . '_' . $this->pos_id . '_' . $filename;
                     
-                    $this->__rotateFiles($path);
+                    $this->rotateFiles($path);
                     ilUtil::moveUploadedFile($temp_name, $filename, $path);
                 }
             }
@@ -231,7 +231,7 @@ class ilFileDataForum extends ilFileData
             
             $path = $this->getForumPath() . '/' . $this->obj_id . '_' . $this->pos_id . '_' . $filename;
             
-            $this->__rotateFiles($path);
+            $this->rotateFiles($path);
             ilUtil::moveUploadedFile($temp_name, $filename, $path);
             
             return true;
@@ -354,7 +354,7 @@ class ilFileDataForum extends ilFileData
         if (!@file_exists($this->getForumPath())) {
             return false;
         }
-        $this->__checkReadWrite();
+        $this->checkReadWrite();
 
         return true;
     }
@@ -364,7 +364,7 @@ class ilFileDataForum extends ilFileData
     * @access	private
     * @return bool
     */
-    public function __checkReadWrite()
+    public function checkReadWrite()
     {
         if (is_writable($this->forum_path) && is_readable($this->forum_path)) {
             return true;
@@ -378,7 +378,7 @@ class ilFileDataForum extends ilFileData
     * @access	public
     * @return string path
     */
-    public function __initDirectory()
+    public function initDirectory()
     {
         if (is_writable($this->getPath())) {
             if (mkdir($this->getPath() . '/' . FORUM_PATH)) {
@@ -397,10 +397,10 @@ class ilFileDataForum extends ilFileData
     * @access	private
     * @return bool
     */
-    public function __rotateFiles($a_path)
+    public function rotateFiles($a_path)
     {
         if (file_exists($a_path)) {
-            $this->__rotateFiles($a_path . ".old");
+            $this->rotateFiles($a_path . ".old");
             return \ilFileUtils::rename($a_path, $a_path . '.old');
         }
         return true;

--- a/Modules/Forum/classes/class.ilFileDataForum.php
+++ b/Modules/Forum/classes/class.ilFileDataForum.php
@@ -45,7 +45,7 @@ class ilFileDataForum extends ilFileData
         $this->forum_path = parent::getPath() . "/" . FORUM_PATH;
         
         // IF DIRECTORY ISN'T CREATED CREATE IT
-        if (!$this->__checkPath()) {
+        if (!$this->checkForumPath()) {
             $this->initDirectory();
         }
         $this->obj_id = $a_obj_id;
@@ -348,8 +348,11 @@ class ilFileDataForum extends ilFileData
         return true;
     }
 
-    // PRIVATE METHODS
-    public function __checkPath()
+    /**
+     * Checks if the forum path exists and is writeable
+     * @return bool
+     */
+    private function checkForumPath() : bool
     {
         if (!@file_exists($this->getForumPath())) {
             return false;

--- a/Modules/Forum/classes/class.ilFileDataForumDrafts.php
+++ b/Modules/Forum/classes/class.ilFileDataForumDrafts.php
@@ -31,7 +31,7 @@ class ilFileDataForumDrafts extends ilFileData
         
         // IF DIRECTORY ISN'T CREATED CREATE IT
         if (!$this->__checkPath()) {
-            $this->__initDirectory();
+            $this->initDirectory();
         }
     }
     
@@ -176,7 +176,7 @@ class ilFileDataForumDrafts extends ilFileData
                 if (strlen($filename) && strlen($temp_name) && $error == 0) {
                     $path = $this->getDraftsPath() . '/' . $this->getDraftId() . '/' . $filename;
                     
-                    $this->__rotateFiles($path);
+                    $this->rotateFiles($path);
                     ilUtil::moveUploadedFile($temp_name, $filename, $path);
                 }
             }
@@ -192,7 +192,7 @@ class ilFileDataForumDrafts extends ilFileData
             
             $path = $this->getDraftsPath() . '/' . $this->getDraftId() . '/' . $filename;
             
-            $this->__rotateFiles($path);
+            $this->rotateFiles($path);
             ilUtil::moveUploadedFile($temp_name, $filename, $path);
             
             return true;
@@ -315,7 +315,7 @@ class ilFileDataForumDrafts extends ilFileData
         if (!@file_exists($this->getDraftsPath() . '/' . $this->getDraftId())) {
             return false;
         }
-        $this->__checkReadWrite();
+        $this->checkReadWrite();
         
         return true;
     }
@@ -325,7 +325,7 @@ class ilFileDataForumDrafts extends ilFileData
      * @access	private
      * @return bool
      */
-    public function __checkReadWrite()
+    public function checkReadWrite()
     {
         if (is_writable($this->getDraftsPath() . '/' . $this->getDraftId()) && is_readable($this->getDraftsPath() . '/' . $this->getDraftId())) {
             return true;
@@ -339,7 +339,7 @@ class ilFileDataForumDrafts extends ilFileData
      * @access	public
      * @return string path
      */
-    public function __initDirectory()
+    public function initDirectory()
     {
         if (is_writable($this->getPath())) {
             if (ilUtil::makeDirParents($this->getDraftsPath() . "/" . $this->getDraftId())) {
@@ -357,10 +357,10 @@ class ilFileDataForumDrafts extends ilFileData
      * @access	private
      * @return bool
      */
-    public function __rotateFiles($a_path)
+    public function rotateFiles($a_path)
     {
         if (file_exists($a_path)) {
-            $this->__rotateFiles($a_path . ".old");
+            $this->rotateFiles($a_path . ".old");
             return \ilFileUtils::rename($a_path, $a_path . '.old');
         }
         return true;

--- a/Modules/Forum/classes/class.ilFileDataForumDrafts.php
+++ b/Modules/Forum/classes/class.ilFileDataForumDrafts.php
@@ -325,10 +325,9 @@ class ilFileDataForumDrafts extends ilFileData
     /**
      * check if directory is writable
      * overwritten method from base class
-     * @access	private
      * @return bool
      */
-    public function checkReadWrite()
+    private function checkReadWrite()
     {
         if (is_writable($this->getDraftsPath() . '/' . $this->getDraftId()) && is_readable($this->getDraftsPath() . '/' . $this->getDraftId())) {
             return true;
@@ -339,10 +338,9 @@ class ilFileDataForumDrafts extends ilFileData
     /**
      * init directory
      * overwritten method
-     * @access	public
      * @return string path
      */
-    public function initDirectory()
+    private function initDirectory()
     {
         if (is_writable($this->getPath())) {
             if (ilUtil::makeDirParents($this->getDraftsPath() . "/" . $this->getDraftId())) {
@@ -357,10 +355,9 @@ class ilFileDataForumDrafts extends ilFileData
      * rotate files with same name
      * recursive method
      * @param string filename
-     * @access	private
      * @return bool
      */
-    public function rotateFiles($a_path)
+    private function rotateFiles($a_path)
     {
         if (file_exists($a_path)) {
             $this->rotateFiles($a_path . ".old");

--- a/Modules/Forum/classes/class.ilFileDataForumDrafts.php
+++ b/Modules/Forum/classes/class.ilFileDataForumDrafts.php
@@ -30,7 +30,7 @@ class ilFileDataForumDrafts extends ilFileData
         $this->drafts_path = parent::getPath() . "/" . FORUM_DRAFTS_PATH;
         
         // IF DIRECTORY ISN'T CREATED CREATE IT
-        if (!$this->__checkPath()) {
+        if (!$this->checkForumDraftsPath()) {
             $this->initDirectory();
         }
     }
@@ -308,15 +308,18 @@ class ilFileDataForumDrafts extends ilFileData
         }
         return true;
     }
-    
-    // PRIVATE METHODS
-    public function __checkPath()
+
+    /**
+     * Checks if the forum drafts path exists and is writable
+     * @return bool
+     */
+    public function checkForumDraftsPath() : bool
     {
         if (!@file_exists($this->getDraftsPath() . '/' . $this->getDraftId())) {
             return false;
         }
         $this->checkReadWrite();
-        
+
         return true;
     }
     /**

--- a/Modules/Forum/classes/class.ilForum.php
+++ b/Modules/Forum/classes/class.ilForum.php
@@ -846,7 +846,7 @@ class ilForum
         }
 
         // DELETE ATTACHMENTS ASSIGNED TO POST
-        $this->__deletePostFiles($del_id);
+        $this->deletePostFiles($del_id);
         
         $dead_pos = count($del_id);
         $dead_thr = 0;
@@ -1922,7 +1922,7 @@ class ilForum
         return $text;
     }
 
-    public function __deletePostFiles($a_ids)
+    public function deletePostFiles($a_ids)
     {
         if (!is_array($a_ids)) {
             return false;

--- a/Modules/Forum/classes/class.ilForum.php
+++ b/Modules/Forum/classes/class.ilForum.php
@@ -1922,7 +1922,7 @@ class ilForum
         return $text;
     }
 
-    public function deletePostFiles($a_ids)
+    private function deletePostFiles($a_ids)
     {
         if (!is_array($a_ids)) {
             return false;

--- a/Modules/Forum/classes/class.ilForumSettingsGUI.php
+++ b/Modules/Forum/classes/class.ilForumSettingsGUI.php
@@ -319,7 +319,7 @@ class ilForumSettingsGUI
                 $members = $this->getUserNotificationTableData($member_ids, $frm_noti);
                 $tutors = $this->getUserNotificationTableData($tutor_ids, $frm_noti);
 
-                $this->__showMembersTable($moderators, $admins, $members, $tutors);
+                $this->showMembersTable($moderators, $admins, $members, $tutors);
             }
         }
     }
@@ -352,7 +352,7 @@ class ilForumSettingsGUI
         return $users;
     }
 
-    private function __showMembersTable(array $moderators, array $admins, array $members, array $tutors)
+    private function showMembersTable(array $moderators, array $admins, array $members, array $tutors)
     {
         foreach (array_filter([
             'moderators' => $moderators,


### PR DESCRIPTION
Removed double underscore from functions inside **Modules/Forum/** to conform with PHP reserving the double underscore prefix.

- Also changed name of the **checkPath()** functions to prevent them from overwriting the parent function (and requiring the **$a_path** parameter to be added).
- Made previously prefixed functions private.