### PR TITLE
Services/Cron: refresh job data for plugin jobs as well (#18411)

### DIFF
--- a/Services/Cron/classes/class.ilCronManager.php
+++ b/Services/Cron/classes/class.ilCronManager.php
@@ -67,7 +67,8 @@ class ilCronManager implements \ilCronManagerInterface
 
         // plugins
         foreach (self::getPluginJobs(true) as $item) {
-            self::runJob($item[0], $item[1]);
+            // #18411 - we are NOT using the initial job data as it might be outdated at this point
+            self::runJob($item[0]);
         }
 
         $this->logger->info("CRON - batch end");


### PR DESCRIPTION
Hi @mjansenDatabay,

for some (unknown, to me) reason, the fix for [#18411](https://mantis.ilias.de/view.php?id=18411) has not been extended to cronjobs of plugins. This changes this situation.

Best regards!