### PR TITLE
Fix Internal Links Modal in Table of Page Editor.

### DIFF
--- a/Services/COPage/classes/class.ilPCTableGUI.php
+++ b/Services/COPage/classes/class.ilPCTableGUI.php
@@ -1244,8 +1244,23 @@ class ilPCTableGUI extends ilPageContentGUI
             $dtpl->parseCurrentBlock();
         }
 
-
         $dtpl->setVariable("TXT_ACTION", $this->lng->txt("cont_table"));
+        
+        // add int link parts
+        $dtpl->setCurrentBlock("int_link_prep");
+        $dtpl->setVariable(
+            "INT_LINK_PREP",
+            ilInternalLinkGUI::getInitHTML(
+                $ilCtrl->getLinkTargetByClass(
+                    array("ilpageeditorgui", "ilinternallinkgui"),
+                    "",
+                    false,
+                    true,
+                    false
+                )
+            )
+        );
+        $dtpl->parseCurrentBlock();
 
         if ($initial) {
             $dtpl->touchBlock("script");


### PR DESCRIPTION
Fixes the missing modal for the internal links in the data table (see: https://mantis.ilias.de/view.php?id=31443).