### PR TITLE
PHP8: Code Review `src/HTTP`

### DIFF
--- a/src/HTTP/Agent/AgentDetermination.php
+++ b/src/HTTP/Agent/AgentDetermination.php
@@ -133,9 +133,9 @@ class AgentDetermination
             '/android.+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|symbian|treo|up\.(browser|link)|vodafone|wap|windows (ce|phone)|xda|xiino/i',
             $this->user_agent
         ) || preg_match(
-                    '/1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|e\-|e\/|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(di|rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|xda(\-|2|g)|yas\-|your|zeto|zte\-/i',
-                    substr($this->user_agent, 0, 4)
-                )) {
+            '/1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|e\-|e\/|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(di|rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|xda(\-|2|g)|yas\-|your|zeto|zte\-/i',
+            substr($this->user_agent, 0, 4)
+        )) {
             return true;
         } else {
             return false;
@@ -169,9 +169,9 @@ class AgentDetermination
     {
         $var = 'is' . ucfirst($device);
         $return = $this->{$var} ?? (bool) preg_match(
-                '/' . $this->devices[strtolower($device)] . '/i',
-                $this->user_agent
-            );
+            '/' . $this->devices[strtolower($device)] . '/i',
+            $this->user_agent
+        );
         if ($device !== 'generic' && $return === true) {
             $this->is_generic = false;
         }

--- a/src/HTTP/Agent/AgentDetermination.php
+++ b/src/HTTP/Agent/AgentDetermination.php
@@ -120,10 +120,7 @@ class AgentDetermination
         }
     }
     
-    /**
-     * @return bool
-     */
-    public function isMobile()
+    public function isMobile() : bool
     {
         if ($this->is_mobile) {
             return true;
@@ -145,7 +142,6 @@ class AgentDetermination
     /**
      * @param string $name
      * @param array  $arguments
-     * @return bool
      * @throws ilException
      */
     public function __call($name, $arguments)

--- a/src/HTTP/Cookies/CookieJarWrapper.php
+++ b/src/HTTP/Cookies/CookieJarWrapper.php
@@ -30,7 +30,6 @@ use Psr\Http\Message\ResponseInterface;
  */
 class CookieJarWrapper implements CookieJar
 {
-
     private SetCookies $cookies;
 
 

--- a/src/HTTP/Cookies/CookieWrapper.php
+++ b/src/HTTP/Cookies/CookieWrapper.php
@@ -27,7 +27,6 @@ use Dflydev\FigCookies\SetCookie;
  */
 class CookieWrapper implements Cookie
 {
-    
     private SetCookie $cookie;
     
     /**
@@ -107,7 +106,7 @@ class CookieWrapper implements Cookie
      */
     public function withValue(string $value = null) : Cookie
     {
-        $clone         = clone $this;
+        $clone = clone $this;
         $clone->cookie = $this->cookie->withValue($value);
         
         return $clone;
@@ -118,7 +117,7 @@ class CookieWrapper implements Cookie
      */
     public function withExpires($expires = null) : Cookie
     {
-        $clone         = clone $this;
+        $clone = clone $this;
         $clone->cookie = $this->cookie->withExpires($expires);
         
         return $clone;
@@ -129,7 +128,7 @@ class CookieWrapper implements Cookie
      */
     public function rememberForLongTime() : Cookie
     {
-        $clone         = clone $this;
+        $clone = clone $this;
         $clone->cookie = $this->cookie->rememberForever();
         
         return $clone;
@@ -140,7 +139,7 @@ class CookieWrapper implements Cookie
      */
     public function expire() : Cookie
     {
-        $clone         = clone $this;
+        $clone = clone $this;
         $clone->cookie = $this->cookie->expire();
         
         return $clone;
@@ -151,7 +150,7 @@ class CookieWrapper implements Cookie
      */
     public function withMaxAge(int $maxAge = null) : Cookie
     {
-        $clone         = clone $this;
+        $clone = clone $this;
         $clone->cookie = $this->cookie->withMaxAge($maxAge);
         
         return $clone;
@@ -162,7 +161,7 @@ class CookieWrapper implements Cookie
      */
     public function withPath(string $path = null) : Cookie
     {
-        $clone         = clone $this;
+        $clone = clone $this;
         $clone->cookie = $this->cookie->withPath($path);
         
         return $clone;
@@ -173,7 +172,7 @@ class CookieWrapper implements Cookie
      */
     public function withDomain(string $domain = null) : Cookie
     {
-        $clone         = clone $this;
+        $clone = clone $this;
         $clone->cookie = $this->cookie->withDomain($domain);
         
         return $clone;
@@ -184,7 +183,7 @@ class CookieWrapper implements Cookie
      */
     public function withSecure(bool $secure = null) : Cookie
     {
-        $clone         = clone $this;
+        $clone = clone $this;
         $clone->cookie = $this->cookie->withSecure($secure);
         
         return $clone;
@@ -195,7 +194,7 @@ class CookieWrapper implements Cookie
      */
     public function withHttpOnly(bool $httpOnly = null) : Cookie
     {
-        $clone         = clone $this;
+        $clone = clone $this;
         $clone->cookie = $this->cookie->withHttpOnly($httpOnly);
         
         return $clone;

--- a/src/HTTP/GlobalHttpState.php
+++ b/src/HTTP/GlobalHttpState.php
@@ -38,7 +38,6 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 interface GlobalHttpState
 {
-
     public function wrapper() : WrapperFactory;
 
     /**

--- a/src/HTTP/RawHTTPServices.php
+++ b/src/HTTP/RawHTTPServices.php
@@ -31,7 +31,6 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 class RawHTTPServices implements GlobalHttpState
 {
-
     private \ILIAS\HTTP\Response\Sender\ResponseSenderStrategy $sender;
     private \ILIAS\HTTP\Cookies\CookieJarFactory $cookieJarFactory;
     private \ILIAS\HTTP\Request\RequestFactory $requestFactory;

--- a/src/HTTP/Response/Sender/NullResponseSenderStrategy.php
+++ b/src/HTTP/Response/Sender/NullResponseSenderStrategy.php
@@ -33,7 +33,7 @@ class NullResponseSenderStrategy implements ResponseSenderStrategy
      *
      * @param ResponseInterface $response Ignored.
      */
-    public function sendResponse(ResponseInterface $response): void
+    public function sendResponse(ResponseInterface $response) : void
     {
         /** @noRector */
         // nothing to do here

--- a/src/HTTP/Wrapper/ArrayBasedRequestWrapper.php
+++ b/src/HTTP/Wrapper/ArrayBasedRequestWrapper.php
@@ -24,7 +24,6 @@ use ILIAS\Refinery\Transformation;
  */
 class ArrayBasedRequestWrapper implements RequestWrapper
 {
-
     private array $raw_values;
 
 

--- a/src/HTTP/Wrapper/WrapperFactory.php
+++ b/src/HTTP/Wrapper/WrapperFactory.php
@@ -23,7 +23,6 @@ use Psr\Http\Message\RequestInterface;
  */
 class WrapperFactory
 {
-    
     private RequestInterface $request;
     
     /**


### PR DESCRIPTION
Hi @chfsx

Here are the results of the `src/HTTP` review.

### Results

- [ ] The code style is PSR-2 + X compliant: _CS-Fixer made changes to 8 files_
- [ ] No usage of $_GET / $_POST / $_REQUEST / $_SESSION:  _Not relevant_
- [x] There is a Unit Test Suite with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] The types are fully documented (PHPDoc) or explicit PHP types are used (type hints, return types, typed properties): _One litte change in this PR_

### Changes made in this PR:

- Move return type definition from phpdocs to declaration

Best regards,
@swiniker