### PR TITLE
Switches redirect targets if there is an init authentication error

### DIFF
--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1413,16 +1413,16 @@ class ilInitialisation
             ilContext::getType() == ilContext::CONTEXT_WAC) {
             throw new Exception("Authentication failed.");
         }
+        if (ilPublicSectionSettings::getInstance()->isEnabledForDomain($_SERVER['SERVER_NAME'])) {
+            ilLoggerFactory::getLogger('init')->debug('Redirect to public section.');
+            return self::goToPublicSection();
+        }
         if (
             $GLOBALS['DIC']['ilAuthSession']->isExpired() &&
             !\ilObjUser::_isAnonymous($GLOBALS['DIC']['ilAuthSession']->getUserId())
         ) {
             ilLoggerFactory::getLogger('init')->debug('Expired session found -> redirect to login page');
             return self::goToLogin();
-        }
-        if (ilPublicSectionSettings::getInstance()->isEnabledForDomain($_SERVER['SERVER_NAME'])) {
-            ilLoggerFactory::getLogger('init')->debug('Redirect to public section.');
-            return self::goToPublicSection();
         }
         ilLoggerFactory::getLogger('init')->debug('Redirect to login page.');
         return self::goToLogin();


### PR DESCRIPTION
(This is PR https://github.com/ILIAS-eLearning/ILIAS/pull/2580 just reopened for Ilias7)

Mantis: https://mantis.ilias.de/view.php?id=31639

Changed behavior in >5.4 (i dont know if 6 or 7 changed this):
@smeyer-ilias fixed the error with a different commit:
https://github.com/ILIAS-eLearning/ILIAS/commit/2fed39872db978c00f8dbdfcf1b678830d6aba04

But this doesnt work anymore since `$GLOBALS['DIC']['ilAuthSession']->getUserId()` stores now the value of the expired user session e.g. 6 for the root user. ID 6 is not anonymous. So there is a redirect loop to the login page. 

My old change request still works in Ilias 7. 


Old PR description:
If the public area is enabled the error should be shown in the anonymous area since the login page blockes a user from proceeding any further with an expired session.
The user has to login successfully or has to clear the cookies to escape a redirect loop to the login.php.

Steps to reproduce:
1)Setup ilias with an anonymous area.
2)Login
3)Surf in the anonymous area until the session expires