### PR TITLE
PHP 8: Code Review `Component`

### DIFF
--- a/Services/Component/classes/Settings/class.ilObjComponentSettings.php
+++ b/Services/Component/classes/Settings/class.ilObjComponentSettings.php
@@ -24,33 +24,21 @@
 require_once "./Services/Object/classes/class.ilObject.php";
 
 /**
-* Settings for components (modules, services, plugins).
-*
-* @author Alex Killing <alex.killing@gmx.de>
-* @version $Id$
-*
-* @ingroup ServicesComponent
-*/
+ * Settings for components (modules, services, plugins).
+ *
+ * @author Alex Killing <alex.killing@gmx.de>
+ * @version $Id$
+ *
+ * @ingroup ServicesComponent
+ */
 class ilObjComponentSettings extends ilObject
 {
-    /**
-    * Constructor
-    * @access	public
-    * @param	integer	reference_id or object_id
-    * @param	boolean	treat the id as reference_id (true) or object_id (false)
-    */
-    public function __construct($a_id = 0, $a_call_by_reference = true)
+    public function __construct(int $a_id = 0, bool $a_call_by_reference = true)
     {
         $this->type = "cmps";
         parent::__construct($a_id, $a_call_by_reference);
     }
 
-    /**
-    * update object data
-    *
-    * @access	public
-    * @return	boolean
-    */
     public function update() : bool
     {
         global $DIC;
@@ -63,9 +51,6 @@ class ilObjComponentSettings extends ilObject
         return true;
     }
     
-    /**
-    * read style folder data
-    */
     public function read() : void
     {
         global $DIC;
@@ -74,12 +59,6 @@ class ilObjComponentSettings extends ilObject
         parent::read();
     }
 
-    /**
-    * delete object and all related data
-    *
-    * @access	public
-    * @return	boolean	true if all object data were removed; false if only a references were removed
-    */
     public function delete() : bool
     {
         // always call parent delete function first!!

--- a/Services/Component/classes/Settings/class.ilObjComponentSettingsGUI.php
+++ b/Services/Component/classes/Settings/class.ilObjComponentSettingsGUI.php
@@ -10,29 +10,29 @@ use ILIAS\UI\Renderer;
  */
 class ilObjComponentSettingsGUI extends ilObjectGUI
 {
-    const TYPE = 'cmps';
+    private const TYPE = 'cmps';
 
-    const CMD_DEFAULT = "listPlugins";
-    const CMD_INSTALL_PLUGIN = "installPlugin";
-    const CMD_CONFIGURE = "configure";
-    const CMD_REFRESH_LANGUAGES = "refreshLanguages";
-    const CMD_ACTIVATE_PLUGIN = "activatePlugin";
-    const CMD_DEACTIVATE_PLUGIN = "deactivatePlugin";
-    const CMD_UPDATE_PLUGIN = "updatePlugin";
-    const CMD_JUMP_TO_PLUGIN_SLOT = "jumpToPluginSlot";
-    const CMD_UNINSTALL_PLUGIN = "uninstallPlugin";
-    const CMD_CONFIRM_UNINSTALL_PLUGIN = "confirmUninstallPlugin";
+    private const TAB_PLUGINS = "plugins";
+    private const TAB_PERMISSION = "perm_settings";
 
-    const TAB_PLUGINS = "plugins";
-    const TAB_PERMISSION = "perm_settings";
+    public const CMD_DEFAULT = "listPlugins";
+    public const CMD_INSTALL_PLUGIN = "installPlugin";
+    public const CMD_CONFIGURE = "configure";
+    public const CMD_REFRESH_LANGUAGES = "refreshLanguages";
+    public const CMD_ACTIVATE_PLUGIN = "activatePlugin";
+    public const CMD_DEACTIVATE_PLUGIN = "deactivatePlugin";
+    public const CMD_UPDATE_PLUGIN = "updatePlugin";
+    public const CMD_JUMP_TO_PLUGIN_SLOT = "jumpToPluginSlot";
+    public const CMD_UNINSTALL_PLUGIN = "uninstallPlugin";
+    public const CMD_CONFIRM_UNINSTALL_PLUGIN = "confirmUninstallPlugin";
 
-    const P_REF_ID = 'ref_id';
-    const P_CTYPE = "ctype";
-    const P_CNAME = "cname";
-    const P_SLOT_ID = "slot_id";
-    const P_PLUGIN_NAME = "pname";
-    const P_PLUGIN_ID = "plugin_id";
-    const P_ADMIN_MODE = 'admin_mode';
+    public const P_REF_ID = 'ref_id';
+    public const P_CTYPE = "ctype";
+    public const P_CNAME = "cname";
+    public const P_SLOT_ID = "slot_id";
+    public const P_PLUGIN_NAME = "pname";
+    public const P_PLUGIN_ID = "plugin_id";
+    public const P_ADMIN_MODE = 'admin_mode';
 
     protected ilTabsGUI $tabs;
     protected ilRbacSystem $rbac_system;
@@ -79,7 +79,7 @@ class ilObjComponentSettingsGUI extends ilObjectGUI
         }
 
         switch (true) {
-            case $next_class == 'ilpermissiongui':
+            case $next_class === 'ilpermissiongui':
                 $this->tabs->activateTab(self::TAB_PERMISSION);
                 $perm_gui = new ilPermissionGUI($this);
                 $this->ctrl->forwardCommand($perm_gui);

--- a/Services/Component/classes/Settings/class.ilPluginsOverviewTable.php
+++ b/Services/Component/classes/Settings/class.ilPluginsOverviewTable.php
@@ -9,11 +9,11 @@ use ILIAS\UI\Component\Button\Shy;
 
 class ilPluginsOverviewTable
 {
-    const F_PLUGIN_NAME = "plugin_name";
-    const F_PLUGIN_ID = "plugin_id";
-    const F_SLOT_NAME = "slot_name";
-    const F_COMPONENT_NAME = "component_name";
-    const F_PLUGIN_ACTIVE = "plugin_active";
+    public const F_PLUGIN_NAME = "plugin_name";
+    public const F_PLUGIN_ID = "plugin_id";
+    public const F_SLOT_NAME = "slot_name";
+    public const F_COMPONENT_NAME = "component_name";
+    public const F_PLUGIN_ACTIVE = "plugin_active";
 
     protected ilObjComponentSettingsGUI $parent_gui;
     protected ilCtrl $ctrl;
@@ -64,15 +64,13 @@ class ilPluginsOverviewTable
 
         if ($plugin_info->isInstalled()) {
             $fields[] = $this->lng->txt("installed");
-        }
-        else {
+        } else {
             $fields[] = $this->lng->txt("not_installed");
         }
 
         if ($plugin_info->isActive()) {
             $fields[] = $this->lng->txt("cmps_active");
-        }
-        else {
+        } else {
             $fields[] = $this->lng->txt("inactive");
         }
 
@@ -93,7 +91,7 @@ class ilPluginsOverviewTable
             $this->lng->txt("cmps_plugin_slot") => $plugin_info->getPluginSlot()->getName(),
             $this->lng->txt("cmps_current_version") => (string) $plugin_info->getCurrentVersion(),
             $this->lng->txt("cmps_available_version") => (string) $plugin_info->getAvailableVersion(),
-            $this->lng->txt("cmps_current_db_version") =>(string) $plugin_info->getCurrentDBVersion(),
+            $this->lng->txt("cmps_current_db_version") => (string) $plugin_info->getCurrentDBVersion(),
             $this->lng->txt("cmps_ilias_min_version") => (string) $plugin_info->getMinimumILIASVersion(),
             $this->lng->txt("cmps_ilias_max_version") => (string) $plugin_info->getMaximumILIASVersion(),
             $this->lng->txt("cmps_responsible") => $plugin_info->getResponsible(),
@@ -118,10 +116,10 @@ class ilPluginsOverviewTable
      */
     protected function filterData(array $data) : array
     {
-        $active_filters = array_filter($this->filter, function ($value) : bool {
+        $active_filters = array_filter($this->filter, static function ($value) : bool {
             return !empty($value);
         });
-        $plugins = array_filter($data, function (ilPluginInfo $plugin_info) use ($active_filters) : bool {
+        $plugins = array_filter($data, static function (ilPluginInfo $plugin_info) use ($active_filters) : bool {
             $matches_filter = true;
             if (isset($active_filters[self::F_PLUGIN_NAME])) {
                 $matches_filter = strpos($plugin_info->getName(), $active_filters[self::F_PLUGIN_NAME]) !== false;
@@ -130,7 +128,7 @@ class ilPluginsOverviewTable
                 $matches_filter = strpos($plugin_info->getId(), $active_filters[self::F_PLUGIN_ID]) !== false;
             }
             if (isset($active_filters[self::F_PLUGIN_ACTIVE])) {
-                $v = (int)$active_filters[self::F_PLUGIN_ACTIVE] === 1;
+                $v = (int) $active_filters[self::F_PLUGIN_ACTIVE] === 1;
                 $matches_filter = $plugin_info->isActive() === $v && $matches_filter;
             }
             if (isset($active_filters[self::F_SLOT_NAME])) {
@@ -138,7 +136,7 @@ class ilPluginsOverviewTable
                     $plugin_info->getPluginSlot()->getName(),
                     $active_filters[self::F_SLOT_NAME],
                     true
-                    );
+                );
             }
             if (isset($active_filters[self::F_COMPONENT_NAME])) {
                 $matches_filter = $matches_filter && in_array(

--- a/Services/Component/classes/Settings/class.ilPluginsOverviewTableFilterGUI.php
+++ b/Services/Component/classes/Settings/class.ilPluginsOverviewTableFilterGUI.php
@@ -9,18 +9,9 @@ use ILIAS\UI\Component\Input\Container\Filter\Standard;
  */
 class ilPluginsOverviewTableFilterGUI
 {
-    /**
-     * @var \ILIAS\UI\Renderer
-     */
-    protected $renderer;
-    /**
-     * @var ilUIFilterService
-     */
-    protected $filter_service;
-    /**
-     * @var Standard
-     */
-    protected $filter;
+    protected \ILIAS\UI\Renderer $renderer;
+    protected ilUIFilterService $filter_service;
+    protected Standard $filter;
 
     /**
      * ilPluginsOverviewTableFilterGUI constructor.
@@ -36,6 +27,7 @@ class ilPluginsOverviewTableFilterGUI
             return $DIC->language()->txt($id);
         };
 
+        /** @var ilComponentRepository $component_repository */
         $component_repository = $DIC["component.repository"];
         $slots = [];
         $components = [];

--- a/Services/Component/classes/Setup/class.ilComponentActivatePluginsObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentActivatePluginsObjective.php
@@ -8,10 +8,7 @@ use ILIAS\DI;
 
 class ilComponentActivatePluginsObjective implements Setup\Objective
 {
-    /**
-     * @var string
-     */
-    protected $plugin_name;
+    protected string $plugin_name;
 
     public function __construct(string $plugin_name)
     {
@@ -144,7 +141,7 @@ class ilComponentActivatePluginsObjective implements Setup\Objective
             {
                 return $GLOBALS["DIC"]["ilLog"];
             }
-            public static function getLogger($a) : ilLogger
+            public static function getLogger($a_component_id) : ilLogger
             {
                 return $GLOBALS["DIC"]["ilLog"];
             }

--- a/Services/Component/classes/Setup/class.ilComponentBuildPluginInfoObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentBuildPluginInfoObjective.php
@@ -4,9 +4,9 @@ use ILIAS\Setup;
 
 class ilComponentBuildPluginInfoObjective extends Setup\Artifact\BuildArtifactObjective
 {
-    const BASE_PATH = "./Customizing/global/plugins/";
-    const PLUGIN_PHP = "plugin.php";
-    const PLUGIN_CLASS_FILE = "classes/class.il%sPlugin.php";
+    protected const BASE_PATH = "./Customizing/global/plugins/";
+    protected const PLUGIN_PHP = "plugin.php";
+    protected const PLUGIN_CLASS_FILE = "classes/class.il%sPlugin.php";
 
     public function getArtifactPath() : string
     {
@@ -18,7 +18,7 @@ class ilComponentBuildPluginInfoObjective extends Setup\Artifact\BuildArtifactOb
     {
         $data = [];
         foreach (["Modules", "Services"] as $type) {
-            $components = $this->scanDir(static::BASE_PATH . "$type");
+            $components = $this->scanDir(static::BASE_PATH . $type);
             foreach ($components as $component) {
                 $slots = $this->scanDir(static::BASE_PATH . "$type/$component");
                 foreach ($slots as $slot) {

--- a/Services/Component/classes/Setup/class.ilComponentDefinitionsStoredObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentDefinitionsStoredObjective.php
@@ -83,15 +83,15 @@ class ilComponentDefinitionsStoredObjective implements Setup\Objective
         $GLOBALS["DIC"]["ilBench"] = null;
         $GLOBALS["DIC"]["ilObjDataCache"] = null;
         $GLOBALS["DIC"]["lng"] = new class() {
-            public function loadLanguageModule()
+            public function loadLanguageModule() : void
             {
             }
         };
         $GLOBALS["DIC"]["ilLog"] = new class() {
-            public function write()
+            public function write() : void
             {
             }
-            public function debug()
+            public function debug() : void
             {
             }
         };
@@ -99,7 +99,7 @@ class ilComponentDefinitionsStoredObjective implements Setup\Objective
             public function getRootLogger()
             {
                 return new class() {
-                    public function write()
+                    public function write() : void
                     {
                     }
                 };
@@ -107,7 +107,7 @@ class ilComponentDefinitionsStoredObjective implements Setup\Objective
             public function getLogger()
             {
                 return new class() {
-                    public function write()
+                    public function write() : void
                     {
                     }
                 };

--- a/Services/Component/classes/Setup/class.ilComponentInstallPluginObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentInstallPluginObjective.php
@@ -146,7 +146,7 @@ class ilComponentInstallPluginObjective implements Setup\Objective
             {
                 return $GLOBALS["DIC"]["ilLog"];
             }
-            public static function getLogger($a) : ilLogger
+            public static function getLogger($a_component_id) : ilLogger
             {
                 return $GLOBALS["DIC"]["ilLog"];
             }

--- a/Services/Component/classes/Setup/class.ilComponentPluginAdminInitObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentPluginAdminInitObjective.php
@@ -53,7 +53,7 @@ class ilComponentPluginAdminInitObjective implements Setup\Objective
         $DIC = $GLOBALS["DIC"];
         $GLOBALS["DIC"] = new DI\Container();
         $GLOBALS["DIC"]["lng"] = new class() {
-            public function loadLanguageModule()
+            public function loadLanguageModule() : void
             {
             }
         };

--- a/Services/Component/classes/Setup/class.ilComponentRepositoryExistsObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentRepositoryExistsObjective.php
@@ -2,7 +2,7 @@
 
 use ILIAS\Setup;
 
-class ilComponentRepositoryExistsObjective  implements Setup\Objective
+class ilComponentRepositoryExistsObjective implements Setup\Objective
 {
     /**
      * @inheritdoc

--- a/Services/Component/classes/Setup/class.ilComponentUpdatePluginObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentUpdatePluginObjective.php
@@ -79,7 +79,7 @@ class ilComponentUpdatePluginObjective implements Setup\Objective
             );
         }
 
-        list($ORIG_DIC, $ORIG_ilDB) = $this->initEnvironment($environment);
+        [$ORIG_DIC, $ORIG_ilDB] = $this->initEnvironment($environment);
         $plugin = $component_factory->getPlugin($info->getId());
         $plugin->update();
         $GLOBALS["DIC"] = $ORIG_DIC;
@@ -177,16 +177,16 @@ class ilComponentUpdatePluginObjective implements Setup\Objective
             public function write(string $a_msg, $a_log_level = ilLogLevel::INFO) : void
             {
             }
-            public function info($msg)
+            public function info($msg) : void
             {
             }
-            public function warning($msg)
+            public function warning($msg) : void
             {
             }
-            public function error($msg)
+            public function error($msg) : void
             {
             }
-            public function debug($msg, $a = [])
+            public function debug($msg, $a = []) : void
             {
             }
             public function dump($a_var, ?int $a_log_level = ilLogLevel::INFO) : void
@@ -201,7 +201,7 @@ class ilComponentUpdatePluginObjective implements Setup\Objective
             {
                 return $GLOBALS["DIC"]["ilLogger"];
             }
-            public static function getLogger($a) : ilLogger
+            public static function getLogger($a_component_id) : ilLogger
             {
                 return $GLOBALS["DIC"]["ilLogger"];
             }

--- a/Services/Component/classes/Setup/class.ilIntroduceComponentArtifactDBUpdateSteps.php
+++ b/Services/Component/classes/Setup/class.ilIntroduceComponentArtifactDBUpdateSteps.php
@@ -24,27 +24,27 @@ class ilIntroduceComponentArtifactDBUpdateSteps implements ilDatabaseUpdateSteps
 {
     protected \ilDBInterface $db;
 
-    public function prepare(\ilDBInterface $db)
+    public function prepare(\ilDBInterface $db) : void
     {
         $this->db = $db;
     }
 
-    public function step_1()
+    public function step_1() : void
     {
         $this->db->dropTable("il_component");
     }
 
-    public function step_2()
+    public function step_2() : void
     {
         $this->db->dropTable("il_pluginslot");
     }
 
-    public function step_3()
+    public function step_3() : void
     {
         $this->db->manipulate("DELETE FROM il_plugin WHERE plugin_id IS NULL");
     }
 
-    public function step_4()
+    public function step_4() : void
     {
         try {
             $this->db->addPrimaryKey("il_plugin", ["plugin_id"]);
@@ -54,7 +54,7 @@ class ilIntroduceComponentArtifactDBUpdateSteps implements ilDatabaseUpdateSteps
         }
     }
 
-    public function step_5()
+    public function step_5() : void
     {
         if (!$this->db->tableColumnExists("il_plugin", "component_type")) {
             return;
@@ -63,7 +63,7 @@ class ilIntroduceComponentArtifactDBUpdateSteps implements ilDatabaseUpdateSteps
         $this->db->dropTableColumn("il_plugin", "component_type");
     }
 
-    public function step_6()
+    public function step_6() : void
     {
         if (!$this->db->tableColumnExists("il_plugin", "component_name")) {
             return;
@@ -72,7 +72,7 @@ class ilIntroduceComponentArtifactDBUpdateSteps implements ilDatabaseUpdateSteps
         $this->db->dropTableColumn("il_plugin", "component_name");
     }
 
-    public function step_7()
+    public function step_7() : void
     {
         if (!$this->db->tableColumnExists("il_plugin", "slot_id")) {
             return;
@@ -81,7 +81,7 @@ class ilIntroduceComponentArtifactDBUpdateSteps implements ilDatabaseUpdateSteps
         $this->db->dropTableColumn("il_plugin", "slot_id");
     }
 
-    public function step_8()
+    public function step_8() : void
     {
         if (!$this->db->tableColumnExists("il_plugin", "name")) {
             return;

--- a/Services/Component/classes/Setup/class.ilPluginDefaultAgent.php
+++ b/Services/Component/classes/Setup/class.ilPluginDefaultAgent.php
@@ -9,10 +9,7 @@ abstract class ilPluginDefaultAgent implements Setup\Agent
 {
     use Setup\Agent\HasNoNamedObjective;
 
-    /**
-     * @var string
-     */
-    protected $plugin_name;
+    protected string $plugin_name;
 
     public function __construct(string $plugin_name)
     {

--- a/Services/Component/classes/class.ilArtifactComponentRepository.php
+++ b/Services/Component/classes/class.ilArtifactComponentRepository.php
@@ -29,7 +29,7 @@ class ilArtifactComponentRepository implements ilComponentRepositoryWrite
         $this->buildDatabase();
     }
 
-    protected function buildDatabase()
+    protected function buildDatabase() : void
     {
         $component_data = $this->readComponentData();
         $plugin_data = $this->readPluginData();
@@ -40,7 +40,7 @@ class ilArtifactComponentRepository implements ilComponentRepositoryWrite
         ];
         $this->pluginslot_by_id = [];
         $plugins_per_slot = [];
-        foreach ($component_data as $comp_id => list($type, $comp_name, $slot_data)) {
+        foreach ($component_data as $comp_id => [$type, $comp_name, $slot_data]) {
             $slots = [];
             $component = new ilComponentInfo(
                 $comp_id,
@@ -48,7 +48,7 @@ class ilArtifactComponentRepository implements ilComponentRepositoryWrite
                 $comp_name,
                 $slots
             );
-            foreach ($slot_data as list($slot_id, $slot_name)) {
+            foreach ($slot_data as [$slot_id, $slot_name]) {
                 $plugins_per_slot[$slot_id] = [];
                 $slots[$slot_id] = new ilPluginSlotInfo(
                     $component,
@@ -64,18 +64,27 @@ class ilArtifactComponentRepository implements ilComponentRepositoryWrite
         }
         $this->plugin_by_id = [];
         foreach ($plugin_data as $plugin_id => $data) {
-            list(
-                $type, $comp_name, $slot_name, $plugin_name, $plugin_version,
-                $ilias_min_version, $ilias_max_version, $responsible, $responsible_mail,
-                $learning_progress, $supports_export, $supports_cli_setup
-            ) = $data;
+            [
+                $type,
+                $comp_name,
+                $slot_name,
+                $plugin_name,
+                $plugin_version,
+                $ilias_min_version,
+                $ilias_max_version,
+                $responsible,
+                $responsible_mail,
+                $learning_progress,
+                $supports_export,
+                $supports_cli_setup
+            ] = $data;
             if (!$this->hasComponent($type, $comp_name)) {
                 throw new \InvalidArgumentException(
                     "Can't find component $type/$comp_name for plugin $plugin_name"
                 );
             }
             $component = $this->getComponentByTypeAndName($type, $comp_name);
-            if (!$component->hasPluginslotName($slot_name)) {
+            if (!$component->hasPluginSlotName($slot_name)) {
                 throw new \InvalidArgumentException(
                     "Can't find slot $type/$comp_name/$slot_name for plugin $plugin_name"
                 );
@@ -194,7 +203,7 @@ class ilArtifactComponentRepository implements ilComponentRepositoryWrite
      */
     public function getPluginSlotById(string $id) : ilPluginSlotInfo
     {
-        if (!$this->hasPluginslotId($id)) {
+        if (!$this->hasPluginSlotId($id)) {
             throw new \InvalidArgumentException(
                 "Unknown pluginslot $id"
             );
@@ -256,7 +265,7 @@ class ilArtifactComponentRepository implements ilComponentRepositoryWrite
         );
     }
 
-    public function setCurrentPluginVersion(string $plugin_id, Data\Version $version, int $db_version)
+    public function setCurrentPluginVersion(string $plugin_id, Data\Version $version, int $db_version) : void
     {
         $plugin = $this->getPluginById($plugin_id);
         if ($plugin->getCurrentVersion() !== null && $plugin->getCurrentVersion()->isGreaterThan($version)) {
@@ -273,7 +282,7 @@ class ilArtifactComponentRepository implements ilComponentRepositoryWrite
         $this->buildDatabase();
     }
 
-    public function setActivation(string $plugin_id, bool $activated)
+    public function setActivation(string $plugin_id, bool $activated) : void
     {
         if (!$this->hasPluginId($plugin_id)) {
             throw new \InvalidArgumentException(
@@ -284,7 +293,7 @@ class ilArtifactComponentRepository implements ilComponentRepositoryWrite
         $this->buildDatabase();
     }
 
-    public function removeStateInformationOf(string $plugin_id)
+    public function removeStateInformationOf(string $plugin_id) : void
     {
         if (!$this->hasPluginId($plugin_id)) {
             throw new \InvalidArgumentException(

--- a/Services/Component/classes/class.ilComponentDefinitionReader.php
+++ b/Services/Component/classes/class.ilComponentDefinitionReader.php
@@ -97,10 +97,10 @@ class ilComponentDefinitionReader
      */
     protected function getComponents() : \Iterator
     {
-        foreach($this->getComponentInfo("Modules", "module.xml") as $i) {
+        foreach ($this->getComponentInfo("Modules", "module.xml") as $i) {
             yield $i;
         }
-        foreach($this->getComponentInfo("Services", "service.xml") as $i) {
+        foreach ($this->getComponentInfo("Services", "service.xml") as $i) {
             yield $i;
         }
     }
@@ -126,14 +126,14 @@ class ilComponentDefinitionReader
     protected function getComponentPaths(string $root, string $name) : \Iterator
     {
         $dir = opendir($root);
-        while($sub = readdir($dir)) {
+        while ($sub = readdir($dir)) {
             if ($sub === "." || $sub === "..") {
                 continue;
             }
-            if (!@is_dir($root . "/" . $sub)) {
+            if (!is_dir($root . "/" . $sub)) {
                 continue;
             }
-            if (!@is_file($root . "/" . $sub. "/" . $name)) {
+            if (!is_file($root . "/" . $sub . "/" . $name)) {
                 continue;
             }
             yield $sub;

--- a/Services/Component/classes/class.ilComponentRepository.php
+++ b/Services/Component/classes/class.ilComponentRepository.php
@@ -52,7 +52,7 @@ interface ilComponentRepository
      *
      * Keys are the ids.
      *
-     * @return Iterator <string, ilPluginSlotInfo>
+     * @return Iterator<string, ilPluginSlotInfo>
      */
     public function getPluginSlots() : Iterator;
 
@@ -73,7 +73,7 @@ interface ilComponentRepository
      *
      * Keys are the ids.
      *
-     * @return Iterator <string, ilPluginInfo>
+     * @return Iterator<string, ilPluginInfo>
      */
     public function getPlugins() : Iterator;
 

--- a/Services/Component/classes/class.ilComponentRepositoryWrite.php
+++ b/Services/Component/classes/class.ilComponentRepositoryWrite.php
@@ -7,8 +7,9 @@ use ILIAS\Data\Version;
  */
 interface ilComponentRepositoryWrite extends ilComponentRepository
 {
-    public function setCurrentPluginVersion(string $plugin_id, Version $version, int $db_version);
+    public function setCurrentPluginVersion(string $plugin_id, Version $version, int $db_version) : void;
 
-    public function setActivation(string $plugin_id, bool $activated);
-    public function removeStateInformationOf(string $plugin_id);
+    public function setActivation(string $plugin_id, bool $activated) : void;
+
+    public function removeStateInformationOf(string $plugin_id) : void;
 }

--- a/Services/Component/classes/class.ilPlugin.php
+++ b/Services/Component/classes/class.ilPlugin.php
@@ -35,21 +35,9 @@ abstract class ilPlugin
     protected ilComponentRepositoryWrite $component_repository;
     protected string $id;
     protected ?ilPluginLanguage $language_handler = null;
-
-    /**
-     * @var bool
-     */
-    protected $lang_initialised = false;
-
-    /**
-     * @var ProviderCollection
-     */
-    protected $provider_collection;
-
-    /**
-     * @var string
-     */
-    protected $message;
+    protected bool $lang_initialised = false;
+    protected ProviderCollection $provider_collection;
+    protected string $message = '';
 
     /**
      * @return string
@@ -58,7 +46,6 @@ abstract class ilPlugin
     {
         return $this->message;
     }
-
 
     // ------------------------------------------
     // Initialisation
@@ -97,7 +84,7 @@ abstract class ilPlugin
      * during __construct. If this contains expensive stuff this will be bad for
      * overall system performance, because Plugins tend to be constructed a lot.
      */
-    protected function init()
+    protected function init() : void
     {
     }
 
@@ -142,12 +129,12 @@ abstract class ilPlugin
      *    - Services/Component/classes/class.ilObjComponentSettingsGUI.php
      *    - Services/Repository/classes/class.ilRepositoryObjectPluginSlot.php
      */
-    public function isActive()
+    public function isActive() : bool
     {
         return $this->getPluginInfo()->isActive();
     }
 
-    public function needsUpdate()
+    public function needsUpdate() : bool
     {
         return $this->getPluginInfo()->isUpdateRequired();
     }
@@ -232,7 +219,7 @@ abstract class ilPlugin
             return false;
         }
 
-        if(!$this->beforeActivation()) {
+        if (!$this->beforeActivation()) {
             return false;
         }
 
@@ -242,7 +229,7 @@ abstract class ilPlugin
         return true;
     }
 
-    public function deactivate()
+    public function deactivate() : bool
     {
         $this->component_repository->setActivation($this->getId(), false);
         $this->afterDeactivation();
@@ -280,7 +267,7 @@ abstract class ilPlugin
     // Update
     // ------------------------------------------
 
-    public function update()
+    public function update() : bool
     {
         global $DIC;
         $ilDB = $DIC->database();
@@ -294,28 +281,24 @@ abstract class ilPlugin
         $this->getLanguageHandler()->updateLanguages();
 
         // DB update
-        if ($result === true) {
-            $db_version = $this->updateDatabase();
-        }
+        $db_version = $this->updateDatabase();
 
         $this->readEventListening();
 
         $this->readEventListening();
 
         // set last update version to current version
-        if ($result === true) {
-            $this->component_repository->setCurrentPluginVersion(
-                $this->getPluginInfo()->getId(),
-                $this->getPluginInfo()->getAvailableVersion(),
-                $db_version
-            );
-            $this->afterUpdate();
-        }
+        $this->component_repository->setCurrentPluginVersion(
+            $this->getPluginInfo()->getId(),
+            $this->getPluginInfo()->getAvailableVersion(),
+            $db_version
+        );
+        $this->afterUpdate();
 
-        return $result;
+        return true;
     }
 
-    protected function updateDatabase()
+    protected function updateDatabase() : int
     {
         global $DIC;
         $ilDB = $DIC->database();
@@ -341,7 +324,7 @@ abstract class ilPlugin
     }
 
 
-    protected function afterUpdate() : void 
+    protected function afterUpdate() : void
     {
     }
 
@@ -416,7 +399,7 @@ abstract class ilPlugin
      * @deprecate ILIAS is moving towards UI components and plugins are expected
      *            to use these components. Hence, this method will be removed.
      */
-    public function addBlockFile($a_tpl, $a_var, $a_block, $a_tplname)
+    public function addBlockFile($a_tpl, $a_var, $a_block, $a_tplname) : void
     {
         $a_tpl->addBlockFile(
             $a_var,
@@ -430,7 +413,7 @@ abstract class ilPlugin
     // Event Handling
     // ------------------------------------------
 
-    protected function readEventListening()
+    protected function readEventListening() : void
     {
         $reader = new ilPluginReader(
             $this->getDirectory() . '/plugin.xml',
@@ -443,7 +426,7 @@ abstract class ilPlugin
         $reader->startParsing();
     }
 
-    protected function clearEventListening()
+    protected function clearEventListening() : void
     {
         $reader = new ilPluginReader(
             $this->getDirectory() . '/plugin.xml',

--- a/Services/Component/classes/class.ilPluginAdmin.php
+++ b/Services/Component/classes/class.ilPluginAdmin.php
@@ -23,7 +23,7 @@ class ilPluginAdmin
         $this->component_repository = $component_repository;
     }
 
-    protected function getPluginInfo($a_ctype, $a_cname, $a_slot_id, $a_pname)
+    protected function getPluginInfo($a_ctype, $a_cname, $a_slot_id, $a_pname) : \ilPluginInfo
     {
         return $this->component_repository
             ->getComponentByTypeAndName(
@@ -59,7 +59,7 @@ class ilPluginAdmin
      *
      * @return bool
      */
-    public function isActive($a_ctype, $a_cname, $a_slot_id, $a_pname)
+    public function isActive($a_ctype, $a_cname, $a_slot_id, $a_pname) : bool
     {
         trigger_error("DEPRECATED: ilPluginAdmin::isActive is deprecated. Remove your usages of the method.");
         try {

--- a/Services/Component/classes/class.ilPluginConfigGUI.php
+++ b/Services/Component/classes/class.ilPluginConfigGUI.php
@@ -19,14 +19,14 @@
  */
 abstract class ilPluginConfigGUI
 {
-    protected $plugin_object = null;
+    protected ?ilPlugin $plugin_object = null;
     
-    final public function setPluginObject($a_val)
+    final public function setPluginObject(ilPlugin $a_val) : void
     {
         $this->plugin_object = $a_val;
     }
 
-    final public function getPluginObject()
+    final public function getPluginObject() : ?ilPlugin
     {
         return $this->plugin_object;
     }
@@ -71,5 +71,5 @@ abstract class ilPluginConfigGUI
         $this->performCommand($ilCtrl->getCmd("configure"));
     }
 
-    abstract public function performCommand(string $cmd): void;
+    abstract public function performCommand(string $cmd) : void;
 }

--- a/Services/Component/classes/class.ilPluginDBUpdate.php
+++ b/Services/Component/classes/class.ilPluginDBUpdate.php
@@ -32,7 +32,6 @@ class ilPluginDBUpdate extends ilDBUpdate
         $this->currentVersion = $plugin->getCurrentDBVersion() ?? 0;
 
         $this->current_file = $this->getFileForStep(0 /* doesn't matter */);
-        ;
         $this->DB_UPDATE_FILE = $this->PATH . $this->getDBUpdateScriptName();
         $this->LAST_UPDATE_FILE = $this->DB_UPDATE_FILE;
 
@@ -47,7 +46,7 @@ class ilPluginDBUpdate extends ilDBUpdate
     /**
      * FROM ilDBUpdate
      */
-    public function getFileForStep(int $_ /* doesn't matter */) : string
+    public function getFileForStep(int $a_version /* doesn't matter */) : string
     {
         return "dbupdate.php";
     }
@@ -68,7 +67,7 @@ class ilPluginDBUpdate extends ilDBUpdate
         $this->currentVersion = $a_version;
     }
 
-    public function loadXMLInfo()
+    public function loadXMLInfo() : bool
     {
         return true;
     }
@@ -82,8 +81,6 @@ class ilPluginDBUpdate extends ilDBUpdate
                 is_int(stripos($q, "drop table")))
             && !is_int(stripos($q, $this->getTablePrefix()))) {
             return false;
-        } else {
-            return true;
         }
 
         return true;

--- a/Services/Component/classes/class.ilPluginLP.php
+++ b/Services/Component/classes/class.ilPluginLP.php
@@ -15,7 +15,7 @@ class ilPluginLP extends ilObjectLP
 {
     protected $status; // [mixed]
     
-    const INACTIVE_PLUGIN = -1;
+    public const INACTIVE_PLUGIN = -1;
     
     protected function __construct($a_obj_id)
     {
@@ -24,7 +24,7 @@ class ilPluginLP extends ilObjectLP
         $this->initPlugin();
     }
     
-    protected function initPlugin()
+    protected function initPlugin() : void
     {
         // active plugin?
         include_once 'Services/Repository/classes/class.ilRepositoryObjectPluginSlot.php';
@@ -66,12 +66,12 @@ class ilPluginLP extends ilObjectLP
         return ilLPObjSettings::LP_MODE_UNDEFINED;
     }
     
-    protected static function isLPMember(array &$a_res, int $a_usr_id, array $a_obj_ids) : bool
+    protected static function isLPMember(array &$res, int $usr_id, array $obj_ids) : bool
     {
         global $DIC;
         $objDefinition = $DIC['objDefinition'];
         
-        $type = $a_obj_ids;
+        $type = $obj_ids;
         $type = array_shift($type);
         $type = ilObject::_lookupType($type);
         
@@ -81,7 +81,7 @@ class ilPluginLP extends ilObjectLP
         
         // forward to plugin object
         if (method_exists($class_name, "isLPMember")) {
-            return $class_name::isLPMember($a_res, $a_usr_id, $a_obj_ids);
+            return $class_name::isLPMember($res, $usr_id, $obj_ids);
         }
 
         return false;

--- a/Services/Component/classes/class.ilPluginReader.php
+++ b/Services/Component/classes/class.ilPluginReader.php
@@ -57,11 +57,9 @@ class ilPluginReader extends ilSaxParser
 
     public function startParsing() : void
     {
-        if ($this->getInputType() == 'file') {
-            if (!file_exists($this->xml_file)) {
-                // not every plugin has a plugin.xml yet
-                return;
-            }
+        if ($this->getInputType() === 'file' && !file_exists($this->xml_file)) {
+            // not every plugin has a plugin.xml yet
+            return;
         }
         parent::startParsing();
     }
@@ -86,7 +84,7 @@ class ilPluginReader extends ilSaxParser
         global $DIC;
         $ilDB = $DIC->database();
 
-        if ($a_name == "event") {
+        if ($a_name === "event") {
             $component = "Plugins/" . $this->pname;
             $q = "INSERT INTO il_event_handling (component, type, id) VALUES (" .
                 $ilDB->quote($component, "text") . "," .
@@ -107,7 +105,6 @@ class ilPluginReader extends ilSaxParser
     {
     }
 
-
     /**
     * end tag handler
     *
@@ -117,14 +114,5 @@ class ilPluginReader extends ilSaxParser
     */
     public function handlerCharacterData($a_xml_parser, $a_data) : void
     {
-        // DELETE WHITESPACES AND NEWLINES OF CHARACTER DATA
-        $a_data = preg_replace("/\n/", "", $a_data);
-        $a_data = preg_replace("/\t+/", "", $a_data);
-
-        if (!empty($a_data)) {
-            switch ($this->current_tag) {
-                case '':
-            }
-        }
     }
 }

--- a/Services/Component/classes/class.ilPluginStateDB.php
+++ b/Services/Component/classes/class.ilPluginStateDB.php
@@ -11,6 +11,6 @@ interface ilPluginStateDB
     public function setActivation(string $id, bool $activated) : void;
     public function getCurrentPluginVersion(string $id) : ?Version;
     public function getCurrentPluginDBVersion(string $id) : ?int;
-    public function setCurrentPluginVersion(string $id, Version $version, int $db_version);
+    public function setCurrentPluginVersion(string $id, Version $version, int $db_version) : void;
     public function remove(string $id);
 }

--- a/Services/Component/classes/class.ilPluginStateDBOverIlDBInterface.php
+++ b/Services/Component/classes/class.ilPluginStateDBOverIlDBInterface.php
@@ -78,7 +78,7 @@ class ilPluginStateDBOverIlDBInterface implements ilPluginStateDB
         return $this->data[$id][2] ?? null;
     }
 
-    public function setCurrentPluginVersion(string $id, Version $version, int $db_version)
+    public function setCurrentPluginVersion(string $id, Version $version, int $db_version) : void
     {
         $this->getData();
         if (isset($this->data[$id])) {

--- a/Services/Component/exceptions/class.ilPluginException.php
+++ b/Services/Component/exceptions/class.ilPluginException.php
@@ -1,6 +1,4 @@
-<?php
-
-include_once('Services/Exceptions/classes/class.ilException.php');
+<?php declare(strict_types=1);
 
 /**
 * @author Alex Killing <alex.killing@gmx.de>
@@ -10,8 +8,4 @@ include_once('Services/Exceptions/classes/class.ilException.php');
 */
 class ilPluginException extends ilException
 {
-    public function __construct($a_message, $a_code = 0)
-    {
-        parent::__construct($a_message, $a_code);
-    }
 }

--- a/Services/Component/test/Settings/ilPluginsOverviewTableTest.php
+++ b/Services/Component/test/Settings/ilPluginsOverviewTableTest.php
@@ -20,7 +20,7 @@ class ilPluginsOverviewTableTest extends TestCase
         $this->renderer = $this->createMock(Renderer::class);
         $this->lng = $this->createMock(ilLanguage::class);
         $this->lng->method("txt")
-            ->will($this->returnCallback(fn ($id) => $id));
+            ->willReturnCallback(fn ($id) => $id);
     }
 
     public function testCreateObject() : void
@@ -44,14 +44,7 @@ class ilPluginsOverviewTableTest extends TestCase
      */
     public function testGetImportantFields(bool $installed, bool $active) : void
     {
-        $obj = new class(
-            $this->parent_gui,
-            $this->ctrl,
-            $this->ui,
-            $this->renderer,
-            $this->lng,
-            []
-        ) extends ilPluginsOverviewTable {
+        $obj = new class($this->parent_gui, $this->ctrl, $this->ui, $this->renderer, $this->lng, []) extends ilPluginsOverviewTable {
             public function getImportantFields(ilPluginInfo $plugin_info) : array
             {
                 return parent::getImportantFields($plugin_info);
@@ -88,14 +81,7 @@ class ilPluginsOverviewTableTest extends TestCase
 
     public function testGetContent() : void
     {
-        $obj = new class(
-            $this->parent_gui,
-            $this->ctrl,
-            $this->ui,
-            $this->renderer,
-            $this->lng,
-            []
-        ) extends ilPluginsOverviewTable {
+        $obj = new class($this->parent_gui, $this->ctrl, $this->ui, $this->renderer, $this->lng, []) extends ilPluginsOverviewTable {
             public function getContent(ilPluginInfo $plugin_info) : array
             {
                 return parent::getContent($plugin_info);
@@ -126,14 +112,7 @@ class ilPluginsOverviewTableTest extends TestCase
 
     public function testBoolToString() : void
     {
-        $obj = new class(
-            $this->parent_gui,
-            $this->ctrl,
-            $this->ui,
-            $this->renderer,
-            $this->lng,
-            []
-        ) extends ilPluginsOverviewTable {
+        $obj = new class($this->parent_gui, $this->ctrl, $this->ui, $this->renderer, $this->lng, []) extends ilPluginsOverviewTable {
             public function boolToString(bool $value) : string
             {
                 return parent::boolToString($value);
@@ -149,14 +128,7 @@ class ilPluginsOverviewTableTest extends TestCase
 
     public function testFilterData() : void
     {
-        $obj = new class(
-            $this->parent_gui,
-            $this->ctrl,
-            $this->ui,
-            $this->renderer,
-            $this->lng,
-            []
-        ) extends ilPluginsOverviewTable {
+        $obj = new class($this->parent_gui, $this->ctrl, $this->ui, $this->renderer, $this->lng, []) extends ilPluginsOverviewTable {
             public function setFilter(array $filter) : void
             {
                 $this->filter = $filter;
@@ -170,41 +142,34 @@ class ilPluginsOverviewTableTest extends TestCase
 
         $plugin_slot = $this->createMock(ilPluginSlotInfo::class);
         $plugin_slot
-            ->expects($this->any())
             ->method("getName")
             ->willReturn("Repository")
         ;
 
         $component = $this->createMock(ilComponentInfo::class);
         $component
-            ->expects($this->any())
             ->method("getQualifiedName")
             ->willReturn("QualifiedName")
         ;
 
         $plugin_info = $this->createMock(ilPluginInfo::class);
         $plugin_info
-            ->expects($this->any())
             ->method("getName")
             ->willReturn("TestRepo")
         ;
         $plugin_info
-            ->expects($this->any())
             ->method("getId")
             ->willReturn("xvw")
         ;
         $plugin_info
-            ->expects($this->any())
             ->method("isActive")
             ->willReturn(true)
         ;
         $plugin_info
-            ->expects($this->any())
             ->method("getPluginSlot")
             ->willReturn($plugin_slot)
         ;
         $plugin_info
-            ->expects($this->any())
             ->method("getComponent")
             ->willReturn($component)
         ;
@@ -252,14 +217,7 @@ class ilPluginsOverviewTableTest extends TestCase
 
     public function testGetData() : void
     {
-        $obj = new class(
-            $this->parent_gui,
-            $this->ctrl,
-            $this->ui,
-            $this->renderer,
-            $this->lng,
-            []
-        ) extends ilPluginsOverviewTable {
+        $obj = new class($this->parent_gui, $this->ctrl, $this->ui, $this->renderer, $this->lng, []) extends ilPluginsOverviewTable {
             public function getData() : array
             {
                 return parent::getData();
@@ -274,14 +232,7 @@ class ilPluginsOverviewTableTest extends TestCase
 
     public function testWithData() : void
     {
-        $obj = new class(
-            $this->parent_gui,
-            $this->ctrl,
-            $this->ui,
-            $this->renderer,
-            $this->lng,
-            []
-        ) extends ilPluginsOverviewTable {
+        $obj = new class($this->parent_gui, $this->ctrl, $this->ui, $this->renderer, $this->lng, []) extends ilPluginsOverviewTable {
             public function getData() : array
             {
                 return parent::getData();
@@ -324,15 +275,7 @@ class ilPluginsOverviewTableTest extends TestCase
             ->willReturn($dropdown)
         ;
 
-        $obj = new class(
-            $this->parent_gui,
-            $this->ctrl,
-            $this->ui,
-            $this->renderer,
-            $this->lng,
-            [],
-            $shy
-        ) extends ilPluginsOverviewTable {
+        $obj = new class($this->parent_gui, $this->ctrl, $this->ui, $this->renderer, $this->lng, [], $shy) extends ilPluginsOverviewTable {
             protected Shy $shy;
 
             public function __construct(
@@ -352,8 +295,12 @@ class ilPluginsOverviewTableTest extends TestCase
             {
                 return parent::getActions($plugin_info);
             }
-            protected function setParameter(ilPluginInfo $plugin) : void {}
-            protected function clearParameter() : void {}
+            protected function setParameter(ilPluginInfo $plugin) : void
+            {
+            }
+            protected function clearParameter() : void
+            {
+            }
             protected function getDropdownButton(string $caption, string $command) : Shy
             {
                 return $this->shy;
@@ -396,15 +343,7 @@ class ilPluginsOverviewTableTest extends TestCase
             ->willReturn($dropdown)
         ;
 
-        $obj = new class(
-            $this->parent_gui,
-            $this->ctrl,
-            $this->ui,
-            $this->renderer,
-            $this->lng,
-            [],
-            $shy
-        ) extends ilPluginsOverviewTable {
+        $obj = new class($this->parent_gui, $this->ctrl, $this->ui, $this->renderer, $this->lng, [], $shy) extends ilPluginsOverviewTable {
             protected Shy $shy;
 
             public function __construct(
@@ -424,9 +363,16 @@ class ilPluginsOverviewTableTest extends TestCase
             {
                 return parent::getActions($plugin_info);
             }
-            protected function setParameter(ilPluginInfo $plugin) : void {}
-            protected function clearParameter() : void {}
-            protected function hasLang(ilPluginInfo $plugin_info) : bool { return false; }
+            protected function setParameter(ilPluginInfo $plugin) : void
+            {
+            }
+            protected function clearParameter() : void
+            {
+            }
+            protected function hasLang(ilPluginInfo $plugin_info) : bool
+            {
+                return false;
+            }
             protected function getDropdownButton(string $caption, string $command) : Shy
             {
                 return $this->shy;

--- a/Services/Component/test/Setup/ilComponentBuildPluginInfoObjectiveTest.php
+++ b/Services/Component/test/Setup/ilComponentBuildPluginInfoObjectiveTest.php
@@ -14,7 +14,7 @@ class ilComponentBuildPluginInfoObjectiveTest extends TestCase
         $this->files = [];
         $this->added = [];
         $this->builder = new class($this) extends ilComponentBuildPluginInfoObjective {
-            const BASE_PATH = "";
+            protected const BASE_PATH = "";
             protected ilComponentBuildPluginInfoObjectiveTest $test;
             public function __construct($test)
             {
@@ -23,10 +23,7 @@ class ilComponentBuildPluginInfoObjectiveTest extends TestCase
             protected function scanDir(string $dir) : array
             {
                 $this->test->scanned[] = $dir;
-                if (isset($this->test->dirs[$dir])) {
-                    return $this->test->dirs[$dir];
-                }
-                return [];
+                return $this->test->dirs[$dir] ?? [];
             }
             public function _scanDir(string $dir) : array
             {

--- a/Services/Component/test/ilArtifactComponentRepositoryTest.php
+++ b/Services/Component/test/ilArtifactComponentRepositoryTest.php
@@ -73,7 +73,7 @@ class ilArtifactComponentRepositoryTest extends TestCase
             {
                 return 13;
             }
-            public function setCurrentPluginVersion(string $id, Data\Version $v, int $db_version)
+            public function setCurrentPluginVersion(string $id, Data\Version $version, int $db_version) : void
             {
             }
             public function remove(string $id) : void
@@ -90,7 +90,7 @@ class ilArtifactComponentRepositoryTest extends TestCase
             {
                 return ilArtifactComponentRepositoryTest::$plugin_data;
             }
-            public function _buildDatabase()
+            public function _buildDatabase() : void
             {
                 $this->buildDatabase();
             }
@@ -197,7 +197,7 @@ class ilArtifactComponentRepositoryTest extends TestCase
         $plugins4["plg2"] = $this->plg2;
     }
 
-    public function testHasComponent()
+    public function testHasComponent() : void
     {
         $this->assertTrue($this->db->hasComponent("Modules", "Module1"));
         $this->assertTrue($this->db->hasComponent("Modules", "Module2"));
@@ -209,13 +209,13 @@ class ilArtifactComponentRepositoryTest extends TestCase
         $this->assertFalse($this->db->hasComponent("Services", "Service4"));
     }
 
-    public function testHasComponentThrowsOnUnknownType()
+    public function testHasComponentThrowsOnUnknownType() : void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->db->hasComponent("OtherComponent", "Module1");
     }
 
-    public function testHasComponentId()
+    public function testHasComponentId() : void
     {
         $this->assertTrue($this->db->hasComponentId("mod1"));
         $this->assertTrue($this->db->hasComponentId("mod2"));
@@ -227,7 +227,7 @@ class ilArtifactComponentRepositoryTest extends TestCase
         $this->assertFalse($this->db->hasComponentId("ser4"));
     }
 
-    public function testGetComponents()
+    public function testGetComponents() : void
     {
         $result = iterator_to_array($this->db->getComponents());
 
@@ -244,7 +244,7 @@ class ilArtifactComponentRepositoryTest extends TestCase
         $this->assertEquals($this->ser2, $result["ser2"]);
     }
 
-    public function testGetComponentById()
+    public function testGetComponentById() : void
     {
         $this->assertEquals($this->mod1, $this->db->getComponentById("mod1"));
         $this->assertEquals($this->mod2, $this->db->getComponentById("mod2"));
@@ -252,7 +252,7 @@ class ilArtifactComponentRepositoryTest extends TestCase
         $this->assertEquals($this->ser2, $this->db->getComponentById("ser2"));
     }
 
-    public function testGetComponentByTypeAndName()
+    public function testGetComponentByTypeAndName() : void
     {
         $this->assertEquals($this->mod1, $this->db->getComponentByTypeAndName("Modules", "Module1"));
         $this->assertEquals($this->mod2, $this->db->getComponentByTypeAndName("Modules", "Module2"));
@@ -260,25 +260,25 @@ class ilArtifactComponentRepositoryTest extends TestCase
         $this->assertEquals($this->ser2, $this->db->getComponentByTypeAndName("Services", "Service2"));
     }
 
-    public function testGetComponentByTypeAndNameThrowsOnUnknownComponent1()
+    public function testGetComponentByTypeAndNameThrowsOnUnknownComponent1() : void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->db->getComponentByTypeAndName("Modules", "Module3");
     }
 
-    public function testGetComponentByTypeAndNameThrowsOnUnknownComponent2()
+    public function testGetComponentByTypeAndNameThrowsOnUnknownComponent2() : void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->db->getComponentByTypeAndName("OtherComponent", "Service1");
     }
 
-    public function testGetComponentByIdTypeThrowsOnInvalidId()
+    public function testGetComponentByIdTypeThrowsOnInvalidId() : void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->db->getComponentById("some_id");
     }
 
-    public function testGetPluginSlots()
+    public function testGetPluginSlots() : void
     {
         $slots = iterator_to_array($this->db->getPluginSlots());
 
@@ -295,15 +295,15 @@ class ilArtifactComponentRepositoryTest extends TestCase
         $this->assertEquals($this->slt4, $slots["slt4"]);
     }
 
-    public function testGetPluginslotById()
+    public function testGetPluginslotById() : void
     {
-        $this->assertEquals($this->slt1, $this->db->getPluginslotById("slt1"));
-        $this->assertEquals($this->slt2, $this->db->getPluginslotById("slt2"));
-        $this->assertEquals($this->slt3, $this->db->getPluginslotById("slt3"));
-        $this->assertEquals($this->slt4, $this->db->getPluginslotById("slt4"));
+        $this->assertEquals($this->slt1, $this->db->getPluginSlotById("slt1"));
+        $this->assertEquals($this->slt2, $this->db->getPluginSlotById("slt2"));
+        $this->assertEquals($this->slt3, $this->db->getPluginSlotById("slt3"));
+        $this->assertEquals($this->slt4, $this->db->getPluginSlotById("slt4"));
     }
 
-    public function testNoPluginSlot()
+    public function testNoPluginSlot() : void
     {
         $db = new class($this->data_factory, $this->plugin_state_db, $this->ilias_version) extends ilArtifactComponentRepository {
             protected function readComponentData() : array
@@ -320,7 +320,7 @@ class ilArtifactComponentRepositoryTest extends TestCase
         $this->assertEquals([], $slots);
     }
 
-    public function testGetPlugins()
+    public function testGetPlugins() : void
     {
         $plugins = iterator_to_array($this->db->getPlugins());
 
@@ -335,25 +335,25 @@ class ilArtifactComponentRepositoryTest extends TestCase
         $this->assertEquals($this->plg2, $plugins["plg2"]);
     }
 
-    public function testGetPluginById()
+    public function testGetPluginById() : void
     {
         $this->assertEquals($this->plg1, $this->db->getPluginById("plg1"));
         $this->assertEquals($this->plg2, $this->db->getPluginById("plg2"));
     }
 
-    public function testGetPluginByName()
+    public function testGetPluginByName() : void
     {
         $this->assertEquals($this->plg1, $this->db->getPluginByName("Plugin1"));
         $this->assertEquals($this->plg2, $this->db->getPluginByName("Plugin2"));
     }
 
-    public function testUnknownPlugin()
+    public function testUnknownPlugin() : void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->db->getPluginById("some_id");
     }
 
-    public function testUsesPluginStateDB()
+    public function testUsesPluginStateDB() : void
     {
         $plugin_state_db = $this->createMock(ilPluginStateDB::class);
         $plugin_state_db->expects($this->once())
@@ -404,7 +404,7 @@ class ilArtifactComponentRepositoryTest extends TestCase
         $this->assertEquals(42, $plugin->getCurrentDBVersion());
     }
 
-    public function testGetPluginViaComponentAndPluginSlot()
+    public function testGetPluginViaComponentAndPluginSlot() : void
     {
         $plg1 = $this->db
             ->getComponentByTypeAndName("Modules", "Module1")
@@ -414,7 +414,7 @@ class ilArtifactComponentRepositoryTest extends TestCase
         $this->assertEquals($this->plg1, $plg1);
     }
 
-    public function testSetCurrentPluginVersionCallsStateDB()
+    public function testSetCurrentPluginVersionCallsStateDB() : void
     {
         $VERSION = $this->data_factory->version("1000.0.0");
         $DB_VERSION = 1000;
@@ -465,7 +465,7 @@ class ilArtifactComponentRepositoryTest extends TestCase
         $db->setCurrentPluginVersion("plg1", $VERSION, $DB_VERSION);
     }
 
-    public function testSetCurrentPluginVersionCallsStateDBTriggersRebuild()
+    public function testSetCurrentPluginVersionCallsStateDBTriggersRebuild() : void
     {
         $VERSION = $this->data_factory->version("1000.0.0");
         $DB_VERSION = 1000;
@@ -473,7 +473,7 @@ class ilArtifactComponentRepositoryTest extends TestCase
         $plugin_state_db = $this->createMock(ilPluginStateDB::class);
         $db = new class($this->data_factory, $plugin_state_db, $this->ilias_version) extends ilArtifactComponentRepository {
             public int $build_called = 0;
-            protected function buildDatabase()
+            protected function buildDatabase() : void
             {
                 $this->build_called++;
                 parent::buildDatabase();
@@ -510,18 +510,18 @@ class ilArtifactComponentRepositoryTest extends TestCase
         $this->assertEquals(2, $db->build_called);
     }
 
-    public function testCallBuildDatabaseTwice()
+    public function testCallBuildDatabaseTwice() : void
     {
         $this->db->_buildDatabase();
 
         $this->assertEquals($this->mod1, $this->db->getComponentById("mod1"));
         $this->assertEquals($this->mod1, $this->db->getComponentByTypeAndName("Modules", "Module1"));
-        $this->assertEquals($this->slt1, $this->db->getPluginslotById("slt1"));
+        $this->assertEquals($this->slt1, $this->db->getPluginSlotById("slt1"));
         $this->assertEquals($this->plg1, $this->db->getPluginById("plg1"));
         $this->assertEquals($this->plg2, $this->db->getPluginByName("Plugin2"));
     }
 
-    public function testSetActivationCallsStateDB()
+    public function testSetActivationCallsStateDB() : void
     {
         $plugin_state_db = $this->createMock(ilPluginStateDB::class);
 
@@ -558,12 +558,12 @@ class ilArtifactComponentRepositoryTest extends TestCase
         $db->setActivation("plg1", true);
     }
 
-    public function testSetActivationTriggersRebuild()
+    public function testSetActivationTriggersRebuild() : void
     {
         $plugin_state_db = $this->createMock(ilPluginStateDB::class);
         $db = new class($this->data_factory, $plugin_state_db, $this->ilias_version) extends ilArtifactComponentRepository {
             public int $build_called = 0;
-            protected function buildDatabase()
+            protected function buildDatabase() : void
             {
                 $this->build_called++;
                 parent::buildDatabase();
@@ -600,7 +600,7 @@ class ilArtifactComponentRepositoryTest extends TestCase
         $this->assertEquals(2, $db->build_called);
     }
 
-    public function testRemoveStateInformationOfCallsStateDB()
+    public function testRemoveStateInformationOfCallsStateDB() : void
     {
         $plugin_state_db = $this->createMock(ilPluginStateDB::class);
 
@@ -637,12 +637,12 @@ class ilArtifactComponentRepositoryTest extends TestCase
         $db->removeStateInformationOf("plg1");
     }
 
-    public function testRemoveStateInformationOfTriggersRebuild()
+    public function testRemoveStateInformationOfTriggersRebuild() : void
     {
         $plugin_state_db = $this->createMock(ilPluginStateDB::class);
         $db = new class($this->data_factory, $plugin_state_db, $this->ilias_version) extends ilArtifactComponentRepository {
             public int $build_called = 0;
-            protected function buildDatabase()
+            protected function buildDatabase() : void
             {
                 $this->build_called++;
                 parent::buildDatabase();

--- a/Services/Component/test/ilComponentDefinitionReaderTest.php
+++ b/Services/Component/test/ilComponentDefinitionReaderTest.php
@@ -6,10 +6,10 @@ use PHPUnit\Framework\TestCase;
 
 interface ilComponentDefinitionProcessorMock1 extends ilComponentDefinitionProcessor
 {
-};
+}
 interface ilComponentDefinitionProcessorMock2 extends ilComponentDefinitionProcessor
 {
-};
+}
 
 class ilComponentDefinitionReaderTest extends TestCase
 {
@@ -94,60 +94,60 @@ class ilComponentDefinitionReaderTest extends TestCase
         $processor1_stack = [];
         $this->processor1
             ->method("beginComponent")
-            ->will($this->returnCallback(function ($s1, $s2) use (&$processor1_stack) {
+            ->willReturnCallback(function ($s1, $s2) use (&$processor1_stack) {
                 $processor1_stack[] = "beginComponent";
                 $processor1_stack[] = $s1;
                 $processor1_stack[] = $s2;
-            }));
+            });
         $this->processor1
             ->method("endComponent")
-            ->will($this->returnCallback(function ($s1, $s2) use (&$processor1_stack) {
+            ->willReturnCallback(function ($s1, $s2) use (&$processor1_stack) {
                 $processor1_stack[] = "endComponent";
                 $processor1_stack[] = $s1;
                 $processor1_stack[] = $s2;
-            }));
+            });
         $this->processor1
             ->method("beginTag")
-            ->will($this->returnCallback(function ($s1, $s2) use (&$processor1_stack) {
+            ->willReturnCallback(function ($s1, $s2) use (&$processor1_stack) {
                 $processor1_stack[] = "beginTag";
                 $processor1_stack[] = $s1;
                 $processor1_stack[] = $s2;
-            }));
+            });
         $this->processor1
             ->method("endTag")
-            ->will($this->returnCallback(function ($s1) use (&$processor1_stack) {
+            ->willReturnCallback(function ($s1) use (&$processor1_stack) {
                 $processor1_stack[] = "endTag";
                 $processor1_stack[] = $s1;
-            }));
+            });
 
         $processor2_stack = [];
         $this->processor2
             ->method("beginComponent")
-            ->will($this->returnCallback(function ($s1, $s2) use (&$processor2_stack) {
+            ->willReturnCallback(function ($s1, $s2) use (&$processor2_stack) {
                 $processor2_stack[] = "beginComponent";
                 $processor2_stack[] = $s1;
                 $processor2_stack[] = $s2;
-            }));
+            });
         $this->processor2
             ->method("endComponent")
-            ->will($this->returnCallback(function ($s1, $s2) use (&$processor2_stack) {
+            ->willReturnCallback(function ($s1, $s2) use (&$processor2_stack) {
                 $processor2_stack[] = "endComponent";
                 $processor2_stack[] = $s1;
                 $processor2_stack[] = $s2;
-            }));
+            });
         $this->processor2
             ->method("beginTag")
-            ->will($this->returnCallback(function ($s1, $s2) use (&$processor2_stack) {
+            ->willReturnCallback(function ($s1, $s2) use (&$processor2_stack) {
                 $processor2_stack[] = "beginTag";
                 $processor2_stack[] = $s1;
                 $processor2_stack[] = $s2;
-            }));
+            });
         $this->processor2
             ->method("endTag")
-            ->will($this->returnCallback(function ($s1) use (&$processor2_stack) {
+            ->willReturnCallback(function ($s1) use (&$processor2_stack) {
                 $processor2_stack[] = "endTag";
                 $processor2_stack[] = $s1;
-            }));
+            });
 
 
         $this->reader->readComponentDefinitions();

--- a/Services/Component/test/ilComponentInfoTest.php
+++ b/Services/Component/test/ilComponentInfoTest.php
@@ -36,7 +36,7 @@ class ilComponentInfoTest extends TestCase
         $slots[] = $this->pluginslot2;
     }
 
-    public function testGetter()
+    public function testGetter() : void
     {
         $this->assertEquals("mod1", $this->component->getId());
         $this->assertEquals("Modules", $this->component->getType());
@@ -44,7 +44,7 @@ class ilComponentInfoTest extends TestCase
         $this->assertEquals("Modules/Module1", $this->component->getQualifiedName());
     }
 
-    public function testInvalidTypeThrowsException()
+    public function testInvalidTypeThrowsException() : void
     {
         $this->expectException(\InvalidArgumentException::class);
         $slots = [];
@@ -56,7 +56,7 @@ class ilComponentInfoTest extends TestCase
         );
     }
 
-    public function testGetPluginsSlots()
+    public function testGetPluginsSlots() : void
     {
         $pluginslots = iterator_to_array($this->component->getPluginSlots());
         $plugins = [];
@@ -65,47 +65,47 @@ class ilComponentInfoTest extends TestCase
         $this->assertEquals(new ilPluginSlotInfo($this->component, "slt2", "Slot2", $plugins), $pluginslots["slt2"]);
     }
 
-    public function testHasPluginSlotId()
+    public function testHasPluginSlotId() : void
     {
         $this->assertTrue($this->component->hasPluginSlotId("slt1"));
         $this->assertTrue($this->component->hasPluginSlotId("slt2"));
         $this->assertFalse($this->component->hasPluginSlotId("slt3"));
     }
 
-    public function testGetPluginSlotById()
+    public function testGetPluginSlotById() : void
     {
         $plugins = [];
         $this->assertEquals(new ilPluginSlotInfo($this->component, "slt1", "Slot1", $plugins), $this->component->getPluginSlotById("slt1"));
         $this->assertEquals(new ilPluginSlotInfo($this->component, "slt2", "Slot2", $plugins), $this->component->getPluginSlotById("slt2"));
     }
 
-    public function testGetUnknownPluginSlotById()
+    public function testGetUnknownPluginSlotById() : void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->component->getPluginSlotById("slt3");
     }
 
-    public function testGetUnknownPluginSlot()
+    public function testGetUnknownPluginSlot() : void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->component->getPluginSlotById("slt3");
     }
 
-    public function testHasPluginSlotName()
+    public function testHasPluginSlotName() : void
     {
         $this->assertTrue($this->component->hasPluginSlotName("Slot1"));
         $this->assertTrue($this->component->hasPluginSlotName("Slot2"));
         $this->assertFalse($this->component->hasPluginSlotName("Slot3"));
     }
 
-    public function testGetPluginSlotByName()
+    public function testGetPluginSlotByName() : void
     {
         $plugins = [];
         $this->assertEquals(new ilPluginSlotInfo($this->component, "slt1", "Slot1", $plugins), $this->component->getPluginSlotByName("Slot1"));
         $this->assertEquals(new ilPluginSlotInfo($this->component, "slt2", "Slot2", $plugins), $this->component->getPluginSlotByName("Slot2"));
     }
 
-    public function testGetUnknownPluginSlotByName()
+    public function testGetUnknownPluginSlotByName() : void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->component->getPluginSlotById("Slot3");

--- a/Services/Component/test/ilPluginInfoTest.php
+++ b/Services/Component/test/ilPluginInfoTest.php
@@ -14,7 +14,7 @@ class ilPluginInfoTest extends TestCase
 
     protected function setUp() : void
     {
-        $this->data_factory = new Data\Factory;
+        $this->data_factory = new Data\Factory();
 
         $slots = [];
         $this->component = new ilComponentInfo(
@@ -52,7 +52,7 @@ class ilPluginInfoTest extends TestCase
         );
     }
 
-    public function testGetter()
+    public function testGetter() : void
     {
         $this->assertEquals($this->pluginslot, $this->plugin->getPluginSlot());
         $this->assertEquals($this->component, $this->plugin->getComponent());
@@ -71,12 +71,12 @@ class ilPluginInfoTest extends TestCase
         $this->assertTrue($this->plugin->supportsCLISetup());
     }
 
-    public function testIsInstalled()
+    public function testIsInstalled() : void
     {
         $this->assertTrue($this->plugin->isInstalled());
     }
 
-    public function testIsNotInstalled()
+    public function testIsNotInstalled() : void
     {
         $this->plugin = new ilPluginInfo(
             $this->data_factory->version("6.5"),
@@ -99,12 +99,12 @@ class ilPluginInfoTest extends TestCase
         $this->assertFalse($this->plugin->isInstalled());
     }
 
-    public function testUpdateIsNotRequired()
+    public function testUpdateIsNotRequired() : void
     {
         $this->assertFalse($this->plugin->isUpdateRequired());
     }
 
-    public function testUpdateIsNotRequiredNotInstalled()
+    public function testUpdateIsNotRequiredNotInstalled() : void
     {
         $this->plugin = new ilPluginInfo(
             $this->data_factory->version("6.5"),
@@ -127,7 +127,7 @@ class ilPluginInfoTest extends TestCase
         $this->assertFalse($this->plugin->isUpdateRequired());
     }
 
-    public function testUpdateIsRequired()
+    public function testUpdateIsRequired() : void
     {
         $this->plugin = new ilPluginInfo(
             $this->data_factory->version("6.5"),
@@ -150,7 +150,7 @@ class ilPluginInfoTest extends TestCase
         $this->assertTrue($this->plugin->isUpdateRequired());
     }
 
-    public function testIsVersionOld()
+    public function testIsVersionOld() : void
     {
         $this->assertFalse($this->plugin->isVersionToOld());
 
@@ -196,7 +196,7 @@ class ilPluginInfoTest extends TestCase
     /**
      * @dataProvider versionCompliance
      */
-    public function testIsCompliantToILIAS(Data\Version $version, bool $is_compliant)
+    public function testIsCompliantToILIAS(Data\Version $version, bool $is_compliant) : void
     {
         $plugin = new ilPluginInfo(
             $version,
@@ -220,7 +220,7 @@ class ilPluginInfoTest extends TestCase
 
     public function versionCompliance() : array
     {
-        $data_factory = new Data\Factory;
+        $data_factory = new Data\Factory();
         return [
             [$data_factory->version("5.4"), false],
             [$data_factory->version("6.5"), true],
@@ -228,7 +228,7 @@ class ilPluginInfoTest extends TestCase
         ];
     }
 
-    public function testGetPath()
+    public function testGetPath() : void
     {
         $this->assertEquals(
             ilComponentRepository::PLUGIN_BASE_PATH . "/" . "Modules/Module1/Slot1/Plugin1",
@@ -236,7 +236,7 @@ class ilPluginInfoTest extends TestCase
         );
     }
 
-    public function testGetClassName()
+    public function testGetClassName() : void
     {
         $this->assertEquals(
             "ilPlugin1Plugin",
@@ -244,7 +244,7 @@ class ilPluginInfoTest extends TestCase
         );
     }
 
-    public function testGetConfigureClassName()
+    public function testGetConfigureClassName() : void
     {
         $this->assertEquals(
             "ilPlugin1ConfigGUI",
@@ -338,13 +338,7 @@ class ilPluginInfoTest extends TestCase
         bool $is_version_to_old,
         bool $is_activation_possible
     ) : void {
-        $plugin = new class(
-            $is_installed,
-            $supports_current_ilias,
-            $needs_update,
-            $is_activated,
-            $is_version_to_old
-        ) extends ilPluginInfo {
+        $plugin = new class($is_installed, $supports_current_ilias, $needs_update, $is_activated, $is_version_to_old) extends ilPluginInfo {
             protected bool $is_installed;
             protected bool $supports_current_ilias;
             protected bool $needs_update;
@@ -446,13 +440,7 @@ class ilPluginInfoTest extends TestCase
         bool $is_version_to_old,
         string $inactivity_reason
     ) : void {
-        $plugin = new class(
-            $is_installed,
-            $supports_current_ilias,
-            $needs_update,
-            $is_activated,
-            $is_version_to_old
-        ) extends ilPluginInfo {
+        $plugin = new class($is_installed, $supports_current_ilias, $needs_update, $is_activated, $is_version_to_old) extends ilPluginInfo {
             protected bool $is_installed;
             protected bool $supports_current_ilias;
             protected bool $needs_update;
@@ -507,7 +495,7 @@ class ilPluginInfoTest extends TestCase
         $this->assertEquals($inactivity_reason, $plugin->getReasonForInactivity());
     }
 
-    public function testGetReasonForInactivityThrowsOnActivePlugin()
+    public function testGetReasonForInactivityThrowsOnActivePlugin() : void
     {
         $this->expectException(LogicException::class);
 

--- a/Services/Component/test/ilPluginSlotInfoTest.php
+++ b/Services/Component/test/ilPluginSlotInfoTest.php
@@ -42,7 +42,7 @@ class ilPluginSlotInfoTest extends TestCase
         $plugins["plg2"] = $this->plugin2;
     }
 
-    public function testGetter()
+    public function testGetter() : void
     {
         $slots = [];
         $this->assertEquals(new ilComponentInfo("mod1", "Modules", "Module1", $slots), $this->pluginslot->getComponent());
@@ -51,7 +51,7 @@ class ilPluginSlotInfoTest extends TestCase
         $this->assertEquals("Modules/Module1/Slot1", $this->pluginslot->getQualifiedName());
     }
 
-    public function testGetPlugins()
+    public function testGetPlugins() : void
     {
         $plugins = iterator_to_array($this->pluginslot->getPlugins());
         $this->assertCount(2, $plugins);
@@ -59,45 +59,45 @@ class ilPluginSlotInfoTest extends TestCase
         $this->assertEquals($this->plugin2, $plugins["plg2"]);
     }
 
-    public function testHasPluginId()
+    public function testHasPluginId() : void
     {
         $this->assertTrue($this->pluginslot->hasPluginId("plg1"));
         $this->assertTrue($this->pluginslot->hasPluginId("plg2"));
         $this->assertFalse($this->pluginslot->hasPluginId("plg3"));
     }
 
-    public function testGetPluginById()
+    public function testGetPluginById() : void
     {
         $this->assertEquals($this->plugin1, $this->pluginslot->getPluginById("plg1"));
         $this->assertEquals($this->plugin2, $this->pluginslot->getPluginById("plg2"));
     }
 
-    public function testGetUnknownPluginId()
+    public function testGetUnknownPluginId() : void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->pluginslot->getPluginById("plg3");
     }
 
-    public function testHasPluginName()
+    public function testHasPluginName() : void
     {
         $this->assertTrue($this->pluginslot->hasPluginName("Plugin1"));
         $this->assertTrue($this->pluginslot->hasPluginName("Plugin2"));
         $this->assertFalse($this->pluginslot->hasPluginName("Plugin3"));
     }
 
-    public function testGetPluginByName()
+    public function testGetPluginByName() : void
     {
         $this->assertEquals($this->plugin1, $this->pluginslot->getPluginByName("Plugin1"));
         $this->assertEquals($this->plugin2, $this->pluginslot->getPluginByName("Plugin2"));
     }
 
-    public function testGetUnknownPluginName()
+    public function testGetUnknownPluginName() : void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->pluginslot->getPluginByName("Plugin3");
     }
 
-    public function testGetPath()
+    public function testGetPath() : void
     {
         $this->assertEquals(
             ilComponentRepository::PLUGIN_BASE_PATH . "/" . "Modules/Module1/Slot1",
@@ -105,19 +105,19 @@ class ilPluginSlotInfoTest extends TestCase
         );
     }
 
-    public function testGetActivePlugins()
+    public function testGetActivePlugins() : void
     {
         $plugins = iterator_to_array($this->pluginslot->getActivePlugins());
         $this->assertCount(1, $plugins);
         $this->assertEquals($this->plugin1, $plugins["plg1"]);
     }
 
-    public function testHasActivePlugins()
+    public function testHasActivePlugins() : void
     {
         $this->assertTrue($this->pluginslot->hasActivePlugins());
     }
 
-    public function testHasNoActivePlugins()
+    public function testHasNoActivePlugins() : void
     {
         $plugins = [];
         $other_pluginslot = new ilPluginSlotInfo(

--- a/Services/Component/test/ilPluginStateDBOverIlDBInterfaceTest.php
+++ b/Services/Component/test/ilPluginStateDBOverIlDBInterfaceTest.php
@@ -32,7 +32,7 @@ class ilPluginStateDBOverIlDBInterfaceTest extends TestCase
         );
     }
 
-    public function testIsPluginActivated()
+    public function testIsPluginActivated() : void
     {
         $handle = $this->createMock(\ilDBStatement::class);
 
@@ -50,7 +50,7 @@ class ilPluginStateDBOverIlDBInterfaceTest extends TestCase
         $this->assertFalse($this->db->isPluginActivated("plg3"));
     }
 
-    public function testGetCurrentPluginVersion()
+    public function testGetCurrentPluginVersion() : void
     {
         $handle = $this->createMock(\ilDBStatement::class);
 
@@ -68,7 +68,7 @@ class ilPluginStateDBOverIlDBInterfaceTest extends TestCase
         $this->assertEquals(null, $this->db->getCurrentPluginVersion("plg3"));
     }
 
-    public function testGetCurrentPluginDBVersion()
+    public function testGetCurrentPluginDBVersion() : void
     {
         $handle = $this->createMock(\ilDBStatement::class);
 
@@ -86,7 +86,7 @@ class ilPluginStateDBOverIlDBInterfaceTest extends TestCase
         $this->assertEquals(null, $this->db->getCurrentPluginVersion("plg3"));
     }
 
-    public function testSetCurrentPluginVersionKnownPlugin()
+    public function testSetCurrentPluginVersionKnownPlugin() : void
     {
         $handle = $this->createMock(\ilDBStatement::class);
 
@@ -119,7 +119,7 @@ class ilPluginStateDBOverIlDBInterfaceTest extends TestCase
         $this->db->setCurrentPluginVersion($PLUGIN_ID, $VERSION, $DB_VERSION);
     }
 
-    public function testSetCurrentPluginVersionUnknownPlugin()
+    public function testSetCurrentPluginVersionUnknownPlugin() : void
     {
         $handle = $this->createMock(\ilDBStatement::class);
 
@@ -151,13 +151,13 @@ class ilPluginStateDBOverIlDBInterfaceTest extends TestCase
         $this->db->setCurrentPluginVersion($PLUGIN_ID, $VERSION, $DB_VERSION);
     }
 
-    public function testSetActivationNotExistingPlugin()
+    public function testSetActivationNotExistingPlugin() : void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->db->setActivation("SOME_ID", true);
     }
 
-    public function testSetActivationTrue()
+    public function testSetActivationTrue() : void
     {
         $handle = $this->createMock(\ilDBStatement::class);
 
@@ -187,7 +187,7 @@ class ilPluginStateDBOverIlDBInterfaceTest extends TestCase
         $this->db->setActivation($PLUGIN_ID, true);
     }
 
-    public function testSetActivationFalse()
+    public function testSetActivationFalse() : void
     {
         $handle = $this->createMock(\ilDBStatement::class);
 
@@ -218,7 +218,7 @@ class ilPluginStateDBOverIlDBInterfaceTest extends TestCase
     }
 
 
-    public function testRemove()
+    public function testRemove() : void
     {
         $PLUGIN_ID = "plg1";
 


### PR DESCRIPTION
Hi @klees ,

I completed the review of the `Services/Component` component. In general the code looked very good.

Results:
- [ ] The code style is `PSR-2 + X` compliant
- [ ] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`: I found 7 usages of `$_GET` which could (IMO) be replaced by using the `HTTP Service`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

--

Furthermore the `PHP-CS-FIXER` "touched" some files because the code was not `PSR-2 + X` compliant.

I also fixed some trivial issues reported by my inspection profile.

--

Actions needed:
- [ ] Get rid of the super global variables

Best regards,
@mjansenDatabay