### PR TITLE
Fix the default showing of all columns in a table

### DIFF
--- a/Services/Table/classes/class.ilTable2GUI.php
+++ b/Services/Table/classes/class.ilTable2GUI.php
@@ -292,7 +292,7 @@ class ilTable2GUI extends ilTableGUI
                 if ($new_column) {
                     $set = true;
                 }
-                if (isset($c["default"])) {
+                if (isset($c["default"]) && $c["default"]) {
                     $this->selected_column[$k] = true;
                 }
             }


### PR DESCRIPTION
In the member view table in courses and groups, columns such as institution, department, e-mail address, and other profile information of the respective members can be shown (if enabled by the user). Normally, all additional columns are hidden and have to be selected by the user. But at the moment, all columns are shown at once which makes the table crowded.

This PR trys to fix the behavior of showing all columns at once. Every column has a so called 'default' value set. It seems to me, as if this value is meant to express if a column should be shown per default or not if there is no selection by the user.
One example where such a value is set is in `ilExportFieldsInfo->getSelectableFieldsInfo:158`:
```php
$fields[$field]['txt'] = $lng->txt($caption);
$fields[$field]['default'] = 0;
```

Later in the code, this value is checked at the position where my commit changes the if-statement.