### PR TITLE
Removes @il-neutral-color (#30939)

### DIFF
--- a/templates/default/less/Services/Preview/delos.less
+++ b/templates/default/less/Services/Preview/delos.less
@@ -21,7 +21,7 @@
 .ilPreviewText {
     font-size: 90%;
     margin-top: -20px;
-    color: @il-neutral-color;
+    color: @mid-gray;
 }
 .ilPreviewTextLoading {
     width: 14px;


### PR DESCRIPTION
This variable isn't defined until Ilias 7 and gives a less compile error in custom themes if not specified. (as well does not exist in templates/default/less/variables.less)