### PR TITLE
Deprecation of Services/Table

### DIFF
--- a/Services/Table/ROADMAP.md
+++ b/Services/Table/ROADMAP.md
@@ -5,11 +5,11 @@ The Legacy-Table-Service has been lingering and causing problems for user experi
 ## Further process
 * Presentation of the project to remove Services/Table at the Jour Fixe for big projects for ILIAS 9 in February 2022.
 * Appointment of a Project Manager through the Technical Board.
-* Collection of missing functionality in Services/Table by responsible maintainers and Project Manager until April 30th 2022.
+* Collection of missing functionality in Services/Table by responsible maintainers and Project Manager until September 30th 2022.
 * Organization by Project Manager of crowdfunding to finance the implementation of the missing functionality of Services/Table and to migrate Components.
-* Planing of implementation of missing functionality by Project Manager. The implementation MUST be finalized by Feature Freeze for ILIAS 10.
-* Migration of Components away from Services/Table until Coding Complete for ILIAS 10.
+* Planing of implementation of missing functionality by Project Manager. The implementation MUST be finalized by Feature Freeze for ILIAS 11.
+* Migration of Components away from Services/Table until Coding Complete for ILIAS 11.
 
 ## Rules and Guidelines
 * If a feature should be implemented in a component still relying on the Table-Service, this reliance MUST be removed first.
-* There will be no ILIAS 10 with the Services/Table in it. If a component cannot be moved, it MUST be abandoned.
+* There will be no ILIAS 11 with the Services/Table in it. If a component cannot be moved, it MUST be abandoned.

--- a/Services/Table/ROADMAP.md
+++ b/Services/Table/ROADMAP.md
@@ -1,0 +1,15 @@
+## Introduction
+
+The Legacy-Table-Service has been lingering and causing problems for user experience, accessibility, updatability, and consistency for a long while now. To avoid this state going on forever Services/Table is marked as depricated and will be removed with ILIAS 10. Please make sure you have moved your UI to the [Table of the UI-Framework](https://github.com/ILIAS-eLearning/ILIAS/tree/trunk/src/UI/Component/Table) until then.
+
+## Further process
+* Presentation of the project to remove Services/Table at the Jour Fixe for big projects for ILIAS 9 in February 2022.
+* Appointment of a Project Manager through the Technical Board.
+* Collection of missing functionality in Services/Table by responsible maintainers and Project Manager until April 30th 2022.
+* Organization by Project Manager of crowdfunding to finance the implementation of the missing functionality of Services/Table and to migrate Components.
+* Planing of implementation of missing functionality by Project Manager. The implementation MUST be finalized by Feature Freeze for ILIAS 10.
+* Migration of Components away from Services/Table until Coding Complete for ILIAS 10.
+
+## Rules and Guidelines
+* If a feature should be implemented in a component still relying on the Table-Service, this reliance MUST be removed first.
+* There will be no ILIAS 10 with the Services/Table in it. If a component cannot be moved, it MUST be abandoned.

--- a/Services/Table/classes/class.TableGUIRequest.php
+++ b/Services/Table/classes/class.TableGUIRequest.php
@@ -20,6 +20,10 @@ namespace ILIAS\Table;
 
 use ILIAS\Repository;
 
+/**
+ *
+ * @deprecated 10
+ */
 class TableGUIRequest
 {
     use Repository\BaseGUIRequest;

--- a/Services/Table/classes/class.TableGUIRequest.php
+++ b/Services/Table/classes/class.TableGUIRequest.php
@@ -22,7 +22,7 @@ use ILIAS\Repository;
 
 /**
  *
- * @deprecated 10
+ * @deprecated 11
  */
 class TableGUIRequest
 {

--- a/Services/Table/classes/class.ilTable2GUI.php
+++ b/Services/Table/classes/class.ilTable2GUI.php
@@ -19,6 +19,8 @@
 /**
  * @author	Alex Killing <alex.killing@gmx.de>
  * @author	Sascha Hofmann <shofmann@databay.de>
+ *
+ * @deprecated 10
  */
 class ilTable2GUI extends ilTableGUI
 {

--- a/Services/Table/classes/class.ilTable2GUI.php
+++ b/Services/Table/classes/class.ilTable2GUI.php
@@ -20,7 +20,7 @@
  * @author	Alex Killing <alex.killing@gmx.de>
  * @author	Sascha Hofmann <shofmann@databay.de>
  *
- * @deprecated 10
+ * @deprecated 11
  */
 class ilTable2GUI extends ilTableGUI
 {

--- a/Services/Table/classes/class.ilTableGUI.php
+++ b/Services/Table/classes/class.ilTableGUI.php
@@ -20,7 +20,7 @@
  * HTML table component
  * @author	Sascha Hofmann <shofmann@databay.de>
  *
- * @deprecated 10
+ * @deprecated 11
  */
 class ilTableGUI
 {

--- a/Services/Table/classes/class.ilTableGUI.php
+++ b/Services/Table/classes/class.ilTableGUI.php
@@ -19,6 +19,8 @@
 /**
  * HTML table component
  * @author	Sascha Hofmann <shofmann@databay.de>
+ *
+ * @deprecated 10
  */
 class ilTableGUI
 {

--- a/Services/Table/classes/class.ilTableTemplatesStorage.php
+++ b/Services/Table/classes/class.ilTableTemplatesStorage.php
@@ -20,7 +20,7 @@
  * Saves (mostly asynchronously) user properties of tables (e.g. filter on/off)
  * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>
  *
- * @deprecated 10
+ * @deprecated 11
  *
  */
 class ilTableTemplatesStorage

--- a/Services/Table/classes/class.ilTableTemplatesStorage.php
+++ b/Services/Table/classes/class.ilTableTemplatesStorage.php
@@ -19,6 +19,9 @@
 /**
  * Saves (mostly asynchronously) user properties of tables (e.g. filter on/off)
  * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>
+ *
+ * @deprecated 10
+ *
  */
 class ilTableTemplatesStorage
 {

--- a/Services/Table/interfaces/interface.ilTableFilterItem.php
+++ b/Services/Table/interfaces/interface.ilTableFilterItem.php
@@ -22,7 +22,7 @@
  *
  * @author Alexander Killing <killing@leifos.de>
  *
- * @deprecated 10
+ * @deprecated 11
  *
  */
 interface ilTableFilterItem

--- a/Services/Table/interfaces/interface.ilTableFilterItem.php
+++ b/Services/Table/interfaces/interface.ilTableFilterItem.php
@@ -21,6 +21,9 @@
  * in table filters
  *
  * @author Alexander Killing <killing@leifos.de>
+ *
+ * @deprecated 10
+ *
  */
 interface ilTableFilterItem
 {


### PR DESCRIPTION
The Technical Board proposes to advance the move to the UI-Framework. This PR defines a way to get rid of Services/Table with ILIAS 10, thus simplifying our code base and the work needed to keep a consistent appearance for our end users.