### PR TITLE
Fix #31111: missing custom metadata after upgrade.

### DIFF
--- a/setup/sql/7_hotfixes.php
+++ b/setup/sql/7_hotfixes.php
@@ -1378,11 +1378,39 @@ if(!$ilDB->indexExistsByFields('il_bt_bucket', ['user_id'])) {
 <#73>
 <?php
 $ilDB->replace("settings", [        // pk
-                           "module" => ["text", "common"],
-                           "keyword" => ["text", "rep_favourites"],
+                                    "module" => ["text", "common"],
+                                    "keyword" => ["text", "rep_favourites"],
 ], [
         "value" => ["text", "1"]
     ]
 );
 
+?>
+<#74>
+<?php
+// https://mantis.ilias.de/view.php?id=31111
+// migrate text-based custom metadata from ILIAS6 table to the new one.
+if ($ilDB->tableExists('adv_md_values_text') &&
+    $ilDB->tableExists('adv_md_values_ltext')
+) {
+    // inserts all values from adv_md_values_text into adv_md_values_ltext WITHOUT
+    // adv_md_values_ltext.value_index, ignoring duplicate entries.
+    $ilDB->manipulate("
+        INSERT IGNORE INTO adv_md_values_ltext (field_id, obj_id, `value`, value_index, disabled, sub_type, sub_id)
+            SELECT val.field_id, val.obj_id, val.value, '', val.disabled, val.sub_type, val.sub_id
+                FROM adv_md_values_text AS val
+        ;
+    ");
+
+    // inserts all values from adv_md_values_text into adv_md_values_ltext WITH
+    // adv_md_values_ltext.value_index, whereas the value_index will be the default
+    // lang-code of adv_md_field_int because the old table didn't store this information.
+    $ilDB->manipulate("
+        INSERT IGNORE INTO adv_md_values_ltext (field_id, obj_id, `value`, value_index, disabled, sub_type, sub_id)
+            SELECT val.field_id, val.obj_id, val.value, field.lang_code, val.disabled, val.sub_type, val.sub_id
+                FROM adv_md_values_text AS val
+                JOIN adv_md_field_int AS field ON field.field_id = val.field_id
+        ;
+    ");
+}
 ?>

--- a/setup/sql/dbupdate_05.php
+++ b/setup/sql/dbupdate_05.php
@@ -5868,31 +5868,3 @@ if (!$ilDB->tableColumnExists('media_item', 'duration')) {
     ));
 }
 ?>
-<#5752>
-<?php
-// https://mantis.ilias.de/view.php?id=31111
-// migrate text-based custom metadata from ILIAS6 table to the new one.
-if ($ilDB->tableExists('adv_md_values_text') &&
-    $ilDB->tableExists('adv_md_values_ltext')
-) {
-    // inserts all values from adv_md_values_text into adv_md_values_ltext WITHOUT
-    // adv_md_values_ltext.value_index, ignoring duplicate entries.
-    $ilDB->manipulate("
-        INSERT IGNORE INTO adv_md_values_ltext (field_id, obj_id, `value`, value_index, disabled, sub_type, sub_id)
-            SELECT val.field_id, val.obj_id, val.value, '', val.disabled, val.sub_type, val.sub_id
-                FROM adv_md_values_text AS val
-        ;
-    ");
-
-    // inserts all values from adv_md_values_text into adv_md_values_ltext WITH
-    // adv_md_values_ltext.value_index, whereas the value_index will be the default
-    // lang-code of adv_md_field_int because the old table didn't store this information.
-    $ilDB->manipulate("
-        INSERT IGNORE INTO adv_md_values_ltext (field_id, obj_id, `value`, value_index, disabled, sub_type, sub_id)
-            SELECT val.field_id, val.obj_id, val.value, field.lang_code, val.disabled, val.sub_type, val.sub_id
-                FROM adv_md_values_text AS val
-                JOIN adv_md_field_int AS field ON field.field_id = val.field_id
-        ;
-    ");
-}
-?>

--- a/setup/sql/dbupdate_05.php
+++ b/setup/sql/dbupdate_05.php
@@ -5868,3 +5868,31 @@ if (!$ilDB->tableColumnExists('media_item', 'duration')) {
     ));
 }
 ?>
+<#5752>
+<?php
+// https://mantis.ilias.de/view.php?id=31111
+// migrate text-based custom metadata from ILIAS6 table to the new one.
+if ($ilDB->tableExists('adv_md_values_text') &&
+    $ilDB->tableExists('adv_md_values_ltext')
+) {
+    // inserts all values from adv_md_values_text into adv_md_values_ltext WITHOUT
+    // adv_md_values_ltext.value_index, ignoring duplicate entries.
+    $ilDB->manipulate("
+        INSERT IGNORE INTO adv_md_values_ltext (field_id, obj_id, `value`, value_index, disabled, sub_type, sub_id)
+            SELECT val.field_id, val.obj_id, val.value, '', val.disabled, val.sub_type, val.sub_id
+                FROM adv_md_values_text AS val
+        ;
+    ");
+
+    // inserts all values from adv_md_values_text into adv_md_values_ltext WITH
+    // adv_md_values_ltext.value_index, whereas the value_index will be the default
+    // lang-code of adv_md_field_int because the old table didn't store this information.
+    $ilDB->manipulate("
+        INSERT IGNORE INTO adv_md_values_ltext (field_id, obj_id, `value`, value_index, disabled, sub_type, sub_id)
+            SELECT val.field_id, val.obj_id, val.value, field.lang_code, val.disabled, val.sub_type, val.sub_id
+                FROM adv_md_values_text AS val
+                JOIN adv_md_field_int AS field ON field.field_id = val.field_id
+        ;
+    ");
+}
+?>


### PR DESCRIPTION
Hello @smeyer-ilias, as described in https://mantis.ilias.de/view.php?id=31111 an update step is missing that migrates data from the database-table `adv_md_values_text` to `adv_md_values_ltext`. This PR introduces that missing step.

I made an assumption though, because the new table `adv_md_values_ltext` contains another column called `value_index`, where I just adpoted the default lang-code from `adv_md_field_int` because that information previously didn't exist.

Is it also necessary to create an entry with and without value_index? because that is the default behaviour when adding custom-metadata values per GUI in ILIAS 7 and I didn't know if that's intended.