### PR TITLE
Fixed `UIServices::mainTemplate()` type-hint

### DIFF
--- a/src/DI/UIServices.php
+++ b/src/DI/UIServices.php
@@ -41,7 +41,7 @@ class UIServices
     /**
      * Get the ILIAS main template.
      *
-     * @return	\ilTemplate
+     * @return	\ilGlobalTemplateInterface
      */
     public function mainTemplate()
     {

--- a/src/DI/UIServices.php
+++ b/src/DI/UIServices.php
@@ -40,10 +40,8 @@ class UIServices
 
     /**
      * Get the ILIAS main template.
-     *
-     * @return	\ilGlobalTemplateInterface
      */
-    public function mainTemplate()
+    public function mainTemplate() : \ilGlobalTemplateInterface
     {
         return $this->container["tpl"];
     }


### PR DESCRIPTION
This annoyed me one time too many now, hence the PR. I don't think there is any case there's not an `ilGlobalTemplateInterface` instance returned right?