### PR TITLE
Test&Assessment: fix for 27679

### DIFF
--- a/Modules/Test/classes/class.ilTestAccess.php
+++ b/Modules/Test/classes/class.ilTestAccess.php
@@ -154,8 +154,7 @@ class ilTestAccess
         if ($this->getAccess()->checkAccess('tst_statistics', '', $this->getRefId())) {
             return true;
         }
-        
-        return $this->checkParticipantsResultsAccess();
+        return false;
     }
     
     /**


### PR DESCRIPTION
Fix for https://mantis.ilias.de/view.php?id=27679
test-statistics no longer show up when only results-permission is given