### PR TITLE
PHP 8: Code Review `Glossary`

### DIFF
--- a/Modules/Glossary/Definition/class.ilGlossaryDefPage.php
+++ b/Modules/Glossary/Definition/class.ilGlossaryDefPage.php
@@ -31,13 +31,4 @@ class ilGlossaryDefPage extends ilPageObject
             $a_page_content->autoLinkGlossaries($glos);
         }
     }
-
-    /**
-     * Get object id of repository object that contains this page,
-     * return 0 if page does not belong to a repo object
-     */
-    public function getRepoObjId() : ?int
-    {
-        return $this->getParentId();
-    }
 }

--- a/Modules/Glossary/Export/class.ilGlossaryDataSet.php
+++ b/Modules/Glossary/Export/class.ilGlossaryDataSet.php
@@ -43,8 +43,8 @@ class ilGlossaryDataSet extends ilDataSet
     {
         return array("5.1.0", "5.4.0");
     }
-    
-    public function getXmlNamespace(string $a_entity, string $a_schema_version) : string
+
+    protected function getXmlNamespace(string $a_entity, string $a_schema_version) : string
     {
         return "https://www.ilias.de/xml/Modules/Glossary/" . $a_entity;
     }

--- a/Modules/Glossary/Export/class.ilGlossaryExporter.php
+++ b/Modules/Glossary/Export/class.ilGlossaryExporter.php
@@ -89,7 +89,7 @@ class ilGlossaryExporter extends ilXmlExporter
                     $tax_ids[$t_ids[0]] = $t_ids[0];
                 }
             }
-            if (sizeof($tax_ids)) {
+            if (count($tax_ids)) {
                 $deps[] = array(
                     "component" => "Services/Taxonomy",
                     "entity" => "tax",
@@ -101,13 +101,13 @@ class ilGlossaryExporter extends ilXmlExporter
             $advmd_ids = array();
             foreach ($a_ids as $id) {
                 $rec_ids = $this->getActiveAdvMDRecords($id);
-                if (sizeof($rec_ids)) {
+                if (count($rec_ids)) {
                     foreach ($rec_ids as $rec_id) {
                         $advmd_ids[] = $id . ":" . $rec_id;
                     }
                 }
             }
-            if (sizeof($advmd_ids)) {
+            if (count($advmd_ids)) {
                 $deps[] = array(
                     "component" => "Services/AdvancedMetaData",
                     "entity" => "advmd",

--- a/Modules/Glossary/Presentation/class.ilGlossaryPresentationGUI.php
+++ b/Modules/Glossary/Presentation/class.ilGlossaryPresentationGUI.php
@@ -452,7 +452,7 @@ class ilGlossaryPresentationGUI implements ilCtrlBaseClassInterface
         // toc
         if (count($defs) > 1 && $a_page_mode == ilPageObjectGUI::PRESENTATION) {
             $def_tpl->setCurrentBlock("toc");
-            for ($j = 1; $j <= count($defs); $j++) {
+            for ($j = 1, $jMax = count($defs); $j <= $jMax; $j++) {
                 $def_tpl->setCurrentBlock("toc_item");
                 $def_tpl->setVariable("TOC_DEF_NR", $j);
                 $def_tpl->setVariable("TOC_DEF", $lng->txt("cont_definition"));
@@ -462,7 +462,7 @@ class ilGlossaryPresentationGUI implements ilCtrlBaseClassInterface
             $def_tpl->parseCurrentBlock();
         }
 
-        for ($j = 0; $j < count($defs); $j++) {
+        for ($j = 0, $jMax = count($defs); $j < $jMax; $j++) {
             $def = $defs[$j];
             $page_gui = new ilGlossaryDefPageGUI($def["id"]);
             $this->basicPageGuiInit($page_gui);
@@ -511,26 +511,24 @@ class ilGlossaryPresentationGUI implements ilCtrlBaseClassInterface
             foreach ($sources as $src) {
                 $type = explode(':', $src['type']);
                 
-                if ($type[0] == 'lm') {
-                    if ($type[1] == 'pg') {
-                        $title = ilLMPageObject::_getPresentationTitle($src['id']);
-                        $lm_id = ilLMObject::_lookupContObjID($src['id']);
-                        $lm_title = ilObject::_lookupTitle($lm_id);
-                        $def_tpl->setCurrentBlock('backlink_item');
-                        $ref_ids = ilObject::_getAllReferences($lm_id);
-                        $access = false;
-                        foreach ($ref_ids as $rid) {
-                            if ($ilAccess->checkAccess("read", "", $rid)) {
-                                $access = true;
-                            }
+                if ($type[0] == 'lm' && $type[1] == 'pg') {
+                    $title = ilLMPageObject::_getPresentationTitle($src['id']);
+                    $lm_id = ilLMObject::_lookupContObjID($src['id']);
+                    $lm_title = ilObject::_lookupTitle($lm_id);
+                    $def_tpl->setCurrentBlock('backlink_item');
+                    $ref_ids = ilObject::_getAllReferences($lm_id);
+                    $access = false;
+                    foreach ($ref_ids as $rid) {
+                        if ($ilAccess->checkAccess("read", "", $rid)) {
+                            $access = true;
                         }
-                        if ($access) {
-                            $def_tpl->setCurrentBlock("backlink_item");
-                            $def_tpl->setVariable("BACKLINK_LINK", ILIAS_HTTP_PATH . "/goto.php?target=" . $type[1] . "_" . $src['id']);
-                            $def_tpl->setVariable("BACKLINK_ITEM", $lm_title . ": " . $title);
-                            $def_tpl->parseCurrentBlock();
-                            $backlist_shown = true;
-                        }
+                    }
+                    if ($access) {
+                        $def_tpl->setCurrentBlock("backlink_item");
+                        $def_tpl->setVariable("BACKLINK_LINK", ILIAS_HTTP_PATH . "/goto.php?target=" . $type[1] . "_" . $src['id']);
+                        $def_tpl->setVariable("BACKLINK_ITEM", $lm_title . ": " . $title);
+                        $def_tpl->parseCurrentBlock();
+                        $backlist_shown = true;
                     }
                 }
             }

--- a/Modules/Glossary/Presentation/class.ilPresentationListTableGUI.php
+++ b/Modules/Glossary/Presentation/class.ilPresentationListTableGUI.php
@@ -161,7 +161,7 @@ class ilPresentationListTableGUI extends ilTable2GUI
     
     public function numericOrdering(string $a_field) : bool
     {
-        if (substr($a_field, 0, 3) == "md_") {
+        if (strpos($a_field, "md_") === 0) {
             $md_id = (int) substr($a_field, 3);
             if ($this->adv_fields[$md_id]["type"] == ilAdvancedMDFieldDefinition::TYPE_DATE) {
                 return true;
@@ -187,14 +187,11 @@ class ilPresentationListTableGUI extends ilTable2GUI
             );
             $this->tpl->parseCurrentBlock();
         } else {
-            if (sizeof($defs)) {
-                for ($j = 0; $j < count($defs); $j++) {
+            if (count($defs)) {
+                for ($j = 0, $jMax = count($defs); $j < $jMax; $j++) {
                     $def = $defs[$j];
                     if (count($defs) > 1) {
                         if (!$this->offline) {
-                            if (!empty($filter)) {
-                                $this->ctrl->setParameter($this->parent_obj, "term", $filter);
-                            }
                             $this->ctrl->setParameter($this->parent_obj, "term_id", $a_set["id"]);
                             $def_href = $this->ctrl->getLinkTarget($this->parent_obj, "listDefinitions");
                             $this->ctrl->clearParameters($this->parent_obj);
@@ -221,8 +218,7 @@ class ilPresentationListTableGUI extends ilTable2GUI
                     }
 
                     if (!$this->page_config->getPreventHTMLUnmasking()) {
-                        $short_str = str_replace("&lt;", "<", $short_str);
-                        $short_str = str_replace("&gt;", ">", $short_str);
+                        $short_str = str_replace(["&lt;", "&gt;"], ["<", ">"], $short_str);
                     }
 
                     // replace tex
@@ -244,9 +240,7 @@ class ilPresentationListTableGUI extends ilTable2GUI
                         $short_str = ilMathJax::getInstance()->insertLatexImages(
                             $short_str,
                             '[tex]',
-                            '[/tex]',
-                            $this->parent_obj->getOfflineDirectory() . '/teximg',
-                            './teximg'
+                            '[/tex]'
                         );
                     }
 
@@ -278,9 +272,6 @@ class ilPresentationListTableGUI extends ilTable2GUI
             if ($c["id"] == 0) {
                 $this->tpl->setCurrentBlock("link_start");
                 if (!$this->offline) {
-                    if (!empty($filter)) {
-                        $this->ctrl->setParameter($this->parent_obj, "term", $filter);
-                    }
                     $this->ctrl->setParameter($this->parent_obj, "term_id", $a_set["id"]);
                     $this->tpl->setVariable(
                         "LINK_VIEW_TERM",

--- a/Modules/Glossary/Term/class.ilGlossaryTerm.php
+++ b/Modules/Glossary/Term/class.ilGlossaryTerm.php
@@ -79,7 +79,7 @@ class ilGlossaryTerm
             " ORDER BY create_date DESC";
         $term_set = $ilDB->query($q);
         while ($term_rec = $ilDB->fetchAssoc($term_set)) {
-            $glo_id = ilGlossaryTerm::_lookGlossaryID($term_rec["id"]);
+            $glo_id = self::_lookGlossaryID($term_rec["id"]);
 
             $ref_ids = ilObject::_getAllReferences($glo_id);	// will be 0 if import of lm is in progress (new import)
             if (count($ref_ids) == 0 || ilObject::_hasUntrashedReference($glo_id)) {
@@ -294,7 +294,7 @@ class ilGlossaryTerm
         global $DIC;
 
         if (count($a_glo_ref_id) > 1) {
-            $a_glo_id = array_map(function ($id) {
+            $a_glo_id = array_map(static function ($id) : int {
                 return ilObject::_lookupObjectId($id);
             }, $a_glo_ref_id);
         } else {
@@ -449,7 +449,7 @@ class ilGlossaryTerm
 
     public static function getNumberOfUsages(int $a_term_id) : int
     {
-        return count(ilGlossaryTerm::getUsages($a_term_id));
+        return count(self::getUsages($a_term_id));
     }
 
     public static function getUsages(int $a_term_id) : array

--- a/Modules/Glossary/Term/class.ilGlossaryTermGUI.php
+++ b/Modules/Glossary/Term/class.ilGlossaryTermGUI.php
@@ -294,7 +294,7 @@ class ilGlossaryTermGUI
 
         $tpl->setVariable("TXT_TERM", $this->term->getTerm());
 
-        for ($j = 0; $j < count($defs); $j++) {
+        for ($j = 0, $jMax = count($defs); $j < $jMax; $j++) {
             $def = $defs[$j];
             $page_gui = new ilGlossaryDefPageGUI($def["id"]);
             $page_gui->setSourcecodeDownloadScript("ilias.php?baseClass=ilGlossaryPresentationGUI&amp;ref_id=" . $this->ref_id);
@@ -338,7 +338,7 @@ class ilGlossaryTermGUI
         $defs = ilGlossaryDefinition::getDefinitionList($this->term->getId());
 
         $term_links = array();
-        for ($j = 0; $j < count($defs); $j++) {
+        for ($j = 0, $jMax = count($defs); $j < $jMax; $j++) {
             $def = $defs[$j];
             $page = new ilGlossaryDefPage($def["id"]);
             $page->buildDom();
@@ -394,7 +394,7 @@ class ilGlossaryTermGUI
 
         $tpl->setVariable("TXT_TERM", $this->term->getTerm());
 
-        for ($j = 0; $j < count($defs); $j++) {
+        for ($j = 0, $jMax = count($defs); $j < $jMax; $j++) {
             $def = $defs[$j];
             $page_gui = new ilGlossaryDefPageGUI($def["id"]);
             $page_gui->setStyleId(

--- a/Modules/Glossary/Term/class.ilTermListTableGUI.php
+++ b/Modules/Glossary/Term/class.ilTermListTableGUI.php
@@ -78,10 +78,8 @@ class ilTermListTableGUI extends ilTable2GUI
         foreach ($this->adv_cols_order as $c) {
             if ($c["id"] == 0) {
                 $this->addColumn($this->lng->txt("cont_term"), "term");
-            } else {
-                if (in_array("md_" . $c["id"], $this->selected_cols)) {
-                    $this->addColumn($c["text"], "md_" . $c["id"]);
-                }
+            } elseif (in_array("md_" . $c["id"], $this->selected_cols)) {
+                $this->addColumn($c["text"], "md_" . $c["id"]);
             }
         }
 
@@ -143,7 +141,7 @@ class ilTermListTableGUI extends ilTable2GUI
 
     public function numericOrdering(string $a_field) : bool
     {
-        if (substr($a_field, 0, 3) == "md_") {
+        if (strpos($a_field, "md_") === 0) {
             $md_id = (int) substr($a_field, 3);
             if ($this->adv_fields[$md_id]["type"] == ilAdvancedMDFieldDefinition::TYPE_DATE) {
                 return true;
@@ -209,7 +207,7 @@ class ilTermListTableGUI extends ilTable2GUI
         }
 
 
-        for ($j = 0; $j < count($defs); $j++) {
+        for ($j = 0, $jMax = count($defs); $j < $jMax; $j++) {
             $def = $defs[$j];
 
 
@@ -295,22 +293,20 @@ class ilTermListTableGUI extends ilTable2GUI
                 $this->tpl->setCurrentBlock("td");
                 $this->tpl->setVariable("TD_VAL", $a_set["term"]);
                 $this->tpl->parseCurrentBlock();
-            } else {
-                if (in_array("md_" . $c["id"], $this->selected_cols)) {
-                    $id = (int) $c["id"];
-                    
-                    $val = " ";
-                    if (isset($a_set["md_" . $id . "_presentation"])) {
-                        $pb = $a_set["md_" . $id . "_presentation"]->getHTML();
-                        if ($pb) {
-                            $val = $pb;
-                        }
+            } elseif (in_array("md_" . $c["id"], $this->selected_cols)) {
+                $id = (int) $c["id"];
+                
+                $val = " ";
+                if (isset($a_set["md_" . $id . "_presentation"])) {
+                    $pb = $a_set["md_" . $id . "_presentation"]->getHTML();
+                    if ($pb) {
+                        $val = $pb;
                     }
-                                        
-                    $this->tpl->setCurrentBlock("td");
-                    $this->tpl->setVariable("TD_VAL", $val);
-                    $this->tpl->parseCurrentBlock();
                 }
+                                    
+                $this->tpl->setCurrentBlock("td");
+                $this->tpl->setVariable("TD_VAL", $val);
+                $this->tpl->parseCurrentBlock();
             }
         }
     }

--- a/Modules/Glossary/Term/class.ilTermQuickListTableGUI.php
+++ b/Modules/Glossary/Term/class.ilTermQuickListTableGUI.php
@@ -62,7 +62,7 @@ class ilTermQuickListTableGUI extends ilTable2GUI
         $ilCtrl->setParameterByClass("ilglossarytermgui", "term_id", $a_set["id"]);
         
         $sep = ": ";
-        for ($j = 0; $j < count($defs); $j++) {
+        for ($j = 0, $jMax = count($defs); $j < $jMax; $j++) {
             $def = $defs[$j];
 
             $this->tpl->setCurrentBlock("definition");

--- a/Modules/Glossary/Term/class.ilTermUsagesTableGUI.php
+++ b/Modules/Glossary/Term/class.ilTermUsagesTableGUI.php
@@ -81,12 +81,12 @@ class ilTermUsagesTableGUI extends ilTable2GUI
                 //$this->tpl->setVariable("TXT_OBJECT", $usage["type"].":".$usage["id"]);
                 switch ($cont_type) {
                     case "sahs":
-                        $page_obj = new ilSCORM2004Page($usage["id"]);
+                        $page_obj = new ilSCORM2004Page($usage["id"]); // This class does not exist (anymore?)
                         $lm_obj = new ilObjSAHSLearningModule($page_obj->getParentId(), false);
                         $item["obj_type_txt"] = $this->lng->txt("obj_" . $cont_type);
                         $item["obj_title"] = $lm_obj->getTitle();
                         $item["sub_txt"] = $this->lng->txt("pg");
-                        $item["sub_title"] = ilSCORM2004PageNode::_lookupTitle($page_obj->getId());
+                        $item["sub_title"] = ilSCORM2004PageNode::_lookupTitle($page_obj->getId()); // This class does not exist (anymore?)
                         $ref_id = $this->getFirstWritableRefId($lm_obj->getId());
                         if ($ref_id > 0) {
                             $item["obj_link"] = ilLink::_getStaticLink($ref_id, "sahs");

--- a/Modules/Glossary/classes/class.ilECSGlossarySettings.php
+++ b/Modules/Glossary/classes/class.ilECSGlossarySettings.php
@@ -20,12 +20,12 @@
  */
 class ilECSGlossarySettings extends ilECSObjectSettings
 {
-    protected function getECSObjectType()
+    protected function getECSObjectType() : string
     {
         return '/campusconnect/glossaries';
     }
     
-    protected function buildJson(ilECSSetting $a_server)
+    protected function buildJson(ilECSSetting $a_server) : stdClass
     {
         $json = $this->getJsonCore('application/ecs-glossary');
         

--- a/Modules/Glossary/classes/class.ilObjGlossaryAccess.php
+++ b/Modules/Glossary/classes/class.ilObjGlossaryAccess.php
@@ -48,7 +48,7 @@ class ilObjGlossaryAccess extends ilObjectAccess
 
         switch ($permission) {
             case "read":
-                if (!ilObjGlossaryAccess::_lookupOnline($obj_id)
+                if (!self::_lookupOnline($obj_id)
                     && !$rbacsystem->checkAccessOfUser($user_id, 'write', $ref_id)) {
                     $ilAccess->addInfoItem(ilAccessInfo::IL_NO_OBJECT_ACCESS, $lng->txt("offline"));
                     return false;
@@ -56,7 +56,7 @@ class ilObjGlossaryAccess extends ilObjectAccess
                 break;
 
             case "visible":
-                if (!ilObjGlossaryAccess::_lookupOnline($obj_id) &&
+                if (!self::_lookupOnline($obj_id) &&
                     (!$rbacsystem->checkAccessOfUser($user_id, 'write', $ref_id))) {
                     $ilAccess->addInfoItem(ilAccessInfo::IL_NO_OBJECT_ACCESS, $lng->txt("offline"));
                     return false;

--- a/Modules/Glossary/classes/class.ilObjGlossaryGUI.php
+++ b/Modules/Glossary/classes/class.ilObjGlossaryGUI.php
@@ -55,7 +55,7 @@ class ilObjGlossaryGUI extends ilObjectGUI
         $this->tabs = $DIC->tabs();
         $this->setting = $DIC["ilSetting"];
         $this->access = $DIC->access();
-        $this->rbacsystem = $DIC->rbac()->system();
+        $this->rbacsystem = $DIC->rbac()->system(); // This property is dynamically declared: Should be fixed or discussed
         $this->help = $DIC["ilHelp"];
 
         $this->edit_request = $DIC->glossary()
@@ -110,7 +110,7 @@ class ilObjGlossaryGUI extends ilObjectGUI
         $cs = $DIC->contentStyle();
         $this->content_style_gui = $cs->gui();
         if (is_object($this->object)) {
-            $this->content_style_domain = $cs->domain()->styleForRefId((int) $this->object->getRefId());
+            $this->content_style_domain = $cs->domain()->styleForRefId($this->object->getRefId());
         }
     }
 
@@ -272,10 +272,8 @@ class ilObjGlossaryGUI extends ilObjectGUI
         }
 
         if ($cmd != "quickList") {
-            if (!$this->in_administration) {
-                if (!$this->getCreationMode()) {
-                    $this->tpl->printToStdout();
-                }
+            if (!$this->in_administration && !$this->getCreationMode()) {
+                $this->tpl->printToStdout();
             }
         } else {
             $this->tpl->printToStdout(false);
@@ -398,7 +396,7 @@ class ilObjGlossaryGUI extends ilObjectGUI
         }
         $info->addMetaDataSections($this->object->getId(), 0, $this->object->getType());
         
-        ilObjGlossaryGUI::addUsagesToInfo($info, $this->object->getId());
+        self::addUsagesToInfo($info, $this->object->getId());
         
         $this->ctrl->forwardCommand($info);
     }
@@ -421,10 +419,8 @@ class ilObjGlossaryGUI extends ilObjectGUI
             $link = false;
             $refs = ilObject::_getAllReferences($sm);
             foreach ($refs as $ref) {
-                if ($link === false) {
-                    if ($ilAccess->checkAccess("write", "", $ref)) {
-                        $link = ilLink::_getLink($ref, 'sahs');
-                    }
+                if ($link === false && $ilAccess->checkAccess("write", "", $ref)) {
+                    $link = ilLink::_getLink($ref, 'sahs');
                 }
             }
             
@@ -973,15 +969,13 @@ class ilObjGlossaryGUI extends ilObjectGUI
     {
         if (strtolower($this->edit_request->getBaseClass()) != "ilglossaryeditorgui") {
             parent::setLocator();
-        } else {
-            if (is_object($this->object)) {
-                $gloss_loc = new ilGlossaryLocatorGUI();
-                if (is_object($this->term)) {
-                    $gloss_loc->setTerm($this->term);
-                }
-                $gloss_loc->setGlossary($this->getGlossary());
-                $gloss_loc->display();
+        } elseif (is_object($this->object)) {
+            $gloss_loc = new ilGlossaryLocatorGUI();
+            if (is_object($this->term)) {
+                $gloss_loc->setTerm($this->term);
             }
+            $gloss_loc->setGlossary($this->getGlossary());
+            $gloss_loc->display();
         }
     }
 
@@ -1030,11 +1024,6 @@ class ilObjGlossaryGUI extends ilObjectGUI
             $this->tpl->setTitleIcon(ilUtil::getImagePath("icon_glo.svg"));
             $this->tpl->setTitle($this->lng->txt("glo") . ": " . $title);
         }
-    }
-
-    protected function setTabs() : void
-    {
-        $this->getTabs();
     }
 
     protected function getTabs() : void
@@ -1398,7 +1387,7 @@ class ilObjGlossaryGUI extends ilObjectGUI
         $this->user->clipboardDeleteObjectsOfType("term");
 
         // put them into the clipboard
-        $time = date("Y-m-d H:i:s", time());
+        $time = date("Y-m-d H:i:s");
         $order = 0;
         foreach ($items as $id) {
             $this->user->addObjectToClipboard(
@@ -1430,7 +1419,7 @@ class ilObjGlossaryGUI extends ilObjectGUI
         $this->user->clipboardDeleteObjectsOfType("term");
 
         // put them into the clipboard
-        $time = date("Y-m-d H:i:s", time());
+        $time = date("Y-m-d H:i:s");
         $order = 0;
         foreach ($items as $id) {
             $this->user->addObjectToClipboard(

--- a/Modules/Glossary/classes/class.ilObjGlossarySubItemListGUI.php
+++ b/Modules/Glossary/classes/class.ilObjGlossarySubItemListGUI.php
@@ -37,7 +37,7 @@ class ilObjGlossarySubItemListGUI extends ilSubItemListGUI
         
         $lng->loadLanguageModule('content');
         foreach ($this->getSubItemIds(true) as $sub_item) {
-            if (is_object($this->getHighlighter()) and strlen($this->getHighlighter()->getContent($this->getObjId(), $sub_item))) {
+            if (is_object($this->getHighlighter()) && $this->getHighlighter()->getContent($this->getObjId(), $sub_item) !== '') {
                 $this->tpl->setCurrentBlock('sea_fragment');
                 $this->tpl->setVariable('TXT_FRAGMENT', $this->getHighlighter()->getContent($this->getObjId(), $sub_item));
                 $this->tpl->parseCurrentBlock();

--- a/Modules/Glossary/test/GloPresentationGUIRequestTest.php
+++ b/Modules/Glossary/test/GloPresentationGUIRequestTest.php
@@ -9,17 +9,6 @@ use PHPUnit\Framework\TestCase;
  */
 class GloPresentationGUIRequestTest extends TestCase
 {
-    //protected $backupGlobals = false;
-
-    protected function setUp() : void
-    {
-        parent::setUp();
-    }
-
-    protected function tearDown() : void
-    {
-    }
-
     protected function getRequest(array $get, array $post) : \ILIAS\Glossary\Presentation\PresentationGUIRequest
     {
         $http_mock = $this->createMock(ILIAS\HTTP\Services::class);
@@ -34,7 +23,7 @@ class GloPresentationGUIRequestTest extends TestCase
         );
     }
 
-    public function testRefId()
+    public function testRefId() : void
     {
         $request = $this->getRequest(
             [
@@ -49,7 +38,7 @@ class GloPresentationGUIRequestTest extends TestCase
         );
     }
 
-    public function testDefinitionId()
+    public function testDefinitionId() : void
     {
         $request = $this->getRequest(
             [
@@ -64,7 +53,7 @@ class GloPresentationGUIRequestTest extends TestCase
         );
     }
 
-    public function testLetter()
+    public function testLetter() : void
     {
         $request = $this->getRequest(
             [
@@ -79,7 +68,7 @@ class GloPresentationGUIRequestTest extends TestCase
         );
     }
 
-    public function testTermId()
+    public function testTermId() : void
     {
         $request = $this->getRequest(
             [
@@ -94,7 +83,7 @@ class GloPresentationGUIRequestTest extends TestCase
         );
     }
 
-    public function test()
+    public function test() : void
     {
         $request = $this->getRequest(
             [

--- a/Modules/Glossary/test/ilModulesGlossarySuite.php
+++ b/Modules/Glossary/test/ilModulesGlossarySuite.php
@@ -22,7 +22,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilModulesGlossarySuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new self();
 


### PR DESCRIPTION
Hi @alex40724 ,

I completed the review of the `Modules/Glossary` component.

Results:
- [x] The code style is `PSR-2 + X` compliant
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

I also fixed some trivial inspection profile issues.

The following methods MUST be checked:
- `\ilObjGlossary::create`: An **untyped** boolean parameter is defined, the parent method has **no** parameter at all

Further actions needed:
- https://github.com/ILIAS-eLearning/ILIAS/pull/4136/files#diff-a107664a8591045a3d243fe5faa6419206f6b54b9e3b4763c5f63abb4d049b52R58
- https://github.com/ILIAS-eLearning/ILIAS/pull/4136/files#diff-5ee56c0535b02d8a1c90d9397b822801423121f9926c60774438f916742116b2R84
- https://github.com/ILIAS-eLearning/ILIAS/pull/4136/files#diff-a107664a8591045a3d243fe5faa6419206f6b54b9e3b4763c5f63abb4d049b52R58

Type documention or explict types are missing for the following methods:
- `\ilObjGlossary::getAdvMDSubItemTitle` / Reason: No types defined/documented in parent class (which has to be provided by another maintainer)

I suggest to specify the expected type of arrays (where possible) by using `PHPDoc`, e.g.:
- `\ilObjGlossary::removeOfflineGlossaries`: `$a_glo_ids` could be `int[]`.
- `\ilObjGlossaryAccess::_lookupOnlineStatus`: `$a_ids` could be `int[]`, the return type is `array<int, bool>`.
- ... some others ...

Best regards,
@mjansenDatabay 