### PR TITLE
didactic templates in create form

### DIFF
--- a/Modules/Glossary/classes/class.ilObjGlossaryGUI.php
+++ b/Modules/Glossary/classes/class.ilObjGlossaryGUI.php
@@ -349,6 +349,9 @@ class ilObjGlossaryGUI extends ilObjectGUI
         $tm->setRequired(true);
         $form->addItem($tm);
 
+        // didactic template
+        $form = $this->initDidacticTemplate($form);
+
         $form->addCommandButton("save", $this->lng->txt($a_new_type . "_add"));
         $form->addCommandButton("cancel", $this->lng->txt("cancel"));
 
@@ -389,6 +392,12 @@ class ilObjGlossaryGUI extends ilObjectGUI
             $newObj->create();
             
             $this->putObjectInTree($newObj);
+
+            // apply didactic template?
+            $dtpl = $this->getDidacticTemplateVar("dtpl");
+            if ($dtpl) {
+                $newObj->applyDidacticTemplate($dtpl);
+            }
 
             // always send a message
             ilUtil::sendSuccess($this->lng->txt("glo_added"), true);


### PR DESCRIPTION
Selecting and applying didactic templates missing in the create dialogue, only possible via the settings tab.
see discussion: https://docu.ilias.de/goto_docu_frm_3454_8030.html