### PR TITLE
ilPasswordInputGUI:: var $retypevalue requires initialization

### DIFF
--- a/Services/Form/classes/class.ilPasswordInputGUI.php
+++ b/Services/Form/classes/class.ilPasswordInputGUI.php
@@ -31,7 +31,7 @@ class ilPasswordInputGUI extends ilSubEnabledFormPropertyGUI
      * @var bool Flag whether the html autocomplete attribute should be set to "off" or not
      */
     protected bool $autocomplete_disabled = true;
-    protected string $retypevalue;
+    protected string $retypevalue = "";
     protected bool $retype;
 
     public function __construct(


### PR DESCRIPTION
When logging in as root for the very first time, the dialog for the mandatory password change is about to be shown - but ends up in a sequence of 10 similar execptions complaining about the same issue:

[978n6] [2021-11-16 10:43:11.379261] trunk8_root.ERROR: Whoops\Handler\CallbackHandler::handle:370 0 Typed property ilPasswordInputGUI::$retypevalue must not be accessed before initialization in /xxx/trunk8/Services/Form/classes/class.ilPasswordInputGUI.php:77#0 /xxx/trunk8/Services/Form/classes/class.ilPasswordInputGUI.php(245): ilPasswordInputGUI->getRetypeValue()
#1 /xxx/trunk8/Services/Form/classes/class.ilPasswordInputGUI.php(287): ilPasswordInputGUI->render()
#2 /xxx/trunk8/Services/Form/classes/class.ilPropertyFormGUI.php(665): ilPasswordInputGUI->insert()
#3 /xxx/trunk8/Services/Form/classes/class.ilPropertyFormGUI.php(560): ilPropertyFormGUI->insertItem()
#4 /xxx/trunk8/Services/Form/classes/class.ilFormGUI.php(126): ilPropertyFormGUI->getContent()
#5 /xxx/trunk8/Services/Form/classes/class.ilPropertyFormGUI.php(798): ilFormGUI->getHTML()
#6 /xxx/trunk8/Services/User/Settings/classes/class.ilPersonalSettingsGUI.php(197): ilPropertyFormGUI->getHTML()
#7 /xxx/trunk8/Services/User/Settings/classes/class.ilPersonalSettingsGUI.php(79): ilPersonalSettingsGUI->showPassword()
#8 /xxx/trunk8/Services/UICore/classes/class.ilCtrl.php(215): ilPersonalSettingsGUI->executeCommand()
#9 /xxx/trunk8/Services/Dashboard/classes/class.ilDashboardGUI.php(122): ilCtrl->forwardCommand()
#10 /xxx/trunk8/Services/UICore/classes/class.ilCtrl.php(215): ilDashboardGUI->executeCommand()
#11 /xxx/trunk8/Services/UICore/classes/class.ilCtrl.php(176): ilCtrl->forwardCommand()
#12 /xxx/trunk8/ilias.php(19): ilCtrl->callBaseClass()
#13 {main}