### PR TITLE
orgUnit Fix mantis bug 31304: Filter a Staff's enrollments

### DIFF
--- a/Services/MyStaff/classes/ShowUser/Courses/class.ilMStShowUserCourses.php
+++ b/Services/MyStaff/classes/ShowUser/Courses/class.ilMStShowUserCourses.php
@@ -10,4 +10,25 @@ use ILIAS\MyStaff\ListCourses\ilMStListCourses;
  */
 class ilMStShowUserCourses extends ilMStListCourses
 {
+    /**
+     * @param array  $arr_filter
+     * @return string
+     */
+    protected  function createWhereStatement(array $arr_filter)
+    {
+        global $DIC;
+
+        if (!$arr_filter['usr_id']) {
+            return '';
+        }
+
+        $where = parent::createWhereStatement($arr_filter);
+        $usr_filter = "a_table.usr_id = " . $DIC->database()->quote($arr_filter['usr_id'], 'integer');
+
+        if (empty($where)) {
+            return ' WHERE ' . $usr_filter;
+        } else {
+            return $where . ' AND ' . $usr_filter;
+        }
+    }
 }


### PR DESCRIPTION
In ILIAS 6 and 7 there seems to be a regression: When an employer needs to see a single staff's enrollments, enrollments of all staffs will be displayed!