### PR TITLE
Write skill profile completion entries

### DIFF
--- a/Modules/Survey/Skills/class.ilSurveySkill.php
+++ b/Modules/Survey/Skills/class.ilSurveySkill.php
@@ -378,6 +378,10 @@ class ilSurveySkill
             }
         }
 
+        //write profile completion entries if fulfilment status has changed
+        $prof_manager = new ilSkillProfileCompletionManager($user_id);
+        $prof_manager->writeCompletionEntryForAllProfiles();
+
         // write self evaluation
         $this->writeAndAddSelfEvalSkills($user_id);
     }

--- a/Modules/Test/classes/class.ilTestSkillEvaluation.php
+++ b/Modules/Test/classes/class.ilTestSkillEvaluation.php
@@ -342,6 +342,9 @@ class ilTestSkillEvaluation
                 ilPersonalSkill::addPersonalSkill($this->getUserId(), $reachedSkillLevel['sklBaseId']);
             }
         }
+        //write profile completion entries if fulfilment status has changed
+        $prof_manager = new ilSkillProfileCompletionManager($this->getUserId());
+        $prof_manager->writeCompletionEntryForAllProfiles();
     }
 
     private function invokeSkillLevelTrigger($skillLevelId, $skillTrefId)

--- a/Services/Container/Skills/classes/class.ilContainerMemberSkills.php
+++ b/Services/Container/Skills/classes/class.ilContainerMemberSkills.php
@@ -175,6 +175,10 @@ class ilContainerMemberSkills
             }
         }
 
+        //write profile completion entries if fulfilment status has changed
+        $prof_manager = new ilSkillProfileCompletionManager($this->getUserId());
+        $prof_manager->writeCompletionEntryForAllProfiles();
+
         $db->manipulate("UPDATE cont_member_skills SET " .
             " published = " . $db->quote(1, "integer") .
             " WHERE obj_id = " . $db->quote($this->getObjId(), "integer") .


### PR DESCRIPTION
Hi @alex40724 and @mbecker-databay,

due to a new [feature](https://docu.ilias.de/goto_docu_wiki_wpage_6133_1357.html) for the Skill Profiles, it must be checked if profiles are fulfilled or not when a user makes progress in her skills. Because this progress happens partly in your components, some additional code is needed to write these profile completion entries.

Please have a quick look at your relevant components and and approve if you have no objections.
Thanks!