### PR TITLE
Search Form, a11y fix for #31095

### DIFF
--- a/Services/Search/templates/default/tpl.main_menu_search.html
+++ b/Services/Search/templates/default/tpl.main_menu_search.html
@@ -9,6 +9,7 @@
 		<p><a id="search_link" target="_top" href="{HREF_SEARCH_LINK}">» {TXT_SEARCH_LINK}</a></p>
 		<div id="mm_search_menu_options" aria-label="{LABEL_SEARCH_OPTIONS}">
 			<fieldset>
+				<legend class="sr-only">{LABEL_SEARCH_OPTIONS}</legend>
 				<!-- BEGIN position --><input type="radio" name="root_id" value="{ROOT_ID}" checked="checked" id="ilmmsg"/> <label for="ilmmsg"> {TXT_GLOBALLY}</label><br/><!-- END position -->
 				<!-- BEGIN position_rep -->
 				<input type="radio" name="root_id" value="{REF_ID}" id="ilmmsc"/> <label for="ilmmsc"> {TXT_CURRENT_POSITION}</label><br />


### PR DESCRIPTION
In our audits, issue https://mantis.ilias.de/view.php?id=31095 comes up every single time, the fix is rather small. Here a proposal on how to fix. 

If accepted plz also pick to trunk.