### PR TITLE
PHP8: Code Review `Services/FileSystem`

### DIFF
--- a/Services/FileSystem/classes/class.ilFileSystemAbstractionStorage.php
+++ b/Services/FileSystem/classes/class.ilFileSystemAbstractionStorage.php
@@ -28,10 +28,10 @@ abstract class ilFileSystemAbstractionStorage
     private const FACTOR = 100;
     private const MAX_EXPONENT = 3;
     private const SECURED_DIRECTORY = "sec";
-    private $container_id;
-    private $storage_type;
+    private $container_id;// @TODO: PHP8 Review: Missing property type.
+    private $storage_type;// @TODO: PHP8 Review: Missing property type.
     private bool $path_conversion = false;
-    protected $path;
+    protected $path;// @TODO: PHP8 Review: Missing property type.
     protected \ILIAS\Filesystem\Filesystems $file_system_service;
 
     /**

--- a/Services/FileSystem/classes/class.ilFileSystemGUI.php
+++ b/Services/FileSystem/classes/class.ilFileSystemGUI.php
@@ -577,12 +577,12 @@ class ilFileSystemGUI
 
         ilFileUtils::renameExecutables($this->main_dir);
         if (is_dir($dir . $new_name)) {
-            $this->tpl->setOnScreenMessage('success', $lng->txt("cont_dir_renamed"), true);
+            $this->tpl->setOnScreenMessage('success', $lng->txt("cont_dir_renamed"), true);// @TODO: PHP8 Review: Undefined variable.
             $this->setPerformedCommand("rename_dir", [self::PARAM_OLD_NAME => $old_name,
                                                       self::POST_PARAM_NEW_NAME => $new_name
             ]);
         } else {
-            $this->tpl->setOnScreenMessage('success', $lng->txt("cont_file_renamed"), true);
+            $this->tpl->setOnScreenMessage('success', $lng->txt("cont_file_renamed"), true);// @TODO: PHP8 Review: Undefined variable.
             $this->setPerformedCommand("rename_file", array(self::PARAM_OLD_NAME => $old_name,
                                                             self::POST_PARAM_NEW_NAME => $new_name
             ));


### PR DESCRIPTION
Hi @chfsx
here are the results of the `Services/FileSystem` review.

### Results
- [x] The code style is `PSR-2 + X` compliant
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] There are no serious `PHPStorm Code Inspection` issues left.
- [x] The types are fully documented (PHPDoc) or explict PHP types are used (type hints, return types, typed properties)

### Changes made in this PR:
- Added `// @TODO: PHP8 Review: Missing property type.`
- Added `// @TODO: PHP8 Review: Undefined variable.`

Best regards,
@lscharmer