### PR TITLE
Session: fix error giving an int as setting-default

### DIFF
--- a/Services/Authentication/classes/class.ilSession.php
+++ b/Services/Authentication/classes/class.ilSession.php
@@ -359,7 +359,8 @@ class ilSession
             return time() + self::getIdleValue($fixedMode);
         } elseif ($ilSetting->get('session_handling_type', (string) self::SESSION_HANDLING_FIXED) == (string) self::SESSION_HANDLING_LOAD_DEPENDENT) {
             // load dependent session settings
-            return time() + (int) ($ilSetting->get('session_max_idle', ilSessionControl::DEFAULT_MAX_IDLE) * 60);
+            $max_idle = $ilSetting->get('session_max_idle') ?? ilSessionControl::DEFAULT_MAX_IDLE;
+            return time() + (int) $max_idle * 60;
         }
     }
 


### PR DESCRIPTION
There is typechecking for settings-defaults now, and int-defaults should be handled differently.