### PR TITLE
UI: Mainbar, check for state before gs-reloading contents; fixes 30610

### DIFF
--- a/src/UI/templates/js/MainControls/dist/mainbar.js
+++ b/src/UI/templates/js/MainControls/dist/mainbar.js
@@ -691,10 +691,16 @@ var renderer = function($) {
             return $('#' + this.html_id);
         },
         engage: function() {
-            this.getElement().addClass(css.engaged);
-            this.getElement().removeClass(css.disengaged);
-            this.getElement().trigger('in_view'); //this is most important for async loading of slates,
-                                                  //it triggers the GlobalScreen-Service.
+            var element = this.getElement(),
+                loaded = element.hasClass(css.engaged);
+
+            element.addClass(css.engaged);
+            element.removeClass(css.disengaged);
+
+            if(! loaded) {
+                element.trigger('in_view'); //this is most important for async loading of slates,
+                                            //it triggers the GlobalScreen-Service.
+            }
             if(il.UI.page.isSmallScreen() && il.UI.maincontrols.metabar) {
                 il.UI.maincontrols.metabar.disengageAll();
             }

--- a/src/UI/templates/js/MainControls/src/mainbar.renderer.js
+++ b/src/UI/templates/js/MainControls/src/mainbar.renderer.js
@@ -23,10 +23,16 @@ var renderer = function($) {
             return $('#' + this.html_id);
         },
         engage: function() {
-            this.getElement().addClass(css.engaged);
-            this.getElement().removeClass(css.disengaged);
-            this.getElement().trigger('in_view'); //this is most important for async loading of slates,
-                                                  //it triggers the GlobalScreen-Service.
+            var element = this.getElement(),
+                loaded = element.hasClass(css.engaged);
+
+            element.addClass(css.engaged);
+            element.removeClass(css.disengaged);
+
+            if(! loaded) {
+                element.trigger('in_view'); //this is most important for async loading of slates,
+                                            //it triggers the GlobalScreen-Service.
+            }
             if(il.UI.page.isSmallScreen() && il.UI.maincontrols.metabar) {
                 il.UI.maincontrols.metabar.disengageAll();
             }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=30610,
followup to https://github.com/ILIAS-eLearning/ILIAS/pull/3606

This one is also valid for 7, for 6 please see https://github.com/ILIAS-eLearning/ILIAS/pull/3609
