### PR TITLE
Rename duplicated language variable.

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -16713,7 +16713,7 @@ common#:#file_system_clean_temp_dir_cron_info#:#Dieser Cronjob räumt das temp-V
 violation#:#not_a_string#:#Wert ist keine Zeichenkette
 common#:#actions_for#:#Aktionen für %s
 validation#:#not_greater_than_or_equal#:#Der Wert ist nicht größer oder gleich '%s'.
-validation#:#not_an_array#:#Wert ist kein Feld
+validation#:#no_array#:#Wert ist kein Feld
 validation#:#not_less_than_or_equal#:#Der Wert ist nicht kleiner oder gleich '%s'.
 skmg#:#skmg_add_skill_tree#:#Kompetenzbaum hinzufügen
 skmg#:#skmg_skill_tree#:#Kompetenzbaum

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -16684,7 +16684,7 @@ common#:#file_system_clean_temp_dir_cron_info#:#This job cleans the ILIAS temp-d
 violation#:#not_a_string#:#Given value is not a String
 common#:#actions_for#:#Actions for %s
 validation#:#not_greater_than_or_equal#:#The value is not greater than or equal '%s'.
-validation#:#not_an_array#:#Given value is not an array
+validation#:#no_array#:#Given value is not an array
 validation#:#not_less_than_or_equal#:#The value is not less than or equal '%s'.
 skmg#:#skmg_add_skill_tree#:#Add Competence Tree
 skmg#:#skmg_skill_tree#:#Competence Tree

--- a/src/Refinery/Random/Transformation/ShuffleTransformation.php
+++ b/src/Refinery/Random/Transformation/ShuffleTransformation.php
@@ -41,7 +41,7 @@ class ShuffleTransformation implements Transformation
     public function transform($array)
     {
         if (!is_array($array)) {
-            throw new ConstraintViolationException('not an array', 'not_an_array');
+            throw new ConstraintViolationException('not an array', 'no_array');
         }
         $this->seed->seedRandomGenerator();
         \shuffle($array);


### PR DESCRIPTION
Rename a duplicated language variable:  `not_an_array` to `no_array`.