### PR TITLE
PHP 8: Code Review `Link`

### DIFF
--- a/Services/Link/classes/class.ilIntLinkRepItemExplorerGUI.php
+++ b/Services/Link/classes/class.ilIntLinkRepItemExplorerGUI.php
@@ -58,18 +58,16 @@ class ilIntLinkRepItemExplorerGUI extends ilRepositorySelectorExplorerGUI
      */
     public function getNodeHref($a_node) : string
     {
-        if ($this->getSetLinkTargetScript() == "") {
+        if ($this->getSetLinkTargetScript() === "") {
             return "#";
-        } else {
-            $link =
-                ilUtil::appendUrlParameterString(
-                    $this->getSetLinkTargetScript(),
-                    "linktype=RepositoryItem" .
-                    "&linktarget=il__" . $a_node["type"] . "_" . $a_node["child"]
-                );
-
-            return $link;
         }
+
+        $link = ilUtil::appendUrlParameterString(
+            $this->getSetLinkTargetScript(),
+            "linktype=RepositoryItem&linktarget=il__" . $a_node["type"] . "_" . $a_node["child"]
+        );
+
+        return $link;
     }
 
     /**
@@ -78,9 +76,10 @@ class ilIntLinkRepItemExplorerGUI extends ilRepositorySelectorExplorerGUI
      */
     public function getNodeOnClick($a_node) : string
     {
-        if ($this->getSetLinkTargetScript() == "") {
+        if ($this->getSetLinkTargetScript() === "") {
             return "return il.IntLink.addInternalLink('[iln " . $a_node['type'] . "=&quot;" . $a_node['child'] . "&quot;]','[/iln]', event);";
         }
+
         return "";
     }
 }

--- a/Services/Link/classes/class.ilInternalLink.php
+++ b/Services/Link/classes/class.ilInternalLink.php
@@ -33,7 +33,7 @@ class ilInternalLink
         $ilDB = $DIC->database();
 
         $lang_where = "";
-        if ($a_lang != "") {
+        if ($a_lang !== "") {
             $lang_where = " AND source_lang = " . $ilDB->quote($a_lang, "text");
         }
         
@@ -141,7 +141,7 @@ class ilInternalLink
         $ilDB = $DIC->database();
 
         $lang_where = "";
-        if ($a_source_lang != "") {
+        if ($a_source_lang !== "") {
             $lang_where = " AND source_lang = " . $ilDB->quote($a_source_lang, "text");
         }
 
@@ -238,7 +238,7 @@ class ilInternalLink
                 // 26 Sep 2018: moved this under the import id handling above
                 // If an imported object is found, this is always preferred.
                 // see also bug #23324
-                if (ilInternalLink::_extractInstOfTarget($a_target) == IL_INST_ID
+                if (self::_extractInstOfTarget($a_target) == IL_INST_ID
                     && IL_INST_ID > 0) {
                     // does it have a ref id part?
                     if ($tarr[4] != "") {
@@ -283,7 +283,7 @@ class ilInternalLink
 
             case "RepositoryItem":
                 if (is_int(strpos($a_target, "_"))) {
-                    $ref_id = ilInternalLink::_extractObjIdOfTarget($a_target);
+                    $ref_id = self::_extractObjIdOfTarget($a_target);
                     return $tree->isInTree($ref_id);
                 }
                 break;

--- a/Services/Link/classes/class.ilInternalLinkGUI.php
+++ b/Services/Link/classes/class.ilInternalLinkGUI.php
@@ -37,7 +37,6 @@ class ilInternalLinkGUI
     public string $set_link_script = "";
     /** @var array<string, string> array link types */
     protected array $ltypes = [];
-    // @var array parent object types for link base types
     /** @var array<string, string> parent object types for link base types */
     protected array $parent_type = [];
     public ilCtrl $ctrl;

--- a/Services/Link/classes/class.ilInternalLinkGUI.php
+++ b/Services/Link/classes/class.ilInternalLinkGUI.php
@@ -35,13 +35,15 @@ class ilInternalLinkGUI
     protected string $link_target = "";		// "New"
     protected string $base_link_type = "";	// "PageObject"
     public string $set_link_script = "";
-    // @var array link types
-    protected array $ltypes = array();
+    /** @var array<string, string> array link types */
+    protected array $ltypes = [];
     // @var array parent object types for link base types
-    protected array $parent_type = array();
+    /** @var array<string, string> parent object types for link base types */
+    protected array $parent_type = [];
     public ilCtrl $ctrl;
     protected bool $filter_white_list = false;
-    protected array $filter_link_types = array();
+    /** @var string[] */
+    protected array $filter_link_types = [];
     protected ilTree $tree;
     protected ilLanguage $lng;
     protected ilObjUser $user;
@@ -140,14 +142,14 @@ class ilInternalLinkGUI
         } else {
             $ltypes = array();
             foreach ($this->ltypes as $k => $l) {
-                if (in_array($k, $this->filter_link_types)) {
+                if (in_array($k, $this->filter_link_types, true)) {
                     $ltypes[$k] = $l;
                 }
             }
             $this->ltypes = $ltypes;
         }
         // determine link type and target
-        $this->link_type = ($this->request->getLinkType() == "")
+        $this->link_type = ($this->request->getLinkType() === "")
             ? $this->default_link_type
             : $this->request->getLinkType();
         $ltype_arr = explode("_", $this->link_type);
@@ -166,12 +168,12 @@ class ilInternalLinkGUI
             case "WikiPage":
             case "PortfolioPage":
             case "PortfolioTemplatePage":
-                if ($this->parent_ref_id == 0 && $this->parent_obj_id == 0
-                    && $def_type == $this->parent_type[$this->base_link_type]) {
+                if ($this->parent_ref_id === 0 && $this->parent_obj_id === 0
+                    && $def_type === $this->parent_type[$this->base_link_type]) {
                     $this->parent_ref_id = $this->default_parent_ref_id;
                     $this->parent_obj_id = $this->default_parent_obj_id;
-                    $ctrl->setParameter($this, "link_par_obj_id", (int) $this->parent_obj_id);
-                    $ctrl->setParameter($this, "link_par_ref_id", (int) $this->parent_ref_id);
+                    $ctrl->setParameter($this, "link_par_obj_id", $this->parent_obj_id);
+                    $ctrl->setParameter($this, "link_par_ref_id", $this->parent_ref_id);
                 }
                 break;
         }
@@ -235,7 +237,7 @@ class ilInternalLinkGUI
 
     public function closeLinkHelp() : void
     {
-        if ($this->return == "") {
+        if ($this->return === "") {
             $this->ctrl->returnToParent($this);
         } else {
             ilUtil::redirect($this->return);
@@ -261,12 +263,12 @@ class ilInternalLinkGUI
 
 
         $parent_type = $this->parent_type[$this->base_link_type];
-        if ((in_array($this->base_link_type, array("GlossaryItem", "WikiPage", "PageObject", "StructureObject")) &&
-            ($this->parent_ref_id == 0))
+        if ((in_array($this->base_link_type, array("GlossaryItem", "WikiPage", "PageObject", "StructureObject"), true) &&
+            ($this->parent_ref_id === 0))
             ||
             (($this->parent_ref_id > 0) &&
-                ilObject::_lookupType($this->parent_ref_id, true) != $parent_type)) {
-            if ($parent_type != "") {
+                ilObject::_lookupType($this->parent_ref_id, true) !== $parent_type)) {
+            if ($parent_type !== "") {
                 $this->changeTargetObject($parent_type);
             }
         }
@@ -330,7 +332,7 @@ class ilInternalLinkGUI
                 $tpl->parseCurrentBlock();
 
                 foreach ($nodes as $node) {
-                    if ($node["type"] == "st") {
+                    if ($node["type"] === "st") {
                         $tpl->setCurrentBlock("header_row");
                         $tpl->setVariable("TXT_HEADER", $node["title"]);
                         $tpl->parseCurrentBlock();
@@ -338,7 +340,7 @@ class ilInternalLinkGUI
                         $tpl->parseCurrentBlock();
                     }
 
-                    if ($node["type"] == "pg") {
+                    if ($node["type"] === "pg") {
                         $this->renderLink(
                             $tpl,
                             $node["title"],
@@ -386,7 +388,7 @@ class ilInternalLinkGUI
             case "StructureObject":
             
                 // check whether current object matchs to type
-                if (ilObject::_lookupType($this->parent_ref_id, true) != "lm") {
+                if (ilObject::_lookupType($this->parent_ref_id, true) !== "lm") {
                     $this->changeTargetObject("lm");
                 }
 
@@ -405,7 +407,7 @@ class ilInternalLinkGUI
                 $tpl->parseCurrentBlock();
 
                 foreach ($nodes as $node) {
-                    if ($node["type"] == "st") {
+                    if ($node["type"] === "st") {
                         $this->renderLink(
                             $tpl,
                             $node["title"],
@@ -454,7 +456,7 @@ class ilInternalLinkGUI
             case "Media":
                 //$tpl->setVariable("TARGET2", " target=\"content\" ");
                 // content object id = 0 --> get clipboard objects
-                if ($this->parent_ref_id == 0) {
+                if ($this->parent_ref_id === 0) {
                     $tpl->setCurrentBlock("change_cont_obj");
                     $tpl->setVariable("CMD_CHANGE_CONT_OBJ", "changeTargetObject");
                     $tpl->setVariable("BTN_CHANGE_CONT_OBJ", $this->lng->txt("change"));
@@ -535,7 +537,7 @@ class ilInternalLinkGUI
                         $tpl->parseCurrentBlock();
                     }
                     foreach ($objs as $obj) {
-                        if ($obj["type"] == "fold") {
+                        if ($obj["type"] === "fold") {
                             $tpl->setCurrentBlock("icon");
                             $tpl->setVariable("ICON_SRC", ilUtil::getImagePath("icon_fold.svg"));
                             $tpl->parseCurrentBlock();
@@ -557,7 +559,7 @@ class ilInternalLinkGUI
                             $tpl->parseCurrentBlock();
                         } else {
                             $fid = ilMediaPoolItem::lookupForeignId($obj["child"]);
-                            if (ilObject::_lookupType($fid) == "mob") {
+                            if (ilObject::_lookupType($fid) === "mob") {
                                 $this->renderLink(
                                     $tpl,
                                     $obj["title"],
@@ -745,7 +747,7 @@ class ilInternalLinkGUI
         $med = $mob->getMediaItem("Standard");
         $target = $med->getThumbnailTarget("small");
         $suff = "";
-        if ($this->getSetLinkTargetScript() != "") {
+        if ($this->getSetLinkTargetScript() !== "") {
             $tpl->setCurrentBlock("thumbnail_link");
             $suff = "_link";
         } else {
@@ -753,7 +755,7 @@ class ilInternalLinkGUI
             $suff = "_js";
         }
 
-        if ($target != "") {
+        if ($target !== "") {
             $tpl->setCurrentBlock("thumb" . $suff);
             $tpl->setVariable("SRC_THUMB", $target);
             $tpl->parseCurrentBlock();
@@ -761,7 +763,7 @@ class ilInternalLinkGUI
             $tpl->setVariable("NO_THUMB", "&nbsp;");
         }
         
-        if ($this->getSetLinkTargetScript() != "") {
+        if ($this->getSetLinkTargetScript() !== "") {
             $tpl->setCurrentBlock("thumbnail_link");
         } else {
             $tpl->setCurrentBlock("thumbnail_js");
@@ -775,7 +777,7 @@ class ilInternalLinkGUI
 
         $ctrl->setParameter($this, "link_type", $this->request->getLinkType());
         $base_type = explode("_", $this->request->getLinkType())[0];
-        if ($this->parent_type[$base_type] != ilObject::_lookupType($this->parent_ref_id, true)) {
+        if ($this->parent_type[$base_type] !== ilObject::_lookupType($this->parent_ref_id, true)) {
             $ctrl->setParameter($this, "link_par_ref_id", 0);
             $ctrl->setParameter($this, "link_par_obj_id", 0);
         }
@@ -807,7 +809,7 @@ class ilInternalLinkGUI
 
         $white[] = $a_type;
         $exp->setClickableType($a_type);
-        if ($a_type == "prtf") {
+        if ($a_type === "prtf") {
             $white[] = "prtt";
             $exp->setClickableType("prtt");
         }
@@ -830,8 +832,8 @@ class ilInternalLinkGUI
         $ilCtrl = $this->ctrl;
 
         $ilCtrl->setParameter($this, "link_par_fold_id", "");
-        if ($this->request->getDo() == "set") {
-            $ilCtrl->setParameter($this, "link_par_ref_id", (int) $this->request->getSelectedId());
+        if ($this->request->getDo() === "set") {
+            $ilCtrl->setParameter($this, "link_par_ref_id", $this->request->getSelectedId());
             $ilCtrl->redirect($this, "showLinkHelp", "", true);
             return;
         }
@@ -849,7 +851,7 @@ class ilInternalLinkGUI
         $tpl->setVariable("BTN_RESET", "resetLinkList");
         $tpl->setVariable("TXT_RESET", $this->lng->txt("back"));
 
-        if ($this->parent_type[$this->base_link_type] == "mep") {
+        if ($this->parent_type[$this->base_link_type] === "mep") {
             $tpl->setCurrentBlock("sel_clipboard");
             $this->ctrl->setParameter($this, "do", "set");
             if ($ilCtrl->isAsynch()) {
@@ -949,13 +951,13 @@ class ilInternalLinkGUI
         $chapterRowBlock = "chapter_row_js";
         $anchor_row_block = "anchor_link_js";
 
-        $target_str = ($this->link_target == "")
+        $target_str = ($this->link_target === "")
             ? ""
             : " target=\"" . $this->link_target . "\"";
 
         if (count($a_anchors) > 0) {
             foreach ($a_anchors as $anchor) {
-                if ($this->getSetLinkTargetScript() != "") {
+                if ($this->getSetLinkTargetScript() !== "") {
                     // not implemented yet (anchors that work with map areas)
 
                     /*$tpl->setCurrentBlock("anchor_link");
@@ -980,9 +982,9 @@ class ilInternalLinkGUI
             }
         }
 
-        if ($this->getSetLinkTargetScript() != "") {
+        if ($this->getSetLinkTargetScript() !== "") {
             ilImageMapEditorGUI::_recoverParameters();
-            if ($a_type == "MediaObject") {
+            if ($a_type === "MediaObject") {
                 $this->outputThumbnail($tpl, $a_obj_id);
             }
             $tpl->setCurrentBlock("link_row");
@@ -998,12 +1000,12 @@ class ilInternalLinkGUI
             );
         } else {
             $tpl->setCurrentBlock($chapterRowBlock);
-            if ($a_type == "MediaObject") {
+            if ($a_type === "MediaObject") {
                 $this->outputThumbnail($tpl, $a_obj_id);
                 $tpl->setCurrentBlock($chapterRowBlock);
             }
             $tpl->setVariable("TXT_CHAPTER", $a_title);
-            if ($a_type == "MediaObject" && empty($target_str)) {
+            if ($a_type === "MediaObject" && empty($target_str)) {
                 $tpl->setVariable(
                     "LINK_BEGIN",
                     $this->prepareJavascriptOutput("[iln " . $a_bb_type . "=\"" . $a_obj_id . "\"/]")
@@ -1073,7 +1075,7 @@ class ilInternalLinkGUI
         $form->checkInput();
 
         $users = ilInternalLink::searchUsers($form->getInput("usr_search_str"));
-        if (count($users) == 0) {
+        if (count($users) === 0) {
             return ilUtil::getSystemMessageHTML($lng->txt("cont_user_search_did_not_match"), "info");
         }
 

--- a/Services/Link/classes/class.ilLink.php
+++ b/Services/Link/classes/class.ilLink.php
@@ -33,7 +33,7 @@ class ilLink
 
         $ilObjDataCache = $DIC["ilObjDataCache"];
 
-        if (!strlen($a_type) && !is_null($a_ref_id)) {
+        if ($a_type === '' && !is_null($a_ref_id)) {
             $a_type = $ilObjDataCache->lookupType($ilObjDataCache->lookupObjId($a_ref_id));
         }
         $param_string = '';
@@ -48,7 +48,7 @@ class ilLink
                 return ILIAS_HTTP_PATH . '/' . self::LINK_SCRIPT . '?client_id=' . CLIENT_ID . $param_string . $append;
             
             default:
-                return ILIAS_HTTP_PATH . '/' . self::LINK_SCRIPT . '?target=' . $a_type . '_' . (string) $a_ref_id . $append . '&client_id=' . CLIENT_ID . $param_string;
+                return ILIAS_HTTP_PATH . '/' . self::LINK_SCRIPT . '?target=' . $a_type . '_' . $a_ref_id . $append . '&client_id=' . CLIENT_ID . $param_string;
         }
     }
 
@@ -69,17 +69,17 @@ class ilLink
 
         $ilObjDataCache = $DIC["ilObjDataCache"];
 
-        if (!strlen($a_type)) {
+        if ($a_type === '') {
             $a_type = $ilObjDataCache->lookupType($ilObjDataCache->lookupObjId($a_ref_id));
         }
         
         $robot_settings = ilRobotSettings::getInstance();
         if (!$robot_settings->robotSupportEnabled()) {
             if ($a_fallback_goto) {
-                return ilLink::_getLink($a_ref_id, $a_type, array(), $append);
-            } else {
-                return false;
+                return self::_getLink($a_ref_id, $a_type, array(), $append);
             }
+
+            return false;
         }
         
         // urlencode for append is needed e.g. to process "/" in wiki page names correctly

--- a/Services/Link/classes/class.ilLinkTargetObjectExplorerGUI.php
+++ b/Services/Link/classes/class.ilLinkTargetObjectExplorerGUI.php
@@ -45,7 +45,7 @@ class ilLinkTargetObjectExplorerGUI extends ilRepositorySelectorExplorerGUI
      *
      * @return string clickable type
      */
-    public function getClickableType()
+    public function getClickableType() : string
     {
         return $this->clickable_type;
     }
@@ -71,7 +71,7 @@ class ilLinkTargetObjectExplorerGUI extends ilRepositorySelectorExplorerGUI
      */
     public function isNodeClickable($a_node) : bool
     {
-        if ($a_node["type"] == $this->getClickableType()) {
+        if ($a_node["type"] === $this->getClickableType()) {
             return true;
         }
         return false;

--- a/Services/Link/test/LinkStandardGUIRequestTest.php
+++ b/Services/Link/test/LinkStandardGUIRequestTest.php
@@ -7,8 +7,6 @@ use PHPUnit\Framework\TestCase;
  */
 class LinkStandardGUIRequestTest extends TestCase
 {
-    //protected $backupGlobals = false;
-
     protected function tearDown() : void
     {
     }
@@ -27,7 +25,7 @@ class LinkStandardGUIRequestTest extends TestCase
         );
     }
 
-    public function testSelectedId()
+    public function testSelectedId() : void
     {
         $request = $this->getRequest(
             [
@@ -43,7 +41,7 @@ class LinkStandardGUIRequestTest extends TestCase
         );
     }
 
-    public function testDo()
+    public function testDo() : void
     {
         $request = $this->getRequest(
             [
@@ -59,7 +57,7 @@ class LinkStandardGUIRequestTest extends TestCase
         );
     }
 
-    public function testMediaPoolFolder()
+    public function testMediaPoolFolder() : void
     {
         $request = $this->getRequest(
             [
@@ -75,7 +73,7 @@ class LinkStandardGUIRequestTest extends TestCase
         );
     }
 
-    public function testLinkType()
+    public function testLinkType() : void
     {
         $request = $this->getRequest(
             [
@@ -91,7 +89,7 @@ class LinkStandardGUIRequestTest extends TestCase
         );
     }
 
-    public function testLinkParentObjId()
+    public function testLinkParentObjId() : void
     {
         $request = $this->getRequest(
             [
@@ -107,7 +105,7 @@ class LinkStandardGUIRequestTest extends TestCase
         );
     }
 
-    public function testLinkParentFolderId()
+    public function testLinkParentFolderId() : void
     {
         $request = $this->getRequest(
             [
@@ -123,7 +121,7 @@ class LinkStandardGUIRequestTest extends TestCase
         );
     }
 
-    public function testLinkParentRefId()
+    public function testLinkParentRefId() : void
     {
         $request = $this->getRequest(
             [
@@ -139,7 +137,7 @@ class LinkStandardGUIRequestTest extends TestCase
         );
     }
 
-    public function testUserSearchString()
+    public function testUserSearchString() : void
     {
         $request = $this->getRequest(
             [

--- a/Services/Link/test/ilServicesLinkSuite.php
+++ b/Services/Link/test/ilServicesLinkSuite.php
@@ -22,7 +22,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilServicesLinkSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new self();
 


### PR DESCRIPTION
Hi @alex40724,

I completed the 3rd part of the review of the `Services/Link` component.

Results:
- [x] The code style is `PSR-2 + X` compliant
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

I also fixed some trivial issues reported by my inspection profile.

--

Actions needed:

None

Best regards,
@mjansenDatabay