### PR TITLE
Fix test question page command forwarder (release_5-4)

### DIFF
--- a/Modules/Test/classes/class.ilAssQuestionPageCommandForwarder.php
+++ b/Modules/Test/classes/class.ilAssQuestionPageCommandForwarder.php
@@ -71,7 +71,7 @@ class ilAssQuestionPageCommandForwarder
         $DIC->ctrl()->saveParameter($this, "q_id");
         $DIC->language()->loadLanguageModule("content");
         $DIC->ctrl()->setReturnByClass("ilAssQuestionPageGUI", "view");
-        $DIC->ctrl()->setReturn($this, "questions");
+        $DIC->ctrl()->setReturnByClass("ilObjTestGUI", "questions");
         $page_gui = new ilAssQuestionPageGUI($_GET["q_id"]);
         $page_gui->setEditPreview(true);
         if (strlen($DIC->ctrl()->getCmd()) == 0) {


### PR DESCRIPTION
A dedicated command forwarder class in the test module is currently broken in all branches. This pull request fixes it.

See the commit message for details.

| Mantis issue                | originally reported for version | currently for version | reproduced in 5.4 | reproduced in 6 | reproduced in 7 | fixed for 5.4 | fixed for 6 | fixed for 7 |
|-----------------------------|---------------------------------|-----------------------|-------------------|-----------------|-----------------|---------------|-------------|-------------|
| [Mantis#28489][Mantis28489] | 5.4.12                          | 7.5                   | ✓ yes             | ✓ yes           | ❌ no<a name="footnote1-back"><a href="#footnote1">¹</a></a> | ✓ yes         | ✓ yes       | N/A         |
| [Mantis#30982][Mantis30982] | 7.2                             | 7.2                   | N/A               | N/A             | ✓ yes           | N/A           | N/A         | ✓ yes       |
| [Mantis#31297][Mantis31297] | 6.10 (also in 5.4.21)           | 6.10 (also in 5.4.21) | ✓ yes             | ✓ yes           | ✓ yes           | ✓ yes         | ✓ yes       | ✓ yes       |

Can not test with ILIAS 8 (branch `trunk`) for the time being, because test creation fails, and [test8] is down for maintenance.

N/A=not applicable (bug not present and/or functionality not present in that version)

<a name="footnote1"><a href="#footnote1-back">¹</a></a> see [Mantis#30982][Mantis30982] for [Mantis#28489~76854][Mantis28489c76854]

[Mantis#30411: HTML-Code in der der Antwortstatistik][Mantis30411] (see [Mantis#30411~74982][Mantis30411c74982]) is unrelated.

This is the pull request for the (obsolete) `release_5-4` branch. Please see the other pull requests for the other branches. If we do not merge pull requests for 5.4 anymore, just close it. Thanks.

[Mantis28489]: https://mantis.ilias.de/view.php?id=28489 "28489: Broken Commandforwarder in Test"
[Mantis30982]: https://mantis.ilias.de/view.php?id=30982 "30982: Nachkorrektur: Lösung editieren nicht möglich / Corrections: Edit Solution not possible"
[Mantis31297]: https://mantis.ilias.de/view.php?id=31297 "31297: Test question: downloading a file in print view leads to error"
[Mantis30411]: https://mantis.ilias.de/view.php?id=30411 "30411: HTML-Code in der der Antwortstatistik"
[Mantis30411c74982]: https://mantis.ilias.de/view.php?id=30411#c74982 "Comment 74982 from ta-bugs in 30411: HTML-Code in der der Antwortstatistik"
[Mantis28489c76854]: https://mantis.ilias.de/view.php?id=28489#c76854 "Comment 28489 from fsest in 28489: Broken Commandforwarder in Test"
[test8]: https://test8.ilias.de/