### PR TITLE
Hotfix for missing translations when importing a course object.

### DIFF
--- a/Modules/Course/classes/class.ilCourseImporter.php
+++ b/Modules/Course/classes/class.ilCourseImporter.php
@@ -70,6 +70,27 @@ class ilCourseImporter extends ilXmlImporter
 
             // set course offline
             $this->course->setOfflineStatus(true);
+
+            // that stuff is so hacky, but IDGAF.
+            // this is as good as it gets, but one can't tell which
+            // language will be the default.
+            $obj_trans = ilObjectTranslation::getInstance($this->course->getId());
+            $md_obj = new ilMD($this->course->getId(), 0, 'crs');
+            $md_obj = $md_obj->getGeneral();
+            if (false !== $md_obj) {
+                foreach ($md_obj->getDescriptionIds() as $description_id) {
+                    $md_desc = $md_obj->getDescription($description_id);
+                    $obj_trans->addLanguage(
+                        $md_desc->getDescriptionLanguageCode(),
+                        $this->course->getTitle(),
+                        $md_desc->getDescription(),
+                        false
+                    );
+                }
+            }
+
+            $obj_trans->save();
+            $this->course->setObjectTranslation($obj_trans);
             $this->course->update();
 
             $a_mapping->addMapping('Modules/Course', 'crs', $a_id, $this->course->getId());

--- a/Modules/Course/classes/class.ilCourseImporter.php
+++ b/Modules/Course/classes/class.ilCourseImporter.php
@@ -71,26 +71,18 @@ class ilCourseImporter extends ilXmlImporter
             // set course offline
             $this->course->setOfflineStatus(true);
 
-            // that stuff is so hacky, but IDGAF.
-            // this is as good as it gets, but one can't tell which
-            // language will be the default.
-            $obj_trans = ilObjectTranslation::getInstance($this->course->getId());
-            $md_obj = new ilMD($this->course->getId(), 0, 'crs');
-            $md_obj = $md_obj->getGeneral();
-            if (false !== $md_obj) {
-                foreach ($md_obj->getDescriptionIds() as $description_id) {
-                    $md_desc = $md_obj->getDescription($description_id);
-                    $obj_trans->addLanguage(
-                        $md_desc->getDescriptionLanguageCode(),
-                        $this->course->getTitle(),
-                        $md_desc->getDescription(),
-                        false
-                    );
-                }
+            $obj_translations = ilObjectTranslation::getInstance($this->course->getId());
+            foreach ($parser->getI18NContent() as $language => $translations) {
+                $obj_translations->addLanguage(
+                    $language,
+                    $translations['Title'] ?? '',
+                    $translations['Description'] ?? '',
+                    $translations['Default'] ?? false
+                );
             }
 
-            $obj_trans->save();
-            $this->course->setObjectTranslation($obj_trans);
+            $obj_translations->save();
+            $this->course->setObjectTranslation($obj_translations);
             $this->course->update();
 
             $a_mapping->addMapping('Modules/Course', 'crs', $a_id, $this->course->getId());

--- a/Services/MetaData/classes/class.ilMDSaxParser.php
+++ b/Services/MetaData/classes/class.ilMDSaxParser.php
@@ -173,8 +173,10 @@ class ilMDSaxParser extends ilSaxParser
             case 'Title':
                 $par = &$this->__getParent();
                 $par->setTitleLanguage(new ilMDLanguageItem($a_attribs['Language']));
-                $this->addLangEntry($a_attribs['Language']);
-                $this->current_lang_code = $a_attribs['Language'];
+                if ($a_attribs['Language']) {
+                    $this->addLangEntry((string) $a_attribs['Language']);
+                    $this->current_lang_code = (string) $a_attribs['Language'];
+                }
                 break;
 
             case 'Language':
@@ -183,8 +185,10 @@ class ilMDSaxParser extends ilSaxParser
                 $this->md_lan->setLanguage(new ilMDLanguageItem($a_attribs['Language']));
                 $this->md_lan->save();
                 $this->__pushParent($this->md_lan);
-                $this->addLangEntry($a_attribs['Language']);
-                $this->addLangValue($a_attribs['Language'], 'Default', true);
+                if ($a_attribs['Language']) {
+                    $this->addLangEntry((string) $a_attribs['Language']);
+                    $this->addLangValue((string) $a_attribs['Language'], 'Default', true);
+                }
                 // Language has no value to be processed, no need to remember the language.
                 $this->current_lang_code = null;
                 break;
@@ -200,8 +204,10 @@ class ilMDSaxParser extends ilSaxParser
                     $this->md_des->setDescriptionLanguage(new ilMDLanguageItem($a_attribs['Language']));
                     $this->md_des->save();
                     $this->__pushParent($this->md_des);
-                    $this->addLangEntry($a_attribs['Language']);
-                    $this->current_lang_code = $a_attribs['Language'];
+                    if ($a_attribs['Language']) {
+                        $this->addLangEntry((string) $a_attribs['Language']);
+                        $this->current_lang_code = (string) $a_attribs['Language'];
+                    }
                 }
                 break;
 
@@ -462,9 +468,11 @@ class ilMDSaxParser extends ilSaxParser
 
             case 'Title':
                 // we cannot set the title yet, because we must know the default language.
-                $this->addLangValue($this->current_lang_code, 'Title', $this->__getCharacterData());
-                $this->first_title = $this->first_title ?? $this->__getCharacterData();
-                $this->current_lang_code = null;
+                if (null !== $this->current_lang_code) {
+                    $this->addLangValue($this->current_lang_code, 'Title', $this->__getCharacterData());
+                    $this->first_title = $this->first_title ?? $this->__getCharacterData();
+                    $this->current_lang_code = null;
+                }
                 break;
 
             case 'Language':
@@ -481,8 +489,10 @@ class ilMDSaxParser extends ilSaxParser
                     );
                 } else {
                     $par->setDescription($this->__getCharacterData());
-                    $this->addLangValue($this->current_lang_code, 'Description', $this->__getCharacterData());
-                    $this->current_lang_code = null;
+                    if (null !== $this->current_lang_code) {
+                        $this->addLangValue($this->current_lang_code, 'Description', $this->__getCharacterData());
+                        $this->current_lang_code = null;
+                    }
                 }
                 $par->update();
                 if ($par instanceof ilMDDescription) {

--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -834,8 +834,12 @@ class ilObject
 
                 foreach ($md_gen->getDescriptionIds() as $id) {
                     $md_des = $md_gen->getDescription($id);
-                    $this->setDescription($md_des->getDescription());
-                    break;
+                    // not that this change will handle i18n more strictly, since the
+                    // description will only be used if it matches the title's language.
+                    if ($md_des->getDescriptionLanguageCode() === $md_gen->getTitleLanguageCode()) {
+                        $this->setDescription($md_des->getDescription());
+                        break;
+                    }
                 }
                 $this->update();
                 break;
@@ -885,12 +889,16 @@ class ilObject
         // END WebDAV: meta data can be missing sometimes.
         $md_gen->setTitle($this->getTitle());
 
-        // sets first description (maybe not appropriate)
+        // sets first description (maybe not appropriate) -> nope, it's not.
         $md_des_ids = $md_gen->getDescriptionIds();
-        if (count($md_des_ids) > 0) {
-            $md_des = $md_gen->getDescription($md_des_ids[0]);
-            $md_des->setDescription($this->getLongDescription());
-            $md_des->update();
+        foreach ($md_des_ids as $id) {
+            $md_des = $md_gen->getDescription($id);
+            // Only update the description that corresponds to the title language,
+            // otherwise wrong translations might be overwritten.
+            if ($md_des->getDescriptionLanguageCode() === $md_gen->getTitleLanguageCode()) {
+                $md_des->setDescription($this->getLongDescription());
+                $md_des->update();
+            }
         }
         $md_gen->update();
     }


### PR DESCRIPTION
Hello @smeyer-ilias

This will probably not be merged, since you'd have to implement this for every other object too, but it would be a hotfix in order to import courses which have multilingualism active.

This is sort of the opposite of https://mantis.ilias.de/view.php?id=32216.

Kind regards.