### PR TITLE
PHP 8: Code Review `LDAP`

### DIFF
--- a/Services/Authentication/classes/class.ilAuthLoginPageEditorGUI.php
+++ b/Services/Authentication/classes/class.ilAuthLoginPageEditorGUI.php
@@ -141,11 +141,9 @@ class ilAuthLoginPageEditorGUI
         //$page_gui->setFullscreenLink($this->ctrl->getLinkTarget($this, "showMediaFullscreen"));
         //$page_gui->setLinkParams($this->ctrl->getUrlParameterString()); // todo
         //		$page_gui->setSourcecodeDownloadScript($this->ctrl->getLinkTarget($this, ""));
-        $page_gui->setPresentationTitle("");
         $page_gui->setStyleId($this->content_style_domain->getEffectiveStyleId());
         $page_gui->setTemplateOutput(false);
         //$page_gui->setLocator($contObjLocator);
-        $page_gui->setHeader("");
 
         // style tab
         //$page_gui->setTabHook($this, "addPageTabs");

--- a/Services/LDAP/classes/class.ilAuthProviderLDAP.php
+++ b/Services/LDAP/classes/class.ilAuthProviderLDAP.php
@@ -13,42 +13,38 @@
  *      https://github.com/ILIAS-eLearning
  *
  *****************************************************************************/
+
 /**
  *
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
  *
  */
-class ilAuthProviderLDAP extends ilAuthProvider implements ilAuthProviderInterface, ilAuthProviderAccountMigrationInterface
+class ilAuthProviderLDAP extends ilAuthProvider implements ilAuthProviderAccountMigrationInterface
 {
     private ilLDAPServer $server;
     private string $migration_account = '';
     private bool $force_new_account = false;
 
-    public function __construct(\ilAuthCredentials $credentials, int $a_server_id = 0)
+    public function __construct(ilAuthCredentials $credentials, int $a_server_id = 0)
     {
         parent::__construct($credentials);
         $this->initServer($a_server_id);
     }
-    
-    /**
-     * Get server
-     */
+
     public function getServer() : ilLDAPServer
     {
         return $this->server;
     }
-    
-    
+
     /**
-     * Do authentication
-     * @param \ilAuthStatus $status
+     * @inheritDoc
      */
-    public function doAuthentication(\ilAuthStatus $status) : bool
+    public function doAuthentication(ilAuthStatus $status) : bool
     {
         try {
             // bind
             $query = new ilLDAPQuery($this->getServer());
-            $query->bind(ilLDAPQuery::LDAP_BIND_DEFAULT);
+            $query->bind();
         } catch (ilLDAPQueryException $e) {
             $this->getLogger()->error('Cannot bind to LDAP server... ' . $e->getMessage());
             $this->handleAuthenticationFail($status, 'auth_err_ldap_exception');
@@ -59,7 +55,7 @@ class ilAuthProviderLDAP extends ilAuthProvider implements ilAuthProviderInterfa
             $users = $query->fetchUser(
                 $this->getCredentials()->getUsername()
             );
-            
+
             if (!$users) {
                 $this->handleAuthenticationFail($status, 'err_wrong_login');
                 return false;
@@ -73,7 +69,7 @@ class ilAuthProviderLDAP extends ilAuthProvider implements ilAuthProviderInterfa
                 $this->handleAuthenticationFail($status, 'auth_err_ldap_exception');
                 return false;
             }
-            
+
             // check group membership
             if (!$query->checkGroupMembership(
                 $this->getCredentials()->getUsername(),
@@ -89,27 +85,32 @@ class ilAuthProviderLDAP extends ilAuthProvider implements ilAuthProviderInterfa
         }
         try {
             // now bind with login credentials
-            $query->bind(ilLDAPQuery::LDAP_BIND_AUTH, $users[$this->changeKeyCase($this->getCredentials()->getUsername())]['dn'], $this->getCredentials()->getPassword());
+            $query->bind(
+                ilLDAPQuery::LDAP_BIND_AUTH,
+                $users[$this->changeKeyCase($this->getCredentials()->getUsername())]['dn'],
+                $this->getCredentials()->getPassword()
+            );
         } catch (ilLDAPQueryException $e) {
             $this->handleAuthenticationFail($status, 'err_wrong_login');
             return false;
         }
-        
+
         // authentication success update profile
         return $this->updateAccount($status, $users[$this->changeKeyCase($this->getCredentials()->getUsername())]);
     }
-    
+
     /**
      * Update Account
-     * @param array $user
-     * @return bool
      */
     protected function updateAccount(ilAuthStatus $status, array $user) : bool
     {
         $user = array_change_key_case($user, CASE_LOWER);
         $this->getLogger()->dump($user, ilLogLevel::DEBUG);
-        
-        $sync = new ilLDAPUserSynchronisation('ldap_' . $this->getServer()->getServerId(), $this->getServer()->getServerId());
+
+        $sync = new ilLDAPUserSynchronisation(
+            'ldap_' . $this->getServer()->getServerId(),
+            $this->getServer()->getServerId()
+        );
         $sync->setExternalAccount($this->getCredentials()->getUsername());
         $sync->setUserData($user);
         $sync->forceCreation($this->force_new_account);
@@ -140,29 +141,22 @@ class ilAuthProviderLDAP extends ilAuthProvider implements ilAuthProviderInterfa
         $status->setAuthenticatedUserId(ilObjUser::_lookupId($internal_account));
         return true;
     }
-    
 
-    
-    /**
-     * Init Server
-     */
     protected function initServer(int $a_server_id) : void
     {
         $this->server = new ilLDAPServer($a_server_id);
     }
 
-    // Account migration
-    
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function createNewAccount(ilAuthStatus $status) : void
     {
         $this->force_new_account = true;
-        
+
         try {
             $query = new ilLDAPQuery($this->getServer());
-            $query->bind(ilLDAPQuery::LDAP_BIND_DEFAULT);
+            $query->bind();
         } catch (ilLDAPQueryException $e) {
             $this->getLogger()->error('Cannot bind to LDAP server... ' . $e->getMessage());
             $this->handleAuthenticationFail($status, 'auth_err_ldap_exception');
@@ -190,32 +184,29 @@ class ilAuthProviderLDAP extends ilAuthProvider implements ilAuthProviderInterfa
         // authentication success update profile
         $this->updateAccount($status, $users[$this->changeKeyCase($this->getCredentials()->getUsername())]);
     }
-    
-    
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function migrateAccount(ilAuthStatus $status) : void
     {
         $this->force_new_account = true;
-        
+
         try {
             $query = new ilLDAPQuery($this->getServer());
-            $query->bind(ilLDAPQuery::LDAP_BIND_DEFAULT);
+            $query->bind();
         } catch (ilLDAPQueryException $e) {
             $this->getLogger()->error('Cannot bind to LDAP server... ' . $e->getMessage());
             $this->handleAuthenticationFail($status, 'auth_err_ldap_exception');
             return;
         }
-        
+
         $users = $query->fetchUser($this->getCredentials()->getUsername());
         $this->updateAccount($status, $users[$this->changeKeyCase($this->getCredentials()->getUsername())]);
-        return;
     }
 
     /**
-     * Get trigger auth mode
+     * @inheritDoc
      */
     public function getTriggerAuthMode() : string
     {
@@ -223,7 +214,7 @@ class ilAuthProviderLDAP extends ilAuthProvider implements ilAuthProviderInterfa
     }
 
     /**
-     * Get user auth mode name
+     * @inheritDoc
      */
     public function getUserAuthModeName() : string
     {
@@ -231,21 +222,18 @@ class ilAuthProviderLDAP extends ilAuthProvider implements ilAuthProviderInterfa
     }
 
     /**
-     * Get external account name
+     * @inheritDoc
      */
     public function getExternalAccountName() : string
     {
         return $this->migration_account;
     }
-    
-    /**
-     * Set external account name
-     */
+
     public function setExternalAccountName(string $a_name) : void
     {
         $this->migration_account = $a_name;
     }
-    
+
     /**
      * Change case similar to array_change_key_case, to avoid further encoding problems.
      * @param string $a_string

--- a/Services/LDAP/classes/class.ilLDAPAttributeMapping.php
+++ b/Services/LDAP/classes/class.ilLDAPAttributeMapping.php
@@ -13,82 +13,69 @@
  *      https://github.com/ILIAS-eLearning
  *
  *****************************************************************************/
+
 /**
-* This class stores the settings that define the mapping between LDAP attribute and user profile fields.
-*
-* @author Stefan Meyer <meyer@leifos.com>
-*/
+ * This class stores the settings that define the mapping between LDAP attribute and user profile fields.
+ *
+ * @author Stefan Meyer <meyer@leifos.com>
+ */
 class ilLDAPAttributeMapping
 {
-    private static $instances = array();
+    private static array $instances = [];
     private int $server_id;
     private ilDBInterface $db;
-    private $mapping_rules = array();
-    private $rules_for_update = array();
-    private ilLanguage $lng;
 
-    /**
-     * Private constructor (Singleton for each server_id)
-     *
-     */
+    private array $mapping_rules = [];
+    private array $rules_for_update = [];
+
     private function __construct(int $a_server_id)
     {
         global $DIC;
-        
+
         $this->db = $DIC->database();
-        $this->lng = $DIC->language();
 
         $this->server_id = $a_server_id;
         $this->read();
     }
-    
-    /**
-     * Get instance of class
-     *
-     */
+
     public static function _getInstanceByServerId(int $a_server_id) : ilLDAPAttributeMapping
     {
-        if (array_key_exists($a_server_id, self::$instances) and is_object(self::$instances[$a_server_id])) {
+        if (array_key_exists($a_server_id, self::$instances) && is_object(self::$instances[$a_server_id])) {
             return self::$instances[$a_server_id];
         }
+
         return self::$instances[$a_server_id] = new ilLDAPAttributeMapping($a_server_id);
     }
-    
 
-    /**
-     * Delete mapping rules by server id
-     */
     public static function _delete(int $a_server_id) : void
     {
         global $DIC;
 
         $ilDB = $DIC['ilDB'];
-        
+
         $query = "DELETE FROM ldap_attribute_mapping " .
             "WHERE server_id =" . $ilDB->quote($a_server_id, 'integer');
         $ilDB->manipulate($query);
     }
-    
-    /**
-     * Lookup global role assignment
-     */
+
     public static function _lookupGlobalRole(int $a_server_id) : int
     {
         global $DIC;
 
         $ilDB = $DIC['ilDB'];
-        
+
         $query = "SELECT value FROM ldap_attribute_mapping " .
             "WHERE server_id =" . $ilDB->quote($a_server_id, 'integer') . " " .
             "AND keyword = " . $ilDB->quote('global_role', 'text');
 
         $res = $ilDB->query($query);
-        while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
+        if ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             return (int) $row->value;
         }
+
         return 0;
     }
-    
+
     /**
      * Check if there is ldap attribute -> user data mapping which
      * which is updated on login
@@ -98,70 +85,51 @@ class ilLDAPAttributeMapping
         global $DIC;
 
         $ilDB = $DIC['ilDB'];
-        
+
         $query = 'SELECT perform_update FROM ldap_attribute_mapping ' .
             'WHERE server_id = ' . $ilDB->quote($a_server_id, 'integer') . ' ' .
             'AND perform_update = 1';
         $res = $ilDB->query($query);
-        return $res->numRows() ? true : false;
+        return $res->numRows() > 0;
     }
 
-    /**
-     * Set mapping rule
-     *
-     * @param string ILIAS user attribute
-     * @param string ldap attribute
-     * @param bool perform update
-     *
-     */
     public function setRule(string $a_field_name, string $a_ldap_attribute, bool $a_perform_update) : void
     {
         $this->mapping_rules[$a_field_name]['value'] = $a_ldap_attribute;
         $this->mapping_rules[$a_field_name]['performUpdate'] = $a_perform_update;
     }
-    
+
     /**
      * Get all mapping rules with option 'update'
-     *
      * @return array mapping rules. E.g. array('firstname' => 'name',...)
-     *
      */
     public function getRulesForUpdate() : array
     {
         return $this->rules_for_update;
     }
-    
+
     /**
      * Get field names of all mapping rules with option 'update'
      *
      */
     public function getFieldsForUpdate() : array
     {
-        $fields = [];
-        foreach (array_values($this->rules_for_update) as $rule) {
-            if (!strlen($rule['value'])) {
-                continue;
-            }
-            if (strpos($rule['value'], ',') === false) {
-                $fields[] = strtolower($rule['value']);
-                continue;
-            }
-            $tmp_fields = explode(',', $rule['value']);
-            foreach ($tmp_fields as $tmp_field) {
-                $fields[] = trim(strtolower($tmp_field));
-            }
-        }
-        return $fields;
+        return self::getMappedFields($this->rules_for_update);
     }
-    
+
     /**
      * Get all mapping fields
      */
     public function getFields() : array
     {
+        return self::getMappedFields($this->mapping_rules);
+    }
+
+    private static function getMappedFields(array $rules) : array
+    {
         $fields = [];
-        foreach (array_values($this->mapping_rules) as $rule) {
-            if (!strlen($rule['value'])) {
+        foreach ($rules as $rule) {
+            if (!$rule['value']) {
                 continue;
             }
             if (strpos($rule['value'], ',') === false) {
@@ -170,40 +138,42 @@ class ilLDAPAttributeMapping
             }
             $tmp_fields = explode(',', $rule['value']);
             foreach ($tmp_fields as $tmp_field) {
-                $fields[] = trim(strtolower($tmp_field));
+                $fields[] = strtolower(trim($tmp_field));
             }
         }
         return $fields;
     }
-    
+
     /**
      * Get all rules
      *
      * @return array mapping rules. E.g. array('firstname' => 'name',...)
-     *
      */
-    public function getRules() : array
+    public function getRules(bool $onlyApplicable = false) : array
     {
-        return $this->mapping_rules;
+        if (!$onlyApplicable) {
+            return $this->mapping_rules;
+        }
+        return array_filter($this->mapping_rules, static function (array $rule) : bool {
+            return $rule['value'] !== '';
+        });
     }
-    
+
     /**
      * Clear rules => Does not perform an update
-     *
      */
     public function clearRules() : void
     {
         $this->mapping_rules = array();
     }
-    
+
     /**
      * Save mapping rules to db
-     *
      */
     public function save() : void
     {
         $this->delete();
-        
+
         foreach ($this->mapping_rules as $keyword => $options) {
             $query = "INSERT INTO ldap_attribute_mapping (server_id,keyword,value,perform_update) " .
                 "VALUES( " .
@@ -215,19 +185,17 @@ class ilLDAPAttributeMapping
             $this->db->manipulate($query);
         }
     }
-    
+
     /**
      * Delete all entries
-     *
      */
     public function delete() : void
     {
         self::_delete($this->server_id);
     }
-    
+
     /**
      * Check whether an update should be performed on a specific user attribute or not
-     *
      * @param string ILIAS user attribute
      *
      */
@@ -236,9 +204,10 @@ class ilLDAPAttributeMapping
         if (array_key_exists($a_field_name, $this->mapping_rules)) {
             return (bool) $this->mapping_rules[$a_field_name]['performUpdate'];
         }
+
         return false;
     }
-    
+
     /**
      * Get LDAP attribute name by given ILIAS profile field
      *
@@ -250,22 +219,23 @@ class ilLDAPAttributeMapping
         if (array_key_exists($a_field_name, $this->mapping_rules)) {
             return $this->mapping_rules[$a_field_name]['value'];
         }
+
         return '';
     }
-    
+
     /**
-     * Read mapping setttings from db
+     * Read mapping settings from db
      */
     private function read() : void
     {
         $query = "SELECT * FROM ldap_attribute_mapping " .
-            "WHERE server_id =" . $this->db->quote($this->server_id, 'integer') . " ";
+            "WHERE server_id =" . $this->db->quote($this->server_id, 'integer');
 
         $res = $this->db->query($query);
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             $this->mapping_rules[$row->keyword]['value'] = $row->value;
             $this->mapping_rules[$row->keyword]['performUpdate'] = (bool) $row->perform_update;
-            
+
             if ($row->perform_update) {
                 $this->rules_for_update[$row->keyword]['value'] = $row->value;
             }

--- a/Services/LDAP/classes/class.ilLDAPAttributeMappingUtils.php
+++ b/Services/LDAP/classes/class.ilLDAPAttributeMappingUtils.php
@@ -13,23 +13,23 @@
  *      https://github.com/ILIAS-eLearning
  *
  *****************************************************************************/
+
 /**
-* A collection of static utility functions for LDAP attribute mapping
-*
-* @author Stefan Meyer <meyer@leifos.com>
-*/
+ * A collection of static utility functions for LDAP attribute mapping
+ *
+ * @author Stefan Meyer <meyer@leifos.com>
+ */
 class ilLDAPAttributeMappingUtils
 {
     /**
      * Get mapping rule by objectClass
-     *
-     * @param string
-     *
+     * @param string $a_class
+     * @return array<string, string>
      */
     public static function _getMappingRulesByClass(string $a_class) : array
     {
-        $mapping_rule = array();
-        
+        $mapping_rule = [];
+
         switch ($a_class) {
             case 'inetOrgPerson':
                 $mapping_rule['firstname'] = 'givenName';
@@ -39,8 +39,8 @@ class ilLDAPAttributeMappingUtils
                 $mapping_rule['phone_mobile'] = 'mobile';
                 $mapping_rule['email'] = 'mail';
                 $mapping_rule['photo'] = 'jpegPhoto';
-                // no break since it inherits from organizationalPerson and person
-                
+            // no break since it inherits from organizationalPerson and person
+
             case 'organizationalPerson':
                 $mapping_rule['fax'] = 'facsimileTelephoneNumber';
                 $mapping_rule['title'] = 'title';
@@ -48,13 +48,13 @@ class ilLDAPAttributeMappingUtils
                 $mapping_rule['zipcode'] = 'postalCode';
                 $mapping_rule['city'] = 'l';
                 $mapping_rule['country'] = 'st';
-                // no break since it inherits from person
-                
+            // no break since it inherits from person
+
             case 'person':
                 $mapping_rule['lastname'] = 'sn';
                 $mapping_rule['phone_office'] = 'telephoneNumber';
                 break;
-                
+
             case 'ad_2003':
                 $mapping_rule['firstname'] = 'givenName';
                 $mapping_rule['lastname'] = 'sn';
@@ -71,6 +71,7 @@ class ilLDAPAttributeMappingUtils
                 $mapping_rule['fax'] = 'facsimileTelephoneNumber';
                 break;
         }
+
         return $mapping_rule;
     }
 }

--- a/Services/LDAP/classes/class.ilLDAPPlugin.php
+++ b/Services/LDAP/classes/class.ilLDAPPlugin.php
@@ -22,27 +22,26 @@ abstract class ilLDAPPlugin extends ilPlugin
 {
     /**
      * Check if user data matches a keyword value combination
-     * @return
-     * @param object $a_user_data
-     * @param object $a_keyword
-     * @param object $a_value
      */
-    protected function checkValue($a_user_data, $a_keyword, $a_value)
+    protected function checkValue(array $a_user_data, string $a_keyword, string $a_value) : bool
     {
         if (!$a_user_data[$a_keyword]) {
             return false;
         }
+
         if (is_array($a_user_data[$a_keyword])) {
             foreach ($a_user_data[$a_keyword] as $values) {
-                if (strcasecmp(trim($values), $a_value) == 0) {
+                if (strcasecmp(trim($values), $a_value) === 0) {
                     return true;
                 }
             }
             return false;
         }
-        if (strcasecmp(trim($a_user_data[$a_keyword]), trim($a_value)) == 0) {
+
+        if (strcasecmp(trim($a_user_data[$a_keyword]), trim($a_value)) === 0) {
             return true;
         }
+
         return false;
     }
 }

--- a/Services/LDAP/classes/class.ilLDAPQuery.php
+++ b/Services/LDAP/classes/class.ilLDAPQuery.php
@@ -15,9 +15,9 @@
  *****************************************************************************/
 
 /**
-*
-* @author Stefan Meyer <meyer@leifos.com>
-*/
+ *
+ * @author Stefan Meyer <meyer@leifos.com>
+ */
 class ilLDAPQuery
 {
     public const LDAP_BIND_DEFAULT = 0;
@@ -25,21 +25,14 @@ class ilLDAPQuery
     public const LDAP_BIND_TEST = 2;
     public const LDAP_BIND_AUTH = 10;
 
-    /**
-     * @deprecated with PHP 7.3 (LDAP_CONTROL_PAGEDRESULTS)
-     */
-    const IL_LDAP_CONTROL_PAGEDRESULTS = '1.2.840.113556.1.4.319';
-
-
-    const IL_LDAP_SUPPORTED_CONTROL = 'supportedControl';
-
-    const PAGINATION_SIZE = 100;
+    private const IL_LDAP_SUPPORTED_CONTROL = 'supportedControl';
+    private const PAGINATION_SIZE = 100;
 
     private string $ldap_server_url;
     private ilLDAPServer $settings;
-    
+
     private ilLogger $logger;
-    
+
     private ilLDAPAttributeMapping $mapping;
 
     private array $user_fields = [];
@@ -50,7 +43,7 @@ class ilLDAPQuery
      * @var resource
      */
     private $lh;
-    
+
     /**
      * @throws ilLDAPQueryException
      */
@@ -60,28 +53,27 @@ class ilLDAPQuery
         $this->logger = $DIC->logger()->auth();
 
         $this->settings = $a_server;
-        
-        if (strlen($a_url)) {
+
+        if ($a_url !== '') {
             $this->ldap_server_url = $a_url;
         } else {
             $this->ldap_server_url = $this->settings->getUrl();
         }
-        
+
         $this->mapping = ilLDAPAttributeMapping::_getInstanceByServerId($this->settings->getServerId());
 
         $this->fetchUserProfileFields();
         $this->connect();
     }
-    
+
     /**
      * Get server
-     * @return ilLDAPServer
      */
     public function getServer() : ilLDAPServer
     {
         return $this->settings;
     }
-    
+
     /**
      * Get one user by login name
      *
@@ -92,12 +84,12 @@ class ilLDAPQuery
     {
         if (!$this->readUserData($a_name)) {
             return [];
-        } else {
-            return $this->users;
         }
+
+        return $this->users;
     }
-    
-    
+
+
     /**
      * Fetch all users
      *
@@ -108,7 +100,7 @@ class ilLDAPQuery
         // First of all check if a group restriction is enabled
         // YES: => fetch all group members
         // No:  => fetch all users
-        if (strlen($this->settings->getGroupName())) {
+        if ($this->settings->getGroupName() !== '') {
             $this->logger->debug('Searching for group members.');
 
             $groups = $this->settings->getGroupNames();
@@ -120,14 +112,14 @@ class ilLDAPQuery
                 }
             }
         }
-        if (!strlen($this->settings->getGroupName()) or $this->settings->isMembershipOptional()) {
+        if ($this->settings->getGroupName() === '' || $this->settings->isMembershipOptional()) {
             $this->logger->info('Start reading all users...');
             $this->readAllUsers();
             #throw new ilLDAPQueryException('LDAP: Called import of users without specifying group restrictions. NOT IMPLEMENTED YET!');
         }
         return $this->users;
     }
-    
+
     /**
      * Perform a query
      * @throws ilLDAPQueryException
@@ -144,9 +136,10 @@ class ilLDAPQuery
                     $a_scope
                 ));
         }
+
         return (new ilLDAPResult($this->lh, $res))->run();
     }
-    
+
     /**
      * Add value to an existing attribute
      *
@@ -154,12 +147,13 @@ class ilLDAPQuery
      */
     public function modAdd(string $a_dn, array $a_attribute) : bool
     {
-        if (@ldap_mod_add($this->lh, $a_dn, $a_attribute)) {
+        if (ldap_mod_add($this->lh, $a_dn, $a_attribute)) {
             return true;
         }
+
         throw new ilLDAPQueryException(__METHOD__ . ' ' . ldap_error($this->lh));
     }
-    
+
     /**
      * Delete value from an existing attribute
      *
@@ -167,26 +161,26 @@ class ilLDAPQuery
      */
     public function modDelete(string $a_dn, array $a_attribute) : bool
     {
-        if (@ldap_mod_del($this->lh, $a_dn, $a_attribute)) {
+        if (ldap_mod_del($this->lh, $a_dn, $a_attribute)) {
             return true;
         }
         throw new ilLDAPQueryException(__METHOD__ . ' ' . ldap_error($this->lh));
     }
-    
+
     /**
      * Fetch all users
      * This function splits the query to filters like e.g (uid=a*) (uid=b*)...
      * This avoids AD page_size_limit
      */
-    private function readAllUsers()
+    private function readAllUsers() : void
     {
         // Build search base
-        if (($dn = $this->settings->getSearchBase()) && substr($dn, -1) != ',') {
+        $this->logger->debug($this->settings->getSearchBase());
+        $this->logger->debug($this->settings->getBaseDN());
+        if (($dn = $this->settings->getSearchBase()) && substr($dn, -1) !== ',') {
             $dn .= ',';
         }
         $dn .= $this->settings->getBaseDN();
-        $tmp_result = null;
-
         if ($this->checkPaginationEnabled()) {
             try {
                 $tmp_result = $this->runReadAllUsersPaged($dn);
@@ -205,14 +199,12 @@ class ilLDAPQuery
         $attribute = strtolower($this->settings->getUserAttribute());
         foreach ($tmp_result->getRows() as $data) {
             if (isset($data[$attribute])) {
-                $this->readUserData($data[$attribute], false, false);
+                $this->readUserData($data[$attribute]);
             } else {
                 $this->logger->warning('Unknown error. No user attribute found.');
             }
         }
         unset($tmp_result);
-
-        return true;
     }
 
     /**
@@ -230,66 +222,69 @@ class ilLDAPQuery
         $cookie = '';
         $estimated_results = 0;
         do {
-            try {
-                $res = ldap_control_paged_result($this->lh, self::PAGINATION_SIZE, true, $cookie);
-                if ($res === false) {
-                    throw new ilLDAPPagingException('Result pagination failed.');
-                }
-            } catch (Exception $e) {
-                $this->logger->warning('Result pagination failed with message: ' . $e->getMessage());
-                throw new ilLDAPPagingException($e->getMessage());
-            }
-
+            // Setup our paged results control.
+            $controls = [
+                LDAP_CONTROL_PAGEDRESULTS => [
+                    'oid' => LDAP_CONTROL_PAGEDRESULTS,
+                    'isCritical' => true,
+                    'value' => [
+                        'size' => self::PAGINATION_SIZE,
+                        'cookie' => $cookie,
+                    ],
+                ],
+            ];
             $res = $this->queryByScope(
                 $this->settings->getUserScope(),
                 $dn,
                 $filter,
-                array($this->settings->getUserAttribute())
+                array($this->settings->getUserAttribute()),
+                $controls
             );
+
             $tmp_result->setResult($res);
             $tmp_result->run();
             try {
-                ldap_control_paged_result_response($this->lh, $res, $cookie, $estimated_results);
+                $errcode = 0;
+                $dn = '';
+                $errmsg = '';
+                $referrals = [];
+                ldap_parse_result($this->lh, $res, $errcode, $dn, $errmsg, $referrals, $controls);
+                $cookie = $controls[LDAP_CONTROL_PAGEDRESULTS]['value']['cookie'] ?? '';
                 $this->logger->debug('Estimated number of results: ' . $estimated_results);
             } catch (Exception $e) {
                 $this->logger->warning('Result pagination failed with message: ' . $e->getMessage());
                 throw new ilLDAPPagingException($e->getMessage());
             }
-        } while ($cookie !== null && $cookie != '');
+        } while (!empty($cookie));
 
         // finally reset cookie
-        ldap_control_paged_result($this->lh, 10000, false, $cookie);
         return $tmp_result;
     }
 
     /**
-     * read all users partial by alphabet
-     *
+     * Read all users partial by alphabet
+     * @param string $dn
      * @return ilLDAPResult
      */
     private function runReadAllUsersPartial(string $dn) : ilLDAPResult
     {
         $filter = $this->settings->getFilter();
-        $page_filter = array('a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','-');
-        $chars = array('a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z');
+        $page_filter = array('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '-');
+        $chars = array('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z');
         $tmp_result = new ilLDAPResult($this->lh);
 
         foreach ($page_filter as $letter) {
             $new_filter = '(&';
             $new_filter .= $filter;
 
-            switch ($letter) {
-                case '-':
-                    $new_filter .= ('(!(|');
-                    foreach ($chars as $char) {
-                        $new_filter .= ('(' . $this->settings->getUserAttribute() . '=' . $char . '*)');
-                    }
-                    $new_filter .= ')))';
-                    break;
-
-                default:
-                    $new_filter .= ('(' . $this->settings->getUserAttribute() . '=' . $letter . '*))');
-                    break;
+            if ($letter === '-') {
+                $new_filter .= ('(!(|');
+                foreach ($chars as $char) {
+                    $new_filter .= ('(' . $this->settings->getUserAttribute() . '=' . $char . '*)');
+                }
+                $new_filter .= ')))';
+            } else {
+                $new_filter .= ('(' . $this->settings->getUserAttribute() . '=' . $letter . '*))');
             }
 
             $this->logger->info('Searching with ldap search and filter ' . $new_filter . ' in ' . $dn);
@@ -315,21 +310,21 @@ class ilLDAPQuery
     public function checkGroupMembership(string $a_ldap_user_name, array $ldap_user_data) : bool
     {
         $group_names = $this->getServer()->getGroupNames();
-        
+
         if (!count($group_names)) {
-            $this->logger()->debug('No LDAP group restrictions found');
+            $this->logger->debug('No LDAP group restrictions found');
             return true;
         }
-        
+
         $group_dn = $this->getServer()->getGroupDN();
         if (
             $group_dn &&
-            (substr($group_dn, -1) != ',')
+            (substr($group_dn, -1) !== ',')
         ) {
             $group_dn .= ',';
         }
         $group_dn .= $this->getServer()->getBaseDN();
-        
+
         foreach ($group_names as $group) {
             $user = $a_ldap_user_name;
             if ($this->getServer()->enabledGroupMemberIsDN()) {
@@ -339,7 +334,7 @@ class ilLDAPQuery
                     $user = $ldap_user_data['dn'];
                 }
             }
-            
+
             $filter = sprintf(
                 '(&(%s=%s)(%s=%s)%s)',
                 $this->getServer()->getGroupAttribute(),
@@ -350,28 +345,28 @@ class ilLDAPQuery
             );
             $this->logger->debug('Current group search base: ' . $group_dn);
             $this->logger->debug('Current group filter: ' . $filter);
-            
+
             $res = $this->queryByScope(
                 $this->getServer()->getGroupScope(),
                 $group_dn,
                 $filter,
                 [$this->getServer()->getGroupMember()]
             );
-            
+
             $this->logger->dump($res);
-            
+
             $tmp_result = new ilLDAPResult($this->lh, $res);
             $tmp_result->run();
             $group_result = $tmp_result->getRows();
-            
+
             $this->logger->debug('Group query returned: ');
             $this->logger->dump($group_result, ilLogLevel::DEBUG);
-            
+
             if (count($group_result)) {
                 return true;
             }
         }
-        
+
         // group restrictions failed check optional membership
         if ($this->getServer()->isMembershipOptional()) {
             $this->logger->debug('Group restrictions failed, checking user filter.');
@@ -383,15 +378,15 @@ class ilLDAPQuery
         $this->logger->debug('Group restrictions failed.');
         return false;
     }
-    
+
 
     /**
      * Fetch group member ids
      */
-    private function fetchGroupMembers($a_name = '') : bool
+    private function fetchGroupMembers(string $a_name = '') : void
     {
-        $group_name = strlen($a_name) ? $a_name : $this->settings->getGroupName();
-        
+        $group_name = $a_name !== '' ? $a_name : $this->settings->getGroupName();
+
         // Build filter
         $filter = sprintf(
             '(&(%s=%s)%s)',
@@ -399,14 +394,14 @@ class ilLDAPQuery
             $group_name,
             $this->settings->getGroupFilter()
         );
-        
-        
+
+
         // Build search base
-        if (($gdn = $this->settings->getGroupDN()) && substr($gdn, -1) != ',') {
+        if (($gdn = $this->settings->getGroupDN()) && substr($gdn, -1) !== ',') {
             $gdn .= ',';
         }
         $gdn .= $this->settings->getBaseDN();
-        
+
         $this->logger->debug('Using filter ' . $filter);
         $this->logger->debug('Using DN ' . $gdn);
         $res = $this->queryByScope(
@@ -415,19 +410,19 @@ class ilLDAPQuery
             $filter,
             array($this->settings->getGroupMember())
         );
-            
+
         $tmp_result = new ilLDAPResult($this->lh, $res);
         $tmp_result->run();
         $group_data = $tmp_result->getRows();
-        
-        
+
+
         if (!$tmp_result->numRows()) {
             $this->logger->info('No group found.');
-            return false;
+            return;
         }
-                
+
         $attribute_name = strtolower($this->settings->getGroupMember());
-        
+
         // All groups
         foreach ($group_data as $data) {
             if (is_array($data[$attribute_name])) {
@@ -440,9 +435,8 @@ class ilLDAPQuery
             }
         }
         unset($tmp_result);
-        return true;
     }
-    
+
     /**
      * Read user data
      * @param bool $a_check_dn check dn
@@ -451,14 +445,12 @@ class ilLDAPQuery
     private function readUserData(string $a_name, bool $a_check_dn = false, bool $a_try_group_user_filter = false) : bool
     {
         $filter = $this->settings->getFilter();
-        if ($a_try_group_user_filter) {
-            if ($this->settings->isMembershipOptional()) {
-                $filter = $this->settings->getGroupUserFilter();
-            }
+        if ($a_try_group_user_filter && $this->settings->isMembershipOptional()) {
+            $filter = $this->settings->getGroupUserFilter();
         }
-        
+
         // Build filter
-        if ($this->settings->enabledGroupMemberIsDN() and $a_check_dn) {
+        if ($a_check_dn && $this->settings->enabledGroupMemberIsDN()) {
             $dn = $a_name;
 
             $fields = array_merge($this->user_fields, array('useraccountcontrol'));
@@ -472,15 +464,15 @@ class ilLDAPQuery
             );
 
             // Build search base
-            if (($dn = $this->settings->getSearchBase()) && substr($dn, -1) != ',') {
+            if (($dn = $this->settings->getSearchBase()) && substr($dn, -1) !== ',') {
                 $dn .= ',';
             }
             $dn .= $this->settings->getBaseDN();
             $fields = array_merge($this->user_fields, array('useraccountcontrol'));
             $res = $this->queryByScope($this->settings->getUserScope(), strtolower($dn), $filter, $fields);
         }
-        
-        
+
+
         $tmp_result = new ilLDAPResult($this->lh, $res);
         $tmp_result->run();
         if (!$tmp_result->numRows()) {
@@ -488,22 +480,20 @@ class ilLDAPQuery
             unset($tmp_result);
             return false;
         }
-        
+
         if ($user_data = $tmp_result->get()) {
-            if (isset($user_data['useraccountcontrol'])) {
-                if (($user_data['useraccountcontrol'] & 0x02)) {
-                    $this->logger->notice('LDAP: ' . $a_name . ' account disabled.');
-                    return false;
-                }
+            if (isset($user_data['useraccountcontrol']) && ($user_data['useraccountcontrol'] & 0x02)) {
+                $this->logger->notice('LDAP: ' . $a_name . ' account disabled.');
+                return false;
             }
-            
+
             $account = $user_data[strtolower($this->settings->getUserAttribute())];
             if (is_array($account)) {
                 $user_ext = strtolower(array_shift($account));
             } else {
                 $user_ext = strtolower($account);
             }
-            
+
             // auth mode depends on ldap server settings
             $auth_mode = $this->settings->getAuthenticationMappingKey();
             $user_data['ilInternalAccount'] = ilObjUser::_checkExternalAuthAccount($auth_mode, $user_ext);
@@ -513,51 +503,45 @@ class ilLDAPQuery
     }
 
     /**
-     * Parse authentication mode
-     * @return string auth mode
-     */
-    private function parseAuthMode() : string
-    {
-        return $this->settings->getAuthenticationMappingKey();
-    }
-    
-    /**
      * Query by scope
      * IL_SCOPE_SUB => ldap_search
      * IL_SCOPE_ONE => ldap_list
+     * @param array|null $controls LDAP Control to be passed on the the ldap functions
+     * @return resource|null
      */
-    private function queryByScope(int $a_scope, string $a_base_dn, string $a_filter, array $a_attributes)
+    private function queryByScope(int $a_scope, string $a_base_dn, string $a_filter, array $a_attributes, array $controls = null)
     {
-        $a_filter = $a_filter ? $a_filter : "(objectclass=*)";
+        $a_filter = $a_filter ?: "(objectclass=*)";
 
         switch ($a_scope) {
             case ilLDAPServer::LDAP_SCOPE_SUB:
-                $res = @ldap_search($this->lh, $a_base_dn, $a_filter, $a_attributes);
+                $res = ldap_search($this->lh, $a_base_dn, $a_filter, $a_attributes, 0, 0, 0, LDAP_DEREF_NEVER, $controls);
                 break;
-                
-            case ilLDAPServer::LDAP_SCOPE_ONE:
-                $res = @ldap_list($this->lh, $a_base_dn, $a_filter, $a_attributes);
-                break;
-            
-            case ilLDAPServer::LDAP_SCOPE_BASE:
 
-                $res = @ldap_read($this->lh, $a_base_dn, $a_filter, $a_attributes);
+            case ilLDAPServer::LDAP_SCOPE_ONE:
+                $res = ldap_list($this->lh, $a_base_dn, $a_filter, $a_attributes, 0, 0, 0, LDAP_DEREF_NEVER, $controls);
+                break;
+
+            case ilLDAPServer::LDAP_SCOPE_BASE:
+                $res = ldap_read($this->lh, $a_base_dn, $a_filter, $a_attributes, 0, 0, 0, LDAP_DEREF_NEVER, $controls);
                 break;
 
             default:
-                $this->logger->warning("LDAP: LDAPQuery: Unknown search scope");
+                throw new ilLDAPUndefinedScopeException(
+                    "Undefined LDAP Search Scope: " . $a_scope
+                );
         }
-        
-        $error = ldap_error($this->lh);
-        if (strcmp('Success', $error) !== 0) {
-            $this->logger->warning($error);
+
+        $error = ldap_errno($this->lh);
+        if ($error) {
+            $this->logger->warning("LDAP Error Code: " . $error . "(" . ldap_err2str($error) . ")");
             $this->logger->warning('Base DN:' . $a_base_dn);
             $this->logger->warning('Filter: ' . $a_filter);
         }
-        
-        return $res;
+
+        return $res ?? null;
     }
-    
+
     /**
      * Connect to LDAP server
      *
@@ -566,8 +550,8 @@ class ilLDAPQuery
      */
     private function connect() : void
     {
-        $this->lh = @ldap_connect($this->ldap_server_url);
-        
+        $this->lh = ldap_connect($this->ldap_server_url);
+
         // LDAP Connect
         if (!$this->lh) {
             throw new ilLDAPQueryException("LDAP: Cannot connect to LDAP Server: " . $this->settings->getUrl());
@@ -586,13 +570,11 @@ class ilLDAPQuery
             $this->logger->debug('Switching referrals to false.');
         }
         // Start TLS
-        if ($this->settings->isActiveTLS()) {
-            if (!ldap_start_tls($this->lh)) {
-                throw new ilLDAPQueryException("LDAP: Cannot start LDAP TLS");
-            }
+        if ($this->settings->isActiveTLS() && !ldap_start_tls($this->lh)) {
+            throw new ilLDAPQueryException("LDAP: Cannot start LDAP TLS");
         }
     }
-    
+
     /**
      * Bind to LDAP server
      *
@@ -601,70 +583,62 @@ class ilLDAPQuery
      * @throws ilLDAPQueryException on connection failure.
      *
      */
-    public function bind(int $a_binding_type = ilLDAPQuery::LDAP_BIND_DEFAULT, string $a_user_dn = '', string $a_password = '')
+    public function bind(int $a_binding_type = ilLDAPQuery::LDAP_BIND_DEFAULT, string $a_user_dn = '', string $a_password = '') : void
     {
         switch ($a_binding_type) {
-            case ilLDAPQuery::LDAP_BIND_TEST:
+            /** @noinspection PhpMissingBreakStatementInspection */
+            case self::LDAP_BIND_TEST:
                 ldap_set_option($this->lh, LDAP_OPT_NETWORK_TIMEOUT, ilLDAPServer::DEFAULT_NETWORK_TIMEOUT);
-                // fall through
-                // no break
-            case ilLDAPQuery::LDAP_BIND_DEFAULT:
+            // fall through
+            // no break
+            case self::LDAP_BIND_DEFAULT:
                 // Now bind anonymously or as user
                 if (
-                ilLDAPServer::LDAP_BIND_USER == $this->settings->getBindingType() &&
-                    strlen($this->settings->getBindUser())
+                    ilLDAPServer::LDAP_BIND_USER === $this->settings->getBindingType() &&
+                    $this->settings->getBindUser() !== ''
                 ) {
                     $user = $this->settings->getBindUser();
                     $pass = $this->settings->getBindPassword();
 
-                    define('IL_LDAP_REBIND_USER', $user);
-                    define('IL_LDAP_REBIND_PASS', $pass);
                     $this->logger->debug('Bind as ' . $user);
                 } else {
                     $user = $pass = '';
                     $this->logger->debug('Bind anonymous');
                 }
                 break;
-                
-            case ilLDAPQuery::LDAP_BIND_ADMIN:
+
+            case self::LDAP_BIND_ADMIN:
                 $user = $this->settings->getRoleBindDN();
                 $pass = $this->settings->getRoleBindPassword();
-                
-                if (!strlen($user) or !strlen($pass)) {
+
+                if ($user === '' || $pass === '') {
                     $user = $this->settings->getBindUser();
                     $pass = $this->settings->getBindPassword();
                 }
-
-                define('IL_LDAP_REBIND_USER', $user);
-                define('IL_LDAP_REBIND_PASS', $pass);
                 break;
-                
-            case ilLDAPQuery::LDAP_BIND_AUTH:
+
+            case self::LDAP_BIND_AUTH:
                 $this->logger->debug('Trying to bind as: ' . $a_user_dn);
                 $user = $a_user_dn;
                 $pass = $a_password;
                 break;
-                
-                
+
+
             default:
                 throw new ilLDAPQueryException('LDAP: unknown binding type in: ' . __METHOD__);
         }
-        
-        if (!@ldap_bind($this->lh, $user, $pass)) {
+
+        if (!ldap_bind($this->lh, $user, $pass)) {
             throw new ilLDAPQueryException('LDAP: Cannot bind as ' . $user . ' with message: ' . ldap_err2str(ldap_errno($this->lh)) . ' Trying fallback...', ldap_errno($this->lh));
-        } else {
-            $this->logger->debug('Bind successful.');
         }
+
+        $this->logger->debug('Bind successful.');
     }
-    
+
     /**
      * fetch required fields of user profile data
-     *
-     * @access private
-     * @param
-     *
      */
-    private function fetchUserProfileFields() : array
+    private function fetchUserProfileFields() : void
     {
         $this->user_fields = array_merge(
             array($this->settings->getUserAttribute()),
@@ -673,37 +647,23 @@ class ilLDAPQuery
             ilLDAPRoleAssignmentRules::getAttributeNames($this->getServer()->getServerId())
         );
     }
-    
-    
-    /**
-     * Unbind
-     */
-    private function unbind() : void
-    {
-        if ($this->lh) {
-            @ldap_unbind($this->lh);
-        }
-    }
-    
-    
+
     /**
      * Destructor unbind from ldap server
-     *
      */
     public function __destruct()
     {
         if ($this->lh) {
-            @ldap_unbind($this->lh);
+            ldap_unbind($this->lh);
         }
     }
 
     /**
      * Check if pagination is enabled (rfc: 2696)
-     * @return bool
      */
     public function checkPaginationEnabled() : bool
     {
-        if ($this->getServer()->getVersion() != 3) {
+        if ($this->getServer()->getVersion() !== 3) {
             $this->logger->info('Pagination control unavailable for ldap v' . $this->getServer()->getVersion());
             return false;
         }
@@ -717,7 +677,7 @@ class ilLDAPQuery
         if (
             array_key_exists(strtolower(self::IL_LDAP_SUPPORTED_CONTROL), $entries) &&
             is_array($entries[strtolower(self::IL_LDAP_SUPPORTED_CONTROL)]) &&
-            in_array(self::IL_LDAP_CONTROL_PAGEDRESULTS, $entries[strtolower(self::IL_LDAP_SUPPORTED_CONTROL)])
+            in_array(LDAP_CONTROL_PAGEDRESULTS, $entries[strtolower(self::IL_LDAP_SUPPORTED_CONTROL)], true)
         ) {
             $this->logger->info('Using paged control');
             return true;

--- a/Services/LDAP/classes/class.ilLDAPQueryException.php
+++ b/Services/LDAP/classes/class.ilLDAPQueryException.php
@@ -13,19 +13,11 @@
  *      https://github.com/ILIAS-eLearning
  *
  *****************************************************************************/
+
 /**
-*
-* @author Stefan Meyer <meyer@leifos.com>
-*/
+ *
+ * @author Stefan Meyer <meyer@leifos.com>
+ */
 class ilLDAPQueryException extends ilException
 {
-    /**
-     *
-     *	Nothing specific here
-     *
-     */
-    public function __construct($a_message, $a_code = 0)
-    {
-        parent::__construct($a_message, $a_code);
-    }
 }

--- a/Services/LDAP/classes/class.ilLDAPResult.php
+++ b/Services/LDAP/classes/class.ilLDAPResult.php
@@ -30,15 +30,8 @@ class ilLDAPResult
      */
     private $result;
 
-    /**
-     * @var array
-     */
-    private $rows;
-
-    /**
-     * @var array
-     */
-    private $last_row;
+    private ?array $rows;
+    private ?array $last_row;
 
     /**
      * ilLDAPPagedResult constructor.
@@ -49,7 +42,7 @@ class ilLDAPResult
     {
         $this->handle = $a_ldap_handle;
 
-        if ($a_result != null) {
+        if ($a_result !== null) {
             $this->result = $a_result;
         }
     }
@@ -58,7 +51,7 @@ class ilLDAPResult
      * Total count of resulted rows
      * @return int
      */
-    public function numRows()
+    public function numRows() : int
     {
         return is_array($this->rows) ? count($this->rows) : 0;
     }
@@ -76,7 +69,7 @@ class ilLDAPResult
      * Resource from ldap_search()
      * @param resource $result
      */
-    public function setResult($result)
+    public function setResult($result) : void
     {
         $this->result = $result;
     }
@@ -85,27 +78,27 @@ class ilLDAPResult
      * Returns last result
      * @return array
      */
-    public function get()
+    public function get() : array
     {
-        return is_array($this->last_row) ? $this->last_row : array();
+        return is_array($this->last_row) ? $this->last_row : [];
     }
 
     /**
      * Returns complete results
      * @return array
      */
-    public function getRows()
+    public function getRows() : array
     {
-        return is_array($this->rows) ? $this->rows : array();
+        return is_array($this->rows) ? $this->rows : [];
     }
 
     /**
      * Starts ldap_get_entries() and transforms results
      * @return self $this
      */
-    public function run()
+    public function run() : self
     {
-        $entries = @ldap_get_entries($this->handle, $this->result);
+        $entries = ldap_get_entries($this->handle, $this->result);
         $this->addEntriesToRows($entries);
 
         return $this;
@@ -113,17 +106,12 @@ class ilLDAPResult
 
     /**
      * Adds Results from ldap_get_entries() to rows
-     * @param array $entries
      */
-    private function addEntriesToRows($entries)
+    private function addEntriesToRows(array $entries) : void
     {
-        if (!$entries) {
-            return;
-        }
-
         $num = $entries['count'];
 
-        if ($num == 0) {
+        if ($num === 0) {
             return;
         }
 
@@ -136,19 +124,18 @@ class ilLDAPResult
 
     /**
      * Transforms results from ldap_get_entries() to a simple format
-     * @param array $entry
-     * @return array
      */
-    private function toSimpleArray($entry)
+
+    private function toSimpleArray(array $entry) : array
     {
         $data = array();
         foreach ($entry as $key => $value) {
-            $key = strtolower($key);
-
             if (is_int($key)) {
                 continue;
             }
-            if ($key == 'dn') {
+
+            $key = strtolower($key);
+            if ($key === 'dn') {
                 $data['dn'] = $value;
                 continue;
             }
@@ -157,7 +144,7 @@ class ilLDAPResult
                     for ($i = 0; $i < $value['count']; $i++) {
                         $data[$key][] = $value[$i];
                     }
-                } elseif ($value['count'] == 1) {
+                } elseif ($value['count'] === 1) {
                     $data[$key] = $value[0];
                 }
             } else {
@@ -173,6 +160,8 @@ class ilLDAPResult
      */
     public function __destruct()
     {
-        @ldap_free_result($this->result);
+        if ($this->result) {
+            ldap_free_result($this->result);
+        }
     }
 }

--- a/Services/LDAP/classes/class.ilLDAPRoleAssignmentRules.php
+++ b/Services/LDAP/classes/class.ilLDAPRoleAssignmentRules.php
@@ -13,6 +13,7 @@
  *      https://github.com/ILIAS-eLearning
  *
  *****************************************************************************/
+
 /**
  * Do role assignemnts
  *
@@ -20,39 +21,43 @@
  */
 class ilLDAPRoleAssignmentRules
 {
-    const ROLE_ACTION_ASSIGN = 'Assign';
-    const ROLE_ACTION_DEASSIGN = 'Detach';
-    
-    protected static $default_role = null;
+    private const ROLE_ACTION_ASSIGN = 'Assign';
+    private const ROLE_ACTION_DEASSIGN = 'Detach';
+
+    protected static ?int $default_role = null;
 
     public static function getDefaultRole(int $a_server_id) : int
     {
         return self::$default_role =
             ilLDAPAttributeMapping::_lookupGlobalRole($a_server_id);
     }
-    
+
     /**
      * Get all assignable roles (used for import parser)
-     * @return array roles
+     * @return array<int, int> array of roles assigned
      */
     public static function getAllPossibleRoles(int $a_server_id) : array
     {
         global $DIC;
 
         $ilDB = $DIC['ilDB'];
-        
+
         $roles = [];
         $query = "SELECT DISTINCT(role_id) FROM ldap_role_assignments " .
-                'WHERE server_id = ' . $ilDB->quote($a_server_id, 'integer');
+            'WHERE server_id = ' . $ilDB->quote($a_server_id, 'integer');
         $res = $ilDB->query($query);
+        //TODO fix this array which is always the some digit twice
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $roles[$row->role_id] = $row->role_id;
+            //TODO if key is int it will get autoconverted to int
+            $roles[$row->role_id] = (int) $row->role_id;
         }
+
         $gr = self::getDefaultRole($a_server_id);
         $roles[$gr] = $gr;
+
         return $roles;
     }
-    
+
     /**
      * get all possible attribute names
      * @return string[]
@@ -62,7 +67,7 @@ class ilLDAPRoleAssignmentRules
         global $DIC;
 
         $ilDB = $DIC['ilDB'];
-        
+
         $query = "SELECT DISTINCT(att_name) " .
             "FROM ldap_role_assignments " .
             'WHERE server_id = ' . $ilDB->quote($a_server_id, 'integer');
@@ -74,11 +79,10 @@ class ilLDAPRoleAssignmentRules
                 $names[] = $name;
             }
         }
-        
-        $names = array_merge($names, self::getAdditionalPluginAttributes($a_server_id));
-        return $names;
+
+        return array_merge($names, self::getAdditionalPluginAttributes());
     }
-    
+
     public static function getAssignmentsForUpdate(int $a_server_id, $a_usr_id, $a_usr_name, $a_usr_data) : array
     {
         global $DIC;
@@ -86,80 +90,74 @@ class ilLDAPRoleAssignmentRules
         $ilDB = $DIC['ilDB'];
         $rbacreview = $DIC['rbacreview'];
         $ilLog = $DIC['ilLog'];
-        
+
         $query = "SELECT rule_id,add_on_update,remove_on_update FROM ldap_role_assignments " .
             "WHERE (add_on_update = 1 OR remove_on_update = 1) " .
-                'AND server_id = ' . $ilDB->quote($a_server_id, 'integer');
-        
+            'AND server_id = ' . $ilDB->quote($a_server_id, 'integer');
+
         $res = $ilDB->query($query);
         $roles = [];
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             $rule = ilLDAPRoleAssignmentRule::_getInstanceByRuleId($row->rule_id);
-            
+
             $matches = $rule->matches($a_usr_data);
-            if ($matches and $row->add_on_update) {
+            if ($matches && $row->add_on_update) {
                 $ilLog->info(': Assigned to role: ' . $a_usr_name . ' => ' . ilObject::_lookupTitle($rule->getRoleId()));
                 $roles[] = self::parseRole($rule->getRoleId(), self::ROLE_ACTION_ASSIGN);
             }
-            if (!$matches and $row->remove_on_update) {
+            if (!$matches && $row->remove_on_update) {
                 $ilLog->info(': Deassigned from role: ' . $a_usr_name . ' => ' . ilObject::_lookupTitle($rule->getRoleId()));
                 $roles[] = self::parseRole($rule->getRoleId(), self::ROLE_ACTION_DEASSIGN);
             }
         }
-        
+
         // Check if there is minimum on global role
         $deassigned_global = 0;
         foreach ($roles as $role_data) {
-            if ($role_data['type'] == 'Global' and
-                $role_data['action'] == self::ROLE_ACTION_DEASSIGN) {
+            if ($role_data['type'] === 'Global' &&
+                $role_data['action'] === self::ROLE_ACTION_DEASSIGN) {
                 $deassigned_global++;
             }
         }
-        if (count($rbacreview->assignedGlobalRoles($a_usr_id)) == $deassigned_global) {
+        if (count($rbacreview->assignedGlobalRoles($a_usr_id)) === $deassigned_global) {
             $ilLog->info(': No global role left. Assigning to default role.');
             $roles[] = self::parseRole(
                 self::getDefaultRole($a_server_id),
                 self::ROLE_ACTION_ASSIGN
             );
         }
-        
+
         return $roles;
     }
-    
-    
+
     /**
-     *
      * @return array role data
-     * @param object $a_usr_id
-     * @param object $a_usr_data
      */
-    public static function getAssignmentsForCreation(int $a_server_id, $a_usr_name, $a_usr_data) : array
+    public static function getAssignmentsForCreation(int $a_server_id, string $a_usr_name, array $a_usr_data) : array
     {
         global $DIC;
 
         $ilDB = $DIC['ilDB'];
         $ilLog = $DIC['ilLog'];
-        
+
         $query = "SELECT rule_id FROM ldap_role_assignments " .
-                'WHERE server_id = ' . $ilDB->quote($a_server_id, 'integer');
+            'WHERE server_id = ' . $ilDB->quote($a_server_id, 'integer');
         $res = $ilDB->query($query);
-        
-        $num_matches = 0;
+
         $roles = [];
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $rule = ilLDAPRoleAssignmentRule::_getInstanceByRuleId($row->rule_id);
-            
+            $rule = ilLDAPRoleAssignmentRule::_getInstanceByRuleId((int) $row->rule_id);
+
             if ($rule->matches($a_usr_data)) {
-                $num_matches++;
                 $ilLog->info(': Assigned to role: ' . $a_usr_name . ' => ' . ilObject::_lookupTitle($rule->getRoleId()));
                 $roles[] = self::parseRole($rule->getRoleId(), self::ROLE_ACTION_ASSIGN);
             }
         }
-        
+
         // DONE: check for global role
         $found_global = false;
         foreach ($roles as $role_data) {
-            if ($role_data['type'] == 'Global') {
+            if ($role_data['type'] === 'Global') {
                 $found_global = true;
                 break;
             }
@@ -171,10 +169,10 @@ class ilLDAPRoleAssignmentRules
                 self::ROLE_ACTION_ASSIGN
             );
         }
-        
+
         return $roles;
     }
-    
+
     /**
      * Call plugin check if the condition matches.
      */
@@ -195,7 +193,7 @@ class ilLDAPRoleAssignmentRules
      * Fetch additional attributes from plugin
      * @return string[]
      */
-    protected static function getAdditionalPluginAttributes(int $a_server_id) : array
+    protected static function getAdditionalPluginAttributes() : array
     {
         global $DIC;
 
@@ -204,24 +202,20 @@ class ilLDAPRoleAssignmentRules
         foreach ($component_factory->getActivePluginsInSlot('ldaphk') as $plugin) {
             $attributes[] = $plugin->getAdditionalAttributeNames();
         }
-        
+
         return array_merge(...$attributes);
     }
 
-    
-    /**
-     * Parse role
-     */
     protected static function parseRole(int $a_role_id, string $a_action) : array
     {
         global $DIC;
 
         $rbacreview = $DIC['rbacreview'];
-        
-        return array(
+
+        return [
             'id' => $a_role_id,
             'type' => $rbacreview->isGlobalRole($a_role_id) ? 'Global' : 'Local',
             'action' => $a_action
-            );
+        ];
     }
 }

--- a/Services/LDAP/classes/class.ilLDAPRoleAssignmentTableGUI.php
+++ b/Services/LDAP/classes/class.ilLDAPRoleAssignmentTableGUI.php
@@ -19,14 +19,7 @@
  */
 class ilLDAPRoleAssignmentTableGUI extends ilTable2GUI
 {
-    /**
-     * constructor
-     *
-     * @access public
-     * @param
-     *
-     */
-    public function __construct($a_parent_obj, $a_parent_cmd = '')
+    public function __construct(object $a_parent_obj, string $a_parent_cmd = '')
     {
         global $DIC;
 
@@ -37,7 +30,7 @@ class ilLDAPRoleAssignmentTableGUI extends ilTable2GUI
         $this->ctrl = $ilCtrl;
         
         parent::__construct($a_parent_obj, $a_parent_cmd);
-        $this->addColumn('', '', 1);
+        $this->addColumn('', '', '1');
         $this->addColumn($this->lng->txt('ldap_rule_type'), 'type', "20%");
         $this->addColumn($this->lng->txt('ldap_ilias_role'), 'role', "30%");
         $this->addColumn($this->lng->txt('ldap_rule_condition'), 'condition', "20%");
@@ -48,15 +41,9 @@ class ilLDAPRoleAssignmentTableGUI extends ilTable2GUI
         $this->setDefaultOrderField('type');
         $this->setDefaultOrderDirection("desc");
     }
-    
-    /**
-     * Fill row
-     *
-     * @access public
-     * @param array row data
-     *
-     */
-    public function fillRow(array $a_set) : void
+
+    /** @noinspection DuplicatedCode */
+    protected function fillRow(array $a_set) : void
     {
         $this->tpl->setVariable('VAL_ID', $a_set['id']);
         $this->tpl->setVariable('VAL_TYPE', $a_set['type']);
@@ -87,12 +74,12 @@ class ilLDAPRoleAssignmentTableGUI extends ilTable2GUI
     /**
      * Parse
      *
-     * @access public
      * @param array array of LDAPRoleAssignmentRule
      *
      */
-    public function parse($rule_objs)
+    public function parse($rule_objs) : void
     {
+        $records_arr = [];
         foreach ($rule_objs as $rule) {
             $tmp_arr['id'] = $rule->getRuleId();
             
@@ -118,6 +105,6 @@ class ilLDAPRoleAssignmentTableGUI extends ilTable2GUI
             $records_arr[] = $tmp_arr;
         }
         
-        $this->setData($records_arr ? $records_arr : array());
+        $this->setData($records_arr);
     }
 }

--- a/Services/LDAP/classes/class.ilLDAPRoleGroupMapping.php
+++ b/Services/LDAP/classes/class.ilLDAPRoleGroupMapping.php
@@ -18,37 +18,39 @@
  */
 class ilLDAPRoleGroupMapping
 {
-    private $log = null;
-    private static $instance = null;
-    private $servers = null;
-    private $mappings = array();
-    private $mapping_members = array();
-    private $query = array();
-    private $active_servers = false;
+    private static ?ilLDAPRoleGroupMapping $instance = null;
+    private ilLogger $log;
+    private ilRbacReview $rbacreview;
+    private ilObjectDataCache $ilObjDataCache;
+
+    private array $servers;
+    private array $mappings;
+    private array $mapping_members;
+    private array $mapping_info;
+    private array $mapping_info_strict;
+    private array $query;
+    private array $users;
+    private ?array $user_dns;
+    private bool $active_servers = false;
     
     /**
      * Singleton contructor
-     *
-     * @access private
-     *
      */
     private function __construct()
     {
         global $DIC;
 
-        $ilLog = $DIC['ilLog'];
-        
-        $this->log = $ilLog;
+        $this->log = $DIC->logger()->auth();
+        $this->rbacreview = $DIC->rbac()->review();
+        $this->ilObjDataCache = $DIC['ilObjDataCache'];
+
         $this->initServers();
     }
     
     /**
      * Get singleton instance of this class
-     *
-     * @access public
-     *
      */
-    public static function _getInstance()
+    public static function _getInstance() : ?ilLDAPRoleGroupMapping
     {
         if (is_object(self::$instance)) {
             return self::$instance;
@@ -60,26 +62,25 @@ class ilLDAPRoleGroupMapping
      * Get info string for object
      * If check info type is enabled this function will check if the info string is visible in the repository.
      *
-     * @access public
      * @param int object id
      * @param bool check info type
-     *
+     * @return string[]
      */
-    public function getInfoStrings($a_obj_id, $a_check_type = false)
+    public function getInfoStrings(int $a_obj_id, bool $a_check_type = false) : array
     {
         if (!$this->active_servers) {
-            return false;
+            return [];
         }
+
         if ($a_check_type) {
-            if (isset($this->mapping_info_strict[$a_obj_id]) and is_array($this->mapping_info_strict[$a_obj_id])) {
+            if (isset($this->mapping_info_strict[$a_obj_id]) && is_array($this->mapping_info_strict[$a_obj_id])) {
                 return $this->mapping_info_strict[$a_obj_id];
             }
-        } else {
-            if (isset($this->mapping_info[$a_obj_id]) and is_array($this->mapping_info[$a_obj_id])) {
-                return $this->mapping_info[$a_obj_id];
-            }
+        } elseif (isset($this->mapping_info[$a_obj_id]) && is_array($this->mapping_info[$a_obj_id])) {
+            return $this->mapping_info[$a_obj_id];
         }
-        return false;
+
+        return [];
     }
     
     
@@ -87,12 +88,8 @@ class ilLDAPRoleGroupMapping
      * This method is typically called from class RbacAdmin::assignUser()
      * It checks if there is a role mapping and if the user has auth mode LDAP
      * After these checks the user is assigned to the LDAP group
-     *
-     * @access public
-     * @param
-     *
      */
-    public function assign($a_role_id, $a_usr_id)
+    public function assign($a_role_id, $a_usr_id) : bool
     {
         // return if there nothing to do
         if (!$this->active_servers) {
@@ -117,16 +114,11 @@ class ilLDAPRoleGroupMapping
      * This function triggered from ilRbacAdmin::deleteRole
      * It deassigns all user from the mapped ldap group.
      *
-     * @access public
      * @param int role id
      *
      */
-    public function deleteRole($a_role_id)
+    public function deleteRole(int $a_role_id) : bool
     {
-        global $DIC;
-
-        $rbacreview = $DIC['rbacreview'];
-        
         // return if there nothing to do
         if (!$this->active_servers) {
             return false;
@@ -136,7 +128,7 @@ class ilLDAPRoleGroupMapping
             return false;
         }
         
-        foreach ($rbacreview->assignedUsers($a_role_id) as $usr_id) {
+        foreach ($this->rbacreview->assignedUsers($a_role_id) as $usr_id) {
             $this->deassign($a_role_id, $usr_id);
         }
         return true;
@@ -147,12 +139,8 @@ class ilLDAPRoleGroupMapping
      * This method is typically called from class RbacAdmin::deassignUser()
      * It checks if there is a role mapping and if the user has auth mode LDAP
      * After these checks the user is deassigned from the LDAP group
-     *
-     * @access public
-     * @param
-     *
      */
-    public function deassign($a_role_id, $a_usr_id)
+    public function deassign($a_role_id, $a_usr_id) : bool
     {
         // return if there notzing to do
         if (!$this->active_servers) {
@@ -173,10 +161,9 @@ class ilLDAPRoleGroupMapping
     /**
      * Delete user => deassign from all ldap groups
      *
-     * @access public
      * @param int user id
      */
-    public function deleteUser($a_usr_id)
+    public function deleteUser($a_usr_id) : bool
     {
         foreach ($this->mappings as $role_id) {
             $this->deassign($role_id, $a_usr_id);
@@ -187,62 +174,54 @@ class ilLDAPRoleGroupMapping
     
     /**
      * Check if there is any active server with
-     *
-     * @access private
-     * @param
-     *
      */
-    private function initServers()
+    private function initServers() : void
     {
         $server_ids = ilLDAPServer::_getRoleSyncServerIds();
         
         if (!count($server_ids)) {
-            return false;
+            return;
         }
 
         // Init servers
         $this->active_servers = true;
-        $this->mappings = array();
+        $this->servers = [];
+        $this->mappings = [];
         foreach ($server_ids as $server_id) {
             $this->servers[$server_id] = new ilLDAPServer($server_id);
             $this->mappings = ilLDAPRoleGroupMappingSettings::_getAllActiveMappings();
         }
-        $this->mapping_info = array();
-        $this->mapping_info_strict = array();
+        $this->mapping_info = [];
+        $this->mapping_info_strict = [];
         foreach ($this->mappings as $mapping) {
-            foreach (array_values($mapping) as $data) {
-                if (strlen($data['info']) and $data['object_id']) {
+            foreach ($mapping as $data) {
+                if ($data['info'] !== '' && $data['object_id']) {
                     $this->mapping_info[$data['object_id']][] = $data['info'];
                 }
-                if (strlen($data['info']) && ($data['info_type'] == ilLDAPRoleGroupMappingSettings::MAPPING_INFO_ALL)) {
+                if ($data['info'] !== '' && ($data['info_type'] === ilLDAPRoleGroupMappingSettings::MAPPING_INFO_ALL)) {
                     $this->mapping_info_strict[$data['object_id']][] = $data['info'];
                 }
             }
         }
         $this->users = ilObjUser::_getExternalAccountsByAuthMode('ldap', true);
-        
-        return true;
     }
     
     /**
      * Check if a role is handled or not
      *
-     * @access private
      * @param int role_id
-     * @return int server id or 0 if mapping exists
+     * @return bool server id or 0 if mapping exists
      *
      */
-    private function isHandledRole($a_role_id)
+    private function isHandledRole($a_role_id) : bool
     {
         return array_key_exists($a_role_id, $this->mappings);
     }
     
     /**
      * Check if user is ldap user
-     *
-     * @access private
      */
-    private function isHandledUser($a_usr_id)
+    private function isHandledUser($a_usr_id) : bool
     {
         return array_key_exists($a_usr_id, $this->users);
     }
@@ -251,11 +230,10 @@ class ilLDAPRoleGroupMapping
     /**
      * Assign user to group
      *
-     * @access private
      * @param int role_id
      * @param int user_id
      */
-    private function assignToGroup($a_role_id, $a_usr_id)
+    private function assignToGroup($a_role_id, $a_usr_id) : void
     {
         foreach ($this->mappings[$a_role_id] as $data) {
             try {
@@ -288,12 +266,11 @@ class ilLDAPRoleGroupMapping
     /**
      * Deassign user from group
      *
-     * @access private
      * @param int role_id
      * @param int user_id
      *
      */
-    private function deassignFromGroup($a_role_id, $a_usr_id)
+    private function deassignFromGroup($a_role_id, $a_usr_id) : void
     {
         foreach ($this->mappings[$a_role_id] as $data) {
             try {
@@ -322,8 +299,8 @@ class ilLDAPRoleGroupMapping
                 
                 // Delete from cache
                 if (is_array($this->mapping_members[$data['mapping_id']])) {
-                    $key = array_search($external_account, $this->mapping_members[$data['mapping_id']]);
-                    if ($key or $key === 0) {
+                    $key = array_search($external_account, $this->mapping_members[$data['mapping_id']], true);
+                    if ($key || $key === 0) {
                         unset($this->mapping_members[$data['mapping_id']]);
                     }
                 }
@@ -336,175 +313,101 @@ class ilLDAPRoleGroupMapping
     }
     
     /**
-     * Check if user is member
-     *
-     * @access private
-     * @throws ilLDAPQueryException
-     */
-    private function isMember($a_uid, $data)
-    {
-        if (!isset($this->mapping_members["$data[mapping_id]"])) {
-            // Read members
-            try {
-                $server = $this->servers["$data[server_id]"];
-                $query_obj = $this->getLDAPQueryInstance($data['server_id'], $server->getUrl());
-
-                // query for members
-                $res = $query_obj->query(
-                    $data['dn'],
-                    '(objectClass=*)',
-                    ilLDAPServer::LDAP_SCOPE_BASE,
-                    array($data['member'])
-                );
-                
-                $this->storeMembers($data['mapping_id'], $res->get());
-                unset($res);
-            } catch (ilLDAPQueryException $exc) {
-                throw $exc;
-            }
-        }
-        #var_dump("<pre>",$a_uid,$this->mapping_members,"</pre>");
-        
-        // Now check for membership in stored result
-        if (in_array($a_uid, $this->mapping_members["$data[mapping_id]"])) {
-            return true;
-        }
-        return false;
-    }
-    
-    /**
      * Check other membership
      *
-     * @access private
-     * @return string role name
+     * @return string|false role name
      *
      */
-    private function checkOtherMembership($a_usr_id, $a_role_id, $a_data)
+    private function checkOtherMembership(int $a_usr_id, int $a_role_id, array $a_data)
     {
-        global $DIC;
-
-        $rbacreview = $DIC['rbacreview'];
-        $ilObjDataCache = $DIC['ilObjDataCache'];
-        
         foreach ($this->mappings as $role_id => $tmp_data) {
             foreach ($tmp_data as $data) {
-                if ($role_id == $a_role_id) {
+                if ($role_id === $a_role_id) {
                     continue;
                 }
-                if ($data['server_id'] != $a_data['server_id']) {
+                if ($data['server_id'] !== $a_data['server_id']) {
                     continue;
                 }
-                if ($data['dn'] != $a_data['dn']) {
+                if ($data['dn'] !== $a_data['dn']) {
                     continue;
                 }
-                if ($rbacreview->isAssigned($a_usr_id, $role_id)) {
-                    return $ilObjDataCache->lookupTitle((int) $role_id);
+                if ($this->rbacreview->isAssigned($a_usr_id, $role_id)) {
+                    return $this->ilObjDataCache->lookupTitle((int) $role_id);
                 }
             }
         }
         return false;
-    }
-    
-    /**
-     * Store Members
-     *
-     * @access private
-     *
-     */
-    private function storeMembers($a_mapping_id, $a_data)
-    {
-        $this->mapping_members[$a_mapping_id] = array();
-        foreach ($a_data as $field => $value) {
-            if (strtolower($field) == 'dn') {
-                continue;
-            }
-            
-            if (!is_array($value)) {
-                $this->mapping_members[$a_mapping_id][] = $value;
-                continue;
-            }
-            foreach ($value as $external_account) {
-                $this->mapping_members[$a_mapping_id][] = $external_account;
-            }
-        }
-        return true;
     }
     
     /**
      * Read DN of user
      *
-     * @access private
      * @param int user id
      * @param int server id
      * @throws ilLDAPQueryException
      */
-    private function readDN($a_usr_id, $a_server_id)
+    private function readDN(int $a_usr_id, int $a_server_id)
     {
+        if ($this->user_dns === null) {
+            $this->user_dns = [];
+        }
         if (isset($this->user_dns[$a_usr_id])) {
             return $this->user_dns[$a_usr_id];
         }
         
         $external_account = $this->users[$a_usr_id];
         
-        try {
-            $server = $this->servers[$a_server_id];
-            $query_obj = $this->getLDAPQueryInstance($a_server_id, $server->getUrl());
-                        
-            if ($search_base = $server->getSearchBase()) {
-                $search_base .= ',';
-            }
-            $search_base .= $server->getBaseDN();
-            
-            // try optional group user filter first
-            if ($server->isMembershipOptional() and $server->getGroupUserFilter()) {
-                $userFilter = $server->getGroupUserFilter();
-            } else {
-                $userFilter = $server->getFilter();
-            }
+        $server = $this->servers[$a_server_id];
+        $query_obj = $this->getLDAPQueryInstance($a_server_id, $server->getUrl());
 
-            $filter = sprintf(
-                '(&(%s=%s)%s)',
-                $server->getUserAttribute(),
-                $external_account,
-                $userFilter
-            );
-
-            $res = $query_obj->query($search_base, $filter, $server->getUserScope(), array('dn'));
-            
-            if (!$res->numRows()) {
-                throw new ilLDAPQueryException(__METHOD__ . ' cannot find dn for user ' . $external_account);
-            }
-            if ($res->numRows() > 1) {
-                throw new ilLDAPQueryException(__METHOD__ . ' found multiple distinguished name for: ' . $external_account);
-            }
-            
-            $data = $res->get();
-            return $this->user_dns[$a_usr_id] = $data['dn'];
-        } catch (ilLDAPQueryException $exc) {
-            throw $exc;
+        if ($search_base = $server->getSearchBase()) {
+            $search_base .= ',';
         }
+        $search_base .= $server->getBaseDN();
+
+        // try optional group user filter first
+        if ($server->isMembershipOptional() && $server->getGroupUserFilter()) {
+            $userFilter = $server->getGroupUserFilter();
+        } else {
+            $userFilter = $server->getFilter();
+        }
+
+        $filter = sprintf(
+            '(&(%s=%s)%s)',
+            $server->getUserAttribute(),
+            $external_account,
+            $userFilter
+        );
+
+        $res = $query_obj->query($search_base, $filter, $server->getUserScope(), array('dn'));
+
+        if (!$res->numRows()) {
+            throw new ilLDAPQueryException(__METHOD__ . ' cannot find dn for user ' . $external_account);
+        }
+        if ($res->numRows() > 1) {
+            throw new ilLDAPQueryException(__METHOD__ . ' found multiple distinguished name for: ' . $external_account);
+        }
+
+        $data = $res->get();
+        $this->user_dns[$a_usr_id] = $data['dn'];
+        return $this->user_dns[$a_usr_id];
     }
     
     /**
      * Get LDAPQueryInstance
      *
-     * @access private
-     * @param
      * @throws ilLDAPQueryException
      */
     private function getLDAPQueryInstance($a_server_id, $a_url)
     {
-        if (array_key_exists($a_server_id, $this->query) and
-            array_key_exists($a_url, $this->query[$a_server_id]) and
+        if (array_key_exists($a_server_id, $this->query) &&
+            array_key_exists($a_url, $this->query[$a_server_id]) &&
             is_object($this->query[$a_server_id][$a_url])) {
             return $this->query[$a_server_id][$a_url];
         }
-        try {
-            $tmp_query = new ilLDAPQuery($this->servers[$a_server_id], $a_url);
-            $tmp_query->bind(ilLDAPQuery::LDAP_BIND_ADMIN);
-        } catch (ilLDAPQueryException $exc) {
-            throw $exc;
-        }
+        $tmp_query = new ilLDAPQuery($this->servers[$a_server_id], $a_url);
+        $tmp_query->bind(ilLDAPQuery::LDAP_BIND_ADMIN);
+
         return $this->query[$a_server_id][$a_url] = $tmp_query;
     }
 }

--- a/Services/LDAP/classes/class.ilLDAPRoleGroupMappingSetting.php
+++ b/Services/LDAP/classes/class.ilLDAPRoleGroupMappingSetting.php
@@ -23,6 +23,15 @@ class ilLDAPRoleGroupMappingSetting
     private ilRbacReview $rbacreview;
 
     private int $mapping_id;
+    private int $server_id;
+
+    private ?string $url;
+    private ?string $dn;
+    private ?string $member_attribute;
+    private ?bool $mapping_info_type;
+    private ?bool $member_isdn;
+    private ?int $role;
+    private ?string $mapping_info;
 
     public function __construct(int $a_mapping_id)
     {
@@ -43,16 +52,15 @@ class ilLDAPRoleGroupMappingSetting
                 . "WHERE mapping_id = " . $this->db->quote($this->getMappingId(), 'integer');
         $set = $this->db->query($query);
         $rec = $this->db->fetchAssoc($set);
-        
-        $this->setMappingId($rec["mapping_id"]);
-        $this->setServerId($rec["server_id"]);
+        $this->setMappingId((int) $rec["mapping_id"]);
+        $this->setServerId((int) $rec["server_id"]);
         $this->setURL($rec["url"]);
         $this->setDN($rec["dn"]);
         $this->setMemberAttribute($rec["member_attribute"]);
         $this->setMemberISDN($rec["member_isdn"]);
-        $this->setRole($rec["role"]);
+        $this->setRole((int) $rec["role"]);
         $this->setMappingInfo($rec["mapping_info"]);
-        $this->setMappingInfoType($rec["mapping_info_type"]);
+        $this->setMappingInfoType((bool) $rec["mapping_info_type"]);
     }
     
     /**
@@ -108,7 +116,7 @@ class ilLDAPRoleGroupMappingSetting
      * get mapping id
      * @return int mapping id
      */
-    public function getMappingId()
+    public function getMappingId() : int
     {
         return $this->mapping_id;
     }
@@ -117,7 +125,7 @@ class ilLDAPRoleGroupMappingSetting
      * set mapping id
      * @param int $a_value mapping id
      */
-    public function setMappingId($a_value)
+    public function setMappingId(int $a_value) : void
     {
         $this->mapping_id = $a_value;
     }
@@ -126,7 +134,7 @@ class ilLDAPRoleGroupMappingSetting
      * get server id
      * @return int server id id
      */
-    public function getServerId()
+    public function getServerId() : int
     {
         return $this->server_id;
     }
@@ -135,7 +143,7 @@ class ilLDAPRoleGroupMappingSetting
      * set server id
      * @param int $a_value server id
      */
-    public function setServerId($a_value)
+    public function setServerId(int $a_value) : void
     {
         $this->server_id = $a_value;
     }
@@ -144,7 +152,7 @@ class ilLDAPRoleGroupMappingSetting
      * get url
      * @return string url
      */
-    public function getURL()
+    public function getURL() : string
     {
         return $this->url;
     }
@@ -153,52 +161,47 @@ class ilLDAPRoleGroupMappingSetting
      * set url
      * @param string $a_value url
      */
-    public function setURL($a_value)
+    public function setURL(string $a_value) : void
     {
         $this->url = $a_value;
     }
     
     /**
      * get group dn
-     * @return string
      */
-    public function getDN()
+    public function getDN() : string
     {
         return $this->dn;
     }
     
     /**
      * set group dn
-     * @param string $a_value
      */
-    public function setDN($a_value)
+    public function setDN(string $a_value) : void
     {
         $this->dn = $a_value;
     }
     
     /**
      * get Group Member Attribute
-     * @return string
      */
-    public function getMemberAttribute()
+    public function getMemberAttribute() : string
     {
         return $this->member_attribute;
     }
     
     /**
      * set Group Member Attribute
-     * @param string $a_value
      */
-    public function setMemberAttribute($a_value)
+    public function setMemberAttribute(string $a_value) : void
     {
         $this->member_attribute = $a_value;
     }
     
     /**
      * get Member Attribute Value is DN
-     * @return bool
      */
-    public function getMemberISDN()
+    public function getMemberISDN() : bool
     {
         return $this->member_isdn;
     }
@@ -207,79 +210,71 @@ class ilLDAPRoleGroupMappingSetting
      * set Member Attribute Value is DN
      * @param bool $a_value
      */
-    public function setMemberISDN($a_value)
+    public function setMemberISDN(bool $a_value) : void
     {
         $this->member_isdn = $a_value;
     }
     
     /**
      * get ILIAS Role Name id
-     * @return int
      */
-    public function getRole()
+    public function getRole() : int
     {
         return $this->role;
     }
     
     /**
      * set ILIAS Role Name id
-     * @param int $a_value
      */
-    public function setRole($a_value)
+    public function setRole(int $a_value) : void
     {
         $this->role = $a_value;
     }
     
     /**
      * get ILIAS Role Name
-     * @return string
      */
-    public function getRoleName()
+    public function getRoleName() : string
     {
         return $this->ilObjDataCache->lookupTitle($this->role);
     }
     
     /**
      * set ILIAS Role Name
-     * @param string $a_value
      */
-    public function setRoleByName($a_value)
+    public function setRoleByName(string $a_value) : void
     {
         $this->role = $this->rbacreview->roleExists(ilUtil::stripSlashes($a_value));
     }
     
     /**
      * get Information Text
-     * @return string
      */
-    public function getMappingInfo()
+    public function getMappingInfo() : string
     {
         return $this->mapping_info;
     }
     
     /**
      * set Information Text
-     * @param string $a_value
      */
-    public function setMappingInfo($a_value)
+    public function setMappingInfo(string $a_value) : void
     {
         $this->mapping_info = $a_value;
     }
     
     /**
      * get Show Information also in the Repository/Personal Desktop
-     * @return bool
      */
-    public function getMappingInfoType()
+    public function getMappingInfoType() : bool
     {
         return $this->mapping_info_type;
     }
     
     /**
      * set Show Information also in the Repository/Personal Desktop
-     * @param bool $a_value
      */
-    public function setMappingInfoType($a_value)
+    public function setMappingInfoType(bool $a_value) : void
     {
         $this->mapping_info_type = $a_value;
     }

--- a/Services/LDAP/classes/class.ilLDAPRoleMappingTableGUI.php
+++ b/Services/LDAP/classes/class.ilLDAPRoleMappingTableGUI.php
@@ -20,8 +20,12 @@ class ilLDAPRoleMappingTableGUI extends ilTable2GUI
 {
     private ilObjectDataCache $ilObjDataCache;
     private ilRbacReview $rbacreview;
+    private int $server_id;
 
-    public function __construct($a_parent_obj, $a_server_id, $a_parent_cmd = '')
+    /**
+     * @throws ilCtrlException
+     */
+    public function __construct(object $a_parent_obj, int $a_server_id, string $a_parent_cmd = '')
     {
         $this->server_id = $a_server_id;
         parent::__construct($a_parent_obj, $a_parent_cmd);
@@ -39,7 +43,6 @@ class ilLDAPRoleMappingTableGUI extends ilTable2GUI
         $this->addColumn($this->lng->txt('ldap_group_member'), "member_attribute");
         $this->addColumn($this->lng->txt('ldap_info_text'), "info");
         $this->addColumn($this->lng->txt('action'));
-    
         $this->setFormAction($this->ctrl->getFormAction($a_parent_obj, $a_parent_cmd));
         $this->setRowTemplate("tpl.ldap_role_mapping_row.html", "Services/LDAP");
         $this->setDefaultOrderField('title');
@@ -48,12 +51,11 @@ class ilLDAPRoleMappingTableGUI extends ilTable2GUI
         
         $this->getItems();
     }
-    
+
     /**
-     * fill row
-     * @param array $a_set
+     * @throws ilCtrlException
      */
-    public function fillRow(array $a_set) : void
+    protected function fillRow(array $a_set) : void
     {
         $title = $this->ilObjDataCache->lookupTitle($this->rbacreview->getObjectOfRole($a_set["role"]));
         $this->tpl->setVariable("VAL_ID", $a_set['mapping_id']);

--- a/Services/LDAP/classes/class.ilLDAPServer.php
+++ b/Services/LDAP/classes/class.ilLDAPServer.php
@@ -18,18 +18,18 @@
  */
 class ilLDAPServer
 {
-    private static $instances = array();
-    
-    const LDAP_BIND_ANONYMOUS = 0;
-    const LDAP_BIND_USER = 1;
+    private static array $instances = [];
 
-    const LDAP_SCOPE_SUB = 0;
-    const LDAP_SCOPE_ONE = 1;
-    const LDAP_SCOPE_BASE = 2;
+    public const LDAP_BIND_ANONYMOUS = 0;
+    public const LDAP_BIND_USER = 1;
 
-    const DEBUG = false;
-    const DEFAULT_VERSION = 3;
-    const DEFAULT_NETWORK_TIMEOUT = 5;
+    public const LDAP_SCOPE_SUB = 0;
+    public const LDAP_SCOPE_ONE = 1;
+    public const LDAP_SCOPE_BASE = 2;
+
+    private const DEBUG = false;
+    private const DEFAULT_VERSION = 3;
+    public const DEFAULT_NETWORK_TIMEOUT = 5;
     
     private string $role_bind_dn = '';
     private string $role_bind_pass = '';
@@ -45,7 +45,34 @@ class ilLDAPServer
     private bool $escape_dn = false;
     
     private bool $active = false;
-    
+
+    private string $name = '';
+    private int $version = self::DEFAULT_VERSION;
+    private string $base_dn = '';
+    private bool $referrals = false;
+    private bool $tls = false;
+    private int $binding_type = self::LDAP_BIND_ANONYMOUS;
+    private string $bind_user = '';
+    private string $bind_password = '';
+    private string $search_base = '';
+    private string $user_attribute = '';
+    private int $user_scope = self::LDAP_SCOPE_ONE;
+    private string $group_filter = '';
+    private string $filter = '';
+    private string $group_dn = '';
+    private string $group_member = '';
+    private int $group_scope = self::LDAP_SCOPE_ONE;
+    private string $group_name = '';
+    private bool $memberisdn = false;
+    private string $group_attribute = '';
+    private bool $group_optional = true;
+    private string $group_user_filter = '';
+    private bool $sync_on_login = false;
+    private bool $sync_per_cron = false;
+    private bool $account_migration = false;
+    private string $username_filter = '';
+    private int $global_role = 0;
+
     private ilDBInterface $db;
     private ilLanguage $lng;
     private ilErrorHandling $ilErr;
@@ -68,10 +95,7 @@ class ilLDAPServer
      */
     public static function getInstanceByServerId(int $a_server_id) : ilLDAPServer
     {
-        if (isset(self::$instances[$a_server_id])) {
-            return self::$instances[$a_server_id];
-        }
-        return self::$instances[$a_server_id] = new ilLDAPServer($a_server_id);
+        return self::$instances[$a_server_id] ?? (self::$instances[$a_server_id] = new ilLDAPServer($a_server_id));
     }
     
     /**
@@ -182,7 +206,7 @@ class ilLDAPServer
      */
     public static function _getFirstActiveServer() : int
     {
-        $servers = ilLDAPServer::_getActiveServerList();
+        $servers = self::_getActiveServerList();
         if (count($servers)) {
             return $servers[0];
         }
@@ -253,20 +277,6 @@ class ilLDAPServer
         }
         return $server;
     }
-    
-    /*
-     * Get first server id
-     */
-    public static function _getFirstServer() : int
-    {
-        $servers = ilLDAPServer::_getServerList();
-        
-        if (count($servers)) {
-            return $servers[0];
-        }
-        return 0;
-    }
-
 
     public static function getAvailableDataSources(int $a_auth_mode) : array
     {
@@ -301,7 +311,7 @@ class ilLDAPServer
             "WHERE authentication_type = " . $ilDB->quote($a_auth_mode, 'integer') . " " .
             "AND authentication = " . $ilDB->quote(0, 'integer');
         $res = $ilDB->query($query);
-        while ($res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
+        if ($res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             return true;
         }
         return false;
@@ -316,7 +326,7 @@ class ilLDAPServer
         $query = "SELECT server_id FROM ldap_server_settings " .
             "WHERE authentication_type = " . $ilDB->quote($a_auth_mode, 'integer') . " ";
         $res = $ilDB->query($query);
-        while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
+        if ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             return $row->server_id;
         }
         return 0;
@@ -374,7 +384,7 @@ class ilLDAPServer
             return false;
         }
         $auth_arr = explode('_', $a_auth_mode);
-        return ($auth_arr[0] == ilAuthUtils::AUTH_LDAP) and $auth_arr[1];
+        return ((int) $auth_arr[0] === ilAuthUtils::AUTH_LDAP) && $auth_arr[1];
     }
     
     /**
@@ -395,7 +405,7 @@ class ilLDAPServer
     public static function getAuthModeByKey(string $a_auth_key) : string
     {
         $auth_arr = explode('_', $a_auth_key);
-        if (count((array) $auth_arr) > 1) {
+        if (count($auth_arr) > 1) {
             return 'ldap_' . $auth_arr[1];
         }
         return 'ldap';
@@ -408,7 +418,7 @@ class ilLDAPServer
     public static function getKeyByAuthMode(string $a_auth_mode)
     {
         $auth_arr = explode('_', $a_auth_mode);
-        if (count((array) $auth_arr) > 1) {
+        if (count($auth_arr) > 1) {
             return ilAuthUtils::AUTH_LDAP . '_' . $auth_arr[1];
         }
         return ilAuthUtils::AUTH_LDAP;
@@ -458,7 +468,7 @@ class ilLDAPServer
      */
     public function getAuthenticationMappingKey() : string
     {
-        if ($this->isAuthenticationEnabled() or !$this->getAuthenticationMapping()) {
+        if ($this->isAuthenticationEnabled() || !$this->getAuthenticationMapping()) {
             return 'ldap_' . $this->getServerId();
         }
         return ilAuthUtils::_getAuthModeName($this->getAuthenticationMapping());
@@ -476,7 +486,7 @@ class ilLDAPServer
     {
         return $this->url;
     }
-    public function setUrl($a_url) : void
+    public function setUrl(string $a_url) : void
     {
         $this->url_string = $a_url;
         
@@ -525,127 +535,127 @@ class ilLDAPServer
     }
     
     
-    public function getName()
+    public function getName() : string
     {
         return $this->name;
     }
-    public function setName($a_name)
+    public function setName(string $a_name) : void
     {
         $this->name = $a_name;
     }
-    public function getVersion()
+    public function getVersion() : int
     {
-        return $this->version ? $this->version : self::DEFAULT_VERSION;
+        return $this->version;
     }
-    public function setVersion($a_version)
+    public function setVersion(int $a_version) : void
     {
         $this->version = $a_version;
     }
-    public function getBaseDN()
+    public function getBaseDN() : string
     {
         return $this->base_dn;
     }
-    public function setBaseDN($a_base_dn)
+    public function setBaseDN(string $a_base_dn) : void
     {
         $this->base_dn = $a_base_dn;
     }
-    public function isActiveReferrer()
+    public function isActiveReferrer() : bool
     {
-        return $this->referrals ? true : false;
+        return $this->referrals;
     }
-    public function toggleReferrer($a_status)
+    public function toggleReferrer(bool $a_status) : void
     {
         $this->referrals = $a_status;
     }
-    public function isActiveTLS()
+    public function isActiveTLS() : bool
     {
-        return $this->tls ? true : false;
+        return $this->tls;
     }
-    public function toggleTLS($a_status)
+    public function toggleTLS(bool $a_status) : void
     {
         $this->tls = $a_status;
     }
-    public function getBindingType()
+    public function getBindingType() : int
     {
         return $this->binding_type;
     }
-    public function setBindingType($a_type)
+    public function setBindingType(int $a_type) : void
     {
-        if ($a_type == ilLDAPServer::LDAP_BIND_USER) {
-            $this->binding_type = ilLDAPServer::LDAP_BIND_USER;
+        if ($a_type === self::LDAP_BIND_USER) {
+            $this->binding_type = self::LDAP_BIND_USER;
         } else {
-            $this->binding_type = ilLDAPServer::LDAP_BIND_ANONYMOUS;
+            $this->binding_type = self::LDAP_BIND_ANONYMOUS;
         }
     }
-    public function getBindUser()
+    public function getBindUser() : string
     {
         return $this->bind_user;
     }
-    public function setBindUser($a_user)
+    public function setBindUser(string $a_user) : void
     {
         $this->bind_user = $a_user;
     }
-    public function getBindPassword()
+    public function getBindPassword() : string
     {
         return $this->bind_password;
     }
-    public function setBindPassword($a_password)
+    public function setBindPassword(string $a_password) : void
     {
         $this->bind_password = $a_password;
     }
-    public function getSearchBase()
+    public function getSearchBase() : string
     {
         return $this->search_base;
     }
-    public function setSearchBase($a_search_base)
+    public function setSearchBase(string $a_search_base) : void
     {
         $this->search_base = $a_search_base;
     }
-    public function getUserAttribute()
+    public function getUserAttribute() : string
     {
         return $this->user_attribute;
     }
-    public function setUserAttribute($a_user_attr)
+    public function setUserAttribute(string $a_user_attr) : void
     {
         $this->user_attribute = $a_user_attr;
     }
-    public function getFilter()
+    public function getFilter() : string
     {
         return $this->prepareFilter($this->filter);
     }
-    public function setFilter($a_filter)
+    public function setFilter(string $a_filter) : void
     {
         $this->filter = $a_filter;
     }
-    public function getGroupDN()
+    public function getGroupDN() : string
     {
         return $this->group_dn;
     }
-    public function setGroupDN($a_value)
+    public function setGroupDN(string $a_value) : void
     {
         $this->group_dn = $a_value;
     }
-    public function getGroupFilter()
+    public function getGroupFilter() : string
     {
         return $this->prepareFilter($this->group_filter);
     }
-    public function setGroupFilter($a_value)
+    public function setGroupFilter(string $a_value) : void
     {
         $this->group_filter = $a_value;
     }
-    public function getGroupMember()
+    public function getGroupMember() : string
     {
         return $this->group_member;
     }
-    public function setGroupMember($a_value)
+    public function setGroupMember(string $a_value) : void
     {
         $this->group_member = $a_value;
     }
-    public function getGroupName()
+    public function getGroupName() : string
     {
         return $this->group_name;
     }
-    public function setGroupName($a_value)
+    public function setGroupName(string $a_value) : void
     {
         $this->group_name = $a_value;
     }
@@ -654,123 +664,122 @@ class ilLDAPServer
      * Get group names as array
      * @return string[]
      */
-    public function getGroupNames()
+    public function getGroupNames() : array
     {
         $names = explode(',', $this->getGroupName());
 
         if (!is_array($names)) {
-            return array();
+            return [];
         }
 
         return array_filter(array_map('trim', $names));
     }
     
     
-    public function getGroupAttribute()
+    public function getGroupAttribute() : string
     {
         return $this->group_attribute;
     }
-    public function setGroupAttribute($a_value)
+    public function setGroupAttribute(string $a_value) : void
     {
         $this->group_attribute = $a_value;
     }
-    
-    public function toggleMembershipOptional($a_status)
+    public function toggleMembershipOptional(bool $a_status) : void
     {
-        $this->group_optional = (bool) $a_status;
+        $this->group_optional = $a_status;
     }
-    public function isMembershipOptional()
+    public function isMembershipOptional() : bool
     {
-        return (bool) $this->group_optional;
+        return $this->group_optional;
     }
-    public function setGroupUserFilter($a_filter)
+    public function setGroupUserFilter(string $a_filter) : void
     {
         $this->group_user_filter = $a_filter;
     }
-    public function getGroupUserFilter()
+    public function getGroupUserFilter() : string
     {
         return $this->group_user_filter;
     }
 
-    public function enabledGroupMemberIsDN()
+    public function enabledGroupMemberIsDN() : bool
     {
-        return (bool) $this->memberisdn;
+        return $this->memberisdn;
     }
-    public function enableGroupMemberIsDN($a_value)
+    public function enableGroupMemberIsDN(bool $a_value) : void
     {
-        $this->memberisdn = (bool) $a_value;
+        $this->memberisdn = $a_value;
     }
-    public function setGroupScope($a_value)
+    public function setGroupScope(int $a_value) : void
     {
         $this->group_scope = $a_value;
     }
-    public function getGroupScope()
+    public function getGroupScope() : int
     {
         return $this->group_scope;
     }
-    public function setUserScope($a_value)
+    public function setUserScope(int $a_value) : void
     {
         $this->user_scope = $a_value;
     }
-    public function getUserScope()
+    public function getUserScope() : int
     {
         return $this->user_scope;
     }
-    public function enabledSyncOnLogin()
+    public function enabledSyncOnLogin() : bool
     {
         return $this->sync_on_login;
     }
-    public function enableSyncOnLogin($a_value)
+    public function enableSyncOnLogin(bool $a_value) : void
     {
-        $this->sync_on_login = (int) $a_value;
+        $this->sync_on_login = $a_value;
     }
-    public function enabledSyncPerCron()
+    public function enabledSyncPerCron() : bool
     {
         return $this->sync_per_cron;
     }
-    public function enableSyncPerCron($a_value)
+    public function enableSyncPerCron(bool $a_value) : void
     {
-        $this->sync_per_cron = (int) $a_value;
+        $this->sync_per_cron = $a_value;
     }
-    public function setGlobalRole($a_role)
+    public function setGlobalRole(int $a_role) : void
     {
         $this->global_role = $a_role;
     }
-    public function getRoleBindDN()
+    public function getRoleBindDN() : string
     {
         return $this->role_bind_dn;
     }
-    public function setRoleBindDN($a_value)
+    public function setRoleBindDN(string $a_value) : void
     {
         $this->role_bind_dn = $a_value;
     }
-    public function getRoleBindPassword()
+    public function getRoleBindPassword() : string
     {
         return $this->role_bind_pass;
     }
-    public function setRoleBindPassword($a_value)
+    public function setRoleBindPassword(string $a_value) : void
     {
         $this->role_bind_pass = $a_value;
     }
-    public function enabledRoleSynchronization()
+    public function enabledRoleSynchronization() : bool
     {
         return $this->role_sync_active;
     }
-    public function enableRoleSynchronization($a_value)
+    public function enableRoleSynchronization(bool $a_value) : void
     {
         $this->role_sync_active = $a_value;
     }
-    // start Patch Name Filter
-    public function getUsernameFilter()
+
+    public function getUsernameFilter() : string
     {
         return $this->username_filter;
     }
-    public function setUsernameFilter($a_value)
+    public function setUsernameFilter(string $a_value) : void
     {
         $this->username_filter = $a_value;
     }
 
-    public function enableEscapeDN(bool $a_value)
+    public function enableEscapeDN(bool $a_value) : void
     {
         $this->escape_dn = $a_value;
     }
@@ -782,25 +791,18 @@ class ilLDAPServer
 
     /**
      * Enable account migration
-     *
-     * @access public
-     * @param bool status
-     *
      */
-    public function enableAccountMigration($a_status)
+    public function enableAccountMigration(bool $a_status) : void
     {
         $this->account_migration = $a_status;
     }
     
     /**
      * enabled account migration
-     *
-     * @access public
-     *
      */
-    public function isAccountMigrationEnabled()
+    public function isAccountMigrationEnabled() : bool
     {
-        return $this->account_migration ? true : false;
+        return $this->account_migration;
     }
     
     
@@ -810,26 +812,26 @@ class ilLDAPServer
     public function validate() : bool
     {
         $this->ilErr->setMessage('');
-        if (!strlen($this->getName()) ||
-            !strlen($this->getUrl()) ||
-            !strlen($this->getBaseDN()) ||
-            !strlen($this->getUserAttribute())) {
+        if ($this->getName() === '' ||
+            $this->getUrl() === '' ||
+            $this->getBaseDN() === '' ||
+            $this->getUserAttribute() === '') {
             $this->ilErr->setMessage($this->lng->txt('fill_out_all_required_fields'));
         }
         
-        if ($this->getBindingType() == ilLDAPServer::LDAP_BIND_USER
-            && (!strlen($this->getBindUser()) || !strlen($this->getBindPassword()))) {
+        if ($this->getBindingType() === self::LDAP_BIND_USER
+            && ($this->getBindUser() === '' || $this->getBindPassword() === '')) {
             $this->ilErr->appendMessage($this->lng->txt('ldap_missing_bind_user'));
         }
         
-        if (($this->enabledSyncPerCron() or $this->enabledSyncOnLogin()) and !$this->global_role) {
+        if (!$this->global_role && ($this->enabledSyncPerCron() || $this->enabledSyncOnLogin())) {
             $this->ilErr->appendMessage($this->lng->txt('ldap_missing_role_assignment'));
         }
-        if ($this->getVersion() == 2 and $this->isActiveTLS()) {
+        if ($this->getVersion() === 2 && $this->isActiveTLS()) {
             $this->ilErr->appendMessage($this->lng->txt('ldap_tls_conflict'));
         }
         
-        return strlen($this->ilErr->getMessage()) ? false : true;
+        return $this->ilErr->getMessage() === '';
     }
     
     public function create() : int
@@ -922,7 +924,7 @@ class ilLDAPServer
             "role_bind_pass = " . $this->db->quote($this->getRoleBindPassword(), 'text') . ", " .
             "migration = " . $this->db->quote((int) $this->isAccountMigrationEnabled(), 'integer') . ", " .
             'authentication = ' . $this->db->quote((int) $this->isAuthenticationEnabled(), 'integer') . ', ' .
-            'authentication_type = ' . $this->db->quote((int) $this->getAuthenticationMapping(), 'integer') . ' ' .
+            'authentication_type = ' . $this->db->quote($this->getAuthenticationMapping(), 'integer') . ' ' .
             ", username_filter = " . $this->db->quote($this->getUsernameFilter(), "text") . " " .
             ", escape_dn = " . $this->db->quote($this->enabledEscapeDN() ? 1 : 0, 'integer') . " " .
             "WHERE server_id = " . $this->db->quote($this->getServerId(), 'integer');
@@ -966,23 +968,20 @@ class ilLDAPServer
     {
         $options = array(
             'url' => $this->getUrl(),
-            'version' => (int) $this->getVersion(),
-            'referrals' => (bool) $this->isActiveReferrer());
+            'version' => $this->getVersion(),
+            'referrals' => $this->isActiveReferrer());
         
-        if ($this->getBindingType() == ilLDAPServer::LDAP_BIND_USER) {
+        if ($this->getBindingType() === self::LDAP_BIND_USER) {
             $options['binddn'] = $this->getBindUser();
             $options['bindpw'] = $this->getBindPassword();
         }
         $options['basedn'] = $this->getBaseDN();
-        $options['start_tls'] = (bool) $this->isActiveTLS();
+        $options['start_tls'] = $this->isActiveTLS();
         $options['userdn'] = $this->getSearchBase();
-        switch ($this->getUserScope()) {
-            case ilLDAPServer::LDAP_SCOPE_ONE:
-                $options['userscope'] = 'one';
-                break;
-            default:
-                $options['userscope'] = 'sub';
-                break;
+        if ($this->getUserScope() === self::LDAP_SCOPE_ONE) {
+            $options['userscope'] = 'one';
+        } else {
+            $options['userscope'] = 'sub';
         }
         
         $options['userattr'] = $this->getUserAttribute();
@@ -994,10 +993,10 @@ class ilLDAPServer
         $options['enableLogging'] = true;
 
         switch ($this->getGroupScope()) {
-            case ilLDAPServer::LDAP_SCOPE_BASE:
+            case self::LDAP_SCOPE_BASE:
                 $options['groupscope'] = 'base';
                 break;
-            case ilLDAPServer::LDAP_SCOPE_ONE:
+            case self::LDAP_SCOPE_ONE:
                 $options['groupscope'] = 'one';
                 break;
             default:
@@ -1023,15 +1022,15 @@ class ilLDAPServer
     {
         $filter = trim($a_filter);
         
-        if (!strlen($filter)) {
+        if ($filter === '') {
             return $filter;
         }
         
         if (strpos($filter, '(') !== 0) {
             $filter = ('(' . $filter);
         }
-        if (substr($filter, -1) != ')') {
-            $filter = ($filter . ')');
+        if (substr($filter, -1) !== ')') {
+            $filter .= ')';
         }
         return $filter;
     }
@@ -1049,13 +1048,11 @@ class ilLDAPServer
                 array('dn'),
                 ilLDAPRoleAssignmentRules::getAttributeNames($this->getServerId())
             );
-        } else {
-            return array($this->getUserAttribute());
         }
+
+        return array($this->getUserAttribute());
     }
-    
-    
-    
+
     /**
      * Read server settings
      *
@@ -1065,26 +1062,26 @@ class ilLDAPServer
         if (!$this->server_id) {
             return;
         }
-        $query = "SELECT * FROM ldap_server_settings WHERE server_id = " . $this->db->quote($this->server_id) . "";
+        $query = "SELECT * FROM ldap_server_settings WHERE server_id = " . $this->db->quote($this->server_id, ilDBConstants::T_INTEGER);
         
         $res = $this->db->query($query);
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             $this->toggleActive((bool) $row->active);
             $this->setName($row->name);
             $this->setUrl($row->url);
-            $this->setVersion($row->version);
+            $this->setVersion((int) $row->version);
             $this->setBaseDN($row->base_dn);
-            $this->toggleReferrer($row->referrals);
-            $this->toggleTLS($row->tls);
-            $this->setBindingType($row->bind_type);
+            $this->toggleReferrer((bool) $row->referrals);
+            $this->toggleTLS((bool) $row->tls);
+            $this->setBindingType((int) $row->bind_type);
             $this->setBindUser($row->bind_user);
             $this->setBindPassword($row->bind_pass);
             $this->setSearchBase($row->search_base);
-            $this->setUserScope($row->user_scope);
+            $this->setUserScope((int) $row->user_scope);
             $this->setUserAttribute($row->user_attribute);
             $this->setFilter($row->filter);
             $this->setGroupDN($row->group_dn);
-            $this->setGroupScope($row->group_scope);
+            $this->setGroupScope((int) $row->group_scope);
             $this->setGroupFilter($row->group_filter);
             $this->setGroupMember($row->group_member);
             $this->setGroupAttribute($row->group_attribute);

--- a/Services/LDAP/classes/class.ilLDAPServerTableGUI.php
+++ b/Services/LDAP/classes/class.ilLDAPServerTableGUI.php
@@ -54,7 +54,10 @@ class ilLDAPServerTableGUI extends ilTable2GUI
         $data = ilLDAPServer::_getAllServer();
         $this->setData($data);
     }
-    
+
+    /**
+     * @throws ilCtrlException
+     */
     protected function fillRow(array $a_set) : void
     {
         if ($a_set['active']) {

--- a/Services/LDAP/classes/class.ilLDAPUserSynchronisation.php
+++ b/Services/LDAP/classes/class.ilLDAPUserSynchronisation.php
@@ -17,30 +17,19 @@
  * Synchronization of user accounts used in auth container ldap, cas,...
  *
  * @author Stefan Meyer <meyer@leifos.com>
- * @ingroup ServicesLDAP
  */
 class ilLDAPUserSynchronisation
 {
     private string $authmode;
-
     private ilLDAPServer $server;
-
     private string $extaccount = '';
     private string $intaccount = '';
 
     private array $user_data = array();
-    
     private bool $force_creation = false;
     private bool $force_read_ldap_data = false;
-
     private ilLogger $logger;
 
-
-    /**
-     * Constructor
-     *
-     * @param string $a_auth_mode
-     */
     public function __construct(string $a_authmode, int $a_server_id)
     {
         global $DIC;
@@ -86,7 +75,7 @@ class ilLDAPUserSynchronisation
      * Get ILIAS unique internal account name
      * @return string internal account
      */
-    public function getInternalAccount() : string
+    public function getInternalAccount() : ?string
     {
         return $this->intaccount;
     }
@@ -105,20 +94,12 @@ class ilLDAPUserSynchronisation
     }
 
     /**
-     * Check if creation of user account is forced (account migration)
-     */
-    public function isCreationForced() : bool
-    {
-        return (bool) $this->force_creation;
-    }
-
-    /**
      * Get user data
      * @return array $user_data
      */
     public function getUserData() : array
     {
-        return (array) $this->user_data;
+        return $this->user_data;
     }
 
     /**
@@ -171,7 +152,7 @@ class ilLDAPUserSynchronisation
             throw new ilLDAPSynchronisationForbiddenException('User synchronisation forbidden.');
         }
         // Account migration
-        if ($this->getServer()->isAccountMigrationEnabled() and !$this->isCreationForced()) {
+        if (!$this->force_creation && $this->getServer()->isAccountMigrationEnabled()) {
             $this->readUserData();
             throw new ilLDAPAccountMigrationRequiredException('Account migration check required.');
         }
@@ -185,7 +166,7 @@ class ilLDAPUserSynchronisation
         ilUserCreationContext::getInstance()->addContext(ilUserCreationContext::CONTEXT_LDAP);
 
         $update = new ilLDAPAttributeToUser($this->getServer());
-        if ($this->isCreationForced()) {
+        if ($this->force_creation) {
             $update->addMode(ilLDAPAttributeToUser::MODE_INITIALIZE_ROLES);
         }
         $update->setNewUserAuthMode($this->getAuthMode());
@@ -250,7 +231,7 @@ class ilLDAPUserSynchronisation
      */
     protected function isUpdateRequired() : bool
     {
-        if ($this->isCreationForced()) {
+        if ($this->force_creation) {
             return true;
         }
         if (!$this->getInternalAccount()) {

--- a/Services/LDAP/exceptions/class.ilLDAPAccountMigrationRequiredException.php
+++ b/Services/LDAP/exceptions/class.ilLDAPAccountMigrationRequiredException.php
@@ -14,10 +14,7 @@
  *
  *****************************************************************************/
 /**
- * Description of ilLDAPAccountMigrationRequiredException
- *
  * @author Stefan Meyer <meyer@leifos.com>
- * @ingroup ServicesLDAP
  */
 class ilLDAPAccountMigrationRequiredException extends ilException
 {

--- a/Services/LDAP/exceptions/class.ilLDAPConnectTimeOutException.php
+++ b/Services/LDAP/exceptions/class.ilLDAPConnectTimeOutException.php
@@ -14,10 +14,7 @@
  *
  *****************************************************************************/
 /**
- * Description of ilLDAPConnectTimeOutException
- *
  * @author Stefan Meyer <meyer@leifos.com>
- * @ingroup ServicesLDAP
  */
 class ilLDAPConnectTimeOutException extends ilException
 {

--- a/Services/LDAP/exceptions/class.ilLDAPPagingException.php
+++ b/Services/LDAP/exceptions/class.ilLDAPPagingException.php
@@ -14,10 +14,7 @@
  *
  *****************************************************************************/
 /**
- * Class ilLDAPPagingException
- *
  * @author Fabian Wolf <wolf@ilias.de>
- * @ingroup ServicesLDAP
  */
 class ilLDAPPagingException extends ilException
 {

--- a/Services/LDAP/exceptions/class.ilLDAPSynchronisationFailedException.php
+++ b/Services/LDAP/exceptions/class.ilLDAPSynchronisationFailedException.php
@@ -17,7 +17,6 @@
  * Thrown in case of failed synchronisation settings
  *
  * @author Stefan Meyer <meyer@leifos.com>
- * @ingroup ServicesLDAP
  */
 class ilLDAPSynchronisationFailedException extends ilException
 {

--- a/Services/LDAP/exceptions/class.ilLDAPUndefinedScopeException.php
+++ b/Services/LDAP/exceptions/class.ilLDAPUndefinedScopeException.php
@@ -14,8 +14,8 @@
  *
  *****************************************************************************/
 /**
- * @author Stefan Meyer <meyer@leifos.com>
+ * @author Per Pascal Seeland <pascal.seeland@tik.uni-stuttgart.de>
  */
-class ilLDAPSynchronisationForbiddenException extends ilException
+class ilLDAPUndefinedScopeException extends ilException
 {
 }

--- a/Services/LDAP/test/ilLDAPServerTest.php
+++ b/Services/LDAP/test/ilLDAPServerTest.php
@@ -1,0 +1,177 @@
+<?php declare(strict_types=1);
+
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
+
+use ILIAS\DI\Container;
+use ILIAS\UI\Component\Legacy\Legacy;
+use ILIAS\UI\Factory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class ilSessionTest
+ */
+class ilLDAPServerTest extends TestCase
+{
+    protected function setUp() : void
+    {
+        $this->dic = new Container();
+        $GLOBALS['DIC'] = $this->dic;
+
+        $this->setGlobalVariable('lng', $this->getLanguageMock());
+        $this->setGlobalVariable(
+            'ilDB',
+            $this->getMockBuilder(ilDBInterface::class)->disableAutoReturnValueGeneration()->getMock()
+        );
+
+        $this->setGlobalVariable(
+            'ilSetting',
+            $this->getMockBuilder(\ILIAS\Administration\Setting::class)->getMock()
+        );
+        $this->setGlobalVariable(
+            'ilErr',
+            $this->getMockBuilder(ilErrorHandling::class)->getMock()
+        );
+        parent::setUp();
+    }
+
+    /**
+     * @param string $name
+     * @param mixed  $value
+     */
+    protected function setGlobalVariable(string $name, $value) : void
+    {
+        global $DIC;
+
+        $GLOBALS[$name] = $value;
+
+        unset($DIC[$name]);
+        $DIC[$name] = static function ($c) use ($name) {
+            return $GLOBALS[$name];
+        };
+    }
+
+    /**
+     * @return MockObject|ilLanguage
+     */
+    protected function getLanguageMock() : ilLanguage
+    {
+        $lng = $this
+            ->getMockBuilder(ilLanguage::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['txt', 'getInstalledLanguages', 'loadLanguageModule'])
+            ->getMock();
+
+        return $lng;
+    }
+
+    public function testConstructorWithoutParam() : void
+    {
+        global $DIC;
+
+        //setup some method calls
+        /** @var $setting MockObject */
+        $setting = $DIC['ilSetting'];
+        $setting->method("get")->willReturnCallback(
+            function ($arg) {
+                if ($arg === 'session_handling_type') {
+                    return (string) ilSession::SESSION_HANDLING_FIXED;
+                }
+                if ($arg === 'session_statistics') {
+                    return "0";
+                }
+
+                throw new \RuntimeException($arg);
+            }
+        );
+        /** @var $ilDB MockObject */
+        $data = null;
+        $ilDB = $DIC['ilDB'];
+        $ilDB->expects($this->never())->method("quote");
+
+        $server = new ilLDAPServer();
+        $this->assertFalse($server->isActive());
+    }
+
+    public function testConstructorWithParameter() : void
+    {
+        global $DIC;
+
+        //setup some method calls
+        /** @var $setting MockObject */
+        $setting = $DIC['ilSetting'];
+        $setting->method("get")->willReturnCallback(
+            function ($arg) {
+                if ($arg === 'session_handling_type') {
+                    return (string) ilSession::SESSION_HANDLING_FIXED;
+                }
+                if ($arg === 'session_statistics') {
+                    return "0";
+                }
+
+                throw new \RuntimeException($arg);
+            }
+        );
+
+        /** @var $ilDB MockObject */
+        $ilDB = $DIC['ilDB'];
+        $ilDB->expects($this->once())->method("quote")->with(1)->willReturn("1");
+
+        $res = $this->getMockBuilder(ilDBStatement::class)->disableAutoReturnValueGeneration()->getMock();
+        $ilDB->method("query")->with(
+            "SELECT * FROM ldap_server_settings WHERE server_id = 1"
+        )->
+        willReturn($res);
+        $res->expects($this->exactly(2))->method("fetchRow")->willReturnOnConsecutiveCalls((object) array(
+            'active' => "true",
+            'name' => "testserver",
+            'url' => "ldap://testurl:389",
+            'version' => "3",
+            'base_dn' => "true",
+            'referrals' => "false",
+            'tls' => "false",
+            'bind_type' => "1",
+            'bind_user' => "nobody",
+            'bind_pass' => "password",
+            'search_base' => "dc=de",
+            'user_scope' => "1",
+            'user_attribute' => "user",
+            'filter' => ".",
+            'group_dn' => "dc=group",
+            'group_scope' => "1",
+            'group_filter' => "",
+            'group_member' => "",
+            'group_attribute' => "",
+            'group_optional' => "false",
+            'group_user_filter' => ".*",
+            'group_memberisdn' => "true",
+            'group_name' => "",
+            'sync_on_login' => "true",
+            'sync_per_cron' => "false",
+            'role_sync_active' => "true",
+            'role_bind_dn' => "rolebind",
+            'role_bind_pass' => "rolebindpwd",
+            'migration' => "true",
+            'authentication' => "true",
+            'authentication_type' => "1",
+            'username_filter' => ".*",
+            'escape_dn' => "false"
+        ), null);
+
+        $server = new ilLDAPServer(1);
+        $this->assertTrue($server->isActive());
+    }
+}

--- a/Services/LDAP/test/ilServicesLDAPSuite.php
+++ b/Services/LDAP/test/ilServicesLDAPSuite.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
+use PHPUnit\Framework\TestSuite;
+
+class ilServicesLDAPSuite extends TestSuite
+{
+    public static function suite() : self
+    {
+        $suite = new ilServicesLDAPSuite();
+        require_once __DIR__ . '/ilLDAPServerTest.php';
+        $suite->addTestSuite(ilLDAPServerTest::class);
+
+        return $suite;
+    }
+}


### PR DESCRIPTION
Hello @pascalseeland, 

I completed the review of the `Services/LDAP` component.

Results:

- [x] The code style is `PSR-2 + X` compliant
- [ ] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`: I found 8 usages of `$_REQUEST`, 16 usages of `$_GET`, 26 usages of `$_SESSION` and 23 usages of `$_POST`.
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] There are no serious `PhpStorm Code Inspection` issues left
- [x] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

--

Actions needed:
- [ ] Please eliminate the usage of super global variables.
- [x] Please add a unit test suite with at least one passing unit test.
- [x] The methods `ldap_control_paged_result` and `ldap_control_paged_result` are **not** compatible with PHP 8. The paging has to be revised for ILIAS 8 to make it work under PHP 8.
- [x] There are dozens of undefined symbols (means: undefined methods and undeclared class properties). I cannot list them all.
- [x] There are dozens of wrong types passed to methods of other services. I cannot list them all. Example: `\ilLDAPSettingsGUI::loadRoleAssignmentRule`.
- [x] Please check my inline comments. Some of them might just be information, some require an action. You can use `TODO PHP8-REVIEW` when searching.


Best regards,
@mjansenDatabay  