### PR TITLE
PHP 8: Code Review `src/KioskMode`

### DIFF
--- a/src/KioskMode/LocatorBuilder.php
+++ b/src/KioskMode/LocatorBuilder.php
@@ -17,7 +17,7 @@ interface LocatorBuilder
     /**
      * Finish building the locator.
      */
-    public function end(): ControlBuilder;
+    public function end() : ControlBuilder;
 
     /**
      * Build an entry in the locator.

--- a/src/KioskMode/State.php
+++ b/src/KioskMode/State.php
@@ -50,6 +50,6 @@ class State
      */
     public function serialize() : string
     {
-        return json_encode($this->store);
+        return json_encode($this->store, JSON_THROW_ON_ERROR);
     }
 }

--- a/src/KioskMode/TOCBuilder.php
+++ b/src/KioskMode/TOCBuilder.php
@@ -11,10 +11,10 @@ use ILIAS\UI;
  */
 interface TOCBuilder
 {
-    const LP_NOT_STARTED = 0;
-    const LP_IN_PROGRESS = 1;
-    const LP_COMPLETED = 2;
-    const LP_FAILED = 3;
+    public const LP_NOT_STARTED = 0;
+    public const LP_IN_PROGRESS = 1;
+    public const LP_COMPLETED = 2;
+    public const LP_FAILED = 3;
 
     /**
      * Finish building the TOC.

--- a/tests/KioskMode/StateTest.php
+++ b/tests/KioskMode/StateTest.php
@@ -7,7 +7,7 @@ use ILIAS\KioskMode\State;
 
 class StateTest extends TestCase
 {
-    public function testGetNullValue()
+    public function testGetNullValue() : State
     {
         $state = new State();
         $this->assertNull($state->getValueFor('invalid_key'));
@@ -17,7 +17,7 @@ class StateTest extends TestCase
     /**
      * @depends testGetNullValue
      */
-    public function testValue(State $state)
+    public function testValue(State $state) : State
     {
         $key = 'key';
         $value = 'value';
@@ -29,20 +29,20 @@ class StateTest extends TestCase
     /**
      * @depends testValue
      */
-    public function testSerialize(State $state)
+    public function testSerialize(State $state) : void
     {
-        $expected = json_encode(['key' => 'value']);
+        $expected = json_encode(['key' => 'value'], JSON_THROW_ON_ERROR);
         $this->assertEquals($expected, $state->serialize());
     }
 
     /**
      * @depends testValue
      */
-    public function testRemoveValue(State $state)
+    public function testRemoveValue(State $state) : void
     {
         $state = $state->withValueFor('keep', 'this');
         $state = $state->withoutKey('key');
-        $expected = json_encode(['keep' => 'this']);
+        $expected = json_encode(['keep' => 'this'], JSON_THROW_ON_ERROR);
         $this->assertEquals($expected, $state->serialize());
     }
 }


### PR DESCRIPTION
Hi @klees,

I completed the review of the `src/KioskMode` component.

Results:
- [ ] The code style is `PSR-2 + X` compliant: 1 File has been changed by the `PHP-CS-FIXER`
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

I also fixed some trivial issues reported by my inspection profile.

--

Actions needed:

None

Best regards,
@mjansenDatabay