### PR TITLE
Feature/php8 compatibility/modules exercise verification

### DIFF
--- a/Modules/Exercise/classes/class.ilExerciseVerificationTableGUI.php
+++ b/Modules/Exercise/classes/class.ilExerciseVerificationTableGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 /**

--- a/Modules/Exercise/classes/class.ilExerciseVerificationTableGUI.php
+++ b/Modules/Exercise/classes/class.ilExerciseVerificationTableGUI.php
@@ -9,26 +9,13 @@
  */
 class ilExerciseVerificationTableGUI extends ilTable2GUI
 {
+    private ?ilUserCertificateRepository $userCertificateRepository;
+    protected ilObjUser $user;
 
-    /**
-     * @var ilUserCertificateRepository
-     */
-    private $userCertificateRepository;
-
-    /**
-     * @var ilObjUser
-     */
-    protected $user;
-
-    /**
-     * @param ilObject $a_parent_obj
-     * @param string $a_parent_cmd
-     * @param ilUserCertificateRepository|null $userCertificateRepository
-     */
     public function __construct(
         ilObject $a_parent_obj,
         string $a_parent_cmd = "",
-        ilUserCertificateRepository $userCertificateRepository = null
+        ?ilUserCertificateRepository $userCertificateRepository = null
     ) {
         global $DIC;
 

--- a/Modules/Exercise/classes/class.ilExerciseVerificationTableGUI.php
+++ b/Modules/Exercise/classes/class.ilExerciseVerificationTableGUI.php
@@ -26,8 +26,8 @@ class ilExerciseVerificationTableGUI extends ilTable2GUI
      * @param ilUserCertificateRepository|null $userCertificateRepository
      */
     public function __construct(
-        $a_parent_obj,
-        $a_parent_cmd = "",
+        ilObject $a_parent_obj,
+        string $a_parent_cmd = "",
         ilUserCertificateRepository $userCertificateRepository = null
     ) {
         global $DIC;

--- a/Modules/Exercise/classes/class.ilExerciseVerificationTableGUI.php
+++ b/Modules/Exercise/classes/class.ilExerciseVerificationTableGUI.php
@@ -61,7 +61,7 @@ class ilExerciseVerificationTableGUI extends ilTable2GUI
     /**
      * Get all achieved test certificates for the current user
      */
-    protected function getItems()
+    protected function getItems() : void
     {
         $ilUser = $this->user;
         $userId = $ilUser->getId();
@@ -87,7 +87,7 @@ class ilExerciseVerificationTableGUI extends ilTable2GUI
      *
      * @param array $a_set
      */
-    protected function fillRow($a_set)
+    protected function fillRow($a_set) : void
     {
         $ilCtrl = $this->ctrl;
 

--- a/Modules/Exercise/classes/class.ilObjExerciseVerification.php
+++ b/Modules/Exercise/classes/class.ilObjExerciseVerification.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 /**

--- a/Modules/Exercise/classes/class.ilObjExerciseVerification.php
+++ b/Modules/Exercise/classes/class.ilObjExerciseVerification.php
@@ -11,12 +11,12 @@
 */
 class ilObjExerciseVerification extends ilVerificationObject
 {
-    protected function initType()
+    protected function initType() : void
     {
         $this->type = "excv";
     }
 
-    protected function getPropertyMap()
+    protected function getPropertyMap() : array
     {
         return array("issued_on" => self::TYPE_DATE,
             "file" => self::TYPE_STRING

--- a/Modules/Exercise/classes/class.ilObjExerciseVerificationAccess.php
+++ b/Modules/Exercise/classes/class.ilObjExerciseVerificationAccess.php
@@ -23,14 +23,14 @@ class ilObjExerciseVerificationAccess extends ilObjectAccess
      *		array("permission" => "write", "cmd" => "edit", "lang_var" => "edit"),
      *	);
      */
-    public static function _getCommands()
+    public static function _getCommands() : array
     {
         $commands = array();
         $commands[] = array("permission" => "read", "cmd" => "view", "lang_var" => "show", "default" => true);
         return $commands;
     }
     
-    public static function _checkGoto($a_target)
+    public static function _checkGoto($a_target) : bool
     {
         global $DIC;
 

--- a/Modules/Exercise/classes/class.ilObjExerciseVerificationAccess.php
+++ b/Modules/Exercise/classes/class.ilObjExerciseVerificationAccess.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 

--- a/Modules/Exercise/classes/class.ilObjExerciseVerificationAccess.php
+++ b/Modules/Exercise/classes/class.ilObjExerciseVerificationAccess.php
@@ -29,7 +29,11 @@ class ilObjExerciseVerificationAccess extends ilObjectAccess
         $commands[] = array("permission" => "read", "cmd" => "view", "lang_var" => "show", "default" => true);
         return $commands;
     }
-    
+
+    /**
+     * @param string $a_target
+     * @return bool
+     */
     public static function _checkGoto($a_target) : bool
     {
         global $DIC;
@@ -40,7 +44,7 @@ class ilObjExerciseVerificationAccess extends ilObjectAccess
         
         // #11021
         // personal workspace context: do not force normal login
-        if (isset($t_arr[2]) && $t_arr[2] == "wsp") {
+        if (isset($t_arr[2]) && $t_arr[2] === "wsp") {
             return ilSharedResourceGUI::hasAccess($t_arr[1]);
         }
 

--- a/Modules/Exercise/classes/class.ilObjExerciseVerificationGUI.php
+++ b/Modules/Exercise/classes/class.ilObjExerciseVerificationGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 

--- a/Modules/Exercise/classes/class.ilObjExerciseVerificationGUI.php
+++ b/Modules/Exercise/classes/class.ilObjExerciseVerificationGUI.php
@@ -11,7 +11,7 @@
  */
 class ilObjExerciseVerificationGUI extends ilObject2GUI
 {
-    public function getType()
+    public function getType() : string
     {
         return "excv";
     }
@@ -19,7 +19,7 @@ class ilObjExerciseVerificationGUI extends ilObject2GUI
     /**
      * List all exercises in which current user participated
      */
-    public function create()
+    public function create() : void
     {
         $ilTabs = $this->tabs_gui;
 
@@ -37,7 +37,7 @@ class ilObjExerciseVerificationGUI extends ilObject2GUI
     /**
      * create new instance and save it
      */
-    public function save()
+    public function save() : void
     {
         global $DIC;
 
@@ -63,7 +63,7 @@ class ilObjExerciseVerificationGUI extends ilObject2GUI
                 $newObj = $certificateVerificationFileService->createFile($userCertificatePresentation);
             } catch (\Exception $exception) {
                 ilUtil::sendFailure($this->lng->txt('error_creating_certificate_pdf'));
-                return $this->create();
+                $this->create();
             }
 
             if ($newObj) {
@@ -81,7 +81,7 @@ class ilObjExerciseVerificationGUI extends ilObject2GUI
         $this->create();
     }
     
-    public function deliver()
+    public function deliver() : void
     {
         $file = $this->object->getFilePath();
         if ($file) {
@@ -95,7 +95,7 @@ class ilObjExerciseVerificationGUI extends ilObject2GUI
      * @param bool $a_return
      * @param string $a_url
      */
-    public function render($a_return = false, $a_url = false)
+    public function render($a_return = false, $a_url = false) : string
     {
         $ilUser = $this->user;
         $lng = $this->lng;
@@ -131,7 +131,7 @@ class ilObjExerciseVerificationGUI extends ilObject2GUI
         }
     }
     
-    public function downloadFromPortfolioPage(ilPortfolioPage $a_page)
+    public function downloadFromPortfolioPage(ilPortfolioPage $a_page) : void
     {
         if (ilPCVerification::isInPortfolioPage($a_page, $this->object->getType(), $this->object->getId())) {
             $this->deliver();
@@ -140,7 +140,7 @@ class ilObjExerciseVerificationGUI extends ilObject2GUI
         throw new ilExerciseException($this->lng->txt('permission_denied'));
     }
 
-    public static function _goto($a_target)
+    public static function _goto($a_target) : void
     {
         $id = explode("_", $a_target);
         

--- a/Modules/Exercise/classes/class.ilObjExerciseVerificationGUI.php
+++ b/Modules/Exercise/classes/class.ilObjExerciseVerificationGUI.php
@@ -43,7 +43,7 @@ class ilObjExerciseVerificationGUI extends ilObject2GUI
 
         $ilUser = $this->user;
 
-        $objectId = $_REQUEST["exc_id"];
+        $objectId = $this->getRequestValue("exc_id");
         if ($objectId) {
             $certificateVerificationFileService = new ilCertificateVerificationFileService(
                 $DIC->language(),
@@ -148,5 +148,22 @@ class ilObjExerciseVerificationGUI extends ilObject2GUI
         $_GET["wsp_id"] = $id[0];
         include("ilias.php");
         exit;
+    }
+
+    /**
+     * @param string $key
+     * @param mixed   $default
+     * @return mixed|null
+     */
+    protected function getRequestValue(string $key, $default = null) {
+        if (isset($this->request->getQueryParams()[$key])) {
+            return $this->request->getQueryParams()[$key];
+        }
+
+        if (isset($this->request->getParsedBody()[$key])) {
+            return $this->request->getParsedBody()[$key];
+        }
+
+        return $default ?? null;
     }
 }

--- a/Modules/Exercise/classes/class.ilObjExerciseVerificationGUI.php
+++ b/Modules/Exercise/classes/class.ilObjExerciseVerificationGUI.php
@@ -88,14 +88,14 @@ class ilObjExerciseVerificationGUI extends ilObject2GUI
             ilUtil::deliverFile($file, $this->object->getTitle() . ".pdf");
         }
     }
-    
+
     /**
      * Render content
-     *
      * @param bool $a_return
-     * @param string $a_url
+     * @param bool|string $a_url
+     * @return string
      */
-    public function render($a_return = false, $a_url = false) : string
+    public function render(bool $a_return = false, $a_url = false) : string
     {
         $ilUser = $this->user;
         $lng = $this->lng;
@@ -140,7 +140,7 @@ class ilObjExerciseVerificationGUI extends ilObject2GUI
         throw new ilExerciseException($this->lng->txt('permission_denied'));
     }
 
-    public static function _goto($a_target) : void
+    public static function _goto(string $a_target) : void
     {
         $id = explode("_", $a_target);
         

--- a/Modules/Exercise/classes/class.ilObjExerciseVerificationGUI.php
+++ b/Modules/Exercise/classes/class.ilObjExerciseVerificationGUI.php
@@ -129,6 +129,8 @@ class ilObjExerciseVerificationGUI extends ilObject2GUI
                 return '<div>' . $caption . ' (' . $message . ')</div>';
             }
         }
+
+        return "";
     }
     
     public function downloadFromPortfolioPage(ilPortfolioPage $a_page) : void

--- a/Modules/Exercise/classes/class.ilObjExerciseVerificationListGUI.php
+++ b/Modules/Exercise/classes/class.ilObjExerciseVerificationListGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 

--- a/Modules/Exercise/classes/class.ilObjExerciseVerificationListGUI.php
+++ b/Modules/Exercise/classes/class.ilObjExerciseVerificationListGUI.php
@@ -16,7 +16,7 @@ class ilObjExerciseVerificationListGUI extends ilObjectListGUI
     /**
     * initialisation
     */
-    public function init()
+    public function init() : void
     {
         $this->delete_enabled = true;
         $this->cut_enabled = true;
@@ -31,7 +31,7 @@ class ilObjExerciseVerificationListGUI extends ilObjectListGUI
         $this->commands = ilObjExerciseVerificationAccess::_getCommands();
     }
     
-    public function getProperties()
+    public function getProperties() : array
     {
         $lng = $this->lng;
         


### PR DESCRIPTION
Makes the php classes located in /Modules/Exercise/classes/ used for verification php 8.0 compatible.

- Added declare(strict_types=1); to all classes
- Added function return types
- Added function parameter types
- Added property types
- Replaced $_REQUEST with function using $DIC->http()->request()