### PR TITLE
Help, Fix MetaBar Provider for Links

### DIFF
--- a/Services/Help/GlobalScreen/classes/class.ilHelpMetaBarProvider.php
+++ b/Services/Help/GlobalScreen/classes/class.ilHelpMetaBarProvider.php
@@ -3,7 +3,8 @@
 use ILIAS\GlobalScreen\Identification\IdentificationInterface;
 use ILIAS\GlobalScreen\Scope\MetaBar\Provider\AbstractStaticMetaBarProvider;
 use ILIAS\GlobalScreen\Scope\MetaBar\Provider\StaticMetaBarProvider;
-use ILIAS\UI\Implementation\Component\Button\Bulky;
+use ILIAS\UI\Implementation\Component\Button\Bulky as BulkyButton;
+use ILIAS\UI\Implementation\Component\Link\Bulky as BulkyLink;
 
 /**
  * Help meta bar provider
@@ -38,7 +39,7 @@ class ilHelpMetaBarProvider extends AbstractStaticMetaBarProvider implements Sta
             // position should be 0, see bug #26794
             $item = $mb->topLinkItem($this->getId())
                        ->addComponentDecorator(static function (ILIAS\UI\Component\Component $c) : ILIAS\UI\Component\Component {
-                           if ($c instanceof Bulky) {
+                           if ($c instanceof BulkyButton || $c instanceof BulkyLink) {
                                return $c->withAdditionalOnLoadCode(static function (string $id) : string {
                                    return "$('#$id').on('click', function() {
                                     console.log('trigger help slate');
@@ -46,6 +47,7 @@ class ilHelpMetaBarProvider extends AbstractStaticMetaBarProvider implements Sta
                                 })";
                                });
                            }
+                           return $c;
                        })
 //                       ->withAction($this->dic->ctrl()->getLinkTargetByClass(ilDashboardGUI::class, "toggleHelp"))
                        ->withSymbol($f->symbol()->glyph()->help())


### PR DESCRIPTION
While fixing: https://mantis.ilias.de/view.php?id=31808 , we had to introduce a small change on global screen, see: https://github.com/ILIAS-eLearning/ILIAS/pull/3975 . Unfortunately, I did not check back on the help. This did trigger any error for me, since I did test english. However, If german and help active, this will trigger a fatal.

See Issue: https://mantis.ilias.de/view.php?id=32308