### PR TITLE
Patch: fix modal buttons

### DIFF
--- a/Modules/TestQuestionPool/templates/default/cloze_gap_builder.js
+++ b/Modules/TestQuestionPool/templates/default/cloze_gap_builder.js
@@ -66,13 +66,14 @@ var ClozeGapBuilder = (function () {
 	pro.addModalFakeFooter = function () {
 		if (ClozeGlobals.jour_fixe_incompatible === false) {
 			if ($('.modal-fake-footer').length === 0) {
-				$('<div class="modal-fake-footer"><input type="button" id="modal_ok_button" class="btn btn-default btn-sm btn-dummy" value="' + ClozeSettings.ok_text + '"> <input type="button" id="modal_cancel_button" class="btn btn-default btn-sm btn-dummy" value="' + ClozeSettings.cancel_text + '"></div>').appendTo('.modal-content');
-				$('#modal_ok_button').on('click', function () {
+				var footer = $('<div class="modal-fake-footer"><input type="button" class="btn btn-default btn-sm btn-dummy modal_ok_button" value="' + ClozeSettings.ok_text + '"> <input type="button" class="btn btn-default btn-sm btn-dummy modal_cancel_button" value="' + ClozeSettings.cancel_text + '"></div>');
+				$(footer).find('.modal_ok_button').on('click', function () {
 					pro.closeModalWithOkButton();
 				});
-				$('#modal_cancel_button').on('click', function () {
+				$(footer).find('.modal_cancel_button').on('click', function () {
 					pro.closeModalWithCancelButton();
 				});
+				footer.appendTo('.modal-content');
 			}
 		}
 	};

--- a/Modules/TestQuestionPool/test/Jasmine/cloze_gap_builderTest.js
+++ b/Modules/TestQuestionPool/test/Jasmine/cloze_gap_builderTest.js
@@ -47,7 +47,7 @@ describe("cloze_gap_builder", function() {
 		});
 		it("after the call div should be empty fake footer should be in place", function () {
 			ClozeGapBuilder.protect.addModalFakeFooter();
-			expect($('.modal-content').html()).toEqual('<div class="modal-fake-footer"><input type="button" id="modal_ok_button" class="btn btn-default btn-sm btn-dummy" value="undefined"> <input type="button" id="modal_cancel_button" class="btn btn-default btn-sm btn-dummy" value="undefined"></div>');
+			expect($('.modal-content').html()).toEqual('<div class="modal-fake-footer"><input type="button" class="btn btn-default btn-sm btn-dummy modal_ok_button" value="undefined"> <input type="button" class="btn btn-default btn-sm btn-dummy modal_cancel_button" value="undefined"></div>');
 		});
 	});
 


### PR DESCRIPTION
I created a patch because the buttons were not functional when a plugin is installed that injects it's own modal. That way we append to a scope and prevent assigning redundant ids on elements.