### PR TITLE
UI: Interface for `Toast Container`

### DIFF
--- a/src/UI/Component/Toast/Container.php
+++ b/src/UI/Component/Toast/Container.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace ILIAS\UI\Component\Toast;
+
+use ILIAS\UI\Component\Component;
+
+/**
+ * Interface Container
+ * @package ILIAS\UI\Component\Toast
+ */
+interface Container extends Component
+{
+    /**
+     * @return Toast[]
+     */
+    public function getToasts() : array;
+
+    public function withAdditionalToast(Toast $toast) : Container;
+
+    public function withoutToasts() : Container;
+}

--- a/src/UI/Component/Toast/Factory.php
+++ b/src/UI/Component/Toast/Factory.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ILIAS\UI\Component\Toast;
 use ILIAS\UI\Component\Symbol\Icon\Icon;
@@ -12,26 +12,24 @@ interface Factory
      * ---
      * description:
      *   purpose:
-     *     Standard Toasts display a normal toast in the top right corner of the ILIAS page content.
+     *     Standard Toasts display a normal toast inside a toast container.
      *   composition:
      *     Standard Toasts contain a title, a close button and an icon, which indicates the service or module
      *     triggering the Toast. They might contain a description and an action, which is triggered
      *     when user interact with the Toast. Further the Toast might contain a number of ILIAS Link components, which
      *     will be presented below the description.
      *   effect:
-     *     The item will be displayed overlaying the main content.
      *     If the item has an action set, a click interaction of the user with the Toast will trigger this
      *     action (The response of this interaction will not be displayed).
+     * context:
+     *   - The Toast should only be used inside a toast container.
      * rules:
      *   style:
-     *     1: The Toast SHOULD be limited in space so it does not cover all of the pages content, no matter the size of
-     *        its own content.
-     *     2: The description of the Toast MUST not render any non-textual context (e.g. HTML).
+     *     1: The description of the Toast MUST not render any non-textual context (e.g. HTML).
      *   ordering:
-     *     1: A new Toast SHOULD be ordered below all existing Toasts.
+     *     1: A new Toast SHOULD be ordered below all existing Toasts of its surrounding toast container.
      *   responsiveness:
      *     1: The Toast SHOULD always have the same size on full display and be independent from the display size.
-     *     2: The Toast MAY be hidden on devices with a low screen size.
      * ---
      *
      * @param string|\ILIAS\UI\Implementation\Component\Button\Shy|\ILIAS\GlobalScreen\Scope\MainMenu\Factory\Item\Link $title Title of the item
@@ -40,4 +38,29 @@ interface Factory
      * @return  \ILIAS\UI\Component\Toast\Toast
      */
     public function standard($title, Icon $icon) : Toast;
+
+    /**
+     * ---
+     * description:
+     *   purpose:
+     *     Toasts Containers display Toasts on the ILIAS page.
+     *     It has no visual appearance on it's own but provides a location for the Toasts.
+     *   composition:
+     *     Toast Containers contain a group of toasts.
+     *   effect:
+     *     The container will be displayed overlaying the main content.
+     *     If the container is empty it will not be displayed.
+     * rules:
+     *   style:
+     *     1: The Toast Container SHOULD be limited in space so it does not cover all of the pages content, no matter
+     *        the size of its own content.
+     *     2: An empty Toast Container SHOULD have no effect on the visible page.
+     *   accessibility:
+     *     1: All Toast Containers MUST alert screen readers when appearing and therefore MUST declare the role "alert" or
+     *        aria-live.
+     * ---
+     *
+     * @return  \ILIAS\UI\Component\Toast\Container
+     */
+    public function container() : Container;
 }

--- a/src/UI/Component/Toast/Toast.php
+++ b/src/UI/Component/Toast/Toast.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ILIAS\UI\Component\Toast;
 

--- a/src/UI/Implementation/Component/Toast/Factory.php
+++ b/src/UI/Implementation/Component/Toast/Factory.php
@@ -3,6 +3,7 @@
 namespace ILIAS\UI\Implementation\Component\Toast;
 
 use ILIAS\UI\Component\Symbol\Icon\Icon;
+use ILIAS\UI\Component\Toast\Container;
 use ILIAS\UI\Implementation\Component\SignalGeneratorInterface;
 
 class Factory implements \ILIAS\UI\Component\Toast\Factory
@@ -20,5 +21,10 @@ class Factory implements \ILIAS\UI\Component\Toast\Factory
     public function standard($title, Icon $icon) : Toast
     {
         return new Toast($title, $icon, $this->signal_generator);
+    }
+
+    public function container() : Container
+    {
+        throw new \ILIAS\UI\NotImplementedException();
     }
 }

--- a/src/UI/examples/Toast/Container/base.php
+++ b/src/UI/examples/Toast/Container/base.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Toast\Container;
+
+function base() : string
+{
+    global $DIC;
+    $tc = $DIC->ui()->factory()->toast()->container();
+    return $DIC->ui()->renderer()->render($tc);
+}

--- a/src/UI/examples/Toast/Container/with_multiple_toasts.php
+++ b/src/UI/examples/Toast/Container/with_multiple_toasts.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Toast\Container;
+
+function with_multiple_toasts() : string
+{
+    global $DIC;
+    $tc = $DIC->ui()->factory()->toast()->container()
+        ->withAdditionalToast(
+            $DIC->ui()->factory()->toast()->standard(
+                'Example 1',
+                $DIC->ui()->factory()->symbol()->icon()->standard('info', 'Test')
+            )
+        )->withAdditionalToast(
+            $DIC->ui()->factory()->toast()->standard(
+                'Example 2',
+                $DIC->ui()->factory()->symbol()->icon()->standard('info', 'Test')
+            )
+        )->withAdditionalToast(
+            $DIC->ui()->factory()->toast()->standard(
+                'Example 3',
+                $DIC->ui()->factory()->symbol()->icon()->standard('info', 'Test')
+            )
+        );
+
+    return $DIC->ui()->renderer()->render($tc);
+}

--- a/src/UI/examples/Toast/Container/with_toast.php
+++ b/src/UI/examples/Toast/Container/with_toast.php
@@ -1,8 +1,8 @@
 <?php declare(strict_types=1);
 
-namespace ILIAS\UI\examples\Toast\Standard;
+namespace ILIAS\UI\examples\Toast\Container;
 
-function base() : string
+function with_toast() : string
 {
     global $DIC;
     $tc = $DIC->ui()->factory()->toast()->container()->withAdditionalToast(

--- a/src/UI/examples/Toast/Standard/with_action.php
+++ b/src/UI/examples/Toast/Standard/with_action.php
@@ -2,15 +2,14 @@
 
 namespace ILIAS\UI\examples\Toast\Standard;
 
-/**
- * With a action on vanishing. (Does not provide any visual representation by itself)
- */
 function with_action() : string
 {
     global $DIC;
-    $toast = $DIC->ui()->factory()->toast()->standard(
-        'Example',
-        $DIC->ui()->factory()->symbol()->icon()->standard('info', 'Test')
-    )->withAction('https://www.ilias.de');
-    return $DIC->ui()->renderer()->render($toast);
+    $tc = $DIC->ui()->factory()->toast()->container()->withAdditionalToast(
+        $DIC->ui()->factory()->toast()->standard(
+            'Example',
+            $DIC->ui()->factory()->symbol()->icon()->standard('info', 'Test')
+        )->withAction('https://www.ilias.de')
+    );
+    return $DIC->ui()->renderer()->render($tc);
 }

--- a/src/UI/examples/Toast/Standard/with_additional_links.php
+++ b/src/UI/examples/Toast/Standard/with_additional_links.php
@@ -5,12 +5,13 @@ namespace ILIAS\UI\examples\Toast\Standard;
 function with_additional_links() : string
 {
     global $DIC;
-    $toast = $DIC->ui()->factory()->toast()->standard(
-        'Example',
-        $DIC->ui()->factory()->symbol()->icon()->standard('info', 'Example')
-    )
-    ->withAdditionalLink($DIC->ui()->factory()->link()->standard('ILIAS', 'https://www.ilias.de'))
-    ->withAdditionalLink($DIC->ui()->factory()->link()->standard('GitHub', 'https://www.github.com'))
-    ;
-    return $DIC->ui()->renderer()->render($toast);
+    $tc = $DIC->ui()->factory()->toast()->container()->withAdditionalToast(
+        $DIC->ui()->factory()->toast()->standard(
+            'Example',
+            $DIC->ui()->factory()->symbol()->icon()->standard('info', 'Example')
+        )
+        ->withAdditionalLink($DIC->ui()->factory()->link()->standard('ILIAS', 'https://www.ilias.de'))
+        ->withAdditionalLink($DIC->ui()->factory()->link()->standard('GitHub', 'https://www.github.com'))
+    );
+    return $DIC->ui()->renderer()->render($tc);
 }

--- a/src/UI/examples/Toast/Standard/with_description.php
+++ b/src/UI/examples/Toast/Standard/with_description.php
@@ -5,9 +5,11 @@ namespace ILIAS\UI\examples\Toast\Standard;
 function with_description() : string
 {
     global $DIC;
-    $toast = $DIC->ui()->factory()->toast()->standard(
-        'Example',
-        $DIC->ui()->factory()->symbol()->icon()->standard('info', 'Test')
-    )->withDescription('This is an example description.');
-    return $DIC->ui()->renderer()->render($toast);
+    $tc = $DIC->ui()->factory()->toast()->container()->withAdditionalToast(
+        $DIC->ui()->factory()->toast()->standard(
+            'Example',
+            $DIC->ui()->factory()->symbol()->icon()->standard('info', 'Test')
+        )->withDescription('This is an example description.')
+    );
+    return $DIC->ui()->renderer()->render($tc);
 }

--- a/src/UI/examples/Toast/Standard/with_link_title.php
+++ b/src/UI/examples/Toast/Standard/with_link_title.php
@@ -5,9 +5,11 @@ namespace ILIAS\UI\examples\Toast\Standard;
 function with_link_title() : string
 {
     global $DIC;
-    $toast = $DIC->ui()->factory()->toast()->standard(
-        $DIC->ui()->factory()->link()->standard('Example', 'https://www.ilias.de'),
-        $DIC->ui()->factory()->symbol()->icon()->standard('info', 'Test')
+    $tc = $DIC->ui()->factory()->toast()->container()->withAdditionalToast(
+        $DIC->ui()->factory()->toast()->standard(
+            $DIC->ui()->factory()->link()->standard('Example', 'https://www.ilias.de'),
+            $DIC->ui()->factory()->symbol()->icon()->standard('info', 'Test')
+        )
     );
-    return $DIC->ui()->renderer()->render($toast);
+    return $DIC->ui()->renderer()->render($tc);
 }

--- a/src/UI/examples/Toast/Standard/with_long_description.php
+++ b/src/UI/examples/Toast/Standard/with_long_description.php
@@ -5,17 +5,19 @@ namespace ILIAS\UI\examples\Toast\Standard;
 function with_long_description() : string
 {
     global $DIC;
-    $toast = $DIC->ui()->factory()->toast()->standard(
-        'Example',
-        $DIC->ui()->factory()->symbol()->icon()->standard('info', 'Test')
-    )->withDescription(
-        'This is an example description which is very long to provide a representative view of the object when it has ' .
-        'to occupy enough space to show a very long toast. This may not be the favorable way of displaying a toast, ' .
-        'since toast are assumed to be readable in a short time due to the temporary visibility, therefore they only ' .
-        'should contain short description which can be read withing seconds. But even if this long description softly ' .
-        'violates the concepts of toast itself due to its long character it still provides a good view on the ' .
-        'scalability of the object and could therefore be called to proof its responsivity which confirms its benefit ' .
-        'as an example in spite of its unnatural form and missing usecase for productive systems'
+    $tc = $DIC->ui()->factory()->toast()->container()->withAdditionalToast(
+        $DIC->ui()->factory()->toast()->standard(
+            'Example',
+            $DIC->ui()->factory()->symbol()->icon()->standard('info', 'Test')
+        )->withDescription(
+            'This is an example description which is very long to provide a representative view of the object when it has ' .
+            'to occupy enough space to show a very long toast. This may not be the favorable way of displaying a toast, ' .
+            'since toast are assumed to be readable in a short time due to the temporary visibility, therefore they only ' .
+            'should contain short description which can be read withing seconds. But even if this long description softly ' .
+            'violates the concepts of toast itself due to its long character it still provides a good view on the ' .
+            'scalability of the object and could therefore be called to proof its responsivity which confirms its benefit ' .
+            'as an example in spite of its unnatural form and missing usecase for productive systems'
+        )
     );
-    return $DIC->ui()->renderer()->render($toast);
+    return $DIC->ui()->renderer()->render($tc);
 }


### PR DESCRIPTION
This PR proposes to introduce the UI-Component for implementing Containers for Toasts.
**Toast Container:**
The Toast Container is a wrapper without direct visual represantation which centralizes the handling and accessebility of Toast components.

A Toast Container can appear in the top right corner , overlaying the ILIAS UI. It can contain and handle Toasts Components and present them to a screen reader. There is not direct way to interact with the Container itself. If the Container does not contain any Toast Components it has no effect on the visual page.

***

The new concept of the Container has the following effect on the existing concept of the Toast (See [Toasts](https://docu.ilias.de/goto_docu_wiki_wpage_6494_1357.html)):
> A Toast can appear in the top right corner, overlaying the ILIAS UI

This ability is omitted since the container decides about the position of apperance.