### PR TITLE
CI: activate captain hook and fix codestyle before commit

### DIFF
--- a/captainhook.json
+++ b/captainhook.json
@@ -36,7 +36,7 @@
         "conditions": []
       },
       {
-        "action": "libs/composer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --config=./CI/PHP-CS-Fixer/code-format.php_cs --using-cache=no --dry-run -vvv {$STAGED_FILES|of-type:php}",
+        "action": "libs/composer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --config=./CI/PHP-CS-Fixer/code-format.php_cs --using-cache=no -vvv {$STAGED_FILES|of-type:php}",
         "options": [],
         "conditions": [
           {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
 	},
 	"scripts": {
 		"post-autoload-dump": [
-			"php setup/cli.php build-artifacts --yes"
+			"php setup/cli.php build-artifacts --yes",
+			"libs/composer/vendor/bin/captainhook install -f"
 		],
 		"post-install-cmd": [
 			"php libs/composer/rmdirs.php"


### PR DESCRIPTION
This PR will activate the captain hooks tool.
To activate the tool, a new composer install/update run must take place.
Be aware, this will override all existing hooks.
In addition, CS fixes are executed immediately during a commit instead of just being displayed.

Thanks to @mjansenDatabay. Your video from the last DevConf about CaptainHook helpes a lot.
