### PR TITLE
setup: StatusCommand::execute() return type fixed

### DIFF
--- a/src/Setup/CLI/StatusCommand.php
+++ b/src/Setup/CLI/StatusCommand.php
@@ -36,11 +36,13 @@ class StatusCommand extends Command
     }
 
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output) : int
     {
         $agent = $this->getRelevantAgent($input);
 
         $output->write($this->getMetrics($agent)->toYAML() . "\n");
+        
+        return 0;
     }
 
     public function getMetrics(Agent $agent) : Metrics\Metric


### PR DESCRIPTION
@klees,

(executed with PHP 8.0.14)
PHP Fatal error:  Uncaught TypeError: Return value of "ILIAS\Setup\CLI\StatusCommand::execute()" must be of the type int, "null" returned. in /srv/www/ilias-t.hsu-hh.de/ilias/8/trunk8/libs/composer/vendor/symfony/console/Command/Command.php:301