### PR TITLE
Add Unit Tests for Modules/Forum

### DIFF
--- a/Modules/Forum/classes/class.ilForumNotification.php
+++ b/Modules/Forum/classes/class.ilForumNotification.php
@@ -133,7 +133,7 @@ class ilForumNotification
         $res = $this->db->queryF(
             '
 			SELECT admin_force_noti FROM frm_notification
-			WHERE user_id = %s 
+			WHERE user_id = %s
 			AND frm_id = %s
 			AND user_id_noti > %s ',
             ['integer', 'integer', 'integer'],
@@ -152,7 +152,7 @@ class ilForumNotification
         $res = $this->db->queryF(
             '
 			SELECT user_toggle_noti FROM frm_notification
-			WHERE user_id = %s 
+			WHERE user_id = %s
 			AND frm_id = %s
 			AND user_id_noti > %s',
             ['integer', 'integer', 'integer'],
@@ -190,8 +190,8 @@ class ilForumNotification
             '
 			DELETE FROM frm_notification
 			WHERE 	user_id = %s
-			AND		frm_id = %s 
-			AND		admin_force_noti = %s 
+			AND		frm_id = %s
+			AND		admin_force_noti = %s
 			AND		user_id_noti > %s',
             ['integer', 'integer', 'integer', 'integer'],
             [$this->getUserId(), $this->getForumId(), 1, 0]
@@ -204,9 +204,9 @@ class ilForumNotification
             '
 			DELETE FROM frm_notification
 			WHERE 	user_id = %s
-			AND		frm_id = %s 
-			AND		admin_force_noti = %s 
-			AND		user_toggle_noti = %s			
+			AND		frm_id = %s
+			AND		admin_force_noti = %s
+			AND		user_toggle_noti = %s
 			AND		user_id_noti > %s',
             ['integer', 'integer', 'integer', 'integer', 'integer'],
             [$this->getUserId(), $this->getForumId(), 1, 1, 0]
@@ -300,7 +300,9 @@ class ilForumNotification
             $node_data = array_filter($node_data, static function (array $forum_node) use ($DIC, $ref_id) : bool {
                 // filter out forum if a grp lies in the path (#0027702)
                 foreach ($DIC->repositoryTree()->getNodePath($forum_node['child'], $ref_id) as $path_node) {
-                    if ((int) $path_node['child'] !== (int) $ref_id && $path_node['type'] === 'grp') {
+                    $notRootNode = (int) $path_node['child'] !== (int) $ref_id;
+                    $isGroup = $path_node['type'] === 'grp';
+                    if ($notRootNode && $isGroup) {
                         return false;
                     }
                 }

--- a/Modules/Forum/classes/class.ilForumTopic.php
+++ b/Modules/Forum/classes/class.ilForumTopic.php
@@ -798,10 +798,10 @@ class ilForumTopic
             $this->db->manipulateF(
                 'UPDATE frm_threads SET is_closed = %s WHERE thr_pk = %s',
                 ['integer', 'integer'],
-                ['0', $this->id]
+                [0, $this->id]
             );
 
-            $this->is_closed = true;
+            $this->is_closed = false;
         }
     }
 

--- a/Modules/Forum/test/ilForumNotificationTest.php
+++ b/Modules/Forum/test/ilForumNotificationTest.php
@@ -1,0 +1,427 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 1998-2021 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+use ILIAS\DI\Container;
+use PHPUnit\Framework\TestCase;
+use \PHPUnit\Framework\MockObject\MockObject;
+
+class ilForumNotificationTest extends TestCase
+{
+    /**
+     * @var MockObject|\ilDBInterface
+     */
+    private $database;
+
+    /**
+     * @var MockObject|\ilObjUser
+     */
+    private $user;
+
+    /**
+     * @var MockObject|\ilTree
+     */
+    private $tree;
+
+    public function testConstruct() : void
+    {
+        $this->assertInstanceOf(\ilForumNotification::class, new \ilForumNotification(938));
+    }
+
+    public function testGetterAndSetter() : void
+    {
+        $instance = new \ilForumNotification(940);
+        $instance->setNotificationId(1);
+        $this->assertEquals(1, $instance->getNotificationId());
+        $instance->setUserId(2);
+        $this->assertEquals(2, $instance->getUserId());
+        $instance->setForumId(3);
+        $this->assertEquals(3, $instance->getForumId());
+        $instance->setThreadId(4);
+        $this->assertEquals(4, $instance->getThreadId());
+        $instance->setInterestedEvents(5);
+        $this->assertEquals(5, $instance->getInterestedEvents());
+        $instance->setAdminForce(true);
+        $this->assertEquals(true, $instance->getAdminForce());
+        $instance->setUserToggle(true);
+        $this->assertEquals(true, $instance->getUserToggle());
+        $instance->setForumRefId(6);
+        $this->assertEquals(6, $instance->getForumRefId());
+        $instance->setUserIdNoti(7);
+        $this->assertEquals(7, $instance->getUserIdNoti());
+    }
+
+    public function testIsAdminForceNotification() : void
+    {
+        $forumId = 745;
+        $userId = 271;
+
+        $mockStatement = $this->mock(\ilDBStatement::class);
+        $this->database->expects(self::once())->method('queryF')->with(
+            '
+			SELECT admin_force_noti FROM frm_notification
+			WHERE user_id = %s
+			AND frm_id = %s
+			AND user_id_noti > %s ',
+            ['integer', 'integer', 'integer'],
+            [$userId, $forumId, 0]
+        )->willReturn($mockStatement);
+        $this->database->expects(self::once())->method('fetchAssoc')->with($mockStatement)->willReturn(['admin_force_noti' => '1']);
+
+        $instance = new \ilForumNotification(375);
+        $instance->setForumId($forumId);
+        $instance->setUserId($userId);
+
+        $this->assertTrue($instance->isAdminForceNotification());
+    }
+
+    public function testIsAdminForceNotificationFailed() : void
+    {
+        $forumId = 745;
+        $userId = 271;
+
+        $mockStatement = $this->mock(\ilDBStatement::class);
+        $this->database->expects(self::once())->method('queryF')->with(
+            '
+			SELECT admin_force_noti FROM frm_notification
+			WHERE user_id = %s
+			AND frm_id = %s
+			AND user_id_noti > %s ',
+            ['integer', 'integer', 'integer'],
+            [$userId, $forumId, 0]
+        )->willReturn($mockStatement);
+        $this->database->expects(self::once())->method('fetchAssoc')->with($mockStatement)->willReturn(null);
+
+        $instance = new \ilForumNotification(375);
+        $instance->setForumId($forumId);
+        $instance->setUserId($userId);
+
+        $this->assertFalse($instance->isAdminForceNotification());
+    }
+
+    public function testIsUserToggleNotification() : void
+    {
+        $forumId = 745;
+        $userId = 271;
+
+        $mockStatement = $this->mock(\ilDBStatement::class);
+        $this->database->expects(self::once())->method('queryF')->with(
+            '
+			SELECT user_toggle_noti FROM frm_notification
+			WHERE user_id = %s
+			AND frm_id = %s
+			AND user_id_noti > %s',
+            ['integer', 'integer', 'integer'],
+            [$userId, $forumId, 0]
+        )->willReturn($mockStatement);
+        $this->database->expects(self::once())->method('fetchAssoc')->with($mockStatement)->willReturn(['user_toggle_noti' => '1']);
+
+        $instance = new \ilForumNotification(375);
+        $instance->setForumId($forumId);
+        $instance->setUserId($userId);
+
+        $this->assertTrue($instance->isUserToggleNotification());
+    }
+
+    public function testIsUserToggleNotificationFailed() : void
+    {
+        $forumId = 745;
+        $userId = 271;
+
+        $mockStatement = $this->mock(\ilDBStatement::class);
+        $this->database->expects(self::once())->method('queryF')->with(
+            '
+			SELECT user_toggle_noti FROM frm_notification
+			WHERE user_id = %s
+			AND frm_id = %s
+			AND user_id_noti > %s',
+            ['integer', 'integer', 'integer'],
+            [$userId, $forumId, 0]
+        )->willReturn($mockStatement);
+        $this->database->expects(self::once())->method('fetchAssoc')->with($mockStatement)->willReturn(null);
+
+        $instance = new \ilForumNotification(375);
+        $instance->setForumId($forumId);
+        $instance->setUserId($userId);
+
+        $this->assertFalse($instance->isUserToggleNotification());
+    }
+
+    public function testInsertAdminForce() : void
+    {
+        $userToggle = true;
+        $adminForce = false;
+        $forumId = 970;
+        $userId = 530;
+        $objUserId = 3627;
+        $nextId = 3737;
+
+        $this->user->expects(self::once())->method('getId')->willReturn($objUserId);
+
+        $this->database->expects(self::once())->method('nextId')->willReturn($nextId);
+        $this->database->expects(self::once())->method('manipulateF')->with(
+            '
+			INSERT INTO frm_notification
+				(notification_id, user_id, frm_id, admin_force_noti, user_toggle_noti, user_id_noti)
+			VALUES(%s, %s, %s, %s, %s, %s)',
+            ['integer', 'integer', 'integer', 'integer', 'integer', 'integer'],
+            [
+                $nextId,
+                $userId,
+                $forumId,
+                $adminForce,
+                $userToggle,
+                $objUserId
+            ]
+        );
+
+        $instance = new \ilForumNotification(480);
+        $instance->setUserId($userId);
+        $instance->setForumId($forumId);
+        $instance->setAdminForce($adminForce);
+        $instance->setUserToggle($userToggle);
+
+        $instance->insertAdminForce();
+    }
+
+    public function testDeleteAdminForce() : void
+    {
+        $userId = 739;
+        $forumId = 48849;
+
+        $this->database->expects(self::once())->method('manipulateF')->with(
+            '
+			DELETE FROM frm_notification
+			WHERE 	user_id = %s
+			AND		frm_id = %s
+			AND		admin_force_noti = %s
+			AND		user_id_noti > %s',
+            ['integer', 'integer', 'integer', 'integer'],
+            [$userId, $forumId, 1, 0]
+        );
+
+        $instance = new \ilForumNotification(292);
+        $instance->setUserId($userId);
+        $instance->setForumId($forumId);
+
+        $instance->deleteAdminForce();
+    }
+
+    public function testDeleteUserToggle() : void
+    {
+        $forumId = 3877;
+        $userId = 3839;
+        $this->database->expects(self::once())->method('manipulateF')->with(
+            '
+			DELETE FROM frm_notification
+			WHERE 	user_id = %s
+			AND		frm_id = %s
+			AND		admin_force_noti = %s
+			AND		user_toggle_noti = %s
+			AND		user_id_noti > %s',
+            ['integer', 'integer', 'integer', 'integer', 'integer'],
+            [$userId, $forumId, 1, 1, 0]
+        );
+
+        $instance = new \ilForumNotification(3830);
+        $instance->setUserId($userId);
+        $instance->setForumId($forumId);
+        $instance->deleteUserToggle();
+    }
+
+    public function testupdateUserToggle() : void
+    {
+        $userToggle = true;
+        $forumId = 3877;
+        $userId = 3839;
+
+        $this->database->expects(self::once())->method('manipulateF')->with(
+            'UPDATE frm_notification SET user_toggle_noti = %s WHERE user_id = %s AND frm_id = %s AND admin_force_noti = %s',
+            ['integer', 'integer', 'integer', 'integer'],
+            [$userToggle, $userId, $forumId, 1]
+        );
+
+        $instance = new \ilForumNotification(3830);
+        $instance->setUserId($userId);
+        $instance->setForumId($forumId);
+        $instance->setUserToggle($userToggle);
+        $instance->updateUserToggle();
+    }
+
+    public function testCheckForumsExistsInsert() : void
+    {
+        $nodeData = [];
+        $userId = 927;
+        $refId = 847;
+        $subTree = [['child' => 3719, 'ref_id' => 3738, 'obj_id' => 182]];
+        $pathNode = [['child' => $refId, 'type' => 'aa']];
+
+        $this->tree->expects(self::once())->method('getNodePath')->with($subTree[0]['child'], $refId)->willReturn($pathNode);
+        $this->tree->expects(self::once())->method('getNodeData')->with($refId)->willReturn($nodeData);
+        $this->tree->expects(self::once())->method('getSubTree')->with(
+            $nodeData,
+            true,
+            ['frm']
+        )->willReturn($subTree);
+
+        \ilForumNotification::checkForumsExistsInsert($refId, $userId);
+    }
+
+    public function testUpdate() : void
+    {
+        $forumId = 1122;
+        $userId = 484;
+        $events = 848;
+        $userToggle = true;
+        $adminForce = false;
+        $this->database->expects(self::once())->method('manipulateF')->with(
+            'UPDATE frm_notification SET admin_force_noti = %s, user_toggle_noti = %s, ' .
+            'interested_events = %s WHERE user_id = %s AND frm_id = %s',
+            ['integer', 'integer', 'integer', 'integer', 'integer'],
+            [
+                (int) $adminForce,
+                (int) $userToggle,
+                $events,
+                $userId,
+                $forumId
+            ]
+        );
+
+        $instance = new \ilForumNotification(8380);
+        $instance->setAdminForce($adminForce);
+        $instance->setUserToggle($userToggle);
+        $instance->setInterestedEvents($events);
+        $instance->setUserId($userId);
+        $instance->setForumId($forumId);
+
+        $instance->update();
+    }
+
+    public function testDeleteNotificationAllUsers() : void
+    {
+        $forumId = 490;
+        $this->database->expects(self::once())->method('manipulateF')->with(
+            'DELETE FROM frm_notification WHERE frm_id = %s AND user_id_noti > %s',
+            ['integer', 'integer'],
+            [$forumId, 0]
+        );
+
+        $instance = new \ilForumNotification(3490);
+        $instance->setForumId($forumId);
+
+        $instance->deleteNotificationAllUsers();
+    }
+
+
+    public function testRead() : void
+    {
+        $forumId = 4859;
+        $row = [
+            'notification_id' => 789,
+            'user_id' => 490,
+            'frm_id' => 380,
+            'thread_id' => 280,
+            'admin_force_noti' => 20,
+            'user_toggle_noti' => 90,
+            'interested_events' => 8,
+        ];
+        $mockStatement = $this->mock(\ilDBStatement::class);
+        $this->database->expects(self::exactly(2))->method('fetchAssoc')->willReturn(
+            $row,
+            null
+        );
+        $this->database->expects(self::once())->method('queryF')->with(
+            'SELECT * FROM frm_notification WHERE frm_id = %s',
+            ['integer'],
+            [$forumId]
+        )->willReturn($mockStatement);
+
+        $instance = new \ilForumNotification(84849);
+        $instance->setForumId($forumId);
+
+        $this->assertEquals([
+            $row['user_id'] => $row,
+        ], $instance->read());
+    }
+
+    public function testMergeThreadNotifications() : void
+    {
+        $srcRow = ['user_id' => 47349];
+        $mismatchUserIdRow = ['user_id' => 37, 'notification_id' => 48];
+        $matchUserIdRow = ['user_id' => $srcRow['user_id'], 'notification_id' => 380];
+        $targetId = 840;
+        $srcId = 5749;
+        $srcStatement = $this->mock(\ilDBStatement::class);
+        $targetStatement = $this->mock(\ilDBStatement::class);
+        $this->database->expects(self::exactly(2))->method('queryF')->withConsecutive(
+            [
+                'SELECT notification_id, user_id FROM frm_notification WHERE frm_id = %s AND  thread_id = %s ORDER BY user_id ASC',
+                ['integer', 'integer'],
+                [0, $srcId],
+            ],
+            [
+                'SELECT DISTINCT user_id FROM frm_notification WHERE frm_id = %s AND  thread_id = %s ORDER BY user_id ASC',
+                ['integer', 'integer'],
+                [0, $targetId],
+            ],
+        )->willReturnOnConsecutiveCalls($srcStatement, $targetStatement);
+
+        $this->database->expects(self::exactly(5))
+                       ->method('fetchAssoc')
+                       ->withConsecutive([$srcStatement], [$srcStatement], [$targetStatement], [$targetStatement], [$targetStatement])
+                       ->willReturnOnConsecutiveCalls($srcRow, null, $matchUserIdRow, $mismatchUserIdRow, null);
+
+        $this->database->expects(self::once())->method('manipulateF')->with(
+            'DELETE FROM frm_notification WHERE notification_id = %s',
+            ['integer'],
+            [$matchUserIdRow['notification_id']]
+        );
+
+        $this->database->expects(self::once())->method('update')->with(
+            'frm_notification',
+            ['thread_id' => ['integer', $targetId]],
+            ['thread_id' => ['integer', $srcId]]
+        );
+
+        \ilForumNotification::mergeThreadNotifications($srcId, $targetId);
+    }
+
+    public function testExistsNotification() : void
+    {
+        $adminForce = false;
+        $forumId = 7332;
+        $userId = 5758;
+
+        $statement = $this->mock(\ilDBStatement::class);
+        $this->database->expects(self::once())->method('queryF')->with(
+            'SELECT user_id FROM frm_notification WHERE user_id = %s AND frm_id = %s AND admin_force_noti = %s',
+            ['integer', 'integer', 'integer'],
+            [$userId, $forumId, (int) $adminForce]
+        )->willReturn($statement);
+
+        $this->database->expects(self::once())->method('numRows')->with($statement)->willReturn(8);
+
+        $instance = new \ilForumNotification(434);
+        $instance->setForumId($forumId);
+        $instance->setUserId($userId);
+
+        $this->assertTrue($instance->existsNotification());
+    }
+
+    protected function setUp() : void
+    {
+        global $DIC;
+
+        $DIC = new Container();
+
+        $DIC['ilDB'] = ($this->database = $this->mock(\ilDBInterface::class));
+        $DIC['ilUser'] = ($this->user = $this->mock(\ilObjUser::class));
+        $DIC['ilObjDataCache'] = $this->mock(\ilObjectDataCache::class);
+        $DIC['tree'] = ($this->tree = $this->mock(\ilTree::class));
+    }
+
+    private function mock(string $className)
+    {
+        return $this->getMockBuilder($className)->disableOriginalConstructor()->getMock();
+    }
+}

--- a/Modules/Forum/test/ilForumTopicTest.php
+++ b/Modules/Forum/test/ilForumTopicTest.php
@@ -1,0 +1,550 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 1998-2021 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+use ILIAS\DI\Container;
+use PHPUnit\Framework\TestCase;
+use \PHPUnit\Framework\MockObject\MockObject;
+
+class ilForumTopicTest extends TestCase
+{
+    /**
+     * @var MockObject|\ilDBInterface
+     */
+    private $mockDatabase;
+
+    /**
+     * @var MockObject|\ilObjUser
+     */
+    private $mockUser;
+
+    public function testConstruct() : void
+    {
+        $id = 78;
+
+        $valueAsObject = new \stdClass();
+
+        $valueAsObject->thr_top_fk = 8;
+        $valueAsObject->thr_display_user_id = 8;
+        $valueAsObject->thr_usr_alias = '';
+        $valueAsObject->thr_subject = '';
+        $valueAsObject->thr_date = '';
+        $valueAsObject->thr_update = '';
+        $valueAsObject->import_name = '';
+        $valueAsObject->thr_num_posts = 8;
+        $valueAsObject->thr_last_post = '';
+        $valueAsObject->visits = 8;
+        $valueAsObject->is_sticky = false;
+        $valueAsObject->is_closed = false;
+        $valueAsObject->frm_obj_id = 8;
+        $valueAsObject->avg_rating = 9;
+        $valueAsObject->thr_author_id = 8;
+
+        $mockStatement = $this->getMockBuilder(\ilDBStatement::class)->disableOriginalConstructor()->getMock();
+        $mockStatement->expects(self::once())
+                      ->method('fetchRow')
+                      ->with(ilDBConstants::FETCHMODE_OBJECT)
+                      ->willReturn($valueAsObject);
+
+        $this->mockDatabase->expects(self::once())->method('queryF')->with(
+            '
+                SELECT frm_threads.*, top_frm_fk frm_obj_id
+                FROM frm_threads
+                INNER JOIN frm_data ON top_pk = thr_top_fk
+                WHERE thr_pk = %s',
+            ['integer'],
+            [$id]
+        )->willReturn($mockStatement);
+
+        $instance = new \ilForumTopic($id);
+
+        $this->assertInstanceOf(\ilForumTopic::class, $instance);
+    }
+
+    public function testAssignData() : void
+    {
+        $data = [
+            'thr_pk' => '',
+            'thr_top_fk' => '',
+            'thr_subject' => '',
+            'thr_display_user_id' => '',
+            'thr_usr_alias' => '',
+            'thr_last_post' => '',
+            'thr_date' => '',
+            'thr_update' => '',
+            'visits' => '',
+            'import_name' => '',
+            'is_sticky' => '',
+            'is_closed' => '',
+            'avg_rating' => '',
+            'thr_author_id' => '',
+
+            'num_posts' => '',
+            'num_unread_posts' => '',
+            'num_new_posts' => '',
+            'usr_notification_is_enabled' => '',
+        ];
+
+        $instance = new \ilForumTopic();
+        $instance->assignData($data);
+
+        $this->assertEquals(0, $instance->getId());
+        $this->assertEquals(0, $instance->getForumId());
+        $this->assertEquals('', $instance->getSubject());
+        $this->assertEquals(0, $instance->getDisplayUserId());
+        $this->assertEquals('', $instance->getUserAlias());
+        $this->assertEquals('', $instance->getLastPostString());
+        $this->assertEquals('', $instance->getCreateDate());
+        $this->assertEquals('', $instance->getChangeDate());
+        $this->assertEquals(0, $instance->getVisits());
+        $this->assertEquals('', $instance->getImportName());
+        $this->assertEquals(false, $instance->isSticky());
+        $this->assertEquals(false, $instance->isClosed());
+        $this->assertEquals(0, $instance->getAverageRating());
+        $this->assertEquals(0, $instance->getThrAuthorId());
+
+        $this->assertEquals(0, $instance->getNumPosts());
+        $this->assertEquals(0, $instance->getNumUnreadPosts());
+        $this->assertEquals(0, $instance->getNumNewPosts());
+        $this->assertEquals(false, $instance->isUserNotificationEnabled());
+    }
+
+    public function testInsert() : void
+    {
+        $instance = new \ilForumTopic();
+        $nextId = 8;
+        $instance->setId(9);
+        $instance->setForumId(10);
+        $instance->setSubject('aa');
+        $instance->setDisplayUserId(188);
+        $instance->setUserAlias('jl');
+        $instance->setNumPosts(86);
+        $instance->setLastPostString('ahssh');
+        $instance->setCreateDate('some date');
+        $instance->setImportName('xaii');
+        $instance->setSticky(true);
+        $instance->setClosed(true);
+        $instance->setAverageRating(78);
+        $instance->setThrAuthorId(8890);
+
+        $this->mockDatabase->expects(self::once())->method('nextId')->with('frm_threads')->willReturn($nextId);
+
+        $this->mockDatabase->expects(self::once())->method('insert')->with(
+            'frm_threads',
+            [
+                'thr_pk' => ['integer', $nextId],
+                'thr_top_fk' => ['integer', 10],
+                'thr_subject' => ['text', 'aa'],
+                'thr_display_user_id' => ['integer', 188],
+                'thr_usr_alias' => ['text', 'jl'],
+                'thr_num_posts' => ['integer', 86],
+                'thr_last_post' => ['text', 'ahssh'],
+                'thr_date' => ['timestamp', 'some date'],
+                'thr_update' => ['timestamp', null],
+                'import_name' => ['text', 'xaii'],
+                'is_sticky' => ['integer', 1],
+                'is_closed' => ['integer', 1],
+                'avg_rating' => ['text', 78],
+                'thr_author_id' => ['integer', 8890],
+            ]
+        );
+
+        $this->assertTrue($instance->insert());
+    }
+
+    public function testInsertFalse() : void
+    {
+        $instance = new \ilForumTopic();
+        $this->mockDatabase->expects(self::never())->method('nextId');
+        $this->mockDatabase->expects(self::never())->method('insert');
+        $instance->setForumId(0);
+        $this->assertFalse($instance->insert());
+    }
+
+    public function testUpdate() : void
+    {
+        $instance = new \ilForumTopic();
+        $instance->setId(8);
+        $instance->setForumId(789);
+        $instance->setSubject('abc');
+        $instance->setNumPosts(67);
+        $instance->setLastPostString('hej');
+        $instance->setAverageRating(27);
+
+        $this->mockDatabase->expects(self::once())->method('manipulateF')->with(
+            '
+                UPDATE frm_threads
+                SET thr_top_fk = %s,
+                    thr_subject = %s,
+                    thr_update = %s,
+                    thr_num_posts = %s,
+                    thr_last_post = %s,
+                    avg_rating = %s
+                WHERE thr_pk = %s',
+            ['integer', 'text', 'timestamp', 'integer', 'text', 'text', 'integer'],
+            [
+                789,
+                'abc',
+                date('Y-m-d H:i:s'),
+                67,
+                'hej',
+                '27',
+                8,
+            ]
+        );
+        $this->assertTrue($instance->update());
+    }
+
+    public function testUpdateFalse() : void
+    {
+        $instance = new \ilForumTopic();
+        $this->mockDatabase->expects(self::never())->method('manipulateF');
+        $instance->setForumId(0);
+        $this->assertFalse($instance->update());
+    }
+
+    public function testReload() : void
+    {
+        $mockStatement = $this->getMockBuilder(\ilDBStatement::class)->disableOriginalConstructor()->getMock();
+        $mockStatement->expects(self::once())->method('fetchRow')->willReturn(null);
+        $this->mockDatabase->expects(self::once())->method('queryF')->willReturn($mockStatement);
+        $instance = new \ilForumTopic();
+        $instance->setId(89);
+        $instance->reload();
+    }
+
+    public function testGetFirstPostId() : void
+    {
+        $id = 909;
+        $stdObject = new \stdClass();
+        $stdObject->pos_fk = 5678;
+        $mockStatement = $this->getMockBuilder(\ilDBStatement::class)->disableOriginalConstructor()->getMock();
+        $this->mockDatabase->expects(self::once())->method('queryF')->with(
+            'SELECT * FROM frm_posts_tree WHERE thr_fk = %s AND parent_pos = %s',
+            ['integer', 'integer'],
+            [$id, 1]
+        )->willReturn($mockStatement);
+        $this->mockDatabase->expects(self::once())->method('fetchObject')->with($mockStatement)->willReturn($stdObject);
+
+        $instance = new \ilForumTopic();
+        $instance->setId($id);
+        $this->assertEquals($stdObject->pos_fk, $instance->getFirstPostId());
+    }
+
+    public function testGetFirstPostIdFailed() : void
+    {
+        $id = 909;
+        $mockStatement = $this->getMockBuilder(\ilDBStatement::class)->disableOriginalConstructor()->getMock();
+        $this->mockDatabase->expects(self::once())->method('queryF')->with(
+            'SELECT * FROM frm_posts_tree WHERE thr_fk = %s AND parent_pos = %s',
+            ['integer', 'integer'],
+            [$id, 1]
+        )->willReturn($mockStatement);
+        $this->mockDatabase->expects(self::once())->method('fetchObject')->with($mockStatement)->willReturn(null);
+
+        $instance = new \ilForumTopic();
+        $instance->setId($id);
+        $this->assertEquals(0, $instance->getFirstPostId());
+    }
+
+    public function testCountPosts() : void
+    {
+        $id = 789;
+        $mockStatement = $this->getMockBuilder(\ilDBStatement::class)->disableOriginalConstructor()->getMock();
+        $this->mockDatabase->expects(self::once())->method('queryF')->with(
+            '
+            SELECT COUNT(*) cnt
+            FROM frm_posts
+            INNER JOIN frm_posts_tree ON frm_posts_tree.pos_fk = pos_pk
+            WHERE pos_thr_fk = %s AND parent_pos != 0 ',
+            ['integer'],
+            [$id]
+        )->willReturn($mockStatement);
+        $this->mockDatabase->expects(self::once())->method('fetchAssoc')->with($mockStatement)->willReturn(['cnt' => 678]);
+
+        $instance = new \ilForumTopic();
+        $instance->setId($id);
+        $this->assertEquals(678, $instance->countPosts(true));
+    }
+
+    public function testCountPostsFailed() : void
+    {
+        $id = 789;
+        $mockStatement = $this->getMockBuilder(\ilDBStatement::class)->disableOriginalConstructor()->getMock();
+        $this->mockDatabase->expects(self::once())->method('queryF')->with(
+            '
+            SELECT COUNT(*) cnt
+            FROM frm_posts
+            INNER JOIN frm_posts_tree ON frm_posts_tree.pos_fk = pos_pk
+            WHERE pos_thr_fk = %s AND parent_pos != 0 ',
+            ['integer'],
+            [$id]
+        )->willReturn($mockStatement);
+        $this->mockDatabase->expects(self::once())->method('fetchAssoc')->with($mockStatement)->willReturn(null);
+
+        $instance = new \ilForumTopic();
+        $instance->setId($id);
+        $this->assertEquals(0, $instance->countPosts(true));
+    }
+
+    public function testCountActivePosts() : void
+    {
+        $id = 789;
+        $userId = 354;
+        $this->mockUser->expects(self::once())->method('getId')->willReturn($userId);
+        $mockStatement = $this->getMockBuilder(\ilDBStatement::class)->disableOriginalConstructor()->getMock();
+        $this->mockDatabase->expects(self::once())->method('queryF')->with(
+            '
+            SELECT COUNT(*) cnt
+            FROM frm_posts
+            INNER JOIN frm_posts_tree ON frm_posts_tree.pos_fk = pos_pk
+            WHERE (pos_status = %s
+                 OR (pos_status = %s AND pos_display_user_id = %s))
+            AND pos_thr_fk = %s AND parent_pos != 0 ',
+            ['integer', 'integer', 'integer', 'integer'],
+            ['1', '0', $userId, $id]
+        )->willReturn($mockStatement);
+        $this->mockDatabase->expects(self::once())->method('fetchAssoc')->with($mockStatement)->willReturn(['cnt' => 79]);
+
+        $instance = new \ilForumTopic();
+        $instance->setId($id);
+        $this->assertEquals(79, $instance->countActivePosts(true));
+    }
+
+    public function testCountActivePostsFailed() : void
+    {
+        $id = 789;
+        $userId = 354;
+        $this->mockUser->expects(self::once())->method('getId')->willReturn($userId);
+        $mockStatement = $this->getMockBuilder(\ilDBStatement::class)->disableOriginalConstructor()->getMock();
+        $this->mockDatabase->expects(self::once())->method('queryF')->with(
+            '
+            SELECT COUNT(*) cnt
+            FROM frm_posts
+            INNER JOIN frm_posts_tree ON frm_posts_tree.pos_fk = pos_pk
+            WHERE (pos_status = %s
+                 OR (pos_status = %s AND pos_display_user_id = %s))
+            AND pos_thr_fk = %s AND parent_pos != 0 ',
+            ['integer', 'integer', 'integer', 'integer'],
+            ['1', '0', $userId, $id]
+        )->willReturn($mockStatement);
+        $this->mockDatabase->expects(self::once())->method('fetchAssoc')->with($mockStatement)->willReturn(null);
+
+        $instance = new \ilForumTopic();
+        $instance->setId($id);
+        $this->assertEquals(0, $instance->countActivePosts(true));
+    }
+
+    public function testGetAllPostIds() : void
+    {
+        $firstRow = new stdClass();
+        $firstRow->pos_pk = 89;
+        $id = 284;
+        $mockStatement = $this->getMockBuilder(\ilDBStatement::class)->disableOriginalConstructor()->getMock();
+        $mockStatement->expects(self::exactly(2))
+                      ->method('fetchRow')
+                      ->with(\ilDBConstants::FETCHMODE_OBJECT)
+                      ->willReturnOnConsecutiveCalls($firstRow, null);
+        $this->mockDatabase->expects(self::once())->method('queryF')->with(
+            'SELECT pos_pk FROM frm_posts WHERE pos_thr_fk = %s',
+            ['integer'],
+            [$id]
+        )->willReturn($mockStatement);
+
+        $instance = new \ilForumTopic();
+        $instance->setId($id);
+        $this->assertEquals([$firstRow->pos_pk => $firstRow->pos_pk], $instance->getAllPostIds());
+    }
+
+    public function testIsNotificationEnabled() : void
+    {
+        $id = 723;
+        $userId = 639;
+
+        $instance = new \ilForumTopic();
+        $instance->setId($id);
+
+        $mockStatement = $this->getMockBuilder(\ilDBStatement::class)->disableOriginalConstructor()->getMock();
+        $this->mockDatabase->expects(self::once())->method('queryF')->with(
+            'SELECT COUNT(notification_id) cnt FROM frm_notification WHERE user_id = %s AND thread_id = %s',
+            ['integer', 'integer'],
+            [$userId, $id]
+        )->willReturn($mockStatement);
+        $this->mockDatabase->expects(self::once())->method('fetchAssoc')->with($mockStatement)->willReturn(['cnt' => 46]);
+
+        $this->assertTrue($instance->isNotificationEnabled($userId));
+    }
+
+    public function testIsNotificationEnabledNoResult() : void
+    {
+        $id = 723;
+        $userId = 639;
+
+        $instance = new \ilForumTopic();
+        $instance->setId($id);
+
+        $mockStatement = $this->getMockBuilder(\ilDBStatement::class)->disableOriginalConstructor()->getMock();
+        $this->mockDatabase->expects(self::once())->method('queryF')->with(
+            'SELECT COUNT(notification_id) cnt FROM frm_notification WHERE user_id = %s AND thread_id = %s',
+            ['integer', 'integer'],
+            [$userId, $id]
+        )->willReturn($mockStatement);
+        $this->mockDatabase->expects(self::once())->method('fetchAssoc')->with($mockStatement)->willReturn(null);
+
+        $this->assertFalse($instance->isNotificationEnabled($userId));
+    }
+
+    public function testIsNotificationEnabledInvalidIds() : void
+    {
+        $id = 723;
+        $userId = 0;
+
+        $instance = new \ilForumTopic();
+        $instance->setId($id);
+
+        $this->mockDatabase->expects(self::never())->method('queryF');
+        $this->mockDatabase->expects(self::never())->method('fetchAssoc');
+
+        $this->assertFalse($instance->isNotificationEnabled($userId));
+    }
+
+    public function testEnableNotification() : void
+    {
+        $nextId = 3847;
+        $id = 3739;
+        $userId = 8283;
+
+        $mockStatement = $this->getMockBuilder(\ilDBStatement::class)->disableOriginalConstructor()->getMock();
+        $this->mockDatabase->expects(self::once())->method('nextId')->with('frm_notification')->willReturn($nextId);
+        $this->mockDatabase->expects(self::once())->method('queryF')->willReturn($mockStatement);
+        $this->mockDatabase->expects(self::once())->method('manipulateF')->with(
+            '
+                INSERT INTO frm_notification
+                (    notification_id,
+                    user_id,
+                    thread_id
+                )
+                VALUES(%s, %s, %s)',
+            ['integer', 'integer', 'integer'],
+            [$nextId, $userId, $id]
+        );
+        $this->mockDatabase->expects(self::once())->method('fetchAssoc')->with($mockStatement)->willReturn(['cnt' => 0]);
+
+        $instance = new \ilForumTopic();
+        $instance->setId($id);
+        $instance->enableNotification($userId);
+    }
+
+    public function testDisableNotification() : void
+    {
+        $id = 384;
+        $userId = 48475;
+
+        $this->mockDatabase->expects(self::once())->method('manipulateF')->with(
+            'DELETE FROM frm_notification WHERE user_id = %s AND thread_id = %s',
+            ['integer', 'integer'],
+            [$userId, $id]
+        );
+
+        $instance = new \ilForumTopic();
+        $instance->setId($id);
+        $instance->disableNotification($userId);
+    }
+
+    public function testMakeSticky() : void
+    {
+        $id = 1929;
+
+        $this->mockDatabase->expects(self::once())->method('manipulateF')->with(
+            'UPDATE frm_threads SET is_sticky = %s WHERE thr_pk = %s',
+            ['integer', 'integer'],
+            [1, $id]
+        );
+
+        $instance = new \ilForumTopic();
+        $instance->setId($id);
+        $this->assertTrue($instance->makeSticky());
+    }
+
+    public function testMakeStickyFailed() : void
+    {
+        $id = 1929;
+
+        $this->mockDatabase->expects(self::never())->method('manipulateF');
+
+        $instance = new \ilForumTopic();
+        $this->assertFalse($instance->makeSticky());
+    }
+
+    public function testUnmakeSticky() : void
+    {
+        $id = 1929;
+
+        $this->mockDatabase->expects(self::once())->method('manipulateF')->with(
+            'UPDATE frm_threads SET is_sticky = %s WHERE thr_pk = %s',
+            ['integer', 'integer'],
+            [0, $id]
+        );
+
+        $instance = new \ilForumTopic();
+        $instance->setId($id);
+        $instance->setSticky(true);
+        $this->assertTrue($instance->unmakeSticky());
+    }
+
+    public function testUnmakeStickyFalse() : void
+    {
+        $id = 1929;
+
+        $this->mockDatabase->expects(self::never())->method('manipulateF');
+
+        $instance = new \ilForumTopic();
+        $instance->setId($id);
+        $this->assertFalse($instance->unmakeSticky());
+    }
+
+    public function testClose() : void
+    {
+        $id = 1929;
+
+        $this->mockDatabase->expects(self::once())->method('manipulateF')->with(
+            'UPDATE frm_threads SET is_closed = %s WHERE thr_pk = %s',
+            ['integer', 'integer'],
+            [1, $id]
+        );
+
+        $instance = new \ilForumTopic();
+        $instance->setId($id);
+        $instance->setClosed(false);
+        $instance->close();
+    }
+
+    public function testReopen() : void
+    {
+        $id = 1929;
+
+        $this->mockDatabase->expects(self::once())->method('manipulateF')->with(
+            'UPDATE frm_threads SET is_closed = %s WHERE thr_pk = %s',
+            ['integer', 'integer'],
+            [0, $id]
+        );
+
+        $instance = new \ilForumTopic();
+        $instance->setId($id);
+        $instance->setClosed(true);
+        $instance->reopen();
+    }
+
+    protected function setUp() : void
+    {
+        global $DIC;
+
+        $DIC = new Container();
+
+        $this->mockDatabase = $this->getMockBuilder(\ilDBInterface::class)->getMock();
+        $this->mockUser = $this->getMockBuilder(\ilObjUser::class)->disableOriginalConstructor()->getMock();
+
+        $DIC['ilDB'] = $this->mockDatabase;
+        $DIC['ilUser'] = $this->mockUser;
+    }
+}

--- a/Modules/Forum/test/ilObjForumAdministrationTest.php
+++ b/Modules/Forum/test/ilObjForumAdministrationTest.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 1998-2021 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+use ILIAS\DI\Container;
+use PHPUnit\Framework\TestCase;
+use \PHPUnit\Framework\MockObject\MockObject;
+
+class ilObjForumAdministrationTest extends TestCase
+{
+    /**
+     * @var MockObject|\ilLanguage
+     */
+    private $mockLanguage;
+
+    public function testConstruct() : void
+    {
+        if (!defined('DEBUG')) {
+            define('DEBUG', false);
+        }
+
+        $this->mockLanguage->expects(self::once())->method('loadLanguageModule')->with('forum');
+        $instance = new \ilObjForumAdministration();
+    }
+
+    protected function setUp() : void
+    {
+        global $DIC;
+
+        $DIC = new Container();
+
+        $DIC['ilias'] = null; // not used just added received
+        $DIC['ilDB'] = $this->getMockBuilder(\ilDBInterface::class)->getMock();
+        // $DIC['ilUser'] = $this->getMockBuilder(\ilObjUser::class)->disableOriginalConstructor()->getMock();
+        $DIC['ilErr'] = null;
+        $DIC['tree'] = $this->getMockBuilder(\ilTree::class)->disableOriginalConstructor()->getMock();
+        $DIC['ilLog'] = null;
+        $DIC['ilAppEventHandler'] = null;
+        $DIC['objDefinition'] = null;
+        $DIC['lng'] = ($this->mockLanguage = $this->getMockBuilder(\ilLanguage::class)->disableOriginalConstructor()->getMock());
+    }
+}

--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -141,12 +141,6 @@ class ilObject
     */
     public $add_dots;
 
-    /**
-     * Legacy compatibility
-     * @var \ILIAS
-     */
-    public $ilias;
-
 
     /**
     * Constructor

--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -143,7 +143,7 @@ class ilObject
 
     /**
      * Legacy compatibility
-     * @var
+     * @var \ILIAS
      */
     public $ilias;
 

--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -141,6 +141,12 @@ class ilObject
     */
     public $add_dots;
 
+    /**
+     * Legacy compatibility
+     * @var
+     */
+    public $ilias;
+
 
     /**
     * Constructor


### PR DESCRIPTION
Add Unit Tests for Modules/Forum.

Correct wrong property $is_open in `ilForumTopic::reopen()`.

Rearrange `if` in `ilForumNotification::getCachedNodeData`.

