### PR TITLE
Mantis 31346: Add missing $

### DIFF
--- a/Services/Language/classes/class.ilObjLanguageExtGUI.php
+++ b/Services/Language/classes/class.ilObjLanguageExtGUI.php
@@ -408,7 +408,7 @@ class ilObjLanguageExtGUI extends ilObjectGUI
 	    $changesSuccessBool = 1;
 
         // view the list
-        $this->viewObject(changesSuccessBool);
+        $this->viewObject($changesSuccessBool);
     }
 
 


### PR DESCRIPTION
This PR fixes:

https://mantis.ilias.de/view.php?id=31346

but actually this variable is not needed in the first place, but i didnt want to make huge changes. 