### PR TITLE
PHP(: Service/HTTPS

### DIFF
--- a/Services/Http/classes/Setup/Condition/ProxyConnectableCondition.php
+++ b/Services/Http/classes/Setup/Condition/ProxyConnectableCondition.php
@@ -20,7 +20,7 @@ class ProxyConnectableCondition extends ExternalConditionObjective
 {
     public function __construct($config)
     {
-        return parent::__construct(
+        parent::__construct(
             "Can establish a connection to proxy",
             function (Setup\Environment $env) use ($config) : bool {
                 try {

--- a/Services/Http/classes/Setup/Condition/ProxyConnectableCondition.php
+++ b/Services/Http/classes/Setup/Condition/ProxyConnectableCondition.php
@@ -1,10 +1,21 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2020 Daniel Weise <daniel.weise@concepts-and-training.de> Extended GPL, see docs/LICENSE */
-
 use ILIAS\Setup;
 use ILIAS\Setup\Condition\ExternalConditionObjective;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 class ProxyConnectableCondition extends ExternalConditionObjective
 {
     public function __construct($config)

--- a/Services/Http/classes/Setup/class.ilHttpConfigStoredObjective.php
+++ b/Services/Http/classes/Setup/class.ilHttpConfigStoredObjective.php
@@ -1,15 +1,23 @@
 <?php
 
-/* Copyright (c) 2019 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
-
 use ILIAS\Setup;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 class ilHttpConfigStoredObjective implements Setup\Objective
 {
-    /**
-     * @var	\ilHttpSetupConfig
-     */
-    protected $config;
+    protected \ilHttpSetupConfig $config;
 
     public function __construct(
         \ilHttpSetupConfig $config
@@ -32,6 +40,9 @@ class ilHttpConfigStoredObjective implements Setup\Objective
         return false;
     }
 
+    /**
+     * @return \ilIniFilesLoadedObjective[]|\ilSettingsFactoryExistsObjective[]
+     */
     public function getPreconditions(Setup\Environment $environment) : array
     {
         return [
@@ -44,10 +55,30 @@ class ilHttpConfigStoredObjective implements Setup\Objective
     {
         $ini = $environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI);
 
-        $ini->setVariable("server", "http_path", $this->config->getHttpPath());
-        $ini->setVariable("https", "auto_https_detect_enabled", $this->config->isAutodetectionEnabled() ? "1" : "0");
-        $ini->setVariable("https", "auto_https_detect_header_name", $this->config->getHeaderName());
-        $ini->setVariable("https", "auto_https_detect_header_value", $this->config->getHeaderValue());
+        $ini->setVariable(
+            ilHTTPS::SETTINGS_GROUP_SERVER,
+            ilHTTPS::SETTING_HTTP_PATH,
+            $this->config->getHttpPath()
+        );
+        $ini->setVariable(
+            ilHTTPS::SETTINGS_GROUP_HTTPS,
+            ilHTTPS::SETTING_FORCED,
+            $this->config->isForced() ? "1" : "0"
+        );
+        $ini->setVariable(
+            ilHTTPS::SETTINGS_GROUP_HTTPS,
+            ilHTTPS::SETTING_AUTO_HTTPS_DETECT_ENABLED,
+            $this->config->isAutodetectionEnabled() ? "1" : "0"
+        );
+        $ini->setVariable(
+            ilHTTPS::SETTINGS_GROUP_HTTPS,
+            ilHTTPS::SETTING_AUTO_HTTPS_DETECT_HEADER_NAME,
+            $this->config->getHeaderName());
+        $ini->setVariable(
+            ilHTTPS::SETTINGS_GROUP_HTTPS,
+            ilHTTPS::SETTING_AUTO_HTTPS_DETECT_HEADER_VALUE,
+            $this->config->getHeaderValue()
+        );
 
 
         if (!$ini->write()) {
@@ -73,12 +104,14 @@ class ilHttpConfigStoredObjective implements Setup\Objective
         $settings = $factory->settingsFor("common");
 
         $detect_enabled = $this->config->isAutodetectionEnabled() ? "1" : "0";
+        $forced = $this->config->isForced() ? "1" : "0";
 
         return
-            $ini->readVariable("server", "http_path") !== $this->config->getHttpPath() ||
-            $ini->readVariable("https", "auto_https_detect_enabled") !== $detect_enabled ||
-            $ini->readVariable("https", "auto_https_detect_header_name") !== $this->config->getHeaderName() ||
-            $ini->readVariable("https", "auto_https_detect_header_value") !== $this->config->getHeaderValue() ||
+            $ini->readVariable(ilHTTPS::SETTINGS_GROUP_SERVER, ilHTTPS::SETTING_HTTP_PATH) !== $this->config->getHttpPath() ||
+            $ini->readVariable(ilHTTPS::SETTINGS_GROUP_HTTPS, ilHTTPS::SETTING_AUTO_HTTPS_DETECT_ENABLED) !== $detect_enabled ||
+            $ini->readVariable(ilHTTPS::SETTINGS_GROUP_HTTPS, ilHTTPS::SETTING_FORCED) !== $forced ||
+            $ini->readVariable(ilHTTPS::SETTINGS_GROUP_HTTPS, ilHTTPS::SETTING_AUTO_HTTPS_DETECT_HEADER_NAME) !== $this->config->getHeaderName() ||
+            $ini->readVariable(ilHTTPS::SETTINGS_GROUP_HTTPS, ilHTTPS::SETTING_AUTO_HTTPS_DETECT_HEADER_VALUE) !== $this->config->getHeaderValue() ||
             $settings->get("proxy_status") !== (int) $this->config->isProxyEnabled() ||
             $settings->get("proxy_host") !== $this->config->getProxyHost() ||
             $settings->get("proxy_port") !== $this->config->getProxyPort()

--- a/Services/Http/classes/Setup/class.ilHttpConfigStoredObjective.php
+++ b/Services/Http/classes/Setup/class.ilHttpConfigStoredObjective.php
@@ -73,7 +73,8 @@ class ilHttpConfigStoredObjective implements Setup\Objective
         $ini->setVariable(
             ilHTTPS::SETTINGS_GROUP_HTTPS,
             ilHTTPS::SETTING_AUTO_HTTPS_DETECT_HEADER_NAME,
-            $this->config->getHeaderName());
+            $this->config->getHeaderName()
+        );
         $ini->setVariable(
             ilHTTPS::SETTINGS_GROUP_HTTPS,
             ilHTTPS::SETTING_AUTO_HTTPS_DETECT_HEADER_VALUE,

--- a/Services/Http/classes/Setup/class.ilHttpMetricsCollectedObjective.php
+++ b/Services/Http/classes/Setup/class.ilHttpMetricsCollectedObjective.php
@@ -1,11 +1,25 @@
 <?php
 
-/* Copyright (c) 2020 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
-
 use ILIAS\Setup;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 class ilHttpMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
 {
+    /**
+     * @return \ilIniFilesLoadedObjective[]|\ilSettingsFactoryExistsObjective[]
+     */
     public function getTentativePreconditions(Setup\Environment $environment) : array
     {
         return [
@@ -23,6 +37,11 @@ class ilHttpMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
                 "http_path",
                 $ilias_ini->readVariable("server", "http_path"),
                 "URL of the server."
+            );
+            $storage->storeConfigText(
+                "https forced",
+                $ilias_ini->readVariable("https", "forced"),
+                ""
             );
 
             if ($ilias_ini->readVariable("https", "auto_https_detect_enabled")) {

--- a/Services/Http/classes/Setup/class.ilHttpSetupAgent.php
+++ b/Services/Http/classes/Setup/class.ilHttpSetupAgent.php
@@ -43,7 +43,7 @@ class ilHttpSetupAgent implements Setup\Agent
      */
     public function getArrayToConfigTransformation() : Refinery\Transformation
     {
-        return $this->refinery->custom()->transformation(function ($data): \ilHttpSetupConfig {
+        return $this->refinery->custom()->transformation(function ($data) : \ilHttpSetupConfig {
             return new \ilHttpSetupConfig(
                 $data["path"],
                 isset($data["https_autodetection"]) && $data["https_autodetection"],

--- a/Services/Http/classes/Setup/class.ilHttpSetupAgent.php
+++ b/Services/Http/classes/Setup/class.ilHttpSetupAgent.php
@@ -1,20 +1,28 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2020 Daniel Weise <daniel.weise@concepts-and-training.de> Extended GPL, see docs/LICENSE */
-
 use ILIAS\Setup;
 use ILIAS\Refinery;
 use ILIAS\Data;
 use ILIAS\UI;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 class ilHttpSetupAgent implements Setup\Agent
 {
     use Setup\Agent\HasNoNamedObjective;
 
-    /**
-     * @var Refinery\Factory
-     */
-    protected $refinery;
+    protected \ILIAS\Refinery\Factory $refinery;
 
     public function __construct(
         Refinery\Factory $refinery
@@ -35,21 +43,18 @@ class ilHttpSetupAgent implements Setup\Agent
      */
     public function getArrayToConfigTransformation() : Refinery\Transformation
     {
-        return $this->refinery->custom()->transformation(function ($data) {
+        return $this->refinery->custom()->transformation(function ($data): \ilHttpSetupConfig {
             return new \ilHttpSetupConfig(
                 $data["path"],
-                (isset($data["https_autodetection"]) && $data["https_autodetection"])
-                    ? true
-                    : false,
+                isset($data["https_autodetection"]) && $data["https_autodetection"],
+                isset($data["forced"]) && $data["forced"],
                 (isset($data["https_autodetection"]) && $data["https_autodetection"])
                     ? $data["https_autodetection"]["header_name"]
                     : null,
                 (isset($data["https_autodetection"]) && $data["https_autodetection"])
                     ? $data["https_autodetection"]["header_value"]
                     : null,
-                (isset($data["proxy"]) && $data["proxy"])
-                    ? true
-                    : false,
+                isset($data["proxy"]) && $data["proxy"],
                 (isset($data["proxy"]) && $data["proxy"])
                     ? $data["proxy"]["host"]
                     : null,
@@ -72,7 +77,7 @@ class ilHttpSetupAgent implements Setup\Agent
         }
 
         return new Setup\Objective\ObjectiveWithPreconditions(
-            $http_config_stored, 
+            $http_config_stored,
             new ProxyConnectableCondition($config)
         );
     }

--- a/Services/Http/classes/Setup/class.ilHttpSetupConfig.php
+++ b/Services/Http/classes/Setup/class.ilHttpSetupConfig.php
@@ -1,50 +1,36 @@
 <?php
 
-/* Copyright (c) 2019 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
-
 use ILIAS\Setup;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 class ilHttpSetupConfig implements Setup\Config
 {
-    /**
-     * @var	string
-     */
-    protected $http_path;
-
-    /**
-     * @var	bool
-     */
-    protected $autodetection_enabled;
-
-    /**
-     * @var string|null
-     */
-    protected $header_name;
-
-    /**
-     * @var string|null
-     */
-    protected $header_value;
-
-    /**
-     * @var bool
-     */
-    protected $proxy_enabled;
-
-    /**
-     * @var string|null
-     */
-    protected $proxy_host;
-
-    /**
-     * @var string|null
-     */
-    protected $proxy_port;
+    protected string $http_path;
+    protected bool $forced = false;
+    protected bool $autodetection_enabled;
+    protected ?string $header_name;
+    protected ?string $header_value;
+    protected bool $proxy_enabled;
+    protected ?string $proxy_host;
+    protected ?string $proxy_port;
 
 
     public function __construct(
         string $http_path,
         bool $autodetection_enabled,
+        bool $forced,
         ?string $header_name,
         ?string $header_value,
         bool $proxy_enabled,
@@ -63,11 +49,18 @@ class ilHttpSetupConfig implements Setup\Config
         }
         $this->http_path = $http_path;
         $this->autodetection_enabled = $autodetection_enabled;
+        $this->forced = $forced;
         $this->header_name = $header_name;
         $this->header_value = $header_value;
         $this->proxy_enabled = $proxy_enabled;
         $this->proxy_host = $proxy_host;
         $this->proxy_port = $proxy_port;
+    }
+
+
+    public function isForced() : bool
+    {
+        return $this->forced;
     }
 
     public function getHttpPath() : string

--- a/Services/Http/classes/class.ilHTTPS.php
+++ b/Services/Http/classes/class.ilHTTPS.php
@@ -1,97 +1,143 @@
 <?php
-/* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 /**
-* HTTPS
-*
-*
-* @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*/
-
+ * Class ilHTTPS
+ * @author  Stefan Meyer <meyer@leifos.com>
+ *
+ *          Find usages: (((DIC|GLOBALS)\[['"]https.*)|(global .* $https))
+ */
 class ilHTTPS
 {
-    const PROTOCOL_HTTP = 1;
-    const PROTOCOL_HTTPS = 2;
-    
-    private static $instance = null;
+    protected const PROTOCOL_HTTP = 1;
+    protected const PROTOCOL_HTTPS = 2;
+    public const SETTINGS_GROUP_SERVER = 'server';
+    public const SETTING_HTTP_PATH = 'http_path';
+    public const SETTINGS_GROUP_HTTPS = 'https';
+    public const SETTING_AUTO_HTTPS_DETECT_ENABLED = "auto_https_detect_enabled";
+    public const SETTING_AUTO_HTTPS_DETECT_HEADER_NAME = "auto_https_detect_header_name";
+    public const SETTING_AUTO_HTTPS_DETECT_HEADER_VALUE = "auto_https_detect_header_value";
+    public const SETTING_FORCED = 'forced';
+    protected bool $enabled = false;
+    protected array $protected_classes = [];
+    protected array $protected_scripts = [];
+    protected bool $automatic_detection = false;
+    protected ?string $header_name = null;
+    protected ?string $header_value = null;
+    protected ilIniFile $ilias_ini;
+    protected ilIniFile $client_ini;
 
-    protected $enabled = false;
-
-    protected $protected_classes = array();
-    protected $protected_scripts = array();
-
-    protected $automaticHTTPSDetectionEnabled = false;
-    protected $headerName = false;
-    protected $headerValue = false;
-
-    /**
-     * @deprected use <code>ilHTTPS::getInstance()</code>
-     * @return
-     */
     public function __construct()
     {
-        global $ilSetting, $ilIliasIniFile;
+        global $DIC;
+        $this->ilias_ini = $DIC->iliasIni();
+        $this->client_ini = $DIC->clientIni();
 
-        if ($this->enabled = (bool) $ilSetting->get('https')) {
-            $this->__readProtectedScripts();
-            $this->__readProtectedClasses();
+        if ($this->enabled = (bool) $this->ilias_ini->readVariable(
+            self::SETTINGS_GROUP_HTTPS,
+            self::SETTING_FORCED
+        )) {
+            $this->readProtectedScripts();
+            $this->readProtectedClasses();
         }
 
-        if ($this->automaticHTTPSDetectionEnabled = (bool) $ilIliasIniFile->readVariable('https', "auto_https_detect_enabled")) {
-            $this->headerName = $ilIliasIniFile->readVariable('https', "auto_https_detect_header_name");
-            $this->headerValue = $ilIliasIniFile->readVariable('https', "auto_https_detect_header_value");
+        if ($this->automatic_detection = (bool) $this->ilias_ini->readVariable(
+            self::SETTINGS_GROUP_HTTPS,
+            self::SETTING_AUTO_HTTPS_DETECT_ENABLED
+        )) {
+            $this->header_name = $this->ilias_ini->readVariable(
+                self::SETTINGS_GROUP_HTTPS,
+                self::SETTING_AUTO_HTTPS_DETECT_HEADER_NAME
+            );
+            $this->header_value = $this->ilias_ini->readVariable(
+                self::SETTINGS_GROUP_HTTPS,
+                self::SETTING_AUTO_HTTPS_DETECT_HEADER_VALUE
+            );
         }
     }
-    
-    /**
-     * Get https instance
-     * @return
-     */
-    public static function getInstance()
+
+    private function readProtectedScripts() : void
     {
-        if (self::$instance) {
-            return self::$instance;
-        }
-        return self::$instance = new ilHTTPS();
+        $this->protected_scripts[] = 'login.php';
+        $this->protected_scripts[] = 'index.php';
+        $this->protected_scripts[] = 'register.php';
+        $this->protected_scripts[] = 'webdav.php';
+        $this->protected_scripts[] = 'shib_login.php';
     }
 
     /**
-     * @param bool $to_protocol
-     * @return bool
+     * check if https is detected
+     *
+     * @return bool, if https is detected by protocol or by automatic detection, if enabled, false otherwise
      */
-    protected function shouldSwitchProtocol($to_protocol)
+    public function isDetected() : bool
     {
-        switch ($to_protocol) {
-            case self::PROTOCOL_HTTP:
-                $should_switch_to_http = (
-                    !in_array(basename($_SERVER['SCRIPT_NAME']), $this->protected_scripts) &&
-                    !in_array(strtolower($_GET['cmdClass']), $this->protected_classes)
-                ) && $_SERVER['HTTPS'] == 'on';
+        if (isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on") {
+            return true;
+        }
 
-                return $should_switch_to_http;
-                break;
-
-            case self::PROTOCOL_HTTPS:
-                $should_switch_to_https = (
-                    in_array(basename($_SERVER['SCRIPT_NAME']), $this->protected_scripts) ||
-                    in_array(strtolower($_GET['cmdClass']), $this->protected_classes)
-                ) && $_SERVER['HTTPS'] != 'on';
-
-                return $should_switch_to_https;
-                break;
+        if ($this->automatic_detection) {
+            $header_name = "HTTP_" . str_replace("-", "_", strtoupper($this->header_name));
+            /* echo $header_name;
+             echo $_SERVER[$header_name];*/
+            if (isset($_SERVER[$header_name])) {
+                if (strcasecmp($_SERVER[$header_name], $this->header_value) == 0) {
+                    $_SERVER["HTTPS"] = "on";
+                    return true;
+                }
+            }
         }
 
         return false;
     }
 
-    /**
-     * check if current port usage is right: if https should be used than redirection is done, to http otherwise.
-     *
-     * @return unknown
-     */
-    public function checkPort()
+    private function readProtectedClasses() : void
+    {
+        $this->protected_classes[] = 'ilstartupgui';
+        $this->protected_classes[] = 'ilaccountregistrationgui';
+        $this->protected_classes[] = 'ilpersonalsettingsgui';
+    }
+
+    public function checkHTTPS(int $port = 443) : bool
+    {
+        if (($sp = fsockopen($_SERVER["SERVER_NAME"], $port, $errno, $error)) === false) {
+            return false;
+        }
+        fclose($sp);
+        return true;
+    }
+
+    public function enableSecureCookies() : void
+    {
+        $secure_disabled = (bool) $this->client_ini->readVariable('session', 'disable_secure_cookies');
+        if (!$secure_disabled && !$this->enabled && $this->isDetected() && !session_id()) {
+            if (!defined('IL_COOKIE_SECURE')) {
+                define('IL_COOKIE_SECURE', true);
+            }
+
+            session_set_cookie_params(
+                IL_COOKIE_EXPIRE,
+                IL_COOKIE_PATH,
+                IL_COOKIE_DOMAIN,
+                true,
+                IL_COOKIE_HTTPONLY
+            );
+        }
+    }
+
+    public function checkProtocolAndRedirectIfNeeded() : bool
     {
         // if https is enabled for scripts or classes, check for redirection
         if ($this->enabled) {
@@ -107,116 +153,23 @@ class ilHTTPS
         return true;
     }
 
-    public function __readProtectedScripts()
+    private function shouldSwitchProtocol($to_protocol) : bool
     {
-        $this->protected_scripts[] = 'login.php';
-        $this->protected_scripts[] = 'index.php';
-        $this->protected_scripts[] = 'register.php';
-        $this->protected_scripts[] = 'webdav.php';
-        $this->protected_scripts[] = 'shib_login.php';
-        
-        return true;
-    }
+        switch ($to_protocol) {
+            case self::PROTOCOL_HTTP:
+                return (
+                        !in_array(basename($_SERVER['SCRIPT_NAME']), $this->protected_scripts) &&
+                        !in_array(strtolower($_GET['cmdClass']), $this->protected_classes)
+                    ) && $_SERVER['HTTPS'] == 'on';
 
-    /**
-     * check if https is detected
-     *
-     * @return boolean true, if https is detected by protocol or by automatic detection, if enabled, false otherwise
-     */
-    public function isDetected()
-    {
-        if (isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on") {
-            return true;
-        }
-
-        if ($this->automaticHTTPSDetectionEnabled) {
-            $headerName = "HTTP_" . str_replace("-", "_", strtoupper($this->headerName));
-            /* echo $headerName;
-             echo $_SERVER[$headerName];*/
-            if (isset($_SERVER[$headerName])) {
-                if (strcasecmp($_SERVER[$headerName], $this->headerValue) == 0) {
-                    $_SERVER["HTTPS"] = "on";
-                    return true;
-                }
-            }
-            /*
-            if(isset($_SERVER[$this->headerName]) && (strcasecmp($_SERVER[$this->headerName],$this->headerValue) == 0))
-            {
-                $_SERVER['HTTPS'] = 'on';
-                return true;
-            }
-            */
+            case self::PROTOCOL_HTTPS:
+                return (
+                        in_array(basename($_SERVER['SCRIPT_NAME']), $this->protected_scripts) ||
+                        in_array(strtolower($_GET['cmdClass']), $this->protected_classes)
+                    ) && $_SERVER['HTTPS'] != 'on';
         }
 
         return false;
     }
 
-    public function __readProtectedClasses()
-    {
-        $this->protected_classes[] = 'ilstartupgui';
-        $this->protected_classes[] = 'ilaccountregistrationgui';
-        $this->protected_classes[] = 'ilpersonalsettingsgui';
-    }
-
-    /**
-    * static method to check if https connections are possible for this server
-    * @access	public
-    * @return	boolean
-    */
-    public static function _checkHTTPS()
-    {
-        // only check standard port in the moment
-        $port = 443;
-
-        if (($sp = fsockopen($_SERVER["SERVER_NAME"], $port, $errno, $error)) === false) {
-            return false;
-        }
-        fclose($sp);
-        return true;
-    }
-    /**
-    * static method to check if http connections are possible for this server
-    *
-    * @access	public
-    * @return	boolean
-    */
-    public function _checkHTTP()
-    {
-        $port = 80;
-
-        if (($sp = fsockopen($_SERVER["SERVER_NAME"], $port, $errno, $error)) === false) {
-            return false;
-        }
-        fclose($sp);
-        return true;
-    }
-    
-    /**
-     * enable secure cookies
-     *
-     * @access public
-     * @param
-     * @return
-     */
-    public function enableSecureCookies()
-    {
-        global $ilClientIniFile;
-
-        $secure_disabled = $ilClientIniFile->readVariable('session', 'disable_secure_cookies');
-        if (!$secure_disabled && !$this->enabled && $this->isDetected() && !session_id()) {
-            if (!defined('IL_COOKIE_SECURE')) {
-                define('IL_COOKIE_SECURE', true);
-            }
-
-            session_set_cookie_params(
-                IL_COOKIE_EXPIRE,
-                IL_COOKIE_PATH,
-                IL_COOKIE_DOMAIN,
-                true,
-                IL_COOKIE_HTTPONLY
-            );
-        }
-
-        return true;
-    }
 }

--- a/Services/Http/classes/class.ilHTTPS.php
+++ b/Services/Http/classes/class.ilHTTPS.php
@@ -171,5 +171,4 @@ class ilHTTPS
 
         return false;
     }
-
 }

--- a/Services/Http/classes/class.ilProxySettings.php
+++ b/Services/Http/classes/class.ilProxySettings.php
@@ -1,13 +1,23 @@
 <?php
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
-
-require_once './Services/Http/exceptions/class.ilProxyException.php';
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 /**
  * class ilProxySettings
  *
- * @author	Michael Jansen <mjansen@databay.de>
- * @version	$Id$
+ * @author     Michael Jansen <mjansen@databay.de>
+ * @version    $Id$
  *
  */
 class ilProxySettings
@@ -18,237 +28,61 @@ class ilProxySettings
      *
      * Unique instance
      *
-     * @access	protected
-     * @var		ilProxySettings
-     * @type	ilProxySettings
+     * @access    protected
+     * @type    ilProxySettings
      *
      */
-    protected static $_instance = null;
-    
-    /**
-     *
-     * Host
-     *
-     * @access	protected
-     * @var		string
-     * @type	string
-     *
-     */
-    protected $host = '';
-    
-    /**
-     *
-     * Port
-     *
-     * @access	protected
-     * @var		string
-     * @type	string
-     *
-     */
-    protected $post = '';
-    
-    /**
-     *
-     * Status
-     *
-     * @access	protected
-     * @var		boolean
-     * @type	boolean
-     *
-     */
-    protected $isActive = false;
-    
-    /**
-     *
-     * Constructor
-     *
-     * @access	protected
-     *
-     */
+    protected static ?\ilProxySettings $_instance = null;
+    protected string $host = '';
+    protected int $port = 80;
+    protected bool $active = false;
+    protected ilSetting $setting;
+    protected ilLanguage $language;
+
     protected function __construct()
     {
+        global $DIC;
+        $this->setting = $DIC->settings();
+        $this->language = $DIC->language();
         $this->read();
     }
-    
-    /**
-     *
-     * __clone
-     *
-     * @access	private
-     *
-     */
-    private function __clone()
-    {
-    }
-    
-    /**
-     *
-     * Getter for unique instance
-     *
-     * @access	public
-     * @static
-     * @return	ilProxySettings
-     *
-     */
-    public static function _getInstance()
+
+    public static function _getInstance() : \ilProxySettings
     {
         if (null === self::$_instance) {
             self::$_instance = new self();
         }
-        
+
         return self::$_instance;
     }
-    
+
     /**
      *
      * Fetches data from database
      *
-     * @access	protected
+     * @access    protected
      *
      */
-    protected function read()
+    protected function read() : void
     {
-        global $ilSetting;
-        
-        $this->setHost($ilSetting->get('proxy_host'));
-        $this->setPort($ilSetting->get('proxy_port'));
-        $this->isActive((bool) $ilSetting->get('proxy_status'));
+        $this->host = (string) $this->setting->get('proxy_host');
+        $this->port = (int) $this->setting->get('proxy_port');
+        $this->active = (bool) $this->setting->get('proxy_status');
     }
-    
-    /**
-     *
-     * Getter/Setter for status
-     *
-     * @access	public
-     * @param	mixed	boolean or null
-     * @return	mixed	ilProxySettings or boolean
-     *
-     */
-    public function isActive($status = null)
+
+    public function isActive() : bool
     {
-        if (null === $status) {
-            return (bool) $this->isActive;
-        }
-        
-        $this->isActive = (bool) $status;
-        
-        return $this;
+        return $this->active;
     }
-    
-    /**
-     *
-     * Setter for host
-     *
-     * @access	public
-     * @param	string
-     * @return	ilProxySettings
-     *
-     */
-    public function setHost($host)
-    {
-        $this->host = $host;
-        
-        return $this;
-    }
-    
-    /**
-     *
-     * Getter for host
-     *
-     * @access	public
-     * @return	string
-     *
-     */
-    public function getHost()
+
+    public function getHost() : string
     {
         return $this->host;
     }
-    
-    /**
-     *
-     * Setter for port
-     *
-     * @access	public
-     * @param	string
-     * @return	ilProxySettings
-     *
-     */
-    public function setPort($port)
-    {
-        $this->port = $port;
 
-        return $this;
-    }
-    
-    /**
-     *
-     * Getter for port
-     *
-     * @access	public
-     * @return	string
-     *
-     */
-    public function getPort()
+    public function getPort() : int
     {
         return $this->port;
     }
-    
-    /**
-     *
-     * Saves the current data in database
-     *
-     * @access	public
-     * @return	ilProxySettings
-     *
-     */
-    public function save()
-    {
-        global $ilSetting;
-        
-        $ilSetting->set('proxy_host', $this->getHost());
-        $ilSetting->set('proxy_port', $this->getPort());
-        $ilSetting->set('proxy_status', (int) $this->isActive());
-        
-        return $this;
-    }
-    
-    /**
-     *
-     * Verifies the proxy server connection
-     *
-     * @access	public
-     * @return	ilProxySettings
-     * @throws	ilProxyException
-     *
-     */
-    public function checkConnection()
-    {
-        global $DIC;
 
-        $errno = null;
-        $errstr = null;
-
-        set_error_handler(function ($severity, $message, $file, $line) {
-            throw new ErrorException($message, $severity, $severity, $file, $line);
-        });
-
-        try {
-            $host = $this->getHost();
-            if (strspn($host, '.0123456789') != strlen($host) && strstr($host, '/') === false) {
-                $host = gethostbyname($host);
-            }
-            $port = $this->getPort() % 65536;
-
-            if (!fsockopen($host, $port, $errno, $errstr, self::CONNECTION_CHECK_TIMEOUT)) {
-                restore_error_handler();
-                throw new ilProxyException(strlen($errstr) ? $errstr : $DIC->language()->txt('proxy_not_connectable'));
-            }
-            restore_error_handler();
-        } catch (Exception $e) {
-            restore_error_handler();
-            throw new ilProxyException(strlen($errstr) ? $errstr : $DIC->language()->txt('proxy_not_connectable'));
-        }
-
-        return $this;
-    }
 }

--- a/Services/Http/classes/class.ilProxySettings.php
+++ b/Services/Http/classes/class.ilProxySettings.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /******************************************************************************
  *
  * This file is part of ILIAS, a powerful learning management system.
@@ -15,39 +15,25 @@
 
 /**
  * class ilProxySettings
- *
- * @author     Michael Jansen <mjansen@databay.de>
- * @version    $Id$
- *
+ * @author Michael Jansen <mjansen@databay.de>
  */
 class ilProxySettings
 {
-    const CONNECTION_CHECK_TIMEOUT = 10;
-
-    /**
-     *
-     * Unique instance
-     *
-     * @access    protected
-     * @type    ilProxySettings
-     *
-     */
-    protected static ?\ilProxySettings $_instance = null;
+    protected static ?ilProxySettings $_instance = null;
     protected string $host = '';
     protected int $port = 80;
     protected bool $active = false;
     protected ilSetting $setting;
-    protected ilLanguage $language;
 
     protected function __construct()
     {
         global $DIC;
+
         $this->setting = $DIC->settings();
-        $this->language = $DIC->language();
         $this->read();
     }
 
-    public static function _getInstance() : \ilProxySettings
+    public static function _getInstance() : ilProxySettings
     {
         if (null === self::$_instance) {
             self::$_instance = new self();
@@ -56,13 +42,6 @@ class ilProxySettings
         return self::$_instance;
     }
 
-    /**
-     *
-     * Fetches data from database
-     *
-     * @access    protected
-     *
-     */
     protected function read() : void
     {
         $this->host = (string) $this->setting->get('proxy_host');
@@ -84,5 +63,4 @@ class ilProxySettings
     {
         return $this->port;
     }
-
 }

--- a/Services/Http/exceptions/class.ilProxyException.php
+++ b/Services/Http/exceptions/class.ilProxyException.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /******************************************************************************
  *
  * This file is part of ILIAS, a powerful learning management system.
@@ -12,26 +12,11 @@
  *      https://github.com/ILIAS-eLearning
  *
  *****************************************************************************/
+
 /**
-* Class for proxy related exception handling in ILIAS.
-*
-* @author Michael Jansen <mjansen@databay.de>
-* @version $Id$
-*
-*/
+ * Class for proxy related exception handling in ILIAS.
+ * @author Michael Jansen <mjansen@databay.de>
+ */
 class ilProxyException extends ilException
 {
-    /**
-    * Constructor
-    *
-    * A message is not optional as in build in class Exception
-    *
-    * @access public
-    * @param	string	$a_message message
-    *
-    */
-    public function __construct($a_message)
-    {
-        parent::__construct($a_message);
-    }
 }

--- a/Services/Http/exceptions/class.ilProxyException.php
+++ b/Services/Http/exceptions/class.ilProxyException.php
@@ -1,8 +1,17 @@
 <?php
-/* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
-
-require_once 'Services/Exceptions/classes/class.ilException.php';
-
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
 * Class for proxy related exception handling in ILIAS.
 *

--- a/Services/Init/classes/Dependencies/InitHttpServices.php
+++ b/Services/Init/classes/Dependencies/InitHttpServices.php
@@ -21,6 +21,10 @@ class InitHttpServices
             return new \ILIAS\HTTP\Response\Sender\DefaultResponseSenderStrategy();
         };
 
+        $container['http.security'] = function ($c) {
+            throw new OutOfBoundsException('TODO');
+        };
+
         $container['http'] = function ($c) {
             return new \ILIAS\HTTP\Services($c);
         };

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -374,10 +374,9 @@ class ilInitialisation
      */
     protected static function buildHTTPPath()
     {
-        include_once './Services/Http/classes/class.ilHTTPS.php';
-        $https = new ilHTTPS();
+        global $DIC;
 
-        if ($https->isDetected()) {
+        if ($DIC['https']->isDetected()) {
             $protocol = 'https://';
         } else {
             $protocol = 'http://';
@@ -640,14 +639,13 @@ class ilInitialisation
      */
     protected static function setSessionCookieParams()
     {
-        global $ilSetting;
+        global $ilSetting, $DIC;
 
         if (!defined('IL_COOKIE_SECURE')) {
             // If this code is executed, we can assume that \ilHTTPS::enableSecureCookies was NOT called before
             // \ilHTTPS::enableSecureCookies already executes session_set_cookie_params()
 
-            include_once './Services/Http/classes/class.ilHTTPS.php';
-            $cookie_secure = !$ilSetting->get('https', 0) && ilHTTPS::getInstance()->isDetected();
+            $cookie_secure = !$ilSetting->get('https', 0) && $DIC['https']->isDetected();
             define('IL_COOKIE_SECURE', $cookie_secure); // Default Value
 
             session_set_cookie_params(
@@ -1274,7 +1272,7 @@ class ilInitialisation
                 "./Services/Component/classes/class.ilPluginAdmin.php"
             );
         }
-
+        self::initGlobal("https", "ilHTTPS", "./Services/Http/classes/class.ilHTTPS.php");
         self::initSettings();
         self::setSessionHandler();
         self::initMail($GLOBALS['DIC']);
@@ -1289,10 +1287,8 @@ class ilInitialisation
         self::initLocale();
 
         if (ilContext::usesHTTP()) {
-            // $https
-            self::initGlobal("https", "ilHTTPS", "./Services/Http/classes/class.ilHTTPS.php");
             $https->enableSecureCookies();
-            $https->checkPort();
+            $https->checkProtocolAndRedirectIfNeeded();
         }
 
 

--- a/Services/PrivacySecurity/classes/class.ilSecuritySettings.php
+++ b/Services/PrivacySecurity/classes/class.ilSecuritySettings.php
@@ -12,6 +12,7 @@
  * https://github.com/ILIAS-eLearning
  */
 
+
 /**
  * Singleton class that stores all security settings
  * @author  Roland Küstermann <roland@kuestermann.com>
@@ -37,6 +38,7 @@ class ilSecuritySettings
     private \ilDBInterface $db;
     private \ilSetting $settings;
     private \ilRbacReview $review;
+    protected ilHTTPS $https;
 
     private bool $https_enable;
 
@@ -75,6 +77,7 @@ class ilSecuritySettings
         $this->db = $DIC->database();
         $this->settings = $DIC->settings();
         $this->review = $DIC->rbac()->review();
+        $this->https = $DIC['https'];
 
         $this->read();
     }
@@ -342,7 +345,7 @@ class ilSecuritySettings
         $code = null;
 
         if ($this->isHTTPSEnabled()) {
-            if (!ilHTTPS::_checkHTTPS()) {
+            if (!$this->https->checkHTTPS()) {
                 $code = ilSecuritySettings::$SECURITY_SETTINGS_ERR_CODE_HTTPS_NOT_AVAILABLE;
                 if (!$a_form) {
                     return $code;

--- a/src/HTTP/Cookies/Cookie.php
+++ b/src/HTTP/Cookies/Cookie.php
@@ -2,6 +2,19 @@
 
 namespace ILIAS\HTTP\Cookies;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Interface Cookie
  *
@@ -18,24 +31,18 @@ interface Cookie
 
     /**
      * Cookie name.
-     *
-     * @return string
      */
     public function getName() : string;
 
 
     /**
      * Cookie value.
-     *
-     * @return string|null
      */
     public function getValue() : ?string;
 
 
     /**
      * Expiration date as unix timestamp.
-     *
-     * @return int
      */
     public function getExpires() : int;
 
@@ -43,40 +50,30 @@ interface Cookie
     /**
      * Max age measured in seconds.
      * If the max age is zero no max age is set.
-     *
-     * @return int
      */
     public function getMaxAge() : int;
 
 
     /**
      * Cookie path.
-     *
-     * @return string
      */
     public function getPath() : ?string;
 
 
     /**
      * Cookie domain.
-     *
-     * @return string
      */
     public function getDomain() : ?string;
 
 
     /**
      * True if it's secure cookie otherwise false.
-     *
-     * @return bool
      */
     public function getSecure() : bool;
 
 
     /**
      * True if the cookie is http only otherwise false.
-     *
-     * @return bool
      */
     public function getHttpOnly() : bool;
 
@@ -85,8 +82,6 @@ interface Cookie
      * Sets the cookie value.
      *
      * @param null|string $value The cookie value.
-     *
-     * @return Cookie
      */
     public function withValue(string $value = null) : Cookie;
 
@@ -99,16 +94,12 @@ interface Cookie
      * then the expires key will be removed from the cookie.
      *
      * @param null|\DateTimeInterface|int|string $expires The expiration time of the Cookie.
-     *
-     * @return Cookie
      */
     public function withExpires($expires = null) : Cookie;
 
 
     /**
      * Sets the expiration date to +5 years.
-     *
-     * @return Cookie
      */
     public function rememberForLongTime() : Cookie;
 
@@ -116,8 +107,6 @@ interface Cookie
     /**
      * Expire the cookie.
      * Useful if the cookie should be deleted at the client side.
-     *
-     * @return Cookie
      */
     public function expire() : Cookie;
 
@@ -127,8 +116,6 @@ interface Cookie
      * The most browser prefer max age over expiration date.
      *
      * @param null|int $maxAge Lifetime in seconds.
-     *
-     * @return Cookie
      */
     public function withMaxAge(int $maxAge = null) : Cookie;
 
@@ -137,8 +124,6 @@ interface Cookie
      * Sets the cookie path.
      *
      * @param null|string $path The cookie path.
-     *
-     * @return Cookie
      */
     public function withPath(string $path = null) : Cookie;
 
@@ -147,8 +132,6 @@ interface Cookie
      * Sets the domain name for the cookie.
      *
      * @param null|string $domain Cookie domain.
-     *
-     * @return Cookie
      */
     public function withDomain(string $domain = null) : Cookie;
 
@@ -157,8 +140,6 @@ interface Cookie
      * Sets if the cookie is a secure cookie or not.
      *
      * @param null|bool $secure Secure flag.
-     *
-     * @return Cookie
      */
     public function withSecure(bool $secure = null) : Cookie;
 
@@ -167,8 +148,6 @@ interface Cookie
      * Sets if the cookie is http only.
      *
      * @param null|bool $httpOnly http only flag.
-     *
-     * @return Cookie
      */
     public function withHttpOnly(bool $httpOnly = null) : Cookie;
 

--- a/src/HTTP/Cookies/CookieFactory.php
+++ b/src/HTTP/Cookies/CookieFactory.php
@@ -2,6 +2,19 @@
 
 namespace ILIAS\HTTP\Cookies;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Interface CookieFactory
  *
@@ -20,8 +33,6 @@ interface CookieFactory
      *
      * @param string      $name  The unique cookie name.
      * @param null|string $value Cookie value.
-     *
-     * @return Cookie
      */
     public function create(string $name, string $value = null) : Cookie;
 
@@ -31,8 +42,6 @@ interface CookieFactory
      *
      * @param string      $name  The unique cookie name.
      * @param null|string $value Cookie value.
-     *
-     * @return Cookie
      */
     public function createRememberedForLongTime(string $name, string $value = null) : Cookie;
 
@@ -42,8 +51,6 @@ interface CookieFactory
      * This is useful if the cookie should be deleted at the client end.
      *
      * @param string $name Cookie name.
-     *
-     * @return Cookie
      */
     public function createExpired(string $name) : Cookie;
 
@@ -52,8 +59,6 @@ interface CookieFactory
      * Creates the cookie from the cookie string.
      *
      * @param string $string Cookie string.
-     *
-     * @return Cookie
      */
     public function fromSetCookieString(string $string) : Cookie;
 }

--- a/src/HTTP/Cookies/CookieFactoryImpl.php
+++ b/src/HTTP/Cookies/CookieFactoryImpl.php
@@ -4,6 +4,19 @@ namespace ILIAS\HTTP\Cookies;
 
 use Dflydev\FigCookies\SetCookie;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Class CookieFactoryImpl
  *
@@ -20,7 +33,7 @@ class CookieFactoryImpl implements CookieFactory
     /**
      * @inheritdoc
      */
-    public function create(string $name, string $value = null) : \ILIAS\HTTP\Cookies\Cookie
+    public function create(string $name, string $value = null) : Cookie
     {
         return new CookieWrapper(SetCookie::create($name, $value));
     }
@@ -29,7 +42,7 @@ class CookieFactoryImpl implements CookieFactory
     /**
      * @inheritdoc
      */
-    public function createRememberedForLongTime(string $name, string $value = null) : \ILIAS\HTTP\Cookies\Cookie
+    public function createRememberedForLongTime(string $name, string $value = null) : Cookie
     {
         return new CookieWrapper(SetCookie::createRememberedForever($name, $value));
     }
@@ -38,7 +51,7 @@ class CookieFactoryImpl implements CookieFactory
     /**
      * @inheritdoc
      */
-    public function createExpired(string $name) : \ILIAS\HTTP\Cookies\Cookie
+    public function createExpired(string $name) : Cookie
     {
         return new CookieWrapper(SetCookie::createExpired($name));
     }
@@ -47,7 +60,7 @@ class CookieFactoryImpl implements CookieFactory
     /**
      * @inheritdoc
      */
-    public function fromSetCookieString(string $string) : \ILIAS\HTTP\Cookies\Cookie
+    public function fromSetCookieString(string $string) : Cookie
     {
         return new CookieWrapper(SetCookie::fromSetCookieString($string));
     }

--- a/src/HTTP/Cookies/CookieJar.php
+++ b/src/HTTP/Cookies/CookieJar.php
@@ -4,6 +4,19 @@ namespace ILIAS\HTTP\Cookies;
 
 use Psr\Http\Message\ResponseInterface;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Interface CookieJar
  *
@@ -39,8 +52,6 @@ interface CookieJar
      * If no cookie could be found, null is returned.
      *
      * @param string $name Name of the cookie which should be returned.
-     *
-     * @return Cookie | null
      */
     public function get(string $name) : ?Cookie;
 
@@ -76,9 +87,7 @@ interface CookieJar
     /**
      * Render CookieJar into a Response.
      *
-     * @param ResponseInterface $response
      *
-     * @return ResponseInterface
      */
     public function renderIntoResponseHeader(ResponseInterface $response) : ResponseInterface;
 }

--- a/src/HTTP/Cookies/CookieJarFactory.php
+++ b/src/HTTP/Cookies/CookieJarFactory.php
@@ -4,6 +4,19 @@ namespace ILIAS\HTTP\Cookies;
 
 use Psr\Http\Message\ResponseInterface;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Interface CookieJarFactory
  *
@@ -21,8 +34,6 @@ interface CookieJarFactory
      * Create CookieJar from a collection of Cookie header value strings.
      *
      * @param string[] $cookieStrings
-     *
-     * @return CookieJar
      */
     public function fromCookieStrings(array $cookieStrings) : CookieJar;
 
@@ -30,9 +41,7 @@ interface CookieJarFactory
     /**
      * Create CookieJar from a Response.
      *
-     * @param ResponseInterface $response
      *
-     * @return CookieJar
      */
     public function fromResponse(ResponseInterface $response) : CookieJar;
 }

--- a/src/HTTP/Cookies/CookieJarFactoryImpl.php
+++ b/src/HTTP/Cookies/CookieJarFactoryImpl.php
@@ -5,6 +5,19 @@ namespace ILIAS\HTTP\Cookies;
 use Dflydev\FigCookies\SetCookies;
 use Psr\Http\Message\ResponseInterface;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Class CookieJarFactoryImpl
  *
@@ -21,7 +34,7 @@ class CookieJarFactoryImpl implements CookieJarFactory
     /**
      * @inheritdoc
      */
-    public function fromCookieStrings(array $cookieStrings) : \ILIAS\HTTP\Cookies\CookieJar
+    public function fromCookieStrings(array $cookieStrings) : CookieJar
     {
         return new CookieJarWrapper(SetCookies::fromSetCookieStrings($cookieStrings));
     }
@@ -30,7 +43,7 @@ class CookieJarFactoryImpl implements CookieJarFactory
     /**
      * @inheritdoc
      */
-    public function fromResponse(ResponseInterface $response) : \ILIAS\HTTP\Cookies\CookieJar
+    public function fromResponse(ResponseInterface $response) : CookieJar
     {
         return new CookieJarWrapper(SetCookies::fromResponse($response));
     }

--- a/src/HTTP/Cookies/CookieJarWrapper.php
+++ b/src/HTTP/Cookies/CookieJarWrapper.php
@@ -5,6 +5,19 @@ namespace ILIAS\HTTP\Cookies;
 use Dflydev\FigCookies\SetCookies;
 use Psr\Http\Message\ResponseInterface;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Class CookieJarWrapper
  *
@@ -18,16 +31,11 @@ use Psr\Http\Message\ResponseInterface;
 class CookieJarWrapper implements CookieJar
 {
 
-    /**
-     * @var SetCookies $cookies
-     */
-    private $cookies;
+    private SetCookies $cookies;
 
 
     /**
      * CookieJarWrapper constructor.
-     *
-     * @param SetCookies $cookies
      */
     public function __construct(SetCookies $cookies)
     {
@@ -72,7 +80,7 @@ class CookieJarWrapper implements CookieJar
     /**
      * @inheritDoc
      */
-    public function with(Cookie $setCookie) : \ILIAS\HTTP\Cookies\CookieJar
+    public function with(Cookie $setCookie) : CookieJar
     {
         /**
          * @var CookieWrapper $wrapper
@@ -90,7 +98,7 @@ class CookieJarWrapper implements CookieJar
     /**
      * @inheritDoc
      */
-    public function without(string $name) : \ILIAS\HTTP\Cookies\CookieJar
+    public function without(string $name) : CookieJar
     {
         $clone = clone $this;
         $clone->cookies = $this->cookies->without($name);
@@ -102,10 +110,8 @@ class CookieJarWrapper implements CookieJar
     /**
      * @inheritDoc
      */
-    public function renderIntoResponseHeader(ResponseInterface $response) : \Psr\Http\Message\ResponseInterface
+    public function renderIntoResponseHeader(ResponseInterface $response) : ResponseInterface
     {
-        $response = $this->cookies->renderIntoSetCookieHeader($response);
-
-        return $response;
+        return $this->cookies->renderIntoSetCookieHeader($response);
     }
 }

--- a/src/HTTP/Cookies/CookieWrapper.php
+++ b/src/HTTP/Cookies/CookieWrapper.php
@@ -4,11 +4,22 @@ namespace ILIAS\HTTP\Cookies;
 
 use Dflydev\FigCookies\SetCookie;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Class CookieWrapper
- *
  * Facade class for the FigCookies SetCookie class.
- *
  * @author  Nicolas Schäfli <ns@studer-raimann.ch>
  * @package ILIAS\HTTP\Cookies
  * @since   5.3
@@ -16,26 +27,17 @@ use Dflydev\FigCookies\SetCookie;
  */
 class CookieWrapper implements Cookie
 {
-
-    /**
-     * Underlying implementation.
-     *
-     * @var SetCookie $cookie
-     */
-    private $cookie;
-
-
+    
+    private SetCookie $cookie;
+    
     /**
      * CookieFacade constructor.
-     *
-     * @param SetCookie $cookie
      */
     public function __construct(SetCookie $cookie)
     {
         $this->cookie = $cookie;
     }
-
-
+    
     /**
      * @inheritDoc
      */
@@ -43,8 +45,7 @@ class CookieWrapper implements Cookie
     {
         return $this->cookie->getName();
     }
-
-
+    
     /**
      * @inheritDoc
      */
@@ -52,8 +53,7 @@ class CookieWrapper implements Cookie
     {
         return $this->cookie->getValue();
     }
-
-
+    
     /**
      * @inheritDoc
      */
@@ -61,8 +61,7 @@ class CookieWrapper implements Cookie
     {
         return $this->cookie->getExpires();
     }
-
-
+    
     /**
      * @inheritDoc
      */
@@ -70,8 +69,7 @@ class CookieWrapper implements Cookie
     {
         return $this->cookie->getMaxAge();
     }
-
-
+    
     /**
      * @inheritDoc
      */
@@ -79,8 +77,7 @@ class CookieWrapper implements Cookie
     {
         return $this->cookie->getPath();
     }
-
-
+    
     /**
      * @inheritDoc
      */
@@ -88,8 +85,7 @@ class CookieWrapper implements Cookie
     {
         return $this->cookie->getDomain();
     }
-
-
+    
     /**
      * @inheritDoc
      */
@@ -97,8 +93,7 @@ class CookieWrapper implements Cookie
     {
         return $this->cookie->getSecure();
     }
-
-
+    
     /**
      * @inheritDoc
      */
@@ -106,116 +101,106 @@ class CookieWrapper implements Cookie
     {
         return $this->cookie->getHttpOnly();
     }
-
-
+    
     /**
      * @inheritDoc
      */
-    public function withValue(string $value = null) : \ILIAS\HTTP\Cookies\Cookie
+    public function withValue(string $value = null) : Cookie
     {
-        $clone = clone $this;
+        $clone         = clone $this;
         $clone->cookie = $this->cookie->withValue($value);
-
+        
         return $clone;
     }
-
-
+    
     /**
      * @inheritDoc
      */
-    public function withExpires($expires = null) : \ILIAS\HTTP\Cookies\Cookie
+    public function withExpires($expires = null) : Cookie
     {
-        $clone = clone $this;
+        $clone         = clone $this;
         $clone->cookie = $this->cookie->withExpires($expires);
-
+        
         return $clone;
     }
-
-
+    
     /**
      * @inheritDoc
      */
-    public function rememberForLongTime() : \ILIAS\HTTP\Cookies\Cookie
+    public function rememberForLongTime() : Cookie
     {
-        $clone = clone $this;
+        $clone         = clone $this;
         $clone->cookie = $this->cookie->rememberForever();
-
+        
         return $clone;
     }
-
-
+    
     /**
      * @inheritDoc
      */
-    public function expire() : \ILIAS\HTTP\Cookies\Cookie
+    public function expire() : Cookie
     {
-        $clone = clone $this;
+        $clone         = clone $this;
         $clone->cookie = $this->cookie->expire();
-
+        
         return $clone;
     }
-
-
+    
     /**
      * @inheritDoc
      */
-    public function withMaxAge(int $maxAge = null) : \ILIAS\HTTP\Cookies\Cookie
+    public function withMaxAge(int $maxAge = null) : Cookie
     {
-        $clone = clone $this;
+        $clone         = clone $this;
         $clone->cookie = $this->cookie->withMaxAge($maxAge);
-
+        
         return $clone;
     }
-
-
+    
     /**
      * @inheritDoc
      */
-    public function withPath(string $path = null) : \ILIAS\HTTP\Cookies\Cookie
+    public function withPath(string $path = null) : Cookie
     {
-        $clone = clone $this;
+        $clone         = clone $this;
         $clone->cookie = $this->cookie->withPath($path);
-
+        
         return $clone;
     }
-
-
+    
     /**
      * @inheritDoc
      */
-    public function withDomain(string $domain = null) : \ILIAS\HTTP\Cookies\Cookie
+    public function withDomain(string $domain = null) : Cookie
     {
-        $clone = clone $this;
+        $clone         = clone $this;
         $clone->cookie = $this->cookie->withDomain($domain);
-
+        
         return $clone;
     }
-
-
+    
     /**
      * @inheritDoc
      */
-    public function withSecure(bool $secure = null) : \ILIAS\HTTP\Cookies\Cookie
+    public function withSecure(bool $secure = null) : Cookie
     {
-        $clone = clone $this;
+        $clone         = clone $this;
         $clone->cookie = $this->cookie->withSecure($secure);
-
+        
         return $clone;
     }
-
-
+    
     /**
      * @inheritDoc
      */
-    public function withHttpOnly(bool $httpOnly = null) : \ILIAS\HTTP\Cookies\Cookie
+    public function withHttpOnly(bool $httpOnly = null) : Cookie
     {
-        $clone = clone $this;
+        $clone         = clone $this;
         $clone->cookie = $this->cookie->withHttpOnly($httpOnly);
-
+        
         return $clone;
     }
-
-
+    
     /**
      * @inheritDoc
      */
@@ -223,16 +208,13 @@ class CookieWrapper implements Cookie
     {
         return $this->cookie->__toString();
     }
-
-
+    
     /**
      * Returns the underlying implementation.
      * Only for package/service internal use!!!
-     *
-     * @return SetCookie
      * @internal
      */
-    public function getImplementation()
+    public function getImplementation() : SetCookie
     {
         return $this->cookie;
     }

--- a/src/HTTP/GlobalHttpState.php
+++ b/src/HTTP/GlobalHttpState.php
@@ -10,6 +10,19 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Interface GlobalHttpState
  *
@@ -38,8 +51,6 @@ interface GlobalHttpState
 
     /**
      * Returns the current psr-7 response.
-     *
-     * @return ResponseInterface
      */
     public function response() : ResponseInterface;
 
@@ -48,8 +59,6 @@ interface GlobalHttpState
      * Returns a cookie jar which has all cookies known by the ILIAS response.
      * Make sure to call the saveResponse method when the cookies are rendered into the response
      * object.
-     *
-     * @return CookieJar
      */
     public function cookieJar() : CookieJar;
 
@@ -60,8 +69,6 @@ interface GlobalHttpState
      * There is a possibility that the request can't be saved back in the near future.
      *
      * @param ServerRequestInterface $request The server request which should be saved.
-     *
-     * @return void
      */
     public function saveRequest(ServerRequestInterface $request) : void;
 
@@ -70,8 +77,6 @@ interface GlobalHttpState
      * Saves the given response for further use.
      *
      * @param ResponseInterface $response The response which should be saved.
-     *
-     * @return void
      */
     public function saveResponse(ResponseInterface $response) : void;
 
@@ -79,7 +84,6 @@ interface GlobalHttpState
     /**
      * Render the current response hold by ILIAS.
      *
-     * @return void
      * @throws ResponseSendingException Each subsequent call will throw this exception.
      */
     public function sendResponse() : void;

--- a/src/HTTP/RawHTTPServices.php
+++ b/src/HTTP/RawHTTPServices.php
@@ -11,6 +11,19 @@ use ILIAS\HTTP\Wrapper\WrapperFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Provides an interface to the ILIAS HTTP services.
  *
@@ -19,30 +32,12 @@ use Psr\Http\Message\ServerRequestInterface;
 class RawHTTPServices implements GlobalHttpState
 {
 
-    /**
-     * @var ResponseSenderStrategy
-     */
-    private $sender;
-    /**
-     * @var CookieJarFactory $cookieJarFactory
-     */
-    private $cookieJarFactory;
-    /**
-     * @var RequestFactory $requestFactory
-     */
-    private $requestFactory;
-    /**
-     * @var ResponseFactory $responseFactory
-     */
-    private $responseFactory;
-    /**
-     * @var ServerRequestInterface $request
-     */
-    private $request;
-    /**
-     * @var ResponseInterface $response
-     */
-    private $response;
+    private \ILIAS\HTTP\Response\Sender\ResponseSenderStrategy $sender;
+    private \ILIAS\HTTP\Cookies\CookieJarFactory $cookieJarFactory;
+    private \ILIAS\HTTP\Request\RequestFactory $requestFactory;
+    private \ILIAS\HTTP\Response\ResponseFactory $responseFactory;
+    private ?\Psr\Http\Message\ServerRequestInterface $request = null;
+    private ?\Psr\Http\Message\ResponseInterface $response = null;
 
 
     /**
@@ -50,8 +45,6 @@ class RawHTTPServices implements GlobalHttpState
      *
      * @param ResponseSenderStrategy $senderStrategy   A response sender strategy.
      * @param CookieJarFactory       $cookieJarFactory Cookie Jar implementation.
-     * @param RequestFactory         $requestFactory
-     * @param ResponseFactory        $responseFactory
      */
     public function __construct(ResponseSenderStrategy $senderStrategy, CookieJarFactory $cookieJarFactory, RequestFactory $requestFactory, ResponseFactory $responseFactory)
     {

--- a/src/HTTP/Request/RequestFactory.php
+++ b/src/HTTP/Request/RequestFactory.php
@@ -4,6 +4,19 @@ namespace ILIAS\HTTP\Request;
 
 use Psr\Http\Message\ServerRequestInterface;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Interface RequestFactory
  *
@@ -19,8 +32,6 @@ interface RequestFactory
 
     /**
      * Creates a new ServerRequest object with the help of the underlying library.
-     *
-     * @return ServerRequestInterface
      */
     public function create() : ServerRequestInterface;
 }

--- a/src/HTTP/Request/RequestFactoryImpl.php
+++ b/src/HTTP/Request/RequestFactoryImpl.php
@@ -5,6 +5,19 @@ namespace ILIAS\HTTP\Request;
 use GuzzleHttp\Psr7\ServerRequest;
 use Psr\Http\Message\ServerRequestInterface;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Class RequestFactoryImpl
  *

--- a/src/HTTP/Response/ResponseFactory.php
+++ b/src/HTTP/Response/ResponseFactory.php
@@ -4,6 +4,19 @@ namespace ILIAS\HTTP\Response;
 
 use Psr\Http\Message\ResponseInterface;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Interface ResponseFactory
  *
@@ -19,8 +32,6 @@ interface ResponseFactory
 
     /**
      * Creates a new response with the help of the underlying library.
-     *
-     * @return ResponseInterface
      */
     public function create() : ResponseInterface;
 }

--- a/src/HTTP/Response/ResponseFactoryImpl.php
+++ b/src/HTTP/Response/ResponseFactoryImpl.php
@@ -5,6 +5,19 @@ namespace ILIAS\HTTP\Response;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\ResponseInterface;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Class ResponseFactoryImpl
  *

--- a/src/HTTP/Response/ResponseHeader.php
+++ b/src/HTTP/Response/ResponseHeader.php
@@ -2,6 +2,19 @@
 
 namespace ILIAS\HTTP\Response;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Interface ResponseHeader
  *
@@ -17,38 +30,38 @@ interface ResponseHeader
      *
      * @example Access-Control-Allow-Origin: *
      */
-    const ACCESS_CONTROL_ALLOW_ORIGIN = 'Access-Control-Allow-Origin';
+    public const ACCESS_CONTROL_ALLOW_ORIGIN = 'Access-Control-Allow-Origin';
     /**
      * Specifies which patch document formats this server supports.
      *
      * @example Accept-Patch: text/example;charset=utf-8
      */
-    const ACCEPT_PATCH = 'Accept-Patch';
+    public const ACCEPT_PATCH = 'Accept-Patch';
     /**
      * What partial content range types this server supports via byte serving.
      *
      * @example Accept-Ranges: bytes
      */
-    const ACCEPT_RANGES = 'Accept-Ranges';
+    public const ACCEPT_RANGES = 'Accept-Ranges';
     /**
      * Valid actions for a specified resource. To be used for a 405 Method not allowed.
      *
      * @example Allow: GET, HEAD
      */
-    const ALLOW = 'Allow';
+    public const ALLOW = 'Allow';
     /**
      * Tells all caching mechanisms from server to client whether they may cache this object. It is
      * measured in seconds.
      *
      * @example Cache-Control: max-age=3600
      */
-    const CACHE_CONTROL = 'Cache-Control';
+    public const CACHE_CONTROL = 'Cache-Control';
     /**
      * Control options for the current connection.
      *
      * @example Connection: close
      */
-    const CONNECTION = 'Connection';
+    public const CONNECTION = 'Connection';
     /**
      * An opportunity to raise a "File Download" dialogue box for a known MIME type with binary
      * format or suggest a filename for dynamic content. Quotes are necessary with special
@@ -56,82 +69,82 @@ interface ResponseHeader
      *
      * @example Content-Disposition: attachment; filename="fname.ext"
      */
-    const CONTENT_DISPOSITION = 'Content-Disposition';
+    public const CONTENT_DISPOSITION = 'Content-Disposition';
     /**
      * The type of encoding used on the data.
      *
      * @example Content-Encoding: gzip
      */
-    const CONTENT_ENCODING = 'Content-Encoding';
+    public const CONTENT_ENCODING = 'Content-Encoding';
     /**
      * The natural language or languages of the intended audience for the enclosed content.
      *
      * @example Content-Language: de
      */
-    const CONTENT_LANGUAGE = 'Content-Language';
+    public const CONTENT_LANGUAGE = 'Content-Language';
     /**
      * The length of the response body in octets (8-bit bytes).
      *
      * @example Content-Length: 348
      */
-    const CONTENT_LENGTH = 'Content-Length';
+    public const CONTENT_LENGTH = 'Content-Length';
     /**
      * An alternate location for the returned data.
      *
      * @example Content-Location: /index.htm
      */
-    const CONTENT_LOCATION = 'Content-Location';
+    public const CONTENT_LOCATION = 'Content-Location';
     /**
      * Where in a full body message this partial message belongs.
      *
      * @example Content-Range: bytes 21010-47021/47022
      */
-    const CONTENT_RANGE = 'Content-Range';
+    public const CONTENT_RANGE = 'Content-Range';
     /**
      * The MIME type of this content.
      *
      * @example Content-Type: text/html; charset=utf-8
      */
-    const CONTENT_TYPE = 'Content-Type';
+    public const CONTENT_TYPE = 'Content-Type';
     /**
      * The date and time that the message was sent (in "HTTP-date" format as defined by RFC 7231)
      *
      * @example Date: Tue, 15 Nov 1994 08:12:31 GMT
      */
-    const DATE = 'Date';
+    public const DATE = 'Date';
     /**
      * An identifier for a specific version of a resource, often a message digest.
      *
      * @example ETag: "737060cd8c284d8af7ad3082f209582d"
      */
-    const ETAG = 'ETag';
+    public const ETAG = 'ETag';
     /**
      * Gives the date/time after which the response is considered stale (in "HTTP-date" format as
      * defined by RFC 7231).
      *
      * @example Expires: Thu, 01 Dec 1994 16:00:00 GMT
      */
-    const EXPIRES = 'Expires';
+    public const EXPIRES = 'Expires';
     /**
      * The last modified date for the requested object (in "HTTP-date" format as defined by RFC
      * 7231).
      *
      * @example Last-Modified: Tue, 15 Nov 1994 12:45:26 GMT
      */
-    const LAST_MODIFIED = 'Last-Modified';
+    public const LAST_MODIFIED = 'Last-Modified';
     /**
      * Used to express a typed relationship with another resource, where the relation type is
      * defined by RFC 5988.
      *
      * @example Link: </feed>; rel="alternate"
      */
-    const LINK = 'Link';
+    public const LINK = 'Link';
     /**
      * Used in redirection, or when a new resource has been created.
      *
      * @example Location: http://www.w3.org/pub/WWW/People.html
      */
-    const LOCATION = 'Location';
+    public const LOCATION = 'Location';
     /**
      * This field is supposed to set P3P policy.
      *
@@ -139,21 +152,21 @@ interface ResponseHeader
      *          http://www.google.com/support/accounts/bin/answer.py?hl=en&answer=151657 for more
      *          info."
      */
-    const P3P = 'P3P';
+    public const P3P = 'P3P';
     /**
      * Implementation-specific fields that may have various effects anywhere along the
      * request-response chain.
      *
      * @example Pragma: no-cache
      */
-    const PRAGMA = 'Pragma';
+    public const PRAGMA = 'Pragma';
     /**
      * HTTP Public Key Pinning, announces hash of website's authentic TLS certificate.
      *
      * @example Public-Key-Pins: max-age=2592000;
      *          pin-sha256="E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g=";
      */
-    const PUBLIC_KEY_PINS = 'Public-Key-Pins';
+    public const PUBLIC_KEY_PINS = 'Public-Key-Pins';
     /**
      * If an entity is temporarily unavailable, this instructs the client to try again later.
      * Value could be a specified period of time (in seconds) or a HTTP-date.
@@ -161,34 +174,34 @@ interface ResponseHeader
      * @example Retry-After: 120
      * @example Retry-After: Fri, 07 Nov 2014 23:59:59 GMT
      */
-    const RETRY_AFTER = 'Retry-After';
+    public const RETRY_AFTER = 'Retry-After';
     /**
      * A name for the server.
      *
      * @example Server: Apache/2.4.1 (Unix)
      */
-    const SERVER = 'Server';
+    public const SERVER = 'Server';
     /**
      * A HSTS Policy informing the HTTP client how long to cache
      * the HTTPS only policy and whether this applies to subdomains.
      *
      * @example Strict-Transport-Security: max-age=16070400; includeSubDomains
      */
-    const STRICT_TRANSPORT_SECURITY = 'Strict-Transport-Security';
+    public const STRICT_TRANSPORT_SECURITY = 'Strict-Transport-Security';
     /**
      * The Trailer general field value indicates that the given set of header fields
      * is present in the trailer of a message encoded with chunked transfer coding.
      *
      * @example Trailer: Max-Forwards
      */
-    const TRAILER = 'Trailer';
+    public const TRAILER = 'Trailer';
     /**
      * The form of encoding used to safely transfer the entity to the user.
      * Currently defined methods are: chunked, compress, deflate, gzip, identity.
      *
      * @example Transfer-Encoding: chunked
      */
-    const TRANSFER_ENCODING = 'Transfer-Encoding';
+    public const TRANSFER_ENCODING = 'Transfer-Encoding';
     /**
      * Tracking Status Value, value suggested to be sent in response to a DNT(do-not-track),
      * possible values:
@@ -204,7 +217,7 @@ interface ResponseHeader
      *
      * @example TSV: ?
      */
-    const TSV = 'TSV';
+    public const TSV = 'TSV';
     /**
      * Tells downstream proxies how to match future request headers to decide whether
      * the cached response can be used rather than requesting a fresh one from the origin server.
@@ -212,25 +225,25 @@ interface ResponseHeader
      * @example Vary: *
      * @example Vary: Accept-Language
      */
-    const VARY = 'Vary';
+    public const VARY = 'Vary';
     /**
      * A general warning about possible problems with the entity body.
      *
      * @example Warning: 199 Miscellaneous warning
      */
-    const WARNING = 'Warning';
+    public const WARNING = 'Warning';
     /**
      * Indicates the authentication scheme that should be used to access the requested entity.
      *
      * @example WWW-Authenticate: Basic
      */
-    const WWW_AUTHENTICATE = 'WWW-Authenticate';
+    public const WWW_AUTHENTICATE = 'WWW-Authenticate';
     /**
      * Cross-site scripting (XSS) filter.
      *
      * @example X-XSS-Protection: 1; mode=block
      */
-    const X_XSS_PROTECTION = 'X-XSS-Protection';
+    public const X_XSS_PROTECTION = 'X-XSS-Protection';
     /**
      * The only defined value, "nosniff", prevents Internet Explorer from MIME-sniffing a response
      * away from the declared content-type. This also applies to Google Chrome, when downloading
@@ -238,11 +251,11 @@ interface ResponseHeader
      *
      * @example X-Content-Type-Options: nosniff
      */
-    const X_CONTENT_TYPE_OPTIONS = 'X-Content-Type-Options';
+    public const X_CONTENT_TYPE_OPTIONS = 'X-Content-Type-Options';
     /**
      * Tells a client to prefer HTTPS.
      *
      * @example Upgrade-Insecure-Requests: 1
      */
-    const UPGRADE_INSECURE_REQUESTS = 'Upgrade-Insecure-Requests';
+    public const UPGRADE_INSECURE_REQUESTS = 'Upgrade-Insecure-Requests';
 }

--- a/src/HTTP/Response/Sender/DefaultResponseSenderStrategy.php
+++ b/src/HTTP/Response/Sender/DefaultResponseSenderStrategy.php
@@ -4,6 +4,19 @@ namespace ILIAS\HTTP\Response\Sender;
 
 use Psr\Http\Message\ResponseInterface;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Class DefaultResponseSenderStrategy
  *
@@ -20,7 +33,6 @@ class DefaultResponseSenderStrategy implements ResponseSenderStrategy
      *
      * @param ResponseInterface $response The response which should be send to the client.
      *
-     * @return void
      * @throws ResponseSendingException Thrown if the response was already sent to the client.
      */
     public function sendResponse(ResponseInterface $response) : void
@@ -34,7 +46,7 @@ class DefaultResponseSenderStrategy implements ResponseSenderStrategy
         http_response_code($response->getStatusCode());
 
         //render all headers
-        foreach ($response->getHeaders() as $key => $header) {
+        foreach (array_keys($response->getHeaders()) as $key) {
             header("$key: " . $response->getHeaderLine($key));
         }
 

--- a/src/HTTP/Response/Sender/NullResponseSenderStrategy.php
+++ b/src/HTTP/Response/Sender/NullResponseSenderStrategy.php
@@ -4,6 +4,19 @@ namespace ILIAS\HTTP\Response\Sender;
 
 use Psr\Http\Message\ResponseInterface;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Class NullResponseSenderStrategy
  *
@@ -19,12 +32,10 @@ class NullResponseSenderStrategy implements ResponseSenderStrategy
      * Noop.
      *
      * @param ResponseInterface $response Ignored.
-     *
-     * @return void
      */
-    public function sendResponse(ResponseInterface $response) : void
+    public function sendResponse(ResponseInterface $response): void
     {
-        //noop
-        return;
+        /** @noRector */
+        // nothing to do here
     }
 }

--- a/src/HTTP/Response/Sender/ResponseSenderStrategy.php
+++ b/src/HTTP/Response/Sender/ResponseSenderStrategy.php
@@ -4,6 +4,19 @@ namespace ILIAS\HTTP\Response\Sender;
 
 use Psr\Http\Message\ResponseInterface;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Interface ResponseSenderStrategy
  *
@@ -17,7 +30,6 @@ interface ResponseSenderStrategy
      *
      * @param ResponseInterface $response The response which should be send to the client.
      *
-     * @return void
      * @throws ResponseSendingException Thrown if the response was already sent to the client.
      */
     public function sendResponse(ResponseInterface $response) : void;

--- a/src/HTTP/Response/Sender/ResponseSendingException.php
+++ b/src/HTTP/Response/Sender/ResponseSendingException.php
@@ -2,13 +2,26 @@
 
 namespace ILIAS\HTTP\Response\Sender;
 
+use ilException;
+
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Exception ResponseSendingException
- *
  * Represents response sending problems.
- *
  * @package ILIAS\HTTP\Response
  */
-class ResponseSendingException extends \ilException
+class ResponseSendingException extends ilException
 {
 }

--- a/src/HTTP/Services.php
+++ b/src/HTTP/Services.php
@@ -9,6 +9,19 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use ILIAS\DI\Container;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Class Services
  * @author              Fabian Schmid <fs@studer-raimann.ch>
@@ -17,18 +30,11 @@ use ILIAS\DI\Container;
  */
 class Services implements GlobalHttpState
 {
-    /**
-     * @var RawHTTPServices
-     */
-    protected $raw;
-    /**
-     * @var WrapperFactory
-     */
-    protected $wrapper;
+    protected GlobalHttpState $raw;
+    protected WrapperFactory $wrapper;
 
     /**
      * Services constructor.
-     * @param Container $dic
      */
     public function __construct(Container $dic)
     {
@@ -41,9 +47,6 @@ class Services implements GlobalHttpState
         $this->wrapper = new WrapperFactory($this->raw->request());
     }
 
-    /**
-     * @return WrapperFactory
-     */
     public function wrapper() : WrapperFactory
     {
         return $this->wrapper;
@@ -53,7 +56,7 @@ class Services implements GlobalHttpState
      * @deprecated Please use $this->wrapper()
      * @see        Services::wrapper();
      */
-    public function raw() : GlobalHttpState
+    public function raw() : RawHTTPServices
     {
         return $this->raw;
     }

--- a/src/HTTP/StatusCode.php
+++ b/src/HTTP/StatusCode.php
@@ -2,6 +2,19 @@
 
 namespace ILIAS\HTTP;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Interface StatusCode
  *
@@ -15,53 +28,53 @@ interface StatusCode
 
     // [Informational 1xx]
 
-    const HTTP_CONTINUE = 100;
-    const HTTP_SWITCHING_PROTOCOLS = 101;
+    public const HTTP_CONTINUE = 100;
+    public const HTTP_SWITCHING_PROTOCOLS = 101;
     // [Successful 2xx]
 
-    const HTTP_OK = 200;
-    const HTTP_CREATED = 201;
-    const HTTP_ACCEPTED = 202;
-    const HTTP_NONAUTHORITATIVE_INFORMATION = 203;
-    const HTTP_NO_CONTENT = 204;
-    const HTTP_RESET_CONTENT = 205;
-    const HTTP_PARTIAL_CONTENT = 206;
+    public const HTTP_OK = 200;
+    public const HTTP_CREATED = 201;
+    public const HTTP_ACCEPTED = 202;
+    public const HTTP_NONAUTHORITATIVE_INFORMATION = 203;
+    public const HTTP_NO_CONTENT = 204;
+    public const HTTP_RESET_CONTENT = 205;
+    public const HTTP_PARTIAL_CONTENT = 206;
     // [Redirection 3xx]
 
-    const HTTP_MULTIPLE_CHOICES = 300;
-    const HTTP_MOVED_PERMANENTLY = 301;
-    const HTTP_FOUND = 302;
-    const HTTP_SEE_OTHER = 303;
-    const HTTP_NOT_MODIFIED = 304;
-    const HTTP_USE_PROXY = 305;
-    const HTTP_UNUSED = 306;
-    const HTTP_TEMPORARY_REDIRECT = 307;
+    public const HTTP_MULTIPLE_CHOICES = 300;
+    public const HTTP_MOVED_PERMANENTLY = 301;
+    public const HTTP_FOUND = 302;
+    public const HTTP_SEE_OTHER = 303;
+    public const HTTP_NOT_MODIFIED = 304;
+    public const HTTP_USE_PROXY = 305;
+    public const HTTP_UNUSED = 306;
+    public const HTTP_TEMPORARY_REDIRECT = 307;
     // [Client Error 4xx]
 
-    const HTTP_BAD_REQUEST = 400;
-    const HTTP_UNAUTHORIZED = 401;
-    const HTTP_PAYMENT_REQUIRED = 402;
-    const HTTP_FORBIDDEN = 403;
-    const HTTP_NOT_FOUND = 404;
-    const HTTP_METHOD_NOT_ALLOWED = 405;
-    const HTTP_NOT_ACCEPTABLE = 406;
-    const HTTP_PROXY_AUTHENTICATION_REQUIRED = 407;
-    const HTTP_REQUEST_TIMEOUT = 408;
-    const HTTP_CONFLICT = 409;
-    const HTTP_GONE = 410;
-    const HTTP_LENGTH_REQUIRED = 411;
-    const HTTP_PRECONDITION_FAILED = 412;
-    const HTTP_REQUEST_ENTITY_TOO_LARGE = 413;
-    const HTTP_REQUEST_URI_TOO_LONG = 414;
-    const HTTP_UNSUPPORTED_MEDIA_TYPE = 415;
-    const HTTP_REQUESTED_RANGE_NOT_SATISFIABLE = 416;
-    const HTTP_EXPECTATION_FAILED = 417;
+    public const HTTP_BAD_REQUEST = 400;
+    public const HTTP_UNAUTHORIZED = 401;
+    public const HTTP_PAYMENT_REQUIRED = 402;
+    public const HTTP_FORBIDDEN = 403;
+    public const HTTP_NOT_FOUND = 404;
+    public const HTTP_METHOD_NOT_ALLOWED = 405;
+    public const HTTP_NOT_ACCEPTABLE = 406;
+    public const HTTP_PROXY_AUTHENTICATION_REQUIRED = 407;
+    public const HTTP_REQUEST_TIMEOUT = 408;
+    public const HTTP_CONFLICT = 409;
+    public const HTTP_GONE = 410;
+    public const HTTP_LENGTH_REQUIRED = 411;
+    public const HTTP_PRECONDITION_FAILED = 412;
+    public const HTTP_REQUEST_ENTITY_TOO_LARGE = 413;
+    public const HTTP_REQUEST_URI_TOO_LONG = 414;
+    public const HTTP_UNSUPPORTED_MEDIA_TYPE = 415;
+    public const HTTP_REQUESTED_RANGE_NOT_SATISFIABLE = 416;
+    public const HTTP_EXPECTATION_FAILED = 417;
     // [Server Error 5xx]
 
-    const HTTP_INTERNAL_SERVER_ERROR = 500;
-    const HTTP_NOT_IMPLEMENTED = 501;
-    const HTTP_BAD_GATEWAY = 502;
-    const HTTP_SERVICE_UNAVAILABLE = 503;
-    const HTTP_GATEWAY_TIMEOUT = 504;
-    const HTTP_VERSION_NOT_SUPPORTED = 505;
+    public const HTTP_INTERNAL_SERVER_ERROR = 500;
+    public const HTTP_NOT_IMPLEMENTED = 501;
+    public const HTTP_BAD_GATEWAY = 502;
+    public const HTTP_SERVICE_UNAVAILABLE = 503;
+    public const HTTP_GATEWAY_TIMEOUT = 504;
+    public const HTTP_VERSION_NOT_SUPPORTED = 505;
 }

--- a/src/HTTP/Wrapper/ArrayBasedRequestWrapper.php
+++ b/src/HTTP/Wrapper/ArrayBasedRequestWrapper.php
@@ -4,6 +4,19 @@ namespace ILIAS\HTTP\Wrapper;
 
 use ILIAS\Refinery\Transformation;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Class ArrayBasedRequestWrapper
  *
@@ -12,16 +25,12 @@ use ILIAS\Refinery\Transformation;
 class ArrayBasedRequestWrapper implements RequestWrapper
 {
 
-    /**
-     * @var array
-     */
-    private $raw_values;
+    private array $raw_values;
 
 
     /**
      * GetRequestWrapper constructor.
-     *
-     * @param array $raw_values
+     * @param mixed[] $raw_values
      */
     public function __construct(array $raw_values)
     {

--- a/src/HTTP/Wrapper/RequestWrapper.php
+++ b/src/HTTP/Wrapper/RequestWrapper.php
@@ -4,6 +4,19 @@ namespace ILIAS\HTTP\Wrapper;
 
 use ILIAS\Refinery\Transformation;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Interface RequestWrapper
  *
@@ -13,18 +26,11 @@ interface RequestWrapper
 {
 
     /**
-     * @param string         $key
-     * @param Transformation $transformation
      *
      * @return mixed
      */
     public function retrieve(string $key, Transformation $transformation);
 
 
-    /**
-     * @param string $key
-     *
-     * @return bool
-     */
     public function has(string $key) : bool;
 }

--- a/src/HTTP/Wrapper/SuperGlobalDropInReplacement.php
+++ b/src/HTTP/Wrapper/SuperGlobalDropInReplacement.php
@@ -5,6 +5,19 @@ namespace ILIAS\HTTP\Wrapper;
 use ILIAS\Refinery\Factory;
 use ILIAS\Refinery\KeyValueAccess;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Class SuperGlobalDropInReplacement
  * This Class wraps SuperGlobals such as $_GET and $_POST to prevent modifying them in a future version.
@@ -15,8 +28,6 @@ class SuperGlobalDropInReplacement extends KeyValueAccess
 
     /**
      * DirectValueAccessDropInReplacement constructor.
-     * @param Factory $factory
-     * @param array   $raw_values
      */
     public function __construct(Factory $factory, array $raw_values)
     {
@@ -29,7 +40,8 @@ class SuperGlobalDropInReplacement extends KeyValueAccess
      */
     public function offsetSet($offset, $value) : void
     {
-//        throw new \OutOfBoundsException("Modifying global Request-Array such as \$_GET is not allowed!");
+        /** @noRector */
+        // this is currently possible, throw new \OutOfBoundsException("Modifying global Request-Array such as \$_GET is not allowed!"); if you want to prevent from overriding a value here
         parent::offsetSet($offset, $value);
     }
 

--- a/src/HTTP/Wrapper/WrapperFactory.php
+++ b/src/HTTP/Wrapper/WrapperFactory.php
@@ -4,44 +4,47 @@ namespace ILIAS\HTTP\Wrapper;
 
 use Psr\Http\Message\RequestInterface;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Class WrapperFactory
- *
  * @author Fabian Schmid <fs@studer-raimann.ch>
  */
 class WrapperFactory
 {
-
-    /**
-     * @var RequestInterface
-     */
-    private $request;
-
-
+    
+    private RequestInterface $request;
+    
     /**
      * WrapperFactory constructor.
-     *
-     * @param RequestInterface $request
      */
     public function __construct(RequestInterface $request)
     {
         $this->request = $request;
     }
-
-
-    public function query() : RequestWrapper
+    
+    public function query() : ArrayBasedRequestWrapper
     {
         return new ArrayBasedRequestWrapper($this->request->getQueryParams());
     }
-
-
-    public function post() : RequestWrapper
+    
+    public function post() : ArrayBasedRequestWrapper
     {
         return new ArrayBasedRequestWrapper($this->request->getParsedBody());
     }
-
-
-    public function cookie() : RequestWrapper
+    
+    public function cookie() : ArrayBasedRequestWrapper
     {
         return new ArrayBasedRequestWrapper($this->request->getCookieParams());
     }

--- a/src/Refinery/KeyValueAccess.php
+++ b/src/Refinery/KeyValueAccess.php
@@ -8,15 +8,9 @@ namespace ILIAS\Refinery;
  */
 class KeyValueAccess implements \ArrayAccess, \Countable
 {
-
-    /**
-     * @var array
-     */
-    private $raw_values;
-    /**
-     * @var Transformation
-     */
-    protected $trafo;
+    
+    private array $raw_values;
+    protected Transformation $trafo;
 
     /**
      * KeyValueAccess constructor.

--- a/tests/HTTP/Cookies/CookieJarWrapperTest.php
+++ b/tests/HTTP/Cookies/CookieJarWrapperTest.php
@@ -9,8 +9,19 @@ namespace ILIAS\HTTP\Cookies;
 
 use PHPUnit\Framework\TestCase;
 
-require_once('./libs/composer/vendor/autoload.php');
-
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Class CookieWrapperTest
  *

--- a/tests/HTTP/Cookies/CookieWrapperTest.php
+++ b/tests/HTTP/Cookies/CookieWrapperTest.php
@@ -9,8 +9,19 @@ namespace ILIAS\HTTP\Cookies;
 
 use PHPUnit\Framework\TestCase;
 
-require_once('./libs/composer/vendor/autoload.php');
-
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Class CookieWrapperTest
  *

--- a/tests/HTTP/Services/AbstractBaseTest.php
+++ b/tests/HTTP/Services/AbstractBaseTest.php
@@ -7,6 +7,19 @@ use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Class AbstractBaseTest
  * @author Fabian Schmid <fs@studer-raimann.ch>

--- a/tests/HTTP/Services/WrapperTest.php
+++ b/tests/HTTP/Services/WrapperTest.php
@@ -6,6 +6,19 @@ require_once "AbstractBaseTest.php";
 use ILIAS\HTTP\Wrapper\WrapperFactory;
 use ILIAS\Refinery\Factory;
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 /**
  * Class WrapperTest
  * @author Fabian Schmid <fs@studer-raimann.ch>


### PR DESCRIPTION
Hi @mjansenDatabay and @smeyer-ilias 

I refactored Service/HTTPS for PHP8 and made several changes:
- made ilHTTPS only accessible via DIC and removed the gestInstance
- License Header
- Typing
- Removal of $_GET/$_POST

maybe it's not 100% but it's quite a good state. There is no real maintainer for Service/HTTPS, you both have classes there and we should thin about moving those things to other locations I think.

Feel free to merge at any time