### PR TITLE
TA 32027, re-enable key-checking on numeric input

### DIFF
--- a/Modules/Test/classes/class.ilTestScoringByQuestionsGUI.php
+++ b/Modules/Test/classes/class.ilTestScoringByQuestionsGUI.php
@@ -302,7 +302,7 @@ class ilTestScoringByQuestionsGUI extends ilTestScoringGUI
             if (!$correction_feedback['feedback']) {
                 $correction_feedback['feedback'] = [];
             }
-            if($correction_feedback['finalized_evaluation'] == 1) {
+            if ($correction_feedback['finalized_evaluation'] == 1) {
                 $correction_feedback['finalized_evaluation'] = $this->lng->txt('yes');
             } else {
                 $correction_feedback['finalized_evaluation'] = $this->lng->txt('no');
@@ -513,6 +513,7 @@ class ilTestScoringByQuestionsGUI extends ilTestScoringGUI
         $reached_points_form->setMinValue(0);
         $reached_points_form->setDisabled($disable);
         $reached_points_form->setValue($reached_points);
+        $reached_points_form->setClientSideValidation(true);
         $form->addItem($reached_points_form);
 
         $hidden_points = new ilHiddenInputGUI('qst_max_points');

--- a/Services/Form/classes/class.ilNumberInputGUI.php
+++ b/Services/Form/classes/class.ilNumberInputGUI.php
@@ -378,10 +378,8 @@ class ilNumberInputGUI extends ilSubEnabledFormPropertyGUI
                 " disabled=\"disabled\""
             );
         }
-        
-        /*
-        $tpl->setVariable("JS_DECIMALS_ALLOWED", (int)$this->areDecimalsAllowed());
-        */
+
+        $tpl->setVariable("JS_DECIMALS_ALLOWED", (int) $this->areDecimalsAllowed());
         
         // constraints
         if ($this->areDecimalsAllowed() && $this->getDecimals() > 0) {

--- a/Services/Form/classes/class.ilNumberInputGUI.php
+++ b/Services/Form/classes/class.ilNumberInputGUI.php
@@ -25,6 +25,7 @@ class ilNumberInputGUI extends ilSubEnabledFormPropertyGUI
     protected $maxvalue_visible = false;
     protected $decimals;
     protected $allow_decimals = false;
+    protected $client_side_validation = false;
     
     /**
     * Constructor
@@ -379,8 +380,12 @@ class ilNumberInputGUI extends ilSubEnabledFormPropertyGUI
             );
         }
 
-        $tpl->setVariable("JS_DECIMALS_ALLOWED", (int) $this->areDecimalsAllowed());
-        
+        if ($this->client_side_validation) {
+            $tpl->setVariable("JS_DECIMALS_ALLOWED", (int) $this->areDecimalsAllowed());
+            $tpl->setVariable("JS_ID", $this->getFieldId());
+        }
+
+
         // constraints
         if ($this->areDecimalsAllowed() && $this->getDecimals() > 0) {
             $constraints = $lng->txt("form_format") . ": ###." . str_repeat("#", $this->getDecimals());
@@ -418,5 +423,10 @@ class ilNumberInputGUI extends ilSubEnabledFormPropertyGUI
         if ($value != "") {
             return (int) $value;
         }
+    }
+
+    public function setClientSideValidation(bool $validate) : void
+    {
+        $this->client_side_validation = $validate;
     }
 }

--- a/Services/Form/js/Form.js
+++ b/Services/Form/js/Form.js
@@ -192,22 +192,24 @@ il.Form = {
 	// initialisation for number fields
 	initNumericCheck: function (id, decimals_allowed) {
 		var current;
-		
+	
 		$('#' + il.Form.escapeSelector(id)).keydown(function (event) {
-
 			// #10562
 			var kcode = event.which;
 			var is_shift = event.shiftKey;
 			var is_ctrl = event.ctrlKey;
-			
-			if (kcode == 190) {
+
+			if (kcode == 190 || kcode == 188) {
 				// decimals are not allowed
 				if (decimals_allowed == undefined || decimals_allowed == 0) {
 					event.preventDefault();
 				} else {
 					// decimal point is only allowed once
 					current = $('#' + id).val();
-					if (current.indexOf('.') > -1) {
+					if (
+						current.indexOf('.') > -1 ||
+						current.indexOf(',') > -1
+					) {
 						event.preventDefault();
 					}
 				}

--- a/Services/Form/templates/default/tpl.prop_number.html
+++ b/Services/Form/templates/default/tpl.prop_number.html
@@ -2,10 +2,9 @@
 <div class="form-inline">
 		<input style="text-align:right;" class="form-control" type="text" size="{SIZE}" id="{ID}" maxlength="{MAXLENGTH}" name="{POST_VAR}" <!-- BEGIN prop_number_propval -->value="{PROPERTY_VALUE}" <!-- END prop_number_propval -->{DISABLED} {REQUIRED} /> {INPUT_SUFFIX}
 		<div class="help-block">{TXT_NUMBER_CONSTRAINTS}</div>
-		<!--
+	
 		<script language="JavaScript" type="text/javascript">
-		il.Form.initNumericCheck("{ID}", "{JS_DECIMALS_ALLOWED}");
+			il.Form.initNumericCheck("{ID}", "{JS_DECIMALS_ALLOWED}");
 		</script>
-		-->
 </div>
 <!-- END prop_number -->

--- a/Services/Form/templates/default/tpl.prop_number.html
+++ b/Services/Form/templates/default/tpl.prop_number.html
@@ -3,8 +3,11 @@
 		<input style="text-align:right;" class="form-control" type="text" size="{SIZE}" id="{ID}" maxlength="{MAXLENGTH}" name="{POST_VAR}" <!-- BEGIN prop_number_propval -->value="{PROPERTY_VALUE}" <!-- END prop_number_propval -->{DISABLED} {REQUIRED} /> {INPUT_SUFFIX}
 		<div class="help-block">{TXT_NUMBER_CONSTRAINTS}</div>
 	
-		<script language="JavaScript" type="text/javascript">
-			il.Form.initNumericCheck("{ID}", "{JS_DECIMALS_ALLOWED}");
-		</script>
 </div>
 <!-- END prop_number -->
+
+<!-- BEGIN prop_number_client_validation -->
+<script language="JavaScript" type="text/javascript">
+	il.Form.initNumericCheck("{JS_ID}", "{JS_DECIMALS_ALLOWED}");
+</script>
+<!-- END prop_number_client_validation -->


### PR DESCRIPTION
re-enable input checking (while typing) with numeric inputs.
fixes https://mantis.ilias.de/view.php?id=32027, but probably there were reasons for taking this out...