### PR TITLE
improved submission of unchecked checkboxes.

### DIFF
--- a/src/UI/Implementation/Component/Input/Field/Checkbox.php
+++ b/src/UI/Implementation/Component/Input/Field/Checkbox.php
@@ -33,11 +33,7 @@ class Checkbox extends Input implements C\Input\Field\Checkbox, C\Changeable, C\
      */
     protected function isClientSideValueOk($value) : bool
     {
-        if ($value == "checked" || $value === "" || is_bool($value)) {
-            return true;
-        } else {
-            return false;
-        }
+        return $value === "checked" || $value === "unchecked" || is_bool($value);
     }
 
 

--- a/src/UI/Implementation/Component/Input/Field/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Field/Renderer.php
@@ -237,8 +237,9 @@ class Renderer extends AbstractComponentRenderer
         $tpl = $this->getTemplate("tpl.checkbox.html", true, true);
         $this->applyName($component, $tpl);
 
-        if ($component->getValue()) {
-            $tpl->touchBlock("value");
+        $checked = $component->getValue();
+        if (null !== $checked && false !== $checked) {
+            $tpl->touchBlock('value');
         }
 
         $this->maybeDisable($component, $tpl);

--- a/src/UI/templates/default/Input/tpl.checkbox.html
+++ b/src/UI/templates/default/Input/tpl.checkbox.html
@@ -1,1 +1,2 @@
-<input type="checkbox" id="{ID}" value="checked" <!-- BEGIN value --> checked="checked" <!-- END value --> name="{NAME}"<!-- BEGIN disabled --> {DISABLED}<!-- END disabled --> class="form-control form-control-sm" />
+<input type="hidden" id="{ID}_hidden" name="{NAME}" value="unchecked" />
+<input type="checkbox" id="{ID}" value="checked" <!-- BEGIN value -->checked="checked"<!-- END value --> name="{NAME}" {DISABLED} class="form-control form-control-sm" />

--- a/tests/UI/Component/Input/Field/CheckboxInputTest.php
+++ b/tests/UI/Component/Input/Field/CheckboxInputTest.php
@@ -60,6 +60,7 @@ class CheckboxInputTest extends ILIAS_UI_TestBase
         <div class="form-group row">
            <label for="id_1" class="control-label col-sm-3">label</label>
            <div class="col-sm-9">
+              <input type="hidden" id="id_1_hidden" name="name_0" value="unchecked"/>
               <input type="checkbox" id="id_1" value="checked" name="name_0" class="form-control form-control-sm"/>
               <div class="help-block">byline</div>
            </div>
@@ -83,6 +84,7 @@ class CheckboxInputTest extends ILIAS_UI_TestBase
            <label for="id_1" class="control-label col-sm-3">label</label>
            <div class="col-sm-9">
               <div class="help-block alert alert-danger" role="alert">an_error</div>
+              <input type="hidden" id="id_1_hidden" name="name_0" value="unchecked"/>
               <input type="checkbox" id="id_1" value="checked" name="name_0" class="form-control form-control-sm"/>
               <div class="help-block">byline</div>
            </div>
@@ -105,6 +107,7 @@ class CheckboxInputTest extends ILIAS_UI_TestBase
         <div class="form-group row">
            <label for="id_1" class="control-label col-sm-3">label</label>
            <div class="col-sm-9">
+           <input type="hidden" id="id_1_hidden" name="name_0" value="unchecked"/>
               <input type="checkbox" id="id_1" value="checked" name="name_0" class="form-control form-control-sm" />
            </div>
         </div>
@@ -125,6 +128,7 @@ class CheckboxInputTest extends ILIAS_UI_TestBase
             <div class="form-group row">
                <label for="id_1" class="control-label col-sm-3">label</label>
                <div class="col-sm-9">
+                  <input type="hidden" id="id_1_hidden" name="name_0" value="unchecked"/>
                   <input type="checkbox" id="id_1" value="checked" checked="checked" name="name_0" class="form-control form-control-sm" />
                </div>
             </div>
@@ -157,7 +161,10 @@ class CheckboxInputTest extends ILIAS_UI_TestBase
         $expected = $this->brutallyTrimHTML('
         <div class="form-group row">
            <label for="id_1" class="control-label col-sm-3">label<span class="asterisk">*</span></label>
-           <div class="col-sm-9"><input type="checkbox" id="id_1" value="checked" name="name_0" class="form-control form-control-sm"/></div>
+           <div class="col-sm-9">
+               <input type="hidden" id="id_1_hidden" name="name_0" value="unchecked"/>
+               <input type="checkbox" id="id_1" value="checked" name="name_0" class="form-control form-control-sm"/>
+           </div>
         </div>
         ');
 
@@ -176,7 +183,10 @@ class CheckboxInputTest extends ILIAS_UI_TestBase
         $expected = $this->brutallyTrimHTML('
             <div class="form-group row">
                <label for="id_1" class="control-label col-sm-3">label</label>
-               <div class="col-sm-9"><input type="checkbox" id="id_1" value="checked" name="name_0" disabled="disabled" class="form-control form-control-sm"/></div>
+               <div class="col-sm-9">
+                   <input type="hidden" id="id_1_hidden" name="name_0" value="unchecked"/>
+                   <input type="checkbox" id="id_1" value="checked" name="name_0" disabled="disabled" class="form-control form-control-sm"/>
+               </div>
             </div>
         ');
 


### PR DESCRIPTION
It's a know issue that unchecked checkboxes aren't submitted and can therefore not be found in `$_POST`. This [solution](https://stackoverflow.com/a/1992745) on stack overflow seemed appropriate to me, so I implemented it for the UI component `Checkbox`. There was really no downside to this until now, but I stumbled upon a problem that was solved by this solution when implementing `DynamicInputsAware` (#3809). 