### PR TITLE
Color picker access of undefined

### DIFF
--- a/Services/Form/classes/class.ilColorPickerInputGUI.php
+++ b/Services/Form/classes/class.ilColorPickerInputGUI.php
@@ -15,6 +15,11 @@ class ilColorPickerInputGUI extends ilTextInputGUI
     protected $hex;
 
     /**
+     * @var bool
+     */
+    protected $acceptnamedcolors = false;
+
+    /**
     * Constructor
     *
     * @param	string	$a_title	Title


### PR DESCRIPTION
Just a tiny php8 fix, which currently throws an error in system styles, making refactoring there somewhat cumbersome. Would love to have this fix in trunk, even if this component is not fully refactored for php8. 