### PR TITLE
UI/PresentationTable: optional fields for rows

### DIFF
--- a/src/UI/Implementation/Component/Table/PresentationRow.php
+++ b/src/UI/Implementation/Component/Table/PresentationRow.php
@@ -21,17 +21,17 @@ class PresentationRow implements T\PresentationRow
     /**
      * @var	Button|Dropdown|null
      */
-    private $action;
+    private $action = null;
 
     protected Signal $show_signal;
     protected Signal $close_signal;
     protected Signal $toggle_signal;
     private ?string $headline;
-    private ?string $subheadline;
-    private array $important_fields;
+    private ?string $subheadline = null;
+    private array $important_fields = [];
     private Descriptive $content;
-    private string $further_fields_headline;
-    private array $further_fields;
+    private ?string $further_fields_headline = null;
+    private array $further_fields = [];
     private array $data;
     protected SignalGeneratorInterface $signal_generator;
 
@@ -177,7 +177,7 @@ class PresentationRow implements T\PresentationRow
     /**
      * @inheritdoc
      */
-    public function getFurtherFieldsHeadline() : string
+    public function getFurtherFieldsHeadline() : ?string
     {
         return $this->further_fields_headline;
     }

--- a/src/UI/Implementation/Component/Table/Renderer.php
+++ b/src/UI/Implementation/Component/Table/Renderer.php
@@ -44,9 +44,9 @@ class Renderer extends AbstractComponentRenderer
                 $tpl->parseCurrentBlock();
             }
         }
-
         $row_mapping = $component->getRowMapping();
         $data = $component->getData();
+
         foreach ($data as $record) {
             $row = $row_mapping(
                 new PresentationRow($component->getSignalGenerator()),
@@ -90,7 +90,10 @@ class Renderer extends AbstractComponentRenderer
 
         $tpl->setVariable("HEADLINE", $component->getHeadline());
         $tpl->setVariable("TOGGLE_SIGNAL", $sig_toggle);
-        $tpl->setVariable("SUBHEADLINE", $component->getSubheadline());
+        $subheadline = $component->getSubheadline();
+        if ($subheadline) {
+            $tpl->setVariable("SUBHEADLINE", $subheadline);
+        }
 
         foreach ($component->getImportantFields() as $label => $value) {
             $tpl->setCurrentBlock("important_field");
@@ -104,17 +107,23 @@ class Renderer extends AbstractComponentRenderer
         $tpl->setVariable("DESCLIST", $default_renderer->render($component->getContent()));
 
         $further_fields_headline = $component->getFurtherFieldsHeadline();
-        if ($further_fields_headline) {
-            $tpl->setVariable("FURTHER_FIELDS_HEADLINE", $further_fields_headline);
-        }
+        $further_fields = $component->getFurtherFields();
 
-        foreach ($component->getFurtherFields() as $label => $value) {
-            $tpl->setCurrentBlock("further_field");
-            if (is_string($label)) {
-                $tpl->setVariable("FIELD_LABEL", $label);
+        if (count($further_fields) > 0) {
+            $tpl->touchBlock("has_further_fields");
+
+            if ($further_fields_headline) {
+                $tpl->setVariable("FURTHER_FIELDS_HEADLINE", $further_fields_headline);
             }
-            $tpl->setVariable("FIELD_VALUE", $value);
-            $tpl->parseCurrentBlock();
+
+            foreach ($further_fields as $label => $value) {
+                $tpl->setCurrentBlock("further_field");
+                if (is_string($label)) {
+                    $tpl->setVariable("FIELD_LABEL", $label);
+                }
+                $tpl->setVariable("FIELD_VALUE", $value);
+                $tpl->parseCurrentBlock();
+            }
         }
 
         $action = $component->getAction();

--- a/src/UI/templates/default/Table/table.less
+++ b/src/UI/templates/default/Table/table.less
@@ -90,8 +90,11 @@
 
         .il-table-presentation-desclist {
             //Using column mixin, to make this responsive
-            .make-sm-column(7);
-            padding-left: 0;
+            padding-right: @padding-small-horizontal;
+            &.desclist-column {
+                .make-sm-column(7);
+                padding-left: 0;
+            }
         }
 
         .il-table-presentation-details {

--- a/src/UI/templates/default/Table/tpl.presentationrow.html
+++ b/src/UI/templates/default/Table/tpl.presentationrow.html
@@ -13,7 +13,7 @@
 	<div class="il-table-presentation-row-contents">
 
 		<div class="il-table-presentation-actions">
-			<!-- BEGIN button -->{BUTTON}<br><!-- END button -->
+			<!-- BEGIN button -->{BUTTON}<br /><!-- END button -->
 		</div>
 
 		<div class="il-table-presentation-row-header">
@@ -21,7 +21,7 @@
 			<h4 class="il-table-presentation-row-header-headline" onClick="$(document).trigger('{TOGGLE_SIGNAL}');">
 				{HEADLINE}
 				<!-- BEGIN subheadline -->
-				<br>
+				<br />
 				<small>
 					{SUBHEADLINE}
 				</small>
@@ -41,10 +41,11 @@
 
 
 		<div class="il-table-presentation-row-expanded">
-			<div class="il-table-presentation-desclist inline">
+			<div class="il-table-presentation-desclist inline<!-- BEGIN has_further_fields --> desclist-column<!-- END has_further_fields -->">
 				{DESCLIST}
 			</div>
 
+			<!-- BEGIN further_fields_section -->
 			<div class="il-table-presentation-details inline">
 
 				<div class="il-table-presentation-fields">
@@ -67,6 +68,7 @@
 				</div>
 
 			</div>
+			<!-- END further_fields_section -->
 		</div>
 
 	</div>

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -8587,6 +8587,9 @@ fieldset[disabled] .il-table-presentation-viewcontrols .btn-default:not(.disable
   margin-right: 0;
 }
 .il-table-presentation-row .il-table-presentation-row-expanded .il-table-presentation-desclist {
+  padding-right: 6px;
+}
+.il-table-presentation-row .il-table-presentation-row-expanded .il-table-presentation-desclist.desclist-column {
   position: relative;
   min-height: 1px;
   padding-right: 15px;
@@ -8594,7 +8597,7 @@ fieldset[disabled] .il-table-presentation-viewcontrols .btn-default:not(.disable
   padding-left: 0;
 }
 @media (min-width: 768px) {
-  .il-table-presentation-row .il-table-presentation-row-expanded .il-table-presentation-desclist {
+  .il-table-presentation-row .il-table-presentation-row-expanded .il-table-presentation-desclist.desclist-column {
     float: left;
     width: 58.33333333%;
   }

--- a/tests/UI/Base.php
+++ b/tests/UI/Base.php
@@ -384,4 +384,14 @@ abstract class ILIAS_UI_TestBase extends TestCase
         $html = str_replace(" <", "<", $html);
         return trim($html);
     }
+
+    /**
+     * A naive replacement of all il_signal-ids with dots
+     * to ease comparisons of rendered output.
+     */
+    protected function brutallyTrimSignals(string $html) : string
+    {
+        $html = preg_replace('/il_signal_(\w+)/', "il_signal...", $html);
+        return $html;
+    }
 }

--- a/tests/UI/Component/Table/PresentationTest.php
+++ b/tests/UI/Component/Table/PresentationTest.php
@@ -6,6 +6,7 @@ require_once("libs/composer/vendor/autoload.php");
 require_once(__DIR__ . "/../../Base.php");
 
 use ILIAS\UI\Implementation as I;
+use ILIAS\UI\Component as C;
 use ILIAS\UI\Implementation\Component\Table\PresentationRow;
 
 /**
@@ -25,12 +26,12 @@ class PresentationTest extends ILIAS_UI_TestBase
         $f = $this->getFactory();
         $this->assertInstanceOf("ILIAS\\UI\\Component\\Table\\Factory", $f);
 
-        $pt = $f->presentation('title', array(), function () {
+        $pt = $f->presentation('title', [], function () {
         });
         $this->assertInstanceOf("ILIAS\\UI\\Component\\Table\\Presentation", $pt);
 
         $this->assertEquals("title", $pt->getTitle());
-        $this->assertEquals(array(), $pt->getViewControls());
+        $this->assertEquals([], $pt->getViewControls());
         $this->assertInstanceOf(Closure::class, $pt->getRowMapping());
 
         $pt = $pt
@@ -44,7 +45,7 @@ class PresentationTest extends ILIAS_UI_TestBase
     {
         $r = $this->getDefaultRenderer();
         $f = $this->getFactory();
-        $pt = $f->presentation('title', array(), function () {
+        $pt = $f->presentation('title', [], function () {
         });
         $expected = '' .
             '<div class="il-table-presentation">' .
@@ -57,7 +58,7 @@ class PresentationTest extends ILIAS_UI_TestBase
     public function testRowConstruction() : void
     {
         $f = $this->getFactory();
-        $pt = $f->presentation('title', array(), function () {
+        $pt = $f->presentation('title', [], function () {
         });
         $row = new PresentationRow($pt->getSignalGenerator());
 
@@ -85,6 +86,198 @@ class PresentationTest extends ILIAS_UI_TestBase
         $this->assertEquals(
             array("ff1" => "fv1"),
             $row->withFurtherFields(array("ff1" => "fv1"))->getFurtherFields()
+        );
+    }
+
+    public function getUIFactory() : NoUIFactory
+    {
+        $factory = new class extends NoUIFactory {
+            public function button() : C\Button\Factory
+            {
+                return new I\Component\Button\Factory(
+                    new I\Component\SignalGenerator()
+                );
+            }
+            public function symbol() : ILIAS\UI\Component\Symbol\Factory
+            {
+                return new I\Component\Symbol\Factory(
+                    new I\Component\Symbol\Icon\Factory(),
+                    new I\Component\Symbol\Glyph\Factory(),
+                    new I\Component\Symbol\Avatar\Factory()
+                );
+            }
+        };
+        $factory->sig_gen = new I\Component\SignalGenerator();
+        return $factory;
+    }
+
+    protected function getDummyData() : array
+    {
+        return [[
+            'headline' => 'some title',
+            'subhead' => 'some type',
+            'important_fields' => ['important-1','important-2'],
+            'content' => ['1st' => 'first content', '2nd' => 'second content'],
+            'further_headline' => 'further fields',
+            'further_fields' => ['f-1' => 'further', 'f-2' => 'way further'],
+            'action' => 'do'
+        ]];
+    }
+
+    protected function brutallyTrimSignals(string $haystack) : string
+    {
+        $offset = 0;
+        while ($cur = strpos($haystack, 'il_signal_', $offset)) {
+            $right_pos = strpos($haystack, "');", $cur + 1);
+            $left = substr($haystack, 0, $cur);
+            $right = substr($haystack, $right_pos);
+            $haystack = $left . "il_signal_..." . $right;
+            $offset = $right_pos;
+        }
+        return $haystack;
+    }
+
+    public function testFullRendering() : void
+    {
+        $mapping = function ($row, $record, $ui_factory, $environment) {
+            return $row
+                ->withHeadline($record['headline'])
+                ->withSubheadline($record['subhead'])
+                ->withImportantFields($record['important_fields'])
+                ->withContent((new I\Component\Listing\Descriptive($record['content'])))
+                ->withFurtherFieldsHeadline($record['further_headline'])
+                ->withFurtherFields($record['further_fields'])
+                ->withAction((new I\Component\Button\Standard($record['action'], '#')));
+        };
+
+        $expected = <<<EXP
+<div class="il-table-presentation">
+    <h3 class="ilHeader">title</h3>
+    <div class="il-table-presentation-data">
+        <div class="il-table-presentation-row row collapsed" id="id_1">
+
+            <div class="il-table-presentation-row-controls">
+                <div class="il-table-presentation-row-controls-expander inline">
+                    <a class="glyph" href="#" aria-label="expand_content" id="id_2">
+                        <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
+                    </a>
+                </div>
+                <div class="il-table-presentation-row-controls-collapser">
+                    <a class="glyph" href="#" aria-label="collapse_content" id="id_3">
+                        <span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span>
+                    </a>
+                </div>
+            </div>
+
+            <div class="il-table-presentation-row-contents">
+                <div class="il-table-presentation-actions">
+                    <button class="btn btn-default" data-action="#" id="id_5">do</button>
+                    <br />
+                </div>
+                <div class="il-table-presentation-row-header">
+                    <h4 class="il-table-presentation-row-header-headline" onClick="$(document).trigger('il_signal_...');">some title<br /><small>some type</small>
+                    </h4>
+                    <div class="il-table-presentation-row-header-fields">important-1|important-2|<button class="btn btn-link" id="id_4">presentation_table_more</button></div>
+                </div>
+
+                <div class="il-table-presentation-row-expanded">
+                    <div class="il-table-presentation-desclist inline desclist-column">
+                        <dl>
+                            <dt>1st</dt>
+                            <dd>first content</dd>
+                            <dt>2nd</dt>
+                            <dd>second content</dd>
+                        </dl>
+                    </div>
+                    
+                    <div class="il-table-presentation-details inline">
+                        <div class="il-table-presentation-fields">
+                            <h5>further fields</h5>
+                            <span class="il-item-property-name">f-1</span>
+                            <span class="il-item-property-value">further</span>
+                            <br />
+                            <span class="il-item-property-name">f-2</span>
+                            <span class="il-item-property-value">way further</span>
+                            <br />
+                        </div>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+    </div>
+</div>
+EXP;
+
+        $r = $this->getDefaultRenderer();
+        $f = $this->getFactory();
+        $pt = $f->presentation('title', [], $mapping);
+        $actual = $r->render($pt->withData($this->getDummyData()));
+        $this->assertHTMLEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($this->brutallyTrimSignals($actual))
+        );
+    }
+
+
+    public function testMinimalRendering() : void
+    {
+        $mapping = function ($row, $record, $ui_factory, $environment) {
+            return $row
+                ->withHeadline($record['headline'])
+                ->withContent((new I\Component\Listing\Descriptive($record['content'])));
+        };
+
+        $expected = <<<EXP
+<div class="il-table-presentation">
+    <h3 class="ilHeader">title</h3>
+    <div class="il-table-presentation-data">
+        <div class="il-table-presentation-row row collapsed" id="id_1">
+
+            <div class="il-table-presentation-row-controls">
+                <div class="il-table-presentation-row-controls-expander inline">
+                    <a class="glyph" href="#" aria-label="expand_content" id="id_2">
+                        <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
+                    </a>
+                </div>
+                <div class="il-table-presentation-row-controls-collapser">
+                    <a class="glyph" href="#" aria-label="collapse_content" id="id_3">
+                        <span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span>
+                    </a>
+                </div>
+            </div>
+
+            <div class="il-table-presentation-row-contents">
+                <div class="il-table-presentation-actions"></div>
+                <div class="il-table-presentation-row-header">
+                    <h4 class="il-table-presentation-row-header-headline" onClick="$(document).trigger('il_signal_...');">some title</h4>
+                    <div class="il-table-presentation-row-header-fields">
+                        <button class="btn btn-link" id="id_4">presentation_table_more</button>
+                    </div>
+                </div>
+                <div class="il-table-presentation-row-expanded">
+                    <div class="il-table-presentation-desclist inline">
+                        <dl>
+                            <dt>1st</dt>
+                            <dd>first content</dd>
+                            <dt>2nd</dt>
+                            <dd>second content</dd>
+                        </dl>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</div>
+EXP;
+        $r = $this->getDefaultRenderer();
+        $f = $this->getFactory();
+        $pt = $f->presentation('title', [], $mapping);
+        $actual = $r->render($pt->withData($this->getDummyData()));
+        $this->assertHTMLEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($this->brutallyTrimSignals($actual))
         );
     }
 }

--- a/tests/UI/Component/Table/PresentationTest.php
+++ b/tests/UI/Component/Table/PresentationTest.php
@@ -124,19 +124,6 @@ class PresentationTest extends ILIAS_UI_TestBase
         ]];
     }
 
-    protected function brutallyTrimSignals(string $haystack) : string
-    {
-        $offset = 0;
-        while ($cur = strpos($haystack, 'il_signal_', $offset)) {
-            $right_pos = strpos($haystack, "');", $cur + 1);
-            $left = substr($haystack, 0, $cur);
-            $right = substr($haystack, $right_pos);
-            $haystack = $left . "il_signal_..." . $right;
-            $offset = $right_pos;
-        }
-        return $haystack;
-    }
-
     public function testFullRendering() : void
     {
         $mapping = function ($row, $record, $ui_factory, $environment) {
@@ -175,7 +162,7 @@ class PresentationTest extends ILIAS_UI_TestBase
                     <br />
                 </div>
                 <div class="il-table-presentation-row-header">
-                    <h4 class="il-table-presentation-row-header-headline" onClick="$(document).trigger('il_signal_...');">some title<br /><small>some type</small>
+                    <h4 class="il-table-presentation-row-header-headline" onClick="$(document).trigger('il_signal...');">some title<br /><small>some type</small>
                     </h4>
                     <div class="il-table-presentation-row-header-fields">important-1|important-2|<button class="btn btn-link" id="id_4">presentation_table_more</button></div>
                 </div>
@@ -250,7 +237,7 @@ EXP;
             <div class="il-table-presentation-row-contents">
                 <div class="il-table-presentation-actions"></div>
                 <div class="il-table-presentation-row-header">
-                    <h4 class="il-table-presentation-row-header-headline" onClick="$(document).trigger('il_signal_...');">some title</h4>
+                    <h4 class="il-table-presentation-row-header-headline" onClick="$(document).trigger('il_signal...');">some title</h4>
                     <div class="il-table-presentation-row-header-fields">
                         <button class="btn btn-link" id="id_4">presentation_table_more</button>
                     </div>


### PR DESCRIPTION
initialize (and optionalize) properties of PresentationTables's rows.
Expand width of presentationlist, when no further fields are present.
Add rendering tests.