### PR TITLE
WIP: Fix for Mantis #16075

### DIFF
--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -8335,7 +8335,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
                 $starting_time = $this->getStartingTimeOfUser($active_id);
                 if ($starting_time !== false) {
                     if ($this->isMaxProcessingTimeReached($starting_time, $active_id)) {
-                        if ($allowPassIncrease && $this->getResetProcessingTime() && (($this->getNrOfTries() == 0) || ($this->getNrOfTries() > (self::_getPass($active_id) + 1)))) {
+                        if ($allowPassIncrease && $this->getResetProcessingTime() && (($this->getNrOfTries() == 0) || ($this->getNrOfTries() > (self::_getPass($active_id))))) {
                             // a test pass was quitted because the maximum processing time was reached, but the time
                             // will be resetted for future passes, so if there are more passes allowed, the participant may
                             // start the test again.


### PR DESCRIPTION
Hello,

i think i have found the solution for a very old bug. https://mantis.ilias.de/view.php?id=16075
If this solution is correct the bug still exists in 7. I think even in the trunk. But i only have fixed it for a 5.4 installation now.

My test setup was a test with 2 allowed passes and a limited time of 60 minutes for each pass.

The learner didnt pass the first try. The tst_active table looks like this:
![tst_active](https://user-images.githubusercontent.com/5864315/155683745-1c38ebf6-cb2c-43d2-bf69-8031478d34cd.png)


`_getPass` returns the col `tries` which is then increased by one. That cant be right?! Then the check fails because `2 > 2` is false


Greetings
Purhur

