### PR TITLE
Fix logic if no clientId parameter is available

### DIFF
--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -450,9 +450,11 @@ class ilInitialisation
             if ($can_set_cookie) {
                 ilUtil::setCookie('ilClientId', $client_id_to_use);
             }
-        } elseif (!isset($_COOKIE['ilClientId'])) {
+        } else {
             $client_id_to_use = $default_client_id;
-            ilUtil::setCookie('ilClientId', $client_id_to_use);
+            if (!isset($_COOKIE['ilClientId'])) {
+                ilUtil::setCookie('ilClientId', $client_id_to_use);
+            }
         }
         
         define('CLIENT_ID', $df->clientId($client_id_to_use)->toString());


### PR DESCRIPTION
In https://github.com/ILIAS-eLearning/ILIAS/commit/a8203bb3cb2f2488c4a2cdabc324321755a4c8d7 the behaviour when no clientId is available in the request changed. It ends up being an empty string instead of the default client id. This PR fixes this behaviour.