### PR TITLE
#31325 - Do not show TOC if it is disabled

### DIFF
--- a/Modules/LearningModule/Presentation/classes/class.ilLMPresentationGUI.php
+++ b/Modules/LearningModule/Presentation/classes/class.ilLMPresentationGUI.php
@@ -214,7 +214,7 @@ class ilLMPresentationGUI
             $DIC->globalScreen()->tool()->context()->claim()->repository();
 
             // moved this into the if due to #0027200
-            if ($this->service->getPresentationStatus()->isTocNecessary()) {
+            if ($this->lm->isActiveTOC() && $this->service->getPresentationStatus()->isTocNecessary()) {
                 $DIC->globalScreen()->tool()->context()->current()->addAdditionalData(
                     ilLMGSToolProvider::SHOW_TOC_TOOL,
                     true


### PR DESCRIPTION
Hi, I've added this condition before the method `isTocNecessary()` so that the TOC won't be displayed if it is deactivated from the "Menu" settings of the module.

Also, I think that the method `isTocNecessary()` is somehow messed up, I didn't get it.