### PR TITLE
UI Form: 31701, display error-message in form

### DIFF
--- a/src/UI/Component/Input/Container/Form/Form.php
+++ b/src/UI/Component/Input/Container/Form/Form.php
@@ -54,5 +54,8 @@ interface Form extends Component
      * TODO: there should be a further method to attach the different submit buttons
      */
 
-    public function getError() : ?string;
+    /**
+     * @return null|string
+     */
+    public function getError();
 }

--- a/src/UI/Component/Input/Container/Form/Form.php
+++ b/src/UI/Component/Input/Container/Form/Form.php
@@ -53,4 +53,6 @@ interface Form extends Component
     /**
      * TODO: there should be a further method to attach the different submit buttons
      */
+
+    public function getError() : ?string;
 }

--- a/src/UI/Implementation/Component/Input/Container/Form/Form.php
+++ b/src/UI/Implementation/Component/Input/Container/Form/Form.php
@@ -36,6 +36,8 @@ abstract class Form implements C\Input\Container\Form\Form, CI\Input\NameSource
      */
     private $count = 0;
 
+    protected ?string $error = null;
+
 
     /**
      * @param array $inputs
@@ -98,6 +100,16 @@ abstract class Form implements C\Input\Container\Form\Form, CI\Input\NameSource
         return $clone;
     }
 
+    public function getError() : ?string
+    {
+        return $this->error;
+    }
+
+    protected function setError(string $error) : void
+    {
+        $this->error = $error;
+    }
+
 
     /**
      * @inheritdocs
@@ -106,6 +118,7 @@ abstract class Form implements C\Input\Container\Form\Form, CI\Input\NameSource
     {
         $content = $this->getInputGroup()->getContent();
         if (!$content->isok()) {
+            $this->setError($content->error());
             return null;
         }
 

--- a/src/UI/Implementation/Component/Input/Container/Form/Form.php
+++ b/src/UI/Implementation/Component/Input/Container/Form/Form.php
@@ -36,7 +36,10 @@ abstract class Form implements C\Input\Container\Form\Form, CI\Input\NameSource
      */
     private $count = 0;
 
-    protected ?string $error = null;
+    /**
+     * @var null|string
+     */
+    protected $error = null;
 
 
     /**
@@ -55,7 +58,7 @@ abstract class Form implements C\Input\Container\Form\Form, CI\Input\NameSource
 
 
     /**
-     * @inheritdocs
+     * @inheritdoc
      */
     public function getInputs()
     {
@@ -64,7 +67,7 @@ abstract class Form implements C\Input\Container\Form\Form, CI\Input\NameSource
 
 
     /**
-     * @inheritdocs
+     * @inheritdoc
      */
     public function getInputGroup()
     {
@@ -73,7 +76,7 @@ abstract class Form implements C\Input\Container\Form\Form, CI\Input\NameSource
 
 
     /**
-     * @inheritdocs
+     * @inheritdoc
      */
     public function withRequest(ServerRequestInterface $request)
     {
@@ -90,7 +93,7 @@ abstract class Form implements C\Input\Container\Form\Form, CI\Input\NameSource
 
 
     /**
-     * @inheritdocs
+     * @inheritdoc
      */
     public function withAdditionalTransformation(Transformation $trafo)
     {
@@ -100,7 +103,10 @@ abstract class Form implements C\Input\Container\Form\Form, CI\Input\NameSource
         return $clone;
     }
 
-    public function getError() : ?string
+    /**
+     * @inheritdoc
+     */
+    public function getError()
     {
         return $this->error;
     }
@@ -112,7 +118,7 @@ abstract class Form implements C\Input\Container\Form\Form, CI\Input\NameSource
 
 
     /**
-     * @inheritdocs
+     * @inheritdoc
      */
     public function getData()
     {

--- a/src/UI/Implementation/Component/Input/Container/Form/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Container/Form/Renderer.php
@@ -45,6 +45,10 @@ class Renderer extends AbstractComponentRenderer
 
         $tpl->setVariable("INPUTS", $default_renderer->render($component->getInputGroup()));
 
+        $error = $component->getError();
+        if (!is_null($error)) {
+            $tpl->setVariable("ERROR", $error);
+        }
         return $tpl->get();
     }
 

--- a/src/UI/templates/default/Input/tpl.standard.html
+++ b/src/UI/templates/default/Input/tpl.standard.html
@@ -2,6 +2,11 @@
 	<div class="il-standard-form-header clearfix">
 		<div class="il-standard-form-cmd">{BUTTONS_TOP}</div>
 	</div>
+	<!-- BEGIN error -->
+	<div class="help-block alert alert-danger" role="alert">
+		{ERROR}
+	</div>
+	<!-- END error -->
 	{INPUTS}
 	<div class="il-standard-form-footer clearfix">
 		<div class="il-standard-form-cmd">{BUTTONS_BOTTOM}</div>

--- a/tests/UI/Component/Input/Container/Form/StandardFormTest.php
+++ b/tests/UI/Component/Input/Container/Form/StandardFormTest.php
@@ -8,6 +8,8 @@ require_once(__DIR__ . "/FormTest.php");
 
 use ILIAS\UI\Implementation\Component\SignalGenerator;
 use \ILIAS\Data;
+use Psr\Http\Message\ServerRequestInterface;
+use ILIAS\UI\Implementation\Component\Input\Container\Form;
 
 class WithButtonNoUIFactory extends NoUIFactory
 {
@@ -133,6 +135,129 @@ class StandardFormTest extends ILIAS_UI_TestBase
       <div class="il-standard-form-cmd"><button class="btn btn-default" data-action="">save</button></div>
    </div>
 </form>
+        ');
+        $this->assertHTMLEquals($expected, $html);
+    }
+
+
+    public function testRenderWithErrorOnFieled()
+    {
+        $r = $this->getDefaultRenderer();
+        $df = new Data\Factory();
+        $language = $this->createMock(\ilLanguage::class);
+        $language
+            ->expects($this->once())
+            ->method("txt")
+            ->willReturn('testing error message');
+
+        $refinery = new \ILIAS\Refinery\Factory($df, $language);
+
+        $if = new ILIAS\UI\Implementation\Component\Input\Field\Factory(
+            new SignalGenerator(),
+            $df,
+            $refinery,
+            $language
+        );
+
+        $fail = $refinery->custom()->constraint(function ($v) {
+            return false;
+        }, "This is invalid...");
+        $input = $if->text("label", "byline");
+        
+        $input = $input->withAdditionalTransformation($fail);
+        
+        $form = new Form\Standard($if, '', [$input]);
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request
+            ->expects($this->once())
+            ->method("getParsedBody")
+            ->willReturn([
+                'form_input_1' => ''
+            ]);
+
+        $form = $form->withRequest($request);
+        $this->assertNull($form->getData());
+
+        $html = $this->brutallyTrimHTML($r->render($form));
+        $expected = $this->brutallyTrimHTML('
+            <form role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" method="post" novalidate="novalidate">
+                <div class="il-standard-form-header clearfix">
+                    <div class="il-standard-form-cmd"><button class="btn btn-default" data-action="">save</button></div>
+                </div>
+
+                <div class="help-block alert alert-danger" role="alert">testing error message</div>
+
+                <div class="form-group row">
+                    <label for="id_1" class="control-label col-sm-3">label</label>
+                    <div class="col-sm-9">
+                        <div class="help-block alert alert-danger" role="alert">This is invalid...</div>
+                        <input id="id_1" type="text" name="form_input_1" class="form-control form-control-sm" />
+                        <div class="help-block">byline</div>
+                    </div>
+                </div>
+                <div class="il-standard-form-footer clearfix">
+                    <div class="il-standard-form-cmd"><button class="btn btn-default" data-action="">save</button></div>
+                </div>
+            </form>
+        ');
+        $this->assertHTMLEquals($expected, $html);
+    }
+
+
+    public function testRenderWithErrorOnForm()
+    {
+        $r = $this->getDefaultRenderer();
+        $df = new Data\Factory();
+        $language = $this->createMock(\ilLanguage::class);
+        $refinery = new \ILIAS\Refinery\Factory($df, $language);
+
+        $if = new ILIAS\UI\Implementation\Component\Input\Field\Factory(
+            new SignalGenerator(),
+            $df,
+            $refinery,
+            $language
+        );
+
+        $fail = $refinery->custom()->constraint(function ($v) {
+            return false;
+        }, "This is a fail on form.");
+        $input = $if->text("label", "byline");
+
+        $form = new Form\Standard($if, '', [$input]);
+        $form = $form->withAdditionalTransformation($fail);
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request
+            ->expects($this->once())
+            ->method("getParsedBody")
+            ->willReturn([
+                'form_input_1' => ''
+            ]);
+
+        $form = $form->withRequest($request);
+        $this->assertNull($form->getData());
+
+        $html = $this->brutallyTrimHTML($r->render($form));
+        $expected = $this->brutallyTrimHTML('
+            <form role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" method="post" novalidate="novalidate">
+                <div class="il-standard-form-header clearfix">
+                    <div class="il-standard-form-cmd"><button class="btn btn-default" data-action="">save</button></div>
+                </div>
+
+                <div class="help-block alert alert-danger" role="alert">This is a fail on form.</div>
+
+                <div class="form-group row">
+                    <label for="id_1" class="control-label col-sm-3">label</label>
+                    <div class="col-sm-9">
+                        <input id="id_1" type="text" name="form_input_1" class="form-control form-control-sm" />
+                        <div class="help-block">byline</div>
+                    </div>
+                </div>
+                <div class="il-standard-form-footer clearfix">
+                    <div class="il-standard-form-cmd"><button class="btn btn-default" data-action="">save</button></div>
+                </div>
+            </form>
         ');
         $this->assertHTMLEquals($expected, $html);
     }

--- a/tests/UI/Component/Input/Container/Form/StandardFormTest.php
+++ b/tests/UI/Component/Input/Container/Form/StandardFormTest.php
@@ -140,7 +140,7 @@ class StandardFormTest extends ILIAS_UI_TestBase
     }
 
 
-    public function testRenderWithErrorOnFieled()
+    public function testRenderWithErrorOnField()
     {
         $r = $this->getDefaultRenderer();
         $df = new Data\Factory();


### PR DESCRIPTION
A user my add contraints on an entire form; however, there will not be any messages. 
See https://mantis.ilias.de/view.php?id=31701

This will display an (additional) error-message on forms, not only on inputs.

