### PR TITLE
Bugfix 0031766

### DIFF
--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -17759,7 +17759,7 @@ body.ilPrtfPdfBody .ilPCMyCoursesToggle img {
 }
 #awareness-content .media-body h4,
 #awareness-content .media-body p {
-  color: #7c7c7c;
+  color: #161616;
   font-size: 12px;
   padding: 5px 3px 0 3px;
   line-height: 1em;
@@ -17767,7 +17767,7 @@ body.ilPrtfPdfBody .ilPCMyCoursesToggle img {
 }
 #awareness-content .media-body h4 {
   padding-top: 0px;
-  color: #161616;
+  font-size: bold;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/templates/default/less/Services/Awareness/delos.less
+++ b/templates/default/less/Services/Awareness/delos.less
@@ -86,7 +86,7 @@
 }
 
 #awareness-content .media-body h4, #awareness-content .media-body p {
-	color: @il-text-light-color;
+	color: @il-text-color;
 	font-size: 12px;
 	padding: 5px 3px 0 3px;
 	line-height: 1em;
@@ -95,7 +95,7 @@
 
 #awareness-content .media-body h4 {
 	padding-top: 0px;
-	color: @il-text-color;
+	font-size: bold;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;


### PR DESCRIPTION
Hi @all,

the PR fixes some contrast issues in the Who-is-Online-tool. To increase the contrast in the dropdowns in the Awareness tool while hovering, text color was adjusted. The less variable @il-text-color is now used here. To highlight the headline anyway, it is now displayed bold. 

0031766: Contrast Issue: Username in Who-is-Online Tool - https://mantis.ilias.de/view.php?id=31766

![Bildschirmfoto 2021-12-28 um 15 16 1](https://user-images.githubusercontent.com/42470261/155179390-070e4106-46da-48f4-bb03-2448a3f87472.png)

Greetings,
Enrico