### PR TITLE
ilDBUpdate:: values for [settings] MUST be strictly of type 'string'

### DIFF
--- a/Services/Database/classes/class.ilDBUpdate.php
+++ b/Services/Database/classes/class.ilDBUpdate.php
@@ -125,7 +125,7 @@ class ilDBUpdate
     public function setCurrentVersion(int $a_version) : void
     {
         $set = new ilSetting("common", true);
-        $set->set("db_version", $a_version);
+        $set->set("db_version", (string) $a_version);
         $this->currentVersion = $a_version;
     }
 
@@ -136,7 +136,7 @@ class ilDBUpdate
     public function setRunningStatus(int $a_nr) : void
     {
         $set = new ilSetting("common", true);
-        $set->set("db_update_running", $a_nr);
+        $set->set("db_update_running", (string) $a_nr);
         $this->db_update_running = $a_nr;
     }
 
@@ -158,7 +158,7 @@ class ilDBUpdate
     public function clearRunningStatus() : void
     {
         $set = new ilSetting("common", true);
-        $set->set("db_update_running", 0);
+        $set->set("db_update_running", "0");
         $this->db_update_running = 0;
     }
 
@@ -607,7 +607,7 @@ class ilDBUpdate
     public function setCustomUpdatesCurrentVersion(?int $a_version) : bool
     {
         $this->readCustomUpdatesInfo();
-        $this->custom_updates_setting->set('db_version_custom', $a_version);
+        $this->custom_updates_setting->set('db_version_custom', (string) $a_version);
         $this->custom_updates_current_version = $a_version;
 
         return true;


### PR DESCRIPTION
(v8.0alpha)
Otherwise TypeErrors during 'setup.php install' aborts processing of the install command:

PHP Fatal error:  Uncaught TypeError: Argument 2 passed to ilSetting::set() must be of the type string, int given, called in /xxx/trunk8/Services/Database/classes/class.ilDBUpdate.php on line 139 and defined in /xxx/trunk8/Services/Administration/classes/class.ilSetting.php:147
Stack trace:
#0 /xxx/trunk8/Services/Database/classes/class.ilDBUpdate.php(139): ilSetting->set()
#1 /xxx/trunk8/Services/Database/classes/class.ilDBUpdate.php(339): ilDBUpdate->setRunningStatus()
#2 /xxx/trunk8/Services/Database/classes/class.ilDBUpdate.php(299): ilDBUpdate->applyUpdateNr()
#3 /xxx/trunk8/Services/Database/classes/Setup/class.ilDatabaseUpdatedObjective.php(120): ilDBUpdate->applyUpdate()
#4 /xxx/trunk8/src/Setup/CLI/ObjectiveHelper.php(34): ilDatabaseUpdatedObjective->achieve()
#5 /xxx/trunk8/src/Set in /xxx/trunk8/Services/Administration/classes/class.ilSetting.php on line 147