### PR TITLE
PHP 8: Code Review `Context`

### DIFF
--- a/Services/Context/classes/class.ilContext.php
+++ b/Services/Context/classes/class.ilContext.php
@@ -24,24 +24,24 @@ class ilContext
     protected static string $class_name = "";
     protected static string $type = "";
     
-    public const CONTEXT_WEB = "ilContextWeb";
-    public const CONTEXT_CRON = "ilContextCron";
-    public const CONTEXT_RSS = "ilContextRss";
-    public const CONTEXT_ICAL = "ilContextIcal";
-    public const CONTEXT_SOAP = "ilContextSoap";
-    public const CONTEXT_SOAP_NO_AUTH = 'ilContextSoapNoAuth';
-    public const CONTEXT_WEBDAV = "ilContextWebdav";
-    public const CONTEXT_RSS_AUTH = "ilContextRssAuth";
-    public const CONTEXT_SESSION_REMINDER = "ilContextSessionReminder";
-    public const CONTEXT_SOAP_WITHOUT_CLIENT = "ilContextSoapWithoutClient";
-    public const CONTEXT_UNITTEST = "ilContextUnitTest";
-    public const CONTEXT_REST = "ilContextRest";
-    public const CONTEXT_SCORM = "ilContextScorm";
-    public const CONTEXT_WAC = "ilContextWAC";
-    public const CONTEXT_APACHE_SSO = 'ilContextApacheSSO';
-    public const CONTEXT_SHIBBOLETH = 'ilContextShibboleth';
-    public const CONTEXT_LTI_PROVIDER = 'ilContextLTIProvider';
-    public const CONTEXT_SAML = 'ilContextSaml';
+    public const CONTEXT_WEB = ilContextWeb::class;
+    public const CONTEXT_CRON = ilContextCron::class;
+    public const CONTEXT_RSS = ilContextRss::class;
+    public const CONTEXT_ICAL = ilContextIcal::class;
+    public const CONTEXT_SOAP = ilContextSoap::class;
+    public const CONTEXT_SOAP_NO_AUTH = ilContextSoapNoAuth::class;
+    public const CONTEXT_WEBDAV = ilContextWebdav::class;
+    public const CONTEXT_RSS_AUTH = ilContextRssAuth::class;
+    public const CONTEXT_SESSION_REMINDER = ilContextSessionReminder::class;
+    public const CONTEXT_SOAP_WITHOUT_CLIENT = ilContextSoapWithoutClient::class;
+    public const CONTEXT_UNITTEST = ilContextUnitTest::class;
+    public const CONTEXT_REST = ilContextRest::class;
+    public const CONTEXT_SCORM = ilContextScorm::class;
+    public const CONTEXT_WAC = ilContextWAC::class;
+    public const CONTEXT_APACHE_SSO = ilContextApacheSSO::class;
+    public const CONTEXT_SHIBBOLETH = ilContextShibboleth::class;
+    public const CONTEXT_LTI_PROVIDER = ilContextLTIProvider::class;
+    public const CONTEXT_SAML = ilContextSaml::class;
 
     /**
      * Init context by type
@@ -61,11 +61,10 @@ class ilContext
     public static function directCall(string $a_type, string $a_method)
     {
         $class_name = $a_type;
-        if ($class_name) {
-            if (method_exists($class_name, $a_method)) {
-                return call_user_func(array($class_name, $a_method));
-            }
+        if ($class_name && method_exists($class_name, $a_method)) {
+            return call_user_func(array($class_name, $a_method));
         }
+
         return null;
     }
 

--- a/Services/Context/test/ilContextTest.php
+++ b/Services/Context/test/ilContextTest.php
@@ -1,4 +1,5 @@
 <?php
+
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -9,19 +10,10 @@ use PHPUnit\Framework\TestCase;
  */
 class ilContextTest extends TestCase
 {
-    protected $backupGlobals = false;
-
-    protected function setUp() : void
-    {
-        require_once("Services/Context/test/class.ilContextExtended.php");
-    }
-    
     /**
-    * test init ilContext
-    *
-    * @dataProvider contextProvider
-    */
-    public function testInit($context, $className)
+     * @dataProvider contextProvider
+     */
+    public function testInit(string $context, string $className) : void
     {
         $context_obj = ilContextExtended::init($context);
         $this->assertTrue($context_obj);
@@ -29,22 +21,22 @@ class ilContextTest extends TestCase
         $this->assertEquals(ilContextExtended::getClassName(), $className);
     }
 
-    public function contextProvider()
+    public function contextProvider() : array
     {
-        require_once("Services/Context/test/class.ilContextExtended.php");
-
-        return array(array(ilContext::CONTEXT_WEB, "ilContextWeb"),
-                     array(ilContext::CONTEXT_CRON, "ilContextCron"),
-                     array(ilContext::CONTEXT_RSS, "ilContextRss"),
-                     array(ilContext::CONTEXT_ICAL, "ilContextIcal"),
-                     array(ilContext::CONTEXT_SOAP, "ilContextSoap"),
-                     array(ilContext::CONTEXT_WEBDAV, "ilContextWebdav"),
-                     array(ilContext::CONTEXT_RSS_AUTH, "ilContextRssAuth"),
-                     array(ilContext::CONTEXT_SESSION_REMINDER, "ilContextSessionReminder"),
-                     array(ilContext::CONTEXT_SOAP_WITHOUT_CLIENT, "ilContextSoapWithoutClient"),
-                     array(ilContext::CONTEXT_UNITTEST, "ilContextUnitTest"),
-                     array(ilContext::CONTEXT_REST, "ilContextRest"),
-                     array(ilContext::CONTEXT_SCORM, "ilContextScorm"),
-                     array(ilContext::CONTEXT_WAC, "ilContextWAC"));
+        return [
+            [ilContext::CONTEXT_WEB, ilContextWeb::class],
+            [ilContext::CONTEXT_CRON, ilContextCron::class],
+            [ilContext::CONTEXT_RSS, ilContextRss::class],
+            [ilContext::CONTEXT_ICAL, ilContextIcal::class],
+            [ilContext::CONTEXT_SOAP, ilContextSoap::class],
+            [ilContext::CONTEXT_WEBDAV, ilContextWebdav::class],
+            [ilContext::CONTEXT_RSS_AUTH, ilContextRssAuth::class],
+            [ilContext::CONTEXT_SESSION_REMINDER, ilContextSessionReminder::class],
+            [ilContext::CONTEXT_SOAP_WITHOUT_CLIENT, ilContextSoapWithoutClient::class],
+            [ilContext::CONTEXT_UNITTEST, ilContextUnitTest::class],
+            [ilContext::CONTEXT_REST, ilContextRest::class],
+            [ilContext::CONTEXT_SCORM, ilContextScorm::class],
+            [ilContext::CONTEXT_WAC, ilContextWAC::class],
+        ];
     }
 }

--- a/Services/Context/test/ilContextTest.php
+++ b/Services/Context/test/ilContextTest.php
@@ -10,6 +10,11 @@ use PHPUnit\Framework\TestCase;
  */
 class ilContextTest extends TestCase
 {
+    protected function setUp() : void
+    {
+        require_once("Services/Context/test/class.ilContextExtended.php");
+    }
+
     /**
      * @dataProvider contextProvider
      */

--- a/Services/Context/test/ilServicesContextSuite.php
+++ b/Services/Context/test/ilServicesContextSuite.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestSuite;
  */
 class ilServicesContextSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new ilServicesContextSuite();
 


### PR DESCRIPTION
Hi @alex40724,

I completed the review of the `Service/Context` component.

Results:
- [x] The code style is `PSR-2 + X` compliant: 1 File has been changed by the `PHP-CS-FIXER`
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

I also fixed some trivial issues reported by my inspection profile.

--

Actions needed:

- [ ] Please delete the PR branch after merge (a button should appear here in this PR) because I accidently used the wrong remote repository :-).

Best regards,
@mjansenDatabay