### PR TITLE
PHP 8: Code Review `Help`

### DIFF
--- a/Services/Help/GlobalScreen/classes/class.ilHelpGSToolProvider.php
+++ b/Services/Help/GlobalScreen/classes/class.ilHelpGSToolProvider.php
@@ -26,9 +26,10 @@ use ILIAS\UI\Implementation\Component\MainControls\Slate\Legacy as LegacySlate;
  */
 class ilHelpGSToolProvider extends AbstractDynamicToolProvider
 {
-    public const SHOW_HELP_TOOL = 'show_help_tool';
     use ilHelpDisplayed;
     use Hasher;
+
+    public const SHOW_HELP_TOOL = 'show_help_tool';
 
     public function isInterestedInContexts() : ContextCollection
     {
@@ -67,7 +68,7 @@ class ilHelpGSToolProvider extends AbstractDynamicToolProvider
                                             ->addComponentDecorator(static function (ILIAS\UI\Component\Component $c) use ($hashed, $hidden) : ILIAS\UI\Component\Component {
                                                 if ($c instanceof LegacySlate) {
                                                     $signal_id = $c->getToggleSignal()->getId();
-                                                    return $c->withAdditionalOnLoadCode(static function ($id) use ($hashed, $hidden) {
+                                                    return $c->withAdditionalOnLoadCode(static function ($id) use ($hashed) {
                                                         return "
                                                  $('body').on('il-help-toggle-slate', function(){
                                                     if (!$('#$id').hasClass('disengaged')) {
@@ -106,7 +107,7 @@ class ilHelpGSToolProvider extends AbstractDynamicToolProvider
         $help_gui->initHelp($main_tpl, $ctrl->getLinkTargetByClass("ilhelpgui", "", "", true));
 
         $html = "";
-        if ((defined("OH_REF_ID") && OH_REF_ID > 0) || DEVMODE == 1) {
+        if ((defined("OH_REF_ID") && OH_REF_ID > 0) || (defined('DEVMODE') && (int) DEVMODE === 1)) {
             $html = "<div class='ilHighlighted small'>Screen ID: " . $help_gui->getScreenId() . "</div>";
         }
 

--- a/Services/Help/GlobalScreen/classes/class.ilHelpMetaBarProvider.php
+++ b/Services/Help/GlobalScreen/classes/class.ilHelpMetaBarProvider.php
@@ -18,7 +18,7 @@ use ILIAS\GlobalScreen\Scope\MetaBar\Provider\AbstractStaticMetaBarProvider;
 use ILIAS\GlobalScreen\Scope\MetaBar\Provider\StaticMetaBarProvider;
 use ILIAS\UI\Implementation\Component\Button\Bulky;
 
-class ilHelpMetaBarProvider extends AbstractStaticMetaBarProvider implements StaticMetaBarProvider
+class ilHelpMetaBarProvider extends AbstractStaticMetaBarProvider
 {
     use ilHelpDisplayed;
 
@@ -51,7 +51,6 @@ class ilHelpMetaBarProvider extends AbstractStaticMetaBarProvider implements Sta
                            }
                            return null;
                        })
-//                       ->withAction($this->dic->ctrl()->getLinkTargetByClass(ilDashboardGUI::class, "toggleHelp"))
                        ->withSymbol($f->symbol()->glyph()->help())
                        ->withTitle($title)
                        ->withPosition(0);

--- a/Services/Help/GlobalScreen/classes/class.ilHelpViewLayoutProvider.php
+++ b/Services/Help/GlobalScreen/classes/class.ilHelpViewLayoutProvider.php
@@ -27,7 +27,7 @@ use ILIAS\GlobalScreen\Scope\MainMenu\Collector\Renderer\Hasher;
  * HTML export view layout provider, hides main and meta bar
  * @author <killing@leifos.de>
  */
-class ilHelpViewLayoutProvider extends AbstractModificationProvider implements ModificationProvider
+class ilHelpViewLayoutProvider extends AbstractModificationProvider
 {
     use Hasher;
     use ilHelpDisplayed;
@@ -53,14 +53,12 @@ class ilHelpViewLayoutProvider extends AbstractModificationProvider implements M
             $tt_text = ilHelp::getMainMenuTooltip($p->getInternalIdentifier());
             $tt_text = addslashes(str_replace(array("\n", "\r"), '', $tt_text));
 
-            if ($tt_text != "") {
-                if ($item instanceof hasSymbol && $item->hasSymbol()) {
-                    $item->addSymbolDecorator(static function (Symbol $symbol) use ($tt_text) : Symbol {
-                        return $symbol->withAdditionalOnLoadCode(static function ($id) use ($tt_text) : string {
-                            return "il.Tooltip.addToNearest('$id', 'button,a', { context:'', my:'bottom center', at:'top center', text:'$tt_text' });";
-                        });
+            if ($tt_text !== "" && $item instanceof hasSymbol && $item->hasSymbol()) {
+                $item->addSymbolDecorator(static function (Symbol $symbol) use ($tt_text) : Symbol {
+                    return $symbol->withAdditionalOnLoadCode(static function ($id) use ($tt_text) : string {
+                        return "il.Tooltip.addToNearest('$id', 'button,a', { context:'', my:'bottom center', at:'top center', text:'$tt_text' });";
                     });
-                }
+                });
             }
         }
 

--- a/Services/Help/GlobalScreen/classes/trait.ilHelpDisplayed.php
+++ b/Services/Help/GlobalScreen/classes/trait.ilHelpDisplayed.php
@@ -19,37 +19,29 @@
  */
 trait ilHelpDisplayed
 {
-    /**
-     * Show help tool?
-     * @param
-     * @return
-     */
     protected function showHelpTool() : bool
     {
         static $show;
+
         if (!isset($show)) {
             global $DIC;
 
             $user = $DIC->user();
             $settings = $DIC->settings();
 
-            if ($user->getLanguage() != "de") {
+            if ($user->getLanguage() !== "de") {
                 return $show = false;
             }
 
-            //if (ilSession::get("show_help_tool") != "1") {
-            //    return $show = false;
-            //}
-
-            if ($settings->get("help_mode") == "2") {
+            if ($settings->get("help_mode") === "2") {
                 return $show = false;
             }
 
-            if ((defined("OH_REF_ID") && OH_REF_ID > 0)) {
+            if (defined("OH_REF_ID") && OH_REF_ID > 0) {
                 return $show = true;
             } else {
                 $module = (int) $settings->get("help_module");
-                if ($module == 0) {
+                if ($module === 0) {
                     return $show = false;
                 }
             }

--- a/Services/Help/classes/class.ilHelp.php
+++ b/Services/Help/classes/class.ilHelp.php
@@ -30,11 +30,11 @@ class ilHelp
         $ilUser = $DIC->user();
         
         
-        if ($ilUser->getLanguage() != "de") {
+        if ($ilUser->getLanguage() !== "de") {
             return "";
         }
         
-        if ($ilSetting->get("help_mode") == "1") {
+        if ($ilSetting->get("help_mode") === "1") {
             return "";
         }
 
@@ -42,11 +42,11 @@ class ilHelp
             return "";
         }
         
-        if (OH_REF_ID > 0) {
+        if (defined('OH_REF_ID') && OH_REF_ID > 0) {
             $module_id = 0;
         } else {
             $module_id = (int) $ilSetting->get("help_module");
-            if ($module_id == 0) {
+            if ($module_id === 0) {
                 return "";
             }
         }
@@ -59,7 +59,7 @@ class ilHelp
         $rec = $ilDB->fetchAssoc($set);
         if (is_array($rec) && $rec["tt_text"] != "") {
             $t = $rec["tt_text"];
-            if ($module_id == 0) {
+            if ($module_id === 0) {
                 $t .= "<br/><i>(" . $a_tt_id . ")</i>";
             }
             return $t;
@@ -74,13 +74,13 @@ class ilHelp
             $rec = $ilDB->fetchAssoc($set);
             if (is_array($rec) && $rec["tt_text"] != "") {
                 $t = $rec["tt_text"];
-                if ($module_id == 0) {
+                if ($module_id === 0) {
                     $t .= "<br/><i>(" . $a_tt_id . ")</i>";
                 }
                 return $t;
             }
         }
-        if ($module_id == 0) {
+        if ($module_id === 0) {
             return "<i>" . $a_tt_id . "</i>";
         }
         return "";
@@ -114,7 +114,7 @@ class ilHelp
         
         $q = "SELECT * FROM help_tooltip";
         $q .= " WHERE module_id = " . $ilDB->quote($a_module_id, "integer");
-        if ($a_comp != "") {
+        if ($a_comp !== "") {
             $q .= " AND comp = " . $ilDB->quote($a_comp, "text");
         }
         $set = $ilDB->query($q);

--- a/Services/Help/classes/class.ilHelpDataSet.php
+++ b/Services/Help/classes/class.ilHelpDataSet.php
@@ -25,14 +25,14 @@ class ilHelpDataSet extends ilDataSet
         return array("4.3.0");
     }
     
-    public function getXmlNamespace(string $a_entity, string $a_schema_version) : string
+    protected function getXmlNamespace(string $a_entity, string $a_schema_version) : string
     {
         return "https://www.ilias.de/xml/Services/Help/" . $a_entity;
     }
     
     protected function getTypes(string $a_entity, string $a_version) : array
     {
-        if ($a_entity == "help_map") {
+        if ($a_entity === "help_map") {
             switch ($a_version) {
                 case "4.3.0":
                     return array(
@@ -45,7 +45,7 @@ class ilHelpDataSet extends ilDataSet
             }
         }
 
-        if ($a_entity == "help_tooltip") {
+        if ($a_entity === "help_tooltip") {
             switch ($a_version) {
                 case "4.3.0":
                     return array(
@@ -64,7 +64,7 @@ class ilHelpDataSet extends ilDataSet
     {
         $ilDB = $this->db;
 
-        if ($a_entity == "help_map") {
+        if ($a_entity === "help_map") {
             switch ($a_version) {
                 case "4.3.0":
                     $this->getDirectDataFromQuery("SELECT chap, component, screen_id, screen_sub_id, perm " .
@@ -75,7 +75,7 @@ class ilHelpDataSet extends ilDataSet
             }
         }
         
-        if ($a_entity == "help_tooltip") {
+        if ($a_entity === "help_tooltip") {
             switch ($a_version) {
                 case "4.3.0":
                     $this->getDirectDataFromQuery("SELECT id, tt_text, tt_id, comp, lang FROM help_tooltip");
@@ -83,16 +83,7 @@ class ilHelpDataSet extends ilDataSet
             }
         }
     }
-    
-    protected function getDependencies(
-        string $a_entity,
-        string $a_version,
-        ?array $a_rec = null,
-        ?array $a_ids = null
-    ) : array {
-        return [];
-    }
-    
+
     public function importRecord(
         string $a_entity,
         array $a_types,
@@ -114,7 +105,7 @@ class ilHelpDataSet extends ilDataSet
                     );
 
                     // new import (5.1): get chapter from learning module import mapping
-                    if ($new_chap == 0) {
+                    if ((int) $new_chap === 0) {
                         $new_chap = $a_mapping->getMapping(
                             'Modules/LearningModule',
                             'lm_tree',

--- a/Services/Help/classes/class.ilHelpExporter.php
+++ b/Services/Help/classes/class.ilHelpExporter.php
@@ -34,7 +34,7 @@ class ilHelpExporter extends ilXmlExporter
         string $a_target_release,
         array $a_ids
     ) : array {
-        if ($a_entity == "help") {
+        if ($a_entity === "help") {
             $lm_node_ids = array();
             foreach ($a_ids as $lm_id) {
                 $chaps = ilLMObject::getObjectList($lm_id, "st");

--- a/Services/Help/classes/class.ilHelpGUI.php
+++ b/Services/Help/classes/class.ilHelpGUI.php
@@ -142,7 +142,7 @@ class ilHelpGUI implements ilCtrlBaseClassInterface
         $lng->loadLanguageModule("help");
         $ui = $this->ui;
 
-        if ($this->help_request->getHelpScreenId() != "") {
+        if ($this->help_request->getHelpScreenId() !== "") {
             ilSession::set("help_screen_id", $this->help_request->getHelpScreenId());
             $help_screen_id = $this->help_request->getHelpScreenId();
         } else {
@@ -310,7 +310,7 @@ class ilHelpGUI implements ilCtrlBaseClassInterface
 
         $module_id = (int) $ilSetting->get("help_module");
 
-        if ((OH_REF_ID > 0 || $module_id > 0) && $ilUser->getLanguage() == "de") {
+        if ((OH_REF_ID > 0 || $module_id > 0) && $ilUser->getLanguage() === "de") {
             if (ilSession::get("help_pg") > 0) {
                 $a_tpl->addOnLoadCode("il.Help.showCurrentPage(" . ilSession::get("help_pg") . ");", 3);
             } else {
@@ -350,7 +350,7 @@ class ilHelpGUI implements ilCtrlBaseClassInterface
         $link_info = "<IntLinkInfos>";
         foreach ($a_int_links as $int_link) {
             $target = $int_link["Target"];
-            if (substr($target, 0, 4) == "il__") {
+            if (strpos($target, "il__") === 0) {
                 $target_arr = explode("_", $target);
                 $target_id = $target_arr[count($target_arr) - 1];
                 $type = $int_link["Type"];
@@ -366,7 +366,7 @@ class ilHelpGUI implements ilCtrlBaseClassInterface
                 switch ($type) {
                     case "PageObject":
                     case "StructureObject":
-                            if ($type == "PageObject") {
+                            if ($type === "PageObject") {
                                 $href = "#pg_" . $target_id;
                             } else {
                                 $href = "#";
@@ -402,7 +402,7 @@ class ilHelpGUI implements ilCtrlBaseClassInterface
 
         $term = $this->help_request->getTerm();
 
-        if ($term == "") {
+        if ($term === "") {
             $term = ilSession::get("help_search_term");
         }
 

--- a/Services/Help/classes/class.ilHelpMapping.php
+++ b/Services/Help/classes/class.ilHelpMapping.php
@@ -150,11 +150,11 @@ class ilHelpMapping
         $ilUser = $DIC->user();
         $ilObjDataCache = $DIC["ilObjDataCache"];
 
-        if (OH_REF_ID > 0) {
+        if (defined('OH_REF_ID') && OH_REF_ID > 0) {
             $module = 0;
         } else {
             $module = (int) $ilSetting->get("help_module");
-            if ($module == 0) {
+            if ($module === 0) {
                 return array();
             }
         }
@@ -181,18 +181,18 @@ class ilHelpMapping
             while ($rec = $ilDB->fetchAssoc($set)) {
                 if ($rec["perm"] != "" && $rec["perm"] != "-") {
                     // check special "create*" permission
-                    if ($rec["perm"] == "create*") {
+                    if ($rec["perm"] === "create*") {
                         $has_create_perm = false;
                         
                         // check owner
-                        if ($ilUser->getId() == $ilObjDataCache->lookupOwner(ilObject::_lookupObjId($a_ref_id))) {
+                        if ($ilUser->getId() === $ilObjDataCache->lookupOwner(ilObject::_lookupObjId($a_ref_id))) {
                             $has_create_perm = true;
                         } elseif ($rbacreview->isAssigned($ilUser->getId(), SYSTEM_ROLE_ID)) { // check admin
                             $has_create_perm = true;
                         } elseif ($ilAccess->checkAccess("read", "", $a_ref_id)) {
                             $perm = $rbacreview->getUserPermissionsOnObject($ilUser->getId(), $a_ref_id);
                             foreach ($perm as $p) {
-                                if (substr($p, 0, 7) == "create_") {
+                                if (strpos($p, "create_") === 0) {
                                     $has_create_perm = true;
                                 }
                             }
@@ -227,19 +227,19 @@ class ilHelpMapping
         $ilSetting = $DIC->settings();
         $ilUser = $DIC->user();
         
-        if ($ilUser->getLanguage() != "de") {
+        if ($ilUser->getLanguage() !== "de") {
             return false;
         }
         
-        if ($ilSetting->get("help_mode") == "2") {
+        if ($ilSetting->get("help_mode") === "2") {
             return false;
         }
 
-        if (OH_REF_ID > 0) {
+        if (defined('OH_REF_ID') && OH_REF_ID > 0) {
             $module = 0;
         } else {
             $module = (int) $ilSetting->get("help_module");
-            if ($module == 0) {
+            if ($module === 0) {
                 return false;
             }
         }

--- a/Services/Help/classes/class.ilHelpModuleTableGUI.php
+++ b/Services/Help/classes/class.ilHelpModuleTableGUI.php
@@ -62,10 +62,7 @@ class ilHelpModuleTableGUI extends ilTable2GUI
     {
         $this->setData($this->parent_obj->getObject()->getHelpModules());
     }
-    
-    /**
-     * Fill table row
-     */
+
     protected function fillRow(array $a_set) : void
     {
         $lng = $this->lng;
@@ -75,7 +72,7 @@ class ilHelpModuleTableGUI extends ilTable2GUI
         $ilCtrl->setParameter($this->parent_obj, "hm_id", $a_set["id"]);
         if ($this->has_write_permission) {
             $this->tpl->setCurrentBlock("cmd");
-            if ($a_set["id"] == $ilSetting->get("help_module")) {
+            if ((int) $a_set["id"] === (int) $ilSetting->get("help_module")) {
                 $this->tpl->setVariable(
                     "HREF_CMD",
                     $ilCtrl->getLinkTarget($this->parent_obj, "deactivateModule")

--- a/Services/Help/classes/class.ilObjHelpSettings.php
+++ b/Services/Help/classes/class.ilObjHelpSettings.php
@@ -31,7 +31,7 @@ class ilObjHelpSettings extends ilObject2
         $this->settings = $DIC->settings();
     }
 
-    public function initType()
+    protected function initType() : void
     {
         $this->type = "hlps";
     }
@@ -71,13 +71,13 @@ class ilObjHelpSettings extends ilObject2
     public function uploadHelpModule(
         array $a_file
     ) : void {
-        $id = $this->createHelpModule();
+        $id = self::createHelpModule();
         
         try {
             $imp = new ilImport();
             $conf = $imp->getConfig("Services/Help");
             $conf->setModuleId($id);
-            $new_id = $imp->importObject("", $a_file["tmp_name"], $a_file["name"], "lm", "Modules/LearningModule");
+            $new_id = $imp->importObject(""/* TODO PHP8-REVIEW This must be NULl or an object */, $a_file["tmp_name"], $a_file["name"], "lm", "Modules/LearningModule"); //
             $newObj = new ilObjLearningModule($new_id, false);
 
             self::writeHelpModuleLmId($id, $newObj->getId());
@@ -104,9 +104,9 @@ class ilObjHelpSettings extends ilObject2
         
         $mods = array();
         while ($rec = $ilDB->fetchAssoc($set)) {
-            if (ilObject::_lookupType($rec["lm_id"]) == "lm") {
+            if (ilObject::_lookupType((int) $rec["lm_id"]) === "lm") {
                 $rec["title"] = ilObject::_lookupTitle($rec["lm_id"]);
-                $rec["create_date"] = ilObject::_lookupCreationDate($rec["lm_id"]);
+                $rec["create_date"] = ilObject::_lookupCreationDate((int) $rec["lm_id"]);
             }
             
             $mods[] = $rec;
@@ -127,8 +127,8 @@ class ilObjHelpSettings extends ilObject2
             " WHERE id = " . $ilDB->quote($a_id, "integer")
         );
         $rec = $ilDB->fetchAssoc($set);
-        if (ilObject::_lookupType($rec["lm_id"]) == "lm") {
-            return ilObject::_lookupTitle($rec["lm_id"]);
+        if (ilObject::_lookupType((int) $rec["lm_id"]) === "lm") {
+            return ilObject::_lookupTitle((int) $rec["lm_id"]);
         }
         return "";
     }
@@ -145,7 +145,7 @@ class ilObjHelpSettings extends ilObject2
             " WHERE id = " . $ilDB->quote($a_id, "integer")
         );
         $rec = $ilDB->fetchAssoc($set);
-        return $rec["lm_id"];
+        return (int) $rec["lm_id"];
     }
     
     public function deleteModule(
@@ -155,7 +155,7 @@ class ilObjHelpSettings extends ilObject2
         $ilSetting = $this->settings;
         
         // if this is the currently activated one, deactivate it first
-        if ($a_id == (int) $ilSetting->get("help_module")) {
+        if ($a_id === (int) $ilSetting->get("help_module")) {
             $ilSetting->set("help_module", "");
         }
         
@@ -166,8 +166,8 @@ class ilObjHelpSettings extends ilObject2
         $rec = $ilDB->fetchAssoc($set);
 
         // delete learning module
-        if (ilObject::_lookupType($rec["lm_id"]) == "lm") {
-            $lm = new ilObjLearningModule($rec["lm_id"], false);
+        if (ilObject::_lookupType($rec["lm_id"]) === "lm") {
+            $lm = new ilObjLearningModule((int) $rec["lm_id"], false);
             $lm->delete();
         }
         

--- a/Services/Help/classes/class.ilObjHelpSettingsGUI.php
+++ b/Services/Help/classes/class.ilObjHelpSettingsGUI.php
@@ -35,7 +35,6 @@ class ilObjHelpSettingsGUI extends ilObject2GUI
         global $DIC;
         parent::__construct($a_id, $a_id_type, $a_parent_node_id);
 
-        $this->rbacsystem = $DIC->rbac()->system();
         $this->access = $DIC->access();
         $this->lng = $DIC->language();
         $this->ctrl = $DIC->ctrl();
@@ -65,7 +64,7 @@ class ilObjHelpSettingsGUI extends ilObject2GUI
 
         $this->prepareOutput();
 
-        if (!$this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
             throw new ilPermissionException($this->lng->txt('no_permission'));
         }
 
@@ -77,7 +76,7 @@ class ilObjHelpSettingsGUI extends ilObject2GUI
                 break;
 
             default:
-                if (!$cmd || $cmd == 'view') {
+                if (!$cmd || $cmd === 'view') {
                     $cmd = "editSettings";
                 }
 
@@ -171,7 +170,7 @@ class ilObjHelpSettingsGUI extends ilObject2GUI
 
         $ids = $this->help_request->getIds();
 
-        if (count($ids) == 0) {
+        if (count($ids) === 0) {
             $this->tpl->setOnScreenMessage('info', $lng->txt("no_checkbox"), true);
             $ilCtrl->redirect($this, "editSettings");
         } else {
@@ -182,7 +181,7 @@ class ilObjHelpSettingsGUI extends ilObject2GUI
             $cgui->setConfirm($lng->txt("delete"), "deleteHelpModules");
             
             foreach ($ids as $i) {
-                $cgui->addItem("id[]", $i, $this->object->lookupModuleTitle($i));
+                $cgui->addItem("id[]", $i, $this->object::lookupModuleTitle($i));
             }
             
             $tpl->setContent($cgui->getHTML());
@@ -224,7 +223,7 @@ class ilObjHelpSettingsGUI extends ilObject2GUI
 
         $this->checkPermission("write");
         
-        if ($ilSetting->get("help_module") == $this->help_request->getHelpModuleId()) {
+        if ((int) $ilSetting->get("help_module") === $this->help_request->getHelpModuleId()) {
             $ilSetting->set("help_module", "");
             $this->tpl->setOnScreenMessage('success', $lng->txt("msg_obj_modified"), true);
         }

--- a/Services/Help/test/HelpStandardGUIRequestTest.php
+++ b/Services/Help/test/HelpStandardGUIRequestTest.php
@@ -9,13 +9,6 @@ use PHPUnit\Framework\TestCase;
  */
 class HelpStandardGUIRequestTest extends TestCase
 {
-    //protected $backupGlobals = false;
-
-    protected function setUp() : void
-    {
-        parent::setUp();
-    }
-
     protected function tearDown() : void
     {
     }
@@ -34,7 +27,7 @@ class HelpStandardGUIRequestTest extends TestCase
         );
     }
 
-    public function testRefId()
+    public function testRefId() : void
     {
         $request = $this->getRequest(
             [
@@ -49,7 +42,7 @@ class HelpStandardGUIRequestTest extends TestCase
         );
     }
 
-    public function testHelpModuleId()
+    public function testHelpModuleId() : void
     {
         $request = $this->getRequest(
             [
@@ -64,7 +57,7 @@ class HelpStandardGUIRequestTest extends TestCase
         );
     }
 
-    public function testTerm()
+    public function testTerm() : void
     {
         $request = $this->getRequest(
             [
@@ -79,7 +72,7 @@ class HelpStandardGUIRequestTest extends TestCase
         );
     }
 
-    public function testIds()
+    public function testIds() : void
     {
         $request = $this->getRequest(
             [
@@ -95,7 +88,7 @@ class HelpStandardGUIRequestTest extends TestCase
         );
     }
 
-    public function testHelpScreenId()
+    public function testHelpScreenId() : void
     {
         $request = $this->getRequest(
             [

--- a/Services/Help/test/ilServicesHelpSuite.php
+++ b/Services/Help/test/ilServicesHelpSuite.php
@@ -22,7 +22,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilServicesHelpSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new self();
 


### PR DESCRIPTION
Hi @alex40724,

I completed the review of the `Service/Help` component.

Results:
- [x] The code style is `PSR-2 + X` compliant: 1 File has been changed by the `PHP-CS-FIXER`
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

I also fixed some trivial issues reported by my inspection profile.

--

Actions needed:

- [ ] Please check my inline comments. Some of them are just information, some require an action. You can use `TODO PHP8-REVIEW` when searching.

Best regards,
@mjansenDatabay