### PR TITLE
Fix logging. Check if classname is set. Fixes #32107

### DIFF
--- a/Services/Logging/classes/extensions/class.ilTraceProcessor.php
+++ b/Services/Logging/classes/extensions/class.ilTraceProcessor.php
@@ -40,8 +40,8 @@ class ilTraceProcessor
         array_shift($trace);
         array_shift($trace);
         array_shift($trace);
-        
-        $trace_info = $trace[0]['class'] . '::' . $trace[0]['function'] . ':' . $trace[0]['line'];
+        $classname = isset($trace[0]['class']) ? $trace[0]['class'] . '::' : '';
+        $trace_info = $classname . $trace[0]['function'] . ':' . $trace[0]['line'];
         
         $record['extra'] = array_merge(
             $record['extra'],


### PR DESCRIPTION
The classname is not set when php internal class are contained in the stacktrace. This happens if logging is used in callback functions.