### PR TITLE
switch to collectOnce

### DIFF
--- a/Services/Help/classes/class.ilHelpGUI.php
+++ b/Services/Help/classes/class.ilHelpGUI.php
@@ -621,7 +621,7 @@ class ilHelpGUI
 
         $mmc = $DIC->globalScreen()->collector()->mainmenu();
         if ($this->raw_menu_items == null) {
-            $mmc->collectStructure();
+            $mmc->collectOnce();
             $this->raw_menu_items = iterator_to_array($mmc->getRawItems());
         }
 


### PR DESCRIPTION
this is a small perfomance improvement with activated help. collectOnce prevents from pulling the GS-items of the mainmenu more than once.