### PR TITLE
Hotfix: Remove HTML in plain text E-Mails

### DIFF
--- a/Services/Mail/classes/class.ilMimeMail.php
+++ b/Services/Mail/classes/class.ilMimeMail.php
@@ -264,8 +264,16 @@ class ilMimeMail
             $this->buildBodyMultiParts($skin);
             $this->buildHtmlInlineImages($skin);
         } else {
-            $this->finalBody = str_ireplace(["<br />", "<br>", "<br/>"], "\n", $this->body);
+            $this->finalBody = $this->removeHTMLTags($this->body);
         }
+    }
+
+    private function removeHTMLTags(string $maybeHTML) : string
+    {
+        $maybeHTML = str_ireplace(['<br />', '<br>', '<br/>'], "\n", $maybeHTML);
+        $maybeHTML = strip_tags($maybeHTML);
+
+        return $maybeHTML;
     }
 
     protected function buildBodyMultiParts(string $skin) : void


### PR DESCRIPTION
Hi @mjansenDatabay,

this PR solve's the mantis ticket: https://mantis.ilias.de/view.php?id=32338 for ILIAS 7.

The following changes will be introduced in this PR:
Remove HTML tags from the email body when the option "HTML Frame" is deactivated (this leads to a plain text email).
For reference see:
- `Services/Mail/classes/class.ilMimeMail.php:267`
- `Services/Mail/classes/Mime/Transport/class.ilMailMimeTransportBase.php:119`

Best regards
@lscharmer