### PR TITLE
fix mantis bug #29165: Tests in lso not shown in testoverview

### DIFF
--- a/Services/Object/classes/class.ilPasteIntoMultipleItemsExplorer.php
+++ b/Services/Object/classes/class.ilPasteIntoMultipleItemsExplorer.php
@@ -74,12 +74,14 @@ class ilPasteIntoMultipleItemsExplorer extends ilRepositoryExplorer
         $this->addFilter('grp');
         $this->addFilter('cat');
         $this->addFilter('fold');
+        $this->addFilter('lso');
         
         $this->addFormItemForType('root');
         $this->addFormItemForType('crs');
         $this->addFormItemForType('grp');
         $this->addFormItemForType('cat');
         $this->addFormItemForType('fold');
+        $this->addFormItemForType('lso');
         
         $this->setFiltered(true);
         $this->setFilterMode(IL_FM_POSITIVE);


### PR DESCRIPTION
This is needed in order to fix mantis bug report #29165 together with https://github.com/DatabayAG/TestOverview/pull/4. In the repo picker of the TestOverView-Plugin lsos are currently not shown. Please have a look if this is a proper fix @mjansenDatabay @mbecker-databay 