### PR TITLE
UI: remove script-tag in template-files

### DIFF
--- a/src/UI/Implementation/Component/Button/Renderer.php
+++ b/src/UI/Implementation/Component/Button/Renderer.php
@@ -256,14 +256,10 @@ class Renderer extends AbstractComponentRenderer
         }
         $tpl->setVariable("LANG", $lang_key);
 
+        $component = $component->withAdditionalOnLoadCode(fn($id) => "il.UI.button.initMonth('$id');");
         $id = $this->bindJavaScript($component);
 
-        if ($id !== null) {
-            $tpl->setCurrentBlock("with_id");
-            $tpl->setVariable("ID", $id);
-            $tpl->parseCurrentBlock();
-            $tpl->setVariable("JSID", $id);
-        }
+        $tpl->setVariable("ID", $id);
 
         return $tpl->get();
     }

--- a/src/UI/ROADMAP.md
+++ b/src/UI/ROADMAP.md
@@ -241,6 +241,21 @@ Top items in the mainbar are wrapped in a <div class="il-mainbar-triggers">;
 We should get rid of this wrapper and have <ol>/<li> only for "menu-items",
 directly under the <nav>-tag.
 
+### Renovate Lightbox Modal (advanced, ~8h)
+The Lightbox Modal is a rather old component that does not follow current standards of
+the UI framework and the web. It should be renovated:
+
+* There are various IDs used internally, they are superflous and are not created in
+the UI framework reliably. Only one id is generated per component, the other HTML
+elements should be located by other means, e.g. using relative selectors.
+* Internally, the Lightbox Modal uses the Bootstrap 3 Carousel. This can be replaced
+with modern CSS transformations.
+* The indicators do not work when clicked.
+* The sizes of the various lightboxes do not align, which looks odd when clicking
+through the various pages.
+* The template file of the lightbox contains a script tag, which is not allowed as
+of Dicto Rule `IliasTemplateFiles cannot contain text: "<script"`.
+
 
 ## Long Term
 

--- a/src/UI/templates/default/Button/tpl.month.html
+++ b/src/UI/templates/default/Button/tpl.month.html
@@ -1,4 +1,4 @@
-<div <!-- BEGIN with_id --> id="{ID}"<!-- END with_id --> class="btn-group il-btn-month">
+<div id="{ID}" class="btn-group il-btn-month">
 	<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
 		<span class="il-current-month">{DEFAULT_LABEL}</span>
 		<span class="caret"></span>
@@ -7,4 +7,3 @@
 		<div class="inline-picker"></div>
 	</div>
 </div>
-<script>il.Util.addOnLoad(function() {il.UI.button.initMonth('{JSID}');});</script>

--- a/src/UI/templates/default/Modal/tpl.lightbox.html
+++ b/src/UI/templates/default/Modal/tpl.lightbox.html
@@ -44,7 +44,7 @@
 	</div>
 </div>
 <script>
-	$(function() {
+	window.setTimeout(function() {
 		$('#{ID}').on('shown.bs.modal', function() {
 			$('.modal-backdrop.in').css('opacity', '0.9');
 		});
@@ -70,5 +70,5 @@
 			var title = $(this).find('.carousel-inner .item.active').attr('data-title');
 			$('#{ID}').find('.modal-title').text(title);
 		});
-	});
+	}, 0);
 </script>

--- a/tests/UI/Component/Button/ButtonMonthTest.php
+++ b/tests/UI/Component/Button/ButtonMonthTest.php
@@ -47,7 +47,7 @@ class ButtonMonthTest extends ILIAS_UI_TestBase
         $html = $r->render($c);
 
         $expected_html = <<<EOT
-		<div  class="btn-group il-btn-month">
+		<div id="id_1" class="btn-group il-btn-month">
 	<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
 		<span class="il-current-month">month_02_short 2017</span>
 		<span class="caret"></span>
@@ -56,7 +56,6 @@ class ButtonMonthTest extends ILIAS_UI_TestBase
 		<div class="inline-picker"></div>
 	</div>
 </div>
-<script>il.Util.addOnLoad(function() {il.UI.button.initMonth('');});</script>
 EOT;
         $this->assertHTMLEquals("<div>" . $expected_html . "</div>", "<div>" . $html . "</div>");
     }

--- a/tests/UI/Component/Modal/LightboxTest.php
+++ b/tests/UI/Component/Modal/LightboxTest.php
@@ -94,7 +94,7 @@ HelloWorld
 	</div>
 </div>
 <script>
-	$(function() {
+	window.setTimeout(function() {
 		$('#id_1').on('shown.bs.modal', function() {
 			$('.modal-backdrop.in').css('opacity', '0.9');
 		});
@@ -120,7 +120,7 @@ HelloWorld
 			var title = $(this).find('.carousel-inner .item.active').attr('data-title');
 			$('#id_1').find('.modal-title').text(title);
 		});
-	});
+	}, 0);
 </script>
 EOT;
 
@@ -169,7 +169,7 @@ EOT;
 	</div>
 </div>
 <script>
-	$(function() {
+	window.setTimeout(function() {
 		$('#id_1').on('shown.bs.modal', function() {
 			$('.modal-backdrop.in').css('opacity', '0.9');
 		});
@@ -195,7 +195,7 @@ EOT;
 			var title = $(this).find('.carousel-inner .item.active').attr('data-title');
 			$('#id_1').find('.modal-title').text(title);
 		});
-	});
+	}, 0);
 </script>
 EOT;
 
@@ -265,7 +265,7 @@ HelloWorld
 	</div>
 </div>
 <script>
-	$(function() {
+	window.setTimeout(function() {
 		$('#id_1').on('shown.bs.modal', function() {
 			$('.modal-backdrop.in').css('opacity', '0.9');
 		});
@@ -291,7 +291,7 @@ HelloWorld
 			var title = $(this).find('.carousel-inner .item.active').attr('data-title');
 			$('#id_1').find('.modal-title').text(title);
 		});
-	});
+	}, 0);
 </script>
 EOT;
         return $expected;


### PR DESCRIPTION
This deals with the script-tags in the template files of the UI framework as far as currently possible. The general need to remove the script tags now is implied by [Ticket 30833](https://mantis.ilias.de/view.php?id=30833)/[PR 3409](https://github.com/ILIAS-eLearning/ILIAS/pull/3409). The script-tag in the `Month Button` has been removed completely. The Lightbox Modal (the other according location) has been investigated. The Lightbox Modal seems to be in dire need of some love anyway and does not work properly currently. So I did not remove that script-tag, but made it complient to the changes in the aforementioned PR by simply wrapping a `setTimeout` around. Also, I did add an according entry to the roadmap.