### PR TITLE
Fix issue that headers must contain 2 parts

### DIFF
--- a/Services/WebServices/Curl/classes/class.ilCurlConnection.php
+++ b/Services/WebServices/Curl/classes/class.ilCurlConnection.php
@@ -177,7 +177,7 @@ class ilCurlConnection
     {
         $len = strlen($header);
         $header = explode(':', $header, 2);
-        if (count($header) < 2) { // ignore invalid headers
+        if (count($header) == 2) { // ignore invalid headers
             $this->header_arr[strtolower(trim($header[0]))] = trim($header[1]);
         }
         return $len;


### PR DESCRIPTION
The previous PR contained a wrong check for the splitting of the header. It will never be more than 2 elements from explode, but one also gets passed the HTTP/1.1 200 OK as header, which cannot be split and is not a proper header.