### PR TITLE
fixed #31401: Special Charactors in Tests don`t work

### DIFF
--- a/Services/UIComponent/CharSelector/js/ilCharSelector.js
+++ b/Services/UIComponent/CharSelector/js/ilCharSelector.js
@@ -413,7 +413,7 @@ il.CharSelector = new function() {
 		
 		// special handling of tinyMCE
 		if (element.tagName.toLowerCase() == 'iframe') {
-			if ($(element).parent().hasClass('mceIframeContainer')) {
+			if ($(element).parent().hasClass('tox-edit-area')) {
 				tinymce.activeEditor.execCommand('mceInsertContent', false, char);
 				return;
 			}


### PR DESCRIPTION
The problem is only related to the new TinyMCE version in ILIAS 7. The solution works for the question presentation of essay questions in a test as well as for the rich text fields in the question editor. 

Please note: If you open the selector from the actions menu of a test question in a test run, you must once click into the text field afterwards. Then the chars can be added at the current editing postion.