### PR TITLE
PHP 8: Code Review `Poll`

### DIFF
--- a/Modules/Poll/classes/class.ilObjPoll.php
+++ b/Modules/Poll/classes/class.ilObjPoll.php
@@ -242,7 +242,7 @@ class ilObjPoll extends ilObject2
         if ($this->ref_id) {
             $activation = ilObjectActivation::getItem($this->ref_id);
             $this->setAccessType((int) ($activation["timing_type"] ?? ilObjectActivation::TIMINGS_DEACTIVATED));
-            if ($this->getAccessType() == ilObjectActivation::TIMINGS_ACTIVATION) {
+            if ($this->getAccessType() === ilObjectActivation::TIMINGS_ACTIVATION) {
                 // default entry values should not be loaded if not activated
                 $this->setAccessBegin((int) ($activation["timing_start"] ?? time()));
                 $this->setAccessEnd((int) ($activation["timing_end"] ?? time()));
@@ -253,7 +253,7 @@ class ilObjPoll extends ilObject2
     
     protected function propertiesToDB() : array
     {
-        $fields = array(
+        return array(
             "question" => array("text", $this->getQuestion()),
             "image" => array("text", $this->getImage()),
             "view_results" => array("integer", $this->getViewResults()),
@@ -265,8 +265,6 @@ class ilObjPoll extends ilObject2
             "non_anon" => array("integer", $this->getNonAnonymous()),
             "show_results_as" => array("integer", $this->getShowResultsAs()),
         );
-                        
-        return $fields;
     }
 
     protected function doCreate() : void
@@ -344,7 +342,7 @@ class ilObjPoll extends ilObject2
      */
     protected function doCloneObject($new_obj, $a_target_id, $a_copy_id = 0) : ilObjPoll
     {
-        assert($new_obj instanceof ilObjPoll);
+        assert($new_obj instanceof self);
         
         // question/image
         $new_obj->setQuestion($this->getQuestion());
@@ -387,7 +385,7 @@ class ilObjPoll extends ilObject2
     {
         $img = $this->getImage();
         if ($img) {
-            $path = $this->initStorage((int) $this->id);
+            $path = $this->initStorage($this->id);
             if (!$a_as_thumb) {
                 return $path . $img;
             } else {
@@ -401,7 +399,7 @@ class ilObjPoll extends ilObject2
     public function deleteImage() : void
     {
         if ($this->id) {
-            $storage = new ilFSStoragePoll((int) $this->id);
+            $storage = new ilFSStoragePoll($this->id);
             $storage->delete();
 
             $this->setImage("");
@@ -439,7 +437,7 @@ class ilObjPoll extends ilObject2
         $tmp_name = (string) ($a_upload['tmp_name'] ?? '');
         $clean_name = preg_replace("/[^a-zA-Z0-9\_\.\-]/", "", $name);
     
-        $path = $this->initStorage((int) $this->id);
+        $path = self::initStorage($this->id);
         $original = "org_" . $this->id . "_" . $clean_name;
         $thumb = "thb_" . $this->id . "_" . $clean_name;
         $processed = $this->id . "_" . $clean_name;
@@ -634,7 +632,7 @@ class ilObjPoll extends ilObject2
                 // existing answer?
                 $found = false;
                 foreach ($existing as $idx => $item) {
-                    if (trim($answer) == (string) ($item["answer"] ?? '')) {
+                    if (trim($answer) === (string) ($item["answer"] ?? '')) {
                         $found = true;
                         unset($existing[$idx]);
 
@@ -655,7 +653,7 @@ class ilObjPoll extends ilObject2
         }
         
         // remove obsolete answers
-        if (sizeof($existing)) {
+        if (count($existing)) {
             foreach ($existing as $item) {
                 if (isset($item["id"])) {
                     $this->deleteAnswer((int) $item["id"]);
@@ -664,11 +662,11 @@ class ilObjPoll extends ilObject2
         }
         
         // save current order
-        if (sizeof($ids)) {
+        if (count($ids)) {
             $this->updateAnswerPositions($ids);
         }
         
-        return sizeof($ids);
+        return count($ids);
     }
     
     
@@ -722,8 +720,8 @@ class ilObjPoll extends ilObject2
             " GROUP BY answer_id";
         $set = $this->db->query($sql);
         while ($row = $this->db->fetchAssoc($set)) {
-            $cnt += $row["cnt"];
-            $res[$row["answer_id"]] = array("abs" => $row["cnt"], "perc" => 0);
+            $cnt += (int) $row["cnt"];
+            $res[(int) $row["answer_id"]] = array("abs" => (int) $row["cnt"], "perc" => 0);
         }
 
         foreach ($res as $id => $item) {

--- a/Modules/Poll/classes/class.ilObjPoll.php
+++ b/Modules/Poll/classes/class.ilObjPoll.php
@@ -385,7 +385,7 @@ class ilObjPoll extends ilObject2
     {
         $img = $this->getImage();
         if ($img) {
-            $path = $this->initStorage($this->id);
+            $path = self::initStorage($this->id);
             if (!$a_as_thumb) {
                 return $path . $img;
             } else {

--- a/Modules/Poll/classes/class.ilObjPollAccess.php
+++ b/Modules/Poll/classes/class.ilObjPollAccess.php
@@ -42,20 +42,20 @@ class ilObjPollAccess extends ilObjectAccess implements ilWACCheckingClass
     /**
     * @inheritdoc
     */
-    public function _checkAccess($a_cmd, $a_permission, $a_ref_id, $a_obj_id, $a_user_id = "") : bool
+    public function _checkAccess(string $cmd, string $permission, int $ref_id, int $obj_id, ?int $user_id = null) : bool
     {
         $ilUser = $this->user;
         $lng = $this->lng;
         $rbacsystem = $this->rbacsystem;
         $ilAccess = $this->access;
 
-        if ($a_user_id == "") {
+        if (!$user_id) {
             $a_user_id = $ilUser->getId();
         }
 
         if (
-            $a_cmd == 'preview' &&
-            $a_permission == 'read'
+            $cmd === 'preview' &&
+            $permission === 'read'
         ) {
             return false;
         }
@@ -85,32 +85,31 @@ class ilObjPollAccess extends ilObjectAccess implements ilWACCheckingClass
      */
     public static function _getCommands() : array
     {
-        $commands = array(
-            array("permission" => "read", "cmd" => "preview", "lang_var" => "show", "default" => true),
-            array("permission" => "write", "cmd" => "render", "lang_var" => "edit")
-        );
-        
-        return $commands;
+        return [
+            ["permission" => "read", "cmd" => "preview", "lang_var" => "show", "default" => true],
+            ["permission" => "write", "cmd" => "render", "lang_var" => "edit"]
+        ];
     }
     
     /**
     * @inheritdoc
     */
-    public static function _checkGoto($a_target) : bool
+    public static function _checkGoto(string $target) : bool
     {
         global $DIC;
 
         $ilAccess = $DIC->access();
         
-        $t_arr = explode("_", $a_target);
+        $t_arr = explode("_", $target);
         
-        if ($t_arr[0] != "poll" || ((int) $t_arr[1]) <= 0) {
+        if ($t_arr[0] !== "poll" || ((int) $t_arr[1]) <= 0) {
             return false;
         }
 
         if ($ilAccess->checkAccess("read", "", (int) $t_arr[1])) {
             return true;
         }
+
         return false;
     }
 

--- a/Modules/Poll/classes/class.ilObjPollGUI.php
+++ b/Modules/Poll/classes/class.ilObjPollGUI.php
@@ -173,27 +173,27 @@ class ilObjPollGUI extends ilObject2GUI
         $a_values["show_results_as"] = $this->object->getShowResultsAs();
     }
     
-    protected function validateCustom(ilPropertyFormGUI $a_form) : bool
+    protected function validateCustom(ilPropertyFormGUI $form) : bool
     {
         #20594
-        if (!$a_form->getInput("voting_period") &&
-            (int) $a_form->getInput("results") === ilObjPoll::VIEW_RESULTS_AFTER_PERIOD) {
+        if (!$form->getInput("voting_period") &&
+            (int) $form->getInput("results") === ilObjPoll::VIEW_RESULTS_AFTER_PERIOD) {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt("form_input_not_valid"));
-            $a_form->getItemByPostVar("results")->setAlert($this->lng->txt("poll_view_results_after_period_impossible"));
+            $form->getItemByPostVar("results")->setAlert($this->lng->txt("poll_view_results_after_period_impossible"));
             return false;
         }
-        return parent::validateCustom($a_form);
+        return parent::validateCustom($form);
     }
 
-    protected function updateCustom(ilPropertyFormGUI $a_form) : void
+    protected function updateCustom(ilPropertyFormGUI $form) : void
     {
-        $this->object->setViewResults((int) $a_form->getInput("results"));
-        $this->object->setOfflineStatus($a_form->getInput("online") == "1" ? false : true);
-        $this->object->setSortResultByVotes((bool) $a_form->getInput("sort"));
-        $this->object->setShowComments((bool) $a_form->getInput("comment"));
-        $this->object->setShowResultsAs((int) $a_form->getInput("show_results_as"));
+        $this->object->setViewResults((int) $form->getInput("results"));
+        $this->object->setOfflineStatus(!((string) $form->getInput("online") === "1"));
+        $this->object->setSortResultByVotes((bool) $form->getInput("sort"));
+        $this->object->setShowComments((bool) $form->getInput("comment"));
+        $this->object->setShowResultsAs((int) $form->getInput("show_results_as"));
 
-        $period = $a_form->getItemByPostVar("access_period");
+        $period = $form->getItemByPostVar("access_period");
         if ($period->getStart() && $period->getEnd()) {
             $this->object->setAccessType(ilObjectActivation::TIMINGS_ACTIVATION);
             $this->object->setAccessBegin($period->getStart()->get(IL_CAL_UNIX));
@@ -202,7 +202,7 @@ class ilObjPollGUI extends ilObject2GUI
             $this->object->setAccessType(ilObjectActivation::TIMINGS_DEACTIVATED);
         }
                                                     
-        $period = $a_form->getItemByPostVar("voting_period");
+        $period = $form->getItemByPostVar("voting_period");
         if ($period->getStart() && $period->getEnd()) {
             $this->object->setVotingPeriod(true);
             $this->object->setVotingPeriodBegin($period->getStart()->get(IL_CAL_UNIX));

--- a/Modules/Poll/classes/class.ilObjPollGUI.php
+++ b/Modules/Poll/classes/class.ilObjPollGUI.php
@@ -63,7 +63,7 @@ class ilObjPollGUI extends ilObject2GUI
         return "poll";
     }
     
-    protected function afterSave(ilObject $a_new_object) : void
+    protected function afterSave(ilObject $new_object) : void
     {
         $this->tpl->setOnScreenMessage('success', $this->lng->txt("object_added"), true);
         $this->ctrl->redirect($this, "render");
@@ -80,7 +80,7 @@ class ilObjPollGUI extends ilObject2GUI
         
         // additional info only with multiple references
         $act_obj_info = $act_ref_info = "";
-        if (sizeof(ilObject::_getAllReferences($this->object->getId())) > 1) {
+        if (count(ilObject::_getAllReferences($this->object->getId())) > 1) {
             $act_obj_info = ' ' . $this->lng->txt('rep_activation_online_object_info');
             $act_ref_info = $this->lng->txt('rep_activation_access_ref_info');
         }
@@ -177,7 +177,7 @@ class ilObjPollGUI extends ilObject2GUI
     {
         #20594
         if (!$a_form->getInput("voting_period") &&
-            (int) $a_form->getInput("results") == ilObjPoll::VIEW_RESULTS_AFTER_PERIOD) {
+            (int) $a_form->getInput("results") === ilObjPoll::VIEW_RESULTS_AFTER_PERIOD) {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt("form_input_not_valid"));
             $a_form->getItemByPostVar("results")->setAlert($this->lng->txt("poll_view_results_after_period_impossible"));
             return false;
@@ -512,16 +512,14 @@ class ilObjPollGUI extends ilObject2GUI
 
         $valid = true;
         if ($this->object->getMaxNumberOfAnswers() > 1) {
-            if (sizeof($aw) > $this->object->getMaxNumberOfAnswers()) {
+            if (count($aw) > $this->object->getMaxNumberOfAnswers()) {
                 $valid = false;
             }
-            if (!sizeof($aw)) {
+            if (!count($aw)) {
                 $valid = false;
             }
-        } else {
-            if ((int) !$aw) {
-                $valid = false;
-            }
+        } elseif ((int) !$aw) {
+            $valid = false;
         }
 
         $session_last_poll_vote = ilSession::get('last_poll_vote');
@@ -564,7 +562,7 @@ class ilObjPollGUI extends ilObject2GUI
             null,
             true
         );
-        if (!sizeof($users)) {
+        if (!count($users)) {
             return;
         }
 

--- a/Modules/Poll/classes/class.ilPollAnswerTableGUI.php
+++ b/Modules/Poll/classes/class.ilPollAnswerTableGUI.php
@@ -62,10 +62,7 @@ class ilPollAnswerTableGUI extends ilTable2GUI
     
     public function numericOrdering(string $a_field) : bool
     {
-        if ($a_field != "answer") {
-            return true;
-        }
-        return false;
+        return $a_field !== "answer";
     }
 
     public function getItems() : int
@@ -102,10 +99,10 @@ class ilPollAnswerTableGUI extends ilTable2GUI
     
     protected function fillRowCSV(ilCSVWriter $a_csv, array $a_set) : void
     {
-        $a_csv->addColumn((int) ($a_set["pos"] ?? 10) / 10);
+        $a_csv->addColumn((string) ((int) ($a_set["pos"] ?? 10) / 10));
         $a_csv->addColumn((string) ($a_set["answer"] ?? ''));
-        $a_csv->addColumn((int) ($a_set["votes"] ?? 0));
-        $a_csv->addColumn((int) ($a_set["percentage"] ?? 0));
+        $a_csv->addColumn((string) ((int) ($a_set["votes"] ?? 0)));
+        $a_csv->addColumn((string) ((int) ($a_set["percentage"] ?? 0)));
         $a_csv->addRow();
     }
     

--- a/Modules/Poll/classes/class.ilPollBlock.php
+++ b/Modules/Poll/classes/class.ilPollBlock.php
@@ -57,7 +57,7 @@ class ilPollBlock extends ilCustomBlock
      */
     public function hasAnyContent(int $a_user_id, int $a_ref_id) : bool
     {
-        if (!sizeof($this->answers)) {
+        if (!count($this->answers)) {
             return false;
         }
 
@@ -80,7 +80,7 @@ class ilPollBlock extends ilCustomBlock
             return false;
         }
         
-        if ($a_user_id == ANONYMOUS_USER_ID) {
+        if ($a_user_id === ANONYMOUS_USER_ID) {
             return false;
         }
         
@@ -99,7 +99,7 @@ class ilPollBlock extends ilCustomBlock
     
     public function mayNotResultsYet() : bool
     {
-        if ($this->poll->getViewResults() == ilObjPoll::VIEW_RESULTS_AFTER_PERIOD &&
+        if ($this->poll->getViewResults() === ilObjPoll::VIEW_RESULTS_AFTER_PERIOD &&
             $this->poll->getVotingPeriod() &&
             $this->poll->getVotingPeriodEnd() > time()) {
             return true;
@@ -135,7 +135,7 @@ class ilPollBlock extends ilCustomBlock
     
     public function getMessage(int $a_user_id) : ?string
     {
-        if (!sizeof($this->answers)) {
+        if (!count($this->answers)) {
             return $this->lng->txt("poll_block_message_no_answers");
         }
         

--- a/Modules/Poll/classes/class.ilPollBlockGUI.php
+++ b/Modules/Poll/classes/class.ilPollBlockGUI.php
@@ -335,8 +335,7 @@ class ilPollBlockGUI extends ilBlockGUI
                     $this,
                     "getNumberOfCommentsForRedraw",
                     "",
-                    true,
-                    false
+                    true
                 );
                 $this->tpl->setVariable("COMMENTS_REDRAW_URL", $redraw_url);
 

--- a/Modules/Poll/classes/class.ilPollBlockGUI.php
+++ b/Modules/Poll/classes/class.ilPollBlockGUI.php
@@ -82,11 +82,6 @@ class ilPollBlockGUI extends ilBlockGUI
         return "ilobjpollgui";
     }
 
-    public static function getScreenMode() : string
-    {
-        return IL_SCREEN_SIDE;
-    }
-
     public function setBlock(ilPollBlock $a_block) : void
     {
         $this->setBlockId((string) $a_block->getId());
@@ -234,8 +229,8 @@ class ilPollBlockGUI extends ilBlockGUI
                         }
 
                         // pie chart
-                        if ($this->poll_block->showResultsAs() == ilObjPoll::SHOW_RESULTS_AS_PIECHART) {
-                            $chart = ilChart::getInstanceByType(ilCHart::TYPE_PIE, "poll_results_pie_" . $this->getRefId());
+                        if ($this->poll_block->showResultsAs() === ilObjPoll::SHOW_RESULTS_AS_PIECHART) {
+                            $chart = ilChart::getInstanceByType(ilChart::TYPE_PIE, "poll_results_pie_" . $this->getRefId());
                             $chart->setSize(400, 200);
                             $chart->setAutoResize(true);
 
@@ -433,10 +428,7 @@ class ilPollBlockGUI extends ilBlockGUI
         );
 
 
-        $comment = new ilNoteGUI();
-        $jsCall = $comment->getListCommentsJSCall($ajaxHash, "ilPoll.redrawComments(" . $refId . ");");
-
-        return $jsCall;
+        return ilNoteGUI::getListCommentsJSCall($ajaxHash, "ilPoll.redrawComments(" . $refId . ");");
     }
 
     public function getNumberOfCommentsForRedraw() : void
@@ -467,7 +459,7 @@ class ilPollBlockGUI extends ilBlockGUI
         $obj_id = ilObject2::_lookupObjectId($ref_id);
         $number = ilNote::_countNotesAndComments($obj_id);
 
-        if (count($number) == 0) {
+        if (count($number) === 0) {
             return 0;
         }
 

--- a/Modules/Poll/classes/class.ilPollDataSet.php
+++ b/Modules/Poll/classes/class.ilPollDataSet.php
@@ -43,7 +43,7 @@ class ilPollDataSet extends ilDataSet
      */
     protected function getTypes(string $a_entity, string $a_version) : array
     {
-        if ($a_entity == "poll") {
+        if ($a_entity === "poll") {
             switch ($a_version) {
                 case "4.3.0":
                     return array(
@@ -79,7 +79,7 @@ class ilPollDataSet extends ilDataSet
             }
         }
         
-        if ($a_entity == "poll_answer") {
+        if ($a_entity === "poll_answer") {
             switch ($a_version) {
                 case "4.3.0":
                 case "5.0.0":
@@ -100,7 +100,7 @@ class ilPollDataSet extends ilDataSet
     {
         $ilDB = $this->db;
         
-        if ($a_entity == "poll") {
+        if ($a_entity === "poll") {
             switch ($a_version) {
                 case "4.3.0":
                     $this->getDirectDataFromQuery("SELECT pl.id,od.title,od.description," .
@@ -123,7 +123,7 @@ class ilPollDataSet extends ilDataSet
             }
         }
 
-        if ($a_entity == "poll_answer") {
+        if ($a_entity === "poll_answer") {
             switch ($a_version) {
                 case "4.3.0":
                 case "5.0.0":
@@ -152,7 +152,7 @@ class ilPollDataSet extends ilDataSet
 
     public function getXmlRecord(string $a_entity, string $a_version, array $a_set) : array
     {
-        if ($a_entity == "poll") {
+        if ($a_entity === "poll") {
             $dir = ilObjPoll::initStorage($a_set["Id"]);
             $a_set["Dir"] = $dir;
             
@@ -173,7 +173,7 @@ class ilPollDataSet extends ilDataSet
             case "poll":
                 // container copy
                 if ($new_id = $a_mapping->getMapping("Services/Container", "objs", (string) ($a_rec["Id"] ?? "0"))) {
-                    $newObj = ilObjectFactory::getInstanceByObjId($new_id, false);
+                    $newObj = ilObjectFactory::getInstanceByObjId((int) $new_id, false);
                 } else {
                     $newObj = new ilObjPoll();
                     $newObj->create();
@@ -201,7 +201,7 @@ class ilPollDataSet extends ilDataSet
                 // handle image(s)
                 if ($a_rec["Image"]) {
                     $dir = str_replace("..", "", (string) ($a_rec["Dir"] ?? ''));
-                    if ($dir != "" && $this->getImportDirectory() != "") {
+                    if ($dir !== "" && $this->getImportDirectory() !== "") {
                         $source_dir = $this->getImportDirectory() . "/" . $dir;
                         $target_dir = ilObjPoll::initStorage($newObj->getId());
                         ilFileUtils::rCopy($source_dir, $target_dir);

--- a/Modules/Poll/classes/class.ilPollImporter.php
+++ b/Modules/Poll/classes/class.ilPollImporter.php
@@ -25,10 +25,7 @@
 class ilPollImporter extends ilXmlImporter
 {
     protected ilPollDataSet $ds;
-    
-    /**
-     * Initialisation
-     */
+
     public function init() : void
     {
         $this->ds = new ilPollDataSet();

--- a/Modules/Poll/classes/class.ilPollUserTableGUI.php
+++ b/Modules/Poll/classes/class.ilPollUserTableGUI.php
@@ -26,7 +26,7 @@ class ilPollUserTableGUI extends ilTable2GUI
 {
     protected array $answer_ids = [];
     
-    public function __construct(?object $a_parent_obj, string $a_parent_cmd)
+    public function __construct(object $a_parent_obj, string $a_parent_cmd)
     {
         global $DIC;
 
@@ -105,9 +105,9 @@ class ilPollUserTableGUI extends ilTable2GUI
         $a_csv->addColumn((string) ($a_set["firstname"] ?? ''));
         foreach ($this->answer_ids as $answer_id) {
             if ($a_set["answer" . $answer_id]) {
-                $a_csv->addColumn(true);
+                $a_csv->addColumn('true');// TODO PHP8-REVIEW I am not sure if my fix is correct
             } else {
-                $a_csv->addColumn(false);
+                $a_csv->addColumn('false');// TODO PHP8-REVIEW I am not sure if my fix is correct
             }
         }
         $a_csv->addRow();


### PR DESCRIPTION
Hi @smeyer-ilias / @tfamula,

I completed the review of the `Modules/Poll` component.

Results:
- [x] The code style is `PSR-2 + X` compliant: 1 File has been changed by the `PHP-CS-FIXER`
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

I also fixed some trivial issues reported by my inspection profile.

--

Actions needed:

- [ ] Please check my inline comments. Some of them are just information, some require an action. You can use `TODO PHP8-REVIEW` when searching.

Best regards,
@mjansenDatabay