### PR TITLE
PHP8: Code Review `Badges`

### DIFF
--- a/Services/Badge/classes/class.ilBadgeGUIRequest.php
+++ b/Services/Badge/classes/class.ilBadgeGUIRequest.php
@@ -31,7 +31,7 @@ class ilBadgeGUIRequest
         );
     }
 
-    protected function initRequest(
+    protected function initRequest(// @TODO: PHP8 Review: Missing return type.
         HTTP\Services $http,
         Refinery\Factory $refinery
     ) {
@@ -40,31 +40,31 @@ class ilBadgeGUIRequest
     }
 
     // get string parameter kindly
-    protected function str($key) : string
+    protected function str($key) : string// @TODO: PHP8 Review: Missing parameter type.
     {
         $t = $this->refinery->kindlyTo()->string();
         return \ilUtil::stripSlashes((string) ($this->get($key, $t) ?? ""));
     }
 
     // get integer parameter kindly
-    protected function int($key) : int
+    protected function int($key) : int// @TODO: PHP8 Review: Missing parameter type.
     {
         $t = $this->refinery->kindlyTo()->int();
         return (int) ($this->get($key, $t) ?? 0);
     }
 
     // get integer array kindly
-    protected function intArray($key) : array
+    protected function intArray($key) : array// @TODO: PHP8 Review: Missing parameter type.
     {
         if (!$this->isArray($key)) {
             return [];
         }
         $t = $this->refinery->custom()->transformation(
-            function ($arr) {
+            static function (array $arr) : array {
                 // keep keys(!), transform all values to int
                 return array_column(
                     array_map(
-                        function ($k, $v) {
+                        static function ($k, $v) : array {
                             return [$k, (int) $v];
                         },
                         array_keys($arr),

--- a/Services/Badge/classes/class.ilBadgeUserTableGUI.php
+++ b/Services/Badge/classes/class.ilBadgeUserTableGUI.php
@@ -113,7 +113,7 @@ class ilBadgeUserTableGUI extends ilTable2GUI
         $this->filter["name"] = $name->getValue();
     }
     
-    public function getItems($a_parent_ref_id, ilBadge $a_award_bagde = null, $a_parent_obj_id = null, $a_restrict_badge_id = null)
+    public function getItems($a_parent_ref_id, ilBadge $a_award_bagde = null, $a_parent_obj_id = null, $a_restrict_badge_id = null)// @TODO: PHP8 Review: Missing return type.// @TODO: PHP8 Review: Missing parameter type.
     {
         $tree = $this->tree;
         $user_ids = null;

--- a/Services/Badge/classes/class.ilFSStorageBadge.php
+++ b/Services/Badge/classes/class.ilFSStorageBadge.php
@@ -23,12 +23,12 @@ class ilFSStorageBadge extends ilFileSystemAbstractionStorage
         parent::__construct(self::STORAGE_SECURED, true, $a_container_id);
     }
 
-    protected function getPathPostfix():string
+    protected function getPathPostfix() : string
     {
         return 'badge';
     }
 
-    protected function getPathPrefix():string
+    protected function getPathPrefix() : string
     {
         return 'ilBadge';
     }

--- a/Services/Badge/classes/class.ilFSStorageBadgeImageTemplate.php
+++ b/Services/Badge/classes/class.ilFSStorageBadgeImageTemplate.php
@@ -23,12 +23,12 @@ class ilFSStorageBadgeImageTemplate extends ilFileSystemAbstractionStorage
         parent::__construct(self::STORAGE_SECURED, true, $a_container_id);
     }
 
-    protected function getPathPostfix():string
+    protected function getPathPostfix() : string
     {
         return 'badgetmpl';
     }
 
-    protected function getPathPrefix():string
+    protected function getPathPrefix() : string
     {
         return 'ilBadge';
     }

--- a/Services/Badge/classes/class.ilObjBadgeAdministrationGUI.php
+++ b/Services/Badge/classes/class.ilObjBadgeAdministrationGUI.php
@@ -33,7 +33,7 @@ class ilObjBadgeAdministrationGUI extends ilObjectGUI
     ) {
         global $DIC;
 
-        $this->rbacsystem = $DIC->rbac()->system();
+        $this->rbacsystem = $DIC->rbac()->system();// @TODO PHP8 Review: Missing property.
         $this->ctrl = $DIC->ctrl();
         $this->access = $DIC->access();
         $this->lng = $DIC->language();

--- a/Services/Badge/lib/baker.lib.php
+++ b/Services/Badge/lib/baker.lib.php
@@ -6,9 +6,9 @@
  */
 class PNGImageBaker
 {
-    private $_contents;
-    private $_size;
-    private $_chunks;
+    private $_contents;// @TODO: PHP8 Review: Missing property type.
+    private $_size;// @TODO: PHP8 Review: Missing property type.
+    private $_chunks;// @TODO: PHP8 Review: Missing property type.
     
     /**
      * Prepares file for handling metadata.

--- a/Services/Badge/lib/baker.lib.php
+++ b/Services/Badge/lib/baker.lib.php
@@ -6,9 +6,9 @@
  */
 class PNGImageBaker
 {
-    private $_contents;// @TODO: PHP8 Review: Missing property type.
-    private $_size;// @TODO: PHP8 Review: Missing property type.
-    private $_chunks;// @TODO: PHP8 Review: Missing property type.
+    private $_contents;
+    private $_size;
+    private $_chunks;
     
     /**
      * Prepares file for handling metadata.

--- a/Services/Badge/test/BadgeManagementSessionRepositoryTest.php
+++ b/Services/Badge/test/BadgeManagementSessionRepositoryTest.php
@@ -20,7 +20,7 @@ class BadgeManagementSessionRepositoryTest extends TestCase
     {
     }
 
-    public function testClear()
+    public function testClear()// @TODO: PHP8 Review: Missing return type.
     {
         $repo = $this->repo;
         $repo->setBadgeIds([1,3,4]);
@@ -31,7 +31,7 @@ class BadgeManagementSessionRepositoryTest extends TestCase
         );
     }
 
-    public function testBadgeIds()
+    public function testBadgeIds()// @TODO: PHP8 Review: Missing return type.
     {
         $repo = $this->repo;
         $repo->setBadgeIds([1,6,7]);

--- a/Services/Badge/test/ilServicesBadgeSuite.php
+++ b/Services/Badge/test/ilServicesBadgeSuite.php
@@ -22,7 +22,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilServicesBadgeSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite()// @TODO: PHP8 Review: Missing return type.
     {
         $suite = new self();
 


### PR DESCRIPTION
Hi @alex40724,

here are the results of the `Services/Badge` review.

### Results
- [ ] The code style is `PSR-2 + X` compliant
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [ ] The types are fully documented (PHPDoc) or explict PHP types are used (type hints, return types, typed properties)

### Changes made in this PR:
- Added `// @TODO: PHP8 Review: Missing return type.`
- Added `// @TODO: PHP8 Review: Missing parameter type.`
- Added `// @TODO PHP8 Review: Missing property.`
- Added `// @TODO: PHP8 Review: Missing property type.`
- Changed some anonymous functions to static.
- Fix `PSR 2 + X`

Do you see any possibility to move the library `Services/Badge/libs/baker.lib.php` to our composer dependencies?

Best regards,
@lscharmer  