### PR TITLE
	[FIX] 0031386: TinyMCE 5.x: Wrong HTTP path set to template

### DIFF
--- a/node_modules/tinymce/plugins/latex/latex.php
+++ b/node_modules/tinymce/plugins/latex/latex.php
@@ -22,7 +22,7 @@ global $DIC;
 $htdocs = $ilIliasIniFile->readVariable('server', 'absolute_path') . '/';
 $weburl = $ilIliasIniFile->readVariable('server', 'absolute_path') . '/';
 if (defined('ILIAS_HTTP_PATH')) {
-    $weburl = substr(ILIAS_HTTP_PATH, 0, strrpos(ILIAS_HTTP_PATH, '/Services')) . '/';
+    $weburl = substr(ILIAS_HTTP_PATH, 0, strrpos(ILIAS_HTTP_PATH, '/node_modules')) . '/';
 }
 $iliasHttpPath = $weburl;
 

--- a/node_modules/tinymce/plugins/latex/tpl.latex.html
+++ b/node_modules/tinymce/plugins/latex/tpl.latex.html
@@ -26,7 +26,6 @@
     </style>
     <script language="javascript" type="text/javascript">
         var hostname = "{ILIAS_INST_PATH}";
-        console.log(hostname)
         const deferredCallback = (function() {
             let timer = 0;
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=31386 

Due to the  HTTP path in node_modules/tinymce/plugins/latex/latex.php being incorrect, the cross-origin communication between the main window objects and the latex pop-up window was throwing errors. This PR fixes the issue.