### PR TITLE
PHP 8: Code Review `Wiki` Part II

### DIFF
--- a/Modules/Wiki/PrintView/class.WikiPrintViewProviderGUI.php
+++ b/Modules/Wiki/PrintView/class.WikiPrintViewProviderGUI.php
@@ -4,8 +4,8 @@
 
 namespace ILIAS\Wiki;
 
-use \ILIAS\COPage;
-use \ILIAS\Export;
+use ILIAS\COPage;
+use ILIAS\Export;
 use ilPropertyFormGUI;
 
 /**

--- a/Modules/Wiki/classes/class.ilObjWiki.php
+++ b/Modules/Wiki/classes/class.ilObjWiki.php
@@ -619,9 +619,9 @@ class ilObjWiki extends ilObject implements ilAdvancedMetaDataSubItems
         return (bool) ilObjWiki::_lookup($a_wiki_id, "page_toc");
     }
 
-    public function cloneObject(int $a_target_id, int $a_copy_id = 0, bool $a_omit_tree = false) : ?ilObject
+    public function cloneObject(int $target, int $copy_id = 0, bool $omit_tree = false) : ?ilObject
     {
-        $new_obj = parent::cloneObject($a_target_id, $a_copy_id, $a_omit_tree);
+        $new_obj = parent::cloneObject($target, $copy_id, $omit_tree);
 
         // Custom meta data activation is stored in a container setting
         ilContainer::_writeContainerSetting(
@@ -635,7 +635,7 @@ class ilObjWiki extends ilObject implements ilAdvancedMetaDataSubItems
         );
 
         //copy online status if object is not the root copy object
-        $cp_options = ilCopyWizardOptions::_getInstance($a_copy_id);
+        $cp_options = ilCopyWizardOptions::_getInstance($copy_id);
 
         if (!$cp_options->isRootNode($this->getRefId())) {
             $new_obj->setOnline($this->getOnline());

--- a/Modules/Wiki/classes/class.ilObjWikiGUI.php
+++ b/Modules/Wiki/classes/class.ilObjWikiGUI.php
@@ -1541,7 +1541,7 @@ class ilObjWikiGUI extends ilObjectGUI
         $lng = $this->lng;
 
         $imp_page_ids = $this->edit_request->getImportantPageIds();
-        if (count($imp_page_ids) == 0) {
+        if (count($imp_page_ids) === 0) {
             $this->tpl->setOnScreenMessage('info', $lng->txt("no_checkbox"), true);
             $ilCtrl->redirect($this, "editImportantPages");
         } else {

--- a/Modules/Wiki/classes/class.ilObjWikiSettingsGUI.php
+++ b/Modules/Wiki/classes/class.ilObjWikiSettingsGUI.php
@@ -35,7 +35,6 @@ class ilObjWikiSettingsGUI extends ilObject2GUI
         parent::__construct($a_id, $a_id_type, $a_parent_node_id);
         global $DIC;
 
-        $this->rbacsystem = $DIC->rbac()->system();
         $this->error = $DIC["ilErr"];
         $this->access = $DIC->access();
         $this->lng = $DIC->language();
@@ -62,7 +61,7 @@ class ilObjWikiSettingsGUI extends ilObject2GUI
 
         $this->prepareOutput();
 
-        if (!$this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
             $ilErr->raiseError($this->lng->txt('no_permission'), $ilErr->WARNING);
         }
 
@@ -74,7 +73,7 @@ class ilObjWikiSettingsGUI extends ilObject2GUI
                 break;
 
             default:
-                if (!$cmd || $cmd == 'view') {
+                if (!$cmd || $cmd === 'view') {
                     $cmd = "editSettings";
                 }
                 $this->$cmd();
@@ -89,7 +88,7 @@ class ilObjWikiSettingsGUI extends ilObject2GUI
         
         $ilTabs->activateTab("settings");
 
-        if ($this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
             if (!$form) {
                 $form = $this->initForm();
                 $this->populateWithCurrentSettings($form);

--- a/Modules/Wiki/classes/class.ilWikiImportantPagesBlockGUI.php
+++ b/Modules/Wiki/classes/class.ilWikiImportantPagesBlockGUI.php
@@ -104,7 +104,7 @@ class ilWikiImportantPagesBlockGUI extends ilBlockGUI
     protected function getLegacyContent() : string
     {
         $ilCtrl = $this->ctrl;
-        $cpar[0] = $cpar[1] = 0;
+        $cpar[1] = 0;
         
         $list = new ilNestedList();
         $list->setItemClass("ilWikiBlockItem");

--- a/Modules/Wiki/classes/class.ilWikiPageGUI.php
+++ b/Modules/Wiki/classes/class.ilWikiPageGUI.php
@@ -13,7 +13,7 @@
  * https://github.com/ILIAS-eLearning
  */
 
-use \ILIAS\DI\HTTPServices;
+use ILIAS\DI\HTTPServices;
 
 /**
  * Class ilWikiPage GUI class
@@ -141,7 +141,7 @@ class ilWikiPageGUI extends ilPageObjectGUI
             case "ilcommonactiondispatchergui":
                 $gui = ilCommonActionDispatcherGUI::getInstanceFromAjaxCall();
                 $gui->enableCommentsSettings(false);
-                $gui->setRatingCallback($this, "preview");
+                $gui->setRatingCallback($this, "preview");// TODO PHP8-REVIEW This cannot work because the type defined in \ilCommonActionDispatcherGUI::setRatingCallback is `ilObjectGUI`
                 $this->ctrl->forwardCommand($gui);
                 break;
             

--- a/Modules/Wiki/classes/class.ilWikiStat.php
+++ b/Modules/Wiki/classes/class.ilWikiStat.php
@@ -721,7 +721,7 @@ class ilWikiStat
             $set = $ilDB->query($sql);
             while ($row = $ilDB->fetchAssoc($set)) {
                 if (!in_array($row[$a_aggr_by], $all_aggr_ids)) {
-                    var_dump("unexpected wiki_stat_page_entry", $row);
+                    var_dump("unexpected wiki_stat_page_entry", $row);// TODO PHP8-REVIEW We should not use debugging code here
                 }
                 $tmp[$row[$a_aggr_by]][$row["ts_day"]] = $row[$a_field];
             }

--- a/Modules/Wiki/classes/class.ilWikiUtil.php
+++ b/Modules/Wiki/classes/class.ilWikiUtil.php
@@ -378,9 +378,9 @@ class ilWikiUtil
     
     /**
      * From mediawiki GlobalFunctions.php
-     * @return string|string[]
+     * @return string
      */
-    public static function wfUrlProtocols()
+    public static function wfUrlProtocols() : string
     {
         $wgUrlProtocols = array(
             'http://',
@@ -397,16 +397,12 @@ class ilWikiUtil
 
         // Support old-style $wgUrlProtocols strings, for backwards compatibility
         // with LocalSettings files from 1.5
-        if (is_array($wgUrlProtocols)) {
-            $protocols = array();
-            foreach ($wgUrlProtocols as $protocol) {
-                $protocols[] = preg_quote($protocol, '/');
-            }
-    
-            return implode('|', $protocols);
-        } else {
-            return $wgUrlProtocols;
+        $protocols = array();
+        foreach ($wgUrlProtocols as $protocol) {
+            $protocols[] = preg_quote($protocol, '/');
         }
+
+        return implode('|', $protocols);
     }
     
     public static function wfUrlencode(

--- a/Modules/Wiki/libs/Sanitizer.php
+++ b/Modules/Wiki/libs/Sanitizer.php
@@ -419,16 +419,16 @@ class Sanitizer
                                 # Pop all elements with an optional close tag
                                 # and see if we find a match below them
                                 $optstack = array();
-                                array_push($optstack, $ot);
+                                $optstack[] = $ot;
                                 while ((($ot = @array_pop($tagstack)) != $t) &&
                                         isset($htmlsingleallowed[$ot])) {
-                                    array_push($optstack, $ot);
+                                    $optstack[] = $ot;
                                 }
                                 if ($t != $ot) {
                                     # No match. Push the optinal elements back again
                                     $badtag = 1;
                                     while ($ot = @array_pop($optstack)) {
-                                        array_push($tagstack, $ot);
+                                        $tagstack[] = $ot;
                                     }
                                 }
                             } else {
@@ -468,10 +468,10 @@ class Sanitizer
                             $text .= "</$t>";
                         } else {
                             if ($t == 'table') {
-                                array_push($tablestack, $tagstack);
+                                $tablestack[] = $tagstack;
                                 $tagstack = array();
                             }
-                            array_push($tagstack, $t);
+                            $tagstack[] = $t;
                         }
 
                         # Replace any variables or template parameters with

--- a/Modules/Wiki/test/WikiUtilTest.php
+++ b/Modules/Wiki/test/WikiUtilTest.php
@@ -9,13 +9,6 @@ use PHPUnit\Framework\TestCase;
  */
 class WikiUtilTest extends TestCase
 {
-    //protected $backupGlobals = false;
-
-    protected function setUp() : void
-    {
-        parent::setUp();
-    }
-
     protected function tearDown() : void
     {
     }
@@ -23,7 +16,7 @@ class WikiUtilTest extends TestCase
     /**
      * Test make URL title
      */
-    public function testMakeUrlTitle() : void
+    public function testRefId() : void
     {
         $input_expected = [
             ["a", "a"]


### PR DESCRIPTION
Hi @alex40724,

I completed the 2nd part of the review of the `Modules/Wiki` component.

Results:
- [x] The code style is `PSR-2 + X` compliant: 1 File has been changed by the `PHP-CS-FIXER`
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [ ] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

I also fixed some trivial issues reported by my inspection profile.

--

Actions needed:

- [x] I am not sure whether the libraries `Sanitize.php` and `Title.php` are compatible with PHP 8. Please check the list item if you already checked this.
- [ ] Please check my inline comments. Some of them are just information, some require an action. You can use `TODO PHP8-REVIEW` when searching.

Best regards,
@mjansenDatabay