### PR TITLE
PHP8: Code Review `Services/FileDelivery`

### DIFF
--- a/Services/FileDelivery/classes/Delivery.php
+++ b/Services/FileDelivery/classes/Delivery.php
@@ -76,7 +76,7 @@ final class Delivery
     }
 
 
-    public function stream(): void
+    public function stream() : void
     {
         if (!$this->delivery()->supportsStreaming()) {
             $this->setDeliveryType(DeliveryMethod::PHP_CHUNKED);
@@ -85,13 +85,13 @@ final class Delivery
     }
 
 
-    private function delivery(): ilFileDeliveryType
+    private function delivery() : ilFileDeliveryType
     {
         return $this->factory->getInstance($this->getDeliveryType());
     }
 
 
-    public function deliver(): void
+    public function deliver() : void
     {
         $response = $this->http->response()->withHeader('X-ILIAS-FileDelivery-Method', $this->getDeliveryType());
         if (
@@ -119,7 +119,7 @@ final class Delivery
     }
 
 
-    public function setGeneralHeaders(): void
+    public function setGeneralHeaders() : void
     {
         $this->checkExisting();
         if ($this->isSendMimeType()) {
@@ -146,7 +146,7 @@ final class Delivery
     }
 
 
-    public function setCachingHeaders(): void
+    public function setCachingHeaders() : void
     {
         $response = $this->http->response()->withHeader(ResponseHeader::CACHE_CONTROL, 'must-revalidate, post-check=0, pre-check=0')->withHeader(ResponseHeader::PRAGMA, 'public');
 
@@ -156,19 +156,19 @@ final class Delivery
     }
 
 
-    public function generateEtag(): void
+    public function generateEtag() : void
     {
         $this->setEtag(md5(filemtime($this->getPathToFile()) . filesize($this->getPathToFile())));
     }
 
 
-    public function close(): void
+    public function close() : void
     {
         $this->http->close();
     }
 
 
-    private function determineMimeType(): void
+    private function determineMimeType() : void
     {
         $info = \ILIAS\FileUpload\MimeType::lookupMimeType($this->getPathToFile(), \ILIAS\FileUpload\MimeType::APPLICATION__OCTET_STREAM);
         if ($info) {
@@ -187,7 +187,7 @@ final class Delivery
     }
 
 
-    private function determineDownloadFileName(): void
+    private function determineDownloadFileName() : void
     {
         if (!$this->getDownloadFileName()) {
             $download_file_name = basename($this->getPathToFile());
@@ -196,7 +196,7 @@ final class Delivery
     }
 
 
-    private function detemineDeliveryType(): void
+    private function detemineDeliveryType() : void
     {
         if (self::$delivery_type_static) {
             $this->setDeliveryType(self::$delivery_type_static);
@@ -235,163 +235,163 @@ final class Delivery
     }
 
 
-    public function getDeliveryType(): string
+    public function getDeliveryType() : string
     {
         return $this->delivery_type;
     }
 
 
-    public function setDeliveryType(string $delivery_type): void
+    public function setDeliveryType(string $delivery_type) : void
     {
         $this->delivery_type = $delivery_type;
     }
 
 
-    public function getMimeType(): string
+    public function getMimeType() : string
     {
         return $this->mime_type;
     }
 
 
-    public function setMimeType(string $mime_type): void
+    public function setMimeType(string $mime_type) : void
     {
         $this->mime_type = $mime_type;
     }
 
 
-    public function getPathToFile(): string
+    public function getPathToFile() : string
     {
         return $this->path_to_file;
     }
 
 
-    public function setPathToFile(string $path_to_file): void
+    public function setPathToFile(string $path_to_file) : void
     {
         $this->path_to_file = $path_to_file;
     }
 
 
-    public function getDownloadFileName(): string
+    public function getDownloadFileName() : string
     {
         return $this->download_file_name;
     }
 
 
-    public function setDownloadFileName(string $download_file_name): void
+    public function setDownloadFileName(string $download_file_name) : void
     {
         $this->download_file_name = $download_file_name;
     }
 
 
-    public function getDisposition(): string
+    public function getDisposition() : string
     {
         return $this->disposition;
     }
 
 
-    public function setDisposition(string $disposition): void
+    public function setDisposition(string $disposition) : void
     {
         $this->disposition = $disposition;
     }
 
 
-    public function isSendMimeType(): bool
+    public function isSendMimeType() : bool
     {
         return $this->send_mime_type;
     }
 
 
-    public function setSendMimeType(bool $send_mime_type): void
+    public function setSendMimeType(bool $send_mime_type) : void
     {
         $this->send_mime_type = $send_mime_type;
     }
 
 
-    public function isExitAfter(): bool
+    public function isExitAfter() : bool
     {
         return $this->exit_after;
     }
 
 
-    public function setExitAfter(bool $exit_after): void
+    public function setExitAfter(bool $exit_after) : void
     {
         $this->exit_after = $exit_after;
     }
 
 
-    public function isConvertFileNameToAsci(): bool
+    public function isConvertFileNameToAsci() : bool
     {
         return $this->convert_file_name_to_asci;
     }
 
 
-    public function setConvertFileNameToAsci(bool $convert_file_name_to_asci): void
+    public function setConvertFileNameToAsci(bool $convert_file_name_to_asci) : void
     {
         $this->convert_file_name_to_asci = $convert_file_name_to_asci;
     }
 
 
-    public function getEtag(): string
+    public function getEtag() : string
     {
         return $this->etag;
     }
 
 
-    public function setEtag(string $etag): void
+    public function setEtag(string $etag) : void
     {
         $this->etag = $etag;
     }
 
 
-    public function getShowLastModified(): bool
+    public function getShowLastModified() : bool
     {
         return $this->show_last_modified;
     }
 
 
-    public function setShowLastModified(bool $show_last_modified): void
+    public function setShowLastModified(bool $show_last_modified) : void
     {
         $this->show_last_modified = $show_last_modified;
     }
 
 
-    public function isHasContext(): bool
+    public function isHasContext() : bool
     {
         return $this->has_context;
     }
 
 
-    public function setHasContext(bool $has_context): void
+    public function setHasContext(bool $has_context) : void
     {
         $this->has_context = $has_context;
     }
 
 
-    public function hasCache(): bool
+    public function hasCache() : bool
     {
         return $this->cache;
     }
 
 
-    public function setCache(bool $cache): void
+    public function setCache(bool $cache) : void
     {
         $this->cache = $cache;
     }
 
 
-    public function hasHashFilename(): bool
+    public function hasHashFilename() : bool
     {
         return $this->hash_filename;
     }
 
 
-    public function setHashFilename(bool $hash_filename): void
+    public function setHashFilename(bool $hash_filename) : void
     {
         $this->hash_filename = $hash_filename;
     }
 
 
-    private function sendEtagHeader(): void
+    private function sendEtagHeader() : void
     {
         if ($this->getEtag()) {
             $response = $this->http->response()->withHeader('ETag', $this->getEtag());
@@ -400,7 +400,7 @@ final class Delivery
     }
 
 
-    private function sendLastModified(): void
+    private function sendLastModified() : void
     {
         if ($this->getShowLastModified()) {
             $response = $this->http->response()->withHeader(
@@ -412,20 +412,20 @@ final class Delivery
         }
     }
 
-    public static function isDEBUG(): bool
+    public static function isDEBUG() : bool
     {
         return (bool) self::$DEBUG;
     }
 
 
-    public static function setDEBUG(bool $DEBUG): void
+    public static function setDEBUG(bool $DEBUG) : void
     {
         assert(is_bool($DEBUG));
         self::$DEBUG = $DEBUG;
     }
 
 
-    public function checkCache(): void
+    public function checkCache() : void
     {
         if ($this->hasCache()) {
             $this->generateEtag();
@@ -455,7 +455,7 @@ final class Delivery
     }
 
 
-    private function checkExisting(): void
+    private function checkExisting() : void
     {
         if ($this->getPathToFile() != self::DIRECT_PHP_OUTPUT
             && !file_exists($this->getPathToFile())
@@ -468,7 +468,7 @@ final class Delivery
     /**
      * Converts the filename to ASCII
      */
-    private function cleanDownloadFileName(): void
+    private function cleanDownloadFileName() : void
     {
         $download_file_name = self::returnASCIIFileName($this->getDownloadFileName());
         $this->setDownloadFileName($download_file_name);
@@ -482,7 +482,7 @@ final class Delivery
      *
      * @return string ASCII-Filename
      */
-    public static function returnASCIIFileName($original_filename): string
+    public static function returnASCIIFileName($original_filename) : string
     {
         // The filename must be converted to ASCII, as of RFC 2183,
         // section 2.3.
@@ -528,20 +528,20 @@ final class Delivery
     }
 
 
-    public function isDeleteFile(): bool
+    public function isDeleteFile() : bool
     {
         return (bool) $this->delete_file;
     }
 
 
-    public function setDeleteFile(bool $delete_file): void
+    public function setDeleteFile(bool $delete_file) : void
     {
         assert(is_bool($delete_file));
         $this->delete_file = $delete_file;
     }
 
 
-    private function setDispositionHeaders(): void
+    private function setDispositionHeaders() : void
     {
         $response = $this->http->response();
         $response = $response->withHeader(

--- a/Services/FileDelivery/classes/FileDeliveryTypes/FileDeliveryTypeFactory.php
+++ b/Services/FileDelivery/classes/FileDeliveryTypes/FileDeliveryTypeFactory.php
@@ -59,7 +59,7 @@ final class FileDeliveryTypeFactory
      *
      * @see DeliveryMethod
      */
-    public function getInstance(string $type): \ILIAS\FileDelivery\ilFileDeliveryType
+    public function getInstance(string $type) : \ILIAS\FileDelivery\ilFileDeliveryType
     {
         assert(is_string($type));
         if (isset(self::$instances[$type])) {

--- a/Services/FileDelivery/classes/FileDeliveryTypes/HeaderBasedDeliveryHelper.php
+++ b/Services/FileDelivery/classes/FileDeliveryTypes/HeaderBasedDeliveryHelper.php
@@ -40,7 +40,7 @@ trait HeaderBasedDeliveryHelper
      *                          $response = $response->withHeader(self::X_SENDFILE,
      *                          realpath($path_to_file));
      */
-    protected function sendFileUnbufferedUsingHeaders(\Closure $closure)
+    protected function sendFileUnbufferedUsingHeaders(\Closure $closure)// @TODO: PHP8 Review: Missing return type.
     {
         ignore_user_abort(true);
         set_time_limit(0);

--- a/Services/FileDelivery/classes/FileDeliveryTypes/PHP.php
+++ b/Services/FileDelivery/classes/FileDeliveryTypes/PHP.php
@@ -52,7 +52,7 @@ final class PHP implements ilFileDeliveryType
     /**
      * @inheritDoc
      */
-    public function doesFileExists($path_to_file): bool
+    public function doesFileExists($path_to_file) : bool// @TODO: PHP8 Review: Signatur missmatch.
     {
         return is_readable($path_to_file);
     }
@@ -61,7 +61,7 @@ final class PHP implements ilFileDeliveryType
     /**
      * @inheritdoc
      */
-    public function prepare($path_to_file): void
+    public function prepare($path_to_file) : void
     {
         set_time_limit(0);
         $this->file = fopen($path_to_file, "rb");
@@ -71,7 +71,7 @@ final class PHP implements ilFileDeliveryType
     /**
      * @inheritdoc
      */
-    public function deliver($path_to_file, $file_marked_to_delete): void
+    public function deliver($path_to_file, $file_marked_to_delete) : void// @TODO: PHP8 Review: Signatur missmatch.
     {
         $this->httpService->sendResponse();
         fpassthru($this->file);
@@ -83,7 +83,7 @@ final class PHP implements ilFileDeliveryType
     /**
      * @inheritdoc
      */
-    public function supportsInlineDelivery(): bool
+    public function supportsInlineDelivery() : bool
     {
         return true;
     }
@@ -92,7 +92,7 @@ final class PHP implements ilFileDeliveryType
     /**
      * @inheritdoc
      */
-    public function supportsAttachmentDelivery(): bool
+    public function supportsAttachmentDelivery() : bool
     {
         return true;
     }
@@ -101,7 +101,7 @@ final class PHP implements ilFileDeliveryType
     /**
      * @inheritdoc
      */
-    public function supportsStreaming(): bool
+    public function supportsStreaming() : bool
     {
         return false;
     }
@@ -110,7 +110,7 @@ final class PHP implements ilFileDeliveryType
     /**
      * @inheritdoc
      */
-    public function handleFileDeletion($path_to_file): bool
+    public function handleFileDeletion($path_to_file) : bool
     {
         return unlink($path_to_file);
     }

--- a/Services/FileDelivery/classes/FileDeliveryTypes/PHPChunked.php
+++ b/Services/FileDelivery/classes/FileDeliveryTypes/PHPChunked.php
@@ -29,7 +29,6 @@ use ILIAS\HTTP\Response\ResponseHeader;
  */
 final class PHPChunked implements ilFileDeliveryType
 {
-
     private \ILIAS\HTTP\Services $httpService;
 
 
@@ -47,7 +46,7 @@ final class PHPChunked implements ilFileDeliveryType
     /**
      * @inheritDoc
      */
-    public function doesFileExists($path_to_file): bool
+    public function doesFileExists($path_to_file) : bool// @TODO: PHP8 Review: Signatur missmatch.
     {
         return is_readable($path_to_file);
     }
@@ -56,7 +55,7 @@ final class PHPChunked implements ilFileDeliveryType
     /**
      * @inheritdoc
      */
-    public function prepare($path_to_file): bool
+    public function prepare($path_to_file) : bool
     {
         return true;
     }
@@ -65,7 +64,7 @@ final class PHPChunked implements ilFileDeliveryType
     /**
      * @inheritdoc
      */
-    public function deliver($path_to_file, $file_marked_to_delete): bool
+    public function deliver($path_to_file, $file_marked_to_delete) : bool// @TODO: PHP8 Review: Signatur missmatch.
     {
         $file = $path_to_file;
         $fp = @fopen($file, 'rb');
@@ -176,7 +175,7 @@ final class PHPChunked implements ilFileDeliveryType
     /**
      * @inheritdoc
      */
-    public function supportsInlineDelivery(): bool
+    public function supportsInlineDelivery() : bool
     {
         return true;
     }
@@ -185,7 +184,7 @@ final class PHPChunked implements ilFileDeliveryType
     /**
      * @inheritdoc
      */
-    public function supportsAttachmentDelivery(): bool
+    public function supportsAttachmentDelivery() : bool
     {
         return true;
     }
@@ -194,13 +193,13 @@ final class PHPChunked implements ilFileDeliveryType
     /**
      * @inheritdoc
      */
-    public function supportsStreaming(): bool
+    public function supportsStreaming() : bool
     {
         return true;
     }
 
 
-    private function close(): void
+    private function close() : void
     {
         //render response
         $this->httpService->sendResponse();
@@ -211,7 +210,7 @@ final class PHPChunked implements ilFileDeliveryType
     /**
      * @inheritdoc
      */
-    public function handleFileDeletion($path_to_file): bool
+    public function handleFileDeletion($path_to_file) : bool
     {
         return unlink($path_to_file);
     }

--- a/Services/FileDelivery/classes/FileDeliveryTypes/XAccel.php
+++ b/Services/FileDelivery/classes/FileDeliveryTypes/XAccel.php
@@ -49,7 +49,7 @@ final class XAccel implements ilFileDeliveryType
     /**
      * @inheritDoc
      */
-    public function doesFileExists($path_to_file): bool
+    public function doesFileExists($path_to_file) : bool// @TODO: PHP8 Review: Signatur missmatch.
     {
         return is_readable($path_to_file);
     }
@@ -59,7 +59,7 @@ final class XAccel implements ilFileDeliveryType
     /**
      * @inheritdoc
      */
-    public function prepare($path_to_file): bool
+    public function prepare($path_to_file) : bool
     {
         $response = $this->httpService->response()->withHeader(ResponseHeader::CONTENT_TYPE, '');
 
@@ -72,7 +72,7 @@ final class XAccel implements ilFileDeliveryType
     /**
      * @inheritdoc
      */
-    public function deliver($path_to_file, $file_marked_to_delete): void
+    public function deliver($path_to_file, $file_marked_to_delete) : void// @TODO: PHP8 Review: Signatur missmatch.
     {
         // There is currently no way to delete the file after delivery
         if (strpos($path_to_file, './' . self::DATA . '/') === 0) {
@@ -81,7 +81,7 @@ final class XAccel implements ilFileDeliveryType
         }
 
         $response = $this->httpService->response();
-        $delivery = function () use ($path_to_file, $response): void {
+        $delivery = function () use ($path_to_file, $response) : void {
             $response = $response->withHeader(self::X_ACCEL_REDIRECT, $path_to_file);
             $this->httpService->saveResponse($response);
             $this->httpService->sendResponse();
@@ -98,7 +98,7 @@ final class XAccel implements ilFileDeliveryType
     /**
      * @inheritdoc
      */
-    public function supportsInlineDelivery(): bool
+    public function supportsInlineDelivery() : bool
     {
         return true;
     }
@@ -107,7 +107,7 @@ final class XAccel implements ilFileDeliveryType
     /**
      * @inheritdoc
      */
-    public function supportsAttachmentDelivery(): bool
+    public function supportsAttachmentDelivery() : bool
     {
         return true;
     }
@@ -116,7 +116,7 @@ final class XAccel implements ilFileDeliveryType
     /**
      * @inheritdoc
      */
-    public function supportsStreaming(): bool
+    public function supportsStreaming() : bool
     {
         return true;
     }
@@ -125,7 +125,7 @@ final class XAccel implements ilFileDeliveryType
     /**
      * @inheritdoc
      */
-    public function handleFileDeletion($path_to_file): void
+    public function handleFileDeletion($path_to_file) : void
     {
         // No possibilities to do this at the moment
     }

--- a/Services/FileDelivery/classes/FileDeliveryTypes/XSendfile.php
+++ b/Services/FileDelivery/classes/FileDeliveryTypes/XSendfile.php
@@ -49,7 +49,7 @@ final class XSendfile implements ilFileDeliveryType
     /**
      * @inheritDoc
      */
-    public function doesFileExists($path_to_file): bool
+    public function doesFileExists($path_to_file) : bool// @TODO: PHP8 Review: Signatur missmatch.
     {
         return is_readable($path_to_file);
     }
@@ -58,7 +58,7 @@ final class XSendfile implements ilFileDeliveryType
     /**
      * @inheritdoc
      */
-    public function prepare($path_to_file): bool
+    public function prepare($path_to_file) : bool
     {
         //	Nothing has to be done here
         return true;
@@ -68,9 +68,9 @@ final class XSendfile implements ilFileDeliveryType
     /**
      * @inheritdoc
      */
-    public function deliver($path_to_file, $file_marked_to_delete): bool
+    public function deliver($path_to_file, $file_marked_to_delete) : bool// @TODO: PHP8 Review: Signatur missmatch.
     {
-        $delivery = function () use ($path_to_file): void {
+        $delivery = function () use ($path_to_file) : void {
             $response = $this->httpService->response()
                 ->withHeader(self::X_SENDFILE, realpath($path_to_file));
             $this->httpService->saveResponse($response);
@@ -90,7 +90,7 @@ final class XSendfile implements ilFileDeliveryType
     /**
      * @inheritdoc
      */
-    public function supportsInlineDelivery(): bool
+    public function supportsInlineDelivery() : bool
     {
         return true;
     }
@@ -99,7 +99,7 @@ final class XSendfile implements ilFileDeliveryType
     /**
      * @inheritdoc
      */
-    public function supportsAttachmentDelivery(): bool
+    public function supportsAttachmentDelivery() : bool
     {
         return true;
     }
@@ -108,7 +108,7 @@ final class XSendfile implements ilFileDeliveryType
     /**
      * @inheritdoc
      */
-    public function supportsStreaming(): bool
+    public function supportsStreaming() : bool
     {
         return true;
     }
@@ -117,7 +117,7 @@ final class XSendfile implements ilFileDeliveryType
     /**
      * @inheritdoc
      */
-    public function handleFileDeletion($path_to_file): void
+    public function handleFileDeletion($path_to_file) : void
     {
         unlink($path_to_file);
     }

--- a/Services/FileDelivery/classes/class.ilFileDelivery.php
+++ b/Services/FileDelivery/classes/class.ilFileDelivery.php
@@ -144,5 +144,7 @@ final class ilFileDelivery implements ilFileDeliveryService
         $delivery->setDeleteFile($removeAfterDelivery);
         $delivery->setExitAfter($a_exit_after);
         $delivery->deliver();
+
+        // @TODO: PHP8 Review: Missing return statement.
     }
 }

--- a/Services/FileDelivery/classes/class.ilFileDelivery.php
+++ b/Services/FileDelivery/classes/class.ilFileDelivery.php
@@ -114,7 +114,7 @@ final class ilFileDelivery implements ilFileDeliveryService
     /**
      * @deprecated
      */
-    public static function deliverFileLegacy(
+    public static function deliverFileLegacy(// @TODO: PHP8 Review: Missing return type.
         string $a_file,
         ?string $a_filename = null,
         ?string $a_mime = null,

--- a/Services/FileDelivery/classes/class.ilPHPOutputDelivery.php
+++ b/Services/FileDelivery/classes/class.ilPHPOutputDelivery.php
@@ -35,7 +35,7 @@ final class ilPHPOutputDelivery
     /**
      * @param        $download_file_name
      */
-    public function start(string $download_file_name, string $mime_type = MimeType::APPLICATION__OCTET_STREAM): void
+    public function start(string $download_file_name, string $mime_type = MimeType::APPLICATION__OCTET_STREAM) : void
     {
         global $DIC;
         $ilClientIniFile = $DIC['ilClientIniFile'];
@@ -52,7 +52,7 @@ final class ilPHPOutputDelivery
     }
 
 
-    public function stop(): void
+    public function stop() : void
     {
         $this->ilFileDelivery->close();
     }

--- a/Services/FileDelivery/interfaces/int.ilFileDeliveryService.php
+++ b/Services/FileDelivery/interfaces/int.ilFileDeliveryService.php
@@ -23,7 +23,6 @@ namespace ILIAS\FileDelivery;
  */
 interface ilFileDeliveryService
 {
-
     public static function deliverFileAttached(
         string $path_to_file,
         ?string $download_file_name = null,

--- a/Services/FileDelivery/interfaces/int.ilFileDeliveryType.php
+++ b/Services/FileDelivery/interfaces/int.ilFileDeliveryType.php
@@ -35,7 +35,7 @@ interface ilFileDeliveryType
      *
      * @return bool
      */
-    public function prepare($path_to_file);
+    public function prepare($path_to_file);// @TODO: PHP8 Review: Missing parameter type.
 
 
     /**
@@ -54,7 +54,7 @@ interface ilFileDeliveryType
      *
      * @return bool
      */
-    public function handleFileDeletion($path_to_file);
+    public function handleFileDeletion($path_to_file);// @TODO: PHP8 Review: Missing parameter type.
 
 
     /**

--- a/Services/FileDelivery/test/FileDeliveryTypes/FileDeliveryTypeFactoryTest.php
+++ b/Services/FileDelivery/test/FileDeliveryTypes/FileDeliveryTypeFactoryTest.php
@@ -52,7 +52,7 @@ class FileDeliveryTypeFactoryTest extends TestCase
     /**
      * @Test
      */
-    public function testCreatePHPFileDeliveryWhichShouldSucceed(): void
+    public function testCreatePHPFileDeliveryWhichShouldSucceed() : void
     {
         $result = $this->subject->getInstance(DeliveryMethod::PHP);
 
@@ -62,7 +62,7 @@ class FileDeliveryTypeFactoryTest extends TestCase
     /**
      * @Test
      */
-    public function testCreatePHPChunkedFileDeliveryWhichShouldSucceed(): void
+    public function testCreatePHPChunkedFileDeliveryWhichShouldSucceed() : void
     {
         $result = $this->subject->getInstance(DeliveryMethod::PHP_CHUNKED);
 
@@ -73,7 +73,7 @@ class FileDeliveryTypeFactoryTest extends TestCase
     /**
      * @Test
      */
-    public function testCreatePHPFileDeliveryTypeWhichShouldYieldTheSameInstance(): void
+    public function testCreatePHPFileDeliveryTypeWhichShouldYieldTheSameInstance() : void
     {
         //fetch the php file delivery type two times to check that only one instance is created.
         $firstResult = $this->subject->getInstance(DeliveryMethod::PHP);
@@ -85,7 +85,7 @@ class FileDeliveryTypeFactoryTest extends TestCase
     /**
      * @Test
      */
-    public function testCreateAnUnknownFileDeliveryTypeWhichShouldFail(): void
+    public function testCreateAnUnknownFileDeliveryTypeWhichShouldFail() : void
     {
         //get instance should throw an exception if the file delivery type is not known.
         $type = 'unknown file delivery type';

--- a/Services/FileDelivery/test/ilServicesFileDeliverySuite.php
+++ b/Services/FileDelivery/test/ilServicesFileDeliverySuite.php
@@ -23,8 +23,7 @@ use PHPUnit\Framework\TestSuite;
  */
 class ilServicesFileDeliverySuite extends TestSuite
 {
-
-    public static function suite(): \ilServicesFileDeliverySuite
+    public static function suite() : \ilServicesFileDeliverySuite
     {
         $suite = new self();
 


### PR DESCRIPTION
Hi @chfsx 
here are the results of the `Services/FileDelivery` review.

### Results
- [x] The code style is `PSR-2 + X` compliant
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] There are no serious `PHPStorm Code Inspection` issues left.
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] The types are fully documented (PHPDoc) or explict PHP types are used (type hints, return types, typed properties)

### Changes made in this PR:
- Added `// @TODO: PHP8 Review: Missing return type.`
- Added `// @TODO: PHP8 Review: Signatur missmatch.`
- Added `// @TODO: PHP8 Review: Missing parameter type.`
- Added `// @TODO: PHP8 Review: Missing return statement.`
- Fix `PSR 2 + X`

Best regards,
@lscharmer