### PR TITLE
Test&Assessment: Fix risky tests

### DIFF
--- a/Modules/Test/test/confirmations/ilTestSettingsChangeConfirmationGUITest.php
+++ b/Modules/Test/test/confirmations/ilTestSettingsChangeConfirmationGUITest.php
@@ -12,24 +12,29 @@ class ilTestSettingsChangeConfirmationGUITest extends ilTestBaseTestCase
 {
     private ilTestSettingsChangeConfirmationGUI $testSettingsChangeConfirmationGUI;
     /**
-     * @var ilObjTest|mixed|MockObject
+     * @var ilObjTest|MockObject
      */
     private $testObj_mock;
     /**
-     * @var ilLanguage|mixed|MockObject
+     * @var ilLanguage|MockObject
      */
     private $lng_mock;
 
     protected function setUp() : void
     {
         parent::setUp();
-        $this->lng_mock = $this->createMock(ilLanguage::class);
-        $this->testObj_mock = $this->createMock(ilObjTest::class);
-        $this->testSettingsChangeConfirmationGUI = new ilTestSettingsChangeConfirmationGUI($this->lng_mock,
-            $this->testObj_mock);
+        $this->lng_mock = $this->getMockBuilder(ilLanguage::class)->disableOriginalConstructor()->getMock();
+        $this->testObj_mock = $this->getMockBuilder(ilObjTest::class)->disableOriginalConstructor()->getMock();
+
+        $this->setGlobalVariable('lng', $this->lng_mock);
+
+        $this->testSettingsChangeConfirmationGUI = new ilTestSettingsChangeConfirmationGUI(
+            $this->lng_mock,
+            $this->testObj_mock
+        );
     }
 
-    protected function testSetAndGetOldQuestionSetType() : void
+    public function testSetAndGetOldQuestionSetType() : void
     {
         $expect = "testType";
 
@@ -38,7 +43,7 @@ class ilTestSettingsChangeConfirmationGUITest extends ilTestBaseTestCase
         $this->assertEquals($expect, $this->testSettingsChangeConfirmationGUI->getOldQuestionSetType());
     }
 
-    protected function testSetAndGetNewQuestionSetType() : void
+    public function testSetAndGetNewQuestionSetType() : void
     {
         $expect = "testType";
 
@@ -47,7 +52,7 @@ class ilTestSettingsChangeConfirmationGUITest extends ilTestBaseTestCase
         $this->assertEquals($expect, $this->testSettingsChangeConfirmationGUI->getNewQuestionSetType());
     }
 
-    protected function testSetAndIsQuestionLossInfoEnabled() : void
+    public function testSetAndIsQuestionLossInfoEnabled() : void
     {
         $expect = true;
 

--- a/Modules/Test/test/ilTestBaseTestCase.php
+++ b/Modules/Test/test/ilTestBaseTestCase.php
@@ -40,7 +40,9 @@ class ilTestBaseTestCase extends TestCase
         $GLOBALS[$name] = $value;
 
         unset($DIC[$name]);
-        $DIC[$name] = $GLOBALS[$name];
+        $DIC[$name] = static function (\ILIAS\DI\Container $c) use ($value) {
+            return $value;
+        };
     }
 
     /**


### PR DESCRIPTION
This PR fixes a PHPUnit test class with multiple risky tests.

Problems:

- The test methods were `protected`
- The mocks were created based on classes, with their `__construct` method being executed (which is a problem for legacy code classes which do not use proper dependency injection)
- The `lng` mock was not put to `$DIC` and `ilTestSettingsChangeConfirmationGUI` called `$DIC->language()`