### PR TITLE
UICore/ilCtrl: Support classes without parents and children

### DIFF
--- a/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
+++ b/Services/UICore/classes/Setup/class.ilCtrlStructureReader.php
@@ -364,7 +364,7 @@ class ilCtrlStructureReader
     // ILCTRL DECLARATION FINDING
     // ----------------------
 
-    const IL_CTRL_DECLARATION_REGEXP = '~^.*@{WHICH}\s+([\w\\\\]+)\s*:\s*([\w\\\\]+(\s*,\s*[\w\\\\]+)*)\s*$~mi';
+    const IL_CTRL_DECLARATION_REGEXP = '~^.*@{WHICH}\s+([\w\\\\]+)\s*:\s*([\w\\\\]+(\s*,\s*[\w\\\\]+)*)?\s*$~mi';
 
     /**
      * @return null|(string,string[])
@@ -402,7 +402,7 @@ class ilCtrlStructureReader
 
         $declaration = [];
         foreach ($res[2] as $ls) {
-            foreach (explode(",", $ls) as $l) {
+            foreach (array_filter(explode(",", $ls)) as $l) {
                 $declaration[] = strtolower(trim($l));
             }
         }


### PR DESCRIPTION
Mantis Issue: https://mantis.ilias.de/view.php?id=31483

If a PR for ILIAS 8 is needed, I already fixed this in a hotfix branch: https://github.com/mjansenDatabay/ILIAS/commit/8dc514ee78195cbfbba9d4628c802dc9a55d3583