### PR TITLE
Allow blank linkes in PHPDoc comments.

### DIFF
--- a/docs/development/code-style-configs/php-storm.xml
+++ b/docs/development/code-style-configs/php-storm.xml
@@ -1,8 +1,8 @@
-<code_scheme name="ILIAS Coding Style 4/2020" version="174">
+<code_scheme name="ILIAS Coding Style 3/2022" version="175">
   <PHPCodeStyleSettings>
     <option name="ALIGN_PHPDOC_PARAM_NAMES" value="true" />
     <option name="ALIGN_PHPDOC_COMMENTS" value="true" />
-    <option name="PHPDOC_KEEP_BLANK_LINES" value="true"/>
+    <option name="PHPDOC_KEEP_BLANK_LINES" value="true" />
     <option name="IMPORT_SORTING" value="DONT_SORT" />
     <option name="LOWER_CASE_BOOLEAN_CONST" value="true" />
     <option name="LOWER_CASE_NULL_CONST" value="true" />

--- a/docs/development/code-style-configs/php-storm.xml
+++ b/docs/development/code-style-configs/php-storm.xml
@@ -2,7 +2,7 @@
   <PHPCodeStyleSettings>
     <option name="ALIGN_PHPDOC_PARAM_NAMES" value="true" />
     <option name="ALIGN_PHPDOC_COMMENTS" value="true" />
-    <option name="PHPDOC_KEEP_BLANK_LINES" value="false" />
+    <option name="PHPDOC_KEEP_BLANK_LINES" value="true"/>
     <option name="IMPORT_SORTING" value="DONT_SORT" />
     <option name="LOWER_CASE_BOOLEAN_CONST" value="true" />
     <option name="LOWER_CASE_NULL_CONST" value="true" />

--- a/src/UI/Component/Input/Field/Factory.php
+++ b/src/UI/Component/Input/Field/Factory.php
@@ -38,8 +38,8 @@ interface Factory
      *         of text-input may not be exceeded (e.g. due to database-limitations).
      *
      * ---
-     * @param    string      $label
-     * @param    string|null $byline
+     * @param string      $label
+     * @param string|null $byline
      * @return    \ILIAS\UI\Component\Input\Field\Text
      */
     public function text(string $label, string $byline = null) : Text;
@@ -63,9 +63,12 @@ interface Factory
      *         options MUST NOT be used.
      *     3: A valid input range SHOULD be specified.
      *
+     *
+     *
+     *
      * ---
-     * @param    string      $label
-     * @param    string|null $byline
+     * @param string      $label
+     * @param string|null $byline
      * @return    \ILIAS\UI\Component\Input\Field\Numeric
      */
     public function numeric(string $label, string $byline = null) : Numeric;


### PR DESCRIPTION
A known issue with PHPStorm when editing the Kitchensink interfaces is that all blank lines will be removed when the PHPDoc string was modified (even if the reformatting is only applied for "changed lines"). This change would "fix" that behaviour by allowing blank lines in PHPDoc comments.