### PR TITLE
PHP 8: Code Review `AdvancedEditing`

### DIFF
--- a/Services/AdvancedEditing/classes/class.ilObjAdvancedEditing.php
+++ b/Services/AdvancedEditing/classes/class.ilObjAdvancedEditing.php
@@ -132,8 +132,7 @@ class ilObjAdvancedEditing extends ilObject
      */
     public static function _getRichTextEditor() : string
     {
-        $setting = new ilSetting("advanced_editing");
-        return $setting->get("advanced_editing_javascript_editor", "0");
+        return (new ilSetting("advanced_editing"))->get("advanced_editing_javascript_editor", "0");
     }
     
     public function setRichTextEditor(string $a_js_editor) : void

--- a/Services/AdvancedEditing/classes/class.ilObjAdvancedEditing.php
+++ b/Services/AdvancedEditing/classes/class.ilObjAdvancedEditing.php
@@ -42,70 +42,68 @@ class ilObjAdvancedEditing extends ilObject
     public static function _getUsedHTMLTags(string $a_module = "") : array
     {
         $setting = new ilSetting("advanced_editing");
-        $tags = $setting->get("advanced_editing_used_html_tags_" . $a_module);
-        if (strlen($tags)) {
-            $usedtags = unserialize($tags);
+        $tags = $setting->get("advanced_editing_used_html_tags_" . $a_module, '');
+        if ($tags !== '') {
+            $usedtags = unserialize($tags, ["allowed_classes" => false]);
+        } elseif ($a_module === 'frm_post' || $a_module === 'exc_ass') {
+            $usedtags = array(
+            "a",
+            "blockquote",
+            "br",
+            "code",
+            "div",
+            "em",
+            "img",
+            "li",
+            "ol",
+            "p",
+            "strong",
+            "u",
+            "ul",
+            "span"
+            );
         } else {
-            if ($a_module == 'frm_post' || $a_module == 'exc_ass') {
-                $usedtags = array(
-                "a",
-                "blockquote",
-                "br",
-                "code",
-                "div",
-                "em",
-                "img",
-                "li",
-                "ol",
-                "p",
-                "strong",
-                "u",
-                "ul",
-                "span"
-                );
-            } else {
-                // default: everything but tables
-                $usedtags = array(
-                "a",
-                "blockquote",
-                "br",
-                "cite",
-                "code",
-                "dd",
-                "div",
-                "dl",
-                "dt",
-                "em",
-                "h1",
-                "h2",
-                "h3",
-                "h4",
-                "h5",
-                "h6",
-                "hr",
-                "img",
-                "li",
-                "ol",
-                "p",
-                "pre",
-                "span",
-                "strike",
-                "strong",
-                "sub",
-                "sup",
-                "u",
-                "ul"
-                );
-            }
+            // default: everything but tables
+            $usedtags = array(
+            "a",
+            "blockquote",
+            "br",
+            "cite",
+            "code",
+            "dd",
+            "div",
+            "dl",
+            "dt",
+            "em",
+            "h1",
+            "h2",
+            "h3",
+            "h4",
+            "h5",
+            "h6",
+            "hr",
+            "img",
+            "li",
+            "ol",
+            "p",
+            "pre",
+            "span",
+            "strike",
+            "strong",
+            "sub",
+            "sup",
+            "u",
+            "ul"
+            );
         }
         
         // frm_posts need blockquote and div urgently
         if ($a_module === 'frm_post') {
-            if (!in_array('div', $usedtags)) {
+            if (!in_array('div', $usedtags, true)) {
                 $usedtags[] = 'div';
             }
             
-            if (!in_array('blockquote', $usedtags)) {
+            if (!in_array('blockquote', $usedtags, true)) {
                 $usedtags[] = 'blockquote';
             }
         }
@@ -121,7 +119,7 @@ class ilObjAdvancedEditing extends ilObject
     public static function _getUsedHTMLTagsAsString(string $a_module = "") : string
     {
         $result = "";
-        $tags = ilObjAdvancedEditing::_getUsedHTMLTags($a_module);
+        $tags = self::_getUsedHTMLTags($a_module);
         foreach ($tags as $tag) {
             $result .= "<$tag>";
         }
@@ -135,8 +133,7 @@ class ilObjAdvancedEditing extends ilObject
     public static function _getRichTextEditor() : string
     {
         $setting = new ilSetting("advanced_editing");
-        $js = $setting->get("advanced_editing_javascript_editor", "0");
-        return $js;
+        return $setting->get("advanced_editing_javascript_editor", "0");
     }
     
     public function setRichTextEditor(string $a_js_editor) : void
@@ -157,16 +154,16 @@ class ilObjAdvancedEditing extends ilObject
     ) : void {
         $lng = $this->lng;
         
-        if (strlen($a_module)) {
+        if ($a_module !== '') {
             $auto_added_tags = array();
             
             // frm_posts need blockquote and div urgently
-            if ($a_module == 'frm_post') {
-                if (!in_array('div', $a_html_tags)) {
+            if ($a_module === 'frm_post') {
+                if (!in_array('div', $a_html_tags, true)) {
                     $auto_added_tags[] = 'div';
                 }
                 
-                if (!in_array('blockquote', $a_html_tags)) {
+                if (!in_array('blockquote', $a_html_tags, true)) {
                     $auto_added_tags[] = 'blockquote';
                 }
             }
@@ -242,7 +239,7 @@ class ilObjAdvancedEditing extends ilObject
      */
     public static function _getAllHTMLTags() : array
     {
-        $tags = array(
+        return array(
             "a",
             "abbr",
             "acronym",
@@ -330,7 +327,6 @@ class ilObjAdvancedEditing extends ilObject
             "rt",
             "rp"
         );
-        return $tags;
     }
 
     /**
@@ -353,7 +349,7 @@ class ilObjAdvancedEditing extends ilObject
         global $DIC;
 
         $ilUser = $DIC->user();
-        if (strlen($ilUser->getPref("show_rte")) > 0) {
+        if ($ilUser->getPref("show_rte") != '') {
             return (int) $ilUser->getPref("show_rte");
         }
         return 1;

--- a/Services/AdvancedEditing/classes/class.ilObjAdvancedEditingGUI.php
+++ b/Services/AdvancedEditing/classes/class.ilObjAdvancedEditingGUI.php
@@ -25,7 +25,6 @@ class ilObjAdvancedEditingGUI extends ilObjectGUI
 {
     protected ilPropertyFormGUI $form;
     protected string $cgrp = "";
-    protected ilTabsGUI $tabs;
     protected StandardGUIRequest $std_request;
     protected ilComponentRepository $component_repository;
 
@@ -37,12 +36,6 @@ class ilObjAdvancedEditingGUI extends ilObjectGUI
         /** @var \ILIAS\DI\Container $DIC */
         global $DIC;
 
-        $this->ctrl = $DIC->ctrl();
-        $this->tabs = $DIC->tabs();
-        $this->tpl = $DIC["tpl"];
-        $this->lng = $DIC->language();
-        $this->access = $DIC->access();
-        $this->settings = $DIC->settings();
         $this->component_repository = $DIC["component.repository"];
 
         $this->type = "adve";
@@ -51,7 +44,7 @@ class ilObjAdvancedEditingGUI extends ilObjectGUI
         $this->lng->loadLanguageModule('meta');
         $this->std_request = new StandardGUIRequest(
             $DIC->http(),
-            $DIC->refinery()
+            $this->refinery
         );
     }
     
@@ -102,10 +95,8 @@ class ilObjAdvancedEditingGUI extends ilObjectGUI
     
     public function addSubtabs() : void
     {
-        $ilCtrl = $this->ctrl;
-
-        if ($ilCtrl->getNextClass() !== "ilpermissiongui" &&
-            !in_array($ilCtrl->getCmd(), array(
+        if ($this->ctrl->getNextClass() !== "ilpermissiongui" &&
+            !in_array($this->ctrl->getCmd(), array(
                 "showPageEditorSettings",
                 "showGeneralPageEditorSettings",
                 "showCharSelectorSettings",
@@ -152,33 +143,28 @@ class ilObjAdvancedEditingGUI extends ilObjectGUI
     
     public function addPageEditorSettingsSubtabs() : void
     {
-        $ilCtrl = $this->ctrl;
-        $ilTabs = $this->tabs;
-
-        $ilTabs->addSubTabTarget(
+        $this->tabs_gui->addSubTabTarget(
             "adve_pe_general",
-            $ilCtrl->getLinkTarget($this, "showGeneralPageEditorSettings"),
+            $this->ctrl->getLinkTarget($this, "showGeneralPageEditorSettings"),
             array("showGeneralPageEditorSettings", "", "view")
         );
 
         $grps = ilPageEditorSettings::getGroups();
         
         foreach ($grps as $g => $types) {
-            $ilCtrl->setParameter($this, "grp", $g);
-            $ilTabs->addSubTabTarget(
+            $this->ctrl->setParameter($this, "grp", $g);
+            $this->tabs_gui->addSubTabTarget(
                 "adve_grp_" . $g,
-                $ilCtrl->getLinkTarget($this, "showPageEditorSettings"),
+                $this->ctrl->getLinkTarget($this, "showPageEditorSettings"),
                 array("showPageEditorSettings")
             );
         }
-        $ilCtrl->setParameter($this, "grp", $this->std_request->getGroup());
+        $this->ctrl->setParameter($this, "grp", $this->std_request->getGroup());
     }
     
     protected function getTabs() : void
     {
-        $rbacsystem = $this->rbacsystem;
-
-        if ($rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "adve_page_editor_settings",
                 $this->ctrl->getLinkTarget($this, "showGeneralPageEditorSettings"),
@@ -200,7 +186,7 @@ class ilObjAdvancedEditingGUI extends ilObjectGUI
             );
         }
 
-        if ($rbacsystem->checkAccess('edit_permission', $this->object->getRefId())) {
+        if ($this->rbac_system->checkAccess('edit_permission', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "perm_settings",
                 $this->ctrl->getLinkTargetByClass(array(get_class($this),'ilpermissiongui'), "perm"),
@@ -220,19 +206,17 @@ class ilObjAdvancedEditingGUI extends ilObjectGUI
 
     public function getTinyForm() : ilPropertyFormGUI
     {
-        $ilCtrl = $this->ctrl;
-        $lng = $this->lng;
-        $editor = self::_getRichTextEditor();
+        $editor = ilObjAdvancedEditing::_getRichTextEditor();
         $form = new ilPropertyFormGUI();
-        $form->setFormAction($ilCtrl->getFormAction($this));
-        $form->setTitle($lng->txt("adve_activation"));
+        $form->setFormAction($this->ctrl->getFormAction($this));
+        $form->setTitle($this->lng->txt("adve_activation"));
         $cb = new ilCheckboxInputGUI($this->lng->txt("adve_use_tiny_mce"), "use_tiny");
         if ($editor === "tinymce") {
             $cb->setChecked(true);
         }
         $form->addItem($cb);
         if ($this->checkPermissionBool("write")) {
-            $form->addCommandButton("saveSettings", $lng->txt("save"));
+            $form->addCommandButton("saveSettings", $this->lng->txt("save"));
         }
         
         return $form;
@@ -357,8 +341,6 @@ class ilObjAdvancedEditingGUI extends ilObjectGUI
         string $a_cmd,
         string $a_title
     ) : ilPropertyFormGUI {
-        $ilAccess = $this->access;
-        
         $form = new ilPropertyFormGUI();
         $form->setFormAction($this->ctrl->getFormAction($this, $a_cmd));
         $form->setTitle($this->lng->txt($a_title));
@@ -374,7 +356,7 @@ class ilObjAdvancedEditingGUI extends ilObjectGUI
         $tags->setValue(ilObjAdvancedEditing::_getUsedHTMLTags($a_id));
         $form->addItem($tags);
         
-        if ($ilAccess->checkAccess("write", "", $this->object->getRefId())) {
+        if ($this->access->checkAccess("write", "", $this->object->getRefId())) {
             $form->addCommandButton($a_cmd, $this->lng->txt("save"));
         }
 
@@ -408,10 +390,6 @@ class ilObjAdvancedEditingGUI extends ilObjectGUI
     
     public function showPageEditorSettingsObject() : void
     {
-        $tpl = $this->tpl;
-        $ilTabs = $this->tabs;
-        $ilCtrl = $this->ctrl;
-        
         $this->addPageEditorSettingsSubtabs();
         
         $grps = ilPageEditorSettings::getGroups();
@@ -421,48 +399,45 @@ class ilObjAdvancedEditingGUI extends ilObjectGUI
             $this->cgrp = (string) key($grps);
         }
 
-        $ilCtrl->setParameter($this, "grp", $this->cgrp);
-        $ilTabs->setSubTabActive("adve_grp_" . $this->cgrp);
+        $this->ctrl->setParameter($this, "grp", $this->cgrp);
+        $this->tabs_gui->setSubTabActive("adve_grp_" . $this->cgrp);
         
         $this->initPageEditorForm();
-        $tpl->setContent($this->form->getHTML());
+        $this->tpl->setContent($this->form->getHTML());
     }
     
     public function initPageEditorForm() : void
     {
-        $lng = $this->lng;
-        $ilSetting = $this->settings;
-        
-        $lng->loadLanguageModule("content");
+        $this->lng->loadLanguageModule("content");
         
         $this->form = new ilPropertyFormGUI();
     
         if ($this->cgrp === "test") {
-            $this->form->setTitle($lng->txt("adve_activation"));
+            $this->form->setTitle($this->lng->txt("adve_activation"));
             $cb = new ilCheckboxInputGUI($this->lng->txt("advanced_editing_tst_editing"), "tst_page_edit");
             $cb->setInfo($this->lng->txt("advanced_editing_tst_editing_desc"));
-            if ($ilSetting->get("enable_tst_page_edit", ilObjAssessmentFolder::ADDITIONAL_QUESTION_CONTENT_EDITING_MODE_PAGE_OBJECT_DISABLED)) {
+            if ($this->settings->get("enable_tst_page_edit", ilObjAssessmentFolder::ADDITIONAL_QUESTION_CONTENT_EDITING_MODE_PAGE_OBJECT_DISABLED)) {
                 $cb->setChecked(true);
             }
             $this->form->addItem($cb);
 
             $sh = new ilFormSectionHeaderGUI();
-            $sh->setTitle($lng->txt("adve_text_content_features"));
+            $sh->setTitle($this->lng->txt("adve_text_content_features"));
             $this->form->addItem($sh);
         } elseif ($this->cgrp === "rep") {
-            $this->form->setTitle($lng->txt("adve_activation"));
+            $this->form->setTitle($this->lng->txt("adve_activation"));
             $cb = new ilCheckboxInputGUI($this->lng->txt("advanced_editing_rep_page_editing"), "cat_page_edit");
             $cb->setInfo($this->lng->txt("advanced_editing_rep_page_editing_desc"));
-            if ($ilSetting->get("enable_cat_page_edit")) {
+            if ($this->settings->get("enable_cat_page_edit")) {
                 $cb->setChecked(true);
             }
             $this->form->addItem($cb);
 
             $sh = new ilFormSectionHeaderGUI();
-            $sh->setTitle($lng->txt("adve_text_content_features"));
+            $sh->setTitle($this->lng->txt("adve_text_content_features"));
             $this->form->addItem($sh);
         } else {
-            $this->form->setTitle($lng->txt("adve_text_content_features"));
+            $this->form->setTitle($this->lng->txt("adve_text_content_features"));
         }
 
         
@@ -476,7 +451,7 @@ class ilObjAdvancedEditingGUI extends ilObjectGUI
     
         // save and cancel commands
         if ($this->checkPermissionBool("write")) {
-            $this->form->addCommandButton("savePageEditorSettings", $lng->txt("save"));
+            $this->form->addCommandButton("savePageEditorSettings", $this->lng->txt("save"));
         }
         
         $this->form->setFormAction($this->ctrl->getFormAction($this));
@@ -516,21 +491,15 @@ class ilObjAdvancedEditingGUI extends ilObjectGUI
     
     public function showGeneralPageEditorSettingsObject() : void
     {
-        $tpl = $this->tpl;
-        $ilTabs = $this->tabs;
-
         $this->addPageEditorSettingsSubtabs();
-        $ilTabs->activateTab("adve_page_editor_settings");
+        $this->tabs_gui->activateTab("adve_page_editor_settings");
         
         $form = $this->initGeneralPageSettingsForm();
-        $tpl->setContent($form->getHTML());
+        $this->tpl->setContent($form->getHTML());
     }
     
     public function initGeneralPageSettingsForm() : ilPropertyFormGUI
     {
-        $lng = $this->lng;
-        $ilCtrl = $this->ctrl;
-    
         $form = new ilPropertyFormGUI();
         
         $aset = new ilSetting("adve");
@@ -572,14 +541,14 @@ class ilObjAdvancedEditingGUI extends ilObjectGUI
         $form->addItem($cb);
 
         if ($this->checkPermissionBool("write")) {
-            $form->addCommandButton("saveGeneralPageSettings", $lng->txt("save"));
+            $form->addCommandButton("saveGeneralPageSettings", $this->lng->txt("save"));
         }
 
         // enable html/js
         $this->lng->loadLanguageModule("copg");
         $sh = new ilFormSectionHeaderGUI();
-        $sh->setTitle($lng->txt("copg_allow_html"));
-        $sh->setInfo($lng->txt("copg_allow_html_info"));
+        $sh->setTitle($this->lng->txt("copg_allow_html"));
+        $sh->setInfo($this->lng->txt("copg_allow_html_info"));
         $form->addItem($sh);
 
         $comps = iterator_to_array($this->component_repository->getComponents());
@@ -602,8 +571,8 @@ class ilObjAdvancedEditingGUI extends ilObjectGUI
         ilGlossaryDefinition::setShortTextsDirtyGlobally();
 
                     
-        $form->setTitle($lng->txt("adve_pe_general"));
-        $form->setFormAction($ilCtrl->getFormAction($this));
+        $form->setTitle($this->lng->txt("adve_pe_general"));
+        $form->setFormAction($this->ctrl->getFormAction($this));
      
         return $form;
     }
@@ -622,10 +591,6 @@ class ilObjAdvancedEditingGUI extends ilObjectGUI
 
     public function saveGeneralPageSettingsObject() : void
     {
-        $ilCtrl = $this->ctrl;
-        $lng = $this->lng;
-        $tpl = $this->tpl;
-
         $this->checkPermission("write");
         
         $form = $this->initGeneralPageSettingsForm();
@@ -658,25 +623,22 @@ class ilObjAdvancedEditingGUI extends ilObjectGUI
                     }
                 }
 
-                $this->tpl->setOnScreenMessage('success', $lng->txt("msg_obj_modified"), true);
-                $ilCtrl->redirect($this, "showGeneralPageEditorSettings");
+                $this->tpl->setOnScreenMessage('success', $this->lng->txt("msg_obj_modified"), true);
+                $this->ctrl->redirect($this, "showGeneralPageEditorSettings");
             }
         }
         
         $form->setValuesByPost();
-        $tpl->setContent($form->getHTML());
+        $this->tpl->setContent($form->getHTML());
     }
     
     public function initCharSelectorSettingsForm(ilCharSelectorGUI $char_selector) : ilPropertyFormGUI
     {
-        $lng = $this->lng;
-        $ilCtrl = $this->ctrl;
-    
         $form = new ilPropertyFormGUI();
-        $form->setTitle($lng->txt('settings'));
-        $form->setFormAction($ilCtrl->getFormAction($this));
+        $form->setTitle($this->lng->txt('settings'));
+        $form->setFormAction($this->ctrl->getFormAction($this));
         if ($this->checkPermissionBool("write")) {
-            $form->addCommandButton("saveCharSelectorSettings", $lng->txt("save"));
+            $form->addCommandButton("saveCharSelectorSettings", $this->lng->txt("save"));
         }
         $char_selector->addFormProperties($form);
 
@@ -689,18 +651,14 @@ class ilObjAdvancedEditingGUI extends ilObjectGUI
      */
     public function showCharSelectorSettingsObject() : void
     {
-        $ilTabs = $this->tabs;
-        $ilSetting = $this->settings;
-        $tpl = $this->tpl;
-
-        $ilTabs->activateTab("adve_char_selector_settings");
+        $this->tabs_gui->activateTab("adve_char_selector_settings");
                 
         $char_selector = new ilCharSelectorGUI(ilCharSelectorConfig::CONTEXT_ADMIN);
-        $char_selector->getConfig()->setAvailability((int) $ilSetting->get('char_selector_availability'));
-        $char_selector->getConfig()->setDefinition((string) $ilSetting->get('char_selector_definition'));
+        $char_selector->getConfig()->setAvailability((int) $this->settings->get('char_selector_availability'));
+        $char_selector->getConfig()->setDefinition((string) $this->settings->get('char_selector_definition'));
         $form = $this->initCharSelectorSettingsForm($char_selector);
         $char_selector->setFormValues($form);
-        $tpl->setContent($form->getHTML());
+        $this->tpl->setContent($form->getHTML());
     }
     
     
@@ -709,11 +667,6 @@ class ilObjAdvancedEditingGUI extends ilObjectGUI
      */
     public function saveCharSelectorSettingsObject() : void
     {
-        $ilSetting = $this->settings;
-        $ilCtrl = $this->ctrl;
-        $lng = $this->lng;
-        $tpl = $this->tpl;
-
         $this->checkPermission("write");
         
         $char_selector = new ilCharSelectorGUI(ilCharSelectorConfig::CONTEXT_ADMIN);
@@ -721,13 +674,13 @@ class ilObjAdvancedEditingGUI extends ilObjectGUI
         if ($form->checkInput()) {
             $char_selector->getFormValues($form);
 
-            $ilSetting->set('char_selector_availability', $char_selector->getConfig()->getAvailability());
-            $ilSetting->set('char_selector_definition', $char_selector->getConfig()->getDefinition());
+            $this->settings->set('char_selector_availability', $char_selector->getConfig()->getAvailability());
+            $this->settings->set('char_selector_definition', $char_selector->getConfig()->getDefinition());
             
-            $this->tpl->setOnScreenMessage('success', $lng->txt("msg_obj_modified"), true);
-            $ilCtrl->redirect($this, "showCharSelectorSettings");
+            $this->tpl->setOnScreenMessage('success', $this->lng->txt("msg_obj_modified"), true);
+            $this->ctrl->redirect($this, "showCharSelectorSettings");
         }
         $form->setValuesByPost();
-        $tpl->setContent($form->getHTML());
+        $this->tpl->setContent($form->getHTML());
     }
 }

--- a/Services/AdvancedEditing/test/AdveStandardGUIRequestTest.php
+++ b/Services/AdvancedEditing/test/AdveStandardGUIRequestTest.php
@@ -9,13 +9,6 @@ use PHPUnit\Framework\TestCase;
  */
 class AdveStandardGUIRequestTest extends TestCase
 {
-    //protected $backupGlobals = false;
-
-    protected function setUp() : void
-    {
-        parent::setUp();
-    }
-
     protected function tearDown() : void
     {
     }
@@ -37,7 +30,7 @@ class AdveStandardGUIRequestTest extends TestCase
     /**
      * Test group
      */
-    public function testGroup()
+    public function testGroup() : void
     {
         $request = $this->getRequest(
             [

--- a/Services/AdvancedEditing/test/ilServicesAdvancedEditingSuite.php
+++ b/Services/AdvancedEditing/test/ilServicesAdvancedEditingSuite.php
@@ -22,7 +22,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilServicesAdvancedEditingSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new self();
 


### PR DESCRIPTION
Hi @alex40724,

I completed the review of the `Services/AdvancedEditing` component.

Results:
- [x] The code style is `PSR-2 + X` compliant
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [ ] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

I also fixed some trivial issues reported by my inspection profile.

--

Actions needed:

None

Best regards,
@mjansenDatabay