### PR TITLE
Add Unit Tests for Services/Mail

### DIFF
--- a/Services/Mail/classes/class.ilMail.php
+++ b/Services/Mail/classes/class.ilMail.php
@@ -400,14 +400,14 @@ class ilMail
         return $row;
     }
 
-    public function getNewDraftId(int $usrId, int $folderId) : int
+    public function getNewDraftId(int $folderId) : int
     {
         $nextId = $this->db->nextId($this->table_mail);
         $this->db->insert($this->table_mail, [
             'mail_id' => ['integer', $nextId],
-            'user_id' => ['integer', $usrId],
+            'user_id' => ['integer', $this->user_id],
             'folder_id' => ['integer', $folderId],
-            'sender_id' => ['integer', $usrId],
+            'sender_id' => ['integer', $this->user_id],
         ]);
 
         return $nextId;

--- a/Services/Mail/classes/class.ilMailFormGUI.php
+++ b/Services/Mail/classes/class.ilMailFormGUI.php
@@ -253,7 +253,7 @@ class ilMailFormGUI
             $draftId = (int) ilSession::get('draft');
             ilSession::clear('draft');
         } else {
-            $draftId = $this->umail->getNewDraftId($this->user->getId(), $draftFolderId);
+            $draftId = $this->umail->getNewDraftId($draftFolderId);
         }
 
         $this->umail->updateDraft(

--- a/Services/Mail/test/ilMailTest.php
+++ b/Services/Mail/test/ilMailTest.php
@@ -3,6 +3,7 @@
 /* Copyright (c) 1998-2021 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 use ILIAS\Refinery\Factory;
+use \PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Class ilMailMimeTest
@@ -10,13 +11,26 @@ use ILIAS\Refinery\Factory;
  */
 class ilMailTest extends ilMailBaseTest
 {
+
     /**
-     * @inheritdoc
+     * @var MockObject|ilDBInterface
      */
-    protected function setUp() : void
-    {
-        parent::setUp();
-    }
+    private ilDBInterface $mockDatabase;
+
+    /**
+     * @var MockObject|ilMailAddressType
+     */
+    private $mockAddressTypeFactory;
+
+    /**
+     * @var MockObject|ilLogger
+     */
+    private $mockLog;
+
+    /**
+     * @var MockObject|ilMailRfc822AddressParserFactory
+     */
+    private $mockParserFactory;
 
     /**
      * @throws ReflectionException
@@ -176,5 +190,370 @@ class ilMailTest extends ilMailBaseTest
         );
 
         ilMimeMail::setDefaultTransport($oldTransport);
+    }
+
+    public function testGetMailObjectReferenceId() : void
+    {
+        $refId = 364;
+        $instance = $this->create($refId);
+
+        $this->assertEquals($refId, $instance->getMailObjectReferenceId());
+    }
+
+    public function testFormatNamesForOutput() : void
+    {
+        $instance = $this->create();
+
+        $this->assertEquals('', $instance->formatNamesForOutput(''));
+        $this->assertEquals('', $instance->formatNamesForOutput(','));
+    }
+
+    /**
+     * @dataProvider provideGetPreviousMail
+     */
+    public function testGetPreviousMail(array $rowData) : void
+    {
+        $mailId = 3454;
+        $instance = $this->createAndExpectDatabaseCall($mailId, $rowData);
+        $this->mockDatabase->expects(self::once())->method('setLimit')->with(1, 0);
+        $instance->getPreviousMail($mailId);
+    }
+
+    public function provideGetPreviousMail() : array
+    {
+        return [
+            [[]],
+            [[
+                'allowed_classes' => '',
+                'attachments' => '',
+                'folder_id' => '',
+                'mail_id' => '',
+                'sender_id' => '',
+                'tpl_ctx_params' => '[]',
+                'use_placeholders' => '',
+                'user_id' => ''
+            ]],
+            [[
+                'allowed_classes' => '',
+                'folder_id' => '',
+                'mail_id' => '',
+                'sender_id' => '',
+                'use_placeholders' => '',
+                'user_id' => ''
+            ]],
+        ];
+    }
+
+    public function testGetNextMail() : void
+    {
+        $mailId = 8484;
+        $instance = $this->createAndExpectDatabaseCall($mailId, []);
+        $this->mockDatabase->expects(self::once())->method('setLimit')->with(1, 0);
+        $instance->getNextMail($mailId);
+    }
+
+    public function testGetMailsOfFolder() : void
+    {
+        $filter = ['status' => 'yes'];
+        $rowData = ['mail_id' => 8908];
+        $one = $rowData + ['attachments' => [], 'tpl_ctx_params' => []];
+        $expected = [$one, $one];
+        $folderId = 89;
+        $userId = 901;
+        $instance = $this->create(234, $userId);
+        $mockStatement = $this->getMockBuilder(ilDBStatement::class)->getMock();
+        $this->mockDatabase->expects(self::never())->method('setLimit');
+        $this->mockDatabase->expects(self::exactly(3))->method('fetchAssoc')->with($mockStatement)->willReturnOnConsecutiveCalls($rowData, $rowData, null);
+        $this->mockDatabase->expects(self::once())->method('queryF')->willReturnCallback($this->queryCallback($mockStatement, ['integer', 'integer'], [$userId, $folderId]));
+
+        $this->mockDatabase->expects(self::once())->method('quote')->with($filter['status'], 'text')->willReturn($filter['status']);
+
+        $this->assertEquals($expected, $instance->getMailsOfFolder($folderId, $filter));
+    }
+
+    public function testCountMailsOfFolder() : void
+    {
+        $userId = 46;
+        $folderId = 68;
+        $numRows = 89;
+        $instance = $this->create(345, $userId);
+        $mockStatement = $this->getMockBuilder(ilDBStatement::class)->getMock();
+        $this->mockDatabase->expects(self::once())->method('queryF')->willReturnCallback($this->queryCallback($mockStatement, ['integer', 'integer'], [$userId, $folderId]));
+        $this->mockDatabase->expects(self::once())->method('numRows')->with($mockStatement)->willReturn($numRows);
+
+        $this->assertEquals($numRows, $instance->countMailsOfFolder($folderId));
+    }
+
+    public function testGetMail() : void
+    {
+        $mailId = 7890;
+        $instance = $this->createAndExpectDatabaseCall($mailId, [], false);
+        $instance->getMail($mailId);
+    }
+
+    public function testMarkRead() : void
+    {
+        $mailIds = [1, 2, 3, 4, 5, 6];
+        $userId = 987;
+        $instance = $this->create(567, $userId);
+        $mockStatement = $this->getMockBuilder(ilDBStatement::class)->getMock();
+        $this->mockDatabase->expects(self::once())->method('in')->with('mail_id', $mailIds, false, 'integer')->willReturn('');
+        $this->mockDatabase->expects(self::once())->method('manipulateF')->willReturnCallback($this->queryCallback(0, ['text', 'integer'], ['read', $userId]));
+
+        $instance->markRead($mailIds);
+    }
+
+    public function testMarkUnread() : void
+    {
+        $mailIds = [1, 2, 3, 4, 5, 6];
+        $userId = 987;
+        $instance = $this->create(567, $userId);
+        $mockStatement = $this->getMockBuilder(ilDBStatement::class)->getMock();
+        $this->mockDatabase->expects(self::once())->method('in')->with('mail_id', $mailIds, false, 'integer')->willReturn('');
+        $this->mockDatabase->expects(self::once())->method('manipulateF')->willReturnCallback($this->queryCallback(0, ['text', 'integer'], ['unread', $userId]));
+
+        $instance->markUnread($mailIds);
+    }
+
+    public function testMoveMailsToFolder() : void
+    {
+        $mailIds = [1, 2, 3, 4, 5, 6];
+        $folderId = 890;
+        $userId = 987;
+        $instance = $this->create(567, $userId);
+        $this->mockDatabase->expects(self::once())->method('in')->with('mail_id', $mailIds, false, 'integer')->willReturn('');
+        $this->mockDatabase->expects(self::once())->method('manipulateF')->willReturnCallback($this->queryCallback(1, ['integer', 'integer', 'integer'], [$folderId, $userId, $userId]));
+
+        $this->assertTrue($instance->moveMailsToFolder($mailIds, $folderId));
+    }
+
+    public function testMoveMailsToFolderFalse() : void
+    {
+        $mailIds = [];
+        $instance = $this->create();
+        $this->mockDatabase->expects(self::never())->method('in');
+        $this->mockDatabase->expects(self::never())->method('manipulateF');
+
+        $this->assertFalse($instance->moveMailsToFolder($mailIds, 892));
+    }
+
+    public function testGetNewDraftId() : void
+    {
+        $nextId = 789;
+        $userId = 5678;
+        $folderId = 47;
+        $instance = $this->create(4749, $userId);
+
+        $this->mockDatabase->expects(self::once())->method('nextId')->with('mail')->willReturn($nextId);
+        $this->mockDatabase->expects(self::once())->method('insert')->with('mail', [
+            'mail_id' => ['integer', $nextId],
+            'user_id' => ['integer', $userId],
+            'folder_id' => ['integer', $folderId],
+            'sender_id' => ['integer', $userId],
+        ]);
+
+        $this->assertEquals($nextId, $instance->getNewDraftId($folderId));
+    }
+
+    public function testUpdateDraft() : void
+    {
+        $folderId = 7890;
+        $instance = $this->create();
+        $to = 'abc';
+        $cc = 'bcde';
+        $bcc = 'jkl';
+        $subject = 'jlh';
+        $message = 'some message';
+        $usePlaceholders = true;
+        $contextId = '87';
+        $params = [];
+        $draftId = 78;
+
+        $this->mockDatabase->expects(self::once())->method('update')->with('mail', [
+            'folder_id' => ['integer', $folderId],
+            'attachments' => ['clob', serialize([])],
+            'send_time' => ['timestamp', date('Y-m-d H:i:s')],
+            'rcp_to' => ['clob', $to],
+            'rcp_cc' => ['clob', $cc],
+            'rcp_bcc' => ['clob', $bcc],
+            'm_status' => ['text', 'read'],
+            'm_subject' => ['text', $subject],
+            'm_message' => ['clob', $message],
+            'use_placeholders' => ['integer', (int) $usePlaceholders],
+            'tpl_ctx_id' => ['text', $contextId],
+            'tpl_ctx_params' => ['blob', json_encode($params)],
+        ], [
+            'mail_id' => ['integer', $draftId],
+        ]);
+
+        $this->assertEquals($draftId, $instance->updateDraft($folderId, [], $to, $cc, $bcc, $subject, $message, $draftId, $usePlaceholders, $contextId, $params));
+    }
+
+    public function testSavePostData() : void
+    {
+        $userId = 897;
+        $attachments = [];
+        $rcpTo = 'jlh';
+        $rcpCc = 'jhkjh';
+        $rcpBcc = 'ououi';
+        $subject = 'hbansn';
+        $message = 'message';
+        $usePlaceholders = false;
+        $contextId = '9080';
+        $params = [];
+
+        $instance = $this->create(789, $userId);
+
+        $this->mockDatabase->expects(self::once())->method('replace')->with('mail_saved', [
+            'user_id' => ['integer', $userId],
+        ], [
+            'attachments' => ['clob', serialize($attachments)],
+            'rcp_to' => ['clob', $rcpTo],
+            'rcp_cc' => ['clob', $rcpCc],
+            'rcp_bcc' => ['clob', $rcpBcc],
+            'm_subject' => ['text', $subject],
+            'm_message' => ['clob', $message],
+            'use_placeholders' => ['integer', (int) $usePlaceholders],
+            'tpl_ctx_id' => ['text', $contextId],
+            'tpl_ctx_params' => ['blob', json_encode($params)],
+        ]);
+
+        $instance->savePostData(
+            78979078,
+            $attachments,
+            $rcpTo,
+            $rcpCc,
+            $rcpBcc,
+            $subject,
+            $message,
+            $usePlaceholders,
+            $contextId,
+            $params,
+        );
+    }
+
+    public function testGetSavedData() : void
+    {
+        $userId = 789;
+        $instance = $this->create(67, $userId);
+        $mockStatement = $this->getMockBuilder(ilDBStatement::class)->disableOriginalConstructor()->getMock();
+        $this->mockDatabase->expects(self::once())->method('fetchAssoc')->with($mockStatement)->willReturn([]);
+        $this->mockDatabase->expects(self::once())->method('queryF')->willReturnCallback($this->queryCallback($mockStatement, ['integer'], [$userId]));
+
+        $this->assertEquals(null, $instance->getSavedData());
+    }
+
+    public function testValidateRecipients($errors = []) : void
+    {
+        $to = 'jkhk';
+        $cc = 'hjhjkl';
+        $bcc = 'jklhjk';
+
+        $instance = $this->create();
+        $this->mockLog->expects(self::exactly(6))->method('debug')->withConsecutive(
+            ['Started parsing of recipient string: ' . $to],
+            ['Parsed addresses: hello'],
+            ['Started parsing of recipient string: ' . $cc],
+            ['Parsed addresses: hello'],
+            ['Started parsing of recipient string: ' . $bcc],
+            ['Parsed addresses: hello']
+        );
+
+        $mockAddress = $this->getMockBuilder(ilMailAddress::class)->disableOriginalConstructor()->getMock();
+        $mockAddress->expects(self::exactly(3))->method('__toString')->willReturn('hello');
+        $mockParser = $this->getMockBuilder(ilMailRecipientParser::class)->disableOriginalConstructor()->getMock();
+        $mockParser->expects(self::exactly(3))->method('parse')->willReturn([$mockAddress]);
+        $this->mockParserFactory->expects(self::exactly(3))->method('getParser')->withConsecutive([$to], [$cc], [$bcc])->willReturn($mockParser);
+
+        $mockAddressType = $this->getMockBuilder(ilMailAddressType::class)->disableOriginalConstructor()->getMock();
+        $mockAddressType->expects(self::exactly(3))->method('validate')->willReturn(empty($errors));
+        $mockAddressType->expects(self::exactly(empty($errors) ? 0 : 3))->method('getErrors')->willReturn($errors);
+        $this->mockAddressTypeFactory->expects(self::exactly(3))->method('getByPrefix')->with($mockAddress)->willReturn($mockAddressType);
+
+        $this->assertEquals([], $instance->validateRecipients($to, $cc, $bcc));
+    }
+
+    public function provideValidateRecipients() : array
+    {
+        return [
+            [[]],
+            [['some error']]
+        ];
+    }
+
+    public function testGetIliasMailerName() : void
+    {
+        $expected = 'Phasellus lacus';
+        $mockSystem = $this->getMockBuilder(ilMailMimeSenderSystem::class)->disableOriginalConstructor()->getMock();
+        $mockSystem->expects(self::once())->method('getFromName')->willReturn($expected);
+        $mockFactory = $this->getMockBuilder(ilMailMimeSenderFactory::class)->disableOriginalConstructor()->getMock();
+        $mockFactory->expects(self::once())->method('system')->willReturn($mockSystem);
+        $this->setGlobalVariable('mail.mime.sender.factory', $mockFactory);
+
+        $this->assertEquals($expected, ilMail::_getIliasMailerName());
+    }
+
+    public function testSaveAttachments() : void
+    {
+        $userId = 89;
+        $attachments = ['aaa', 'bb', 'cc', 'rrr'];
+        $instance = $this->create(789, $userId);
+
+        $this->mockDatabase->expects(self::once())->method('update')->with(
+            'mail_saved',
+            [
+                'attachments' => ['clob', serialize($attachments)],
+            ],
+            [
+                'user_id' => ['integer', $userId],
+            ]
+        );
+
+        $instance->saveAttachments($attachments);
+    }
+
+    private function queryCallback($returnValue, array $expectedTypes, array $expectedValues) : Closure
+    {
+        return function (string $query, array $types, array $values) use ($expectedTypes, $expectedValues, $returnValue) {
+            $this->assertEquals($expectedTypes, $types);
+            $this->assertEquals($expectedValues, $values);
+
+            return $returnValue;
+        };
+    }
+
+    private function createAndExpectDatabaseCall(int $someMailId, array $rowData) : ilMail
+    {
+        $userId = 900;
+        $instance = $this->create(234, $userId);
+        $mockStatement = $this->getMockBuilder(ilDBStatement::class)->getMock();
+        $this->mockDatabase->expects(self::once())->method('fetchAssoc')->with($mockStatement)->willReturn($rowData);
+        $this->mockDatabase->expects(self::once())->method('queryF')->willReturnCallback($this->queryCallback($mockStatement, ['integer', 'integer'], [$userId, $someMailId]));
+
+        return $instance;
+    }
+
+    private function create(int $refId = 234, int $userId = 123) : ilMail
+    {
+        $instance = new ilMail(
+            $userId,
+            ($this->mockAddressTypeFactory = $this->getMockBuilder(ilMailAddressTypeFactory::class)->disableOriginalConstructor()->getMock()),
+            ($this->mockParserFactory = $this->getMockBuilder(ilMailRfc822AddressParserFactory::class)->disableOriginalConstructor()->getMock()),
+            $this->getMockBuilder(ilAppEventHandler::class)->disableOriginalConstructor()->getMock(),
+            ($this->mockLog = $this->getMockBuilder(ilLogger::class)->disableOriginalConstructor()->getMock()),
+            ($this->mockDatabase = $this->getMockBuilder(ilDBInterface::class)->disableOriginalConstructor()->getMock()),
+            $this->getMockBuilder(ilLanguage::class)->disableOriginalConstructor()->getMock(),
+            $this->getMockBuilder(ilFileDataMail::class)->disableOriginalConstructor()->getMock(),
+            $this->getMockBuilder(ilMailOptions::class)->disableOriginalConstructor()->getMock(),
+            $this->getMockBuilder(ilMailbox::class)->disableOriginalConstructor()->getMock(),
+            $this->getMockBuilder(ilMailMimeSenderFactory::class)->disableOriginalConstructor()->getMock(),
+            static function (string $login) : int {
+                return 780;
+            },
+            $refId,
+            $this->getMockBuilder(ilObjUser::class)->disableOriginalConstructor()->getMock()
+        );
+
+        return $instance;
     }
 }

--- a/Services/Mail/test/ilMailTest.php
+++ b/Services/Mail/test/ilMailTest.php
@@ -224,7 +224,6 @@ class ilMailTest extends ilMailBaseTest
         return [
             [[]],
             [[
-                'allowed_classes' => '',
                 'attachments' => '',
                 'folder_id' => '',
                 'mail_id' => '',
@@ -234,7 +233,6 @@ class ilMailTest extends ilMailBaseTest
                 'user_id' => ''
             ]],
             [[
-                'allowed_classes' => '',
                 'folder_id' => '',
                 'mail_id' => '',
                 'sender_id' => '',

--- a/Services/Mail/test/ilMailTest.php
+++ b/Services/Mail/test/ilMailTest.php
@@ -33,6 +33,11 @@ class ilMailTest extends ilMailBaseTest
     private $mockParserFactory;
 
     /**
+     * @var MockObject|ilLanguage
+     */
+    private $mockLanguage;
+
+    /**
      * @throws ReflectionException
      */
     public function testExternalMailDeliveryToLocalRecipientsWorksAsExpected() : void
@@ -204,7 +209,9 @@ class ilMailTest extends ilMailBaseTest
     {
         $instance = $this->create();
 
-        $this->assertEquals('', $instance->formatNamesForOutput(''));
+        $this->mockLanguage->expects(self::once())->method('txt')->with('not_available')->willReturn('not_available');
+
+        $this->assertEquals('not_available', $instance->formatNamesForOutput(''));
         $this->assertEquals('', $instance->formatNamesForOutput(','));
     }
 
@@ -540,7 +547,7 @@ class ilMailTest extends ilMailBaseTest
             $this->getMockBuilder(ilAppEventHandler::class)->disableOriginalConstructor()->getMock(),
             ($this->mockLog = $this->getMockBuilder(ilLogger::class)->disableOriginalConstructor()->getMock()),
             ($this->mockDatabase = $this->getMockBuilder(ilDBInterface::class)->disableOriginalConstructor()->getMock()),
-            $this->getMockBuilder(ilLanguage::class)->disableOriginalConstructor()->getMock(),
+            ($this->mockLanguage = $this->getMockBuilder(ilLanguage::class)->disableOriginalConstructor()->getMock()),
             $this->getMockBuilder(ilFileDataMail::class)->disableOriginalConstructor()->getMock(),
             $this->getMockBuilder(ilMailOptions::class)->disableOriginalConstructor()->getMock(),
             $this->getMockBuilder(ilMailbox::class)->disableOriginalConstructor()->getMock(),


### PR DESCRIPTION
Add Unit Tests for ilMail.

Remove unnecessary $usrId Parameter from `ilMail::getNewDraftId(...)` and adjust the only usage of this method (in `ilMailFormGUI`).