### PR TITLE
Add PluginRender to unify UI Handling

### DIFF
--- a/src/UI/Implementation/Render/DecoratedRenderer.php
+++ b/src/UI/Implementation/Render/DecoratedRenderer.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types=1);
+
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
+namespace ILIAS\UI\Implementation\Render;
+
+use ILIAS\UI\Renderer;
+use ILIAS\UI\Component\Component;
+
+abstract class DecoratedRenderer implements Renderer
+{
+    private $default;
+
+    public function __construct(Renderer $default)
+    {
+        $this->default = $default;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function withAdditionalContext(Component $context) : DecoratedRenderer
+    {
+        $clone = clone $this;
+        $clone->default = $clone->default->withAdditionalContext($context);
+        return $clone;
+    }
+
+    /**
+     * Manipulates the rendering of one or multiple components by appending, prepending or exchanging their rendered
+     * content with custom adjustments.
+     *
+     * @return string|null Return the manipulated rendering of the component or NULL if the component should be
+     * rendered native
+     */
+    abstract protected function manipulateRendering($component, Renderer $root) : ?string;
+
+    /**
+     * Manipulates the async Rendering separately if needed.
+     * @see manipulateRendering
+     */
+    protected function manipulateAsyncRendering($component, Renderer $root) : ?string
+    {
+        return null;
+    }
+
+    /**
+     * Renders the component by default. Can be used for appending and prepending manipulations.
+     * @see manipulateRendering
+     */
+    final protected function renderDefault($component, ?Renderer $root = null) : string
+    {
+        $root = $root ?? $this;
+        return $this->default->render($component, $root);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    final public function render($component, ?Renderer $root = null) : string
+    {
+        $root = $root ?? $this;
+        return $this->manipulateRendering($component, $root) ?? $this->default->render($component, $root);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    final public function renderAsync($component, ?Renderer $root = null) : string
+    {
+        $root = $root ?? $this;
+        return $this->manipulateAsyncRendering($component, $root) ?? $this->default->renderAsync($component, $root);
+    }
+}

--- a/tests/UI/Base.php
+++ b/tests/UI/Base.php
@@ -10,6 +10,7 @@ require_once(__DIR__ . "/../../Services/Language/classes/class.ilLanguage.php");
 use ILIAS\UI\Component as C;
 use ILIAS\UI\Component\Component as IComponent;
 use ILIAS\UI\Implementaiton\Component as I;
+use ILIAS\UI\Implementation\Render\DecoratedRenderer;
 use ILIAS\UI\Implementation\Render\TemplateFactory;
 use ILIAS\UI\Implementation\Render\ResourceRegistry;
 use ILIAS\UI\Implementation\Render\JavaScriptBinding;
@@ -20,6 +21,7 @@ use ILIAS\UI\Implementation\Render;
 use ILIAS\UI\Implementation\Component\Symbol\Glyph\GlyphRendererFactory;
 use ILIAS\UI\Implementation\Component\Input\Field\FieldRendererFactory;
 use ILIAS\UI\Factory;
+use ILIAS\UI\Renderer;
 use PHPUnit\Framework\TestCase;
 
 class ilIndependentTemplateFactory implements TemplateFactory
@@ -175,6 +177,25 @@ class TestDefaultRenderer extends DefaultRenderer
     }
 }
 
+class TestDecoratedRenderer extends DecoratedRenderer
+{
+    private $manipulate = false;
+
+    public function manipulate() : void
+    {
+        $this->manipulate = true;
+    }
+
+    protected function manipulateRendering($component, Renderer $root) : ?string
+    {
+        if ($this->manipulate) {
+            return "This content was manipulated";
+        } else {
+            return null;
+        }
+    }
+}
+
 class IncrementalSignalGenerator extends \ILIAS\UI\Implementation\Component\SignalGenerator
 {
     protected $id = 0;
@@ -286,6 +307,11 @@ abstract class ILIAS_UI_TestBase extends TestCase
                 )
             );
         return new TestDefaultRenderer($component_renderer_loader);
+    }
+    
+    public function getDecoratedRenderer(Renderer $default)
+    {
+        return new TestDecoratedRenderer($default);
     }
 
     public function normalizeHTML($html)

--- a/tests/UI/Renderer/DecoratedRendererTest.php
+++ b/tests/UI/Renderer/DecoratedRendererTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
+require_once(__DIR__ . "/TestComponent.php");
+require_once(__DIR__ . "/../Base.php");
+
+use ILIAS\UI\Component\Test\TestComponent;
+use ILIAS\UI\Implementation\Render\DecoratedRenderer;
+
+class DecoratedRendererTest extends ILIAS_UI_TestBase
+{
+    public function test_render()
+    {
+        $c1 = new TestComponent("foo");
+        $renderer = $this->getDecoratedRenderer($this->getDefaultRenderer());
+        $html = $renderer->render($c1);
+        $this->assertEquals("foo", $html);
+    }
+
+    public function test_render_async()
+    {
+        $c1 = new TestComponent("foo");
+        $renderer = $this->getDecoratedRenderer($this->getDefaultRenderer());
+        $html = $renderer->renderAsync($c1);
+        $this->assertEquals("foo", $html);
+    }
+
+    public function test_render_with_manipulation()
+    {
+        $c1 = new TestComponent("foo");
+        $renderer = $this->getDecoratedRenderer($this->getDefaultRenderer());
+        $renderer->manipulate();
+        $html = $renderer->render($c1);
+        $this->assertEquals("This content was manipulated", $html);
+    }
+}


### PR DESCRIPTION
This is the improved Version of #4118 wich will use the changes made to the [default renderer](https://github.com/ILIAS-eLearning/ILIAS/pull/4137) to add the chaining on the render progress for more flexibility.