### PR TITLE
Setup: add composer dependency Seld\JsonLint and use it in ConfigReader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,8 @@
 		"ramsey/uuid": "^3.8",
 		"enshrined/svg-sanitize": "^0.13.0",
 		"guzzlehttp/guzzle": "^6.3",
-		"simplesamlphp/simplesamlphp": "^1.18"
+		"simplesamlphp/simplesamlphp": "^1.18",
+		"seld/jsonlint": "^1.8"
 	},
 	"require-dev": {
 		"mikey179/vfsstream": "^1.6",
@@ -396,6 +397,16 @@
 			"last_update_by" : "Alex Killing <killing@leifos.de>",
 			"approved-by": "see security issue 20339",
 			"approved-date": "2017-04-05"
+		},
+		"seld/jsonlint" : {
+			"source" : "https://github.com/Seldaek/jsonlint",
+			"used_version" : "v1.8.3",
+			"wrapped_by" : null,
+			"added_by" : "Daniel Weise <daniel.weise@concepts-and-training.de>",
+			"last_update" : "2021-11-18",
+			"last_update_by" : "Daniel Weise <daniel.weise@concepts-and-training.de>",
+			"approved-by": "Jour Fix",
+			"approved-date": "2021-11-29"
 		},
 		"patches": {
 			"tecnickcom/tcpdf": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "50df347b74ce2011c4ac32f79dd0df6b",
+    "content-hash": "f8ec8daf049be704ddf00e48dc0ba1c0",
     "packages": [
         {
             "name": "cweagans/composer-patches",
@@ -2728,6 +2728,69 @@
                 "xml"
             ],
             "time": "2020-10-03T10:08:14+00:00"
+        },
+        {
+            "name": "seld/jsonlint",
+            "version": "1.8.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/jsonlint.git",
+                "reference": "9ad6ce79c342fbd44df10ea95511a1b24dee5b57"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/9ad6ce79c342fbd44df10ea95511a1b24dee5b57",
+                "reference": "9ad6ce79c342fbd44df10ea95511a1b24dee5b57",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+            },
+            "bin": [
+                "bin/jsonlint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Seld\\JsonLint\\": "src/Seld/JsonLint/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "JSON Linter",
+            "keywords": [
+                "json",
+                "linter",
+                "parser",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/jsonlint/issues",
+                "source": "https://github.com/Seldaek/jsonlint/tree/1.8.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/seld/jsonlint",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-11T09:19:24+00:00"
         },
         {
             "name": "simplesamlphp/composer-module-installer",

--- a/setup/cli.php
+++ b/setup/cli.php
@@ -144,6 +144,7 @@ function build_container_for_setup(string $executed_in_directory) : \Pimple\Cont
 
     $c["config_reader"] = function ($c) use ($executed_in_directory) {
         return new \ILIAS\Setup\CLI\ConfigReader(
+            $c["json.parser"],
             $executed_in_directory
         );
     };
@@ -154,6 +155,10 @@ function build_container_for_setup(string $executed_in_directory) : \Pimple\Cont
 
     $c["plugin_raw_reader"] = function ($c) {
         return new \ilPluginRawReader();
+    };
+
+    $c["json.parser"] = function ($c) {
+        return new \Seld\JsonLint\JsonParser();
     };
 
     return $c;

--- a/src/Setup/CLI/ConfigReader.php
+++ b/src/Setup/CLI/ConfigReader.php
@@ -11,16 +11,19 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Seld\JsonLint\JsonParser;
 
 /**
  * Read a json-formatted config from a file and overwrite some fields.
  */
 class ConfigReader
 {
+    protected JsonParser $json_parser;
     protected string $base_dir;
 
-    public function __construct(string $base_dir = null)
+    public function __construct(JsonParser $json_parser, string $base_dir = null)
     {
+        $this->json_parser = $json_parser;
         $this->base_dir = $base_dir ?? getcwd();
     }
 
@@ -41,7 +44,11 @@ class ConfigReader
                 "Config-file '$name' does not exist or is not readable."
             );
         }
-        $json = json_decode(file_get_contents($name), (bool) JSON_OBJECT_AS_ARRAY);
+        $json = $this->json_parser->parse(
+            file_get_contents($name),
+            JsonParser::PARSE_TO_ASSOC | JsonParser::DETECT_KEY_CONFLICTS
+        );
+
         if (!is_array($json)) {
             throw new \InvalidArgumentException(
                 "Could not find JSON-array in '$name'."

--- a/tests/Setup/CLI/ConfigReaderTest.php
+++ b/tests/Setup/CLI/ConfigReaderTest.php
@@ -6,6 +6,7 @@ namespace ILIAS\Tests\Setup\CLI;
 
 use ILIAS\Setup;
 use PHPUnit\Framework\TestCase;
+use Seld\JsonLint\JsonParser;
 
 class ConfigReaderTest extends TestCase
 {
@@ -18,8 +19,7 @@ class ConfigReaderTest extends TestCase
             ]
         ];
         file_put_contents($filename, json_encode($expected));
-
-        $obj = new Setup\CLI\ConfigReader();
+        $obj = new Setup\CLI\ConfigReader(new JsonParser());
 
         $config = $obj->readConfigFile($filename);
 
@@ -36,7 +36,7 @@ class ConfigReaderTest extends TestCase
         ];
         file_put_contents($filename, json_encode($expected));
 
-        $obj = new Setup\CLI\ConfigReader("/tmp");
+        $obj = new Setup\CLI\ConfigReader(new JsonParser(), "/tmp");
 
         $config = $obj->readConfigFile(basename($filename));
 
@@ -53,7 +53,7 @@ class ConfigReaderTest extends TestCase
         ];
         file_put_contents($filename, json_encode($expected));
 
-        $obj = new Setup\CLI\ConfigReader("/foo");
+        $obj = new Setup\CLI\ConfigReader(new JsonParser(), "/foo");
 
         $config = $obj->readConfigFile($filename);
 
@@ -62,7 +62,7 @@ class ConfigReaderTest extends TestCase
 
     public function testApplyOverwrites() : void
     {
-        $cr = new class() extends Setup\CLI\ConfigReader {
+        $cr = new class(new JsonParser()) extends Setup\CLI\ConfigReader {
             public function _applyOverwrites($j, $o)
             {
                 return $this->applyOverwrites($j, $o);
@@ -98,7 +98,7 @@ class ConfigReaderTest extends TestCase
 
     public function testApplyOverwritesToUnsetField() : void
     {
-        $cr = new class() extends Setup\CLI\ConfigReader {
+        $cr = new class(new JsonParser()) extends Setup\CLI\ConfigReader {
             public function _applyOverwrites($j, $o)
             {
                 return $this->applyOverwrites($j, $o);


### PR DESCRIPTION
Using the Seld\JsonLint lib will help to locate errors in the setup config file. Its output contains line number and error type.