### PR TITLE
PRG: skip update for LPcompleted event 

### DIFF
--- a/Modules/StudyProgramme/classes/class.ilObjStudyProgramme.php
+++ b/Modules/StudyProgramme/classes/class.ilObjStudyProgramme.php
@@ -1725,14 +1725,10 @@ class ilObjStudyProgramme extends ilContainer
         $now = new DateTimeImmutable();
         foreach ($prg->getProgressesOf($user_id) as $progress) {
             $progress_deadline = $progress->getDeadline();
-            $succeed = (is_null($progress_deadline) || $progress_deadline >= $now)
-                && !in_array($progress->getStatus(), [
-                    ilStudyProgrammeProgress::STATUS_COMPLETED,
-                    ilStudyProgrammeProgress::STATUS_NOT_RELEVANT,
-                    ilStudyProgrammeProgress::STATUS_FAILED
-                ]);
-
-            if ($succeed) {
+            if (
+                (is_null($progress_deadline) || $progress_deadline >= $now)
+                && $progress->getStatus() === ilStudyProgrammeProgress::STATUS_IN_PROGRESS
+            ) {
                 $prg->succeed($progress->getId(), $obj_id);
             }
         }


### PR DESCRIPTION
- if deadline is reached 
- or progress status is in a 'final' state

Amends accidentally completing already failed progresses; avoids updating the "completed by"-column by last finished course.
