### PR TITLE
PHP 8: Code Review `Survey` Part II

### DIFF
--- a/Modules/Survey/Participants/class.StatusManager.php
+++ b/Modules/Survey/Participants/class.StatusManager.php
@@ -31,7 +31,7 @@ class StatusManager
     protected int $user_id;
     protected \ILIAS\Survey\Access\AccessManager $access;
     protected \ILIAS\Survey\Mode\FeatureConfig $feature_config;
-    protected $repo_service;
+    protected InternalRepoService $repo_service;
 
     public function __construct(
         InternalDomainService $domain_service,

--- a/Modules/Survey/Skills/class.ilSurveySkillExplorer.php
+++ b/Modules/Survey/Skills/class.ilSurveySkillExplorer.php
@@ -26,8 +26,8 @@ class ilSurveySkillExplorer extends ilExplorer
     protected array $force_open_path;
     protected ilObjUser $user;
     protected ilCtrl $ctrl;
-    protected $all_nodes = [];
-    protected $child_nodes = [];
+    protected array $all_nodes = [];
+    protected array $child_nodes = [];
 
     public function __construct(
         string $a_target,

--- a/Modules/Survey/Skills/class.ilSurveySkillThresholdsTableGUI.php
+++ b/Modules/Survey/Skills/class.ilSurveySkillThresholdsTableGUI.php
@@ -85,15 +85,8 @@ class ilSurveySkillThresholdsTableGUI extends ilTable2GUI
             $this->tref_id
         );
     }
-    
-    
-    /**
-     * Get levels
-     *
-     * @param
-     * @return
-     */
-    public function getLevels()
+
+    public function getLevels() : array
     {
         $bs = new ilBasicSkill($this->base_skill_id);
         return $bs->getLevelData();

--- a/Modules/Survey/classes/class.ilObjSurvey.php
+++ b/Modules/Survey/classes/class.ilObjSurvey.php
@@ -1344,7 +1344,7 @@ class ilObjSurvey extends ilObject
     public function getQuestionpoolTitles(
         bool $could_be_offline = false,
         bool $showPath = false
-    ) {
+    ) : array {
         return ilObjSurveyQuestionPool::_getAvailableQuestionpools(true, $could_be_offline, $showPath);
     }
     

--- a/Modules/SurveyQuestionPool/Export/class.ilSurveyQuestionPoolExporter.php
+++ b/Modules/SurveyQuestionPool/Export/class.ilSurveyQuestionPoolExporter.php
@@ -20,7 +20,7 @@
  */
 class ilSurveyQuestionPoolExporter extends ilXmlExporter
 {
-    private $ds;
+    private $ds;// TODO PHP8-REVIEW A type is missing here
 
     public function init() : void
     {

--- a/Modules/SurveyQuestionPool/Questions/class.SurveyQuestion.php
+++ b/Modules/SurveyQuestionPool/Questions/class.SurveyQuestion.php
@@ -43,10 +43,7 @@ class SurveyQuestion
     private array $arrData;         //  question data
     protected ilLogger $log;
 
-    /**
-     * @var \ILIAS\SurveyQuestionPool\Export\ImportSessionRepository
-     */
-    protected $import_manager;
+    protected \ILIAS\SurveyQuestionPool\Export\ImportSessionRepository $import_manager;
 
     public function __construct(
         string $title = "",
@@ -254,7 +251,7 @@ class SurveyQuestion
         return $this->id;
     }
 
-    public function getObligatory()
+    public function getObligatory() : bool
     {
         return $this->obligatory;
     }
@@ -1671,7 +1668,7 @@ class SurveyQuestion
     
     public function hasCopies() : bool
     {
-        return (bool) sizeof($this->getCopyIds());
+        return (bool) count($this->getCopyIds());
     }
     
     public static function _lookupSurveyObjId(

--- a/Modules/SurveyQuestionPool/Questions/class.SurveyTextQuestion.php
+++ b/Modules/SurveyQuestionPool/Questions/class.SurveyTextQuestion.php
@@ -137,7 +137,7 @@ class SurveyTextQuestion extends SurveyQuestion
     public function toXML(
         bool $a_include_header = true,
         bool $obligatory_state = false
-    ) {
+    ) : string {
         $a_xml_writer = new ilXmlWriter();
         $a_xml_writer->xmlHeader();
         $this->insertXML($a_xml_writer, $a_include_header);

--- a/Services/Survey/classes/class.SurveyImportParser.php
+++ b/Services/Survey/classes/class.SurveyImportParser.php
@@ -23,7 +23,7 @@ class SurveyImportParser extends ilSaxParser
     protected int $showQuestiontext;
     protected int $showBlocktitle;
     protected int $compressView;
-    public $path;
+    public $path;// TODO PHP8-Review All types below are not typed
     public $depth;
     public $activequestion;
     public $spl;
@@ -74,7 +74,7 @@ class SurveyImportParser extends ilSaxParser
     public function __construct($a_spl_id, ?string $a_xml_file = '', $spl_exists = false, $a_mapping = null)
     {
         parent::__construct($a_xml_file);
-        $this->spl_id = $a_spl_id;
+        $this->spl_id = $a_spl_id;// TODO PHP8-Review This property is dynamically declared
         $this->has_error = false;
         $this->characterbuffer = "";
         $this->survey_status = 0;
@@ -106,7 +106,7 @@ class SurveyImportParser extends ilSaxParser
         $this->showBlocktitle = 0;
         $this->compressView = 0;
         $this->questionblocktitle = "";
-        $this->mapping = $a_mapping;
+        $this->mapping = $a_mapping;// TODO PHP8-Review This property is dynamically declared
     }
 
     /**
@@ -139,10 +139,10 @@ class SurveyImportParser extends ilSaxParser
     }
 
     /**
-    * parse xml file
-    *
-    * @access	private
-    */
+     * @param resource|XMLParser $a_xml_parser
+     * @param resource|null $a_fp
+     * @return void
+     */
     public function parse($a_xml_parser, $a_fp = null) : void
     {
         switch ($this->getInputType()) {


### PR DESCRIPTION
Hi @alex40724,

this is the 2nd review of the `Modules/Survey`, `Modules/SurveyQuestionPool` and (most important, because I did not know this directory exists) `Services/Survey` components.

This component looked very good, but of course I found some issues.

Results:
- [x] The code style is `PSR-2 + X` compliant: 1 File has been changed by the `PHP-CS-FIXER`
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [ ] There is a `Unit Test Suite` with at least one unit test
- [ ] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [ ] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

--

Actions needed:
- [ ] Please check my inline comments. Some of them are just information, some require an action. You can use `TODO PHP8-REVIEW` when searching.
- [ ] The question is: Do we need a separate test suite for `Services/Survey`?

Best regards,
@mjansenDatabay