### PR TITLE
UI: Mainbar/Drilldown - use DD for Mainmenu Administration

### DIFF
--- a/Services/MainMenu/classes/Provider/StandardTopItemsProvider.php
+++ b/Services/MainMenu/classes/Provider/StandardTopItemsProvider.php
@@ -6,6 +6,8 @@ use ILIAS\GlobalScreen\Identification\IdentificationInterface;
 use ILIAS\GlobalScreen\Scope\MainMenu\Provider\AbstractStaticMainMenuProvider;
 use ILIAS\MyStaff\ilMyStaffAccess;
 use ILIAS\UI\Component\Symbol\Icon\Standard;
+use ILIAS\GlobalScreen\Scope\MainMenu\Collector\Renderer\TopParentItemDrilldownRenderer;
+use ILIAS\GlobalScreen\Scope\MainMenu\Collector\Information\TypeInformation;
 
 /**
  * Class StandardTopItemsProvider
@@ -158,7 +160,8 @@ class StandardTopItemsProvider extends AbstractStaticMainMenuProvider
             ->withAvailableCallable(
                 static function () : bool {
                     return (bool) ilMyStaffAccess::getInstance()->hasCurrentUserAccessToMyStaff();
-                });
+                }
+            );
 
         $title = $f("mm_administration");
         $icon = $this->dic->ui()->factory()->symbol()->icon()->standard("adm", $title)->withIsOutlined(true);
@@ -171,6 +174,12 @@ class StandardTopItemsProvider extends AbstractStaticMainMenuProvider
             ->withPosition(70)
             ->withVisibilityCallable($this->basic_access_helper->hasAdministrationAccess());
 
+        $dd_renderer = new TopParentItemDrilldownRenderer();
+        $ti = new TypeInformation(get_class($administration), get_class($administration));
+        $ti->setRenderer($dd_renderer);
+        $administration = $administration->setTypeInformation($ti);
+
+
         return [
             $dashboard,
             $repository,
@@ -178,7 +187,7 @@ class StandardTopItemsProvider extends AbstractStaticMainMenuProvider
             $achievements,
             $communication,
             $organisation,
-            $administration,
+            $administration
         ];
     }
 

--- a/src/GlobalScreen/README.md
+++ b/src/GlobalScreen/README.md
@@ -110,3 +110,18 @@ of all available Providers in the system. E.g.:
         $this->provider_collection->setToolProvider(new ToolProvider($DIC, $this));
     }
 ```
+
+# A note on Items/TypeInformation and rendering
+Providers yield Items for a certain Scope. Those Items carry all information necessary to finally "translate" them into UI Components.
+Therefore those `TypeInformation` will naturally have similiar or identical atttributes as the UI Component - they are, however, part of the GS and safeguard consistency and functionality of page parts.
+One type of Item SHOULD result in one type of UI Component.
+
+On the other hand, alternative options for the UI Component are feasible if they manifest similar principles and can be derived from the same information.
+An example for this is the construction of a DrilldonwMenu based on ListItems, which will work fine for one level of items,
+but will not suffice for deeper structures as ListItems cannot provide those.
+
+In summary, you are generally warned about changing UI-Components for Items on GS-Provider level.
+Furthermore, your are encouraged to discuss your plans with people at the JourFixe _before_ embarking on a project.
+Finally, you MUST get the JourFix's approval for changing UI-Components for specific GS Items;
+this also holds true for changing appearance or behavior of the currently used Component.
+Probably it is best to actually create a new Item.

--- a/src/GlobalScreen/Scope/MainMenu/Collector/MainMenuMainCollector.php
+++ b/src/GlobalScreen/Scope/MainMenu/Collector/MainMenuMainCollector.php
@@ -132,7 +132,11 @@ class MainMenuMainCollector extends AbstractBaseCollector implements ItemCollect
         });*/
 
         $this->map->walk(function (isItem &$item) : isItem {
-            $item->setTypeInformation($this->getTypeInformationForItem($item));
+            if (is_null($item->getTypeInformation())) {
+                $item->setTypeInformation(
+                    $this->getTypeInformationForItem($item)
+                );
+            }
 
             // Apply the TypeHandler
             $item = $this->getTypeHandlerForItem($item)->enrichItem($item);

--- a/src/GlobalScreen/Scope/MainMenu/Collector/Renderer/BaseTypeRenderer.php
+++ b/src/GlobalScreen/Scope/MainMenu/Collector/Renderer/BaseTypeRenderer.php
@@ -31,6 +31,12 @@ class BaseTypeRenderer implements TypeRenderer
     protected $ui_factory;
 
     /**
+     * @var Renderer
+     */
+    protected $ui_renderer;
+
+
+    /**
      * BaseTypeRenderer constructor.
      */
     public function __construct()
@@ -64,10 +70,10 @@ class BaseTypeRenderer implements TypeRenderer
             return $this->getComponentWithContent($item);
         }
         $content = $this->ui_factory->legacy('...');
-        $name    = $item instanceof hasTitle ? $item->getTitle() : "-";
-        $slate   = $this->ui_factory->mainControls()->slate()->legacy($name, $this->getStandardSymbol($item), $content);
-        $slate   = $this->addAsyncLoadingCode($slate, $item);
-        $slate   = $this->addOnloadCode($slate, $item);
+        $name = $item instanceof hasTitle ? $item->getTitle() : "-";
+        $slate = $this->ui_factory->mainControls()->slate()->legacy($name, $this->getStandardSymbol($item), $content);
+        $slate = $this->addAsyncLoadingCode($slate, $item);
+        $slate = $this->addOnloadCode($slate, $item);
 
         return $slate;
     }
@@ -144,7 +150,7 @@ class BaseTypeRenderer implements TypeRenderer
     public static function getURIConverter() : \Closure
     {
         return static function (string $v) : string {
-            if(strpos($v, './') === 0) {
+            if (strpos($v, './') === 0) {
                 $v = ltrim($v, './');
                 return ILIAS_HTTP_PATH . '/' . $v;
             }

--- a/src/GlobalScreen/Scope/MainMenu/Collector/Renderer/TopParentItemDrilldownRenderer.php
+++ b/src/GlobalScreen/Scope/MainMenu/Collector/Renderer/TopParentItemDrilldownRenderer.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types=1);
+
+namespace ILIAS\GlobalScreen\Scope\MainMenu\Collector\Renderer;
+
+use ILIAS\GlobalScreen\Collector\Renderer\isSupportedTrait;
+use ILIAS\GlobalScreen\Scope\MainMenu\Factory\isItem;
+use ILIAS\UI\Component\Component;
+use ILIAS\GlobalScreen\Scope\MainMenu\Factory\AbstractChildItem;
+use ILIAS\GlobalScreen\Scope\MainMenu\Factory\Item\Link;
+use ILIAS\GlobalScreen\Scope\MainMenu\Factory\Item\LinkList;
+
+/**
+ * Render a TopItem as Drilldown (DD in Slate)
+ * @author Nils Haagen <nils.haagen@concepts-and-training.de>
+ */
+class TopParentItemDrilldownRenderer extends BaseTypeRenderer
+{
+    public function getComponentWithContent(isItem $item) : Component
+    {
+        $entries = [];
+        foreach ($item->getChildren() as $child) {
+            $entries[] = $this->buildEntry($child);
+        }
+
+        $dd = $this->ui_factory->menu()->drilldown($item->getTitle(), $entries);
+
+        $slate = $this->ui_factory->mainControls()->slate()->drilldown(
+            $item->getTitle(),
+            $this->getStandardSymbol($item),
+            $dd
+        );
+
+        return $slate;
+    }
+
+    protected function buildEntry(AbstractChildItem $item)
+    {
+        $title = $item->getTitle();
+        $symbol = $this->getStandardSymbol($item);
+        $type = get_class($item);
+
+        switch ($type) {
+
+            case Link::class:
+                $act = $this->getDataFactory()->uri(
+                    $this->getBaseURL()
+                    . '/'
+                    . $item->getAction()
+                );
+                $entry = $this->ui_factory->link()->bulky($symbol, $title, $act);
+                break;
+
+            case LinkList::class:
+                $links = [];
+                foreach ($item->getLinks() as $child) {
+                    $links[] = $this->buildEntry($child);
+                }
+                $entry = $this->ui_factory->menu()->sub($title, $links);
+                break;
+
+            default:
+                throw new \Exception("Invalid type: " . $type, 1);
+        }
+
+        return $entry;
+    }
+
+
+    protected function getDataFactory() : \ILIAS\Data\Factory
+    {
+        return new \ILIAS\Data\Factory();
+    }
+
+    private function getBaseURL() : string
+    {
+        return ILIAS_HTTP_PATH;
+    }
+}

--- a/src/GlobalScreen/Scope/MainMenu/Factory/AbstractBaseItem.php
+++ b/src/GlobalScreen/Scope/MainMenu/Factory/AbstractBaseItem.php
@@ -200,9 +200,9 @@ abstract class AbstractBaseItem implements isItem
     /**
      * @inheritDoc
      */
-    public function getTypeInformation() : TypeInformation
+    public function getTypeInformation() : ?TypeInformation
     {
-        return $this->type_information instanceof TypeInformation ? $this->type_information : new TypeInformation(get_class($this), get_class($this));
+        return $this->type_information;
     }
 
     public function isTop() : bool
@@ -211,7 +211,7 @@ abstract class AbstractBaseItem implements isItem
             return $this->getParent() instanceof NullIdentification || (int) $this->getParent()->serialize() === false;
         }
         if ($this instanceof isTopItem && $this instanceof isInterchangeableItem) {
-            return $this->getParent()===null || $this->getParent() instanceof NullIdentification;
+            return $this->getParent() === null || $this->getParent() instanceof NullIdentification;
         }
         return $this instanceof isTopItem;
     }

--- a/src/GlobalScreen/Scope/MainMenu/Factory/isItem.php
+++ b/src/GlobalScreen/Scope/MainMenu/Factory/isItem.php
@@ -84,10 +84,7 @@ interface isItem extends isGlobalScreenItem
      */
     public function setTypeInformation(TypeInformation $information) : isItem;
 
-    /**
-     * @return TypeInformation
-     */
-    public function getTypeInformation() : TypeInformation;
+    public function getTypeInformation() : ?TypeInformation;
 
     public function isTop() : bool;
 }

--- a/src/UI/Component/MainControls/Slate/Drilldown.php
+++ b/src/UI/Component/MainControls/Slate/Drilldown.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 2021 Nils Haagen <nils.haagen@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\UI\Component\MainControls\Slate;
+
+use ILIAS\UI\Component\Menu\Drilldown as DDMenu;
+
+/**
+ * This describes the Drilldown Slate
+ */
+interface Drilldown extends Slate
+{
+}

--- a/src/UI/Component/MainControls/Slate/Factory.php
+++ b/src/UI/Component/MainControls/Slate/Factory.php
@@ -125,4 +125,44 @@ interface Factory
      * @return \ILIAS\UI\Component\MainControls\Slate\Notification
      */
     public function notification(string $name, array $notification_items) : Notification;
+
+
+    /**
+     * ---
+     * description:
+     *   purpose: >
+     *     Drilldown Slates provide further menu structure in a slate.
+     *     Only one level of the (contained) menu tree is visible at a time.
+     *   composition: >
+     *     A Drilldown Slate contains exactly one Drilldown Menu.
+     *   effect: >
+     *     Same as Drilldown Menu: Clicking on a Button containing lower levels,
+     *     the Drilldown will display those.
+     *     Clicking on a leaf-Button will trigger its action.
+     *   rivals:
+     *      Combined Slates: >
+     *          Combined Slates can hold other slates and buttons, which might
+     *          give the impression of a menu; Drilldown Slates contain an actual Menu.
+     *          Therefore, they are less heterogeneous than Combined Slates but
+     *          clear and dedicated in their nature of providing a navigational
+     *          menu structure.
+     *
+     * context:
+     *   - The Drilldown Slate is used in the Main Bar.
+     *
+     * rules:
+     *   usage:
+     *     1: >
+     *       Drilldowns in Slates MUST use this component.
+     *
+     * ----
+     * @param string $name
+     * @param \ILIAS\UI\Component\Symbol\Symbol $symbol
+     * @return \ILIAS\UI\Component\MainControls\Slate\Drilldown
+     */
+    public function drilldown(
+        string $name,
+        \ILIAS\UI\Component\Symbol\Symbol $symbol,
+        \ILIAS\UI\Component\Menu\Drilldown $drilldown
+    ) : Drilldown;
 }

--- a/src/UI/Component/Menu/Factory.php
+++ b/src/UI/Component/Menu/Factory.php
@@ -44,9 +44,9 @@ interface Factory
      *          Drilldown Menus MUST contain more than one entry (Submenu or Button).
      *
      * ---
-     * @param 	string		$label
-     * @param 	array<Component\Menu\Sub | Component\Clickable| Divider\Horizontal| Divider\Horizontal> $items
-     * @return 	\ILIAS\UI\Component\Menu\Drilldown
+     * @param 	string $label
+     * @param 	array<Component\Menu\Sub | Component\Clickable| Divider\Horizontal> $items
+     * @return \ILIAS\UI\Component\Menu\Drilldown
      */
     public function drilldown(string $label, array $items) : Drilldown;
 
@@ -80,7 +80,6 @@ interface Factory
      *          or purpose of contained entries.
      *
      * ---
-     * @param 	string $label
      * @param 	array<Component\Menu\Sub | Component\Clickable| Divider\Horizontal> $items
      * @return 	\ILIAS\UI\Component\Menu\Sub
      */

--- a/src/UI/Implementation/Component/MainControls/Slate/Drilldown.php
+++ b/src/UI/Implementation/Component/MainControls/Slate/Drilldown.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 2021 Nils Haagen <nils.haagen@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+namespace ILIAS\UI\Implementation\Component\MainControls\Slate;
+
+use ILIAS\UI\Component\MainControls\Slate as ISlate;
+use ILIAS\UI\Implementation\Component\SignalGeneratorInterface;
+use ILIAS\UI\Component\Symbol\Symbol;
+use ILIAS\UI\Component\Menu\Drilldown as DrilldownMenu;
+
+/**
+ * Drilldown Slate
+ */
+class Drilldown extends Slate implements ISlate\Drilldown
+{
+    protected DrilldownMenu $drilldown;
+
+    public function __construct(
+        SignalGeneratorInterface $signal_generator,
+        string $name,
+        Symbol $symbol,
+        DrilldownMenu $drilldown
+    ) {
+        parent::__construct($signal_generator, $name, $symbol);
+        $this->drilldown = $drilldown;
+    }
+
+    public function getContents() : array
+    {
+        return [$this->drilldown];
+    }
+
+    public function withMappedSubNodes(callable $f) : self
+    {
+        return $this;
+    }
+}

--- a/src/UI/Implementation/Component/MainControls/Slate/Factory.php
+++ b/src/UI/Implementation/Component/MainControls/Slate/Factory.php
@@ -10,6 +10,7 @@ use ILIAS\UI\Implementation\Component\SignalGeneratorInterface;
 use ILIAS\UI\Component\Counter\Factory as CounterFactory;
 use ILIAS\UI\Component\Symbol\Symbol;
 use ILIAS\UI\Component\Symbol\Factory as SymbolFactory;
+use ILIAS\UI\Component\Menu\Drilldown as IDrilldownMenu;
 
 class Factory implements ISlate\Factory
 {
@@ -28,7 +29,7 @@ class Factory implements ISlate\Factory
     }
 
     /**
-     * @inheritdocs
+     * @inheritdoc
      */
     public function legacy(string $name, Symbol $symbol, ILegacy $content) : ISlate\Legacy
     {
@@ -36,7 +37,7 @@ class Factory implements ISlate\Factory
     }
 
     /**
-     * @inheritdocs
+     * @inheritdoc
      */
     public function combined(string $name, Symbol $symbol) : ISlate\Combined
     {
@@ -44,11 +45,19 @@ class Factory implements ISlate\Factory
     }
 
     /**
-     * @inheritdocs
+     * @inheritdoc
      */
     public function notification(string $name, array $notification_items) : ISlate\Notification
     {
         $notification_symbol = $this->symbol_factory->glyph()->notification();
         return new Notification($this->signal_generator, $name, $notification_items, $notification_symbol);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function drilldown(string $name, Symbol $symbol, IDrilldownMenu $drilldown) : ISlate\Drilldown
+    {
+        return new Drilldown($this->signal_generator, $name, $symbol, $drilldown);
     }
 }

--- a/src/UI/Implementation/Component/Menu/Drilldown.php
+++ b/src/UI/Implementation/Component/Menu/Drilldown.php
@@ -16,10 +16,8 @@ class Drilldown extends Menu implements IMenu\Drilldown
 {
     use JavaScriptBindable;
 
-    /**
-     * @var Signal
-     */
-    protected $signal;
+    protected Signal $signal;
+    protected ?string $persistence_id = null;
 
     /**
      * @param array <Sub|Component\Clickable|Component\Divider\Horizontal> $items
@@ -38,5 +36,20 @@ class Drilldown extends Menu implements IMenu\Drilldown
     public function getBacklinkSignal() : Signal
     {
         return $this->signal;
+    }
+
+    public function withPersistenceId(?string $id) : self
+    {
+        if (is_null($id)) {
+            return $this;
+        }
+        $clone = clone $this;
+        $clone->persistence_id = $id;
+        return $clone;
+    }
+    
+    public function getPersistenceId() : ?string
+    {
+        return $this->persistence_id;
     }
 }

--- a/src/UI/Implementation/Component/Menu/Renderer.php
+++ b/src/UI/Implementation/Component/Menu/Renderer.php
@@ -27,13 +27,20 @@ class Renderer extends AbstractComponentRenderer
         if ($component instanceof Menu\Drilldown) {
             $ui_factory = $this->getUIFactory();
             $back_signal = $component->getBacklinkSignal();
+            $persistence_id = $component->getPersistenceId();
             $glyph = $ui_factory->symbol()->glyph()->collapsehorizontal();
             $btn = $ui_factory->button()->bulky($glyph, '', '#')->withOnClick($back_signal);
             $back_button_html = $default_renderer->render($btn);
 
             $component = $component->withAdditionalOnLoadCode(
-                function ($id) use ($back_signal) {
-                    return "il.UI.menu.drilldown.init('$id', '$back_signal');";
+                function ($id) use ($back_signal, $persistence_id) {
+                    $params = "'$id', '$back_signal'";
+                    if (is_null($persistence_id)) {
+                        $params .= ", null";
+                    } else {
+                        $params .= ", '$persistence_id'";
+                    }
+                    return "il.UI.menu.drilldown.init($params);";
                 }
             );
             $id = $this->bindJavaScript($component);

--- a/src/UI/examples/MainControls/Slate/Drilldown/drilldownslate.php
+++ b/src/UI/examples/MainControls/Slate/Drilldown/drilldownslate.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace ILIAS\UI\examples\MainControls\Slate\Drilldown;
+
+use ILIAS\UI\examples\Menu\Drilldown;
+
+function drilldownslate()
+{
+    global $DIC;
+    $f = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $ico = $f->symbol()->icon()->standard('', '')->withSize('small')->withAbbreviation('+');
+    $uri = new \ILIAS\Data\URI('https://ilias.de');
+    $link = [$f->link()->bulky($ico->withAbbreviation('>'), 'Link', $uri)];
+
+    $items = [
+        $f->menu()->sub('Switzerland', [
+            $f->menu()->sub('Riverine Amphipod', $link),
+            $f->menu()->sub('Wildcat', [
+                $f->menu()->sub('European Wildcat', $link),
+                $f->menu()->sub('African Wildcat', $link)
+            ]),
+            $link[0]
+        ]),
+
+        $f->menu()->sub('Germany', [
+            $f->menu()->sub('Otter', $link),
+            $f->menu()->sub('Mole', $link),
+            $f->menu()->sub('Deer', $link)
+        ])
+    ];
+
+    $ddmenu = $f->menu()->drilldown('Animal of the year', $items);
+
+    $icon = $f->symbol()->glyph()->comment();
+    $slate = $f->maincontrols()->slate()->drilldown('drilldown example', $icon, $ddmenu);
+
+    $triggerer = $f->button()->bulky(
+        $slate->getSymbol(),
+        $slate->getName(),
+        '#'
+    )
+    ->withOnClick($slate->getToggleSignal());
+
+    return $renderer->render([
+        $triggerer,
+        $slate
+    ]);
+}

--- a/src/UI/templates/js/Menu/src/drilldown.instances.js
+++ b/src/UI/templates/js/Menu/src/drilldown.instances.js
@@ -1,0 +1,21 @@
+var drilldown = function(model, mapping, persistence, dd) {
+	var 
+	model = model,
+	mapping = mapping,
+	persistence = persistence,
+	dd = dd,
+	instances = {},
+
+	init = function(id, back_signal, persistence_id) {
+		instances[id] = new dd(model(), mapping(), persistence(persistence_id));
+		instances[id].init(id, back_signal);
+	},
+	
+	public_interface = {
+		init: init,
+		instances: instances
+    };
+    return public_interface;
+};
+
+export default drilldown;

--- a/src/UI/templates/js/Menu/src/drilldown.js
+++ b/src/UI/templates/js/Menu/src/drilldown.js
@@ -1,6 +1,8 @@
-import drilldown from './drilldown.main.js';
+import drilldown from './drilldown.instances.js';
+import dd from './drilldown.main.js';
 import ddmodel from './drilldown.model.js';
 import ddmapping from './drilldown.mapping.js';
+import ddpersistence from './drilldown.persistence.js';
 
 
 il = il || {};
@@ -8,6 +10,8 @@ il.UI = il.UI || {};
 il.UI.menu = il.UI.menu || {};
 
 il.UI.menu.drilldown = drilldown(
- 	ddmodel(),
-	ddmapping()
+ 	ddmodel,
+	ddmapping,
+	ddpersistence,
+	dd
 );

--- a/src/UI/templates/js/Menu/src/drilldown.main.js
+++ b/src/UI/templates/js/Menu/src/drilldown.main.js
@@ -1,13 +1,21 @@
-var drilldown = function(model, mapping) {
+var dd = function(model, mapping, persistence) {
 
 	var 
 	model = model,
 	mapping = mapping,
+	persistence = persistence,
+
 	init = function(id, back_signal) {
 		$(document).on(back_signal, upLevel);
 		var list = mapping.parse(id);
 		mapping.parseLevel(list, model.actions.addLevel, engageLevel);
-		engageLevel(0);
+
+		var level = persistence.read();
+		if(!level) {
+			level = 0;
+		}
+
+		engageLevel(level);
 	},
 	engageLevel = function(id) {
 		model.actions.engageLevel(id);
@@ -17,22 +25,19 @@ var drilldown = function(model, mapping) {
 		model.actions.upLevel();
 		apply();
 	},
-
 	apply = function() {
-		var current = model.actions.getCurrent(),
-			idx;
-		for(idx in model.data) {
-			mapping.unsetEngaged(model.data[idx].id);
-		}
+		var current = model.actions.getCurrent();
 		mapping.setEngaged(current.id);
+		persistence.store(current.id);
 		mapping.setHeaderTitle(current.label);
 		mapping.setHeaderBacknav(current.parent != null);
 	},
 
 	public_interface = {
-		init: init
+		init: init,
+		engage: engageLevel
     };
     return public_interface;
 };
 
-export default drilldown;
+export default dd;

--- a/src/UI/templates/js/Menu/src/drilldown.mapping.js
+++ b/src/UI/templates/js/Menu/src/drilldown.mapping.js
@@ -33,7 +33,7 @@ var ddmapping = function() {
             },
             getLabelForList = function(list) {
                 var btn = list.parentElement.querySelector(classes.BUTTON); 
-                return btn.innerText;   
+                return btn.childNodes[0].nodeValue;     
             },
             getParentIdOfList = function(list) {
                 var parent = list.parentElement.parentElement;
@@ -69,12 +69,16 @@ var ddmapping = function() {
             }
             elements.levels[id].parentElement.querySelector(classes.BUTTON)
                 .classList.add(classes.ACTIVE);
-            //focus first entry            
-            lower = elements.levels[id].children[0].children[0]
-            lower.focus();
+            
+             try { //cannot access children in mocha/jsdom
+                lower = elements.levels[id].children[0].children[0]
+                lower.focus();
+            }
+            catch (e) {
+            }
         },
         setHeaderTitle : function(title) {
-            elements.header_title.innerText = title;
+            elements.header_title.innerHTML = title;
         },
         setHeaderBacknav : function(status) {
             if(status) {

--- a/src/UI/templates/js/Menu/src/drilldown.model.js
+++ b/src/UI/templates/js/Menu/src/drilldown.model.js
@@ -29,6 +29,9 @@ var ddmodel = function() {
             data[level.id] = level;
             return level;
         },
+        /**
+         * @param  {String} id
+         */
         engageLevel : function(id) {
             for(var idx in data) {
                 data[idx].engaged = false;

--- a/src/UI/templates/js/Menu/src/drilldown.persistence.js
+++ b/src/UI/templates/js/Menu/src/drilldown.persistence.js
@@ -1,0 +1,34 @@
+var ddpersistence = function(dd_id) {
+    var cs = null,
+        dd_id,
+        key = 'level_id',
+
+    storage = function() {
+        if (cs && dd_id !== null) { return cs; }
+        return new il.Utilities.CookieStorage(dd_id);
+    },
+
+    store = function(level_id) {
+        cs = storage();
+        if(cs) {
+            cs.add(key, level_id);
+            cs.store();
+        }
+    },
+
+    read = function() {
+        cs = storage();
+        if (!cs) {
+            return null;
+        }
+        return cs.items[key];
+    },
+
+    public_interface = {
+        read: read,
+        store: store
+    };
+    return public_interface;
+};
+
+export default ddpersistence;

--- a/tests/UI/Component/MainControls/Slate/DrilldownSlateTest.php
+++ b/tests/UI/Component/MainControls/Slate/DrilldownSlateTest.php
@@ -1,0 +1,102 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 2021 Nils Haagen <nils.haagen@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+require_once("libs/composer/vendor/autoload.php");
+require_once(__DIR__ . "/../../../Base.php");
+
+use ILIAS\UI\Component as C;
+use ILIAS\UI\Implementation\Component as I;
+use ILIAS\UI\Implementation\Component\MainControls\Slate\Drilldown;
+
+/**
+ * Tests for the DrilldownSlate.
+ */
+class DrilldownSlateTest extends ILIAS_UI_TestBase
+{
+    public function getUIFactory() : NoUIFactory
+    {
+        return new class extends NoUIFactory {
+            protected function getSigGen()
+            {
+                return new I\SignalGenerator();
+            }
+
+            public function menu() : C\Menu\Factory
+            {
+                return new I\Menu\Factory($this->getSigGen());
+            }
+
+            public function symbol() : C\Symbol\Factory
+            {
+                return new I\Symbol\Factory(
+                    new I\Symbol\Icon\Factory(),
+                    new I\Symbol\Glyph\Factory(),
+                    new I\Symbol\Avatar\Factory()
+                );
+            }
+
+            public function mainControls() : C\MainControls\Factory
+            {
+                $slate_factory = new I\MainControls\Slate\Factory(
+                    $this->getSigGen(),
+                    new I\Counter\Factory(),
+                    $this->symbol()
+                );
+                return new I\MainControls\Factory($this->getSigGen(), $slate_factory);
+            }
+
+            public function button() : C\Button\Factory
+            {
+                return new I\Button\Factory();
+            }
+        };
+    }
+
+    public function testImplementsFactoryInterface() : Drilldown
+    {
+        $f = $this->getUIFactory();
+        $slate = $f->mainControls()->slate()->drilldown(
+            "ddslate",
+            $f->symbol()->icon()->custom('', ''),
+            $f->menu()->drilldown('ddmenu', [])
+        );
+        $this->assertInstanceOf("ILIAS\\UI\\Component\\MainControls\\Slate\\Drilldown", $slate);
+        return $slate;
+    }
+
+    /**
+     * @depends testImplementsFactoryInterface
+     */
+    public function testRendering(Drilldown $slate) : void
+    {
+        $r = $this->getDefaultRenderer();
+        $html = $r->render($slate);
+
+        $expected = '
+
+            <div class="il-maincontrols-slate disengaged" id="id_3">
+                <div class="il-maincontrols-slate-content" data-replace-marker="content">
+                    <div class="il-drilldown" id="id_2">
+
+                        <header class="show-title show-backnav">
+                            <h2>ddmenu</h2>
+                            <div class="backnav">
+                                <button class="btn btn-bulky" id="id_1"><span class="glyph" aria-label="collapse/back" role="img"><span class="glyphicon glyphicon-triangle-left" aria-hidden="true"></span></span><span class="bulky-label"></span></button>
+                            </div>
+                        </header>
+                        <ul>
+                            <li><button class="menulevel" aria-expanded="false">ddmenu<span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span></button>
+                                <ul></ul>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        ';
+        $this->assertEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($html)
+        );
+    }
+}

--- a/tests/UI/Component/Menu/Drilldown/DrilldownTest.php
+++ b/tests/UI/Component/Menu/Drilldown/DrilldownTest.php
@@ -77,6 +77,8 @@ class DrilldownTest extends ILIAS_UI_TestBase
             $menu
         );
 
+        $menu = $f->menu()->drilldown('root', []);
+
         return $menu;
     }
 
@@ -131,48 +133,40 @@ class DrilldownTest extends ILIAS_UI_TestBase
     /**
      * @depends testWithEntries
      */
-    public function testRendering(C\Menu\Drilldown $menu) : void
+    public function testRendering() : void
     {
         $r = $this->getDefaultRenderer();
+        $f = $this->getUIFactory();
+
+        $items = [
+            $f->menu()->sub('1', [
+                $f->menu()->sub('1.1', []),
+                $f->menu()->sub('1.2', []),
+            ]),
+            $f->menu()->sub('2', [])
+        ];
+        $menu = $f->menu()->drilldown('root', $items);
+
         $html = $r->render($menu);
-        $expected = <<<EOT
-<div class="il-drilldown" id="id_2"> 
-    <header class="show-title show-backnav"> 
-        <h2>root</h2> 
-        <div class="backnav">
-            <button class="btn btn-bulky" id="id_1" ><span class="glyph" aria-label="collapse/back" role="img"><span class="glyphicon glyphicon-triangle-left" aria-hidden="true"></span></span><span class="bulky-label"></span></button>
-        </div> 
-    </header>
-    <ul> 
-        <li> 
-            <button class="menulevel" aria-expanded="false">root<span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span></button>
-            <ul>
-                <li> 
-                    <button class="menulevel" aria-expanded="false">sub<span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span></button>
-                    <ul>
-                        <li>
-                            <button class="btn btn-default" data-action=""></button>
-                        </li>
-                        <li>
-                            <a class="glyph" href="" aria-label="show_who_is_online"><span class="glyphicon glyphicon-user" aria-hidden="true"></span></a>
-                        </li>
-                    </ul>
-                </li>
-                <li>
-                    <hr />
-                </li>
-                <li>
-                    <button class="btn btn-default" data-action=""></button>
-                </li>
-            </ul> 
-        </li> 
-    </ul>
-</div>
-EOT;
+        $expected = file_get_contents(__DIR__ . "/drilldown_test.html");
 
         $this->assertEquals(
             $this->brutallyTrimHTML($expected),
             $this->brutallyTrimHTML($html)
+        );
+    }
+
+    /**
+     * @depends testConstruction
+     */
+    public function testWithPersistenceId($menu)
+    {
+        $this->assertNull($menu->getPersistenceId()) ;
+
+        $id = "some_id";
+        $this->assertEquals(
+            $id,
+            $menu->withPersistenceId($id)->getPersistenceId()
         );
     }
 }

--- a/tests/UI/Component/Menu/Drilldown/drilldown_test.html
+++ b/tests/UI/Component/Menu/Drilldown/drilldown_test.html
@@ -1,0 +1,35 @@
+<div class="il-drilldown" id="id_2"> 
+    
+    <header class="show-title show-backnav"> 
+        <h2>root</h2> 
+        <div class="backnav">
+            <button class="btn btn-bulky" id="id_1" ><span class="glyph" aria-label="collapse/back" role="img"><span class="glyphicon glyphicon-triangle-left" aria-hidden="true"></span></span><span class="bulky-label"></span></button>
+        </div> 
+    </header>
+
+    <ul>
+        <li>
+            <button class="menulevel" aria-expanded="false">root<span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span></button>
+            <ul>
+                <li>
+                    <button class="menulevel" aria-expanded="false">1<span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span></button>
+                    <ul>
+                        <li>
+                            <button class="menulevel" aria-expanded="false">1.1<span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span></button>
+                            <ul></ul>
+                        </li>
+                        <li>
+                            <button class="menulevel" aria-expanded="false">1.2<span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span></button>
+                            <ul></ul>
+                        </li>
+                    </ul>
+                </li>
+                <li>
+                    <button class="menulevel" aria-expanded="false">2<span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span></button>
+                    <ul></ul>
+                </li>
+            </ul>
+        </li>
+    </ul>
+
+</div>


### PR DESCRIPTION
This renders the mainbar's administration menu as drilldown.

- UI/Menu Drilldown with multiple instances (was buggy before, sorry)
- make instances and engageLevel available externally
- use CookieStorage for DD-persistence
- TopParentItemDrilldownRenderer
- introduces [DrilldownSlate](https://github.com/ILIAS-eLearning/ILIAS/pull/3726/files#diff-f8a1e6c4212102c1cae91939d22ba208e085092c371d020a8d1af3878e265a62R131-R166)

![dd1](https://user-images.githubusercontent.com/3328364/140053873-43e0a813-e619-41e2-a4c5-bca2f53d7ca6.png)
![dd2](https://user-images.githubusercontent.com/3328364/140053884-213e6487-c465-4241-8798-532d0f42c2bc.png)


