### PR TITLE
change favorites visibility to match the rest of the dashboard

### DIFF
--- a/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemsBlockSelectedItemsProvider.php
+++ b/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemsBlockSelectedItemsProvider.php
@@ -46,7 +46,7 @@ class ilPDSelectedItemsBlockSelectedItemsProvider implements ilPDSelectedItemsBl
         );
         $access_granted_favourites = [];
         foreach ($favourites as $idx => $favourite) {
-            if (!$this->access->checkAccess('read', '', $favourite['ref_id'])) {
+            if (!$this->access->checkAccess('visible', '', $favourite['ref_id'])) {
                 continue;
             }
             $access_granted_favourites[$idx] = $favourite;


### PR DESCRIPTION
The "Favourites" on the Dashboard differ in their visual permissions from the rest of the dashboard. While "Recommended Content" and "My Courses and Groups" show objects depending on their visibility (as common in most of the ILIAS GUIs), the "Favourites" show them depending on ther readability.

This causes major Problems and unintuitive side-effects (see https://mantis.ilias.de/view.php?id=30819) where Course "dis/reapear" just because they are moved into/out of the Favourites.

This PR resolve this problem by aligning the permission controll to the rest of the Dashboard.

This would also affect:
ILIAS 6: https://github.com/ILIAS-eLearning/ILIAS/pull/4072
ILIAS 8: https://github.com/ILIAS-eLearning/ILIAS/pull/4073