### PR TITLE
A11y Actions Menu is not available by keyboard, see #32257

### DIFF
--- a/Services/UIComponent/AdvancedSelectionList/classes/class.ilAdvancedSelectionListGUI.php
+++ b/Services/UIComponent/AdvancedSelectionList/classes/class.ilAdvancedSelectionListGUI.php
@@ -897,6 +897,7 @@ class ilAdvancedSelectionListGUI implements ilToolbarItem
             case self::STYLE_LINK:
                 $tpl->setVariable("BTN_CLASS", "");
                 $tpl->setVariable("TAG", "a");
+                $tpl->touchBlock("href_link");
                 break;
         }
 

--- a/Services/UIComponent/AdvancedSelectionList/templates/default/tpl.adv_selection_list.html
+++ b/Services/UIComponent/AdvancedSelectionList/templates/default/tpl.adv_selection_list.html
@@ -1,7 +1,7 @@
 <!-- BEGIN js_section -->
 <div class="btn-group">
 <!-- Important: The next a-tag had a this.blur(); in the onclick event before. Please do not add it again, see bug #8723 -->
-<{TAG} type="button" {ACCKEY} class="{BTN_CLASS} dropdown-toggle" data-toggle="dropdown" data-container="body" id="ilAdvSelListAnchorText_{ID}" aria-label="{TXT_ARIA_TOP}">
+<{TAG} <!-- BEGIN href_link -->href="#" <!-- END href_link --> type="button" {ACCKEY} class="{BTN_CLASS} dropdown-toggle" data-toggle="dropdown" data-container="body" id="ilAdvSelListAnchorText_{ID}" aria-label="{TXT_ARIA_TOP}">
 <span>{TXT_SEL_TOP}</span> <!-- BEGIN top_img --><span class="{IMG_SPAN_STYLE}"></span><!-- END top_img -->
 </{TAG}>
 {GROUPED_LIST_HTML}


### PR DESCRIPTION
Issue seems to be, that if the advanced table is rendered as ilAdvancedSelectionListGUI::STYLE_LINK, then we have a <a> tag with no href and therefore no tabbing per default. See issue: https://mantis.ilias.de/view.php?id=32257#bugnotes as an example