### PR TITLE
ILIAS 6 forum html export overflow added to template

### DIFF
--- a/Modules/Forum/templates/default/tpl.forums_export_html.html
+++ b/Modules/Forum/templates/default/tpl.forums_export_html.html
@@ -33,7 +33,7 @@
 	<script type="text/javascript" src="{JS_FILE}"></script>
 	<!-- END js_file -->
 </head>
-<body style="overflow: auto;"><!-- BEGIN thread_block -->
+<body class="frm-thread-scrollable-print"><!-- BEGIN thread_block -->
 
 <!-- BEGIN thread_headline -->
 <p>

--- a/Modules/Forum/templates/default/tpl.forums_export_html.html
+++ b/Modules/Forum/templates/default/tpl.forums_export_html.html
@@ -33,7 +33,7 @@
 	<script type="text/javascript" src="{JS_FILE}"></script>
 	<!-- END js_file -->
 </head>
-<body><!-- BEGIN thread_block -->
+<body style="overflow: auto;"><!-- BEGIN thread_block -->
 
 <!-- BEGIN thread_headline -->
 <p>

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -14203,6 +14203,9 @@ div.ilFrmPostHeader span.small {
   color: #333333;
   padding-left: 23px;
 }
+.frm-thread-scrollable-print {
+  overflow: auto;
+}
 /* Services/Mail */
 a.mailread,
 a.mailread:visited {

--- a/templates/default/less/Modules/Forum/delos.less
+++ b/templates/default/less/Modules/Forum/delos.less
@@ -169,3 +169,7 @@ div.ilFrmPostHeader span.small {
 	color: @text-color;
 	padding-left: 23px;
 }
+
+.frm-thread-scrollable-print {
+	overflow: auto;
+}


### PR DESCRIPTION
If multiple forum threads are exported as html.
The html can't be viewed correctly as the body won't scroll.
This adds **overflow: auto;** to the **<body>** tag in the **tpl.forums_export_html.html** template

https://mantis.ilias.de/view.php?id=30853