### PR TITLE
Fix type of maxlength from bool to int

### DIFF
--- a/Services/Form/classes/class.ilPasswordInputGUI.php
+++ b/Services/Form/classes/class.ilPasswordInputGUI.php
@@ -25,7 +25,7 @@ class ilPasswordInputGUI extends ilSubEnabledFormPropertyGUI
     protected int $size = 20;
     protected string $validateauthpost = "";
     protected bool $requiredonauth = false;
-    protected bool $maxlength = false;
+    protected int $maxlength = 0;
     protected bool $use_strip_slashes = true;
     /**
      * @var bool Flag whether the html autocomplete attribute should be set to "off" or not


### PR DESCRIPTION
The type should be int. Otherwise the maxlength will always be 1.