### PR TITLE
[FIX] 0031174: Lucene Suche indiziert keine PDF Dateien

### DIFF
--- a/Modules/File/LuceneObjectDefinition.xml
+++ b/Modules/File/LuceneObjectDefinition.xml
@@ -28,10 +28,31 @@
 		</DataSource>
 		<DataSource type="JDBC" action="append">
 			<Query>
-				SELECT MAX(version) version, file_name, rid
+				SELECT
+				MAX(version) AS version
+				, file_name
+				, rid
+				, il_resource.storage_id
+				, IF(
+				STRCMP(il_resource.storage_id, 'fsv2') = 0,
+				CONCAT(
+				'fsv2/'
+				, SUBSTRING(REPLACE(rid, '-', ''), 1, 3)
+				, '/'
+				, SUBSTRING(REPLACE(rid, '-', ''), 4, 3)
+				, '/'
+				, SUBSTRING(REPLACE(rid, '-', ''), 7, 3)
+				, '/'
+				, SUBSTRING(REPLACE(rid, '-', ''), 10)
+				),
+				REPLACE(rid, '-', '/')
+				) AS resource_path
+
 				FROM file_data
-				WHERE file_id IN (?)
-				AND rid IS NOT NULL
+				JOIN il_resource ON il_resource.identification = file_data.rid
+				WHERE
+				file_id IN (?) AND
+				rid IS NOT NULL
 				GROUP BY file_id,file_name
 			</Query>
 			<Param format="list" type="int" value="objId" />

--- a/Services/WebServices/RPC/lib/src/de/ilias/services/lucene/index/file/path/FileObjectPathCreator7.java
+++ b/Services/WebServices/RPC/lib/src/de/ilias/services/lucene/index/file/path/FileObjectPathCreator7.java
@@ -83,8 +83,7 @@ public class FileObjectPathCreator7  implements PathCreator
 			fullPath.append(System.getProperty("file.separator"));
 			fullPath.append(getBasePath());
 			fullPath.append(System.getProperty("file.separator"));
-			fullPath.append(rid.replaceAll("-", System.getProperty("file.separator")));
-			
+			fullPath.append(res.getString("resource_path"));
 			versionPath.append(fullPath);
 			versionPath.append(System.getProperty("file.separator"));
 			versionPath.append(String.valueOf(versionCode));


### PR DESCRIPTION
Hi @smeyer-ilias 
as mentioned in https://mantis.ilias.de/view.php?id=31174 I tried to fix the issue that files in storage v2 are not indexed (only files in fsv1). I implemented the creation of the path to the file in the query, don't know if this is a good idea (performance?). otherwise this would need another `FileObjectPathCreator`. Could you have a look at this and merge at will? Thanks a lot!