### PR TITLE
PHP 8: Code Review `Multilingualism`

### DIFF
--- a/Services/Multilingualism/classes/class.ilMultilingualism.php
+++ b/Services/Multilingualism/classes/class.ilMultilingualism.php
@@ -146,7 +146,7 @@ class ilMultilingualism
         bool $a_default,
         bool $a_force = false
     ) : void {
-        if ($a_lang != "" && (!isset($this->languages[$a_lang]) || $a_force)) {
+        if ($a_lang !== "" && (!isset($this->languages[$a_lang]) || $a_force)) {
             if ($a_default) {
                 foreach ($this->languages as $k => $l) {
                     $this->languages[$k]["lang_default"] = false;
@@ -214,7 +214,7 @@ class ilMultilingualism
      */
     public function removeLanguage(string $a_lang) : void
     {
-        if ($a_lang != $this->getDefaultLanguage()) {
+        if ($a_lang !== $this->getDefaultLanguage()) {
             unset($this->languages[$a_lang]);
         }
     }
@@ -295,7 +295,7 @@ class ilMultilingualism
      * xml import
      * @param SimpleXMLElement $root
      */
-    public function fromXML(SimpleXMLElement $root)
+    public function fromXML(SimpleXMLElement $root) : void
     {
         if ($root->translations) {
             $root = $root->translations;
@@ -306,7 +306,7 @@ class ilMultilingualism
                 trim($trans["language"]),
                 trim($trans->title),
                 trim($trans->description),
-                (int) $trans["default"] != 0
+                (int) $trans["default"] !== 0
             );
         }
     }

--- a/Services/Multilingualism/classes/class.ilMultilingualism.php
+++ b/Services/Multilingualism/classes/class.ilMultilingualism.php
@@ -40,10 +40,11 @@ class ilMultilingualism
     protected ilLanguage $lng;
     protected ilDBInterface $db;
     protected int $obj_id;
-    /** @var array<string, array{lang_code: string, lang_default: bool|int, title: string, description: string}> */
-    protected array $languages = array();
+    /** @var array<string, array{lang_code: string, lang_default: bool, title: string, description: string}> */
+    protected array $languages = [];
     protected string $type = "";
-    protected static array $instances = array();
+    /** @var array<string, array<int, self>> */
+    protected static array $instances = [];
 
     /**
      * @throws ilObjectException
@@ -92,7 +93,8 @@ class ilMultilingualism
     }
 
     /**
-     * @param array $a_val array of language codes
+     * @param array<string, array{lang_code: string, lang_default: bool, title: string, description: string}> $a_val
+     * @return void
      */
     public function setLanguages(array $a_val) : void
     {
@@ -100,7 +102,7 @@ class ilMultilingualism
     }
 
     /**
-     * @return array<string, array{lang_code: string, lang_default: bool|int, title: string, description: string}>
+     * @return array<string, array{lang_code: string, lang_default: bool, title: string, description: string}>
      */
     public function getLanguages() : array
     {
@@ -153,8 +155,12 @@ class ilMultilingualism
                     $this->languages[$k]["lang_default"] = false;
                 }
             }
-            $this->languages[$a_lang] = array("lang_code" => $a_lang, "lang_default" => $a_default,
-                "title" => $a_title, "description" => $a_description);
+            $this->languages[$a_lang] = [
+                "lang_code" => $a_lang,
+                "lang_default" => $a_default,
+                "title" => $a_title,
+                "description" => $a_description
+            ];
         }
     }
 
@@ -229,7 +235,12 @@ class ilMultilingualism
             " AND id_type = " . $this->db->quote($this->getType(), "text")
         );
         while ($rec = $this->db->fetchAssoc($set)) {
-            $this->addLanguage($rec["lang_code"], $rec["title"], $rec["description"], $rec["lang_default"]);
+            $this->addLanguage(
+                $rec["lang_code"],
+                (string) $rec["title"],
+                (string) $rec["description"],
+                (bool) $rec["lang_default"]
+            );
         }
     }
 

--- a/Services/Multilingualism/classes/class.ilMultilingualism.php
+++ b/Services/Multilingualism/classes/class.ilMultilingualism.php
@@ -40,6 +40,7 @@ class ilMultilingualism
     protected ilLanguage $lng;
     protected ilDBInterface $db;
     protected int $obj_id;
+    /** @var array<string, array{lang_code: string, lang_default: bool|int, title: string, description: string}> */
     protected array $languages = array();
     protected string $type = "";
     protected static array $instances = array();
@@ -99,9 +100,9 @@ class ilMultilingualism
     }
 
     /**
-     * @return array array of language codes
+     * @return array<string, array{lang_code: string, lang_default: bool|int, title: string, description: string}>
      */
-    public function getLanguages() : string
+    public function getLanguages() : array
     {
         return $this->languages;
     }

--- a/Services/Multilingualism/classes/class.ilMultilingualismGUI.php
+++ b/Services/Multilingualism/classes/class.ilMultilingualismGUI.php
@@ -151,7 +151,7 @@ class ilMultilingualismGUI
         $descs = $this->request->getDescriptions();
 
         // default language set?
-        if ($default == "") {
+        if ($default === "") {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt("msg_no_default_language"));
             $this->listTranslations(true);
             return;
@@ -203,9 +203,7 @@ class ilMultilingualismGUI
             if ($check[$k]) {
                 // default translation cannot be deleted
                 if ($k != $default) {
-                    unset($titles[$k]);
-                    unset($descs[$k]);
-                    unset($langs[$k]);
+                    unset($titles[$k], $descs[$k], $langs[$k]);
                 } else {
                     $this->tpl->setOnScreenMessage('failure', $this->lng->txt("msg_no_default_language"));
                     $this->listTranslations();
@@ -351,7 +349,7 @@ class ilMultilingualismGUI
         $lng->loadLanguageModule("meta");
         $langs = $this->request->getLanguages();
 
-        if (count($langs) == 0) {
+        if (count($langs) === 0) {
             $this->tpl->setOnScreenMessage('info', $lng->txt("no_checkbox"), true);
             $ilCtrl->redirect($this, "listTranslations");
         } else {

--- a/Services/Multilingualism/classes/class.ilMultilingualismTableGUI.php
+++ b/Services/Multilingualism/classes/class.ilMultilingualismTableGUI.php
@@ -88,7 +88,7 @@ class ilMultilingualismTableGUI extends ilTable2GUI
             $this->tpl->parseCurrentBlock();
         }
 
-        if ($this->master_lang == "") {
+        if ($this->master_lang === "") {
             $this->tpl->setCurrentBlock("rb");
             $this->tpl->setVariable("RB_NR", $this->nr);
             if ($a_set["default"]) {

--- a/Services/Multilingualism/test/MultilingualismStandardGUIRequestTest.php
+++ b/Services/Multilingualism/test/MultilingualismStandardGUIRequestTest.php
@@ -9,13 +9,6 @@ use PHPUnit\Framework\TestCase;
  */
 class MultilingualismStandardGUIRequestTest extends TestCase
 {
-    //protected $backupGlobals = false;
-
-    protected function setUp() : void
-    {
-        parent::setUp();
-    }
-
     protected function tearDown() : void
     {
     }
@@ -34,7 +27,7 @@ class MultilingualismStandardGUIRequestTest extends TestCase
         );
     }
 
-    public function testRefId()
+    public function testRefId() : void
     {
         $request = $this->getRequest(
             [

--- a/Services/Multilingualism/test/ilServicesMultilingualismSuite.php
+++ b/Services/Multilingualism/test/ilServicesMultilingualismSuite.php
@@ -22,7 +22,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilServicesMultilingualismSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new self();
 


### PR DESCRIPTION
Hi @alex40724 ,

I completed the review of the `Multilingualism` component.

Results:
- [x] The code style is `PSR-2 + X` compliant
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [ ] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

I also fixed some trivial issues reported by my inspection profile.

--

Actions needed:

None

Best regards,
@mjansenDatabay