### PR TITLE
PHP 8: Review `Taxonomy`

### DIFF
--- a/Services/Taxonomy/GlobalScreen/classes/class.ilTaxonomyGSToolProvider.php
+++ b/Services/Taxonomy/GlobalScreen/classes/class.ilTaxonomyGSToolProvider.php
@@ -6,7 +6,6 @@ use ILIAS\GlobalScreen\ScreenContext\Stack\ContextCollection;
 
 /**
  * Taxonomy GS tool provider
- *
  * @author Alex Killing <killing@leifos.com>
  */
 class ilTaxonomyGSToolProvider extends AbstractDynamicToolProvider
@@ -25,7 +24,6 @@ class ilTaxonomyGSToolProvider extends AbstractDynamicToolProvider
         return $this->context_collection->main()->main();
     }
 
-
     /**
      * @inheritDoc
      */
@@ -42,22 +40,26 @@ class ilTaxonomyGSToolProvider extends AbstractDynamicToolProvider
         $tools = [];
         $additional_data = $called_contexts->current()->getAdditionalData();
         if ($additional_data->is(self::SHOW_TAX_TREE, true)) {
-            $iff = fn ($id) : \ILIAS\GlobalScreen\Identification\IdentificationInterface => $this->identification_provider->contextAwareIdentifier($id);
-            $l = fn (string $content) : \ILIAS\UI\Component\Legacy\Legacy => $this->dic->ui()->factory()->legacy($content);
+            $iff = fn (
+                $id
+            ) : \ILIAS\GlobalScreen\Identification\IdentificationInterface => $this->identification_provider->contextAwareIdentifier($id);
+            $l = fn (
+                string $content
+            ) : \ILIAS\UI\Component\Legacy\Legacy => $this->dic->ui()->factory()->legacy($content);
             $tools[] = $this->factory->tool($iff("tree"))
-                ->withTitle($title)
-                ->withSymbol($icon)
-                ->withContentWrapper(fn () : \ILIAS\UI\Component\Legacy\Legacy => $l($this->getEditTree(
-                    $additional_data->get(self::TAX_TREE_GUI_PATH),
-                    $additional_data->get(self::TAX_ID),
-                    $additional_data->get(self::TAX_TREE_CMD),
-                    $additional_data->get(self::TAX_TREE_PARENT_CMD)
-                )));
+                                     ->withTitle($title)
+                                     ->withSymbol($icon)
+                                     ->withContentWrapper(fn (
+                                     ) : \ILIAS\UI\Component\Legacy\Legacy => $l($this->getEditTree(
+                                         $additional_data->get(self::TAX_TREE_GUI_PATH),
+                                         $additional_data->get(self::TAX_ID),
+                                         $additional_data->get(self::TAX_TREE_CMD),
+                                         $additional_data->get(self::TAX_TREE_PARENT_CMD)
+                                     )));
         }
 
         return $tools;
     }
-
 
     private function getEditTree(array $gui_path, int $tax_id, string $cmd, string $parent_cmd) : string
     {

--- a/Services/Taxonomy/classes/class.ilObjTaxonomy.php
+++ b/Services/Taxonomy/classes/class.ilObjTaxonomy.php
@@ -4,7 +4,6 @@
 
 /**
  * Taxonomy
- *
  * @author Alexander Killing <killing@leifos.de>
  */
 class ilObjTaxonomy extends ilObject2
@@ -15,7 +14,7 @@ class ilObjTaxonomy extends ilObject2
     protected array $node_mapping = array();
     protected bool $item_sorting = false;
     protected int $sorting_mode = self::SORT_ALPHABETICAL;
-    
+
     /**
      * ilObjTaxonomy constructor.
      * @param int $a_id
@@ -33,27 +32,27 @@ class ilObjTaxonomy extends ilObject2
     {
         $this->type = "tax";
     }
-    
+
     public function setSortingMode(int $a_val) : void
     {
         $this->sorting_mode = $a_val;
     }
-    
+
     public function getSortingMode() : int
     {
         return $this->sorting_mode;
     }
-    
+
     public function setItemSorting(bool $a_val) : void
     {
         $this->item_sorting = $a_val;
     }
-    
+
     public function getItemSorting() : bool
     {
         return $this->item_sorting;
     }
-    
+
     public function getTree() : ?ilTaxonomyTree
     {
         if ($this->getId() > 0) {
@@ -68,13 +67,10 @@ class ilObjTaxonomy extends ilObject2
         return $this->node_mapping;
     }
 
-    /**
-     * @inheritDoc
-     */
     protected function doCreate() : void
     {
         $ilDB = $this->db;
-        
+
         // create tax data record
         $ilDB->manipulate("INSERT INTO tax_data " .
             "(id, sorting_mode, item_sorting) VALUES (" .
@@ -83,17 +79,14 @@ class ilObjTaxonomy extends ilObject2
             $ilDB->quote((int) $this->getItemSorting(), "integer") .
             ")");
         $node = new ilTaxonomyNode();
-        $node->setType("");	// empty type
+        $node->setType("");    // empty type
         $node->setTitle("Root node for taxonomy " . $this->getId());
         $node->setTaxonomyId($this->getId());
         $node->create();
         $tax_tree = new ilTaxonomyTree($this->getId());
         $tax_tree->addTree($this->getId(), $node->getId());
     }
-    
-    /**
-     * @inheritDoc
-     */
+
     protected function doCloneObject($a_new_obj, $a_target_id, $a_copy_id = null) : void
     {
         $a_new_obj->setTitle($this->getTitle());
@@ -101,7 +94,7 @@ class ilObjTaxonomy extends ilObject2
         $a_new_obj->setSortingMode($this->getSortingMode());
 
         $this->node_mapping = array();
-        
+
         $this->cloneNodes(
             $a_new_obj,
             $a_new_obj->getTree()->readRootId(),
@@ -135,10 +128,7 @@ class ilObjTaxonomy extends ilObject2
             }
         }
     }
-    
-    /**
-     * @inheritDoc
-     */
+
     protected function doDelete() : void
     {
         $ilDB = $this->db;
@@ -150,7 +140,7 @@ class ilObjTaxonomy extends ilObject2
         $tree = $this->getTree();
         $subtree = $tree->getSubTreeIds($tree->readRootId());
         $subtree[] = $tree->readRootId();
-        
+
         // get root node data (important: must happen before we
         // delete the nodes
         $root_node_data = $tree->getNodeData($tree->readRootId());
@@ -159,7 +149,7 @@ class ilObjTaxonomy extends ilObject2
             $node = new ilTaxonomyNode($node_id);
             $node->delete();
         }
-        
+
         // delete the tree
         $tree->deleteTree($root_node_data);
 
@@ -170,47 +160,40 @@ class ilObjTaxonomy extends ilObject2
         );
     }
 
-
-    /**
-     * @inheritDoc
-     */
     protected function doRead() : void
     {
         $ilDB = $this->db;
-        
+
         $set = $ilDB->query(
             "SELECT * FROM tax_data " .
             " WHERE id = " . $ilDB->quote($this->getId(), "integer")
         );
         $rec = $ilDB->fetchAssoc($set);
-        $this->setSortingMode($rec["sorting_mode"]);
-        $this->setItemSorting($rec["item_sorting"]);
+        $this->setSortingMode((int) $rec["sorting_mode"]);
+        $this->setItemSorting((bool) $rec["item_sorting"]);
     }
 
-    /**
-     * @inheritDoc
-     */
     protected function doUpdate() : void
     {
         $ilDB = $this->db;
-        
+
         $ilDB->manipulate(
             $t = "UPDATE tax_data SET " .
-            " sorting_mode = " . $ilDB->quote($this->getSortingMode(), "integer") . ", " .
-            " item_sorting = " . $ilDB->quote((int) $this->getItemSorting(), "integer") .
-            " WHERE id = " . $ilDB->quote($this->getId(), "integer")
+                " sorting_mode = " . $ilDB->quote($this->getSortingMode(), "integer") . ", " .
+                " item_sorting = " . $ilDB->quote((int) $this->getItemSorting(), "integer") .
+                " WHERE id = " . $ilDB->quote($this->getId(), "integer")
         );
     }
-    
+
     public static function loadLanguageModule() : void
     {
         global $DIC;
 
         $lng = $DIC->language();
-        
+
         $lng->loadLanguageModule("tax");
     }
-    
+
     public static function saveUsage(int $a_tax_id, int $a_obj_id) : void
     {
         global $DIC;
@@ -221,15 +204,15 @@ class ilObjTaxonomy extends ilObject2
             $ilDB->replace(
                 "tax_usage",
                 array("tax_id" => array("integer", $a_tax_id),
-                    "obj_id" => array("integer", $a_obj_id)
-                    ),
+                      "obj_id" => array("integer", $a_obj_id)
+                ),
                 array()
             );
         }
     }
-    
+
     /**
-     * @param int  $a_obj_id object id
+     * @param int  $a_obj_id         object id
      * @param bool $a_include_titles include titles in array
      * @return array array of tax IDs or array of arrays with keys tax_id, title
      */
@@ -238,7 +221,7 @@ class ilObjTaxonomy extends ilObject2
         global $DIC;
 
         $ilDB = $DIC->database();
-        
+
         $set = $ilDB->query(
             "SELECT tax_id FROM tax_usage " .
             " WHERE obj_id = " . $ilDB->quote($a_obj_id, "integer")
@@ -246,30 +229,29 @@ class ilObjTaxonomy extends ilObject2
         $tax = array();
         while ($rec = $ilDB->fetchAssoc($set)) {
             if (!$a_include_titles) {
-                $tax[] = $rec["tax_id"];
+                $tax[] = (int) $rec["tax_id"];
             } else {
-                $tax[] = array("tax_id" => $rec["tax_id"],
-                    "title" => ilObject::_lookupTitle($rec["tax_id"])
-                    );
+                $tax[] = array("tax_id" => (int) $rec["tax_id"],
+                               "title" => ilObject::_lookupTitle((int) $rec["tax_id"])
+                );
             }
         }
         return $tax;
     }
-    
+
     // Delete all usages of a taxonomy
     public static function deleteUsagesOfTaxonomy(int $a_id) : void
     {
         global $DIC;
 
         $ilDB = $DIC->database();
-        
+
         $ilDB->manipulate(
             "DELETE FROM tax_usage WHERE " .
             " tax_id = " . $ilDB->quote($a_id, "integer")
         );
     }
-    
-    
+
     /**
      * Get all assigned items under a node
      * @param string $a_comp
@@ -291,12 +273,12 @@ class ilObjTaxonomy extends ilObject2
 
         $sub_nodes = $tree->getSubTreeIds($a_node);
         $sub_nodes[] = $a_node;
-        
+
         $tn_ass = new ilTaxNodeAssignment($a_comp, $a_obj_id, $a_item_type, $a_tax_id);
-        
+
         return $tn_ass->getAssignmentsOfNode($sub_nodes);
     }
-    
+
     // lookup property in tax_data record
     protected static function lookup(string $a_field, int $a_id) : string
     {
@@ -312,7 +294,7 @@ class ilObjTaxonomy extends ilObject2
 
         return $rec[$a_field];
     }
-    
+
     public static function lookupSortingMode(int $a_id) : int
     {
         return (int) self::lookup("sorting_mode", $a_id);

--- a/Services/Taxonomy/classes/class.ilObjTaxonomyAdministration.php
+++ b/Services/Taxonomy/classes/class.ilObjTaxonomyAdministration.php
@@ -4,7 +4,6 @@
 
 /**
  * Class ilObjTaxonomyAdministration
- *
  * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>
  */
 class ilObjTaxonomyAdministration extends ilObject
@@ -24,52 +23,55 @@ class ilObjTaxonomyAdministration extends ilObject
         // DISABLED
         return false;
     }
-    
+
     protected function getPath(int $a_ref_id) : array
     {
         $tree = $this->tree;
-        
+
         $res = array();
-        
+
         foreach ($tree->getPathFull($a_ref_id) as $data) {
             $res[] = $data['title'];
         }
-                
+
         return $res;
     }
-    
+
     public function getRepositoryTaxonomies() : array
     {
         $ilDB = $this->db;
         $tree = $this->tree;
-                    
+
         $res = array();
-                
+
         $sql = "SELECT oref.ref_id, od.obj_id, od.type obj_type, od.title obj_title," .
             " tu.tax_id, od2.title tax_title, cs.value tax_status" .
             " FROM object_data od" .
             " JOIN object_reference oref ON (od.obj_id = oref.obj_id)" .
             " JOIN tax_usage tu ON (tu.obj_id = od.obj_id)" .
             " JOIN object_data od2 ON (od2.obj_id = tu.tax_id)" .
-            " LEFT JOIN container_settings cs ON (cs.id = od.obj_id AND keyword = " . $ilDB->quote(ilObjectServiceSettingsGUI::TAXONOMIES, "text") . ")" .
+            " LEFT JOIN container_settings cs ON (cs.id = od.obj_id AND keyword = " . $ilDB->quote(
+                ilObjectServiceSettingsGUI::TAXONOMIES,
+                "text"
+            ) . ")" .
             " WHERE od.type = " . $ilDB->quote("cat", "text") . // categories only currently
             " AND tu.tax_id > " . $ilDB->quote(0, "integer");
         $set = $ilDB->query($sql);
         while ($row = $ilDB->fetchAssoc($set)) {
-            if (!$tree->isDeleted($row["ref_id"])) {
+            if (!$tree->isDeleted((int) $row["ref_id"])) {
                 $res[$row["tax_id"]][$row["obj_id"]] = array(
-                    "tax_id" => $row["tax_id"]
-                    ,"tax_title" => $row["tax_title"]
-                    ,"tax_status" => (bool) $row["tax_status"]
-                    ,"obj_title" => $row["obj_title"]
-                    ,"obj_type" => $row["obj_type"]
-                    ,"obj_id" => $row["obj_id"]
-                    ,"ref_id" => $row["ref_id"]
-                    ,"path" => $this->getPath($row["ref_id"])
+                    "tax_id" => $row["tax_id"],  // TODO PHP8-REVIEW: Please check. Cast to int could be relevant
+                    "tax_title" => $row["tax_title"],
+                    "tax_status" => (bool) $row["tax_status"],
+                    "obj_title" => $row["obj_title"],
+                    "obj_type" => $row["obj_type"],
+                    "obj_id" => $row["obj_id"], // TODO PHP8-REVIEW: Please check. Cast to int could be relevant
+                    "ref_id" => $row["ref_id"],// TODO PHP8-REVIEW: Please check. Cast to int could be relevant
+                    "path" => $this->getPath((int) $row["ref_id"])
                 );
             }
         }
-                    
+
         return $res;
     }
 }

--- a/Services/Taxonomy/classes/class.ilObjTaxonomyAdministrationAccess.php
+++ b/Services/Taxonomy/classes/class.ilObjTaxonomyAdministrationAccess.php
@@ -4,7 +4,6 @@
 
 /**
  * Class ilObjTaxonomyAdministrationAccess
- *
  * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>
  */
 class ilObjTaxonomyAdministrationAccess extends ilObjectAccess

--- a/Services/Taxonomy/classes/class.ilObjTaxonomyAdministrationGUI.php
+++ b/Services/Taxonomy/classes/class.ilObjTaxonomyAdministrationGUI.php
@@ -4,16 +4,12 @@
 
 /**
  * Taxonomy Administration Settings
- *
- * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>
+ * @author       Jörg Lützenkirchen <luetzenkirchen@leifos.com>
  * @ilCtrl_Calls ilObjTaxonomyAdministrationGUI: ilPermissionGUI
  */
 class ilObjTaxonomyAdministrationGUI extends ilObjectGUI
 {
-    /**
-     * @var ilRbacSystem
-     */
-    protected $rbacsystem;
+    protected ilRbacSystem $rbacsystem;
 
     /**
      * @inheritDoc
@@ -74,7 +70,7 @@ class ilObjTaxonomyAdministrationGUI extends ilObjectGUI
             );
         }
     }
-    
+
     /**
      * List taxonomies of repository objects
      */

--- a/Services/Taxonomy/classes/class.ilObjTaxonomyGUI.php
+++ b/Services/Taxonomy/classes/class.ilObjTaxonomyGUI.php
@@ -4,14 +4,13 @@
 
 /**
  * Taxonomy GUI class
- *
- * @author Alexander Killing <killing@leifos.de>
+ * @author       Alexander Killing <killing@leifos.de>
  * @ilCtrl_Calls ilObjTaxonomyGUI: ilObjTaxonomyGUI
  */
 class ilObjTaxonomyGUI extends ilObject2GUI
 {
-    protected \ilTabsGUI $tabs;
-    protected \ilHelpGUI $help;
+    protected ilTabsGUI $tabs;
+    protected ilHelpGUI $help;
     protected bool $multiple = false;
     protected bool $assigned_item_sorting = false;
     protected int $assigned_object_id;
@@ -37,23 +36,23 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $this->tabs = $DIC->tabs();
         $this->toolbar = $DIC->toolbar();
         $this->tpl = $DIC["tpl"];
-        $this->help = $DIC[\ilHelp::class];
+        $this->help = $DIC[ilHelp::class];
         $ilCtrl = $DIC->ctrl();
         $lng = $DIC->language();
-        
+
         parent::__construct($a_id, ilObject2GUI::OBJECT_ID);
-        
+
         $ilCtrl->saveParameter($this, "tax_node");
         $ilCtrl->saveParameter($this, "tax_id");
-        
+
         $lng->loadLanguageModule("tax");
 
-        $params = $DIC->http()->request()->getQueryParams();
+        $params = $DIC->http()->request()->getQueryParams(); // // TODO PHP8-REVIEW: Please use http()->wrapper()
         $this->current_tax_node = (int) ($params["tax_node"] ?? null);
         $this->requested_tax_id = (int) ($params["tax_id"] ?? null);
         $this->requested_move_ids = (string) ($params["move_ids"] ?? "");
     }
-    
+
     public function getType() : string
     {
         return "tax";
@@ -66,37 +65,36 @@ class ilObjTaxonomyGUI extends ilObject2GUI
     {
         $this->assigned_object_id = $a_val;
     }
-    
+
     public function getAssignedObject() : int
     {
         return $this->assigned_object_id;
     }
-    
+
     /**
      * Set multiple
-     *
      * @param bool $a_val multiple
      */
     public function setMultiple(bool $a_val) : void
     {
         $this->multiple = $a_val;
     }
-    
+
     public function getMultiple() : bool
     {
         return $this->multiple;
     }
-    
+
     public function setListInfo(string $a_val) : void
     {
         $this->list_info = trim($a_val);
     }
-    
+
     public function getListInfo() : string
     {
         return $this->list_info;
     }
-    
+
     /**
      * Activate sorting mode of assigned objects
      */
@@ -112,39 +110,38 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $this->assigned_item_obj_id = $a_obj_id;
         $this->assigned_item_type = $a_item_type;
     }
-    
-    
+
     /**
      * Execute command
      */
     public function executeCommand() : void
     {
         $ilCtrl = $this->ctrl;
-        
+
         $cmd = $ilCtrl->getCmd("listTaxonomies");
         $this->$cmd();
     }
-    
+
     /**
      * Init creation forms
      */
-    protected function initCreationForms($a_new_type) : array
+    protected function initCreationForms(string $a_new_type) : array
     {
         return array(
             self::CFORM_NEW => $this->initCreateForm("tax")
-            );
+        );
     }
 
-    
+
     ////
     //// Features that work on the base of an assigned object (AO)
     ////
-    
+
     public function editAOTaxonomySettings() : void
     {
         $this->listTaxonomies();
     }
-    
+
     public function getCurrentTaxonomyId() : ?int
     {
         $tax_ids = ilObjTaxonomy::getUsageOfObject($this->getAssignedObject());
@@ -154,8 +151,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         }
         return null;
     }
-    
-    
+
     public function getCurrentTaxonomy() : ?ilObjTaxonomy
     {
         $tax_id = $this->getCurrentTaxonomyId();
@@ -164,8 +160,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         }
         return null;
     }
-    
-    
+
     /**
      * List items
      */
@@ -175,21 +170,20 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $ilToolbar = $this->toolbar;
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-        
+
         $tax = $this->getCurrentTaxonomy();
-        
+
         $this->setTabs("list_items");
-        
+
         // show toolbar
         $ilToolbar->setFormAction($ilCtrl->getFormAction($this));
         $ilToolbar->addFormButton($lng->txt("tax_create_node"), "createTaxNode");
-        
+
         $ilToolbar->setCloseFormTag(false);
-        
-        
+
         // show tree
         $this->showTree();
-        
+
         // show subitems
         $table = new ilTaxonomyTableGUI(
             $this,
@@ -202,8 +196,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
 
         $tpl->setContent($table->getHTML());
     }
-    
-    
+
     /**
      * Create assigned taxonomy
      */
@@ -211,11 +204,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
     {
         $this->create();
     }
-    
-    
-    /**
-     * @inheritDoc
-     */
+
     protected function checkPermissionBool(
         string $perm,
         string $cmd = "",
@@ -228,7 +217,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
             return parent::checkPermissionBool($perm, $cmd, $type, $node_id);
         }
     }
-    
+
     /**
      * Cancel creation
      */
@@ -240,7 +229,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         }
         parent::cancel();
     }
-    
+
     public function save() : void
     {
         if ($this->getAssignedObject() > 0) {
@@ -248,7 +237,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         }
         parent::saveObject();
     }
-    
+
     /**
      * After saving,
      */
@@ -314,7 +303,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         );
         $tax_exp->handleCommand();
     }
-    
+
     /**
      * Create tax node
      */
@@ -325,24 +314,23 @@ class ilObjTaxonomyGUI extends ilObject2GUI
 
         $this->setTabs("list_items");
         $ilHelp->setSubScreenId("create_node");
-        
+
         $form = $this->initTaxNodeForm("create");
         $tpl->setContent($form->getHTML());
     }
-    
-    
+
     // Init tax node form
     public function initTaxNodeForm(string $a_mode = "edit") : ilPropertyFormGUI
     {
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-    
+
         $form = new ilPropertyFormGUI();
 
         // title
         $ti = new ilTextInputGUI($this->lng->txt("title"), "title");
         $form->addItem($ti);
-        
+
         // order nr
         $tax = $this->getCurrentTaxonomy();
         $or = null;
@@ -352,7 +340,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
             $or->setSize(5);
             $form->addItem($or);
         }
-        
+
         if ($a_mode == "edit") {
             $node = new ilTaxonomyNode($this->current_tax_node);
             $ti->setValue($node->getTitle());
@@ -360,7 +348,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
                 $or->setValue($node->getOrderNr());
             }
         }
-        
+
         // save and cancel commands
         if ($a_mode == "create") {
             $form->addCommandButton("saveTaxNode", $lng->txt("save"));
@@ -376,25 +364,22 @@ class ilObjTaxonomyGUI extends ilObject2GUI
 
         return $form;
     }
-    
+
     /**
      * Save tax node form
-     *
      */
     public function saveTaxNode() : void
     {
         $tpl = $this->tpl;
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-    
+
         $form = $this->initTaxNodeForm("create");
         if ($form->checkInput()) {
-            $tax = $this->getCurrentTaxonomy();
-            
             // create node
             $node = new ilTaxonomyNode();
             $node->setTitle($form->getInput("title"));
-            
+
             $tax = $this->getCurrentTaxonomy();
             $order_nr = "";
             if ($tax->getSortingMode() == ilObjTaxonomy::SORT_MANUAL) {
@@ -407,12 +392,12 @@ class ilObjTaxonomyGUI extends ilObject2GUI
             $node->setOrderNr($order_nr);
             $node->setTaxonomyId($tax->getId());
             $node->create();
-            
+
             // put in tree
             ilTaxonomyNode::putInTree($tax->getId(), $node, $this->current_tax_node);
-            
+
             ilTaxonomyNode::fixOrderNumbers($tax->getId(), $this->current_tax_node);
-            
+
             $this->tpl->setOnScreenMessage('success', $lng->txt("msg_obj_modified"), true);
             $ilCtrl->redirect($this, "listNodes");
         } else {
@@ -420,7 +405,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
             $tpl->setContent($form->getHTML());
         }
     }
-    
+
     /**
      * Update tax node
      */
@@ -429,7 +414,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
         $tpl = $this->tpl;
-        
+
         $form = $this->initTaxNodeForm("edit");
         if ($form->checkInput()) {
             // create node
@@ -450,7 +435,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
             $tpl->setContent($form->getHTML());
         }
     }
-    
+
     /**
      * Confirm deletion screen for items
      */
@@ -471,7 +456,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $ilHelp->setSubScreenId("del_items");
 
         //		$ilTabs->clearTargets();
-        
+
         $confirmation_gui = new ilConfirmationGUI();
 
         $confirmation_gui->setFormAction($ilCtrl->getFormAction($this));
@@ -499,7 +484,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
     {
         $ilCtrl = $this->ctrl;
         $body = $this->request->getParsedBody();
-        
+
         // delete all selected objects
         foreach ($body["id"] as $id) {
             $node = new ilTaxonomyNode($id);
@@ -517,7 +502,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
 
         // feedback
         $this->tpl->setOnScreenMessage('info', $this->lng->txt("info_deleted"), true);
-        
+
         $ilCtrl->redirect($this, "listNodes");
     }
 
@@ -529,7 +514,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $ilCtrl = $this->ctrl;
         $lng = $this->lng;
         $body = $this->request->getParsedBody();
-        
+
         // save sorting
         if (is_array($body["order"])) {
             foreach ($body["order"] as $k => $v) {
@@ -537,7 +522,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
             }
             ilTaxonomyNode::fixOrderNumbers($this->getCurrentTaxonomyId(), $this->current_tax_node);
         }
-        
+
         // save titles
         if (is_array($body["title"])) {
             foreach ($body["title"] as $k => $v) {
@@ -550,7 +535,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $this->tpl->setOnScreenMessage('success', $lng->txt("msg_obj_modified"));
         $ilCtrl->redirect($this, "listNodes");
     }
-    
+
     /**
      * Move items
      */
@@ -574,12 +559,12 @@ class ilObjTaxonomyGUI extends ilObject2GUI
             $lng->txt("cancel"),
             $ilCtrl->getLinkTarget($this, "listNodes")
         );
-        
+
         $this->tpl->setOnScreenMessage('info', $lng->txt("tax_please_select_target"));
-        
+
         if (is_array($body["id"])) {
             $ilCtrl->setParameter($this, "move_ids", implode(",", $body["id"]));
-            
+
             $tpl = $this->tpl;
 
             $tax_exp = new ilTaxonomyExplorerGUI(
@@ -595,7 +580,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
             }
         }
     }
-    
+
     /**
      * Paste items (move operation)
      */
@@ -607,20 +592,20 @@ class ilObjTaxonomyGUI extends ilObject2GUI
             $move_ids = explode(",", $this->requested_move_ids);
             $tax = $this->getCurrentTaxonomy();
             $tree = $tax->getTree();
-            
+
             $target_node = new ilTaxonomyNode($this->current_tax_node);
             foreach ($move_ids as $m_id) {
                 // cross check taxonomy
                 $node = new ilTaxonomyNode((int) $m_id);
                 if ($node->getTaxonomyId() == $tax->getId() &&
                     ($target_node->getTaxonomyId() == $tax->getId() ||
-                    $target_node->getId() == $tree->readRootId())) {
+                        $target_node->getId() == $tree->readRootId())) {
                     // check if target is not within the selected nodes
                     if ($tree->isGrandChild((int) $m_id, $target_node->getId())) {
                         $this->tpl->setOnScreenMessage('failure', $lng->txt("tax_target_within_nodes"), true);
                         $this->ctrl->redirect($this, "listNodes");
                     }
-                    
+
                     // if target is not current place, move
                     $parent_id = $tree->getParentId((int) $m_id);
                     if ($parent_id != $target_node->getId()) {
@@ -635,7 +620,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $this->tpl->setOnScreenMessage('success', $lng->txt("msg_obj_modified"), true);
         $ilCtrl->redirect($this, "listNodes");
     }
-    
+
     /**
      * Confirm taxonomy deletion
      */
@@ -646,18 +631,18 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $lng = $this->lng;
 
         $tax = $this->getCurrentTaxonomy();
-        
+
         $cgui = new ilConfirmationGUI();
         $cgui->setFormAction($ilCtrl->getFormAction($this));
         $cgui->setHeaderText($lng->txt("tax_confirm_deletion"));
         $cgui->setCancel($lng->txt("cancel"), "listTaxonomies");
         $cgui->setConfirm($lng->txt("delete"), "deleteTaxonomy");
-        
+
         $cgui->addItem("id[]", 0, $tax->getTitle());
-        
+
         $tpl->setContent($cgui->getHTML());
     }
-    
+
     /**
      * Delete taxonomy
      */
@@ -665,10 +650,10 @@ class ilObjTaxonomyGUI extends ilObject2GUI
     {
         $ilCtrl = $this->ctrl;
         $lng = $this->lng;
-        
+
         $tax = $this->getCurrentTaxonomy();
         $tax->delete();
-        
+
         $this->tpl->setOnScreenMessage('success', $lng->txt("tax_tax_deleted"), true);
         $ilCtrl->redirect($this, "listTaxonomies");
     }
@@ -682,7 +667,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $ilToolbar = $this->toolbar;
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-        
+
         $tax_ids = ilObjTaxonomy::getUsageOfObject($this->getAssignedObject());
         if (count($tax_ids) == 0 || $this->getMultiple()) {
             $ilToolbar->addButton(
@@ -692,17 +677,17 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         } else {
             $this->tpl->setOnScreenMessage('info', $lng->txt("tax_max_one_tax"));
         }
-        
+
         $tab = new ilTaxonomyListTableGUI(
             $this,
             "listTaxonomies",
             $this->getAssignedObject(),
             $this->getListInfo()
         );
-        
+
         $tpl->setContent($tab->getHTML());
     }
-    
+
     /**
      * @inheritDoc
      */
@@ -713,7 +698,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $tpl = $this->tpl;
         $lng = $this->lng;
         $ilHelp = $this->help;
-        
+
         $ilTabs->clearTargets();
 
         $ilHelp->setScreenIdComponent("tax");
@@ -721,12 +706,12 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $tpl->setTitle(ilObject::_lookupTitle($this->getCurrentTaxonomyId()));
         $tpl->setDescription(ilObject::_lookupDescription($this->getCurrentTaxonomyId()));
         $tpl->setTitleIcon(ilUtil::getImagePath("icon_tax.svg"));
-        
+
         $ilTabs->setBackTarget(
             $lng->txt("back"),
             $ilCtrl->getLinkTarget($this, "listTaxonomies")
         );
-        
+
         $ilTabs->addTab(
             "list_items",
             $lng->txt("tax_nodes"),
@@ -744,24 +729,24 @@ class ilObjTaxonomyGUI extends ilObject2GUI
             $lng->txt("settings"),
             $ilCtrl->getLinkTarget($this, "editSettings")
         );
-        
+
         $ilTabs->activateTab($a_id);
     }
-    
+
     /**
      * Edit settings
      */
     public function editSettings() : void
     {
         $tpl = $this->tpl;
-        
+
         $this->setTabs("settings");
-        
+
         $form = $this->initSettingsForm();
         $tpl->setContent($form->getHTML());
     }
-    
-    public function initSettingsForm() : \ilPropertyFormGUI
+
+    public function initSettingsForm() : ilPropertyFormGUI
     {
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
@@ -788,7 +773,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $options = array(
             ilObjTaxonomy::SORT_ALPHABETICAL => $lng->txt("tax_alphabetical"),
             ilObjTaxonomy::SORT_MANUAL => $lng->txt("tax_manual")
-            );
+        );
         $si = new ilSelectInputGUI($lng->txt("tax_node_sorting"), "sorting");
 
         $si->setOptions($options);
@@ -809,7 +794,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
 
         return $form;
     }
-    
+
     /**
      * Update taxonomy settings
      */
@@ -818,14 +803,14 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $tpl = $this->tpl;
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-    
+
         $form = $this->initSettingsForm();
         if ($form->checkInput()) {
             $tax = $this->getCurrentTaxonomy();
             $tax->setTitle($form->getInput("title"));
             $tax->setDescription($form->getInput("description"));
-            $tax->setSortingMode($form->getInput("sorting"));
-            $tax->setItemSorting($form->getInput("item_sorting"));
+            $tax->setSortingMode((int) $form->getInput("sorting"));
+            $tax->setItemSorting((bool) $form->getInput("item_sorting"));
             $tax->update();
 
             $this->tpl->setOnScreenMessage('success', $lng->txt("msg_obj_modified"), true);
@@ -835,7 +820,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
             $tpl->setContent($form->getHTML());
         }
     }
-    
+
     /**
      * List assigned items
      */
@@ -844,16 +829,16 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $tpl = $this->tpl;
 
         $this->setTabs("ass_items");
-                
+
         // show tree
         $this->showTree(true);
-        
+
         // list assigned items
         $table = new ilTaxAssignedItemsTableGUI(
             $this,
             "listAssignedItems",
             $this->current_tax_node,
-            $this->getCurrentTaxonomy(),
+            (int) $this->getCurrentTaxonomy(),
             $this->assigned_item_comp_id,
             $this->assigned_item_obj_id,
             $this->assigned_item_type,
@@ -880,7 +865,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
                     $this->assigned_item_comp_id,
                     $this->assigned_item_obj_id,
                     $this->assigned_item_type,
-                    $this->getCurrentTaxonomyId()
+                    (int) $this->getCurrentTaxonomyId()
                 );
                 $tax_ass->setOrderNr($tax_node, $a_item_id, $ord_nr);
             }

--- a/Services/Taxonomy/classes/class.ilTaxAssignInputGUI.php
+++ b/Services/Taxonomy/classes/class.ilTaxAssignInputGUI.php
@@ -4,7 +4,6 @@
 
 /**
  * Input GUI class for taxonomy assignments
- *
  * @author Alexander Killing <killing@leifos.de>
  */
 class ilTaxAssignInputGUI extends ilSelectInputGUI
@@ -23,42 +22,40 @@ class ilTaxAssignInputGUI extends ilSelectInputGUI
 
         $this->lng = $DIC->language();
         $lng = $DIC->language();
-        
+
         $lng->loadLanguageModule("tax");
         $this->setMulti($a_multi);
         $this->include_please_select = $a_include_please_select;
-        
+
         if ($a_title == "") {
             $a_title = $lng->txt("tax_taxonomy");
         }
-        
+
         if ($a_postvar == "") {
             $a_postvar = "tax_node_assign";
         }
-        
+
         parent::__construct($a_title, $a_postvar);
         $this->setType("tax_assign");
-        
+
         if ((int) $a_taxonomy_id == 0) {
             throw new ilTaxonomyException("No taxonomy ID passed to ilTaxAssignInputGUI.");
         }
-        
+
         $this->setTaxonomyId((int) $a_taxonomy_id);
     }
-    
+
     /**
      * Set taxonomy id
-     *
      * @param int $a_val taxonomy id
      */
     public function setTaxonomyId(int $a_val) : void
     {
         $this->taxononmy_id = $a_val;
     }
-    
+
     /**
      * Get taxonomy id
-     *
      * @return int taxonomy id
      */
     public function getTaxonomyId() : int
@@ -68,8 +65,7 @@ class ilTaxAssignInputGUI extends ilSelectInputGUI
 
     /**
      * Set Options.
-     *
-     * @param	array	$a_options	Options. Array ("value" => "option_text")
+     * @param array $a_options Options. Array ("value" => "option_text")
      */
     public function setOptions($a_options) : void
     {
@@ -78,8 +74,7 @@ class ilTaxAssignInputGUI extends ilSelectInputGUI
 
     /**
      * Get Options.
-     *
-     * @return	array	Options. Array ("value" => "option_text")
+     * @return    array    Options. Array ("value" => "option_text")
      */
     public function getOptions() : array
     {
@@ -89,19 +84,19 @@ class ilTaxAssignInputGUI extends ilSelectInputGUI
         if ($this->include_please_select) {
             $options = array("" => $lng->txt("please_select"));
         }
-        
+
         $tax_tree = new ilTaxonomyTree($this->getTaxonomyId());
-        
+
         $nodes = $tax_tree->getSubTree($tax_tree->getNodeData($tax_tree->readRootId()));
         foreach ($nodes as $n) {
             if ($n["type"] == "taxn") {
                 $options[$n["child"]] = str_repeat("&nbsp;", ($n["depth"] - 2) * 2) . $n["title"];
             }
         }
-        
+
         return $options;
     }
-    
+
     /**
      * Save input
      * @throws ilTaxonomyException
@@ -130,19 +125,19 @@ class ilTaxAssignInputGUI extends ilSelectInputGUI
         $exising = array();
         foreach ($current_ass as $ca) {
             if (!in_array($ca["node_id"], $post)) {
-                $tax_node_ass->deleteAssignment($ca["node_id"], $a_item_id);
+                $tax_node_ass->deleteAssignment((int) $ca["node_id"], $a_item_id);
             } else {
-                $exising[] = $ca["node_id"];
+                $exising[] = (int) $ca["node_id"];
             }
         }
 
         foreach ($post as $p) {
             if (!in_array($p, $exising)) {
-                $tax_node_ass->addAssignment(ilUtil::stripSlashes($p), $a_item_id);
+                $tax_node_ass->addAssignment(ilUtil::stripSlashes($p), $a_item_id); //  // TODO PHP8-REVIEW: Fix this: $p should be of type int
             }
         }
     }
-    
+
     /**
      * Set current values
      * @throws ilTaxonomyException
@@ -155,7 +150,7 @@ class ilTaxAssignInputGUI extends ilSelectInputGUI
     ) : void {
         $tax_node_ass = new ilTaxNodeAssignment($a_component_id, $a_obj_id, $a_item_type, $this->getTaxonomyId());
         $ass = $tax_node_ass->getAssignmentsOfItem($a_item_id);
-        
+
         $nodes = array();
         foreach ($ass as $a) {
             $nodes[] = $a["node_id"];

--- a/Services/Taxonomy/classes/class.ilTaxAssignedItemsTableGUI.php
+++ b/Services/Taxonomy/classes/class.ilTaxAssignedItemsTableGUI.php
@@ -4,7 +4,6 @@
 
 /**
  * TableGUI class for taxonomy list
- *
  * @author Alexander Killing <killing@leifos.de>
  */
 class ilTaxAssignedItemsTableGUI extends ilTable2GUI
@@ -24,11 +23,11 @@ class ilTaxAssignedItemsTableGUI extends ilTable2GUI
         $a_parent_obj,
         string $a_parent_cmd,
         int $a_node_id,
-        \ilObjTaxonomy $a_tax,
+        ilObjTaxonomy $a_tax,
         string $a_comp_id,
         int $a_obj_id,
         string $a_item_type,
-        \ilTaxAssignedItemInfo $a_info_obj
+        ilTaxAssignedItemInfo $a_info_obj
     ) {
         global $DIC;
 
@@ -38,7 +37,7 @@ class ilTaxAssignedItemsTableGUI extends ilTable2GUI
 
         $ilCtrl = $DIC->ctrl();
         $lng = $DIC->language();
-        
+
         $this->setId("tax_ass_it");
         $this->setLimit(9999);
         $this->tax = $a_tax;
@@ -49,17 +48,17 @@ class ilTaxAssignedItemsTableGUI extends ilTable2GUI
         $this->info_obj = $a_info_obj;
 
         parent::__construct($a_parent_obj, $a_parent_cmd);
-        
+
         $tax_ass = new ilTaxNodeAssignment($this->comp_id, $this->obj_id, $this->item_type, $this->tax->getId());
         $this->setData($tax_ass->getAssignmentsOfNode($this->node_id));
         $this->setTitle($lng->txt("tax_assigned_items"));
-        
+
         $this->addColumn($this->lng->txt("tax_order"));
         $this->setDefaultOrderField("order_nr");
         $this->setDefaultOrderDirection("asc");
 
         $this->addColumn($this->lng->txt("title"));
-        
+
         $this->setFormAction($ilCtrl->getFormAction($a_parent_obj));
         $this->setRowTemplate("tpl.tax_ass_items_row.html", "Services/Taxonomy");
         $this->addCommandButton("saveAssignedItemsSorting", $lng->txt("save"));
@@ -77,7 +76,7 @@ class ilTaxAssignedItemsTableGUI extends ilTable2GUI
         $this->tpl->setVariable("TITLE", $this->info_obj->getTitle(
             $a_set["component"],
             $a_set["item_type"],
-            $a_set["item_id"]
+            (int) $a_set["item_id"]
         ));
     }
 }

--- a/Services/Taxonomy/classes/class.ilTaxMDGUI.php
+++ b/Services/Taxonomy/classes/class.ilTaxMDGUI.php
@@ -12,17 +12,17 @@ use \Psr\Http\Message\RequestInterface;
  */
 class ilTaxMDGUI
 {
-    protected \ilObjectDefinition $obj_definition;
-    protected \ilTree $tree;
+    protected ilObjectDefinition $obj_definition;
+    protected ilTree $tree;
     protected int $md_rbac_id;
     protected int $md_obj_id;
     protected string $md_obj_type;
     protected string $requested_post_var;
     protected RequestInterface $request;
-    protected \ilCtrl $ctrl;
-    protected \ilGlobalTemplateInterface $tpl;
-    protected \ilLanguage $lng;
-    protected \ilTabsGUI $tabs;
+    protected ilCtrl $ctrl;
+    protected ilGlobalTemplateInterface $tpl;
+    protected ilLanguage $lng;
+    protected ilTabsGUI $tabs;
     protected int $ref_id;
 
     /**
@@ -45,7 +45,7 @@ class ilTaxMDGUI
         $this->lng = $DIC->language();
         $this->tpl = $DIC->ui()->mainTemplate();
 
-        $this->request = $DIC->http()->request();
+        $this->request = $DIC->http()->request(); // TODO PHP8 REVIEW: Please use http()->wrapper()
 
         $this->md_rbac_id = $a_md_rbac_id;
         $this->md_obj_id = $a_md_obj_id;
@@ -72,10 +72,8 @@ class ilTaxMDGUI
             $item = $form->getItemByPostVar($this->requested_post_var);
             $form_prop_dispatch->setItem($item);
             return $this->ctrl->forwardCommand($form_prop_dispatch);
-        } else {
-            if (in_array($cmd, array("show", "save"))) {
-                $this->$cmd();
-            }
+        } elseif (in_array($cmd, array("show", "save"))) {
+            $this->$cmd();
         }
         return "";
     }
@@ -129,14 +127,14 @@ class ilTaxMDGUI
             // get all active taxonomies of parent objects
             foreach ($tree->getPathFull($this->ref_id) as $node) {
                 // currently only active for categories
-                if ($node["ref_id"] != $this->ref_id && $node["type"] == "cat") {
+                if ((int) $node["ref_id"] != $this->ref_id && $node["type"] == "cat") {
                     if (ilContainer::_lookupContainerSetting(
-                        $node["obj_id"],
+                        (int) $node["obj_id"],
                         ilObjectServiceSettingsGUI::TAXONOMIES,
                         false
                     ) !== ''
                     ) {
-                        $tax_ids = ilObjTaxonomy::getUsageOfObject($node["obj_id"]);
+                        $tax_ids = ilObjTaxonomy::getUsageOfObject((int) $node["obj_id"]);
                         if (count($tax_ids) !== 0) {
                             $res = array_merge($res, $tax_ids);
                         }
@@ -146,7 +144,10 @@ class ilTaxMDGUI
         }
         return $res;
     }
-    
+
+    /**
+     * @throws ilTaxonomyException
+     */
     protected function initTaxNodeAssignment(int $a_tax_id) : ilTaxNodeAssignment
     {
         return new ilTaxNodeAssignment($this->md_obj_type, $this->md_obj_id, "obj", $a_tax_id);
@@ -162,7 +163,7 @@ class ilTaxMDGUI
             foreach ($tax_ids as $tax_id) {
                 // get existing assignments
                 $node_ids = array();
-                $ta = $this->initTaxNodeAssignment($tax_id);
+                $ta = $this->initTaxNodeAssignment((int) $tax_id);
                 foreach ($ta->getAssignmentsOfItem($this->md_obj_id) as $ass) {
                     $node_ids[] = $ass["node_id"];
                 }

--- a/Services/Taxonomy/classes/class.ilTaxNodeAssignment.php
+++ b/Services/Taxonomy/classes/class.ilTaxNodeAssignment.php
@@ -4,14 +4,12 @@
 
 /**
  * Taxonomy node <-> item assignment
- *
  * This class allows to assign items to taxonomy nodes.
- *
  * @author Alexander Killing <killing@leifos.de>
  */
 class ilTaxNodeAssignment
 {
-    protected \ilDBInterface $db;
+    protected ilDBInterface $db;
     protected string $component_id;
     protected int $taxonomy_id;
     protected string $item_type;
@@ -19,11 +17,10 @@ class ilTaxNodeAssignment
 
     /**
      * Constructor
-     *
-     * @param string $a_component_id component id (e.g. "glo" for Modules/Glossary)
-     * @param int $a_obj_id repository object id of the object that is responsible for the assignment
-     * @param string $a_item_type item type (e.g. "term", must be unique component wide) [use "obj" if repository object wide taxonomies!]
-     * @param int $a_tax_id taxonomy id
+     * @param string             $a_component_id component id (e.g. "glo" for Modules/Glossary)
+     * @param int                $a_obj_id       repository object id of the object that is responsible for the assignment
+     * @param string             $a_item_type    item type (e.g. "term", must be unique component wide) [use "obj" if repository object wide taxonomies!]
+     * @param int                $a_tax_id       taxonomy id
      * @param ilDBInterface|null $db
      * @throws ilTaxonomyException
      */
@@ -32,7 +29,7 @@ class ilTaxNodeAssignment
         int $a_obj_id,
         string $a_item_type,
         int $a_tax_id,
-        \ilDBInterface $db = null
+        ilDBInterface $db = null
     ) {
         global $DIC;
 
@@ -43,7 +40,7 @@ class ilTaxNodeAssignment
         if ($a_component_id == "") {
             throw new ilTaxonomyException('No component ID passed to ilTaxNodeAssignment.');
         }
-        
+
         if ($a_item_type == "") {
             throw new ilTaxonomyException('No item type passed to ilTaxNodeAssignment.');
         }
@@ -57,37 +54,37 @@ class ilTaxNodeAssignment
         $this->setTaxonomyId($a_tax_id);
         $this->setObjectId($a_obj_id);
     }
-    
+
     protected function setComponentId(string $a_val) : void
     {
         $this->component_id = $a_val;
     }
-    
+
     public function getComponentId() : string
     {
         return $this->component_id;
     }
-    
+
     protected function setItemType(string $a_val) : void
     {
         $this->item_type = $a_val;
     }
-    
+
     public function getItemType() : string
     {
         return $this->item_type;
     }
-    
+
     protected function setTaxonomyId(int $a_val) : void
     {
         $this->taxonomy_id = $a_val;
     }
-    
+
     public function getTaxonomyId() : int
     {
         return $this->taxonomy_id;
     }
-    
+
     public function setObjectId(int $a_val) : void
     {
         $this->obj_id = $a_val;
@@ -97,7 +94,7 @@ class ilTaxNodeAssignment
     {
         return $this->obj_id;
     }
-    
+
     /**
      * Get assignments of node
      * @param string|array $a_node_id node id
@@ -132,10 +129,10 @@ class ilTaxNodeAssignment
         while ($rec = $ilDB->fetchAssoc($set)) {
             $ass[] = $rec;
         }
-        
+
         return $ass;
     }
-    
+
     /**
      * Get assignments for item
      * @return array array of tax node assignments arrays
@@ -158,21 +155,20 @@ class ilTaxNodeAssignment
         }
         return $ass;
     }
-    
+
     /**
      * Add assignment
-     *
      * @throws ilTaxonomyException
      */
     public function addAssignment(int $a_node_id, int $a_item_id, int $a_order_nr = 0) : void
     {
         $ilDB = $this->db;
-        
+
         // nothing to do, if not both IDs are greater 0
         if ($a_node_id == 0 || $a_item_id == 0) {
             return;
         }
-        
+
         // sanity check: does the node belong to the given taxonomy?
         $set = $ilDB->query(
             "SELECT tax_tree_id FROM tax_tree " .
@@ -187,12 +183,12 @@ class ilTaxNodeAssignment
         // order number should be kept in this case
         $set2 = $ilDB->query(
             $q = "SELECT item_id FROM tax_node_assignment " .
-            " WHERE component = " . $ilDB->quote($this->getComponentId(), "text") .
-            " AND item_type = " . $ilDB->quote($this->getItemType(), "text") .
-            " AND obj_id = " . $ilDB->quote($this->getObjectId(), "integer") .
-            " AND node_id = " . $ilDB->quote($a_node_id, "integer") .
-            " AND tax_id = " . $ilDB->quote($this->getTaxonomyId(), "integer") .
-            " AND item_id = " . $ilDB->quote($a_item_id, "integer")
+                " WHERE component = " . $ilDB->quote($this->getComponentId(), "text") .
+                " AND item_type = " . $ilDB->quote($this->getItemType(), "text") .
+                " AND obj_id = " . $ilDB->quote($this->getObjectId(), "integer") .
+                " AND node_id = " . $ilDB->quote($a_node_id, "integer") .
+                " AND tax_id = " . $ilDB->quote($this->getTaxonomyId(), "integer") .
+                " AND item_id = " . $ilDB->quote($a_item_id, "integer")
         );
         if ($rec2 = $ilDB->fetchAssoc($set2)) {
             return;
@@ -201,7 +197,7 @@ class ilTaxNodeAssignment
         if ($a_order_nr == 0) {
             $a_order_nr = $this->getMaxOrderNr($a_node_id) + 10;
         }
-        
+
         $ilDB->replace(
             "tax_node_assignment",
             array(
@@ -210,11 +206,11 @@ class ilTaxNodeAssignment
                 "item_type" => array("text", $this->getItemType()),
                 "obj_id" => array("integer", $this->getObjectId()),
                 "item_id" => array("integer", $a_item_id)
-                ),
+            ),
             array(
                 "tax_id" => array("integer", $this->getTaxonomyId()),
                 "order_nr" => array("integer", $a_order_nr)
-                )
+            )
         );
     }
 
@@ -233,7 +229,7 @@ class ilTaxNodeAssignment
             " WHERE child = " . $ilDB->quote($a_node_id, "integer")
         );
         $rec = $ilDB->fetchAssoc($set);
-        if ($rec["tax_tree_id"] != $this->getTaxonomyId()) {
+        if ((int) $rec["tax_tree_id"] != $this->getTaxonomyId()) {
             throw new ilTaxonomyException('addAssignment: Node ID does not belong to current taxonomy.');
         }
 
@@ -251,7 +247,7 @@ class ilTaxNodeAssignment
     public function getMaxOrderNr(int $a_node_id) : int
     {
         $ilDB = $this->db;
-        
+
         $set = $ilDB->query(
             "SELECT max(order_nr) mnr FROM tax_node_assignment " .
             " WHERE component = " . $ilDB->quote($this->getComponentId(), "text") .
@@ -261,14 +257,14 @@ class ilTaxNodeAssignment
             " AND tax_id = " . $ilDB->quote($this->getTaxonomyId(), "integer")
         );
         $rec = $ilDB->fetchAssoc($set);
-        
+
         return (int) $rec["mnr"];
     }
-    
+
     public function setOrderNr(int $a_node_id, int $a_item_id, int $a_order_nr) : void
     {
         $ilDB = $this->db;
-        
+
         $ilDB->manipulate(
             "UPDATE tax_node_assignment SET " .
             " order_nr = " . $ilDB->quote($a_order_nr, "integer") .
@@ -280,7 +276,7 @@ class ilTaxNodeAssignment
             " AND tax_id = " . $ilDB->quote($this->getTaxonomyId(), "integer")
         );
     }
-    
+
     public function deleteAssignmentsOfItem(int $a_item_id) : void
     {
         $ilDB = $this->db;
@@ -307,7 +303,7 @@ class ilTaxNodeAssignment
             " AND item_type = " . $ilDB->quote($this->getItemType(), "text")
         );
     }
-    
+
     public static function deleteAllAssignmentsOfNode(int $a_node_id) : void
     {
         global $DIC;
@@ -350,8 +346,6 @@ class ilTaxNodeAssignment
         }
     }
 
-
-
     /**
      * Find object which have assigned nodes
      */
@@ -360,9 +354,9 @@ class ilTaxNodeAssignment
         global $DIC;
 
         $ilDB = $DIC->database();
-        
+
         $res = array();
-    
+
         $set = $ilDB->query(
             "SELECT * FROM tax_node_assignment" .
             " WHERE " . $ilDB->in("node_id", $a_node_ids, "", "integer") .
@@ -371,9 +365,9 @@ class ilTaxNodeAssignment
             " ORDER BY order_nr ASC"
         );
         while ($row = $ilDB->fetchAssoc($set)) {
-            $res[] = $row["obj_id"];
+            $res[] = (int) $row["obj_id"];
         }
-        
+
         return $res;
     }
 }

--- a/Services/Taxonomy/classes/class.ilTaxSelectInputGUI.php
+++ b/Services/Taxonomy/classes/class.ilTaxSelectInputGUI.php
@@ -4,8 +4,7 @@
 
 /**
  * Select taxonomy nodes input GUI
- *
- * @author Alexander Killing <killing@leifos.de>
+ * @author            Alexander Killing <killing@leifos.de>
  * @ilCtrl_IsCalledBy ilTaxSelectInputGUI: ilFormPropertyDispatchGUI
  */
 class ilTaxSelectInputGUI extends ilExplorerSelectInputGUI
@@ -22,7 +21,7 @@ class ilTaxSelectInputGUI extends ilExplorerSelectInputGUI
         $this->ctrl = $DIC->ctrl();
         $lng = $DIC->language();
         $ilCtrl = $DIC->ctrl();
-        
+
         $lng->loadLanguageModule("tax");
         $this->multi_nodes = $a_multi;
         $ilCtrl->setParameterByClass("ilformpropertydispatchgui", "postvar", $a_postvar);
@@ -37,22 +36,27 @@ class ilTaxSelectInputGUI extends ilExplorerSelectInputGUI
         $this->explorer_gui->setSelectMode($a_postvar . "_sel", $this->multi_nodes);
         $this->explorer_gui->setSkipRootNode(true);
 
-        parent::__construct(ilObject::_lookupTitle($a_taxonomy_id), $a_postvar, $this->explorer_gui, $this->multi_nodes);
+        parent::__construct(
+            ilObject::_lookupTitle($a_taxonomy_id),
+            $a_postvar,
+            $this->explorer_gui,
+            $this->multi_nodes
+        );
         $this->setType("tax_select");
-        
+
         if ((int) $a_taxonomy_id == 0) {
             throw new ilTaxonomyException("No taxonomy ID passed to ilTaxSelectInputGUI.");
         }
-        
+
         $this->setTaxonomyId((int) $a_taxonomy_id);
         $this->tax = new ilObjTaxonomy($this->getTaxonomyId());
     }
-    
+
     public function setTaxonomyId(int $a_val) : void
     {
         $this->taxononmy_id = $a_val;
     }
-    
+
     public function getTaxonomyId() : int
     {
         return $this->taxononmy_id;

--- a/Services/Taxonomy/classes/class.ilTaxonomyAdministrationRepositoryTableGUI.php
+++ b/Services/Taxonomy/classes/class.ilTaxonomyAdministrationRepositoryTableGUI.php
@@ -4,7 +4,6 @@
 
 /**
  * TableGUI class for repository taxonomies
- *
  * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>
  */
 class ilTaxonomyAdministrationRepositoryTableGUI extends ilTable2GUI
@@ -22,51 +21,52 @@ class ilTaxonomyAdministrationRepositoryTableGUI extends ilTable2GUI
         $this->access = $DIC->access();
 
         $this->obj = $a_obj;
-        
+
         $this->setId("tax_adm_repo");
-        
+
         parent::__construct($a_parent_obj, $a_parent_cmd);
-            
+
         $this->addColumn($this->lng->txt("obj_tax"), "tax_title");
         $this->addColumn($this->lng->txt("status"), "status");
         $this->addColumn($this->lng->txt("object"), "obj_title");
-        
+
         $this->setDefaultOrderField("tax_title");
         $this->setDefaultOrderDirection("asc");
-        
+
         $this->setRowTemplate("tpl.tax_admin_repo_row.html", "Services/Taxonomy");
-        
+
         $this->initItems();
     }
-    
+
     protected function initItems() : void
     {
         $data = array();
-        
+
         foreach ($this->obj->getRepositoryTaxonomies() as $tax_id => $objs) {
             foreach ($objs as $obj_id => $obj) {
                 $idx = $tax_id . "_" . $obj_id;
                 if (!isset($data[$idx])) {
                     $data[$idx] = array(
-                        "tax_title" => $obj["tax_title"]
-                        ,"obj_title" => $obj["obj_title"]
-                        ,"tax_status" => $obj["tax_status"]
-                        ,"references" => array()
+                        "tax_title" => $obj["tax_title"],
+                        "obj_title" => $obj["obj_title"],
+                        "tax_status" => $obj["tax_status"],
+                        "references" => array()
                     );
                 }
-                
+
                 $path = $obj["path"];
                 array_pop($path);
                 $path = implode(" &rsaquo; ", $path);
-                
+
                 $data[$idx]["references"][$obj["ref_id"]] =
                     array(
                         "path" => $path
-                        ,"url" => ilLink::_getLink($obj["ref_id"])
+                        ,
+                        "url" => ilLink::_getLink($obj["ref_id"])
                     );
             }
         }
-        
+
         $this->setData($data);
     }
 
@@ -79,7 +79,7 @@ class ilTaxonomyAdministrationRepositoryTableGUI extends ilTable2GUI
             $this->tpl->setVariable("OBJ_URL", $ref["url"]);
             $this->tpl->parseCurrentBlock();
         }
-        
+
         if ($a_set["tax_status"]) {
             $this->tpl->setVariable("TAX_STATUS", $this->lng->txt("active"));
             $this->tpl->setVariable("TAX_STATUS_COLOR", "smallgreen");
@@ -87,7 +87,7 @@ class ilTaxonomyAdministrationRepositoryTableGUI extends ilTable2GUI
             $this->tpl->setVariable("TAX_STATUS", $this->lng->txt("inactive"));
             $this->tpl->setVariable("TAX_STATUS_COLOR", "smallred");
         }
-        
+
         $this->tpl->setVariable("TAX_TITLE", $a_set["tax_title"]);
     }
 }

--- a/Services/Taxonomy/classes/class.ilTaxonomyClassificationProvider.php
+++ b/Services/Taxonomy/classes/class.ilTaxonomyClassificationProvider.php
@@ -4,7 +4,6 @@
 
 /**
  * Taxonomy classification provider
- *
  * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>
  */
 class ilTaxonomyClassificationProvider extends ilClassificationProvider
@@ -12,45 +11,42 @@ class ilTaxonomyClassificationProvider extends ilClassificationProvider
     protected array $selection;
     protected static array $valid_tax_map = [];
     protected int $incoming_id;
-    
+
     public static function isActive(int $a_parent_ref_id, int $a_parent_obj_id, string $a_parent_obj_type) : bool
     {
         return (bool) self::getActiveTaxonomiesForParentRefId($a_parent_ref_id);
     }
 
-    /**
-     * @inheritDoc
-     */
     protected function init() : void
     {
         $params = $this->request->getQueryParams();
         $body = $this->request->getParsedBody();
         $this->incoming_id = (int) ($body["tax_node"] ?? ($params["tax_node"] ?? null));
     }
-    
+
     public function render(array &$a_html, object $a_parent_gui) : void
     {
         foreach (self::$valid_tax_map[$this->parent_ref_id] as $tax_id) {
-            $tax_exp = new ilTaxonomyExplorerGUI($a_parent_gui, null, $tax_id, null, null);
+            $tax_exp = new ilTaxonomyExplorerGUI($a_parent_gui, null, (int) $tax_id, null, null);
             $tax_exp->setSkipRootNode(true);
             $tax_exp->setOnClick("il.Classification.toggle({tax_node: '{NODE_CHILD}'});");
-            
+
             if (is_array($this->selection)) {
                 foreach ($this->selection as $node_id) {
                     $tax_exp->setPathOpen($node_id);
                     $tax_exp->setNodeSelected($node_id);
                 }
             }
-            
+
             if (!$tax_exp->handleCommand()) {
                 $a_html[] = array(
-                    "title" => ilObject::_lookupTitle($tax_id),
+                    "title" => ilObject::_lookupTitle((int) $tax_id),
                     "html" => $tax_exp->getHTML()
                 );
             }
         }
     }
-    
+
     public function importPostData(?array $a_saved = null) : array
     {
         $incoming_id = $this->incoming_id;
@@ -78,13 +74,13 @@ class ilTaxonomyClassificationProvider extends ilClassificationProvider
     {
         $this->selection = $a_value;
     }
-    
+
     protected static function getActiveTaxonomiesForParentRefId(int $a_parent_ref_id) : int
     {
         global $DIC;
 
         $tree = $DIC->repositoryTree();
-        
+
         if (!isset(self::$valid_tax_map[$a_parent_ref_id])) {
             $prefix = ilObjCategoryGUI::CONTAINER_SETTING_TAXBLOCK;
 
@@ -92,36 +88,36 @@ class ilTaxonomyClassificationProvider extends ilClassificationProvider
             foreach ($tree->getPathFull($a_parent_ref_id) as $node) {
                 if ($node["type"] == "cat") {
                     $node_valid = array();
-                    
+
                     if (ilContainer::_lookupContainerSetting(
-                        $node["obj_id"],
+                        (int) $node["obj_id"],
                         ilObjectServiceSettingsGUI::TAXONOMIES,
                         false
                     ) !== '') {
                         $all_valid = array_merge(
                             $all_valid,
-                            ilObjTaxonomy::getUsageOfObject($node["obj_id"])
+                            ilObjTaxonomy::getUsageOfObject((int) $node["obj_id"])
                         );
-                        
+
                         $active = array();
-                        foreach (ilContainer::_getContainerSettings($node["obj_id"]) as $keyword => $value) {
+                        foreach (ilContainer::_getContainerSettings((int) $node["obj_id"]) as $keyword => $value) {
                             if (substr($keyword, 0, strlen($prefix)) == $prefix && (bool) $value) {
                                 $active[] = substr($keyword, strlen($prefix));
                             }
                         }
-                        
+
                         $node_valid = array_intersect($all_valid, $active);
                     }
-                    
+
                     if (count($node_valid) !== 0) {
                         foreach ($node_valid as $idx => $node_id) {
                             // #15268 - deleted taxonomy?
-                            if (ilObject::_lookupType($node_id) != "tax") {
+                            if (ilObject::_lookupType((int) $node_id) != "tax") {
                                 unset($node_valid[$idx]);
                             }
                         }
                     }
-                    
+
                     self::$valid_tax_map[$node["ref_id"]] = $node_valid;
                 }
             }
@@ -133,37 +129,37 @@ class ilTaxonomyClassificationProvider extends ilClassificationProvider
 
         return 0;
     }
-    
+
     public function getFilteredObjects() : array
     {
         $tax_obj_ids = array();
         $tax_map = array();
-            
+
         // :TODO: this could be smarter
         foreach ($this->selection as $node_id) {
-            $node = new ilTaxonomyNode($node_id);
-            $tax_map[$node->getTaxonomyId()][] = $node_id;
+            $node = new ilTaxonomyNode((int) $node_id);
+            $tax_map[$node->getTaxonomyId()][] = (int) $node_id;
         }
-        
+
         foreach ($tax_map as $tax_id => $node_ids) {
-            $tax_tree = new ilTaxonomyTree($tax_id);
-            
+            $tax_tree = new ilTaxonomyTree((int) $tax_id);
+
             // combine taxonomy nodes OR
             $tax_nodes = array();
             foreach ($node_ids as $node_id) {
-                $tax_nodes = array_merge($tax_nodes, $tax_tree->getSubTreeIds($node_id));
-                $tax_nodes[] = $node_id;
+                $tax_nodes = array_merge($tax_nodes, $tax_tree->getSubTreeIds((int) $node_id));
+                $tax_nodes[] = (int) $node_id;
             }
-                        
-            $tax_obj_ids[$tax_id] = ilTaxNodeAssignment::findObjectsByNode($tax_id, $tax_nodes, "obj");
+
+            $tax_obj_ids[$tax_id] = ilTaxNodeAssignment::findObjectsByNode((int) $tax_id, $tax_nodes, "obj");
         }
-                    
+
         // combine taxonomies AND
         $obj_ids = null;
         foreach ($tax_obj_ids as $tax_objs) {
             $obj_ids = $obj_ids === null ? $tax_objs : array_intersect($obj_ids, $tax_objs);
         }
-        
+
         return (array) $obj_ids;
     }
 }

--- a/Services/Taxonomy/classes/class.ilTaxonomyDataSet.php
+++ b/Services/Taxonomy/classes/class.ilTaxonomyDataSet.php
@@ -4,35 +4,27 @@
 
 /**
  * Taxonomy data set class
- *
  * This class implements the following entities:
  * - tax: data from table tax_data/object_data
  * - tax_usage: data from table tax_usage
  * - tax_tree: data from a join on tax_tree and tax_node
  * - tax_node_assignment: data from table tax_node_assignment
- *
  * @author Alexander Killing <killing@leifos.de>
  */
 class ilTaxonomyDataSet extends ilDataSet
 {
     protected ilObjTaxonomy $current_obj;
 
-    /**
-     * @inheritDoc
-     */
     public function getSupportedVersions() : array
     {
         return array("4.3.0");
     }
-    
-    /**
-     * @inheritDoc
-     */
+
     protected function getXmlNamespace(string $a_entity, string $a_schema_version) : string
     {
         return "http://www.ilias.de/xml/Services/Taxonomy/" . $a_entity;
     }
-    
+
     /**
      * @inheritDoc
      */
@@ -46,18 +38,19 @@ class ilTaxonomyDataSet extends ilDataSet
                         "Id" => "integer",
                         "Title" => "text",
                         "Description" => "text",
-                        "SortingMode" => "integer");
+                        "SortingMode" => "integer"
+                    );
             }
         }
-    
+
         // tax_usage
         if ($a_entity == "tax_usage") {
             switch ($a_version) {
                 case "4.3.0":
-                        return array(
-                            "TaxId" => "integer",
-                            "ObjId" => "integer"
-                        );
+                    return array(
+                        "TaxId" => "integer",
+                        "ObjId" => "integer"
+                    );
             }
         }
 
@@ -65,15 +58,15 @@ class ilTaxonomyDataSet extends ilDataSet
         if ($a_entity == "tax_tree") {
             switch ($a_version) {
                 case "4.3.0":
-                        return array(
-                            "TaxId" => "integer",
-                            "Child" => "integer",
-                            "Parent" => "integer",
-                            "Depth" => "integer",
-                            "Type" => "text",
-                            "Title" => "text",
-                            "OrderNr" => "integer"
-                        );
+                    return array(
+                        "TaxId" => "integer",
+                        "Child" => "integer",
+                        "Parent" => "integer",
+                        "Depth" => "integer",
+                        "Type" => "text",
+                        "Title" => "text",
+                        "OrderNr" => "integer"
+                    );
             }
         }
 
@@ -81,12 +74,12 @@ class ilTaxonomyDataSet extends ilDataSet
         if ($a_entity == "tax_node_assignment") {
             switch ($a_version) {
                 case "4.3.0":
-                        return array(
-                            "NodeId" => "integer",
-                            "Component" => "text",
-                            "ItemType" => "text",
-                            "ItemId" => "integer"
-                        );
+                    return array(
+                        "NodeId" => "integer",
+                        "Component" => "text",
+                        "ItemType" => "text",
+                        "ItemId" => "integer"
+                    );
             }
         }
         return [];
@@ -102,7 +95,7 @@ class ilTaxonomyDataSet extends ilDataSet
         if (!is_array($a_ids)) {
             $a_ids = array($a_ids);
         }
-                
+
         // tax
         if ($a_entity == "tax") {
             switch ($a_version) {
@@ -154,7 +147,7 @@ class ilTaxonomyDataSet extends ilDataSet
             }
         }
     }
-    
+
     /**
      * Determine the dependent sets of data
      */
@@ -177,12 +170,11 @@ class ilTaxonomyDataSet extends ilDataSet
         }
         return [];
     }
-    
+
     ////
     //// Needs abstraction (interface?) and version handling
     ////
-    
-    
+
     public function importRecord(
         string $a_entity,
         array $a_types,
@@ -197,9 +189,9 @@ class ilTaxonomyDataSet extends ilDataSet
 
                 $newObj->setTitle($a_rec["Title"]);
                 $newObj->setDescription($a_rec["Description"]);
-                $newObj->setSortingMode($a_rec["SortingMode"]);
+                $newObj->setSortingMode((int) $a_rec["SortingMode"]);
                 $newObj->update();
-                
+
                 $this->current_obj = $newObj;
                 $a_mapping->addMapping("Services/Taxonomy", "tax", $a_rec["Id"], $newObj->getId());
                 break;
@@ -214,10 +206,10 @@ class ilTaxonomyDataSet extends ilDataSet
                         }
                         $node = new ilTaxonomyNode();
                         $node->setTitle($a_rec["Title"]);
-                        $node->setOrderNr($a_rec["OrderNr"]);
-                        $node->setTaxonomyId($tax_id);
+                        $node->setOrderNr((int) $a_rec["OrderNr"]);
+                        $node->setTaxonomyId((int) $tax_id);
                         $node->create();
-                        ilTaxonomyNode::putInTree($tax_id, $node, (int) $parent, "", $a_rec["OrderNr"]);
+                        ilTaxonomyNode::putInTree((int) $tax_id, $node, (int) $parent, 0, (int) $a_rec["OrderNr"]);
                         $a_mapping->addMapping(
                             "Services/Taxonomy",
                             "tax_tree",
@@ -225,10 +217,10 @@ class ilTaxonomyDataSet extends ilDataSet
                             $node->getId()
                         );
                         break;
-                        
+
                 }
-                
-                // no break
+
+            // no break
             case "tax_node_assignment":
                 $new_item_id = (int) $a_mapping->getMapping(
                     "Services/Taxonomy",
@@ -245,11 +237,16 @@ class ilTaxonomyDataSet extends ilDataSet
                     $a_rec["Component"] . ":" . $a_rec["ItemType"] . ":" . $a_rec["ItemId"]
                 );
                 if ($new_item_id > 0 && $new_node_id > 0 && $new_item_id_obj > 0) {
-                    $node_ass = new ilTaxNodeAssignment($a_rec["Component"], $new_item_id_obj, $a_rec["ItemType"], $this->current_obj->getId());
+                    $node_ass = new ilTaxNodeAssignment(
+                        $a_rec["Component"],
+                        $new_item_id_obj,
+                        $a_rec["ItemType"],
+                        $this->current_obj->getId()
+                    );
                     $node_ass->addAssignment($new_node_id, $new_item_id);
                 }
                 break;
-                
+
             case "tax_usage":
                 $usage = $a_mapping->getMapping("Services/Taxonomy", "tax_usage_of_obj", $a_rec["ObjId"]);
                 if ($usage != "") {

--- a/Services/Taxonomy/classes/class.ilTaxonomyExplorerGUI.php
+++ b/Services/Taxonomy/classes/class.ilTaxonomyExplorerGUI.php
@@ -4,7 +4,6 @@
 
 /**
  * Taxonomy explorer GUI class
- *
  * @author Alex Killing <alex.killing@gmx.de>
  */
 class ilTaxonomyExplorerGUI extends ilTreeExplorerGUI
@@ -30,7 +29,7 @@ class ilTaxonomyExplorerGUI extends ilTreeExplorerGUI
     ) {
         global $DIC;
         $this->ctrl = $DIC->ctrl();
-        $this->tax_tree = new ilTaxonomyTree($a_tax_id);
+        $this->tax_tree = new ilTaxonomyTree((int) $a_tax_id);
         $this->id = $a_id != "" ? $a_id : "tax_expl_" . $this->tax_tree->getTreeId();
         if (ilObjTaxonomy::lookupSortingMode($a_tax_id) == ilObjTaxonomy::SORT_ALPHABETICAL) {
             $this->setOrderField("title");
@@ -45,8 +44,7 @@ class ilTaxonomyExplorerGUI extends ilTreeExplorerGUI
         $this->requested_tax_node = (string) ilUtil::stripSlashes($tax_node);
         parent::__construct($this->id, $a_parent_obj, $a_parent_cmd, $this->tax_tree);
     }
-    
-    
+
     /**
      * @inheritDoc
      */
@@ -59,9 +57,11 @@ class ilTaxonomyExplorerGUI extends ilTreeExplorerGUI
             return $a_node["title"];
         }
     }
-    
+
     /**
-     * @inheritDoc
+     * @param array|object $a_node
+     * @return string
+     * @throws ilCtrlException
      */
     public function getNodeHref($a_node) : string
     {
@@ -84,17 +84,19 @@ class ilTaxonomyExplorerGUI extends ilTreeExplorerGUI
             return "#";
         }
     }
-    
+
     /**
-     * @inheritDoc
+     * @param array|object $a_node
+     * @return string
      */
     public function getNodeIcon($a_node) : string
     {
         return ilUtil::getImagePath("icon_taxn.svg");
     }
-    
+
     /**
-     * @inheritDoc
+     * @param array|object $a_node
+     * @return bool
      */
     public function isNodeHighlighted($a_node) : bool
     {
@@ -102,16 +104,14 @@ class ilTaxonomyExplorerGUI extends ilTreeExplorerGUI
             ($this->onclick && is_array($this->selected_nodes) && in_array($a_node["child"], $this->selected_nodes));
     }
 
-    /**
-     * @inheritDoc
-     */
     public function setOnClick(string $a_value) : void
     {
         $this->onclick = $a_value;
     }
 
     /**
-     * @inheritDoc
+     * @param array|object $a_node
+     * @return string
      */
     public function getNodeOnClick($a_node) : string
     {

--- a/Services/Taxonomy/classes/class.ilTaxonomyExporter.php
+++ b/Services/Taxonomy/classes/class.ilTaxonomyExporter.php
@@ -4,12 +4,11 @@
 
 /**
  * Export class for taxonomies
- *
  * @author Alexander Killing <killing@leifos.de>
  */
 class ilTaxonomyExporter extends ilXmlExporter
 {
-    private ?\ilTaxonomyDataSet $ds = null;
+    private ?ilTaxonomyDataSet $ds = null;
 
     /**
      * Initialisation
@@ -23,22 +22,21 @@ class ilTaxonomyExporter extends ilXmlExporter
 
     /**
      * Get head dependencies
-     * @param		string		entity
-     * @param		string		target release
-     * @param		array		ids
-     * @return		array		array of array with keys "component", entity", "ids"
+     * @param string        entity
+     * @param string        target release
+     * @param array        ids
+     * @return        array        array of array with keys "component", entity", "ids"
      */
     public function getXmlExportHeadDependencies(string $a_entity, string $a_target_release, array $a_ids) : array
     {
         return array();
     }
 
-
     /**
      * Get tail dependencies
-     * @param		string		entity
-     * @param		string		target release
-     * @param		array		ids
+     * @param string        entity
+     * @param string        target release
+     * @param array        ids
      * @return        array        array of array with keys "component", entity", "ids"
      */
     public function getXmlExportTailDependencies(string $a_entity, string $a_target_release, array $a_ids) : array
@@ -48,10 +46,10 @@ class ilTaxonomyExporter extends ilXmlExporter
 
     /**
      * Get xml representation
-     * @param	string		entity
-     * @param	string		schema version
-     * @param	string		id
-     * @return	string		xml string
+     * @param string        entity
+     * @param string        schema version
+     * @param string        id
+     * @return    string        xml string
      */
     public function getXmlRepresentation(string $a_entity, string $a_schema_version, string $a_id) : string
     {
@@ -62,6 +60,7 @@ class ilTaxonomyExporter extends ilXmlExporter
      * Returns schema versions that the component can export to.
      * ILIAS chooses the first one, that has min/max constraints which
      * fit to the target release. Please put the newest on top.
+     * @param string $a_entity
      * @return array
      */
     public function getValidSchemaVersions(string $a_entity) : array
@@ -72,7 +71,8 @@ class ilTaxonomyExporter extends ilXmlExporter
                 "xsd_file" => "ilias_tax_4_3.xsd",
                 "uses_dataset" => true,
                 "min" => "4.3.0",
-                "max" => "")
+                "max" => ""
+            )
         );
     }
 }

--- a/Services/Taxonomy/classes/class.ilTaxonomyImporter.php
+++ b/Services/Taxonomy/classes/class.ilTaxonomyImporter.php
@@ -4,7 +4,6 @@
 
 /**
  * Importer class for taxonomies
- *
  * @author Alexander Killing <killing@leifos.de>
  */
 class ilTaxonomyImporter extends ilXmlImporter
@@ -20,12 +19,12 @@ class ilTaxonomyImporter extends ilXmlImporter
         $this->ds->setDSPrefix("ds");
     }
 
-
-    /**
-     * @inheritDoc
-     */
-    public function importXmlRepresentation(string $a_entity, string $a_id, string $a_xml, ilImportMapping $a_mapping) : void
-    {
+    public function importXmlRepresentation(
+        string $a_entity,
+        string $a_id,
+        string $a_xml,
+        ilImportMapping $a_mapping
+    ) : void {
         $parser = new ilDataSetImportParser(
             $a_entity,
             $this->getSchemaVersion(),

--- a/Services/Taxonomy/classes/class.ilTaxonomyListTableGUI.php
+++ b/Services/Taxonomy/classes/class.ilTaxonomyListTableGUI.php
@@ -4,12 +4,11 @@
 
 /**
  * TableGUI class for taxonomy list
- *
  * @author Alexander Killing <killing@leifos.de>
  */
 class ilTaxonomyListTableGUI extends ilTable2GUI
 {
-    protected \ilAccessHandler $access;
+    protected ilAccessHandler $access;
     protected int $requested_tax_id;
     protected int $assigned_object_id;
 
@@ -25,10 +24,10 @@ class ilTaxonomyListTableGUI extends ilTable2GUI
         $this->access = $DIC->access();
         $ilCtrl = $DIC->ctrl();
         $lng = $DIC->language();
-        
+
         parent::__construct($a_parent_obj, $a_parent_cmd);
         $this->assigned_object_id = $a_assigned_object_id;
-        
+
         $this->setData(ilObjTaxonomy::getUsageOfObject($this->assigned_object_id, true));
         $this->setTitle($lng->txt("obj_taxf"));
         $this->setDescription($a_info);
@@ -36,17 +35,17 @@ class ilTaxonomyListTableGUI extends ilTable2GUI
         $this->addColumn($this->lng->txt("title"), "title");
         $this->addColumn($this->lng->txt("description"));
         $this->addColumn($this->lng->txt("actions"));
-        
+
         $this->setDefaultOrderField("title");
         $this->setDefaultOrderDirection("asc");
-        
+
         $this->setFormAction($ilCtrl->getFormAction($a_parent_obj));
         $this->setRowTemplate("tpl.taxonomy_list_row.html", "Services/Taxonomy");
 
-        $params = $DIC->http()->request()->getQueryParams();
+        $params = $DIC->http()->request()->getQueryParams();  // TODO PHP8-REVIEW: Please use http()->wrapper()
         $this->requested_tax_id = (int) ($params["tax_id"] ?? null);
     }
-    
+
     /**
      * @inheritDoc
      */

--- a/Services/Taxonomy/classes/class.ilTaxonomyNode.php
+++ b/Services/Taxonomy/classes/class.ilTaxonomyNode.php
@@ -4,12 +4,11 @@
 
 /**
  * Taxonomy node
- *
  * @author Alexander Killing <killing@leifos.de>
  */
 class ilTaxonomyNode
 {
-    protected \ilDBInterface $db;
+    protected ilDBInterface $db;
     public string $type;
     public int $id;
     public string $title;
@@ -18,7 +17,7 @@ class ilTaxonomyNode
 
     /**
      * Constructor
-     * @access	public
+     * @access    public
      */
     public function __construct($a_id = 0)
     {
@@ -26,7 +25,7 @@ class ilTaxonomyNode
 
         $this->db = $DIC->database();
         $this->id = $a_id;
-        
+
         if ($a_id != 0) {
             $this->read();
         }
@@ -34,7 +33,7 @@ class ilTaxonomyNode
         $this->setType("taxn");
     }
 
-    public function setTitle(string $a_title)
+    public function setTitle(string $a_title) : void
     {
         $this->title = $a_title;
     }
@@ -44,7 +43,7 @@ class ilTaxonomyNode
         return $this->title;
     }
 
-    public function setType(string $a_type)
+    public function setType(string $a_type) : void
     {
         $this->type = $a_type;
     }
@@ -54,7 +53,7 @@ class ilTaxonomyNode
         return $this->type;
     }
 
-    public function setId(int $a_id)
+    public function setId(int $a_id) : void
     {
         $this->id = $a_id;
     }
@@ -64,26 +63,26 @@ class ilTaxonomyNode
         return $this->id;
     }
 
-    public function setOrderNr(int $a_val)
+    public function setOrderNr(int $a_val) : void
     {
         $this->order_nr = $a_val;
     }
-    
+
     public function getOrderNr() : int
     {
         return $this->order_nr;
     }
 
-    public function setTaxonomyId(int $a_val)
+    public function setTaxonomyId(int $a_val) : void
     {
         $this->taxonomy_id = $a_val;
     }
-    
+
     public function getTaxonomyId() : int
     {
         return $this->taxonomy_id;
     }
-    
+
     public function read() : void
     {
         $ilDB = $this->db;
@@ -96,14 +95,14 @@ class ilTaxonomyNode
         }
         $this->setType($this->data_record["type"]);
         $this->setTitle($this->data_record["title"]);
-        $this->setOrderNr($this->data_record["order_nr"]);
-        $this->setTaxonomyId($this->data_record["tax_id"]);
+        $this->setOrderNr((int) $this->data_record["order_nr"]);
+        $this->setTaxonomyId((int) $this->data_record["tax_id"]);
     }
 
     public function create() : void
     {
         $ilDB = $this->db;
-        
+
         if ($this->getTaxonomyId() <= 0) {
             die("ilTaxonomyNode->create: No taxonomy ID given");
         }
@@ -138,16 +137,16 @@ class ilTaxonomyNode
     public function delete() : void
     {
         $ilDB = $this->db;
-        
+
         // delete all assignments of the node
         ilTaxNodeAssignment::deleteAllAssignmentsOfNode($this->getId());
-        
+
         $query = "DELETE FROM tax_node WHERE obj_id= " .
             $ilDB->quote($this->getId(), "integer");
         $ilDB->manipulate($query);
     }
 
-    public function copy(int $a_tax_id = 0) : \ilTaxonomyNode
+    public function copy(int $a_tax_id = 0) : ilTaxonomyNode
     {
         $taxn = new ilTaxonomyNode();
         $taxn->setTitle($this->getTitle());
@@ -180,20 +179,16 @@ class ilTaxonomyNode
 
     public static function _lookupTitle(int $a_obj_id) : string
     {
-        global $DIC;
-
-        $ilDB = $DIC->database();
-
         return self::_lookup($a_obj_id, "title");
     }
 
     public static function putInTree(
         int $a_tax_id,
-        int $a_node,
+        ilTaxonomyNode $a_node,
         int $a_parent_id = 0,
         int $a_target_node_id = 0,
         int $a_order_nr = 0
-    ) {
+    ) : void {
         $tax_tree = new ilTaxonomyTree($a_tax_id);
 
         // determine parent
@@ -226,14 +221,14 @@ class ilTaxonomyNode
         global $DIC;
 
         $ilDB = $DIC->database();
-        
+
         $ilDB->manipulate(
             "UPDATE tax_node SET " .
             " order_nr = " . $ilDB->quote($a_order_nr, "integer") .
             " WHERE obj_id = " . $ilDB->quote($a_node_id, "integer")
         );
     }
-    
+
     /**
      * Write title
      */
@@ -242,18 +237,18 @@ class ilTaxonomyNode
         global $DIC;
 
         $ilDB = $DIC->database();
-        
+
         $ilDB->manipulate(
             "UPDATE tax_node SET " .
             " title = " . $ilDB->quote($a_title, "text") .
             " WHERE obj_id = " . $ilDB->quote($a_node_id, "integer")
         );
     }
-    
+
     /**
      * Put this node into the taxonomy tree
      */
-    public static function getNextOrderNr(int $a_tax_id, int $a_parent_id)
+    public static function getNextOrderNr(int $a_tax_id, int $a_parent_id) : int
     {
         $tax_tree = new ilTaxonomyTree($a_tax_id);
         if ($a_parent_id == 0) {
@@ -263,14 +258,14 @@ class ilTaxonomyNode
         $max = 0;
 
         foreach ($childs as $c) {
-            if ($c["order_nr"] > $max) {
-                $max = $c["order_nr"] + 10;
+            if ((int) $c["order_nr"] > $max) {
+                $max = (int) $c["order_nr"] + 10;
             }
         }
 
         return $max;
     }
-    
+
     // set order nrs to 10, 20, ...
     public static function fixOrderNumbers(int $a_tax_id, int $a_parent_id) : void
     {
@@ -283,7 +278,7 @@ class ilTaxonomyNode
 
         $cnt = 10;
         foreach ($childs as $c) {
-            self::writeOrderNr($c["child"], $cnt);
+            self::writeOrderNr((int) $c["child"], $cnt);
             $cnt += 10;
         }
     }

--- a/Services/Taxonomy/classes/class.ilTaxonomyTableGUI.php
+++ b/Services/Taxonomy/classes/class.ilTaxonomyTableGUI.php
@@ -4,7 +4,6 @@
 
 /**
  * TableGUI class for taxonomies
- *
  * @author Alexander Killing <killing@leifos.de>
  */
 class ilTaxonomyTableGUI extends ilTable2GUI
@@ -31,37 +30,37 @@ class ilTaxonomyTableGUI extends ilTable2GUI
         $this->lng = $DIC->language();
         $this->access = $DIC->access();
 
-        $params = $DIC->http()->request()->getQueryParams();
+        $params = $DIC->http()->request()->getQueryParams();  // TODO PHP8-REVIEW: Please user http()->wrapper()
 
         $this->requested_tax_node = $params["tax_node"] ?? "";
 
         $ilCtrl = $DIC->ctrl();
         $lng = $DIC->language();
-        
+
         if ($a_node_id == "") {
             $a_node_id = $a_tree->readRootId();
         }
-        
+
         $this->tree = $a_tree;
         $this->tax = $a_tax;
         $this->node_id = $a_node_id;
 
         parent::__construct($a_parent_obj, $a_parent_cmd);
-        
+
         $childs = $this->tree->getChildsByTypeFilter(
             $a_node_id,
             array("taxn")
         );
-        
+
         if ($a_tax->getSortingMode() == ilObjTaxonomy::SORT_MANUAL) {
             $childs = ilArrayUtil::sortArray($childs, "order_nr", "asc", false);
         } else {
             $childs = ilArrayUtil::sortArray($childs, "title", "asc", false);
         }
         $this->setData($childs);
-        
+
         $this->setTitle($lng->txt("tax_nodes"));
-        
+
         $this->addColumn($this->lng->txt(""), "", "1px", true);
         if ($this->tax->getSortingMode() == ilObjTaxonomy::SORT_MANUAL) {
             $this->addColumn($this->lng->txt("tax_order"), "order_nr", "1px");
@@ -69,7 +68,7 @@ class ilTaxonomyTableGUI extends ilTable2GUI
             $this->setDefaultOrderDirection("asc");
         }
         $this->addColumn($this->lng->txt("title"));
-        
+
         $this->setFormAction($ilCtrl->getFormAction($a_parent_obj));
         $this->setRowTemplate("tpl.tax_row.html", "Services/Taxonomy");
 
@@ -77,22 +76,15 @@ class ilTaxonomyTableGUI extends ilTable2GUI
         $this->addMultiCommand("moveItems", $lng->txt("move"));
         $this->addCommandButton("saveSorting", $lng->txt("save"));
     }
-    
-        
-    /**
-     * @inheritDoc
-     */
+
     public function numericOrdering(string $a_field) : bool
     {
-        if (in_array($a_field, array("order_nr"))) {
+        if ($a_field == "order_nr") {
             return true;
         }
         return false;
     }
-    
-    /**
-     * @inheritDoc
-     */
+
     protected function fillRow(array $a_set) : void
     {
         $ilCtrl = $this->ctrl;
@@ -108,7 +100,7 @@ class ilTaxonomyTableGUI extends ilTable2GUI
         }
 
         $this->tpl->setVariable("HREF_TITLE", $ret);
-        
+
         $this->tpl->setVariable("TITLE", ilLegacyFormElementsUtil::prepareFormOutput($a_set["title"]));
         $this->tpl->setVariable("NODE_ID", $a_set["child"]);
     }

--- a/Services/Taxonomy/classes/class.ilTaxonomyTree.php
+++ b/Services/Taxonomy/classes/class.ilTaxonomyTree.php
@@ -4,12 +4,11 @@
 
 /**
  * Taxonomy tree
- *
  * @author Alexander Killing <killing@leifos.de>
  */
 class ilTaxonomyTree extends ilTree
 {
-    public function __construct($a_id)
+    public function __construct(int $a_id)
     {
         parent::__construct($a_id);
         $this->setTreeTablePK("tax_tree_id");

--- a/Services/Taxonomy/exceptions/class.ilTaxonomyException.php
+++ b/Services/Taxonomy/exceptions/class.ilTaxonomyException.php
@@ -4,7 +4,6 @@
 
 /**
  * Class for advanced editing exception handling in ILIAS.
- *
  * @author Michael Jansen <mjansen@databay.de>
  */
 class ilTaxonomyException extends ilException

--- a/Services/Taxonomy/interfaces/interface.ilTaxAssignedItemInfo.php
+++ b/Services/Taxonomy/interfaces/interface.ilTaxAssignedItemInfo.php
@@ -4,17 +4,15 @@
 
 /**
  * Interface for assigned items of taxonomies
- *
  * @author Alexander Killing <killing@leifos.de>
  */
 interface ilTaxAssignedItemInfo
 {
     /**
      * Get title of an assigned item
-     *
-     * @param string $a_comp_id component identifier, e.g. "glo" for glossary
+     * @param string $a_comp_id   component identifier, e.g. "glo" for glossary
      * @param string $a_item_type item type identifier, e.g. "term" for glossary terms
-     * @param int $a_item_id item id
+     * @param int    $a_item_id   item id
      * @return string
      */
     public function getTitle(string $a_comp_id, string $a_item_type, int $a_item_id) : string;

--- a/Services/Taxonomy/test/Assignment/TaxAssignmentTest.php
+++ b/Services/Taxonomy/test/Assignment/TaxAssignmentTest.php
@@ -4,7 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Test peer reviews
- *
  * @author Alexander Killing <killing@leifos.de>
  */
 class TaxAssignmentTest extends TestCase
@@ -23,7 +22,7 @@ class TaxAssignmentTest extends TestCase
     /**
      * Test if each rater has $num_assignments peers
      */
-    public function testNewTaxAssignment()
+    public function testNewTaxAssignment() : void
     {
         $database = $this->getMockBuilder(ilDBInterface::class)->getMock();
 

--- a/Services/Taxonomy/test/ilServicesTaxonomySuite.php
+++ b/Services/Taxonomy/test/ilServicesTaxonomySuite.php
@@ -11,7 +11,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilServicesTaxonomySuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : ilServicesTaxonomySuite
     {
         $suite = new self();
 


### PR DESCRIPTION
Dear @alex40724,

I completed the review of the `Services/Taxonomy` component.

Results:

- [ ] The code style is `PSR-2 + X` compliant
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [ ] External libraries are compatible with PHP 8 (if relevant)
- [ ] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

Best regards,
Nadia