### PR TITLE
This allows for correct naming of files from php://input streams.

### DIFF
--- a/src/ResourceStorage/Resource/InfoResolver/StreamInfoResolver.php
+++ b/src/ResourceStorage/Resource/InfoResolver/StreamInfoResolver.php
@@ -86,7 +86,7 @@ class StreamInfoResolver extends AbstractInfoResolver implements InfoResolver
     protected function initFileName() : void
     {
         $this->file_name = basename($this->path);
-        if ($this->file_name === 'memory') { // in case the stream is ofString
+        if ($this->file_name === 'memory' || $this->file_name === 'input') { // in case the stream is ofString or of php://input
             $this->file_name = $this->getRevisionTitle();
         }
     }


### PR DESCRIPTION
Right now if you hand a php://input wrapped in a stream to the IRSS the filename will be resolved to "input". This will in this case set it to the given name, same as for memory. Sabre/DAV hands over the data as a handle on php://input.