### PR TITLE
UI Components legacy, ilSubmitButton fix

### DIFF
--- a/Services/UIComponent/Button/classes/class.ilSubmitButton.php
+++ b/Services/UIComponent/Button/classes/class.ilSubmitButton.php
@@ -21,7 +21,7 @@
  */
 class ilSubmitButton extends ilButtonBase
 {
-    protected string $cmd;
+    protected string $cmd = "";
     
     public static function getInstance() : self
     {


### PR DESCRIPTION
Just a minor fix, to prevent ILIAS8 to crash on some few screens featuring ilSubmitButtons. 