### PR TITLE
[FIX] 0031865: Online Help Main Menu Tooltips are missing (was: Place…

### DIFF
--- a/src/UI/Implementation/Component/Symbol/Icon/Renderer.php
+++ b/src/UI/Implementation/Component/Symbol/Icon/Renderer.php
@@ -25,6 +25,14 @@ class Renderer extends AbstractComponentRenderer
         $this->checkComponent($component);
         $tpl = $this->getTemplate("tpl.icon.html", true, true);
 
+        $id = $this->bindJavaScript($component);
+    
+        if ($id !== null) {
+            $tpl->setCurrentBlock("with_id");
+            $tpl->setVariable("ID", $id);
+            $tpl->parseCurrentBlock();
+        }
+
         $tpl->setVariable("NAME", $component->getName());
         $tpl->setVariable("SIZE", $component->getSize());
 

--- a/src/UI/templates/default/Symbol/tpl.icon.html
+++ b/src/UI/templates/default/Symbol/tpl.icon.html
@@ -1,5 +1,5 @@
 
-<img
+<img<!-- BEGIN with_id --> id="{ID}"<!-- END with_id -->
  class="icon {NAME} {SIZE}<!-- BEGIN disabled --> disabled<!-- END disabled --><!-- BEGIN outlined --> outlined<!-- END outlined -->"
  src="{CUSTOMIMAGE}" alt="{ALT}"
 <!-- BEGIN aria_disabled --> aria-disabled="true"<!-- END aria_disabled -->

--- a/tests/UI/Component/Symbol/Icon/IconTest.php
+++ b/tests/UI/Component/Symbol/Icon/IconTest.php
@@ -195,4 +195,17 @@ imgtag;
             $this->assertTrue(file_exists($path), "Missing Outlined Icon: " . $path);
         }
     }
+    
+    /**
+     * @depends testRenderingStandard
+     */
+    public function testRenderingStandardJSBindable($ico)
+    {
+        $ico = $ico->withAdditionalOnLoadCode(function ($id) {
+            return 'alert();';
+        });
+        $html = $this->normalizeHTML($this->getDefaultRenderer()->render($ico));
+        $expected = $this->normalizeHTML('<img id="id_1" class="icon crs medium" src="./templates/default/images/icon_crs.svg" alt="Course"/>');
+        $this->assertEquals($expected, $html);
+    }
 }


### PR DESCRIPTION
… holders are missing)

The UI `Icon` is `JavaScriptBindable` but did not implement an ID in its template, this causes e.g. https://mantis.ilias.de/view.php?id=31865