### PR TITLE
Mail: PHP8 review

### DIFF
--- a/Services/Mail/classes/Form/class.ilIncomingMailInputGUI.php
+++ b/Services/Mail/classes/Form/class.ilIncomingMailInputGUI.php
@@ -134,7 +134,6 @@ class ilIncomingMailInputGUI extends ilRadioGroupInputGUI
             (string) ilMailOptions::BOTH_EMAIL
         );
         $sub_both_opt3->setDisabled($this->getDisabled());
-        $email_info = [];
         if (!$this->isFreeOptionChoice()) {
             $email_info = [];
             if (

--- a/Services/Mail/classes/Form/class.ilMailQuickFilterInputGUI.php
+++ b/Services/Mail/classes/Form/class.ilMailQuickFilterInputGUI.php
@@ -1,18 +1,20 @@
 <?php declare(strict_types=1);
 /* Copyright (c) 1998-2021 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+use ILIAS\Refinery\Factory;
+use ILIAS\HTTP\GlobalHttpState;
+
 /**
  * @author  Michael Jansen <mjansen@databay.de>
  * @ingroup ServicesMail
  */
 class ilMailQuickFilterInputGUI extends ilTextInputGUI
 {
-    protected ?\ILIAS\Refinery\Factory $refinery;
-    protected \ILIAS\HTTP\GlobalHttpState $httpState;
+    protected ?Factory $refinery;
+    protected GlobalHttpState $httpState;
 
     public function __construct($a_title, $a_postvar)
     {
-        /** @var $DIC \ILIAS\DI\Container */
         global $DIC;
         
         $this->refinery = $DIC->refinery();

--- a/Services/Mail/classes/Form/class.ilManualPlaceholderInputGUI.php
+++ b/Services/Mail/classes/Form/class.ilManualPlaceholderInputGUI.php
@@ -1,13 +1,16 @@
 <?php declare(strict_types=1);
 /* Copyright (c) 1998-2021 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+use ILIAS\HTTP\GlobalHttpState;
+use ILIAS\Filesystem\Stream\Streams;
+
 /**
  * Class ilManualPlaceholderInputGUI
  * @author Nadia Ahmad <nahmad@databay.de>
  */
 class ilManualPlaceholderInputGUI extends ilSubEnabledFormPropertyGUI
 {
-    protected \ILIAS\HTTP\GlobalHttpState $httpState;
+    protected GlobalHttpState $httpState;
     /**
      * @var array<string, array{placeholder: string, title: string}>
      */
@@ -22,7 +25,6 @@ class ilManualPlaceholderInputGUI extends ilSubEnabledFormPropertyGUI
 
     public function __construct(string $dependencyElementId)
     {
-        /** @var $DIC \ILIAS\DI\Container */
         global $DIC;
 
         $this->tpl = $DIC->ui()->mainTemplate();
@@ -118,7 +120,7 @@ class ilManualPlaceholderInputGUI extends ilSubEnabledFormPropertyGUI
             $this->httpState->saveResponse(
                 $this->httpState
                     ->response()
-                    ->withBody(\ILIAS\Filesystem\Stream\Streams::ofString($subtpl->get()))
+                    ->withBody(Streams::ofString($subtpl->get()))
             );
             $this->httpState->sendResponse();
             $this->httpState->close();

--- a/Services/Mail/classes/Provider/MailNotificationProvider.php
+++ b/Services/Mail/classes/Provider/MailNotificationProvider.php
@@ -4,12 +4,13 @@ namespace ILIAS\Mail\Provider;
 
 use ILIAS\GlobalScreen\Identification\IdentificationInterface;
 use ILIAS\GlobalScreen\Scope\Notification\Provider\AbstractNotificationProvider;
-use ILIAS\GlobalScreen\Scope\Notification\Provider\NotificationProvider;
 use ILIAS\UI\Component\Symbol\Icon\Standard;
 use ilMailGlobalServices;
 use DateTimeImmutable;
 use ilDateTime;
 use ilDatePresentation;
+use Throwable;
+use ILIAS\UI\Component\Item\Notification;
 
 /**
  * Class MailNotificationProvider
@@ -79,6 +80,7 @@ class MailNotificationProvider extends AbstractNotificationProvider
             $mailUrl
         );
 
+        /** @var Notification $notificationItem */
         $notificationItem = $this->dic->ui()->factory()
             ->item()
             ->notification($title, $icon)
@@ -91,7 +93,7 @@ class MailNotificationProvider extends AbstractNotificationProvider
                     new ilDateTime($dateTime->getTimestamp(), IL_CAL_UNIX)
                 ),
             ]);
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
         }
 
         $group = $factory->standardGroup($id('mail_bucket_group'))

--- a/Services/Mail/classes/Setup/class.ilMailSetupAgent.php
+++ b/Services/Mail/classes/Setup/class.ilMailSetupAgent.php
@@ -4,7 +4,6 @@
 
 use ILIAS\Setup;
 use ILIAS\Refinery;
-use ILIAS\UI;
 
 class ilMailSetupAgent implements Setup\Agent
 {

--- a/Services/Mail/classes/class.ilAccountMail.php
+++ b/Services/Mail/classes/class.ilAccountMail.php
@@ -129,7 +129,7 @@ class ilAccountMail
         return $this->amail[$a_lang];
     }
 
-    private function addAttachments($mailData) : void
+    private function addAttachments(array $mailData) : void
     {
         if (isset($mailData['att_file']) && $this->shouldAttachConfiguredFiles()) {
             $fs = new ilFSStorageUserFolder(USER_FOLDER_ID);

--- a/Services/Mail/classes/class.ilFileDataMail.php
+++ b/Services/Mail/classes/class.ilFileDataMail.php
@@ -11,7 +11,6 @@
 */
 
 use ILIAS\Filesystem\Filesystem;
-use GuzzleHttp\Psr7\UploadedFile;
 
 class ilFileDataMail extends ilFileData
 {

--- a/Services/Mail/classes/class.ilFormatMail.php
+++ b/Services/Mail/classes/class.ilFormatMail.php
@@ -120,7 +120,7 @@ class ilFormatMail extends ilMail
         $linebreak = $this->mail_options->getLinebreak();
 
         $lines = explode(chr(10), $message);
-        foreach ($lines as $i => $iValue) {
+        foreach ($lines as $iValue) {
             if (strpos($iValue, '>') !== 0) {
                 $formatted[] = wordwrap($iValue, $linebreak, chr(10));
             } else {

--- a/Services/Mail/classes/class.ilMailAttachmentTableGUI.php
+++ b/Services/Mail/classes/class.ilMailAttachmentTableGUI.php
@@ -8,10 +8,8 @@
  */
 class ilMailAttachmentTableGUI extends ilTable2GUI
 {
-    public function __construct($a_parent_obj, $a_parent_cmd)
+    public function __construct(?object $a_parent_obj, string $a_parent_cmd)
     {
-        global $DIC;
-
         $this->setId('mail_attachments');
 
         $this->setDefaultOrderDirection('ASC');

--- a/Services/Mail/classes/class.ilMailCronOrphanedMails.php
+++ b/Services/Mail/classes/class.ilMailCronOrphanedMails.php
@@ -4,6 +4,7 @@
 
 use ILIAS\HTTP\GlobalHttpState;
 use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Refinery\Transformation;
 
 /**
  * Delete orphaned mails
@@ -223,7 +224,7 @@ class ilMailCronOrphanedMails extends ilCronJob
         $processor->processDeletion();
     }
     
-    private function emptyStringOrFloatOrIntToEmptyOrIntegerString() : \ILIAS\Refinery\Transformation
+    private function emptyStringOrFloatOrIntToEmptyOrIntegerString() : Transformation
     {
         $empty_string_or_null_to_stirng_trafo = $this->refinery->custom()->transformation(static function ($value) : string {
             if ($value === '' || null === $value) {

--- a/Services/Mail/classes/class.ilMailCronOrphanedMailsNotificationCollector.php
+++ b/Services/Mail/classes/class.ilMailCronOrphanedMailsNotificationCollector.php
@@ -67,7 +67,6 @@ class ilMailCronOrphanedMailsNotificationCollector
         ) . " ORDER BY m.user_id, folder_id, mail_id";
 
         $collection_obj = null;
-        $folder_obj = null;
 
         $res = $this->db->queryF($notification_query, $types, $data);
         while ($row = $this->db->fetchAssoc($res)) {

--- a/Services/Mail/classes/class.ilMailExplorer.php
+++ b/Services/Mail/classes/class.ilMailExplorer.php
@@ -39,7 +39,6 @@ class ilMailExplorer extends ilTreeExplorerGUI
 
     protected function initFolder() : void
     {
-        $folderId = 0;
         if ($this->http->wrapper()->post()->has('mobj_id')) {
             $folderId = $this->http->wrapper()->post()->retrieve('mobj_id', $this->refinery->kindlyTo()->int());
         } elseif ($this->http->wrapper()->query()->has('mobj_id')) {

--- a/Services/Mail/classes/class.ilMailFolderGUI.php
+++ b/Services/Mail/classes/class.ilMailFolderGUI.php
@@ -2,7 +2,6 @@
 
 /* Copyright (c) 1998-2021 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-use Psr\Http\Message\ServerRequestInterface;
 use ILIAS\HTTP\GlobalHttpState;
 use ILIAS\Refinery\Factory as Refinery;
 
@@ -51,7 +50,6 @@ class ilMailFolderGUI
 
     protected function initFolder() : void
     {
-        $folderId = 0;
         if ($this->http->wrapper()->post()->has('mobj_id')) {
             $folderId = $this->http->wrapper()->post()->retrieve('mobj_id', $this->refinery->kindlyTo()->int());
         } elseif ($this->http->wrapper()->query()->has('mobj_id')) {

--- a/Services/Mail/classes/class.ilMailFolderTableGUI.php
+++ b/Services/Mail/classes/class.ilMailFolderTableGUI.php
@@ -84,7 +84,7 @@ class ilMailFolderTableGUI extends ilTable2GUI
         });
 
         $columns = [];
-        foreach ($optionalColumns as $index => $column) {
+        foreach ($optionalColumns as $column) {
             $columns[$column['field']] = $column;
         }
 

--- a/Services/Mail/classes/class.ilMailForm.php
+++ b/Services/Mail/classes/class.ilMailForm.php
@@ -1,18 +1,12 @@
 <?php declare(strict_types=1);
 /* Copyright (c) 1998-2021 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-use ILIAS\HTTP\GlobalHttpState;
-use ILIAS\Refinery\Factory as Refinery;
-
 /**
  * @author Nadia Ahmad
  * @version $Id$
  */
 class ilMailForm
 {
-    private GlobalHttpState $http;
-    private Refinery $refinery;
-
     /**
      * @param string $quotedTerm
      * @param string $term
@@ -23,13 +17,13 @@ class ilMailForm
     {
         global $DIC;
 
-        $this->http = $DIC->http();
-        $this->refinery = $DIC->refinery();
+        $http = $DIC->http();
+        $refinery = $DIC->refinery();
 
         $mode = ilMailAutoCompleteRecipientResult::MODE_STOP_ON_MAX_ENTRIES;
         if (
-            $this->http->wrapper()->query()->has('fetchall') &&
-            $this->http->wrapper()->query()->retrieve('fetchall', $this->refinery->kindlyTo()->bool())
+            $http->wrapper()->query()->has('fetchall') &&
+            $http->wrapper()->query()->retrieve('fetchall', $refinery->kindlyTo()->bool())
         ) {
             $mode = ilMailAutoCompleteRecipientResult::MODE_FETCH_ALL;
         }

--- a/Services/Mail/classes/class.ilMailFormAttachmentPropertyGUI.php
+++ b/Services/Mail/classes/class.ilMailFormAttachmentPropertyGUI.php
@@ -14,8 +14,6 @@ class ilMailFormAttachmentPropertyGUI extends ilFormPropertyGUI
 
     public function __construct(string $buttonLabel)
     {
-        global $DIC;
-
         $this->buttonLabel = $buttonLabel;
         parent::__construct();
         $this->setTitle($this->lng->txt('attachments'));

--- a/Services/Mail/classes/class.ilMailFormGUI.php
+++ b/Services/Mail/classes/class.ilMailFormGUI.php
@@ -4,6 +4,8 @@
 use ILIAS\HTTP\GlobalHttpState;
 use ILIAS\HTTP\Response\ResponseHeader;
 use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Refinery\Transformation;
+use ILIAS\Filesystem\Stream\Streams;
 
 /**
  * @author Jens Conze
@@ -32,9 +34,7 @@ class ilMailFormGUI
     private ilFileDataMail $mfile;
     private GlobalHttpState $http;
     private Refinery $refinery;
-    private int $requestMailObjId = 0;
     private ?array $requestAttachments = null;
-    private string $requestMailSubject = '';
     protected ilMailTemplateService $templateService;
     private ilMailBodyPurifier $purifier;
     private string $mail_form_type = '';
@@ -75,7 +75,7 @@ class ilMailFormGUI
         $this->ctrl->setParameter($this, 'mobj_id', $requestMailObjId);
     }
     
-    private function getQueryParam(string $name, \ILIAS\Refinery\Transformation $trafo, $default = null)
+    private function getQueryParam(string $name, Transformation $trafo, $default = null)
     {
         if ($this->http->wrapper()->query()->has($name)) {
             return $this->http->wrapper()->query()->retrieve(
@@ -87,7 +87,7 @@ class ilMailFormGUI
         return $default;
     }
 
-    private function getBodyParam(string $name, \ILIAS\Refinery\Transformation $trafo, $default = null)
+    private function getBodyParam(string $name, Transformation $trafo, $default = null)
     {
         if ($this->http->wrapper()->post()->has($name)) {
             return $this->http->wrapper()->post()->retrieve(
@@ -203,8 +203,7 @@ class ilMailFormGUI
                 '',
                 '',
                 '',
-                '',
-                false
+                ''
             );
 
             $this->ctrl->setParameterByClass(ilMailGUI::class, 'type', 'message_sent');
@@ -468,7 +467,7 @@ class ilMailFormGUI
             $this->http->saveResponse(
                 $this->http->response()
                     ->withHeader(ResponseHeader::CONTENT_TYPE, 'application/json')
-                    ->withBody(\ILIAS\Filesystem\Stream\Streams::ofString(json_encode([
+                    ->withBody(Streams::ofString(json_encode([
                         'm_subject' => $template->getSubject(),
                         'm_message' => $template->getMessage() . $this->umail->appendSignature(),
                     ], JSON_THROW_ON_ERROR)))
@@ -874,7 +873,7 @@ class ilMailFormGUI
             $this->http->saveResponse(
                 $this->http->response()
                     ->withHeader(ResponseHeader::CONTENT_TYPE, 'application/json')
-                    ->withBody(\ILIAS\Filesystem\Stream\Streams::ofString(json_encode($result, JSON_THROW_ON_ERROR)))
+                    ->withBody(Streams::ofString(json_encode($result, JSON_THROW_ON_ERROR)))
             );
 
             $this->http->sendResponse();
@@ -891,7 +890,7 @@ class ilMailFormGUI
         $this->http->saveResponse(
             $this->http->response()
                 ->withHeader(ResponseHeader::CONTENT_TYPE, 'application/json')
-                ->withBody(\ILIAS\Filesystem\Stream\Streams::ofString(json_encode($result, JSON_THROW_ON_ERROR)))
+                ->withBody(Streams::ofString(json_encode($result, JSON_THROW_ON_ERROR)))
         );
         $this->http->sendResponse();
         $this->http->close();

--- a/Services/Mail/classes/class.ilMailGUI.php
+++ b/Services/Mail/classes/class.ilMailGUI.php
@@ -63,7 +63,6 @@ class ilMailGUI implements ilCtrlBaseClassInterface
 
     protected function initFolder() : void
     {
-        $folderId = 0;
         if ($this->http->wrapper()->post()->has('mobj_id')) {
             $folderId = $this->http->wrapper()->post()->retrieve('mobj_id', $this->refinery->kindlyTo()->int());
         } elseif ($this->http->wrapper()->query()->has('mobj_id')) {

--- a/Services/Mail/classes/class.ilMailOptionsFormGUI.php
+++ b/Services/Mail/classes/class.ilMailOptionsFormGUI.php
@@ -17,8 +17,6 @@ class ilMailOptionsFormGUI extends ilPropertyFormGUI
      */
     public function __construct(ilMailOptions $options, object $parentGui, string $positiveCmd)
     {
-        global $DIC;
-
         if (!method_exists($parentGui, 'executeCommand')) {
             throw new InvalidArgumentException(sprintf(
                 'Parameter $parentGui must be ilCtrl enabled by implementing executeCommand(), %s given.',

--- a/Services/Mail/classes/class.ilMailTemplateContextService.php
+++ b/Services/Mail/classes/class.ilMailTemplateContextService.php
@@ -115,10 +115,6 @@ class ilMailTemplateContextService
         ?string $a_path,
         bool $isCreationContext = false
     ) : ?ilMailTemplateContext {
-        global $DIC;
-
-        $mess = '';
-
         if (!$a_path) {
             $a_path = $a_component . '/classes/';
         }

--- a/Services/Mail/classes/class.ilMailTemplateGUI.php
+++ b/Services/Mail/classes/class.ilMailTemplateGUI.php
@@ -287,7 +287,6 @@ class ilMailTemplateGUI
             );
         }
         if (count($templateIds) === 0) {
-            $templateId = 0;
             if ($this->http->wrapper()->query()->has('tpl_id')) {
                 $templateIds = [$this->http->wrapper()->query()->retrieve(
                     'tpl_id',
@@ -377,7 +376,7 @@ class ilMailTemplateGUI
         $placeholders->setAdviseText(sprintf($this->lng->txt('placeholders_advise'), '<br />'));
 
         $context = ilMailTemplateContextService::getTemplateContextById($contextId);
-        foreach ($context->getPlaceholders() as $key => $value) {
+        foreach ($context->getPlaceholders() as $value) {
             $placeholders->addPlaceholder($value['placeholder'], $value['label']);
         }
 

--- a/Services/Mail/classes/class.ilMimeMailNotification.php
+++ b/Services/Mail/classes/class.ilMimeMailNotification.php
@@ -60,7 +60,6 @@ abstract class ilMimeMailNotification extends ilMailNotification
             $this->setCurrentRecipient($rcp);
             $this->initLanguageByIso2Code();
         } elseif ($rcp instanceof ilObjUser) {
-            /** @var $rcp ilObjUser */
             $this->setCurrentRecipient($rcp->getEmail());
             $this->initLanguage($rcp->getId());
         } else {

--- a/Services/Mail/classes/class.ilObjMailGUI.php
+++ b/Services/Mail/classes/class.ilObjMailGUI.php
@@ -524,7 +524,7 @@ class ilObjMailGUI extends ilObjectGUI
             ['placeholder' => 'CLIENT_DESC', 'label' => $this->lng->txt('mail_nacc_client_desc')],
             ['placeholder' => 'CLIENT_URL', 'label' => $this->lng->txt('mail_nacc_ilias_url')],
         ];
-        foreach ($placeholder_list as $key => $value) {
+        foreach ($placeholder_list as $value) {
             $placeholders->addPlaceholder($value['placeholder'], $value['label']);
         }
         $placeholders->setDisabled(!$this->isEditingAllowed());

--- a/Services/Mail/classes/class.ilPDMailBlockGUI.php
+++ b/Services/Mail/classes/class.ilPDMailBlockGUI.php
@@ -3,6 +3,7 @@
 
 use ILIAS\HTTP\GlobalHttpState;
 use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\UI\Component\Item\Item;
 
 /**
  * BlockGUI class for Personal Desktop Mail block
@@ -246,7 +247,7 @@ class ilPDMailBlockGUI extends ilBlockGUI
 
     protected $new_rendering = true;
 
-    protected function getListItemForData(array $data) : ?\ILIAS\UI\Component\Item\Item
+    protected function getListItemForData(array $data) : ?Item
     {
         $f = $this->ui->factory();
 

--- a/Services/Mail/test/gui/ilMailOptionsGUITest.php
+++ b/Services/Mail/test/gui/ilMailOptionsGUITest.php
@@ -4,6 +4,8 @@
 
 use ILIAS\HTTP\Wrapper\WrapperFactory;
 use Psr\Http\Message\ServerRequestInterface;
+use ILIAS\HTTP\GlobalHttpState;
+use ILIAS\Refinery\Factory;
 
 /**
  * Class ilMailOptionsGUITest
@@ -15,7 +17,7 @@ class ilMailOptionsGUITest extends ilMailBaseTest
      * @throws ReflectionException
      */
     protected function getMailOptionsGUI(
-        \ILIAS\HTTP\GlobalHttpState $httpState,
+        GlobalHttpState $httpState,
         ilCtrl $ctrl,
         ilSetting $settings
     ) : ilMailOptionsGUI {
@@ -34,7 +36,7 @@ class ilMailOptionsGUITest extends ilMailBaseTest
             $httpState,
             $mail,
             $mailBox,
-            new \ILIAS\Refinery\Factory(new \ILIAS\Data\Factory(), $lng)
+            new Factory(new \ILIAS\Data\Factory(), $lng)
         );
     }
 
@@ -55,7 +57,7 @@ class ilMailOptionsGUITest extends ilMailBaseTest
         $request->method('getQueryParams')->willReturn([]);
         $wrapper = new WrapperFactory($request);
 
-        $http = $this->getMockBuilder(\ILIAS\HTTP\GlobalHttpState::class)->getMock();
+        $http = $this->getMockBuilder(GlobalHttpState::class)->getMock();
         $http->method('wrapper')->willReturn($wrapper);
 
         $gui = $this->getMailOptionsGUI($http, $ctrl, $settings);
@@ -79,7 +81,7 @@ class ilMailOptionsGUITest extends ilMailBaseTest
         $request->method('getQueryParams')->willReturn([]);
         $wrapper = new WrapperFactory($request);
 
-        $http = $this->getMockBuilder(\ILIAS\HTTP\GlobalHttpState::class)->getMock();
+        $http = $this->getMockBuilder(GlobalHttpState::class)->getMock();
         $http->method('wrapper')->willReturn($wrapper);
 
         $ctrl->expects($this->once())->method('redirectByClass')->with(ilMailGUI::class);
@@ -110,7 +112,7 @@ class ilMailOptionsGUITest extends ilMailBaseTest
         ]);
         $wrapper = new WrapperFactory($request);
 
-        $http = $this->getMockBuilder(\ILIAS\HTTP\GlobalHttpState::class)->getMock();
+        $http = $this->getMockBuilder(GlobalHttpState::class)->getMock();
         $http->method('wrapper')->willReturn($wrapper);
 
         $gui = $this->getMailOptionsGUI($http, $ctrl, $settings);


### PR DESCRIPTION
# Must-Package
### What must be the agreed minimum goal from the community?  - Whether developers, operators or users.

## Goals
 * [x] ILIAS can be used with PHP 8 without producing PHP-specific errors.
 * [x] Refactored code conforms to current coding styles
 * [ ] Elimination of all warnings and errors of the static code inspection (without weak | incl. undeclared variables)
   * 18 warnings
   * 33 weak warnings
 * [x] Transfer of GET params into Constructor
 * [x] Avoidance/reduction of POST accesses (e.g. through $form->getInput()) and switch to Request classes
 * [x] Use of SESSION (session object, alternative assignment of static session in constructor member variables)
 * [x] Documentation of all existing typifications as typehints (of parameters, return values and properties)
 * [x] Creation of a unit test infrastructure in the component

## Requirements and analysis criteria
* [x] Preserve unit test coverage even in refactoring.
* [x]  Simple call of all tabs/screens (without e.g. delete and move actions) and fixing of the corresponding bugs
  * GUI ilMailSearchObjectGUI produce errors sometimes, but is not a Mail object
* [x]  Checking of external libraries
* [x]  Basis of the refactoring and the reviews is, among others, ILIAS Development Documentation.

# Should-Package
### What do we need to do in the mid-term to catch recurring large code revisions and to refactor more than the minimum?

 * [x] Expansion of the unit test coverage
  * General and structural improvements and optimisations to the code base. For example ...
   * [ ]  ... in static functions and by removing static methods
   * [x]  ... by introducing return type declarations
   * ... by typification of all variables
     * [x] Input/output typing of methods
     * [x] Typification of member variables
 * [ ]   Use of UI components from the UI framework "KitchenSink" that have been introduced and established in the meantime. Reduction of legacy UI and legacy code.

# Sustainability-Package
### he developer community has identified topics that would also improve the quality of ILIAS from the point of view of PHP and ILIAS in general. Ideally, these topics could be directly addressed in the process of systematic refactoring.

* [x] Introduction and use of declarations of "strict_types" for data
* [ ]  Replace previous arrays with classes that enable ArrayAccess - in future also getter / setter
* [ ]  Switching previous arrays to generators/data objects