### PR TITLE
Fix removal of files with no rid

### DIFF
--- a/Modules/File/classes/class.ilObjFile.php
+++ b/Modules/File/classes/class.ilObjFile.php
@@ -563,7 +563,7 @@ class ilObjFile extends ilObject2 implements ilObjFileImplementationInterface
 
         // delete resource
         $identification = $this->getResourceId();
-        if ($identification) {
+        if ($identification && $identification != '-') {
             $this->manager->remove($this->manager->find($identification), $this->stakeholder);
         }
     }


### PR DESCRIPTION
The cron-job to empty the trash sometimes fails on our system. The problem seem to be records in `file_data` with the value _null_ for the field `rid`. I assume that those are not migrated files. In our case, this might be from files that failed to migrate. In other cases, this might be because the migration hasn't finished yet. Either way, this leads to an exception while removing the file from the system.

Following, I will describe how this exception occurs:
The return of `getResourceId()` looks like following `return $this->resource_id ?? '-';`.  Therefore, `$identification` can either have the value of a correct `rid` or just a simple hyphen. If a hyphen is passed to `$this->manager->find('-');`, _null_ will be returned which leads to an exception in `$this->manager->remove(...)`.