### PR TITLE
Add info messages for favourites and membership settings

### DIFF
--- a/Services/Dashboard/Administration/classes/class.ilObjDashboardSettingsGUI.php
+++ b/Services/Dashboard/Administration/classes/class.ilObjDashboardSettingsGUI.php
@@ -1,6 +1,22 @@
 <?php
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\UI\Component\Input\Field\FormInput;
 
@@ -155,10 +171,16 @@ class ilObjDashboardSettingsGUI extends ilObjectGUI
     */
     public function editSettings()
     {
-        $this->setSettingsSubTabs("general");
-        $ui = $this->ui;
-        $form = $this->initForm();
-        $this->tpl->setContent($ui->renderer()->renderAsync($form));
+        if ($this->settings->get('rep_favourites', '0') !== '1') {
+            $content[] = $this->ui->factory()->messageBox()->info($this->lng->txt('favourites_disabled_info'));
+        }
+
+        if ($this->settings->get('mmbr_my_crs_grp', '0') !== '1') {
+            $content[] = $this->ui->factory()->messageBox()->info($this->lng->txt('memberships_disabled_info'));
+        }
+        $this->setSettingsSubTabs('general');
+        $content[] = $this->initForm();
+        $this->tpl->setContent($this->ui->renderer()->renderAsync($content));
     }
 
     /**
@@ -286,16 +308,14 @@ class ilObjDashboardSettingsGUI extends ilObjectGUI
      */
     protected function editViewCoursesGroups()
     {
-        $main_tpl = $this->tpl;
-        $tabs = $this->tabs_gui;
-        $ui_renderer = $this->ui_renderer;
-
-        $tabs->activateTab("settings");
+        if ($this->settings->get('mmbr_my_crs_grp', '0') !== '1') {
+            $content[] = $this->ui->factory()->messageBox()->info($this->lng->txt('memberships_disabled_info'));
+        }
+        $this->tabs_gui->activateTab("settings");
         $this->setSettingsSubTabs("view_courses_groups");
 
-        $form = $this->getViewSettingsForm($this->viewSettings->getMembershipsView());
-
-        $main_tpl->setContent($ui_renderer->render($form));
+        $content[] = $this->getViewSettingsForm($this->viewSettings->getMembershipsView());
+        $this->tpl->setContent($this->ui_renderer->render($content));
     }
 
     /**
@@ -373,18 +393,14 @@ class ilObjDashboardSettingsGUI extends ilObjectGUI
      */
     protected function editViewFavourites()
     {
-        $main_tpl = $this->tpl;
-        $tabs = $this->tabs_gui;
-        $ui_renderer = $this->ui_renderer;
-
-        $tabs->activateTab("settings");
+        if ($this->settings->get('rep_favourites', "0") !== '1') {
+            $content[] = $this->ui->factory()->messageBox()->info($this->lng->txt('favourites_disabled_info'));
+        }
+        $this->tabs_gui->activateTab("settings");
         $this->setSettingsSubTabs("view_favourites");
 
-        $view = $this->viewSettings->getSelectedItemsView();
-
-        $form = $this->getViewSettingsForm($view);
-
-        $main_tpl->setContent($ui_renderer->render($form));
+        $content[] = $this->getViewSettingsForm($this->viewSettings->getSelectedItemsView());
+        $this->tpl->setContent($this->ui_renderer->render($content));
     }
 
     /**

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -7965,6 +7965,8 @@ dash#:#dash_studyprogramme#:#Meine Studienprogramme
 dash#:#dash_tile#:#Kacheln
 dash#:#dash_view_courses_groups#:#Block ‘Meine Kurse und Gruppen’
 dash#:#dash_view_favourites#:#Block ‘Favoriten’
+dash#:#favourites_disabled_info#:#Das Setzen von Favoriten ist deaktiviert. Sie können dieses in den Magazin-Einstellungen ändern.
+dash#:#memberships_disabled_info#:#Das Setzen von Mitgliedschaften ist deaktiviert. Sie können dieses in den Kurs-Einstellungen ändern.
 dateplaner#:#Fr_long#:#Freitag
 dateplaner#:#Fr_short#:#Fr
 dateplaner#:#Mo_long#:#Montag

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -7966,6 +7966,8 @@ dash#:#dash_studyprogramme#:#My Study Programmes
 dash#:#dash_tile#:#Tile
 dash#:#dash_view_courses_groups#:#Section ‘My Courses and Groups’
 dash#:#dash_view_favourites#:#Section ‘Favourites’
+dash#:#favourites_disabled_info#:#Add to favorites is deactivated. You may change this inside the repository settings.
+dash#:#memberships_disabled_info#:#Subscriptions are deactivated. You may change this inside the course settings.
 dateplaner#:#Fr_long#:#Friday
 dateplaner#:#Fr_short#:#Fr
 dateplaner#:#Mo_long#:#Monday


### PR DESCRIPTION
This PR adds an message box to the dashboard settings if the specific setting of favourites or memberships are unfavorable for the dashboard.
https://mantis.ilias.de/view.php?id=32014