### PR TITLE
UI/Layout: Breadcrumbs in Content

### DIFF
--- a/src/UI/templates/default/Breadcrumbs/breadcrumbs.less
+++ b/src/UI/templates/default/Breadcrumbs/breadcrumbs.less
@@ -12,8 +12,8 @@
 		margin: 0;
 		font-weight: @il-standard-page-breadcrumbs-font-weight;
 		font-size: @font-size-small;
-		padding: @il-padding-small-vertical;
-		padding-left: @il-mainbar-btn-width + @il-standard-page-content-padding;
+		padding: (@il-padding-small-vertical * 2);
+		padding-left: @il-standard-page-content-padding;
 
 		span.crumb {
 			color: @il-standard-page-breadcrumbs-color;

--- a/src/UI/templates/default/Layout/standardpage.less
+++ b/src/UI/templates/default/Layout/standardpage.less
@@ -61,13 +61,10 @@ grid-based layout
 // main grid without slates
 .il-layout-page {
 	background: @body-bg;
-	display: -ms-grid;
 	display: grid;
 	grid-gap: 0px;
-	-ms-grid-columns: auto 1fr;
     grid-template-columns: auto 1fr;
-	-ms-grid-rows: @il-standard-page-header-height auto @il-standard-page-breadcrumbs-height 1fr;
-    grid-template-rows: @il-standard-page-header-height auto @il-standard-page-breadcrumbs-height 1fr;
+    grid-template-rows: auto @il-standard-page-header-height 1fr;
     height: 100%;
 	overflow: hidden;
 	width: 100%;
@@ -82,16 +79,13 @@ grid-based layout
 	}
 	// main grid with active slates
 	&.with-mainbar-slates-engaged {
-		-ms-grid-columns: auto 1fr;
 		grid-template-columns: auto 1fr;
 		.il-maincontrols-mainbar {
 			width: @il-standard-page-slate-width + @il-mainbar-btn-width;
 
 			// slate
 			.il-mainbar-slates {
-				display: -ms-flexbox;
 				display: flex;
-				-ms-flex-direction: column;
 				flex-direction: column;
 				z-index: @il-standard-page-zindex-mainbar-slates;
 				.il-maincontrols-slate {
@@ -102,7 +96,6 @@ grid-based layout
 			}
 			// show slate remove btn
 			.il-mainbar-close-slates {
-				display: -ms-flexbox;
 				display: flex;
 			}
 		}
@@ -111,60 +104,41 @@ grid-based layout
 
 // metabar
 header {
-	-ms-grid-column: 1;
-	-ms-grid-column-span: 2;
-	-ms-grid-row: 1;
 	grid-column-start: 1;
 	grid-column-end: 3;
-	grid-row: 1;
+	grid-row: 2;
 	z-index: @il-standard-page-zindex-header;
+	.shadow-bottom();
 }
 
 //Breadcrumbs
 .breadcrumbs {
-	-ms-flex-align: center;
 	align-items: center;
 	background-color: @il-standard-page-breadcrumbs-bg-color;
-	border-top: 1px solid @il-standard-page-border-light-color;
-	display: -ms-flexbox;
 	display: flex;
-	-ms-flex-direction: row;
 	flex-direction: row;
-	-ms-grid-column: 1;
-	-ms-grid-column-span: 2;
-	-ms-grid-row: 3;
-	grid-column-start: 1;
-	grid-column-end: 3;
-	grid-row: 3;
 	z-index: @il-standard-page-zindex-breadcrumbs;
 	.shadow-bottom();
 }
 
 // system-infos
 div.il-system-infos {
-	-ms-grid-column: 1;
-	-ms-grid-column-span: 2;
-	-ms-grid-row: 2;
 	grid-column-start: 1;
 	grid-column-end: 3;
-	grid-row: 2;
+	grid-row: 1;
 	z-index: @il-standard-page-zindex-systeminfo
 }
 
 // head-container with logo pagetitle and metabar
 .header-inner {
-	-ms-flex-align: center;
     align-items: center;
     background: @il-standard-page-header-bg-color;
-	display: -ms-flexbox;
     display: flex;
-	-ms-flex-direction: row;
     flex-direction: row;
     height: @il-standard-page-header-height;
     padding: 0 15px;
     position: fixed;
     width: 100%;
-	-ms-flex-pack: justify;
     justify-content: space-between;
 }
 
@@ -190,8 +164,6 @@ div.il-system-infos {
 }
 // mainbar
 nav.il-maincontrols {
-	-ms-grid-column: 1;
-	-ms-grid-row: 4;
 	grid-column: 1;
 	grid-row: 4;
 	z-index: @il-standard-page-zindex-maincontrols;
@@ -200,12 +172,9 @@ nav.il-maincontrols {
 // Subgrid mainbar
 .il-maincontrols-mainbar {
 	background-color: @il-maincontrols-mainbar-bg-color;
-	display: -ms-grid;
 	display: grid;
 	height: 100%;
-	-ms-grid-colums: @il-mainbar-btn-width @il-standard-page-slate-width;
 	grid-template-columns: @il-mainbar-btn-width @il-standard-page-slate-width;
-	-ms-grid-rows: 1fr;
 	grid-template-rows: 1fr;
 	width: @il-mainbar-btn-width;
 	&.engaged {
@@ -216,20 +185,15 @@ nav.il-maincontrols {
 // mainbar
 .il-mainbar {
 	background-color: @il-mainbar-btn-bg-color;
-	-ms-grid-column: 1;
-	-ms-grid-row: 1;
 	grid-column: 1;
 	grid-row: 1;
-	.shadow-right();
 	z-index: @il-standard-page-zindex-mainbar;
-
+	.shadow-right();
 }
 
 // tools section
 .il-mainbar-tools-button {
-	display: -ms-flexbox;
     display: flex;
-	-ms-flex-direction: row;
     flex-direction: row;
 }
 
@@ -244,9 +208,7 @@ nav.il-maincontrols {
 		width: @il-mainbar-btn-width;
 	}
 	&.engaged {
-		display: -ms-flexbox;
 		display: flex;
-		-ms-flex-direction: row;
 		flex-direction: row;
 	}
 }
@@ -257,8 +219,6 @@ nav.il-maincontrols {
 
 // mainbar slates
 .il-mainbar-slates {
-	-ms-grid-column: 2;
-	-ms-grid-row: 1;
 	grid-column: 2;
 	grid-row: 1;
 }
@@ -269,15 +229,20 @@ main {
 }
 
 .il-layout-page-content {
-	display: -ms-grid;
 	display: grid;
-	-ms-grid-rows: 1fr auto;
 	grid-template-rows: 1fr auto;
-	-ms-grid-column: 2;
-	-ms-grid-row: 4;
 	grid-column: 2;
-	grid-row: 4;
+	grid-row: 3;
 	overflow: auto;
+	> div {
+		// contains breadcrumbs, mainspacekeeper of content
+		display: flex;
+		flex-flow: column;
+	}
+	#mainspacekeeper {
+	    flex-grow: 1; // stretches content from top to footer
+    	width: 100%;
+	}
 }
 
 /* Footer */
@@ -327,13 +292,10 @@ footer {
 	// main grid without slates
 	.il-layout-page {
 		background: @body-bg;
-		display: -ms-grid;
 		display: grid;
 		grid-gap: 0px;
-		-ms-grid-columns: 1fr;
 	    grid-template-columns: 1fr;
-		-ms-grid-rows: @il-standard-page-small-header-height auto 1fr;
-	    grid-template-rows: @il-standard-page-small-header-height auto 1fr;
+	    grid-template-rows: auto @il-standard-page-small-header-height 1fr auto; // systeminfo, mini header, content, slate
 	    height: 100%;
 		overflow: hidden;
 		width: 100%;
@@ -415,7 +377,7 @@ footer {
 		-ms-grid-column: 1;
 		-ms-grid-row: 1;
 		grid-column: 1;
-		grid-row: 1;
+		grid-row: 2;
 		z-index: @il-standard-page-zindex-header;
 	}
 

--- a/src/UI/templates/default/Layout/tpl.standardpage.html
+++ b/src/UI/templates/default/Layout/tpl.standardpage.html
@@ -57,9 +57,11 @@
 		<!-- html5 main-tag is not supported in IE / div is needed -->
 		<main class="il-layout-page-content">
 			<div>
+				<!-- BEGIN content_breadcrumbs -->
 				<div class="breadcrumbs">
 					{BREADCRUMBS}
 				</div>
+				<!-- END content_breadcrumbs -->
 
 				{CONTENT}
 			</div>

--- a/src/UI/templates/default/Layout/tpl.standardpage.html
+++ b/src/UI/templates/default/Layout/tpl.standardpage.html
@@ -46,10 +46,6 @@
 			</div>
 		</header>
 
-		<div class="breadcrumbs">
-			{BREADCRUMBS}
-		</div>
-
 		<div class="il-system-infos">
 			{SYSTEMINFOS}
 		</div>
@@ -61,9 +57,12 @@
 		<!-- html5 main-tag is not supported in IE / div is needed -->
 		<main class="il-layout-page-content">
 			<div>
+				<div class="breadcrumbs">
+					{BREADCRUMBS}
+				</div>
+
 				{CONTENT}
 			</div>
-
 
 			<!-- BEGIN pagefooter -->
 			<footer role="contentinfo">
@@ -71,7 +70,6 @@
 			</footer>
 			<!-- END pagefooter -->
 		</main>
-
 
 	</div>
 

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -7879,8 +7879,8 @@ ul.dropdown-menu > li > .btn:focus {
   margin: 0;
   font-weight: 600;
   font-size: 12px;
-  padding: 3px;
-  padding-left: 100px;
+  padding: 6px;
+  padding-left: 20px;
 }
 .breadcrumb_wrapper .breadcrumb span.crumb {
   color: #4c6586;
@@ -8912,13 +8912,10 @@ grid-based layout
 }
 .il-layout-page {
   background: #f0f0f0;
-  display: -ms-grid;
   display: grid;
   grid-gap: 0px;
-  -ms-grid-columns: auto 1fr;
   grid-template-columns: auto 1fr;
-  -ms-grid-rows: 60px auto 33px 1fr;
-  grid-template-rows: 60px auto 33px 1fr;
+  grid-template-rows: auto 60px 1fr;
   height: 100%;
   overflow: hidden;
   width: 100%;
@@ -8931,16 +8928,13 @@ grid-based layout
   display: none;
 }
 .il-layout-page.with-mainbar-slates-engaged {
-  -ms-grid-columns: auto 1fr;
   grid-template-columns: auto 1fr;
 }
 .il-layout-page.with-mainbar-slates-engaged .il-maincontrols-mainbar {
   width: 409px;
 }
 .il-layout-page.with-mainbar-slates-engaged .il-maincontrols-mainbar .il-mainbar-slates {
-  display: -ms-flexbox;
   display: flex;
-  -ms-flex-direction: column;
   flex-direction: column;
   z-index: 995;
 }
@@ -8950,58 +8944,38 @@ grid-based layout
   min-height: 0;
 }
 .il-layout-page.with-mainbar-slates-engaged .il-maincontrols-mainbar .il-mainbar-close-slates {
-  display: -ms-flexbox;
   display: flex;
 }
 header {
-  -ms-grid-column: 1;
-  -ms-grid-column-span: 2;
-  -ms-grid-row: 1;
   grid-column-start: 1;
   grid-column-end: 3;
-  grid-row: 1;
+  grid-row: 2;
   z-index: 999;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 .breadcrumbs {
-  -ms-flex-align: center;
   align-items: center;
   background-color: white;
-  border-top: 1px solid #dddddd;
-  display: -ms-flexbox;
   display: flex;
-  -ms-flex-direction: row;
   flex-direction: row;
-  -ms-grid-column: 1;
-  -ms-grid-column-span: 2;
-  -ms-grid-row: 3;
-  grid-column-start: 1;
-  grid-column-end: 3;
-  grid-row: 3;
   z-index: 998;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 div.il-system-infos {
-  -ms-grid-column: 1;
-  -ms-grid-column-span: 2;
-  -ms-grid-row: 2;
   grid-column-start: 1;
   grid-column-end: 3;
-  grid-row: 2;
+  grid-row: 1;
   z-index: 998;
 }
 .header-inner {
-  -ms-flex-align: center;
   align-items: center;
   background: white;
-  display: -ms-flexbox;
   display: flex;
-  -ms-flex-direction: row;
   flex-direction: row;
   height: 60px;
   padding: 0 15px;
   position: fixed;
   width: 100%;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 .il-logo {
@@ -9022,36 +8996,27 @@ div.il-system-infos {
   display: none;
 }
 nav.il-maincontrols {
-  -ms-grid-column: 1;
-  -ms-grid-row: 4;
   grid-column: 1;
   grid-row: 4;
   z-index: 997;
 }
 .il-maincontrols-mainbar {
   background-color: white;
-  display: -ms-grid;
   display: grid;
   height: 100%;
-  -ms-grid-colums: 80px 329px;
   grid-template-columns: 80px 329px;
-  -ms-grid-rows: 1fr;
   grid-template-rows: 1fr;
   width: 80px;
 }
 .il-mainbar {
   background-color: #2c2c2c;
-  -ms-grid-column: 1;
-  -ms-grid-row: 1;
   grid-column: 1;
   grid-row: 1;
-  box-shadow: 1px 3px 4px rgba(0, 0, 0, 0.1);
   z-index: 996;
+  box-shadow: 1px 3px 4px rgba(0, 0, 0, 0.1);
 }
 .il-mainbar-tools-button {
-  display: -ms-flexbox;
   display: flex;
-  -ms-flex-direction: row;
   flex-direction: row;
 }
 .il-mainbar-tools-button button {
@@ -9063,14 +9028,10 @@ nav.il-maincontrols {
   width: 80px;
 }
 .il-mainbar-tools-entries.engaged {
-  display: -ms-flexbox;
   display: flex;
-  -ms-flex-direction: row;
   flex-direction: row;
 }
 .il-mainbar-slates {
-  -ms-grid-column: 2;
-  -ms-grid-row: 1;
   grid-column: 2;
   grid-row: 1;
 }
@@ -9078,15 +9039,19 @@ main {
   display: block;
 }
 .il-layout-page-content {
-  display: -ms-grid;
   display: grid;
-  -ms-grid-rows: 1fr auto;
   grid-template-rows: 1fr auto;
-  -ms-grid-column: 2;
-  -ms-grid-row: 4;
   grid-column: 2;
-  grid-row: 4;
+  grid-row: 3;
   overflow: auto;
+}
+.il-layout-page-content > div {
+  display: flex;
+  flex-flow: column;
+}
+.il-layout-page-content #mainspacekeeper {
+  flex-grow: 1;
+  width: 100%;
 }
 /* Footer */
 footer {
@@ -9123,13 +9088,10 @@ footer {
 @media only screen and (max-width: 768px) {
   .il-layout-page {
     background: #f0f0f0;
-    display: -ms-grid;
     display: grid;
     grid-gap: 0px;
-    -ms-grid-columns: 1fr;
     grid-template-columns: 1fr;
-    -ms-grid-rows: 45px auto 1fr;
-    grid-template-rows: 45px auto 1fr;
+    grid-template-rows: auto 45px 1fr auto;
     height: 100%;
     overflow: hidden;
     width: 100%;
@@ -9205,7 +9167,7 @@ footer {
     -ms-grid-column: 1;
     -ms-grid-row: 1;
     grid-column: 1;
-    grid-row: 1;
+    grid-row: 2;
     z-index: 999;
   }
   .header-inner {

--- a/tests/UI/Component/Layout/Page/StandardPageTest.php
+++ b/tests/UI/Component/Layout/Page/StandardPageTest.php
@@ -12,6 +12,10 @@ use ILIAS\UI\Component\Image\Image;
 use ILIAS\UI\Implementation\Component\Layout\Page;
 use ILIAS\UI\Implementation\Component\Legacy\Legacy;
 use ILIAS\UI\Implementation\Component\SignalGenerator;
+use ILIAS\UI\Implementation\Component\Breadcrumbs\Breadcrumbs as Crumbs;
+use ILIAS\UI\Implementation\Component\Link\Standard as CrumbEntry;
+use ILIAS\UI\Implementation\Component\Button;
+use ILIAS\UI\Implementation\Component\Dropdown;
 
 /**
  * Tests for the Standard Page
@@ -191,7 +195,7 @@ class StandardPageTest extends ILIAS_UI_TestBase
          <div class="nav il-maincontrols">MainBar Stub</div>
          <!-- html5 main-tag is not supported in IE / div is needed -->
          <main class="il-layout-page-content">
-            <div><div class="breadcrumbs"></div>some content</div>
+            <div>some content</div>
          </main>
       </div>
       <script>il.Util.addOnLoad(function() {});</script>
@@ -228,7 +232,82 @@ class StandardPageTest extends ILIAS_UI_TestBase
          <div class="nav il-maincontrols">MainBar Stub</div>
          <!-- html5 main-tag is not supported in IE / div is needed -->
          <main class="il-layout-page-content">
-            <div><div class="breadcrumbs"></div>some content</div>
+            <div>some content</div>
+         </main>
+      </div>
+      <script>il.Util.addOnLoad(function() {});</script>
+   </body>
+</html>');
+        $this->assertEquals($exptected, $html);
+    }
+
+
+    public function getUIFactory() : NoUIFactory
+    {
+        return new class extends NoUIFactory {
+            public function button() : \ILIAS\UI\Component\Button\Factory
+            {
+                return new Button\Factory();
+            }
+            public function dropdown() : \ILIAS\UI\Component\Dropdown\Factory
+            {
+                return new Dropdown\Factory();
+            }
+        };
+    }
+
+    public function testRenderingWithCrumbs() : void
+    {
+        $crumbs = new Crumbs([
+            new CrumbEntry("label1", '#'),
+            new CrumbEntry("label2", '#'),
+            new CrumbEntry("label3", '#')
+        ]);
+        $r = $this->getDefaultRenderer(null, [$this->metabar, $this->mainbar, $this->logo]);
+
+        $stdpage = $this->factory->standard(
+            $this->contents,
+            $this->metabar,
+            $this->mainbar,
+            $crumbs,
+            $this->logo,
+            null,
+            $this->title
+        );
+
+        $html = $this->brutallyTrimHTML($r->render($stdpage));
+
+        $exptected = $this->brutallyTrimHTML('
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+   <head>
+      <meta charset="utf-8" />
+      <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+      <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+      <title>:</title>
+      <style></style>
+   </head>
+   <body>
+      <div class="il-layout-page">
+         <header>
+            <div class="header-inner">
+                <div class="il-logo">Logo Stub<div class="il-pagetitle">pagetitle</div></div>
+                <nav class="il-header-locator">
+                    <div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">label3<span class="caret"></span></button><ul class="dropdown-menu"><li><button class="btn btn-link" data-action="#" id="id_1">label2</button></li><li><button class="btn btn-link" data-action="#" id="id_2">label1</button></li></ul></div>
+                </nav>MetaBar Stub
+            </div>
+         </header>
+         <div class="il-system-infos"></div>
+         <div class="nav il-maincontrols">MainBar Stub</div>
+         <!-- html5 main-tag is not supported in IE / div is needed -->
+         <main class="il-layout-page-content">
+            <div>
+                <div class="breadcrumbs">
+                    <nav aria-label="breadcrumbs_aria_label" class="breadcrumb_wrapper">
+                        <div class="breadcrumb"><span class="crumb"><a href="#">label1</a></span><span class="crumb"><a href="#">label2</a></span><span class="crumb"><a href="#">label3</a></span></div>
+                    </nav>
+                </div>some content
+            </div>
          </main>
       </div>
       <script>il.Util.addOnLoad(function() {});</script>

--- a/tests/UI/Component/Layout/Page/StandardPageTest.php
+++ b/tests/UI/Component/Layout/Page/StandardPageTest.php
@@ -187,12 +187,11 @@ class StandardPageTest extends ILIAS_UI_TestBase
             <div class="header-inner">
                <div class="il-logo">Logo Stub<div class="il-pagetitle">Title</div></div>MetaBar Stub</div>
          </header>
-         <div class="breadcrumbs"></div>
          <div class="il-system-infos"></div>
          <div class="nav il-maincontrols">MainBar Stub</div>
          <!-- html5 main-tag is not supported in IE / div is needed -->
          <main class="il-layout-page-content">
-            <div>some content</div>
+            <div><div class="breadcrumbs"></div>some content</div>
          </main>
       </div>
       <script>il.Util.addOnLoad(function() {});</script>
@@ -224,12 +223,12 @@ class StandardPageTest extends ILIAS_UI_TestBase
             <div class="header-inner">
                <div class="il-logo">Logo Stub<div class="il-pagetitle">pagetitle</div></div>MetaBar Stub</div>
          </header>
-         <div class="breadcrumbs"></div>
+         
          <div class="il-system-infos"></div>
          <div class="nav il-maincontrols">MainBar Stub</div>
          <!-- html5 main-tag is not supported in IE / div is needed -->
          <main class="il-layout-page-content">
-            <div>some content</div>
+            <div><div class="breadcrumbs"></div>some content</div>
          </main>
       </div>
       <script>il.Util.addOnLoad(function() {});</script>


### PR DESCRIPTION
This moves the breadcrumbs into the content-space of the main template.
Results look like this:
![Screenshot from 2022-01-14 11-55-30](https://user-images.githubusercontent.com/3328364/149509106-5d322b1c-b32f-47fc-8f68-a3572cdadd26.png)
![Screenshot from 2022-01-14 11-56-07](https://user-images.githubusercontent.com/3328364/149509114-08cf1da7-1011-42db-b1e1-863ba5299f6b.png)

