### PR TITLE
PHP 8: Review `Feeds`

### DIFF
--- a/Services/Feeds/classes/class.ilFeedItem.php
+++ b/Services/Feeds/classes/class.ilFeedItem.php
@@ -15,7 +15,6 @@
 
 /**
  * A FeedItem represents an item in a News Feed.
- *
  * @author Alexander Killing <killing@leifos.de>
  */
 class ilFeedItem
@@ -100,7 +99,7 @@ class ilFeedItem
     }
 
     /**
-     * @param	string	$a_date	Date (yyyy-mm-dd hh:mm:ss)
+     * @param string $a_date Date (yyyy-mm-dd hh:mm:ss)
      */
     public function setDate(string $a_date) : void
     {

--- a/Services/Feeds/classes/class.ilFeedWriter.php
+++ b/Services/Feeds/classes/class.ilFeedWriter.php
@@ -15,7 +15,6 @@
 
 /**
  * Feed writer class.
- *
  * how to make it "secure"
  * alternative 1:
  * - hash for all objects
@@ -23,7 +22,6 @@
  * - link includes ref id, user id, combined hash (kind of password)
  * - combined hash = hash(user hash + object hash)
  * - ilias checks whether ref id / user id / combined hash match
- *
  * @author Alexander Killing <killing@leifos.de>
  */
 class ilFeedWriter
@@ -46,12 +44,12 @@ class ilFeedWriter
         $this->tree = $DIC->repositoryTree();
         $this->lng = $DIC->language();
     }
-    
+
     public function setEncoding(string $a_enc) : void
     {
         $this->encoding = $a_enc;
     }
-    
+
     public function getEncoding() : string
     {
         return $this->encoding;
@@ -61,7 +59,7 @@ class ilFeedWriter
     {
         $this->ch_about = $a_ab;
     }
-    
+
     public function getChannelAbout() : string
     {
         return $this->ch_about;
@@ -71,7 +69,7 @@ class ilFeedWriter
     {
         $this->ch_title = $a_title;
     }
-    
+
     public function getChannelTitle() : string
     {
         return $this->ch_title;
@@ -81,7 +79,7 @@ class ilFeedWriter
     {
         $this->ch_link = $a_link;
     }
-    
+
     public function getChannelLink() : string
     {
         return $this->ch_link;
@@ -91,7 +89,7 @@ class ilFeedWriter
     {
         $this->ch_desc = $a_desc;
     }
-    
+
     public function getChannelDescription() : string
     {
         return $this->ch_desc;
@@ -101,7 +99,7 @@ class ilFeedWriter
     {
         $this->items[] = $a_item;
     }
-    
+
     public function getItems() : array
     {
         return $this->items;
@@ -118,19 +116,19 @@ class ilFeedWriter
     public function getFeed() : string
     {
         $this->tpl = new ilTemplate("tpl.rss_2_0.xml", true, true, "Services/Feeds");
-        
+
         $this->tpl->setVariable("XML", "xml");
         $this->tpl->setVariable("CONTENT_ENCODING", $this->getEncoding());
         $this->tpl->setVariable("CHANNEL_ABOUT", $this->getChannelAbout());
         $this->tpl->setVariable("CHANNEL_TITLE", $this->getChannelTitle());
         $this->tpl->setVariable("CHANNEL_LINK", $this->getChannelLink());
         $this->tpl->setVariable("CHANNEL_DESCRIPTION", $this->getChannelDescription());
-        
+
         foreach ($this->items as $item) {
             $this->tpl->setCurrentBlock("rdf_seq");
             $this->tpl->setVariable("RESOURCE", $item->getAbout());
             $this->tpl->parseCurrentBlock();
-            
+
             // Date
             if ($item->getDate() != "") {
                 $this->tpl->setCurrentBlock("date");
@@ -147,7 +145,7 @@ class ilFeedWriter
                 );
                 $this->tpl->parseCurrentBlock();
             }
-            
+
             // Enclosure
             if ($item->getEnclosureUrl() != "") {
                 $this->tpl->setCurrentBlock("enclosure");
@@ -156,7 +154,7 @@ class ilFeedWriter
                 $this->tpl->setVariable("ENC_TYPE", $item->getEnclosureType());
                 $this->tpl->parseCurrentBlock();
             }
-            
+
             $this->tpl->setCurrentBlock("item");
             $this->tpl->setVariable("ITEM_ABOUT", $item->getAbout());
             $this->tpl->setVariable("ITEM_TITLE", $item->getTitle());
@@ -164,11 +162,11 @@ class ilFeedWriter
             $this->tpl->setVariable("ITEM_LINK", $item->getLink());
             $this->tpl->parseCurrentBlock();
         }
-        
+
         $this->tpl->parseCurrentBlock();
         return $this->tpl->get();
     }
-    
+
     public function showFeed() : void
     {
         header("Content-Type: text/xml; charset=UTF-8;");

--- a/Services/Feeds/classes/class.ilFeedWriter.php
+++ b/Services/Feeds/classes/class.ilFeedWriter.php
@@ -107,9 +107,7 @@ class ilFeedWriter
 
     public function prepareStr(string $a_str) : string
     {
-        $a_str = str_replace("&", "&amp;", $a_str);
-        $a_str = str_replace("<", "&lt;", $a_str);
-        $a_str = str_replace(">", "&gt;", $a_str);
+        $a_str = str_replace(["&", "<", ">"], ["&amp;", "&lt;", "&gt;"], $a_str);
         return $a_str;
     }
 

--- a/Services/Feeds/classes/class.ilObjectFeedWriter.php
+++ b/Services/Feeds/classes/class.ilObjectFeedWriter.php
@@ -15,7 +15,6 @@
 
 /**
  * Feed writer for objects.
- *
  * @author Alexander Killing <killing@leifos.de>
  */
 class ilObjectFeedWriter extends ilFeedWriter
@@ -34,13 +33,13 @@ class ilObjectFeedWriter extends ilFeedWriter
         $this->lng = $DIC->language();
         $ilSetting = $DIC->settings();
         $lng = $DIC->language();
-        
+
         parent::__construct();
-        
+
         if ($a_ref_id <= 0) {
             return;
         }
-        
+
         $news_set = new ilSetting("news");
         if (!$news_set->get("enable_rss_for_internal")) {
             return;
@@ -69,7 +68,7 @@ class ilObjectFeedWriter extends ilFeedWriter
         if ($obj_type == "mcst") {
             if (!ilObjMediaCastAccess::_lookupOnline($obj_id)) {
                 $lng->loadLanguageModule("mcst");
-                
+
                 $feed_item = new ilFeedItem();
                 $feed_item->setTitle($lng->txt("mcst_media_cast_not_online"));
                 $feed_item->setDescription($lng->txt("mcst_media_cast_not_online_text"));
@@ -79,7 +78,6 @@ class ilObjectFeedWriter extends ilFeedWriter
                 return;
             }
         }
-
 
         $rss_period = ilNewsItem::_lookupRSSPeriod();
 
@@ -92,7 +90,7 @@ class ilObjectFeedWriter extends ilFeedWriter
         $i = 0;
         foreach ($items as $item) {
             $i++;
-            
+
             if ($a_purpose != false && $obj_type == "mcst") {
                 $mob = ilMediaItem::_getMediaItemsOfMObId($item["mob_id"], $a_purpose);
 
@@ -102,9 +100,9 @@ class ilObjectFeedWriter extends ilFeedWriter
             }
 
             $obj_title = ilObject::_lookupTitle($item["context_obj_id"]);
-            
+
             $feed_item = new ilFeedItem();
-            
+
             $title = ilNewsItem::determineNewsTitle(
                 $item["context_obj_type"],
                 $item["title"],
@@ -126,7 +124,8 @@ class ilObjectFeedWriter extends ilFeedWriter
                     ": " . $this->prepareStr($title));
             }
             $feed_item->setDescription($this->prepareStr(nl2br(
-                ilNewsItem::determineNewsContent($item["context_obj_type"], $item["content"], $item["content_text_is_lang_var"])
+                ilNewsItem::determineNewsContent($item["context_obj_type"], $item["content"],
+                    $item["content_text_is_lang_var"])
             )));
 
             // lm hack, not nice
@@ -156,10 +155,10 @@ class ilObjectFeedWriter extends ilFeedWriter
                 //echo "<br>".ILIAS_HTTP_PATH."/goto.php?client_id=".CLIENT_ID.
 //					"&amp;target=".$item["context_obj_type"]."_".$item["ref_id"];
             }
-    
+
             $feed_item->setAbout($feed_item->getLink() . "&amp;il_about_feed=" . $item["id"]);
             $feed_item->setDate($item["creation_date"]);
-            
+
             // Enclosure
             if ($item["content_type"] == NEWS_AUDIO &&
                 $item["mob_id"] > 0 && ilObject::_exists($item["mob_id"])) {
@@ -169,7 +168,7 @@ class ilObjectFeedWriter extends ilFeedWriter
                         $go_on = false;
                     }
                 }
-                
+
                 if ($go_on && isset($mob)) {
                     $url = ilObjMediaObject::_lookupItemPath($item["mob_id"], true, true, $mob["purpose"]);
                     $file = ilObjMediaObject::_lookupItemPath($item["mob_id"], false, false, $mob["purpose"]);
@@ -178,7 +177,7 @@ class ilObjectFeedWriter extends ilFeedWriter
                         $size = filesize($file);
                     }
                     $feed_item->setEnclosureUrl($url);
-                    $feed_item->setEnclosureType((isset($mob["format"]))?$mob["format"]:"audio/mpeg");
+                    $feed_item->setEnclosureType((isset($mob["format"])) ? $mob["format"] : "audio/mpeg");
                     $feed_item->setEnclosureLength($size);
                 }
             }

--- a/Services/Feeds/classes/class.ilObjectFeedWriter.php
+++ b/Services/Feeds/classes/class.ilObjectFeedWriter.php
@@ -124,12 +124,15 @@ class ilObjectFeedWriter extends ilFeedWriter
                     ": " . $this->prepareStr($title));
             }
             $feed_item->setDescription($this->prepareStr(nl2br(
-                ilNewsItem::determineNewsContent($item["context_obj_type"], $item["content"],
-                    $item["content_text_is_lang_var"])
+                ilNewsItem::determineNewsContent(
+                    $item["context_obj_type"],
+                    $item["content"],
+                    $item["content_text_is_lang_var"]
+                )
             )));
 
             // lm hack, not nice
-            if (in_array($item["context_obj_type"], array("lm")) && $item["context_sub_obj_type"] == "pg"
+            if ($item["context_obj_type"] == "lm" && $item["context_sub_obj_type"] == "pg"
                 && $item["context_sub_obj_id"] > 0) {
                 $feed_item->setLink(ILIAS_HTTP_PATH . "/goto.php?client_id=" . CLIENT_ID .
                     "&amp;target=pg_" . $item["context_sub_obj_id"] . "_" . $item["ref_id"]);
@@ -138,7 +141,7 @@ class ilObjectFeedWriter extends ilFeedWriter
                 $wptitle = ilWikiUtil::makeUrlTitle(ilWikiPage::lookupTitle($item["context_sub_obj_id"]));
                 $feed_item->setLink(ILIAS_HTTP_PATH . "/goto.php?client_id=" . CLIENT_ID .
                     "&amp;target=" . $item["context_obj_type"] . "_" . $item["ref_id"] . "_" . $wptitle);
-            } elseif (in_array($item["context_obj_type"], array("frm")) && $item["context_sub_obj_type"] == "pos"
+            } elseif ($item["context_obj_type"] == "frm" && $item["context_sub_obj_type"] == "pos"
                 && $item["context_sub_obj_id"] > 0) {
                 // frm hack, not nice
                 $thread_id = ilObjForumAccess::_getThreadForPosting($item["context_sub_obj_id"]);

--- a/Services/Feeds/classes/class.ilUserFeedWriter.php
+++ b/Services/Feeds/classes/class.ilUserFeedWriter.php
@@ -15,7 +15,6 @@
 
 /**
  * Feed writer for personal user feeds.
- *
  * @author Alexander Killing <killing@leifos.de>
  */
 class ilUserFeedWriter extends ilFeedWriter
@@ -35,18 +34,18 @@ class ilUserFeedWriter extends ilFeedWriter
         $ilSetting = $DIC->settings();
 
         parent::__construct();
-        
+
         if ($a_user_id == "" || $a_hash == "") {
             return;
         }
-        
+
         $news_set = new ilSetting("news");
         if (!$news_set->get("enable_rss_for_internal")) {
             return;
         }
 
         $hash = ilObjUser::_lookupFeedHash($a_user_id);
-        
+
         $rss_period = ilNewsItem::_lookupRSSPeriod();
 
         if ($a_hash == $hash) {
@@ -56,7 +55,7 @@ class ilUserFeedWriter extends ilFeedWriter
             } else {
                 $items = ilNewsItem::_getNewsItemsOfUser($a_user_id, true, true, $rss_period);
             }
-            
+
             if ($ilSetting->get('short_inst_name') != "") {
                 $this->setChannelTitle($ilSetting->get('short_inst_name'));
             } else {
@@ -91,7 +90,7 @@ class ilUserFeedWriter extends ilFeedWriter
 
                 // path
                 $loc = $this->getContextPath($item["ref_id"]);
-                
+
                 // title
                 if ($news_set->get("rss_title_format") == "news_obj") {
                     $feed_item->setTitle($this->prepareStr(str_replace("<br />", " ", $title)) .
@@ -101,10 +100,11 @@ class ilUserFeedWriter extends ilFeedWriter
                     $feed_item->setTitle($this->prepareStr($loc) . " " . $this->prepareStr($obj_title) .
                         ": " . $this->prepareStr(str_replace("<br />", " ", $title)));
                 }
-                                
+
                 // description
                 $content = $this->prepareStr(nl2br(
-                    ilNewsItem::determineNewsContent($item["context_obj_type"], $item["content"], $item["content_text_is_lang_var"])
+                    ilNewsItem::determineNewsContent($item["context_obj_type"], $item["content"],
+                        $item["content_text_is_lang_var"])
                 ));
                 $feed_item->setDescription($content);
 

--- a/Services/Feeds/classes/class.ilUserFeedWriter.php
+++ b/Services/Feeds/classes/class.ilUserFeedWriter.php
@@ -65,7 +65,6 @@ class ilUserFeedWriter extends ilFeedWriter
             $this->setChannelAbout(ILIAS_HTTP_PATH);
             $this->setChannelLink(ILIAS_HTTP_PATH);
             //$this->setChannelDescription("ILIAS Channel Description");
-            $i = 0;
             foreach ($items as $item) {
                 $obj_id = ilObject::_lookupObjId($item["ref_id"]);
                 $obj_type = ilObject::_lookupType($obj_id);
@@ -78,7 +77,6 @@ class ilUserFeedWriter extends ilFeedWriter
                     }
                 }
 
-                $i++;
                 $feed_item = new ilFeedItem();
                 $title = ilNewsItem::determineNewsTitle(
                     $item["context_obj_type"],
@@ -103,13 +101,16 @@ class ilUserFeedWriter extends ilFeedWriter
 
                 // description
                 $content = $this->prepareStr(nl2br(
-                    ilNewsItem::determineNewsContent($item["context_obj_type"], $item["content"],
-                        $item["content_text_is_lang_var"])
+                    ilNewsItem::determineNewsContent(
+                        $item["context_obj_type"],
+                        $item["content"],
+                        $item["content_text_is_lang_var"]
+                    )
                 ));
                 $feed_item->setDescription($content);
 
                 // lm page hack, not nice
-                if (in_array($item["context_obj_type"], array("lm")) && $item["context_sub_obj_type"] == "pg"
+                if ($item["context_obj_type"] == "lm" && $item["context_sub_obj_type"] == "pg"
                     && $item["context_sub_obj_id"] > 0) {
                     $feed_item->setLink(ILIAS_HTTP_PATH . "/goto.php?client_id=" . CLIENT_ID .
                         "&amp;target=pg_" . $item["context_sub_obj_id"] . "_" . $item["ref_id"]);
@@ -118,7 +119,7 @@ class ilUserFeedWriter extends ilFeedWriter
                     $wptitle = ilWikiPage::lookupTitle($item["context_sub_obj_id"]);
                     $feed_item->setLink(ILIAS_HTTP_PATH . "/goto.php?client_id=" . CLIENT_ID .
                         "&amp;target=" . $item["context_obj_type"] . "_" . $item["ref_id"] . "_" . urlencode($wptitle)); // #14629
-                } elseif (in_array($item["context_obj_type"], array("frm")) && $item["context_sub_obj_type"] == "pos"
+                } elseif ($item["context_obj_type"] == "frm" && $item["context_sub_obj_type"] == "pos"
                     && $item["context_sub_obj_id"] > 0) {
                     // frm hack, not nice
                     $thread_id = ilObjForumAccess::_getThreadForPosting($item["context_sub_obj_id"]);

--- a/Services/Feeds/test/FeedItemTest.php
+++ b/Services/Feeds/test/FeedItemTest.php
@@ -4,7 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Test clipboard repository
- *
  * @author Alexander Killing <killing@leifos.de>
  */
 class FeedItemTest extends TestCase

--- a/Services/Feeds/test/FeedItemTest.php
+++ b/Services/Feeds/test/FeedItemTest.php
@@ -8,13 +8,6 @@ use PHPUnit\Framework\TestCase;
  */
 class FeedItemTest extends TestCase
 {
-    //protected $backupGlobals = false;
-
-    protected function setUp() : void
-    {
-        parent::setUp();
-    }
-
     protected function tearDown() : void
     {
     }
@@ -22,7 +15,7 @@ class FeedItemTest extends TestCase
     /**
      * Test get HTML return an array
      */
-    public function testFeedItemProperties()
+    public function testFeedItemProperties() : void
     {
         $feed_item = new ilFeedItem();
 

--- a/Services/Feeds/test/ilServicesFeedsSuite.php
+++ b/Services/Feeds/test/ilServicesFeedsSuite.php
@@ -22,7 +22,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilServicesFeedsSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new self();
 


### PR DESCRIPTION
Hi @alex40724,

I completed the review of the `Services/Feeds` component.

Due to the estimated effort (0,3h) for the review (which is quite little) we only fixed the most relevant findings. There is still potential for other optimizations.

Results:
- [ ] The code style is `PSR-2 + X` compliant
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

Best  regards,
@nmatuschek 
 