### PR TITLE
Make reset administrative notification work from table (trunk)

### DIFF
--- a/Services/AdministrativeNotification/classes/class.ilADNNotificationTableGUI.php
+++ b/Services/AdministrativeNotification/classes/class.ilADNNotificationTableGUI.php
@@ -117,7 +117,7 @@ class ilADNNotificationTableGUI extends ilTable2GUI
             
             $reset_modal = $this->modal($ditem, ilADNNotificationGUI::CMD_RESET);
             $items[] = $this->ui->factory()->button()->shy($this->lng->txt('btn_' . ilADNNotificationGUI::CMD_RESET), "")
-                                ->withOnClick($delete_modal->getShowSignal());
+                                ->withOnClick($reset_modal->getShowSignal());
             $this->modals[] = $reset_modal;
             
             $actions = $this->ui->renderer()->render([$this->ui->factory()->dropdown()->standard($items)->withLabel($this->lng->txt('actions'))]);


### PR DESCRIPTION
Fix a copy and paste mistake from 1334c90afb8fcf06f960afeaa145b27702e82a8c (forward-ported as be0bcf957bc406d48a751ce15e1d7e3944f50159) so that the _reset_ function (and not the delete function) for administrative notifications is called when users select the corresponding entry from the actions button menu.

This is the pull request for trunk.