### PR TITLE
PHP8: Code Review `src/DI`

### DIFF
--- a/src/DI/LoggingServices.php
+++ b/src/DI/LoggingServices.php
@@ -17,7 +17,7 @@ namespace ILIAS\DI;
  *
  *****************************************************************************/
 /**
- * Provides fluid interface to RBAC services.
+ * Provides fluid interface to LoggingServices.
  */
 class LoggingServices
 {
@@ -31,17 +31,15 @@ class LoggingServices
     /**
      * Get interface to the global logger.
      */
-    public function root()
+    public function root() : \ilLogger
     {
         return $this->container["ilLoggerFactory"]->getRootLogger();
     }
 
     /**
      * Get a component logger.
-     *
-     * @return	\ilLogger
      */
-    public function __call($method_name, $args)
+    public function __call(string $method_name, array $args) : \ilLogger
     {
         assert(count($args) === 0);
         return $this->container['ilLoggerFactory']->getComponentLogger($method_name);


### PR DESCRIPTION
Hi @chfsx

Here are the results of the `src/DI` review.

### Results

- [x] The code style is PSR-2 + X compliant: _CS-Fixer made changes to 5 files_
- [x] No usage of $_GET / $_POST / $_REQUEST / $_SESSION
- [x] There is a Unit Test Suite with at least one unit test: _There is a suite not containing any tests._
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [ ] The types are fully documented (PHPDoc) or explicit PHP types are used (type hints, return types, typed properties): _There are two return types missing. I think they are given so this PR adds them._

### Changes made in this PR:

- Add return-Types to LoggingServices

Best regards,
@swiniker