### PR TITLE
BT-31667: Added missing descriptor of hidden breadcrumb headline

### DIFF
--- a/Services/Tree/classes/class.ilPathGUI.php
+++ b/Services/Tree/classes/class.ilPathGUI.php
@@ -231,6 +231,7 @@ class ilPathGUI
 
                 $first = false;
             }
+            $tpl->setVariable("TXT_BREADCRUMBS", $this->lng->txt("breadcrumb_navigation"));
             return $tpl->get();
         }
     }


### PR DESCRIPTION
Link to PR:
https://mantis.ilias.de/view.php?id=31667

I believe that adding content to the invisible headline is the least invasive way of fixing this accessibility issue and also helps describing the breadcrumb navigation below if it gets read by a screenreader.