### PR TITLE
LSO: constant LP polling, bypass player GUIs

### DIFF
--- a/Modules/LearningSequence/classes/Player/class.ilLegacyKioskModeView.php
+++ b/Modules/LearningSequence/classes/Player/class.ilLegacyKioskModeView.php
@@ -73,8 +73,8 @@ class ilLegacyKioskModeView implements ILIAS\KioskMode\View
             false
         );
 
+        $obj_id = $this->object->getId();
         if (in_array($type, self::GET_VIEW_CMD_FROM_LIST_GUI_FOR)) {
-            $obj_id = $this->object->getId();
             $item_list_gui = \ilObjectListGUIFactory::_getListGUIByType($type);
             $item_list_gui->initItem($ref_id, $obj_id, $type);
             $view_link = $item_list_gui->getCommandLink('view');
@@ -83,7 +83,7 @@ class ilLegacyKioskModeView implements ILIAS\KioskMode\View
             $url = $view_link;
         }
 
-        $builder->start($label, $url, 0);
+        $builder->start($label, $url, (int) $obj_id);
 
         return $builder;
     }

--- a/Modules/LearningSequence/classes/Player/class.ilObjLearningSequenceLPPollingGUI.php
+++ b/Modules/LearningSequence/classes/Player/class.ilObjLearningSequenceLPPollingGUI.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+class ilObjLearningSequenceLPPollingGUI
+{
+    const PARAM_LSO_LP_OBJID = LSUrlBuilder::PARAM_LSO_PARAMETER;
+
+    protected ilCtrl $ctrl;
+    protected int $current_user_id;
+    protected ilObjectDataCache $obj_data_cache;
+
+    public function __construct(
+        ilCtrl $ctrl,
+        int $current_user_id,
+        ilObjectDataCache $obj_data_cache
+    ) {
+        $this->ctrl = $ctrl;
+        $this->current_user_id = $current_user_id;
+        $this->obj_data_cache = $obj_data_cache;
+    }
+
+    public function executeCommand()
+    {
+        $cmd = $this->ctrl->getCmd();
+        switch ($cmd) {
+            case LSControlBuilder::CMD_CHECK_CURRENT_ITEM_LP:
+                $this->getCurrentItemLearningProgress();
+                // no break
+            default:
+                throw new ilException("Command not supported: $cmd");
+        }
+    }
+    
+    protected function getCurrentItemLearningProgress()
+    {
+        $obj_id = (int) $_GET[self::PARAM_LSO_LP_OBJID];
+        $il_lp_status = ilLPStatus::LP_STATUS_NOT_ATTEMPTED_NUM;
+        if (ilObjectLP::isSupportedObjectType($this->obj_data_cache->lookupType($obj_id))) {
+            $il_lp_status = ilLPStatus::_lookupStatus($obj_id, $this->current_user_id, true);
+        }
+        print $il_lp_status;
+        exit;
+    }
+}

--- a/Modules/LearningSequence/classes/Player/class.ilObjLearningSequenceLearnerGUI.php
+++ b/Modules/LearningSequence/classes/Player/class.ilObjLearningSequenceLearnerGUI.php
@@ -86,10 +86,6 @@ class ilObjLearningSequenceLearnerGUI
                 $this->play();
                 break;
 
-            case LSControlBuilder::CMD_CHECK_CURRENT_ITEM_LP:
-                $this->getCurrentItemLearningProgress();
-
-                // no break
             default:
                 throw new ilException(
                     "ilObjLearningSequenceLearnerGUI: " .
@@ -252,11 +248,5 @@ class ilObjLearningSequenceLearnerGUI
         }
         $href = $this->ctrl->getLinkTarget($this, $cmd, '', false, false);
         \ilUtil::redirect($href);
-    }
-
-    protected function getCurrentItemLearningProgress() : void
-    {
-        print $this->player->getCurrentItemLearningProgress();
-        exit;
     }
 }

--- a/Modules/LearningSequence/classes/class.ilLSLocalDI.php
+++ b/Modules/LearningSequence/classes/class.ilLSLocalDI.php
@@ -85,6 +85,26 @@ class ilLSLocalDI extends Container
             );
         };
 
+        $this["player.urlbuilder.lp"] = function ($c) use ($dic, $data_factory) : LSUrlBuilder {
+            $player_base_url = $dic['ilCtrl']->getLinkTargetByClass(
+                'ilObjLearningSequenceLPPollingGUI',
+                \LSControlBuilder::CMD_CHECK_CURRENT_ITEM_LP,
+                '',
+                false,
+                false
+            );
+            $player_base_url = $data_factory->uri(ILIAS_HTTP_PATH . '/' . $player_base_url);
+
+            return new LSUrlBuilder($player_base_url);
+        };
+        $this["gui.learner.lp"] = function ($c) use ($dic) : ilObjLearningSequenceLPPollingGUI {
+            return new ilObjLearningSequenceLPPollingGUI(
+                $dic["ilCtrl"],
+                $c["usr.id"],
+                $dic['ilObjDataCache']
+            );
+        };
+
         $this["gui.toc"] = function ($c) use ($dic) : ilLSTOCGUI {
             return new ilLSTOCGUI(
                 $c["player.urlbuilder"]
@@ -129,8 +149,9 @@ class ilLSLocalDI extends Container
                 $dic["ui.factory"],
                 $c["player.urlbuilder"],
                 $dic["lng"],
-                $c["globalsetttings"]
-             );
+                $c["globalsetttings"],
+                $c["player.urlbuilder.lp"]
+            );
         };
 
         $this["player.kioskrenderer"] = function ($c) use ($dic) : ilKioskPageRenderer {

--- a/Modules/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
+++ b/Modules/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
@@ -20,6 +20,7 @@ use ILIAS\Data;
  * @ilCtrl_Calls ilObjLearningSequenceGUI: ilObjLearningSequenceSettingsGUI
  * @ilCtrl_Calls ilObjLearningSequenceGUI: ilObjLearningSequenceContentGUI
  * @ilCtrl_Calls ilObjLearningSequenceGUI: ilObjLearningSequenceLearnerGUI
+ * @ilCtrl_Calls ilObjLearningSequenceGUI: ilObjLearningSequenceLPPollingGUI
  * @ilCtrl_Calls ilObjLearningSequenceGUI: ilLearningSequenceMembershipGUI
  * @ilCtrl_Calls ilObjLearningSequenceGUI: ilLearningProgressGUI
  *
@@ -279,6 +280,12 @@ class ilObjLearningSequenceGUI extends ilContainerGUI
                 $struct = ['ilrepositorygui','ilobjtestgui'];
                 $this->ctrl->redirectByClass($struct, $cmd);
                 break;
+            case 'ilobjlearningsequencelppollinggui':
+                $gui = $this->object->getLocalDI()["gui.learner.lp"];
+                $this->ctrl->setCmd($cmd);
+                $this->ctrl->forwardCommand($gui);
+                break;
+
 
             case false:
                 if ($cmd === '') {

--- a/Modules/LearningSequence/test/LSControlBuilderTest.php
+++ b/Modules/LearningSequence/test/LSControlBuilderTest.php
@@ -28,8 +28,10 @@ class LSControlBuilderTest extends TestCase
         $uri = $data_factory->uri('https://ilias.de/somepath');
         $url_builder = new LSUrlBuilder($uri);
         $settings = new LSGlobalSettings(12);
+        $uri = $data_factory->uri('http://ilias.de/some/other/path');
+        $lp_url_builder = new LSUrlBuilder($uri);
 
-        $this->control_builder = new LSControlBuilder($ui_factory, $url_builder, $lang, $settings);
+        $this->control_builder = new LSControlBuilder($ui_factory, $url_builder, $lang, $settings, $lp_url_builder);
     }
 
     public function testConstruction()


### PR DESCRIPTION
There are two relevant changes in this PR:
1st: polling learning progress is started instantly when reaching the (legacy-)view of an object, w/o the need to open the object's window by clicking "start". This also fixes interrupted polling for subsequent status changes, as e.g. in starting a survey (->in progress) and finishing it (->completed) - the latter is not found due to an reload caused by the former.

2nd: constructing the player GUI (class.ilObjLearningSequenceLearnerGUI.php) needs quite some information about contained items; this is not necessary for simply polling a LPstatus. The new ilObjLearningSequenceLPPollingGUI bypasses the player GUI. I also do not see a need for security checks, since the LP-check depends on the current user which is not injected via external parameter.