### PR TITLE
DB: adjusted new db steps classes to fit intended interface

### DIFF
--- a/Modules/StudyProgramme/classes/Setup/ilStudyProgrammeProgressTableUpdateSteps.php
+++ b/Modules/StudyProgramme/classes/Setup/ilStudyProgrammeProgressTableUpdateSteps.php
@@ -11,12 +11,12 @@ class ilStudyProgrammeProgressTableUpdateSteps implements ilDatabaseUpdateSteps
         $this->db = $db;
     }
     
-    public function step_1(\ilDBInterface $db)
+    public function step_1()
     {
         $column_name = 'individual';
 
-        if (!$db->tableColumnExists(self::TABLE_NAME, $column_name)) {
-            $db->addTableColumn(
+        if (!$this->db->tableColumnExists(self::TABLE_NAME, $column_name)) {
+            $this->db->addTableColumn(
                 self::TABLE_NAME,
                 $column_name,
                 [
@@ -29,26 +29,26 @@ class ilStudyProgrammeProgressTableUpdateSteps implements ilDatabaseUpdateSteps
             $query = 'UPDATE ' . self::TABLE_NAME
                 . ' SET ' . $column_name . ' = 1'
                 . ' WHERE last_change_by IS NOT NULL';
-            $db->manipulate($query);
+            $this->db->manipulate($query);
         }
     }
     
-    public function step_2(\ilDBInterface $db)
+    public function step_2()
     {
         $old = "risky_to_fail_mail_send";
         $new = "sent_mail_risky_to_fail";
         $table = "prg_usr_progress";
-        if ($db->tableColumnExists(self::TABLE_NAME, $old) && !$db->tableColumnExists(self::TABLE_NAME, $new)) {
-            $db->renameTableColumn(self::TABLE_NAME, $old, $new);
+        if ($this->db->tableColumnExists(self::TABLE_NAME, $old) && !$this->db->tableColumnExists(self::TABLE_NAME, $new)) {
+            $this->db->renameTableColumn(self::TABLE_NAME, $old, $new);
         }
     }
     
-    public function step_3(\ilDBInterface $db)
+    public function step_3()
     {
         $column_name = 'sent_mail_expires';
 
-        if (!$db->tableColumnExists(self::TABLE_NAME, $column_name)) {
-            $db->addTableColumn(
+        if (!$this->db->tableColumnExists(self::TABLE_NAME, $column_name)) {
+            $this->db->addTableColumn(
                 self::TABLE_NAME,
                 $column_name,
                 [

--- a/Modules/TestQuestionPool/Setup/class.ilTestQuestionPool80DBUpdateSteps.php
+++ b/Modules/TestQuestionPool/Setup/class.ilTestQuestionPool80DBUpdateSteps.php
@@ -9,9 +9,9 @@ class ilTestQuestionPool80DBUpdateSteps implements ilDatabaseUpdateSteps
         $this->db = $db;
     }
 
-    public function step_1(ilDBInterface $db) : void
+    public function step_1() : void
     {
-        $db->manipulateF("DELETE FROM qpl_qst_type WHERE type_tag = %s", ['text'], ['assJavaApplet']);
-        $db->manipulateF("DELETE FROM qpl_qst_type WHERE type_tag = %s", ['text'], ['assFlashQuestion']);
+        $this->db->manipulateF("DELETE FROM qpl_qst_type WHERE type_tag = %s", ['text'], ['assJavaApplet']);
+        $this->db->manipulateF("DELETE FROM qpl_qst_type WHERE type_tag = %s", ['text'], ['assFlashQuestion']);
     }
 }

--- a/Services/COPage/classes/Setup/class.ilCOPageDBUpdateSteps.php
+++ b/Services/COPage/classes/Setup/class.ilCOPageDBUpdateSteps.php
@@ -28,7 +28,7 @@ class ilCOPageDBUpdateSteps implements \ilDatabaseUpdateSteps
         $this->db = $db;
     }
 
-    public function step_1(\ilDBInterface $db)
+    public function step_1()
     {
         $field = array(
             'type' => 'integer',
@@ -37,6 +37,6 @@ class ilCOPageDBUpdateSteps implements \ilDatabaseUpdateSteps
             'default' => 0
         );
 
-        $db->modifyTableColumn("copg_pc_def", "order_nr", $field);
+        $this->db->modifyTableColumn("copg_pc_def", "order_nr", $field);
     }
 }

--- a/Services/Database/classes/Setup/class.ilDatabaseUpdateStepsExecutedObjective.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseUpdateStepsExecutedObjective.php
@@ -90,7 +90,7 @@ class ilDatabaseUpdateStepsExecutedObjective implements Objective
             }
             $execution_log->started($this->steps_class, $step);
             $method = self::STEP_METHOD_PREFIX . $step;
-            $this->steps->$method($db);
+            $this->steps->$method();
             $execution_log->finished($this->steps_class, $step);
         }
 

--- a/Services/Database/classes/Setup/ilDatabaseSetupStepsUpdateSteps.php
+++ b/Services/Database/classes/Setup/ilDatabaseSetupStepsUpdateSteps.php
@@ -13,12 +13,12 @@ class ilDatabaseSetupStepsUpdateSteps implements ilDatabaseUpdateSteps
         $this->db = $db;
     }
     
-    public function step_1(\ilDBInterface $db)
+    public function step_1()
     {
-        if ($db->tableExists(self::TABLE_NAME)
-        && $db->tableColumnExists(self::TABLE_NAME, self::FIELD_STARTED)
+        if ($this->db->tableExists(self::TABLE_NAME)
+        && $this->db->tableColumnExists(self::TABLE_NAME, self::FIELD_STARTED)
         ) {
-            $db->modifyTableColumn(self::TABLE_NAME, self::FIELD_STARTED, [
+            $this->db->modifyTableColumn(self::TABLE_NAME, self::FIELD_STARTED, [
                 'length' => 26,
                 'type' => ilDBConstants::T_TEXT,
                 'notnull' => false
@@ -26,12 +26,12 @@ class ilDatabaseSetupStepsUpdateSteps implements ilDatabaseUpdateSteps
         }
     }
     
-    public function step_2(\ilDBInterface $db)
+    public function step_2()
     {
-        if ($db->tableExists(self::TABLE_NAME)
-        && $db->tableColumnExists(self::TABLE_NAME, self::FIELD_FINISHED)
+        if ($this->db->tableExists(self::TABLE_NAME)
+        && $this->db->tableColumnExists(self::TABLE_NAME, self::FIELD_FINISHED)
         ) {
-            $db->modifyTableColumn(self::TABLE_NAME, self::FIELD_FINISHED, [
+            $this->db->modifyTableColumn(self::TABLE_NAME, self::FIELD_FINISHED, [
                 'length' => 26,
                 'type' => ilDBConstants::T_TEXT,
                 'notnull' => false

--- a/Services/Database/test/Setup/ilDatabaseUpdateStepsExecutedObjectiveTest.php
+++ b/Services/Database/test/Setup/ilDatabaseUpdateStepsExecutedObjectiveTest.php
@@ -21,7 +21,7 @@ class Test_ilDatabaseUpdateSteps implements ilDatabaseUpdateSteps
     }
 
 
-    public function step_1(\ilDBInterface $db)
+    public function step_1()
     {
         $this->called[] = 1;
         // Call some function on the interface to check if this step
@@ -30,7 +30,7 @@ class Test_ilDatabaseUpdateSteps implements ilDatabaseUpdateSteps
     }
 
     // 4 comes before 2 to check if the class gets the sorting right
-    public function step_4(\ilDBInterface $db)
+    public function step_4()
     {
         $this->called[] = 4;
         // Call some function on the interface to check if this step
@@ -38,7 +38,7 @@ class Test_ilDatabaseUpdateSteps implements ilDatabaseUpdateSteps
         $this->db->connect();
     }
 
-    public function step_2(\ilDBInterface $db)
+    public function step_2()
     {
         $this->called[] = 2;
         // Call some function on the interface to check if this step


### PR DESCRIPTION
Hi @chfsx,

I just noticed that my original PR for the DB steps did not implement the intended `prepare`-interface fully. Also, the documentation was not fully adjusted. I already fixed the documentation, this PR fixes the actual behaviour, including the small amount of current usages of the new steps logic.

Best regards!