### PR TITLE
PRG: update LP per user (instead per node)

### DIFF
--- a/Modules/StudyProgramme/classes/class.ilObjStudyProgramme.php
+++ b/Modules/StudyProgramme/classes/class.ilObjStudyProgramme.php
@@ -2223,10 +2223,7 @@ class ilObjStudyProgramme extends ilContainer
         if (is_null($node_obj_id)) {
             $node_obj_id = $this->getId();
         }
-        // thanks to some caching within ilLPStatusWrapper
-        // the status may not be read properly otherwise ...
-        ilLPStatusWrapper::_resetInfoCaches($node_obj_id);
-        ilLPStatusWrapper::_refreshStatus($node_obj_id, [$usr_id]);
+        ilLPStatusWrapper::_updateStatus($node_obj_id, $usr_id);
     }
 
     protected function updateParentProgress(ilStudyProgrammeProgress $progress) : ilStudyProgrammeProgress


### PR DESCRIPTION
triggered by https://mantis.ilias.de/view.php?id=31326 (compare to https://mantis.ilias.de/view.php?id=31326),
the ilLPStatusWrapper-call of PRGs should read _updateStatus rather than _refreshStatus.

Also, I did not see any negative side-effect in leaving the cache untouched, so I removed the according line.