### PR TITLE
Updated base.php to demonstrate issue #30933

### DIFF
--- a/src/UI/examples/Input/Field/MultiSelect/base.php
+++ b/src/UI/examples/Input/Field/MultiSelect/base.php
@@ -22,11 +22,11 @@ function base()
     );
 
     //Step 1: define the select
-    $multi = $ui->input()->field()->multiselect("Take your picks", $options, "This is the byline text")
-        ->withRequired(true);
+    $multi = $ui->input()->field()->multiselect("Take your picks", $options, "This is the byline text")->withValue(['2']);
+    $text  = $ui->input()->field()->text("Some label")->withValue('some string');
 
     //Step 2: define form and form actions
-    $form = $ui->input()->container()->form()->standard('#', ['multi' => $multi]);
+    $form = $ui->input()->container()->form()->standard('#', ['multi' => $multi, 'text' => $text]);
 
     //Step 3: implement some form data processing.
     if ($request->getMethod() == "POST") {


### PR DESCRIPTION
This adjustment demonstrates an inconsistent behaviour of "withValue()":
Steps to reproduce:
1) load the snippet, a form with a multi-select- and text-input appears.
2) note that "Pick 2" is selected and "some string" is the text-input's value.
3) uncheck "Pick 2" and remove the value "some string" from the text-input (so it has no value).
4) click save to submit the form and check $result that appears above the form.
You will notice that 'text' has a nullish entry but 'multi' does still have "Pick 2" (index '2') as the selected option.