### PR TITLE
Session Handler: Implement interface / Remove PHP version conditional…

### DIFF
--- a/Services/Authentication/classes/class.ilSession.php
+++ b/Services/Authentication/classes/class.ilSession.php
@@ -278,9 +278,10 @@ class ilSession
     }
 
     /**
-    * Destroy expired sessions
-    */
-    public static function _destroyExpiredSessions()
+     * Destroy expired sessions
+     * @return int The number of deleted sessions on success
+     */
+    public static function _destroyExpiredSessions() : int
     {
         global $DIC;
 
@@ -289,15 +290,15 @@ class ilSession
         $q = "SELECT session_id,expires FROM usr_session WHERE expires < " .
             $ilDB->quote(time(), "integer");
         $res = $ilDB->query($q);
-        $ids = array();
+        $ids = [];
         while ($row = $ilDB->fetchAssoc($res)) {
             $ids[$row["session_id"]] = $row["expires"];
         }
-        if (sizeof($ids)) {
+        if ($ids !== []) {
             self::_destroy($ids, self::SESSION_CLOSE_EXPIRE, true);
         }
         
-        return true;
+        return count($ids);
     }
     
     /**

--- a/Services/Authentication/classes/class.ilSessionDBHandler.php
+++ b/Services/Authentication/classes/class.ilSessionDBHandler.php
@@ -1,119 +1,90 @@
-<?php
-
+<?php declare(strict_types=1);
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-include_once("./Services/Authentication/classes/class.ilSession.php");
-
 /**
-* Database Session Handling
-*
-* @module		inc.db_session_handler.php
-* @modulegroup	iliascore
-* @version		$Id: inc.db_session_handler.php 18894 2009-02-06 15:24:04Z akill $
-*/
-class ilSessionDBHandler
+ * Database Session Handling
+ * @module inc.db_session_handler.php
+ * @modulegroup iliascore
+ */
+class ilSessionDBHandler implements SessionHandlerInterface
 {
-    /*
-    * register callback functions
-    * session.save_handler must be 'user' or safe mode off to succeed
-    */
-    public function setSaveHandler()
+    /**
+     * Register callback functions
+     * session.save_handler must be 'user' or safe mode off to succeed
+     */
+    public function setSaveHandler() : bool
     {
-        // register save handler functions
         if (session_status() === PHP_SESSION_ACTIVE) {
             return true;
         }
 
-        if (ini_get("session.save_handler") == "user" || version_compare(PHP_VERSION, '7.2.0', '>=')) {
-            session_set_save_handler(
-                array($this, "open"),
-                array($this, "close"),
-                array($this, "read"),
-                array($this, "write"),
-                array($this, "destroy"),
-                array($this, "gc")
-            );
+        session_set_save_handler(
+            $this,
+            true // Registers session_write_close() as a register_shutdown_function() function.
+        );
 
-            return true;
-        }
-
-        return false;
+        return true;
     }
-    
-    /*
-    * open session, normally a db connection would be opened here, but
-    * we use the standard ilias db connection, so nothing must be done here
-    *
-    * @param	string		$save_pathDSN	information about how to access the database, format:
-    *										dbtype(dbsyntax)://username:password@protocol+hostspec/database
-    *										eg. mysql://phpsessmgr:topsecret@db.example.com/sessiondb
-    * @param	string		$name			session name [PHPSESSID]
-    */
-    public function open($save_path, $name)
+
+    /**
+     * Open session, normally a db connection would be opened here, but
+     * we use the standard ilias db connection, so nothing must be done here
+     * @param string $path
+     * @param string $name session name [PHPSESSID]
+     */
+    public function open($path, $name) : bool
     {
         return true;
     }
 
     /**
-    * close session
-    *
-    * for a db nothing has to be done here
-    */
-    public function close()
+     * close session
+     *
+     * for a db nothing has to be done here
+     */
+    public function close() : bool
     {
         return true;
     }
 
-    /*
-    * Reads data of the session identified by $session_id and returns it as a
-    * serialised string. If there is no session with this ID an empty string is
-    * returned
-    *
-    * @param	integer		$session_id		session id
-    */
-    public function read($session_id)
+    /**
+     * Reads data of the session identified by $session_id and returns it as a
+     * serialised string. If there is no session with this ID an empty string is
+     * returned
+     * @param string $id
+     */
+    public function read($id) : string
     {
-        return ilSession::_getData($session_id);
+        return ilSession::_getData($id);
     }
 
     /**
-    * Writes serialized session data to the database.
-    *
-    * @param	integer		$session_id		session id
-    * @param	string		$data			session data
-    */
-    public function write($session_id, $data)
+     * Writes serialized session data to the database.
+     * @param string $id session id
+     * @param string $data session data
+     */
+    public function write($id, $data) : bool
     {
-        $cwd = getcwd();
         chdir(IL_INITIAL_WD);
-        include_once("./Services/Authentication/classes/class.ilSession.php");
-        $r = ilSession::_writeData($session_id, $data);
-        // see bug http://www.ilias.de/mantis/view.php?id=18000
-        //chdir($cwd);
-        return $r;
+
+        return ilSession::_writeData($id, $data);
     }
 
     /**
-    * destroy session
-    *
-    * @param	integer		$session_id			session id
-    */
-    public function destroy($session_id)
+     * Destroy session
+     * @param string $id session id
+     */
+    public function destroy($id) : bool
     {
-        return ilSession::_destroy($session_id);
+        return ilSession::_destroy($id);
     }
 
     /**
-    * removes sessions that weren't updated for more than gc_maxlifetime seconds
-    *
-    * @param	integer		$gc_maxlifetime			max lifetime in seconds
-    */
-    public function gc($gc_maxlifetime)
+     * Removes sessions that weren't updated for more than gc_maxlifetime seconds
+     * @param int $max_lifetime Maximum lifetime in seconds
+     */
+    public function gc($max_lifetime) : bool
     {
         return ilSession::_destroyExpiredSessions();
     }
 }
-
-// needs to be done to assure that $ilDB exists,
-// when db_session_write is called
-register_shutdown_function("session_write_close");

--- a/Services/Authentication/classes/class.ilSessionDBHandler.php
+++ b/Services/Authentication/classes/class.ilSessionDBHandler.php
@@ -18,12 +18,10 @@ class ilSessionDBHandler implements SessionHandlerInterface
             return true;
         }
 
-        session_set_save_handler(
+        return session_set_save_handler(
             $this,
             true // Registers session_write_close() as a register_shutdown_function() function.
         );
-
-        return true;
     }
 
     /**
@@ -81,9 +79,10 @@ class ilSessionDBHandler implements SessionHandlerInterface
 
     /**
      * Removes sessions that weren't updated for more than gc_maxlifetime seconds
-     * @param int $max_lifetime Maximum lifetime in seconds
+     * @param int $max_lifetime Sessions that have not updated for the last max_lifetime seconds will be removed.
+     * @return int|bool
      */
-    public function gc($max_lifetime) : bool
+    public function gc($max_lifetime)
     {
         return ilSession::_destroyExpiredSessions();
     }

--- a/Services/Authentication/classes/class.ilSessionDBHandler.php
+++ b/Services/Authentication/classes/class.ilSessionDBHandler.php
@@ -9,8 +9,8 @@
 class ilSessionDBHandler implements SessionHandlerInterface
 {
     /**
-     * Register callback functions
-     * session.save_handler must be 'user' or safe mode off to succeed
+     * Registers the session save handler
+     * session.save_handler must be 'user'
      */
     public function setSaveHandler() : bool
     {
@@ -27,7 +27,7 @@ class ilSessionDBHandler implements SessionHandlerInterface
     }
 
     /**
-     * Open session, normally a db connection would be opened here, but
+     * Opens session, normally a db connection would be opened here, but
      * we use the standard ilias db connection, so nothing must be done here
      * @param string $path
      * @param string $name session name [PHPSESSID]
@@ -71,7 +71,7 @@ class ilSessionDBHandler implements SessionHandlerInterface
     }
 
     /**
-     * Destroy session
+     * Destroys session
      * @param string $id session id
      */
     public function destroy($id) : bool

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -574,7 +574,7 @@ class ilInitialisation
     {
         $db_session_handler = new ilSessionDBHandler();
         if (!$db_session_handler->setSaveHandler()) {
-            self::abortAndDie("Please turn off Safe mode OR set session.save_handler to \"user\" in your php.ini");
+            self::abortAndDie("Please set session.save_handler to \"user\" in your php.ini");
         }
 
         // Do not accept external session ids

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -572,11 +572,6 @@ class ilInitialisation
      */
     public static function setSessionHandler()
     {
-        if (ini_get('session.save_handler') != 'user' && version_compare(PHP_VERSION, '7.2.0', '<')) {
-            ini_set("session.save_handler", "user");
-        }
-
-        require_once "Services/Authentication/classes/class.ilSessionDBHandler.php";
         $db_session_handler = new ilSessionDBHandler();
         if (!$db_session_handler->setSaveHandler()) {
             self::abortAndDie("Please turn off Safe mode OR set session.save_handler to \"user\" in your php.ini");

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -574,7 +574,7 @@ class ilInitialisation
     {
         $db_session_handler = new ilSessionDBHandler();
         if (!$db_session_handler->setSaveHandler()) {
-            self::abortAndDie("Please set session.save_handler to \"user\" in your php.ini");
+            self::abortAndDie("Cannot start session handling.");
         }
 
         // Do not accept external session ids


### PR DESCRIPTION
…s / Remove obsolete register_shutdown_function

This PR ...

- ... removes several obsolete `version_compare` conditions for PHP 7.2
- ... adds an implementation of the `SessionHandlerInterface` interface to `ilSessionDBHandler`
- ... removes an explicit `register_shutdown_function('session_write_close');` call (**please double/cross check on review/testing**)
- ... uses `strict_types`
- ... formats `PHPDoc` comments