### PR TITLE
PHP8: Code Review `Services/FileServices`

### DIFF
--- a/Services/FileServices/classes/FileSystemService/class.ilFileServicesFilenameSanitizer.php
+++ b/Services/FileServices/classes/FileSystemService/class.ilFileServicesFilenameSanitizer.php
@@ -13,5 +13,4 @@ class ilFileServicesFilenameSanitizer extends FilenameSanitizerImpl
     {
         parent::__construct($settings->getWhiteListedSuffixes());
     }
-    
 }

--- a/Services/FileServices/classes/StorageService/class.ilFileServicesPolicy.php
+++ b/Services/FileServices/classes/StorageService/class.ilFileServicesPolicy.php
@@ -21,10 +21,8 @@ class ilFileServicesPolicy extends WhiteAndBlacklistedFileNamePolicy
         $this->sanitizer = new ilFileServicesFilenameSanitizer($settings);
     }
     
-    public function prepareFileNameForConsumer(string $filename_with_extension): string
+    public function prepareFileNameForConsumer(string $filename_with_extension) : string
     {
         return $this->sanitizer->sanitize($filename_with_extension);
     }
-    
 }
-

--- a/Services/FileServices/classes/UploadService/class.ilFileServicesPreProcessor.php
+++ b/Services/FileServices/classes/UploadService/class.ilFileServicesPreProcessor.php
@@ -37,9 +37,6 @@ class ilFileServicesPreProcessor extends BlacklistExtensionPreProcessor
         return parent::process($stream, $metadata);
     }
     
-    /**
-     * @return int
-     */
     private function determineFileAdminRefId() : int
     {
         $objects_by_type = ilObject2::_getObjectsByType('facs');

--- a/Services/FileServices/classes/UploadService/class.ilFileServicesPreProcessor.php
+++ b/Services/FileServices/classes/UploadService/class.ilFileServicesPreProcessor.php
@@ -15,7 +15,6 @@ use ILIAS\FileUpload\DTO\ProcessingStatus;
  */
 class ilFileServicesPreProcessor extends BlacklistExtensionPreProcessor
 {
-    
     protected ilRbacSystem $rbac;
     
     private int $fileadmin_ref_id;
@@ -41,13 +40,11 @@ class ilFileServicesPreProcessor extends BlacklistExtensionPreProcessor
     /**
      * @return int
      */
-    private function determineFileAdminRefId(): int
+    private function determineFileAdminRefId() : int
     {
         $objects_by_type = ilObject2::_getObjectsByType('facs');
         $id = (int) reset($objects_by_type)['obj_id'];
         $references = ilObject2::_getAllReferences($id);
         return (int) reset($references);
     }
-    
 }
-

--- a/Services/FileServices/classes/class.ilFileServicesSettings.php
+++ b/Services/FileServices/classes/class.ilFileServicesSettings.php
@@ -39,13 +39,13 @@ class ilFileServicesSettings
         $this->read();
     }
     
-    private function read(): void
+    private function read() : void
     {
         $this->readBlackList();
         $this->readWhiteList();
     }
     
-    private function readWhiteList(): void
+    private function readWhiteList() : void
     {
         $cleaner = $this->getCleaner();
         
@@ -69,7 +69,7 @@ class ilFileServicesSettings
     /**
      * @return void
      */
-    private function readBlackList(): void
+    private function readBlackList() : void
     {
         $cleaner = $this->getCleaner();
         
@@ -78,23 +78,23 @@ class ilFileServicesSettings
             explode(",", $this->settings->get("suffix_custom_expl_black") ?? '')
         );
         
-        $this->black_list_prohibited = array_filter($this->black_list_prohibited, fn($item): bool => $item !== '');
+        $this->black_list_prohibited = array_filter($this->black_list_prohibited, fn ($item) : bool => $item !== '');
         $this->black_list_overall = $this->black_list_prohibited;
     }
     
-    private function getCleaner(): Closure
+    private function getCleaner() : Closure
     {
-        return function(string $suffix): string {
+        return function (string $suffix) : string {
             return trim(strtolower($suffix));
         };
     }
     
-    public function getWhiteListedSuffixes(): array
+    public function getWhiteListedSuffixes() : array
     {
         return $this->white_list_overall;
     }
     
-    public function getBlackListedSuffixes(): array
+    public function getBlackListedSuffixes() : array
     {
         return $this->black_list_overall;
     }
@@ -110,7 +110,7 @@ class ilFileServicesSettings
     /**
      * @internal
      */
-    public function getWhiteListNegative(): array
+    public function getWhiteListNegative() : array
     {
         return $this->white_list_negative;
     }
@@ -118,7 +118,7 @@ class ilFileServicesSettings
     /**
      * @internal
      */
-    public function getWhiteListPositive(): array
+    public function getWhiteListPositive() : array
     {
         return $this->white_list_positive;
     }
@@ -126,9 +126,8 @@ class ilFileServicesSettings
     /**
      * @internal
      */
-    public function getProhibited(): array
+    public function getProhibited() : array
     {
         return $this->black_list_prohibited;
     }
-    
 }

--- a/Services/FileServices/classes/class.ilFileServicesSettings.php
+++ b/Services/FileServices/classes/class.ilFileServicesSettings.php
@@ -66,9 +66,6 @@ class ilFileServicesSettings
         $this->white_list_overall = array_unique($this->white_list_overall);
     }
     
-    /**
-     * @return void
-     */
     private function readBlackList() : void
     {
         $cleaner = $this->getCleaner();

--- a/Services/FileServices/classes/class.ilFileUtils.php
+++ b/Services/FileServices/classes/class.ilFileUtils.php
@@ -1067,8 +1067,7 @@ class ilFileUtils
      */
     public static function getUploadSizeLimitBytes() : string
     {
-        $convertPhpIniSizeValueToBytes = function ($phpIniSizeValue)
-        {
+        $convertPhpIniSizeValueToBytes = function ($phpIniSizeValue) {
             if (is_numeric($phpIniSizeValue)) {
                 return $phpIniSizeValue;
             }

--- a/Services/FileServices/classes/class.ilObjFileServices.php
+++ b/Services/FileServices/classes/class.ilObjFileServices.php
@@ -19,7 +19,7 @@
  */
 class ilObjFileServices extends ilObject
 {
-    const TYPE_FILE_SERVICES = "fils";
+    public const TYPE_FILE_SERVICES = "fils";
 
     /**
      * ilObjFileServices constructor.


### PR DESCRIPTION
Hi @chfsx

Here are the results of the `Services/FileServices` review.

### Results

- [ ] The code style is PSR-2 + X compliant: _CS-Fixer made changes to 5 files_
- [x] No usage of $_GET / $_POST / $_REQUEST / $_SESSION
- [ ] There is a Unit Test Suite with at least one unit test: _There is a suite not containing any tests._
- [ ] The unit tests pass
- [ ] External libraries are compatible with PHP 8 (if relevant): _Not relevant_
- [ ] The types are fully documented (PHPDoc) or explicit PHP types are used (type hints, return types, typed properties): _The class `ilFileUtils`is missing quite a few type-hints. I know it is officially deprecated, but then again it is widely used._

### Changes made in this PR:

- Fix PSR-2 + X
- Remove some unnecessary Doc-Strings
- Add a modifier to a const.

Best regards,
@swiniker