### PR TITLE
Null array offset fixed

### DIFF
--- a/Services/WebServices/classes/Setup/class.ilWebServicesSetupAgent.php
+++ b/Services/WebServices/classes/Setup/class.ilWebServicesSetupAgent.php
@@ -43,11 +43,11 @@ class ilWebServicesSetupAgent implements Setup\Agent
     {
         return $this->refinery->custom()->transformation(function ($data) {
             return new \ilWebServicesSetupConfig(
-                (bool) $data["soap_user_administration"] ?? false,
+                (bool) ($data["soap_user_administration"] ?? false),
                 $data["soap_wsdl_path"] ?? "",
-                (int) $data["soap_connect_timeout"] ?? ilSoapClient::DEFAULT_CONNECT_TIMEOUT,
+                (int) ($data["soap_connect_timeout"] ?? ilSoapClient::DEFAULT_CONNECT_TIMEOUT),
                 $data["rpc_server_host"] ?? "",
-                (int) $data["rpc_server_port"]
+                (int) ($data["rpc_server_port"] ?? 0)
             );
         });
     }


### PR DESCRIPTION
When ``soap_user_administration`` and/or ``soap_connect_timeout`` and/or ``rpc_server_port`` are not set in the config setup file, PHP prints a warning:

```php
PHP Notice:  Trying to access array offset on value of type null in /var/www/html/ilias/Services/WebServices/classes/Setup/class.ilWebServicesSetupAgent.php on line 46
PHP Notice:  Trying to access array offset on value of type null in /var/www/html/ilias/Services/WebServices/classes/Setup/class.ilWebServicesSetupAgent.php on line 48
PHP Notice:  Trying to access array offset on value of type null in /var/www/html/ilias/Services/WebServices/classes/Setup/class.ilWebServicesSetupAgent.php on line 50
```

The problem is that casting has the precedence, not the ``??`` operator. Solved by adding parentheses.