### PR TITLE
ErrorHandling: only show error message once #31213

### DIFF
--- a/error.php
+++ b/error.php
@@ -16,15 +16,8 @@ try {
     $local_tpl->SetVariable("LINK", ilUtil::secureUrl(ILIAS_HTTP_PATH . '/ilias.php?baseClass=ilRepositoryGUI&amp;client_id=' . CLIENT_ID));
     $local_tpl->ParseCurrentBlock();
 
-    $local_tpl->setCurrentBlock("content");
-    $local_tpl->setVariable("ERROR_MESSAGE", ($_SESSION["failure"]));
-    $tpl->setTitle($lng->txt('error_sry_error'));
-
-    //$tpl->parseCurrentBlock();
-
     ilSession::clear("referer");
     ilSession::clear("message");
-    //$local_tpl->printToStdout();
     $tpl->setContent($local_tpl->get());
     $tpl->printToStdout();
 } catch (Exception $e) {

--- a/templates/default/tpl.error.html
+++ b/templates/default/tpl.error.html
@@ -1,4 +1,3 @@
-<div class="alert alert-danger">{ERROR_MESSAGE}</div>
 <!-- BEGIN ErrorLink -->
 <!-- additional link e.g. by WebAccessChecker -->
 <p>


### PR DESCRIPTION
For some reason the error message on error.php is rendered twice. This removes the superfluous rendering in error.php.

https://mantis.ilias.de/view.php?id=31213