### PR TITLE
T&A: explain inavailability of corrections (release_5-4)

### DIFF
--- a/Modules/Test/classes/class.ilTestCorrectionsGUI.php
+++ b/Modules/Test/classes/class.ilTestCorrectionsGUI.php
@@ -74,19 +74,32 @@ class ilTestCorrectionsGUI
     {
         $this->DIC->tabs()->activateTab(ilTestTabsManager::TAB_ID_CORRECTION);
         
-        $table_gui = new ilTestQuestionsTableGUI(
-            $this,
-            'showQuestionList',
-            $this->testOBJ->getRefId()
-        );
-        
-        $table_gui->setQuestionTitleLinksEnabled(true);
-        $table_gui->setQuestionRemoveRowButtonEnabled(true);
-        $table_gui->init();
-        
-        $table_gui->setData($this->getQuestions());
-        
-        $this->DIC->ui()->mainTemplate()->setContent($table_gui->getHTML());
+        $ui = $this->DIC->ui();
+
+        if ($this->testOBJ->isFixedTest()) {
+            $table_gui = new ilTestQuestionsTableGUI(
+                $this,
+                'showQuestionList',
+                $this->testOBJ->getRefId()
+            );
+
+            $table_gui->setQuestionTitleLinksEnabled(true);
+            $table_gui->setQuestionRemoveRowButtonEnabled(true);
+            $table_gui->init();
+
+            $table_gui->setData($this->getQuestions());
+
+            $rendered_gui_component = $table_gui->getHTML();
+        } else {
+            $lng = $this->DIC->language();
+            $txt = $lng->txt('tst_corrections_incompatible_question_set_type');
+
+            $infoBox = $ui->factory()->messageBox()->info($txt);
+
+            $rendered_gui_component = $ui->renderer()->render($infoBox);
+        }
+
+        $ui->mainTemplate()->setContent($rendered_gui_component);
     }
     
     protected function showQuestion(ilPropertyFormGUI $form = null)

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -1257,6 +1257,7 @@ assessment#:#tst_corr_answ_stat_tbl_header_answer#:#Antwort
 assessment#:#tst_corr_answ_stat_tbl_header_frequency#:#Häufigkeit
 assessment#:#tst_corrections_answers_tbl#:#Antwortstatistik
 assessment#:#tst_corrections_answers_tbl_subindex#:#Antwortstatistik für %s
+assessment#:#tst_corrections_incompatible_question_set_type#:#Eine Nachkorrektur ist nur möglich, wenn der Test eine fest definierte Fragenauswahl verwendet.
 assessment#:#tst_corrections_manscore_reset_warning#:#Es liegen %s manuelle Bewertungen für die Frage "%s (ID: %s)" vor. Alle manuellen Bewertungen werden zurückgesetzt wenn die Frage gespeichert wird.
 assessment#:#tst_corrections_qst_form#:#Korrektur der Punkte
 assessment#:#tst_corrections_qst_remove_confirmation#:#Möchten Sie die Frage "%s (ID: %s)" wirklich endgültig aus dem Test entfernen?

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -404,6 +404,7 @@ assessment#:#assessment_scoring_adjust#:#Enable corrections
 assessment#:#assessment_scoring_adjust_desc#:#Enables the corrections feature to allow modifications to questions in a test.
 assessment#:#assessment_log_scoring_adjustment_activate#:#Question types available in adjustment
 assessment#:#assessment_log_scoring_adjustment_desc#:#Question types checked here are available in adjustment. This setting is regardless of the current ability of the question types, e.g. a question that does not support adjustment is still shown here.
+assessment#:#tst_corrections_incompatible_question_set_type#:#Corrections are only possible if the test uses a fixed set of questions.
 assessment#:#tst_corrections_qst_remove_confirmation#:#Do you really want to finally remove the question "%s (ID: %s)" from the test?
 assessment#:#tst_corrections_tab_question#:#Question
 assessment#:#tst_corrections_tab_solution#:#Solution


### PR DESCRIPTION
Introduce a change to the test&assessment code which should help users understand ILIAS behavior in certain situations: when corrections are enabled, and users open the corrections view of a test which is not using a fixed question set, tell them that corrections are not supported in this configuration.

I simply exchange the table for a message. The code has been tested with current ILIAS 5.4, 6, and 7 branches (couldn’t test with trunk due to a problem during setup), and works properly, as far as I can tell.

Two questions which I am not sure about:
1. Is the code correct which sets up and retrieves the localized string? I looked at other parts of the code and this seems to be OK. But I do not know whether the initialization put into the constructor is necessary and correct like this.
2. I tried to find out how a message like the new one should best be displayed in the ILIAS web UI, but I haven’t been successful. If there is a dedicated component which is suitable, this one could of course be used. I don’t see a big problem with the current solution, but thought about using one of these alert boxes (with informative/warning level perhaps?). What do you think and recommend? (I also do not like for this seemingly simple change to become overly complex in the end, as my main intent is to signal to users that what they see is intended behavior.)

[Mantis #17901](https://mantis.ilias.de/view.php?id=17901 "Mantis 0017901: Bei einem Test mit zufälliger Fragenauswahl funktioniert die Nachkorrektur nicht") is the issue report about the underlying problem for ILIAS users.

This is the pull request for the `release_5-4` branch.