### PR TITLE
Tests/PHPUnit: Use XML config (instead of arguments) / Be more strict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ virtual-data
 override.php
 captainhook.config.json
 captainhook.local.json
+.phpunit.result.cache

--- a/CI/PHPUnit/phpunit.xml
+++ b/CI/PHPUnit/phpunit.xml
@@ -5,6 +5,10 @@
          cacheResultFile="../../.phpunit.result.cache"
          verbose="true"
          colors="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         failOnRisky="true"
+         failOnWarning="true"
         >
     <testsuites>
         <testsuite name="unit">

--- a/CI/PHPUnit/phpunit.xml
+++ b/CI/PHPUnit/phpunit.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="phpunit.xsd"
+         bootstrap="../../libs/composer/vendor/autoload.php"
+         cacheResultFile="../../.phpunit.result.cache"
+         verbose="true"
+         colors="true"
+        >
+    <testsuites>
+        <testsuite name="unit">
+            <file>../../tests/ILIASSuite.php</file>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/CI/PHPUnit/run_tests.sh
+++ b/CI/PHPUnit/run_tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./libs/composer/vendor/phpunit/phpunit/phpunit tests/ILIASSuite.php --bootstrap ./libs/composer/vendor/autoload.php --verbose $@
+./libs/composer/vendor/phpunit/phpunit/phpunit -c ./CI/PHPUnit/phpunit.xml $@


### PR DESCRIPTION
This PR improves the unit test executions by ...

- ... using the XML configuration file instead of the arguments on `PHPunit` command execution
- ... ignoring the `PHPUnit` result cache file, which is useful for local test execution
- ... being more strict for:
  - warnings
  - deprecations
  - undesired output on test execution
  - risky tests  (which lead to https://github.com/ILIAS-eLearning/ILIAS/pull/3653)

Passing the `args` to the `PHPUnit` call is still possible when executing `CI\PHPUnit\runtests.sh`.

Nevertheless, the tests for this PR fail because of the `risky` test mentioned above, which is fixed by https://github.com/ILIAS-eLearning/ILIAS/pull/3653