### PR TITLE
LTI: id can only be used once

### DIFF
--- a/Services/LTI/service.xml
+++ b/Services/LTI/service.xml
@@ -1,5 +1,5 @@
 <?xml version = "1.0" encoding = "UTF-8"?>
-<service xmlns="http://www.w3.org" version="$Id$" id="lti">
+<service xmlns="http://www.w3.org" version="$Id$" id="ltis">
     <baseclasses>
 	    <baseclass name="ilLTIRouterGUI" dir="classes" />
     </baseclasses>


### PR DESCRIPTION
Hi @Uwe-Kohnle,

the id `lti` is used for two different components, which is `Services/LTI` and `Modules/LTIConsumer`. This seems to defeat the purpose of an id =)

Best regards!