### PR TITLE
Administration: Fix expected type of in ilAdministrationSettingsFormH…

### DIFF
--- a/Services/Administration/classes/class.ilAdministrationSettingsFormHandler.php
+++ b/Services/Administration/classes/class.ilAdministrationSettingsFormHandler.php
@@ -205,7 +205,7 @@ class ilAdministrationSettingsFormHandler
     }
     
     protected static function parseFieldDefinition(
-        int $a_type,
+        string $a_type,
         ilPropertyFormGUI $a_form,
         ilObjectGUI $a_gui,
         $a_data


### PR DESCRIPTION
…andler::parseFieldDefinition

All `SETTINGS_USER_*` constants are of type `string`.