### PR TITLE
Empty Table Heading in TA Results screen

### DIFF
--- a/Modules/Test/classes/tables/class.ilParticipantsTestResultsTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilParticipantsTestResultsTableGUI.php
@@ -135,7 +135,7 @@ class ilParticipantsTestResultsTableGUI extends ilTable2GUI
         $this->addColumn($this->lng->txt("tst_tbl_col_final_mark"), 'final_mark');
         
         if ($this->isActionsColumnRequired()) {
-            $this->addColumn('', '', '');
+            $this->addColumn($this->lng->txt('actions'), '', '');
         }
     }
     


### PR DESCRIPTION
Currently we have a wcag failing issue on a table in Test and assessment. Reported issue is, that there is a blank table header cell, which posses an issue for screenreader, since they heavily rely on table headings. See: https://mantis.ilias.de/view.php?id=32259

This was the table reported, although, there are many many more with the same issue. I put the linked issue therefore on the jf agenda.

<img width="1123" alt="image" src="https://user-images.githubusercontent.com/1866896/161296028-bd6921f8-6906-49a6-b8e3-ee5db8dfd546.png">
