### PR TITLE
Setup: Use `ClientId` type in setup

### DIFF
--- a/setup/classes/class.ilSetupAgent.php
+++ b/setup/classes/class.ilSetupAgent.php
@@ -44,7 +44,7 @@ class ilSetupAgent implements Setup\Agent
         return $this->refinery->custom()->transformation(function ($data) {
             $datetimezone = $this->refinery->to()->toNew(\DateTimeZone::class);
             return new \ilSetupConfig(
-                $data["client_id"],
+                $this->data->clientId($data["client_id"] ?? ''),
                 $datetimezone->transform([$data["server_timezone"] ?? "UTC"]),
                 $data["register_nic"] ?? false
             );

--- a/setup/classes/class.ilSetupConfig.php
+++ b/setup/classes/class.ilSetupConfig.php
@@ -7,20 +7,15 @@ use ILIAS\Data\Password;
 
 class ilSetupConfig implements Setup\Config
 {
-    protected string $client_id;
+    protected \ILIAS\Data\ClientId $client_id;
     protected \DateTimeZone $server_timezone;
     protected bool $register_nic;
 
     public function __construct(
-        string $client_id,
+        \ILIAS\Data\ClientId $client_id,
         \DateTimeZone $server_timezone,
         bool $register_nic
     ) {
-        if (!preg_match("/^[A-Za-z0-9]+$/", $client_id)) {
-            throw new \InvalidArgumentException(
-                "client_id must not be empty and may only contain alphanumeric characters"
-            );
-        }
         $this->client_id = $client_id;
         $this->server_timezone = $server_timezone;
         $this->register_nic = $register_nic;
@@ -28,7 +23,7 @@ class ilSetupConfig implements Setup\Config
 
     public function getClientId() : string
     {
-        return $this->client_id;
+        return $this->client_id->toString();
     }
 
     public function getServerTimeZone() : \DateTimeZone


### PR DESCRIPTION
The `Client Id` validation (to be more precisely: the `RegEx`) in the setup differs from that used in our `ClientId` data type. This PR applies a fix by using the `ClientId` data type in the `ilSetupConfig` instead. 

This should be cherry-picked to `release_7`. The `Type Property` MUST be removed afterwards.

Mantis Issue: https://mantis.ilias.de/view.php?id=32301