### PR TITLE
Proposal/8/headers in files

### DIFF
--- a/CI/Rector/ChangeLicenseHeader.php
+++ b/CI/Rector/ChangeLicenseHeader.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace ILIAS\CI\Rector;
+
+use PhpParser\Node;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use PhpParser\Comment;
+
+final class ChangeLicenseHeader extends AbstractRector
+{
+    const EXISTING_LICENSE_PATTERN = '(copyright|Copyright|GPL-3\.0|GPLv3|LICENSE)';
+    const IGNORE_SUBPATHS = '(lib|vendor|CI|data|Customizing)';
+    private $license_header_default = "/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/";
+
+    private Comment $standard_comment;
+
+    public function __construct()
+    {
+        $this->standard_comment = new Comment($this->license_header_default);
+    }
+
+    public function getNodeTypes() : array
+    {
+        return [
+            Node\Stmt\Use_::class,
+            Node\Stmt\Class_::class,
+            Node\Expr\Include_::class
+        ];
+    }
+
+    /**
+     * @param Node\Stmt\Global_ $node
+     */
+    public function refactor(Node $node) : ?Node
+    {
+        if (preg_match(self::IGNORE_SUBPATHS, $this->file->getSmartFileInfo()->getPathname()) > 0) {
+            return $node;
+        }
+
+        switch (true) {
+            case $node instanceof Node\Stmt\Use_:
+            case $node instanceof Node\Expr\Include_:
+                $node->setAttribute('comments', $this->filterComments($node));
+                return $node;
+            case $node instanceof Node\Stmt\Class_:
+                $node->setAttribute('comments', $this->filterComments($node, [$this->standard_comment]));
+                return $node;
+            default:
+                return $node;
+        }
+
+    }
+
+    /**
+     * @param Node $node
+     * @return Comment[]
+     */
+    private function filterComments(Node $node, array $default = []) : array
+    {
+        foreach ($node->getComments() as $comment) {
+            if (preg_match(self::EXISTING_LICENSE_PATTERN, $comment->getText()) > 0) {
+                continue;
+            }
+            $default[] = $comment;
+        }
+        return $default;
+    }
+
+    public function getRuleDefinition() : RuleDefinition
+    {
+        return new RuleDefinition(
+            'Adds or replaces a license-header in each class-file', [
+                new CodeSample(
+                    // code before
+                    '',
+                    // code after
+                    ''
+                ),
+            ]
+        );
+    }
+}

--- a/CI/Rector/rector.php
+++ b/CI/Rector/rector.php
@@ -18,20 +18,22 @@ return static function (ContainerConfigurator $containerConfigurator) : void {
     // We need the parameters to set e.g. the language level of PHP
     $parameters = $containerConfigurator->parameters();
     $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_74);
-    
+
     // get services (needed for register a single rule)
     $services = $containerConfigurator->services();
-    
+
     // We start with a single and sinle (own) rule. remove requires and include.
     $services->set(\ILIAS\CI\Rector\RemoveRequiresAndIncludesRector::class);
-    
+    // The second rule will add (or replace) e license-header for every class-file
+    $services->set(\ILIAS\CI\Rector\ChangeLicenseHeader::class);
+
     // After that, you can try to introduce TypeDeclarations in your component
     // $containerConfigurator->import(SetList::TYPE_DECLARATION);
-    
+
     // This SetList intricuces some changes concerning PHP7.4,
     // see libs/composer/vendor/rector/rector/config/set/php74.php for more details.
     $containerConfigurator->import(SetList::PHP_74);
-    
+
     // You can introduce or modify visibilities of constants and/or methods with there rectors:
     // $services->set(ChangeConstantVisibilityRector::class);
     // $services->set(ChangeMethodVisibilityRector::class);


### PR DESCRIPTION
We looked for a mechanism to add a standard-license-header to every file of our code-base (and a mechanism to update those comments if needed). With PHPRector (already in trunk) we developed a Rector which can do that with some restrictions:
- only existing comments above or beneath reuires/use statements and/or above a class definition are removed with string containing (copyright|Copyright|GPL-3\.0|GPLv3|LICENSE)
- if there are directories which must be excluded, the list in (lib|vendor|CI|data|Customizing) must be adopted
- if a file has two class-definitions in it, two license headers will be added (such files should not exists but there are some...)
- there can be false positives, use with care

with the current rector.php in CI/Rector you can run it for a directory with:

./libs/composer/vendor/bin/rector process --config ./CI/Rector/rector.php Modules/LTIConsumer