### PR TITLE
ILIAS 8: inherit content styles / Refactoring

### DIFF
--- a/Modules/Blog/Export/BlogHtmlExport.php
+++ b/Modules/Blog/Export/BlogHtmlExport.php
@@ -40,6 +40,7 @@ class BlogHtmlExport
     protected bool $include_comments = false;
     protected bool $print_version = false;
     protected static bool $export_key_set = false;
+    protected \ILIAS\Style\Content\Object\ObjectFacade $content_style_domain;
 
     public function __construct(
         \ilObjBlogGUI $blog_gui,
@@ -71,6 +72,13 @@ class BlogHtmlExport
                 \ilHTMLExportViewLayoutProvider::HTML_EXPORT_RENDERING,
                 true
             );
+        }
+
+        $cs = $DIC->contentStyle();
+        if ($this->blog_gui->getIdType() == \ilObject2GUI::REPOSITORY_NODE_ID) {
+            $this->content_style_domain = $cs->domain()->styleForRefId($this->blog->getRefId());
+        } else {
+            $this->content_style_domain = $cs->domain()->styleForObjId($this->blog->getId());
         }
     }
     protected function init() : void
@@ -104,7 +112,10 @@ class BlogHtmlExport
     {
         $this->initDirectories();
         $this->export_util->exportSystemStyle();
-        $this->export_util->exportCOPageFiles($this->blog->getStyleSheetId(), "blog");
+        $this->export_util->exportCOPageFiles(
+            $this->content_style_domain->getEffectiveStyleId(),
+            "blog"
+        );
 
         // export banner
         $this->exportBanner();
@@ -346,7 +357,7 @@ class BlogHtmlExport
         $location_stylesheet = \ilUtil::getStyleSheetLocation();
         $this->global_screen->layout()->meta()->addCss($location_stylesheet);
         $this->global_screen->layout()->meta()->addCss(
-            \ilObjStyleSheet::getContentStylePath($this->blog->getStyleSheetId())
+            \ilObjStyleSheet::getContentStylePath($this->content_style_domain->getEffectiveStyleId())
         );
         \ilPCQuestion::resetInitialState();
 

--- a/Modules/Blog/Export/class.ilBlogDataSet.php
+++ b/Modules/Blog/Export/class.ilBlogDataSet.php
@@ -26,7 +26,17 @@ class ilBlogDataSet extends ilDataSet
 {
     protected ilObjBlog $current_blog;
     public static array $style_map = array();
-    
+    protected \ILIAS\Style\Content\DomainService $content_style_domain;
+
+    public function __construct()
+    {
+        global $DIC;
+        parent::__construct();
+        $this->content_style_domain = $DIC
+            ->contentStyle()
+            ->domain();
+    }
+
     public function getSupportedVersions() : array
     {
         return array("4.3.0", "5.0.0", "5.3.0");
@@ -231,10 +241,12 @@ class ilBlogDataSet extends ilDataSet
         array $a_set
     ) : array {
         if ($a_entity == "blog") {
+            $style = $this->content_style_domain->styleForObjId((int) $a_set["Id"]);
+
             $dir = ilObjBlog::initStorage($a_set["Id"]);
             $a_set["Dir"] = $dir;
             
-            $a_set["Style"] = ilObjStyleSheet::lookupObjectStyle($a_set["Id"]);
+            $a_set["Style"] = $style->getStyleId();
             
             // #14734
             $a_set["Notes"] = ilNote::commentsActivated($a_set["Id"], 0, "blog");

--- a/Modules/Blog/Export/class.ilBlogExporter.php
+++ b/Modules/Blog/Export/class.ilBlogExporter.php
@@ -20,11 +20,17 @@
 class ilBlogExporter extends ilXmlExporter
 {
     protected ilBlogDataSet $ds;
-    
+    protected \ILIAS\Style\Content\DomainService $content_style_domain;
+
     public function init() : void
     {
+        global $DIC;
+
         $this->ds = new ilBlogDataSet();
         $this->ds->setDSPrefix("ds");
+        $this->content_style_domain = $DIC
+            ->contentStyle()
+            ->domain();
     }
     
     public function getXmlExportTailDependencies(
@@ -53,7 +59,7 @@ class ilBlogExporter extends ilXmlExporter
         // style
         $style_ids = array();
         foreach ($a_ids as $id) {
-            $style_id = ilObjStyleSheet::lookupObjectStyle($id);
+            $style_id = $this->content_style_domain->styleForObjId((int) $id)->getStyleId();
             if ($style_id > 0) {
                 $style_ids[] = $style_id;
             }

--- a/Modules/Blog/Export/class.ilBlogImporter.php
+++ b/Modules/Blog/Export/class.ilBlogImporter.php
@@ -21,11 +21,17 @@
 class ilBlogImporter extends ilXmlImporter
 {
     protected ilBlogDataSet $ds;
-    
+    protected \ILIAS\Style\Content\DomainService $content_style_domain;
+
     public function init() : void
     {
+        global $DIC;
+
         $this->ds = new ilBlogDataSet();
         $this->ds->setDSPrefix("ds");
+        $this->content_style_domain = $DIC
+            ->contentStyle()
+            ->domain();
     }
 
     public function importXmlRepresentation(
@@ -58,7 +64,9 @@ class ilBlogImporter extends ilXmlImporter
         foreach ($sty_map as $old_sty_id => $new_sty_id) {
             if (is_array(ilBlogDataSet::$style_map[$old_sty_id])) {
                 foreach (ilBlogDataSet::$style_map[$old_sty_id] as $blog_id) {
-                    ilObjStyleSheet::writeStyleUsage($blog_id, $new_sty_id);
+                    $this->content_style_domain
+                        ->styleForObjId($blog_id)
+                        ->updateStyleId($new_sty_id);
                 }
             }
         }

--- a/Modules/Blog/classes/class.ilObjBlogGUI.php
+++ b/Modules/Blog/classes/class.ilObjBlogGUI.php
@@ -22,7 +22,7 @@ use ILIAS\Blog\StandardGUIRequest;
  * @ilCtrl_Calls ilObjBlogGUI: ilBlogPostingGUI, ilWorkspaceAccessGUI, ilPortfolioPageGUI
  * @ilCtrl_Calls ilObjBlogGUI: ilInfoScreenGUI, ilNoteGUI, ilCommonActionDispatcherGUI
  * @ilCtrl_Calls ilObjBlogGUI: ilPermissionGUI, ilObjectCopyGUI, ilRepositorySearchGUI
- * @ilCtrl_Calls ilObjBlogGUI: ilExportGUI, ilObjStyleSheetGUI, ilBlogExerciseGUI, ilObjNotificationSettingsGUI
+ * @ilCtrl_Calls ilObjBlogGUI: ilExportGUI, ilObjectContentStyleSettingsGUI, ilBlogExerciseGUI, ilObjNotificationSettingsGUI
  */
 class ilObjBlogGUI extends ilObject2GUI implements ilDesktopItemHandling
 {
@@ -53,6 +53,8 @@ class ilObjBlogGUI extends ilObject2GUI implements ilDesktopItemHandling
     protected ContextServices $tool_context;
     protected \ILIAS\HTTP\Services $http;
     protected \ILIAS\DI\UIServices $ui;
+    protected \ILIAS\Style\Content\GUIService $content_style_gui;
+    protected \ILIAS\Style\Content\Object\ObjectFacade $content_style_domain;
 
     public function __construct(
         int $a_id = 0,
@@ -126,6 +128,15 @@ class ilObjBlogGUI extends ilObject2GUI implements ilDesktopItemHandling
         
         $lng->loadLanguageModule("blog");
         $ilCtrl->saveParameter($this, "prvm");
+        $cs = $DIC->contentStyle();
+        $this->content_style_gui = $cs->gui();
+        if (is_object($this->object)) {
+            if ($this->id_type != self::REPOSITORY_NODE_ID) {
+                $this->content_style_domain = $cs->domain()->styleForObjId($this->object->getId());
+            } else {
+                $this->content_style_domain = $cs->domain()->styleForRefId($this->object->getRefId());
+            }
+        }
     }
 
     public function getType() : string
@@ -176,7 +187,7 @@ class ilObjBlogGUI extends ilObject2GUI implements ilDesktopItemHandling
         $this->tabs_gui->addSubTab(
             "style",
             $this->lng->txt("obj_sty"),
-            $this->ctrl->getLinkTarget($this, 'editStyleProperties')
+            $this->ctrl->getLinkTargetByClass("ilobjectcontentstylesettingsgui", "")
         );
 
         // notification settings for blogs in courses and groups
@@ -574,10 +585,7 @@ class ilObjBlogGUI extends ilObject2GUI implements ilDesktopItemHandling
                     $ilCtrl->getLinkTarget($this, "")
                 );
 
-                $style_sheet_id = ilObjStyleSheet::getEffectiveContentStyleId(
-                    $this->object->getStyleSheetId(),
-                    "blog"
-                );
+                $style_sheet_id = $this->content_style_domain->getEffectiveStyleId();
 
                 $bpost_gui = new ilBlogPostingGUI(
                     $this->node_id,
@@ -750,29 +758,31 @@ class ilObjBlogGUI extends ilObject2GUI implements ilDesktopItemHandling
                 $ilCtrl->forwardCommand($exp_gui);
                 break;
             
-            case "ilobjstylesheetgui":
-                $this->ctrl->setReturn($this, "editStyleProperties");
-                $style_gui = new ilObjStyleSheetGUI("", $this->object->getStyleSheetId(), false, false);
-                $style_gui->omitLocator();
-                if ($cmd == "create" || $this->new_type == "sty") {
-                    $style_gui->setCreationMode(true);
-                }
+            case "ilobjectcontentstylesettingsgui":
+                $this->checkPermission("write");
+                $this->prepareOutput();
+                $this->addHeaderAction();
+                $ilTabs->activateTab("settings");
+                $this->setSettingsSubTabs("style");
 
-                if ($cmd == "confirmedDelete") {
-                    $this->object->setStyleSheetId(0);
-                    $this->object->update();
-                }
 
-                $ret = $this->ctrl->forwardCommand($style_gui);
-
-                if ($cmd == "save" || $cmd == "copyStyle" || $cmd == "importStyle") {
-                    $style_id = $ret;
-                    $this->object->setStyleSheetId($style_id);
-                    $this->object->update();
-                    $this->ctrl->redirectByClass("ilobjstylesheetgui", "edit");
+                if ($this->id_type == self::REPOSITORY_NODE_ID) {
+                    $settings_gui = $this->content_style_gui
+                        ->objectSettingsGUIForRefId(
+                            null,
+                            $this->object->getRefId()
+                        );
+                } else {
+                    $settings_gui = $this->content_style_gui
+                        ->objectSettingsGUIForObjId(
+                            null,
+                            $this->object->getId()
+                        );
                 }
+                $this->ctrl->forwardCommand($settings_gui);
                 break;
-                
+
+
             case "ilblogexercisegui":
                 $this->ctrl->setReturn($this, "render");
                 $gui = new ilBlogExerciseGUI($this->node_id);
@@ -2796,116 +2806,13 @@ class ilObjBlogGUI extends ilObject2GUI implements ilDesktopItemHandling
             $ctpl = $tpl;
         }
 
-        $ctpl->setCurrentBlock("ContentStyle");
-        $ctpl->setVariable(
-            "LOCATION_CONTENT_STYLESHEET",
-            ilObjStyleSheet::getContentStylePath($this->object->getStyleSheetId())
+        $this->content_style_gui->addCss(
+            $ctpl,
+            $this->object->getRefId(),
+            $this->object->getId()
         );
-        $ctpl->parseCurrentBlock();
-    }
-    
-    public function editStyleProperties() : void
-    {
-        $this->checkPermission("write");
-        
-        $this->tabs_gui->activateTab("settings");
-        $this->setSettingsSubTabs("style");
-        
-        $form = $this->initStylePropertiesForm();
-        $this->tpl->setContent($form->getHTML());
-    }
-    
-    public function initStylePropertiesForm() : ilPropertyFormGUI
-    {
-        $ilSetting = $this->settings;
-                        
-        $this->lng->loadLanguageModule("style");
-
-        $form = new ilPropertyFormGUI();
-        
-        $fixed_style = $ilSetting->get("fixed_content_style_id");
-        $style_id = $this->object->getStyleSheetId();
-
-        if ($fixed_style > 0) {
-            $st = new ilNonEditableValueGUI($this->lng->txt("style_current_style"));
-            $st->setValue(ilObject::_lookupTitle($fixed_style) . " (" .
-                $this->lng->txt("global_fixed") . ")");
-            $form->addItem($st);
-        } else {
-            $st_styles = ilObjStyleSheet::_getStandardStyles(
-                true,
-                false,
-                $this->ref_id
-            );
-
-            $st_styles[0] = $this->lng->txt("default");
-            ksort($st_styles);
-
-            if ($style_id > 0) {
-                // individual style
-                if (!ilObjStyleSheet::_lookupStandard($style_id)) {
-                    $st = new ilNonEditableValueGUI($this->lng->txt("style_current_style"));
-                    $st->setValue(ilObject::_lookupTitle($style_id));
-                    $form->addItem($st);
-
-                    // delete command
-                    $form->addCommandButton("editStyle", $this->lng->txt("style_edit_style"));
-                    $form->addCommandButton("deleteStyle", $this->lng->txt("style_delete_style"));
-                }
-            }
-
-            if ($style_id <= 0 || ilObjStyleSheet::_lookupStandard($style_id)) {
-                $style_sel = new ilSelectInputGUI(
-                    $this->lng->txt("style_current_style"),
-                    "style_id"
-                );
-                $style_sel->setOptions($st_styles);
-                $style_sel->setValue($style_id);
-                $form->addItem($style_sel);
-
-                $form->addCommandButton("saveStyleSettings", $this->lng->txt("save"));
-                $form->addCommandButton("createStyle", $this->lng->txt("sty_create_ind_style"));
-            }
-        }
-        
-        $form->setTitle($this->lng->txt("blog_style"));
-        $form->setFormAction($this->ctrl->getFormAction($this));
-        
-        return $form;
     }
 
-    public function createStyle() : void
-    {
-        $this->ctrl->redirectByClass("ilobjstylesheetgui", "create");
-    }
-        
-    public function editStyle() : void
-    {
-        $this->ctrl->redirectByClass("ilobjstylesheetgui", "edit");
-    }
-
-    public function deleteStyle() : void
-    {
-        $this->ctrl->redirectByClass("ilobjstylesheetgui", "delete");
-    }
-
-    public function saveStyleSettings() : void
-    {
-        $ilSetting = $this->settings;
-    
-        if ($ilSetting->get("fixed_content_style_id") <= 0 &&
-            (ilObjStyleSheet::_lookupStandard($this->object->getStyleSheetId())
-            || $this->object->getStyleSheetId() == 0)) {
-            $this->object->setStyleSheetId(
-                $this->blog_request->getStyleId()
-            );
-            $this->object->update();
-            
-            ilUtil::sendSuccess($this->lng->txt("msg_obj_modified"), true);
-        }
-        $this->ctrl->redirect($this, "editStyleProperties");
-    }
-    
     /**
      * Deep link
      */

--- a/Modules/ContentPage/classes/class.ilContentPageDataSet.php
+++ b/Modules/ContentPage/classes/class.ilContentPageDataSet.php
@@ -29,8 +29,7 @@ class ilContentPageDataSet extends ilDataSet implements ilContentPageObjectConst
                     'id' => 'integer',
                     'title' => 'text',
                     'description' => 'text',
-                    'info-tab' => 'integer',
-                    'style-id' => 'integer',
+                    'info-tab' => 'integer'
                 ];
 
             default:
@@ -71,8 +70,7 @@ class ilContentPageDataSet extends ilDataSet implements ilContentPageObjectConst
                                 $obj->getId(),
                                 ilObjectServiceSettingsGUI::INFO_TAB_VISIBILITY,
                                 '1'
-                            )),
-                            'style-id' => $obj->getStyleSheetId(),
+                            ))
                         ];
                     }
                 }
@@ -100,7 +98,6 @@ class ilContentPageDataSet extends ilDataSet implements ilContentPageObjectConst
 
                 $newObject->setTitle(ilUtil::stripSlashes($a_rec['title']));
                 $newObject->setDescription(ilUtil::stripSlashes($a_rec['description']));
-                $newObject->setStyleSheetId((int) ilUtil::stripSlashes($a_rec['style-id']));
 
                 if (!$newObject->getId()) {
                     $newObject->create();
@@ -117,12 +114,6 @@ class ilContentPageDataSet extends ilDataSet implements ilContentPageObjectConst
                     self::OBJ_TYPE,
                     (string) $a_rec['id'],
                     (string) $newObject->getId()
-                );
-                $a_mapping->addMapping(
-                    'Modules/ContentPage',
-                    'style',
-                    (string) $newObject->getId(),
-                    (string) $newObject->getStyleSheetId()
                 );
                 $a_mapping->addMapping(
                     'Services/COPage',

--- a/Modules/ContentPage/classes/class.ilContentPageExporter.php
+++ b/Modules/ContentPage/classes/class.ilContentPageExporter.php
@@ -1,14 +1,21 @@
 <?php declare(strict_types=1);
 /* Copyright (c) 1998-2018 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+use ILIAS\Style\Content\DomainService;
+
 class ilContentPageExporter extends ilXmlExporter implements ilContentPageObjectConstants
 {
     protected ilContentPageDataSet $ds;
+    protected DomainService $content_style_domain;
 
     public function init() : void
     {
+        global $DIC;
+
         $this->ds = new ilContentPageDataSet();
         $this->ds->setDSPrefix('ds');
+        $this->content_style_domain = $DIC->contentStyle()
+                                          ->domain();
     }
 
     public function getXmlRepresentation(string $a_entity, string $a_schema_version, string $a_id) : string
@@ -48,8 +55,11 @@ class ilContentPageExporter extends ilXmlExporter implements ilContentPageObject
                 $pageObjectIds[] = self::OBJ_TYPE . ':' . $copaPageObjId;
             }
 
-            if ($copa->getStyleSheetId() > 0) {
-                $styleIds[$copa->getStyleSheetId()] = $copa->getStyleSheetId();
+            $style_id = $this->content_style_domain
+                ->styleForObjId($copa->getId())
+                ->getStyleId();
+            if ($style_id > 0) {
+                $styleIds[$style_id] = $style_id;
             }
         }
 

--- a/Modules/ContentPage/classes/class.ilContentPageKioskModeView.php
+++ b/Modules/ContentPage/classes/class.ilContentPageKioskModeView.php
@@ -26,6 +26,8 @@ class ilContentPageKioskModeView extends ilKioskModeView
     protected ilTabsGUI $tabs;
     /** @var MessageBox[] */
     protected array $messages = [];
+    protected \ILIAS\Style\Content\Object\ObjectFacade $content_style_domain;
+    protected \ILIAS\Style\Content\GUIService $content_style_gui;
 
     protected function getObjectClass() : string
     {
@@ -46,6 +48,9 @@ class ilContentPageKioskModeView extends ilKioskModeView
         $this->refinery = $DIC->refinery();
         $this->tabs = $DIC->tabs();
         $this->user = $DIC->user();
+        $cs = $DIC->contentStyle();
+        $this->content_style_gui = $cs->gui();
+        $this->content_style_domain = $cs->domain()->styleForRefId($object->getRefId());
     }
 
     protected function hasPermissionToAccessKioskMode() : bool
@@ -145,7 +150,8 @@ class ilContentPageKioskModeView extends ilKioskModeView
             $this->lng,
             $this->contentPageObject,
             $this->user,
-            $this->refinery
+            $this->refinery,
+            $this->content_style_domain
         );
         $forwarder->setPresentationMode(ilContentPagePageCommandForwarder::PRESENTATION_MODE_EMBEDDED_PRESENTATION);
 
@@ -165,10 +171,9 @@ class ilContentPageKioskModeView extends ilKioskModeView
     protected function renderContentStyle() : void
     {
         $this->mainTemplate->addCss(ilObjStyleSheet::getSyntaxStylePath());
-        $this->mainTemplate->addCss(
-            ilObjStyleSheet::getContentStylePath(
-                $this->contentPageObject->getStyleSheetId()
-            )
+        $this->content_style_gui->addCss(
+            $this->mainTemplate,
+            $this->contentPageObject->getRefId()
         );
     }
 }

--- a/Modules/ContentPage/classes/class.ilContentPagePageCommandForwarder.php
+++ b/Modules/ContentPage/classes/class.ilContentPagePageCommandForwarder.php
@@ -4,6 +4,7 @@
 use ILIAS\ContentPage\PageMetrics\Event\PageUpdatedEvent;
 use ILIAS\HTTP\GlobalHttpState;
 use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Style\Content\Object\ObjectFacade;
 
 class ilContentPagePageCommandForwarder implements ilContentPageObjectConstants
 {
@@ -33,6 +34,7 @@ class ilContentPagePageCommandForwarder implements ilContentPageObjectConstants
     protected array $updateListeners = [];
     protected GlobalHttpState $http;
     protected Refinery $refinery;
+    protected ObjectFacade $content_style_domain;
 
     public function __construct(
         GlobalHttpState $http,
@@ -41,7 +43,8 @@ class ilContentPagePageCommandForwarder implements ilContentPageObjectConstants
         ilLanguage $lng,
         ilObjContentPage $parentObject,
         ilObjUser $actor,
-        Refinery $refinery
+        Refinery $refinery,
+        ObjectFacade $content_style_domain
     ) {
         $this->http = $http;
         $this->ctrl = $ctrl;
@@ -50,6 +53,7 @@ class ilContentPagePageCommandForwarder implements ilContentPageObjectConstants
         $this->parentObject = $parentObject;
         $this->actor = $actor;
         $this->refinery = $refinery;
+        $this->content_style_domain = $content_style_domain;
 
         $this->lng->loadLanguageModule('content');
 
@@ -85,10 +89,7 @@ class ilContentPagePageCommandForwarder implements ilContentPageObjectConstants
     {
         $pageObjectGUI = new ilContentPagePageGUI($this->parentObject->getId(), 0, $isEmbedded, $language);
         $pageObjectGUI->setStyleId(
-            ilObjStyleSheet::getEffectiveContentStyleId(
-                $this->parentObject->getStyleSheetId(),
-                $this->parentObject->getType()
-            )
+            $this->content_style_domain->getEffectiveStyleId()
         );
 
         $pageObjectGUI->obj->addUpdateListener($this->parentObject, 'update');
@@ -153,10 +154,7 @@ class ilContentPagePageCommandForwarder implements ilContentPageObjectConstants
         $pageObjectGUI->setEnabledTabs(false);
 
         $pageObjectGUI->setStyleId(
-            ilObjStyleSheet::getEffectiveContentStyleId(
-                $this->parentObject->getStyleSheetId(),
-                $this->parentObject->getType()
-            )
+            $this->content_style_domain->getEffectiveStyleId()
         );
 
         return $pageObjectGUI;
@@ -170,10 +168,7 @@ class ilContentPagePageCommandForwarder implements ilContentPageObjectConstants
         $pageObjectGUI->setEnabledTabs(false);
 
         $pageObjectGUI->setStyleId(
-            ilObjStyleSheet::getEffectiveContentStyleId(
-                $this->parentObject->getStyleSheetId(),
-                $this->parentObject->getType()
-            )
+            $this->content_style_domain->getEffectiveStyleId()
         );
 
         return $pageObjectGUI;

--- a/Modules/ContentPage/classes/class.ilObjContentPage.php
+++ b/Modules/ContentPage/classes/class.ilObjContentPage.php
@@ -4,12 +4,14 @@
 use ILIAS\ContentPage\PageMetrics\Command\StorePageMetricsCommand;
 use ILIAS\ContentPage\PageMetrics\PageMetricsRepositoryImp;
 use ILIAS\ContentPage\PageMetrics\PageMetricsService;
+use ILIAS\Style\Content\DomainService;
 
 class ilObjContentPage extends ilObject2 implements ilContentPageObjectConstants
 {
     protected int $styleId = 0;
     protected ?ilObjectTranslation $objTrans = null;
     private PageMetricsService $pageMetricsService;
+    protected DomainService $content_style_domain;
 
     public function __construct(int $a_id = 0, bool $a_reference = true)
     {
@@ -18,6 +20,8 @@ class ilObjContentPage extends ilObject2 implements ilContentPageObjectConstants
         parent::__construct($a_id, $a_reference);
         $this->initTranslationService();
         $this->initPageMetricsService($DIC->refinery());
+        $this->content_style_domain = $DIC->contentStyle()
+            ->domain();
     }
 
     private function initTranslationService() : void
@@ -43,31 +47,6 @@ class ilObjContentPage extends ilObject2 implements ilContentPageObjectConstants
     protected function initType() : void
     {
         $this->type = self::OBJ_TYPE;
-    }
-
-    public function getStyleSheetId() : int
-    {
-        return $this->styleId;
-    }
-
-    /**
-     * Note: A typehint cannot be be used here, because the consumer passes a string
-     * @param int $styleId
-     */
-    public function setStyleSheetId($styleId) : void
-    {
-        $this->styleId = (int) $styleId;
-    }
-
-    public function writeStyleSheetId(int $styleId) : void
-    {
-        $this->db->manipulateF(
-            'UPDATE content_object SET stylesheet = %s WHERE id = %s',
-            ['integer', 'integer'],
-            [$styleId, $this->getId()]
-        );
-
-        $this->setStyleSheetId($styleId);
     }
 
     protected function doCloneObject($new_obj, $a_target_id, $a_copy_id = null) : void
@@ -100,15 +79,8 @@ class ilObjContentPage extends ilObject2 implements ilContentPageObjectConstants
             }
         }
 
-        $styleId = $this->getStyleSheetId();
-        if ($styleId > 0 && !ilObjStyleSheet::_lookupStandard($styleId)) {
-            $style = ilObjectFactory::getInstanceByObjId($styleId, false);
-            if ($style) {
-                $new_id = $style->ilClone();
-                $new_obj->setStyleSheetId($new_id);
-                $new_obj->update();
-            }
-        }
+        $style = $this->content_style_domain->styleForObjId($this->getId());
+        $style->cloneTo($new_obj->getId());
 
         ilContainer::_writeContainerSetting(
             $new_obj->getId(),
@@ -138,16 +110,6 @@ class ilObjContentPage extends ilObject2 implements ilContentPageObjectConstants
         parent::doRead();
 
         $this->initTranslationService();
-
-        $res = $this->db->queryF(
-            'SELECT * FROM content_page_data WHERE content_page_id = %s',
-            ['integer'],
-            [$this->getId()]
-        );
-
-        while ($data = $this->db->fetchAssoc($res)) {
-            $this->setStyleSheetId((int) $data['stylesheet']);
-        }
     }
 
     protected function doCreate() : void
@@ -176,12 +138,6 @@ class ilObjContentPage extends ilObject2 implements ilContentPageObjectConstants
         $trans->setDefaultTitle($this->getTitle());
         $trans->setDefaultDescription($this->getLongDescription());
         $trans->save();
-
-        $this->db->manipulateF(
-            'UPDATE content_page_data SET stylesheet = %s WHERE content_page_id = %s',
-            ['integer', 'integer'],
-            [$this->getStyleSheetId(), $this->getId()]
-        );
     }
 
     protected function doDelete() : void

--- a/Modules/ContentPage/classes/class.ilObjContentPageGUI.php
+++ b/Modules/ContentPage/classes/class.ilObjContentPageGUI.php
@@ -211,7 +211,7 @@ class ilObjContentPageGUI extends ilObject2GUI implements ilContentPageObjectCon
                 $this->ctrl->forwardCommand($transgui);
                 break;
 
-            case "ilobjectcontentstylesettingsgui":
+            case strtolower(ilObjectContentStyleSettingsGUI::class):
                 $this->checkPermission("write");
                 $this->prepareOutput();
                 $this->setLocator();

--- a/Modules/ContentPage/classes/class.ilObjContentPageGUI.php
+++ b/Modules/ContentPage/classes/class.ilObjContentPageGUI.php
@@ -22,7 +22,7 @@ use ILIAS\Refinery\Factory as Refinery;
  * @ilCtrl_Calls      ilObjContentPageGUI: ilCommonActionDispatcherGUI
  * @ilCtrl_Calls      ilObjContentPageGUI: ilContentPagePageGUI
  * @ilCtrl_Calls      ilObjContentPageGUI: ilObjectCustomIconConfigurationGUI
- * @ilCtrl_Calls      ilObjContentPageGUI: ilObjStyleSheetGUI
+ * @ilCtrl_Calls      ilObjContentPageGUI: ilObjectContentStyleSettingsGUI
  * @ilCtrl_Calls      ilObjContentPageGUI: ilObjectTranslationGUI
  * @ilCtrl_Calls      ilObjContentPageGUI: ilPageMultiLangGUI
  */
@@ -32,6 +32,8 @@ class ilObjContentPageGUI extends ilObject2GUI implements ilContentPageObjectCon
     protected $http;
     /** @var Refinery */
     protected $refinery;
+    protected \ILIAS\Style\Content\Object\ObjectFacade $content_style_domain;
+    protected \ILIAS\Style\Content\GUIService $content_style_gui;
     /** @var ilCtrl */
     protected $ctrl;
     /** @var ilAccessHandler */
@@ -87,6 +89,11 @@ class ilObjContentPageGUI extends ilObject2GUI implements ilContentPageObjectCon
             new PageMetricsRepositoryImp($DIC->database()),
             $DIC->refinery()
         );
+        $cs = $DIC->contentStyle();
+        $this->content_style_gui = $cs->gui();
+        if (is_object($this->object)) {
+            $this->content_style_domain = $cs->domain()->styleForRefId($this->object->getRefId());
+        }
     }
 
     public static function _goto(string $target) : void
@@ -188,7 +195,7 @@ class ilObjContentPageGUI extends ilObject2GUI implements ilContentPageObjectCon
 
         $this->addToNavigationHistory();
 
-        if (strtolower($nextClass) !== strtolower(ilObjStyleSheetGUI::class)) {
+        if (strtolower($nextClass) !== strtolower(ilObjectContentStyleSettingsGUI::class)) {
             $this->renderHeaderActions();
         }
 
@@ -204,44 +211,18 @@ class ilObjContentPageGUI extends ilObject2GUI implements ilContentPageObjectCon
                 $this->ctrl->forwardCommand($transgui);
                 break;
 
-            case strtolower(ilObjStyleSheetGUI::class):
-                $this->checkPermission('write');
-
+            case "ilobjectcontentstylesettingsgui":
+                $this->checkPermission("write");
+                $this->prepareOutput();
                 $this->setLocator();
-
-                $this->ctrl->setReturn($this, 'editStyleProperties');
-                $style_gui = new ilObjStyleSheetGUI(
-                    '',
-                    $this->object->getStyleSheetId(),
-                    false,
-                    false
-                );
-                $style_gui->omitLocator();
-
-                $new_type = '';
-                if ($this->http->wrapper()->query()->has('new_type')) {
-                    $new_type = $this->http->wrapper()->query()->retrieve(
-                        'new_type',
-                        $this->refinery->kindlyTo()->string()
+                $this->tabs->activateTab(self::UI_TAB_ID_SETTINGS);
+                $this->setSettingsSubTabs(self::UI_TAB_ID_STYLE);
+                $settings_gui = $this->content_style_gui
+                    ->objectSettingsGUIForRefId(
+                        null,
+                        $this->object->getRefId()
                     );
-                }
-                if ($cmd === 'create' || $new_type === 'sty') {
-                    $style_gui->setCreationMode();
-                }
-
-                if ($cmd === 'confirmedDelete') {
-                    $this->object->setStyleSheetId(0);
-                    $this->object->update();
-                }
-
-                $ret = $this->ctrl->forwardCommand($style_gui);
-
-                if ($cmd === 'save' || $cmd === 'copyStyle' || $cmd === 'importStyle') {
-                    $styleId = $ret;
-                    $this->object->setStyleSheetId((int) $styleId);
-                    $this->object->update();
-                    $this->ctrl->redirectByClass(ilObjStyleSheetGUI::class, 'edit');
-                }
+                $this->ctrl->forwardCommand($settings_gui);
                 break;
 
             case strtolower(ilContentPagePageGUI::class):
@@ -260,10 +241,7 @@ class ilObjContentPageGUI extends ilObject2GUI implements ilContentPageObjectCon
 
                 $this->prepareOutput();
 
-                $this->tpl->setVariable(
-                    'LOCATION_CONTENT_STYLESHEET',
-                    ilObjStyleSheet::getContentStylePath($this->object->getStyleSheetId())
-                );
+                $this->content_style_gui->addCss($this->tpl, $this->object->getRefId());
                 $this->tpl->setCurrentBlock('SyntaxStyle');
                 $this->tpl->setVariable('LOCATION_SYNTAX_STYLESHEET', ilObjStyleSheet::getSyntaxStylePath());
                 $this->tpl->parseCurrentBlock();
@@ -275,7 +253,8 @@ class ilObjContentPageGUI extends ilObject2GUI implements ilContentPageObjectCon
                     $this->lng,
                     $this->object,
                     $this->user,
-                    $this->refinery
+                    $this->refinery,
+                    $this->content_style_domain
                 );
 
                 $forwarder->addUpdateListener(function (PageUpdatedEvent $event) : void {
@@ -447,7 +426,7 @@ class ilObjContentPageGUI extends ilObject2GUI implements ilContentPageObjectCon
             $this->tabs_gui->addSubTab(
                 self::UI_TAB_ID_STYLE,
                 $this->lng->txt('cont_style'),
-                $this->ctrl->getLinkTarget($this, 'editStyleProperties')
+                $this->ctrl->getLinkTargetByClass("ilobjectcontentstylesettingsgui", "")
             );
 
             $this->tabs_gui->addSubTab(
@@ -525,7 +504,8 @@ class ilObjContentPageGUI extends ilObject2GUI implements ilContentPageObjectCon
                 $this->lng,
                 $this->object,
                 $this->user,
-                $this->refinery
+                $this->refinery,
+                $this->content_style_domain
             );
             $forwarder->setPresentationMode(ilContentPagePageCommandForwarder::PRESENTATION_MODE_PRESENTATION);
 
@@ -537,10 +517,7 @@ class ilObjContentPageGUI extends ilObject2GUI implements ilContentPageObjectCon
 
     protected function initStyleSheets() : void
     {
-        $this->tpl->setVariable(
-            'LOCATION_CONTENT_STYLESHEET',
-            ilObjStyleSheet::getContentStylePath($this->object->getStyleSheetId())
-        );
+        $this->content_style_gui->addCss($this->tpl, $this->object->getRefId());
         $this->tpl->setCurrentBlock('SyntaxStyle');
         $this->tpl->setVariable('LOCATION_SYNTAX_STYLESHEET', ilObjStyleSheet::getSyntaxStylePath());
         $this->tpl->parseCurrentBlock();
@@ -622,107 +599,5 @@ class ilObjContentPageGUI extends ilObject2GUI implements ilContentPageObjectCon
             ]
         );
         $this->obj_service->commonSettings()->legacyForm($a_form, $this->object)->saveTileImage();
-    }
-
-    protected function editStyleProperties() : void
-    {
-        $this->checkPermission('write');
-
-        $this->tabs->activateTab(self::UI_TAB_ID_SETTINGS);
-        $this->setSettingsSubTabs(self::UI_TAB_ID_STYLE);
-
-        $form = $this->buildStylePropertiesForm();
-        $this->tpl->setContent($form->getHTML());
-    }
-
-    protected function buildStylePropertiesForm() : ilPropertyFormGUI
-    {
-        $form = new ilPropertyFormGUI();
-
-        $fixedStyle = (int) $this->settings->get('fixed_content_style_id', '0');
-        $defaultStyle = (int) $this->settings->get('default_content_style_id', '0');
-        $styleId = $this->object->getStyleSheetId();
-
-        if ($fixedStyle > 0) {
-            $st = new ilNonEditableValueGUI($this->lng->txt('cont_current_style'));
-            $st->setValue(
-                ilObject::_lookupTitle($fixedStyle) . ' (' . $this->lng->txt('global_fixed') . ')'
-            );
-            $form->addItem($st);
-        } else {
-            $st_styles = ilObjStyleSheet::_getStandardStyles(
-                true,
-                false,
-                $this->http->wrapper()->query()->retrieve('ref_id', $this->refinery->kindlyTo()->int())
-            );
-
-            if ($defaultStyle > 0) {
-                $st_styles[0] = ilObject::_lookupTitle($defaultStyle) . ' (' . $this->lng->txt('default') . ')';
-            } else {
-                $st_styles[0] = $this->lng->txt('default');
-            }
-            ksort($st_styles);
-
-            if ($styleId > 0 && !ilObjStyleSheet::_lookupStandard($styleId)) {
-                $st = new ilNonEditableValueGUI($this->lng->txt('cont_current_style'));
-                $st->setValue(ilObject::_lookupTitle($styleId));
-                $form->addItem($st);
-
-                $form->addCommandButton('editStyle', $this->lng->txt('cont_edit_style'));
-                $form->addCommandButton('deleteStyle', $this->lng->txt('cont_delete_style'));
-            }
-
-            if ($styleId <= 0 || ilObjStyleSheet::_lookupStandard($styleId)) {
-                $style_sel = new ilSelectInputGUI($this->lng->txt('cont_current_style'), 'style_id');
-                $style_sel->setOptions($st_styles);
-                $style_sel->setValue($styleId);
-                $form->addItem($style_sel);
-                $form->addCommandButton('saveStyleSettings', $this->lng->txt('save'));
-                $form->addCommandButton('createStyle', $this->lng->txt('sty_create_ind_style'));
-            }
-        }
-
-        $form->setTitle($this->lng->txt('cont_style'));
-        $form->setFormAction($this->ctrl->getFormAction($this));
-
-        return $form;
-    }
-
-    protected function createStyle() : void
-    {
-        $this->ctrl->redirectByClass(ilObjStyleSheetGUI::class, 'create');
-    }
-
-    protected function editStyle() : void
-    {
-        $this->ctrl->redirectByClass(ilObjStyleSheetGUI::class, 'edit');
-    }
-
-    protected function deleteStyle() : void
-    {
-        $this->ctrl->redirectByClass(ilObjStyleSheetGUI::class, 'delete');
-    }
-
-    protected function saveStyleSettings() : void
-    {
-        $this->checkPermission('write');
-
-        if (
-            (int) $this->settings->get('fixed_content_style_id', '0') <= 0 &&
-            (
-                ilObjStyleSheet::_lookupStandard(
-                    $this->object->getStyleSheetId()
-                ) ||
-                $this->object->getStyleSheetId() === 0
-            )
-        ) {
-            $this->object->setStyleSheetId(
-                $this->http->wrapper()->query()->retrieve('style_id', $this->refinery->kindlyTo()->int())
-            );
-            $this->object->update();
-            ilUtil::sendSuccess($this->lng->txt('msg_obj_modified'), true);
-        }
-
-        $this->ctrl->redirect($this, 'editStyleProperties');
     }
 }

--- a/Modules/Course/classes/Objectives/class.ilLOEditorGUI.php
+++ b/Modules/Course/classes/Objectives/class.ilLOEditorGUI.php
@@ -1,7 +1,7 @@
 <?php
 /* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-
+use ILIAS\Style\Content\Object\ObjectFacade;
 
 /**
 * Class ilLOEditorGUI
@@ -38,20 +38,24 @@ class ilLOEditorGUI
     private $ctrl = null;
 
     private $test_type = 0;
-    
-    
+    protected ObjectFacade $content_style_domain;
+
     /**
      * Constructor
      * @param type $a_parent_obj
      */
     public function __construct($a_parent_obj)
     {
+        global $DIC;
+
         $this->parent_obj = $a_parent_obj;
         $this->settings = ilLOSettings::getInstanceByObjId($this->getParentObject()->getId());
 
         $this->lng = $GLOBALS['DIC']['lng'];
         $this->ctrl = $GLOBALS['DIC']['ilCtrl'];
         $this->logger = $GLOBALS['DIC']->logger()->crs();
+        $cs = $DIC->contentStyle();
+        $this->content_style_domain = $cs->domain()->styleForRefId($this->parent_obj->getRefId());
     }
     
     /**
@@ -140,19 +144,13 @@ class ilLOEditorGUI
                 $pgui = new ilLOPageGUI($objtv_id);
                 $pgui->setPresentationTitle(ilCourseObjective::lookupObjectiveTitle($objtv_id));
 
-                $pgui->setStyleId(ilObjStyleSheet::getEffectiveContentStyleId(
-                    $this->parent_obj->getStyleSheetId(),
-                    $this->parent_obj->getType()
-                ));
+                $pgui->setStyleId($this->content_style_domain->getEffectiveStyleId());
 
                 // #14895
                 $GLOBALS['DIC']['tpl']->setCurrentBlock("ContentStyle");
                 $GLOBALS['DIC']['tpl']->setVariable(
                     "LOCATION_CONTENT_STYLESHEET",
-                    ilObjStyleSheet::getContentStylePath(ilObjStyleSheet::getEffectiveContentStyleId(
-                        $this->parent_obj->getStyleSheetId(),
-                        $this->parent_obj->getType()
-                    ))
+                    ilObjStyleSheet::getContentStylePath($this->content_style_domain->getEffectiveStyleId())
                 );
                 $GLOBALS['DIC']['tpl']->parseCurrentBlock();
                 
@@ -806,7 +804,6 @@ class ilLOEditorGUI
      */
     protected function applySettingsTemplate(ilObjTest $tst)
     {
-        
         $tpl_id = 0;
         foreach (ilSettingsTemplate::getAllSettingsTemplates('tst', true) as $nr => $template) {
             switch ($this->getTestType()) {

--- a/Modules/Course/classes/class.ilObjCourseGUI.php
+++ b/Modules/Course/classes/class.ilObjCourseGUI.php
@@ -15,7 +15,7 @@
  * @ilCtrl_Calls ilObjCourseGUI: ilCourseContentGUI, ilPublicUserProfileGUI, ilMemberExportGUI
  * @ilCtrl_Calls ilObjCourseGUI: ilObjectCustomUserFieldsGUI, ilMemberAgreementGUI, ilSessionOverviewGUI
  * @ilCtrl_Calls ilObjCourseGUI: ilColumnGUI, ilContainerPageGUI
- * @ilCtrl_Calls ilObjCourseGUI: ilObjectCopyGUI, ilObjStyleSheetGUI
+ * @ilCtrl_Calls ilObjCourseGUI: ilObjectCopyGUI, ilObjectContentStyleSettingsGUI
  * @ilCtrl_Calls ilObjCourseGUI: ilCourseParticipantsGroupsGUI, ilExportGUI, ilCommonActionDispatcherGUI
  * @ilCtrl_Calls ilObjCourseGUI: ilDidacticTemplateGUI, ilCertificateGUI, ilObjectServiceSettingsGUI
  * @ilCtrl_Calls ilObjCourseGUI: ilContainerStartObjectsGUI, ilContainerStartObjectsPageGUI
@@ -315,7 +315,6 @@ class ilObjCourseGUI extends ilContainerGUI
             );
         }
         if ($this->object->getContactEmail()) {
-            
             $emails = explode(",", $this->object->getContactEmail());
             foreach ($emails as $email) {
                 $email = trim($email);
@@ -463,7 +462,6 @@ class ilObjCourseGUI extends ilContainerGUI
         $privacy = ilPrivacySettings::getInstance();
         
         if ($privacy->courseConfirmationRequired() or ilCourseDefinedFieldDefinition::_getFields($this->object->getId()) or $privacy->enabledCourseExport()) {
-            
             $field_info = ilExportFieldsInfo::_getInstanceByType($this->object->getType());
         
             $this->lng->loadLanguageModule('ps');
@@ -506,7 +504,6 @@ class ilObjCourseGUI extends ilContainerGUI
      */
     public function editInfoObject(ilPropertyFormGUI $a_form = null)
     {
-
         global $DIC;
 
         $ilErr = $DIC['ilErr'];
@@ -1124,12 +1121,16 @@ class ilObjCourseGUI extends ilContainerGUI
         );
         // $reg_proc->setInfo($this->lng->txt('crs_reg_type_info'));
 
-        $opt = new ilRadioOption($this->lng->txt('crs_subscription_options_direct'),
-            ilCourseConstants::IL_CRS_SUBSCRIPTION_DIRECT);
+        $opt = new ilRadioOption(
+            $this->lng->txt('crs_subscription_options_direct'),
+            ilCourseConstants::IL_CRS_SUBSCRIPTION_DIRECT
+        );
         $reg_proc->addOption($opt);
         
-        $opt = new ilRadioOption($this->lng->txt('crs_subscription_options_password'),
-            ilCourseConstants::IL_CRS_SUBSCRIPTION_PASSWORD);
+        $opt = new ilRadioOption(
+            $this->lng->txt('crs_subscription_options_password'),
+            ilCourseConstants::IL_CRS_SUBSCRIPTION_PASSWORD
+        );
             
         $pass = new ilTextInputGUI($this->lng->txt("password"), 'subscription_password');
         $pass->setRequired(true);
@@ -1142,13 +1143,17 @@ class ilObjCourseGUI extends ilContainerGUI
         $opt->addSubItem($pass);
         $reg_proc->addOption($opt);
         
-        $opt = new ilRadioOption($this->lng->txt('crs_subscription_options_confirmation'),
-            ilCourseConstants::IL_CRS_SUBSCRIPTION_CONFIRMATION);
+        $opt = new ilRadioOption(
+            $this->lng->txt('crs_subscription_options_confirmation'),
+            ilCourseConstants::IL_CRS_SUBSCRIPTION_CONFIRMATION
+        );
         $opt->setInfo($this->lng->txt('crs_registration_confirmation_info'));
         $reg_proc->addOption($opt);
             
-        $opt = new ilRadioOption($this->lng->txt('crs_reg_no_selfreg'),
-            ilCourseConstants::IL_CRS_SUBSCRIPTION_DEACTIVATED);
+        $opt = new ilRadioOption(
+            $this->lng->txt('crs_reg_no_selfreg'),
+            ilCourseConstants::IL_CRS_SUBSCRIPTION_DEACTIVATED
+        );
         $opt->setInfo($this->lng->txt('crs_registration_deactivated'));
         $reg_proc->addOption($opt);
 
@@ -2379,11 +2384,17 @@ class ilObjCourseGUI extends ilContainerGUI
                 $cp->setType('crs');
                 $this->ctrl->forwardCommand($cp);
                 break;
-                
-            case "ilobjstylesheetgui":
-                $this->forwardToStyleSheet();
-                break;
 
+            case "ilobjectcontentstylesettingsgui":
+                $this->checkPermission("write");
+                $this->setTitleAndDescription();
+                $settings_gui = $this->content_style_gui
+                    ->objectSettingsGUIForRefId(
+                        null,
+                        $this->object->getRefId()
+                    );
+                $this->ctrl->forwardCommand($settings_gui);
+                break;
                 
             case 'ilexportgui':
                 $this->tabs_gui->setTabActive('export');
@@ -2603,7 +2614,6 @@ class ilObjCourseGUI extends ilContainerGUI
                 }
 
                 if ($cmd == 'listObjectives') {
-
                     $this->ctrl->setReturn($this, "");
                     $obj_gui = new ilCourseObjectivesGUI($this->object->getRefId());
                     $ret = &$this->ctrl->forwardCommand($obj_gui);

--- a/Modules/DataCollection/classes/DetailedView/class.ilDclDetailedViewGUI.php
+++ b/Modules/DataCollection/classes/DetailedView/class.ilDclDetailedViewGUI.php
@@ -13,6 +13,10 @@
  */
 class ilDclDetailedViewGUI
 {
+    /**
+     * @var \ILIAS\Style\Content\Object\ObjectFacade
+     */
+    protected $content_style_domain;
 
     /**
      * @var ilObjDataCollectionGUI
@@ -107,6 +111,11 @@ class ilDclDetailedViewGUI
         if ($this->is_enabled_paging) {
             $this->determineNextPrevRecords();
         }
+        $this->content_style_domain = $DIC->contentStyle()
+            ->domain()
+            ->styleForRefId(
+                $this->dcl_gui_object->getDataCollectionObject()->getRefId()
+            );
     }
 
 
@@ -189,7 +198,9 @@ class ilDclDetailedViewGUI
 
         // see ilObjDataCollectionGUI->executeCommand about instantiation
         $pageObj = new ilDclDetailedViewDefinitionGUI($this->tableview_id);
-        $pageObj->setStyleId(ilObjStyleSheet::getEffectiveContentStyleId(0, "dcl"));
+        $pageObj->setStyleId(
+            $this->content_style_domain->getEffectiveStyleId()
+        );
 
         $html = $pageObj->getHTML();
         $rctpl->addCss("./Services/COPage/css/content.css");

--- a/Modules/Folder/classes/class.ilObjFolderGUI.php
+++ b/Modules/Folder/classes/class.ilObjFolderGUI.php
@@ -18,12 +18,12 @@ use ILIAS\Folder\StandardGUIRequest;
 /**
  * Class ilObjFolderGUI
  *
- * @author Alex Killing <alex.killing@gmx.de>
+ * @author Alexander Killing <killing@leifos.de>
  *
  * @ilCtrl_Calls ilObjFolderGUI: ilPermissionGUI
  * @ilCtrl_Calls ilObjFolderGUI: ilCourseContentGUI, ilLearningProgressGUI
  * @ilCtrl_Calls ilObjFolderGUI: ilInfoScreenGUI, ilContainerPageGUI, ilColumnGUI
- * @ilCtrl_Calls ilObjFolderGUI: ilObjectCopyGUI, ilObjStyleSheetGUI
+ * @ilCtrl_Calls ilObjFolderGUI: ilObjectCopyGUI, ilObjectContentStyleSettingsGUI
  * @ilCtrl_Calls ilObjFolderGUI: ilExportGUI, ilCommonActionDispatcherGUI, ilDidacticTemplateGUI
  * @ilCtrl_Calls ilObjFolderGUI: ilBackgroundTaskHub, ilObjectTranslationGUI, ilRepositoryTrashGUI
  */
@@ -39,7 +39,6 @@ class ilObjFolderGUI extends ilContainerGUI
         bool $a_call_by_reference = true,
         bool $a_prepare_output = false
     ) {
-        /** @var \ILIAS\DI\Container $DIC */
         global $DIC;
 
         $this->tree = $DIC->repositoryTree();
@@ -111,7 +110,7 @@ class ilObjFolderGUI extends ilContainerGUI
                 $this->prepareOutput();
                 $this->tabs_gui->activateTab('perm_settings');
                 $perm_gui = new ilPermissionGUI($this);
-                $ret = &$this->ctrl->forwardCommand($perm_gui);
+                $ret = $this->ctrl->forwardCommand($perm_gui);
                 break;
 
 
@@ -155,8 +154,16 @@ class ilObjFolderGUI extends ilContainerGUI
                 $this->ctrl->forwardCommand($cp);
                 break;
 
-            case "ilobjstylesheetgui":
-                $this->forwardToStyleSheet();
+            case "ilobjectcontentstylesettingsgui":
+                $this->checkPermission("write");
+                $this->setTitleAndDescription();
+                $this->showContainerPageTabs();
+                $settings_gui = $this->content_style_gui
+                    ->objectSettingsGUIForRefId(
+                        null,
+                        $this->object->getRefId()
+                    );
+                $this->ctrl->forwardCommand($settings_gui);
                 break;
                 
             case 'ilexportgui':

--- a/Modules/Forum/classes/CoPage/class.ilForumPageCommandForwarder.php
+++ b/Modules/Forum/classes/CoPage/class.ilForumPageCommandForwarder.php
@@ -18,6 +18,7 @@
  */
 
 use ILIAS\HTTP\GlobalHttpState;
+use ILIAS\Style\Content\Object\ObjectFacade;
 
 class ilForumPageCommandForwarder implements ilForumObjectConstants
 {
@@ -45,6 +46,7 @@ class ilForumPageCommandForwarder implements ilForumObjectConstants
     protected ilObjUser $actor;
     protected GlobalHttpState $http;
     private ilForumProperties $forumProperties;
+    protected ObjectFacade $content_style_domain;
 
     public function __construct(
         GlobalHttpState $http,
@@ -53,7 +55,8 @@ class ilForumPageCommandForwarder implements ilForumObjectConstants
         ilLanguage $lng,
         ilObjForum $parentObject,
         ilForumProperties $forumProperties,
-        ilObjUser $actor
+        ilObjUser $actor,
+        ObjectFacade $content_style_domain
     ) {
         $this->http = $http;
         $this->ctrl = $ctrl;
@@ -62,6 +65,7 @@ class ilForumPageCommandForwarder implements ilForumObjectConstants
         $this->parentObject = $parentObject;
         $this->forumProperties = $forumProperties;
         $this->actor = $actor;
+        $this->content_style_domain = $content_style_domain;
 
         $this->lng->loadLanguageModule('content');
 
@@ -86,10 +90,7 @@ class ilForumPageCommandForwarder implements ilForumObjectConstants
     {
         $pageObjectGUI = new ilForumPageGUI($this->parentObject->getId(), 0, $isEmbedded, $language);
         $pageObjectGUI->setStyleId(
-            ilObjStyleSheet::getEffectiveContentStyleId(
-                $this->forumProperties->getStyleSheetId(),
-                $this->parentObject->getType()
-            )
+            $this->content_style_domain->getEffectiveStyleId()
         );
 
         $pageObjectGUI->obj->addUpdateListener($this->parentObject, 'update');
@@ -153,10 +154,7 @@ class ilForumPageCommandForwarder implements ilForumObjectConstants
         $pageObjectGUI = $this->getPageObjectGUI($language);
         $pageObjectGUI->setEnabledTabs(false);
         $pageObjectGUI->setStyleId(
-            ilObjStyleSheet::getEffectiveContentStyleId(
-                $this->forumProperties->getStyleSheetId(),
-                $this->parentObject->getType()
-            )
+            $this->content_style_domain->getEffectiveStyleId()
         );
 
         return $pageObjectGUI;
@@ -169,10 +167,7 @@ class ilForumPageCommandForwarder implements ilForumObjectConstants
         $pageObjectGUI = $this->getPageObjectGUI($language, true);
         $pageObjectGUI->setEnabledTabs(false);
         $pageObjectGUI->setStyleId(
-            ilObjStyleSheet::getEffectiveContentStyleId(
-                $this->forumProperties->getStyleSheetId(),
-                $this->parentObject->getType()
-            )
+            $this->content_style_domain->getEffectiveStyleId()
         );
 
         return $pageObjectGUI;

--- a/Modules/Forum/classes/class.ilForumExporter.php
+++ b/Modules/Forum/classes/class.ilForumExporter.php
@@ -10,9 +10,14 @@
 class ilForumExporter extends ilXmlExporter implements ilForumObjectConstants
 {
     private $ds;
+    protected \ILIAS\Style\Content\DomainService $content_style_domain;
 
     public function init() : void
     {
+        global $DIC;
+        $this->content_style_domain = $DIC
+            ->contentStyle()
+            ->domain();
     }
 
 
@@ -64,9 +69,9 @@ class ilForumExporter extends ilXmlExporter implements ilForumObjectConstants
                 $pageObjectIds[] = self::OBJ_TYPE . ':' . $frmPageObjId;
             }
 
-            $properties = ilForumProperties::getInstance($frm->getId());
-            if ($properties->getStyleSheetId() > 0) {
-                $styleIds[$properties->getStyleSheetId()] = $properties->getStyleSheetId();
+            $style_id = $this->content_style_domain->styleForObjId((int) $frmObjId)->getStyleId();
+            if ($style_id > 0) {
+                $styleIds[$style_id] = $style_id;
             }
         }
 

--- a/Modules/Forum/classes/class.ilForumImporter.php
+++ b/Modules/Forum/classes/class.ilForumImporter.php
@@ -9,6 +9,16 @@
  */
 class ilForumImporter extends ilXmlImporter implements ilForumObjectConstants
 {
+    protected \ILIAS\Style\Content\DomainService $content_style_domain;
+
+    public function init() : void
+    {
+        global $DIC;
+        $this->content_style_domain = $DIC
+            ->contentStyle()
+            ->domain();
+    }
+
     public function importXmlRepresentation(string $a_entity, string $a_id, string $a_xml, ilImportMapping $a_mapping) : void
     {
         if ($new_id = $a_mapping->getMapping('Services/Container', 'objs', $a_id)) {
@@ -47,7 +57,9 @@ class ilForumImporter extends ilXmlImporter implements ilForumObjectConstants
                 if (!$frm || !($frm instanceof ilObjForum)) {
                     continue;
                 }
-                ilForumProperties::getInstance($frm->getId())->writeStyleSheetId($newStyleId);
+                $this->content_style_domain
+                    ->styleForObjId($newForumId)
+                    ->updateStyleId($newStyleId);
             }
         }
     }

--- a/Modules/Forum/classes/class.ilForumXMLParser.php
+++ b/Modules/Forum/classes/class.ilForumXMLParser.php
@@ -292,7 +292,6 @@ class ilForumXMLParser extends ilSaxParser
                     $newObjProp->setFileUploadAllowed((bool) ($this->forumArray['FileUpload'] ?? false));
                     $newObjProp->setThreadSorting((int) ($this->forumArray['Sorting'] ?? ilForumProperties::THREAD_SORTING_DEFAULT));
                     $newObjProp->setMarkModeratorPosts((bool) ($this->forumArray['MarkModeratorPosts'] ?? false));
-                    $newObjProp->setStyleSheetId((int) ($this->forumArray['StyleId'] ?? 0));
                     $newObjProp->update();
 
                     $id = $this->getNewForumPk();
@@ -300,12 +299,6 @@ class ilForumXMLParser extends ilSaxParser
                     $this->mapping['frm'][$this->forumArray['Id']] = $id;
                     $this->lastHandledForumId = $id;
 
-                    $this->importMapping->addMapping(
-                        'Modules/Forum',
-                        'style',
-                        (string) $this->forum->getId(),
-                        (string) $newObjProp->getStyleSheetId()
-                    );
                     $this->importMapping->addMapping(
                         'Services/COPage',
                         'pg',

--- a/Modules/Forum/classes/class.ilForumXMLWriter.php
+++ b/Modules/Forum/classes/class.ilForumXMLWriter.php
@@ -59,9 +59,6 @@ class ilForumXMLWriter extends ilXmlWriter
         $this->xmlElement("Id", null, (int) $row->top_pk);
         $this->xmlElement("ObjId", null, (int) $row->obj_id);
         $this->xmlElement("Title", null, $row->title);
-        if ($row->stylesheet > 0) {
-            $this->xmlElement("StyleId", null, $row->stylesheet);
-        }
         $this->xmlElement("Description", null, $row->description);
         $this->xmlElement("DefaultView", null, (int) $row->default_view);
         $this->xmlElement("Pseudonyms", null, (int) $row->anonymized);

--- a/Modules/Glossary/Export/GlossaryHtmlExport.php
+++ b/Modules/Glossary/Export/GlossaryHtmlExport.php
@@ -32,6 +32,7 @@ class GlossaryHtmlExport
     protected \ILIAS\GlobalScreen\Services $global_screen;
     protected \ILIAS\Services\Export\HTML\Util $export_util;
     protected \ilCOPageHTMLExport $co_page_html_export;
+    protected \ILIAS\Style\Content\Object\ObjectFacade $content_style;
 
     public function __construct(
         \ilObjGlossary $glo,
@@ -53,6 +54,10 @@ class GlossaryHtmlExport
         $this->glo_gui = new \ilGlossaryPresentationGUI("html", $this->target_dir);
 
         $this->global_screen->tool()->context()->current()->addAdditionalData(\ilHTMLExportViewLayoutProvider::HTML_EXPORT_RENDERING, true);
+        $this->content_style = $DIC
+            ->contentStyle()
+            ->domain()
+            ->styleForRefId($glo->getRefId());
     }
 
     protected function initDirectories() : void
@@ -66,7 +71,7 @@ class GlossaryHtmlExport
     {
         $this->initDirectories();
         $this->export_util->exportSystemStyle();
-        $this->export_util->exportCOPageFiles($this->glossary->getStyleSheetId(), "glo");
+        $this->export_util->exportCOPageFiles($this->content_style->getEffectiveStyleId(), "glo");
 
         // export terms
         $this->exportHTMLGlossaryTerms();
@@ -116,9 +121,8 @@ class GlossaryHtmlExport
         $location_stylesheet = \ilUtil::getStyleSheetLocation();
         $this->global_screen->layout()->meta()->addCss($location_stylesheet);
         $this->global_screen->layout()->meta()->addCss(
-            \ilObjStyleSheet::getContentStylePath($this->glossary->getStyleSheetId())
+            \ilObjStyleSheet::getContentStylePath($this->content_style->getEffectiveStyleId())
         );
-
 
         //$this->addSupplyingExportFiles();
 

--- a/Modules/Glossary/Term/class.ilGlossaryTermGUI.php
+++ b/Modules/Glossary/Term/class.ilGlossaryTermGUI.php
@@ -36,6 +36,8 @@ class ilGlossaryTermGUI
     protected ilLogger $log;
     protected ?ilObjGlossary $term_glossary = null;
     protected $toolbar;
+    protected \ILIAS\Style\Content\GUIService $content_style_gui;
+    protected \ILIAS\Style\Content\DomainService $content_style_domain;
 
     public function __construct(
         int $a_id = 0
@@ -73,6 +75,9 @@ class ilGlossaryTermGUI
                 $this->term_glossary = new ilObjGlossary(ilGlossaryTerm::_lookGlossaryID($a_id), false);
             }
         }
+        $cs = $DIC->contentStyle();
+        $this->content_style_gui = $cs->gui();
+        $this->content_style_domain = $cs->domain();
     }
 
     public function executeCommand() : void
@@ -356,7 +361,11 @@ class ilGlossaryTermGUI
         $ilTabs->activateTab("definitions");
 
         // content style
-        $this->tpl->addCss(ilObjStyleSheet::getContentStylePath($this->term_glossary->getStyleSheetId()));
+        $this->content_style_gui->addCss(
+            $this->tpl,
+            $this->term_glossary->getRefId(),
+            $this->term_glossary->getId()
+        );
         $this->tpl->addCss(ilObjStyleSheet::getSyntaxStylePath());
 
 
@@ -388,7 +397,11 @@ class ilGlossaryTermGUI
         for ($j = 0; $j < count($defs); $j++) {
             $def = $defs[$j];
             $page_gui = new ilGlossaryDefPageGUI($def["id"]);
-            $page_gui->setStyleId($this->term_glossary->getStyleSheetId());
+            $page_gui->setStyleId(
+                $this->content_style_domain->styleForObjId(
+                    $this->term_glossary->getId()
+                )->getEffectiveStyleId()
+            );
             $page_gui->setSourcecodeDownloadScript("ilias.php?baseClass=ilGlossaryPresentationGUI&amp;ref_id=" . $this->ref_id);
             $page_gui->setTemplateOutput(false);
             $output = $page_gui->preview();
@@ -459,7 +472,11 @@ class ilGlossaryTermGUI
         $this->setTabs();
         $ilTabs->activateTab("definitions");
 
-        $this->tpl->addCss(ilObjStyleSheet::getContentStylePath($this->term_glossary->getStyleSheetId()));
+        $this->content_style_gui->addCss(
+            $this->tpl,
+            $this->term_glossary->getRefId(),
+            $this->term_glossary->getId()
+        );
         $this->tpl->addCss(ilObjStyleSheet::getSyntaxStylePath());
 
         $this->tpl->setTitle(
@@ -475,7 +492,11 @@ class ilGlossaryTermGUI
         $definition = new ilGlossaryDefinition($this->request->getDefinitionId());
         $page_gui = new ilGlossaryDefPageGUI($definition->getId());
         $page_gui->setTemplateOutput(false);
-        $page_gui->setStyleId($this->term_glossary->getStyleSheetId());
+        $page_gui->setStyleId(
+            $this->content_style_domain->styleForObjId(
+                $this->term_glossary->getId()
+            )->getEffectiveStyleId()
+        );
         $page_gui->setSourcecodeDownloadScript("ilias.php?baseClass=ilGlossaryPresentationGUI&amp;ref_id=" . $this->ref_id);
         $page_gui->setFileDownloadLink("ilias.php?baseClass=ilGlossaryPresentationGUI&amp;ref_id=" . $this->ref_id);
         $page_gui->setFullscreenLink("ilias.php?baseClass=ilGlossaryPresentationGUI&amp;ref_id=" . $this->ref_id);

--- a/Modules/Glossary/Term/class.ilTermDefinitionEditorGUI.php
+++ b/Modules/Glossary/Term/class.ilTermDefinitionEditorGUI.php
@@ -29,6 +29,8 @@ class ilTermDefinitionEditorGUI
     public ilObjGlossary $glossary;
     public ilGlossaryDefinition $definition;
     public ilGlossaryTerm $term;
+    protected \ILIAS\Style\Content\GUIService $content_style_gui;
+    protected \ILIAS\Style\Content\Object\ObjectFacade $content_style_domain;
 
     public function __construct()
     {
@@ -57,6 +59,10 @@ class ilTermDefinitionEditorGUI
         $this->tabs_gui = $ilTabs;
 
         $this->ctrl->saveParameter($this, array("def"));
+
+        $cs = $DIC->contentStyle();
+        $this->content_style_gui = $cs->gui();
+        $this->content_style_domain = $cs->domain()->styleForRefId($this->glossary->getRefId());
     }
 
 
@@ -70,12 +76,11 @@ class ilTermDefinitionEditorGUI
         $cmd = $this->ctrl->getCmd();
 
         // content style
-        $this->tpl->setCurrentBlock("ContentStyle");
-        $this->tpl->setVariable(
-            "LOCATION_CONTENT_STYLESHEET",
-            ilObjStyleSheet::getContentStylePath($this->term_glossary->getStyleSheetId())
+        $this->content_style_gui->addCss(
+            $this->tpl,
+            $this->term_glossary->getRefId(),
+            $this->term_glossary->getId()
         );
-        $this->tpl->parseCurrentBlock();
 
         // syntax style
         $this->tpl->setCurrentBlock("SyntaxStyle");
@@ -150,10 +155,9 @@ class ilTermDefinitionEditorGUI
                 $page_gui->setTemplateTargetVar("ADM_CONTENT");
                 $page_gui->setOutputMode("edit");
 
-                $page_gui->setStyleId(ilObjStyleSheet::getEffectiveContentStyleId(
-                    $this->term_glossary->getStyleSheetId(),
-                    "glo"
-                ));
+                $page_gui->setStyleId($this->content_style_domain->getEffectiveStyleId());
+
+                $page_gui->setLocator($gloss_loc);
                 $page_gui->setIntLinkReturn($this->ctrl->getLinkTargetByClass(
                     "ilobjglossarygui",
                     "quickList",

--- a/Modules/Glossary/classes/class.ilObjGlossary.php
+++ b/Modules/Glossary/classes/class.ilObjGlossary.php
@@ -34,6 +34,8 @@ class ilObjGlossary extends ilObject implements ilAdvancedMetaDataSubItems
     public array $auto_glossaries = array();
     protected ilObjUser $user;
     protected array $public_export_file = [];
+    protected \ILIAS\Style\Content\Object\ObjectFacade $content_style_service;
+
 
     public function __construct(
         int $a_id = 0,
@@ -46,6 +48,10 @@ class ilObjGlossary extends ilObject implements ilAdvancedMetaDataSubItems
         $this->user = $DIC->user();
         $this->type = "glo";
         parent::__construct($a_id, $a_call_by_reference);
+        $this->content_style_service = $DIC
+            ->contentStyle()
+            ->domain()
+            ->styleForRefId((int) $this->getRefId());
     }
 
     public function create($a_upload = false)
@@ -72,10 +78,6 @@ class ilObjGlossary extends ilObject implements ilAdvancedMetaDataSubItems
         $this->setSnippetLength(200);
 
         $this->updateAutoGlossaries();
-
-        if (($this->getStyleSheetId()) > 0) {
-            ilObjStyleSheet::writeStyleUsage($this->getId(), $this->getStyleSheetId());
-        }
     }
 
     public function read()
@@ -100,8 +102,6 @@ class ilObjGlossary extends ilObject implements ilAdvancedMetaDataSubItems
         $this->setPresentationMode($gl_rec["pres_mode"]);
         $this->setSnippetLength($gl_rec["snippet_length"]);
         $this->setShowTaxonomy($gl_rec["show_tax"]);
-
-        $this->setStyleSheetId(ilObjStyleSheet::lookupObjectStyle($this->getId()));
 
         // read auto glossaries
         $set = $this->db->query(
@@ -234,17 +234,6 @@ class ilObjGlossary extends ilObject implements ilAdvancedMetaDataSubItems
         return $this->downloads_active;
     }
     
-    public function getStyleSheetId() : int
-    {
-        return $this->style_id;
-    }
-
-    public function setStyleSheetId(int $a_style_id) : void
-    {
-        $this->style_id = $a_style_id;
-    }
-
-
     public function setShowTaxonomy(bool $a_val) : void
     {
         $this->show_tax = $a_val;
@@ -316,7 +305,6 @@ class ilObjGlossary extends ilObject implements ilAdvancedMetaDataSubItems
                 'id' => array('integer', $this->getId())
             )
         );
-        ilObjStyleSheet::writeStyleUsage($this->getId(), $this->getStyleSheetId());
 
         $this->updateAutoGlossaries();
         parent::update();
@@ -758,13 +746,7 @@ class ilObjGlossary extends ilObject implements ilAdvancedMetaDataSubItems
         $new_obj->update();
 
         // set/copy stylesheet
-        $style_id = $this->getStyleSheetId();
-        if ($style_id > 0 && !ilObjStyleSheet::_lookupStandard($style_id)) {
-            $style_obj = ilObjectFactory::getInstanceByObjId($style_id);
-            $new_id = $style_obj->ilClone();
-            $new_obj->setStyleSheetId($new_id);
-            $new_obj->update();
-        }
+        $this->content_style_service->cloneTo($new_obj->getId());
         
         // copy taxonomy
         if (($tax_id = $this->getTaxonomyId()) > 0) {

--- a/Modules/Group/classes/class.ilObjGroupGUI.php
+++ b/Modules/Group/classes/class.ilObjGroupGUI.php
@@ -12,7 +12,7 @@ use ILIAS\Refinery\Factory;
  * @author    Sascha Hofmann <saschahofmann@gmx.de>
  *
  * @ilCtrl_Calls ilObjGroupGUI: ilGroupRegistrationGUI, ilPermissionGUI, ilInfoScreenGUI, ilLearningProgressGUI
- * @ilCtrl_Calls ilObjGroupGUI: ilPublicUserProfileGUI, ilObjCourseGroupingGUI, ilObjStyleSheetGUI
+ * @ilCtrl_Calls ilObjGroupGUI: ilPublicUserProfileGUI, ilObjCourseGroupingGUI, ilObjectContentStyleSettingsGUI
  * @ilCtrl_Calls ilObjGroupGUI: ilCourseContentGUI, ilColumnGUI, ilContainerPageGUI, ilObjectCopyGUI
  * @ilCtrl_Calls ilObjGroupGUI: ilObjectCustomUserFieldsGUI, ilMemberAgreementGUI, ilExportGUI, ilMemberExportGUI
  * @ilCtrl_Calls ilObjGroupGUI: ilCommonActionDispatcherGUI, ilObjectServiceSettingsGUI, ilSessionOverviewGUI
@@ -221,8 +221,16 @@ class ilObjGroupGUI extends ilContainerGUI
                 $this->ctrl->forwardCommand($cp);
                 break;
 
-            case "ilobjstylesheetgui":
-                $this->forwardToStyleSheet();
+            case "ilobjectcontentstylesettingsgui":
+                $this->checkPermission("write");
+                $this->setTitleAndDescription();
+                $this->showContainerPageTabs();
+                $settings_gui = $this->content_style_gui
+                    ->objectSettingsGUIForRefId(
+                        null,
+                        $this->object->getRefId()
+                    );
+                $this->ctrl->forwardCommand($settings_gui);
                 break;
                 
             case 'ilobjectcustomuserfieldsgui':

--- a/Modules/LearningModule/Editing/class.ilLMEditorGUI.php
+++ b/Modules/LearningModule/Editing/class.ilLMEditorGUI.php
@@ -37,6 +37,7 @@ class ilLMEditorGUI implements ilCtrlBaseClassInterface
     protected int $requested_active_node = 0;
     protected bool $to_page = false;
     protected EditingGUIRequest $request;
+    protected \ILIAS\Style\Content\GUIService $content_style_gui;
 
     public function __construct()
     {
@@ -94,6 +95,8 @@ class ilLMEditorGUI implements ilCtrlBaseClassInterface
         $this->to_page = $this->request->getToPage();
 
         $this->checkRequestParameters();
+        $cs = $DIC->contentStyle();
+        $this->content_style_gui = $cs->gui();
     }
     
     /**
@@ -198,12 +201,10 @@ class ilLMEditorGUI implements ilCtrlBaseClassInterface
         $this->tpl->loadStandardTemplate();
 
         // content style
-        $this->tpl->setCurrentBlock("ContentStyle");
-        $this->tpl->setVariable(
-            "LOCATION_CONTENT_STYLESHEET",
-            ilObjStyleSheet::getContentStylePath($this->lm_obj->getStyleSheetId())
+        $this->content_style_gui->addCss(
+            $this->tpl,
+            $this->lm_obj->getRefId()
         );
-        $this->tpl->parseCurrentBlock();
 
         // syntax style
         $this->tpl->setCurrentBlock("SyntaxStyle");

--- a/Modules/LearningModule/Export/class.LMHtmlExport.php
+++ b/Modules/LearningModule/Export/class.LMHtmlExport.php
@@ -44,6 +44,7 @@ class LMHtmlExport
     protected string $initial_user_language;
     protected string $initial_current_user_language;
     protected \ILIAS\GlobalScreen\Services $global_screen;
+    protected \ILIAS\Style\Content\Object\ObjectFacade $content_style_domain;
 
     public function __construct(
         \ilObjLearningModule $lm,
@@ -62,10 +63,9 @@ class LMHtmlExport
         $this->lang = $lang;
         $this->target_dir = $export_dir . "/" . $sub_dir;
         $this->co_page_html_export = new \ilCOPageHTMLExport($this->target_dir, $this->getLinker(), $lm->getRefId());
-        $this->co_page_html_export->setContentStyleId(\ilObjStyleSheet::getEffectiveContentStyleId(
-            $this->lm->getStyleSheetId(),
-            "lm"
-        ));
+        $this->co_page_html_export->setContentStyleId(
+            $this->content_style_domain->getEffectiveStyleId()
+        );
         $this->export_format = $export_format;
 
         // get learning module presentation gui class
@@ -83,6 +83,8 @@ class LMHtmlExport
         $this->export_util = new \ILIAS\Services\Export\HTML\Util($export_dir, $sub_dir);
 
         $this->setAdditionalContextData(\ilLMEditGSToolProvider::SHOW_TREE, false);
+        $cs = $DIC->contentStyle();
+        $this->content_style_domain = $cs->domain()->styleForRefId($this->lm->getRefId());
     }
 
     protected function getLinker() : PageLinker
@@ -226,7 +228,7 @@ class LMHtmlExport
         $this->initDirectories();
 
         $this->export_util->exportSystemStyle();
-        $this->export_util->exportCOPageFiles($this->lm->getStyleSheetId(), "lm");
+        $this->export_util->exportCOPageFiles($this->content_style_domain->getEffectiveStyleId(), "lm");
 
         $lang_iterator = $this->getLanguageIterator();
 

--- a/Modules/LearningModule/Export/class.ilContObjectExport.php
+++ b/Modules/LearningModule/Export/class.ilContObjectExport.php
@@ -136,6 +136,7 @@ class ilContObjectExport
         );
 
         // export style
+        /*
         if ($this->cont_obj->getStyleSheetId() > 0) {
             $style_obj = new ilObjStyleSheet($this->cont_obj->getStyleSheetId(), false);
             $style_obj->setExportSubDir("style");
@@ -143,7 +144,7 @@ class ilContObjectExport
             if (is_file($style_file)) {
                 copy($style_file, $this->export_dir . "/" . $this->subdir . "/style.zip");
             }
-        }
+        }*/
 
         // dump xml document to file
         $this->xml->xmlDumpFile($this->export_dir . "/" . $this->subdir . "/" . $this->filename, false);

--- a/Modules/LearningModule/Presentation/class.ilLMPresentationGUI.php
+++ b/Modules/LearningModule/Presentation/class.ilLMPresentationGUI.php
@@ -78,6 +78,9 @@ class ilLMPresentationGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInt
     protected int $requested_notification_switch = 0;
     protected bool $abstract = false;
     protected ilObjectTranslation $ot;
+    protected \ILIAS\Style\Content\Object\ObjectFacade $content_style_domain;
+    protected \ILIAS\Style\Content\GUIService $content_style_gui;
+    protected \ILIAS\Style\Content\Service $cs;
 
     public function __construct(
         string $a_export_format = "",
@@ -163,6 +166,8 @@ class ilLMPresentationGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInt
                 $params
             );
         }
+
+        $this->cs = $DIC->contentStyle();
     }
 
     public function getUnsafeGetCommands() : array
@@ -244,6 +249,8 @@ class ilLMPresentationGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInt
         $this->lm_tree = $this->service->getLMTree();
         $this->focus_id = $this->service->getPresentationStatus()->getFocusId();
         $this->ot = ilObjectTranslation::getInstance($this->lm->getId());
+        $this->content_style_gui = $this->cs->gui();
+        $this->content_style_domain = $this->cs->domain()->styleForRefId($this->lm->getRefId());
     }
 
     public function getService() : \ilLMPresentationService
@@ -1065,7 +1072,10 @@ class ilLMPresentationGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInt
     protected function setContentStyles() : void
     {
         // content style
-        $this->tpl->addCss(ilObjStyleSheet::getContentStylePath($this->lm->getStyleSheetId()));
+        $this->content_style_gui->addCss(
+            $this->tpl,
+            $this->lm->getRefId()
+        );
         $this->tpl->addCss(ilObjStyleSheet::getSyntaxStylePath());
     }
 
@@ -1185,10 +1195,9 @@ class ilLMPresentationGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInt
 
     public function basicPageGuiInit(\ilPageObjectGUI $a_page_gui) : void
     {
-        $a_page_gui->setStyleId(ilObjStyleSheet::getEffectiveContentStyleId(
-            $this->lm->getStyleSheetId(),
-            "lm"
-        ));
+        $a_page_gui->setStyleId(
+            $this->content_style_domain->getEffectiveStyleId()
+        );
         if (!$this->offlineMode()) {
             $a_page_gui->setOutputMode("presentation");
             $this->fill_on_load_code = true;
@@ -1683,10 +1692,9 @@ class ilLMPresentationGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInt
         if ($this->lm->getFooterPage() > 0 && !$this->lm->getHideHeaderFooterPrint()) {
             if (ilLMObject::_exists($this->lm->getFooterPage())) {
                 $page_object_gui = $this->getLMPageGUI($this->lm->getFooterPage());
-                $page_object_gui->setStyleId(ilObjStyleSheet::getEffectiveContentStyleId(
-                    $this->lm->getStyleSheetId(),
-                    "lm"
-                ));
+                $page_object_gui->setStyleId(
+                    $this->content_style_domain->getEffectiveStyleId()
+                );
 
                 // determine target frames for internal links
                 $page_object_gui->setLinkFrame($this->requested_frame);
@@ -1701,10 +1709,9 @@ class ilLMPresentationGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInt
         if ($this->lm->getHeaderPage() > 0 && !$this->lm->getHideHeaderFooterPrint()) {
             if (ilLMObject::_exists($this->lm->getHeaderPage())) {
                 $page_object_gui = $this->getLMPageGUI($this->lm->getHeaderPage());
-                $page_object_gui->setStyleId(ilObjStyleSheet::getEffectiveContentStyleId(
-                    $this->lm->getStyleSheetId(),
-                    "lm"
-                ));
+                $page_object_gui->setStyleId(
+                    $this->content_style_domain->getEffectiveStyleId()
+                );
 
                 // determine target frames for internal links
                 $page_object_gui->setLinkFrame($this->requested_frame);
@@ -1823,10 +1830,9 @@ class ilLMPresentationGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInt
                     $page_id = $node["obj_id"];
                     $page_object_gui = $this->getLMPageGUI($page_id);
                     $page_object = $page_object_gui->getPageObject();
-                    $page_object_gui->setStyleId(ilObjStyleSheet::getEffectiveContentStyleId(
-                        $this->lm->getStyleSheetId(),
-                        "lm"
-                    ));
+                    $page_object_gui->setStyleId(
+                        $this->content_style_domain->getEffectiveStyleId()
+                    );
 
                     // get lm page
                     $lm_pg_obj = new ilLMPageObject($this->lm, $page_id);

--- a/Modules/LearningModule/classes/class.ilLMPageObjectGUI.php
+++ b/Modules/LearningModule/classes/class.ilLMPageObjectGUI.php
@@ -26,6 +26,7 @@ class ilLMPageObjectGUI extends ilLMObjectGUI
     protected ilPropertyFormGUI $form;
     protected ilTabsGUI $tabs;
     protected ilSetting $settings;
+    protected \ILIAS\Style\Content\DomainService $content_style_domain;
 
     public function __construct(
         ilObjLearningModule $a_content_obj
@@ -38,6 +39,8 @@ class ilLMPageObjectGUI extends ilLMObjectGUI
         $this->settings = $DIC->settings();
         $this->lng = $DIC->language();
         parent::__construct($a_content_obj);
+        $cs = $DIC->contentStyle();
+        $this->content_style_domain = $cs->domain();
     }
 
     /**
@@ -106,10 +109,9 @@ class ilLMPageObjectGUI extends ilLMObjectGUI
                     $view_frame
                 );
 
-                $page_gui->setStyleId(ilObjStyleSheet::getEffectiveContentStyleId(
-                    $this->content_object->getStyleSheetId(),
-                    "lm"
-                ));
+                $page_gui->setStyleId($this->content_style_domain
+                    ->styleForRefId($this->content_object->getRefId())
+                    ->getEffectiveStyleId());
                 $page_gui->setTemplateTargetVar("ADM_CONTENT");
                 $page_gui->getPageObject()->buildDom();
                 $int_links = $page_gui->getPageObject()->getInternalLinks();

--- a/Modules/LearningModule/classes/class.ilLearningModuleExporter.php
+++ b/Modules/LearningModule/classes/class.ilLearningModuleExporter.php
@@ -22,9 +22,12 @@ class ilLearningModuleExporter extends ilXmlExporter
 {
     private ilLearningModuleDataSet $ds;
     private ilExportConfig $config;
+    protected \ILIAS\Style\Content\DomainService $content_style_domain;
 
     public function init() : void
     {
+        global $DIC;
+
         $this->ds = new ilLearningModuleDataSet();
         $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
         $this->ds->setDSPrefix("ds");
@@ -34,6 +37,8 @@ class ilLearningModuleExporter extends ilXmlExporter
             $conf->setMasterLanguageOnly(true, $this->config->getIncludeMedia());
             $this->ds->setMasterLanguageOnly(true);
         }
+        $this->content_style_domain = $DIC->contentStyle()
+            ->domain();
     }
 
     public function getXmlExportTailDependencies(
@@ -105,11 +110,12 @@ class ilLearningModuleExporter extends ilXmlExporter
 
             // style
             foreach ($a_ids as $id) {
-                if (($s = ilObjContentObject::_lookupStyleSheetId($id)) > 0) {
+                $style_id = $this->content_style_domain->styleForObjId($id)->getStyleId();
+                if ($style_id > 0) {
                     $deps[] = array(
                         "component" => "Services/Style",
                         "entity" => "sty",
-                        "ids" => $s
+                        "ids" => $style_id
                     );
                 }
             }

--- a/Modules/LearningModule/classes/class.ilObjContentObjectGUI.php
+++ b/Modules/LearningModule/classes/class.ilObjContentObjectGUI.php
@@ -57,6 +57,7 @@ class ilObjContentObjectGUI extends ilObjectGUI
     protected bool $requested_lmmovecopy = false;
     protected ilObjLearningModule $lm;
     protected EditingGUIRequest $edit_request;
+    protected \ILIAS\Style\Content\Service $content_style_service;
 
     public function __construct(
         $a_data,
@@ -116,6 +117,8 @@ class ilObjContentObjectGUI extends ilObjectGUI
         $this->requested_link_ref_id = $req->getLinkRefId();
         $this->requested_totransl = $req->getToTranslation();
         $this->requested_lmmovecopy = $req->getLMMoveCopy();
+        $this->content_style_service = $DIC
+            ->contentStyle();
     }
 
     /**
@@ -192,23 +195,23 @@ class ilObjContentObjectGUI extends ilObjectGUI
                 $this->ctrl->forwardCommand($md_gui);
                 break;
 
-            case "ilobjstylesheetgui":
+            case "ilobjectcontentstylesettingsgui":
+                $this->checkPermission("write");
+                $this->addHeaderAction();
+                $this->setTitleAndDescription();
                 $this->addLocations();
-                $this->ctrl->setReturn($this, "editStyleProperties");
-                $style_gui = new ilObjStyleSheetGUI("", $this->lm->getStyleSheetId(), false, false);
-                $style_gui->omitLocator();
-                if ($cmd == "create" || $this->requested_new_type == "sty") {
-                    $style_gui->setCreationMode(true);
-                }
-                $ret = $this->ctrl->forwardCommand($style_gui);
+                $this->setTabs("settings");
+                $this->setSubTabs("cont_style");
 
-                if ($cmd == "save" || $cmd == "copyStyle" || $cmd == "importStyle") {
-                    $style_id = $ret;
-                    $this->lm->setStyleSheetId($style_id);
-                    $this->lm->update();
-                    $this->ctrl->redirectByClass("ilobjstylesheetgui", "edit");
-                }
+                $settings_gui = $this->content_style_service
+                    ->gui()
+                    ->objectSettingsGUIForRefId(
+                        null,
+                        $this->object->getRefId()
+                    );
+                $this->ctrl->forwardCommand($settings_gui);
                 break;
+
 
             case "illmpageobjectgui":
                 $this->setTitleAndDescription();
@@ -719,130 +722,6 @@ class ilObjContentObjectGUI extends ilObjectGUI
             $this->form->setValuesByPost();
             $this->tpl->setContent($this->form->getHTML());
         }
-    }
-
-    /**
-     * Edit style properties
-     */
-    public function editStyleProperties() : void
-    {
-        $tpl = $this->tpl;
-        
-        $this->initStylePropertiesForm();
-        $tpl->setContent($this->form->getHTML());
-    }
-    
-    /**
-     * Init style properties form
-     */
-    public function initStylePropertiesForm() : void
-    {
-        $ilCtrl = $this->ctrl;
-        $lng = $this->lng;
-        $ilTabs = $this->tabs;
-        $ilSetting = $this->settings;
-        
-        $lng->loadLanguageModule("style");
-        $this->setTabs();
-        $ilTabs->setTabActive("settings");
-        $this->setSubTabs("cont_style");
-
-        $this->form = new ilPropertyFormGUI();
-        
-        $fixed_style = $ilSetting->get("fixed_content_style_id");
-        $def_style = $ilSetting->get("default_content_style_id");
-        $style_id = $this->lm->getStyleSheetId();
-
-        if ($fixed_style > 0) {
-            $st = new ilNonEditableValueGUI($lng->txt("cont_current_style"));
-            $st->setValue(ilObject::_lookupTitle($fixed_style) . " (" .
-                $this->lng->txt("global_fixed") . ")");
-            $this->form->addItem($st);
-        } else {
-            $st_styles = ilObjStyleSheet::_getStandardStyles(
-                true,
-                false,
-                $this->requested_ref_id
-            );
-
-            if ($def_style > 0) {
-                $st_styles[0] = ilObject::_lookupTitle($def_style) . " (" . $this->lng->txt("default") . ")";
-            } else {
-                $st_styles[0] = $this->lng->txt("default");
-            }
-            ksort($st_styles);
-
-            if ($style_id > 0) {
-                // individual style
-                if (!ilObjStyleSheet::_lookupStandard($style_id)) {
-                    $st = new ilNonEditableValueGUI($lng->txt("cont_current_style"));
-                    $st->setValue(ilObject::_lookupTitle($style_id));
-                    $this->form->addItem($st);
-
-                    // delete command
-                    $this->form->addCommandButton(
-                        "editStyle",
-                        $lng->txt("cont_edit_style")
-                    );
-                    $this->form->addCommandButton(
-                        "deleteStyle",
-                        $lng->txt("cont_delete_style")
-                    );
-                }
-            }
-
-            if ($style_id <= 0 || ilObjStyleSheet::_lookupStandard($style_id)) {
-                $style_sel = new ilSelectInputGUI($lng->txt("cont_current_style"), "style_id");
-                $style_sel->setOptions($st_styles);
-                $style_sel->setValue($style_id);
-                $this->form->addItem($style_sel);
-                $this->form->addCommandButton(
-                    "saveStyleSettings",
-                    $lng->txt("save")
-                );
-                $this->form->addCommandButton(
-                    "createStyle",
-                    $lng->txt("sty_create_ind_style")
-                );
-            }
-        }
-        $this->form->setTitle($lng->txt("cont_style"));
-        $this->form->setFormAction($ilCtrl->getFormAction($this));
-    }
-    
-    public function createStyle() : void
-    {
-        $ilCtrl = $this->ctrl;
-
-        $ilCtrl->redirectByClass("ilobjstylesheetgui", "create");
-    }
-    
-    public function editStyle() : void
-    {
-        $ilCtrl = $this->ctrl;
-
-        $ilCtrl->redirectByClass("ilobjstylesheetgui", "edit");
-    }
-
-    public function deleteStyle() : void
-    {
-        $ilCtrl = $this->ctrl;
-
-        $ilCtrl->redirectByClass("ilobjstylesheetgui", "delete");
-    }
-
-    public function saveStyleSettings() : void
-    {
-        $ilSetting = $this->settings;
-    
-        if ($ilSetting->get("fixed_content_style_id") <= 0 &&
-            (ilObjStyleSheet::_lookupStandard($this->lm->getStyleSheetId())
-            || $this->lm->getStyleSheetId() == 0)) {
-            $this->lm->setStyleSheetId($this->edit_request->getStyleId());
-            $this->lm->update();
-            ilUtil::sendSuccess($this->lng->txt("msg_obj_modified"), true);
-        }
-        $this->ctrl->redirect($this, "editStyleProperties");
     }
 
     public function initMenuForm() : ilPropertyFormGUI
@@ -2021,9 +1900,9 @@ class ilObjContentObjectGUI extends ilObjectGUI
             // style properties
             $ilTabs->addSubTabTarget(
                 "cont_style",
-                $this->ctrl->getLinkTarget($this, 'editStyleProperties'),
+                $this->ctrl->getLinkTargetByClass("ilObjectContentStyleSettingsGUI", ""),
                 "",
-                ""
+                "ilObjectContentStyleSettingsGUI"
             );
 
             // menu properties

--- a/Modules/LearningModule/classes/class.ilObjLearningModuleGUI.php
+++ b/Modules/LearningModule/classes/class.ilObjLearningModuleGUI.php
@@ -15,7 +15,7 @@
 
 /**
 * @author Alexander Killing <killing@leifos.de>
-* @ilCtrl_Calls ilObjLearningModuleGUI: ilLMPageObjectGUI, ilStructureObjectGUI, ilObjStyleSheetGUI, ilObjectMetaDataGUI
+* @ilCtrl_Calls ilObjLearningModuleGUI: ilLMPageObjectGUI, ilStructureObjectGUI, ilObjectContentStyleSettingsGUI, ilObjectMetaDataGUI
 * @ilCtrl_Calls ilObjLearningModuleGUI: ilLearningProgressGUI, ilPermissionGUI, ilInfoScreenGUI, ilObjectCopyGUI
 * @ilCtrl_Calls ilObjLearningModuleGUI: ilExportGUI, ilCommonActionDispatcherGUI, ilPageMultiLangGUI, ilObjectTranslationGUI
 * @ilCtrl_Calls ilObjLearningModuleGUI: ilMobMultiSrtUploadGUI, ilLMImportGUI, ilLMEditShortTitlesGUI, ilLTIProviderObjectSettingGUI

--- a/Modules/MediaPool/classes/class.ilMediaPoolPageGUI.php
+++ b/Modules/MediaPool/classes/class.ilMediaPoolPageGUI.php
@@ -39,7 +39,10 @@ class ilMediaPoolPageGUI extends ilPageObjectGUI
         
         parent::__construct("mep", $a_id, $a_old_nr, $a_prevent_get_id, $a_lang);
 
-        $this->setStyleId(ilObjStyleSheet::getEffectiveContentStyleId(0));
+        $cs = $DIC->contentStyle()
+            ->domain()
+            ->styleForObjId($this->getPageObject()->getParentId());
+        $this->setStyleId($cs->getEffectiveStyleId());
 
         $this->setEditPreview(true);
     }

--- a/Modules/Portfolio/Export/PortfolioHtmlExport.php
+++ b/Modules/Portfolio/Export/PortfolioHtmlExport.php
@@ -39,6 +39,7 @@ class PortfolioHtmlExport
     protected string $active_tab;
     protected bool $include_comments = false;
     protected bool $print_version = false;
+    protected \ILIAS\Style\Content\Object\ObjectFacade $content_style_domain;
 
     public function __construct(
         \ilObjPortfolioBaseGUI $portfolio_gui
@@ -58,6 +59,10 @@ class PortfolioHtmlExport
             \ilHTMLExportViewLayoutProvider::HTML_EXPORT_RENDERING,
             true
         );
+
+        $this->content_style_domain = $DIC
+            ->contentStyle()
+            ->domain()->styleForObjId($this->portfolio->getId());
     }
 
     protected function init() : void
@@ -135,7 +140,7 @@ class PortfolioHtmlExport
 
         $this->export_util->exportSystemStyle();
         $this->export_util->exportCOPageFiles(
-            $this->portfolio->getStyleSheetId(),
+            $this->content_style_domain->getEffectiveStyleId(),
             $this->portfolio->getType()
         );
 
@@ -293,7 +298,9 @@ class PortfolioHtmlExport
         $location_stylesheet = \ilUtil::getStyleSheetLocation();
         $this->global_screen->layout()->meta()->addCss($location_stylesheet);
         $this->global_screen->layout()->meta()->addCss(
-            \ilObjStyleSheet::getContentStylePath($this->portfolio->getStyleSheetId())
+            \ilObjStyleSheet::getContentStylePath(
+                $this->content_style_domain->getEffectiveStyleId()
+            )
         );
         \ilPCQuestion::resetInitialState();
 

--- a/Modules/Portfolio/Template/class.ilObjPortfolioTemplateGUI.php
+++ b/Modules/Portfolio/Template/class.ilObjPortfolioTemplateGUI.php
@@ -20,8 +20,9 @@
  *
  * @ilCtrl_Calls ilObjPortfolioTemplateGUI: ilPortfolioTemplatePageGUI, ilPageObjectGUI, ilNoteGUI
  * @ilCtrl_Calls ilObjPortfolioTemplateGUI: ilObjectCopyGUI, ilInfoScreenGUI, ilCommonActionDispatcherGUI
- * @ilCtrl_Calls ilObjPortfolioTemplateGUI: ilPermissionGUI, ilExportGUI, ilObjStyleSheetGUI
+ * @ilCtrl_Calls ilObjPortfolioTemplateGUI: ilPermissionGUI, ilExportGUI, ilObjectContentStyleSettingsGUI
  * @ilCtrl_Calls ilObjPortfolioTemplateGUI: ilObjectMetaDataGUI
+.php
  */
 class ilObjPortfolioTemplateGUI extends ilObjPortfolioBaseGUI
 {
@@ -106,37 +107,19 @@ class ilObjPortfolioTemplateGUI extends ilObjPortfolioBaseGUI
                 $exp_gui->addFormat("xml");
                 $this->ctrl->forwardCommand($exp_gui);
                 break;
-            
-            case "ilobjstylesheetgui":
-                $this->ctrl->setReturn($this, "editStyleProperties");
-                $style_gui = new ilObjStyleSheetGUI("", $this->object->getStyleSheetId(), false, false);
-                $style_gui->omitLocator();
-                if ($cmd == "create" || $this->port_request->getNewType() == "sty") {
-                    $style_gui->setCreationMode(true);
-                }
 
-                if ($cmd == "confirmedDelete") {
-                    $this->object->setStyleSheetId(0);
-                    $this->object->update();
-                }
-
-                $ret = $this->ctrl->forwardCommand($style_gui);
-
-                if ($cmd == "save" || $cmd == "copyStyle" || $cmd == "importStyle") {
-                    $style_id = $ret;
-                    $this->object->setStyleSheetId($style_id);
-                    $this->object->update();
-                    $this->ctrl->redirectByClass("ilobjstylesheetgui", "edit");
-                }
-                break;
-
-            case 'ilobjectmetadatagui':
+            case "ilobjectcontentstylesettingsgui":
                 $this->checkPermission("write");
                 $this->prepareOutput();
                 $this->addHeaderAction();
-                $this->tabs->activateTab("advmd");
-                $md_gui = new ilObjectMetaDataGUI($this->object, "pfpg");
-                $this->ctrl->forwardCommand($md_gui);
+                $this->tabs_gui->activateTab("settings");
+                $this->setSettingsSubTabs("style");
+                $settings_gui = $this->content_style_gui
+                    ->objectSettingsGUIForRefId(
+                        null,
+                        $this->object->getRefId()
+                    );
+                $this->ctrl->forwardCommand($settings_gui);
                 break;
 
             default:

--- a/Modules/Portfolio/classes/class.ilObjPortfolioBase.php
+++ b/Modules/Portfolio/classes/class.ilObjPortfolioBase.php
@@ -28,6 +28,7 @@ abstract class ilObjPortfolioBase extends ilObject2
     protected string $img;
     protected string $ppic;
     protected bool $style;
+    protected \ILIAS\Style\Content\Object\ObjectFacade $content_style_domain;
 
     public function __construct(
         int $a_id = 0,
@@ -39,6 +40,10 @@ abstract class ilObjPortfolioBase extends ilObject2
         $this->setting = $DIC->settings();
 
         $this->db = $DIC->database();
+        $this->content_style_domain = $DIC
+            ->contentStyle()
+            ->domain()
+            ->styleForObjId($this->getId());
     }
 
 
@@ -134,17 +139,6 @@ abstract class ilObjPortfolioBase extends ilObject2
         $this->img = $a_value;
     }
     
-    public function getStyleSheetId() : int
-    {
-        return (int) $this->style;
-    }
-
-    public function setStyleSheetId(int $a_style) : void
-    {
-        $this->style = $a_style;
-    }
-    
-    
     //
     // CRUD
     //
@@ -165,8 +159,6 @@ abstract class ilObjPortfolioBase extends ilObject2
         
         // #14661
         $this->setPublicComments(ilNote::commentsActivated($this->id, 0, $this->getType()));
-        
-        $this->setStyleSheetId(ilObjStyleSheet::lookupObjectStyle($this->id));
         
         $this->doReadCustom($row);
     }
@@ -200,8 +192,6 @@ abstract class ilObjPortfolioBase extends ilObject2
         // #14661
         ilNote::activateComments($this->id, 0, $this->getType(), $this->hasPublicComments());
         
-        ilObjStyleSheet::writeStyleUsage($this->id, $this->getStyleSheetId());
-                
         $ilDB->update(
             "usr_portfolio",
             $fields,
@@ -357,19 +347,17 @@ abstract class ilObjPortfolioBase extends ilObject2
         $target_dir = $a_target->initStorage($a_target->getId());
         ilFSStoragePortfolio::_copyDirectory($source_dir, $target_dir);
         
-        // set/copy stylesheet
-        $style_id = $a_source->getStyleSheetId();
-        if ($style_id > 0 && !ilObjStyleSheet::_lookupStandard($style_id)) {
-            $style_obj = ilObjectFactory::getInstanceByObjId($style_id);
-            $new_id = $style_obj->ilClone();
-            $a_target->setStyleSheetId($new_id);
-            $a_target->update();
-        }
-
         // container settings
         foreach (ilContainer::_getContainerSettings($a_source->getId()) as $keyword => $value) {
             ilContainer::_writeContainerSetting($a_target->getId(), $keyword, $value);
         }
+
+        // style
+        $content_style_domain = $DIC
+            ->contentStyle()
+            ->domain()
+            ->styleForObjId($a_source->getId());
+        $content_style_domain->cloneTo($a_target->getId());
     }
 
     /**

--- a/Modules/Portfolio/classes/class.ilObjPortfolioGUI.php
+++ b/Modules/Portfolio/classes/class.ilObjPortfolioGUI.php
@@ -20,7 +20,7 @@ use ILIAS\GlobalScreen\ScreenContext\ContextServices;
  * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>
  * @ilCtrl_Calls ilObjPortfolioGUI: ilPortfolioPageGUI, ilPageObjectGUI
  * @ilCtrl_Calls ilObjPortfolioGUI: ilWorkspaceAccessGUI, ilNoteGUI
- * @ilCtrl_Calls ilObjPortfolioGUI: ilObjStyleSheetGUI, ilPortfolioExerciseGUI
+ * @ilCtrl_Calls ilObjPortfolioGUI: ilObjectContentStyleSettingsGUI, ilPortfolioExerciseGUI
  */
 class ilObjPortfolioGUI extends ilObjPortfolioBaseGUI
 {
@@ -113,7 +113,8 @@ class ilObjPortfolioGUI extends ilObjPortfolioBaseGUI
             case "ilnotegui":
                 $this->preview();
                 break;
-            
+
+                /*
             case "ilobjstylesheetgui":
                 $this->ctrl->setReturn($this, "editStyleProperties");
                 $style_gui = new ilObjStyleSheetGUI("", $this->object->getStyleSheetId(), false, false);
@@ -136,8 +137,22 @@ class ilObjPortfolioGUI extends ilObjPortfolioBaseGUI
                     $this->object->update();
                     $this->ctrl->redirectByClass("ilobjstylesheetgui", "edit");
                 }
+                break;*/
+
+            case "ilobjectcontentstylesettingsgui":
+                $this->checkPermission("write");
+                $this->addLocator();
+                $this->setTabs();
+                $this->tabs_gui->activateTab("settings");
+                $this->setSettingsSubTabs("style");
+                $settings_gui = $this->content_style_gui
+                    ->objectSettingsGUIForObjId(
+                        null,
+                        $this->object->getId()
+                    );
+                $this->ctrl->forwardCommand($settings_gui);
                 break;
-                
+
             case "ilportfolioexercisegui":
                 $this->ctrl->setReturn($this, "view");
                 $gui = new ilPortfolioExerciseGUI($this->user_id, $this->object->getId());

--- a/Modules/RootFolder/classes/class.ilObjRootFolderGUI.php
+++ b/Modules/RootFolder/classes/class.ilObjRootFolderGUI.php
@@ -21,7 +21,7 @@ use ILIAS\RootFolder\StandardGUIRequest;
  * @author Stefan Meyer <meyer@leifos.com>
  *
  * @ilCtrl_Calls ilObjRootFolderGUI: ilPermissionGUI, ilContainerPageGUI
- * @ilCtrl_Calls ilObjRootFolderGUI: ilColumnGUI, ilObjectCopyGUI, ilObjStyleSheetGUI
+ * @ilCtrl_Calls ilObjRootFolderGUI: ilColumnGUI, ilObjectCopyGUI, ilObjectContentStyleSettingsGUI
  * @ilCtrl_Calls ilObjRootFolderGUI: ilCommonActionDispatcherGUI, ilObjectTranslationGUI
  * @ilCtrl_Calls ilObjRootFolderGUI: ilRepositoryTrashGUI
  */
@@ -120,9 +120,9 @@ class ilObjRootFolderGUI extends ilContainerGUI
             case "ilcolumngui":
                 $this->checkPermission("read");
                 $this->prepareOutput();
-                $this->tpl->setVariable(
-                    "LOCATION_CONTENT_STYLESHEET",
-                    ilObjStyleSheet::getContentStylePath($this->object->getStyleSheetId())
+                $this->content_style_gui->addCss(
+                    $this->tpl,
+                    $this->object->getRefId()
                 );
                 $this->renderObject();
                 break;
@@ -133,9 +133,17 @@ class ilObjRootFolderGUI extends ilContainerGUI
                 $cp->setType('root');
                 $this->ctrl->forwardCommand($cp);
                 break;
-                
-            case "ilobjstylesheetgui":
-                $this->forwardToStyleSheet();
+
+            case "ilobjectcontentstylesettingsgui":
+                $this->checkPermission("write");
+                $this->setTitleAndDescription();
+                $this->showContainerPageTabs();
+                $settings_gui = $this->content_style_gui
+                    ->objectSettingsGUIForRefId(
+                        null,
+                        $this->object->getRefId()
+                    );
+                $this->ctrl->forwardCommand($settings_gui);
                 break;
             
             case "ilcommonactiondispatchergui":
@@ -162,9 +170,9 @@ class ilObjRootFolderGUI extends ilContainerGUI
                     }
                 }
                 $this->prepareOutput();
-                $this->tpl->setVariable(
-                    "LOCATION_CONTENT_STYLESHEET",
-                    ilObjStyleSheet::getContentStylePath($this->object->getStyleSheetId())
+                $this->content_style_gui->addCss(
+                    $this->tpl,
+                    $this->object->getRefId()
                 );
 
                 if (!$cmd) {

--- a/Modules/SystemFolder/classes/class.ilObjSystemFolderGUI.php
+++ b/Modules/SystemFolder/classes/class.ilObjSystemFolderGUI.php
@@ -19,6 +19,11 @@ use ILIAS\Setup\CLI\StatusCommand;
 class ilObjSystemFolderGUI extends ilObjectGUI
 {
     /**
+     * @var \ILIAS\Style\Content\Object\ObjectFacade
+     */
+    protected $content_style_domain;
+
+    /**
      * @var ilTabsGUI
      */
     protected $tabs;
@@ -103,6 +108,9 @@ class ilObjSystemFolderGUI extends ilObjectGUI
 
         $this->lng->loadLanguageModule("administration");
         $this->lng->loadLanguageModule("adm");
+        $this->content_style_domain = $DIC->contentStyle()
+                  ->domain()
+                  ->styleForRefId($this->object->getRefId());
     }
 
     public function executeCommand()
@@ -129,7 +137,9 @@ class ilObjSystemFolderGUI extends ilObjectGUI
                 $igui = new ilImprintGUI();
                                 
                 // needed for editor
-                $igui->setStyleId(ilObjStyleSheet::getEffectiveContentStyleId(0, "impr"));
+                $igui->setStyleId(
+                    $this->content_style_domain->getEffectiveStyleId()
+                );
                 
                 if (!$this->checkPermissionBool("write")) {
                     $igui->setEnableEditing(false);

--- a/Modules/Wiki/Export/WikiHtmlExport.php
+++ b/Modules/Wiki/Export/WikiHtmlExport.php
@@ -42,6 +42,7 @@ class WikiHtmlExport
     protected \ILIAS\GlobalScreen\Services $global_screen;
     protected \ilGlobalTemplateInterface $main_tpl;
     protected \ilWikiUserHTMLExport $user_html_exp;
+    protected \ILIAS\Style\Content\Object\ObjectFacade $content_style_domain;
 
     // has global context been initialized?
     protected static $context_init = false;
@@ -58,6 +59,10 @@ class WikiHtmlExport
         $this->log = \ilLoggerFactory::getLogger('wiki');
         $this->global_screen = $DIC->globalScreen();
         $this->main_tpl = $DIC->ui()->mainTemplate();
+        $this->content_style_domain = $DIC
+            ->contentStyle()
+            ->domain()
+            ->styleForRefId($a_wiki->getRefId());
     }
     
     public function setMode(
@@ -123,13 +128,10 @@ class WikiHtmlExport
 
 
         $this->export_util->exportSystemStyle();
-        $this->export_util->exportCOPageFiles($this->wiki->getStyleSheetId(), "wiki");
-
+        $eff_style_id = $this->content_style_domain->getEffectiveStyleId();
+        $this->export_util->exportCOPageFiles($eff_style_id, "wiki");
         $this->co_page_html_export = new \ilCOPageHTMLExport($this->export_dir);
-        $this->co_page_html_export->setContentStyleId(\ilObjStyleSheet::getEffectiveContentStyleId(
-            $this->wiki->getStyleSheetId(),
-            "wiki"
-        ));
+        $this->co_page_html_export->setContentStyleId($eff_style_id);
 
         // export pages
         $this->log->debug("export pages");

--- a/Services/Authentication/classes/class.ilAuthLoginPageEditorGUI.php
+++ b/Services/Authentication/classes/class.ilAuthLoginPageEditorGUI.php
@@ -38,6 +38,7 @@ class ilAuthLoginPageEditorGUI
     private int $ref_id = 0;
     private ilAuthLoginPageEditorSettings $settings;
     private ?ilSetting $loginSettings = null;
+    protected \ILIAS\Style\Content\Object\ObjectFacade $content_style_domain;
 
     public function __construct(int $a_ref_id)
     {
@@ -58,6 +59,9 @@ class ilAuthLoginPageEditorGUI
         $this->ref_id = $a_ref_id;
 
         $this->settings = ilAuthLoginPageEditorSettings::getInstance();
+        $this->content_style_domain = $DIC->contentStyle()
+            ->domain()
+            ->styleForRefId($a_ref_id);
     }
 
     /**
@@ -139,7 +143,7 @@ class ilAuthLoginPageEditorGUI
         //$page_gui->setLinkParams($this->ctrl->getUrlParameterString()); // todo
         //		$page_gui->setSourcecodeDownloadScript($this->ctrl->getLinkTarget($this, ""));
         $page_gui->setPresentationTitle("");
-        $page_gui->setStyleId(ilObjStyleSheet::getEffectiveContentStyleId(0));
+        $page_gui->setStyleId($this->content_style_domain->getEffectiveStyleId());
         $page_gui->setTemplateOutput(false);
         //$page_gui->setLocator($contObjLocator);
         $page_gui->setHeader("");

--- a/Services/Container/Content/class.ilContainerObjectiveGUI.php
+++ b/Services/Container/Content/class.ilContainerObjectiveGUI.php
@@ -33,7 +33,8 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
     protected ilLOSettings $loc_settings;
     private string $output_html = '';
     private ?ilLOTestAssignments $test_assignments = null;
-    
+    protected \ILIAS\Style\Content\Object\ObjectFacade $content_style_domain;
+
     public function __construct(ilContainerGUI $a_container_gui)
     {
         global $DIC;
@@ -51,6 +52,13 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
         parent::__construct($a_container_gui);
         
         $this->initTestAssignments();
+
+        // ak: note, also in ILIAS <= 7 this page did not
+        // use the container style, it could however, but this would be a conceptual change
+        $this->content_style_domain = $DIC
+            ->contentStyle()
+            ->domain()
+            ->styleForObjId(0);
     }
     
     public function getTestAssignments() : ilLOTestAssignments
@@ -792,7 +800,9 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
                 
                 $page_gui = new ilLOPageGUI($objective->getObjectiveId());
                 
-                $page_gui->setStyleId(ilObjStyleSheet::getEffectiveContentStyleId(0));
+                $page_gui->setStyleId(
+                    $this->content_style_domain->getEffectiveStyleId()
+                );
                 $page_gui->setPresentationTitle("");
                 $page_gui->setTemplateOutput(false);
                 $page_gui->setHeader("");

--- a/Services/Container/Export/class.ilContainerExporter.php
+++ b/Services/Container/Export/class.ilContainerExporter.php
@@ -20,8 +20,13 @@
  */
 class ilContainerExporter extends ilXmlExporter
 {
+    protected \ILIAS\Style\Content\DomainService $content_style_domain;
+
     public function __construct()
     {
+        global $DIC;
+        $this->content_style_domain = $DIC->contentStyle()
+            ->domain();
     }
     
     public function init() : void
@@ -66,9 +71,9 @@ class ilContainerExporter extends ilXmlExporter
         // style
         $style_ids = array();
         foreach ($a_ids as $id) {
-            $style_id = ilObjStyleSheet::lookupObjectStyle($id);
             // see #24888
-            $style_id = ilObjStyleSheet::getEffectiveContentStyleId($style_id);
+            $style = $this->content_style_domain->styleForObjId($id);
+            $style_id = $style->getEffectiveStyleId();
             if ($style_id > 0) {
                 $style_ids[] = $style_id;
             }

--- a/Services/Container/StartObjects/class.ilContainerStartObjectsContentGUI.php
+++ b/Services/Container/StartObjects/class.ilContainerStartObjectsContentGUI.php
@@ -28,7 +28,9 @@ class ilContainerStartObjectsContentGUI
     protected bool $enable_desktop;
     protected ilContainerGUI $parent_gui;
     protected ilContainer $parent_obj;
-    
+    protected \ILIAS\Style\Content\GUIService $content_style_gui;
+    protected \ILIAS\Style\Content\Object\ObjectFacade $content_style_domain;
+
     public function __construct(
         ilContainerGUI $a_gui,
         ilContainer $a_parent_obj
@@ -45,6 +47,9 @@ class ilContainerStartObjectsContentGUI
             $a_parent_obj->getRefId(),
             $a_parent_obj->getId()
         );
+        $cs = $DIC->contentStyle();
+        $this->content_style_domain = $cs->domain()->styleForRefId($a_parent_obj->getRefId());
+        $this->content_style_gui = $cs->gui();
     }
     
     public function enableDesktop(
@@ -94,13 +99,7 @@ class ilContainerStartObjectsContentGUI
             return "";
         }
 
-        $tpl->setVariable(
-            "LOCATION_CONTENT_STYLESHEET",
-            ilObjStyleSheet::getContentStylePath(ilObjStyleSheet::getEffectiveContentStyleId(
-                $this->parent_obj->getStyleSheetId(),
-                $this->parent_obj->getType()
-            ))
-        );
+        $this->content_style_gui->addCss($tpl, $this->parent_obj->getRefId());
         $tpl->setCurrentBlock("SyntaxStyle");
         $tpl->setVariable(
             "LOCATION_SYNTAX_STYLESHEET",
@@ -110,10 +109,7 @@ class ilContainerStartObjectsContentGUI
 
         $page_gui = new ilContainerStartObjectsPageGUI($page_id);
         
-        $page_gui->setStyleId(ilObjStyleSheet::getEffectiveContentStyleId(
-            $this->parent_obj->getStyleSheetId(),
-            $this->parent_obj->getType()
-        ));
+        $page_gui->setStyleId($this->content_style_domain->getEffectiveStyleId());
 
         $page_gui->setPresentationTitle("");
         $page_gui->setTemplateOutput(false);

--- a/Services/Container/StartObjects/class.ilContainerStartObjectsGUI.php
+++ b/Services/Container/StartObjects/class.ilContainerStartObjectsGUI.php
@@ -33,10 +33,18 @@ class ilContainerStartObjectsGUI
     protected ilObject $object;
     protected ilContainerStartObjects $start_object;
     protected StandardGUIRequest $request;
-    
+    /**
+     * @var \ILIAS\Style\Content\GUIService
+     */
+    protected $content_style_gui;
+
+    /**
+     * @var \ILIAS\Style\Content\Object\ObjectFacade
+     */
+    protected $content_style_domain;
+
     public function __construct(ilObject $a_parent_obj)
     {
-        /** @var \ILIAS\DI\Container $DIC */
         global $DIC;
 
         $this->access = $DIC->access();
@@ -64,6 +72,9 @@ class ilContainerStartObjectsGUI
             ->standardRequest();
         
         $this->lng->loadLanguageModule("crs");
+        $cs = $DIC->contentStyle();
+        $this->content_style_domain = $cs->domain()->styleForRefId($a_parent_obj->getRefId());
+        $this->content_style_gui = $cs->gui();
     }
     
     public function executeCommand() : void
@@ -86,20 +97,16 @@ class ilContainerStartObjectsGUI
                     unset($new_page_object);
                 }
 
-                $this->tpl->setVariable(
-                    "LOCATION_CONTENT_STYLESHEET",
-                    ilObjStyleSheet::getContentStylePath(ilObjStyleSheet::getEffectiveContentStyleId(
-                        $this->object->getStyleSheetId(),
-                        $this->object->getType()
-                    ))
+                $this->content_style_gui->addCss(
+                    $this->tpl,
+                    $this->object->getRefId()
                 );
 
                 $this->ctrl->setReturnByClass("ilcontainerstartobjectspagegui", "edit");
                 $pgui = new ilContainerStartObjectsPageGUI($this->object->getId());
-                $pgui->setStyleId(ilObjStyleSheet::getEffectiveContentStyleId(
-                    $this->object->getStyleSheetId(),
-                    $this->object->getType()
-                ));
+                $pgui->setStyleId(
+                    $this->content_style_domain->getEffectiveStyleId()
+                );
 
                 $ret = $this->ctrl->forwardCommand($pgui);
                 if ($ret) {

--- a/Services/Export/HTML/class.Util.php
+++ b/Services/Export/HTML/class.Util.php
@@ -55,10 +55,7 @@ class Util
         \ilMathJax::getInstance()->init(\ilMathJax::PURPOSE_EXPORT);
 
         // init co page html exporter
-        $this->co_page_html_export->setContentStyleId(\ilObjStyleSheet::getEffectiveContentStyleId(
-            $style_sheet_id,
-            $obj_type
-        ));
+        $this->co_page_html_export->setContentStyleId($style_sheet_id);
         $this->co_page_html_export->createDirectories();
         $this->co_page_html_export->exportStyles();
         $this->co_page_html_export->exportSupportScripts();

--- a/Services/Form/classes/class.ilImageFileInputGUI.php
+++ b/Services/Form/classes/class.ilImageFileInputGUI.php
@@ -23,7 +23,7 @@ class ilImageFileInputGUI extends ilFileInputGUI
     protected bool $cache = false;
     protected string $alt = "";
     protected string $image = "";
-    protected bool $allow_capture;
+    protected bool $allow_capture = false;
 
     public function __construct(
         string $a_title = "",

--- a/Services/Object/classes/class.ilObject2GUI.php
+++ b/Services/Object/classes/class.ilObject2GUI.php
@@ -207,6 +207,11 @@ abstract class ilObject2GUI extends ilObjectGUI
         return true;
     }
 
+    public function getIdType() : int
+    {
+        return $this->id_type;
+    }
+
     /**
      * create object instance as internal property (repository/workspace switch)
      */

--- a/Services/Style/Content/Container/class.ContainerDBRepository.php
+++ b/Services/Style/Content/Container/class.ContainerDBRepository.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+namespace ILIAS\Style\Content\Container;
+
+/**
+ * This repo stores infos on repository objects that are using booking managers as a service
+ * (resource management).
+ *
+ * @author Alexander Killing <killing@leifos.de>
+ */
+class ContainerDBRepository
+{
+    const TABLE_NAME = 'sty_rep_container';
+
+    /**
+     * @var \ilDBInterface
+     */
+    protected $db;
+
+    public function __construct(\ilDBInterface $db)
+    {
+        $this->db = $db;
+    }
+
+    public function updateReuse(int $ref_id, bool $reuse)
+    {
+        $db = $this->db;
+
+        $db->replace(
+            self::TABLE_NAME,
+            [
+                "ref_id" => ["integer", $ref_id]
+            ],
+            [
+                "reuse" => ["integer", (int) $reuse]
+            ]
+        );
+    }
+
+    public function readReuse(int $ref_id) : bool
+    {
+        $db = $this->db;
+
+        $set = $db->queryF(
+            "SELECT * FROM " . self::TABLE_NAME .
+            " WHERE ref_id = %s ",
+            ["integer"],
+            [$ref_id]
+        );
+        $rec = $db->fetchAssoc($set);
+
+        return (bool) ($rec["reuse"] ?? false);
+    }
+
+    /**
+     * For an array of ref ids, return only the ref ids
+     * that have the reuse flag set.
+     */
+    public function filterByReuse(array $ref_ids) : array
+    {
+        $db = $this->db;
+
+        $set = $db->queryF(
+            "SELECT * FROM " . self::TABLE_NAME .
+            " WHERE reuse = %s AND " . $db->in("ref_id", $ref_ids, false, "integer"),
+            ["integer"],
+            [1]
+        );
+        $ref_ids = [];
+        while ($rec = $db->fetchAssoc($set)) {
+            $ref_ids[] = (int) $rec["ref_id"];
+        }
+        return $ref_ids;
+    }
+}

--- a/Services/Style/Content/Container/class.ContainerManager.php
+++ b/Services/Style/Content/Container/class.ContainerManager.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+namespace ILIAS\Style\Content\Container;
+
+use \ILIAS\Style\Content\InternalRepoService;
+
+    /**
+ * Manages container related content style behaviour
+ * @author Alexander Killing <killing@leifos.de>
+ */
+class ContainerManager
+{
+    /**
+     * @var ContainerDBRepository
+     */
+    protected $container_repo;
+
+    /**
+     * @var int
+     */
+    protected $ref_id;
+
+    /**
+     * @var InternalRepoService
+     */
+    protected $repo_service;
+
+    public function __construct(
+        InternalRepoService $repo_service,
+        int $ref_id
+    ) {
+        $this->ref_id = $ref_id;
+        $this->repo_service = $repo_service;
+        $this->container_repo = $repo_service->repositoryContainer();
+    }
+
+    public function saveReuse(bool $reuse)
+    {
+        $this->container_repo->updateReuse($this->ref_id, $reuse);
+    }
+
+    public function getReuse() : bool
+    {
+        return $this->container_repo->readReuse($this->ref_id);
+    }
+}

--- a/Services/Style/Content/Object/class.ObjectDBRepository.php
+++ b/Services/Style/Content/Object/class.ObjectDBRepository.php
@@ -23,7 +23,7 @@ namespace ILIAS\Style\Content\Object;
  */
 class ObjectDBRepository
 {
-    const USAGE_TABLE_NAME = 'style_usage';
+    private const USAGE_TABLE_NAME = 'style_usage';
     const DATA_TABLE_NAME = 'style_data';
 
     /**

--- a/Services/Style/Content/Object/class.ObjectDBRepository.php
+++ b/Services/Style/Content/Object/class.ObjectDBRepository.php
@@ -29,7 +29,7 @@ class ObjectDBRepository
     /**
      * @var \ilDBInterface
      */
-    protected $db;
+    protected \ilDBInterface $db;
 
     public function __construct(\ilDBInterface $db)
     {

--- a/Services/Style/Content/Object/class.ObjectDBRepository.php
+++ b/Services/Style/Content/Object/class.ObjectDBRepository.php
@@ -40,7 +40,7 @@ class ObjectDBRepository
      * For an array of object IDs (objects using styles) get back
      * their owned styles (if any), object IDs without ownerships are removed
      * @param int[] $owner_obj_ids
-     * @return int[]
+     * @return array<int, int>
      */
     public function getOwnedStyles(array $owner_obj_ids) : array
     {

--- a/Services/Style/Content/Object/class.ObjectDBRepository.php
+++ b/Services/Style/Content/Object/class.ObjectDBRepository.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+namespace ILIAS\Style\Content\Object;
+
+/**
+ * This repo stores infos on repository objects that are using booking managers as a service
+ * (resource management).
+ *
+ * @author Alexander Killing <killing@leifos.de>
+ */
+class ObjectDBRepository
+{
+    const USAGE_TABLE_NAME = 'style_usage';
+    const DATA_TABLE_NAME = 'style_data';
+
+    /**
+     * @var \ilDBInterface
+     */
+    protected $db;
+
+    public function __construct(\ilDBInterface $db)
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * For an array of object IDs (objects using styles) get back
+     * their owned styles (if any), object IDs without ownerships are removed
+     * @param int[] $owner_obj_ids
+     * @return int[]
+     */
+    public function getOwnedStyles(array $owner_obj_ids) : array
+    {
+        $db = $this->db;
+
+        $set = $db->queryF(
+            "SELECT * FROM style_usage su JOIN style_data sd " .
+            " ON (su.style_id = sd.id AND su.obj_id = sd.owner_obj) " .
+            " WHERE " . $db->in("su.obj_id", $owner_obj_ids, false, "integer"),
+            [],
+            []
+        );
+
+        $owned = [];
+        while ($rec = $db->fetchAssoc($set)) {
+            $owned[$rec["owner_obj"]] = $rec["style_id"];
+        }
+        return $owned;
+    }
+
+    // is a style owned by an object?
+    public function isOwned(int $obj_id, int $style_id) : bool
+    {
+        $db = $this->db;
+
+        $set = $db->queryF(
+            "SELECT * FROM style_data " .
+            " WHERE id = %s AND owner_obj = %s",
+            ["integer", "integer"],
+            [$style_id, $obj_id]
+        );
+
+        if ($rec = $db->fetchAssoc($set)) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/Services/Style/Content/Object/class.ObjectDBRepository.php
+++ b/Services/Style/Content/Object/class.ObjectDBRepository.php
@@ -56,7 +56,7 @@ class ObjectDBRepository
 
         $owned = [];
         while ($rec = $db->fetchAssoc($set)) {
-            $owned[$rec["owner_obj"]] = $rec["style_id"];
+            $owned[(int) $rec["owner_obj"]] = (int) $rec["style_id"];
         }
         return $owned;
     }

--- a/Services/Style/Content/Object/class.ObjectFacade.php
+++ b/Services/Style/Content/Object/class.ObjectFacade.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+namespace ILIAS\Style\Content\Object;
+
+use \ILIAS\Style\Content\InternalDataService;
+use \ILIAS\Style\Content\InternalDomainService;
+
+/**
+ * External facade for object content styles
+ * @author Alexander Killing <killing@leifos.de>
+ */
+class ObjectFacade
+{
+    /**
+     * @var ObjectManager
+     */
+    protected $object_manager;
+
+    /**
+     * @var int
+     */
+    protected $ref_id;
+
+    /**
+     * @var int
+     */
+    protected $obj_id;
+
+    /**
+     * @var InternalDataService
+     */
+    protected $data_service;
+
+    /**
+     * @var InternalDomainService
+     */
+    protected $domain_service;
+
+    public function __construct(
+        InternalDataService $data_service,
+        InternalDomainService $domain_service,
+        int $ref_id,
+        int $obj_id = 0
+    ) {
+        $this->ref_id = $ref_id;
+        $this->ref_id = ($obj_id > 0)
+            ? $obj_id
+            : \ilObject::_lookupObjId($ref_id);
+        $this->domain_service = $domain_service;
+        $this->object_manager = $domain_service->object($this->ref_id, $obj_id);
+    }
+
+    /**
+     * This must be called on cloning the parent object, with passing
+     * the object id of the clone.
+     */
+    public function cloneTo(int $obj_id) : void
+    {
+        $this->object_manager->cloneTo($obj_id);
+    }
+
+    /**
+     * This ID must be used when rendering the object (pages). It respects global
+     * settings like fixed style IDs.
+     */
+    public function getEffectiveStyleId() : int
+    {
+        return $this->object_manager->getEffectiveStyleId();
+    }
+
+    /**
+     * Get the style ID currently set (stored) by the object.
+     * Note: This may be different from the effective style id, e.g. if a fixed
+     * global style overwrites the ID of the current object, or the ID of the
+     * current object is invalid, e.g. by referencing a non-shared parent style ID.
+     */
+    public function getStyleId() : int
+    {
+        return $this->object_manager->getStyleId();
+    }
+
+    /**
+     * Calling this should usually be avoided, currently this is
+     * necessary on import routines, but otherwise updates should be
+     * called internally automatically.
+     */
+    public function updateStyleId(int $style_id) : void
+    {
+        $this->object_manager->updateStyleId($style_id);
+    }
+
+    /**
+     * Inherits a non local style from the parent container
+     */
+    public function inheritFromParent()
+    {
+        $this->object_manager->inheritFromParent();
+    }
+}

--- a/Services/Style/Content/Object/class.ObjectManager.php
+++ b/Services/Style/Content/Object/class.ObjectManager.php
@@ -1,0 +1,211 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+namespace ILIAS\Style\Content\Object;
+
+use \ILIAS\Style\Content\InternalRepoService;
+use \ILIAS\Style\Content\InternalDomainService;
+
+/**
+ * Manages repository object related content style behaviour
+ * @author Alexander Killing <killing@leifos.de>
+ */
+class ObjectManager
+{
+    /**
+     * @var \ilSetting
+     */
+    protected $settings;
+
+    /**
+     * @var ObjectDBRepository
+     */
+    protected $object_repo;
+
+    /**
+     * @var int
+     */
+    protected $obj_id;
+
+    /**
+     * @var \ILIAS\Style\Content\Container\ContainerDBRepository
+     */
+    protected $container_repo;
+
+    /**
+     * @var int
+     */
+    protected $ref_id;
+
+    /**
+     * @var InternalRepoService
+     */
+    protected $repo_service;
+
+    /**
+     * @var InternalRepoService
+     */
+    protected $domain_service;
+
+    public function __construct(
+        InternalRepoService $repo_service,
+        InternalDomainService $domain_service,
+        int $ref_id,
+        int $obj_id = 0
+    ) {
+        $this->settings = $domain_service->settings();
+        $this->ref_id = $ref_id;
+        $this->obj_id = ($obj_id > 0)
+            ? $obj_id
+            : \ilObject::_lookupObjId($ref_id);
+        $this->repo_service = $repo_service;
+        $this->domain_service = $domain_service;
+        $this->container_repo = $repo_service->repositoryContainer();
+        $this->object_repo = $repo_service->object();
+    }
+
+    /**
+     * Get all selectable styles. If a global fixed style is set,
+     * this returns an empty array. If a ref id is provided for the manager,
+     * upper container will be searched for shared local content styles.
+     */
+    public function getSelectableStyles() : array
+    {
+        $settings = $this->settings;
+        $tree = $this->domain_service->repositoryTree();
+        $container_repo = $this->container_repo;
+
+        $fixed_style = $settings->get("fixed_content_style_id");
+        $st_styles = [];
+        if ($fixed_style > 0) {
+            return [];
+        } else {
+            $st_styles = \ilObjStyleSheet::_getStandardStyles(
+                true,
+                false,
+                $this->ref_id
+            );
+
+            if ($this->ref_id > 0) {
+                $path = $tree->getPathId($this->ref_id);
+                $reuse_ref_ids = $container_repo->filterByReuse($path);
+                $container_obj_ids = array_map(function ($ref_id) {
+                    return \ilObject::_lookupObjId($ref_id);
+                }, $reuse_ref_ids);
+                foreach ($this->object_repo->getOwnedStyles($container_obj_ids) as $obj_id => $style_id) {
+                    $st_styles[$style_id] =
+                        \ilObject::_lookupTitle($style_id) .
+                        " (" . \ilObject::_lookupTitle($obj_id) . ")";
+                }
+            }
+        }
+        ksort($st_styles);
+        return $st_styles;
+    }
+
+    protected function isSelectable(int $style_id) : bool
+    {
+        $sel_types = $this->getSelectableStyles();
+        if (isset($sel_types[$style_id])) {
+            return true;
+        }
+        return false;
+    }
+
+    public function updateStyleId(int $style_id)
+    {
+        \ilObjStyleSheet::writeStyleUsage($this->obj_id, $style_id);
+    }
+
+    public function setOwnerOfStyle(int $style_id)
+    {
+        \ilObjStyleSheet::writeOwner($this->obj_id, $style_id);
+    }
+
+    public function getStyleId() : int
+    {
+        return \ilObjStyleSheet::lookupObjectStyle($this->obj_id);
+    }
+
+    /**
+     * Clones a style to a new object (or references the same standard style)
+     */
+    public function cloneTo(int $obj_id) : void
+    {
+        $style_id = $this->getStyleId();
+        if ($style_id > 0 && !\ilObjStyleSheet::_lookupStandard($style_id)) {
+            $style_obj = \ilObjectFactory::getInstanceByObjId($style_id);
+            $new_id = $style_obj->ilClone();
+            \ilObjStyleSheet::writeStyleUsage($obj_id, $new_id);
+            \ilObjStyleSheet::writeOwner($obj_id, $new_id);
+        } else {
+            \ilObjStyleSheet::writeStyleUsage($obj_id, $style_id);
+        }
+    }
+
+    /**
+     * Inherits a non local style from the parent container
+     */
+    public function inheritFromParent()
+    {
+        if ($this->ref_id > 0) {
+            $tree = $this->domain_service->repositoryTree();
+            $parent_ref_id = $tree->getParentId($this->ref_id);
+            $parent_id = \ilObject::_lookupObjId($parent_ref_id);
+            $obj_id = \ilObject::_lookupObjId($this->ref_id);
+            $style_id = \ilObjStyleSheet::lookupObjectStyle($parent_id);
+            if ($style_id > 0) {
+                if (\ilObjStyleSheet::_lookupStandard($style_id)) {
+                    \ilObjStyleSheet::writeStyleUsage($obj_id, $style_id);
+                }
+            }
+        }
+    }
+
+    public function getEffectiveStyleId() : int
+    {
+        $settings = $this->settings;
+
+        // the currently set/stored style for the object
+        $style_id = $this->getStyleId();
+
+        // the set style must either be owned or be selectable
+        if (!$this->isOwned($style_id) && !$this->isSelectable($style_id)) {
+            $style_id = 0;
+        }
+
+        // check global fixed content style, which overwrites anything
+        $fixed_style = $settings->get("fixed_content_style_id");
+        if ($fixed_style > 0) {
+            $style_id = $fixed_style;
+        }
+
+        // if no style id is set up to this point, check/use global default style
+        if ($style_id <= 0) {
+            $style_id = $settings->get("default_content_style_id");
+        }
+
+        if ($style_id > 0 && \ilObject::_lookupType($style_id) == "sty") {
+            return $style_id;
+        }
+        return 0;
+    }
+
+    // is a style owned by an object?
+    public function isOwned(int $style_id) : bool
+    {
+        return $this->object_repo->isOwned($this->obj_id, $style_id);
+    }
+}

--- a/Services/Style/Content/Object/class.ObjectManager.php
+++ b/Services/Style/Content/Object/class.ObjectManager.php
@@ -158,7 +158,7 @@ class ObjectManager
     /**
      * Inherits a non local style from the parent container
      */
-    public function inheritFromParent()
+    public function inheritFromParent() : void
     {
         if ($this->ref_id > 0) {
             $tree = $this->domain_service->repositoryTree();

--- a/Services/Style/Content/Object/class.ilObjectContentStyleSettingsGUI.php
+++ b/Services/Style/Content/Object/class.ilObjectContentStyleSettingsGUI.php
@@ -1,0 +1,311 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+/**
+ * Style settings of a repository object
+ * @author Alexander Killing <killing@leifos.de>
+ * @ilCtrl_Calls ilObjectContentStyleSettingsGUI: ilObjStyleSheetGUI
+ */
+class ilObjectContentStyleSettingsGUI
+{
+    /**
+     * @var \ILIAS\Style\Content\Object\ObjectManager
+     */
+    protected $object_manager;
+
+    /**
+     * @var \ILIAS\Style\Content\Container\ContainerManager
+     */
+    protected $container_manager;
+
+    /**
+     * @var \ILIAS\Style\Content\InternalDomainService
+     */
+    protected $domain;
+
+    /**
+     * @var \ILIAS\Style\Content\InternalGUIService
+     */
+    protected $gui;
+
+    /**
+     * @var int
+     */
+    protected $current_style_id;
+
+    /**
+     * @var int
+     */
+    protected $ref_id;
+
+    /**
+     * @var int
+     */
+    protected $obj_id;
+
+    public function __construct(
+        \ILIAS\Style\Content\InternalDomainService $domain_service,
+        \ILIAS\Style\Content\InternalGUIService $gui_service,
+        ?int $current_style_id,
+        int $ref_id,
+        int $obj_id
+    ) {
+        $this->domain = $domain_service;
+        $this->gui = $gui_service;
+        $this->ref_id = $ref_id;
+        $this->obj_id = ($obj_id > 0)
+            ? $obj_id
+            : ilObject::_lookupObjId($ref_id);
+        $this->container_manager = $domain_service->repositoryContainer($ref_id);
+        $this->object_manager = $domain_service->object($ref_id, $this->obj_id);
+        $this->current_style_id = $current_style_id ?? $this->object_manager->getStyleId();
+    }
+
+    public function executeCommand() : void
+    {
+        $ctrl = $this->gui->ctrl();
+
+        $next_class = $ctrl->getNextClass($this);
+        $cmd = $ctrl->getCmd("settings");
+
+        switch ($next_class) {
+
+            case "ilobjstylesheetgui":
+                $this->gui->tabs()->clearTargets();
+                $ctrl->setReturn($this, "settings");
+                $this->forwardToStyleSheet();
+                break;
+
+            default:
+                if (in_array($cmd, [
+                    "settings",
+                    "editStyle",
+                    "updateStyle",
+                    "createStyle",
+                    "deleteStyle",
+                    "saveStyleSettings",
+                    "saveIndividualStyleSettings"
+                ])) {
+                    $this->$cmd();
+                }
+        }
+    }
+
+    protected function settings() : void
+    {
+        $mt = $this->gui->mainTemplate();
+        $form = $this->initStylePropertiesForm();
+        $mt->setContent(
+            $form->getHTML()
+        );
+    }
+
+    /**
+     * Init style properties form
+     */
+    public function initStylePropertiesForm() : ilPropertyFormGUI
+    {
+        $ilCtrl = $this->gui->ctrl();
+        $lng = $this->domain->lng();
+        $tabs = $this->gui->tabs();
+        $settings = $this->domain->settings();
+        $mt = $this->gui->mainTemplate();
+
+        $style_id = $this->current_style_id;
+
+        /*
+        if (ilObject::_lookupType($style_id) == "sty") {
+            $page_gui->setStyleId($style_id);
+        } else {
+            $style_id = 0;
+        }
+
+        $page_gui->setTabHook($this, "addPageTabs");
+        $ilCtrl->getHTML($page_gui);
+        $ilTabs->setTabActive("obj_sty");*/
+
+        $lng->loadLanguageModule("style");
+
+        $form = new ilPropertyFormGUI();
+        $fixed_style = $settings->get("fixed_content_style_id");
+        if ($fixed_style > 0) {
+            $st = new ilNonEditableValueGUI($lng->txt("style_current_style"));
+            $st->setValue(ilObject::_lookupTitle($fixed_style) . " (" .
+                $lng->txt("global_fixed") . ")");
+            $form->addItem($st);
+        } else {
+            $st_styles = $this->object_manager->getSelectableStyles();
+
+            $st_styles[0] = $lng->txt("default");
+            ksort($st_styles);
+
+            if ($style_id > 0) {
+                // individual style
+                if ($this->object_manager->isOwned($style_id)) {
+                    $st = new ilNonEditableValueGUI($lng->txt("style_current_style"));
+                    $st->setValue(ilObject::_lookupTitle($style_id));
+                    $form->addItem($st);
+
+                    if ($this->isContainer()) {
+                        $cb = new ilCheckboxInputGUI($lng->txt("style_support_reuse"), "support_reuse");
+                        $cb->setInfo($lng->txt("style_support_reuse_info"));
+                        $cb->setChecked($this->container_manager->getReuse());
+                        $form->addItem($cb);
+                        $form->addCommandButton(
+                            "saveIndividualStyleSettings",
+                            $lng->txt("save")
+                        );
+                    }
+
+                    $form->addCommandButton(
+                        "editStyle",
+                        $lng->txt("style_edit_style")
+                    );
+                    $form->addCommandButton(
+                        "deleteStyle",
+                        $lng->txt("style_delete_style")
+                    );
+                }
+            }
+
+            if ($style_id <= 0 || !$this->object_manager->isOwned($style_id)) {
+                $style_sel = ilUtil::formSelect(
+                    $style_id,
+                    "style_id",
+                    $st_styles,
+                    false,
+                    true
+                );
+                $style_sel = new ilSelectInputGUI(
+                    $lng->txt("style_current_style"),
+                    "style_id"
+                );
+                $style_sel->setOptions($st_styles);
+                $style_sel->setValue($style_id);
+                $form->addItem($style_sel);
+                $form->addCommandButton(
+                    "saveStyleSettings",
+                    $lng->txt("save")
+                );
+                $form->addCommandButton(
+                    "createStyle",
+                    $lng->txt("sty_create_ind_style")
+                );
+            }
+        }
+        $form->setTitle($lng->txt("obj_sty"));
+        $form->setFormAction($ilCtrl->getFormAction($this));
+
+        return $form;
+    }
+
+    protected function isContainer() : bool
+    {
+        if ($this->ref_id > 0) {
+            $type = ilObject::_lookupType($this->ref_id, true);
+            if ($this->domain->objectDefinition()->isContainer($type)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public function forwardToStyleSheet()
+    {
+        $ctrl = $this->gui->ctrl();
+        $cmd = $ctrl->getCmd();
+
+        $style_gui = new ilObjStyleSheetGUI(
+            "",
+            $this->current_style_id,
+            false,
+            false
+        );
+        $style_id = $ctrl->forwardCommand($style_gui);
+        if (in_array($cmd, ["save", "copyStyle", "importStyle", "confirmedDelete"])) {
+            if ($cmd == "confirmedDelete") {
+                $style_id = 0;
+            } else {
+                $this->setOwnerId($style_id);
+            }
+            $this->updateStyleId($style_id);
+            $ctrl->redirect($this, "settings");
+        }
+    }
+
+    protected function updateStyleId(int $style_id) : void
+    {
+        $this->object_manager->updateStyleId($style_id);
+    }
+
+    protected function setOwnerId(int $style_id) : void
+    {
+        $this->object_manager->setOwnerOfStyle($style_id);
+    }
+
+    public function createStyle() : void
+    {
+        $ctrl = $this->gui->ctrl();
+        $ctrl->redirectByClass("ilobjstylesheetgui", "create");
+    }
+
+    public function editStyle() : void
+    {
+        $ctrl = $this->gui->ctrl();
+        $ctrl->redirectByClass("ilobjstylesheetgui", "edit");
+    }
+
+    public function deleteStyle() : void
+    {
+        $ctrl = $this->gui->ctrl();
+        $ctrl->redirectByClass("ilobjstylesheetgui", "delete");
+    }
+
+    /**
+     * Save style settings
+     */
+    protected function saveStyleSettings()
+    {
+        $settings = $this->domain->settings();
+        $lng = $this->domain->lng();
+        $ctrl = $this->gui->ctrl();
+
+        $form = $this->initStylePropertiesForm();
+        $form->checkInput();
+        if ($settings->get("fixed_content_style_id") <= 0 &&
+            (ilObjStyleSheet::_lookupStandard($this->current_style_id)
+                || $this->current_style_id == 0)) {
+            $style_id = (int) $form->getInput("style_id");
+            $this->updateStyleId($style_id);
+            ilUtil::sendSuccess($lng->txt("msg_obj_modified"), true);
+        }
+        $ctrl->redirect($this, "settings");
+    }
+
+    protected function saveIndividualStyleSettings() : void
+    {
+        $settings = $this->domain->settings();
+        $lng = $this->domain->lng();
+        $ctrl = $this->gui->ctrl();
+
+        $form = $this->initStylePropertiesForm();
+        $form->checkInput();
+        if ($this->isContainer()) {
+            $this->container_manager->saveReuse($form->getInput("support_reuse"));
+            ilUtil::sendSuccess($lng->txt("msg_obj_modified"), true);
+        }
+        $ctrl->redirect($this, "settings");
+    }
+}

--- a/Services/Style/Content/Service/class.DomainService.php
+++ b/Services/Style/Content/Service/class.DomainService.php
@@ -28,7 +28,7 @@ class DomainService
     /**
      * @var InternalService
      */
-    private $internal;
+    private InternalService $internal;
 
     public function __construct(
         InternalService $internal_service

--- a/Services/Style/Content/Service/class.DomainService.php
+++ b/Services/Style/Content/Service/class.DomainService.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types = 1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+namespace ILIAS\Style\Content;
+
+use ILIAS\DI\Container;
+use ILIAS\Style\Content\Object\ObjectFacade;
+
+/**
+ * Facade for consumer domain interface
+ *
+ * @author Alexander Killing <killing@leifos.de>
+ */
+class DomainService
+{
+    /**
+     * @var InternalService
+     */
+    private $internal;
+
+    public function __construct(
+        InternalService $internal_service
+    ) {
+        $this->internal = $internal_service;
+    }
+
+    public function styleForObjId(int $obj_id) : ObjectFacade
+    {
+        return new ObjectFacade(
+            $this->internal->data(),
+            $this->internal->domain(),
+            0,
+            $obj_id
+        );
+    }
+
+    public function styleForRefId(int $ref_id) : ObjectFacade
+    {
+        return new ObjectFacade(
+            $this->internal->data(),
+            $this->internal->domain(),
+            $ref_id
+        );
+    }
+}

--- a/Services/Style/Content/Service/class.GUIService.php
+++ b/Services/Style/Content/Service/class.GUIService.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types = 1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+namespace ILIAS\Style\Content;
+
+use ILIAS\DI\Container;
+
+/**
+ * Facade for consumer gui interface
+ *
+ * @author Alexander Killing <killing@leifos.de>
+ */
+class GUIService
+{
+    /**
+     * @var InternalService
+     */
+    private $internal;
+
+    public function __construct(
+        InternalService $internal_service
+    ) {
+        $this->internal = $internal_service;
+    }
+
+    public function objectSettingsClass(bool $lower = true) : string
+    {
+        $class = \ilObjectContentStyleSettingsGUI::class;
+        if ($lower) {
+            $class = strtolower($class);
+        }
+        return $this->internal->gui()->objectSettingsClass($lower);
+    }
+
+    public function objectSettingsGUIForRefId(
+        ?int $selected_style_id,
+        int $ref_id
+    ) : \ilObjectContentStyleSettingsGUI {
+        return $this->internal->gui()->objectSettingsGUI(
+            $selected_style_id,
+            $ref_id
+        );
+    }
+
+    public function objectSettingsGUIForObjId(
+        int $selected_style_id,
+        int $obj_id
+    ) : \ilObjectContentStyleSettingsGUI {
+        return $this->internal->gui()->objectSettingsGUI(
+            $selected_style_id,
+            0,
+            $obj_id
+        );
+    }
+
+
+    public function redirectToObjectSettings() : void
+    {
+        $this->internal->gui()->ctrl()->redirectByClass(
+            $this->objectSettingsClass(),
+            ""
+        );
+    }
+
+    // add effective style sheet path to global template
+    public function addCss(\ilGlobalTemplateInterface $tpl, int $ref_id, int $obj_id = 0)
+    {
+        $eff_style_id = $this->internal->domain()->object($ref_id, $obj_id)->getEffectiveStyleId();
+        $tpl->addCss(\ilObjStyleSheet::getContentStylePath($eff_style_id));
+    }
+}

--- a/Services/Style/Content/Service/class.GUIService.php
+++ b/Services/Style/Content/Service/class.GUIService.php
@@ -75,7 +75,7 @@ class GUIService
     }
 
     // add effective style sheet path to global template
-    public function addCss(\ilGlobalTemplateInterface $tpl, int $ref_id, int $obj_id = 0)
+    public function addCss(\ilGlobalTemplateInterface $tpl, int $ref_id, int $obj_id = 0) : void
     {
         $eff_style_id = $this->internal->domain()->object($ref_id, $obj_id)->getEffectiveStyleId();
         $tpl->addCss(\ilObjStyleSheet::getContentStylePath($eff_style_id));

--- a/Services/Style/Content/Service/class.GUIService.php
+++ b/Services/Style/Content/Service/class.GUIService.php
@@ -27,7 +27,7 @@ class GUIService
     /**
      * @var InternalService
      */
-    private $internal;
+    private InternalService $internal;
 
     public function __construct(
         InternalService $internal_service

--- a/Services/Style/Content/Service/class.InternalDataService.php
+++ b/Services/Style/Content/Service/class.InternalDataService.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system

--- a/Services/Style/Content/Service/class.InternalDomainService.php
+++ b/Services/Style/Content/Service/class.InternalDomainService.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -18,9 +18,10 @@ namespace ILIAS\Style\Content;
 use ILIAS\Style\Content\Access\StyleAccessManager;
 use ILIAS\DI\Container;
 use ILIAS\Repository\GlobalDICDomainServices;
+use ILIAS\Style\Content\Container\ContainerManager;
+use ILIAS\Style\Content\Object\ObjectManager;
 
-/**
- * Content style internal manager service
+ /**
  * @author Alexander Killing <killing@leifos.de>
  */
 class InternalDomainService
@@ -89,6 +90,28 @@ class InternalDomainService
             $style_id,
             $access_manager,
             $this->repo_service->image()
+        );
+    }
+
+    public function repositoryContainer(int $ref_id) : ContainerManager
+    {
+        return new ContainerManager(
+            $this->repo_service,
+            $ref_id
+        );
+    }
+
+    /**
+     * Objects without ref id (e.g. portfolios) can use
+     * the manager with a ref_id of 0, e.g. to get selectable styles
+     */
+    public function object(int $ref_id, int $obj_id = 0) : ObjectManager
+    {
+        return new ObjectManager(
+            $this->repo_service,
+            $this,
+            $ref_id,
+            $obj_id
         );
     }
 }

--- a/Services/Style/Content/Service/class.InternalGUIService.php
+++ b/Services/Style/Content/Service/class.InternalGUIService.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -15,7 +15,6 @@
 
 namespace ILIAS\Style\Content;
 
-use Psr\Http\Message;
 use ILIAS\DI\Container;
 use ILIAS\Repository\GlobalDICGUIServices;
 
@@ -70,6 +69,31 @@ class InternalGUIService
             $this->domain_service->refinery(),
             $passed_query_params,
             $passed_post_data
+        );
+    }
+
+    // get class name of object settings gui class
+    public function objectSettingsClass(bool $lower = true) : string
+    {
+        $class = \ilObjectContentStyleSettingsGUI::class;
+        if ($lower) {
+            $class = strtolower($class);
+        }
+        return $class;
+    }
+
+    // get instance of objecgt settings gui class
+    public function objectSettingsGUI(
+        ?int $selected_style_id,
+        int $ref_id,
+        int $obj_id = 0
+    ) : \ilObjectContentStyleSettingsGUI {
+        return new \ilObjectContentStyleSettingsGUI(
+            $this->domain_service,
+            $this,
+            $selected_style_id,
+            $ref_id,
+            $obj_id
         );
     }
 }

--- a/Services/Style/Content/Service/class.InternalRepoService.php
+++ b/Services/Style/Content/Service/class.InternalRepoService.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -77,5 +77,23 @@ class InternalRepoService
     public function image() : ImageFileRepo
     {
         return $this->image_repo;
+    }
+
+    public function repositoryContainer() : Container\ContainerDBRepository
+    {
+        return new Container\ContainerDBRepository(
+            $this->db
+        );
+    }
+
+    /**
+     * Objects without ref id (e.g. portfolios) can use
+     * the manager with a ref_id of 0, e.g. to get selectable styles
+     */
+    public function object() : Object\ObjectDBRepository
+    {
+        return new Object\ObjectDBRepository(
+            $this->db
+        );
     }
 }

--- a/Services/Style/Content/Service/class.InternalService.php
+++ b/Services/Style/Content/Service/class.InternalService.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -60,13 +60,11 @@ class InternalService
         return $this->repo;
     }
 
-    // was manager()
     public function domain() : InternalDomainService
     {
         return $this->domain;
     }
 
-    // was ui()
     public function gui() : InternalGUIService
     {
         return $this->gui;

--- a/Services/Style/Content/Service/class.Service.php
+++ b/Services/Style/Content/Service/class.Service.php
@@ -24,10 +24,21 @@ use ILIAS\DI\Container;
 class Service
 {
     protected Container $DIC;
+    protected InternalService $internal;
+    protected DomainService $domain;
+    protected GUIService $gui;
 
     public function __construct(Container $DIC)
     {
         $this->DIC = $DIC;
+
+        $this->internal = new InternalService($this->DIC);
+        $this->gui = new GUIService(
+            $this->internal
+        );
+        $this->domain = new DomainService(
+            $this->internal
+        );
     }
 
     /**
@@ -35,6 +46,16 @@ class Service
      */
     public function internal() : InternalService
     {
-        return new InternalService($this->DIC);
+        return $this->internal;
+    }
+
+    public function gui() : GUIService
+    {
+        return $this->gui;
+    }
+
+    public function domain() : DomainService
+    {
+        return $this->domain;
     }
 }

--- a/Services/Style/Content/classes/class.ilObjStyleSheet.php
+++ b/Services/Style/Content/classes/class.ilObjStyleSheet.php
@@ -628,6 +628,18 @@ class ilObjStyleSheet extends ilObject
         $ilDB->manipulate($q);
     }
 
+    public static function writeOwner($obj_id, $style_id)
+    {
+        global $DIC;
+
+        $ilDB = $DIC->database();
+
+        $q = "UPDATE style_data SET owner_obj = " .
+            $ilDB->quote((int) $obj_id, "integer") .
+            " WHERE id = " . $ilDB->quote($style_id, "integer");
+        $ilDB->manipulate($q);
+    }
+
     public static function _lookupUpToDate(int $a_id) : bool
     {
         global $DIC;
@@ -1402,6 +1414,10 @@ class ilObjStyleSheet extends ilObject
         string $a_image_dir = ""
     ) : void {
         $style = $this->getStyle();
+
+        if (!is_dir(ilUtil::getWebspaceDir() . "/css")) {
+            ilUtil::makeDirParents(ilUtil::getWebspaceDir() . "/css");
+        }
 
         if ($a_target_file == "") {
             $css_file_name = ilFileUtils::getWebspaceDir() . "/css/style_" . $this->getId() . ".css";

--- a/Services/Style/Content/classes/class.ilObjStyleSheet.php
+++ b/Services/Style/Content/classes/class.ilObjStyleSheet.php
@@ -697,7 +697,7 @@ class ilObjStyleSheet extends ilObject
         $res = $ilDB->query($q);
         $sty = $ilDB->fetchAssoc($res);
         
-        return (bool) $sty["standard"];
+        return (bool) ($sty["standard"] ?? false);
     }
 
     public static function _writeActive(int $a_id, bool $a_active) : void
@@ -1415,8 +1415,8 @@ class ilObjStyleSheet extends ilObject
     ) : void {
         $style = $this->getStyle();
 
-        if (!is_dir(ilUtil::getWebspaceDir() . "/css")) {
-            ilUtil::makeDirParents(ilUtil::getWebspaceDir() . "/css");
+        if (!is_dir(ilFileUtils::getWebspaceDir() . "/css")) {
+            ilFileUtils::makeDirParents(ilFileUtils::getWebspaceDir() . "/css");
         }
 
         if ($a_target_file == "") {

--- a/Services/Style/Content/classes/class.ilObjStyleSheetGUI.php
+++ b/Services/Style/Content/classes/class.ilObjStyleSheetGUI.php
@@ -155,7 +155,14 @@ class ilObjStyleSheetGUI extends ilObjectGUI
                 break;
         }
     }
-    
+
+    protected function getStyleSheet() : ilObjStyleSheet
+    {
+        /** @var ilObjStyleSheet $obj */
+        $obj = $this->object;
+        return $obj;
+    }
+
     public function viewObject()
     {
         $this->editObject();

--- a/Services/Style/Content/classes/class.ilObjStyleSheetGUI.php
+++ b/Services/Style/Content/classes/class.ilObjStyleSheetGUI.php
@@ -95,13 +95,6 @@ class ilObjStyleSheetGUI extends ilObjectGUI
         );
     }
 
-    protected function getStyleSheet() : ilObjStyleSheet
-    {
-        /** @var ilObjStyleSheet $style */
-        $style = $this->object;
-        return $style;
-    }
-
     /**
      * Enable writing
      */
@@ -119,11 +112,10 @@ class ilObjStyleSheetGUI extends ilObjectGUI
         $cmd = $ctrl->getCmd("edit");
         
         // #9440/#9489: prepareOutput will fail if not set properly
-        if (!$this->object) {
+        if (!$this->object || $cmd == "create") {
             $this->setCreationMode(true);
         }
 
-        $this->prepareOutput();
         switch ($next_class) {
 
             case "ilexportgui":
@@ -157,6 +149,7 @@ class ilObjStyleSheetGUI extends ilObjectGUI
                 break;
 
             default:
+                $this->prepareOutput();
                 $cmd .= "Object";
                 $ret = $this->$cmd();
                 break;

--- a/Services/Style/classes/Setup/class.ilStyleDBUpdateSteps.php
+++ b/Services/Style/classes/Setup/class.ilStyleDBUpdateSteps.php
@@ -99,4 +99,105 @@ class ilStyleDBUpdateSteps implements \ilDatabaseUpdateSteps
     {
         $this->db->renameTableColumn('style_char', "deprecated", 'outdated');
     }
+
+    public function step_6()
+    {
+        if (!$this->db->tableExists('sty_rep_container')) {
+            $fields = [
+                'ref_id' => [
+                    'type' => 'integer',
+                    'length' => 4,
+                    'notnull' => true,
+                    'default' => 0
+                ],
+                'reuse' => [
+                    'type' => 'integer',
+                    'length' => 1,
+                    'notnull' => true,
+                    'default' => 0
+                ]
+            ];
+
+            $this->db->createTable('sty_rep_container', $fields);
+            $this->db->addPrimaryKey('sty_rep_container', ['ref_id']);
+        }
+    }
+
+    public function step_7()
+    {
+        $set = $this->db->queryF(
+            "SELECT * FROM content_object ",
+            [],
+            []
+        );
+        while ($rec = $this->db->fetchAssoc($set)) {
+            $this->db->replace(
+                "style_usage",
+                array(
+                    "obj_id" => array("integer", (int) $rec["id"])
+                ),
+                array(
+                    "style_id" => array("integer", (int) $rec["stylesheet"])
+                )
+            );
+        }
+    }
+
+    public function step_8()
+    {
+        $set = $this->db->queryF(
+            "SELECT * FROM content_page_data ",
+            [],
+            []
+        );
+        while ($rec = $this->db->fetchAssoc($set)) {
+            $this->db->replace(
+                "style_usage",
+                array(
+                    "obj_id" => array("integer", (int) $rec["content_page_id"])),
+                array(
+                    "style_id" => array("integer", (int) $rec["stylesheet"]))
+            );
+        }
+    }
+
+    public function step_9()
+    {
+        if (!$this->db->tableColumnExists('style_data', 'owner_obj')) {
+            $this->db->addTableColumn('style_data', 'owner_obj', array(
+                'type' => 'integer',
+                'notnull' => false,
+                'length' => 4,
+                'default' => 0
+            ));
+        }
+    }
+
+    public function step_10()
+    {
+        $set = $this->db->queryF(
+            "SELECT * FROM style_data WHERE standard = %s",
+            ["integer"],
+            [0]
+        );
+        while ($rec = $this->db->fetchAssoc($set)) {
+            $set2 = $this->db->queryF(
+                "SELECT * FROM style_usage " .
+                " WHERE style_id = %s ",
+                ["integer"],
+                [$rec["id"]]
+            );
+            while ($rec2 = $this->db->fetchAssoc($set2)) {
+                $this->db->update(
+                    "style_data",
+                    [
+                    "owner_obj" => ["integer", $rec2["obj_id"]]
+                ],
+                    [    // where
+                        "id" => ["integer", $rec["id"]]
+                    ]
+                );
+            }
+        }
+    }
 }

--- a/Services/Tree/classes/class.ilMaterializedPathTree.php
+++ b/Services/Tree/classes/class.ilMaterializedPathTree.php
@@ -110,8 +110,12 @@ class ilMaterializedPathTree implements ilTreeImplementation
         $type_str = '';
         if (is_array($a_types)) {
             if ($a_types) {
-                $type_str = "AND " . $this->db->in($this->getTree()->getObjectDataTable() . ".type", $a_types, false,
-                        "text");
+                $type_str = "AND " . $this->db->in(
+                    $this->getTree()->getObjectDataTable() . ".type",
+                    $a_types,
+                    false,
+                    "text"
+                );
             }
         }
 
@@ -158,8 +162,12 @@ class ilMaterializedPathTree implements ilTreeImplementation
         $type_str = '';
         if (count($a_types)) {
             if ($a_types) {
-                $type_str = "AND " . $this->db->in($this->getTree()->getObjectDataTable() . ".type", $a_types, false,
-                        "text");
+                $type_str = "AND " . $this->db->in(
+                    $this->getTree()->getObjectDataTable() . ".type",
+                    $a_types,
+                    false,
+                    "text"
+                );
             }
         }
 
@@ -182,8 +190,10 @@ class ilMaterializedPathTree implements ilTreeImplementation
             'BETWEEN ' .
             $this->db->quote($a_node['path'], 'text') . ' AND ' .
             $this->db->quote($a_node['path'] . '.Z', 'text') . ' ' .
-            'AND ' . $this->getTree()->getTreeTable() . '.' . $this->getTree()->getTreePk() . ' = ' . $this->db->quote($this->getTree()->getTreeId(),
-                'integer') . ' ' .
+            'AND ' . $this->getTree()->getTreeTable() . '.' . $this->getTree()->getTreePk() . ' = ' . $this->db->quote(
+                $this->getTree()->getTreeId(),
+                'integer'
+            ) . ' ' .
             $type_str . ' ' .
             'ORDER BY ' . $this->getTree()->getTreeTable() . '.path';
 
@@ -200,7 +210,7 @@ class ilMaterializedPathTree implements ilTreeImplementation
             'WHERE child = ' . $this->db->quote($a_endnode, 'integer') . ' ';
         $res = $this->db->query($query);
 
-        $path = null;
+        $path = "";
         while ($row = $this->db->fetchAssoc($res)) {
             $path = (string) $row['path'];
         }
@@ -249,7 +259,8 @@ class ilMaterializedPathTree implements ilTreeImplementation
             $lft = 0;
             $rgt = 0;
 
-            $this->db->insert($this->getTree()->getTreeTable(),
+            $this->db->insert(
+                $this->getTree()->getTreeTable(),
                 array($this->getTree()->getTreePk() => array('integer', $this->getTree()->getTreeId()),
                       'child' => array('integer', $a_node_id),
                       'parent' => array('integer', $a_parent_id),
@@ -257,7 +268,8 @@ class ilMaterializedPathTree implements ilTreeImplementation
                       'rgt' => array('integer', $rgt),
                       'depth' => array('integer', $depth),
                       'path' => array('text', $parentPath . "." . $a_node_id)
-                ));
+                )
+            );
         };
 
         // use ilAtomQuery to lock tables if tree is main tree
@@ -290,8 +302,10 @@ class ilMaterializedPathTree implements ilTreeImplementation
             $query = 'DELETE FROM ' . $this->getTree()->getTreeTable() . ' ' .
                 'WHERE path BETWEEN ' . $this->db->quote($row['path'], 'text') . ' ' .
                 'AND ' . $this->db->quote($row['path'] . '.Z', 'text') . ' ' .
-                'AND ' . $this->getTree()->getTreePk() . ' = ' . $this->db->quote($this->getTree()->getTreeId(),
-                    'integer');
+                'AND ' . $this->getTree()->getTreePk() . ' = ' . $this->db->quote(
+                    $this->getTree()->getTreeId(),
+                    'integer'
+                );
             $this->db->manipulate($query);
         };
 
@@ -462,8 +476,10 @@ class ilMaterializedPathTree implements ilTreeImplementation
         $db = $DIC->database();
 
         $q = ' UPDATE tree
-			SET path = CONCAT(COALESCE(' . $db->quote($parentPath, 'text') . ', \'\'), COALESCE( ' . $db->cast("child",
-                "text") . ' , \'\'))
+			SET path = CONCAT(COALESCE(' . $db->quote($parentPath, 'text') . ', \'\'), COALESCE( ' . $db->cast(
+            "child",
+            "text"
+        ) . ' , \'\'))
 			WHERE parent = %s';
         $r = $db->manipulateF($q, array('integer'), array($parent));
 
@@ -485,10 +501,14 @@ class ilMaterializedPathTree implements ilTreeImplementation
             $treeClause1 = '';
             $treeClause2 = '';
         } else {
-            $treeClause1 = ' AND t1.' . $this->getTree()->getTreePk() . ' = ' . $this->db->quote($this->getTree()->getTreeId(),
-                    'integer');
-            $treeClause2 = ' AND t2.' . $this->getTree()->getTreePk() . ' = ' . $this->db->quote($this->getTree()->getTreeId(),
-                    'integer');
+            $treeClause1 = ' AND t1.' . $this->getTree()->getTreePk() . ' = ' . $this->db->quote(
+                $this->getTree()->getTreeId(),
+                'integer'
+            );
+            $treeClause2 = ' AND t2.' . $this->getTree()->getTreePk() . ' = ' . $this->db->quote(
+                $this->getTree()->getTreeId(),
+                'integer'
+            );
         }
 
         // first query for the path of the given node
@@ -511,8 +531,10 @@ class ilMaterializedPathTree implements ilTreeImplementation
             "FROM " . $this->getTree()->getTreeTable() . " t2 " .
             "JOIN " . $this->getTree()->getTableReference() . " obr ON t2.child = obr.ref_id " .
             "JOIN " . $this->getTree()->getObjectDataTable() . " obd ON obr.obj_id = obd.obj_id " .
-            "WHERE t2.path BETWEEN " . $this->db->quote($path, 'text') . " AND " . $this->db->quote($path . '.Z',
-                'text') .
+            "WHERE t2.path BETWEEN " . $this->db->quote($path, 'text') . " AND " . $this->db->quote(
+                $path . '.Z',
+                'text'
+            ) .
             $treeClause2 . ' ' .
             "ORDER BY t2.path";
 

--- a/Services/UIComponent/Tabs/classes/class.ilTabsGUI.php
+++ b/Services/UIComponent/Tabs/classes/class.ilTabsGUI.php
@@ -428,7 +428,7 @@ class ilTabsGUI
                     $tabtype = $pre . "tabinactive";
                 }
                 
-                if (($a_get_sub_tabs ? $this->subtab_manual_activation : $this->manual_activation) && $target["activate"]) {
+                if (($a_get_sub_tabs ? $this->subtab_manual_activation : $this->manual_activation) && ($target["activate"] ?? false)) {
                     $tabtype = $pre . "tabactive";
                 }
 

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -27,6 +27,8 @@
 // to the corresponding mode!
 // Language file names refer to ISO 639, see: http://www.oasis-open.org/cover/iso639a.html
 <!-- language file start -->
+style#:#style_support_reuse#:#Re-Use
+style#:#style_support_reuse_info#:#Allow sub-objects of the current container to re-use this content style.
 style#:#sty_resize_image#:#Bildgröße anpassen
 style#:#sty_resize#:#Bildgröße anpassen
 style#:#sty_outdated#:#Veraltet

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -29,6 +29,8 @@
 // to the corresponding mode!
 // Language file names refer to ISO 639, see: http://www.oasis-open.org/cover/iso639a.html
 <!-- language file start -->
+style#:#style_support_reuse#:#Re-Use
+style#:#style_support_reuse_info#:#Allow sub-objects of the current container to re-use this content style.
 style#:#sty_resize_image#:#Resize Image
 style#:#sty_resize#:#Resize
 style#:#sty_outdated#:#Outdated


### PR DESCRIPTION
This is the implementation of https://docu.ilias.de/goto_docu_wiki_wpage_6305_1357.html

It includes some changes in the use of content styles for consumers. Goals are to require less code on the consumer side and to remove static calls. The refactoring is not complete, but includes a major first step.

The objects do not need to store the "style ID" themselves anymore. The selected style is saved by the GUI part of the service itself.

The static calls are replaced by a service available via $DIC->contentStyle(); (not all yet)

The GUI part of the service includes the whole settings part (store the selected style for an object). editStyleProperties() and similar functions are removed from the consumer side.

@mjansenDatabay
The Content Page related changes are starting here:
https://github.com/ILIAS-eLearning/ILIAS/pull/3998/files#diff-c506bb183d6a262ae6cef33c4074c1460f598656a6fb817e934b3e8bf3a2d330

@smeyer-ilias 
Course
https://github.com/ILIAS-eLearning/ILIAS/pull/3998/files#diff-42d437023d95d4a9d14073e672c2421ffa272dd9d9e71071c1d1a42b40783383
Group
https://github.com/ILIAS-eLearning/ILIAS/pull/3998/files#diff-046aec59e2acee9fcca089685b9d0753915933bc6a9de6cda5804f9c8d56791c

The materialized path tree changes are only because of a wrong initialization in getPathId (null instead of empty string) and cs changes.

