### PR TITLE
BT-31828: Added postvar to disabled inputs

### DIFF
--- a/Services/Form/classes/class.ilRadioGroupInputGUI.php
+++ b/Services/Form/classes/class.ilRadioGroupInputGUI.php
@@ -188,9 +188,7 @@ class ilRadioGroupInputGUI extends ilSubEnabledFormPropertyGUI implements ilTabl
             }
 
             $tpl->setCurrentBlock("prop_radio_option");
-            if (!$this->getDisabled()) {
-                $tpl->setVariable("POST_VAR", $this->getPostVar());
-            }
+            $tpl->setVariable("POST_VAR", $this->getPostVar());
             $tpl->setVariable("VAL_RADIO_OPTION", $option->getValue());
             $tpl->setVariable("OP_ID", $this->getFieldId() . "_" . $option->getValue());
             $tpl->setVariable("FID", $this->getFieldId());

--- a/Services/Form/classes/class.ilSelectInputGUI.php
+++ b/Services/Form/classes/class.ilSelectInputGUI.php
@@ -185,7 +185,8 @@ class ilSelectInputGUI extends ilSubEnabledFormPropertyGUI implements ilTableFil
         if ($this->getMulti() && substr($postvar, -2) != "[]") {
             $postvar .= "[]";
         }
-        
+
+        $tpl->setVariable("POST_VAR", $postvar);
         if ($this->getDisabled()) {
             if ($this->getMulti()) {
                 $value = $this->getMultiValues();
@@ -202,8 +203,6 @@ class ilSelectInputGUI extends ilSubEnabledFormPropertyGUI implements ilTableFil
                 $tpl->setVariable("DISABLED", " disabled=\"disabled\"");
                 $tpl->setVariable("HIDDEN_INPUT", $hidden);
             }
-        } else {
-            $tpl->setVariable("POST_VAR", $postvar);
         }
         
         // multi icons

--- a/Services/Form/classes/class.ilTextAreaInputGUI.php
+++ b/Services/Form/classes/class.ilTextAreaInputGUI.php
@@ -561,12 +561,8 @@ class ilTextAreaInputGUI extends ilSubEnabledFormPropertyGUI
                 $ttpl->setCurrentBlock("prop_textarea");
                 $ttpl->setVariable("ROWS", $this->getRows());
             }
-            if (!$this->getDisabled()) {
-                $ttpl->setVariable(
-                    "POST_VAR",
-                    $this->getPostVar()
-                );
-            }
+
+            $ttpl->setVariable("POST_VAR", $this->getPostVar());
             $ttpl->setVariable("ID", $this->getFieldId());
             if ($this->getDisabled()) {
                 $ttpl->setVariable('DISABLED', 'disabled="disabled" ');

--- a/Services/Form/classes/class.ilTextInputGUI.php
+++ b/Services/Form/classes/class.ilTextInputGUI.php
@@ -421,7 +421,8 @@ class ilTextInputGUI extends ilSubEnabledFormPropertyGUI implements ilTableFilte
         if ($this->getMulti() && substr($postvar, -2) != "[]") {
             $postvar .= "[]";
         }
-        
+
+        $tpl->setVariable("POST_VAR", $postvar);
         if ($this->getDisabled()) {
             if ($this->getMulti()) {
                 $value = $this->getMultiValues();
@@ -438,8 +439,6 @@ class ilTextInputGUI extends ilSubEnabledFormPropertyGUI implements ilTableFilte
                 $tpl->setVariable("HIDDEN_INPUT", $hidden);
             }
             $tpl->setVariable("DISABLED", " disabled=\"disabled\"");
-        } else {
-            $tpl->setVariable("POST_VAR", $postvar);
         }
 
         // use autocomplete feature?


### PR DESCRIPTION
Link to Mantis-Report:
https://mantis.ilias.de/view.php?id=31828

In some Input-GUIs the postvar would deliberately not be set if the input field was disabled, in others it would. 
Since the removing of postvars were old changes that seemed obsolete and did lead to empty name elements in the HTML (as seen in the BR), I decided to re-implement them on disabled input fields.
Furthermore, the re-implementing of them did not lead to any errors or wonkiness in the process of working with the form.
