### PR TITLE
UI/Input/Duration - translate default labels for start/end

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -16711,3 +16711,5 @@ skmg#:#skmg_skill_needs_self_eval_box#:#Bitte beachten Sie, dass für mindestens
 skmg#:#skmg_recommended_learning_material#:#Lerninhalte zur Zielerreichung
 skmg#:#skmg_recommended_learning_material_info#:#Wählen Sie genau einen der folgenden Lerninhalte aus. Bearbeiten Sie ihn um das Kompetenzziel zu erreichen.
 skmg#:#skmg_no_skills_selected_info#:#Sie haben noch keine Kompetenzen ausgewählt. Klicken Sie auf den Button "Kompetenz hinzufügen" um eine Kompetenz auszuwählen und sie hier angezeigt zu bekommen. Sie können beliebig viele Kompetenzen hinzufügen.
+ui#:#duration_default_label_start#:#Beginn
+ui#:#duration_default_label_end#:#Ende

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -16712,3 +16712,5 @@ skmg#:#skmg_skill_needs_self_eval_box#:#Please note that you have not conducted 
 skmg#:#skmg_recommended_learning_material#:#Learning Materials for target achievement
 skmg#:#skmg_recommended_learning_material_info#:#Select exactly one of the following learning materials. Please work through it to achieve the competence target.
 skmg#:#skmg_no_skills_selected_info#:#You have not selected any competences yet. Click on the button "Add Competence" to select a competence and to see it here. You can add any number of competences.
+ui#:#duration_default_label_start#:#start
+ui#:#duration_default_label_end#:#end

--- a/src/UI/Implementation/Component/Input/Field/Duration.php
+++ b/src/UI/Implementation/Component/Input/Field/Duration.php
@@ -22,9 +22,6 @@ class Duration extends Group implements C\Input\Field\Duration
     use ComponentHelper;
     use JavaScriptBindable;
 
-    const DEFAULT_START_LABEL = 'start';
-    const DEFAULT_END_LABEL = 'end';
-
     protected DateFormat $format;
     protected DateTimeImmutable $min_date;
     protected DateTimeImmutable $max_date;
@@ -41,8 +38,8 @@ class Duration extends Group implements C\Input\Field\Duration
         ?string $byline
     ) {
         $inputs = [
-            $field_factory->dateTime(self::DEFAULT_START_LABEL),
-            $field_factory->dateTime(self::DEFAULT_END_LABEL)
+            $field_factory->dateTime($lng->txt('duration_default_label_start')),
+            $field_factory->dateTime($lng->txt('duration_default_label_end'))
         ];
 
         parent::__construct($data_factory, $refinery, $lng, $inputs, $label, $byline);

--- a/tests/UI/Component/Input/Field/DurationInputTest.php
+++ b/tests/UI/Component/Input/Field/DurationInputTest.php
@@ -28,9 +28,10 @@ class DurationInputTest extends ILIAS_UI_TestBase
 
     protected function buildLanguage() : ilLanguage
     {
-        if (!isset($this->lng)) {
-            $this->lng = $this->createMock(ilLanguage::class);
-        }
+        $this->lng = $this->createMock(ilLanguage::class);
+        $this->lng->method("txt")
+            ->will($this->returnArgument(0));
+
         return $this->lng;
     }
 
@@ -143,6 +144,9 @@ class DurationInputTest extends ILIAS_UI_TestBase
         $datetime = $this->factory->duration('label', 'byline');
         $r = $this->getDefaultRenderer();
         $html = $this->brutallyTrimHTML($r->render($datetime));
+        $label_start = 'duration_default_label_start';
+        $label_end = 'duration_default_label_end';
+
 
         $expected = $this->brutallyTrimHTML('
         <div class="form-group row">
@@ -150,13 +154,13 @@ class DurationInputTest extends ILIAS_UI_TestBase
            <div class="col-sm-9">
               <div class="il-input-duration" id="id_1">
                  <div class="form-group row">
-                    <label for="id_2" class="control-label col-sm-3">' . I\Input\Field\Duration::DEFAULT_START_LABEL . '</label>
+                    <label for="id_2" class="control-label col-sm-3">' . $label_start . '</label>
                     <div class="col-sm-9">
                        <div class="input-group date il-input-datetime" id="id_2"><input type="text" name="" placeholder="YYYY-MM-DD" class="form-control form-control-sm" /><span class="input-group-addon"><a class="glyph" href="#" aria-label="calendar"><span class="glyphicon glyphicon-calendar" aria-hidden="true"></span></a></span></div>
                     </div>
                  </div>
                  <div class="form-group row">
-                    <label for="id_3" class="control-label col-sm-3">' . I\Input\Field\Duration::DEFAULT_END_LABEL . '</label>
+                    <label for="id_3" class="control-label col-sm-3">' . $label_end . '</label>
                     <div class="col-sm-9">
                        <div class="input-group date il-input-datetime" id="id_3"><input type="text" name="" placeholder="YYYY-MM-DD" class="form-control form-control-sm" /><span class="input-group-addon"><a class="glyph" href="#" aria-label="calendar"><span class="glyphicon glyphicon-calendar" aria-hidden="true"></span></a></span></div>
                     </div>


### PR DESCRIPTION
The default labels of the inner inputs were not translated. This is the fix. 
(thanks, @chfsx, for pointing that out)