### PR TITLE
PHP8: Code Review `Modules/ItemGroup`

### DIFF
--- a/Modules/ItemGroup/classes/class.ilObjItemGroup.php
+++ b/Modules/ItemGroup/classes/class.ilObjItemGroup.php
@@ -100,12 +100,12 @@ class ilObjItemGroup extends ilObject2
         return $this->item_data_ar->getBehaviour();
     }
 
-    protected function doRead()
+    protected function doRead() : void
     {
         $this->item_data_ar = new ilItemGroupAR($this->getId());
     }
 
-    protected function doCreate()
+    protected function doCreate() : void
     {
         if ($this->getId()) {
             $this->item_data_ar->setId($this->getId());
@@ -113,21 +113,21 @@ class ilObjItemGroup extends ilObject2
         }
     }
         
-    protected function doUpdate()
+    protected function doUpdate() : void
     {
         if ($this->getId()) {
             $this->item_data_ar->update();
         }
     }
 
-    protected function doDelete()
+    protected function doDelete() : void
     {
         if ($this->getId()) {
             $this->item_data_ar->delete();
         }
     }
     
-    protected function doCloneObject($new_obj, $a_target_id, $a_copy_id = null, $a_omit_tree = false)
+    protected function doCloneObject($new_obj, $a_target_id, $a_copy_id = null, $a_omit_tree = false) : void // @TODO: PHP8 Review: Missing parameter type.
     {
         $new_obj->setHideTitle($this->getHideTitle());
         $new_obj->setBehaviour($this->getBehaviour());

--- a/Modules/ItemGroup/classes/class.ilObjItemGroupGUI.php
+++ b/Modules/ItemGroup/classes/class.ilObjItemGroupGUI.php
@@ -29,7 +29,7 @@ class ilObjItemGroupGUI extends ilObject2GUI
     protected ilHelpGUI $help;
 
     public function __construct(
-        ?int $a_id = 0,
+        int $a_id = 0,
         int $a_id_type = self::REPOSITORY_NODE_ID,
         int $a_parent_node_id = 0
     ) {


### PR DESCRIPTION
Hi @alex40724 

Here are the results of the `Modules/ItemGroup` review.

### Results

- [x] The code style is PSR-2 + X compliant: _CS-Fixer made changes to 5 files_
- [x] No usage of $_GET / $_POST / $_REQUEST / $_SESSION
- [x] There is a Unit Test Suite with at least one unit test
- [x] The unit tests pass
- [ ] External libraries are compatible with PHP 8 (if relevant): _Not relevant_
- [ ] The types are fully documented (PHPDoc) or explicit PHP types are used (type hints, return types, typed properties)

### Comments
- The `Services`-Folder is very much a construction site. Most of what is in there doesn't (yet) do anything. How about removing all the classes without function from this version? They can easily be reintroduced after the Split of release_8.
- This type here is rather under specific: https://github.com/ILIAS-eLearning/ILIAS/blob/0c481000999db16b07030815f91c010cacfaa379/Modules/ItemGroup/classes/class.ilItemGroupItemsTableGUI.php#L29 . Can't we make this more specific or at least add a comment to specify what Object we are expecting?

### Changes made in this PR:

- Some small changes in types and a // @TODO: PHP8 Review: Missing parameter type.

Best regards,
@swiniker