### PR TITLE
fixed DynamicInputDataIterator::current().

### DIFF
--- a/src/UI/Implementation/Component/Input/DynamicInputDataIterator.php
+++ b/src/UI/Implementation/Component/Input/DynamicInputDataIterator.php
@@ -25,12 +25,12 @@ class DynamicInputDataIterator implements Iterator
     {
         if ($this->valid()) {
             $entry = [];
-            // For the dynamic input, the values for a field "foo" a dynamically
-            // created input are all listed in one field "foo" in the input. For
-            // every subsequent input, we need to pick the next value from that
-            // list and map it to "foo" for further processing.
-            foreach ($this->post_data as $key => $data) {
-                $entry[$key] = $data[$this->index];
+            // for each input of the dynamic input template, the input data must
+            // be mapped to the rendered name, similar to one delivered by
+            // DynamicInputsNameSource for further processing.
+            foreach ($this->post_data as $input_name => $data) {
+                $dynamic_input_name = "$this->parent_input_name[$input_name][]";
+                $entry[$dynamic_input_name] = $data[$this->index];
             }
 
             return new ArrayInputData($entry);

--- a/tests/UI/Component/Input/DynamicInputDataIteratorTest.php
+++ b/tests/UI/Component/Input/DynamicInputDataIteratorTest.php
@@ -75,9 +75,10 @@ class DynamicInputDataIteratorTest extends TestCase
             $current
         );
 
+        $rendered_dynamic_input_name = "{$parent_input_name}[$dynamic_input_name][]";
         $this->assertEquals(
             $test_value,
-            $current->getOr($dynamic_input_name, null)
+            $current->getOr($rendered_dynamic_input_name, null)
         );
     }
 


### PR DESCRIPTION
The solution introduced by @klees in https://github.com/srsolutionsag/ILIAS/pull/12 was almost right. I forgot that the key when iterating is the submitted name of the input, but in order to delegate it with `withInput()` it must be the same as the rendered name. Therefore the key must be used similarly as in `DynamicInputsNameSource::getNewName()`.