### PR TITLE
Add background to focus

### DIFF
--- a/Services/WebDAV/classes/mount_instructions/class.ilWebDAVMountInstructionsGUI.php
+++ b/Services/WebDAV/classes/mount_instructions/class.ilWebDAVMountInstructionsGUI.php
@@ -119,7 +119,7 @@ class ilWebDAVMountInstructionsGUI
 
         // Add view control and legacy add the beginning of the array (so they will be rendered first)
         $header_comps = array(
-            $f->legacy("<div style='text-align: center'>"),
+            $f->legacy("<div class='webdav-view-control'>"),
             $view_control,
             $f->legacy("</div>"),
             $js_function_legacy);

--- a/src/UI/templates/default/Breadcrumbs/breadcrumbs.less
+++ b/src/UI/templates/default/Breadcrumbs/breadcrumbs.less
@@ -20,6 +20,13 @@
 			&:hover {
 				color: @il-standard-page-breadcrumbs-active-color;
 			}
+			&:focus {
+				border: @il-focus-outline-inner;
+				
+				&::after {
+					content: none;
+				}
+			}
 		}
 
 		&>span+span:before {

--- a/src/UI/templates/default/Button/button.less
+++ b/src/UI/templates/default/Button/button.less
@@ -17,15 +17,12 @@ input.btn{
 .btn-default {
   .button-variant(@il-btn-standard-color; @il-btn-standard-bg; @il-btn-standard-border);
   &:focus-visible {
-    outline-offset: @il-focus-outline-offset;
+    position: relative;
   }
 }
 
 .btn-primary {
   .button-variant(@il-btn-primary-color; @il-btn-primary-bg; @il-btn-primary-border);
-  &:focus-visible {
-    outline-offset: @il-focus-outline-offset;
-  }
 }
 
 .btn, .btn.btn-tag{

--- a/src/UI/templates/default/Card/card.less
+++ b/src/UI/templates/default/Card/card.less
@@ -15,8 +15,16 @@
 		overflow: hidden;
 	}
 
-	.thumbnail{
+	&.thumbnail{
 		margin-bottom: 0px;
+		
+		&:focus-within .il-card-repository-head {
+			z-index: 1;
+		}
+		
+		a:focus-visible {
+			overflow: visible;
+		}
 	}
 	.card-highlight {
 		background: @il-card-highlight-bg;
@@ -97,6 +105,11 @@
 						display: block;
 						margin-left: auto;
 						margin-right: auto;
+					}
+					
+					&:focus-visible {
+						overflow: visible;
+						outline-offset: @il-focus-outline-inner-width + @il-focus-outline-outer-width - 1;
 					}
 				}
 			}

--- a/src/UI/templates/default/Item/item.less
+++ b/src/UI/templates/default/Item/item.less
@@ -14,6 +14,10 @@
 		.btn-link, a {
 			font-size: inherit;
 			line-height: @line-height-base;
+			
+			&:focus-visible {
+				display: block;
+			}
 		}
 	}
 

--- a/src/UI/templates/default/MainControls/Slate/slate.less
+++ b/src/UI/templates/default/MainControls/Slate/slate.less
@@ -20,18 +20,18 @@
 		display: flex;
 		margin-bottom: @il-slate-content-spacing;
 		position: relative;
-		&.engaged:after,
-		&.disengaged:after {
+		&.engaged::before,
+		&.disengaged::before {
 				font-family: "il-icons";
 				font-size: @il-slate-bulky-glyph-size * 0.85;
 				position: absolute;
 				right: 10px;
 				top: 20px;
 		}
-		&.engaged:after {
+		&.engaged::before {
 				content: " \e604";
 		}
-		&.disengaged:after {
+		&.disengaged::before {
 				content: " \e606";
 		}
 		&:focus{

--- a/src/UI/templates/default/MainControls/mainbar.less
+++ b/src/UI/templates/default/MainControls/mainbar.less
@@ -22,11 +22,16 @@
 		line-height: @il-mainbar-btn-label-size * @line-height-large;
 		&:focus,
 		&:active {
-			box-shadow: none; 
+			box-shadow: none;
 		}
-		&:focus-visible {
-			border: 3px solid @il-focus-color;
+		&:focus-visible,
+		&:active:focus-visible {
+			border: @il-focus-outline-inner;
 			outline: none;
+			
+			&::after {
+				content: none;
+			}
 		}
 	}
 	.bulky-label {

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -10224,8 +10224,8 @@ footer {
   }
   .il-mainbar-triggers .btn-bulky .icon.small,
   .il-mainbar-triggers .il-link.link-bulky .icon.small {
-    height: 17px;
-    width: 17px;
+    height: 15px;
+    width: 15px;
   }
   .il-mainbar-tools-entries.engaged {
     height: 50px;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -1127,6 +1127,17 @@ a:focus {
   outline-offset: 0px;
 }
 a:focus:focus-visible {
+  outline: 2px solid #FFFFFF;
+  outline-offset: 5px;
+}
+a:focus:focus-visible::after {
+  content: " ";
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+  border: 2px solid #FFFFFF;
   outline: 3px solid #0078D7;
 }
 figure {
@@ -2724,6 +2735,19 @@ input[type="checkbox"]:focus {
 input[type="file"]:focus:focus-visible,
 input[type="radio"]:focus:focus-visible,
 input[type="checkbox"]:focus:focus-visible {
+  outline: 2px solid #FFFFFF;
+  outline-offset: 5px;
+}
+input[type="file"]:focus:focus-visible::after,
+input[type="radio"]:focus:focus-visible::after,
+input[type="checkbox"]:focus:focus-visible::after {
+  content: " ";
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+  border: 2px solid #FFFFFF;
   outline: 3px solid #0078D7;
 }
 output {
@@ -2799,7 +2823,7 @@ textarea.form-control {
   .input-group-sm input[type="time"],
   .input-group-sm input[type="datetime-local"],
   .input-group-sm input[type="month"] {
-    line-height: 26px;
+    line-height: 28px;
   }
   input[type="date"].input-lg,
   input[type="time"].input-lg,
@@ -2881,39 +2905,39 @@ fieldset[disabled] .checkbox-inline {
   padding-left: 0;
 }
 .input-sm {
-  height: 26px;
-  padding: 3px 6px;
+  height: 28px;
+  padding: 4px 6px;
   font-size: 12px;
   line-height: 1.5;
   border-radius: 0px;
 }
 select.input-sm {
-  height: 26px;
-  line-height: 26px;
+  height: 28px;
+  line-height: 28px;
 }
 textarea.input-sm,
 select[multiple].input-sm {
   height: auto;
 }
 .form-group-sm .form-control {
-  height: 26px;
-  padding: 3px 6px;
+  height: 28px;
+  padding: 4px 6px;
   font-size: 12px;
   line-height: 1.5;
   border-radius: 0px;
 }
 .form-group-sm select.form-control {
-  height: 26px;
-  line-height: 26px;
+  height: 28px;
+  line-height: 28px;
 }
 .form-group-sm textarea.form-control,
 .form-group-sm select[multiple].form-control {
   height: auto;
 }
 .form-group-sm .form-control-static {
-  height: 26px;
+  height: 28px;
   min-height: 32px;
-  padding: 4px 6px;
+  padding: 5px 6px;
   font-size: 12px;
   line-height: 1.5;
 }
@@ -2982,9 +3006,9 @@ select[multiple].input-lg {
 .input-sm + .form-control-feedback,
 .input-group-sm + .form-control-feedback,
 .form-group-sm .form-control + .form-control-feedback {
-  width: 26px;
-  height: 26px;
-  line-height: 26px;
+  width: 28px;
+  height: 28px;
+  line-height: 28px;
 }
 .has-success .help-block,
 .has-success .control-label,
@@ -3172,7 +3196,7 @@ select[multiple].input-lg {
 }
 @media (min-width: 768px) {
   .form-horizontal .form-group-sm .control-label {
-    padding-top: 4px;
+    padding-top: 5px;
     font-size: 12px;
   }
 }
@@ -3213,6 +3237,22 @@ select[multiple].input-lg {
 .btn.focus:focus-visible,
 .btn:active.focus:focus-visible,
 .btn.active.focus:focus-visible {
+  outline: 2px solid #FFFFFF;
+  outline-offset: 5px;
+}
+.btn:focus:focus-visible::after,
+.btn:active:focus:focus-visible::after,
+.btn.active:focus:focus-visible::after,
+.btn.focus:focus-visible::after,
+.btn:active.focus:focus-visible::after,
+.btn.active.focus:focus-visible::after {
+  content: " ";
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+  border: 2px solid #FFFFFF;
   outline: 3px solid #0078D7;
 }
 .btn:hover,
@@ -3601,7 +3641,7 @@ fieldset[disabled] .btn-link:focus {
 }
 .btn-sm,
 .btn-group-sm > .btn {
-  padding: 3px 6px;
+  padding: 4px 6px;
   font-size: 12px;
   line-height: 1.5;
   border-radius: 0px;
@@ -4017,8 +4057,8 @@ select[multiple].input-group-lg > .input-group-btn > .btn {
 .input-group-sm > .form-control,
 .input-group-sm > .input-group-addon,
 .input-group-sm > .input-group-btn > .btn {
-  height: 26px;
-  padding: 3px 6px;
+  height: 28px;
+  padding: 4px 6px;
   font-size: 12px;
   line-height: 1.5;
   border-radius: 0px;
@@ -4026,8 +4066,8 @@ select[multiple].input-group-lg > .input-group-btn > .btn {
 select.input-group-sm > .form-control,
 select.input-group-sm > .input-group-addon,
 select.input-group-sm > .input-group-btn > .btn {
-  height: 26px;
-  line-height: 26px;
+  height: 28px;
+  line-height: 28px;
 }
 textarea.input-group-sm > .form-control,
 textarea.input-group-sm > .input-group-addon,
@@ -4065,7 +4105,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   border-radius: 0;
 }
 .input-group-addon.input-sm {
-  padding: 3px 6px;
+  padding: 4px 6px;
   font-size: 12px;
   border-radius: 0px;
 }
@@ -4617,8 +4657,8 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   margin-bottom: 7.5px;
 }
 .navbar-btn.btn-sm {
-  margin-top: 7px;
-  margin-bottom: 7px;
+  margin-top: 6px;
+  margin-bottom: 6px;
 }
 .navbar-btn.btn-xs {
   margin-top: 9px;
@@ -4927,7 +4967,7 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
 }
 .pagination-sm > li > a,
 .pagination-sm > li > span {
-  padding: 3px 6px;
+  padding: 4px 6px;
   font-size: 12px;
   line-height: 1.5;
 }
@@ -6924,7 +6964,7 @@ button.close {
   background-color: #f9f9f9;
   margin: 0;
   padding: 9px 12px;
-  padding-bottom: 3px;
+  padding-bottom: 4px;
   border: none;
   -webkit-box-shadow: none;
   box-shadow: none;
@@ -7010,8 +7050,8 @@ button.close {
   padding: 6px 12px;
 }
 .panel-secondary .panel-heading.ilHeader h4 {
-  padding-top: 3px;
-  padding-bottom: 3px;
+  padding-top: 4px;
+  padding-bottom: 4px;
 }
 .panel-secondary .panel-heading.ilHeader h2.ilHeader {
   font-size: 17px;
@@ -7076,7 +7116,7 @@ button.close {
   font-weight: 600;
   float: left;
   padding: 9px 12px;
-  padding-bottom: 3px;
+  padding-bottom: 4px;
   margin: 0;
   line-height: 1.33;
 }
@@ -7087,7 +7127,7 @@ button.close {
   padding: 9px 12px;
 }
 .il-panel-listing-std-container > .dropdown:not(:last-child) {
-  padding-bottom: 3px;
+  padding-bottom: 4px;
 }
 .il-card {
   padding: 0 0 6px 0;
@@ -7104,8 +7144,14 @@ button.close {
 .il-card a {
   overflow: hidden;
 }
-.il-card .thumbnail {
+.il-card.thumbnail {
   margin-bottom: 0px;
+}
+.il-card.thumbnail:focus-within .il-card-repository-head {
+  z-index: 1;
+}
+.il-card.thumbnail a:focus-visible {
+  overflow: visible;
 }
 .il-card .card-highlight {
   background: #B54F00;
@@ -7151,7 +7197,7 @@ button.close {
 }
 .il-card .il-card-repository-head .il-chart-progressmeter-box {
   width: 41px;
-  height: 38px;
+  height: 39px;
 }
 .il-card .il-card-repository-head .il-chart-progressmeter-box > .il-chart-progressmeter-container .il-chart-progressmeter-viewbox {
   max-width: 100%;
@@ -7171,6 +7217,10 @@ button.close {
   display: block;
   margin-left: auto;
   margin-right: auto;
+}
+.il-card .il-card-repository-head > div.il-card-repository-dropdown > .dropdown > button:focus-visible {
+  overflow: visible;
+  outline-offset: 4px;
 }
 .il-panel-report .il-card {
   background-color: #f9f9f9;
@@ -7292,8 +7342,20 @@ button.close {
   font-size: 12px;
 }
 .btn:focus-visible {
+  position: relative;
+  border: none;
+  outline: 2px solid #FFFFFF;
+  outline-offset: 4px;
+}
+.btn:focus-visible::after {
+  content: " ";
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+  border: 2px solid #FFFFFF;
   outline: 3px solid #0078D7;
-  outline-offset: 0px;
 }
 .btn:active,
 .btn.engaged {
@@ -7363,7 +7425,7 @@ fieldset[disabled] .btn-default.focus {
   background-color: white;
 }
 .btn-default:focus-visible {
-  outline-offset: 2px;
+  position: relative;
 }
 .btn-primary {
   color: white;
@@ -7417,9 +7479,6 @@ fieldset[disabled] .btn-primary.focus {
 .btn-primary .badge {
   color: #557b2e;
   background-color: white;
-}
-.btn-primary:focus-visible {
-  outline-offset: 2px;
 }
 .btn[disabled],
 .btn.btn-tag[disabled],
@@ -7631,7 +7690,7 @@ a fieldset[disabled] .active {
   font-size: 12px;
 }
 h4.il-divider {
-  padding: 3px 6px;
+  padding: 4px 6px;
   margin-bottom: 0px;
   background-color: white;
   display: block;
@@ -7720,6 +7779,10 @@ ul.dropdown-menu > li > .btn:focus {
 .il-item .il-item-title a {
   font-size: inherit;
   line-height: 1.42857143;
+}
+.il-item .il-item-title .btn-link:focus-visible,
+.il-item .il-item-title a:focus-visible {
+  display: block;
 }
 .il-item .il-item-divider {
   clear: both;
@@ -7903,7 +7966,7 @@ ul.dropdown-menu > li > .btn:focus {
   margin: 0;
   font-weight: 600;
   font-size: 12px;
-  padding: 3px;
+  padding: 4px;
   padding-left: 100px;
 }
 .breadcrumb_wrapper .breadcrumb span.crumb a {
@@ -7911,6 +7974,12 @@ ul.dropdown-menu > li > .btn:focus {
 }
 .breadcrumb_wrapper .breadcrumb span.crumb a:hover {
   color: #3a4c65;
+}
+.breadcrumb_wrapper .breadcrumb span.crumb a:focus {
+  border: 3px solid #0078D7;
+}
+.breadcrumb_wrapper .breadcrumb span.crumb a:focus::after {
+  content: none;
 }
 .breadcrumb_wrapper .breadcrumb > span + span:before {
   content: " \e606";
@@ -8106,14 +8175,14 @@ ul.dropdown-menu > li > .btn:focus {
 .il-standard-form .il-section-input-header h2 {
   font-size: 19px;
   padding-top: 12px;
-  padding-bottom: 3px;
+  padding-bottom: 4px;
 }
 .il-standard-form .il-standar-form-header-byline,
 .il-standard-form .il-section-input-header-byline {
   font-size: 12px;
 }
 .il-standard-form .il-standard-form-header + .il-section-input {
-  margin-top: -21.14285715px;
+  margin-top: -22.14285715px;
   padding: 0;
 }
 .il-standard-form .il-standard-form-header + .il-section-input .il-section-input-header h2 {
@@ -8122,7 +8191,7 @@ ul.dropdown-menu > li > .btn:focus {
 }
 .il-standard-form .il-dependant-group {
   background-color: #f9f9f9;
-  padding: 3px 0;
+  padding: 4px 0;
 }
 .il-standard-form .il-dependant-group .form-group {
   margin: 0;
@@ -8154,8 +8223,8 @@ ul.dropdown-menu > li > .btn:focus {
   margin: 2px 0 10px;
 }
 .form-horizontal .help-block.alert-danger {
-  margin: 3px 0 0;
-  padding: 0 3px 0 3px;
+  margin: 4px 0 0;
+  padding: 0 4px 0 4px;
   color: #a94442;
   background-color: #f2dede;
   border-color: #ebccd1;
@@ -8271,7 +8340,7 @@ ul.dropdown-menu > li > .btn:focus {
 }
 .il-filter-bar {
   display: flex;
-  padding: 3px 12px;
+  padding: 4px 12px;
 }
 .il-filter-bar .il-filter-bar-opener {
   flex: 1;
@@ -8302,11 +8371,11 @@ ul.dropdown-menu > li > .btn:focus {
 }
 .il-filter-inputs-active {
   background-color: #f9f9f9;
-  padding: 3px 8px;
+  padding: 4px 8px;
 }
 .il-filter-inputs-active span {
   display: inline-block;
-  margin: 3px 8px 3px 0;
+  margin: 4px 8px 4px 0;
   padding: 0 8px;
   float: left;
   background-color: white;
@@ -8852,7 +8921,7 @@ fieldset[disabled] .il-table-presentation-viewcontrols .btn-default.engaged.focu
 /* when characteristic value listing is used in the card */
 .il-card .il-listing-characteristic-value-row {
   border-top: none;
-  padding: 6px 3px;
+  padding: 6px 4px;
 }
 .il-card .il-listing-characteristic-value-label {
   padding-left: 6px;
@@ -8908,7 +8977,7 @@ div.alert ul > li:before {
 }
 .il-tree {
   list-style-type: none;
-  padding: 0 3px 0 calc(3px + 4px);
+  padding: 0 4px 0 calc(4px + 4px);
   margin-left: 0;
 }
 .il-tree ul {
@@ -9452,22 +9521,22 @@ footer {
   margin-bottom: 2px;
   position: relative;
 }
-.il-maincontrols-slate .btn-bulky.engaged:after,
-.il-maincontrols-slate .link-bulky.engaged:after,
-.il-maincontrols-slate .btn-bulky.disengaged:after,
-.il-maincontrols-slate .link-bulky.disengaged:after {
+.il-maincontrols-slate .btn-bulky.engaged::before,
+.il-maincontrols-slate .link-bulky.engaged::before,
+.il-maincontrols-slate .btn-bulky.disengaged::before,
+.il-maincontrols-slate .link-bulky.disengaged::before {
   font-family: "il-icons";
   font-size: 1.7rem;
   position: absolute;
   right: 10px;
   top: 20px;
 }
-.il-maincontrols-slate .btn-bulky.engaged:after,
-.il-maincontrols-slate .link-bulky.engaged:after {
+.il-maincontrols-slate .btn-bulky.engaged::before,
+.il-maincontrols-slate .link-bulky.engaged::before {
   content: " \e604";
 }
-.il-maincontrols-slate .btn-bulky.disengaged:after,
-.il-maincontrols-slate .link-bulky.disengaged:after {
+.il-maincontrols-slate .btn-bulky.disengaged::before,
+.il-maincontrols-slate .link-bulky.disengaged::before {
   content: " \e606";
 }
 .il-maincontrols-slate .btn-bulky:focus,
@@ -9483,7 +9552,7 @@ footer {
 }
 .il-maincontrols-slate .btn-bulky .icon,
 .il-maincontrols-slate .link-bulky .icon {
-  margin-top: 3px;
+  margin-top: 4px;
   margin-right: 5px;
   filter: invert(50%);
 }
@@ -9811,9 +9880,23 @@ footer {
 .il-maincontrols-mainbar .btn-bulky:focus-visible,
 .il-maincontrols-metabar .btn-bulky:focus-visible,
 .il-maincontrols-mainbar .il-link.link-bulky:focus-visible,
-.il-maincontrols-metabar .il-link.link-bulky:focus-visible {
+.il-maincontrols-metabar .il-link.link-bulky:focus-visible,
+.il-maincontrols-mainbar .btn-bulky:active:focus-visible,
+.il-maincontrols-metabar .btn-bulky:active:focus-visible,
+.il-maincontrols-mainbar .il-link.link-bulky:active:focus-visible,
+.il-maincontrols-metabar .il-link.link-bulky:active:focus-visible {
   border: 3px solid #0078D7;
   outline: none;
+}
+.il-maincontrols-mainbar .btn-bulky:focus-visible::after,
+.il-maincontrols-metabar .btn-bulky:focus-visible::after,
+.il-maincontrols-mainbar .il-link.link-bulky:focus-visible::after,
+.il-maincontrols-metabar .il-link.link-bulky:focus-visible::after,
+.il-maincontrols-mainbar .btn-bulky:active:focus-visible::after,
+.il-maincontrols-metabar .btn-bulky:active:focus-visible::after,
+.il-maincontrols-mainbar .il-link.link-bulky:active:focus-visible::after,
+.il-maincontrols-metabar .il-link.link-bulky:active:focus-visible::after {
+  content: none;
 }
 .il-maincontrols-mainbar .bulky-label,
 .il-maincontrols-metabar .bulky-label {
@@ -10787,8 +10870,20 @@ footer {
   }
 }
 .il-link:focus-visible {
+  position: relative;
+  border: none;
+  outline: 2px solid #FFFFFF;
+  outline-offset: 4px;
+}
+.il-link:focus-visible::after {
+  content: " ";
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+  border: 2px solid #FFFFFF;
   outline: 3px solid #0078D7;
-  outline-offset: 0px;
 }
 .il-link:active,
 .il-link.engaged {
@@ -11893,6 +11988,26 @@ a:hover {
   color: #3a4c65;
   text-decoration: underline;
 }
+a:focus-visible {
+  position: relative;
+  border: none;
+  outline: 2px solid #FFFFFF;
+  outline-offset: 4px;
+}
+a:focus-visible::after {
+  content: " ";
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+  border: 2px solid #FFFFFF;
+  outline: 3px solid #0078D7;
+}
+a:active,
+a.engaged {
+  outline: none;
+}
 hr {
   margin-bottom: 0.8em;
   border: none;
@@ -12422,6 +12537,10 @@ div.il_TreeIcons {
 #current_perma_link {
   color: #161616;
   font-size: 90%;
+}
+#current_perma_link:focus-visible {
+  outline: 3px solid #FFFFFF;
+  outline-offset: 2px;
 }
 a.permalink_label > span.glyphicon {
   display: none;
@@ -13048,8 +13167,15 @@ form.form-inline {
   box-shadow: none;
   outline: 3px solid #0078D7;
 }
-.btn-file:focus-within {
+input.btn.btn-default:focus-visible {
   outline: 3px solid #0078D7;
+  outline-offset: 3px;
+}
+.btn-file:focus-within,
+.btn-file:hover:focus-within {
+  z-index: 3;
+  outline: 3px solid #0078D7;
+  outline-offset: 3px;
 }
 textarea.form-control {
   max-width: 100%;
@@ -13118,6 +13244,11 @@ label {
 td.form-inline > div.form-group {
   display: block;
   padding: 4px 0;
+}
+input[type="radio"]:focus:focus-visible,
+input[type="checkbox"]:focus:focus-visible {
+  outline: 3px solid #0078D7;
+  outline-offset: 2px;
 }
 input[type="file"].form-control {
   border: none;
@@ -15274,6 +15405,9 @@ ul.il-mm-selfloading {
   border: 0 none;
   border-bottom: 2px solid #2c2c2c;
 }
+#ilTab a:focus-visible {
+  z-index: 3;
+}
 .ilSetupContent #ilTab {
   margin: 7px 0 23px;
 }
@@ -15303,7 +15437,7 @@ ul.il-mm-selfloading {
 }
 /* Services/UIComponent/GroupedLists */
 div.ilGroupedListH {
-  padding: 6px 0 3px 0;
+  padding: 6px 0 4px 0;
   color: #161616;
 }
 div.ilGroupedListSep {
@@ -17124,7 +17258,24 @@ div#il_startup_logo img {
   background-color: white;
 }
 .ilToolbar .navbar-toggle:focus-visible {
+  position: relative;
+  border: none;
+  outline: 2px solid #FFFFFF;
+  outline-offset: 4px;
+}
+.ilToolbar .navbar-toggle:focus-visible::after {
+  content: " ";
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+  border: 2px solid #FFFFFF;
   outline: 3px solid #0078D7;
+}
+.ilToolbar .navbar-toggle:active,
+.ilToolbar .navbar-toggle.engaged {
+  outline: none;
 }
 .ilToolbar .ilToolbarItems {
   padding: 0;
@@ -17175,7 +17326,7 @@ div#il_startup_logo img {
   margin-right: 0;
 }
 .ilToolbar .btn[disabled] {
-  padding: 3px 6px;
+  padding: 4px 6px;
 }
 .ilToolbar .ilToolbarStickyItems {
   float: left;
@@ -17829,8 +17980,25 @@ body.ilPrtfPdfBody .ilPCMyCoursesToggle img {
   border-bottom: 1px solid #dddddd;
   background-color: white;
 }
-.ilAwarenessItem > div[role='button']:focus-visible {
+.ilAwarenessItem > div[role='button']:focus-visible:focus-visible {
+  position: relative;
+  border: none;
+  outline: 2px solid #FFFFFF;
+  outline-offset: 4px;
+}
+.ilAwarenessItem > div[role='button']:focus-visible:focus-visible::after {
+  content: " ";
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+  border: 2px solid #FFFFFF;
   outline: 3px solid #0078D7;
+}
+.ilAwarenessItem > div[role='button']:focus-visible:active,
+.ilAwarenessItem > div[role='button']:focus-visible.engaged {
+  outline: none;
 }
 .ilAwarenessItem ul {
   margin: 0;
@@ -18974,6 +19142,10 @@ span.ilProfileBadge .modal .img-responsive {
 .ilPreviewInlineContent .ilPreviewText {
   font-size: 100%;
   margin-top: 0;
+}
+.webdav-view-control {
+  text-align: center;
+  padding: 5px;
 }
 .noMargin {
   margin: 0;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -7343,7 +7343,6 @@ button.close {
 }
 .btn:focus-visible {
   position: relative;
-  border: none;
   outline: 2px solid #FFFFFF;
   outline-offset: 4px;
 }
@@ -10871,7 +10870,6 @@ footer {
 }
 .il-link:focus-visible {
   position: relative;
-  border: none;
   outline: 2px solid #FFFFFF;
   outline-offset: 4px;
 }
@@ -11990,7 +11988,6 @@ a:hover {
 }
 a:focus-visible {
   position: relative;
-  border: none;
   outline: 2px solid #FFFFFF;
   outline-offset: 4px;
 }
@@ -13166,6 +13163,11 @@ form.form-inline {
   -webkit-box-shadow: none;
   box-shadow: none;
   outline: 3px solid #0078D7;
+}
+input[type="file"]:focus:focus-visible::after,
+input[type="radio"]:focus:focus-visible::after,
+input[type="checkbox"]:focus:focus-visible::after {
+  content: none;
 }
 input.btn.btn-default:focus-visible {
   outline: 3px solid #0078D7;
@@ -14612,6 +14614,10 @@ table.calmini td.calminiprev > .il_calmini_monthday > a,
 table.calmini td.calmininext > .il_calmini_monthday > a {
   color: #161616;
   display: none;
+}
+table.calmini a {
+  display: block;
+  width: 100%;
 }
 a.callink:link,
 a.callink:visited {
@@ -17259,7 +17265,6 @@ div#il_startup_logo img {
 }
 .ilToolbar .navbar-toggle:focus-visible {
   position: relative;
-  border: none;
   outline: 2px solid #FFFFFF;
   outline-offset: 4px;
 }
@@ -17982,7 +17987,6 @@ body.ilPrtfPdfBody .ilPCMyCoursesToggle img {
 }
 .ilAwarenessItem > div[role='button']:focus-visible:focus-visible {
   position: relative;
-  border: none;
   outline: 2px solid #FFFFFF;
   outline-offset: 4px;
 }

--- a/templates/default/delos.less
+++ b/templates/default/delos.less
@@ -527,6 +527,8 @@ a {
 		color: @link-hover-color;
 		text-decoration: underline;
 	}
+	
+	.il-focus();
 }
 
 hr {
@@ -1141,6 +1143,11 @@ div.il_TreeIcons {
 #current_perma_link {
 	color: @il-text-color;
 	font-size: 90%;
+	
+	&:focus-visible {
+		outline: @il-focus-outline-inner-width solid @il-focus-protection-color;
+		outline-offset: @il-focus-outline-outer-width;
+	}
 }
 a.permalink_label {
 	> span.glyphicon {
@@ -1778,6 +1785,7 @@ span.ilIcalIcon {
 @import "less/Modules/LearningSequence/delos.less";
 @import "less/Services/LearningHistory/delos.less";
 @import "less/Services/Preview/delos.less";
+@import "less/Services/WebDAV/delos.less";
 
 .noMargin {
 	margin: 0;

--- a/templates/default/less/Services/Awareness/delos.less
+++ b/templates/default/less/Services/Awareness/delos.less
@@ -62,7 +62,7 @@
 	background-color:  @il-main-bg;
 
 	> div[role='button']:focus-visible {
-		outline: @il-focus-outline;
+		.il-focus();
 	}
 
 	ul {

--- a/templates/default/less/Services/Calendar/delos.less
+++ b/templates/default/less/Services/Calendar/delos.less
@@ -132,6 +132,10 @@ table.calmini {
 		color: @il-text-color;
 		display:none;
 	}
+	a {
+        display: block;
+        width: 100%;
+    }
 }
 
 a.callink:link, a.callink:visited {

--- a/templates/default/less/Services/Form/delos.less
+++ b/templates/default/less/Services/Form/delos.less
@@ -40,6 +40,12 @@ form.form-inline {
 	outline: @il-focus-outline-inner;
 }
 
+input[type="file"]:focus:focus-visible::after,
+input[type="radio"]:focus:focus-visible::after,
+input[type="checkbox"]:focus:focus-visible::after {
+	content: none;
+}
+
 input.btn.btn-default:focus-visible {
 	outline: @il-focus-outline-inner;
 	outline-offset: @il-focus-outline-inner-width;
@@ -64,7 +70,7 @@ select.form-control {
 	color: @il-standard-form-label-color;
 	font-size: 100%;
 }
-				
+
 .form-control-static {
 	//needed until bootstrap set min-heigth and padding...
 	//no effect without it!
@@ -121,7 +127,7 @@ select.form-control {
 
 label {
 	font-weight: normal;
-}						
+}
 
 td.form-inline > div.form-group {
 	display: block;

--- a/templates/default/less/Services/Form/delos.less
+++ b/templates/default/less/Services/Form/delos.less
@@ -37,11 +37,18 @@ form.form-inline {
 
 .form-control:focus-visible {
 	.box-shadow(none);
-	outline: @il-focus-outline;
+	outline: @il-focus-outline-inner;
 }
 
-.btn-file:focus-within {
-	outline: @il-focus-outline;
+input.btn.btn-default:focus-visible {
+	outline: @il-focus-outline-inner;
+	outline-offset: @il-focus-outline-inner-width;
+}
+
+.btn-file:focus-within, .btn-file:hover:focus-within {
+    z-index: 3;
+    outline: @il-focus-outline-inner;
+    outline-offset: @il-focus-outline-inner-width;
 }
 
 textarea.form-control {
@@ -57,7 +64,7 @@ select.form-control {
 	color: @il-standard-form-label-color;
 	font-size: 100%;
 }
-
+				
 .form-control-static {
 	//needed until bootstrap set min-heigth and padding...
 	//no effect without it!
@@ -114,11 +121,17 @@ select.form-control {
 
 label {
 	font-weight: normal;
-}
+}						
 
 td.form-inline > div.form-group {
 	display: block;
 	padding: 4px 0;
+}
+
+input[type="radio"]:focus:focus-visible,
+input[type="checkbox"]:focus:focus-visible {
+	outline: @il-focus-outline-inner;
+	outline-offset: @il-focus-outline-outer-width;
 }
 
 input[type="file"].form-control {

--- a/templates/default/less/Services/UIComponent/Tabs/delos.less
+++ b/templates/default/less/Services/UIComponent/Tabs/delos.less
@@ -46,6 +46,10 @@
 	border-bottom: 2px solid @il-neutral-color;
 }
 
+#ilTab a:focus-visible {
+	z-index: 3;
+}
+
 .ilSetupContent #ilTab {
 	margin:  7px 0 23px;
 }

--- a/templates/default/less/Services/UIComponent/Toolbar/delos.less
+++ b/templates/default/less/Services/UIComponent/Toolbar/delos.less
@@ -9,9 +9,7 @@
 		background-color: @il-toolbar-bg;
 	}
 	.navbar-toggle {
-		&:focus-visible {
-			outline: @il-focus-outline;
-		}
+		.il-focus();
 	}
 	.ilToolbarItems {
 		padding: 0;

--- a/templates/default/less/Services/WebDAV/delos.less
+++ b/templates/default/less/Services/WebDAV/delos.less
@@ -1,0 +1,4 @@
+.webdav-view-control {
+	text-align: center;
+	padding: @il-focus-outline-inner-width + @il-focus-outline-outer-width;
+}

--- a/templates/default/less/focus-mixin.less
+++ b/templates/default/less/focus-mixin.less
@@ -1,6 +1,6 @@
 // In order not to manually overwrite the focus in all places, the following bootstrap focus mixin is overwritten ilias/libs/bower/bower_components/bootstrap/less/mixins/tab-focus.less.
 
-.tab-focus() {
+.tab-focus(){
     // WebKit-specific. Other browsers will keep their default outline style.
     // (Initially tried to also force default via `outline: initial`,
     // but that seems to erroneously remove the outline in Firefox altogether.)
@@ -17,7 +17,6 @@
 .il-focus() {
 	&:focus-visible {
 		position: relative;
-		border: none;
 		outline: @il-focus-outline-outer;
 		outline-offset: @il-focus-outline-inner-width + @il-focus-outline-outer-width - 1px;
 		

--- a/templates/default/less/focus-mixin.less
+++ b/templates/default/less/focus-mixin.less
@@ -7,17 +7,37 @@
     outline: none;
     outline-offset: 0px;
     &:focus-visible {
-        outline: @il-focus-outline;
+        outline: @il-focus-outline-outer;
+        outline-offset: @il-focus-outline-inner-width + @il-focus-outline-outer-width;
+        
+        .il-focus-after();
     }
   }
 
-.il-focus(){
+.il-focus() {
 	&:focus-visible {
-		outline: @il-focus-outline;
-		outline-offset: 0px;
+		position: relative;
+		border: none;
+		outline: @il-focus-outline-outer;
+		outline-offset: @il-focus-outline-inner-width + @il-focus-outline-outer-width - 1px;
+		
+		.il-focus-after();
 	}
 
 	&:active,&.engaged{
 		outline: none;
+	}
+}
+
+.il-focus-after() {
+	&::after {
+		content: " ";
+		position: absolute;
+		top: -@il-focus-outline-outer-width;
+		left: -@il-focus-outline-outer-width;
+		right: -@il-focus-outline-outer-width;
+		bottom: -@il-focus-outline-outer-width;
+		border: @il-focus-outline-outer;
+		outline: @il-focus-outline-inner;
 	}
 }

--- a/templates/default/less/variables.less
+++ b/templates/default/less/variables.less
@@ -720,7 +720,7 @@ with the il- variable set here.
 @il-background-images-path: "images/";
 
 //** Size for icons: xsmall is used in the tree. e.g.
-@il-icon-size-xsmall: 17px;
+@il-icon-size-xsmall: 15px;
 //** Size for icons: Small is used in the tree. e.g.
 @il-icon-size-small: 20px;
 //** Size for icons: Medium is used in the content-listing. e.g.

--- a/templates/default/less/variables.less
+++ b/templates/default/less/variables.less
@@ -55,6 +55,7 @@ with the il- variable set here.
 
 //** Used to set focus on interactive elements for keyboard navigation.
 @il-focus-color: #0078D7;
+@il-focus-protection-color: #FFFFFF;
 
 //== Extended Colors
 //
@@ -129,7 +130,7 @@ with the il- variable set here.
 @il-padding-large-vertical: 6px;
 @il-padding-large-horizontal: 12px;
 
-@il-padding-small-vertical: 3px;
+@il-padding-small-vertical: 4px;
 @il-padding-small-horizontal: 6px;
 
 @il-padding-xs-vertical: 1px;
@@ -139,9 +140,11 @@ with the il- variable set here.
 @il-border-radius-large: 0px;
 @il-border-radius-small: 0px;
 
-@il-focus-outline: 3px solid @il-focus-color;
+@il-focus-outline-inner: @il-focus-outline-inner-width solid @il-focus-color;
+@il-focus-outline-outer: @il-focus-outline-outer-width solid @il-focus-protection-color;
 // The offset should only be used if the contrast between the focus outline and the component is insufficient.
-@il-focus-outline-offset: 2px;
+@il-focus-outline-inner-width: 3px;
+@il-focus-outline-outer-width: 2px;
 
 //== Layout (UI Layout Page)
 //


### PR DESCRIPTION
This is the second of two pull requests to remove a visibility issue for the focus on tabbing (see: https://mantis.ilias.de/view.php?id=32137). It adds a double outline to the element having :focus-visible. I believe this one to be the superior of the two as it shields the outline on both sides from its environment.

A few important notes:
- This does not touch the entries in the main- and metabar, as there the focus is shown as a border. A few changes where added to keep it this way.
- I had to move the open/close glyph in the slate to avoid removing it. I don't think this has serious consequences for accessibility, but we could also change the approach: I would then move the border to before and keep after. This would require more changes to CSS then the approach I chose here.
- I introduced new less variables and renamed existing ones.
- There is still a issue on FF: When tabbing into the breadcrumb it gets an ellipse. Will try to find a workaround.