### PR TITLE
PHP 8: Code Review `Wiki` Part III

### DIFF
--- a/Modules/Wiki/Editing/class.EditingGUIRequest.php
+++ b/Modules/Wiki/Editing/class.EditingGUIRequest.php
@@ -170,7 +170,7 @@ class EditingGUIRequest
     public function getPageTemplateId() : int
     {
         $templ_id = $this->int("page_templ");
-        if ($templ_id == 0) {
+        if ($templ_id === 0) {
             $templ_id = $this->int("templ_page_id");
         }
         return $templ_id;

--- a/Modules/Wiki/Export/WikiHtmlExport.php
+++ b/Modules/Wiki/Export/WikiHtmlExport.php
@@ -92,7 +92,7 @@ class WikiHtmlExport
         \ilMathJax::getInstance()->init(\ilMathJax::PURPOSE_EXPORT);
 
         if (in_array($this->getMode(), [self::MODE_USER, self::MODE_USER_COMMENTS])) {
-            $this->user_html_exp = new \ilWikiUserHTMLExport($this->wiki, $ilDB, $ilUser, ($this->getMode() == self::MODE_USER_COMMENTS));
+            $this->user_html_exp = new \ilWikiUserHTMLExport($this->wiki, $ilDB, $ilUser, ($this->getMode() === self::MODE_USER_COMMENTS));
         }
 
         $ascii_name = str_replace(" ", "_", ilFileUtils::getASCIIFilename($this->wiki->getTitle()));
@@ -330,7 +330,7 @@ class WikiHtmlExport
         // close file
         fclose($fp);
 
-        if ($this->wiki->getStartPage() == $wpg_gui->getPageObject()->getTitle()) {
+        if ($this->wiki->getStartPage() === $wpg_gui->getPageObject()->getTitle()) {
             copy($file, $this->export_dir . "/index.html");
         }
     }

--- a/Modules/Wiki/Export/WikiHtmlExport.php
+++ b/Modules/Wiki/Export/WikiHtmlExport.php
@@ -81,7 +81,7 @@ class WikiHtmlExport
      * @throws \ilTemplateException
      * @throws \ilWikiExportException
      */
-    public function buildExportFile($print_version = false)
+    public function buildExportFile(bool $print_version = false) : string
     {
         $global_screen = $this->global_screen;
         $ilDB = $this->db;
@@ -212,7 +212,7 @@ class WikiHtmlExport
     /**
      * Export all pages as one print version
      */
-    public function exportHTMLPagesPrint()
+    public function exportHTMLPagesPrint() : void
     {
         // collect page elements
         $pages = \ilWikiPage::getAllWikiPages($this->wiki->getId());
@@ -315,7 +315,7 @@ class WikiHtmlExport
 
         // open file
         $this->log->debug("write file: " . $file);
-        if (!($fp = fopen($file, "w+"))) {
+        if (!($fp = fopen($file, 'wb+'))) {
             $this->log->error("Could not open " . $file . " for writing.");
             throw new \ilWikiExportException("Could not open \"" . $file . "\" for writing.");
         }
@@ -348,7 +348,7 @@ class WikiHtmlExport
         }
         foreach (new \DirectoryIterator($exp_dir) as $fileInfo) {
             $this->log->debug("file: " . $fileInfo->getFilename());
-            if (pathinfo($fileInfo->getFilename(), PATHINFO_EXTENSION) == "zip") {
+            if (pathinfo($fileInfo->getFilename(), PATHINFO_EXTENSION) === "zip") {
                 $this->log->debug("return: " . $exp_dir . "/" . $fileInfo->getFilename());
                 return $exp_dir . "/" . $fileInfo->getFilename();
             }

--- a/Modules/Wiki/PrintView/class.WikiPrintViewProviderGUI.php
+++ b/Modules/Wiki/PrintView/class.WikiPrintViewProviderGUI.php
@@ -53,7 +53,7 @@ class WikiPrintViewProviderGUI extends Export\AbstractPrintViewProvider
         $this->selected_pages = (!is_null($selected_pages))
             ? $selected_pages
             : array_map(
-                function ($p) {
+                static function ($p) {
                     return $p["id"];
                 },
                 \ilWikiPage::getAllWikiPages($this->wiki->getId())

--- a/Modules/Wiki/classes/class.ilECSWikiSettings.php
+++ b/Modules/Wiki/classes/class.ilECSWikiSettings.php
@@ -20,7 +20,7 @@
  */
 class ilECSWikiSettings extends ilECSObjectSettings
 {
-    protected function getECSObjectType()
+    protected function getECSObjectType() : string
     {
         return '/campusconnect/wikis';
     }

--- a/Modules/Wiki/classes/class.ilObjWiki.php
+++ b/Modules/Wiki/classes/class.ilObjWiki.php
@@ -206,7 +206,7 @@ class ilObjWiki extends ilObject implements ilAdvancedMetaDataSubItems
             ));
 
         // create start page
-        if ($this->getStartPage() != "" && !$a_prevent_start_page_creation) {
+        if ($this->getStartPage() !== "" && !$a_prevent_start_page_creation) {
             $start_page = new ilWikiPage();
             $start_page->setWikiId($this->getId());
             $start_page->setTitle($this->getStartPage());

--- a/Modules/Wiki/classes/class.ilObjWiki.php
+++ b/Modules/Wiki/classes/class.ilObjWiki.php
@@ -333,7 +333,7 @@ class ilObjWiki extends ilObject implements ilAdvancedMetaDataSubItems
      */
     public static function _lookupRatingOverall(int $a_wiki_id) : bool
     {
-        return (bool) ilObjWiki::_lookup($a_wiki_id, "rating_overall");
+        return (bool) self::_lookup($a_wiki_id, "rating_overall");
     }
     
     /**
@@ -341,7 +341,7 @@ class ilObjWiki extends ilObject implements ilAdvancedMetaDataSubItems
      */
     public static function _lookupRating(int $a_wiki_id) : bool
     {
-        return (bool) ilObjWiki::_lookup($a_wiki_id, "rating");
+        return (bool) self::_lookup($a_wiki_id, "rating");
     }
     
     /**
@@ -349,7 +349,7 @@ class ilObjWiki extends ilObject implements ilAdvancedMetaDataSubItems
      */
     public static function _lookupRatingCategories(int $a_wiki_id) : bool
     {
-        return (bool) ilObjWiki::_lookup($a_wiki_id, "rating_ext");
+        return (bool) self::_lookup($a_wiki_id, "rating_ext");
     }
     
     /**
@@ -357,7 +357,7 @@ class ilObjWiki extends ilObject implements ilAdvancedMetaDataSubItems
      */
     public static function _lookupRatingAsBlock(int $a_wiki_id) : bool
     {
-        return (bool) ilObjWiki::_lookup($a_wiki_id, "rating_side");
+        return (bool) self::_lookup($a_wiki_id, "rating_side");
     }
 
     /**
@@ -365,7 +365,7 @@ class ilObjWiki extends ilObject implements ilAdvancedMetaDataSubItems
      */
     public static function _lookupPublicNotes(int $a_wiki_id) : bool
     {
-        return (bool) ilObjWiki::_lookup($a_wiki_id, "public_notes");
+        return (bool) self::_lookup($a_wiki_id, "public_notes");
     }
 
     /**
@@ -373,7 +373,7 @@ class ilObjWiki extends ilObject implements ilAdvancedMetaDataSubItems
      */
     public static function _lookupLinkMetadataValues(int $a_wiki_id) : bool
     {
-        return (bool) ilObjWiki::_lookup($a_wiki_id, "link_md_values");
+        return (bool) self::_lookup($a_wiki_id, "link_md_values");
     }
 
     /**
@@ -395,7 +395,7 @@ class ilObjWiki extends ilObject implements ilAdvancedMetaDataSubItems
 
     public static function _lookupStartPage(int $a_wiki_id) : string
     {
-        return (string) ilObjWiki::_lookup($a_wiki_id, "startpage");
+        return (string) self::_lookup($a_wiki_id, "startpage");
     }
 
     public static function writeStartPage(int $a_id, string $a_name) : void
@@ -493,7 +493,7 @@ class ilObjWiki extends ilObject implements ilAdvancedMetaDataSubItems
 
         if (!$this->isImportantPage($a_page_id)) {
             if ($a_nr == 0) {
-                $a_nr = ilObjWiki::_lookupMaxOrdNrImportantPages($this->getId()) + 10;
+                $a_nr = self::_lookupMaxOrdNrImportantPages($this->getId()) + 10;
             }
 
             $ilDB->manipulate("INSERT INTO il_wiki_imp_pages " .
@@ -542,7 +542,7 @@ class ilObjWiki extends ilObject implements ilAdvancedMetaDataSubItems
     ) : bool {
         $ilDB = $this->db;
 
-        $ipages = ilObjWiki::_lookupImportantPagesList($this->getId());
+        $ipages = self::_lookupImportantPagesList($this->getId());
 
         foreach ($ipages as $k => $v) {
             if (isset($a_ord[$v["page_id"]])) {
@@ -585,7 +585,7 @@ class ilObjWiki extends ilObject implements ilAdvancedMetaDataSubItems
     {
         $ilDB = $this->db;
 
-        $ipages = ilObjWiki::_lookupImportantPagesList($this->getId());
+        $ipages = self::_lookupImportantPagesList($this->getId());
 
         // fix indentation: no 2 is allowed after a 0
         $c_indent = 0;
@@ -616,12 +616,12 @@ class ilObjWiki extends ilObject implements ilAdvancedMetaDataSubItems
     public static function _lookupPageToc(
         int $a_wiki_id
     ) : bool {
-        return (bool) ilObjWiki::_lookup($a_wiki_id, "page_toc");
+        return (bool) self::_lookup($a_wiki_id, "page_toc");
     }
 
-    public function cloneObject(int $target, int $copy_id = 0, bool $omit_tree = false) : ?ilObject
+    public function cloneObject(int $target_id, int $copy_id = 0, bool $omit_tree = false) : ?ilObject
     {
-        $new_obj = parent::cloneObject($target, $copy_id, $omit_tree);
+        $new_obj = parent::cloneObject($target_id, $copy_id, $omit_tree);
 
         // Custom meta data activation is stored in a container setting
         ilContainer::_writeContainerSetting(
@@ -686,7 +686,7 @@ class ilObjWiki extends ilObject implements ilAdvancedMetaDataSubItems
         }
         
         // copy important pages
-        foreach (ilObjWiki::_lookupImportantPagesList($this->getId()) as $ip) {
+        foreach (self::_lookupImportantPagesList($this->getId()) as $ip) {
             $new_obj->addImportantPage($map[$ip["page_id"]], $ip["ord"], $ip["indent"]);
         }
 
@@ -769,13 +769,13 @@ class ilObjWiki extends ilObject implements ilAdvancedMetaDataSubItems
         return $page;
     }
 
-    public static function getAdvMDSubItemTitle($a_obj_id, $a_sub_type, $a_sub_id)
+    public static function getAdvMDSubItemTitle($a_obj_id, $a_sub_type, $a_sub_id) : string // TODO PHP8-REVIEW Type hints are missing here
     {
         global $DIC;
 
         $lng = $DIC->language();
     
-        if ($a_sub_type == "wpg") {
+        if ($a_sub_type === "wpg") {
             $lng->loadLanguageModule("wiki");
             return $lng->txt("wiki_wpg") . ' "' . ilWikiPage::lookupTitle($a_sub_id) . '"';
         }

--- a/Modules/Wiki/classes/class.ilObjWiki.php
+++ b/Modules/Wiki/classes/class.ilObjWiki.php
@@ -313,7 +313,7 @@ class ilObjWiki extends ilObject implements ilAdvancedMetaDataSubItems
         global $DIC;
         $ilDB = $DIC->database();
 
-        if ($a_short_title == "") {
+        if ($a_short_title === "") {
             return true;
         }
         $res = $ilDB->queryF(
@@ -492,7 +492,7 @@ class ilObjWiki extends ilObject implements ilAdvancedMetaDataSubItems
         $ilDB = $this->db;
 
         if (!$this->isImportantPage($a_page_id)) {
-            if ($a_nr == 0) {
+            if ($a_nr === 0) {
                 $a_nr = self::_lookupMaxOrdNrImportantPages($this->getId()) + 10;
             }
 
@@ -727,11 +727,11 @@ class ilObjWiki extends ilObject implements ilAdvancedMetaDataSubItems
         int $a_template_page = 0
     ) : ilWikiPage {
         // check if template has to be used
-        if ($a_template_page == 0) {
+        if ($a_template_page === 0) {
             if (!$this->getEmptyPageTemplate()) {
                 $wt = new ilWikiPageTemplate($this->getId());
                 $ts = $wt->getAllInfo(ilWikiPageTemplate::TYPE_NEW_PAGES);
-                if (count($ts) == 1) {
+                if (count($ts) === 1) {
                     $t = current($ts);
                     $a_template_page = $t["wpage_id"];
                 }

--- a/Modules/Wiki/classes/class.ilObjWikiAccess.php
+++ b/Modules/Wiki/classes/class.ilObjWikiAccess.php
@@ -59,7 +59,7 @@ class ilObjWikiAccess extends ilObjectAccess
         switch ($cmd) {
             case "view":
 
-                if (!ilObjWikiAccess::_lookupOnline($obj_id)
+                if (!self::_lookupOnline($obj_id)
                     && !$rbacsystem->checkAccessOfUser($user_id, 'write', $ref_id)) {
                     $ilAccess->addInfoItem(ilAccessInfo::IL_NO_OBJECT_ACCESS, $lng->txt("offline"));
                     return false;
@@ -68,7 +68,7 @@ class ilObjWikiAccess extends ilObjectAccess
                 
             // for permission query feature
             case "infoScreen":
-                if (!ilObjWikiAccess::_lookupOnline($obj_id)) {
+                if (!self::_lookupOnline($obj_id)) {
                     $ilAccess->addInfoItem(ilAccessInfo::IL_NO_OBJECT_ACCESS, $lng->txt("offline"));
                 } else {
                     $ilAccess->addInfoItem(ilAccessInfo::IL_STATUS_MESSAGE, $lng->txt("online"));
@@ -79,7 +79,7 @@ class ilObjWikiAccess extends ilObjectAccess
         switch ($permission) {
             case "read":
             case "visible":
-                if (!ilObjWikiAccess::_lookupOnline($obj_id) &&
+                if (!self::_lookupOnline($obj_id) &&
                     (!$rbacsystem->checkAccessOfUser($user_id, 'write', $ref_id))) {
                     $ilAccess->addInfoItem(ilAccessInfo::IL_NO_OBJECT_ACCESS, $lng->txt("offline"));
                     return false;
@@ -104,11 +104,11 @@ class ilObjWikiAccess extends ilObjectAccess
         //	echo "-".$target."-"; exit;
         $t_arr = explode("_", $target);
 
-        if ($t_arr[0] != "wiki" || (((int) $t_arr[1]) <= 0) && $t_arr[1] != "wpage") {
+        if ($t_arr[0] !== "wiki" || (((int) $t_arr[1]) <= 0) && $t_arr[1] !== "wpage") {
             return false;
         }
         
-        if ($t_arr[1] == "wpage") {
+        if ($t_arr[1] === "wpage") {
             $wpg_id = (int) $t_arr[2];
             $w_id = ilWikiPage::lookupWikiId($wpg_id);
             if ((int) $t_arr[3] > 0) {

--- a/Modules/Wiki/classes/class.ilObjWikiGUI.php
+++ b/Modules/Wiki/classes/class.ilObjWikiGUI.php
@@ -80,7 +80,7 @@ class ilObjWikiGUI extends ilObjectGUI
         $lng->loadLanguageModule("wiki");
 
         $this->requested_page = $this->edit_request->getPage();
-        if ($this->requested_page != "") {
+        if ($this->requested_page !== "") {
             $ilCtrl->setParameter($this, "page", ilWikiUtil::makeUrlTitle($this->requested_page));
         }
 
@@ -394,7 +394,7 @@ class ilObjWikiGUI extends ilObjectGUI
 
         $info = new ilInfoScreenGUI($this);
         $info->enablePrivateNotes();
-        if (trim($this->object->getIntroduction()) != "") {
+        if (trim($this->object->getIntroduction()) !== "") {
             $info->addSection($lng->txt("wiki_introduction"));
             $info->addProperty("", nl2br($this->object->getIntroduction()));
         }
@@ -403,28 +403,28 @@ class ilObjWikiGUI extends ilObjectGUI
         $lpcomment = ilLPMarks::_lookupComment($ilUser->getId(), $this->object->getId());
         $mark = ilLPMarks::_lookupMark($ilUser->getId(), $this->object->getId());
         $status = ilWikiContributor::_lookupStatus($this->object->getId(), $ilUser->getId());
-        if ($lpcomment != "" || $mark != "" || $status != ilWikiContributor::STATUS_NOT_GRADED) {
+        if ($lpcomment !== "" || $mark !== "" || (int) $status !== ilWikiContributor::STATUS_NOT_GRADED) {
             $info->addSection($this->lng->txt("wiki_feedback_from_tutor"));
-            if ($lpcomment != "") {
+            if ($lpcomment !== "") {
                 $info->addProperty(
                     $this->lng->txt("wiki_comment"),
                     $lpcomment
                 );
             }
-            if ($mark != "") {
+            if ($mark !== "") {
                 $info->addProperty(
                     $this->lng->txt("wiki_mark"),
                     $mark
                 );
             }
 
-            if ($status == ilWikiContributor::STATUS_PASSED) {
+            if ((int) $status === ilWikiContributor::STATUS_PASSED) {
                 $info->addProperty(
                     $this->lng->txt("status"),
                     $this->lng->txt("wiki_passed")
                 );
             }
-            if ($status == ilWikiContributor::STATUS_FAILED) {
+            if ((int) $status === ilWikiContributor::STATUS_FAILED) {
                 $info->addProperty(
                     $this->lng->txt("status"),
                     $this->lng->txt("wiki_failed")
@@ -535,7 +535,7 @@ class ilObjWikiGUI extends ilObjectGUI
             "ilinfoscreengui", "ilpermissiongui", "ilexportgui", "ilratingcategorygui", "ilobjnotificationsettingsgui", "iltaxmdgui",
             "ilwikistatgui", "ilwikipagetemplategui", "iladvancedmdsettingsgui", "ilsettingspermissiongui", 'ilrepositoryobjectsearchgui'
             ), true) || $ilCtrl->getNextClass() === "ilpermissiongui") {
-            if ($this->requested_page != "") {
+            if ($this->requested_page !== "") {
                 $this->tabs_gui->setBackTarget(
                     $lng->txt("wiki_last_visited_page"),
                     self::getGotoLink(
@@ -982,9 +982,9 @@ class ilObjWikiGUI extends ilObjectGUI
                 $new_comment = ilUtil::stripSlashes($comments[$user_id]);
                 $new_status = ilUtil::stripSlashes($status[$user_id]);
 
-                if ($marks_obj->getMark() != $new_mark ||
-                    $marks_obj->getComment() != $new_comment ||
-                    ilWikiContributor::_lookupStatus($this->object->getId(), $user_id) != $new_status) {
+                if ($marks_obj->getMark() !== $new_mark ||
+                    $marks_obj->getComment() !== $new_comment ||
+                    (int) ilWikiContributor::_lookupStatus($this->object->getId(), $user_id) !== (int) $new_status) {
                     ilWikiContributor::_writeStatus($this->object->getId(), $user_id, $new_status);
                     $marks_obj->setMark($new_mark);
                     $marks_obj->setComment($new_comment);
@@ -1081,7 +1081,7 @@ class ilObjWikiGUI extends ilObjectGUI
         int $a_ref_id,
         string $a_page = ""
     ) : string {
-        if ($a_page == "") {
+        if ($a_page === "") {
             $a_page = ilObjWiki::_lookupStartPage(ilObject::_lookupObjId($a_ref_id));
         }
         
@@ -1104,7 +1104,7 @@ class ilObjWikiGUI extends ilObjectGUI
         $ilTabs->clearTargets();
         $tpl->setHeaderActionMenu("");
 
-        $page = ($this->requested_page != "")
+        $page = ($this->requested_page !== "")
             ? $this->requested_page
             : $this->object->getStartPage();
 
@@ -1223,7 +1223,7 @@ class ilObjWikiGUI extends ilObjectGUI
     ) : void {
         $ilCtrl = $this->ctrl;
         
-        if ($a_page == "") {
+        if ($a_page === "") {
             $a_page = $this->requested_page;
         }
         
@@ -1233,32 +1233,30 @@ class ilObjWikiGUI extends ilObjectGUI
         )) {
             // to do: get rid of this redirect
             ilUtil::redirect(self::getGotoLink($this->object->getRefId(), $a_page));
-        } else {
-            if (!$this->object->getTemplateSelectionOnCreation()) {
-                // check length
-                if (ilStr::strLen(ilWikiUtil::makeDbTitle($a_page)) > 200) {
-                    $this->tpl->setOnScreenMessage('failure', $this->lng->txt("wiki_page_title_too_long") . " (" . $a_page . ")", true);
-                    $ilCtrl->setParameterByClass(
-                        "ilwikipagegui",
-                        "page",
-                        ilWikiUtil::makeUrlTitle($this->edit_request->getFromPage())
-                    );
-                    $ilCtrl->redirectByClass("ilwikipagegui", "preview");
-                }
-                $this->object->createWikiPage($a_page);
-
-                // redirect to newly created page
-                $ilCtrl->setParameterByClass("ilwikipagegui", "page", ilWikiUtil::makeUrlTitle(($a_page)));
-                $ilCtrl->redirectByClass("ilwikipagegui", "edit");
-            } else {
-                $ilCtrl->setParameter($this, "page", ilWikiUtil::makeUrlTitle($this->requested_page));
-                $ilCtrl->setParameter(
-                    $this,
-                    "from_page",
+        } elseif (!$this->object->getTemplateSelectionOnCreation()) {
+            // check length
+            if (ilStr::strLen(ilWikiUtil::makeDbTitle($a_page)) > 200) {
+                $this->tpl->setOnScreenMessage('failure', $this->lng->txt("wiki_page_title_too_long") . " (" . $a_page . ")", true);
+                $ilCtrl->setParameterByClass(
+                    "ilwikipagegui",
+                    "page",
                     ilWikiUtil::makeUrlTitle($this->edit_request->getFromPage())
                 );
-                $ilCtrl->redirect($this, "showTemplateSelection");
+                $ilCtrl->redirectByClass("ilwikipagegui", "preview");
             }
+            $this->object->createWikiPage($a_page);
+
+            // redirect to newly created page
+            $ilCtrl->setParameterByClass("ilwikipagegui", "page", ilWikiUtil::makeUrlTitle(($a_page)));
+            $ilCtrl->redirectByClass("ilwikipagegui", "edit");
+        } else {
+            $ilCtrl->setParameter($this, "page", ilWikiUtil::makeUrlTitle($this->requested_page));
+            $ilCtrl->setParameter(
+                $this,
+                "from_page",
+                ilWikiUtil::makeUrlTitle($this->edit_request->getFromPage())
+            );
+            $ilCtrl->redirect($this, "showTemplateSelection");
         }
     }
 
@@ -1437,7 +1435,7 @@ class ilObjWikiGUI extends ilObjectGUI
         
         $ilTabs->setTabActive("wiki_search_results");
         
-        if ($this->edit_request->getSearchTerm() == "") {
+        if ($this->edit_request->getSearchTerm() === "") {
             $this->tpl->setOnScreenMessage('failure', $lng->txt("wiki_please_enter_search_term"), true);
             $ilCtrl->redirectByClass("ilwikipagegui", "preview");
         }
@@ -1596,7 +1594,7 @@ class ilObjWikiGUI extends ilObjectGUI
         $this->checkPermission("edit_wiki_navigation");
 
         $imp_page_ids = $this->edit_request->getImportantPageIds();
-        if (count($imp_page_ids) != 1) {
+        if (count($imp_page_ids) !== 1) {
             $this->tpl->setOnScreenMessage('info', $lng->txt("wiki_select_one_item"), true);
         } else {
             $this->object->removeImportantPage($imp_page_ids[0]);
@@ -1631,7 +1629,7 @@ class ilObjWikiGUI extends ilObjectGUI
      * Get title for wiki page (used in ilNotesGUI)
      */
     public static function lookupSubObjectTitle(
-        string $a_wiki_id,
+        string $a_wiki_id,// TODO PHP8-REVIEW This is a `string`, but it is passed to a constructor expecting and `int`. Furthermore it is compared to an `int` below.
         string $a_page_id
     ) : string {
         $page = new ilWikiPage($a_page_id);

--- a/Modules/Wiki/classes/class.ilObjWikiGUI.php
+++ b/Modules/Wiki/classes/class.ilObjWikiGUI.php
@@ -108,7 +108,7 @@ class ilObjWikiGUI extends ilObjectGUI
         
         // see ilWikiPageGUI::printViewOrderList()
         // printView() cannot be in ilWikiPageGUI because of stylesheet confusion
-        if ($cmd == "printView") {
+        if ($cmd === "printView") {
             $next_class = null;
         }
     
@@ -280,8 +280,8 @@ class ilObjWikiGUI extends ilObjectGUI
                     $cmd = "infoScreen";
                 }
                 $cmd .= "Object";
-                if ($cmd != "cancelObject") {
-                    if ($cmd != "infoScreenObject") {
+                if ($cmd !== "cancelObject") {
+                    if ($cmd !== "infoScreenObject") {
                         if (!in_array($cmd, array("createObject", "saveObject", "importFileObject"))) {
                             $this->checkPermission("read");
                         }
@@ -363,7 +363,7 @@ class ilObjWikiGUI extends ilObjectGUI
 
         // always send a message
         $this->tpl->setOnScreenMessage('success', $this->lng->txt("object_added"), true);
-        ilUtil::redirect(ilObjWikiGUI::getGotoLink($new_object->getRefId()));
+        ilUtil::redirect(self::getGotoLink($new_object->getRefId()));
     }
 
     /**
@@ -433,7 +433,7 @@ class ilObjWikiGUI extends ilObjectGUI
         }
         
         if ($ilAccess->checkAccess("read", "", $this->object->getRefId())) {
-            $info->addButton($lng->txt("wiki_start_page"), ilObjWikiGUI::getGotoLink($this->object->getRefId()));
+            $info->addButton($lng->txt("wiki_start_page"), self::getGotoLink($this->object->getRefId()));
         }
         
         // general information
@@ -446,7 +446,7 @@ class ilObjWikiGUI extends ilObjectGUI
     
     public function gotoStartPageObject() : void
     {
-        ilUtil::redirect(ilObjWikiGUI::getGotoLink($this->object->getRefId()));
+        ilUtil::redirect(self::getGotoLink($this->object->getRefId()));
     }
 
     public function addPageTabs() : void
@@ -534,11 +534,11 @@ class ilObjWikiGUI extends ilObjectGUI
         if (in_array($ilCtrl->getCmdClass(), array("", "ilobjectcontentstylesettingsgui", "ilobjwikigui",
             "ilinfoscreengui", "ilpermissiongui", "ilexportgui", "ilratingcategorygui", "ilobjnotificationsettingsgui", "iltaxmdgui",
             "ilwikistatgui", "ilwikipagetemplategui", "iladvancedmdsettingsgui", "ilsettingspermissiongui", 'ilrepositoryobjectsearchgui'
-            )) || (in_array($ilCtrl->getNextClass(), array("ilpermissiongui")))) {
+            ), true) || $ilCtrl->getNextClass() === "ilpermissiongui") {
             if ($this->requested_page != "") {
                 $this->tabs_gui->setBackTarget(
                     $lng->txt("wiki_last_visited_page"),
-                    $this->getGotoLink(
+                    self::getGotoLink(
                         $this->requested_ref_id,
                         ilWikiUtil::makeDbTitle($this->requested_page)
                     )
@@ -742,7 +742,7 @@ class ilObjWikiGUI extends ilObjectGUI
 
         // Start Page
         $options = [];
-        if ($a_mode == "edit") {
+        if ($a_mode === "edit") {
             $pages = ilWikiPage::getAllWikiPages($this->object->getId());
             foreach ($pages as $p) {
                 $options[$p["id"]] = ilStr::shortenTextExtended($p["title"], 60, true);
@@ -752,7 +752,7 @@ class ilObjWikiGUI extends ilObjectGUI
             $this->form_gui->addItem($si);
         } else {
             $sp = new ilTextInputGUI($lng->txt("wiki_start_page"), "startpage");
-            if ($a_mode == "edit") {
+            if ($a_mode === "edit") {
                 $sp->setInfo($lng->txt("wiki_start_page_info"));
             }
             $sp->setMaxLength(200);
@@ -802,7 +802,7 @@ class ilObjWikiGUI extends ilObjectGUI
         $page_toc->setInfo($lng->txt("wiki_page_toc_info"));
         $this->form_gui->addItem($page_toc);
         
-        if ($a_mode == "edit") {
+        if ($a_mode === "edit") {
             // advanced metadata auto-linking
             if (count(ilAdvancedMDRecord::_getSelectedRecordsByObject("wiki", $this->object->getRefId(), "wpg")) > 0) {
                 $link_md = new ilCheckboxInputGUI($lng->txt("wiki_link_md_values"), "link_md_values");
@@ -837,7 +837,7 @@ class ilObjWikiGUI extends ilObjectGUI
 
         // Form action and save button
         $this->form_gui->setTitleIcon(ilUtil::getImagePath("icon_wiki.svg"));
-        if ($a_mode != "create") {
+        if ($a_mode !== "create") {
             $this->form_gui->setTitle($lng->txt("wiki_settings"));
             $this->form_gui->addCommandButton("saveSettings", $lng->txt("save"));
         } else {
@@ -847,7 +847,7 @@ class ilObjWikiGUI extends ilObjectGUI
         }
         
         // set values
-        if ($a_mode == "create") {
+        if ($a_mode === "create") {
             $ilCtrl->setParameter($this, "new_type", "wiki");
         }
 
@@ -857,7 +857,7 @@ class ilObjWikiGUI extends ilObjectGUI
     public function getSettingsFormValues(string $a_mode = "edit") : void
     {
         // set values
-        if ($a_mode == "create") {
+        if ($a_mode === "create") {
             $values["rating_new"] = true;
             
             $values["rating_overall"] = ilObject::hasAutoRating("wiki", $this->requested_ref_id);
@@ -1008,7 +1008,7 @@ class ilObjWikiGUI extends ilObjectGUI
         if (is_object($this->object)) {
             $ilLocator->addItem(
                 $this->object->getTitle(),
-                $this->getGotoLink($this->object->getRefId()),
+                self::getGotoLink($this->object->getRefId()),
                 "",
                 $this->requested_ref_id
             );
@@ -1031,7 +1031,7 @@ class ilObjWikiGUI extends ilObjectGUI
             $a_target = substr($a_target, 0, $i);
         }
         
-        if ($a_target == "wpage") {
+        if ($a_target === "wpage") {
             $a_page_arr = explode("_", $a_page);
             $wpg_id = (int) $a_page_arr[0];
             $ref_id = (int) $a_page_arr[1];
@@ -1232,7 +1232,7 @@ class ilObjWikiGUI extends ilObjectGUI
             ilWikiUtil::makeDbTitle($a_page)
         )) {
             // to do: get rid of this redirect
-            ilUtil::redirect(ilObjWikiGUI::getGotoLink($this->object->getRefId(), $a_page));
+            ilUtil::redirect(self::getGotoLink($this->object->getRefId(), $a_page));
         } else {
             if (!$this->object->getTemplateSelectionOnCreation()) {
                 // check length
@@ -1290,7 +1290,7 @@ class ilObjWikiGUI extends ilObjectGUI
 
     public function setSideBlock(int $a_wpg_id = 0) : void
     {
-        ilObjWikiGUI::renderSideBlock($a_wpg_id, $this->object->getRefId());
+        self::renderSideBlock($a_wpg_id, $this->object->getRefId());
     }
 
     public static function renderSideBlock(
@@ -1420,7 +1420,7 @@ class ilObjWikiGUI extends ilObjectGUI
         );
     }
 
-    public function printViewObject()
+    public function printViewObject() : void
     {
         $print_view = $this->getPrintView();
         $print_view->sendPrintView();
@@ -1620,7 +1620,7 @@ class ilObjWikiGUI extends ilObjectGUI
         $cont_exp = new Export\WikiHtmlExport($wiki);
 
         $format = explode("_", $this->edit_request->getFormat());
-        if ($format[1] == "comments") {
+        if ($format[1] === "comments") {
             $cont_exp->setMode(Export\WikiHtmlExport::MODE_COMMENTS);
         }
 
@@ -1751,7 +1751,7 @@ class ilObjWikiGUI extends ilObjectGUI
 
     protected function checkPermissionBool(string $perm, string $cmd = "", string $type = "", ?int $ref_id = null) : bool
     {
-        if ($perm == "create") {
+        if ($perm === "create") {
             return parent::checkPermissionBool($perm, $cmd, $type, $ref_id);
         } else {
             if (!$ref_id) {
@@ -1830,7 +1830,7 @@ class ilObjWikiGUI extends ilObjectGUI
             $this->user->getId()
         );
         if (count($ass_info) > 0) {
-            $ass_ids = array_map(function ($i) {
+            $ass_ids = array_map(static function ($i) : int {
                 return $i->getId();
             }, $ass_info);
             $this->tool_context->current()->addAdditionalData(ilExerciseGSToolProvider::SHOW_EXC_ASSIGNMENT_INFO, true);

--- a/Modules/Wiki/classes/class.ilObjWikiGUI.php
+++ b/Modules/Wiki/classes/class.ilObjWikiGUI.php
@@ -896,7 +896,7 @@ class ilObjWikiGUI extends ilObjectGUI
         
         if ($this->form_gui->checkInput()) {
             if (!ilObjWiki::checkShortTitleAvailability($this->form_gui->getInput("shorttitle")) &&
-                $this->form_gui->getInput("shorttitle") != $this->object->getShortTitle()) {
+                $this->form_gui->getInput("shorttitle") !== $this->object->getShortTitle()) {
                 $short_item = $this->form_gui->getItemByPostVar("shorttitle");
                 $short_item->setAlert($lng->txt("wiki_short_title_already_in_use"));
             } else {

--- a/Modules/Wiki/classes/class.ilObjWikiListGUI.php
+++ b/Modules/Wiki/classes/class.ilObjWikiListGUI.php
@@ -68,7 +68,7 @@ class ilObjWikiListGUI extends ilObjectListGUI
             $sub = ilExSubmission::getSubmissionsForFilename($this->ref_id, array(ilExAssignment::TYPE_WIKI_TEAM));
             foreach ($sub as $s) {
                 $team = new ilExAssignmentTeam($s["team_id"]);
-                $mem = array_map(function ($id) {
+                $mem = array_map(static function ($id) : string {
                     $name = ilObjUser::_lookupName($id);
                     return $name["firstname"] . " " . $name["lastname"];
                 }, $team->getMembers());

--- a/Modules/Wiki/classes/class.ilObjWikiSearchResultTableGUI.php
+++ b/Modules/Wiki/classes/class.ilObjWikiSearchResultTableGUI.php
@@ -20,7 +20,7 @@
  */
 class ilObjWikiSearchResultTableGUI extends ilRepositoryObjectSearchResultTableGUI
 {
-    public function parse()
+    public function parse() : void
     {
         $ilCtrl = $this->ctrl;
         

--- a/Modules/Wiki/classes/class.ilObjWikiSearchResultTableGUI.php
+++ b/Modules/Wiki/classes/class.ilObjWikiSearchResultTableGUI.php
@@ -53,7 +53,8 @@ class ilObjWikiSearchResultTableGUI extends ilRepositoryObjectSearchResultTableG
         if ($this->getSettings()->enabledLucene()) {
             $this->tpl->setVariable('RELEVANCE', $this->getRelevanceHTML($a_set['relevance']));
         }
-        if (strlen($a_set['content'])) {
+
+        if ($a_set['content'] !== '') {
             $this->tpl->setVariable('HIGHLIGHT_CONTENT', $a_set['content']);
         }
     }

--- a/Modules/Wiki/classes/class.ilObjWikiSettings.php
+++ b/Modules/Wiki/classes/class.ilObjWikiSettings.php
@@ -20,7 +20,7 @@
  */
 class ilObjWikiSettings extends ilObject2
 {
-    protected function initType()
+    protected function initType() : void
     {
         $this->type = "wiks";
     }

--- a/Modules/Wiki/classes/class.ilObjWikiSubItemListGUI.php
+++ b/Modules/Wiki/classes/class.ilObjWikiSubItemListGUI.php
@@ -38,7 +38,7 @@ class ilObjWikiSubItemListGUI extends ilSubItemListGUI
 
         $lng->loadLanguageModule('content');
         foreach ($this->getSubItemIds(true) as $sub_item) {
-            if (is_object($this->getHighlighter()) and strlen($this->getHighlighter()->getContent($this->getObjId(), $sub_item))) {
+            if (is_object($this->getHighlighter()) && strlen($this->getHighlighter()->getContent($this->getObjId(), $sub_item))) {
                 $this->tpl->setCurrentBlock('sea_fragment');
                 $this->tpl->setVariable('TXT_FRAGMENT', $this->getHighlighter()->getContent($this->getObjId(), $sub_item));
                 $this->tpl->parseCurrentBlock();

--- a/Modules/Wiki/classes/class.ilObjWikiSubItemListGUI.php
+++ b/Modules/Wiki/classes/class.ilObjWikiSubItemListGUI.php
@@ -38,7 +38,8 @@ class ilObjWikiSubItemListGUI extends ilSubItemListGUI
 
         $lng->loadLanguageModule('content');
         foreach ($this->getSubItemIds(true) as $sub_item) {
-            if (is_object($this->getHighlighter()) && strlen($this->getHighlighter()->getContent($this->getObjId(), $sub_item))) {
+            if (is_object($this->getHighlighter()) &&
+                $this->getHighlighter()->getContent($this->getObjId(), $sub_item) !== '') {
                 $this->tpl->setCurrentBlock('sea_fragment');
                 $this->tpl->setVariable('TXT_FRAGMENT', $this->getHighlighter()->getContent($this->getObjId(), $sub_item));
                 $this->tpl->parseCurrentBlock();

--- a/Modules/Wiki/classes/class.ilPCAMDPageList.php
+++ b/Modules/Wiki/classes/class.ilPCAMDPageList.php
@@ -112,7 +112,7 @@ class ilPCAMDPageList extends ilPageContent
             $set = $ilDB->query("SELECT * FROM pg_amd_page_list" .
                 " WHERE id = " . $ilDB->quote($a_data_id, "integer"));
             while ($row = $ilDB->fetchAssoc($set)) {
-                $res[$row["field_id"]] = unserialize($row["data"]);
+                $res[$row["field_id"]] = unserialize($row["data"], ["allowed_classes" => false]);
             }
         }
         return $res;
@@ -212,7 +212,7 @@ class ilPCAMDPageList extends ilPageContent
         string $a_mode,
         bool $a_abstract_only = false
     ) : string {
-        if ($this->getPage()->getParentType() != "wpg") {
+        if ($this->getPage()->getParentType() !== "wpg") {
             return $a_output;
         }
         $end = 0;
@@ -226,14 +226,14 @@ class ilPCAMDPageList extends ilPageContent
             $parts = explode(";", substr($a_output, $start + 17, $end - $start - 17));
             
             $list_id = (int) $parts[0];
-            $list_mode = (sizeof($parts) == 2)
+            $list_mode = (count($parts) === 2)
                 ? (int) $parts[1]
                 : 0;
             
             $ltpl = new ilTemplate("tpl.wiki_amd_page_list.html", true, true, "Modules/Wiki");
                 
             $pages = $this->findPages($list_id);
-            if (sizeof($pages)) {
+            if (count($pages)) {
                 $ltpl->setCurrentBlock("page_bl");
                 foreach ($pages as $page_id => $page_title) {
                     // see ilWikiUtil::makeLink()
@@ -283,7 +283,7 @@ class ilPCAMDPageList extends ilPageContent
         $set = $ilDB->query("SELECT * FROM pg_amd_page_list" .
             " WHERE field_id = " . $ilDB->quote($a_field_id, "integer"));
         while ($row = $ilDB->fetchAssoc($set)) {
-            $data = unserialize(unserialize($row["data"]));
+            $data = unserialize(unserialize($row["data"], ["allowed_classes" => false]), ["allowed_classes" => false]);
             if (is_array($data) &&
                 in_array($old_option, $data)) {
                 $idx = array_search($old_option, $data);

--- a/Modules/Wiki/classes/class.ilPCAMDPageListGUI.php
+++ b/Modules/Wiki/classes/class.ilPCAMDPageListGUI.php
@@ -111,7 +111,7 @@ class ilPCAMDPageListGUI extends ilPageContentGUI
         
         $this->record_gui->parse();
 
-        $no_fields = (count($form->getItems()) == 1);
+        $no_fields = (count($form->getItems()) === 1);
         if ($no_fields) {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt("wiki_pg_list_no_search_fields"));
         }

--- a/Modules/Wiki/classes/class.ilWikiDataSet.php
+++ b/Modules/Wiki/classes/class.ilWikiDataSet.php
@@ -370,8 +370,8 @@ class ilWikiDataSet extends ilDataSet
             case "wiki_imp_page":
                 $wiki_id = $a_mapping->getMapping("Modules/Wiki", "wiki", $a_rec["WikiId"]);
                 $page_id = $a_mapping->getMapping("Modules/Wiki", "wpg", $a_rec["PageId"]);
-                if ($wiki_id > 0 && $page_id > 0 && is_object($this->current_obj) && $this->current_obj->getId() == $wiki_id) {
-                    $this->current_obj->addImportantPage($page_id, $a_rec["Ord"], $a_rec["Indent"]);
+                if ($wiki_id > 0 && $page_id > 0 && is_object($this->current_obj) && $this->current_obj->getId() === (int) $wiki_id) {
+                    $this->current_obj->addImportantPage((int) $page_id, (int) $a_rec["Ord"], (int) $a_rec["Indent"]);
                 }
                 break;
         }

--- a/Modules/Wiki/classes/class.ilWikiDataSet.php
+++ b/Modules/Wiki/classes/class.ilWikiDataSet.php
@@ -48,7 +48,7 @@ class ilWikiDataSet extends ilDataSet
     
     protected function getTypes(string $a_entity, string $a_version) : array
     {
-        if ($a_entity == "wiki") {
+        if ($a_entity === "wiki") {
             switch ($a_version) {
                 case "4.1.0":
                     return array(
@@ -134,7 +134,7 @@ class ilWikiDataSet extends ilDataSet
             }
         }
 
-        if ($a_entity == "wpg") {
+        if ($a_entity === "wpg") {
             switch ($a_version) {
                 case "4.1.0":
                     return array(
@@ -165,7 +165,7 @@ class ilWikiDataSet extends ilDataSet
             }
         }
 
-        if ($a_entity == "wiki_imp_page") {
+        if ($a_entity === "wiki_imp_page") {
             switch ($a_version) {
                 case "5.1.0":
                 case "5.4.0":
@@ -187,7 +187,7 @@ class ilWikiDataSet extends ilDataSet
             $a_ids = array($a_ids);
         }
                 
-        if ($a_entity == "wiki") {
+        if ($a_entity === "wiki") {
             switch ($a_version) {
                 case "4.1.0":
                     $this->getDirectDataFromQuery("SELECT id, title, description," .
@@ -230,7 +230,7 @@ class ilWikiDataSet extends ilDataSet
             }
         }
 
-        if ($a_entity == "wpg") {
+        if ($a_entity === "wpg") {
             switch ($a_version) {
                 case "4.1.0":
                     $this->getDirectDataFromQuery("SELECT id, title, wiki_id" .
@@ -269,7 +269,7 @@ class ilWikiDataSet extends ilDataSet
             }
         }
 
-        if ($a_entity == "wiki_imp_page") {
+        if ($a_entity === "wiki_imp_page") {
             switch ($a_version) {
                 case "5.1.0":
                 case "5.4.0":

--- a/Modules/Wiki/classes/class.ilWikiExporter.php
+++ b/Modules/Wiki/classes/class.ilWikiExporter.php
@@ -62,7 +62,7 @@ class ilWikiExporter extends ilXmlExporter
         foreach ($a_ids as $id) {
             $rec_ids = $this->getActiveAdvMDRecords($id);
             $this->wiki_log->debug("advmd rec ids: wiki id:" . $id . ", adv rec ids" . print_r($rec_ids, true));
-            if (sizeof($rec_ids)) {
+            if (count($rec_ids)) {
                 foreach ($rec_ids as $rec_id) {
                     $advmd_ids[] = $id . ":" . $rec_id;
                 }
@@ -71,7 +71,7 @@ class ilWikiExporter extends ilXmlExporter
 
         $this->wiki_log->debug("advmd ids: " . print_r($advmd_ids, true));
 
-        if (sizeof($advmd_ids)) {
+        if (count($advmd_ids)) {
             $deps[] = array(
                 "component" => "Services/AdvancedMetaData",
                 "entity" => "advmd",

--- a/Modules/Wiki/classes/class.ilWikiExporter.php
+++ b/Modules/Wiki/classes/class.ilWikiExporter.php
@@ -106,7 +106,7 @@ class ilWikiExporter extends ilXmlExporter
 
         foreach (ilAdvancedMDRecord::_getActivatedRecordsByObjectType("wiki", "wpg") as $record_obj) {
             // local ones and globally activated for the object
-            if ($record_obj->getParentObject() == $a_id || in_array($record_obj->getRecordId(), $sel_globals)) {
+            if ($record_obj->getParentObject() === $a_id || in_array($record_obj->getRecordId(), $sel_globals)) {
                 $active[] = $record_obj->getRecordId();
             }
         }

--- a/Modules/Wiki/classes/class.ilWikiFunctionsBlockGUI.php
+++ b/Modules/Wiki/classes/class.ilWikiFunctionsBlockGUI.php
@@ -56,11 +56,6 @@ class ilWikiFunctionsBlockGUI extends ilBlockGUI
     {
         return false;
     }
-    
-    public static function getScreenMode() : string
-    {
-        return IL_SCREEN_SIDE;
-    }
 
     /**
     * execute command
@@ -206,7 +201,7 @@ class ilWikiFunctionsBlockGUI extends ilBlockGUI
         if ($ilAccess->checkAccess("write", "", $this->ref_id) ||
             $ilAccess->checkAccess("edit_page_meta", "", $this->ref_id)) {
             // unhide advmd?
-            if (sizeof(ilAdvancedMDRecord::_getSelectedRecordsByObject("wiki", $this->ref_id, "wpg")) &&
+            if (count(ilAdvancedMDRecord::_getSelectedRecordsByObject("wiki", $this->ref_id, "wpg")) &&
                 ilWikiPage::lookupAdvancedMetadataHidden($this->getPageObject()->getId())) {
                 $list->addItem(
                     $lng->txt("wiki_unhide_meta_adv_records"),

--- a/Modules/Wiki/classes/class.ilWikiFunctionsBlockGUI.php
+++ b/Modules/Wiki/classes/class.ilWikiFunctionsBlockGUI.php
@@ -241,7 +241,7 @@ class ilWikiFunctionsBlockGUI extends ilBlockGUI
         if (ilWikiPerm::check("delete_wiki_pages", $this->ref_id)) {
             // delete page
             $st_page = ilObjWiki::_lookupStartPage($this->getPageObject()->getParentId());
-            if ($st_page != $this->getPageObject()->getTitle()) {
+            if ($st_page !== $this->getPageObject()->getTitle()) {
                 $list->addItem(
                     $lng->txt("wiki_delete_page"),
                     "",

--- a/Modules/Wiki/classes/class.ilWikiHandlerGUI.php
+++ b/Modules/Wiki/classes/class.ilWikiHandlerGUI.php
@@ -71,7 +71,7 @@ class ilWikiHandlerGUI implements ilCtrlBaseClassInterface
             $obj_id = ilObject::_lookupObjId($this->requested_ref_id);
             $title = ilObject::_lookupTitle($obj_id);
 
-            if ($this->requested_page != "") {
+            if ($this->requested_page !== "") {
                 $page = $this->requested_page;
             } else {
                 $page = ilObjWiki::_lookupStartPage($obj_id);
@@ -85,7 +85,7 @@ class ilWikiHandlerGUI implements ilCtrlBaseClassInterface
                 
                 $title .= ": " . $ptitle;
                 
-                $append = ($this->requested_page != "")
+                $append = ($this->requested_page !== "")
                     ? "_" . ilWikiUtil::makeUrlTitle($page)
                     : "";
                 $goto = ilLink::_getStaticLink(

--- a/Modules/Wiki/classes/class.ilWikiImportantPagesBlockGUI.php
+++ b/Modules/Wiki/classes/class.ilWikiImportantPagesBlockGUI.php
@@ -50,11 +50,6 @@ class ilWikiImportantPagesBlockGUI extends ilBlockGUI
     {
         return false;
     }
-    
-    public static function getScreenMode() : string
-    {
-        return IL_SCREEN_SIDE;
-    }
 
     /**
      * @return mixed

--- a/Modules/Wiki/classes/class.ilWikiNewsRendererGUI.php
+++ b/Modules/Wiki/classes/class.ilWikiNewsRendererGUI.php
@@ -24,7 +24,7 @@ class ilWikiNewsRendererGUI extends ilNewsDefaultRendererGUI
     {
         $add = "";
         $n = $this->getNewsItem();
-        if ($n->getContextSubObjType() == "wpg"
+        if ($n->getContextSubObjType() === "wpg"
             && $n->getContextSubObjId() > 0) {
             $wptitle = ilWikiPage::lookupTitle($n->getContextSubObjId());
             if ($wptitle != "") {

--- a/Modules/Wiki/classes/class.ilWikiPage.php
+++ b/Modules/Wiki/classes/class.ilWikiPage.php
@@ -158,15 +158,15 @@ class ilWikiPage extends ilPageObject
         string $xml
     ) : void {
         // internal == wiki links
-        $int_links = sizeof(ilWikiUtil::collectInternalLinks($xml, $this->getWikiId(), true));
+        $int_links = count(ilWikiUtil::collectInternalLinks($xml, $this->getWikiId(), true));
         
         $xpath = new DOMXPath($domdoc);
     
         // external = internal + external links
-        $ext_links = sizeof($xpath->query('//IntLink'));
-        $ext_links += sizeof($xpath->query('//ExtLink'));
+        $ext_links = count($xpath->query('//IntLink'));
+        $ext_links += count($xpath->query('//ExtLink'));
         
-        $footnotes = sizeof($xpath->query('//Footnote'));
+        $footnotes = count($xpath->query('//Footnote'));
         
         
         // words/characters (xml)
@@ -174,7 +174,7 @@ class ilWikiPage extends ilPageObject
         $xml = strip_tags($xml);
 
         $num_chars = ilStr::strLen($xml);
-        $num_words = sizeof(explode(" ", $xml));
+        $num_words = count(explode(" ", $xml));
                         
         $page_data = array(
             "int_links" => $int_links,
@@ -247,7 +247,7 @@ class ilWikiPage extends ilPageObject
         $ilDB = $this->db;
         
         // get other pages that link to this page
-        $linking_pages = ilWikiPage::getLinksToPage(
+        $linking_pages = self::getLinksToPage(
             $this->getWikiId(),
             $this->getId()
         );
@@ -423,7 +423,7 @@ class ilWikiPage extends ilPageObject
         
         $ids = array();
         foreach ($sources as $source) {
-            if ($source["type"] == "wpg:pg") {
+            if ($source["type"] === "wpg:pg") {
                 $ids[] = $source["id"];
             }
         }
@@ -451,7 +451,7 @@ class ilWikiPage extends ilPageObject
 
         $ilDB = $DIC->database();
         
-        $pages = ilWikiPage::getAllWikiPages($a_wiki_id);
+        $pages = self::getAllWikiPages($a_wiki_id);
         
         $orphaned = array();
         foreach ($pages as $k => $page) {
@@ -459,7 +459,7 @@ class ilWikiPage extends ilPageObject
             
             $ids = array();
             foreach ($sources as $source) {
-                if ($source["type"] == "wpg:pg") {
+                if ($source["type"] === "wpg:pg") {
                     $ids[] = $source["id"];
                 }
             }
@@ -566,7 +566,7 @@ class ilWikiPage extends ilPageObject
         $xml = $a_domdoc->saveXML();
         $int_wiki_links = ilWikiUtil::collectInternalLinks($xml, $this->getWikiId(), true);
         foreach ($int_wiki_links as $wlink) {
-            $page_id = ilWikiPage::_getPageIdForWikiTitle($this->getWikiId(), $wlink);
+            $page_id = self::_getPageIdForWikiTitle($this->getWikiId(), $wlink);
             
             if ($page_id > 0) {		// save internal link for existing page
                 ilInternalLink::_saveLink(
@@ -648,7 +648,7 @@ class ilWikiPage extends ilPageObject
 
         $ilDB = $DIC->database();
         
-        $cnt = ilWikiPage::countPages($a_wiki_id);
+        $cnt = self::countPages($a_wiki_id);
         
         if ($cnt < 1) {
             return "";
@@ -672,7 +672,7 @@ class ilWikiPage extends ilPageObject
     ) : array {
         $pages = parent::getNewPages("wpg", $a_wiki_id);
         foreach ($pages as $k => $page) {
-            $pages[$k]["title"] = ilWikiPage::lookupTitle($page["id"]);
+            $pages[$k]["title"] = self::lookupTitle($page["id"]);
         }
         
         return $pages;
@@ -714,7 +714,7 @@ class ilWikiPage extends ilPageObject
         $a_new_name = trim(preg_replace('!\s+!', ' ', $a_new_name));
                 
         $page_title = ilWikiUtil::makeDbTitle($a_new_name);
-        $pg_id = ilWikiPage::_getPageIdForWikiTitle($this->getWikiId(), $page_title);
+        $pg_id = self::_getPageIdForWikiTitle($this->getWikiId(), $page_title);
         
         $xml_new_name = str_replace("&", "&amp;", $a_new_name);
 
@@ -722,7 +722,7 @@ class ilWikiPage extends ilPageObject
             $sources = ilInternalLink::_getSourcesOfTarget("wpg", $this->getId(), 0);
 
             foreach ($sources as $s) {
-                if ($s["type"] == "wpg:pg" && ilPageObject::_exists("wpg", $s["id"])) {
+                if ($s["type"] === "wpg:pg" && ilPageObject::_exists("wpg", $s["id"])) {
                     $wpage = new ilWikiPage($s["id"]);
                     
                     $col = ilWikiUtil::collectInternalLinks(

--- a/Modules/Wiki/classes/class.ilWikiPage.php
+++ b/Modules/Wiki/classes/class.ilWikiPage.php
@@ -470,7 +470,7 @@ class ilWikiPage extends ilPageObject
             $set = $ilDB->query($query);
             $rec = $ilDB->fetchAssoc($set);
             if ($rec["cnt"] == 0 &&
-                ilObjWiki::_lookupStartPage($a_wiki_id) != $page["title"]) {
+                ilObjWiki::_lookupStartPage($a_wiki_id) !== $page["title"]) {
                 $orphaned[] = $page;
             }
         }
@@ -783,7 +783,7 @@ class ilWikiPage extends ilPageObject
                 }
             }
 
-            if (ilObjWiki::_lookupStartPage($this->getWikiId()) == $this->getTitle()) {
+            if (ilObjWiki::_lookupStartPage($this->getWikiId()) === $this->getTitle()) {
                 ilObjWiki::writeStartPage($this->getWikiId(), $a_new_name);
             }
 

--- a/Modules/Wiki/classes/class.ilWikiPage.php
+++ b/Modules/Wiki/classes/class.ilWikiPage.php
@@ -469,7 +469,7 @@ class ilWikiPage extends ilPageObject
                 " GROUP BY wiki_id";
             $set = $ilDB->query($query);
             $rec = $ilDB->fetchAssoc($set);
-            if ($rec["cnt"] == 0 &&
+            if ((int) $rec["cnt"] === 0 &&
                 ilObjWiki::_lookupStartPage($a_wiki_id) !== $page["title"]) {
                 $orphaned[] = $page;
             }

--- a/Modules/Wiki/classes/class.ilWikiPageGUI.php
+++ b/Modules/Wiki/classes/class.ilWikiPageGUI.php
@@ -13,8 +13,6 @@
  * https://github.com/ILIAS-eLearning
  */
 
-use ILIAS\DI\HTTPServices;
-
 /**
  * Class ilWikiPage GUI class
  *
@@ -173,7 +171,7 @@ class ilWikiPageGUI extends ilPageObjectGUI
 
             default:
 
-                if (strtolower($ilCtrl->getNextClass()) == "ilpageeditorgui") {
+                if (strtolower($ilCtrl->getNextClass()) === "ilpageeditorgui") {
                     self::initEditingJS($this->tpl);
                 }
 
@@ -213,8 +211,7 @@ class ilWikiPageGUI extends ilPageObjectGUI
     public function getWikiPage() : ilWikiPage
     {
         /** @var ilWikiPage $wp */
-        $wp = $this->getPageObject();
-        return $wp;
+        return $this->getPageObject();
     }
 
     /**
@@ -227,9 +224,7 @@ class ilWikiPageGUI extends ilPageObjectGUI
         int $a_wiki_ref_id = 0
     ) : ilWikiPageGUI {
         $id = ilWikiPage::getPageIdForTitle($a_wiki_id, $a_title);
-        $page_gui = new ilWikiPageGUI($id, $a_old_nr, $a_wiki_ref_id);
-        
-        return $page_gui;
+        return new ilWikiPageGUI($id, $a_old_nr, $a_wiki_ref_id);
     }
     
     public function setSideBlock() : void
@@ -359,7 +354,7 @@ class ilWikiPageGUI extends ilPageObjectGUI
         $this->addHeaderAction();
         
         // content
-        if ($ilCtrl->getNextClass() != "ilnotegui") {
+        if ($ilCtrl->getNextClass() !== "ilnotegui") {
             $this->setSideBlock();
         }
 
@@ -485,7 +480,7 @@ class ilWikiPageGUI extends ilPageObjectGUI
         );
     }
 
-    protected function increaseViewCount()
+    protected function increaseViewCount() : void
     {
         $ilUser = $this->user;
         
@@ -515,7 +510,7 @@ class ilWikiPageGUI extends ilPageObjectGUI
             $output = ilWikiUtil::replaceInternalLinks(
                 $a_output,
                 $this->getWikiPage()->getWikiId(),
-                ($this->getOutputMode() == "offline")
+                ($this->getOutputMode() === "offline")
             );
         } else {
             $output = $a_output;
@@ -528,7 +523,7 @@ class ilWikiPageGUI extends ilPageObjectGUI
 
 
         // metadata in print view
-        if ($this->getOutputMode() == "print" && $this->wiki instanceof ilObjWiki) {
+        if ($this->getOutputMode() === "print" && $this->wiki instanceof ilObjWiki) {
             $mdgui = new ilObjectMetaDataGUI($this->wiki, "wpg", $this->getId());
             $md = $mdgui->getKeyValueList();
             if ($md != "") {
@@ -696,7 +691,7 @@ class ilWikiPageGUI extends ilPageObjectGUI
     //// Print view selection
     ////
 
-    public function printViewSelection()
+    public function printViewSelection() : void
     {
         $view = $this->getPrintView();
         $view->sendForm();
@@ -729,7 +724,7 @@ class ilWikiPageGUI extends ilPageObjectGUI
                     if (count($pg_ids) == 0) {
                         $pg_ids = [$this->wiki_request->getWikiPageId()];
                     }
-                    if (sizeof($pg_ids) > 1) {
+                    if (count($pg_ids) > 1) {
                         break;
                     } else {
                         $wiki_page_id = array_pop($pg_ids);
@@ -764,7 +759,7 @@ class ilWikiPageGUI extends ilPageObjectGUI
             $this->ctrl->getLinkTarget($this, "preview")
         );
         
-        if (!sizeof($all_pages)) {
+        if (!count($all_pages)) {
             $all_pages = ilWikiPage::getAllWikiPages($this->getPageObject()->getWikiId());
         }
         

--- a/Modules/Wiki/classes/class.ilWikiPageGUI.php
+++ b/Modules/Wiki/classes/class.ilWikiPageGUI.php
@@ -103,7 +103,7 @@ class ilWikiPageGUI extends ilPageObjectGUI
             ": " . $this->getWikiPage()->getTitle();
         $tpl->setHeaderPageTitle($head_title);
         // see #13804
-        if ($this->wiki_request->getPage() != "") {
+        if ($this->wiki_request->getPage() !== "") {
             $tpl->setPermanentLink(
                 "wiki",
                 $this->requested_ref_id,
@@ -211,6 +211,7 @@ class ilWikiPageGUI extends ilPageObjectGUI
     public function getWikiPage() : ilWikiPage
     {
         /** @var ilWikiPage $wp */
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
         return $this->getPageObject();
     }
 
@@ -276,7 +277,7 @@ class ilWikiPageGUI extends ilPageObjectGUI
         }
 
         // notification
-        if ($ilUser->getId() != ANONYMOUS_USER_ID) {
+        if ($ilUser->getId() !== ANONYMOUS_USER_ID) {
             if (ilNotification::hasNotification(ilNotification::TYPE_WIKI, $ilUser->getId(), $wiki_id)) {
                 $this->ctrl->setParameter($this, "ntf", 1);
                 if (ilNotification::hasOptOut($wiki_id)) {
@@ -435,7 +436,7 @@ class ilWikiPageGUI extends ilPageObjectGUI
     
     public function showPage() : string
     {
-        if ($this->getOutputMode() == ilPageObjectGUI::PRESENTATION) {
+        if ($this->getOutputMode() === ilPageObjectGUI::PRESENTATION) {
             $this->initToolbar();
         }
         $this->setTemplateOutput(false);
@@ -526,7 +527,7 @@ class ilWikiPageGUI extends ilPageObjectGUI
         if ($this->getOutputMode() === "print" && $this->wiki instanceof ilObjWiki) {
             $mdgui = new ilObjectMetaDataGUI($this->wiki, "wpg", $this->getId());
             $md = $mdgui->getKeyValueList();
-            if ($md != "") {
+            if ($md !== "") {
                 $output = str_replace("<!--COPage-PageTop-->", "<p>" . $md . "</p>", $output);
             }
         }
@@ -710,7 +711,7 @@ class ilWikiPageGUI extends ilPageObjectGUI
         
         // coming from type selection
         $ordering = $this->wiki_request->getPrintOrdering();
-        if (count($ordering) == 0) {
+        if (count($ordering) === 0) {
             switch ($this->wiki_request->getSelectedPrintType()) {
                 case "wiki":
                     $all_pages = ilWikiPage::getAllWikiPages($this->getPageObject()->getWikiId());
@@ -721,7 +722,7 @@ class ilWikiPageGUI extends ilPageObjectGUI
 
                 case "selection":
                     $pg_ids = $this->wiki_request->getWikiPageIds();
-                    if (count($pg_ids) == 0) {
+                    if (count($pg_ids) === 0) {
                         $pg_ids = [$this->wiki_request->getWikiPageId()];
                     }
                     if (count($pg_ids) > 1) {
@@ -1180,9 +1181,9 @@ class ilWikiPageGUI extends ilPageObjectGUI
             $tpl->parseCurrentBlock();
         }
 
-        if (count($pages) == 0) {
+        if (count($pages) === 0) {
             $tpl->setVariable("INFOTEXT", str_replace("$1", $term, $lng->txt("wiki_no_page_found")));
-        } elseif ($term == '') {
+        } elseif ($term === '') {
             $tpl->setVariable("INFOTEXT", $lng->txt("wiki_no_search_term"));
         } else {
             $tpl->setVariable("INFOTEXT", str_replace("$1", $term, $lng->txt("wiki_pages_found")));

--- a/Modules/Wiki/classes/class.ilWikiPageGUI.php
+++ b/Modules/Wiki/classes/class.ilWikiPageGUI.php
@@ -1171,7 +1171,7 @@ class ilWikiPageGUI extends ilPageObjectGUI
         }
 
         // sort if all pages are listed
-        if ($term == "") {
+        if ($term === "") {
             $found = ilArrayUtil::sortArray($found, "title", "asc");
         }
 

--- a/Modules/Wiki/classes/class.ilWikiPageTemplate.php
+++ b/Modules/Wiki/classes/class.ilWikiPageTemplate.php
@@ -40,10 +40,10 @@ class ilWikiPageTemplate
         int $a_type = self::TYPE_ALL
     ) : array {
         $and = "";
-        if ($a_type == self::TYPE_NEW_PAGES) {
+        if ($a_type === self::TYPE_NEW_PAGES) {
             $and = " AND t.new_pages = " . $this->db->quote(1, "integer");
         }
-        if ($a_type == self::TYPE_ADD_TO_PAGE) {
+        if ($a_type === self::TYPE_ADD_TO_PAGE) {
             $and = " AND t.add_to_page = " . $this->db->quote(1, "integer");
         }
 

--- a/Modules/Wiki/classes/class.ilWikiPageTemplateGUI.php
+++ b/Modules/Wiki/classes/class.ilWikiPageTemplateGUI.php
@@ -164,7 +164,7 @@ class ilWikiPageTemplateGUI
         $this->ctrl->redirect($this, "listTemplates");
     }
     
-    public function addPageTemplateFromPageAction()
+    public function addPageTemplateFromPageAction() : void
     {
         $page_id = $this->request->getWikiPageId();
         if ($page_id) {

--- a/Modules/Wiki/classes/class.ilWikiPagesTableGUI.php
+++ b/Modules/Wiki/classes/class.ilWikiPagesTableGUI.php
@@ -13,11 +13,11 @@
  * https://github.com/ILIAS-eLearning
  */
 
-define("IL_WIKI_ALL_PAGES", "all");
-define("IL_WIKI_NEW_PAGES", "new");
-define("IL_WIKI_POPULAR_PAGES", "popular");
-define("IL_WIKI_WHAT_LINKS_HERE", "what_links");
-define("IL_WIKI_ORPHANED_PAGES", "orphaned");
+const IL_WIKI_ALL_PAGES = "all";
+const IL_WIKI_NEW_PAGES = "new";
+const IL_WIKI_POPULAR_PAGES = "popular";
+const IL_WIKI_WHAT_LINKS_HERE = "what_links";
+const IL_WIKI_ORPHANED_PAGES = "orphaned";
 
 /**
  * TableGUI class for wiki pages table
@@ -173,13 +173,13 @@ class ilWikiPagesTableGUI extends ilTable2GUI
     {
         $ilCtrl = $this->ctrl;
         
-        if ($this->pg_list_mode == IL_WIKI_NEW_PAGES) {
+        if ($this->pg_list_mode === IL_WIKI_NEW_PAGES) {
             $this->tpl->setVariable("TXT_PAGE_TITLE", $a_set["title"]);
             $this->tpl->setVariable(
                 "DATE",
                 ilDatePresentation::formatDate(new ilDateTime($a_set["created"], IL_CAL_DATETIME))
             );
-        } elseif ($this->pg_list_mode == IL_WIKI_POPULAR_PAGES) {
+        } elseif ($this->pg_list_mode === IL_WIKI_POPULAR_PAGES) {
             $this->tpl->setVariable("TXT_PAGE_TITLE", $a_set["title"]);
             $this->tpl->setVariable("HITS", $a_set["cnt"]);
         } else {

--- a/Modules/Wiki/classes/class.ilWikiPagesTableGUI.php
+++ b/Modules/Wiki/classes/class.ilWikiPagesTableGUI.php
@@ -163,7 +163,7 @@ class ilWikiPagesTableGUI extends ilTable2GUI
     
     public function numericOrdering(string $a_field) : bool
     {
-        if ($a_field == "cnt") {
+        if ($a_field === "cnt") {
             return true;
         }
         return false;

--- a/Modules/Wiki/classes/class.ilWikiStat.php
+++ b/Modules/Wiki/classes/class.ilWikiStat.php
@@ -149,7 +149,7 @@ class ilWikiStat
         if (!$a_user_id) {
             $a_user_id = $ilUser->getId();
         }
-        if (!$a_user_id || $a_user_id == ANONYMOUS_USER_ID) {
+        if (!$a_user_id || $a_user_id === ANONYMOUS_USER_ID) {
             return;
         }
         

--- a/Modules/Wiki/classes/class.ilWikiStat.php
+++ b/Modules/Wiki/classes/class.ilWikiStat.php
@@ -224,9 +224,9 @@ class ilWikiStat
                 if ($is_update) {
                     $values = array();
                     foreach ($a_values as $column => $value) {
-                        if ($value[0] == "increment") {
+                        if ($value[0] === "increment") {
                             $values[] = $column . " = " . $column . "+1";
-                        } elseif ($value[0] == "decrement") {
+                        } elseif ($value[0] === "decrement") {
                             $values[] = $column . " = " . $column . "-1";
                         } else {
                             $values[] = $column . " = " . $ilDB->quote($value[1], $value[0]);
@@ -247,9 +247,9 @@ class ilWikiStat
                     $values = array();
                     foreach ($a_values as $column => $value) {
                         $columns[] = $column;
-                        if ($value[0] == "increment") {
+                        if ($value[0] === "increment") {
                             $value[0] = "integer";
-                        } elseif ($value[0] == "decrement") {
+                        } elseif ($value[0] === "decrement") {
                             $value[0] = "integer";
                             $value[1] = 0;
                         }
@@ -293,7 +293,7 @@ class ilWikiStat
         int $a_wiki_id,
         int $a_page_id,
         array $a_values
-    ) {
+    ) : void {
         $primary = array(
             "wiki_id" => array("integer", $a_wiki_id),
             "page_id" => array("integer", $a_page_id),
@@ -339,7 +339,7 @@ class ilWikiStat
     protected static function countPages(
         int $a_wiki_id
     ) : int {
-        return sizeof(ilWikiPage::getAllWikiPages($a_wiki_id));
+        return count(ilWikiPage::getAllWikiPages($a_wiki_id));
     }
     
     /**
@@ -551,7 +551,7 @@ class ilWikiStat
         $deleted = null;
         
         $sql = "SELECT ts_day, " . sprintf($a_aggr_value, $a_field) . " " . $a_field;
-        if ($a_table == "wiki_stat_page" && $a_sub_field) {
+        if ($a_table === "wiki_stat_page" && $a_sub_field) {
             $sql .= ", MAX(deleted) deleted";
         }
         $sql .= " FROM " . $a_table .
@@ -580,7 +580,7 @@ class ilWikiStat
             $period_last = $a_day_to;
             
             // check if sub was deleted in period
-            if ($a_table == "wiki_stat_page" && $a_sub_field && $deleted) {
+            if ($a_table === "wiki_stat_page" && $a_sub_field && $deleted) {
                 $sql = "SELECT MAX(ts_day) last_day, MIN(ts_day) first_day" .
                     " FROM " . $a_table .
                     " WHERE wiki_id = " . $ilDB->quote($a_wiki_id, "integer") .
@@ -681,7 +681,7 @@ class ilWikiStat
         } else {
             $tmp = $all_aggr_ids = $deleted_in_period = $first_day_in_period = array();
             
-            if ($a_table != "wiki_stat_page") {
+            if ($a_table !== "wiki_stat_page") {
                 echo "can only build full period averages for wiki_stat_page";
                 exit();
             }
@@ -758,7 +758,7 @@ class ilWikiStat
             foreach ($res as $day => $values) {
                 switch ($a_aggr_value) {
                     case "AVG(%s)":
-                        $res[$day] = array_sum($values) / sizeof($values);
+                        $res[$day] = array_sum($values) / count($values);
                         break;
                     
                     case "SUM(%s)":
@@ -766,7 +766,7 @@ class ilWikiStat
                         break;
                     
                     default:
-                        var_dump("unsupport aggr " . $a_aggr_value);
+                        var_dump("unsupport aggr " . $a_aggr_value);// TODO PHP8-REVIEW We should not use debugging code here
                         break;
                 }
             }
@@ -1007,7 +1007,7 @@ class ilWikiStat
         
         foreach (array_keys($res) as $day) {
             // int-to-float
-            $res[$day] = $res[$day] / 100;
+            $res[$day] /= 100;
         }
         
         return $res;
@@ -1103,7 +1103,7 @@ class ilWikiStat
         int $a_page_id,
         string $a_day_from,
         string $a_day_to
-    ) {
+    ) : array {
         return self::getWikiAggr($a_wiki_id, $a_day_from, $a_day_to, "wiki_stat_page_user", "changes", "SUM(%s)", "page_id", $a_page_id);
     }
     
@@ -1184,7 +1184,7 @@ class ilWikiStat
         int $a_page_id,
         string $a_day_from,
         string $a_day_to
-    ) {
+    ) : array {
         return self::getWikiAggr($a_wiki_id, $a_day_from, $a_day_to, "wiki_stat_page", "num_ratings", "SUM(%s)", "page_id", $a_page_id);
     }
     

--- a/Modules/Wiki/classes/class.ilWikiStatGUI.php
+++ b/Modules/Wiki/classes/class.ilWikiStatGUI.php
@@ -288,7 +288,7 @@ class ilWikiStatGUI
         int $a_figure,
         array $a_data
     ) : string {
-        $scope = ceil(sizeof($a_data) / 31);
+        $scope = ceil(count($a_data) / 31);
 
         $chart = ilChart::getInstanceByType(ilChart::TYPE_GRID, "wikistat");
         $chart->setSize("100%", 400);
@@ -346,7 +346,7 @@ class ilWikiStatGUI
                 }
             } else {
                 // 1st/15th
-                if ($day == 1 || $day == 15 || $x == sizeof($a_data) - 1) {
+                if ($day == 1 || $day == 15 || $x == count($a_data) - 1) {
                     $labels[$x] = substr($date, 8, 2) . "." . substr($date, 5, 2) . ".";
                 }
             }

--- a/Modules/Wiki/classes/class.ilWikiStatGUI.php
+++ b/Modules/Wiki/classes/class.ilWikiStatGUI.php
@@ -344,11 +344,9 @@ class ilWikiStatGUI
                 if (!($x % 7)) {
                     $labels[$x] = substr($date, 8, 2) . "." . substr($date, 5, 2) . ".";
                 }
-            } else {
+            } elseif ($day === 1 || $day === 15 || $x === count($a_data) - 1) {
                 // 1st/15th
-                if ($day == 1 || $day == 15 || $x == count($a_data) - 1) {
-                    $labels[$x] = substr($date, 8, 2) . "." . substr($date, 5, 2) . ".";
-                }
+                $labels[$x] = substr($date, 8, 2) . "." . substr($date, 5, 2) . ".";
             }
                         
             $x++;

--- a/Modules/Wiki/classes/class.ilWikiStatGUI.php
+++ b/Modules/Wiki/classes/class.ilWikiStatGUI.php
@@ -318,7 +318,7 @@ class ilWikiStatGUI
             ,ilWikiStat::KEY_FIGURE_WIKI_PAGE_WORDS
             ,ilWikiStat::KEY_FIGURE_WIKI_PAGE_CHARS
             ,ilWikiStat::KEY_FIGURE_WIKI_PAGE_FOOTNOTES
-            ))) {
+            ), true)) {
             $series = $chart->getDataInstance(ilChartGrid::DATA_LINES);
             $series->setLineSteps(true);
             $series->setFill(true, "#E0F0FF");
@@ -382,7 +382,7 @@ class ilWikiStatGUI
             ,ilWikiStat::KEY_FIGURE_WIKI_PAGE_CHARS
             ,ilWikiStat::KEY_FIGURE_WIKI_PAGE_FOOTNOTES
             ,ilWikiStat::KEY_FIGURE_WIKI_PAGE_RATINGS
-            ))) {
+            ), true)) {
             $chart->setYAxisToInteger(true);
         }
         

--- a/Modules/Wiki/classes/class.ilWikiUtil.php
+++ b/Modules/Wiki/classes/class.ilWikiUtil.php
@@ -26,9 +26,9 @@
  * the ilWikiUtil::makeUrlTitle($mTextform) ("_" for " ")for embedding things in URLs.
  *
  */
-define("IL_WIKI_MODE_REPLACE", "replace");
-define("IL_WIKI_MODE_COLLECT", "collect");
-define("IL_WIKI_MODE_EXT_COLLECT", "ext_collect");
+const IL_WIKI_MODE_REPLACE = "replace";
+const IL_WIKI_MODE_COLLECT = "collect";
+const IL_WIKI_MODE_EXT_COLLECT = "ext_collect";
 
 /**
  * Utility class for wiki.
@@ -90,11 +90,11 @@ class ilWikiUtil
 
         // dummies for wiki globals
         $GLOBALS["wgContLang"] = new class {
-            public function getNsIndex($a_p)
+            public function getNsIndex($a_p) : bool
             {
                 return false;
             }
-            public function lc($a_key)
+            public function lc($a_key) : bool
             {
                 return false;
             }
@@ -227,7 +227,7 @@ class ilWikiUtil
             }
 
             // Media wiki performs an intermediate step here (Parser->makeLinkHolder)
-            if ($a_mode == IL_WIKI_MODE_REPLACE) {
+            if ($a_mode === IL_WIKI_MODE_REPLACE) {
                 $s .= self::makeLink(
                     $nt,
                     $a_wiki_id,
@@ -238,7 +238,7 @@ class ilWikiUtil
                     $a_offline
                 );
             }
-            if ($a_mode == IL_WIKI_MODE_EXT_COLLECT) {
+            if ($a_mode === IL_WIKI_MODE_EXT_COLLECT) {
                 if (is_object($nt)) {
                     $url_title = self::makeUrlTitle($nt->mTextform);
                     $db_title = self::makeDbTitle($nt->mTextform);
@@ -261,8 +261,8 @@ class ilWikiUtil
 
         //wfProfileOut( $fname );
 
-        if ($a_mode == IL_WIKI_MODE_COLLECT ||
-            $a_mode == IL_WIKI_MODE_EXT_COLLECT) {
+        if ($a_mode === IL_WIKI_MODE_COLLECT ||
+            $a_mode === IL_WIKI_MODE_EXT_COLLECT) {
             return $collect;
         } else {
             return $s;
@@ -312,8 +312,7 @@ class ilWikiUtil
             // remove anchor from text, define anchor
             $anc = "";
             if ($nt->mFragment != "") {
-                if (substr($text, strlen($text) - strlen("#" . $nt->mFragment))
-                    == "#" . $nt->mFragment) {
+                if (substr($text, strlen($text) - strlen("#" . $nt->mFragment)) === "#" . $nt->mFragment) {
                     $text = substr($text, 0, strlen($text) - strlen("#" . $nt->mFragment));
                 }
                 $anc = "#" . $nt->mFragment;
@@ -447,7 +446,7 @@ class ilWikiUtil
 
     public static function sendNotification(
         string $a_action,
-        string $a_type,
+        string $a_type, // TODO PHP8-REVIEW Type is a `string` but is passed to methods expecting an `int`
         int $a_wiki_ref_id,
         int $a_page_id,
         ?string $a_comment = null
@@ -463,10 +462,10 @@ class ilWikiUtil
         $page = new ilWikiPage($a_page_id);
         
         // #11138
-        $ignore_threshold = ($a_action == "comment");
+        $ignore_threshold = ($a_action === "comment");
         
         // 1st update will be converted to new - see below
-        if ($a_action == "new") {
+        if ($a_action === "new") {
             return;
         }
 
@@ -514,7 +513,7 @@ class ilWikiUtil
         $hist = $page->getHistoryEntries();
         $current_version = array_shift($hist);
         $current_version = $current_version["nr"];
-        if (!$current_version && $a_action != "comment") {
+        if (!$current_version && $a_action !== "comment") {
             $a_type = ilNotification::TYPE_WIKI;
             $a_action = "new";
         }
@@ -526,7 +525,7 @@ class ilWikiUtil
                 $ulng = ilLanguageFactory::_getLanguageOfUser($user_id);
                 $ulng->loadLanguageModule('wiki');
 
-                if ($a_action == "comment") {
+                if ($a_action === "comment") {
                     $subject = sprintf($ulng->txt('wiki_notification_comment_subject'), $wiki->getTitle(), $page->getTitle());
                     $message = sprintf($ulng->txt('wiki_change_notification_salutation'), ilObjUser::_lookupFullname($user_id)) . "\n\n";
 

--- a/Modules/Wiki/libs/Sanitizer.php
+++ b/Modules/Wiki/libs/Sanitizer.php
@@ -768,7 +768,7 @@ class Sanitizer
             '%' => '.'
         );
 
-        $id = urlencode(Sanitizer::decodeCharReferences(strtr($id, ' ', '_')));
+        $id = urlencode(Sanitizer::decodeCharReferences(str_replace(' ', '_', $id)));
 
         return str_replace(array_keys($replace), array_values($replace), $id);
     }
@@ -1098,9 +1098,8 @@ class Sanitizer
         if (!isset($list)) {
             $list = Sanitizer::setupAttributeWhitelist();
         }
-        return isset($list[$element])
-            ? $list[$element]
-            : array();
+
+        return $list[$element] ?? array();
     }
 
     /**


### PR DESCRIPTION
Hi @alex40724,

I completed the 3rd part of the review of the `Modules/Wiki` component.

Results:
- [x] The code style is `PSR-2 + X` compliant: 1 File has been changed by the `PHP-CS-FIXER`
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [ ] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

I also fixed some trivial issues reported by my inspection profile.

--

Actions needed:

- [x] I am not sure whether the libraries `Sanitize.php` and `Title.php` are compatible with PHP 8. Please check the list item if you already checked this.
- [ ] Please check my inline comments. Some of them are just information, some require an action. You can use `TODO PHP8-REVIEW` when searching.

Best regards,
@mjansenDatabay