### PR TITLE
log: avoid static call

### DIFF
--- a/src/DI/LoggingServices.php
+++ b/src/DI/LoggingServices.php
@@ -36,6 +36,6 @@ class LoggingServices
     public function __call($method_name, $args)
     {
         assert(count($args) === 0);
-        return $this->container["ilLoggerFactory"]->getLogger($method_name);
+        return $this->container['ilLoggerFactory']->getComponentLogger($method_name);
     }
 }


### PR DESCRIPTION
This is a minor improvement of the DIC initialisation.
['ilLoggerFactory']->getLogger() was in fact a static call. Using getComponentLogger() here makes it easier to create mock objects. E.g here https://github.com/ILIAS-eLearning/ILIAS/blob/3dbf9f7583c00ab9314e6d6cff36ec10cea4e3f1/Services/Tree/test/ilRepositoryTreeTest.php#L72