### PR TITLE
Fix/wrong header check

### DIFF
--- a/Modules/RemoteCategory/classes/class.ilObjRemoteCategory.php
+++ b/Modules/RemoteCategory/classes/class.ilObjRemoteCategory.php
@@ -32,12 +32,12 @@ class ilObjRemoteCategory extends ilRemoteObjectBase
         $this->type = "rcat";
     }
     
-    protected function getTableName()
+    protected function getTableName() : string
     {
         return self::DB_TABLE_NAME;
     }
     
-    protected function getECSObjectType()
+    protected function getECSObjectType() : string
     {
         return "/campusconnect/categories";
     }

--- a/Modules/RemoteCourse/classes/class.ilObjRemoteCourse.php
+++ b/Modules/RemoteCourse/classes/class.ilObjRemoteCourse.php
@@ -40,12 +40,12 @@ class ilObjRemoteCourse extends ilRemoteObjectBase
         $this->type = "rcrs";
     }
     
-    protected function getTableName()
+    protected function getTableName() : string
     {
         return self::DB_TABLE_NAME;
     }
     
-    protected function getECSObjectType()
+    protected function getECSObjectType() : string
     {
         return "/campusconnect/courselinks";
     }
@@ -141,7 +141,7 @@ class ilObjRemoteCourse extends ilRemoteObjectBase
         return false;
     }
     
-    protected function doCreateCustomFields(array &$a_fields)
+    protected function doCreateCustomFields(array &$a_fields) : void
     {
         $a_fields["availability_type"] = array("integer", 0);
         $a_fields["r_start"] = array("integer", 0);

--- a/Modules/RemoteFile/classes/class.ilObjRemoteFile.php
+++ b/Modules/RemoteFile/classes/class.ilObjRemoteFile.php
@@ -35,12 +35,12 @@ class ilObjRemoteFile extends ilRemoteObjectBase
         $this->type = "rfil";
     }
     
-    protected function getTableName()
+    protected function getTableName() : string
     {
         return self::DB_TABLE_NAME;
     }
     
-    protected function getECSObjectType()
+    protected function getECSObjectType() : string
     {
         return "/campusconnect/files";
     }
@@ -85,7 +85,7 @@ class ilObjRemoteFile extends ilRemoteObjectBase
         return $this->version_tstamp;
     }
     
-    protected function doCreateCustomFields(array &$a_fields)
+    protected function doCreateCustomFields(array &$a_fields) : void
     {
         $a_fields["version"] = array("integer", 1);
         $a_fields["version_tstamp"] = array("integer", time());

--- a/Modules/RemoteGlossary/classes/class.ilObjRemoteGlossary.php
+++ b/Modules/RemoteGlossary/classes/class.ilObjRemoteGlossary.php
@@ -37,12 +37,12 @@ class ilObjRemoteGlossary extends ilRemoteObjectBase
         $this->type = "rglo";
     }
     
-    protected function getTableName()
+    protected function getTableName() : string
     {
         return self::DB_TABLE_NAME;
     }
     
-    protected function getECSObjectType()
+    protected function getECSObjectType() : string
     {
         return "/campusconnect/glossaries";
     }
@@ -95,7 +95,7 @@ class ilObjRemoteGlossary extends ilRemoteObjectBase
         return false;
     }
     
-    protected function doCreateCustomFields(array &$a_fields)
+    protected function doCreateCustomFields(array &$a_fields) : void
     {
         $a_fields["availability_type"] = array("integer", 0);
     }

--- a/Modules/RemoteGroup/classes/class.ilObjRemoteGroup.php
+++ b/Modules/RemoteGroup/classes/class.ilObjRemoteGroup.php
@@ -41,12 +41,12 @@ class ilObjRemoteGroup extends ilRemoteObjectBase
         $this->type = "rgrp";
     }
     
-    protected function getTableName()
+    protected function getTableName() : string
     {
         return self::DB_TABLE_NAME;
     }
     
-    protected function getECSObjectType()
+    protected function getECSObjectType() : string
     {
         return "/campusconnect/groups";
     }
@@ -142,7 +142,7 @@ class ilObjRemoteGroup extends ilRemoteObjectBase
         return false;
     }
     
-    protected function doCreateCustomFields(array &$a_fields)
+    protected function doCreateCustomFields(array &$a_fields) : void
     {
         $a_fields["availability_type"] = array("integer", 0);
         $a_fields["availability_start"] = array("integer", 0);

--- a/Modules/RemoteLearningModule/classes/class.ilObjRemoteLearningModule.php
+++ b/Modules/RemoteLearningModule/classes/class.ilObjRemoteLearningModule.php
@@ -37,12 +37,12 @@ class ilObjRemoteLearningModule extends ilRemoteObjectBase
         $this->type = "rlm";
     }
     
-    protected function getTableName()
+    protected function getTableName() : string
     {
         return self::DB_TABLE_NAME;
     }
     
-    protected function getECSObjectType()
+    protected function getECSObjectType() : string
     {
         return "/campusconnect/learningmodules";
     }
@@ -95,7 +95,7 @@ class ilObjRemoteLearningModule extends ilRemoteObjectBase
         return false;
     }
     
-    protected function doCreateCustomFields(array &$a_fields)
+    protected function doCreateCustomFields(array &$a_fields) : void
     {
         $a_fields["availability_type"] = array("integer", 0);
     }

--- a/Modules/RemoteTest/classes/class.ilObjRemoteTest.php
+++ b/Modules/RemoteTest/classes/class.ilObjRemoteTest.php
@@ -40,12 +40,12 @@ class ilObjRemoteTest extends ilRemoteObjectBase
         $this->type = "rtst";
     }
     
-    protected function getTableName()
+    protected function getTableName() : string
     {
         return self::DB_TABLE_NAME;
     }
     
-    protected function getECSObjectType()
+    protected function getECSObjectType() : string
     {
         return "/campusconnect/tests";
     }
@@ -141,7 +141,7 @@ class ilObjRemoteTest extends ilRemoteObjectBase
         return false;
     }
     
-    protected function doCreateCustomFields(array &$a_fields)
+    protected function doCreateCustomFields(array &$a_fields) : void
     {
         $a_fields["availability_type"] = array("integer", 0);
         $a_fields["availability_start"] = array("integer", 0);

--- a/Modules/RemoteWiki/classes/class.ilObjRemoteWiki.php
+++ b/Modules/RemoteWiki/classes/class.ilObjRemoteWiki.php
@@ -37,12 +37,12 @@ class ilObjRemoteWiki extends ilRemoteObjectBase
         $this->type = "rwik";
     }
     
-    protected function getTableName()
+    protected function getTableName() : string
     {
         return self::DB_TABLE_NAME;
     }
     
-    protected function getECSObjectType()
+    protected function getECSObjectType() : string
     {
         return "/campusconnect/wikis";
     }
@@ -95,7 +95,7 @@ class ilObjRemoteWiki extends ilRemoteObjectBase
         return false;
     }
     
-    protected function doCreateCustomFields(array &$a_fields)
+    protected function doCreateCustomFields(array &$a_fields) : void
     {
         $a_fields["availability_type"] = array("integer", 0);
     }

--- a/Services/WebServices/Curl/classes/class.ilCurlConnection.php
+++ b/Services/WebServices/Curl/classes/class.ilCurlConnection.php
@@ -177,7 +177,7 @@ class ilCurlConnection
     {
         $len = strlen($header);
         $header = explode(':', $header, 2);
-        if (count($header) < 2) { // ignore invalid headers
+        if (count($header) == 2) { // ignore invalid headers
             $this->header_arr[strtolower(trim($header[0]))] = trim($header[1]);
         }
         return $len;

--- a/Services/WebServices/ECS/classes/Connectors/class.ilECSEnrolmentStatus.php
+++ b/Services/WebServices/ECS/classes/Connectors/class.ilECSEnrolmentStatus.php
@@ -17,7 +17,6 @@
 /**
  * Presentation of ecs enrolment status
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
- * $Id$
  */
 class ilECSEnrolmentStatus
 {

--- a/Services/WebServices/ECS/classes/Connectors/class.ilECSEnrolmentStatusCommandQueueHandler.php
+++ b/Services/WebServices/ECS/classes/Connectors/class.ilECSEnrolmentStatusCommandQueueHandler.php
@@ -15,8 +15,6 @@
  *****************************************************************************/
 
 /**
- * Description of class
- *
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
  */
 class ilECSEnrolmentStatusCommandQueueHandler implements ilECSCommandQueueHandler

--- a/Services/WebServices/ECS/classes/Connectors/class.ilECSEnrolmentStatusConnector.php
+++ b/Services/WebServices/ECS/classes/Connectors/class.ilECSEnrolmentStatusConnector.php
@@ -18,14 +18,9 @@
  * Connector for course member ressource
  *
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
- * $Id$
  */
 class ilECSEnrolmentStatusConnector extends ilECSConnector
 {
-    /**
-     * Constructor
-     * @param ilECSSetting $settings
-     */
     public function __construct(ilECSSetting $settings = null)
     {
         parent::__construct($settings);

--- a/Services/WebServices/ECS/classes/Course/class.ilECSCmsCourseMemberCommandQueueHandler.php
+++ b/Services/WebServices/ECS/classes/Course/class.ilECSCmsCourseMemberCommandQueueHandler.php
@@ -207,27 +207,22 @@ class ilECSCmsCourseMemberCommandQueueHandler implements ilECSCommandQueueHandle
      */
     protected function readAssignments($course, $course_member)
     {
-        $put_in_course = true;
-        
+        //TODO check if this switch is still needed
         switch ((int) $course->groupScenario) {
             case ilECSMappingUtils::PARALLEL_ONE_COURSE:
                 $this->log->debug('Parallel group scenario one course.');
-                $put_in_course = true;
                 break;
                 
             case ilECSMappingUtils::PARALLEL_GROUPS_IN_COURSE:
                 $this->log->debug('Parallel group scenario groups in courses.');
-                $put_in_course = false;
                 break;
                 
             case ilECSMappingUtils::PARALLEL_ALL_COURSES:
                 $this->log->debug('Parallel group scenario only courses.');
-                $put_in_course = false;
                 break;
-            
+
             default:
                 $this->log->debug('Parallel group scenario undefined.');
-                $put_in_course = true;
                 break;
         }
         
@@ -438,7 +433,6 @@ class ilECSCmsCourseMemberCommandQueueHandler implements ilECSCommandQueueHandle
     
     /**
      * Create user account
-     * @param type $a_person_id
      */
     private function createMember($a_person_id)
     {
@@ -483,7 +477,6 @@ class ilECSCmsCourseMemberCommandQueueHandler implements ilECSCommandQueueHandle
 
     /**
      * Read course from ecs
-     * @return boolean
      */
     private function readCourseMember(ilECSSetting $server, $a_content_id)
     {
@@ -499,7 +492,6 @@ class ilECSCmsCourseMemberCommandQueueHandler implements ilECSCommandQueueHandle
     
     /**
      * Read course from ecs
-     * @return boolean
      */
     private function readCourse($course_member)
     {

--- a/Services/WebServices/ECS/classes/Course/class.ilECSCourseConnector.php
+++ b/Services/WebServices/ECS/classes/Course/class.ilECSCourseConnector.php
@@ -15,18 +15,10 @@
  *****************************************************************************/
 
 /**
- *
- *
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
- * $Id$
  */
 class ilECSCourseConnector extends ilECSConnector
 {
-
-    /**
-     * Constructor
-     * @param ilECSSetting $settings
-     */
     public function __construct(ilECSSetting $settings = null)
     {
         parent::__construct($settings);

--- a/Services/WebServices/ECS/classes/Course/class.ilECSCourseLmsUrl.php
+++ b/Services/WebServices/ECS/classes/Course/class.ilECSCourseLmsUrl.php
@@ -18,7 +18,6 @@
  * Represents a ecs course lms url
  *
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
- * $Id$
  */
 class ilECSCourseLmsUrl
 {
@@ -26,17 +25,9 @@ class ilECSCourseLmsUrl
     public string $url = '';
     
     /**
-     * Constructor
-     */
-    public function __construct()
-    {
-    }
-    
-    /**
      * Set title
-     * @param type $a_title
      */
-    public function setTitle($a_title)
+    public function setTitle(string $a_title) : void
     {
         $this->title = $a_title;
     }
@@ -44,7 +35,7 @@ class ilECSCourseLmsUrl
     /**
      * Set url
      */
-    public function setUrl($a_url)
+    public function setUrl(string $a_url)
     {
         $this->url = $a_url;
     }

--- a/Services/WebServices/ECS/classes/Course/class.ilECSCourseMappingRule.php
+++ b/Services/WebServices/ECS/classes/Course/class.ilECSCourseMappingRule.php
@@ -27,7 +27,7 @@ class ilECSCourseMappingRule
     private ilLanguage $lng;
     private ilDBInterface $db;
     
-    private $rid;
+    private int $rid;
     private $sid;
     private $mid;
     private $attribute;
@@ -39,11 +39,7 @@ class ilECSCourseMappingRule
     private int $subdir_type = self::SUBDIR_VALUE;
     private string $directory = '';
     
-    /**
-     * Constructor
-     * @param int $a_rid
-     */
-    public function __construct($a_rid = 0)
+    public function __construct(int $a_rid = 0)
     {
         global $DIC;
         
@@ -58,10 +54,9 @@ class ilECSCourseMappingRule
     
     /**
      * Lookup existing attributes
-     * @param type $a_attributes
      * @return array
      */
-    public static function lookupLastExistingAttribute($a_sid, $a_mid, $a_ref_id)
+    public static function lookupLastExistingAttribute(int $a_sid, int $a_mid, int $a_ref_id)
     {
         global $DIC;
 
@@ -81,12 +76,7 @@ class ilECSCourseMappingRule
         return $attributes;
     }
     
-    /**
-     *
-     * @param type $a_sid
-     * @param type $a_mid
-     */
-    public static function getRuleRefIds($a_sid, $a_mid)
+    public static function getRuleRefIds(int $a_sid, int $a_mid)
     {
         global $DIC;
 
@@ -121,7 +111,7 @@ class ilECSCourseMappingRule
      * @param type $a_ref_id
      * @return int[]
      */
-    public static function getRulesOfRefId($a_sid, $a_mid, $a_ref_id)
+    public static function getRulesOfRefId(int $a_sid, int $a_mid, int $a_ref_id) : array
     {
         global $DIC;
 
@@ -132,14 +122,14 @@ class ilECSCourseMappingRule
                 'AND mid = ' . $ilDB->quote($a_mid, 'integer') . ' ' .
                 'AND ref_id = ' . $ilDB->quote($a_ref_id, 'integer');
         $res = $ilDB->query($query);
-        $rids = array();
+        $rids = [];
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             $rids = $row->rid;
         }
-        return (array) $rids;
+        return $rids;
     }
     
-    public static function hasRules($a_sid, $a_mid, $a_ref_id)
+    public static function hasRules(int $a_sid, int $a_mid, int $a_ref_id) : bool
     {
         global $DIC;
 

--- a/Services/WebServices/ECS/classes/Course/class.ilECSCourseMemberConnector.php
+++ b/Services/WebServices/ECS/classes/Course/class.ilECSCourseMemberConnector.php
@@ -18,14 +18,9 @@
  * Connector for course member ressource
  *
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
- * $Id$
  */
 class ilECSCourseMemberConnector extends ilECSConnector
 {
-    /**
-     * Constructor
-     * @param ilECSSetting $settings
-     */
     public function __construct(ilECSSetting $settings = null)
     {
         parent::__construct($settings);
@@ -36,7 +31,7 @@ class ilECSCourseMemberConnector extends ilECSConnector
      * Get single directory tree
      * @return array an array of ecs cms directory tree entries
      */
-    public function getCourseMember($course_member_id, $a_details = false)
+    public function getCourseMember($course_member_id, bool $a_details = false)
     {
         $this->path_postfix = '/campusconnect/course_members/' . (int) $course_member_id;
         

--- a/Services/WebServices/ECS/classes/Course/class.ilECSCourseUrl.php
+++ b/Services/WebServices/ECS/classes/Course/class.ilECSCourseUrl.php
@@ -18,7 +18,6 @@
  * Represents a ecs course url
  *
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
- * $Id$
  */
 class ilECSCourseUrl
 {
@@ -31,10 +30,6 @@ class ilECSCourseUrl
     public string $ecs_course_url = '';
     public ?array $lms_course_urls = null;
     
-    
-    /**
-     * Constructor
-     */
     public function __construct()
     {
         global $DIC;
@@ -44,25 +39,22 @@ class ilECSCourseUrl
     
     /**
      * Set lecture id
-     * @param type $a_id
      */
-    public function setCmsLectureId($a_id)
+    public function setCmsLectureId(string $a_id)
     {
         $this->cms_lecture_id = $a_id;
     }
     
     /**
      * Set ecs course id
-     * @param int $a_id
      */
-    public function setECSId($a_id)
+    public function setECSId(int $a_id)
     {
         $this->ecs_course_url = self::COURSE_URL_PREFIX . $a_id;
     }
     
     /**
      * Add lms url
-     * @param ilECSCourseLmsUrl $lms_url
      */
     public function addLmsCourseUrls(ilECSCourseLmsUrl $lms_url = null)
     {

--- a/Services/WebServices/ECS/classes/Course/class.ilECSCourseUrlConnector.php
+++ b/Services/WebServices/ECS/classes/Course/class.ilECSCourseUrlConnector.php
@@ -18,14 +18,9 @@
  * Connector for writing ecs course urls
  *
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
- * $Id$
  */
 class ilECSCourseUrlConnector extends ilECSConnector
 {
-    /**
-     * Constructor
-     * @param ilECSSetting $settings
-     */
     public function __construct(ilECSSetting $settings = null)
     {
         parent::__construct($settings);
@@ -33,7 +28,6 @@ class ilECSCourseUrlConnector extends ilECSConnector
     
     /**
      * Send url of newly created courses to ecs
-     * @return type
      * @throws ilECSConnectorException
      */
     public function addUrl(ilECSCourseUrl $url, $a_target_mid)
@@ -55,7 +49,7 @@ class ilECSCourseUrlConnector extends ilECSConnector
             
             $this->logger->debug('Sending url ' . print_r(json_encode($url), true));
             
-            $ret = $this->call();
+            $this->call();
 
             $info = $this->curl->getInfo(CURLINFO_HTTP_CODE);
     

--- a/Services/WebServices/ECS/classes/Mapping/class.ilECSMappingSettingsGUI.php
+++ b/Services/WebServices/ECS/classes/Mapping/class.ilECSMappingSettingsGUI.php
@@ -18,9 +18,6 @@
  * Class for ECS node and directory mapping settings
  *
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
- * @version $ID$
- *
- * @ingroup ServicesWebServicesECS
  * @ilCtrl_isCalledBy ilECSMappingSettingsGUI: ilECSSettingsGUI
  */
 class ilECSMappingSettingsGUI
@@ -28,9 +25,6 @@ class ilECSMappingSettingsGUI
     const TAB_DIRECTORY = 1;
     const TAB_COURSE = 2;
     
-    /**
-     * @var ilLogger
-     */
     protected ilLogger $log;
     protected ilLanguage $lng;
     protected ilCtrl $ctrl;
@@ -612,7 +606,7 @@ class ilECSMappingSettingsGUI
             $settings->setAuthMode($form->getInput('auth_mode'));
 
             $role_mappings = array();
-            foreach (ilECSMappingUtils::getRoleMappingInfo() as $name => $info) {
+            foreach (ilECSMappingUtils::getRoleMappingInfo() as $name) {
                 $role_mappings[$name] = $form->getInput((string) $name);
             }
             $settings->setRoleMappings($role_mappings);
@@ -1042,7 +1036,7 @@ class ilECSMappingSettingsGUI
         $explorer->setPostVar('rnodes[]');
 
         // Read checked items from mapping of checked items in local explorer
-        $active_node = $this->tree->getRootId();
+//         $active_node = $this->tree->getRootId();
         foreach ($localExplorer->getCheckedItems() as $ref_id) {
             $explorer->setCheckedItems(
                 ilECSNodeMappingAssignments::lookupMappedItemsForRefId(
@@ -1052,20 +1046,20 @@ class ilECSMappingSettingsGUI
                     $ref_id
                 )
             );
-            $active_node = $ref_id;
+//             $active_node = $ref_id;
         }
 
-        $cmsTree = new ilECSCmsTree((int) $_REQUEST['tid']);
-        foreach (ilECSNodeMappingAssignments::lookupAssignmentsByRefId(
-            $this->getServer()->getServerId(),
-            $this->getMid(),
-            (int) $_REQUEST['tid'],
-            $active_node
-        ) as $cs_id) {
-            foreach ($cmsTree->getPathId($cs_id) as $path_id) {
-                #$explorer->setExpand($path_id);
-            }
-        }
+//         $cmsTree = new ilECSCmsTree((int) $_REQUEST['tid']);
+//         foreach (ilECSNodeMappingAssignments::lookupAssignmentsByRefId(
+//             $this->getServer()->getServerId(),
+//             $this->getMid(),
+//             (int) $_REQUEST['tid'],
+//             $active_node
+//         ) as $cs_id) {
+//             foreach ($cmsTree->getPathId($cs_id) as $path_id) {
+//                 #$explorer->setExpand($path_id);
+//             }
+//         }
 
         $explorer->setTargetGet('rref_id');
         $explorer->setSessionExpandVariable('rexpand');
@@ -1222,9 +1216,6 @@ class ilECSMappingSettingsGUI
             );
         }
         if ($a_tab == self::TAB_COURSE) {
-            // Check if attributes are available
-            $atts = ilECSCourseAttributes::getInstance($this->getServer()->getServerId(), $this->getMid());
-
             if (ilECSNodeMappingSettings::getInstanceByServerMid($this->getServer()->getServerId(), $this->getMid())->isCourseAllocationEnabled()) {
                 $this->tabs->addSubTab(
                     'cInitTree',

--- a/Services/WebServices/ECS/classes/Mapping/class.ilECSMappingUtils.php
+++ b/Services/WebServices/ECS/classes/Mapping/class.ilECSMappingUtils.php
@@ -18,7 +18,6 @@
  * Mapping utils
  *
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
- * $Id$
  */
 class ilECSMappingUtils
 {

--- a/Services/WebServices/ECS/classes/Mapping/class.ilECSNodeMappingAssignment.php
+++ b/Services/WebServices/ECS/classes/Mapping/class.ilECSNodeMappingAssignment.php
@@ -15,10 +15,7 @@
  *****************************************************************************/
 
 /**
- *
- *
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
- * $Id$
  */
 class ilECSNodeMappingAssignment
 {

--- a/Services/WebServices/ECS/classes/Mapping/class.ilECSNodeMappingAssignments.php
+++ b/Services/WebServices/ECS/classes/Mapping/class.ilECSNodeMappingAssignments.php
@@ -15,10 +15,7 @@
  *****************************************************************************/
 
 /**
- *
- *
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
- * $Id$
  */
 class ilECSNodeMappingAssignments
 {
@@ -32,6 +29,9 @@ class ilECSNodeMappingAssignments
     {
         global $DIC;
 
+        /**
+         * @var ilDBInterface $ilDB
+         */
         $ilDB = $DIC['ilDB'];
         
         $query = 'SELECT ref_id FROM ecs_node_mapping_a ' .
@@ -40,10 +40,7 @@ class ilECSNodeMappingAssignments
             'AND cs_root = ' . $ilDB->quote($a_tree_id, 'integer') . ' ' .
             'AND ref_id > 0';
         $res = $ilDB->query($query);
-        while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            return true;
-        }
-        return false;
+        return $res->rowCount() > 0;
     }
     
     /**

--- a/Services/WebServices/ECS/classes/Mapping/class.ilECSNodeMappingCmsExplorer.php
+++ b/Services/WebServices/ECS/classes/Mapping/class.ilECSNodeMappingCmsExplorer.php
@@ -18,7 +18,6 @@
  * Explorer for ILIAS tree
  *
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
- * $Id$
  */
 class ilECSNodeMappingCmsExplorer extends ilExplorer
 {
@@ -215,14 +214,16 @@ class ilECSNodeMappingCmsExplorer extends ilExplorer
             }
 
             $tpl->setVariable("LINK_NAME", $a_node_id);
-            $tpl->setVariable("TITLE",
+            $tpl->setVariable(
+                "TITLE",
                 ilStr::shortenTextExtended(
                     $this->buildTitle($a_option["title"], $a_node_id, $a_option["type"]),
                     $this->textwidth,
                     true
                 )
             );
-            $tpl->setVariable("DESC",
+            $tpl->setVariable(
+                "DESC",
                 ilStr::shortenTextExtended(
                     $this->buildDescription($a_option["description"], $a_node_id, $a_option["type"]),
                     $this->textwidth,
@@ -236,14 +237,16 @@ class ilECSNodeMappingCmsExplorer extends ilExplorer
             $tpl->parseCurrentBlock();
         } else {			// output text only
             $tpl->setCurrentBlock("text");
-            $tpl->setVariable("OBJ_TITLE",
+            $tpl->setVariable(
+                "OBJ_TITLE",
                 ilStr::shortenTextExtended(
                     $this->buildTitle($a_option["title"], $a_node_id, $a_option["type"]),
                     $this->textwidth,
                     true
                 )
             );
-            $tpl->setVariable("OBJ_DESC",
+            $tpl->setVariable(
+                "OBJ_DESC",
                 ilStr::shortenTextExtended(
                     $this->buildDescription($a_option["desc"], $a_node_id, $a_option["type"]),
                     $this->textwidth,

--- a/Services/WebServices/ECS/classes/Mapping/class.ilECSNodeMappingLocalExplorer.php
+++ b/Services/WebServices/ECS/classes/Mapping/class.ilECSNodeMappingLocalExplorer.php
@@ -18,7 +18,6 @@
  * Explorer for ILIAS tree
  *
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
- * $Id$
  */
 class ilECSNodeMappingLocalExplorer extends ilExplorer
 {
@@ -224,7 +223,8 @@ class ilECSNodeMappingLocalExplorer extends ilExplorer
                 "TITLE",
                 $this->buildTitle($a_option["title"], $a_node_id, $a_option["type"])
             );
-            $tpl->setVariable("DESC",
+            $tpl->setVariable(
+                "DESC",
                 ilStr::shortenTextExtended(
                     $this->buildDescription($a_option["description"], $a_node_id, $a_option["type"]),
                     $this->textwidth,
@@ -242,7 +242,8 @@ class ilECSNodeMappingLocalExplorer extends ilExplorer
                 "OBJ_TITLE",
                 $this->buildTitle($a_option["title"], $a_node_id, $a_option["type"])
             );
-            $tpl->setVariable("OBJ_DESC",
+            $tpl->setVariable(
+                "OBJ_DESC",
                 ilStr::shortenTextExtended(
                     $this->buildDescription($a_option["desc"], $a_node_id, $a_option["type"]),
                     $this->textwidth,
@@ -327,7 +328,7 @@ class ilECSNodeMappingLocalExplorer extends ilExplorer
             $mappings[$ref_id] = array();
         }
         
-        foreach ($mappings as $ref_id => $tmp) {
+        foreach ($mappings as $ref_id) {
             $this->mappings[$ref_id] = $this->tree->getPathId($ref_id, 1);
         }
         return true;
@@ -340,7 +341,7 @@ class ilECSNodeMappingLocalExplorer extends ilExplorer
     
     protected function hasParentMapping($a_ref_id)
     {
-        foreach ($this->mappings as $ref_id => $parent_nodes) {
+        foreach (array_values($this->mappings) as $parent_nodes) {
             if (in_array($a_ref_id, $parent_nodes)) {
                 return true;
             }

--- a/Services/WebServices/ECS/classes/Mapping/class.ilECSNodeMappingTreeTableGUI.php
+++ b/Services/WebServices/ECS/classes/Mapping/class.ilECSNodeMappingTreeTableGUI.php
@@ -18,7 +18,6 @@
  * Table GUI for ecs trees
  *
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
- * $Id$
  */
 class ilECSNodeMappingTreeTableGUI extends ilTable2GUI
 {

--- a/Services/WebServices/ECS/classes/Tree/class.ilECSCmsData.php
+++ b/Services/WebServices/ECS/classes/Tree/class.ilECSCmsData.php
@@ -15,9 +15,7 @@
  *****************************************************************************/
 
 /**
- *
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
- * $Id$
  */
 class ilECSCmsData
 {

--- a/Services/WebServices/ECS/classes/Tree/class.ilECSCmsTree.php
+++ b/Services/WebServices/ECS/classes/Tree/class.ilECSCmsTree.php
@@ -15,14 +15,11 @@
  *****************************************************************************/
 
 /**
- *
- *
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
- * $Id$
  */
 class ilECSCmsTree extends ilTree
 {
-    public function __construct($a_tree_id)
+    public function __construct(int $a_tree_id)
     {
         parent::__construct($a_tree_id, self::lookupRootId($a_tree_id));
 

--- a/Services/WebServices/ECS/classes/Tree/class.ilECSCmsTreeCommandQueueHandler.php
+++ b/Services/WebServices/ECS/classes/Tree/class.ilECSCmsTreeCommandQueueHandler.php
@@ -15,8 +15,6 @@
  *****************************************************************************/
 
 /**
- * Description of class
- *
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
  */
 class ilECSCmsTreeCommandQueueHandler implements ilECSCommandQueueHandler
@@ -26,10 +24,6 @@ class ilECSCmsTreeCommandQueueHandler implements ilECSCommandQueueHandler
     private ?\ilECSSetting $server = null;
     private int $mid = 0;
     
-    
-    /**
-     * Constructor
-     */
     public function __construct(ilECSSetting $server)
     {
         global $DIC;
@@ -41,9 +35,8 @@ class ilECSCmsTreeCommandQueueHandler implements ilECSCommandQueueHandler
     
     /**
      * Get server
-     * @return ilECSServerSetting
      */
-    public function getServer()
+    public function getServer() : ilECSSetting
     {
         return $this->server;
     }
@@ -51,7 +44,6 @@ class ilECSCmsTreeCommandQueueHandler implements ilECSCommandQueueHandler
 
     /**
      * Handle create
-     * @param ilECSSetting $server
      * @param type $a_content_id
      */
     public function handleCreate(ilECSSetting $server, $a_content_id)
@@ -268,7 +260,7 @@ class ilECSCmsTreeCommandQueueHandler implements ilECSCommandQueueHandler
         
         foreach ((array) $deleted as $obj_id) {
             $parent = 0;
-            foreach ((array) $old_nodes as $tmp_id => $node) {
+            foreach (array_values($old_nodes) as $node) {
                 if ($node['child'] == $obj_id) {
                     $parent = $node['parent'];
                     break;

--- a/Services/WebServices/ECS/classes/class.ilAuthProviderECS.php
+++ b/Services/WebServices/ECS/classes/class.ilAuthProviderECS.php
@@ -18,7 +18,6 @@
  * Auth prvider for ecs auth
  *
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
- *
  */
 class ilAuthProviderECS extends ilAuthProvider implements ilAuthProviderInterface
 {
@@ -64,8 +63,6 @@ class ilAuthProviderECS extends ilAuthProvider implements ilAuthProviderInterfac
     
     /**
      * get mid
-     *
-     * @access public
      */
     public function getMID() : int
     {
@@ -79,16 +76,14 @@ class ilAuthProviderECS extends ilAuthProvider implements ilAuthProviderInterfac
 
     /**
      * Set current server
-     * @param ilECSSetting $server
      */
-    public function setCurrentServer(ilECSSetting $server = null)
+    public function setCurrentServer(ilECSSetting $server) : void
     {
         $this->currentServer = $server;
     }
 
     /**
      * Get current server
-     * @return ilECSSetting
      */
     public function getCurrentServer() : ilECSSetting
     {
@@ -97,7 +92,6 @@ class ilAuthProviderECS extends ilAuthProvider implements ilAuthProviderInterfac
 
     /**
      * Get server settings
-     * @return ilECSServerSettings
      */
     public function getServerSettings() : ilECSServerSettings
     {
@@ -107,8 +101,6 @@ class ilAuthProviderECS extends ilAuthProvider implements ilAuthProviderInterfac
 
     /**
      * Try ecs authentication
-     * @param \ilAuthStatus $status
-     * @return boolean
      */
     public function doAuthentication(\ilAuthStatus $status) : bool
     {
@@ -140,8 +132,6 @@ class ilAuthProviderECS extends ilAuthProvider implements ilAuthProviderInterfac
     
     /**
      * Called from base class after successful login
-     *
-     * @param string username
      */
     public function handleLogin()
     {
@@ -174,13 +164,8 @@ class ilAuthProviderECS extends ilAuthProvider implements ilAuthProviderInterfac
     
     /**
      * Validate ECS hash
-     *
-     * @access public
-     * @param string username
-     * @param string pass
-     *
      */
-    public function validateHash()
+    public function validateHash() : bool
     {
         // fetch hash
         if (isset($_GET['ecs_hash']) and strlen($_GET['ecs_hash'])) {
@@ -189,7 +174,6 @@ class ilAuthProviderECS extends ilAuthProvider implements ilAuthProviderInterfac
         if (isset($_GET['ecs_hash_url'])) {
             $hashurl = urldecode($_GET['ecs_hash_url']);
             $hash = basename(parse_url($hashurl, PHP_URL_PATH));
-            //$hash = urldecode($_GET['ecs_hash_url']);
         }
         
         $this->getLogger()->info('Using ecs hash: ' . $hash);
@@ -246,21 +230,16 @@ class ilAuthProviderECS extends ilAuthProvider implements ilAuthProviderInterfac
     
     /**
      * Init ECS Services
-     * @access private
-     * @param
-     *
      */
-    private function initECSServices()
+    private function initECSServices() : void
     {
         $this->servers = ilECSServerSettings::getInstance();
     }
     
     /**
      * create new user
-     *
-     * @access protected
      */
-    protected function createUser(ilECSUser $user)
+    protected function createUser(ilECSUser $user) : string
     {
         $userObj = new ilObjUser();
         $userObj->setOwner(SYSTEM_USER_ID);
@@ -294,9 +273,6 @@ class ilAuthProviderECS extends ilAuthProvider implements ilAuthProviderInterfac
         $userObj->setTimeLimitFrom(time() - 5);
         $userObj->setTimeLimitUntil(time() + $this->clientIniFile->readVariable("session", "expire"));
 
-        #$now = new ilDateTime(time(), IL_CAL_UNIX);
-        #$userObj->setAgreeDate($now->get(IL_CAL_DATETIME));
-
         // Create user in DB
         $userObj->setOwner(6);
         $userObj->create();
@@ -321,10 +297,8 @@ class ilAuthProviderECS extends ilAuthProvider implements ilAuthProviderInterfac
     
     /**
      * update existing user
-     *
-     * @access protected
      */
-    protected function updateUser(ilECSUser $user, $a_local_user_id)
+    protected function updateUser(ilECSUser $user, int $a_local_user_id) : string
     {
         $user_obj = new ilObjUser($a_local_user_id);
         $user_obj->setFirstname($user->getFirstname());
@@ -360,7 +334,7 @@ class ilAuthProviderECS extends ilAuthProvider implements ilAuthProviderInterfac
      * Reset mail options to "local only"
      *
      */
-    protected function resetMailOptions($a_usr_id)
+    protected function resetMailOptions(int $a_usr_id) : void
     {
         $options = new ilMailOptions($a_usr_id);
         $options->setIncomingType(ilMailOptions::INCOMING_LOCAL);

--- a/Services/WebServices/ECS/classes/class.ilECSAppEventListener.php
+++ b/Services/WebServices/ECS/classes/class.ilECSAppEventListener.php
@@ -17,11 +17,6 @@
 /**
  * ECS Event Handler
  * @author Stefan Meyer <meyer@leifos.com>
- * @version $Id$
- *
- *
- * @ilCtrl_Calls
- * @ingroup ServicesWebServicesECS
  */
 class ilECSAppEventListener implements ilAppEventListener
 {
@@ -227,7 +222,7 @@ class ilECSAppEventListener implements ilAppEventListener
      */
     private function handleMembership(ilObjUser $user)
     {
-        $this->log->debug('Handling ECS assignments ');
+        $this->logger->debug('Handling ECS assignments ');
         
         $assignments = ilECSCourseMemberAssignment::lookupMissingAssignmentsOfUser($user->getExternalAccount());
         foreach ($assignments as $assignment) {
@@ -236,11 +231,11 @@ class ilECSAppEventListener implements ilAppEventListener
                 $assignment->getMid()
             );
             if ($user->getAuthMode() == $msettings->getAuthMode()) {
-                $this->log->info('Adding user ' . $assignment->getUid() . ' to course/group: ' . $assignment->getObjId());
+                $this->logger->info('Adding user ' . $assignment->getUid() . ' to course/group: ' . $assignment->getObjId());
                 $obj_type = ilObject::_lookupType($assignment->getObjId());
                 if ($obj_type !== 'crs' && $obj_type !== 'grp') {
-                    $this->log->error('Invalid assignment type: ' . $obj_type);
-                    $this->log->logStack(ilLogLevel::ERROR);
+                    $this->logger->error('Invalid assignment type: ' . $obj_type);
+                    $this->logger->logStack(ilLogLevel::ERROR);
                     continue;
                 }
                 $refs = ilObject::_getAllReferences($assignment->getObjId());
@@ -254,12 +249,12 @@ class ilECSAppEventListener implements ilAppEventListener
                         $part->add($user->getId(), ilParticipants::IL_GRP_MEMBER);
                     }
                 } catch (InvalidArgumentException $e) {
-                    $this->log->error('Invalid ref_id given: ' . (int) $ref_id);
-                    $this->log->logStack(ilLogLevel::ERROR);
+                    $this->logger->error('Invalid ref_id given: ' . (int) $ref_id);
+                    $this->logger->logStack(ilLogLevel::ERROR);
                     continue;
                 }
             } else {
-                $this->log->notice('Auth mode of user: ' . $user->getAuthMode() . ' conflicts ' . $msettings->getAuthMode());
+                $this->logger->notice('Auth mode of user: ' . $user->getAuthMode() . ' conflicts ' . $msettings->getAuthMode());
             }
         }
     }

--- a/Services/WebServices/ECS/classes/class.ilECSAuth.php
+++ b/Services/WebServices/ECS/classes/class.ilECSAuth.php
@@ -15,36 +15,19 @@
  *****************************************************************************/
 
 /**
-*
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*
-* @ilCtrl_Calls
-* @ingroup ServicesWebServicesECS
 */
 class ilECSAuth
 {
     protected ilLogger $log;
     protected array $mids = array();
 
-    //public $url;
-    public $realm;
-    #	public $hash;
-    #	public $sov;
-    #	public $eov;
-    #	public $url;
-    #	public $abbr;
-    #	public $pid;
-    
+    private string $realm = '';
+    private string $url = '';
+    private ?int $pid = null;
+    private $sov;
+    private $eov;
 
-    /**
-     * constuctor
-     *
-     * @access public
-     * @param
-     *
-     */
     public function __construct()
     {
         global $DIC;
@@ -52,51 +35,40 @@ class ilECSAuth
         $this->log = $DIC->logger()->wsrv();
     }
     
-    public function setPid($a_pid)
+    public function setPid(int $a_pid) : void
     {
         $this->pid = $a_pid;
     }
     
-    public function getPid()
+    public function getPid() : int
     {
         return $this->pid;
     }
 
-    /**
-     * URL
-     * @param string $a_url
-     */
-    public function setUrl($a_url)
+    public function setUrl(string $a_url) : void
     {
         $this->url = $a_url;
     }
     
-    /**
-     * get Url
-     * @return <type>
-     */
-    public function getUrl()
+    public function getUrl() : string
     {
         return $this->url;
     }
     
-    public function setRealm($a_realm)
+    public function setRealm(string $a_realm) : void
     {
         $this->realm = $a_realm;
     }
     
-    public function getRealm()
+    public function getRealm() : string
     {
         return $this->realm;
     }
     
     /**
      * get hash
-     *
-     * @access public
-     *
      */
-    public function getHash()
+    public function getHash() : string
     {
         return $this->hash;
     }
@@ -104,11 +76,10 @@ class ilECSAuth
     /**
      * set SOV
      *
-     * @access public
      * @param int start of verification
      *
      */
-    public function setSOV($a_sov)
+    public function setSOV(int $a_sov) : void
     {
         $dt = new ilDateTime($a_sov, IL_CAL_UNIX);
         $this->sov = $dt->get(IL_CAL_ISO_8601);
@@ -117,13 +88,12 @@ class ilECSAuth
     /**
      * set EOV
      *
-     * @access public
-     * @param int eov of verification
+     * @param int end of verification
      *
      */
-    public function setEOV($a_eov)
+    public function setEOV(int $a_eov) : void
     {
         $dt = new ilDateTime($a_eov, IL_CAL_UNIX);
-        $this->sov = $dt->get(IL_CAL_ISO_8601);
+        $this->eov = $dt->get(IL_CAL_ISO_8601);
     }
 }

--- a/Services/WebServices/ECS/classes/class.ilECSCategoryMapping.php
+++ b/Services/WebServices/ECS/classes/class.ilECSCategoryMapping.php
@@ -15,13 +15,7 @@
  *****************************************************************************/
 
 /**
-*
-*
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*
-* @ingroup ServicesWebServicesECS
 */
 class ilECSCategoryMapping
 {

--- a/Services/WebServices/ECS/classes/class.ilECSCategoryMappingRule.php
+++ b/Services/WebServices/ECS/classes/class.ilECSCategoryMappingRule.php
@@ -18,10 +18,6 @@
 * Defines a rule for the assignment of ECS remote courses to categories.
 *
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*
-* @ingroup ServicesWebServicesECS
 */
 class ilECSCategoryMappingRule
 {

--- a/Services/WebServices/ECS/classes/class.ilECSCategoryMappingTableGUI.php
+++ b/Services/WebServices/ECS/classes/class.ilECSCategoryMappingTableGUI.php
@@ -18,10 +18,6 @@
 * Show active rules
 *
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*
-* @ingroup ServicesWebServicesECS
 */
 class ilECSCategoryMappingTableGUI extends ilTable2GUI
 {

--- a/Services/WebServices/ECS/classes/class.ilECSCommunitiesCache.php
+++ b/Services/WebServices/ECS/classes/class.ilECSCommunitiesCache.php
@@ -16,10 +16,6 @@
 
 /**
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*
-* @ingroup ServicesWebServicesECS
 */
 class ilECSCommunitiesCache
 {

--- a/Services/WebServices/ECS/classes/class.ilECSCommunity.php
+++ b/Services/WebServices/ECS/classes/class.ilECSCommunity.php
@@ -16,10 +16,6 @@
 
 /**
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*
-* @ingroup ServicesWebServicesECS
 */
 class ilECSCommunity
 {

--- a/Services/WebServices/ECS/classes/class.ilECSCommunityCache.php
+++ b/Services/WebServices/ECS/classes/class.ilECSCommunityCache.php
@@ -16,10 +16,6 @@
 
 /**
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*
-* @ingroup ServicesWebServicesECS
 */
 class ilECSCommunityCache
 {

--- a/Services/WebServices/ECS/classes/class.ilECSCommunityReader.php
+++ b/Services/WebServices/ECS/classes/class.ilECSCommunityReader.php
@@ -15,14 +15,7 @@
  *****************************************************************************/
 
 /**
-*
-*
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*
-* @ilCtrl_Calls
-* @ingroup ServicesWebServicesECS
 */
 class ilECSCommunityReader
 {

--- a/Services/WebServices/ECS/classes/class.ilECSCommunityTableGUI.php
+++ b/Services/WebServices/ECS/classes/class.ilECSCommunityTableGUI.php
@@ -15,12 +15,7 @@
  *****************************************************************************/
 
 /**
-*
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*
-* @ingroup ServicesWebServicesECS
 */
 class ilECSCommunityTableGUI extends ilTable2GUI
 {
@@ -31,14 +26,7 @@ class ilECSCommunityTableGUI extends ilTable2GUI
     private ilECSSetting $server;
     private int $cid;
     
-    /**
-     * constructor
-     *
-     * @access public
-     * @param
-     *
-     */
-    public function __construct(ilECSSetting $set, $a_parent_obj, $a_parent_cmd, $cid)
+    public function __construct(ilECSSetting $set, ?object $a_parent_obj, string $a_parent_cmd, int $cid)
     {
         parent::__construct($a_parent_obj, $a_parent_cmd);
 
@@ -56,7 +44,7 @@ class ilECSCommunityTableGUI extends ilTable2GUI
         $this->addColumn($this->lng->txt('ecs_tbl_import'), 'import', '5%');
         $this->addColumn($this->lng->txt('ecs_tbl_import_type'), 'type', '10%');
 
-        if ($this->access->checkAccess('write', '', intval($_REQUEST["ref_id"]))) {
+        if ($this->access->checkAccess('write', '', (int) $_REQUEST["ref_id"])) {
             $this->addColumn('', 'actions', '10%');
         }
 
@@ -71,9 +59,8 @@ class ilECSCommunityTableGUI extends ilTable2GUI
 
     /**
      * Get current server
-     * @return ilECSSetting
      */
-    public function getServer()
+    public function getServer() : ilECSSetting
     {
         return $this->server;
     }
@@ -81,9 +68,7 @@ class ilECSCommunityTableGUI extends ilTable2GUI
     /**
      * Fill row
      *
-     * @access public
      * @param array row data
-     *
      */
     public function fillRow(array $a_set) : void
     {
@@ -188,7 +173,7 @@ class ilECSCommunityTableGUI extends ilTable2GUI
                 break;
         }
 
-        if ($this->access->checkAccess('write', '', intval($_REQUEST["ref_id"]))) {
+        if ($this->access->checkAccess('write', '', (int) $_REQUEST["ref_id"])) {
             $this->tpl->setCurrentBlock("actions");
             $this->tpl->setVariable('ACTIONS', $list->getHTML());
             $this->tpl->parseCurrentBlock();
@@ -196,15 +181,11 @@ class ilECSCommunityTableGUI extends ilTable2GUI
     }
     
     /**
-     * Parse
-     *
-     * @access public
-     * @param array array of LDAPRoleAssignmentRule
-     *
+     * @param ilECSCommunity[] $a_participants list of participants
      */
-    public function parse($a_participants)
+    public function parse(array $participants) : void
     {
-        foreach ($a_participants as $participant) {
+        foreach ($participants as $participant) {
             $tmp_arr['mid'] = $participant->getMID();
             $tmp_arr['participants'] = $participant->getParticipantName();
             $tmp_arr['description'] = $participant->getDescription();

--- a/Services/WebServices/ECS/classes/class.ilECSConnectorException.php
+++ b/Services/WebServices/ECS/classes/class.ilECSConnectorException.php
@@ -15,13 +15,7 @@
  *****************************************************************************/
 
 /**
-*
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*
-* @ilCtrl_Calls
-* @ingroup ServicesWebServicesECS
 */
 class ilECSConnectorException extends ilException
 {

--- a/Services/WebServices/ECS/classes/class.ilECSDataMappingSetting.php
+++ b/Services/WebServices/ECS/classes/class.ilECSDataMappingSetting.php
@@ -15,12 +15,7 @@
  *****************************************************************************/
 
 /**
-*
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*
-* @ingroup ServicesWebServicesECS
 */
 class ilECSDataMappingSetting
 {
@@ -35,12 +30,6 @@ class ilECSDataMappingSetting
     private $ecs_field = 0;
     private $advmd_id = 0;
 
-
-    /**
-     * constructor
-     * @access public
-     *
-     */
     public function __construct($a_server_id = 0, $mapping_type = 0, $ecs_field = '')
     {
         global $DIC;

--- a/Services/WebServices/ECS/classes/class.ilECSDataMappingSettings.php
+++ b/Services/WebServices/ECS/classes/class.ilECSDataMappingSettings.php
@@ -15,12 +15,7 @@
  *****************************************************************************/
 
 /**
-*
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*
-* @ingroup ServicesWebServicesECS
 */
 class ilECSDataMappingSettings
 {

--- a/Services/WebServices/ECS/classes/class.ilECSEContentDetails.php
+++ b/Services/WebServices/ECS/classes/class.ilECSEContentDetails.php
@@ -18,9 +18,6 @@
  * Presentation of ecs content details (http://...campusconnect/courselinks/id/details)
  *
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
- * @version $Id$
- *
- * @ingroup ServicesWebServicesECS
  */
 class ilECSEContentDetails
 {

--- a/Services/WebServices/ECS/classes/class.ilECSEvent.php
+++ b/Services/WebServices/ECS/classes/class.ilECSEvent.php
@@ -16,10 +16,6 @@
 
 /**
 * @author Stefan Meyer <smeyer.ilias@gmx.de>
-* @version $Id$
-*
-*
-* @ingroup ServicesWebServicesECS
 */
 class ilECSEvent
 {

--- a/Services/WebServices/ECS/classes/class.ilECSEventQueueReader.php
+++ b/Services/WebServices/ECS/classes/class.ilECSEventQueueReader.php
@@ -18,10 +18,6 @@
 * Reads ECS events and stores them in the database.
 *
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*
-* @ingroup ServicesWebServicesECS
 */
 class ilECSEventQueueReader
 {

--- a/Services/WebServices/ECS/classes/class.ilECSExport.php
+++ b/Services/WebServices/ECS/classes/class.ilECSExport.php
@@ -19,28 +19,17 @@
 * This class stores the econtent id and informations whether an object is exported or not.
 *
 * @author Stefan Meyer <smeyer.ilias@gmx.de>
-* @version $Id$
-*
-*
-* @ingroup ServicesWebServicesECS
 */
 class ilECSExport
 {
     protected ilDBInterface $db;
 
-    protected $server_id = 0;
+    protected int $server_id = 0;
     protected int $obj_id = 0;
-    protected $econtent_id = 0;
-    protected $exported = false;
+    protected int $econtent_id = 0;
+    protected bool $exported = false;
 
-    /**
-     * Constructor
-     *
-     * @access public
-     * @param
-     *
-     */
-    public function __construct($a_server_id, $a_obj_id)
+    public function __construct(int $a_server_id, int $a_obj_id)
     {
         global $DIC;
 
@@ -53,18 +42,16 @@ class ilECSExport
 
     /**
      * Get server id
-     * @return int
      */
-    public function getServerId()
+    public function getServerId() : int
     {
         return $this->server_id;
     }
 
     /**
      * Set server id
-     * @param int $a_server_id
      */
-    public function setServerId($a_server_id)
+    public function setServerId(int $a_server_id) : void
     {
         $this->server_id = $a_server_id;
     }
@@ -72,34 +59,28 @@ class ilECSExport
     /**
      * Set exported
      *
-     * @access public
-     * @param bool export status
+     * @param bool $a_status export status
      *
      */
-    public function setExported($a_status)
+    public function setExported(bool $a_status) : void
     {
         $this->exported = $a_status;
     }
     
     /**
      * check if an object is exported or not
-     *
-     * @access public
-     *
      */
-    public function isExported()
+    public function isExported() : bool
     {
-        return (bool) $this->exported;
+        return $this->exported;
     }
 
     /**
      * set econtent id
      *
-     * @access public
-     * @param int econtent id (received from ECS::addResource)
-     *
+     * @param int $a_id econtent id (received from ECS::addResource)
      */
-    public function setEContentId($a_id)
+    public function setEContentId(int $a_id) : void
     {
         $this->econtent_id = $a_id;
     }
@@ -107,21 +88,17 @@ class ilECSExport
     /**
      * get econtent id
      *
-     * @access public
      * @return int econtent id
-     *
      */
-    public function getEContentId()
+    public function getEContentId() : int
     {
         return $this->econtent_id;
     }
     
     /**
      * Save
-     *
-     * @access public
      */
-    public function save()
+    public function save() : bool
     {
         $query = "DELETE FROM ecs_export " .
             "WHERE obj_id = " . $this->db->quote($this->obj_id, 'integer') . " " .
@@ -143,9 +120,8 @@ class ilECSExport
     
     /**
      * Read
-     * @access private
      */
-    private function read()
+    private function read() : void
     {
         $query = "SELECT * FROM ecs_export WHERE " .
             "obj_id = " . $this->db->quote($this->obj_id, 'integer') . " AND " .

--- a/Services/WebServices/ECS/classes/class.ilECSExportManager.php
+++ b/Services/WebServices/ECS/classes/class.ilECSExportManager.php
@@ -19,9 +19,6 @@
 * This class contains mainly helper functions to work with exported objects.
 *
 * @author Per Pascal Seeland<pascal.seeland@tik.uni-stuttgart.de>
-*
-*
-* @ingroup ServicesWebServicesECS
 */
 class ilECSExportManager
 {
@@ -29,13 +26,6 @@ class ilECSExportManager
 
     private static ilECSExportManager $instance;
 
-    /**
-     * Constructor
-     *
-     * @access public
-     * @param
-     *
-     */
     private function __construct()
     {
         global $DIC;
@@ -45,7 +35,6 @@ class ilECSExportManager
 
     /**
      * Get the singelton instance of this ilECSExportManager
-     * @return ilECSExportManager
      */
     public static function getInstance() : ilECSExportManager
     {
@@ -57,10 +46,8 @@ class ilECSExportManager
 
     /**
      * Check if object is exported
-     * @param int $a_obj_id
-     * @return bool
      */
-    public function _isExported($a_obj_id)
+    public function _isExported(int $a_obj_id) : bool
     {
         $query = 'SELECT * FROM ecs_export ' .
             'WHERE obj_id = ' . $this->db->quote($a_obj_id, 'integer');
@@ -74,12 +61,8 @@ class ilECSExportManager
 
     /**
      * get all exported econtent ids per server
-     *
-     * @access public
-     * @static
-     *
      */
-    public function _getAllEContentIds($a_server_id)
+    public function _getAllEContentIds(int $a_server_id) : array
     {
         $econtent_ids = array();
         $query = "SELECT econtent_id,obj_id FROM ecs_export " .
@@ -94,10 +77,8 @@ class ilECSExportManager
 
     /**
      * Get exported ids
-     * @global ilDB $ilDB
-     * @return array
      */
-    public function getExportedIds()
+    public function getExportedIds() : array
     {
         $query = "SELECT obj_id FROM ecs_export ";
         $res = $this->db->query($query);
@@ -110,10 +91,8 @@ class ilECSExportManager
 
     /**
      * Get exported ids by type
-     * @global ilDB $ilDB
-     * @return array
      */
-    public function getExportedIdsByType($a_type)
+    public function getExportedIdsByType(string $a_type) : array
     {
         $obj_ids = array();
         $query = "SELECT e.obj_id FROM ecs_export e" .
@@ -128,11 +107,8 @@ class ilECSExportManager
 
     /**
      * lookup server ids of exported materials
-     * @global ilDB $ilDB
-     * @param int $a_obj_id
-     * @return array
      */
-    public function getExportServerIds($a_obj_id)
+    public function getExportServerIds(int $a_obj_id) : array
     {
         $query = 'SELECT * FROM ecs_export ' .
             'WHERE obj_id = ' . $this->db->quote($a_obj_id, 'integer');
@@ -147,29 +123,23 @@ class ilECSExportManager
 
     /**
      * get exported ids for server
-     *
-     * @access public
-     * @return
-     * @static
      */
-    public function _getExportedIDsByServer($a_server_id)
+    public function _getExportedIDsByServer(int $a_server_id) : array
     {
         $query = "SELECT obj_id FROM ecs_export " .
             'WHERE server_id = ' . $this->db->quote($a_server_id, 'integer');
         $res = $this->db->query($query);
+        $obj_ids = [];
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             $obj_ids[] = $row->obj_id;
         }
-        return $obj_ids ? $obj_ids : array();
+        return $obj_ids;
     }
 
     /**
      * Lookup server ids of exported objects
-     * @global ilDB $ilDB
-     * @param <type> $a_obj_id
-     * @return <type>
      */
-    public function lookupServerIds($a_obj_id)
+    public function lookupServerIds(int $a_obj_id) : array
     {
         $query = 'SELECT * FROM ecs_export ' .
             'WHERE obj_id = ' . $this->db->quote($a_obj_id, 'integer') . ' ';
@@ -184,17 +154,14 @@ class ilECSExportManager
     /**
      * Delete econtent ids for server
      *
-     * @access public
-     * @static
-     *
-     * @param array array of econtent ids
+     * @param int $a_server_id id of the server
+     * @param int[] $a_ids array of econtent ids
      */
-    public function _deleteEContentIds($a_server_id, $a_ids)
+    public function _deleteEContentIds(int $a_server_id, array $a_ids) : bool
     {
         if (!is_array($a_ids) or !count($a_ids)) {
             return true;
         }
-        #$query = "DELETE FROM ecs_export WHERE econtent_id IN (".implode(',',ilUtil::quoteArray($a_ids)).')';
         $query = "DELETE FROM ecs_export WHERE " . $this->db->in('econtent_id', $a_ids, false, 'integer') . ' ' .
             'AND server_id = ' . $this->db->quote($a_server_id, 'integer');
         $this->db->manipulate($query);
@@ -203,10 +170,8 @@ class ilECSExportManager
 
     /**
      * Delete by server id
-     * @global ilDB $ilDB
-     * @param int $a_server_id
      */
-    public function deleteByServer($a_server_id)
+    public function deleteByServer(int $a_server_id) : void
     {
         $query = 'DELETE FROM ecs_export ' .
             'WHERE server_id = ' . $this->db->quote($a_server_id, 'integer');
@@ -215,13 +180,8 @@ class ilECSExportManager
 
     /**
      * is remote object
-     *
-     * @access public
-     * @static
-     *
-     * @param int econtent_id
      */
-    public function _isRemote($a_server_id, $a_econtent_id)
+    public function _isRemote(int $a_server_id, int $a_econtent_id) : bool
     {
         $query = "SELECT obj_id FROM ecs_export " .
             "WHERE econtent_id = " . $this->db->quote($a_econtent_id, 'integer') . " " .

--- a/Services/WebServices/ECS/classes/class.ilECSExportedContentTableGUI.php
+++ b/Services/WebServices/ECS/classes/class.ilECSExportedContentTableGUI.php
@@ -15,24 +15,12 @@
  *****************************************************************************/
 
 /**
-*
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*
-* @ingroup ServicesWebServicesECS
 */
 class ilECSExportedContentTableGUI extends ilTable2GUI
 {
     private ilObjectDataCache $ilObjDataCache;
     
-    /**
-     * constructor
-     *
-     * @access public
-     * @param
-     *
-     */
     public function __construct($a_parent_obj, $a_parent_cmd = '')
     {
         global $DIC;
@@ -51,7 +39,6 @@ class ilECSExportedContentTableGUI extends ilTable2GUI
     /**
      * Fill row
      *
-     * @access public
      * @param array row data
      *
      */
@@ -120,7 +107,6 @@ class ilECSExportedContentTableGUI extends ilTable2GUI
     /**
      * Parse
      *
-     * @access public
      * @param array array of released content obj_ids
      *
      */

--- a/Services/WebServices/ECS/classes/class.ilECSImport.php
+++ b/Services/WebServices/ECS/classes/class.ilECSImport.php
@@ -19,10 +19,6 @@
 * This class stores the econent id and informations whether an object is imported or not.
 *
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*
-* @ingroup ServicesWebServicesECS
 */
 class ilECSImport
 {
@@ -36,15 +32,7 @@ class ilECSImport
     protected int $mid = 0;
     protected bool $imported = false;
 
-
-    /**
-     * Constructor
-     *
-     * @access public
-     * @param int $a_server_id
-     * @param int $a_obj_id
-     */
-    public function __construct($a_server_id, $a_obj_id)
+    public function __construct(int $a_server_id, int $a_obj_id)
     {
         global $DIC;
         $this->db = $DIC->database();
@@ -68,8 +56,7 @@ class ilECSImport
     /**
      * Set imported
      *
-     * @access public
-     * @param bool export status
+     * @param bool $a_status import status
      *
      */
     public function setImported($a_status)
@@ -89,7 +76,6 @@ class ilECSImport
     
     /**
      * Set content id.
-     * @param type $a_content_id
      */
     public function setContentId($a_content_id)
     {
@@ -98,7 +84,6 @@ class ilECSImport
     
     /**
      * get content id
-     * @return type
      */
     public function getContentId()
     {
@@ -108,7 +93,6 @@ class ilECSImport
     /**
      * set mid
      *
-     * @access public
      * @param int mid
      *
      */
@@ -119,9 +103,6 @@ class ilECSImport
     
     /**
      * get mid
-     *
-     * @access public
-     *
      */
     public function getMID()
     {
@@ -131,7 +112,6 @@ class ilECSImport
     /**
      * set econtent id
      *
-     * @access public
      * @param int econtent id
      *
      */
@@ -142,9 +122,6 @@ class ilECSImport
     
     /**
      * get econtent id
-     *
-     * @access public
-     *
      */
     public function getEContentId()
     {
@@ -153,8 +130,6 @@ class ilECSImport
     
     /**
      * Save
-     *
-     * @access public
      */
     public function save()
     {

--- a/Services/WebServices/ECS/classes/class.ilECSImportManager.php
+++ b/Services/WebServices/ECS/classes/class.ilECSImportManager.php
@@ -19,19 +19,12 @@
 * This class contains mainly helper functions to work with imported objects.
 *
 * @author Per Pascal Seeland<pascal.seeland@tik.uni-stuttgart.de>
-*
-* @ingroup ServicesWebServicesECS
 */
 class ilECSImportManager
 {
     protected ilDBInterface $db;
     private static ilECSImportManager $instance;
 
-    /**
-     * Constructor
-     *
-     * @access public
-     */
     private function __construct()
     {
         global $DIC;
@@ -40,7 +33,7 @@ class ilECSImportManager
     }
 
     /**
-     * Get the singelton instance of this ilECSImportManager
+     * Get the singleton instance of this ilECSImportManager
      * @return ilECSImportManager
      */
     public static function getInstance() : ilECSImportManager

--- a/Services/WebServices/ECS/classes/class.ilECSImportedContentTableGUI.php
+++ b/Services/WebServices/ECS/classes/class.ilECSImportedContentTableGUI.php
@@ -27,14 +27,7 @@ class ilECSImportedContentTableGUI extends ilTable2GUI
     private ilTree $tree;
     private ilObjectDataCache $objDataCache;
     
-    /**
-     * constructor
-     *
-     * @access public
-     * @param
-     *
-     */
-    public function __construct($a_parent_obj, $a_parent_cmd = '')
+    public function __construct(?object $a_parent_obj, string $a_parent_cmd = '')
     {
         parent::__construct($a_parent_obj, $a_parent_cmd);
 

--- a/Services/WebServices/ECS/classes/class.ilECSObjectSettings.php
+++ b/Services/WebServices/ECS/classes/class.ilECSObjectSettings.php
@@ -18,16 +18,11 @@
 * Handles object exports to ECS
 *
 * @author Stefan Meyer <smeyer.ilias@gmx.de>
-*
-* @ingroup ServicesWebServicesECS
 */
 abstract class ilECSObjectSettings
 {
     protected \ilObject $content_obj; // [ilObj]
     
-    /**
-     * @var ilLogger
-     */
     private ilLogger $logger;
     private ilLanguage $lng;
     private ilTree $tree;

--- a/Services/WebServices/ECS/classes/class.ilECSOrganisation.php
+++ b/Services/WebServices/ECS/classes/class.ilECSOrganisation.php
@@ -16,27 +16,14 @@
 
 /**
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*
-* @ilCtrl_Calls
-* @ingroup ServicesWebServicesECS
 */
 class ilECSOrganisation
 {
-    protected $json_obj;
-    protected $name;
-    protected $abbr;
+    protected string $name;
+    protected string $abbr;
 
     private ilLogger $logger;
 
-    /**
-     * Constructor
-     *
-     * @access public
-     * @param
-     *
-     */
     public function __construct()
     {
         global $DIC;
@@ -47,7 +34,6 @@ class ilECSOrganisation
     /**
      * load from json
      *
-     * @access public
      * @param object json representation
      * @throws ilException
      */
@@ -63,18 +49,16 @@ class ilECSOrganisation
 
     /**
      * Get name
-     * @return string
      */
-    public function getName()
+    public function getName() : string
     {
         return $this->name;
     }
 
     /**
      * Get abbreviation
-     * @return string
      */
-    public function getAbbreviation()
+    public function getAbbreviation() : string
     {
         return $this->abbr;
     }

--- a/Services/WebServices/ECS/classes/class.ilECSParticipant.php
+++ b/Services/WebServices/ECS/classes/class.ilECSParticipant.php
@@ -16,38 +16,25 @@
 
 /**
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*
-* @ilCtrl_Calls
-* @ingroup ServicesWebServicesECS
 */
 class ilECSParticipant
 {
-    protected $json_obj;
-    protected $cid;
-    protected $pid;
+    protected object $json_obj;
+    protected int $cid;
+    protected int $pid;
     protected $mid;
     protected $email;
     protected $certid;
     protected $dns;
     protected $description;
     protected $participantname;
-    protected $is_self;
+    protected bool $is_self;
 
-    /**
-     * @var null | \ilLogger
-     */
+    private ilECSOrganisation $org;
+
     private ilLogger $logger;
     
-    /**
-     * Constructor
-     *
-     * @access public
-     * @param
-     *
-     */
-    public function __construct($json_obj, $a_cid)
+    public function __construct(object $json_obj, int $a_cid)
     {
         global $DIC;
 
@@ -60,21 +47,14 @@ class ilECSParticipant
     
     /**
      * get community id
-     *
-     * @access public
-     *
      */
-    public function getCommunityId()
+    public function getCommunityId() : int
     {
         return $this->cid;
     }
     
     /**
      * get mid
-     *
-     * @access public
-     * @param
-     *
      */
     public function getMID()
     {
@@ -83,9 +63,6 @@ class ilECSParticipant
     
     /**
      * get email
-     *
-     * @access public
-     *
      */
     public function getEmail()
     {
@@ -95,10 +72,6 @@ class ilECSParticipant
     
     /**
      * get dns
-     *
-     * @access public
-     * @param
-     *
      */
     public function getDNS()
     {
@@ -107,9 +80,6 @@ class ilECSParticipant
     
     /**
      * get description
-     *
-     * @access public
-     *
      */
     public function getDescription()
     {
@@ -118,9 +88,6 @@ class ilECSParticipant
 
     /**
      * get participant name
-     *
-     * @access public
-     *
      */
     public function getParticipantName()
     {
@@ -129,9 +96,6 @@ class ilECSParticipant
     
     /**
      * get abbreviation of participant
-     *
-     * @access public
-     *
      */
     public function getAbbreviation()
     {
@@ -140,35 +104,26 @@ class ilECSParticipant
 
     /**
      * Get pid
-     * @return int
      */
-    public function getPid()
+    public function getPid() : int
     {
         return $this->pid;
     }
     
     /**
      * is publishable (enabled and mid with own cert id)
-     *
-     * @access public
-     * @param
-     *
      */
-    public function isPublishable()
+    public function isPublishable() : bool
     {
         return $this->isSelf();
     }
     
     /**
      * is self
-     *
-     * @access public
-     * @param
-     *
      */
-    public function isSelf()
+    public function isSelf() : bool
     {
-        return (bool) $this->is_self;
+        return $this->is_self;
     }
     
     
@@ -189,18 +144,15 @@ class ilECSParticipant
      * Get organisation
      * @return ilECSOrganisation $org
      */
-    public function getOrganisation()
+    public function getOrganisation() : ilECSOrganisation
     {
         return $this->org;
     }
 
     /**
      * Read
-     *
-     * @access private
-     *
      */
-    private function read()
+    private function read() : bool
     {
         $this->pid = $this->json_obj->pid;
         $this->mid = $this->json_obj->mid;

--- a/Services/WebServices/ECS/classes/class.ilECSParticipantSetting.php
+++ b/Services/WebServices/ECS/classes/class.ilECSParticipantSetting.php
@@ -15,12 +15,7 @@
  *****************************************************************************/
 
 /**
-*
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*
-* @ingroup ServicesWebServicesECS
 */
 class ilECSParticipantSetting
 {
@@ -62,12 +57,6 @@ class ilECSParticipantSetting
 
     private ilDBInterface $db;
     
-    /**
-     * Constructor
-     *
-     * @access private
-     *
-     */
     public function __construct(int $a_server_id, int $mid)
     {
         global $DIC;
@@ -286,13 +275,13 @@ class ilECSParticipantSetting
         $this->exists = ($res->numRows() ? true : false);
 
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $this->enableExport(boolval($row->export));
-            $this->enableImport(boolval($row->import));
-            $this->setImportType(intval($row->import_type));
+            $this->enableExport((bool) $row->export);
+            $this->enableImport((bool) $row->import);
+            $this->setImportType((int) $row->import_type);
             $this->setTitle($row->title);
             $this->setCommunityName($row->cname);
-            $this->enableToken(boolval($row->token));
-            $this->enableDeprecatedToken(boolval($row->dtoken));
+            $this->enableToken((bool) $row->token);
+            $this->enableDeprecatedToken((bool) $row->dtoken);
             
             $this->setExportTypes((array) unserialize($row->export_types));
             $this->setImportTypes((array) unserialize($row->import_types));

--- a/Services/WebServices/ECS/classes/class.ilECSParticipantSettings.php
+++ b/Services/WebServices/ECS/classes/class.ilECSParticipantSettings.php
@@ -15,12 +15,7 @@
  *****************************************************************************/
 
 /**
-*
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*
-* @ingroup ServicesWebServicesECS
 */
 class ilECSParticipantSettings
 {
@@ -35,11 +30,8 @@ class ilECSParticipantSettings
     
     /**
      * Constructor (Singleton)
-     *
-     * @access private
-     *
      */
-    private function __construct($a_server_id)
+    private function __construct(int $a_server_id)
     {
         global $DIC;
 
@@ -50,10 +42,8 @@ class ilECSParticipantSettings
 
     /**
      * Get instance by server id
-     * @param int $a_server_id
-     * @return ilECSParticipantSettings
      */
-    public static function getInstanceByServerId($a_server_id)
+    public static function getInstanceByServerId(int $a_server_id) : ilECSParticipantSettings
     {
         if (isset(self::$instances[$a_server_id])) {
             return self::$instances[$a_server_id];
@@ -63,9 +53,9 @@ class ilECSParticipantSettings
     
     /**
      * Get all available mids
-     * @return type
+     * @return int[] membership id
      */
-    public function getAvailabeMids()
+    public function getAvailabeMids() : array
     {
         $query = 'SELECT mid FROM ecs_part_settings ' .
             'WHERE sid = ' . $this->db->quote($this->server_id, 'integer');
@@ -97,16 +87,14 @@ class ilECSParticipantSettings
 
     /**
      * Get server id
-     * @return int
      */
-    public function getServerId()
+    public function getServerId() : int
     {
         return $this->server_id;
     }
 
     /**
      * Read stored entry
-     * @return <type>
      */
     private function read()
     {
@@ -125,8 +113,6 @@ class ilECSParticipantSettings
 
     /**
      * Check if import is allowed for specific mid
-     * @param array $a_mids
-     * @return <type>
      */
     public function isImportAllowed(array $a_mids)
     {
@@ -141,7 +127,6 @@ class ilECSParticipantSettings
     /**
      * get number of participants that are enabled
      *
-     * @access public
      * @deprecated
      */
     public function getEnabledParticipants()
@@ -159,7 +144,6 @@ class ilECSParticipantSettings
     /**
      * is participant enabled
      *
-     * @access public
      * @param int mid
      * @deprecated
      *
@@ -172,7 +156,6 @@ class ilECSParticipantSettings
     /**
      * set enabled participants by community
      *
-     * @access public
      * @param int community id
      * @param array participant ids
      */

--- a/Services/WebServices/ECS/classes/class.ilECSParticipantSettingsGUI.php
+++ b/Services/WebServices/ECS/classes/class.ilECSParticipantSettingsGUI.php
@@ -15,10 +15,7 @@
  *****************************************************************************/
 
 /**
-*
 * @author Stefan Meyer <smeyer.ilias@gmx.de>
-*
-* @ingroup ServicesWebServicesECS
 */
 class ilECSParticipantSettingsGUI
 {
@@ -67,12 +64,8 @@ class ilECSParticipantSettingsGUI
 
     /**
      * Execute command
-     *
-     * @access public
-     * @param
-     *
      */
-    public function executeCommand()
+    public function executeCommand() : bool
     {
         $this->ctrl->saveParameter($this, 'server_id');
         $this->ctrl->saveParameter($this, 'mid');
@@ -95,7 +88,7 @@ class ilECSParticipantSettingsGUI
     /**
      * Abort editing
      */
-    private function abort()
+    private function abort() : void
     {
         $this->ctrl->returnToParent($this);
     }
@@ -103,9 +96,8 @@ class ilECSParticipantSettingsGUI
 
     /**
      * Settings
-     * @param ilPropertyFormGUI $form
      */
-    private function settings(ilPropertyFormGUI $form = null)
+    private function settings(ilPropertyFormGUI $form = null) : void
     {
         if (!$form instanceof ilPropertyFormGUI) {
             $form = $this->initFormSettings();
@@ -116,7 +108,7 @@ class ilECSParticipantSettingsGUI
     /**
      * Save settings
      */
-    protected function saveSettings()
+    protected function saveSettings() : void
     {
         $form = $this->initFormSettings();
         if ($form->checkInput()) {
@@ -130,7 +122,8 @@ class ilECSParticipantSettingsGUI
             
             $this->tpl->setOnScreenMessage('success', $this->lng->txt('settings_saved'), true);
             $this->ctrl->redirect($this, 'settings');
-            return true;
+            //TODO check if we need return true
+            return;
         }
         $form->setValuesByPost();
         $this->tpl->setOnScreenMessage('failure', $this->lng->txt('err_check_input'));
@@ -201,7 +194,7 @@ class ilECSParticipantSettingsGUI
     /**
      * Set tabs
      */
-    private function setTabs()
+    private function setTabs() : void
     {
         $this->tabs->clearTargets();
         $this->tabs->setBackTarget(

--- a/Services/WebServices/ECS/classes/class.ilECSParticipantSettingsRepository.php
+++ b/Services/WebServices/ECS/classes/class.ilECSParticipantSettingsRepository.php
@@ -15,10 +15,7 @@
  *****************************************************************************/
 
 /**
- *
  * @author Per Pascal Seeland <pascal.seeland@tik.uni-stuttgart.de>
- *
- * @ingroup ServicesWebServicesECS
  */
 class ilECSParticipantSettingsRepository
 {

--- a/Services/WebServices/ECS/classes/class.ilECSReaderException.php
+++ b/Services/WebServices/ECS/classes/class.ilECSReaderException.php
@@ -17,19 +17,9 @@
 /**
 *
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*
-* @ingroup ServicesWebServicesECS
 */
 class ilECSReaderException extends ilException
 {
-    /**
-     * Constructor
-     *
-     * @access public
-     *
-     */
     public function __construct($a_message, $a_code = 0)
     {
         parent::__construct($a_message, $a_code);

--- a/Services/WebServices/ECS/classes/class.ilECSRemoteUser.php
+++ b/Services/WebServices/ECS/classes/class.ilECSRemoteUser.php
@@ -17,7 +17,6 @@
 /**
  * Storage of ecs remote user
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
- * $Id$
  */
 class ilECSRemoteUser
 {

--- a/Services/WebServices/ECS/classes/class.ilECSRemoteUserRepository.php
+++ b/Services/WebServices/ECS/classes/class.ilECSRemoteUserRepository.php
@@ -15,10 +15,7 @@
  *****************************************************************************/
 
 /**
- *
  * @author Per Pascal Seeland <pascal.seeland@tik.uni-stuttgart.de>
- *
- * @ingroup ServicesWebServicesECS
  */
 class ilECSRemoteUserRepository
 {
@@ -26,9 +23,6 @@ class ilECSRemoteUserRepository
 
     /**
      * Constructor (Singleton)
-     *
-     * @access private
-     *
      */
     private function __construct()
     {

--- a/Services/WebServices/ECS/classes/class.ilECSResult.php
+++ b/Services/WebServices/ECS/classes/class.ilECSResult.php
@@ -15,12 +15,7 @@
  *****************************************************************************/
 
 /**
-*
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*
-* @ingroup ServicesWebServicesECS
 */
 class ilECSResult
 {

--- a/Services/WebServices/ECS/classes/class.ilECSServerSettings.php
+++ b/Services/WebServices/ECS/classes/class.ilECSServerSettings.php
@@ -18,8 +18,6 @@
  * Collection of ECS settings
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
  * @author Per Pascal Seeland <pascal.seeland@tik.uni-stuttgart.de>
- *
- * @ingroup ServicesWebServicesECS
  */
 class ilECSServerSettings
 {

--- a/Services/WebServices/ECS/classes/class.ilECSServerTableGUI.php
+++ b/Services/WebServices/ECS/classes/class.ilECSServerTableGUI.php
@@ -15,10 +15,7 @@
  *****************************************************************************/
 
 /**
- * Description of ilECSServerTableGUI
- *
  * @author Stefan Meyer <meyer@leifos.com>
- * @ingroup ServicesWebServicesECS
  */
 class ilECSServerTableGUI extends ilTable2GUI
 {

--- a/Services/WebServices/ECS/classes/class.ilECSSetting.php
+++ b/Services/WebServices/ECS/classes/class.ilECSSetting.php
@@ -15,13 +15,7 @@
  *****************************************************************************/
 
 /**
-* @defgroup ServicesWebServicesECS Services/WebServices/ECS
-*
 * @author Stefan Meyer <smeyer.ilias@gmx.de>
-* @version $Id$
-*
-*
-* @ingroup ServicesWebServicesECS
 */
 class ilECSSetting
 {
@@ -744,7 +738,7 @@ class ilECSSetting
     {
         $this->server_id = $this->db->nextId('ecs_server');
         $this->db->manipulate(
-            $q = 'INSERT INTO ecs_server (server_id,active,title,protocol,server,port,auth_type,client_cert_path,ca_cert_path,' .
+            'INSERT INTO ecs_server (server_id,active,title,protocol,server,port,auth_type,client_cert_path,ca_cert_path,' .
             'key_path,key_password,cert_serial,polling_time,import_id,global_role,econtent_rcp,user_rcp,approval_rcp,duration,auth_user,auth_pass) ' .
             'VALUES (' .
             $this->db->quote($this->getServerId(), 'integer') . ', ' .

--- a/Services/WebServices/ECS/classes/class.ilECSSettingsGUI.php
+++ b/Services/WebServices/ECS/classes/class.ilECSSettingsGUI.php
@@ -692,8 +692,8 @@ class ilECSSettingsGUI
             }
         }
 
-        foreach ((array) $_POST['sci_mid'] as $sid => $tmp) {
-            foreach ((array) $_POST['sci_mid'][$sid] as $mid => $tmp) {
+        foreach ((array) $_POST['sci_mid'] as $sid) {
+            foreach ((array) $_POST['sci_mid'][$sid] as $mid) {
                 $set = new ilECSParticipantSetting($sid, $mid);
                 #$set->enableExport(array_key_exists($mid, (array) $_POST['export'][$sid]) ? true : false);
                 #$set->enableImport(array_key_exists($mid, (array) $_POST['import'][$sid]) ? true : false);

--- a/Services/WebServices/ECS/classes/class.ilECSTaskScheduler.php
+++ b/Services/WebServices/ECS/classes/class.ilECSTaskScheduler.php
@@ -15,12 +15,7 @@
  *****************************************************************************/
 
 /**
-*
 * @author Stefan Meyer <smeyer.ilias@gmx.de>
-* @version $Id$
-*
-*
-* @ingroup ServicesWebServicesECS
 */
 class ilECSTaskScheduler
 {
@@ -364,10 +359,10 @@ class ilECSTaskScheduler
 
         if ($soap_client->init() and 0) {
             $this->log->info('Calling soap handleECSTasks method...');
-            $res = $soap_client->call('handleECSTasks', array($new_session_id . '::' . $client_id,$this->settings->getServerId()));
+            $soap_client->call('handleECSTasks', array($new_session_id . '::' . $client_id,$this->settings->getServerId()));
         } else {
             $this->log->info('SOAP call failed. Calling clone method manually. ');
-            $res = ilSoapFunctions::handleECSTasks($new_session_id . '::' . $client_id, $this->settings->getServerId());
+            ilSoapFunctions::handleECSTasks($new_session_id . '::' . $client_id, $this->settings->getServerId());
         }
     }
 }

--- a/Services/WebServices/ECS/classes/class.ilECSTimePlace.php
+++ b/Services/WebServices/ECS/classes/class.ilECSTimePlace.php
@@ -31,13 +31,6 @@ class ilECSTimePlace
     private string $end = '';
     private string $cycle = '';
 
-    /**
-     * Constructor
-     *
-     * @access public
-     * @param
-     *
-     */
     public function __construct()
     {
         global $DIC;

--- a/Services/WebServices/ECS/classes/class.ilECSUriList.php
+++ b/Services/WebServices/ECS/classes/class.ilECSUriList.php
@@ -18,47 +18,32 @@
  * Presentation of ecs uril (http://...campusconnect/courselinks)
  *
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
- * @version $Id$
- *
- * @ingroup ServicesWebServicesECS
  */
 class ilECSUriList
 {
     public array $uris = array();
 
     /**
-     * Constructor
-     */
-    public function __construct()
-    {
-    }
-
-
-    /**
      * Add uri
-     * @param  string $a_uri
-     * @param int $a_link_id
      */
-    public function add($a_uri, $a_link_id)
+    public function add(string $a_uri, int $a_link_id)
     {
         $this->uris[$a_link_id] = $a_uri;
     }
 
     /**
      * Get link ids
-     * @return <type>
      */
-    public function getLinkIds()
+    public function getLinkIds() : array
     {
-        return (array) array_keys($this->uris);
+        return array_keys($this->uris);
     }
 
     /**
      * Get uris
-     * @return array
      */
-    public function getUris()
+    public function getUris() : array
     {
-        return (array) $this->uris;
+        return $this->uris;
     }
 }

--- a/Services/WebServices/ECS/classes/class.ilECSUser.php
+++ b/Services/WebServices/ECS/classes/class.ilECSUser.php
@@ -18,11 +18,6 @@
 * Stores relevant user data.
 *
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*
-* @ilCtrl_Calls
-* @ingroup ServicesWebServicesECS
 */
 class ilECSUser
 {

--- a/Services/WebServices/ECS/classes/class.ilECSUtils.php
+++ b/Services/WebServices/ECS/classes/class.ilECSUtils.php
@@ -15,13 +15,7 @@
  *****************************************************************************/
 
 /**
-*
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*
-* @ilCtrl_Calls
-* @ingroup ServicesWebServicesECS
 */
 class ilECSUtils
 {

--- a/Services/WebServices/ECS/classes/class.ilObjECSSettings.php
+++ b/Services/WebServices/ECS/classes/class.ilObjECSSettings.php
@@ -15,23 +15,17 @@
  *****************************************************************************/
 
 /**
-*
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*
-* @ingroup ServicesWebServicesECS
 */
 class ilObjECSSettings extends ilObject
 {
 
     /**
     * Constructor
-    * @access	public
-    * @param	integer	reference_id or object_id
-    * @param	boolean	treat the id as reference_id (true) or object_id (false)
+    * @param	$a_id int reference_id or object_id
+    * @param	$a_call_by_reference bool treat the id as reference_id (true) or object_id (false)
     */
-    public function __construct($a_id = 0, $a_call_by_reference = true)
+    public function __construct(int $a_id = 0, bool $a_call_by_reference = true)
     {
         $this->type = "ecss";
         parent::__construct($a_id, $a_call_by_reference);

--- a/Services/WebServices/ECS/classes/class.ilObjECSSettingsAccess.php
+++ b/Services/WebServices/ECS/classes/class.ilObjECSSettingsAccess.php
@@ -15,12 +15,7 @@
  *****************************************************************************/
 
 /**
-*
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*
-* @ingroup ServicesWebServicesECS
 */
 class ilObjECSSettingsAccess extends ilObjectAccess
 {

--- a/Services/WebServices/ECS/classes/class.ilObjECSSettingsGUI.php
+++ b/Services/WebServices/ECS/classes/class.ilObjECSSettingsGUI.php
@@ -17,20 +17,12 @@
 /**
 *
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
 *
 * @ilCtrl_Calls ilObjECSSettingsGUI: ilPermissionGUI, ilECSSettingsGUI
 */
 class ilObjECSSettingsGUI extends ilObjectGUI
 {
-
-    /**
-     * Constructor
-     *
-     * @access public
-     */
-    public function __construct($a_data, $a_id, $a_call_by_reference = true, $a_prepare_output = true)
+    public function __construct($a_data, int $a_id, bool $a_call_by_reference = true, bool $a_prepare_output = true)
     {
         $this->type = 'cals';
         parent::__construct($a_data, $a_id, $a_call_by_reference, $a_prepare_output);

--- a/Services/WebServices/ECS/classes/class.ilRemoteObjectBaseGUI.php
+++ b/Services/WebServices/ECS/classes/class.ilRemoteObjectBaseGUI.php
@@ -15,11 +15,7 @@
  *****************************************************************************/
 
 /**
-*
 * @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-* @ingroup ServicesWebServicesECS
 */
 abstract class ilRemoteObjectBaseGUI extends ilObject2GUI
 {

--- a/Services/WebServices/ECS/classes/class.ilRemoteObjectBaseListGUI.php
+++ b/Services/WebServices/ECS/classes/class.ilRemoteObjectBaseListGUI.php
@@ -17,12 +17,7 @@
 class ilRemoteObjectBaseListGUI extends ilObjectListGUI
 {
     private ilDBInterface $db;
-    /**
-     * Constructor
-     *
-     * @access public
-     *
-     */
+
     public function __construct()
     {
         global $DIC;
@@ -33,11 +28,8 @@ class ilRemoteObjectBaseListGUI extends ilObjectListGUI
 
     /**
      * lookup organization
-     *
-     * @param int $a_obj_id
-     * @return string
      */
-    public function _lookupOrganization($table, $a_obj_id)
+    public function _lookupOrganization(string $table, int $a_obj_id) : string
     {
         $query = "SELECT organization FROM " . $this->db->quoteIdentifier($table) .
         " WHERE obj_id = " . $this->db->quote($a_obj_id, 'integer') . " ";


### PR DESCRIPTION
The previous PR contained a wrong check for the splitting of the header. It will never be more than 2 elements from explode, but one also gets passed the ```HTTP/1.1 200 OK``` as header, which cannot be split and is not a proper header.