### PR TITLE
PHP 8: Code Review `MediaPool`

### DIFF
--- a/Modules/MediaPool/Clipboard/class.ilClipboardTableGUI.php
+++ b/Modules/MediaPool/Clipboard/class.ilClipboardTableGUI.php
@@ -55,7 +55,7 @@ class ilClipboardTableGUI extends ilTable2GUI
         $this->setDefaultOrderField("title");
         
         // action commands
-        if ($this->parent_obj->mode == "getObject") {
+        if ($this->parent_obj->mode === "getObject") {
             $this->addMultiCommand("insert", $this->parent_obj->getInsertButtonTitle());
         }
         $this->addMultiCommand("remove", $lng->txt("remove"));
@@ -82,7 +82,7 @@ class ilClipboardTableGUI extends ilTable2GUI
         $ilCtrl = $this->ctrl;
 
         $mob = null;
-        if ($a_set["type"] == "mob") {
+        if ($a_set["type"] === "mob") {
             // output thumbnail
             $mob = new ilObjMediaObject($a_set["id"]);
             $med = $mob->getMediaItem("Standard");
@@ -93,7 +93,7 @@ class ilClipboardTableGUI extends ilTable2GUI
                 $this->tpl->parseCurrentBlock();
             }
             if (ilUtil::deducibleSize($med->getFormat()) &&
-                $med->getLocationType() == "Reference") {
+                $med->getLocationType() === "Reference") {
                 $size = getimagesize($med->getLocation());
                 if ($size[0] > 0 && $size[1] > 0) {
                     $wr = $size[0] / 80;
@@ -107,7 +107,7 @@ class ilClipboardTableGUI extends ilTable2GUI
                     );
                 }
             }
-        } elseif ($a_set["type"] == "incl") {
+        } elseif ($a_set["type"] === "incl") {
             $this->tpl->setCurrentBlock("thumbnail");
             $this->tpl->setVariable(
                 "IMG_THUMB",
@@ -117,7 +117,7 @@ class ilClipboardTableGUI extends ilTable2GUI
         }
 
         // allow editing of media objects
-        if ($this->parent_obj->mode != "getObject" && $a_set["type"] == "mob") {
+        if ($this->parent_obj->mode !== "getObject" && $a_set["type"] === "mob") {
             // output edit link
             $this->tpl->setCurrentBlock("edit");
             $ilCtrl->setParameter($this->parent_obj, "clip_item_id", $a_set["id"]);
@@ -138,7 +138,7 @@ class ilClipboardTableGUI extends ilTable2GUI
         }
         $this->tpl->parseCurrentBlock();
 
-        if ($a_set["type"] == "mob") {
+        if ($a_set["type"] === "mob") {
             $this->tpl->setVariable(
                 "MEDIA_INFO",
                 ilObjMediaObjectGUI::_getMediaInfoHTML($mob)

--- a/Modules/MediaPool/Clipboard/class.ilClipboardTableGUI.php
+++ b/Modules/MediaPool/Clipboard/class.ilClipboardTableGUI.php
@@ -87,7 +87,7 @@ class ilClipboardTableGUI extends ilTable2GUI
             $mob = new ilObjMediaObject($a_set["id"]);
             $med = $mob->getMediaItem("Standard");
             $target = $med->getThumbnailTarget();
-            if ($target != "") {
+            if ($target !== "") {
                 $this->tpl->setCurrentBlock("thumbnail");
                 $this->tpl->setVariable("IMG_THUMB", $target);
                 $this->tpl->parseCurrentBlock();

--- a/Modules/MediaPool/Clipboard/class.ilEditClipboardGUI.php
+++ b/Modules/MediaPool/Clipboard/class.ilEditClipboardGUI.php
@@ -186,13 +186,13 @@ class ilEditClipboardGUI
 
         foreach ($ids as $obj_id) {
             $id = explode(":", $obj_id);
-            if ($id[0] == "mob") {
+            if ($id[0] === "mob") {
                 $ilUser->removeObjectFromClipboard($id[1], "mob");
                 include_once("./Services/MediaObjects/classes/class.ilObjMediaObject.php");
                 $mob = new ilObjMediaObject($id[1]);
                 $mob->delete();			// this method don't delete, if mob is used elsewhere
             }
-            if ($id[0] == "incl") {
+            if ($id[0] === "incl") {
                 $ilUser->removeObjectFromClipboard($id[1], "incl");
             }
         }

--- a/Modules/MediaPool/Clipboard/class.ilEditClipboardGUI.php
+++ b/Modules/MediaPool/Clipboard/class.ilEditClipboardGUI.php
@@ -69,7 +69,7 @@ class ilEditClipboardGUI
            ->domain()
            ->clipboard();
 
-        if ($this->requested_return_cmd != "") {
+        if ($this->requested_return_cmd !== "") {
             $this->mode = "getObject";
         } else {
             $this->mode = "";
@@ -138,7 +138,7 @@ class ilEditClipboardGUI
     {
         $lng = $this->lng;
         
-        if ($this->insertbuttontitle == "") {
+        if ($this->insertbuttontitle === "") {
             return $lng->txt("insert");
         }
         
@@ -179,7 +179,7 @@ class ilEditClipboardGUI
         
         // check number of objects
         $ids = $this->request->getItemIds();
-        if (count($ids) == 0) {
+        if (count($ids) === 0) {
             $this->tpl->setOnScreenMessage('failure', $lng->txt("no_checkbox"), true);
             $ilCtrl->redirect($this, "view");
         }
@@ -211,16 +211,14 @@ class ilEditClipboardGUI
         $ids = $this->request->getItemIds();
 
         // check number of objects
-        if (count($ids) == 0) {
+        if (count($ids) === 0) {
             $this->tpl->setOnScreenMessage('failure', $lng->txt("no_checkbox"), true);
             ilUtil::redirect($return);
         }
         
-        if (!$this->getMultipleSelections()) {
-            if (count($ids) > 1) {
-                $this->tpl->setOnScreenMessage('failure', $lng->txt("cont_select_max_one_item"), true);
-                ilUtil::redirect($return);
-            }
+        if (!$this->getMultipleSelections() && count($ids) > 1) {
+            $this->tpl->setOnScreenMessage('failure', $lng->txt("cont_select_max_one_item"), true);
+            ilUtil::redirect($return);
         }
 
         $this->clipboard_manager->setIds($ids);

--- a/Modules/MediaPool/classes/class.StandardGUIRequest.php
+++ b/Modules/MediaPool/classes/class.StandardGUIRequest.php
@@ -53,7 +53,7 @@ class StandardGUIRequest
     public function getUploadHash() : string
     {
         $hash = $this->str("mep_hash");
-        if ($hash == "") {
+        if ($hash === "") {
             $hash = $this->str("ilfilehash");
         }
         return $hash;

--- a/Modules/MediaPool/classes/class.ilMediaPoolAppEventListener.php
+++ b/Modules/MediaPool/classes/class.ilMediaPoolAppEventListener.php
@@ -36,7 +36,7 @@ class ilMediaPoolAppEventListener
             case "Services/Object":
                 switch ($a_event) {
                     case "update":
-                        if ($a_parameter["obj_type"] == "mob") {
+                        if ($a_parameter["obj_type"] === "mob") {
                             ilMediaPoolItem::updateObjectTitle($a_parameter["obj_id"]);
                         }
                         break;

--- a/Modules/MediaPool/classes/class.ilMediaPoolDataSet.php
+++ b/Modules/MediaPool/classes/class.ilMediaPoolDataSet.php
@@ -60,7 +60,7 @@ class ilMediaPoolDataSet extends ilDataSet
         ?ilObjMediaPool $a_mep,
         string $a_lang = ""
     ) : void {
-        if ($a_mep != null) {
+        if ($a_mep !== null) {
             $this->transl_into = true;
             $this->transl_into_mep = $a_mep;
             $this->transl_lang = $a_lang;
@@ -325,25 +325,23 @@ class ilMediaPoolDataSet extends ilDataSet
                             break;
 
                     }
-                } else {
-                    if ($a_rec["Type"] === "pg") {
-                        $imp_id = explode("_", $a_rec["ImportId"]);
-                        if ($imp_id[0] === "il" &&
-                            (int) $imp_id[1] == (int) IL_INST_ID &&
-                            $imp_id[2] === "pg"
-                        ) {
-                            $pg_id = $imp_id[3];
-                            $pool = ilMediaPoolItem::getPoolForItemId($pg_id);
-                            $pool = current($pool);
-                            if ($pool == $this->getTranslationMep()->getId()) {
-                                $a_mapping->addMapping("Modules/MediaPool", "pg", $a_rec["Child"], $pg_id);
-                                $a_mapping->addMapping(
-                                    "Services/COPage",
-                                    "pg",
-                                    "mep:" . $a_rec["Child"],
-                                    "mep:" . $pg_id
-                                );
-                            }
+                } elseif ($a_rec["Type"] === "pg") {
+                    $imp_id = explode("_", $a_rec["ImportId"]);
+                    if ($imp_id[0] === "il" &&
+                        (int) $imp_id[1] == (int) IL_INST_ID &&
+                        $imp_id[2] === "pg"
+                    ) {
+                        $pg_id = $imp_id[3];
+                        $pool = ilMediaPoolItem::getPoolForItemId($pg_id);
+                        $pool = current($pool);
+                        if ($pool == $this->getTranslationMep()->getId()) {
+                            $a_mapping->addMapping("Modules/MediaPool", "pg", $a_rec["Child"], $pg_id);
+                            $a_mapping->addMapping(
+                                "Services/COPage",
+                                "pg",
+                                "mep:" . $a_rec["Child"],
+                                "mep:" . $pg_id
+                            );
                         }
                     }
                 }

--- a/Modules/MediaPool/classes/class.ilMediaPoolDataSet.php
+++ b/Modules/MediaPool/classes/class.ilMediaPoolDataSet.php
@@ -38,7 +38,7 @@ class ilMediaPoolDataSet extends ilDataSet
         return array("5.1.0", "4.1.0");
     }
     
-    public function getXmlNamespace(string $a_entity, string $a_schema_version) : string
+    protected function getXmlNamespace(string $a_entity, string $a_schema_version) : string
     {
         return "https://www.ilias.de/xml/Modules/MediaPool/" . $a_entity;
     }
@@ -90,7 +90,7 @@ class ilMediaPoolDataSet extends ilDataSet
     protected function getTypes(string $a_entity, string $a_version) : array
     {
         // mep
-        if ($a_entity == "mep") {
+        if ($a_entity === "mep") {
             switch ($a_version) {
                 case "4.1.0":
                     return array(
@@ -113,7 +113,7 @@ class ilMediaPoolDataSet extends ilDataSet
         }
     
         // mep_tree
-        if ($a_entity == "mep_tree") {
+        if ($a_entity === "mep_tree") {
             switch ($a_version) {
                 case "4.1.0":
                 case "5.1.0":
@@ -137,7 +137,7 @@ class ilMediaPoolDataSet extends ilDataSet
         $ilDB = $this->db;
 
         // mep_data
-        if ($a_entity == "mep") {
+        if ($a_entity === "mep") {
             switch ($a_version) {
                 case "4.1.0":
                     $this->getDirectDataFromQuery("SELECT id, title, description, " .
@@ -175,7 +175,7 @@ class ilMediaPoolDataSet extends ilDataSet
         }
 
         // mep_tree
-        if ($a_entity == "mep_tree") {
+        if ($a_entity === "mep_tree") {
             switch ($a_version) {
                 case "4.1.0":
                     $this->getDirectDataFromQuery("SELECT mep_id, child " .
@@ -326,11 +326,11 @@ class ilMediaPoolDataSet extends ilDataSet
 
                     }
                 } else {
-                    if ($a_rec["Type"] == "pg") {
+                    if ($a_rec["Type"] === "pg") {
                         $imp_id = explode("_", $a_rec["ImportId"]);
-                        if ($imp_id[0] == "il" &&
+                        if ($imp_id[0] === "il" &&
                             (int) $imp_id[1] == (int) IL_INST_ID &&
-                            $imp_id[2] == "pg"
+                            $imp_id[2] === "pg"
                         ) {
                             $pg_id = $imp_id[3];
                             $pool = ilMediaPoolItem::getPoolForItemId($pg_id);

--- a/Modules/MediaPool/classes/class.ilMediaPoolImportConfig.php
+++ b/Modules/MediaPool/classes/class.ilMediaPoolImportConfig.php
@@ -28,7 +28,7 @@ class ilMediaPoolImportConfig extends ilImportConfig
         ?ilObjMediaPool $a_mep,
         string $a_lang = ""
     ) : void {
-        if ($a_mep != null) {
+        if ($a_mep !== null) {
             $this->transl_into = true;
             $this->transl_into_mep = $a_mep;
             $this->transl_lang = $a_lang;

--- a/Modules/MediaPool/classes/class.ilMediaPoolImportGUI.php
+++ b/Modules/MediaPool/classes/class.ilMediaPoolImportGUI.php
@@ -107,7 +107,7 @@ class ilMediaPoolImportGUI
 
         $target_lang = $this->request->getImportLang();
         $ot = ilObjectTranslation::getInstance($this->mep->getId());
-        if ($target_lang == $ot->getMasterLanguage()) {
+        if ($target_lang === $ot->getMasterLanguage()) {
             $this->tpl->setOnScreenMessage('failure', $lng->txt("mep_transl_master_language_not_allowed"), true);
             $ilCtrl->redirect($this, "showTranslationImportForm");
         }

--- a/Modules/MediaPool/classes/class.ilMediaPoolItem.php
+++ b/Modules/MediaPool/classes/class.ilMediaPoolItem.php
@@ -189,7 +189,7 @@ class ilMediaPoolItem
 
         $ilDB = $DIC->database();
 
-        if (ilObject::_lookupType($a_obj) == "mob") {
+        if (ilObject::_lookupType($a_obj) === "mob") {
             $title = ilObject::_lookupTitle($a_obj);
             $ilDB->manipulate(
                 "UPDATE mep_item SET " .

--- a/Modules/MediaPool/classes/class.ilMediaPoolPage.php
+++ b/Modules/MediaPool/classes/class.ilMediaPoolPage.php
@@ -25,7 +25,7 @@ class ilMediaPoolPage extends ilPageObject
         return "mep";
     }
 
-    public static function deleteAllPagesOfMediaPool($a_media_pool_id)
+    public static function deleteAllPagesOfMediaPool($a_media_pool_id) : void// TODO PHP8-REVIEW Type hint missing
     {
         // @todo deletion process of snippets
     }
@@ -33,7 +33,7 @@ class ilMediaPoolPage extends ilPageObject
     /**
      * Checks whether a page with given title exists
      */
-    public static function exists($a_media_pool_id, $a_title)
+    public static function exists($a_media_pool_id, $a_title) : void// TODO PHP8-REVIEW Type hints missing
     {
         // @todo: check if we need this
     }
@@ -85,10 +85,8 @@ class ilMediaPoolPage extends ilPageObject
 
             // check whether page exists
             $skip = false;
-            if ($ut == "pg") {
-                if (!ilPageObject::_exists($ct, $us_rec["usage_id"])) {
-                    $skip = true;
-                }
+            if ($ut === "pg" && !ilPageObject::_exists($ct, $us_rec["usage_id"])) {
+                $skip = true;
             }
                 
             if (!$skip) {
@@ -104,8 +102,10 @@ class ilMediaPoolPage extends ilPageObject
             $ilDB->quote($a_id, "integer") . " AND mep_item.type = " . $ilDB->quote("pg", "text");
         $us_set = $ilDB->query($q);
         while ($us_rec = $ilDB->fetchAssoc($us_set)) {
-            $ret[] = array("type" => "mep",
-                "id" => $us_rec["mep_id"]);
+            $ret[] = [
+                "type" => "mep",
+                "id" => (int) $us_rec["mep_id"]
+            ];
         }
         
         return $ret;

--- a/Modules/MediaPool/classes/class.ilMediaPoolPageUsagesTableGUI.php
+++ b/Modules/MediaPool/classes/class.ilMediaPoolPageUsagesTableGUI.php
@@ -81,16 +81,14 @@ class ilMediaPoolPageUsagesTableGUI extends ilTable2GUI
 
             if ($usage["type"] === "clip") {
                 $clip_cnt++;
-            } else {
-                if ($this->incl_hist || !$usage["trash"]) {
-                    if (empty($agg_usages[$usage["type"] . ":" . $usage["id"]])) {
-                        $agg_usages[$usage["type"] . ":" . $usage["id"]] = $usage;
-                    }
-                    $agg_usages[$usage["type"] . ":" . $usage["id"]]["versions"][] =
-                        ["hist_nr" => $usage["hist_nr"],
-                         "lang" => $usage["lang"]
-                        ];
+            } elseif ($this->incl_hist || !$usage["trash"]) {
+                if (empty($agg_usages[$usage["type"] . ":" . $usage["id"]])) {
+                    $agg_usages[$usage["type"] . ":" . $usage["id"]] = $usage;
                 }
+                $agg_usages[$usage["type"] . ":" . $usage["id"]]["versions"][] =
+                    ["hist_nr" => $usage["hist_nr"],
+                     "lang" => $usage["lang"]
+                    ];
             }
         }
 

--- a/Modules/MediaPool/classes/class.ilMediaPoolPageUsagesTableGUI.php
+++ b/Modules/MediaPool/classes/class.ilMediaPoolPageUsagesTableGUI.php
@@ -62,24 +62,24 @@ class ilMediaPoolPageUsagesTableGUI extends ilTable2GUI
                 $us_arr = explode(":", $usage["type"]);
 
                 // try to figure out object id of pages
-                if ($us_arr[1] == "pg") {
+                if ($us_arr[1] === "pg") {
                     $page_obj = ilPageObjectFactory::getInstance($us_arr[0], $usage["id"]);
                     $usage["page"] = $page_obj;
                     $repo_tree = $this->repo_tree;
                     $ref_ids = array_filter(
                         ilObject::_getAllReferences($page_obj->getRepoObjId()),
-                        function ($ref_id) use ($repo_tree) {
+                        static function ($ref_id) use ($repo_tree) : bool {
                             return $repo_tree->isInTree($ref_id);
                         }
                     );
                     $usage["ref_ids"] = $ref_ids;
-                    if (count($ref_ids) == 0) {
+                    if (count($ref_ids) === 0) {
                         $usage["trash"] = true;
                     }
                 }
             }
 
-            if ($usage["type"] == "clip") {
+            if ($usage["type"] === "clip") {
                 $clip_cnt++;
             } else {
                 if ($this->incl_hist || !$usage["trash"]) {
@@ -223,7 +223,7 @@ class ilMediaPoolPageUsagesTableGUI extends ilTable2GUI
             $this->tpl->parseCurrentBlock();
         }
 
-        if ($usage["type"] != "clip") {
+        if ($usage["type"] !== "clip") {
             if ($item["obj_link"]) {
                 $this->tpl->setCurrentBlock("linked_item");
                 $this->tpl->setVariable("TXT_OBJECT", $item["obj_title"]);

--- a/Modules/MediaPool/classes/class.ilMediaPoolTableGUI.php
+++ b/Modules/MediaPool/classes/class.ilMediaPoolTableGUI.php
@@ -74,7 +74,7 @@ class ilMediaPoolTableGUI extends ilTable2GUI
             ->standardRequest();
 
         if ($a_parent_tpl === null) {
-            $a_parent_tpl = $GLOBALS["tpl"];
+            $a_parent_tpl = $DIC->ui()->mainTemplate();
         }
         $this->parent_tpl = $a_parent_tpl;
         if ($a_all_objects) {
@@ -144,7 +144,7 @@ class ilMediaPoolTableGUI extends ilTable2GUI
             );
             $adv_th_record_gui->setTableGUI($this);
             $adv_th_record_gui->parse();
-            if ($a_mode == self::IL_MEP_SELECT) {
+            if ($a_mode === self::IL_MEP_SELECT) {
                 $this->setFilterCommand("insert_applyFilter");
                 $this->setResetCommand("insert_resetFilter");
             }
@@ -157,8 +157,8 @@ class ilMediaPoolTableGUI extends ilTable2GUI
         $this->getItems();
 
         // title
-        if ($a_mode != self::IL_MEP_EDIT) {
-            if ($this->current_folder != $this->tree->getRootId() && !$this->all_objects) {
+        if ($a_mode !== self::IL_MEP_EDIT) {
+            if ($this->current_folder !== $this->tree->getRootId() && !$this->all_objects) {
                 $node = $this->tree->getNodeData($this->current_folder);
                 $this->setTitle(
                     $lng->txt("mep_choose_from_folder") . ": " . $node["title"],
@@ -177,17 +177,17 @@ class ilMediaPoolTableGUI extends ilTable2GUI
         
         // action commands
         if ($ilAccess->checkAccess("write", "", $this->media_pool->getRefId()) &&
-            $this->getMode() == self::IL_MEP_EDIT) {
+            $this->getMode() === self::IL_MEP_EDIT) {
             $this->addMultiCommand("copyToClipboard", $lng->txt("cont_copy_to_clipboard"));
             $this->addMultiCommand("confirmRemove", $lng->txt("remove"));
         }
 
-        if ($this->getMode() == self::IL_MEP_SELECT_SINGLE) {
+        if ($this->getMode() === self::IL_MEP_SELECT_SINGLE) {
             // ... even more coupling with ilpcmediaobjectgui
             $this->addMultiCommand("selectObjectReference", $lng->txt("cont_select"));
         }
         
-        if ($this->getMode() == self::IL_MEP_EDIT &&
+        if ($this->getMode() === self::IL_MEP_EDIT &&
             $ilAccess->checkAccess("write", "", $this->media_pool->getRefId())) {
             $this->setSelectAllCheckbox("id");
         }
@@ -305,9 +305,9 @@ class ilMediaPoolTableGUI extends ilTable2GUI
             ksort($f2objs);
             
             // get current media objects / pages
-            if ($this->getMode() == self::IL_MEP_SELECT) {
+            if ($this->getMode() === self::IL_MEP_SELECT) {
                 $mobjs = $this->media_pool->getChilds($this->current_folder, "mob");
-            } elseif ($this->getMode() == self::IL_MEP_SELECT_CONTENT) {
+            } elseif ($this->getMode() === self::IL_MEP_SELECT_CONTENT) {
                 $mobjs = $this->media_pool->getChilds($this->current_folder, "pg");
             } else {
                 $mobjs = $this->media_pool->getChildsExceptFolders($this->current_folder);
@@ -350,8 +350,8 @@ class ilMediaPoolTableGUI extends ilTable2GUI
     {
         $lng = $this->lng;
         
-        if ($this->getMode() == self::IL_MEP_SELECT ||
-            $this->getMode() == self::IL_MEP_SELECT_CONTENT) {
+        if ($this->getMode() === self::IL_MEP_SELECT ||
+            $this->getMode() === self::IL_MEP_SELECT_CONTENT) {
             $this->addMultiCommand($this->getInsertCommand(), $lng->txt("insert"));
             $this->addCommandButton("cancelCreate", $lng->txt("cancel"));
         }
@@ -390,7 +390,7 @@ class ilMediaPoolTableGUI extends ilTable2GUI
                 $this->tpl->parseCurrentBlock();
                 
                 if ($ilAccess->checkAccess("write", "", $this->media_pool->getRefId()) &&
-                    $this->getMode() == self::IL_MEP_EDIT) {
+                    $this->getMode() === self::IL_MEP_EDIT) {
                     $this->tpl->setCurrentBlock("edit");
                     $this->tpl->setVariable("TXT_EDIT", $lng->txt("edit"));
                     $ilCtrl->setParameter($this->parent_obj, $this->folder_par, $a_set["obj_id"]);
@@ -412,8 +412,8 @@ class ilMediaPoolTableGUI extends ilTable2GUI
                 break;
 
             case "pg":
-                if ($this->getMode() == self::IL_MEP_SELECT ||
-                    $this->getMode() == self::IL_MEP_SELECT_SINGLE) {
+                if ($this->getMode() === self::IL_MEP_SELECT ||
+                    $this->getMode() === self::IL_MEP_SELECT_SINGLE) {
                     $this->tpl->setVariable("TXT_NO_LINK_TITLE", $a_set["title"]);
                 } else {
                     $this->tpl->setVariable("ONCLICK", "il.MediaPool.preview('" . $a_set["child"] . "'); return false;");
@@ -421,8 +421,8 @@ class ilMediaPoolTableGUI extends ilTable2GUI
                     $ilCtrl->setParameterByClass("ilobjmediapoolgui", "mepitem_id", $a_set["child"]);
                 }
                 
-                if ($ilAccess->checkAccess("write", "", $this->media_pool->getRefId()) &&
-                    $this->getMode() == self::IL_MEP_EDIT) {
+                if ($this->getMode() === self::IL_MEP_EDIT &&
+                    $ilAccess->checkAccess("write", "", $this->media_pool->getRefId())) {
                     $this->tpl->setCurrentBlock("edit");
                     $this->tpl->setVariable("TXT_EDIT", $lng->txt("edit"));
                     $ilCtrl->setParameterByClass("ilmediapoolpagegui", "mepitem_id", $a_set["child"]);
@@ -446,7 +446,7 @@ class ilMediaPoolTableGUI extends ilTable2GUI
 
                 // edit link
                 if ($ilAccess->checkAccess("write", "", $this->media_pool->getRefId()) &&
-                    $this->getMode() == self::IL_MEP_EDIT) {
+                    $this->getMode() === self::IL_MEP_EDIT) {
                     $this->tpl->setCurrentBlock("edit");
                     $this->tpl->setVariable("TXT_EDIT", $lng->txt("edit"));
                     $this->tpl->setVariable(
@@ -467,7 +467,7 @@ class ilMediaPoolTableGUI extends ilTable2GUI
                     if ($med) {
                         $target = $med->getThumbnailTarget();
                     }
-                    if ($target != "") {
+                    if ($target !== "") {
                         $this->tpl->setVariable("IMG", ilUtil::img(ilWACSignedPath::signFile($target)));
                     } else {
                         $this->tpl->setVariable(
@@ -503,15 +503,15 @@ class ilMediaPoolTableGUI extends ilTable2GUI
 
         if ($ilAccess->checkAccess("write", "", $this->media_pool->getRefId())) {
             if ((
-                $this->getMode() == self::IL_MEP_EDIT ||
-                    ($this->getMode() == self::IL_MEP_SELECT && $a_set["type"] === "mob") ||
-                    ($this->getMode() == self::IL_MEP_SELECT_CONTENT && $a_set["type"] === "pg")
+                $this->getMode() === self::IL_MEP_EDIT ||
+                    ($this->getMode() === self::IL_MEP_SELECT && $a_set["type"] === "mob") ||
+                    ($this->getMode() === self::IL_MEP_SELECT_CONTENT && $a_set["type"] === "pg")
             )) {
                 $this->tpl->setCurrentBlock("chbox");
                 $this->tpl->setVariable("CHECKBOX_ID", $a_set["child"]);
                 $this->tpl->parseCurrentBlock();
                 $this->tpl->setCurrentBlock("tbl_content");
-            } elseif ($this->getMode() == self::IL_MEP_SELECT_SINGLE && $a_set["type"] === "mob") {
+            } elseif ($this->getMode() === self::IL_MEP_SELECT_SINGLE && $a_set["type"] === "mob") {
                 $this->tpl->setCurrentBlock("radio");
                 $this->tpl->setVariable("RADIO_ID", $a_set["child"]);
                 $this->tpl->parseCurrentBlock();
@@ -527,7 +527,7 @@ class ilMediaPoolTableGUI extends ilTable2GUI
         $mtpl = new ilTemplate("tpl.media_sel_table.html", true, true, "Modules/MediaPool");
         
         $pre = "";
-        if ($this->current_folder != $this->tree->getRootId() && !$this->all_objects) {
+        if ($this->current_folder !== $this->tree->getRootId() && !$this->all_objects) {
             $path = $this->tree->getPathFull($this->current_folder);
 
             $loc = new ilLocatorGUI();

--- a/Modules/MediaPool/classes/class.ilMediaPoolTableGUI.php
+++ b/Modules/MediaPool/classes/class.ilMediaPoolTableGUI.php
@@ -73,7 +73,7 @@ class ilMediaPoolTableGUI extends ilTable2GUI
             ->gui()
             ->standardRequest();
 
-        if ($a_parent_tpl == null) {
+        if ($a_parent_tpl === null) {
             $a_parent_tpl = $GLOBALS["tpl"];
         }
         $this->parent_tpl = $a_parent_tpl;
@@ -157,7 +157,7 @@ class ilMediaPoolTableGUI extends ilTable2GUI
         $this->getItems();
 
         // title
-        if ($a_mode != ilMediaPoolTableGUI::IL_MEP_EDIT) {
+        if ($a_mode != self::IL_MEP_EDIT) {
             if ($this->current_folder != $this->tree->getRootId() && !$this->all_objects) {
                 $node = $this->tree->getNodeData($this->current_folder);
                 $this->setTitle(
@@ -177,17 +177,17 @@ class ilMediaPoolTableGUI extends ilTable2GUI
         
         // action commands
         if ($ilAccess->checkAccess("write", "", $this->media_pool->getRefId()) &&
-            $this->getMode() == ilMediaPoolTableGUI::IL_MEP_EDIT) {
+            $this->getMode() == self::IL_MEP_EDIT) {
             $this->addMultiCommand("copyToClipboard", $lng->txt("cont_copy_to_clipboard"));
             $this->addMultiCommand("confirmRemove", $lng->txt("remove"));
         }
 
-        if ($this->getMode() == ilMediaPoolTableGUI::IL_MEP_SELECT_SINGLE) {
+        if ($this->getMode() == self::IL_MEP_SELECT_SINGLE) {
             // ... even more coupling with ilpcmediaobjectgui
             $this->addMultiCommand("selectObjectReference", $lng->txt("cont_select"));
         }
         
-        if ($this->getMode() == ilMediaPoolTableGUI::IL_MEP_EDIT &&
+        if ($this->getMode() == self::IL_MEP_EDIT &&
             $ilAccess->checkAccess("write", "", $this->media_pool->getRefId())) {
             $this->setSelectAllCheckbox("id");
         }
@@ -305,9 +305,9 @@ class ilMediaPoolTableGUI extends ilTable2GUI
             ksort($f2objs);
             
             // get current media objects / pages
-            if ($this->getMode() == ilMediaPoolTableGUI::IL_MEP_SELECT) {
+            if ($this->getMode() == self::IL_MEP_SELECT) {
                 $mobjs = $this->media_pool->getChilds($this->current_folder, "mob");
-            } elseif ($this->getMode() == ilMediaPoolTableGUI::IL_MEP_SELECT_CONTENT) {
+            } elseif ($this->getMode() == self::IL_MEP_SELECT_CONTENT) {
                 $mobjs = $this->media_pool->getChilds($this->current_folder, "pg");
             } else {
                 $mobjs = $this->media_pool->getChildsExceptFolders($this->current_folder);
@@ -350,8 +350,8 @@ class ilMediaPoolTableGUI extends ilTable2GUI
     {
         $lng = $this->lng;
         
-        if ($this->getMode() == ilMediaPoolTableGUI::IL_MEP_SELECT ||
-            $this->getMode() == ilMediaPoolTableGUI::IL_MEP_SELECT_CONTENT) {
+        if ($this->getMode() == self::IL_MEP_SELECT ||
+            $this->getMode() == self::IL_MEP_SELECT_CONTENT) {
             $this->addMultiCommand($this->getInsertCommand(), $lng->txt("insert"));
             $this->addCommandButton("cancelCreate", $lng->txt("cancel"));
         }
@@ -390,7 +390,7 @@ class ilMediaPoolTableGUI extends ilTable2GUI
                 $this->tpl->parseCurrentBlock();
                 
                 if ($ilAccess->checkAccess("write", "", $this->media_pool->getRefId()) &&
-                    $this->getMode() == ilMediaPoolTableGUI::IL_MEP_EDIT) {
+                    $this->getMode() == self::IL_MEP_EDIT) {
                     $this->tpl->setCurrentBlock("edit");
                     $this->tpl->setVariable("TXT_EDIT", $lng->txt("edit"));
                     $ilCtrl->setParameter($this->parent_obj, $this->folder_par, $a_set["obj_id"]);
@@ -412,8 +412,8 @@ class ilMediaPoolTableGUI extends ilTable2GUI
                 break;
 
             case "pg":
-                if ($this->getMode() == ilMediaPoolTableGUI::IL_MEP_SELECT ||
-                    $this->getMode() == ilMediaPoolTableGUI::IL_MEP_SELECT_SINGLE) {
+                if ($this->getMode() == self::IL_MEP_SELECT ||
+                    $this->getMode() == self::IL_MEP_SELECT_SINGLE) {
                     $this->tpl->setVariable("TXT_NO_LINK_TITLE", $a_set["title"]);
                 } else {
                     $this->tpl->setVariable("ONCLICK", "il.MediaPool.preview('" . $a_set["child"] . "'); return false;");
@@ -422,7 +422,7 @@ class ilMediaPoolTableGUI extends ilTable2GUI
                 }
                 
                 if ($ilAccess->checkAccess("write", "", $this->media_pool->getRefId()) &&
-                    $this->getMode() == ilMediaPoolTableGUI::IL_MEP_EDIT) {
+                    $this->getMode() == self::IL_MEP_EDIT) {
                     $this->tpl->setCurrentBlock("edit");
                     $this->tpl->setVariable("TXT_EDIT", $lng->txt("edit"));
                     $ilCtrl->setParameterByClass("ilmediapoolpagegui", "mepitem_id", $a_set["child"]);
@@ -446,7 +446,7 @@ class ilMediaPoolTableGUI extends ilTable2GUI
 
                 // edit link
                 if ($ilAccess->checkAccess("write", "", $this->media_pool->getRefId()) &&
-                    $this->getMode() == ilMediaPoolTableGUI::IL_MEP_EDIT) {
+                    $this->getMode() == self::IL_MEP_EDIT) {
                     $this->tpl->setCurrentBlock("edit");
                     $this->tpl->setVariable("TXT_EDIT", $lng->txt("edit"));
                     $this->tpl->setVariable(
@@ -460,7 +460,7 @@ class ilMediaPoolTableGUI extends ilTable2GUI
                 $this->tpl->setCurrentBlock("tbl_content");
                 
                 // output thumbnail (or mob icon)
-                if (ilObject::_lookupType($a_set["foreign_id"]) == "mob") {
+                if (ilObject::_lookupType($a_set["foreign_id"]) === "mob") {
                     $mob = new ilObjMediaObject($a_set["foreign_id"]);
                     $med = $mob->getMediaItem("Standard");
                     $target = "";
@@ -476,7 +476,7 @@ class ilMediaPoolTableGUI extends ilTable2GUI
                         );
                     }
                     if ($med && ilUtil::deducibleSize($med->getFormat()) &&
-                        $med->getLocationType() == "Reference") {
+                        $med->getLocationType() === "Reference") {
                         $size = getimagesize($med->getLocation());
                         if ($size[0] > 0 && $size[1] > 0) {
                             $wr = $size[0] / 80;
@@ -503,15 +503,15 @@ class ilMediaPoolTableGUI extends ilTable2GUI
 
         if ($ilAccess->checkAccess("write", "", $this->media_pool->getRefId())) {
             if ((
-                $this->getMode() == ilMediaPoolTableGUI::IL_MEP_EDIT ||
-                    ($this->getMode() == ilMediaPoolTableGUI::IL_MEP_SELECT && $a_set["type"] == "mob") ||
-                    ($this->getMode() == ilMediaPoolTableGUI::IL_MEP_SELECT_CONTENT && $a_set["type"] == "pg")
+                $this->getMode() == self::IL_MEP_EDIT ||
+                    ($this->getMode() == self::IL_MEP_SELECT && $a_set["type"] === "mob") ||
+                    ($this->getMode() == self::IL_MEP_SELECT_CONTENT && $a_set["type"] === "pg")
             )) {
                 $this->tpl->setCurrentBlock("chbox");
                 $this->tpl->setVariable("CHECKBOX_ID", $a_set["child"]);
                 $this->tpl->parseCurrentBlock();
                 $this->tpl->setCurrentBlock("tbl_content");
-            } elseif ($this->getMode() == ilMediaPoolTableGUI::IL_MEP_SELECT_SINGLE && $a_set["type"] == "mob") {
+            } elseif ($this->getMode() == self::IL_MEP_SELECT_SINGLE && $a_set["type"] === "mob") {
                 $this->tpl->setCurrentBlock("radio");
                 $this->tpl->setVariable("RADIO_ID", $a_set["child"]);
                 $this->tpl->parseCurrentBlock();

--- a/Modules/MediaPool/classes/class.ilObjMediaPool.php
+++ b/Modules/MediaPool/classes/class.ilObjMediaPool.php
@@ -86,7 +86,7 @@ class ilObjMediaPool extends ilObject
             $this->setDefaultHeight($rec["default_height"]);
             $this->setForTranslation($rec["for_translation"]);
         }
-        $this->mep_tree = ilObjMediaPool::_getPoolTree($this->getId());
+        $this->mep_tree = self::_getPoolTree($this->getId());
     }
 
 
@@ -178,7 +178,7 @@ class ilObjMediaPool extends ilObject
             $fid = ilMediaPoolItem::lookupForeignId($child["obj_id"]);
             switch ($child["type"]) {
                 case "mob":
-                    if (ilObject::_lookupType($fid) == "mob") {
+                    if (ilObject::_lookupType($fid) === "mob") {
                         $mob = new ilObjMediaObject($fid);
                         $mob->delete();
                     }
@@ -203,16 +203,16 @@ class ilObjMediaPool extends ilObject
             $obj_id = $this->mep_tree->getRootId();
         }
 
-        if ($a_type == "fold" || $a_type == "") {
+        if ($a_type === "fold" || $a_type == "") {
             $objs = $this->mep_tree->getChildsByType($obj_id, "fold");
         }
-        if ($a_type == "mob" || $a_type == "") {
+        if ($a_type === "mob" || $a_type == "") {
             $mobs = $this->mep_tree->getChildsByType($obj_id, "mob");
         }
         foreach ($mobs as $key => $mob) {
             $objs[] = $mob;
         }
-        if ($a_type == "pg" || $a_type == "") {
+        if ($a_type === "pg" || $a_type == "") {
             $pgs = $this->mep_tree->getChildsByType($obj_id, "pg");
         }
         foreach ($pgs as $key => $pg) {
@@ -261,7 +261,7 @@ class ilObjMediaPool extends ilObject
             $query .= " AND " . $ilDB->like("object_data.title", "text", "%" . trim($a_title_filter) . "%");
         }
         if ($a_format_filter != "") {			// format
-            $filter = ($a_format_filter == "unknown")
+            $filter = ($a_format_filter === "unknown")
                 ? ""
                 : $a_format_filter;
             $query .= " AND " . $ilDB->equals("media_item.format", $filter, "text", true);
@@ -395,21 +395,21 @@ class ilObjMediaPool extends ilObject
         // delete objects
         foreach ($subtree as $node) {
             $fid = ilMediaPoolItem::lookupForeignId($node["child"]);
-            if ($node["type"] == "mob") {
-                if (ilObject::_lookupType($fid) == "mob") {
+            if ($node["type"] === "mob") {
+                if (ilObject::_lookupType($fid) === "mob") {
                     $obj = new ilObjMediaObject($fid);
                     $obj->delete();
                 }
             }
 
-            if ($node["type"] == "fold") {
-                if ($fid > 0 && ilObject::_lookupType($fid) == "fold") {
+            if ($node["type"] === "fold") {
+                if ($fid > 0 && ilObject::_lookupType($fid) === "fold") {
                     $obj = new ilObjFolder($fid, false);
                     $obj->delete();
                 }
             }
 
-            if ($node["type"] == "pg") {
+            if ($node["type"] === "pg") {
                 if (ilPageObject::_exists("mep", $node["child"])) {
                     $pg = new ilMediaPoolPage($node["child"]);
                     $pg->delete();
@@ -489,10 +489,10 @@ class ilObjMediaPool extends ilObject
      * @param int target ref_id
      * @param int copy id
      */
-    public function cloneObject(int $a_target_id, int $a_copy_id = 0, bool $a_omit_tree = false) : ?ilObject
+    public function cloneObject(int $target_id, int $copy_id = 0, bool $omit_tree = false) : ?ilObject
     {
         /** @var ilObjMediaPool $new_obj */
-        $new_obj = parent::cloneObject($a_target_id, $a_copy_id, $a_omit_tree);
+        $new_obj = parent::cloneObject($target_id, $copy_id, $omit_tree);
         
         $new_obj->setTitle($this->getTitle());
         $new_obj->setDescription($this->getDescription());
@@ -565,7 +565,7 @@ class ilObjMediaPool extends ilObject
         if (in_array($a_mode, array("master", "masternomedia"))) {
             $exp = new ilExport();
             $conf = $exp->getConfig("Modules/MediaPool");
-            $conf->setMasterLanguageOnly(true, ($a_mode == "master"));
+            $conf->setMasterLanguageOnly(true, ($a_mode === "master"));
             $exp->exportObject($this->getType(), $this->getId(), "4.4.0");
         }
     }

--- a/Modules/MediaPool/classes/class.ilObjMediaPool.php
+++ b/Modules/MediaPool/classes/class.ilObjMediaPool.php
@@ -199,20 +199,20 @@ class ilObjMediaPool extends ilObject
         $objs = array();
         $mobs = array();
         $pgs = array();
-        if ($obj_id == 0) {
+        if ($obj_id === 0) {
             $obj_id = $this->mep_tree->getRootId();
         }
 
-        if ($a_type === "fold" || $a_type == "") {
+        if ($a_type === "fold" || $a_type === "") {
             $objs = $this->mep_tree->getChildsByType($obj_id, "fold");
         }
-        if ($a_type === "mob" || $a_type == "") {
+        if ($a_type === "mob" || $a_type === "") {
             $mobs = $this->mep_tree->getChildsByType($obj_id, "mob");
         }
         foreach ($mobs as $key => $mob) {
             $objs[] = $mob;
         }
-        if ($a_type === "pg" || $a_type == "") {
+        if ($a_type === "pg" || $a_type === "") {
             $pgs = $this->mep_tree->getChildsByType($obj_id, "pg");
         }
         foreach ($pgs as $key => $pg) {
@@ -225,12 +225,11 @@ class ilObjMediaPool extends ilObject
     public function getChildsExceptFolders(
         int $obj_id = 0
     ) : array {
-        if ($obj_id == 0) {
+        if ($obj_id === 0) {
             $obj_id = $this->mep_tree->getRootId();
         }
 
-        $objs = $this->mep_tree->getFilteredChilds(array("fold", "dummy"), $obj_id);
-        return $objs;
+        return $this->mep_tree->getFilteredChilds(array("fold", "dummy"), $obj_id);
     }
 
     /**
@@ -248,7 +247,7 @@ class ilObjMediaPool extends ilObject
             "FROM mep_tree JOIN mep_item ON (mep_tree.child = mep_item.obj_id) " .
             " JOIN object_data ON (mep_item.foreign_id = object_data.obj_id) ";
             
-        if ($a_format_filter != "" or $a_caption_filter != '') {
+        if ($a_format_filter !== "" || $a_caption_filter !== '') {
             $query .= " JOIN media_item ON (media_item.mob_id = object_data.obj_id) ";
         }
             
@@ -257,10 +256,10 @@ class ilObjMediaPool extends ilObject
             " AND object_data.type = " . $ilDB->quote("mob", "text");
             
         // filter
-        if (trim($a_title_filter) != "") {	// title
+        if (trim($a_title_filter) !== "") {	// title
             $query .= " AND " . $ilDB->like("object_data.title", "text", "%" . trim($a_title_filter) . "%");
         }
-        if ($a_format_filter != "") {			// format
+        if ($a_format_filter !== "") {			// format
             $filter = ($a_format_filter === "unknown")
                 ? ""
                 : $a_format_filter;
@@ -350,10 +349,10 @@ class ilObjMediaPool extends ilObject
     
     public function getParentId(int $obj_id = 0) : ?int
     {
-        if ($obj_id == 0) {
+        if ($obj_id === 0) {
             return null;
         }
-        if ($obj_id == $this->mep_tree->getRootId()) {
+        if ($obj_id === $this->mep_tree->getRootId()) {
             return null;
         }
 
@@ -373,9 +372,9 @@ class ilObjMediaPool extends ilObject
                 : $a_parent;
             $this->mep_tree->insertNode($a_obj_id, $parent);
             return true;
-        } else {
-            return false;
         }
+
+        return false;
     }
 
 
@@ -395,25 +394,19 @@ class ilObjMediaPool extends ilObject
         // delete objects
         foreach ($subtree as $node) {
             $fid = ilMediaPoolItem::lookupForeignId($node["child"]);
-            if ($node["type"] === "mob") {
-                if (ilObject::_lookupType($fid) === "mob") {
-                    $obj = new ilObjMediaObject($fid);
-                    $obj->delete();
-                }
+            if ($node["type"] === "mob" && ilObject::_lookupType($fid) === "mob") {
+                $obj = new ilObjMediaObject($fid);
+                $obj->delete();
             }
 
-            if ($node["type"] === "fold") {
-                if ($fid > 0 && ilObject::_lookupType($fid) === "fold") {
-                    $obj = new ilObjFolder($fid, false);
-                    $obj->delete();
-                }
+            if ($node["type"] === "fold" && $fid > 0 && ilObject::_lookupType($fid) === "fold") {
+                $obj = new ilObjFolder($fid, false);
+                $obj->delete();
             }
 
-            if ($node["type"] === "pg") {
-                if (ilPageObject::_exists("mep", $node["child"])) {
-                    $pg = new ilMediaPoolPage($node["child"]);
-                    $pg->delete();
-                }
+            if ($node["type"] === "pg" && ilPageObject::_exists("mep", $node["child"])) {
+                $pg = new ilMediaPoolPage($node["child"]);
+                $pg->delete();
             }
 
             $item = new ilMediaPoolItem($node["child"]);

--- a/Modules/MediaPool/classes/class.ilObjMediaPoolGUI.php
+++ b/Modules/MediaPool/classes/class.ilObjMediaPoolGUI.php
@@ -583,7 +583,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
 
             $upload_factory = new ilImportDirectoryFactory();
             $media_upload = $upload_factory->getInstanceForComponent(ilImportDirectoryFactory::TYPE_MOB);
-            if ($media_upload->exists() && $this->rbacsystem->checkAccess("visible", SYSTEM_FOLDER_ID)) {
+            if ($media_upload->exists() && $this->rbac_system->checkAccess("visible", SYSTEM_FOLDER_ID)) {
                 $ilToolbar->addButton(
                     $lng->txt("mep_create_from_upload_dir"),
                     $ilCtrl->getLinkTargetByClass("ilfilesystemgui", "listFiles")
@@ -1667,7 +1667,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
 
         $this->checkPermission("write");
 
-        if ($this->rbacsystem->checkAccess("visible", SYSTEM_FOLDER_ID)) {
+        if ($this->rbac_system->checkAccess("visible", SYSTEM_FOLDER_ID)) {
 
             // action type
             $options = array(
@@ -1703,7 +1703,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
         $upload_dir = $mob_import_directory->getAbsolutePath();
 
         $files = $this->mep_request->getFiles();
-        if ($this->rbacsystem->checkAccess("visible", SYSTEM_FOLDER_ID)) {
+        if ($this->rbac_system->checkAccess("visible", SYSTEM_FOLDER_ID)) {
             foreach ($files as $f) {
                 $f = str_replace("..", "", $f);
                 $fullpath = $upload_dir . "/" . $f;

--- a/Modules/MediaPool/classes/class.ilObjMediaPoolGUI.php
+++ b/Modules/MediaPool/classes/class.ilObjMediaPoolGUI.php
@@ -65,7 +65,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
             ->standardRequest();
 
         $this->mep_item_id = $this->mep_request->getItemId();
-        $this->mode = ($this->mep_request->getMode() != "")
+        $this->mode = ($this->mep_request->getMode() !== "")
             ? $this->mep_request->getMode()
             : "listMedia";
     }
@@ -119,7 +119,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
         $new_type = $this->mep_request->getNewType();
         $tree = null;
 
-        if ($new_type != "" && ($cmd !== "confirmRemove" && $cmd !== "copyToClipboard"
+        if ($new_type !== "" && ($cmd !== "confirmRemove" && $cmd !== "copyToClipboard"
             && $cmd !== "pasteFromClipboard")) {
             $this->setCreationMode(true);
         }
@@ -252,13 +252,11 @@ class ilObjMediaPoolGUI extends ilObject2GUI
                         break;
 
                     case "saveObject":
-                        //$folder_gui->setReturnLocation("save", $this->ctrl->getLinkTarget($this, "listMedia"));
                         $parent = ($this->mep_item_id == 0)
                             ? $tree->getRootId()
                             : $this->mep_item_id;
                         $folder_gui->setFolderTree($tree);
-                        $folder_gui->saveObject($parent);
-                        //$this->ctrl->redirect($this, "listMedia");
+                        $folder_gui->saveObject();
                         break;
 
                     case "editObject":
@@ -704,9 +702,9 @@ class ilObjMediaPoolGUI extends ilObject2GUI
         $par_id = $this->object->getPoolTree()->getParentId($this->mep_item_id);
         if ($par_id != $this->object->getPoolTree()->getRootId()) {
             return (int) $par_id;
-        } else {
-            return null;
         }
+
+        return null;
     }
     
     /**
@@ -836,7 +834,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
         $this->checkPermission("write");
 
         $ids = $this->mep_request->getItemIds();
-        if (count($ids) == 0) {
+        if (count($ids) === 0) {
             $this->main_tpl->setOnScreenMessage('failure', $this->lng->txt("no_checkbox"), true);
             $ilCtrl->redirect($this, "");
         }
@@ -997,7 +995,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
         $this->checkPermission("write");
 
         $ids = $this->mep_request->getItemIds();
-        if (count($ids) == 0) {
+        if (count($ids) === 0) {
             $this->main_tpl->setOnScreenMessage('failure', $this->lng->txt("no_checkbox"), true);
             $this->ctrl->redirect($this, $this->mode);
         }
@@ -2056,7 +2054,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
             $form->checkInput();
             $title = $form->getInput("title_" . $mi["mob_id"]);
             $desc = $form->getInput("description_" . $mi["mob_id"]);
-            if (trim($title) != "") {
+            if (trim($title) !== "") {
                 $mob->setTitle($title);
             }
             $mob->setDescription($desc);

--- a/Modules/MediaPool/classes/class.ilObjMediaPoolGUI.php
+++ b/Modules/MediaPool/classes/class.ilObjMediaPoolGUI.php
@@ -86,7 +86,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
         
         $lng->loadLanguageModule("mep");
         
-        if ($this->ctrl->getCmd() == "explorer") {
+        if ($this->ctrl->getCmd() === "explorer") {
             $this->ctrl->saveParameter($this, array("ref_id"));
         } else {
             $this->ctrl->saveParameter($this, array("ref_id", "mepitem_id"));
@@ -119,8 +119,8 @@ class ilObjMediaPoolGUI extends ilObject2GUI
         $new_type = $this->mep_request->getNewType();
         $tree = null;
 
-        if ($new_type != "" && ($cmd != "confirmRemove" && $cmd != "copyToClipboard"
-            && $cmd != "pasteFromClipboard")) {
+        if ($new_type != "" && ($cmd !== "confirmRemove" && $cmd !== "copyToClipboard"
+            && $cmd !== "pasteFromClipboard")) {
             $this->setCreationMode(true);
         }
 
@@ -130,7 +130,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
                 $this->mep_item_id = $tree->getRootId();
             }
         }
-        if ($cmd == "create") {
+        if ($cmd === "create") {
             switch ($this->mep_request->getNewType()) {
                 case "mob":
                     $this->ctrl->redirectByClass("ilobjmediaobjectgui", "create");
@@ -179,7 +179,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
 
             case "ilobjmediaobjectgui":
                 $this->checkPermission("write");
-                if ($cmd == "create" || $cmd == "save" || $cmd == "cancel") {
+                if ($cmd === "create" || $cmd === "save" || $cmd === "cancel") {
                     $ret_obj = $this->mep_item_id;
                     $ilObjMediaObjectGUI = new ilObjMediaObjectGUI("", 0, false, false);
                     $ilObjMediaObjectGUI->setWidthPreset($this->getMediaPool()->getDefaultWidth());
@@ -196,7 +196,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
                         )
                     );
                 }
-                if ($this->ctrl->getCmdClass() == "ilinternallinkgui") {
+                if ($this->ctrl->getCmdClass() === "ilinternallinkgui") {
                     $this->ctrl->setReturn($this, "explorer");
                 } else {
                     $this->ctrl->setParameter($this, "mepitem_id", $ret_obj);
@@ -215,7 +215,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
 
                 $ret = $this->ctrl->forwardCommand($ilObjMediaObjectGUI);
 
-                if ($cmd == "save" && $ret != false) {
+                if ($cmd === "save" && $ret != false) {
                     $mep_item = new ilMediaPoolItem();
                     $mep_item->setTitle($ret->getTitle());
                     $mep_item->setType("mob");
@@ -442,7 +442,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
         ilUtil::redirect("ilias.php?baseClass=ilMediaPoolPresentationGUI&ref_id=" . $new_object->getRefId() . "&cmd=listMedia");
     }
 
-    protected function initEditCustomForm(ilPropertyFormGUI $form) : void
+    protected function initEditCustomForm(ilPropertyFormGUI $a_form) : void
     {
         $obj_service = $this->object_service;
 
@@ -452,7 +452,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
         $ni->setSuffix("px");
         $ni->setMaxLength(5);
         $ni->setSize(5);
-        $form->addItem($ni);
+        $a_form->addItem($ni);
 
         // default height
         $ni = new ilNumberInputGUI($this->lng->txt("mep_default_height"), "default_height");
@@ -461,24 +461,24 @@ class ilObjMediaPoolGUI extends ilObject2GUI
         $ni->setMaxLength(5);
         $ni->setSize(5);
         $ni->setInfo($this->lng->txt("mep_default_width_height_info"));
-        $form->addItem($ni);
+        $a_form->addItem($ni);
 
         // presentation
         $pres = new ilFormSectionHeaderGUI();
         $pres->setTitle($this->lng->txt('obj_presentation'));
-        $form->addItem($pres);
+        $a_form->addItem($pres);
 
         // tile image
-        $obj_service->commonSettings()->legacyForm($form, $this->object)->addTileImage();
+        $obj_service->commonSettings()->legacyForm($a_form, $this->object)->addTileImage();
 
         // additional features
         $feat = new ilFormSectionHeaderGUI();
         $feat->setTitle($this->lng->txt('obj_features'));
-        $form->addItem($feat);
+        $a_form->addItem($feat);
 
         ilObjectServiceSettingsGUI::initServiceSettingsForm(
             $this->object->getId(),
-            $form,
+            $a_form,
             array(
                 ilObjectServiceSettingsGUI::CUSTOM_METADATA
             )
@@ -513,13 +513,13 @@ class ilObjMediaPoolGUI extends ilObject2GUI
     }
 
 
-    protected function getEditFormCustomValues(array &$values) : void
+    protected function getEditFormCustomValues(array &$a_values) : void
     {
         if ($this->getMediaPool()->getDefaultWidth() > 0) {
-            $values["default_width"] = $this->object->getDefaultWidth();
+            $a_values["default_width"] = $this->object->getDefaultWidth();
         }
         if ($this->getMediaPool()->getDefaultHeight() > 0) {
-            $values["default_height"] = $this->object->getDefaultHeight();
+            $a_values["default_height"] = $this->object->getDefaultHeight();
         }
     }
 
@@ -749,7 +749,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
 
         $wb_path = ilFileUtils::getWebspaceDir("output") . "/";
 
-        $mode = ($this->ctrl->getCmd() != "showPreview")
+        $mode = ($this->ctrl->getCmd() !== "showPreview")
             ? "fullscreen"
             : "media";
         $enlarge_path = ilUtil::getImagePath("enlarge.svg", false, "output");
@@ -854,7 +854,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
             
             // check whether page can be removed
             $add = "";
-            if ($type == "pg") {
+            if ($type === "pg") {
                 $usages = ilPageContentUsage::getUsages("incl", $obj_id, false);
                 if (count($usages) > 0) {
                     $this->main_tpl->setOnScreenMessage('failure', sprintf($lng->txt("mep_content_snippet_in_use"), $title), true);
@@ -915,7 +915,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
             $type = $id[0];
             $id = $id[1];
 
-            if ($type == "mob") {		// media object
+            if ($type === "mob") {		// media object
                 if (ilObjMediaPool::isForeignIdInTree($this->object->getId(), $id)) {
                     $not_inserted[] = ilObject::_lookupTitle($id) . " [" .
                         $id . "]";
@@ -930,7 +930,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
                     }
                 }
             }
-            if ($type == "incl") {		// content snippet
+            if ($type === "incl") {		// content snippet
                 if (ilObjMediaPool::isItemIdInTree($this->object->getId(), $id)) {
                     $not_inserted[] = ilMediaPoolPage::lookupTitle($id) . " [" .
                         $id . "]";
@@ -1004,7 +1004,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
 
         foreach ($ids as $obj_id) {
             $type = ilMediaPoolItem::lookupType($obj_id);
-            if ($type == "fold") {
+            if ($type === "fold") {
                 $this->main_tpl->setOnScreenMessage('failure', $this->lng->txt("cont_cant_copy_folders"), true);
                 $this->ctrl->redirect($this, $this->mode);
             }
@@ -1012,10 +1012,10 @@ class ilObjMediaPoolGUI extends ilObject2GUI
         foreach ($ids as $obj_id) {
             $fid = ilMediaPoolItem::lookupForeignId($obj_id);
             $type = ilMediaPoolItem::lookupType($obj_id);
-            if ($type == "mob") {
+            if ($type === "mob") {
                 $ilUser->addObjectToClipboard($fid, "mob", "");
             }
-            if ($type == "pg") {
+            if ($type === "pg") {
                 $ilUser->addObjectToClipboard($obj_id, "incl", "");
             }
         }
@@ -1026,12 +1026,12 @@ class ilObjMediaPoolGUI extends ilObject2GUI
     /**
      * add locator items for media pool
      */
-    public function addLocatorItems() : void
+    protected function addLocatorItems() : void
     {
         $ilLocator = $this->locator;
         $ilAccess = $this->access;
         
-        if (!$this->getCreationMode() && $this->ctrl->getCmd() != "explorer") {
+        if (!$this->getCreationMode() && $this->ctrl->getCmd() !== "explorer") {
             $tree = $this->object->getTree();
             $obj_id = ($this->mep_item_id == 0)
                 ? $tree->getRootId()
@@ -1158,7 +1158,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
         $this->form->addItem($ti);
 
         // save and cancel commands
-        if ($a_mode == "create") {
+        if ($a_mode === "create") {
             $this->form->addCommandButton("saveFolder", $lng->txt("save"));
             $this->form->addCommandButton("cancelSave", $lng->txt("cancel"));
             $this->form->setTitle($lng->txt("mep_new_folder"));
@@ -1308,7 +1308,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
         $this->form->addItem($ti);
     
         // save and cancel commands
-        if ($a_mode == "create") {
+        if ($a_mode === "create") {
             $this->form->addCommandButton("saveMediaPoolPage", $lng->txt("save"));
             $this->form->addCommandButton("cancelSave", $lng->txt("cancel"));
             $this->form->setTitle($lng->txt("mep_new_content_snippet"));
@@ -1460,8 +1460,8 @@ class ilObjMediaPoolGUI extends ilObject2GUI
         if ($ilAccess->checkAccess('visible', '', $this->ref_id) ||
             $ilAccess->checkAccess('read', '', $this->ref_id) ||
             $ilAccess->checkAccess('write', '', $this->ref_id)) {
-            $force_active = $this->ctrl->getNextClass() == "ilinfoscreengui"
-                || strtolower($this->ctrl->getCmdClass()) == "ilnotegui";
+            $force_active = $this->ctrl->getNextClass() === "ilinfoscreengui"
+                || strtolower($this->ctrl->getCmdClass()) === "ilnotegui";
             $ilTabs->addTarget(
                 "info_short",
                 $this->ctrl->getLinkTargetByClass(
@@ -1620,7 +1620,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
             throw new ilPermissionException($this->lng->txt("msg_no_perm_read"));
         }
         
-        if ($this->ctrl->getCmd() == "infoScreen") {
+        if ($this->ctrl->getCmd() === "infoScreen") {
             $this->ctrl->setCmd("showSummary");
             $this->ctrl->setCmdClass("ilinfoscreengui");
         }
@@ -1956,7 +1956,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
                     }
                 } catch (Exception $e) {
                     $log->debug("Got exception: " . $e->getMessage());
-                    echo json_encode(array( 'success' => false, 'message' => $e->getMessage()));
+                    echo json_encode(['success' => false, 'message' => $e->getMessage()], JSON_THROW_ON_ERROR);
                 }
                 $log->debug("end of 'has_uploads'");
             }

--- a/Modules/MediaPool/classes/class.ilObjMediaPoolSubItemListGUI.php
+++ b/Modules/MediaPool/classes/class.ilObjMediaPoolSubItemListGUI.php
@@ -25,7 +25,10 @@ class ilObjMediaPoolSubItemListGUI extends ilSubItemListGUI
         
         $lng->loadLanguageModule('content');
         foreach ($this->getSubItemIds(true) as $sub_item) {
-            if (is_object($this->getHighlighter()) and strlen($this->getHighlighter()->getContent($this->getObjId(), $sub_item))) {
+            if (
+                is_object($this->getHighlighter()) &&
+                $this->getHighlighter()->getContent($this->getObjId(), $sub_item) !== ''
+            ) {
                 $this->tpl->setCurrentBlock('sea_fragment');
                 $this->tpl->setVariable('TXT_FRAGMENT', $this->getHighlighter()->getContent($this->getObjId(), $sub_item));
                 $this->tpl->parseCurrentBlock();
@@ -81,7 +84,7 @@ class ilObjMediaPoolSubItemListGUI extends ilSubItemListGUI
     {
         $sub_id = ilMediaPoolItem::lookupForeignId($a_sub_id);
         // output thumbnail (or mob icon)
-        if (ilObject::_lookupType($sub_id) == "mob") {
+        if (ilObject::_lookupType($sub_id) === "mob") {
             $mob = new ilObjMediaObject($sub_id);
             $med = $mob->getMediaItem("Standard");
             $target = $med->getThumbnailTarget();
@@ -102,7 +105,7 @@ class ilObjMediaPoolSubItemListGUI extends ilSubItemListGUI
             } else {
                 $this->tpl->setVariable("SUB_ITEM_IMAGE", ilUtil::img(ilUtil::getImagePath("icon_" . "mob" . ".gif")));
             }
-            if (ilUtil::deducibleSize($med->getFormat()) && $med->getLocationType() == "Reference") {
+            if (ilUtil::deducibleSize($med->getFormat()) && $med->getLocationType() === "Reference") {
                 $size = getimagesize($med->getLocation());
                 if ($size[0] > 0 && $size[1] > 0) {
                     $wr = $size[0] / 80;

--- a/Modules/MediaPool/classes/class.ilUploadDirFilesTableGUI.php
+++ b/Modules/MediaPool/classes/class.ilUploadDirFilesTableGUI.php
@@ -70,7 +70,7 @@ class ilUploadDirFilesTableGUI extends ilTable2GUI
             } elseif (is_dir($this->upload_dir . "/" . $f)) {
                 $dir = ilFileUtils::getDir($this->upload_dir . "/" . $f, true);
                 foreach ($dir as $d) {
-                    if ($d["type"] == "file") {
+                    if ($d["type"] === "file") {
                         $files[] = $f . $d["subdir"] . "/" . $d["entry"];
                     }
                 }

--- a/Modules/MediaPool/test/MepClipboardSessionRepositoryTest.php
+++ b/Modules/MediaPool/test/MepClipboardSessionRepositoryTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\TestCase;
  */
 class MepClipboardSessionRepositoryTest extends TestCase
 {
-    //protected $backupGlobals = false;
     protected \ILIAS\MediaPool\Clipboard\ClipboardSessionRepository $clipboard;
 
     protected function setUp() : void
@@ -22,7 +21,7 @@ class MepClipboardSessionRepositoryTest extends TestCase
     {
     }
 
-    public function testFolder()
+    public function testFolder() : void
     {
         $clipboard = $this->clipboard;
         $clipboard->setFolder(4);
@@ -32,7 +31,7 @@ class MepClipboardSessionRepositoryTest extends TestCase
         );
     }
 
-    public function testIds()
+    public function testIds() : void
     {
         $clipboard = $this->clipboard;
         $clipboard->setIds([3,5,7]);

--- a/Modules/MediaPool/test/ilModulesMediaPoolSuite.php
+++ b/Modules/MediaPool/test/ilModulesMediaPoolSuite.php
@@ -23,7 +23,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilModulesMediaPoolSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new self();
 


### PR DESCRIPTION
Hi @alex40724 ,

I completed the review of the `Modules/MediaPool` component.

Results:
- [x] The code style is `PSR-2 + X` compliant
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [ ] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

I also fixed some trivial issues reported by my inspection profile.

--

Actions needed:

- [ ] Please check my inline comments. Some of them might be just information, some require an action. You can use `TODO PHP8-REVIEW` when searching.

Best regards,
@mjansenDatabay