### PR TITLE
SystemFolder: id can only be used once

### DIFF
--- a/Services/Administration/service.xml
+++ b/Services/Administration/service.xml
@@ -1,6 +1,6 @@
 <?xml version = "1.0" encoding = "UTF-8"?>
 <service xmlns="http://www.w3.org" version="$Id$"
-	id="adm">
+	id="adms">
 	<baseclasses>
 		<baseclass name="ilAdministrationGUI" dir="classes" />
 	</baseclasses>


### PR DESCRIPTION
Hi @smeyer-ilias,

the id `adm` is used for two different components, which is `Services/Administration` and `Modules/SystemFolder`. This seems to defeat the purpose of an id =)

Best regards!