### PR TITLE
Fix escaping of \\

### DIFF
--- a/Services/MathJax/classes/class.ilMathJax.php
+++ b/Services/MathJax/classes/class.ilMathJax.php
@@ -341,18 +341,15 @@ class ilMathJax
                 }
 
                 // omit the html newlines added by the ILIAS page editor
-                // handle custom newlines in JSMath (still needed?)
                 $tex = str_replace('<br>', '', $tex);
                 $tex = str_replace('<br/>', '', $tex);
                 $tex = str_replace('<br />', '', $tex);
-                $tex = str_replace('\\\\', '\\cr', $tex);
 
                 // check, if tags go across div borders
                 if (is_int(ilStr::strPos($tex, '<div>')) || is_int(ilStr::strPos($tex, '</div>'))) {
                     // keep the original including delimiters, continue search behind
                     $cpos = $epos + ilStr::strLen($a_end);
-                }
-                else {
+                } else {
                     switch ($this->engine) {
                         case self::ENGINE_CLIENT:
                             // prepare code for processing in the browser
@@ -393,8 +390,7 @@ class ilMathJax
                     // continue search behind replacement
                     $cpos = $spos + ilStr::strLen($replacement);
                 }
-            }
-            else {
+            } else {
                 // end delimiter position not found => stop search
                 break;
             }


### PR DESCRIPTION
This fixes the escaping of \\ in MathJax as reported in https://mantis.ilias.de/view.php?id=31788. I tested this with server- and client-side rendering. With client-side rendering this also fixes the rendering of newlines (\\). When using server-side rendering this does still not produce an output when a newline is inserted, but instead of showing an Error it leads to an empty image (at least on my setup).