### PR TITLE
PHP 8: Code Review `Authentication`

### DIFF
--- a/Services/Authentication/classes/Cookie/class.ilCookie.php
+++ b/Services/Authentication/classes/Cookie/class.ilCookie.php
@@ -22,27 +22,26 @@
  */
 class ilCookie
 {
-    private $name = '';// TODO PHP8-REVIEW Property type missing
-    private $value = '';// TODO PHP8-REVIEW Property type missing
-    private $expire = 0;// TODO PHP8-REVIEW Property type missing
-    private $path = '';// TODO PHP8-REVIEW Property type missing
-    private $domain = '';// TODO PHP8-REVIEW Property type missing
-    private $secure = false;// TODO PHP8-REVIEW Property type missing
-    private $http_only = false;// TODO PHP8-REVIEW Property type missing
+    private string $name;
+    private string $value = '';
+    private int $expire = 0;
+    private string $path = '';
+    private string $domain = '';
+    private bool $secure = false;
+    private bool $http_only = false;
     
-    public function __construct($a_name)// TODO PHP8-REVIEW Type hints missing
+    public function __construct(string $a_name)
     {
-        $this->setName($a_name);
+        $this->name = $a_name;
     }
     
-    public function setName($a_name) : void// TODO PHP8-REVIEW Type hints missing
+    public function setName(string $a_name) : void
     {
         $this->name = $a_name;
     }
     
     /**
      * Get name
-     * @return string
      */
     public function getName() : string
     {
@@ -52,9 +51,8 @@ class ilCookie
     /**
      * Currently no restriction on cookie length.
      * RFC 2965 suggests a minimum of 4096 bytes
-     * @param string $a_value
      */
-    public function setValue($a_value) : void// TODO PHP8-REVIEW Type hints missing
+    public function setValue(string $a_value) : void
     {
         $this->value = $a_value;
     }
@@ -64,9 +62,9 @@ class ilCookie
         return $this->value;
     }
     
-    public function setExpire($a_expire) : void// TODO PHP8-REVIEW Type hints missing
+    public function setExpire(int $a_expire) : void
     {
-        $this->expire = (int) $a_expire;
+        $this->expire = $a_expire;
     }
     
     public function getExpire() : int
@@ -74,7 +72,7 @@ class ilCookie
         return $this->expire;
     }
     
-    public function setPath($a_path) : void// TODO PHP8-REVIEW Type hints missing
+    public function setPath(string $a_path) : void
     {
         $this->path = $a_path;
     }
@@ -84,7 +82,7 @@ class ilCookie
         return $this->path;
     }
     
-    public function setDomain($a_domain) : void/// TODO PHP8-REVIEW Type hints missing
+    public function setDomain(string $a_domain) : void
     {
         $this->domain = $a_domain;
     }
@@ -94,9 +92,9 @@ class ilCookie
         return $this->domain;
     }
     
-    public function setSecure($a_status) : void// TODO PHP8-REVIEW Type hints missing
+    public function setSecure(bool $a_status) : void
     {
-        $this->secure = (bool) $a_status;
+        $this->secure = $a_status;
     }
     
     public function isSecure() : bool
@@ -104,7 +102,7 @@ class ilCookie
         return $this->secure;
     }
     
-    public function setHttpOnly($a_http_only) : void// TODO PHP8-REVIEW Type hints missing
+    public function setHttpOnly(bool $a_http_only) : void
     {
         $this->http_only = $a_http_only;
     }

--- a/Services/Authentication/classes/Cookie/class.ilCookie.php
+++ b/Services/Authentication/classes/Cookie/class.ilCookie.php
@@ -22,20 +22,20 @@
  */
 class ilCookie
 {
-    private $name = '';
-    private $value = '';
-    private $expire = 0;
-    private $path = '';
-    private $domain = '';
-    private $secure = false;
-    private $http_only = false;
+    private $name = '';// TODO PHP8-REVIEW Property type missing
+    private $value = '';// TODO PHP8-REVIEW Property type missing
+    private $expire = 0;// TODO PHP8-REVIEW Property type missing
+    private $path = '';// TODO PHP8-REVIEW Property type missing
+    private $domain = '';// TODO PHP8-REVIEW Property type missing
+    private $secure = false;// TODO PHP8-REVIEW Property type missing
+    private $http_only = false;// TODO PHP8-REVIEW Property type missing
     
-    public function __construct($a_name)
+    public function __construct($a_name)// TODO PHP8-REVIEW Type hints missing
     {
         $this->setName($a_name);
     }
     
-    public function setName($a_name)
+    public function setName($a_name) : void// TODO PHP8-REVIEW Type hints missing
     {
         $this->name = $a_name;
     }
@@ -44,7 +44,7 @@ class ilCookie
      * Get name
      * @return string
      */
-    public function getName()
+    public function getName() : string
     {
         return $this->name;
     }
@@ -54,62 +54,62 @@ class ilCookie
      * RFC 2965 suggests a minimum of 4096 bytes
      * @param string $a_value
      */
-    public function setValue($a_value)
+    public function setValue($a_value) : void// TODO PHP8-REVIEW Type hints missing
     {
         $this->value = $a_value;
     }
     
-    public function getValue()
+    public function getValue() : string
     {
         return $this->value;
     }
     
-    public function setExpire($a_expire)
+    public function setExpire($a_expire) : void// TODO PHP8-REVIEW Type hints missing
     {
         $this->expire = (int) $a_expire;
     }
     
-    public function getExpire()
+    public function getExpire() : int
     {
         return $this->expire;
     }
     
-    public function setPath($a_path)
+    public function setPath($a_path) : void// TODO PHP8-REVIEW Type hints missing
     {
         $this->path = $a_path;
     }
     
-    public function getPath()
+    public function getPath() : string
     {
         return $this->path;
     }
     
-    public function setDomain($a_domain)
+    public function setDomain($a_domain) : void/// TODO PHP8-REVIEW Type hints missing
     {
         $this->domain = $a_domain;
     }
     
-    public function getDomain()
+    public function getDomain() : string
     {
         return $this->domain;
     }
     
-    public function setSecure($a_status)
+    public function setSecure($a_status) : void// TODO PHP8-REVIEW Type hints missing
     {
         $this->secure = (bool) $a_status;
     }
     
-    public function isSecure()
+    public function isSecure() : bool
     {
         return $this->secure;
     }
     
-    public function setHttpOnly($a_http_only)
+    public function setHttpOnly($a_http_only) : void// TODO PHP8-REVIEW Type hints missing
     {
         $this->http_only = $a_http_only;
     }
     
-    public function isHttpOnly()
+    public function isHttpOnly() : bool
     {
         return $this->http_only;
     }

--- a/Services/Authentication/classes/Frontend/class.ilAuthFrontend.php
+++ b/Services/Authentication/classes/Frontend/class.ilAuthFrontend.php
@@ -322,7 +322,7 @@ class ilAuthFrontend
         // (last login date is set to current date in next step)
         if (
             $security_settings->isPasswordChangeOnFirstLoginEnabled() &&
-            $user->getLastLogin() == null
+            $user->getLastLogin() === ''
         ) {
             $user->resetLastPasswordChange();
         }
@@ -423,13 +423,8 @@ class ilAuthFrontend
     protected function checkSimultaneousLogins(ilObjUser $user) : bool
     {
         $this->logger->debug('Setting prevent simultaneous session is: ' . $this->settings->get('ps_prevent_simultaneous_logins'));
-        if (
-            $this->settings->get('ps_prevent_simultaneous_logins') &&
-            ilObjUser::hasActiveSession($user->getId(), $this->getAuthSession()->getId())
-        ) {
-            return false;
-        }
-        return true;
+        return !($this->settings->get('ps_prevent_simultaneous_logins') &&
+            ilObjUser::hasActiveSession($user->getId(), $this->getAuthSession()->getId()));
     }
 
     /**

--- a/Services/Authentication/classes/Frontend/class.ilAuthFrontendCredentialsApache.php
+++ b/Services/Authentication/classes/Frontend/class.ilAuthFrontendCredentialsApache.php
@@ -23,7 +23,7 @@ use Psr\Http\Message\ServerRequestInterface;
  * @author Michael Jansen <mjansen@databay.de>
  *
  */
-class ilAuthFrontendCredentialsApache extends ilAuthFrontendCredentials implements ilAuthCredentials
+class ilAuthFrontendCredentialsApache extends ilAuthFrontendCredentials
 {
     private ServerRequestInterface $httpRequest;
     private ilCtrl $ctrl;

--- a/Services/Authentication/classes/Frontend/class.ilAuthFrontendCredentialsHTTP.php
+++ b/Services/Authentication/classes/Frontend/class.ilAuthFrontendCredentialsHTTP.php
@@ -20,7 +20,7 @@
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
  *
  */
-class ilAuthFrontendCredentialsHTTP extends ilAuthFrontendCredentials implements ilAuthCredentials
+class ilAuthFrontendCredentialsHTTP extends ilAuthFrontendCredentials
 {
     /**
      * Init credentials from request

--- a/Services/Authentication/classes/Frontend/class.ilAuthFrontendCredentialsHTTP.php
+++ b/Services/Authentication/classes/Frontend/class.ilAuthFrontendCredentialsHTTP.php
@@ -25,7 +25,7 @@ class ilAuthFrontendCredentialsHTTP extends ilAuthFrontendCredentials implements
     /**
      * Init credentials from request
      */
-    public function initFromRequest()
+    public function initFromRequest() : void
     {
         $this->setUsername($_SERVER['PHP_AUTH_USER']);
         $this->setPassword($_SERVER['PHP_AUTH_PW']);

--- a/Services/Authentication/classes/Frontend/class.ilAuthFrontendCredentialsSoap.php
+++ b/Services/Authentication/classes/Frontend/class.ilAuthFrontendCredentialsSoap.php
@@ -55,10 +55,9 @@ class ilAuthFrontendCredentialsSoap extends ilAuthFrontendCredentials
         if (isset($this->httpRequest->getQueryParams()['cmd']) && is_string($this->httpRequest->getQueryParams()['cmd'])) {
             $cmd = $this->httpRequest->getQueryParams()['cmd'];
         }
-        if ('' === $cmd) {
-            if (isset($this->httpRequest->getParsedBody()['cmd']) && is_string($this->httpRequest->getParsedBody()['cmd'])) {
-                $cmd = $this->httpRequest->getParsedBody()['cmd'];
-            }
+        if ('' === $cmd &&
+            isset($this->httpRequest->getParsedBody()['cmd']) && is_string($this->httpRequest->getParsedBody()['cmd'])) {
+            $cmd = $this->httpRequest->getParsedBody()['cmd'];
         }
 
         $passedSso = '';

--- a/Services/Authentication/classes/Frontend/class.ilAuthFrontendFactory.php
+++ b/Services/Authentication/classes/Frontend/class.ilAuthFrontendFactory.php
@@ -22,20 +22,20 @@
  */
 class ilAuthFrontendFactory
 {
-    const CONTEXT_UNDEFINED = 0;
+    private const CONTEXT_UNDEFINED = 0;
     
     // authentication with id and password. Used for standard form based authentication
     // soap auth (login) but not for (CLI (cron)?) and HTTP basic authentication
-    const CONTEXT_STANDARD_FORM = 2;
+    public const CONTEXT_STANDARD_FORM = 2;
     
     // CLI context for cron
-    const CONTEXT_CLI = 3;
+    public const CONTEXT_CLI = 3;
     
     // Rest soap context
-    const CONTEXT_WS = 4;
+    public const CONTEXT_WS = 4;
     
     // http auth
-    const CONTEXT_HTTP = 5;
+    public const CONTEXT_HTTP = 5;
     
     
     private int $context = self::CONTEXT_UNDEFINED;

--- a/Services/Authentication/classes/Provider/class.ilAuthProvider.php
+++ b/Services/Authentication/classes/Provider/class.ilAuthProvider.php
@@ -63,9 +63,8 @@ abstract class ilAuthProvider implements ilAuthProviderInterface
     
     /**
      * Handle failed authentication
-     * @param string $a_reason
      */
-    protected function handleAuthenticationFail(ilAuthStatus $status, $a_reason) : bool// TODO PHP8-REVIEW Type hints missing
+    protected function handleAuthenticationFail(ilAuthStatus $status, string $a_reason) : bool
     {
         $status->setStatus(ilAuthStatus::STATUS_AUTHENTICATION_FAILED);
         $status->setReason($a_reason);

--- a/Services/Authentication/classes/Provider/class.ilAuthProvider.php
+++ b/Services/Authentication/classes/Provider/class.ilAuthProvider.php
@@ -22,10 +22,10 @@
  */
 abstract class ilAuthProvider implements ilAuthProviderInterface
 {
-    const STATUS_UNDEFINED = 0;
-    const STATUS_AUTHENTICATION_SUCCESS = 1;
-    const STATUS_AUTHENTICATION_FAILED = 2;
-    const STATUS_MIGRATION = 3;
+    private const STATUS_UNDEFINED = 0;
+    private const STATUS_AUTHENTICATION_SUCCESS = 1;
+    private const STATUS_AUTHENTICATION_FAILED = 2;
+    private const STATUS_MIGRATION = 3;
     
     
     private ilLogger $logger;
@@ -65,7 +65,7 @@ abstract class ilAuthProvider implements ilAuthProviderInterface
      * Handle failed authentication
      * @param string $a_reason
      */
-    protected function handleAuthenticationFail(ilAuthStatus $status, $a_reason) : bool
+    protected function handleAuthenticationFail(ilAuthStatus $status, $a_reason) : bool// TODO PHP8-REVIEW Type hints missing
     {
         $status->setStatus(ilAuthStatus::STATUS_AUTHENTICATION_FAILED);
         $status->setReason($a_reason);

--- a/Services/Authentication/classes/Provider/class.ilAuthProviderDatabase.php
+++ b/Services/Authentication/classes/Provider/class.ilAuthProviderDatabase.php
@@ -19,7 +19,7 @@
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
  *
  */
-class ilAuthProviderDatabase extends ilAuthProvider implements ilAuthProviderInterface
+class ilAuthProviderDatabase extends ilAuthProvider
 {
 
     

--- a/Services/Authentication/classes/Provider/class.ilAuthProviderDatabase.php
+++ b/Services/Authentication/classes/Provider/class.ilAuthProviderDatabase.php
@@ -35,7 +35,7 @@ class ilAuthProviderDatabase extends ilAuthProvider implements ilAuthProviderInt
 
         $this->getLogger()->debug('Trying to authenticate user: ' . $this->getCredentials()->getUsername());
         if ($user instanceof ilObjUser) {
-            if ($user->getId() == ANONYMOUS_USER_ID) {
+            if ($user->getId() === ANONYMOUS_USER_ID) {
                 $this->getLogger()->notice('Failed authentication for anonymous user id. ');
                 $this->handleAuthenticationFail($status, 'err_wrong_login');
                 return false;

--- a/Services/Authentication/classes/Provider/class.ilAuthProviderFactory.php
+++ b/Services/Authentication/classes/Provider/class.ilAuthProviderFactory.php
@@ -39,7 +39,7 @@ class ilAuthProviderFactory
     public function getProviders(ilAuthCredentials $credentials) : array
     {
         // Fixed provider selection;
-        if (strlen($credentials->getAuthMode())) {
+        if ($credentials->getAuthMode() !== '') {
             $this->logger->debug('Returning fixed provider for auth mode: ' . $credentials->getAuthMode());
             return array(
                 $this->getProviderByAuthMode($credentials, $credentials->getAuthMode())

--- a/Services/Authentication/classes/class.ilAuthFactory.php
+++ b/Services/Authentication/classes/class.ilAuthFactory.php
@@ -24,7 +24,7 @@ class ilAuthFactory
     /**
      * Web based authentication
      */
-    const CONTEXT_WEB = 1;
+    public const CONTEXT_WEB = 1;
 
     /**
      * HTTP Auth used for WebDAV and CalDAV
@@ -32,39 +32,39 @@ class ilAuthFactory
      * overwrite ilAuthHTTP with ilAuthCalDAV and create new
      * constants.
      */
-    const CONTEXT_HTTP = 2;
+    public const CONTEXT_HTTP = 2;
     
     
     /**
      * SOAP based authentication
      */
-    const CONTEXT_SOAP = 3;
+    public const CONTEXT_SOAP = 3;
 
-    const CONTEXT_CAS = 5;
+    public const CONTEXT_CAS = 5;
     
     /**
      * Maybe not required. HTTP based authentication for calendar access
      */
-    const CONTEXT_CALENDAR = 6;
+    public const CONTEXT_CALENDAR = 6;
     
     
     /**
      * Calendar authentication with auth token
      */
-    const CONTEXT_CALENDAR_TOKEN = 7;
+    public const CONTEXT_CALENDAR_TOKEN = 7;
     
     
     /**
      * Calendar authentication with auth token
      */
-    const CONTEXT_ECS = 8;
+    public const CONTEXT_ECS = 8;
     
     
 
     /**
      * Apache based authentication
      */
-    const CONTEXT_APACHE = 10;
+    public const CONTEXT_APACHE = 10;
 
     private static int $context = self::CONTEXT_WEB;
 

--- a/Services/Authentication/classes/class.ilAuthLoginPageEditorGUI.php
+++ b/Services/Authentication/classes/class.ilAuthLoginPageEditorGUI.php
@@ -35,7 +35,7 @@ class ilAuthLoginPageEditorGUI
     private ilErrorHandling $ilErr;
     private ?ilPropertyFormGUI $form;
 
-    private int $ref_id = 0;
+    private int $ref_id;
     private ilAuthLoginPageEditorSettings $settings;
     private ?ilSetting $loginSettings = null;
     protected \ILIAS\Style\Content\Object\ObjectFacade $content_style_domain;
@@ -155,14 +155,13 @@ class ilAuthLoginPageEditorGUI
         }
         $html = $this->ctrl->forwardCommand($page_gui);
 
-        if ($html != "") {
+        if ($html !== "") {
             $this->tpl->setContent($html);
         }
     }
 
     /**
      * Show current activated editor
-     * @return void
      */
     protected function show() : void
     {
@@ -284,7 +283,6 @@ class ilAuthLoginPageEditorGUI
     /**
      * saves the login information data
      *
-     * @access protected
      * @author Michael Jansen
      */
     protected function saveLoginInfo() : void
@@ -351,7 +349,7 @@ class ilAuthLoginPageEditorGUI
 
         foreach ($this->setDefLangFirst($def_language, $languages) as $lang_key) {
             $add = "";
-            if ($lang_key == $def_language) {
+            if ($lang_key === $def_language) {
                 $add = " (" . $this->lng->txt("default") . ")";
             }
 
@@ -360,8 +358,9 @@ class ilAuthLoginPageEditorGUI
                 'login_message_' . $lang_key
             );
             $textarea->setRows(10);
-            if (isset($login_settings["login_message_" . $lang_key])) {
-                $textarea->setValue($login_settings["login_message_" . $lang_key]);
+            $msg_login_lang = "login_message_" . $lang_key;
+            if (isset($login_settings[$msg_login_lang])) {
+                $textarea->setValue($login_settings[$msg_login_lang]);
             }
             $textarea->setUseRte(true);
             $textarea->setRteTagSet("extended");
@@ -389,20 +388,17 @@ class ilAuthLoginPageEditorGUI
     }
 
     /**
-     *
      * returns an array of all installed languages, default language at the first position
-     *
      * @param string $a_def_language Default language of the current installation
      * @param array $a_languages Array of all installed languages
-     * @return array $languages Array of the installed languages, default language at first position
-     * @access public
+     * @return array $languages Array of the installed languages, default language at first position or
+     *         an empty array, if $a_a_def_language is empty
      * @author Michael Jansen
-     *
      */
-    protected function setDefLangFirst($a_def_language, $a_languages) : array// TODO PHP8-REVIEW Type hints missing
+    private function setDefLangFirst(string $a_def_language, array $a_languages) : array
     {
-        if (is_array($a_languages) && $a_def_language != "") {
-            $languages = array();
+        $languages = [];
+        if ($a_def_language !== "") {
             $languages[] = $a_def_language;
 
             foreach ($a_languages as $val) {
@@ -410,10 +406,8 @@ class ilAuthLoginPageEditorGUI
                     $languages[] = $val;
                 }
             }
-
-            return $languages;
         }
 
-        return array();
+        return $languages;
     }
 }

--- a/Services/Authentication/classes/class.ilAuthLoginPageEditorGUI.php
+++ b/Services/Authentication/classes/class.ilAuthLoginPageEditorGUI.php
@@ -93,7 +93,7 @@ class ilAuthLoginPageEditorGUI
                     '_top'
                 );
 
-                if ($_GET["redirectSource"] != "ilinternallinkgui") {
+                if ($_GET["redirectSource"] !== "ilinternallinkgui") {
                     $this->forwardToPageObject();
                 }
                 break;
@@ -150,7 +150,7 @@ class ilAuthLoginPageEditorGUI
         // style tab
         //$page_gui->setTabHook($this, "addPageTabs");
 
-        if ($this->ctrl->getCmd() == 'editPage') {
+        if ($this->ctrl->getCmd() === 'editPage') {
             $this->ctrl->setCmd('edit');
         }
         $html = $this->ctrl->forwardCommand($page_gui);
@@ -234,7 +234,7 @@ class ilAuthLoginPageEditorGUI
     {
         $settings = ilAuthLoginPageEditorSettings::getInstance();
         foreach ((array) $_POST['visible_languages'] as $lang_key) {
-            $settings->enableIliasEditor($lang_key, in_array($lang_key, (array) $_POST['languages']));
+            $settings->enableIliasEditor($lang_key, in_array($lang_key, (array) $_POST['languages'], true));
         }
         $settings->update();
 
@@ -260,7 +260,7 @@ class ilAuthLoginPageEditorGUI
      * @global ilSetting $ilSetting
      * @author Michael Jansen
      */
-    protected function showRichtextEditor()
+    protected function showRichtextEditor() : void
     {
         if (!$this->rbacsystem->checkAccess("visible,read", $this->getRefId())) {
             $this->ilErr->raiseError($this->lng->txt("permission_denied"), $this->ilErr->MESSAGE);
@@ -326,7 +326,7 @@ class ilAuthLoginPageEditorGUI
         $this->form->addCommandButton('saveLoginInfo', $this->lng->txt('save'));
 
         $rad_settings = ilRadiusSettings::_getInstance();
-        if ($ldap_id = ilLDAPServer::_getFirstActiveServer() or $rad_settings->isActive()) {
+        if (($ldap_id = ilLDAPServer::_getFirstActiveServer()) || $rad_settings->isActive()) {
             $select = new ilSelectInputGUI($this->lng->txt('default_auth_mode'), 'default_auth_mode');
             $select->setValue($this->setting->get('default_auth_mode', (string) ilAuthUtils::AUTH_LOCAL));
             $select->setInfo($this->lng->txt('default_auth_mode_info'));
@@ -381,7 +381,7 @@ class ilAuthLoginPageEditorGUI
             $textarea->setValue($message);
             $textarea->setUseRte(true);
             $textarea->setRteTagSet("extended");
-            if (!in_array($lang_key, $languages)) {
+            if (!in_array($lang_key, $languages, true)) {
                 $textarea->setAlert($this->lng->txt("not_installed"));
             }
             $this->form->addItem($textarea);
@@ -399,21 +399,21 @@ class ilAuthLoginPageEditorGUI
      * @author Michael Jansen
      *
      */
-    protected function setDefLangFirst($a_def_language, $a_languages)
+    protected function setDefLangFirst($a_def_language, $a_languages) : array// TODO PHP8-REVIEW Type hints missing
     {
         if (is_array($a_languages) && $a_def_language != "") {
             $languages = array();
             $languages[] = $a_def_language;
 
             foreach ($a_languages as $val) {
-                if (!in_array($val, $languages)) {
+                if (!in_array($val, $languages, true)) {
                     $languages[] = $val;
                 }
             }
 
             return $languages;
-        } else {
-            return array();
         }
+
+        return array();
     }
 }

--- a/Services/Authentication/classes/class.ilAuthLoginPageEditorSettings.php
+++ b/Services/Authentication/classes/class.ilAuthLoginPageEditorSettings.php
@@ -21,9 +21,9 @@
  */
 class ilAuthLoginPageEditorSettings
 {
-    const MODE__UNDEFINED = 0;
-    const MODE_RTE = 1;
-    const MODE_IPE = 2;
+    public const MODE__UNDEFINED = 0;
+    public const MODE_RTE = 1;
+    public const MODE_IPE = 2;
 
     private array $languages = [];
 
@@ -81,7 +81,7 @@ class ilAuthLoginPageEditorSettings
      */
     public function getIliasEditorLanguage(string $a_langkey) : string
     {
-        if ($this->mode != self::MODE_IPE) {
+        if ($this->mode !== self::MODE_IPE) {
             return '';
         }
         if ($this->isIliasEditorEnabled($a_langkey)) {
@@ -96,7 +96,7 @@ class ilAuthLoginPageEditorSettings
     /**
      * Enable editor for language
      */
-    public function enableIliasEditor(string $a_langkey, bool $a_status)
+    public function enableIliasEditor(string $a_langkey, bool $a_status) : void
     {
         $this->languages[$a_langkey] = $a_status;
     }
@@ -106,16 +106,13 @@ class ilAuthLoginPageEditorSettings
      */
     public function isIliasEditorEnabled(string $a_langkey) : bool
     {
-        if (isset($this->languages[$a_langkey])) {
-            return $this->languages[$a_langkey];
-        }
-        return false;
+        return $this->languages[$a_langkey] ?? false;
     }
 
     /**
      * Update settings
      */
-    public function update()
+    public function update() : void
     {
         $this->getStorage()->set('mode', (string) $this->getMode());
 
@@ -127,7 +124,7 @@ class ilAuthLoginPageEditorSettings
     /**
      * Read settings
      */
-    public function read()
+    public function read() : void
     {
         $this->setMode((int) $this->getStorage()->get('mode', (string) self::MODE_RTE));
 

--- a/Services/Authentication/classes/class.ilAuthLoginPageEditorTableGUI.php
+++ b/Services/Authentication/classes/class.ilAuthLoginPageEditorTableGUI.php
@@ -59,7 +59,7 @@ class ilAuthLoginPageEditorTableGUI extends ilTable2GUI
         $this->tpl->setVariable('LANGKEY_CHECKED', $a_set['status'] ? 'checked="checked' : '');
         $this->tpl->setVariable('TXT_LANGUAGE', $a_set['language']);
 
-        if ($this->lng->getDefaultLanguage() == $a_set['key']) {
+        if ($this->lng->getDefaultLanguage() === $a_set['key']) {
             $this->tpl->setVariable('TXT_SYSTEM', $this->lng->txt('system_language'));
         }
         if ($a_set['status']) {

--- a/Services/Authentication/classes/class.ilAuthModeDetermination.php
+++ b/Services/Authentication/classes/class.ilAuthModeDetermination.php
@@ -107,7 +107,7 @@ class ilAuthModeDetermination
             if ($sid) {
                 $server = ilLDAPServer::getInstanceByServerId($sid);
                 $this->logger->debug('Validating username filter for ' . $server->getName());
-                if (strlen($server->getUsernameFilter())) {
+                if ($server->getUsernameFilter() !== '') {
                     //#17731
                     $pattern = str_replace('*', '.*?', $server->getUsernameFilter());
 
@@ -227,30 +227,30 @@ class ilAuthModeDetermination
         }
 
         // Append missing active auth modes
-        if (!in_array(ilAuthUtils::AUTH_LOCAL, $this->position)) {
+        if (!in_array(ilAuthUtils::AUTH_LOCAL, $this->position, true)) {
             $this->position[] = ilAuthUtils::AUTH_LOCAL;
         }
         // begin-patch ldap_multiple
         foreach (ilLDAPServer::_getActiveServerList() as $sid) {
             $server = ilLDAPServer::getInstanceByServerId($sid);
-            if ($server->isActive() && !in_array(ilAuthUtils::AUTH_LDAP . '_' . $sid, $this->position)) {
+            if ($server->isActive() && !in_array(ilAuthUtils::AUTH_LDAP . '_' . $sid, $this->position, true)) {
                 $this->position[] = (ilAuthUtils::AUTH_LDAP . '_' . $sid);
             }
         }
         // end-patch ldap_multiple
-        if ($rad_active && !in_array(ilAuthUtils::AUTH_RADIUS, $this->position)) {
+        if ($rad_active && !in_array(ilAuthUtils::AUTH_RADIUS, $this->position, true)) {
             $this->position[] = ilAuthUtils::AUTH_RADIUS;
         }
-        if ($soap_active && !in_array(ilAuthUtils::AUTH_SOAP, $this->position)) {
+        if ($soap_active && !in_array(ilAuthUtils::AUTH_SOAP, $this->position, true)) {
             $this->position[] = ilAuthUtils::AUTH_SOAP;
         }
-        if ($apache_active && !in_array(ilAuthUtils::AUTH_APACHE, $this->position)) {
+        if ($apache_active && !in_array(ilAuthUtils::AUTH_APACHE, $this->position, true)) {
             $this->position[] = ilAuthUtils::AUTH_APACHE;
         }
         // begin-patch auth_plugin
         foreach (ilAuthUtils::getAuthPlugins() as $pl) {
             foreach ($pl->getAuthIds() as $auth_id) {
-                if ($pl->isAuthActive($auth_id) && !in_array($auth_id, $this->position)) {
+                if ($pl->isAuthActive($auth_id) && !in_array($auth_id, $this->position, true)) {
                     $this->position[] = $auth_id;
                 }
             }

--- a/Services/Authentication/classes/class.ilAuthModeDetermination.php
+++ b/Services/Authentication/classes/class.ilAuthModeDetermination.php
@@ -21,8 +21,8 @@
 
 class ilAuthModeDetermination
 {
-    const TYPE_MANUAL = 0;
-    const TYPE_AUTOMATIC = 1;
+    private const TYPE_MANUAL = 0;
+    private const TYPE_AUTOMATIC = 1;
     
     private static ?ilAuthModeDetermination $instance = null;
     
@@ -69,7 +69,7 @@ class ilAuthModeDetermination
      */
     public function isManualSelection() : bool
     {
-        return $this->kind == self::TYPE_MANUAL;
+        return $this->kind === self::TYPE_MANUAL;
     }
 
     /**
@@ -97,7 +97,7 @@ class ilAuthModeDetermination
      */
     public function getAuthModeSequence(string $a_username = '') : array
     {
-        if (!strlen($a_username)) {
+        if ($a_username === '') {
             return $this->position ?: array();
         }
         $sorted = array();
@@ -163,7 +163,7 @@ class ilAuthModeDetermination
     /**
      * Read settings
      */
-    private function read()
+    private function read() : void
     {
         $this->kind = (int) $this->settings->get('kind', (string) self::TYPE_MANUAL);
 
@@ -233,35 +233,25 @@ class ilAuthModeDetermination
         // begin-patch ldap_multiple
         foreach (ilLDAPServer::_getActiveServerList() as $sid) {
             $server = ilLDAPServer::getInstanceByServerId($sid);
-            if ($server->isActive()) {
-                if (!in_array(ilAuthUtils::AUTH_LDAP . '_' . $sid, $this->position)) {
-                    $this->position[] = (ilAuthUtils::AUTH_LDAP . '_' . $sid);
-                }
+            if ($server->isActive() && !in_array(ilAuthUtils::AUTH_LDAP . '_' . $sid, $this->position)) {
+                $this->position[] = (ilAuthUtils::AUTH_LDAP . '_' . $sid);
             }
         }
         // end-patch ldap_multiple
-        if ($rad_active) {
-            if (!in_array(ilAuthUtils::AUTH_RADIUS, $this->position)) {
-                $this->position[] = ilAuthUtils::AUTH_RADIUS;
-            }
+        if ($rad_active && !in_array(ilAuthUtils::AUTH_RADIUS, $this->position)) {
+            $this->position[] = ilAuthUtils::AUTH_RADIUS;
         }
-        if ($soap_active) {
-            if (!in_array(ilAuthUtils::AUTH_SOAP, $this->position)) {
-                $this->position[] = ilAuthUtils::AUTH_SOAP;
-            }
+        if ($soap_active && !in_array(ilAuthUtils::AUTH_SOAP, $this->position)) {
+            $this->position[] = ilAuthUtils::AUTH_SOAP;
         }
-        if ($apache_active) {
-            if (!in_array(ilAuthUtils::AUTH_APACHE, $this->position)) {
-                $this->position[] = ilAuthUtils::AUTH_APACHE;
-            }
+        if ($apache_active && !in_array(ilAuthUtils::AUTH_APACHE, $this->position)) {
+            $this->position[] = ilAuthUtils::AUTH_APACHE;
         }
         // begin-patch auth_plugin
         foreach (ilAuthUtils::getAuthPlugins() as $pl) {
             foreach ($pl->getAuthIds() as $auth_id) {
-                if ($pl->isAuthActive($auth_id)) {
-                    if (!in_array($auth_id, $this->position)) {
-                        $this->position[] = $auth_id;
-                    }
+                if ($pl->isAuthActive($auth_id) && !in_array($auth_id, $this->position)) {
+                    $this->position[] = $auth_id;
                 }
             }
         }

--- a/Services/Authentication/classes/class.ilAuthPlugin.php
+++ b/Services/Authentication/classes/class.ilAuthPlugin.php
@@ -53,7 +53,7 @@ abstract class ilAuthPlugin extends ilPlugin implements ilAuthDefinition
 
     /**
      *
-     * @param string $id
+     * @param int $id
      *            (can be your Mode or – if you have any – a Sub-mode.
      */
     abstract public function isAuthActive(int $a_auth_id) : bool;

--- a/Services/Authentication/classes/class.ilAuthSession.php
+++ b/Services/Authentication/classes/class.ilAuthSession.php
@@ -19,9 +19,9 @@
  */
 class ilAuthSession
 {
-    const SESSION_AUTH_AUTHENTICATED = '_authsession_authenticated';
-    const SESSION_AUTH_USER_ID = '_authsession_user_id';
-    const SESSION_AUTH_EXPIRED = '_authsession_expired';
+    private const SESSION_AUTH_AUTHENTICATED = '_authsession_authenticated';
+    private const SESSION_AUTH_USER_ID = '_authsession_user_id';
+    private const SESSION_AUTH_EXPIRED = '_authsession_expired';
     
     private static ?ilAuthSession $instance = null;
     
@@ -128,7 +128,7 @@ class ilAuthSession
     /**
      * Set authenticated
      */
-    public function setAuthenticated(bool $a_status, int $a_user_id)
+    public function setAuthenticated(bool $a_status, int $a_user_id) : void
     {
         $this->authenticated = $a_status;
         $this->user_id = $a_user_id;

--- a/Services/Authentication/classes/class.ilAuthStatus.php
+++ b/Services/Authentication/classes/class.ilAuthStatus.php
@@ -26,11 +26,11 @@ class ilAuthStatus
     
     private ilLanguage $lng;
 
-    const STATUS_UNDEFINED = 1;
-    const STATUS_AUTHENTICATED = 2;
-    const STATUS_AUTHENTICATION_FAILED = 3;
-    const STATUS_ACCOUNT_MIGRATION_REQUIRED = 4;
-    const STATUS_CODE_ACTIVATION_REQUIRED = 5;
+    public const STATUS_UNDEFINED = 1;
+    public const STATUS_AUTHENTICATED = 2;
+    public const STATUS_AUTHENTICATION_FAILED = 3;
+    public const STATUS_ACCOUNT_MIGRATION_REQUIRED = 4;
+    public const STATUS_CODE_ACTIVATION_REQUIRED = 5;
     
     private int $status = self::STATUS_UNDEFINED;
     private string $reason = '';
@@ -106,7 +106,7 @@ class ilAuthStatus
      */
     public function getTranslatedReason() : string
     {
-        if (strlen($this->translated_reason)) {
+        if ($this->translated_reason !== '') {
             return $this->translated_reason;
         }
         return $this->lng->txt($this->getReason());

--- a/Services/Authentication/classes/class.ilAuthUtils.php
+++ b/Services/Authentication/classes/class.ilAuthUtils.php
@@ -486,7 +486,7 @@ class ilAuthUtils
             $options[$default]['checked'] = true;
         }
 
-        return $options ?: array();
+        return $options;
     }
 
     /**

--- a/Services/Authentication/classes/class.ilAuthUtils.php
+++ b/Services/Authentication/classes/class.ilAuthUtils.php
@@ -125,8 +125,11 @@ class ilAuthUtils
             }
         }
     }
-    
-    public static function _getAuthMode($a_auth_mode)// TODO PHP8-REVIEW Type hints missing
+
+    /**
+     * @return string|int
+     */
+    public static function _getAuthMode(string $a_auth_mode)
     {
         global $DIC;
 
@@ -295,7 +298,8 @@ class ilAuthUtils
         }
 
         foreach (ilSamlIdp::getActiveIdpList() as $idp) {
-            $modes['saml_' . $idp->getIdpId()] = self::AUTH_SAML . '_' . $idp->getIdpId();
+            $idpId = $idp->getIdpId();
+            $modes['saml_' . $idpId] = self::AUTH_SAML . '_' . $idpId;
         }
 
         // begin-path auth_plugin
@@ -345,7 +349,9 @@ class ilAuthUtils
                     $ret[$id] = self::_getAuthModeName($id);
                 }
                 continue;
-            } elseif ($mode === self::AUTH_SAML) {
+            }
+
+            if ($mode === self::AUTH_SAML) {
                 foreach (ilSamlIdp::getAllIdps() as $idp) {
                     $id = self::AUTH_SAML . '_' . $idp->getIdpId();
                     $ret[$id] = self::_getAuthModeName($id);
@@ -361,7 +367,7 @@ class ilAuthUtils
     * generate free login by starting with a default string and adding
     * postfix numbers
     */
-    public static function _generateLogin($a_login)// TODO PHP8-REVIEW Type hints missing / TODO PHP8-REVIEW Return types missing
+    public static function _generateLogin(string $a_login) : string
     {
         global $DIC;
 
@@ -536,13 +542,9 @@ class ilAuthUtils
     
     /**
      * Allow password modification
-     *
-     * @access public
-     * @static
-     *
-     * @param int auth_mode
+     * @param int|string auth_mode
      */
-    public static function _allowPasswordModificationByAuthMode($a_auth_mode) : ?bool// TODO PHP8-REVIEW Type hints missing or the the PhpDoc should be changed to appropriate
+    public static function _allowPasswordModificationByAuthMode($a_auth_mode) : bool
     {
         switch ((int) $a_auth_mode) {
             case self::AUTH_LDAP:
@@ -559,12 +561,9 @@ class ilAuthUtils
     /**
      * Check if chosen auth mode needs an external account entry
      *
-     * @access public
-     * @static
-     *
-     * @param int auth_mode
+     * @param string|int $a_auth_mode auth_mode
      */
-    public static function _needsExternalAccountByAuthMode($a_auth_mode) : ?bool// TODO PHP8-REVIEW Type hints missing or the the PhpDoc should be changed to appropriate
+    public static function _needsExternalAccountByAuthMode($a_auth_mode) : bool
     {
         switch ($a_auth_mode) {
             case self::AUTH_LOCAL:
@@ -590,10 +589,10 @@ class ilAuthUtils
     
     /**
      * Check if local password validation is enabled for a specific auth_mode
-     * @param int $a_authmode
+     * @param int|string $a_authmode
      * @return bool
      */
-    public static function isLocalPasswordEnabledForAuthMode($a_authmode) : bool// TODO PHP8-REVIEW Type hints missing or the the PhpDoc should be changed to int|string
+    public static function isLocalPasswordEnabledForAuthMode($a_authmode) : bool
     {
         global $DIC;
 
@@ -633,10 +632,10 @@ class ilAuthUtils
 
     /**
      * Check if password modification is enabled
-     * @param int $a_authmode
+     * @param int|string $a_authmode
      * @return bool
      */
-    public static function isPasswordModificationEnabled($a_authmode) : ?bool// TODO PHP8-REVIEW Type hints missing or the the PhpDoc should be changed to int|string
+    public static function isPasswordModificationEnabled($a_authmode) : bool
     {
         global $DIC;
 
@@ -679,10 +678,10 @@ class ilAuthUtils
     
     /**
      * Check if local password validation is supported
-     * @param object $a_authmode
+     * @param string|int $a_authmode
      * @return
      */
-    public static function supportsLocalPasswordValidation($a_authmode) : ?int// TODO PHP8-REVIEW Type hints missing, or an appropriate PhpDoc comment
+    public static function supportsLocalPasswordValidation($a_authmode) : int
     {
         //TODO fix casting strings like 2_1 (auth_key for first ldap server) to int to get it to 2
         switch ((int) $a_authmode) {

--- a/Services/Authentication/classes/class.ilAuthUtils.php
+++ b/Services/Authentication/classes/class.ilAuthUtils.php
@@ -20,41 +20,41 @@
 */
 class ilAuthUtils
 {
-    const LOCAL_PWV_FULL = 1;
-    const LOCAL_PWV_NO = 2;
-    const LOCAL_PWV_USER = 3;
+    public const LOCAL_PWV_FULL = 1;
+    public const LOCAL_PWV_NO = 2;
+    public const LOCAL_PWV_USER = 3;
 
-    
-    const AUTH_LOCAL = 1;
-    const AUTH_LDAP = 2;
-    const AUTH_RADIUS = 3;
-    const AUTH_SCRIPT = 4;
-    const AUTH_SHIBBOLETH = 5;
-    const AUTH_CAS = 6;
-    const AUTH_SOAP = 7;
-    const AUTH_HTTP = 8; // Used for WebDAV
-    const AUTH_ECS = 9;
-    
-    const AUTH_APACHE = 11;
-    const AUTH_SAML = 12;
-    
-    const AUTH_OPENID_CONNECT = 15;
-    
-    //TODO this is not used anywhere, can it be removed
-    const AUTH_INACTIVE = 18;
+
+    public const AUTH_LOCAL = 1;
+    public const AUTH_LDAP = 2;
+    public const AUTH_RADIUS = 3;
+    public const AUTH_SCRIPT = 4;
+    public const AUTH_SHIBBOLETH = 5;
+    public const AUTH_CAS = 6;
+    public const AUTH_SOAP = 7;
+    public const AUTH_HTTP = 8; // Used for WebDAV
+    public const AUTH_ECS = 9;
+
+    public const AUTH_APACHE = 11;
+    public const AUTH_SAML = 12;
+
+    public const AUTH_OPENID_CONNECT = 15;
     
     //TODO this is not used anywhere, can it be removed
-    const AUTH_MULTIPLE = 20;
+    private const AUTH_INACTIVE = 18;
     
     //TODO this is not used anywhere, can it be removed
-    const AUTH_SESSION = 21;
-    
-    const AUTH_PROVIDER_LTI = 22;
+    private const AUTH_MULTIPLE = 20;
     
     //TODO this is not used anywhere, can it be removed
-    const AUTH_SOAP_NO_ILIAS_USER = -100;
+    private const AUTH_SESSION = 21;
+
+    public const AUTH_PROVIDER_LTI = 22;
+    
     //TODO this is not used anywhere, can it be removed
-    const AUTH_LDAP_NO_ILIAS_USER = -200;
+    private const AUTH_SOAP_NO_ILIAS_USER = -100;
+    //TODO this is not used anywhere, can it be removed
+    private const AUTH_LDAP_NO_ILIAS_USER = -200;
     //TODO found no more refs to this, check if can go away
     //const AUTH_RADIUS_NO_ILIAS_USER = -300;
     
@@ -62,42 +62,39 @@ class ilAuthUtils
     // maybe no (valid) certificate or
     // username could not be extracted
     //TODO this is not used anywhere, can it be removed
-    const AUTH_APACHE_FAILED = -500;
+    private const AUTH_APACHE_FAILED = -500;
     
     //TODO this is not used anywhere, can it be removed
-    const AUTH_SAML_FAILED = -501;
+    private const AUTH_SAML_FAILED = -501;
   
     //TODO this is not used anywhere, can it be removed
-    const AUTH_MODE_INACTIVE = -1000;
+    private const AUTH_MODE_INACTIVE = -1000;
     
     // an external user cannot be found in ilias, but his email address
     // matches one or more ILIAS users
     //TODO this is not used anywhere, can it be removed?
-    const AUTH_SOAP_NO_ILIAS_USER_BUT_EMAIL = -101;
+    private const AUTH_SOAP_NO_ILIAS_USER_BUT_EMAIL = -101;
     //TODO this is not used anywhere, can it be removed?
-    const AUTH_CAS_NO_ILIAS_USER = -90;
+    private const AUTH_CAS_NO_ILIAS_USER = -90;
     
     // ilUser validation (no login)
     //TODO All these are is not used anywhere, can it be removed?
-    const AUTH_USER_WRONG_IP = -600;
-    const AUTH_USER_INACTIVE = -601;
-    const AUTH_USER_TIME_LIMIT_EXCEEDED = -602;
-    const AUTH_USER_SIMULTANEOUS_LOGIN = -603;
+    private const AUTH_USER_WRONG_IP = -600;
+    private const AUTH_USER_INACTIVE = -601;
+    private const AUTH_USER_TIME_LIMIT_EXCEEDED = -602;
+    private const AUTH_USER_SIMULTANEOUS_LOGIN = -603;
 
     /**
      * Check if authentication is should be forced.
      */
-    public static function isAuthenticationForced()
+    public static function isAuthenticationForced() : bool
     {
-        if (isset($_GET['ecs_hash']) or isset($_GET['ecs_hash_url'])) {
-            return true;
-        }
-        return false;
+        return isset($_GET['ecs_hash']) || isset($_GET['ecs_hash_url']);
     }
 
-    public static function handleForcedAuthentication()
+    public static function handleForcedAuthentication() : void
     {
-        if (isset($_GET['ecs_hash']) or isset($_GET['ecs_hash_url'])) {
+        if (isset($_GET['ecs_hash']) || isset($_GET['ecs_hash_url'])) {
             $credentials = new ilAuthFrontendCredentials();
             $credentials->setUsername($_GET['ecs_login']);
             $credentials->setAuthMode((string) self::AUTH_ECS);
@@ -129,7 +126,7 @@ class ilAuthUtils
         }
     }
     
-    public static function _getAuthMode($a_auth_mode)
+    public static function _getAuthMode($a_auth_mode)// TODO PHP8-REVIEW Type hints missing
     {
         global $DIC;
 
@@ -143,7 +140,7 @@ class ilAuthUtils
         }
         switch ($auth_switch) {
             case "local":
-                return ilAuthUtils::AUTH_LOCAL;
+                return self::AUTH_LOCAL;
                 break;
                 
             case "ldap":
@@ -153,37 +150,37 @@ class ilAuthUtils
                 return ilAuthProviderLTI::getKeyByAuthMode($a_auth_mode);
                 
             case "radius":
-                return ilAuthUtils::AUTH_RADIUS;
+                return self::AUTH_RADIUS;
                 break;
                 
             case "script":
-                return ilAuthUtils::AUTH_SCRIPT;
+                return self::AUTH_SCRIPT;
                 break;
                 
             case "shibboleth":
-                return ilAuthUtils::AUTH_SHIBBOLETH;
+                return self::AUTH_SHIBBOLETH;
                 break;
 
             case 'oidc':
-                return ilAuthUtils::AUTH_OPENID_CONNECT;
+                return self::AUTH_OPENID_CONNECT;
                 break;
 
             case 'saml':
                 return ilSamlIdp::getKeyByAuthMode($a_auth_mode);
 
             case "cas":
-                return ilAuthUtils::AUTH_CAS;
+                return self::AUTH_CAS;
                 break;
 
             case "soap":
-                return ilAuthUtils::AUTH_SOAP;
+                return self::AUTH_SOAP;
                 break;
                 
             case 'ecs':
-                return ilAuthUtils::AUTH_ECS;
+                return self::AUTH_ECS;
 
             case 'apache':
-                return ilAuthUtils::AUTH_APACHE;
+                return self::AUTH_APACHE;
 
             default:
                 return $ilSetting->get("auth_mode");
@@ -197,48 +194,48 @@ class ilAuthUtils
     public static function _getAuthModeName($a_auth_key) : string
     {
         switch ($a_auth_key) {
-            case ilAuthUtils::AUTH_LOCAL:
+            case self::AUTH_LOCAL:
                 return "local";
                 break;
                 
-            case ilAuthUtils::AUTH_LDAP:
+            case self::AUTH_LDAP:
                 // begin-patch ldap_multiple
                 return ilLDAPServer::getAuthModeByKey($a_auth_key);
                 // end-patch ldap_multiple
                 
-            case ilAuthUtils::AUTH_PROVIDER_LTI:
+            case self::AUTH_PROVIDER_LTI:
                 return ilAuthProviderLTI::getAuthModeByKey($a_auth_key);
                 
-            case ilAuthUtils::AUTH_RADIUS:
+            case self::AUTH_RADIUS:
                 return "radius";
                 break;
 
-            case ilAuthUtils::AUTH_CAS:
+            case self::AUTH_CAS:
                 return "cas";
                 break;
 
-            case ilAuthUtils::AUTH_SCRIPT:
+            case self::AUTH_SCRIPT:
                 return "script";
                 break;
                 
-            case ilAuthUtils::AUTH_SHIBBOLETH:
+            case self::AUTH_SHIBBOLETH:
                 return "shibboleth";
                 break;
 
-            case ilAuthUtils::AUTH_SAML:
+            case self::AUTH_SAML:
                 return ilSamlIdp::getAuthModeByKey($a_auth_key);
 
-            case ilAuthUtils::AUTH_SOAP:
+            case self::AUTH_SOAP:
                 return "soap";
                 break;
                 
-            case ilAuthUtils::AUTH_ECS:
+            case self::AUTH_ECS:
                 return 'ecs';
 
-            case ilAuthUtils::AUTH_APACHE:
+            case self::AUTH_APACHE:
                 return 'apache';
 
-            case ilAuthUtils::AUTH_OPENID_CONNECT:
+            case self::AUTH_OPENID_CONNECT:
                 return 'oidc';
                 break;
 
@@ -247,54 +244,58 @@ class ilAuthUtils
                 break;
         }
     }
-    
-    public static function _getActiveAuthModes()
+
+    /**
+     * @return array<string, int|string>
+     */
+    public static function _getActiveAuthModes() : array
     {
         global $DIC;
 
         $ilSetting = $DIC['ilSetting'];
-        
-        $modes = array(
-                        'default' => $ilSetting->get("auth_mode"),
-            'local' => ilAuthUtils::AUTH_LOCAL
-                        );
+
+        $modes = [
+            'default' => $ilSetting->get("auth_mode"),
+            'local' => self::AUTH_LOCAL
+        ];
+
         foreach (ilLDAPServer::_getActiveServerList() as $sid) {
-            $modes['ldap_' . $sid] = (ilAuthUtils::AUTH_LDAP . '_' . $sid);
+            $modes['ldap_' . $sid] = (self::AUTH_LDAP . '_' . $sid);
         }
         
         foreach (ilAuthProviderLTI::getAuthModes() as $sid) {
-            $modes['lti_' . $sid] = (ilAuthUtils::AUTH_PROVIDER_LTI . '_' . $sid);
+            $modes['lti_' . $sid] = (self::AUTH_PROVIDER_LTI . '_' . $sid);
         }
 
         if (ilOpenIdConnectSettings::getInstance()->getActive()) {
-            $modes['oidc'] = ilAuthUtils::AUTH_OPENID_CONNECT;
+            $modes['oidc'] = self::AUTH_OPENID_CONNECT;
         }
 
         if ($ilSetting->get("radius_active")) {
-            $modes['radius'] = ilAuthUtils::AUTH_RADIUS;
+            $modes['radius'] = self::AUTH_RADIUS;
         }
         if ($ilSetting->get("shib_active")) {
-            $modes['shibboleth'] = ilAuthUtils::AUTH_SHIBBOLETH;
+            $modes['shibboleth'] = self::AUTH_SHIBBOLETH;
         }
         if ($ilSetting->get("script_active")) {
-            $modes['script'] = ilAuthUtils::AUTH_SCRIPT;
+            $modes['script'] = self::AUTH_SCRIPT;
         }
         if ($ilSetting->get("cas_active")) {
-            $modes['cas'] = ilAuthUtils::AUTH_CAS;
+            $modes['cas'] = self::AUTH_CAS;
         }
         if ($ilSetting->get("soap_auth_active")) {
-            $modes['soap'] = ilAuthUtils::AUTH_SOAP;
+            $modes['soap'] = self::AUTH_SOAP;
         }
         if ($ilSetting->get("apache_active")) {
-            $modes['apache'] = ilAuthUtils::AUTH_APACHE;
+            $modes['apache'] = self::AUTH_APACHE;
         }
                 
         if (ilECSServerSettings::getInstance()->activeServerExists()) {
-            $modes['ecs'] = ilAuthUtils::AUTH_ECS;
+            $modes['ecs'] = self::AUTH_ECS;
         }
 
         foreach (ilSamlIdp::getActiveIdpList() as $idp) {
-            $modes['saml_' . $idp->getIdpId()] = ilAuthUtils::AUTH_SAML . '_' . $idp->getIdpId();
+            $modes['saml_' . $idp->getIdpId()] = self::AUTH_SAML . '_' . $idp->getIdpId();
         }
 
         // begin-path auth_plugin
@@ -308,47 +309,50 @@ class ilAuthUtils
         // end-path auth_plugin
         return $modes;
     }
-    
+
+    /**
+     * @return array<int|string, string>
+     */
     public static function _getAllAuthModes() : array
     {
         $modes = array(
-            ilAuthUtils::AUTH_LOCAL,
-            ilAuthUtils::AUTH_LDAP,
-            ilAuthUtils::AUTH_SHIBBOLETH,
-            ilAuthUtils::AUTH_SAML,
-            ilAuthUtils::AUTH_CAS,
-            ilAuthUtils::AUTH_SOAP,
-            ilAuthUtils::AUTH_RADIUS,
-            ilAuthUtils::AUTH_ECS,
-            ilAuthUtils::AUTH_PROVIDER_LTI,
-            ilAuthUtils::AUTH_OPENID_CONNECT,
-            ilAuthUtils::AUTH_APACHE
+            self::AUTH_LOCAL,
+            self::AUTH_LDAP,
+            self::AUTH_SHIBBOLETH,
+            self::AUTH_SAML,
+            self::AUTH_CAS,
+            self::AUTH_SOAP,
+            self::AUTH_RADIUS,
+            self::AUTH_ECS,
+            self::AUTH_PROVIDER_LTI,
+            self::AUTH_OPENID_CONNECT,
+            self::AUTH_APACHE
         );
         $ret = array();
         foreach ($modes as $mode) {
-            if ($mode == ilAuthUtils::AUTH_PROVIDER_LTI) {
+            if ($mode === self::AUTH_PROVIDER_LTI) {
                 foreach (ilAuthProviderLTI::getAuthModes() as $sid) {
-                    $id = ilAuthUtils::AUTH_PROVIDER_LTI . '_' . $sid;
-                    $ret[$id] = ilAuthUtils::_getAuthModeName($id);
+                    $id = self::AUTH_PROVIDER_LTI . '_' . $sid;
+                    $ret[$id] = self::_getAuthModeName($id);
                 }
                 continue;
             }
 
             // multi ldap implementation
-            if ($mode == ilAuthUtils::AUTH_LDAP) {
+            if ($mode === self::AUTH_LDAP) {
                 foreach (ilLDAPServer::_getServerList() as $ldap_id) {
-                    $id = ilAuthUtils::AUTH_LDAP . '_' . $ldap_id;
-                    $ret[$id] = ilAuthUtils::_getAuthModeName($id);
+                    $id = self::AUTH_LDAP . '_' . $ldap_id;
+                    $ret[$id] = self::_getAuthModeName($id);
                 }
                 continue;
-            } elseif ($mode == ilAuthUtils::AUTH_SAML) {
+            } elseif ($mode === self::AUTH_SAML) {
                 foreach (ilSamlIdp::getAllIdps() as $idp) {
-                    $id = ilAuthUtils::AUTH_SAML . '_' . $idp->getIdpId();
-                    $ret[$id] = ilAuthUtils::_getAuthModeName($id);
+                    $id = self::AUTH_SAML . '_' . $idp->getIdpId();
+                    $ret[$id] = self::_getAuthModeName($id);
                 }
                 continue;
             }
-            $ret[$mode] = ilAuthUtils::_getAuthModeName($mode);
+            $ret[$mode] = self::_getAuthModeName($mode);
         }
         return $ret;
     }
@@ -357,7 +361,7 @@ class ilAuthUtils
     * generate free login by starting with a default string and adding
     * postfix numbers
     */
-    public static function _generateLogin($a_login)
+    public static function _generateLogin($a_login)// TODO PHP8-REVIEW Type hints missing / TODO PHP8-REVIEW Return types missing
     {
         global $DIC;
 
@@ -381,7 +385,7 @@ class ilAuthUtils
         return $c_login;
     }
     
-    public static function _hasMultipleAuthenticationMethods()
+    public static function _hasMultipleAuthenticationMethods() : bool
     {
         $rad_settings = ilRadiusSettings::_getInstance();
         if ($rad_settings->isActive()) {
@@ -401,7 +405,7 @@ class ilAuthUtils
         }
         
         // begin-patch auth_plugin
-        foreach (ilAuthUtils::getAuthPlugins() as $pl) {
+        foreach (self::getAuthPlugins() as $pl) {
             foreach ($pl->getAuthIds() as $auth_id) {
                 if ($pl->getMultipleAuthModeOptions($auth_id)) {
                     return true;
@@ -413,8 +417,12 @@ class ilAuthUtils
         
         return false;
     }
-    
-    public static function _getMultipleAuthModeOptions($lng)
+
+    /**
+     * @param ilLanguage $lng
+     * @return array<int|string, string>
+     */
+    public static function _getMultipleAuthModeOptions(ilLanguage $lng) : array
     {
         global $DIC;
 
@@ -422,17 +430,17 @@ class ilAuthUtils
         $options = [];
         // in the moment only ldap is activated as additional authentication method
         
-        $options[ilAuthUtils::AUTH_LOCAL]['txt'] = $lng->txt('authenticate_ilias');
+        $options[self::AUTH_LOCAL]['txt'] = $lng->txt('authenticate_ilias');
 
         
         foreach (ilLDAPServer::_getActiveServerList() as $sid) {
             $server = ilLDAPServer::getInstanceByServerId($sid);
-            $options[ilAuthUtils::AUTH_LDAP . '_' . $sid]['txt'] = $server->getName();
+            $options[self::AUTH_LDAP . '_' . $sid]['txt'] = $server->getName();
         }
         
         $rad_settings = ilRadiusSettings::_getInstance();
         if ($rad_settings->isActive()) {
-            $options[ilAuthUtils::AUTH_RADIUS]['txt'] = $rad_settings->getName();
+            $options[self::AUTH_RADIUS]['txt'] = $rad_settings->getName();
         }
 
         if ($ilSetting->get('apache_active')) {
@@ -440,29 +448,29 @@ class ilAuthUtils
 
             $lng = $DIC['lng'];
             $apache_settings = new ilSetting('apache_auth');
-            $options[ilAuthUtils::AUTH_APACHE]['txt'] = $apache_settings->get('name', $lng->txt('apache_auth'));
-            $options[ilAuthUtils::AUTH_APACHE]['hide_in_ui'] = true;
+            $options[self::AUTH_APACHE]['txt'] = $apache_settings->get('name', $lng->txt('apache_auth'));
+            $options[self::AUTH_APACHE]['hide_in_ui'] = true;
         }
 
-        if ($ilSetting->get('auth_mode', (string) ilAuthUtils::AUTH_LOCAL) == (string) ilAuthUtils::AUTH_LDAP) {
-            $default = ilAuthUtils::AUTH_LDAP;
-        } elseif ($ilSetting->get('auth_mode', (string) ilAuthUtils::AUTH_LOCAL) == (string) ilAuthUtils::AUTH_RADIUS) {
-            $default = ilAuthUtils::AUTH_RADIUS;
+        if ($ilSetting->get('auth_mode', (string) self::AUTH_LOCAL) === (string) self::AUTH_LDAP) {
+            $default = self::AUTH_LDAP;
+        } elseif ($ilSetting->get('auth_mode', (string) self::AUTH_LOCAL) === (string) self::AUTH_RADIUS) {
+            $default = self::AUTH_RADIUS;
         } else {
-            $default = ilAuthUtils::AUTH_LOCAL;
+            $default = self::AUTH_LOCAL;
         }
         
         $default = $ilSetting->get('default_auth_mode', (string) $default);
         $default = (int) ($_REQUEST['auth_mode'] ?? $default);
 
         // begin-patch auth_plugin
-        $pls = ilAuthUtils::getAuthPlugins();
+        $pls = self::getAuthPlugins();
         foreach ($pls as $pl) {
             $auths = $pl->getAuthIds();
             foreach ($auths as $auth_id) {
                 $pl_auth_option = $pl->getMultipleAuthModeOptions($auth_id);
                 if ($pl_auth_option) {
-                    $options = $options + $pl_auth_option;
+                    $options += $pl_auth_option;
                 }
             }
         }
@@ -479,7 +487,7 @@ class ilAuthUtils
      * Check if an external account name is required.
      * That's the case if Radius,LDAP, CAS or SOAP is active
      */
-    public static function _isExternalAccountEnabled()
+    public static function _isExternalAccountEnabled() : bool
     {
         global $DIC;
 
@@ -516,7 +524,7 @@ class ilAuthUtils
         // begin-path auth_plugin
         foreach (self::getAuthPlugins() as $pl) {
             foreach ($pl->getAuthIds() as $auth_id) {
-                if ($pl->isAuthActive($auth_id) and $pl->isExternalAccountNameRequired($auth_id)) {
+                if ($pl->isAuthActive($auth_id) && $pl->isExternalAccountNameRequired($auth_id)) {
                     return true;
                 }
             }
@@ -534,14 +542,14 @@ class ilAuthUtils
      *
      * @param int auth_mode
      */
-    public static function _allowPasswordModificationByAuthMode($a_auth_mode)
+    public static function _allowPasswordModificationByAuthMode($a_auth_mode) : ?bool// TODO PHP8-REVIEW Type hints missing or the the PhpDoc should be changed to appropriate
     {
         switch ((int) $a_auth_mode) {
-            case ilAuthUtils::AUTH_LDAP:
-            case ilAuthUtils::AUTH_RADIUS:
-            case ilAuthUtils::AUTH_ECS:
-            case ilAuthUtils::AUTH_PROVIDER_LTI:
-            case ilAuthUtils::AUTH_OPENID_CONNECT:
+            case self::AUTH_LDAP:
+            case self::AUTH_RADIUS:
+            case self::AUTH_ECS:
+            case self::AUTH_PROVIDER_LTI:
+            case self::AUTH_OPENID_CONNECT:
                 return false;
             default:
                 return true;
@@ -556,11 +564,11 @@ class ilAuthUtils
      *
      * @param int auth_mode
      */
-    public static function _needsExternalAccountByAuthMode($a_auth_mode)
+    public static function _needsExternalAccountByAuthMode($a_auth_mode) : ?bool// TODO PHP8-REVIEW Type hints missing or the the PhpDoc should be changed to appropriate
     {
         switch ($a_auth_mode) {
-            case ilAuthUtils::AUTH_LOCAL:
-            case ilAuthUtils::AUTH_APACHE:
+            case self::AUTH_LOCAL:
+            case self::AUTH_APACHE:
                 return false;
             default:
                 return true;
@@ -570,18 +578,14 @@ class ilAuthUtils
     /**
      * @return bool
      */
-    public static function isPasswordModificationHidden()
+    public static function isPasswordModificationHidden() : bool
     {
         /** @var $ilSetting \ilSetting */
         global $DIC;
 
         $ilSetting = $DIC['ilSetting'];
 
-        if ($ilSetting->get('usr_settings_hide_password') || $ilSetting->get('usr_settings_disable_password')) {
-            return true;
-        }
-
-        return false;
+        return $ilSetting->get('usr_settings_hide_password') || $ilSetting->get('usr_settings_disable_password');
     }
     
     /**
@@ -589,7 +593,7 @@ class ilAuthUtils
      * @param int $a_authmode
      * @return bool
      */
-    public static function isLocalPasswordEnabledForAuthMode($a_authmode)
+    public static function isLocalPasswordEnabledForAuthMode($a_authmode) : bool// TODO PHP8-REVIEW Type hints missing or the the PhpDoc should be changed to int|string
     {
         global $DIC;
 
@@ -597,29 +601,29 @@ class ilAuthUtils
 
         switch ((int) $a_authmode) {
             // always enabled
-            case ilAuthUtils::AUTH_LOCAL:
-            case ilAuthUtils::AUTH_APACHE:
+            case self::AUTH_LOCAL:
+            case self::AUTH_APACHE:
                 return true;
 
             // No local passwords for these auth modes
-            case ilAuthUtils::AUTH_LDAP:
-            case ilAuthUtils::AUTH_RADIUS:
-            case ilAuthUtils::AUTH_ECS:
-            case ilAuthUtils::AUTH_SCRIPT:
-            case ilAuthUtils::AUTH_PROVIDER_LTI:
-            case ilAuthUtils::AUTH_OPENID_CONNECT:
+            case self::AUTH_LDAP:
+            case self::AUTH_RADIUS:
+            case self::AUTH_ECS:
+            case self::AUTH_SCRIPT:
+            case self::AUTH_PROVIDER_LTI:
+            case self::AUTH_OPENID_CONNECT:
                 return false;
 
-            case ilAuthUtils::AUTH_SAML:
+            case self::AUTH_SAML:
                 $idp = ilSamlIdp::getInstanceByIdpId(ilSamlIdp::getIdpIdByAuthMode((string) $a_authmode));
                 return $idp->isActive() && $idp->allowLocalAuthentication();
 
-            case ilAuthUtils::AUTH_SHIBBOLETH:
-                return $ilSetting->get("shib_auth_allow_local");
-            case ilAuthUtils::AUTH_SOAP:
-                return $ilSetting->get("soap_auth_allow_local");
-            case ilAuthUtils::AUTH_CAS:
-                return $ilSetting->get("cas_allow_local");
+            case self::AUTH_SHIBBOLETH:
+                return (bool) $ilSetting->get("shib_auth_allow_local", '0');
+            case self::AUTH_SOAP:
+                return (bool) $ilSetting->get("soap_auth_allow_local", '0');
+            case self::AUTH_CAS:
+                return (bool) $ilSetting->get("cas_allow_local", '0');
 
         }
         return false;
@@ -632,7 +636,7 @@ class ilAuthUtils
      * @param int $a_authmode
      * @return bool
      */
-    public static function isPasswordModificationEnabled($a_authmode)
+    public static function isPasswordModificationEnabled($a_authmode) : ?bool// TODO PHP8-REVIEW Type hints missing or the the PhpDoc should be changed to int|string
     {
         global $DIC;
 
@@ -646,29 +650,29 @@ class ilAuthUtils
         switch ((int) $a_authmode) {
             // No local passwords for these auth modes and default
             default:
-            case ilAuthUtils::AUTH_LDAP:
-            case ilAuthUtils::AUTH_RADIUS:
-            case ilAuthUtils::AUTH_ECS:
-            case ilAuthUtils::AUTH_SCRIPT:
-            case ilAuthUtils::AUTH_PROVIDER_LTI:
-            case ilAuthUtils::AUTH_OPENID_CONNECT:
+            case self::AUTH_LDAP:
+            case self::AUTH_RADIUS:
+            case self::AUTH_ECS:
+            case self::AUTH_SCRIPT:
+            case self::AUTH_PROVIDER_LTI:
+            case self::AUTH_OPENID_CONNECT:
                 return false;
 
-            case ilAuthUtils::AUTH_SAML:
+            case self::AUTH_SAML:
                 $idp = ilSamlIdp::getInstanceByIdpId(ilSamlIdp::getIdpIdByAuthMode((string) $a_authmode));
                 return $idp->isActive() && $idp->allowLocalAuthentication();
             
             // Always for and local
-            case ilAuthUtils::AUTH_LOCAL:
-            case ilAuthUtils::AUTH_APACHE:
+            case self::AUTH_LOCAL:
+            case self::AUTH_APACHE:
                 return true;
 
             // Read setting:
-            case ilAuthUtils::AUTH_SHIBBOLETH:
+            case self::AUTH_SHIBBOLETH:
                 return $ilSetting->get("shib_auth_allow_local");
-            case ilAuthUtils::AUTH_SOAP:
+            case self::AUTH_SOAP:
                 return $ilSetting->get("soap_auth_allow_local");
-            case ilAuthUtils::AUTH_CAS:
+            case self::AUTH_CAS:
                 return $ilSetting->get("cas_allow_local");
         }
     }
@@ -678,31 +682,31 @@ class ilAuthUtils
      * @param object $a_authmode
      * @return
      */
-    public static function supportsLocalPasswordValidation($a_authmode)
+    public static function supportsLocalPasswordValidation($a_authmode) : ?int// TODO PHP8-REVIEW Type hints missing, or an appropriate PhpDoc comment
     {
         //TODO fix casting strings like 2_1 (auth_key for first ldap server) to int to get it to 2
         switch ((int) $a_authmode) {
-            case ilAuthUtils::AUTH_LDAP:
-            case ilAuthUtils::AUTH_LOCAL:
-            case ilAuthUtils::AUTH_RADIUS:
-                return ilAuthUtils::LOCAL_PWV_FULL;
+            case self::AUTH_LDAP:
+            case self::AUTH_LOCAL:
+            case self::AUTH_RADIUS:
+                return self::LOCAL_PWV_FULL;
             
-            case ilAuthUtils::AUTH_SHIBBOLETH:
-            case ilAuthUtils::AUTH_OPENID_CONNECT:
-            case ilAuthUtils::AUTH_SAML:
-            case ilAuthUtils::AUTH_SOAP:
-            case ilAuthUtils::AUTH_CAS:
-                if (!ilAuthUtils::isPasswordModificationEnabled((int) $a_authmode)) {
-                    return ilAuthUtils::LOCAL_PWV_NO;
+            case self::AUTH_SHIBBOLETH:
+            case self::AUTH_OPENID_CONNECT:
+            case self::AUTH_SAML:
+            case self::AUTH_SOAP:
+            case self::AUTH_CAS:
+                if (!self::isPasswordModificationEnabled((int) $a_authmode)) {
+                    return self::LOCAL_PWV_NO;
                 }
-                return ilAuthUtils::LOCAL_PWV_USER;
+                return self::LOCAL_PWV_USER;
                 
-            case ilAuthUtils::AUTH_PROVIDER_LTI:
-            case ilAuthUtils::AUTH_ECS:
-            case ilAuthUtils::AUTH_SCRIPT:
-            case ilAuthUtils::AUTH_APACHE:
+            case self::AUTH_PROVIDER_LTI:
+            case self::AUTH_ECS:
+            case self::AUTH_SCRIPT:
+            case self::AUTH_APACHE:
             default:
-                return ilAuthUtils::LOCAL_PWV_USER;
+                return self::LOCAL_PWV_USER;
         }
     }
     
@@ -710,12 +714,12 @@ class ilAuthUtils
      * Get active enabled auth plugins
      * @return ilAuthDefinition
      */
-    public static function getAuthPlugins()
+    public static function getAuthPlugins() : \ilAuthDefinition
     {
         return $GLOBALS['DIC']['component.factory']->getActivePluginsInSlot('authhk');
     }
 
-    public static function getAuthModeTranslation(string $a_auth_key, string $auth_name = '')
+    public static function getAuthModeTranslation(string $a_auth_key, string $auth_name = '') : ?string
     {
         global $DIC;
 
@@ -723,28 +727,26 @@ class ilAuthUtils
         
         //TODO fix casting strings like 2_1 (auth_key for first ldap server) to int to get it to 2
         switch ((int) $a_auth_key) {
-            case ilAuthUtils::AUTH_LDAP:
+            case self::AUTH_LDAP:
                 $sid = ilLDAPServer::getServerIdByAuthMode($a_auth_key);
-                $server = ilLDAPServer::getInstanceByServerId($sid);
-                return $server->getName();
+                return ilLDAPServer::getInstanceByServerId($sid)->getName();
                 
-            case ilAuthUtils::AUTH_PROVIDER_LTI:
+            case self::AUTH_PROVIDER_LTI:
                 $sid = ilAuthProviderLTI::getServerIdByAuthMode($a_auth_key);
                 return ilAuthProviderLTI::lookupConsumer($sid);
                 
 
-            case ilAuthUtils::AUTH_SAML:
+            case self::AUTH_SAML:
                 $idp_id = ilSamlIdp::getIdpIdByAuthMode($a_auth_key);
-                $idp = ilSamlIdp::getInstanceByIdpId($idp_id);
-                return $idp->getEntityId();
+                return ilSamlIdp::getInstanceByIdpId($idp_id)->getEntityId();
 
             default:
                 $lng->loadLanguageModule('auth');
                 if (!empty($auth_name)) {
                     return $lng->txt('auth_' . $auth_name);
-                } else {
-                    return $lng->txt('auth_' . self::_getAuthModeName($a_auth_key));
                 }
+
+                return $lng->txt('auth_' . self::_getAuthModeName($a_auth_key));
 
         }
     }

--- a/Services/Authentication/classes/class.ilObjAuthSettings.php
+++ b/Services/Authentication/classes/class.ilObjAuthSettings.php
@@ -34,7 +34,7 @@ class ilObjAuthSettings extends ilObject
     {
         $settings = $this->ilias->getAllSettings();
 
-        if (!$settings["ldap_server"] or !$settings["ldap_basedn"] or !$settings["ldap_port"]) {
+        if (!$settings["ldap_server"] || !$settings["ldap_basedn"] || !$settings["ldap_port"]) {
             return false;
         }
 
@@ -47,8 +47,8 @@ class ilObjAuthSettings extends ilObject
     {
         $settings = $this->ilias->getAllSettings();
 
-        if (!$settings["shib_hos_type"] or !isset($settings["shib_user_default_role"]) or !$settings["shib_login"]
-            or !$settings["shib_firstname"] or !$settings["shib_lastname"]) {
+        if (!$settings["shib_hos_type"] || !isset($settings["shib_user_default_role"]) || !$settings["shib_login"]
+            || !$settings["shib_firstname"] || !$settings["shib_lastname"]) {
             return false;
         }
 
@@ -61,7 +61,7 @@ class ilObjAuthSettings extends ilObject
     {
         $settings = $this->ilias->getAllSettings();
 
-        if (!$settings["radius_server"] or !$settings["radius_shared_secret"] or !$settings["radius_port"]) {
+        if (!$settings["radius_server"] || !$settings["radius_shared_secret"] || !$settings["radius_port"]) {
             return false;
         }
 

--- a/Services/Authentication/classes/class.ilObjAuthSettingsGUI.php
+++ b/Services/Authentication/classes/class.ilObjAuthSettingsGUI.php
@@ -80,14 +80,23 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
 
         $auth_cnt = ilObjUser::_getNumberOfUsersPerAuthMode();
         $auth_modes = ilAuthUtils::_getAllAuthModes();
-        $valid_modes = array(ilAuthUtils::AUTH_LOCAL,ilAuthUtils::AUTH_LDAP,ilAuthUtils::AUTH_SHIBBOLETH,ilAuthUtils::AUTH_SAML,ilAuthUtils::AUTH_CAS,ilAuthUtils::AUTH_RADIUS,ilAuthUtils::AUTH_APACHE,ilAuthUtils::AUTH_OPENID_CONNECT);
+        $valid_modes = [
+            ilAuthUtils::AUTH_LOCAL,
+            ilAuthUtils::AUTH_LDAP,
+            ilAuthUtils::AUTH_SHIBBOLETH,
+            ilAuthUtils::AUTH_SAML,
+            ilAuthUtils::AUTH_CAS,
+            ilAuthUtils::AUTH_RADIUS,
+            ilAuthUtils::AUTH_APACHE,
+            ilAuthUtils::AUTH_OPENID_CONNECT
+        ];
         // icon handlers
         $icon_ok = "<img src=\"" . ilUtil::getImagePath("icon_ok.svg") . "\" alt=\"" . $this->lng->txt("enabled") . "\" title=\"" . $this->lng->txt("enabled") . "\" border=\"0\" vspace=\"0\"/>";
         $icon_not_ok = "<img src=\"" . ilUtil::getImagePath("icon_not_ok.svg") . "\" alt=\"" . $this->lng->txt("disabled") . "\" title=\"" . $this->lng->txt("disabled") . "\" border=\"0\" vspace=\"0\"/>";
 
         $this->logger->debug(print_r($auth_modes, true));
         foreach ($auth_modes as $mode => $mode_name) {
-            if (!in_array($mode, $valid_modes) && !ilLDAPServer::isAuthModeLDAP((string) $mode) && !ilSamlIdp::isAuthModeSaml((string) $mode)) {
+            if (!in_array($mode, $valid_modes, true) && !ilLDAPServer::isAuthModeLDAP((string) $mode) && !ilSamlIdp::isAuthModeSaml((string) $mode)) {
                 continue;
             }
 
@@ -103,7 +112,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
                 $generalSettingsTpl->setVariable('AUTH_ACTIVE', $idp->isActive() ? $icon_ok : $icon_not_ok);
             } else {
                 $generalSettingsTpl->setVariable("AUTH_NAME", $this->lng->txt("auth_" . $mode_name));
-                $generalSettingsTpl->setVariable('AUTH_ACTIVE', $this->ilias->getSetting($mode_name . '_active') || $mode == ilAuthUtils::AUTH_LOCAL ? $icon_ok : $icon_not_ok);
+                $generalSettingsTpl->setVariable('AUTH_ACTIVE', $this->ilias->getSetting($mode_name . '_active') || (int) $mode === ilAuthUtils::AUTH_LOCAL ? $icon_ok : $icon_not_ok);
             }
 
             $auth_cnt_mode = $auth_cnt[$mode_name] ?? 0;
@@ -164,17 +173,17 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
                 // do not list auth modes with external login screen
                 // even not default, because it can easily be set to
                 // a non-working auth mode
-                if ($auth_name == "default" || $auth_name == "cas"
-                    || $auth_name == 'saml'
-                    || $auth_name == "shibboleth" || $auth_name == 'ldap'
-                    || $auth_name == 'apache' || $auth_name == "ecs"
-                    || $auth_name == "openid") {
+                if ($auth_name === "default" || $auth_name === "cas"
+                    || $auth_name === 'saml'
+                    || $auth_name === "shibboleth" || $auth_name === 'ldap'
+                    || $auth_name === 'apache' || $auth_name === "ecs"
+                    || $auth_name === "openid") {
                     continue;
                 }
 
                 $generalSettingsTpl->setCurrentBlock("auth_mode_selection");
 
-                if ($auth_name == 'default') {
+                if ($auth_name === 'default') {
                     $name = $this->lng->txt('auth_' . $auth_name) . " (" . $this->lng->txt('auth_' . ilAuthUtils::_getAuthModeName($auth_key)) . ")";
                 } elseif ($id = ilLDAPServer::getServerIdByAuthMode((string) $auth_key)) {
                     $server = ilLDAPServer::getInstanceByServerId($id);
@@ -483,7 +492,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
         );
         
         $ret = "";
-        if ($this->ctrl->getCmd() == "testSoapAuthConnection") {
+        if ($this->ctrl->getCmd() === "testSoapAuthConnection") {
             $ret .= "<br />" . ilSOAPAuth::testConnection(
                 ilUtil::stripSlashes($_POST["ext_uid"]),
                 ilUtil::stripSlashes($_POST["soap_pw"]),
@@ -967,7 +976,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
     {
         $this->lng->loadLanguageModule('auth');
 
-        if ($a_tab == 'authSettings') {
+        if ($a_tab === 'authSettings') {
             if ($this->access->checkAccess('write', '', $this->object->getRefId())) {
                 $this->tabs_gui->addSubTabTarget(
                     "auth_settings",
@@ -1166,7 +1175,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
         return implode("\n", preg_split("/[\r\n]+/", $text));
     }
 
-    public function registrationSettingsObject()
+    public function registrationSettingsObject() : void
     {
         $registration_gui = new ilRegistrationSettingsGUI();
         $this->ctrl->redirect($registration_gui);

--- a/Services/Authentication/classes/class.ilSession.php
+++ b/Services/Authentication/classes/class.ilSession.php
@@ -329,6 +329,7 @@ class ilSession
             self::_writeData($new_session, $row->data);
             return $new_session;
         }
+        //TODO check if throwing an excpetion might be a better choice
         return "";
     }
     
@@ -350,6 +351,7 @@ class ilSession
             return time() + self::getIdleValue($fixedMode);
         }
 
+        /** @var ilSetting $ilSetting */
         $ilSetting = $DIC['ilSetting'];
         if ($ilSetting->get('session_handling_type', (string) self::SESSION_HANDLING_FIXED) === (string) self::SESSION_HANDLING_FIXED) {
             return time() + self::getIdleValue($fixedMode);

--- a/Services/Authentication/classes/class.ilSession.php
+++ b/Services/Authentication/classes/class.ilSession.php
@@ -105,7 +105,7 @@ class ilSession
         $query = 'SELECT expires FROM usr_session WHERE session_id = ' .
             $ilDB->quote($a_session_id, 'text');
         $res = $ilDB->query($query);
-        while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
+        if ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             return (int) $row->expires;
         }
         return 0;
@@ -325,7 +325,7 @@ class ilSession
             "WHERE session_id = " . $ilDB->quote($a_session_id, "text");
         $res = $ilDB->query($query);
 
-        while ($row = $ilDB->fetchObject($res)) {
+        if ($row = $ilDB->fetchObject($res)) {
             self::_writeData($new_session, $row->data);
             return $new_session;
         }
@@ -353,10 +353,12 @@ class ilSession
         $ilSetting = $DIC['ilSetting'];
         if ($ilSetting->get('session_handling_type', (string) self::SESSION_HANDLING_FIXED) === (string) self::SESSION_HANDLING_FIXED) {
             return time() + self::getIdleValue($fixedMode);
-        } elseif ($ilSetting->get('session_handling_type', (string) self::SESSION_HANDLING_FIXED) === (string) self::SESSION_HANDLING_LOAD_DEPENDENT) {
+        }
+
+        if ($ilSetting->get('session_handling_type', (string) self::SESSION_HANDLING_FIXED) === (string) self::SESSION_HANDLING_LOAD_DEPENDENT) {
             // load dependent session settings
-            $max_idle = $ilSetting->get('session_max_idle') ?? ilSessionControl::DEFAULT_MAX_IDLE;
-            return time() + (int) $max_idle * 60;
+            $max_idle = (int) ($ilSetting->get('session_max_idle') ?? ilSessionControl::DEFAULT_MAX_IDLE);
+            return time() + $max_idle * 60;
         }
         return time() + ilSessionControl::DEFAULT_MAX_IDLE * 60;
     }
@@ -374,11 +376,13 @@ class ilSession
 
         $ilSetting = $DIC['ilSetting'];
         $ilClientIniFile = $DIC['ilClientIniFile'];
-        
+
         if ($fixedMode || $ilSetting->get('session_handling_type', (string) self::SESSION_HANDLING_FIXED) === (string) self::SESSION_HANDLING_FIXED) {
             // fixed session
             return (int) $ilClientIniFile->readVariable('session', 'expire');
-        } elseif ($ilSetting->get('session_handling_type', (string) self::SESSION_HANDLING_FIXED) === (string) self::SESSION_HANDLING_LOAD_DEPENDENT) {
+        }
+
+        if ($ilSetting->get('session_handling_type', (string) self::SESSION_HANDLING_FIXED) === (string) self::SESSION_HANDLING_LOAD_DEPENDENT) {
             // load dependent session settings
             return (int) ($ilSetting->get('session_max_idle', ilSessionControl::DEFAULT_MAX_IDLE) * 60);
         }

--- a/Services/Authentication/classes/class.ilSessionControl.php
+++ b/Services/Authentication/classes/class.ilSessionControl.php
@@ -361,7 +361,7 @@ class ilSessionControl
             array($ts, $ts, $max_idle, $min_idle)
         );
         
-        while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
+        if ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             ilSession::_destroy($row->session_id, ilSession::SESSION_CLOSE_IDLE, $row->expires);
 
             self::debug(__METHOD__ . ' --> successfully deleted one min idle session');

--- a/Services/Authentication/classes/class.ilSessionControl.php
+++ b/Services/Authentication/classes/class.ilSessionControl.php
@@ -201,6 +201,7 @@ class ilSessionControl
         }
                 
         if (in_array($type, self::$session_types_controlled, true)) {
+            //TODO rework this, as it did return value of a void method call
             self::checkCurrentSessionIsAllowed($auth_session, $user_id);
             return true;
         }
@@ -286,8 +287,6 @@ class ilSessionControl
                         $auth->logout();
 
                         // Trigger reachedSessionPoolLimit Event
-                        global $DIC;
-
                         $ilAppEventHandler = $DIC['ilAppEventHandler'];
                         $ilAppEventHandler->raise(
                             'Services/Authentication',
@@ -330,7 +329,7 @@ class ilSessionControl
                     "AND " . $ilDB->in('type', $a_types, false, 'integer');
     
         $res = $ilDB->queryF($query, array('integer'), array($ts));
-        return $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)->num_sessions;
+        return (int) $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)->num_sessions;
     }
 
     /**

--- a/Services/Authentication/classes/class.ilSessionDBHandler.php
+++ b/Services/Authentication/classes/class.ilSessionDBHandler.php
@@ -41,7 +41,7 @@ class ilSessionDBHandler implements SessionHandlerInterface
      * @param string $path
      * @param string $name session name [PHPSESSID]
      */
-    public function open($path, $name) : bool// TODO PHP8-REVIEW Type hints missing
+    public function open($path, $name) : bool
     {
         return true;
     }
@@ -62,7 +62,7 @@ class ilSessionDBHandler implements SessionHandlerInterface
      * returned
      * @param string $id
      */
-    public function read($id) : string// TODO PHP8-REVIEW Type hints missing
+    public function read($id) : string
     {
         return ilSession::_getData($id);
     }
@@ -72,7 +72,7 @@ class ilSessionDBHandler implements SessionHandlerInterface
      * @param string $id session id
      * @param string $data session data
      */
-    public function write($id, $data) : bool// TODO PHP8-REVIEW Type hints missing
+    public function write($id, $data) : bool
     {
         chdir(IL_INITIAL_WD);
 
@@ -83,7 +83,7 @@ class ilSessionDBHandler implements SessionHandlerInterface
      * Destroys session
      * @param string $id session id
      */
-    public function destroy($id) : bool// TODO PHP8-REVIEW Type hints missing
+    public function destroy($id) : bool
     {
         return ilSession::_destroy($id);
     }

--- a/Services/Authentication/classes/class.ilSessionDBHandler.php
+++ b/Services/Authentication/classes/class.ilSessionDBHandler.php
@@ -41,7 +41,7 @@ class ilSessionDBHandler implements SessionHandlerInterface
      * @param string $path
      * @param string $name session name [PHPSESSID]
      */
-    public function open($path, $name)
+    public function open($path, $name) : bool// TODO PHP8-REVIEW Type hints missing
     {
         return true;
     }
@@ -62,7 +62,7 @@ class ilSessionDBHandler implements SessionHandlerInterface
      * returned
      * @param string $id
      */
-    public function read($id) : string
+    public function read($id) : string// TODO PHP8-REVIEW Type hints missing
     {
         return ilSession::_getData($id);
     }
@@ -72,7 +72,7 @@ class ilSessionDBHandler implements SessionHandlerInterface
      * @param string $id session id
      * @param string $data session data
      */
-    public function write($id, $data)
+    public function write($id, $data) : bool// TODO PHP8-REVIEW Type hints missing
     {
         chdir(IL_INITIAL_WD);
 
@@ -83,7 +83,7 @@ class ilSessionDBHandler implements SessionHandlerInterface
      * Destroys session
      * @param string $id session id
      */
-    public function destroy($id)
+    public function destroy($id) : bool// TODO PHP8-REVIEW Type hints missing
     {
         return ilSession::_destroy($id);
     }

--- a/Services/Authentication/classes/class.ilSessionIStorage.php
+++ b/Services/Authentication/classes/class.ilSessionIStorage.php
@@ -37,7 +37,7 @@
 class ilSessionIStorage
 {
     private string $session_id = "";
-    private string $component_id = "";
+    private string $component_id;
     private static array $values = [];
     
     /**

--- a/Services/Authentication/classes/class.ilSessionIStorage.php
+++ b/Services/Authentication/classes/class.ilSessionIStorage.php
@@ -49,7 +49,7 @@ class ilSessionIStorage
     public function __construct(string $a_component_id, string $a_sess_id = "")
     {
         $this->component_id = $a_component_id;
-        if ($a_sess_id != "") {
+        if ($a_sess_id !== "") {
             $this->session_id = $a_sess_id;
         } else {
             $this->session_id = session_id();
@@ -68,7 +68,7 @@ class ilSessionIStorage
      *
      * @param string $a_val value
      */
-    public function set(string $a_key, string $a_val)
+    public function set(string $a_key, string $a_val) : void
     {
         global $DIC;
 
@@ -98,10 +98,7 @@ class ilSessionIStorage
 
         $ilDB = $DIC['ilDB'];
         
-        if (
-            isset(self::$values[$this->component_id]) && is_array(self::$values[$this->component_id]) &&
-            isset(self::$values[$this->component_id][$a_key])
-        ) {
+        if (isset(self::$values[$this->component_id][$a_key]) && is_array(self::$values[$this->component_id])) {
             return self::$values[$this->component_id][$a_key];
         }
         

--- a/Services/Authentication/classes/class.ilSessionStatistics.php
+++ b/Services/Authentication/classes/class.ilSessionStatistics.php
@@ -427,6 +427,7 @@ class ilSessionStatistics
         if ($row["latest"]) {
             return $row["latest"];
         }
+        //TODO check if return null as timestamp causes issues
         return null;
     }
     
@@ -451,6 +452,7 @@ class ilSessionStatistics
         if ($row["dur"]) {
             return $row["dur"];
         }
+        //TODO check if return null as timestamp causes issues
         return null;
     }
     
@@ -512,6 +514,7 @@ class ilSessionStatistics
         if ($row["latest"]) {
             return $row["latest"];
         }
+        //TODO check if return null as timestamp causes issues
         return null;
     }
     

--- a/Services/Authentication/classes/class.ilSessionStatistics.php
+++ b/Services/Authentication/classes/class.ilSessionStatistics.php
@@ -301,7 +301,7 @@ class ilSessionStatistics
             }
             // session closed
             if ($item["end_time"] && $item["end_time"] <= $a_end) {
-                if (in_array($item["end_context"], $separate_closed)) {
+                if (in_array($item["end_context"], $separate_closed, true)) {
                     $closed_counter[$item["end_context"]]++;
                 } else {
                     $closed_counter[0]++;
@@ -456,12 +456,8 @@ class ilSessionStatistics
     
     /**
      * Get session counters by type (opened, closed)
-     *
-     * @param int $a_from
-     * @param int $a_to
-     * @return array
      */
-    public static function getNumberOfSessionsByType($a_from, $a_to) : array// TODO PHP8-REVIEW Type hints missing
+    public static function getNumberOfSessionsByType(int $a_from, int $a_to) : array
     {
         global $DIC;
 
@@ -480,12 +476,8 @@ class ilSessionStatistics
     
     /**
      * Get active sessions aggregated data
-     *
-     * @param int $a_from
-     * @param int $a_to
-     * @return array
      */
-    public static function getActiveSessions($a_from, $a_to) : array// TODO PHP8-REVIEW Type hints missing
+    public static function getActiveSessions(int $a_from, int $a_to) : array
     {
         global $DIC;
 
@@ -507,8 +499,6 @@ class ilSessionStatistics
     
     /**
      * Get timestamp of last aggregation
-     *
-     * @return ?int timestamp
      */
     public static function getLastAggregation() : ?int
     {
@@ -551,10 +541,8 @@ class ilSessionStatistics
     
     /**
      * Log max session setting
-     *
-     * @param int $a_new_value
      */
-    public static function updateLimitLog($a_new_value) : void// TODO PHP8-REVIEW Type hints missing
+    public static function updateLimitLog(int $a_new_value) : void
     {
         global $DIC;
 
@@ -562,7 +550,7 @@ class ilSessionStatistics
         $ilSetting = $DIC['ilSetting'];
         $ilUser = $DIC['ilUser'];
         
-        $new_value = (int) $a_new_value;
+        $new_value = $a_new_value;
         $old_value = (int) $ilSetting->get("session_max_count", (string) ilSessionControl::DEFAULT_MAX_COUNT);
         
         if ($new_value !== $old_value) {

--- a/Services/Authentication/classes/class.ilSessionStatistics.php
+++ b/Services/Authentication/classes/class.ilSessionStatistics.php
@@ -19,7 +19,7 @@
 */
 class ilSessionStatistics
 {
-    const SLOT_SIZE = 15;
+    private const SLOT_SIZE = 15;
     
     /**
      * Is session statistics active at all?
@@ -36,7 +36,7 @@ class ilSessionStatistics
     /**
      * Create raw data entry
      */
-    public static function createRawEntry(string $a_session_id, int $a_session_type, int $a_timestamp, int $a_user_id)
+    public static function createRawEntry(string $a_session_id, int $a_session_type, int $a_timestamp, int $a_user_id) : void
     {
         global $DIC;
 
@@ -69,7 +69,7 @@ class ilSessionStatistics
      * @param int $a_context
      * @param int|bool $a_expired_at
      */
-    public static function closeRawEntry($a_session_id, ?int $a_context = null, $a_expired_at = null)
+    public static function closeRawEntry($a_session_id, ?int $a_context = null, $a_expired_at = null) : void
     {
         global $DIC;
 
@@ -268,7 +268,7 @@ class ilSessionStatistics
      * Aggregate statistics data for one slot
      *
      */
-    public static function aggregateRawHelper(int $a_begin, int $a_end)
+    public static function aggregateRawHelper(int $a_begin, int $a_end) : void
     {
         global $DIC;
 
@@ -315,7 +315,7 @@ class ilSessionStatistics
         $active_end = $active_min = $active_max = $active_avg = $active_begin;
         
         // parsing events / building avergages
-        if (sizeof($events)) {
+        if (count($events)) {
             $last_update_avg = $a_begin - 1;
             $slot_seconds = self::SLOT_SIZE * 60;
             $active_avg = 0;
@@ -350,8 +350,7 @@ class ilSessionStatistics
                 $active_avg += $diff / $slot_seconds * $active_end;
                 $last_update_avg = $ts;
             }
-            unset($actions);
-            
+
             // add up to end of slot if needed
             if ($last_update_avg < $a_end) {
                 $diff = $a_end - $last_update_avg;
@@ -396,7 +395,7 @@ class ilSessionStatistics
      *
      * @param integer $a_now
      */
-    protected static function deleteAggregatedRaw($a_now)
+    protected static function deleteAggregatedRaw($a_now) : void
     {
         global $DIC;
 
@@ -462,7 +461,7 @@ class ilSessionStatistics
      * @param int $a_to
      * @return array
      */
-    public static function getNumberOfSessionsByType($a_from, $a_to)
+    public static function getNumberOfSessionsByType($a_from, $a_to) : array// TODO PHP8-REVIEW Type hints missing
     {
         global $DIC;
 
@@ -486,7 +485,7 @@ class ilSessionStatistics
      * @param int $a_to
      * @return array
      */
-    public static function getActiveSessions($a_from, $a_to)
+    public static function getActiveSessions($a_from, $a_to) : array// TODO PHP8-REVIEW Type hints missing
     {
         global $DIC;
 
@@ -545,9 +544,9 @@ class ilSessionStatistics
         $val = $ilDB->fetchAssoc($res);
         if (isset($val["maxval"]) && $val["maxval"]) {
             return (int) $val["maxval"];
-        } else {
-            return (int) $ilSetting->get("session_max_count", (string) ilSessionControl::DEFAULT_MAX_COUNT);
         }
+
+        return (int) $ilSetting->get("session_max_count", (string) ilSessionControl::DEFAULT_MAX_COUNT);
     }
     
     /**
@@ -555,7 +554,7 @@ class ilSessionStatistics
      *
      * @param int $a_new_value
      */
-    public static function updateLimitLog($a_new_value)
+    public static function updateLimitLog($a_new_value) : void// TODO PHP8-REVIEW Type hints missing
     {
         global $DIC;
 
@@ -566,7 +565,7 @@ class ilSessionStatistics
         $new_value = (int) $a_new_value;
         $old_value = (int) $ilSetting->get("session_max_count", (string) ilSessionControl::DEFAULT_MAX_COUNT);
         
-        if ($new_value != $old_value) {
+        if ($new_value !== $old_value) {
             $fields = array(
                 "tstamp" => array("timestamp", time()),
                 "maxval" => array("integer", $new_value),

--- a/Services/Authentication/classes/class.ilSessionStatisticsGUI.php
+++ b/Services/Authentication/classes/class.ilSessionStatisticsGUI.php
@@ -463,7 +463,7 @@ class ilSessionStatisticsGUI
         return $left->get();
     }
     
-    protected function buildData($a_time_from, $a_time_to, $a_title) : array// TODO PHP8-REVIEW Type hints missing
+    protected function buildData(int $a_time_from, int $a_time_to, string $a_title) : array
     {
         // basic data - time related
         
@@ -498,7 +498,7 @@ class ilSessionStatisticsGUI
         return $data;
     }
     
-    protected function render($a_data, $a_scale, $a_measure = null) : string// TODO PHP8-REVIEW Type hints missing
+    protected function render(array $a_data, int $a_scale, string $a_measure = null) : string
     {
         $center = new ilTemplate("tpl.session_statistics_center.html", true, true, "Services/Authentication");
         
@@ -537,14 +537,8 @@ class ilSessionStatisticsGUI
             
     /**
      * Build chart for active sessions
-     *
-     * @param array $a_data
-     * @param string $a_title
-     * @param int $a_scale
-     * @param array $a_measure
-     * @return string
      */
-    protected function getChart($a_data, $a_title, $a_scale = self::SCALE_DAY, $a_measure = null) : string// TODO PHP8-REVIEW Type hints missing
+    protected function getChart(array $a_data, string $a_title, int $a_scale = self::SCALE_DAY, string $a_measure = null) : string
     {
         $chart = ilChart::getInstanceByType(ilChart::TYPE_GRID, "objstacc");
         $chart->setSize(700, 500);
@@ -554,9 +548,9 @@ class ilSessionStatisticsGUI
         $chart->setLegend($legend);
 
         if (!$a_measure) {
-            $a_measure = array("min", "avg", "max");
-        } elseif (!is_array($a_measure)) {
-            $a_measure = array($a_measure);
+            $measures = ["min", "avg", "max"];
+        } else {
+            $measures = [$a_measure];
         }
 
         $colors_map = array("min" => "#00cc00",
@@ -564,14 +558,14 @@ class ilSessionStatisticsGUI
             "max" => "#cc00cc");
         
         $colors = $act_line = array();
-        foreach ($a_measure as $measure) {
+        foreach ($measures as $measure) {
             $act_line[$measure] = $chart->getDataInstance(ilChartGrid::DATA_LINES);
             $act_line[$measure]->setLineSteps(true);
             $act_line[$measure]->setLabel($this->lng->txt("trac_session_active_" . $measure));
             $colors[] = $colors_map[$measure];
         }
         
-        if ($a_scale != self::SCALE_PERIODIC_WEEK) {
+        if ($a_scale !== self::SCALE_PERIODIC_WEEK) {
             $max_line = $chart->getDataInstance(ilChartGrid::DATA_LINES);
             $max_line->setLabel($this->lng->txt("session_max_count"));
             $colors[] = "#cc0000";
@@ -586,7 +580,7 @@ class ilSessionStatisticsGUI
         foreach ($chart_data as $idx => $item) {
             $date = $item["slot_begin"];
             
-            if ($a_scale == self::SCALE_PERIODIC_WEEK || !($idx % ceil($scale))) {
+            if ($a_scale === self::SCALE_PERIODIC_WEEK || !($idx % ceil($scale))) {
                 switch ($a_scale) {
                     case self::SCALE_DAY:
                         $labels[$date] = date("H:i", $date);
@@ -627,12 +621,12 @@ class ilSessionStatisticsGUI
                 }
             }
             
-            foreach ($a_measure as $measure) {
+            foreach ($measures as $measure) {
                 $value = (int) $item["active_" . $measure];
                 $act_line[$measure]->addPoint($date, $value);
             }
             
-            if (isset($max_line) && $a_scale != self::SCALE_PERIODIC_WEEK) {
+            if (isset($max_line) && $a_scale !== self::SCALE_PERIODIC_WEEK) {
                 $max_line->addPoint($date, (int) $item["max_sessions"]);
             }
         }
@@ -640,7 +634,7 @@ class ilSessionStatisticsGUI
         foreach ($act_line as $line) {
             $chart->addData($line);
         }
-        if (isset($max_line) && $a_scale != self::SCALE_PERIODIC_WEEK) {
+        if (isset($max_line) && $a_scale !== self::SCALE_PERIODIC_WEEK) {
             $chart->addData($max_line);
         }
         
@@ -649,7 +643,7 @@ class ilSessionStatisticsGUI
         return $chart->getHTML();
     }
     
-    protected function adaptDataToScale($a_scale, array $a_data) : array// TODO PHP8-REVIEW Type hints missing
+    protected function adaptDataToScale(int $a_scale, array $a_data) : array
     {
         // can we use original data?
         switch ($a_scale) {
@@ -662,7 +656,7 @@ class ilSessionStatisticsGUI
                 return $a_data;
         }
         
-        $tmp = array();
+        $tmp = [];
         foreach ($a_data as $item) {
             $date_parts = getdate($item["slot_begin"]);
             
@@ -781,7 +775,7 @@ class ilSessionStatisticsGUI
         $first = array_keys(array_shift($first));
         foreach ($first as $column) {
             // split weekday and time slot again
-            if ($a_scale == self::SCALE_PERIODIC_WEEK && $column === "slot_begin") {
+            if ($a_scale === self::SCALE_PERIODIC_WEEK && $column === "slot_begin") {
                 $csv->addColumn("weekday");
                 $csv->addColumn("time");
             } else {
@@ -799,7 +793,7 @@ class ilSessionStatisticsGUI
                 switch ($column) {
                     case "slot_begin":
                         // split weekday and time slot again
-                        if ($a_scale == self::SCALE_PERIODIC_WEEK) {
+                        if ($a_scale === self::SCALE_PERIODIC_WEEK) {
                             $csv->addColumn(ilCalendarUtil::_numericDayToString((int) substr($value, 0, 1)));
                             $value = substr($value, 1, 2) . ":" . substr($value, 3, 2);
                             break;

--- a/Services/Authentication/classes/class.ilSessionStatisticsGUI.php
+++ b/Services/Authentication/classes/class.ilSessionStatisticsGUI.php
@@ -99,17 +99,19 @@ class ilSessionStatisticsGUI
         
         // current mode
         if (!$_REQUEST["smd"]) {
-            $_REQUEST["smd"] = self::MODE_TODAY;
+            $mode = self::MODE_TODAY;
+        } else {
+            $mode = (int) $_REQUEST["smd"];
         }
-        $mode = (int) $_REQUEST["smd"];
         
         // current measure
         if (!$_REQUEST["smm"]) {
-            $_REQUEST["smm"] = "avg";
+            $measure = "avg";
+        } else {
+            $measure = $_REQUEST["smm"];
         }
-        $measure = (string) $_REQUEST["smm"];
-        
-                
+
+
         switch ($mode) {
             default:
             case self::MODE_TODAY:
@@ -206,16 +208,18 @@ class ilSessionStatisticsGUI
         
         // current mode
         if (!$_REQUEST["smd"]) {
-            $_REQUEST["smd"] = self::MODE_DAY;
+            $mode = self::MODE_DAY;
+        } else {
+            $mode = (int) $_REQUEST["smd"];
         }
-        $mode = (int) $_REQUEST["smd"];
         
         // current measure
         if (!$_REQUEST["smm"]) {
-            $_REQUEST["smm"] = "avg";
+            $measure = "avg";
+        } else {
+            $measure = $_REQUEST["smm"];
         }
-        $measure = (string) $_REQUEST["smm"];
-                                
+
         switch ($mode) {
             default:
             case self::MODE_DAY:
@@ -284,13 +288,14 @@ class ilSessionStatisticsGUI
         
         // current start
         $time_to = $this->importDate($_REQUEST["sst"]);
-        
+
         // current mode
         if (!$_REQUEST["smd"]) {
-            $_REQUEST["smd"] = self::MODE_WEEK;
+            $mode = self::MODE_WEEK;
+        } else {
+            $mode = (int) $_REQUEST["smd"];
         }
-        $mode = (int) $_REQUEST["smd"];
-        
+
         switch ($mode) {
             default:
             case self::MODE_WEEK:
@@ -608,12 +613,12 @@ class ilSessionStatisticsGUI
                         $date = $day_value + $hour * 60 * 60 + $min * 60;
                         
                         // 6-hour interval labels
-                        if (isset($old_hour) && $hour != $old_hour && $hour && $hour % 6 == 0) {
+                        if ((!isset($old_hour) || $hour != $old_hour) && $hour && $hour % 6 == 0) {
                             $labels[$date] = $hour;
                             $old_hour = $hour;
                         }
                         // day label
-                        if (isset($old_day) && $day != $old_day) {
+                        if (!isset($old_day) || $day != $old_day) {
                             $labels[$date] = ilCalendarUtil::_numericDayToString((int) $day, false);
                             $old_day = $day;
                         }

--- a/Services/Authentication/classes/class.ilSessionStatisticsGUI.php
+++ b/Services/Authentication/classes/class.ilSessionStatisticsGUI.php
@@ -19,20 +19,20 @@
  */
 class ilSessionStatisticsGUI
 {
-    const MODE_TODAY = 1;
-    const MODE_LAST_DAY = 2;
-    const MODE_LAST_WEEK = 3;
-    const MODE_LAST_MONTH = 4;
-    const MODE_DAY = 5;
-    const MODE_WEEK = 6;
-    const MODE_MONTH = 7;
-    const MODE_YEAR = 8;
-    
-    const SCALE_DAY = 1;
-    const SCALE_WEEK = 2;
-    const SCALE_MONTH = 3;
-    const SCALE_YEAR = 4;
-    const SCALE_PERIODIC_WEEK = 5;
+    private const MODE_TODAY = 1;
+    private const MODE_LAST_DAY = 2;
+    private const MODE_LAST_WEEK = 3;
+    private const MODE_LAST_MONTH = 4;
+    private const MODE_DAY = 5;
+    private const MODE_WEEK = 6;
+    private const MODE_MONTH = 7;
+    private const MODE_YEAR = 8;
+
+    private const SCALE_DAY = 1;
+    private const SCALE_WEEK = 2;
+    private const SCALE_MONTH = 3;
+    private const SCALE_YEAR = 4;
+    private const SCALE_PERIODIC_WEEK = 5;
     
     private ilCtrl $ilCtrl;
     private ilTabsGUI $ilTabs;
@@ -44,7 +44,7 @@ class ilSessionStatisticsGUI
     private ilIniFile $clientIniFile;
     private ilObjUser $user;
     
-    public function executeCommand()
+    public function executeCommand() : bool
     {
         global $DIC;
 
@@ -69,7 +69,7 @@ class ilSessionStatisticsGUI
         return true;
     }
     
-    protected function setSubTabs()
+    protected function setSubTabs() : void
     {
         $this->ilTabs->addSubTab(
             "current",
@@ -93,7 +93,7 @@ class ilSessionStatisticsGUI
         );
     }
     
-    protected function current($a_export = false)
+    protected function current($a_export = false) : void
     {
         $this->ilTabs->activateSubTab("current");
         
@@ -167,7 +167,7 @@ class ilSessionStatisticsGUI
 
             $this->toolbar->addFormButton($this->lng->txt("ok"), "current");
             
-            if (sizeof($data["active"])) {
+            if (count($data["active"])) {
                 $this->toolbar->addSeparator();
                 $this->toolbar->addFormButton($this->lng->txt("export"), "currentExport");
             }
@@ -180,7 +180,7 @@ class ilSessionStatisticsGUI
         }
     }
     
-    protected function currentExport()
+    protected function currentExport() : void
     {
         $this->current(true);
     }
@@ -197,7 +197,7 @@ class ilSessionStatisticsGUI
             : $a_default;
     }
         
-    protected function short($a_export = false)
+    protected function short($a_export = false) : void
     {
         $this->ilTabs->activateSubTab("short");
         
@@ -262,7 +262,7 @@ class ilSessionStatisticsGUI
 
             $this->toolbar->addFormButton($this->lng->txt("ok"), "short");
             
-            if (sizeof($data["active"])) {
+            if (count($data["active"])) {
                 $this->toolbar->addSeparator();
                 $this->toolbar->addFormButton($this->lng->txt("export"), "shortExport");
             }
@@ -273,12 +273,12 @@ class ilSessionStatisticsGUI
         }
     }
     
-    protected function shortExport()
+    protected function shortExport() : void
     {
         $this->short(true);
     }
     
-    protected function long($a_export = false)
+    protected function long($a_export = false) : void
     {
         $this->ilTabs->activateSubTab("long");
         
@@ -333,7 +333,7 @@ class ilSessionStatisticsGUI
 
             $this->toolbar->addFormButton($this->lng->txt("ok"), "long");
             
-            if (sizeof($data["active"])) {
+            if (count($data["active"])) {
                 $this->toolbar->addSeparator();
                 $this->toolbar->addFormButton($this->lng->txt("export"), "longExport");
             }
@@ -344,12 +344,12 @@ class ilSessionStatisticsGUI
         }
     }
     
-    protected function longExport()
+    protected function longExport() : void
     {
         $this->long(true);
     }
     
-    protected function periodic($a_export = false)
+    protected function periodic($a_export = false) : void
     {
         $this->ilTabs->activateSubTab("periodic");
         
@@ -383,7 +383,7 @@ class ilSessionStatisticsGUI
 
             $this->toolbar->addFormButton($this->lng->txt("ok"), "periodic");
             
-            if (sizeof($data["active"])) {
+            if (count($data["active"])) {
                 $this->toolbar->addSeparator();
                 $this->toolbar->addFormButton($this->lng->txt("export"), "periodicExport");
             }
@@ -394,18 +394,18 @@ class ilSessionStatisticsGUI
         }
     }
     
-    protected function periodicExport()
+    protected function periodicExport() : void
     {
         $this->periodic(true);
     }
     
-    protected function renderCurrentBasics()
+    protected function renderCurrentBasics() : string
     {
         // basic data - not time related
         
         $active = ilSessionControl::getExistingSessionCount(ilSessionControl::$session_types_controlled);
         
-        $control_active = ((int) $this->settings->get('session_handling_type', "0") == 1);
+        $control_active = ((int) $this->settings->get('session_handling_type', "0") === 1);
         if ($control_active) {
             $control_max_sessions = (int) $this->settings->get('session_max_count', (string) ilSessionControl::DEFAULT_MAX_COUNT);
             $control_min_idle = (int) $this->settings->get('session_min_idle', (string) ilSessionControl::DEFAULT_MIN_IDLE);
@@ -463,7 +463,7 @@ class ilSessionStatisticsGUI
         return $left->get();
     }
     
-    protected function buildData($a_time_from, $a_time_to, $a_title)
+    protected function buildData($a_time_from, $a_time_to, $a_title) : array// TODO PHP8-REVIEW Type hints missing
     {
         // basic data - time related
         
@@ -471,10 +471,9 @@ class ilSessionStatisticsGUI
         $counters = ilSessionStatistics::getNumberOfSessionsByType($a_time_from, $a_time_to);
         $opened = (int) $counters["opened"];
         $closed_limit = (int) $counters["closed_limit"];
-        unset($counters["opened"]);
-        unset($counters["closed_limit"]);
-        
-        
+        unset($counters["opened"], $counters["closed_limit"]);
+
+
         // build center column
         
         $data = array();
@@ -499,7 +498,7 @@ class ilSessionStatisticsGUI
         return $data;
     }
     
-    protected function render($a_data, $a_scale, $a_measure = null)
+    protected function render($a_data, $a_scale, $a_measure = null) : string// TODO PHP8-REVIEW Type hints missing
     {
         $center = new ilTemplate("tpl.session_statistics_center.html", true, true, "Services/Authentication");
         
@@ -545,10 +544,10 @@ class ilSessionStatisticsGUI
      * @param array $a_measure
      * @return string
      */
-    protected function getChart($a_data, $a_title, $a_scale = self::SCALE_DAY, $a_measure = null)
+    protected function getChart($a_data, $a_title, $a_scale = self::SCALE_DAY, $a_measure = null) : string// TODO PHP8-REVIEW Type hints missing
     {
         $chart = ilChart::getInstanceByType(ilChart::TYPE_GRID, "objstacc");
-        $chart->setsize(700, 500);
+        $chart->setSize(700, 500);
         $chart->setYAxisToInteger(true);
         
         $legend = new ilChartLegend();
@@ -581,9 +580,8 @@ class ilSessionStatisticsGUI
         $chart->setColors($colors);
         
         $chart_data = $this->adaptDataToScale($a_scale, $a_data);
-        unset($a_data);
-        
-        $scale = ceil(sizeof($chart_data) / 5);
+
+        $scale = ceil(count($chart_data) / 5);
         $labels = array();
         foreach ($chart_data as $idx => $item) {
             $date = $item["slot_begin"];
@@ -651,7 +649,7 @@ class ilSessionStatisticsGUI
         return $chart->getHTML();
     }
     
-    protected function adaptDataToScale($a_scale, array $a_data)
+    protected function adaptDataToScale($a_scale, array $a_data) : array// TODO PHP8-REVIEW Type hints missing
     {
         // can we use original data?
         switch ($a_scale) {
@@ -714,14 +712,14 @@ class ilSessionStatisticsGUI
         }
         
         foreach ($tmp as $slot => $attr) {
-            $tmp[$slot]["active_avg"] = (int) round(array_sum($attr["active_avg"]) / sizeof($attr["active_avg"]));
+            $tmp[$slot]["active_avg"] = (int) round(array_sum($attr["active_avg"]) / count($attr["active_avg"]));
             $tmp[$slot]["slot_begin"] = $slot;
         }
         ksort($tmp);
         return array_values($tmp);
     }
     
-    protected function adminSync()
+    protected function adminSync() : void
     {
         // see ilSession::_writeData()
         $now = time();
@@ -732,7 +730,7 @@ class ilSessionStatisticsGUI
         $this->ilCtrl->redirect($this);
     }
     
-    protected function exportCSV(array $a_data, $a_scale)
+    protected function exportCSV(array $a_data, $a_scale) : void
     {
         ilDatePresentation::setUseRelativeDates(false);
         
@@ -777,14 +775,13 @@ class ilSessionStatisticsGUI
         
         // aggregate data
         $aggr_data = $this->adaptDataToScale($a_scale, $a_data["active"]);
-        unset($a_data);
-        
+
         // header
         $first = $aggr_data;
         $first = array_keys(array_shift($first));
         foreach ($first as $column) {
             // split weekday and time slot again
-            if ($a_scale == self::SCALE_PERIODIC_WEEK && $column == "slot_begin") {
+            if ($a_scale == self::SCALE_PERIODIC_WEEK && $column === "slot_begin") {
                 $csv->addColumn("weekday");
                 $csv->addColumn("time");
             } else {

--- a/Services/Authentication/test/ilServicesAuthenticationSuite.php
+++ b/Services/Authentication/test/ilServicesAuthenticationSuite.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestSuite;
 
 class ilServicesAuthenticationSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new ilServicesAuthenticationSuite();
         require_once __DIR__ . '/ilSessionTest.php';

--- a/Services/Authentication/test/ilSessionTest.php
+++ b/Services/Authentication/test/ilSessionTest.php
@@ -15,26 +15,168 @@
  *****************************************************************************/
 
 
+use ILIAS\DI\Container;
+use ILIAS\UI\Component\Legacy\Legacy;
+use ILIAS\UI\Factory;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Class ilSessionTest
  */
-class ilSessionTest //extends TestCase
+class ilSessionTest extends TestCase
 {
     protected function setUp() : void
     {
+        $this->dic = new Container();
+        $GLOBALS['DIC'] = $this->dic;
+
+        //$this->setGlobalVariable('lng', $this->getLanguageMock());
+        $this->setGlobalVariable(
+            'ilCtrl',
+            $this->getMockBuilder(ilCtrl::class)->disableOriginalConstructor()->getMock()
+        );
+        $this->setGlobalVariable(
+            'ilUser',
+            $this->getMockBuilder(ilObjUser::class)->disableOriginalConstructor()->getMock()
+        );
+        $this->setGlobalVariable(
+            'ilDB',
+            $this->getMockBuilder(ilDBInterface::class)->disableAutoReturnValueGeneration()->getMock()
+        );
+        $this->setGlobalVariable(
+            'ilClientIniFile',
+            $this->getMockBuilder(ilIniFile::class)->disableOriginalConstructor()->getMock()
+        );
+        $this->setGlobalVariable(
+            'ilSetting',
+            $this->getMockBuilder(\ILIAS\Administration\Setting::class)->getMock()
+        );
+        parent::setUp();
     }
 
     /**
-     * @group IL_Init
+     * @param string $name
+     * @param mixed  $value
      */
+    protected function setGlobalVariable(string $name, $value) : void
+    {
+        global $DIC;
+
+        $GLOBALS[$name] = $value;
+
+        unset($DIC[$name]);
+        $DIC[$name] = static function ($c) use ($name) {
+            return $GLOBALS[$name];
+        };
+    }
+
     public function testBasicSessionBehaviour() : void
     {
         global $DIC;
 
-        $ilUser = $DIC['ilUser'];
-        
+        //setup some method calls
+        /** @var $setting MockObject */
+        $setting = $DIC['ilSetting'];
+        $setting->method("get")->willReturnCallback(
+            function ($arg) {
+                if ($arg === 'session_handling_type') {
+                    return (string) ilSession::SESSION_HANDLING_FIXED;
+                }
+                if ($arg === 'session_statistics') {
+                    return "0";
+                }
+
+                throw new \RuntimeException($arg);
+            }
+        );
+        /** @var $ilDB MockObject */
+        $data = null;
+        $ilDB = $DIC['ilDB'];
+        $ilDB->method("update")->
+            with("usr_session")->willReturn(1);
+
+        $ilDB->method("quote")->withConsecutive(
+            ["123456"],
+            ["123456"],
+            ["123456"],
+            ["e10adc3949ba59abbe56e057f20f883e"],
+            ["123456"],
+            ["e10adc3949ba59abbe56e057f20f883e"],
+            ["e10adc3949ba59abbe56e057f20f883e"],
+            ["123456"],
+            ["123456"],
+            ["123456"],
+            [$this->greaterThan(time() - 100)],
+            ["e10adc3949ba59abbe56e057f20f883e"],
+            ["17"]
+        )->
+        willReturnOnConsecutiveCalls(
+            "123456",
+            "123456",
+            "123456",
+            "e10adc3949ba59abbe56e057f20f883e",
+            "e10adc3949ba59abbe56e057f20f883e",
+            "123456",
+            "e10adc3949ba59abbe56e057f20f883e",
+            "e10adc3949ba59abbe56e057f20f883e",
+            "123456",
+            "123456",
+            "123456",
+            (string) time(),
+            "e10adc3949ba59abbe56e057f20f883e",
+            "17"
+        );
+        $ilDB->expects($this->exactly(6))->method("numRows")->willReturn(1, 1, 1, 0, 1, 0);
+
+
+        $ilDB->method("query")->withConsecutive(
+            ["SELECT 1 FROM usr_session WHERE session_id = 123456"],
+            ["SELECT 1 FROM usr_session WHERE session_id = 123456"],
+            ["SELECT data FROM usr_session WHERE session_id = 123456"],
+            ['SELECT * FROM usr_session WHERE session_id = e10adc3949ba59abbe56e057f20f883e'],
+            ['SELECT * FROM usr_session WHERE session_id = e10adc3949ba59abbe56e057f20f883e'],
+            ["SELECT 1 FROM usr_session WHERE session_id = 123456"],
+            ['SELECT data FROM usr_session WHERE session_id = e10adc3949ba59abbe56e057f20f883e'],
+            ['SELECT 1 FROM usr_session WHERE session_id = 123456'],
+            ['SELECT session_id,expires FROM usr_session WHERE expires < 123456'],
+            [$this->stringStartsWith('SELECT 1 FROM usr_session WHERE session_id = ')],
+            ['SELECT 1 FROM usr_session WHERE session_id = 17']
+        )->
+            willReturnOnConsecutiveCalls(
+                $this->getMockBuilder(ilDBStatement::class)->disableAutoReturnValueGeneration()->getMock(),
+                $this->getMockBuilder(ilDBStatement::class)->disableAutoReturnValueGeneration()->getMock(),
+                $this->getMockBuilder(ilDBStatement::class)->disableAutoReturnValueGeneration()->getMock(),
+                $this->getMockBuilder(ilDBStatement::class)->disableAutoReturnValueGeneration()->getMock(),
+                $this->getMockBuilder(ilDBStatement::class)->disableAutoReturnValueGeneration()->getMock(),
+                $this->getMockBuilder(ilDBStatement::class)->disableAutoReturnValueGeneration()->getMock(),
+                $this->getMockBuilder(ilDBStatement::class)->disableAutoReturnValueGeneration()->getMock(),
+                $this->getMockBuilder(ilDBStatement::class)->disableAutoReturnValueGeneration()->getMock(),
+                $this->getMockBuilder(ilDBStatement::class)->disableAutoReturnValueGeneration()->getMock(),
+                $this->getMockBuilder(ilDBStatement::class)->disableAutoReturnValueGeneration()->getMock(),
+                $this->getMockBuilder(ilDBStatement::class)->disableAutoReturnValueGeneration()->getMock()
+            );
+        $ilDB->expects($this->exactly(4))->method("fetchAssoc")->willReturn(
+            ["data" => "Testdata"],
+            [],
+            ["data" => "Testdata"],
+            []
+        );
+        $ilDB->expects($this->exactly(1))->method("fetchObject")->willReturn((object) array(
+            'data' => "Testdata"
+        ));
+
+        $ilDB->method("manipulate")->withConsecutive(
+            ['DELETE FROM usr_sess_istorage WHERE session_id = 123456'],
+            ['DELETE FROM usr_session WHERE session_id = e10adc3949ba59abbe56e057f20f883e'],
+            ['DELETE FROM usr_session WHERE user_id = e10adc3949ba59abbe56e057f20f883e']
+        )->
+        willReturnOnConsecutiveCalls(
+            1,
+            1,
+            1
+        );
+
         $result = "";
         ilSession::_writeData("123456", "Testdata");
         if (ilSession::_exists("123456")) {
@@ -56,16 +198,13 @@ class ilSessionTest //extends TestCase
             $result .= "destroyExp-";
         }
         
-        ilSession::_destroyByUserId($ilUser->getId());
+        ilSession::_destroyByUserId(17);
         if (!ilSession::_exists($duplicate)) {
             $result .= "destroyByUser-";
         }
-        $this->assertEquals("exists-write-get-duplicate-destroy-destroyExp-destroyByUser-", $result);// TODO PHP8-REVIEW This method does not exists (because this class has no parent class)
+        $this->assertEquals("exists-write-get-duplicate-destroy-destroyExp-destroyByUser-", $result);
     }
 
-    /**
-     * @group IL_Init
-     */
     public function testPasswordAssisstanceSession() : void
     {
         global $DIC;
@@ -73,7 +212,10 @@ class ilSessionTest //extends TestCase
         $ilUser = $DIC['ilUser'];
                 
         $result = "";
-        
+        $this->markTestIncomplete(
+            'This test has not been implemented yet.'
+        );
+        return;
         // write session
         db_pwassist_session_write("12345", 60, $ilUser->getId());
         

--- a/Services/Authentication/test/ilSessionTest.php
+++ b/Services/Authentication/test/ilSessionTest.php
@@ -22,8 +22,6 @@ use PHPUnit\Framework\TestCase;
  */
 class ilSessionTest //extends TestCase
 {
-    protected $backupGlobals = false;
-
     protected function setUp() : void
     {
     }
@@ -31,7 +29,7 @@ class ilSessionTest //extends TestCase
     /**
      * @group IL_Init
      */
-    public function testBasicSessionBehaviour()
+    public function testBasicSessionBehaviour() : void
     {
         global $DIC;
 
@@ -42,11 +40,11 @@ class ilSessionTest //extends TestCase
         if (ilSession::_exists("123456")) {
             $result .= "exists-";
         }
-        if (ilSession::_getData("123456") == "Testdata") {
+        if (ilSession::_getData("123456") === "Testdata") {
             $result .= "write-get-";
         }
         $duplicate = ilSession::_duplicate("123456");
-        if (ilSession::_getData($duplicate) == "Testdata") {
+        if (ilSession::_getData($duplicate) === "Testdata") {
             $result .= "duplicate-";
         }
         ilSession::_destroy("123456");
@@ -62,13 +60,13 @@ class ilSessionTest //extends TestCase
         if (!ilSession::_exists($duplicate)) {
             $result .= "destroyByUser-";
         }
-        $this->assertEquals("exists-write-get-duplicate-destroy-destroyExp-destroyByUser-", $result);
+        $this->assertEquals("exists-write-get-duplicate-destroy-destroyExp-destroyByUser-", $result);// TODO PHP8-REVIEW This method does not exists (because this class has no parent class)
     }
 
     /**
      * @group IL_Init
      */
-    public function testPasswordAssisstanceSession()
+    public function testPasswordAssisstanceSession() : void
     {
         global $DIC;
 
@@ -81,13 +79,13 @@ class ilSessionTest //extends TestCase
         
         // find
         $res = db_pwassist_session_find($ilUser->getId());
-        if ($res["pwassist_id"] == "12345") {
+        if ($res["pwassist_id"] === "12345") {
             $result .= "find-";
         }
         
         // read
         $res = db_pwassist_session_read("12345");
-        if ($res["user_id"] == $ilUser->getId()) {
+        if ((int) $res["user_id"] === $ilUser->getId()) {
             $result .= "read-";
         }
         
@@ -100,6 +98,6 @@ class ilSessionTest //extends TestCase
 
         db_pwassist_session_gc();
 
-        $this->assertEquals("find-read-destroy-", $result);
+        $this->assertEquals("find-read-destroy-", $result);// TODO PHP8-REVIEW This method does not exists (because this class has no parent class)
     }
 }

--- a/Services/Saml/classes/class.ilAuthProviderSaml.php
+++ b/Services/Saml/classes/class.ilAuthProviderSaml.php
@@ -29,7 +29,7 @@ class ilAuthProviderSaml extends ilAuthProvider implements ilAuthProviderAccount
     protected bool $force_new_account = false;
     protected string $migration_account = '';
 
-    public function __construct(ilAuthFrontendCredentials $credentials, ?int $a_idp_id = null)
+    public function __construct(ilAuthCredentials $credentials, ?int $a_idp_id = null)
     {
         parent::__construct($credentials);
 


### PR DESCRIPTION
Hello @pascalseeland, 

I completed the review of the `Services/Authentication` component.

Results:

- [x] The code style is `PSR-2 + X` compliant
- [ ] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`: I found 22 usages of `$_REQUEST`, 7 usages of `$_GET`, 30 usages of `$_SESSION` and 34 usages of `$_POST`.
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] There are no serious `PhpStorm Code Inspection` issues left
- [x] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

--

Actions needed:
- [ ] Please eliminate the usage of super global variables.
- [x] The unit test does not extend from the base class provided by `PhpUnit`. The current tests are NOT executed.
- [x] Please check my inline comments. Some of them might be just information, some require an action. You can use `TODO PHP8-REVIEW` when searching.

Best regards,
@mjansenDatabay  