### PR TITLE
PHP 8: Code Review `SurveyQuestionPool`

### DIFF
--- a/Modules/SurveyQuestionPool/Categories/class.SurveyCategories.php
+++ b/Modules/SurveyQuestionPool/Categories/class.SurveyCategories.php
@@ -125,11 +125,7 @@ class SurveyCategories
     public function getCategory(
         int $index
     ) : ?ilSurveyCategory {
-        if (array_key_exists($index, $this->categories)) {
-            return $this->categories[$index];
-        }
-
-        return null;
+        return $this->categories[$index] ?? null;
     }
 
     public function getCategoryForScale(

--- a/Modules/SurveyQuestionPool/Categories/class.ilCategoryWizardInputGUI.php
+++ b/Modules/SurveyQuestionPool/Categories/class.ilCategoryWizardInputGUI.php
@@ -80,9 +80,9 @@ class ilCategoryWizardInputGUI extends ilTextInputGUI
                 }
             }
             return $scale + 1;
-        } else {
-            return 99;
         }
+
+        return 99;
     }
     
     public function setShowNeutralCategory(bool $a_value) : void
@@ -120,7 +120,7 @@ class ilCategoryWizardInputGUI extends ilTextInputGUI
         }
         if (array_key_exists('neutral', $a_value)) {
             $scale = $this->str($this->postvar . '_neutral_scale');
-            $scale = ($scale == "")
+            $scale = ($scale === "")
                 ? null
                 : (int) $scale;
             $this->values->addCategory(
@@ -232,7 +232,7 @@ class ilCategoryWizardInputGUI extends ilTextInputGUI
                     }
                 }
                 //scales no duplicates.
-                if (count(array_unique($foundvalues['scale'])) != count($foundvalues['scale'])) {
+                if (count(array_unique($foundvalues['scale'])) !== count($foundvalues['scale'])) {
                     $this->setAlert($lng->txt("msg_duplicate_scale"));
                     return false;
                 }
@@ -364,7 +364,7 @@ class ilCategoryWizardInputGUI extends ilTextInputGUI
                 );
                 $tpl->parseCurrentBlock();
             }
-            if (strlen($this->getNeutralCategoryTitle())) {
+            if ($this->getNeutralCategoryTitle() !== '') {
                 $tpl->setCurrentBlock("neutral_category_title");
                 $tpl->setVariable("NEUTRAL_COLS", ($this->getUseOtherAnswer()) ? 4 : 3);
                 $tpl->setVariable(

--- a/Modules/SurveyQuestionPool/Categories/class.ilCategoryWizardInputGUI.php
+++ b/Modules/SurveyQuestionPool/Categories/class.ilCategoryWizardInputGUI.php
@@ -287,7 +287,8 @@ class ilCategoryWizardInputGUI extends ilTextInputGUI
                     $tpl->setVariable("PROPERTY_VALUE", ilLegacyFormElementsUtil::prepareFormOutput($cat->title));
                     $tpl->parseCurrentBlock();
                     $tpl->setCurrentBlock("prop_scale_propval");
-                    $tpl->setVariable("PROPERTY_VALUE",
+                    $tpl->setVariable(
+                        "PROPERTY_VALUE",
                         ilLegacyFormElementsUtil::prepareFormOutput($this->values->getScale($i))
                     );
                     $tpl->parseCurrentBlock();
@@ -357,7 +358,8 @@ class ilCategoryWizardInputGUI extends ilTextInputGUI
         if ($this->getShowNeutralCategory()) {
             if (is_object($neutral_category) && strlen($neutral_category->title)) {
                 $tpl->setCurrentBlock("prop_text_neutral_propval");
-                $tpl->setVariable("PROPERTY_VALUE",
+                $tpl->setVariable(
+                    "PROPERTY_VALUE",
                     ilLegacyFormElementsUtil::prepareFormOutput($neutral_category->title)
                 );
                 $tpl->parseCurrentBlock();
@@ -365,7 +367,8 @@ class ilCategoryWizardInputGUI extends ilTextInputGUI
             if (strlen($this->getNeutralCategoryTitle())) {
                 $tpl->setCurrentBlock("neutral_category_title");
                 $tpl->setVariable("NEUTRAL_COLS", ($this->getUseOtherAnswer()) ? 4 : 3);
-                $tpl->setVariable("CATEGORY_TITLE",
+                $tpl->setVariable(
+                    "CATEGORY_TITLE",
                     ilLegacyFormElementsUtil::prepareFormOutput($this->getNeutralCategoryTitle())
                 );
                 $tpl->parseCurrentBlock();

--- a/Modules/SurveyQuestionPool/Categories/class.ilSurveyCategory.php
+++ b/Modules/SurveyQuestionPool/Categories/class.ilSurveyCategory.php
@@ -21,6 +21,7 @@
  */
 class ilSurveyCategory
 {
+    /** @var array{title: ?string, other: int, neutral: int, label: ?string, scale: ?int} */
     private array $arrData;
 
     public function __construct(
@@ -38,8 +39,9 @@ class ilSurveyCategory
             "scale" => $scale
         );
     }
-    
+
     /**
+     * @param string $value
      * @return mixed
      */
     public function __get(string $value)
@@ -49,18 +51,16 @@ class ilSurveyCategory
             case 'neutral':
                 return ($this->arrData[$value]) ? 1 : 0;
             default:
-                if (array_key_exists($value, $this->arrData)) {
-                    return $this->arrData[$value];
-                } else {
-                    return null;
-                }
+                return $this->arrData[$value] ?? null;
         }
     }
 
     /**
+     * @param string $key
      * @param mixed $value
+     * @return void
      */
-    public function __set(string $key, $value)
+    public function __set(string $key, $value) : void
     {
         switch ($key) {
             default:

--- a/Modules/SurveyQuestionPool/Editing/class.EditingGUIRequest.php
+++ b/Modules/SurveyQuestionPool/Editing/class.EditingGUIRequest.php
@@ -25,7 +25,6 @@ class EditingGUIRequest
 {
     use BaseGUIRequest;
 
-    protected \ILIAS\HTTP\Services $http;
     protected array $params;
 
     public function __construct(
@@ -56,7 +55,7 @@ class EditingGUIRequest
     public function getQuestionIds() : array
     {
         $ids = $this->intArray("q_id");
-        if (count($ids) == 0) {
+        if (count($ids) === 0) {
             $ids = $this->intArray("qid");  // this one is used in SurveyQuestionGUI
         }
         return $ids;

--- a/Modules/SurveyQuestionPool/Export/class.ilSurveyQuestionpoolExport.php
+++ b/Modules/SurveyQuestionPool/Export/class.ilSurveyQuestionpoolExport.php
@@ -88,7 +88,7 @@ class ilSurveyQuestionpoolExport
         $expLog->setLogFormat("");
         $expLog->write(date("[y-m-d H:i:s] ") . "Start Export");
         // write qti file
-        $qti_file = fopen($this->export_dir . "/" . $this->subdir . "/" . $this->filename, "w");
+        $qti_file = fopen($this->export_dir . "/" . $this->subdir . "/" . $this->filename, 'wb');
         fwrite($qti_file, $this->spl_obj->toXML($questions));
         fclose($qti_file);
 

--- a/Modules/SurveyQuestionPool/Material/class.ilMaterialExplorer.php
+++ b/Modules/SurveyQuestionPool/Material/class.ilMaterialExplorer.php
@@ -62,6 +62,6 @@ class ilMaterialExplorer extends ilTreeExplorerGUI
 
     public function isNodeClickable($a_node) : bool
     {
-        return ($a_node["type"] == $this->current_type);
+        return ($a_node["type"] === $this->current_type);
     }
 }

--- a/Modules/SurveyQuestionPool/Phrases/class.ilSurveyPhrases.php
+++ b/Modules/SurveyQuestionPool/Phrases/class.ilSurveyPhrases.php
@@ -60,7 +60,7 @@ class ilSurveyPhrases
             array('1', $ilUser->getId())
         );
         while ($row = $ilDB->fetchObject($result)) {
-            if (($row->defaultvalue == 1) and ($row->owner_fi == 0)) {
+            if ((int) $row->defaultvalue === 1 && (int) $row->owner_fi === 0) {
                 if (!$useronly) {
                     $phrases[$row->phrase_id] = array(
                         "title" => $lng->txt($row->title),
@@ -68,13 +68,11 @@ class ilSurveyPhrases
                         "org_title" => $row->title
                     );
                 }
-            } else {
-                if ($ilUser->getId() == $row->owner_fi) {
-                    $phrases[$row->phrase_id] = array(
-                        "title" => $row->title,
-                        "owner" => $row->owner_fi
-                    );
-                }
+            } elseif ($ilUser->getId() === (int) $row->owner_fi) {
+                $phrases[$row->phrase_id] = array(
+                    "title" => $row->title,
+                    "owner" => $row->owner_fi
+                );
             }
         }
         return $phrases;
@@ -100,7 +98,7 @@ class ilSurveyPhrases
             array($phrase_id)
         );
         while ($row = $ilDB->fetchObject($result)) {
-            if (($row->defaultvalue == 1) and ($row->owner_fi == 0)) {
+            if ((int) $row->defaultvalue === 1 && (int) $row->owner_fi === 0) {
                 $categories[$row->category_id] = $lng->txt($row->title);
             } else {
                 $categories[$row->category_id] = $row->title;
@@ -202,11 +200,7 @@ class ilSurveyPhrases
     {
         switch ($value) {
             default:
-                if (array_key_exists($value, $this->arrData)) {
-                    return $this->arrData[$value];
-                } else {
-                    return null;
-                }
+                return $this->arrData[$value] ?? null;
         }
     }
 

--- a/Modules/SurveyQuestionPool/Phrases/class.ilSurveyPhrasesGUI.php
+++ b/Modules/SurveyQuestionPool/Phrases/class.ilSurveyPhrasesGUI.php
@@ -55,7 +55,7 @@ class ilSurveyPhrasesGUI
         $this->ctrl = $ilCtrl;
         $this->object = new ilSurveyPhrases();
         $this->tree = $tree;
-        $this->ref_id = $a_object->ref_id;
+        $this->ref_id = $a_object->getRefId();
         $this->ctrl->saveParameter($this, "p_id");
         $this->request = $DIC->surveyQuestionPool()
                                   ->internal()
@@ -82,7 +82,7 @@ class ilSurveyPhrasesGUI
      */
     public function deletePhrase() : void
     {
-        $this->tpl->setOnScreenMessage('info');
+        $this->tpl->setOnScreenMessage('info');// TODO PHP8-REVIEW: Missing arguments here
 
         $checked_phrases = $this->request->getPhraseIds();
         if (count($checked_phrases) > 0) {
@@ -117,7 +117,7 @@ class ilSurveyPhrasesGUI
                 $categories = ilSurveyPhrases::_getCategoriesForPhrase($phrase_id);
                 $data[] = array('phrase_id' => $phrase_id,
                                 'phrase' => $phrase_array["title"],
-                                'answers' => join(", ", $categories)
+                                'answers' => implode(", ", $categories)
                 );
             }
             $table_gui->setData($data);
@@ -199,7 +199,7 @@ class ilSurveyPhrasesGUI
             $categories = ilSurveyPhrases::_getCategoriesForPhrase($phrase_id);
             $data[] = array('phrase_id' => $phrase_id,
                             'phrase' => $phrase_array["title"],
-                            'answers' => join(", ", $categories)
+                            'answers' => implode(", ", $categories)
             );
         }
         $table_gui->setData($data);
@@ -214,7 +214,7 @@ class ilSurveyPhrasesGUI
     public function saveEditPhrase() : void
     {
         $result = $this->writePostData();
-        if ($result == 0) {
+        if ($result === 0) {
             if ($this->request->getPhraseId()) {
                 $this->object->updatePhrase($this->request->getPhraseId());
                 $this->tpl->setOnScreenMessage('success', $this->lng->txt('phrase_saved'), true);
@@ -245,7 +245,7 @@ class ilSurveyPhrasesGUI
                     $categories->addCategory($value, $answers['other'][$key], 0, null, $answers['scale'][$key]);
                 }
             }
-            if ($this->request->getNeutral() != "") {
+            if ($this->request->getNeutral() !== "") {
                 $categories->addCategory(
                     $this->request->getNeutral(),
                     0,
@@ -256,9 +256,9 @@ class ilSurveyPhrasesGUI
             }
             $this->object->categories = $categories;
             return 0;
-        } else {
-            return 1;
         }
+
+        return 1;
     }
     
     public function newPhrase() : void
@@ -269,7 +269,7 @@ class ilSurveyPhrasesGUI
     public function editPhrase() : void
     {
         $ids = $this->request->getPhraseIds();
-        if (count($ids) == 0) {
+        if (count($ids) === 0) {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('no_phrase_selected'), true);
             $this->ctrl->redirect($this, 'phrases');
         }
@@ -287,7 +287,7 @@ class ilSurveyPhrasesGUI
     public function phraseEditor(
         bool $checkonly = false
     ) : bool {
-        $save = strcmp($this->ctrl->getCmd(), "saveEditPhrase") == 0;
+        $save = strcmp($this->ctrl->getCmd(), "saveEditPhrase") === 0;
 
         $form = new ilPropertyFormGUI();
         $form->setFormAction($this->ctrl->getFormAction($this, 'phraseEditor'));

--- a/Modules/SurveyQuestionPool/Questions/class.SurveyMatrixQuestion.php
+++ b/Modules/SurveyQuestionPool/Questions/class.SurveyMatrixQuestion.php
@@ -182,7 +182,7 @@ class SurveyMatrixQuestion extends SurveyQuestion
      */
     public function getBipolarAdjective(int $a_index) : string
     {
-        if ($a_index == 1) {
+        if ($a_index === 1) {
             return $this->bipolar_adjective2;
         }
         return $this->bipolar_adjective1;
@@ -192,7 +192,7 @@ class SurveyMatrixQuestion extends SurveyQuestion
         int $a_index,
         string $a_value
     ) : void {
-        if ($a_index == 1) {
+        if ($a_index === 1) {
             $this->bipolar_adjective2 = $a_value;
         } else {
             $this->bipolar_adjective1 = $a_value;
@@ -214,7 +214,7 @@ class SurveyMatrixQuestion extends SurveyQuestion
         );
         while ($row = $ilDB->fetchAssoc($result)) {
             $neutral = $row["neutral"];
-            if (($row["defaultvalue"] == 1) && ($row["owner_fi"] == 0)) {
+            if ((int) $row["defaultvalue"] === 1 && (int) $row["owner_fi"] === 0) {
                 $this->columns->addCategory($this->lng->txt($row["title"]), 0, $neutral);
             } else {
                 $this->columns->addCategory($row["title"], 0, $neutral);
@@ -234,11 +234,11 @@ class SurveyMatrixQuestion extends SurveyQuestion
             array('integer'),
             array($id)
         );
-        if ($result->numRows() == 1) {
+        if ($result->numRows() === 1) {
             return $ilDB->fetchAssoc($result);
-        } else {
-            return array();
         }
+
+        return array();
     }
     
     public function loadFromDb(int $question_id) : void
@@ -249,7 +249,7 @@ class SurveyMatrixQuestion extends SurveyQuestion
             array('integer'),
             array($question_id)
         );
-        if ($result->numRows() == 1) {
+        if ($result->numRows() === 1) {
             $data = $ilDB->fetchAssoc($result);
             $this->setId((int) $data["question_id"]);
             $this->setTitle((string) $data["title"]);
@@ -300,17 +300,13 @@ class SurveyMatrixQuestion extends SurveyQuestion
 
     public function isComplete() : bool
     {
-        if (
-            strlen($this->getTitle()) &&
-            strlen($this->getAuthor()) &&
-            strlen($this->getQuestiontext()) &&
+        return (
+            $this->getTitle() !== '' &&
+            $this->getAuthor() !== '' &&
+            $this->getQuestiontext() !== '' &&
             $this->getColumnCount() &&
             $this->getRowCount()
-        ) {
-            return true;
-        } else {
-            return false;
-        }
+        );
     }
     
     public function saveToDb(int $original_id = 0) : int
@@ -319,7 +315,7 @@ class SurveyMatrixQuestion extends SurveyQuestion
 
         $affectedRows = parent::saveToDb($original_id);
 
-        if ($affectedRows == 1) {
+        if ($affectedRows === 1) {
             $ilDB->manipulateF(
                 "DELETE FROM " . $this->getAdditionalTableName() . " WHERE question_fi = %s",
                 array('integer'),
@@ -370,7 +366,7 @@ class SurveyMatrixQuestion extends SurveyQuestion
         $ilDB->manipulateF(
             "UPDATE " . $this->getAdditionalTableName() . " SET bipolar_adjective1 = %s, bipolar_adjective2 = %s WHERE question_fi = %s",
             array('text', 'text', 'integer'),
-            array((strlen($adjective1)) ? $adjective1 : null, (strlen($adjective2)) ? $adjective2 : null, $this->getId())
+            array(($adjective1 !== '') ? $adjective1 : null, ($adjective2 !== '') ? $adjective2 : null, $this->getId())
         );
     }
 
@@ -391,7 +387,7 @@ class SurveyMatrixQuestion extends SurveyQuestion
         $insert = true;
         if ($result->numRows()) {
             while ($row = $ilDB->fetchAssoc($result)) {
-                if (strcmp($row["title"], $columntext) == 0) {
+                if (strcmp($row["title"] ?? '', $columntext) === 0) {
                     $returnvalue = $row["category_id"];
                     $insert = false;
                 }
@@ -532,7 +528,7 @@ class SurveyMatrixQuestion extends SurveyQuestion
         $a_xml_writer->xmlEndTag("matrixrows");
         
         $a_xml_writer->xmlStartTag("responses");
-        if (strlen($this->getBipolarAdjective(0)) && (strlen($this->getBipolarAdjective(1)))) {
+        if ($this->getBipolarAdjective(0) !== '' && ($this->getBipolarAdjective(1) !== '')) {
             $a_xml_writer->xmlStartTag("bipolar_adjectives");
             $attribs = array(
                 "label" => "0"
@@ -580,7 +576,7 @@ class SurveyMatrixQuestion extends SurveyQuestion
                 );
                 $a_xml_writer->xmlStartTag("material", $attrs);
                 $intlink = "il_" . IL_INST_ID . "_" . $matches[2] . "_" . $matches[3];
-                if (strcmp($matches[1], "") != 0) {
+                if (strcmp($matches[1], "") !== 0) {
                     $intlink = $this->material["internal_link"];
                 }
                 $a_xml_writer->xmlElement("mattext", null, $intlink);
@@ -739,7 +735,7 @@ class SurveyMatrixQuestion extends SurveyQuestion
                         $counter++;
                     }
                 }
-                if ($counter != $this->getRowCount()) {
+                if ($counter !== $this->getRowCount()) {
                     return $this->lng->txt("matrix_question_radio_button_not_checked");
                 }
                 break;
@@ -756,7 +752,7 @@ class SurveyMatrixQuestion extends SurveyQuestion
                         }
                     }
                 }
-                if ($counter != $this->getRowCount()) {
+                if ($counter !== $this->getRowCount()) {
                     return $this->lng->txt("matrix_question_checkbox_not_checked");
                 }
                 break;
@@ -811,7 +807,7 @@ class SurveyMatrixQuestion extends SurveyQuestion
         }
             
         // #16387 - only if any input
-        if (sizeof($answer_data)) {
+        if (count($answer_data)) {
             // save data
             foreach ($answer_data as $item) {
                 $next_id = $ilDB->nextId('svy_answer');
@@ -892,7 +888,7 @@ class SurveyMatrixQuestion extends SurveyQuestion
     /**
      * Enables/Disables separators for the matrix rows
      */
-    public function setRowSeparators(bool $enable = false)
+    public function setRowSeparators(bool $enable = false) : void
     {
         $this->rowSeparators = $enable;
     }
@@ -902,7 +898,7 @@ class SurveyMatrixQuestion extends SurveyQuestion
         return $this->rowSeparators;
     }
 
-    public function setNeutralColumnSeparator(bool $enable = true)
+    public function setNeutralColumnSeparator(bool $enable = true) : void
     {
         $this->neutralColumnSeparator = $enable;
     }
@@ -1041,7 +1037,7 @@ class SurveyMatrixQuestion extends SurveyQuestion
 
     public function getLayout() : array
     {
-        if (count($this->layout) == 0) {
+        if (count($this->layout) === 0) {
             if ($this->hasBipolarAdjectives() && $this->hasNeutralColumn()) {
                 $this->layout = array(
                     "percent_row" => 30,
@@ -1087,7 +1083,7 @@ class SurveyMatrixQuestion extends SurveyQuestion
         if (is_array($layout)) {
             $this->layout = $layout;
         } else {
-            $this->layout = unserialize($layout) ?: [];
+            $this->layout = unserialize($layout, ['allowed_classes' => false]) ?: [];
         }
     }
     
@@ -1096,11 +1092,7 @@ class SurveyMatrixQuestion extends SurveyQuestion
      */
     public function hasBipolarAdjectives() : bool
     {
-        if ((strlen($this->getBipolarAdjective(0))) && (strlen($this->getBipolarAdjective(1)))) {
-            return true;
-        } else {
-            return false;
-        }
+        return $this->getBipolarAdjective(0) !== '' && $this->getBipolarAdjective(1) !== '';
     }
     
     /**

--- a/Modules/SurveyQuestionPool/Questions/class.SurveyMatrixQuestionEvaluation.php
+++ b/Modules/SurveyQuestionPool/Questions/class.SurveyMatrixQuestionEvaluation.php
@@ -145,7 +145,7 @@ class SurveyMatrixQuestionEvaluation extends SurveyQuestionEvaluation
                     
         $data = $labels = $legend = array();
         
-        $row_idx = sizeof($a_results);
+        $row_idx = count($a_results);
 
         $row_counter = 0;
         $text_shortened = false;
@@ -333,7 +333,7 @@ class SurveyMatrixQuestionEvaluation extends SurveyQuestionEvaluation
             }
             
             // mc
-            if ($this->question->getSubtype() == 1) {
+            if ($this->question->getSubtype() === 1) {
                 for ($index = 0; $index < $this->question->getColumnCount(); $index++) {
                     $col = $this->question->getColumn($index);
                     
@@ -361,7 +361,7 @@ class SurveyMatrixQuestionEvaluation extends SurveyQuestionEvaluation
             if ($answers !== null) {
                 foreach ($answers as $answer) {
                     // mc
-                    if ($this->question->getSubtype() == 1) {
+                    if ($this->question->getSubtype() === 1) {
                         $answer_map[$row_title . "|" . $answer[2]] = $answer[2];
                     } else {
                         $answer_map[$row_title] = $answer[3];
@@ -374,7 +374,7 @@ class SurveyMatrixQuestionEvaluation extends SurveyQuestionEvaluation
             }
         }
         
-        if (!sizeof($answer_map)) {
+        if (!count($answer_map)) {
             $a_row[] = $this->getSkippedValue();
         } else {
             $a_row[] = "";
@@ -385,7 +385,7 @@ class SurveyMatrixQuestionEvaluation extends SurveyQuestionEvaluation
             $row_title = $row->title;
             
             $a_row[] = $answer_map[$row_title];
-            if ($this->question->getSubtype() == 0) {
+            if ($this->question->getSubtype() === 0) {
                 $a_row[] = $answer_map[$row_title . "|scale"];    // see #20646
             }
             
@@ -394,7 +394,7 @@ class SurveyMatrixQuestionEvaluation extends SurveyQuestionEvaluation
             }
             
             // mc
-            if ($this->question->getSubtype() == 1) {
+            if ($this->question->getSubtype() === 1) {
                 for ($index = 0; $index < $this->question->getColumnCount(); $index++) {
                     $col = $this->question->getColumn($index);
                     $a_row[] = $answer_map[$row_title . "|" . $col->scale];
@@ -410,7 +410,7 @@ class SurveyMatrixQuestionEvaluation extends SurveyQuestionEvaluation
 
     protected function isSumScoreValid(int $nr_answer_records) : bool
     {
-        if ($nr_answer_records == $this->question->getRowCount()) {
+        if ($nr_answer_records === $this->question->getRowCount()) {
             return true;
         }
         return false;

--- a/Modules/SurveyQuestionPool/Questions/class.SurveyMatrixQuestionGUI.php
+++ b/Modules/SurveyQuestionPool/Questions/class.SurveyMatrixQuestionGUI.php
@@ -146,7 +146,7 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
         $bipolar1->setValue($this->object->getBipolarAdjective(0));
         $bipolar2->setValue($this->object->getBipolarAdjective(1));
         
-        if ($this->object->getRowCount() == 0) {
+        if ($this->object->getRowCount() === 0) {
             $this->object->getRows()->addCategory("");
         }
         $rows->setValues($this->object->getRows());
@@ -224,7 +224,7 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
                     }
                 }
                 
-                if (!$a_only_user_anwers || $checked == "checked") {
+                if (!$a_only_user_anwers || $checked === "checked") {
                     $cols[$value] = array(
                         "title" => trim($cat->title)
                         ,"neutral" => (bool) $cat->neutral
@@ -233,7 +233,7 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
                 }
             }
             
-            if ($a_only_user_anwers || sizeof($cols) || $text) {
+            if ($a_only_user_anwers || count($cols) || $text) {
                 $row_idx = $i;
                 $options[$row_idx] = array(
                     "title" => trim($rowobj->title)
@@ -268,7 +268,7 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
         }
         
         $tplheaders = new ilTemplate("tpl.il_svy_out_matrix_columnheaders.html", true, true, "Modules/SurveyQuestionPool");
-        if ((strlen($this->object->getBipolarAdjective(0))) && (strlen($this->object->getBipolarAdjective(1)))) {
+        if ($this->object->getBipolarAdjective(0) !== '' && $this->object->getBipolarAdjective(1) !== '') {
             $tplheaders->setCurrentBlock("bipolar_start");
             $style = array();
             $style[] = sprintf("width: %.2F%s!important", $layout["percent_bipolar_adjective1"], "%");
@@ -291,7 +291,7 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
                 }
             } else {
                 $style = array();
-                if ($this->object->getColumnSeparators() == 1) {
+                if ($this->object->getColumnSeparators()) {
                     if (($i < $this->object->getColumnCount() - 1)) {
                         $style[] = "border-right: 1px solid $bordercolor!important";
                     }
@@ -311,7 +311,7 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
             $tplheaders->parseCurrentBlock();
         }
 
-        if ((strlen($this->object->getBipolarAdjective(0))) && (strlen($this->object->getBipolarAdjective(1)))) {
+        if ($this->object->getBipolarAdjective(0) !== '' && $this->object->getBipolarAdjective(1) !== '') {
             $tplheaders->setCurrentBlock("bipolar_end");
             $style = array();
             $style[] = sprintf("width: %.2F%s!important", $layout["percent_bipolar_adjective2"], "%");
@@ -338,8 +338,8 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
             $tplrow = new ilTemplate("tpl.il_svy_qpl_matrix_printview_row.html", true, true, "Modules/SurveyQuestionPool");
             for ($j = 0; $j < $this->object->getColumnCount(); $j++) {
                 $cat = $this->object->getColumn($j);
-                if (($i == 0) && ($j == 0)) {
-                    if ((strlen($this->object->getBipolarAdjective(0))) && (strlen($this->object->getBipolarAdjective(1)))) {
+                if ($i === 0 && $j === 0) {
+                    if ($this->object->getBipolarAdjective(0) !== '' && $this->object->getBipolarAdjective(1) !== '') {
                         $tplrow->setCurrentBlock("bipolar_start");
                         $tplrow->setVariable(
                             "TEXT_BIPOLAR_START",
@@ -349,8 +349,8 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
                         $tplrow->parseCurrentBlock();
                     }
                 }
-                if (($i == 0) && ($j == $this->object->getColumnCount() - 1)) {
-                    if ((strlen($this->object->getBipolarAdjective(0))) && (strlen($this->object->getBipolarAdjective(1)))) {
+                if ($i === 0 && $j === $this->object->getColumnCount() - 1) {
+                    if ($this->object->getBipolarAdjective(0) !== '' && $this->object->getBipolarAdjective(1) !== '') {
                         $tplrow->setCurrentBlock("bipolar_end");
                         $tplrow->setVariable(
                             "TEXT_BIPOLAR_END",
@@ -398,12 +398,12 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
                     $tplrow->setCurrentBlock("answer");
                     $style = array();
                 }
-                if ($this->object->getColumnSeparators() == 1) {
+                if ($this->object->getColumnSeparators()) {
                     if ($j < $this->object->getColumnCount() - 1) {
                         $style[] = "border-right: 1px solid $bordercolor!important";
                     }
                 }
-                if ($this->object->getRowSeparators() == 1) {
+                if ($this->object->getRowSeparators()) {
                     if ($i < $this->object->getRowCount() - 1) {
                         $style[] = "border-bottom: 1px solid $bordercolor!important";
                     }
@@ -425,7 +425,7 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
             #force to have always the title
             #22526
             $row_title = ilLegacyFormElementsUtil::prepareFormOutput($rowobj->title);
-            if ($question_title == 3) {
+            if ($question_title === 3) {
                 if (trim($rowobj->label)) {
                     $row_title .= ' <span class="questionLabel">(' . ilLegacyFormElementsUtil::prepareFormOutput(
                         $rowobj->label
@@ -435,7 +435,7 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
 
             $tplrow->setVariable("TEXT_ROW", $row_title);
             $tplrow->setVariable("ROWCLASS", $rowclass[$i % 2]);
-            if ($this->object->getRowSeparators() == 1) {
+            if ($this->object->getRowSeparators()) {
                 if ($i < $this->object->getRowCount() - 1) {
                     $tplrow->setVariable("STYLE", " style=\"border-bottom: 1px solid $bordercolor!important\"");
                 }
@@ -515,7 +515,7 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
     {
         $percent_values = $this->object->getLayout();
         $template = new ilTemplate("tpl.il_svy_out_matrix_layout.html", true, true, "Modules/SurveyQuestionPool");
-        if (strlen($this->object->getBipolarAdjective(0)) && strlen($this->object->getBipolarAdjective(1))) {
+        if ($this->object->getBipolarAdjective(0) !== '' && $this->object->getBipolarAdjective(1) !== '') {
             $template->setCurrentBlock("bipolar_start");
             $template->setVariable("VALUE_PERCENT_BIPOLAR_ADJECTIVE1", " value=\"" . $percent_values["percent_bipolar_adjective1"] . "\"");
             $template->setVariable("STYLE", " style=\"width:" . $percent_values["percent_bipolar_adjective1"] . "%\"");
@@ -526,7 +526,7 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
             $template->parseCurrentBlock();
         }
         $counter = $this->object->getColumnCount();
-        if (strlen($this->object->hasNeutralColumn())) {
+        if ($this->object->hasNeutralColumn()) {
             $template->setCurrentBlock("neutral_start");
             $template->setVariable("VALUE_PERCENT_NEUTRAL", " value=\"" . $percent_values["percent_neutral"] . "\"");
             $template->setVariable("STYLE_NEUTRAL", " style=\"width:" . $percent_values["percent_neutral"] . "%\"");
@@ -573,7 +573,7 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
         }
         
         $tplheaders = new ilTemplate("tpl.il_svy_out_matrix_columnheaders.html", true, true, "Modules/SurveyQuestionPool");
-        if ((strlen($this->object->getBipolarAdjective(0))) && (strlen($this->object->getBipolarAdjective(1)))) {
+        if ($this->object->getBipolarAdjective(0) !== '' && $this->object->getBipolarAdjective(1) !== '') {
             $tplheaders->setCurrentBlock("bipolar_start");
             $style = array();
             $style[] = sprintf("width: %.2f%s!important", $layout["percent_bipolar_adjective1"], "%");
@@ -595,7 +595,7 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
                     $style[] = "border-left: $neutralstyle!important;";
                 }
             } else {
-                if ($this->object->getColumnSeparators() == 1) {
+                if ($this->object->getColumnSeparators()) {
                     if (($i < $this->object->getColumnCount() - 1)) {
                         $style[] = "border-right: 1px solid $bordercolor!important";
                     }
@@ -614,7 +614,7 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
             }
             $tplheaders->parseCurrentBlock();
         }
-        if ((strlen($this->object->getBipolarAdjective(0))) && (strlen($this->object->getBipolarAdjective(1)))) {
+        if ($this->object->getBipolarAdjective(0) !== '' && $this->object->getBipolarAdjective(1) !== '') {
             $tplheaders->setCurrentBlock("bipolar_end");
             $style = array();
             $style[] = sprintf("width: %.2f%s!important", $layout["percent_bipolar_adjective2"], "%");
@@ -640,8 +640,8 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
             $tplrow = new ilTemplate("tpl.il_svy_out_matrix_row.html", true, true, "Modules/SurveyQuestionPool");
             for ($j = 0; $j < $this->object->getColumnCount(); $j++) {
                 $cat = $this->object->getColumn($j);
-                if (($i == 0) && ($j == 0)) {
-                    if ((strlen($this->object->getBipolarAdjective(0))) && (strlen($this->object->getBipolarAdjective(1)))) {
+                if ($i === 0 && $j === 0) {
+                    if ($this->object->getBipolarAdjective(0) !== '' && $this->object->getBipolarAdjective(1) !== '') {
                         $tplrow->setCurrentBlock("bipolar_start");
                         $tplrow->setVariable(
                             "TEXT_BIPOLAR_START",
@@ -651,8 +651,8 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
                         $tplrow->parseCurrentBlock();
                     }
                 }
-                if (($i == 0) && ($j == $this->object->getColumnCount() - 1)) {
-                    if ((strlen($this->object->getBipolarAdjective(0))) && (strlen($this->object->getBipolarAdjective(1)))) {
+                if ($i === 0 && $j === $this->object->getColumnCount() - 1) {
+                    if ($this->object->getBipolarAdjective(0) !== '' && $this->object->getBipolarAdjective(1) !== '') {
                         $tplrow->setCurrentBlock("bipolar_end");
                         $tplrow->setVariable(
                             "TEXT_BIPOLAR_END",
@@ -710,12 +710,12 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
                     $tplrow->setCurrentBlock("answer");
                     $style = array();
                 }
-                if ($this->object->getColumnSeparators() == 1) {
+                if ($this->object->getColumnSeparators()) {
                     if ($j < $this->object->getColumnCount() - 1) {
                         $style[] = "border-right: 1px solid $bordercolor!important";
                     }
                 }
-                if ($this->object->getRowSeparators() == 1) {
+                if ($this->object->getRowSeparators()) {
                     if ($i < $this->object->getRowCount() - 1) {
                         $style[] = "border-bottom: 1px solid $bordercolor!important";
                     }
@@ -744,7 +744,7 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
             }
             $tplrow->setVariable("TEXT_ROW", ilLegacyFormElementsUtil::prepareFormOutput($rowobj->title));
             $tplrow->setVariable("ROWCLASS", $rowclass[$i % 2]);
-            if ($this->object->getRowSeparators() == 1) {
+            if ($this->object->getRowSeparators()) {
                 if ($i < $this->object->getRowCount() - 1) {
                     $tplrow->setVariable("STYLE", " style=\"border-bottom: 1px solid $bordercolor!important\"");
                 }
@@ -761,7 +761,7 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
             );
         }
         $template->setCurrentBlock("question_data_matrix");
-        if (strcmp($error_message, "") != 0) {
+        if (strcmp($error_message, "") !== 0) {
             $template->setVariable("ERROR_MESSAGE", "<p class=\"warning\">$error_message</p>");
         }
         if ($show_questiontext) {

--- a/Modules/SurveyQuestionPool/Questions/class.SurveyMatrixQuestionGUI.php
+++ b/Modules/SurveyQuestionPool/Questions/class.SurveyMatrixQuestionGUI.php
@@ -341,7 +341,8 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
                 if (($i == 0) && ($j == 0)) {
                     if ((strlen($this->object->getBipolarAdjective(0))) && (strlen($this->object->getBipolarAdjective(1)))) {
                         $tplrow->setCurrentBlock("bipolar_start");
-                        $tplrow->setVariable("TEXT_BIPOLAR_START",
+                        $tplrow->setVariable(
+                            "TEXT_BIPOLAR_START",
                             ilLegacyFormElementsUtil::prepareFormOutput($this->object->getBipolarAdjective(0))
                         );
                         $tplrow->setVariable("ROWSPAN", $this->object->getRowCount());
@@ -351,7 +352,8 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
                 if (($i == 0) && ($j == $this->object->getColumnCount() - 1)) {
                     if ((strlen($this->object->getBipolarAdjective(0))) && (strlen($this->object->getBipolarAdjective(1)))) {
                         $tplrow->setCurrentBlock("bipolar_end");
-                        $tplrow->setVariable("TEXT_BIPOLAR_END",
+                        $tplrow->setVariable(
+                            "TEXT_BIPOLAR_END",
                             ilLegacyFormElementsUtil::prepareFormOutput($this->object->getBipolarAdjective(1))
                         );
                         $tplrow->setVariable("ROWSPAN", $this->object->getRowCount());
@@ -426,8 +428,8 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
             if ($question_title == 3) {
                 if (trim($rowobj->label)) {
                     $row_title .= ' <span class="questionLabel">(' . ilLegacyFormElementsUtil::prepareFormOutput(
-                            $rowobj->label
-                        ) . ')</span>';
+                        $rowobj->label
+                    ) . ')</span>';
                 }
             }
 
@@ -641,7 +643,8 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
                 if (($i == 0) && ($j == 0)) {
                     if ((strlen($this->object->getBipolarAdjective(0))) && (strlen($this->object->getBipolarAdjective(1)))) {
                         $tplrow->setCurrentBlock("bipolar_start");
-                        $tplrow->setVariable("TEXT_BIPOLAR_START",
+                        $tplrow->setVariable(
+                            "TEXT_BIPOLAR_START",
                             ilLegacyFormElementsUtil::prepareFormOutput($this->object->getBipolarAdjective(0))
                         );
                         $tplrow->setVariable("ROWSPAN", $this->object->getRowCount());
@@ -651,7 +654,8 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
                 if (($i == 0) && ($j == $this->object->getColumnCount() - 1)) {
                     if ((strlen($this->object->getBipolarAdjective(0))) && (strlen($this->object->getBipolarAdjective(1)))) {
                         $tplrow->setCurrentBlock("bipolar_end");
-                        $tplrow->setVariable("TEXT_BIPOLAR_END",
+                        $tplrow->setVariable(
+                            "TEXT_BIPOLAR_END",
                             ilLegacyFormElementsUtil::prepareFormOutput($this->object->getBipolarAdjective(1))
                         );
                         $tplrow->setVariable("ROWSPAN", $this->object->getRowCount());
@@ -729,7 +733,8 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
                 if (is_array($working_data)) {
                     foreach ($working_data as $data) {
                         if ($data["rowvalue"] == $i) {
-                            $tplrow->setVariable("VALUE_OTHER",
+                            $tplrow->setVariable(
+                                "VALUE_OTHER",
                                 ilLegacyFormElementsUtil::prepareFormOutput($data['textanswer'])
                             );
                         }
@@ -750,7 +755,8 @@ class SurveyMatrixQuestionGUI extends SurveyQuestionGUI
         }
         
         if ($question_title) {
-            $template->setVariable("QUESTION_TITLE",
+            $template->setVariable(
+                "QUESTION_TITLE",
                 ilLegacyFormElementsUtil::prepareFormOutput($this->object->getTitle())
             );
         }

--- a/Modules/SurveyQuestionPool/Questions/class.SurveyMetricQuestionEvaluation.php
+++ b/Modules/SurveyQuestionPool/Questions/class.SurveyMetricQuestionEvaluation.php
@@ -134,7 +134,7 @@ class SurveyMetricQuestionEvaluation extends SurveyQuestionEvaluation
         $data->setBarOptions(0.5, "center");
         $data->setFill(1);
         
-        $total = sizeof($a_results->getAnswers());
+        $total = count($a_results->getAnswers());
         if ($total > 0) {
             $cumulated = array();
             foreach ($a_results->getAnswers() as $answer) {
@@ -181,7 +181,7 @@ class SurveyMetricQuestionEvaluation extends SurveyQuestionEvaluation
         );
         
         // as we have no variables build rows from answers directly
-        $total = sizeof($a_results->getAnswers());
+        $total = count($a_results->getAnswers());
         if ($total > 0) {
             $cumulated = array();
             foreach ($a_results->getAnswers() as $answer) {
@@ -208,7 +208,7 @@ class SurveyMetricQuestionEvaluation extends SurveyQuestionEvaluation
         $a_results
     ) : void {
         $answer = $a_results->getUserResults($a_user_id);
-        if (count($answer) == 0) {
+        if (count($answer) === 0) {
             $a_row[] = $this->getSkippedValue();
         } else {
             $a_row[] = $answer[0][0];

--- a/Modules/SurveyQuestionPool/Questions/class.SurveyMetricQuestionGUI.php
+++ b/Modules/SurveyQuestionPool/Questions/class.SurveyMetricQuestionGUI.php
@@ -210,7 +210,7 @@ class SurveyMetricQuestionGUI extends SurveyQuestionGUI
 
         $template->setVariable("INPUT_SIZE", 10);
 
-        if (strcmp($error_message, "") != 0) {
+        if (strcmp($error_message, "") !== 0) {
             $template->setVariable("ERROR_MESSAGE", "<p class=\"warning\">$error_message</p>");
         }
         $template->parseCurrentBlock();

--- a/Modules/SurveyQuestionPool/Questions/class.SurveyMultipleChoiceQuestion.php
+++ b/Modules/SurveyQuestionPool/Questions/class.SurveyMultipleChoiceQuestion.php
@@ -50,11 +50,11 @@ class SurveyMultipleChoiceQuestion extends SurveyQuestion
             array('integer'),
             array($id)
         );
-        if ($result->numRows() == 1) {
+        if ($result->numRows() === 1) {
             return $ilDB->fetchAssoc($result);
-        } else {
-            return array();
         }
+
+        return array();
     }
     
     public function loadFromDb(int $question_id) : void
@@ -66,7 +66,7 @@ class SurveyMultipleChoiceQuestion extends SurveyQuestion
             array('integer'),
             array($question_id)
         );
-        if ($result->numRows() == 1) {
+        if ($result->numRows() === 1) {
             $data = $ilDB->fetchAssoc($result);
             $this->setId($data["question_id"]);
             $this->setTitle($data["title"]);
@@ -101,16 +101,12 @@ class SurveyMultipleChoiceQuestion extends SurveyQuestion
 
     public function isComplete() : bool
     {
-        if (
-            strlen($this->getTitle()) &&
-            strlen($this->getAuthor()) &&
-            strlen($this->getQuestiontext()) &&
+        return (
+            $this->getTitle() !== '' &&
+            $this->getAuthor() !== '' &&
+            $this->getQuestiontext() !== '' &&
             $this->categories->getCategoryCount()
-        ) {
-            return 1;
-        } else {
-            return 0;
-        }
+        );
     }
 
     public function saveToDb(int $original_id = 0) : int
@@ -118,7 +114,7 @@ class SurveyMultipleChoiceQuestion extends SurveyQuestion
         $ilDB = $this->db;
 
         $affectedRows = parent::saveToDb($original_id);
-        if ($affectedRows == 1) {
+        if ($affectedRows === 1) {
             $ilDB->manipulateF(
                 "DELETE FROM " . $this->getAdditionalTableName() . " WHERE question_fi = %s",
                 array('integer'),
@@ -241,7 +237,7 @@ class SurveyMultipleChoiceQuestion extends SurveyQuestion
                 );
                 $a_xml_writer->xmlStartTag("material", $attrs);
                 $intlink = "il_" . IL_INST_ID . "_" . $matches[2] . "_" . $matches[3];
-                if (strcmp($matches[1], "") != 0) {
+                if (strcmp($matches[1], "") !== 0) {
                     $intlink = $this->material["internal_link"];
                 }
                 $a_xml_writer->xmlElement("mattext", null, $intlink);
@@ -317,11 +313,11 @@ class SurveyMultipleChoiceQuestion extends SurveyQuestion
         int $survey_id
     ) : string {
         $entered_value = (array) $post_data[$this->getId() . "_value"];
-        if (!$this->getObligatory() && (count($entered_value) == 0)) {
+        if (!$this->getObligatory() && (count($entered_value) === 0)) {
             return "";
         }
 
-        if ($this->use_min_answers && $this->nr_min_answers > 0 && $this->nr_max_answers > 0 && $this->nr_min_answers == $this->nr_max_answers && count($entered_value) != $this->nr_max_answers) {
+        if ($this->use_min_answers && $this->nr_min_answers > 0 && $this->nr_max_answers > 0 && $this->nr_min_answers == $this->nr_max_answers && count($entered_value) !== $this->nr_max_answers) {
             return sprintf($this->lng->txt("err_no_exact_answers"), $this->nr_min_answers);
         }
         if ($this->use_min_answers && $this->nr_min_answers > 0 && count($entered_value) < $this->nr_min_answers) {
@@ -340,10 +336,8 @@ class SurveyMultipleChoiceQuestion extends SurveyQuestion
                     if (array_key_exists($this->getId() . "_" . $i . "_other", $post_data) && !strlen($post_data[$this->getId() . "_" . $i . "_other"])) {
                         return $this->lng->txt("question_mr_no_other_answer");
                     }
-                } else {
-                    if (strlen($post_data[$this->getId() . "_" . $i . "_other"])) {
-                        return $this->lng->txt("question_mr_no_other_answer_checked");
-                    }
+                } elseif (strlen($post_data[$this->getId() . "_" . $i . "_other"])) {
+                    return $this->lng->txt("question_mr_no_other_answer_checked");
                 }
             }
         }

--- a/Modules/SurveyQuestionPool/Questions/class.SurveyMultipleChoiceQuestionEvaluation.php
+++ b/Modules/SurveyQuestionPool/Questions/class.SurveyMultipleChoiceQuestionEvaluation.php
@@ -58,7 +58,7 @@ class SurveyMultipleChoiceQuestionEvaluation extends SurveyQuestionEvaluation
         $categories = $this->question->getCategories();
                 
         $answers = $a_results->getUserResults($a_user_id);
-        if (count($answers) == 0) {
+        if (count($answers) === 0) {
             $a_row[] = $this->getSkippedValue();
             
             for ($i = 0; $i < $categories->getCategoryCount(); $i++) {

--- a/Modules/SurveyQuestionPool/Questions/class.SurveyMultipleChoiceQuestionGUI.php
+++ b/Modules/SurveyQuestionPool/Questions/class.SurveyMultipleChoiceQuestionGUI.php
@@ -215,7 +215,8 @@ class SurveyMultipleChoiceQuestionGUI extends SurveyQuestionGUI
                         $template->setVariable("IMAGE_CHECKBOX", ilUtil::getHtmlPath(ilUtil::getImagePath("checkbox_" . $option["checked"] . ".png")));
                         $template->setVariable("ALT_CHECKBOX", $this->lng->txt($option["checked"]));
                         $template->setVariable("TITLE_CHECKBOX", $this->lng->txt($option["checked"]));
-                        $template->setVariable("OTHER_LABEL",
+                        $template->setVariable(
+                            "OTHER_LABEL",
                             ilLegacyFormElementsUtil::prepareFormOutput($option["title"])
                         );
                         $template->setVariable("OTHER_ANSWER", $option["textanswer"]
@@ -243,7 +244,8 @@ class SurveyMultipleChoiceQuestionGUI extends SurveyQuestionGUI
                 foreach ($options as $option) {
                     if ($option["other"]) {
                         $template->setCurrentBlock("other_text_col");
-                        $template->setVariable("OTHER_LABEL",
+                        $template->setVariable(
+                            "OTHER_LABEL",
                             ilLegacyFormElementsUtil::prepareFormOutput($option["title"])
                         );
                         $template->setVariable("OTHER_ANSWER", $option["textanswer"]
@@ -316,8 +318,8 @@ class SurveyMultipleChoiceQuestionGUI extends SurveyQuestionGUI
                                 if (strlen($value["value"])) {
                                     if ($value["value"] == $cat->scale - 1) {
                                         $template->setVariable("OTHER_VALUE", ' value="' . ilLegacyFormElementsUtil::prepareFormOutput(
-                                                $value['textanswer']
-                                            ) . '"');
+                                            $value['textanswer']
+                                        ) . '"');
                                         if (!$value['uncheck']) {
                                             $template->setVariable("CHECKED_MC", " checked=\"checked\"");
                                         }
@@ -389,8 +391,8 @@ class SurveyMultipleChoiceQuestionGUI extends SurveyQuestionGUI
                                 if (strlen($value["value"])) {
                                     if ($value["value"] == $cat->scale - 1) {
                                         $template->setVariable("OTHER_VALUE", ' value="' . ilLegacyFormElementsUtil::prepareFormOutput(
-                                                $value['textanswer']
-                                            ) . '"');
+                                            $value['textanswer']
+                                        ) . '"');
                                     }
                                 }
                             }

--- a/Modules/SurveyQuestionPool/Questions/class.SurveyMultipleChoiceQuestionGUI.php
+++ b/Modules/SurveyQuestionPool/Questions/class.SurveyMultipleChoiceQuestionGUI.php
@@ -102,7 +102,7 @@ class SurveyMultipleChoiceQuestionGUI extends SurveyQuestionGUI
                     $cnt_answers++;
                 }
             }
-            if ($this->request->getNeutral() != "") {
+            if ($this->request->getNeutral() !== "") {
                 $cnt_answers++;
             }
             /* this would be the DB-values
@@ -146,7 +146,7 @@ class SurveyMultipleChoiceQuestionGUI extends SurveyQuestionGUI
                 $this->object->getCategories()->addCategory($value, $answers['other'][$key], 0, null, $answers['scale'][$key]);
             }
         }
-        if ($this->request->getNeutral() != "") {
+        if ($this->request->getNeutral() !== "") {
             $this->object->getCategories()->addCategory($this->request->getNeutral(), 0, 1, null, $this->request->getNeutralScale());
         }
     }
@@ -181,7 +181,7 @@ class SurveyMultipleChoiceQuestionGUI extends SurveyQuestionGUI
             // "other" options have to be last or horizontal will be screwed
             $idx = $cat->other . "_" . $value;
             
-            if (!$a_only_user_anwers || $checked == "checked") {
+            if (!$a_only_user_anwers || $checked === "checked") {
                 $options[$idx] = array(
                 "value" => $value
                 ,"title" => trim($cat->title)
@@ -430,7 +430,7 @@ class SurveyMultipleChoiceQuestionGUI extends SurveyQuestionGUI
             }
             $template->parseCurrentBlock();
         }
-        if (strcmp($error_message, "") != 0) {
+        if (strcmp($error_message, "") !== 0) {
             $template->setVariable("ERROR_MESSAGE", "<p class=\"warning\">$error_message</p>");
         }
         if ($show_questiontext) {

--- a/Modules/SurveyQuestionPool/Questions/class.SurveyQuestion.php
+++ b/Modules/SurveyQuestionPool/Questions/class.SurveyQuestion.php
@@ -73,7 +73,7 @@ class SurveyQuestion
             $this->author = $ilUser->fullname;
         }
         $this->owner = $owner;
-        if ($this->owner == -1) {
+        if ($this->owner === -1) {
             $this->owner = $ilUser->getId();
         }
         $this->id = -1;
@@ -198,7 +198,7 @@ class SurveyQuestion
         string $materials_name = ""
     ) : void {
         foreach ($this->materials as $key => $value) {
-            if (strcmp($key, $materials_name) == 0) {
+            if (strcmp($key, $materials_name) === 0) {
                 if (file_exists($this->getMaterialsPath() . $value)) {
                     unlink($this->getMaterialsPath() . $value);
                 }
@@ -440,7 +440,7 @@ class SurveyQuestion
         );
         if ($result->numRows()) {
             $row = $ilDB->fetchAssoc($result);
-            if ($row["complete"] == 1) {
+            if ((int) $row["complete"] === 1) {
                 return true;
             }
         }
@@ -482,7 +482,7 @@ class SurveyQuestion
         // cleanup RTE images which are not inserted into the question text
         ilRTE::_cleanupMediaObjectUsage($this->getQuestiontext(), "spl:html", $this->getId());
         $affectedRows = 0;
-        if ($this->getId() == -1) {
+        if ($this->getId() === -1) {
             // Write new dataset
             $next_id = $ilDB->nextId('svy_question');
             $affectedRows = $ilDB->insert("svy_question", array(
@@ -664,7 +664,7 @@ class SurveyQuestion
         $insert = true;
         if ($result->numRows()) {
             while ($row = $ilDB->fetchAssoc($result)) {
-                if (strcmp($row["title"], $categorytext) == 0) {
+                if (strcmp($row["title"], $categorytext) === 0) {
                     $returnvalue = $row["category_id"];
                     $insert = false;
                 }
@@ -717,7 +717,7 @@ class SurveyQuestion
             array('integer'),
             array($question_id)
         );
-        if ($result->numRows() == 1) {
+        if ($result->numRows() === 1) {
             $row = $ilDB->fetchAssoc($result);
             $obj_id = $row["obj_fi"];
         } else {
@@ -831,7 +831,7 @@ class SurveyQuestion
             array('integer'),
             array($question_id)
         );
-        if ($result->numRows() == 1) {
+        if ($result->numRows() === 1) {
             $data = $ilDB->fetchAssoc($result);
             return $data["type_tag"];
         } else {
@@ -975,13 +975,13 @@ class SurveyQuestion
             array('integer'),
             array($question_id)
         );
-        return $result->numRows() == 1;
+        return $result->numRows() === 1;
     }
 
     public function addInternalLink(string $material_id) : void
     {
         $material_title = "";
-        if (strlen($material_id)) {
+        if ($material_id !== '') {
             if (preg_match("/il__(\w+)_(\d+)/", $material_id, $matches)) {
                 $type = $matches[1];
                 $target_id = $matches[2];
@@ -1059,7 +1059,7 @@ class SurveyQuestion
         }
     }
     
-    public function addMaterial(ilSurveyMaterial $obj_material)
+    public function addMaterial(ilSurveyMaterial $obj_material) : void
     {
         $this->material[] = $obj_material;
     }
@@ -1074,13 +1074,13 @@ class SurveyQuestion
         bool $is_import = false,
         string $material_title = ""
     ) : void {
-        if (strcmp($material_id, "") != 0) {
+        if (strcmp($material_id, "") !== 0) {
             $import_id = "";
             if ($is_import) {
                 $import_id = $material_id;
                 $material_id = self::_resolveInternalLink($import_id);
             }
-            if (strcmp($material_title, "") == 0) {
+            if (strcmp($material_title, "") === 0) {
                 if (preg_match("/il__(\w+)_(\d+)/", $material_id, $matches)) {
                     $type = $matches[1];
                     $target_id = $matches[2];
@@ -1149,7 +1149,7 @@ class SurveyQuestion
                     $resolved_link = ilInternalLink::_getIdForImportId("MediaObject", $internal_link);
                     break;
             }
-            if (strcmp($resolved_link, "") == 0) {
+            if (strcmp($resolved_link, "") === 0) {
                 $resolved_link = $internal_link;
             }
         } else {
@@ -1174,7 +1174,7 @@ class SurveyQuestion
             while ($row = $ilDB->fetchAssoc($result)) {
                 $internal_link = $row["internal_link"];
                 $resolved_link = self::_resolveInternalLink($internal_link);
-                if (strcmp($internal_link, $resolved_link) != 0) {
+                if (strcmp($internal_link, $resolved_link) !== 0) {
                     // internal link was resolved successfully
                     $affectedRows = $ilDB->manipulateF(
                         "UPDATE svy_material SET internal_link = %s, tstamp = %s WHERE material_id = %s",
@@ -1258,13 +1258,13 @@ class SurveyQuestion
             array('integer'),
             array($question_id)
         );
-        if ($result->numRows() == 1) {
+        if ($result->numRows() === 1) {
             $row = $ilDB->fetchAssoc($result);
             $qpl_object_id = $row["obj_fi"];
             return ilObjSurveyQuestionPool::_isWriteable($qpl_object_id);
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     public function getQuestionTypeID() : int
@@ -1275,12 +1275,12 @@ class SurveyQuestion
             array('text'),
             array($this->getQuestionType())
         );
-        if ($result->numRows() == 1) {
+        if ($result->numRows() === 1) {
             $row = $ilDB->fetchAssoc($result);
             return (int) $row["questiontype_id"];
-        } else {
-            return 0;
         }
+
+        return 0;
     }
 
     public function getQuestionType() : string
@@ -1297,9 +1297,9 @@ class SurveyQuestion
         int $gui = 0
     ) : bool {
         $type = $question_type;
-        if ($gui == 1) {
+        if ($gui === 1) {
             $type .= "GUI";
-        } elseif ($gui == 2) {
+        } elseif ($gui === 2) {
             $type .= "Evaluation";
         }
         if (file_exists("./Modules/SurveyQuestionPool/Questions/class." . $type . ".php")) {
@@ -1309,7 +1309,7 @@ class SurveyQuestion
 
             $component_factory = $DIC["component.factory"];
             foreach ($component_factory->getActivePluginsInSlot("svyq") as $pl) {
-                if (strcmp($pl->getQuestionType(), $question_type) == 0) {
+                if (strcmp($pl->getQuestionType(), $question_type) === 0) {
                     return true;
                 }
             }
@@ -1332,7 +1332,7 @@ class SurveyQuestion
         } else {
             $component_factory = $DIC["component.factory"];
             foreach ($component_factory->getActivePluginsInSlot("svyq") as $pl) {
-                if (strcmp($pl->getQuestionType(), $type_tag) == 0) {
+                if (strcmp($pl->getQuestionType(), $type_tag) === 0) {
                     return $pl->getQuestionTypeTranslation();
                 }
             }
@@ -1397,9 +1397,9 @@ class SurveyQuestion
     {
         if (preg_match("/<[^>]*?>/", $a_text)) {
             return true;
-        } else {
-            return false;
         }
+
+        return false;
     }
     
     /**
@@ -1413,10 +1413,10 @@ class SurveyQuestion
         $result = "";
         for ($i = 0; $i < $a_material->getMaterialCount(); $i++) {
             $material = $a_material->getMaterial($i);
-            if (strcmp($material["type"], "mattext") == 0) {
+            if (strcmp($material["type"], "mattext") === 0) {
                 $result .= $material["material"]->getContent();
             }
-            if (strcmp($material["type"], "matimage") == 0) {
+            if (strcmp($material["type"], "matimage") === 0) {
                 $matimage = $material["material"];
                 if (preg_match("/(il_([0-9]+)_mob_([0-9]+))/", $matimage->getLabel(), $matches)) {
                     // import an mediaobject which was inserted using tiny mce
@@ -1439,7 +1439,7 @@ class SurveyQuestion
         bool $close_material_tag = true,
         bool $add_mobs = true,
         ?array $a_attrs = null
-    ) {
+    ) : void {
         $a_xml_writer->xmlStartTag("material");
         $attrs = array(
             "type" => "text/plain"
@@ -1615,9 +1615,9 @@ class SurveyQuestion
             default:
                 if (array_key_exists($value, $this->arrData)) {
                     return (string) $this->arrData[$value];
-                } else {
-                    return null;
                 }
+
+                return null;
         }
     }
 
@@ -1715,7 +1715,7 @@ class SurveyQuestion
     public function stripSlashesAddSpaceFallback(string $a_str) : string
     {
         $str = ilUtil::stripSlashes($a_str);
-        if ($str != $a_str) {
+        if ($str !== $a_str) {
             $str = ilUtil::stripSlashes(str_replace("<", "< ", $a_str));
         }
         return $str;

--- a/Modules/SurveyQuestionPool/Questions/class.SurveyQuestion.php
+++ b/Modules/SurveyQuestionPool/Questions/class.SurveyQuestion.php
@@ -626,7 +626,9 @@ class SurveyQuestion
         $webdir = ilFileUtils::removeTrailingPathSeparators(CLIENT_WEB_DIR) . "/survey/$this->obj_id/$this->id/images/";
         return str_replace(
             ilFileUtils::removeTrailingPathSeparators(ILIAS_ABSOLUTE_PATH),
-            ilFileUtils::removeTrailingPathSeparators(ILIAS_HTTP_PATH), $webdir);
+            ilFileUtils::removeTrailingPathSeparators(ILIAS_HTTP_PATH),
+            $webdir
+        );
     }
 
     /**
@@ -637,7 +639,9 @@ class SurveyQuestion
         $webdir = ilFileUtils::removeTrailingPathSeparators(CLIENT_WEB_DIR) . "/survey/$this->obj_id/$this->id/materials/";
         return str_replace(
             ilFileUtils::removeTrailingPathSeparators(ILIAS_ABSOLUTE_PATH),
-            ilFileUtils::removeTrailingPathSeparators(ILIAS_HTTP_PATH), $webdir);
+            ilFileUtils::removeTrailingPathSeparators(ILIAS_HTTP_PATH),
+            $webdir
+        );
     }
 
     /**
@@ -1226,8 +1230,8 @@ class SurveyQuestion
                     break;
                 case "MediaObject":
                     $href = ilFileUtils::removeTrailingPathSeparators(
-                            ILIAS_HTTP_PATH
-                        ) . "/ilias.php?baseClass=ilLMPresentationGUI&obj_type=" . $linktypes[$type] . "&cmd=media&ref_id=" . $a_parent_ref_id . "&mob_id=" . $target_id;
+                        ILIAS_HTTP_PATH
+                    ) . "/ilias.php?baseClass=ilLMPresentationGUI&obj_type=" . $linktypes[$type] . "&cmd=media&ref_id=" . $a_parent_ref_id . "&mob_id=" . $target_id;
                     break;
             }
         }

--- a/Modules/SurveyQuestionPool/Questions/class.SurveyQuestionEvaluation.php
+++ b/Modules/SurveyQuestionPool/Questions/class.SurveyQuestionEvaluation.php
@@ -122,7 +122,7 @@ abstract class SurveyQuestionEvaluation
         array $a_answers,
         SurveyCategories $a_categories = null
     ) : void {
-        $num_users_answered = sizeof($a_answers);
+        $num_users_answered = count($a_answers);
 
         $a_results->setUsersAnswered($num_users_answered);
         $a_results->setUsersSkipped($this->getNrOfParticipants() - $num_users_answered);
@@ -132,7 +132,7 @@ abstract class SurveyQuestionEvaluation
         $selections = array();
         foreach ($a_answers as $active_id => $answers) {
             // :TODO:
-            if (sizeof($answers) > 1) {
+            if (count($answers) > 1) {
                 $has_multi = true;
             }
             foreach ($answers as $answer) {
@@ -180,7 +180,7 @@ abstract class SurveyQuestionEvaluation
                         $median[] = $value;
                     }
                 }
-                if ($total % 2 == 0) {
+                if ($total % 2 === 0) {
                     $lower = $median[($total / 2) - 1];
                     $upper = $median[($total / 2)];
                     $median_value = 0.5 * ($lower + $upper);
@@ -443,7 +443,7 @@ abstract class SurveyQuestionEvaluation
         $ilDB = $this->db;
         
         if (count($this->finished_ids) > 0) {
-            return sizeof($this->finished_ids);
+            return count($this->finished_ids);
         }
         
         $set = $ilDB->query("SELECT finished_id FROM svy_finished" .

--- a/Modules/SurveyQuestionPool/Questions/class.SurveyQuestionGUI.php
+++ b/Modules/SurveyQuestionPool/Questions/class.SurveyQuestionGUI.php
@@ -565,8 +565,8 @@ abstract class SurveyQuestionGUI
                 $title = ilLegacyFormElementsUtil::prepareFormOutput($this->object->getTitle());
                 if (trim($this->object->getLabel())) {
                     $title .= ' <span class="questionLabel">(' . ilLegacyFormElementsUtil::prepareFormOutput(
-                            $this->object->getLabel()
-                        ) . ')</span>';
+                        $this->object->getLabel()
+                    ) . ')</span>';
                 }
                 break;
         }

--- a/Modules/SurveyQuestionPool/Questions/class.SurveySingleChoiceQuestion.php
+++ b/Modules/SurveyQuestionPool/Questions/class.SurveySingleChoiceQuestion.php
@@ -57,7 +57,7 @@ class SurveySingleChoiceQuestion extends SurveyQuestion
             array($phrase_id)
         );
         while ($row = $ilDB->fetchAssoc($result)) {
-            if (($row["defaultvalue"] == 1) and ($row["owner_fi"] == 0)) {
+            if ((int) $row["defaultvalue"] === 1 && (int) $row["owner_fi"] === 0) {
                 $categories[$row["category_id"]] = $this->lng->txt($row["title"]);
             } else {
                 $categories[$row["category_id"]] = $row["title"];
@@ -81,7 +81,7 @@ class SurveySingleChoiceQuestion extends SurveyQuestion
         );
         while ($row = $ilDB->fetchAssoc($result)) {
             $neutral = $row["neutral"];
-            if (($row["defaultvalue"] == 1) and ($row["owner_fi"] == 0)) {
+            if ((int) $row["defaultvalue"] === 1 && (int) $row["owner_fi"] === 0) {
                 $this->categories->addCategory($this->lng->txt($row["title"]), 0, $neutral);
             } else {
                 $this->categories->addCategory($row["title"], 0, $neutral);
@@ -98,7 +98,7 @@ class SurveySingleChoiceQuestion extends SurveyQuestion
             array('integer'),
             array($id)
         );
-        if ($result->numRows() == 1) {
+        if ($result->numRows() === 1) {
             return $ilDB->fetchAssoc($result);
         } else {
             return array();
@@ -114,7 +114,7 @@ class SurveySingleChoiceQuestion extends SurveyQuestion
             array('integer'),
             array($question_id)
         );
-        if ($result->numRows() == 1) {
+        if ($result->numRows() === 1) {
             $data = $ilDB->fetchAssoc($result);
             $this->setId((int) $data["question_id"]);
             $this->setTitle((string) $data["title"]);
@@ -147,9 +147,9 @@ class SurveySingleChoiceQuestion extends SurveyQuestion
     public function isComplete() : bool
     {
         if (
-            strlen($this->getTitle()) &&
-            strlen($this->getAuthor()) &&
-            strlen($this->getQuestiontext()) &&
+            $this->getTitle() !== '' &&
+            $this->getAuthor() !== '' &&
+            $this->getQuestiontext() !== '' &&
             $this->categories->getCategoryCount()
         ) {
             return true;
@@ -163,7 +163,7 @@ class SurveySingleChoiceQuestion extends SurveyQuestion
         $ilDB = $this->db;
 
         $affectedRows = parent::saveToDb($original_id);
-        if ($affectedRows == 1) {
+        if ($affectedRows === 1) {
             $this->log->debug("Before save Category-> DELETE from svy_qst_sc WHERE question_fi = " . $this->getId() . " AND INSERT again the same id and orientation in svy_qst_sc");
             $ilDB->manipulateF(
                 "DELETE FROM " . $this->getAdditionalTableName() . " WHERE question_fi = %s",
@@ -231,7 +231,7 @@ class SurveySingleChoiceQuestion extends SurveyQuestion
     public function insertXML(
         ilXmlWriter $a_xml_writer,
         bool $a_include_header = true
-    ) {
+    ) : void {
         $attrs = array(
             "id" => $this->getId(),
             "title" => $this->getTitle(),
@@ -426,10 +426,8 @@ class SurveySingleChoiceQuestion extends SurveyQuestion
                     if (array_key_exists($this->getId() . "_" . $entered_value . "_other", $post_data) && !strlen($post_data[$this->getId() . "_" . $entered_value . "_other"])) {
                         return $this->lng->txt("question_mr_no_other_answer");
                     }
-                } else {
-                    if (strlen($post_data[$this->getId() . "_" . $i . "_other"])) {
-                        return $this->lng->txt("question_sr_no_other_answer_checked");
-                    }
+                } elseif (strlen($post_data[$this->getId() . "_" . $i . "_other"])) {
+                    return $this->lng->txt("question_sr_no_other_answer_checked");
                 }
             }
         }
@@ -574,10 +572,10 @@ class SurveySingleChoiceQuestion extends SurveyQuestion
         $q1 = SurveyQuestion::_instanciateQuestion($id1);
         /** @var SurveySingleChoiceQuestion $q2 */
         $q2 = SurveyQuestion::_instanciateQuestion($id2);
-        if ($q1->getOrientation() != 1 || $q2->getOrientation() != 1) {
+        if ($q1->getOrientation() !== 1 || $q2->getOrientation() !== 1) {
             return false;
         }
-        if (self::getCompressCompareString($q1) == self::getCompressCompareString($q2)) {
+        if (self::getCompressCompareString($q1) === self::getCompressCompareString($q2)) {
             return true;
         }
         return false;

--- a/Modules/SurveyQuestionPool/Questions/class.SurveySingleChoiceQuestionEvaluation.php
+++ b/Modules/SurveyQuestionPool/Questions/class.SurveySingleChoiceQuestionEvaluation.php
@@ -67,7 +67,7 @@ class SurveySingleChoiceQuestionEvaluation extends SurveyQuestionEvaluation
         }
         
         $answer = $a_results->getUserResults($a_user_id);
-        if (count($answer) == 0) {
+        if (count($answer) === 0) {
             $a_row[] = $this->getSkippedValue();
             $a_row[] = "";	// see #20646
             foreach ($other as $dummy) {

--- a/Modules/SurveyQuestionPool/Questions/class.SurveySingleChoiceQuestionGUI.php
+++ b/Modules/SurveyQuestionPool/Questions/class.SurveySingleChoiceQuestionGUI.php
@@ -86,7 +86,7 @@ class SurveySingleChoiceQuestionGUI extends SurveyQuestionGUI
                 );
             }
         }
-        if ($this->request->getNeutral() != "") {
+        if ($this->request->getNeutral() !== "") {
             $this->object->getCategories()->addCategory($this->request->getNeutral(), 0, 1, null, $this->request->getNeutralScale());
         }
     }
@@ -119,7 +119,7 @@ class SurveySingleChoiceQuestionGUI extends SurveyQuestionGUI
             // "other" options have to be last or horizontal will be screwed
             $idx = $cat->other . "_" . $value;
             
-            if (!$a_only_user_anwers || $checked == "checked") {
+            if (!$a_only_user_anwers || $checked === "checked") {
                 $options[$idx] = array(
                     "value" => $value
                     ,"title" => trim($cat->title)
@@ -203,7 +203,7 @@ class SurveySingleChoiceQuestionGUI extends SurveyQuestionGUI
                     $template->setCurrentBlock("comborow");
                     $template->setVariable("TEXT_SC", ilLegacyFormElementsUtil::prepareFormOutput($option["title"]));
                     $template->setVariable("VALUE_SC", $option["value"]);
-                    if ($option["checked"] == "checked") {
+                    if ($option["checked"] === "checked") {
                         $template->setVariable("SELECTED_SC", ' selected="selected"');
                     }
                     $template->parseCurrentBlock();
@@ -240,12 +240,12 @@ class SurveySingleChoiceQuestionGUI extends SurveyQuestionGUI
     ) : string {
         $orientation = $this->object->orientation;
         $template_file = "tpl.il_svy_out_sc.html";
-        if ($compress_view && $orientation == 1) {
+        if ($compress_view && $orientation === 1) {
             $template_file = "tpl.il_svy_out_sc_comp.html";
             $orientation = 3;
         }
         $template = new ilTemplate($template_file, true, true, "Modules/SurveyQuestionPool");
-        if ($this->getMaterialOutput() != "") {
+        if ($this->getMaterialOutput() !== "") {
             $template->setCurrentBlock("material");
             $template->setVariable("TEXT_MATERIAL", $this->getMaterialOutput());
             $template->parseCurrentBlock();
@@ -292,7 +292,7 @@ class SurveySingleChoiceQuestionGUI extends SurveyQuestionGUI
                         $template->setVariable("QUESTION_ID", $this->object->getId());
                         if (is_array($working_data)) {
                             foreach ($working_data as $value) {
-                                if (strcmp($value["value"], "") != 0) {
+                                if (strcmp($value["value"], "") !== 0) {
                                     if ($value["value"] == $cat->scale - 1) {
                                         if (!($value['uncheck'] ?? false)) {
                                             $template->setVariable("CHECKED_SC", " checked=\"checked\"");
@@ -322,7 +322,7 @@ class SurveySingleChoiceQuestionGUI extends SurveyQuestionGUI
                     $template->setVariable("QUESTION_ID", $this->object->getId());
                     if (is_array($working_data)) {
                         foreach ($working_data as $value) {
-                            if (strcmp($value["value"], "") != 0) {
+                            if (strcmp($value["value"], "") !== 0) {
                                 if ($value["value"] == $cat->scale - 1) {
                                     if (!($value['uncheck'] ?? false)) {
                                         $template->setVariable("CHECKED_SC", " checked=\"checked\"");
@@ -382,7 +382,7 @@ class SurveySingleChoiceQuestionGUI extends SurveyQuestionGUI
                     $template->setVariable("TEXT_SC", $cat->title);
                     $template->setVariable("VALUE_SC", ($cat->scale) ? ($cat->scale - 1) : $i);
                     if (is_array($working_data)) {
-                        if (strcmp($working_data[0]["value"], "") != 0) {
+                        if (strcmp($working_data[0]["value"], "") !== 0) {
                             if ($working_data[0]["value"] == $cat->scale - 1) {
                                 $template->setVariable("SELECTED_SC", " selected=\"selected\"");
                             }
@@ -431,7 +431,7 @@ class SurveySingleChoiceQuestionGUI extends SurveyQuestionGUI
                     $template->setVariable("QUESTION_ID", $this->object->getId());
                     if (is_array($working_data)) {
                         foreach ($working_data as $value) {
-                            if (strcmp($value["value"], "") != 0) {
+                            if (strcmp($value["value"], "") !== 0) {
                                 if ($value["value"] == $cat->scale - 1) {
                                     if (!($value['uncheck'] ?? false)) {
                                         $template->setVariable("CHECKED_SC", " checked=\"checked\"");
@@ -465,7 +465,7 @@ class SurveySingleChoiceQuestionGUI extends SurveyQuestionGUI
             $template->setVariable("QUESTION_TITLE", $this->object->getTitle());
         }
         $template->setCurrentBlock("question_data");
-        if (strcmp($error_message, "") != 0) {
+        if (strcmp($error_message, "") !== 0) {
             $template->setVariable("ERROR_MESSAGE", "<p class=\"warning\">$error_message</p>");
         }
         if ($show_questiontext) {

--- a/Modules/SurveyQuestionPool/Questions/class.SurveySingleChoiceQuestionGUI.php
+++ b/Modules/SurveyQuestionPool/Questions/class.SurveySingleChoiceQuestionGUI.php
@@ -155,7 +155,8 @@ class SurveySingleChoiceQuestionGUI extends SurveyQuestionGUI
                         $template->setVariable("IMAGE_RADIO", ilUtil::getHtmlPath(ilUtil::getImagePath("radiobutton_" . $option["checked"] . ".png")));
                         $template->setVariable("ALT_RADIO", $this->lng->txt($option["checked"]));
                         $template->setVariable("TITLE_RADIO", $this->lng->txt($option["checked"]));
-                        $template->setVariable("OTHER_LABEL",
+                        $template->setVariable(
+                            "OTHER_LABEL",
                             ilLegacyFormElementsUtil::prepareFormOutput($option["title"])
                         );
                         $template->setVariable("OTHER_ANSWER", $option["textanswer"]
@@ -183,7 +184,8 @@ class SurveySingleChoiceQuestionGUI extends SurveyQuestionGUI
                 foreach ($options as $option) {
                     if ($option["other"]) {
                         $template->setCurrentBlock("other_text_col");
-                        $template->setVariable("OTHER_LABEL",
+                        $template->setVariable(
+                            "OTHER_LABEL",
                             ilLegacyFormElementsUtil::prepareFormOutput($option["title"])
                         );
                         $template->setVariable("OTHER_ANSWER", $option["textanswer"]
@@ -270,8 +272,8 @@ class SurveySingleChoiceQuestionGUI extends SurveyQuestionGUI
                                     if ($value["value"] == $cat->scale - 1) {
                                         if (strlen($value['textanswer'])) {
                                             $template->setVariable("OTHER_VALUE", ' value="' . ilLegacyFormElementsUtil::prepareFormOutput(
-                                                    $value['textanswer']
-                                                ) . '"');
+                                                $value['textanswer']
+                                            ) . '"');
                                         }
                                         if (!($value['uncheck'] ?? false)) {
                                             $template->setVariable("CHECKED_SC", " checked=\"checked\"");
@@ -349,8 +351,8 @@ class SurveySingleChoiceQuestionGUI extends SurveyQuestionGUI
                                 if (strlen($value["value"])) {
                                     if ($value["value"] == $cat->scale - 1 && strlen($value['textanswer'])) {
                                         $template->setVariable("OTHER_VALUE", ' value="' . ilLegacyFormElementsUtil::prepareFormOutput(
-                                                $value['textanswer']
-                                            ) . '"');
+                                            $value['textanswer']
+                                        ) . '"');
                                     }
                                 }
                             }
@@ -411,8 +413,8 @@ class SurveySingleChoiceQuestionGUI extends SurveyQuestionGUI
                                 if (strlen($value["value"])) {
                                     if ($value["value"] == $cat->scale - 1 && strlen($value['textanswer'])) {
                                         $template->setVariable("OTHER_VALUE", ' value="' . ilLegacyFormElementsUtil::prepareFormOutput(
-                                                $value['textanswer']
-                                            ) . '"');
+                                            $value['textanswer']
+                                        ) . '"');
                                     }
                                 }
                             }

--- a/Modules/SurveyQuestionPool/Questions/class.SurveyTextQuestion.php
+++ b/Modules/SurveyQuestionPool/Questions/class.SurveyTextQuestion.php
@@ -52,7 +52,7 @@ class SurveyTextQuestion extends SurveyQuestion
             array('integer'),
             array($id)
         );
-        if ($result->numRows() == 1) {
+        if ($result->numRows() === 1) {
             return $ilDB->fetchAssoc($result);
         } else {
             return array();
@@ -68,7 +68,7 @@ class SurveyTextQuestion extends SurveyQuestion
             array('integer'),
             array($question_id)
         );
-        if ($result->numRows() == 1) {
+        if ($result->numRows() === 1) {
             $data = $ilDB->fetchAssoc($result);
             $this->setId($data["question_id"]);
             $this->setTitle($data["title"]);
@@ -117,7 +117,7 @@ class SurveyTextQuestion extends SurveyQuestion
         $ilDB = $this->db;
         
         $affectedRows = parent::saveToDb($original_id);
-        if ($affectedRows == 1) {
+        if ($affectedRows === 1) {
             $ilDB->manipulateF(
                 "DELETE FROM " . $this->getAdditionalTableName() . " WHERE question_fi = %s",
                 array('integer'),

--- a/Modules/SurveyQuestionPool/Questions/class.SurveyTextQuestionEvaluation.php
+++ b/Modules/SurveyQuestionPool/Questions/class.SurveyTextQuestionEvaluation.php
@@ -62,7 +62,7 @@ class SurveyTextQuestionEvaluation extends SurveyQuestionEvaluation
         $a_results
     ) : void {
         $answer = $a_results->getUserResults($a_user_id);
-        if (count($answer) == 0) {
+        if (count($answer) === 0) {
             $a_row[] = $this->getSkippedValue();
         } else {
             $a_row[] = $answer[0][1];

--- a/Modules/SurveyQuestionPool/Questions/class.SurveyTextQuestionGUI.php
+++ b/Modules/SurveyQuestionPool/Questions/class.SurveyTextQuestionGUI.php
@@ -147,7 +147,7 @@ class SurveyTextQuestionGUI extends SurveyQuestionGUI
         $template->setVariable("TEXT_MATERIAL", $this->getMaterialOutput());
         $template->parseCurrentBlock();
 
-        if ($this->object->getTextHeight() == 1) {
+        if ($this->object->getTextHeight() === 1) {
             $template->setCurrentBlock("textinput");
             if (is_array($working_data)) {
                 if (isset($working_data[0]["textanswer"])) {
@@ -178,7 +178,7 @@ class SurveyTextQuestionGUI extends SurveyQuestionGUI
         }
         $template->setVariable("TEXT_ANSWER", $this->lng->txt("answer"));
         $template->setVariable("LABEL_QUESTION_ID", $this->object->getId());
-        if (strcmp($error_message, "") != 0) {
+        if (strcmp($error_message, "") !== 0) {
             $template->setVariable("ERROR_MESSAGE", "<p class=\"warning\">$error_message</p>");
         }
         if ($this->object->getMaxChars()) {

--- a/Modules/SurveyQuestionPool/Questions/class.ilSurveyQuestionsTableGUI.php
+++ b/Modules/SurveyQuestionPool/Questions/class.ilSurveyQuestionsTableGUI.php
@@ -54,19 +54,19 @@ class ilSurveyQuestionsTableGUI extends ilTable2GUI
         $this->addColumn($this->lng->txt("obligatory"), "");
         
         foreach ($this->getSelectedColumns() as $c) {
-            if (strcmp($c, 'description') == 0) {
+            if (strcmp($c, 'description') === 0) {
                 $this->addColumn($this->lng->txt("description"), 'description', '');
             }
-            if (strcmp($c, 'type') == 0) {
+            if (strcmp($c, 'type') === 0) {
                 $this->addColumn($this->lng->txt("question_type"), 'type', '');
             }
-            if (strcmp($c, 'author') == 0) {
+            if (strcmp($c, 'author') === 0) {
                 $this->addColumn($this->lng->txt("author"), 'author', '');
             }
-            if (strcmp($c, 'created') == 0) {
+            if (strcmp($c, 'created') === 0) {
                 $this->addColumn($this->lng->txt("create_date"), 'created', '');
             }
-            if (strcmp($c, 'updated') == 0) {
+            if (strcmp($c, 'updated') === 0) {
                 $this->addColumn($this->lng->txt("last_update"), 'tstamp', '');
             }
         }
@@ -194,7 +194,7 @@ class ilSurveyQuestionsTableGUI extends ilTable2GUI
         }
         $this->tpl->parseCurrentBlock();
 
-        if ($a_set["complete"] == 0) {
+        if ((int) $a_set["complete"] === 0) {
             $this->tpl->setCurrentBlock("qpl_warning");
             $this->tpl->setVariable("IMAGE_WARNING", ilUtil::getImagePath("icon_alert.svg"));
             $this->tpl->setVariable("ALT_WARNING", $this->lng->txt("warning_question_not_complete"));
@@ -203,27 +203,27 @@ class ilSurveyQuestionsTableGUI extends ilTable2GUI
         }
         
         foreach ($this->getSelectedColumns() as $c) {
-            if (strcmp($c, 'description') == 0) {
+            if (strcmp($c, 'description') === 0) {
                 $this->tpl->setCurrentBlock('description');
-                $this->tpl->setVariable("QUESTION_COMMENT", (strlen($a_set["description"])) ? $a_set["description"] : "&nbsp;");
+                $this->tpl->setVariable("QUESTION_COMMENT", ($a_set["description"] ?? '') !== '' ? $a_set["description"] : "&nbsp;");
                 $this->tpl->parseCurrentBlock();
             }
-            if (strcmp($c, 'type') == 0) {
+            if (strcmp($c, 'type') === 0) {
                 $this->tpl->setCurrentBlock('type');
                 $this->tpl->setVariable("QUESTION_TYPE", SurveyQuestion::_getQuestionTypeName($a_set["type_tag"]));
                 $this->tpl->parseCurrentBlock();
             }
-            if (strcmp($c, 'author') == 0) {
+            if (strcmp($c, 'author') === 0) {
                 $this->tpl->setCurrentBlock('author');
                 $this->tpl->setVariable("QUESTION_AUTHOR", $a_set["author"]);
                 $this->tpl->parseCurrentBlock();
             }
-            if (strcmp($c, 'created') == 0) {
+            if (strcmp($c, 'created') === 0) {
                 $this->tpl->setCurrentBlock('created');
                 $this->tpl->setVariable("QUESTION_CREATED", ilDatePresentation::formatDate(new ilDate($a_set['created'], IL_CAL_UNIX)));
                 $this->tpl->parseCurrentBlock();
             }
-            if (strcmp($c, 'updated') == 0) {
+            if (strcmp($c, 'updated') === 0) {
                 $this->tpl->setCurrentBlock('updated');
                 $this->tpl->setVariable("QUESTION_UPDATED", ilDatePresentation::formatDate(new ilDate($a_set["tstamp"], IL_CAL_UNIX)));
                 $this->tpl->parseCurrentBlock();

--- a/Modules/SurveyQuestionPool/classes/class.ilMatrixRowWizardInputGUI.php
+++ b/Modules/SurveyQuestionPool/classes/class.ilMatrixRowWizardInputGUI.php
@@ -65,11 +65,9 @@ class ilMatrixRowWizardInputGUI extends ilTextInputGUI
     public function setValue($a_value) : void
     {
         $this->values = new SurveyCategories();
-        if (is_array($a_value)) {
-            if (is_array($a_value['answer'])) {
-                foreach ($a_value['answer'] as $index => $value) {
-                    $this->values->addCategory($value, $a_value['other'][$index]);
-                }
+        if (is_array($a_value) && is_array($a_value['answer'])) {
+            foreach ($a_value['answer'] as $index => $value) {
+                $this->values->addCategory($value, $a_value['other'][$index]);
             }
         }
     }

--- a/Modules/SurveyQuestionPool/classes/class.ilObjSurveyQuestionPool.php
+++ b/Modules/SurveyQuestionPool/classes/class.ilObjSurveyQuestionPool.php
@@ -69,12 +69,12 @@ class ilObjSurveyQuestionPool extends ilObject
         $this->loadFromDb();
     }
 
-    public function cloneObject(int $a_target_id, int $a_copy_id = 0, bool $a_omit_tree = false) : ?ilObject
+    public function cloneObject(int $target_id, int $copy_id = 0, bool $omit_tree = false) : ?ilObject
     {
-        $newObj = parent::cloneObject($a_target_id, $a_copy_id, $a_omit_tree);
+        $newObj = parent::cloneObject($target_id, $copy_id, $omit_tree);
 
         //copy online status if object is not the root copy object
-        $cp_options = ilCopyWizardOptions::_getInstance($a_copy_id);
+        $cp_options = ilCopyWizardOptions::_getInstance($copy_id);
 
         if (!$cp_options->isRootNode($this->getRefId())) {
             $newObj->setOnline($this->getOnline());
@@ -126,7 +126,7 @@ class ilObjSurveyQuestionPool extends ilObject
         int $questionpool_to
     ) : void {
         $question_gui = $this->createQuestion("", $question_id);
-        if ($question_gui->object->getObjId() == $questionpool_to) {
+        if ($question_gui->object->getObjId() === $questionpool_to) {
             // the question is copied into the same question pool
             $this->duplicateQuestion($question_id);
         } else {
@@ -148,11 +148,11 @@ class ilObjSurveyQuestionPool extends ilObject
         $ilDB = $this->db;
         
         $result = $ilDB->queryF(
-            "SELECT * FROM svy_qpl WHERE obj_fi = %s",
+            "SELECT isonline FROM svy_qpl WHERE obj_fi = %s",
             array('integer'),
             array($this->getId())
         );
-        if ($result->numRows() == 1) {
+        if ($result->numRows() === 1) {
             $row = $ilDB->fetchAssoc($result);
             $this->setOnline((bool) $row["isonline"]);
         }
@@ -169,7 +169,7 @@ class ilObjSurveyQuestionPool extends ilObject
             array('integer'),
             array($this->getId())
         );
-        if ($result->numRows() == 1) {
+        if ($result->numRows() === 1) {
             $affectedRows = $ilDB->manipulateF(
                 "UPDATE svy_qpl SET isonline = %s, tstamp = %s WHERE obj_fi = %s",
                 array('text','integer','integer'),
@@ -250,7 +250,7 @@ class ilObjSurveyQuestionPool extends ilObject
             array('integer'),
             array($question_id)
         );
-        if ($result->numRows() == 1) {
+        if ($result->numRows() === 1) {
             $data = $ilDB->fetchAssoc($result);
             return $data["type_tag"];
         } else {
@@ -281,7 +281,7 @@ class ilObjSurveyQuestionPool extends ilObject
             array($question_id)
         );
         $inserted = $result->numRows();
-        if (($inserted + $answered) == 0) {
+        if (($inserted + $answered) === 0) {
             return null;
         }
         $result_array = array();
@@ -433,7 +433,7 @@ class ilObjSurveyQuestionPool extends ilObject
     {
         // quit if import dir not available
         if (!is_dir($dir) or
-            !is_writeable($dir)) {
+            !is_writable($dir)) {
             return array();
         }
 
@@ -445,8 +445,8 @@ class ilObjSurveyQuestionPool extends ilObject
 
         // get files and save the in the array
         while ($entry = $dir->read()) {
-            if ($entry != "." &&
-                $entry != ".." &&
+            if ($entry !== "." &&
+                $entry !== ".." &&
                 preg_match("/^[0-9]{10}__[0-9]+__(spl_)*[0-9]+\.[A-Za-z]{3}$/", $entry)) {
                 $file[] = $entry;
             }
@@ -501,7 +501,7 @@ class ilObjSurveyQuestionPool extends ilObject
      */
     public function toXML(array $questions) : string
     {
-        if (count($questions) == 0) {
+        if (count($questions) === 0) {
             $questions = $this->getQuestions();
         }
         $a_xml_writer = new ilXmlWriter();
@@ -576,7 +576,7 @@ class ilObjSurveyQuestionPool extends ilObject
         bool $spl_exists = false
     ) : void {
         if (is_file($source)) {
-            $isZip = (strcmp(strtolower(substr($source, -3)), 'zip') == 0);
+            $isZip = (strcmp(strtolower(substr($source, -3)), 'zip') === 0);
             if ($isZip) {
                 // unzip file
                 ilFileUtils::unzip($source);
@@ -586,7 +586,7 @@ class ilObjSurveyQuestionPool extends ilObject
                 $source = dirname($source) . "/" . $subdir . "/" . $subdir . ".xml";
             }
 
-            $fh = fopen($source, "r") or die("");
+            $fh = fopen($source, 'rb') or die("");
             $xml = fread($fh, filesize($source));
             fclose($fh) or die("");
             if ($isZip) {
@@ -597,12 +597,12 @@ class ilObjSurveyQuestionPool extends ilObject
             }
             if (strpos($xml, "questestinterop") > 0) {
                 throw new ilInvalidSurveyImportFileException("Unsupported survey version (< 3.8) found.");
-            } else {
-                // survey questions for ILIAS >= 3.8
-                $import = new SurveyImportParser($this->getId(), "", $spl_exists);
-                $import->setXMLContent($xml);
-                $import->startParsing();
             }
+
+            // survey questions for ILIAS >= 3.8
+            $import = new SurveyImportParser($this->getId(), "", $spl_exists);
+            $import->setXMLContent($xml);
+            $import->startParsing();
         }
     }
 
@@ -685,14 +685,14 @@ class ilObjSurveyQuestionPool extends ilObject
         $query_result = $ilDB->query("SELECT * FROM svy_qtype ORDER BY type_tag");
         while ($row = $ilDB->fetchAssoc($query_result)) {
             //array_push($questiontypes, $row["type_tag"]);
-            if ($row["plugin"] == 0) {
+            if ((int) $row["plugin"] === 0) {
                 $types[$lng->txt($row["type_tag"])] = $row;
             } else {
                 global $DIC;
 
                 $component_factory = $DIC["component.factory"];
                 foreach ($component_factory->getActivePluginsInSlot("svyq") as $pl) {
-                    if (strcmp($pl->getQuestionType(), $row["type_tag"]) == 0) {
+                    if (strcmp($pl->getQuestionType(), $row["type_tag"]) === 0) {
                         $types[$pl->getQuestionTypeTranslation()] = $row;
                     }
                 }
@@ -712,7 +712,7 @@ class ilObjSurveyQuestionPool extends ilObject
         ));
    
         $sorted = array();
-        $idx = sizeof($default_sorting);
+        $idx = count($default_sorting);
         foreach ($types as $caption => $item) {
             $type = $item["type_tag"];
             $item["caption"] = $caption;
@@ -741,7 +741,7 @@ class ilObjSurveyQuestionPool extends ilObject
     public static function _getQuestionClasses() : array
     {
         $classes = array_map(
-            function ($c) {
+            static function (array $c) : string {
                 return $c["type_tag"];
             },
             self::_getQuestiontypes()
@@ -765,11 +765,11 @@ class ilObjSurveyQuestionPool extends ilObject
         $result = $ilDB->query("SELECT * FROM svy_qtype");
         $types = array();
         while ($row = $ilDB->fetchAssoc($result)) {
-            if ($row["plugin"] == 0) {
+            if ((int) $row["plugin"] === 0) {
                 $types[$row['type_tag']] = $lng->txt($row["type_tag"]);
             } else {
                 foreach ($component_factory->getActivePluginsInSlot("svyq") as $pl) {
-                    if (strcmp($pl->getQuestionType(), $row["type_tag"]) == 0) {
+                    if (strcmp($pl->getQuestionType(), $row["type_tag"]) === 0) {
                         $types[$row['type_tag']] = $pl->getQuestionTypeTranslation();
                     }
                 }
@@ -898,17 +898,16 @@ class ilObjSurveyQuestionPool extends ilObject
     {
         $ilDB = $this->db;
 
-
         $qentries = $this->edit_manager->getQuestionsFromClipboard();
         if (count($qentries) > 0) {
             foreach ($qentries as $question_object) {
-                if (strcmp($question_object["action"], "move") == 0) {
+                if (strcmp($question_object["action"], "move") === 0) {
                     $result = $ilDB->queryF(
                         "SELECT obj_fi FROM svy_question WHERE question_id = %s",
                         array('integer'),
                         array($question_object["question_id"])
                     );
-                    if ($result->numRows() == 1) {
+                    if ($result->numRows() === 1) {
                         $row = $ilDB->fetchAssoc($result);
                         $source_questionpool = $row["obj_fi"];
                         if ($this->getId() != $source_questionpool) {

--- a/Modules/SurveyQuestionPool/classes/class.ilObjSurveyQuestionPoolGUI.php
+++ b/Modules/SurveyQuestionPool/classes/class.ilObjSurveyQuestionPoolGUI.php
@@ -145,8 +145,8 @@ class ilObjSurveyQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassI
                 }
                 break;
         }
-        if (strtolower($this->edit_request->getBaseClass()) != "iladministrationgui" &&
-            $this->getCreationMode() != true) {
+        if (strtolower($this->edit_request->getBaseClass()) !== "iladministrationgui" &&
+            $this->getCreationMode() !== true) {
             $this->tpl->printToStdout();
         }
     }
@@ -287,7 +287,7 @@ class ilObjSurveyQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassI
         
         // create an array of all checked checkboxes
         $checked_questions = $this->edit_request->getQuestionIds();
-        if (count($checked_questions) == 0) {
+        if (count($checked_questions) === 0) {
             $this->tpl->setOnScreenMessage('info', $this->lng->txt("qpl_delete_select_none"));
             $this->questionsObject();
             return;
@@ -374,7 +374,7 @@ class ilObjSurveyQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassI
         // check if file was uploaded
         $source = $_FILES["qtidoc"]["tmp_name"];
         $error = 0;
-        if (($source == 'none') || (!$source) || $_FILES["qtidoc"]["error"] > UPLOAD_ERR_OK) {
+        if (($source === 'none') || (!$source) || $_FILES["qtidoc"]["error"] > UPLOAD_ERR_OK) {
             $error = 1;
         }
         // check correct file type
@@ -389,7 +389,7 @@ class ilObjSurveyQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassI
             // copy uploaded file to import directory
             $full_path = $this->object->getImportDirectory() . "/" . $_FILES["qtidoc"]["name"];
 
-            ilUtil::moveUploadedFile(
+            ilFileUtils::moveUploadedFile(
                 $_FILES["qtidoc"]["tmp_name"],
                 $_FILES["qtidoc"]["name"],
                 $full_path
@@ -469,12 +469,12 @@ class ilObjSurveyQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassI
         $this->tpl->setOnScreenMessage('success', $this->lng->txt("msg_obj_modified"), true);
     }
     
-    protected function afterSave(ilObject $a_new_object) : void
+    protected function afterSave(ilObject $new_object) : void
     {
         // always send a message
         $this->tpl->setOnScreenMessage('success', $this->lng->txt("object_added"), true);
         
-        ilUtil::redirect("ilias.php?ref_id=" . $a_new_object->getRefId() .
+        ilUtil::redirect("ilias.php?ref_id=" . $new_object->getRefId() .
             "&baseClass=ilObjSurveyQuestionPoolGUI");
     }
 
@@ -525,7 +525,7 @@ class ilObjSurveyQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassI
     public function downloadExportFileObject() : void
     {
         $files = $this->edit_request->getFiles();
-        if (count($files) == 0) {
+        if (count($files) === 0) {
             $this->tpl->setOnScreenMessage('info', $this->lng->txt("no_checkbox"), true);
             $this->ctrl->redirect($this, "export");
         }
@@ -549,7 +549,7 @@ class ilObjSurveyQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassI
     public function confirmDeleteExportFileObject() : void
     {
         $files = $this->edit_request->getFiles();
-        if (count($files) == 0) {
+        if (count($files) === 0) {
             $this->tpl->setOnScreenMessage('info', $this->lng->txt("no_checkbox"), true);
             $this->ctrl->redirect($this, "export");
         }
@@ -583,12 +583,12 @@ class ilObjSurveyQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassI
             $file = basename($file);
             
             $exp_file = $export_dir . "/" . $file;
-            $exp_dir = $export_dir . "/" . substr($file, 0, strlen($file) - 4);
+            $exp_dir = $export_dir . "/" . substr($file, 0, -4);
             if (is_file($exp_file)) {
                 unlink($exp_file);
             }
             if (is_dir($exp_dir)) {
-                ilUtil::delDir($exp_dir);
+                ilFileUtils::delDir($exp_dir);
             }
         }
         $this->ctrl->redirect($this, "export");
@@ -643,7 +643,7 @@ class ilObjSurveyQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassI
             $upload = $_FILES["importfile"];
             $file = pathinfo($upload["name"]);
             $full_path = $newObj->getImportDirectory() . "/" . $upload["name"];
-            ilUtil::moveUploadedFile(
+            ilFileUtils::moveUploadedFile(
                 $upload["tmp_name"],
                 $upload["name"],
                 $full_path
@@ -776,9 +776,9 @@ class ilObjSurveyQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassI
         }
             
         // questions
-        $force_active = ($this->ctrl->getCmdClass() == "" &&
-            $this->ctrl->getCmd() != "properties" && $this->ctrl->getCmd() != "infoScreen") ||
-            $this->ctrl->getCmd() == "";
+        $force_active = ($this->ctrl->getCmdClass() === "" &&
+            $this->ctrl->getCmd() !== "properties" && $this->ctrl->getCmd() !== "infoScreen") ||
+            ($this->ctrl->getCmd() === "" || $this->ctrl->getCmd() === null);
         if (!$force_active) {
             $sort = $this->edit_request->getSort();
             if (count($sort) > 0) {

--- a/Modules/SurveyQuestionPool/classes/class.ilSurveySyncTableGUI.php
+++ b/Modules/SurveyQuestionPool/classes/class.ilSurveySyncTableGUI.php
@@ -155,7 +155,7 @@ class ilSurveySyncTableGUI extends ilTable2GUI
             
             $counter = 0;
             $path_full = $tree->getPathFull($ref_id);
-            if (sizeof($path_full)) {
+            if (count($path_full)) {
                 foreach ($path_full as $data) {
                     if (++$counter < (count($path_full) - 1)) {
                         continue;

--- a/Modules/SurveyQuestionPool/test/SplEditingGUIRequestTest.php
+++ b/Modules/SurveyQuestionPool/test/SplEditingGUIRequestTest.php
@@ -9,13 +9,6 @@ use PHPUnit\Framework\TestCase;
  */
 class SplEditingGUIRequestTest extends TestCase
 {
-    //protected $backupGlobals = false;
-
-    protected function setUp() : void
-    {
-        parent::setUp();
-    }
-
     protected function tearDown() : void
     {
     }
@@ -34,7 +27,7 @@ class SplEditingGUIRequestTest extends TestCase
         );
     }
 
-    public function testRefId()
+    public function testRefId() : void
     {
         $request = $this->getRequest(
             [
@@ -49,7 +42,7 @@ class SplEditingGUIRequestTest extends TestCase
         );
     }
 
-    public function testQuestionId()
+    public function testQuestionId() : void
     {
         $request = $this->getRequest(
             [
@@ -64,7 +57,7 @@ class SplEditingGUIRequestTest extends TestCase
         );
     }
 
-    public function testQuestionIds()
+    public function testQuestionIds() : void
     {
         $request = $this->getRequest(
             [
@@ -81,7 +74,7 @@ class SplEditingGUIRequestTest extends TestCase
         );
     }
 
-    public function testPreview()
+    public function testPreview() : void
     {
         $request = $this->getRequest(
             [
@@ -96,7 +89,7 @@ class SplEditingGUIRequestTest extends TestCase
         );
     }
 
-    public function testSelectedQuestionTypes()
+    public function testSelectedQuestionTypes() : void
     {
         $request = $this->getRequest(
             [
@@ -111,7 +104,7 @@ class SplEditingGUIRequestTest extends TestCase
         );
     }
 
-    public function testSort()
+    public function testSort() : void
     {
         $request = $this->getRequest(
             [
@@ -136,7 +129,7 @@ class SplEditingGUIRequestTest extends TestCase
         );
     }
 
-    public function testPhraseId()
+    public function testPhraseId() : void
     {
         $request = $this->getRequest(
             [
@@ -151,7 +144,7 @@ class SplEditingGUIRequestTest extends TestCase
         );
     }
 
-    public function testPhraseIds()
+    public function testPhraseIds() : void
     {
         $request = $this->getRequest(
             [

--- a/Modules/SurveyQuestionPool/test/ilModulesSurveyQuestionPoolSuite.php
+++ b/Modules/SurveyQuestionPool/test/ilModulesSurveyQuestionPoolSuite.php
@@ -22,7 +22,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilModulesSurveyQuestionPoolSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new self();
 


### PR DESCRIPTION
Hi @alex40724,

I completed the review of the `Modules/SurveyQuestionPool`.
This component looked very good, but of course I found some issues.

Results:
- [ ] The code style is `PSR-2 + X` compliant: 6 files have been changed by the `PHP-CS-FIXER`
- [ ] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`: If found 2 usages of `$_SESSION`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

I also fixed some trivial issues reported by my inspection profile.

--

Actions needed:
- [ ] Please eliminate the usage of `$_SESSION`
- [ ] Please check my inline comments. Some of them are just information, some require an action. You can use `TODO PHP8-REVIEW` when searching.

Best regards,
@mjansenDatabay