### PR TITLE
Data/ClientId: Throw exception if argument is empty

### DIFF
--- a/src/Data/ClientId.php
+++ b/src/Data/ClientId.php
@@ -21,6 +21,10 @@ class ClientId
      */
     public function __construct(string $clientId)
     {
+        if ($clientId === '') {
+            throw new \InvalidArgumentException('Empty $clientId');
+        }
+
         if (preg_match('/[^A-Za-z0-9#_\.\-]/', $clientId)) {
             throw new \InvalidArgumentException('Invalid value for $clientId');
         }

--- a/tests/Data/ClientIdTest.php
+++ b/tests/Data/ClientIdTest.php
@@ -28,9 +28,16 @@ class ClientIdTest extends TestCase
     public function clientIdProvider() : array
     {
         return [
-            ['default'],
-            ['default_with_underscore'],
-            ['ilias_with_12345'],
+            'single letter' => ['c'],
+            'multiple letters' => ['client'],
+            'single uppercase letter' => ['C'],
+            'multiple uppercase letters' => ['CLIENT'],
+            'single digit' => ['1'],
+            'multiple digits' => ['12'],
+            'letters + underscores' => ['client_with_underscore'],
+            'letters + underscores + digits' => ['client_with_12345'],
+            'letters + hyphens' => ['client-with-hyphen'],
+            'dots + sharps' => ['.#'] // looks weird, but is considered valid
         ];
     }
 
@@ -40,7 +47,10 @@ class ClientIdTest extends TestCase
     public function invalidClientIdProvider() : array
     {
         return [
-            ['../../some/obscure/path'],
+            'path traversal' => ['../../some/obscure/path'],
+            'space in between' => ['my client'],
+            'wrapped in spaces' => [' myclient '],
+            'umlaut' => ['clüent'],
         ];
     }
 
@@ -58,7 +68,7 @@ class ClientIdTest extends TestCase
      * @param string $value
      * @dataProvider invalidClientIdProvider
      */
-    public function tesInvalidArguments(string $value)
+    public function testInvalidArguments(string $value)
     {
         try {
             $clientId = $this->f->clientId($value);
@@ -66,5 +76,12 @@ class ClientIdTest extends TestCase
         } catch (\InvalidArgumentException $e) {
             $this->assertTrue(true);
         }
+    }
+
+    public function testClientIdCannotBeCreatedByAnEmptyString() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->f->clientId('');
     }
 }


### PR DESCRIPTION
This PR adds an additional constraint to the validation of the passed `$cliendId` string: A `Client ID` MUST NOT be an empty string, therefore a dedicated exception should be thrown.

If approved, this should be cherry-picked to `release_7` and `trunk`.