### PR TITLE
fix typo in dashboard mainbard provider

### DIFF
--- a/Services/Dashboard/GlobalScreen/classes/PDMainBarProvider.php
+++ b/Services/Dashboard/GlobalScreen/classes/PDMainBarProvider.php
@@ -87,7 +87,7 @@ class PDMainBarProvider extends AbstractStaticMainMenuProvider
                                       ->withSymbol($icon)
                                       ->withPosition(25)
                                         ->withVisibilityCallable(function() use($admin_ref_id){
-                                            return $this->dic->rbac()->system()->checkAccess('visible,read', $ref_id);
+                                            return $this->dic->rbac()->system()->checkAccess('visible,read', $admin_ref_id);
                                         });
         }
 


### PR DESCRIPTION
ATM you cant login as a normal user (not admin) in a newly installed ilias 7 caused by a typo inside the mainbar provider of the dashboard

https://mantis.ilias.de/view.php?id=32105