### PR TITLE
UI/Mainbar: trigger in_view for fully engaged path only, store loaded…

### DIFF
--- a/src/UI/templates/js/MainControls/dist/mainbar.js
+++ b/src/UI/templates/js/MainControls/dist/mainbar.js
@@ -424,6 +424,21 @@ var model = function() {
                 }
             }
             return null;
+        },
+        isInView : function (entry_id) {
+            if(!state.entries[entry_id]) { //tools
+                return true;
+            }
+            var hops = entry_id.split(':'),
+                entries = state.entries;
+            while (hops.length > 1) {
+                entry_id = hops.join(':');
+                if(!state.entries[entry_id].engaged) {
+                    return false;
+                }
+                hops.pop();
+            }
+            return true;
         }
     },
     actions = {
@@ -536,7 +551,8 @@ var model = function() {
         actions: actions,
         getState: () => factories.cloned(state),
         setState: factories.state,
-        getTopLevelEntries: helpers.getTopLevelEntries
+        getTopLevelEntries: helpers.getTopLevelEntries,
+        isInView: helpers.isInView
     },
     init = function() {
         state = factories.cloned(classes.bar);
@@ -682,6 +698,8 @@ var renderer = function($) {
     },
 
     dom_references = {},
+    dom_ref_to_element = {},
+    thrown_for = {},
     dom_element = {
         withHtmlId: function (html_id) {
             return Object.assign({}, this, {html_id: html_id});
@@ -691,16 +709,11 @@ var renderer = function($) {
             return $('#' + this.html_id);
         },
         engage: function() {
-            var element = this.getElement(),
-                loaded = element.hasClass(css.engaged);
+            var element = this.getElement();
 
             element.addClass(css.engaged);
             element.removeClass(css.disengaged);
 
-            if(! loaded) {
-                element.trigger('in_view'); //this is most important for async loading of slates,
-                                            //it triggers the GlobalScreen-Service.
-            }
             if(il.UI.page.isSmallScreen() && il.UI.maincontrols.metabar) {
                 il.UI.maincontrols.metabar.disengageAll();
             }
@@ -743,12 +756,27 @@ var renderer = function($) {
             mb_hide: null,
             mb_show: null,
             additional_engage: function(){
-                this.getElement().attr('aria-expanded', true);
-                this.getElement().attr('aria-hidden', false);
+                var element = this.getElement(),
+                    entry_id = dom_ref_to_element[this.html_id],
+                    isInView = il.UI.maincontrols.mainbar.model.isInView(entry_id),
+                    thrown = thrown_for[entry_id];
+                
+                element.attr('aria-expanded', true);
+                element.attr('aria-hidden', false);
                 //https://www.w3.org/TR/wai-aria-practices-1.1/examples/accordion/accordion.html
-                this.getElement().attr('role', 'region');
+                element.attr('role', 'region');
+                if(isInView && !thrown) {
+                    element.trigger('in_view'); //this is most important for async loading of slates,
+                                                //it triggers the GlobalScreen-Service.
+                    thrown_for[entry_id] = true;
+                }
+                if(!isInView) {
+                    thrown_for[entry_id] = false;
+                }
             },
             additional_disengage: function(){
+                var entry_id = dom_ref_to_element[this.html_id];
+                thrown_for[entry_id] = false;
                 this.getElement().attr('aria-expanded', false);
                 this.getElement().attr('aria-hidden', true);
                 this.getElement().removeAttr('role', 'region');
@@ -832,6 +860,8 @@ var renderer = function($) {
         addEntry: function (entry_id, part, html_id) {
             dom_references[entry_id] = dom_references[entry_id] || {};
             dom_references[entry_id][part] = html_id;
+            dom_ref_to_element[html_id] = entry_id;
+            thrown_for[entry_id] = false;
         },
         renderEntry: function (entry, is_tool) {
             if(!dom_references[entry.id]){

--- a/src/UI/templates/js/MainControls/src/mainbar.model.js
+++ b/src/UI/templates/js/MainControls/src/mainbar.model.js
@@ -126,6 +126,21 @@ var model = function() {
                 }
             }
             return null;
+        },
+        isInView : function (entry_id) {
+            if(!state.entries[entry_id]) { //tools
+                return true;
+            }
+            var hops = entry_id.split(':'),
+                entries = state.entries;
+            while (hops.length > 1) {
+                entry_id = hops.join(':');
+                if(!state.entries[entry_id].engaged) {
+                    return false;
+                }
+                hops.pop();
+            }
+            return true;
         }
     },
     actions = {
@@ -239,7 +254,8 @@ var model = function() {
         actions: actions,
         getState: () => factories.cloned(state),
         setState: factories.state,
-        getTopLevelEntries: helpers.getTopLevelEntries
+        getTopLevelEntries: helpers.getTopLevelEntries,
+        isInView: helpers.isInView
     },
     init = function() {
         state = factories.cloned(classes.bar);

--- a/src/UI/templates/js/MainControls/src/mainbar.renderer.js
+++ b/src/UI/templates/js/MainControls/src/mainbar.renderer.js
@@ -14,6 +14,8 @@ var renderer = function($) {
     },
 
     dom_references = {},
+    dom_ref_to_element = {},
+    thrown_for = {},
     dom_element = {
         withHtmlId: function (html_id) {
             return Object.assign({}, this, {html_id: html_id});
@@ -23,16 +25,11 @@ var renderer = function($) {
             return $('#' + this.html_id);
         },
         engage: function() {
-            var element = this.getElement(),
-                loaded = element.hasClass(css.engaged);
+            var element = this.getElement();
 
             element.addClass(css.engaged);
             element.removeClass(css.disengaged);
 
-            if(! loaded) {
-                element.trigger('in_view'); //this is most important for async loading of slates,
-                                            //it triggers the GlobalScreen-Service.
-            }
             if(il.UI.page.isSmallScreen() && il.UI.maincontrols.metabar) {
                 il.UI.maincontrols.metabar.disengageAll();
             }
@@ -75,12 +72,27 @@ var renderer = function($) {
             mb_hide: null,
             mb_show: null,
             additional_engage: function(){
-                this.getElement().attr('aria-expanded', true);
-                this.getElement().attr('aria-hidden', false);
+                var element = this.getElement(),
+                    entry_id = dom_ref_to_element[this.html_id],
+                    isInView = il.UI.maincontrols.mainbar.model.isInView(entry_id),
+                    thrown = thrown_for[entry_id];
+                
+                element.attr('aria-expanded', true);
+                element.attr('aria-hidden', false);
                 //https://www.w3.org/TR/wai-aria-practices-1.1/examples/accordion/accordion.html
-                this.getElement().attr('role', 'region');
+                element.attr('role', 'region');
+                if(isInView && !thrown) {
+                    element.trigger('in_view'); //this is most important for async loading of slates,
+                                                //it triggers the GlobalScreen-Service.
+                    thrown_for[entry_id] = true;
+                }
+                if(!isInView) {
+                    thrown_for[entry_id] = false;
+                }
             },
             additional_disengage: function(){
+                var entry_id = dom_ref_to_element[this.html_id];
+                thrown_for[entry_id] = false;
                 this.getElement().attr('aria-expanded', false);
                 this.getElement().attr('aria-hidden', true);
                 this.getElement().removeAttr('role', 'region');
@@ -164,6 +176,8 @@ var renderer = function($) {
         addEntry: function (entry_id, part, html_id) {
             dom_references[entry_id] = dom_references[entry_id] || {};
             dom_references[entry_id][part] = html_id;
+            dom_ref_to_element[html_id] = entry_id;
+            thrown_for[entry_id] = false;
         },
         renderEntry: function (entry, is_tool) {
             if(!dom_references[entry.id]){

--- a/src/UI/templates/js/MainControls/test/mainbar.test.js
+++ b/src/UI/templates/js/MainControls/test/mainbar.test.js
@@ -142,5 +142,22 @@ describe('model', function() {
         ]);
 
     });
+    
+    it('calculates engaged path correctly', function() {
+        m.actions.addEntry('xx:1');
+        m.actions.addEntry('xx:1:1');
+        state = m.getState();
 
+        state.entries['xx:1'].engaged = true;
+        state.entries['xx:1:1'].engaged = true;
+        expect(m.isInView('xx:1')).to.be.true;
+        expect(m.isInView('xx:1:1')).to.be.true;
+
+        state.entries['xx:1'].engaged = false;
+        state.entries['xx:1:1'].engaged = true;
+        expect(m.isInView('xx:1')).to.be.false;
+        expect(m.isInView('xx:1:1')).to.be.false;
+
+        expect(m.isInView('apparently_nonsense')).to.be.true;
+    });
 });


### PR DESCRIPTION
In reference to https://github.com/ILIAS-eLearning/ILIAS/pull/3698, this changes the mainbar's loading-behavior;
'in_view' will be triggered for engaged slates, but only if _all_ upper levels are engaged as well.
