### PR TITLE
Feature/php8 compatibility/modules course verification

### DIFF
--- a/Modules/Course/classes/Verification/class.ilCourseVerificationTableGUI.php
+++ b/Modules/Course/classes/Verification/class.ilCourseVerificationTableGUI.php
@@ -25,7 +25,7 @@ class ilCourseVerificationTableGUI extends ilTable2GUI
     ) {
         global $DIC;
 
-        $ilCtrl = $DIC['ilCtrl'];
+        $ilCtrl = $DIC->ctrl();
         $database = $DIC->database();
         $logger = $DIC->logger()->root();
 
@@ -56,7 +56,7 @@ class ilCourseVerificationTableGUI extends ilTable2GUI
     {
         global $DIC;
 
-        $ilUser = $DIC['ilUser'];
+        $ilUser = $DIC->user();
 
         $data = array();
 
@@ -85,7 +85,7 @@ class ilCourseVerificationTableGUI extends ilTable2GUI
     {
         global $DIC;
 
-        $ilCtrl = $DIC['ilCtrl'];
+        $ilCtrl = $DIC->ctrl();
 
         $this->tpl->setVariable("TITLE", $a_set["title"]);
         $this->tpl->setVariable("PASSED", ($a_set["passed"]) ? $this->lng->txt("yes") :

--- a/Modules/Course/classes/Verification/class.ilCourseVerificationTableGUI.php
+++ b/Modules/Course/classes/Verification/class.ilCourseVerificationTableGUI.php
@@ -60,13 +60,13 @@ class ilCourseVerificationTableGUI extends ilTable2GUI
 
         $certificateArray = $this->userCertificateRepository->fetchActiveCertificatesByTypeForPresentation($userId, 'crs');
 
-        $data = array();
+        $data = [];
         foreach ($certificateArray as $certificate) {
-            $data[] = array(
+            $data[] = [
                 'id' => $certificate->getUserCertificate()->getObjId(),
                 'title' => $certificate->getObjectTitle(),
                 'passed' => true
-            );
+            ];
         }
 
         $this->setData($data);

--- a/Modules/Course/classes/Verification/class.ilCourseVerificationTableGUI.php
+++ b/Modules/Course/classes/Verification/class.ilCourseVerificationTableGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 use ILIAS\DI\Container;

--- a/Modules/Course/classes/Verification/class.ilCourseVerificationTableGUI.php
+++ b/Modules/Course/classes/Verification/class.ilCourseVerificationTableGUI.php
@@ -1,6 +1,8 @@
 <?php
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+use ILIAS\DI\Container;
+
 include_once './Services/Table/classes/class.ilTable2GUI.php';
 
 /**
@@ -12,6 +14,7 @@ include_once './Services/Table/classes/class.ilTable2GUI.php';
 class ilCourseVerificationTableGUI extends ilTable2GUI
 {
     private $userCertificateRepository;
+    private Container $dic;
 
     /**
      * @param ilObject $a_parent_obj
@@ -24,6 +27,8 @@ class ilCourseVerificationTableGUI extends ilTable2GUI
         ilUserCertificateRepository $userCertificateRepository = null
     ) {
         global $DIC;
+
+        $this->dic = $DIC;
 
         $ilCtrl = $DIC->ctrl();
         $database = $DIC->database();
@@ -54,9 +59,7 @@ class ilCourseVerificationTableGUI extends ilTable2GUI
      */
     protected function getItems()
     {
-        global $DIC;
-
-        $ilUser = $DIC->user();
+        $ilUser = $this->dic->user();
 
         $data = array();
 
@@ -83,9 +86,7 @@ class ilCourseVerificationTableGUI extends ilTable2GUI
      */
     protected function fillRow($a_set)
     {
-        global $DIC;
-
-        $ilCtrl = $DIC->ctrl();
+        $ilCtrl = $this->dic->ctrl();
 
         $this->tpl->setVariable("TITLE", $a_set["title"]);
         $this->tpl->setVariable("PASSED", ($a_set["passed"]) ? $this->lng->txt("yes") :

--- a/Modules/Course/classes/Verification/class.ilCourseVerificationTableGUI.php
+++ b/Modules/Course/classes/Verification/class.ilCourseVerificationTableGUI.php
@@ -13,17 +13,12 @@ include_once './Services/Table/classes/class.ilTable2GUI.php';
  */
 class ilCourseVerificationTableGUI extends ilTable2GUI
 {
-    private $userCertificateRepository;
+    private ?ilUserCertificateRepository $userCertificateRepository;
     private Container $dic;
 
-    /**
-     * @param ilObject $a_parent_obj
-     * @param string $a_parent_cmd
-     * @param ilUserCertificateRepository|null $userCertificateRepository
-     */
     public function __construct(
-        $a_parent_obj,
-        $a_parent_cmd = "",
+        ilObject $a_parent_obj,
+        string $a_parent_cmd = "",
         ilUserCertificateRepository $userCertificateRepository = null
     ) {
         global $DIC;
@@ -57,11 +52,9 @@ class ilCourseVerificationTableGUI extends ilTable2GUI
     /**
      * Get all completed tests
      */
-    protected function getItems()
+    protected function getItems() : void
     {
         $ilUser = $this->dic->user();
-
-        $data = array();
 
         $userId = $ilUser->getId();
 
@@ -84,7 +77,7 @@ class ilCourseVerificationTableGUI extends ilTable2GUI
      *
      * @param array $a_set
      */
-    protected function fillRow($a_set)
+    protected function fillRow($a_set) : void
     {
         $ilCtrl = $this->dic->ctrl();
 

--- a/Modules/Course/classes/Verification/class.ilObjCourseVerification.php
+++ b/Modules/Course/classes/Verification/class.ilObjCourseVerification.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 include_once('./Services/Verification/classes/class.ilVerificationObject.php');

--- a/Modules/Course/classes/Verification/class.ilObjCourseVerification.php
+++ b/Modules/Course/classes/Verification/class.ilObjCourseVerification.php
@@ -14,15 +14,19 @@ include_once('./Services/Verification/classes/class.ilVerificationObject.php');
 */
 class ilObjCourseVerification extends ilVerificationObject
 {
-    protected function initType()
+    protected function initType() : void
     {
         $this->type = "crsv";
     }
 
-    protected function getPropertyMap()
+    /**
+     * @return int[]
+     */
+    protected function getPropertyMap() : array
     {
-        return array("issued_on" => self::TYPE_DATE,
+        return [
+            "issued_on" => self::TYPE_DATE,
             "file" => self::TYPE_STRING
-            );
+        ];
     }
 }

--- a/Modules/Course/classes/Verification/class.ilObjCourseVerificationAccess.php
+++ b/Modules/Course/classes/Verification/class.ilObjCourseVerificationAccess.php
@@ -36,7 +36,7 @@ class ilObjCourseVerificationAccess extends ilObjectAccess
     {
         global $DIC;
 
-        $ilAccess = $DIC['ilAccess'];
+        $ilAccess = $DIC->access();
         
         $t_arr = explode("_", $a_target);
         

--- a/Modules/Course/classes/Verification/class.ilObjCourseVerificationAccess.php
+++ b/Modules/Course/classes/Verification/class.ilObjCourseVerificationAccess.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 
@@ -42,7 +42,7 @@ class ilObjCourseVerificationAccess extends ilObjectAccess
         
         // #11021
         // personal workspace context: do not force normal login
-        if (isset($t_arr[2]) && $t_arr[2] == "wsp") {
+        if (isset($t_arr[2]) && $t_arr[2] === "wsp") {
             include_once "Services/PersonalWorkspace/classes/class.ilSharedResourceGUI.php";
             return ilSharedResourceGUI::hasAccess($t_arr[1]);
         }

--- a/Modules/Course/classes/Verification/class.ilObjCourseVerificationAccess.php
+++ b/Modules/Course/classes/Verification/class.ilObjCourseVerificationAccess.php
@@ -32,6 +32,10 @@ class ilObjCourseVerificationAccess extends ilObjectAccess
         return $commands;
     }
 
+    /**
+     * @param string $a_target
+     * @return bool
+     */
     public static function _checkGoto($a_target) : bool
     {
         global $DIC;

--- a/Modules/Course/classes/Verification/class.ilObjCourseVerificationAccess.php
+++ b/Modules/Course/classes/Verification/class.ilObjCourseVerificationAccess.php
@@ -25,14 +25,14 @@ class ilObjCourseVerificationAccess extends ilObjectAccess
      *		array("permission" => "write", "cmd" => "edit", "lang_var" => "edit"),
      *	);
      */
-    public static function _getCommands()
+    public static function _getCommands() : array
     {
-        $commands = array();
-        $commands[] = array("permission" => "read", "cmd" => "view", "lang_var" => "show", "default" => true);
+        $commands = [];
+        $commands[] = ["permission" => "read", "cmd" => "view", "lang_var" => "show", "default" => true];
         return $commands;
     }
-    
-    public static function _checkGoto($a_target)
+
+    public static function _checkGoto($a_target) : bool
     {
         global $DIC;
 

--- a/Modules/Course/classes/Verification/class.ilObjCourseVerificationGUI.php
+++ b/Modules/Course/classes/Verification/class.ilObjCourseVerificationGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 
@@ -49,6 +49,7 @@ class ilObjCourseVerificationGUI extends ilObject2GUI
 
     /**
      * create new instance and save it
+     * @throws ilException
      */
     public function save() : void
     {

--- a/Modules/Course/classes/Verification/class.ilObjCourseVerificationGUI.php
+++ b/Modules/Course/classes/Verification/class.ilObjCourseVerificationGUI.php
@@ -2,6 +2,8 @@
 
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+use ILIAS\DI\Container;
+
 include_once('./Services/Object/classes/class.ilObject2GUI.php');
 
 /**
@@ -13,6 +15,15 @@ include_once('./Services/Object/classes/class.ilObject2GUI.php');
  */
 class ilObjCourseVerificationGUI extends ilObject2GUI
 {
+    private Container $dic;
+
+    public function __construct($a_id = 0, $a_id_type = self::REPOSITORY_NODE_ID, $a_parent_node_id = 0)
+    {
+        global $DIC;
+        $this->dic = $DIC;
+        parent::__construct($a_id, $a_id_type, $a_parent_node_id);
+    }
+
     public function getType()
     {
         return "crsv";
@@ -23,9 +34,7 @@ class ilObjCourseVerificationGUI extends ilObject2GUI
      */
     public function create()
     {
-        global $DIC;
-
-        $ilTabs = $DIC->tabs();
+        $ilTabs = $this->dic->tabs();
 
         $this->lng->loadLanguageModule("crsv");
 
@@ -43,16 +52,14 @@ class ilObjCourseVerificationGUI extends ilObject2GUI
      */
     public function save()
     {
-        global $DIC;
-
-        $ilUser = $DIC->user();
+        $ilUser = $this->dic->user();
         
         $objectId = $_REQUEST["crs_id"];
         if ($objectId) {
             $certificateVerificationFileService = new ilCertificateVerificationFileService(
-                $DIC->language(),
-                $DIC->database(),
-                $DIC->logger()->root(),
+                $this->dic->language(),
+                $this->dic->database(),
+                $this->dic->logger()->root(),
                 new ilCertificateVerificationClassMap()
             );
 
@@ -102,10 +109,8 @@ class ilObjCourseVerificationGUI extends ilObject2GUI
      */
     public function render($a_return = false, $a_url = false)
     {
-        global $DIC;
-
-        $ilUser = $DIC->user();
-        $lng = $DIC->language();
+        $ilUser = $this->dic->user();
+        $lng = $this->dic->language();
         
         if (!$a_return) {
             $this->deliver();
@@ -141,9 +146,7 @@ class ilObjCourseVerificationGUI extends ilObject2GUI
     
     public function downloadFromPortfolioPage(ilPortfolioPage $a_page)
     {
-        global $DIC;
-
-        $ilErr = $DIC['ilErr'];
+        $ilErr = $this->dic['ilErr'];
         
         include_once "Services/COPage/classes/class.ilPCVerification.php";
         if (ilPCVerification::isInPortfolioPage($a_page, $this->object->getType(), $this->object->getId())) {

--- a/Modules/Course/classes/Verification/class.ilObjCourseVerificationGUI.php
+++ b/Modules/Course/classes/Verification/class.ilObjCourseVerificationGUI.php
@@ -54,7 +54,7 @@ class ilObjCourseVerificationGUI extends ilObject2GUI
     {
         $ilUser = $this->dic->user();
         
-        $objectId = $_REQUEST["crs_id"];
+        $objectId = $this->getRequestValue("crs_id");
         if ($objectId) {
             $certificateVerificationFileService = new ilCertificateVerificationFileService(
                 $this->dic->language(),
@@ -164,5 +164,22 @@ class ilObjCourseVerificationGUI extends ilObject2GUI
         $_GET["wsp_id"] = $id[0];
         include("ilias.php");
         exit;
+    }
+
+    /**
+     * @param string $key
+     * @param mixed   $default
+     * @return mixed|null
+     */
+    protected function getRequestValue(string $key, $default = null) {
+        if (isset($this->request->getQueryParams()[$key])) {
+            return $this->request->getQueryParams()[$key];
+        }
+
+        if (isset($this->request->getParsedBody()[$key])) {
+            return $this->request->getParsedBody()[$key];
+        }
+
+        return $default ?? null;
     }
 }

--- a/Modules/Course/classes/Verification/class.ilObjCourseVerificationGUI.php
+++ b/Modules/Course/classes/Verification/class.ilObjCourseVerificationGUI.php
@@ -25,7 +25,7 @@ class ilObjCourseVerificationGUI extends ilObject2GUI
     {
         global $DIC;
 
-        $ilTabs = $DIC['ilTabs'];
+        $ilTabs = $DIC->tabs();
 
         $this->lng->loadLanguageModule("crsv");
 
@@ -45,7 +45,7 @@ class ilObjCourseVerificationGUI extends ilObject2GUI
     {
         global $DIC;
 
-        $ilUser = $DIC['ilUser'];
+        $ilUser = $DIC->user();
         
         $objectId = $_REQUEST["crs_id"];
         if ($objectId) {
@@ -104,8 +104,8 @@ class ilObjCourseVerificationGUI extends ilObject2GUI
     {
         global $DIC;
 
-        $ilUser = $DIC['ilUser'];
-        $lng = $DIC['lng'];
+        $ilUser = $DIC->user();
+        $lng = $DIC->language();
         
         if (!$a_return) {
             $this->deliver();

--- a/Modules/Course/classes/Verification/class.ilObjCourseVerificationGUI.php
+++ b/Modules/Course/classes/Verification/class.ilObjCourseVerificationGUI.php
@@ -24,7 +24,7 @@ class ilObjCourseVerificationGUI extends ilObject2GUI
         parent::__construct($a_id, $a_id_type, $a_parent_node_id);
     }
 
-    public function getType()
+    public function getType() : string
     {
         return "crsv";
     }
@@ -32,7 +32,7 @@ class ilObjCourseVerificationGUI extends ilObject2GUI
     /**
      * List all tests in which current user participated
      */
-    public function create()
+    public function create() : void
     {
         $ilTabs = $this->dic->tabs();
 
@@ -50,7 +50,7 @@ class ilObjCourseVerificationGUI extends ilObject2GUI
     /**
      * create new instance and save it
      */
-    public function save()
+    public function save() : void
     {
         $ilUser = $this->dic->user();
         
@@ -74,7 +74,8 @@ class ilObjCourseVerificationGUI extends ilObject2GUI
                 $newObj = $certificateVerificationFileService->createFile($userCertificatePresentation);
             } catch (\Exception $exception) {
                 ilUtil::sendFailure($this->lng->txt('error_creating_certificate_pdf'));
-                return $this->create();
+                $this->create();
+                return;
             }
 
             if ($newObj) {
@@ -93,21 +94,21 @@ class ilObjCourseVerificationGUI extends ilObject2GUI
         $this->create();
     }
     
-    public function deliver()
+    public function deliver() : void
     {
         $file = $this->object->getFilePath();
         if ($file) {
             ilUtil::deliverFile($file, $this->object->getTitle() . ".pdf");
         }
     }
-    
+
     /**
      * Render content
-     *
-     * @param bool $a_return
-     * @param string $a_url
+     * @param bool        $a_return
+     * @param string|bool $a_url
+     * @return string
      */
-    public function render($a_return = false, $a_url = false)
+    public function render(bool $a_return = false, $a_url = false) : string
     {
         $ilUser = $this->dic->user();
         $lng = $this->dic->language();
@@ -142,9 +143,11 @@ class ilObjCourseVerificationGUI extends ilObject2GUI
                 return '<div>' . $caption . ' (' . $message . ')</div>';
             }
         }
+
+        return "";
     }
     
-    public function downloadFromPortfolioPage(ilPortfolioPage $a_page)
+    public function downloadFromPortfolioPage(ilPortfolioPage $a_page) : void
     {
         $ilErr = $this->dic['ilErr'];
         
@@ -156,7 +159,7 @@ class ilObjCourseVerificationGUI extends ilObject2GUI
         $ilErr->raiseError($this->lng->txt('permission_denied'), $ilErr->MESSAGE);
     }
     
-    public static function _goto($a_target)
+    public static function _goto(string $a_target) : void
     {
         $id = explode("_", $a_target);
         

--- a/Modules/Course/classes/Verification/class.ilObjCourseVerificationListGUI.php
+++ b/Modules/Course/classes/Verification/class.ilObjCourseVerificationListGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 

--- a/Modules/Course/classes/Verification/class.ilObjCourseVerificationListGUI.php
+++ b/Modules/Course/classes/Verification/class.ilObjCourseVerificationListGUI.php
@@ -38,7 +38,7 @@ class ilObjCourseVerificationListGUI extends ilObjectListGUI
     {
         global $DIC;
 
-        $lng = $DIC['lng'];
+        $lng = $DIC->language();
         
         return array(
             array("alert" => false, "property" => $lng->txt("type"),

--- a/Modules/Course/classes/Verification/class.ilObjCourseVerificationListGUI.php
+++ b/Modules/Course/classes/Verification/class.ilObjCourseVerificationListGUI.php
@@ -18,7 +18,7 @@ class ilObjCourseVerificationListGUI extends ilObjectListGUI
     /**
     * initialisation
     */
-    public function init()
+    public function init() : void
     {
         $this->delete_enabled = true;
         $this->cut_enabled = true;
@@ -34,15 +34,18 @@ class ilObjCourseVerificationListGUI extends ilObjectListGUI
         $this->commands = ilObjCourseVerificationAccess::_getCommands();
     }
     
-    public function getProperties()
+    public function getProperties() : array
     {
         global $DIC;
 
         $lng = $DIC->language();
         
-        return array(
-            array("alert" => false, "property" => $lng->txt("type"),
-                "value" => $lng->txt("wsp_list_crsv"))
-        );
+        return [
+            [
+                "alert" => false,
+                "property" => $lng->txt("type"),
+                "value" => $lng->txt("wsp_list_crsv")
+            ]
+        ];
     }
 } // END class.ilObjTestVerificationListGUI


### PR DESCRIPTION
Makes the php classes located in **/Modules/Course/classes/Verification** php 8.0 compatible

- Added declare(strict_types=1); to the top of all classes.
- Added type hints.
- Added return type hints.
- Replace direct access to $_REQUEST and $_SESSION.