### PR TITLE
ILIAS trunk forum html export overflow added to template

### DIFF
--- a/Modules/Forum/templates/default/tpl.forums_export_html.html
+++ b/Modules/Forum/templates/default/tpl.forums_export_html.html
@@ -33,7 +33,7 @@
 	<script type="text/javascript" src="{JS_FILE}"></script>
 	<!-- END js_file -->
 </head>
-<body style="overflow: auto;"><!-- BEGIN thread_block -->
+<body class="frm-thread-scrollable-print"><!-- BEGIN thread_block -->
 
 <!-- BEGIN thread_headline -->
 <p>

--- a/Modules/Forum/templates/default/tpl.forums_export_html.html
+++ b/Modules/Forum/templates/default/tpl.forums_export_html.html
@@ -33,7 +33,7 @@
 	<script type="text/javascript" src="{JS_FILE}"></script>
 	<!-- END js_file -->
 </head>
-<body><!-- BEGIN thread_block -->
+<body style="overflow: auto;"><!-- BEGIN thread_block -->
 
 <!-- BEGIN thread_headline -->
 <p>

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -7091,7 +7091,7 @@ button.close {
   position: relative;
   background-color: white;
   border: none;
-  box-shadow: 0 1px 2px rgb(0 0 0%), 0 0px 0px rgb(0 0 0%);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15), 0 0px 0px rgba(0, 0, 0, 0.15);
   /* see bug #24947 */
 }
 .il-card img {
@@ -13457,6 +13457,9 @@ div.ilFrmPostHeader span.small {
   font-size: smaller;
   color: #434343;
   padding-left: 23px;
+}
+.frm-thread-scrollable-print {
+  overflow: auto;
 }
 /* Services/Mail */
 a.mailread,

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -7091,7 +7091,7 @@ button.close {
   position: relative;
   background-color: white;
   border: none;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15), 0 0px 0px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 1px 2px rgb(0 0 0%), 0 0px 0px rgb(0 0 0%);
   /* see bug #24947 */
 }
 .il-card img {

--- a/templates/default/less/Modules/Forum/delos.less
+++ b/templates/default/less/Modules/Forum/delos.less
@@ -183,3 +183,7 @@ div.ilFrmPostHeader span.small {
 	color: @il-text-color;
 	padding-left: 23px;
 }
+
+.frm-thread-scrollable-print {
+	overflow: auto;
+}


### PR DESCRIPTION
If multiple forum threads are exported as html.
The html can't be viewed correctly as the body won't scroll.
This adds overflow: auto; to the tag in the tpl.forums_export_html.html template

https://mantis.ilias.de/view.php?id=30853