### PR TITLE
PHP 8: Code Review `Registration`

### DIFF
--- a/Services/Registration/classes/class.ilAccountRegistrationGUI.php
+++ b/Services/Registration/classes/class.ilAccountRegistrationGUI.php
@@ -92,7 +92,7 @@ class ilAccountRegistrationGUI
 
     public function displayForm() : ilTemplate
     {
-        $tpl = ilStartUpGUI::initStartUpTemplate(array('tpl.usr_registration.html', 'Services/Registration'), true);
+        $tpl = ilStartUpGUI::initStartUpTemplate(['tpl.usr_registration.html', 'Services/Registration'], true);
         $tpl->setVariable('TXT_PAGEHEADLINE', $this->lng->txt('registration'));
 
         if (!$this->form) {
@@ -133,7 +133,7 @@ class ilAccountRegistrationGUI
         // user defined fields
         $user_defined_data = $this->globalUser->getUserDefinedData();
         $user_defined_fields = ilUserDefinedFields::_getInstance();
-        $custom_fields = array();
+        $custom_fields = [];
 
         foreach ($user_defined_fields->getRegistrationDefinitions() as $field_id => $definition) {
             $fprop = ilCustomUserFieldsHelper::getInstance()->getFormPropertyForDefinition(
@@ -150,7 +150,7 @@ class ilAccountRegistrationGUI
         //TODO-PHP8-REVIEW please check if there is a need for this static call. It looks like of odd to me, that
         //we need a global static state variable in class that changes the behaviour of all instances.
         $up = new ilUserProfile();
-        $up->setMode(ilUserProfile::MODE_REGISTRATION);
+        ilUserProfile::setMode(ilUserProfile::MODE_REGISTRATION);
         $up->skipGroup("preferences");
 
         $up->setAjaxCallback(
@@ -176,7 +176,7 @@ class ilAccountRegistrationGUI
         }
 
         // #11407
-        $domains = array();
+        $domains = [];
         foreach ($this->registration_settings->getAllowedDomains() as $item) {
             if (trim($item)) {
                 $domains[] = $item;
@@ -199,7 +199,7 @@ class ilAccountRegistrationGUI
             }
         }
 
-        if (\ilTermsOfServiceHelper::isEnabled() && $this->termsOfServiceEvaluation->hasDocument()) {
+        if (ilTermsOfServiceHelper::isEnabled() && $this->termsOfServiceEvaluation->hasDocument()) {
             $document = $this->termsOfServiceEvaluation->document();
 
             $field = new ilFormSectionHeaderGUI();
@@ -258,7 +258,7 @@ class ilAccountRegistrationGUI
             $email = $this->form->getInput("usr_email");
             if ($email) {
                 // #10366
-                $domains = array();
+                $domains = [];
                 foreach ($this->registration_settings->getAllowedDomains() as $item) {
                     if (trim($item)) {
                         $domains[] = $item;
@@ -268,7 +268,7 @@ class ilAccountRegistrationGUI
                     $mail_valid = false;
                     foreach ($domains as $domain) {
                         $domain = str_replace("*", "~~~", $domain);
-                        $domain = preg_quote($domain); //TODO-PHP8-REVIEW please provide a delimiter, even if it is optional
+                        $domain = preg_quote($domain, '/');
                         $domain = str_replace("~~~", ".+", $domain);
                         if (preg_match("/^" . $domain . "$/", $email, $hit)) {
                             $mail_valid = true;
@@ -302,7 +302,7 @@ class ilAccountRegistrationGUI
         }
 
         $showGlobalTermsOfServieFailure = false;
-        if (\ilTermsOfServiceHelper::isEnabled() && !$this->form->getInput('accept_terms_of_service')) {
+        if (ilTermsOfServiceHelper::isEnabled() && !$this->form->getInput('accept_terms_of_service')) {
             $agr_obj = $this->form->getItemByPostVar('accept_terms_of_service');
             if ($agr_obj) {
                 $agr_obj->setAlert($this->lng->txt('force_accept_usr_agreement'));
@@ -343,7 +343,7 @@ class ilAccountRegistrationGUI
             $login_obj->setAlert($this->lng->txt("login_exists"));
             $form_valid = false;
         } elseif ((int) $this->settings->get('allow_change_loginname') &&
-            (int) $this->settings->get('reuse_of_loginnames') == 0 &&
+            (int) $this->settings->get('reuse_of_loginnames') === 0 &&
             ilObjUser::_doesLoginnameExistInHistory($login)) {
             $login_obj->setAlert($this->lng->txt('login_exists'));
             $form_valid = false;
@@ -380,9 +380,7 @@ class ilAccountRegistrationGUI
         $this->userObj = new ilObjUser();
 
         $up = new ilUserProfile();
-        //TODO-PHP8-REVIEW please check if there is a need for this static call. It looks like of odd to me, that
-        //we need a global static state variable in class that changes the behaviour of all instances.
-        $up->setMode(ilUserProfile::MODE_REGISTRATION);
+        ilUserProfile::setMode(ilUserProfile::MODE_REGISTRATION);
 
         $map = [];
         $up->skipGroup("preferences");
@@ -427,7 +425,7 @@ class ilAccountRegistrationGUI
         // Set user defined data
         $user_defined_fields = ilUserDefinedFields::_getInstance();
         $defs = $user_defined_fields->getRegistrationDefinitions();
-        $udf = array();
+        $udf = [];
         foreach ($_POST as $k => $v) {
             if (strpos($k, "udf_") === 0) {
                 $f = substr($k, 4);
@@ -510,11 +508,11 @@ class ilAccountRegistrationGUI
 
         $this->userObj->create();
 
-        if ($this->registration_settings->getRegistrationType() == ilRegistrationSettings::IL_REG_DIRECT ||
-            $this->registration_settings->getRegistrationType() == ilRegistrationSettings::IL_REG_CODES ||
+        if ($this->registration_settings->getRegistrationType() === ilRegistrationSettings::IL_REG_DIRECT ||
+            $this->registration_settings->getRegistrationType() === ilRegistrationSettings::IL_REG_CODES ||
             $this->code_was_used) {
             $this->userObj->setActive(true, 0);
-        } elseif ($this->registration_settings->getRegistrationType() == ilRegistrationSettings::IL_REG_ACTIVATION) {
+        } elseif ($this->registration_settings->getRegistrationType() === ilRegistrationSettings::IL_REG_ACTIVATION) {
             $this->userObj->setActive(false, 0);
         } else {
             $this->userObj->setActive(false, 0);
@@ -534,9 +532,9 @@ class ilAccountRegistrationGUI
         // setup user preferences
         $this->userObj->setLanguage($this->form->getInput('usr_language'));
 
-        $handleDocument = \ilTermsOfServiceHelper::isEnabled() && $this->termsOfServiceEvaluation->hasDocument();
+        $handleDocument = ilTermsOfServiceHelper::isEnabled() && $this->termsOfServiceEvaluation->hasDocument();
         if ($handleDocument) {
-            $helper = new \ilTermsOfServiceHelper();
+            $helper = new ilTermsOfServiceHelper();
 
             $helper->trackAcceptance($this->userObj, $this->termsOfServiceEvaluation->document());
         }
@@ -598,7 +596,7 @@ class ilAccountRegistrationGUI
             $mail->setType(ilRegistrationMailNotification::TYPE_NOTIFICATION_APPROVERS);
         }
         $mail->setRecipients($this->registration_settings->getApproveRecipients());
-        $mail->setAdditionalInformation(array('usr' => $this->userObj));
+        $mail->setAdditionalInformation(['usr' => $this->userObj]);
         $mail->send();
 
         // Send mail to new user
@@ -606,12 +604,12 @@ class ilAccountRegistrationGUI
         if ($this->registration_settings->getRegistrationType() === ilRegistrationSettings::IL_REG_ACTIVATION && !$this->code_was_used) {
             $mail = new ilRegistrationMimeMailNotification();
             $mail->setType(ilRegistrationMimeMailNotification::TYPE_NOTIFICATION_ACTIVATION);
-            $mail->setRecipients(array($this->userObj));
+            $mail->setRecipients([$this->userObj]);
             $mail->setAdditionalInformation(
-                array(
+                [
                     'usr' => $this->userObj,
                     'hash_lifetime' => $this->registration_settings->getRegistrationHashLifetime()
-                )
+                ]
             );
             $mail->send();
         } else {
@@ -626,7 +624,7 @@ class ilAccountRegistrationGUI
 
     public function login() : ilTemplate
     {
-        $tpl = ilStartUpGUI::initStartUpTemplate(array('tpl.usr_registered.html', 'Services/Registration'), false);
+        $tpl = ilStartUpGUI::initStartUpTemplate(['tpl.usr_registered.html', 'Services/Registration'], false);
         $this->tpl->setVariable('TXT_PAGEHEADLINE', $this->lng->txt('registration'));
 
         $tpl->setVariable("TXT_WELCOME", $this->lng->txt("welcome") . ", " . $this->userObj->getTitle() . "!");

--- a/Services/Registration/classes/class.ilAccountRegistrationMail.php
+++ b/Services/Registration/classes/class.ilAccountRegistrationMail.php
@@ -16,7 +16,7 @@
  * Class ilAccountRegistrationMail
  * @author Michael Jansen <mjansen@databay.de>
  */
-class ilAccountRegistrationMail extends \ilMimeMailNotification
+class ilAccountRegistrationMail extends ilMimeMailNotification
 {
     protected const MODE_DIRECT_REGISTRATION = 1;
     protected const MODE_REGISTRATION_WITH_EMAIL_CONFIRMATION = 2;
@@ -79,16 +79,7 @@ class ilAccountRegistrationMail extends \ilMimeMailNotification
             $user->getLanguage()
         ));
 
-        $mailData = ilObjUserFolder::_lookupNewAccountMail($user->getLanguage());
-        if (!is_array($mailData)) {
-            $this->logger->debug(sprintf(
-                "Did not find any email configuration for language '%s' at all, skipping attempt ...",
-                $user->getLanguage()
-            ));
-            return false;
-        }
-
-        $mailData = array_map($trimStrings, $mailData);
+        $mailData = array_map($trimStrings, ilObjUserFolder::_lookupNewAccountMail($user->getLanguage()));
 
         if ($this->isEmptyMailConfigurationData($mailData)) {
             $this->logger->debug(sprintf(
@@ -123,12 +114,12 @@ class ilAccountRegistrationMail extends \ilMimeMailNotification
             $fs = new ilFSStorageUserFolder(USER_FOLDER_ID);
             $fs->create();
 
-            $pathToFile = '/' . implode('/', array_map(static function ($pathPart) {
+            $pathToFile = '/' . implode('/', array_map(static function (string $pathPart) : string {
                 return trim($pathPart, '/');
             }, [
-                    $fs->getAbsolutePath(),
-                    $mailData['lang'],
-                ]));
+                $fs->getAbsolutePath(),
+                $mailData['lang'],
+            ]));
 
             $accountMail->addAttachment($pathToFile, $mailData['att_file']);
 

--- a/Services/Registration/classes/class.ilRegistrationCode.php
+++ b/Services/Registration/classes/class.ilRegistrationCode.php
@@ -43,27 +43,27 @@ class ilRegistrationCode
             $code = self::generateRandomCode();
             $chk = $ilDB->queryF(
                 "SELECT code_id FROM " . self::DB_TABLE . " WHERE code = %s",
-                array("text"),
-                array($code)
+                ["text"],
+                [$code]
             );
             $found = (bool) $ilDB->numRows($chk);
         }
 
-        if ($limit === "relative" && is_array($limit_date)) {
+        if ($limit === "relative") {
             $limit_date = serialize($limit_date); //TODO-PHP8-REVIEW please don't override variables with different types
         }
 
-        $data = array(
-            'code_id' => array('integer', $id),
-            'code' => array('text', $code),
-            'generated_on' => array('integer', $stamp),
-            'role' => array('integer', $role),
-            'role_local' => array('text', implode(";", $local_roles)),
-            'alimit' => array('text', $limit),
-            'alimitdt' => array('text', $limit_date),
-            'reg_enabled' => array('integer', $reg_type),
-            'ext_enabled' => array('integer', $ext_type)
-        );
+        $data = [
+            'code_id' => ['integer', $id],
+            'code' => ['text', $code],
+            'generated_on' => ['integer', $stamp],
+            'role' => ['integer', $role],
+            'role_local' => ['text', implode(";", $local_roles)],
+            'alimit' => ['text', $limit],
+            'alimitdt' => ['text', $limit_date],
+            'reg_enabled' => ['integer', $reg_type],
+            'ext_enabled' => ['integer', $ext_type]
+        ];
 
         $ilDB->insert(self::DB_TABLE, $data);
         return $id;
@@ -117,12 +117,12 @@ class ilRegistrationCode
         // set query
         $ilDB->setLimit($limit, $offset);
         $set = $ilDB->query($sql);
-        $result = array();
+        $result = [];
         while ($rec = $ilDB->fetchAssoc($set)) {
             $rec['generated'] = $rec['generated_on'];
             $result[] = $rec;
         }
-        return array("cnt" => $cnt, "set" => $result);
+        return ["cnt" => $cnt, "set" => $result];
     }
 
     public static function loadCodesByIds(array $ids) : array
@@ -137,7 +137,7 @@ class ilRegistrationCode
             false,
             "integer"
         ));
-        $result = array();
+        $result = [];
         while ($rec = $ilDB->fetchAssoc($set)) {
             $result[] = $rec;
         }
@@ -167,7 +167,7 @@ class ilRegistrationCode
         $ilDB = $DIC->database();
 
         $set = $ilDB->query("SELECT DISTINCT(generated_on) genr FROM " . self::DB_TABLE . " ORDER BY genr");
-        $result = array();
+        $result = [];
         while ($rec = $ilDB->fetchAssoc($set)) {
             $result[] = $rec["genr"];
         }
@@ -184,7 +184,7 @@ class ilRegistrationCode
 
         $ilDB = $DIC['ilDB'];
 
-        $where = array();
+        $where = [];
         if ($filter_code) {
             $where[] = $ilDB->like("code", "text", "%" . $filter_code . "%");
         }
@@ -219,7 +219,7 @@ class ilRegistrationCode
 
         // set query
         $set = $ilDB->query("SELECT code FROM " . self::DB_TABLE . $where . " ORDER BY code_id");
-        $result = array();
+        $result = [];
         while ($rec = $ilDB->fetchAssoc($set)) {
             $result[] = $rec["code"];
         }
@@ -259,8 +259,8 @@ class ilRegistrationCode
         $ilDB = $DIC->database();
         return (bool) $ilDB->update(
             self::DB_TABLE,
-            array("used" => array("timestamp", time())),
-            array("code" => array("text", $code))
+            ["used" => ["timestamp", time()]],
+            ["code" => ["text", $code]]
         );
     }
 

--- a/Services/Registration/classes/class.ilRegistrationCodesTableGUI.php
+++ b/Services/Registration/classes/class.ilRegistrationCodesTableGUI.php
@@ -25,6 +25,7 @@ class ilRegistrationCodesTableGUI extends ilTable2GUI
     protected ilRbacReview $rbacreview;
 
     public array $filter = [];
+    /** @var array<int, string> */
     protected array $role_map = [];
 
     /**
@@ -41,7 +42,7 @@ class ilRegistrationCodesTableGUI extends ilTable2GUI
 
         $this->addColumn("", "", "1", true);
         foreach ($this->getSelectedColumns() as $c => $caption) {
-            if ($c == "role_local" || $c == "alimit") {
+            if ($c === "role_local" || $c === "alimit") {
                 $c = "";
             }
             $this->addColumn($this->lng->txt($caption), $c);
@@ -77,7 +78,7 @@ class ilRegistrationCodesTableGUI extends ilTable2GUI
         $this->determineOffsetAndOrder();
 
         // #12737
-        if (!in_array($this->getOrderField(), array_keys($this->getSelectedColumns()))) {
+        if (!array_key_exists($this->getOrderField(), $this->getSelectedColumns())) {
             $this->setOrderField($this->getDefaultOrderField());
         }
 
@@ -106,14 +107,15 @@ class ilRegistrationCodesTableGUI extends ilTable2GUI
             );
         }
 
-        $options = array();
+        $options = [];
+        $this->role_map = [];
         foreach ($this->rbacreview->getGlobalRoles() as $role_id) {
-            if (!in_array($role_id, array(SYSTEM_ROLE_ID, ANONYMOUS_ROLE_ID))) {
-                $role_map[$role_id] = ilObject::_lookupTitle($role_id);
+            if (!in_array($role_id, [SYSTEM_ROLE_ID, ANONYMOUS_ROLE_ID], true)) {
+                $this->role_map[$role_id] = ilObject::_lookupTitle($role_id);
             }
         }
 
-        $result = array();
+        $result = [];
         foreach ($codes_data["set"] as $k => $code) {
             $result[$k]["code"] = $code["code"];
             $result[$k]["code_id"] = $code["code_id"];
@@ -129,9 +131,9 @@ class ilRegistrationCodesTableGUI extends ilTable2GUI
             }
 
             if ($code["role_local"]) {
-                $local = array();
+                $local = [];
                 foreach (explode(";", $code["role_local"]) as $role_id) {
-                    $role = ilObject::_lookupTitle($role_id);
+                    $role = ilObject::_lookupTitle((int) $role_id);
                     if ($role) {
                         $local[] = $role;
                     }
@@ -154,7 +156,7 @@ class ilRegistrationCodesTableGUI extends ilTable2GUI
                         break;
 
                     case "relative":
-                        $limit_caption = array();
+                        $limit_caption = [];
                         $limit = unserialize($code["alimitdt"], ['allowed_classes' => false]);
                         if ((int) $limit["d"]) {
                             $limit_caption[] = (int) $limit["d"] . " " . $this->lng->txt("days");
@@ -194,14 +196,14 @@ class ilRegistrationCodesTableGUI extends ilTable2GUI
 
         // role
 
-        $this->role_map = array();
+        $this->role_map = [];
         foreach ($this->rbacreview->getGlobalRoles() as $role_id) {
-            if (!in_array($role_id, array(SYSTEM_ROLE_ID, ANONYMOUS_ROLE_ID))) {
+            if (!in_array($role_id, [SYSTEM_ROLE_ID, ANONYMOUS_ROLE_ID], true)) {
                 $this->role_map[$role_id] = ilObject::_lookupTitle($role_id);
             }
         }
 
-        $options = array("" => $this->lng->txt("registration_roles_all")) +
+        $options = ["" => $this->lng->txt("registration_roles_all")] +
             $this->role_map;
         $si = new ilSelectInputGUI($this->lng->txt("role"), "role");
         $si->setOptions($options);
@@ -210,11 +212,12 @@ class ilRegistrationCodesTableGUI extends ilTable2GUI
         $this->filter["role"] = $si->getValue();
 
         // access limitation
-        $options = array("" => $this->lng->txt("registration_codes_access_limitation_all"),
-                         "unlimited" => $this->lng->txt("reg_access_limitation_none"),
-                         "absolute" => $this->lng->txt("reg_access_limitation_mode_absolute"),
-                         "relative" => $this->lng->txt("reg_access_limitation_mode_relative")
-        );
+        $options = [
+            "" => $this->lng->txt("registration_codes_access_limitation_all"),
+            "unlimited" => $this->lng->txt("reg_access_limitation_none"),
+            "absolute" => $this->lng->txt("reg_access_limitation_mode_absolute"),
+            "relative" => $this->lng->txt("reg_access_limitation_mode_relative")
+        ];
         $si = new ilSelectInputGUI($this->lng->txt("reg_access_limitations"), "alimit");
         $si->setOptions($options);
         $this->addFilterItem($si);
@@ -222,7 +225,7 @@ class ilRegistrationCodesTableGUI extends ilTable2GUI
         $this->filter["alimit"] = $si->getValue();
 
         // generated
-        $options = array("" => $this->lng->txt("registration_generated_all"));
+        $options = ["" => $this->lng->txt("registration_generated_all")];
         foreach (ilRegistrationCode::getGenerationDates() as $date) {
             $options[$date] = ilDatePresentation::formatDate(new ilDateTime($date, IL_CAL_UNIX));
         }
@@ -235,13 +238,14 @@ class ilRegistrationCodesTableGUI extends ilTable2GUI
 
     public function getSelectedColumns() : array
     {
-        return array("code" => "registration_code",
-                     "role" => "registration_codes_roles",
-                     "role_local" => "registration_codes_roles_local",
-                     "alimit" => "reg_access_limitations",
-                     "generated" => "registration_generated",
-                     "used" => "registration_used"
-        );
+        return [
+            "code" => "registration_code",
+            "role" => "registration_codes_roles",
+            "role_local" => "registration_codes_roles_local",
+            "alimit" => "reg_access_limitations",
+            "generated" => "registration_generated",
+            "used" => "registration_used"
+        ];
     }
 
     protected function fillRow(array $a_set) : void

--- a/Services/Registration/classes/class.ilRegistrationMailNotification.php
+++ b/Services/Registration/classes/class.ilRegistrationMailNotification.php
@@ -53,7 +53,7 @@ class ilRegistrationMailNotification extends ilMailNotification
                     $this->appendBody($this->getLanguageText('reg_mail_body_reason'));
 
                     $this->getMail()->appendInstallationSignature(true);
-                    $this->sendMail(array($rcp));
+                    $this->sendMail([$rcp]);
                 }
                 break;
 
@@ -87,7 +87,7 @@ class ilRegistrationMailNotification extends ilMailNotification
                     $this->appendBody($this->getLanguageText('reg_mail_body_reason'));
 
                     $this->getMail()->appendInstallationSignature(true);
-                    $this->sendMail(array($rcp));
+                    $this->sendMail([$rcp]);
                 }
                 break;
         }

--- a/Services/Registration/classes/class.ilRegistrationRoleAccessLimitations.php
+++ b/Services/Registration/classes/class.ilRegistrationRoleAccessLimitations.php
@@ -39,7 +39,7 @@ class ilRegistrationRoleAccessLimitations
         $query = "SELECT * FROM reg_access_limit ";
         $res = $this->db->query($query);
 
-        $this->access_limitations = array();
+        $this->access_limitations = [];
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             $this->access_limitations[$row->role_id]['id'] = (int) $row->role_id;
             $this->access_limitations[$row->role_id]['absolute'] = (int) $row->limit_absolute;
@@ -76,15 +76,15 @@ class ilRegistrationRoleAccessLimitations
     public function validate() : int
     {
         foreach ($this->access_limitations as $data) {
-            if ($data['mode'] == "null") {
+            if ($data['mode'] === "null") {
                 return self::IL_REG_ACCESS_LIMITATION_MISSING_MODE;
             }
 
-            if ($data['mode'] == 'absolute' && $data['absolute'] < time()) {
+            if ($data['mode'] === 'absolute' && $data['absolute'] < time()) {
                 return self::IL_REG_ACCESS_LIMITATION_OUT_OF_DATE;
             }
 
-            if ($data['mode'] == 'relative' && ($data['relative_d'] < 1 && $data['relative_m'] < 1)) {
+            if ($data['mode'] === 'relative' && ($data['relative_d'] < 1 && $data['relative_m'] < 1)) {
                 return self::IL_REG_ACCESS_LIMITATION_OUT_OF_DATE;
             }
         }
@@ -124,6 +124,6 @@ class ilRegistrationRoleAccessLimitations
 
     public function resetAccessLimitations() : void
     {
-        $this->access_limitations = array();
+        $this->access_limitations = [];
     }
 }

--- a/Services/Registration/classes/class.ilRegistrationRoleAssignments.php
+++ b/Services/Registration/classes/class.ilRegistrationRoleAssignments.php
@@ -21,7 +21,7 @@ class ilRegistrationRoleAssignments
     public const IL_REG_MISSING_DOMAIN = 1;
     public const IL_REG_MISSING_ROLE = 2;
 
-    public array $assignments = array();
+    public array $assignments = [];
     public int $default_role = 0;
 
     protected ilDBInterface $db;
@@ -125,7 +125,7 @@ class ilRegistrationRoleAssignments
         $query = "SELECT * FROM reg_er_assignments ";
         $res = $this->db->query($query);
 
-        $this->assignments = array();
+        $this->assignments = [];
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             $this->assignments[$row->assignment_id]['id'] = $row->assignment_id;
             $this->assignments[$row->assignment_id]['role'] = $row->role;

--- a/Services/Registration/classes/class.ilRegistrationSettings.php
+++ b/Services/Registration/classes/class.ilRegistrationSettings.php
@@ -194,7 +194,7 @@ class ilRegistrationSettings
     public function setAllowedDomains(string $a_value) : void
     {
         $a_value = array_map(
-            static function ($value) {
+            static function (string $value) : string {
                 return trim($value);
             },
             explode(";", trim($a_value))
@@ -210,10 +210,10 @@ class ilRegistrationSettings
 
     public function validate() : int
     {
-        $this->unknown = array();
+        $this->unknown = [];
 
         $login_arr = explode(',', $this->getApproveRecipientLogins());
-        $login_arr = $login_arr ?: array();
+        $login_arr = $login_arr ?: [];
         $valid = [];
         foreach ($login_arr as $recipient) {
             if (!$recipient = trim($recipient)) {
@@ -258,11 +258,14 @@ class ilRegistrationSettings
         $this->reg_hash_life_time = (int) $this->settings->get('reg_hash_life_time');
         $this->reg_allow_codes = (bool) $this->settings->get('reg_allow_codes');
 
-        $this->approve_recipient_ids = (array) unserialize(stripslashes($this->settings->get('approve_recipient')), ['allowed_classes' => false]);
-        $this->approve_recipient_ids = $this->approve_recipient_ids ?: array();
+        $this->approve_recipient_ids = (array) unserialize(
+            stripslashes($this->settings->get('approve_recipient')),
+            ['allowed_classes' => false]
+        );
+        $this->approve_recipient_ids = $this->approve_recipient_ids ?: [];
 
         // create login array
-        $tmp_logins = array();
+        $tmp_logins = [];
         foreach ($this->approve_recipient_ids as $id) {
             if ($login = ilObjUser::_lookupLogin($id)) {
                 $tmp_logins[] = $login;

--- a/Services/Registration/test/ilRegistrationSettingsTest.php
+++ b/Services/Registration/test/ilRegistrationSettingsTest.php
@@ -20,8 +20,6 @@ use ILIAS\DI\Container;
  */
 class ilRegistrationSettingsTest extends TestCase
 {
-    protected $backupGlobals = false;
-
     protected Container $dic;
 
     protected function setUp() : void
@@ -33,7 +31,7 @@ class ilRegistrationSettingsTest extends TestCase
     public function testConstruct() : void
     {
         $settings = new ilRegistrationSettings();
-        $this->assertTrue($settings instanceof ilRegistrationSettings);
+        $this->assertInstanceOf(ilRegistrationSettings::class, $settings);
     }
 
     protected function setGlobalVariable(string $name, $value) : void
@@ -42,7 +40,7 @@ class ilRegistrationSettingsTest extends TestCase
 
         $GLOBALS[$name] = $value;
         unset($DIC[$name]);
-        $DIC[$name] = static function (\ILIAS\DI\Container $c) use ($value) {
+        $DIC[$name] = static function (Container $c) use ($value) {
             return $value;
         };
     }

--- a/Services/Registration/test/ilServicesRegistrationSuite.php
+++ b/Services/Registration/test/ilServicesRegistrationSuite.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestSuite;
 
 class ilServicesRegistrationSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new self();
         include_once("./Services/Registration/test/ilRegistrationSettingsTest.php");


### PR DESCRIPTION
Hello @pascalseeland, 

I completed the review of the `Services/Registration` component.

Results:

- [ ] The code style is `PSR-2 + X` compliant
- [ ] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`: I found 3 usages of `$_REQUEST`, 1 usage of `$_GET` and 1usage of `$_POST`.
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [ ] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

--

Actions needed:
- [ ] Please eliminate the usage of super global variables.

Best regards,
@mjansenDatabay  