### PR TITLE
Bugfix 31767: Contrast Issue: Dropdown in Who-is-Online Tool

### DIFF
--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -17732,7 +17732,7 @@ body.ilPrtfPdfBody .ilPCMyCoursesToggle img {
   font-size: 12px;
 }
 #awareness-content .dropdown-menu a {
-  color: #7c7c7c;
+  color: #161616;
 }
 #awareness-content .dropdown-menu a:hover {
   color: #000000;

--- a/templates/default/less/Services/Awareness/delos.less
+++ b/templates/default/less/Services/Awareness/delos.less
@@ -108,7 +108,7 @@
 }
 
 #awareness-content .dropdown-menu a {
-	color: @il-text-light-color;
+	color: @il-text-color;
 }
 
 #awareness-content .dropdown-menu a:hover {


### PR DESCRIPTION
Hi @ALL,

the PR fixes some contrast issues in the Who-is-Online-tool. To increase the contrast in the dropdowns in the WIO tool, text color was adjusted. The less variable @il-text-color is now used here. 

0031767: Contrast Issue: Dropdown in Who-is-Online Tool - https://mantis.ilias.de/view.php?id=31767

Greetings,
Enrico