### PR TITLE
$this->ilClientIniFile need a fallback

### DIFF
--- a/Services/Logging/classes/error/class.ilLoggingErrorSettings.php
+++ b/Services/Logging/classes/error/class.ilLoggingErrorSettings.php
@@ -38,9 +38,7 @@ class ilLoggingErrorSettings
             $this->ilias_ini = $ilIliasIniFile;
         }
 
-        if ($ilClientIniFile !== null) {
-            $this->gClientIniFile = $ilClientIniFile;
-        }
+        $this->gClientIniFile = ($ilClientIniFile !== null) ? $ilClientIniFile : null;
 
         $this->folder = null;
         $this->mail = null;


### PR DESCRIPTION
if $ilClientIniFile !== null then $this->ilClientIniFile will be undefined, throwing errors later (in functions ``read`` and ``update``)

I don't really know if this is the best solution, another one can be to throw a specific exception.