### PR TITLE
Added missing property in ObjectDataCache

### DIFF
--- a/Services/Object/classes/class.ilObjectDataCache.php
+++ b/Services/Object/classes/class.ilObjectDataCache.php
@@ -12,6 +12,9 @@
 */
 class ilObjectDataCache
 {
+    /** @var array<int, bool> */
+    protected $trans_loaded = [];
+    
     public $db = null;
     public $reference_cache = array();
     public $object_data_cache = array();


### PR DESCRIPTION
Removes a undefined property notice.

The lines are just copied from the trunk: (i removed the type for extra compatiblity ;) )
https://github.com/ILIAS-eLearning/ILIAS/commit/4e72c3d6aee5c0b99be3953a46ee753adae1924a

