### PR TITLE
Remove type bug in STR Utils

### DIFF
--- a/Services/Utilities/classes/class.ilStr.php
+++ b/Services/Utilities/classes/class.ilStr.php
@@ -34,7 +34,7 @@ class ilStr
         }
     }
     
-    public static function strPos(string $a_haystack, string $a_needle, ?int $a_offset = null) : int
+    public static function strPos(string $a_haystack, string $a_needle, ?int $a_offset = null)
     {
         if (function_exists("mb_strpos")) {
             return mb_strpos($a_haystack, $a_needle, $a_offset, "UTF-8");


### PR DESCRIPTION
I saw that other fix and this is the same as the other one.

https://www.php.net/manual/de/function.strpos.php

The function could return `int|false`. In PHP 8 unified types are possible but i dont know if ilias would/want to support these so i just used the same fix.
