### PR TITLE
GlobalScreen/Layout: Add named location for displaying `Toasts`

### DIFF
--- a/src/GlobalScreen/Scope/Layout/Builder/StandardPageBuilder.php
+++ b/src/GlobalScreen/Scope/Layout/Builder/StandardPageBuilder.php
@@ -41,10 +41,10 @@ class StandardPageBuilder implements PageBuilder
      */
     public function build(PagePartProvider $parts) : Page
     {
-        $header_image = $parts->getLogo();
-        $main_bar = $parts->getMainBar();
         $meta_bar = $parts->getMetaBar();
+        $main_bar = $parts->getMainBar();
         $bread_crumbs = $parts->getBreadCrumbs();
+        $header_image = $parts->getLogo();
         $footer = $parts->getFooter();
         $title = $parts->getTitle();
         $short_title = $parts->getShortTitle();
@@ -56,6 +56,7 @@ class StandardPageBuilder implements PageBuilder
             $main_bar,
             $bread_crumbs,
             $header_image,
+            $this->ui->factory()->toast()->container(),
             $footer,
             $title,
             $short_title,

--- a/src/UI/Component/Layout/Page/Factory.php
+++ b/src/UI/Component/Layout/Page/Factory.php
@@ -2,9 +2,12 @@
 
 namespace ILIAS\UI\Component\Layout\Page;
 
-use ILIAS\UI\Component\MainControls;
-use ILIAS\UI\Component\Image\Image;
+use ILIAS\UI\Component\MainControls\Mainbar;
+use ILIAS\UI\Component\MainControls\MetaBar;
 use ILIAS\UI\Component\Breadcrumbs\Breadcrumbs;
+use ILIAS\UI\Component\Image\Image;
+use ILIAS\UI\Component\Toast\Container;
+use ILIAS\UI\Component\MainControls\Footer;
 
 /**
  * This is what a factory for pages looks like.
@@ -62,9 +65,11 @@ interface Factory
      *        Footer MUST additionally be declared with the ARIA role "Contentinfo".
      * ----
      * @param  \ILIAS\UI\Component\Component[] $content
-     * @param  \ILIAS\UI\Component\MainControls\MetaBar $Metabar
+     * @param  \ILIAS\UI\Component\MainControls\MetaBar $metabar
      * @param  \ILIAS\UI\Component\MainControls\MetaBar $mainbar
      * @param  \ILIAS\UI\Component\Breadcrumbs\Breadcrumbs $locator
+     * @param  \ILIAS\UI\Component\Image\Image $logo
+     * @param  \ILIAS\UI\Component\Toast\Container $overlay
      * @param  \ILIAS\UI\Component\MainControls\Footer $footer
      * @param  string $title
      * @param  string $short_title
@@ -73,11 +78,12 @@ interface Factory
      */
     public function standard(
         array $content,
-        MainControls\MetaBar $metabar = null,
-        MainControls\MainBar $mainbar = null,
+        MetaBar $metabar = null,
+        MainBar $mainbar = null,
         Breadcrumbs $locator = null,
         Image $logo = null,
-        MainControls\Footer $footer = null,
+        Container $overlay = null,
+        Footer $footer = null,
         string $title = '',
         string $short_title = '',
         string $view_title = ''

--- a/src/UI/Component/Layout/Page/Standard.php
+++ b/src/UI/Component/Layout/Page/Standard.php
@@ -12,6 +12,7 @@ use ILIAS\UI\Component\MainControls\MainBar;
 use ILIAS\UI\Component\MainControls\MetaBar;
 use ILIAS\UI\Component\MainControls\ModeInfo;
 use ILIAS\UI\Component\MainControls\Footer;
+use ILIAS\UI\Component\Toast\Container;
 
 /**
  * This describes the Page.
@@ -34,6 +35,8 @@ interface Standard extends Page, JavaScriptBindable
 
     public function hasLogo() : bool;
 
+    public function hasOverlay() : bool;
+
     public function getMetabar() : ?MetaBar;
 
     public function getMainbar() : ?MainBar;
@@ -41,6 +44,8 @@ interface Standard extends Page, JavaScriptBindable
     public function getBreadcrumbs() : ?Breadcrumbs;
 
     public function getLogo() : ?Image;
+
+    public function getOverlay() : ?Container;
 
     public function getFooter() : ?Footer;
 

--- a/src/UI/Implementation/Component/Layout/Page/Factory.php
+++ b/src/UI/Implementation/Component/Layout/Page/Factory.php
@@ -8,6 +8,7 @@ use ILIAS\UI\Component\Breadcrumbs\Breadcrumbs;
 use ILIAS\UI\Component\Image\Image;
 use ILIAS\UI\Component\Layout\Page;
 use ILIAS\UI\Component\MainControls;
+use ILIAS\UI\Component\Toast\Container;
 
 class Factory implements Page\Factory
 {
@@ -20,6 +21,7 @@ class Factory implements Page\Factory
         MainControls\MainBar $mainbar = null,
         Breadcrumbs $locator = null,
         Image $logo = null,
+        Container $overlay = null,
         MainControls\Footer $footer = null,
         string $title = '',
         string $short_title = '',
@@ -31,6 +33,7 @@ class Factory implements Page\Factory
             $mainbar,
             $locator,
             $logo,
+            $overlay,
             $footer,
             $title,
             $short_title,

--- a/src/UI/Implementation/Component/Layout/Page/Renderer.php
+++ b/src/UI/Implementation/Component/Layout/Page/Renderer.php
@@ -38,6 +38,9 @@ class Renderer extends AbstractComponentRenderer
     ) : string {
         $tpl = $this->getTemplate("tpl.standardpage.html", true, true);
 
+        if ($component->hasOverlay()) {
+            $tpl->setVariable('OVERLAY', $default_renderer->render($component->getOverlay()));
+        }
         if ($component->hasMetabar()) {
             $tpl->setVariable('METABAR', $default_renderer->render($component->getMetabar()));
         }

--- a/src/UI/Implementation/Component/Layout/Page/Standard.php
+++ b/src/UI/Implementation/Component/Layout/Page/Standard.php
@@ -12,6 +12,7 @@ use ILIAS\UI\Component\MainControls\MainBar;
 use ILIAS\UI\Component\MainControls\MetaBar;
 use ILIAS\UI\Component\MainControls\ModeInfo;
 use ILIAS\UI\Component\MainControls\SystemInfo;
+use ILIAS\UI\Component\Toast\Container;
 use ILIAS\UI\Implementation\Component\ComponentHelper;
 use ILIAS\UI\Implementation\Component\JavaScriptBindable;
 use ILIAS\UI\Component\Component;
@@ -30,6 +31,7 @@ class Standard implements Page\Standard
     private ?MainBar $mainbar;
     private ?Breadcrumbs $breadcrumbs;
     private ?Image $logo;
+    private ?Container $overlay;
     private ?Footer $footer;
     private string $short_title;
     private string $view_title;
@@ -45,6 +47,7 @@ class Standard implements Page\Standard
         ?MainBar $mainbar = null,
         ?Breadcrumbs $locator = null,
         ?Image $logo = null,
+        ?Container $overlay = null,
         ?Footer $footer = null,
         string $title = '',
         string $short_title = '',
@@ -58,6 +61,7 @@ class Standard implements Page\Standard
         $this->mainbar = $mainbar;
         $this->breadcrumbs = $locator;
         $this->logo = $logo;
+        $this->overlay = $overlay;
         $this->footer = $footer;
         $this->title = $title;
         $this->short_title = $short_title;
@@ -303,5 +307,15 @@ class Standard implements Page\Standard
     public function getTextDirection() : string
     {
         return $this->text_direction;
+    }
+
+    public function hasOverlay() : bool
+    {
+        return $this->overlay instanceof Container;
+    }
+
+    public function getOverlay() : ?Container
+    {
+        return $this->overlay;
     }
 }

--- a/src/UI/templates/default/Layout/tpl.standardpage.html
+++ b/src/UI/templates/default/Layout/tpl.standardpage.html
@@ -6,9 +6,9 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 
 	<!-- BEGIN for_ui_examples_only -->
-    <!-- ATTENTION: This only exists to provide an example of the complete page.     -->
-    <!-- This won't be included in renderings of ordinary pages. Also have a look    -->
-    <!-- into \ILIAS\UI\Implementation\Component\Layout\Page\Renderer::setHeaderVars -->
+	<!-- ATTENTION: This only exists to provide an example of the complete page.     -->
+	<!-- This won't be included in renderings of ordinary pages. Also have a look    -->
+	<!-- into \ILIAS\UI\Implementation\Component\Layout\Page\Renderer::setHeaderVars -->
 	<base href="{BASE}" />
 	<!-- END for_ui_examples_only -->
 
@@ -26,6 +26,10 @@
 	<!-- BEGIN mode_info -->
 	{MODEINFO}
 	<!-- END mode_info -->
+
+	<div class="il-page-overlay">
+		{OVERLAY}
+	</div>
 
 	<div class="il-layout-page<!-- BEGIN slates_engaged --> with-mainbar-slates-engaged<!-- END slates_engaged -->">
 		<header>
@@ -78,7 +82,7 @@
 <!-- BEGIN js_file -->
 <script src="{JS_FILE}"></script>
 <!-- END js_file -->
-	
+
 <!-- BEGIN on_load_code -->
 <script>
 	<!-- BEGIN on_load_code_inner -->

--- a/src/UI/templates/js/Page/stdpage.js
+++ b/src/UI/templates/js/Page/stdpage.js
@@ -3,11 +3,16 @@ il.UI = il.UI || {};
 (function($, ui) {
 	ui.page = (function($) {
 		var _cls_page_content = '.il-layout-page-content',
+		    _page_overlay = '.il-page-overlay',
 			_id_right_col = '#il_right_col';
 
 		var breakpoint_max_width = 768, //this corresponds to @grid-float-breakpoint-max, see mainbar.less/metabar.less
 			resized_poppers_margin = 25, //dropdown, date-picker
 			mq_orientation = window.matchMedia("(orientation: portrait)");
+
+		var getOverlay = function () {
+			return document.querySelector(_page_overlay);
+		}
 
 		var isSmallScreen = function() {
 			var media_query = "only screen"
@@ -61,6 +66,7 @@ il.UI = il.UI || {};
 		};
 
 		return {
+			getOverlay: getOverlay,
 			isSmallScreen: isSmallScreen,
 			getOrientation: getOrientation,
 			isPortrait: isPortrait,


### PR DESCRIPTION
Depends on the implementation of [Toast Container](https://github.com/ILIAS-eLearning/ILIAS/pull/4059) since its the first overlay content.