### PR TITLE
UI/Input: 31271, render duration group before generic group

### DIFF
--- a/src/UI/Implementation/Component/Input/Field/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Field/Renderer.php
@@ -58,6 +58,8 @@ class Renderer extends AbstractComponentRenderer
             case ($component instanceof F\Section):
                 return $this->renderSection($component, $default_renderer);
 
+            case ($component instanceof F\Duration):
+                return $this->renderDurationField($component, $default_renderer);
 
             case ($component instanceof F\Group):
             case ($component instanceof F\Link):
@@ -92,9 +94,6 @@ class Renderer extends AbstractComponentRenderer
 
             case ($component instanceof F\DateTime):
                 return $this->renderDateTimeField($component, $default_renderer);
-
-            case ($component instanceof F\Duration):
-                return $this->renderDurationField($component, $default_renderer);
 
             case ($component instanceof F\File):
                 return $this->renderFileField($component, $default_renderer);


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=31271

group derivates must accounted for before rendering generic group.