### PR TITLE
UI Components, Required Tag, see #32305

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -16329,6 +16329,7 @@ ui#:#ui_invalid_url#:#Das Format der URL ist nicht korrekt.
 ui#:#ui_link_label#:#Label
 ui#:#ui_link_url#:#URL
 ui#:#ui_numeric_only#:#Bitte geben sie eine ganze Zahl ein.
+ui#:#ui_tag_required#:#Bitte geben sie mindestens ein Tag ein.
 user#:#all_roles_has_starting_point#:#Alle Rollen mit definierter Startseite
 user#:#back_to_starting_points_list#:#Zurück zu Startseiten
 user#:#clipboard_add_btn#:#Der Zwischenablage hinzufügen

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -16302,6 +16302,7 @@ ui#:#ui_invalid_url#:#Invalid URL-format
 ui#:#ui_link_label#:#Label
 ui#:#ui_link_url#:#URL
 ui#:#ui_numeric_only#:#Please insert a whole number.
+ui#:#ui_tag_required#:#Please insert at least one tag.
 user#:#all_roles_has_starting_point#:#All the roles have starting points
 user#:#back_to_starting_points_list#:#Back to Starting Points
 user#:#clipboard_add_btn#:#Add to Clipboard

--- a/src/UI/Implementation/Component/Input/Field/Tag.php
+++ b/src/UI/Implementation/Component/Input/Field/Tag.php
@@ -101,18 +101,12 @@ class Tag extends Input implements FormInputInternal, C\Input\Field\Tag
      */
     protected function getConstraintForRequirement() : ?Constraint
     {
-        return $this->refinery->custom()->constraint(
-            function ($value) {
-                $valueIsAString = $this->refinery
-                    ->to()
-                    ->string()
-                    ->applyTo(new Ok($value))
-                    ->isOK();
-
-                return ($valueIsAString);
-            },
-            "No string"
-        );
+        return $this->refinery->logical()->sequential([
+            $this->refinery->logical()->not($this->refinery->null()),
+            $this->refinery->string()->hasMinLength(1)
+        ])->withProblemBuilder(function ($txt) {
+            return $txt('ui_tag_required');
+        });
     }
 
     /**

--- a/tests/UI/Component/Input/Field/TagInputTest.php
+++ b/tests/UI/Component/Input/Field/TagInputTest.php
@@ -200,8 +200,28 @@ class TagInputTest extends ILIAS_UI_TestBase
 
         $tag2 = $tag->withInput(new DefInputData([$name => '']));
         $result = $tag2->getContent();
+        $this->assertFalse($result->isOk());
+        try {
+            $result->value();
+            $this->fail();
+        } catch (Exception $e) {
+            $this->assertInstanceOf('ILIAS\Data\NotOKException', $e);
+        }
+    }
+
+    public function testStringAsInputAsRequired() : void
+    {
+        $f = $this->buildFactory();
+        $label = "label";
+        $name = "name_0";
+        $tags = ["lorem", "ipsum", "dolor",];
+        /** @var I\Input\Field\Tag $tag */
+        $tag = $f->tag($label, $tags)->withNameFrom($this->name_source)->withRequired(true);
+
+        $tag2 = $tag->withInput(new DefInputData([$name => 'test']));
+        $result = $tag2->getContent();
         $this->assertTrue($result->isOk());
-        $this->assertEquals([], $result->value());
+        $this->assertEquals(['test'], $result->value());
     }
 
     public function testNullValueLeadsToException() : void


### PR DESCRIPTION
Empty string are not allowed for required Tags, see: https://mantis.ilias.de/view.php?id=32305 , including prooper translation of error.