### PR TITLE
Empty Heading on Infoscreen of Text and Survey

### DIFF
--- a/Modules/Survey/classes/class.ilObjSurveyGUI.php
+++ b/Modules/Survey/classes/class.ilObjSurveyGUI.php
@@ -1967,7 +1967,7 @@ class ilObjSurveyGUI extends ilObjectGUI
             $info->addProperty("", $this->object->prepareTextareaOutput($introduction) .
                 "<br />" . $info->getHiddenToggleButton());
         } else {
-            $info->addSection("");
+            $info->addSection($this->lng->txt("show_details"));
             $info->addProperty("", $info->getHiddenToggleButton());
         }
 

--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -2817,7 +2817,7 @@ class ilObjTestGUI extends ilObjectGUI
             $info->addProperty("", $this->object->prepareTextareaOutput($this->object->getIntroduction(), true) .
                     $info->getHiddenToggleButton());
         } else {
-            $info->addSection("");
+            $info->addSection($this->lng->txt("show_details"));
             $info->addProperty("", $info->getHiddenToggleButton());
         }
 


### PR DESCRIPTION
Currently we have a wcag failing issue on the info screen of the Test and the Survey if no description is provided. There will be an empty h2 heading. See: https://mantis.ilias.de/view.php?id=32255 and https://mantis.ilias.de/view.php?id=32365 . 

Easiest (and maybe best) solution would be to just provide a proper heading. Another option would be to provide s sr-only heading or provide no h2 heading at all in those cases. If @alex40724 prefers this, I will assign the issue to him, since there would be some moving around of the InfoScreenGUI be required to check if the heading is required/sr-only.

The change would look as follows:
<img width="891" alt="image" src="https://user-images.githubusercontent.com/1866896/161279062-f5a7891b-1337-4a39-9bae-a168515e179d.png">
