### PR TITLE
Fix for: https://mantis.ilias.de/view.php?id=31016

### DIFF
--- a/Modules/TestQuestionPool/classes/class.ilImagemapPreview.php
+++ b/Modules/TestQuestionPool/classes/class.ilImagemapPreview.php
@@ -194,8 +194,10 @@ class ilImagemapPreview
 
         $source = ilUtil::escapeShellCmd($this->imagemap_filename);
         $target = ilUtil::escapeShellCmd($this->preview_filename);
+        $convert_cmd = ilUtil::escapeShellCmd($convert_cmd);
+        $convert_cmd = preg_replace('/\\\\(#([a-fA-F0-9]{3}|[a-fA-F0-9]{6}|[a-fA-F0-9]{8}))/', '${1}', $convert_cmd);
         $convert_cmd = $source . "[0] " . $convert_cmd . " " . $target;
-        ilUtil::execConvert($convert_cmd);
+        ilUtil::execQuoted(PATH_TO_CONVERT, $convert_cmd);
     }
 
     public function getPreviewFilename($imagePath, $baseFileName)


### PR DESCRIPTION
This PR changes the way images are converted, but tries to keep as much of the sanitation provided by escapeshellcmd as possible to avoid any potential vulnerabilities. As discussed in the meeting of the Taskforce on Bugfixing it moves most of the logic to execute convert to the Test.

I decided to go with this summary approach instead of calling escapeshellarg() on every arg. Technically this would probably be cleaner, but it would mean a gazillion calls to escapeshellarg().

I would personally also like to rename the variable "convert_cmd" to "convert_args" as I think this would make its purpose clearer as there is no command to be found nowhere in the assigned string. I can expand this PR accordingly, if you want.

I can also provide a PR for Trunk, if you want, as Fabian has just cleaned up the mess called ilUtil and thus this can't simply be cherry-picked.