### PR TITLE
Feature/php8 compatibility/modules test verification

### DIFF
--- a/Modules/Test/classes/class.ilObjTestVerification.php
+++ b/Modules/Test/classes/class.ilObjTestVerification.php
@@ -14,12 +14,12 @@ include_once('./Services/Verification/classes/class.ilVerificationObject.php');
 */
 class ilObjTestVerification extends ilVerificationObject
 {
-    protected function initType()
+    protected function initType() : void
     {
         $this->type = "tstv";
     }
 
-    protected function getPropertyMap()
+    protected function getPropertyMap() : array
     {
         return array("issued_on" => self::TYPE_DATE,
             "file" => self::TYPE_STRING

--- a/Modules/Test/classes/class.ilObjTestVerification.php
+++ b/Modules/Test/classes/class.ilObjTestVerification.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 include_once('./Services/Verification/classes/class.ilVerificationObject.php');

--- a/Modules/Test/classes/class.ilObjTestVerificationAccess.php
+++ b/Modules/Test/classes/class.ilObjTestVerificationAccess.php
@@ -25,14 +25,14 @@ class ilObjTestVerificationAccess extends ilObjectAccess
      *		array("permission" => "write", "cmd" => "edit", "lang_var" => "edit"),
      *	);
      */
-    public static function _getCommands()
+    public static function _getCommands() : array
     {
         $commands = array();
         $commands[] = array("permission" => "read", "cmd" => "view", "lang_var" => "show", "default" => true);
         return $commands;
     }
     
-    public static function _checkGoto($a_target)
+    public static function _checkGoto($a_target) : bool
     {
         global $DIC;
         $ilAccess = $DIC['ilAccess'];

--- a/Modules/Test/classes/class.ilObjTestVerificationAccess.php
+++ b/Modules/Test/classes/class.ilObjTestVerificationAccess.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 include_once("./Services/Object/classes/class.ilObjectAccess.php");

--- a/Modules/Test/classes/class.ilObjTestVerificationAccess.php
+++ b/Modules/Test/classes/class.ilObjTestVerificationAccess.php
@@ -31,7 +31,11 @@ class ilObjTestVerificationAccess extends ilObjectAccess
         $commands[] = array("permission" => "read", "cmd" => "view", "lang_var" => "show", "default" => true);
         return $commands;
     }
-    
+
+    /**
+     * @param string $a_target
+     * @return bool
+     */
     public static function _checkGoto($a_target) : bool
     {
         global $DIC;

--- a/Modules/Test/classes/class.ilObjTestVerificationGUI.php
+++ b/Modules/Test/classes/class.ilObjTestVerificationGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 include_once('./Services/Object/classes/class.ilObject2GUI.php');

--- a/Modules/Test/classes/class.ilObjTestVerificationGUI.php
+++ b/Modules/Test/classes/class.ilObjTestVerificationGUI.php
@@ -48,7 +48,7 @@ class ilObjTestVerificationGUI extends ilObject2GUI
         global $DIC;
         $ilUser = $DIC['ilUser'];
 
-        $objectId = $_REQUEST["tst_id"];
+        $objectId = $this->getRequestValue("tst_id");
         if ($objectId) {
             $certificateVerificationFileService = new ilCertificateVerificationFileService(
                 $DIC->language(),
@@ -160,5 +160,22 @@ class ilObjTestVerificationGUI extends ilObject2GUI
         $_GET["wsp_id"] = $id[0];
         include("ilias.php");
         exit;
+    }
+
+    /**
+     * @param string $key
+     * @param mixed   $default
+     * @return mixed|null
+     */
+    protected function getRequestValue(string $key, $default = null) {
+        if (isset($this->request->getQueryParams()[$key])) {
+            return $this->request->getQueryParams()[$key];
+        }
+
+        if (isset($this->request->getParsedBody()[$key])) {
+            return $this->request->getParsedBody()[$key];
+        }
+
+        return $default ?? null;
     }
 }

--- a/Modules/Test/classes/class.ilObjTestVerificationGUI.php
+++ b/Modules/Test/classes/class.ilObjTestVerificationGUI.php
@@ -15,7 +15,7 @@ include_once('./Services/Object/classes/class.ilObject2GUI.php');
 */
 class ilObjTestVerificationGUI extends ilObject2GUI
 {
-    public function getType()
+    public function getType() : string
     {
         return "tstv";
     }
@@ -23,7 +23,7 @@ class ilObjTestVerificationGUI extends ilObject2GUI
     /**
      * List all tests in which current user participated
      */
-    public function create()
+    public function create() : void
     {
         global $DIC;
         $ilTabs = $DIC['ilTabs'];
@@ -43,7 +43,7 @@ class ilObjTestVerificationGUI extends ilObject2GUI
     /**
      * create new instance and save it
      */
-    public function save()
+    public function save() : void
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];
@@ -68,7 +68,7 @@ class ilObjTestVerificationGUI extends ilObject2GUI
                 $newObj = $certificateVerificationFileService->createFile($userCertificatePresentation);
             } catch (\Exception $exception) {
                 ilUtil::sendFailure($this->lng->txt('error_creating_certificate_pdf'));
-                return $this->create();
+                $this->create();
             }
 
             if ($newObj) {
@@ -86,7 +86,7 @@ class ilObjTestVerificationGUI extends ilObject2GUI
         $this->create();
     }
     
-    public function deliver()
+    public function deliver() : void
     {
         $file = $this->object->getFilePath();
         if ($file) {
@@ -100,7 +100,7 @@ class ilObjTestVerificationGUI extends ilObject2GUI
      * @param bool $a_return
      * @param string $a_url
      */
-    public function render($a_return = false, $a_url = false)
+    public function render($a_return = false, $a_url = false) : string
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];
@@ -135,9 +135,11 @@ class ilObjTestVerificationGUI extends ilObject2GUI
                 return '<div>' . $caption . ' (' . $message . ')</div>';
             }
         }
+
+        return "";
     }
     
-    public function downloadFromPortfolioPage(ilPortfolioPage $a_page)
+    public function downloadFromPortfolioPage(ilPortfolioPage $a_page) : void
     {
         global $DIC;
         $ilErr = $DIC['ilErr'];
@@ -150,7 +152,7 @@ class ilObjTestVerificationGUI extends ilObject2GUI
         $ilErr->raiseError($this->lng->txt('permission_denied'), $ilErr->MESSAGE);
     }
 
-    public static function _goto($a_target)
+    public static function _goto($a_target) : void
     {
         $id = explode("_", $a_target);
         

--- a/Modules/Test/classes/class.ilObjTestVerificationGUI.php
+++ b/Modules/Test/classes/class.ilObjTestVerificationGUI.php
@@ -96,11 +96,11 @@ class ilObjTestVerificationGUI extends ilObject2GUI
 
     /**
      * Render content
-     *
-     * @param bool $a_return
-     * @param string $a_url
+     * @param bool        $a_return
+     * @param string|bool $a_url
+     * @return string
      */
-    public function render($a_return = false, $a_url = false) : string
+    public function render(bool $a_return = false, $a_url = false) : string
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];
@@ -152,7 +152,7 @@ class ilObjTestVerificationGUI extends ilObject2GUI
         $ilErr->raiseError($this->lng->txt('permission_denied'), $ilErr->MESSAGE);
     }
 
-    public static function _goto($a_target) : void
+    public static function _goto(string $a_target) : void
     {
         $id = explode("_", $a_target);
         

--- a/Modules/Test/classes/class.ilObjTestVerificationListGUI.php
+++ b/Modules/Test/classes/class.ilObjTestVerificationListGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 /**

--- a/Modules/Test/classes/class.ilObjTestVerificationListGUI.php
+++ b/Modules/Test/classes/class.ilObjTestVerificationListGUI.php
@@ -17,7 +17,7 @@ class ilObjTestVerificationListGUI extends ilObjectListGUI
     /**
     * initialisation
     */
-    public function init()
+    public function init() : void
     {
         $this->delete_enabled = true;
         $this->cut_enabled = true;
@@ -33,7 +33,7 @@ class ilObjTestVerificationListGUI extends ilObjectListGUI
         $this->commands = ilObjTestVerificationAccess::_getCommands();
     }
     
-    public function getProperties()
+    public function getProperties() : array
     {
         global $DIC;
         $lng = $DIC['lng'];

--- a/Modules/Test/classes/tables/class.ilTestVerificationTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilTestVerificationTableGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 include_once './Services/Table/classes/class.ilTable2GUI.php';

--- a/Modules/Test/classes/tables/class.ilTestVerificationTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilTestVerificationTableGUI.php
@@ -16,15 +16,10 @@ class ilTestVerificationTableGUI extends ilTable2GUI
      */
     private $userCertificateRepository;
 
-    /**
-     * @param ilObject $a_parent_obj
-     * @param string $a_parent_cmd
-     * @param ilUserCertificateRepository|null $userCertificateRepository
-     */
     public function __construct(
-        $a_parent_obj,
-        $a_parent_cmd = "",
-        ilUserCertificateRepository $userCertificateRepository = null
+        ilObject $a_parent_obj,
+        string $a_parent_cmd = "",
+        ?ilUserCertificateRepository $userCertificateRepository = null
     ) {
         global $DIC;
 

--- a/Modules/Test/classes/tables/class.ilTestVerificationTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilTestVerificationTableGUI.php
@@ -55,7 +55,7 @@ class ilTestVerificationTableGUI extends ilTable2GUI
     /**
      * Get all completed tests
      */
-    protected function getItems()
+    protected function getItems() : void
     {
         global $DIC;
 
@@ -82,7 +82,7 @@ class ilTestVerificationTableGUI extends ilTable2GUI
      *
      * @param array $a_set
      */
-    protected function fillRow($a_set)
+    protected function fillRow($a_set) : void
     {
         global $DIC;
         $ilCtrl = $DIC['ilCtrl'];

--- a/Modules/Test/classes/tables/class.ilTestVerificationTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilTestVerificationTableGUI.php
@@ -11,10 +11,7 @@ include_once './Services/Table/classes/class.ilTable2GUI.php';
  */
 class ilTestVerificationTableGUI extends ilTable2GUI
 {
-    /**
-     * @var ilUserCertificateRepository|null
-     */
-    private $userCertificateRepository;
+    private ilUserCertificateRepository $userCertificateRepository;
 
     public function __construct(
         ilObject $a_parent_obj,

--- a/Modules/Test/classes/tables/class.ilTestVerificationTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilTestVerificationTableGUI.php
@@ -11,7 +11,7 @@ include_once './Services/Table/classes/class.ilTable2GUI.php';
  */
 class ilTestVerificationTableGUI extends ilTable2GUI
 {
-    private ilUserCertificateRepository $userCertificateRepository;
+    private ?ilUserCertificateRepository $userCertificateRepository;
 
     public function __construct(
         ilObject $a_parent_obj,


### PR DESCRIPTION
Makes the php classes located in /Modules/Test/classes/ used for verification php 8.0 compatible.

- Added declare(strict_types=1); to all classes
- Added function return types
- Added function parameter types
- Added property types
- Replaced $_REQUEST with function using $DIC->http()->request()