### PR TITLE
UI Components, fix of responsive Logo Issue, see: #32016

### DIFF
--- a/src/GlobalScreen/Scope/Layout/Builder/StandardPageBuilder.php
+++ b/src/GlobalScreen/Scope/Layout/Builder/StandardPageBuilder.php
@@ -37,6 +37,7 @@ class StandardPageBuilder implements PageBuilder
     public function build(PagePartProvider $parts) : Page
     {
         $header_image = $parts->getLogo();
+        $responsive_header_image = $parts->getResponsiveLogo();
         $main_bar = $parts->getMainBar();
         $meta_bar = $parts->getMetaBar();
         $bread_crumbs = $parts->getBreadCrumbs();
@@ -58,6 +59,7 @@ class StandardPageBuilder implements PageBuilder
         );
 
         return $standard->withSystemInfos($parts->getSystemInfos())
+                        ->withResponsiveLogo($responsive_header_image)
                         ->withTextDirection($this->meta->getTextDirection() ?? Standard::LTR);
     }
 }

--- a/src/GlobalScreen/Scope/Layout/Provider/PagePart/DecoratedPagePartProvider.php
+++ b/src/GlobalScreen/Scope/Layout/Provider/PagePart/DecoratedPagePartProvider.php
@@ -116,6 +116,14 @@ class DecoratedPagePartProvider implements PagePartProvider
     /**
      * @inheritDoc
      */
+    public function getResponsiveLogo() : ?Image
+    {
+        return $this->getDecoratedOrOriginal(Image::class, $this->original->getResponsiveLogo());
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function getSystemInfos() : array
     {
         return $this->original->getSystemInfos();

--- a/src/GlobalScreen/Scope/Layout/Provider/PagePart/PagePartProvider.php
+++ b/src/GlobalScreen/Scope/Layout/Provider/PagePart/PagePartProvider.php
@@ -43,6 +43,11 @@ interface PagePartProvider
     public function getLogo() : ?Image;
 
     /**
+     * @return Image|null
+     */
+    public function getResponsiveLogo() : ?Image;
+
+    /**
      * @return SystemInfo[]
      */
     public function getSystemInfos() : array;

--- a/src/GlobalScreen/Scope/Layout/Provider/PagePart/StandardPagePartProvider.php
+++ b/src/GlobalScreen/Scope/Layout/Provider/PagePart/StandardPagePartProvider.php
@@ -168,15 +168,33 @@ class StandardPagePartProvider implements PagePartProvider
     public function getLogo() : ?Image
     {
         $std_logo = ilUtil::getImagePath("HeaderIcon.svg");
+
+        return $this->ui->factory()->image()
+                        ->standard($std_logo, "ILIAS")
+                        ->withAction($this->getStartingPointAsUrl());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getResponsiveLogo() : ?Image
+    {
+        $responsive_logo = ilUtil::getImagePath("HeaderIconResponsive.svg");
+
+        return $this->ui->factory()->image()
+                        ->standard($responsive_logo, "ILIAS")
+                        ->withAction($this->getStartingPointAsUrl());
+    }
+
+    protected function getStartingPointAsUrl() : string
+    {
         $std_logo_link = ilUserUtil::getStartingPointAsUrl();
         if (!$std_logo_link) {
             $std_logo_link = "./goto.php?target=root_1";
         }
-
-        return $this->ui->factory()->image()
-                        ->standard($std_logo, "ILIAS")
-                        ->withAction($std_logo_link);
+        return $std_logo_link;
     }
+
 
     /**
      * @inheritDoc

--- a/src/UI/Component/Layout/Page/Standard.php
+++ b/src/UI/Component/Layout/Page/Standard.php
@@ -43,6 +43,13 @@ interface Standard extends Page, JavaScriptBindable
     public function withLogo(Image $logo) : Standard;
 
     /**
+     * @param Image $logo
+     *
+     * @return Standard
+     */
+    public function withResponsiveLogo(Image $logo) : Standard;
+
+    /**
      * @return bool
      */
     public function hasMetabar() : bool;
@@ -56,6 +63,11 @@ interface Standard extends Page, JavaScriptBindable
      * @return bool
      */
     public function hasLogo() : bool;
+
+    /**
+     * @return bool
+     */
+    public function hasResponsiveLogo() : bool;
 
     /**
      * @return Metabar|null
@@ -76,6 +88,11 @@ interface Standard extends Page, JavaScriptBindable
      * @return Image|null
      */
     public function getLogo();
+
+    /**
+     * @return Image|null
+     */
+    public function getResponsiveLogo();
 
     /**
      * @return Footer|null

--- a/src/UI/Implementation/Component/Layout/Page/Renderer.php
+++ b/src/UI/Implementation/Component/Layout/Page/Renderer.php
@@ -52,10 +52,12 @@ class Renderer extends AbstractComponentRenderer
             $tpl->setVariable('HEADER_BREADCRUMBS', $default_renderer->render($dropdown));
         }
         if ($component->hasLogo()) {
-            $logo = $component->getLogo();
-            if ($logo) {
-                $tpl->setVariable("LOGO", $default_renderer->render($logo));
-            }
+            $tpl->setVariable('LOGO', $default_renderer->render($component->getLogo()));
+        }
+        if ($component->hasResponsiveLogo()) {
+            $tpl->setVariable('RESPONSIVE_LOGO', $default_renderer->render($component->getResponsiveLogo()));
+        } elseif ($component->hasLogo()) {
+            $tpl->setVariable('RESPONSIVE_LOGO', $default_renderer->render($component->getLogo()));
         }
 
         $slates_cookie = $_COOKIE[self::COOKIE_NAME_SLATES_ENGAGED] ?? '';

--- a/src/UI/Implementation/Component/Layout/Page/Standard.php
+++ b/src/UI/Implementation/Component/Layout/Page/Standard.php
@@ -47,6 +47,10 @@ class Standard implements Page\Standard
      */
     private $logo;
     /**
+     * @var Image|null
+     */
+    private $responsive_logo;
+    /**
      * @var    footer|null
      */
     private $footer;
@@ -146,6 +150,16 @@ class Standard implements Page\Standard
     /**
      * @inheritDoc
      */
+    public function withResponsiveLogo(Image $logo) : Page\Standard
+    {
+        $clone = clone $this;
+        $clone->responsive_logo = $logo;
+        return $clone;
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function withFooter(Footer $footer) : Page\Standard
     {
         $clone = clone $this;
@@ -175,6 +189,14 @@ class Standard implements Page\Standard
     public function hasLogo() : bool
     {
         return ($this->logo instanceof Image);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hasResponsiveLogo() : bool
+    {
+        return ($this->responsive_logo instanceof Image);
     }
 
     /**
@@ -223,6 +245,14 @@ class Standard implements Page\Standard
     public function getLogo()
     {
         return $this->logo;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getResponsiveLogo()
+    {
+        return $this->responsive_logo;
     }
 
     /**

--- a/src/UI/templates/default/Layout/tpl.standardpage.html
+++ b/src/UI/templates/default/Layout/tpl.standardpage.html
@@ -34,7 +34,8 @@
 		<header>
 			<div class="header-inner">
 				<div class="il-logo">
-					{LOGO}
+					<span class="hidden-xs">{LOGO}</span>
+					<span class="visible-xs">{RESPONSIVE_LOGO}</span>
 					<div class="il-pagetitle">
 						{TITLE}
 					</div>

--- a/tests/UI/Component/Layout/Page/StandardPageTest.php
+++ b/tests/UI/Component/Layout/Page/StandardPageTest.php
@@ -59,6 +59,8 @@ class StandardPageTest extends ILIAS_UI_TestBase
         $this->crumbs->method("getCanonicalName")->willReturn("Breadcrumbs Stub");
         $this->logo = $this->createMock(Image::class);
         $this->logo->method("getCanonicalName")->willReturn("Logo Stub");
+        $this->responsive_logo = $this->createMock(Image::class);
+        $this->responsive_logo->method("getCanonicalName")->willReturn("Responsive Logo Stub");
         $this->contents = array(new Legacy('some content', $sig_gen));
         $this->title = 'pagetitle';
 
@@ -71,7 +73,7 @@ class StandardPageTest extends ILIAS_UI_TestBase
             $this->logo,
             null,
             $this->title
-        );
+        )->withResponsiveLogo($this->responsive_logo);
     }
 
     public function testConstruction()
@@ -120,6 +122,24 @@ class StandardPageTest extends ILIAS_UI_TestBase
             $this->logo,
             $this->stdpage->getLogo()
         );
+    }
+
+    public function testHasLogo()
+    {
+        $this->assertTrue($this->stdpage->hasLogo());
+    }
+
+    public function testGetResponsiveLogo()
+    {
+        $this->assertEquals(
+            $this->responsive_logo,
+            $this->stdpage->getResponsiveLogo()
+        );
+    }
+
+    public function testHasResponsiveLogo()
+    {
+        $this->assertTrue($this->stdpage->hasResponsiveLogo());
     }
 
     public function testWithWrongContents()
@@ -202,7 +222,12 @@ class StandardPageTest extends ILIAS_UI_TestBase
       <div class="il-layout-page">
          <header>
             <div class="header-inner">
-               <div class="il-logo">Logo Stub<div class="il-pagetitle">Title</div></div>MetaBar Stub</div>
+              <div class="il-logo">
+                <span class="hidden-xs">Logo Stub</span>
+                <span class="visible-xs">Responsive Logo Stub</span>
+                <div class="il-pagetitle">Title</div>
+              </div>MetaBar Stub
+            </div>
          </header>
          <div class="breadcrumbs"></div>
          <div class="il-system-infos"></div>
@@ -239,7 +264,12 @@ class StandardPageTest extends ILIAS_UI_TestBase
       <div class="il-layout-page">
          <header>
             <div class="header-inner">
-               <div class="il-logo">Logo Stub<div class="il-pagetitle">pagetitle</div></div>MetaBar Stub</div>
+              <div class="il-logo">
+                <span class="hidden-xs">Logo Stub</span>
+                <span class="visible-xs">Responsive Logo Stub</span>
+                <div class="il-pagetitle">pagetitle</div>
+              </div>MetaBar Stub
+            </div>
          </header>
          <div class="breadcrumbs"></div>
          <div class="il-system-infos"></div>


### PR DESCRIPTION
Currently, the responsive Header Logo is not displayed on small screen sizes, the standard one is. See: https://mantis.ilias.de/view.php?id=32016

Fix intended for ILIAS 7 and Trunk, JF approval needed due to interface change on Standard Page Layout.