### PR TITLE
GlobalCache/Setup: Expose status of global cache service

### DIFF
--- a/Services/GlobalCache/classes/Setup/class.ilGlobalCacheMetricsCollectedObjective.php
+++ b/Services/GlobalCache/classes/Setup/class.ilGlobalCacheMetricsCollectedObjective.php
@@ -40,6 +40,10 @@ class ilGlobalCacheMetricsCollectedObjective extends Setup\Metrics\CollectedObje
             $service,
             "The backend that is used for the ILIAS cache."
         );
+        $storage->storeConfigText(
+            "active",
+            $settings->isActive() ? 'yes' : 'no',
+        );
 
         $servers = ilMemcacheServer::get();
         if (


### PR DESCRIPTION
Currently the `status` does not provide any explicit information whether the global cache service is active.

This PR adds an explicit `active` property to the status of the `ilGlobalCacheMetricsCollectedObjective`.