### PR TITLE
UI Components, Layout: Fix of #31141, Type in Tags not necessary

### DIFF
--- a/src/UI/templates/default/Layout/tpl.standardpage.html
+++ b/src/UI/templates/default/Layout/tpl.standardpage.html
@@ -14,7 +14,7 @@
 
 	<title>{SHORT_TITLE}: {VIEW_TITLE}</title>
 
-	<style type="text/css">
+	<style>
 		{CSS_INLINE}
 	</style>
 
@@ -23,7 +23,7 @@
 	<!-- END css_file -->
 
 	<!-- BEGIN js_file -->
-	<script type="text/javascript" src="{JS_FILE}"></script>
+	<script src="{JS_FILE}"></script>
 	<!-- END js_file -->
 </head>
 
@@ -83,7 +83,7 @@
 
 
 <!-- BEGIN on_load_code -->
-<script type="text/javascript">
+<script>
 	<!-- BEGIN on_load_code_inner -->
 		il.Util.addOnLoad(function() {
 			{OLCODE}

--- a/tests/UI/Component/Layout/Page/StandardPageTest.php
+++ b/tests/UI/Component/Layout/Page/StandardPageTest.php
@@ -196,7 +196,7 @@ class StandardPageTest extends ILIAS_UI_TestBase
       <meta http-equiv="X-UA-Compatible" content="IE=edge" />
       <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
       <title>Short Title: View Title</title>
-      <style type="text/css"></style>
+      <style></style>
    </head>
    <body>
       <div class="il-layout-page">
@@ -212,7 +212,7 @@ class StandardPageTest extends ILIAS_UI_TestBase
             <div>some content</div>
          </main>
       </div>
-      <script type="text/javascript">il.Util.addOnLoad(function() {});</script>
+      <script>il.Util.addOnLoad(function() {});</script>
    </body>
 </html>');
         $this->assertEquals($exptected, $html);
@@ -233,7 +233,7 @@ class StandardPageTest extends ILIAS_UI_TestBase
       <meta http-equiv="X-UA-Compatible" content="IE=edge" />
       <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
       <title>: </title>
-      <style type="text/css"></style>
+      <style></style>
    </head>
    <body>
       <div class="il-layout-page">
@@ -249,7 +249,7 @@ class StandardPageTest extends ILIAS_UI_TestBase
             <div>some content</div>
          </main>
       </div>
-      <script type="text/javascript">il.Util.addOnLoad(function() {});</script>
+      <script>il.Util.addOnLoad(function() {});</script>
    </body>
 </html>');
         $this->assertEquals($exptected, $html);


### PR DESCRIPTION
Type not necessary for JS and CSS resources. They generate noise in automated reports, since numerous info/warning are thrown to the user due to that. See: https://mantis.ilias.de/view.php?id=31141

IMO, this is a (small) issue, see mantis, therefore I would up to merge that to 7 and trunk.