### PR TITLE
Improve error propagation in ilServer (release_5-4)

### DIFF
--- a/Services/WebServices/RPC/lib/src/de/ilias/ilServer.java
+++ b/Services/WebServices/RPC/lib/src/de/ilias/ilServer.java
@@ -72,7 +72,8 @@ public class ilServer {
 		
 		ilServer server = null;
 		server = new ilServer(args);
-		server.handleRequest();
+		boolean success = server.handleRequest();
+		System.exit(success ? 0 : 1);
 	}
 	
 	

--- a/Services/WebServices/RPC/lib/src/de/ilias/ilServer.java
+++ b/Services/WebServices/RPC/lib/src/de/ilias/ilServer.java
@@ -94,7 +94,7 @@ public class ilServer {
 		} catch (ConfigurationException | IOException ex) {
 			System.err.println("Failed to initialize logging: "  + ex.getMessage());
 		}
-		return true;
+		return false;
 	}
 	
 


### PR DESCRIPTION
With the recent changes to ilServer that upgraded Log4j to 2.15 (and later, 2.16) there has been a small oversight: if logging initialization fails, the initialization method returns success. This pull request fixes that.

While at it, let’s make ilServer return a proper exit code to the operating system so that callers can handle it appropriately.

I have verified that the code compiles, but nothing further.

This is the pull request for the `release_5-4` branch.