### PR TITLE
Clock: Introduce `PSR-20 Clock Service` as `src/Data` type

### DIFF
--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -3,13 +3,10 @@
 
 namespace ILIAS\DI;
 
-use ILIAS\Filesystem\Filesystems;
-use ILIAS\FileUpload\FileUpload;
-use ILIAS\GlobalScreen\Services;
-use ILIAS\Refinery\Factory;
-use ILIAS\Skill\Service\SkillService;
-use ILIAS\Repository;
 use ILIAS\BackgroundTasks\BackgroundTaskServices;
+use ILIAS\Data\Clock\ClockFactoryImpl;
+use ILIAS\Repository;
+use ILIAS\Skill\Service\SkillService;
 
 /******************************************************************************
  *

--- a/src/Data/Clock/ClockFactory.php
+++ b/src/Data/Clock/ClockFactory.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
+namespace ILIAS\Data\Clock;
+
+use DateTimeZone;
+
+interface ClockFactory
+{
+    public function system() : ClockInterface;
+
+    public function utc() : ClockInterface;
+
+    public function local(DateTimeZone $time_zone) : ClockInterface;
+}

--- a/src/Data/Clock/ClockFactoryImpl.php
+++ b/src/Data/Clock/ClockFactoryImpl.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
+namespace ILIAS\Data\Clock;
+
+use DateTimeZone;
+
+class ClockFactoryImpl implements ClockFactory
+{
+    /**
+     * @inheritDoc
+     */
+    public function system() : ClockInterface
+    {
+        return new SystemClock();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function utc() : ClockInterface
+    {
+        return new UtcClock();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function local(DateTimeZone $time_zone) : ClockInterface
+    {
+        return new LocalClock($time_zone);
+    }
+}

--- a/src/Data/Clock/ClockInterface.php
+++ b/src/Data/Clock/ClockInterface.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
+namespace ILIAS\Data\Clock;
+
+use DateTimeImmutable;
+
+interface ClockInterface
+{
+    public function now() : DateTimeImmutable;
+}

--- a/src/Data/Clock/LocalClock.php
+++ b/src/Data/Clock/LocalClock.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
+namespace ILIAS\Data\Clock;
+
+use DateTimeImmutable;
+use DateTimeZone;
+
+class LocalClock implements ClockInterface
+{
+    private DateTimeZone $time_zone;
+
+    public function __construct(DateTimeZone $time_zone)
+    {
+        $this->time_zone = $time_zone;
+    }
+
+    public function now() : DateTimeImmutable
+    {
+        return new DateTimeImmutable('now', $this->time_zone);
+    }
+}

--- a/src/Data/Clock/SystemClock.php
+++ b/src/Data/Clock/SystemClock.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
+namespace ILIAS\Data\Clock;
+
+use DateTimeImmutable;
+
+class SystemClock implements ClockInterface
+{
+    public function now() : DateTimeImmutable
+    {
+        return new DateTimeImmutable('now');
+    }
+}

--- a/src/Data/Clock/UtcClock.php
+++ b/src/Data/Clock/UtcClock.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
+namespace ILIAS\Data\Clock;
+
+use DateTimeImmutable;
+use DateTimeZone;
+
+class UtcClock implements ClockInterface
+{
+    public function now() : DateTimeImmutable
+    {
+        return new DateTimeImmutable('now', new DateTimeZone('UTC'));
+    }
+}

--- a/src/Data/Factory.php
+++ b/src/Data/Factory.php
@@ -4,6 +4,9 @@
 
 namespace ILIAS\Data;
 
+use ILIAS\Data\Clock\ClockFactory;
+use ILIAS\Data\Clock\ClockFactoryImpl;
+
 /**
  * Builds data types.
  *
@@ -153,5 +156,10 @@ class Factory
     public function link(string $label, URI $url) : Link
     {
         return new Link($label, $url);
+    }
+
+    public function clock() : ClockFactory
+    {
+        return new ClockFactoryImpl();
     }
 }

--- a/src/Data/README.md
+++ b/src/Data/README.md
@@ -3,6 +3,26 @@
 This service should contain standard datatypes for ILIAS that are used in many
 locations in the system and do not belong to a certain service.
 
+The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”,
+“SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be
+interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+**Table of Contents**
+* [Result](#result)
+* [Color](#color)
+* [URI](#uri)
+* [DataSize](#datasize)
+* [Password](#password)
+* [ClientId](#clientid)
+* [ReferenceId](#referenceid)
+* [ObjectId](#objectid)
+* [Alphanumeric](#alphanumeric)
+* [PositiveInteger](#positiveinteger)
+* [DateFormat](#dateformat)
+* [Range](#Range)
+* [Order](#order)
+* [Clock](#clock)
+
 Other examples for data types that could (and maybe should) be added here:
 
 * Option (akin to rusts type)
@@ -385,5 +405,53 @@ $join = $order2->join('sort', function($pre, $k, $v) { return "$pre $k $v,"; });
 assert($order1->get() === ['subject1' => 'ASC']);
 assert($order2->get() === ['subject1' => 'ASC', 'subject2' => 'DESC']);
 assert($join === 'sort subject1 ASC, subject2 DESC,');
+?>
+```
+
+## Clock
+
+This package provides a fully psr-20 compliant clock handling.
+
+### Example
+
+#### System Clock
+
+The `\ILIAS\Data\Clock\SystemClock` returns a `\DateTimeImmutable` instance always referring to the
+current default system timezone.
+
+```php
+<?php
+$f = new \ILIAS\Data\Factory;
+
+$clock = $f->clock()->system();
+$now = $clock->now();
+?>
+```
+
+#### UTC Clock
+
+The `\ILIAS\Data\Clock\UtcClock` returns a `\DateTimeImmutable` instance always referring to the
+`UTC` timezone.
+
+```php
+<?php
+$f = new \ILIAS\Data\Factory;
+
+$clock = $f->clock()->utc();
+$now = $clock->now();
+?>
+```
+
+#### Local Clock
+
+The `\ILIAS\Data\Clock\UtcClock` returns a `\DateTimeImmutable` instance always referring to the
+timezone passed to the factory method.
+
+```php
+<?php
+$f = new \ILIAS\Data\Factory;
+
+$clock = $f->clock()->local(new \DateTimeZone('Europe/Berlin'));
+$now = $clock->now();
 ?>
 ```

--- a/src/Data/ROADMAP.md
+++ b/src/Data/ROADMAP.md
@@ -1,0 +1,1 @@
+# Roadmap

--- a/tests/Data/LocalClockTest.php
+++ b/tests/Data/LocalClockTest.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
+namespace ILIAS\Data\Clock;
+
+use DateTimeZone;
+use ILIAS\Data\Clock\LocalClock;
+use PHPUnit\Framework\TestCase;
+
+class LocalClockTest extends TestCase
+{
+    private string $default_timezone;
+
+    protected function setUp() : void
+    {
+        $this->default_timezone = date_default_timezone_get();
+    }
+
+    protected function tearDown() : void
+    {
+        date_default_timezone_set($this->default_timezone);
+    }
+
+    public function testUtcClockIsNotAffectedByGlobalTimezoneChanges() : void
+    {
+        date_default_timezone_set('UTC');
+
+        $clock = new LocalClock(new DateTimeZone('Africa/Windhoek'));
+
+        self::assertSame('Africa/Windhoek', $clock->now()->getTimezone()->getName());
+    }
+}

--- a/tests/Data/SystemClockTest.php
+++ b/tests/Data/SystemClockTest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
+namespace ILIAS\Data\Clock;
+
+use ILIAS\Data\Clock\SystemClock;
+use PHPUnit\Framework\TestCase;
+
+class SystemClockTest extends TestCase
+{
+    private string $default_timezone;
+
+    protected function setUp() : void
+    {
+        $this->default_timezone = date_default_timezone_get();
+    }
+
+    protected function tearDown() : void
+    {
+        date_default_timezone_set($this->default_timezone);
+    }
+
+    public function testUtcClockIsNotAffectedByGlobalTimezoneChanges() : void
+    {
+        date_default_timezone_set('Africa/Windhoek');
+
+        $clock = new SystemClock();
+
+        self::assertSame('Africa/Windhoek', $clock->now()->getTimezone()->getName());
+    }
+}

--- a/tests/Data/UtcClockTest.php
+++ b/tests/Data/UtcClockTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
+namespace ILIAS\Data\Clock;
+
+use ILIAS\Data\Clock\UtcClock;
+use PHPUnit\Framework\TestCase;
+
+class UtcClockTest extends TestCase
+{
+    private string $default_timezone;
+
+    protected function setUp() : void
+    {
+        $this->default_timezone = date_default_timezone_get();
+    }
+
+    protected function tearDown() : void
+    {
+        date_default_timezone_set($this->default_timezone);
+    }
+
+    public function testUtcClockIsNotAffectedByGlobalTimezoneChanges() : void
+    {
+        date_default_timezone_set('Europe/Berlin');
+        $clock = new UtcClock();
+
+        self::assertSame('UTC', $clock->now()->getTimezone()->getName());
+    }
+}


### PR DESCRIPTION
With this PR I would like to introduce a [`PSR-20` compliant `Clock Service`](https://github.com/php-fig/fig-standards/blob/master/proposed/clock.md). While I refactored `Services/Cron` I once again stumbled upon `time()` and `date()`, which caused issues due to wrong usage/wrong assumptions when dealing with `now` (`time()` relies on `January 1 1970 00:00:00 GMT` which is more or less `UTC`, `date()` always relies on `date_default_timezone_set()`, this MUST NOT be mixed when storing `now` information or doing arithmetics when retrieving a `Y-m-d H:i:s` back from the persistence layer).
In addition the usage of these functions posseses the same issues like accessing the global scope or other infrastructure without relying on `Dependency Injection`. Accessing the `time` or `date` is just another subtle way of “reaching out”, which makes it hard/impossible to test those methods.
I would like to change this with this PR.

`User Land` Perspective: See https://github.com/ILIAS-eLearning/ILIAS/pull/4004/files#diff-19ff14f8652abd51b667e794b4258fa8cc58e7845c95af91fbc8ac15f0a41f8aR411