### PR TITLE
Proposed fix for #30357

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -1475,7 +1475,9 @@ assessment#:#tst_finish_notification_no#:#Keine Benachrichtigung
 assessment#:#tst_finished#:#Beendet
 assessment#:#unfinished_passes#:#Unbeendeter Testdurchlauf
 assessment#:#finish_pass_for_user_confirmation#:#Wollen Sie den Test Durchlauf für den Teilnehmer "%s" wirklich beenden?
+assessment#:#finish_pass_for_user_in_processing_time#:#WARNUNG: die Bearbeitungszeit für diesen Benutzer ist noch nicht vorbei! Sie sollten den Testlauf nur bei zwingendem Grund (z.B. Ausschluss vom Test) beenden.
 assessment#:#finish_pass_for_all_users#:#Wollen Sie wirklich die Test Durchläufe für alle Benutzer beenden?
+assessment#:#finish_pass_for_all_users_in_processing_time#:#Sie können die Durchläufe aller Benutzer nicht gemeinsam beenden, da für mindestens einen Benutzer die Bearbeitungszeit noch nicht vorbei ist.
 assessment#:#finish_all_user_passes#:#Alle Testdurchläufe beenden
 assessment#:#finish_unfinished_passes#:#Beendet noch offene Testdurchläufe
 assessment#:#finish_unfinished_passes_desc#:#Noch nicht beendete Testdurchläufe werden automatisch beendet – vorausgesetzt, es wurde für diese Tests ein Endzeitpunkt festgelegt oder Teilnehmende haben die maximale Bearbeitungsdauer überschritten.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -1400,7 +1400,9 @@ assessment#:#tst_finish_notification_desc#:#Sends an e-mail to the test owner fo
 assessment#:#tst_finished#:#Finished
 assessment#:#unfinished_passes#:#Unfinished Passes
 assessment#:#finish_pass_for_user_confirmation#:#Are you sure you want to finish this test pass for the participant "%s"?
+assessment#:#finish_pass_for_user_in_processing_time#:#WARNING: the processing time for this user is not over yet! You should only end the test run if there is a compelling reason (e.g. exclusion from the test).
 assessment#:#finish_pass_for_all_users#:#Are you sure you want to finish the test passes for all Users?
+assessment#:#finish_pass_for_all_users_in_processing_time#:#You cannot finish the passes of all users together, because for at least one user the processing time is not over yet.
 assessment#:#finish_all_user_passes#:#Finish all Test Passes
 assessment#:#finish_unfinished_passes#:#Finish Open Passes
 assessment#:#finish_unfinished_passes_desc#:#Passes which have a finishing time or a duration limit configured will be closed by this cron job.


### PR DESCRIPTION
Implementation of the JF decision:
Jour Fixe, 19 APR 2021: We follow the maintainer's suggestion and accept the following change for all maintained versions:
When clicking on the button "Finish all Test passes", ILIAS checks if the options "Finishing Time" and/or "Limit Duration of Test" are activated in the test. If yes and the finishing time has not yet been reached or the processing time has not yet expired, the test runs will not be finished and an error message will be displayed.
However, it should still be possible to terminate individual test runs from participants, even if the above conditions apply (e.g. in the case of cheating). Nevertheless, the warning message should clearly warn that a single test run will be terminated although the end time or the end of the processing time has not yet been reached. 