### PR TITLE
PHP8: Code Review `ILIAS Page Editor`

### DIFF
--- a/Services/COPage/DOM/class.ilDomDocument.php
+++ b/Services/COPage/DOM/class.ilDomDocument.php
@@ -61,7 +61,7 @@ class ilDomDocument
      */
     public function __set(string $a_mem, $a_val) : void
     {
-        $this->_delegate->$a_mem = $a_val;
+        $this->_delegate->$a_mem = $a_val;//@TODO: PHP8 Review: The property is dynamically declared
     }
 
     /**

--- a/Services/COPage/Editor/Components/Paragraph/class.ParagraphResponseFactory.php
+++ b/Services/COPage/Editor/Components/Paragraph/class.ParagraphResponseFactory.php
@@ -51,7 +51,7 @@ class ParagraphResponseFactory
                     if (is_array($msg)) {
                         $error .= implode("<br />", $msg);
                     } else {
-                        $error .= (string) $msg;
+                        $error .= $msg;
                     }
                 }
             } elseif (is_string($updated)) {

--- a/Services/COPage/Editor/Components/Table/class.TableCommandActionHandler.php
+++ b/Services/COPage/Editor/Components/Table/class.TableCommandActionHandler.php
@@ -114,7 +114,7 @@ class TableCommandActionHandler implements Server\CommandActionHandler
 
         $data = [];
         $updated = true;
-        if (is_array($content)) {
+        if (is_array($content)) {// @TODO: PHP8 Review: Condition is always true
             foreach ($content as $i => $row) {
                 if (is_array($row)) {
                     foreach ($row as $j => $cell) {

--- a/Services/COPage/Editor/Server/class.Server.php
+++ b/Services/COPage/Editor/Server/class.Server.php
@@ -77,7 +77,7 @@ class Server
         }
 
         if ($handler === null) {
-            throw new Exception("Unknown Action " . ((string) $query));
+            throw new Exception("Unknown Action " . ((string) $query));// @TODO: PHP8 Review: Array to string conversion.
         }
         return $handler;
     }

--- a/Services/COPage/Editor/Server/class.UIWrapper.php
+++ b/Services/COPage/Editor/Server/class.UIWrapper.php
@@ -168,7 +168,7 @@ class UIWrapper
         if ($updated !== true) {
             if (is_array($updated)) {
                 $error = implode("<br />", $updated);
-            } elseif (is_string($updated)) {
+            } elseif (is_string($updated)) {// @TODO: PHP8 Review: Condition is always false
                 $error = $updated;
             } else {
                 $error = print_r($updated, true);

--- a/Services/COPage/Layout/classes/class.ilPageLayout.php
+++ b/Services/COPage/Layout/classes/class.ilPageLayout.php
@@ -268,7 +268,7 @@ class ilPageLayout
         $query = "SELECT * FROM page_layout $add ORDER BY title ";
         $result = $ilDB->query($query);
         while ($row = $result->fetchRow(ilDBConstants::FETCHMODE_ASSOC)) {
-            array_push($arr_layouts, $row);
+            $arr_layouts[] = $row;
         }
         return $arr_layouts;
     }
@@ -302,7 +302,7 @@ class ilPageLayout
         $query = "SELECT layout_id FROM page_layout $add ORDER BY title ";
         $result = $ilDB->query($query);
         while ($row = $result->fetchRow(ilDBConstants::FETCHMODE_ASSOC)) {
-            array_push($arr_layouts, new ilPageLayout($row['layout_id']));
+            $arr_layouts[] = new ilPageLayout($row['layout_id']);
         }
 
         return $arr_layouts;

--- a/Services/COPage/classes/class.ilCOPageHTMLExport.php
+++ b/Services/COPage/classes/class.ilCOPageHTMLExport.php
@@ -305,7 +305,7 @@ class ilCOPageHTMLExport
                 switch ($a_type) {
                     case "prtf:pg":
                         $page = new ilPortfolioPage($a_id);
-                        $user_id = $page->create_user;
+                        $user_id = $page->create_user;//@TODO: PHP8 Review: The property is dynamically declared and is probably undefined.
                         break;
                     
                     default:

--- a/Services/COPage/classes/class.ilCOPageHTMLExport.php
+++ b/Services/COPage/classes/class.ilCOPageHTMLExport.php
@@ -322,7 +322,7 @@ class ilCOPageHTMLExport
                     }
 
                     // walk skill tree
-                    $vtree = new ilVirtualSkillTree();
+                    $vtree = new ilVirtualSkillTree();// @TODO: PHP8 Review: Missing argument.
                     $tref_id = 0;
                     $skill_id = (int) $skill_id;
                     if (ilSkillTreeNode::_lookupType($skill_id) == "sktr") {
@@ -608,7 +608,7 @@ class ilCOPageHTMLExport
             $term_gui = new ilGlossaryTermGUI($term_id);
             $term_gui->setPageLinker($this->page_linker);
             $term_gui->setOfflineDirectory($this->exp_dir);
-            $term_gui->output(true, $tpl);
+            $term_gui->output(true, $tpl);// @TODO: PHP8 Review: Invalid argument.
 
             // write file
             $html = $tpl->printToString();

--- a/Services/COPage/classes/class.ilCOPageHTMLExport.php
+++ b/Services/COPage/classes/class.ilCOPageHTMLExport.php
@@ -337,7 +337,7 @@ class ilCOPageHTMLExport
                         foreach ($level_data as $k => $v) {
                             // get assigned materials from personal skill
                             $mat = ilPersonalSkill::getAssignedMaterial($user_id, $bs["tref_id"], $v["id"]);
-                            if (sizeof($mat)) {
+                            if (count($mat)) {
                                 foreach ($mat as $item) {
                                     $wsp_id = $item["wsp_id"];
                                     $obj_id = $ws_tree->lookupObjectId($wsp_id);

--- a/Services/COPage/classes/class.ilMediaAliasItem.php
+++ b/Services/COPage/classes/class.ilMediaAliasItem.php
@@ -898,7 +898,7 @@ class ilMediaAliasItem
         string $a_area_type,
         string $a_coords
     ) : bool {
-        if (!$a_st_item->copyOriginal()) {
+        if (!$a_st_item->copyOriginal()) {// @TODO: PHP8 Review: Void result used.
             return false;
         }
         $a_st_item->buildMapWorkImage();

--- a/Services/COPage/classes/class.ilPCBlog.php
+++ b/Services/COPage/classes/class.ilPCBlog.php
@@ -69,7 +69,7 @@ class ilPCBlog extends ilPageContent
             }
         }
 
-        if (sizeof($a_posting_ids)) {
+        if (count($a_posting_ids)) {
             foreach ($a_posting_ids as $posting_id) {
                 $post_node = $this->dom->create_element("BlogPosting");
                 $post_node = $this->blog_node->append_child($post_node);

--- a/Services/COPage/classes/class.ilPCFileItemGUI.php
+++ b/Services/COPage/classes/class.ilPCFileItemGUI.php
@@ -83,7 +83,7 @@ class ilPCFileItemGUI extends ilPageContentGUI
         $fileObj->setMode("filelist");
         $fileObj->create();
         // upload file to filesystem
-        $fileObj->createDirectory();
+        $fileObj->createDirectory();// @TODO: PHP8 Review: Undefined method.
         global $DIC;
         $upload = $DIC->upload();
         if ($upload->hasBeenProcessed() !== true) {

--- a/Services/COPage/classes/class.ilPCFileListGUI.php
+++ b/Services/COPage/classes/class.ilPCFileListGUI.php
@@ -221,8 +221,8 @@ class ilPCFileListGUI extends ilPageContentGUI
             $fileObj->setMode("filelist");
             $fileObj->create();
             // upload file to filesystem
-            $fileObj->createDirectory();
-            $fileObj->raiseUploadError(false);
+            $fileObj->createDirectory();// @TODO: PHP8 Review: Undefined method.
+            $fileObj->raiseUploadError(false);// @TODO: PHP8 Review: Undefined method.
 
             $upload = $DIC->upload();
             if ($upload->hasBeenProcessed() !== true) {
@@ -691,7 +691,7 @@ class ilPCFileListGUI extends ilPageContentGUI
         $fileObj->setMode("filelist");
         $fileObj->create();
         // upload file to filesystem
-        $fileObj->createDirectory();
+        $fileObj->createDirectory();// @TODO: PHP8 Review: Undefined method.
 
         $upload = $DIC->upload();
         if ($upload->hasBeenProcessed() !== true) {

--- a/Services/COPage/classes/class.ilPCMapGUI.php
+++ b/Services/COPage/classes/class.ilPCMapGUI.php
@@ -82,6 +82,8 @@ class ilPCMapGUI extends ilPageContentGUI
         $values["horizontal_align"] = $this->content_obj->getHorizontalAlign();
         
         $this->form->setValuesByArray($values);
+
+        // @TODO: PHP8 Review: Missing return statement.
     }
 
     public function initForm(string $a_mode) : void

--- a/Services/COPage/classes/class.ilPCMediaObjectGUI.php
+++ b/Services/COPage/classes/class.ilPCMediaObjectGUI.php
@@ -1242,7 +1242,7 @@ class ilPCMediaObjectGUI extends ilPageContentGUI
         );
         //$this->setBasicTableCellStyles();
         $this->setCharacteristics([]);
-        $this->getCharacteristicsOfCurrentStyle("media_caption");
+        $this->getCharacteristicsOfCurrentStyle("media_caption");// @TODO: PHP8 Review: Invalid argument.
         $chars = $this->getCharacteristics();
         $options = $chars;
         //$options = array_merge(array("" => $this->lng->txt("none")), $chars);

--- a/Services/COPage/classes/class.ilPCMediaObjectGUI.php
+++ b/Services/COPage/classes/class.ilPCMediaObjectGUI.php
@@ -1253,9 +1253,7 @@ class ilPCMediaObjectGUI extends ilPageContentGUI
         }
 
         if (count($options) > 0) {
-            $current_value = $this->content_obj->getCaptionClass()
-                ? $this->content_obj->getCaptionClass()
-                : "MediaCaption";
+            $current_value = $this->content_obj->getCaptionClass() ?: "MediaCaption";
             $cap_style->setValue($current_value);
             $form->addItem($cap_style);
         }

--- a/Services/COPage/classes/class.ilPCParagraph.php
+++ b/Services/COPage/classes/class.ilPCParagraph.php
@@ -100,7 +100,7 @@ class ilPCParagraph extends ilPageContent
         parent::setNode($a_node);		// this is the PageContent node
 
         $childs = $a_node->child_nodes();
-        for ($i = 0; $i < count($childs); $i++) {
+        for ($i = 0, $iMax = count($childs); $i < $iMax; $i++) {
             if ($childs[$i]->node_name() == "Paragraph") {
                 $this->par_node = $childs[$i];		//... and this the Paragraph node
             }
@@ -211,7 +211,7 @@ class ilPCParagraph extends ilPageContent
 
             // delete children of paragraph node
             $children = $this->par_node->child_nodes();
-            for ($i = 0; $i < count($children); $i++) {
+            for ($i = 0, $iMax = count($children); $i < $iMax; $i++) {
                 $this->par_node->remove_child($children[$i]);
             }
 
@@ -223,7 +223,7 @@ class ilPCParagraph extends ilPageContent
                 $new_par_node = $res->nodeset[0];
                 $new_childs = $new_par_node->child_nodes();
 
-                for ($i = 0; $i < count($new_childs); $i++) {
+                for ($i = 0, $iMax = count($new_childs); $i < $iMax; $i++) {
                     $cloned_child = $new_childs[$i]->clone_node(true);
                     $this->par_node->append_child($cloned_child);
                 }
@@ -243,7 +243,7 @@ class ilPCParagraph extends ilPageContent
 
             $c_node = $this->node;
             // add other chunks afterwards
-            for ($i = 1; $i < count($text); $i++) {
+            for ($i = 1, $iMax = count($text); $i < $iMax; $i++) {
                 if ($ok) {
                     $next_par = new ilPCParagraph($this->getPage());
                     $next_par->createAfter($c_node);
@@ -317,7 +317,7 @@ class ilPCParagraph extends ilPageContent
         $dom = new DOMDocument();
         $dom->recover = true;
         // try to fix
-        for ($i = 0; $i < count($text); $i++) {
+        for ($i = 0, $iMax = count($text); $i < $iMax; $i++) {
             $dom->loadXML(
                 '<?xml version="1.0" encoding="UTF-8"?><Paragraph>' . $text[$i]["text"] . '</Paragraph>',
                 LIBXML_NOWARNING | LIBXML_NOERROR
@@ -343,7 +343,7 @@ class ilPCParagraph extends ilPageContent
         if (is_object($this->par_node)) {
             $content = "";
             $childs = $this->par_node->child_nodes();
-            for ($i = 0; $i < count($childs); $i++) {
+            for ($i = 0, $iMax = count($childs); $i < $iMax; $i++) {
                 $content .= $this->dom->dump_node($childs[$i]);
             }
             return $content;
@@ -364,7 +364,7 @@ class ilPCParagraph extends ilPageContent
         $found = false;
         $pc_id = $this->readPCId();
         $hier_id = $this->readHierId();
-        for ($i = 0; $i < count($childs); $i++) {
+        for ($i = 0, $iMax = count($childs); $i < $iMax; $i++) {
             $pchilds = $childs[$i]->child_nodes();
             if ($pchilds[0]->node_name() == "Paragraph" &&
                 $pchilds[0]->get_attribute("Characteristic") != "Code") {
@@ -1040,18 +1040,18 @@ class ilPCParagraph extends ilPageContent
 
         $current_list = array();
         $text = "";
-        for ($i = 0; $i < count($segments); $i++) {
+        for ($i = 0, $iMax = count($segments); $i < $iMax; $i++) {
             if ($segments[$i] == "<SimpleBulletList>") {
                 if (count($current_list) == 0) {
                     $list_start = true;
                 }
-                array_push($current_list, "*");
+                $current_list[] = "*";
                 $li = false;
             } elseif ($segments[$i] == "<SimpleNumberedList>") {
                 if (count($current_list) == 0) {
                     $list_start = true;
                 }
-                array_push($current_list, "#");
+                $current_list[] = "#";
                 $li = false;
             } elseif ($segments[$i] == "</SimpleBulletList>") {
                 array_pop($current_list);
@@ -1614,7 +1614,7 @@ class ilPCParagraph extends ilPageContent
                     $cnode = ilDOM2Util::changeName($element, "ilMarked", false);
                     $cnode->setAttribute("Class", substr($class_arr[0], 16));
                 }
-                for ($i = 1; $i < count($class_arr); $i++) {
+                for ($i = 1, $iMax = count($class_arr); $i < $iMax; $i++) {
                     $tag = substr($class_arr[$i], 16);
                     if (isset($tags[$tag])) {		// known tag like strong
                         $cnode = ilDOM2Util::addParent($cnode, "il" . substr($class_arr[$i], 16));

--- a/Services/COPage/classes/class.ilPCParagraph.php
+++ b/Services/COPage/classes/class.ilPCParagraph.php
@@ -187,7 +187,7 @@ class ilPCParagraph extends ilPageContent
         string $a_text,
         bool $a_auto_split = false
     ) {
-        if (!is_array($a_text)) {
+        if (!is_array($a_text)) {// @TODO: PHP8 Review: Condition is always true
             $text = array(array("level" => 0, "text" => $a_text));
         } else {
             $text = $a_text;

--- a/Services/COPage/classes/class.ilPCParagraphGUI.php
+++ b/Services/COPage/classes/class.ilPCParagraphGUI.php
@@ -13,7 +13,7 @@
  * https://github.com/ILIAS-eLearning
  */
 
-use \ILIAS\Style;
+use ILIAS\Style;
 
 /**
  * Class ilPCParagraphGUI

--- a/Services/COPage/classes/class.ilPCParagraphGUI.php
+++ b/Services/COPage/classes/class.ilPCParagraphGUI.php
@@ -652,7 +652,7 @@ class ilPCParagraphGUI extends ilPageContentGUI
         //$selection->setSelectedValue($a_selected);
         $selection->setUseImages(false);
         $selection->setOnClickMode(ilAdvancedSelectionListGUI::ON_ITEM_CLICK_NOP);
-        if (is_string($a_use_callback)) {
+        if (is_string($a_use_callback)) {// @TODO: PHP8 Review: Thje
             $selection->setSelectCallback($a_use_callback);
         } elseif ($a_use_callback === true) {
             $selection->setSelectCallback("ilCOPage.setCharacterClass");

--- a/Services/COPage/classes/class.ilPCParagraphGUI.php
+++ b/Services/COPage/classes/class.ilPCParagraphGUI.php
@@ -471,12 +471,12 @@ class ilPCParagraphGUI extends ilPageContentGUI
         $a_pc_id_str = $this->content_obj->getLastSavedPCId($this->pg_obj, true);
 
         $ilCtrl->setParameterByClass(
-            $ilCtrl->getReturnClass($this),
+            $ilCtrl->getReturnClass($this),// @TODO: PHP8 Review: Undefined method.
             "updated_pc_id_str",
             urlencode($a_pc_id_str)
         );
-        $this->log->debug("ilPCParagraphGUI, saveJS: redirecting to edit command of " . $ilCtrl->getReturnClass($this) . ".");
-        $ilCtrl->redirectByClass($ilCtrl->getReturnClass($this), "edit", "", true);
+        $this->log->debug("ilPCParagraphGUI, saveJS: redirecting to edit command of " . $ilCtrl->getReturnClass($this) . ".");// @TODO: PHP8 Review: Undefined method.
+        $ilCtrl->redirectByClass($ilCtrl->getReturnClass($this), "edit", "", true);// @TODO: PHP8 Review: Undefined method.
     }
 
     /**
@@ -855,13 +855,13 @@ class ilPCParagraphGUI extends ilPageContentGUI
         // e.g. e.g. ###3:110dad8bad6df8620071a0a693a2d328###
         $a_pc_id_str = $this->content_obj->getLastSavedPCId($this->pg_obj, true);
         $ilCtrl->setParameterByClass(
-            $ilCtrl->getReturnClass($this),
+            $ilCtrl->getReturnClass($this),// @TODO: PHP8 Review: Undefined method.
             "updated_pc_id_str",
             urlencode($a_pc_id_str)
         );
-        $this->log->debug("ilPCParagraphGUI, createJS(): return to edit cmd of " . $ilCtrl->getReturnClass($this));
+        $this->log->debug("ilPCParagraphGUI, createJS(): return to edit cmd of " . $ilCtrl->getReturnClass($this));// @TODO: PHP8 Review: Undefined method.
 
-        $ilCtrl->redirectByClass($ilCtrl->getReturnClass($this), "edit", "", true);
+        $ilCtrl->redirectByClass($ilCtrl->getReturnClass($this), "edit", "", true);// @TODO: PHP8 Review: Undefined method.
     }
 
     /**

--- a/Services/COPage/classes/class.ilPCPlaceHolderGUI.php
+++ b/Services/COPage/classes/class.ilPCPlaceHolderGUI.php
@@ -253,7 +253,7 @@ class ilPCPlaceHolderGUI extends ilPageContentGUI
         switch ($this->request->getString("pctext_type")) {
             case 0:  //Paragraph / Text
                 
-                $ret_class = $this->ctrl->getReturnClass($this);
+                $ret_class = $this->ctrl->getReturnClass($this);// @TODO: PHP8 Review: Undefined method.
                 $this->ctrl->setParameterByClass($ret_class, "pl_hier_id", $this->hier_id);
                 $this->ctrl->setParameterByClass($ret_class, "pl_pc_id", $this->pc_id);
                 $this->ctrl->redirectByClass(

--- a/Services/COPage/classes/class.ilPCPlugged.php
+++ b/Services/COPage/classes/class.ilPCPlugged.php
@@ -257,6 +257,7 @@ class ilPCPlugged extends ilPageContent
             }
 
             $plugin_info = $this->component_repository->getPluginByName($plugin_name);
+            $plugin_html = '';
             if ($plugin_info->isActive()) {
                 $plugin_obj = $this->component_factory->getPlugin($plugin_info->getId());
                 $plugin_obj->setPageObj($this->getPage());

--- a/Services/COPage/classes/class.ilPCQuestion.php
+++ b/Services/COPage/classes/class.ilPCQuestion.php
@@ -224,7 +224,7 @@ class ilPCQuestion extends ilPageContent
                 // this exports the questions which is needed below
                 $qhtml = $this->getQuestionJsOfPage($a_mode == "edit", $a_mode);
                                                             
-                $a_output = "<script>" . ilQuestionExporter::questionsJS($q_ids) . "</script>" . $a_output;
+                $a_output = "<script>" . ilQuestionExporter::questionsJS($q_ids) . "</script>" . $a_output;// @TODO: PHP8 Review: Undefined class.
                 if (!self::$initial_done) {
                     $a_output = "<script>var ScormApi=null; var questions = new Array();</script>" . $a_output;
                     self::$initial_done = true;
@@ -376,7 +376,7 @@ class ilPCQuestion extends ilPageContent
         $js = array();
         if (count($q_ids) > 0) {
             foreach ($q_ids as $q_id) {
-                $q_exporter = new ilQuestionExporter($a_no_interaction);
+                $q_exporter = new ilQuestionExporter($a_no_interaction);// @TODO: PHP8 Review: Undefined class.
                 $image_path = "";
                 if ($a_mode == "offline") {
                     if ($this->getPage()->getParentType() == "sahs") {

--- a/Services/COPage/classes/class.ilPCQuestion.php
+++ b/Services/COPage/classes/class.ilPCQuestion.php
@@ -208,7 +208,7 @@ class ilPCQuestion extends ilPageContent
         if ($this->getPage()->getPageConfig()->getEnableSelfAssessment()) {
             // #14154
             $q_ids = $this->getPage()->getQuestionIds();
-            if (sizeof($q_ids)) {
+            if (count($q_ids)) {
                 foreach ($q_ids as $q_id) {
                     $q_gui = assQuestionGUI::_getQuestionGUI("", $q_id);
                     // object check due to #16557
@@ -238,7 +238,7 @@ class ilPCQuestion extends ilPageContent
             if (!is_array($qhtml) || count($qhtml) == 0) {
                 // #14154
                 $q_ids = $this->getPage()->getQuestionIds();
-                if (sizeof($q_ids)) {
+                if (count($q_ids)) {
                     foreach ($q_ids as $k) {
                         $a_output = str_replace("{{{{{Question;il__qst_$k" . "}}}}}", " " . $lng->txt("copg_questions_not_supported_here"), $a_output);
                     }

--- a/Services/COPage/classes/class.ilPCQuestionGUI.php
+++ b/Services/COPage/classes/class.ilPCQuestionGUI.php
@@ -360,7 +360,7 @@ class ilPCQuestionGUI extends ilPageContentGUI
         $ilTabs = $this->tabs;
         $ilCtrl = $this->ctrl;
 
-        if ($this->content_obj != "") {
+        if ($this->content_obj != "") {// @TODO: PHP8 Review: This is either null or an object, but the object does not implement __toString)
             $q_ref = $this->content_obj->getQuestionReference();
         }
         

--- a/Services/COPage/classes/class.ilPCQuestionGUI.php
+++ b/Services/COPage/classes/class.ilPCQuestionGUI.php
@@ -388,7 +388,7 @@ class ilPCQuestionGUI extends ilPageContentGUI
                 $tabCommands = assQuestionGUI::getCommandsFromClassConstants('ilAssQuestionFeedbackEditingGUI');
                 $tabLink = ilUtil::appendUrlParameterString(
                     $ilCtrl->getLinkTargetByClass('ilAssQuestionFeedbackEditingGUI', ilAssQuestionFeedbackEditingGUI::CMD_SHOW),
-                    "q_id=" . (int) $q_id
+                    "q_id=" . $q_id
                 );
                 $ilTabs->addTarget('feedback', $tabLink, $tabCommands, $ilCtrl->getCmdClass(), '');
             }

--- a/Services/COPage/classes/class.ilPageComponentPluginExporter.php
+++ b/Services/COPage/classes/class.ilPageComponentPluginExporter.php
@@ -53,11 +53,7 @@ abstract class ilPageComponentPluginExporter extends ilXmlExporter
      */
     public static function getPCProperties(string $a_id) : ?array
     {
-        if (isset(self::$pc_properties[$a_id])) {
-            return self::$pc_properties[$a_id];
-        } else {
-            return null;
-        }
+        return self::$pc_properties[$a_id] ?? null;
     }
 
     /**
@@ -76,10 +72,6 @@ abstract class ilPageComponentPluginExporter extends ilXmlExporter
      */
     public static function getPCVersion(string $a_id) : ?string
     {
-        if (isset(self::$pc_version[$a_id])) {
-            return self::$pc_version[$a_id];
-        } else {
-            return null;
-        }
+        return self::$pc_version[$a_id] ?? null;
     }
 }

--- a/Services/COPage/classes/class.ilPageComponentPluginImporter.php
+++ b/Services/COPage/classes/class.ilPageComponentPluginImporter.php
@@ -54,11 +54,7 @@ abstract class ilPageComponentPluginImporter extends ilXmlImporter
      */
     public static function getPCProperties(string $a_id) : ?array
     {
-        if (isset(self::$pc_properties[$a_id])) {
-            return self::$pc_properties[$a_id];
-        } else {
-            return null;
-        }
+        return self::$pc_properties[$a_id] ?? null;
     }
 
     /**
@@ -77,11 +73,7 @@ abstract class ilPageComponentPluginImporter extends ilXmlImporter
      */
     public static function getPCVersion(string $a_id) : ?string
     {
-        if (isset(self::$pc_version[$a_id])) {
-            return self::$pc_version[$a_id];
-        } else {
-            return null;
-        }
+        return self::$pc_version[$a_id] ?? null;
     }
 
 

--- a/Services/COPage/classes/class.ilPageConfig.php
+++ b/Services/COPage/classes/class.ilPageConfig.php
@@ -25,7 +25,7 @@ abstract class ilPageConfig
     public const SEC_PROTECT_EDITABLE = 1;      // current use can edit protected sections
     public const SEC_PROTECT_PROTECTED = 2;     // current use cannot edit protected sections
 
-    protected $int_link_def_id_is_ref = false;
+    protected bool $int_link_def_id_is_ref = false;
     protected ilLanguage $lng;
     protected array $int_link_filter = array("File", "PortfolioPage", "PortfolioTemplatePage");
     protected bool $prevent_rte_usage = false;
@@ -175,7 +175,7 @@ abstract class ilPageConfig
         $lng = $this->lng;
         
         $this->setLocalizationLanguage($lng->getLangKey());
-        if (is_array($a_val)) {
+        if (is_array($a_val)) {// @TODO: PHP8 Review: Condition is always false
             $this->int_link_filter =
                 array_merge($a_val, $this->int_link_filter);
         } else {

--- a/Services/COPage/classes/class.ilPageContentGUI.php
+++ b/Services/COPage/classes/class.ilPageContentGUI.php
@@ -16,7 +16,7 @@
 use ILIAS\COPage\PC\EditGUIRequest;
 use ILIAS\COPage\Editor\EditSessionRepository;
 
-use \ILIAS\Style;
+use ILIAS\Style;
 
 /**
  * User Interface for Editing of Page Content Objects (Paragraphs, Tables, ...)

--- a/Services/COPage/classes/class.ilPageObject.php
+++ b/Services/COPage/classes/class.ilPageObject.php
@@ -986,7 +986,7 @@ s     */
         $res = xpath_eval($xpc, $path);
 
         $q_ids = array();
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $or_id = $res->nodeset[$i]->get_attribute("OriginId");
 
             $inst_id = ilInternalLink::_extractInstOfTarget($or_id);
@@ -1017,7 +1017,7 @@ s     */
         $res = xpath_eval($xpc, $path);
 
         $q_ids = array();
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $or_id = $res->nodeset[$i]->get_attribute("OriginId");
 
             $inst_id = ilInternalLink::_extractInstOfTarget($or_id);
@@ -1049,7 +1049,7 @@ s     */
         $res = xpath_eval($xpc, $path);
 
         $q_ids = array();
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $qref = $res->nodeset[$i]->get_attribute("QRef");
 
             $inst_id = ilInternalLink::_extractInstOfTarget($qref);
@@ -1085,7 +1085,7 @@ s     */
         $path = "//Question";
         $xpc = xpath_new_context($temp_dom);
         $res = xpath_eval($xpc, $path);
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $parent_node = $res->nodeset[$i]->parent_node();
             $parent_node->unlink_node($parent_node);
         }
@@ -1137,7 +1137,7 @@ s     */
                     if ($a_omit_pageobject_tag) {
                         $xml = "";
                         $childs = $this->node->child_nodes();
-                        for ($i = 0; $i < count($childs); $i++) {
+                        for ($i = 0, $iMax = count($childs); $i < $iMax; $i++) {
                             $xml .= $this->dom->dump_node($childs[$i]);
                         }
                     } else {
@@ -1342,7 +1342,7 @@ s     */
         $path = "//MediaObject/MediaAlias";
         $res = xpath_eval($xpc, $path);
         $mob_ids = array();
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $id_arr = explode("_", $res->nodeset[$i]->get_attribute("OriginId"));
             $mob_id = $id_arr[count($id_arr) - 1];
             $mob_ids[$mob_id] = $mob_id;
@@ -1352,7 +1352,7 @@ s     */
         $xpc = xpath_new_context($this->dom);
         $path = "//InteractiveImage/MediaAlias";
         $res = xpath_eval($xpc, $path);
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $id_arr = explode("_", $res->nodeset[$i]->get_attribute("OriginId"));
             $mob_id = $id_arr[count($id_arr) - 1];
             $mob_ids[$mob_id] = $mob_id;
@@ -1363,7 +1363,7 @@ s     */
         $path = "//IntLink[@Type = 'MediaObject']";
         $res = xpath_eval($xpc, $path);
 
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             if (($res->nodeset[$i]->get_attribute("TargetFrame") == "") ||
                 (!$a_inline_only)) {
                 $target = $res->nodeset[$i]->get_attribute("Target");
@@ -1395,7 +1395,7 @@ s     */
 
         $links = array();
         $cnt_multiple = 1;
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $add = "";
             if ($a_cnt_multiple) {
                 $add = ":" . $cnt_multiple;
@@ -1433,7 +1433,7 @@ s     */
         $path = "//MediaAlias";
         $res = xpath_eval($xpc, $path);
 
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $oid = $res->nodeset[$i]->get_attribute("OriginId");
             if (substr($oid, 0, 4) == "il__") {
                 $id_arr = explode("_", $oid);
@@ -1532,7 +1532,7 @@ s     */
         }
 
         $res = xpath_eval($xpc, $path);
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $cnode = $res->nodeset[$i];
             $ctag = $cnode->node_name();
 
@@ -1603,7 +1603,7 @@ s     */
         $xpc = xpath_new_context($this->dom);
         $path = "//PageObject";
         $res = xpath_eval($xpc, $path);
-        for ($i = 0; $i < count($res->nodeset); $i++) {    // should only be 1
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {    // should only be 1
             $res->nodeset[$i]->set_attribute("HierId", "pg");
             $this->hier_ids[] = "pg";
         }
@@ -1663,7 +1663,7 @@ s     */
             $xpc = xpath_new_context($this->dom);
             $path = "//*[@HierId]";
             $res = xpath_eval($xpc, $path);
-            for ($i = 0; $i < count($res->nodeset); $i++) {    // should only be 1
+            for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {    // should only be 1
                 if ($res->nodeset[$i]->has_attribute("HierId")) {
                     $res->nodeset[$i]->remove_attribute("HierId");
                 }
@@ -1686,7 +1686,7 @@ s     */
             $xpc = xpath_new_context($this->dom);
             $path = "//*[@PCID]";
             $res = xpath_eval($xpc, $path);
-            for ($i = 0; $i < count($res->nodeset); $i++) {    // should only be 1
+            for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {    // should only be 1
                 $pc_id = $res->nodeset[$i]->get_attribute("PCID");
                 if (in_array($pc_id, $a_pc_ids)) {
                     $ret[$pc_id] = $res->nodeset[$i]->get_attribute("HierId");
@@ -1718,7 +1718,7 @@ s     */
             $xpc = xpath_new_context($this->dom);
             $path = "//*[@HierId]";
             $res = xpath_eval($xpc, $path);
-            for ($i = 0; $i < count($res->nodeset); $i++) {    // should only be 1
+            for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {    // should only be 1
                 $hier_id = $res->nodeset[$i]->get_attribute("HierId");
                 if (in_array($hier_id, $hier_ids)) {
                     $ret[$hier_id] = $res->nodeset[$i]->get_attribute("PCID");
@@ -1744,14 +1744,14 @@ s     */
         $xpc = xpath_new_context($this->dom);
         $path = "//FileItem";
         $res = xpath_eval($xpc, $path);
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $cnode = $res->nodeset[$i];
             $size_node = $this->dom->create_element("Size");
             $size_node = $cnode->append_child($size_node);
 
             $childs = $cnode->child_nodes();
             $size = "";
-            for ($j = 0; $j < count($childs); $j++) {
+            for ($j = 0, $jMax = count($childs); $j < $jMax; $j++) {
                 if ($childs[$j]->node_name() == "Identifier") {
                     if ($childs[$j]->has_attribute("Entry")) {
                         $entry = $childs[$j]->get_attribute("Entry");
@@ -1781,7 +1781,7 @@ s     */
         $xpc = xpath_new_context($this->dom);
         $path = "//IntLink";
         $res = xpath_eval($xpc, $path);
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $target = $res->nodeset[$i]->get_attribute("Target");
             $type = $res->nodeset[$i]->get_attribute("Type");
 
@@ -1818,7 +1818,7 @@ s     */
         $res = xpath_eval($xpc, $path);
         //echo "<br><b>page::resolve</b><br>";
         //echo "Content:".htmlentities($this->getXMLFromDOM()).":<br>";
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $orig_id = $res->nodeset[$i]->get_attribute("OriginId");
             $id_arr = explode("_", $orig_id);
             $mob_id = $id_arr[count($id_arr) - 1];
@@ -1841,7 +1841,7 @@ s     */
         $path = "//MediaAlias";
         $res = xpath_eval($xpc, $path);
         $changed = false;
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             // get the ID of the import file from the xml
             $old_id = $res->nodeset[$i]->get_attribute("OriginId");
             $old_id = explode("_", $old_id);
@@ -1896,7 +1896,7 @@ s     */
         $path = "//InteractiveImage/MediaAlias";
         $res = xpath_eval($xpc, $path);
         $changed = false;
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $old_id = $res->nodeset[$i]->get_attribute("OriginId");
             if ($a_mapping[$old_id] > 0) {
                 $res->nodeset[$i]->set_attribute("OriginId", "il__mob_" . $a_mapping[$old_id]);
@@ -1920,7 +1920,7 @@ s     */
         $path = "//FileItem/Identifier";
         $res = xpath_eval($xpc, $path);
         $changed = false;
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $old_id = $res->nodeset[$i]->get_attribute("Entry");
             $old_id = explode("_", $old_id);
             $old_id = $old_id[count($old_id) - 1];
@@ -1946,7 +1946,7 @@ s     */
         $path = "//Question";
         $res = xpath_eval($xpc, $path);
         $updated = false;
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $qref = $res->nodeset[$i]->get_attribute("QRef");
 
             if (isset($a_mapping[$qref])) {
@@ -1975,7 +1975,7 @@ s     */
         $xpc = xpath_new_context($this->dom);
         $path = "//IntLink";
         $res = xpath_eval($xpc, $path);
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $target = $res->nodeset[$i]->get_attribute("Target");
             $type = $res->nodeset[$i]->get_attribute("Type");
             $obj_id = ilInternalLink::_extractObjIdOfTarget($target);
@@ -2002,7 +2002,7 @@ s     */
         $path = "//MediaAlias";
         $res = xpath_eval($xpc, $path);
 
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $media_object_node = $res->nodeset[$i]->parent_node();
             $page_content_node = $media_object_node->parent_node();
             $c_hier_id = $page_content_node->get_attribute("HierId");
@@ -2157,7 +2157,7 @@ s     */
         $path = "//IntLink";
         $res = xpath_eval($xpc, $path);
         //echo "1";
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             //echo "2";
             $target = $res->nodeset[$i]->get_attribute("Target");
             $type = $res->nodeset[$i]->get_attribute("Type");
@@ -2190,7 +2190,7 @@ s     */
         $xpc = xpath_new_context($this->dom);
         $path = "//IntLink";
         $res = xpath_eval($xpc, $path);
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $target = $res->nodeset[$i]->get_attribute("Target");
             $type = $res->nodeset[$i]->get_attribute("Type");
             $this->log->debug("Target: " . $target);
@@ -2214,7 +2214,7 @@ s     */
                         $new_node = $source_node->clone_node(true);
                         $new_node->unlink_node($new_node);
                         $childs = $new_node->child_nodes();
-                        for ($j = 0; $j < count($childs); $j++) {
+                        for ($j = 0, $jMax = count($childs); $j < $jMax; $j++) {
                             $this->log->debug("... move node $j " . $childs[$j]->node_name() . " before " . $source_node->node_name());
                             $source_node->insert_before($childs[$j], $source_node);
                         }
@@ -2230,7 +2230,7 @@ s     */
         $xpc = xpath_new_context($this->dom);
         $path = "//ExtLink";
         $res = xpath_eval($xpc, $path);
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $href = $res->nodeset[$i]->get_attribute("Href");
             $this->log->debug("Href: " . $href);
 
@@ -2304,7 +2304,7 @@ s     */
                         $new_node = $source_node->clone_node(true);
                         $new_node->unlink_node($new_node);
                         $childs = $new_node->child_nodes();
-                        for ($j = 0; $j < count($childs); $j++) {
+                        for ($j = 0, $jMax = count($childs); $j < $jMax; $j++) {
                             $this->log->debug("... move node $j " . $childs[$j]->node_name() . " before " . $source_node->node_name());
                             $source_node->insert_before($childs[$j], $source_node);
                         }
@@ -3564,7 +3564,7 @@ s     */
         $xpc = xpath_new_context($this->dom);
         $path = "//IntLink";
         $res = xpath_eval($xpc, $path);
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $target = $res->nodeset[$i]->get_attribute("Target");
             $type = $res->nodeset[$i]->get_attribute("Type");
 
@@ -3604,7 +3604,7 @@ s     */
         $xpc = xpath_new_context($this->dom);
         $path = "//MediaAlias";
         $res = xpath_eval($xpc, $path);
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $origin_id = $res->nodeset[$i]->get_attribute("OriginId");
             if (substr($origin_id, 0, 4) == "il__") {
                 $new_id = "il_" . $a_inst . "_" . substr($origin_id, 4, strlen($origin_id) - 4);
@@ -3617,7 +3617,7 @@ s     */
         $xpc = xpath_new_context($this->dom);
         $path = "//FileItem/Identifier";
         $res = xpath_eval($xpc, $path);
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $origin_id = $res->nodeset[$i]->get_attribute("Entry");
             if (substr($origin_id, 0, 4) == "il__") {
                 $new_id = "il_" . $a_inst . "_" . substr($origin_id, 4, strlen($origin_id) - 4);
@@ -3630,7 +3630,7 @@ s     */
         $xpc = xpath_new_context($this->dom);
         $path = "//Question";
         $res = xpath_eval($xpc, $path);
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $qref = $res->nodeset[$i]->get_attribute("QRef");
             //echo "<br>setted:".$qref;
             if (substr($qref, 0, 4) == "il__") {
@@ -3645,7 +3645,7 @@ s     */
         $xpc = xpath_new_context($this->dom);
         $path = "//ContentInclude";
         $res = xpath_eval($xpc, $path);
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $ci = $res->nodeset[$i]->get_attribute("InstId");
             if ($ci == "") {
                 $res->nodeset[$i]->set_attribute("InstId", $a_inst);
@@ -3698,7 +3698,7 @@ s     */
         $xpc = xpath_new_context($mydom);
         $res = xpath_eval($xpc, $path);
 
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $node = $res->nodeset[$i];
             $pcids[] = $node->get_attribute("PCID");
         }
@@ -3722,7 +3722,7 @@ s     */
         $xpc = xpath_new_context($mydom);
         $res = xpath_eval($xpc, $path);
 
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $node = $res->nodeset[$i];
             $pc_id = $node->get_attribute("PCID");
             if ($pc_id != "") {
@@ -3777,7 +3777,7 @@ s     */
         $xpc = xpath_new_context($mydom);
         $res = xpath_eval($xpc, $path);
 
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $id = self::randomhash();
             $res->nodeset[$i]->set_attribute("PCID", $id);
         }
@@ -3798,7 +3798,7 @@ s     */
         $res = xpath_eval($xpc, $path);
 
         $hashes = array();
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $hier_id = $res->nodeset[$i]->get_attribute("HierId");
             $pc_id = $res->nodeset[$i]->get_attribute("PCID");
             $dump = $mydom->dump_node($res->nodeset[$i]);
@@ -3840,7 +3840,7 @@ s     */
         $res = xpath_eval($xpc, $path);
 
         $q_ids = array();
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $qref = $res->nodeset[$i]->get_attribute("QRef");
             $inst_id = ilInternalLink::_extractInstOfTarget($qref);
             $obj_id = ilInternalLink::_extractObjIdOfTarget($qref);
@@ -3879,7 +3879,7 @@ s     */
 
         $childs = $context_node->child_nodes();
 
-        for ($j = 0; $j < count($childs); $j++) {
+        for ($j = 0, $jMax = count($childs); $j < $jMax; $j++) {
             $content .= $mydom->dump_node($childs[$j]);
         }
 
@@ -4568,7 +4568,7 @@ s     */
             if (count($res->nodeset) > 0) {
                 $init_node = $res->nodeset[0];
                 $childs = $init_node->child_nodes();
-                for ($i = 0; $i < count($childs); $i++) {
+                for ($i = 0, $iMax = count($childs); $i < $iMax; $i++) {
                     if ($childs[$i]->node_name() == "IntLink") {
                         $il_node = $childs[$i];
                     }
@@ -4605,7 +4605,7 @@ s     */
         if (count($res->nodeset) > 0) {
             $init_node = $res->nodeset[0];
             $childs = $init_node->child_nodes();
-            for ($i = 0; $i < count($childs); $i++) {
+            for ($i = 0, $iMax = count($childs); $i < $iMax; $i++) {
                 if ($childs[$i]->node_name() == "IntLink") {
                     $il_node = $childs[$i];
                 }
@@ -5023,7 +5023,7 @@ s     */
         $xpc = xpath_new_context($this->dom);
         $path = "//FileItem/Identifier";
         $res = xpath_eval($xpc, $path);
-        for ($i = 0; $i < count($res->nodeset); $i++) {
+        for ($i = 0, $iMax = count($res->nodeset); $i < $iMax; $i++) {
             $file_obj_ids[] = $res->nodeset[$i]->get_attribute("Entry");
         }
         unset($xpc);

--- a/Services/COPage/classes/class.ilPageObject.php
+++ b/Services/COPage/classes/class.ilPageObject.php
@@ -4936,7 +4936,7 @@ s     */
         }
 
         // THIS IS BUGGY AS IT MIGHT BREAK AN OPEN TAG AT THE END
-        if (!sizeof($open_tags)) {
+        if (!count($open_tags)) {
             // if the words shouldn't be cut in the middle...
             if (!$a_exact) {
                 // ...search the last occurance of a space...

--- a/Services/COPage/classes/class.ilPageObject.php
+++ b/Services/COPage/classes/class.ilPageObject.php
@@ -278,7 +278,7 @@ abstract class ilPageObject
         $this->xml = $this->page_record["content"];
         $this->setParentId((int) $this->page_record["parent_id"]);
         $this->last_change_user = $this->page_record["last_change_user"];
-        $this->create_user = $this->page_record["create_user"];
+        $this->create_user = $this->page_record["create_user"];//@TODO: PHP8 Review: The property is dynamically declared
         $this->setRenderedContent((string) $this->page_record["rendered_content"]);
         $this->setRenderMd5((string) $this->page_record["render_md5"]);
         $this->setRenderedTime((string) $this->page_record["rendered_time"]);

--- a/Services/COPage/classes/class.ilPageObjectGUI.php
+++ b/Services/COPage/classes/class.ilPageObjectGUI.php
@@ -779,7 +779,7 @@ class ilPageObjectGUI
                 $md_gui = new ilObjectMetaDataGUI($this->meta_data_rep_obj, $this->meta_data_type, $this->meta_data_sub_obj_id);
                 if (is_object($this->meta_data_observer_obj)) {
                     $md_gui->addMDObserver(
-                        $this->meta_data_observer_obj,
+                        $this->meta_data_observer_obj,// @TODO: PHP8 Review: Invalid argument. If $this->meta_data_observer_obj can only be ilObject, please change it's type.
                         $this->meta_data_observer_func,
                         "General"
                     );

--- a/Services/COPage/classes/class.ilPageObjectGUI.php
+++ b/Services/COPage/classes/class.ilPageObjectGUI.php
@@ -2096,7 +2096,7 @@ class ilPageObjectGUI
         }
 
         $page_heads = array();
-        foreach ($offsets as $os) {
+        foreach ($offsets as $os) {// @TODO: PHP8 Review: Array is always empty
             $level = (int) substr($a_output, $os + 10, 1);
             if (in_array($level, array(1,2,3))) {
                 $anchor = str_replace(


### PR DESCRIPTION
Hi @alex40724,

sorry for the inconvenience, here is the last last part of the `Services/COPage` review.

### Results
- [ ] There are no serious `PHPStorm Code Inspection` issues left
- [ ] External libraries are compatible with PHP 8 (if relevant, see my comment below)

### Changes made in this PR
- Added `// @TODO: PHP8 Review: Array to string conversion.`
- Added `// @TODO: PHP8 Review: Missing argument.`
- Added `// @TODO: PHP8 Review: Invalid argument.`
- Added `// @TODO: PHP8 Review: Void result used.`
- Added `// @TODO: PHP8 Review: Undefined method.`
- Added `// @TODO: PHP8 Review: Missing return statement.`
- Added `// @TODO: PHP8 Review: Undefined class.`
- Added `// @TODO: PHP8 Review: Array is always empty`
- Added `// @TODO: PHP8 Review: Condition is always false`
- Added `// @TODO: PHP8 Review: Condition is always true`
- Added `// @TODO: PHP8 Review: This is either null or an object, but the object does not implement __toString)`

I am not sure whether `Services/COPage/mediawikidiff/class.WordLevelDiff.php` is compatible with PHP 8. Please check the list item above if you already checked this. There are **a lot** of dynamically declared properties in the library, which will result in issues.

Best regards,
@lscharmer
