### PR TITLE
Cron: Get rid of static methods (almost all) / Use `Dependency Injection`

### DIFF
--- a/Modules/Forum/classes/class.ilForumAppEventListener.php
+++ b/Modules/Forum/classes/class.ilForumAppEventListener.php
@@ -107,7 +107,7 @@ class ilForumAppEventListener implements ilAppEventListener
 
                         // If the author of the parent post wants to be notified and the author of the new post is not the same individual: Send a message
                         // This notification will be NOT send via cron job
-                        if ($immediate_notifications_enabled || ilCronManager::isJobActive('frm_notification')) {
+                        if ($immediate_notifications_enabled || $DIC->cron()->manager()->isJobActive('frm_notification')) {
                             if ($post->isActivated() && $post->getParentId() > 0) {
                                 $parent_post = new ilForumPost($post->getParentId());
                                 if (
@@ -341,7 +341,7 @@ class ilForumAppEventListener implements ilAppEventListener
                         );
 
                         if ($post->isActivated()) {
-                            if (ilCronManager::isJobActive('frm_notification')) {
+                            if ($DIC->cron()->manager()->isJobActive('frm_notification')) {
                                 $logger->debug(
                                     'Notification delivery via cron job is enabled: ' .
                                     'Storing posting data for deferred "Posting/Thread Deleted" notifications ...'

--- a/Modules/Forum/classes/class.ilObjForumAdministrationGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumAdministrationGUI.php
@@ -13,6 +13,7 @@ class ilObjForumAdministrationGUI extends ilObjectGUI
 {
     private \ILIAS\DI\RBACServices $rbac;
     private ilErrorHandling $error;
+    private ilCronManagerInterface $cronManager;
 
     public function __construct($a_data, int $a_id, bool $a_call_by_reference = true, bool $a_prepare_output = true)
     {
@@ -23,6 +24,7 @@ class ilObjForumAdministrationGUI extends ilObjectGUI
 
         $this->rbac = $DIC->rbac();
         $this->error = $DIC['ilErr'];
+        $this->cronManager = $DIC->cron()->manager();
 
         $this->type = 'frma';
         parent::__construct($a_data, $a_id, $a_call_by_reference, $a_prepare_output);
@@ -108,7 +110,7 @@ class ilObjForumAdministrationGUI extends ilObjectGUI
         $this->settings->set('enable_fora_statistics', (string) $form->getInput('fora_statistics'));
         $this->settings->set('enable_anonymous_fora', (string) $form->getInput('anonymous_fora'));
 
-        if (!ilCronManager::isJobActive('frm_notification')) {
+        if (!$this->cronManager->isJobActive('frm_notification')) {
             $this->settings->set('forum_notification', (string) $form->getInput('forum_notification'));
         }
 
@@ -184,7 +186,7 @@ class ilObjForumAdministrationGUI extends ilObjectGUI
 
         $form->addItem($file_upload);
 
-        if (ilCronManager::isJobActive('frm_notification')) {
+        if ($this->cronManager->isJobActive('frm_notification')) {
             ilAdministrationSettingsFormHandler::addFieldsToForm(
                 ilAdministrationSettingsFormHandler::FORM_FORUM,
                 $form,

--- a/Modules/WebResource/classes/class.ilWebResourceCronLinkCheck.php
+++ b/Modules/WebResource/classes/class.ilWebResourceCronLinkCheck.php
@@ -136,13 +136,9 @@ class ilWebResourceCronLinkCheck extends ilCronJob
         return $period;
     }
     
-    public function activationWasToggled(bool $a_currently_active) : void
+    public function activationWasToggled(ilDBInterface $db, ilSetting $setting, bool $a_currently_active) : void
     {
-        global $DIC;
-
-        $ilSetting = $DIC['ilSetting'];
-                
         // propagate cron-job setting to object setting
-        $ilSetting->set("cron_web_resource_check", (bool) $a_currently_active);
+        $setting->set("cron_web_resource_check", (bool) ((int) $a_currently_active));
     }
 }

--- a/Services/Certificate/classes/class.ilCertificateCron.php
+++ b/Services/Certificate/classes/class.ilCertificateCron.php
@@ -20,6 +20,7 @@ class ilCertificateCron extends ilCronJob
     private ?ilCertificateObjectHelper $objectHelper;
     private Container $dic;
     private ?ilSetting $settings;
+    private ?ilCronManagerInterface $cronManager;
 
     public function __construct(
         ?ilCertificateQueueRepository $queueRepository = null,
@@ -30,7 +31,8 @@ class ilCertificateCron extends ilCronJob
         ?Container $dic = null,
         ?ilLanguage $language = null,
         ?ilCertificateObjectHelper $objectHelper = null,
-        ?ilSetting $setting = null
+        ?ilSetting $setting = null,
+        ?ilCronManagerInterface $cronManager = null
     ) {
         if (null === $dic) {
             global $DIC;
@@ -45,6 +47,7 @@ class ilCertificateCron extends ilCronJob
         $this->logger = $logger;
         $this->objectHelper = $objectHelper;
         $this->settings = $setting;
+        $this->cronManager = $cronManager;
 
         if ($dic && isset($dic['lng'])) {
             $language = $dic->language();
@@ -75,6 +78,10 @@ class ilCertificateCron extends ilCronJob
 
         if (null === $this->logger) {
             $this->logger = $this->dic->logger()->cert();
+        }
+
+        if (null === $this->cronManager) {
+            $this->cronManager = $this->dic->cron()->manager();
         }
 
         if (null === $this->queueRepository) {
@@ -204,7 +211,7 @@ class ilCertificateCron extends ilCronJob
     public function processEntry(int $entryCounter, ilCertificateQueueEntry $entry, array $succeededGenerations) : array
     {
         if ($entryCounter > 0 && $entryCounter % 10 === 0) {
-            ilCronManager::ping($this->getId());
+            $this->cronManager->ping($this->getId());
         }
 
         $this->logger->debug('Entry found will start of processing the entry');

--- a/Services/Component/classes/Setup/class.ilComponentDefinitionsStoredObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentDefinitionsStoredObjective.php
@@ -47,7 +47,10 @@ class ilComponentDefinitionsStoredObjective implements Setup\Objective
     {
         return [
             new \ilDatabaseUpdatedObjective(),
-            new \ilDatabaseUpdateStepsExecutedObjective(new ilCOPageDBUpdateSteps())
+            new \ilDatabaseUpdateStepsExecutedObjective(new ilCOPageDBUpdateSteps()),
+            new \ilSettingsFactoryExistsObjective(),
+            new \ilComponentRepositoryExistsObjective(),
+            new \ilComponentFactoryExistsObjective(),
         ];
     }
 
@@ -61,6 +64,12 @@ class ilComponentDefinitionsStoredObjective implements Setup\Objective
         $db = $environment->getResource(Setup\Environment::RESOURCE_DATABASE);
         $ini = $environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI);
         $client_ini = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_INI);
+        /** @var ilComponentRepository $component_repository  */
+        $component_repository = $environment->getResource(Setup\Environment::RESOURCE_COMPONENT_REPOSITORY);
+        /** @var ilComponentFactory $component_factory  */
+        $component_factory = $environment->getResource(Setup\Environment::RESOURCE_COMPONENT_FACTORY);
+        /** @var ilSettingsFactory $settings_factory */
+        $settings_factory = $environment->getResource(Setup\Environment::RESOURCE_SETTINGS_FACTORY);
 
         // ATTENTION: This is a total abomination. It only exists to allow various
         // sub components of the various readers to run. This is a memento to the
@@ -115,9 +124,14 @@ class ilComponentDefinitionsStoredObjective implements Setup\Objective
             new \ilBadgeDefinitionProcessor($db),
             new \ilCOPageDefinitionProcessor($db),
             new \ilComponentInfoDefinitionProcessor($db),
-            new \ilCronDefinitionProcessor($db),
             new \ilEventDefinitionProcessor($db),
             new \ilLoggingDefinitionProcessor($db),
+            new \ilCronDefinitionProcessor(
+                $db,
+                $settings_factory->settingsFor('common'),
+                $component_repository,
+                $component_factory
+            ),
             new \ilMailTemplateContextDefinitionProcessor($db),
             new \ilObjectDefinitionProcessor($db),
             new \ilPDFGenerationDefinitionProcessor($db),

--- a/Services/Cron/classes/class.ilCronHookPlugin.php
+++ b/Services/Cron/classes/class.ilCronHookPlugin.php
@@ -1,17 +1,19 @@
-<?php
+<?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
-include_once("./Services/Component/classes/class.ilPlugin.php");
- 
-/**
- * Abstract parent class for all cron hook plugin classes.
- *
- * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>
- * @version $Id$
- *
- * @ingroup ServicesCron
- */
 abstract class ilCronHookPlugin extends ilPlugin implements ilCronJobProvider
 {
 }

--- a/Services/Cron/classes/class.ilCronJob.php
+++ b/Services/Cron/classes/class.ilCronJob.php
@@ -1,13 +1,19 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
-
-/**
- * Cron job application base class
+/******************************************************************************
  *
- * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>
- * @ingroup ServicesCron
- */
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
 abstract class ilCronJob
 {
     public const SCHEDULE_TYPE_DAILY = 1;
@@ -238,10 +244,16 @@ abstract class ilCronJob
     {
     }
 
-    public function activationWasToggled(bool $a_currently_active) : void
+    /**
+     * Important: This method is (also) called from the setup process, where the constructor of an ilCronJob ist NOT executed.
+     * Furthermore only few dependencies may be available in the $DIC.
+     * @param ilDBInterface $db
+     * @param ilSetting $setting
+     * @param bool $a_currently_active
+     * @return void
+     */
+    public function activationWasToggled(ilDBInterface $db, ilSetting $setting, bool $a_currently_active) : void
     {
-        // we cannot use ilObject or any higher level construct here
-        // this may be called from setup, so it is limited to handling ilSetting/ilDB mostly
     }
 
     abstract public function getId() : string;

--- a/Services/Cron/classes/class.ilCronJobEntities.php
+++ b/Services/Cron/classes/class.ilCronJobEntities.php
@@ -1,16 +1,24 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-/**
- * Class ilCronJobEntities
- * @author Michael Jansen <mjansen@databay.de>
- */
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
 class ilCronJobEntities implements ilCronJobCollection
 {
     private ArrayIterator $jobs;
 
     /**
-     * ilCronJobs constructor.
      * @param ilCronJobEntity[] $jobs
      */
     public function __construct(array $jobs = [])

--- a/Services/Cron/classes/class.ilCronJobEntity.php
+++ b/Services/Cron/classes/class.ilCronJobEntity.php
@@ -1,10 +1,19 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-/**
- * Class ilCronJobEntity
- * @author Michael Jansen <mjansen@databay.de>
- */
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
 class ilCronJobEntity
 {
     private ilCronJob $job;

--- a/Services/Cron/classes/class.ilCronJobRepositoryImpl.php
+++ b/Services/Cron/classes/class.ilCronJobRepositoryImpl.php
@@ -1,29 +1,398 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-/**
- * Class ilCronJobRepositoryImpl
- * @author Michael Jansen <mjansen@databay.de>
- */
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
 class ilCronJobRepositoryImpl implements ilCronJobRepository
 {
+    private ilDBInterface $db;
+    private ilSetting $setting;
+    private ilLogger $logger;
+    private ilComponentRepository $componentRepository;
+    private ilComponentFactory $componentFactory;
+
+    public function __construct(
+        ilDBInterface $db,
+        ilSetting $setting,
+        ilLogger $logger,
+        ilComponentRepository $componentRepository,
+        ilComponentFactory $componentFactory
+    ) {
+        $this->db = $db;
+        $this->setting = $setting;
+        $this->logger = $logger;
+        $this->componentRepository = $componentRepository;
+        $this->componentFactory = $componentFactory;
+    }
+
+    public function getJobInstanceById(string $id) : ?ilCronJob
+    {
+        // plugin
+        if (strpos($id, 'pl__') === 0) {
+            $parts = explode('__', $id);
+            $pl_name = $parts[1];
+            $job_id = $parts[2];
+
+            foreach ($this->componentRepository->getPlugins() as $pl) {
+                if ($pl->getName() !== $pl_name || !$pl->isActive()) {
+                    continue;
+                }
+
+                $plugin = $this->componentFactory->getPlugin($pl->getId());
+                if (!$plugin instanceof ilCronJobProvider) {
+                    continue;
+                }
+
+                try {
+                    $job = $plugin->getCronJobInstance($job_id);
+
+                    // should never happen but who knows...
+                    $jobs_data = $this->getCronJobData($job_id);
+                    if ($jobs_data === []) {
+                        // as job is not 'imported' from xml
+                        $this->createDefaultEntry($job, $pl_name, IL_COMP_PLUGIN, '');
+                    }
+
+                    return $job;
+                } catch (OutOfBoundsException $e) {
+                    // Maybe a job was removed from plugin, renamed etc.
+                }
+                break;
+            }
+        } else {
+            $jobs_data = $this->getCronJobData($id);
+            if ($jobs_data !== [] && $jobs_data[0]['job_id'] === $id) {
+                return $this->getJobInstance(
+                    $jobs_data[0]['job_id'],
+                    $jobs_data[0]['component'],
+                    $jobs_data[0]['class']
+                );
+            }
+        }
+
+        $this->logger->info('CRON - job ' . $id . ' seems invalid or is inactive');
+
+        return null;
+    }
+
+    public function getJobInstance(
+        string $a_id,
+        string $a_component,
+        string $a_class,
+        bool $isCreationContext = false
+    ) : ?ilCronJob {
+        if (class_exists($a_class)) {
+            if ($isCreationContext) {
+                $refl = new ReflectionClass($a_class);
+                $job = $refl->newInstanceWithoutConstructor();
+            } else {
+                $job = new $a_class;
+            }
+
+            if ($job instanceof ilCronJob && $job->getId() === $a_id) {
+                return $job;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get cron job configuration/execution data
+     * @param array|string|null $id
+     * @param bool $withInactiveJobsIncluded
+     * @return array<int, array<string, mixed>>
+     */
+    public function getCronJobData($id = null, bool $withInactiveJobsIncluded = true) : array
+    {
+        $jobData = [];
+
+        if ($id && !is_array($id)) {
+            $id = [$id];
+        }
+
+        $query = "SELECT * FROM cron_job";
+        $where = [];
+        if ($id) {
+            $where[] = $this->db->in('job_id', $id, false, 'text');
+        } else {
+            $where[] = 'class != ' . $this->db->quote(IL_COMP_PLUGIN, 'text');
+        }
+        if (!$withInactiveJobsIncluded) {
+            $where[] = 'job_status = ' . $this->db->quote(1, 'integer');
+        }
+        if ($where !== []) {
+            $query .= ' WHERE ' . implode(' AND ', $where);
+        }
+        // :TODO: discuss job execution order
+        $query .= ' ORDER BY job_id';
+
+        $res = $this->db->query($query);
+        while ($row = $this->db->fetchAssoc($res)) {
+            $jobData[] = $row;
+        }
+
+        return $jobData;
+    }
+
+    public function registerJob(
+        string $a_component,
+        string $a_id,
+        string $a_class,
+        ?string $a_path
+    ) : void {
+        if (!$this->db->tableExists('cron_job')) {
+            return;
+        }
+
+        $job = $this->getJobInstance($a_id, $a_component, $a_class, true);
+        if ($job) {
+            $this->createDefaultEntry($job, $a_component, $a_class, $a_path);
+        }
+    }
+
+    public function unregisterJob(string $a_component, array $a_xml_job_ids) : void
+    {
+        if (!$this->db->tableExists('cron_job')) {
+            return;
+        }
+
+        $jobs = [];
+        $query = 'SELECT job_id FROM cron_job WHERE component = ' . $this->db->quote($a_component, 'text');
+        $res = $this->db->query($query);
+        while ($row = $this->db->fetchAssoc($res)) {
+            $jobs[] = $row['job_id'];
+        }
+
+        if ($jobs !== []) {
+            if ($a_xml_job_ids !== []) {
+                foreach ($jobs as $job_id) {
+                    if (!in_array($job_id, $a_xml_job_ids, true)) {
+                        $this->db->manipulate(
+                            'DELETE FROM cron_job' .
+                            ' WHERE component = ' . $this->db->quote($a_component, 'text') .
+                            ' AND job_id = ' . $this->db->quote($job_id, 'text')
+                        );
+                    }
+                }
+            } else {
+                $this->db->manipulate('DELETE FROM cron_job WHERE component = ' . $this->db->quote($a_component, 'text'));
+            }
+        }
+    }
+
+    public function createDefaultEntry(
+        ilCronJob $job,
+        string $component,
+        string $class,
+        ?string $path
+    ) : void {
+        $query = "SELECT job_id, schedule_type, component, class, path FROM cron_job" .
+            " WHERE job_id = " . $this->db->quote($job->getId(), "text");
+        $res = $this->db->query($query);
+        $row = $this->db->fetchAssoc($res);
+        $job_id = $row['job_id'] ?? null;
+        $job_exists = ($job_id === $job->getId());
+        $schedule_type = $row["schedule_type"] ?? null;
+
+        if (
+            $job_exists && (
+                $row['component'] !== $component ||
+                $row['class'] !== $class ||
+                $row['path'] !== $path
+            )
+        ) {
+            $this->db->manipulateF(
+                'UPDATE cron_job SET component = %s, class = %s, path = %s WHERE job_id = %s',
+                ['text', 'text', 'text', 'text'],
+                [$component, $class, $path, $job->getId()]
+            );
+        }
+
+        // new job
+        if (!$job_exists) {
+            $query = 'INSERT INTO cron_job (job_id, component, class, path)' .
+                ' VALUES (' . $this->db->quote($job->getId(), 'text') . ', ' .
+                $this->db->quote($component, 'text') . ', ' .
+                $this->db->quote($class, 'text') . ', ' .
+                $this->db->quote($path, 'text') . ')';
+            $this->db->manipulate($query);
+
+            $this->logger->info('Cron XML - Job ' . $job->getId() . ' in class ' . $class . ' added.');
+
+            // only if flexible
+            $this->updateJobSchedule(
+                $job,
+                $job->getDefaultScheduleType(),
+                $job->getDefaultScheduleValue()
+            );
+
+            if ($job->hasAutoActivation()) {
+                $this->activateJob($job);
+                $job->activationWasToggled($this->db, $this->setting, true);
+            } else {
+                // to overwrite dependent settings
+                $job->activationWasToggled($this->db, $this->setting, false);
+            }
+        } // existing job - but schedule is flexible now
+        elseif (!$schedule_type && $job->hasFlexibleSchedule()) {
+            $this->updateJobSchedule(
+                $job,
+                $job->getDefaultScheduleType(),
+                $job->getDefaultScheduleValue()
+            );
+        } // existing job - but schedule is static now
+        elseif ($schedule_type && !$job->hasFlexibleSchedule()) {
+            $this->updateJobSchedule($job, null, null);
+        }
+    }
+
+    /**
+     * @param bool $withOnlyActive
+     * @return array<int, array{0: ilCronJob, 1: array<string, mixed>}>
+     */
+    public function getPluginJobs(bool $withOnlyActive = false) : array
+    {
+        $res = [];
+        foreach ($this->componentRepository->getPlugins() as $pl) {
+            if (!$pl->isActive()) {
+                continue;
+            }
+
+            $plugin = $this->componentFactory->getPlugin($pl->getId());
+
+            if (!$plugin instanceof ilCronJobProvider) {
+                continue;
+            }
+
+            foreach ($plugin->getCronJobInstances() as $job) {
+                $jobs_data = $this->getCronJobData($job->getId());
+                $job_data = $jobs_data[0] ?? null;
+                if (!is_array($job_data) || $job_data === []) {
+                    // as job is not "imported" from xml
+                    $this->createDefaultEntry($job, $plugin->getPluginName(), IL_COMP_PLUGIN, '');
+                }
+
+                $jobs_data = $this->getCronJobData($job->getId());
+                $job_data = $jobs_data[0];
+
+                // #17941
+                if (!$withOnlyActive || (int) $job_data['job_status'] === 1) {
+                    $res[$job->getId()] = [$job, $job_data];
+                }
+            }
+        }
+
+        return $res;
+    }
+    
+    public function resetJob(ilCronJob $job) : void
+    {
+        $this->db->manipulate('UPDATE cron_job' .
+            ' SET running_ts = ' . $this->db->quote(0, 'integer') .
+            ' , alive_ts = ' . $this->db->quote(0, 'integer') .
+            ' , job_result_ts = ' . $this->db->quote(0, 'integer') .
+            ' WHERE job_id = ' . $this->db->quote($job->getId(), 'text'));
+    }
+
+    public function updateJobResult(
+        ilCronJob $job,
+        ilObjUser $actor,
+        ilCronJobResult $result,
+        bool $wasManualExecution = false
+    ) : void {
+        $user_id = $wasManualExecution ? $actor->getId() : 0;
+
+        $query = 'UPDATE cron_job SET ' .
+            ' job_result_status = ' . $this->db->quote($result->getStatus(), 'integer') .
+            ' , job_result_user_id = ' . $this->db->quote($user_id, 'integer') .
+            ' , job_result_code = ' . $this->db->quote($result->getCode(), 'text') .
+            ' , job_result_message = ' . $this->db->quote($result->getMessage(), 'text') .
+            ' , job_result_type = ' . $this->db->quote((int) $wasManualExecution, 'integer') .
+            ' , job_result_ts = ' . $this->db->quote(time(), 'integer') .
+            ' , job_result_dur = ' . $this->db->quote($result->getDuration() * 1000, 'integer') .
+            ' WHERE job_id = ' . $this->db->quote($job->getId(), 'text');
+        $this->db->manipulate($query);
+    }
+    
+    public function updateRunInformation(string $jobId, int $runningTimestamp, int $aliveTimestamp) : void
+    {
+        $this->db->manipulate('UPDATE cron_job SET' .
+            ' running_ts = ' . $this->db->quote(0, 'integer') .
+            ' , alive_ts = ' . $this->db->quote(0, 'integer') .
+            ' WHERE job_id = ' . $this->db->quote($jobId, 'text'));
+    }
+
+    public function updateJobSchedule(ilCronJob $job, ?int $scheduleType, ?int $scheduleValue) : void
+    {
+        if (
+            $scheduleType === null ||
+            ($job->hasFlexibleSchedule() && in_array($scheduleType, $job->getValidScheduleTypes(), true))
+        ) {
+            $query = 'UPDATE cron_job SET ' .
+                ' schedule_type = ' . $this->db->quote($scheduleType, 'integer') .
+                ' , schedule_value = ' . $this->db->quote($scheduleValue, 'integer') .
+                ' WHERE job_id = ' . $this->db->quote($job->getId(), 'text');
+            $this->db->manipulate($query);
+        }
+    }
+
+    public function activateJob(ilCronJob $job, ?ilObjUser $actor = null, bool $wasManuallyExecuted = false) : void
+    {
+        $usrId = 0;
+        if ($wasManuallyExecuted && $actor instanceof ilObjUser) {
+            $usrId = $actor->getId();
+        }
+
+        $query = 'UPDATE cron_job SET ' .
+            ' job_status = ' . $this->db->quote(1, 'integer') .
+            ' , job_status_user_id = ' . $this->db->quote($usrId, 'integer') .
+            ' , job_status_type = ' . $this->db->quote($wasManuallyExecuted, 'integer') .
+            ' , job_status_ts = ' . $this->db->quote(time(), 'integer') .
+            ' WHERE job_id = ' . $this->db->quote($job->getId(), 'text');
+        $this->db->manipulate($query);
+    }
+
+    public function deactivateJob(ilCronJob $job, ilObjUser $actor, bool $wasManuallyExecuted = false) : void
+    {
+        $usrId = $wasManuallyExecuted ? $actor->getId() : 0;
+
+        $query = 'UPDATE cron_job SET ' .
+            ' job_status = ' . $this->db->quote(0, 'integer') .
+            ' , job_status_user_id = ' . $this->db->quote($usrId, 'integer') .
+            ' , job_status_type = ' . $this->db->quote($wasManuallyExecuted, 'integer') .
+            ' , job_status_ts = ' . $this->db->quote(time(), 'integer') .
+            ' WHERE job_id = ' . $this->db->quote($job->getId(), 'text');
+        $this->db->manipulate($query);
+    }
+
     public function findAll() : ilCronJobCollection
     {
         $collection = new ilCronJobEntities();
 
-        foreach (ilCronManager::getCronJobData() as $item) {
-            $job = ilCronManager::getJobInstance(
+        foreach ($this->getCronJobData() as $item) {
+            $job = $this->getJobInstance(
                 $item['job_id'],
                 $item['component'],
-                $item['class'],
-                $item['path']
+                $item['class']
             );
             if ($job) {
                 $collection->add(new ilCronJobEntity($job, $item));
             }
         }
 
-        foreach (ilCronManager::getPluginJobs() as $item) {
+        foreach ($this->getPluginJobs() as $item) {
             $collection->add(new ilCronJobEntity($item[0], $item[1], true));
         }
 

--- a/Services/Cron/classes/class.ilCronJobResult.php
+++ b/Services/Cron/classes/class.ilCronJobResult.php
@@ -1,13 +1,19 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
-
-/**
- * Cron job result data container
+/******************************************************************************
  *
- * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>
- * @ingroup ServicesCron
- */
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
 class ilCronJobResult
 {
     public const STATUS_INVALID_CONFIGURATION = 1;

--- a/Services/Cron/classes/class.ilCronManager.php
+++ b/Services/Cron/classes/class.ilCronManager.php
@@ -1,5 +1,18 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 /**
  * Cron management
@@ -8,16 +21,30 @@
  */
 class ilCronManager implements ilCronManagerInterface
 {
-    protected ilSetting $settings;
-    protected ilLogger $logger;
+    private ilCronJobRepository $cronRepository;
+    private ilDBInterface $db;
+    private ilSetting $settings;
+    private ilLogger $logger;
 
-    public function __construct(ilSetting $settings, ilLogger $logger)
-    {
+    public function __construct(
+        ilCronJobRepository $cronRepository,
+        ilDBInterface $db,
+        ilSetting $settings,
+        ilLogger $logger
+    ) {
+        $this->cronRepository = $cronRepository;
+        $this->db = $db;
         $this->settings = $settings;
         $this->logger = $logger;
     }
 
-    public function runActiveJobs() : void
+    private function getMicrotime() : float
+    {
+        [$usec, $sec] = explode(' ', microtime());
+        return ((float) $usec + (float) $sec);
+    }
+
+    public function runActiveJobs(ilObjUser $actor) : void
     {
         $this->logger->info('CRON - batch start');
 
@@ -36,7 +63,7 @@ class ilCronManager implements ilCronManagerInterface
                 new ilDateTime(ilSetting::_lookupValue('common', 'last_cronjob_start_ts'), IL_CAL_UNIX)
             )
         ));
-        ilDatePresentation::setUseRelativeDates((bool) $useRelativeDates);
+        ilDatePresentation::setUseRelativeDates($useRelativeDates);
 
         // ilLink::_getStaticLink() should work in crons
         if (!defined('ILIAS_HTTP_PATH')) {
@@ -44,126 +71,112 @@ class ilCronManager implements ilCronManagerInterface
         }
 
         // system
-        foreach (self::getCronJobData(null, false) as $row) {
-            $job = self::getJobInstanceById($row['job_id']);
+        foreach ($this->cronRepository->getCronJobData(null, false) as $row) {
+            $job = $this->cronRepository->getJobInstanceById($row['job_id']);
             if ($job instanceof ilCronJob) {
                 // #18411 - we are NOT using the initial job data as it might be outdated at this point
-                self::runJob($job);
+                $this->runJob($job, $actor);
             }
         }
 
         // plugins
-        foreach (self::getPluginJobs(true) as $item) {
+        foreach ($this->cronRepository->getPluginJobs(true) as $item) {
             // #18411 - we are NOT using the initial job data as it might be outdated at this point
-            self::runJob($item[0]);
+            $this->runJob($item[0], $actor);
         }
 
         $this->logger->info('CRON - batch end');
     }
 
-    public static function runJobManual(string $a_job_id) : bool
+    public function runJobManual(string $jobId, ilObjUser $actor) : bool
     {
-        global $DIC;
-
-        $ilLog = $DIC->logger()->root();
-
         $result = false;
 
-        $ilLog->write('CRON - manual start (' . $a_job_id . ')');
+        $this->logger->info('CRON - manual start (' . $jobId . ')');
 
-        $job = self::getJobInstanceById($a_job_id);
+        $job = $this->cronRepository->getJobInstanceById($jobId);
         if ($job instanceof ilCronJob) {
             if ($job->isManuallyExecutable()) {
-                $result = self::runJob($job, null, true);
+                $result = $this->runJob($job, $actor, null, true);
             } else {
-                $ilLog->write('CRON - job ' . $a_job_id . ' is not intended to be executed manually');
+                $this->logger->info('CRON - job ' . $jobId . ' is not intended to be executed manually');
             }
         } else {
-            $ilLog->write('CRON - job ' . $a_job_id . ' seems invalid or is inactive');
+            $this->logger->info('CRON - job ' . $jobId . ' seems invalid or is inactive');
         }
 
-        $ilLog->write('CRON - manual end (' . $a_job_id . ')');
+        $this->logger->info('CRON - manual end (' . $jobId . ')');
 
         return $result;
     }
 
     /**
      * Run single cron job (internal)
-     * @param ilCronJob $a_job
-     * @param array|null $a_job_data
-     * @param bool $a_manual
+     * @param ilCronJob $job
+     * @param ilObjUser $actor
+     * @param array|null $jobData
+     * @param bool $isManualExecution
      * @return bool
      * @internal
      */
-    protected static function runJob(ilCronJob $a_job, ?array $a_job_data = null, bool $a_manual = false) : bool
+    private function runJob(ilCronJob $job, ilObjUser $actor, ?array $jobData = null, bool $isManualExecution = false) : bool
     {
-        global $DIC;
-
-        $ilLog = $DIC->logger()->root();
-        $ilDB = $DIC->database();
-
         $did_run = false;
 
-        if (null === $a_job_data) {
+        if (null === $jobData) {
             // aquire "fresh" job (status) data
-            $jobData = self::getCronJobData($a_job->getId());
-            $a_job_data = array_pop($jobData);
+            $jobsData = $this->cronRepository->getCronJobData($job->getId());
+            $jobData = array_pop($jobsData);
         }
 
         // already running?
-        if ($a_job_data['alive_ts']) {
-            $ilLog->write('CRON - job ' . $a_job_data['job_id'] . ' still running');
+        if ($jobData['alive_ts']) {
+            $this->logger->info('CRON - job ' . $jobData['job_id'] . ' still running');
 
-            $cut = 60 * 60 * 3; // 3h
+            $cut = 60 * 60 * 3;
 
             // is running (and has not pinged) for 3 hours straight, we assume it crashed
-            if (time() - ((int) $a_job_data['alive_ts']) > $cut) {
-                $ilDB->manipulate('UPDATE cron_job SET' .
-                    ' running_ts = ' . $ilDB->quote(0, 'integer') .
-                    ' , alive_ts = ' . $ilDB->quote(0, 'integer') .
-                    ' WHERE job_id = ' . $ilDB->quote($a_job_data['job_id'], 'text'));
-
-                self::deactivateJob($a_job); // #13082
+            if (time() - ((int) $jobData['alive_ts']) > $cut) {
+                $this->cronRepository->updateRunInformation($jobData['job_id'], 0, 0);
+                $this->deactivateJob($job, $actor); // #13082
 
                 $result = new ilCronJobResult();
                 $result->setStatus(ilCronJobResult::STATUS_CRASHED);
                 $result->setCode(ilCronJobResult::CODE_SUPPOSED_CRASH);
                 $result->setMessage('Cron job deactivated because it has been inactive for 3 hours');
 
-                self::updateJobResult($a_job, $result, $a_manual);
+                $this->cronRepository->updateJobResult($job, $actor, $result, $isManualExecution);
 
-                $ilLog->write('CRON - job ' . $a_job_data['job_id'] . ' deactivated (assumed crash)');
+                $this->logger->info('CRON - job ' . $jobData['job_id'] . ' deactivated (assumed crash)');
             }
         } // initiate run?
-        elseif ($a_job->isDue(
-            $a_job_data['job_result_ts'] ? (int) $a_job_data['job_result_ts'] : null,
-            $a_job_data['schedule_type'] ? (int) $a_job_data['schedule_type'] : null,
-            $a_job_data['schedule_value'] ? (int) $a_job_data['schedule_value'] : null,
-            $a_manual
+        elseif ($job->isDue(
+            $jobData['job_result_ts'] ? (int) $jobData['job_result_ts'] : null,
+            $jobData['schedule_type'] ? (int) $jobData['schedule_type'] : null,
+            $jobData['schedule_value'] ? (int) $jobData['schedule_value'] : null,
+            $isManualExecution
         )) {
-            $ilLog->write('CRON - job ' . $a_job_data['job_id'] . ' started');
+            $this->logger->info('CRON - job ' . $jobData['job_id'] . ' started');
 
-            $ilDB->manipulate('UPDATE cron_job SET' .
-                ' running_ts = ' . $ilDB->quote(time(), 'integer') .
-                ' , alive_ts = ' . $ilDB->quote(time(), 'integer') .
-                ' WHERE job_id = ' . $ilDB->quote($a_job_data['job_id'], 'text'));
+            $this->cronRepository->updateRunInformation($jobData['job_id'], time(), time());
 
-            $ts_in = self::getMicrotime();
+            $ts_in = $this->getMicrotime();
             try {
-                $result = $a_job->run();
+                $result = $job->run();
             } catch (Throwable $e) {
                 $result = new ilCronJobResult();
                 $result->setStatus(ilCronJobResult::STATUS_CRASHED);
                 $result->setMessage(sprintf('Exception: %s', $e->getMessage()));
 
-                $ilLog->error($e->getMessage());
-                $ilLog->error($e->getTraceAsString());
+                $this->logger->error($e->getMessage());
+                $this->logger->error($e->getTraceAsString());
+            } finally {
+                $ts_dur = $this->getMicrotime() - $ts_in;
             }
-            $ts_dur = self::getMicrotime() - $ts_in;
 
             if ($result->getStatus() === ilCronJobResult::STATUS_INVALID_CONFIGURATION) {
-                self::deactivateJob($a_job);
-                $ilLog->write('CRON - job ' . $a_job_data['job_id'] . ' invalid configuration');
+                $this->deactivateJob($job, $actor);
+                $this->logger->info('CRON - job ' . $jobData['job_id'] . ' invalid configuration');
             } else {
                 // success!
                 $did_run = true;
@@ -171,480 +184,63 @@ class ilCronManager implements ilCronManagerInterface
 
             $result->setDuration($ts_dur);
 
-            self::updateJobResult($a_job, $result, $a_manual);
+            $this->cronRepository->updateJobResult($job, $actor, $result, $isManualExecution);
+            $this->cronRepository->updateRunInformation($jobData['job_id'], 0, 0);
 
-            $ilDB->manipulate('UPDATE cron_job SET' .
-                ' running_ts = ' . $ilDB->quote(0, 'integer') .
-                ' , alive_ts = ' . $ilDB->quote(0, 'integer') .
-                ' WHERE job_id = ' . $ilDB->quote($a_job_data['job_id'], 'text'));
-
-            $ilLog->write('CRON - job ' . $a_job_data['job_id'] . ' finished');
+            $this->logger->info('CRON - job ' . $jobData['job_id'] . ' finished');
         } else {
-            $ilLog->write('CRON - job ' . $a_job_data['job_id'] . ' returned status inactive');
+            $this->logger->info('CRON - job ' . $jobData['job_id'] . ' returned status inactive');
         }
 
         return $did_run;
     }
 
-    public static function getJobInstanceById(string $a_job_id) : ?ilCronJob
+    public function resetJob(ilCronJob $job, ilObjUser $actor) : void
     {
-        global $DIC;
-
-        $ilLog = $DIC->logger()->root();
-        /** @var ilComponentRepository $component_repository */
-        $component_repository = $DIC['component.repository'];
-        /** @var ilComponentFactory $component_factory */
-        $component_factory = $DIC['component.factory'];
-
-        // plugin
-        if (strpos($a_job_id, 'pl__') === 0) {
-            $parts = explode('__', $a_job_id);
-            $pl_name = $parts[1];
-            $job_id = $parts[2];
-
-            foreach ($component_repository->getPlugins() as $pl) {
-                if ($pl->getName() !== $pl_name || !$pl->isActive()) {
-                    continue;
-                }
-
-                $plugin = $component_factory->getPlugin($pl->getId());
-
-                if (!$plugin instanceof ilCronJobProvider) {
-                    continue;
-                }
-
-                try {
-                    $job = $plugin->getCronJobInstance($job_id);
-
-                    // should never happen but who knows...
-                    $jobs_data = self::getCronJobData($job_id);
-                    if ($jobs_data === []) {
-                        // as job is not 'imported' from xml
-                        self::createDefaultEntry($job, $pl_name, IL_COMP_PLUGIN, '');
-                    }
-
-                    return $job;
-                } catch (OutOfBoundsException $e) {
-                    // Maybe a job was removed from plugin, renamed etc.
-                }
-
-                break;
-            }
-        } else {
-            $jobs_data = self::getCronJobData($a_job_id);
-            if ($jobs_data !== [] && $jobs_data[0]['job_id'] === $a_job_id) {
-                return self::getJobInstance(
-                    $jobs_data[0]['job_id'],
-                    $jobs_data[0]['component'],
-                    $jobs_data[0]['class'],
-                    $jobs_data[0]['path']
-                );
-            }
-        }
-
-        $ilLog->write('CRON - job ' . $a_job_id . ' seems invalid or is inactive');
-
-        return null;
-    }
-
-    public static function getJobInstance(
-        string $a_id,
-        string $a_component,
-        string $a_class,
-        ?string $a_path,
-        bool $isCreationContext = false
-    ) : ?ilCronJob {
-        if (!$a_path) {
-            $a_path = $a_component . '/classes/';
-        }
-
-        $class_file = $a_path . 'class.' . $a_class . '.php';
-
-        if (is_file($class_file)) {
-            include_once $class_file;
-            if (class_exists($a_class)) {
-                if ($isCreationContext) {
-                    $refl = new ReflectionClass($a_class);
-                    $job = $refl->newInstanceWithoutConstructor();
-                } else {
-                    $job = new $a_class;
-                }
-
-                if ($job instanceof ilCronJob && $job->getId() === $a_id) {
-                    return $job;
-                }
-            }
-        }
-
-        return null;
-    }
-
-    public static function createDefaultEntry(
-        ilCronJob $a_job,
-        string $a_component,
-        string $a_class,
-        ?string $a_path
-    ) : void {
-        global $DIC;
-
-        $ilLog = $DIC->logger()->root();
-        $ilDB = $DIC->database();
-
-        if (!isset($DIC['ilSetting'])) {
-            $DIC['ilSetting'] = static function (\ILIAS\DI\Container $c) : ilSetting {
-                return new ilSetting();
-            };
-        }
-
-        $ilSetting = $DIC->settings();
-
-        $sql = "SELECT job_id, schedule_type, component, class, path FROM cron_job" .
-            " WHERE job_id = " . $ilDB->quote($a_job->getId(), "text");
-        $set = $ilDB->query($sql);
-        $row = $ilDB->fetchAssoc($set);
-        $job_id = $row['job_id'] ?? null;
-        $job_exists = ($job_id === $a_job->getId());
-        $schedule_type = $row["schedule_type"] ?? null;
-
-        if ($job_exists && (
-            $row['component'] !== $a_component ||
-                $row['class'] !== $a_class ||
-                $row['path'] !== $a_path
-        )) {
-            $ilDB->manipulateF(
-                'UPDATE cron_job SET component = %s, class = %s, path = %s WHERE job_id = %s',
-                ['text', 'text', 'text', 'text'],
-                [$a_component, $a_class, $a_path, $a_job->getId()]
-            );
-        }
-
-        // new job
-        if (!$job_exists) {
-            $sql = 'INSERT INTO cron_job (job_id, component, class, path)' .
-                ' VALUES (' . $ilDB->quote($a_job->getId(), 'text') . ', ' .
-                $ilDB->quote($a_component, 'text') . ', ' .
-                $ilDB->quote($a_class, 'text') . ', ' .
-                $ilDB->quote($a_path, 'text') . ')';
-            $ilDB->manipulate($sql);
-
-            $ilLog->write('Cron XML - Job ' . $a_job->getId() . ' in class ' . $a_class . ' added.');
-
-            // only if flexible
-            self::updateJobSchedule(
-                $a_job,
-                $a_job->getDefaultScheduleType(),
-                $a_job->getDefaultScheduleValue()
-            );
-
-            // #12221
-            if (!is_object($ilSetting)) {
-                $ilSetting = new ilSetting();
-            }
-
-            if ($a_job->hasAutoActivation()) {
-                self::activateJob($a_job);
-            } else {
-                // to overwrite dependent settings
-                $a_job->activationWasToggled(false);
-            }
-        } // existing job - but schedule is flexible now
-        elseif (!$schedule_type && $a_job->hasFlexibleSchedule()) {
-            self::updateJobSchedule(
-                $a_job,
-                $a_job->getDefaultScheduleType(),
-                $a_job->getDefaultScheduleValue()
-            );
-        } // existing job - but schedule is static now
-        elseif ($schedule_type && !$a_job->hasFlexibleSchedule()) {
-            self::updateJobSchedule($a_job, null, null);
-        }
-    }
-
-    public static function updateFromXML(
-        string $a_component,
-        string $a_id,
-        string $a_class,
-        ?string $a_path
-    ) : void {
-        global $DIC;
-
-        $ilDB = $DIC->database();
-
-        if (!$ilDB->tableExists('cron_job')) {
-            return;
-        }
-
-        $job = self::getJobInstance($a_id, $a_component, $a_class, $a_path, true);
-        if ($job) {
-            self::createDefaultEntry($job, $a_component, $a_class, $a_path);
-        }
-    }
-
-    /**
-     * Clear job data
-     * @param string $a_component
-     * @param string[] $a_xml_job_ids
-     */
-    public static function clearFromXML(string $a_component, array $a_xml_job_ids) : void
-    {
-        global $DIC;
-
-        $ilDB = $DIC->database();
-
-        if (!$ilDB->tableExists('cron_job')) {
-            return;
-        }
-
-        $all_jobs = [];
-        $sql = 'SELECT job_id FROM cron_job WHERE component = ' . $ilDB->quote($a_component, 'text');
-        $set = $ilDB->query($sql);
-        while ($row = $ilDB->fetchAssoc($set)) {
-            $all_jobs[] = $row['job_id'];
-        }
-
-        if ($all_jobs !== []) {
-            if ($a_xml_job_ids !== []) {
-                foreach ($all_jobs as $job_id) {
-                    if (!in_array($job_id, $a_xml_job_ids, true)) {
-                        $ilDB->manipulate('DELETE FROM cron_job' .
-                            ' WHERE component = ' . $ilDB->quote($a_component, 'text') .
-                            ' AND job_id = ' . $ilDB->quote($job_id, 'text'));
-                    }
-                }
-            } else {
-                $ilDB->manipulate('DELETE FROM cron_job WHERE component = ' . $ilDB->quote($a_component, 'text'));
-            }
-        }
-    }
-
-    /**
-     * @param bool $a_only_active
-     * @return array<int, array{0: ilCronJob, 1: array}>
-     */
-    public static function getPluginJobs(bool $a_only_active = false) : array
-    {
-        global $DIC;
-
-        /** @var ilComponentRepository $component_repository */
-        $component_repository = $DIC['component.repository'];
-        /** @var ilComponentFactory $component_factory */
-        $component_factory = $DIC['component.factory'];
-
-        $res = [];
-
-        foreach ($component_repository->getPlugins() as $pl) {
-            if (!$pl->isActive()) {
-                continue;
-            }
-
-            $plugin = $component_factory->getPlugin($pl->getId());
-
-            if (!$plugin instanceof ilCronJobProvider) {
-                continue;
-            }
-
-            foreach ($plugin->getCronJobInstances() as $job) {
-                $jobs_data = self::getCronJobData($job->getId());
-                $job_data = $jobs_data[0] ?? null;
-                if (!is_array($job_data) || $job_data === []) {
-                    // as job is not "imported" from xml
-                    self::createDefaultEntry($job, $plugin->getPluginName(), IL_COMP_PLUGIN, '');
-                }
-
-                $jobs_data = self::getCronJobData($job->getId());
-                $job_data = $jobs_data[0];
-
-                // #17941
-                if (!$a_only_active || (int) $job_data['job_status'] === 1) {
-                    $res[$job->getId()] = [$job, $job_data];
-                }
-            }
-        }
-
-        return $res;
-    }
-
-    /**
-     * Get cron job configuration/execution data
-     * @param array|string|null $a_id
-     * @param array $a_include_inactive
-     * @return array
-     */
-    public static function getCronJobData($a_id = null, bool $a_include_inactive = true) : array
-    {
-        global $DIC;
-        $ilDB = $DIC->database();
-
-        $res = [];
-
-        if ($a_id && !is_array($a_id)) {
-            $a_id = [$a_id];
-        }
-
-        $sql = "SELECT * FROM cron_job";
-
-        $where = [];
-        if ($a_id) {
-            $where[] = $ilDB->in('job_id', $a_id, false, 'text');
-        } else {
-            $where[] = 'class != ' . $ilDB->quote(IL_COMP_PLUGIN, 'text');
-        }
-        if (!$a_include_inactive) {
-            $where[] = 'job_status = ' . $ilDB->quote(1, 'integer');
-        }
-        if ($where !== []) {
-            $sql .= ' WHERE ' . implode(' AND ', $where);
-        }
-
-        // :TODO: discuss job execution order
-        $sql .= ' ORDER BY job_id';
-
-        $set = $ilDB->query($sql);
-        while ($row = $ilDB->fetchAssoc($set)) {
-            $res[] = $row;
-        }
-
-        return $res;
-    }
-
-    public static function resetJob(ilCronJob $a_job) : void
-    {
-        global $DIC;
-
-        $ilDB = $DIC->database();
-
         $result = new ilCronJobResult();
         $result->setStatus(ilCronJobResult::STATUS_RESET);
         $result->setCode(ilCronJobResult::CODE_MANUAL_RESET);
         $result->setMessage('Cron job re-activated by admin');
 
-        self::updateJobResult($a_job, $result, true);
+        $this->cronRepository->updateJobResult($job, $actor, $result, true);
+        $this->cronRepository->resetJob($job);
 
-        $ilDB->manipulate('UPDATE cron_job' .
-            ' SET running_ts = ' . $ilDB->quote(0, 'integer') .
-            ' , alive_ts = ' . $ilDB->quote(0, 'integer') .
-            ' , job_result_ts = ' . $ilDB->quote(0, 'integer') .
-            ' WHERE job_id = ' . $ilDB->quote($a_job->getId(), 'text'));
-
-        self::activateJob($a_job, true);
+        $this->activateJob($job, $actor, true);
     }
 
-    public static function activateJob(ilCronJob $a_job, bool $a_manual = false) : void
+    public function activateJob(ilCronJob $job, ilObjUser $actor, bool $wasManuallyExecuted = false) : void
     {
-        global $DIC;
-
-        $ilDB = $DIC->database();
-
-        $user_id = 0;
-        if ($DIC->isDependencyAvailable('user')) {
-            $user = $DIC->user();
-            $user_id = $a_manual ? $user->getId() : 0;
-        }
-
-        $sql = 'UPDATE cron_job SET ' .
-            ' job_status = ' . $ilDB->quote(1, 'integer') .
-            ' , job_status_user_id = ' . $ilDB->quote($user_id, 'integer') .
-            ' , job_status_type = ' . $ilDB->quote($a_manual, 'integer') .
-            ' , job_status_ts = ' . $ilDB->quote(time(), 'integer') .
-            ' WHERE job_id = ' . $ilDB->quote($a_job->getId(), 'text');
-        $ilDB->manipulate($sql);
-
-        $a_job->activationWasToggled(true);
+        $this->cronRepository->activateJob($job, $actor, $wasManuallyExecuted);
+        $job->activationWasToggled($this->db, $this->settings, true);
     }
 
-    public static function deactivateJob(ilCronJob $a_job, bool $a_manual = false) : void
+    public function deactivateJob(ilCronJob $job, ilObjUser $actor, bool $wasManuallyExecuted = false) : void
     {
-        global $DIC;
-
-        $ilDB = $DIC->database();
-        $ilUser = $DIC->user();
-
-        $user_id = $a_manual ? $ilUser->getId() : 0;
-
-        $sql = 'UPDATE cron_job SET ' .
-            ' job_status = ' . $ilDB->quote(0, 'integer') .
-            ' , job_status_user_id = ' . $ilDB->quote($user_id, 'integer') .
-            ' , job_status_type = ' . $ilDB->quote($a_manual, 'integer') .
-            ' , job_status_ts = ' . $ilDB->quote(time(), 'integer') .
-            ' WHERE job_id = ' . $ilDB->quote($a_job->getId(), 'text');
-        $ilDB->manipulate($sql);
-
-        $a_job->activationWasToggled(false);
+        $this->cronRepository->deactivateJob($job, $actor, $wasManuallyExecuted);
+        $job->activationWasToggled($this->db, $this->settings, false);
     }
 
-    public static function isJobActive(string $a_job_id) : bool
+    public function isJobActive(string $jobId) : bool
     {
-        $jobs_data = self::getCronJobData($a_job_id);
+        $jobs_data = $this->cronRepository->getCronJobData($jobId);
 
         return $jobs_data !== [] && $jobs_data[0]['job_status'];
     }
 
-    public static function isJobInactive(string $a_job_id) : bool
+    public function isJobInactive(string $jobId) : bool
     {
-        $jobs_data = self::getCronJobData($a_job_id);
+        $jobs_data = $this->cronRepository->getCronJobData($jobId);
 
         return $jobs_data !== [] && !((bool) $jobs_data[0]['job_status']);
     }
 
-    protected static function updateJobResult(
-        ilCronJob $a_job,
-        ilCronJobResult $a_result,
-        bool $a_manual = false
-    ) : void {
-        global $DIC;
-
-        $ilDB = $DIC->database();
-        $ilUser = $DIC->user();
-
-        $user_id = $a_manual ? $ilUser->getId() : 0;
-
-        $sql = 'UPDATE cron_job SET ' .
-            ' job_result_status = ' . $ilDB->quote($a_result->getStatus(), 'integer') .
-            ' , job_result_user_id = ' . $ilDB->quote($user_id, 'integer') .
-            ' , job_result_code = ' . $ilDB->quote($a_result->getCode(), 'text') .
-            ' , job_result_message = ' . $ilDB->quote($a_result->getMessage(), 'text') .
-            ' , job_result_type = ' . $ilDB->quote($a_manual, 'integer') .
-            ' , job_result_ts = ' . $ilDB->quote(time(), 'integer') .
-            ' , job_result_dur = ' . $ilDB->quote($a_result->getDuration() * 1000, 'integer') .
-            ' WHERE job_id = ' . $ilDB->quote($a_job->getId(), 'text');
-        $ilDB->manipulate($sql);
-    }
-
-    public static function updateJobSchedule(ilCronJob $a_job, ?int $a_schedule_type, ?int $a_schedule_value) : void
-    {
-        global $DIC;
-
-        $ilDB = $DIC->database();
-
-        if (
-            $a_schedule_type === null ||
-            ($a_job->hasFlexibleSchedule() && in_array($a_schedule_type, $a_job->getValidScheduleTypes(), true))
-        ) {
-            $sql = 'UPDATE cron_job SET ' .
-                ' schedule_type = ' . $ilDB->quote($a_schedule_type, 'integer') .
-                ' , schedule_value = ' . $ilDB->quote($a_schedule_value, 'integer') .
-                ' WHERE job_id = ' . $ilDB->quote($a_job->getId(), 'text');
-            $ilDB->manipulate($sql);
-        }
-    }
-
-    protected static function getMicrotime() : float
-    {
-        [$usec, $sec] = explode(' ', microtime());
-        return ((float) $usec + (float) $sec);
-    }
-
-    /**
-     * Keep cron job alive
-     * @param string $a_job_id
-     */
-    public static function ping(string $a_job_id) : void
+    public function ping(string $jobId) : void
     {
         global $DIC;
 
         $ilDB = $DIC->database();
 
         $ilDB->manipulate('UPDATE cron_job SET alive_ts = ' . $ilDB->quote(time(), 'integer') .
-            ' WHERE job_id = ' . $ilDB->quote($a_job_id, 'text'));
+            ' WHERE job_id = ' . $ilDB->quote($jobId, 'text'));
     }
 }

--- a/Services/Cron/classes/class.ilCronManagerGUI.php
+++ b/Services/Cron/classes/class.ilCronManagerGUI.php
@@ -1,6 +1,18 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 use ILIAS\HTTP\Wrapper\WrapperFactory;
 use ILIAS\UI\Factory;
@@ -22,11 +34,13 @@ class ilCronManagerGUI // implements ilCtrlBaseClassInterface
     private Factory $uiFactory;
     private Renderer $uiRenderer;
     private ilUIService $uiService;
-    private ilCronJobRepository $repository;
+    private ilCronJobRepository $cronRepository;
     private \ILIAS\DI\RBACServices $rbac;
     private ilErrorHandling $error;
     private WrapperFactory $httpRequest;
     private \ILIAS\Refinery\Factory $refinery;
+    private ilCronManagerInterface $cronManager;
+    private ilObjUser $actor;
 
     public function __construct()
     {
@@ -42,9 +56,11 @@ class ilCronManagerGUI // implements ilCtrlBaseClassInterface
         $this->uiService = $DIC->uiService();
         $this->rbac = $DIC->rbac();
         $this->error = $DIC['ilErr'];
-        $this->repository = new ilCronJobRepositoryImpl();
         $this->httpRequest = $DIC->http()->wrapper();
         $this->refinery = $DIC->refinery();
+        $this->actor = $DIC->user();
+        $this->cronRepository = $DIC->cron()->repository();
+        $this->cronManager = $DIC->cron()->manager();
 
         $this->lng->loadLanguageModule('cron');
         $this->lng->loadLanguageModule('cmps');
@@ -122,7 +138,7 @@ class ilCronManagerGUI // implements ilCtrlBaseClassInterface
 
         $message = $this->uiFactory->messageBox()->info($this->lng->txt('cronjob_last_start') . ': ' . $tstamp);
 
-        $cronJobs = $this->repository->findAll();
+        $cronJobs = $this->cronRepository->findAll();
 
         $tableFilterMediator = new ilCronManagerTableFilterMediator(
             $cronJobs,
@@ -139,6 +155,7 @@ class ilCronManagerGUI // implements ilCtrlBaseClassInterface
 
         $tbl = new ilCronManagerTableGUI(
             $this,
+            $this->cronRepository,
             'render',
             $this->rbac->system()->checkAccess('write', SYSTEM_FOLDER_ID)
         );
@@ -170,11 +187,6 @@ class ilCronManagerGUI // implements ilCtrlBaseClassInterface
         $this->tpl->setContent($a_form->getHTML());
     }
 
-    /**
-     * @param int $scheduleTypeId
-     * @return string
-     * @throws InvalidArgumentException
-     */
     protected function getScheduleTypeFormElementName(int $scheduleTypeId) : string
     {
         switch ($scheduleTypeId) {
@@ -209,11 +221,6 @@ class ilCronManagerGUI // implements ilCtrlBaseClassInterface
         ));
     }
 
-    /**
-     * @param int $scheduleTypeId
-     * @return string
-     * @throws InvalidArgumentException
-     */
     protected function getScheduleValueFormElementName(int $scheduleTypeId) : string
     {
         switch ($scheduleTypeId) {
@@ -233,10 +240,6 @@ class ilCronManagerGUI // implements ilCtrlBaseClassInterface
         ));
     }
 
-    /**
-     * @param int $scheduleTypeId
-     * @return bool
-     */
     protected function hasScheduleValue(int $scheduleTypeId) : bool
     {
         return in_array($scheduleTypeId, [
@@ -248,14 +251,14 @@ class ilCronManagerGUI // implements ilCtrlBaseClassInterface
 
     protected function initEditForm(string $a_job_id) : ilPropertyFormGUI
     {
-        $job = ilCronManager::getJobInstanceById($a_job_id);
+        $job = $this->cronRepository->getJobInstanceById($a_job_id);
         if (!($job instanceof ilCronJob)) {
             $this->ctrl->redirect($this, 'render');
         }
 
         $this->ctrl->setParameter($this, 'jid', $a_job_id);
 
-        $jobs_data = ilCronManager::getCronJobData($job->getId());
+        $jobs_data = $this->cronRepository->getCronJobData($job->getId());
         $job_data = $jobs_data[0];
 
         $form = new ilPropertyFormGUI();
@@ -319,7 +322,7 @@ class ilCronManagerGUI // implements ilCtrlBaseClassInterface
 
         $form = $this->initEditForm($job_id);
         if ($form->checkInput()) {
-            $job = ilCronManager::getJobInstanceById($job_id);
+            $job = $this->cronRepository->getJobInstanceById($job_id);
             if ($job instanceof ilCronJob) {
                 $valid = true;
                 if ($job->hasCustomSettings() && !$job->saveCustomSettings($form)) {
@@ -338,7 +341,7 @@ class ilCronManagerGUI // implements ilCtrlBaseClassInterface
                             break;
                     }
 
-                    ilCronManager::updateJobSchedule($job, $type, $value);
+                    $this->cronRepository->updateJobSchedule($job, $type, $value);
                 }
 
                 if ($valid) {
@@ -365,7 +368,7 @@ class ilCronManagerGUI // implements ilCtrlBaseClassInterface
 
         $job_id = $this->getRequestValue('jid', $this->refinery->kindlyTo()->string());
         if ($job_id) {
-            if (ilCronManager::runJobManual($job_id)) {
+            if ($this->cronManager->runJobManual($job_id, $this->actor)) {
                 ilUtil::sendSuccess($this->lng->txt('cron_action_run_success'), true);
             } else {
                 ilUtil::sendFailure($this->lng->txt('cron_action_run_fail'), true);
@@ -389,9 +392,8 @@ class ilCronManagerGUI // implements ilCtrlBaseClassInterface
         $jobs = $this->getMultiActionData();
         if ($jobs !== []) {
             foreach ($jobs as $job) {
-                if (ilCronManager::isJobInactive($job->getId())) {
-                    ilCronManager::resetJob($job);
-                    ilCronManager::activateJob($job, true);
+                if ($this->cronManager->isJobInactive($job->getId())) {
+                    $this->cronManager->resetJob($job, $this->actor);
                 }
             }
 
@@ -415,8 +417,8 @@ class ilCronManagerGUI // implements ilCtrlBaseClassInterface
         $jobs = $this->getMultiActionData();
         if ($jobs) {
             foreach ($jobs as $job) {
-                if (ilCronManager::isJobActive($job->getId())) {
-                    ilCronManager::deactivateJob($job, true);
+                if ($this->cronManager->isJobActive($job->getId())) {
+                    $this->cronManager->deactivateJob($job, $this->actor, true);
                 }
             }
 
@@ -440,7 +442,7 @@ class ilCronManagerGUI // implements ilCtrlBaseClassInterface
         $jobs = $this->getMultiActionData();
         if ($jobs) {
             foreach ($jobs as $job) {
-                ilCronManager::resetJob($job);
+                $this->cronManager->resetJob($job, $this->actor);
             }
             ilUtil::sendSuccess($this->lng->txt('cron_action_reset_success'), true);
         }
@@ -468,7 +470,7 @@ class ilCronManagerGUI // implements ilCtrlBaseClassInterface
         }
 
         foreach ($job_ids as $job_id) {
-            $job = ilCronManager::getJobInstanceById($job_id);
+            $job = $this->cronRepository->getJobInstanceById($job_id);
             if ($job instanceof ilCronJob) {
                 $res[$job_id] = $job;
             }
@@ -535,13 +537,12 @@ class ilCronManagerGUI // implements ilCtrlBaseClassInterface
     {
         $form_elements = [];
         $fields = [];
-        $data = ilCronManager::getCronJobData();
+        $data = $this->cronRepository->getCronJobData();
         foreach ($data as $item) {
-            $job = ilCronManager::getJobInstance(
+            $job = $this->cronRepository->getJobInstance(
                 $item['job_id'],
                 $item['component'],
-                $item['class'],
-                $item['path']
+                $item['class']
             );
             if (!is_null($job)) {
                 $job->addToExternalSettingsForm($a_form_id, $fields, (bool) $item['job_status']);

--- a/Services/Cron/classes/class.ilCronManagerTableFilterMediator.php
+++ b/Services/Cron/classes/class.ilCronManagerTableFilterMediator.php
@@ -1,14 +1,22 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 use ILIAS\UI\Component\Input\Container\Filter\Standard;
 use ILIAS\UI\Factory;
 
-/**
- * Class ilCronManagerTableFilterMediator
- * @author Michael Jansen <mjansen@databay.de>
- */
 class ilCronManagerTableFilterMediator
 {
     private const FILTER_PROPERTY_NAME_TITLE = 'title';

--- a/Services/Cron/classes/class.ilCronManagerTableGUI.php
+++ b/Services/Cron/classes/class.ilCronManagerTableGUI.php
@@ -1,17 +1,31 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-/**
- * List all active cron jobs
- * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>
- * @ingroup ServicesCron
- */
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
 class ilCronManagerTableGUI extends ilTable2GUI
 {
+    private ilCronJobRepository $cronRepository;
     private bool $mayWrite;
 
-    public function __construct(object $a_parent_obj, string $a_parent_cmd, bool $mayWrite = false)
-    {
+    public function __construct(
+        ilCronManagerGUI $a_parent_obj,
+        ilCronJobRepository $cronRepository,
+        string $a_parent_cmd,
+        bool $mayWrite = false
+    ) {
+        $this->cronRepository = $cronRepository;
         $this->mayWrite = $mayWrite;
 
         $this->setId('crnmng'); // #14526 / #16391
@@ -216,14 +230,14 @@ class ilCronManagerTableGUI extends ilTable2GUI
             if ($entity->getJob()->hasFlexibleSchedule()) {
                 $row['editable_schedule'] = true;
                 if (!$entity->getScheduleType()) {
-                    ilCronManager::updateJobSchedule(
+                    $this->cronRepository->updateJobSchedule(
                         $entity->getJob(),
                         $entity->getEffectiveScheduleType(),
                         $entity->getEffectiveScheduleValue()
                     );
                 }
             } elseif ($entity->getScheduleType()) {
-                ilCronManager::updateJobSchedule($entity->getJob(), null, null);
+                $this->cronRepository->updateJobSchedule($entity->getJob(), null, null);
             }
 
             return $row;

--- a/Services/Cron/classes/class.ilCronServicesImpl.php
+++ b/Services/Cron/classes/class.ilCronServicesImpl.php
@@ -14,17 +14,22 @@
  *
  *****************************************************************************/
 
-interface ilCronJobProvider
+class ilCronServicesImpl implements ilCronServices
 {
-    /**
-     * @return ilCronJob[]
-     */
-    public function getCronJobInstances() : array;
+    private \ILIAS\DI\Container $dic;
 
-    /**
-     * @param string $jobId
-     * @return ilCronJob
-     * @throws OutOfBoundsException if the passed argument does not match any cron job
-     */
-    public function getCronJobInstance(string $jobId) : ilCronJob;
+    public function __construct(\ILIAS\DI\Container $dic)
+    {
+        $this->dic = $dic;
+    }
+
+    public function manager() : ilCronManagerInterface
+    {
+        return $this->dic['cron.manager'];
+    }
+
+    public function repository() : ilCronJobRepository
+    {
+        return $this->dic['cron.repository'];
+    }
 }

--- a/Services/Cron/classes/class.ilCronStartUp.php
+++ b/Services/Cron/classes/class.ilCronStartUp.php
@@ -1,11 +1,19 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
-/**
- * Handles cron (cli) request
- * @author Stefan Meyer <smeyer.ilias@gmx.de>
- */
 class ilCronStartUp
 {
     private string $client;

--- a/Services/Cron/classes/class.ilStrictCliCronManager.php
+++ b/Services/Cron/classes/class.ilStrictCliCronManager.php
@@ -1,11 +1,20 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2018 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-/**
- * Class ilStrictCliCronManager
- * @author Michael Jansen <mjansen@databay.de>
- */
-class ilStrictCliCronManager implements \ilCronManagerInterface
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
+class ilStrictCliCronManager implements ilCronManagerInterface
 {
     protected ilCronManagerInterface $cronManager;
 
@@ -24,10 +33,45 @@ class ilStrictCliCronManager implements \ilCronManagerInterface
         ];
     }
 
-    public function runActiveJobs() : void
+    public function runActiveJobs(ilObjUser $actor) : void
     {
         if (in_array(PHP_SAPI, array_map('strtolower', $this->getValidPhpApis()), true)) {
-            $this->cronManager->runActiveJobs();
+            $this->cronManager->runActiveJobs($actor);
         }
+    }
+
+    public function runJobManual(string $jobId, ilObjUser $actor) : bool
+    {
+        return $this->cronManager->runJobManual($jobId, $actor);
+    }
+
+    public function resetJob(ilCronJob $job, ilObjUser $actor) : void
+    {
+        $this->cronManager->resetJob($job, $actor);
+    }
+
+    public function activateJob(ilCronJob $job, ilObjUser $actor, bool $wasManuallyExecuted = false) : void
+    {
+        $this->cronManager->activateJob($job, $actor, $wasManuallyExecuted);
+    }
+
+    public function deactivateJob(ilCronJob $job, ilObjUser $actor, bool $wasManuallyExecuted = false) : void
+    {
+        $this->cronManager->deactivateJob($job, $actor, $wasManuallyExecuted);
+    }
+
+    public function isJobActive(string $jobId) : bool
+    {
+        return $this->cronManager->isJobActive($jobId);
+    }
+
+    public function isJobInactive(string $jobId) : bool
+    {
+        return $this->cronManager->isJobInactive($jobId);
+    }
+
+    public function ping(string $jobId) : void
+    {
+        $this->cronManager->ping($jobId);
     }
 }

--- a/Services/Cron/interfaces/interface.ilCronJobCollection.php
+++ b/Services/Cron/interfaces/interface.ilCronJobCollection.php
@@ -1,10 +1,19 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-/**
- * Class ilCronJobCollection
- * @author Michael Jansen <mjansen@databay.de>
- */
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
 interface ilCronJobCollection extends Countable, IteratorAggregate
 {
     public function add(ilCronJobEntity $job) : void;

--- a/Services/Cron/interfaces/interface.ilCronJobRepository.php
+++ b/Services/Cron/interfaces/interface.ilCronJobRepository.php
@@ -1,11 +1,66 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-/**
- * Interface ilCronJobRepository
- * @author Michael Jansen <mjansen@databay.de>
- */
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
 interface ilCronJobRepository
 {
+    public function getJobInstanceById(string $id) : ?ilCronJob;
+
+    public function getJobInstance(
+        string $a_id,
+        string $a_component,
+        string $a_class,
+        bool $isCreationContext = false
+    ) : ?ilCronJob;
+
+    /**
+     * Get cron job configuration/execution data
+     * @param array|string|null $id
+     * @param bool $withInactiveJobsIncluded
+     * @return array<int, array<string, mixed>>
+     */
+    public function getCronJobData($id = null, bool $withInactiveJobsIncluded = true) : array;
+
+    public function registerJob(string $a_component, string $a_id, string $a_class, ?string $a_path) : void;
+
+    public function unregisterJob(string $a_component, array $a_xml_job_ids) : void;
+
+    public function createDefaultEntry(ilCronJob $job, string $component, string $class, ?string $path) : void;
+
+    /**
+     * @param bool $withOnlyActive
+     * @return array<int, array{0: ilCronJob, 1: array<string, mixed>}>
+     */
+    public function getPluginJobs(bool $withOnlyActive = false) : array;
+
+    public function resetJob(ilCronJob $job) : void;
+
+    public function updateJobResult(
+        ilCronJob $job,
+        ilObjUser $actor,
+        ilCronJobResult $result,
+        bool $wasManualExecution = false
+    ) : void;
+
+    public function updateRunInformation(string $jobId, int $runningTimestamp, int $aliveTimestamp) : void;
+
+    public function updateJobSchedule(ilCronJob $job, ?int $scheduleType, ?int $scheduleValue) : void;
+
+    public function activateJob(ilCronJob $job, ilObjUser $actor, bool $wasManuallyExecuted = false) : void;
+
+    public function deactivateJob(ilCronJob $job, ilObjUser $actor, bool $wasManuallyExecuted = false) : void;
+
     public function findAll() : ilCronJobCollection;
 }

--- a/Services/Cron/interfaces/interface.ilCronManagerInterface.php
+++ b/Services/Cron/interfaces/interface.ilCronManagerInterface.php
@@ -1,14 +1,34 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2018 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-/**
- * Class ilStrictCliCronManager
- * @author Michael Jansen <mjansen@databay.de>
- */
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
 interface ilCronManagerInterface
 {
-    /**
-     * Run all active jobs
-     */
-    public function runActiveJobs();
+    public function runActiveJobs(ilObjUser $actor) : void;
+
+    public function runJobManual(string $jobId, ilObjUser $actor) : bool;
+
+    public function resetJob(ilCronJob $job, ilObjUser $actor) : void;
+
+    public function activateJob(ilCronJob $job, ilObjUser $actor, bool $wasManuallyExecuted = false) : void;
+
+    public function deactivateJob(ilCronJob $job, ilObjUser $actor, bool $wasManuallyExecuted = false) : void;
+
+    public function isJobActive(string $jobId) : bool;
+
+    public function isJobInactive(string $jobId) : bool;
+
+    public function ping(string $jobId) : void;
 }

--- a/Services/Cron/interfaces/interface.ilCronServices.php
+++ b/Services/Cron/interfaces/interface.ilCronServices.php
@@ -14,17 +14,9 @@
  *
  *****************************************************************************/
 
-interface ilCronJobProvider
+interface ilCronServices
 {
-    /**
-     * @return ilCronJob[]
-     */
-    public function getCronJobInstances() : array;
+    public function manager() : ilCronManagerInterface;
 
-    /**
-     * @param string $jobId
-     * @return ilCronJob
-     * @throws OutOfBoundsException if the passed argument does not match any cron job
-     */
-    public function getCronJobInstance(string $jobId) : ilCronJob;
+    public function repository() : ilCronJobRepository;
 }

--- a/Services/Cron/service.xml
+++ b/Services/Cron/service.xml
@@ -6,5 +6,6 @@
 	</baseclasses>
 	<pluginslots>
 		<pluginslot id="crnhk" name="CronHook" />
-    </pluginslots>
+	</pluginslots>
+	<logging />
 </service>

--- a/Services/Cron/test/CronJobScheduleTest.php
+++ b/Services/Cron/test/CronJobScheduleTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 class CronJobScheduleTest extends TestCase
 {
     private DateTimeImmutable $now;
-    private DateTimeImmutable $this_quater_start;
+    private DateTimeImmutable $this_quarter_start;
 
     private function getJob(
         bool $has_flexible_schedule,
@@ -20,7 +20,7 @@ class CronJobScheduleTest extends TestCase
         int $schedule_type,
         ?int $schedule_value
     ) : ilCronJob {
-        $job_istance = new class($has_flexible_schedule, $default_schedule_type, $default_schedule_value, $schedule_type, $schedule_value) extends ilCronJob {
+        $job_instance = new class($has_flexible_schedule, $default_schedule_type, $default_schedule_value, $schedule_type, $schedule_value) extends ilCronJob {
             private bool $has_flexible_schedule;
             private int $default_schedule_type;
             private ?int $default_schedule_value;
@@ -80,11 +80,11 @@ class CronJobScheduleTest extends TestCase
             }
         };
 
-        $job_istance->setDateTimeProviver(function () : DateTimeImmutable {
+        $job_instance->setDateTimeProviver(function () : DateTimeImmutable {
             return $this->now;
         });
 
-        return $job_istance;
+        return $job_instance;
     }
 
     public function jobProvider() : array
@@ -93,7 +93,7 @@ class CronJobScheduleTest extends TestCase
         $this->now = new DateTimeImmutable('@' . time());
 
         $offset = (((int) $this->now->format('n')) - 1) % 3;
-        $this->this_quater_start = $this->now->modify("first day of -$offset month midnight");
+        $this->this_quarter_start = $this->now->modify("first day of -$offset month midnight");
 
         return [
             'Manual Run is Always Due' => [
@@ -176,23 +176,23 @@ class CronJobScheduleTest extends TestCase
                 null,
                 false
             ],
-            'Quaterly Schedule / Did not run this Quater' => [
+            'Quarterly Schedule / Did not run this Quarter' => [
                 $this->getJob(true, ilCronJob::SCHEDULE_TYPE_QUARTERLY, null, ilCronJob::SCHEDULE_TYPE_QUARTERLY, null),
                 false,
-                $this->this_quater_start->modify('-1 seconds')->getTimestamp(),
+                $this->this_quarter_start->modify('-1 seconds')->getTimestamp(),
                 ilCronJob::SCHEDULE_TYPE_QUARTERLY,
                 null,
                 true
             ],
-            'Quaterly Schedule / Did run this Quater' => [
+            'Quarterly Schedule / Did run this Quarter' => [
                 $this->getJob(true, ilCronJob::SCHEDULE_TYPE_QUARTERLY, null, ilCronJob::SCHEDULE_TYPE_QUARTERLY, null),
                 false,
-                $this->this_quater_start->modify('+30 seconds')->getTimestamp(),
+                $this->this_quarter_start->modify('+30 seconds')->getTimestamp(),
                 ilCronJob::SCHEDULE_TYPE_QUARTERLY,
                 null,
                 false
             ],
-            'Minutly Schedule / Did not run this Minute' => [
+            'Minutely Schedule / Did not run this Minute' => [
                 $this->getJob(true, ilCronJob::SCHEDULE_TYPE_IN_MINUTES, 1, ilCronJob::SCHEDULE_TYPE_IN_MINUTES, 1),
                 false,
                 $this->now->modify('-1 minute')->getTimestamp(),
@@ -200,7 +200,7 @@ class CronJobScheduleTest extends TestCase
                 1,
                 true
             ],
-            'Minutly Schedule / Did run this Minute' => [
+            'Minutely Schedule / Did run this Minute' => [
                 $this->getJob(true, ilCronJob::SCHEDULE_TYPE_IN_MINUTES, 1, ilCronJob::SCHEDULE_TYPE_IN_MINUTES, 1),
                 false,
                 $this->now->modify('-30 seconds')->getTimestamp(),

--- a/Services/LDAP/classes/class.ilLDAPCronSynchronization.php
+++ b/Services/LDAP/classes/class.ilLDAPCronSynchronization.php
@@ -106,7 +106,7 @@ class ilLDAPCronSynchronization extends ilCronJob
                         
                         $offset += $limit;
 
-                        ilCronManager::ping($this->getId());
+                        $DIC->cron()->manager()->ping($this->getId());
                     }
                     $this->counter++;
                 } else {

--- a/Services/LTI/classes/class.ilLTICronOutcomeService.php
+++ b/Services/LTI/classes/class.ilLTICronOutcomeService.php
@@ -66,7 +66,7 @@ class ilLTICronOutcomeService extends ilCronJob
 
         $status = \ilCronJobResult::STATUS_NO_ACTION;
 
-        $info = ilCronManager::getCronJobData($this->getId());
+        $info = $DIC->cron()->repository()->getCronJobData($this->getId());
         $last_ts = $info['job_status_ts'];
         if (!$last_ts) {
             $last_ts = time() - 24 * 3600;

--- a/Services/Mail/classes/class.ilMailCronNotification.php
+++ b/Services/Mail/classes/class.ilMailCronNotification.php
@@ -109,9 +109,8 @@ class ilMailCronNotification extends ilCronJob
         return true;
     }
 
-    public function activationWasToggled(bool $a_currently_active) : void
+    public function activationWasToggled(ilDBInterface $db, ilSetting $setting, bool $a_currently_active) : void
     {
-        $this->init();
-        $this->settings->set('mail_notification', (string) ((int) $a_currently_active));
+        $setting->set('mail_notification', (string) ((int) $a_currently_active));
     }
 }

--- a/Services/Membership/classes/Cron/class.ilMembershipCronNotifications.php
+++ b/Services/Membership/classes/Cron/class.ilMembershipCronNotifications.php
@@ -65,6 +65,8 @@ class ilMembershipCronNotifications extends ilCronJob
 
     public function run() : ilCronJobResult
     {
+        global $DIC;
+
         $this->logger->debug("===Member Notifications=== start");
 
         $status = ilCronJobResult::STATUS_NO_ACTION;
@@ -103,7 +105,7 @@ class ilMembershipCronNotifications extends ilCronJob
             foreach ($user_news_aggr as $user_id => $user_news) {
                 $this->logger->debug("sending mails to user " . $user_id . ", nr news: " . count($user_news));
                 $this->sendMail($user_id, $user_news, $last_run);
-                ilCronManager::ping($this->getId());
+                $DIC->cron()->manager()->ping($this->getId());
             }
             // mails were sent - set cron job status accordingly
             $status = ilCronJobResult::STATUS_OK;
@@ -450,13 +452,8 @@ class ilMembershipCronNotifications extends ilCronJob
         }
     }
 
-    public function activationWasToggled(bool $a_currently_active) : void
+    public function activationWasToggled(ilDBInterface $db, ilSetting $setting, bool $a_currently_active) : void
     {
-        global $DIC;
-
-        $ilSetting = $DIC['ilSetting'];
-
-        // propagate cron-job setting to object setting
-        $ilSetting->set("crsgrp_ntf", $a_currently_active);
+        $setting->set("crsgrp_ntf", (string) ((int) $a_currently_active));
     }
 }

--- a/Services/Membership/classes/Cron/class.ilMembershipCronNotificationsData.php
+++ b/Services/Membership/classes/Cron/class.ilMembershipCronNotificationsData.php
@@ -267,7 +267,9 @@ class ilMembershipCronNotificationsData
      */
     protected function ping() : void
     {
-        ilCronManager::ping($this->cron_id);
+        global $DIC;
+
+        $DIC->cron()->manager()->ping($this->cron_id);
     }
 
     /**

--- a/Services/Tracking/classes/class.ilLPCronObjectStatistics.php
+++ b/Services/Tracking/classes/class.ilLPCronObjectStatistics.php
@@ -158,7 +158,7 @@ class ilLPCronObjectStatistics extends ilCronJob
                     $count++;
                     
                     // #17928
-                    ilCronManager::ping($this->getId());
+                    $DIC->cron()->manager()->ping($this->getId());
                 }
             }
         }
@@ -198,7 +198,7 @@ class ilLPCronObjectStatistics extends ilCronJob
             $count++;
             
             // #17928
-            ilCronManager::ping($this->getId());
+            $DIC->cron()->manager()->ping($this->getId());
         }
         
         return $count;
@@ -239,7 +239,7 @@ class ilLPCronObjectStatistics extends ilCronJob
             $count++;
             
             // #17928
-            ilCronManager::ping($this->getId());
+            $DIC->cron()->manager()->ping($this->getId());
         }
         
         return $count;

--- a/Services/Tracking/classes/object_statistics/class.ilLPObjectStatisticsGUI.php
+++ b/Services/Tracking/classes/object_statistics/class.ilLPObjectStatisticsGUI.php
@@ -486,7 +486,7 @@ class ilLPObjectStatisticsGUI extends ilLearningProgressBaseGUI
         $lng = $DIC['lng'];
         
         include_once "Services/Cron/classes/class.ilCronManager.php";
-        if (!ilCronManager::isJobActive("lp_object_statistics")) {
+        if (!$DIC->cron()->manager()->isJobActive("lp_object_statistics")) {
             ilUtil::sendInfo($lng->txt("trac_cron_info"));
         }
     }

--- a/Services/User/classes/class.ilCronDeleteInactiveUserAccounts.php
+++ b/Services/User/classes/class.ilCronDeleteInactiveUserAccounts.php
@@ -34,6 +34,7 @@ class ilCronDeleteInactiveUserAccounts extends ilCronJob
     private ilObjectDataCache $objectDataCache;
     private \ILIAS\HTTP\GlobalHttpState $http;
     private \ILIAS\Refinery\Factory $refinery;
+    private ilCronJobRepository $cronRepository;
 
     public function __construct()
     {
@@ -58,6 +59,10 @@ class ilCronDeleteInactiveUserAccounts extends ilCronJob
 
             if (isset($DIC['rbacreview'])) {
                 $this->rbacReview = $DIC->rbac()->review();
+            }
+
+            if (isset($DIC['cron.repository'])) {
+                $this->cronRepository = $DIC->cron()->repository();
             }
 
             if (isset($DIC['ilSetting'])) {
@@ -237,7 +242,7 @@ class ilCronDeleteInactiveUserAccounts extends ilCronJob
     
     protected function calculateDeletionData(int $date_for_deletion) : int
     {
-        $cron_timing = ilCronManager::getCronJobData($this->getId());
+        $cron_timing = $this->cronRepository->getCronJobData($this->getId());
         $time_difference = 0;
         $multiplier = 1;
 

--- a/cron/cron.php
+++ b/cron/cron.php
@@ -21,12 +21,14 @@ $cron = new ilCronStartUp(
 );
 
 try {
+    global $DIC;
+
     $cron->authenticate();
 
-    $cronManager = new ilStrictCliCronManager(
-        new ilCronManager($DIC->settings(), $DIC->logger()->root())
+    $strictCronManager = new ilStrictCliCronManager(
+        $DIC->cron()->manager()
     );
-    $cronManager->runActiveJobs();
+    $strictCronManager->runActiveJobs($DIC->user());
 
     $cron->logout();
 } catch (Exception $e) {

--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -378,6 +378,11 @@ class Container extends \Pimple\Container
         return new \ILIAS\Style\Content\Service($this);
     }
 
+    public function cron() : \ilCronServices
+    {
+        return new \ilCronServicesImpl($this);
+    }
+
     /**
      * Note: Only use isDependencyAvailable if strictly required. The need for this,
      * mostly points to some underlying problem needing to be solved instead of using this.


### PR DESCRIPTION
This PR changes the nature of most `ilCronManager` methods from `static` to `instance`, which allows `Dependency Injection` and more `Unit Tests` in the future.

Depends on: (#3957 or #3954) and #3966

@klees With this PR I'll get rid of almost all static method calls in `Services/Cron` and used a lot (more) dependency injection. This should prevent issues like mentioned here: https://github.com/ILIAS-eLearning/ILIAS/commit/97b50e9c31a3ed21ab0ef8db24df9683c649194f .
To achieve this, I'll had to slightly modify [`ilComponentDefinitionsStoredObjective`](https://github.com/ILIAS-eLearning/ILIAS/pull/3956/files#diff-efcbdd1c8b2ea080a6b6dc4a6a09ccbc124be47fc6fe127a3a3c0d6d60d1236c). Furtheremore these code changes depend on #3966 .