### PR TITLE
GlobalCache: streamline config and status output.

### DIFF
--- a/Services/GlobalCache/classes/Setup/class.ilGlobalCacheMetricsCollectedObjective.php
+++ b/Services/GlobalCache/classes/Setup/class.ilGlobalCacheMetricsCollectedObjective.php
@@ -106,7 +106,7 @@ class ilGlobalCacheMetricsCollectedObjective extends Setup\Metrics\CollectedObje
             "Which components are activated to use caching?"
         );
         $storage->store(
-            "component_activation",
+            "components",
             $component_activation
         );
 


### PR DESCRIPTION
Hi @chfsx,

this streamlines the output of the global cache via status and the input as a config, as found in: https://mantis.ilias.de/view.php?id=30727

I think this should be pulled down to previous versions as well.

Best regards!