### PR TITLE
Adding a check for empty condition types when saving a learning sequence

### DIFF
--- a/Modules/LearningSequence/classes/Content/class.ilObjLearningSequenceContentGUI.php
+++ b/Modules/LearningSequence/classes/Content/class.ilObjLearningSequenceContentGUI.php
@@ -151,12 +151,14 @@ class ilObjLearningSequenceContentGUI
             $order = $this->getFieldName(self::FIELD_ORDER, $ref_id);
             $condition_type = $this->getFieldName(self::FIELD_POSTCONDITION_TYPE, $ref_id);
 
-            $condition = $lsitem->getPostCondition()
+            if (!empty($post[$condition_type])) {
+              $condition = $lsitem->getPostCondition()
                 ->withConditionOperator($post[$condition_type]);
-            $updated[] = $lsitem
+              $updated[] = $lsitem
                 ->withOnline((bool) $post[$online])
                 ->withOrderNumber((int) $post[$order])
                 ->withPostCondition($condition);
+            }
         }
 
         $this->parent_gui->getObject()->storeLSItems($updated);

--- a/Modules/LearningSequence/classes/Content/class.ilObjLearningSequenceContentGUI.php
+++ b/Modules/LearningSequence/classes/Content/class.ilObjLearningSequenceContentGUI.php
@@ -152,9 +152,9 @@ class ilObjLearningSequenceContentGUI
             $condition_type = $this->getFieldName(self::FIELD_POSTCONDITION_TYPE, $ref_id);
 
             if (!empty($post[$condition_type])) {
-              $condition = $lsitem->getPostCondition()
+                $condition = $lsitem->getPostCondition()
                 ->withConditionOperator($post[$condition_type]);
-              $updated[] = $lsitem
+                $updated[] = $lsitem
                 ->withOnline((bool) $post[$online])
                 ->withOrderNumber((int) $post[$order])
                 ->withPostCondition($condition);


### PR DESCRIPTION
Fixes the bug I created in Mantis: https://mantis.ilias.de/view.php?id=30854. It doesn't show a message as I suggested but maybe it does not need to.

Not an issue in version 6.9