### PR TITLE
Auth/Logout: Use CSRF token for logout HTTP GET (Mantis 29991)

### DIFF
--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -100,7 +100,9 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
      */
     public function getUnsafeGetCommands() : array
     {
-        return [];
+        return [
+            'doLogout'
+        ];
     }
 
     /**

--- a/Services/User/classes/Provider/UserMetaBarProvider.php
+++ b/Services/User/classes/Provider/UserMetaBarProvider.php
@@ -19,6 +19,7 @@ use ILIAS\GlobalScreen\Identification\IdentificationInterface;
 use ILIAS\GlobalScreen\Scope\MetaBar\Provider\AbstractStaticMetaBarProvider;
 use ilUtil;
 use ILIAS\GlobalScreen\Helper\BasicAccessCheckClosuresSingleton;
+use ilStartUpGUI;
 
 /**
  * @author Fabian Schmid <fs@studer-raimann.ch>
@@ -53,8 +54,14 @@ class UserMetaBarProvider extends AbstractStaticMetaBarProvider
             ->withPosition(2)
             ->withSymbol($f->symbol()->icon()->custom(ilUtil::getImagePath("icon_personal_settings.svg"), $txt("personal_settings")));
 
+        $this->dic->ctrl()->setTargetScript('logout.php');
+        // Actually, we only need the CSRF token, but there is no other way to retrieve this.
+        $logoutUrl = $this->dic->ctrl()->getLinkTargetByClass([ilStartUpGUI::class], 'doLogout');
+        $logoutUrl .= '&lang=' . $this->dic->user()->getCurrentLanguage();
+        $this->dic->ctrl()->setTargetScript('ilias.php');
+
         $children[] = $mb->linkItem($id('logout'))
-            ->withAction("logout.php?lang=" . $this->dic->user()->getCurrentLanguage())
+            ->withAction($logoutUrl)
             ->withPosition(3)
             ->withTitle($txt("logout"))
             ->withSymbol($f->symbol()->glyph()->logout());


### PR DESCRIPTION
This PR adds a `CSRF` token to the logout URL of the link in the ILIAS `MetaBar`.

Mantis Issue: https://mantis.ilias.de/view.php?id=29991