### PR TITLE
WIP: Add double border to focus

### DIFF
--- a/src/UI/templates/default/Button/button.less
+++ b/src/UI/templates/default/Button/button.less
@@ -17,15 +17,12 @@ input.btn{
 .btn-default {
   .button-variant(@il-btn-standard-color; @il-btn-standard-bg; @il-btn-standard-border);
   &:focus-visible {
-    outline-offset: @il-focus-outline-offset;
+    position: relative;
   }
 }
 
 .btn-primary {
   .button-variant(@il-btn-primary-color; @il-btn-primary-bg; @il-btn-primary-border);
-  &:focus-visible {
-    outline-offset: @il-focus-outline-offset;
-  }
 }
 
 .btn, .btn.btn-tag{

--- a/src/UI/templates/default/Card/card.less
+++ b/src/UI/templates/default/Card/card.less
@@ -55,6 +55,7 @@
 		top:0;
 		left:0;
 		right:0;
+		z-index: 1;
 		height: @il-icon-size-medium + @padding-large-horizontal;
 		padding: 0 @padding-small-horizontal;
 
@@ -97,6 +98,10 @@
 						display: block;
 						margin-left: auto;
 						margin-right: auto;
+					}
+					
+					&:focus-visible {
+						outline-offset: @il-focus-outline-width - 1;
 					}
 				}
 			}

--- a/src/UI/templates/default/MainControls/Slate/slate.less
+++ b/src/UI/templates/default/MainControls/Slate/slate.less
@@ -20,18 +20,18 @@
 		display: flex;
 		margin-bottom: @il-slate-content-spacing;
 		position: relative;
-		&.engaged:after,
-		&.disengaged:after {
+		&.engaged::before,
+		&.disengaged::before {
 				font-family: "il-icons";
 				font-size: @il-slate-bulky-glyph-size * 0.85;
 				position: absolute;
 				right: 10px;
 				top: 20px;
 		}
-		&.engaged:after {
+		&.engaged::before {
 				content: " \e604";
 		}
-		&.disengaged:after {
+		&.disengaged::before {
 				content: " \e606";
 		}
 		&:focus{

--- a/src/UI/templates/default/MainControls/mainbar.less
+++ b/src/UI/templates/default/MainControls/mainbar.less
@@ -22,11 +22,16 @@
 		line-height: @il-mainbar-btn-label-size * @line-height-large;
 		&:focus,
 		&:active {
-			box-shadow: none; 
+			box-shadow: none;
 		}
-		&:focus-visible {
-			border: 3px solid @il-focus-color;
+		&:focus-visible,
+		&:active:focus-visible {
+			border: @il-focus-outline-outer;
 			outline: none;
+			
+			&::after {
+				content: none;
+			}
 		}
 	}
 	.bulky-label {

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -1128,6 +1128,16 @@ a:focus {
 }
 a:focus:focus-visible {
   outline: 3px solid #0078D7;
+  outline-offset: 3px;
+}
+a:focus:focus-visible::after {
+  content: " ";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  outline: 3px solid white;
 }
 figure {
   margin: 0;
@@ -2725,6 +2735,18 @@ input[type="file"]:focus:focus-visible,
 input[type="radio"]:focus:focus-visible,
 input[type="checkbox"]:focus:focus-visible {
   outline: 3px solid #0078D7;
+  outline-offset: 3px;
+}
+input[type="file"]:focus:focus-visible::after,
+input[type="radio"]:focus:focus-visible::after,
+input[type="checkbox"]:focus:focus-visible::after {
+  content: " ";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  outline: 3px solid white;
 }
 output {
   display: block;
@@ -2799,7 +2821,7 @@ textarea.form-control {
   .input-group-sm input[type="time"],
   .input-group-sm input[type="datetime-local"],
   .input-group-sm input[type="month"] {
-    line-height: 26px;
+    line-height: 28px;
   }
   input[type="date"].input-lg,
   input[type="time"].input-lg,
@@ -2881,39 +2903,39 @@ fieldset[disabled] .checkbox-inline {
   padding-left: 0;
 }
 .input-sm {
-  height: 26px;
-  padding: 3px 6px;
+  height: 28px;
+  padding: 4px 6px;
   font-size: 12px;
   line-height: 1.5;
   border-radius: 0px;
 }
 select.input-sm {
-  height: 26px;
-  line-height: 26px;
+  height: 28px;
+  line-height: 28px;
 }
 textarea.input-sm,
 select[multiple].input-sm {
   height: auto;
 }
 .form-group-sm .form-control {
-  height: 26px;
-  padding: 3px 6px;
+  height: 28px;
+  padding: 4px 6px;
   font-size: 12px;
   line-height: 1.5;
   border-radius: 0px;
 }
 .form-group-sm select.form-control {
-  height: 26px;
-  line-height: 26px;
+  height: 28px;
+  line-height: 28px;
 }
 .form-group-sm textarea.form-control,
 .form-group-sm select[multiple].form-control {
   height: auto;
 }
 .form-group-sm .form-control-static {
-  height: 26px;
+  height: 28px;
   min-height: 32px;
-  padding: 4px 6px;
+  padding: 5px 6px;
   font-size: 12px;
   line-height: 1.5;
 }
@@ -2982,9 +3004,9 @@ select[multiple].input-lg {
 .input-sm + .form-control-feedback,
 .input-group-sm + .form-control-feedback,
 .form-group-sm .form-control + .form-control-feedback {
-  width: 26px;
-  height: 26px;
-  line-height: 26px;
+  width: 28px;
+  height: 28px;
+  line-height: 28px;
 }
 .has-success .help-block,
 .has-success .control-label,
@@ -3172,7 +3194,7 @@ select[multiple].input-lg {
 }
 @media (min-width: 768px) {
   .form-horizontal .form-group-sm .control-label {
-    padding-top: 4px;
+    padding-top: 5px;
     font-size: 12px;
   }
 }
@@ -3214,6 +3236,21 @@ select[multiple].input-lg {
 .btn:active.focus:focus-visible,
 .btn.active.focus:focus-visible {
   outline: 3px solid #0078D7;
+  outline-offset: 3px;
+}
+.btn:focus:focus-visible::after,
+.btn:active:focus:focus-visible::after,
+.btn.active:focus:focus-visible::after,
+.btn.focus:focus-visible::after,
+.btn:active.focus:focus-visible::after,
+.btn.active.focus:focus-visible::after {
+  content: " ";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  outline: 3px solid white;
 }
 .btn:hover,
 .btn:focus,
@@ -3601,7 +3638,7 @@ fieldset[disabled] .btn-link:focus {
 }
 .btn-sm,
 .btn-group-sm > .btn {
-  padding: 3px 6px;
+  padding: 4px 6px;
   font-size: 12px;
   line-height: 1.5;
   border-radius: 0px;
@@ -4017,8 +4054,8 @@ select[multiple].input-group-lg > .input-group-btn > .btn {
 .input-group-sm > .form-control,
 .input-group-sm > .input-group-addon,
 .input-group-sm > .input-group-btn > .btn {
-  height: 26px;
-  padding: 3px 6px;
+  height: 28px;
+  padding: 4px 6px;
   font-size: 12px;
   line-height: 1.5;
   border-radius: 0px;
@@ -4026,8 +4063,8 @@ select[multiple].input-group-lg > .input-group-btn > .btn {
 select.input-group-sm > .form-control,
 select.input-group-sm > .input-group-addon,
 select.input-group-sm > .input-group-btn > .btn {
-  height: 26px;
-  line-height: 26px;
+  height: 28px;
+  line-height: 28px;
 }
 textarea.input-group-sm > .form-control,
 textarea.input-group-sm > .input-group-addon,
@@ -4065,7 +4102,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   border-radius: 0;
 }
 .input-group-addon.input-sm {
-  padding: 3px 6px;
+  padding: 4px 6px;
   font-size: 12px;
   border-radius: 0px;
 }
@@ -4617,8 +4654,8 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   margin-bottom: 7.5px;
 }
 .navbar-btn.btn-sm {
-  margin-top: 7px;
-  margin-bottom: 7px;
+  margin-top: 6px;
+  margin-bottom: 6px;
 }
 .navbar-btn.btn-xs {
   margin-top: 9px;
@@ -4927,7 +4964,7 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
 }
 .pagination-sm > li > a,
 .pagination-sm > li > span {
-  padding: 3px 6px;
+  padding: 4px 6px;
   font-size: 12px;
   line-height: 1.5;
 }
@@ -6924,7 +6961,7 @@ button.close {
   background-color: #f9f9f9;
   margin: 0;
   padding: 9px 12px;
-  padding-bottom: 3px;
+  padding-bottom: 4px;
   border: none;
   -webkit-box-shadow: none;
   box-shadow: none;
@@ -7010,8 +7047,8 @@ button.close {
   padding: 6px 12px;
 }
 .panel-secondary .panel-heading.ilHeader h4 {
-  padding-top: 3px;
-  padding-bottom: 3px;
+  padding-top: 4px;
+  padding-bottom: 4px;
 }
 .panel-secondary .panel-heading.ilHeader h2.ilHeader {
   font-size: 17px;
@@ -7076,7 +7113,7 @@ button.close {
   font-weight: 600;
   float: left;
   padding: 9px 12px;
-  padding-bottom: 3px;
+  padding-bottom: 4px;
   margin: 0;
   line-height: 1.33;
 }
@@ -7087,7 +7124,7 @@ button.close {
   padding: 9px 12px;
 }
 .il-panel-listing-std-container > .dropdown:not(:last-child) {
-  padding-bottom: 3px;
+  padding-bottom: 4px;
 }
 .il-card {
   padding: 0 0 6px 0;
@@ -7136,6 +7173,7 @@ button.close {
   top: 0;
   left: 0;
   right: 0;
+  z-index: 1;
   height: 47px;
   padding: 0 6px;
 }
@@ -7151,7 +7189,7 @@ button.close {
 }
 .il-card .il-card-repository-head .il-chart-progressmeter-box {
   width: 41px;
-  height: 38px;
+  height: 39px;
 }
 .il-card .il-card-repository-head .il-chart-progressmeter-box > .il-chart-progressmeter-container .il-chart-progressmeter-viewbox {
   max-width: 100%;
@@ -7171,6 +7209,9 @@ button.close {
   display: block;
   margin-left: auto;
   margin-right: auto;
+}
+.il-card .il-card-repository-head > div.il-card-repository-dropdown > .dropdown > button:focus-visible {
+  outline-offset: 2px;
 }
 .il-panel-report .il-card {
   background-color: #f9f9f9;
@@ -7292,8 +7333,19 @@ button.close {
   font-size: 12px;
 }
 .btn:focus-visible {
+  position: relative;
+  border: none;
   outline: 3px solid #0078D7;
-  outline-offset: 0px;
+  outline-offset: 2px;
+}
+.btn:focus-visible::after {
+  content: " ";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  outline: 3px solid white;
 }
 .btn:active,
 .btn.engaged {
@@ -7363,7 +7415,7 @@ fieldset[disabled] .btn-default.focus {
   background-color: white;
 }
 .btn-default:focus-visible {
-  outline-offset: 2px;
+  position: relative;
 }
 .btn-primary {
   color: white;
@@ -7417,9 +7469,6 @@ fieldset[disabled] .btn-primary.focus {
 .btn-primary .badge {
   color: #557b2e;
   background-color: white;
-}
-.btn-primary:focus-visible {
-  outline-offset: 2px;
 }
 .btn[disabled],
 .btn.btn-tag[disabled],
@@ -7631,7 +7680,7 @@ a fieldset[disabled] .active {
   font-size: 12px;
 }
 h4.il-divider {
-  padding: 3px 6px;
+  padding: 4px 6px;
   margin-bottom: 0px;
   background-color: white;
   display: block;
@@ -7895,7 +7944,7 @@ ul.dropdown-menu > li > .btn:focus {
   margin: 0;
   font-weight: 600;
   font-size: 12px;
-  padding: 3px;
+  padding: 4px;
   padding-left: 100px;
 }
 .breadcrumb_wrapper .breadcrumb span.crumb a {
@@ -8098,14 +8147,14 @@ ul.dropdown-menu > li > .btn:focus {
 .il-standard-form .il-section-input-header h2 {
   font-size: 19px;
   padding-top: 12px;
-  padding-bottom: 3px;
+  padding-bottom: 4px;
 }
 .il-standard-form .il-standar-form-header-byline,
 .il-standard-form .il-section-input-header-byline {
   font-size: 12px;
 }
 .il-standard-form .il-standard-form-header + .il-section-input {
-  margin-top: -21.14285715px;
+  margin-top: -22.14285715px;
   padding: 0;
 }
 .il-standard-form .il-standard-form-header + .il-section-input .il-section-input-header h2 {
@@ -8114,7 +8163,7 @@ ul.dropdown-menu > li > .btn:focus {
 }
 .il-standard-form .il-dependant-group {
   background-color: #f9f9f9;
-  padding: 3px 0;
+  padding: 4px 0;
 }
 .il-standard-form .il-dependant-group .form-group {
   margin: 0;
@@ -8146,8 +8195,8 @@ ul.dropdown-menu > li > .btn:focus {
   margin: 2px 0 10px;
 }
 .form-horizontal .help-block.alert-danger {
-  margin: 3px 0 0;
-  padding: 0 3px 0 3px;
+  margin: 4px 0 0;
+  padding: 0 4px 0 4px;
   color: #a94442;
   background-color: #f2dede;
   border-color: #ebccd1;
@@ -8263,7 +8312,7 @@ ul.dropdown-menu > li > .btn:focus {
 }
 .il-filter-bar {
   display: flex;
-  padding: 3px 12px;
+  padding: 4px 12px;
 }
 .il-filter-bar .il-filter-bar-opener {
   flex: 1;
@@ -8294,11 +8343,11 @@ ul.dropdown-menu > li > .btn:focus {
 }
 .il-filter-inputs-active {
   background-color: #f9f9f9;
-  padding: 3px 8px;
+  padding: 4px 8px;
 }
 .il-filter-inputs-active span {
   display: inline-block;
-  margin: 3px 8px 3px 0;
+  margin: 4px 8px 4px 0;
   padding: 0 8px;
   float: left;
   background-color: white;
@@ -8791,7 +8840,7 @@ fieldset[disabled] .il-table-presentation-viewcontrols .btn-default:not(.disable
 /* when characteristic value listing is used in the card */
 .il-card .il-listing-characteristic-value-row {
   border-top: none;
-  padding: 6px 3px;
+  padding: 6px 4px;
 }
 .il-card .il-listing-characteristic-value-label {
   padding-left: 6px;
@@ -8847,7 +8896,7 @@ div.alert ul > li:before {
 }
 .il-tree {
   list-style-type: none;
-  padding: 0 3px 0 calc(3px + 4px);
+  padding: 0 4px 0 calc(4px + 4px);
   margin-left: 0;
 }
 .il-tree ul {
@@ -9391,22 +9440,22 @@ footer {
   margin-bottom: 2px;
   position: relative;
 }
-.il-maincontrols-slate .btn-bulky.engaged:after,
-.il-maincontrols-slate .link-bulky.engaged:after,
-.il-maincontrols-slate .btn-bulky.disengaged:after,
-.il-maincontrols-slate .link-bulky.disengaged:after {
+.il-maincontrols-slate .btn-bulky.engaged::before,
+.il-maincontrols-slate .link-bulky.engaged::before,
+.il-maincontrols-slate .btn-bulky.disengaged::before,
+.il-maincontrols-slate .link-bulky.disengaged::before {
   font-family: "il-icons";
   font-size: 1.7rem;
   position: absolute;
   right: 10px;
   top: 20px;
 }
-.il-maincontrols-slate .btn-bulky.engaged:after,
-.il-maincontrols-slate .link-bulky.engaged:after {
+.il-maincontrols-slate .btn-bulky.engaged::before,
+.il-maincontrols-slate .link-bulky.engaged::before {
   content: " \e604";
 }
-.il-maincontrols-slate .btn-bulky.disengaged:after,
-.il-maincontrols-slate .link-bulky.disengaged:after {
+.il-maincontrols-slate .btn-bulky.disengaged::before,
+.il-maincontrols-slate .link-bulky.disengaged::before {
   content: " \e606";
 }
 .il-maincontrols-slate .btn-bulky:focus,
@@ -9422,7 +9471,7 @@ footer {
 }
 .il-maincontrols-slate .btn-bulky .icon,
 .il-maincontrols-slate .link-bulky .icon {
-  margin-top: 3px;
+  margin-top: 4px;
   margin-right: 5px;
   filter: invert(50%);
 }
@@ -9743,9 +9792,23 @@ footer {
 .il-maincontrols-mainbar .btn-bulky:focus-visible,
 .il-maincontrols-metabar .btn-bulky:focus-visible,
 .il-maincontrols-mainbar .il-link.link-bulky:focus-visible,
-.il-maincontrols-metabar .il-link.link-bulky:focus-visible {
+.il-maincontrols-metabar .il-link.link-bulky:focus-visible,
+.il-maincontrols-mainbar .btn-bulky:active:focus-visible,
+.il-maincontrols-metabar .btn-bulky:active:focus-visible,
+.il-maincontrols-mainbar .il-link.link-bulky:active:focus-visible,
+.il-maincontrols-metabar .il-link.link-bulky:active:focus-visible {
   border: 3px solid #0078D7;
   outline: none;
+}
+.il-maincontrols-mainbar .btn-bulky:focus-visible::after,
+.il-maincontrols-metabar .btn-bulky:focus-visible::after,
+.il-maincontrols-mainbar .il-link.link-bulky:focus-visible::after,
+.il-maincontrols-metabar .il-link.link-bulky:focus-visible::after,
+.il-maincontrols-mainbar .btn-bulky:active:focus-visible::after,
+.il-maincontrols-metabar .btn-bulky:active:focus-visible::after,
+.il-maincontrols-mainbar .il-link.link-bulky:active:focus-visible::after,
+.il-maincontrols-metabar .il-link.link-bulky:active:focus-visible::after {
+  content: none;
 }
 .il-maincontrols-mainbar .bulky-label,
 .il-maincontrols-metabar .bulky-label {
@@ -10712,8 +10775,19 @@ footer {
   }
 }
 .il-link:focus-visible {
+  position: relative;
+  border: none;
   outline: 3px solid #0078D7;
-  outline-offset: 0px;
+  outline-offset: 2px;
+}
+.il-link:focus-visible::after {
+  content: " ";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  outline: 3px solid white;
 }
 .il-link:active,
 .il-link.engaged {
@@ -11817,6 +11891,25 @@ a {
 a:hover {
   color: #3a4c65;
   text-decoration: underline;
+}
+a:focus-visible {
+  position: relative;
+  border: none;
+  outline: 3px solid #0078D7;
+  outline-offset: 2px;
+}
+a:focus-visible::after {
+  content: " ";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  outline: 3px solid white;
+}
+a:active,
+a.engaged {
+  outline: none;
 }
 hr {
   margin-bottom: 0.8em;
@@ -12971,10 +13064,39 @@ form.form-inline {
 .form-control:focus-visible {
   -webkit-box-shadow: none;
   box-shadow: none;
+}
+.form-control:focus-visible:focus-visible {
+  position: relative;
+  border: none;
   outline: 3px solid #0078D7;
+  outline-offset: 2px;
+}
+.form-control:focus-visible:focus-visible::after {
+  content: " ";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  outline: 3px solid white;
+}
+.form-control:focus-visible:active,
+.form-control:focus-visible.engaged {
+  outline: none;
 }
 .btn-file:focus-within {
+  z-index: 3;
   outline: 3px solid #0078D7;
+  outline-offset: 3px;
+}
+.btn-file:focus-within::after {
+  content: " ";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  outline: 3px solid white;
 }
 textarea.form-control {
   max-width: 100%;
@@ -15221,7 +15343,7 @@ ul.il-mm-selfloading {
 }
 /* Services/UIComponent/GroupedLists */
 div.ilGroupedListH {
-  padding: 6px 0 3px 0;
+  padding: 6px 0 4px 0;
   color: #161616;
 }
 div.ilGroupedListSep {
@@ -17043,7 +17165,23 @@ div#il_startup_logo img {
   background-color: white;
 }
 .ilToolbar .navbar-toggle:focus-visible {
+  position: relative;
+  border: none;
   outline: 3px solid #0078D7;
+  outline-offset: 2px;
+}
+.ilToolbar .navbar-toggle:focus-visible::after {
+  content: " ";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  outline: 3px solid white;
+}
+.ilToolbar .navbar-toggle:active,
+.ilToolbar .navbar-toggle.engaged {
+  outline: none;
 }
 .ilToolbar .ilToolbarItems {
   padding: 0;
@@ -17091,7 +17229,7 @@ div#il_startup_logo img {
   margin-right: 0;
 }
 .ilToolbar .btn[disabled] {
-  padding: 3px 6px;
+  padding: 4px 6px;
 }
 .ilToolbar .ilToolbarStickyItems {
   float: left;
@@ -17745,8 +17883,24 @@ body.ilPrtfPdfBody .ilPCMyCoursesToggle img {
   border-bottom: 1px solid #dddddd;
   background-color: white;
 }
-.ilAwarenessItem > div[role='button']:focus-visible {
+.ilAwarenessItem > div[role='button']:focus-visible:focus-visible {
+  position: relative;
+  border: none;
   outline: 3px solid #0078D7;
+  outline-offset: 2px;
+}
+.ilAwarenessItem > div[role='button']:focus-visible:focus-visible::after {
+  content: " ";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  outline: 3px solid white;
+}
+.ilAwarenessItem > div[role='button']:focus-visible:active,
+.ilAwarenessItem > div[role='button']:focus-visible.engaged {
+  outline: none;
 }
 .ilAwarenessItem ul {
   margin: 0;

--- a/templates/default/delos.less
+++ b/templates/default/delos.less
@@ -527,6 +527,8 @@ a {
 		color: @link-hover-color;
 		text-decoration: underline;
 	}
+	
+	.il-focus();
 }
 
 hr {

--- a/templates/default/less/Services/Awareness/delos.less
+++ b/templates/default/less/Services/Awareness/delos.less
@@ -62,7 +62,7 @@
 	background-color:  @il-main-bg;
 
 	> div[role='button']:focus-visible {
-		outline: @il-focus-outline;
+		.il-focus();
 	}
 
 	ul {

--- a/templates/default/less/Services/Form/delos.less
+++ b/templates/default/less/Services/Form/delos.less
@@ -37,11 +37,15 @@ form.form-inline {
 
 .form-control:focus-visible {
 	.box-shadow(none);
-	outline: @il-focus-outline;
+	.il-focus();
 }
 
 .btn-file:focus-within {
-	outline: @il-focus-outline;
+    z-index: 3;
+    outline: @il-focus-outline-outer;
+    outline-offset: @il-focus-outline-width;
+        
+    .il-focus-after();
 }
 
 textarea.form-control {

--- a/templates/default/less/Services/UIComponent/Toolbar/delos.less
+++ b/templates/default/less/Services/UIComponent/Toolbar/delos.less
@@ -9,9 +9,7 @@
 		background-color: @il-toolbar-bg;
 	}
 	.navbar-toggle {
-		&:focus-visible {
-			outline: @il-focus-outline;
-		}
+		.il-focus();
 	}
 	.ilToolbarItems {
 		padding: 0;

--- a/templates/default/less/focus-mixin.less
+++ b/templates/default/less/focus-mixin.less
@@ -7,17 +7,36 @@
     outline: none;
     outline-offset: 0px;
     &:focus-visible {
-        outline: @il-focus-outline;
+        outline: @il-focus-outline-outer;
+        outline-offset: @il-focus-outline-width;
+        
+        .il-focus-after();
     }
   }
 
-.il-focus(){
+.il-focus() {
 	&:focus-visible {
-		outline: @il-focus-outline;
-		outline-offset: 0px;
+		position: relative;
+		border: none;
+		outline: @il-focus-outline-outer;
+		outline-offset: @il-focus-outline-width - 1px;
+		
+		.il-focus-after();
 	}
 
 	&:active,&.engaged{
 		outline: none;
+	}
+}
+
+.il-focus-after() {
+	&::after {
+		content: " ";
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		outline: @il-focus-outline-inner;
 	}
 }

--- a/templates/default/less/variables.less
+++ b/templates/default/less/variables.less
@@ -126,7 +126,7 @@ with the il- variable set here.
 @il-padding-large-vertical: 6px;
 @il-padding-large-horizontal: 12px;
 
-@il-padding-small-vertical: 3px;
+@il-padding-small-vertical: 4px;
 @il-padding-small-horizontal: 6px;
 
 @il-padding-xs-vertical: 1px;
@@ -136,9 +136,10 @@ with the il- variable set here.
 @il-border-radius-large: 0px;
 @il-border-radius-small: 0px;
 
-@il-focus-outline: 3px solid @il-focus-color;
+@il-focus-outline-inner: @il-focus-outline-width solid white;
+@il-focus-outline-outer: @il-focus-outline-width solid @il-focus-color;
 // The offset should only be used if the contrast between the focus outline and the component is insufficient.
-@il-focus-outline-offset: 2px;
+@il-focus-outline-width: 3px;
 
 //== Layout (UI Layout Page)
 //


### PR DESCRIPTION
This is the first of two pull requests to remove a visibility issue for the focus on tabbing (see: https://mantis.ilias.de/view.php?id=32137). It adds a double outline to the element having :focus-visible. I believe this one to be the inferior of the two as it only shields the outline to one side from its environment.

A few important notes:
- This does not touch the entries in the main- and metabar, as there the focus is shown as a border. A few changes where added to keep it this way.
- I had to move the open/close glyph in the slate to avoid removing it. I don't think this has serious consequences for accessibility, but we could also change the approach: I would then move the border to before and keep after. This would require more changes to CSS then the approach I chose here.
- I introduced new less variables and renamed existing ones. I can a
- There is still a issue on FF: When tabbing into the breadcrumb it gets an ellipse. Will try to find a workaround.