### PR TITLE
UI: new Inputs URL and Link

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -16587,3 +16587,6 @@ irss#:#resource_id#:#Resource ID
 irss#:#storage_id#:#Storage ID
 irss#:#max_revision#:#Max. Revision
 irss#:#stakeholders#:#Stakeholders
+ui#:#ui_invalid_url#:#Das Format der URL ist nicht korrekt.
+ui#:#ui_link_label#:#Label
+ui#:#ui_link_url#:#URL

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -16588,3 +16588,6 @@ irss#:#resource_id#:#Resource ID
 irss#:#storage_id#:#Storage ID
 irss#:#max_revision#:#Max. Revision
 irss#:#stakeholders#:#Stakeholders
+ui#:#ui_invalid_url#:#Invalid URL-format
+ui#:#ui_link_label#:#Label
+ui#:#ui_link_url#:#URL

--- a/src/Data/Factory.php
+++ b/src/Data/Factory.php
@@ -67,9 +67,9 @@ class Factory
     /**
      * Represents the size of some data.
      *
-     * @param	string|int	$size	string might be a string like "126 MB"
-     * @throw	\InvalidArgumentException if first argument is int and second is not a valid unit.
-     * @throw	\InvalidArgumentException if string size can't be interpreted
+     * @param   string|int  $size   string might be a string like "126 MB"
+     * @throw   \InvalidArgumentException if first argument is int and second is not a valid unit.
+     * @throw   \InvalidArgumentException if string size can't be interpreted
      */
     public function dataSize($size, string $unit = null) : DataSize
     {
@@ -148,5 +148,10 @@ class Factory
     public function version(string $version) : Version
     {
         return new Version($version);
+    }
+
+    public function link(string $label, URI $url) : Link
+    {
+        return new Link($label, $url);
     }
 }

--- a/src/Data/Link.php
+++ b/src/Data/Link.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace ILIAS\Data;
+
+/**
+ * A Link is the often used combination of a label and an URL.
+ *
+ * @author Nils Haagen <nils.haagen@concepts-and-training.de>
+ */
+class Link
+{
+    /**
+     * @var string
+     */
+    protected $label;
+
+    /**
+     * @var URI
+     */
+    protected $url;
+
+    public function __construct(string $label, URI $url)
+    {
+        $this->label = $label;
+        $this->url = $url;
+    }
+
+    public function getLabel() : string
+    {
+        return $this->label;
+    }
+
+    public function getURL() : URI
+    {
+        return $this->url;
+    }
+}

--- a/src/UI/Component/Input/Field/Factory.php
+++ b/src/UI/Component/Input/Field/Factory.php
@@ -609,4 +609,64 @@ interface Factory
      * @return \ILIAS\UI\Component\Input\Field\File
      */
     public function file(UploadHandler $handler, string $label, string $byline = null) : File;
+
+    /**
+     * ---
+     * description:
+     *   purpose: >
+     *      The URL Input is intended for entering a single URL.
+     *   composition: >
+     *      URL Inputs will render an input-tag with type="url".
+     *   effect: >
+     *      URL Inputs are restricted to a single URL without a label.
+     *      A URI check will ensure a correct URL format (e.g. 'https://www.ilias.de/') is
+     *      inserted.
+     *   rivals:
+     *      Text Input: use a Text Input if users should input texts.
+     *      Link Input: use a Link Input if users may also set a label for the URL
+     *
+     * context:
+     *   - The single URL Input is used in UI-forms.
+     *
+     * rules:
+     *   usage:
+     *      1: The URL Input MUST NOT be used if a URL label has to be set.
+     *
+     * ---
+     * @param string $label
+     * @param string|null $byline
+     *
+     * @return \ILIAS\UI\Component\Input\Field\Url
+     */
+    public function url(string $label, string $byline = null) : Url;
+
+
+    /**
+     * ---
+     * description:
+     *   purpose: >
+     *      Link Inputs are used to enter URLs in conjunction with a label.
+     *   composition: >
+     *      Link Inputs are Input Groups consiting of a Text- and an Url Input.
+     *   effect: >
+     *      Two Text Inputs are rendered, of which the first one will accept all kinds of text
+     *      while the second one will be restricted to URLs.
+     *   rivals:
+     *      Url Input: use a Url Input if users should input a URL only (without a label or similar)
+     *
+     * context:
+     *   - The Link Input is used in UI-forms.
+     *
+     * rules:
+     *   usage:
+     *      1: >
+     *        The URL Input MUST be used if a URL is to be entered together with an assigned label
+     *
+     * ---
+     * @param string $label
+     * @param string|null $byline
+     *
+     * @return \ILIAS\UI\Component\Input\Field\Link
+     */
+    public function link(string $label, string $byline = null) : Link;
 }

--- a/src/UI/Component/Input/Field/Link.php
+++ b/src/UI/Component/Input/Field/Link.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 2021 Nils Haagen <nils.haagen@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\UI\Component\Input\Field;
+
+/**
+ * This describes the Link input, a combination of Text and Url.
+ */
+interface Link extends Group
+{
+}

--- a/src/UI/Component/Input/Field/Url.php
+++ b/src/UI/Component/Input/Field/Url.php
@@ -1,0 +1,12 @@
+<?php
+
+/* Copyright (c) 2021 Luka Stocker <luka.stocker@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\UI\Component\Input\Field;
+
+/**
+ * This describes a URL input.
+ */
+interface Url extends FormInput
+{
+}

--- a/src/UI/Implementation/Component/Input/Field/Factory.php
+++ b/src/UI/Implementation/Component/Input/Field/Factory.php
@@ -186,4 +186,20 @@ class Factory implements Field\Factory
     {
         return new \ILIAS\UI\Implementation\Component\Input\Field\File($this->data_factory, $this->refinery, $handler, $label, $byline);
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function url(string $label, string $byline = null) : Url
+    {
+        return new \ILIAS\UI\Implementation\Component\Input\Field\Url($this->data_factory, $this->refinery, $label, $byline);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function link(string $label, string $byline = null) : Link
+    {
+        return new \ILIAS\UI\Implementation\Component\Input\Field\Link($this->data_factory, $this->refinery, $this->lng, $this, $label, $byline);
+    }
 }

--- a/src/UI/Implementation/Component/Input/Field/Link.php
+++ b/src/UI/Implementation/Component/Input/Field/Link.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 2021 Nils Haagen <nils.haagen@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\UI\Implementation\Component\Input\Field;
+
+use ILIAS\UI\Component as C;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery as Refinery;
+use ILIAS\Data\URI;
+
+/**
+ * This implements the link input group.
+ */
+class Link extends Group implements C\Input\Field\Link
+{
+    public function __construct(
+        DataFactory $data_factory,
+        \ILIAS\Refinery\Factory $refinery,
+        \ilLanguage $lng,
+        Factory $field_factory,
+        string $label,
+        string $byline
+    ) {
+        $inputs = [
+            $field_factory->text($lng->txt('ui_link_label')),
+            $field_factory->url($lng->txt('ui_link_url'))
+        ];
+
+        parent::__construct($data_factory, $refinery, $lng, $inputs, $label, $byline);
+        $this->addValidation();
+        $this->addTransformation();
+    }
+
+    protected function addValidation()
+    {
+        $txt_id = 'label_cannot_be_empty_if_url_is_set';
+        $error = function (callable $txt, $value) use ($txt_id) {
+            return $txt($txt_id, $value);
+        };
+        $is_ok = function ($v) {
+            list($label, $url) = $v;
+            $ok = (
+                (is_null($label) || $label === '') &&
+                is_null($url)
+            ) || (
+                !is_null($label) && !is_null($url)
+                && strlen($label) > 0
+                && is_a($url, URI::class)
+            );
+            return $ok;
+        };
+
+        $label_is_set_for_url = $this->refinery->custom()->constraint($is_ok, $error);
+        $this->setAdditionalTransformation($label_is_set_for_url);
+    }
+
+
+    protected function addTransformation()
+    {
+        $trafo = $this->refinery->custom()->transformation(function ($v) {
+            list($label, $url) = $v;
+            return $this->data_factory->link($label, $url);
+        });
+
+        $this->setAdditionalTransformation($trafo);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function isClientSideValueOk($value) : bool
+    {
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getConstraintForRequirement()
+    {
+        return null;
+    }
+}

--- a/src/UI/Implementation/Component/Input/Field/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Field/Renderer.php
@@ -58,7 +58,9 @@ class Renderer extends AbstractComponentRenderer
             case ($component instanceof F\Section):
                 return $this->renderSection($component, $default_renderer);
 
+
             case ($component instanceof F\Group):
+            case ($component instanceof F\Link):
                 return $default_renderer->render($component->getInputs());
 
             case ($component instanceof F\Text):
@@ -97,6 +99,9 @@ class Renderer extends AbstractComponentRenderer
             case ($component instanceof F\File):
                 return $this->renderFileField($component, $default_renderer);
 
+            case ($component instanceof F\Url):
+                return $this->renderUrlField($component, $default_renderer);
+            
             default:
                 throw new \LogicException("Cannot render '" . get_class($component) . "'");
         }
@@ -749,7 +754,8 @@ class Renderer extends AbstractComponentRenderer
             Component\Input\Field\MultiSelect::class,
             Component\Input\Field\DateTime::class,
             Component\Input\Field\Duration::class,
-            Component\Input\Field\File::class
+            Component\Input\Field\File::class,
+            Component\Input\Field\Url::class
         ];
     }
 
@@ -783,5 +789,16 @@ class Renderer extends AbstractComponentRenderer
          * @var $input Component\Input\Field\File
          */
         return $input;
+    }
+
+    
+    protected function renderUrlField(F\Url $component) : string
+    {
+        $tpl = $this->getTemplate("tpl.url.html", true, true);
+        $this->applyName($component, $tpl);
+        $this->applyValue($component, $tpl, $this->escapeSpecialChars());
+        $this->maybeDisable($component, $tpl);
+        $id = $this->bindJSandApplyId($component, $tpl);
+        return $this->wrapInFormContext($component, $tpl->get(), $id);
     }
 }

--- a/src/UI/Implementation/Component/Input/Field/Url.php
+++ b/src/UI/Implementation/Component/Input/Field/Url.php
@@ -1,0 +1,126 @@
+<?php declare(strict_types=1);
+
+
+/* Copyright (c) 2021 Luka Stocker <luka.stocker@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\UI\Implementation\Component\Input\Field;
+
+use ILIAS\UI\Component as C;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Data\URI;
+use ILIAS\Refinery\Factory;
+use ILIAS\Refinery\Transformation;
+
+/**
+ * This implements the URL input.
+ */
+class Url extends Input implements C\Input\Field\Url
+{
+    /**
+     * @var string
+     */
+    protected $value;
+
+    /**
+     * @inheritdoc
+     */
+    public function __construct(
+        DataFactory $data_factory,
+        Factory $refinery,
+        string $label,
+        ?string $byline
+    ) {
+        parent::__construct($data_factory, $refinery, $label, $byline);
+        $this->addValidation();
+        $this->addTransformation();
+    }
+
+    protected function addValidation()
+    {
+        $txt_id = 'ui_invalid_url';
+        $error = function (callable $txt, $value) use ($txt_id) {
+            return $txt($txt_id, $value);
+        };
+        $is_ok = function ($v) {
+            if (is_string($v) && trim($v) === '') {
+                return true;
+            }
+            try {
+                $this->data_factory->uri($v);
+            } catch (\Throwable $e) {
+                return false;
+            }
+            return true;
+        };
+
+        $from_before_until = $this->refinery->custom()->constraint($is_ok, $error);
+        $this->setAdditionalTransformation($from_before_until);
+    }
+
+    protected function addTransformation()
+    {
+        $trafo = $this->refinery->custom()->transformation(function ($v) {
+            if (is_string($v) && trim($v) === '') {
+                return null;
+            }
+            return $this->data_factory->uri($v);
+        });
+
+        $this->setAdditionalTransformation($trafo);
+    }
+
+    /**
+     * @inheritcoc
+     */
+    public static function getURIChecker() : \Closure
+    {
+        return static function (string $value) : bool {
+            try {
+                new URI($value);
+            } catch (\Throwable $e) {
+                return false;
+            }
+            return true;
+        };
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function isClientSideValueOk($value) : bool
+    {
+        if (is_string($value) && trim($value) === "") {
+            return true;
+        }
+
+        if (!self::getURIChecker()) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getConstraintForRequirement()
+    {
+        if (!self::getURIChecker()) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getUpdateOnLoadCode() : \Closure
+    {
+        return function ($id) {
+            $code = "$('#$id').on('input', function(event) {
+				il.UI.input.onFieldUpdate(event, '$id', $('#$id').val());
+			});
+			il.UI.input.onFieldUpdate(event, '$id', $('#$id').val());";
+            return $code;
+        };
+    }
+}

--- a/src/UI/examples/Input/Field/Link/base.php
+++ b/src/UI/examples/Input/Field/Link/base.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Input\Field\Link;
+
+function base()
+{
+    global $DIC;
+    $ui = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+    $request = $DIC->http()->request();
+
+    $link_input = $ui->input()->field()->link("Link Input", "Enter a label and the url ")
+        ->withValue(['ILIAS Homepage', "https://www.ilias.de/"]);
+
+    $form = $ui->input()->container()->form()->standard("#", [$link_input]);
+
+    if ($request->getMethod() == "POST") {
+        $form = $form->withRequest($request);
+        $result = $form->getData()[0];
+    } else {
+        $result = "No result yet.";
+    }
+
+    return
+        "<pre>" . print_r($result, true) . "</pre><br />" .
+        $renderer->render($form);
+}

--- a/src/UI/examples/Input/Field/Url/base.php
+++ b/src/UI/examples/Input/Field/Url/base.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+namespace ILIAS\UI\examples\Input\Field\Url;
+
+/**
+ * This example shows how to create and render a basic input field and attach it to a form.
+ * It does not contain any data processing.
+ */
+function base()
+{
+    //Step 0: Declare dependencies
+    global $DIC;
+    $ui = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    //Step 1: Define the URL input field
+    $url_input = $ui->input()->field()->url("Basic Input", "Just some basic input");
+
+    //Step 2: Define the form and attach the section
+    $form = $ui->input()->container()->form()->standard("#", [$url_input]);
+
+    //Step 4: Render the form with the URL input field
+    return $renderer->render($form);
+}

--- a/src/UI/examples/Input/Field/Url/disabled.php
+++ b/src/UI/examples/Input/Field/Url/disabled.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Input\Field\Url;
+
+/**
+ * This example shows how to create and render a disabled URL input field and attach it to a form.
+ * It does not contain any data processing.
+ */
+function disabled()
+{
+    //Step 0: Declare dependencies
+    global $DIC;
+    $ui = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    //Step 1: Define the URL input field
+    $url_input = $ui->input()->field()->url("Disabled Input", "Just some disabled input")->withDisabled(true);
+
+    //Step 2: Define the form and attach the section
+    $form = $ui->input()->container()->form()->standard("#", [$url_input]);
+
+    //Step 4: Render the form with the URL input field
+    return $renderer->render($form);
+}

--- a/src/UI/examples/Input/Field/Url/with_error.php
+++ b/src/UI/examples/Input/Field/Url/with_error.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Input\Field\Url;
+
+/**
+ * This example shows how to create and render a basic URL input field with an error and
+ * attach to it. It does not contain any data processing.
+ */
+function with_error()
+{
+    //Step 0: Declare dependencies
+    global $DIC;
+    $ui = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    //Step 1: Define the URL input field
+    $url_input = $ui->input()->field()->url("Basic Input", "Just some basic input with 
+    some error attached.")
+        ->withError("Some error");
+
+    //Step 2: Define the form and attach the section
+    $form = $ui->input()->container()->form()->standard("#", [$url_input]);
+
+    //Step 4: Render the form with the URL input field
+    return $renderer->render($form);
+}

--- a/src/UI/examples/Input/Field/Url/with_value.php
+++ b/src/UI/examples/Input/Field/Url/with_value.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Input\Field\Url;
+
+/**
+ * This example shows how to create and render a basic URL input field with an value
+ * attached to it. It does also contain data processing.
+ */
+function with_value()
+{
+    //Step 0: Declare dependencies
+    global $DIC;
+    $ui = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+    $request = $DIC->http()->request();
+
+    //Step 1: Define the URL input field and attach some default value
+    $url_input = $ui->input()->field()->url("Basic Input", "Just some basic input with 
+    some default url value.")
+        ->withValue("https://www.ilias.de/");
+
+    //Step 2: Define the form and attach the section
+    $form = $ui->input()->container()->form()->standard("#", [$url_input]);
+    
+    //Step 3: Define some data processing
+    if ($request->getMethod() == "POST") {
+        $form = $form->withRequest($request);
+        $result = $form->getData()[0];
+    } else {
+        $result = "No result yet.";
+    }
+
+    //Step 4: Render the form with the URL input field
+    return
+        "<pre>" . print_r($result, true) . "</pre><br />" .
+        $renderer->render($form);
+}

--- a/src/UI/templates/default/Input/tpl.url.html
+++ b/src/UI/templates/default/Input/tpl.url.html
@@ -1,0 +1,1 @@
+<input id="{ID}" type="url"<!-- BEGIN value --> value="{VALUE}"<!-- END value --> name="{NAME}"<!-- BEGIN disabled --> {DISABLED}<!-- END disabled --> class="form-control form-control-sm" />

--- a/tests/Data/LinkTest.php
+++ b/tests/Data/LinkTest.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+use ILIAS\Data\Link;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the Link Datatype
+ */
+class DataLinkTest extends TestCase
+{
+    protected function setUp() : void
+    {
+        $this->f = new ILIAS\Data\Factory();
+        $this->label = 'ILIAS Homepage';
+        $this->url = $this->f->uri('https://www.ilias.de');
+    }
+    
+    public function testFactory() : Link
+    {
+        $link = $this->f->link($this->label, $this->url);
+        $this->assertInstanceOf(Link::class, $link);
+        return $link;
+    }
+
+    /**
+     * @depends testFactory
+     */
+    public function testValues(Link $link)
+    {
+        $this->assertEquals(
+            $this->label,
+            $link->getLabel()
+        );
+        $this->assertEquals(
+            $this->url,
+            $link->getUrl()
+        );
+    }
+}

--- a/tests/UI/Component/Input/Field/LinkInputTest.php
+++ b/tests/UI/Component/Input/Field/LinkInputTest.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 2021 Nils Haagen <nils.haagen@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+require_once(__DIR__ . "/../../../../../libs/composer/vendor/autoload.php");
+require_once(__DIR__ . "/../../../Base.php");
+require_once(__DIR__ . "/InputTest.php");
+
+use ILIAS\UI\Implementation\Component\SignalGenerator;
+use \ILIAS\UI\Component\Input\Field;
+use \ILIAS\Data;
+
+class LinkInputTest extends ILIAS_UI_TestBase
+{
+    /**
+     * @var DefNamesource
+     */
+    private $name_source;
+
+    public function setUp() : void
+    {
+        $this->name_source = new DefNamesource();
+    }
+
+    protected function buildFactory()
+    {
+        $data_factory = new Data\Factory();
+        $language = $this->createMock(\ilLanguage::class);
+        $language->method("txt")
+            ->willReturn($this->returnArgument(0));
+
+        return new ILIAS\UI\Implementation\Component\Input\Field\Factory(
+            new SignalGenerator(),
+            $data_factory,
+            new ILIAS\Refinery\Factory($data_factory, $language),
+            $language
+        );
+    }
+
+    public function test_implements_factory_interface()
+    {
+        $factory = $this->buildFactory();
+        $url = $factory->link("Test Label", "Test Byline");
+
+        $this->assertInstanceOf(Field\Link::class, $url);
+    }
+
+    public function test_rendering()
+    {
+        $factory = $this->buildFactory();
+        $renderer = $this->getDefaultRenderer();
+        $label = "Test Label";
+        $byline = "Test Byline";
+        $url = $factory->link($label, $byline)->withNameFrom($this->name_source);
+        $html = $this->normalizeHTML($renderer->render($url));
+
+        $expected = '
+            <div class="form-group row">
+                <label for="id_1" class="control-label col-sm-3">ui_link_label</label>
+                <div class="col-sm-9">
+                    <input id="id_1" type="text" name="name_1" class="form-control form-control-sm" />
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="id_2" class="control-label col-sm-3">ui_link_url</label>
+                <div class="col-sm-9">
+                    <input id="id_2" type="url" name="name_2" class="form-control form-control-sm" />
+                </div>
+            </div>';
+
+        $this->assertEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($html)
+        );
+    }
+}

--- a/tests/UI/Component/Input/Field/UrlInputTest.php
+++ b/tests/UI/Component/Input/Field/UrlInputTest.php
@@ -1,0 +1,190 @@
+<?php
+
+/* Copyright (c) 2021 Luka Stocker <luka.stocker@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+require_once(__DIR__ . "/../../../../../libs/composer/vendor/autoload.php");
+require_once(__DIR__ . "/../../../Base.php");
+require_once(__DIR__ . "/InputTest.php");
+
+use ILIAS\UI\Implementation\Component\SignalGenerator;
+use \ILIAS\UI\Component\Input\Field;
+use \ILIAS\Data;
+
+class UrlInputTest extends ILIAS_UI_TestBase
+{
+    /**
+     * @var DefNamesource
+     */
+    private $name_source;
+
+    public function setUp() : void
+    {
+        $this->name_source = new DefNamesource();
+    }
+
+    protected function buildFactory()
+    {
+        $data_factory = new Data\Factory();
+        $language = $this->createMock(\ilLanguage::class);
+        return new ILIAS\UI\Implementation\Component\Input\Field\Factory(
+            new SignalGenerator(),
+            $data_factory,
+            new ILIAS\Refinery\Factory($data_factory, $language),
+            $language
+        );
+    }
+
+    public function test_implements_factory_interface()
+    {
+        $factory = $this->buildFactory();
+        $url = $factory->url("Test Label", "Test Byline");
+
+        $this->assertInstanceOf(Field\Input::class, $url);
+        $this->assertInstanceOf(Field\Url::class, $url);
+    }
+
+    public function test_rendering()
+    {
+        $factory = $this->buildFactory();
+        $renderer = $this->getDefaultRenderer();
+        $label = "Test Label";
+        $byline = "Test Byline";
+        $id = "id_1";
+        $name = "name_0";
+        $url = $factory->url($label, $byline)->withNameFrom($this->name_source);
+        $html = $this->normalizeHTML($renderer->render($url));
+
+        $expected = "<div class=\"form-group row\">
+                        <label for=\"$id\" class=\"control-label col-sm-3\">$label</label>
+                        <div class=\"col-sm-9\">
+                            <input id=\"$id\" type=\"url\" name=\"$name\" class=\"form-control form-control-sm\" />
+                            <div class=\"help-block\">$byline</div>
+                        </div>
+                    </div>";
+        $this->assertEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($html)
+        );
+    }
+
+    public function test_render_error()
+    {
+        $factory = $this->buildFactory();
+        $renderer = $this->getDefaultRenderer();
+        $label = "Test Label";
+        $byline = "Test Byline";
+        $id = "id_1";
+        $name = "name_0";
+        $error = "test_error";
+        $url = $factory->url($label, $byline)->withNameFrom($this->name_source)
+            ->withError($error);
+        $html = $this->normalizeHTML($renderer->render($url));
+
+        $expected = "<div class=\"form-group row\">
+                        <label for=\"$id\" class=\"control-label col-sm-3\">$label</label>
+                        <div class=\"col-sm-9\">
+                            <div class=\"help-block alert alert-danger\" role=\"alert\">$error</div>
+                            <input id=\"$id\" type=\"url\" name=\"$name\" class=\"form-control form-control-sm\" />
+                            <div class=\"help-block\">$byline</div>
+                        </div>
+                    </div>";
+
+        $this->assertEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($html)
+        );
+    }
+
+    public function test_render_no_byline()
+    {
+        $factory = $this->buildFactory();
+        $renderer = $this->getDefaultRenderer();
+        $label = "Test Label";
+        $id = "id_1";
+        $name = "name_0";
+        $url = $factory->url($label)->withNameFrom($this->name_source);
+        $html = $this->normalizeHTML($renderer->render($url));
+
+        $expected = "<div class=\"form-group row\">
+                        <label for=\"$id\" class=\"control-label col-sm-3\">$label</label>
+                        <div class=\"col-sm-9\">
+                            <input id=\"$id\" type=\"url\" name=\"$name\" class=\"form-control form-control-sm\" />
+                        </div>
+                    </div>";
+        $this->assertEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($html)
+        );
+    }
+
+    public function test_render_value()
+    {
+        $factory = $this->buildFactory();
+        $renderer = $this->getDefaultRenderer();
+        $label = "Test Label";
+        $value = "https://www.ilias.de/";
+        $id = "id_1";
+        $name = "name_0";
+        $url = $factory->url($label)->withValue($value)
+            ->withNameFrom($this->name_source);
+        $html = $this->normalizeHTML($renderer->render($url));
+
+        $expected = "<div class=\"form-group row\">
+                        <label for=\"$id\" class=\"control-label col-sm-3\">$label</label>
+                        <div class=\"col-sm-9\">
+                           <input id=\"$id\" type=\"url\" value=\"$value\" name=\"$name\" class=\"form-control form-control-sm\" />
+                        </div>
+                     </div>";
+        $this->assertEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($html)
+        );
+    }
+
+    public function test_render_required()
+    {
+        $factory = $this->buildFactory();
+        $renderer = $this->getDefaultRenderer();
+        $label = "Test Label";
+        $id = "id_1";
+        $name = "name_0";
+        $url = $factory->url($label)->withNameFrom($this->name_source)
+            ->withRequired(true);
+        $html = $this->normalizeHTML($renderer->render($url));
+
+        $expected = "<div class=\"form-group row\">
+                        <label for=\"$id\" class=\"control-label col-sm-3\">$label<span class=\"asterisk\">*</span></label>
+                        <div class=\"col-sm-9\">
+                            <input id=\"$id\" type=\"url\" name=\"$name\" class=\"form-control form-control-sm\" />
+                        </div>
+                    </div>";
+        $this->assertEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($html)
+        );
+    }
+
+    public function test_render_disabled()
+    {
+        $factory = $this->buildFactory();
+        $renderer = $this->getDefaultRenderer();
+        $label = "Test Label";
+        $id = "id_1";
+        $name = "name_0";
+        $url = $factory->url($label)->withNameFrom($this->name_source)
+            ->withDisabled(true);
+        $html = $this->normalizeHTML($renderer->render($url));
+
+        $expected = "<div class=\"form-group row\">
+                        <label for=\"$id\" class=\"control-label col-sm-3\">$label</label>
+                        <div class=\"col-sm-9\">
+                            <input id=\"$id\" type=\"url\" name=\"$name\" disabled=\"disabled\" class=\"form-control form-control-sm\" />
+                        </div>
+                    </div>";
+
+        $this->assertEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($html)
+        );
+    }
+}


### PR DESCRIPTION
Dear colleagues,
this introduces a [URL Input](https://github.com/ILIAS-eLearning/ILIAS/pull/3457/files#diff-f857fabc59021b54422647cb7c8c77b1cb280a7b70024c1df86571f02863b2eeR615-R641) (thanks, @lukastocker) and a [Link Input](https://github.com/ILIAS-eLearning/ILIAS/pull/3457/files#diff-f857fabc59021b54422647cb7c8c77b1cb280a7b70024c1df86571f02863b2eeR644-R671) with its according datatype.
Not much surprisingly, the URL Input is a Text Input that will accept well-formed URIs and provide URI datatype to the form's result, while the Link Input uses the former in conjunction with a mandatory Text Input to ask for a label as well.
The Datatype "Link" bundles label and url, as both belong closely to each other and otherwise require manual alignment.

![link](https://user-images.githubusercontent.com/3328364/122735434-51ccfc00-d27f-11eb-8592-6a8a76e0f121.png)

Please kindly consider, best regards, 
Nils

