### PR TITLE
PHP 8: Code Review `HTMLLearningModule`

### DIFF
--- a/Modules/HTMLLearningModule/classes/class.ilHTMLLearningModuleDataSet.php
+++ b/Modules/HTMLLearningModule/classes/class.ilHTMLLearningModuleDataSet.php
@@ -26,14 +26,14 @@ class ilHTMLLearningModuleDataSet extends ilDataSet
         return array("4.1.0");
     }
     
-    public function getXmlNamespace(string $a_entity, string $a_schema_version) : string
+    protected function getXmlNamespace(string $a_entity, string $a_schema_version) : string
     {
         return "https://www.ilias.de/xml/Modules/HTMLLearningModule/" . $a_entity;
     }
     
     protected function getTypes(string $a_entity, string $a_version) : array
     {
-        if ($a_entity == "htlm") {
+        if ($a_entity === "htlm") {
             switch ($a_version) {
                 case "4.1.0":
                     return array(
@@ -51,7 +51,7 @@ class ilHTMLLearningModuleDataSet extends ilDataSet
     {
         $ilDB = $this->db;
 
-        if ($a_entity == "htlm") {
+        if ($a_entity === "htlm") {
             switch ($a_version) {
                 case "4.1.0":
                     $this->getDirectDataFromQuery("SELECT id, title, description, " .
@@ -63,16 +63,7 @@ class ilHTMLLearningModuleDataSet extends ilDataSet
             }
         }
     }
-    
-    protected function getDependencies(
-        string $a_entity,
-        string $a_version,
-        ?array $a_rec = null,
-        ?array $a_ids = null
-    ) : array {
-        return [];
-    }
-    
+
     public function getXmlRecord(string $a_entity, string $a_version, array $a_set) : array
     {
         $lm = new ilObjFileBasedLM($a_set["Id"], false);
@@ -103,7 +94,7 @@ class ilHTMLLearningModuleDataSet extends ilDataSet
                 $this->current_obj = $newObj;
 
                 $dir = str_replace("..", "", $a_rec["Dir"]);
-                if ($dir != "" && $this->getImportDirectory() != "") {
+                if ($dir !== "" && $this->getImportDirectory() !== "") {
                     $source_dir = $this->getImportDirectory() . "/" . $dir;
                     $target_dir = $newObj->getDataDirectory();
                     ilFileUtils::rCopy($source_dir, $target_dir);

--- a/Modules/HTMLLearningModule/classes/class.ilHTMLLearningModuleLP.php
+++ b/Modules/HTMLLearningModule/classes/class.ilHTMLLearningModuleLP.php
@@ -19,9 +19,9 @@
  */
 class ilHTMLLearningModuleLP extends ilObjectLP
 {
-    public static function getDefaultModes(bool $a_lp_active) : array
+    public static function getDefaultModes(bool $lp_active) : array
     {
-        if (!$a_lp_active) {
+        if (!$lp_active) {
             return array(
                 ilLPObjSettings::LP_MODE_DEACTIVATED
             );

--- a/Modules/HTMLLearningModule/classes/class.ilObjFileBasedLM.php
+++ b/Modules/HTMLLearningModule/classes/class.ilObjFileBasedLM.php
@@ -150,19 +150,20 @@ class ilObjFileBasedLM extends ilObject
     ) : void {
         preg_match("/.*htlm_([0-9]*)\.zip/", $a_filename, $match);
         if (is_dir($a_dir . "/htlm_" . $match[1])) {
-            $a_dir = $a_dir . "/htlm_" . $match[1];
+            $a_dir .= "/htlm_" . $match[1];
         }
         ilFileUtils::rCopy($a_dir, $this->getDataDirectory());
         ilFileUtils::renameExecutables($this->getDataDirectory());
     }
     
-    public function cloneObject(int $a_target_id, int $a_copy_id = 0, bool $a_omit_tree = false) : ?ilObject
+    public function cloneObject(int $target_id, int $copy_id = 0, bool $omit_tree = false) : ?ilObject
     {
-        $new_obj = parent::cloneObject($a_target_id, $a_copy_id, $a_omit_tree);
+        /** @var ilObjFileBasedLM $new_obj */
+        $new_obj = parent::cloneObject($target_id, $copy_id, $omit_tree);
         $this->cloneMetaData($new_obj);
 
         //copy online status if object is not the root copy object
-        $cp_options = ilCopyWizardOptions::_getInstance($a_copy_id);
+        $cp_options = ilCopyWizardOptions::_getInstance($copy_id);
 
         if (!$cp_options->isRootNode($this->getRefId())) {
             $new_obj->setOfflineStatus($this->getOfflineStatus());

--- a/Modules/HTMLLearningModule/classes/class.ilObjFileBasedLMAccess.php
+++ b/Modules/HTMLLearningModule/classes/class.ilObjFileBasedLMAccess.php
@@ -42,7 +42,7 @@ class ilObjFileBasedLMAccess extends ilObjectAccess
         switch ($permission) {
             case "read":
 
-                if (ilObjFileBasedLMAccess::_determineStartUrl($obj_id) == "") {
+                if (self::_determineStartUrl($obj_id) === "") {
                     $ilAccess->addInfoItem(ilAccessInfo::IL_NO_OBJECT_ACCESS, $lng->txt("offline"));
                     return false;
                 }
@@ -53,14 +53,14 @@ class ilObjFileBasedLMAccess extends ilObjectAccess
     
     public static function _getCommands() : array
     {
-        $commands = array(
-            array("permission" => "read", "cmd" => "view", "lang_var" => "show",
-                "default" => true),
-            array("permission" => "write", "cmd" => "edit", "lang_var" => "edit_content"),
-            array("permission" => "write", "cmd" => "properties", "lang_var" => "settings")
-        );
-        
-        return $commands;
+        return [
+            [
+                "permission" => "read", "cmd" => "view", "lang_var" => "show",
+                "default" => true
+            ],
+            ["permission" => "write", "cmd" => "edit", "lang_var" => "edit_content"],
+            ["permission" => "write", "cmd" => "properties", "lang_var" => "settings"]
+        ];
     }
 
     //
@@ -85,7 +85,7 @@ class ilObjFileBasedLMAccess extends ilObjectAccess
         
         $dir = ilFileUtils::getWebspaceDir() . "/lm_data/lm_" . $a_id;
         
-        if (($start_file != "") &&
+        if (($start_file !== "") &&
             (is_file($dir . "/" . $start_file))) {
             return "./" . $dir . "/" . $start_file;
         } elseif (is_file($dir . "/index.html")) {
@@ -105,7 +105,7 @@ class ilObjFileBasedLMAccess extends ilObjectAccess
         
         $t_arr = explode("_", $target);
 
-        if ($t_arr[0] != "htlm" || ((int) $t_arr[1]) <= 0) {
+        if ($t_arr[0] !== "htlm" || ((int) $t_arr[1]) <= 0) {
             return false;
         }
 

--- a/Modules/HTMLLearningModule/test/HTMLLearningModuleStandardGUIRequestTest.php
+++ b/Modules/HTMLLearningModule/test/HTMLLearningModuleStandardGUIRequestTest.php
@@ -7,8 +7,6 @@ use PHPUnit\Framework\TestCase;
  */
 class HTMLLearningModuleStandardGUIRequestTest extends TestCase
 {
-    //protected $backupGlobals = false;
-
     protected function tearDown() : void
     {
     }
@@ -27,7 +25,7 @@ class HTMLLearningModuleStandardGUIRequestTest extends TestCase
         );
     }
 
-    public function testRefId()
+    public function testRefId() : void
     {
         $request = $this->getRequest(
             [
@@ -43,7 +41,7 @@ class HTMLLearningModuleStandardGUIRequestTest extends TestCase
         );
     }
 
-    public function testUserId()
+    public function testUserId() : void
     {
         $request = $this->getRequest(
             [

--- a/Modules/HTMLLearningModule/test/ilModulesHTMLLearningModuleSuite.php
+++ b/Modules/HTMLLearningModule/test/ilModulesHTMLLearningModuleSuite.php
@@ -22,7 +22,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilModulesHTMLLearningModuleSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new self();
 


### PR DESCRIPTION
Hi @alex40724,

I completed the review of the `Modules/HTMLLearningModule` component.

Results:
- [x] The code style is `PSR-2 + X` compliant: 1 File has been changed by the `PHP-CS-FIXER`
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

I also fixed some trivial issues reported by my inspection profile.

--

Actions needed:

None

Best regards,
@mjansenDatabay