### PR TITLE
UI Tree/Node: Add horizontal space between node line elements (arrow,…

### DIFF
--- a/src/UI/templates/default/Tree/tree.less
+++ b/src/UI/templates/default/Tree/tree.less
@@ -16,7 +16,7 @@
 			flex-wrap: wrap;
 			> .node-label {
 				padding-left: @il-tree-node-horizontal-spacing;
-				> .icon {
+				.icon {
 					vertical-align: text-bottom;
 				}
 			}

--- a/src/UI/templates/default/Tree/tree.less
+++ b/src/UI/templates/default/Tree/tree.less
@@ -1,6 +1,6 @@
 .il-tree {
 	list-style-type: none;
-	padding: 0 @padding-small-vertical 0 @padding-small-vertical;
+	padding: 0 @padding-small-vertical 0 calc(@padding-small-vertical + @il-tree-node-horizontal-spacing);
 	margin-left: 0;
 	ul {
 		padding-left: @il-tree-node-indentation;
@@ -14,10 +14,14 @@
 			cursor: pointer;
 			display: flex;
 			flex-wrap: wrap;
-			> .node-label .icon{
-				vertical-align: text-bottom;
+			> .node-label {
+				padding-left: @il-tree-node-horizontal-spacing;
+				> .icon {
+					vertical-align: text-bottom;
+				}
 			}
 			> .node-byline {
+				padding-left: @il-tree-node-horizontal-spacing;
 				width: 100%;
 			}
 		}

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -8851,7 +8851,7 @@ div.alert ul > li:before {
 .il-tree li.il-tree-node .node-line > .node-label {
   padding-left: 4px;
 }
-.il-tree li.il-tree-node .node-line > .node-label > .icon {
+.il-tree li.il-tree-node .node-line > .node-label .icon {
   vertical-align: text-bottom;
 }
 .il-tree li.il-tree-node .node-line > .node-byline {

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -8832,7 +8832,7 @@ div.alert ul > li:before {
 }
 .il-tree {
   list-style-type: none;
-  padding: 0 3px 0 3px;
+  padding: 0 3px 0 calc(3px + 4px);
   margin-left: 0;
 }
 .il-tree ul {
@@ -8848,10 +8848,14 @@ div.alert ul > li:before {
   display: flex;
   flex-wrap: wrap;
 }
-.il-tree li.il-tree-node .node-line > .node-label .icon {
+.il-tree li.il-tree-node .node-line > .node-label {
+  padding-left: 4px;
+}
+.il-tree li.il-tree-node .node-line > .node-label > .icon {
   vertical-align: text-bottom;
 }
 .il-tree li.il-tree-node .node-line > .node-byline {
+  padding-left: 4px;
   width: 100%;
 }
 .il-tree li.il-tree-node.highlighted > .node-line {

--- a/templates/default/less/variables.less
+++ b/templates/default/less/variables.less
@@ -831,7 +831,8 @@ with the il- variable set here.
 @il-tree-node-indentation: @il-font-size-base;
 //** Vertical Space between nodes
 @il-tree-node-vertical-spacing: 3px;
-
+//** Horizontal space between expand/collapse icon, an optional node icon and node label
+@il-tree-node-horizontal-spacing: 4px;
 //== Characteristic Value Listing
 //** item rows layout
 @il-characteristic-value-border-color: @il-main-border-color;


### PR DESCRIPTION
… icon, label) according to Mantis issue 31840

This PR introduces a new LESS variable (for the `UI Tree/Node`)  to make the horizontal space between the expand/collapse element, the optional node icon and the node label configurable.

Mantis Issue: https://mantis.ilias.de/view.php?id=31840