### PR TITLE
Remove trailing space

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -482,8 +482,8 @@ are printed bold**, all other fields might be omitted. A minimal example is
 		"sub_directory" : "/chat",
 		"https" : {
 			"cert" : "/etc/ssl/certs/server.pem",
-			"key " : "/etc/ssl/private/server.key",
-			"dhparam " : "/etc/ssl/private/dhparam.pem"
+			"key" : "/etc/ssl/private/server.key",
+			"dhparam" : "/etc/ssl/private/dhparam.pem"
 		},
 		"log" : "/var/log/ilias_onscreenchat/access.log",
 		"log_level" : "info",


### PR DESCRIPTION
Remove trailing space from options `key` and `dhparam`. The space leads to the options not being recognized by the setup CLI and therefore missing in the configuration file server.cfg.