### PR TITLE
Fix Glossary Print Presentation

### DIFF
--- a/Modules/Glossary/Presentation/class.ilGlossaryPresentationGUI.php
+++ b/Modules/Glossary/Presentation/class.ilGlossaryPresentationGUI.php
@@ -572,7 +572,7 @@ class ilGlossaryPresentationGUI
         $def_tpl = new ilTemplate("tpl.glossary_definition_list.html", true, true, "Modules/Glossary");
 
         $defs = ilGlossaryDefinition::getDefinitionList($term_id);
-        $tpl->setVariable("TXT_TERM", $term->getTerm());
+        $def_tpl->setVariable("TXT_TERM", $term->getTerm());
         $this->mobs = array();
 
         // toc


### PR DESCRIPTION
This fixes the issue with missing titles in the Glossary Print View:

https://mantis.ilias.de/view.php?id=31593