### PR TITLE
fix for 31592: check if value for divider is too big

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
@@ -689,6 +689,11 @@ class assFormulaQuestionGUI extends assQuestionGUI
                         $max_range->setAlert($this->lng->txt('err_range'));
                         $custom_errors = true;
                     }
+                    $intPrecision = $form->getItemByPostVar('intprecision_' . $variable->getVariable());
+                    if ( $intPrecision >= $max_range) {
+                        $intPrecision->setAlert($this->lng->txt('err_division'));
+                        $custom_errors = true;
+                    }
                 }
             }
 

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
@@ -690,7 +690,7 @@ class assFormulaQuestionGUI extends assQuestionGUI
                         $custom_errors = true;
                     }
                     $intPrecision = $form->getItemByPostVar('intprecision_' . $variable->getVariable());
-                    if ( $intPrecision >= $max_range) {
+                    if ($intPrecision->getValue() > $max_range->getValue()) {
                         $intPrecision->setAlert($this->lng->txt('err_division'));
                         $custom_errors = true;
                     }

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionVariable.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionVariable.php
@@ -47,6 +47,12 @@ class assFormulaQuestionVariable
     {
         
 //		@todo check this
+        if ($this->getIntprecision() > $this->getRangeMax())
+        {
+            global $DIC;
+            $lng = $DIC['lng'];
+            ilUtil::sendFailure($lng->txt('err_divider_too_big'));
+        }
         
         include_once "./Services/Math/classes/class.ilMath.php";
         $mul = ilMath::_pow(10, $this->getPrecision());

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionVariable.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionVariable.php
@@ -47,8 +47,7 @@ class assFormulaQuestionVariable
     {
         
 //		@todo check this
-        if ($this->getIntprecision() > $this->getRangeMax())
-        {
+        if ($this->getIntprecision() > $this->getRangeMax()){
             global $DIC;
             $lng = $DIC['lng'];
             ilUtil::sendFailure($lng->txt('err_divider_too_big'));

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -11675,6 +11675,7 @@ assessment#:#result_units#:#Auswählbare Einheiten
 assessment#:#precision#:#Präzision
 assessment#:#err_range#:#Die obere Grenze muss größer als die untere Grenze sein.
 assessment#:#err_division#:#Dieser Wert muss kleiner als das Maximum sein.
+assessment#:#err_divider_too_big#:#Der Teiler einer der Variablen in dieser Frage ist zu gross.
 assessment#:#err_no_formula#:#Bitte geben Sie eine Formel zur Berechnung des Ergebnisses an.
 assessment#:#err_wrong_rating_advanced#:#Bitte stellen Sie sicher, dass die Summe der erweiterten Bewertungsoptionen genau 100 Prozent ergibt.
 assessment#:#rating_sign#:#Bewertung (Vorzeichen)

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -11674,6 +11674,7 @@ assessment#:#tolerance#:#Toleranz (%)
 assessment#:#result_units#:#Auswählbare Einheiten
 assessment#:#precision#:#Präzision
 assessment#:#err_range#:#Die obere Grenze muss größer als die untere Grenze sein.
+assessment#:#err_division#:#Dieser Wert muss kleiner als das Maximum sein.
 assessment#:#err_no_formula#:#Bitte geben Sie eine Formel zur Berechnung des Ergebnisses an.
 assessment#:#err_wrong_rating_advanced#:#Bitte stellen Sie sicher, dass die Summe der erweiterten Bewertungsoptionen genau 100 Prozent ergibt.
 assessment#:#rating_sign#:#Bewertung (Vorzeichen)

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -11723,7 +11723,7 @@ assessment#:#tolerance#:#Tolerance (%)
 assessment#:#result_units#:#Available Units
 assessment#:#precision#:#Precision
 assessment#:#err_range#:#The maximum range must be greater than the minimum range
-assessment#:#err_division#:#This number has to be smaller than the maximum range.
+assessment#:#err_division#:#This value has to be smaller than the maximum range.
 assessment#:#err_no_formula#:#You must enter a formula
 assessment#:#err_wrong_rating_advanced#:#Please make sure that the addition of the advanced rating settings equals to 100 percent
 assessment#:#rating_sign#:#Rate Sign

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -11724,6 +11724,7 @@ assessment#:#result_units#:#Available Units
 assessment#:#precision#:#Precision
 assessment#:#err_range#:#The maximum range must be greater than the minimum range
 assessment#:#err_division#:#This value has to be smaller than the maximum range.
+assessment#:#err_divider_too_big#:#The divider of one of the variables in this question is too big.
 assessment#:#err_no_formula#:#You must enter a formula
 assessment#:#err_wrong_rating_advanced#:#Please make sure that the addition of the advanced rating settings equals to 100 percent
 assessment#:#rating_sign#:#Rate Sign

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -11723,6 +11723,7 @@ assessment#:#tolerance#:#Tolerance (%)
 assessment#:#result_units#:#Available Units
 assessment#:#precision#:#Precision
 assessment#:#err_range#:#The maximum range must be greater than the minimum range
+assessment#:#err_division#:#This number has to be smaller than the maximum range.
 assessment#:#err_no_formula#:#You must enter a formula
 assessment#:#err_wrong_rating_advanced#:#Please make sure that the addition of the advanced rating settings equals to 100 percent
 assessment#:#rating_sign#:#Rate Sign


### PR DESCRIPTION
Fixes https://mantis.ilias.de/view.php?id=31592
When trying to save a value for divider that is to big, a message will show up: 
"This number has to be smaller than the maximum range."
