### PR TITLE
StudyProgamme: harmonize the usage of the integer constraints in settings

### DIFF
--- a/Modules/StudyProgramme/classes/class.ilStudyProgrammeAutoMailSettings.php
+++ b/Modules/StudyProgramme/classes/class.ilStudyProgrammeAutoMailSettings.php
@@ -98,7 +98,7 @@ class ilStudyProgrammeAutoMailSettings
                     [$input->numeric(
                         $ilLng->txt('prg_user_not_restarted_time_input'),
                         $ilLng->txt('prg_user_not_restarted_time_input_info')
-                    )->withAdditionalTransformation($refinery->int()->isGreaterThan(0))],
+                    )->withAdditionalTransformation($refinery->int()->isGreaterThanOrEqual(1))],
                     $ilLng->txt("send_info_to_re_assign_mail"),
                     $ilLng->txt("send_info_to_re_assign_mail_info")
                 )
@@ -108,7 +108,7 @@ class ilStudyProgrammeAutoMailSettings
                     [$input->numeric(
                         $ilLng->txt('prg_processing_ends_no_success'),
                         $ilLng->txt('prg_processing_ends_no_success_info')
-                    )->withAdditionalTransformation($refinery->int()->isGreaterThan(0))],
+                    )->withAdditionalTransformation($refinery->int()->isGreaterThanOrEqual(1))],
                     $ilLng->txt("send_risky_to_fail_mail"),
                     $ilLng->txt("send_risky_to_fail_mail_info")
                 )

--- a/Modules/StudyProgramme/classes/class.ilStudyProgrammeDeadlineSettings.php
+++ b/Modules/StudyProgramme/classes/class.ilStudyProgrammeDeadlineSettings.php
@@ -62,7 +62,7 @@ class ilStudyProgrammeDeadlineSettings
                     '',
                     $lng->txt('prg_deadline_period_desc')
                 )
-                ->withAdditionalTransformation($refinery->int()->isGreaterThan(-1))
+                ->withAdditionalTransformation($refinery->int()->isGreaterThanOrEqual(1))
                 ->withValue($this->getDeadlinePeriod() !== null ? $this->getDeadlinePeriod() : null)
             ],
             $lng->txt('prg_deadline_period')

--- a/Modules/StudyProgramme/classes/class.ilStudyProgrammeValidityOfAchievedQualificationSettings.php
+++ b/Modules/StudyProgramme/classes/class.ilStudyProgrammeValidityOfAchievedQualificationSettings.php
@@ -100,7 +100,7 @@ class ilStudyProgrammeValidityOfAchievedQualificationSettings
                     '',
                     $lng->txt('validity_qualification_period_desc')
                 )
-                ->withAdditionalTransformation($refinery->int()->isGreaterThan(0))
+                ->withAdditionalTransformation($refinery->int()->isGreaterThanOrEqual(1))
                 ->withValue($this->getQualificationPeriod() !== null ? $this->getQualificationPeriod() : null)
             ],
             $lng->txt('validity_qualification_period')
@@ -124,7 +124,7 @@ class ilStudyProgrammeValidityOfAchievedQualificationSettings
                     '',
                     $lng->txt('restart_period_desc')
                 )
-                ->withAdditionalTransformation($refinery->int()->isGreaterThan(0))
+                ->withAdditionalTransformation($refinery->int()->isGreaterThanOrEqual(1))
                 ->withValue($this->getRestartPeriod() !== null ? $this->getRestartPeriod() : null)
             ],
             $lng->txt('restart_period')


### PR DESCRIPTION
Lately we use the newly implemented "isGreaterThanOrEqual" integer constraint to set points in the StudyProgramme module. To harmonize the usage of the constraints in the StudyProgramme module settings I changed all "isGreaterThan" constraints. Therefore following scenarios are now possible:

1. Points: accepts every input greater than or equal "0" (this constraint was already adjusted in another PR).
2. Individual expiration date for qualifications: now accepts every input greater than or equal "1".
3. Individual user timetable: now accepts every input greater than or equal "1".
4. Auto Mail: now accepts every input greater than or equal "1".

