### PR TITLE
UI/Tree: Fix PSR-4 issue is expandable2 example

### DIFF
--- a/src/UI/examples/Tree/Expandable/expandable2.php
+++ b/src/UI/examples/Tree/Expandable/expandable2.php
@@ -2,43 +2,38 @@
 
 namespace ILIAS\UI\examples\Tree\Expandable;
 
-class DataNode
-{
-    /**
-     * @var string
-     */
-    protected $label = "";
-
-    /**
-     * @var array
-     */
-    protected $children = [];
-
-    public function __construct(string $label, array $children = [])
-    {
-        $this->label = $label;
-        $this->children = $children;
-    }
-    public function getLabel()
-    {
-        return $this->label;
-    }
-    public function getChildren()
-    {
-        return $this->children;
-    }
-}
-
-function expandable2()
+function expandable2() : string
 {
     global $DIC;
     $f = $DIC->ui()->factory();
     $renderer = $DIC->ui()->renderer();
 
+    $getDataNode = function (string $label, array $children = []) {
+        return new class($label, $children) {
+            protected string $label = '';
+            protected array$children = [];
 
-    $n11 = new DataNode('1.1');
-    $n12 = new DataNode('1.2', array(new DataNode('1.2.1')));
-    $n1 = new DataNode('1', [$n11, $n12]);
+            public function __construct(string $label, array $children = [])
+            {
+                $this->label = $label;
+                $this->children = $children;
+            }
+
+            public function getLabel() : string
+            {
+                return $this->label;
+            }
+
+            public function getChildren() : array
+            {
+                return $this->children;
+            }
+        };
+    };
+
+    $n11 = $getDataNode('1.1');
+    $n12 = $getDataNode('1.2', [$getDataNode('1.2.1')]);
+    $n1 = $getDataNode('1', [$n11, $n12]);
     $data = [$n1];
 
     $recursion = new class implements \ILIAS\UI\Component\Tree\TreeRecursion {


### PR DESCRIPTION
This commit fixes a PSR-4 issue reported when the autoloader files are build by composer.
Instead of using a class definition, a factory function is introduced to retrieve anonymous classes (equivalent to the former `DataNode`).

`Class ILIAS\UI\examples\Tree\Expandable\DataNode located in ./src/UI/examples/Tree/Expandable/expandable2.php does not comply with psr-4 autoloading standard. Skipping.`