### PR TITLE
WAC: Fix issue with denied requests for resources when requesting log…

### DIFF
--- a/Services/WebAccessChecker/classes/class.ilWebAccessChecker.php
+++ b/Services/WebAccessChecker/classes/class.ilWebAccessChecker.php
@@ -228,9 +228,22 @@ class ilWebAccessChecker
         $pub_section_activated = (bool) $DIC['ilSetting']->get('pub_section');
         $isset = isset($DIC['ilSetting']);
         $instanceof = $DIC['ilSetting'] instanceof ilSetting;
-        if (!$isset || !$instanceof || (!$pub_section_activated && ($is_anonymous || ($is_null_user && $not_on_login_page)))) {
+
+        if (!$isset || !$instanceof) {
             throw new ilWACException(ilWACException::ACCESS_DENIED_NO_PUB);
         }
+
+        if (!$not_on_login_page && ($is_null_user || $is_anonymous)) {
+            // Request is initiated from login page
+            return;
+        }
+
+        if ($not_on_login_page && $pub_section_activated && ($is_null_user || $is_anonymous)) {
+            // Request is initiated from an enabled public area
+            return;
+        }
+
+        throw new ilWACException(ilWACException::ACCESS_DENIED_NO_PUB);
     }
 
 

--- a/Services/WebAccessChecker/classes/class.ilWebAccessChecker.php
+++ b/Services/WebAccessChecker/classes/class.ilWebAccessChecker.php
@@ -222,7 +222,7 @@ class ilWebAccessChecker
     protected function checkPublicSection()
     {
         global $DIC;
-        $not_on_login_page = $this->isRequestNotFromLoginPage();
+        $on_login_page = !$this->isRequestNotFromLoginPage();
         $is_anonymous = ((int) $DIC->user()->getId() === (int) ANONYMOUS_USER_ID);
         $is_null_user = ($DIC->user()->getId() === 0);
         $pub_section_activated = (bool) $DIC['ilSetting']->get('pub_section');
@@ -233,17 +233,19 @@ class ilWebAccessChecker
             throw new ilWACException(ilWACException::ACCESS_DENIED_NO_PUB);
         }
 
-        if (!$not_on_login_page && ($is_null_user || $is_anonymous)) {
+        if ($on_login_page && ($is_null_user || $is_anonymous)) {
             // Request is initiated from login page
             return;
         }
 
-        if ($not_on_login_page && $pub_section_activated && ($is_null_user || $is_anonymous)) {
+        if ($pub_section_activated && ($is_null_user || $is_anonymous)) {
             // Request is initiated from an enabled public area
             return;
         }
 
-        throw new ilWACException(ilWACException::ACCESS_DENIED_NO_PUB);
+        if ($is_anonymous || $is_null_user) {
+            throw new ilWACException(ilWACException::ACCESS_DENIED_NO_PUB);
+        }
     }
 
 


### PR DESCRIPTION
…in page after logout

This PR fixes an issue of denied `WAC` requests for resources used on the login page after a logout process.

Mantis Issue: https://mantis.ilias.de/view.php?id=31392