### PR TITLE
Review services `Services/Init`

### DIFF
--- a/Services/Init/classes/Dependencies/InitComponentService.php
+++ b/Services/Init/classes/Dependencies/InitComponentService.php
@@ -9,9 +9,9 @@ class InitComponentService
     {
         $int = $this->initInternal($c);
 
-        $c["component.repository"] = fn($c) : \ilComponentRepository => $int["db_write"];
+        $c["component.repository"] = fn ($c) : \ilComponentRepository => $int["db_write"];
 
-        $c["component.factory"] = fn($c) : \ilComponentFactory => new ilComponentFactoryImplementation(
+        $c["component.factory"] = fn ($c) : \ilComponentFactory => new ilComponentFactoryImplementation(
             $int["db_write"],
             $c["ilDB"]
         );
@@ -22,12 +22,12 @@ class InitComponentService
         $int = new \Pimple\Container();
         $data_factory = new \ILIAS\Data\Factory();
 
-        $int["plugin_state_db"] = fn($int) : \ilPluginStateDB => new ilPluginStateDBOverIlDBInterface(
+        $int["plugin_state_db"] = fn ($int) : \ilPluginStateDB => new ilPluginStateDBOverIlDBInterface(
             $data_factory,
             $c["ilDB"]
         );
 
-        $int["db_write"] = fn($int) : \ilComponentRepositoryWrite => new ilArtifactComponentRepository(
+        $int["db_write"] = fn ($int) : \ilComponentRepositoryWrite => new ilArtifactComponentRepository(
             $data_factory,
             $int["plugin_state_db"],
             $c["ilias.version"]

--- a/Services/Init/classes/Dependencies/InitHttpServices.php
+++ b/Services/Init/classes/Dependencies/InitHttpServices.php
@@ -31,5 +31,4 @@ class InitHttpServices
             return new \ILIAS\HTTP\Services($c);
         };
     }
-
 }

--- a/Services/Init/classes/Dependencies/InitHttpServices.php
+++ b/Services/Init/classes/Dependencies/InitHttpServices.php
@@ -5,7 +5,7 @@
  */
 class InitHttpServices
 {
-    public function init(\ILIAS\DI\Container $container)
+    public function init(\ILIAS\DI\Container $container) : void
     {
         $container['http.request_factory'] = function ($c) {
             return new \ILIAS\HTTP\Request\RequestFactoryImpl();

--- a/Services/Init/classes/Dependencies/InitUIFramework.php
+++ b/Services/Init/classes/Dependencies/InitUIFramework.php
@@ -81,8 +81,7 @@ class InitUIFramework
         };
         $c["ui.factory.viewcontrol"] = function ($c) {
             return new ILIAS\UI\Implementation\Component\ViewControl\Factory(
-                $c["ui.signal_generator"],
-                $c["ui.factory.input"]
+                $c["ui.signal_generator"]
             );
         };
         $c["ui.factory.chart"] = function ($c) {
@@ -242,7 +241,7 @@ class InitUIFramework
         };
 
         $c["ui.factory.tree"] = function ($c) {
-            return new ILIAS\UI\Implementation\Component\Tree\Factory($c["ui.signal_generator"]);
+            return new ILIAS\UI\Implementation\Component\Tree\Factory();
         };
 
         $c["ui.factory.legacy"] = function ($c) {

--- a/Services/Init/classes/Provider/StartUpMetaBarProvider.php
+++ b/Services/Init/classes/Provider/StartUpMetaBarProvider.php
@@ -5,6 +5,7 @@ namespace ILIAS\Init\Provider;
 use ILIAS\GlobalScreen\Identification\IdentificationInterface;
 use ILIAS\GlobalScreen\Scope\MetaBar\Factory\TopParentItem;
 use ILIAS\GlobalScreen\Scope\MetaBar\Provider\AbstractStaticMetaBarProvider;
+use Psr\Http\Message\UriInterface;
 
 /**
  * Class StartUpMetaBarProvider
@@ -51,8 +52,8 @@ class StartUpMetaBarProvider extends AbstractStaticMetaBarProvider
                                 ->withAvailableCallable(function () {
                                     return !$this->isUserLoggedIn();
                                 })
-                                ->withVisibilityCallable(function () {
-                                    return !$this->isUserOnLoginPage();
+                                ->withVisibilityCallable(function () use ($request) {
+                                    return !$this->isUserOnLoginPage($request->getUri());
                                 });
 
         // Language-Selection
@@ -67,7 +68,7 @@ class StartUpMetaBarProvider extends AbstractStaticMetaBarProvider
                                              })
                                              ->withTitle($txt('language'));
 
-        $base = $this->getBaseURL();
+        $base = $this->getBaseURL($request->getUri());
 
         /**
          * @var $language_selection TopParentItem
@@ -98,9 +99,9 @@ class StartUpMetaBarProvider extends AbstractStaticMetaBarProvider
         return (!$this->dic->user()->isAnonymous() && $this->dic->user()->getId() != 0);
     }
 
-    private function isUserOnLoginPage() : bool
+    private function isUserOnLoginPage(UriInterface $uri) : bool
     {
-        $b = preg_match("%^.*/login.php$%", $_SERVER["SCRIPT_NAME"]) === 1;
+        $b = preg_match("%^.*/login.php$%", $uri->getPath()) === 1;
 
         return $b;
     }
@@ -116,10 +117,9 @@ class StartUpMetaBarProvider extends AbstractStaticMetaBarProvider
         return $url;
     }
 
-    private function getBaseURL() : string
+    private function getBaseURL(UriInterface $uri) : string
     {
-        $base = substr($_SERVER["REQUEST_URI"], strrpos($_SERVER["REQUEST_URI"], "/") + 1);
-
+        $base = substr($uri->__toString(), strrpos($uri->__toString(), "/") + 1);
         return preg_replace("/&*lang=[a-z]{2}&*/", "", $base);
     }
 }

--- a/Services/Init/classes/Provider/StartUpMetaBarProvider.php
+++ b/Services/Init/classes/Provider/StartUpMetaBarProvider.php
@@ -70,9 +70,6 @@ class StartUpMetaBarProvider extends AbstractStaticMetaBarProvider
 
         $base = $this->getBaseURL($request->getUri());
 
-        /**
-         * @var $language_selection TopParentItem
-         */
         foreach ($languages as $lang_key) {
             $link = $this->appendUrlParameterString($base, "lang=" . $lang_key);
             $language_name = $this->dic->language()->_lookupEntry($lang_key, "meta", "meta_l_" . $lang_key);

--- a/Services/Init/classes/StartupSequence/StartUpSequenceDispatcher.php
+++ b/Services/Init/classes/StartupSequence/StartUpSequenceDispatcher.php
@@ -19,8 +19,7 @@ use SplQueue;
  */
 class StartUpSequenceDispatcher
 {
-    /** @var Container */
-    private $dic;
+    private Container $dic;
     /** @var SplQueue|\ILIAS\Init\StartupSequence\StartUpSequenceStep[] */
     private $sequence = [];
 

--- a/Services/Init/classes/StartupSequence/StartUpSequenceDispatcher.php
+++ b/Services/Init/classes/StartupSequence/StartUpSequenceDispatcher.php
@@ -23,9 +23,6 @@ class StartUpSequenceDispatcher
     /** @var SplQueue|\ILIAS\Init\StartupSequence\StartUpSequenceStep[] */
     private $sequence = [];
 
-    /**
-     * @param Container $dic
-     */
     public function __construct(Container $dic)
     {
         $this->dic = $dic;

--- a/Services/Init/classes/class.ilErrorHandling.php
+++ b/Services/Init/classes/class.ilErrorHandling.php
@@ -54,7 +54,7 @@ class ilErrorHandling extends PEAR
     protected static bool $whoops_handlers_registered = false;
 
     /**
-     * PEAR error obj
+     * @var ?error PEAR error obj
      */
     protected $error_obj = null;
 
@@ -126,7 +126,7 @@ class ilErrorHandling extends PEAR
 
     /**
      * defines what has to happen in case of error
-     * @param object    Error
+     * @param error $a_error_obj PEAR Error object
      */
     public function errorHandler($a_error_obj) : void
     {

--- a/Services/Init/classes/class.ilErrorHandling.php
+++ b/Services/Init/classes/class.ilErrorHandling.php
@@ -85,9 +85,8 @@ class ilErrorHandling extends PEAR
      * Initialize Error and Exception Handlers.
      * Initializes Whoops, a logging handler and a delegate handler for the late initialisation
      * of an appropriate error handler.
-     * @return void
      */
-    protected function initWhoopsHandlers()
+    protected function initWhoopsHandlers() : void
     {
         if (self::$whoops_handlers_registered) {
             // Only register whoops error handlers once.
@@ -119,8 +118,8 @@ class ilErrorHandling extends PEAR
 
         return $this->defaultHandler();
     }
-
-    public function getLastError()
+    
+    public function getLastError() // ToDo PHP8: Return type missing. You seem to have different declarations for possible error objects. I'm not sure which is the right one.
     {
         return $this->error_obj;
     }
@@ -129,7 +128,7 @@ class ilErrorHandling extends PEAR
      * defines what has to happen in case of error
      * @param object    Error
      */
-    public function errorHandler($a_error_obj)
+    public function errorHandler($a_error_obj) : void
     {
         global $log;
 
@@ -432,7 +431,7 @@ class ilErrorHandling extends PEAR
         });
     }
 
-    public function handlePreWhoops($level, $message, $file, $line)
+    public function handlePreWhoops($level, $message, $file, $line) : bool //Todo PHP8: Missing paramter types
     {
         global $ilLog;
 

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -55,7 +55,7 @@ class ilInitialisation
     /**
      * Remove unsafe characters from GET
      */
-    protected static function removeUnsafeCharacters()
+    protected static function removeUnsafeCharacters() : void
     {
         // Remove unsafe characters from GET parameters.
         // We do not need this characters in any case, so it is
@@ -874,7 +874,7 @@ class ilInitialisation
     {
         global $ilSetting;
 
-        if (trim($ilSetting->get("locale") != "")) {
+        if (trim($ilSetting->get("locale")) != "") {
             $larr = explode(",", trim($ilSetting->get("locale")));
             $ls = array();
             $first = $larr[0];
@@ -1058,10 +1058,9 @@ class ilInitialisation
 
     /**
      * Initialize global instance
-     * @param string
-     * @param string|object
-     * @param ?string
-     * @return void
+     * @param string $a_name
+     * @param string|object $a_class
+     * @param ?string $a_source_file
      */
     protected static function initGlobal($a_name, $a_class, $a_source_file = null) : void
     {
@@ -1093,7 +1092,7 @@ class ilInitialisation
         }
     }
 
-    protected static $already_initialized;
+    protected static bool $already_initialized;
 
     public static function reinitILIAS() : void
     {
@@ -1157,7 +1156,7 @@ class ilInitialisation
     /**
      * Init auth session.
      */
-    protected static function initSession()
+    protected static function initSession() : void
     {
         $GLOBALS["DIC"]["ilAuthSession"] = function ($c) {
             $auth_session = ilAuthSession::getInstance(

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -707,20 +707,14 @@ class ilInitialisation
             );
         };
     }
-
-    /**
-     * @param \ILIAS\DI\Container $c
-     */
+    
     protected static function initAvatar(\ILIAS\DI\Container $c) : void
     {
         $c["user.avatar.factory"] = function ($c) {
             return new \ilUserAvatarFactory($c);
         };
     }
-
-    /**
-     * @param \ILIAS\DI\Container $c
-     */
+    
     protected static function initTermsOfService(\ILIAS\DI\Container $c) : void
     {
         $c['tos.criteria.type.factory'] = function (
@@ -1595,14 +1589,18 @@ class ilInitialisation
      */
     protected static function getCurrentCmd() : string
     {
+        if (!isset($_REQUEST["cmd"])) {
+            return '';
+        }
+        
         $cmd = $_REQUEST["cmd"];
         if (is_array($cmd)) {
             $keys = array_keys($cmd);
 
             return array_shift($keys);
-        } else {
-            return $cmd;
         }
+        
+        return $cmd;
     }
 
     /**

--- a/Services/Init/classes/class.ilPasswordAssistanceGUI.php
+++ b/Services/Init/classes/class.ilPasswordAssistanceGUI.php
@@ -78,7 +78,7 @@ class ilPasswordAssistanceGUI
         }
 
         if ($lang != '' && $this->lng->getLangKey() != $lang) {
-            $lng = new ilLanguage($lang);
+            $lng = new ilLanguage($lang); //ToDo PHP8: I don't think this is right. $lng is never used. I believe we can get rid of the whole if-statement
         }
         $this->lng->loadLanguageModule('pwassist');
 
@@ -513,10 +513,7 @@ class ilPasswordAssistanceGUI
             }
         }
     }
-
-    /**
-     * @return ilPropertyFormGUI
-     */
+    
     protected function getUsernameAssistanceForm() : ilPropertyFormGUI
     {
         $form = new ilPropertyFormGUI();
@@ -540,7 +537,6 @@ class ilPasswordAssistanceGUI
      * email
      * When the user submits the form, then this script is invoked with the cmd
      * 'submitAssistanceForm'.
-     * @param ilPropertyFormGUI $form
      */
     public function showUsernameAssistanceForm(ilPropertyFormGUI $form = null) : void
     {
@@ -615,8 +611,6 @@ class ilPasswordAssistanceGUI
      * and contains the following URL parameters:
      * client_id
      * key
-     * @param $email
-     * @param $logins
      */
     public function sendUsernameAssistanceMail(string $email, array $logins) : void
     {

--- a/Services/Init/classes/class.ilPasswordAssistanceGUI.php
+++ b/Services/Init/classes/class.ilPasswordAssistanceGUI.php
@@ -89,7 +89,7 @@ class ilPasswordAssistanceGUI
             default:
                 if ($cmd != '' && method_exists($this, $cmd)) {
                     return $this->$cmd();
-                } elseif (!empty($key)) {
+                } elseif (!empty($key)) { //ToDo PHP8: This will never happen.
                     $this->showAssignPasswordForm();
                 } else {
                     $this->showAssistanceForm();
@@ -268,7 +268,6 @@ class ilPasswordAssistanceGUI
      * and contains the following URL parameters:
      * client_id
      * key
-     * @param $userObj ilObjUser
      */
     public function sendPasswordAssistanceMail(ilObjUser $userObj) : void
     {
@@ -282,7 +281,7 @@ class ilPasswordAssistanceGUI
             !is_array($pwassist_session) ||
             count($pwassist_session) == 0 ||
             $pwassist_session['expires'] < time() ||
-            true // comment by mjansen: wtf? :-)
+            true // comment by mjansen: wtf? :-) //ToDo PHP8: I agree with mjansen, please fix.
         ) {
             // Create a new session id
             // #9700 - this didn't do anything before?!
@@ -668,6 +667,6 @@ class ilPasswordAssistanceGUI
 
     protected function fillPermanentLink(string $context) : void
     {
-        $this->tpl->setPermanentLink('usr', null, $context);
+        $this->tpl->setPermanentLink('usr', null, $context); //ToDo PHP8 Review: This does not work (anymore) as the second parameter can NOT be null.
     }
 }

--- a/Services/Init/classes/class.ilPublicSectionSettings.php
+++ b/Services/Init/classes/class.ilPublicSectionSettings.php
@@ -12,13 +12,14 @@ class ilPublicSectionSettings
      * @var ilPublicSectionSettings
      */
     protected static $instance = null;
-
-    /**
-     * @var ilSetting
-     */
+    
     private ilSetting $settings;
 
     private bool $enabled = false;
+    
+    /**
+     * @var string[]
+     */
     private array $domains = array();
 
     /**
@@ -40,11 +41,18 @@ class ilPublicSectionSettings
         return self::$instance;
     }
 
-    public function setDomains(array $domains)
+    /**
+     * @param string[] $domains
+     */
+    public function setDomains(array $domains) : void
     {
         $this->domains = $domains;
     }
 
+    /**
+     *
+     * @return string[]
+     */
     public function getDomains() : array
     {
         return $this->domains;

--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -292,7 +292,7 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
     }
 
     /**
-     * @param ilTemplate|ilGlobalTemplateInterface
+     * @param ilTemplate|ilGlobalTemplateInterface $tpl
      */
     public static function printToGlobalTemplate($tpl) : void
     {
@@ -302,7 +302,7 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
         $gtpl->printToStdout("DEFAULT", false, true);
     }
 
-    protected function showCodeForm($a_username = null, $a_form = null)
+    protected function showCodeForm($a_username = null, $a_form = null) : void
     {
         global $tpl;
 
@@ -745,7 +745,7 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
     /**
      * Show login information
      */
-    protected function showLoginInformation(string $page_editor_html, $tpl) : string
+    protected function showLoginInformation(string $page_editor_html, $tpl) : string //ToDo PHP8: Type for $tpl missing.
     {
         if (strlen($page_editor_html)) {
             // page editor active return
@@ -921,7 +921,7 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
         $page_gui = new ilLoginPageGUI(ilLanguage::lookupId($active_lang));
 
         include_once("./Services/Style/Content/classes/class.ilObjStyleSheet.php");
-        $page_gui->setStyleId(0, 'auth');
+        $page_gui->setStyleId(0);
 
         $page_gui->setPresentationTitle("");
         $page_gui->setTemplateOutput(false);
@@ -1118,7 +1118,7 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
      * Migrate Account
      * @return bool
      */
-    protected function migrateAccount() : bool
+    protected function migrateAccount() : bool //Todo PHP8: All returns are conditional, but return is mandatory.
     {
         if (!isset($this->httpRequest->getParsedBody()['account_migration'])) {
             $this->showAccountMigration(
@@ -1533,7 +1533,7 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
         $this->showLoginPage();
     }
 
-    public static function _checkGoto($a_target)
+    public static function _checkGoto($a_target)  //Todo PHP8: Return Type missing.
     {
         global $DIC;
         global $objDefinition, $ilUser;
@@ -1776,7 +1776,7 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
      * @param bool  $a_show_back
      * @param bool  $a_show_logout
      */
-    public static function initStartUpTemplate($a_tmpl, bool $a_show_back = false, bool $a_show_logout = false)
+    public static function initStartUpTemplate($a_tmpl, bool $a_show_back = false, bool $a_show_logout = false) //ToDo PHP8 Review: Return type missing
     {
         /**
          * @var $tpl       ilTemplate

--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -804,8 +804,8 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
             ); // Bugfix http://ilias.de/mantis/view.php?id=10662 {$tpl->setVariable('SHIB_FORMACTION', $this->ctrl->getFormAction($this));}
             $federation_name = $this->setting->get("shib_federation_name");
             $admin_mail = ' <a href="mailto:' . $this->setting->get("admin_email") . '">ILIAS ' . $this->lng->txt(
-                    "administrator"
-                ) . '</a>.';
+                "administrator"
+            ) . '</a>.';
             if ($this->setting->get("shib_hos_type") == 'external_wayf') {
                 $tpl->setCurrentBlock("shibboleth_login");
                 $tpl->setVariable("TXT_SHIB_LOGIN", $this->lng->txt("login_to_ilias_via_shibboleth"));

--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -339,7 +339,7 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
     /**
      * @todo has to be refactored.
      */
-    protected function processCode()
+    protected function processCode() : ?bool
     {
         $uname = $_POST["uname"];
         $form = $this->initCodeForm($uname);
@@ -903,8 +903,6 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
      */
     protected function getLoginPageEditorHTML() : string
     {
-        global $tpl;
-
         include_once './Services/Authentication/classes/class.ilAuthLoginPageEditorSettings.php';
         $lpe = ilAuthLoginPageEditorSettings::getInstance();
         $active_lang = $lpe->getIliasEditorLanguage($this->lng->getLangKey());
@@ -1315,7 +1313,7 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
     /**
      * show logout screen
      */
-    public function doLogout()
+    public function doLogout() : void
     {
         global $DIC;
 
@@ -1910,7 +1908,7 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
     /**
      * do open id connect authentication
      */
-    protected function doOpenIdConnectAuthentication()
+    protected function doOpenIdConnectAuthentication() : void
     {
         $this->getLogger()->debug('Trying openid connect authentication');
 

--- a/Services/Init/classes/class.ilias.php
+++ b/Services/Init/classes/class.ilias.php
@@ -53,7 +53,7 @@ class ILIAS
      * setup ILIAS global object
      * @access    public
      */
-    public function __construct($a_client_id = 0)
+    public function __construct($a_client_id = 0) //ToDo PHP8: What do we need $a_client_id for if it is never used?
     {
         global $DIC, $ilClientIniFile, $ilIliasIniFile, $ilDB;
 
@@ -122,7 +122,7 @@ class ILIAS
      * wrapper for downward compability
      * @deprecated
      */
-    public function raiseError(string $a_msg, int $a_err_obj)
+    public function raiseError(string $a_msg, int $a_err_obj) : void
     {
         $this->error_obj->raiseError($a_msg, $a_err_obj);
     }

--- a/Services/Init/test/InitHttpServicesTest.php
+++ b/Services/Init/test/InitHttpServicesTest.php
@@ -19,7 +19,7 @@ class InitHttpServicesTest extends TestCase
         $this->dic = new \ILIAS\DI\Container();
     }
 
-    public function testUIFrameworkInitialization()
+    public function testUIFrameworkInitialization() : void
     {
         $this->assertFalse(isset($this->dic['http']));
         $this->assertFalse(isset($this->dic['http.response_sender_strategy']));

--- a/Services/Init/test/InitUIFrameworkTest.php
+++ b/Services/Init/test/InitUIFrameworkTest.php
@@ -45,8 +45,10 @@ class InitUIFrameworkTest extends TestCase
     {
         (new \InitUIFramework())->init($this->dic);
 
-        $this->assertInstanceOf("ILIAS\UI\Implementation\Component\Divider\Vertical",
-            $this->dic->ui()->factory()->divider()->vertical());
+        $this->assertInstanceOf(
+            "ILIAS\UI\Implementation\Component\Divider\Vertical",
+            $this->dic->ui()->factory()->divider()->vertical()
+        );
     }
 
     /**

--- a/Services/Init/test/InitUIFrameworkTest.php
+++ b/Services/Init/test/InitUIFrameworkTest.php
@@ -25,7 +25,7 @@ class InitUIFrameworkTest extends TestCase
         $this->dic["refinery"] = Mockery::mock("\ILIAS\Refinery\Factory");
     }
 
-    public function testUIFrameworkInitialization()
+    public function testUIFrameworkInitialization() : void
     {
         $this->assertInstanceOf("\ILIAS\DI\UIServices", $this->dic->ui());
         $this->assertFalse(isset($this->dic['ui.factory']));
@@ -41,7 +41,7 @@ class InitUIFrameworkTest extends TestCase
      * This checks only by example that the factory is loaded and ready to work.
      * A complete check of the factory is performed in the Test cases of tests/UI
      */
-    public function testByExampleThatFactoryIsLoaded()
+    public function testByExampleThatFactoryIsLoaded() : void
     {
         (new \InitUIFramework())->init($this->dic);
 
@@ -56,7 +56,7 @@ class InitUIFrameworkTest extends TestCase
      * A complete set of the rendering tests is performed in the Test cases of tests/UI
      * Note that some additional dependencies are needed for this to run.
      */
-    public function testByExampleThatRendererIsReadyToWork()
+    public function testByExampleThatRendererIsReadyToWork() : void
     {
         (new \InitUIFramework())->init($this->dic);
         $this->dic["tpl"]->shouldReceive("addJavaScript");


### PR DESCRIPTION
Hi @smeyer-ilias  

2022-04-11: Sorry, just added one more commit with more fixes and ToDos after rechecking.

Here are the results of the `ServicesInit` review.

### Results

- [ ] The code style is PSR-2 + X compliant: _CS-Fixer made changes to 4 files_
- [ ] No usage of $_GET / $_POST / $_REQUEST / $_SESSION: _There are quite a few superglobals used, it is hard for me in a useful time frame to judge which ones are necessary in this context. I removed two accesses I was pretty sure we could easily get rid of._
- [x] There is a Unit Test Suite with at least one unit test: _Did you not add the tests for the UIFramework to the Suite on purpose?_
- [x] The unit tests pass
- [ ] External libraries are compatible with PHP 8 (if relevant): _Not relevant_
- [ ] The types are fully documented (PHPDoc) or explicit PHP types are used (type hints, return types, typed properties)

### Comments
- There are quite a few globals used. Do you really need to put all this in the global scope? We e.g. have two different variables in global scope for log: $log and $ilLog. Do we really need both of them and can we not take one or both of them out of the global scope? An other example would be the ilUser here: https://github.com/ILIAS-eLearning/ILIAS/pull/4272/files#diff-5c2233ae6af0264344f1d3415e104429899c63359ffb40cd2503cbd7fd44d894L1524
- Please also see the inline comment

### Changes made in this PR:
- Fixed CS
- Added some types, removed some duplicate doc-strings, and moved some declarations from doc-strings.
- Added a few // @TODO PHP8: - Comments

Best regards,
@swiniker