### PR TITLE
UI, Inputs: add only message-strings of exceptions to errors

### DIFF
--- a/src/UI/Implementation/Component/Input/Field/Input.php
+++ b/src/UI/Implementation/Component/Input/Field/Input.php
@@ -379,7 +379,11 @@ abstract class Input implements C\Input\Field\Input, FormInputInternal
 
         $clone->content = $this->applyOperationsTo($clone->getValue());
         if ($clone->content->isError()) {
-            return $clone->withError("" . $clone->content->error());
+            $error = $clone->content->error();
+            if ($error instanceof \Exception) {
+                $error = $error->getMessage();
+            }
+            return $clone->withError("" . $error);
         }
 
         return $clone;


### PR DESCRIPTION
In order to turn ugly erros-messages like this:
![Screenshot from 2021-11-24 15-45-41](https://user-images.githubusercontent.com/3328364/143259910-da1615f6-d6f7-4e70-9681-2aee1f8a1601.png)

into something nicer like that:
![Screenshot from 2021-11-24 15-46-17](https://user-images.githubusercontent.com/3328364/143259987-9d4f94b5-cdfc-4cd8-b036-0e343afc72b7.png)

