### PR TITLE
PHP8: Code Review `ILIAS Page Editor`

### DIFF
--- a/Services/COPage/DOM/class.ilDomDocument.php
+++ b/Services/COPage/DOM/class.ilDomDocument.php
@@ -67,7 +67,7 @@ class ilDomDocument
     /**
      * Handle error
      */
-    public function handleError(
+    public function handleError(// @TODO: PHP8 Review: Missing return type.
         int $a_no,
         string $a_string,
         string $a_file = null,

--- a/Services/COPage/Editor/Components/Paragraph/class.ParagraphCommandActionHandler.php
+++ b/Services/COPage/Editor/Components/Paragraph/class.ParagraphCommandActionHandler.php
@@ -93,7 +93,7 @@ class ParagraphCommandActionHandler implements Server\CommandActionHandler
      * @throws \ilCOPagePCEditException
      * @throws \ilCOPageUnknownPCTypeException
      */
-    protected function insertParagraph(
+    protected function insertParagraph(// @TODO: PHP8 Review: Missing return type.
         string $pcid,
         string $after_pcid,
         string $content,
@@ -137,7 +137,7 @@ class ParagraphCommandActionHandler implements Server\CommandActionHandler
      * @throws \ilCOPagePCEditException
      * @throws \ilCOPageUnknownPCTypeException
      */
-    protected function updateParagraph(
+    protected function updateParagraph(// @TODO: PHP8 Review: Missing return type.
         string $pcid,
         string $content,
         string $characteristic

--- a/Services/COPage/Editor/Components/Table/class.TableCommandActionHandler.php
+++ b/Services/COPage/Editor/Components/Table/class.TableCommandActionHandler.php
@@ -105,7 +105,7 @@ class TableCommandActionHandler implements Server\CommandActionHandler
      * @return array|bool
      * @throws \ilDateTimeException
      */
-    protected function updateData(
+    protected function updateData(// @TODO: PHP8 Review: Missing return type.
         string $pcid,
         string $content
     ) {

--- a/Services/COPage/Editor/Server/class.Server.php
+++ b/Services/COPage/Editor/Server/class.Server.php
@@ -49,7 +49,7 @@ class Server
     {
         $query = $this->request->getQueryParams();
 
-        if (is_array($_POST) && count($_POST) > 0) {
+        if (is_array($_POST) && count($_POST) > 0) { // @TODO: PHP8 Review: Direct access to $_POST.
             $body = $this->request->getParsedBody();
         } else {
             $body = json_decode($this->request->getBody()->getContents(), true);
@@ -69,7 +69,7 @@ class Server
     ) : QueryActionHandler {
         $handler = null;
 
-        switch ($query["component"]) {
+        switch ($query["component"]) { // @TODO: PHP8 Review: switch with one case.
             case "Page":
                 $handler = new Page\PageQueryActionHandler($this->page_gui);
                 break;

--- a/Services/COPage/Editor/UI/Init.php
+++ b/Services/COPage/Editor/UI/Init.php
@@ -31,7 +31,7 @@ class Init
         $this->lng = $DIC->language();
     }
 
-    public function initUI(
+    public function initUI(// @TODO: PHP8 Review: Missing return type.
         \ilGlobalTemplateInterface $main_tpl,
         string $openPlaceHolderPcId = ""
     ) {

--- a/Services/COPage/Editor/class.EditSessionRepository.php
+++ b/Services/COPage/Editor/class.EditSessionRepository.php
@@ -62,7 +62,7 @@ class EditSessionRepository
     /**
      * @return string|array
      */
-    public function getPageError()
+    public function getPageError() // @TODO: PHP8 Review: Missing return type.
     {
         return \ilSession::get(self::ERROR_KEY) ?? "";
     }

--- a/Services/COPage/Editor/class.ilPageEditorServerAdapterGUI.php
+++ b/Services/COPage/Editor/class.ilPageEditorServerAdapterGUI.php
@@ -46,7 +46,7 @@ class ilPageEditorServerAdapterGUI
         $next_class = $ctrl->getNextClass($this);
         $cmd = $ctrl->getCmd("invokeServer");
 
-        switch ($next_class) {
+        switch ($next_class) { // @TODO: PHP8 Review: switch with one case.
             default:
                 if (in_array($cmd, array("invokeServer"))) {
                     $this->$cmd();

--- a/Services/COPage/Layout/classes/class.ilPageLayout.php
+++ b/Services/COPage/Layout/classes/class.ilPageLayout.php
@@ -273,7 +273,7 @@ class ilPageLayout
         return $arr_layouts;
     }
     
-    public static function getLayouts(
+    public static function getLayouts(// @TODO: PHP8 Review: Missing return type.
         bool $a_active = false,
         bool $a_special_page = false,
         int $a_module = 0
@@ -311,7 +311,7 @@ class ilPageLayout
     /**
      * Get active layouts
      */
-    public static function activeLayouts(
+    public static function activeLayouts(// @TODO: PHP8 Review: Missing return type.
         bool $a_special_page = false,
         int $a_module = 0
     ) {

--- a/Services/COPage/PC/class.EditGUIRequest.php
+++ b/Services/COPage/PC/class.EditGUIRequest.php
@@ -59,17 +59,17 @@ class EditGUIRequest
         return $pc_id;
     }
 
-    public function getInt($key) : int
+    public function getInt($key) : int // @TODO: PHP8 Review: Missing parameter type.
     {
         return $this->int($key);
     }
 
-    public function getString($key) : string
+    public function getString($key) : string // @TODO: PHP8 Review: Missing parameter type.
     {
         return $this->str($key);
     }
 
-    public function getRaw($key) : string
+    public function getRaw($key) : string // @TODO: PHP8 Review: Missing parameter type.
     {
         return $this->raw($key);
     }
@@ -77,7 +77,7 @@ class EditGUIRequest
     /**
      * @return int[]
      */
-    public function getIntArray($key) : array
+    public function getIntArray($key) : array // @TODO: PHP8 Review: Missing parameter type.
     {
         return $this->intArray($key);
     }
@@ -85,7 +85,7 @@ class EditGUIRequest
     /**
      * @return string[]
      */
-    public function getStringArray($key) : array
+    public function getStringArray($key) : array // @TODO: PHP8 Review: Missing parameter type.
     {
         return $this->strArray($key);
     }
@@ -94,7 +94,7 @@ class EditGUIRequest
     /**
      * @return array[]
      */
-    public function getArrayArray($key) : array
+    public function getArrayArray($key) : array // @TODO: PHP8 Review: Missing parameter type.
     {
         return $this->arrayArray($key);
     }

--- a/Services/COPage/Page/class.EditGUIRequest.php
+++ b/Services/COPage/Page/class.EditGUIRequest.php
@@ -75,17 +75,17 @@ class EditGUIRequest
         return $this->strArray("ids");
     }
 
-    public function getString($key) : string
+    public function getString($key) : string // @TODO: PHP8 Review: Missing parameter type.
     {
         return $this->str($key);
     }
 
-    public function getInt($key) : int
+    public function getInt($key) : int // @TODO: PHP8 Review: Missing parameter type.
     {
         return $this->int($key);
     }
 
-    public function getStringArray($key) : array
+    public function getStringArray($key) : array // @TODO: PHP8 Review: Missing parameter type.
     {
         return $this->strArray($key);
     }

--- a/Services/COPage/classes/Setup/class.ilCOPageDBUpdateSteps.php
+++ b/Services/COPage/classes/Setup/class.ilCOPageDBUpdateSteps.php
@@ -22,7 +22,7 @@ class ilCOPageDBUpdateSteps implements \ilDatabaseUpdateSteps
 {
     protected \ilDBInterface $db;
 
-    public function prepare(\ilDBInterface $db)
+    public function prepare(\ilDBInterface $db) // @TODO: PHP8 Review: Missing return type.
     {
         $this->db = $db;
     }
@@ -39,7 +39,7 @@ class ilCOPageDBUpdateSteps implements \ilDatabaseUpdateSteps
         $this->db->modifyTableColumn("copg_pc_def", "order_nr", $field);
     }
 
-    public function step_2()
+    public function step_2() // @TODO: PHP8 Review: Missing return type.
     {
         $field = array(
             'type' => 'integer',

--- a/Services/COPage/classes/class.ilCOPageDataSet.php
+++ b/Services/COPage/classes/class.ilCOPageDataSet.php
@@ -51,7 +51,7 @@ class ilCOPageDataSet extends ilDataSet
     {
         // pgtp: page layout template
         if ($a_entity == "pgtp") {
-            switch ($a_version) {
+            switch ($a_version) { // @TODO: PHP8 Review: switch with one case.
                 case "4.2.0":
                     return array(
                         "Id" => "integer",
@@ -74,7 +74,7 @@ class ilCOPageDataSet extends ilDataSet
                 
         // mep_data
         if ($a_entity == "pgtp") {
-            switch ($a_version) {
+            switch ($a_version) { // @TODO: PHP8 Review: switch with one case.
                 case "4.2.0":
                     $this->getDirectDataFromQuery("SELECT layout_id id, title, description, " .
                         " style_id, special_page " .
@@ -100,7 +100,7 @@ class ilCOPageDataSet extends ilDataSet
     
     public function importRecord(string $a_entity, array $a_types, array $a_rec, ilImportMapping $a_mapping, string $a_schema_version) : void
     {
-        switch ($a_entity) {
+        switch ($a_entity) { // @TODO: PHP8 Review: switch with one case.
             case "pgtp":
                 $pt = new ilPageLayout();
                 $pt->setTitle($a_rec["Title"]);

--- a/Services/COPage/classes/class.ilCOPageHTMLExport.php
+++ b/Services/COPage/classes/class.ilCOPageHTMLExport.php
@@ -118,8 +118,10 @@ class ilCOPageHTMLExport
 
         // export content style sheet
         if ($this->getContentStyleId() < 1) {     // basic style
-            ilFileUtils::rCopy(ilObjStyleSheet::getBasicImageDir(),
-                $this->exp_dir . "/" . ilObjStyleSheet::getBasicImageDir());
+            ilFileUtils::rCopy(
+                ilObjStyleSheet::getBasicImageDir(),
+                $this->exp_dir . "/" . ilObjStyleSheet::getBasicImageDir()
+            );
             ilFileUtils::makeDirParents($this->exp_dir . "/Services/COPage/css");
             copy("Services/COPage/css/content.css", $this->exp_dir . "/Services/COPage/css/content.css");
         } else {
@@ -300,7 +302,7 @@ class ilCOPageHTMLExport
                 
                 // trying to find user id
                 $user_id = null;
-                switch ($a_type) {
+                switch ($a_type) { // @TODO: PHP8 Review: switch with one case.
                     case "prtf:pg":
                         $page = new ilPortfolioPage($a_id);
                         $user_id = $page->create_user;

--- a/Services/COPage/classes/class.ilCOPageObjDef.php
+++ b/Services/COPage/classes/class.ilCOPageObjDef.php
@@ -21,7 +21,7 @@ class ilCOPageObjDef
 {
     public static ?array $page_obj_def = null;
     
-    public static function init()
+    public static function init() // @TODO: PHP8 Review: Missing return type.
     {
         global $DIC;
 

--- a/Services/COPage/classes/class.ilCOPagePCDef.php
+++ b/Services/COPage/classes/class.ilCOPagePCDef.php
@@ -28,7 +28,7 @@ class ilCOPagePCDef
     public static array $pc_gui_classes_lc = array();
     public static array $pc_def_by_gui_class_cl = array();
     
-    public static function init()
+    public static function init() // @TODO: PHP8 Review: Missing return type.
     {
         global $DIC;
 

--- a/Services/COPage/classes/class.ilPCBlogGUI.php
+++ b/Services/COPage/classes/class.ilPCBlogGUI.php
@@ -47,7 +47,7 @@ class ilPCBlogGUI extends ilPageContentGUI
     /**
     * execute command
     */
-    public function executeCommand()
+    public function executeCommand() // @TODO: PHP8 Review: Missing return type.
     {
         // get next class that processes or forwards current command
         $next_class = $this->ctrl->getNextClass($this);
@@ -55,7 +55,7 @@ class ilPCBlogGUI extends ilPageContentGUI
         // get current command
         $cmd = $this->ctrl->getCmd();
 
-        switch ($next_class) {
+        switch ($next_class) { // @TODO: PHP8 Review: switch with one case.
             default:
                 $ret = $this->$cmd();
                 break;

--- a/Services/COPage/classes/class.ilPCContentIncludeGUI.php
+++ b/Services/COPage/classes/class.ilPCContentIncludeGUI.php
@@ -49,7 +49,7 @@ class ilPCContentIncludeGUI extends ilPageContentGUI
         // get current command
         $cmd = $this->ctrl->getCmd();
 
-        switch ($next_class) {
+        switch ($next_class) { // @TODO: PHP8 Review: switch with one case.
             default:
                 $this->$cmd();
                 break;

--- a/Services/COPage/classes/class.ilPCContentTemplate.php
+++ b/Services/COPage/classes/class.ilPCContentTemplate.php
@@ -42,7 +42,7 @@ class ilPCContentTemplate extends ilPageContent
      * @param string $a_pc_id pc id
      * @param int $a_page_templ template page id
      */
-    public function create($a_pg_obj, $a_hier_id, $a_pc_id, $a_page_templ)
+    public function create($a_pg_obj, $a_hier_id, $a_pc_id, $a_page_templ) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         $source_id = explode(":", $a_page_templ);
         $source_page = ilPageObjectFactory::getInstance($source_id[1], $source_id[0]);

--- a/Services/COPage/classes/class.ilPCContentTemplateGUI.php
+++ b/Services/COPage/classes/class.ilPCContentTemplateGUI.php
@@ -48,7 +48,7 @@ class ilPCContentTemplateGUI extends ilPageContentGUI
         // get current command
         $cmd = $this->ctrl->getCmd();
 
-        switch ($next_class) {
+        switch ($next_class) { // @TODO: PHP8 Review: switch with one case.
             default:
                 $this->$cmd();
                 break;

--- a/Services/COPage/classes/class.ilPCDataTable.php
+++ b/Services/COPage/classes/class.ilPCDataTable.php
@@ -76,7 +76,7 @@ class ilPCDataTable extends ilPCTable
      * Set data of cells
      * @return bool|array
      */
-    public function setData(array $a_data)
+    public function setData(array $a_data) // @TODO: PHP8 Review: Missing return type.
     {
         if (is_array($a_data)) {
             foreach ($a_data as $i => $row) {

--- a/Services/COPage/classes/class.ilPCDataTableGUI.php
+++ b/Services/COPage/classes/class.ilPCDataTableGUI.php
@@ -53,7 +53,7 @@ class ilPCDataTableGUI extends ilPCTableGUI
         // get current command
         $cmd = $this->ctrl->getCmd();
 
-        switch ($next_class) {
+        switch ($next_class) { // @TODO: PHP8 Review: switch with one case.
             default:
                 $ret = $this->$cmd();
                 break;
@@ -293,7 +293,7 @@ class ilPCDataTableGUI extends ilPCTableGUI
 
         // handle input data
         $data = array();
-        foreach ($_POST as $k => $content) {
+        foreach ($_POST as $k => $content) { // @TODO: PHP8 Review: Direct access to $_POST.
             if (substr($k, 0, 5) != "cell_") {
                 continue;
             }

--- a/Services/COPage/classes/class.ilPCFileItemGUI.php
+++ b/Services/COPage/classes/class.ilPCFileItemGUI.php
@@ -52,7 +52,7 @@ class ilPCFileItemGUI extends ilPageContentGUI
 
         // get current command
         $cmd = $this->ctrl->getCmd();
-        switch ($next_class) {
+        switch ($next_class) { // @TODO: PHP8 Review: switch with one case.
             default:
                 $this->$cmd();
                 break;

--- a/Services/COPage/classes/class.ilPCFileListGUI.php
+++ b/Services/COPage/classes/class.ilPCFileListGUI.php
@@ -62,7 +62,7 @@ class ilPCFileListGUI extends ilPageContentGUI
         // get current command
         $cmd = $this->ctrl->getCmd();
 
-        switch ($next_class) {
+        switch ($next_class) { // @TODO: PHP8 Review: switch with one case.
             default:
                 $this->$cmd();
                 break;
@@ -118,7 +118,7 @@ class ilPCFileListGUI extends ilPageContentGUI
     /**
     * Select file
     */
-    public function selectFile()
+    public function selectFile() // @TODO: PHP8 Review: Missing return type.
     {
         $ilTabs = $this->tabs;
         $ilUser = $this->user;

--- a/Services/COPage/classes/class.ilPCFileListTableGUI.php
+++ b/Services/COPage/classes/class.ilPCFileListTableGUI.php
@@ -75,7 +75,8 @@ class ilPCFileListTableGUI extends ilTable2GUI
             $sel = ($a_set["class"] == "")
                 ? "FileListItem"
                 : $a_set["class"];
-            $this->tpl->setVariable("CLASS_SEL",
+            $this->tpl->setVariable(
+                "CLASS_SEL",
                 ilLegacyFormElementsUtil::formSelect(
                     $sel,
                     "class[" . $a_set["hier_id"] . ":" . $a_set["pc_id"] . "]",

--- a/Services/COPage/classes/class.ilPCGrid.php
+++ b/Services/COPage/classes/class.ilPCGrid.php
@@ -75,7 +75,7 @@ class ilPCGrid extends ilPageContent
         $this->grid_node = $this->node->append_child($this->grid_node);
     }
 
-    public function applyTemplate(
+    public function applyTemplate(// @TODO: PHP8 Review: Missing return type.
         int $post_layout_template,
         int $number_of_cells,
         int $s,
@@ -144,7 +144,7 @@ class ilPCGrid extends ilPageContent
     /**
      * Save widths of cells
      */
-    public function saveWidths(
+    public function saveWidths(// @TODO: PHP8 Review: Missing return type.
         array $a_width_s,
         array $a_width_m,
         array $a_width_l,

--- a/Services/COPage/classes/class.ilPCGridCellGUI.php
+++ b/Services/COPage/classes/class.ilPCGridCellGUI.php
@@ -37,7 +37,7 @@ class ilPCGridCellGUI extends ilPageContentGUI
         // get current command
         $cmd = $this->ctrl->getCmd();
 
-        switch ($next_class) {
+        switch ($next_class) { // @TODO: PHP8 Review: switch with one case.
             default:
                 $this->$cmd();
                 break;

--- a/Services/COPage/classes/class.ilPCGridCellTableGUI.php
+++ b/Services/COPage/classes/class.ilPCGridCellTableGUI.php
@@ -69,7 +69,8 @@ class ilPCGridCellTableGUI extends ilTable2GUI
         $this->tpl->setVariable("TID", $tid);
         foreach (ilPCGrid::getSizes() as $s) {
             $this->tpl->setCurrentBlock("select_width");
-            $this->tpl->setVariable("SELECT_WIDTH",
+            $this->tpl->setVariable(
+                "SELECT_WIDTH",
                 ilLegacyFormElementsUtil::formSelect(
                     $a_set[$s],
                     "width_" . $s . "[$tid]",

--- a/Services/COPage/classes/class.ilPCGridGUI.php
+++ b/Services/COPage/classes/class.ilPCGridGUI.php
@@ -54,7 +54,7 @@ class ilPCGridGUI extends ilPageContentGUI
         // get current command
         $cmd = $this->ctrl->getCmd();
 
-        switch ($next_class) {
+        switch ($next_class) { // @TODO: PHP8 Review: switch with one case.
             default:
                 $this->$cmd();
                 break;

--- a/Services/COPage/classes/class.ilPCList.php
+++ b/Services/COPage/classes/class.ilPCList.php
@@ -85,7 +85,7 @@ class ilPCList extends ilPageContent
     /**
     * Get list type
     */
-    public function getListType()
+    public function getListType() // @TODO: PHP8 Review: Missing return type.
     {
         if ($this->list_node->get_attribute("Type") == "Unordered") {
             return "Unordered";

--- a/Services/COPage/classes/class.ilPCListGUI.php
+++ b/Services/COPage/classes/class.ilPCListGUI.php
@@ -46,7 +46,7 @@ class ilPCListGUI extends ilPageContentGUI
         // get current command
         $cmd = $this->ctrl->getCmd();
 
-        switch ($next_class) {
+        switch ($next_class) { // @TODO: PHP8 Review: switch with one case.
             default:
                 $this->$cmd();
                 break;

--- a/Services/COPage/classes/class.ilPCListItemGUI.php
+++ b/Services/COPage/classes/class.ilPCListItemGUI.php
@@ -37,7 +37,7 @@ class ilPCListItemGUI extends ilPageContentGUI
         // get current command
         $cmd = $this->ctrl->getCmd();
 
-        switch ($next_class) {
+        switch ($next_class) { // @TODO: PHP8 Review: switch with one case.
             default:
                 $this->$cmd();
                 break;

--- a/Services/COPage/classes/class.ilPCLoginPageElementGUI.php
+++ b/Services/COPage/classes/class.ilPCLoginPageElementGUI.php
@@ -50,7 +50,7 @@ class ilPCLoginPageElementGUI extends ilPageContentGUI
         // get current command
         $cmd = $this->ctrl->getCmd();
 
-        switch ($next_class) {
+        switch ($next_class) { // @TODO: PHP8 Review: switch with one case.
             default:
                 $this->$cmd();
                 break;

--- a/Services/COPage/classes/class.ilPCMapGUI.php
+++ b/Services/COPage/classes/class.ilPCMapGUI.php
@@ -44,7 +44,7 @@ class ilPCMapGUI extends ilPageContentGUI
         // get current command
         $cmd = $this->ctrl->getCmd();
 
-        switch ($next_class) {
+        switch ($next_class) { // @TODO: PHP8 Review: switch with one case.
             default:
                 $this->$cmd();
                 break;
@@ -69,7 +69,7 @@ class ilPCMapGUI extends ilPageContentGUI
         $tpl->setContent($this->form->getHTML());
     }
 
-    public function getValues()
+    public function getValues() // @TODO: PHP8 Review: Missing return type.
     {
         $values = array();
         
@@ -83,8 +83,8 @@ class ilPCMapGUI extends ilPageContentGUI
         
         $this->form->setValuesByArray($values);
     }
-    
-    public function initForm($a_mode)
+
+    public function initForm($a_mode) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         $ilCtrl = $this->ctrl;
         $lng = $this->lng;

--- a/Services/COPage/classes/class.ilPCMediaObjectGUI.php
+++ b/Services/COPage/classes/class.ilPCMediaObjectGUI.php
@@ -22,7 +22,7 @@ class ilPCMediaObjectGUI extends ilPageContentGUI
 {
     protected ilPropertyFormGUI $form;
     protected ilPropertyFormGUI $form_gui;
-    protected $page_back_title = "";
+    protected $page_back_title = ""; // @TODO: PHP8 Review: Missing property type.
     protected bool $enabledmapareas;
     protected ilTabsGUI $tabs;
     protected ilAccessHandler $access;
@@ -124,7 +124,7 @@ class ilPCMediaObjectGUI extends ilPageContentGUI
      * @return mixed
      * @throws ilCtrlException
      */
-    public function executeCommand()
+    public function executeCommand() // @TODO: PHP8 Review: Missing return type.
     {
         $tpl = $this->tpl;
         $lng = $this->lng;
@@ -993,7 +993,7 @@ class ilPCMediaObjectGUI extends ilPageContentGUI
     /**
     * save table properties in db and return to page edit screen
     */
-    public function saveAliasProperties()
+    public function saveAliasProperties() // @TODO: PHP8 Review: Missing return type.
     {
         $this->initAliasForm();
         $form = $this->form_gui;

--- a/Services/COPage/classes/class.ilPCMediaObjectQuickEdit.php
+++ b/Services/COPage/classes/class.ilPCMediaObjectQuickEdit.php
@@ -53,7 +53,7 @@ class ilPCMediaObjectQuickEdit
     /**
      * Set title
      */
-    public function setTitle(string $title)
+    public function setTitle(string $title) // @TODO: PHP8 Review: Missing return type.
     {
         if (!$this->isTitleReadOnly()) {
             $this->mob->setTitle($title);
@@ -168,7 +168,7 @@ class ilPCMediaObjectQuickEdit
     /**
      * Set caption (pc if more usages, otherwise mob)
      */
-    public function setCaption(string $caption)
+    public function setCaption(string $caption) // @TODO: PHP8 Review: Missing return type.
     {
         $std_alias = $this->pcmedia->getStandardMediaAliasItem();
         $std_item = $this->mob->getMediaItem("Standard");

--- a/Services/COPage/classes/class.ilPCParagraph.php
+++ b/Services/COPage/classes/class.ilPCParagraph.php
@@ -183,7 +183,7 @@ class ilPCParagraph extends ilPageContent
      * @param bool      $a_auto_split auto split paragraph at headlines true/false
      * @return bool|string
      */
-    public function setText(
+    public function setText(// @TODO: PHP8 Review: Missing return type.
         string $a_text,
         bool $a_auto_split = false
     ) {
@@ -1480,7 +1480,7 @@ class ilPCParagraph extends ilPageContent
      * @throws ilCOPagePCEditException
      * @throws ilCOPageUnknownPCTypeException
      */
-    public function saveJS(
+    public function saveJS(// @TODO: PHP8 Review: Missing return type.
         ilPageObject $a_pg_obj,
         string $a_content,
         string $a_char,
@@ -1784,7 +1784,7 @@ class ilPCParagraph extends ilPageContent
      * @return array|bool
      * @throws ilDateTimeException
      */
-    public function updatePage(ilPageObject $a_page)
+    public function updatePage(ilPageObject $a_page) // @TODO: PHP8 Review: Missing return type.
     {
         $a_page->beforePageContentUpdate($this);
         return $a_page->update();
@@ -1965,7 +1965,7 @@ class ilPCParagraph extends ilPageContent
      * Auto link glossary of whole page
      * @throws ilDateTimeException
      */
-    public static function autoLinkGlossariesPage(
+    public static function autoLinkGlossariesPage(// @TODO: PHP8 Review: Missing return type.
         ilPageObject $a_page,
         array $a_terms
     ) {
@@ -2213,7 +2213,7 @@ class ilPCParagraph extends ilPageContent
      * @throws ilCOPageUnknownPCTypeException
      * @throws ilDateTimeException
      */
-    public function insert(
+    public function insert(// @TODO: PHP8 Review: Missing return type.
         \ilPageObject $page,
         string $a_content,
         string $a_char,

--- a/Services/COPage/classes/class.ilPCParagraphGUI.php
+++ b/Services/COPage/classes/class.ilPCParagraphGUI.php
@@ -84,7 +84,7 @@ class ilPCParagraphGUI extends ilPageContentGUI
         if ($a_style_id > 0 &&
             ilObject::_lookupType($a_style_id) == "sty") {
             $access_manager = $service->domain()->access(
-                (int) $_GET["ref_id"],
+                (int) $_GET["ref_id"], // @TODO: PHP8 Review: Direct access to $_GET.
                 $DIC->user()->getId()
             );
             $char_manager = $service->domain()->characteristic(
@@ -149,7 +149,7 @@ class ilPCParagraphGUI extends ilPageContentGUI
      * execute command
      * @return mixed
      */
-    public function executeCommand()
+    public function executeCommand() // @TODO: PHP8 Review: Missing return type.
     {
         // get next class that processes or forwards current command
         $next_class = $this->ctrl->getNextClass($this);
@@ -163,7 +163,7 @@ class ilPCParagraphGUI extends ilPageContentGUI
 
         $this->log->debug("ilPCParagraphGUI: executeCommand " . $cmd);
 
-        switch ($next_class) {
+        switch ($next_class) { // @TODO: PHP8 Review: switch with one case.
             default:
                 $ret = $this->$cmd();
                 break;
@@ -686,7 +686,7 @@ class ilPCParagraphGUI extends ilPageContentGUI
             )) {
                 $t = "text_inline";
                 $tag = "span";
-                switch ($key) {
+                switch ($key) { // @TODO: PHP8 Review: switch with one case.
                     case "Code": $tag = "code"; break;
                 }
                 $html = '<' . $tag . ' class="ilc_' . $t . '_' . $key . '" style="font-size:90%; margin-top:2px; margin-bottom:2px; position:static;">' . $char["txt"] . "</" . $tag . ">";

--- a/Services/COPage/classes/class.ilPCPluggedGUI.php
+++ b/Services/COPage/classes/class.ilPCPluggedGUI.php
@@ -60,7 +60,7 @@ class ilPCPluggedGUI extends ilPageContentGUI
      * @return mixed
      * @throws ilCtrlException
      */
-    public function executeCommand()
+    public function executeCommand() // @TODO: PHP8 Review: Missing return type.
     {
         $ilTabs = $this->tabs;
         $lng = $this->lng;

--- a/Services/COPage/classes/class.ilPCProfileGUI.php
+++ b/Services/COPage/classes/class.ilPCProfileGUI.php
@@ -44,7 +44,7 @@ class ilPCProfileGUI extends ilPageContentGUI
         // get current command
         $cmd = $this->ctrl->getCmd();
 
-        switch ($next_class) {
+        switch ($next_class) { // @TODO: PHP8 Review: switch with one case.
             default:
                 $this->$cmd();
                 break;
@@ -157,7 +157,7 @@ class ilPCProfileGUI extends ilPageContentGUI
     protected function getFieldsValues() : array
     {
         $fields = array();
-        foreach ($_POST as $name => $value) {
+        foreach ($_POST as $name => $value) { // @TODO: PHP8 Review: Direct access to $_POST.
             if (substr($name, 0, 4) == "chk_") {
                 if ($value) {
                     $fields[] = substr($name, 4);

--- a/Services/COPage/classes/class.ilPCQuestionGUI.php
+++ b/Services/COPage/classes/class.ilPCQuestionGUI.php
@@ -51,7 +51,7 @@ class ilPCQuestionGUI extends ilPageContentGUI
         $ilCtrl->saveParameter($this, array("qpool_ref_id"));
     }
 
-    public function executeCommand()
+    public function executeCommand() // @TODO: PHP8 Review: Missing return type.
     {
         $ilCtrl = $this->ctrl;
 
@@ -59,7 +59,7 @@ class ilPCQuestionGUI extends ilPageContentGUI
         $cmd = $ilCtrl->getCmd();
         $next_class = $ilCtrl->getNextClass($this);
 
-        switch ($next_class) {
+        switch ($next_class) { // @TODO: PHP8 Review: switch with one case.
             default:
                 //set tabs
                 if ($cmd != "insert") {
@@ -292,7 +292,7 @@ class ilPCQuestionGUI extends ilPageContentGUI
      * @return mixed
      * @throws ilCtrlException
      */
-    public function feedback()
+    public function feedback() // @TODO: PHP8 Review: Missing return type.
     {
         $ilCtrl = $this->ctrl;
         $ilTabs = $this->tabs;

--- a/Services/COPage/classes/class.ilPCQuestionOverviewGUI.php
+++ b/Services/COPage/classes/class.ilPCQuestionOverviewGUI.php
@@ -42,7 +42,7 @@ class ilPCQuestionOverviewGUI extends ilPageContentGUI
         // get current command
         $cmd = $this->ctrl->getCmd();
 
-        switch ($next_class) {
+        switch ($next_class) { // @TODO: PHP8 Review: switch with one case.
             default:
                 $this->$cmd();
                 break;

--- a/Services/COPage/classes/class.ilPCResourcesGUI.php
+++ b/Services/COPage/classes/class.ilPCResourcesGUI.php
@@ -49,7 +49,7 @@ class ilPCResourcesGUI extends ilPageContentGUI
         // get current command
         $cmd = $this->ctrl->getCmd();
 
-        switch ($next_class) {
+        switch ($next_class) { // @TODO: PHP8 Review: switch with one case.
             default:
                 $this->$cmd();
                 break;

--- a/Services/COPage/classes/class.ilPCSectionGUI.php
+++ b/Services/COPage/classes/class.ilPCSectionGUI.php
@@ -130,7 +130,7 @@ class ilPCSectionGUI extends ilPageContentGUI
      * @return mixed
      * @throws ilCtrlException
      */
-    public function executeCommand()
+    public function executeCommand() // @TODO: PHP8 Review: Missing return type.
     {
         $ret = "";
 

--- a/Services/COPage/classes/class.ilPCSkillsGUI.php
+++ b/Services/COPage/classes/class.ilPCSkillsGUI.php
@@ -45,7 +45,7 @@ class ilPCSkillsGUI extends ilPageContentGUI
         // get current command
         $cmd = $this->ctrl->getCmd();
 
-        switch ($next_class) {
+        switch ($next_class) { // @TODO: PHP8 Review: switch with one case.
             default:
                 $this->$cmd();
                 break;

--- a/Services/COPage/classes/class.ilPCSourceCodeGUI.php
+++ b/Services/COPage/classes/class.ilPCSourceCodeGUI.php
@@ -49,7 +49,7 @@ class ilPCSourceCodeGUI extends ilPageContentGUI
         // get current command
         $cmd = $this->ctrl->getCmd();
 
-        switch ($next_class) {
+        switch ($next_class) { // @TODO: PHP8 Review: switch with one case.
             default:
                 $this->$cmd();
                 break;

--- a/Services/COPage/classes/class.ilPCTabGUI.php
+++ b/Services/COPage/classes/class.ilPCTabGUI.php
@@ -27,7 +27,7 @@ class ilPCTabGUI extends ilPageContentGUI
         // get current command
         $cmd = $this->ctrl->getCmd();
 
-        switch ($next_class) {
+        switch ($next_class) { // @TODO: PHP8 Review: switch with one case.
             default:
                 $this->$cmd();
                 break;

--- a/Services/COPage/classes/class.ilPCTable.php
+++ b/Services/COPage/classes/class.ilPCTable.php
@@ -732,7 +732,7 @@ class ilPCTable extends ilPageContent
     /**
      * @return bool|string
      */
-    public function importHtml(
+    public function importHtml(// @TODO: PHP8 Review: Missing return type.
         string $lng,
         string $htmlTable
     ) {

--- a/Services/COPage/classes/class.ilPCTableDataGUI.php
+++ b/Services/COPage/classes/class.ilPCTableDataGUI.php
@@ -37,7 +37,7 @@ class ilPCTableDataGUI extends ilPageContentGUI
         // get current command
         $cmd = $this->ctrl->getCmd();
 
-        switch ($next_class) {
+        switch ($next_class) { // @TODO: PHP8 Review: switch with one case.
             default:
                 $this->$cmd();
                 break;

--- a/Services/COPage/classes/class.ilPCTableGUI.php
+++ b/Services/COPage/classes/class.ilPCTableGUI.php
@@ -51,7 +51,7 @@ class ilPCTableGUI extends ilPageContentGUI
     /**
      * @return mixed
      */
-    public function executeCommand()
+    public function executeCommand() // @TODO: PHP8 Review: Missing return type.
     {
         $this->getCharacteristicsOfCurrentStyle(["table"]);	// scorm-2004
         
@@ -61,7 +61,7 @@ class ilPCTableGUI extends ilPageContentGUI
         // get current command
         $cmd = $this->ctrl->getCmd();
 
-        switch ($next_class) {
+        switch ($next_class) { // @TODO: PHP8 Review: switch with one case.
             default:
                 $this->$cmd();
                 break;
@@ -1009,7 +1009,7 @@ class ilPCTableGUI extends ilPageContentGUI
     /**
      * Set editor tool context
      */
-    protected function setEditorToolContext()
+    protected function setEditorToolContext() // @TODO: PHP8 Review: Missing return type.
     {
         $collection = $this->tool_context->current()->getAdditionalData();
         if ($collection->exists(ilCOPageEditGSToolProvider::SHOW_EDITOR)) {
@@ -1193,7 +1193,7 @@ class ilPCTableGUI extends ilPageContentGUI
         return $dtpl->get();
     }
 
-    protected function getColumnCaption(int $nr)
+    protected function getColumnCaption(int $nr) // @TODO: PHP8 Review: Missing return type.
     {
         $cap = "";
         $base = 26;

--- a/Services/COPage/classes/class.ilPCTabsGUI.php
+++ b/Services/COPage/classes/class.ilPCTabsGUI.php
@@ -49,7 +49,7 @@ class ilPCTabsGUI extends ilPageContentGUI
         // get current command
         $cmd = $this->ctrl->getCmd();
 
-        switch ($next_class) {
+        switch ($next_class) { // @TODO: PHP8 Review: switch with one case.
             default:
                 $this->$cmd();
                 break;

--- a/Services/COPage/classes/class.ilPageComponentPluginGUI.php
+++ b/Services/COPage/classes/class.ilPageComponentPluginGUI.php
@@ -23,7 +23,7 @@ abstract class ilPageComponentPluginGUI
     protected ilLanguage $lng;
     protected ilPageComponentPlugin $plugin;
     protected ilPCPluggedGUI $pc_gui;
-    protected $pc;
+    protected $pc; // @TODO: PHP8 Review: Missing property type.
 
     public function __construct()
     {
@@ -84,12 +84,12 @@ abstract class ilPageComponentPluginGUI
         string $plugin_version
     ) : string;
     
-    public function createElement(array $a_properties)
+    public function createElement(array $a_properties) // @TODO: PHP8 Review: Missing return type.
     {
         return $this->getPCGUI()->createElement($a_properties);
     }
     
-    public function updateElement(array $a_properties)
+    public function updateElement(array $a_properties) // @TODO: PHP8 Review: Missing return type.
     {
         return $this->getPCGUI()->updateElement($a_properties);
     }

--- a/Services/COPage/classes/class.ilPageContentGUI.php
+++ b/Services/COPage/classes/class.ilPageContentGUI.php
@@ -160,7 +160,7 @@ class ilPageContentGUI
         global $DIC;
         $service = $DIC->contentStyle()->internal();
         $access_manager = $service->domain()->access(
-            (int) $_GET["ref_id"],
+            (int) $_GET["ref_id"], // @TODO: PHP8 Review: Direct access to $_GET.
             $DIC->user()->getId()
         );
 
@@ -602,7 +602,7 @@ class ilPageContentGUI
         return $ilCtrl->getParentReturn($this) . "#add" . $pcid;
     }
 
-    protected function updateAndReturn()
+    protected function updateAndReturn() // @TODO: PHP8 Review: Missing return type.
     {
         $up = $this->pg_obj->update();
         if ($up === true) {

--- a/Services/COPage/classes/class.ilPageMultiLangGUI.php
+++ b/Services/COPage/classes/class.ilPageMultiLangGUI.php
@@ -22,7 +22,7 @@
 class ilPageMultiLangGUI
 {
     protected ilObjectTranslation $ot;
-    protected $ctrl;
+    protected $ctrl; // @TODO: PHP8 Review: Missing property type.
     protected ilLanguage $lng;
     protected bool $single_page_mode = false;
 
@@ -57,7 +57,7 @@ class ilPageMultiLangGUI
         
         $next_class = $ilCtrl->getNextClass();
         
-        switch ($next_class) {
+        switch ($next_class) { // @TODO: PHP8 Review: switch with one case.
             default:
                 $cmd = $ilCtrl->getCmd("settings");
                 if (in_array($cmd, array("settings", "activateMultilinguality", "cancel",

--- a/Services/COPage/classes/class.ilPageObject.php
+++ b/Services/COPage/classes/class.ilPageObject.php
@@ -178,7 +178,7 @@ abstract class ilPageObject
         return $this->page_config;
     }
     
-    public static function randomhash()
+    public static function randomhash() // @TODO: PHP8 Review: Missing return type.
     {
         $random = new \ilRandom();
         return md5($random->int(1, 9999999) + str_replace(" ", "", (string) microtime()));
@@ -334,7 +334,7 @@ abstract class ilPageObject
     /**
      * @return bool|array
      */
-    public function buildDom(bool $a_force = false)
+    public function buildDom(bool $a_force = false) // @TODO: PHP8 Review: Missing return type.
     {
         if ($this->dom_builded && !$a_force) {
             return true;
@@ -2145,7 +2145,7 @@ s     */
     }
 
     // @todo: generalize, internal links usage info
-    public function handleImportRepositoryLink($a_rep_import_id, $a_rep_type, $a_rep_ref_id)
+    public function handleImportRepositoryLink($a_rep_import_id, $a_rep_type, $a_rep_ref_id) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         $this->buildDom();
 
@@ -2448,7 +2448,7 @@ s     */
      * @return array|bool
      * @throws ilDateTimeException
      */
-    public function update(bool $a_validate = true, bool $a_no_history = false)
+    public function update(bool $a_validate = true, bool $a_no_history = false) // @TODO: PHP8 Review: Missing return type.
     {
         $this->log->debug("ilPageObject, update(): start, id: " . $this->getId());
 
@@ -2959,7 +2959,7 @@ s     */
      * @return array|bool
      * @throws ilDateTimeException
      */
-    public function deleteContent(string $a_hid, bool $a_update = true, string $a_pcid = "")
+    public function deleteContent(string $a_hid, bool $a_update = true, string $a_pcid = "") // @TODO: PHP8 Review: Missing return type.
     {
         $curr_node = $this->getContentNode($a_hid, $a_pcid);
         $this->handleDeleteContent($curr_node);
@@ -2977,7 +2977,7 @@ s     */
      * @return array|bool
      * @throws ilDateTimeException
      */
-    public function deleteContents(
+    public function deleteContents(// @TODO: PHP8 Review: Missing return type.
         array $a_hids,
         bool $a_update = true,
         bool $a_self_ass = false
@@ -3013,7 +3013,7 @@ s     */
      * @return array|bool
      * @throws ilDateTimeException
      */
-    public function cutContents(array $a_hids)
+    public function cutContents(array $a_hids) // @TODO: PHP8 Review: Missing return type.
     {
         $this->copyContents($a_hids);
         return $this->deleteContents($a_hids, true, $this->getPageConfig()->getEnableSelfAssessment());
@@ -3084,7 +3084,7 @@ s     */
      * @return array|bool
      * @throws ilDateTimeException
      */
-    public function pasteContents(
+    public function pasteContents(// @TODO: PHP8 Review: Missing return type.
         string $a_hier_id,
         bool $a_self_ass = false
     ) {
@@ -3132,7 +3132,7 @@ s     */
      * @throws ilCOPageUnknownPCTypeException
      * @throws ilDateTimeException
      */
-    public function switchEnableMultiple(
+    public function switchEnableMultiple(// @TODO: PHP8 Review: Missing return type.
         array $a_hids,
         bool $a_update = true,
         bool $a_self_ass = false
@@ -3173,7 +3173,7 @@ s     */
      * @return array|bool
      * @throws ilDateTimeException
      */
-    public function deleteContentFromHierId(
+    public function deleteContentFromHierId(// @TODO: PHP8 Review: Missing return type.
         string $a_hid,
         bool $a_update = true
     ) {
@@ -3204,7 +3204,7 @@ s     */
      * @return array|bool
      * @throws ilDateTimeException
      */
-    public function deleteContentBeforeHierId(
+    public function deleteContentBeforeHierId(// @TODO: PHP8 Review: Missing return type.
         string $a_hid,
         bool $a_update = true
     ) {
@@ -3471,7 +3471,7 @@ s     */
      * @throws ilCOPageUnknownPCTypeException
      * @throws ilDateTimeException
      */
-    public function moveContentBefore(
+    public function moveContentBefore(// @TODO: PHP8 Review: Missing return type.
         string $a_source,
         string $a_target,
         string $a_spcid = "",
@@ -3507,7 +3507,7 @@ s     */
      * @throws ilCOPageUnknownPCTypeException
      * @throws ilDateTimeException
      */
-    public function moveContentAfter(
+    public function moveContentAfter(// @TODO: PHP8 Review: Missing return type.
         string $a_source,
         string $a_target,
         string $a_spcid = "",
@@ -5068,7 +5068,7 @@ s     */
      * @throws ilCOPageUnknownPCTypeException
      * @throws ilDateTimeException
      */
-    public function assignCharacteristic(
+    public function assignCharacteristic(// @TODO: PHP8 Review: Missing return type.
         array $targets,
         string $char_par,
         string $char_sec,

--- a/Services/COPage/classes/class.ilPageObjectGUI.php
+++ b/Services/COPage/classes/class.ilPageObjectGUI.php
@@ -303,7 +303,7 @@ class ilPageObjectGUI
         return $this->page_config;
     }
     
-    public function setPageObject(ilPageObject $a_pg_obj)
+    public function setPageObject(ilPageObject $a_pg_obj) // @TODO: PHP8 Review: Missing return type.
     {
         $this->obj = $a_pg_obj;
     }
@@ -1750,7 +1750,7 @@ class ilPageObjectGUI
             )) {
                 $t = "text_inline";
                 $tag = "span";
-                switch ($key) {
+                switch ($key) { // @TODO: PHP8 Review: switch with one case.
                     case "Code": $tag = "code"; break;
                 }
                 $html = '<' . $tag . ' class="ilc_' . $t . '_' . $key . '" style="font-size:90%; margin-top:2px; margin-bottom:2px; position:static;">' . $char["txt"] . "</" . $tag . ">";
@@ -2013,7 +2013,7 @@ class ilPageObjectGUI
         $this->displayMedia(true);
     }
 
-    public function displayMedia($a_fullscreen = false) : void
+    public function displayMedia($a_fullscreen = false) : void // @TODO: PHP8 Review: Missing parameter type.
     {
         $tpl = new ilGlobalTemplate("tpl.fullscreen.html", true, true, "Modules/LearningModule");
         $tpl->setCurrentBlock("ilMedia");
@@ -2446,7 +2446,7 @@ class ilPageObjectGUI
     *
     * @param	string		$a_error		error string
     */
-    public function displayValidationError($a_error)
+    public function displayValidationError($a_error) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         if (is_array($a_error)) {
             $error_str = "<b>Error(s):</b><br>";
@@ -3012,7 +3012,7 @@ class ilPageObjectGUI
     /**
      * Add resources to template
      */
-    protected function addResourcesToTemplate(ilGlobalTemplateInterface $tpl)
+    protected function addResourcesToTemplate(ilGlobalTemplateInterface $tpl) // @TODO: PHP8 Review: Missing return type.
     {
         $collector = new \ILIAS\COPage\ResourcesCollector($this->getOutputMode(), $this->getPageObject());
 

--- a/Services/COPage/mediawikidiff/class.WordLevelDiff.php
+++ b/Services/COPage/mediawikidiff/class.WordLevelDiff.php
@@ -19,21 +19,21 @@ class DifferenceEngine
     /**#@+
      * @private
      */
-    public $mOldid;
-    public $mNewid;
-    public $mTitle;
-    public $mOldtitle;
-    public $mNewtitle;
-    public $mPagetitle;
-    public $mOldtext;
-    public $mNewtext;
-    public $mOldPage;
-    public $mNewPage;
-    public $mRcidMarkPatrolled;
-    public $mOldRev;
-    public $mNewRev;
+    public $mOldid; // @TODO: PHP8 Review: Missing property type.
+    public $mNewid; // @TODO: PHP8 Review: Missing property type.
+    public $mTitle; // @TODO: PHP8 Review: Missing property type.
+    public $mOldtitle; // @TODO: PHP8 Review: Missing property type.
+    public $mNewtitle; // @TODO: PHP8 Review: Missing property type.
+    public $mPagetitle; // @TODO: PHP8 Review: Missing property type.
+    public $mOldtext; // @TODO: PHP8 Review: Missing property type.
+    public $mNewtext; // @TODO: PHP8 Review: Missing property type.
+    public $mOldPage; // @TODO: PHP8 Review: Missing property type.
+    public $mNewPage; // @TODO: PHP8 Review: Missing property type.
+    public $mRcidMarkPatrolled; // @TODO: PHP8 Review: Missing property type.
+    public $mOldRev; // @TODO: PHP8 Review: Missing property type.
+    public $mNewRev; // @TODO: PHP8 Review: Missing property type.
     public $mRevisionsLoaded = false; // Have the revisions been loaded
-    public $mTextLoaded = 0; // How many text blobs have been loaded, 0, 1 or 2?
+    public $mTextLoaded = 0; // How many text blobs have been loaded, 0, 1 or 2 ? // @TODO: PHP8 Review: Missing property type.
     /**#@-*/
 
     /**
@@ -43,7 +43,7 @@ class DifferenceEngine
      * @param $new String: either 'prev' or 'next'.
      * @param $rcid Integer: ??? FIXME (default 0)
      */
-    public function __construct($titleObj = null, $old = 0, $new = 0, $rcid = 0)
+    public function __construct($titleObj = null, $old = 0, $new = 0, $rcid = 0) // @TODO: PHP8 Review: Missing parameter type.
     {
         $this->mTitle = $titleObj;
         wfDebug("DifferenceEngine old '$old' new '$new' rcid '$rcid'\n");
@@ -73,7 +73,7 @@ class DifferenceEngine
         $this->mRcidMarkPatrolled = intval($rcid);  # force it to be an integer
     }
 
-    public function showDiffPage($diffOnly = false)
+    public function showDiffPage($diffOnly = false) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         global $wgUser, $wgOut, $wgUseExternalEditor, $wgUseRCPatrol;
         $fname = 'DifferenceEngine::showDiffPage';
@@ -227,7 +227,7 @@ CONTROL;
     /**
      * Show the new revision of the page.
      */
-    public function renderNewRevision()
+    public function renderNewRevision() // @TODO: PHP8 Review: Missing return type.
     {
         global $wgOut;
         $fname = 'DifferenceEngine::renderNewRevision';
@@ -261,7 +261,7 @@ CONTROL;
      * Show the first revision of an article. Uses normal diff headers in
      * contrast to normal "old revision" display style.
      */
-    public function showFirstRevision()
+    public function showFirstRevision() // @TODO: PHP8 Review: Missing return type.
     {
         global $wgOut, $wgUser;
 
@@ -314,7 +314,7 @@ CONTROL;
      * Get the diff text, send it to $wgOut
      * Returns false if the diff could not be generated, otherwise returns true
      */
-    public function showDiff($otitle, $ntitle)
+    public function showDiff($otitle, $ntitle) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         global $wgOut;
         $diff = $this->getDiff($otitle, $ntitle);
@@ -332,7 +332,7 @@ CONTROL;
      * Note that the interface has changed, it's no longer static.
      * Returns false on error
      */
-    public function getDiff($otitle, $ntitle)
+    public function getDiff($otitle, $ntitle) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         $body = $this->getDiffBody();
         if ($body === false) {
@@ -348,7 +348,7 @@ CONTROL;
      * Results are cached
      * Returns false on error
      */
-    public function getDiffBody()
+    public function getDiffBody() // @TODO: PHP8 Review: Missing return type.
     {
         global $wgMemc;
         $fname = 'DifferenceEngine::getDiffBody';
@@ -400,7 +400,7 @@ CONTROL;
      * Generate a diff, no caching
      * $otext and $ntext must be already segmented
      */
-    public function generateDiffBody($otext, $ntext)
+    public function generateDiffBody($otext, $ntext) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         global $wgExternalDiffEngine, $wgContLang;
         $fname = 'DifferenceEngine::generateDiffBody';
@@ -475,7 +475,7 @@ CONTROL;
     /**
      * Replace line numbers with the text in the user's language
      */
-    public function localiseLineNumbers($text)
+    public function localiseLineNumbers($text) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         return preg_replace_callback(
             '/<!--LINE (\d+)-->/',
@@ -484,7 +484,7 @@ CONTROL;
         );
     }
 
-    public function localiseLineNumbersCb($matches)
+    public function localiseLineNumbersCb($matches) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         global $wgLang;
         return wfMsgExt('lineno', array('parseinline'), $wgLang->formatNum($matches[1]));
@@ -494,7 +494,7 @@ CONTROL;
     /**
      * If there are revisions between the ones being compared, return a note saying so.
      */
-    public function getMultiNotice()
+    public function getMultiNotice() // @TODO: PHP8 Review: Missing return type.
     {
         if (!is_object($this->mOldRev) || !is_object($this->mNewRev)) {
             return '';
@@ -525,7 +525,7 @@ CONTROL;
     /**
      * Add the header to a diff body
      */
-    public function addHeader($diff, $otitle, $ntitle, $multi = '')
+    public function addHeader($diff, $otitle, $ntitle, $multi = '') // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         global $wgOut;
     
@@ -553,7 +553,7 @@ CONTROL;
     /**
      * Use specified text instead of loading from the database
      */
-    public function setText($oldText, $newText)
+    public function setText($oldText, $newText) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         $this->mOldtext = $oldText;
         $this->mNewtext = $newText;
@@ -570,7 +570,7 @@ CONTROL;
      * to false. This is impossible via ordinary user input, and is provided for
      * API convenience.
      */
-    public function loadRevisionData()
+    public function loadRevisionData() // @TODO: PHP8 Review: Missing return type.
     {
         global $wgLang;
         if ($this->mRevisionsLoaded) {
@@ -649,7 +649,7 @@ CONTROL;
     /**
      * Load the text of the revisions, as well as revision data.
      */
-    public function loadText()
+    public function loadText() // @TODO: PHP8 Review: Missing return type.
     {
         if ($this->mTextLoaded == 2) {
             return true;
@@ -680,7 +680,7 @@ CONTROL;
     /**
      * Load the text of the new revision, not the old one
      */
-    public function loadNewText()
+    public function loadNewText() // @TODO: PHP8 Review: Missing return type.
     {
         if ($this->mTextLoaded >= 1) {
             return true;
@@ -710,21 +710,21 @@ define('USE_ASSERTS', function_exists('assert'));
  */
 class _DiffOp
 {
-    public $type;
-    public $orig;
-    public $closing;
+    public $type; // @TODO: PHP8 Review: Missing property type.
+    public $orig; // @TODO: PHP8 Review: Missing property type.
+    public $closing; // @TODO: PHP8 Review: Missing property type.
 
-    public function reverse()
+    public function reverse() // @TODO: PHP8 Review: Missing return type.
     {
         trigger_error('pure virtual', E_USER_ERROR);
     }
 
-    public function norig()
+    public function norig() // @TODO: PHP8 Review: Missing return type.
     {
         return $this->orig ? sizeof($this->orig) : 0;
     }
 
-    public function nclosing()
+    public function nclosing() // @TODO: PHP8 Review: Missing return type.
     {
         return $this->closing ? sizeof($this->closing) : 0;
     }
@@ -737,9 +737,9 @@ class _DiffOp
  */
 class _DiffOp_Copy extends _DiffOp
 {
-    public $type = 'copy';
+    public $type = 'copy'; // @TODO: PHP8 Review: Missing property type.
 
-    public function __construct($orig, $closing = false)
+    public function __construct($orig, $closing = false) // @TODO: PHP8 Review: Missing parameter type.
     {
         if (!is_array($closing)) {
             $closing = $orig;
@@ -748,7 +748,7 @@ class _DiffOp_Copy extends _DiffOp
         $this->closing = $closing;
     }
 
-    public function reverse()
+    public function reverse() // @TODO: PHP8 Review: Missing return type.
     {
         return new _DiffOp_Copy($this->closing, $this->orig);
     }
@@ -761,15 +761,15 @@ class _DiffOp_Copy extends _DiffOp
  */
 class _DiffOp_Delete extends _DiffOp
 {
-    public $type = 'delete';
+    public $type = 'delete'; // @TODO: PHP8 Review: Missing property type.
 
-    public function __construct($lines)
+    public function __construct($lines) // @TODO: PHP8 Review: Missing parameter type.
     {
         $this->orig = $lines;
         $this->closing = false;
     }
 
-    public function reverse()
+    public function reverse() // @TODO: PHP8 Review: Missing return type.
     {
         return new _DiffOp_Add($this->orig);
     }
@@ -782,15 +782,15 @@ class _DiffOp_Delete extends _DiffOp
  */
 class _DiffOp_Add extends _DiffOp
 {
-    public $type = 'add';
+    public $type = 'add'; // @TODO: PHP8 Review: Missing property type.
 
-    public function __construct($lines)
+    public function __construct($lines) // @TODO: PHP8 Review: Missing parameter type.
     {
         $this->closing = $lines;
         $this->orig = false;
     }
 
-    public function reverse()
+    public function reverse() // @TODO: PHP8 Review: Missing return type.
     {
         return new _DiffOp_Delete($this->closing);
     }
@@ -803,15 +803,15 @@ class _DiffOp_Add extends _DiffOp
  */
 class _DiffOp_Change extends _DiffOp
 {
-    public $type = 'change';
+    public $type = 'change'; // @TODO: PHP8 Review: Missing property type.
 
-    public function __construct($orig, $closing)
+    public function __construct($orig, $closing) // @TODO: PHP8 Review: Missing parameter type.
     {
         $this->orig = $orig;
         $this->closing = $closing;
     }
 
-    public function reverse()
+    public function reverse() // @TODO: PHP8 Review: Missing return type.
     {
         return new _DiffOp_Change($this->closing, $this->orig);
     }
@@ -845,7 +845,7 @@ class _DiffEngine
 {
     const MAX_XREF_LENGTH = 10000;
 
-    public function diff($from_lines, $to_lines)
+    public function diff($from_lines, $to_lines) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         $fname = '_DiffEngine::diff';
         //wfProfileIn( $fname );
@@ -951,7 +951,7 @@ class _DiffEngine
     /**
      * Returns the whole line if it's small enough, or the MD5 hash otherwise
      */
-    public function _line_hash($line)
+    public function _line_hash($line) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         if (strlen($line) > self::MAX_XREF_LENGTH) {
             return md5($line);
@@ -977,7 +977,7 @@ class _DiffEngine
      * match.  The caller must trim matching lines from the beginning and end
      * of the portions it is going to specify.
      */
-    public function _diag($xoff, $xlim, $yoff, $ylim, $nchunks)
+    public function _diag($xoff, $xlim, $yoff, $ylim, $nchunks) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         $fname = '_DiffEngine::_diag';
         //wfProfileIn( $fname );
@@ -1063,7 +1063,7 @@ class _DiffEngine
         return array($this->lcs, $seps);
     }
 
-    public function _lcs_pos($ypos)
+    public function _lcs_pos($ypos) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         $fname = '_DiffEngine::_lcs_pos';
         //wfProfileIn( $fname );
@@ -1106,7 +1106,7 @@ class _DiffEngine
      * Note that XLIM, YLIM are exclusive bounds.
      * All line numbers are origin-0 and discarded lines are not counted.
      */
-    public function _compareseq($xoff, $xlim, $yoff, $ylim)
+    public function _compareseq($xoff, $xlim, $yoff, $ylim) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         $fname = '_DiffEngine::_compareseq';
         //wfProfileIn( $fname );
@@ -1169,7 +1169,7 @@ class _DiffEngine
      *
      * This is extracted verbatim from analyze.c (GNU diffutils-2.7).
      */
-    public function _shift_boundaries($lines, &$changed, $other_changed)
+    public function _shift_boundaries($lines, &$changed, $other_changed) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         $fname = '_DiffEngine::_shift_boundaries';
         //wfProfileIn( $fname );
@@ -1296,7 +1296,7 @@ class _DiffEngine
  */
 class Diff
 {
-    public $edits;
+    public $edits; // @TODO: PHP8 Review: Missing property type.
 
     /**
      * Constructor.
@@ -1306,7 +1306,7 @@ class Diff
      *		  (Typically these are lines from a file.)
      * @param $to_lines array An array of strings.
      */
-    public function __construct($from_lines, $to_lines)
+    public function __construct($from_lines, $to_lines) // @TODO: PHP8 Review: Missing parameter type.
     {
         $eng = new _DiffEngine;
         $this->edits = $eng->diff($from_lines, $to_lines);
@@ -1323,7 +1323,7 @@ class Diff
      * @return object A Diff object representing the inverse of the
      *				  original diff.
      */
-    public function reverse()
+    public function reverse() // @TODO: PHP8 Review: Missing return type.
     {
         $rev = $this;
         $rev->edits = array();
@@ -1338,7 +1338,7 @@ class Diff
      *
      * @return bool True iff two sequences were identical.
      */
-    public function isEmpty()
+    public function isEmpty() // @TODO: PHP8 Review: Missing return type.
     {
         foreach ($this->edits as $edit) {
             if ($edit->type != 'copy') {
@@ -1355,7 +1355,7 @@ class Diff
      *
      * @return int The length of the LCS.
      */
-    public function lcs()
+    public function lcs() // @TODO: PHP8 Review: Missing return type.
     {
         $lcs = 0;
         foreach ($this->edits as $edit) {
@@ -1374,7 +1374,7 @@ class Diff
      *
      * @return array The original sequence of strings.
      */
-    public function orig()
+    public function orig() // @TODO: PHP8 Review: Missing return type.
     {
         $lines = array();
 
@@ -1394,7 +1394,7 @@ class Diff
      *
      * @return array The sequence of strings.
      */
-    public function closing()
+    public function closing() // @TODO: PHP8 Review: Missing return type.
     {
         $lines = array();
 
@@ -1411,7 +1411,7 @@ class Diff
      *
      * This is here only for debugging purposes.
      */
-    public function _check($from_lines, $to_lines)
+    public function _check($from_lines, $to_lines) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         $fname = 'Diff::_check';
         //wfProfileIn( $fname );
@@ -1525,7 +1525,7 @@ class DiffFormatter
      * This should be left at zero for this class, but subclasses
      * may want to set this to other values.
      */
-    public $leading_context_lines = 0;
+    public $leading_context_lines = 0; // @TODO: PHP8 Review: Missing property type.
 
     /**
      * Number of trailing context "lines" to preserve.
@@ -1533,7 +1533,7 @@ class DiffFormatter
      * This should be left at zero for this class, but subclasses
      * may want to set this to other values.
      */
-    public $trailing_context_lines = 0;
+    public $trailing_context_lines = 0; // @TODO: PHP8 Review: Missing property type.
 
     /**
      * Format a diff.
@@ -1541,7 +1541,7 @@ class DiffFormatter
      * @param $diff object A Diff object.
      * @return string The formatted output.
      */
-    public function format($diff)
+    public function format($diff) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         $fname = 'DiffFormatter::format';
         //wfProfileIn( $fname );
@@ -1612,7 +1612,7 @@ class DiffFormatter
         return $end;
     }
 
-    public function _block($xbeg, $xlen, $ybeg, $ylen, $edits)
+    public function _block($xbeg, $xlen, $ybeg, $ylen, $edits) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         $fname = 'DiffFormatter::_block';
         //wfProfileIn( $fname );
@@ -1634,19 +1634,19 @@ class DiffFormatter
         //wfProfileOut( $fname );
     }
 
-    public function _start_diff()
+    public function _start_diff() // @TODO: PHP8 Review: Missing return type.
     {
         ob_start();
     }
 
-    public function _end_diff()
+    public function _end_diff() // @TODO: PHP8 Review: Missing return type.
     {
         $val = ob_get_contents();
         ob_end_clean();
         return $val;
     }
 
-    public function _block_header($xbeg, $xlen, $ybeg, $ylen)
+    public function _block_header($xbeg, $xlen, $ybeg, $ylen) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         if ($xlen > 1) {
             $xbeg .= "," . ($xbeg + $xlen - 1);
@@ -1658,37 +1658,37 @@ class DiffFormatter
         return $xbeg . ($xlen ? ($ylen ? 'c' : 'd') : 'a') . $ybeg;
     }
 
-    public function _start_block($header)
+    public function _start_block($header) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         echo $header;
     }
 
-    public function _end_block()
+    public function _end_block() // @TODO: PHP8 Review: Missing return type.
     {
     }
 
-    public function _lines($lines, $prefix = ' ')
+    public function _lines($lines, $prefix = ' ') // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         foreach ($lines as $line) {
             echo "$prefix $line\n";
         }
     }
 
-    public function _context($lines)
+    public function _context($lines) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         $this->_lines($lines);
     }
 
-    public function _added($lines)
+    public function _added($lines) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         $this->_lines($lines, '>');
     }
-    public function _deleted($lines)
+    public function _deleted($lines) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         $this->_lines($lines, '<');
     }
 
-    public function _changed($orig, $closing)
+    public function _changed($orig, $closing) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         $this->_deleted($orig);
         echo "---\n";
@@ -1719,7 +1719,7 @@ class _HWLDF_WordAccumulator
         $this->_tag = '';
     }
 
-    public function _flushGroup($new_tag)
+    public function _flushGroup($new_tag) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         if ($this->_group !== '') {
             if ($this->_tag == 'ins') {
@@ -1736,7 +1736,7 @@ class _HWLDF_WordAccumulator
         $this->_tag = $new_tag;
     }
 
-    public function _flushLine($new_tag)
+    public function _flushLine($new_tag) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         $this->_flushGroup($new_tag);
         if ($this->_line != '') {
@@ -1748,7 +1748,7 @@ class _HWLDF_WordAccumulator
         $this->_line = '';
     }
 
-    public function addWords($words, $tag = '')
+    public function addWords($words, $tag = '') // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         if ($tag != $this->_tag) {
             $this->_flushGroup($tag);
@@ -1768,7 +1768,7 @@ class _HWLDF_WordAccumulator
         }
     }
 
-    public function getLines()
+    public function getLines() // @TODO: PHP8 Review: Missing return type.
     {
         $this->_flushLine('~done');
         return $this->_lines;
@@ -1784,7 +1784,7 @@ class WordLevelDiff extends MappedDiff
 {
     const MAX_LINE_LENGTH = 10000;
 
-    public function __construct($orig_lines, $closing_lines)
+    public function __construct($orig_lines, $closing_lines) // @TODO: PHP8 Review: Missing parameter type.
     {
         $fname = 'WordLevelDiff::WordLevelDiff';
         //wfProfileIn( $fname );
@@ -1801,7 +1801,7 @@ class WordLevelDiff extends MappedDiff
         //wfProfileOut( $fname );
     }
 
-    public function _split($lines)
+    public function _split($lines) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         $fname = 'WordLevelDiff::_split';
         //wfProfileIn( $fname );
@@ -1837,7 +1837,7 @@ class WordLevelDiff extends MappedDiff
         return array($words, $stripped);
     }
 
-    public function orig()
+    public function orig() // @TODO: PHP8 Review: Missing return type.
     {
         $fname = 'WordLevelDiff::orig';
         //wfProfileIn( $fname );
@@ -1855,7 +1855,7 @@ class WordLevelDiff extends MappedDiff
         return $lines;
     }
 
-    public function closing()
+    public function closing() // @TODO: PHP8 Review: Missing return type.
     {
         $fname = 'WordLevelDiff::closing';
         //wfProfileIn( $fname );
@@ -1888,50 +1888,50 @@ class TableDiffFormatter extends DiffFormatter
         $this->trailing_context_lines = 2;
     }
 
-    public function _block_header($xbeg, $xlen, $ybeg, $ylen)
+    public function _block_header($xbeg, $xlen, $ybeg, $ylen) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         $r = '<tr><td colspan="2" align="left"><strong><!--LINE ' . $xbeg . "--></strong></td>\n" .
           '<td colspan="2" align="left"><strong><!--LINE ' . $ybeg . "--></strong></td></tr>\n";
         return $r;
     }
 
-    public function _start_block($header)
+    public function _start_block($header) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         echo $header;
     }
 
-    public function _end_block()
+    public function _end_block() // @TODO: PHP8 Review: Missing return type.
     {
     }
 
-    public function _lines($lines, $prefix = ' ', $color = 'white')
+    public function _lines($lines, $prefix = ' ', $color = 'white') // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
     }
 
     # HTML-escape parameter before calling this
-    public function addedLine($line)
+    public function addedLine($line) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         return "<td>+</td><td class='diff-addedline'>{$line}</td>";
     }
 
     # HTML-escape parameter before calling this
-    public function deletedLine($line)
+    public function deletedLine($line) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         return "<td>-</td><td class='diff-deletedline'>{$line}</td>";
     }
 
     # HTML-escape parameter before calling this
-    public function contextLine($line)
+    public function contextLine($line) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         return "<td> </td><td class='diff-context'>{$line}</td>";
     }
 
-    public function emptyLine()
+    public function emptyLine() // @TODO: PHP8 Review: Missing return type.
     {
         return '<td colspan="2">&nbsp;</td>';
     }
 
-    public function _added($lines)
+    public function _added($lines) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         foreach ($lines as $line) {
             echo '<tr>' . $this->emptyLine() .
@@ -1939,7 +1939,7 @@ class TableDiffFormatter extends DiffFormatter
         }
     }
 
-    public function _deleted($lines)
+    public function _deleted($lines) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         foreach ($lines as $line) {
             echo '<tr>' . $this->deletedLine(htmlspecialchars($line)) .
@@ -1947,7 +1947,7 @@ class TableDiffFormatter extends DiffFormatter
         }
     }
 
-    public function _context($lines)
+    public function _context($lines) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         foreach ($lines as $line) {
             echo '<tr>' .
@@ -1956,7 +1956,7 @@ class TableDiffFormatter extends DiffFormatter
         }
     }
 
-    public function _changed($orig, $closing)
+    public function _changed($orig, $closing) // @TODO: PHP8 Review: Missing parameter type. // @TODO: PHP8 Review: Missing return type.
     {
         $fname = 'TableDiffFormatter::_changed';
         //wfProfileIn( $fname );

--- a/Services/COPage/test/EditorEditSessionRepositoryTest.php
+++ b/Services/COPage/test/EditorEditSessionRepositoryTest.php
@@ -26,7 +26,7 @@ class EditorEditSessionRepositoryTest extends TestCase
     /**
      * Test clear
      */
-    public function testClear()
+    public function testClear() // @TODO: PHP8 Review: Missing return type.
     {
         $repo = $this->repo;
         $repo->setPageError("page_error");
@@ -48,7 +48,7 @@ class EditorEditSessionRepositoryTest extends TestCase
     /**
      * Test page error
      */
-    public function testPageError()
+    public function testPageError() // @TODO: PHP8 Review: Missing return type.
     {
         $repo = $this->repo;
         $repo->setPageError("page_error");
@@ -61,7 +61,7 @@ class EditorEditSessionRepositoryTest extends TestCase
     /**
      * Test sub-command
      */
-    public function testSubCmd()
+    public function testSubCmd() // @TODO: PHP8 Review: Missing return type.
     {
         $repo = $this->repo;
         $repo->setSubCmd("sub");
@@ -74,7 +74,7 @@ class EditorEditSessionRepositoryTest extends TestCase
     /**
      * Test question pool
      */
-    public function testQuestionPool()
+    public function testQuestionPool() // @TODO: PHP8 Review: Missing return type.
     {
         $repo = $this->repo;
         $repo->setQuestionPool(15);
@@ -87,7 +87,7 @@ class EditorEditSessionRepositoryTest extends TestCase
     /**
      * Test media pool
      */
-    public function testMediaPool()
+    public function testMediaPool() // @TODO: PHP8 Review: Missing return type.
     {
         $repo = $this->repo;
         $repo->setMediaPool(12);
@@ -100,7 +100,7 @@ class EditorEditSessionRepositoryTest extends TestCase
     /**
      * Test text lang
      */
-    public function testTextLang()
+    public function testTextLang() // @TODO: PHP8 Review: Missing return type.
     {
         $repo = $this->repo;
         $repo->setTextLang(17, "fr");

--- a/Services/COPage/test/PCMapEditorSessionRepositoryTest.php
+++ b/Services/COPage/test/PCMapEditorSessionRepositoryTest.php
@@ -25,7 +25,7 @@ class PCMapEditorSessionRepositoryTest extends TestCase
     /**
      * Test mode
      */
-    public function testMode()
+    public function testMode() // @TODO: PHP8 Review: Missing return type.
     {
         $repo = $this->repo;
         $repo->setMode("testmode");
@@ -38,7 +38,7 @@ class PCMapEditorSessionRepositoryTest extends TestCase
     /**
      * Test area nr
      */
-    public function testAreaNr()
+    public function testAreaNr() // @TODO: PHP8 Review: Missing return type.
     {
         $repo = $this->repo;
         $repo->setAreaNr("3");

--- a/Services/COPage/test/PCParagraphTest.php
+++ b/Services/COPage/test/PCParagraphTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class PCParagraphTest extends TestCase
 {
-    protected function setGlobalVariable(string $name, $value) : void
+    protected function setGlobalVariable(string $name, $value) : void // @TODO: PHP8 Review: Missing parameter type.
     {
         global $DIC;
 
@@ -49,7 +49,7 @@ class PCParagraphTest extends TestCase
     /**
      * Test _input2xml (empty)
      */
-    public function test_input2xmlEmpty()
+    public function test_input2xmlEmpty() // @TODO: PHP8 Review: Missing return type.
     {
         $res = ilPCParagraph::_input2xml("", "en", true, false);
         $this->assertEquals(
@@ -61,7 +61,7 @@ class PCParagraphTest extends TestCase
     /**
      * Test _input2xml for validity
      */
-    public function test_input2xmlValidXml()
+    public function test_input2xmlValidXml() // @TODO: PHP8 Review: Missing return type.
     {
         $cases = [
             '',
@@ -90,7 +90,7 @@ class PCParagraphTest extends TestCase
     /**
      * Test _input2xml
      */
-    public function test_input2xmlResult()
+    public function test_input2xmlResult() // @TODO: PHP8 Review: Missing return type.
     {
         $cases = [
             ''
@@ -203,7 +203,7 @@ class PCParagraphTest extends TestCase
     /**
      * Test handleAjaxContentPost
      */
-    public function testHandleAjaxContentPost()
+    public function testHandleAjaxContentPost() // @TODO: PHP8 Review: Missing return type.
     {
         $cases = [
             '&lt;ul class="ilc_list_u_BulletedList"&gt;&lt;li class="ilc_list_item_StandardListItem"&gt;aa&lt;/li&gt;&lt;li class="ilc_list_item_StandardListItem"&gt;bb&lt;/li&gt;&lt;li class="ilc_list_item_StandardListItem"&gt;cc&lt;/li&gt;&lt;/ul&gt;'

--- a/Services/COPage/test/ilServicesCOPageSuite.php
+++ b/Services/COPage/test/ilServicesCOPageSuite.php
@@ -22,7 +22,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilServicesCOPageSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() // @TODO: PHP8 Review: Missing return type.
     {
         $suite = new self();
 


### PR DESCRIPTION
Hi @alex40724,

here are the results of the `Services/COPage` review.

### Results
- [ ] The code style is `PSR-2 + X` compliant
- [ ] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [ ] The types are fully documented (PHPDoc) or explict PHP types are used (type hints, return types, typed properties)

### Changes made in this PR:
- Added `// @TODO: PHP8 Review: Missing return type.`
- Added `// @TODO: PHP8 Review: Missing parameter type.`
- Added `// @TODO: PHP8 Review: Missing property type.`
- Added `// @TODO: PHP8 Review: Direct access to $_POST`
- Added `// @TODO: PHP8 Review: Direct access to $_GET`
- Added `// @TODO: PHP8 Review: switch with one case.`
- Fix `PSR 2 + X`

Best regards,
@lscharmer  