### PR TITLE
User/Registration: Check for existing login only when form is valid

### DIFF
--- a/Services/Registration/classes/class.ilAccountRegistrationGUI.php
+++ b/Services/Registration/classes/class.ilAccountRegistrationGUI.php
@@ -355,18 +355,22 @@ class ilAccountRegistrationGUI
         if (!ilUtil::isLogin($login)) {
             $login_obj->setAlert($this->lng->txt("login_invalid"));
             $form_valid = false;
-        } elseif (ilObjUser::_loginExists($login)) {
-            if(!empty($captcha) && empty($captcha->getAlert()) || empty($captcha)) {
-                $login_obj->setAlert($this->lng->txt("login_exists"));
+        }
+
+        if ($form_valid) {
+            if (ilObjUser::_loginExists($login)) {
+                if (empty($captcha) || empty($captcha->getAlert())) {
+                    $login_obj->setAlert($this->lng->txt("login_exists"));
+                }
+                $form_valid = false;
+            } elseif ((int) $ilSetting->get('allow_change_loginname') &&
+                (int) $ilSetting->get('reuse_of_loginnames') == 0 &&
+                ilObjUser::_doesLoginnameExistInHistory($login)) {
+                if (empty($captcha) || empty($captcha->getAlert())) {
+                    $login_obj->setAlert($this->lng->txt("login_exists"));
+                }
+                $form_valid = false;
             }
-            $form_valid = false;
-        } elseif ((int) $ilSetting->get('allow_change_loginname') &&
-            (int) $ilSetting->get('reuse_of_loginnames') == 0 &&
-            ilObjUser::_doesLoginnameExistInHistory($login)) {
-            if(!empty($captcha) && empty($captcha->getAlert()) || empty($captcha)) {
-                $login_obj->setAlert($this->lng->txt("login_exists"));
-            }
-            $form_valid = false;
         }
 
         if (!$form_valid) {


### PR DESCRIPTION
This PR changes the (moment of) feedback given to actors regarding already used user names when submitting an **invalid** registration form.

Mantis Issue: https://mantis.ilias.de/view.php?id=32037