### PR TITLE
Added additional check if style doesn't exist for the user which will then revert to the default style.

### DIFF
--- a/Services/User/classes/class.ilObjUser.php
+++ b/Services/User/classes/class.ilObjUser.php
@@ -283,7 +283,8 @@ class ilObjUser extends ilObject
 
             //check style-setting (skins could have more than one stylesheet
             if ($this->prefs["style"] == "" ||
-                    (!ilStyleDefinition::skinExists($this->skin) && ilStyleDefinition::styleExistsForSkinId($this->skin, $this->prefs["style"]))) {
+                    (!ilStyleDefinition::skinExists($this->skin) && ilStyleDefinition::styleExistsForSkinId($this->skin, $this->prefs["style"])) ||
+                    !ilStyleDefinition::styleExists($this->prefs["style"])) {
                 //load default (css)
                 $this->prefs["style"] = $this->ilias->ini->readVariable("layout", "style");
             }


### PR DESCRIPTION
This fixes the bug https://mantis.ilias.de/view.php?id=31078 where we discovered an error if the style and skin is deleted for user and the default is not 'delos'