### PR TITLE
Fix wrong namespace in Refinery Tests

### DIFF
--- a/tests/Refinery/IdentityTransformationTest.php
+++ b/tests/Refinery/IdentityTransformationTest.php
@@ -3,7 +3,7 @@
 /**
  * @author  Lukas Scharmer <lscharmer@databay.de>
  */
-namespace ILIAS\Tests\Refinery\Random\Transformation;
+namespace ILIAS\Tests\Refinery;
 
 use ILIAS\Data\NotOKException;
 use ILIAS\Data\Result\Ok;

--- a/tests/Refinery/Random/Transformation/ShuffleTransformationTest.php
+++ b/tests/Refinery/Random/Transformation/ShuffleTransformationTest.php
@@ -3,7 +3,7 @@
 /**
  * @author  Lukas Scharmer <lscharmer@databay.de>
  */
-namespace ILIAS\Tests\Refinery;
+namespace ILIAS\Tests\Refinery\Random\Transformation;
 
 use ILIAS\Refinery\Random\Transformation\ShuffleTransformation;
 use ILIAS\Refinery\Random\Seed\Seed;


### PR DESCRIPTION
Fix wrong namespace for Refinery Tests