### PR TITLE
fix for 31090: slow SessionOverviewTableGUI

### DIFF
--- a/Modules/Session/classes/class.ilEventParticipants.php
+++ b/Modules/Session/classes/class.ilEventParticipants.php
@@ -332,7 +332,7 @@ class ilEventParticipants
             "AND participated = 1";
         $res = $ilDB->query($query);
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $user_ids[] = $row->usr_id;
+            $user_ids[$row->usr_id] = $row->usr_id;
         }
         return $user_ids ? $user_ids : array();
     }

--- a/Modules/Session/classes/class.ilSessionOverviewTableGUI.php
+++ b/Modules/Session/classes/class.ilSessionOverviewTableGUI.php
@@ -89,21 +89,24 @@ class ilSessionOverviewTableGUI extends ilTable2GUI
     {
         $data = array();
         
-        include_once 'Modules/Session/classes/class.ilEventParticipants.php';
-        
         foreach ($a_members as $user_id) {
             $name = ilObjUser::_lookupName($user_id);
             $data[$user_id] = array(
                 'name' => $name['lastname'] . ', ' . $name['firstname'],
                 'login' => $name['login']
             );
-            
+            include_once 'Modules/Session/classes/class.ilEventParticipants.php';
             foreach ($a_events as $event_obj) {
-                $event_part = new ilEventParticipants($event_obj->getId());
-                $data[$user_id]['event_' . $event_obj->getId()] = $event_part->hasParticipated($user_id);
+                $users_of_event = ilEventParticipants::_getParticipated($event_obj->getID());
+                foreach ($a_members as $user_id) {
+                    if (array_key_exists($user_id, $users_of_event)) {
+                        $data[$user_id]['event_' . $event_obj->getId()] = true;
+                    } else {
+                        $data[$user_id]['event_' . $event_obj->getId()] = false;
+                    }
+                }
             }
         }
-        
         $this->setData($data);
     }
         

--- a/Modules/Session/classes/class.ilSessionOverviewTableGUI.php
+++ b/Modules/Session/classes/class.ilSessionOverviewTableGUI.php
@@ -95,6 +95,7 @@ class ilSessionOverviewTableGUI extends ilTable2GUI
                 'name' => $name['lastname'] . ', ' . $name['firstname'],
                 'login' => $name['login']
             );
+        }
             include_once 'Modules/Session/classes/class.ilEventParticipants.php';
             foreach ($a_events as $event_obj) {
                 $users_of_event = ilEventParticipants::_getParticipated($event_obj->getID());
@@ -106,7 +107,6 @@ class ilSessionOverviewTableGUI extends ilTable2GUI
                     }
                 }
             }
-        }
         $this->setData($data);
     }
         


### PR DESCRIPTION
Hello
This change should fix this issue:  https://mantis.ilias.de/view.php?id=31090
If you have a course with many sessions and you click on the tab "members" and then the subtab "sessions" you are supposed to get a view that shows which course-member participated in which session. If there are many users and many sessions in a course, loading the page takes too long and we run into a gateway timeout.

Instead of creating a new ilEventsParticipants-object, I use the static method _getParticipated. This is faster because the constructor of ilEventsParticipants looks up a lot of information, that is not needed in this context.

I added a key to the array $user_ids in ilEventParticipants so that I can use array_key_exists instead of in_array. This makes it about 7 times faster.

I tested this change in a course with 700 sessions and 400 participants. Without the change loading the site took more than 10 minutes. With this change it only took 7 seconds.

Thank you and goodbye

