### PR TITLE
Fix test result update after scoring system change (Mantis #29735) (release_6)

### DIFF
--- a/Modules/Test/classes/class.ilObjTestSettingsScoringResultsGUI.php
+++ b/Modules/Test/classes/class.ilObjTestSettingsScoringResultsGUI.php
@@ -170,11 +170,16 @@ class ilObjTestSettingsScoringResultsGUI extends ilTestSettingsGUI
             return $this->showConfirmation($form);
         }
 
+        // saving the form leads to isScoreRecalculationRequired($form)
+        // returning false, so remember whether recalculation is needed
+
+        $recalcRequired = $this->isScoreRecalculationRequired($form);
+
         // perform save
 
         $this->performSaveForm($form);
 
-        if ($this->isScoreRecalculationRequired($form)) {
+        if ($recalcRequired) {
             $this->testOBJ->recalculateScores(true);
         }
 


### PR DESCRIPTION
Fix for [Mantis #29735](https://mantis.ilias.de/view.php?id=29735 "0029735: Teilpunkte werden nicht berechnet"), see there and see the commit message for more details.

This is the pull request for the `release_6` branch.