### PR TITLE
UI-Framework: load JavaScript at the end of the page

### DIFF
--- a/src/UI/templates/default/Layout/tpl.standardpage.html
+++ b/src/UI/templates/default/Layout/tpl.standardpage.html
@@ -21,10 +21,6 @@
 	<!-- BEGIN css_file -->
 	<link rel="stylesheet" type="text/css" href="{CSS_FILE}" />
 	<!-- END css_file -->
-
-	<!-- BEGIN js_file -->
-	<script type="text/javascript" src="{JS_FILE}"></script>
-	<!-- END js_file -->
 </head>
 <body>
 	<!-- BEGIN mode_info -->
@@ -79,7 +75,10 @@
 
 	</div>
 
-
+<!-- BEGIN js_file -->
+<script type="text/javascript" src="{JS_FILE}"></script>
+<!-- END js_file -->
+	
 <!-- BEGIN on_load_code -->
 <script type="text/javascript">
 	<!-- BEGIN on_load_code_inner -->


### PR DESCRIPTION
by @klees: This will load the javascript after the actual content of the page instead of before. This currently seems to be _the way_ (tm) how things are done in javascript land. It has the advantage, that content will be rendered by the browser earlier, as far as I understand. This also will allow @Hadrian-II to introduce a certain markdown editing library, that insisted on being loaded after the content. Also, this was the problem that actually spawned this change.