### PR TITLE
PHP 8: Code Review `CAS`

### DIFF
--- a/Services/CAS/classes/class.ilAuthFrontendCredentialsCAS.php
+++ b/Services/CAS/classes/class.ilAuthFrontendCredentialsCAS.php
@@ -16,9 +16,7 @@
 
 /**
  * Auth frontend credentials for CAS auth
- *
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
- *
  */
 class ilAuthFrontendCredentialsCAS extends ilAuthFrontendCredentials
 {

--- a/Services/CAS/classes/class.ilAuthProviderCAS.php
+++ b/Services/CAS/classes/class.ilAuthProviderCAS.php
@@ -43,7 +43,7 @@ class ilAuthProviderCAS extends ilAuthProvider
             phpCAS::client(
                 CAS_VERSION_2_0,
                 $this->getSettings()->getServer(),
-                (int) $this->getSettings()->getPort(),
+                $this->getSettings()->getPort(),
                 $this->getSettings()->getUri()
             );
 

--- a/Services/CAS/classes/class.ilCASAttributeToUser.php
+++ b/Services/CAS/classes/class.ilCASAttributeToUser.php
@@ -18,7 +18,6 @@
  * CAS user creation helper
  *
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
- *
  */
 class ilCASAttributeToUser
 {

--- a/Services/CAS/classes/class.ilCASAttributeToUser.php
+++ b/Services/CAS/classes/class.ilCASAttributeToUser.php
@@ -23,18 +23,9 @@
 class ilCASAttributeToUser
 {
     private ilLogger $logger;
-
     private ilXmlWriter $writer;
-
     private ilCASSettings $settings;
 
-
-    /**
-     * Constructor
-     *
-     * @access public
-     *
-     */
     public function __construct(\ilCASSettings $settings)
     {
         global $DIC;
@@ -46,20 +37,13 @@ class ilCASAttributeToUser
         $this->settings = $settings;
     }
 
-    /**
-     * Create new ILIAS account
-     *
-     * @param string external username
-     */
-    public function create($a_username)
+    public function create(string $a_username) : string
     {
         $this->writer->xmlStartTag('Users');
 
-        // Single users
-        // Required fields
-        // Create user
         $this->writer->xmlStartTag('User', array('Action' => 'Insert'));
-        $this->writer->xmlElement('Login', array(), $new_name = ilAuthUtils::_generateLogin($a_username));
+        $new_name = ilAuthUtils::_generateLogin($a_username);
+        $this->writer->xmlElement('Login', array(), $new_name);
 
         // Assign to role only for new users
         $this->writer->xmlElement(

--- a/Services/CAS/classes/class.ilCASSettings.php
+++ b/Services/CAS/classes/class.ilCASSettings.php
@@ -15,9 +15,7 @@
  *****************************************************************************/
 
 /**
- *
  * @author Stefan Meyer <meyer@leifos.com>
- * @ingroup ServicesCAS
  */
 class ilCASSettings
 {

--- a/Services/CAS/classes/class.ilCASSettings.php
+++ b/Services/CAS/classes/class.ilCASSettings.php
@@ -21,9 +21,9 @@
  */
 class ilCASSettings
 {
-    const SYNC_DISABLED = 0;
-    const SYNC_CAS = 1;
-    const SYNC_LDAP = 2;
+    public const SYNC_DISABLED = 0;
+    public const SYNC_CAS = 1;
+    public const SYNC_LDAP = 2;
 
     private static ?ilCASSettings $instance = null;
 
@@ -36,6 +36,7 @@ class ilCASSettings
     private bool $create_users = false;
     private bool $allow_local = false;
     private int $user_default_role = 0;
+    private int $default_role = 0;
     
     /**
      * Singleton constructor
@@ -139,9 +140,6 @@ class ilCASSettings
         return $this->default_role;
     }
 
-    /**
-     * Save settings
-     */
     public function save() : void
     {
         $this->getStorage()->set('cas_server', $this->getServer());
@@ -154,9 +152,6 @@ class ilCASSettings
         $this->getStorage()->set('cas_user_default_role', (string) $this->getDefaultRole());
     }
 
-    /**
-     * Read settings
-     */
     private function read() : void
     {
         $this->setServer($this->getStorage()->get('cas_server', $this->server));
@@ -169,12 +164,6 @@ class ilCASSettings
         $this->enableUserCreation((bool) $this->getStorage()->get('cas_create_users', (string) $this->create_users));
     }
 
-
-
-
-    /**
-     * Get storage object
-     */
     private function getStorage() : ilSetting
     {
         return $this->storage;

--- a/Services/CAS/classes/class.ilCASSettingsGUI.php
+++ b/Services/CAS/classes/class.ilCASSettingsGUI.php
@@ -19,9 +19,9 @@
  */
 class ilCASSettingsGUI
 {
-    const SYNC_DISABLED = 0;
-    const SYNC_CAS = 1;
-    const SYNC_LDAP = 2;
+    public const SYNC_DISABLED = 0;
+    public const SYNC_CAS = 1;
+    public const SYNC_LDAP = 2;
 
     private ilCASSettings $settings;
 
@@ -41,6 +41,7 @@ class ilCASSettingsGUI
 
         $this->ctrl = $DIC->ctrl();
         $this->rbacSystem = $DIC->rbac()->system();
+        $this->rbacReview = $DIC->rbac()->review();
         $this->ilErr = $DIC['ilErr'];
         $this->lng = $DIC->language();
         $this->lng->loadLanguageModule('registration');
@@ -224,7 +225,7 @@ class ilCASSettingsGUI
             $this->getSettings()->setDefaultRole((int) $form->getInput('role'));
             $this->getSettings()->enableLocalAuthentication((bool) $form->getInput('local'));
             $this->getSettings()->setLoginInstruction($form->getInput('instruction'));
-            $this->getSettings()->enableUserCreation((int) $form->getInput('sync') == ilCASSettings::SYNC_CAS);
+            $this->getSettings()->enableUserCreation((int) $form->getInput('sync') === ilCASSettings::SYNC_CAS);
             $this->getSettings()->save();
 
             switch ((int) $form->getInput('sync')) {
@@ -234,14 +235,14 @@ class ilCASSettingsGUI
                     break;
 
                 case ilCASSettings::SYNC_LDAP:
-                    if (!(int) $_REQUEST['ldap_sid']) {
+                    if (!(int) $form->getInput('ldap_sid')) {
                         $this->tpl->setOnScreenMessage('failure', $this->lng->txt('err_check_input'));
                         $this->settings();
                         //TODO do we need return false?
                         return;
                     }
 
-                    ilLDAPServer::toggleDataSource((int) $_REQUEST['ldap_sid'], ilAuthUtils::AUTH_CAS, 1);
+                    ilLDAPServer::toggleDataSource((int) $form->getInput('ldap_sid'), ilAuthUtils::AUTH_CAS, 1);
                     break;
             }
 

--- a/Services/CAS/maintenance.json
+++ b/Services/CAS/maintenance.json
@@ -1,7 +1,7 @@
 {
     "maintenance_model": "Classic",
-    "first_maintainer": "smeyer(191)",
-    "second_maintainer": "bheyser(14300)",
+    "first_maintainer": "PerPascalSeeland(31492)",
+    "second_maintainer": "",
     "implicit_maintainers": [],
     "coordinator": [
         ""

--- a/Services/CAS/test/ilCASSettingsTest.php
+++ b/Services/CAS/test/ilCASSettingsTest.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types=1);
+
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
+
+use ILIAS\DI\Container;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ilCASSettingsTest extends TestCase
+{
+    protected function setUp() : void
+    {
+        $this->dic = new Container();
+        $GLOBALS['DIC'] = $this->dic;
+        $this->setGlobalVariable(
+            'ilSetting',
+            $this->getMockBuilder(ilSetting::class)->disableOriginalConstructor()->getMock()
+        );
+        parent::setUp();
+    }
+
+    /**
+     * @param string $name
+     * @param mixed  $value
+     */
+    protected function setGlobalVariable(string $name, $value) : void
+    {
+        global $DIC;
+
+        $GLOBALS[$name] = $value;
+
+        unset($DIC[$name]);
+        $DIC[$name] = static function ($c) use ($name) {
+            return $GLOBALS[$name];
+        };
+    }
+
+    public function testBasicSessionBehaviour() : void
+    {
+        global $DIC;
+
+        //setup some method calls
+        /** @var $setting MockObject */
+        $setting = $DIC['ilSetting'];
+        $setting->method("get")->withConsecutive(
+            ['cas_server'],
+            ['cas_port'],
+            ['cas_uri'],
+            ['cas_active'],
+            ['cas_user_default_role'],
+            ['cas_login_instructions'],
+            ['cas_allow_local'],
+            ['cas_create_users']
+        )->
+        willReturnOnConsecutiveCalls(
+            'casserver',
+            "1",
+            'cas',
+            'true',
+            '0',
+            'casInstruction',
+            'false',
+            'true'
+        );
+
+        $casSettings = ilCASSettings::getInstance();
+        $this->assertEquals("casserver", $casSettings->getServer());
+        $this->assertTrue($casSettings->isActive());
+    }
+}

--- a/Services/CAS/test/ilServicesCASSuite.php
+++ b/Services/CAS/test/ilServicesCASSuite.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
+use PHPUnit\Framework\TestSuite;
+
+class ilServicesCASSuite extends TestSuite
+{
+    public static function suite() : self
+    {
+        $suite = new ilServicesCASSuite();
+        require_once __DIR__ . '/ilCASSettingsTest.php';
+        $suite->addTestSuite(ilCASSettingsTest::class);
+
+        return $suite;
+    }
+}


### PR DESCRIPTION
Hello @pascalseeland, 

I completed the review of the `Services/CAS` component.

Results:

- [x] The code style is `PSR-2 + X` compliant
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`: I found 2 usages of `$_REQUEST`.
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] There are no serious `PhpStorm Code Inspection` issues left
- [x] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

--

Actions needed:
- [x] Please eliminate the super global variable usages
- [x] Please add a unit test suite with at least one passing unit test
- [x] I am not sure whether https://packagist.org/packages/jasig/phpcas is compatible with PHP 8. Please check the list item above if you already checked this. 

Best regards,
@mjansenDatabay  