### PR TITLE
[FIX] 0031418: bad performance due to unnecessary background requests

### DIFF
--- a/src/UI/templates/js/MainControls/src/mainbar.main.js
+++ b/src/UI/templates/js/MainControls/src/mainbar.main.js
@@ -117,13 +117,13 @@ var mainbar = function() {
                     case 'disengage_all':
                         mb.model.actions.disengageAll();
                         var state = mb.model.getState()
-                            last_top_id = state.last_active_top;
+                            last_top_id = state.current_active_top;
 
                         after_render = function() {
                             mb.renderer.focusTopentry(last_top_id);
                         }
 
-                        state.last_active_top = null;
+                        state.current_active_top = null;
                         mb.model.setState(state);
                         break;
 
@@ -254,7 +254,7 @@ var mainbar = function() {
             ) {
                 mb.model.actions.disengageAll();
             } else {
-                last_top = mb.model.getState().last_active_top;
+                last_top = mb.model.getState().current_active_top;
                 if(last_top) {
                     mb.model.actions.engageEntry(last_top);
                 }else {

--- a/src/UI/templates/js/MainControls/src/mainbar.model.js
+++ b/src/UI/templates/js/MainControls/src/mainbar.model.js
@@ -37,8 +37,7 @@ var model = function() {
             tools: {}, //"moving" parts, current tools
             known_tools: [], //gs-ids; a tool is "new", if not listed here
             current_active_top: null,
-            last_actively_engaged: null,
-            top_level_changed: null
+            last_actively_engaged: null
         },
         entry: {
             id: null,
@@ -154,9 +153,7 @@ var model = function() {
             state.entries = reducers.entries.engageEntryPath(state.entries, entry_id);
             state = reducers.bar.disengageTools(state);
             state = reducers.bar.anySlates(state);
-            var last_active_top = state.current_active_top;
             state.current_active_top = helpers.getEngagedTopLevelEntryId();
-            state.top_level_changed = state.current_active_top !== last_active_top;
         },
         disengageEntry: function (entry_id) {
             state.last_actively_engaged = null;

--- a/src/UI/templates/js/MainControls/src/mainbar.persistence.js
+++ b/src/UI/templates/js/MainControls/src/mainbar.persistence.js
@@ -85,6 +85,7 @@ var persistence = function() {
     storeStates = function(state) {
         state.entries = compressEntries(state.entries);
         state.tools = compressTools(state.tools);
+        state.last_actively_engaged = null;
         cs = storage();
         for(idx in state) {
             cs.add(idx, state[idx]);

--- a/src/UI/templates/js/MainControls/src/mainbar.renderer.js
+++ b/src/UI/templates/js/MainControls/src/mainbar.renderer.js
@@ -19,20 +19,14 @@ var renderer = function($) {
             return Object.assign({}, this, {html_id: html_id});
         },
         getElement: function(){
-            //return document.getElementById(this.html_id);
             return $('#' + this.html_id);
         },
         engage: function() {
-            var element = this.getElement(),
-                loaded = element.hasClass(css.engaged);
+            var element = this.getElement();
 
             element.addClass(css.engaged);
             element.removeClass(css.disengaged);
 
-            if(! loaded) {
-                element.trigger('in_view'); //this is most important for async loading of slates,
-                                            //it triggers the GlobalScreen-Service.
-            }
             if(il.UI.page.isSmallScreen() && il.UI.maincontrols.metabar) {
                 il.UI.maincontrols.metabar.disengageAll();
             }
@@ -165,7 +159,7 @@ var renderer = function($) {
             dom_references[entry_id] = dom_references[entry_id] || {};
             dom_references[entry_id][part] = html_id;
         },
-        renderEntry: function (entry, is_tool) {
+        renderEntry: function (entry, is_tool, fire_event = false) {
             if(!dom_references[entry.id]){
                 return;
             }
@@ -187,6 +181,11 @@ var renderer = function($) {
             if(entry.engaged) {
                 triggerer.engage();
                 slate.engage();
+                // fire event
+                if(fire_event) {
+                    slate.getElement().trigger('in_view');
+                }
+
                 if(entry.removeable) {
                     remover = parts.remover.withHtmlId(dom_references[entry.id].remover);
                     remover.mb_show(true);
@@ -242,8 +241,10 @@ var renderer = function($) {
                 parts.tools_area.disengage();
             }
 
-            for(idx in model_state.entries) {
-                actions.renderEntry(model_state.entries[idx], false);
+            for (idx in model_state.entries) {
+                actions.renderEntry(model_state.entries[idx], false,
+                  model_state.last_actively_engaged === idx
+                  || (model_state.top_level_changed && model_state.current_active_top === model_state.entries[idx].getTopLevel()));
             }
             for(idx in model_state.tools) {
                 actions.renderEntry(model_state.tools[idx], true);

--- a/src/UI/templates/js/MainControls/src/mainbar.renderer.js
+++ b/src/UI/templates/js/MainControls/src/mainbar.renderer.js
@@ -12,6 +12,7 @@ var renderer = function($) {
         ,mainbar_buttons: '.il-mainbar .il-mainbar-entries .btn-bulky, .il-mainbar .il-mainbar-entries .link-bulky'
         ,mainbar_entries: 'il-mainbar-entries'
     },
+      events_fired_for = [],
 
     dom_references = {},
     dom_element = {
@@ -166,7 +167,7 @@ var renderer = function($) {
 
             var triggerer = parts.triggerer.withHtmlId(dom_references[entry.id].triggerer),
                 slate = parts.slate.withHtmlId(dom_references[entry.id].slate);
-                
+
                 //a11y
                 triggerer.getElement().attr('aria-controls', slate.html_id);
                 triggerer.getElement().attr('aria-labelledby', triggerer.html_id);
@@ -182,7 +183,8 @@ var renderer = function($) {
                 triggerer.engage();
                 slate.engage();
                 // fire event
-                if(fire_event) {
+                if(fire_event && !events_fired_for.includes(entry.id)) {
+                    events_fired_for.push(entry.id);
                     slate.getElement().trigger('in_view');
                 }
 
@@ -244,7 +246,7 @@ var renderer = function($) {
             for (idx in model_state.entries) {
                 actions.renderEntry(model_state.entries[idx], false,
                   model_state.last_actively_engaged === idx
-                  || (model_state.top_level_changed && model_state.current_active_top === model_state.entries[idx].getTopLevel()));
+                  || model_state.current_active_top === model_state.entries[idx].getTopLevel());
             }
             for(idx in model_state.tools) {
                 actions.renderEntry(model_state.tools[idx], true);


### PR DESCRIPTION
Hi @klees !

Mantis: https://mantis.ilias.de/view.php?id=31418

As discussed before I had a look at the mainbar.js to prevent the mainbar from pulling to much async content. The state model now saves:
- the current active top-level (it did before, but not in all cases)
- the last "clicked" entry
- and an entry always knows it's toplevel entry

with this info, the event to reload the content of a slate only fires when
- the active top-level changed and an entry is within the active toplevel
- the entry was actively clicked

why this both cases?
- we could also trigger the event for every entry which is in the active top-level, but this leads to unnecessary requests for siblings within the same toplevel, therefore we check for a "top level changed"
- but if we only fire the event on a "top level changed", a new sibling actively clicked nested in the same top-level would not fire, therefore the 'fore on actively clicked'

see: https://github.com/ILIAS-eLearning/ILIAS/compare/release_7...studer-raimann:fix/0031418/7/unnecessary-requests#diff-84d572049e14e3939184146d40735f1ab00485ec64184969aa6992f1a39c7850R926