### PR TITLE
T&A: explain inavailability of corrections (trunk)

### DIFF
--- a/Modules/Test/classes/class.ilTestCorrectionsGUI.php
+++ b/Modules/Test/classes/class.ilTestCorrectionsGUI.php
@@ -74,19 +74,32 @@ class ilTestCorrectionsGUI
     {
         $this->DIC->tabs()->activateTab(ilTestTabsManager::TAB_ID_CORRECTION);
         
-        $table_gui = new ilTestQuestionsTableGUI(
-            $this,
-            'showQuestionList',
-            $this->testOBJ->getRefId()
-        );
-        
-        $table_gui->setQuestionTitleLinksEnabled(true);
-        $table_gui->setQuestionRemoveRowButtonEnabled(true);
-        $table_gui->init();
-        
-        $table_gui->setData($this->getQuestions());
-        
-        $this->DIC->ui()->mainTemplate()->setContent($table_gui->getHTML());
+        $ui = $this->DIC->ui();
+
+        if ($this->testOBJ->isFixedTest()) {
+            $table_gui = new ilTestQuestionsTableGUI(
+                $this,
+                'showQuestionList',
+                $this->testOBJ->getRefId()
+            );
+
+            $table_gui->setQuestionTitleLinksEnabled(true);
+            $table_gui->setQuestionRemoveRowButtonEnabled(true);
+            $table_gui->init();
+
+            $table_gui->setData($this->getQuestions());
+
+            $rendered_gui_component = $table_gui->getHTML();
+        } else {
+            $lng = $this->DIC->language();
+            $txt = $lng->txt('tst_corrections_incompatible_question_set_type');
+
+            $infoBox = $ui->factory()->messageBox()->info($txt);
+
+            $rendered_gui_component = $ui->renderer()->render($infoBox);
+        }
+
+        $ui->mainTemplate()->setContent($rendered_gui_component);
     }
     
     protected function showQuestion(ilPropertyFormGUI $form = null)

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -649,6 +649,7 @@ assessment#:#assessment_scoring_adjust#:#Nachkorrekturmodus aktivieren
 assessment#:#assessment_scoring_adjust_desc#:#Aktiviert den Nachkorrekturmodus, um nachträglich die Bewertung von Fragen in Tests anzupassen.
 assessment#:#assessment_log_scoring_adjustment_activate#:#Verfügbare Fragetypen für den Nachkorrekturmodus
 assessment#:#assessment_log_scoring_adjustment_desc#:#Gewählte Fragetypen stehen im Nachkorrekturmodus zur Verfügung. Diese Einstellung berücksichtigt nicht, ob die Frage im Nachkorrekturmodus bearbeitet werden kann.
+assessment#:#tst_corrections_incompatible_question_set_type#:#Eine Nachkorrektur ist nur möglich, wenn der Test eine fest definierte Fragenauswahl verwendet.
 assessment#:#tst_corrections_qst_remove_confirmation#:#Möchten Sie die Frage "%s (ID: %s)" wirklich endgültig aus dem Test entfernen?
 assessment#:#tst_corrections_tab_question#:#Frage
 assessment#:#tst_corrections_tab_solution#:#Lösung

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -624,6 +624,7 @@ assessment#:#assessment_scoring_adjust#:#Enable corrections
 assessment#:#assessment_scoring_adjust_desc#:#Enables the corrections feature to allow modifications to questions in a test.
 assessment#:#assessment_log_scoring_adjustment_activate#:#Question types available in adjustment
 assessment#:#assessment_log_scoring_adjustment_desc#:#Question types checked here are available in adjustment. This setting is regardless of the current ability of the question types, e.g. a question that does not support adjustment is still shown here.
+assessment#:#tst_corrections_incompatible_question_set_type#:#Corrections are only possible if the test uses a fixed set of questions.
 assessment#:#tst_corrections_qst_remove_confirmation#:#Do you really want to finally remove the question "%s (ID: %s)" from the test?
 assessment#:#tst_corrections_tab_question#:#Question
 assessment#:#tst_corrections_tab_solution#:#Solution


### PR DESCRIPTION
Introduce a change to the test&assessment code which should help users understand ILIAS behavior in certain situations: when corrections are enabled, and users open the corrections view of a test which is not using a fixed question set, tell them that corrections are not supported in this configuration.

This is the pull request for the `trunk` branch.

Please see #3500 for further explanations and (possibly) general discussion.
