### PR TITLE
PRIVACY.md: format according to guidelines and streamlining

### DIFF
--- a/Modules/HTMLLearningModule/PRIVACY.md
+++ b/Modules/HTMLLearningModule/PRIVACY.md
@@ -1,45 +1,53 @@
 # HTML Learning Module Privacy
 
-This documentation does not warrant completeness or correctness. Please report any missing or wrong information using the <a href="https://mantis.ilias.de/">ILIAS issue tracker</a>.
+This documentation does not warrant completeness or correctness. Please report any
+missing or wrong information using the [ILIAS issue tracker](https://mantis.ilias.de)
+or contribute a fix via [Pull Request](docs/development/contributing.md#pull-request-to-the-repositories).
+
 
 ## Data being stored
 
 - The HTML Learning Module component itself does not store any personal data.
-- The HTML Learning Module component employs the following services, please consult the respective privacy.mds 
-  - Reference to Learning Progress (Move to respective md: Learning Progress service stores data on access time speifically last time, number of accesses and the progress status specifically in progress, completed for each user accessing the object.) 
-  - Reference to Metadata (Move to respective md: Metadata  service contains two branches: LOM and custom metdata. The LOM offers storing personal dates like author. Custom metadata do contain user-created metadata sets which may contain personal dates, which mus be individually checked in the global administration.)
-  - Reference to Permission (Move to respective md: The account which created the very object is stored as it's owner, creation and update timestamps for the object. The permission service stores which users / user roles have what kind of access to the object.) 
+- The HTML Learning Module component employs the following services, please consult
+  the respective privacy.mds
+  - Reference to Learning Progress (Move to respective md: Learning Progress service
+    stores data on access time speifically last time, number of accesses and the
+    progress status specifically in progress, completed for each user accessing the
+    object.)
+  - Reference to Metadata (Move to respective md: Metadata  service contains two
+    branches: LOM and custom metdata. The LOM offers storing personal dates like
+    author. Custom metadata do contain user-created metadata sets which may contain
+    personal dates, which mus be individually checked in the global administration.)
+  - Reference to Permission (Move to respective md: The account which created the
+    very object is stored as it's owner, creation and update timestamps for the
+    object. The permission service stores which users / user roles have what kindo
+    of access to the object.)
+
 
 ## Data being presented
 
 - The HTML Learning Module component itself does not present any personal data.
-- Reference to Learning Progress (Move to respective md: Depending on global settings Learning Progress service presents progress and access data to accounts having the "View learning progress" permission.
-- Reference to Metadata (Move to respective md: Metadata service presents metadata to accounts with "view" permission on respective Info-tab). 
-- Reference to Permission (Move to respective md: The service presents the owner to accounts with "view" permission on respective Info-tab). 
+- Reference to Learning Progress (Move to respective md: Depending on global
+  settings Learning Progress service presents progress and access data to accounts
+  having the "View learning progress" permission.
+- Reference to Metadata (Move to respective md: Metadata service presents metadata
+  to accounts with "view" permission on respective Info-tab).
+- Reference to Permission (Move to respective md: The service presents the owner
+  to accounts with "view" permission on respective Info-tab).
 
 
 ## Data being deleted
 
 - The HTML Learning Module itself does not store or delete any personal data.
-- Basic object, permission and learning progress data is deleted only, once the object is deleted from trash. User can empty the trash at Administration > System Settings an Maintenance > Repository Trash and Permissions.
+- Basic object, permission and learning progress data is deleted only, once the
+  object is deleted from trash. User can empty the trash at Administration > System
+  Settings an Maintenance > Repository Trash and Permissions.
 
 
 ## Data being exported 
 
 - The HTML Learning Module component itself does not export any personal data.
-- Reference to Learning Progress (Move to respective md: Personal data can be exported from the Learning Progress service.) 
-- Reference to Metadata (Move to respective md: Metadata  service exports metadata like author along with the compnent itself.)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+- Reference to Learning Progress (Move to respective md: Personal data can be
+  exported from the Learning Progress service.)
+- Reference to Metadata (Move to respective md: Metadata  service exports metadata
+  like author along with the compnent itself.)

--- a/Modules/ItemGroup/PRIVACY.md
+++ b/Modules/ItemGroup/PRIVACY.md
@@ -1,19 +1,29 @@
 # Item Group Privacy
 
-This documentation comes with no guarantee of completeness or correctness. Please report any issues (missing or wrong information) in the ILIAS issue tracker.
+This documentation does not warrant completeness or correctness. Please report any
+missing or wrong information using the [ILIAS issue tracker](https://mantis.ilias.de)
+or contribute a fix via [Pull Request](docs/development/contributing.md#pull-request-to-the-repositories).
+
 
 ## Data being stored
 
 - The Item Group module itself does not store any personal data.
-- Like all repository objects, it uses the basic Object service which stores the owner, creation and update timestamps for the object.
-- Like all repository objects it uses the Permission service which stores information about which users / user roles have what kind of access to the object.
+- Like all repository objects, it uses the basic Object service which stores the
+  owner, creation and update timestamps for the object.
+- Like all repository objects it uses the Permission service which stores information
+  about which users / user roles have what kind of access to the object.
+
 
 ## Data presentation
 
 - The Item group itself does not present any personal data.
-- Like all repository objects it integrates screens of the Permission service which present information about which users / user roles have what kind of access to the object.
+- Like all repository objects it integrates screens of the Permission service which
+  present information about which users / user roles have what kind of access to the
+  object.
+
 
 ## Data Deletion
 
 - The Item group itself does not store or delete any personal data.
-- Basic object and permission data is deleted once the object is "finally" deleted (removed from trash).
+- Basic object and permission data is deleted once the object is "finally" deleted
+  (removed from trash).

--- a/Services/COPage/PRIVACY.md
+++ b/Services/COPage/PRIVACY.md
@@ -1,21 +1,47 @@
 # COPage (Page Editor) Service Privacy
 
-This documentation comes with no guarantee of completeness or correctness. Please report any issues (missing or wrong information) in the ILIAS issue tracker.
+This documentation does not warrant completeness or correctness. Please report any
+missing or wrong information using the [ILIAS issue tracker](https://mantis.ilias.de)
+or contribute a fix via [Pull Request](docs/development/contributing.md#pull-request-to-the-repositories).
+
 
 ## Data being stored
 
-- Each page stores the **content** together with the **user ID** of the page **creator**, the **last user who changed** the page and **timestamps** of the **creation** and **last change**.
-- The service stores not only the current page state, but **stores historic versions of pages with each change** being made.
+- Each page stores the **content** together with the **user ID** of the page
+  **creator**, the **last user who changed** the page and **timestamps** of the
+  **creation** and **last change**.
+- The service stores not only the current page state, but **stores historic versions
+  of pages with each change** being made.
 - Some container (e.g. Wikis) allow to add **user links** within the content. 
+
 
 ## Data presentation
 
-- **User links** within the content: Depending on the profile publishing settings of the user, the user is presented with a **clickable "lastname, firstname, account name"** link which leads to the personal profile of the user. If the profile is not published, nothing will be presented.
-- The container of the page (e.g. a Wiki or a Learning module) controls the **read permission** to the content of pages. Each user granted with this permission can access the **content**, which may include **profile links**. Also the **content itself may include personal data**, if other users have entered this data. Some container (e.g. Wikis) present the **timestamp of the last change together with the authoring user** (profile link as above).
-- The container of the page also controls **write access** (e.g. write or edit content permission) to the page. This gives user access to the full **page history** including **timestamps and users that made these changes**. Depending on the container it also enables users to add user links to any user, if the account name is known. The internal link feature offers also a **search for users with activated public profiles** for this purpose. Search strings must have a minimum of three characters. If this string matches firstname, lastname or account name a user will be listed.
+- **User links** within the content: Depending on the profile publishing settings
+  of the user, the user is presented with a **clickable "lastname, firstname,
+  account name"** link which leads to the personal profile of the user. If the
+  profile is not published, nothing will be presented.
+- The container of the page (e.g. a Wiki or a Learning module) controls the
+  **read permission** to the content of pages. Each user granted with this permission
+  can access the **content**, which may include **profile links**. Also the **content
+  itself may include personal data**, if other users have entered this data. Some
+  container (e.g. Wikis) present the **timestamp of the last change together with
+  the authoring user** (profile link as above).
+- The container of the page also controls **write access** (e.g. write or edit
+  content permission) to the page. This gives user access to the full **page
+  history** including **timestamps and users that made these changes**. Depending
+  on the container it also enables users to add user links to any user, if the
+  account name is known. The internal link feature offers also a **search for
+  users with activated public profiles** for this purpose. Search strings must
+  have a minimum of three characters. If this string matches firstname, lastname
+  or account name a user will be listed.
+
 
 ## Data Deletion
 
 - **Users cannot delete** entries in the page **history**.
-- **Pages and their history are deleted**, if the **single page or** the **container object** is **deleted** and **removed from the trash**.
-- If a **user is deleted** the **content** authored by the user is **not deleted**. However **no account name, firstname or lastname will be presented** in the "last edited" information, the page history or as user links **anymore**.
+- **Pages and their history are deleted**, if the **single page or** the **container
+  object** is **deleted** and **removed from the trash**.
+- If a **user is deleted** the **content** authored by the user is **not deleted**.
+  However **no account name, firstname or lastname will be presented** in the "last
+  edited" information, the page history or as user links **anymore**.

--- a/Services/News/PRIVACY.md
+++ b/Services/News/PRIVACY.md
@@ -1,25 +1,56 @@
 # News Service Privacy
 
-This documentation comes with no guarantee of completeness or correctness. Please report any issues (missing or wrong information) in the ILIAS issue tracker.
+This documentation does not warrant completeness or correctness. Please report any
+missing or wrong information using the [ILIAS issue tracker](https://mantis.ilias.de)
+or contribute a fix via [Pull Request](docs/development/contributing.md#pull-request-to-the-repositories).
+
 
 ## General Information 
-- The News service can be activated in the global administration. The RSS service can be activated in the global administration and it can be configured, if the feed is presented to the internet or only to registered users. 
+
+- The News service can be activated in the global administration. The RSS service
+  can be activated in the global administration and it can be configured, if the
+  feed is presented to the internet or only to registered users.
+
 
 ## Data being stored
-- Each **news entry** stores the **user ID** of the account that originally created the news entry along with a **creation timestamp**, the **user ID** of the account that last updated the news entry  along with the **timestamp of the last update**. These are not neccessarily the same and could be different accounts.  _Reason_: This data is required to be able to list news only after a specific date or to be able to adress authors of news for collaboration or reference.
-- For **each user** and **each news entry**, ILIAS stores, whether the **news has been presented ("is read")** to the user or not. No timestamp is included in this data. _Reason_: Unread news entries should be visually distinguishable from read entries.
+
+- Each **news entry** stores the **user ID** of the account that originally created
+  the news entry along with a **creation timestamp**, the **user ID** of the account
+  that last updated the news entry  along with the **timestamp of the last update**.
+  These are not neccessarily the same and could be different accounts.  _Reason_:
+  This data is required to be able to list news only after a specific date or to be
+  able to adress authors of news for collaboration or reference.
+- For **each user** and **each news entry**, ILIAS stores, whether the **news has
+  been presented ("is read")** to the user or not. No timestamp is included in this
+  data. _Reason_: Unread news entries should be visually distinguishable from read
+  entries.
 
 
 ## Data presentation
-- ILIAS presents news listings in **various contexts of the repository**, e.g. courses, groups, wikis or forums. This information is usually shown to all users having **Read** permission in this context. 
-- Accounts having **Edit Settings** permission in a context are usually able to create and update news. News are automatically created e.g. when a new file is uploaded. These automatically created news cannot be updated. 
-- Additionally news are presented in an **personal context in an aggregated form** for users. All news of their favourite repository objects are presented in these views. However only news are presented, that are also accessible in the repository contexts directly (meaning read permission to the context is needed).
-- Optionally news can be **configured** as being readable to the **public as an open RSS webfeed**. These feeds include all public news entries of a context and are accessible via an URL without any authentication.
+
+- ILIAS presents news listings in **various contexts of the repository**, e.g.
+  courses, groups, wikis or forums. This information is usually shown to all users
+  having **Read** permission in this context.
+- Accounts having **Edit Settings** permission in a context are usually able to
+  create and update news. News are automatically created e.g. when a new file is
+  uploaded. These automatically created news cannot be updated.
+- Additionally news are presented in an **personal context in an aggregated form**
+  for users. All news of their favourite repository objects are presented in these
+  views. However only news are presented, that are also accessible in the repository
+  contexts directly (meaning read permission to the context is needed).
+- Optionally news can be **configured** as being readable to the **public as an open
+  RSS webfeed**. These feeds include all public news entries of a context and are
+  accessible via an URL without any authentication.
+
 
 ## Data Deletion
 
-- News related to an object are deleted on final object deletion. Users need the **Delete** permission for this action.
+- News related to an object are deleted on final object deletion. Users need the
+  **Delete** permission for this action.
+
 
 ## Data Export
 
-- News entries are currently not exportable. If the context objects (e.g. courses) are exported as XML, news data is not included. These object related exports explicitly should not container personal data.
+- News entries are currently not exportable. If the context objects (e.g. courses)
+  are exported as XML, news data is not included. These object related exports
+  explicitly should not container personal data.

--- a/Services/Skill/PRIVACY.md
+++ b/Services/Skill/PRIVACY.md
@@ -1,28 +1,59 @@
 # Skill (Competence) Service Privacy
 
-This documentation comes with no guarantee of completeness or correctness. Please report any issues (missing or wrong information) in the ILIAS issue tracker.
+This documentation does not warrant completeness or correctness. Please report any
+missing or wrong information using the [ILIAS issue tracker](https://mantis.ilias.de)
+or contribute a fix via [Pull Request](docs/development/contributing.md#pull-request-to-the-repositories).
+
 
 ## Data being stored
 
 - **Personal competences** selected by users (User ID / Skill ID).
-- **Competence profile assignments**. Competence management administrators can assign competence profiles to users directly or via roles and organisational units. Course administrators can assign competence profiles to the local member role. (Profile ID + User ID/Role ID/OrgUnit ID).
-- Documents to prove personal skill level achievements: Users can **assign workspace files to single skill levels**. The documents are organised in the workspace service. The skill service stores the reference "user/document/skill level".
-- **Competence assessment/achievements** are aquired either by self evaluation, evaluation of others (e.g. 360° surveys) or measured by tools like tests. For all these cases the service stores user ID, competence level ID, timestamp of achievement, triggering object (e.g. test ID) and level of fulfillment (e.g. 60% of level 3).
+- **Competence profile assignments**. Competence management administrators can
+  assign competence profiles to users directly or via roles and organisational
+  units. Course administrators can assign competence profiles to the local member
+  role. (Profile ID + User ID/Role ID/OrgUnit ID).
+- Documents to prove personal skill level achievements: Users can **assign workspace
+  files to single skill levels**. The documents are organised in the workspace
+  service. The skill service stores the reference "user/document/skill level".
+- **Competence assessment/achievements** are aquired either by self evaluation,
+  evaluation of others (e.g. 360° surveys) or measured by tools like tests. For
+  all these cases the service stores user ID, competence level ID, timestamp of
+  achievement, triggering object (e.g. test ID) and level of fulfillment (e.g.
+  60% of level 3).
 
 
 ## Data presentation
 
-- **Administrators** of the competence management system have an overview on the **assignment** of **users to competence profiles**.
-- **Administrators/Tutors of repository objects** (e.g. course, survey, test) that make use of the competence service can assign competences and profiles to these objects. They can configure how competence levels will be achieved by measurement or manual assignment. Usually access is controlled by "**write/edit settings**" or "**edit learning progress**" permissions. The repository objects can provide views that show the **participating users** (e.g. members or survey participants) and **their competence level achievements**, also **compared to assigned profiles**.
-- The **users themselves get an overview on their assigned profiles and achieved competence levels**. These views allow to perform self evaluations and assign materials of proof to single competence levels. In the context of repository objects they get overviews of achieved competences within these objects and locally assigned profiles.
-- **Users may publish their personal competence achievements** in **portfolios**. The portfolio service controls the access to the portfolios including the competence data.
-- The **staff (MyStaff) service** presents competence achievement data for superiors, too.
+- **Administrators** of the competence management system have an overview on the
+  **assignment** of **users to competence profiles**.
+- **Administrators/Tutors of repository objects** (e.g. course, survey, test) that
+  make use of the competence service can assign competences and profiles to these
+  objects. They can configure how competence levels will be achieved by measurement
+  or manual assignment. Usually access is controlled by "**write/edit settings**"
+  or "**edit learning progress**" permissions. The repository objects can provide
+  views that show the **participating users** (e.g. members or survey participants)
+  and **their competence level achievements**, also **compared to assigned profiles**.
+- The **users themselves get an overview on their assigned profiles and achieved
+  competence levels**. These views allow to perform self evaluations and assign
+  materials of proof to single competence levels. In the context of repository
+  objects they get overviews of achieved competences within these objects and
+  locally assigned profiles.
+- **Users may publish their personal competence achievements** in **portfolios**.
+  The portfolio service controls the access to the portfolios including the competence
+  data.
+- The **staff (MyStaff) service** presents competence achievement data for superiors,
+  too.
 
-In General: The details on **how competence data is presented in other components** (survey, course, portfolios, staff, ...) should be **documented in the privacy documentation of these components**.
+In General: The details on **how competence data is presented in other components**
+(survey, course, portfolios, staff, ...) should be **documented in the privacy
+documentation of these components**.
+
 
 ## Data Deletion
 
-- Personal selected competences can be deselected by the user anytime. They are also deleted on user deletion
+- Personal selected competences can be deselected by the user anytime. They are
+also deleted on user deletion
 - Personally assigned workspace documents can be removed by the user anytime.
-- Assignments to competence profiles are deleted when either the assignment is removed by tutors/admins or the profile or the user is deleted.
+- Assignments to competence profiles are deleted when either the assignment is
+  removed by tutors/admins or the profile or the user is deleted.
 - Competence achievement data is deleted on user deletion.

--- a/Services/Tagging/PRIVACY.md
+++ b/Services/Tagging/PRIVACY.md
@@ -1,23 +1,41 @@
 # Tagging Service Privacy
-Disclaimer: This documentation does not warrant completeness or correctness. Please report any missing or wrong information using the <a href="https://mantis.ilias.de/">ILIAS issue tracker</a>
+
+This documentation does not warrant completeness or correctness. Please report any
+missing or wrong information using the [ILIAS issue tracker](https://mantis.ilias.de)
+or contribute a fix via [Pull Request](docs/development/contributing.md#pull-request-to-the-repositories).
+
 
 ## Data being stored
 
-- Each tag stores the user ID of the account that created the tag and the referenced object in the database. The purpose is to being able to identify the author of the tag i.e. to show own tags in main menu. 
-  
+- Each tag stores the user ID of the account that created the tag and the referenced
+  object in the database. The purpose is to being able to identify the author of the
+  tag i.e. to show own tags in main menu.
+
+
 ## Data being presented
 
-- An account with "Edit Settings" permissions Administration > Personal Workspace > Tagging > Edit Settings can enable the Tagging Service globally. 
+- An account with "Edit Settings" permissions Administration > Personal Workspace >
+  Tagging > Edit Settings can enable the Tagging Service globally.
   - Only accounts that created tags will be presented with them. 
-  - ILIAS presents the tags created by an account on various screens, e.g. in repository lists, the "Info"-tab or in the main menu.
-- An account with "Edit Settings" permissions Administration > Personal Workspace > Tagging > Edit Settings can additionally enable the presentation of all tags of all users related to an object. If that setting is activated, then all tags of all accounts related to an object are presented on its "Info"-tab as "Tags of All Users". This presentation of all tags of all accounts does not contain any personal data besides tag term.
-- An account with "Edit Settings" permissions Administration > Personal Workspace > Tagging > Users can all up list users of specific tags. The purpose is to identify accounts adding tags conflicting with the terms of use in the system.
+  - ILIAS presents the tags created by an account on various screens, e.g. in
+    repository lists, the "Info"-tab or in the main menu.
+- An account with "Edit Settings" permissions Administration > Personal Workspace
+  > Tagging > Edit Settings can additionally enable the presentation of all tags
+  of all users related to an object. If that setting is activated, then all tags
+  of all accounts related to an object are presented on its "Info"-tab as "Tags of
+  All Users". This presentation of all tags of all accounts does not contain any
+  personal data besides tag term.
+- An account with "Edit Settings" permissions Administration > Personal Workspace
+  > Tagging > Users can all up list users of specific tags. The purpose is to
+  identify accounts adding tags conflicting with the terms of use in the system.
+
 
 ## Data being deleted
 
 - Accounts can remove tags they created from an object on the objects "Info"-tab. 
 - Tags related to an object are deleted once an object is deleted from trash.
 - Tags related to a user are deleted once the user is deleted. 
+
 
 ## Data being exported 
 Tags cannot be exported


### PR DESCRIPTION
Hi @ezenzen,

AFAIK you took the lead in working out these PRIVACY.mds on some JF some time ago. So I address you here. I assign @alex40724, since I cannot assign you directly.

So, this formats the new documentation files according to our [guideline for docs](docs/development/docs-guidelines.md). I also streamlined the header of the files and the formatting a little. I did not change anything in the content, except for the explicit mention of pull requests in the header.

You might want to have a look into the [guideline for docs](docs/development/docs-guidelines.md), I think we would want to mention the PRIVACY.md there explicitely. Currently the naming of the file isn't covered by the guideline, I think we would want to adjust the guideline there. Maybe we could also include or reference the template and content for the PRIVACY.md that you have been using.

Best regards!