### PR TITLE
Fix Mime Type Detection for stream

### DIFF
--- a/src/ResourceStorage/Resource/InfoResolver/StreamInfoResolver.php
+++ b/src/ResourceStorage/Resource/InfoResolver/StreamInfoResolver.php
@@ -60,6 +60,9 @@ class StreamInfoResolver extends AbstractInfoResolver implements InfoResolver
         if (class_exists('finfo')) {
             $finfo = finfo_open(FILEINFO_MIME_TYPE);
             $this->mime_type = finfo_buffer($finfo, $this->file_stream->getContents());
+            if ($this->file_stream->isSeekable()) {
+                $this->file_stream->rewind();
+            }
         }
     }
 
@@ -73,6 +76,10 @@ class StreamInfoResolver extends AbstractInfoResolver implements InfoResolver
                 $this->size = mb_strlen($this->file_stream->getContents(), '8bit');
             } else {
                 $this->size = strlen($this->file_stream->getContents());
+            }
+            
+            if ($this->file_stream->isSeekable()) {
+                $this->file_stream->rewind();
             }
         }
     }


### PR DESCRIPTION
When using getContents() on a stream the position is moved forward, thus
a consecutive call on getContents() will receive an empty string back.
As we are calling this twice here (in getMimeType and in getFileSize)
this will leed to undetected mime-types (second call). To avoid any
troubles I rewind the position both times and check first if strings are
seekable to avoid throwing an exception.

See: https://mantis.ilias.de/view.php?id=31948