### PR TITLE
PHP 8: Code Review `jQuery` Part II

### DIFF
--- a/Services/jQuery/classes/class.iljQueryUtil.php
+++ b/Services/jQuery/classes/class.iljQueryUtil.php
@@ -37,7 +37,7 @@ class iljQueryUtil
         global $DIC;
 
         self::$min = "";
-        if ($a_tpl == null) {
+        if ($a_tpl === null) {
             $a_tpl = $DIC["tpl"];
         }
 
@@ -54,7 +54,7 @@ class iljQueryUtil
     {
         global $DIC;
 
-        if ($a_tpl == null) {
+        if ($a_tpl === null) {
             $a_tpl = $DIC["tpl"];
         }
 

--- a/Services/jQuery/test/PathTest.php
+++ b/Services/jQuery/test/PathTest.php
@@ -22,11 +22,6 @@ use PHPUnit\Framework\TestCase;
  */
 class PathTest extends TestCase
 {
-    protected function setUp() : void
-    {
-        parent::setUp();
-    }
-
     protected function tearDown() : void
     {
     }
@@ -34,7 +29,7 @@ class PathTest extends TestCase
     /**
      * Check if we got non empty paths
      */
-    public function testPath()
+    public function testPath() : void
     {
         $this->assertNotEquals(
             "",

--- a/Services/jQuery/test/ilServicesjQuerySuite.php
+++ b/Services/jQuery/test/ilServicesjQuerySuite.php
@@ -22,7 +22,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilServicesjQuerySuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new self();
 


### PR DESCRIPTION
Hi @alex40724, FYI @gvollbach,

I completed the 2nd part of the review of the `Services/jQuery` component.

Results:
- [x] The code style is `PSR-2 + X` compliant: 1 File has been changed by the `PHP-CS-FIXER`
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

I also fixed some trivial issues reported by my inspection profile.

--

Actions needed:

None

Best regards,
@mjansenDatabay