### PR TITLE
Deprecation of Legacy-UIComponents-Service

### DIFF
--- a/Services/UIComponent/AdvancedSelectionList/classes/class.ilAdvancedSelectionListGUI.php
+++ b/Services/UIComponent/AdvancedSelectionList/classes/class.ilAdvancedSelectionListGUI.php
@@ -20,7 +20,7 @@
  * User interface class for advanced drop-down selection lists
  *
  * @author Alexander Killing <killing@leifos.de>
- * @deprecated use KS Dropdowns instead
+ * @deprecated 9 Use KS Dropdowns instead
  */
 class ilAdvancedSelectionListGUI implements ilToolbarItem
 {

--- a/Services/UIComponent/AdvancedSelectionList/classes/class.ilAdvancedSelectionListGUI.php
+++ b/Services/UIComponent/AdvancedSelectionList/classes/class.ilAdvancedSelectionListGUI.php
@@ -20,7 +20,7 @@
  * User interface class for advanced drop-down selection lists
  *
  * @author Alexander Killing <killing@leifos.de>
- * @deprecated 9 Use KS Dropdowns instead
+ * @deprecated 10 Use KS Dropdowns instead
  */
 class ilAdvancedSelectionListGUI implements ilToolbarItem
 {

--- a/Services/UIComponent/Button/classes/class.ilButton.php
+++ b/Services/UIComponent/Button/classes/class.ilButton.php
@@ -19,7 +19,7 @@
 /**
  * Description: <button> (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button) by Mozilla Contributors is licensed under CC-BY-SA 2.5.
  * @author  Michael Jansen <mjansen@databay.de>
- * @deprecated use KS Buttons instead
+ * @deprecated 9 Use KS Buttons instead
  */
 class ilButton extends ilButtonBase
 {

--- a/Services/UIComponent/Button/classes/class.ilButton.php
+++ b/Services/UIComponent/Button/classes/class.ilButton.php
@@ -19,7 +19,7 @@
 /**
  * Description: <button> (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button) by Mozilla Contributors is licensed under CC-BY-SA 2.5.
  * @author  Michael Jansen <mjansen@databay.de>
- * @deprecated 9 Use KS Buttons instead
+ * @deprecated 10 Use KS Buttons instead
  */
 class ilButton extends ilButtonBase
 {

--- a/Services/UIComponent/Button/classes/class.ilButtonBase.php
+++ b/Services/UIComponent/Button/classes/class.ilButtonBase.php
@@ -20,7 +20,7 @@
  * Button GUI
  *
  * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>
- * @deprecated 10 Use KS Buttons instead
+ * @deprecated 11 Use KS Buttons instead
  */
 abstract class ilButtonBase implements ilToolbarItem
 {

--- a/Services/UIComponent/Button/classes/class.ilButtonBase.php
+++ b/Services/UIComponent/Button/classes/class.ilButtonBase.php
@@ -20,7 +20,7 @@
  * Button GUI
  *
  * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>
- * @deprecated use KS Buttons instead
+ * @deprecated 10 Use KS Buttons instead
  */
 abstract class ilButtonBase implements ilToolbarItem
 {

--- a/Services/UIComponent/Button/classes/class.ilImageLinkButton.php
+++ b/Services/UIComponent/Button/classes/class.ilImageLinkButton.php
@@ -20,7 +20,7 @@
  * Image Link Button GUI
  *
  * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>
- * @deprecated use KS Buttons instead
+ * @deprecated 9 Use KS Buttons instead
  */
 class ilImageLinkButton extends ilLinkButton
 {

--- a/Services/UIComponent/Button/classes/class.ilImageLinkButton.php
+++ b/Services/UIComponent/Button/classes/class.ilImageLinkButton.php
@@ -20,7 +20,7 @@
  * Image Link Button GUI
  *
  * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>
- * @deprecated 9 Use KS Buttons instead
+ * @deprecated 10 Use KS Buttons instead
  */
 class ilImageLinkButton extends ilLinkButton
 {

--- a/Services/UIComponent/Button/classes/class.ilJsLinkButton.php
+++ b/Services/UIComponent/Button/classes/class.ilJsLinkButton.php
@@ -19,7 +19,7 @@
 /**
  * Link Button GUI
  * @author  Jörg Lützenkirchen <luetzenkirchen@leifos.com>
- * @deprecated use KS Buttons instead
+ * @deprecated 9 Use KS Buttons instead
  */
 class ilJsLinkButton extends ilButton
 {

--- a/Services/UIComponent/Button/classes/class.ilJsLinkButton.php
+++ b/Services/UIComponent/Button/classes/class.ilJsLinkButton.php
@@ -19,7 +19,7 @@
 /**
  * Link Button GUI
  * @author  Jörg Lützenkirchen <luetzenkirchen@leifos.com>
- * @deprecated 9 Use KS Buttons instead
+ * @deprecated 10 Use KS Buttons instead
  */
 class ilJsLinkButton extends ilButton
 {

--- a/Services/UIComponent/Button/classes/class.ilLinkButton.php
+++ b/Services/UIComponent/Button/classes/class.ilLinkButton.php
@@ -20,7 +20,7 @@
  * Link Button GUI
  *
  * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>
- * @deprecated 9 Use KS Buttons instead
+ * @deprecated 10 Use KS Buttons instead
  */
 class ilLinkButton extends ilButtonBase
 {

--- a/Services/UIComponent/Button/classes/class.ilLinkButton.php
+++ b/Services/UIComponent/Button/classes/class.ilLinkButton.php
@@ -20,7 +20,7 @@
  * Link Button GUI
  *
  * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>
- * @deprecated use KS Buttons instead
+ * @deprecated 9 Use KS Buttons instead
  */
 class ilLinkButton extends ilButtonBase
 {

--- a/Services/UIComponent/Button/classes/class.ilSubmitButton.php
+++ b/Services/UIComponent/Button/classes/class.ilSubmitButton.php
@@ -20,7 +20,7 @@
  * Submit Button GUI
  *
  * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>
- * @deprecated 9 Use KS Buttons instead
+ * @deprecated 10 Use KS Buttons instead
  */
 class ilSubmitButton extends ilButtonBase
 {

--- a/Services/UIComponent/Button/classes/class.ilSubmitButton.php
+++ b/Services/UIComponent/Button/classes/class.ilSubmitButton.php
@@ -20,7 +20,7 @@
  * Submit Button GUI
  *
  * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>
- * @deprecated use KS Buttons instead
+ * @deprecated 9 Use KS Buttons instead
  */
 class ilSubmitButton extends ilButtonBase
 {

--- a/Services/UIComponent/CheckboxListOverlay/classes/class.ilCheckboxListOverlayGUI.php
+++ b/Services/UIComponent/CheckboxListOverlay/classes/class.ilCheckboxListOverlayGUI.php
@@ -20,7 +20,7 @@
  * User interface class for a checkbox list overlay
  *
  * @author Alexander Killing <killing@leifos.de>
- * @deprecated only used in legacy tables, do not introduce this anywhere else
+ * @deprecated 9 Only used in legacy tables, do not introduce this anywhere else
  */
 class ilCheckboxListOverlayGUI
 {

--- a/Services/UIComponent/CheckboxListOverlay/classes/class.ilCheckboxListOverlayGUI.php
+++ b/Services/UIComponent/CheckboxListOverlay/classes/class.ilCheckboxListOverlayGUI.php
@@ -20,7 +20,7 @@
  * User interface class for a checkbox list overlay
  *
  * @author Alexander Killing <killing@leifos.de>
- * @deprecated 9 Only used in legacy tables, do not introduce this anywhere else
+ * @deprecated 10 Only used in legacy tables, do not introduce this anywhere else
  */
 class ilCheckboxListOverlayGUI
 {

--- a/Services/UIComponent/Confirmation/class.ilConfirmationGUI.php
+++ b/Services/UIComponent/Confirmation/class.ilConfirmationGUI.php
@@ -21,7 +21,7 @@
  *
  * @author Alexander Killing <killing@leifos.de>
  *
- * @deprecated 10
+ * @deprecated 11
  */
 class ilConfirmationGUI
 {

--- a/Services/UIComponent/Confirmation/class.ilConfirmationGUI.php
+++ b/Services/UIComponent/Confirmation/class.ilConfirmationGUI.php
@@ -20,6 +20,8 @@
  * Confirmation screen class.
  *
  * @author Alexander Killing <killing@leifos.de>
+ *
+ * @deprecated 10
  */
 class ilConfirmationGUI
 {

--- a/Services/UIComponent/Confirmation/class.ilConfirmationTableGUI.php
+++ b/Services/UIComponent/Confirmation/class.ilConfirmationTableGUI.php
@@ -21,7 +21,7 @@
  *
  * @author Alexander Killing <killing@leifos.de>
  *
- * @deprecated 10
+ * @deprecated 11
  */
 class ilConfirmationTableGUI extends ilTable2GUI
 {

--- a/Services/UIComponent/Confirmation/class.ilConfirmationTableGUI.php
+++ b/Services/UIComponent/Confirmation/class.ilConfirmationTableGUI.php
@@ -20,6 +20,8 @@
  * TableGUI class for
  *
  * @author Alexander Killing <killing@leifos.de>
+ *
+ * @deprecated 10
  */
 class ilConfirmationTableGUI extends ilTable2GUI
 {

--- a/Services/UIComponent/Explorer/classes/class.ilExplorer.php
+++ b/Services/UIComponent/Explorer/classes/class.ilExplorer.php
@@ -23,7 +23,8 @@ const IL_FM_NEGATIVE = 2;
  * class for explorer view in admin frame
  *
  * @author Stefan Meyer <meyer@leifos.com>
- * @deprecated
+ *
+ * @deprecated 10
  */
 class ilExplorer
 {

--- a/Services/UIComponent/Explorer/classes/class.ilExplorer.php
+++ b/Services/UIComponent/Explorer/classes/class.ilExplorer.php
@@ -24,7 +24,7 @@ const IL_FM_NEGATIVE = 2;
  *
  * @author Stefan Meyer <meyer@leifos.com>
  *
- * @deprecated 10
+ * @deprecated 11
  */
 class ilExplorer
 {

--- a/Services/UIComponent/Explorer2/classes/class.ilExplorerBaseGUI.php
+++ b/Services/UIComponent/Explorer2/classes/class.ilExplorerBaseGUI.php
@@ -22,6 +22,8 @@
  * is not defined by this abstract class.
  *
  * @author Alexander Killing <killing@leifos.de>
+ *
+ * @deprecated 10
  */
 abstract class ilExplorerBaseGUI
 {

--- a/Services/UIComponent/Explorer2/classes/class.ilExplorerBaseGUI.php
+++ b/Services/UIComponent/Explorer2/classes/class.ilExplorerBaseGUI.php
@@ -23,7 +23,7 @@
  *
  * @author Alexander Killing <killing@leifos.de>
  *
- * @deprecated 10
+ * @deprecated 11
  */
 abstract class ilExplorerBaseGUI
 {

--- a/Services/UIComponent/Explorer2/classes/class.ilExplorerSelectInputGUI.php
+++ b/Services/UIComponent/Explorer2/classes/class.ilExplorerSelectInputGUI.php
@@ -21,7 +21,7 @@
  *
  * @author Alexander Killing <killing@leifos.de>
  *
- * @deprecated 10
+ * @deprecated 11
  */
 abstract class ilExplorerSelectInputGUI extends ilFormPropertyGUI implements ilTableFilterItem
 {

--- a/Services/UIComponent/Explorer2/classes/class.ilExplorerSelectInputGUI.php
+++ b/Services/UIComponent/Explorer2/classes/class.ilExplorerSelectInputGUI.php
@@ -20,6 +20,8 @@
  * Select explorer tree nodes input GUI
  *
  * @author Alexander Killing <killing@leifos.de>
+ *
+ * @deprecated 10
  */
 abstract class ilExplorerSelectInputGUI extends ilFormPropertyGUI implements ilTableFilterItem
 {

--- a/Services/UIComponent/Explorer2/classes/class.ilTreeExplorerGUI.php
+++ b/Services/UIComponent/Explorer2/classes/class.ilTreeExplorerGUI.php
@@ -22,6 +22,8 @@ use ILIAS\UI\Component\Tree\Tree;
  * Explorer class that works on tree objects (Services/Tree)
  *
  * @author Alexander Killing <killing@leifos.de>
+ *
+ * @deprecated 10
  */
 abstract class ilTreeExplorerGUI extends ilExplorerBaseGUI implements \ILIAS\UI\Component\Tree\TreeRecursion
 {

--- a/Services/UIComponent/Explorer2/classes/class.ilTreeExplorerGUI.php
+++ b/Services/UIComponent/Explorer2/classes/class.ilTreeExplorerGUI.php
@@ -23,7 +23,7 @@ use ILIAS\UI\Component\Tree\Tree;
  *
  * @author Alexander Killing <killing@leifos.de>
  *
- * @deprecated 10
+ * @deprecated 11
  */
 abstract class ilTreeExplorerGUI extends ilExplorerBaseGUI implements \ILIAS\UI\Component\Tree\TreeRecursion
 {

--- a/Services/UIComponent/Glyph/classes/class.ilGlyphGUI.php
+++ b/Services/UIComponent/Glyph/classes/class.ilGlyphGUI.php
@@ -19,7 +19,7 @@
 /**
  * @author Alexander Killing <killing@leifos.de>
  *
- * @deprecated 10
+ * @deprecated 11
  */
 class ilGlyphGUI
 {

--- a/Services/UIComponent/Glyph/classes/class.ilGlyphGUI.php
+++ b/Services/UIComponent/Glyph/classes/class.ilGlyphGUI.php
@@ -18,6 +18,8 @@
 
 /**
  * @author Alexander Killing <killing@leifos.de>
+ *
+ * @deprecated 10
  */
 class ilGlyphGUI
 {

--- a/Services/UIComponent/GroupedList/classes/class.ilGroupedListGUI.php
+++ b/Services/UIComponent/GroupedList/classes/class.ilGroupedListGUI.php
@@ -20,6 +20,8 @@
  * Grouped list GUI class
  *
  * @author Alexander Killing <killing@leifos.de>
+ *
+ * @deprecated 10
  */
 class ilGroupedListGUI
 {

--- a/Services/UIComponent/GroupedList/classes/class.ilGroupedListGUI.php
+++ b/Services/UIComponent/GroupedList/classes/class.ilGroupedListGUI.php
@@ -21,7 +21,7 @@
  *
  * @author Alexander Killing <killing@leifos.de>
  *
- * @deprecated 10
+ * @deprecated 11
  */
 class ilGroupedListGUI
 {

--- a/Services/UIComponent/Lightbox/classes/class.ilLightboxGUI.php
+++ b/Services/UIComponent/Lightbox/classes/class.ilLightboxGUI.php
@@ -20,7 +20,7 @@
  * Lightbox handling
  * @author Alexander Killing <killing@leifos.de>
  *
- * @deprecated 10
+ * @deprecated 11
  */
 class ilLightboxGUI
 {

--- a/Services/UIComponent/Lightbox/classes/class.ilLightboxGUI.php
+++ b/Services/UIComponent/Lightbox/classes/class.ilLightboxGUI.php
@@ -19,6 +19,8 @@
 /**
  * Lightbox handling
  * @author Alexander Killing <killing@leifos.de>
+ *
+ * @deprecated 10
  */
 class ilLightboxGUI
 {

--- a/Services/UIComponent/Modal/classes/class.ilModalGUI.php
+++ b/Services/UIComponent/Modal/classes/class.ilModalGUI.php
@@ -21,7 +21,7 @@
  *
  * @author Alexander Killing <killing@leifos.de>
  *
- * @deprecated 10
+ * @deprecated 11
  */
 class ilModalGUI
 {

--- a/Services/UIComponent/Modal/classes/class.ilModalGUI.php
+++ b/Services/UIComponent/Modal/classes/class.ilModalGUI.php
@@ -20,6 +20,8 @@
  * Modal class
  *
  * @author Alexander Killing <killing@leifos.de>
+ *
+ * @deprecated 10
  */
 class ilModalGUI
 {

--- a/Services/UIComponent/NestedList/classes/class.ilNestedList.php
+++ b/Services/UIComponent/NestedList/classes/class.ilNestedList.php
@@ -19,6 +19,8 @@
 /**
  * Nested List
  * @author Alexander Killing <killing@leifos.de>
+ *
+ * @deprecated 10
  */
 class ilNestedList
 {

--- a/Services/UIComponent/NestedList/classes/class.ilNestedList.php
+++ b/Services/UIComponent/NestedList/classes/class.ilNestedList.php
@@ -20,7 +20,7 @@
  * Nested List
  * @author Alexander Killing <killing@leifos.de>
  *
- * @deprecated 10
+ * @deprecated 11
  */
 class ilNestedList
 {

--- a/Services/UIComponent/Overlay/classes/class.ilOverlayGUI.php
+++ b/Services/UIComponent/Overlay/classes/class.ilOverlayGUI.php
@@ -20,7 +20,7 @@
  * This is a utility class for the yui overlays.
  * this only works, if a parent has class="yui-skin-sam" attached.
  *
- * @deprecated 10
+ * @deprecated 11
  */
 class ilOverlayGUI
 {

--- a/Services/UIComponent/Overlay/classes/class.ilOverlayGUI.php
+++ b/Services/UIComponent/Overlay/classes/class.ilOverlayGUI.php
@@ -19,6 +19,8 @@
 /**
  * This is a utility class for the yui overlays.
  * this only works, if a parent has class="yui-skin-sam" attached.
+ *
+ * @deprecated 10
  */
 class ilOverlayGUI
 {

--- a/Services/UIComponent/Panel/classes/class.ilPanelGUI.php
+++ b/Services/UIComponent/Panel/classes/class.ilPanelGUI.php
@@ -21,7 +21,7 @@
  *
  * @author Alexander Killing <killing@leifos.de>
  *
- * @deprecated 10
+ * @deprecated 11
  */
 class ilPanelGUI
 {

--- a/Services/UIComponent/Panel/classes/class.ilPanelGUI.php
+++ b/Services/UIComponent/Panel/classes/class.ilPanelGUI.php
@@ -20,6 +20,8 @@
  * Simple panel class
  *
  * @author Alexander Killing <killing@leifos.de>
+ *
+ * @deprecated 10
  */
 class ilPanelGUI
 {

--- a/Services/UIComponent/ProgressBar/classes/class.ilProgressBar.php
+++ b/Services/UIComponent/ProgressBar/classes/class.ilProgressBar.php
@@ -20,7 +20,7 @@
  * Progress bar GUI
  * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>
  *
- * @deprecated 10
+ * @deprecated 11
  */
 class ilProgressBar
 {

--- a/Services/UIComponent/ProgressBar/classes/class.ilProgressBar.php
+++ b/Services/UIComponent/ProgressBar/classes/class.ilProgressBar.php
@@ -19,6 +19,8 @@
 /**
  * Progress bar GUI
  * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>
+ *
+ * @deprecated 10
  */
 class ilProgressBar
 {

--- a/Services/UIComponent/README.md
+++ b/Services/UIComponent/README.md
@@ -1,9 +1,6 @@
 # UIComponent Service
 
-The UI Component Service provides wrappers for several UI Components to be re-used. Note that many of those components
-have been deprecated, since we are migrating much of the content of this service to src/UI. If you feel that you need
-to use one of those components nevertheless for new developments, maybe think about providing a PR to src/UI to add the
-missing feature. This would be highly appreciated.
+The UI Component Service is depricated and MUST NOT be used anymore.
 
 ## UserInterfaceHook Pluginslot 
 This plugin slot has been published as stable with ILIAS 4.2. The goal of the user interface plugin slot is to allow simple

--- a/Services/UIComponent/README.md
+++ b/Services/UIComponent/README.md
@@ -1,15 +1,15 @@
 # UIComponent Service
 
-The UI Component Service is depricated and MUST NOT be used anymore.
+***The UI Component Service is deprecated and MUST NOT be used anymore.***
 
-## UserInterfaceHook Pluginslot 
+## UserInterfaceHook Pluginslot
 This plugin slot has been published as stable with ILIAS 4.2. The goal of the user interface plugin slot is to allow simple
- modifications of standard components of the ILIAS user interface. The slot is defined by the UIComponent Service of ILIAS 
+ modifications of standard components of the ILIAS user interface. The slot is defined by the UIComponent Service of ILIAS
  and named "UserInterfaceHook". This means all plugins have to be installed into directories at:
 
 `Customizing/global/plugins/Services/UIComponent/UserInterfaceHook/<Plugin_Name>`
 
-The ID of the UIComponent Service is "ui", the ID of the slot is "uihk". These are used as prefixes together with your 
+The ID of the UIComponent Service is "ui", the ID of the slot is "uihk". These are used as prefixes together with your
 plugin id for database tables and for language variable identifiers:
 
 DB Table / Language VariablePrefixes: `ui_uihk_<Plugin_ID>_`

--- a/Services/UIComponent/ROADMAP.md
+++ b/Services/UIComponent/ROADMAP.md
@@ -7,25 +7,25 @@ The Legacy-UIComponents-Service has been lingering and causing problems for user
 ## Further process
 * Presentation of the project to remove the UIComponents-Service at the Jour Fixe for big projects for ILIAS 9 in February 2022.
 * Appointment of a Project Manager through the Technical Board.
-* Collection of missing UI-Elements in UI-Service by responsible maintainers and Project Manager until April 30th 2022.
+* Collection of missing UI-Elements in UI-Service by responsible maintainers and Project Manager until September 30th 2022.
 * Organization by Project Manager of crowdfunding to finance the creation of the missing UI-Elements and to migrate Components.
-* Migration of Components relying on already depricated UIComponents until Coding Complete for ILIAS 9.
-* Planing of implementation of missing UI-Elements by Project Manager. The implementation MUST be finalized by Feature Freeze for ILIAS 10.
-* Migration of Components away from UIComponents-Service until Coding Complete for ILIAS 10.
+* Migration of Components relying on already deprecated UIComponents until Coding Complete for ILIAS 10.
+* Planing of implementation of missing UI-Elements by Project Manager. The implementation MUST be finalized by Feature Freeze for ILIAS 11.
+* Migration of Components away from UIComponents-Service until Coding Complete for ILIAS 11.
 
 ## Rules and Guidelines
 * If a feature should be implemented in a component still relying on the UIComponents-Service, this reliance MUST be removed first.
-* There will be no ILIAS 10 with the UIComponents in it. If a component cannot be moved, it MUST be abandoned.
+* There will be no ILIAS 11 with the UIComponents in it. If a component cannot be moved, it MUST be abandoned.
 
 ## Removal
 
-### ILIAS 9
+### ILIAS 10
 * Advanced Selection List
-* Buttons (except ilButtonBase as it is needed for the SplitButton to be removed with ILIAS 10)
+* Buttons (except ilButtonBase as it is needed for the SplitButton to be removed with ILIAS 11)
 * Character Selector
 * Checkbox List Overlay
 
-### ILIAS 10
+### ILIAS 11
 * Confirmation & Confirmation Table
 * Explorer & Explorer2
 * Glyph

--- a/Services/UIComponent/ROADMAP.md
+++ b/Services/UIComponent/ROADMAP.md
@@ -1,97 +1,44 @@
 # Roadmap
 
-## Removing deprecated UI implementations
+## Introduction
 
-The priorities for deprecation and removing the components are discussed frequently in the Page Layout Revision meetings.
+The Legacy-UIComponents-Service has been lingering and causing problems for user experience, accessibility, updatability, and consistency for a long while now. It also causes a lot of work as many changes in the UI need to be backported here. To avoid this state going on forever the whole UIComponents-Service is marked as depricated and will be removed with ILIAS 10. Parts of the UIComponents already marked as depricated on January 1st 2022 will be removed with ILIAS 9. Please make sure you have moved your UI to the [UI-Framework](https://github.com/ILIAS-eLearning/ILIAS/tree/trunk/src/UI) until then.
 
-PLR Meeting, 13 Aug 2020: We currently would like to focus on the following elements to be removed completely: Checklist, Glyph, GroupedList, Lightbox, Modal.
+## Further process
+* Presentation of the project to remove the UIComponents-Service at the Jour Fixe for big projects for ILIAS 9 in February 2022.
+* Appointment of a Project Manager through the Technical Board.
+* Collection of missing UI-Elements in UI-Service by responsible maintainers and Project Manager until April 30th 2022.
+* Organization by Project Manager of crowdfunding to finance the creation of the missing UI-Elements and to migrate Components.
+* Migration of Components relying on already depricated UIComponents until Coding Complete for ILIAS 9.
+* Planing of implementation of missing UI-Elements by Project Manager. The implementation MUST be finalized by Feature Freeze for ILIAS 10.
+* Migration of Components away from UIComponents-Service until Coding Complete for ILIAS 10.
 
-### AdvancedSelectionListGUI
+## Rules and Guidelines
+* If a feature should be implemented in a component still relying on the UIComponents-Service, this reliance MUST be removed first.
+* There will be no ILIAS 10 with the UIComponents in it. If a component cannot be moved, it MUST be abandoned.
 
-Please migrate to KS Dropdowns. If this is not possible, please contact the PLR group.
+## Removal
 
-**Usages**
-- Oct 2021: More than 100 usages in various components.
+### ILIAS 9
+* Advanced Selection List
+* Buttons (except ilButtonBase as it is needed for the SplitButton to be removed with ILIAS 10)
+* Character Selector
+* Checkbox List Overlay
 
-### Checklist (ilChecklistGUI)
-
-- Should be easy to remove with ILIAS 7 setup refactorings.
-
-**Usages**
-
-- setup: Checklist in setup, seems to be obsolete/dead code. -> RK
-
-### Glyph (ilGlyphGUI)
-
-- Missing in KS: Filter, Drag
-- Other usages should be replaced by KS glyphs.
-
-**Usages**
-
-- Filter Glyph
-  - Services/Awareness -> AK
-- Add Glyph
-  - Services/COPage (Page Editor) -> AK
-- Drag Glyph
-  - Services/COPage (Page Editor) -> AK
-  - Services/Form (HierarchyForm) -> AK
-- Up/Down Glyph
-  - Services/Form (FileWizardInput) -> FS
-  - Services/Form (FormProperty) -> AK
-  - Services/Form (MultipleImagesInput, MultipleTextsInput, TextWizardInput) -> BH/MB
-  - Services/Form (SelectBuilderInput) -> SM
-- Add/Remove Glyph
-  - Services/Form (FileWizardInput) -> FS
-  - Services/Form (FormProperty, HierarchyForm) -> AK
-  - Services/Form (MultipleImagesInput, MultipleTextsInput, TextWizardInput) -> BH/MB
-  - Services/Form (SelectBuilderInput) -> SM
-- Search Glyph
-  - Services/Help -> AK
-- Close Glyph
-  - Services/Help, Services/MediaObjects, Services/Notes -> AK
-  - Services/Notification (OSD) -> MJ
-- Caret Glyph
-  - Services/Search -> SM
-- Previous/Next Glyph
-  - Services/Tabs -> AK
-
-### GroupedList (ilGroupedListGUI)
-
-- KS replacement needed. Most prominent use is the "Add New Item Dropdown". Grouped lists are lists with subheadings and a possible multi-column layout.
-
-**Usages**
-
-- **Services/Object**: Used for "Add New Item" Dropdown. Replacing this instance needs a broader discussion in the PLR group. Currently there does not seem to exist anything in the KS that could be a simple replacement. -> ALL
-- **Services/Help**: Used for listings of help pages. -> AK
-- **Services/MainMenu**: Used for rendering of help topics. Most probable deprecated. -> AK
-- **Modules/Test**: Used for list of questions? -> BH/MB
-- **Services/UIComponent/Checklist**: Old check list presentation (see above). Obsolete. -> AK after RK
-
-### Lightbox (ilLightboxGUI)
-
-- Should be replaced with KS element. Missing: ilLightboxGUI does not only support special content types, but any media object. Maybe this is not a necessary requirement in the mediacast with ILIAS 7 anymore.
-
-**Usages**
-
-- **Services/MediaObjects**: Used for lightbox in media casts. -> AK
-
-### Modal (ilModalGUI)
-
-- These might not all be easily transferrable to the KS elements. Sometimes the JS API is being used by consumers, e.g. in the chatroom.
-
-**Usages**
-
-- Modules/Chatroom -> MJ
-- Modules/Excercise -> AK
-- Modules/Forum -> MJ
-- Modules/MediaPool -> AK
-- Modules/StudyProgramme -> RK
-- Modules/Survey -> AK
-- Modules/Test -> BH/MB
-- Modules/TestQuestionPool -> BH/MB
-- Services/COPage -> AK
-- Services/Link (Internal link modal) -> AK
-
-### Other components
-
-WIP
+### ILIAS 10
+* Confirmation & Confirmation Table
+* Explorer & Explorer2
+* Glyph
+* Grouped List
+* Lightbox
+* Modal
+* Nested List
+* Overlay
+* Panel
+* Progress Bar
+* Split Button
+* Syntax Highlighter (only used in in Page Editor, move there?)
+* Tabs
+* Text Highlighter
+* Toolbar
+* Tooltip

--- a/Services/UIComponent/SplitButton/classes/class.ilButtonToSplitButtonMenuItemAdapter.php
+++ b/Services/UIComponent/SplitButton/classes/class.ilButtonToSplitButtonMenuItemAdapter.php
@@ -19,6 +19,8 @@
 /**
  * Class ilButtonToSplitButtonMenuItemAdapter
  * @author Michael Jansen <mjansen@databay.de>
+ *
+ * @deprecated 10
  */
 class ilButtonToSplitButtonMenuItemAdapter implements ilSplitButtonMenuItem
 {

--- a/Services/UIComponent/SplitButton/classes/class.ilButtonToSplitButtonMenuItemAdapter.php
+++ b/Services/UIComponent/SplitButton/classes/class.ilButtonToSplitButtonMenuItemAdapter.php
@@ -20,7 +20,7 @@
  * Class ilButtonToSplitButtonMenuItemAdapter
  * @author Michael Jansen <mjansen@databay.de>
  *
- * @deprecated 10
+ * @deprecated 11
  */
 class ilButtonToSplitButtonMenuItemAdapter implements ilSplitButtonMenuItem
 {

--- a/Services/UIComponent/SplitButton/classes/class.ilSplitButtonGUI.php
+++ b/Services/UIComponent/SplitButton/classes/class.ilSplitButtonGUI.php
@@ -20,7 +20,7 @@
  * Class ilSplitButton
  * @author Michael Jansen <mjansen@databay.de>
  *
- * @deprecated 10
+ * @deprecated 11
  */
 class ilSplitButtonGUI extends ilButtonBase
 {

--- a/Services/UIComponent/SplitButton/classes/class.ilSplitButtonGUI.php
+++ b/Services/UIComponent/SplitButton/classes/class.ilSplitButtonGUI.php
@@ -19,6 +19,8 @@
 /**
  * Class ilSplitButton
  * @author Michael Jansen <mjansen@databay.de>
+ *
+ * @deprecated 10
  */
 class ilSplitButtonGUI extends ilButtonBase
 {

--- a/Services/UIComponent/SplitButton/classes/class.ilSplitButtonItemDivider.php
+++ b/Services/UIComponent/SplitButton/classes/class.ilSplitButtonItemDivider.php
@@ -19,6 +19,8 @@
 /**
  * Class ilSplitButtonItemDivider
  * @author Michael Jansen <mjansen@databay.de>
+ *
+ * @deprecated 10
  */
 class ilSplitButtonItemDivider implements ilSplitButtonSeparatorMenuItem
 {

--- a/Services/UIComponent/SplitButton/classes/class.ilSplitButtonItemDivider.php
+++ b/Services/UIComponent/SplitButton/classes/class.ilSplitButtonItemDivider.php
@@ -20,7 +20,7 @@
  * Class ilSplitButtonItemDivider
  * @author Michael Jansen <mjansen@databay.de>
  *
- * @deprecated 10
+ * @deprecated 11
  */
 class ilSplitButtonItemDivider implements ilSplitButtonSeparatorMenuItem
 {

--- a/Services/UIComponent/SplitButton/classes/class.ilUiLinkToSplitButtonMenuItemAdapter.php
+++ b/Services/UIComponent/SplitButton/classes/class.ilUiLinkToSplitButtonMenuItemAdapter.php
@@ -23,7 +23,7 @@ use ILIAS\UI\Renderer;
  * Class ilUiLinkToSplitButtonMenuItemAdapter
  * @author Michael Jansen <mjansen@databay.de>
  *
- * @deprecated 10
+ * @deprecated 11
  */
 class ilUiLinkToSplitButtonMenuItemAdapter implements ilSplitButtonMenuItem
 {

--- a/Services/UIComponent/SplitButton/classes/class.ilUiLinkToSplitButtonMenuItemAdapter.php
+++ b/Services/UIComponent/SplitButton/classes/class.ilUiLinkToSplitButtonMenuItemAdapter.php
@@ -22,6 +22,8 @@ use ILIAS\UI\Renderer;
 /**
  * Class ilUiLinkToSplitButtonMenuItemAdapter
  * @author Michael Jansen <mjansen@databay.de>
+ *
+ * @deprecated 10
  */
 class ilUiLinkToSplitButtonMenuItemAdapter implements ilSplitButtonMenuItem
 {

--- a/Services/UIComponent/SyntaxHighlighter/classes/class.ilSyntaxHighlighter.php
+++ b/Services/UIComponent/SyntaxHighlighter/classes/class.ilSyntaxHighlighter.php
@@ -21,7 +21,7 @@
  *
  * @author Alexander Killing <killing@leifos.de>
  *
- * @deprecated 10
+ * @deprecated 11
  */
 class ilSyntaxHighlighter
 {

--- a/Services/UIComponent/SyntaxHighlighter/classes/class.ilSyntaxHighlighter.php
+++ b/Services/UIComponent/SyntaxHighlighter/classes/class.ilSyntaxHighlighter.php
@@ -20,6 +20,8 @@
  * Syntax highlighter wrapper class
  *
  * @author Alexander Killing <killing@leifos.de>
+ *
+ * @deprecated 10
  */
 class ilSyntaxHighlighter
 {

--- a/Services/UIComponent/Tabs/classes/class.ilTabsGUI.php
+++ b/Services/UIComponent/Tabs/classes/class.ilTabsGUI.php
@@ -20,7 +20,7 @@
  * Tabs GUI
  * @author Alexander Killing <killing@leifos.de>
  *
- * @deprecated 10
+ * @deprecated 11
  */
 class ilTabsGUI
 {

--- a/Services/UIComponent/Tabs/classes/class.ilTabsGUI.php
+++ b/Services/UIComponent/Tabs/classes/class.ilTabsGUI.php
@@ -19,6 +19,8 @@
 /**
  * Tabs GUI
  * @author Alexander Killing <killing@leifos.de>
+ *
+ * @deprecated 10
  */
 class ilTabsGUI
 {

--- a/Services/UIComponent/TextHighlighter/classes/class.ilTextHighlighterGUI.php
+++ b/Services/UIComponent/TextHighlighter/classes/class.ilTextHighlighterGUI.php
@@ -19,6 +19,8 @@
 /**
  * Text highlighter.
  * @author Alexander Killing <killing@leifos.de>
+ *
+ * @deprecated 10
  */
 class ilTextHighlighterGUI
 {

--- a/Services/UIComponent/TextHighlighter/classes/class.ilTextHighlighterGUI.php
+++ b/Services/UIComponent/TextHighlighter/classes/class.ilTextHighlighterGUI.php
@@ -20,7 +20,7 @@
  * Text highlighter.
  * @author Alexander Killing <killing@leifos.de>
  *
- * @deprecated 10
+ * @deprecated 11
  */
 class ilTextHighlighterGUI
 {

--- a/Services/UIComponent/Toolbar/classes/class.ilToolbarGUI.php
+++ b/Services/UIComponent/Toolbar/classes/class.ilToolbarGUI.php
@@ -21,6 +21,8 @@
  * A default toolbar object is available in the $ilToolbar global object.
  * @author Alexander Killing <killing@leifos.de>
  * @author Stefan Wanzenried <sw@studer-raimann.ch>
+ *
+ * @deprecated 10
  */
 class ilToolbarGUI
 {

--- a/Services/UIComponent/Toolbar/classes/class.ilToolbarGUI.php
+++ b/Services/UIComponent/Toolbar/classes/class.ilToolbarGUI.php
@@ -22,7 +22,7 @@
  * @author Alexander Killing <killing@leifos.de>
  * @author Stefan Wanzenried <sw@studer-raimann.ch>
  *
- * @deprecated 10
+ * @deprecated 11
  */
 class ilToolbarGUI
 {

--- a/Services/UIComponent/Tooltip/classes/class.ilTooltipGUI.php
+++ b/Services/UIComponent/Tooltip/classes/class.ilTooltipGUI.php
@@ -20,7 +20,7 @@
  * This is a utility class for the yui tooltips.
  * this only works, if a parent has class="yui-skin-sam" attached.
  *
- * @deprecated 10
+ * @deprecated 11
  */
 class ilTooltipGUI
 {

--- a/Services/UIComponent/Tooltip/classes/class.ilTooltipGUI.php
+++ b/Services/UIComponent/Tooltip/classes/class.ilTooltipGUI.php
@@ -19,6 +19,8 @@
 /**
  * This is a utility class for the yui tooltips.
  * this only works, if a parent has class="yui-skin-sam" attached.
+ *
+ * @deprecated 10
  */
 class ilTooltipGUI
 {


### PR DESCRIPTION
The Technical Board proposes to advance the move to the UI-Framework. This PR defines a way to get rid of Services/UIComponents with ILIAS 10 and to remove already deprecated functions with ILIAS 9, thus simplifying our code base and the work needed to keep a consistent appearance for our end users.