### PR TITLE
ilCtrl: Don't use PHP 8.0 functions

### DIFF
--- a/Services/UICore/classes/Structure/class.ilCtrlStructureCidGenerator.php
+++ b/Services/UICore/classes/Structure/class.ilCtrlStructureCidGenerator.php
@@ -32,7 +32,7 @@ class ilCtrlStructureCidGenerator
      */
     public function getIndexByCid(string $cid) : int
     {
-        if (str_starts_with($cid, '-')) {
+        if (strpos($cid, '-') === 0) {
             $inverted_cid = str_replace('-', '', $cid);
             $index = (int) base_convert($inverted_cid, 36, 10);
 

--- a/Services/UICore/classes/class.ilCtrl.php
+++ b/Services/UICore/classes/class.ilCtrl.php
@@ -517,8 +517,8 @@ class ilCtrl implements ilCtrlInterface
     {
         // prepend the ILIAS HTTP path if it wasn't already.
         if (defined("ILIAS_HTTP_PATH") &&
-            !str_contains($target_url, "://") &&
-            !str_starts_with($target_url, "/")
+            strpos($target_url, "://") === false &&
+            strpos($target_url, "/") !== 0
         ) {
             $target_url = ILIAS_HTTP_PATH . "/" . $target_url;
         }
@@ -750,10 +750,10 @@ class ilCtrl implements ilCtrlInterface
             return false;
         }
 
-        return str_contains(
+        return strpos(
             $this->context->getPath()->getCidPath() ?? '',
             $class_cid
-        );
+        ) !== false;
     }
 
     /**
@@ -1087,7 +1087,7 @@ class ilCtrl implements ilCtrlInterface
                 // append the parameter key => value pair and prepend
                 // a question mark or ampersand, determined by whether
                 // it's the first query param or not.
-                $url .= (str_contains($url, '?')) ?
+                $url .= (strpos($url, '?') !== false) ?
                     $ampersand . $parameter_name . '=' . $value :
                     '?' . $parameter_name . '=' . $value;
             }


### PR DESCRIPTION
See: https://stitcher.io/blog/new-in-php-8#new-str_contains()-function-rfc and https://stitcher.io/blog/new-in-php-8#new-str_starts_with()-and-str_ends_with()-functions-rfc