### PR TITLE
Fix order of questions not always being random

### DIFF
--- a/Modules/Test/classes/class.ilTestRandomQuestionSetBuilderWithAmountPerPool.php
+++ b/Modules/Test/classes/class.ilTestRandomQuestionSetBuilderWithAmountPerPool.php
@@ -100,6 +100,7 @@ class ilTestRandomQuestionSetBuilderWithAmountPerPool extends ilTestRandomQuesti
                 $questions = $actualQuestionStage;
             }
 
+            $questions->shuffleQuestions();
             $questionSet->mergeQuestionCollection($questions);
         }
 


### PR DESCRIPTION
This PR ensures that the order of questions is always random, even when exactly as many questions are pulled as a pool contains. This is not the case right now.