### PR TITLE
Authentication: Use `SameSite` cookie attribute

### DIFF
--- a/Services/Http/classes/class.ilHTTPS.php
+++ b/Services/Http/classes/class.ilHTTPS.php
@@ -206,13 +206,14 @@ class ilHTTPS
                 define('IL_COOKIE_SECURE', true);
             }
 
-            session_set_cookie_params(
-                IL_COOKIE_EXPIRE,
-                IL_COOKIE_PATH,
-                IL_COOKIE_DOMAIN,
-                true,
-                IL_COOKIE_HTTPONLY
-            );
+            session_set_cookie_params([
+                'lifetime' => IL_COOKIE_EXPIRE,
+                'path' => IL_COOKIE_PATH,
+                'domain' => IL_COOKIE_DOMAIN,
+                'secure' => IL_COOKIE_SECURE,
+                'httponly' => true,
+                'samesite' => (strtolower(session_get_cookie_params()['samesite'] ?? '')) === 'strict' ? session_get_cookie_params()['samesite'] : 'Lax'
+            ]);
         }
 
         return true;

--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -1040,7 +1040,7 @@ class ilStartUpGUI
         if (ilPublicSectionSettings::getInstance()->isEnabledForDomain($_SERVER['SERVER_NAME']) &&
             $ilAccess->checkAccessOfUser(ANONYMOUS_USER_ID, "read", "", ROOT_FOLDER_ID)) {
             $rtpl->setCurrentBlock("homelink");
-            $rtpl->setVariable("CLIENT_ID", "?client_id=" . $_COOKIE["ilClientId"] . "&lang=" . $lng->getLangKey());
+            $rtpl->setVariable("CLIENT_ID", "?client_id=" . CLIENT_ID . "&lang=" . $lng->getLangKey());
             $rtpl->setVariable("TXT_HOME", $lng->txt("home"));
             $rtpl->parseCurrentBlock();
         }
@@ -1386,11 +1386,10 @@ class ilStartUpGUI
         }
 
         // reset cookie
-        $client_id = $_COOKIE["ilClientId"];
         ilUtil::setCookie("ilClientId", "");
 
         // redirect and show logout information
-        $this->ctrl->setParameter($this, 'client_id', $client_id);
+        $this->ctrl->setParameter($this, 'client_id', CLIENT_ID);
         $this->ctrl->setParameter($this, 'lang', $user_language);
         $this->ctrl->redirect($this, 'showLogout');
     }
@@ -1808,7 +1807,7 @@ class ilStartUpGUI
             $soap_client->call(
                 'deleteExpiredDualOptInUserObjects',
                 [
-                    $_COOKIE[session_name()] . '::' . $_COOKIE['ilClientId'],
+                    $_COOKIE[session_name()] . '::' . CLIENT_ID,
                     $exception->getCode() // user id
                 ]
             );
@@ -1850,7 +1849,7 @@ class ilStartUpGUI
         $view_title = $lng->txt('login_to_ilias');
         if ($a_show_back) {
             // #13400
-            $param = 'client_id=' . $_COOKIE['ilClientId'] . '&lang=' . $lng->getLangKey();
+            $param = 'client_id=' . CLIENT_ID . '&lang=' . $lng->getLangKey();
 
             $tpl->setCurrentBlock('link_item_bl');
             $tpl->setVariable('LINK_TXT', $view_title);

--- a/Services/Utilities/classes/class.ilUtil.php
+++ b/Services/Utilities/classes/class.ilUtil.php
@@ -4690,14 +4690,25 @@ class ilUtil
             $secure = IL_COOKIE_SECURE;
         }
 
+        $cookie_parameters = [
+            'expires' => $expire,
+            'path' => IL_COOKIE_PATH,
+            'domain' => IL_COOKIE_DOMAIN,
+            'secure' => $secure,
+            'httponly' => IL_COOKIE_HTTPONLY,
+        ];
+
+        if (
+            $secure &&
+            (!isset(session_get_cookie_params()['samesite']) || strtolower(session_get_cookie_params()['samesite']) !== 'strict')
+        ) {
+            $cookie_parameters['samesite'] = 'Lax';
+        }
+
         setcookie(
             $a_cookie_name,
             $a_cookie_value,
-            $expire,
-            IL_COOKIE_PATH,
-            IL_COOKIE_DOMAIN,
-            $secure,
-            IL_COOKIE_HTTPONLY
+            $cookie_parameters
         );
 
         if ((bool) $a_also_set_super_global) {


### PR DESCRIPTION
This PR adds the `SameSite` cookie attribute to the session cookie and the common cookies send by ILIAS.

- ~~`Strict` is used for the `Session Cookie`~~
- `Lax` is used for the `Session Cookie` and other cookies
- I re-parametrized the `client_id` cookie after the bootstrap process of ILIAS is completed to workaround the known `chicken-egg` situation, which led to wrong cookie flags applied to the `client_id` cookie. This was a general problem in the past (also valid for the `secure` flag).

The flag is only set in `Secure Contexts` (https). The cookie parameters are passed by using the `options` array introduced with `PHP 7.3`. This PR can only be cherry-picked to `trunk` (or to be more precisely: to `ILIAS >= 8.x`).

See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite

Mantis Issue: https://mantis.ilias.de/view.php?id=32043