### PR TITLE
UI Components, fix for Invalid href in Close Button Glyph, see #31369

### DIFF
--- a/src/UI/Implementation/Component/Symbol/Glyph/ButtonContextRenderer.php
+++ b/src/UI/Implementation/Component/Symbol/Glyph/ButtonContextRenderer.php
@@ -4,10 +4,18 @@
 
 namespace ILIAS\UI\Implementation\Component\Symbol\Glyph;
 
+use ILIAS\UI\Component;
+use ILIAS\UI\Implementation\Render\Template;
+
 class ButtonContextRenderer extends Renderer
 {
     protected function getTemplateFilename()
     {
         return "tpl.glyph.context_btn.html";
+    }
+
+    protected function renderAction(Component\Component $component, Template $tpl)
+    {
+        return $tpl;
     }
 }

--- a/src/UI/Implementation/Component/Symbol/Glyph/Renderer.php
+++ b/src/UI/Implementation/Component/Symbol/Glyph/Renderer.php
@@ -7,6 +7,7 @@ namespace ILIAS\UI\Implementation\Component\Symbol\Glyph;
 use ILIAS\UI\Implementation\Render\AbstractComponentRenderer;
 use ILIAS\UI\Renderer as RendererInterface;
 use ILIAS\UI\Component;
+use ILIAS\UI\Implementation\Render\Template;
 
 class Renderer extends AbstractComponentRenderer
 {
@@ -28,12 +29,7 @@ class Renderer extends AbstractComponentRenderer
         $tpl_file = $this->getTemplateFilename();
         $tpl = $this->getTemplate($tpl_file, true, true);
 
-        $action = $component->getAction();
-        if ($component->isActive() && $action !== null) {
-            $tpl->setCurrentBlock("with_action");
-            $tpl->setVariable("ACTION", $component->getAction());
-            $tpl->parseCurrentBlock();
-        }
+        $tpl = $this->renderAction($component,$tpl);
 
         if ($component->isHighlighted()) {
             $tpl->touchBlock("highlighted");
@@ -61,6 +57,16 @@ class Renderer extends AbstractComponentRenderer
         return $tpl->get();
     }
 
+    protected function renderAction(Component\Component $component, Template $tpl)
+    {
+        $action = $component->getAction();
+        if ($component->isActive() && $action !== null) {
+            $tpl->setCurrentBlock("with_action");
+            $tpl->setVariable("ACTION", $component->getAction());
+            $tpl->parseCurrentBlock();
+        }
+        return $tpl;
+    }
 
     protected function getInnerGlyphHTML(Component\Component $component, RendererInterface $default_renderer)
     {

--- a/src/UI/templates/default/Symbol/tpl.glyph.context_btn.html
+++ b/src/UI/templates/default/Symbol/tpl.glyph.context_btn.html
@@ -1,3 +1,3 @@
-<span class="glyph<!-- BEGIN highlighted --> highlighted<!-- END highlighted --><!-- BEGIN disabled --> disabled<!-- END disabled -->"<!-- BEGIN with_action --> href="{ACTION}"<!-- END with_action --> aria-label="{LABEL}"<!-- BEGIN with_aria_disabled --> aria-disabled="{ARIA_DISABLED}"<!-- END with_aria_disabled --> role="img"<!-- BEGIN with_id --> id="{ID}"<!-- END with_id -->>
+<span class="glyph<!-- BEGIN highlighted --> highlighted<!-- END highlighted --><!-- BEGIN disabled --> disabled<!-- END disabled -->" aria-label="{LABEL}"<!-- BEGIN with_aria_disabled --> aria-disabled="{ARIA_DISABLED}"<!-- END with_aria_disabled --> role="img"<!-- BEGIN with_id --> id="{ID}"<!-- END with_id -->>
 {GLYPH}
 </span>

--- a/tests/UI/Component/MainControls/MainBarTest.php
+++ b/tests/UI/Component/MainControls/MainBarTest.php
@@ -254,7 +254,7 @@ class MainBarTest extends ILIAS_UI_TestBase
 
 					<div class="il-mainbar-close-slates">
 						<button class="btn btn-bulky" id="id_11" >
-						    <span class="glyph" href="#" aria-label="back" role="img"><span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span></span>
+						    <span class="glyph" aria-label="back" role="img"><span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span></span>
 						    <span class="bulky-label">close</span></button>
 					</div>
 				</div>


### PR DESCRIPTION
Glyphs in the Context Bulky Button currently render a href in span, which is not valid. 

See: https://mantis.ilias.de/view.php?id=31369

Note, we already agreed, that it in the longrun, it might be better, that glyphs should not get an action at all. This is a further indication, that this seems correct.