### PR TITLE
Tree: Fix wrong tree root id fallback in constructor

### DIFF
--- a/Services/Tree/classes/class.ilTree.php
+++ b/Services/Tree/classes/class.ilTree.php
@@ -142,7 +142,7 @@ class ilTree
             throw new InvalidArgumentException("Wrong parameter count!");
         }
 
-        if (!$a_root_id) {
+        if ($a_root_id > 0) {
             $this->root_id = $a_root_id;
         } else {
             $this->root_id = ROOT_FOLDER_ID;


### PR DESCRIPTION
This PR fixes a major (and silent) issue of setting the `root` ID of main tree to `0`, which leads to a lot of problems (e.g. with RBAC).