### PR TITLE
Setup: move dbupdate_3560 to objectives

### DIFF
--- a/Services/AccessControl/classes/Setup/class.ilAccessCustomRBACOperationAddedObjective.php
+++ b/Services/AccessControl/classes/Setup/class.ilAccessCustomRBACOperationAddedObjective.php
@@ -1,0 +1,171 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 2021 - Daniel Weise <daniel.weise@concepts-and-training.de> - Extended GPL, see LICENSE */
+
+use ILIAS\Setup;
+use ILIAS\Setup\Environment;
+use ILIAS\DI;
+
+class ilAccessCustomRBACOperationAddedObjective implements Setup\Objective
+{
+    protected string $id;
+    protected string $title;
+    protected string $class;
+    protected int $pos;
+    protected array $types;
+
+    public function __construct(string $id, string $title, string $class, int $pos, array $types = [])
+    {
+        $this->id = $id;
+        $this->title = $title;
+        $this->class = $class;
+        $this->pos = $pos;
+        $this->types = $types;
+    }
+
+    public function getHash() : string
+    {
+        return hash("sha256", self::class);
+    }
+
+    public function getLabel() : string
+    {
+        $types = implode(",", $this->types);
+        return "Add custom rbac operation (id=$this->id;title=$this->title;class=$this->class;pos=$this->pos;types=($types))";
+    }
+
+    public function isNotable() : bool
+    {
+        return true;
+    }
+
+    public function getPreconditions(Environment $environment) : array
+    {
+        return [
+            new ilDatabaseInitializedObjective()
+        ];
+    }
+
+    public function achieve(Environment $environment) : Environment
+    {
+        $db = $environment->getResource(Environment::RESOURCE_DATABASE);
+
+        $dic = $this->initEnvironment($environment);
+
+        if ($this->class == "create") {
+            $this->pos = 9999;
+        }
+
+        $ops_id = ilRbacReview::_getCustomRBACOperationId($this->id);
+        if (is_null($ops_id)) {
+            $ops_id = $db->nextId("rbac_operations");
+
+            $values = [
+                'ops_id' => ['integer', $ops_id],
+                'operation' => ['text', $this->id],
+                'description' => ['text', $this->title],
+                'class' => ['text', $this->class],
+                'op_order' => ['integer', $this->pos]
+            ];
+
+            $db->insert("rbac_operations", $values);
+        }
+
+        foreach ($this->types as $type) {
+            $type_id = ilObject::_getObjectTypeIdByTitle($type);
+            if (!$type_id) {
+                $type_id = $db->nextId('object_data');
+
+                $fields = [
+                    'obj_id' => ['integer', $type_id],
+                    'type' => ['text', 'typ'],
+                    'title' => ['text', $type],
+                    'description' => ['text', $this->title],
+                    'owner' => ['integer', -1],
+                    'create_date' => ['timestamp', $db->now()],
+                    'last_update' => ['timestamp', $db->now()]
+                ];
+                $db->insert('object_data', $fields);
+            }
+
+            $sql =
+                "SELECT typ_id, ops_id " . PHP_EOL
+                . "FROM rbac_ta" . PHP_EOL
+                . "WHERE typ_id = " . $db->quote($type_id, "integer") . PHP_EOL
+                . "AND ops_id = " . $db->quote($ops_id, 'integer') . PHP_EOL
+            ;
+
+            $result = $db->query($sql);
+            if ($db->numRows($result)) {
+                continue;
+            }
+
+            $values = [
+                "typ_id" => ["integer", $type_id],
+                "ops_id" => ["integer", $ops_id]
+            ];
+
+            $db->insert("rbac_ta", $values);
+        }
+
+        $GLOBALS["DIC"] = $dic;
+        return $environment;
+    }
+
+    public function isApplicable(Environment $environment) : bool
+    {
+        $db = $environment->getResource(Environment::RESOURCE_DATABASE);
+
+        $dic = $this->initEnvironment($environment);
+
+        $ops_id = ilRbacReview::_getCustomRBACOperationId($this->id);
+        if (!$ops_id) {
+            return true;
+        }
+
+        foreach ($this->types as $key => $type) {
+            $type_id = ilObject::_getObjectTypeIdByTitle($type);
+            if (is_null($type_id)) {
+                return true;
+            }
+
+            $sql =
+                "SELECT typ_id, ops_id " . PHP_EOL
+                . "FROM rbac_ta" . PHP_EOL
+                . "WHERE typ_id = " . $db->quote($type_id, "integer") . PHP_EOL
+                . "AND ops_id = " . $db->quote($ops_id, 'integer') . PHP_EOL
+            ;
+
+            $result = $db->query($sql);
+            if ($db->numRows($result)) {
+                unset($this->types[$key]);
+            }
+        }
+
+        $GLOBALS["DIC"] = $dic;
+
+        return count($this->types) && in_array($this->class, ['create', 'object', 'general']);
+    }
+
+    protected function initEnvironment(Setup\Environment $environment)
+    {
+        $db = $environment->getResource(Setup\Environment::RESOURCE_DATABASE);
+
+        // ATTENTION: This is a total abomination. It only exists to allow various
+        // subcomponents of the various readers to run. This is a memento to the
+        // fact, that dependency injection is something we want. Currently, every
+        // component could just service locate the whole world via the global $DIC.
+        $DIC = [];
+        if (isset($GLOBALS["DIC"])) {
+            $DIC = $GLOBALS["DIC"];
+        }
+        $GLOBALS["DIC"] = new DI\Container();
+        $GLOBALS["DIC"]["ilDB"] = $db;
+
+        if (!defined("ILIAS_ABSOLUTE_PATH")) {
+            define("ILIAS_ABSOLUTE_PATH", dirname(__FILE__, 5));
+        }
+
+        return $DIC;
+    }
+}

--- a/Services/AccessControl/classes/Setup/class.ilAccessInitialPermissionGuidelineAppliedObjective.php
+++ b/Services/AccessControl/classes/Setup/class.ilAccessInitialPermissionGuidelineAppliedObjective.php
@@ -1,0 +1,263 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 2021 - Daniel Weise <daniel.weise@concepts-and-training.de> - Extended GPL, see LICENSE */
+
+use ILIAS\Setup;
+use ILIAS\Setup\Environment;
+
+class ilAccessInitialPermissionGuidelineAppliedObjective implements Setup\Objective
+{
+    protected const RBAC_OP_EDIT_PERMISSIONS = 1;
+    protected const RBAC_OP_VISIBLE = 2;
+    protected const RBAC_OP_READ = 3;
+    protected const RBAC_OP_WRITE = 4;
+    protected const RBAC_OP_DELETE = 6;
+    protected const RBAC_OP_COPY = 99;
+
+    protected array $initial_permission_definition = [
+        'role' => [
+            'User' => [
+                'id' => 4,
+                'ignore_for_authoring_objects' => true,
+                'object' => [
+                    self::RBAC_OP_VISIBLE,
+                    self::RBAC_OP_READ,
+                ]
+            ]
+        ],
+        'rolt' => [
+            'il_crs_admin' => [
+                'object' => [
+                    self::RBAC_OP_VISIBLE,
+                    self::RBAC_OP_READ,
+                    self::RBAC_OP_WRITE,
+                    self::RBAC_OP_DELETE,
+                    self::RBAC_OP_COPY,
+                    self::RBAC_OP_EDIT_PERMISSIONS,
+                ],
+                'lp' => true,
+                'create' => [
+                    'crs',
+                    'grp',
+                    'fold',
+                ]
+            ],
+            'il_crs_tutor' => [
+                'object' => [
+                    self::RBAC_OP_VISIBLE,
+                    self::RBAC_OP_READ,
+                    self::RBAC_OP_WRITE,
+                    self::RBAC_OP_COPY,
+                ],
+                'create' => [
+                    'crs',
+                    'fold',
+                ]
+            ],
+            'il_crs_member' => [
+                'ignore_for_authoring_objects' => true,
+                'object' => [
+                    self::RBAC_OP_VISIBLE,
+                    self::RBAC_OP_READ,
+                ]
+            ],
+            'il_grp_admin' => [
+                'object' => [
+                    self::RBAC_OP_VISIBLE,
+                    self::RBAC_OP_READ,
+                    self::RBAC_OP_WRITE,
+                    self::RBAC_OP_DELETE,
+                    self::RBAC_OP_COPY,
+                    self::RBAC_OP_EDIT_PERMISSIONS,
+                ],
+                'lp' => true,
+                'create' => [
+                    'grp',
+                    'fold',
+                ]
+            ],
+            'il_grp_member' => [
+                'ignore_for_authoring_objects' => true,
+                'object' => [
+                    self::RBAC_OP_VISIBLE,
+                    self::RBAC_OP_READ,
+                ]
+            ],
+            'Author' => [
+                'object' => [
+                    self::RBAC_OP_VISIBLE,
+                    self::RBAC_OP_READ,
+                    self::RBAC_OP_WRITE,
+                    self::RBAC_OP_DELETE,
+                    self::RBAC_OP_COPY,
+                    self::RBAC_OP_EDIT_PERMISSIONS,
+                ],
+                'lp' => true,
+                'create' => [
+                    'cat',
+                    'crs',
+                    'grp',
+                    'fold',
+                ]
+            ],
+            'Local Administrator' => [
+                'object' => [
+                    self::RBAC_OP_VISIBLE,
+                    self::RBAC_OP_DELETE,
+                    self::RBAC_OP_EDIT_PERMISSIONS,
+                ],
+                'create' => [
+                    'cat',
+                ]
+            ],
+        ]
+    ];
+
+    protected string $object_type;
+    protected bool $has_learning_progress;
+    protected bool $used_for_authoring;
+
+    public function __construct(
+        string $object_type,
+        bool $has_learning_progress = false,
+        bool $used_for_authoring = false
+    ) {
+        $this->object_type = $object_type;
+        $this->has_learning_progress = $has_learning_progress;
+        $this->used_for_authoring = $used_for_authoring;
+    }
+
+    public function getHash() : string
+    {
+        return hash("sha256", self::class);
+    }
+
+    public function getLabel() : string
+    {
+        return "Apply initial permission guideline";
+    }
+
+    public function isNotable() : bool
+    {
+        return true;
+    }
+
+    public function getPreconditions(Environment $environment) : array
+    {
+        return [
+            new ilIniFilesLoadedObjective(),
+            new ilDatabaseInitializedObjective()
+        ];
+    }
+
+    public function achieve(Environment $environment) : Environment
+    {
+        $client_ini = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_INI);
+        $db = $environment->getResource(Environment::RESOURCE_DATABASE);
+
+        $role_folder_id = (int) $client_ini->readVariable("system", "ROLE_FOLDER_ID");
+
+        $learning_progress_permissions = [];
+        if ($this->has_learning_progress) {
+            $learning_progress_permissions = array_filter(
+                ilRbacReview::_getOperationIdsByName("read_learning_progress"),
+                ilRbacReview::_getCustomRBACOperationId("edit_learning_progress")
+            );
+        }
+
+        foreach ($this->initial_permission_definition as $role_type => $roles) {
+            foreach ($roles as $role_title => $definition) {
+                if (
+                    $this->used_for_authoring &&
+                    array_key_exists('ignore_for_authoring_objects', $definition) &&
+                    $definition['ignore_for_authoring_objects']
+                ) {
+                    continue;
+                }
+
+                if (array_key_exists('id', $definition) && is_numeric($definition['id'])) {
+                    // According to JF (2018-07-02), some roles have to be selected by if, not by title
+                    $query = "SELECT obj_id FROM object_data WHERE type = %s AND obj_id = %s";
+                    $query_types = ['text', 'integer'];
+                    $query_values = [$role_type, $definition['id']];
+                } else {
+                    $query = "SELECT obj_id FROM object_data WHERE type = %s AND title = %s";
+                    $query_types = ['text', 'text'];
+                    $query_values = [$role_type, $role_title];
+                }
+
+                $res = $db->queryF($query, $query_types, $query_values);
+                if (1 == $db->numRows($res)) {
+                    $row = $db->fetchAssoc($res);
+                    $role_id = (int) $row['obj_id'];
+
+                    $operation_ids = [];
+
+                    if (array_key_exists('object', $definition) && is_array($definition['object'])) {
+                        $operation_ids = array_merge($operation_ids, $definition['object']);
+                    }
+
+                    if (array_key_exists('lp', $definition) && $definition['lp']) {
+                        $operation_ids = array_merge($operation_ids, $learning_progress_permissions);
+                    }
+
+                    foreach (array_filter(array_map('intval', $operation_ids)) as $ops_id) {
+                        if ($ops_id == self::RBAC_OP_COPY) {
+                            $ops_id = ilRbacReview::_getCustomRBACOperationId('copy');
+                        }
+
+                        $db->replace(
+                            'rbac_templates',
+                            [
+                                'rol_id' => ['integer', $role_id],
+                                'type' => ['text', $this->object_type],
+                                'ops_id' => ['integer', $ops_id],
+                                'parent' => ['integer', $role_folder_id]
+                            ],
+                            []
+                        );
+                    }
+
+                    if (array_key_exists('create', $definition) && is_array($definition['create'])) {
+                        foreach ($definition['create'] as $container_object_type) {
+                            foreach (ilRbacReview::_getCustomRBACOperationId("create_" . $this->object_type) as $ops_id) {
+                                if ($ops_id == self::RBAC_OP_COPY) {
+                                    $ops_id = ilRbacReview::_getCustomRBACOperationId('copy');
+                                }
+
+                                $db->replace(
+                                    'rbac_templates',
+                                    [
+                                        'rol_id' => ['integer', $role_id],
+                                        'type' => ['text', $container_object_type],
+                                        'ops_id' => ['integer', $ops_id],
+                                        'parent' => ['integer', $role_folder_id]
+                                    ],
+                                    []
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+
+        return $environment;
+    }
+
+    public function isApplicable(Environment $environment) : bool
+    {
+        if (!ilObject::_getObjectTypeIdByTitle($this->object_type)) {
+            throw new Exception("Something went wrong, there MUST be valid id for object_type " . $this->object_type);
+        }
+
+        if (!ilRbacReview::_getCustomRBACOperationId("create_" . $this->object_type)) {
+            throw new Exception(
+                "Something went wrong, missing CREATE operation id for object type " . $this->object_type
+            );
+        }
+
+        return true;
+    }
+}

--- a/Services/AccessControl/classes/Setup/class.ilAccessRBACOperationClonedObjective.php
+++ b/Services/AccessControl/classes/Setup/class.ilAccessRBACOperationClonedObjective.php
@@ -1,0 +1,110 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 2021 - Daniel Weise <daniel.weise@concepts-and-training.de> - Extended GPL, see LICENSE */
+
+use ILIAS\Setup;
+use ILIAS\Setup\Environment;
+
+class ilAccessRBACOperationClonedObjective implements Setup\Objective
+{
+    protected string $type;
+    protected int $src_id;
+    protected int $dest_id;
+
+    public function __construct(string $type, int $src_id, int $dest_id)
+    {
+        $this->type = $type;
+        $this->src_id = $src_id;
+        $this->dest_id = $dest_id;
+    }
+
+    public function getHash() : string
+    {
+        return hash("sha256", self::class);
+    }
+
+    public function getLabel() : string
+    {
+        return "Clone rbac operation from $this->src_id to $this->dest_id";
+    }
+
+    public function isNotable() : bool
+    {
+        return true;
+    }
+
+    public function getPreconditions(Environment $environment) : array
+    {
+        return [
+            new ilDatabaseInitializedObjective()
+        ];
+    }
+
+    public function achieve(Environment $environment) : Environment
+    {
+        $db = $environment->getResource(Environment::RESOURCE_DATABASE);
+
+        $sql =
+            "SELECT rpa.rol_id, rpa.ops_id, rpa.ref_id" . PHP_EOL
+            ."FROM rbac_pa rpa" . PHP_EOL
+            ."JOIN object_reference ref ON (ref.ref_id = rpa.ref_id)" . PHP_EOL
+            ."JOIN object_data od ON (od.obj_id = ref.obj_id AND od.type = " . $db->quote($this->type, "text") . ")" . PHP_EOL
+            ."WHERE (" . $db->like("ops_id", "text", "%i:" . $this->src_id . "%") . PHP_EOL
+            ."OR " . $db->like("ops_id", "text", "%:\"" . $this->src_id . "\";%") . ")" . PHP_EOL
+        ;
+
+        while ($row = $db->fetchAssoc($db->query($sql))) {
+            $ops = unserialize($row["ops_id"]);
+            // the query above could match by array KEY, we need extra checks
+            if (in_array($this->src_id, $ops) && !in_array($this->dest_id, $ops)) {
+                $ops[] = $this->dest_id;
+
+                $sql =
+                    "UPDATE rbac_pa" . PHP_EOL
+                    ."SET ops_id = " . $db->quote(serialize($ops), "text") . PHP_EOL
+                    ."WHERE rol_id = " . $db->quote($row["rol_id"], "integer") . PHP_EOL
+                    ."AND ref_id = " . $db->quote($row["ref_id"], "integer") . PHP_EOL
+                ;
+
+                $db->manipulate($sql);
+            }
+        }
+
+        // rbac_templates
+        $tmp = array();
+        $sql =
+            "SELECT rol_id, parent, ops_id" . PHP_EOL
+            ."FROM rbac_templates" . PHP_EOL
+            ."WHERE type = " . $db->quote($this->type, "text") . PHP_EOL
+            ."AND (ops_id = " . $db->quote($this->src_id, "integer") . PHP_EOL
+            ."OR ops_id = " . $db->quote($this->dest_id, "integer") . ")" . PHP_EOL
+        ;
+
+        while ($row = $db->fetchAssoc($db->query($sql))) {
+            $tmp[$row["rol_id"]][$row["parent"]][] = $row["ops_id"];
+        }
+
+        foreach ($tmp as $role_id => $parents) {
+            foreach ($parents as $parent_id => $ops_ids) {
+                // only if the target op is missing
+                if (sizeof($ops_ids) < 2 && in_array($this->src_id, $ops_ids)) {
+                    $values = [
+                        "rol_id" => ["integer", $role_id],
+                        "type" => ["text", $this->type],
+                        "ops_id" => ["integer", $this->dest_id],
+                        "parent" => ["integer", $parent_id]
+                    ];
+
+                    $db->insert("rbac_templates", $values);
+                }
+            }
+        }
+
+        return $environment;
+    }
+
+    public function isApplicable(Environment $environment) : bool
+    {
+        return true;
+    }
+}

--- a/Services/AccessControl/classes/Setup/class.ilAccessRBACOperationDeletedObjective.php
+++ b/Services/AccessControl/classes/Setup/class.ilAccessRBACOperationDeletedObjective.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 2021 - Daniel Weise <daniel.weise@concepts-and-training.de> - Extended GPL, see LICENSE */
+
+use ILIAS\Setup;
+use ILIAS\Setup\Environment;
+
+class ilAccessRBACOperationDeletedObjective implements Setup\Objective
+{
+    protected string $type;
+    protected int $ops_id;
+
+    public function __construct(string $type, int $ops_id)
+    {
+        $this->type = $type;
+        $this->ops_id = $ops_id;
+    }
+
+    public function getHash() : string
+    {
+        return hash("sha256", self::class);
+    }
+
+    public function getLabel() : string
+    {
+        return "Delete rbac operation and rbac template for type $this->type and id $this->ops_id";
+    }
+
+    public function isNotable() : bool
+    {
+        return true;
+    }
+
+    public function getPreconditions(Environment $environment) : array
+    {
+        return [
+            new ilDatabaseInitializedObjective()
+        ];
+    }
+
+    public function achieve(Environment $environment) : Environment
+    {
+        $db = $environment->getResource(Environment::RESOURCE_DATABASE);
+
+        $type_id = ilObject::_getObjectTypeIdByTitle($this->type);
+
+        $sql =
+            "DELETE FROM rbac_ta" . PHP_EOL
+            ."WHERE typ_id = " . $db->quote($type_id, "integer") . PHP_EOL
+            ."AND ops_id = " . $db->quote($this->ops_id, "integer") . PHP_EOL
+        ;
+
+        $db->manipulate($sql);
+
+        $sql =
+            "DELETE FROM rbac_templates" . PHP_EOL
+            ."WHERE type = " . $db->quote($this->type, "text") . PHP_EOL
+            ."ops_id = " . $db->quote($this->ops_id, "integer") . PHP_EOL
+        ;
+
+        $db->manipulate($sql);
+
+        return $environment;
+    }
+
+    public function isApplicable(Environment $environment) : bool
+    {
+        return true;
+    }
+}

--- a/Services/AccessControl/classes/Setup/class.ilAccessRBACOperationOrderUpdatedObjective.php
+++ b/Services/AccessControl/classes/Setup/class.ilAccessRBACOperationOrderUpdatedObjective.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 2021 - Daniel Weise <daniel.weise@concepts-and-training.de> - Extended GPL, see LICENSE */
+
+use ILIAS\Setup;
+use ILIAS\Setup\Environment;
+
+class ilAccessRBACOperationOrderUpdatedObjective implements Setup\Objective
+{
+    protected string $operation;
+    protected int $pos;
+
+    public function __construct(string $operation, int $pos)
+    {
+        $this->operation = $operation;
+        $this->pos = $pos;
+    }
+
+    public function getHash() : string
+    {
+        return hash("sha256", self::class);
+    }
+
+    public function getLabel() : string
+    {
+        return "Update operation order (operation=$this->operation;pos=$this->pos)";
+    }
+
+    public function isNotable() : bool
+    {
+        return true;
+    }
+
+    public function getPreconditions(Environment $environment) : array
+    {
+        return [
+            new ilDatabaseInitializedObjective()
+        ];
+    }
+
+    public function achieve(Environment $environment) : Environment
+    {
+        $db = $environment->getResource(Environment::RESOURCE_DATABASE);
+
+        $db->update(
+            'rbac_operations',
+            ['op_order' => ["integer", $this->pos]],
+            ["operation" => ["text", $this->operation]]
+        );
+
+        return $environment;
+    }
+
+    public function isApplicable(Environment $environment) : bool
+    {
+        $db = $environment->getResource(Environment::RESOURCE_DATABASE);
+
+        $sql =
+            "SELECT ops_id" . PHP_EOL
+            ."FROM rbac_operations" . PHP_EOL
+            ."WHERE operation = " . $db->quote($this->operation, "text") . PHP_EOL
+        ;
+
+        return $db->numRows($db->query($sql)) == 1;
+    }
+}

--- a/Services/AccessControl/classes/Setup/class.ilAccessRBACOperationsAddedObjective.php
+++ b/Services/AccessControl/classes/Setup/class.ilAccessRBACOperationsAddedObjective.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 2021 - Daniel Weise <daniel.weise@concepts-and-training.de> - Extended GPL, see LICENSE */
+
+use ILIAS\Setup;
+use ILIAS\Setup\Environment;
+
+class ilAccessRbacOperationsAddedObjective implements Setup\Objective
+{
+    protected const RBAC_OP_EDIT_PERMISSIONS = 1;
+    protected const RBAC_OP_VISIBLE = 2;
+    protected const RBAC_OP_READ = 3;
+    protected const RBAC_OP_WRITE = 4;
+    protected const RBAC_OP_DELETE = 6;
+    protected const RBAC_OP_COPY = 99;
+
+    protected array $valid_operations = [
+        self::RBAC_OP_EDIT_PERMISSIONS,
+        self::RBAC_OP_VISIBLE,
+        self::RBAC_OP_READ,
+        self::RBAC_OP_WRITE,
+        self::RBAC_OP_DELETE,
+        self::RBAC_OP_COPY
+    ];
+
+    protected int $type_id;
+    protected array $operations;
+
+    public function __construct(int $type_id, array $operations = [])
+    {
+        $this->type_id = $type_id;
+        $this->operations = $operations;
+    }
+
+    public function getHash() : string
+    {
+        return hash("sha256", self::class);
+    }
+
+    public function getLabel() : string
+    {
+        $operations = implode(",", $this->operations);
+        return "Add rbac operations (type id=$this->type_id;operations=$operations)";
+    }
+
+    public function isNotable() : bool
+    {
+        return true;
+    }
+
+    public function getPreconditions(Environment $environment) : array
+    {
+        return [
+            new ilDatabaseInitializedObjective()
+        ];
+    }
+
+    public function achieve(Environment $environment) : Environment
+    {
+        $db = $environment->getResource(Environment::RESOURCE_DATABASE);
+
+        foreach ($this->operations as $ops_id) {
+            if (!$this->isValidRbacOperation($ops_id)) {
+                continue;
+            }
+
+            if ($ops_id == self::RBAC_OP_COPY) {
+                $ops_id = ilRbacReview::_getCustomRBACOperationId("copy");
+            }
+
+            if (ilRbacReview::_isRBACOperation($this->type_id, $ops_id)) {
+                continue;
+            }
+
+            $values = [
+                "typ_id" => ["integer", $this->type_id],
+                "ops_id" => ["integer", $ops_id]
+            ];
+
+            $db->insert("rbac_ta", $values);
+        }
+
+        return $environment;
+    }
+
+    public function isApplicable(Environment $environment) : bool
+    {
+        return true;
+    }
+
+    protected function isValidRbacOperation(int $ops_id) : bool
+    {
+        return in_array($ops_id, $this->valid_operations);
+    }
+}

--- a/Services/AccessControl/classes/Setup/class.ilAccessRBACTemplateAddedObjective.php
+++ b/Services/AccessControl/classes/Setup/class.ilAccessRBACTemplateAddedObjective.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 2021 - Daniel Weise <daniel.weise@concepts-and-training.de> - Extended GPL, see LICENSE */
+
+use ILIAS\Setup;
+use ILIAS\Setup\Environment;
+
+class ilAccessRBACTemplateAddedObjective implements Setup\Objective
+{
+    protected string $type;
+    protected string $id;
+    protected string $description;
+    protected array $op_ids;
+
+    public function __construct(string $type, string $id, string $description, array $op_ids = [])
+    {
+        $this->type = $type;
+        $this->id = $id;
+        $this->description = $description;
+        $this->op_ids = $op_ids;
+    }
+
+    public function getHash() : string
+    {
+        return hash("sha256", self::class);
+    }
+
+    public function getLabel() : string
+    {
+        $op_ids = implode(",", $this->op_ids);
+        return "Add rbac template (type=$this->type;id=$this->id;description=$this->description;op_ids=$op_ids)";
+    }
+
+    public function isNotable() : bool
+    {
+        return true;
+    }
+
+    public function getPreconditions(Environment $environment) : array
+    {
+        return [
+            new ilDatabaseInitializedObjective()
+        ];
+    }
+
+    public function achieve(Environment $environment) : Environment
+    {
+        $db = $environment->getResource(Environment::RESOURCE_DATABASE);
+
+        $tpl_id = $db->nextId("object_data");
+        $values = [
+            "obj_id" => ["integer", $tpl_id],
+            "type" => ["text", "rolt"],
+            "title" => ["text", $this->id],
+            "description" => ["text", $this->description],
+            "owner" => ["integer", -1],
+            "create_date" => ["timestamp", date("Y-m-d H:i:s")],
+            "last_update" => ["timestamp", date("Y-m-d H:i:s")]
+        ];
+        $db->insert("object_data", $values);
+
+        $values = [
+            "rol_id" => ["integer", $tpl_id],
+            "parent" => ["integer", 8],
+            "assign" => ["text", "n"],
+            "protected" => ["text", "n"]
+        ];
+        $db->insert("rbac_fa", $values);
+
+        foreach ($this->op_ids as $op_id) {
+            $values = [
+                "rol_id" => ["integer", $tpl_id],
+                "type" => ["text", $this->type],
+                "ops_id" => ["integer", $op_id],
+                "parent" => ["integer", 8]
+            ];
+            $db->insert("rbac_templates", $values);
+        }
+
+        return $environment;
+    }
+
+    public function isApplicable(Environment $environment) : bool
+    {
+        return (bool) count($this->op_ids);
+    }
+}

--- a/Services/AccessControl/classes/Setup/class.ilAccessRolePermissionSetObjective.php
+++ b/Services/AccessControl/classes/Setup/class.ilAccessRolePermissionSetObjective.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 2021 - Daniel Weise <daniel.weise@concepts-and-training.de> - Extended GPL, see LICENSE */
+
+use ILIAS\Setup;
+use ILIAS\Setup\Environment;
+
+class ilAccessRolePermissionSetObjective implements Setup\Objective
+{
+    protected const RBAC_OP_COPY = 99;
+
+    protected int $role_id;
+    protected string $type;
+    protected array $ops;
+    protected int $ref_id;
+
+    public function __construct(int $role_id, string $type, array $ops, int $ref_id)
+    {
+        $this->role_id = $role_id;
+        $this->type = $type;
+        $this->ops = $ops;
+        $this->ref_id = $ref_id;
+    }
+
+    public function getHash() : string
+    {
+        return hash("sha256", self::class);
+    }
+
+    public function getLabel() : string
+    {
+        $ops = implode(",", $this->ops);
+        return "Set role permission (role id=$this->role_id;type=$this->type;ops=$ops;ref id=$this->ref_id)";
+    }
+
+    public function isNotable() : bool
+    {
+        return true;
+    }
+
+    public function getPreconditions(Environment $environment) : array
+    {
+        return [
+            new ilDatabaseInitializedObjective()
+        ];
+    }
+
+    public function achieve(Environment $environment) : Environment
+    {
+        $db = $environment->getResource(Environment::RESOURCE_DATABASE);
+
+        foreach ($this->ops as $ops_id) {
+            if ($ops_id == self::RBAC_OP_COPY) {
+                $ops_id = ilRbacReview::_getCustomRBACOperationId('copy');
+            }
+
+            $db->replace(
+                'rbac_templates',
+                [
+                    'rol_id' => ['integer', $this->role_id],
+                    'type' => ['text', $this->type],
+                    'ops_id' => ['integer', $ops_id],
+                    'parent' => ['integer', $this->ref_id]
+                ],
+                []
+            );
+        }
+
+        return $environment;
+    }
+
+    public function isApplicable(Environment $environment) : bool
+    {
+        return true;
+    }
+}

--- a/Services/AccessControl/classes/class.ilRbacReview.php
+++ b/Services/AccessControl/classes/class.ilRbacReview.php
@@ -1320,4 +1320,39 @@ class ilRbacReview
         self::$is_assigned_cache = array();
         self::$assigned_users_cache = array();
     }
+
+    public static function _getCustomRBACOperationId(string $operation) : ?int
+    {
+        global $DIC;
+        $ilDB = $DIC['ilDB'];
+
+        $sql =
+            "SELECT ops_id" . PHP_EOL
+            ."FROM rbac_operations" . PHP_EOL
+            ."WHERE operation = " . $ilDB->quote($operation, "text") . PHP_EOL
+        ;
+
+        $res = $ilDB->query($sql);
+        if ($ilDB->numRows($res) == 0) {
+            return null;
+        }
+
+        $row = $ilDB->fetchAssoc($res);
+        return (int) $row["ops_id"] ?? null;
+    }
+
+    public static function _isRBACOperation(int $type_id, int $ops_id) : bool
+    {
+        global $DIC;
+        $ilDB = $DIC['ilDB'];
+
+        $sql =
+            "SELECT typ_id" . PHP_EOL
+            ."FROM rbac_ta" . PHP_EOL
+            ."WHERE typ_id = " . $ilDB->quote($type_id, "integer") . PHP_EOL
+            ."AND ops_id = " . $ilDB->quote($ops_id, "integer") . PHP_EOL
+        ;
+
+        return (bool) $ilDB->numRows($ilDB->query($sql));
+    }
 } // END class.ilRbacReview

--- a/Services/Migration/DBUpdate_3560/classes/class.ilDBUpdateNewObjectType.php
+++ b/Services/Migration/DBUpdate_3560/classes/class.ilDBUpdateNewObjectType.php
@@ -124,6 +124,7 @@ class ilDBUpdateNewObjectType
      * @param string $a_type_id
      * @param string $a_type_title
      * @return int insert id
+     * @deprecated use Services/Object/classes/Setup/class.ilObjectNewTypeAddedObjective.php instead
      */
     public static function addNewType($a_type_id, $a_type_title)
     {
@@ -156,6 +157,7 @@ class ilDBUpdateNewObjectType
      *
      * @param int $a_type_id
      * @param array $a_operations
+     * @deprecated use Services/AccessControl/classes/Setup/class.ilAccessRBACOperationsAddedObjective.php instead
      */
     public static function addRBACOperations($a_type_id, array $a_operations)
     {
@@ -176,6 +178,7 @@ class ilDBUpdateNewObjectType
      * @param int $a_type_id
      * @param int $a_ops_id
      * @return bool
+     * @deprecated use Services/AccessControl/classes/Setup/class.ilAccessRBACOperationsAddedObjective.php instead
      */
     public static function addRBACOperation($a_type_id, $a_ops_id)
     {
@@ -203,6 +206,7 @@ class ilDBUpdateNewObjectType
      * @param int $a_type_id type id
      * @param int $a_ops_id operation id
      * @return bool
+     * @deprecated use ilRbacReview::_isRBACOperation instead
      */
     public static function isRBACOperation($a_type_id, $a_ops_id)
     {
@@ -223,6 +227,7 @@ class ilDBUpdateNewObjectType
      *
      * @param int $a_type
      * @param int $a_ops_id
+     * @deprecated use Services/AccessControl/classes/Setup/class.ilAccessRBACOperationDeletedObjective.php instead
      */
     public static function deleteRBACOperation($a_type, $a_ops_id)
     {
@@ -251,6 +256,7 @@ class ilDBUpdateNewObjectType
      *
      * @param string $a_type
      * @param int $a_ops_id
+     * @deprecated use Services/AccessControl/classes/Setup/class.ilAccessRBACOperationDeletedObjective.php instead
      */
     public static function deleteRBACTemplateOperation($a_type, $a_ops_id)
     {
@@ -272,6 +278,7 @@ class ilDBUpdateNewObjectType
      *
      * @param int $a_ops_id
      * @return bool
+     * @deprecated
      */
     protected static function isValidRBACOperation($a_ops_id)
     {
@@ -294,6 +301,7 @@ class ilDBUpdateNewObjectType
      *
      * @param string $a_operation
      * @return int
+     * @deprecated use ilRbacReview::_getCustomRBACOperationId instead
      */
     public static function getCustomRBACOperationId($a_operation)
     {
@@ -315,6 +323,7 @@ class ilDBUpdateNewObjectType
      * @param string $a_class
      * @param string $a_pos
      * @return int ops_id
+     * @deprecated use Services/AccessControl/classes/Setup/class.ilAccessCustomRBACOperationAddedObjective.php instead
      */
     public static function addCustomRBACOperation($a_id, $a_title, $a_class, $a_pos)
     {
@@ -352,6 +361,7 @@ class ilDBUpdateNewObjectType
      *
      * @param string $a_type
      * @return int
+     * @deprecated use ilObject::_getObjectTypeIdByTitle() instead
      */
     public static function getObjectTypeId($a_type)
     {
@@ -371,6 +381,8 @@ class ilDBUpdateNewObjectType
      * @param string  $a_id
      * @param string $a_title
      * @param array $a_parent_types
+     * @deprecated use Services/AccessControl/classes/Setup/class.ilAccessCustomRBACOperationAddedObjective.php instead
+     *             use 'create' for class param
      */
     public static function addRBACCreate($a_id, $a_title, array $a_parent_types)
     {
@@ -389,6 +401,7 @@ class ilDBUpdateNewObjectType
      *
      * @param string $a_operation
      * @param int $a_pos
+     * @deprecated use Services/AccessControl/classes/Setup/class.ilAccessRBACOperationOrderUpdatedObjective.php instead
      */
     public static function updateOperationOrder($a_operation, $a_pos)
     {
@@ -406,6 +419,7 @@ class ilDBUpdateNewObjectType
      *
      * @param string $a_id
      * @param string $a_title
+     * @deprecated use Services/Tree/classes/Setup/class.ilTreeAdminNodeAddedObjective.php instead
      */
     public static function addAdminNode($a_obj_type, $a_title)
     {
@@ -456,6 +470,7 @@ class ilDBUpdateNewObjectType
      * @param string $a_obj_type
      * @param int $a_source_op_id
      * @param int $a_target_op_id
+     * @deprecated use Services/AccessControl/classes/Setup/class.ilAccessRBACOperationClonedObjective.php instead
      */
     public static function cloneOperation($a_obj_type, $a_source_op_id, $a_target_op_id)
     {
@@ -511,94 +526,15 @@ class ilDBUpdateNewObjectType
             }
         }
     }
-    
+
     /**
-     * Migrate varchar column to text/clob
-     *
-     * @param string $a_table_name
-     * @param string $a_column_name
-     * @return bool
+     * @param int    $a_rol_id
+     * @param string $a_type
+     * @param array  $a_ops
+     * @param int    $a_ref_id
+     * @return void
+     * @deprecated use Services/AccessControl/classes/Setup/class.ilAccessRolePermissionSetObjective.php instead
      */
-    public static function varchar2text($a_table_name, $a_column_name)
-    {
-        global $ilDB;
-        
-        $tmp_column_name = $a_column_name . "_tmp_clob";
-        
-        if (!$ilDB->tableColumnExists($a_table_name, $a_column_name) ||
-            $ilDB->tableColumnExists($a_table_name, $tmp_column_name)) {
-            return false;
-        }
-        
-        // oracle does not support ALTER TABLE varchar2 to CLOB
-
-        $ilAtomQuery = $ilDB->buildAtomQuery();
-        $ilAtomQuery->addTableLock($a_table_name);
-
-        $ilAtomQuery->addQueryCallable(
-            function (ilDBInterface $ilDB) use ($a_table_name, $a_column_name, $tmp_column_name) {
-                $def = array(
-                    'type' => 'clob',
-                    'notnull' => false
-                );
-                $ilDB->addTableColumn($a_table_name, $tmp_column_name, $def);
-
-                $ilDB->manipulate('UPDATE ' . $a_table_name . ' SET ' . $tmp_column_name . ' = ' . $a_column_name);
-
-                $ilDB->dropTableColumn($a_table_name, $a_column_name);
-
-                $ilDB->renameTableColumn($a_table_name, $tmp_column_name, $a_column_name);
-            }
-        );
-
-        $ilAtomQuery->run();
-        
-        return true;
-    }
-    
-    /**
-     * Add new RBAC template
-     *
-     * @param string $a_obj_type
-     * @param string $a_id
-     * @param string $a_description
-     * @param int|array $a_op_ids
-     */
-    public static function addRBACTemplate($a_obj_type, $a_id, $a_description, $a_op_ids)
-    {
-        global $ilDB;
-        
-        $new_tpl_id = $ilDB->nextId('object_data');
-
-        $ilDB->manipulateF(
-            "INSERT INTO object_data (obj_id, type, title, description," .
-            " owner, create_date, last_update) VALUES (%s, %s, %s, %s, %s, %s, %s)",
-            array("integer", "text", "text", "text", "integer", "timestamp", "timestamp"),
-            array($new_tpl_id, "rolt", $a_id, $a_description, -1, ilUtil::now(), ilUtil::now())
-        );
-                
-        $ilDB->manipulateF(
-            "INSERT INTO rbac_fa (rol_id, parent, assign, protected)" .
-            " VALUES (%s, %s, %s, %s)",
-            array("integer", "integer", "text", "text"),
-            array($new_tpl_id, 8, "n", "n")
-        );
-        
-        if ($a_op_ids) {
-            if (!is_array($a_op_ids)) {
-                $a_op_ids = array($a_op_ids);
-            }
-            foreach ($a_op_ids as $op_id) {
-                $ilDB->manipulateF(
-                    "INSERT INTO rbac_templates (rol_id, type, ops_id, parent)" .
-                " VALUES (%s, %s, %s, %s)",
-                    array("integer", "text", "integer", "integer"),
-                    array($new_tpl_id, $a_obj_type, $op_id, 8)
-                );
-            }
-        }
-    }
-
     public static function setRolePermission(int $a_rol_id, string $a_type, array $a_ops, int $a_ref_id)
     {
         global $DIC;
@@ -631,6 +567,7 @@ class ilDBUpdateNewObjectType
      * @param bool $hasLearningProgress A boolean flag whether or not the object type supports learning progress
      * @param bool $usedForAuthoring A boolean flag to tell whether or not the object type is mainly used for authoring
      * @see https://www.ilias.de/docu/goto_docu_wiki_wpage_2273_1357.html
+     * @deprecated use Services/AccessControl/classes/Setup/class.ilAccessInitialPermissionGuidelineAppliedObjective.php instead
      */
     public static function applyInitialPermissionGuideline(string $objectType, bool $hasLearningProgress = false, bool $usedForAuthoring = false)
     {

--- a/Services/Object/classes/Setup/class.ilObjectNewTypeAddedObjective.php
+++ b/Services/Object/classes/Setup/class.ilObjectNewTypeAddedObjective.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 2021 - Daniel Weise <daniel.weise@concepts-and-training.de> - Extended GPL, see LICENSE */
+
+use ILIAS\Setup;
+use ILIAS\Setup\Environment;
+
+class ilObjectNewTypeAddedObjective implements Setup\Objective
+{
+    protected string $type;
+    protected string $type_title;
+
+    public function __construct(string $type, string $type_title)
+    {
+        $this->type = $type;
+        $this->type_title = $type_title;
+    }
+
+    public function getHash() : string
+    {
+        return hash("sha256", self::class);
+    }
+
+    public function getLabel() : string
+    {
+        return "Add new type $this->type to object data";
+    }
+
+    public function isNotable() : bool
+    {
+        return true;
+    }
+
+    public function getPreconditions(Environment $environment) : array
+    {
+        return [
+            new ilDatabaseInitializedObjective()
+        ];
+    }
+
+    public function achieve(Environment $environment) : Environment
+    {
+        $db = $environment->getResource(Environment::RESOURCE_DATABASE);
+
+        $id = $db->nextId("object_data");
+
+        $values = [
+            'obj_id' => ['integer', $id],
+            'type' => ['text', 'typ'],
+            'title' => ['text', $this->type],
+            'description' => ['text', $this->type_title],
+            'owner' => ['integer', -1],
+            'create_date' => ['timestamp', date("Y-m-d H:i:s")],
+            'last_update' => ['timestamp', date("Y-m-d H:i:s")]
+        ];
+
+        $db->insert("object_data", $values);
+
+        return $environment;
+    }
+
+    public function isApplicable(Environment $environment) : bool
+    {
+        if (is_null(ilObject::_getObjectTypeIdByTitle($this->type))) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -2002,4 +2002,24 @@ class ilObject
     {
         return $this->obj_definition->getSubObjects($this->type, $filter);
     }
-}
+
+    public static function _getObjectTypeIdByTitle(string $type) : ?int
+    {
+        global $DIC;
+        $ilDB = $DIC->database();
+
+        $sql =
+            "SELECT obj_id FROM object_data" . PHP_EOL
+            ."WHERE type = 'typ'" . PHP_EOL
+            ."AND title = " . $ilDB->quote($type, 'text') . PHP_EOL
+        ;
+
+        $res = $ilDB->query($sql);
+        if ($ilDB->numRows($res) == 0) {
+            return null;
+        }
+
+        $row = $ilDB->fetchAssoc($res);
+        return (int) $row['obj_id'] ?? null;
+    }
+} // END class.ilObject

--- a/Services/Tree/classes/Setup/class.ilTreeAdminNodeAddedObjective.php
+++ b/Services/Tree/classes/Setup/class.ilTreeAdminNodeAddedObjective.php
@@ -1,0 +1,118 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 2021 - Daniel Weise <daniel.weise@concepts-and-training.de> - Extended GPL, see LICENSE */
+
+use ILIAS\Setup;
+use ILIAS\Setup\Environment;
+
+class ilTreeAdminNodeAddedObjective implements Setup\Objective
+{
+    protected const RBAC_OP_EDIT_PERMISSIONS = 1;
+    protected const RBAC_OP_VISIBLE = 2;
+    protected const RBAC_OP_READ = 3;
+    protected const RBAC_OP_WRITE = 4;
+
+    protected array $rbac_ops = [
+        self::RBAC_OP_EDIT_PERMISSIONS,
+        self::RBAC_OP_VISIBLE,
+        self::RBAC_OP_READ,
+        self::RBAC_OP_WRITE
+    ];
+
+    protected string $type;
+    protected string $title;
+
+    public function __construct(string $type, string $title)
+    {
+        $this->type = $type;
+        $this->title = $title;
+    }
+
+    public function getHash() : string
+    {
+        return hash("sha256", self::class);
+    }
+
+    public function getLabel() : string
+    {
+        return "Add new admin node to tree (type=$this->type;title=$this->title)";
+    }
+
+    public function isNotable() : bool
+    {
+        return true;
+    }
+
+    public function getPreconditions(Environment $environment) : array
+    {
+        return [
+            new ilIniFilesLoadedObjective(),
+            new ilDatabaseInitializedObjective()
+        ];
+    }
+
+    public function achieve(Environment $environment) : Environment
+    {
+        $client_ini = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_INI);
+        $db = $environment->getResource(Environment::RESOURCE_DATABASE);
+
+        if (!defined("ROOT_FOLDER_ID")) {
+            define("ROOT_FOLDER_ID", (int) $client_ini->readVariable("system", "ROOT_FOLDER_ID"));
+        }
+        if (!defined("SYSTEM_FOLDER_ID")) {
+            define("SYSTEM_FOLDER_ID", $client_ini->readVariable("system", "SYSTEM_FOLDER_ID"));
+        }
+
+        $obj_type_id = $db->nextId("object_data");
+        $values = [
+            'obj_id' => ['integer', $obj_type_id],
+            'type' => ['text', 'typ'],
+            'title' => ['text', $this->type],
+            'description' => ['text', $this->title],
+            'owner' => ['integer', -1],
+            'create_date' => ['timestamp', date("Y-m-d H:i:s")],
+            'last_update' => ['timestamp', date("Y-m-d H:i:s")]
+        ];
+        $db->insert("object_data", $values);
+
+        $obj_id = $db->nextId("object_data");
+        $values = [
+            'obj_id' => ['integer', $obj_id],
+            'type' => ['text', $this->type],
+            'title' => ['text', $this->title],
+            'description' => ['text', $this->title],
+            'owner' => ['integer', -1],
+            'create_date' => ['timestamp', date("Y-m-d H:i:s")],
+            'last_update' => ['timestamp', date("Y-m-d H:i:s")]
+        ];
+        $db->insert("object_data", $values);
+
+        $ref_id = $db->nextId("object_reference");
+        $values = [
+            "obj_id" => ["integer", $obj_id],
+            "ref_id" => ["integer", $ref_id]
+        ];
+        $db->insert("object_reference", $values);
+
+        $tree = new ilTree(ROOT_FOLDER_ID);
+        $tree->insertNode($ref_id, SYSTEM_FOLDER_ID);
+
+        foreach ($this->rbac_ops as $ops_id) {
+            if (ilRbacReview::_isRBACOperation($obj_type_id, $ops_id)) {
+                continue;
+            }
+            $values = [
+                "typ_id" => ["integer", $obj_type_id],
+                "ops_id" => ["integer", $ops_id]
+            ];
+            $db->insert("rbac_ta", $values);
+        }
+
+        return $environment;
+    }
+
+    public function isApplicable(Environment $environment) : bool
+    {
+        return !((bool) ilObject::_getObjectTypeIdByTitle($this->type));
+    }
+}


### PR DESCRIPTION
Hi,
we moved the migration functions of DBUpdate 3560 from ilDBUpdateNew ObjectType to Objectives. So that we can use them e.g. as a precondition in other objectives and no longer have to use them in db update steps.