### PR TITLE
UI Components: Interface for Button/Minimize

### DIFF
--- a/src/UI/Component/Button/Factory.php
+++ b/src/UI/Component/Button/Factory.php
@@ -160,7 +160,7 @@ interface Factory
      * ---
      * @return  \ILIAS\UI\Component\Button\Minimize
      */
-    public function minimize();
+    public function minimize() : Minimize;
 
     /**
      * ---

--- a/src/UI/Component/Button/Factory.php
+++ b/src/UI/Component/Button/Factory.php
@@ -148,6 +148,23 @@ interface Factory
     /**
      * ---
      * description:
+     *   purpose: The minimize button triggers the minimizing of a collection or an overlay.
+     *   composition: The minimize button is displayed as a simple icon without any further decoration.
+     *   effect: Clicking the minimize button minimize the related content into a target location.
+     * rules:
+     *   ordering:
+     *       1: The minimize button MUST always be positioned in the top right of its related content.
+     *       2: The minimize button MUST always be positioned left to a close button of the same related content if given.
+     *   accessibility:
+     *       1: The functionality of the minimize button MUST be indicated for screen readers by an aria-label.
+     * ---
+     * @return  \ILIAS\UI\Component\Button\Minimize
+     */
+    public function minimize();
+
+    /**
+     * ---
+     * description:
      *   purpose: >
      *       Shy buttons are used in contexts that need a less obtrusive presentation
      *       than usual buttons have, e.g. in UI collections like Dropdowns.

--- a/src/UI/Component/Button/Minimize.php
+++ b/src/UI/Component/Button/Minimize.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace ILIAS\UI\Component\Button;
+
+use ILIAS\UI\Component\Component;
+use ILIAS\UI\Component\JavaScriptBindable;
+use ILIAS\UI\Component\Clickable;
+
+interface Minimize extends Component, JavaScriptBindable, Clickable
+{
+}

--- a/src/UI/Implementation/Component/Button/Factory.php
+++ b/src/UI/Implementation/Component/Button/Factory.php
@@ -36,6 +36,14 @@ class Factory implements B\Factory
     /**
      * @inheritdoc
      */
+    public function minimize()
+    {
+        throw new \ILIAS\UI\NotImplementedException();
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function tag($label, $action)
     {
         return new Tag($label, $action);

--- a/src/UI/Implementation/Component/Button/Factory.php
+++ b/src/UI/Implementation/Component/Button/Factory.php
@@ -36,7 +36,7 @@ class Factory implements B\Factory
     /**
      * @inheritdoc
      */
-    public function minimize()
+    public function minimize() : B\Minimize
     {
         throw new \ILIAS\UI\NotImplementedException();
     }

--- a/src/UI/examples/Button/Minimize/base.php
+++ b/src/UI/examples/Button/Minimize/base.php
@@ -1,5 +1,5 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types=1);
+
 namespace ILIAS\UI\examples\Button\Close;
 
 /**

--- a/src/UI/examples/Button/Minimize/base.php
+++ b/src/UI/examples/Button/Minimize/base.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace ILIAS\UI\examples\Button\Close;
+namespace ILIAS\UI\examples\Button\Minimize;
 
 /**
  * Note that this example is rather artificial, since the minimize button is only used in other components

--- a/src/UI/examples/Button/Minimize/base.php
+++ b/src/UI/examples/Button/Minimize/base.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+namespace ILIAS\UI\examples\Button\Close;
+
+/**
+ * Note that this example is rather artificial, since the minimize button is only used in other components
+ * (see purpose). This examples just shows how one could render the button if implementing
+ * such a component. Note that in some cases additional CSS would be needed for placing
+ * the button properly by the surrounding component.
+ */
+function base()
+{
+    global $DIC;;
+
+    return $DIC->ui()->renderer()->render(
+        $DIC->ui()->factory()->button()->minimize()
+    );
+}

--- a/tests/UI/Component/Button/ButtonFactoryTest.php
+++ b/tests/UI/Component/Button/ButtonFactoryTest.php
@@ -6,6 +6,7 @@ class ButtonFactoryTest extends AbstractFactoryTest
 {
     public $kitchensink_info_settings = array( "standard" => array("context" => false)
         , "close" => array("context" => false)
+        , "minimize" => array("context" => false)
         , "shy" => array("context" => false)
         , "tag" => array("context" => false)
         , "bulky" => array("context" => false)


### PR DESCRIPTION
This PR proposes to introduce the UI-Component for implementing Minimize Buttons

The Minimize Button is a visual, interactive area wich is capable of minimizing its related, surrounding content if clicked. 

A minimize Button can appear inside the top right corner of its related content but always left to the close button of the same content if it exists. It contains a square area with a simple graphic of minimisation. Otherwise its completly undercorated.
Further it contains an action wich can be triggered on left clicking the button. This interaction causes the related surrounding content of the minimize button to free its occupying space partialy or complete. Further in can cause logical reactions to this action like moving the minimized content into another area for later reaccess.

![image](https://user-images.githubusercontent.com/45942348/135843985-9325f474-4076-45f8-98c3-39a781843280.png)
