### PR TITLE
PHP 8: Code Review `src/ResourceStorage`

### DIFF
--- a/src/ResourceStorage/Consumer/AbsolutePathConsumer.php
+++ b/src/ResourceStorage/Consumer/AbsolutePathConsumer.php
@@ -37,5 +37,4 @@ class AbsolutePathConsumer extends BaseConsumer
 
         $this->absolute_path = (string) $stream->getMetadata('uri');
     }
-
 }

--- a/src/ResourceStorage/Consumer/BaseConsumer.php
+++ b/src/ResourceStorage/Consumer/BaseConsumer.php
@@ -40,8 +40,7 @@ abstract class BaseConsumer implements DeliveryConsumer
         StorableResource $resource,
         StorageHandler $storage_handler,
         FileNamePolicy $file_name_policy
-    )
-    {
+    ) {
         $this->resource = $resource;
         $this->storage_handler = $storage_handler;
         $this->file_name_policy = $file_name_policy;
@@ -64,5 +63,4 @@ abstract class BaseConsumer implements DeliveryConsumer
         $this->file_name = $file_name;
         return $this;
     }
-
 }

--- a/src/ResourceStorage/Consumer/ConsumerFactory.php
+++ b/src/ResourceStorage/Consumer/ConsumerFactory.php
@@ -26,7 +26,6 @@ use ILIAS\ResourceStorage\Policy\NoneFileNamePolicy;
  */
 class ConsumerFactory
 {
-
     private \ILIAS\ResourceStorage\StorageHandler\StorageHandlerFactory $storage_handler_factory;
     protected \ILIAS\ResourceStorage\Policy\FileNamePolicy $file_name_policy;
 

--- a/src/ResourceStorage/Consumer/Consumers.php
+++ b/src/ResourceStorage/Consumer/Consumers.php
@@ -25,7 +25,6 @@ use ILIAS\ResourceStorage\Resource\ResourceBuilder;
  */
 class Consumers
 {
-
     private \ILIAS\ResourceStorage\Consumer\ConsumerFactory $consumer_factory;
     private \ILIAS\ResourceStorage\Resource\ResourceBuilder $resource_builder;
 

--- a/src/ResourceStorage/Consumer/DownloadConsumer.php
+++ b/src/ResourceStorage/Consumer/DownloadConsumer.php
@@ -23,7 +23,6 @@ use ILIAS\HTTP\Response\ResponseHeader;
  */
 class DownloadConsumer extends BaseConsumer implements DeliveryConsumer
 {
-
     public function run() : void
     {
         global $DIC;
@@ -54,5 +53,4 @@ class DownloadConsumer extends BaseConsumer implements DeliveryConsumer
         $DIC->http()->sendResponse();
         $DIC->http()->close();
     }
-
 }

--- a/src/ResourceStorage/Consumer/FileStreamConsumer.php
+++ b/src/ResourceStorage/Consumer/FileStreamConsumer.php
@@ -55,5 +55,4 @@ class FileStreamConsumer implements StreamConsumer
         $this->revision_number = $revision_number;
         return $this;
     }
-
 }

--- a/src/ResourceStorage/Consumer/GetRevisionTrait.php
+++ b/src/ResourceStorage/Consumer/GetRevisionTrait.php
@@ -40,5 +40,4 @@ trait GetRevisionTrait
         }
         return $revision;
     }
-
 }

--- a/src/ResourceStorage/Consumer/InlineConsumer.php
+++ b/src/ResourceStorage/Consumer/InlineConsumer.php
@@ -23,7 +23,6 @@ use ILIAS\HTTP\Response\ResponseHeader;
  */
 class InlineConsumer extends BaseConsumer implements DeliveryConsumer
 {
-
     public function run() : void
     {
         global $DIC;

--- a/src/ResourceStorage/Consumer/SrcConsumer.php
+++ b/src/ResourceStorage/Consumer/SrcConsumer.php
@@ -57,5 +57,4 @@ class SrcConsumer
         $this->revision_number = $revision_number;
         return $this;
     }
-
 }

--- a/src/ResourceStorage/Consumer/StreamConsumer.php
+++ b/src/ResourceStorage/Consumer/StreamConsumer.php
@@ -23,6 +23,5 @@ use ILIAS\Filesystem\Stream\FileStream;
  */
 interface StreamConsumer
 {
-
     public function getStream() : FileStream;
 }

--- a/src/ResourceStorage/Identification/ResourceIdentification.php
+++ b/src/ResourceStorage/Identification/ResourceIdentification.php
@@ -26,7 +26,6 @@ use Serializable;
  */
 class ResourceIdentification implements Serializable
 {
-
     private string $unique_id;
 
 

--- a/src/ResourceStorage/Information/FileInformation.php
+++ b/src/ResourceStorage/Information/FileInformation.php
@@ -23,7 +23,6 @@ use DateTimeImmutable;
  */
 class FileInformation implements Information
 {
-
     protected string $title = '';
     protected string $suffix = '';
     protected string $mime_type = '';

--- a/src/ResourceStorage/Information/Information.php
+++ b/src/ResourceStorage/Information/Information.php
@@ -23,7 +23,6 @@ use DateTimeImmutable;
  */
 interface Information
 {
-
     public function getTitle() : string;
 
     public function getSuffix() : string;

--- a/src/ResourceStorage/Information/Repository/InformationRepository.php
+++ b/src/ResourceStorage/Information/Repository/InformationRepository.php
@@ -27,7 +27,6 @@ use ILIAS\ResourceStorage\Preloader\PreloadableRepository;
  */
 interface InformationRepository extends LockingRepository, PreloadableRepository
 {
-    
     public function blank() : Information;
 
 

--- a/src/ResourceStorage/Lock/LockHandlerResult.php
+++ b/src/ResourceStorage/Lock/LockHandlerResult.php
@@ -21,6 +21,5 @@ namespace ILIAS\ResourceStorage\Lock;
  */
 interface LockHandlerResult
 {
-
     public function runAndUnlock() : void;
 }

--- a/src/ResourceStorage/Lock/LockHandlerResultilDB.php
+++ b/src/ResourceStorage/Lock/LockHandlerResultilDB.php
@@ -35,5 +35,4 @@ class LockHandlerResultilDB implements LockHandlerResult
     {
         $this->atom->run();
     }
-
 }

--- a/src/ResourceStorage/Lock/LockHandlerilDB.php
+++ b/src/ResourceStorage/Lock/LockHandlerilDB.php
@@ -38,7 +38,7 @@ class LockHandlerilDB implements LockHandler
         foreach ($table_names as $table_name) {
             $lock->addTableLock($table_name);
         }
-        $lock->addQueryCallable(static function (\ilDBInterface $db) use ($during): void {
+        $lock->addQueryCallable(static function (\ilDBInterface $db) use ($during) : void {
             $during();
         });
 

--- a/src/ResourceStorage/Manager/Manager.php
+++ b/src/ResourceStorage/Manager/Manager.php
@@ -77,7 +77,6 @@ class Manager
         ResourceStakeholder $stakeholder,
         string $revision_title = null
     ) : ResourceIdentification {
-
         $info_resolver = new StreamInfoResolver(
             $stream,
             1,

--- a/src/ResourceStorage/Policy/FileNamePolicyException.php
+++ b/src/ResourceStorage/Policy/FileNamePolicyException.php
@@ -21,5 +21,4 @@ namespace ILIAS\ResourceStorage\Policy;
  */
 class FileNamePolicyException extends \ilException
 {
-
 }

--- a/src/ResourceStorage/Policy/FileNamePolicyStack.php
+++ b/src/ResourceStorage/Policy/FileNamePolicyStack.php
@@ -67,5 +67,4 @@ class FileNamePolicyStack implements FileNamePolicy
         }
         return true;
     }
-
 }

--- a/src/ResourceStorage/Policy/NoneFileNamePolicy.php
+++ b/src/ResourceStorage/Policy/NoneFileNamePolicy.php
@@ -41,5 +41,4 @@ class NoneFileNamePolicy implements FileNamePolicy
     {
         return $filename_with_extension;
     }
-
 }

--- a/src/ResourceStorage/Policy/WhiteAndBlacklistedFileNamePolicy.php
+++ b/src/ResourceStorage/Policy/WhiteAndBlacklistedFileNamePolicy.php
@@ -42,22 +42,21 @@ abstract class WhiteAndBlacklistedFileNamePolicy implements FileNamePolicy
         $this->whitelisted = $whitelisted;
     }
     
-    public function isValidExtension(string $extension): bool
+    public function isValidExtension(string $extension) : bool
     {
         return in_array($extension, $this->whitelisted) && !in_array($extension, $this->blacklisted);
     }
     
-    public function isBlockedExtension(string $extension): bool
+    public function isBlockedExtension(string $extension) : bool
     {
         return in_array($extension, $this->blacklisted);
     }
     
-    public function check(string $extension): bool
+    public function check(string $extension) : bool
     {
         if ($this->isBlockedExtension($extension)) {
             throw new FileNamePolicyException("Extension '$extension' is blacklisted.");
         }
         return true;
     }
-    
 }

--- a/src/ResourceStorage/Preloader/PreloadableRepository.php
+++ b/src/ResourceStorage/Preloader/PreloadableRepository.php
@@ -22,7 +22,6 @@ namespace ILIAS\ResourceStorage\Preloader;
  */
 interface PreloadableRepository
 {
-
     public function preload(array $identification_strings) : void;
 
     public function populateFromArray(array $data) : void;

--- a/src/ResourceStorage/Resource/InfoResolver/AbstractInfoResolver.php
+++ b/src/ResourceStorage/Resource/InfoResolver/AbstractInfoResolver.php
@@ -50,5 +50,4 @@ abstract class AbstractInfoResolver implements InfoResolver
     {
         return $this->revision_title;
     }
-
 }

--- a/src/ResourceStorage/Resource/InfoResolver/ClonedRevisionInfoResolver.php
+++ b/src/ResourceStorage/Resource/InfoResolver/ClonedRevisionInfoResolver.php
@@ -78,5 +78,4 @@ class ClonedRevisionInfoResolver implements InfoResolver
     {
         return $this->info->getSize();
     }
-
 }

--- a/src/ResourceStorage/Resource/Repository/ResourceRepository.php
+++ b/src/ResourceStorage/Resource/Repository/ResourceRepository.php
@@ -29,7 +29,6 @@ use ILIAS\ResourceStorage\Preloader\PreloadableRepository;
  */
 interface ResourceRepository extends LockingRepository, PreloadableRepository
 {
-
     public function blank(ResourceIdentification $identification) : StorableResource;
 
 

--- a/src/ResourceStorage/Resource/ResourceBuilder.php
+++ b/src/ResourceStorage/Resource/ResourceBuilder.php
@@ -45,7 +45,6 @@ use ILIAS\ResourceStorage\StorageHandler\StorageHandlerFactory;
  */
 class ResourceBuilder
 {
-
     private \ILIAS\ResourceStorage\Information\Repository\InformationRepository $information_repository;
     private \ILIAS\ResourceStorage\Resource\Repository\ResourceRepository $resource_repository;
     private \ILIAS\ResourceStorage\Revision\Repository\RevisionRepository $revision_repository;
@@ -212,7 +211,6 @@ class ResourceBuilder
             return $resource;
         }
         return $resource;
-
     }
 
     /**
@@ -238,8 +236,7 @@ class ResourceBuilder
             $this->revision_repository->getNamesForLocking(),
             $this->information_repository->getNamesForLocking(),
             $this->stakeholder_repository->getNamesForLocking(),
-
-        ), function () use ($resource): void {
+        ), function () use ($resource) : void {
             $this->resource_repository->store($resource);
 
             foreach ($resource->getAllRevisions() as $revision) {
@@ -285,7 +282,6 @@ class ResourceBuilder
         }
         $this->store($new_resource);
         return $new_resource;
-
     }
 
     /**

--- a/src/ResourceStorage/Resource/StorableFileResource.php
+++ b/src/ResourceStorage/Resource/StorableFileResource.php
@@ -26,7 +26,6 @@ use ILIAS\ResourceStorage\Revision\RevisionCollection;
  */
 class StorableFileResource implements StorableResource
 {
-
     private \ILIAS\ResourceStorage\Identification\ResourceIdentification $identification;
     private \ILIAS\ResourceStorage\Revision\RevisionCollection $revisions;
     /**
@@ -184,5 +183,4 @@ class StorableFileResource implements StorableResource
     {
         return $this->revisions->getMax();
     }
-
 }

--- a/src/ResourceStorage/Resource/StorableResource.php
+++ b/src/ResourceStorage/Resource/StorableResource.php
@@ -26,7 +26,6 @@ use ILIAS\ResourceStorage\Revision\RevisionCollection;
  */
 interface StorableResource
 {
-
     public function getIdentification() : ResourceIdentification;
 
     public function getCurrentRevision() : Revision;

--- a/src/ResourceStorage/Revision/CloneRevision.php
+++ b/src/ResourceStorage/Revision/CloneRevision.php
@@ -25,7 +25,6 @@ use ILIAS\ResourceStorage\Information\Information;
  */
 class CloneRevision implements Revision
 {
-
     protected bool $available = true;
     protected \ILIAS\ResourceStorage\Identification\ResourceIdentification $identification;
     protected int $version_number = 0;
@@ -119,5 +118,4 @@ class CloneRevision implements Revision
     {
         return $this->revision_to_clone;
     }
-
 }

--- a/src/ResourceStorage/Revision/FileRevision.php
+++ b/src/ResourceStorage/Revision/FileRevision.php
@@ -25,7 +25,6 @@ use ILIAS\ResourceStorage\Information\Information;
  */
 class FileRevision implements Revision
 {
-
     protected bool $available = true;
     protected \ILIAS\ResourceStorage\Identification\ResourceIdentification $identification;
     protected int $version_number = 0;
@@ -112,5 +111,4 @@ class FileRevision implements Revision
     {
         return $this->title;
     }
-
 }

--- a/src/ResourceStorage/Revision/FileStreamRevision.php
+++ b/src/ResourceStorage/Revision/FileStreamRevision.php
@@ -25,7 +25,6 @@ use ILIAS\ResourceStorage\Information\FileInformation;
  */
 class FileStreamRevision extends FileRevision implements Revision
 {
-
     private \ILIAS\Filesystem\Stream\FileStream $stream;
     protected bool $keep_original = true;
 
@@ -50,5 +49,4 @@ class FileStreamRevision extends FileRevision implements Revision
     {
         return $this->keep_original;
     }
-
 }

--- a/src/ResourceStorage/Revision/NonMatchingIdentificationException.php
+++ b/src/ResourceStorage/Revision/NonMatchingIdentificationException.php
@@ -23,5 +23,4 @@ use LogicException;
  */
 class NonMatchingIdentificationException extends LogicException
 {
-
 }

--- a/src/ResourceStorage/Revision/NullRevision.php
+++ b/src/ResourceStorage/Revision/NullRevision.php
@@ -26,7 +26,6 @@ use ILIAS\ResourceStorage\Information\Information;
  */
 class NullRevision implements Revision
 {
-
     private \ILIAS\ResourceStorage\Identification\ResourceIdentification $identification;
 
     /**
@@ -94,11 +93,11 @@ class NullRevision implements Revision
     public function setTitle(string $title) : Revision
     {
         // do nothing
+        // @TODO: PHP8 Review: Missing return statement.
     }
 
     public function getTitle() : string
     {
         return '';
     }
-
 }

--- a/src/ResourceStorage/Revision/Repository/RevisionRepository.php
+++ b/src/ResourceStorage/Revision/Repository/RevisionRepository.php
@@ -35,7 +35,6 @@ use ILIAS\ResourceStorage\Preloader\PreloadableRepository;
  */
 interface RevisionRepository extends LockingRepository, PreloadableRepository
 {
-
     public function blankFromUpload(
         InfoResolver $info_resolver,
         StorableResource $resource,

--- a/src/ResourceStorage/Revision/Revision.php
+++ b/src/ResourceStorage/Revision/Revision.php
@@ -32,7 +32,7 @@ interface Revision
 
     public function getInformation() : Information;
 
-    public function setInformation(Information $information);
+    public function setInformation(Information $information);// @TODO: PHP8 Review: Missing return type.
 
     public function setUnavailable() : void;
 

--- a/src/ResourceStorage/Revision/RevisionCollection.php
+++ b/src/ResourceStorage/Revision/RevisionCollection.php
@@ -47,8 +47,10 @@ class RevisionCollection
         }
         foreach ($this->revisions as $r) {
             if ($r->getVersionNumber() === $revision->getVersionNumber()) {
-                throw new RevisionExistsException(sprintf("Can't add already existing version number: %s",
-                    $revision->getVersionNumber()));
+                throw new RevisionExistsException(sprintf(
+                    "Can't add already existing version number: %s",
+                    $revision->getVersionNumber()
+                ));
             }
         }
         $this->revisions[$revision->getVersionNumber()] = $revision;

--- a/src/ResourceStorage/Revision/RevisionExistsException.php
+++ b/src/ResourceStorage/Revision/RevisionExistsException.php
@@ -23,5 +23,4 @@ use LogicException;
  */
 class RevisionExistsException extends LogicException
 {
-
 }

--- a/src/ResourceStorage/Revision/UploadedFileRevision.php
+++ b/src/ResourceStorage/Revision/UploadedFileRevision.php
@@ -26,7 +26,6 @@ use ILIAS\ResourceStorage\Information\FileInformation;
  */
 class UploadedFileRevision extends FileRevision implements Revision
 {
-
     private \ILIAS\FileUpload\DTO\UploadResult $upload;
 
 

--- a/src/ResourceStorage/Services.php
+++ b/src/ResourceStorage/Services.php
@@ -38,7 +38,6 @@ use ILIAS\ResourceStorage\Preloader\StandardRepositoryPreloader;
  */
 class Services
 {
-
     protected \ILIAS\ResourceStorage\Manager\Manager $manager;
     protected \ILIAS\ResourceStorage\Consumer\Consumers $consumers;
     protected \ILIAS\ResourceStorage\Preloader\RepositoryPreloader $preloader;
@@ -71,11 +70,11 @@ class Services
             $file_name_policy_stack
         );
         $this->preloader = $preloader ?? new StandardRepositoryPreloader(
-                $resource_repository,
-                $revision_repository,
-                $information_repository,
-                $stakeholder_repository
-            );
+            $resource_repository,
+            $revision_repository,
+            $information_repository,
+            $stakeholder_repository
+        );
 
         $this->manager = new Manager($b, $this->preloader);
         $this->consumers = new Consumers(
@@ -101,5 +100,4 @@ class Services
     {
         $this->preloader->preload($identification_strings);
     }
-
 }

--- a/src/ResourceStorage/Stakeholder/AbstractResourceStakeholder.php
+++ b/src/ResourceStorage/Stakeholder/AbstractResourceStakeholder.php
@@ -23,7 +23,6 @@ use ILIAS\ResourceStorage\Identification\ResourceIdentification;
  */
 abstract class AbstractResourceStakeholder implements ResourceStakeholder
 {
-
     private string $provider_name_cache = '';
 
     /**

--- a/src/ResourceStorage/StorageHandler/FileSystemBased/AbstractFileSystemStorageHandler.php
+++ b/src/ResourceStorage/StorageHandler/FileSystemBased/AbstractFileSystemStorageHandler.php
@@ -128,8 +128,12 @@ abstract class AbstractFileSystemStorageHandler implements StorageHandler
     {
         global $DIC;
 
-        $DIC->upload()->moveOneFileTo($revision->getUpload(), $this->getRevisionPath($revision), $this->location,
-            self::DATA);
+        $DIC->upload()->moveOneFileTo(
+            $revision->getUpload(),
+            $this->getRevisionPath($revision),
+            $this->location,
+            self::DATA
+        );
 
         return true;
     }
@@ -151,8 +155,10 @@ abstract class AbstractFileSystemStorageHandler implements StorageHandler
                     link($target, $this->getAbsoluteRevisionPath($revision) . '/' . self::DATA);
                     unlink($target);
                 } else {
-                    $this->fs->rename(LegacyPathHelper::createRelativePath($target),
-                        $this->getRevisionPath($revision) . '/' . self::DATA);
+                    $this->fs->rename(
+                        LegacyPathHelper::createRelativePath($target),
+                        $this->getRevisionPath($revision) . '/' . self::DATA
+                    );
                 }
                 $revision->getStream()->close();
             }
@@ -184,9 +190,7 @@ abstract class AbstractFileSystemStorageHandler implements StorageHandler
         try {
             $this->fs->deleteDir($this->getRevisionPath($revision));
         } catch (\Throwable $t) {
-
         }
-
     }
 
     /**
@@ -202,7 +206,6 @@ abstract class AbstractFileSystemStorageHandler implements StorageHandler
             $this->cleanUpContainer($resource);
         } catch (\Throwable $t) {
         }
-
     }
 
     public function cleanUpContainer(StorableResource $resource) : void
@@ -248,5 +251,4 @@ abstract class AbstractFileSystemStorageHandler implements StorageHandler
     {
         return $this->links_possible ? 'link' : 'rename';
     }
-
 }

--- a/src/ResourceStorage/StorageHandler/FileSystemBased/FileSystemStorageHandler.php
+++ b/src/ResourceStorage/StorageHandler/FileSystemBased/FileSystemStorageHandler.php
@@ -53,5 +53,4 @@ class FileSystemStorageHandler extends AbstractFileSystemStorageHandler
     {
         return false;
     }
-
 }

--- a/src/ResourceStorage/StorageHandler/FileSystemBased/MaxNestingFileSystemStorageHandler.php
+++ b/src/ResourceStorage/StorageHandler/FileSystemBased/MaxNestingFileSystemStorageHandler.php
@@ -54,5 +54,4 @@ class MaxNestingFileSystemStorageHandler extends AbstractFileSystemStorageHandle
     {
         return true;
     }
-
 }

--- a/src/ResourceStorage/StorageHandler/Migrator.php
+++ b/src/ResourceStorage/StorageHandler/Migrator.php
@@ -81,7 +81,7 @@ class Migrator
         return false;
     }
 
-    public function removeEmptySubFolders($path) : bool
+    public function removeEmptySubFolders($path) : bool// @TODO: PHP8 Review: Missing parameter type.
     {
         $empty = true;
         foreach (glob($path . DIRECTORY_SEPARATOR . "*") as $file) {

--- a/src/ResourceStorage/StorageHandler/PathGenerator/MaxNestingPathGenerator.php
+++ b/src/ResourceStorage/StorageHandler/PathGenerator/MaxNestingPathGenerator.php
@@ -73,5 +73,4 @@ class MaxNestingPathGenerator implements PathGenerator
 
         return new ResourceIdentification("$p1-$p2-$p3-$p4-$p5");
     }
-
 }

--- a/src/ResourceStorage/StorageHandler/PathGenerator/UUIDBasedPathGenerator.php
+++ b/src/ResourceStorage/StorageHandler/PathGenerator/UUIDBasedPathGenerator.php
@@ -34,5 +34,4 @@ class UUIDBasedPathGenerator implements PathGenerator
     {
         return new ResourceIdentification(str_replace("/", "-", $path));
     }
-
 }


### PR DESCRIPTION
Hi @chfsx,

here are the results of the `src/ResourceStorage` review.

### Results
- [ ] The code style is `PSR-2 + X` compliant.
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`.
- [x] There is a `Unit Test Suite` with at least one unit test.
- [x] The unit tests pass.
- [x] External libraries are compatible with PHP 8 (if relevant).
- [ ] There are no serious `PHPStorm Code Inspection` issues left.
- [ ] The types are fully documented (PHPDoc) or explicit PHP types are used (type hints, return types, typed properties).

### Changes made in this PR:
- Added `// @TODO: PHP8 Review: Missing parameter type.`
- Added `// @TODO: PHP8 Review: Missing return type.`
- Added `// @TODO: PHP8 Review: Missing return statement.`
- Fix `PSR-2 + X`

Best regards,
@lscharmer  