### PR TITLE
Saml: PHP8 review

### DIFF
--- a/Services/Saml/classes/class.ilSamlAuthFactory.php
+++ b/Services/Saml/classes/class.ilSamlAuthFactory.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 /* Copyright (c) 1998-2017 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+use ILIAS\Filesystem\Exception\IOException;
+
 /**
  * Class ilSamlAuthFactory
  */
@@ -23,7 +25,7 @@ class ilSamlAuthFactory
 
     /**
      * @return string
-     * @throws \ILIAS\Filesystem\Exception\IOException
+     * @throws IOException
      */
     public function getConfigDirectory() : string
     {

--- a/Services/Saml/classes/class.ilSamlIdp.php
+++ b/Services/Saml/classes/class.ilSamlIdp.php
@@ -88,8 +88,8 @@ class ilSamlIdp
     }
 
     /**
-     * Deletes an idp with all relvant mapping rules.
-     * Furthermore the auth_mode of the relevant user accounts will be switched to 'default'
+     * Deletes an idp with all relevant mapping rules.
+     * Furthermore, the auth_mode of the relevant user accounts will be switched to 'default'
      */
     public function delete() : void
     {

--- a/Services/Saml/classes/class.ilSamlIdpSelectionTableGUI.php
+++ b/Services/Saml/classes/class.ilSamlIdpSelectionTableGUI.php
@@ -5,7 +5,7 @@
  * Class ilSamlIdpSelectionTableGUI
  * @author Michael Jansen <mjansen@databay.de>
  */
-class ilSamlIdpSelectionTableGUI extends \ilTable2GUI
+class ilSamlIdpSelectionTableGUI extends ilTable2GUI
 {
     public function __construct(object $parent_gui, string $parent_cmd)
     {

--- a/Services/Saml/classes/class.ilSamlSettingsGUI.php
+++ b/Services/Saml/classes/class.ilSamlSettingsGUI.php
@@ -2,6 +2,9 @@
 /* Copyright (c) 1998-2016 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\DI\RBACServices;
+use ILIAS\HTTP\GlobalHttpState;
+use ILIAS\Data\Factory;
 
 /**
  * Class ilSamlSettingsGUI
@@ -17,7 +20,7 @@ class ilSamlSettingsGUI
     /**
      * @var string[]
      */
-    protected static $globalCommands = [
+    protected static array $globalCommands = [
         self::DEFAULT_CMD,
         'showAddIdpForm',
         'showSettings',
@@ -29,7 +32,7 @@ class ilSamlSettingsGUI
     /**
      * @var string[]
      */
-    protected static $globalEntityCommands = [
+    protected static array $globalEntityCommands = [
         'deactivateIdp',
         'activateIdp',
         'confirmDeleteIdp',
@@ -39,7 +42,7 @@ class ilSamlSettingsGUI
     /**
      * @var string[]
      */
-    protected static $ignoredUserFields = [
+    protected static array $ignoredUserFields = [
         'mail_incoming_mail',
         'preferences',
         'hide_own_online_status',
@@ -64,11 +67,11 @@ class ilSamlSettingsGUI
     protected ilLanguage $lng;
     protected ilGlobalTemplateInterface $tpl;
     protected ilAccessHandler $access;
-    protected \ILIAS\DI\RBACServices $rbac;
+    protected RBACServices $rbac;
     protected ilErrorHandling $error_handler;
     protected ilTabsGUI $tabs;
     protected ilToolbarGUI $toolbar;
-    protected \ILIAS\HTTP\GlobalHttpState $httpState;
+    protected GlobalHttpState $httpState;
     protected Refinery $refinery;
     protected ilHelpGUI $help;
     protected ?ilExternalAuthUserAttributeMapping $mapping = null;
@@ -597,7 +600,7 @@ class ilSamlSettingsGUI
             $this->lng->txt('auth_saml_add_idp_md_label'),
             'metadata',
             new ilSamlIdpXmlMetadataParser(
-                new \ILIAS\Data\Factory(),
+                new Factory(),
                 new ilSamlIdpXmlMetadataErrorFormatter()
             )
         );


### PR DESCRIPTION
# Must-Package
### What must be the agreed minimum goal from the community?  - Whether developers, operators or users.

## Goals
 * [x] ILIAS can be used with PHP 8 without producing PHP-specific errors.
 * [x] Refactored code conforms to current coding styles
 * [x] Elimination of all warnings and errors of the static code inspection (without weak | incl. undeclared variables)
   * 6 weak warnings
 * [ ] Transfer of GET params into Constructor
 * [x] Avoidance/reduction of POST accesses (e.g. through $form->getInput()) and switch to Request classes
 * [x] Use of SESSION (session object, alternative assignment of static session in constructor member variables)
 * [x] Documentation of all existing typifications as typehints (of parameters, return values and properties)
 * [x] Creation of a unit test infrastructure in the component

## Requirements and analysis criteria
* [x] Preserve unit test coverage even in refactoring.
* [x]  Simple call of all tabs/screens (without e.g. delete and move actions) and fixing of the corresponding bugs
* [x]  Checking of external libraries
* [x]  Basis of the refactoring and the reviews is, among others, ILIAS Development Documentation.

# Should-Package
### What do we need to do in the mid-term to catch recurring large code revisions and to refactor more than the minimum?

 * [x] Expansion of the unit test coverage
  * General and structural improvements and optimisations to the code base. For example ...
   * [ ]  ... in static functions and by removing static methods
   * [x]  ... by introducing return type declarations
   * ... by typification of all variables
     * [x] Input/output typing of methods
     * [x] Typification of member variables
 * [ ]   Use of UI components from the UI framework "KitchenSink" that have been introduced and established in the meantime. Reduction of legacy UI and legacy code.

# Sustainability-Package
### he developer community has identified topics that would also improve the quality of ILIAS from the point of view of PHP and ILIAS in general. Ideally, these topics could be directly addressed in the process of systematic refactoring.

* [x] Introduction and use of declarations of "strict_types" for data
* [ ]  Replace previous arrays with classes that enable ArrayAccess - in future also getter / setter
* [ ]  Switching previous arrays to generators/data objects