### PR TITLE
UIComponent: Fix 'Access key function ids are integers not strings'

### DIFF
--- a/Services/UIComponent/Button/classes/class.ilButtonBase.php
+++ b/Services/UIComponent/Button/classes/class.ilButtonBase.php
@@ -29,7 +29,7 @@ abstract class ilButtonBase implements ilToolbarItem
     protected bool $primary = false; // [bool]
     protected bool $omit_prevent_double_submission = false; // [bool]
     protected string $onclick = ""; // [string]
-    protected string $acc_key = ""; // [string]
+    protected int $acc_key = 0;
     protected bool $disabled = false; // [bool]
     protected array $css = array(); // [array]
     protected bool $apply_default_css = true;
@@ -131,12 +131,12 @@ abstract class ilButtonBase implements ilToolbarItem
         return $this->onclick;
     }
     
-    public function setAccessKey(string $a_value) : void
+    public function setAccessKey(int $a_value) : void
     {
-        $this->acc_key = trim($a_value);
+        $this->acc_key = $a_value;
     }
     
-    public function getAccessKey() : string
+    public function getAccessKey() : int
     {
         return $this->acc_key;
     }

--- a/Services/UIComponent/Toolbar/classes/class.ilToolbarGUI.php
+++ b/Services/UIComponent/Toolbar/classes/class.ilToolbarGUI.php
@@ -114,7 +114,7 @@ class ilToolbarGUI
         string $a_txt,
         string $a_cmd,
         string $a_target = "",
-        string $a_acc_key = "",
+        ?int $a_acc_key = null,
         string $a_additional_attrs = '',
         string $a_id = "",
         string $a_class = 'submit'
@@ -130,7 +130,7 @@ class ilToolbarGUI
     public function addFormButton(
         string $a_txt,
         string $a_cmd,
-        string $a_acc_key = "",
+        ?int $a_acc_key = null,
         bool $a_primary = false,
         ?string $a_class = null
     ) : void {
@@ -139,7 +139,9 @@ class ilToolbarGUI
             $button->setPrimary(true);
             $button->setCaption($a_txt, false);
             $button->setCommand($a_cmd);
-            $button->setAccessKey($a_acc_key);
+            if ($a_acc_key !== null) {
+                $button->setAccessKey($a_acc_key);
+            }
             $this->addStickyItem($button);
         } else {
             $this->items[] = array("type" => "fbutton", "txt" => $a_txt, "cmd" => $a_cmd,
@@ -337,7 +339,7 @@ class ilToolbarGUI
                             if ($item["id"] != "") {
                                 $tpl_items->setVariable("BID", 'id="' . $item["id"] . '"');
                             }
-                            if ($item["acc_key"] != "") {
+                            if ($item["acc_key"] > 0) {
                                 $tpl_items->setVariable(
                                     "BTN_ACC_KEY",
                                     ilAccessKeyGUI::getAttribute($item["acc_key"])
@@ -508,8 +510,8 @@ class ilToolbarGUI
      */
     protected function applyAutoStickyToSingleElement() : void
     {
-        if (count($this->items) == 1 && count($this->sticky_items) == 0) {
-            $supported_types = array('button', 'fbutton', 'button_obj');
+        if (count($this->items) === 1 && count($this->sticky_items) === 0) {
+            $supported_types = ['button', 'fbutton', 'button_obj'];
             $item = $this->items[0];
             if (!in_array($item['type'], $supported_types)) {
                 return;
@@ -524,7 +526,9 @@ class ilToolbarGUI
                     $button->setPrimary($item['primary']);
                     $button->setCaption($item['txt'], false);
                     $button->setCommand($item['cmd']);
-                    $button->setAccessKey($item['acc_key']);
+                    if ($item['acc_key'] !== null) {
+                        $button->setAccessKey($item['acc_key']);
+                    }
                     break;
                 case 'button':
                     $button = ilLinkButton::getInstance();
@@ -532,11 +536,13 @@ class ilToolbarGUI
                     $button->setUrl($item['cmd']);
                     $button->setTarget($item['target']);
                     $button->setId($item['id']);
-                    $button->setAccessKey($item['acc_key']);
+                    if ($item['acc_key'] !== null) {
+                        $button->setAccessKey($item['acc_key']);
+                    }
                     break;
             }
             $this->addStickyItem($button);
-            $this->items = array();
+            $this->items = [];
         }
     }
 }


### PR DESCRIPTION
`Access Keys` are constants of type `integer`, see: `ilAccessKey`

Currently (latest trunk revision) these constants are passed to `Legacy Buttons` or `Toolbars Buttons` by consumers, but these classes expect arguments of type `string`.