### PR TITLE
ilTree: Add type cast

### DIFF
--- a/Services/Tree/classes/class.ilTree.php
+++ b/Services/Tree/classes/class.ilTree.php
@@ -754,7 +754,7 @@ class ilTree
                 ));
             }
         }
-        $this->getTreeImplementation()->deleteTree($a_node['child']);
+        $this->getTreeImplementation()->deleteTree((int) $a_node['child']);
         $this->resetInTreeCache();
     }
 


### PR DESCRIPTION
Without this cast, I get a type error (string instead of int) when using `deleteTree()`