### PR TITLE
PHP 8: Code Review `SystemCheck`

### DIFF
--- a/Services/SystemCheck/classes/Setup/class.ilSystemCheckDefinitionProcessor.php
+++ b/Services/SystemCheck/classes/Setup/class.ilSystemCheckDefinitionProcessor.php
@@ -46,7 +46,7 @@ class ilSystemCheckDefinitionProcessor implements ilComponentDefinitionProcessor
         }
         if ($name === "systemcheck_task") {
             $group_id = ilSCGroups::getInstance()->lookupGroupByComponentId($this->component_id);
-            $tasks    = ilSCTasks::getInstanceByGroupId($group_id);
+            $tasks = ilSCTasks::getInstanceByGroupId($group_id);
             $tasks->updateFromComponentDefinition((string) ($attributes['identifier'] ?? ''));
         }
     }

--- a/Services/SystemCheck/classes/class.ilObjSystemCheck.php
+++ b/Services/SystemCheck/classes/class.ilObjSystemCheck.php
@@ -6,7 +6,6 @@
  */
 class ilObjSystemCheck extends ilObject
 {
-
     public function __construct(int $a_id = 0, bool $a_call_by_reference = true)
     {
         $this->type = 'sysc';

--- a/Services/SystemCheck/classes/class.ilObjSystemCheckGUI.php
+++ b/Services/SystemCheck/classes/class.ilObjSystemCheckGUI.php
@@ -88,7 +88,7 @@ class ilObjSystemCheckGUI extends ilObjectGUI
 
             case '':
             case 'ilobjsystemcheckgui':
-                if ($cmd == '' || $cmd == 'view') {
+                if ($cmd === null || $cmd === '' || $cmd === 'view') {
                     $cmd = 'overview';
                 }
                 $this->$cmd();
@@ -196,7 +196,7 @@ class ilObjSystemCheckGUI extends ilObjectGUI
         $options = array();
         $options[0] = '';
         foreach ($sub_objects as $obj_type) {
-            if (!$this->obj_definition->isRBACObject($obj_type) or !$this->obj_definition->isAllowedInRepository($obj_type)) {
+            if (!$this->obj_definition->isRBACObject($obj_type) || !$this->obj_definition->isAllowedInRepository($obj_type)) {
                 continue;
             }
             $options[$obj_type] = $this->lng->txt('obj_' . $obj_type);

--- a/Services/SystemCheck/classes/class.ilSCComponentTaskFactory.php
+++ b/Services/SystemCheck/classes/class.ilSCComponentTaskFactory.php
@@ -8,10 +8,8 @@
  */
 class ilSCComponentTaskFactory
 {
-
     public static function getComponentTaskGUIForGroup(int $a_group_id, ?int $a_task_id = null) : ?ilSCComponentTaskGUI
     {
-
         $component_id = ilSCGroup::lookupComponent($a_group_id);
 
         $task = null;
@@ -34,7 +32,7 @@ class ilSCComponentTaskFactory
         $component_id = ilSCGroup::lookupComponent($a_group_id);
         switch ($component_id) {
             case 'tree':
-                if (ilSCTasks::lookupIdentifierForTask($a_task_id) == ilSCTreeTasksGUI::TYPE_DUMP) {
+                if (ilSCTasks::lookupIdentifierForTask($a_task_id) === ilSCTreeTasksGUI::TYPE_DUMP) {
                     return new ilSCTreeDumpTask($a_task_id);
                 }
         }
@@ -43,7 +41,6 @@ class ilSCComponentTaskFactory
 
     public static function getComponentTask(int $a_task_id) : ilSCTreeTasksGUI
     {
-
         $group_id = ilSCTasks::lookupGroupId($a_task_id);
 
         return self::getComponentTaskGUIForGroup($group_id, $a_task_id);

--- a/Services/SystemCheck/classes/class.ilSCComponentTaskGUI.php
+++ b/Services/SystemCheck/classes/class.ilSCComponentTaskGUI.php
@@ -20,8 +20,8 @@ abstract class ilSCComponentTaskGUI
         $this->task = $task;
 
         $this->ctrl = $DIC->ctrl();
-        $this->lng  = $DIC->language();
-        $this->tpl  = $DIC->ui()->mainTemplate();
+        $this->lng = $DIC->language();
+        $this->tpl = $DIC->ui()->mainTemplate();
     }
 
     /**
@@ -58,7 +58,7 @@ abstract class ilSCComponentTaskGUI
     public function executeCommand() : void
     {
         $next_class = $this->getCtrl()->getNextClass($this);
-        $cmd        = $this->getCtrl()->getCmd();
+        $cmd = $this->getCtrl()->getCmd();
 
         switch ($next_class) {
             default:

--- a/Services/SystemCheck/classes/class.ilSCCronTrash.php
+++ b/Services/SystemCheck/classes/class.ilSCCronTrash.php
@@ -15,8 +15,8 @@ class ilSCCronTrash extends ilCronJob
     {
         global $DIC;
 
-        $this->lng           = $DIC->language();
-        $this->tree          = $DIC->repositoryTree();
+        $this->lng = $DIC->language();
+        $this->tree = $DIC->repositoryTree();
         $this->objDefinition = $DIC['objDefinition'];
         $this->lng->loadLanguageModule('sysc');
     }
@@ -72,9 +72,8 @@ class ilSCCronTrash extends ilCronJob
         return true;
     }
 
-    public function addCustomSettingsToForm(ilPropertyFormGUI $form) : void
+    public function addCustomSettingsToForm(ilPropertyFormGUI $a_form) : void
     {
-
         $this->lng->loadLanguageModule('sysc');
 
         $settings = new ilSetting('sysc');
@@ -85,7 +84,7 @@ class ilSCCronTrash extends ilCronJob
         $num->setSize(10);
         $num->setMinValue(1);
         $num->setValue($settings->get('num', ''));
-        $form->addItem($num);
+        $a_form->addItem($num);
 
         $age = new ilNumberInputGUI($this->lng->txt('sysc_trash_limit_age'), 'age');
         $age->setInfo($this->lng->txt('purge_age_limit_desc'));
@@ -97,16 +96,16 @@ class ilSCCronTrash extends ilCronJob
             $age->setValue($settings->get('age', ''));
         }
 
-        $form->addItem($age);
+        $a_form->addItem($age);
 
         // limit types
-        $types       = new ilSelectInputGUI($this->lng->txt('sysc_trash_limit_type'), 'types');
+        $types = new ilSelectInputGUI($this->lng->txt('sysc_trash_limit_type'), 'types');
         $sub_objects = $this->tree->lookupTrashedObjectTypes();
 
-        $options    = array();
+        $options = array();
         $options[0] = '';
         foreach ($sub_objects as $obj_type) {
-            if (!$this->objDefinition->isRBACObject($obj_type) or !$this->objDefinition->isAllowedInRepository($obj_type)) {
+            if (!$this->objDefinition->isRBACObject($obj_type) || !$this->objDefinition->isAllowedInRepository($obj_type)) {
                 continue;
             }
             $options[$obj_type] = $this->lng->txt('obj_' . $obj_type);
@@ -114,12 +113,11 @@ class ilSCCronTrash extends ilCronJob
         asort($options);
         $types->setOptions($options);
         $types->setValue($settings->get('types', ''));
-        $form->addItem($types);
+        $a_form->addItem($types);
     }
 
     public function saveCustomSettings(ilPropertyFormGUI $a_form) : bool
     {
-
         $settings = new ilSetting('sysc');
 
         $settings->set('num', $a_form->getInput('number'));
@@ -131,7 +129,6 @@ class ilSCCronTrash extends ilCronJob
 
     public function run() : ilCronJobResult
     {
-
         $trash = new ilSystemCheckTrash();
         $trash->setMode(ilSystemCheckTrash::MODE_TRASH_REMOVE);
 

--- a/Services/SystemCheck/classes/class.ilSCGroup.php
+++ b/Services/SystemCheck/classes/class.ilSCGroup.php
@@ -31,7 +31,7 @@ class ilSCGroup
 
         $query = 'SELECT component FROM sysc_groups ' .
             'WHERE id = ' . $ilDB->quote($a_id, ilDBConstants::T_INTEGER);
-        $res   = $ilDB->query($query);
+        $res = $ilDB->query($query);
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             return (string) $row->component;
         }
@@ -78,15 +78,13 @@ class ilSCGroup
 
     public function read() : bool
     {
-
-
         if (!$this->getId()) {
             return false;
         }
 
         $query = 'SELECT * FROM sysc_groups ' .
             'WHERE id = ' . $this->db->quote($this->getId(), ilDBConstants::T_INTEGER);
-        $res   = $this->db->query($query);
+        $res = $this->db->query($query);
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             $this->setComponentId($row->component);
             $this->setLastUpdate(new ilDateTime($row->last_update, IL_CAL_DATETIME, ilTimeZone::UTC));
@@ -97,8 +95,6 @@ class ilSCGroup
 
     public function create() : int
     {
-
-
         $this->id = $this->db->nextId('sysc_groups');
 
         $query = 'INSERT INTO sysc_groups (id,component,status) ' .

--- a/Services/SystemCheck/classes/class.ilSCGroups.php
+++ b/Services/SystemCheck/classes/class.ilSCGroups.php
@@ -8,8 +8,7 @@
  */
 class ilSCGroups
 {
-
-    private static ilSCGroups $instance;
+    private static ?ilSCGroups $instance = null;
 
     private array $groups = array();
 
@@ -25,16 +24,13 @@ class ilSCGroups
 
     public static function getInstance() : ilSCGroups
     {
-        if (!self::$instance instanceof ilSCGroups) {
-            return self::$instance = new self();
-        }
-        return self::$instance;
+        return self::$instance ?? (self::$instance = new self());
     }
 
     public function updateFromComponentDefinition(string $a_component_id) : int
     {
         foreach ($this->getGroups() as $group) {
-            if ($group->getComponentId() == $a_component_id) {
+            if ($group->getComponentId() === $a_component_id) {
                 return $group->getId();
             }
         }
@@ -48,10 +44,9 @@ class ilSCGroups
 
     public function lookupGroupByComponentId(string $a_component_id) : int
     {
-
         $query = 'SELECT id FROM sysc_groups ' .
             'WHERE component = ' . $this->db->quote($a_component_id, ilDBConstants::T_TEXT);
-        $res   = $this->db->query($query);
+        $res = $this->db->query($query);
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             return $row->id;
         }
@@ -68,10 +63,9 @@ class ilSCGroups
 
     protected function read() : void
     {
-
         $query = 'SELECT id FROM sysc_groups ' .
             'ORDER BY id ';
-        $res   = $this->db->query($query);
+        $res = $this->db->query($query);
 
         $this->groups = array();
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {

--- a/Services/SystemCheck/classes/class.ilSCTask.php
+++ b/Services/SystemCheck/classes/class.ilSCTask.php
@@ -85,15 +85,13 @@ class ilSCTask
 
     public function read() : bool
     {
-
-
         if (!$this->getId()) {
             return false;
         }
 
         $query = 'SELECT * FROM sysc_tasks ' .
             'WHERE id = ' . $this->db->quote($this->getId(), ilDBConstants::T_INTEGER);
-        $res   = $this->db->query($query);
+        $res = $this->db->query($query);
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             $this->setGroupId($row->grp_id);
             $this->setLastUpdate(new ilDateTime($row->last_update, IL_CAL_DATETIME, ilTimeZone::UTC));
@@ -105,8 +103,6 @@ class ilSCTask
 
     public function create() : int
     {
-
-
         $this->id = $this->db->nextId('sysc_tasks');
 
         $query = 'INSERT INTO sysc_tasks (id,grp_id,status,identifier) ' .
@@ -122,7 +118,6 @@ class ilSCTask
 
     public function update() : void
     {
-
         $query = 'UPDATE sysc_tasks SET ' .
             'last_update = ' . $this->db->quote($this->getLastUpdate()->get(IL_CAL_DATETIME, '', ilTimeZone::UTC), ilDBConstants::T_TIMESTAMP) . ', ' .
             'status = ' . $this->db->quote($this->getStatus(), ilDBConstants::T_INTEGER) . ', ' .

--- a/Services/SystemCheck/classes/class.ilSCTaskTableGUI.php
+++ b/Services/SystemCheck/classes/class.ilSCTaskTableGUI.php
@@ -9,7 +9,6 @@
 class ilSCTaskTableGUI extends ilTable2GUI
 {
     private int $group_id = 0;
-    private $component_task_handler = null;
 
     private ilAccess $access;
 

--- a/Services/SystemCheck/classes/class.ilSCTasks.php
+++ b/Services/SystemCheck/classes/class.ilSCTasks.php
@@ -8,7 +8,6 @@
  */
 class ilSCTasks
 {
-
     private static array $instances = array();
 
     private int $grp_id = 0;
@@ -20,7 +19,7 @@ class ilSCTasks
     {
         global $DIC;
 
-        $this->db     = $DIC->database();
+        $this->db = $DIC->database();
         $this->grp_id = $a_grp_id;
         $this->read();
     }
@@ -40,10 +39,10 @@ class ilSCTasks
     {
         global $DIC;
 
-        $db    = $DIC->database();
+        $db = $DIC->database();
         $query = 'select identifier from sysc_tasks ' .
             'where id = ' . $db->quote($a_task_id, ilDBConstants::T_INTEGER);
-        $res   = $db->query($query);
+        $res = $db->query($query);
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             return $row->identifier;
         }
@@ -53,7 +52,7 @@ class ilSCTasks
     public function updateFromComponentDefinition(string $a_identifier) : int
     {
         foreach ($this->getTasks() as $task) {
-            if ($task->getIdentifier() == $a_identifier) {
+            if ($task->getIdentifier() === $a_identifier) {
                 return 1;
             }
         }
@@ -74,7 +73,7 @@ class ilSCTasks
 
         $query = 'SELECT grp_id FROM sysc_tasks ' .
             'WHERE id = ' . $ilDB->quote($a_task_id, ilDBConstants::T_INTEGER);
-        $res   = $ilDB->query($query);
+        $res = $ilDB->query($query);
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             return $row->grp_id;
         }
@@ -90,7 +89,7 @@ class ilSCTasks
             if (!$task->isActive()) {
                 continue;
             }
-            if ($task->getStatus() == ilSCTask::STATUS_COMPLETED) {
+            if ($task->getStatus() === ilSCTask::STATUS_COMPLETED) {
                 $num_completed++;
             }
         }
@@ -107,7 +106,7 @@ class ilSCTasks
                 continue;
             }
 
-            if ($task->getStatus() == ilSCTask::STATUS_FAILED) {
+            if ($task->getStatus() === ilSCTask::STATUS_FAILED) {
                 $num_failed++;
             }
         }
@@ -123,7 +122,7 @@ class ilSCTasks
         $query = 'SELECT MAX(last_update) last_update FROM sysc_tasks ' .
             'WHERE status = ' . $ilDB->quote(ilSCTask::STATUS_FAILED, ilDBConstants::T_INTEGER) . ' ' .
             'AND grp_id = ' . $ilDB->quote($a_grp_id, ilDBConstants::T_INTEGER);
-        $res   = $ilDB->query($query);
+        $res = $ilDB->query($query);
 
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             return new ilDateTime($row->last_update, IL_CAL_DATETIME, ilTimeZone::UTC);
@@ -146,10 +145,9 @@ class ilSCTasks
 
     protected function read() : void
     {
-
         $query = 'SELECT id, grp_id FROM sysc_tasks ' .
             'ORDER BY id ';
-        $res   = $this->db->query($query);
+        $res = $this->db->query($query);
 
         $this->tasks = array();
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {

--- a/Services/SystemCheck/classes/class.ilSystemCheckTrash.php
+++ b/Services/SystemCheck/classes/class.ilSystemCheckTrash.php
@@ -23,9 +23,9 @@ class ilSystemCheckTrash
         global $DIC;
 
         $this->logger = $DIC->logger()->sysc();
-        $this->db     = $DIC->database();
-        $this->tree   = $DIC->repositoryTree();
-        $this->admin  = $DIC->rbac()->admin();
+        $this->db = $DIC->database();
+        $this->tree = $DIC->repositoryTree();
+        $this->admin = $DIC->rbac()->admin();
 
         $this->limit_age = new ilDate(0, IL_CAL_UNIX);
     }
@@ -101,7 +101,7 @@ class ilSystemCheckTrash
 
         foreach ($deleted as $tmp_num => $deleted_info) {
             $child_id = (int) ($deleted_info['child'] ?? 0);
-            $ref_obj  = ilObjectFactory::getInstanceByRefId($child_id, false);
+            $ref_obj = ilObjectFactory::getInstanceByRefId($child_id, false);
             if (!$ref_obj instanceof ilObject) {
                 continue;
             }
@@ -109,7 +109,7 @@ class ilSystemCheckTrash
             $this->tree->deleteNode((int) ($deleted_info['tree'] ?? 0), $child_id);
             $this->logger->info('Object tree entry deleted');
 
-            if ($ref_obj->getType() != 'rolf') {
+            if ($ref_obj->getType() !== 'rolf') {
                 $this->admin->revokePermission($child_id);
                 $ref_obj->putInTree(RECOVERY_FOLDER_ID);
                 $ref_obj->setPermissions(RECOVERY_FOLDER_ID);
@@ -120,7 +120,6 @@ class ilSystemCheckTrash
 
     protected function removeSelectedFromSystem() : void
     {
-
         $deleted = $this->readSelectedDeleted();
         foreach ($deleted as $del_num => $deleted_info) {
             $sub_nodes = $this->readDeleted((int) ($deleted_info['tree'] ?? 0));
@@ -139,7 +138,6 @@ class ilSystemCheckTrash
 
     protected function readSelectedDeleted() : array
     {
-
         $and_types = '';
         $this->logger->dump($this->getTypesLimit());
 
@@ -153,7 +151,7 @@ class ilSystemCheckTrash
             $and_types = 'AND ' . $this->db->in('o.type', $this->getTypesLimit(), false, ilDBConstants::T_TEXT) . ' ';
         }
 
-        $and_age   = '';
+        $and_age = '';
         $age_limit = $this->getAgeLimit()->get(IL_CAL_UNIX);
         if ($age_limit > 0) {
             $and_age = 'AND r.deleted < ' . $this->db->quote($this->getAgeLimit()->get(IL_CAL_DATETIME)) . ' ';
@@ -176,10 +174,10 @@ class ilSystemCheckTrash
         $this->logger->info($query);
 
         $deleted = array();
-        $res     = $this->db->query($query);
+        $res = $this->db->query($query);
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             $deleted[] = array(
-                'tree'  => $row->tree,
+                'tree' => $row->tree,
                 'child' => $row->child
             );
         }
@@ -188,7 +186,6 @@ class ilSystemCheckTrash
 
     protected function readDeleted(?int $tree_id = null) : array
     {
-
         $query = 'SELECT child,tree FROM tree t JOIN object_reference r ON child = r.ref_id ' .
             'JOIN object_data o on r.obj_id = o.obj_id ';
 
@@ -204,7 +201,7 @@ class ilSystemCheckTrash
         $deleted = array();
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             $deleted[] = array(
-                'tree'  => $row->tree,
+                'tree' => $row->tree,
                 'child' => $row->child
             );
         }


### PR DESCRIPTION
Hello @smeyer-ilias, 

I completed the review of the `Services/SystemCheck` component.

Results:

- [ ] The code style is `PSR-2 + X` compliant
- [ ] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [ ] There is a `Unit Test Suite` with at least one unit test
- [ ] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [ ] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

--

Actions needed:
- [ ] Please add a unit test suite with at least one passing unit test

Best regards,
@mjansenDatabay  