### PR TITLE
Object: move cache from component to object

### DIFF
--- a/Services/Object/classes/class.ilCachedObjectDefinition.php
+++ b/Services/Object/classes/class.ilCachedObjectDefinition.php
@@ -1,0 +1,168 @@
+<?php declare(strict_types=1);
+
+/**
+ * Cache for object definitions, based on ilGlobalCache.
+ */
+class ilCachedObjectDefinition
+{
+    protected array $cached_results = [];
+    protected static ilCachedObjectDefinition $instance;
+    protected bool $changed = false;
+    protected array $il_object_def = [];
+    protected array $subobj_for_parent = [];
+    protected array $grouped_rep_obj_types = [];
+    protected array $il_object_group = [];
+    protected array $il_object_sub_type = [];
+    
+    protected function __construct()
+    {
+        $this->global_cache = ilGlobalCache::getInstance(ilGlobalCache::COMP_OBJ_DEF);
+        $this->readFromDB();
+    }
+
+
+    protected function readFromDB() : void
+    {
+        global $DIC;
+        $ilDB = $DIC->database();
+        /**
+         * @var $ilDB ilDB
+         */
+
+        $set = $ilDB->query('SELECT * FROM il_object_def');
+        while ($rec = $ilDB->fetchAssoc($set)) {
+            $this->il_object_def[$rec['id']] = $rec;
+        }
+
+        $set = $ilDB->query('SELECT * FROM il_object_subobj');
+        while ($rec = $ilDB->fetchAssoc($set)) {
+            $parent = $rec['parent'];
+            $this->subobj_for_parent[$parent][] = $rec;
+        }
+        $set = $ilDB->query('SELECT DISTINCT(id) AS sid, parent, il_object_def.* FROM il_object_def, il_object_subobj WHERE NOT (' . $ilDB->quoteIdentifier('system') . ' = 1) AND NOT (sideblock = 1) AND subobj = id');
+        while ($rec = $ilDB->fetchAssoc($set)) {
+            $this->grouped_rep_obj_types[$rec['parent']][] = $rec;
+        }
+        $set = $ilDB->query('SELECT * FROM il_object_group');
+        while ($rec = $ilDB->fetchAssoc($set)) {
+            $this->il_object_group[$rec['id']] = $rec;
+        }
+        $set = $ilDB->query('SELECT * FROM il_object_sub_type');
+        while ($rec = $ilDB->fetchAssoc($set)) {
+            $this->il_object_sub_type[$rec['obj_type']][] = $rec;
+        }
+    }
+
+    public function getIlObjectDef() : array
+    {
+        return $this->il_object_def;
+    }
+
+    public function getIlObjectGroup() : array
+    {
+        return $this->il_object_group;
+    }
+
+    public function getIlObjectSubType() : array
+    {
+        return $this->il_object_sub_type;
+    }
+
+    public static function getInstance() : ilCachedObjectDefinition
+    {
+        if (!isset(self::$instance)) {
+            $global_cache = ilGlobalCache::getInstance(ilGlobalCache::COMP_OBJ_DEF);
+            $cached_obj = $global_cache->get('ilCachedObjectDefinition');
+            if ($cached_obj instanceof ilCachedObjectDefinition) {
+                self::$instance = $cached_obj;
+            } else {
+                self::$instance = new self();
+                $global_cache->set('ilCachedObjectDefinition', self::$instance);
+            }
+        }
+
+        return self::$instance;
+    }
+
+
+    public static function flush() : void
+    {
+        ilGlobalCache::getInstance(ilGlobalCache::COMP_OBJ_DEF)->flush();
+        self::$instance = null;
+    }
+
+
+    /** 
+     * @param mixed $parent
+     *
+     * @return mixed
+     */
+    public function lookupSubObjForParent($parent)
+    {
+        if (is_array($parent)) {
+            $index = md5(serialize($parent));
+            if (isset($this->cached_results['subop_par'][$index])) {
+                return $this->cached_results['subop_par'][$index];
+            }
+
+            $return = array();
+            foreach ($parent as $p) {
+                if (is_array($this->subobj_for_parent[$p])) {
+                    foreach ($this->subobj_for_parent[$p] as $rec) {
+                        $return[] = $rec;
+                    }
+                }
+            }
+
+            $this->cached_results['subop_par'][$index] = $return;
+            $this->changed = true;
+
+            return $return;
+        }
+
+        return $this->subobj_for_parent[$parent];
+    }
+
+    public function __destruct()
+    {
+        $ilGlobalCache = ilGlobalCache::getInstance(ilGlobalCache::COMP_OBJ_DEF);
+        if ($this->changed && $ilGlobalCache->isActive()) {
+            $this->changed = false;
+            $ilGlobalCache->set('ilCachedObjectDefinition', $this);
+        }
+    }
+
+
+    /**
+     * @param mixed $parent
+     *
+     * @return mixed
+     */
+    public function lookupGroupedRepObj($parent)
+    {
+        if (is_array($parent)) {
+            $index = md5(serialize($parent));
+            if (isset($this->cached_results['grpd_repo'][$index])) {
+                return $this->cached_results['grpd_repo'][$index];
+            }
+
+            $return = array();
+            $sids = array();
+            foreach ($parent as $p) {
+                $s = $this->grouped_rep_obj_types[$p];
+                foreach ($s as $child) {
+                    if (!in_array($child['sid'], $sids)) {
+                        $sids[] = $child['sid'];
+                        $return[] = $child;
+                    }
+                }
+            }
+            $this->changed = true;
+            $this->cached_results['grpd_repo'][$index] = $return;
+
+            return $return;
+        } else {
+            return $this->grouped_rep_obj_types[$parent];
+        }
+    }
+}

--- a/Services/Object/classes/class.ilObjectDefinition.php
+++ b/Services/Object/classes/class.ilObjectDefinition.php
@@ -66,7 +66,7 @@ class ilObjectDefinition // extends ilSaxParser
     {
         $this->obj_data = array();
         $defIds = array();
-        $global_cache = ilCachedComponentData::getInstance();
+        $global_cache = ilCachedObjectDefinition::getInstance();
         foreach ($global_cache->getIlObjectDef() as $rec) {
             $this->obj_data[$rec["id"]] = array(
                 "name" => $rec["id"],
@@ -197,7 +197,7 @@ class ilObjectDefinition // extends ilSaxParser
     */
     public function readDefinitionData()
     {
-        if (ilGlobalCache::getInstance(ilGlobalCache::COMP_COMPONENT)->isActive()) {
+        if (ilGlobalCache::getInstance(ilGlobalCache::COMP_OBJ_DEF)->isActive()) {
             $this->readDefinitionDataFromCache();
         } else {
             $this->readDefinitionDataFromDB();
@@ -908,7 +908,7 @@ class ilObjectDefinition // extends ilSaxParser
             $groups[$gr_rec["id"]] = $gr_rec;
         }
 
-        $global_cache = ilCachedComponentData::getInstance();
+        $global_cache = ilCachedObjectDefinition::getInstance();
 
         $recs = $global_cache->lookupGroupedRepObj($a_parent_obj_type);
         


### PR DESCRIPTION
Hi @smeyer-ilias and @alex40724,

I moved caching related to ilObject from `Services/Component` to `Services/Object`. I was surprised to find, that we already have an according entry (`obj_def`) in the configuration of the global cache, which, in fact, does not do anything. This PR makes this config effective and modularizes the system a little more.

Best regards!