### PR TITLE
Make Chaining of `Renderer`s possible

### DIFF
--- a/src/UI/Renderer.php
+++ b/src/UI/Renderer.php
@@ -19,10 +19,11 @@ interface Renderer
      * each rendered component, in the same order as given in the array
      *
      * @param Component|Component[] $component
+     * @param ?Renderer $root of renderers in the chain to be used for rendering sub components.
      *
      * @return string
      */
-    public function render($component);
+    public function render($component, ?Renderer $root = null);
 
     /**
      * Same as render, except that this version also returns any javascript code bound to the on load event,
@@ -30,9 +31,11 @@ interface Renderer
      * so it will not be rendered twice if render async is called multiple times.
      *
      * @param Component|Component[] $component
+     * @param ?Renderer $root of renderers in the chain to be used for rendering sub components.
+     *
      * @return string
      */
-    public function renderAsync($component);
+    public function renderAsync($component, ?Renderer $root = null);
 
     /**
      * Get a new renderer with an additional context.

--- a/tests/UI/Renderer/AbstractRendererTest.php
+++ b/tests/UI/Renderer/AbstractRendererTest.php
@@ -108,11 +108,11 @@ namespace {
 
     class NullDefaultRenderer implements \ILIAS\UI\Renderer
     {
-        public function render($component)
+        public function render($component, ?\ILIAS\UI\Renderer $root = null)
         {
             return "";
         }
-        public function renderAsync($component)
+        public function renderAsync($component, ?\ILIAS\UI\Renderer $root = null)
         {
             return '';
         }


### PR DESCRIPTION
As pitched by @iszmais in #4118, this makes it possible to write decorators for `Renderer` in the UI-framework, by passing the root of a chain of decoratred `Renderer`s through the `render`-function.

The change is non-breaking from the perspective of the core, since existing usages of `Renderer::render` will continue to work as expected. This is breaking from the perspective of plugins, however, since the interface changed and implementing classes will need to change accordingly.

We might want to take this to the JF for this reason or even decide to only make the change in the trunk. I would be happy if @Amstutz takes an according decision as I'm the one who proposes this.