### PR TITLE
Init/CronContext/UI: Allow 'HTML' and 'Template' for cron context

### DIFF
--- a/Services/Context/classes/class.ilContextCron.php
+++ b/Services/Context/classes/class.ilContextCron.php
@@ -51,7 +51,7 @@ class ilContextCron implements ilContextTemplate
      */
     public static function hasHTML()
     {
-        return false;
+        return true;
     }
     
     /**
@@ -61,7 +61,7 @@ class ilContextCron implements ilContextTemplate
      */
     public static function usesTemplate()
     {
-        return false;
+        return true;
     }
     
     /**


### PR DESCRIPTION
There are issues in certain components (Test, Survey, ...) where UI componets or templates in the `$DIC` are accessed in a `Cron Context`, but the corresponding services are not available.

Until now the `Cron Context` did not initialize these services at all, see:

- https://github.com/ILIAS-eLearning/ILIAS/commit/c00cb16100441968b1c83dda4a8693e2e5c3b57d
- https://github.com/ILIAS-eLearning/ILIAS/commit/ec2d09e64acb571f23f9a3359ebd6fa24c8c23aa


Bug-Reports:
- e.g.: https://mantis.ilias.de/view.php?id=29217