### PR TITLE
fix contraint for numeric inputs

### DIFF
--- a/src/UI/Implementation/Component/Input/Field/Numeric.php
+++ b/src/UI/Implementation/Component/Input/Field/Numeric.php
@@ -53,7 +53,7 @@ class Numeric extends Input implements C\Input\Field\Numeric
      */
     protected function getConstraintForRequirement() : ?Constraint
     {
-        return $this->refinery->to()->int();
+        return $this->refinery->numeric()->isNumeric();
     }
 
     /**


### PR DESCRIPTION
The constraint to check the given request value from numeric input checks falsefully if those are int.
It should check if those are numerics (including numeric strings).