### PR TITLE
fix misformatted language files de/en

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -16620,5 +16620,5 @@ prg#:#will_not_modify_validity_on_non_successful_progress#:#Gültigkeit kann nur
 prg#:#status_unchanged#:#Status unverändert
 content#:#cont_media#:#Bilder/Audio/Video
 content#:#cont_sur_block_format#:#Umgebender Block
-ui#:#datetime_required#:Zeit/Datum erforderlich
+ui#:#datetime_required#:#Zeit/Datum erforderlich
 ui#:#duration_end_must_not_be_earlier_than_start#:#Der Beginn muss zeitlich vor dem Ende liegen.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -16608,5 +16608,5 @@ prg#:#will_not_modify_validity_on_non_successful_progress#:#Can change only when
 prg#:#status_unchanged#:#Status unchanged
 content#:#cont_media#:#Images/Media
 content#:#cont_sur_block_format#:#Surrounding Section
-ui#:#datetime_required#:Time/Date required
+ui#:#datetime_required#:#Time/Date required
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.


### PR DESCRIPTION
Saw this when I updated a installation to latest 7 release. Prevents Ilias from updating the languages from the files.