### PR TITLE
BookingPool: Fix missing $idx when filtering by period

### DIFF
--- a/Modules/BookingManager/Objects/classes/class.ilBookingObjectsTableGUI.php
+++ b/Modules/BookingManager/Objects/classes/class.ilBookingObjectsTableGUI.php
@@ -186,7 +186,7 @@ class ilBookingObjectsTableGUI extends ilTable2GUI
             }
         }
         
-        foreach ($data as $item) {
+        foreach ($data as $idx => $item) {
             $item_id = $item["booking_object_id"];
             
             // available for given period?


### PR DESCRIPTION
Mantis Issue: https://mantis.ilias.de/view.php?id=31932