### PR TITLE
PHP 8: Code Review `UIComponent`

### DIFF
--- a/Services/Skill/classes/class.ilSkillSelectorGUI.php
+++ b/Services/Skill/classes/class.ilSkillSelectorGUI.php
@@ -32,7 +32,6 @@ class ilSkillSelectorGUI extends ilVirtualSkillTreeExplorerGUI
     protected $select_gui = "";
     protected string $select_cmd = "";
     protected string $select_par = "";
-    protected bool $select_multi = false;
     protected SkillAdminGUIRequest $admin_gui_request;
     protected array $requested_selected_ids = [];
 

--- a/Services/UIComponent/AdvancedSelectionList/classes/class.ilAdvancedSelectionListGUI.php
+++ b/Services/UIComponent/AdvancedSelectionList/classes/class.ilAdvancedSelectionListGUI.php
@@ -84,7 +84,7 @@ class ilAdvancedSelectionListGUI implements ilToolbarItem
     private \ILIAS\UI\Renderer $renderer;
     protected ilLanguage $lng;
     protected string $on_click_form_id;
-    protected ilGlobalPageTemplate $global_tpl;
+    protected ilGlobalTemplateInterface $global_tpl;
 
     /*
 
@@ -113,9 +113,9 @@ class ilAdvancedSelectionListGUI implements ilToolbarItem
 
         $this->renderer = $DIC->ui()->renderer();
         $this->lng = $DIC->language();
-        $this->mode = ilAdvancedSelectionListGUI::MODE_LINKS;
-        $this->setHeaderIcon(ilAdvancedSelectionListGUI::DOWN_ARROW_DARK);
-        $this->setOnClickMode(ilAdvancedSelectionListGUI::ON_ITEM_CLICK_HREF);
+        $this->mode = self::MODE_LINKS;
+        $this->setHeaderIcon(self::DOWN_ARROW_DARK);
+        $this->setOnClickMode(self::ON_ITEM_CLICK_HREF);
         $this->global_tpl = $DIC['tpl'];
     }
 
@@ -125,7 +125,7 @@ class ilAdvancedSelectionListGUI implements ilToolbarItem
     public function setLinksMode(
         string $a_link_class = ""
     ) : void {
-        $this->mode = ilAdvancedSelectionListGUI::MODE_LINKS;
+        $this->mode = self::MODE_LINKS;
         $this->links_mode = array(
             "link_class" => $a_link_class);
     }
@@ -146,7 +146,7 @@ class ilAdvancedSelectionListGUI implements ilToolbarItem
         string $a_button_class = "",
         string $a_button_cmd = ""
     ) : void {
-        $this->mode = ilAdvancedSelectionListGUI::MODE_FORM_SELECT;
+        $this->mode = self::MODE_FORM_SELECT;
         $this->form_mode = array(
             "select_name" => $a_select_name,
             "select_class" => $a_select_class,
@@ -447,7 +447,7 @@ class ilAdvancedSelectionListGUI implements ilToolbarItem
             return "";
         }
 
-        $this->global_tpl->addJavascript("./Services/UIComponent/AdvancedSelectionList/js/AdvancedSelectionList.js");
+        $this->global_tpl->addJavaScript("./Services/UIComponent/AdvancedSelectionList/js/AdvancedSelectionList.js");
 
         $js_tpl = new ilTemplate(
             "tpl.adv_selection_list_js_init.js",
@@ -477,180 +477,170 @@ class ilAdvancedSelectionListGUI implements ilToolbarItem
             $tpl->setCurrentBlock("asynch_request");
             $tpl->setVariable("IMG_LOADER", ilUtil::getImagePath("loader.svg"));
             $tpl->parseCurrentBlock();
+        } elseif ($this->getGroupedList() != null) {
+            $tpl->setVariable("GROUPED_LIST_HTML", $this->getGroupedList()->getHTML());
         } else {
-            if ($this->getGroupedList() != null) {
-                $tpl->setVariable("GROUPED_LIST_HTML", $this->getGroupedList()->getHTML());
-            } else {
-                foreach ($items as $item) {
-                    $this->css_row = ($this->css_row != "tblrow1_mo")
-                        ? "tblrow1_mo"
-                        : "tblrow2_mo";
+            foreach ($items as $item) {
+                $this->css_row = ($this->css_row != "tblrow1_mo")
+                    ? "tblrow1_mo"
+                    : "tblrow2_mo";
 
-                    if (isset($item['component'])) {
-                        $tpl->setCurrentBlock('component');
-                        $tpl->setVariable('COMPONENT', $this->renderer->render([$item['component']]));
-                        $tpl->parseCurrentBlock();
-
-                        $tpl->setCurrentBlock('item_loop');
-                        $tpl->parseCurrentBlock();
-                        continue;
-                    }
-
-                    if ($this->getUseImages()) {
-                        if ($item["img"]) {
-                            $tpl->setCurrentBlock("image");
-                            $tpl->setVariable("IMG_ITEM", $item["img"]);
-                            $tpl->setVariable("ALT_ITEM", $item["alt"]);
-                            $tpl->parseCurrentBlock();
-                        } else {
-                            $tpl->touchBlock("no_image");
-                        }
-                    }
-
-                    if (isset($item["ref_id"])) {
-                        $sel_arr[$item["ref_id"]] = (isset($item["title"]))
-                            ? $item["title"]
-                            : "";
-                    }
-
-                    if ($this->getOnClickMode() ==
-                        ilAdvancedSelectionListGUI::ON_ITEM_CLICK_HREF ||
-                        $this->getItemLinkClass() != "") {
-                        if ($item["frame"]) {
-                            $tpl->setCurrentBlock("frame");
-                            $tpl->setVariable("TARGET_ITEM", $item["frame"]);
-                            $tpl->parseCurrentBlock();
-                        }
-
-                        if ($this->getItemLinkClass() != "") {
-                            $tpl->setCurrentBlock("item_link_class");
-                            $tpl->setVariable("ITEM_LINK_CLASS", $this->getItemLinkClass());
-                            $tpl->parseCurrentBlock();
-                        }
-
-                        if (is_array($item["data"])) {
-                            foreach ($item["data"] as $k => $v) {
-                                $tpl->setCurrentBlock("f_data");
-                                $tpl->setVariable("DATA_KEY", $k);
-                                $tpl->setVariable("DATA_VAL", ilLegacyFormElementsUtil::prepareFormOutput($v));
-                                $tpl->parseCurrentBlock();
-                            }
-                        }
-                        if ($item["value"] != "") {
-                            $tpl->setCurrentBlock("item_id");
-                            $tpl->setVariable("ID_ITEM", $this->getId() . "_" . $item["value"]);
-                            $tpl->parseCurrentBlock();
-                        }
-
-                        $tpl->setCurrentBlock("href_s");
-                        $tpl->setVariable("HREF_ITEM", 'href="' . $item["link"] . '"');
-                        $tpl->parseCurrentBlock();
-
-                        $tpl->touchBlock("href_e");
-                    }
-
-                    $tpl->setCurrentBlock("item");
-                    if ($this->getOnClickMode() ==
-                        ilAdvancedSelectionListGUI::ON_ITEM_CLICK_HREF) {
-                        if ($item["prevent_background_click"]) {
-                            $tpl->setVariable("ONCLICK_ITEM", '');
-                        } else {
-                            if ($item["onclick"] == "" && $item["frame"] != "") {       // see #28730
-                                $tpl->setVariable(
-                                    "ONCLICK_ITEM",
-                                    'onclick="' . "return il.AdvancedSelectionList.openTarget('" . $item["link"] . "','" . $item["frame"] . "');" . '"'
-                                );
-                            } elseif ($item["onclick"] != "") {
-                                $tpl->setVariable(
-                                    "ONCLICK_ITEM",
-                                    'onclick="' . "return " . $item["onclick"] . ";" . '"'
-                                );
-                            }
-                        }
-                    } elseif ($this->getOnClickMode() ==
-                        ilAdvancedSelectionListGUI::ON_ITEM_CLICK_FORM_SUBMIT) {
-                        $tpl->setVariable(
-                            "ONCLICK_ITEM",
-                            'onclick="return il.AdvancedSelectionList.submitForm(\'' . $this->getId() . '\'' .
-                                ", '" . $this->form_mode["select_name"] . "','" . $item["value"] . "'," .
-                                "'" . $this->on_click_form_id . "','" . $this->form_mode["button_cmd"] . "');\""
-                        );
-                    } elseif ($this->getOnClickMode() ==
-                        ilAdvancedSelectionListGUI::ON_ITEM_CLICK_FORM_SELECT) {
-                        $tpl->setVariable(
-                            "ONCLICK_ITEM",
-                            'onclick="return il.AdvancedSelectionList.selectForm(\'' . $this->getId() . '\'' .
-                                ", '" . $this->form_mode["select_name"] . "','" . $item["value"] . "'," .
-                                "'" . $item["title"] . "');\""
-                        );
-                    } elseif ($this->getOnClickMode() ==
-                        ilAdvancedSelectionListGUI::ON_ITEM_CLICK_NOP) {
-                        $tpl->setVariable(
-                            "ONCLICK_ITEM",
-                            'onclick="il.AdvancedSelectionList.clickNop(\'' . $this->getId() . '\'' .
-                                ", '" . $this->form_mode["select_name"] . "','" . $item["value"] . "'," .
-                                "'" . $item["title"] . "');\""
-                        );
-                    }
-
-                    $tpl->setVariable("CSS_ROW", $this->css_row);
-                    if ($item["html"] == "") {
-                        $tpl->setVariable("TXT_ITEM", $item["title"]);
-                    } else {
-                        $tpl->setVariable("TXT_ITEM", $item["html"]);
-                    }
-
-                    $tpl->setVariable("ID_ITEM_TR", $this->getId() . "_" . $item["value"] . "_tr");
-                    if ($item["ttip"] != "") {
-                        ilTooltipGUI::addTooltip(
-                            $this->getId() . "_" . $item["value"] . "_tr",
-                            $item["ttip"],
-                            "",
-                            $item["tt_my"],
-                            $item["tt_at"],
-                            $item["tt_use_htmlspecialchars"]
-                        );
-                    }
-
+                if (isset($item['component'])) {
+                    $tpl->setCurrentBlock('component');
+                    $tpl->setVariable('COMPONENT', $this->renderer->render([$item['component']]));
                     $tpl->parseCurrentBlock();
 
                     $tpl->setCurrentBlock('item_loop');
                     $tpl->parseCurrentBlock();
-
-                    // add item to js object
-                    $js_tpl->setCurrentBlock("js_item");
-                    $js_tpl->setVariable("IT_ID", $this->getId());
-                    $js_tpl->setVariable("IT_HID_NAME", $this->form_mode["select_name"]);
-
-                    $js_tpl->setVariable("IT_HID_VAL", $item["value"]);
-                    $js_tpl->setVariable("IT_TITLE", str_replace("'", "\\'", $item["title"]));
-                    $js_tpl->parseCurrentBlock();
+                    continue;
                 }
 
-                // output hidden input, if click mode is form submission
-                if ($this->getOnClickMode() == ilAdvancedSelectionListGUI::ON_ITEM_CLICK_FORM_SUBMIT) {
-                    $tpl->setCurrentBlock("hidden_input");
-                    $tpl->setVariable("HID", $this->getId());
+                if ($this->getUseImages()) {
+                    if ($item["img"]) {
+                        $tpl->setCurrentBlock("image");
+                        $tpl->setVariable("IMG_ITEM", $item["img"]);
+                        $tpl->setVariable("ALT_ITEM", $item["alt"]);
+                        $tpl->parseCurrentBlock();
+                    } else {
+                        $tpl->touchBlock("no_image");
+                    }
+                }
+
+                if ($this->getOnClickMode() ==
+                    self::ON_ITEM_CLICK_HREF ||
+                    $this->getItemLinkClass() != "") {
+                    if ($item["frame"]) {
+                        $tpl->setCurrentBlock("frame");
+                        $tpl->setVariable("TARGET_ITEM", $item["frame"]);
+                        $tpl->parseCurrentBlock();
+                    }
+
+                    if ($this->getItemLinkClass() != "") {
+                        $tpl->setCurrentBlock("item_link_class");
+                        $tpl->setVariable("ITEM_LINK_CLASS", $this->getItemLinkClass());
+                        $tpl->parseCurrentBlock();
+                    }
+
+                    if (is_array($item["data"])) {
+                        foreach ($item["data"] as $k => $v) {
+                            $tpl->setCurrentBlock("f_data");
+                            $tpl->setVariable("DATA_KEY", $k);
+                            $tpl->setVariable("DATA_VAL", ilLegacyFormElementsUtil::prepareFormOutput($v));
+                            $tpl->parseCurrentBlock();
+                        }
+                    }
+                    if ($item["value"] != "") {
+                        $tpl->setCurrentBlock("item_id");
+                        $tpl->setVariable("ID_ITEM", $this->getId() . "_" . $item["value"]);
+                        $tpl->parseCurrentBlock();
+                    }
+
+                    $tpl->setCurrentBlock("href_s");
+                    $tpl->setVariable("HREF_ITEM", 'href="' . $item["link"] . '"');
                     $tpl->parseCurrentBlock();
 
-                    $js_tpl->setCurrentBlock("hidden_input");
-                    $js_tpl->setVariable("HID", $this->getId());
-                    $js_tpl->parseCurrentBlock();
+                    $tpl->touchBlock("href_e");
                 }
 
-                // output hidden input and initialize
-                if ($this->getOnClickMode() == ilAdvancedSelectionListGUI::ON_ITEM_CLICK_FORM_SELECT) {
-                    $tpl->setCurrentBlock("hidden_input");
-                    $tpl->setVariable("HID", $this->getId());
-                    $tpl->parseCurrentBlock();
-
-                    // init hidden input with selected value
-                    $js_tpl->setCurrentBlock("init_hidden_input");
-                    $js_tpl->setVariable("H2ID", $this->getId());
-                    $js_tpl->setVariable("HID_NAME", $this->form_mode["select_name"]);
-                    $js_tpl->setVariable("HID_VALUE", $this->getSelectedValue());
-                    $js_tpl->parseCurrentBlock();
+                $tpl->setCurrentBlock("item");
+                if ($this->getOnClickMode() ==
+                    self::ON_ITEM_CLICK_HREF) {
+                    if ($item["prevent_background_click"]) {
+                        $tpl->setVariable("ONCLICK_ITEM", '');
+                    } elseif ($item["onclick"] == "" && $item["frame"] != "") {       // see #28730
+                        $tpl->setVariable(
+                            "ONCLICK_ITEM",
+                            'onclick="' . "return il.AdvancedSelectionList.openTarget('" . $item["link"] . "','" . $item["frame"] . "');" . '"'
+                        );
+                    } elseif ($item["onclick"] != "") {
+                        $tpl->setVariable(
+                            "ONCLICK_ITEM",
+                            'onclick="' . "return " . $item["onclick"] . ";" . '"'
+                        );
+                    }
+                } elseif ($this->getOnClickMode() ==
+                    self::ON_ITEM_CLICK_FORM_SUBMIT) {
+                    $tpl->setVariable(
+                        "ONCLICK_ITEM",
+                        'onclick="return il.AdvancedSelectionList.submitForm(\'' . $this->getId() . '\'' .
+                            ", '" . $this->form_mode["select_name"] . "','" . $item["value"] . "'," .
+                            "'" . $this->on_click_form_id . "','" . $this->form_mode["button_cmd"] . "');\""
+                    );
+                } elseif ($this->getOnClickMode() ==
+                    self::ON_ITEM_CLICK_FORM_SELECT) {
+                    $tpl->setVariable(
+                        "ONCLICK_ITEM",
+                        'onclick="return il.AdvancedSelectionList.selectForm(\'' . $this->getId() . '\'' .
+                            ", '" . $this->form_mode["select_name"] . "','" . $item["value"] . "'," .
+                            "'" . $item["title"] . "');\""
+                    );
+                } elseif ($this->getOnClickMode() ==
+                    self::ON_ITEM_CLICK_NOP) {
+                    $tpl->setVariable(
+                        "ONCLICK_ITEM",
+                        'onclick="il.AdvancedSelectionList.clickNop(\'' . $this->getId() . '\'' .
+                            ", '" . $this->form_mode["select_name"] . "','" . $item["value"] . "'," .
+                            "'" . $item["title"] . "');\""
+                    );
                 }
+
+                $tpl->setVariable("CSS_ROW", $this->css_row);
+                if ($item["html"] == "") {
+                    $tpl->setVariable("TXT_ITEM", $item["title"]);
+                } else {
+                    $tpl->setVariable("TXT_ITEM", $item["html"]);
+                }
+
+                $tpl->setVariable("ID_ITEM_TR", $this->getId() . "_" . $item["value"] . "_tr");
+                if ($item["ttip"] != "") {
+                    ilTooltipGUI::addTooltip(
+                        $this->getId() . "_" . $item["value"] . "_tr",
+                        $item["ttip"],
+                        "",
+                        $item["tt_my"],
+                        $item["tt_at"],
+                        $item["tt_use_htmlspecialchars"]
+                    );
+                }
+
+                $tpl->parseCurrentBlock();
+
+                $tpl->setCurrentBlock('item_loop');
+                $tpl->parseCurrentBlock();
+
+                // add item to js object
+                $js_tpl->setCurrentBlock("js_item");
+                $js_tpl->setVariable("IT_ID", $this->getId());
+                $js_tpl->setVariable("IT_HID_NAME", $this->form_mode["select_name"]);
+
+                $js_tpl->setVariable("IT_HID_VAL", $item["value"]);
+                $js_tpl->setVariable("IT_TITLE", str_replace("'", "\\'", $item["title"]));
+                $js_tpl->parseCurrentBlock();
+            }
+
+            // output hidden input, if click mode is form submission
+            if ($this->getOnClickMode() == self::ON_ITEM_CLICK_FORM_SUBMIT) {
+                $tpl->setCurrentBlock("hidden_input");
+                $tpl->setVariable("HID", $this->getId());
+                $tpl->parseCurrentBlock();
+
+                $js_tpl->setCurrentBlock("hidden_input");
+                $js_tpl->setVariable("HID", $this->getId());
+                $js_tpl->parseCurrentBlock();
+            }
+
+            // output hidden input and initialize
+            if ($this->getOnClickMode() == self::ON_ITEM_CLICK_FORM_SELECT) {
+                $tpl->setCurrentBlock("hidden_input");
+                $tpl->setVariable("HID", $this->getId());
+                $tpl->parseCurrentBlock();
+
+                // init hidden input with selected value
+                $js_tpl->setCurrentBlock("init_hidden_input");
+                $js_tpl->setVariable("H2ID", $this->getId());
+                $js_tpl->setVariable("HID_NAME", $this->form_mode["select_name"]);
+                $js_tpl->setVariable("HID_VALUE", $this->getSelectedValue());
+                $js_tpl->parseCurrentBlock();
             }
         }
         
@@ -670,16 +660,16 @@ class ilAdvancedSelectionListGUI implements ilToolbarItem
             $tpl->parseCurrentBlock();
         }
 
-        if ($this->getHeaderIcon() != ilAdvancedSelectionListGUI::NO_ICON) {
+        if ($this->getHeaderIcon() != self::NO_ICON) {
             $tpl->setCurrentBlock("top_img");
             switch ($this->getHeaderIcon()) {
-                case ilAdvancedSelectionListGUI::ICON_CONFIG:
-                    $tpl->setVariable("IMG_SPAN_STYLE", ilAdvancedSelectionListGUI::ICON_CONFIG);
+                case self::ICON_CONFIG:
+                    $tpl->setVariable("IMG_SPAN_STYLE", self::ICON_CONFIG);
                     break;
 
-                case ilAdvancedSelectionListGUI::DOWN_ARROW_DARK:
+                case self::DOWN_ARROW_DARK:
                 default:
-                    $tpl->setVariable("IMG_SPAN_STYLE", ilAdvancedSelectionListGUI::ICON_ARROW);
+                    $tpl->setVariable("IMG_SPAN_STYLE", self::ICON_ARROW);
                     break;
             }
             $tpl->parseCurrentBlock();
@@ -764,7 +754,7 @@ class ilAdvancedSelectionListGUI implements ilToolbarItem
 
         $tpl->parseCurrentBlock();
 
-        $this->global_tpl->addOnloadCode(
+        $this->global_tpl->addOnLoadCode(
             $js_tpl->get()
         );
 

--- a/Services/UIComponent/AdvancedSelectionList/classes/class.ilAdvancedSelectionListGUI.php
+++ b/Services/UIComponent/AdvancedSelectionList/classes/class.ilAdvancedSelectionListGUI.php
@@ -443,7 +443,7 @@ class ilAdvancedSelectionListGUI implements ilToolbarItem
         $items = $this->getItems();
 
         // do not show list, if no item is in list
-        if (count($items) == 0 && !$this->getAsynch() && $this->getGroupedList() == null) {
+        if (count($items) === 0 && !$this->getAsynch() && $this->getGroupedList() === null) {
             return "";
         }
 
@@ -477,11 +477,11 @@ class ilAdvancedSelectionListGUI implements ilToolbarItem
             $tpl->setCurrentBlock("asynch_request");
             $tpl->setVariable("IMG_LOADER", ilUtil::getImagePath("loader.svg"));
             $tpl->parseCurrentBlock();
-        } elseif ($this->getGroupedList() != null) {
+        } elseif ($this->getGroupedList() !== null) {
             $tpl->setVariable("GROUPED_LIST_HTML", $this->getGroupedList()->getHTML());
         } else {
             foreach ($items as $item) {
-                $this->css_row = ($this->css_row != "tblrow1_mo")
+                $this->css_row = ($this->css_row !== "tblrow1_mo")
                     ? "tblrow1_mo"
                     : "tblrow2_mo";
 
@@ -506,16 +506,14 @@ class ilAdvancedSelectionListGUI implements ilToolbarItem
                     }
                 }
 
-                if ($this->getOnClickMode() ==
-                    self::ON_ITEM_CLICK_HREF ||
-                    $this->getItemLinkClass() != "") {
+                if ($this->getOnClickMode() === self::ON_ITEM_CLICK_HREF || $this->getItemLinkClass() !== "") {
                     if ($item["frame"]) {
                         $tpl->setCurrentBlock("frame");
                         $tpl->setVariable("TARGET_ITEM", $item["frame"]);
                         $tpl->parseCurrentBlock();
                     }
 
-                    if ($this->getItemLinkClass() != "") {
+                    if ($this->getItemLinkClass() !== "") {
                         $tpl->setCurrentBlock("item_link_class");
                         $tpl->setVariable("ITEM_LINK_CLASS", $this->getItemLinkClass());
                         $tpl->parseCurrentBlock();
@@ -543,8 +541,7 @@ class ilAdvancedSelectionListGUI implements ilToolbarItem
                 }
 
                 $tpl->setCurrentBlock("item");
-                if ($this->getOnClickMode() ==
-                    self::ON_ITEM_CLICK_HREF) {
+                if ($this->getOnClickMode() === self::ON_ITEM_CLICK_HREF) {
                     if ($item["prevent_background_click"]) {
                         $tpl->setVariable("ONCLICK_ITEM", '');
                     } elseif ($item["onclick"] == "" && $item["frame"] != "") {       // see #28730
@@ -558,24 +555,21 @@ class ilAdvancedSelectionListGUI implements ilToolbarItem
                             'onclick="' . "return " . $item["onclick"] . ";" . '"'
                         );
                     }
-                } elseif ($this->getOnClickMode() ==
-                    self::ON_ITEM_CLICK_FORM_SUBMIT) {
+                } elseif ($this->getOnClickMode() === self::ON_ITEM_CLICK_FORM_SUBMIT) {
                     $tpl->setVariable(
                         "ONCLICK_ITEM",
                         'onclick="return il.AdvancedSelectionList.submitForm(\'' . $this->getId() . '\'' .
                             ", '" . $this->form_mode["select_name"] . "','" . $item["value"] . "'," .
                             "'" . $this->on_click_form_id . "','" . $this->form_mode["button_cmd"] . "');\""
                     );
-                } elseif ($this->getOnClickMode() ==
-                    self::ON_ITEM_CLICK_FORM_SELECT) {
+                } elseif ($this->getOnClickMode() === self::ON_ITEM_CLICK_FORM_SELECT) {
                     $tpl->setVariable(
                         "ONCLICK_ITEM",
                         'onclick="return il.AdvancedSelectionList.selectForm(\'' . $this->getId() . '\'' .
                             ", '" . $this->form_mode["select_name"] . "','" . $item["value"] . "'," .
                             "'" . $item["title"] . "');\""
                     );
-                } elseif ($this->getOnClickMode() ==
-                    self::ON_ITEM_CLICK_NOP) {
+                } elseif ($this->getOnClickMode() === self::ON_ITEM_CLICK_NOP) {
                     $tpl->setVariable(
                         "ONCLICK_ITEM",
                         'onclick="il.AdvancedSelectionList.clickNop(\'' . $this->getId() . '\'' .
@@ -619,7 +613,7 @@ class ilAdvancedSelectionListGUI implements ilToolbarItem
             }
 
             // output hidden input, if click mode is form submission
-            if ($this->getOnClickMode() == self::ON_ITEM_CLICK_FORM_SUBMIT) {
+            if ($this->getOnClickMode() === self::ON_ITEM_CLICK_FORM_SUBMIT) {
                 $tpl->setCurrentBlock("hidden_input");
                 $tpl->setVariable("HID", $this->getId());
                 $tpl->parseCurrentBlock();
@@ -630,7 +624,7 @@ class ilAdvancedSelectionListGUI implements ilToolbarItem
             }
 
             // output hidden input and initialize
-            if ($this->getOnClickMode() == self::ON_ITEM_CLICK_FORM_SELECT) {
+            if ($this->getOnClickMode() === self::ON_ITEM_CLICK_FORM_SELECT) {
                 $tpl->setCurrentBlock("hidden_input");
                 $tpl->setVariable("HID", $this->getId());
                 $tpl->parseCurrentBlock();
@@ -649,7 +643,7 @@ class ilAdvancedSelectionListGUI implements ilToolbarItem
             return $tpl->get("cmd_table");
         }
 
-        if ($this->getGroupedList() == null) {
+        if ($this->getGroupedList() === null) {
             $tpl->setCurrentBlock("dd_content");
             if ($this->getPullRight()) {
                 $tpl->setVariable("UL_CLASS", "dropdown-menu pull-right");
@@ -660,7 +654,7 @@ class ilAdvancedSelectionListGUI implements ilToolbarItem
             $tpl->parseCurrentBlock();
         }
 
-        if ($this->getHeaderIcon() != self::NO_ICON) {
+        if ($this->getHeaderIcon() !== self::NO_ICON) {
             $tpl->setCurrentBlock("top_img");
             switch ($this->getHeaderIcon()) {
                 case self::ICON_CONFIG:
@@ -690,7 +684,7 @@ class ilAdvancedSelectionListGUI implements ilToolbarItem
         $cfg["trigger_event"] = $this->getTriggerEvent();
         $cfg["auto_hide"] = $this->getAutoHide();
 
-        if ($this->getSelectCallback() != "") {
+        if ($this->getSelectCallback() !== "") {
             $cfg["select_callback"] = $this->getSelectCallback();
         }
         $cfg["anchor_id"] = "ilAdvSelListAnchorElement_" . $this->getId();
@@ -707,8 +701,8 @@ class ilAdvancedSelectionListGUI implements ilToolbarItem
         //echo htmlentities(ilJsonUtil::encode($cfg));
         
         $tpl->setVariable("TXT_SEL_TOP", $this->getListTitle());
-        if ($this->getListTitle() == "" || $this->getAriaListTitle() != "") {
-            $aria_title = ($this->getAriaListTitle() != "")
+        if ($this->getListTitle() === "" || $this->getAriaListTitle() !== "") {
+            $aria_title = ($this->getAriaListTitle() !== "")
                 ? $this->getAriaListTitle()
                 : $this->lng->txt("actions");
             $tpl->setVariable("TXT_ARIA_TOP", $aria_title);
@@ -741,7 +735,7 @@ class ilAdvancedSelectionListGUI implements ilToolbarItem
         }
 
 
-        if ($this->getSelectionHeaderSpanClass() != "") {
+        if ($this->getSelectionHeaderSpanClass() !== "") {
             $tpl->setVariable(
                 "CLASS_SEL_TOP_SPAN",
                 $this->getSelectionHeaderSpanClass()

--- a/Services/UIComponent/Button/classes/class.ilButtonBase.php
+++ b/Services/UIComponent/Button/classes/class.ilButtonBase.php
@@ -180,7 +180,7 @@ abstract class ilButtonBase implements ilToolbarItem
             }
         }
         
-        if (sizeof($res)) {
+        if (count($res)) {
             return " " . implode(" ", $res);
         }
         return "";
@@ -200,7 +200,7 @@ abstract class ilButtonBase implements ilToolbarItem
             $attr["disabled"] = "disabled";
         }
         
-        if (sizeof($a_additional_attr)) {
+        if (count($a_additional_attr)) {
             $attr = array_merge($attr, $a_additional_attr);
         }
         

--- a/Services/UIComponent/Button/classes/class.ilImageLinkButton.php
+++ b/Services/UIComponent/Button/classes/class.ilImageLinkButton.php
@@ -34,7 +34,7 @@ class ilImageLinkButton extends ilLinkButton
     // properties
     //
     
-    public function setImage(string $a_value, bool $a_is_internal = true)
+    public function setImage(string $a_value, bool $a_is_internal = true) : void
     {
         if ($a_is_internal) {
             $a_value = ilUtil::getImagePath($a_value);

--- a/Services/UIComponent/Button/classes/class.ilLinkButton.php
+++ b/Services/UIComponent/Button/classes/class.ilLinkButton.php
@@ -44,7 +44,7 @@ class ilLinkButton extends ilButtonBase
         return $this->url;
     }
     
-    public function setTarget(string $a_value)
+    public function setTarget(string $a_value) : void
     {
         $this->target = trim($a_value);
     }

--- a/Services/UIComponent/CharSelector/classes/class.ilCharSelectorGUI.php
+++ b/Services/UIComponent/CharSelector/classes/class.ilCharSelectorGUI.php
@@ -237,7 +237,11 @@ class ilCharSelectorGUI
         $tpl->addCss(ilUtil::getStyleSheetLocation('', 'char_selector_style.css', 'Services/UIComponent/CharSelector'));
         $tpl->addJavaScript('./Services/UIComponent/CharSelector/js/ilCharSelector.js');
         $tpl->addLightbox($this->getSelectorHTML(), 2);
-        $tpl->addOnLoadCode('il.CharSelector.init(' . json_encode($this->jsconfig) . ',' . json_encode($this->jstexts) . ')');
+        $tpl->addOnLoadCode(
+            'il.CharSelector.init(' .
+            json_encode($this->jsconfig, JSON_THROW_ON_ERROR) . ',' .
+            json_encode($this->jstexts, JSON_THROW_ON_ERROR) . ')'
+        );
         $this->added_to_page = true;
     }
     
@@ -295,7 +299,7 @@ class ilCharSelectorGUI
             'open' => ilSession::get('char_selector_open'),
             'current_page' => ilSession::get('char_selector_current_page'),
             'current_subpage' => ilSession::get('char_selector_current_subpage'),
-        ));
+        ), JSON_THROW_ON_ERROR);
         exit;
     }
     

--- a/Services/UIComponent/CharSelector/classes/class.ilCharSelectorGUI.php
+++ b/Services/UIComponent/CharSelector/classes/class.ilCharSelectorGUI.php
@@ -77,7 +77,7 @@ class ilCharSelectorGUI
         // with correct case for checking parent classes
         $class = false;
         foreach ($ilCtrl->getCallHistory() as $call) {
-            if ($call['mode'] == 'execComm') {
+            if ($call['mode'] === 'execComm') {
                 $class = $call['class'];
             }
         }

--- a/Services/UIComponent/CharSelector/classes/class.ilCharSelectorRadioGroupInputGUI.php
+++ b/Services/UIComponent/CharSelector/classes/class.ilCharSelectorRadioGroupInputGUI.php
@@ -35,9 +35,9 @@ class ilCharSelectorRadioGroupInputGUI extends ilRadioGroupInputGUI
             return false;
         }
 
-        if ($this->int('char_selector_availability') == ilCharSelectorConfig::ENABLED
-            and trim(implode("", $this->strArray('char_selector_blocks'))) == ""
-            and trim($this->str('char_selector_custom_items')) == '') {
+        if ($this->int('char_selector_availability') === ilCharSelectorConfig::ENABLED
+            && trim(implode("", $this->strArray('char_selector_blocks'))) === ""
+            && trim($this->str('char_selector_custom_items')) === '') {
             $this->setAlert($lng->txt("char_selector_msg_blocks_or_custom_needed"));
             return false;
         } else {

--- a/Services/UIComponent/CharSelector/classes/ilCharSelectorConfig.php
+++ b/Services/UIComponent/CharSelector/classes/ilCharSelectorConfig.php
@@ -302,7 +302,7 @@ class ilCharSelectorConfig
         $admin_config = new self(self::CONTEXT_ADMIN);
         $admin_config->setAvailability($ilSetting->get('char_selector_availability'));
         $admin_config->setDefinition($ilSetting->get('char_selector_definition'));
-        if ($admin_config->getAvailability() == self::INACTIVE) {
+        if ($admin_config->getAvailability() === self::INACTIVE) {
             // a globally inactive selector can't be overwritten by users or tests
             return $admin_config;
         }
@@ -312,7 +312,7 @@ class ilCharSelectorConfig
             $test_config = new self(self::CONTEXT_TEST);
             $test_config->setAvailability($a_test_obj->getCharSelectorAvailability());
             $test_config->setDefinition($a_test_obj->getCharSelectorDefinition());
-            if ($test_config->getAvailability() != self::INHERIT) {
+            if ($test_config->getAvailability() !== self::INHERIT) {
                 // a specific test configuration has precedence over user configuration
                 return $test_config;
             }
@@ -322,7 +322,7 @@ class ilCharSelectorConfig
         $user_config = new self(self::CONTEXT_USER);
         $user_config->setAvailability($ilUser->getPref('char_selector_availability'));
         $user_config->setDefinition($ilUser->getPref('char_selector_definition'));
-        if ($user_config->getAvailability() != self::INHERIT) {
+        if ($user_config->getAvailability() !== self::INHERIT) {
             // take user specific config
             return $user_config;
         } else {
@@ -419,16 +419,16 @@ class ilCharSelectorConfig
         $this->custom_items = array();
 
         // set the default definition to all unicode blocks
-        if (trim($a_definition) == '') {
+        if (trim($a_definition) === '') {
             $a_definition = "[all]";
         }
         
         // analyze definition items
         $items = explode(' ', $a_definition);
         foreach ($items as $item) {
-            if (strlen($block_name = $this->extractUnicodeBlock($item))) {
+            if (($block_name = $this->extractUnicodeBlock($item)) !== '') {
                 $this->added_blocks[] = $block_name;
-            } elseif ($item != '') {
+            } elseif ($item !== '') {
                 $this->custom_items[] = trim($item);
             }
         }
@@ -475,7 +475,7 @@ class ilCharSelectorConfig
         global $lng;
         
         $langvar = 'char_selector_unicode_' . $a_block_name;
-        if ($lng->txt($langvar) != '-' . $langvar . '-') {
+        if ($lng->txt($langvar) !== '-' . $langvar . '-') {
             return $lng->txt($langvar);
         } else {
             return self::$unicode_blocks[$a_block_name][0];

--- a/Services/UIComponent/CharSelector/classes/ilCharSelectorConfig.php
+++ b/Services/UIComponent/CharSelector/classes/ilCharSelectorConfig.php
@@ -442,7 +442,7 @@ class ilCharSelectorConfig
     {
         $definition = implode(' ', $this->custom_items);
         foreach ($this->added_blocks as $block_name) {
-            $definition = $definition . ' [' . $block_name . ']';
+            $definition .= ' [' . $block_name . ']';
         }
         return trim($definition);
     }

--- a/Services/UIComponent/CharSelector/classes/ilCharSelectorConfig.php
+++ b/Services/UIComponent/CharSelector/classes/ilCharSelectorConfig.php
@@ -367,9 +367,8 @@ class ilCharSelectorConfig
     {
         $this->added_blocks = array();
         foreach ($a_blocks as $block_name) {
-            if ($block_name == "all" or
-                in_array($block_name, array_keys(self::$unicode_blocks))) {
-                array_push($this->added_blocks, $block_name);
+            if ($block_name === "all" || array_key_exists($block_name, self::$unicode_blocks)) {
+                $this->added_blocks[] = $block_name;
             }
         }
     }
@@ -428,9 +427,9 @@ class ilCharSelectorConfig
         $items = explode(' ', $a_definition);
         foreach ($items as $item) {
             if (strlen($block_name = $this->extractUnicodeBlock($item))) {
-                array_push($this->added_blocks, $block_name);
+                $this->added_blocks[] = $block_name;
             } elseif ($item != '') {
-                array_push($this->custom_items, trim($item));
+                $this->custom_items[] = trim($item);
             }
         }
     }
@@ -494,8 +493,7 @@ class ilCharSelectorConfig
         $matches = array();
         if (preg_match('/^\[(.+)\]$/', $a_item, $matches)) {
             $block_name = $matches[1];
-            if ($block_name == 'all'
-                or in_array($block_name, array_keys(self::$unicode_blocks))) {
+            if ($block_name === 'all' || array_key_exists($block_name, self::$unicode_blocks)) {
                 return $block_name;
             }
         }
@@ -523,14 +521,14 @@ class ilCharSelectorConfig
                 $subitems = explode('-', $item);
                 $start = $this->getItemCodepoint($subitems[0]);
                 $end = $this->getItemCodepoint($subitems[1]);
-                array_push($page, array($start, $end));
+                $page[] = array($start, $end);
             } else {
                 // handle normal item
-                array_push($page, $this->getItemParsed($item));
+                $page[] = $this->getItemParsed($item);
             }
         }
         if (count($page) > 1) {
-            array_push($pages, $page);
+            $pages[] = $page;
         }
     
         // add unicode blocks
@@ -543,7 +541,7 @@ class ilCharSelectorConfig
             $start = hexdec(self::$unicode_blocks[$block_name][1]);
             $end = hexdec(self::$unicode_blocks[$block_name][2]);
             $page = array($this->getBlockTitle($block_name), array($start, $end));
-            array_push($pages, $page);
+            $pages[] = $page;
         }
         
         return $pages;

--- a/Services/UIComponent/CheckboxListOverlay/classes/class.ilCheckboxListOverlayGUI.php
+++ b/Services/UIComponent/CheckboxListOverlay/classes/class.ilCheckboxListOverlayGUI.php
@@ -39,12 +39,12 @@ class ilCheckboxListOverlayGUI
         $this->setId($a_id);
     }
 
-    public function setId($a_val)
+    public function setId(string $a_val) : void
     {
         $this->id = $a_val;
     }
     
-    public function getId()
+    public function getId() : string
     {
         return $this->id;
     }

--- a/Services/UIComponent/Explorer/classes/class.ilExplorer.php
+++ b/Services/UIComponent/Explorer/classes/class.ilExplorer.php
@@ -778,14 +778,16 @@ class ilExplorer
             }
 
             //$tpl->setVariable("LINK_NAME", $a_node_id);
-            $tpl->setVariable("TITLE",
+            $tpl->setVariable(
+                "TITLE",
                 ilStr::shortenTextExtended(
                     $this->buildTitle($a_option["title"], $a_node_id, $a_option["type"]),
                     $this->textwidth,
                     true
                 )
             );
-            $tpl->setVariable("DESC",
+            $tpl->setVariable(
+                "DESC",
                 ilStr::shortenTextExtended(
                     $this->buildDescription($a_option["description"], $a_node_id, $a_option["type"]),
                     $this->textwidth,
@@ -798,14 +800,16 @@ class ilExplorer
             }
         } else {			// output text only
             $tpl->setCurrentBlock("text");
-            $tpl->setVariable("OBJ_TITLE",
+            $tpl->setVariable(
+                "OBJ_TITLE",
                 ilStr::shortenTextExtended(
                     $this->buildTitle($a_option["title"], $a_node_id, $a_option["type"]),
                     $this->textwidth,
                     true
                 )
             );
-            $tpl->setVariable("OBJ_DESC",
+            $tpl->setVariable(
+                "OBJ_DESC",
                 ilStr::shortenTextExtended(
                     $this->buildDescription($a_option["desc"], $a_node_id, $a_option["type"]),
                     $this->textwidth,

--- a/Services/UIComponent/Explorer/classes/class.ilExplorer.php
+++ b/Services/UIComponent/Explorer/classes/class.ilExplorer.php
@@ -196,7 +196,7 @@ class ilExplorer
 
     public function setOrderDirection(string $a_direction) : void
     {
-        if ($a_direction == "desc") {
+        if ($a_direction === "desc") {
             $this->order_direction = $a_direction;
         } else {
             $this->order_direction = "asc";
@@ -318,11 +318,7 @@ class ilExplorer
         // only the type determines, wether an object should be clickable or not
         // but this method can be overwritten and make $exp->setFilterMode(IL_FM_NEGATIVE);use of the ref id
         // (this happens e.g. in class ilRepositoryExplorerGUI)
-        if ($this->is_clickable[$a_type] == "n") {
-            return false;
-        } else {
-            return true;
-        }
+        return $this->is_clickable[$a_type] !== "n";
     }
 
     public function setPostSort(bool $a_sort) : void
@@ -408,7 +404,7 @@ class ilExplorer
                 }
                 //echo "<br>-".$object["child"]."-".$this->forceExpanded($object["child"])."-";
                 //ask for FILTER
-                if ($this->filtered == false or $this->checkFilter($object["type"]) == false) {
+                if ($this->filtered === false || $this->checkFilter($object["type"]) === false) {
                     if ($this->isVisible($object['child'], $object['type'])) {
                         #echo 'CHILD getIndex() '.$object['child'].' parent: '.$this->getRoot();
                         if ($object["child"] != $this->getRoot()) {
@@ -431,7 +427,7 @@ class ilExplorer
                         }
 
                         // fix explorer (sometimes explorer disappears)
-                        if ($parent_index == 0) {
+                        if ($parent_index === 0) {
                             if (!$this->expand_all && !in_array($object["parent"], $this->expanded)) {
                                 $this->expanded[] = $object["parent"];
                             }
@@ -541,9 +537,9 @@ class ilExplorer
         $tpl_tree = new ilTemplate("tpl.tree.html", true, true, "Services/UIComponent/Explorer");
         
         // updater
-        if (($this->requestStr("ict") != "" ||
-            $this->requestStr("collapseAll") != "" ||
-            $this->requestStr("expandAll") != "") && $this->up_frame != "") {
+        if (($this->requestStr("ict") !== "" ||
+            $this->requestStr("collapseAll") !== "" ||
+            $this->requestStr("expandAll") !== "") && $this->up_frame !== "") {
             $tpl_tree->setCurrentBlock("updater");
             $tpl_tree->setVariable("UPDATE_FRAME", $this->up_frame);
             $tpl_tree->setVariable("UPDATE_SCRIPT", $this->up_script);
@@ -584,12 +580,12 @@ class ilExplorer
         $this->handleListEndTags($tpl_tree, $cur_depth, -1);
         
         $tpl_tree->setVariable("TREE_LEAD", "");
-        if ($this->tree_lead != "") {
+        if ($this->tree_lead !== "") {
             $tpl_tree->setCurrentBlock("tree_lead");
             $tpl_tree->setVariable("TREE_LEAD", $this->tree_lead);
             $tpl_tree->parseCurrentBlock();
         }
-        if ($this->getId() != "") {
+        if ($this->getId() !== "") {
             $tpl_tree->setVariable("TREE_ID", 'id="' . $this->getId() . '_tree"');
         }
 
@@ -600,10 +596,10 @@ class ilExplorer
             $mtpl->setVariable("LOCATION_STYLESHEET", ilUtil::getStyleSheetLocation());
             $mtpl->setVariable("BODY_CLASS", "il_Explorer");
             $mtpl->addBlockFile("CONTENT", "content", "tpl.explorer.html");
-            if ($this->getTitle() != "") {
+            if ($this->getTitle() !== "") {
                 $mtpl->setVariable("TXT_EXPLORER_HEADER", $this->getTitle());
             }
-            if ($this->getId() != "") {
+            if ($this->getId() !== "") {
                 $mtpl->setVariable("ID", 'id="' . $this->getId() . '"');
             }
             $mtpl->setVariable("IMG_SPACE", ilUtil::getImagePath("spacer.png", false));
@@ -688,7 +684,7 @@ class ilExplorer
 
         $pic = false;
         foreach ((array) $a_option["tab"] as $picture) {
-            if ($picture == 'plus') {
+            if ($picture === 'plus') {
                 $tpl->setCurrentBlock("expander");
                 $tpl->setVariable("EXP_DESC", $lng->txt("collapsed"));
                 $tpl->setVariable("LINK_NAME", $a_node_id);
@@ -705,7 +701,7 @@ class ilExplorer
                 $pic = true;
             }
 
-            if ($picture == 'forceexp') {
+            if ($picture === 'forceexp') {
                 $tpl->setCurrentBlock("expander");
                 $tpl->setVariable("EXP_DESC", $lng->txt("expanded"));
                 $target = $this->createTarget('+', $a_node_id);
@@ -716,7 +712,7 @@ class ilExplorer
                 $pic = true;
             }
 
-            if ($picture == 'minus' && $this->show_minus) {
+            if ($picture === 'minus' && $this->show_minus) {
                 $tpl->setCurrentBlock("expander");
                 $tpl->setVariable("EXP_DESC", $lng->txt("expanded"));
                 $tpl->setVariable("LINK_NAME", $a_node_id);
@@ -753,7 +749,7 @@ class ilExplorer
             $tpl->parseCurrentBlock();
         }
         
-        if (strlen($sel = $this->buildSelect($a_node_id, $a_option['type']))) {
+        if (($sel = $this->buildSelect($a_node_id, $a_option['type'])) !== '') {
             $tpl->setCurrentBlock('select');
             $tpl->setVariable('OBJ_SEL', $sel);
             $tpl->parseCurrentBlock();
@@ -768,7 +764,7 @@ class ilExplorer
                 
             $style_class = $this->getNodeStyleClass($a_node_id, $a_option["type"]);
             
-            if ($style_class != "") {
+            if ($style_class !== "") {
                 $tpl->setVariable("A_CLASS", ' class="' . $style_class . '" ');
             }
 
@@ -794,7 +790,7 @@ class ilExplorer
                 )
             );
             $frame_target = $this->buildFrameTarget($a_option["type"], $a_node_id, $a_option["obj_id"]);
-            if ($frame_target != "") {
+            if ($frame_target !== "") {
                 $tpl->setVariable("TARGET", " target=\"" . $frame_target . "\"");
             }
         } else {			// output text only
@@ -916,14 +912,14 @@ class ilExplorer
         // SET expand parameter:
         //     positive if object is expanded
         //     negative if object is compressed
-        $a_node_id = $a_type == '+' ? $a_node_id : -(int) $a_node_id;
+        $a_node_id = $a_type === '+' ? $a_node_id : -(int) $a_node_id;
 
         $sep = (is_int(strpos($this->expand_target, "?")))
             ? "&"
             : "?";
         
         // in current tree flag
-        $ict_str = ($a_highlighted_subtree || $this->highlighted == "")
+        $ict_str = ($a_highlighted_subtree || $this->highlighted === "")
             ? "&ict=1"
             : "";
         if ($this->getAsynchExpanding()) {
@@ -1003,7 +999,7 @@ class ilExplorer
         if (is_array($this->filter)) {
             //run through filter
             foreach ($this->filter as $item) {
-                if ($item == $a_item) {
+                if ($item === $a_item) {
                     return false;
                 }
             }
@@ -1024,7 +1020,7 @@ class ilExplorer
             $tmp = array();
 
             foreach ($this->filter as $item) {
-                if ($item != $a_item) {
+                if ($item !== $a_item) {
                     $tmp[] = $item;
                 } else {
                     $deleted = 1;
@@ -1036,11 +1032,7 @@ class ilExplorer
             return false;
         }
 
-        if ($deleted == 1) {
-            return true;
-        } else {
-            return false;
-        }
+        return $deleted === 1;
     }
 
     /**
@@ -1099,7 +1091,7 @@ class ilExplorer
             $ret = false;
         }
 
-        if ($this->getFilterMode() == IL_FM_NEGATIVE) {
+        if ($this->getFilterMode() === IL_FM_NEGATIVE) {
             return $ret;
         } else {
             return !$ret;
@@ -1113,7 +1105,7 @@ class ilExplorer
     {
         $adm_node = null;
         foreach ($a_nodes as $key => $node) {
-            if ($node["type"] == "adm") {
+            if ($node["type"] === "adm") {
                 $match = $key;
                 $adm_node = $node;
                 break;

--- a/Services/UIComponent/Explorer/classes/class.ilExplorer.php
+++ b/Services/UIComponent/Explorer/classes/class.ilExplorer.php
@@ -178,17 +178,15 @@ class ilExplorer
         return $this->title;
     }
     
-    public function setRoot($a_root_id)
+    public function setRoot($a_root_id) : void
     {
         #$this->tree = new ilTree(ROOT_FOLDER_ID,$a_root_id);
         $this->root_id = $a_root_id;
     }
     
-    public function getRoot()
+    public function getRoot() : ?int
     {
-        return $this->root_id == null ?
-            $this->tree->getRootId() :
-            $this->root_id;
+        return $this->root_id ?? $this->tree->getRootId();
     }
 
     public function setOrderColumn(string $a_column) : void
@@ -416,57 +414,57 @@ class ilExplorer
                         if ($object["child"] != $this->getRoot()) {
                             $parent_index = $this->getIndex($object);
                         }
-                        $this->format_options["$this->counter"]["parent"] = $object["parent"];
-                        $this->format_options["$this->counter"]["child"] = $object["child"];
-                        $this->format_options["$this->counter"]["title"] = $object["title"];
-                        $this->format_options["$this->counter"]["type"] = $object["type"];
-                        $this->format_options["$this->counter"]["obj_id"] = $object["obj_id"];
-                        $this->format_options["$this->counter"]["desc"] = "obj_" . $object["type"];
-                        $this->format_options["$this->counter"]["depth"] = $tab;
-                        $this->format_options["$this->counter"]["container"] = false;
-                        $this->format_options["$this->counter"]["visible"] = true;
-                        $this->format_options["$this->counter"]["highlighted_subtree"] = $a_highlighted_subtree;
+                        $this->format_options[(string) $this->counter]["parent"] = $object["parent"];
+                        $this->format_options[(string) $this->counter]["child"] = $object["child"];
+                        $this->format_options[(string) $this->counter]["title"] = $object["title"];
+                        $this->format_options[(string) $this->counter]["type"] = $object["type"];
+                        $this->format_options[(string) $this->counter]["obj_id"] = $object["obj_id"];
+                        $this->format_options[(string) $this->counter]["desc"] = "obj_" . $object["type"];
+                        $this->format_options[(string) $this->counter]["depth"] = $tab;
+                        $this->format_options[(string) $this->counter]["container"] = false;
+                        $this->format_options[(string) $this->counter]["visible"] = true;
+                        $this->format_options[(string) $this->counter]["highlighted_subtree"] = $a_highlighted_subtree;
 
                         // Create prefix array
                         for ($i = 0; $i < $tab; ++$i) {
-                            $this->format_options["$this->counter"]["tab"][] = 'blank';
+                            $this->format_options[(string) $this->counter]["tab"][] = 'blank';
                         }
 
                         // fix explorer (sometimes explorer disappears)
                         if ($parent_index == 0) {
-                            if (!$this->expand_all and !in_array($object["parent"], $this->expanded)) {
+                            if (!$this->expand_all && !in_array($object["parent"], $this->expanded)) {
                                 $this->expanded[] = $object["parent"];
                             }
                         }
 
                         // only if parent is expanded and visible, object is visible
-                        if ($object["child"] != $this->getRoot() and ((!$this->expand_all and !in_array($object["parent"], $this->expanded))
-                           or !$this->format_options["$parent_index"]["visible"])) {
+                        if ($object["child"] != $this->getRoot() && ((!$this->expand_all && !in_array($object["parent"], $this->expanded))
+                           or !$this->format_options[(string) $parent_index]["visible"])) {
                             if (!$this->forceExpanded($object["child"])) {
                                 // if parent is not expanded, and one child is
                                 // visible we don't need more information and
                                 // can skip the rest of the childs
-                                if ($this->format_options["$this->counter"]["visible"]) {
+                                if ($this->format_options[(string) $this->counter]["visible"]) {
                                     //echo "-setSkipping";
                                     $skip_rest = true;
                                 }
-                                $this->format_options["$this->counter"]["visible"] = false;
+                                $this->format_options[(string) $this->counter]["visible"] = false;
                             }
                         }
 
                         // if object exists parent is container
                         if ($object["child"] != $this->getRoot()) {
-                            $this->format_options["$parent_index"]["container"] = true;
+                            $this->format_options[(string) $parent_index]["container"] = true;
 
-                            if ($this->expand_all or in_array($object["parent"], $this->expanded)) {
+                            if ($this->expand_all || in_array($object["parent"], $this->expanded)) {
                                 //echo "<br>-".$object["child"]."-".$this->forceExpanded($object["child"])."-";
                                 if ($this->forceExpanded($object["parent"])) {
-                                    $this->format_options["$parent_index"]["tab"][($tab - 2)] = 'forceexp';
+                                    $this->format_options[(string) $parent_index]["tab"][($tab - 2)] = 'forceexp';
                                 } else {
-                                    $this->format_options["$parent_index"]["tab"][($tab - 2)] = 'minus';
+                                    $this->format_options[(string) $parent_index]["tab"][($tab - 2)] = 'minus';
                                 }
                             } else {
-                                $this->format_options["$parent_index"]["tab"][($tab - 2)] = 'plus';
+                                $this->format_options[(string) $parent_index]["tab"][($tab - 2)] = 'plus';
                             }
                         }
                         //echo "-"."$parent_index"."-";
@@ -474,7 +472,7 @@ class ilExplorer
                         ++$this->counter;
 
                         // stop recursion if 2. level beyond expanded nodes is reached
-                        if ($this->expand_all or in_array($object["parent"], $this->expanded) or ($object["parent"] == 0)
+                        if ($this->expand_all || in_array($object["parent"], $this->expanded) or ($object["parent"] == 0)
                             or $this->forceExpanded($object["child"])) {
                             $highlighted_subtree = $a_highlighted_subtree ||
                                 ($object["child"] == $this->highlighted);
@@ -679,7 +677,7 @@ class ilExplorer
         $a_node_id,
         array $a_option,
         $a_obj_id = 0
-    ) {
+    ) : void {
         $lng = $this->lng;
         $ilErr = $this->error;
 
@@ -949,20 +947,20 @@ class ilExplorer
             if ($this->format_options[$i]["depth"] == $a_depth + 1
                and !$this->format_options[$i]["container"]
                 and $this->format_options[$i]["depth"] != 1) {
-                $this->format_options[$i]["tab"]["$a_depth"] = "quer";
+                $this->format_options[$i]["tab"][(string) $a_depth] = "quer";
             }
 
             if ($this->format_options[$i]["depth"] == $a_depth + 2) {
                 if ($this->is_in_array($i + 1, $this->format_options[$i]["depth"])) {
-                    $this->format_options[$i]["tab"]["$a_depth"] = "winkel";
+                    $this->format_options[$i]["tab"][(string) $a_depth] = "winkel";
                 } else {
-                    $this->format_options[$i]["tab"]["$a_depth"] = "ecke";
+                    $this->format_options[$i]["tab"][(string) $a_depth] = "ecke";
                 }
             }
 
             if ($this->format_options[$i]["depth"] > $a_depth + 2) {
                 if ($this->is_in_array($i + 1, $a_depth + 2)) {
-                    $this->format_options[$i]["tab"]["$a_depth"] = "hoch";
+                    $this->format_options[$i]["tab"][(string) $a_depth] = "hoch";
                 }
             }
         }

--- a/Services/UIComponent/Explorer/classes/class.ilExplorer.php
+++ b/Services/UIComponent/Explorer/classes/class.ilExplorer.php
@@ -47,6 +47,7 @@ class ilExplorer
     public array $is_clickable;
     public bool $post_sort;
     public bool $filtered = false;
+    protected $filter = [];
     public bool $filter_mode;
     // expand entire tree regardless of values in $expanded
     public bool$expand_all = false;
@@ -684,7 +685,7 @@ class ilExplorer
 
         if (!isset($a_node_id) or !is_array($a_option)) {
             $ilErr->raiseError(get_class($this) . "::formatObject(): Missing parameter or wrong datatype! " .
-                                    "node_id: " . $a_node_id . " options:" . var_dump($a_option), $ilErr->WARNING);
+                                    "node_id: " . $a_node_id . " options:" . var_export($a_option, true), $ilErr->WARNING);
         }
 
         $pic = false;
@@ -944,7 +945,7 @@ class ilExplorer
 
     public function createLines(int $a_depth) : void
     {
-        for ($i = 0; $i < count($this->format_options); ++$i) {
+        for ($i = 0, $iMax = count($this->format_options); $i < $iMax; ++$i) {
             if ($this->format_options[$i]["depth"] == $a_depth + 1
                and !$this->format_options[$i]["container"]
                 and $this->format_options[$i]["depth"] != 1) {
@@ -971,7 +972,7 @@ class ilExplorer
         int $a_start,
         int $a_depth
     ) : bool {
-        for ($i = $a_start;$i < count($this->format_options);++$i) {
+        for ($i = $a_start, $iMax = count($this->format_options); $i < $iMax; ++$i) {
             if ($this->format_options[$i]["depth"] < $a_depth) {
                 break;
             }
@@ -1130,7 +1131,7 @@ class ilExplorer
 
         // append adm node to end of list
         if (isset($match)) {
-            array_push($a_nodes, $adm_node);
+            $a_nodes[] = $adm_node;
         }
 
         return $a_nodes;

--- a/Services/UIComponent/Explorer2/classes/class.ilExplorerBaseGUI.php
+++ b/Services/UIComponent/Explorer2/classes/class.ilExplorerBaseGUI.php
@@ -41,7 +41,7 @@ abstract class ilExplorerBaseGUI
     protected string $search_term = "";
     protected array $open_nodes = [];
     protected ilSessionIStorage $store;
-    protected $select_multi = false;
+    protected bool $select_multi = false;
 
     /**
      * @var string|object|array

--- a/Services/UIComponent/Explorer2/classes/class.ilExplorerBaseGUI.php
+++ b/Services/UIComponent/Explorer2/classes/class.ilExplorerBaseGUI.php
@@ -73,7 +73,7 @@ abstract class ilExplorerBaseGUI
         // get open nodes
         $this->store = new ilSessionIStorage("expl2");
         $open_nodes = $this->store->get("on_" . $this->id);
-        $this->open_nodes = unserialize($open_nodes) ?: [];
+        $this->open_nodes = unserialize($open_nodes, ['allowed_classes' => false]) ?: [];
         if (!is_array($this->open_nodes)) {
             $this->open_nodes = array();
         }

--- a/Services/UIComponent/Explorer2/classes/class.ilExplorerBaseGUI.php
+++ b/Services/UIComponent/Explorer2/classes/class.ilExplorerBaseGUI.php
@@ -41,6 +41,7 @@ abstract class ilExplorerBaseGUI
     protected string $search_term = "";
     protected array $open_nodes = [];
     protected ilSessionIStorage $store;
+    protected $select_multi = false;
 
     /**
      * @var string|object|array

--- a/Services/UIComponent/Explorer2/classes/class.ilExplorerBaseGUI.php
+++ b/Services/UIComponent/Explorer2/classes/class.ilExplorerBaseGUI.php
@@ -252,7 +252,7 @@ abstract class ilExplorerBaseGUI
      */
     public function getNodeOnClick($a_node) : string
     {
-        if ($this->select_postvar != "") {
+        if ($this->select_postvar !== "") {
             return $this->getSelectOnClick($a_node);
         }
         return "";
@@ -421,8 +421,8 @@ abstract class ilExplorerBaseGUI
      */
     public function handleCommand() : bool
     {
-        if ($this->requested_exp_cmd != "" &&
-            $this->requested_exp_cont == $this->getContainerId()) {
+        if ($this->requested_exp_cmd !== "" &&
+            $this->requested_exp_cont === $this->getContainerId()) {
             $cmd = $this->requested_exp_cmd;
             if (in_array($cmd, array("openNode", "closeNode", "getNodeAsync"))) {
                 $this->$cmd();
@@ -479,7 +479,7 @@ abstract class ilExplorerBaseGUI
             $this->open_nodes[] = $root;
         }
 
-        if ($this->requested_node_id != "") {
+        if ($this->requested_node_id !== "") {
             $id = $this->getNodeIdForDomNodeId($this->requested_node_id);
             $this->setSearchTerm(ilUtil::stripSlashes($this->requested_searchterm));
             $this->renderChilds($id, $etpl);
@@ -568,7 +568,11 @@ abstract class ilExplorerBaseGUI
             "html_data" => array()
         );
 
-        return 'il.Explorer2.init(' . json_encode($config) . ', ' . json_encode($js_tree_config) . ');';
+        return (
+            'il.Explorer2.init(' .
+            json_encode($config, JSON_THROW_ON_ERROR) . ', ' .
+            json_encode($js_tree_config, JSON_THROW_ON_ERROR) . ');'
+        );
     }
 
     protected function getJSTreePlugins() : array
@@ -586,11 +590,7 @@ abstract class ilExplorerBaseGUI
     {
         global $DIC;
 
-        if ($a_main_tpl == null) {
-            $tpl = $DIC["tpl"];
-        } else {
-            $tpl = $a_main_tpl;
-        }
+        $tpl = $a_main_tpl ?? $DIC["tpl"];
 
         iljQueryUtil::initjQuery($tpl);
 
@@ -675,7 +675,7 @@ abstract class ilExplorerBaseGUI
             $this->listItemStart($tpl, $a_node);
 
             // select mode?
-            if ($this->select_postvar != "" && $this->isNodeSelectable($a_node)) {
+            if ($this->select_postvar !== "" && $this->isNodeSelectable($a_node)) {
                 if ($this->select_multi) {
                     $tpl->setCurrentBlock("cb");
                     if (in_array($this->getNodeId($a_node), $this->selected_nodes)) {
@@ -699,7 +699,7 @@ abstract class ilExplorerBaseGUI
                 $tpl->touchBlock("hl");
             }
             $tpl->setCurrentBlock("content");
-            if ($this->getNodeIcon($a_node) != "") {
+            if ($this->getNodeIcon($a_node) !== "") {
                 $tpl->setVariable("ICON", ilUtil::img($this->getNodeIcon($a_node), $this->getNodeIconAlt($a_node)) . " ");
             }
             $tpl->setVariable("CONTENT", $this->getNodeContent($a_node));
@@ -707,7 +707,7 @@ abstract class ilExplorerBaseGUI
                 $tpl->setVariable("HREF", $this->getNodeHref($a_node));
             }
             $target = $this->getNodeTarget($a_node);
-            if ($target != "") {
+            if ($target !== "") {
                 $targetRelatedParams = array(
                     'target="' . $target . '"'
                 );
@@ -723,7 +723,7 @@ abstract class ilExplorerBaseGUI
                 $tpl->setVariable("A_CLASS", 'class="disabled"');
             } else {
                 $onclick = $this->getNodeOnClick($a_node);
-                if ($onclick != "") {
+                if ($onclick !== "") {
                     $tpl->setVariable("ONCLICK", 'onclick="' . $onclick . '"');
                 }
             }
@@ -751,7 +751,7 @@ abstract class ilExplorerBaseGUI
         $childs = $this->getChildsOfNode($a_node_id);
         $childs = $this->sortChilds($childs, $a_node_id);
 
-        if (count($childs) > 0 || ($this->getSearchTerm() != "" && $this->requested_node_id == $this->getDomNodeIdForNodeId($a_node_id))) {
+        if (count($childs) > 0 || ($this->getSearchTerm() !== "" && $this->requested_node_id === $this->getDomNodeIdForNodeId($a_node_id))) {
             // collect visible childs
 
             $visible_childs = [];
@@ -770,15 +770,14 @@ abstract class ilExplorerBaseGUI
 
             // search field, if too many childs
             $any = false;
-            if ($this->getChildLimit() > 0 && $this->getChildLimit() < $cnt_child
-                || ($this->getSearchTerm() != "")) {
+            if (($this->getChildLimit() > 0 && $this->getChildLimit() < $cnt_child) || $this->getSearchTerm() !== "") {
                 if (!$any) {
                     $this->listStart($tpl);
                     $any = true;
                 }
                 $tpl->setCurrentBlock("list_search");
                 $tpl->setVariable("SEARCH_CONTAINER_ID", $a_node_id);
-                if ($this->requested_node_id == $this->getDomNodeIdForNodeId($a_node_id)) {
+                if ($this->requested_node_id === $this->getDomNodeIdForNodeId($a_node_id)) {
                     $tpl->setVariable("SEARCH_VAL", $this->getSearchTerm());
                 }
                 $tpl->parseCurrentBlock();

--- a/Services/UIComponent/Explorer2/classes/class.ilExplorerSelectInputGUI.php
+++ b/Services/UIComponent/Explorer2/classes/class.ilExplorerSelectInputGUI.php
@@ -118,8 +118,8 @@ abstract class ilExplorerSelectInputGUI extends ilFormPropertyGUI implements ilT
         
         // check required
         if ($this->getRequired()) {
-            if ((!$this->multi_nodes && trim($this->getInput()) == "") ||
-                ($this->multi_nodes && count($this->getInput()) == 0)) {
+            if ((!$this->multi_nodes && trim($this->getInput()) === "") ||
+                ($this->multi_nodes && count($this->getInput()) === 0)) {
                 $this->setAlert($lng->txt("msg_input_is_required"));
                 return false;
             }
@@ -151,7 +151,7 @@ abstract class ilExplorerSelectInputGUI extends ilFormPropertyGUI implements ilT
 
         $tpl = new ilTemplate("tpl.prop_expl_select.html", true, true, "Services/UIComponent/Explorer2");
 
-        if ($a_mode != "property_form") {
+        if ($a_mode !== "property_form") {
             $tpl->touchBlock("tiny_presentation");
         }
 

--- a/Services/UIComponent/Explorer2/classes/class.ilTreeExplorerGUI.php
+++ b/Services/UIComponent/Explorer2/classes/class.ilTreeExplorerGUI.php
@@ -133,7 +133,7 @@ abstract class ilTreeExplorerGUI extends ilExplorerBaseGUI implements \ILIAS\UI\
             $this->all_childs[$s["child"]] = $s;
         }
 
-        if ($this->order_field != "") {
+        if ($this->order_field !== "") {
             foreach ($this->childs as $k => $childs) {
                 $this->childs[$k] = ilArrayUtil::sortArray(
                     $childs,
@@ -145,7 +145,7 @@ abstract class ilTreeExplorerGUI extends ilExplorerBaseGUI implements \ILIAS\UI\
         }
 
         // sort childs and store prev/next reference
-        if ($this->order_field == "") {
+        if ($this->order_field === "") {
             $this->all_childs =
                 ilArrayUtil::sortArray($this->all_childs, "lft", "asc", true, true);
             $prev = false;
@@ -174,14 +174,14 @@ abstract class ilTreeExplorerGUI extends ilExplorerBaseGUI implements \ILIAS\UI\
         $a_node_id,
         string $a_type = ""
     ) {
-        if ($this->order_field != "") {
+        if ($this->order_field !== "") {
             die("ilTreeExplorerGUI::getSuccessorNode not implemented for order field " . $this->order_field);
         }
 
         if ($this->preloaded) {
             $next_id = $a_node_id;
-            while (($next_id = $this->all_childs[$next_id]["next_node_id"]) && $a_type != "" &&
-                $this->all_childs[$next_id]["type"] != $a_type) {
+            while (($next_id = $this->all_childs[$next_id]["next_node_id"]) && $a_type !== "" &&
+                $this->all_childs[$next_id]["type"] !== $a_type) {
                 // do nothing
             }
             if ($next_id) {
@@ -201,7 +201,7 @@ abstract class ilTreeExplorerGUI extends ilExplorerBaseGUI implements \ILIAS\UI\
      */
     public function getChildsOfNode($a_parent_node_id) : array
     {
-        if ($this->preloaded && $this->getSearchTerm() == "") {
+        if ($this->preloaded && $this->getSearchTerm() === "") {
             if (isset($this->childs[$a_parent_node_id]) && is_array($this->childs[$a_parent_node_id])) {
                 return $this->childs[$a_parent_node_id];
             }
@@ -209,7 +209,7 @@ abstract class ilTreeExplorerGUI extends ilExplorerBaseGUI implements \ILIAS\UI\
         }
 
         $wl = $this->getTypeWhiteList();
-        if (is_array($wl) && count($wl) > 0) {
+        if (count($wl) > 0) {
             $childs = $this->tree->getChildsByTypeFilter($a_parent_node_id, $wl, $this->getOrderField());
         } else {
             $childs = $this->tree->getChilds($a_parent_node_id, $this->getOrderField());
@@ -220,7 +220,7 @@ abstract class ilTreeExplorerGUI extends ilExplorerBaseGUI implements \ILIAS\UI\
         if (is_array($bl) && count($bl) > 0) {
             $bl_childs = array();
             foreach ($childs as $k => $c) {
-                if (!in_array($c["type"], $bl) && ($this->matches($c) || $this->requested_node_id != $this->getDomNodeIdForNodeId($a_parent_node_id))) {
+                if (!in_array($c["type"], $bl, true) && ($this->matches($c) || $this->requested_node_id !== $this->getDomNodeIdForNodeId($a_parent_node_id))) {
                     $bl_childs[$k] = $c;
                 }
             }
@@ -229,7 +229,7 @@ abstract class ilTreeExplorerGUI extends ilExplorerBaseGUI implements \ILIAS\UI\
 
         $final_childs = [];
         foreach ($childs as $k => $c) {
-            if ($this->matches($c) || $this->requested_node_id != $this->getDomNodeIdForNodeId($a_parent_node_id)) {
+            if ($this->matches($c) || $this->requested_node_id !== $this->getDomNodeIdForNodeId($a_parent_node_id)) {
                 $final_childs[$k] = $c;
             }
         }
@@ -243,11 +243,10 @@ abstract class ilTreeExplorerGUI extends ilExplorerBaseGUI implements \ILIAS\UI\
      */
     protected function matches($node) : bool
     {
-        if ($this->getSearchTerm() == "" ||
-            is_int(stripos($this->getNodeContent($node), $this->getSearchTerm()))) {
-            return true;
-        }
-        return false;
+        return (
+            $this->getSearchTerm() === "" ||
+            is_int(ilStr::striPos($this->getNodeContent($node), $this->getSearchTerm()))
+        );
     }
 
     
@@ -255,7 +254,7 @@ abstract class ilTreeExplorerGUI extends ilExplorerBaseGUI implements \ILIAS\UI\
      * Get id for node
      *
      * @param object|array $a_node
-     * @return string id
+     * @return string
      */
     public function getNodeId($a_node)
     {
@@ -290,15 +289,12 @@ abstract class ilTreeExplorerGUI extends ilExplorerBaseGUI implements \ILIAS\UI\
     /**
      * @param int|string $a_root
      */
-    public function setRootId($a_root)
+    public function setRootId($a_root) : void
     {
         $this->root_id = $a_root;
     }
 
-    /**
-     * @return int
-     */
-    protected function getRootId()
+    protected function getRootId() : int
     {
         return $this->root_id
             ?: $this->getTree()->readRootId();
@@ -350,7 +346,7 @@ abstract class ilTreeExplorerGUI extends ilExplorerBaseGUI implements \ILIAS\UI\
         $nodeIconPath = $this->getNodeIcon($record);
 
         $icon = null;
-        if (is_string($nodeIconPath) && strlen($nodeIconPath) > 0) {
+        if ($nodeIconPath !== '') {
             $icon = $this->ui
                 ->factory()
                 ->symbol()
@@ -380,7 +376,7 @@ abstract class ilTreeExplorerGUI extends ilExplorerBaseGUI implements \ILIAS\UI\
         $node = $this->createNode($factory, $record);
 
         $href = $this->getNodeHref($record);
-        if (is_string($href) && strlen($href) > 0 && '#' !== $href) {
+        if ($href !== '' && '#' !== $href) {
             $node = $node->withLink(new \ILIAS\Data\URI(ILIAS_HTTP_PATH . '/' . $href));
         }
 
@@ -391,8 +387,8 @@ abstract class ilTreeExplorerGUI extends ilExplorerBaseGUI implements \ILIAS\UI\
         $nodeStateToggleCmdClasses = $this->getNodeStateToggleCmdClasses($record);
         $cmdClass = end($nodeStateToggleCmdClasses);
 
-        if (is_string($cmdClass) && strlen($cmdClass) > 0) {
-            $node = $node->withAdditionalOnLoadCode(function ($id) use ($record, $nodeStateToggleCmdClasses, $cmdClass) {
+        if (is_string($cmdClass) && $cmdClass !== '') {
+            $node = $node->withAdditionalOnLoadCode(function ($id) use ($record, $nodeStateToggleCmdClasses, $cmdClass) : string {
                 $serverNodeId = $this->getNodeId($record);
 
                 $this->ctrl->setParameterByClass($cmdClass, 'node_id', $serverNodeId);
@@ -423,7 +419,7 @@ abstract class ilTreeExplorerGUI extends ilExplorerBaseGUI implements \ILIAS\UI\
         );
 
         $label = $this->getTreeLabel();
-        if ($this->getTreeLabel() == "" && $this->getNodeContent($this->getRootNode())) {
+        if ($this->getTreeLabel() === "" && $this->getNodeContent($this->getRootNode())) {
             $label = $this->getNodeContent($this->getRootNode());
         }
 

--- a/Services/UIComponent/Explorer2/classes/class.ilTreeExplorerGUI.php
+++ b/Services/UIComponent/Explorer2/classes/class.ilTreeExplorerGUI.php
@@ -181,7 +181,9 @@ abstract class ilTreeExplorerGUI extends ilExplorerBaseGUI implements \ILIAS\UI\
         if ($this->preloaded) {
             $next_id = $a_node_id;
             while (($next_id = $this->all_childs[$next_id]["next_node_id"]) && $a_type != "" &&
-                $this->all_childs[$next_id]["type"] != $a_type);
+                $this->all_childs[$next_id]["type"] != $a_type) {
+                // do nothing
+            }
             if ($next_id) {
                 return $this->all_childs[$next_id];
             }

--- a/Services/UIComponent/Glyph/classes/class.ilGlyphGUI.php
+++ b/Services/UIComponent/Glyph/classes/class.ilGlyphGUI.php
@@ -61,9 +61,9 @@ class ilGlyphGUI
 
         $lng = $DIC->language();
 
-        $text = ($a_text == "")
+        $text = ($a_text === "")
             ? $lng->txt(self::$map[$a_glyph]["txt"])
-            : (($a_text == self::NO_TEXT)
+            : (($a_text === self::NO_TEXT)
                 ? ""
                 : $a_text);
         switch ($a_glyph) {

--- a/Services/UIComponent/GroupedList/classes/class.ilGroupedListGUI.php
+++ b/Services/UIComponent/GroupedList/classes/class.ilGroupedListGUI.php
@@ -174,13 +174,13 @@ class ilGroupedListGUI
             $tpl->touchBlock("multi_end");
         }
         
-        if ($tt_calls != "") {
+        if ($tt_calls !== "") {
             $tpl->setCurrentBlock("script");
             $tpl->setVariable("TT_CALLS", $tt_calls);
             $tpl->parseCurrentBlock();
         }
 
-        if ($this->id != "") {
+        if ($this->id !== "") {
             $tpl->setCurrentBlock("id");
             $tpl->setVariable("ID", $this->id);
             $tpl->parseCurrentBlock();

--- a/Services/UIComponent/Lightbox/classes/class.ilLightboxGUI.php
+++ b/Services/UIComponent/Lightbox/classes/class.ilLightboxGUI.php
@@ -60,7 +60,7 @@ class ilLightboxGUI
     {
         $tpl = $this->tpl;
         
-        if ($a_tpl == null) {
+        if ($a_tpl === null) {
             $a_tpl = $tpl;
         }
 
@@ -73,7 +73,7 @@ class ilLightboxGUI
         $tpl = new ilTemplate("tpl.lightbox.html", true, true, "Services/UIComponent/Lightbox");
         $tpl->setVariable("LIGHTBOX_CONTENT", "");
         $tpl->setVariable("ID", $this->getId());
-        if ($this->getWidth() != "") {
+        if ($this->getWidth() !== "") {
             $tpl->setVariable("WIDTH", "width: " . $this->getWidth() . ";");
         }
         return $tpl->get();

--- a/Services/UIComponent/Modal/classes/class.ilModalGUI.php
+++ b/Services/UIComponent/Modal/classes/class.ilModalGUI.php
@@ -136,11 +136,7 @@ class ilModalGUI
     {
         global $DIC;
 
-        if ($a_main_tpl != null) {
-            $tpl = $a_main_tpl;
-        } else {
-            $tpl = $DIC["tpl"];
-        }
+        $tpl = $a_main_tpl ?? $DIC["tpl"];
 
         $tpl->addJavaScript("./Services/UIComponent/Modal/js/Modal.js");
     }

--- a/Services/UIComponent/NestedList/classes/class.ilNestedList.php
+++ b/Services/UIComponent/NestedList/classes/class.ilNestedList.php
@@ -26,7 +26,7 @@ class ilNestedList
     protected array $nodes = [];
     protected array $childs = [];
 
-    public function __constructor()
+    public function __construct()
     {
         $this->list_class[0] = "il_Explorer";
         $this->childs[0] = array();

--- a/Services/UIComponent/NestedList/classes/class.ilNestedList.php
+++ b/Services/UIComponent/NestedList/classes/class.ilNestedList.php
@@ -137,7 +137,7 @@ class ilNestedList
 
     public function listItemStart(ilTemplate $tpl) : void
     {
-        if ($this->getItemClass() != "") {
+        if ($this->getItemClass() !== "") {
             $tpl->setCurrentBlock("list_item_start");
             $tpl->setVariable("LI_CLASS", ' class="' . $this->getItemClass() . '" ');
             $tpl->parseCurrentBlock();
@@ -157,11 +157,11 @@ class ilNestedList
     {
         //echo "<br>listStart";
 
-        $class = ($this->getListClass($depth) != "")
+        $class = ($this->getListClass($depth) !== "")
             ? $this->getListClass($depth)
             : $this->getListClass();
         //echo "-$class-";
-        if ($class != "") {
+        if ($class !== "") {
             $tpl->setCurrentBlock("list_start");
             $tpl->setVariable("UL_CLASS", ' class="' . $class . '" ');
             $tpl->parseCurrentBlock();

--- a/Services/UIComponent/NestedList/classes/class.ilNestedList.php
+++ b/Services/UIComponent/NestedList/classes/class.ilNestedList.php
@@ -58,7 +58,7 @@ class ilNestedList
         string $a_content,
         string $a_id,
         $a_parent = 0
-    ) {
+    ) : void {
         $this->nodes[$a_id] = $a_content;
         $this->childs[$a_parent][] = $a_id;
     }

--- a/Services/UIComponent/Overlay/classes/class.ilOverlayGUI.php
+++ b/Services/UIComponent/Overlay/classes/class.ilOverlayGUI.php
@@ -112,15 +112,15 @@ class ilOverlayGUI
         // yui cfg string
         $yuicfg["visible"] = $this->visible;
         
-        if ($this->width != "") {
+        if ($this->width !== "") {
             $yuicfg["width"] = $this->width;
         }
         
-        if ($this->height != "") {
+        if ($this->height !== "") {
             $yuicfg["height"] = $this->height;
         }
         $yuicfg["fixedcenter"] = $this->fixed_center;
-        if ($this->anchor_el_id != "") {
+        if ($this->anchor_el_id !== "") {
             $yuicfg["context"] = array($this->anchor_el_id, $this->anchor_ov_corner,
                     $this->anchor_anch_corner, array("beforeShow", "windowResize"));
         }

--- a/Services/UIComponent/Panel/classes/class.ilPanelGUI.php
+++ b/Services/UIComponent/Panel/classes/class.ilPanelGUI.php
@@ -107,7 +107,7 @@ class ilPanelGUI
         $tpl = new ilTemplate("tpl.panel.html", true, true, "Services/UIComponent/Panel");
 
         $head_outer_div_style = "";
-        if ($this->getHeading() != "") {
+        if ($this->getHeading() !== "") {
             $tpl->setCurrentBlock("heading");
             $tpl->setVariable("HEADING", $this->getHeading());
 
@@ -129,7 +129,7 @@ class ilPanelGUI
 
         $tpl->setVariable("BODY", $this->getBody());
         
-        if ($this->getFooter() != "") {
+        if ($this->getFooter() !== "") {
             $tpl->setCurrentBlock("footer");
             $tpl->setVariable("FOOTER", $this->getFooter());
             

--- a/Services/UIComponent/ProgressBar/classes/class.ilProgressBar.php
+++ b/Services/UIComponent/ProgressBar/classes/class.ilProgressBar.php
@@ -147,7 +147,7 @@ class ilProgressBar
             $tpl->touchBlock("hide_caption_out_bl");
         }
         
-        if (strlen($this->ajax_url) and $this->ajax_timeout) {
+        if ($this->ajax_url !== '' && $this->ajax_timeout) {
             $tpl->setCurrentBlock('async_status');
             $tpl->setVariable('ASYNC_STATUS_ID', $this->unique_id);
             $tpl->setVariable('ICON_OK', ilUtil::getImagePath('icon_ok.svg'));

--- a/Services/UIComponent/SplitButton/classes/class.ilSplitButtonGUI.php
+++ b/Services/UIComponent/SplitButton/classes/class.ilSplitButtonGUI.php
@@ -67,7 +67,7 @@ class ilSplitButtonGUI extends ilButtonBase
      */
     public function setMenuItems(array $menu_items) : void
     {
-        array_walk($menu_items, function ($item, $idx) {
+        array_walk($menu_items, static function ($item, $idx) : void {
             if (!($item instanceof ilSplitButtonMenuItem)) {
                 throw new ilSplitButtonException(sprintf(
                     "Cannot set menu items, element at index '%s' is not of type 'ilSplitButtonItem'",

--- a/Services/UIComponent/SyntaxHighlighter/classes/class.ilSyntaxHighlighter.php
+++ b/Services/UIComponent/SyntaxHighlighter/classes/class.ilSyntaxHighlighter.php
@@ -87,10 +87,7 @@ class ilSyntaxHighlighter
      */
     public static function getNewLanguageId(string $a_old_lang_id) : string
     {
-        if (isset(self::$v51_map[$a_old_lang_id])) {
-            return self::$v51_map[$a_old_lang_id];
-        }
-        return $a_old_lang_id;
+        return self::$v51_map[$a_old_lang_id] ?? $a_old_lang_id;
     }
 
 

--- a/Services/UIComponent/Tabs/classes/class.ilTabsGUI.php
+++ b/Services/UIComponent/Tabs/classes/class.ilTabsGUI.php
@@ -175,9 +175,8 @@ class ilTabsGUI
         string $a_link,
         string $a_frame = ''
     ) : void {
-        for ($i = 0; $i < count($this->target); $i++) {
+        for ($i = 0, $iMax = count($this->target); $i < $iMax; $i++) {
             if ($this->target[$i]['id'] == $a_old_id) {
-                $this->target[$i] = array();
                 $this->target[$i] = array(
                     "text" => $a_text,
                     "link" => $a_link,
@@ -279,7 +278,7 @@ class ilTabsGUI
      */
     public function setSubTabActive(string $a_text) : void
     {
-        for ($i = 0; $i < count($this->sub_target);$i++) {
+        for ($i = 0, $iMax = count($this->sub_target); $i < $iMax; $i++) {
             $this->sub_target[$i]['activate'] = $this->sub_target[$i]['id'] == $a_text;
         }
         $this->subtab_manual_activation = true;
@@ -343,12 +342,10 @@ class ilTabsGUI
         if (isset($DIC["ilUser"])) {
             $ilUser = $DIC->user();
         }
-        if (isset($DIC["component.factory"])) {
-            $component_factory = $DIC["component.factory"];
-        }
+        $component_factory = $DIC["component.factory"] ?? null;
 
         // user interface hook [uihk]
-        if (!$this->getSetupMode() && $component_factory) {
+        if ($component_factory && !$this->getSetupMode()) {
             foreach ($component_factory->getActivePluginsInSlot("uihk") as $plugin) {
                 $gui_class = $plugin->getUIClassInstance();
                 $resp = $gui_class->modifyGUI(

--- a/Services/UIComponent/Tabs/classes/class.ilTabsGUI.php
+++ b/Services/UIComponent/Tabs/classes/class.ilTabsGUI.php
@@ -256,9 +256,9 @@ class ilTabsGUI
     public function setTabActive(string $a_id) : void
     {
         foreach ($this->target as $key => $target) {
-            $this->target[$key]['activate'] = $this->target[$key]['id'] == $a_id;
+            $this->target[$key]['activate'] = $this->target[$key]['id'] === $a_id;
         }
-        if ($a_id != "") {
+        if ($a_id !== "") {
             $this->manual_activation = true;
         } else {
             $this->manual_activation = false;
@@ -276,7 +276,7 @@ class ilTabsGUI
     public function setSubTabActive(string $a_text) : void
     {
         for ($i = 0, $iMax = count($this->sub_target); $i < $iMax; $i++) {
-            $this->sub_target[$i]['activate'] = $this->sub_target[$i]['id'] == $a_text;
+            $this->sub_target[$i]['activate'] = $this->sub_target[$i]['id'] === $a_text;
         }
         $this->subtab_manual_activation = true;
     }
@@ -370,12 +370,12 @@ class ilTabsGUI
             $pre = $pre2 = "";
 
             // back 2 tab
-            if ($this->back_2_title != "") {
+            if ($this->back_2_title !== "") {
                 $tpl->setCurrentBlock("back_2_tab");
                 $tpl->setVariable("BACK_2_ICON", ilGlyphGUI::get(ilGlyphGUI::PREVIOUS, ilGlyphGUI::NO_TEXT));
                 $tpl->setVariable("BACK_2_TAB_LINK", $this->back_2_target);
                 $tpl->setVariable("BACK_2_TAB_TEXT", $this->back_2_title);
-                if ($this->back_2_frame != "") {
+                if ($this->back_2_frame !== "") {
                     $tpl->setVariable("BACK_2_TAB_TARGET", ' target="' . $this->back_2_frame . '" ');
                 }
 
@@ -383,12 +383,12 @@ class ilTabsGUI
             }
             
             // back tab
-            if ($this->back_title != "") {
+            if ($this->back_title !== "") {
                 $tpl->setCurrentBlock("back_tab");
                 $tpl->setVariable("BACK_ICON", ilGlyphGUI::get(ilGlyphGUI::PREVIOUS, ilGlyphGUI::NO_TEXT));
                 $tpl->setVariable("BACK_TAB_LINK", $this->back_target);
                 $tpl->setVariable("BACK_TAB_TEXT", $this->back_title);
-                if ($this->back_frame != "") {
+                if ($this->back_frame !== "") {
                     $tpl->setVariable("BACK_TAB_TARGET", ' target="' . $this->back_frame . '" ');
                 }
                 $tpl->parseCurrentBlock();
@@ -400,7 +400,7 @@ class ilTabsGUI
         $i = 0;
 
         // do not display one tab only
-        if ((count($targets) > 1 || $this->force_one_tab) || ($this->back_title != "" && !$a_get_sub_tabs)
+        if ((count($targets) > 1 || $this->force_one_tab) || ($this->back_title !== "" && !$a_get_sub_tabs)
             || (count($this->non_tabbed_link) > 0 && !$a_get_sub_tabs)) {
             foreach ($targets as $target) {
                 $i++;
@@ -423,7 +423,7 @@ class ilTabsGUI
                     $tabtype = $pre . "tabactive";
                 }
 
-                if ($tabtype == "tabactive" || $tabtype == "subtabactive") {
+                if ($tabtype === "tabactive" || $tabtype === "subtabactive") {
                     $tpl->setCurrentBlock("sel_text");
                     $tpl->setVariable("TXT_SELECTED", $lng->txt("stat_selected"));
                     $tpl->parseCurrentBlock();
@@ -444,7 +444,7 @@ class ilTabsGUI
                 // tooltip
                 if (!$this->getSetupMode()) {
                     $ttext = $ilHelp->getTabTooltipText($target["id"]);
-                    if ($ttext != "") {
+                    if ($ttext !== "") {
                         ilTooltipGUI::addTooltip(
                             $pre . "tab_" . $target["id"],
                             $ttext,
@@ -495,7 +495,7 @@ class ilTabsGUI
                     // tooltip
                     if (!$this->getSetupMode()) {
                         $ttext = $ilHelp->getTabTooltipText($link["id"]);
-                        if ($ttext != "") {
+                        if ($ttext !== "") {
                             ilTooltipGUI::addTooltip(
                                 "nontab_" . $link["id"],
                                 $ttext,

--- a/Services/UIComponent/Tabs/classes/class.ilTabsGUI.php
+++ b/Services/UIComponent/Tabs/classes/class.ilTabsGUI.php
@@ -195,11 +195,8 @@ class ilTabsGUI
     {
         global $DIC;
 
-        $ilHelp = null;
-        if (isset($DIC["ilHelp"])) {
-            $ilHelp = $DIC["ilHelp"];
-        }
-        
+        $ilHelp = $DIC["ilHelp"] ?? null;
+
         if (!$this->getSetupMode()) {
             $ilHelp->setScreenIdComponent("");
         }
@@ -331,10 +328,7 @@ class ilTabsGUI
         $sr_pre = "";
         $hash = "";
 
-        $ilHelp = null;
-        if (isset($DIC["ilHelp"])) {
-            $ilHelp = $DIC["ilHelp"];
-        }
+        $ilHelp = $DIC["ilHelp"] ?? null;
 
         $ilCtrl = $this->ctrl;
         $lng = $this->lng;

--- a/Services/UIComponent/TextHighlighter/classes/class.ilTextHighlighterGUI.php
+++ b/Services/UIComponent/TextHighlighter/classes/class.ilTextHighlighterGUI.php
@@ -36,7 +36,7 @@ class ilTextHighlighterGUI
             return;
         }
         
-        if ($a_tpl == null) {
+        if ($a_tpl === null) {
             $a_tpl = $tpl;
         }
         $a_tpl->addJavaScript("./Services/UIComponent/TextHighlighter/js/ilTextHighlighter.js");

--- a/Services/UIComponent/Toolbar/classes/class.ilToolbarGUI.php
+++ b/Services/UIComponent/Toolbar/classes/class.ilToolbarGUI.php
@@ -260,7 +260,7 @@ class ilToolbarGUI
         $groups = array();
         $group = array();
         foreach ($this->items as $item) {
-            if ($item['type'] == 'separator') {
+            if ($item['type'] === 'separator') {
                 $groups[] = $group;
                 $group = array();
             } else {
@@ -309,7 +309,7 @@ class ilToolbarGUI
             }
 
             // Hide toggle button if only sticky items are in the toolbar
-            if (count($this->items) == 0) {
+            if (count($this->items) === 0) {
                 $tpl->setVariable('HIDE_TOGGLE_CLASS', ' hidden');
             }
 
@@ -442,7 +442,7 @@ class ilToolbarGUI
             }
 
             // form?
-            if ($this->getFormAction() != "") {
+            if ($this->getFormAction() !== "") {
                 // #18947
                 $GLOBALS["tpl"]->addJavaScript("Services/Form/js/Form.js");
 
@@ -455,10 +455,10 @@ class ilToolbarGUI
                     if ($this->multipart) {
                         $tpl->setVariable("ENC_TYPE", 'enctype="multipart/form-data"');
                     }
-                    if ($this->form_target != "") {
+                    if ($this->form_target !== "") {
                         $tpl->setVariable("TARGET", ' target="' . $this->form_target . '" ');
                     }
-                    if ($this->form_name != "") {
+                    if ($this->form_name !== "") {
                         $tpl->setVariable("FORMNAME", 'name="' . $this->getFormName() . '"');
                     }
 
@@ -470,7 +470,7 @@ class ilToolbarGUI
             }
 
             // id
-            if ($this->getId() != "") {
+            if ($this->getId() !== "") {
                 $tpl->setVariable("ID", ' id="' . $this->getId() . '" ');
             }
 

--- a/Services/UIComponent/Tooltip/classes/class.ilTooltipGUI.php
+++ b/Services/UIComponent/Tooltip/classes/class.ilTooltipGUI.php
@@ -64,7 +64,7 @@ class ilTooltipGUI
         // not needed, just make sure the position plugin is included
         //		$addstr.= ", position: {viewport: $('#fixed_content')}";
         
-        if ($a_container != "") {
+        if ($a_container !== "") {
             $addstr .= ", container: '" . $a_container . "'";
         }
 

--- a/Services/UIComponent/test/UIHookPluginGUITest.php
+++ b/Services/UIComponent/test/UIHookPluginGUITest.php
@@ -11,11 +11,6 @@ class UIHookPluginGUITest extends TestCase
 {
     //protected $backupGlobals = false;
 
-    protected function setUp() : void
-    {
-        parent::setUp();
-    }
-
     protected function tearDown() : void
     {
     }
@@ -23,7 +18,7 @@ class UIHookPluginGUITest extends TestCase
     /**
      * Test get HTML return an array
      */
-    public function testGetHTMLReturnsArray()
+    public function testGetHTMLReturnsArray() : void
     {
         $plugin_gui = new ilUIHookPluginGUI();
         $res = $plugin_gui->getHTML("Test", "test", []);

--- a/Services/UIComponent/test/ilServicesUIComponentSuite.php
+++ b/Services/UIComponent/test/ilServicesUIComponentSuite.php
@@ -22,7 +22,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilServicesUIComponentSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new self();
 

--- a/Services/WebServices/ECS/classes/Mapping/class.ilECSNodeMappingCmsExplorer.php
+++ b/Services/WebServices/ECS/classes/Mapping/class.ilECSNodeMappingCmsExplorer.php
@@ -142,7 +142,7 @@ class ilECSNodeMappingCmsExplorer extends ilExplorer
         }
     }
 
-    public function formatObject($tpl, $a_node_id, $a_option, $a_obj_id = 0)
+    public function formatObject($tpl, $a_node_id, $a_option, $a_obj_id = 0) : void
     {
         if (!isset($a_node_id) or !is_array($a_option)) {
             $this->ilias->raiseError(get_class($this) . "::formatObject(): Missing parameter or wrong datatype! " .

--- a/Services/WebServices/ECS/classes/Mapping/class.ilECSNodeMappingLocalExplorer.php
+++ b/Services/WebServices/ECS/classes/Mapping/class.ilECSNodeMappingLocalExplorer.php
@@ -147,7 +147,7 @@ class ilECSNodeMappingLocalExplorer extends ilExplorer
         }
     }
 
-    public function formatObject($tpl, $a_node_id, $a_option, $a_obj_id = 0)
+    public function formatObject($tpl, $a_node_id, $a_option, $a_obj_id = 0) : void
     {
         if (!isset($a_node_id) or !is_array($a_option)) {
             $this->ilias->raiseError(get_class($this) . "::formatObject(): Missing parameter or wrong datatype! " .


### PR DESCRIPTION
Hi @alex40724,

I completed the review of the `Services/UIComponent` component.

This component looked very good, I only found one file where the coding style was not compliant. Furthermore I had to add a few types here and there.

Results:
- [ ] The code style is `PSR-2 + X` compliant
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

I am not sure whether https://packagist.org/packages/geshi/geshi (used by `Services/UIComponent/SyntaxHighlighter`) is compatible with PHP 8. Please check the list item above if you already checked this.

I also fixed some trivial issues reported by my inspection profile.

Best regards,
@mjansenDatabay