### PR TITLE
EventHandler: Improve logging of parameters

### DIFF
--- a/Services/EventHandling/classes/class.ilAppEventHandler.php
+++ b/Services/EventHandling/classes/class.ilAppEventHandler.php
@@ -105,20 +105,25 @@ class ilAppEventHandler
             $a_component
         ));
 
-        // lazy transforming event data to string
-        $this->logger->debug((new class($a_parameter) {
-            protected array $parameter;
-
-            public function __construct(array $parameter)
-            {
-                $this->parameter = $parameter;
+        $parameter_formatter = static function ($value) use (&$parameter_formatter) {
+            if (is_object($value)) {
+                return get_class($value);
             }
 
-            public function __toString()
-            {
-                return 'Event data size: ' . count($this->parameter);
+            if (is_array($value)) {
+                return array_map(
+                    $parameter_formatter,
+                    $value
+                );
             }
-        })->__toString());
+
+            return $value;
+        };
+
+        $this->logger->debug('Event data: ' . var_export(array_map(
+            $parameter_formatter,
+            $a_parameter
+        ), true));
 
         $this->logger->debug("Started event propagation for event listeners ...");
 


### PR DESCRIPTION
With ILIAS 8 the logging methods (`debug`, `info`, ...) have been changed to only accept strings. Therefore the anonymous class used for `lazy evaluation` of complex data structure logging could not be used anymore.
To comply with the new method signatures, the `__toString()` method was immediately called. Since other code modifications in the past changed the behaviour to only log the amount of parameters, the initial intention of this approach got lost at all anyway.

This PR suggests a change to (again) log the parameter array. Instead of recursive logging of objects, only the classname is exported.