### PR TITLE
BUGFIX [31661]: Insufficient Contrast in Star Ratings

### DIFF
--- a/templates/default/images/icon_rate_0.svg
+++ b/templates/default/images/icon_rate_0.svg
@@ -1,7 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 18.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
-<polygon fill="#CAD0DF" points="16,2.7 21.4,10 30,12.9 24.8,20.2 24.7,29.3 16,26.6 7.3,29.3 7.2,20.2 2,12.9 10.6,10 "/>
+<svg width="280" height="267" viewBox="0 0 280 267" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_7_2)">
+<path d="M67.45 170.78L23.92 109.49L95.16 85.49L140 25.15L184.84 85.49L256.08 109.49L212.55 170.78L211.74 245.95L140 223.49L68.26 245.95L67.45 170.78ZM140 0L85.92 72.77L0 101.72L52.5 175.64L53.5 266.3L140 239.21L226.52 266.3L227.52 175.64L280 101.72L194.08 72.78L140 0Z" fill="#B54F00"/>
+</g>
+<defs>
+<clipPath id="clip0_7_2">
+<rect width="280" height="266.3" fill="white"/>
+</clipPath>
+</defs>
 </svg>

--- a/templates/default/images/icon_rate_0.svg
+++ b/templates/default/images/icon_rate_0.svg
@@ -1,10 +1,10 @@
-<svg width="280" height="267" viewBox="0 0 280 267" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_7_2)">
-<path d="M67.45 170.78L23.92 109.49L95.16 85.49L140 25.15L184.84 85.49L256.08 109.49L212.55 170.78L211.74 245.95L140 223.49L68.26 245.95L67.45 170.78ZM140 0L85.92 72.77L0 101.72L52.5 175.64L53.5 266.3L140 239.21L226.52 266.3L227.52 175.64L280 101.72L194.08 72.78L140 0Z" fill="#B54F00"/>
-</g>
-<defs>
-<clipPath id="clip0_7_2">
-<rect width="280" height="266.3" fill="white"/>
-</clipPath>
-</defs>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 280 266.3" style="enable-background:new 0 0 280 266.3;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#B54F00;}
+</style>
+<path class="st0" d="M67.4,170.8l-43.5-61.3l71.2-24L140,25.1l44.8,60.3l71.2,24l-43.5,61.3l-0.8,75.2L140,223.5l-71.7,22.5
+	L67.4,170.8z M140,0L85.9,72.8L0,101.7l52.5,73.9l1,90.7l86.5-27.1l86.5,27.1l1-90.7l52.5-73.9l-85.9-28.9L140,0z"/>
 </svg>

--- a/templates/default/images/icon_rate_1.svg
+++ b/templates/default/images/icon_rate_1.svg
@@ -1,10 +1,11 @@
-<svg width="280" height="267" viewBox="0 0 280 267" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_7_6)">
-<path d="M67.45 170.78L36 126.5V105.42L95.16 85.49L140 25.15L184.84 85.49L256.08 109.49L212.55 170.78L211.74 245.95L140 223.49L68.26 245.95L67.45 170.78ZM140 0L85.92 72.77L0 101.72L36 152.41L52.5 175.64L53.5 266.3L140 239.21L226.52 266.3L227.52 175.64L280 101.72L194.08 72.78L140 0Z" fill="#B54F00"/>
-</g>
-<defs>
-<clipPath id="clip0_7_6">
-<rect width="280" height="266.3" fill="white"/>
-</clipPath>
-</defs>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 280 266.3" style="enable-background:new 0 0 280 266.3;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#B54F00;}
+</style>
+<path class="st0" d="M67.4,170.8L36,126.5v-21.1l59.2-19.9L140,25.1l44.8,60.3l71.2,24l-43.5,61.3l-0.8,75.2L140,223.5l-71.7,22.5
+	L67.4,170.8z M140,0L85.9,72.8L0,101.7l0,0l36,50.7l16.5,23.2l1,90.7l86.5-27.1l0,0l86.5,27.1l1-90.7l52.5-73.9l-85.9-28.9L140,0z"
+	/>
 </svg>

--- a/templates/default/images/icon_rate_1.svg
+++ b/templates/default/images/icon_rate_1.svg
@@ -1,25 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 18.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
-<g>
-	<g>
-		<defs>
-			<polygon id="SVGID_1_" points="2,12.9 5.6,17.9 5.6,11.6 			"/>
-		</defs>
-		<clipPath id="SVGID_2_">
-			<use xlink:href="#SVGID_1_"  overflow="visible"/>
-		</clipPath>
-		
-			<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="0.9643" y1="33.6506" x2="1.9643" y2="33.6506" gradientTransform="matrix(-28 0 0 -28 57 957.0001)">
-			<stop  offset="0" style="stop-color:#FF8D2C"/>
-			<stop  offset="1.000000e-02" style="stop-color:#FF8D2C"/>
-			<stop  offset="1" style="stop-color:#E56E1E"/>
-		</linearGradient>
-		<rect x="2" y="11.6" clip-path="url(#SVGID_2_)" fill="url(#SVGID_3_)" width="3.6" height="6.3"/>
-	</g>
-	<polygon fill="#CAD0DF" points="16,2.7 10.6,10 5.6,11.6 5.6,17.9 7.2,20.2 7.3,29.3 16,26.6 24.7,29.3 24.8,20.2 30,12.9 21.4,10 
-			"/>
+<svg width="280" height="267" viewBox="0 0 280 267" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_7_6)">
+<path d="M67.45 170.78L36 126.5V105.42L95.16 85.49L140 25.15L184.84 85.49L256.08 109.49L212.55 170.78L211.74 245.95L140 223.49L68.26 245.95L67.45 170.78ZM140 0L85.92 72.77L0 101.72L36 152.41L52.5 175.64L53.5 266.3L140 239.21L226.52 266.3L227.52 175.64L280 101.72L194.08 72.78L140 0Z" fill="#B54F00"/>
 </g>
+<defs>
+<clipPath id="clip0_7_6">
+<rect width="280" height="266.3" fill="white"/>
+</clipPath>
+</defs>
 </svg>

--- a/templates/default/images/icon_rate_10.svg
+++ b/templates/default/images/icon_rate_10.svg
@@ -1,10 +1,10 @@
-<svg width="280" height="267" viewBox="0 0 280 267" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_7_17)">
-<path d="M140 0L85.92 72.77L0 101.72L52.5 175.63L53.48 266.3L140 239.21L226.52 266.3L227.5 175.63L280 101.72L194.08 72.77L140 0Z" fill="#B54F00"/>
-</g>
-<defs>
-<clipPath id="clip0_7_17">
-<rect width="280" height="266.3" fill="white"/>
-</clipPath>
-</defs>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 280 266.3" style="enable-background:new 0 0 280 266.3;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#B54F00;}
+</style>
+<polygon class="st0" points="140,0 85.9,72.8 0,101.7 52.5,175.6 53.5,266.3 140,239.2 226.5,266.3 227.5,175.6 280,101.7 
+	194.1,72.8 "/>
 </svg>

--- a/templates/default/images/icon_rate_10.svg
+++ b/templates/default/images/icon_rate_10.svg
@@ -1,21 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 18.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
-<g>
-	<defs>
-		<polygon id="SVGID_1_" points="16,2.7 10.6,10 2,12.9 7.2,20.2 7.3,29.3 16,26.6 24.7,29.3 24.8,20.2 30,12.9 21.4,10 		"/>
-	</defs>
-	<clipPath id="SVGID_2_">
-		<use xlink:href="#SVGID_1_"  overflow="visible"/>
-	</clipPath>
-	
-		<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="0.9643" y1="33.6071" x2="1.9643" y2="33.6071" gradientTransform="matrix(-28 0 0 -28 57 957)">
-		<stop  offset="0" style="stop-color:#FF8E2C"/>
-		<stop  offset="1.000000e-02" style="stop-color:#FF8E2C"/>
-		<stop  offset="1" style="stop-color:#E66E1E"/>
-	</linearGradient>
-	<rect x="2" y="2.7" clip-path="url(#SVGID_2_)" fill="url(#SVGID_3_)" width="28" height="26.6"/>
+<svg width="280" height="267" viewBox="0 0 280 267" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_7_17)">
+<path d="M140 0L85.92 72.77L0 101.72L52.5 175.63L53.48 266.3L140 239.21L226.52 266.3L227.5 175.63L280 101.72L194.08 72.77L140 0Z" fill="#B54F00"/>
 </g>
+<defs>
+<clipPath id="clip0_7_17">
+<rect width="280" height="266.3" fill="white"/>
+</clipPath>
+</defs>
 </svg>

--- a/templates/default/images/icon_rate_2.svg
+++ b/templates/default/images/icon_rate_2.svg
@@ -1,22 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 18.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
-<g>
-	<defs>
-		<polygon id="SVGID_1_" points="2,12.9 7.3,20.2 7.3,29.3 8.4,29 8.4,10.7 		"/>
-	</defs>
-	<clipPath id="SVGID_2_">
-		<use xlink:href="#SVGID_1_"  overflow="visible"/>
-	</clipPath>
-	
-		<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="0.9643" y1="33.464" x2="1.9643" y2="33.464" gradientTransform="matrix(-28 0 0 -28 57 957.0001)">
-		<stop  offset="0" style="stop-color:#FF8D2C"/>
-		<stop  offset="1.000000e-02" style="stop-color:#FF8D2C"/>
-		<stop  offset="1" style="stop-color:#E56E1E"/>
-	</linearGradient>
-	<rect x="2" y="10.7" clip-path="url(#SVGID_2_)" fill="url(#SVGID_3_)" width="6.4" height="18.6"/>
+<svg width="280" height="267" viewBox="0 0 280 267" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_7_4)">
+<path d="M67.45 170.78L64 165.93V95.99L95.16 85.49L140 25.15L184.84 85.49L256.08 109.49L212.55 170.78L211.74 245.95L140 223.49L68.26 245.95L67.45 170.78ZM140 0L85.92 72.77L0 101.72L31.15 145.58L52.5 175.64L53.5 266.3L140 239.21L226.52 266.3L227.52 175.64L280 101.72L194.08 72.78L140 0Z" fill="#B54F00"/>
 </g>
-<polygon fill="#CAD0DF" points="16,2.7 10.6,10 8.4,10.7 8.4,29 16,26.6 24.7,29.3 24.8,20.2 30,12.9 21.4,10 "/>
+<defs>
+<clipPath id="clip0_7_4">
+<rect width="280" height="266.3" fill="white"/>
+</clipPath>
+</defs>
 </svg>

--- a/templates/default/images/icon_rate_2.svg
+++ b/templates/default/images/icon_rate_2.svg
@@ -1,10 +1,11 @@
-<svg width="280" height="267" viewBox="0 0 280 267" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_7_4)">
-<path d="M67.45 170.78L64 165.93V95.99L95.16 85.49L140 25.15L184.84 85.49L256.08 109.49L212.55 170.78L211.74 245.95L140 223.49L68.26 245.95L67.45 170.78ZM140 0L85.92 72.77L0 101.72L31.15 145.58L52.5 175.64L53.5 266.3L140 239.21L226.52 266.3L227.52 175.64L280 101.72L194.08 72.78L140 0Z" fill="#B54F00"/>
-</g>
-<defs>
-<clipPath id="clip0_7_4">
-<rect width="280" height="266.3" fill="white"/>
-</clipPath>
-</defs>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 280 266.3" style="enable-background:new 0 0 280 266.3;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#B54F00;}
+</style>
+<path class="st0" d="M67.4,170.8l-3.4-4.9V96l31.2-10.5L140,25.1l44.8,60.3l71.2,24l-43.5,61.3l-0.8,75.2L140,223.5l-71.7,22.5
+	L67.4,170.8z M140,0L85.9,72.8L0,101.7l0,0l31.2,43.9l21.3,30.1l1,90.7l86.5-27.1l0,0l86.5,27.1l1-90.7l52.5-73.9l-85.9-28.9L140,0z
+	"/>
 </svg>

--- a/templates/default/images/icon_rate_3.svg
+++ b/templates/default/images/icon_rate_3.svg
@@ -1,22 +1,89 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 18.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
-<g>
-	<defs>
-		<polygon id="SVGID_1_" points="2,12.9 7.3,20.2 7.3,29.3 10.4,28.4 10.4,10 		"/>
-	</defs>
-	<clipPath id="SVGID_2_">
-		<use xlink:href="#SVGID_1_"  overflow="visible"/>
-	</clipPath>
-	
-		<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="0.9643" y1="33.476" x2="1.9643" y2="33.476" gradientTransform="matrix(-28 0 0 -28 57 957.0001)">
-		<stop  offset="0" style="stop-color:#FF8D2C"/>
-		<stop  offset="1.000000e-02" style="stop-color:#FF8D2C"/>
-		<stop  offset="1" style="stop-color:#E56E1E"/>
-	</linearGradient>
-	<rect x="2" y="10" clip-path="url(#SVGID_2_)" fill="url(#SVGID_3_)" width="8.4" height="19.3"/>
-</g>
-<polygon fill="#CAD0DF" points="16,2.7 10.6,10 10.4,10 10.4,28.4 16,26.6 24.7,29.3 24.8,20.2 30,12.9 21.4,10 "/>
-</svg>
+%PDF-1.7
+
+1 0 obj
+  << >>
+endobj
+
+2 0 obj
+  << /Length 3 0 R >>
+stream
+/DeviceRGB CS
+/DeviceRGB cs
+q
+1.000000 0.000000 -0.000000 1.000000 0.000000 0.000000 cm
+0.709804 0.309804 0.000000 scn
+84.000000 177.049805 m
+95.160004 180.809814 l
+140.000000 241.149811 l
+184.839996 180.809814 l
+256.079987 156.809814 l
+212.550003 95.519806 l
+211.740005 20.349823 l
+140.000000 42.809814 l
+84.000000 25.279816 l
+84.000000 177.049805 l
+h
+140.000000 266.299805 m
+85.919998 193.529800 l
+0.000000 164.579803 l
+31.150002 120.719818 l
+52.500000 90.659805 l
+53.500000 -0.000183 l
+140.000000 27.089813 l
+226.520004 -0.000183 l
+227.520004 90.659805 l
+280.000000 164.579803 l
+194.080002 193.519806 l
+140.000000 266.299805 l
+h
+f
+n
+Q
+
+endstream
+endobj
+
+3 0 obj
+  638
+endobj
+
+4 0 obj
+  << /Annots []
+     /Type /Page
+     /MediaBox [ 0.000000 0.000000 280.000000 266.299805 ]
+     /Resources 1 0 R
+     /Contents 2 0 R
+     /Parent 5 0 R
+  >>
+endobj
+
+5 0 obj
+  << /Kids [ 4 0 R ]
+     /Count 1
+     /Type /Pages
+  >>
+endobj
+
+6 0 obj
+  << /Pages 5 0 R
+     /Type /Catalog
+  >>
+endobj
+
+xref
+0 7
+0000000000 65535 f
+0000000010 00000 n
+0000000034 00000 n
+0000000728 00000 n
+0000000750 00000 n
+0000000925 00000 n
+0000000999 00000 n
+trailer
+<< /ID [ (some) (id) ]
+   /Root 6 0 R
+   /Size 7
+>>
+startxref
+1058
+%%EOF

--- a/templates/default/images/icon_rate_3.svg
+++ b/templates/default/images/icon_rate_3.svg
@@ -1,89 +1,10 @@
-%PDF-1.7
-
-1 0 obj
-  << >>
-endobj
-
-2 0 obj
-  << /Length 3 0 R >>
-stream
-/DeviceRGB CS
-/DeviceRGB cs
-q
-1.000000 0.000000 -0.000000 1.000000 0.000000 0.000000 cm
-0.709804 0.309804 0.000000 scn
-84.000000 177.049805 m
-95.160004 180.809814 l
-140.000000 241.149811 l
-184.839996 180.809814 l
-256.079987 156.809814 l
-212.550003 95.519806 l
-211.740005 20.349823 l
-140.000000 42.809814 l
-84.000000 25.279816 l
-84.000000 177.049805 l
-h
-140.000000 266.299805 m
-85.919998 193.529800 l
-0.000000 164.579803 l
-31.150002 120.719818 l
-52.500000 90.659805 l
-53.500000 -0.000183 l
-140.000000 27.089813 l
-226.520004 -0.000183 l
-227.520004 90.659805 l
-280.000000 164.579803 l
-194.080002 193.519806 l
-140.000000 266.299805 l
-h
-f
-n
-Q
-
-endstream
-endobj
-
-3 0 obj
-  638
-endobj
-
-4 0 obj
-  << /Annots []
-     /Type /Page
-     /MediaBox [ 0.000000 0.000000 280.000000 266.299805 ]
-     /Resources 1 0 R
-     /Contents 2 0 R
-     /Parent 5 0 R
-  >>
-endobj
-
-5 0 obj
-  << /Kids [ 4 0 R ]
-     /Count 1
-     /Type /Pages
-  >>
-endobj
-
-6 0 obj
-  << /Pages 5 0 R
-     /Type /Catalog
-  >>
-endobj
-
-xref
-0 7
-0000000000 65535 f
-0000000010 00000 n
-0000000034 00000 n
-0000000728 00000 n
-0000000750 00000 n
-0000000925 00000 n
-0000000999 00000 n
-trailer
-<< /ID [ (some) (id) ]
-   /Root 6 0 R
-   /Size 7
->>
-startxref
-1058
-%%EOF
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 280 266.3" style="enable-background:new 0 0 280 266.3;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#B54F00;}
+</style>
+<path class="st0" d="M84,89.2l11.2-3.8L140,25.1l44.8,60.3l71.2,24l-43.5,61.3l-0.8,75.2L140,223.5L84,241V89.2z M140,0L85.9,72.8
+	L0,101.7l0,0l31.2,43.9l21.3,30.1l1,90.7l86.5-27.1l0,0l86.5,27.1l1-90.7l52.5-73.9l-85.9-28.9L140,0z"/>
+</svg>

--- a/templates/default/images/icon_rate_4.svg
+++ b/templates/default/images/icon_rate_4.svg
@@ -1,22 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 18.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
-<g>
-	<defs>
-		<polygon id="SVGID_1_" points="10.6,10 2,12.9 7.3,20.2 7.3,29.3 13.2,27.5 13.2,6.5 		"/>
-	</defs>
-	<clipPath id="SVGID_2_">
-		<use xlink:href="#SVGID_1_"  overflow="visible"/>
-	</clipPath>
-	
-		<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="0.9643" y1="33.5399" x2="1.9643" y2="33.5399" gradientTransform="matrix(-28 0 0 -28 57 957.0001)">
-		<stop  offset="0" style="stop-color:#FF8D2C"/>
-		<stop  offset="1.000000e-02" style="stop-color:#FF8D2C"/>
-		<stop  offset="1" style="stop-color:#E56E1E"/>
-	</linearGradient>
-	<rect x="2" y="6.5" clip-path="url(#SVGID_2_)" fill="url(#SVGID_3_)" width="11.2" height="22.9"/>
+<svg width="280" height="267" viewBox="0 0 280 267" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_7_80)">
+<path d="M112 62.83L140 25.15L184.84 85.49L256.08 109.49L212.55 170.78L211.74 245.95L140 223.49L112 232.26V62.83ZM140 0L85.92 72.77L0 101.72L31.15 145.58L52.5 175.64L53.5 266.3L140 239.21L226.52 266.3L227.52 175.64L280 101.72L194.08 72.78L140 0Z" fill="#B54F00"/>
 </g>
-<polygon fill="#CAD0DF" points="16,2.7 13.2,6.5 13.2,27.5 16,26.6 24.7,29.3 24.8,20.2 30,12.9 21.4,10 "/>
+<defs>
+<clipPath id="clip0_7_80">
+<rect width="280" height="266.3" fill="white"/>
+</clipPath>
+</defs>
 </svg>

--- a/templates/default/images/icon_rate_4.svg
+++ b/templates/default/images/icon_rate_4.svg
@@ -1,10 +1,10 @@
-<svg width="280" height="267" viewBox="0 0 280 267" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_7_80)">
-<path d="M112 62.83L140 25.15L184.84 85.49L256.08 109.49L212.55 170.78L211.74 245.95L140 223.49L112 232.26V62.83ZM140 0L85.92 72.77L0 101.72L31.15 145.58L52.5 175.64L53.5 266.3L140 239.21L226.52 266.3L227.52 175.64L280 101.72L194.08 72.78L140 0Z" fill="#B54F00"/>
-</g>
-<defs>
-<clipPath id="clip0_7_80">
-<rect width="280" height="266.3" fill="white"/>
-</clipPath>
-</defs>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 280 266.3" style="enable-background:new 0 0 280 266.3;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#B54F00;}
+</style>
+<path class="st0" d="M112,62.8l28-37.7l44.8,60.3l71.2,24l-43.5,61.3l-0.8,75.2L140,223.5l-28,8.8V62.8z M140,0L85.9,72.8L0,101.7
+	l0,0l31.2,43.9l21.3,30.1l1,90.7l86.5-27.1l0,0l86.5,27.1l1-90.7l52.5-73.9l-85.9-28.9L140,0z"/>
 </svg>

--- a/templates/default/images/icon_rate_5.svg
+++ b/templates/default/images/icon_rate_5.svg
@@ -1,10 +1,10 @@
-<svg width="280" height="267" viewBox="0 0 280 267" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_7_43)">
-<path d="M140 223.49V25.15L184.84 85.49L256.08 109.49L212.55 170.78L211.74 245.95L140 223.49ZM140 0L85.92 72.77L0 101.72L31.15 145.58L52.5 175.64L53.5 266.3L140 239.21L226.52 266.3L227.52 175.64L280 101.72L194.08 72.78L140 0Z" fill="#B54F00"/>
-</g>
-<defs>
-<clipPath id="clip0_7_43">
-<rect width="280" height="266.3" fill="white"/>
-</clipPath>
-</defs>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 280 266.3" style="enable-background:new 0 0 280 266.3;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#B54F00;}
+</style>
+<path class="st0" d="M140,223.5V25.1l44.8,60.3l71.2,24l-43.5,61.3l-0.8,75.2L140,223.5z M140,0L85.9,72.8L0,101.7l0,0l31.2,43.9
+	l21.3,30.1l1,90.7l86.5-27.1l0,0l86.5,27.1l1-90.7l52.5-73.9l-85.9-28.9L140,0z"/>
 </svg>

--- a/templates/default/images/icon_rate_5.svg
+++ b/templates/default/images/icon_rate_5.svg
@@ -1,22 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 18.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
-<g>
-	<defs>
-		<polygon id="SVGID_1_" points="16,2.7 10.6,10 2,12.9 7.3,20.2 7.3,29.3 16,26.6 		"/>
-	</defs>
-	<clipPath id="SVGID_2_">
-		<use xlink:href="#SVGID_1_"  overflow="visible"/>
-	</clipPath>
-	
-		<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="0.9643" y1="33.6071" x2="1.9643" y2="33.6071" gradientTransform="matrix(-28 0 0 -28 57 957.0001)">
-		<stop  offset="0" style="stop-color:#FF8D2C"/>
-		<stop  offset="1.000000e-02" style="stop-color:#FF8D2C"/>
-		<stop  offset="1" style="stop-color:#E56E1E"/>
-	</linearGradient>
-	<rect x="2" y="2.7" clip-path="url(#SVGID_2_)" fill="url(#SVGID_3_)" width="14" height="26.6"/>
+<svg width="280" height="267" viewBox="0 0 280 267" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_7_43)">
+<path d="M140 223.49V25.15L184.84 85.49L256.08 109.49L212.55 170.78L211.74 245.95L140 223.49ZM140 0L85.92 72.77L0 101.72L31.15 145.58L52.5 175.64L53.5 266.3L140 239.21L226.52 266.3L227.52 175.64L280 101.72L194.08 72.78L140 0Z" fill="#B54F00"/>
 </g>
-<polygon fill="#CAD0DF" points="16,2.7 16,26.6 24.7,29.3 24.8,20.2 30,12.9 21.4,10 "/>
+<defs>
+<clipPath id="clip0_7_43">
+<rect width="280" height="266.3" fill="white"/>
+</clipPath>
+</defs>
 </svg>

--- a/templates/default/images/icon_rate_6.svg
+++ b/templates/default/images/icon_rate_6.svg
@@ -1,86 +1,10 @@
-%PDF-1.7
-
-1 0 obj
-  << >>
-endobj
-
-2 0 obj
-  << /Length 3 0 R >>
-stream
-/DeviceRGB CS
-/DeviceRGB cs
-q
-1.000000 0.000000 -0.000000 1.000000 0.000000 0.000000 cm
-0.709804 0.309804 0.000000 scn
-168.000000 34.039825 m
-168.000000 203.469803 l
-184.839996 180.809814 l
-256.079987 156.809814 l
-212.550003 95.519806 l
-211.740005 20.349823 l
-168.000000 34.039825 l
-h
-140.000000 266.299805 m
-85.919998 193.529800 l
-0.000000 164.579803 l
-26.790001 126.859818 l
-52.500000 90.659805 l
-53.500000 -0.000183 l
-140.000000 27.089813 l
-226.520004 -0.000183 l
-227.520004 90.659805 l
-280.000000 164.579803 l
-194.080002 193.519806 l
-140.000000 266.299805 l
-h
-f
-n
-Q
-
-endstream
-endobj
-
-3 0 obj
-  570
-endobj
-
-4 0 obj
-  << /Annots []
-     /Type /Page
-     /MediaBox [ 0.000000 0.000000 280.000000 266.299805 ]
-     /Resources 1 0 R
-     /Contents 2 0 R
-     /Parent 5 0 R
-  >>
-endobj
-
-5 0 obj
-  << /Kids [ 4 0 R ]
-     /Count 1
-     /Type /Pages
-  >>
-endobj
-
-6 0 obj
-  << /Pages 5 0 R
-     /Type /Catalog
-  >>
-endobj
-
-xref
-0 7
-0000000000 65535 f
-0000000010 00000 n
-0000000034 00000 n
-0000000660 00000 n
-0000000682 00000 n
-0000000857 00000 n
-0000000931 00000 n
-trailer
-<< /ID [ (some) (id) ]
-   /Root 6 0 R
-   /Size 7
->>
-startxref
-990
-%%EOF
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 280 266.3" style="enable-background:new 0 0 280 266.3;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#B54F00;}
+</style>
+<path class="st0" d="M168,232.3V62.8l16.8,22.7l71.2,24l-43.5,61.3l-0.8,75.2L168,232.3z M140,0L85.9,72.8L0,101.7l0,0l26.8,37.7
+	l25.7,36.2l1,90.7l86.5-27.1l0,0l86.5,27.1l1-90.7l52.5-73.9l-85.9-28.9L140,0z"/>
+</svg>

--- a/templates/default/images/icon_rate_6.svg
+++ b/templates/default/images/icon_rate_6.svg
@@ -1,22 +1,86 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 18.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
-<polygon fill="#CAD0DF" points="18.8,27.5 24.7,29.3 24.8,20.2 30,12.9 21.4,10 18.8,6.5 "/>
-<g>
-	<defs>
-		<polygon id="SVGID_1_" points="16,2.7 10.6,10 2,12.9 7.2,20.2 7.3,29.3 16,26.6 18.8,27.5 18.8,6.5 		"/>
-	</defs>
-	<clipPath id="SVGID_2_">
-		<use xlink:href="#SVGID_1_"  overflow="visible"/>
-	</clipPath>
-	
-		<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="0.9405" y1="34.0119" x2="1.9405" y2="34.0119" gradientTransform="matrix(-16.7999 0 0 -16.7999 34.5998 587.3967)">
-		<stop  offset="0" style="stop-color:#FF8D2C"/>
-		<stop  offset="1.000000e-02" style="stop-color:#FF8D2C"/>
-		<stop  offset="1" style="stop-color:#E56E1E"/>
-	</linearGradient>
-	<rect x="2" y="2.7" clip-path="url(#SVGID_2_)" fill="url(#SVGID_3_)" width="16.8" height="26.6"/>
-</g>
-</svg>
+%PDF-1.7
+
+1 0 obj
+  << >>
+endobj
+
+2 0 obj
+  << /Length 3 0 R >>
+stream
+/DeviceRGB CS
+/DeviceRGB cs
+q
+1.000000 0.000000 -0.000000 1.000000 0.000000 0.000000 cm
+0.709804 0.309804 0.000000 scn
+168.000000 34.039825 m
+168.000000 203.469803 l
+184.839996 180.809814 l
+256.079987 156.809814 l
+212.550003 95.519806 l
+211.740005 20.349823 l
+168.000000 34.039825 l
+h
+140.000000 266.299805 m
+85.919998 193.529800 l
+0.000000 164.579803 l
+26.790001 126.859818 l
+52.500000 90.659805 l
+53.500000 -0.000183 l
+140.000000 27.089813 l
+226.520004 -0.000183 l
+227.520004 90.659805 l
+280.000000 164.579803 l
+194.080002 193.519806 l
+140.000000 266.299805 l
+h
+f
+n
+Q
+
+endstream
+endobj
+
+3 0 obj
+  570
+endobj
+
+4 0 obj
+  << /Annots []
+     /Type /Page
+     /MediaBox [ 0.000000 0.000000 280.000000 266.299805 ]
+     /Resources 1 0 R
+     /Contents 2 0 R
+     /Parent 5 0 R
+  >>
+endobj
+
+5 0 obj
+  << /Kids [ 4 0 R ]
+     /Count 1
+     /Type /Pages
+  >>
+endobj
+
+6 0 obj
+  << /Pages 5 0 R
+     /Type /Catalog
+  >>
+endobj
+
+xref
+0 7
+0000000000 65535 f
+0000000010 00000 n
+0000000034 00000 n
+0000000660 00000 n
+0000000682 00000 n
+0000000857 00000 n
+0000000931 00000 n
+trailer
+<< /ID [ (some) (id) ]
+   /Root 6 0 R
+   /Size 7
+>>
+startxref
+990
+%%EOF

--- a/templates/default/images/icon_rate_7.svg
+++ b/templates/default/images/icon_rate_7.svg
@@ -1,85 +1,10 @@
-%PDF-1.7
-
-1 0 obj
-  << >>
-endobj
-
-2 0 obj
-  << /Length 3 0 R >>
-stream
-/DeviceRGB CS
-/DeviceRGB cs
-q
-1.000000 0.000000 -0.000000 1.000000 0.000000 0.000000 cm
-0.709804 0.309804 0.000000 scn
-196.000000 25.279785 m
-196.000000 177.049789 l
-256.079987 156.809784 l
-212.550003 95.519775 l
-211.740005 20.349792 l
-196.000000 25.279785 l
-h
-140.000000 266.279785 m
-85.919998 193.529785 l
-0.000000 164.579773 l
-26.790001 126.859787 l
-52.500000 90.659775 l
-53.500000 -0.000214 l
-140.000000 27.089783 l
-226.520004 -0.000214 l
-227.520004 90.659775 l
-280.000000 164.579773 l
-194.080002 193.519791 l
-140.000000 266.279785 l
-h
-f
-n
-Q
-
-endstream
-endobj
-
-3 0 obj
-  546
-endobj
-
-4 0 obj
-  << /Annots []
-     /Type /Page
-     /MediaBox [ 0.000000 0.000000 280.000000 266.299805 ]
-     /Resources 1 0 R
-     /Contents 2 0 R
-     /Parent 5 0 R
-  >>
-endobj
-
-5 0 obj
-  << /Kids [ 4 0 R ]
-     /Count 1
-     /Type /Pages
-  >>
-endobj
-
-6 0 obj
-  << /Pages 5 0 R
-     /Type /Catalog
-  >>
-endobj
-
-xref
-0 7
-0000000000 65535 f
-0000000010 00000 n
-0000000034 00000 n
-0000000636 00000 n
-0000000658 00000 n
-0000000833 00000 n
-0000000907 00000 n
-trailer
-<< /ID [ (some) (id) ]
-   /Root 6 0 R
-   /Size 7
->>
-startxref
-966
-%%EOF
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 280 266.3" style="enable-background:new 0 0 280 266.3;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#B54F00;}
+</style>
+<path class="st0" d="M196,241V89.2l60.1,20.2l-43.5,61.3l-0.8,75.2L196,241z M140,0L85.9,72.8L0,101.7l0,0l26.8,37.7l25.7,36.2
+	l1,90.7l86.5-27.1l0,0l86.5,27.1l1-90.7l52.5-73.9l-85.9-28.9L140,0z"/>
+</svg>

--- a/templates/default/images/icon_rate_7.svg
+++ b/templates/default/images/icon_rate_7.svg
@@ -1,22 +1,85 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 18.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
-<polygon fill="#CAD0DF" points="21.6,28.4 24.7,29.3 24.8,20.2 30,12.9 21.6,10 "/>
-<g>
-	<defs>
-		<polygon id="SVGID_1_" points="16,2.7 10.6,10 2,12.9 7.2,20.2 7.3,29.3 16,26.6 21.6,28.4 21.6,10 21.4,10 		"/>
-	</defs>
-	<clipPath id="SVGID_2_">
-		<use xlink:href="#SVGID_1_"  overflow="visible"/>
-	</clipPath>
-	
-		<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="0.949" y1="33.8674" x2="1.949" y2="33.8674" gradientTransform="matrix(-19.5999 0 0 -19.5999 40.1998 679.7967)">
-		<stop  offset="0" style="stop-color:#FF8D2C"/>
-		<stop  offset="1.000000e-02" style="stop-color:#FF8D2C"/>
-		<stop  offset="1" style="stop-color:#E56E1E"/>
-	</linearGradient>
-	<rect x="2" y="2.7" clip-path="url(#SVGID_2_)" fill="url(#SVGID_3_)" width="19.6" height="26.6"/>
-</g>
-</svg>
+%PDF-1.7
+
+1 0 obj
+  << >>
+endobj
+
+2 0 obj
+  << /Length 3 0 R >>
+stream
+/DeviceRGB CS
+/DeviceRGB cs
+q
+1.000000 0.000000 -0.000000 1.000000 0.000000 0.000000 cm
+0.709804 0.309804 0.000000 scn
+196.000000 25.279785 m
+196.000000 177.049789 l
+256.079987 156.809784 l
+212.550003 95.519775 l
+211.740005 20.349792 l
+196.000000 25.279785 l
+h
+140.000000 266.279785 m
+85.919998 193.529785 l
+0.000000 164.579773 l
+26.790001 126.859787 l
+52.500000 90.659775 l
+53.500000 -0.000214 l
+140.000000 27.089783 l
+226.520004 -0.000214 l
+227.520004 90.659775 l
+280.000000 164.579773 l
+194.080002 193.519791 l
+140.000000 266.279785 l
+h
+f
+n
+Q
+
+endstream
+endobj
+
+3 0 obj
+  546
+endobj
+
+4 0 obj
+  << /Annots []
+     /Type /Page
+     /MediaBox [ 0.000000 0.000000 280.000000 266.299805 ]
+     /Resources 1 0 R
+     /Contents 2 0 R
+     /Parent 5 0 R
+  >>
+endobj
+
+5 0 obj
+  << /Kids [ 4 0 R ]
+     /Count 1
+     /Type /Pages
+  >>
+endobj
+
+6 0 obj
+  << /Pages 5 0 R
+     /Type /Catalog
+  >>
+endobj
+
+xref
+0 7
+0000000000 65535 f
+0000000010 00000 n
+0000000034 00000 n
+0000000636 00000 n
+0000000658 00000 n
+0000000833 00000 n
+0000000907 00000 n
+trailer
+<< /ID [ (some) (id) ]
+   /Root 6 0 R
+   /Size 7
+>>
+startxref
+966
+%%EOF

--- a/templates/default/images/icon_rate_8.svg
+++ b/templates/default/images/icon_rate_8.svg
@@ -1,22 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 18.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
-<polygon fill="#CAD0DF" points="23.6,29 24.7,29.3 24.8,20.2 30,12.9 23.6,10.7 "/>
-<g>
-	<defs>
-		<polygon id="SVGID_1_" points="16,2.7 10.6,10 2,12.9 7.2,20.2 7.3,29.3 16,26.6 23.6,29 23.6,10.7 21.4,10 		"/>
-	</defs>
-	<clipPath id="SVGID_2_">
-		<use xlink:href="#SVGID_1_"  overflow="visible"/>
-	</clipPath>
-	
-		<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="0.9537" y1="33.787" x2="1.9537" y2="33.787" gradientTransform="matrix(-21.5999 0 0 -21.5999 44.1998 745.7967)">
-		<stop  offset="0" style="stop-color:#FF8D2C"/>
-		<stop  offset="1.000000e-02" style="stop-color:#FF8D2C"/>
-		<stop  offset="1" style="stop-color:#E56E1E"/>
-	</linearGradient>
-	<rect x="2" y="2.7" clip-path="url(#SVGID_2_)" fill="url(#SVGID_3_)" width="21.6" height="26.6"/>
+<svg width="280" height="267" viewBox="0 0 280 267" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_8_109)">
+<path d="M216 95.9902L256.08 109.49L216 165.92V95.9902ZM140 -0.00976562L85.92 72.7702L0 101.72L26.79 139.44L52.5 175.64L53.5 266.3L140 239.21L226.52 266.3L227.52 175.64L280 101.72L194.08 72.7802L140 -0.00976562Z" fill="#B54F00"/>
 </g>
+<defs>
+<clipPath id="clip0_8_109">
+<rect width="280" height="266.3" fill="white"/>
+</clipPath>
+</defs>
 </svg>

--- a/templates/default/images/icon_rate_8.svg
+++ b/templates/default/images/icon_rate_8.svg
@@ -1,10 +1,10 @@
-<svg width="280" height="267" viewBox="0 0 280 267" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_8_109)">
-<path d="M216 95.9902L256.08 109.49L216 165.92V95.9902ZM140 -0.00976562L85.92 72.7702L0 101.72L26.79 139.44L52.5 175.64L53.5 266.3L140 239.21L226.52 266.3L227.52 175.64L280 101.72L194.08 72.7802L140 -0.00976562Z" fill="#B54F00"/>
-</g>
-<defs>
-<clipPath id="clip0_8_109">
-<rect width="280" height="266.3" fill="white"/>
-</clipPath>
-</defs>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 280 266.3" style="enable-background:new 0 0 280 266.3;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#B54F00;}
+</style>
+<path class="st0" d="M216,96l40.1,13.5L216,165.9V96z M140,0L85.9,72.8L0,101.7l0,0l26.8,37.7l25.7,36.2l1,90.7l86.5-27.1l0,0
+	l86.5,27.1l1-90.7l52.5-73.9l-85.9-28.9L140,0z"/>
 </svg>

--- a/templates/default/images/icon_rate_9.svg
+++ b/templates/default/images/icon_rate_9.svg
@@ -1,23 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 18.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
-<polygon fill="#CAD0DF" points="26.4,17.9 30,12.9 26.4,11.6 "/>
-<g>
-	<defs>
-		<polygon id="SVGID_1_" points="16,2.7 10.6,10 2,12.9 7.3,20.2 7.3,29.3 16,26.6 24.7,29.3 24.8,20.2 26.4,17.9 26.4,11.6 
-			21.4,10 		"/>
-	</defs>
-	<clipPath id="SVGID_2_">
-		<use xlink:href="#SVGID_1_"  overflow="visible"/>
-	</clipPath>
-	
-		<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="0.959" y1="33.6967" x2="1.959" y2="33.6967" gradientTransform="matrix(-24.3999 0 0 -24.3999 49.7998 838.1967)">
-		<stop  offset="0" style="stop-color:#FF8D2C"/>
-		<stop  offset="1.000000e-02" style="stop-color:#FF8D2C"/>
-		<stop  offset="1" style="stop-color:#E56E1E"/>
-	</linearGradient>
-	<rect x="2" y="2.7" clip-path="url(#SVGID_2_)" fill="url(#SVGID_3_)" width="24.4" height="26.6"/>
+<svg width="280" height="267" viewBox="0 0 280 267" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_8_111)">
+<path d="M244 105.42L256.08 109.49L244 126.49V105.42ZM140 0L85.92 72.77L0 101.72L26.79 139.44L52.5 175.64L53.5 266.3L140 239.21L226.52 266.3L227.52 175.64L280 101.72L194.08 72.78L140 0Z" fill="#B54F00"/>
 </g>
+<defs>
+<clipPath id="clip0_8_111">
+<rect width="280" height="266.3" fill="white"/>
+</clipPath>
+</defs>
 </svg>

--- a/templates/default/images/icon_rate_9.svg
+++ b/templates/default/images/icon_rate_9.svg
@@ -1,10 +1,10 @@
-<svg width="280" height="267" viewBox="0 0 280 267" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_8_111)">
-<path d="M244 105.42L256.08 109.49L244 126.49V105.42ZM140 0L85.92 72.77L0 101.72L26.79 139.44L52.5 175.64L53.5 266.3L140 239.21L226.52 266.3L227.52 175.64L280 101.72L194.08 72.78L140 0Z" fill="#B54F00"/>
-</g>
-<defs>
-<clipPath id="clip0_8_111">
-<rect width="280" height="266.3" fill="white"/>
-</clipPath>
-</defs>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 280 266.3" style="enable-background:new 0 0 280 266.3;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#B54F00;}
+</style>
+<path class="st0" d="M244,105.4l12.1,4.1l-12.1,17V105.4z M140,0L85.9,72.8L0,101.7l0,0l26.8,37.7l25.7,36.2l1,90.7l86.5-27.1l0,0
+	l86.5,27.1l1-90.7l52.5-73.9l-85.9-28.9L140,0z"/>
 </svg>

--- a/templates/default/images/icon_rate_off.svg
+++ b/templates/default/images/icon_rate_off.svg
@@ -1,7 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 18.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
-<polygon fill="#CAD0DF" points="16,2.7 21.4,10 30,12.9 24.8,20.2 24.7,29.3 16,26.6 7.3,29.3 7.2,20.2 2,12.9 10.6,10 "/>
+<svg width="280" height="267" viewBox="0 0 280 267" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_7_103)">
+<path d="M67.45 170.78L23.92 109.49L95.16 85.49L140 25.15L184.84 85.49L256.08 109.49L212.55 170.78L211.74 245.95L140 223.49L68.26 245.95L67.45 170.78ZM140 0L85.92 72.77L0 101.72L52.5 175.64L53.5 266.3L140 239.21L226.52 266.3L227.52 175.64L280 101.72L194.08 72.78L140 0Z" fill="#B54F00"/>
+</g>
+<defs>
+<clipPath id="clip0_7_103">
+<rect width="280" height="266.3" fill="white"/>
+</clipPath>
+</defs>
 </svg>

--- a/templates/default/images/icon_rate_off.svg
+++ b/templates/default/images/icon_rate_off.svg
@@ -1,10 +1,10 @@
-<svg width="280" height="267" viewBox="0 0 280 267" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_7_103)">
-<path d="M67.45 170.78L23.92 109.49L95.16 85.49L140 25.15L184.84 85.49L256.08 109.49L212.55 170.78L211.74 245.95L140 223.49L68.26 245.95L67.45 170.78ZM140 0L85.92 72.77L0 101.72L52.5 175.64L53.5 266.3L140 239.21L226.52 266.3L227.52 175.64L280 101.72L194.08 72.78L140 0Z" fill="#B54F00"/>
-</g>
-<defs>
-<clipPath id="clip0_7_103">
-<rect width="280" height="266.3" fill="white"/>
-</clipPath>
-</defs>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 280 266.3" style="enable-background:new 0 0 280 266.3;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#B54F00;}
+</style>
+<path class="st0" d="M67.4,170.8l-43.5-61.3l71.2-24L140,25.1l44.8,60.3l71.2,24l-43.5,61.3l-0.8,75.2L140,223.5l-71.7,22.5
+	L67.4,170.8z M140,0L85.9,72.8L0,101.7l52.5,73.9l1,90.7l86.5-27.1l86.5,27.1l1-90.7l52.5-73.9l-85.9-28.9L140,0z"/>
 </svg>

--- a/templates/default/images/icon_rate_on.svg
+++ b/templates/default/images/icon_rate_on.svg
@@ -1,21 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 18.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
-<g>
-	<defs>
-		<polygon id="SVGID_1_" points="16,2.7 10.6,10 2,12.9 7.2,20.2 7.3,29.3 16,26.6 24.7,29.3 24.8,20.2 30,12.9 21.4,10 		"/>
-	</defs>
-	<clipPath id="SVGID_2_">
-		<use xlink:href="#SVGID_1_"  overflow="visible"/>
-	</clipPath>
-	
-		<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="0.9643" y1="33.6071" x2="1.9643" y2="33.6071" gradientTransform="matrix(-28 0 0 -28 57 957)">
-		<stop  offset="0" style="stop-color:#FF8E2C"/>
-		<stop  offset="1.000000e-02" style="stop-color:#FF8E2C"/>
-		<stop  offset="1" style="stop-color:#E66E1E"/>
-	</linearGradient>
-	<rect x="2" y="2.7" clip-path="url(#SVGID_2_)" fill="url(#SVGID_3_)" width="28" height="26.6"/>
+<svg width="280" height="267" viewBox="0 0 280 267" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_7_105)">
+<path d="M140 0L85.92 72.77L0 101.72L52.5 175.63L53.48 266.3L140 239.21L226.52 266.3L227.5 175.63L280 101.72L194.08 72.77L140 0Z" fill="#B54F00"/>
 </g>
+<defs>
+<clipPath id="clip0_7_105">
+<rect width="280" height="266.3" fill="white"/>
+</clipPath>
+</defs>
 </svg>

--- a/templates/default/images/icon_rate_on.svg
+++ b/templates/default/images/icon_rate_on.svg
@@ -1,10 +1,10 @@
-<svg width="280" height="267" viewBox="0 0 280 267" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_7_105)">
-<path d="M140 0L85.92 72.77L0 101.72L52.5 175.63L53.48 266.3L140 239.21L226.52 266.3L227.5 175.63L280 101.72L194.08 72.77L140 0Z" fill="#B54F00"/>
-</g>
-<defs>
-<clipPath id="clip0_7_105">
-<rect width="280" height="266.3" fill="white"/>
-</clipPath>
-</defs>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 280 266.3" style="enable-background:new 0 0 280 266.3;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#B54F00;}
+</style>
+<polygon class="st0" points="140,0 85.9,72.8 0,101.7 52.5,175.6 53.5,266.3 140,239.2 226.5,266.3 227.5,175.6 280,101.7 
+	194.1,72.8 "/>
 </svg>

--- a/templates/default/images/icon_rate_on_user.svg
+++ b/templates/default/images/icon_rate_on_user.svg
@@ -1,10 +1,10 @@
-<svg width="280" height="267" viewBox="0 0 280 267" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_8_107)">
-<path d="M140 0L85.92 72.77L0 101.72L52.5 175.63L53.48 266.3L140 239.21L226.52 266.3L227.5 175.63L280 101.72L194.08 72.77L140 0Z" fill="#4C6586"/>
-</g>
-<defs>
-<clipPath id="clip0_8_107">
-<rect width="280" height="266.3" fill="white"/>
-</clipPath>
-</defs>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 280 266.3" style="enable-background:new 0 0 280 266.3;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#4C6586;}
+</style>
+<polygon class="st0" points="140,0 85.9,72.8 0,101.7 52.5,175.6 53.5,266.3 140,239.2 226.5,266.3 227.5,175.6 280,101.7 
+	194.1,72.8 "/>
 </svg>

--- a/templates/default/images/icon_rate_on_user.svg
+++ b/templates/default/images/icon_rate_on_user.svg
@@ -1,21 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 18.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
-<g>
-	<defs>
-		<polygon id="SVGID_1_" points="16,2.7 10.6,10 2,12.9 7.2,20.2 7.3,29.3 16,26.6 24.7,29.3 24.8,20.2 30,12.9 21.4,10 		"/>
-	</defs>
-	<clipPath id="SVGID_2_">
-		<use xlink:href="#SVGID_1_"  overflow="visible"/>
-	</clipPath>
-	
-		<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="-120.4643" y1="163.0714" x2="-119.4643" y2="163.0714" gradientTransform="matrix(28 0 0 -28 3375 4582)">
-		<stop  offset="0" style="stop-color:#002555"/>
-		<stop  offset="1.983430e-02" style="stop-color:#002555"/>
-		<stop  offset="1" style="stop-color:#0F4187"/>
-	</linearGradient>
-	<rect x="2" y="2.7" clip-path="url(#SVGID_2_)" fill="url(#SVGID_3_)" width="28" height="26.6"/>
+<svg width="280" height="267" viewBox="0 0 280 267" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_8_107)">
+<path d="M140 0L85.92 72.77L0 101.72L52.5 175.63L53.48 266.3L140 239.21L226.52 266.3L227.5 175.63L280 101.72L194.08 72.77L140 0Z" fill="#4C6586"/>
 </g>
+<defs>
+<clipPath id="clip0_8_107">
+<rect width="280" height="266.3" fill="white"/>
+</clipPath>
+</defs>
 </svg>


### PR DESCRIPTION
Hi @ALL,

the PR fixes some rating-contrast issues. To increase the contrast between active and non-active rating stars, the .svg-icons were revised together with @yseiler and Carolin Wanner. 

0031104: Insufficient Contrast in Star Ratings - https://mantis.ilias.de/view.php?id=31104

To further unify ILIAS, the scheme headline on gray background, content on white background was introduced. In addition, the outdated yellow background color for hover, was replaced with the @il-highlight-bg provided for this purpose.

This PR exchanges only the 14 rating icons. 

Greetings,
Enrico

![Screenshot 2021-12-07 at 17-22-32 TEST 7 History of ILIAS](https://user-images.githubusercontent.com/42470261/145066961-7c8a92d8-837b-49ba-b18c-b446b2452981.png)


