### PR TITLE
UI Components, Unit Tests, add some helper Class for Dependency Injection

### DIFF
--- a/tests/UI/UITestHelper.php
+++ b/tests/UI/UITestHelper.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+require_once("libs/composer/vendor/autoload.php");
+
+require_once(__DIR__ . "/Base.php");
+
+use ILIAS\DI\Container;
+use ILIAS\UI\Factory;
+use ILIAS\UI\Renderer;
+use ILIAS\Refinery\Factory as RefinaryFactory;
+use \ILIAS\Data\Factory as DataFactory;
+
+/**
+ * Class UITestHelper can be helpful for test cases outside the UI Components, to inject a working
+ * factory and renderer into some clases to be unit tested.
+ *
+ * See; UITestHelperTest, testRenderExample for an example of how this can be used.
+ */
+class UITestHelper
+{
+    protected Container $dic;
+
+    protected function init() : void
+    {
+        $this->dic = new Container();
+        $tpl_fac = new ilIndependentTemplateFactory();
+        $this->dic["tpl"] = $tpl_fac->getTemplate("tpl.main.html", false, false);
+        $this->dic["lng"] = new ilLanguageMock();
+        $data_factory = new DataFactory();
+        $this->dic["refinery"] = new RefinaryFactory($data_factory, $this->dic["lng"]);
+        (new InitUIFramework())->init($this->dic);
+    }
+
+    public function factory() : Factory
+    {
+        if (!isset($this->dic)) {
+            $this->init();
+        }
+        return $this->dic->ui()->factory();
+    }
+
+    public function renderer() : Renderer
+    {
+        if (!isset($this->dic)) {
+            $this->init();
+        }
+        return $this->dic->ui()->renderer();
+    }
+}

--- a/tests/UI/UITestHelper.php
+++ b/tests/UI/UITestHelper.php
@@ -12,9 +12,9 @@ use \ILIAS\Data\Factory as DataFactory;
 
 /**
  * Class UITestHelper can be helpful for test cases outside the UI Components, to inject a working
- * factory and renderer into some clases to be unit tested.
+ * factory and renderer into some classes to be unit tested.
  *
- * See; UITestHelperTest, testRenderExample for an example of how this can be used.
+ * See UITestHelperTest for an example of how this can be used.
  */
 class UITestHelper
 {

--- a/tests/UI/UITestHelper.php
+++ b/tests/UI/UITestHelper.php
@@ -7,7 +7,7 @@ require_once(__DIR__ . "/Base.php");
 use ILIAS\DI\Container;
 use ILIAS\UI\Factory;
 use ILIAS\UI\Renderer;
-use ILIAS\Refinery\Factory as RefinaryFactory;
+use ILIAS\Refinery\Factory as RefineryFactory;
 use \ILIAS\Data\Factory as DataFactory;
 
 /**
@@ -27,7 +27,7 @@ class UITestHelper
         $this->dic["tpl"] = $tpl_fac->getTemplate("tpl.main.html", false, false);
         $this->dic["lng"] = new ilLanguageMock();
         $data_factory = new DataFactory();
-        $this->dic["refinery"] = new RefinaryFactory($data_factory, $this->dic["lng"]);
+        $this->dic["refinery"] = new RefineryFactory($data_factory, $this->dic["lng"]);
         (new InitUIFramework())->init($this->dic);
     }
 

--- a/tests/UI/UITestHelperTest.php
+++ b/tests/UI/UITestHelperTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+require_once("libs/composer/vendor/autoload.php");
+
+require_once(__DIR__ . "/UITestHelper.php");
+
+use PHPUnit\Framework\TestCase;
+use ILIAS\UI\Factory;
+use ILIAS\UI\Renderer;
+
+class UITestHelperTest extends TestCase
+{
+    public function testConstruct() : void
+    {
+        $this->assertInstanceOf("UITestHelper", new UITestHelper());
+    }
+
+    public function testGetFactory() : void
+    {
+        $this->assertInstanceOf(Factory::class, (new UITestHelper())->factory());
+    }
+
+    public function testGetRenderer() : void
+    {
+        $this->assertInstanceOf(Renderer::class, (new UITestHelper())->renderer());
+    }
+
+    public function testRenderExample() : void
+    {
+        $helper = new UITestHelper();
+        $c = $helper->factory()->legacy("hello world");
+        $this->assertEquals("hello world", $helper->renderer()->render($c));
+    }
+}


### PR DESCRIPTION
While working on the sustainability classes for PHP8, I got rid of some legacy GUI components by replacing them with UI Components. The refactored classes got much easier to test, which is done. However, I observed, that even though it is not that much work to mock the deps to the framework, it still work that generates code duplicates. 

It would be helpful, to have some helper at hand, which creates a working UI Factory and Renderer to be injected in the classes to be tested without any hassle. This is what I hereby propose.