### PR TITLE
Rule for new files in root

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ You may even join us at one of our regular [ILIAS Conferences](http://www.ilias.
 ### Development
 
 Information on our software development processes and guidelines and ways to contribute can be found the the [development section](docs/development) of our documentation.
+
+
+### ILIAS Root Directory
+Requests to add new files and directories in the root directory of ILIAS MUST be presented as development issues at and approved by the Jour Fixe.


### PR DESCRIPTION
The Technical Board believes we should try to minimize the amount of files and directories we hold in the root directory of ILIAS. In the middle run, we believe we should move most of the files out of the web-root altogether. To avoid creating more files and directories in the root directory of ILIAS, if not absolutely necessary, we propose the rule in this PR.