### PR TITLE
GlobalCache/APC: Fix iterating over invalid iterator state (trunk)

### DIFF
--- a/Services/GlobalCache/classes/Apc/class.ilApc.php
+++ b/Services/GlobalCache/classes/Apc/class.ilApc.php
@@ -51,7 +51,7 @@ class ilApc extends ilGlobalCacheService implements ilGlobalCacheServiceInterfac
             $key_prefix = $this->returnKey('');
             $apcu_iterator = new APCUIterator();
             $apcu_iterator->rewind();
-            while ($current_key = $apcu_iterator->key()) {
+            while ($apcu_iterator->valid() && $current_key = $apcu_iterator->key()) {
                 // "begins with"
                 if (substr($current_key, 0, strlen($key_prefix)) === $key_prefix) {
                     $this->delete($current_key);


### PR DESCRIPTION
(cherry picked from commit 1545d236c47edf358ef14af7852573e52c051728)