### PR TITLE
User/Registration: 30799, delete registration hash on user->update()

### DIFF
--- a/Services/User/classes/class.ilObjUser.php
+++ b/Services/User/classes/class.ilObjUser.php
@@ -614,7 +614,8 @@ class ilObjUser extends ilObject
             "last_password_change" => array("integer", $this->last_password_change_ts),
             "passwd_policy_reset" => array("integer", $this->passwd_policy_reset),
             "last_update" => array("timestamp", ilUtil::now()),
-            'inactivation_date' => array('timestamp', $this->inactivation_date)
+            'inactivation_date' => array('timestamp', $this->inactivation_date),
+            'reg_hash' => null
             );
             
         if (isset($this->agree_date) && (strtotime($this->agree_date) !== false || $this->agree_date == null)) {


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=30799

If a registration hash remains in the table for an inactive user, the user will be deleted during the verification attempt of a user with an outdated link. 
Since any action on a user somehow verifies the account - meaning: "should probably not be deleted" - I reccon it is OK to simply remove the reg-hash on update.
Maybe I'm thinking in too simple a way, so please comment.