### PR TITLE
Feature/8/lom keywords in header

### DIFF
--- a/Services/MetaData/classes/GlobalScreen/class.ilMDKeywordExposer.php
+++ b/Services/MetaData/classes/GlobalScreen/class.ilMDKeywordExposer.php
@@ -1,0 +1,84 @@
+<?php
+
+use ILIAS\GlobalScreen\Scope\Layout\Provider\AbstractModificationProvider;
+use ILIAS\GlobalScreen\ScreenContext\Stack\ContextCollection;
+use ILIAS\GlobalScreen\ScreenContext\Stack\CalledContexts;
+use ILIAS\GlobalScreen\Scope\Layout\Factory\ContentModification;
+
+/**
+ * Class ilMDKeywordExposer
+ *
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class ilMDKeywordExposer extends AbstractModificationProvider
+{
+    public function isInterestedInContexts() : ContextCollection
+    {
+        return $this->context_collection->repository();
+    }
+    
+    public function getContentModification(CalledContexts $screen_context_stack) : ?ContentModification
+    {
+        if ($screen_context_stack->current()->hasReferenceId()) {
+            $object_id = $screen_context_stack->current()->getReferenceId()->toObjectId()->toInt();
+            
+            if ($general = $this->getGeneral($object_id)) {
+                // Keywords
+                $keywords = [];
+                foreach ($general->getKeywordIds() as $keyword_id) {
+                    $keyword = $general->getKeyword($keyword_id);
+                    $keywords[] = $keyword->getKeyword();
+                }
+    
+                $delimiter = ilMDSettings::_getInstance()->getDelimiter() ?? ",";
+                
+                if (count($keywords) > 0) {
+                    $this->globalScreen()->layout()->meta()->addMetaDatum('keywords', implode($delimiter, $keywords));
+                }
+                // Languages
+                $languages = [];
+                foreach ($general->getLanguageIds() as $language_id) {
+                    $language = $general->getLanguage($language_id);
+                    $languages[] = $language->getLanguageCode();
+                }
+                if (count($languages) > 0) {
+                    $this->globalScreen()->layout()->meta()->addMetaDatum('languages', implode($delimiter, $languages));
+                }
+            }
+    
+            if ($rights = $this->getRights($object_id)) {
+                // Copyright
+                $copy_right_id = ilMDCopyrightSelectionEntry::_extractEntryId($rights->getDescription());
+                if ($copy_right_id > 0) {
+                    $entry = new ilMDCopyrightSelectionEntry($copy_right_id);
+                    $this->globalScreen()->layout()->meta()->addMetaDatum('copyright', $entry->getTitle());
+                }
+            }
+        }
+        
+        return null;
+    }
+    
+    private function getGeneral(int $object_id) : ?ilMDGeneral
+    {
+        if ($id = ilMDGeneral::_getId($object_id, $object_id)) {
+            $gen = new ilMDGeneral();
+            $gen->setMetaId($id);
+            
+            return $gen;
+        }
+        return null;
+    }
+    
+    private function getRights(int $object_id) : ?ilMDRights
+    {
+        if ($id = ilMDRights::_getId($object_id, $object_id)) {
+            $rig = new ilMDRights();
+            $rig->setMetaId($id);
+            
+            return $rig;
+        }
+        return null;
+    }
+    
+}

--- a/src/GlobalScreen/Scope/Layout/Builder/StandardPageBuilder.php
+++ b/src/GlobalScreen/Scope/Layout/Builder/StandardPageBuilder.php
@@ -62,6 +62,10 @@ class StandardPageBuilder implements PageBuilder
             $view_title
         );
         
+        foreach ($this->meta->getMetaData()->getItems() as $meta_datum) {
+            $standard = $standard->withAdditionalMetaDatum($meta_datum->getKey(), $meta_datum->getValue());
+        }
+        
         return $standard->withSystemInfos($parts->getSystemInfos())
                         ->withTextDirection($this->meta->getTextDirection() ?? Standard::LTR);
     }

--- a/src/GlobalScreen/Scope/Layout/MetaContent/MetaContent.php
+++ b/src/GlobalScreen/Scope/Layout/MetaContent/MetaContent.php
@@ -8,7 +8,9 @@ use ILIAS\GlobalScreen\Scope\Layout\MetaContent\Media\Js;
 use ILIAS\GlobalScreen\Scope\Layout\MetaContent\Media\JsCollection;
 use ILIAS\GlobalScreen\Scope\Layout\MetaContent\Media\OnLoadCode;
 use ILIAS\GlobalScreen\Scope\Layout\MetaContent\Media\OnLoadCodeCollection;
-use ILIAS\UI\Implementation\Component\Layout\Page\Standard;
+use ILIAS\UI\Component\Layout\Page\Standard;
+use ILIAS\GlobalScreen\Scope\Layout\MetaContent\MetaData\MetaDataCollection;
+use ILIAS\GlobalScreen\Scope\Layout\MetaContent\MetaData\MetaDatum;
 
 /******************************************************************************
  * This file is part of ILIAS, a powerful learning management system.
@@ -22,23 +24,22 @@ use ILIAS\UI\Implementation\Component\Layout\Page\Standard;
 
 /**
  * Class MetaContent
+ *
  * @package ILIAS\GlobalScreen\Scope\LayoutDefinition\MetaContent
  */
 class MetaContent
 {
     const MEDIA_SCREEN = "screen";
-
+    
     private InlineCssCollection $inline_css;
     private OnLoadCodeCollection $on_load_code;
     private JsCollection $js;
     private CssCollection $css;
+    protected MetaDataCollection $meta_data;
     private string $base_url = "";
     private string $text_direction;
     protected string $resource_version;
-
-    /**
-     * MetaContent constructor.
-     */
+    
     public function __construct(string $resource_version)
     {
         $this->resource_version = $resource_version;
@@ -46,8 +47,9 @@ class MetaContent
         $this->js = new JsCollection($resource_version);
         $this->on_load_code = new OnLoadCodeCollection($resource_version);
         $this->inline_css = new InlineCssCollection($resource_version);
+        $this->meta_data = new MetaDataCollection();
     }
-
+    
     /**
      * Reset
      */
@@ -57,101 +59,74 @@ class MetaContent
         $this->js = new JsCollection($this->resource_version);
         $this->on_load_code = new OnLoadCodeCollection($this->resource_version);
         $this->inline_css = new InlineCssCollection($this->resource_version);
+        $this->meta_data = new MetaDataCollection();
     }
-
-    /**
-     * @param string $path
-     * @param string $media
-     */
+    
     public function addCss(string $path, string $media = self::MEDIA_SCREEN) : void
     {
         $this->css->addItem(new Css($path, $this->resource_version, $media));
     }
-
-    /**
-     * @param string $path
-     * @param bool   $add_version_number
-     * @param int    $batch
-     */
+    
     public function addJs(string $path, bool $add_version_number = false, int $batch = 2) : void
     {
         $this->js->addItem(new Js($path, $this->resource_version, $add_version_number, $batch));
     }
-
-    /**
-     * @param string $content
-     * @param string $media
-     */
+    
     public function addInlineCss(string $content, string $media = self::MEDIA_SCREEN) : void
     {
         $this->inline_css->addItem(new InlineCss($content, $this->resource_version, $media));
     }
-
-    /**
-     * @param string $content
-     * @param int    $batch
-     */
+    
     public function addOnloadCode(string $content, int $batch = 2) : void
     {
         $this->on_load_code->addItem(new OnLoadCode($content, $this->resource_version, $batch));
     }
-
-    /**
-     * @return InlineCssCollection
-     */
+    
+    public function addMetaDatum(string $key, string $value) : void
+    {
+        $this->meta_data->add(new MetaDatum($key, $value));
+    }
+    
     public function getInlineCss() : InlineCssCollection
     {
         return $this->inline_css;
     }
-
-    /**
-     * @return OnLoadCodeCollection
-     */
+    
     public function getOnLoadCode() : OnLoadCodeCollection
     {
         return $this->on_load_code;
     }
-
-    /**
-     * @return JsCollection
-     */
+    
     public function getJs() : JsCollection
     {
         return $this->js;
     }
-
-    /**
-     * @return CssCollection
-     */
+    
     public function getCss() : CssCollection
     {
         return $this->css;
     }
-
-    /**
-     * @param string $base_url
-     */
+    
+    public function getMetaData() : MetaDataCollection
+    {
+        return $this->meta_data;
+    }
+    
     public function setBaseURL(string $base_url) : void
     {
         $this->base_url = $base_url;
     }
-
-    /**
-     * @return string
-     */
+    
     public function getBaseURL() : string
     {
         return $this->base_url;
     }
-
+    
     public function getTextDirection() : string
     {
         return $this->text_direction;
     }
-
-    /**
-     * @param string $text_direction
-     */
+    
     public function setTextDirection(string $text_direction) : void
     {
         if (!in_array($text_direction, [Standard::LTR, Standard::RTL], true)) {

--- a/src/GlobalScreen/Scope/Layout/MetaContent/MetaData/MetaDataCollection.php
+++ b/src/GlobalScreen/Scope/Layout/MetaContent/MetaData/MetaDataCollection.php
@@ -1,0 +1,49 @@
+<?php namespace ILIAS\GlobalScreen\Scope\Layout\MetaContent\MetaData;
+
+use ILIAS\GlobalScreen\Scope\Layout\MetaContent\Media\Js;
+use ILIAS\GlobalScreen\Scope\Layout\MetaContent\Media\Css;
+use ILIAS\GlobalScreen\Scope\Layout\MetaContent\Media\InlineCss;
+use ILIAS\GlobalScreen\Scope\Layout\MetaContent\Media\OnLoadCode;
+
+/**
+ * Class MetaDataCollection
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+class MetaDataCollection
+{
+    /**
+     * @var MetaDatum[]
+     */
+    protected array $items = [];
+    
+    public function add(MetaDatum $meta_datum) : void
+    {
+        $this->items[] = $meta_datum;
+    }
+    
+    public function clear()
+    {
+        $this->items = [];
+    }
+    
+    /**
+     * @return \Iterator|MetaDatum[]
+     */
+    public function getItems() : \Iterator
+    {
+        yield from $this->items;
+    }
+    
+    /**
+     * @return array
+     */
+    public function getItemsAsKeyValuePairs() : array
+    {
+        $key_value_pairs = [];
+        array_walk($this->items, function (MetaDatum $d) use (&$key_value_pairs) {
+            $key_value_pairs[$d->getKey()] = $d->getValue();
+        });
+        return $key_value_pairs;
+    }
+}

--- a/src/GlobalScreen/Scope/Layout/MetaContent/MetaData/MetaDatum.php
+++ b/src/GlobalScreen/Scope/Layout/MetaContent/MetaData/MetaDatum.php
@@ -1,0 +1,29 @@
+<?php namespace ILIAS\GlobalScreen\Scope\Layout\MetaContent\MetaData;
+
+/**
+ * Class MetaDataCollection
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+class MetaDatum
+{
+    protected string $key;
+    protected string $value;
+    
+    public function __construct(string $key, string $value)
+    {
+        $this->key = $key;
+        $this->value = $value;
+    }
+    
+    public function getKey() : string
+    {
+        return $this->key;
+    }
+    
+    public function getValue() : string
+    {
+        return $this->value;
+    }
+    
+}

--- a/src/GlobalScreen/Scope/Layout/README.md
+++ b/src/GlobalScreen/Scope/Layout/README.md
@@ -1,5 +1,7 @@
 Scope Layout
 ============
+
+## Modification
 The GlobalScreen service takes care of the mediation between the command classes and UI components and is responsible for assembling all necessary elements into a complete `Page` and submitting it to rendering.
 
 > Currently (ILIAS 6.0), the services and modules deliver their content via an `ilGlobalPageTemplate`, an implementation of the `ilGlobalTemplateInterface`. This is done for compatibility reasons. Internally, this instance delegates all relevant elements to the scope layout of the GlobalScreen service.
@@ -24,7 +26,7 @@ Currently the following areas can be addressed:
 - Icon
 - Content
 
-## Register modification
+### Register modification
 
 Like all other scopes, this scope works in the provider/collector procedure. In order to be able to make a change to the page, you implement your own `ModificationProvider`. These providers are `ScreenContextAwareProviders`, further information can be found at [src/GlobalScreen/ScreenContext/README.md](../../ScreenContext/README.md)
 
@@ -76,9 +78,41 @@ The example returns - if in the `ScreenContext` 'repository', if a Ref-ID is pre
 
 Since multiple `ModificationProviders` could modify the same area of the page at the same time, a priority is set for each modification (in this case `->withHighPriority()`). Same priorities lead to an exception and it must be decided in JourFixe which of the two modifications gets the higher priority.
 
-# Attention
+## Attention
 
 The possibility of influencing the components of the "page" holds dangers:
 
 - You can never be sure that you will not make any changes before or after the change.
 - Do not use this option to bring menu items or `Tools` into the `MainBar`. Use the methods provided for this purpose as `Providers` in the respective scopes.
+
+# MetaContent (such as CSS, JS und MetaData)
+The GlobalScreen Scope 'Layout' is also used to collect and prepare other contents for rendering, so that they can be taken into account in the final rendering. The MetaContents are not added via `Provider`, but currently via the call via
+
+```
+$DIC->globalScreen()->layout()->meta()->addXY(...);
+```
+
+Currently there are the following areas:
+- addCss
+- addJs
+- addInlineCss
+- addOnloadCode
+- addMetaDate
+
+## Examples
+**CSS**
+```php
+$DIC->globalScreen()->layout()->meta()->addCss('./path/to.css');
+$DIC->globalScreen()->layout()->meta()->addInlineCss('.my-class {color: red; };');
+```
+
+**JS**
+```php
+$DIC->globalScreen()->layout()->meta()->addJs('./path/to.js');
+$DIC->globalScreen()->layout()->meta()->addOnloadCode('alert();');
+```
+
+**MetaData**
+```php
+$DIC->globalScreen()->layout()->meta()->addMetaDatum('keywords', 'Learning,Management');
+```

--- a/src/UI/Component/Layout/Page/Standard.php
+++ b/src/UI/Component/Layout/Page/Standard.php
@@ -61,6 +61,10 @@ interface Standard extends Page, JavaScriptBindable
     public function getModeInfo() : ?ModeInfo;
 
     public function hasModeInfo() : bool;
+    
+    public function withAdditionalMetaDatum(string $key, string $value) : Standard;
+    
+    public function getMetaData() : array;
 
     /**
      * @param SystemInfo[] $system_infos

--- a/src/UI/Implementation/Component/Layout/Page/Renderer.php
+++ b/src/UI/Implementation/Component/Layout/Page/Renderer.php
@@ -84,6 +84,13 @@ class Renderer extends AbstractComponentRenderer
         if ($component->getWithHeaders()) {
             $tpl = $this->setHeaderVars($tpl, $component->getIsUIDemo());
         }
+    
+        foreach ($component->getMetaData() as $meta_key => $meta_value) {
+            $tpl->setCurrentBlock('meta_datum');
+            $tpl->setVariable('META_KEY', $meta_key);
+            $tpl->setVariable('META_VALUE', $meta_value);
+            $tpl->parseCurrentBlock();
+        }
 
         return $tpl->get();
     }

--- a/src/UI/Implementation/Component/Layout/Page/Standard.php
+++ b/src/UI/Implementation/Component/Layout/Page/Standard.php
@@ -38,7 +38,8 @@ class Standard implements Page\Standard
     private bool $ui_demo = false;
     protected array $system_infos = [];
     protected string $text_direction = "ltr";
-
+    protected array $meta_data = [];
+    
     public function __construct(
         array $content,
         ?MetaBar $metabar = null,
@@ -267,7 +268,19 @@ class Standard implements Page\Standard
         $clone->footer = null;
         return $clone;
     }
-
+    
+    public function withAdditionalMetaDatum(string $key, string $value) : Page\Standard
+    {
+        $clone = clone $this;
+        $clone->meta_data[$key] = $value;
+        return $clone;
+    }
+    
+    public function getMetaData() : array
+    {
+        return $this->meta_data;
+    }
+    
     public function withSystemInfos(array $system_infos) : Page\Standard
     {
         $this->checkArgListElements("system_infos", $system_infos, [SystemInfo::class]);

--- a/src/UI/templates/default/Layout/tpl.standardpage.html
+++ b/src/UI/templates/default/Layout/tpl.standardpage.html
@@ -21,6 +21,9 @@
 	<!-- BEGIN css_file -->
 	<link rel="stylesheet" type="text/css" href="{CSS_FILE}" />
 	<!-- END css_file -->
+    <!-- BEGIN meta_datum -->
+    <meta name="{META_KEY}" content="{META_VALUE}" />
+    <!-- END meta_datum -->
 </head>
 <body>
 	<!-- BEGIN mode_info -->

--- a/tests/GlobalScreen/Scope/Layout/MediaTest.php
+++ b/tests/GlobalScreen/Scope/Layout/MediaTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ILIAS\GlobalScreen\Media;
+namespace ILIAS\GlobalScreen\Scope\Layout;
 
 use PHPUnit\Framework\TestCase;
 use ILIAS\GlobalScreen\Scope\Layout\MetaContent\MetaContent;

--- a/tests/GlobalScreen/Scope/Layout/MetaDataTest.php
+++ b/tests/GlobalScreen/Scope/Layout/MetaDataTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace ILIAS\GlobalScreen\Scope\Layout;
+
+use PHPUnit\Framework\TestCase;
+use ILIAS\GlobalScreen\Scope\Layout\MetaContent\MetaContent;
+use ILIAS\GlobalScreen\Scope\Layout\MetaContent\Media\Css;
+use ILIAS\GlobalScreen\Scope\Layout\MetaContent\Media\InlineCss;
+use ILIAS\GlobalScreen\Scope\Layout\MetaContent\Media\Js;
+use ILIAS\GlobalScreen\Scope\Layout\MetaContent\MetaData\MetaDatum;
+
+require_once('./libs/composer/vendor/autoload.php');
+
+/**
+ * Class MetaDataTest
+ *
+ * @author                 Fabian Schmid <fs@studer-raimann.ch>
+ */
+class MetaDataTest extends TestCase
+{
+    public MetaContent $meta_content;
+    
+    protected function setUp() : void
+    {
+        parent::setUp();
+        $this->meta_content = new MetaContent('1.0');
+    }
+    
+    public function testAddMetaDatum() : void
+    {
+        $key = 'key';
+        $value = 'value';
+        $this->meta_content->addMetaDatum($key, $value);
+        $collection = $this->meta_content->getMetaData();
+        
+        $first_item = iterator_to_array($collection->getItems())[0];
+        $this->assertInstanceOf(MetaDatum::class, $first_item);
+        $this->assertEquals($key, $first_item->getKey());
+        $this->assertEquals($value, $first_item->getValue());
+    }
+    
+}

--- a/tests/UI/Component/Layout/Page/StandardPageTest.php
+++ b/tests/UI/Component/Layout/Page/StandardPageTest.php
@@ -164,6 +164,17 @@ class StandardPageTest extends ILIAS_UI_TestBase
             ->getTextDirection()
         );
     }
+    
+    public function testWithMetaDatum() : void
+    {
+        $meta_datum_key = 'meta_datum_key';
+        $meta_datum_value = 'meta_datum_value';
+        $meta_data = [$meta_datum_key => $meta_datum_value];
+        $this->assertEquals(
+            $meta_data,
+            $this->stdpage->withAdditionalMetaDatum($meta_datum_key, $meta_datum_value)->getMetaData()
+        );
+    }
 
     public function testRenderingWithTitle() : void
     {
@@ -239,6 +250,45 @@ class StandardPageTest extends ILIAS_UI_TestBase
    </body>
 </html>');
         $this->assertEquals($exptected, $html);
+    }
+    
+    public function testRenderingWithMetaData() : void
+    {
+        $this->stdpage = $this->stdpage->withAdditionalMetaDatum('meta_datum_key_1', 'meta_datum_value_1');
+        $this->stdpage = $this->stdpage->withAdditionalMetaDatum('meta_datum_key_2', 'meta_datum_value_2');
+        
+        $r = $this->getDefaultRenderer(null, [$this->metabar, $this->mainbar, $this->crumbs, $this->logo]);
+        $html = $this->brutallyTrimHTML($r->render($this->stdpage));
+        $expected = $this->brutallyTrimHTML('
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+   <head>
+      <meta charset="utf-8" />
+      <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+      <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+      <title>: </title>
+      <style></style>
+      <meta name="meta_datum_key_1" content="meta_datum_value_1" />
+      <meta name="meta_datum_key_2" content="meta_datum_value_2" />
+   </head>
+   <body>
+      <div class="il-layout-page">
+         <header>
+            <div class="header-inner">
+               <div class="il-logo">Logo Stub<div class="il-pagetitle">pagetitle</div></div>MetaBar Stub</div>
+         </header>
+         
+         <div class="il-system-infos"></div>
+         <div class="nav il-maincontrols">MainBar Stub</div>
+         <!-- html5 main-tag is not supported in IE / div is needed -->
+         <main class="il-layout-page-content">
+            <div>some content</div>
+         </main>
+      </div>
+      <script>il.Util.addOnLoad(function() {});</script>
+   </body>
+</html>');
+        $this->assertEquals($expected, $html);
     }
 
 


### PR DESCRIPTION
Hi @klees and @smeyer-ilias 

This PR contains the Feature ["Expose LOM keywords in HTML header"](https://docu.ilias.de/goto.php?target=wiki_1357_Expose_LOM_keywords_in_HTML_header), which brings changes for 

- UI Page
- Metadata
- GlobalScreen

Background of the Feature is the missing rendering of LOM Keywords in the HTML header since ILIAS 6.

- @klees: All changes for UI Page incl. new Tests are here: https://github.com/ILIAS-eLearning/ILIAS/commit/c48162e429cc3d884f1f82f50bd4661748b0237a
- @smeyer-ilias: All Changes for MetaData are here: https://github.com/ILIAS-eLearning/ILIAS/commit/2923d8918b8ec8e15ec20f4096b3f8f562f4a8be and https://github.com/ILIAS-eLearning/ILIAS/pull/4048/commits/40ae8136e1593a5068546f93d7e86991de2bedea