### PR TITLE
Bibliografic db step improvement

### DIFF
--- a/Modules/Bibliographic/classes/Setup/class.ilBibliograficDB80.php
+++ b/Modules/Bibliographic/classes/Setup/class.ilBibliograficDB80.php
@@ -18,6 +18,8 @@ class ilBibliograficDB80 implements ilDatabaseUpdateSteps
 
     public function step_1() : void
     {
-        $this->database->dropTableColumn('il_bibl_field', 'object_id');
+        if ($this->database->tableColumnExists('il_bibl_field', 'object_id')) {
+            $this->database->dropTableColumn('il_bibl_field', 'object_id');
+        }
     }
 }


### PR DESCRIPTION
Hi @chfsx,

this is just a small improvement for your recently added database update step. IMO, before trying to drop a table column or table, it should be firstly checked if this table column or table even exists to avoid potential errors.


The way I noticed your recent update step is quite strange. I tried to update the current trunk and stumbled over this error:

`SQLSTATE[42S02]: Base table or view not found: 1146 Table 'ilias_trunk_db.il_bibl_field' doesn't exist`

I cannot explain why this table does not exist in my local Installation, because normally it should have been created in `dbupdate_04.php` (step #5268). If you have any idea why the table creation was skipped in my case, please let me know. But I guess I'm pretty alone with this problem and will simply add this table manually, so this error will vanish. Adding an additional check if the table also exists is rather not a good solution...