### PR TITLE
PHP 8: Code Review `OpenIDConnect`

### DIFF
--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -1929,7 +1929,11 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
         switch ($status->getStatus()) {
             case ilAuthStatus::STATUS_AUTHENTICATED:
                 $this->logger->debug('Authentication successful; Redirecting to starting page.');
-                ilInitialisation::redirectToStartingPage();
+                if ($credentials->getRedirectionTarget()) {
+                    ilInitialisation::redirectToStartingPage($credentials->getRedirectionTarget());
+                } else {
+                    ilInitialisation::redirectToStartingPage();
+                }
                 return;
 
             case ilAuthStatus::STATUS_AUTHENTICATION_FAILED:

--- a/Services/OpenIdConnect/classes/class.ilAuthFrontendCredentialsOpenIdConnect.php
+++ b/Services/OpenIdConnect/classes/class.ilAuthFrontendCredentialsOpenIdConnect.php
@@ -20,14 +20,21 @@
 class ilAuthFrontendCredentialsOpenIdConnect extends ilAuthFrontendCredentials
 {
     private const SESSION_TARGET = 'oidc_target';
+    private const QUERY_PARAM_TARGET = 'target';
 
     private ilOpenIdConnectSettings $settings;
     private ?string $target = null;
 
     public function __construct()
     {
+        global $DIC;
+
         parent::__construct();
         $this->settings = ilOpenIdConnectSettings::getInstance();
+        $httpquery = $DIC->http()->wrapper()->query();
+        if ($httpquery->has(self::QUERY_PARAM_TARGET)) {
+            $this->target = $httpquery->retrieve(self::QUERY_PARAM_TARGET, $DIC->refinery()->to()->string());
+        }
     }
 
     protected function getSettings() : ilOpenIdConnectSettings
@@ -35,7 +42,7 @@ class ilAuthFrontendCredentialsOpenIdConnect extends ilAuthFrontendCredentials
         return $this->settings;
     }
 
-    public function getRedirectionTarget() : string
+    public function getRedirectionTarget() : ?string
     {
         return $this->target;
     }
@@ -50,8 +57,7 @@ class ilAuthFrontendCredentialsOpenIdConnect extends ilAuthFrontendCredentials
 
     protected function parseRedirectionTarget() : void
     {
-        if (!empty($_GET['target'])) { // TODO PHP8-REVIEW Please eliminate this.
-            $this->target = $_GET['target']; // TODO PHP8-REVIEW Please eliminate this.
+        if ($this->target) {
             ilSession::set(self::SESSION_TARGET, $this->target);
         } elseif (ilSession::get(self::SESSION_TARGET)) {
             $this->target = ilSession::get(self::SESSION_TARGET);

--- a/Services/OpenIdConnect/classes/class.ilAuthFrontendCredentialsOpenIdConnect.php
+++ b/Services/OpenIdConnect/classes/class.ilAuthFrontendCredentialsOpenIdConnect.php
@@ -17,12 +17,11 @@
 /**
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
  */
-class ilAuthFrontendCredentialsOpenIdConnect extends ilAuthFrontendCredentials implements ilAuthCredentials
+class ilAuthFrontendCredentialsOpenIdConnect extends ilAuthFrontendCredentials
 {
-    const SESSION_TARGET = 'oidc_target';
+    private const SESSION_TARGET = 'oidc_target';
 
     private ilOpenIdConnectSettings $settings;
-
     private ?string $target = null;
 
     public function __construct()
@@ -41,9 +40,6 @@ class ilAuthFrontendCredentialsOpenIdConnect extends ilAuthFrontendCredentials i
         return $this->target;
     }
 
-    /**
-     * Init credentials from request
-     */
     public function initFromRequest() : void
     {
         $this->setUsername('');
@@ -54,11 +50,11 @@ class ilAuthFrontendCredentialsOpenIdConnect extends ilAuthFrontendCredentials i
 
     protected function parseRedirectionTarget() : void
     {
-        if (!empty($_GET['target'])) {
-            $this->target = $_GET['target'];
-            \ilSession::set(self::SESSION_TARGET, $this->target);
+        if (!empty($_GET['target'])) { // TODO PHP8-REVIEW Please eliminate this.
+            $this->target = $_GET['target']; // TODO PHP8-REVIEW Please eliminate this.
+            ilSession::set(self::SESSION_TARGET, $this->target);
         } elseif (ilSession::get(self::SESSION_TARGET)) {
-            $this->target = \ilSession::get(self::SESSION_TARGET);
+            $this->target = ilSession::get(self::SESSION_TARGET);
         }
     }
 }

--- a/Services/OpenIdConnect/classes/class.ilOpenIdConnectAppEventListener.php
+++ b/Services/OpenIdConnect/classes/class.ilOpenIdConnectAppEventListener.php
@@ -32,14 +32,11 @@ class ilOpenIdConnectAppEventListener implements ilAppEventListener
      */
     public static function handleEvent(string $a_component, string $a_event, array $a_parameter) : void
     {
-        ilLoggerFactory::getLogger('root')->info($a_component . ' : ' . $a_event);
-        if ($a_component === 'Services/Authentication') {
-            ilLoggerFactory::getLogger('root')->info($a_component . ' : ' . $a_event);
-            if ($a_event === 'beforeLogout') {
-                ilLoggerFactory::getLogger('root')->info($a_component . ' : ' . $a_event);
-                $listener = new self();
-                $listener->handleLogoutFor($a_parameter['user_id']);
-            }
+        global $DIC;
+        $DIC->logger()->auth()->debug($a_component . ' : ' . $a_event);
+        if (($a_component === 'Services/Authentication') && $a_event === 'beforeLogout') {
+            $listener = new self();
+            $listener->handleLogoutFor($a_parameter['user_id']);
         }
     }
 }

--- a/Services/OpenIdConnect/classes/class.ilOpenIdConnectAppEventListener.php
+++ b/Services/OpenIdConnect/classes/class.ilOpenIdConnectAppEventListener.php
@@ -19,42 +19,23 @@
  *
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
  */
-class ilOpenIdConnectAppEventListener
+class ilOpenIdConnectAppEventListener implements ilAppEventListener
 {
-    private ilLogger $logger;
-    
-    /**
-     * Constructor
-     */
-    public function __construct()
-    {
-        global $DIC;
-        $this->logger = $DIC->logger()->auth();
-    }
-
-    /**
-     * @param int $user_id
-     */
-    protected function handleLogoutFor(int $user_id)
+    protected function handleLogoutFor(int $user_id) : void
     {
         $provider = new ilAuthProviderOpenIdConnect(new ilAuthFrontendCredentials());
         $provider->handleLogout();
     }
-    
 
     /**
-    * Handle an event in a listener.
-    *
-    * @param	string	$a_component	component, e.g. "Modules/Forum" or "Services/User"
-    * @param	string	$a_event		event e.g. "createUser", "updateUser", "deleteUser", ...
-    * @param	array	$a_parameter	parameter array (assoc), array("name" => ..., "phone_office" => ...)
-    */
-    public static function handleEvent($a_component, $a_event, $a_parameter)
+     * @inheritDoc
+     */
+    public static function handleEvent(string $a_component, string $a_event, array $a_parameter) : void
     {
         ilLoggerFactory::getLogger('root')->info($a_component . ' : ' . $a_event);
-        if ($a_component == 'Services/Authentication') {
+        if ($a_component === 'Services/Authentication') {
             ilLoggerFactory::getLogger('root')->info($a_component . ' : ' . $a_event);
-            if ($a_event == 'beforeLogout') {
+            if ($a_event === 'beforeLogout') {
                 ilLoggerFactory::getLogger('root')->info($a_component . ' : ' . $a_event);
                 $listener = new self();
                 $listener->handleLogoutFor($a_parameter['user_id']);

--- a/Services/OpenIdConnect/classes/class.ilOpenIdConnectSettings.php
+++ b/Services/OpenIdConnect/classes/class.ilOpenIdConnectSettings.php
@@ -17,63 +17,47 @@
 /**
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
  */
+
 use ILIAS\Filesystem\Filesystem;
 
 class ilOpenIdConnectSettings
 {
-    const FILE_STORAGE = 'openidconnect/login_form_image';
-    const STORAGE_ID = 'oidc';
-    const DEFAULT_SCOPE = 'openid';
+    private const STORAGE_ID = 'oidc';
 
-    const LOGIN_ELEMENT_TYPE_TXT = 0;
-    const LOGIN_ELEMENT_TYPE_IMG = 1;
+    public const FILE_STORAGE = 'openidconnect/login_form_image';
+    public const DEFAULT_SCOPE = 'openid';
+    public const LOGIN_ELEMENT_TYPE_TXT = 0;
+    public const LOGIN_ELEMENT_TYPE_IMG = 1;
+    public const LOGIN_ENFORCE = 0;
+    public const LOGIN_STANDARD = 1;
+    public const LOGOUT_SCOPE_GLOBAL = 0;
+    public const LOGOUT_SCOPE_LOCAL = 1;
 
-    const LOGIN_ENFORCE = 0;
-    const LOGIN_STANDARD = 1;
-
-    const LOGOUT_SCOPE_GLOBAL = 0;
-    const LOGOUT_SCOPE_LOCAL = 1;
-
-    private static ?ilOpenIdConnectSettings $instance = null;
+    private static ?self $instance = null;
 
     private ilSetting $storage;
-
     private Filesystem $filesystem;
-
     private bool $active = false;
-
     private string $provider = '';
-
     private string $client_id = '';
-
     private string $secret = '';
-
     private int $login_element_type = self::LOGIN_ELEMENT_TYPE_TXT;
-
     private ?string $login_element_img_name = null;
-
     private ?string $login_element_text = null;
-
     private int $login_prompt_type = self::LOGIN_ENFORCE;
-
     private ?int $logout_scope = null;
-
     private bool $custom_session = false;
-
     private int $session_duration = 60;
-
     private ?bool $allow_sync;
-
     private ?int $role;
-
     private string $uid = '';
-
+    /** @var array<string, string> */
     private array $profile_map = [];
-
+    /** @var array<string, bool> */
     private array $profile_update_map = [];
-
+    /** @var array<int, array{value: string, update: bool}> */
     private array $role_mappings = [];
-
+    /** @var string[] */
     private array $additional_scopes = [];
 
     private function __construct()
@@ -85,108 +69,70 @@ class ilOpenIdConnectSettings
         $this->load();
     }
 
-    /**
-     * Get singleton instance
-     */
-    public static function getInstance() : \ilOpenIdConnectSettings
+    public static function getInstance() : self
     {
-        if (!self::$instance) {
+        if (self::$instance === null) {
             self::$instance = new self();
         }
-        return new self::$instance;
+
+        return self::$instance;
     }
 
-    /**
-     * @param bool $active
-     */
     public function setActive(bool $active) : void
     {
         $this->active = $active;
     }
 
-    /**
-     * @return bool
-     */
     public function getActive() : bool
     {
         return $this->active;
     }
 
-    /**
-     * @param string $url
-     */
     public function setProvider(string $url) : void
     {
         $this->provider = $url;
     }
 
-    /**
-     * @return string
-     */
     public function getProvider() : string
     {
         return $this->provider;
     }
 
-    /**
-     * @param string $client_id
-     */
     public function setClientId(string $client_id) : void
     {
         $this->client_id = $client_id;
     }
 
-    /**
-     * @return string
-     */
     public function getClientId() : string
     {
         return $this->client_id;
     }
 
-    /**
-     * @param string $secret
-     */
     public function setSecret(string $secret) : void
     {
         $this->secret = $secret;
     }
 
-    /**
-     * Get secret
-     */
     public function getSecret() : string
     {
         return $this->secret;
     }
 
-    /**
-     * Set login element type
-     */
     public function setLoginElementType(int $type) : void
     {
         $this->login_element_type = $type;
     }
 
-    /**
-     * @return int
-     */
     public function getLoginElementType() : int
     {
         return $this->login_element_type;
     }
 
-    /**
-     * @param string $a_img_name
-     */
     public function setLoginElementImage(string $a_img_name) : void
     {
         $this->login_element_img_name = $a_img_name;
     }
 
-    /**
-     * @return string
-     */
     public function getLoginElementImage() : string
     {
         return $this->login_element_img_name;
@@ -203,120 +149,78 @@ class ilOpenIdConnectSettings
         return $this->login_element_text;
     }
 
-    /**
-     * @param int $a_type
-     */
     public function setLoginPromptType(int $a_type) : void
     {
         $this->login_prompt_type = $a_type;
     }
 
-    /**
-     * @return int
-     */
     public function getLoginPromptType() : int
     {
         return $this->login_prompt_type;
     }
 
-    /**
-     * @param int $a_scope
-     */
     public function setLogoutScope(int $a_scope) : void
     {
         $this->logout_scope = $a_scope;
     }
 
-    /**
-     * @return int
-     */
     public function getLogoutScope() : int
     {
         return $this->logout_scope;
     }
 
-    /**
-     * @param bool $a_stat
-     */
     public function useCustomSession(bool $a_stat) : void
     {
         $this->custom_session = $a_stat;
     }
 
-    /**
-     * @return bool
-     */
     public function isCustomSession() : bool
     {
         return $this->custom_session;
     }
 
-    /**
-     * @param int $a_duration
-     */
     public function setSessionDuration(int $a_duration) : void
     {
         $this->session_duration = $a_duration;
     }
 
-    /**
-     * @return int
-     */
     public function getSessionDuration() : int
     {
         return $this->session_duration;
     }
 
-    /**
-     * @return bool
-     */
     public function isSyncAllowed() : bool
     {
         return $this->allow_sync;
     }
 
-    /**
-     * @param bool $a_stat
-     */
     public function allowSync(bool $a_stat) : void
     {
         $this->allow_sync = $a_stat;
     }
 
-    /**
-     * @param int $role
-     */
     public function setRole(int $role) : void
     {
         $this->role = $role;
     }
 
-    /**
-     * @return int
-     */
     public function getRole() : int
     {
         return $this->role;
     }
 
-    /**
-     * @param string $field
-     */
     public function setUidField(string $field) : void
     {
         $this->uid = $field;
     }
 
-    /**
-     * @return string
-     */
     public function getUidField() : string
     {
         return $this->uid;
     }
 
     /**
-     * @return array
+     * @return string[]
      */
     public function getAdditionalScopes() : array
     {
@@ -324,7 +228,8 @@ class ilOpenIdConnectSettings
     }
 
     /**
-     * @param array $additional_scopes
+     * @param string[] $additional_scopes
+     * @return void
      */
     public function setAdditionalScopes(array $additional_scopes) : void
     {
@@ -332,7 +237,7 @@ class ilOpenIdConnectSettings
     }
 
     /**
-     * @return array
+     * @return string[]
      */
     public function getAllScopes() : array
     {
@@ -343,8 +248,6 @@ class ilOpenIdConnectSettings
     }
 
     /**
-     * Delete image file
-     *
      * @throws \ILIAS\Filesystem\Exception\FileNotFoundException
      * @throws \ILIAS\Filesystem\Exception\IOException
      */
@@ -355,19 +258,13 @@ class ilOpenIdConnectSettings
         }
     }
 
-    /**
-     * @return bool
-     */
     public function hasImageFile() : bool
     {
         return
-            strlen($this->getLoginElementImage()) &&
+            $this->getLoginElementImage() !== '' &&
             $this->filesystem->has(self::FILE_STORAGE . '/' . $this->getLoginElementImage());
     }
 
-    /**
-     * @return string
-     */
     public function getImageFilePath() : string
     {
         return implode(
@@ -380,7 +277,7 @@ class ilOpenIdConnectSettings
     }
 
     /**
-     * @param array $a_role_mappings
+     * @param array<int, array{value: string, update: bool}> $a_role_mappings
      */
     public function setRoleMappings(array $a_role_mappings) : void
     {
@@ -388,32 +285,28 @@ class ilOpenIdConnectSettings
     }
 
     /**
-     * Get role mappings
+     * @return array<int, array{value: string, update: bool}>
      */
     public function getRoleMappings() : array
     {
-        return (array) $this->role_mappings;
+        return $this->role_mappings;
     }
 
-    public function getRoleMappingValueForId($a_role_id) : string
+    public function getRoleMappingValueForId(int $a_role_id) : string
     {
-        if (
-            isset($this->role_mappings[$a_role_id]) &&
-            isset($this->role_mappings[$a_role_id]['value'])
-        ) {
+        if (isset($this->role_mappings[$a_role_id]['value'])) {
             return (string) $this->role_mappings[$a_role_id]['value'];
         }
+
         return '';
     }
 
-    public function getRoleMappingUpdateForId($a_role_id) : bool
+    public function getRoleMappingUpdateForId(int $a_role_id) : bool
     {
-        if (
-            isset($this->role_mappings[$a_role_id]) &&
-            isset($this->role_mappings[$a_role_id]['update'])
-        ) {
+        if (isset($this->role_mappings[$a_role_id]['update'])) {
             return (bool) $this->role_mappings[$a_role_id]['update'];
         }
+
         return false;
     }
 
@@ -427,7 +320,7 @@ class ilOpenIdConnectSettings
             $curl->setOpt(CURLOPT_RETURNTRANSFER, true);
             $curl->setOpt(CURLOPT_TIMEOUT, 4);
 
-            $response = json_decode($curl->exec());
+            $response = json_decode($curl->exec(), false, 512, JSON_THROW_ON_ERROR);
 
             if ($curl->getInfo(CURLINFO_RESPONSE_CODE) !== 200) {
                 return array();
@@ -446,65 +339,65 @@ class ilOpenIdConnectSettings
         return $result;
     }
 
-    /**
-     * Save in settings
-     */
     public function save() : void
     {
-        $this->storage->set('active', (int) $this->getActive());
+        $this->storage->set('active', (string) ((int) $this->getActive()));
         $this->storage->set('provider', $this->getProvider());
         $this->storage->set('client_id', $this->getClientId());
         $this->storage->set('secret', $this->getSecret());
-        $this->storage->set('scopes', (string) serialize($this->getAdditionalScopes()));
+        $this->storage->set('scopes', serialize($this->getAdditionalScopes()));
         $this->storage->set('le_img', $this->getLoginElementImage());
         $this->storage->set('le_text', $this->getLoginElemenText());
-        $this->storage->set('le_type', $this->getLoginElementType());
-        $this->storage->set('prompt_type', $this->getLoginPromptType());
-        $this->storage->set('logout_scope', $this->getLogoutScope());
-        $this->storage->set('custom_session', (int) $this->isCustomSession());
-        $this->storage->set('session_duration', (int) $this->getSessionDuration());
-        $this->storage->set('allow_sync', (int) $this->isSyncAllowed());
-        $this->storage->set('role', (int) $this->getRole());
-        $this->storage->set('uid', (string) $this->getUidField());
+        $this->storage->set('le_type', (string) $this->getLoginElementType());
+        $this->storage->set('prompt_type', (string) $this->getLoginPromptType());
+        $this->storage->set('logout_scope', (string) $this->getLogoutScope());
+        $this->storage->set('custom_session', (string) ((int) $this->isCustomSession()));
+        $this->storage->set('session_duration', (string) $this->getSessionDuration());
+        $this->storage->set('allow_sync', (string) ((int) $this->isSyncAllowed()));
+        $this->storage->set('role', (string) $this->getRole());
+        $this->storage->set('uid', $this->getUidField());
 
         foreach ($this->getProfileMappingFields() as $field => $lang_key) {
             $this->storage->set('pmap_' . $field, $this->getProfileMappingFieldValue($field));
-            $this->storage->set('pumap_' . $field, $this->getProfileMappingFieldUpdate($field));
+            $this->storage->set('pumap_' . $field, (string) ((int) $this->getProfileMappingFieldUpdate($field)));
         }
-        $this->storage->set('role_mappings', (string) serialize($this->getRoleMappings()));
+        $this->storage->set('role_mappings', serialize($this->getRoleMappings()));
     }
 
-    /**
-     * Load from settings
-     */
     protected function load() : void
     {
         foreach ($this->getProfileMappingFields() as $field => $lang_key) {
             $this->profile_map[$field] = (string) $this->storage->get('pmap_' . $field, '');
-            $this->profile_update_map[$field] = (bool) $this->storage->get('pumap_' . $field, '');
+            $this->profile_update_map[$field] = (bool) $this->storage->get('pumap_' . $field, '0');
         }
 
-        $this->setActive((bool) $this->storage->get('active', (string) 0));
+        $this->setActive((bool) $this->storage->get('active', '0'));
         $this->setProvider($this->storage->get('provider', ''));
         $this->setClientId($this->storage->get('client_id', ''));
         $this->setSecret($this->storage->get('secret', ''));
-        $this->setAdditionalScopes((array) unserialize($this->storage->get('scopes', serialize([]))));
+        $this->setAdditionalScopes((array) unserialize(
+            $this->storage->get('scopes', serialize([])),
+            ['allowed_classes' => false]
+        ));
         $this->setLoginElementImage($this->storage->get('le_img', ''));
         $this->setLoginElementText((string) $this->storage->get('le_text'));
         $this->setLoginElementType((int) $this->storage->get('le_type'));
         $this->setLoginPromptType((int) $this->storage->get('prompt_type', (string) self::LOGIN_ENFORCE));
         $this->setLogoutScope((int) $this->storage->get('logout_scope', (string) self::LOGOUT_SCOPE_GLOBAL));
-        $this->useCustomSession((bool) $this->storage->get('custom_session'), (string) false);
-        $this->setSessionDuration((int) $this->storage->get('session_duration', (string) 60));
-        $this->allowSync((bool) $this->storage->get('allow_sync'), (string) false);
-        $this->setRole((int) $this->storage->get('role'), (string) 0);
+        $this->useCustomSession((bool) $this->storage->get('custom_session'), '0');
+        $this->setSessionDuration((int) $this->storage->get('session_duration', '60'));
+        $this->allowSync((bool) $this->storage->get('allow_sync'), '0');
+        $this->setRole((int) $this->storage->get('role'), '0');
         $this->setUidField((string) $this->storage->get('uid'), '');
-        $this->setRoleMappings((array) unserialize($this->storage->get('role_mappings', serialize([]))));
+        $this->setRoleMappings((array) unserialize(
+            $this->storage->get('role_mappings', serialize([])),
+            ['allowed_classes' => false]
+        ));
     }
 
     public function getProfileMappingFieldValue(string $field) : string
     {
-        return (string) $this->profile_map[$field];
+        return (string) ($this->profile_map[$field] ?? '');
     }
 
     public function setProfileMappingFieldValue(string $field, string $value) : void
@@ -514,7 +407,7 @@ class ilOpenIdConnectSettings
 
     public function getProfileMappingFieldUpdate(string $field) : bool
     {
-        return (bool) $this->profile_update_map[$field];
+        return (bool) ($this->profile_update_map[$field] ?? false);
     }
 
     public function setProfileMappingFieldUpdate(string $field, bool $value) : void
@@ -522,6 +415,9 @@ class ilOpenIdConnectSettings
         $this->profile_update_map[$field] = $value;
     }
 
+    /**
+     * @return array<string, string>
+     */
     public function getProfileMappingFields() : array
     {
         return [

--- a/Services/OpenIdConnect/classes/class.ilOpenIdConnectSettingsGUI.php
+++ b/Services/OpenIdConnect/classes/class.ilOpenIdConnectSettingsGUI.php
@@ -27,7 +27,9 @@ class ilOpenIdConnectSettingsGUI
     private const STAB_ROLES = 'roles';
 
     private const DEFAULT_CMD = 'settings';
-    private int $ref_id = 0;
+    private int $ref_id;
+    /** @var array $body */
+    private $body;
     private ilOpenIdConnectSettings $settings;
     private ilLanguage $lng;
     private ilCtrl $ctrl;
@@ -57,7 +59,7 @@ class ilOpenIdConnectSettingsGUI
         $this->review = $DIC->rbac()->review();
         $this->error = $DIC['ilErr'];
         $this->upload = $DIC->upload();
-
+        $this->body = $DIC->http()->request()->getParsedBody();
         $this->settings = ilOpenIdConnectSettings::getInstance();
     }
 
@@ -540,7 +542,7 @@ class ilOpenIdConnectSettingsGUI
         $this->checkAccess('write');
         $form = $this->initRolesForm();
         if ($form->checkInput()) {
-            $this->logger->dump($_POST, ilLogLevel::DEBUG); // TODO PHP8-REVIEW Please Use the `getParsedBody()` method of the HTTP request instead
+            $this->logger->dump($this->body, ilLogLevel::DEBUG);
 
 
             $role_settings = [];
@@ -554,11 +556,13 @@ class ilOpenIdConnectSettingsGUI
                 $this->logger->dump($role_params, ilLogLevel::DEBUG);
 
                 if (count($role_params) !== 2) {
-                    $form->getItemByPostVar('role_map_' . $role_id)->setAlert($this->lng->txt('msg_wrong_format'));
+                    if ($form->getItemByPostVar('role_map_' . $role_id)) {
+                        $form->getItemByPostVar('role_map_' . $role_id)->setAlert($this->lng->txt('msg_wrong_format'));
+                    }
                     $role_valid = false;
                     continue;
                 }
-                $role_settings[(int) $role_id]['update'] = (bool) !$form->getInput('role_map_update_' . $role_id);
+                $role_settings[(int) $role_id]['update'] = !$form->getInput('role_map_update_' . $role_id);
                 $role_settings[(int) $role_id]['value'] = (string) $form->getInput('role_map_' . $role_id);
             }
 

--- a/Services/OpenIdConnect/classes/class.ilOpenIdConnectSettingsGUI.php
+++ b/Services/OpenIdConnect/classes/class.ilOpenIdConnectSettingsGUI.php
@@ -14,48 +14,31 @@
  *
  *****************************************************************************/
 
-/**
- * Class ilOpenIdConnectSettingsGUI
- *
- * @author Stefan Meyer <smeyer.ilias@gmx.de>
- *
- *
- */
 use ILIAS\FileUpload\FileUpload;
 
+/**
+ * Class ilOpenIdConnectSettingsGUI
+ * @author Stefan Meyer <smeyer.ilias@gmx.de>
+ */
 class ilOpenIdConnectSettingsGUI
 {
-    const STAB_SETTINGS = 'settings';
-    const STAB_PROFILE = 'profile';
-    const STAB_ROLES = 'roles';
+    private const STAB_SETTINGS = 'settings';
+    private const STAB_PROFILE = 'profile';
+    private const STAB_ROLES = 'roles';
 
-    const DEFAULT_CMD = 'settings';
-
+    private const DEFAULT_CMD = 'settings';
     private int $ref_id = 0;
-
     private ilOpenIdConnectSettings $settings;
-
-    protected ilLanguage $lng;
-
-    protected ilCtrl $ctrl;
-
-    protected ilLogger $logger;
-
-    protected ilAccessHandler $access;
-
-    protected ilRbacReview $review;
-
-    protected ilErrorHandling $error;
-
-    protected ilGlobalTemplateInterface $mainTemplate;
-
-    protected ilTabsGUI $tabs;
-
+    private ilLanguage $lng;
+    private ilCtrl $ctrl;
+    private ilLogger $logger;
+    private ilAccessHandler $access;
+    private ilRbacReview $review;
+    private ilErrorHandling $error;
+    private ilGlobalTemplateInterface $mainTemplate;
+    private ilTabsGUI $tabs;
     private FileUpload $upload;
 
-    /**
-     * ilOpenIdConnectSettingsGUI constructor.
-     */
     public function __construct(int $a_ref_id)
     {
         global $DIC;
@@ -154,7 +137,7 @@ class ilOpenIdConnectSettingsGUI
         $secret->setSkipSyntaxCheck(true);
         $secret->setRetype(false);
         $secret->setRequired(false);
-        if (strlen($this->settings->getSecret())) {
+        if ($this->settings->getSecret() !== '') {
             $secret->setValue('******');
         }
         $form->addItem($secret);
@@ -216,7 +199,7 @@ class ilOpenIdConnectSettingsGUI
             '',
             'le_img'
         );
-        $image->setALlowDeletion(false);
+        $image->setAllowDeletion(false);
 
         if ($this->settings->hasImageFile()) {
             $image->setImage($this->settings->getImageFilePath());
@@ -300,7 +283,6 @@ class ilOpenIdConnectSettingsGUI
             $form->addCommandButton('saveSettings', $this->lng->txt('save'));
         }
 
-
         // User sync settings --------------------------------------------------------------
         $user_sync = new ilFormSectionHeaderGUI();
         $user_sync->setTitle($this->lng->txt('auth_oidc_settings_section_user_sync'));
@@ -336,9 +318,6 @@ class ilOpenIdConnectSettingsGUI
         return $form;
     }
 
-    /**
-     * Save settings
-     */
     protected function saveSettings() : void
     {
         $this->checkAccess('write');
@@ -351,6 +330,7 @@ class ilOpenIdConnectSettingsGUI
             return;
         }
 
+        $scopes = [];
         if (!empty($form->getInput('scopes'))) {
             $scopes = $form->getInput('scopes');
             foreach ($scopes as $key => $value) {
@@ -362,7 +342,10 @@ class ilOpenIdConnectSettingsGUI
 
         $invalid_scopes = $this->settings->validateScopes((string) $form->getInput('provider'), (array) $scopes);
         if (!empty($invalid_scopes)) {
-            $this->mainTemplate->setOnScreenMessage('failure', sprintf($this->lng->txt('auth_oidc_settings_invalid_scopes'), implode(",", $invalid_scopes)));
+            $this->mainTemplate->setOnScreenMessage(
+                'failure',
+                sprintf($this->lng->txt('auth_oidc_settings_invalid_scopes'), implode(",", $invalid_scopes))
+            );
             $form->setValuesByPost();
             $this->settings($form);
             return;
@@ -371,7 +354,7 @@ class ilOpenIdConnectSettingsGUI
         $this->settings->setActive((bool) $form->getInput('activation'));
         $this->settings->setProvider((string) $form->getInput('provider'));
         $this->settings->setClientId((string) $form->getInput('client_id'));
-        if (strlen($form->getInput('secret')) && strcmp($form->getInput('secret'), '******') !== 0) {
+        if ((string) $form->getInput('secret') !== '' && strcmp($form->getInput('secret'), '******') !== 0) {
             $this->settings->setSecret((string) $form->getInput('secret'));
         }
         $this->settings->setAdditionalScopes((array) $scopes);
@@ -387,7 +370,7 @@ class ilOpenIdConnectSettingsGUI
 
         $fileData = (array) $form->getInput('le_img');
 
-        if (strlen($fileData['tmp_name'])) {
+        if ((string) ($fileData['tmp_name'] ?? '') !== '') {
             $this->saveImageFromHttpRequest();
         }
 
@@ -397,9 +380,6 @@ class ilOpenIdConnectSettingsGUI
         $this->ctrl->redirect($this, 'settings');
     }
 
-    /**
-     * Save image from http request
-     */
     protected function saveImageFromHttpRequest() : void
     {
         try {
@@ -423,9 +403,9 @@ class ilOpenIdConnectSettingsGUI
 
     /**
      * @param bool $a_with_select_option
-     * @return mixed
+     * @return array<string, string>
      */
-    protected function prepareRoleSelection($a_with_select_option = true) : array
+    protected function prepareRoleSelection(bool $a_with_select_option = true) : array
     {
         $global_roles = ilUtil::_sortIds(
             $this->review->getGlobalRoles(),
@@ -439,11 +419,12 @@ class ilOpenIdConnectSettingsGUI
             $select[0] = $this->lng->txt('links_select_one');
         }
         foreach ($global_roles as $role_id) {
-            if ($role_id == ANONYMOUS_ROLE_ID) {
+            if ($role_id === ANONYMOUS_ROLE_ID) {
                 continue;
             }
-            $select[$role_id] = ilObject::_lookupTitle((int) $role_id);
+            $select[(string) $role_id] = ilObject::_lookupTitle((int) $role_id);
         }
+
         return $select;
     }
 
@@ -458,7 +439,7 @@ class ilOpenIdConnectSettingsGUI
         $this->mainTemplate->setContent($form->getHTML());
     }
 
-    protected function initProfileForm() : \ilPropertyFormGUI
+    protected function initProfileForm() : ilPropertyFormGUI
     {
         $form = new ilPropertyFormGUI();
         $form->setTitle($this->lng->txt('auth_oidc_mapping_table'));
@@ -481,13 +462,11 @@ class ilOpenIdConnectSettingsGUI
         if ($this->checkAccessBool('write')) {
             $form->addCommandButton('saveProfile', $this->lng->txt('save'));
         }
+
         return $form;
     }
 
-    /**
-     * @return bool
-     */
-    protected function saveProfile() : bool
+    protected function saveProfile() : void
     {
         $this->checkAccessBool('write');
 
@@ -496,7 +475,7 @@ class ilOpenIdConnectSettingsGUI
             $this->mainTemplate->setOnScreenMessage('failure', $this->lng->txt('err_check_input'));
             $form->setValuesByPost();
             $this->profile($form);
-            return false;
+            return;
         }
 
         foreach ($this->settings->getProfileMappingFields() as $field => $lng_key) {
@@ -506,7 +485,7 @@ class ilOpenIdConnectSettingsGUI
             );
             $this->settings->setProfileMappingFieldUpdate(
                 $field,
-                $form->getInput($field . '_update')
+                (bool) $form->getInput($field . '_update')
             );
         }
         $this->settings->save();
@@ -514,7 +493,7 @@ class ilOpenIdConnectSettingsGUI
         $this->ctrl->redirect($this, self::STAB_PROFILE);
     }
 
-    protected function roles(\ilPropertyFormGUI $form = null) : void
+    protected function roles(ilPropertyFormGUI $form = null) : void
     {
         $this->checkAccess('read');
         $this->setSubTabs(self::STAB_ROLES);
@@ -537,7 +516,7 @@ class ilOpenIdConnectSettingsGUI
                 'role_map_' . $role_id
             );
             $role_map->setInfo($this->lng->txt('auth_oidc_role_info'));
-            $role_map->setValue($this->settings->getRoleMappingValueForId($role_id));
+            $role_map->setValue($this->settings->getRoleMappingValueForId((int) $role_id));
             $form->addItem($role_map);
 
             $update = new ilCheckboxInputGUI(
@@ -546,7 +525,7 @@ class ilOpenIdConnectSettingsGUI
             );
             $update->setOptionTitle($this->lng->txt('auth_oidc_update_role_info'));
             $update->setValue("1");
-            $update->setChecked(!$this->settings->getRoleMappingUpdateForId($role_id));
+            $update->setChecked(!$this->settings->getRoleMappingUpdateForId((int) $role_id));
             $form->addItem($update);
         }
 
@@ -556,34 +535,31 @@ class ilOpenIdConnectSettingsGUI
         return $form;
     }
 
-    /**
-     * save role selection
-     */
     protected function saveRoles() : void
     {
         $this->checkAccess('write');
         $form = $this->initRolesForm();
         if ($form->checkInput()) {
-            $this->logger->dump($_POST, \ilLogLevel::DEBUG);
+            $this->logger->dump($_POST, ilLogLevel::DEBUG); // TODO PHP8-REVIEW Please Use the `getParsedBody()` method of the HTTP request instead
 
 
             $role_settings = [];
             $role_valid = true;
             foreach ($this->prepareRoleSelection(false) as $role_id => $role_title) {
-                if (!strlen(trim($form->getInput('role_map_' . $role_id)))) {
+                if (trim($form->getInput('role_map_' . $role_id)) === '') {
                     continue;
                 }
 
                 $role_params = explode('::', $form->getInput('role_map_' . $role_id));
-                $this->logger->dump($role_params, \ilLogLevel::DEBUG);
+                $this->logger->dump($role_params, ilLogLevel::DEBUG);
 
                 if (count($role_params) !== 2) {
                     $form->getItemByPostVar('role_map_' . $role_id)->setAlert($this->lng->txt('msg_wrong_format'));
                     $role_valid = false;
                     continue;
                 }
-                $role_settings[$role_id]['update'] = (bool) !$form->getInput('role_map_update_' . $role_id);
-                $role_settings[$role_id]['value'] = (string) $form->getInput('role_map_' . $role_id);
+                $role_settings[(int) $role_id]['update'] = (bool) !$form->getInput('role_map_update_' . $role_id);
+                $role_settings[(int) $role_id]['value'] = (string) $form->getInput('role_map_' . $role_id);
             }
 
             if (!$role_valid) {
@@ -604,9 +580,6 @@ class ilOpenIdConnectSettingsGUI
         $this->roles($form);
     }
 
-    /**
-     * Set sub tabs
-     */
     protected function setSubTabs(string $active_tab) : void
     {
         $this->tabs->addSubTab(

--- a/Services/OpenIdConnect/classes/class.ilOpenIdConnectUserSync.php
+++ b/Services/OpenIdConnect/classes/class.ilOpenIdConnectUserSync.php
@@ -204,7 +204,7 @@ class ilOpenIdConnectUserSync
             }
 
             if (is_array($this->user_info->{$role_attribute})) {
-                if (!in_array($role_value, $this->user_info->{$role_attribute})) {
+                if (!in_array($role_value, $this->user_info->{$role_attribute}, true)) {
                     $this->logger->debug('User account has no ' . $role_value);
                     continue;
                 }
@@ -256,7 +256,6 @@ class ilOpenIdConnectUserSync
             return '';
         }
 
-        $val = $this->user_info->{$connect_name};
-        return $val;
+        return $this->user_info->{$connect_name};
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
 		"league/flysystem": "^1.0",
 		"james-heinrich/getid3": "^1.9",
 		"phpoffice/phpspreadsheet": "^1.18.0",
-		"jumbojett/openid-connect-php": "^0.9.2",
+		"jumbojett/openid-connect-php": "^0.9.5",
 		"sabre/dav": "^4.1",
 		"symfony/console" : "^5.0",
 		"slim/slim": "^3.11",

--- a/openidconnect.php
+++ b/openidconnect.php
@@ -1,11 +1,25 @@
 <?php
-include_once './Services/Context/classes/class.ilContext.php';
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+/** @noRector */
+require_once("libs/composer/vendor/autoload.php");
 ilContext::init(ilContext::CONTEXT_SHIBBOLETH);
-
-require_once("Services/Init/classes/class.ilInitialisation.php");
 ilInitialisation::initILIAS();
+global $DIC;
+
 
 // authentication is done here ->
-$ilCtrl->setCmd('doOpenIdConnectAuthentication');
-$ilCtrl->setTargetScript('ilias.php');
-$ilCtrl->callBaseClass('ilStartUpGUI');
+$DIC->ctrl()->setCmd('doOpenIdConnectAuthentication');
+$DIC->ctrl()->setTargetScript('ilias.php');
+$DIC->ctrl()->callBaseClass(ilStartUpGUI::class);


### PR DESCRIPTION
Hello @pascalseeland, 

I completed the review of the `Services/OpenIdConnect` component.

Results:

- [x] The code style is `PSR-2 + X` compliant
- [ ] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`: I found 7 usages of `$_GET` and 1 usage of `$_POST`.
- [ ] There is a `Unit Test Suite` with at least one unit test
- [ ] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] There are no serious `PhpStorm Code Inspection` issues left
- [x] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

--

Actions needed:
- [ ] Please check my inline comments. Some of them are just information, some require an action. You can use `TODO PHP8-REVIEW` when searching. The found super globals might be okay if there is a **good** reason to keep them.
- [ ] Please add a unit test suite with at least one passing unit test
- [x] I am not sure whether https://packagist.org/packages/jumbojett/openid-connect-php is compatible with PHP 8. Please check the list item above if you already checked this. I doubt that this works 100% because `\Jumbojett\OpenIDConnectClient::getVerifiedClaims` accesses `$this->verifiedClaims->$attribute`, but `$this->verifiedClaims` is an array, not an object. So the return type of `\Jumbojett\OpenIDConnectClient::getVerifiedClaims` seems to be mixed. If `\Jumbojett\OpenIDConnectClient::authenticate` is executed before `\Jumbojett\OpenIDConnectClient::getVerifiedClaims`, `$this->verifiedClaims` is an `stdClass`, which should be the type we'll have to work with.

Best regards,
@mjansenDatabay  