### PR TITLE
Draft bugfix for mantis 31277 file inline download

### DIFF
--- a/Modules/File/classes/Implementation/class.ilObjFileImplementationStorage.php
+++ b/Modules/File/classes/Implementation/class.ilObjFileImplementationStorage.php
@@ -101,17 +101,33 @@ class ilObjFileImplementationStorage extends ilObjFileImplementationAbstract imp
 
         $storage = $DIC->resourceStorage();
 
-//        if ($this->isInline()) { // FSX
-//            $consumer = $storage->consume()->inline($this->resource->getIdentification());
-//        } else {
-        $consumer = $storage->consume()->download($this->resource->getIdentification());
-//        }
+        if ($this->isInline($a_hist_entry_id)) { // FSX
+            $consumer = $storage->consume()->inline($this->resource->getIdentification());
+        } else {
+            $consumer = $storage->consume()->download($this->resource->getIdentification());
+        }
 
         if ($a_hist_entry_id) {
             $consumer->setRevisionNumber($a_hist_entry_id);
         }
         $consumer->run();
 
+    }
+
+    /**
+     * @param null $a_hist_entry_id
+     * @return bool
+     */
+    public function isInline($a_hist_entry_id = null)
+    {
+        try {
+            $revision = $a_hist_entry_id ?
+                $this->resource->getSpecificRevision($a_hist_entry_id) :
+                $this->resource->getCurrentRevision();
+            return \ilObjFileAccess::_isFileInline($revision->getTitle());
+        } catch (Exception $e) {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
This is a short draft on how mantis issue [31277 ](https://mantis.ilias.de/view.php?id=31277) could be fixed.

I assume there is a way better / cleaner solution since the `isInline`-Method is marked as deprecated in `ilObjFileImplementationLegacy`. It was just the nearest solution before the condition if consume should use `->download()` or `->inline()`.

