### PR TITLE
UI Components, Slates in Main- and Metabar wrong aria attributes

### DIFF
--- a/src/UI/templates/js/MainControls/dist/mainbar.js
+++ b/src/UI/templates/js/MainControls/dist/mainbar.js
@@ -752,10 +752,10 @@ var renderer = function($) {
         triggerer: Object.assign({}, dom_element, {
             remove: function() {},
             additional_engage: function(){
-                this.getElement().attr('aria-pressed', true);
+                this.getElement().attr('aria-expanded', true);
             },
             additional_disengage: function(){
-                this.getElement().attr('aria-pressed', false);
+                this.getElement().attr('aria-expanded', false);
             }
         }),
         slate: Object.assign({}, dom_element, {
@@ -767,8 +767,7 @@ var renderer = function($) {
                     entry_id = dom_ref_to_element[this.html_id],
                     isInView = il.UI.maincontrols.mainbar.model.isInView(entry_id),
                     thrown = thrown_for[entry_id];
-                
-                element.attr('aria-expanded', true);
+
                 element.attr('aria-hidden', false);
                 //https://www.w3.org/TR/wai-aria-practices-1.1/examples/accordion/accordion.html
                 element.attr('role', 'region');
@@ -784,7 +783,6 @@ var renderer = function($) {
             additional_disengage: function(){
                 var entry_id = dom_ref_to_element[this.html_id];
                 thrown_for[entry_id] = false;
-                this.getElement().attr('aria-expanded', false);
                 this.getElement().attr('aria-hidden', true);
                 this.getElement().removeAttr('role', 'region');
             }
@@ -826,10 +824,10 @@ var renderer = function($) {
             },
             remove: null,
             additional_engage: function(){
-                this.getElement().attr('aria-pressed', true);
+                this.getElement().attr('aria-expanded', true);
             },
             additional_disengage: function(){
-                this.getElement().attr('aria-pressed', false);
+                this.getElement().attr('aria-expanded', false);
             }
         }),
         mainbar: {

--- a/src/UI/templates/js/MainControls/metabar.js
+++ b/src/UI/templates/js/MainControls/metabar.js
@@ -87,11 +87,11 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 		};
 		var _engageButton = function(btn) {
 			btn.addClass(_cls_btn_engaged);
-			btn.attr('aria-pressed', true);
+			btn.attr('aria-expanded', true);
 		};
 		var _disengageButton = function(btn) {
 			btn.removeClass(_cls_btn_engaged);
-			btn.attr('aria-pressed', false);
+			btn.attr('aria-expanded', false);
 		};
 		var _isEngaged = function(btn) {
 			return btn.hasClass(_cls_btn_engaged);
@@ -135,7 +135,6 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 			$('.' + _cls_entries).css("visibility","visible");
 			$('#' + id +' .' + _cls_slates).children('.' + _cls_single_slate)
 				.attr('aria-hidden', true)
-				.attr('aria-expanded', false);
 		};
 
 		var _initCondensed = function () {

--- a/src/UI/templates/js/MainControls/src/mainbar.renderer.js
+++ b/src/UI/templates/js/MainControls/src/mainbar.renderer.js
@@ -61,10 +61,10 @@ var renderer = function($) {
         triggerer: Object.assign({}, dom_element, {
             remove: function() {},
             additional_engage: function(){
-                this.getElement().attr('aria-pressed', true);
+                this.getElement().attr('aria-expanded', true);
             },
             additional_disengage: function(){
-                this.getElement().attr('aria-pressed', false);
+                this.getElement().attr('aria-expanded', false);
             }
         }),
         slate: Object.assign({}, dom_element, {
@@ -76,8 +76,7 @@ var renderer = function($) {
                     entry_id = dom_ref_to_element[this.html_id],
                     isInView = il.UI.maincontrols.mainbar.model.isInView(entry_id),
                     thrown = thrown_for[entry_id];
-                
-                element.attr('aria-expanded', true);
+
                 element.attr('aria-hidden', false);
                 //https://www.w3.org/TR/wai-aria-practices-1.1/examples/accordion/accordion.html
                 element.attr('role', 'region');
@@ -93,7 +92,6 @@ var renderer = function($) {
             additional_disengage: function(){
                 var entry_id = dom_ref_to_element[this.html_id];
                 thrown_for[entry_id] = false;
-                this.getElement().attr('aria-expanded', false);
                 this.getElement().attr('aria-hidden', true);
                 this.getElement().removeAttr('role', 'region');
             }
@@ -135,10 +133,10 @@ var renderer = function($) {
             },
             remove: null,
             additional_engage: function(){
-                this.getElement().attr('aria-pressed', true);
+                this.getElement().attr('aria-expanded', true);
             },
             additional_disengage: function(){
-                this.getElement().attr('aria-pressed', false);
+                this.getElement().attr('aria-expanded', false);
             }
         }),
         mainbar: {


### PR DESCRIPTION
In the Materna report we failed the part "4.9.4.1.1 Syntaxanalyse". Various Issues have been found by using the Nu-Checker, see: https://mantis.ilias.de/view.php?id=32121 . Two of them have todo with the wrong use the aria-pressed (see: https://mantis.ilias.de/view.php?id=32150, should only be used for toggle buttons) and aria-expanded (see: https://mantis.ilias.de/view.php?id=32149, should be used on the trigger, not the element being triggered) attributes. 

Both issues are fixed with this PR, if I understood the this correctly. Note that this will be audited again after fixing. It might be possible, that further improvements will be needed.