### PR TITLE
Fix existing UI Filters after Filter Revision

### DIFF
--- a/Services/Container/Filter/classes/class.ilContainerFilterService.php
+++ b/Services/Container/Filter/classes/class.ilContainerFilterService.php
@@ -120,7 +120,7 @@ class ilContainerFilterService
     /**
      * User filter
      *
-     * @param array $data
+     * @param array|null $data
      * @return ilContainerUserFilter
      */
     public function userFilter($data)

--- a/Services/Container/Filter/classes/class.ilContainerUserFilter.php
+++ b/Services/Container/Filter/classes/class.ilContainerUserFilter.php
@@ -14,7 +14,7 @@
 class ilContainerUserFilter
 {
     /**
-     * @var array
+     * @var array|null
      */
     protected $data;
 
@@ -29,7 +29,7 @@ class ilContainerUserFilter
     /**
      * Get data
      *
-     * @return array
+     * @return array|null
      */
     public function getData()
     {

--- a/Services/Container/classes/class.ilContainerGUI.php
+++ b/Services/Container/classes/class.ilContainerGUI.php
@@ -3426,17 +3426,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             (bool) $this->isActiveAdministrationPanel()
         );
 
-        $filter_data = [];
-
-        // @todo: this is something we need to do better
-        if ($request->getMethod() == "POST" && $_GET["cmd"] == "render") {
-            $filter_data = $DIC->uiService()->filter()->getData($filter);
-        } else {
-            /** @var \ILIAS\UI\Implementation\Component\Input\Field\Input $i */
-            foreach ($filter->getInputs() as $k => $i) {
-                $filter_data[$k] = $i->getValue();
-            }
-        }
+        $filter_data = $DIC->uiService()->filter()->getData($filter);
 
         $this->container_user_filter = $filter_service->userFilter($filter_data);
         $this->ui_filter = $filter;

--- a/Services/Cron/classes/class.ilCronManagerGUI.php
+++ b/Services/Cron/classes/class.ilCronManagerGUI.php
@@ -112,8 +112,7 @@ class ilCronManagerGUI
             $this->uiRenderer->render([$message, $filter]),
             $tbl->populate(
                 $tableFilterMediator->filteredJobs(
-                    $filter,
-                    false
+                    $filter
                 )
             )->getHTML()
         ]));

--- a/Services/Cron/classes/class.ilCronManagerTableFilterMediator.php
+++ b/Services/Cron/classes/class.ilCronManagerTableFilterMediator.php
@@ -134,20 +134,11 @@ class ilCronManagerTableFilterMediator
 
     /**
      * @param Standard $filter
-     * @param bool $fromRequest
      * @return ilCronJobCollection
      */
-    public function filteredJobs(Standard $filter, bool $fromRequest = false) : ilCronJobCollection
+    public function filteredJobs(Standard $filter) : ilCronJobCollection
     {
-        $filterValues = [];
-        if ($fromRequest) {
-            $filterValues = $this->uiService->filter()->getData($filter);
-        } else {
-            /** @var \ILIAS\UI\Implementation\Component\Input\Field\Input $i */
-            foreach ($filter->getInputs() as $k => $i) {
-                $filterValues[$k] = $i->getValue();
-            }
-        }
+        $filterValues = $this->uiService->filter()->getData($filter);
 
         return $this->items->filter(function (ilCronJobEntity $entity) use ($filterValues) : bool {
             if (

--- a/Services/UI/classes/class.ilUIFilterService.php
+++ b/Services/UI/classes/class.ilUIFilterService.php
@@ -139,9 +139,8 @@ class ilUIFilterService
      * @param Filter\Standard $filter
      * @return array|null
      */
-    public function getData(Filter\Standard $filter)
+    public function getData(Filter\Standard $filter) : ?array
     {
-        $result = null;
         $filter_data = null;
         if ($filter->isActivated()) {
             foreach ($filter->getInputs() as $k => $i) {


### PR DESCRIPTION
Hello @alex40724 and @mjansenDatabay,
in this PR I fixed some usages of the UI Filter in `Services/Container` and `Services/Cron`, so that the Filter can work properly at these places after the revision was done in #3390.
Please note that I have done the same changes also for the down merge to release 7 which can be found in #3556.