### PR TITLE
UI/ViewControl: add possibility of return value null to Pagination::getRange

### DIFF
--- a/src/UI/Component/ViewControl/Pagination.php
+++ b/src/UI/Component/ViewControl/Pagination.php
@@ -121,5 +121,5 @@ interface Pagination extends C\Component, JavaScriptBindable, Triggerer
     /**
      * Get the current number of entries on this page.
      */
-    public function getRange() : Range;
+    public function getRange() : ?Range;
 }

--- a/src/UI/Implementation/Component/ViewControl/Pagination.php
+++ b/src/UI/Implementation/Component/ViewControl/Pagination.php
@@ -277,8 +277,11 @@ class Pagination implements PaginationInterface
         return self::DEFAULT_DROPDOWN_LABEL;
     }
 
-    public function getRange() : Range
+    public function getRange() : ?Range
     {
+        if ($this->getPageLength() < 1) {
+            return null;
+        }
         $f = new \ILIAS\Data\Factory();
         return $f->range($this->getOffset(), $this->getPageLength());
     }

--- a/tests/UI/Component/ViewControl/PaginationTest.php
+++ b/tests/UI/Component/ViewControl/PaginationTest.php
@@ -292,4 +292,18 @@ EOT;
         $html = $this->getDefaultRenderer()->render($p);
         $this->assertHTMLEquals($expected_html, $html);
     }
+
+    public function testGetRangeOnNull()
+    {
+        $page_size = 0;
+        $current_page = 1;
+        $range = null;
+
+        $pagination = $this->getFactory()->pagination()
+            ->withCurrentPage($current_page)
+            ->withPageSize($page_size);
+
+        $this->assertNull($pagination->getRange());
+        $this->assertEquals($range, $pagination->getRange());
+    }
 }


### PR DESCRIPTION
Now Pagination::getRange can return null as value. Thus a user can react appropriate if the list is empty.