### PR TITLE
Feature/php8 compatibility/modules scorm verification

### DIFF
--- a/Modules/ScormAicc/classes/Verification/class.ilObjSCORMVerification.php
+++ b/Modules/ScormAicc/classes/Verification/class.ilObjSCORMVerification.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 include_once('./Services/Verification/classes/class.ilVerificationObject.php');

--- a/Modules/ScormAicc/classes/Verification/class.ilObjSCORMVerification.php
+++ b/Modules/ScormAicc/classes/Verification/class.ilObjSCORMVerification.php
@@ -14,12 +14,12 @@ include_once('./Services/Verification/classes/class.ilVerificationObject.php');
 */
 class ilObjSCORMVerification extends ilVerificationObject
 {
-    protected function initType()
+    protected function initType() : void
     {
         $this->type = "scov";
     }
 
-    protected function getPropertyMap()
+    protected function getPropertyMap() : array
     {
         return array("issued_on" => self::TYPE_DATE,
             "file" => self::TYPE_STRING

--- a/Modules/ScormAicc/classes/Verification/class.ilObjSCORMVerificationAccess.php
+++ b/Modules/ScormAicc/classes/Verification/class.ilObjSCORMVerificationAccess.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 

--- a/Modules/ScormAicc/classes/Verification/class.ilObjSCORMVerificationAccess.php
+++ b/Modules/ScormAicc/classes/Verification/class.ilObjSCORMVerificationAccess.php
@@ -25,14 +25,14 @@ class ilObjSCORMVerificationAccess extends ilObjectAccess
      *		array("permission" => "write", "cmd" => "edit", "lang_var" => "edit"),
      *	);
      */
-    public static function _getCommands()
+    public static function _getCommands() : array
     {
         $commands = array();
         $commands[] = array("permission" => "read", "cmd" => "view", "lang_var" => "show", "default" => true);
         return $commands;
     }
     
-    public static function _checkGoto($a_target)
+    public static function _checkGoto($a_target) : bool
     {
         global $DIC;
         $ilAccess = $DIC['ilAccess'];

--- a/Modules/ScormAicc/classes/Verification/class.ilObjSCORMVerificationAccess.php
+++ b/Modules/ScormAicc/classes/Verification/class.ilObjSCORMVerificationAccess.php
@@ -31,7 +31,11 @@ class ilObjSCORMVerificationAccess extends ilObjectAccess
         $commands[] = array("permission" => "read", "cmd" => "view", "lang_var" => "show", "default" => true);
         return $commands;
     }
-    
+
+    /**
+     * @param string $a_target
+     * @return bool
+     */
     public static function _checkGoto($a_target) : bool
     {
         global $DIC;

--- a/Modules/ScormAicc/classes/Verification/class.ilObjSCORMVerificationGUI.php
+++ b/Modules/ScormAicc/classes/Verification/class.ilObjSCORMVerificationGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 

--- a/Modules/ScormAicc/classes/Verification/class.ilObjSCORMVerificationGUI.php
+++ b/Modules/ScormAicc/classes/Verification/class.ilObjSCORMVerificationGUI.php
@@ -95,11 +95,11 @@ class ilObjSCORMVerificationGUI extends ilObject2GUI
 
     /**
      * Render content
-     *
-     * @param bool $a_return
-     * @param string $a_url
+     * @param bool        $a_return
+     * @param string|bool $a_url
+     * @return string
      */
-    public function render($a_return = false, $a_url = false) : string
+    public function render(bool $a_return = false, $a_url = false) : string
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];
@@ -152,7 +152,7 @@ class ilObjSCORMVerificationGUI extends ilObject2GUI
         $ilErr->raiseError($this->lng->txt('permission_denied'), $ilErr->MESSAGE);
     }
 
-    public static function _goto($a_target) : void
+    public static function _goto(string $a_target) : void
     {
         $id = explode("_", $a_target);
 

--- a/Modules/ScormAicc/classes/Verification/class.ilObjSCORMVerificationGUI.php
+++ b/Modules/ScormAicc/classes/Verification/class.ilObjSCORMVerificationGUI.php
@@ -47,7 +47,7 @@ class ilObjSCORMVerificationGUI extends ilObject2GUI
 
         $ilUser = $DIC->user();
 
-        $objectId = $_REQUEST["lm_id"];
+        $objectId = $this->getRequestValue("lm_id");
         if ($objectId) {
             $certificateVerificationFileService = new ilCertificateVerificationFileService(
                 $DIC->language(),
@@ -160,5 +160,22 @@ class ilObjSCORMVerificationGUI extends ilObject2GUI
         $_GET["wsp_id"] = $id[0];
         include("ilias.php");
         exit;
+    }
+
+    /**
+     * @param string $key
+     * @param mixed   $default
+     * @return mixed|null
+     */
+    protected function getRequestValue(string $key, $default = null) {
+        if (isset($this->request->getQueryParams()[$key])) {
+            return $this->request->getQueryParams()[$key];
+        }
+
+        if (isset($this->request->getParsedBody()[$key])) {
+            return $this->request->getParsedBody()[$key];
+        }
+
+        return $default ?? null;
     }
 }

--- a/Modules/ScormAicc/classes/Verification/class.ilObjSCORMVerificationGUI.php
+++ b/Modules/ScormAicc/classes/Verification/class.ilObjSCORMVerificationGUI.php
@@ -13,7 +13,7 @@ include_once('./Services/Object/classes/class.ilObject2GUI.php');
  */
 class ilObjSCORMVerificationGUI extends ilObject2GUI
 {
-    public function getType()
+    public function getType() : string
     {
         return "scov";
     }
@@ -21,7 +21,7 @@ class ilObjSCORMVerificationGUI extends ilObject2GUI
     /**
      * List all tests in which current user participated
      */
-    public function create()
+    public function create() : void
     {
         global $DIC;
         $ilTabs = $DIC['ilTabs'];
@@ -41,7 +41,7 @@ class ilObjSCORMVerificationGUI extends ilObject2GUI
     /**
      * create new instance and save it
      */
-    public function save()
+    public function save() : void
     {
         global $DIC;
 
@@ -67,7 +67,7 @@ class ilObjSCORMVerificationGUI extends ilObject2GUI
                 $newObj = $certificateVerificationFileService->createFile($userCertificatePresentation);
             } catch (\Exception $exception) {
                 ilUtil::sendFailure($this->lng->txt('error_creating_certificate_pdf'));
-                return $this->create();
+                $this->create();
             }
 
             if ($newObj) {
@@ -85,7 +85,7 @@ class ilObjSCORMVerificationGUI extends ilObject2GUI
         $this->create();
     }
 
-    public function deliver()
+    public function deliver() : void
     {
         $file = $this->object->getFilePath();
         if ($file) {
@@ -99,7 +99,7 @@ class ilObjSCORMVerificationGUI extends ilObject2GUI
      * @param bool $a_return
      * @param string $a_url
      */
-    public function render($a_return = false, $a_url = false)
+    public function render($a_return = false, $a_url = false) : string
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];
@@ -135,9 +135,11 @@ class ilObjSCORMVerificationGUI extends ilObject2GUI
                 return '<div>' . $caption . ' (' . $message . ')</div>';
             }
         }
+
+        return "";
     }
 
-    public function downloadFromPortfolioPage(ilPortfolioPage $a_page)
+    public function downloadFromPortfolioPage(ilPortfolioPage $a_page) : void
     {
         global $DIC;
         $ilErr = $DIC['ilErr'];
@@ -150,7 +152,7 @@ class ilObjSCORMVerificationGUI extends ilObject2GUI
         $ilErr->raiseError($this->lng->txt('permission_denied'), $ilErr->MESSAGE);
     }
 
-    public static function _goto($a_target)
+    public static function _goto($a_target) : void
     {
         $id = explode("_", $a_target);
 

--- a/Modules/ScormAicc/classes/Verification/class.ilObjSCORMVerificationListGUI.php
+++ b/Modules/ScormAicc/classes/Verification/class.ilObjSCORMVerificationListGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 

--- a/Modules/ScormAicc/classes/Verification/class.ilObjSCORMVerificationListGUI.php
+++ b/Modules/ScormAicc/classes/Verification/class.ilObjSCORMVerificationListGUI.php
@@ -18,7 +18,7 @@ class ilObjSCORMVerificationListGUI extends ilObjectListGUI
     /**
     * initialisation
     */
-    public function init()
+    public function init() : void
     {
         $this->delete_enabled = true;
         $this->cut_enabled = true;
@@ -34,7 +34,7 @@ class ilObjSCORMVerificationListGUI extends ilObjectListGUI
         $this->commands = ilObjSCORMVerificationAccess::_getCommands();
     }
     
-    public function getProperties()
+    public function getProperties() : array
     {
         global $DIC;
         $lng = $DIC['lng'];

--- a/Modules/ScormAicc/classes/Verification/class.ilSCORMVerificationTableGUI.php
+++ b/Modules/ScormAicc/classes/Verification/class.ilSCORMVerificationTableGUI.php
@@ -19,12 +19,12 @@ class ilSCORMVerificationTableGUI extends ilTable2GUI
     /**
      * @param ilObject $a_parent_obj
      * @param string $a_parent_cmd
-     * @param null $userCertificateRepository
+     * @param ilUserCertificateRepository|null $userCertificateRepository
      */
     public function __construct(
-        $a_parent_obj,
-        $a_parent_cmd = "",
-        $userCertificateRepository = null
+        ilObject $a_parent_obj,
+        string $a_parent_cmd = "",
+        ?ilUserCertificateRepository $userCertificateRepository = null
     ) {
         global $DIC;
 

--- a/Modules/ScormAicc/classes/Verification/class.ilSCORMVerificationTableGUI.php
+++ b/Modules/ScormAicc/classes/Verification/class.ilSCORMVerificationTableGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 include_once './Services/Table/classes/class.ilTable2GUI.php';

--- a/Modules/ScormAicc/classes/Verification/class.ilSCORMVerificationTableGUI.php
+++ b/Modules/ScormAicc/classes/Verification/class.ilSCORMVerificationTableGUI.php
@@ -11,10 +11,7 @@ include_once './Services/Table/classes/class.ilTable2GUI.php';
  */
 class ilSCORMVerificationTableGUI extends ilTable2GUI
 {
-    /**
-     * @var ilUserCertificateRepository|null
-     */
-    private $userCertificateRepository;
+    private ?ilUserCertificateRepository $userCertificateRepository;
 
     /**
      * @param ilObject $a_parent_obj

--- a/Modules/ScormAicc/classes/Verification/class.ilSCORMVerificationTableGUI.php
+++ b/Modules/ScormAicc/classes/Verification/class.ilSCORMVerificationTableGUI.php
@@ -55,7 +55,7 @@ class ilSCORMVerificationTableGUI extends ilTable2GUI
     /**
      * Get all achieved certificates of SCORM modules for current user
      */
-    protected function getItems()
+    protected function getItems() : void
     {
         global $DIC;
 
@@ -82,7 +82,7 @@ class ilSCORMVerificationTableGUI extends ilTable2GUI
      *
      * @param array $a_set
      */
-    protected function fillRow($a_set)
+    protected function fillRow($a_set) : void
     {
         global $DIC;
         $ilCtrl = $DIC['ilCtrl'];


### PR DESCRIPTION
Makes the php classes located in **/Modules/ScormAicc/classes/Verification** php 8.0 compatible.

Added declare(strict_types=1); to all classes
Added function return types
Added function parameter types
Added property types
Replaced $_REQUEST with function using $DIC->http()->request()