### PR TITLE
PHP 8: Review `PrivacySecurity`

### DIFF
--- a/Services/PrivacySecurity/classes/Setup/class.ilPrivacySecurityConfigStoredObjective.php
+++ b/Services/PrivacySecurity/classes/Setup/class.ilPrivacySecurityConfigStoredObjective.php
@@ -12,11 +12,11 @@ use ILIAS\Setup;
 class ilPrivacySecurityConfigStoredObjective implements Setup\Objective
 {
     /**
-     * @var    \ilPrivacySecuritySetupConfig
+     * @var    ilPrivacySecuritySetupConfig
      */
-    protected $config;
+    protected ilPrivacySecuritySetupConfig $config;
 
-    public function __construct(\ilPrivacySecuritySetupConfig $config)
+    public function __construct(ilPrivacySecuritySetupConfig $config)
     {
         $this->config = $config;
     }
@@ -39,8 +39,8 @@ class ilPrivacySecurityConfigStoredObjective implements Setup\Objective
     public function getPreconditions(Setup\Environment $environment) : array
     {
         return [
-            new \ilIniFilesPopulatedObjective(),
-            new \ilSettingsFactoryExistsObjective()
+            new ilIniFilesPopulatedObjective(),
+            new ilSettingsFactoryExistsObjective()
         ];
     }
 

--- a/Services/PrivacySecurity/classes/Setup/class.ilPrivacySecuritySetupAgent.php
+++ b/Services/PrivacySecurity/classes/Setup/class.ilPrivacySecuritySetupAgent.php
@@ -13,7 +13,7 @@ class ilPrivacySecuritySetupAgent implements Setup\Agent
     /**
      * @var Refinery\Factory
      */
-    protected $refinery;
+    protected Refinery\Factory $refinery;
 
     public function __construct(Refinery\Factory $refinery)
     {
@@ -33,7 +33,7 @@ class ilPrivacySecuritySetupAgent implements Setup\Agent
      */
     public function getConfigInput(Setup\Config $config = null) : UI\Component\Input\Field\Input
     {
-        throw new \LogicException("Not yet implemented.");
+        throw new LogicException("Not yet implemented.");
     }
 
     /**
@@ -42,7 +42,7 @@ class ilPrivacySecuritySetupAgent implements Setup\Agent
     public function getArrayToConfigTransformation() : Refinery\Transformation
     {
         return $this->refinery->custom()->transformation(function ($data) {
-            return new \ilPrivacySecuritySetupConfig(
+            return new ilPrivacySecuritySetupConfig(
                 (bool) ($data["https_enabled"] ?? false)
             );
         });

--- a/Services/PrivacySecurity/classes/Setup/class.ilPrivacySecuritySetupConfig.php
+++ b/Services/PrivacySecurity/classes/Setup/class.ilPrivacySecuritySetupConfig.php
@@ -9,7 +9,7 @@ class ilPrivacySecuritySetupConfig implements Setup\Config
     /**
      * @var bool
      */
-    protected $force_https_on_login;
+    protected bool $force_https_on_login;
 
     public function __construct(bool $force_https_on_login = false)
     {

--- a/Services/PrivacySecurity/classes/class.ilExportFieldsInfo.php
+++ b/Services/PrivacySecurity/classes/class.ilExportFieldsInfo.php
@@ -21,8 +21,8 @@ class ilExportFieldsInfo
 {
     private static array $instances = [];
 
-    private \ilSetting $settings;
-    private \ilLanguage $lng;
+    private ilSetting $settings;
+    private ilLanguage $lng;
     private string $obj_type = '';
     private array $possible_fields = array();
 
@@ -44,7 +44,7 @@ class ilExportFieldsInfo
     /**
      * Get Singleton Instance
      */
-    public static function _getInstanceByType($a_type) : \ilExportFieldsInfo
+    public static function _getInstanceByType($a_type) : ilExportFieldsInfo
     {
         if (!isset(self::$instances[$a_type])) {
             self::$instances[$a_type] = new self($a_type);
@@ -171,7 +171,7 @@ class ilExportFieldsInfo
      */
     private function read() : void
     {
-        $profile = new \ilUserProfile();
+        $profile = new ilUserProfile();
         $profile->skipGroup('settings');
 
         foreach ($profile->getStandardFields() as $key => $data) {

--- a/Services/PrivacySecurity/classes/class.ilExportFieldsInfo.php
+++ b/Services/PrivacySecurity/classes/class.ilExportFieldsInfo.php
@@ -44,7 +44,7 @@ class ilExportFieldsInfo
     /**
      * Get Singleton Instance
      */
-    public static function _getInstanceByType($a_type) : ilExportFieldsInfo
+    public static function _getInstanceByType(string $a_type) : ilExportFieldsInfo
     {
         if (!isset(self::$instances[$a_type])) {
             self::$instances[$a_type] = new self($a_type);
@@ -91,7 +91,7 @@ class ilExportFieldsInfo
     /**
      * Get selectable fields
      */
-    public function getSelectableFieldsInfo($a_obj_id) : array
+    public function getSelectableFieldsInfo(int $a_obj_id) : array
     {
         global $DIC;
 

--- a/Services/PrivacySecurity/classes/class.ilObjPrivacySecurityAccess.php
+++ b/Services/PrivacySecurity/classes/class.ilObjPrivacySecurityAccess.php
@@ -16,7 +16,7 @@
  * @author  Stefan Meyer <meyer@leifos.de>
  * @ingroup ServicesPrivacySecurity
  */
-class ilObjPrivacySecurityAccess extends \ilObjectAccess
+class ilObjPrivacySecurityAccess extends ilObjectAccess
 {
     /**
      * Overwritten checkAccess

--- a/Services/PrivacySecurity/classes/class.ilObjPrivacySecurityGUI.php
+++ b/Services/PrivacySecurity/classes/class.ilObjPrivacySecurityGUI.php
@@ -114,7 +114,7 @@ class ilObjPrivacySecurityGUI extends ilObjectGUI
         }
     }
 
-    protected function initPrivacyForm() : \ilPropertyFormGUI
+    protected function initPrivacyForm() : ilPropertyFormGUI
     {
         $privacy = ilPrivacySettings::getInstance();
 
@@ -177,7 +177,7 @@ class ilObjPrivacySecurityGUI extends ilObjectGUI
         $check->setValue('crs_access_times');
         $group->addOption($check);
         $form->addItem($group);
-        $check = new \ilCheckboxOption();
+        $check = new ilCheckboxOption();
         $check->setTitle($this->lng->txt('ps_participants_list_courses'));
         $check->setValue('participants_list_courses');
         $group->addOption($check);
@@ -198,9 +198,9 @@ class ilObjPrivacySecurityGUI extends ilObjectGUI
      * Show Privacy settings
      * @access public
      */
-    public function showPrivacy(?\ilPropertyFormGUI $form = null) : void
+    public function showPrivacy(?ilPropertyFormGUI $form = null) : void
     {
-        if (!$form instanceof \ilPropertyFormGUI) {
+        if (!$form instanceof ilPropertyFormGUI) {
             $form = $this->initPrivacyForm();
         }
         $this->tpl->setContent($form->getHTML());
@@ -265,7 +265,7 @@ class ilObjPrivacySecurityGUI extends ilObjectGUI
         $code = $privacy->validate();
         // if error code != 0, display error and do not save
         if ($code !== 0) {
-            $msg = $this->getErrorMessage($code);
+            $msg = self::getErrorMessage($code);
             $this->tpl->setOnScreenMessage('failure', $msg);
             $form->setValuesByPost();
             $this->showPrivacy($form);
@@ -349,7 +349,7 @@ class ilObjPrivacySecurityGUI extends ilObjectGUI
                                                   ilAdministrationSettingsFormHandler::VALUE_BOOL
                     ),
                     'ps_participants_list_courses' => [$privacy->participantsListInCoursesEnabled(),
-                                                       \ilAdministrationSettingsFormHandler::VALUE_BOOL
+                                                       ilAdministrationSettingsFormHandler::VALUE_BOOL
                     ]
                 );
                 $fields = [

--- a/Services/PrivacySecurity/classes/class.ilPrivacySettings.php
+++ b/Services/PrivacySecurity/classes/class.ilPrivacySettings.php
@@ -19,9 +19,9 @@
  */
 class ilPrivacySettings
 {
-    private static ?\ilPrivacySettings $instance = null;
-    private \ilDBInterface $db;
-    private \ilSetting $settings;
+    private static ?ilPrivacySettings $instance = null;
+    private ilDBInterface $db;
+    private ilSetting $settings;
 
     private bool $export_course;
     private bool $export_group;
@@ -59,9 +59,9 @@ class ilPrivacySettings
         $this->read();
     }
 
-    public static function getInstance() : \ilPrivacySettings
+    public static function getInstance() : ilPrivacySettings
     {
-        if (!self::$instance instanceof \ilPrivacySettings) {
+        if (!self::$instance instanceof ilPrivacySettings) {
             self::$instance = new self();
         }
         return self::$instance;
@@ -181,7 +181,7 @@ class ilPrivacySettings
     /**
      * write access to property anonymous fora
      */
-    public function enableAnonymousFora(bool $a_status)
+    public function enableAnonymousFora(bool $a_status) : void
     {
         $this->anonymous_fora = $a_status;
     }
@@ -213,7 +213,7 @@ class ilPrivacySettings
     /**
      * write access to property rbac log age
      */
-    public function setRbacLogAge(int $a_age)
+    public function setRbacLogAge(int $a_age) : void
     {
         $this->rbac_log_age = $a_age;
     }
@@ -290,7 +290,7 @@ class ilPrivacySettings
     /**
      * show course access times
      */
-    public function showCourseAccessTimes(bool $a_status)
+    public function showCourseAccessTimes(bool $a_status) : void
     {
         $this->show_crs_access_times = $a_status;
     }
@@ -399,7 +399,7 @@ class ilPrivacySettings
 
     /**
      * validate settings
-     * @return 0, if everything is ok, an error code otherwise
+     * @return int 0, if everything is ok, an error code otherwise
      */
     public function validate() : int
     {

--- a/Services/PrivacySecurity/classes/class.ilRobotSettings.php
+++ b/Services/PrivacySecurity/classes/class.ilRobotSettings.php
@@ -19,7 +19,7 @@
 class ilRobotSettings
 {
     private bool $open_robots = false;
-    private \ilSetting $settings;
+    private ilSetting $settings;
     private static ?self $instance = null;
 
     /**
@@ -36,9 +36,9 @@ class ilRobotSettings
     /**
      * get singleton instance
      */
-    public static function getInstance()
+    public static function getInstance() : ?\ilRobotSettings
     {
-        if (!self::$instance instanceof \ilRobotSettings) {
+        if (!self::$instance instanceof ilRobotSettings) {
             self::$instance = new self();
         }
         return self::$instance;
@@ -56,7 +56,7 @@ class ilRobotSettings
      * Read settings
      * @access private
      */
-    private function read()
+    private function read() : void
     {
         $this->open_robots = (bool) $this->settings->get('open_google', null);
     }

--- a/Services/PrivacySecurity/classes/class.ilSecuritySettings.php
+++ b/Services/PrivacySecurity/classes/class.ilSecuritySettings.php
@@ -35,9 +35,9 @@ class ilSecuritySettings
     public const SECURITY_SETTINGS_ERR_CODE_PASSWORD_MAX_LENGTH_LESS_MIN_LENGTH = 10;
 
     private static ?self $instance = null;
-    private \ilDBInterface $db;
-    private \ilSetting $settings;
-    private \ilRbacReview $review;
+    private ilDBInterface $db;
+    private ilSetting $settings;
+    private ilRbacReview $review;
     protected ilHTTPS $https;
 
     private bool $https_enable;
@@ -87,7 +87,7 @@ class ilSecuritySettings
      * @return ilSecuritySettings  instance
      * @access public
      */
-    public static function _getInstance() : \ilSecuritySettings
+    public static function _getInstance() : ilSecuritySettings
     {
         if (!self::$instance instanceof self) {
             self::$instance = new self();
@@ -338,9 +338,10 @@ class ilSecuritySettings
 
     /**
      * validate settings
-     * @return int 0, if everything is ok, an error code otherwise
+     * @param ilPropertyFormGUI|null $a_form
+     * @return int|null 0, if everything is ok, an error code otherwise
      */
-    public function validate(\ilPropertyFormGUI $a_form = null) : ?int
+    public function validate(ilPropertyFormGUI $a_form = null) : ?int
     {
         $code = null;
 

--- a/Services/PrivacySecurity/classes/class.ilSecuritySettingsChecker.php
+++ b/Services/PrivacySecurity/classes/class.ilSecuritySettingsChecker.php
@@ -70,8 +70,8 @@ class ilSecuritySettingsChecker
         
         if ($security->getPasswordNumberOfUppercaseChars() > 0) {
             if (ilStr::strLen($a_passwd) - ilStr::strLen(
-                    preg_replace('/[A-Z]/', '', $a_passwd)
-                ) < $security->getPasswordNumberOfUppercaseChars()) {
+                preg_replace('/[A-Z]/', '', $a_passwd)
+            ) < $security->getPasswordNumberOfUppercaseChars()) {
                 $errors[] = sprintf(
                     $lng->txt('password_must_contain_ucase_chars'),
                     $security->getPasswordNumberOfUppercaseChars()
@@ -82,8 +82,8 @@ class ilSecuritySettingsChecker
         
         if ($security->getPasswordNumberOfLowercaseChars() > 0) {
             if (ilStr::strLen($a_passwd) - ilStr::strLen(
-                    preg_replace('/[a-z]/', '', $a_passwd)
-                ) < $security->getPasswordNumberOfLowercaseChars()) {
+                preg_replace('/[a-z]/', '', $a_passwd)
+            ) < $security->getPasswordNumberOfLowercaseChars()) {
                 $errors[] = sprintf(
                     $lng->txt('password_must_contain_lcase_chars'),
                     $security->getPasswordNumberOfLowercaseChars()
@@ -125,7 +125,7 @@ class ilSecuritySettingsChecker
      * @param bool $a_only_special_chars
      * @return string
      */
-    public static function getPasswordValidChars(bool $a_as_regex = true, bool $a_only_special_chars = false)
+    public static function getPasswordValidChars(bool $a_as_regex = true, bool $a_only_special_chars = false) : ?string
     {
         if ($a_as_regex) {
             if ($a_only_special_chars) {
@@ -140,13 +140,13 @@ class ilSecuritySettingsChecker
     
     /**
      * @param string                 $clear_text_password The validated clear text password
-     * @param ilObjUser|string|array $user                Could be an instance of ilObjUser, the users' loginname as string, or an array containing the users' loginname and id
+     * @param array|ilObjUser|string $user                Could be an instance of ilObjUser, the users' loginname as string, or an array containing the users' loginname and id
      * @param string|null            $error_language_variable
      * @return bool
      */
     public static function isPasswordValidForUserContext(
         string $clear_text_password,
-        $user,
+        array|ilObjUser|string $user,
         ?string &$error_language_variable = null
     ) : bool {
         $security = ilSecuritySettings::_getInstance();
@@ -175,15 +175,14 @@ class ilSecuritySettingsChecker
         
         return true;
     }
-    
+
     /**
      *    infotext for ilPasswordInputGUI setInfo()
-     *
-     * @return <string>  info about allowed chars for password
+     * @return string info about allowed chars for password
      * @static
      * @global <type> $lng
      */
-    public static function getPasswordRequirementsInfo()
+    public static function getPasswordRequirementsInfo() : string
     {
         global $DIC;
         
@@ -236,7 +235,7 @@ class ilSecuritySettingsChecker
      * @static
      *
      */
-    public static function generatePasswords($a_number)
+    public static function generatePasswords($a_number) : array
     {
         $ret = [];
         srand((double) microtime() * 1000000);
@@ -253,7 +252,7 @@ class ilSecuritySettingsChecker
             if ($min > $max) {
                 $max = $max + 1;
             }
-            $random = new \ilRandom();
+            $random = new ilRandom();
             $length = $random->int($min, $max);
             $next = $random->int(1, 2);
             $vowels = "aeiou";

--- a/Services/PrivacySecurity/classes/class.ilSecuritySettingsChecker.php
+++ b/Services/PrivacySecurity/classes/class.ilSecuritySettingsChecker.php
@@ -146,7 +146,7 @@ class ilSecuritySettingsChecker
      */
     public static function isPasswordValidForUserContext(
         string $clear_text_password,
-        array|ilObjUser|string $user,
+        $user,
         ?string &$error_language_variable = null
     ) : bool {
         $security = ilSecuritySettings::_getInstance();
@@ -235,7 +235,7 @@ class ilSecuritySettingsChecker
      * @static
      *
      */
-    public static function generatePasswords($a_number) : array
+    public static function generatePasswords(int $a_number) : array
     {
         $ret = [];
         srand((double) microtime() * 1000000);


### PR DESCRIPTION
Dear @smeyer-ilias 

I completed the review of the `Services/DidacticTemplate` component.

Results:

- [ ] The code style is `PSR-2 + X` compliant
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [ ] There is a `Unit Test Suite` with at least one unit test
- [ ] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

--

Actions needed:
- [ ] Please add a unit test suite with at least one passing unit test

Best regards,
@nmatuschek 
