### PR TITLE
GlobalCache: add named objective to flush all caches

### DIFF
--- a/Services/GlobalCache/classes/Setup/class.ilGlobalCacheAllFlushedObjective.php
+++ b/Services/GlobalCache/classes/Setup/class.ilGlobalCacheAllFlushedObjective.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 2022 - Daniel Weise <daniel.weise@concepts-and-training.de> - Extended GPL, see LICENSE */
+
+use ILIAS\Setup;
+
+class ilGlobalCacheAllFlushedObjective extends ilSetupObjective
+{
+    public function __construct()
+    {
+    }
+
+    public function getHash() : string
+    {
+        return hash("sha256", self::class);
+    }
+
+    public function getLabel() : string
+    {
+        return "All global caches flushed";
+    }
+
+    public function isNotable() : bool
+    {
+        return true;
+    }
+
+    public function getPreconditions(Setup\Environment $environment) : array
+    {
+        return [];
+    }
+
+    public function achieve(Setup\Environment $environment) : Setup\Environment
+    {
+        ilGlobalCache::flushAll();
+
+        return $environment;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isApplicable(Setup\Environment $environment) : bool
+    {
+        return true;
+    }
+}

--- a/Services/GlobalCache/classes/Setup/class.ilGlobalCacheSetupAgent.php
+++ b/Services/GlobalCache/classes/Setup/class.ilGlobalCacheSetupAgent.php
@@ -1,15 +1,12 @@
-<?php
+<?php declare(strict_types=1);
 
 /* Copyright (c) 2019 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
 
 use ILIAS\Setup;
 use ILIAS\Refinery;
-use ILIAS\UI;
 
 class ilGlobalCacheSetupAgent implements Setup\Agent
 {
-    use Setup\Agent\HasNoNamedObjective;
-
     /**
      * @var Refinery\Factory
      */
@@ -139,5 +136,15 @@ class ilGlobalCacheSetupAgent implements Setup\Agent
     public function getMigrations() : array
     {
         return [];
+    }
+
+    public function getNamedObjective(string $name, Setup\Config $config = null) : Setup\Objective
+    {
+        if ($name == "flushAll") {
+            return new ilGlobalCacheAllFlushedObjective();
+        }
+        throw new InvalidArgumentException(
+            "There is no named objective '$name'"
+        );
     }
 }


### PR DESCRIPTION
Hi @chfsx,

this adds a named objective that makes it possible to flush all caches via the setup. The GUI setup had that functionality, but we did not recreate it for the CLI setup until now.

One can call this via `php setup/setup.php achieve globalcache.flushAll`.

Best regards!