### PR TITLE
Implement Renderer for plugins to prevent collision

### DIFF
--- a/src/UI/Implementation/Render/AdditionRenderer.php
+++ b/src/UI/Implementation/Render/AdditionRenderer.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace ILIAS\UI\Implementation\Render;
+
+use ILIAS\UI\Component\Component;
+use ILIAS\UI\Renderer;
+
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
+/**
+ * An entity that renders additions on components to a string output.
+ *
+ * @author	Ingmar Szmais <iszmais@databay.de>
+ */
+interface AdditionRenderer
+{
+    /**
+     * Render the addition.
+     *
+     * @param	Component 		$component
+     * @param	Renderer		$default_renderer
+     * @throws	\LogicException	if renderer is called with a component it can't render
+     * @return	string
+     */
+    public function render(Component $component, Renderer $default_renderer) : string;
+
+    /**
+     * Announce resources this renderer requires.
+     *
+     * @param	ResourceRegistry	$registry
+     * @return	null
+     */
+    public function registerResources(ResourceRegistry $registry);
+
+    public function append() : bool;
+
+    public function prepend() : bool;
+}
+

--- a/src/UI/Implementation/Render/PluginRenderer.php
+++ b/src/UI/Implementation/Render/PluginRenderer.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+namespace ILIAS\UI\Implementation\Render;
+
+use ILIAS\UI\Component\Component;
+use ILIAS\UI\Implementation\DefaultRenderer;
+
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
+/**
+ * Class PluginRenderer
+ *
+ * @author Ingmar Szmais <iszmais@databay.de>
+ */
+class PluginRenderer extends DefaultRenderer
+{
+    protected $registry;
+    protected $default;
+
+    public function __construct(Loader $component_renderer_loader, ResourceRegistry $registry, DefaultRenderer $default)
+    {
+        $this->registry = $registry;
+        $this->default = $default;
+        parent::__construct($component_renderer_loader);
+    }
+
+    protected function getRendererFor(Component $component, $renderer = null) : ComponentRenderer
+    {
+        if ($renderer) {
+            if ($renderer instanceof ComponentRenderer) {
+                $default = $this->default->getRendererFor($component);
+                if ($default instanceof WrappingRenderer) {
+                    $default->exchangeRenderer($renderer);
+                } else {
+                    $default = $renderer;
+                }
+                $default->registerResources($this->registry);
+                return $default;
+            }
+
+            if ($renderer instanceof AdditionRenderer) {
+                $wrapper = new WrappingRenderer($this->default->getRendererFor($component));
+                if ($renderer->prepend() === true) {
+                    $wrapper->prependRenderer($renderer);
+                }
+                if ($renderer->append() === true) {
+                    $wrapper->appendRenderer($renderer);
+                }
+                $wrapper->registerResources($this->registry);
+                return $wrapper;
+            }
+        }
+        return $this->default->getRendererFor($component);
+    }
+}

--- a/src/UI/Implementation/Render/PluginRenderer.php
+++ b/src/UI/Implementation/Render/PluginRenderer.php
@@ -36,6 +36,17 @@ class PluginRenderer extends DefaultRenderer
         parent::__construct($component_renderer_loader);
     }
 
+
+    /**
+     * @inheritdoc
+     */
+    public function withAdditionalContext(Component $context)
+    {
+        $clone = parent::withAdditionalContext($context);
+        $clone->default = $clone->default->withAdditionalContext($context);
+        return $clone;
+    }
+
     protected function getRendererFor(Component $component, $renderer = null) : ComponentRenderer
     {
         if ($renderer) {

--- a/src/UI/Implementation/Render/WrappingRenderer.php
+++ b/src/UI/Implementation/Render/WrappingRenderer.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types=1);
+
+namespace ILIAS\UI\Implementation\Render;
+
+use ILIAS\UI\Component\Component;
+use ILIAS\UI\Renderer;
+
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
+/**
+ * Class WrappingRenderer
+ *
+ * @author Ingmar Szmais <iszmais@databay.de>
+ */
+class WrappingRenderer implements ComponentRenderer
+{
+    protected $prefix = null;
+    protected $renderer;
+    protected $suffix = null;
+
+
+    public function __construct(ComponentRenderer $renderer)
+    {
+        $this->renderer = $renderer;
+    }
+
+    public function exchangeRenderer(ComponentRenderer $renderer)
+    {
+        $this->renderer = $renderer;
+    }
+
+    public function prependRenderer(AdditionRenderer $renderer) : void
+    {
+        $this->prefix = $renderer;
+    }
+
+    public function appendRenderer(AdditionRenderer $renderer) : void
+    {
+        $this->suffix = $renderer;
+    }
+
+    public function render(Component $component, Renderer $default_renderer)
+    {
+        $out = '';
+        if ($this->prefix !== null) {
+            $out .= $this->prefix->render($component, $default_renderer);
+        }
+        $out .= $this->renderer->render($component, $default_renderer);
+        if ($this->suffix !== null) {
+            $out .= $this->suffix->render($component, $default_renderer);
+        }
+
+        return $out;
+    }
+
+    public function registerResources(ResourceRegistry $registry)
+    {
+        $this->renderer->registerResources($registry);
+        if ($this->prefix !== null) {
+            $this->prefix->registerResources($registry);
+        }
+        if ($this->suffix !== null) {
+            $this->suffix->registerResources($registry);
+        }
+    }
+}

--- a/tests/UI/Renderer/PluginRendererTest.php
+++ b/tests/UI/Renderer/PluginRendererTest.php
@@ -1,0 +1,98 @@
+<?php
+
+require_once(__DIR__ . "/TestComponent.php");
+require_once(__DIR__ . "/../Base.php");
+
+use \ILIAS\UI\Component as C;
+
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
+class PluginRendererTest extends ILIAS_UI_TestBase
+{
+    public function test_getRenderer_successfully()
+    {
+        $plugin_renderer = $this->getPluginRenderer();
+        $renderer = $plugin_renderer->_getRendererFor(new C\Test\TestComponent('test'));
+        $this->assertInstanceOf(\ILIAS\UI\Implementation\Render\ComponentRenderer::class, $renderer);
+    }
+
+    public function test_getRenderer_caching()
+    {
+        $plugin_renderer = $this->getPluginRenderer();
+        $renderer1 = $plugin_renderer->_getRendererFor(new C\Test\TestComponent('test'));
+        $renderer2 = $plugin_renderer->_getRendererFor(new C\Test\TestComponent('test'));
+        $this->assertTrue($renderer1 === $renderer2, "Instances not equal");
+    }
+
+    public function test_getRenderer_withAppend()
+    {
+        $plugin_renderer = $this->getPluginRendererWithAppend();
+        $renderer = $plugin_renderer->_getRendererFor(new \ILIAS\UI\Implementation\Component\Symbol\Glyph\Glyph("up", "up"));
+        $this->assertInstanceOf(\ILIAS\UI\Implementation\Render\ComponentRenderer::class, $renderer);
+        $renderer = $plugin_renderer->_getRendererFor(new C\Test\TestComponent('test'));
+        $this->assertInstanceOf(\ILIAS\UI\Implementation\Render\WrappingRenderer::class, $renderer);
+    }
+
+    public function test_getRenderer_withPrepend()
+    {
+        $plugin_renderer = $this->getPluginRendererWithPrepend();
+        $renderer = $plugin_renderer->_getRendererFor(new \ILIAS\UI\Implementation\Component\Symbol\Glyph\Glyph("up", "up"));
+        $this->assertInstanceOf(\ILIAS\UI\Implementation\Render\ComponentRenderer::class, $renderer);
+        $renderer = $plugin_renderer->_getRendererFor(new C\Test\TestComponent('test'));
+        $this->assertInstanceOf(\ILIAS\UI\Implementation\Render\WrappingRenderer::class, $renderer);
+    }
+
+    public function test_getRenderer_withReplace()
+    {
+        $plugin_renderer = $this->getPluginRendererWithReplace();
+        $renderer = $plugin_renderer->_getRendererFor(new \ILIAS\UI\Implementation\Component\Symbol\Glyph\Glyph("up", "up"));
+        $this->assertInstanceOf(\ILIAS\UI\Implementation\Render\ComponentRenderer::class, $renderer);
+        $renderer = $plugin_renderer->_getRendererFor(new C\Test\TestComponent('test'));
+        $this->assertInstanceOf(C\Test\Renderer::class, $renderer);
+    }
+
+    public function test_render()
+    {
+        $component = new C\Test\TestComponent('test');
+        $plugin_renderer = $this->getPluginRenderer();
+        $html = $plugin_renderer->_getRendererFor($component)->render($component, $this->getDefaultRenderer());
+        $this->assertEquals("test", $html);
+    }
+
+    public function test_render_with_append()
+    {
+        $component = new C\Test\TestComponent('test');
+        $plugin_renderer = $this->getPluginRendererWithAppend();
+        $html = $plugin_renderer->_getRendererFor($component)->render($component, $this->getDefaultRenderer());
+        $this->assertEquals("testappend", $html);
+    }
+
+    public function test_render_with_prepend()
+    {
+        $component = new C\Test\TestComponent('test');
+        $plugin_renderer = $this->getPluginRendererWithPrepend();
+        $html = $plugin_renderer->_getRendererFor($component)->render($component, $this->getDefaultRenderer());
+        $this->assertEquals("prependtest", $html);
+    }
+
+    public function test_render_with_replace()
+    {
+        $component = new C\Test\TestComponent('test');
+        $plugin_renderer = $this->getPluginRendererWithReplace();
+        $html = $plugin_renderer->_getRendererFor($component)->render($component, $this->getDefaultRenderer());
+        $this->assertEquals("replace", $html);
+    }
+}
+


### PR DESCRIPTION
~~This PR prpose a solution to https://mantis.ilias.de/view.php?id=32196 by offering the plugin developers a base renderer wich can handle multiple replacements/eschanges by `exchangeUIRendererAfterInitialization() `.~~

~~Additional this also adds a wrapping Renderer wich allows to prepend or append conent to ILIAS components without having to manipulate them and therefore allows multiple plugins to take an effect on the same component.
This provides a new way to use the ILIAS5.4 concept of APPEND and PREPEND in UIHookPlugins without take along their problems.~~

This PR will centralize the basic function of chaining renderers inside a abstract renderer to simplify the usage of renderer exchanges without the need to implment a chaining yourself