### PR TITLE
HTTP: Change `Drop-In-Replacement` handling

### DIFF
--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1480,7 +1480,7 @@ class ilInitialisation
      */
     protected static function replaceSuperGlobals(\ILIAS\DI\Container $container) : void
     {
-        if (define('DEVMODE') && DEVMODE) {
+        if (defined('DEVMODE') && DEVMODE) {
             $_GET = new SuperGlobalDropInReplacement($container['refinery'], $_GET);
             $_POST = new SuperGlobalDropInReplacement($container['refinery'], $_POST);
             $_COOKIE = new SuperGlobalDropInReplacement($container['refinery'], $_COOKIE);

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1480,12 +1480,22 @@ class ilInitialisation
      */
     protected static function replaceSuperGlobals(\ILIAS\DI\Container $container) : void
     {
-        $throwOnValueAssignment = defined('DEVMODE') && DEVMODE;
+        /** @var ilIniFile $client_ini */
+        $client_ini = $container['ilClientIniFile'];
 
-        $_GET = new SuperGlobalDropInReplacement($container['refinery'], $_GET, $throwOnValueAssignment);
-        $_POST = new SuperGlobalDropInReplacement($container['refinery'], $_POST, $throwOnValueAssignment);
-        $_COOKIE = new SuperGlobalDropInReplacement($container['refinery'], $_COOKIE, $throwOnValueAssignment);
-        $_REQUEST = new SuperGlobalDropInReplacement($container['refinery'], $_REQUEST, $throwOnValueAssignment);
+        $replace_super_globals = (
+            !$client_ini->variableExists('system', 'prevent_super_global_replacement') ||
+            !(bool) $client_ini->readVariable('system', 'prevent_super_global_replacement')
+        );
+
+        if ($replace_super_globals) {
+            $throwOnValueAssignment = defined('DEVMODE') && DEVMODE;
+
+            $_GET = new SuperGlobalDropInReplacement($container['refinery'], $_GET, $throwOnValueAssignment);
+            $_POST = new SuperGlobalDropInReplacement($container['refinery'], $_POST, $throwOnValueAssignment);
+            $_COOKIE = new SuperGlobalDropInReplacement($container['refinery'], $_COOKIE, $throwOnValueAssignment);
+            $_REQUEST = new SuperGlobalDropInReplacement($container['refinery'], $_REQUEST, $throwOnValueAssignment);
+        }
     }
 
     protected static function initComponentService(\ILIAS\DI\Container $container) : void

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1480,12 +1480,12 @@ class ilInitialisation
      */
     protected static function replaceSuperGlobals(\ILIAS\DI\Container $container) : void
     {
-        if (defined('DEVMODE') && DEVMODE) {
-            $_GET = new SuperGlobalDropInReplacement($container['refinery'], $_GET);
-            $_POST = new SuperGlobalDropInReplacement($container['refinery'], $_POST);
-            $_COOKIE = new SuperGlobalDropInReplacement($container['refinery'], $_COOKIE);
-            $_REQUEST = new SuperGlobalDropInReplacement($container['refinery'], $_REQUEST);
-        }
+        $throwOnValueAssignment = defined('DEVMODE') && DEVMODE;
+
+        $_GET = new SuperGlobalDropInReplacement($container['refinery'], $_GET, $throwOnValueAssignment);
+        $_POST = new SuperGlobalDropInReplacement($container['refinery'], $_POST, $throwOnValueAssignment);
+        $_COOKIE = new SuperGlobalDropInReplacement($container['refinery'], $_COOKIE, $throwOnValueAssignment);
+        $_REQUEST = new SuperGlobalDropInReplacement($container['refinery'], $_REQUEST, $throwOnValueAssignment);
     }
 
     protected static function initComponentService(\ILIAS\DI\Container $container) : void

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1480,10 +1480,12 @@ class ilInitialisation
      */
     protected static function replaceSuperGlobals(\ILIAS\DI\Container $container) : void
     {
-        $_GET = new SuperGlobalDropInReplacement($container['refinery'], $_GET);
-        $_POST = new SuperGlobalDropInReplacement($container['refinery'], $_POST);
-        $_COOKIE = new SuperGlobalDropInReplacement($container['refinery'], $_COOKIE);
-        $_REQUEST = new SuperGlobalDropInReplacement($container['refinery'], $_REQUEST);
+        if (define('DEVMODE') && DEVMODE) {
+            $_GET = new SuperGlobalDropInReplacement($container['refinery'], $_GET);
+            $_POST = new SuperGlobalDropInReplacement($container['refinery'], $_POST);
+            $_COOKIE = new SuperGlobalDropInReplacement($container['refinery'], $_COOKIE);
+            $_REQUEST = new SuperGlobalDropInReplacement($container['refinery'], $_REQUEST);
+        }
     }
 
     protected static function initComponentService(\ILIAS\DI\Container $container) : void

--- a/Services/Saml/README.md
+++ b/Services/Saml/README.md
@@ -8,6 +8,7 @@ in this document are to be interpreted as described in
 **Table of Contents**
 
 * [Server Configuration](#web-server-configuration)
+* [ILIAS Configuration](#ilias-configuration)
 
 ## Web Server Configuration
 
@@ -61,4 +62,19 @@ location ~ \.php$ {
 }
 
 [...]
+```
+
+## ILIAS Configuration
+
+With ILIAS 8 `HTTP Requests` and the derived `Super Global Variables ($_GET, $_POST, $_COOKIE, $_REQUEST)` are made
+immutable. This leads to issues with the `SimpleSAMLphp` library, which is not aware of this mechanism
+in ILIAS (these variables are objects implementing `ArrayAccess`, which is not exactly an `array`).
+
+To use the `SAML` authentication in ILIAS >= 8.x, you'll have to add the following setting to the `client.ini.php` file:
+
+```ini
+[system]
+...
+prevent_super_global_replacement = "1"
+...
 ```

--- a/Services/Saml/README.md
+++ b/Services/Saml/README.md
@@ -66,15 +66,5 @@ location ~ \.php$ {
 
 ## ILIAS Configuration
 
-With ILIAS 8 `HTTP Requests` and the derived `Super Global Variables ($_GET, $_POST, $_COOKIE, $_REQUEST)` are made
-immutable. This leads to issues with the `SimpleSAMLphp` library, which is not aware of this mechanism
-in ILIAS (these variables are objects implementing `ArrayAccess`, which is not exactly an `array`).
-
-To use the `SAML` authentication in ILIAS >= 8.x, you'll have to add the following setting to the `client.ini.php` file:
-
-```ini
-[system]
-...
-prevent_super_global_replacement = "1"
-...
-```
+Please change your ILIAS configuration according to the `Superglobal` behaviour described in
+the [`HTTP README`](../../src/HTTP/README.md#dropinreplacements)

--- a/src/HTTP/README.md
+++ b/src/HTTP/README.md
@@ -215,7 +215,7 @@ The project is also actively maintained.
 The http-message package contains the specified interfaces of the php-fig which defined psr-7.
 
 # DropInReplacements
-With ILIAS 8, the Technical Board has decided to replace the [Superglobals](https://www.php.net/manual/en/language.variables.superglobals.php)
+With ILIAS 8, the Technical Board has decided to replace the [`Superglobals`](https://www.php.net/manual/en/language.variables.superglobals.php)
 `$_GET`, `$_POST`, `$_COOKIE` and `$_REQUEST` with so called `SuperGlobalDropInReplacement` instances.
 These are `ArrayAccess` wrappers for the respective `Superglobals`. They contain the [`Refinery`](../Refinery/README.md)
 and run values on readout through the `->kindlyTo()->string()` `transformation` respectively.
@@ -223,7 +223,7 @@ Furthermore, the `SuperGlobalDropInReplacement` should prevent that values in th
 assigned or modified/overwritten, because this violates the immutability of these values in the HTTP request.
 The general replacement of the `Superglobals` for some 3rd-Party-Libraries however leads to problems, because these
 require an `array` and no `ArrayAccess` object (currently known for `SimpleSAMLphp`). Therefore, there is the
-possibility to override the `Superglobals` via an ini setting in the `client.ini.php` file:
+possibility to override the `Superglobals` via an ini setting in the `client.ini.php` file.
 
 ```
 [server]

--- a/src/HTTP/README.md
+++ b/src/HTTP/README.md
@@ -214,5 +214,15 @@ The project is also actively maintained.
 #### Why ?
 The http-message package contains the specified interfaces of the php-fig which defined psr-7.
 
+# DropInReplacements
+With ILIAS 8, the Technical Board has decided to replace the SuperGlobals $_GET, $_POST, $_COOKIE and $_REQUEST with so called `SuperGlobalDropInReplacement`. These are ArrayAccess wrappers for the respective SuperGlobals. These contain the refinery and and run values on readout through the `->kindlyTo()->string()` `transformation` respectively.
+Further the `SuperGlobalDropInReplacement` should prevent that further values in the SuperGlobals are manually overwritten or changed, because this violates the immutability of these values in the request.
+The general replacement of the SuperGlobals for some 3rd-Prty-Libraries however leads to problems, because these require an `array` and no `ArrayAccess` object (currently known for SimpleSAML-PHP). Therefore there is the possibility to override the SuperGlobals via an ini setting in ilias.ini:
 
+```
+[server]
+prevent_super_global_replacement = 1
+```
+
+Furthermore, the `SuperGlobalDropInReplacement` behave in such a way when `DEVMODE` is enabled that overwriting a value in one of the SuperGlobals leads to a `\OutOfBoundsException`.
 

--- a/src/HTTP/README.md
+++ b/src/HTTP/README.md
@@ -215,9 +215,15 @@ The project is also actively maintained.
 The http-message package contains the specified interfaces of the php-fig which defined psr-7.
 
 # DropInReplacements
-With ILIAS 8, the Technical Board has decided to replace the SuperGlobals $_GET, $_POST, $_COOKIE and $_REQUEST with so called `SuperGlobalDropInReplacement`. These are ArrayAccess wrappers for the respective SuperGlobals. These contain the refinery and and run values on readout through the `->kindlyTo()->string()` `transformation` respectively.
-Further the `SuperGlobalDropInReplacement` should prevent that further values in the SuperGlobals are manually overwritten or changed, because this violates the immutability of these values in the request.
-The general replacement of the SuperGlobals for some 3rd-Prty-Libraries however leads to problems, because these require an `array` and no `ArrayAccess` object (currently known for SimpleSAML-PHP). Therefore there is the possibility to override the SuperGlobals via an ini setting in ilias.ini:
+With ILIAS 8, the Technical Board has decided to replace the [Superglobals](https://www.php.net/manual/en/language.variables.superglobals.php)
+`$_GET`, `$_POST`, `$_COOKIE` and `$_REQUEST` with so called `SuperGlobalDropInReplacement` instances.
+These are `ArrayAccess` wrappers for the respective `Superglobals`. These contain the refinery and run values on
+readout through the `->kindlyTo()->string()` `transformation` respectively.
+Furthermore, the `SuperGlobalDropInReplacement` should prevent that values in the `Superglobals` are manually
+assigned or modified/overwritten, because this violates the immutability of these values in the HTTP request.
+The general replacement of the `Superglobals` for some 3rd-Party-Libraries however leads to problems, because these
+require an `array` and no `ArrayAccess` object (currently known for `SimpleSAMLphp`). Therefore, there is the
+possibility to override the `Superglobals` via an ini setting in the `client.ini.php` file:
 
 ```
 [server]

--- a/src/HTTP/README.md
+++ b/src/HTTP/README.md
@@ -217,8 +217,8 @@ The http-message package contains the specified interfaces of the php-fig which 
 # DropInReplacements
 With ILIAS 8, the Technical Board has decided to replace the [Superglobals](https://www.php.net/manual/en/language.variables.superglobals.php)
 `$_GET`, `$_POST`, `$_COOKIE` and `$_REQUEST` with so called `SuperGlobalDropInReplacement` instances.
-These are `ArrayAccess` wrappers for the respective `Superglobals`. These contain the refinery and run values on
-readout through the `->kindlyTo()->string()` `transformation` respectively.
+These are `ArrayAccess` wrappers for the respective `Superglobals`. They contain the [`Refinery`](../Refinery/README.md)
+and run values on readout through the `->kindlyTo()->string()` `transformation` respectively.
 Furthermore, the `SuperGlobalDropInReplacement` should prevent that values in the `Superglobals` are manually
 assigned or modified/overwritten, because this violates the immutability of these values in the HTTP request.
 The general replacement of the `Superglobals` for some 3rd-Party-Libraries however leads to problems, because these
@@ -230,5 +230,6 @@ possibility to override the `Superglobals` via an ini setting in the `client.ini
 prevent_super_global_replacement = 1
 ```
 
-Furthermore, the `SuperGlobalDropInReplacement` behave in such a way when `DEVMODE` is enabled that overwriting a value in one of the SuperGlobals leads to a `\OutOfBoundsException`.
+Furthermore, the `SuperGlobalDropInReplacement` behave in such a way when `DEVMODE` is enabled that overwriting a value
+in one of the `Superglobals` leads to a `\OutOfBoundsException`.
 

--- a/src/HTTP/Wrapper/SuperGlobalDropInReplacement.php
+++ b/src/HTTP/Wrapper/SuperGlobalDropInReplacement.php
@@ -41,6 +41,8 @@ class SuperGlobalDropInReplacement extends KeyValueAccess
         if ($this->throwOnValueAssignment) {
             throw new \OutOfBoundsException("Modifying global Request-Array such as \$_GET is not allowed!");
         }
+
+        parent::offsetSet($offset, $value);
     }
 
     /**

--- a/src/HTTP/Wrapper/SuperGlobalDropInReplacement.php
+++ b/src/HTTP/Wrapper/SuperGlobalDropInReplacement.php
@@ -35,14 +35,11 @@ class SuperGlobalDropInReplacement extends KeyValueAccess
     }
 
     /**
-     * @deprecated Please note that this will throw an exception in a future version
      * @inheritDoc
      */
     public function offsetSet($offset, $value) : void
     {
-        /** @noRector */
-        // this is currently possible, throw new \OutOfBoundsException("Modifying global Request-Array such as \$_GET is not allowed!"); if you want to prevent from overriding a value here
-        parent::offsetSet($offset, $value);
+        throw new \OutOfBoundsException("Modifying global Request-Array such as \$_GET is not allowed!");
     }
 
     /**
@@ -52,5 +49,4 @@ class SuperGlobalDropInReplacement extends KeyValueAccess
     {
         throw new \LogicException("Modifying global Request-Array such as \$_GET is not allowed!");
     }
-
 }

--- a/src/HTTP/Wrapper/SuperGlobalDropInReplacement.php
+++ b/src/HTTP/Wrapper/SuperGlobalDropInReplacement.php
@@ -25,12 +25,11 @@ use ILIAS\Refinery\KeyValueAccess;
  */
 class SuperGlobalDropInReplacement extends KeyValueAccess
 {
+    private bool $throwOnValueAssignment;
 
-    /**
-     * DirectValueAccessDropInReplacement constructor.
-     */
-    public function __construct(Factory $factory, array $raw_values)
+    public function __construct(Factory $factory, array $raw_values, bool $throwOnValueAssignment = false)
     {
+        $this->throwOnValueAssignment = $throwOnValueAssignment;
         parent::__construct($raw_values, $factory->kindlyTo()->string());
     }
 
@@ -39,7 +38,9 @@ class SuperGlobalDropInReplacement extends KeyValueAccess
      */
     public function offsetSet($offset, $value) : void
     {
-        throw new \OutOfBoundsException("Modifying global Request-Array such as \$_GET is not allowed!");
+        if ($this->throwOnValueAssignment) {
+            throw new \OutOfBoundsException("Modifying global Request-Array such as \$_GET is not allowed!");
+        }
     }
 
     /**

--- a/tests/HTTP/Services/SuperGlobalDropInReplacementTest.php
+++ b/tests/HTTP/Services/SuperGlobalDropInReplacementTest.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
+namespace ILIAS\HTTP;
+
+/** @noRector */
+require_once "AbstractBaseTest.php";
+
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\HTTP\Wrapper\SuperGlobalDropInReplacement;
+use ILIAS\Refinery\Factory as Refinery;
+use ilLanguage;
+use OutOfBoundsException;
+
+class SuperGlobalDropInReplacementTest extends AbstractBaseTest
+{
+    private function getRefinery() : Refinery
+    {
+        return new Refinery(
+            new DataFactory(),
+            $this->getMockBuilder(ilLanguage::class)->disableOriginalConstructor()->getMock()
+        );
+    }
+
+    public function testValueCanBeAssignedIfSuperGlobalIsMutable() : void
+    {
+        $super_global = new SuperGlobalDropInReplacement($this->getRefinery(), ['foo' => 'bar']);
+        $super_global['foo'] = 'phpunit';
+
+        self::assertEquals('phpunit', $super_global['foo']);
+    }
+
+    public function testExceptionIsRaisedIfValueIsAssignedButSuperGlobalIsImmutable() : void
+    {
+        $this->expectException(OutOfBoundsException::class);
+
+        $super_global = new SuperGlobalDropInReplacement($this->getRefinery(), ['foo' => 'bar'], true);
+        $super_global['foo'] = 'phpunit';
+    }
+}


### PR DESCRIPTION
Mantis Issue: https://mantis.ilias.de/view.php?id=32081

This PR changes the behaviour of the `Drop-In-Replacement` used for `$_GET`, `$_POST`, `$_COOKIE` and `$_REQUEST`. We noticed issues with this when relying on external libraries not expecting an `ArrayAccess` implementation, but a real array.

We suggest to ...

- throw an exception in the `Drop-In-Replacement` if a value of the respective super global variable is manipulated in `DEVMODE`
- add an additional `INI` setting (see comments) to disable the `Drop-In-Replacement`