### PR TITLE
UI: add on-first-view trigger to slate (#31434)

### DIFF
--- a/src/UI/templates/js/MainControls/slate.js
+++ b/src/UI/templates/js/MainControls/slate.js
@@ -28,6 +28,7 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 		};
 
 		var onToggleSignal = function(slate, triggerer, is_in_metabar_more) {
+			already_engaged = _isEngaged(slate);
 			//special case for metabar-more
 			if(triggerer.attr('id') === il.UI.maincontrols.metabar._getMoreButton().attr('id')) {
 				if(il.UI.maincontrols.metabar.getEngagedSlates().length > 0){
@@ -46,6 +47,9 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 				triggerer.addClass(_cls_engaged);
 				triggerer.removeClass(_cls_disengaged);
 				slate.trigger('in_view');
+				if (! already_engaged) {
+					slate.trigger('on_first_view');
+				}
 			} else {
 				triggerer.removeClass(_cls_engaged);
 				triggerer.addClass(_cls_disengaged);


### PR DESCRIPTION
This fixes [#31434](https://mantis.ilias.de/view.php?id=31434) by adding the missing trigger for "on_first_view" to the slate as well (and not the mainbar only).

This is a witness for the observation, that we really want some good js-tests that also cover PHP/JS-integration.