### PR TITLE
PHP 8: Code Review `AuthShibboleth`

### DIFF
--- a/Services/AuthShibboleth/classes/Config/class.ilShibbolethSettings.php
+++ b/Services/AuthShibboleth/classes/Config/class.ilShibbolethSettings.php
@@ -78,7 +78,7 @@ class ilShibbolethSettings
     {
         $a_keyword = str_replace(self::PREFIX, '', $a_keyword);
 
-        return (string) isset($this->data[$a_keyword]) ?? $a_default_value;
+        return (string) ($this->data[$a_keyword] ?? $a_default_value);
     }
 
     public function delete(string $a_keyword) : void
@@ -107,7 +107,6 @@ class ilShibbolethSettings
         }
     }
 
-    //
     public function getDefaultRole() : int
     {
         return $this->data['user_default_role'] ?? 4;

--- a/Services/AuthShibboleth/classes/Config/class.ilShibbolethSettings.php
+++ b/Services/AuthShibboleth/classes/Config/class.ilShibbolethSettings.php
@@ -23,13 +23,15 @@ use function _PHPStan_e04cc8dfb\RingCentral\Psr7\str;
  */
 class ilShibbolethSettings
 {
-    const PREFIX = 'shib_';
-    const DEFAULT_IDP_LIST = "urn:mace:organization1:providerID, Example Organization 1\nurn:mace:organization2:providerID, Example Organization 2, /Shibboleth.sso/WAYF/SWITCHaai";
-    const DEFAULT_LOGIN_BUTTON = "templates/default/images/shib_login_button.png";
-    const DEFAULT_ORGANISATION_SELECTION = "external_wayf";
+    private const PREFIX = 'shib_';
+    private const DEFAULT_IDP_LIST = "urn:mace:organization1:providerID, Example Organization 1\nurn:mace:organization2:providerID, Example Organization 2, /Shibboleth.sso/WAYF/SWITCHaai";
+    private const DEFAULT_LOGIN_BUTTON = "templates/default/images/shib_login_button.png";
+    private const DEFAULT_ORGANISATION_SELECTION = "external_wayf";
+
     protected ilSetting $settings;
     protected array $data = [];
 
+    /** @var array<string, bool> */
     protected array $user_fields = [
         'login' => true,
         'firstname' => true,
@@ -53,12 +55,13 @@ class ilShibbolethSettings
     public function __construct()
     {
         global $DIC;
+
         $this->settings = $DIC->settings();
         $this->read();
     }
 
     /**
-     * @return mixed[]
+     * @return array<string, bool>
      */
     public function getUserFields() : array
     {
@@ -67,7 +70,11 @@ class ilShibbolethSettings
 
     public function read() : void
     {
-        $filtered_data = array_filter($this->settings->getAll(), fn ($value, string $key) : bool => strpos($key, self::PREFIX) === 0, ARRAY_FILTER_USE_BOTH);
+        $filtered_data = array_filter(
+            $this->settings->getAll(),
+            static fn ($value, string $key) : bool => strpos($key, self::PREFIX) === 0,
+            ARRAY_FILTER_USE_BOTH
+        );
 
         array_walk($filtered_data, function ($v, string $k) : void {
             $this->data[str_replace(self::PREFIX, '', $k)] = $v === '' ? null : $v;

--- a/Services/AuthShibboleth/classes/User/class.shibUser.php
+++ b/Services/AuthShibboleth/classes/User/class.shibUser.php
@@ -12,6 +12,7 @@
  *      https://github.com/ILIAS-eLearning
  *
  *****************************************************************************/
+
 /**
  * Class shibUser
  *
@@ -21,8 +22,7 @@ class shibUser extends ilObjUser
 {
     protected shibServerData $shibServerData;
 
-
-    public static function buildInstance(shibServerData $shibServerData) : \shibUser
+    public static function buildInstance(shibServerData $shibServerData) : shibUser
     {
         $shibUser = new self();
         $shibUser->shibServerData = $shibServerData;
@@ -37,7 +37,6 @@ class shibUser extends ilObjUser
 
         return $shibUser;
     }
-
 
     public function updateFields() : void
     {
@@ -96,7 +95,6 @@ class shibUser extends ilObjUser
         $this->setDescription($this->getEmail());
     }
 
-
     public function createFields() : void
     {
         $this->setFirstname($this->shibServerData->getFirstname());
@@ -129,7 +127,6 @@ class shibUser extends ilObjUser
         $this->setActive(true);
     }
 
-
     public function create() : int
     {
         $c = shibConfig::getInstance();
@@ -143,13 +140,12 @@ class shibUser extends ilObjUser
             $mail->send();
         }
 
-        if ($this->getLogin() != '' && $this->getLogin() != '.') {
+        if ($this->getLogin() !== '' && $this->getLogin() !== '.') {
             return parent::create();
-        } else {
-            throw new ilUserException('No Login-name created');
         }
-    }
 
+        throw new ilUserException('No Login-name created');
+    }
 
     protected function returnNewLoginName() : ?string
     {
@@ -166,62 +162,50 @@ class shibUser extends ilObjUser
         return $login;
     }
 
-
     public function isNew() : bool
     {
-        return $this->getId() == 0;
+        return $this->getId() === 0;
     }
 
-
-    /**
-     * @param $name
-     *
-     * @return mixed
-     */
-    protected static function cleanName($name) : string
+    protected static function cleanName(string $name) : string
     {
-        return strtolower(strtr(utf8_decode($name), utf8_decode('ŠŒŽšœžŸ¥µÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýÿ'), 'SOZsozYYuAAAAAAACEEEEIIIIDNOOOOOOUUUUYsaaaaaaaceeeeiiiionoooooouuuuyy'));
+        return strtolower(strtr(
+            utf8_decode($name),
+            utf8_decode('ŠŒŽšœžŸ¥µÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýÿ'),
+            'SOZsozYYuAAAAAAACEEEEIIIIDNOOOOOOUUUUYsaaaaaaaceeeeiiiionoooooouuuuyy'
+        ));
     }
 
-
-    /**
-     * @param $login
-     * @param $usr_id
-     */
-    private static function loginExists($login, $usr_id) : bool
+    private static function loginExists(string $login, int $usr_id) : bool
     {
         global $DIC;
-        $ilDB = $DIC['ilDB'];
-        /**
-         * @var $ilDB ilDB
-         */
+
+        $ilDB = $DIC->database();
+
         $query = 'SELECT usr_id FROM usr_data WHERE login = ' . $ilDB->quote($login, 'text');
         $query .= ' AND usr_id != ' . $ilDB->quote($usr_id, 'integer');
 
         return $ilDB->numRows($ilDB->query($query)) > 0;
     }
 
-
     /**
      * @param $ext_id
-     *
-     * @return bool
+     * @return false|int
      */
-    protected static function getUsrIdByExtId($ext_id)
+    protected static function getUsrIdByExtId(string $ext_id)
     {
         global $DIC;
-        $ilDB = $DIC['ilDB'];
-        /**
-         * @var $ilDB ilDB
-         */
+
+        $ilDB = $DIC->database();
+
         $query = 'SELECT usr_id FROM usr_data WHERE ext_account = ' . $ilDB->quote($ext_id, 'text');
         $a_set = $ilDB->query($query);
-        if ($ilDB->numRows($a_set) == 0) {
+        if ($ilDB->numRows($a_set) === 0) {
             return false;
-        } else {
-            $usr = $ilDB->fetchObject($a_set);
-
-            return $usr->usr_id;
         }
+
+        $usr = $ilDB->fetchObject($a_set);
+
+        return (int) $usr->usr_id;
     }
 }

--- a/Services/AuthShibboleth/classes/class.ilAuthFrontendCredentialsShibboleth.php
+++ b/Services/AuthShibboleth/classes/class.ilAuthFrontendCredentialsShibboleth.php
@@ -13,19 +13,17 @@
  *      https://github.com/ILIAS-eLearning
  *
  *****************************************************************************/
+
 /**
  * Description of class class
  *
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
  *
  */
-class ilAuthFrontendCredentialsShibboleth extends ilAuthFrontendCredentials implements ilAuthCredentials
+class ilAuthFrontendCredentialsShibboleth extends ilAuthFrontendCredentials
 {
-    private \ilSetting $settings;
+    private ilSetting $settings;
 
-    /**
-     * Constructor
-     */
     public function __construct()
     {
         global $DIC;
@@ -33,14 +31,11 @@ class ilAuthFrontendCredentialsShibboleth extends ilAuthFrontendCredentials impl
         $this->settings = $DIC->settings();
     }
 
-    protected function getSettings() : \ilSetting
+    protected function getSettings() : ilSetting
     {
         return $this->settings;
     }
 
-    /**
-     * Init credentials from request
-     */
     public function initFromRequest() : void
     {
         $this->setUsername($this->settings->get('shib_login', ''));

--- a/Services/AuthShibboleth/classes/class.ilAuthProviderShibboleth.php
+++ b/Services/AuthShibboleth/classes/class.ilAuthProviderShibboleth.php
@@ -86,5 +86,7 @@ class ilAuthProviderShibboleth extends ilAuthProvider
             $this->handleAuthenticationFail($status, 'err_wrong_login');
             return false;
         }
+
+        return true;
     }
 }

--- a/Services/AuthShibboleth/classes/class.ilAuthProviderShibboleth.php
+++ b/Services/AuthShibboleth/classes/class.ilAuthProviderShibboleth.php
@@ -17,12 +17,9 @@
  * Shibboleth authentication provider
  *
  */
-class ilAuthProviderShibboleth extends ilAuthProvider implements ilAuthProviderInterface
+class ilAuthProviderShibboleth extends ilAuthProvider
 {
-    /**
-     * Do apache auth
-     */
-    public function doAuthentication(\ilAuthStatus $status) : bool
+    public function doAuthentication(ilAuthStatus $status) : bool
     {
         global $DIC; // for backwards compatibility of hook environment variables
         $ilias = $DIC['ilias'];
@@ -41,7 +38,10 @@ class ilAuthProviderShibboleth extends ilAuthProvider implements ilAuthProviderI
                 // Modify user data before creating the user
                 // Include custom code that can be used to further modify
                 // certain Shibboleth user attributes
-                if ($ilias->getSetting('shib_data_conv') && $ilias->getSetting('shib_data_conv') != '' && is_readable($ilias->getSetting('shib_data_conv'))
+                if (
+                    $ilias->getSetting('shib_data_conv') &&
+                    $ilias->getSetting('shib_data_conv', '') !== '' &&
+                    is_readable($ilias->getSetting('shib_data_conv'))
                 ) {
                     /** @noRector */
                     include($ilias->getSetting('shib_data_conv'));
@@ -57,7 +57,10 @@ class ilAuthProviderShibboleth extends ilAuthProvider implements ilAuthProviderI
                 $shibUser->updateFields();
                 // Include custom code that can be used to further modify
                 // certain Shibboleth user attributes
-                if ($ilias->getSetting('shib_data_conv') && $ilias->getSetting('shib_data_conv') != '' && is_readable($ilias->getSetting('shib_data_conv'))
+                if (
+                    $ilias->getSetting('shib_data_conv') &&
+                    $ilias->getSetting('shib_data_conv') !== '' &&
+                    is_readable($ilias->getSetting('shib_data_conv'))
                 ) {
                     /** @noRector */
                     include($ilias->getSetting('shib_data_conv'));
@@ -71,11 +74,10 @@ class ilAuthProviderShibboleth extends ilAuthProvider implements ilAuthProviderI
 
             $settings = new ilShibbolethSettings();
 
-
-            if (($newUser && !$settings->adminMustActivate()) || !$newUser) {
+            if (!$newUser || !$settings->adminMustActivate()) {
                 $status->setStatus(ilAuthStatus::STATUS_AUTHENTICATED);
                 $status->setAuthenticatedUserId(ilObjUser::_lookupId($shibUser->getLogin()));
-            } elseif ($newUser && $settings->adminMustActivate()) {
+            } elseif ($settings->adminMustActivate()) {
                 $status->setStatus(ilAuthStatus::STATUS_AUTHENTICATION_FAILED);
                 $status->setReason('err_inactive');
             }

--- a/Services/AuthShibboleth/classes/class.ilAuthShibbolethSettingsGUI.php
+++ b/Services/AuthShibboleth/classes/class.ilAuthShibbolethSettingsGUI.php
@@ -128,7 +128,7 @@ class ilAuthShibbolethSettingsGUI
         return $rules_table->getHTML();
     }
 
-    protected function confirmDeleteRules()
+    protected function confirmDeleteRules() : bool
     {
         if (!is_array($_POST['rule_ids'])) {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('select_one'));
@@ -152,6 +152,7 @@ class ilAuthShibbolethSettingsGUI
             $c_gui->addItem('rule_ids[]', $rule_id, $info);
         }
         $this->tpl->setContent($c_gui->getHTML());
+        return true;
     }
 
     protected function deleteRules() : bool

--- a/Services/AuthShibboleth/classes/class.ilAuthShibbolethSettingsGUI.php
+++ b/Services/AuthShibboleth/classes/class.ilAuthShibbolethSettingsGUI.php
@@ -23,7 +23,8 @@
  */
 class ilAuthShibbolethSettingsGUI
 {
-    const PARAM_RULE_ID = 'rule_id';
+    private const PARAM_RULE_ID = 'rule_id';
+
     private ?\ilPropertyFormGUI $form = null;
     private ?ilShibbolethRoleAssignmentRule $rule = null;
     private \ilCtrl $ctrl;
@@ -31,19 +32,13 @@ class ilAuthShibbolethSettingsGUI
     private \ilLanguage $lng;
     private \ilGlobalTemplateInterface $tpl;
     private int $ref_id;
-    protected ilComponentRepository $component_repository;
+    private ilComponentRepository $component_repository;
     private \ILIAS\DI\RBACServices $rbac;
     private ilAccessHandler $access;
     private \ILIAS\HTTP\Wrapper\WrapperFactory $wrapper;
     private \ILIAS\Refinery\Factory $refinery;
-    protected ilShibbolethSettings $shib_settings;
+    private ilShibbolethSettings $shib_settings;
 
-    /**
-     *
-     * @param
-     *
-     * @return \ilAuthShibbolethSettingsGUI
-     */
     public function __construct(int $a_auth_ref_id)
     {
         global $DIC;
@@ -62,16 +57,13 @@ class ilAuthShibbolethSettingsGUI
         $this->shib_settings = new ilShibbolethSettings();
     }
 
-    /**
-     * Execute Command
-     */
     public function executeCommand() : void
     {
         $cmd = $this->ctrl->getCmd();
         if (!$this->access->checkAccess('read', '', $this->ref_id)) {
             throw new ilException('Permission denied');
         }
-        if (!$this->access->checkAccess('write', '', $this->ref_id) && $cmd != "settings") {
+        if (!$this->access->checkAccess('write', '', $this->ref_id) && $cmd !== "settings") {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('msg_no_perm_write'), true);
             $this->ctrl->redirect($this, "settings");
         }
@@ -115,7 +107,7 @@ class ilAuthShibbolethSettingsGUI
             'Services/AuthShibboleth'
         );
         $this->tpl->setVariable('NEW_RULE_TABLE', $this->form->getHTML());
-        if (strlen($html = $this->parseRulesTable()) !== 0) {
+        if (($html = $this->parseRulesTable()) !== '') {
             $this->tpl->setVariable('RULE_TABLE', $html);
         }
 
@@ -124,7 +116,7 @@ class ilAuthShibbolethSettingsGUI
 
     protected function parseRulesTable() : string
     {
-        if (ilShibbolethRoleAssignmentRules::getCountRules() == 0) {
+        if (ilShibbolethRoleAssignmentRules::getCountRules() === 0) {
             return '';
         }
         $rules_table = new ilShibbolethRoleAssignmentTableGUI($this, 'roleAssignment');
@@ -136,14 +128,6 @@ class ilAuthShibbolethSettingsGUI
         return $rules_table->getHTML();
     }
 
-    /**
-     * Confirm delete rules
-     *
-     * @access public
-     *
-     * @param
-     *
-     */
     protected function confirmDeleteRules()
     {
         if (!is_array($_POST['rule_ids'])) {
@@ -170,12 +154,6 @@ class ilAuthShibbolethSettingsGUI
         $this->tpl->setContent($c_gui->getHTML());
     }
 
-    /**
-     * delete role assignment rule
-     *
-     * @access public
-     *
-     */
     protected function deleteRules() : bool
     {
         if (!is_array($_POST['rule_ids'])) {
@@ -194,12 +172,12 @@ class ilAuthShibbolethSettingsGUI
         return true;
     }
 
-    protected function initFormRoleAssignment($a_mode = 'default') : void
+    protected function initFormRoleAssignment(string $a_mode = 'default') : void
     {
         $this->form = new ilPropertyFormGUI();
         $this->form->setFormAction($this->ctrl->getFormAction($this, 'cancel'));
         $this->form->setTitle($this->lng->txt('shib_role_ass_table'));
-        if ($a_mode == 'default') {
+        if ($a_mode === 'default') {
             $this->form->setTitle($this->lng->txt('shib_role_ass_table'));
             $this->form->addCommandButton('addRoleAssignmentRule', $this->lng->txt('shib_new_rule'));
             $this->form->addCommandButton('settings', $this->lng->txt('cancel'));
@@ -263,9 +241,6 @@ class ilAuthShibbolethSettingsGUI
         $this->form->addItem($kind);
     }
 
-    /**
-     * Add Member for autoComplete
-     */
     public function addRoleAutoCompleteObject() : void
     {
         ilRoleAutoCompleteInputGUI::echoAutoCompleteList();
@@ -293,7 +268,7 @@ class ilAuthShibbolethSettingsGUI
                 'Services/AuthShibboleth'
             );
             $this->tpl->setVariable('NEW_RULE_TABLE', $this->form->getHTML());
-            if (strlen($html = $this->parseRulesTable()) !== 0) {
+            if (($html = $this->parseRulesTable()) !== '') {
                 $this->tpl->setVariable('RULE_TABLE', $html);
             }
 
@@ -308,11 +283,6 @@ class ilAuthShibbolethSettingsGUI
         return true;
     }
 
-    /**
-     * Edit Role Assignment
-     *
-     * @return
-     */
     protected function editRoleAssignment() : bool
     {
         $this->ctrl->saveParameter($this, self::PARAM_RULE_ID);
@@ -366,10 +336,10 @@ class ilAuthShibbolethSettingsGUI
         return true;
     }
 
-    private function loadRule($a_rule_id = 0) : \ilShibbolethRoleAssignmentRule
+    private function loadRule(int $a_rule_id = 0) : ilShibbolethRoleAssignmentRule
     {
         $this->rule = new ilShibbolethRoleAssignmentRule($a_rule_id);
-        if ($this->form->getInput('role_name') == 0) {
+        if ((int) $this->form->getInput('role_name') === 0) {
             $this->rule->setRoleId($this->form->getInput('role_id'));
         } elseif ($this->form->getInput('role_search')) {
             $parser = new ilQueryParser($this->form->getInput('role_search'));
@@ -381,7 +351,7 @@ class ilAuthShibbolethSettingsGUI
             $object_search->setFilter(array('role'));
             $res = $object_search->performSearch();
             $entries = $res->getEntries();
-            if (count($entries) == 1) {
+            if (count($entries) === 1) {
                 $role = current($entries);
                 $this->rule->setRoleId($role['obj_id']);
             } elseif (count($entries) > 1) {
@@ -392,7 +362,7 @@ class ilAuthShibbolethSettingsGUI
         $this->rule->setValue($this->form->getInput('attr_value'));
         $this->rule->enableAddOnUpdate($this->form->getInput('add_missing'));
         $this->rule->enableRemoveOnUpdate($this->form->getInput('remove_deprecated'));
-        $this->rule->enablePlugin($this->form->getInput('kind') == 2);
+        $this->rule->enablePlugin((int) $this->form->getInput('kind') === 2);
         $this->rule->setPluginId($this->form->getInput('plugin_id'));
 
         return $this->rule;
@@ -433,12 +403,12 @@ class ilAuthShibbolethSettingsGUI
         return $this->rule->validate();
     }
 
-    private function showLocalRoleSelection()
+    private function showLocalRoleSelection() : void
     {
         if ($this->rule->getRoleId() > 0) {
-            return false;
+            return;
         }
-        $_SESSION['shib_role_ass'][self::PARAM_RULE_ID] = $_REQUEST[self::PARAM_RULE_ID] ? $_REQUEST[self::PARAM_RULE_ID] : 0;
+        $_SESSION['shib_role_ass'][self::PARAM_RULE_ID] = $_REQUEST[self::PARAM_RULE_ID] ?: 0;
         $_SESSION['shib_role_ass']['search'] = $this->form->getInput('role_search');
         $_SESSION['shib_role_ass']['add_on_update'] = $this->rule->isAddOnUpdateEnabled();
         $_SESSION['shib_role_ass']['remove_on_update'] = $this->rule->isRemoveOnUpdateEnabled();
@@ -496,20 +466,25 @@ class ilAuthShibbolethSettingsGUI
     private function prepareRoleSelect() : array
     {
         global $DIC;
+
         $rbacreview = $DIC['rbacreview'];
+
         $global_roles = ilUtil::_sortIds($rbacreview->getGlobalRoles(), 'object_data', 'title', 'obj_id');
         $select[0] = $this->lng->txt('links_select_one');
         foreach ($global_roles as $role_id) {
             $select[$role_id] = ilObject::_lookupTitle($role_id);
         }
+
         return $select;
     }
 
     protected function setSubTabs() : bool
     {
         global $DIC;
+
         $ilSetting = $DIC['ilSetting'];
-        if ($ilSetting->get('shib_active') == 0 && ilShibbolethRoleAssignmentRules::getCountRules() == 0) {
+
+        if ($ilSetting->get('shib_active', '0') && ilShibbolethRoleAssignmentRules::getCountRules() === 0) {
             return false;
         }
         // DONE: show sub tabs if there is any role assignment rule

--- a/Services/AuthShibboleth/classes/class.ilShibbolethAuthenticationPlugin.php
+++ b/Services/AuthShibboleth/classes/class.ilShibbolethAuthenticationPlugin.php
@@ -38,14 +38,14 @@ abstract class ilShibbolethAuthenticationPlugin extends ilPlugin implements ilSh
         }
         if (is_array($a_user_data[$a_keyword])) {
             foreach ($a_user_data[$a_keyword] as $values) {
-                if (strcasecmp(trim($values), $a_value) == 0) {
+                if (strcasecmp(trim($values), $a_value) === 0) {
                     return true;
                 }
             }
 
             return false;
         }
-        return strcasecmp(trim($a_user_data[$a_keyword]), trim($a_value)) == 0;
+        return strcasecmp(trim($a_user_data[$a_keyword]), trim($a_value)) === 0;
     }
 
 

--- a/Services/AuthShibboleth/classes/class.ilShibbolethPluginWrapper.php
+++ b/Services/AuthShibboleth/classes/class.ilShibbolethPluginWrapper.php
@@ -12,6 +12,7 @@
  *      https://github.com/ILIAS-eLearning
  *
  *****************************************************************************/
+
 /**
  * Class ilShibbolethPluginWrapper
  *
@@ -23,7 +24,6 @@ class ilShibbolethPluginWrapper implements ilShibbolethAuthenticationPluginInt
     protected ilLog $log;
     protected static ?ilShibbolethPluginWrapper $cache = null;
 
-
     protected function __construct()
     {
         global $DIC;
@@ -32,21 +32,19 @@ class ilShibbolethPluginWrapper implements ilShibbolethAuthenticationPluginInt
         $this->component_factory = $DIC["component.factory"];
     }
 
-
-    public static function getInstance() : \ilShibbolethPluginWrapper
+    public static function getInstance() : self
     {
-        if (!self::$cache instanceof ilShibbolethPluginWrapper) {
+        if (!self::$cache instanceof self) {
             self::$cache = new self();
         }
 
         return self::$cache;
     }
 
-
     /**
      * @return ilShibbolethAuthenticationPlugin[]
      */
-    protected function getPluginObjects() : \Iterator
+    protected function getPluginObjects() : Iterator
     {
         return $this->component_factory->getActivePluginsInSlot('shibhk');
     }

--- a/Services/AuthShibboleth/classes/class.ilShibbolethRoleAssignmentRule.php
+++ b/Services/AuthShibboleth/classes/class.ilShibbolethRoleAssignmentRule.php
@@ -24,12 +24,13 @@
  */
 class ilShibbolethRoleAssignmentRule
 {
-    const ERR_MISSING_NAME = 'shib_missing_attr_name';
-    const ERR_MISSING_VALUE = 'shib_missing_attr_value';
-    const ERR_MISSING_ROLE = 'shib_missing_role';
-    const ERR_MISSING_PLUGIN_ID = 'shib_missing_plugin_id';
-    const TABLE_NAME = 'shib_role_assignment';
-    protected ilDBInterface $db;
+    private const ERR_MISSING_NAME = 'shib_missing_attr_name';
+    private const ERR_MISSING_VALUE = 'shib_missing_attr_value';
+    private const ERR_MISSING_ROLE = 'shib_missing_role';
+    private const ERR_MISSING_PLUGIN_ID = 'shib_missing_plugin_id';
+    private const TABLE_NAME = 'shib_role_assignment';
+
+    private ilDBInterface $db;
     private int $rule_id;
     private int $role_id = 0;
     private string $attribute_name = '';
@@ -48,9 +49,6 @@ class ilShibbolethRoleAssignmentRule
         $this->read();
     }
 
-    /**
-     * @param $a_id
-     */
     public function setRuleId(int $a_id) : void
     {
         $this->rule_id = $a_id;
@@ -61,9 +59,6 @@ class ilShibbolethRoleAssignmentRule
         return $this->rule_id;
     }
 
-    /**
-     * @param $a_id
-     */
     public function setRoleId(int $a_id) : void
     {
         $this->role_id = $a_id;
@@ -74,9 +69,6 @@ class ilShibbolethRoleAssignmentRule
         return $this->role_id;
     }
 
-    /**
-     * @param $a_name
-     */
     public function setName(string $a_name) : void
     {
         $this->attribute_name = $a_name;
@@ -87,9 +79,6 @@ class ilShibbolethRoleAssignmentRule
         return $this->attribute_name;
     }
 
-    /**
-     * @param $a_value
-     */
     public function setValue(string $a_value) : void
     {
         $this->attribute_value = $a_value;
@@ -100,9 +89,6 @@ class ilShibbolethRoleAssignmentRule
         return $this->attribute_value;
     }
 
-    /**
-     * @param $a_status
-     */
     public function enablePlugin(bool $a_status) : void
     {
         $this->plugin_active = $a_status;
@@ -113,9 +99,6 @@ class ilShibbolethRoleAssignmentRule
         return $this->plugin_active;
     }
 
-    /**
-     * @param $a_status
-     */
     public function enableAddOnUpdate(bool $a_status) : void
     {
         $this->add_on_update = $a_status;
@@ -126,9 +109,6 @@ class ilShibbolethRoleAssignmentRule
         return $this->add_on_update;
     }
 
-    /**
-     * @param $a_status
-     */
     public function enableRemoveOnUpdate(bool $a_status) : void
     {
         $this->remove_on_update = $a_status;
@@ -149,18 +129,15 @@ class ilShibbolethRoleAssignmentRule
         return $this->plugin_id;
     }
 
-    /**
-     * @return string
-     */
-    public function conditionToString()
+    public function conditionToString() : ?string
     {
         global $DIC;
         $lng = $DIC['lng'];
         if ($this->isPluginActive()) {
             return $lng->txt('shib_plugin_id') . ': ' . $this->getPluginId();
-        } else {
-            return $this->getName() . '=' . $this->getValue();
         }
+
+        return $this->getName() . '=' . $this->getValue();
     }
 
     public function validate() : string
@@ -232,12 +209,9 @@ class ilShibbolethRoleAssignmentRule
     }
 
     /**
-     * @param $a_data
-     *
-     * @return bool
      * @deprecated
      */
-    public function matches($a_data)
+    public function matches(array $a_data) : bool
     {
         if ($this->isPluginActive()) {
             return ilShibbolethRoleAssignmentRules::callPlugin($this->getPluginId(), $a_data);
@@ -249,53 +223,47 @@ class ilShibbolethRoleAssignmentRule
         $values = $a_data[$this->getName()];
         if (is_array($values)) {
             return in_array($this->getValue(), $values);
-        } else {
-            return $this->wildcardCompare($this->getValue(), $values);
         }
+
+        return $this->wildcardCompare($this->getValue(), $values);
     }
 
     /**
-     * @param $a_str1
-     * @param $a_str2
-     *
      * @deprecated
      */
-    protected function wildcardCompare($a_str1, $a_str2) : bool
+    protected function wildcardCompare(string $a_str1, string $a_str2) : bool
     {
         $pattern = str_replace('*', '.*?', $a_str1);
 
         return (bool) preg_match("/" . $pattern . "/us", $a_str2);
     }
 
-    /**
-     * @return bool
-     */
-    public function doesMatch(array $a_data)
+    public function doesMatch(array $a_data) : bool
     {
         if ($this->isPluginActive()) {
             return ilShibbolethRoleAssignmentRules::callPlugin($this->getPluginId(), $a_data);
         }
+
         if (!isset($a_data[$this->getName()])) {
             return false;
         }
+
         $values = $a_data[$this->getName()];
         if (is_array($values)) {
             return in_array($this->getValue(), $values);
-        } else {
-            $pattern = str_replace('*', '.*?', $this->getValue());
-
-            return (bool) preg_match('/^' . $pattern . '$/us', $values);
         }
+
+        $pattern = str_replace('*', '.*?', $this->getValue());
+
+        return (bool) preg_match('/^' . $pattern . '$/us', $values);
     }
 
-    /**
-     * @return bool
-     */
-    private function read()
+    private function read() : void
     {
         if ($this->getRuleId() === 0) {
-            return true;
+            return;
         }
+
         $query = 'SELECT * FROM ' . self::TABLE_NAME . ' ' . 'WHERE rule_id = ' . $this->db->quote(
             $this->getRuleId(),
             'integer'

--- a/Services/AuthShibboleth/classes/class.ilShibbolethRoleAssignmentRules.php
+++ b/Services/AuthShibboleth/classes/class.ilShibbolethRoleAssignmentRules.php
@@ -53,7 +53,7 @@ class ilShibbolethRoleAssignmentRules
         $query = "SELECT COUNT(*) num FROM shib_role_assignment ";
         $res = $ilDB->query($query);
         $row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT);
-        return (int) $row->num ?? 0;
+        return (int) ($row->num ?? 0);
     }
 
     public static function updateAssignments(int $a_usr_id, array $a_data) : bool

--- a/Services/AuthShibboleth/classes/class.ilShibbolethRoleAssignmentTableGUI.php
+++ b/Services/AuthShibboleth/classes/class.ilShibbolethRoleAssignmentTableGUI.php
@@ -42,8 +42,7 @@ class ilShibbolethRoleAssignmentTableGUI extends ilTable2GUI
         $this->setDefaultOrderDirection("desc");
     }
 
-
-    public function fillRow(array $a_set) : void
+    protected function fillRow(array $a_set) : void
     {
         $this->tpl->setVariable('VAL_ID', $a_set['id']);
         $this->tpl->setVariable('VAL_TYPE', $a_set['type']);

--- a/Services/AuthShibboleth/classes/class.ilShibbolethWAYF.php
+++ b/Services/AuthShibboleth/classes/class.ilShibbolethWAYF.php
@@ -81,6 +81,7 @@ class ilShibbolethWAYF
     {
         $idp_cookie = $this->generateCookieArray($_COOKIE['_saml_idp']);
 
+        $selectedIDP = null;
         if ($idp_cookie !== [] && isset($this->idp_list[end($idp_cookie)])) {
             $selectedIDP = end($idp_cookie);
             $selectElement = '
@@ -91,6 +92,7 @@ class ilShibbolethWAYF
 		<select name="idp_selection">
 			<option value="-" selected="selected">' . $this->lng->txt("shib_member_of") . '</option>';
         }
+
         foreach ($this->idp_list as $idp_id => $idp_data) {
             if ($idp_id == $selectedIDP) {
                 $selectElement .= '<option value="' . $idp_id . '" selected="selected">' . $idp_data[0] . '</option>';

--- a/Services/AuthShibboleth/classes/class.ilShibbolethWAYF.php
+++ b/Services/AuthShibboleth/classes/class.ilShibbolethWAYF.php
@@ -139,9 +139,9 @@ class ilShibbolethWAYF
     {
         if (!$this->isSelection() || $this->isValidSelection()) {
             return '';
-        } else {
-            return $this->lng->txt("shib_invalid_home_organization");
         }
+
+        return $this->lng->txt("shib_invalid_home_organization");
     }
 
     /**

--- a/Services/AuthShibboleth/interfaces/interface.ilShibbolethRoleAssignmentPlugin.php
+++ b/Services/AuthShibboleth/interfaces/interface.ilShibbolethRoleAssignmentPlugin.php
@@ -12,25 +12,22 @@
  *      https://github.com/ILIAS-eLearning
  *
  *****************************************************************************/
+
 /**
-* Interface for shibboleth role assignment plugins
-*
-* @author Stefan Meyer <meyer@leifos.com>
-* @version $Id$
-*
-*
-* @ingroup ServicesAuthShibboleth
-*/
+ * Interface for shibboleth role assignment plugins
+ * @author Stefan Meyer <meyer@leifos.com>
+ * @version $Id$
+ * @ingroup ServicesAuthShibboleth
+ */
 interface ilShibbolethRoleAssignmentPlugin
 {
-    
     /**
      * check role assignment for a specific plugin id
      * (defined in the shibboleth role assignment administration).
      *
-     * @param int	$a_plugin_id	Unique plugin id
-     * @param array $a_user_data	Array with user data ($_SERVER)
+     * @param int $a_plugin_id Unique plugin id
+     * @param array $a_user_data Array with user data ($_SERVER)
      * @return bool whether the condition is fullfilled or not
      */
-    public function checkRoleAssignment(int $a_plugin_id, array $a_user_data);
+    public function checkRoleAssignment(int $a_plugin_id, array $a_user_data) : bool;
 }


### PR DESCRIPTION
Hello @chfsx, 

I completed the review of the `Services/AuthShibboleth` component.

Results:

- [x] The code style is `PSR-2 + X` compliant
- [ ] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`: I found 3 usages of `$_REQUEST`, 17 usages of `$_SESSION` and 6 usage of `$_POST`.
- [ ] There is a `Unit Test Suite` with at least one unit test
- [ ] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

--

Actions needed:
- [ ] Please eliminate the usage of super global variables.
- [ ] Please add a unit test suite with at least one passing unit test.

Best regards,
@mjansenDatabay  