### PR TITLE
UI, Mainbar: 30644 render menuitems as list, focus contents

### DIFF
--- a/src/UI/examples/Layout/Page/Standard/ui.php
+++ b/src/UI/examples/Layout/Page/Standard/ui.php
@@ -399,7 +399,17 @@ function getDemoEntryTools($f)
     $slate = $f->maincontrols()->slate()->legacy(
         'Help',
         $symbol,
-        $f->legacy('<h2>tool 1</h2><p>Some Text for Tool 1 entry</p>')
+        $f->legacy('
+            <h2>Help</h2>
+            <p>
+                Some Text for help entry
+            </p>
+            <p>
+                <button onclick="alert(\'helo - tool 1 \');">Some Dummybutton</button>
+                <br>
+                <button onclick="alert(\'helo - tool 1, button 2 \');">some other dummybutton</button>
+            </p>
+        ')
     );
     $tools['tool1'] = $slate;
 
@@ -409,7 +419,16 @@ function getDemoEntryTools($f)
     $slate = $f->maincontrols()->slate()->legacy(
         'Editor',
         $symbol,
-        $f->legacy('<h2>tool 2</h2><p>Some Text for Tool 1 entry</p>')
+        $f->legacy('
+            <h2>Editor</h2>
+            <p>
+                Some Text for editor entry
+                <br><br>
+                <button onclick="alert(\'helo\');">Some Dummybutton</button>
+                <br><br>
+                end of tool.
+            </p>
+        ')
     );
     $tools['tool2'] = $slate;
 

--- a/src/UI/examples/Layout/Page/Standard/ui_mainbar.php
+++ b/src/UI/examples/Layout/Page/Standard/ui_mainbar.php
@@ -114,7 +114,11 @@ EOT;
 function getUIContent($f, $request)
 {
     $params = $request->getQueryParams();
-    $cidx = $params['c'];
+    $cidx = -1;
+    if (array_key_exists('c', $params)) {
+        $cidx = $params['c'];
+    }
+
 
     switch ($cidx) {
         case 1:

--- a/src/UI/templates/default/MainControls/mainbar.less
+++ b/src/UI/templates/default/MainControls/mainbar.less
@@ -204,6 +204,9 @@
 	display: flex;
 	height: @il-mainbar-btn-height;
 	width: 100%;
+
+	padding: 0;
+	margin: 0;
 }
 
 // remove tools

--- a/src/UI/templates/default/MainControls/tpl.mainbar.html
+++ b/src/UI/templates/default/MainControls/tpl.mainbar.html
@@ -17,13 +17,11 @@
 
 	<div class="il-mainbar-slates">
 		<div class="il-mainbar-tools-entries">
-			<div class="il-mainbar-tools-entries-bg">
+			<ul class="il-mainbar-tools-entries-bg" role="menubar">
 				<!-- BEGIN tool_trigger_item -->
-				<div class="il-mainbar-tool-trigger-item">
-					{BUTTON}
-				</div>
+				<li class="il-mainbar-tool-trigger-item" role="none">{BUTTON}</li>
 				<!-- END tool_trigger_item -->
-			</div>
+			</ul>
 			<!-- BEGIN tool_removal -->
 			<div class="il-mainbar-remove-tool">
 				{REMOVE_TOOL}
@@ -39,6 +37,5 @@
 		</div>
 
 	</div>
-
 
 </div>

--- a/src/UI/templates/js/MainControls/dist/mainbar.js
+++ b/src/UI/templates/js/MainControls/dist/mainbar.js
@@ -94,6 +94,9 @@ var mainbar = function() {
                         state = mb.model.getState();
                         if(id in state.tools) {
                             mb.model.actions.engageTool(id);
+                            after_render = function() {
+                                mb.renderer.focusSubentry(id);
+                            };
                         }
                         if(id in state.entries) { //toggle
                             if(state.entries[id].engaged) {
@@ -932,6 +935,9 @@ var renderer = function($) {
                     .children().first()
                     .children().first();
             if(someting_to_focus_on[0]){
+                if(!someting_to_focus_on.attr('tabindex')) { //cannot focus w/o index
+                    someting_to_focus_on.attr('tabindex', '-1');
+                }
                 someting_to_focus_on[0].focus();
             }
         },

--- a/src/UI/templates/js/MainControls/src/mainbar.main.js
+++ b/src/UI/templates/js/MainControls/src/mainbar.main.js
@@ -94,6 +94,9 @@ var mainbar = function() {
                         state = mb.model.getState();
                         if(id in state.tools) {
                             mb.model.actions.engageTool(id);
+                            after_render = function() {
+                                mb.renderer.focusSubentry(id);
+                            };
                         }
                         if(id in state.entries) { //toggle
                             if(state.entries[id].engaged) {

--- a/src/UI/templates/js/MainControls/src/mainbar.renderer.js
+++ b/src/UI/templates/js/MainControls/src/mainbar.renderer.js
@@ -265,6 +265,9 @@ var renderer = function($) {
                     .children().first()
                     .children().first();
             if(someting_to_focus_on[0]){
+                if(!someting_to_focus_on.attr('tabindex')) { //cannot focus w/o index
+                    someting_to_focus_on.attr('tabindex', '-1');
+                }
                 someting_to_focus_on[0].focus();
             }
         },

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -9921,6 +9921,8 @@ footer {
   display: flex;
   height: 80px;
   width: 100%;
+  padding: 0;
+  margin: 0;
 }
 .il-mainbar-remove-tool {
   display: none;

--- a/tests/UI/Component/MainControls/MainBarTest.php
+++ b/tests/UI/Component/MainControls/MainBarTest.php
@@ -205,16 +205,25 @@ class MainBarTest extends ILIAS_UI_TestBase
                     )
             );
 
+        $toolslate = $sf->legacy('Help', $icon, new I\Legacy\Legacy('Help', new I\SignalGenerator()));
+
         $mb = $this->factory->mainBar()
             ->withAdditionalEntry('test1', $this->getButton())
             ->withAdditionalEntry('test2', $this->getButton())
-            ->withAdditionalEntry('slate', $slate);
+            ->withAdditionalEntry('slate', $slate)
+            ->withToolsButton($this->getButton())
+            ->withAdditionalToolEntry('tool1', $toolslate);
 
         $html = $r->render($mb);
 
         $expected = <<<EOT
-			<div class="il-maincontrols-mainbar" id="id_12">
+			<div class="il-maincontrols-mainbar" id="id_16">
 				<nav class="il-mainbar" aria-label="mainbar_aria_label">
+
+					<div class="il-mainbar-tools-button">
+						<button class="btn btn-bulky" id="id_14" role="menuitem"><img class="icon custom small" src="" alt=""/><span class="bulky-label">TestEntry</span></button>
+					</div>
+
 					<div class="il-mainbar-triggers">
 						<ul class="il-mainbar-entries" role="menubar" style="visibility: hidden">
 							<li role="none"><button class="btn btn-bulky" data-action="#" id="id_1" role="menuitem" ><img class="icon custom small" src="" alt=""/><span class="bulky-label">TestEntry</span></button></li>
@@ -227,7 +236,11 @@ class MainBarTest extends ILIAS_UI_TestBase
 
 				<div class="il-mainbar-slates">
 					<div class="il-mainbar-tools-entries">
-						<div class="il-mainbar-tools-entries-bg"></div>
+						<ul class="il-mainbar-tools-entries-bg" role="menubar">
+							<li class="il-mainbar-tool-trigger-item" role="none">
+								<button class="btn btn-bulky" id="id_11" role="menuitem"><img class="icon custom small" src="" alt=""/><span class="bulky-label">Help</span></button>
+							</li>
+						</ul>
 					</div>
 					<div class="il-maincontrols-slate disengaged" id="id_8" data-depth-level="1" role="menu">
 						<div class="il-maincontrols-slate-content" data-replace-marker="content">
@@ -249,11 +262,16 @@ class MainBarTest extends ILIAS_UI_TestBase
 					<div class="il-maincontrols-slate disengaged" id="id_10" data-depth-level="1" role="menu">
 						<div class="il-maincontrols-slate-content" data-replace-marker="content"></div>
 					</div>
+					
+					<div class="il-maincontrols-slate disengaged" id="id_13" data-depth-level="1" role="menu">
+						<div class="il-maincontrols-slate-content" data-replace-marker="content">Help</div>
+					</div>
+
 
 					<div class="il-mainbar-close-slates">
-						<button class="btn btn-bulky" id="id_11" >
-						    <span class="glyph" aria-label="collapse/back" role="img"><span class="glyphicon glyphicon-triangle-left" aria-hidden="true"></span></span>
-						    <span class="bulky-label">close</span></button>
+						<button class="btn btn-bulky" id="id_15" >
+							<span class="glyph" aria-label="collapse/back" role="img"><span class="glyphicon glyphicon-triangle-left" aria-hidden="true"></span></span>
+							<span class="bulky-label">close</span></button>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=30644
This renders mainbar's toolentries as ul/li lists and sets focus to their slates contents when triggered.
Screenreaders will now mention the number of tools, and tool-contents can be accessed by tabbing.
I'd be glad, though, if somebody would doublecheck on the anticipated a11y-improvement.

