### PR TITLE
PHP8: Code Review `Search`

### DIFF
--- a/Services/Search/classes/Form/class.ilLuceneQueryInputGUI.php
+++ b/Services/Search/classes/Form/class.ilLuceneQueryInputGUI.php
@@ -33,9 +33,8 @@ class ilLuceneQueryInputGUI extends ilTextInputGUI
 {
     public function checkInput() : bool
     {
-        
         $ok = parent::checkInput();
-        $query = ilUtil::stripSlashes($_POST[$this->getPostVar()]);
+        $query = ilUtil::stripSlashes($_POST[$this->getPostVar()]);// @TODO: PHP8 Review: Direct access to $_POST.
         if (!$ok or !strlen($query)) {
             return false;
         }

--- a/Services/Search/classes/Like/class.ilAbstractSearch.php
+++ b/Services/Search/classes/Like/class.ilAbstractSearch.php
@@ -63,7 +63,7 @@ abstract class ilAbstractSearch
         $this->object_types = $a_filter;
     }
 
-    public function setIdFilter(array $a_id_filter)
+    public function setIdFilter(array $a_id_filter)// @TODO: PHP8 Review: Missing return type.
     {
         $this->id_filter = $a_id_filter;
     }
@@ -103,7 +103,6 @@ abstract class ilAbstractSearch
                 $tmp_fields[] = array($field,'text');
             }
             $complete_str = $this->db->concat($tmp_fields);
-
         } else {
             $complete_str = $this->fields[0];
         }

--- a/Services/Search/classes/Like/class.ilLikeAdvancedSearch.php
+++ b/Services/Search/classes/Like/class.ilLikeAdvancedSearch.php
@@ -31,7 +31,6 @@ class ilLikeAdvancedSearch extends ilAdvancedSearch
 {
     public function __createTaxonWhereCondition() : string
     {
-        
         if ($this->options['lom_taxon']) {
             $where = " WHERE (";
             
@@ -51,7 +50,6 @@ class ilLikeAdvancedSearch extends ilAdvancedSearch
     
     public function __createKeywordWhereCondition() : string
     {
-        
         $where = " WHERE (";
         
         $counter = 0;
@@ -68,7 +66,6 @@ class ilLikeAdvancedSearch extends ilAdvancedSearch
     
     public function __createLifecycleWhereCondition() : string
     {
-        
         if ($this->options['lom_version']) {
             $where = " WHERE (";
             
@@ -88,7 +85,6 @@ class ilLikeAdvancedSearch extends ilAdvancedSearch
     
     public function __createEntityWhereCondition() : string
     {
-
         if ($this->options['lom_role_entry']) {
             $where = " WHERE (";
             
@@ -108,7 +104,6 @@ class ilLikeAdvancedSearch extends ilAdvancedSearch
 
     public function __createCoverageAndCondition() : string
     {
-
         if ($this->options['lom_coverage']) {
             $where = " AND (";
             
@@ -128,7 +123,6 @@ class ilLikeAdvancedSearch extends ilAdvancedSearch
     
     public function __createTitleDescriptionWhereCondition() : string
     {
-        
         $concat = $this->db->concat(
             array(
                 array('title','text'),

--- a/Services/Search/classes/Like/class.ilLikeExerciseSearch.php
+++ b/Services/Search/classes/Like/class.ilLikeExerciseSearch.php
@@ -36,7 +36,6 @@ class ilLikeExerciseSearch extends ilExerciseSearch
 {
     public function __createWhereCondition() : string
     {
-        
         $concat = $this->db->concat(
             array(
                 array('title','text'),

--- a/Services/Search/classes/Like/class.ilLikeForumSearch.php
+++ b/Services/Search/classes/Like/class.ilLikeForumSearch.php
@@ -63,7 +63,6 @@ class ilLikeForumSearch extends ilForumSearch
 
     public function __createTopicAndCondition() : string
     {
-
         $field = 'thr_subject ';
         $and = " AND( ";
 

--- a/Services/Search/classes/Like/class.ilLikeGlossaryDefinitionSearch.php
+++ b/Services/Search/classes/Like/class.ilLikeGlossaryDefinitionSearch.php
@@ -36,7 +36,6 @@ class ilLikeGlossaryDefinitionSearch extends ilGlossaryDefinitionSearch
 {
     public function __createWhereCondition() : string
     {
-        
         $concat = " term ";
 
         $and = "  WHERE ( ";

--- a/Services/Search/classes/Like/class.ilLikeLMContentSearch.php
+++ b/Services/Search/classes/Like/class.ilLikeLMContentSearch.php
@@ -36,7 +36,6 @@ class ilLikeLMContentSearch extends ilLMContentSearch
 {
     public function __createWhereCondition() : string
     {
-
         $concat = " content ";
 
         $and = "  WHERE ( ";

--- a/Services/Search/classes/Like/class.ilLikeMediaPoolSearch.php
+++ b/Services/Search/classes/Like/class.ilLikeMediaPoolSearch.php
@@ -63,7 +63,6 @@ class ilLikeMediaPoolSearch extends ilMediaPoolSearch
      */
     public function __createKeywordAndCondition() : string
     {
-
         $concat = ' keyword ';
 
         $and = "  WHERE  ";

--- a/Services/Search/classes/Like/class.ilLikeMetaDataSearch.php
+++ b/Services/Search/classes/Like/class.ilLikeMetaDataSearch.php
@@ -54,7 +54,6 @@ class ilLikeMetaDataSearch extends ilMetaDataSearch
 
     public function __createContributeWhereCondition() : string
     {
-        
         $concat = ' entity ';
         $where = " WHERE (";
         $counter = 0;
@@ -99,7 +98,6 @@ class ilLikeMetaDataSearch extends ilMetaDataSearch
 
     public function __createDescriptionWhereCondition() : string
     {
-        
         $concat = ' description ';
         $where = " WHERE (";
         $counter = 0;

--- a/Services/Search/classes/Like/class.ilLikeTestSearch.php
+++ b/Services/Search/classes/Like/class.ilLikeTestSearch.php
@@ -36,7 +36,6 @@ class ilLikeTestSearch extends ilTestSearch
 {
     public function __createWhereCondition() : string
     {
-
         foreach ($this->getFields() as $field) {
             $tmp_field[$field] = 'text';
         }

--- a/Services/Search/classes/Like/class.ilLikeUserDefinedFieldSearch.php
+++ b/Services/Search/classes/Like/class.ilLikeUserDefinedFieldSearch.php
@@ -14,7 +14,6 @@
 */
 class ilLikeUserDefinedFieldSearch extends ilUserDefinedFieldSearch
 {
-
     public function setFields(array $a_fields) : void
     {
         $fields = [];

--- a/Services/Search/classes/Like/class.ilLikeUserMultiFieldSearch.php
+++ b/Services/Search/classes/Like/class.ilLikeUserMultiFieldSearch.php
@@ -14,7 +14,6 @@
 */
 class ilLikeUserMultiFieldSearch extends ilAbstractSearch
 {
-
     public function performSearch() : ilSearchResult
     {
         $where = $this->__createWhereCondition();
@@ -45,7 +44,6 @@ class ilLikeUserMultiFieldSearch extends ilAbstractSearch
 
     public function __createWhereCondition() : string
     {
-        
         $fields = $this->getFields();
         $field = $fields[0];
 

--- a/Services/Search/classes/Like/class.ilLikeUserOrgUnitSearch.php
+++ b/Services/Search/classes/Like/class.ilLikeUserOrgUnitSearch.php
@@ -44,7 +44,6 @@ class ilLikeUserOrgUnitSearch extends ilAbstractSearch
 
     public function __createWhereCondition() : string
     {
-
         $and = '';
         $where = 'WHERE ';
         $counter = 0;

--- a/Services/Search/classes/Like/class.ilLikeUserSearch.php
+++ b/Services/Search/classes/Like/class.ilLikeUserSearch.php
@@ -36,7 +36,6 @@ class ilLikeUserSearch extends ilUserSearch
 {
     public function __createWhereCondition() : string
     {
-        
         $fields = $this->getFields();
         $field = $fields[0] . ' ';
 

--- a/Services/Search/classes/Like/class.ilLikeWebresourceSearch.php
+++ b/Services/Search/classes/Like/class.ilLikeWebresourceSearch.php
@@ -33,10 +33,8 @@
 
 class ilLikeWebresourceSearch extends ilWebresourceSearch
 {
-
     public function __createWhereCondition() : string
     {
-
         $concat = ' title ';
 
         $and = "  WHERE  ";

--- a/Services/Search/classes/Like/class.ilLikeWikiContentSearch.php
+++ b/Services/Search/classes/Like/class.ilLikeWikiContentSearch.php
@@ -34,10 +34,8 @@
 */
 class ilLikeWikiContentSearch extends ilWikiContentSearch
 {
-
     public function __createWhereCondition() : string
     {
-
         $and = "  WHERE ( ";
         $counter = 0;
         foreach ($this->query_parser->getQuotedWords() as $word) {

--- a/Services/Search/classes/Lucene/class.ilLuceneAdvancedSearchFields.php
+++ b/Services/Search/classes/Lucene/class.ilLuceneAdvancedSearchFields.php
@@ -317,7 +317,7 @@ class ilLuceneAdvancedSearchFields
                         'query[' . 'lom_level_end' . ']',
                         array(0 => $this->lng->txt('search_any'))
                     )
-                    );
+                );
                 $range->setHtml($html);
                 return $range;
                         
@@ -336,7 +336,7 @@ class ilLuceneAdvancedSearchFields
                         'query[' . 'lom_density_end' . ']',
                         array(0 => $this->lng->txt('search_any'))
                     )
-                    );
+                );
                 $range->setHtml($html);
                 return $range;
 
@@ -378,7 +378,7 @@ class ilLuceneAdvancedSearchFields
                         'query[' . 'lom_difficulty_end' . ']',
                         array(0 => $this->lng->txt('search_any'))
                     )
-                    );
+                );
                 $range->setHtml($html);
                 return $range;
 
@@ -476,6 +476,7 @@ class ilLuceneAdvancedSearchFields
                 }
 
             // General
+            // no break
             case 'lom_language':
                 return 'lomLanguage:' . $a_query;
                 
@@ -655,7 +656,6 @@ class ilLuceneAdvancedSearchFields
      */
     protected function readSections() : void
     {
-
         foreach ($this->getActiveFields() as $field_name => $translation) {
             switch ($field_name) {
                 // Default section
@@ -795,9 +795,8 @@ class ilLuceneAdvancedSearchFields
         string $txt_from,
         string $select_from,
         string $txt_until,
-        string $select_until)
-    : string
-    {
+        string $select_until
+    ) : string {
         $tpl = new ilTemplate('tpl.range_search.html', true, true, 'Services/Search');
         $tpl->setVariable('TXT_FROM', $txt_from);
         $tpl->setVariable('FROM', $select_from);

--- a/Services/Search/classes/Lucene/class.ilLuceneAdvancedSearchGUI.php
+++ b/Services/Search/classes/Lucene/class.ilLuceneAdvancedSearchGUI.php
@@ -192,7 +192,7 @@ class ilLuceneAdvancedSearchGUI extends ilSearchBaseGUI
             $this->showSavedResults();
             return;
         }
-        unset($_SESSION['max_page']);
+        unset($_SESSION['max_page']);// @TODO: PHP8 Review: Direct access to $_SESSION.
         $this->search_cache->deleteCachedEntries();
         
         // Reset details
@@ -216,7 +216,7 @@ class ilLuceneAdvancedSearchGUI extends ilSearchBaseGUI
      */
     protected function performSearch() : void
     {
-        unset($_SESSION['vis_references']);
+        unset($_SESSION['vis_references']);// @TODO: PHP8 Review: Direct access to $_SESSION.
         
         $qp = new ilLuceneAdvancedQueryParser($this->search_cache->getQuery());
         $qp->parse();

--- a/Services/Search/classes/Lucene/class.ilLuceneAdvancedSearchGUI.php
+++ b/Services/Search/classes/Lucene/class.ilLuceneAdvancedSearchGUI.php
@@ -74,7 +74,7 @@ class ilLuceneAdvancedSearchGUI extends ilSearchBaseGUI
         switch ($next_class) {
             case 'ilobjectcopygui':
                 $this->ctrl->setReturn($this);
-                $cp = new ilObjectCopyGUI($this);
+                $cp = new ilObjectCopyGUI($this);// @TODO: PHP8 Review: Invalid argument.
                 $this->ctrl->forwardCommand($cp);
                 break;
             

--- a/Services/Search/classes/Lucene/class.ilLuceneAdvancedSearchSettings.php
+++ b/Services/Search/classes/Lucene/class.ilLuceneAdvancedSearchSettings.php
@@ -55,7 +55,7 @@ class ilLuceneAdvancedSearchSettings
     /**
      * check if field is active
      */
-    public function isActive($a_field) : bool
+    public function isActive($a_field) : bool// @TODO: PHP8 Review: Missing parameter type.
     {
         return $this->fields[$a_field] ?: false;
     }

--- a/Services/Search/classes/Lucene/class.ilLucenePathFilter.php
+++ b/Services/Search/classes/Lucene/class.ilLucenePathFilter.php
@@ -35,7 +35,7 @@ class ilLucenePathFilter implements ilLuceneResultFilter
     protected array $subnodes = [];
     protected ilTree $tree;
     
-    public function __construct($a_root)
+    public function __construct($a_root)// @TODO: PHP8 Review: Missing parameter type.
     {
         global $DIC;
 
@@ -48,7 +48,6 @@ class ilLucenePathFilter implements ilLuceneResultFilter
      */
     public function filter(int $a_ref_id) : bool
     {
-        
         if ($this->root == ROOT_FOLDER_ID) {
             return true;
         }
@@ -64,7 +63,6 @@ class ilLucenePathFilter implements ilLuceneResultFilter
      */
     protected function init() : void
     {
-        
         if ($this->root == ROOT_FOLDER_ID) {
             $this->subnodes = array();
         } else {

--- a/Services/Search/classes/Lucene/class.ilLuceneQueryParser.php
+++ b/Services/Search/classes/Lucene/class.ilLuceneQueryParser.php
@@ -95,7 +95,7 @@ class ilLuceneQueryParser
      * @throws ilLuceneQueryParserException
      * @todo add multi byte query validation.
      */
-    public static function validateQuery($a_query)
+    public static function validateQuery($a_query)// @TODO: PHP8 Review: Missing return type.// @TODO: PHP8 Review: Missing parameter type.
     {
         #ilLuceneQueryParser::checkAllowedCharacters($a_query);
         #ilLuceneQueryParser::checkAsterisk($a_query);

--- a/Services/Search/classes/Lucene/class.ilLuceneSearchGUI.php
+++ b/Services/Search/classes/Lucene/class.ilLuceneSearchGUI.php
@@ -85,7 +85,7 @@ class ilLuceneSearchGUI extends ilSearchBaseGUI
 
             case 'ilobjectcopygui':
                 $this->ctrl->setReturn($this, '');
-                $cp = new ilObjectCopyGUI($this);
+                $cp = new ilObjectCopyGUI($this);// @TODO: PHP8 Review: Invalid argument.
                 $this->ctrl->forwardCommand($cp);
                 break;
 

--- a/Services/Search/classes/Lucene/class.ilLuceneSearchGUI.php
+++ b/Services/Search/classes/Lucene/class.ilLuceneSearchGUI.php
@@ -217,7 +217,7 @@ class ilLuceneSearchGUI extends ilSearchBaseGUI
             return;
         }
 
-        unset($_SESSION['max_page']);
+        unset($_SESSION['max_page']);// @TODO: PHP8 Review: Direct access to $_SESSION.
         $this->search_cache->deleteCachedEntries();
 
         // Reset details
@@ -230,7 +230,7 @@ class ilLuceneSearchGUI extends ilSearchBaseGUI
      */
     protected function performSearch() : void
     {
-        unset($_SESSION['vis_references']);
+        unset($_SESSION['vis_references']);// @TODO: PHP8 Review: Direct access to $_SESSION.
 
         $filter_query = '';
         if ($this->search_cache->getItemFilter() and ilSearchSettings::getInstance()->isLuceneItemFilterEnabled()) {
@@ -357,12 +357,12 @@ class ilLuceneSearchGUI extends ilSearchBaseGUI
         if ($page_number) {
             $this->search_cache->setResultPageNumber($page_number);
         }
-        if (isset($_POST['term'])) {
-            $this->search_cache->setQuery(ilUtil::stripSlashes($_POST['term']));
-            if ($_POST['item_filter_enabled']) {
+        if (isset($_POST['term'])) {// @TODO: PHP8 Review: Direct access to $_POST.
+            $this->search_cache->setQuery(ilUtil::stripSlashes($_POST['term']));// @TODO: PHP8 Review: Direct access to $_POST.
+            if ($_POST['item_filter_enabled']) {// @TODO: PHP8 Review: Direct access to $_POST.
                 $filtered = array();
                 foreach (ilSearchSettings::getInstance()->getEnabledLuceneItemFilterDefinitions() as $type => $data) {
-                    if ($_POST['filter_type'][$type]) {
+                    if ($_POST['filter_type'][$type]) {// @TODO: PHP8 Review: Direct access to $_POST.
                         $filtered[$type] = 1;
                     }
                 }
@@ -371,19 +371,19 @@ class ilLuceneSearchGUI extends ilSearchBaseGUI
                 // Mime filter
                 $mime = array();
                 foreach (ilSearchSettings::getInstance()->getEnabledLuceneMimeFilterDefinitions() as $type => $data) {
-                    if ($_POST['filter_type'][$type]) {
+                    if ($_POST['filter_type'][$type]) {// @TODO: PHP8 Review: Direct access to $_POST.
                         $mime[$type] = 1;
                     }
                 }
                 $this->search_cache->setMimeFilter($mime);
             }
             $this->search_cache->setCreationFilter($this->loadCreationFilter());
-            if (!$_POST['item_filter_enabled']) {
+            if (!$_POST['item_filter_enabled']) {// @TODO: PHP8 Review: Direct access to $_POST.
                 // @todo: keep item filter settings
                 $this->search_cache->setItemFilter(array());
                 $this->search_cache->setMimeFilter(array());
             }
-            if (!$_POST['screation']) {
+            if (!$_POST['screation']) {// @TODO: PHP8 Review: Direct access to $_POST.
                 $this->search_cache->setCreationFilter(array());
             }
         }

--- a/Services/Search/classes/Lucene/class.ilLuceneSearcher.php
+++ b/Services/Search/classes/Lucene/class.ilLuceneSearcher.php
@@ -58,7 +58,7 @@ class ilLuceneSearcher
     /**
      * Get singleton instance
      */
-    public static function getInstance(ilLuceneQueryParser $qp)
+    public static function getInstance(ilLuceneQueryParser $qp)// @TODO: PHP8 Review: Missing return type.
     {
         if (self::$instance instanceof ilLuceneSearcher) {
             return self::$instance;
@@ -107,7 +107,7 @@ class ilLuceneSearcher
                 CLIENT_ID . '_' . $this->setting->get('inst_id', '0'),
                 $a_obj_ids,
                 $this->query_parser->getQuery()
-                );
+            );
         } catch (Exception $e) {
             ilLoggerFactory::getLogger('src')->error('Highlighting failed with message: ' . $e->getMessage());
             return new ilLuceneHighlighterResultParser();
@@ -140,7 +140,7 @@ class ilLuceneSearcher
     /**
      * Get result
      */
-    public function getResult()
+    public function getResult()// @TODO: PHP8 Review: Missing return type.
     {
         return $this->result;
     }

--- a/Services/Search/classes/Lucene/class.ilLuceneSubItemListGUIFactory.php
+++ b/Services/Search/classes/Lucene/class.ilLuceneSubItemListGUIFactory.php
@@ -52,7 +52,7 @@ class ilLuceneSubItemListGUIFactory
         if (@include_once($location . "/class." . $full_class . ".php")) {
             return self::$instances[$a_type] = new $full_class($a_cmd_class);
         } else {
-            return self::$instances[$a_type] = new ilObjectSubItemListGUI($a_cmd_class);
+            return self::$instances[$a_type] = new ilObjectSubItemListGUI($a_cmd_class);// @TODO: PHP8 Review: Invalid argument.
         }
     }
 }

--- a/Services/Search/classes/Lucene/class.ilLuceneUserSearchGUI.php
+++ b/Services/Search/classes/Lucene/class.ilLuceneUserSearchGUI.php
@@ -42,7 +42,7 @@ class ilLuceneUserSearchGUI extends ilSearchBaseGUI
         $this->prepareOutput();
         switch ($next_class) {
             case "ilpublicuserprofilegui":
-                $profile = new ilPublicUserProfileGUI((int) $_REQUEST['user']);
+                $profile = new ilPublicUserProfileGUI((int) $_REQUEST['user']);// @TODO: PHP8 Review: Direct access to $_REQUEST.
                 $profile->setBackUrl($this->ctrl->getLinkTarget($this, 'showSavedResults'));
                 $ret = $this->ctrl->forwardCommand($profile);
                 $this->tpl->setContent($ret);
@@ -72,7 +72,7 @@ class ilLuceneUserSearchGUI extends ilSearchBaseGUI
      * @todo rename
      * Needed for base class search form
      */
-    protected function getType()
+    protected function getType()// @TODO: PHP8 Review: Missing return type.
     {
         return self::SEARCH_DETAILS;
     }
@@ -81,7 +81,7 @@ class ilLuceneUserSearchGUI extends ilSearchBaseGUI
      * Needed for base class search form
      * @todo rename
      */
-    protected function getDetails()
+    protected function getDetails()// @TODO: PHP8 Review: Missing return type.
     {
         return $this->search_cache->getItemFilter();
     }
@@ -118,7 +118,6 @@ class ilLuceneUserSearchGUI extends ilSearchBaseGUI
      */
     protected function showSavedResults() : void
     {
-        
         if (strlen($this->search_cache->getQuery())) {
             $this->performSearch();
             return;
@@ -141,7 +140,7 @@ class ilLuceneUserSearchGUI extends ilSearchBaseGUI
             return;
         }
         
-        unset($_SESSION['max_page']);
+        unset($_SESSION['max_page']);// @TODO: PHP8 Review: Direct access to $_SESSION.
         $this->search_cache->deleteCachedEntries();
         
         // Reset details
@@ -162,7 +161,7 @@ class ilLuceneUserSearchGUI extends ilSearchBaseGUI
         
         $this->showSearchForm();
         
-                $user_table = new ilRepositoryUserResultTableGUI(
+        $user_table = new ilRepositoryUserResultTableGUI(
             $this,
             'performSearch',
             false,
@@ -171,7 +170,7 @@ class ilLuceneUserSearchGUI extends ilSearchBaseGUI
         $user_table->setLuceneResult($searcher->getResult());
         $user_table->parseUserIds($searcher->getResult()->getCandidates());
 
-       $this->tpl->setVariable('SEARCH_RESULTS', $user_table->getHTML());
+        $this->tpl->setVariable('SEARCH_RESULTS', $user_table->getHTML());
     }
     
     /**
@@ -179,7 +178,6 @@ class ilLuceneUserSearchGUI extends ilSearchBaseGUI
      */
     protected function getTabs() : void
     {
-
         $this->help->setScreenIdComponent("src_luc");
 
         $this->tabs->addTarget('search', $this->ctrl->getLinkTargetByClass('illucenesearchgui'));
@@ -204,7 +202,6 @@ class ilLuceneUserSearchGUI extends ilSearchBaseGUI
      */
     protected function initUserSearchCache() : void
     {
-        
         $this->search_cache = ilUserSearchCache::_getInstance($this->user->getId());
         $this->search_cache->switchSearchType(ilUserSearchCache::LUCENE_USER_SEARCH);
         $page_number = $this->initPageNumberFromQuery();
@@ -232,7 +229,6 @@ class ilLuceneUserSearchGUI extends ilSearchBaseGUI
      */
     protected function showSearchForm()
     {
-        
         $this->tpl->addBlockFile('ADM_CONTENT', 'adm_content', 'tpl.lucene_usr_search.html', 'Services/Search');
 
         ilOverlayGUI::initJavascript();

--- a/Services/Search/classes/class.ilAdvancedSearch.php
+++ b/Services/Search/classes/class.ilAdvancedSearch.php
@@ -172,7 +172,6 @@ class ilAdvancedSearch extends ilAbstractSearch
 
     public function __searchLanguage() : ?ilSearchResult
     {
-        
         if (!$this->options['lom_language']) {
             return null;
         }
@@ -192,7 +191,6 @@ class ilAdvancedSearch extends ilAbstractSearch
 
     public function __searchContribute() : ?ilSearchResult
     {
-        
         if (!$this->options['lom_role']) {
             return null;
         }
@@ -373,7 +371,6 @@ class ilAdvancedSearch extends ilAbstractSearch
     }
     public function __searchLifecycle() : ilSearchResult
     {
-        
         $this->setFields(array('meta_version'));
 
         $locate = '';
@@ -407,7 +404,6 @@ class ilAdvancedSearch extends ilAbstractSearch
 
     public function __searchFormat() : ?ilSearchResult
     {
-        
         if (!$this->options['lom_format']) {
             return null;
         }
@@ -427,7 +423,6 @@ class ilAdvancedSearch extends ilAbstractSearch
 
     public function __createRightsWhere() : string
     {
-        
         $counter = 0;
         $where = 'WHERE ';
 
@@ -444,7 +439,6 @@ class ilAdvancedSearch extends ilAbstractSearch
     }
     public function __createClassificationWhere() : string
     {
-
         $counter = 0;
         $where = 'WHERE ';
 
@@ -457,7 +451,6 @@ class ilAdvancedSearch extends ilAbstractSearch
     }
     public function __createEducationalWhere() : string
     {
-
         $counter = 0;
         $where = 'WHERE ';
 
@@ -516,7 +509,6 @@ class ilAdvancedSearch extends ilAbstractSearch
     }
     public function __createRequirementWhere() : string
     {
-
         $counter = 0;
         $where = 'WHERE ';
 

--- a/Services/Search/classes/class.ilAdvancedSearchGUI.php
+++ b/Services/Search/classes/class.ilAdvancedSearchGUI.php
@@ -97,7 +97,7 @@ class ilAdvancedSearchGUI extends ilSearchBaseGUI
             default:
                 $this->initUserSearchCache();
                 if (!$cmd) {
-                    switch ($_SESSION['search_last_sub_section']) {
+                    switch ($_SESSION['search_last_sub_section']) {// @TODO: PHP8 Review: Direct access to $_SESSION.
                         case self::TYPE_ADV_MD:
                             $cmd = "showSavedAdvMDResults";
                             break;
@@ -127,7 +127,7 @@ class ilAdvancedSearchGUI extends ilSearchBaseGUI
         $this->initSearchType(self::TYPE_LOM);
         $this->search_mode = 'in_results';
         $this->search_cache->setResultPageNumber(1);
-        unset($_SESSION['adv_max_page']);
+        unset($_SESSION['adv_max_page']);// @TODO: PHP8 Review: Direct access to $_SESSION.
         $this->performSearch();
 
         return true;
@@ -167,7 +167,7 @@ class ilAdvancedSearchGUI extends ilSearchBaseGUI
         $this->initSearchType(self::TYPE_LOM);
         $page_number = $this->initPageNumberFromQuery();
         if (!$page_number and $this->search_mode != 'in_results') {
-            unset($_SESSION['adv_max_page']);
+            unset($_SESSION['adv_max_page']);// @TODO: PHP8 Review: Direct access to $_SESSION.
             $this->search_cache->deleteCachedEntries();
         }
 
@@ -308,7 +308,7 @@ class ilAdvancedSearchGUI extends ilSearchBaseGUI
         $this->initSearchType(self::TYPE_ADV_MD);
         $page_number = $this->initPageNumberFromQuery();
         if (!$page_number and $this->search_mode != 'in_results') {
-            unset($_SESSION['adv_max_page']);
+            unset($_SESSION['adv_max_page']);// @TODO: PHP8 Review: Direct access to $_SESSION.
             $this->search_cache->delete();
         }
         $res = new ilSearchResult();
@@ -350,8 +350,8 @@ class ilAdvancedSearchGUI extends ilSearchBaseGUI
     
     public function showAdvMDSearch() : bool
     {
-        if (isset($_SESSION['search_adv_md'])) {
-            $this->options = $_SESSION['search_adv_md'];
+        if (isset($_SESSION['search_adv_md'])) {// @TODO: PHP8 Review: Direct access to $_SESSION.
+            $this->options = $_SESSION['search_adv_md'];// @TODO: PHP8 Review: Direct access to $_SESSION.
         }
         $this->setSubTabs();
         $this->tabs_gui->setSubTabActive('search_adv_md');
@@ -807,12 +807,12 @@ class ilAdvancedSearchGUI extends ilSearchBaseGUI
             );
         }
 
-        if (isset($_POST['cmd']['performSearch'])) {
-            $this->options = $_SESSION['search_adv'] = $query;
-        } elseif (isset($_POST['cmd']['performAdvMDSearch'])) {
-            $this->options = $_SESSION['search_adv_md'] = $_POST;
+        if (isset($_POST['cmd']['performSearch'])) {// @TODO: PHP8 Review: Direct access to $_POST.
+            $this->options = $_SESSION['search_adv'] = $query;// @TODO: PHP8 Review: Direct access to $_SESSION.
+        } elseif (isset($_POST['cmd']['performAdvMDSearch'])) {// @TODO: PHP8 Review: Direct access to $_POST.
+            $this->options = $_SESSION['search_adv_md'] = $_POST;// @TODO: PHP8 Review: Direct access to $_POST.// @TODO: PHP8 Review: Direct access to $_SESSION.
         } else {
-            $this->options = ($_SESSION['search_adv'] ?? array());
+            $this->options = ($_SESSION['search_adv'] ?? array());// @TODO: PHP8 Review: Direct access to $_SESSION.
         }
         $this->filter = array();
 
@@ -923,8 +923,8 @@ class ilAdvancedSearchGUI extends ilSearchBaseGUI
         if ($page_number) {
             $this->search_cache->setResultPageNumber($page_number);
         }
-        if ($_POST['cmd']['performSearch']) {
-            $this->search_cache->setQuery(ilUtil::stripSlashes($_POST['query']['lomContent']));
+        if ($_POST['cmd']['performSearch']) {// @TODO: PHP8 Review: Direct access to $_POST.
+            $this->search_cache->setQuery(ilUtil::stripSlashes($_POST['query']['lomContent']));// @TODO: PHP8 Review: Direct access to $_POST.
             $this->search_cache->save();
         }
     }
@@ -948,10 +948,10 @@ class ilAdvancedSearchGUI extends ilSearchBaseGUI
     private function initSearchType(int $type) : void
     {
         if ($type == self::TYPE_LOM) {
-            $_SESSION['search_last_sub_section'] = self::TYPE_LOM;
+            $_SESSION['search_last_sub_section'] = self::TYPE_LOM;// @TODO: PHP8 Review: Direct access to $_SESSION.
             $this->search_cache->switchSearchType(ilUserSearchCache::ADVANCED_SEARCH);
         } else {
-            $_SESSION['search_last_sub_section'] = self::TYPE_ADV_MD;
+            $_SESSION['search_last_sub_section'] = self::TYPE_ADV_MD;// @TODO: PHP8 Review: Direct access to $_SESSION.
             $this->search_cache->switchSearchType(ilUserSearchCache::ADVANCED_MD_SEARCH);
         }
     }

--- a/Services/Search/classes/class.ilAdvancedSearchGUI.php
+++ b/Services/Search/classes/class.ilAdvancedSearchGUI.php
@@ -90,7 +90,7 @@ class ilAdvancedSearchGUI extends ilSearchBaseGUI
                 $this->prepareOutput();
                 $this->ctrl->setReturn($this, '');
 
-                $cp = new ilObjectCopyGUI($this);
+                $cp = new ilObjectCopyGUI($this);// @TODO: PHP8 Review: Invalid argument.
                 $this->ctrl->forwardCommand($cp);
                 break;
             

--- a/Services/Search/classes/class.ilMainMenuSearchGUI.php
+++ b/Services/Search/classes/class.ilMainMenuSearchGUI.php
@@ -47,7 +47,7 @@ class ilMainMenuSearchGUI
     {
         $this->ref_id = ROOT_FOLDER_ID;
         if ($this->http->wrapper()->query()->has('ref_id')) {
-            $this->ref_id  = $this->http->wrapper()->query()->retrieve(
+            $this->ref_id = $this->http->wrapper()->query()->retrieve(
                 'ref_id',
                 $this->refinery->kindlyTo()->int()
             );
@@ -96,7 +96,8 @@ class ilMainMenuSearchGUI
         );
         $this->tpl->setVariable('BTN_SEARCH', $this->lng->txt('search'));
         $this->tpl->setVariable('SEARCH_INPUT_LABEL', $this->lng->txt('search_field'));
-        $this->tpl->setVariable('AC_DATASOURCE',
+        $this->tpl->setVariable(
+            'AC_DATASOURCE',
             $this->ctrl->getLinkTargetByClass(
                 ilSearchControllerGUI::class,
                 'autoComplete',

--- a/Services/Search/classes/class.ilObjSearchSettingsGUI.php
+++ b/Services/Search/classes/class.ilObjSearchSettingsGUI.php
@@ -304,7 +304,7 @@ class ilObjSearchSettingsGUI extends ilObjectGUI
 
     protected function initFormLuceneSettings() : ilPropertyFormGUI
     {
-        $this->settings = ilSearchSettings::getInstance();
+        $this->settings = ilSearchSettings::getInstance();// @TODO: PHP8 Review: Wrong type. Instance of ilSettings expected.
         $form = new ilPropertyFormGUI();
         $form->setFormAction($this->ctrl->getFormAction($this, 'cancel'));
 

--- a/Services/Search/classes/class.ilObjectSearch.php
+++ b/Services/Search/classes/class.ilObjectSearch.php
@@ -53,7 +53,6 @@ class ilObjectSearch extends ilAbstractSearch
 
     public function performSearch() : ilSearchResult
     {
-        
         $in = $this->__createInStatement();
         $where = $this->__createWhereCondition();
         

--- a/Services/Search/classes/class.ilQueryParser.php
+++ b/Services/Search/classes/class.ilQueryParser.php
@@ -39,7 +39,7 @@ class ilQueryParser
      */
     public const MIN_WORD_LENGTH = 3;
     public const QP_COMBINATION_AND = 'and';
-    public const QP_COMBINATION_OR  = 'or';
+    public const QP_COMBINATION_OR = 'or';
 
     protected ilLanguage $lng;
     protected ilSearchSettings $settings;

--- a/Services/Search/classes/class.ilRepositoryObjectDetailSearch.php
+++ b/Services/Search/classes/class.ilRepositoryObjectDetailSearch.php
@@ -45,7 +45,7 @@ class ilRepositoryObjectDetailSearch
     }
     
     
-    public function setQueryString(string $a_query)
+    public function setQueryString(string $a_query)// @TODO: PHP8 Review: Missing return type.
     {
         $this->query_string = $a_query;
     }
@@ -104,7 +104,6 @@ class ilRepositoryObjectDetailSearch
      */
     protected function performDBSearch() : ilRepositoryObjectDetailSearchResult
     {
-
         $query_parser = new ilQueryParser($this->getQueryString());
         
         $query_parser->setCombination(

--- a/Services/Search/classes/class.ilRepositoryObjectSearchBlockGUI.php
+++ b/Services/Search/classes/class.ilRepositoryObjectSearchBlockGUI.php
@@ -15,7 +15,7 @@
 class ilRepositoryObjectSearchBlockGUI extends ilBlockGUI
 {
     public static string $block_type = "objectsearch";
-    public static $st_data;
+    public static $st_data;// @TODO: PHP8 Review: Missing property type.
 
 
     public function __construct(string $a_title)
@@ -79,7 +79,7 @@ class ilRepositoryObjectSearchBlockGUI extends ilBlockGUI
     // New rendering
     //
 
-    protected $new_rendering = true;
+    protected $new_rendering = true;// @TODO: PHP8 Review: Missing property type.
 
 
     /**
@@ -95,7 +95,7 @@ class ilRepositoryObjectSearchBlockGUI extends ilBlockGUI
         $tpl->setVariable("FORMACTION", $this->ctrl->getFormActionByClass('ilrepositoryobjectsearchgui', 'performSearch'));
         $tpl->setVariable(
             "SEARCH_TERM",
-            ilLegacyFormElementsUtil::prepareFormOutput(ilUtil::stripSlashes($_POST["search_term"] ?? ""))
+            ilLegacyFormElementsUtil::prepareFormOutput(ilUtil::stripSlashes($_POST["search_term"] ?? ""))// @TODO: PHP8 Review: Direct access to $_POST.
         );
 
         return $tpl->get();

--- a/Services/Search/classes/class.ilRepositorySearchGUI.php
+++ b/Services/Search/classes/class.ilRepositorySearchGUI.php
@@ -420,7 +420,7 @@ class ilRepositorySearchGUI
         if ($this->http->wrapper()->post()->has('obj')) {
             $obj_ids = $this->http->wrapper()->post()->retrieve(
                 'obj',
-                $this->refinery->kindlyTo()->listOf($this->refinery->int())
+                $this->refinery->kindlyTo()->listOf($this->refinery->int())// @TODO: PHP8 Review: Invalid argument.
             );
         }
         $role_ids = array();

--- a/Services/Search/classes/class.ilRepositorySearchGUI.php
+++ b/Services/Search/classes/class.ilRepositorySearchGUI.php
@@ -134,7 +134,7 @@ class ilRepositorySearchGUI
         return $this->search_title;
     }
 
-    public function enableSearchableCheck(bool $a_status)
+    public function enableSearchableCheck(bool $a_status)// @TODO: PHP8 Review: Missing return type.
     {
         $this->searchable_check = $a_status;
     }
@@ -341,7 +341,7 @@ class ilRepositorySearchGUI
         $auto = new ilUserAutoComplete();
         $auto->setPrivacyMode($this->getPrivacyMode());
 
-        if (($_REQUEST['fetchall'])) {
+        if (($_REQUEST['fetchall'])) {// @TODO: PHP8 Review: Direct access to $_REQUEST.
             $auto->setLimit(ilUserAutoComplete::MAX_ENTRIES);
         }
 
@@ -354,14 +354,14 @@ class ilRepositorySearchGUI
             $auto->addUserAccessFilterCallable($this->user_filter);
         }
 
-        echo $auto->getList($_REQUEST['term']);
+        echo $auto->getList($_REQUEST['term']);// @TODO: PHP8 Review: Direct access to $_REQUEST.
         return null;
     }
 
 
     public function setString(string $a_str) : void
     {
-        $_SESSION['search']['string'] = $this->string = $a_str;
+        $_SESSION['search']['string'] = $this->string = $a_str;// @TODO: PHP8 Review: Direct access to $_SESSION.
     }
     public function getString() : string
     {
@@ -388,10 +388,10 @@ class ilRepositorySearchGUI
 
     public function __clearSession() : void
     {
-        unset($_SESSION['rep_search']);
-        unset($_SESSION['append_results']);
-        unset($_SESSION['rep_query']);
-        unset($_SESSION['rep_search_type']);
+        unset($_SESSION['rep_search']);// @TODO: PHP8 Review: Direct access to $_SESSION.
+        unset($_SESSION['append_results']);// @TODO: PHP8 Review: Direct access to $_SESSION.
+        unset($_SESSION['rep_query']);// @TODO: PHP8 Review: Direct access to $_SESSION.
+        unset($_SESSION['rep_search_type']);// @TODO: PHP8 Review: Direct access to $_SESSION.
     }
 
     public function cancel() : void
@@ -466,7 +466,7 @@ class ilRepositorySearchGUI
         $class = $this->callback['class'];
         $method = $this->callback['method'];
 
-        $users = explode(',', $_POST['user_login']);
+        $users = explode(',', $_POST['user_login']);// @TODO: PHP8 Review: Direct access to $_POST.
         $user_ids = array();
         foreach ($users as $user) {
             $user_id = ilObjUser::_lookupId($user);
@@ -475,7 +475,7 @@ class ilRepositorySearchGUI
             }
         }
 
-        $user_type = $_REQUEST['user_type'] ?? 0;
+        $user_type = $_REQUEST['user_type'] ?? 0;// @TODO: PHP8 Review: Direct access to $_REQUEST.
 
         if (!$class->$method($user_ids, (int) $user_type)) {
             $this->ctrl->returnToParent($this);
@@ -484,9 +484,9 @@ class ilRepositorySearchGUI
     
     protected function showClipboard() : void
     {
-        $this->ctrl->setParameter($this, 'user_type', (int) $_REQUEST['user_type']);
+        $this->ctrl->setParameter($this, 'user_type', (int) $_REQUEST['user_type']);// @TODO: PHP8 Review: Direct access to $_REQUEST.
         
-        ilLoggerFactory::getLogger('crs')->dump($_REQUEST);
+        ilLoggerFactory::getLogger('crs')->dump($_REQUEST);// @TODO: PHP8 Review: Direct access to $_REQUEST.
         
         $this->tabs->clearTargets();
         $this->tabs->setBackTarget(
@@ -505,15 +505,15 @@ class ilRepositorySearchGUI
 
     protected function addFromClipboard() : void
     {
-        $this->ctrl->setParameter($this, 'user_type', (int) $_REQUEST['user_type']);
-        $users = (array) $_POST['uids'];
+        $this->ctrl->setParameter($this, 'user_type', (int) $_REQUEST['user_type']);// @TODO: PHP8 Review: Direct access to $_REQUEST.
+        $users = (array) $_POST['uids'];// @TODO: PHP8 Review: Direct access to $_POST.
         if (!count($users)) {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('select_one'), true);
             $this->ctrl->redirect($this, 'showClipboard');
         }
         $class = $this->callback['class'];
         $method = $this->callback['method'];
-        $user_type = $_REQUEST['user_type'] ?? 0;
+        $user_type = $_REQUEST['user_type'] ?? 0;// @TODO: PHP8 Review: Direct access to $_REQUEST.
 
         if (!$class->$method($users, $user_type)) {
             $this->ctrl->returnToParent($this);
@@ -533,7 +533,7 @@ class ilRepositorySearchGUI
             );
         }
 
-        $this->ctrl->setParameter($this, 'user_type', (int) $_REQUEST['user_type']);
+        $this->ctrl->setParameter($this, 'user_type', (int) $_REQUEST['user_type']);// @TODO: PHP8 Review: Direct access to $_REQUEST.
         if (!count($users)) {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('select_one'), true);
             $this->ctrl->redirect($this, 'showClipboard');
@@ -565,7 +565,7 @@ class ilRepositorySearchGUI
         $method = $this->callback['method'];
 
         // Redirects if everything is ok
-        if (!$class->$method((array) $_POST['user'], $_POST['selectedCommand'])) {
+        if (!$class->$method((array) $_POST['user'], $_POST['selectedCommand'])) {// @TODO: PHP8 Review: Direct access to $_POST.
             $this->showSearchResults();
         }
     }
@@ -600,7 +600,7 @@ class ilRepositorySearchGUI
     
     public function showSearchSelected() : void
     {
-        $selected = (int) $_REQUEST['selected_id'];
+        $selected = (int) $_REQUEST['selected_id'];// @TODO: PHP8 Review: Direct access to $_REQUEST.
         
         $this->tpl->addBlockFile('ADM_CONTENT', 'adm_content', 'tpl.rep_search_result.html', 'Services/Search');
         $this->addNewSearchButton();
@@ -740,7 +740,7 @@ class ilRepositorySearchGUI
 
     public function appendSearch() : void
     {
-        $_SESSION['search_append'] = true;
+        $_SESSION['search_append'] = true;// @TODO: PHP8 Review: Direct access to $_SESSION.
         $this->performSearch();
     }
 
@@ -752,7 +752,7 @@ class ilRepositorySearchGUI
             return false;
         }
         $found_query = false;
-        foreach ((array) $_POST['rep_query'][$_POST['search_for']] as $field => $value) {
+        foreach ((array) $_POST['rep_query'][$_POST['search_for']] as $field => $value) {// @TODO: PHP8 Review: Direct access to $_POST.
             if (trim(ilUtil::stripSlashes($value))) {
                 $found_query = true;
                 break;
@@ -768,8 +768,8 @@ class ilRepositorySearchGUI
         }
     
         // unset search_append if called directly
-        if ($_POST['cmd']['performSearch']) {
-            unset($_SESSION['search_append']);
+        if ($_POST['cmd']['performSearch']) {// @TODO: PHP8 Review: Direct access to $_POST.
+            unset($_SESSION['search_append']);// @TODO: PHP8 Review: Direct access to $_SESSION.
         }
 
         switch ($this->search_type) {
@@ -789,11 +789,11 @@ class ilRepositorySearchGUI
                 $this->__performRoleSearch();
                 break;
             case 'orgu':
-                $_POST['obj'] = array_map(
+                $_POST['obj'] = array_map(// @TODO: PHP8 Review: Direct access to $_POST.
                     function ($ref_id) {
                         return ilObject::_lookupObjId($ref_id);
                     },
-                    $_POST['rep_query_orgu']
+                    $_POST['rep_query_orgu']// @TODO: PHP8 Review: Direct access to $_POST.
                 );
                 return $this->listUsers();
             default:
@@ -844,7 +844,7 @@ class ilRepositorySearchGUI
     {
         foreach (ilUserSearchOptions::_getSearchableFieldsInfo(!$this->isSearchableCheckEnabled()) as $info) {
             $name = $info['db'];
-            $query_string = $_SESSION['rep_query']['usr'][$name];
+            $query_string = $_SESSION['rep_query']['usr'][$name];// @TODO: PHP8 Review: Direct access to $_SESSION.
 
             // continue if no query string is given
             if (!$query_string) {
@@ -906,7 +906,7 @@ class ilRepositorySearchGUI
 
     public function __performGroupSearch() : bool
     {
-        $query_string = $_SESSION['rep_query']['grp']['title'];
+        $query_string = $_SESSION['rep_query']['grp']['title'];// @TODO: PHP8 Review: Direct access to $_SESSION.
         if (!is_object($query_parser = $this->__parseQueryString($query_string))) {
             $this->tpl->setOnScreenMessage('info', $query_parser, true);
             return false;
@@ -921,7 +921,7 @@ class ilRepositorySearchGUI
 
     protected function __performCourseSearch() : bool
     {
-        $query_string = $_SESSION['rep_query']['crs']['title'];
+        $query_string = $_SESSION['rep_query']['crs']['title'];// @TODO: PHP8 Review: Direct access to $_SESSION.
         if (!is_object($query_parser = $this->__parseQueryString($query_string))) {
             $this->tpl->setOnScreenMessage('info', $query_parser, true);
             return false;
@@ -936,7 +936,7 @@ class ilRepositorySearchGUI
 
     public function __performRoleSearch() : bool
     {
-        $query_string = $_SESSION['rep_query']['role']['title'];
+        $query_string = $_SESSION['rep_query']['role']['title'];// @TODO: PHP8 Review: Direct access to $_SESSION.
         if (!is_object($query_parser = $this->__parseQueryString($query_string))) {
             $this->tpl->setOnScreenMessage('info', $query_parser, true);
             return false;
@@ -975,8 +975,8 @@ class ilRepositorySearchGUI
     // Private
     public function __loadQueries() : void
     {
-        if (is_array($_POST['rep_query'])) {
-            $_SESSION['rep_query'] = $_POST['rep_query'];
+        if (is_array($_POST['rep_query'])) {// @TODO: PHP8 Review: Direct access to $_POST.
+            $_SESSION['rep_query'] = $_POST['rep_query'];// @TODO: PHP8 Review: Direct access to $_POST.// @TODO: PHP8 Review: Direct access to $_SESSION.
         }
     }
 
@@ -984,16 +984,16 @@ class ilRepositorySearchGUI
     public function __setSearchType() : bool
     {
         // Update search type. Default to user search
-        if ($_POST['search_for']) {
+        if ($_POST['search_for']) {// @TODO: PHP8 Review: Direct access to $_POST.
             #echo 1;
-            $_SESSION['rep_search_type'] = $_POST['search_for'];
+            $_SESSION['rep_search_type'] = $_POST['search_for'];// @TODO: PHP8 Review: Direct access to $_POST.// @TODO: PHP8 Review: Direct access to $_SESSION.
         }
-        if (!$_POST['search_for'] and !$_SESSION['rep_search_type']) {
+        if (!$_POST['search_for'] and !$_SESSION['rep_search_type']) {// @TODO: PHP8 Review: Direct access to $_POST.// @TODO: PHP8 Review: Direct access to $_SESSION.
             #echo 2;
-            $_SESSION['rep_search_type'] = 'usr';
+            $_SESSION['rep_search_type'] = 'usr';// @TODO: PHP8 Review: Direct access to $_SESSION.
         }
         
-        $this->search_type = $_SESSION['rep_search_type'];
+        $this->search_type = $_SESSION['rep_search_type'];// @TODO: PHP8 Review: Direct access to $_SESSION.
 
         return true;
     }
@@ -1001,17 +1001,17 @@ class ilRepositorySearchGUI
 
     public function __updateResults() : bool
     {
-        if (!$_SESSION['search_append']) {
-            $_SESSION['rep_search'] = array();
+        if (!$_SESSION['search_append']) {// @TODO: PHP8 Review: Direct access to $_SESSION.
+            $_SESSION['rep_search'] = array();// @TODO: PHP8 Review: Direct access to $_SESSION.
         }
         foreach ($this->search_results as $result) {
-            $_SESSION['rep_search'][$this->search_type][] = $result;
+            $_SESSION['rep_search'][$this->search_type][] = $result;// @TODO: PHP8 Review: Direct access to $_SESSION.
         }
-        if (!$_SESSION['rep_search'][$this->search_type]) {
-            $_SESSION['rep_search'][$this->search_type] = array();
+        if (!$_SESSION['rep_search'][$this->search_type]) {// @TODO: PHP8 Review: Direct access to $_SESSION.
+            $_SESSION['rep_search'][$this->search_type] = array();// @TODO: PHP8 Review: Direct access to $_SESSION.
         } else {
             // remove duplicate entries
-            $_SESSION['rep_search'][$this->search_type] = array_unique($_SESSION['rep_search'][$this->search_type]);
+            $_SESSION['rep_search'][$this->search_type] = array_unique($_SESSION['rep_search'][$this->search_type]);// @TODO: PHP8 Review: Direct access to $_SESSION.
         }
         return true;
     }
@@ -1021,14 +1021,14 @@ class ilRepositorySearchGUI
      */
     public function __appendToStoredResults(array $a_usr_ids) : array
     {
-        if (!$_SESSION['search_append']) {
-            return $_SESSION['rep_search']['usr'] = $a_usr_ids;
+        if (!$_SESSION['search_append']) {// @TODO: PHP8 Review: Direct access to $_SESSION.
+            return $_SESSION['rep_search']['usr'] = $a_usr_ids;// @TODO: PHP8 Review: Direct access to $_SESSION.
         }
-        $_SESSION['rep_search']['usr'] = array();
+        $_SESSION['rep_search']['usr'] = array();// @TODO: PHP8 Review: Direct access to $_SESSION.
         foreach ($a_usr_ids as $usr_id) {
-            $_SESSION['rep_search']['usr'][] = $usr_id;
+            $_SESSION['rep_search']['usr'][] = $usr_id;// @TODO: PHP8 Review: Direct access to $_SESSION.
         }
-        return $_SESSION['rep_search']['usr'] ? array_unique($_SESSION['rep_search']['usr']) : array();
+        return $_SESSION['rep_search']['usr'] ? array_unique($_SESSION['rep_search']['usr']) : array();// @TODO: PHP8 Review: Direct access to $_SESSION.
     }
 
     public function __storeEntries(ilSearchResult $new_res) : bool
@@ -1063,29 +1063,29 @@ class ilRepositorySearchGUI
         
         switch ($this->search_type) {
             case "usr":
-                $this->showSearchUserTable($_SESSION['rep_search']['usr'], 'showSearchResults');
+                $this->showSearchUserTable($_SESSION['rep_search']['usr'], 'showSearchResults');// @TODO: PHP8 Review: Direct access to $_SESSION.
                 break;
 
             case 'grp':
-                $this->showSearchGroupTable($_SESSION['rep_search']['grp']);
+                $this->showSearchGroupTable($_SESSION['rep_search']['grp']);// @TODO: PHP8 Review: Direct access to $_SESSION.
                 break;
 
             case 'crs':
-                $this->showSearchCourseTable($_SESSION['rep_search']['crs']);
+                $this->showSearchCourseTable($_SESSION['rep_search']['crs']);// @TODO: PHP8 Review: Direct access to $_SESSION.
                 break;
 
             case 'role':
-                $this->showSearchRoleTable($_SESSION['rep_search']['role']);
+                $this->showSearchRoleTable($_SESSION['rep_search']['role']);// @TODO: PHP8 Review: Direct access to $_SESSION.
                 break;
         }
     }
 
     protected function showSearchUserTable(array $a_usr_ids, string $a_parent_cmd) : void
     {
-        $is_in_admin = ($_REQUEST['baseClass'] == 'ilAdministrationGUI');
+        $is_in_admin = ($_REQUEST['baseClass'] == 'ilAdministrationGUI');// @TODO: PHP8 Review: Direct access to $_REQUEST.
         if ($is_in_admin) {
             // remember link target to admin search gui (this)
-            $_SESSION["usr_search_link"] = $this->ctrl->getLinkTarget($this, 'show');
+            $_SESSION["usr_search_link"] = $this->ctrl->getLinkTarget($this, 'show');// @TODO: PHP8 Review: Direct access to $_SESSION.
         }
         
         
@@ -1155,7 +1155,7 @@ class ilRepositorySearchGUI
             $this->showSearchResults();
             return false;
         }
-        $_SESSION['rep_search']['objs'] = $selected_entries;
+        $_SESSION['rep_search']['objs'] = $selected_entries;// @TODO: PHP8 Review: Direct access to $_SESSION.
         
         // Get all members
         $members = array();
@@ -1221,13 +1221,13 @@ class ilRepositorySearchGUI
         $this->tpl->addBlockFile('ADM_CONTENT', 'adm_content', 'tpl.rep_search_result.html', 'Services/Search');
         
         $this->addNewSearchButton();
-        $this->showSearchUserTable($_SESSION['rep_search']['usr'], 'storedUserList');
+        $this->showSearchUserTable($_SESSION['rep_search']['usr'], 'storedUserList');// @TODO: PHP8 Review: Direct access to $_SESSION.
         return true;
     }
     
     protected function storedUserList() : bool
     {
-        $_POST['obj'] = $_SESSION['rep_search']['objs'];
+        $_POST['obj'] = $_SESSION['rep_search']['objs'];// @TODO: PHP8 Review: Direct access to $_POST.// @TODO: PHP8 Review: Direct access to $_SESSION.
         $this->listUsers();
         return true;
     }

--- a/Services/Search/classes/class.ilRepositoryUserResultTableGUI.php
+++ b/Services/Search/classes/class.ilRepositoryUserResultTableGUI.php
@@ -91,7 +91,7 @@ class ilRepositoryUserResultTableGUI extends ilTable2GUI
         return $this->type;
     }
 
-    public function setLuceneResult(ilLuceneSearchResult $res)
+    public function setLuceneResult(ilLuceneSearchResult $res)// @TODO: PHP8 Review: Missing return type.
     {
         $this->lucene_result = $res;
     }
@@ -101,7 +101,7 @@ class ilRepositoryUserResultTableGUI extends ilTable2GUI
         return $this->lucene_result;
     }
 
-    public function setUserLimitations(bool $a_limitations)
+    public function setUserLimitations(bool $a_limitations)// @TODO: PHP8 Review: Missing return type.
     {
         $this->user_limitations = $a_limitations;
     }

--- a/Services/Search/classes/class.ilSearchAutoComplete.php
+++ b/Services/Search/classes/class.ilSearchAutoComplete.php
@@ -7,7 +7,6 @@
 */
 class ilSearchAutoComplete
 {
-
     public static function getLuceneList(string $a_str) : string
     {
         $qp = new ilLuceneQueryParser('title:' . $a_str . '*');

--- a/Services/Search/classes/class.ilSearchBaseGUI.php
+++ b/Services/Search/classes/class.ilSearchBaseGUI.php
@@ -7,7 +7,6 @@ use ILIAS\Container\Content\ViewManager;
 use ILIAS\HTTP\GlobalHttpState;
 use ILIAS\Refinery\Factory;
 
-
 /**
 * Class ilSearchBaseGUI
 *
@@ -85,7 +84,6 @@ class ilSearchBaseGUI implements ilDesktopItemHandling, ilAdministrationCommandH
         $this->search_cache = ilUserSearchCache::_getInstance($this->user->getId());
         $this->http = $DIC->http();
         $this->refinery = $DIC->refinery();
-
     }
 
     protected function initPageNumberFromQuery() : int
@@ -102,7 +100,6 @@ class ilSearchBaseGUI implements ilDesktopItemHandling, ilAdministrationCommandH
 
     public function prepareOutput() : void
     {
-
         $this->tpl->loadStandardTemplate();
         
         $this->tpl->setTitleIcon(
@@ -233,13 +230,13 @@ class ilSearchBaseGUI implements ilDesktopItemHandling, ilAdministrationCommandH
     
     public function addToDeskObject() : void
     {
-        $this->favourites->add($this->user->getId(), (int) $_GET["item_ref_id"]);
+        $this->favourites->add($this->user->getId(), (int) $_GET["item_ref_id"]);// @TODO: PHP8 Review: Direct access to $_GET.
         $this->showSavedResults();
     }
      
     public function removeFromDeskObject() : void
     {
-        $this->favourites->remove($this->user->getId(), (int) $_GET["item_ref_id"]);
+        $this->favourites->remove($this->user->getId(), (int) $_GET["item_ref_id"]);// @TODO: PHP8 Review: Direct access to $_GET.
         $this->showSavedResults();
     }
      
@@ -340,9 +337,9 @@ class ilSearchBaseGUI implements ilDesktopItemHandling, ilAdministrationCommandH
      */
     protected function addPager($result, string $a_session_key) : bool
     {
-        $_SESSION["$a_session_key"] = max($_SESSION["$a_session_key"], $this->search_cache->getResultPageNumber());
+        $_SESSION["$a_session_key"] = max($_SESSION["$a_session_key"], $this->search_cache->getResultPageNumber());// @TODO: PHP8 Review: Direct access to $_SESSION.
         
-        if ($_SESSION["$a_session_key"] == 1 and
+        if ($_SESSION["$a_session_key"] == 1 and // @TODO: PHP8 Review: Direct access to $_SESSION.
             (count($result->getResults()) < $result->getMaxHits())) {
             return true;
         }
@@ -351,7 +348,7 @@ class ilSearchBaseGUI implements ilDesktopItemHandling, ilAdministrationCommandH
             $this->ctrl->setParameter($this, 'page_number', $this->search_cache->getResultPageNumber() - 1);
             $this->prev_link = $this->ctrl->getLinkTarget($this, 'performSearch');
         }
-        for ($i = 1;$i <= $_SESSION["$a_session_key"];$i++) {
+        for ($i = 1;$i <= $_SESSION["$a_session_key"];$i++) {// @TODO: PHP8 Review: Direct access to $_SESSION.
             if ($i == $this->search_cache->getResultPageNumber()) {
                 continue;
             }
@@ -373,7 +370,6 @@ class ilSearchBaseGUI implements ilDesktopItemHandling, ilAdministrationCommandH
     
     protected function buildSearchAreaPath(int $a_root_node) : string
     {
-
         $path_arr = $this->tree->getPathFull($a_root_node, ROOT_FOLDER_ID);
         $counter = 0;
         $path = '';
@@ -390,7 +386,7 @@ class ilSearchBaseGUI implements ilDesktopItemHandling, ilAdministrationCommandH
     
     public function autoComplete() : void
     {
-        $q = $_REQUEST["term"];
+        $q = $_REQUEST["term"];// @TODO: PHP8 Review: Direct access to $_REQUEST.
         $list = ilSearchAutoComplete::getList($q);
         echo $list;
         exit;

--- a/Services/Search/classes/class.ilSearchCommandQueue.php
+++ b/Services/Search/classes/class.ilSearchCommandQueue.php
@@ -31,7 +31,7 @@
 */
 class ilSearchCommandQueue
 {
-    private static $instance = null;
+    private static $instance = null;// @TODO: PHP8 Review: Missing property type.
 
     protected ilDBInterface $db;
 
@@ -77,7 +77,6 @@ class ilSearchCommandQueue
      */
     protected function insert(ilSearchCommandQueueElement $element) : void
     {
-        
         $query = "INSERT INTO search_command_queue (obj_id,obj_type,sub_id,sub_type,command,last_update,finished) " .
             "VALUES( " .
             $this->db->quote($element->getObjId(), 'integer') . ", " .

--- a/Services/Search/classes/class.ilSearchControllerGUI.php
+++ b/Services/Search/classes/class.ilSearchControllerGUI.php
@@ -41,22 +41,22 @@ class ilSearchControllerGUI implements ilCtrlBaseClassInterface
 
     public function getLastClass() : string
     {
-                if (ilSearchSettings::getInstance()->enabledLucene()) {
+        if (ilSearchSettings::getInstance()->enabledLucene()) {
             $default = 'illucenesearchgui';
         } else {
             $default = 'ilsearchgui';
         }
-        if ($_REQUEST['root_id'] == self::TYPE_USER_SEARCH) {
+        if ($_REQUEST['root_id'] == self::TYPE_USER_SEARCH) {// @TODO: PHP8 Review: Direct access to $_REQUEST.
             $default = 'illuceneusersearchgui';
         }
         
         $this->setLastClass($default);
         
-        return $_SESSION['search_last_class'] ?: $default;
+        return $_SESSION['search_last_class'] ?: $default;// @TODO: PHP8 Review: Direct access to $_SESSION.
     }
     public function setLastClass(string $a_class) : void
     {
-        $_SESSION['search_last_class'] = $a_class;
+        $_SESSION['search_last_class'] = $a_class;// @TODO: PHP8 Review: Direct access to $_SESSION.
     }
 
     public function executeCommand() : void

--- a/Services/Search/classes/class.ilSearchGUI.php
+++ b/Services/Search/classes/class.ilSearchGUI.php
@@ -92,7 +92,7 @@ class ilSearchGUI extends ilSearchBaseGUI
             case 'ilobjectcopygui':
                 $this->prepareOutput();
                 $this->ctrl->setReturn($this, '');
-                                $cp = new ilObjectCopyGUI($this);
+                                $cp = new ilObjectCopyGUI($this);// @TODO: PHP8 Review: Invalid argument.
                 $this->ctrl->forwardCommand($cp);
                 break;
             

--- a/Services/Search/classes/class.ilSearchGUI.php
+++ b/Services/Search/classes/class.ilSearchGUI.php
@@ -44,30 +44,30 @@ class ilSearchGUI extends ilSearchBaseGUI
         $this->initStandardSearchForm(ilSearchBaseGUI::SEARCH_FORM_STANDARD);
         $this->form->checkInput();
         
-        $new_search = isset($_POST['cmd']['performSearch']) ? true : false;
+        $new_search = isset($_POST['cmd']['performSearch']) ? true : false;// @TODO: PHP8 Review: Direct access to $_POST.
 
         $enabled_types = ilSearchSettings::getInstance()->getEnabledLuceneItemFilterDefinitions();
         foreach ($enabled_types as $type => $pval) {
-            if ($_POST['filter_type'][$type] == 1) {
-                $_POST["search"]["details"][$type] = $_POST['filter_type'][$type];
+            if ($_POST['filter_type'][$type] == 1) {// @TODO: PHP8 Review: Direct access to $_POST.
+                $_POST["search"]["details"][$type] = $_POST['filter_type'][$type];// @TODO: PHP8 Review: Direct access to $_POST.
             }
         }
 
-        $_POST["search"]["string"] = $_POST["term"];
-        $_POST["search"]["combination"] = $_POST["combination"];
-        $_POST["search"]["type"] = $_POST["type"];
-        $_SESSION['search_root'] = $_POST["area"];
+        $_POST["search"]["string"] = $_POST["term"];// @TODO: PHP8 Review: Direct access to $_POST.
+        $_POST["search"]["combination"] = $_POST["combination"];// @TODO: PHP8 Review: Direct access to $_POST.
+        $_POST["search"]["type"] = $_POST["type"];// @TODO: PHP8 Review: Direct access to $_POST.
+        $_SESSION['search_root'] = $_POST["area"];// @TODO: PHP8 Review: Direct access to $_POST.// @TODO: PHP8 Review: Direct access to $_SESSION.
 
-        $this->root_node = (int) ($_SESSION['search_root'] ?? ROOT_FOLDER_ID);
-        $this->setType((int) ($_POST['search']['type'] ?? $_SESSION['search']['type']));
+        $this->root_node = (int) ($_SESSION['search_root'] ?? ROOT_FOLDER_ID);// @TODO: PHP8 Review: Direct access to $_SESSION.
+        $this->setType((int) ($_POST['search']['type'] ?? $_SESSION['search']['type']));// @TODO: PHP8 Review: Direct access to $_POST.// @TODO: PHP8 Review: Direct access to $_SESSION.
 
         $this->setCombination(
             ilSearchSettings::getInstance()->getDefaultOperator() == ilSearchSettings::OPERATOR_AND ?
                 self::SEARCH_AND :
                 self::SEARCH_OR
         );
-        $this->setString((string) ($_POST['search']['string'] ?? $_SESSION['search']['string']));
-        $this->setDetails($new_search ? $_POST['search']['details'] : $_SESSION['search']['details']);
+        $this->setString((string) ($_POST['search']['string'] ?? $_SESSION['search']['string']));// @TODO: PHP8 Review: Direct access to $_POST.// @TODO: PHP8 Review: Direct access to $_SESSION.
+        $this->setDetails($new_search ? $_POST['search']['details'] : $_SESSION['search']['details']);// @TODO: PHP8 Review: Direct access to $_POST.// @TODO: PHP8 Review: Direct access to $_SESSION.
     }
 
 
@@ -112,7 +112,7 @@ class ilSearchGUI extends ilSearchBaseGUI
     */
     public function setType(int $a_type) : void
     {
-        $_SESSION['search']['type'] = $this->type = $a_type;
+        $_SESSION['search']['type'] = $this->type = $a_type;// @TODO: PHP8 Review: Direct access to $_SESSION.
     }
     public function getType() : int
     {
@@ -124,7 +124,7 @@ class ilSearchGUI extends ilSearchBaseGUI
     */
     public function setCombination(string $a_combination) : void
     {
-        $_SESSION['search']['combination'] = $this->combination = $a_combination;
+        $_SESSION['search']['combination'] = $this->combination = $a_combination;// @TODO: PHP8 Review: Direct access to $_SESSION.
     }
     public function getCombination() : string
     {
@@ -136,7 +136,7 @@ class ilSearchGUI extends ilSearchBaseGUI
     */
     public function setString(string $a_str) : void
     {
-        $_SESSION['search']['string'] = $this->string = $a_str;
+        $_SESSION['search']['string'] = $this->string = $a_str;// @TODO: PHP8 Review: Direct access to $_SESSION.
     }
     public function getString() : string
     {
@@ -148,7 +148,7 @@ class ilSearchGUI extends ilSearchBaseGUI
     */
     public function setDetails(array $a_details) : void
     {
-        $_SESSION['search']['details'] = $this->details = $a_details;
+        $_SESSION['search']['details'] = $this->details = $a_details;// @TODO: PHP8 Review: Direct access to $_SESSION.
     }
     public function getDetails() : array
     {
@@ -162,7 +162,7 @@ class ilSearchGUI extends ilSearchBaseGUI
     }
     public function setRootNode(int $a_node_id) : void
     {
-        $_SESSION['search_root'] = $this->root_node = $a_node_id;
+        $_SESSION['search_root'] = $this->root_node = $a_node_id;// @TODO: PHP8 Review: Direct access to $_SESSION.
     }
         
     
@@ -207,7 +207,7 @@ class ilSearchGUI extends ilSearchBaseGUI
     */
     public function autoComplete() : void
     {
-        if ((int) $_REQUEST['search_type'] == -1) {
+        if ((int) $_REQUEST['search_type'] == -1) {// @TODO: PHP8 Review: Direct access to $_REQUEST.
             $a_fields = array('login','firstname','lastname','email');
             $result_field = 'login';
 
@@ -221,7 +221,7 @@ class ilSearchGUI extends ilSearchBaseGUI
             $auto->enableFieldSearchableCheck(true);
             $auto->setUserLimitations(true);
 
-            $res = $auto->getList($_REQUEST['term']);
+            $res = $auto->getList($_REQUEST['term']);// @TODO: PHP8 Review: Direct access to $_REQUEST.
             
             $res_obj = json_decode($res);
             
@@ -234,7 +234,7 @@ class ilSearchGUI extends ilSearchBaseGUI
                 exit;
             }
         } else {
-            $q = $_REQUEST["term"];
+            $q = $_REQUEST["term"];// @TODO: PHP8 Review: Direct access to $_REQUEST.
             $list = ilSearchAutoComplete::getList($q);
             ilLoggerFactory::getLogger('sea')->dump(json_decode($list));
             echo $list;
@@ -322,7 +322,7 @@ class ilSearchGUI extends ilSearchBaseGUI
     {
         $page_number = $this->initPageNumberFromQuery();
         if (!$page_number and $this->search_mode != 'in_results') {
-            unset($_SESSION['max_page']);
+            unset($_SESSION['max_page']);// @TODO: PHP8 Review: Direct access to $_SESSION.
             $this->search_cache->deleteCachedEntries();
         }
 

--- a/Services/Search/classes/class.ilSearchResult.php
+++ b/Services/Search/classes/class.ilSearchResult.php
@@ -42,8 +42,8 @@ class ilSearchResult
     private array $observers = array();
     private int $max_hits = 0;
 
-    protected $search_cache = null;
-    protected $offset = 0;
+    protected $search_cache = null;// @TODO: PHP8 Review: Missing property type.
+    protected $offset = 0;// @TODO: PHP8 Review: Missing property type.
 
     // OBJECT VARIABLES
     protected ILIAS $ilias;
@@ -122,7 +122,7 @@ class ilSearchResult
     {
         $this->max_hits = $a_max_hits;
     }
-    public function getMaxHits()
+    public function getMaxHits()// @TODO: PHP8 Review: Missing return type.
     {
         return $this->max_hits;
     }

--- a/Services/Search/classes/class.ilSearchResultPresentation.php
+++ b/Services/Search/classes/class.ilSearchResultPresentation.php
@@ -73,8 +73,8 @@ class ilSearchResultPresentation
         
         $this->initReferences();
         
-        if (isset($_GET['details'])) {
-            ilSubItemListGUI::setShowDetails((int) $_GET['details']);
+        if (isset($_GET['details'])) {// @TODO: PHP8 Review: Direct access to $_GET.
+            ilSubItemListGUI::setShowDetails((int) $_GET['details']);// @TODO: PHP8 Review: Direct access to $_GET.
         }
     }
     
@@ -165,7 +165,7 @@ class ilSearchResultPresentation
     {
         if (!isset($this->has_more_ref_ids[$a_ref_id]) or
             !$this->has_more_ref_ids[$a_ref_id] or
-            isset($_SESSION['vis_references'][$a_ref_id])) {
+            isset($_SESSION['vis_references'][$a_ref_id])) {// @TODO: PHP8 Review: Direct access to $_SESSION.
             return false;
         }
         return $this->has_more_ref_ids[$a_ref_id];
@@ -173,7 +173,7 @@ class ilSearchResultPresentation
     
     protected function getAllReferences(int $a_ref_id) : array
     {
-        if (isset($_SESSION['vis_references'][$a_ref_id])) {
+        if (isset($_SESSION['vis_references'][$a_ref_id])) {// @TODO: PHP8 Review: Direct access to $_SESSION.
             return $this->all_references[$a_ref_id] ?: array();
         } else {
             return array($a_ref_id);
@@ -220,7 +220,6 @@ class ilSearchResultPresentation
      */
     protected function renderItemList() : bool
     {
-
         $this->html = '';
         
         $this->parseResultReferences();
@@ -316,8 +315,7 @@ class ilSearchResultPresentation
         int $ref_id,
         int $obj_id,
         string $type
-    ) : void
-    {
+    ) : void {
         $sub = $this->appendSubItems($item_list_gui, $ref_id, $obj_id, $type);
         $path = $this->appendPath($ref_id);
         $more = $this->appendMorePathes($ref_id);
@@ -376,8 +374,7 @@ class ilSearchResultPresentation
         int $ref_id,
         int $obj_id,
         string $a_type
-    ) : string
-    {
+    ) : string {
         $subitem_ids = array();
         $highlighter = null;
         if ($this->getMode() == self::MODE_STANDARD) {
@@ -400,8 +397,8 @@ class ilSearchResultPresentation
     
     protected function initReferences() : void
     {
-        if (isset($_REQUEST['refs'])) {
-            $_SESSION['vis_references'][(int) $_REQUEST['refs']] = (int) $_REQUEST['refs'];
+        if (isset($_REQUEST['refs'])) {// @TODO: PHP8 Review: Direct access to $_REQUEST.
+            $_SESSION['vis_references'][(int) $_REQUEST['refs']] = (int) $_REQUEST['refs'];// @TODO: PHP8 Review: Direct access to $_REQUEST.// @TODO: PHP8 Review: Direct access to $_SESSION.
         }
     }
 }

--- a/Services/Search/classes/class.ilSearchRootSelector.php
+++ b/Services/Search/classes/class.ilSearchRootSelector.php
@@ -134,7 +134,6 @@ class ilSearchRootSelector extends ilExplorer
 
     public function showChilds($a_parent_id) : bool
     {
-
         if ($a_parent_id == 0) {
             return true;
         }

--- a/Services/Search/classes/class.ilSearchSettings.php
+++ b/Services/Search/classes/class.ilSearchSettings.php
@@ -327,7 +327,7 @@ class ilSearchSettings
     }
     
     
-    public function setLastIndexTime(ilDateTime $time)
+    public function setLastIndexTime(ilDateTime $time)// @TODO: PHP8 Review: Missing return type.
     {
         $this->last_index_date = $time;
     }
@@ -361,7 +361,7 @@ class ilSearchSettings
      * are inactive user visible in user search
      * @return bool
      */
-    public function isInactiveUserVisible():bool
+    public function isInactiveUserVisible() : bool
     {
         return $this->show_inactiv_user;
     }
@@ -405,7 +405,7 @@ class ilSearchSettings
         $this->setting->set('auto_complete_length', (string) $this->getAutoCompleteLength());
         $this->setting->set('lucene_item_filter_enabled', (string) $this->isLuceneItemFilterEnabled());
         $this->setting->set('lucene_item_filter', serialize($this->getLuceneItemFilter()));
-        $this->setting->set('lucene_offline_filter', (string)  $this->isLuceneOfflineFilterEnabled());
+        $this->setting->set('lucene_offline_filter', (string) $this->isLuceneOfflineFilterEnabled());
         $this->setting->set('lucene_mime_filter', serialize($this->getLuceneMimeFilter()));
         $this->setting->set('lucene_sub_relevance', (string) $this->isSubRelevanceVisible());
         $this->setting->set('lucene_mime_filter_enabled', (string) $this->isLuceneMimeFilterEnabled());

--- a/Services/Search/classes/class.ilUserFilterGUI.php
+++ b/Services/Search/classes/class.ilUserFilterGUI.php
@@ -83,7 +83,6 @@ class ilUserFilterGUI
 
     public function getHTML() : string
     {
-
         $tpl = new ilTemplate('tpl.search_user_filter.html', true, true, 'Services/Search');
 
         $tpl->setVariable("FILTER_ACTION", $this->ctrl->getFormAction($this));
@@ -94,10 +93,12 @@ class ilUserFilterGUI
         $tpl->setVariable("BTN_REFRESH", $this->lng->txt('trac_refresh'));
 
         $tpl->setVariable("QUERY", ilLegacyFormElementsUtil::prepareFormOutput($this->filter->getQueryString('login')));
-        $tpl->setVariable("FIRSTNAME",
+        $tpl->setVariable(
+            "FIRSTNAME",
             ilLegacyFormElementsUtil::prepareFormOutput($this->filter->getQueryString('firstname'))
         );
-        $tpl->setVariable("LASTNAME",
+        $tpl->setVariable(
+            "LASTNAME",
             ilLegacyFormElementsUtil::prepareFormOutput($this->filter->getQueryString('lastname'))
         );
 
@@ -108,9 +109,9 @@ class ilUserFilterGUI
         
     public function refresh() : bool
     {
-        $_GET['offset'] = 0;
+        $_GET['offset'] = 0;// @TODO: PHP8 Review: Direct access to $_GET.
         $this->ctrl->saveParameter($this, 'offset');
-        $this->filter->storeQueryStrings($_POST['filter']);
+        $this->filter->storeQueryStrings($_POST['filter']);// @TODO: PHP8 Review: Direct access to $_POST.
         $this->ctrl->returnToParent($this);
 
         return true;

--- a/Services/Search/classes/class.ilUserSearchCache.php
+++ b/Services/Search/classes/class.ilUserSearchCache.php
@@ -88,7 +88,7 @@ class ilUserSearchCache
         $this->read();
     }
     
-    public static function _getInstance($a_usr_id) : ilUserSearchCache
+    public static function _getInstance($a_usr_id) : ilUserSearchCache// @TODO: PHP8 Review: Missing parameter type.
     {
         if (self::$instance instanceof ilUserSearchCache) {
             return self::$instance;
@@ -200,7 +200,7 @@ class ilUserSearchCache
      * @access public
      * @return array array(ref_id => obj_id)
      */
-    public function getCheckedItems():array
+    public function getCheckedItems() : array
     {
         return $this->checked ?: array();
     }
@@ -263,7 +263,7 @@ class ilUserSearchCache
     /**
      * set root node of search
      */
-    public function setRoot(int $a_root)
+    public function setRoot(int $a_root)// @TODO: PHP8 Review: Missing return type.
     {
         $this->root = $a_root;
     }
@@ -374,7 +374,6 @@ class ilUserSearchCache
     
     public function delete() : bool
     {
-
         $query = "DELETE FROM usr_search " .
             "WHERE usr_id = " . $this->db->quote($this->usr_id, 'integer') . " " .
             "AND search_type = " . $this->db->quote($this->search_type, 'integer');
@@ -425,19 +424,19 @@ class ilUserSearchCache
 
     public function saveForAnonymous() : void
     {
-        unset($_SESSION['usr_search_cache']);
+        unset($_SESSION['usr_search_cache']);// @TODO: PHP8 Review: Direct access to $_SESSION.
 
-        $_SESSION['usr_search_cache'][$this->search_type]['search_result'] = $this->search_result;
-        $_SESSION['usr_search_cache'][$this->search_type]['checked'] = $this->checked;
-        $_SESSION['usr_search_cache'][$this->search_type]['failed'] = $this->failed;
-        $_SESSION['usr_search_cache'][$this->search_type]['page'] = $this->page_number;
-        $_SESSION['usr_search_cache'][$this->search_type]['query'] = $this->getQuery();
-        $_SESSION['usr_search_cache'][$this->search_type]['root'] = $this->getRoot();
-        $_SESSION['usr_search_cache'][$this->search_type]['item_filter'] = $this->getItemFilter();
-        $_SESSION['usr_search_cache'][$this->search_type]['mime_filter'] = $this->getMimeFilter();
-        $_SESSION['usr_search_cache'][$this->search_type]['creation_filter'] = $this->getCreationFilter();
+        $_SESSION['usr_search_cache'][$this->search_type]['search_result'] = $this->search_result;// @TODO: PHP8 Review: Direct access to $_SESSION.
+        $_SESSION['usr_search_cache'][$this->search_type]['checked'] = $this->checked;// @TODO: PHP8 Review: Direct access to $_SESSION.
+        $_SESSION['usr_search_cache'][$this->search_type]['failed'] = $this->failed;// @TODO: PHP8 Review: Direct access to $_SESSION.
+        $_SESSION['usr_search_cache'][$this->search_type]['page'] = $this->page_number;// @TODO: PHP8 Review: Direct access to $_SESSION.
+        $_SESSION['usr_search_cache'][$this->search_type]['query'] = $this->getQuery();// @TODO: PHP8 Review: Direct access to $_SESSION.
+        $_SESSION['usr_search_cache'][$this->search_type]['root'] = $this->getRoot();// @TODO: PHP8 Review: Direct access to $_SESSION.
+        $_SESSION['usr_search_cache'][$this->search_type]['item_filter'] = $this->getItemFilter();// @TODO: PHP8 Review: Direct access to $_SESSION.
+        $_SESSION['usr_search_cache'][$this->search_type]['mime_filter'] = $this->getMimeFilter();// @TODO: PHP8 Review: Direct access to $_SESSION.
+        $_SESSION['usr_search_cache'][$this->search_type]['creation_filter'] = $this->getCreationFilter();// @TODO: PHP8 Review: Direct access to $_SESSION.
 
-        $_SESSION['usr_search_cache'][self::LAST_QUERY]['query'] = $this->getQuery();
+        $_SESSION['usr_search_cache'][self::LAST_QUERY]['query'] = $this->getQuery();// @TODO: PHP8 Review: Direct access to $_SESSION.
     }
     
     
@@ -485,15 +484,15 @@ class ilUserSearchCache
      */
     private function readAnonymous() : void
     {
-        $this->search_result = (array) $_SESSION['usr_search_cache'][$this->search_type]['search_result'];
-        $this->checked = (array) $_SESSION['usr_search_cache'][$this->search_type]['checked'];
-        $this->failed = (array) $_SESSION['usr_search_cache'][$this->search_type]['failed'];
-        $this->page_number = $_SESSION['usr_search_cache'][$this->search_type]['page_number'];
+        $this->search_result = (array) $_SESSION['usr_search_cache'][$this->search_type]['search_result'];// @TODO: PHP8 Review: Direct access to $_SESSION.
+        $this->checked = (array) $_SESSION['usr_search_cache'][$this->search_type]['checked'];// @TODO: PHP8 Review: Direct access to $_SESSION.
+        $this->failed = (array) $_SESSION['usr_search_cache'][$this->search_type]['failed'];// @TODO: PHP8 Review: Direct access to $_SESSION.
+        $this->page_number = $_SESSION['usr_search_cache'][$this->search_type]['page_number'];// @TODO: PHP8 Review: Direct access to $_SESSION.
 
-        $this->setQuery($_SESSION['usr_search_cache'][$this->search_type]['query']);
-        $this->setRoot((int) $_SESSION['usr_search_cache'][$this->search_type]['root']);
-        $this->setItemFilter((array) $_SESSION['usr_search_cache'][$this->search_type]['item_filter']);
-        $this->setMimeFilter((array) $_SESSION['usr_search_cache'][$this->search_type]['mime_filter']);
-        $this->setCreationFilter((array) $_SESSION['usr_search_cache'][$this->search_type]['creation_filter']);
+        $this->setQuery($_SESSION['usr_search_cache'][$this->search_type]['query']);// @TODO: PHP8 Review: Direct access to $_SESSION.
+        $this->setRoot((int) $_SESSION['usr_search_cache'][$this->search_type]['root']);// @TODO: PHP8 Review: Direct access to $_SESSION.
+        $this->setItemFilter((array) $_SESSION['usr_search_cache'][$this->search_type]['item_filter']);// @TODO: PHP8 Review: Direct access to $_SESSION.
+        $this->setMimeFilter((array) $_SESSION['usr_search_cache'][$this->search_type]['mime_filter']);// @TODO: PHP8 Review: Direct access to $_SESSION.
+        $this->setCreationFilter((array) $_SESSION['usr_search_cache'][$this->search_type]['creation_filter']);// @TODO: PHP8 Review: Direct access to $_SESSION.
     }
 }

--- a/Services/Search/classes/class.ilUserSearchFilter.php
+++ b/Services/Search/classes/class.ilUserSearchFilter.php
@@ -71,7 +71,7 @@ class ilUserSearchFilter
         $this->ilias = $DIC['ilias'];
 
         // Limit of filtered objects is search max hits
-        $this->limit = (int) $this->ilias->getSetting('search_max_hits', 50);
+        $this->limit = (int) $this->ilias->getSetting('search_max_hits', 50);// @TODO: PHP8 Review: Invalid argument.
         $this->result_obj = new ilSearchResult();
     }
 

--- a/Services/Search/classes/class.ilUserSearchFilter.php
+++ b/Services/Search/classes/class.ilUserSearchFilter.php
@@ -111,12 +111,12 @@ class ilUserSearchFilter
     
     public function storeQueryStrings(array $a_strings) : void
     {
-        $_SESSION['search_usr_filter'] = $a_strings;
+        $_SESSION['search_usr_filter'] = $a_strings;// @TODO: PHP8 Review: Direct access to $_SESSION.
     }
 
     public function getQueryString(string $a_field) : string
     {
-        return $_SESSION['search_usr_filter'][$a_field] ?? '';
+        return $_SESSION['search_usr_filter'][$a_field] ?? '';// @TODO: PHP8 Review: Direct access to $_SESSION.
     }
 
 
@@ -127,7 +127,7 @@ class ilUserSearchFilter
             if (!$enabled) {
                 continue;
             }
-            if (strlen($_SESSION['search_usr_filter'][$field])) {
+            if (strlen($_SESSION['search_usr_filter'][$field])) {// @TODO: PHP8 Review: Direct access to $_SESSION.
                 $search = true;
                 break;
             }
@@ -144,7 +144,7 @@ class ilUserSearchFilter
                 continue;
             }
 
-            $query_string = $_SESSION['search_usr_filter'][$field];
+            $query_string = $_SESSION['search_usr_filter'][$field];// @TODO: PHP8 Review: Direct access to $_SESSION.
             if (!$query_string) {
                 continue;
             }

--- a/Services/Search/classes/class.ilUserSearchOptions.php
+++ b/Services/Search/classes/class.ilUserSearchOptions.php
@@ -190,7 +190,7 @@ class ilUserSearchOptions
         return in_array($a_key, ilUserSearchOptions::_getPossibleFields());
     }
 
-    public static function _isEnabled($a_key)
+    public static function _isEnabled($a_key)// @TODO: PHP8 Review: Missing return type.// @TODO: PHP8 Review: Missing parameter type.
     {
         global $DIC;
 

--- a/Services/Search/test/ilSearchLuceneQueryParserTest.php
+++ b/Services/Search/test/ilSearchLuceneQueryParserTest.php
@@ -3,7 +3,6 @@
 use PHPUnit\Framework\TestCase;
 use ILIAS\DI\Container;
 
-
 /**
  * Unit tests for class ilDidacticTemplate
  * @author  Stefan Meyer <meyer@leifos.com>
@@ -11,7 +10,7 @@ use ILIAS\DI\Container;
  */
 class ilSearchLuceneQueryParserTest extends TestCase
 {
-    protected $backupGlobals = false;
+    protected $backupGlobals = false;// @TODO: PHP8 Review: Missing property type.
 
     protected Container $dic;
 

--- a/Services/Search/test/ilServicesSearchSuite.php
+++ b/Services/Search/test/ilServicesSearchSuite.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestSuite;
 
 class ilServicesSearchSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite()// @TODO: PHP8 Review: Missing return type.
     {
         $suite = new ilServicesSearchSuite();
 


### PR DESCRIPTION
Hi @smeyer-ilias 

here are the results of the `Services/Search` review.

### Results
- [ ] The code style is `PSR-2 + X` compliant
- [ ] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [ ] There are no serious PHPStorm Code Inspection issues left.
- [ ] The types are fully documented (PHPDoc) or explict PHP types are used (type hints, return types, typed properties)

### Changes made in this PR:
- Added `// @TODO: PHP8 Review: Missing return type.`
- Added `// @TODO: PHP8 Review: Missing property type.`
- Added `// @TODO: PHP8 Review: Direct access to $_POST.`
- Added `// @TODO: PHP8 Review: Direct access to $_GET.`
- Added `// @TODO: PHP8 Review: Direct access to $_REQUEST.`
- Added `// @TODO: PHP8 Review: Direct access to $_SESSION.`
- Added `// @TODO: PHP8 Review: Missing parameter type.`
- Added `// @TODO: PHP8 Review: Invalid argument.`
- Added `// @TODO: PHP8 Review: Wrong type. Instance of ilSettings expected.`
- Fix `PSR-2 + X`

Best regards,
@lscharmer