### PR TITLE
Global Template, double head Action

### DIFF
--- a/Modules/DataCollection/classes/class.ilDataCollectionGlobalTemplate.php
+++ b/Modules/DataCollection/classes/class.ilDataCollectionGlobalTemplate.php
@@ -885,7 +885,6 @@ class ilDataCollectionGlobalTemplate implements ilGlobalTemplateInterface
             $this->setCurrentBlock("head_action_inner");
             $this->setVariable("HEAD_ACTION", $header);
             $this->parseCurrentBlock();
-            $this->touchBlock("head_action");
         }
 
         if (count((array) $this->title_alerts)) {

--- a/Services/COPage/classes/class.ilCOPageGlobalTemplate.php
+++ b/Services/COPage/classes/class.ilCOPageGlobalTemplate.php
@@ -841,7 +841,6 @@ class ilCOPageGlobalTemplate implements ilGlobalTemplateInterface
             $this->setCurrentBlock("head_action_inner");
             $this->setVariable("HEAD_ACTION", $header);
             $this->parseCurrentBlock();
-            $this->touchBlock("head_action");
         }
 
         if (count((array) $this->title_alerts)) {

--- a/Services/RTE/classes/class.ilRTEGlobalTemplate.php
+++ b/Services/RTE/classes/class.ilRTEGlobalTemplate.php
@@ -854,7 +854,6 @@ class ilRTEGlobalTemplate implements ilGlobalTemplateInterface
             $this->setCurrentBlock("head_action_inner");
             $this->setVariable("HEAD_ACTION", $header);
             $this->parseCurrentBlock();
-            $this->touchBlock("head_action");
         }
 
         if (count((array) $this->title_alerts)) {

--- a/Services/UICore/classes/MetaTemplate/PageContentGUI.php
+++ b/Services/UICore/classes/MetaTemplate/PageContentGUI.php
@@ -623,7 +623,6 @@ class PageContentGUI
             $this->template_file->setCurrentBlock("head_action_inner");
             $this->template_file->setVariable("HEAD_ACTION", $header);
             $this->template_file->parseCurrentBlock();
-            $this->template_file->touchBlock("head_action");
         }
 
         if (count((array) $this->title_alerts)) {

--- a/Services/UICore/classes/class.ilGlobalTemplate.php
+++ b/Services/UICore/classes/class.ilGlobalTemplate.php
@@ -954,7 +954,6 @@ class ilGlobalTemplate implements ilGlobalTemplateInterface
             $this->setCurrentBlock("head_action_inner");
             $this->setVariable("HEAD_ACTION", $header);
             $this->parseCurrentBlock();
-            $this->touchBlock("head_action");
         }
 
         if (count((array) $this->title_alerts)) {


### PR DESCRIPTION
While working on a11y issues with automated HTML Validators (W3c Online in Google Chrome in this case) I observed, that one ID is given twice: il_head_action, which causes the tool to display an error on almost any page. This is caused due to rendering the respective section in the template twice. I am not sure why this is done, however, IMO we can just remove the touch block. 

**Important**: I am not sure if this is the way to go. It is somewhat hard for me to completely understand the rendering logic in tpl.amd_content.html. E.g. I guess it could be possible, that this touch block statement is needed in some (edge) cases. So please check this rather throughly. 

If possible I would like to merge this down to 7 as well, if fine, give me a short +1. 

See: https://mantis.ilias.de/view.php?id=31156