### PR TITLE
Bugfix 0032119

### DIFF
--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -17039,6 +17039,9 @@ div#il_startup_logo img {
   border: 0 none;
   background-color: white;
 }
+.ilToolbar .navbar-toggle:focus-visible {
+  outline: 3px solid #0078D7;
+}
 .ilToolbar .ilToolbarItems {
   padding: 0;
 }

--- a/templates/default/less/Services/UIComponent/Toolbar/delos.less
+++ b/templates/default/less/Services/UIComponent/Toolbar/delos.less
@@ -8,6 +8,11 @@
 		border: 0 none;
 		background-color: @il-toolbar-bg;
 	}
+	.navbar-toggle {
+		&:focus-visible {
+			outline: @il-focus-outline;
+		}
+	}
 	.ilToolbarItems {
 		padding: 0;
 	}


### PR DESCRIPTION
Hi @all,

the focus of .navbar-toggles in toolbars is not noticeable enough. To change this I added the @il-focus-outline for .navbar-toggles in toolbars in mobile view.

0032119: Fokus sichtbar, Toolbar Responsive - https://mantis.ilias.de/view.php?id=32119

Greetings,
Enrico

![Screenshot 2022-02-22 at 18-27-27 ILIAS Testkurs](https://user-images.githubusercontent.com/42470261/155185799-406ae8a1-8bbd-4cfb-900d-1f53685ce01f.png)