### PR TITLE
JS, Forms: 'softer' use of  global; fix broken tests

### DIFF
--- a/Services/Form/classes/class.ilFormPropertyGUI.php
+++ b/Services/Form/classes/class.ilFormPropertyGUI.php
@@ -45,7 +45,7 @@ class ilFormPropertyGUI
     protected ?Refinery\Factory $refinery = null;
     protected bool $disabled = false;
 
-    protected ilGlobalPageTemplate $global_tpl;
+    protected ?ilGlobalTemplateInterface $global_tpl = null;
 
     public function __construct(
         string $a_title = "",
@@ -70,7 +70,9 @@ class ilFormPropertyGUI
         if (isset($DIC["http"])) {      // some unit tests will fail otherwise
             $this->request = $DIC->http()->request();
         }
-        $this->global_tpl = $DIC['tpl'];
+        if (isset($DIC["tpl"])) {      // some unit tests will fail otherwise
+            $this->global_tpl = $DIC['tpl'];
+        }
     }
 
     /**

--- a/Services/Form/classes/class.ilPropertyFormGUI.php
+++ b/Services/Form/classes/class.ilPropertyFormGUI.php
@@ -49,7 +49,7 @@ class ilPropertyFormGUI extends ilFormGUI
     protected HTTP\Services $http;
     protected ?Refinery\Factory $refinery = null;
 
-    protected ilGlobalPageTemplate $global_tpl;
+    protected ?ilGlobalTemplateInterface $global_tpl = null;
 
     public function __construct()
     {
@@ -84,8 +84,9 @@ class ilPropertyFormGUI extends ilFormGUI
         if (isset($DIC["refinery"])) {
             $this->refinery = $DIC->refinery();
         }
-
-        $this->global_tpl = $DIC['tpl'];
+        if (isset($DIC["tpl"])) {      // some unit tests will fail otherwise
+            $this->global_tpl = $DIC['tpl'];
+        }
     }
 
     /**
@@ -760,10 +761,12 @@ class ilPropertyFormGUI extends ilFormGUI
             if ($item->getType() != "non_editable_value" or 1) {
                 $sf = $item->getSubForm();
                 if ($item->hideSubForm() && is_object($sf)) {
-                    $dsfid = $item->getFieldId();
-                    $this->global_tpl->addOnloadCode(
-                        "il.Form.hideSubForm('subform_$dsfid');"
-                    );
+                    if ($this->global_tpl) {
+                        $dsfid = $item->getFieldId();
+                        $this->global_tpl->addOnloadCode(
+                            "il.Form.hideSubForm('subform_$dsfid');"
+                        );
+                    }
                 }
             }
             

--- a/Services/Form/classes/class.ilRadioGroupInputGUI.php
+++ b/Services/Form/classes/class.ilRadioGroupInputGUI.php
@@ -118,10 +118,12 @@ class ilRadioGroupInputGUI extends ilSubEnabledFormPropertyGUI implements ilTabl
             if (count($option->getSubItems()) > 0) {
                 if ($option->getValue() != $this->getValue()) {
                     // #10930
-                    $hop_id = $this->getFieldId() . "_" . $option->getValue();
-                    $this->global_tpl->addOnloadCode(
-                        "il.Form.hideSubForm('subform_$hop_id');"
-                    );
+                    if ($this->global_tpl) {
+                        $hop_id = $this->getFieldId() . "_" . $option->getValue();
+                        $this->global_tpl->addOnloadCode(
+                            "il.Form.hideSubForm('subform_$hop_id');"
+                        );
+                    }
                 }
                 $tpl->setCurrentBlock("radio_option_subform");
                 $pf = new ilPropertyFormGUI();


### PR DESCRIPTION
https://github.com/ILIAS-eLearning/ILIAS/pull/3755 broke a lot of tests (sorry for that).
This allows for "tpl" to be not available in global $DIC and checks before adding JS - that would be useless anyways in a scenario w/o template, right?