### PR TITLE
Restore page scroll on mobile #26915

### DIFF
--- a/src/UI/templates/default/Layout/standardpage.less
+++ b/src/UI/templates/default/Layout/standardpage.less
@@ -327,19 +327,14 @@ footer {
 	// main grid without slates
 	.il-layout-page {
 		background: @body-bg;
-		display: -ms-grid;
-		display: grid;
-		grid-gap: 0px;
-		-ms-grid-columns: 1fr;
-	    grid-template-columns: 1fr;
-		-ms-grid-rows: @il-standard-page-small-header-height auto 1fr;
-	    grid-template-rows: @il-standard-page-small-header-height auto 1fr;
-	    height: 100%;
-		overflow: hidden;
+		display: block;
+		overflow: initial;
 		width: 100%;
 		.nav.il-maincontrols {
-			grid-row: 4;
-			grid-column: 1;
+			position: fixed;
+			bottom: 0;
+			z-index: @il-standard-page-zindex-maincontrols;
+			width: 100%;
 			.il-maincontrols-mainbar {
 				display: grid;
 				display: -ms-grid;
@@ -374,7 +369,7 @@ footer {
 				-ms-grid-row: 3;
 				grid-column: 1;
 				grid-row: 3;
-				height: 100%; // calc(100% - (@il-standard-page-small-header-height + @il-standard-page-breadcrumbs-height);
+				height: calc(100% - @il-standard-page-small-header-height);
 				.il-maincontrols-mainbar {
 					-ms-grid-columns: 1fr;
 				    grid-template-columns: 1fr;
@@ -412,15 +407,15 @@ footer {
 
 	// metabar
 	header {
-		-ms-grid-column: 1;
-		-ms-grid-row: 1;
-		grid-column: 1;
-		grid-row: 1;
-		z-index: @il-standard-page-zindex-header;
+		position: -webkit-sticky;
+		position: sticky;
+		width: 100%;
+		top: 0;
 	}
 
 	// head-container with logo and metabar
 	.header-inner {
+		position: relative;
 	    height: @il-standard-page-small-header-height;
 	    padding: 0;
 	    width: 100%;
@@ -570,16 +565,13 @@ footer {
 	}
 
 	.il-layout-page-content {
-		-ms-grid-column: 1;
-		-ms-grid-row: 3;
-		grid-column: 1;
-		grid-row: 3;
-		overflow: auto;
-	}
-
-	div.il-system-infos {
-		grid-column: 1;
-		-ms-grid-column: 1;
+		display: flex;
+		flex-direction: column;
+		min-height: calc(100vh -  @il-standard-page-small-header-height);
+		padding-bottom: @il-standard-page-small-mainbar-height;
+		> div {
+			flex-grow: 1;
+		}
 	}
 }
 

--- a/src/UI/templates/js/Page/stdpage.js
+++ b/src/UI/templates/js/Page/stdpage.js
@@ -70,10 +70,12 @@ il.UI = il.UI || {};
 
 	})($);
 })($, il.UI);
-il.Util.addOnLoad(function() {
+il.Util.addOnLoad(function () {
 	window.setTimeout(
-		function(){
-			$("main").attr("tabindex", -1).focus();
+		function () {
+			if (il.UI.page.isSmallScreen() === false) {
+				$("main").attr("tabindex", -1).focus();
+			}
 		}, 10
 	);
 });

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -9270,20 +9270,15 @@ footer {
 @media only screen and (max-width: 768px) {
   .il-layout-page {
     background: #f0f0f0;
-    display: -ms-grid;
-    display: grid;
-    grid-gap: 0px;
-    -ms-grid-columns: 1fr;
-    grid-template-columns: 1fr;
-    -ms-grid-rows: 45px auto 1fr;
-    grid-template-rows: 45px auto 1fr;
-    height: 100%;
-    overflow: hidden;
+    display: block;
+    overflow: initial;
     width: 100%;
   }
   .il-layout-page .nav.il-maincontrols {
-    grid-row: 4;
-    grid-column: 1;
+    position: fixed;
+    bottom: 0;
+    z-index: 997;
+    width: 100%;
   }
   .il-layout-page .nav.il-maincontrols .il-maincontrols-mainbar {
     display: grid;
@@ -9318,7 +9313,7 @@ footer {
     -ms-grid-row: 3;
     grid-column: 1;
     grid-row: 3;
-    height: 100%;
+    height: calc(100% - 45px);
   }
   .il-layout-page.with-mainbar-slates-engaged .nav.il-maincontrols .il-maincontrols-mainbar {
     -ms-grid-columns: 1fr;
@@ -9349,13 +9344,13 @@ footer {
     display: none;
   }
   header {
-    -ms-grid-column: 1;
-    -ms-grid-row: 1;
-    grid-column: 1;
-    grid-row: 1;
-    z-index: 999;
+    position: -webkit-sticky;
+    position: sticky;
+    width: 100%;
+    top: 0;
   }
   .header-inner {
+    position: relative;
     height: 45px;
     padding: 0;
     width: 100%;
@@ -9465,15 +9460,13 @@ footer {
     display: block;
   }
   .il-layout-page-content {
-    -ms-grid-column: 1;
-    -ms-grid-row: 3;
-    grid-column: 1;
-    grid-row: 3;
-    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    min-height: calc(100vh - 45px);
+    padding-bottom: 50px;
   }
-  div.il-system-infos {
-    grid-column: 1;
-    -ms-grid-column: 1;
+  .il-layout-page-content > div {
+    flex-grow: 1;
   }
 }
 /*
@@ -11844,6 +11837,14 @@ body {
 @media only screen and (max-width: 768px) {
   html {
     -webkit-text-size-adjust: none;
+  }
+}
+@media only screen and (max-width: 768px) {
+  html,
+  body {
+    overflow: initial;
+    height: auto;
+    min-height: 100vh;
   }
 }
 /* see bug ILIAS bug #17589 and http://stackoverflow.com/questions/17045132/scrollbar-overlay-in-ie10-how-do-you-stop-that */

--- a/templates/default/delos.less
+++ b/templates/default/delos.less
@@ -369,6 +369,13 @@ html {
 		-webkit-text-size-adjust: none;
 	}
 }
+html, body {
+	@media only screen and (max-width: @grid-float-breakpoint-max) {
+		overflow: initial;
+		height: auto;
+		min-height: 100vh;
+	}
+}
 /* see bug ILIAS bug #17589 and http://stackoverflow.com/questions/17045132/scrollbar-overlay-in-ie10-how-do-you-stop-that */
 body{
 	-ms-overflow-style: scrollbar;


### PR DESCRIPTION
# Issue

Mantis Issue: https://mantis.ilias.de/view.php?id=26915

**Mobile browsers usually hide the address bar and other system or browser UI elements after a certain scrolling distanc**e on the webpage. In ILIAS those elements didn't disappear as they do on other websites.

This happens because the main container in ILIAS is affixed in a CSS grid. Instead of scrolling the actual page, the user would scroll inside a container on an unmoving page. This already caused the need for other fixes e.g. https://mantis.ilias.de/view.php?id=27270 to enable scrolling with the keyboard arrows.

# Changes

All of these changes effect only the mobile breakpoint:
* Switched the layout from a CSS grid to a more conventional setup that keeps **as many elements as possible in the document flow**
* The **overlapping header is solved through position: sticky**, which keeps it inside the document flow until scrolling begins. I chose this over position: fixed so we don't need to reserve any space through margin/padding-top "under" the header. While the legacy IE is unsupported, big websites like spiegel.de are using position: sticky for their header.
* Because of the mainbar's middle position in the DOM structure position: sticky cannot be used for it. Therefor, the mainbar is ripped out of the document flow with position: fixed and a padding-bottom creates sufficient space so that the footer can scroll all the way up from under the mainbar. Maybe this can be improved if we also revise the desktop breakpoint.
* The main container now uses a flexbox layout to push the footer to the bottom as the complexitiy of a grid with columns isn't needed for this screen size. This also might be worth considering for the desktop version.
* With a normal document flow restored, the Javascript put in place to fix https://mantis.ilias.de/view.php?id=27270 caused the mobile page to scroll down to the upper edge of the main container, which caused the page to jump and looked like the header was overlapping the page title immediately after loading. This is why the script now checks for screen size and causes the focus switch on desktop only.

# Test Pages

Page with some content to test scrolling: https://dev.cate-tms.de/ilias7mobile/goto.php?target=cat_85&client_id=ilias
Empty page to test fixed footer: https://dev.cate-tms.de/ilias7mobile/goto.php?target=cat_86&client_id=ilias

# Outlook and bigger context

I discussed this issue with @catkrahl who worked on the initial implementation of the CSS grid. We debated if keeping the CSS grid on desktop is even worth it as detecting alternative layouts (e.g. kiosk mode) are tricky to handle. Having two plugins adding elements to the standard page could cause unsolvable problems as the CSS grid layout can only handle one overwrite at a time.

In the long term, we might want to look into restoring a document flow that could handle the re-ordering and inserting elements more dynamically - maybe for the whole page, maybe just for the inner grids.