### PR TITLE
0031173: Too many open files: close existing curl handles

### DIFF
--- a/Services/WebServices/Curl/classes/class.ilCurlConnection.php
+++ b/Services/WebServices/Curl/classes/class.ilCurlConnection.php
@@ -104,6 +104,8 @@ class ilCurlConnection
      */
     final public function init()
     {
+        // teminate existing handles
+        $this->close();
         if (strlen($this->url)) {
             $this->ch = curl_init($this->url);
         #$GLOBALS['DIC']['ilLog']->write(__METHOD__ . ': ' . $this->url);

--- a/Services/WebServices/ECS/classes/class.ilECSConnector.php
+++ b/Services/WebServices/ECS/classes/class.ilECSConnector.php
@@ -290,6 +290,8 @@ class ilECSConnector
             return $result;
         } catch (ilCurlConnectionException $exc) {
             throw new ilECSConnectorException('Error calling ECS service: ' . $exc->getMessage());
+        } finally {
+            $this->curl->close();
         }
     }
     


### PR DESCRIPTION
This fixes an issue when trying to read the ecs event queue. 
See mantis #000031173 for further information