### PR TITLE
Correct error in presentation of sc questions in survey

### DIFF
--- a/Modules/Survey/Execution/class.ilSurveyExecutionGUI.php
+++ b/Modules/Survey/Execution/class.ilSurveyExecutionGUI.php
@@ -507,7 +507,7 @@ class ilSurveyExecutionGUI
             foreach ($page as $k => $data) {
                 $page[$k]["compressed"] = false;
                 $page[$k]["compressed_first"] = false;
-                if ($this->compressQuestion($previous_page, $data)) {
+                if ($compress_view && $this->compressQuestion($previous_page, $data)) {
                     $page[$k]["compressed"] = true;
                     if ($previous_key !== null && $page[$previous_key]["compressed"] == false) {
                         $page[$previous_key]["compressed_first"] = true;


### PR DESCRIPTION
Fix for https://mantis.ilias.de/view.php?id=31350

This avoids that the readio-buttons of a second sc question are hidden when not in compact view.