### PR TITLE
CI: activate captain hook and fix codestyle before commitook + Windows approved

### DIFF
--- a/captainhook.json
+++ b/captainhook.json
@@ -36,7 +36,7 @@
         "conditions": []
       },
       {
-        "action": "libs/composer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --config=./CI/PHP-CS-Fixer/code-format.php_cs --using-cache=no --dry-run -vvv {$STAGED_FILES|of-type:php}",
+        "action": "libs/composer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --config=./CI/PHP-CS-Fixer/code-format.php_cs --using-cache=no -vvv {$STAGED_FILES|of-type:php}",
         "options": [],
         "conditions": [
           {


### PR DESCRIPTION
As #4930 already adds the git hooks from captainhook this PR just removes the `--dry-run` option from the `captainhook.json` to automatically fix the codestyle before commiting.

As a side note:
The captainhook git hooks are executed with `/usr/bin/env php`. Therefore `$ which php` must point to `php8.0` or `php8.1`. Linting will fail under `php7.4`.
