### PR TITLE
PHP 8: Code Review `soap`

### DIFF
--- a/Modules/OrgUnit/classes/Webservices/SOAP/Base.php
+++ b/Modules/OrgUnit/classes/Webservices/SOAP/Base.php
@@ -57,8 +57,8 @@ abstract class Base extends ilSoapAdministration implements ilSoapMethod
     {
         $this->initAuth($session_id);
         $this->initIlias();
-        if (!$this->__checkSession($session_id)) {
-            throw new ilSoapPluginException($this->__getMessage());
+        if (!$this->checkSession($session_id)) {
+            throw new ilSoapPluginException($this->getMessage());
         }
     }
 
@@ -142,7 +142,7 @@ abstract class Base extends ilSoapAdministration implements ilSoapMethod
      */
     protected function error($message)
     {
-        throw $this->__raiseError($message, 'ERROR');
+        throw $this->raiseError($message, 'ERROR');
     }
 
     /**

--- a/Services/BackgroundTasks/classes/class.ilSoapBackgroundTasksAdministration.php
+++ b/Services/BackgroundTasks/classes/class.ilSoapBackgroundTasksAdministration.php
@@ -32,8 +32,8 @@ class ilSoapBackgroundTasksAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
         
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
         
         $tm = new AsyncTaskManager($this->persistence);

--- a/Services/WebServices/SOAP/classes/class.ilAbstractSoapMethod.php
+++ b/Services/WebServices/SOAP/classes/class.ilAbstractSoapMethod.php
@@ -44,8 +44,8 @@ abstract class ilAbstractSoapMethod extends ilSoapAdministration implements ilSo
     {
         $this->initAuth($session_id);
         $this->initIlias();
-        if (!$this->__checkSession($session_id)) {
-            throw new ilSoapPluginException($this->__getMessage());
+        if (!$this->checkSession($session_id)) {
+            throw new ilSoapPluginException($this->getMessage());
         }
     }
 
@@ -74,7 +74,7 @@ abstract class ilAbstractSoapMethod extends ilSoapAdministration implements ilSo
      * @return void
      * @throws ilSoapPluginException
      */
-    protected function __raiseError(string $a_message, $a_code)
+    protected function raiseError(string $a_message, $a_code)
     {
         throw new ilSoapPluginException($a_message, $a_code);
     }

--- a/Services/WebServices/SOAP/classes/class.ilSoapHookPlugin.php
+++ b/Services/WebServices/SOAP/classes/class.ilSoapHookPlugin.php
@@ -18,7 +18,7 @@ abstract class ilSoapHookPlugin extends ilPlugin
      * Get any (new) types which the SOAP methods may use.
      * These types are registered in WSDL.
      *
-     * @see ilNusoapUserAdministrationAdapter::__registerMethods()
+     * @see ilNusoapUserAdministrationAdapter::registerMethods()
      *
      * @return ilWsdlType[]
      */

--- a/Services/WebServices/SOAP/classes/ilSoapMethod.php
+++ b/Services/WebServices/SOAP/classes/ilSoapMethod.php
@@ -19,7 +19,7 @@ interface ilSoapMethod
      * Get the input parameters. Array keys must correspond to parameter names and values must correspond
      * to a valid SOAP data-type
      * @return array
-     * @see ilNusoapUserAdministrationAdapter::__registerMethods() for examples
+     * @see ilNusoapUserAdministrationAdapter::registerMethods() for examples
      */
     public function getInputParams() : array;
 

--- a/webservice/soap/classes/class.ilCopyWizardSettingsXMLParser.php
+++ b/webservice/soap/classes/class.ilCopyWizardSettingsXMLParser.php
@@ -14,14 +14,17 @@ class ilCopyWizardSettingsXMLParser extends ilSaxParser
     private array $options = [];
     private int $source_id = 0;
     private int $target_id = 0;
-    private int $default_action = 0;
 
-    public function __construct($xml)
+    public function __construct(string $xml)
     {
         parent::__construct('', true);
         $this->setXMLContent($xml);
     }
 
+    /**
+     * @param XMLParser|resource $a_xml_parser
+     * @return void
+     */
     public function setHandlers($a_xml_parser) : void
     {
         xml_set_object($a_xml_parser, $this);
@@ -29,6 +32,12 @@ class ilCopyWizardSettingsXMLParser extends ilSaxParser
         xml_set_character_data_handler($a_xml_parser, 'handlerCharacterData');
     }
 
+    /**
+     * @param XMLParser|resource $a_xml_parser
+     * @param string $a_name
+     * @param array $a_attribs
+     * @return void
+     */
     public function handlerBeginTag($a_xml_parser, string $a_name, array $a_attribs) : void
     {
         global $DIC;
@@ -48,8 +57,6 @@ class ilCopyWizardSettingsXMLParser extends ilSaxParser
                 if (ilObject::_isInTrash($this->target_id)) {
                     throw new ilSaxParserException("target id" . $this->target_id . " is in trash");
                 }
-
-                $this->default_action = ilCopyWizardSettingsXMLParser::getActionForString($a_attribs["default_action"]);
                 break;
             case 'Option':
                 $id = (int) $a_attribs["id"];
@@ -60,7 +67,7 @@ class ilCopyWizardSettingsXMLParser extends ilSaxParser
                     throw new ilSaxParserException("Id $id does not exist");
                 }
 
-                $action = ilCopyWizardSettingsXMLParser::getActionForString($a_attribs["action"]);
+                $action = self::getActionForString($a_attribs["action"]);
                 $type = ilObjectFactory::getTypeByRefId($id);
 
                 switch ($action) {
@@ -94,7 +101,7 @@ class ilCopyWizardSettingsXMLParser extends ilSaxParser
 
     public function getOptions() : array
     {
-        return is_array($this->options) ? $this->options : array();
+        return $this->options;
     }
 
     public function getSourceId() : ?int
@@ -109,19 +116,31 @@ class ilCopyWizardSettingsXMLParser extends ilSaxParser
 
     private static function getActionForString($s) : int
     {
-        if ($s == "COPY") {
+        if ($s === "COPY") {
             return ilCopyWizardOptions::COPY_WIZARD_COPY;
         }
-        if ($s == "LINK") {
+
+        if ($s === "LINK") {
             return ilCopyWizardOptions::COPY_WIZARD_LINK;
         }
+
         return ilCopyWizardOptions::COPY_WIZARD_OMIT;
     }
 
-    public function handlerEndTag($a_xml_parser, $a_name) : void
+    /**
+     * @param XMLParser|resource $a_xml_parser
+     * @param string $a_name
+     * @return void
+     */
+    public function handlerEndTag($a_xml_parser, string $a_name) : void
     {
     }
 
+    /**
+     * @param XMLParser|resource $a_xml_parser
+     * @param string $a_data
+     * @return void
+     */
     public function handlerCharacterData($a_xml_parser, string $a_data) : void
     {
     }

--- a/webservice/soap/classes/class.ilNusoapUserAdministrationAdapter.php
+++ b/webservice/soap/classes/class.ilNusoapUserAdministrationAdapter.php
@@ -49,10 +49,7 @@ require_once('./Services/Init/classes/class.ilInitialisation.php');
 
 class ilNusoapUserAdministrationAdapter
 {
-    /*
-     * @var object Nusoap-Server
-     */
-    public $server = null;
+    public soap_server $server;
 
     public function __construct(bool $a_use_wsdl = true)
     {
@@ -65,10 +62,10 @@ class ilNusoapUserAdministrationAdapter
         $this->server->class = "ilSoapFunctions";
 
         if ($a_use_wsdl) {
-            $this->__enableWSDL();
+            $this->enableWSDL();
         }
 
-        $this->__registerMethods();
+        $this->registerMethods();
     }
 
     public function start() : void
@@ -78,13 +75,12 @@ class ilNusoapUserAdministrationAdapter
         exit();
     }
 
-    // PRIVATE
-    public function __enableWSDL() : void
+    private function enableWSDL() : void
     {
         $this->server->configureWSDL(SERVICE_NAME, SERVICE_NAMESPACE);
     }
 
-    public function __registerMethods() : void
+    private function registerMethods() : void
     {
 
         // Add useful complex types. E.g. array("a","b") or array(1,2)
@@ -1588,7 +1584,7 @@ class ilNusoapUserAdministrationAdapter
     /**
      * Register any methods and types of SOAP plugins to the SOAP server
      */
-    protected function handleSoapPlugins()
+    protected function handleSoapPlugins() : void
     {
         // Note: We need a context that does not handle authentication at this point, because this is
         // handled by an actual SOAP request which always contains the session ID and client

--- a/webservice/soap/classes/class.ilObjectXMLException.php
+++ b/webservice/soap/classes/class.ilObjectXMLException.php
@@ -31,14 +31,4 @@ include_once('Services/Exceptions/classes/class.ilException.php');
  */
 class ilObjectXMLException extends ilException
 {
-    /**
-     * Constructor
-     * @access public
-     * @param string message
-     * @param int errno
-     */
-    public function __construct($a_message, $a_errno = 0)
-    {
-        parent::__construct($a_message, $a_errno);
-    }
 }

--- a/webservice/soap/classes/class.ilObjectXMLParser.php
+++ b/webservice/soap/classes/class.ilObjectXMLParser.php
@@ -53,9 +53,13 @@ class ilObjectXMLParser extends ilSaxParser
                 ++$this->curr_obj;
 
                 $this->__addProperty('type', $a_attribs['type']);
-                $this->__addProperty('obj_id',
-                    is_numeric($a_attribs['obj_id']) ? (int) $a_attribs["obj_id"] : ilUtil::__extractId($a_attribs["obj_id"],
-                        IL_INST_ID));
+                $this->__addProperty(
+                    'obj_id',
+                    is_numeric($a_attribs['obj_id']) ? (int) $a_attribs["obj_id"] : ilUtil::__extractId(
+                        $a_attribs["obj_id"],
+                        IL_INST_ID
+                    )
+                );
                 $this->__addProperty('offline', $a_attribs['offline']);
                 break;
 

--- a/webservice/soap/classes/class.ilObjectXMLWriter.php
+++ b/webservice/soap/classes/class.ilObjectXMLWriter.php
@@ -117,8 +117,12 @@ class ilObjectXMLWriter extends ilXmlWriter
         $this->__buildHeader();
         foreach ($this->__getObjects() as $object) {
             if (method_exists($object, 'getType') and $objDefinition->isRBACObject($object->getType())) {
-                if ($this->isPermissionCheckEnabled() and !$ilAccess->checkAccessOfUser($this->getUserId(), 'read', '',
-                        $object->getRefId())) {
+                if ($this->isPermissionCheckEnabled() and !$ilAccess->checkAccessOfUser(
+                    $this->getUserId(),
+                    'read',
+                    '',
+                    $object->getRefId()
+                )) {
                     continue;
                 }
             }
@@ -288,8 +292,11 @@ class ilObjectXMLWriter extends ilXmlWriter
                 $this->xmlElement("Property", array('name' => 'fileSize'), (int) $size);
                 $this->xmlElement("Property", array('name' => 'fileExtension'), (string) $extension);
                 // begin-patch fm
-                $this->xmlElement('Property', array('name' => 'fileVersion'),
-                    (string) ilObjFileAccess::_lookupVersion($obj->getId()));
+                $this->xmlElement(
+                    'Property',
+                    array('name' => 'fileVersion'),
+                    (string) ilObjFileAccess::_lookupVersion($obj->getId())
+                );
                 // end-patch fm
                 $this->xmlEndTag('Properties');
                 break;
@@ -310,8 +317,12 @@ class ilObjectXMLWriter extends ilXmlWriter
                 foreach ($ops as $ops_id) {
                     $operation = $rbacreview->getOperation($ops_id);
 
-                    if (count($operation) && $ilAccess->checkAccessOfUser($this->getUserId(), $operation['operation'],
-                            'view', $a_ref_id)) {
+                    if (count($operation) && $ilAccess->checkAccessOfUser(
+                        $this->getUserId(),
+                        $operation['operation'],
+                        'view',
+                        $a_ref_id
+                    )) {
                         $this->xmlElement('Operation', null, $operation['operation']);
                     }
                 }
@@ -331,8 +342,12 @@ class ilObjectXMLWriter extends ilXmlWriter
 
                 $operation = $rbacreview->getOperation($ops_id);
 
-                if (count($operation) && $ilAccess->checkAccessOfUser($this->getUserId(), $operation['operation'],
-                        'view', $a_ref_id)) {
+                if (count($operation) && $ilAccess->checkAccessOfUser(
+                    $this->getUserId(),
+                    $operation['operation'],
+                    'view',
+                    $a_ref_id
+                )) {
                     $this->xmlElement('Operation', null, $operation['operation']);
                 }
             }

--- a/webservice/soap/classes/class.ilObjectXMLWriter.php
+++ b/webservice/soap/classes/class.ilObjectXMLWriter.php
@@ -270,7 +270,7 @@ class ilObjectXMLWriter extends ilXmlWriter
                 $size = ilObjFileAccess::_lookupFileSize($obj->getId());
                 $extension = ilObjFileAccess::_lookupSuffix($obj->getId());
                 $this->xmlStartTag('Properties');
-                $this->xmlElement("Property", array('name' => 'fileSize'), (int) $size);
+                $this->xmlElement("Property", array('name' => 'fileSize'), (string) $size);
                 $this->xmlElement("Property", array('name' => 'fileExtension'), (string) $extension);
                 $this->xmlElement(
                     'Property',

--- a/webservice/soap/classes/class.ilObjectXMLWriter.php
+++ b/webservice/soap/classes/class.ilObjectXMLWriter.php
@@ -17,15 +17,15 @@ class ilObjectXMLWriter extends ilXmlWriter
 {
     public const MODE_SEARCH_RESULT = 1;
 
-    private int $mode = 0;
-    private ?ilLuceneHighlighterResultParser $highlighter = null;
-
     public const TIMING_DEACTIVATED = 0;
     public const TIMING_TEMPORARILY_AVAILABLE = 1;
     public const TIMING_PRESETTING = 2;
 
     public const TIMING_VISIBILITY_OFF = 0;
     public const TIMING_VISIBILITY_ON = 1;
+
+    private int $mode = 0;
+    private ?ilLuceneHighlighterResultParser $highlighter = null;
 
     protected string $xml;
     protected bool $enable_operations = false;
@@ -84,7 +84,6 @@ class ilObjectXMLWriter extends ilXmlWriter
         return $this->enable_operations;
     }
 
-    // begin-patch filemanager
     public function enableReferences(bool $a_stat) : void
     {
         $this->enable_references = $a_stat;
@@ -95,14 +94,12 @@ class ilObjectXMLWriter extends ilXmlWriter
         return $this->enable_references;
     }
 
-    // end-patch filemanager
-
     public function setObjects(array $objects) : void
     {
         $this->objects = $objects;
     }
 
-    public function __getObjects() : array
+    public function getObjects() : array
     {
         return $this->objects;
     }
@@ -114,21 +111,22 @@ class ilObjectXMLWriter extends ilXmlWriter
         $ilAccess = $DIC['ilAccess'];
         $objDefinition = $DIC['objDefinition'];
 
-        $this->__buildHeader();
-        foreach ($this->__getObjects() as $object) {
-            if (method_exists($object, 'getType') and $objDefinition->isRBACObject($object->getType())) {
-                if ($this->isPermissionCheckEnabled() and !$ilAccess->checkAccessOfUser(
+        $this->buildHeader();
+        foreach ($this->getObjects() as $object) {
+            if (method_exists($object, 'getType') &&
+                $this->isPermissionCheckEnabled() &&
+                $objDefinition->isRBACObject($object->getType()) &&
+                !$ilAccess->checkAccessOfUser(
                     $this->getUserId(),
                     'read',
                     '',
                     $object->getRefId()
                 )) {
-                    continue;
-                }
+                continue;
             }
-            $this->__appendObject($object);
+            $this->appendObject($object);
         }
-        $this->__buildFooter();
+        $this->buildFooter();
         return true;
     }
 
@@ -137,52 +135,41 @@ class ilObjectXMLWriter extends ilXmlWriter
         return $this->xmlDumpMem(false);
     }
 
-    // PRIVATE
-    public function __appendObject(ilObject $object) : void
+    private function appendObject(ilObject $object) : void
     {
         global $DIC;
 
         $tree = $DIC['tree'];
         $rbacreview = $DIC['rbacreview'];
 
-        /**
-         * @var ilObjectDefinition
-         */
+        /** @var ilObjectDefinition */
         $objectDefinition = $DIC['objDefinition'];
 
         $id = $object->getId();
-        if ($object->getType() == "role" && $rbacreview->isRoleDeleted($id)) {
+        if ($object->getType() === "role" && $rbacreview->isRoleDeleted($id)) {
             return;
         }
 
-        $attrs = array(
+        $attrs = [
             'type' => $object->getType(),
             'obj_id' => $id
-        );
+        ];
 
         if ($objectDefinition->supportsOfflineHandling($object->getType())) {
             $attrs['offline'] = (int) $object->getOfflineStatus();
         }
 
         $this->xmlStartTag('Object', $attrs);
-        //$this->xmlElement('Title',null,$object->getTitle());
-        //$this->xmlElement('Description',null,$object->getDescription());
 
-        // begin-patch fm
-        if ($this->mode == self::MODE_SEARCH_RESULT) {
-            $title = $object->getTitle();
+        if ($this->mode === self::MODE_SEARCH_RESULT) {
+            $title = $object->getTitle();// TODO PHP8-REVIEW Unnecessary operations: The variablers are not used
             if ($this->highlighter->getTitle($object->getId(), 0)) {
                 $title = $this->highlighter->getTitle($object->getId(), 0);
             }
-            $description = $object->getDescription();
+            $description = $object->getDescription();// TODO PHP8-REVIEW Unnecessary operations: The variablers are not used
             if ($this->highlighter->getDescription($object->getId(), 0)) {
                 $description = $this->highlighter->getDescription($object->getId(), 0);
             }
-
-            // Currently disabled
-            #$this->xmlElement('Title', null, $title);
-            #$this->xmlElement('Description',null,$description);
-            #$this->xmlElement('SearchResultContent', null, $this->highlighter->getContent($object->getId(),0));
 
             $this->xmlElement('Title', null, $object->getTitle());
             $this->xmlElement('Description', null, $object->getDescription());
@@ -190,37 +177,34 @@ class ilObjectXMLWriter extends ilXmlWriter
             $this->xmlElement('Title', null, $object->getTitle());
             $this->xmlElement('Description', null, $object->getDescription());
         }
-        // end-patch fm
 
         $this->xmlElement('Owner', null, $object->getOwner());
         $this->xmlElement('CreateDate', null, $object->getCreateDate());
         $this->xmlElement('LastUpdate', null, $object->getLastUpdateDate());
         $this->xmlElement('ImportId', null, $object->getImportId());
 
-        $this->__appendObjectProperties($object);
+        $this->appendObjectProperties($object);
 
-        // begin-patch filemanager
         if ($this->enabledReferences()) {
             $refs = ilObject::_getAllReferences($object->getId());
         } else {
-            $refs = array($object->getRefId());
+            $refs = [$object->getRefId()];
         }
 
         foreach ($refs as $ref_id) {
-            // end-patch filemanager
             if (!$tree->isInTree($ref_id)) {
                 continue;
             }
 
             $attr = array(
                 'ref_id' => $ref_id,
-                'parent_id' => $tree->getParentId(intval($ref_id))
+                'parent_id' => $tree->getParentId($ref_id)
             );
-            $attr['accessInfo'] = $this->__getAccessInfo($object, $ref_id);
+            $attr['accessInfo'] = $this->getAccessInfo($object, $ref_id);
             $this->xmlStartTag('References', $attr);
-            $this->__appendTimeTargets($ref_id);
-            $this->__appendOperations($ref_id, $object->getType());
-            $this->__appendPath($ref_id);
+            $this->appendTimeTargets($ref_id);
+            $this->appendOperations($ref_id, $object->getType());
+            $this->appendPath($ref_id);
             $this->xmlEndTag('References');
         }
         $this->xmlEndTag('Object');
@@ -231,7 +215,7 @@ class ilObjectXMLWriter extends ilXmlWriter
      * @param int $ref_id Reference id of object
      * @return void
      */
-    public function __appendTimeTargets(int $a_ref_id) : void
+    private function appendTimeTargets(int $a_ref_id) : void
     {
         global $DIC;
 
@@ -244,15 +228,13 @@ class ilObjectXMLWriter extends ilXmlWriter
         $time_targets = ilObjectActivation::getItem($a_ref_id);
 
         switch ($time_targets['timing_type']) {
-            case ilObjectActivation::TIMINGS_DEACTIVATED:
-                $type = self::TIMING_DEACTIVATED;
-                break;
             case ilObjectActivation::TIMINGS_ACTIVATION:
                 $type = self::TIMING_TEMPORARILY_AVAILABLE;
                 break;
             case ilObjectActivation::TIMINGS_PRESETTING:
                 $type = self::TIMING_PRESETTING;
                 break;
+            case ilObjectActivation::TIMINGS_DEACTIVATED:
             default:
                 $type = self::TIMING_DEACTIVATED;
                 break;
@@ -260,7 +242,7 @@ class ilObjectXMLWriter extends ilXmlWriter
 
         $this->xmlStartTag('TimeTarget', array('type' => $type));
 
-        $vis = $time_targets['visible'] == 0 ? self::TIMING_VISIBILITY_OFF : self::TIMING_VISIBILITY_ON;
+        $vis = (int) $time_targets['visible'] === 0 ? self::TIMING_VISIBILITY_OFF : self::TIMING_VISIBILITY_ON;
         $this->xmlElement(
             'Timing',
             array('starting_time' => $time_targets['timing_start'],
@@ -280,10 +262,9 @@ class ilObjectXMLWriter extends ilXmlWriter
         $this->xmlEndTag('TimeTarget');
     }
 
-    public function __appendObjectProperties(ilObject $obj) : void
+    private function appendObjectProperties(ilObject $obj) : void
     {
         switch ($obj->getType()) {
-
             case 'file':
                 include_once './Modules/File/classes/class.ilObjFileAccess.php';
                 $size = ilObjFileAccess::_lookupFileSize($obj->getId());
@@ -291,19 +272,17 @@ class ilObjectXMLWriter extends ilXmlWriter
                 $this->xmlStartTag('Properties');
                 $this->xmlElement("Property", array('name' => 'fileSize'), (int) $size);
                 $this->xmlElement("Property", array('name' => 'fileExtension'), (string) $extension);
-                // begin-patch fm
                 $this->xmlElement(
                     'Property',
                     array('name' => 'fileVersion'),
                     (string) ilObjFileAccess::_lookupVersion($obj->getId())
                 );
-                // end-patch fm
                 $this->xmlEndTag('Properties');
                 break;
         }
     }
 
-    public function __appendOperations(int $a_ref_id, string $a_type) : void
+    private function appendOperations(int $a_ref_id, string $a_type) : void
     {
         global $DIC;
 
@@ -328,8 +307,6 @@ class ilObjectXMLWriter extends ilXmlWriter
                 }
             }
 
-            // Create operations
-            // Get creatable objects
             $objects = $objDefinition->getCreatableSubObjects($a_type);
             $ops_ids = ilRbacReview::lookupCreateOperationIds(array_keys($objects));
             $creation_operations = array();
@@ -354,12 +331,12 @@ class ilObjectXMLWriter extends ilXmlWriter
         }
     }
 
-    public function __appendPath(int $refid) : void
+    private function appendPath(int $refid) : void
     {
-        ilObjectXMLWriter::appendPathToObject($this, $refid);
+        self::appendPathToObject($this, $refid);
     }
 
-    public function __buildHeader() : void
+    private function buildHeader() : void
     {
         $this->xmlSetDtdDef("<!DOCTYPE Objects PUBLIC \"-//ILIAS//DTD ILIAS Repositoryobjects//EN\" \"" . ILIAS_HTTP_PATH . "/xml/ilias_object_4_0.dtd\">");
         $this->xmlSetGenCmt("Export of ILIAS objects");
@@ -367,12 +344,12 @@ class ilObjectXMLWriter extends ilXmlWriter
         $this->xmlStartTag("Objects");
     }
 
-    public function __buildFooter() : void
+    private function buildFooter() : void
     {
         $this->xmlEndTag('Objects');
     }
 
-    public function __getAccessInfo(ilObject $object, int $ref_id) : string
+    private function getAccessInfo(ilObject $object, int $ref_id) : string
     {
         global $DIC;
 
@@ -384,9 +361,9 @@ class ilObjectXMLWriter extends ilXmlWriter
 
         if (!$info = $ilAccess->getInfo()) {
             return 'granted';
-        } else {
-            return $info[0]['type'];
         }
+
+        return $info[0]['type'];
     }
 
     public static function appendPathToObject(ilXmlWriter $writer, int $refid) : void
@@ -398,10 +375,10 @@ class ilObjectXMLWriter extends ilXmlWriter
         $items = $tree->getPathFull($refid);
         $writer->xmlStartTag("Path");
         foreach ($items as $item) {
-            if ($item["ref_id"] == $refid) {
+            if ((int) $item["ref_id"] === $refid) {
                 continue;
             }
-            if ($item["type"] == "root") {
+            if ($item["type"] === "root") {
                 $item["title"] = $lng->txt("repository");
             }
             $writer->xmlElement("Element", array("ref_id" => $item["ref_id"], "type" => $item["type"]), $item["title"]);

--- a/webservice/soap/classes/class.ilSoapAdministration.php
+++ b/webservice/soap/classes/class.ilSoapAdministration.php
@@ -56,86 +56,86 @@ class ilSoapAdministration
             $this->error_method = self::PHP5;
         }
 
-        $this->__initAuthenticationObject();
+        $this->initAuthenticationObject();
     }
 
-    protected function __checkSession(string $sid) : bool
+    protected function checkSession(string $sid) : bool
     {
         global $DIC;
 
         $ilUser = $DIC->user();
 
-        list($sid, $client) = $this->__explodeSid($sid);
+        [$sid, $client] = $this->explodeSid($sid);
 
-        if (!strlen($sid)) {
-            $this->__setMessage('No session id given');
-            $this->__setMessageCode('Client');
+        if ($sid === '') {
+            $this->setMessage('No session id given');
+            $this->setMessageCode('Client');
             return false;
         }
         if (!$client) {
-            $this->__setMessage('No client given');
-            $this->__setMessageCode('Client');
+            $this->setMessage('No client given');
+            $this->setMessageCode('Client');
             return false;
         }
 
         if (!$GLOBALS['DIC']['ilAuthSession']->isAuthenticated()) {
-            $this->__setMessage('Session invalid');
-            $this->__setMessageCode('Client');
+            $this->setMessage('Session invalid');
+            $this->setMessageCode('Client');
             return false;
         }
 
         if ($ilUser->hasToAcceptTermsOfService()) {
-            $this->__setMessage('User agreement no accepted.');
-            $this->__setMessageCode('Server');
+            $this->setMessage('User agreement no accepted.');
+            $this->setMessageCode('Server');
             return false;
         }
 
         if ($this->soap_check) {
             $set = new ilSetting();
-            $this->__setMessage('SOAP is not enabled in ILIAS administration for this client');
-            $this->__setMessageCode('Server');
-            return $set->get("soap_user_administration") == 1;
+            $this->setMessage('SOAP is not enabled in ILIAS administration for this client');
+            $this->setMessageCode('Server');
+            return (int) $set->get("soap_user_administration", '0') === 1;
         }
 
         return true;
     }
 
-    protected function __explodeSid(string $sid) : array
+    protected function explodeSid(string $sid) : array
     {
         $exploded = explode('::', $sid);
 
         return is_array($exploded) ? $exploded : array('sid' => '', 'client' => '');
     }
 
-    protected function __setMessage(string $a_str) : void
+    protected function setMessage(string $a_str) : void
     {
         $this->message = $a_str;
     }
 
-    public function __getMessage() : string
+    public function getMessage() : string
     {
         return $this->message;
     }
 
-    public function __appendMessage(string $a_str) : void
+    public function appendMessage(string $a_str) : void
     {
         $this->message .= isset($this->message) ? ' ' : '';
         $this->message .= $a_str;
     }
 
-    public function __setMessageCode(string $a_code) : void
+    public function setMessageCode(string $a_code) : void
     {
         $this->message_code = $a_code;
     }
 
-    public function __getMessageCode() : string
+    public function getMessageCode() : string
     {
         return $this->message_code;
     }
 
     protected function initAuth(string $sid) : void
     {
-        list($sid, $client) = $this->__explodeSid($sid);
+        [$sid, $client] = $this->explodeSid($sid);
         define('CLIENT_ID', $client);
         $_COOKIE['ilClientId'] = $client;
         $_COOKIE[session_name()] = $sid;
@@ -143,7 +143,7 @@ class ilSoapAdministration
 
     protected function initIlias() : void
     {
-        if (ilContext::getType() == ilContext::CONTEXT_SOAP) {
+        if (ilContext::getType() === ilContext::CONTEXT_SOAP) {
             try {
                 require_once("Services/Init/classes/class.ilInitialisation.php");
                 ilInitialisation::reinitILIAS();
@@ -154,7 +154,7 @@ class ilSoapAdministration
         }
     }
 
-    protected function __initAuthenticationObject() : void
+    protected function initAuthenticationObject() : void
     {
         include_once './Services/Authentication/classes/class.ilAuthFactory.php';
         ilAuthFactory::setContext(ilAuthFactory::CONTEXT_SOAP);
@@ -165,7 +165,7 @@ class ilSoapAdministration
      * @param string|int $a_code
      * @return soap_fault|SoapFault|null
      */
-    protected function __raiseError(string $a_message, $a_code)
+    protected function raiseError(string $a_message, $a_code)
     {
         switch ($this->error_method) {
             case self::NUSOAP:
@@ -176,7 +176,7 @@ class ilSoapAdministration
         return null;
     }
 
-    public function isFault($object)
+    public function isFault($object) : bool
     {
         switch ($this->error_method) {
             case self::NUSOAP:
@@ -199,35 +199,30 @@ class ilSoapAdministration
         global $DIC;
 
         $rbacsystem = $DIC->rbac()->system();
-        if (!is_numeric($ref_id)) {
-            return $this->__raiseError(
-                'No valid id given.',
-                'Client'
-            );
-        }
+
         if (!ilObject::_exists($ref_id, true)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No object for id.',
                 'CLIENT_OBJECT_NOT_FOUND'
             );
         }
 
         if (ilObject::_isInTrash($ref_id)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'Object is already trashed.',
                 'CLIENT_OBJECT_DELETED'
             );
         }
 
         $type = ilObject::_lookupType(ilObject::_lookupObjId($ref_id));
-        if (!in_array($type, $expected_type)) {
-            return $this->__raiseError(
-                "Wrong type $type for id. Expected: " . join(",", $expected_type),
+        if (!in_array($type, $expected_type, true)) {
+            return $this->raiseError(
+                "Wrong type $type for id. Expected: " . implode(",", $expected_type),
                 'CLIENT_OBJECT_WRONG_TYPE'
             );
         }
         if (!$rbacsystem->checkAccess($permission, $ref_id, $type)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'Missing permission $permission for type $type.',
                 'CLIENT_OBJECT_WRONG_PERMISSION'
             );
@@ -236,7 +231,7 @@ class ilSoapAdministration
             try {
                 return ilObjectFactory::getInstanceByRefId($ref_id);
             } catch (ilObjectNotFoundException $e) {
-                return $this->__raiseError('No valid ref_id given', 'Client');
+                return $this->raiseError('No valid ref_id given', 'Client');
             }
         }
         return $type;
@@ -267,7 +262,7 @@ class ilSoapAdministration
 
     /**
      * @param string $clientid
-     * @return string|soap_fault|SoapFault|string|null
+     * @return string|soap_fault|SoapFault|null
      */
     public function getClientInfoXML(string $clientid)
     {
@@ -284,13 +279,13 @@ class ilSoapAdministration
         if (is_object($client = $this->getClientInfo(null, $clientdir))) {
             $writer->addClient($client);
         } else {
-            return $this->__raiseError("Client ID $clientid does not exist!", 'Client');
+            return $this->raiseError("Client ID $clientid does not exist!", 'Client');
         }
         $writer->end();
         return $writer->getXML();
     }
 
-    private function getClientInfo($init, $client_dir)
+    private function getClientInfo($init, $client_dir)// TODO PHP8-REVIEW Type hint missing
     {
         global $DIC;
 
@@ -301,13 +296,13 @@ class ilSoapAdministration
 
         $ilClientIniFile = new ilIniFile($ini_file);
         $ilClientIniFile->read();
-        if ($ilClientIniFile->ERROR != "") {
+        if ($ilClientIniFile->ERROR !== "") {
             return false;
         }
         $client_id = $ilClientIniFile->readVariable('client', 'name');
         if ($ilClientIniFile->variableExists('client', 'expose')) {
             $client_expose = $ilClientIniFile->readVariable('client', 'expose');
-            if ($client_expose == "0") {
+            if ($client_expose === "0") {
                 return false;
             }
         }
@@ -328,19 +323,19 @@ class ilSoapAdministration
             $DIC["ilSetting"] = $settings;
             // workaround to determine http path of client
             define("IL_INST_ID", (int) $settings->get("inst_id", '0'));
-            $settings->access = $ilClientIniFile->readVariable("client", "access");
-            $settings->description = $ilClientIniFile->readVariable("client", "description");
-            $settings->session = min(
+            $settings->access = $ilClientIniFile->readVariable("client", "access");// TODO PHP8-REVIEW Property dynamically declared
+            $settings->description = $ilClientIniFile->readVariable("client", "description");// TODO PHP8-REVIEW Property dynamically declared
+            $settings->session = min(// TODO PHP8-REVIEW Property dynamically declared
                 (int) ini_get("session.gc_maxlifetime"),
                 (int) $ilClientIniFile->readVariable("session", "expire")
             );
-            $settings->language = $ilClientIniFile->readVariable("language", "default");
-            $settings->clientid = basename($client_dir); //pathinfo($client_dir, PATHINFO_FILENAME);
-            $settings->default_show_users_online = $settings->get("show_users_online");
-            $settings->default_hits_per_page = $settings->get("hits_per_page");
+            $settings->language = $ilClientIniFile->readVariable("language", "default");// TODO PHP8-REVIEW Property dynamically declared
+            $settings->clientid = basename($client_dir); // TODO PHP8-REVIEW Property dynamically declared
+            $settings->default_show_users_online = $settings->get("show_users_online");// TODO PHP8-REVIEW Property dynamically declared
+            $settings->default_hits_per_page = $settings->get("hits_per_page");// TODO PHP8-REVIEW Property dynamically declared
             $skin = $ilClientIniFile->readVariable("layout", "skin");
             $style = $ilClientIniFile->readVariable("layout", "style");
-            $settings->default_skin_style = $skin . ":" . $style;
+            $settings->default_skin_style = $skin . ":" . $style;// TODO PHP8-REVIEW Property dynamically declared
             return $settings;
         }
         return null;

--- a/webservice/soap/classes/class.ilSoapAdministration.php
+++ b/webservice/soap/classes/class.ilSoapAdministration.php
@@ -221,12 +221,16 @@ class ilSoapAdministration
 
         $type = ilObject::_lookupType(ilObject::_lookupObjId($ref_id));
         if (!in_array($type, $expected_type)) {
-            return $this->__raiseError("Wrong type $type for id. Expected: " . join(",", $expected_type),
-                'CLIENT_OBJECT_WRONG_TYPE');
+            return $this->__raiseError(
+                "Wrong type $type for id. Expected: " . join(",", $expected_type),
+                'CLIENT_OBJECT_WRONG_TYPE'
+            );
         }
         if (!$rbacsystem->checkAccess($permission, $ref_id, $type)) {
-            return $this->__raiseError('Missing permission $permission for type $type.',
-                'CLIENT_OBJECT_WRONG_PERMISSION');
+            return $this->__raiseError(
+                'Missing permission $permission for type $type.',
+                'CLIENT_OBJECT_WRONG_PERMISSION'
+            );
         }
         if ($returnObject) {
             try {
@@ -326,8 +330,10 @@ class ilSoapAdministration
             define("IL_INST_ID", (int) $settings->get("inst_id", '0'));
             $settings->access = $ilClientIniFile->readVariable("client", "access");
             $settings->description = $ilClientIniFile->readVariable("client", "description");
-            $settings->session = min((int) ini_get("session.gc_maxlifetime"),
-                (int) $ilClientIniFile->readVariable("session", "expire"));
+            $settings->session = min(
+                (int) ini_get("session.gc_maxlifetime"),
+                (int) $ilClientIniFile->readVariable("session", "expire")
+            );
             $settings->language = $ilClientIniFile->readVariable("language", "default");
             $settings->clientid = basename($client_dir); //pathinfo($client_dir, PATHINFO_FILENAME);
             $settings->default_show_users_online = $settings->get("show_users_online");

--- a/webservice/soap/classes/class.ilSoapCourseAdministration.php
+++ b/webservice/soap/classes/class.ilSoapCourseAdministration.php
@@ -114,8 +114,10 @@ class ilSoapCourseAdministration extends ilSoapAdministration
             $ref_ids = ilObject::_getAllReferences($course_id);
             $course_id = end($ref_ids);
             if (ilObject::_lookupType(ilObject::_lookupObjId($course_id)) != 'crs') {
-                return $this->__raiseError('Invalid course id. Object with id "' . $course_id . '" is not of type "course"',
-                    'Client');
+                return $this->__raiseError(
+                    'Invalid course id. Object with id "' . $course_id . '" is not of type "course"',
+                    'Client'
+                );
             }
         }
 
@@ -169,8 +171,10 @@ class ilSoapCourseAdministration extends ilSoapAdministration
             $ref_ids = ilObject::_getAllReferences($course_id);
             $course_id = end($ref_ids);
             if (ilObject::_lookupType(ilObject::_lookupObjId($course_id)) != 'crs') {
-                return $this->__raiseError('Invalid course id. Object with id "' . $course_id . '" is not of type "course"',
-                    'Client');
+                return $this->__raiseError(
+                    'Invalid course id. Object with id "' . $course_id . '" is not of type "course"',
+                    'Client'
+                );
             }
         }
 
@@ -184,8 +188,10 @@ class ilSoapCourseAdministration extends ilSoapAdministration
         if ($type != 'Admin' and
             $type != 'Tutor' and
             $type != 'Member') {
-            return $this->__raiseError('Invalid type given. Parameter "type" must be "Admin", "Tutor" or "Member"',
-                'Client');
+            return $this->__raiseError(
+                'Invalid type given. Parameter "type" must be "Admin", "Tutor" or "Member"',
+                'Client'
+            );
         }
 
         if (!$tmp_course = ilObjectFactory::getInstanceByRefId($course_id, false)) {
@@ -205,8 +211,10 @@ class ilSoapCourseAdministration extends ilSoapAdministration
                 require_once("Services/Administration/classes/class.ilSetting.php");
                 $settings = new ilSetting();
                 $course_members->add($tmp_user->getId(), ilParticipants::IL_CRS_ADMIN);
-                $course_members->updateNotification($tmp_user->getId(),
-                    (bool) $settings->get('mail_crs_admin_notification', "1"));
+                $course_members->updateNotification(
+                    $tmp_user->getId(),
+                    (bool) $settings->get('mail_crs_admin_notification', "1")
+                );
                 break;
 
             case 'Tutor':
@@ -243,8 +251,10 @@ class ilSoapCourseAdministration extends ilSoapAdministration
             $ref_ids = ilObject::_getAllReferences($course_id);
             $course_id = end($ref_ids);
             if (ilObject::_lookupType(ilObject::_lookupObjId($course_id)) != 'crs') {
-                return $this->__raiseError('Invalid course id. Object with id "' . $course_id . '" is not of type "course"',
-                    'Client');
+                return $this->__raiseError(
+                    'Invalid course id. Object with id "' . $course_id . '" is not of type "course"',
+                    'Client'
+                );
             }
         }
 
@@ -292,8 +302,10 @@ class ilSoapCourseAdministration extends ilSoapAdministration
             $ref_ids = ilObject::_getAllReferences($course_id);
             $course_id = end($ref_ids);
             if (ilObject::_lookupType(ilObject::_lookupObjId($course_id)) != 'crs') {
-                return $this->__raiseError('Invalid course id. Object with id "' . $course_id . '" is not of type "course"',
-                    'Client');
+                return $this->__raiseError(
+                    'Invalid course id. Object with id "' . $course_id . '" is not of type "course"',
+                    'Client'
+                );
             }
         }
 
@@ -377,8 +389,10 @@ class ilSoapCourseAdministration extends ilSoapAdministration
             $ref_ids = ilObject::_getAllReferences($course_id);
             $course_id = end($ref_ids);
             if (ilObject::_lookupType(ilObject::_lookupObjId($course_id)) != 'crs') {
-                return $this->__raiseError('Invalid course id. Object with id "' . $course_id . '" is not of type "course"',
-                    'Client');
+                return $this->__raiseError(
+                    'Invalid course id. Object with id "' . $course_id . '" is not of type "course"',
+                    'Client'
+                );
             }
         }
 
@@ -461,9 +475,9 @@ class ilSoapCourseAdministration extends ilSoapAdministration
         #var_dump($xmlResultSet);
         #echo "uid:".$user_id;
         #echo "status:".$status;
-        if (ilSoapCourseAdministration::MEMBER == ($status&ilSoapCourseAdministration::MEMBER) ||
-            ilSoapCourseAdministration::TUTOR == ($status&ilSoapCourseAdministration::TUTOR) ||
-            ilSoapCourseAdministration::ADMIN == ($status&ilSoapCourseAdministration::ADMIN)) {
+        if (ilSoapCourseAdministration::MEMBER == ($status & ilSoapCourseAdministration::MEMBER) ||
+            ilSoapCourseAdministration::TUTOR == ($status & ilSoapCourseAdministration::TUTOR) ||
+            ilSoapCourseAdministration::ADMIN == ($status & ilSoapCourseAdministration::ADMIN)) {
             foreach ($rbacreview->assignedRoles($user_id) as $role_id) {
                 if ($role = ilObjectFactory::getInstanceByObjId($role_id, false)) {
                     #echo $role->getType();
@@ -481,16 +495,22 @@ class ilSoapCourseAdministration extends ilSoapAdministration
                         }
 
                         #echo $role_title;
-                        if (ilSoapCourseAdministration::MEMBER == ($status&ilSoapCourseAdministration::MEMBER) && strpos($role_title,
-                                "member") !== false) {
+                        if (ilSoapCourseAdministration::MEMBER == ($status & ilSoapCourseAdministration::MEMBER) && strpos(
+                            $role_title,
+                            "member"
+                        ) !== false) {
                             $ref_ids [] = $ref_id;
-                        } elseif (ilSoapCourseAdministration::TUTOR == ($status&ilSoapCourseAdministration::TUTOR) && strpos($role_title,
-                                "tutor") !== false) {
+                        } elseif (ilSoapCourseAdministration::TUTOR == ($status & ilSoapCourseAdministration::TUTOR) && strpos(
+                            $role_title,
+                            "tutor"
+                        ) !== false) {
                             $ref_ids [] = $ref_id;
-                        } elseif (ilSoapCourseAdministration::ADMIN == ($status&ilSoapCourseAdministration::ADMIN) && strpos($role_title,
-                                "admin") !== false) {
+                        } elseif (ilSoapCourseAdministration::ADMIN == ($status & ilSoapCourseAdministration::ADMIN) && strpos(
+                            $role_title,
+                            "admin"
+                        ) !== false) {
                             $ref_ids [] = $ref_id;
-                        } elseif (($status&ilSoapCourseAdministration::OWNER) == ilSoapCourseAdministration::OWNER && $ilObjDataCache->lookupOwner($ilObjDataCache->lookupObjId($ref_id)) == $user_id) {
+                        } elseif (($status & ilSoapCourseAdministration::OWNER) == ilSoapCourseAdministration::OWNER && $ilObjDataCache->lookupOwner($ilObjDataCache->lookupObjId($ref_id)) == $user_id) {
                             $ref_ids [] = $ref_id;
                         }
                     }

--- a/webservice/soap/classes/class.ilSoapCourseAdministration.php
+++ b/webservice/soap/classes/class.ilSoapCourseAdministration.php
@@ -36,21 +36,13 @@ class ilSoapCourseAdministration extends ilSoapAdministration
     public const ADMIN = 4;
     public const OWNER = 8;
 
-    // Service methods
     public function addCourse(string $sid, int $target_id, string $crs_xml)
     {
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
-        }
-
-        if (!is_numeric($target_id)) {
-            return $this->__raiseError(
-                'No valid target id given. Please choose an existing reference id of an ILIAS category',
-                'Client'
-            );
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
@@ -58,18 +50,17 @@ class ilSoapCourseAdministration extends ilSoapAdministration
         $rbacsystem = $DIC['rbacsystem'];
 
         if (!$target_obj = ilObjectFactory::getInstanceByRefId($target_id, false)) {
-            return $this->__raiseError('No valid target given.', 'Client');
+            return $this->raiseError('No valid target given.', 'Client');
         }
 
         if (ilObject::_isInTrash($target_id)) {
-            return $this->__raiseError("Parent with ID $target_id has been deleted.", 'CLIENT_OBJECT_DELETED');
+            return $this->raiseError("Parent with ID $target_id has been deleted.", 'CLIENT_OBJECT_DELETED');
         }
 
         if (!$rbacsystem->checkAccess('create', $target_id, 'crs')) {
-            return $this->__raiseError('Check access failed. No permission to create courses', 'Server');
+            return $this->raiseError('Check access failed. No permission to create courses', 'Server');
         }
 
-        // Start import
         include_once("Modules/Course/classes/class.ilObjCourse.php");
 
         $newObj = new ilObjCourse();
@@ -94,15 +85,8 @@ class ilSoapCourseAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
-        }
-
-        if (!is_numeric($course_id)) {
-            return $this->__raiseError(
-                'No valid course id given. Please choose an existing reference id of an ILIAS course',
-                'Client'
-            );
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         include_once "./Services/Utilities/classes/class.ilUtil.php";
@@ -110,11 +94,11 @@ class ilSoapCourseAdministration extends ilSoapAdministration
 
         $rbacsystem = $DIC['rbacsystem'];
 
-        if (($obj_type = ilObject::_lookupType(ilObject::_lookupObjId($course_id))) != 'crs') {
+        if (ilObject::_lookupType(ilObject::_lookupObjId($course_id)) !== 'crs') {
             $ref_ids = ilObject::_getAllReferences($course_id);
             $course_id = end($ref_ids);
-            if (ilObject::_lookupType(ilObject::_lookupObjId($course_id)) != 'crs') {
-                return $this->__raiseError(
+            if (ilObject::_lookupType(ilObject::_lookupObjId($course_id)) !== 'crs') {
+                return $this->raiseError(
                     'Invalid course id. Object with id "' . $course_id . '" is not of type "course"',
                     'Client'
                 );
@@ -122,7 +106,7 @@ class ilSoapCourseAdministration extends ilSoapAdministration
         }
 
         if (!$rbacsystem->checkAccess('delete', $course_id)) {
-            return $this->__raiseError('Check access failed. No permission to delete course', 'Server');
+            return $this->raiseError('Check access failed. No permission to delete course', 'Server');
         }
 
         global $DIC;
@@ -132,7 +116,7 @@ class ilSoapCourseAdministration extends ilSoapAdministration
         $log = $DIC['log'];
 
         if ($tree->isDeleted($course_id)) {
-            return $this->__raiseError('Node already deleted', 'Server');
+            return $this->raiseError('Node already deleted', 'Server');
         }
 
         $subnodes = $tree->getSubTree($tree->getNodeData($course_id));
@@ -140,9 +124,9 @@ class ilSoapCourseAdministration extends ilSoapAdministration
             $rbacadmin->revokePermission($subnode["child"]);
         }
         if (!$tree->moveToTrash($course_id, true, $user->getId())) {
-            return $this->__raiseError('Node already deleted', 'Client');
+            return $this->raiseError('Node already deleted', 'Client');
         }
-        // write log entry
+
         $log->write("SOAP ilObjectGUI::confirmedDeleteObject(), moved ref_id " . $course_id . " to trash");
         return true;
     }
@@ -152,26 +136,19 @@ class ilSoapCourseAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
-        }
-
-        if (!is_numeric($course_id)) {
-            return $this->__raiseError(
-                'No valid course id given. Please choose an existing reference id of an ILIAS course',
-                'Client'
-            );
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
 
         $rbacsystem = $DIC['rbacsystem'];
 
-        if (($obj_type = ilObject::_lookupType(ilObject::_lookupObjId($course_id))) != 'crs') {
+        if (ilObject::_lookupType(ilObject::_lookupObjId($course_id)) !== 'crs') {
             $ref_ids = ilObject::_getAllReferences($course_id);
             $course_id = end($ref_ids);
-            if (ilObject::_lookupType(ilObject::_lookupObjId($course_id)) != 'crs') {
-                return $this->__raiseError(
+            if (ilObject::_lookupType(ilObject::_lookupObjId($course_id)) !== 'crs') {
+                return $this->raiseError(
                     'Invalid course id. Object with id "' . $course_id . '" is not of type "course"',
                     'Client'
                 );
@@ -179,27 +156,27 @@ class ilSoapCourseAdministration extends ilSoapAdministration
         }
 
         if (!$rbacsystem->checkAccess('manage_members', $course_id)) {
-            return $this->__raiseError('Check access failed. No permission to write to course', 'Server');
+            return $this->raiseError('Check access failed. No permission to write to course', 'Server');
         }
 
-        if (ilObject::_lookupType($user_id) != 'usr') {
-            return $this->__raiseError('Invalid user id. User with id "' . $user_id . ' does not exist', 'Client');
+        if (ilObject::_lookupType($user_id) !== 'usr') {
+            return $this->raiseError('Invalid user id. User with id "' . $user_id . ' does not exist', 'Client');
         }
-        if ($type != 'Admin' and
-            $type != 'Tutor' and
-            $type != 'Member') {
-            return $this->__raiseError(
+        if ($type !== 'Admin' && // TODO PHP8-REVIEW Wrong type
+            $type !== 'Tutor' && // TODO PHP8-REVIEW Wrong type
+            $type !== 'Member') {// TODO PHP8-REVIEW Wrong type
+            return $this->raiseError(
                 'Invalid type given. Parameter "type" must be "Admin", "Tutor" or "Member"',
                 'Client'
             );
         }
 
         if (!$tmp_course = ilObjectFactory::getInstanceByRefId($course_id, false)) {
-            return $this->__raiseError('Cannot create course instance!', 'Server');
+            return $this->raiseError('Cannot create course instance!', 'Server');
         }
 
         if (!$tmp_user = ilObjectFactory::getInstanceByObjId($user_id, false)) {
-            return $this->__raiseError('Cannot create user instance!', 'Server');
+            return $this->raiseError('Cannot create user instance!', 'Server');
         }
 
         include_once 'Modules/Course/classes/class.ilCourseParticipants.php';
@@ -233,48 +210,42 @@ class ilSoapCourseAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
-        }
-        if (!is_numeric($course_id)) {
-            return $this->__raiseError(
-                'No valid course id given. Please choose an existing reference id of an ILIAS course',
-                'Client'
-            );
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
 
         $rbacsystem = $DIC['rbacsystem'];
 
-        if (($obj_type = ilObject::_lookupType(ilObject::_lookupObjId($course_id))) != 'crs') {
+        if (ilObject::_lookupType(ilObject::_lookupObjId($course_id)) !== 'crs') {
             $ref_ids = ilObject::_getAllReferences($course_id);
             $course_id = end($ref_ids);
-            if (ilObject::_lookupType(ilObject::_lookupObjId($course_id)) != 'crs') {
-                return $this->__raiseError(
+            if (ilObject::_lookupType(ilObject::_lookupObjId($course_id)) !== 'crs') {
+                return $this->raiseError(
                     'Invalid course id. Object with id "' . $course_id . '" is not of type "course"',
                     'Client'
                 );
             }
         }
 
-        if (ilObject::_lookupType($user_id) != 'usr') {
-            return $this->__raiseError('Invalid user id. User with id "' . $user_id . ' does not exist', 'Client');
+        if (ilObject::_lookupType($user_id) !== 'usr') {
+            return $this->raiseError('Invalid user id. User with id "' . $user_id . ' does not exist', 'Client');
         }
 
         if (!$tmp_course = ilObjectFactory::getInstanceByRefId($course_id, false)) {
-            return $this->__raiseError('Cannot create course instance!', 'Server');
+            return $this->raiseError('Cannot create course instance!', 'Server');
         }
 
         if (!$rbacsystem->checkAccess('manage_members', $course_id)) {
-            return $this->__raiseError('Check access failed. No permission to write to course', 'Server');
+            return $this->raiseError('Check access failed. No permission to write to course', 'Server');
         }
 
         include_once 'Modules/Course/classes/class.ilCourseParticipants.php';
 
         $course_members = ilCourseParticipants::_getInstanceByObjId($tmp_course->getId());
         if (!$course_members->checkLastAdmin(array($user_id))) {
-            return $this->__raiseError('Cannot deassign last administrator from course', 'Server');
+            return $this->raiseError('Cannot deassign last administrator from course', 'Server');
         }
         $course_members->delete($user_id);
         return true;
@@ -285,40 +256,36 @@ class ilSoapCourseAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
-        if (!is_numeric($course_id)) {
-            return $this->__raiseError(
-                'No valid course id given. Please choose an existing reference id of an ILIAS course',
-                'Client'
-            );
-        }
+
         global $DIC;
 
         $rbacsystem = $DIC['rbacsystem'];
 
-        if (($obj_type = ilObject::_lookupType(ilObject::_lookupObjId($course_id))) != 'crs') {
+        if (ilObject::_lookupType(ilObject::_lookupObjId($course_id)) !== 'crs') {
             $ref_ids = ilObject::_getAllReferences($course_id);
             $course_id = end($ref_ids);
-            if (ilObject::_lookupType(ilObject::_lookupObjId($course_id)) != 'crs') {
-                return $this->__raiseError(
+            if (ilObject::_lookupType(ilObject::_lookupObjId($course_id)) !== 'crs') {
+                return $this->raiseError(
                     'Invalid course id. Object with id "' . $course_id . '" is not of type "course"',
                     'Client'
                 );
             }
         }
 
-        if (ilObject::_lookupType($user_id) != 'usr') {
-            return $this->__raiseError('Invalid user id. User with id "' . $user_id . ' does not exist', 'Client');
+        if (ilObject::_lookupType($user_id) !== 'usr') {
+            return $this->raiseError('Invalid user id. User with id "' . $user_id . ' does not exist', 'Client');
         }
 
+        /** @var ilObjCourse $tmp_course */
         if (!$tmp_course = ilObjectFactory::getInstanceByRefId($course_id, false)) {
-            return $this->__raiseError('Cannot create course instance!', 'Server');
+            return $this->raiseError('Cannot create course instance!', 'Server');
         }
 
         if (!$rbacsystem->checkAccess('manage_members', $course_id)) {
-            return $this->__raiseError('Check access failed. No permission to write to course', 'Server');
+            return $this->raiseError('Check access failed. No permission to write to course', 'Server');
         }
 
         include_once './Modules/Course/classes/class.ilCourseParticipants.php';
@@ -341,24 +308,20 @@ class ilSoapCourseAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
-        }
-        if (!is_numeric($course_id)) {
-            return $this->__raiseError(
-                'No valid course id given. Please choose an existing reference id of an ILIAS course',
-                'Client'
-            );
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
 
         $rbacsystem = $DIC['rbacsystem'];
 
+        /** @var ilObjCourse $tmp_course */
         $tmp_course = $this->checkObjectAccess($course_id, ['crs'], "read", true);
         if ($this->isFault($tmp_course)) {
             return $tmp_course;
         }
+
         include_once 'Modules/Course/classes/class.ilCourseXMLWriter.php';
         $xml_writer = new ilCourseXMLWriter($tmp_course);
         $xml_writer->start();
@@ -370,38 +333,32 @@ class ilSoapCourseAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
-        }
-
-        if (!is_numeric($course_id)) {
-            return $this->__raiseError(
-                'No valid course id given. Please choose an existing reference id of an ILIAS course',
-                'Client'
-            );
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
 
         $rbacsystem = $DIC['rbacsystem'];
 
-        if (($obj_type = ilObject::_lookupType(ilObject::_lookupObjId($course_id))) != 'crs') {
+        if (ilObject::_lookupType(ilObject::_lookupObjId($course_id)) !== 'crs') {
             $ref_ids = ilObject::_getAllReferences($course_id);
             $course_id = end($ref_ids);
-            if (ilObject::_lookupType(ilObject::_lookupObjId($course_id)) != 'crs') {
-                return $this->__raiseError(
+            if (ilObject::_lookupType(ilObject::_lookupObjId($course_id)) !== 'crs') {
+                return $this->raiseError(
                     'Invalid course id. Object with id "' . $course_id . '" is not of type "course"',
                     'Client'
                 );
             }
         }
 
+        /** @var ilObjCourse $tmp_course */
         if (!$tmp_course = ilObjectFactory::getInstanceByRefId($course_id, false)) {
-            return $this->__raiseError('Cannot create course instance!', 'Server');
+            return $this->raiseError('Cannot create course instance!', 'Server');
         }
 
         if (!$rbacsystem->checkAccess('write', $course_id)) {
-            return $this->__raiseError('Check access failed. No permission to write course', 'Server');
+            return $this->raiseError('Check access failed. No permission to write course', 'Server');
         }
 
         // First delete old meta data
@@ -426,21 +383,19 @@ class ilSoapCourseAdministration extends ilSoapAdministration
         return true;
     }
 
-    // PRIVATE
-
     /**
      * get courses which belong to a specific user, fullilling the status
      * @param string $sid
      * @param string $parameters following xmlresultset, columns (user_id, status with values  1 = "MEMBER", 2 = "TUTOR", 4 = "ADMIN", 8 = "OWNER" and any xor operation e.g.  1 + 4 = 5 = ADMIN and TUTOR, 7 = ADMIN and TUTOR and MEMBER)
-     * @param string XMLResultSet, columns (ref_id, xml, parent_ref_id)
+     * @return string XMLResultSet, columns (ref_id, xml, parent_ref_id)
      */
     public function getCoursesForUser(string $sid, string $parameters)
     {
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
@@ -454,16 +409,16 @@ class ilSoapCourseAdministration extends ilSoapAdministration
         try {
             $parser->startParsing();
         } catch (ilSaxParserException $exception) {
-            return $this->__raiseError($exception->getMessage(), "Client");
+            return $this->raiseError($exception->getMessage(), "Client");
         }
         $xmlResultSet = $parser->getXMLResultSet();
 
         if (!$xmlResultSet->hasColumn("user_id")) {
-            return $this->__raiseError("parameter user_id is missing", "Client");
+            return $this->raiseError("parameter user_id is missing", "Client");
         }
 
         if (!$xmlResultSet->hasColumn("status")) {
-            return $this->__raiseError("parameter status is missing", "Client");
+            return $this->raiseError("parameter status is missing", "Client");
         }
 
         $user_id = (int) $xmlResultSet->getValue(0, "user_id");
@@ -471,17 +426,13 @@ class ilSoapCourseAdministration extends ilSoapAdministration
 
         $ref_ids = array();
 
-        // get roles
-        #var_dump($xmlResultSet);
-        #echo "uid:".$user_id;
-        #echo "status:".$status;
-        if (ilSoapCourseAdministration::MEMBER == ($status & ilSoapCourseAdministration::MEMBER) ||
-            ilSoapCourseAdministration::TUTOR == ($status & ilSoapCourseAdministration::TUTOR) ||
-            ilSoapCourseAdministration::ADMIN == ($status & ilSoapCourseAdministration::ADMIN)) {
+        if (self::MEMBER == ($status & self::MEMBER) ||
+            self::TUTOR == ($status & self::TUTOR) ||
+            self::ADMIN == ($status & self::ADMIN)) {
             foreach ($rbacreview->assignedRoles($user_id) as $role_id) {
                 if ($role = ilObjectFactory::getInstanceByObjId($role_id, false)) {
                     #echo $role->getType();
-                    if ($role->getType() != "role") {
+                    if ($role->getType() !== "role") {
                         continue;
                     }
                     if ($role->getParent() == ROLE_FOLDER_ID) {
@@ -494,30 +445,29 @@ class ilSoapCourseAdministration extends ilSoapAdministration
                             continue;
                         }
 
-                        #echo $role_title;
-                        if (ilSoapCourseAdministration::MEMBER == ($status & ilSoapCourseAdministration::MEMBER) && strpos(
+                        if (self::MEMBER == ($status & self::MEMBER) && strpos(
                             $role_title,
                             "member"
                         ) !== false) {
                             $ref_ids [] = $ref_id;
-                        } elseif (ilSoapCourseAdministration::TUTOR == ($status & ilSoapCourseAdministration::TUTOR) && strpos(
+                        } elseif (self::TUTOR == ($status & self::TUTOR) && strpos(
                             $role_title,
                             "tutor"
                         ) !== false) {
                             $ref_ids [] = $ref_id;
-                        } elseif (ilSoapCourseAdministration::ADMIN == ($status & ilSoapCourseAdministration::ADMIN) && strpos(
+                        } elseif (self::ADMIN == ($status & self::ADMIN) && strpos(
                             $role_title,
                             "admin"
                         ) !== false) {
                             $ref_ids [] = $ref_id;
-                        } elseif (($status & ilSoapCourseAdministration::OWNER) == ilSoapCourseAdministration::OWNER && $ilObjDataCache->lookupOwner($ilObjDataCache->lookupObjId($ref_id)) == $user_id) {
+                        } elseif (($status & self::OWNER) == self::OWNER && $ilObjDataCache->lookupOwner($ilObjDataCache->lookupObjId($ref_id)) == $user_id) {
                             $ref_ids [] = $ref_id;
                         }
                     }
                 }
             }
         }
-        if (($status & ilSoapCourseAdministration::OWNER) == ilSoapCourseAdministration::OWNER) {
+        if (($status & self::OWNER) == self::OWNER) {
             $owned_objects = ilObjectFactory::getObjectsForOwner("crs", $user_id);
             $refs = [];
             foreach ($owned_objects as $obj_id) {
@@ -538,7 +488,7 @@ class ilSoapCourseAdministration extends ilSoapAdministration
         $ref_ids = array_unique($ref_ids);
 
         $ref_ids = array_unique($ref_ids);
-        #print_r($ref_ids);
+
         include_once 'webservice/soap/classes/class.ilXMLResultSetWriter.php';
         include_once 'Modules/Course/classes/class.ilObjCourse.php';
         include_once 'Modules/Course/classes/class.ilCourseXMLWriter.php';
@@ -553,7 +503,7 @@ class ilSoapCourseAdministration extends ilSoapAdministration
         $ilUser = $DIC['ilUser'];
         //#18004
         // Enable to see own participations by reducing the needed permissions
-        $permission = $user_id == $ilUser->getId() ? 'read' : 'write';
+        $permission = $user_id === $ilUser->getId() ? 'read' : 'write';
 
         foreach ($ref_ids as $course_id) {
             $course_obj = $this->checkObjectAccess($course_id, ['crs'], $permission, true);

--- a/webservice/soap/classes/class.ilSoapDataCollectionAdministration.php
+++ b/webservice/soap/classes/class.ilSoapDataCollectionAdministration.php
@@ -46,24 +46,24 @@ class ilSoapDataCollectionAdministration extends ilSoapAdministration
     ) {
         $this->initAuth($sid);
         $this->initIlias();
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         require_once "Modules/DataCollection/classes/class.ilObjDataCollection.php";
         if (!$target_obj = new ilObjDataCollection($target_ref_id)) {
-            return $this->__raiseError('No valid target given.', 'CLIENT');
+            return $this->raiseError('No valid target given.', 'CLIENT');
         }
 
         if (ilObject::_isInTrash($target_ref_id)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 "Parent with ID $target_ref_id has been deleted.",
                 'CLIENT_TARGET_DELETED'
             );
         }
 
         if (!ilObjDataCollectionAccess::hasReadAccess($target_ref_id)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'Check access failed. No permission to read DataCollection',
                 "CLIENT_PERMISSION_ISSUE"
             );
@@ -74,7 +74,7 @@ class ilSoapDataCollectionAdministration extends ilSoapAdministration
             $exporter = new ilDclContentExporter($target_ref_id, $table_id);
             return $exporter->export($format, $filepath);
         } catch (ilException $exception) {
-            return $this->__raiseError($exception->getMessage(), $exception->getCode());
+            return $this->raiseError($exception->getMessage(), $exception->getCode());
         }
     }
 }

--- a/webservice/soap/classes/class.ilSoapExerciseAdministration.php
+++ b/webservice/soap/classes/class.ilSoapExerciseAdministration.php
@@ -54,8 +54,10 @@ class ilSoapExerciseAdministration extends ilSoapAdministration
         // Check access
         $allowed_types = array('cat', 'grp', 'crs', 'fold', 'root');
         if (!in_array($target_obj->getType(), $allowed_types)) {
-            return $this->__raiseError('No valid target type. Target must be reference id of "course, group, category or folder"',
-                'Client');
+            return $this->__raiseError(
+                'No valid target type. Target must be reference id of "course, group, category or folder"',
+                'Client'
+            );
         }
 
         if (!$rbacsystem->checkAccess('create', $target_id, "exc")) {
@@ -110,8 +112,10 @@ class ilSoapExerciseAdministration extends ilSoapAdministration
         $ilLog = $DIC['ilLog'];
 
         if (ilObject::_isInTrash($ref_id)) {
-            return $this->__raiseError('Cannot perform update since exercise has been deleted.',
-                'CLIENT_OBJECT_DELETED');
+            return $this->__raiseError(
+                'Cannot perform update since exercise has been deleted.',
+                'CLIENT_OBJECT_DELETED'
+            );
         }
         // get obj_id
         if (!$obj_id = ilObject::_lookupObjectId($ref_id)) {

--- a/webservice/soap/classes/class.ilSoapExerciseAdministration.php
+++ b/webservice/soap/classes/class.ilSoapExerciseAdministration.php
@@ -34,8 +34,8 @@ class ilSoapExerciseAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
         global $DIC;
 
@@ -44,24 +44,23 @@ class ilSoapExerciseAdministration extends ilSoapAdministration
         $ilLog = $DIC['ilLog'];
 
         if (!$target_obj = ilObjectFactory::getInstanceByRefId($target_id, false)) {
-            return $this->__raiseError('No valid target given.', 'Client');
+            return $this->raiseError('No valid target given.', 'Client');
         }
 
         if (ilObject::_isInTrash($target_id)) {
-            return $this->__raiseError("Parent with ID $target_id has been deleted.", 'CLIENT_OBJECT_DELETED');
+            return $this->raiseError("Parent with ID $target_id has been deleted.", 'CLIENT_OBJECT_DELETED');
         }
 
-        // Check access
         $allowed_types = array('cat', 'grp', 'crs', 'fold', 'root');
         if (!in_array($target_obj->getType(), $allowed_types)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No valid target type. Target must be reference id of "course, group, category or folder"',
                 'Client'
             );
         }
 
         if (!$rbacsystem->checkAccess('create', $target_id, "exc")) {
-            return $this->__raiseError('No permission to create exercises in target  ' . $target_id . '!', 'Client');
+            return $this->raiseError('No permission to create exercises in target  ' . $target_id . '!', 'Client');
         }
 
         // create object, put it into the tree and use the parser to update the settings
@@ -87,7 +86,7 @@ class ilSoapExerciseAdministration extends ilSoapAdministration
             }
             throw new ilExerciseException("Could not parse XML");
         } catch (ilExerciseException $exception) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 $exception->getMessage(),
                 $exception->getCode() == ilExerciseException::$ID_MISMATCH ? "Client" : "Server"
             );
@@ -97,13 +96,13 @@ class ilSoapExerciseAdministration extends ilSoapAdministration
     /**
      * update a exercise with id.
      */
-    public function updateExercise(string $sid, int $ref_id, string $exercise_xml)
+    public function updateExercise(string $sid, int $requested_ref_id, string $exercise_xml)
     {
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
         global $DIC;
 
@@ -111,21 +110,20 @@ class ilSoapExerciseAdministration extends ilSoapAdministration
         $tree = $DIC['tree'];
         $ilLog = $DIC['ilLog'];
 
-        if (ilObject::_isInTrash($ref_id)) {
-            return $this->__raiseError(
+        if (ilObject::_isInTrash($requested_ref_id)) {
+            return $this->raiseError(
                 'Cannot perform update since exercise has been deleted.',
                 'CLIENT_OBJECT_DELETED'
             );
         }
-        // get obj_id
-        if (!$obj_id = ilObject::_lookupObjectId($ref_id)) {
-            return $this->__raiseError(
-                'No exercise found for id: ' . $ref_id,
+
+        if (!$obj_id = ilObject::_lookupObjectId($requested_ref_id)) {
+            return $this->raiseError(
+                'No exercise found for id: ' . $requested_ref_id,
                 'CLIENT_OBJECT_NOT_FOUND'
             );
         }
 
-        // Check access
         $permission_ok = false;
         foreach ($ref_ids = ilObject::_getAllReferences($obj_id) as $ref_id) {
             if ($rbacsystem->checkAccess('edit', $ref_id)) {
@@ -135,17 +133,18 @@ class ilSoapExerciseAdministration extends ilSoapAdministration
         }
 
         if (!$permission_ok) {
-            return $this->__raiseError(
-                'No permission to edit the exercise with id: ' . $ref_id,
+            return $this->raiseError(
+                'No permission to edit the exercise with id: ' . $requested_ref_id,
                 'Server'
             );
         }
 
+        /** @var ilObjExercise $exercise */
         $exercise = ilObjectFactory::getInstanceByObjId($obj_id, false);
 
-        if (!is_object($exercise) || $exercise->getType() != "exc") {
-            return $this->__raiseError(
-                'Wrong obj id or type for exercise with id ' . $ref_id,
+        if (!is_object($exercise) || $exercise->getType() !== "exc") {
+            return $this->raiseError(
+                'Wrong obj id or type for exercise with id ' . $requested_ref_id,
                 'CLIENT_OBJECT_NOI_FOUND'
             );
         }
@@ -161,7 +160,7 @@ class ilSoapExerciseAdministration extends ilSoapAdministration
             }
             throw new ilExerciseException("Could not parse XML");
         } catch (ilExerciseException $exception) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 $exception->getMessage(),
                 $exception->getCode() == ilExerciseException::$ID_MISMATCH ? "Client" : "Server"
             );
@@ -172,16 +171,16 @@ class ilSoapExerciseAdministration extends ilSoapAdministration
      * get exercise xml
      */
 
-    public function getExerciseXML(string $sid, int $ref_id, int $attachFileContentsMode)
+    public function getExerciseXML(string $sid, int $requested_ref_id, int $attachFileContentsMode)
     {
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
-        if (!$ref_id) {
-            return $this->__raiseError(
+        if (!$requested_ref_id) {
+            return $this->raiseError(
                 'No ref id given. Aborting!',
                 'Client'
             );
@@ -193,18 +192,17 @@ class ilSoapExerciseAdministration extends ilSoapAdministration
         $ilLog = $DIC['ilLog'];
 
         // get obj_id
-        if (!$obj_id = ilObject::_lookupObjectId($ref_id)) {
-            return $this->__raiseError(
-                'No exercise found for id: ' . $ref_id,
+        if (!$obj_id = ilObject::_lookupObjectId($requested_ref_id)) {
+            return $this->raiseError(
+                'No exercise found for id: ' . $requested_ref_id,
                 'Client'
             );
         }
 
-        if (ilObject::_isInTrash($ref_id)) {
-            return $this->__raiseError("Parent with ID $ref_id has been deleted.", 'Client');
+        if (ilObject::_isInTrash($requested_ref_id)) {
+            return $this->raiseError("Parent with ID $requested_ref_id has been deleted.", 'Client');
         }
 
-        // Check access
         $permission_ok = false;
         $write_permission_ok = false;
         foreach ($ref_ids = ilObject::_getAllReferences($obj_id) as $ref_id) {
@@ -219,24 +217,24 @@ class ilSoapExerciseAdministration extends ilSoapAdministration
         }
 
         if (!$permission_ok && !$write_permission_ok) {
-            return $this->__raiseError(
-                'No permission to edit the object with id: ' . $ref_id,
+            return $this->raiseError(
+                'No permission to edit the object with id: ' . $requested_ref_id,
                 'Server'
             );
         }
 
+        /** @var ilObjExercise $exercise */
         $exercise = ilObjectFactory::getInstanceByObjId($obj_id, false);
 
-        if (!is_object($exercise) || $exercise->getType() != "exc") {
-            return $this->__raiseError(
-                'Wrong obj id or type for exercise with id ' . $ref_id,
+        if (!is_object($exercise) || $exercise->getType() !== "exc") {
+            return $this->raiseError(
+                'Wrong obj id or type for exercise with id ' . $requested_ref_id,
                 'Server'
             );
         }
-        // store into xml result set
+
         include_once './Modules/Exercise/classes/class.ilExerciseXMLWriter.php';
 
-        // create writer
         $xmlWriter = new ilExerciseXMLWriter();
         $xmlWriter->setExercise($exercise);
         $xmlWriter->setAttachMembers($write_permission_ok);

--- a/webservice/soap/classes/class.ilSoapFileAdministration.php
+++ b/webservice/soap/classes/class.ilSoapFileAdministration.php
@@ -55,8 +55,10 @@ class ilSoapFileAdministration extends ilSoapAdministration
         // Check access
         $allowed_types = array('cat', 'grp', 'crs', 'fold', 'root');
         if (!in_array($target_obj->getType(), $allowed_types)) {
-            return $this->__raiseError('No valid target type. Target must be reference id of "course, group, category or folder"',
-                'Client');
+            return $this->__raiseError(
+                'No valid target type. Target must be reference id of "course, group, category or folder"',
+                'Client'
+            );
         }
 
         if (!$ilAccess->checkAccess('create', '', $target_id, "file")) {
@@ -93,8 +95,10 @@ class ilSoapFileAdministration extends ilSoapAdministration
                 return $this->__raiseError("Could not add file", "Server");
             }
         } catch (ilFileException $exception) {
-            return $this->__raiseError($exception->getMessage(),
-                $exception->getCode() == ilFileException::$ID_MISMATCH ? "Client" : "Server");
+            return $this->__raiseError(
+                $exception->getMessage(),
+                $exception->getCode() == ilFileException::$ID_MISMATCH ? "Client" : "Server"
+            );
         }
     }
 

--- a/webservice/soap/classes/class.ilSoapFileAdministration.php
+++ b/webservice/soap/classes/class.ilSoapFileAdministration.php
@@ -37,32 +37,31 @@ class ilSoapFileAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
         global $DIC;
 
         $ilAccess = $DIC['ilAccess'];
 
         if (!$target_obj = ilObjectFactory::getInstanceByRefId($target_id, false)) {
-            return $this->__raiseError('No valid target given.', 'Client');
+            return $this->raiseError('No valid target given.', 'Client');
         }
 
         if (ilObject::_isInTrash($target_id)) {
-            return $this->__raiseError("Parent with ID $target_id has been deleted.", 'CLIENT_TARGET_DELETED');
+            return $this->raiseError("Parent with ID $target_id has been deleted.", 'CLIENT_TARGET_DELETED');
         }
 
-        // Check access
         $allowed_types = array('cat', 'grp', 'crs', 'fold', 'root');
         if (!in_array($target_obj->getType(), $allowed_types)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No valid target type. Target must be reference id of "course, group, category or folder"',
                 'Client'
             );
         }
 
         if (!$ilAccess->checkAccess('create', '', $target_id, "file")) {
-            return $this->__raiseError('No permission to create Files in target  ' . $target_id . '!', 'Client');
+            return $this->raiseError('No permission to create Files in target  ' . $target_id . '!', 'Client');
         }
 
         // create object, put it into the tree and use the parser to update the settings
@@ -91,24 +90,24 @@ class ilSoapFileAdministration extends ilSoapAdministration
                 #$file->update();
 
                 return $file->getRefId();
-            } else {
-                return $this->__raiseError("Could not add file", "Server");
             }
+
+            return $this->raiseError("Could not add file", "Server");
         } catch (ilFileException $exception) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 $exception->getMessage(),
                 $exception->getCode() == ilFileException::$ID_MISMATCH ? "Client" : "Server"
             );
         }
     }
 
-    public function updateFile(string $sid, int $ref_id, string $file_xml)
+    public function updateFile(string $sid, int $requested_ref_id, string $file_xml)
     {
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
         global $DIC;
 
@@ -117,18 +116,17 @@ class ilSoapFileAdministration extends ilSoapAdministration
         $ilLog = $DIC['ilLog'];
         $ilAccess = $DIC['ilAccess'];
 
-        if (ilObject::_isInTrash($ref_id)) {
-            return $this->__raiseError('Cannot perform update since file has been deleted.', 'CLIENT_OBJECT_DELETED');
+        if (ilObject::_isInTrash($requested_ref_id)) {
+            return $this->raiseError('Cannot perform update since file has been deleted.', 'CLIENT_OBJECT_DELETED');
         }
-        // get obj_id
-        if (!$obj_id = ilObject::_lookupObjectId($ref_id)) {
-            return $this->__raiseError(
-                'No File found for id: ' . $ref_id,
+
+        if (!$obj_id = ilObject::_lookupObjectId($requested_ref_id)) {
+            return $this->raiseError(
+                'No File found for id: ' . $requested_ref_id,
                 'Client'
             );
         }
 
-        // Check access
         $permission_ok = false;
         foreach ($ref_ids = ilObject::_getAllReferences($obj_id) as $ref_id) {
             if ($ilAccess->checkAccess('write', '', $ref_id)) {
@@ -138,17 +136,18 @@ class ilSoapFileAdministration extends ilSoapAdministration
         }
 
         if (!$permission_ok) {
-            return $this->__raiseError(
-                'No permission to edit the File with id: ' . $ref_id,
+            return $this->raiseError(
+                'No permission to edit the File with id: ' . $requested_ref_id,
                 'Server'
             );
         }
 
+        /** @var ilObjFile $file */
         $file = ilObjectFactory::getInstanceByObjId($obj_id, false);
 
-        if (!is_object($file) || $file->getType() != "file") {
-            return $this->__raiseError(
-                'Wrong obj id or type for File with id ' . $ref_id,
+        if (!is_object($file) || $file->getType() !== "file") {
+            return $this->raiseError(
+                'Wrong obj id or type for File with id ' . $requested_ref_id,
                 'Server'
             );
         }
@@ -164,7 +163,7 @@ class ilSoapFileAdministration extends ilSoapAdministration
                 return $file->update();
             }
         } catch (ilFileException $exception) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 $exception->getMessage(),
                 $exception->getCode() == ilFileException::$ID_MISMATCH ? "Client" : "Server"
             );
@@ -172,20 +171,22 @@ class ilSoapFileAdministration extends ilSoapAdministration
         return false;
     }
 
-    public function getFileXML(string $sid, int $ref_id, int $attachFileContentsMode)
+    public function getFileXML(string $sid, int $requested_ref_id, int $attachFileContentsMode)
     {
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
-        if (!strlen($ref_id)) {
-            return $this->__raiseError(
+
+        if (!($requested_ref_id > 0)) {
+            return $this->raiseError(
                 'No ref id given. Aborting!',
                 'Client'
             );
         }
+
         global $DIC;
 
         $rbacsystem = $DIC['rbacsystem'];
@@ -193,19 +194,17 @@ class ilSoapFileAdministration extends ilSoapAdministration
         $ilLog = $DIC['ilLog'];
         $ilAccess = $DIC['ilAccess'];
 
-        // get obj_id
-        if (!$obj_id = ilObject::_lookupObjectId($ref_id)) {
-            return $this->__raiseError(
-                'No File found for id: ' . $ref_id,
+        if (!$obj_id = ilObject::_lookupObjectId($requested_ref_id)) {
+            return $this->raiseError(
+                'No File found for id: ' . $requested_ref_id,
                 'Client'
             );
         }
 
-        if (ilObject::_isInTrash($ref_id)) {
-            return $this->__raiseError("Object with ID $ref_id has been deleted.", 'Client');
+        if (ilObject::_isInTrash($requested_ref_id)) {
+            return $this->raiseError("Object with ID $requested_ref_id has been deleted.", 'Client');
         }
 
-        // Check access
         $permission_ok = false;
         foreach ($ref_ids = ilObject::_getAllReferences($obj_id) as $ref_id) {
             if ($ilAccess->checkAccess('read', '', $ref_id)) {
@@ -215,24 +214,24 @@ class ilSoapFileAdministration extends ilSoapAdministration
         }
 
         if (!$permission_ok) {
-            return $this->__raiseError(
-                'No permission to edit the object with id: ' . $ref_id,
+            return $this->raiseError(
+                'No permission to edit the object with id: ' . $requested_ref_id,
                 'Server'
             );
         }
 
+        /** @var ilObjFile $file */
         $file = ilObjectFactory::getInstanceByObjId($obj_id, false);
 
-        if (!is_object($file) || $file->getType() != "file") {
-            return $this->__raiseError(
-                'Wrong obj id or type for File with id ' . $ref_id,
+        if (!is_object($file) || $file->getType() !== "file") {
+            return $this->raiseError(
+                'Wrong obj id or type for File with id ' . $requested_ref_id,
                 'Server'
             );
         }
-        // store into xml result set
+
         include_once './Modules/File/classes/class.ilFileXMLWriter.php';
 
-        // create writer
         $xmlWriter = new ilFileXMLWriter();
         $xmlWriter->setFile($file);
         $xmlWriter->setAttachFileContents($attachFileContentsMode);

--- a/webservice/soap/classes/class.ilSoapGLOStructureReader.php
+++ b/webservice/soap/classes/class.ilSoapGLOStructureReader.php
@@ -35,13 +35,12 @@ class ilSoapGLOStructureReader extends ilSoapStructureReader
     public function _parseStructure() : void
     {
         /* @var $object ilObjGlossary */
+        $object = $this->object;
 
         $terms = $this->object->getTermList();
         foreach ($terms as $term) {
-
-            /* @var $termStructureObject ilSoapGLOTermStructureObject */
             $termStructureObject = ilSoapStructureObjectFactory::getInstance(
-                $term["id"],
+                (int) $term["id"],
                 "git",
                 $term["term"],
                 "",
@@ -50,11 +49,10 @@ class ilSoapGLOStructureReader extends ilSoapStructureReader
 
             $this->structureObject->addStructureObject($termStructureObject);
 
-            $defs = ilGlossaryDefinition::getDefinitionList($term["id"]);
-
+            $defs = ilGlossaryDefinition::getDefinitionList((int) $term["id"]);
             foreach ($defs as $def) {
                 $defStructureObject = ilSoapStructureObjectFactory::getInstance(
-                    $def["id"],
+                    (int) $def["id"],
                     "gdf",
                     $def["short_text"],
                     "",

--- a/webservice/soap/classes/class.ilSoapGLOTermDefinitionStructureObject.php
+++ b/webservice/soap/classes/class.ilSoapGLOTermDefinitionStructureObject.php
@@ -40,7 +40,6 @@ class ilSoapGLOTermDefinitionStructureObject extends ilSoapStructureObject
 
     public function getGotoLink() : string
     {
-        /* @var $ilInit ilInitialisation */
         return "";
     }
 }

--- a/webservice/soap/classes/class.ilSoapGroupAdministration.php
+++ b/webservice/soap/classes/class.ilSoapGroupAdministration.php
@@ -35,21 +35,13 @@ class ilSoapGroupAdministration extends ilSoapAdministration
     public const ADMIN = 2;
     public const OWNER = 4;
 
-    // Service methods
     public function addGroup(string $sid, int $target_id, string $grp_xml)
     {
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
-        }
-
-        if (!is_numeric($target_id)) {
-            return $this->__raiseError(
-                'No valid target id given. Please choose an existing reference id of an ILIAS category or group',
-                'Client'
-            );
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
@@ -57,11 +49,11 @@ class ilSoapGroupAdministration extends ilSoapAdministration
         $rbacsystem = $DIC['rbacsystem'];
 
         if (!$rbacsystem->checkAccess('create', $target_id, 'grp')) {
-            return $this->__raiseError('Check access failed. No permission to create groups', 'Server');
+            return $this->raiseError('Check access failed. No permission to create groups', 'Server');
         }
 
         if (ilObject::_isInTrash($target_id)) {
-            return $this->__raiseError("Parent with ID $target_id has been deleted.", 'CLIENT_TARGET_DELETED');
+            return $this->raiseError("Parent with ID $target_id has been deleted.", 'CLIENT_TARGET_DELETED');
         }
 
         $newObj = new ilObjGroup();
@@ -69,7 +61,6 @@ class ilSoapGroupAdministration extends ilSoapAdministration
         $newObj->setDescription("");
         $newObj->create();
 
-        // Start import
         include_once("./Modules/Group/classes/class.ilObjGroup.php");
         include_once 'Modules/Group/classes/class.ilGroupXMLParser.php';
         $xml_parser = new ilGroupXMLParser($newObj, $grp_xml, $target_id);
@@ -79,21 +70,13 @@ class ilSoapGroupAdministration extends ilSoapAdministration
         return $new_ref_id ?: "0";
     }
 
-    // Service methods
     public function updateGroup(string $sid, int $ref_id, string $grp_xml)
     {
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
-        }
-
-        if (!is_numeric($ref_id)) {
-            return $this->__raiseError(
-                'No valid target id given. Please choose an existing reference id of an ILIAS category or group',
-                'Client'
-            );
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
@@ -101,22 +84,22 @@ class ilSoapGroupAdministration extends ilSoapAdministration
         $rbacsystem = $DIC['rbacsystem'];
 
         if (!$rbacsystem->checkAccess('write', $ref_id, 'grp')) {
-            return $this->__raiseError('Check access failed. No permission to edit groups', 'Server');
+            return $this->raiseError('Check access failed. No permission to edit groups', 'Server');
         }
 
-        // Start import
         include_once("./Modules/Group/classes/class.ilObjGroup.php");
 
+        /** @var ilObjGroup $grp */
         if (!$grp = ilObjectFactory::getInstanceByRefId($ref_id, false)) {
-            return $this->__raiseError('Cannot create group instance!', 'CLIENT_OBJECT_NOT_FOUND');
+            return $this->raiseError('Cannot create group instance!', 'CLIENT_OBJECT_NOT_FOUND');
         }
 
         if (ilObject::_isInTrash($ref_id)) {
-            return $this->__raiseError("Object with ID $ref_id has been deleted.", 'CLIENT_OBJECT_DELETED');
+            return $this->raiseError("Object with ID $ref_id has been deleted.", 'CLIENT_OBJECT_DELETED');
         }
 
-        if (ilObjectFactory::getTypeByRefId($ref_id, false) != "grp") {
-            return $this->__raiseError('Reference id does not point to a group!', 'CLIENT_WRONG_TYPE');
+        if (ilObjectFactory::getTypeByRefId($ref_id, false) !== "grp") {
+            return $this->raiseError('Reference id does not point to a group!', 'CLIENT_WRONG_TYPE');
         }
 
         include_once 'Modules/Group/classes/class.ilGroupXMLParser.php';
@@ -133,12 +116,12 @@ class ilSoapGroupAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         if (!$title) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No title given. Please choose an title for the group in question.',
                 'Client'
             );
@@ -152,16 +135,17 @@ class ilSoapGroupAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         if (ilObject::_isInTrash($ref_id)) {
-            return $this->__raiseError("Parent with ID $ref_id has been deleted.", 'CLIENT_OBJECT_DELETED');
+            return $this->raiseError("Parent with ID $ref_id has been deleted.", 'CLIENT_OBJECT_DELETED');
         }
 
+        /** @var ilObjGroup $grp_obj */
         if (!$grp_obj = ilObjectFactory::getInstanceByRefId($ref_id, false)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No valid reference id given.',
                 'Client'
             );
@@ -170,8 +154,8 @@ class ilSoapGroupAdministration extends ilSoapAdministration
         include_once 'Modules/Group/classes/class.ilGroupXMLWriter.php';
         $xml_writer = new ilGroupXMLWriter($grp_obj);
         $xml_writer->start();
-        $xml = $xml_writer->getXML();
-        return strlen($xml) ? $xml : '';
+
+        return $xml_writer->getXML();
     }
 
     public function assignGroupMember(string $sid, int $group_id, int $user_id, string $type)
@@ -179,26 +163,19 @@ class ilSoapGroupAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
-        }
-
-        if (!is_numeric($group_id)) {
-            return $this->__raiseError(
-                'No valid group id given. Please choose an existing reference id of an ILIAS group',
-                'Client'
-            );
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
 
         $rbacsystem = $DIC['rbacsystem'];
 
-        if (($obj_type = ilObject::_lookupType(ilObject::_lookupObjId($group_id))) != 'grp') {
+        if (ilObject::_lookupType(ilObject::_lookupObjId($group_id)) !== 'grp') {
             $ref_ids = ilObject::_getAllReferences($group_id);
             $group_id = end($ref_ids);
-            if (ilObject::_lookupType(ilObject::_lookupObjId($group_id)) != 'grp') {
-                return $this->__raiseError(
+            if (ilObject::_lookupType(ilObject::_lookupObjId($group_id)) !== 'grp') {
+                return $this->raiseError(
                     'Invalid group id. Object with id "' . $group_id . '" is not of type "group"',
                     'Client'
                 );
@@ -206,26 +183,28 @@ class ilSoapGroupAdministration extends ilSoapAdministration
         }
 
         if (!$rbacsystem->checkAccess('manage_members', $group_id)) {
-            return $this->__raiseError('Check access failed. No permission to write to group', 'Server');
+            return $this->raiseError('Check access failed. No permission to write to group', 'Server');
         }
 
-        if (ilObject::_lookupType($user_id) != 'usr') {
-            return $this->__raiseError('Invalid user id. User with id "' . $user_id . ' does not exist', 'Client');
+        if (ilObject::_lookupType($user_id) !== 'usr') {
+            return $this->raiseError('Invalid user id. User with id "' . $user_id . ' does not exist', 'Client');
         }
-        if ($type != 'Admin' and
-            $type != 'Member') {
-            return $this->__raiseError(
+        if ($type !== 'Admin' &&
+            $type !== 'Member') {
+            return $this->raiseError(
                 'Invalid type ' . $type . ' given. Parameter "type" must be "Admin","Member"',
                 'Client'
             );
         }
 
+        /** @var ilObjGroup $tmp_group */
         if (!$tmp_group = ilObjectFactory::getInstanceByRefId($group_id, false)) {
-            return $this->__raiseError('Cannot create group instance!', 'Server');
+            return $this->raiseError('Cannot create group instance!', 'Server');
         }
 
+        /** @var ilObjUser $tmp_user */
         if (!$tmp_user = ilObjectFactory::getInstanceByObjId($user_id, false)) {
-            return $this->__raiseError('Cannot create user instance!', 'Server');
+            return $this->raiseError('Cannot create user instance!', 'Server');
         }
 
         include_once 'Modules/Group/classes/class.ilGroupParticipants.php';
@@ -248,41 +227,36 @@ class ilSoapGroupAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
-        }
-        if (!is_numeric($group_id)) {
-            return $this->__raiseError(
-                'No valid group id given. Please choose an existing reference id of an ILIAS group',
-                'Client'
-            );
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
 
         $rbacsystem = $DIC['rbacsystem'];
 
-        if (($type = ilObject::_lookupType(ilObject::_lookupObjId($group_id))) != 'grp') {
+        if (ilObject::_lookupType(ilObject::_lookupObjId($group_id)) !== 'grp') {
             $ref_ids = ilObject::_getAllReferences($group_id);
             $group_id = end($ref_ids);
-            if (ilObject::_lookupType(ilObject::_lookupObjId($group_id)) != 'grp') {
-                return $this->__raiseError(
+            if (ilObject::_lookupType(ilObject::_lookupObjId($group_id)) !== 'grp') {
+                return $this->raiseError(
                     'Invalid group id. Object with id "' . $group_id . '" is not of type "group"',
                     'Client'
                 );
             }
         }
 
-        if (ilObject::_lookupType($user_id) != 'usr') {
-            return $this->__raiseError('Invalid user id. User with id "' . $user_id . ' does not exist', 'Client');
+        if (ilObject::_lookupType($user_id) !== 'usr') {
+            return $this->raiseError('Invalid user id. User with id "' . $user_id . ' does not exist', 'Client');
         }
 
+        /** @var ilObjGroup $tmp_group */
         if (!$tmp_group = ilObjectFactory::getInstanceByRefId($group_id, false)) {
-            return $this->__raiseError('Cannot create group instance!', 'Server');
+            return $this->raiseError('Cannot create group instance!', 'Server');
         }
 
         if (!$rbacsystem->checkAccess('manage_members', $group_id)) {
-            return $this->__raiseError('Check access failed. No permission to write to group', 'Server');
+            return $this->raiseError('Check access failed. No permission to write to group', 'Server');
         }
 
         $tmp_group->leave($user_id);
@@ -294,40 +268,36 @@ class ilSoapGroupAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
-        if (!is_numeric($group_id)) {
-            return $this->__raiseError(
-                'No valid group id given. Please choose an existing id of an ILIAS group',
-                'Client'
-            );
-        }
+
         global $DIC;
 
         $rbacsystem = $DIC['rbacsystem'];
 
-        if (($type = ilObject::_lookupType(ilObject::_lookupObjId($group_id))) != 'grp') {
+        if (ilObject::_lookupType(ilObject::_lookupObjId($group_id)) !== 'grp') {
             $ref_ids = ilObject::_getAllReferences($group_id);
             $group_id = end($ref_ids);
-            if (ilObject::_lookupType(ilObject::_lookupObjId($group_id)) != 'grp') {
-                return $this->__raiseError(
+            if (ilObject::_lookupType(ilObject::_lookupObjId($group_id)) !== 'grp') {
+                return $this->raiseError(
                     'Invalid group id. Object with id "' . $group_id . '" is not of type "group"',
                     'Client'
                 );
             }
         }
 
-        if (ilObject::_lookupType($user_id) != 'usr') {
-            return $this->__raiseError('Invalid user id. User with id "' . $user_id . ' does not exist', 'Client');
+        if (ilObject::_lookupType($user_id) !== 'usr') {
+            return $this->raiseError('Invalid user id. User with id "' . $user_id . ' does not exist', 'Client');
         }
 
+        /** @var ilObjGroup $tmp_group */
         if (!$tmp_group = ilObjectFactory::getInstanceByRefId($group_id, false)) {
-            return $this->__raiseError('Cannot create group instance!', 'Server');
+            return $this->raiseError('Cannot create group instance!', 'Server');
         }
 
         if (!$rbacsystem->checkAccess('read', $group_id)) {
-            return $this->__raiseError('Check access failed. No permission to read group data', 'Server');
+            return $this->raiseError('Check access failed. No permission to read group data', 'Server');
         }
 
         include_once('./Modules/Group/classes/class.ilGroupParticipants.php');
@@ -347,8 +317,8 @@ class ilSoapGroupAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
         global $DIC;
 
@@ -361,16 +331,16 @@ class ilSoapGroupAdministration extends ilSoapAdministration
         try {
             $parser->startParsing();
         } catch (ilSaxParserException $exception) {
-            return $this->__raiseError($exception->getMessage(), "Client");
+            return $this->raiseError($exception->getMessage(), "Client");
         }
         $xmlResultSet = $parser->getXMLResultSet();
 
         if (!$xmlResultSet->hasColumn("user_id")) {
-            return $this->__raiseError("parameter user_id is missing", "Client");
+            return $this->raiseError("parameter user_id is missing", "Client");
         }
 
         if (!$xmlResultSet->hasColumn("status")) {
-            return $this->__raiseError("parameter status is missing", "Client");
+            return $this->raiseError("parameter status is missing", "Client");
         }
 
         $user_id = (int) $xmlResultSet->getValue(0, "user_id");
@@ -378,16 +348,12 @@ class ilSoapGroupAdministration extends ilSoapAdministration
 
         $ref_ids = array();
 
-        // get roles
-        #var_dump($xmlResultSet);
-        #echo "uid:".$user_id;
-        #echo "status:".$status;
         if (ilSoapGroupAdministration::MEMBER == ($status & ilSoapGroupAdministration::MEMBER) ||
             ilSoapGroupAdministration::ADMIN == ($status & ilSoapGroupAdministration::ADMIN)) {
             foreach ($rbacreview->assignedRoles($user_id) as $role_id) {
                 if ($role = ilObjectFactory::getInstanceByObjId($role_id, false)) {
                     #echo $role->getType();
-                    if ($role->getType() != "role") {
+                    if ($role->getType() !== "role") {
                         continue;
                     }
 
@@ -438,7 +404,6 @@ class ilSoapGroupAdministration extends ilSoapAdministration
         }
         $ref_ids = array_unique($ref_ids);
 
-        #print_r($ref_ids);
         include_once 'webservice/soap/classes/class.ilXMLResultSetWriter.php';
         include_once 'Modules/Group/classes/class.ilObjGroup.php';
         include_once 'Modules/Group/classes/class.ilGroupXMLWriter.php';

--- a/webservice/soap/classes/class.ilSoapGroupAdministration.php
+++ b/webservice/soap/classes/class.ilSoapGroupAdministration.php
@@ -198,8 +198,10 @@ class ilSoapGroupAdministration extends ilSoapAdministration
             $ref_ids = ilObject::_getAllReferences($group_id);
             $group_id = end($ref_ids);
             if (ilObject::_lookupType(ilObject::_lookupObjId($group_id)) != 'grp') {
-                return $this->__raiseError('Invalid group id. Object with id "' . $group_id . '" is not of type "group"',
-                    'Client');
+                return $this->__raiseError(
+                    'Invalid group id. Object with id "' . $group_id . '" is not of type "group"',
+                    'Client'
+                );
             }
         }
 
@@ -212,8 +214,10 @@ class ilSoapGroupAdministration extends ilSoapAdministration
         }
         if ($type != 'Admin' and
             $type != 'Member') {
-            return $this->__raiseError('Invalid type ' . $type . ' given. Parameter "type" must be "Admin","Member"',
-                'Client');
+            return $this->__raiseError(
+                'Invalid type ' . $type . ' given. Parameter "type" must be "Admin","Member"',
+                'Client'
+            );
         }
 
         if (!$tmp_group = ilObjectFactory::getInstanceByRefId($group_id, false)) {
@@ -262,8 +266,10 @@ class ilSoapGroupAdministration extends ilSoapAdministration
             $ref_ids = ilObject::_getAllReferences($group_id);
             $group_id = end($ref_ids);
             if (ilObject::_lookupType(ilObject::_lookupObjId($group_id)) != 'grp') {
-                return $this->__raiseError('Invalid group id. Object with id "' . $group_id . '" is not of type "group"',
-                    'Client');
+                return $this->__raiseError(
+                    'Invalid group id. Object with id "' . $group_id . '" is not of type "group"',
+                    'Client'
+                );
             }
         }
 
@@ -305,8 +311,10 @@ class ilSoapGroupAdministration extends ilSoapAdministration
             $ref_ids = ilObject::_getAllReferences($group_id);
             $group_id = end($ref_ids);
             if (ilObject::_lookupType(ilObject::_lookupObjId($group_id)) != 'grp') {
-                return $this->__raiseError('Invalid group id. Object with id "' . $group_id . '" is not of type "group"',
-                    'Client');
+                return $this->__raiseError(
+                    'Invalid group id. Object with id "' . $group_id . '" is not of type "group"',
+                    'Client'
+                );
             }
         }
 
@@ -374,8 +382,8 @@ class ilSoapGroupAdministration extends ilSoapAdministration
         #var_dump($xmlResultSet);
         #echo "uid:".$user_id;
         #echo "status:".$status;
-        if (ilSoapGroupAdministration::MEMBER == ($status&ilSoapGroupAdministration::MEMBER) ||
-            ilSoapGroupAdministration::ADMIN == ($status&ilSoapGroupAdministration::ADMIN)) {
+        if (ilSoapGroupAdministration::MEMBER == ($status & ilSoapGroupAdministration::MEMBER) ||
+            ilSoapGroupAdministration::ADMIN == ($status & ilSoapGroupAdministration::ADMIN)) {
             foreach ($rbacreview->assignedRoles($user_id) as $role_id) {
                 if ($role = ilObjectFactory::getInstanceByObjId($role_id, false)) {
                     #echo $role->getType();
@@ -394,11 +402,15 @@ class ilSoapGroupAdministration extends ilSoapAdministration
                         }
 
                         #echo $role_title;
-                        if (ilSoapGroupAdministration::MEMBER == ($status&ilSoapGroupAdministration::MEMBER) && strpos($role_title,
-                                "member") !== false) {
+                        if (ilSoapGroupAdministration::MEMBER == ($status & ilSoapGroupAdministration::MEMBER) && strpos(
+                            $role_title,
+                            "member"
+                        ) !== false) {
                             $ref_ids [] = $ref_id;
-                        } elseif (ilSoapGroupAdministration::ADMIN == ($status&ilSoapGroupAdministration::ADMIN) && strpos($role_title,
-                                "admin") !== false) {
+                        } elseif (ilSoapGroupAdministration::ADMIN == ($status & ilSoapGroupAdministration::ADMIN) && strpos(
+                            $role_title,
+                            "admin"
+                        ) !== false) {
                             $ref_ids [] = $ref_id;
                         }
                     }
@@ -406,7 +418,7 @@ class ilSoapGroupAdministration extends ilSoapAdministration
             }
         }
 
-        if (($status&ilSoapGroupAdministration::OWNER) == ilSoapGroupAdministration::OWNER) {
+        if (($status & ilSoapGroupAdministration::OWNER) == ilSoapGroupAdministration::OWNER) {
             $owned_objects = ilObjectFactory::getObjectsForOwner("grp", $user_id);
             foreach ($owned_objects as $obj_id) {
                 $allrefs = ilObject::_getAllReferences($obj_id);

--- a/webservice/soap/classes/class.ilSoapInstallationInfoXMLWriter.php
+++ b/webservice/soap/classes/class.ilSoapInstallationInfoXMLWriter.php
@@ -100,8 +100,11 @@ class ilSoapInstallationInfoXMLWriter extends ilXmlWriter
     private function __buildInstallationInfo() : void
     {
         $this->xmlStartTag("Settings");
-        $this->xmlElement("Setting", array("key" => "default_client"),
-            $GLOBALS['DIC']['ilIliasIniFile']->readVariable("clients", "default"));
+        $this->xmlElement(
+            "Setting",
+            array("key" => "default_client"),
+            $GLOBALS['DIC']['ilIliasIniFile']->readVariable("clients", "default")
+        );
         $this->xmlEndTag("Settings");
     }
 }

--- a/webservice/soap/classes/class.ilSoapInstallationInfoXMLWriter.php
+++ b/webservice/soap/classes/class.ilSoapInstallationInfoXMLWriter.php
@@ -8,32 +8,29 @@ class ilSoapInstallationInfoXMLWriter extends ilXmlWriter
 {
     protected array $settings = [];
 
-    /**
-     * write access to property settings
-     */
-    public function setSettings(array $settings)
+    public function setSettings(array $settings) : void
     {
         $this->settings = $settings;
     }
 
     public function start() : void
     {
-        $this->__buildHeader();
-        $this->__buildInstallationInfo();
+        $this->buildHeader();
+        $this->buildInstallationInfo();
         $this->xmlStartTag("Clients");
     }
 
     public function addClient(?ilSetting $client) : void
     {
-        if (is_object($client)) {
-            $this->__buildClient($client);
+        if ($client instanceof ilSetting) {
+            $this->buildClient($client);
         }
     }
 
     public function end() : void
     {
         $this->xmlEndTag("Clients");
-        $this->__buildFooter();
+        $this->buildFooter();
     }
 
     public function getXML() : string
@@ -41,7 +38,7 @@ class ilSoapInstallationInfoXMLWriter extends ilXmlWriter
         return $this->xmlDumpMem(false);
     }
 
-    private function __buildHeader() : void
+    private function buildHeader() : void
     {
         // we have to build the http path here since this request is client independent!
         $httpPath = ilSoapFunctions::buildHTTPPath();
@@ -57,19 +54,19 @@ class ilSoapInstallationInfoXMLWriter extends ilXmlWriter
         );
     }
 
-    private function __buildFooter() : void
+    private function buildFooter() : void
     {
         $this->xmlEndTag('Installation');
     }
 
-    private function __buildClient(ilSetting $setting) : void
+    private function buildClient(ilSetting $setting) : void
     {
         // determine skins/styles
-        $skin_styles = array();
+        $skin_styles = array();// TODO PHP8-REVIEW Unnecessary operations
         include_once("./Services/Style/System/classes/class.ilStyleDefinition.php");
-        $skins = ilStyleDefinition::getAllSkins();
+        $skins = ilStyleDefinition::getAllSkins();// TODO PHP8-REVIEW Unnecessary operations
 
-        if (is_array($skins)) {
+        if (is_array($skins)) {// TODO PHP8-REVIEW Unnecessary operations
             foreach ($skins as $skin) {
                 foreach ($skin->getStyles() as $style) {
                     include_once("./Services/Style/System/classes/class.ilSystemStyleSettings.php");
@@ -82,22 +79,22 @@ class ilSoapInstallationInfoXMLWriter extends ilXmlWriter
         }
 
         // timezones
-        include_once('Services/Calendar/classes/class.ilTimeZone.php');
+        include_once('Services/Calendar/classes/class.ilTimeZone.php');// TODO PHP8-REVIEW Unnecessary operations
 
         $this->xmlStartTag(
             "Client",
             array(
                 "inst_id" => $setting->get("inst_id"),
-                "id" => $setting->clientid,
-                "enabled" => $setting->access == 1 ? "TRUE" : "FALSE",
-                "default_lang" => $setting->language,
+                "id" => $setting->clientid,// TODO PHP8-REVIEW Property dynamically declared
+                "enabled" => $setting->access == 1 ? "TRUE" : "FALSE",// TODO PHP8-REVIEW Property dynamically declared
+                "default_lang" => $setting->language,// TODO PHP8-REVIEW Property dynamically declared
 
             )
         );
         $this->xmlEndTag("Client");
     }
 
-    private function __buildInstallationInfo() : void
+    private function buildInstallationInfo() : void
     {
         $this->xmlStartTag("Settings");
         $this->xmlElement(

--- a/webservice/soap/classes/class.ilSoapLMStructureReader.php
+++ b/webservice/soap/classes/class.ilSoapLMStructureReader.php
@@ -34,38 +34,36 @@ class ilSoapLMStructureReader extends ilSoapStructureReader
 {
     public function _parseStructure() : void
     {
-        // get all child nodes in LM
-        $ctree = $this->object->getLMTree();
+        /** @var ilObjLearningModule $obect */
+        $obect = $this->object;
+        
+        $ctree = $obect->getLMTree();
 
-        $nodes = $ctree->getSubtree($ctree->getNodeData($ctree->getRootId()));
+        $nodes = $ctree->getSubTree($ctree->getNodeData($ctree->getRootId()));
 
         $currentParentStructureObject = $this->structureObject;
         $currentParent = 1;
 
-        $parents = array();
-        $parents [$currentParent] = $currentParentStructureObject;
+        $parents = [];
+        $parents[$currentParent] = $currentParentStructureObject;
 
         $lastStructureObject = null;
         $lastNode = null;
-        $i = 0;
         foreach ($nodes as $node) {
 
             // only pages and chapters
-            if ($node["type"] == "st" || $node["type"] == "pg") {
+            if ($node["type"] === "st" || $node["type"] === "pg") {
                 // parent has changed, to build a tree
-                if ($currentParent != $node["parent"]) {
+                if ((int) $currentParent !== (int) $node["parent"]) {
                     // did we passed this parent before?
 
                     if (array_key_exists($node["parent"], $parents)) {
                         $currentParentStructureObject = $parents[$node["parent"]];
-                    } else {
+                    } elseif ($lastNode["type"] !== "pg") {
                         // no, we did not, so use the last inserted structure as new parent
-                        if ($lastNode["type"] != "pg") {
-                            $parents[$lastNode["child"]] = $lastStructureObject;
-                            $currentParentStructureObject = $lastStructureObject;
-                        }
+                        $parents[$lastNode["child"]] = $lastStructureObject;
+                        $currentParentStructureObject = $lastStructureObject;
                     }
-                    $i++;
                     $currentParent = $lastNode["child"];
                 }
 

--- a/webservice/soap/classes/class.ilSoapLMStructureReader.php
+++ b/webservice/soap/classes/class.ilSoapLMStructureReader.php
@@ -32,7 +32,6 @@ include_once "./webservice/soap/classes/class.ilSoapStructureObjectFactory.php";
  */
 class ilSoapLMStructureReader extends ilSoapStructureReader
 {
-
     public function _parseStructure() : void
     {
         // get all child nodes in LM
@@ -72,8 +71,13 @@ class ilSoapLMStructureReader extends ilSoapStructureReader
 
                 $lastNode = $node;
 
-                $lastStructureObject = ilSoapStructureObjectFactory::getInstance($node["obj_id"], $node["type"],
-                    $node["title"], $node["description"], $this->getObject()->getRefId());
+                $lastStructureObject = ilSoapStructureObjectFactory::getInstance(
+                    $node["obj_id"],
+                    $node["type"],
+                    $node["title"],
+                    $node["description"],
+                    $this->getObject()->getRefId()
+                );
 
                 $currentParentStructureObject->addStructureObject($lastStructureObject);
             }

--- a/webservice/soap/classes/class.ilSoapLearningProgressAdministration.php
+++ b/webservice/soap/classes/class.ilSoapLearningProgressAdministration.php
@@ -11,7 +11,8 @@ include_once './webservice/soap/classes/class.ilSoapAdministration.php';
  */
 class ilSoapLearningProgressAdministration extends ilSoapAdministration
 {
-    protected static $DELETE_PROGRESS_FILTER_TYPES = array('sahs', 'tst');
+    /** @var string[] */
+    protected static $DELETE_PROGRESS_FILTER_TYPES = ['sahs', 'tst'];
 
     public const PROGRESS_FILTER_ALL = 0;
     public const PROGRESS_FILTER_IN_PROGRESS = 1;
@@ -26,13 +27,14 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
     public const SOAP_LP_ERROR_NO_PERMISSION = 58;
     public const SOAP_LP_ERROR_LP_NOT_ENABLED = 60;
 
-    protected static $PROGRESS_INFO_TYPES = array(
+    /** @var int[] */
+    protected static $PROGRESS_INFO_TYPES = [
         self::PROGRESS_FILTER_ALL,
         self::PROGRESS_FILTER_IN_PROGRESS,
         self::PROGRESS_FILTER_COMPLETED,
         self::PROGRESS_FILTER_FAILED,
         self::PROGRESS_FILTER_NOT_ATTEMPTED
-    );
+    ];
 
     public const USER_FILTER_ALL = -1;
 
@@ -52,19 +54,17 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
             $type_filter = (array) $type_filter;
         }
 
-        // Check session
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
-        // Check filter
         if (array_diff((array) $type_filter, self::$DELETE_PROGRESS_FILTER_TYPES)) {
-            return $this->__raiseError('Invalid filter type given', 'Client');
+            return $this->raiseError('Invalid filter type given', 'Client');
         }
 
         include_once 'Services/User/classes/class.ilObjUser.php';
-        if (!in_array(self::USER_FILTER_ALL, $usr_ids) and !ilObjUser::userExists($usr_ids)) {
-            return $this->__raiseError('Invalid user ids given', 'Client');
+        if (!in_array(self::USER_FILTER_ALL, $usr_ids) && !ilObjUser::userExists($usr_ids)) {
+            return $this->raiseError('Invalid user ids given', 'Client');
         }
 
         $valid_refs = array();
@@ -88,7 +88,7 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
                 foreach ($all_sub_objs as $child_ref) {
                     $child_type = ilObject::_lookupType(ilObject::_lookupObjId($child_ref));
                     if (!$GLOBALS['DIC']['ilAccess']->checkAccess('write', '', $child_ref)) {
-                        return $this->__raiseError(
+                        return $this->raiseError(
                             'Permission denied for : ' . $ref_id . ' -> type ' . $type,
                             'Client'
                         );
@@ -97,11 +97,11 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
                 }
             } elseif (in_array($type, $type_filter)) {
                 if (!$GLOBALS['DIC']['ilAccess']->checkAccess('write', '', $ref_id)) {
-                    return $this->__raiseError('Permission denied for : ' . $ref_id . ' -> type ' . $type, 'Client');
+                    return $this->raiseError('Permission denied for : ' . $ref_id . ' -> type ' . $type, 'Client');
                 }
                 $valid_refs[] = $ref_id;
             } else {
-                return $this->__raiseError(
+                return $this->raiseError(
                     'Invalid object type given for : ' . $ref_id . ' -> type ' . $type,
                     'Client'
                 );
@@ -114,11 +114,11 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
             $obj = ilObjectFactory::getInstanceByRefId($ref_id, false);
 
             if (!$obj instanceof ilObject) {
-                return $this->__raiseError('Invalid reference id given : ' . $ref_id . ' -> type ' . $type, 'Client');
+                return $this->raiseError('Invalid reference id given : ' . $ref_id . ' -> type ' . $type, 'Client');
             }
 
             // filter users
-            $valid_users = $this->applyProgressFilter($obj->getId(), (array) $usr_ids, (array) $progress_filter);
+            $valid_users = $this->applyProgressFilter($obj->getId(), (array) $usr_ids, $progress_filter);
 
             switch ($obj->getType()) {
                 case 'sahs':
@@ -127,11 +127,11 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
 
                     switch ($subtype) {
                         case 'scorm':
-                            $this->deleteScormTracking($obj->getId(), (array) $valid_users);
+                            $this->deleteScormTracking($obj->getId(), $valid_users);
                             break;
 
                         case 'scorm2004':
-                            $this->deleteScorm2004Tracking($obj->getId(), (array) $valid_users);
+                            $this->deleteScorm2004Tracking($obj->getId(), $valid_users);
                             break;
                     }
                     break;
@@ -139,7 +139,7 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
                 case 'tst':
 
                     /** @var $obj ilObjTest */
-                    $obj->removeTestResultsFromSoapLpAdministration(array_values((array) $valid_users));
+                    $obj->removeTestResultsFromSoapLpAdministration(array_values($valid_users));
                     break;
             }
 
@@ -167,16 +167,16 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
         $ilAccess = $DIC->access();
 
         // Check session
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError(
-                'Error ' . self::SOAP_LP_ERROR_AUTHENTICATION . ':' . $this->__getMessage(),
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError(
+                'Error ' . self::SOAP_LP_ERROR_AUTHENTICATION . ':' . $this->getMessage(),
                 self::SOAP_LP_ERROR_AUTHENTICATION
             );
         }
 
         // Check filter
-        if (array_diff((array) $a_progress_filter, self::$PROGRESS_INFO_TYPES)) {
-            return $this->__raiseError(
+        if (array_diff($a_progress_filter, self::$PROGRESS_INFO_TYPES)) {
+            return $this->raiseError(
                 'Error ' . self::SOAP_LP_ERROR_INVALID_FILTER . ': Invalid filter type given',
                 self::SOAP_LP_ERROR_INVALID_FILTER
             );
@@ -184,7 +184,7 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
         // Check LP enabled
         include_once("Services/Tracking/classes/class.ilObjUserTracking.php");
         if (!ilObjUserTracking::_enabledLearningProgress()) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'Error ' . self::SOAP_LP_ERROR_LP_NOT_ENABLED . ': Learning progress not enabled in ILIAS',
                 self::SOAP_LP_ERROR_LP_NOT_ENABLED
             );
@@ -193,7 +193,7 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
         include_once './Services/Object/classes/class.ilObjectFactory.php';
         $obj = ilObjectFactory::getInstanceByRefId($a_ref_id, false);
         if (!$obj instanceof ilObject) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'Error ' . self::SOAP_LP_ERROR_INVALID_REF_ID . ': Invalid reference id ' . $a_ref_id . ' given',
                 self::SOAP_LP_ERROR_INVALID_REF_ID
             );
@@ -202,8 +202,8 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
         // check lp available
         include_once './Services/Tracking/classes/class.ilLPObjSettings.php';
         $mode = ilLPObjSettings::_lookupDBMode($obj->getId());
-        if ($mode == ilLPObjSettings::LP_MODE_UNDEFINED) {
-            return $this->__raiseError(
+        if ($mode === ilLPObjSettings::LP_MODE_UNDEFINED) {
+            return $this->raiseError(
                 'Error ' . self::SOAP_LP_ERROR_LP_NOT_AVAILABLE . ': Learning progress not available for objects of type ' .
                 $obj->getType(),
                 self::SOAP_LP_ERROR_LP_NOT_AVAILABLE
@@ -219,7 +219,7 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
             'read_learning_progress',
             $a_ref_id
         )) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'Error ' . self::SOAP_LP_ERROR_NO_PERMISSION . ': No Permission to access learning progress in this object',
                 self::SOAP_LP_ERROR_NO_PERMISSION
             );
@@ -238,7 +238,7 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
         $writer->xmlStartTag('LearningProgressSummary');
 
         include_once './Services/Tracking/classes/class.ilLPStatusWrapper.php';
-        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) or in_array(
+        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) || in_array(
             self::PROGRESS_FILTER_COMPLETED,
             $a_progress_filter
         )) {
@@ -255,11 +255,11 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
                 'Status',
                 array(
                     'type' => self::PROGRESS_FILTER_COMPLETED,
-                    'num' => (int) $completed
+                    'num' => $completed
                 )
             );
         }
-        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) or in_array(
+        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) || in_array(
             self::PROGRESS_FILTER_IN_PROGRESS,
             $a_progress_filter
         )) {
@@ -276,11 +276,11 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
                 'Status',
                 array(
                     'type' => self::PROGRESS_FILTER_IN_PROGRESS,
-                    'num' => (int) $completed
+                    'num' => $completed
                 )
             );
         }
-        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) or in_array(
+        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) || in_array(
             self::PROGRESS_FILTER_FAILED,
             $a_progress_filter
         )) {
@@ -297,11 +297,11 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
                 'Status',
                 array(
                     'type' => self::PROGRESS_FILTER_FAILED,
-                    'num' => (int) $completed
+                    'num' => $completed
                 )
             );
         }
-        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) or in_array(
+        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) || in_array(
             self::PROGRESS_FILTER_NOT_ATTEMPTED,
             $a_progress_filter
         )) {
@@ -318,13 +318,13 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
                 'Status',
                 array(
                     'type' => self::PROGRESS_FILTER_NOT_ATTEMPTED,
-                    'num' => (int) $completed
+                    'num' => $completed
                 )
             );
         }
         $writer->xmlEndTag('LearningProgressSummary');
         $writer->xmlStartTag('UserProgress');
-        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) or in_array(
+        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) || in_array(
             self::PROGRESS_FILTER_COMPLETED,
             $a_progress_filter
         )) {
@@ -338,7 +338,7 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
 
             $this->addUserProgress($writer, $completed, self::PROGRESS_FILTER_COMPLETED);
         }
-        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) or in_array(
+        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) || in_array(
             self::PROGRESS_FILTER_IN_PROGRESS,
             $a_progress_filter
         )) {
@@ -351,7 +351,7 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
             );
             $this->addUserProgress($writer, $completed, self::PROGRESS_FILTER_IN_PROGRESS);
         }
-        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) or in_array(
+        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) || in_array(
             self::PROGRESS_FILTER_FAILED,
             $a_progress_filter
         )) {
@@ -364,7 +364,7 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
             );
             $this->addUserProgress($writer, $completed, self::PROGRESS_FILTER_FAILED);
         }
-        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) or in_array(
+        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) || in_array(
             self::PROGRESS_FILTER_NOT_ATTEMPTED,
             $a_progress_filter
         )) {
@@ -384,7 +384,7 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
         return $writer->xmlDumpMem();
     }
 
-    protected function addUserProgress(ilXmlWriter $writer, array $users, int $a_type)
+    protected function addUserProgress(ilXmlWriter $writer, array $users, int $a_type) : void
     {
         foreach ($users as $user_id) {
             $writer->xmlStartTag(
@@ -427,7 +427,7 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
             $all_users = $usr_ids;
         }
 
-        if (!$filter or in_array(self::PROGRESS_FILTER_ALL, $filter)) {
+        if (!$filter || in_array(self::PROGRESS_FILTER_ALL, $filter)) {
             $GLOBALS['DIC']['log']->write(__METHOD__ . ': Deleting all progress data');
             return $all_users;
         }
@@ -453,7 +453,7 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
     /**
      * Delete SCORM Tracking
      */
-    protected function deleteScormTracking(int $a_obj_id, array $a_usr_ids)
+    protected function deleteScormTracking(int $a_obj_id, array $a_usr_ids) : bool
     {
         global $DIC;
 
@@ -469,7 +469,7 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
     /**
      * Delete scorm 2004 tracking
      */
-    protected function deleteScorm2004Tracking(int $a_obj_id, array $a_usr_ids)
+    protected function deleteScorm2004Tracking(int $a_obj_id, array $a_usr_ids) : void
     {
         global $DIC;
 
@@ -499,8 +499,8 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
         global $DIC;
 
@@ -525,7 +525,7 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
 
             return $writer->xmlDumpMem(true);
         } catch (UnexpectedValueException $e) {
-            return $this->__raiseError($e->getMessage(), 'Client');
+            return $this->raiseError($e->getMessage(), 'Client');
         }
     }
 }

--- a/webservice/soap/classes/class.ilSoapLearningProgressAdministration.php
+++ b/webservice/soap/classes/class.ilSoapLearningProgressAdministration.php
@@ -69,7 +69,7 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
 
         $valid_refs = array();
         $type = '';
-        foreach ((array) $ref_ids as $ref_id) {
+        foreach ($ref_ids as $ref_id) {
             $obj_id = ilObject::_lookupObjId($ref_id);
             $type = ilObject::_lookupType($obj_id);
 
@@ -486,7 +486,7 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
         }
 
         $query = 'DELETE FROM cmi_node ' .
-            'WHERE ' . $ilDB->in('user_id', (array) $a_usr_ids, false, 'integer') . ' ' .
+            'WHERE ' . $ilDB->in('user_id', $a_usr_ids, false, 'integer') . ' ' .
             'AND ' . $ilDB->in('cp_node_id', $scos, false, 'integer');
         $ilDB->manipulate($query);
     }

--- a/webservice/soap/classes/class.ilSoapLearningProgressAdministration.php
+++ b/webservice/soap/classes/class.ilSoapLearningProgressAdministration.php
@@ -88,8 +88,10 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
                 foreach ($all_sub_objs as $child_ref) {
                     $child_type = ilObject::_lookupType(ilObject::_lookupObjId($child_ref));
                     if (!$GLOBALS['DIC']['ilAccess']->checkAccess('write', '', $child_ref)) {
-                        return $this->__raiseError('Permission denied for : ' . $ref_id . ' -> type ' . $type,
-                            'Client');
+                        return $this->__raiseError(
+                            'Permission denied for : ' . $ref_id . ' -> type ' . $type,
+                            'Client'
+                        );
                     }
                     $valid_refs[] = $child_ref;
                 }
@@ -99,8 +101,10 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
                 }
                 $valid_refs[] = $ref_id;
             } else {
-                return $this->__raiseError('Invalid object type given for : ' . $ref_id . ' -> type ' . $type,
-                    'Client');
+                return $this->__raiseError(
+                    'Invalid object type given for : ' . $ref_id . ' -> type ' . $type,
+                    'Client'
+                );
             }
         }
 
@@ -210,8 +214,11 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
         /**
          * @var ilAccess
          */
-        if (!$ilAccess->checkRbacOrPositionPermissionAccess('read_learning_progress', 'read_learning_progress',
-            $a_ref_id)) {
+        if (!$ilAccess->checkRbacOrPositionPermissionAccess(
+            'read_learning_progress',
+            'read_learning_progress',
+            $a_ref_id
+        )) {
             return $this->__raiseError(
                 'Error ' . self::SOAP_LP_ERROR_NO_PERMISSION . ': No Permission to access learning progress in this object',
                 self::SOAP_LP_ERROR_NO_PERMISSION
@@ -231,8 +238,10 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
         $writer->xmlStartTag('LearningProgressSummary');
 
         include_once './Services/Tracking/classes/class.ilLPStatusWrapper.php';
-        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) or in_array(self::PROGRESS_FILTER_COMPLETED,
-                $a_progress_filter)) {
+        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) or in_array(
+            self::PROGRESS_FILTER_COMPLETED,
+            $a_progress_filter
+        )) {
             $completed = ilLPStatusWrapper::_getCompleted($obj->getId());
             $completed = $GLOBALS['DIC']->access()->filterUserIdsByRbacOrPositionOfCurrentUser(
                 'read_learning_progress',
@@ -250,8 +259,10 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
                 )
             );
         }
-        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) or in_array(self::PROGRESS_FILTER_IN_PROGRESS,
-                $a_progress_filter)) {
+        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) or in_array(
+            self::PROGRESS_FILTER_IN_PROGRESS,
+            $a_progress_filter
+        )) {
             $completed = ilLPStatusWrapper::_getInProgress($obj->getId());
             $completed = $GLOBALS['DIC']->access()->filterUserIdsByRbacOrPositionOfCurrentUser(
                 'read_learning_progress',
@@ -269,8 +280,10 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
                 )
             );
         }
-        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) or in_array(self::PROGRESS_FILTER_FAILED,
-                $a_progress_filter)) {
+        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) or in_array(
+            self::PROGRESS_FILTER_FAILED,
+            $a_progress_filter
+        )) {
             $completed = ilLPStatusWrapper::_getFailed($obj->getId());
             $completed = $GLOBALS['DIC']->access()->filterUserIdsByRbacOrPositionOfCurrentUser(
                 'read_learning_progress',
@@ -288,8 +301,10 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
                 )
             );
         }
-        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) or in_array(self::PROGRESS_FILTER_NOT_ATTEMPTED,
-                $a_progress_filter)) {
+        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) or in_array(
+            self::PROGRESS_FILTER_NOT_ATTEMPTED,
+            $a_progress_filter
+        )) {
             $completed = ilLPStatusWrapper::_getNotAttempted($obj->getId());
             $completed = $GLOBALS['DIC']->access()->filterUserIdsByRbacOrPositionOfCurrentUser(
                 'read_learning_progress',
@@ -309,8 +324,10 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
         }
         $writer->xmlEndTag('LearningProgressSummary');
         $writer->xmlStartTag('UserProgress');
-        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) or in_array(self::PROGRESS_FILTER_COMPLETED,
-                $a_progress_filter)) {
+        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) or in_array(
+            self::PROGRESS_FILTER_COMPLETED,
+            $a_progress_filter
+        )) {
             $completed = ilLPStatusWrapper::_getCompleted($obj->getId());
             $completed = $GLOBALS['DIC']->access()->filterUserIdsByRbacOrPositionOfCurrentUser(
                 'read_learning_progress',
@@ -321,8 +338,10 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
 
             $this->addUserProgress($writer, $completed, self::PROGRESS_FILTER_COMPLETED);
         }
-        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) or in_array(self::PROGRESS_FILTER_IN_PROGRESS,
-                $a_progress_filter)) {
+        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) or in_array(
+            self::PROGRESS_FILTER_IN_PROGRESS,
+            $a_progress_filter
+        )) {
             $completed = ilLPStatusWrapper::_getInProgress($obj->getId());
             $completed = $GLOBALS['DIC']->access()->filterUserIdsByRbacOrPositionOfCurrentUser(
                 'read_learning_progress',
@@ -332,8 +351,10 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
             );
             $this->addUserProgress($writer, $completed, self::PROGRESS_FILTER_IN_PROGRESS);
         }
-        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) or in_array(self::PROGRESS_FILTER_FAILED,
-                $a_progress_filter)) {
+        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) or in_array(
+            self::PROGRESS_FILTER_FAILED,
+            $a_progress_filter
+        )) {
             $completed = ilLPStatusWrapper::_getFailed($obj->getId());
             $completed = $GLOBALS['DIC']->access()->filterUserIdsByRbacOrPositionOfCurrentUser(
                 'read_learning_progress',
@@ -343,8 +364,10 @@ class ilSoapLearningProgressAdministration extends ilSoapAdministration
             );
             $this->addUserProgress($writer, $completed, self::PROGRESS_FILTER_FAILED);
         }
-        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) or in_array(self::PROGRESS_FILTER_NOT_ATTEMPTED,
-                $a_progress_filter)) {
+        if (in_array(self::PROGRESS_FILTER_ALL, $a_progress_filter) or in_array(
+            self::PROGRESS_FILTER_NOT_ATTEMPTED,
+            $a_progress_filter
+        )) {
             $completed = ilLPStatusWrapper::_getNotAttempted($obj->getId());
             $completed = $GLOBALS['DIC']->access()->filterUserIdsByRbacOrPositionOfCurrentUser(
                 'read_learning_progress',

--- a/webservice/soap/classes/class.ilSoapMailXmlParser.php
+++ b/webservice/soap/classes/class.ilSoapMailXmlParser.php
@@ -22,9 +22,6 @@ class ilSoapMailXmlParser extends ilSaxParser
     protected array $lines = [];
     protected string $cdata = '';
 
-    /**
-     * Constructor
-     */
     public function __construct(string $a_xml)
     {
         parent::__construct('', true);
@@ -32,12 +29,9 @@ class ilSoapMailXmlParser extends ilSaxParser
         $this->setXMLContent($a_xml);
     }
 
-    /**
-     * Get parsed mails
-     */
     public function getMails() : array
     {
-        return (array) $this->mails;
+        return $this->mails;
     }
 
     public function start() : bool
@@ -47,9 +41,8 @@ class ilSoapMailXmlParser extends ilSaxParser
     }
 
     /**
-     * set event handlers
-     * @param resource    reference to the xml parser
-     * @access    private
+     * Set event handlers
+     * @param XMLParser|resource A reference to the xml parser
      */
     public function setHandlers($a_xml_parser) : void
     {
@@ -60,9 +53,9 @@ class ilSoapMailXmlParser extends ilSaxParser
 
     /**
      * handler for begin of element
-     * @param resource $a_xml_parser xml parser
-     * @param string   $a_name       element name
-     * @param array    $a_attribs    element attributes array
+     * @param XMLParser|resource $a_xml_parser xml parser
+     * @param string $a_name element name
+     * @param array $a_attribs element attributes array
      */
     public function handlerBeginTag($a_xml_parser, string $a_name, array $a_attribs) : void
     {
@@ -70,7 +63,7 @@ class ilSoapMailXmlParser extends ilSaxParser
             case 'Mail':
                 $this->mail = array();
                 $this->mail['usePlaceholders'] = (bool) $a_attribs['usePlaceholders'];
-                $this->mail['type'] = $a_attribs['type'] == 'System' ? 'system' : 'normal';
+                $this->mail['type'] = $a_attribs['type'] === 'System' ? 'system' : 'normal';
                 break;
 
             case 'To':
@@ -101,9 +94,9 @@ class ilSoapMailXmlParser extends ilSaxParser
     }
 
     /**
-     * handler for end of element
-     * @param resource $a_xml_parser xml parser
-     * @param string   $a_name       element name
+     * Handler for end of element
+     * @param XMLParser|resource $a_xml_parser xml parser
+     * @param string $a_name element name
      */
     public function handlerEndTag($a_xml_parser, string $a_name) : void
     {
@@ -133,16 +126,21 @@ class ilSoapMailXmlParser extends ilSaxParser
         $this->cdata = '';
     }
 
+    /**
+     * @param XMLParser|resource $a_xml_parser
+     * @param string $a_data
+     * @return void
+     */
     public function handlerCharacterData($a_xml_parser, string $a_data) : void
     {
-        if ($a_data != "\n") {
+        if ($a_data !== "\n") {
             // Replace multiple tabs with one space
             $a_data = preg_replace("/\t+/", " ", $a_data);
             $this->cdata .= $a_data;
         }
     }
 
-    protected function parseName(array $a_attribs)
+    protected function parseName(array $a_attribs)// TODO PHP8-REVIEW Return type missing
     {
         if ($a_attribs['obj_id']) {
             $il_id = explode('_', $a_attribs['obj_id']);
@@ -151,8 +149,8 @@ class ilSoapMailXmlParser extends ilSaxParser
                 throw new InvalidArgumentException("Invalid user id given: obj_id => " . $a_attribs['obj_id']);
             }
             return $user->getLogin();
-        } else {
-            return $a_attribs['name'];
         }
+
+        return $a_attribs['name'];
     }
 }

--- a/webservice/soap/classes/class.ilSoapMailXmlParser.php
+++ b/webservice/soap/classes/class.ilSoapMailXmlParser.php
@@ -110,7 +110,7 @@ class ilSoapMailXmlParser extends ilSaxParser
                 break;
 
             case 'Message':
-                $this->mail['body'] = (array) $this->lines;
+                $this->mail['body'] = $this->lines;
                 break;
 
             case 'P':

--- a/webservice/soap/classes/class.ilSoapObjectAdministration.php
+++ b/webservice/soap/classes/class.ilSoapObjectAdministration.php
@@ -32,7 +32,6 @@ include_once './webservice/soap/classes/class.ilSoapAdministration.php';
 
 class ilSoapObjectAdministration extends ilSoapAdministration
 {
-
     public function getObjIdByImportId(string $sid, string $import_id)
     {
         $this->initAuth($sid);
@@ -142,8 +141,10 @@ class ilSoapObjectAdministration extends ilSoapAdministration
                     return $this->__raiseError('No object found for reference ID. Value: ' . $ref_id, 'Client');
                 }
                 if (!ilObject::_hasUntrashedReference($obj_id)) {
-                    return $this->__raiseError('No untrashed reference found for reference ID. Value: ' . $ref_id,
-                        'Client');
+                    return $this->__raiseError(
+                        'No untrashed reference found for reference ID. Value: ' . $ref_id,
+                        'Client'
+                    );
                 }
                 $obj_ids[] = $obj_id;
             }
@@ -643,8 +644,12 @@ class ilSoapObjectAdministration extends ilSoapAdministration
                     break;
                 case 'cat':
                     /** @var $newObj ilObjCategory */
-                    $newObj->addTranslation($object_data["title"], $object_data["description"], $lng->getLangKey(),
-                        true);
+                    $newObj->addTranslation(
+                        $object_data["title"],
+                        $object_data["description"],
+                        $lng->getLangKey(),
+                        true
+                    );
                     break;
             }
 
@@ -958,8 +963,10 @@ class ilSoapObjectAdministration extends ilSoapAdministration
 
                 $obj_id_from_refid = ilObject::_lookupObjectId($object_data["references"][0]);
                 if (!$obj_id_from_refid) {
-                    return $this->__raiseError('No obj_id found for reference id ' . $object_data["references"][0],
-                        'CLIENT_OBJECT_NOT_FOUND');
+                    return $this->__raiseError(
+                        'No obj_id found for reference id ' . $object_data["references"][0],
+                        'CLIENT_OBJECT_NOT_FOUND'
+                    );
                 } else {
                     $tmp_obj = ilObjectFactory::getInstanceByObjId($object_data['obj_id'], false);
                     $object_data["obj_id"] = $obj_id_from_refid;
@@ -968,8 +975,10 @@ class ilSoapObjectAdministration extends ilSoapAdministration
 
             $tmp_obj = ilObjectFactory::getInstanceByObjId($object_data['obj_id'], false);
             if ($tmp_obj == null) {
-                return $this->__raiseError('No object for id ' . $object_data['obj_id'] . '!',
-                    'CLIENT_OBJECT_NOT_FOUND');
+                return $this->__raiseError(
+                    'No object for id ' . $object_data['obj_id'] . '!',
+                    'CLIENT_OBJECT_NOT_FOUND'
+                );
             } else {
                 $object_data["instance"] = $tmp_obj;
             }
@@ -979,8 +988,10 @@ class ilSoapObjectAdministration extends ilSoapAdministration
                 $rolf_id = $rolf_ids[0];
 
                 if (!$rbacsystem->checkAccess('write', $rolf_id)) {
-                    return $this->__raiseError('No write permission for object with id ' . $object_data['obj_id'] . '!',
-                        'Client');
+                    return $this->__raiseError(
+                        'No write permission for object with id ' . $object_data['obj_id'] . '!',
+                        'Client'
+                    );
                 }
             } else {
                 $permission_ok = false;
@@ -991,8 +1002,10 @@ class ilSoapObjectAdministration extends ilSoapAdministration
                     }
                 }
                 if (!$permission_ok) {
-                    return $this->__raiseError('No write permission for object with id ' . $object_data['obj_id'] . '!',
-                        'Client');
+                    return $this->__raiseError(
+                        'No write permission for object with id ' . $object_data['obj_id'] . '!',
+                        'Client'
+                    );
                 }
             }
         }
@@ -1121,8 +1134,10 @@ class ilSoapObjectAdministration extends ilSoapAdministration
 
         // checking copy permissions, objects and create permissions
         if (!$rbacsystem->checkAccess('copy', $xml_parser->getSourceId())) {
-            return $this->__raiseError("Missing copy permissions for object with reference id " . $xml_parser->getSourceId(),
-                'Client');
+            return $this->__raiseError(
+                "Missing copy permissions for object with reference id " . $xml_parser->getSourceId(),
+                'Client'
+            );
         }
 
         // checking copy permissions, objects and create permissions
@@ -1250,8 +1265,10 @@ class ilSoapObjectAdministration extends ilSoapAdministration
 
         $allowed_types = array('root', 'cat', 'grp', 'crs', 'fold');
         if (!in_array($target_type, $allowed_types)) {
-            return $this->__raiseError('No valid target type. Target must be reference id of "course, group, category or folder"',
-                'Client');
+            return $this->__raiseError(
+                'No valid target type. Target must be reference id of "course, group, category or folder"',
+                'Client'
+            );
         }
 
         $allowed_subtypes = $objDefinition->getSubObjects($target_type);
@@ -1264,8 +1281,10 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         }
 
         if (!in_array($type, $allowed)) {
-            return $this->__raiseError('Objects of type: ' . $type . ' are not allowed to be subobjects of type ' . $target_type . '!',
-                'Client');
+            return $this->__raiseError(
+                'Objects of type: ' . $type . ' are not allowed to be subobjects of type ' . $target_type . '!',
+                'Client'
+            );
         }
         if (!$rbacsystem->checkAccess('create', $target_id, $type)) {
             return $this->__raiseError('No permission to create objects of type ' . $type . '!', 'Client');
@@ -1322,8 +1341,10 @@ class ilSoapObjectAdministration extends ilSoapAdministration
                 }
                 // check permissions
                 if (!$ilAccess->checkAccess('write', '', $ref_data['ref_id'])) {
-                    return $this->__raiseError('No write permission for object with reference id ' . $ref_data['ref_id'] . '!',
-                        'Client');
+                    return $this->__raiseError(
+                        'No write permission for object with reference id ' . $ref_data['ref_id'] . '!',
+                        'Client'
+                    );
                 }
                 // TODO: check if all references belong to the same object
             }

--- a/webservice/soap/classes/class.ilSoapObjectAdministration.php
+++ b/webservice/soap/classes/class.ilSoapObjectAdministration.php
@@ -1313,6 +1313,8 @@ class ilSoapObjectAdministration extends ilSoapAdministration
             }
             return true;
         }
+
+        // TODO PHP8-REVIEW Missing return value
     }
 
     private function updateReferences(array $a_object_data) : void

--- a/webservice/soap/classes/class.ilSoapObjectAdministration.php
+++ b/webservice/soap/classes/class.ilSoapObjectAdministration.php
@@ -330,7 +330,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
             $object_search->setFilter($types);
             $res = $object_search->performSearch();
             if ($user_id) {
-                $res->setUserId((int) $user_id);
+                $res->setUserId($user_id);
             }
             $res->setMaxHits(100);
             $res->filter(ROOT_FOLDER_ID, $combination === 'and');

--- a/webservice/soap/classes/class.ilSoapObjectAdministration.php
+++ b/webservice/soap/classes/class.ilSoapObjectAdministration.php
@@ -37,11 +37,11 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
         if (!$import_id) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No import id given.',
                 'Client'
             );
@@ -60,11 +60,11 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
         if (!$import_id) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No import id given.',
                 'Client'
             );
@@ -78,7 +78,6 @@ class ilSoapObjectAdministration extends ilSoapAdministration
 
         $new_refs = [];
         foreach ($ref_ids as $ref_id) {
-            // only get non deleted reference ids
             if ($tree->isInTree($ref_id)) {
                 $new_refs[] = $ref_id;
             }
@@ -91,11 +90,11 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
         if (!$obj_id) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No object id given.',
                 'Client'
             );
@@ -120,35 +119,34 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
-        if (!count($ref_ids) || !is_array($ref_ids)) {
-            return $this->__raiseError('No reference id(s) given.', 'Client');
+        if (!count($ref_ids)) {
+            return $this->raiseError('No reference id(s) given.', 'Client');
         }
 
-        $obj_ids = array();
-        if (count($ref_ids)) {
-            foreach ($ref_ids as $ref_id) {
-                $ref_id = trim($ref_id);
-                if (!is_numeric($ref_id)) {
-                    return $this->__raiseError('Reference ID has to be numeric. Value: ' . $ref_id, 'Client');
-                }
-
-                $obj_id = ilObject::_lookupObjectId($ref_id);
-                if (!$obj_id) {
-                    return $this->__raiseError('No object found for reference ID. Value: ' . $ref_id, 'Client');
-                }
-                if (!ilObject::_hasUntrashedReference($obj_id)) {
-                    return $this->__raiseError(
-                        'No untrashed reference found for reference ID. Value: ' . $ref_id,
-                        'Client'
-                    );
-                }
-                $obj_ids[] = $obj_id;
+        $obj_ids = [];
+        foreach ($ref_ids as $ref_id) {
+            $ref_id = trim($ref_id);
+            if (!is_numeric($ref_id)) {
+                return $this->raiseError('Reference ID has to be numeric. Value: ' . $ref_id, 'Client');
             }
+
+            $obj_id = ilObject::_lookupObjectId($ref_id);
+            if (!$obj_id) {
+                return $this->raiseError('No object found for reference ID. Value: ' . $ref_id, 'Client');
+            }
+            if (!ilObject::_hasUntrashedReference($obj_id)) {
+                return $this->raiseError(
+                    'No untrashed reference found for reference ID. Value: ' . $ref_id,
+                    'Client'
+                );
+            }
+            $obj_ids[] = $obj_id;
         }
+
         return $obj_ids;
     }
 
@@ -157,20 +155,15 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
-        if (!is_numeric($a_ref_id)) {
-            return $this->__raiseError(
-                'No valid reference id given. Please choose an existing reference id of an ILIAS object',
-                'Client'
-            );
-        }
+
         if (!$tmp_obj = ilObjectFactory::getInstanceByRefId($a_ref_id, false)) {
-            return $this->__raiseError('Cannot create object instance!', 'Server');
+            return $this->raiseError('Cannot create object instance!', 'Server');
         }
         if (ilObject::_isInTrash($a_ref_id)) {
-            return $this->__raiseError("Object with ID $a_ref_id has been deleted.", 'Client');
+            return $this->raiseError("Object with ID $a_ref_id has been deleted.", 'Client');
         }
         include_once './webservice/soap/classes/class.ilObjectXMLWriter.php';
 
@@ -184,7 +177,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         if ($xml_writer->start()) {
             return $xml_writer->getXML();
         }
-        return $this->__raiseError('Cannot create object xml !', 'Server');
+        return $this->raiseError('Cannot create object xml !', 'Server');
     }
 
     public function getObjectsByTitle(string $sid, string $a_title, int $user_id)
@@ -192,11 +185,11 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
-        if (!strlen($a_title)) {
-            return $this->__raiseError(
+        if ($a_title === '') {
+            return $this->raiseError(
                 'No valid query string given.',
                 'Client'
             );
@@ -207,7 +200,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $query_parser->setCombination(ilQueryParser::QP_COMBINATION_AND);
         $query_parser->parse();
         if (!$query_parser->validate()) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 $query_parser->getMessage(),
                 'Client'
             );
@@ -221,14 +214,14 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $object_search->appendToFilter('rolt');
         $res = $object_search->performSearch();
         if ($user_id) {
-            $res->setUserId((int) $user_id);
+            $res->setUserId($user_id);
         }
 
         $res->filter(ROOT_FOLDER_ID, true);
 
         $objs = array();
         foreach ($res->getUniqueResults() as $entry) {
-            if ($entry['type'] == 'role' or $entry['type'] == 'rolt') {
+            if ($entry['type'] === 'role' || $entry['type'] === 'rolt') {
                 if ($tmp = ilObjectFactory::getInstanceByObjId($entry['obj_id'], false)) {
                     $objs[] = $tmp;
                 }
@@ -254,7 +247,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         if ($xml_writer->start()) {
             return $xml_writer->getXML();
         }
-        return $this->__raiseError('Cannot create object xml !', 'Server');
+        return $this->raiseError('Cannot create object xml !', 'Server');
     }
 
     public function searchObjects(string $sid, array $types, string $key, string $combination, int $user_id)
@@ -262,23 +255,18 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
-        if (!is_array($types)) {
-            return $this->__raiseError(
-                'Types must be an array of object types.',
-                'Client'
-            );
-        }
-        if ($combination != 'and' and $combination != 'or') {
-            return $this->__raiseError(
+
+        if ($combination !== 'and' && $combination !== 'or') {
+            return $this->raiseError(
                 'No valid combination given. Must be "and" or "or".',
                 'Client'
             );
         }
 
-        $higlighter = null;
+        $highlighter = null;
         include_once './Services/Search/classes/class.ilSearchSettings.php';
         if (ilSearchSettings::getInstance()->enabledLucene()) {
             ilSearchSettings::getInstance()->setMaxHits(25);
@@ -286,12 +274,12 @@ class ilSoapObjectAdministration extends ilSoapAdministration
             $typeFilterQuery = '';
             if (is_array($types)) {
                 foreach ($types as $objectType) {
-                    if (0 === strlen($typeFilterQuery)) {
+                    if ($typeFilterQuery === '') {
                         $typeFilterQuery .= '+( ';
                     } else {
                         $typeFilterQuery .= 'OR';
                     }
-                    $typeFilterQuery .= (' type:' . (string) $objectType . ' ');
+                    $typeFilterQuery .= (' type:' . $objectType . ' ');
                 }
                 $typeFilterQuery .= ') ';
             }
@@ -313,7 +301,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
             $result_ids = $filter->getResults();
             $objs = array();
             $objs[ROOT_FOLDER_ID] = ilObjectFactory::getInstanceByRefId(ROOT_FOLDER_ID, false);
-            foreach ((array) $result_ids as $ref_id => $obj_id) {
+            foreach ($result_ids as $ref_id => $obj_id) {
                 $obj = ilObjectFactory::getInstanceByRefId($ref_id, false);
                 if ($obj instanceof ilObject) {
                     $objs[] = $obj;
@@ -328,18 +316,14 @@ class ilSoapObjectAdministration extends ilSoapAdministration
             include_once './Services/Search/classes/class.ilQueryParser.php';
 
             $query_parser = new ilQueryParser($key);
-            #$query_parser->setMinWordLength(3);
-            $query_parser->setCombination($combination == 'and' ? ilQueryParser::QP_COMBINATION_AND : ilQueryParser::QP_COMBINATION_OR);
+            $query_parser->setCombination($combination === 'and' ? ilQueryParser::QP_COMBINATION_AND : ilQueryParser::QP_COMBINATION_OR);
             $query_parser->parse();
             if (!$query_parser->validate()) {
-                return $this->__raiseError(
+                return $this->raiseError(
                     $query_parser->getMessage(),
                     'Client'
                 );
             }
-
-            #include_once './Services/Search/classes/class.ilObjectSearchFactory.php';
-            #$object_search =& ilObjectSearchFactory::_getObjectSearchInstance($query_parser);
 
             include_once './Services/Search/classes/Like/class.ilLikeObjectSearch.php';
             $object_search = new ilLikeObjectSearch($query_parser);
@@ -348,10 +332,8 @@ class ilSoapObjectAdministration extends ilSoapAdministration
             if ($user_id) {
                 $res->setUserId((int) $user_id);
             }
-            // begin-patch fm
             $res->setMaxHits(100);
-            // begin-patch fm
-            $res->filter(ROOT_FOLDER_ID, $combination == 'and' ? true : false);
+            $res->filter(ROOT_FOLDER_ID, $combination === 'and');
             $counter = 0;
             $objs = array();
             foreach ($res->getUniqueResults() as $entry) {
@@ -368,10 +350,9 @@ class ilSoapObjectAdministration extends ilSoapAdministration
 
         include_once './webservice/soap/classes/class.ilObjectXMLWriter.php';
         $xml_writer = new ilObjectXMLWriter();
-        // begin-patch fm
         if (ilSearchSettings::getInstance()->enabledLucene()) {
             $xml_writer->enableReferences(false);
-            $xml_writer->setMode(ilObjectXmlWriter::MODE_SEARCH_RESULT);
+            $xml_writer->setMode(ilObjectXMLWriter::MODE_SEARCH_RESULT);
             $xml_writer->setHighlighter($highlighter);
         }
 
@@ -384,11 +365,10 @@ class ilSoapObjectAdministration extends ilSoapAdministration
 
         $xml_writer->setObjects($objs);
         if ($xml_writer->start()) {
-            #$GLOBALS['DIC']['ilLog']->write(__METHOD__.': '.$xml_writer->xmlDumpMem(true));
             return $xml_writer->getXML();
         }
 
-        return $this->__raiseError('Cannot create object xml !', 'Server');
+        return $this->raiseError('Cannot create object xml !', 'Server');
     }
 
     public function getTreeChilds(string $sid, int $ref_id, array $types, int $user_id)
@@ -396,8 +376,8 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         $all = false;
@@ -407,13 +387,13 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $tree = $DIC['tree'];
 
         if (!$target_obj = ilObjectFactory::getInstanceByRefId($ref_id, false)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No valid reference id given.',
                 'Client'
             );
         }
-        if (intval($ref_id) == SYSTEM_FOLDER_ID) {
-            return $this->__raiseError(
+        if ($ref_id === SYSTEM_FOLDER_ID) {
+            return $this->raiseError(
                 'No valid reference id given.',
                 'Client'
             );
@@ -426,7 +406,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $objs = array();
 
         foreach ($tree->getChilds($ref_id, 'title') as $child) {
-            if ($all or in_array($child['type'], $types)) {
+            if ($all || in_array($child['type'], $types, true)) {
                 if ($tmp = ilObjectFactory::getInstanceByRefId($child['ref_id'], false)) {
                     $objs[] = $tmp;
                 }
@@ -445,7 +425,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         if ($xml_writer->start()) {
             return $xml_writer->getXML();
         }
-        return $this->__raiseError('Cannot create object xml !', 'Server');
+        return $this->raiseError('Cannot create object xml !', 'Server');
     }
 
     public function getXMLTree(string $sid, int $ref_id, array $types, int $user_id)
@@ -453,8 +433,8 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
@@ -464,19 +444,19 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $nodedata = $tree->getNodeData($ref_id);
         $nodearray = $tree->getSubTree($nodedata);
 
-        $filter = (array) $types;
+        $filter = $types;
 
         global $DIC;
 
         $objDefinition = $DIC['objDefinition'];
         $nodes = [];
         foreach ($nodearray as $node) {
-            if (!$objDefinition->isAdministrationObject($node['type']) && !$objDefinition->isSystemObject($node['type'])) {
-                if (!in_array($node['type'], $filter)) {
-                    if ($tmp = ilObjectFactory::getInstanceByRefId($node['ref_id'], false)) {
-                        $nodes[] = $tmp;
-                    }
-                }
+            if (
+                !$objDefinition->isAdministrationObject($node['type']) &&
+                !$objDefinition->isSystemObject($node['type']) &&
+                !in_array($node['type'], $filter, true) &&
+                ($tmp = ilObjectFactory::getInstanceByRefId($node['ref_id'], false))) {
+                $nodes[] = $tmp;
             }
         }
 
@@ -494,7 +474,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
             return $xml_writer->getXML();
         }
 
-        return $this->__raiseError('Cannot create object xml !', 'Server');
+        return $this->raiseError('Cannot create object xml !', 'Server');
     }
 
     public function addObject(string $sid, int $a_target_id, string $a_xml)
@@ -502,11 +482,11 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
-        if (!strlen($a_xml)) {
-            return $this->__raiseError(
+        if ($a_xml === '') {
+            return $this->raiseError(
                 'No valid xml string given.',
                 'Client'
             );
@@ -521,19 +501,19 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $ilObjDataCache = $DIC['ilObjDataCache'];
 
         if (!$target_obj = ilObjectFactory::getInstanceByRefId($a_target_id, false)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No valid target given.',
                 'Client'
             );
         }
 
         if (ilObject::_isInTrash($a_target_id)) {
-            return $this->__raiseError("Parent with ID $a_target_id has been deleted.", 'Client');
+            return $this->raiseError("Parent with ID $a_target_id has been deleted.", 'Client');
         }
 
         $allowed_types = array('root', 'cat', 'grp', 'crs', 'fold');
         if (!in_array($target_obj->getType(), $allowed_types)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No valid target type. Target must be reference id of "course, group, category or folder"',
                 'Client'
             );
@@ -542,7 +522,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $allowed_subtypes = $target_obj->getPossibleSubObjects();
         $allowed = [];
         foreach ($allowed_subtypes as $row) {
-            if ($row['name'] != 'rolf') {
+            if ($row['name'] !== 'rolf') {
                 $allowed[] = $row['name'];
             }
         }
@@ -553,9 +533,9 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         try {
             $xml_parser->startParsing();
         } catch (ilSaxParserException $se) {
-            return $this->__raiseError($se->getMessage(), 'Client');
+            return $this->raiseError($se->getMessage(), 'Client');
         } catch (ilObjectXMLException $e) {
-            return $this->__raiseError($e->getMessage(), 'Client');
+            return $this->raiseError($e->getMessage(), 'Client');
         }
 
         $newObj = null;
@@ -566,23 +546,23 @@ class ilSoapObjectAdministration extends ilSoapAdministration
             }
 
             // Check possible subtype
-            if (!in_array($object_data['type'], $allowed)) {
-                return $this->__raiseError(
+            if (!in_array($object_data['type'], $allowed, true)) {
+                return $this->raiseError(
                     'Objects of type: ' . $object_data['type'] . ' are not allowed to be subobjects of type ' .
                     $target_obj->getType() . '!',
                     'Client'
                 );
             }
             if (!$rbacsystem->checkAccess('create', $a_target_id, $object_data['type'])) {
-                return $this->__raiseError(
+                return $this->raiseError(
                     'No permission to create objects of type ' . $object_data['type'] . '!',
                     'Client'
                 );
             }
 
             // It's not possible to add objects with non unique import ids
-            if (strlen($object_data['import_id']) and ilObject::_lookupObjIdByImportId($object_data['import_id'])) {
-                return $this->__raiseError(
+            if ($object_data['import_id'] != '' && ilObject::_lookupObjIdByImportId($object_data['import_id'])) {
+                return $this->raiseError(
                     'An object with import id ' . $object_data['import_id'] . ' already exists!',
                     'Server'
                 );
@@ -596,10 +576,10 @@ class ilSoapObjectAdministration extends ilSoapAdministration
             require_once($location . "/class.ilObj" . $class_name . ".php");
 
             $newObj = new $class_constr();
-            if (isset($object_data['owner']) && strlen($object_data['owner'])) {
+            if (isset($object_data['owner']) && $object_data['owner'] != '') {
                 if ((int) $object_data['owner']) {
                     if (ilObject::_exists((int) $object_data['owner']) &&
-                        $ilObjDataCache->lookupType((int) $object_data['owner']) == 'usr') {
+                        $ilObjDataCache->lookupType((int) $object_data['owner']) === 'usr') {
                         $newObj->setOwner((int) $object_data['owner']);
                     }
                 } else {
@@ -611,7 +591,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
             }
 
             $newObj->setType($object_data['type']);
-            if (strlen($object_data['import_id'])) {
+            if ($object_data['import_id'] != '') {
                 $newObj->setImportId($object_data['import_id']);
             }
 
@@ -629,16 +609,14 @@ class ilSoapObjectAdministration extends ilSoapAdministration
                 case 'grp':
                     // Add member
                     $newObj->addMember(
-                        $object_data['owner'] ? $object_data['owner'] : $ilUser->getId(),
+                        $object_data['owner'] ?: $ilUser->getId(),
                         $newObj->getDefaultAdminRole()
                     );
                     break;
 
-                // begin-patch fm
                 case 'crs':
                     $newObj->getMemberObject()->add($ilUser->getId(), ilParticipants::IL_CRS_ADMIN);
                     break;
-                // end-patch fm
                 case 'lm':
                     $newObj->createLMTree();
                     break;
@@ -667,20 +645,8 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
-        }
-        if (!is_numeric($a_source_id)) {
-            return $this->__raiseError(
-                'No source id given.',
-                'Client'
-            );
-        }
-        if (!is_numeric($a_target_id)) {
-            return $this->__raiseError(
-                'No target id given.',
-                'Client'
-            );
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
@@ -690,22 +656,22 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $tree = $DIC['tree'];
 
         if (!$source_obj = ilObjectFactory::getInstanceByRefId($a_source_id, false)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No valid source id given.',
                 'Client'
             );
         }
         if (!$target_obj = ilObjectFactory::getInstanceByRefId($a_target_id, false)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No valid target id given.',
                 'Client'
             );
         }
 
         if (!$objDefinition->allowLink($source_obj->getType()) and
-            $source_obj->getType() != 'cat' and
-            $source_obj->getType() != 'crs') {
-            return $this->__raiseError(
+            $source_obj->getType() !== 'cat' and
+            $source_obj->getType() !== 'crs') {
+            return $this->raiseError(
                 'Linking of object type: ' . $source_obj->getType() . ' is not allowed',
                 'Client'
             );
@@ -714,12 +680,12 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $allowed_subtypes = $target_obj->getPossibleSubObjects();
         $allowed = [];
         foreach ($allowed_subtypes as $row) {
-            if ($row['name'] != 'rolf') {
+            if ($row['name'] !== 'rolf') {
                 $allowed[] = $row['name'];
             }
         }
-        if (!in_array($source_obj->getType(), $allowed)) {
-            return $this->__raiseError(
+        if (!in_array($source_obj->getType(), $allowed, true)) {
+            return $this->raiseError(
                 'Objects of type: ' . $source_obj->getType() . ' are not allowed to be subobjects of type ' .
                 $target_obj->getType() . '!',
                 'Client'
@@ -728,24 +694,24 @@ class ilSoapObjectAdministration extends ilSoapAdministration
 
         // Permission checks
         if (!$rbacsystem->checkAccess('create', $target_obj->getRefId(), $source_obj->getType())) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No permission to create objects of type ' . $source_obj->getType() . '!',
                 'Client'
             );
         }
         if (!$rbacsystem->checkAccess('delete', $source_obj->getRefId())) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No permission to link object with id: ' . $source_obj->getRefId() . '!',
                 'Client'
             );
         }
 
-        if ($source_obj->getType() != 'cat' and $source_obj->getType() != 'crs') {
+        if ($source_obj->getType() !== 'cat' and $source_obj->getType() !== 'crs') {
             // check if object already linked to target
             $possibleChilds = $tree->getChildsByType($target_obj->getRefId(), $source_obj->getType());
             foreach ($possibleChilds as $child) {
-                if ($child["obj_id"] == $source_obj->getId()) {
-                    return $this->__raiseError("Object already linked to target.", "Client");
+                if ((int) $child["obj_id"] === $source_obj->getId()) {
+                    return $this->raiseError("Object already linked to target.", "Client");
                 }
             }
 
@@ -756,37 +722,38 @@ class ilSoapObjectAdministration extends ilSoapAdministration
             $source_obj->setPermissions($target_obj->getRefId());
 
             return $new_ref_id ?: "0";
-        } else {
-            $new_ref = null;
-            switch ($source_obj->getType()) {
-                case 'cat':
-                    include_once('./Modules/CategoryReference/classes/class.ilObjCategoryReference.php');
-                    $new_ref = new ilObjCategoryReference();
-                    break;
-
-                case 'crs':
-                    include_once('./Modules/CourseReference/classes/class.ilObjCourseReference.php');
-                    $new_ref = new ilObjCourseReference();
-                    break;
-                case 'grp':
-                    include_once('./Modules/GroupReference/classes/class.ilObjGroupReference.php');
-                    $new_ref = new ilObjGroupReference();
-                    break;
-            }
-            $new_ref->create();
-            $new_ref_id = $new_ref->createReference();
-
-            $new_ref->putInTree($target_obj->getRefId());
-            $new_ref->setPermissions($target_obj->getRefId());
-
-            $new_ref->setTargetId($source_obj->getId());
-            $new_ref->update();
-
-            if (!$new_ref instanceof ilObject) {
-                return 0;
-            }
-            return $new_ref_id ?: 0;
         }
+
+        $new_ref = null;
+        switch ($source_obj->getType()) {
+            case 'cat':
+                include_once('./Modules/CategoryReference/classes/class.ilObjCategoryReference.php');
+                $new_ref = new ilObjCategoryReference();
+                break;
+
+            case 'crs':
+                include_once('./Modules/CourseReference/classes/class.ilObjCourseReference.php');
+                $new_ref = new ilObjCourseReference();
+                break;
+            case 'grp':
+                include_once('./Modules/GroupReference/classes/class.ilObjGroupReference.php');
+                $new_ref = new ilObjGroupReference();
+                break;
+        }
+        $new_ref->create();
+        $new_ref_id = $new_ref->createReference();
+
+        $new_ref->putInTree($target_obj->getRefId());
+        $new_ref->setPermissions($target_obj->getRefId());
+
+        $new_ref->setTargetId($source_obj->getId());
+        $new_ref->update();
+
+        if (!$new_ref instanceof ilObject) {
+            return 0;
+        }
+
+        return $new_ref_id ?: 0;
     }
 
     public function deleteObject(string $sid, int $reference_id)
@@ -794,15 +761,10 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
-        if (!is_numeric($reference_id)) {
-            return $this->__raiseError(
-                'No reference id given.',
-                'Client'
-            );
-        }
+
         global $DIC;
 
         $tree = $DIC->repositoryTree();
@@ -811,25 +773,24 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $user = $DIC->user();
 
         if (!$del_obj = ilObjectFactory::getInstanceByRefId($reference_id, false)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No valid reference id given.',
                 'Client'
             );
         }
         if (!$rbacsystem->checkAccess('delete', $del_obj->getRefId())) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No permission to delete object with id: ' . $del_obj->getRefId() . '!',
                 'Client'
             );
         }
 
-        // Delete tree
         if ($tree->isDeleted($reference_id)) {
-            return $this->__raiseError('Node already deleted', 'Server');
+            return $this->raiseError('Node already deleted', 'Server');
         }
 
-        if ($del_obj->getType() == 'rolf') {
-            return $this->__raiseError('Delete is not available for role folders.', 'Client');
+        if ($del_obj->getType() === 'rolf') {
+            return $this->raiseError('Delete is not available for role folders.', 'Client');
         }
 
         $subnodes = $tree->getSubTree($tree->getNodeData($reference_id));
@@ -837,7 +798,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
             $rbacadmin->revokePermission($subnode["child"]);
         }
         if (!$tree->moveToTrash($reference_id, true, $user->getId())) {
-            return $this->__raiseError('Node already deleted', 'Client');
+            return $this->raiseError('Node already deleted', 'Client');
         }
         return true;
     }
@@ -847,11 +808,11 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
-        if (!strlen($import_id)) {
-            return $this->__raiseError(
+        if ($import_id === '') {
+            return $this->raiseError(
                 'No import id given. Aborting!',
                 'Client'
             );
@@ -864,7 +825,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
 
         // get obj_id
         if (!$obj_id = ilObject::_lookupObjIdByImportId($import_id)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No object found with import id: ' . $import_id,
                 'Client'
             );
@@ -879,7 +840,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
             }
         }
         if (!$permission_ok) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No permission to delete the object with import id: ' . $import_id,
                 'Server'
             );
@@ -895,7 +856,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
                 $ilLog->write('Soap: removeFromSystemByImportId(). Deleting object with title id: ' . $node['title']);
                 $tmp_obj = ilObjectFactory::getInstanceByRefId($node['ref_id']);
                 if (!is_object($tmp_obj)) {
-                    return $this->__raiseError(
+                    return $this->raiseError(
                         'Cannot create instance of reference id: ' . $node['ref_id'],
                         'Server'
                     );
@@ -913,11 +874,11 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
-        if (!strlen($a_xml)) {
-            return $this->__raiseError(
+        if ($a_xml === '') {
+            return $this->raiseError(
                 'No valid xml string given.',
                 'Client'
             );
@@ -936,9 +897,9 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         try {
             $xml_parser->startParsing();
         } catch (ilSaxParserException $se) {
-            return $this->__raiseError($se->getMessage(), 'Client');
+            return $this->raiseError($se->getMessage(), 'Client');
         } catch (ilObjectXMLException $e) {
-            return $this->__raiseError($e->getMessage(), 'Client');
+            return $this->raiseError($e->getMessage(), 'Client');
         }
 
         // Validate incoming data
@@ -950,8 +911,8 @@ class ilSoapObjectAdministration extends ilSoapAdministration
             }
 
             if (!$object_data["obj_id"]) {
-                return $this->__raiseError('No obj_id in xml found.', 'Client');
-            } elseif ((int) $object_data["obj_id"] == -1 && count($object_data["references"]) > 0) {
+                return $this->raiseError('No obj_id in xml found.', 'Client');
+            } elseif ((int) $object_data["obj_id"] === -1 && count($object_data["references"]) > 0) {
                 // object id might be unknown, resolve references instead to determine object id
                 // all references should point to the same object, so using the first one is ok.
                 foreach ($object_data["references"] as $refid) {
@@ -963,32 +924,32 @@ class ilSoapObjectAdministration extends ilSoapAdministration
 
                 $obj_id_from_refid = ilObject::_lookupObjectId($object_data["references"][0]);
                 if (!$obj_id_from_refid) {
-                    return $this->__raiseError(
+                    return $this->raiseError(
                         'No obj_id found for reference id ' . $object_data["references"][0],
                         'CLIENT_OBJECT_NOT_FOUND'
                     );
-                } else {
-                    $tmp_obj = ilObjectFactory::getInstanceByObjId($object_data['obj_id'], false);
-                    $object_data["obj_id"] = $obj_id_from_refid;
                 }
+
+                $tmp_obj = ilObjectFactory::getInstanceByObjId($object_data['obj_id'], false);
+                $object_data["obj_id"] = $obj_id_from_refid;
             }
 
             $tmp_obj = ilObjectFactory::getInstanceByObjId($object_data['obj_id'], false);
-            if ($tmp_obj == null) {
-                return $this->__raiseError(
+            if ($tmp_obj === null) {
+                return $this->raiseError(
                     'No object for id ' . $object_data['obj_id'] . '!',
                     'CLIENT_OBJECT_NOT_FOUND'
                 );
-            } else {
-                $object_data["instance"] = $tmp_obj;
             }
 
-            if ($object_data['type'] == 'role') {
+            $object_data["instance"] = $tmp_obj;
+
+            if ($object_data['type'] === 'role') {
                 $rolf_ids = $rbacreview->getFoldersAssignedToRole($object_data['obj_id'], true);
                 $rolf_id = $rolf_ids[0];
 
                 if (!$rbacsystem->checkAccess('write', $rolf_id)) {
-                    return $this->__raiseError(
+                    return $this->raiseError(
                         'No write permission for object with id ' . $object_data['obj_id'] . '!',
                         'Client'
                     );
@@ -1002,13 +963,15 @@ class ilSoapObjectAdministration extends ilSoapAdministration
                     }
                 }
                 if (!$permission_ok) {
-                    return $this->__raiseError(
+                    return $this->raiseError(
                         'No write permission for object with id ' . $object_data['obj_id'] . '!',
                         'Client'
                     );
                 }
             }
         }
+        unset($object_data);
+
         // perform update
         if (count($object_datas) > 0) {
             foreach ($object_datas as $object_data) {
@@ -1025,7 +988,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
                 }
 
                 $tmp_obj->update();
-                if (strlen($object_data['owner']) && is_numeric($object_data['owner'])) {
+                if ($object_data['owner'] != '' && is_numeric($object_data['owner'])) {
                     $tmp_obj->setOwner($object_data['owner']);
                     $tmp_obj->updateOwner();
                 }
@@ -1040,8 +1003,8 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         include_once './webservice/soap/classes/class.ilSoapUtils.php';
@@ -1057,21 +1020,21 @@ class ilSoapObjectAdministration extends ilSoapAdministration
 
         // does source object exist
         if (!$source_object_type = ilObjectFactory::getTypeByRefId($ref_id, false)) {
-            return $this->__raiseError('No valid source given.', 'Client');
+            return $this->raiseError('No valid source given.', 'Client');
         }
 
         // does target object exist
         if (!$target_object_type = ilObjectFactory::getTypeByRefId($target_id, false)) {
-            return $this->__raiseError('No valid target given.', 'Client');
+            return $this->raiseError('No valid target given.', 'Client');
         }
 
         // check for trash
         if (ilObject::_isInTrash($ref_id)) {
-            return $this->__raiseError('Object is trashed.', 'Client');
+            return $this->raiseError('Object is trashed.', 'Client');
         }
 
         if (ilObject::_isInTrash($target_id)) {
-            return $this->__raiseError('Object is trashed.', 'Client');
+            return $this->raiseError('Object is trashed.', 'Client');
         }
 
         $canAddType = $this->canAddType($source_object_type, $target_object_type, $target_id);
@@ -1082,14 +1045,14 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         // check if object already linked to target
         $possibleChilds = $tree->getChildsByType($target_id, $ref_id);
         foreach ($possibleChilds as $child) {
-            if ($child["obj_id"] == $ref_id) {
-                return $this->__raiseError("Object already exists in target.", "Client");
+            if ((int) $child["obj_id"] === $ref_id) {
+                return $this->raiseError("Object already exists in target.", "Client");
             }
         }
 
         // CHECK IF PASTE OBJECT SHALL BE CHILD OF ITSELF
         if ($tree->isGrandChild($ref_id, $target_id)) {
-            return $this->__raiseError("Cannot move object into itself.", "Client");
+            return $this->raiseError("Cannot move object into itself.", "Client");
         }
 
         $old_parent = $tree->getParentId($ref_id);
@@ -1111,8 +1074,8 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         include_once './webservice/soap/classes/class.ilSoapUtils.php';
@@ -1129,12 +1092,12 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         try {
             $xml_parser->startParsing();
         } catch (ilSaxParserException $se) {
-            return $this->__raiseError($se->getMessage(), "Client");
+            return $this->raiseError($se->getMessage(), "Client");
         }
 
         // checking copy permissions, objects and create permissions
         if (!$rbacsystem->checkAccess('copy', $xml_parser->getSourceId())) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 "Missing copy permissions for object with reference id " . $xml_parser->getSourceId(),
                 'Client'
             );
@@ -1146,12 +1109,12 @@ class ilSoapObjectAdministration extends ilSoapAdministration
 
         // does source object exist
         if (!$source_object_type = ilObjectFactory::getTypeByRefId($source_id, false)) {
-            return $this->__raiseError('No valid source given.', 'Client');
+            return $this->raiseError('No valid source given.', 'Client');
         }
 
         // does target object exist
         if (!$target_object_type = ilObjectFactory::getTypeByRefId($xml_parser->getTargetId(), false)) {
-            return $this->__raiseError('No valid target given.', 'Client');
+            return $this->raiseError('No valid target given.', 'Client');
         }
 
         $canAddType = $this->canAddType($source_object_type, $target_object_type, $target_id);
@@ -1179,22 +1142,22 @@ class ilSoapObjectAdministration extends ilSoapAdministration
             );
 
             return $ret['ref_id'];
-        } else {
-            // create copy wizard settings
-            $copy_id = ilCopyWizardOptions::_allocateCopyId();
-            $wizard_options = ilCopyWizardOptions::_getInstance($copy_id);
-            $wizard_options->saveOwner($ilUser->getId());
-            $wizard_options->saveRoot($source_id);
-
-            foreach ($options as $source_id => $option) {
-                $wizard_options->addEntry($source_id, $option);
-            }
-            $wizard_options->read();
-
-            // call object clone
-            $newObject = $source_object->cloneObject($xml_parser->getTargetId(), $copy_id);
-            return is_object($newObject) ? $newObject->getRefId() : -1;
         }
+
+        // create copy wizard settings
+        $copy_id = ilCopyWizardOptions::_allocateCopyId();
+        $wizard_options = ilCopyWizardOptions::_getInstance($copy_id);
+        $wizard_options->saveOwner($ilUser->getId());
+        $wizard_options->saveRoot($source_id);
+
+        foreach ($options as $source_id => $option) {
+            $wizard_options->addEntry($source_id, $option);
+        }
+        $wizard_options->read();
+
+        // call object clone
+        $newObject = $source_object->cloneObject($xml_parser->getTargetId(), $copy_id);
+        return is_object($newObject) ? $newObject->getRefId() : -1;
     }
 
     public function getPathForRefId(string $sid, int $ref_id)
@@ -1202,8 +1165,8 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
@@ -1215,11 +1178,11 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $ilUser = $DIC['ilUser'];
 
         if (!$rbacsystem->checkAccess('read', $ref_id)) {
-            return $this->__raiseError("Missing read permissions for object with reference id " . $ref_id, 'Client');
+            return $this->raiseError("Missing read permissions for object with reference id " . $ref_id, 'Client');
         }
 
         if (ilObject::_isInTrash($ref_id)) {
-            return $this->__raiseError("Object is in Trash", 'Client');
+            return $this->raiseError("Object is in Trash", 'Client');
         }
         global $DIC;
 
@@ -1238,10 +1201,10 @@ class ilSoapObjectAdministration extends ilSoapAdministration
 
         $writer = new ilXMLResultSetWriter($xmlResultSet);
         foreach ($items as $item) {
-            if ($item["ref_id"] == $ref_id) {
+            if ((int) $item["ref_id"] === $ref_id) {
                 continue;
             }
-            if ($item["title"] == "ILIAS" && $item["type"] == "root") {
+            if ($item["title"] === "ILIAS" && $item["type"] === "root") {
                 $item["title"] = $lng->txt("repository");
             }
 
@@ -1264,8 +1227,8 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $rbacsystem = $DIC['rbacsystem'];
 
         $allowed_types = array('root', 'cat', 'grp', 'crs', 'fold');
-        if (!in_array($target_type, $allowed_types)) {
-            return $this->__raiseError(
+        if (!in_array($target_type, $allowed_types, true)) {
+            return $this->raiseError(
                 'No valid target type. Target must be reference id of "course, group, category or folder"',
                 'Client'
             );
@@ -1275,19 +1238,19 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $allowed = array();
 
         foreach ($allowed_subtypes as $row) {
-            if ($row['name'] != 'rolf') {
+            if ($row['name'] !== 'rolf') {
                 $allowed[] = $row['name'];
             }
         }
 
-        if (!in_array($type, $allowed)) {
-            return $this->__raiseError(
+        if (!in_array($type, $allowed, true)) {
+            return $this->raiseError(
                 'Objects of type: ' . $type . ' are not allowed to be subobjects of type ' . $target_type . '!',
                 'Client'
             );
         }
         if (!$rbacsystem->checkAccess('create', $target_id, $type)) {
-            return $this->__raiseError('No permission to create objects of type ' . $type . '!', 'Client');
+            return $this->raiseError('No permission to create objects of type ' . $type . '!', 'Client');
         }
 
         return true;
@@ -1302,27 +1265,27 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         if (!isset($a_object_data['references']) or !count($a_object_data['references'])) {
             return true;
         }
-        if ($a_action == 'create') {
-            if (count($a_object_data['references']) > 1) {
-                if (in_array($a_object_data['type'], array('cat', 'crs', 'grp', 'fold'))) {
-                    return $this->__raiseError(
-                        "Cannot create references for type " . $a_object_data['type'],
-                        'Client'
-                    );
-                }
+        if ($a_action === 'create') {
+            if (count($a_object_data['references']) > 1 && in_array(
+                $a_object_data['type'],
+                ['cat', 'crs', 'grp', 'fold'],
+                true
+            )) {
+                return $this->raiseError(
+                    "Cannot create references for type " . $a_object_data['type'],
+                    'Client'
+                );
             }
-            if (count($a_object_data['references']) == 1) {
-                if ($a_target_id != $a_object_data['references'][0]['parent_id']) {
-                    return $this->__raiseError(
-                        "Cannot create references for type " . $a_object_data['type'],
-                        'Client'
-                    );
-                }
+            if (count($a_object_data['references']) === 1 && $a_target_id != $a_object_data['references'][0]['parent_id']) {
+                return $this->raiseError(
+                    "Cannot create references for type " . $a_object_data['type'],
+                    'Client'
+                );
             }
 
             foreach ($a_object_data['references'] as $ref_data) {
                 if (!$ref_data['parent_id']) {
-                    return $this->__raiseError('Element References: No parent Id given!', 'Client');
+                    return $this->raiseError('Element References: No parent Id given!', 'Client');
                 }
 
                 $target_type = ilObject::_lookupType(ilObject::_lookupObjId($ref_data['parent_id']));
@@ -1334,14 +1297,14 @@ class ilSoapObjectAdministration extends ilSoapAdministration
             return true;
         }
 
-        if ($a_action == 'update') {
+        if ($a_action === 'update') {
             foreach ($a_object_data['references'] as $ref_data) {
                 if (!$ref_data['ref_id']) {
-                    return $this->__raiseError('Element References: No reference id given!', 'Client');
+                    return $this->raiseError('Element References: No reference id given!', 'Client');
                 }
                 // check permissions
                 if (!$ilAccess->checkAccess('write', '', $ref_data['ref_id'])) {
-                    return $this->__raiseError(
+                    return $this->raiseError(
                         'No write permission for object with reference id ' . $ref_data['ref_id'] . '!',
                         'Client'
                     );
@@ -1352,30 +1315,30 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         }
     }
 
-    private function updateReferences(array $a_object_data)
+    private function updateReferences(array $a_object_data) : void
     {
         global $DIC;
 
         $tree = $DIC['tree'];
         $ilLog = $DIC['ilLog'];
 
-        if (!isset($a_object_data['references']) or !count($a_object_data['references'])) {
+        if (!isset($a_object_data['references']) || !count($a_object_data['references'])) {
             return;
         }
 
         foreach ($a_object_data['references'] as $ref_data) {
-            if (isset($ref_data['time_target']) /* and ($crs_ref_id = $tree->checkForParentType($ref_data['ref_id'],'crs')) */) {
+            if (isset($ref_data['time_target'])) {
                 include_once('./webservice/soap/classes/class.ilObjectXMLWriter.php');
                 include_once('./Services/Object/classes/class.ilObjectActivation.php');
                 $old = ilObjectActivation::getItem($ref_data['ref_id']);
 
                 $items = new ilObjectActivation();
-                $items->toggleChangeable(isset($ref_data['time_target']['changeable']) ? $ref_data['time_target']['changeable'] : $old['changeable']);
-                $items->setTimingStart(isset($ref_data['time_target']['starting_time']) ? $ref_data['time_target']['starting_time'] : $old['timing_start']);
-                $items->setTimingEnd(isset($ref_data['time_target']['ending_time']) ? $ref_data['time_target']['ending_time'] : $old['timing_end']);
-                $items->toggleVisible(isset($ref_data['time_target']['timing_visibility']) ? $ref_data['time_target']['timing_visibility'] : $old['visible']);
-                $items->setSuggestionStart(isset($ref_data['time_target']['suggestion_start']) ? $ref_data['time_target']['suggestion_start'] : $old['suggestion_start']);
-                $items->setSuggestionEnd(isset($ref_data['time_target']['suggestion_end']) ? $ref_data['time_target']['suggestion_end'] : $old['suggestion_end']);
+                $items->toggleChangeable($ref_data['time_target']['changeable'] ?? $old['changeable']);
+                $items->setTimingStart($ref_data['time_target']['starting_time'] ?? $old['timing_start']);
+                $items->setTimingEnd($ref_data['time_target']['ending_time'] ?? $old['timing_end']);
+                $items->toggleVisible($ref_data['time_target']['timing_visibility'] ?? $old['visible']);
+                $items->setSuggestionStart($ref_data['time_target']['suggestion_start'] ?? $old['suggestion_start']);
+                $items->setSuggestionEnd($ref_data['time_target']['suggestion_end'] ?? $old['suggestion_end']);
 
                 switch ($ref_data['time_target']['timing_type']) {
                     case ilObjectXMLWriter::TIMING_DEACTIVATED:
@@ -1402,18 +1365,18 @@ class ilSoapObjectAdministration extends ilSoapAdministration
     {
         global $DIC;
 
-        $tree = $DIC['tree'];
+        $tree = $DIC->repositoryTree();
         $ilLog = $DIC['ilLog'];
 
-        if (!isset($a_object_data['references']) or !count($a_object_data['references'])) {
+        if (!isset($a_object_data['references']) || !count($a_object_data['references'])) {
             return;
         }
 
         $original_id = $source->getRefId();
 
         foreach ($a_object_data['references'] as $ref_data) {
-            $new_ref_id = $ref_id = $original_id;
-            if ($tree->getParentId($original_id) != $ref_data['parent_id']) {
+            $new_ref_id = $original_id;
+            if ($tree->getParentId($original_id) !== (int) $ref_data['parent_id']) {
                 // New reference requested => create it
                 $new_ref_id = $source->createReference();
                 $source->putInTree($ref_data['parent_id']);

--- a/webservice/soap/classes/class.ilSoapRBACAdministration.php
+++ b/webservice/soap/classes/class.ilSoapRBACAdministration.php
@@ -34,8 +34,8 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
@@ -44,8 +44,8 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         $rbacsystem = $DIC['rbacsystem'];
         $ilAccess = $DIC['ilAccess'];
 
-        if (!$tmp_role = ilObjectFactory::getInstanceByObjId($role_id, false) or $tmp_role->getType() != 'role') {
-            return $this->__raiseError(
+        if (!($tmp_role = ilObjectFactory::getInstanceByObjId($role_id, false)) || $tmp_role->getType() !== 'role') {
+            return $this->raiseError(
                 'No valid role id given. Please choose an existing id of an ILIAS role',
                 'Client'
             );
@@ -53,13 +53,13 @@ class ilSoapRBACAdministration extends ilSoapAdministration
 
         $obj_ref = $rbacreview->getObjectReferenceOfRole($role_id);
         if (!$ilAccess->checkAccess('edit_permission', '', $obj_ref)) {
-            return $this->__raiseError('Check access failed. No permission to delete role', 'Server');
+            return $this->raiseError('Check access failed. No permission to delete role', 'Server');
         }
 
         // if it's last role of an user
         foreach ($assigned_users = $rbacreview->assignedUsers($role_id) as $user_id) {
-            if (count($rbacreview->assignedRoles($user_id)) == 1) {
-                return $this->__raiseError(
+            if (count($rbacreview->assignedRoles($user_id)) === 1) {
+                return $this->raiseError(
                     'Cannot deassign last role of users',
                     'Client'
                 );
@@ -79,8 +79,8 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
@@ -91,14 +91,14 @@ class ilSoapRBACAdministration extends ilSoapAdministration
 
         $tmp_user = ilObjectFactory::getInstanceByObjId($user_id, false);
         if (!$tmp_user instanceof ilObjUser) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No valid user id given. Please choose an existing id of an ILIAS user',
                 'Client'
             );
         }
         $tmp_role = ilObjectFactory::getInstanceByObjId($role_id, false);
         if (!$tmp_role instanceof ilObjRole) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No valid role id given. Please choose an existing id of an ILIAS role',
                 'Client'
             );
@@ -106,11 +106,11 @@ class ilSoapRBACAdministration extends ilSoapAdministration
 
         $obj_ref = $rbacreview->getObjectReferenceOfRole($role_id);
         if (!$ilAccess->checkAccess('edit_permission', '', $obj_ref)) {
-            return $this->__raiseError('Check access failed. No permission to assign users', 'Server');
+            return $this->raiseError('Check access failed. No permission to assign users', 'Server');
         }
 
         if (!$rbacadmin->assignUser($role_id, $user_id)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'Error rbacadmin->assignUser()',
                 'Server'
             );
@@ -123,8 +123,8 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
@@ -133,14 +133,14 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         $ilAccess = $DIC['ilAccess'];
         $rbacreview = $DIC['rbacreview'];
 
-        if ($tmp_user = ilObjectFactory::getInstanceByObjId($user_id, false) and $tmp_user->getType() != 'usr') {
-            return $this->__raiseError(
+        if ($tmp_user = ilObjectFactory::getInstanceByObjId($user_id, false) and $tmp_user->getType() !== 'usr') {
+            return $this->raiseError(
                 'No valid user id given. Please choose an existing id of an ILIAS user',
                 'Client'
             );
         }
-        if ($tmp_role = ilObjectFactory::getInstanceByObjId($role_id, false) and $tmp_role->getType() != 'role') {
-            return $this->__raiseError(
+        if ($tmp_role = ilObjectFactory::getInstanceByObjId($role_id, false) and $tmp_role->getType() !== 'role') {
+            return $this->raiseError(
                 'No valid role id given. Please choose an existing id of an ILIAS role',
                 'Client'
             );
@@ -148,11 +148,11 @@ class ilSoapRBACAdministration extends ilSoapAdministration
 
         $obj_ref = $rbacreview->getObjectReferenceOfRole($role_id);
         if (!$ilAccess->checkAccess('edit_permission', '', $obj_ref)) {
-            return $this->__raiseError('Check access failed. No permission to deassign users', 'Server');
+            return $this->raiseError('Check access failed. No permission to deassign users', 'Server');
         }
 
         if (!$rbacadmin->deassignUser($role_id, $user_id)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'Error rbacadmin->deassignUser()',
                 'Server'
             );
@@ -165,8 +165,8 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
@@ -175,9 +175,9 @@ class ilSoapRBACAdministration extends ilSoapAdministration
 
         if (is_array($ops = $rbacreview->getOperations())) {
             return $ops;
-        } else {
-            return $this->__raiseError('Unknown error', 'Server');
         }
+
+        return $this->raiseError('Unknown error', 'Server');
     }
 
     public function revokePermissions(string $sid, int $ref_id, int $role_id)
@@ -185,8 +185,8 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
@@ -195,26 +195,26 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         $ilAccess = $DIC['ilAccess'];
 
         if (!$tmp_obj = ilObjectFactory::getInstanceByRefId($ref_id, false)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No valid ref id given. Please choose an existing reference id of an ILIAS object',
                 'Client'
             );
         }
-        if ($tmp_role = ilObjectFactory::getInstanceByObjId($role_id, false) and $tmp_role->getType() != 'role') {
-            return $this->__raiseError(
+        if (($tmp_role = ilObjectFactory::getInstanceByObjId($role_id, false)) && $tmp_role->getType() !== 'role') {
+            return $this->raiseError(
                 'No valid role id given. Please choose an existing id of an ILIAS role',
                 'Client'
             );
         }
-        if ($role_id == SYSTEM_ROLE_ID) {
-            return $this->__raiseError(
+        if ($role_id === SYSTEM_ROLE_ID) {
+            return $this->raiseError(
                 'Cannot revoke permissions of system role',
                 'Client'
             );
         }
 
         if (!$ilAccess->checkAccess('edit_permission', '', $ref_id)) {
-            return $this->__raiseError('Check access failed. No permission to revoke permissions', 'Server');
+            return $this->raiseError('Check access failed. No permission to revoke permissions', 'Server');
         }
         $rbacadmin->revokePermission($ref_id, $role_id);
         return true;
@@ -225,8 +225,8 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
@@ -235,20 +235,20 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         $ilAccess = $DIC['ilAccess'];
 
         if (!$tmp_obj = ilObjectFactory::getInstanceByRefId($ref_id, false)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No valid ref id given. Please choose an existing reference id of an ILIAS object',
                 'Client'
             );
         }
-        if ($tmp_role = ilObjectFactory::getInstanceByObjId($role_id, false) and $tmp_role->getType() != 'role') {
-            return $this->__raiseError(
+        if (($tmp_role = ilObjectFactory::getInstanceByObjId($role_id, false)) && $tmp_role->getType() !== 'role') {
+            return $this->raiseError(
                 'No valid role id given. Please choose an existing id of an ILIAS role',
                 'Client'
             );
         }
 
         if (!$ilAccess->checkAccess('edit_permission', '', $ref_id)) {
-            return $this->__raiseError('Check access failed. No permission to grant permissions', 'Server');
+            return $this->raiseError('Check access failed. No permission to grant permissions', 'Server');
         }
 
         // mjansen@databay.de: dirty fix
@@ -257,7 +257,7 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         }
 
         if (!is_array($permissions)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No valid permissions given.' . print_r($permissions),
                 'Client'
             );
@@ -273,8 +273,8 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
@@ -283,14 +283,14 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         $ilAccess = $DIC['ilAccess'];
 
         if (!$tmp_obj = ilObjectFactory::getInstanceByRefId($ref_id, false)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No valid ref id given. Please choose an existing reference id of an ILIAS object',
                 'Client'
             );
         }
 
         if (!$ilAccess->checkAccess('edit_permission', '', $ref_id)) {
-            return $this->__raiseError('Check access failed. No permission to access role information', 'Server');
+            return $this->raiseError('Check access failed. No permission to access role information', 'Server');
         }
 
         $objs = [];
@@ -316,8 +316,8 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
@@ -325,7 +325,7 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         $rbacreview = $DIC['rbacreview'];
 
         if (!$tmp_user = ilObjectFactory::getInstanceByObjId($user_id, false)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No valid user id given. Please choose an existing id of an ILIAS user',
                 'Client'
             );
@@ -354,8 +354,8 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
@@ -366,18 +366,18 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         $ilAccess = $DIC['ilAccess'];
 
         if (!$tmp_obj = ilObjectFactory::getInstanceByRefId($target_id, false)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No valid ref id given. Please choose an existing reference id of an ILIAS object',
                 'Client'
             );
         }
 
         if (ilObject::_isInTrash($target_id)) {
-            return $this->__raiseError("Parent with ID $target_id has been deleted.", 'CLIENT_TARGET_DELETED');
+            return $this->raiseError("Parent with ID $target_id has been deleted.", 'CLIENT_TARGET_DELETED');
         }
 
         if (!$ilAccess->checkAccess('edit_permission', '', $target_id)) {
-            return $this->__raiseError('Check access failed. No permission to create roles', 'Server');
+            return $this->raiseError('Check access failed. No permission to create roles', 'Server');
         }
 
         include_once 'webservice/soap/classes/class.ilObjectXMLParser.php';
@@ -387,8 +387,8 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         $new_roles = [];
         foreach ($xml_parser->getObjectData() as $object_data) {
             // check if role title has il_ prefix
-            if (substr($object_data['title'], 0, 3) == "il_") {
-                return $this->__raiseError(
+            if (strpos($object_data['title'], "il_") === 0) {
+                return $this->raiseError(
                     'Rolenames are not allowed to start with "il_" ',
                     'Client'
                 );
@@ -412,8 +412,8 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
@@ -425,24 +425,24 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         $ilAccess = $DIC['ilAccess'];
 
         if (!$tmp_obj = ilObjectFactory::getInstanceByRefId($target_id, false)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No valid ref id given. Please choose an existing reference id of an ILIAS object',
                 'Client'
             );
         }
-        if (ilObject::_lookupType($template_id) != 'rolt') {
-            return $this->__raiseError(
+        if (ilObject::_lookupType($template_id) !== 'rolt') {
+            return $this->raiseError(
                 'No valid template id given. Please choose an existing object id of an ILIAS role template',
                 'Client'
             );
         }
 
         if (ilObject::_isInTrash($target_id)) {
-            return $this->__raiseError("Parent with ID $target_id has been deleted.", 'CLIENT_TARGET_DELETED');
+            return $this->raiseError("Parent with ID $target_id has been deleted.", 'CLIENT_TARGET_DELETED');
         }
 
         if (!$ilAccess->checkAccess('edit_permission', '', $target_id)) {
-            return $this->__raiseError('Check access failed. No permission to create roles', 'Server');
+            return $this->raiseError('Check access failed. No permission to create roles', 'Server');
         }
 
         include_once 'webservice/soap/classes/class.ilObjectXMLParser.php';
@@ -453,8 +453,8 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         foreach ($xml_parser->getObjectData() as $object_data) {
 
             // check if role title has il_ prefix
-            if (substr($object_data['title'], 0, 3) == "il_") {
-                return $this->__raiseError(
+            if (strpos($object_data['title'], "il_") === 0) {
+                return $this->raiseError(
                     'Rolenames are not allowed to start with "il_" ',
                     'Client'
                 );
@@ -485,8 +485,8 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
@@ -496,21 +496,21 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         $ilAccess = $DIC['ilAccess'];
 
         if (!$tmp_obj = ilObjectFactory::getInstanceByRefId($ref_id, false)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No valid ref id given. Please choose an existing reference id of an ILIAS object',
                 'Client'
             );
         }
 
         if (!$tmp_user = ilObjectFactory::getInstanceByObjId($user_id, false)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No valid user id given.',
                 'Client'
             );
         }
 
         if (ilObject::_isInTrash($ref_id)) {
-            return $this->__raiseError("Parent with ID " . $ref_id . "has been deleted.", 'CLIENT_TARGET_DELETED');
+            return $this->raiseError("Parent with ID " . $ref_id . "has been deleted.", 'CLIENT_TARGET_DELETED');
         }
 
         // check visible for all upper tree entries
@@ -549,8 +549,8 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
@@ -560,13 +560,13 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         $ilUser = $DIC['ilUser'];
         $ilDB = $DIC['ilDB'];
 
-        if (strcasecmp($role_type, "") != 0 &&
-            strcasecmp($role_type, "local") != 0 &&
-            strcasecmp($role_type, "global") != 0 &&
-            strcasecmp($role_type, "user") != 0 &&
-            strcasecmp($role_type, "user_login") != 0 &&
-            strcasecmp($role_type, "template") != 0) {
-            return $this->__raiseError(
+        if (strcasecmp($role_type, "") !== 0 &&
+            strcasecmp($role_type, "local") !== 0 &&
+            strcasecmp($role_type, "global") !== 0 &&
+            strcasecmp($role_type, "user") !== 0 &&
+            strcasecmp($role_type, "user_login") !== 0 &&
+            strcasecmp($role_type, "template") !== 0) {
+            return $this->raiseError(
                 'Called service with wrong role_type parameter \'' . $role_type . '\'',
                 'Client'
             );
@@ -574,36 +574,36 @@ class ilSoapRBACAdministration extends ilSoapAdministration
 
         $roles = array();
 
-        if (strcasecmp($role_type, "template") == 0) {
+        if (strcasecmp($role_type, "template") === 0) {
             // get templates
             $roles = $rbacreview->getRolesByFilter(6, $ilUser->getId());
-        } elseif (strcasecmp($role_type, "user") == 0 || strcasecmp($role_type, "user_login") == 0) {
+        } elseif (strcasecmp($role_type, "user") === 0 || strcasecmp($role_type, "user_login") === 0) {
             // handle user roles
             $user_id = $this->parseUserID($id, $role_type);
-            if ($user_id != $ilUser->getId()) {
+            if ((int) $user_id !== $ilUser->getId()) {
                 // check access for user folder
                 $tmpUser = new ilObjUser($user_id);
                 $timelimitOwner = $tmpUser->getTimeLimitOwner();
                 if (!$rbacsystem->checkAccess('read', $timelimitOwner)) {
-                    return $this->__raiseError('Check access for time limit owner failed.', 'Server');
+                    return $this->raiseError('Check access for time limit owner failed.', 'Server');
                 }
             }
             $role_type = ""; // local and global roles for user
 
             $query = sprintf(
                 "SELECT object_data.title, rbac_fa.* FROM object_data, rbac_ua, rbac_fa WHERE rbac_ua.rol_id IN ('%s') AND rbac_ua.rol_id = rbac_fa.rol_id AND object_data.obj_id = rbac_fa.rol_id AND rbac_ua.usr_id=" . $user_id,
-                join("','", $rbacreview->assignedRoles($user_id))
+                implode("','", $rbacreview->assignedRoles($user_id))
             );
 
             $rbacresult = $ilDB->query($query);
             while ($rbacrow = $rbacresult->fetchRow(ilDBConstants::FETCHMODE_ASSOC)) {
-                if ($rbacrow["assign"] != "y") {
+                if ($rbacrow["assign"] !== "y") {
                     continue;
                 }
 
                 $type = "";
 
-                if ($rbacrow["parent"] == ROLE_FOLDER_ID) {
+                if ((int) $rbacrow["parent"] === ROLE_FOLDER_ID) {
                     $type = "Global";
                 } else {
                     $type = "Local";
@@ -618,10 +618,10 @@ class ilSoapRBACAdministration extends ilSoapAdministration
                     );
                 }
             }
-        } elseif ($id == "-1") {
+        } elseif ($id === -1) {
             // get all roles of system role folder
             if (!$rbacsystem->checkAccess('read', ROLE_FOLDER_ID)) {
-                return $this->__raiseError('Check access failed.', 'Server');
+                return $this->raiseError('Check access failed.', 'Server');
             }
 
             $roles = $rbacreview->getAssignableRoles(false, true);
@@ -629,22 +629,19 @@ class ilSoapRBACAdministration extends ilSoapAdministration
             // get local roles for a specific repository object
             // needs permission to read permissions of this object
             if (!$rbacsystem->checkAccess('edit_permission', $id)) {
-                return $this->__raiseError('Check access for local roles failed.', 'Server');
-            }
-
-            if (!is_numeric($id)) {
-                return $this->__raiseError('Id must be numeric to process roles of a repository object.', 'Client');
+                return $this->raiseError('Check access for local roles failed.', 'Server');
             }
 
             $role_type = "local";
 
             foreach ($rbacreview->getRolesOfRoleFolder($id, false) as $role_id) {
                 if ($tmp_obj = ilObjectFactory::getInstanceByObjId($role_id, false)) {
-                    $roles[] = array("obj_id" => $role_id,
-                                     "title" => $tmp_obj->getTitle(),
-                                     "description" => $tmp_obj->getDescription(),
-                                     "role_type" => $role_type
-                    );
+                    $roles[] = [
+                        "obj_id" => $role_id,
+                        "title" => $tmp_obj->getTitle(),
+                        "description" => $tmp_obj->getDescription(),
+                        "role_type" => $role_type
+                    ];
                 }
             }
         }
@@ -672,8 +669,8 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
@@ -683,18 +680,18 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         $ilUser = $DIC['ilUser'];
         $ilDB = $DIC['ilDB'];
 
-        if (strcasecmp($role_type, "") != 0 &&
-            strcasecmp($role_type, "local") != 0 &&
-            strcasecmp($role_type, "global") != 0 &&
-            strcasecmp($role_type, "template") != 0) {
-            return $this->__raiseError(
+        if (strcasecmp($role_type, "") !== 0 &&
+            strcasecmp($role_type, "local") !== 0 &&
+            strcasecmp($role_type, "global") !== 0 &&
+            strcasecmp($role_type, "template") !== 0) {
+            return $this->raiseError(
                 'Called service with wrong role_type parameter \'' . $role_type . '\'',
                 'Client'
             );
         }
 
-        if ($combination != 'and' and $combination != 'or') {
-            return $this->__raiseError(
+        if ($combination !== 'and' && $combination !== 'or') {
+            return $this->raiseError(
                 'No valid combination given. Must be "and" or "or".',
                 'Client'
             );
@@ -704,10 +701,10 @@ class ilSoapRBACAdministration extends ilSoapAdministration
 
         $query_parser = new ilQueryParser($key);
         $query_parser->setMinWordLength(3);
-        $query_parser->setCombination($combination == 'and' ? ilQueryParser::QP_COMBINATION_AND : ilQueryParser::QP_COMBINATION_OR);
+        $query_parser->setCombination($combination === 'and' ? ilQueryParser::QP_COMBINATION_AND : ilQueryParser::QP_COMBINATION_OR);
         $query_parser->parse();
         if (!$query_parser->validate()) {
-            return $this->__raiseError($query_parser->getMessage(), 'Client');
+            return $this->raiseError($query_parser->getMessage(), 'Client');
         }
 
         include_once './Services/Search/classes/class.ilObjectSearchFactory.php';
@@ -716,7 +713,7 @@ class ilSoapRBACAdministration extends ilSoapAdministration
         $object_search->setFilter(array("role", "rolt"));
 
         $res = $object_search->performSearch();
-        $res->filter(ROOT_FOLDER_ID, $combination == 'and' ? true : false);
+        $res->filter(ROOT_FOLDER_ID, $combination === 'and');
 
         $obj_ids = array();
         foreach ($res->getUniqueResults() as $entry) {
@@ -725,10 +722,9 @@ class ilSoapRBACAdministration extends ilSoapAdministration
 
         $roles = array();
         if (count($obj_ids) > 0) {
-            #print_r($obj_ids);
-            $roles = $rbacreview->getRolesForIDs($obj_ids, $role_type == "template");
+            $roles = $rbacreview->getRolesForIDs($obj_ids, $role_type === "template");
         }
-        #print_r($roles);
+
         include_once './webservice/soap/classes/class.ilSoapRoleObjectXMLWriter.php';
         $xml_writer = new ilSoapRoleObjectXMLWriter();
         $xml_writer->setObjects($roles);
@@ -742,18 +738,18 @@ class ilSoapRBACAdministration extends ilSoapAdministration
     private function parseUserID(int $id, string $role_type)
     {
         $user_id = 0;
-        if (strcasecmp($role_type, "user") == 0) {
+        if (strcasecmp($role_type, "user") === 0) {
             // get user roles for user id, which can be numeric or ilias id
             $user_id = !is_numeric($id) ? ilUtil::__extractId($id, IL_INST_ID) : $id;
             if (!is_numeric($user_id)) {
-                return $this->__raiseError('ID must be either numeric or ILIAS conform id for type \'user\'', 'Client');
+                return $this->raiseError('ID must be either numeric or ILIAS conform id for type \'user\'', 'Client');
             }
-        } elseif (strcasecmp($role_type, "user_login") == 0) {
+        } elseif (strcasecmp($role_type, "user_login") === 0) {
             // check for login
             $user_id = ilObjUser::_lookupId($id);
             if (!$user_id) {
                 // could not find a valid user
-                return $this->__raiseError('User with login \'' . $id . '\' does not exist!', 'Client');
+                return $this->raiseError('User with login \'' . $id . '\' does not exist!', 'Client');
             }
         }
         return $user_id;

--- a/webservice/soap/classes/class.ilSoapRBACAdministration.php
+++ b/webservice/soap/classes/class.ilSoapRBACAdministration.php
@@ -566,8 +566,10 @@ class ilSoapRBACAdministration extends ilSoapAdministration
             strcasecmp($role_type, "user") != 0 &&
             strcasecmp($role_type, "user_login") != 0 &&
             strcasecmp($role_type, "template") != 0) {
-            return $this->__raiseError('Called service with wrong role_type parameter \'' . $role_type . '\'',
-                'Client');
+            return $this->__raiseError(
+                'Called service with wrong role_type parameter \'' . $role_type . '\'',
+                'Client'
+            );
         }
 
         $roles = array();
@@ -685,8 +687,10 @@ class ilSoapRBACAdministration extends ilSoapAdministration
             strcasecmp($role_type, "local") != 0 &&
             strcasecmp($role_type, "global") != 0 &&
             strcasecmp($role_type, "template") != 0) {
-            return $this->__raiseError('Called service with wrong role_type parameter \'' . $role_type . '\'',
-                'Client');
+            return $this->__raiseError(
+                'Called service with wrong role_type parameter \'' . $role_type . '\'',
+                'Client'
+            );
         }
 
         if ($combination != 'and' and $combination != 'or') {

--- a/webservice/soap/classes/class.ilSoapRepositoryStructureObject.php
+++ b/webservice/soap/classes/class.ilSoapRepositoryStructureObject.php
@@ -61,14 +61,16 @@ class ilSoapRepositoryStructureObject extends ilSoapStructureObject
         return ILIAS_HTTP_PATH . "/" . "goto.php?target=" . $this->getType() . "_" . $this->getRefId() . "&client_id=" . CLIENT_ID;
     }
 
+    /**
+     * @return array{type: string, ref_id: int, obj_id: int}
+     */
     public function _getXMLAttributes() : array
     {
-        $attrs = array('type' => $this->getType(),
-                       'obj_id' => $this->getObjId(),
-                       'ref_id' => $this->getRefId()
-        );
-
-        return $attrs;
+        return [
+            'type' => $this->getType(),
+            'obj_id' => $this->getObjId(),
+            'ref_id' => $this->getRefId()
+        ];
     }
 
     public function _getTagName() : string

--- a/webservice/soap/classes/class.ilSoapSCORMAdministration.php
+++ b/webservice/soap/classes/class.ilSoapSCORMAdministration.php
@@ -31,16 +31,16 @@ include_once './webservice/soap/classes/class.ilSoapAdministration.php';
 
 class ilSoapSCORMAdministration extends ilSoapAdministration
 {
-    public function getIMSManifestXML(string $sid, int $ref_id)
+    public function getIMSManifestXML(string $sid, int $requested_ref_id)
     {
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
-        if (!strlen($ref_id)) {
-            return $this->__raiseError(
+        if (!($requested_ref_id > 0)) {
+            return $this->raiseError(
                 'No ref id given. Aborting!',
                 'Client'
             );
@@ -51,19 +51,17 @@ class ilSoapSCORMAdministration extends ilSoapAdministration
         $tree = $DIC['tree'];
         $ilLog = $DIC['ilLog'];
 
-        // get obj_id
-        if (!$obj_id = ilObject::_lookupObjectId($ref_id)) {
-            return $this->__raiseError(
-                'No exercise found for id: ' . $ref_id,
+        if (!$obj_id = ilObject::_lookupObjectId($requested_ref_id)) {
+            return $this->raiseError(
+                'No exercise found for id: ' . $requested_ref_id,
                 'Client'
             );
         }
 
-        if (ilObject::_isInTrash($ref_id)) {
-            return $this->__raiseError("Parent with ID $ref_id has been deleted.", 'Client');
+        if (ilObject::_isInTrash($requested_ref_id)) {
+            return $this->raiseError("Parent with ID $requested_ref_id has been deleted.", 'Client');
         }
 
-        // Check access
         $permission_ok = false;
         foreach ($ref_ids = ilObject::_getAllReferences($obj_id) as $ref_id) {
             if ($rbacsystem->checkAccess('read', $ref_id)) {
@@ -73,28 +71,28 @@ class ilSoapSCORMAdministration extends ilSoapAdministration
         }
 
         if (!$permission_ok) {
-            return $this->__raiseError(
-                'No permission to read the object with id: ' . $ref_id,
+            return $this->raiseError(
+                'No permission to read the object with id: ' . $requested_ref_id,
                 'Server'
             );
         }
 
         $lm_obj = ilObjectFactory::getInstanceByObjId($obj_id, false);
-        if (!is_object($lm_obj) || $lm_obj->getType() != "sahs") {
-            return $this->__raiseError(
-                'Wrong obj id or type for scorm object with id ' . $ref_id,
+        if (!is_object($lm_obj) || $lm_obj->getType() !== "sahs") {
+            return $this->raiseError(
+                'Wrong obj id or type for scorm object with id ' . $requested_ref_id,
                 'Server'
             );
         }
-        // get scorm xml
+
         require_once("./Modules/ScormAicc/classes/SCORM/class.ilSCORMObject.php");
         require_once("./Modules/ScormAicc/classes/SCORM/class.ilSCORMResource.php");
 
         $imsFilename = $lm_obj->getDataDirectory() . DIRECTORY_SEPARATOR . "imsmanifest.xml";
 
         if (!file_exists($imsFilename)) {
-            return $this->__raiseError(
-                'Could not find manifest file for object with ref id ' . $ref_id,
+            return $this->raiseError(
+                'Could not find manifest file for object with ref id ' . $requested_ref_id,
                 'Server'
             );
         }
@@ -106,11 +104,11 @@ class ilSoapSCORMAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
-        if (!strlen($ref_id)) {
-            return $this->__raiseError(
+        if (!($ref_id > 0)) {
+            return $this->raiseError(
                 'No ref id given. Aborting!',
                 'Client'
             );
@@ -121,22 +119,20 @@ class ilSoapSCORMAdministration extends ilSoapAdministration
         $tree = $DIC['tree'];
         $ilLog = $DIC['ilLog'];
 
-        // get obj_id
         if (!$obj_id = ilObject::_lookupObjectId($ref_id)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No exercise found for id: ' . $ref_id,
                 'Client'
             );
         }
 
         if (ilObject::_isInTrash($ref_id)) {
-            return $this->__raiseError("Parent with ID $ref_id has been deleted.", 'Client');
+            return $this->raiseError("Parent with ID $ref_id has been deleted.", 'Client');
         }
 
         $certValidator = new ilCertificateUserCertificateAccessValidator();
-        $result = $certValidator->validate($usr_id, $obj_id);
 
-        return $result;
+        return $certValidator->validate($usr_id, $obj_id);
     }
 
     public function getSCORMCompletionStatus(string $sid, int $a_usr_id, int $a_ref_id)
@@ -144,19 +140,18 @@ class ilSoapSCORMAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
-        if (!strlen($a_ref_id)) {
-            return $this->__raiseError('No ref_id given. Aborting!', 'Client');
+        if (!($a_ref_id > 0)) {
+            return $this->raiseError('No ref_id given. Aborting!', 'Client');
         }
 
         include_once 'include/inc.header.php';
 
-        // get obj_id
         if (!$obj_id = ilObject::_lookupObjectId($a_ref_id)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No scorm module found for id: ' . $a_ref_id,
                 'Client'
             );
@@ -166,15 +161,15 @@ class ilSoapSCORMAdministration extends ilSoapAdministration
         include_once 'Services/Tracking/classes/class.ilObjUserTracking.php';
 
         if (!ilObjUserTracking::_enabledLearningProgress()) {
-            return $this->__raiseError('Learning progress not enabled in this installation. Aborting!', 'Server');
+            return $this->raiseError('Learning progress not enabled in this installation. Aborting!', 'Server');
         }
 
         $status = ilLPStatus::_lookupStatus($obj_id, $a_usr_id);
-        if ($status == ilLPStatus::LP_STATUS_COMPLETED_NUM) {
+        if ($status === ilLPStatus::LP_STATUS_COMPLETED_NUM) {
             return 'completed';
-        } elseif ($status == ilLPStatus::LP_STATUS_FAILED_NUM) {
+        } elseif ($status === ilLPStatus::LP_STATUS_FAILED_NUM) {
             return 'failed';
-        } elseif ($status == ilLPStatus::LP_STATUS_IN_PROGRESS_NUM) {
+        } elseif ($status === ilLPStatus::LP_STATUS_IN_PROGRESS_NUM) {
             return 'in_progress';
         } else {
             return 'not_attempted';

--- a/webservice/soap/classes/class.ilSoapSCORMAdministration.php
+++ b/webservice/soap/classes/class.ilSoapSCORMAdministration.php
@@ -31,7 +31,6 @@ include_once './webservice/soap/classes/class.ilSoapAdministration.php';
 
 class ilSoapSCORMAdministration extends ilSoapAdministration
 {
-
     public function getIMSManifestXML(string $sid, int $ref_id)
     {
         $this->initAuth($sid);

--- a/webservice/soap/classes/class.ilSoapStructureObject.php
+++ b/webservice/soap/classes/class.ilSoapStructureObject.php
@@ -44,7 +44,7 @@ class ilSoapStructureObject
         $this->parentRefId = $parentRefId;
     }
 
-    public function addStructureObject(ilSoapStructureObject $structureObject)
+    public function addStructureObject(ilSoapStructureObject $structureObject) : void
     {
         $this->structureObjects [$structureObject->getObjId()] = $structureObject;
     }
@@ -54,17 +54,11 @@ class ilSoapStructureObject
         return $this->structureObjects;
     }
 
-    /**
-     *    set current ObjId
-     */
     public function setObjId(int $value) : void
     {
         $this->obj_id = $value;
     }
 
-    /**
-     * return current object id
-     */
     public function getObjId() : int
     {
         return $this->obj_id;
@@ -102,21 +96,24 @@ class ilSoapStructureObject
 
     public function getGotoLink() : string
     {
-        return ILIAS_HTTP_PATH . "/" . "goto.php?target=" . $this->getType() . "_" . $this->getObjId() . (is_numeric($this->getParentRefId()) ? "_" . $this->getParentRefId() : "") . "&client_id=" . CLIENT_ID;
+        return ILIAS_HTTP_PATH . "/" . "goto.php?target=" . $this->getType() .
+            "_" . $this->getObjId() .
+            (is_numeric($this->getParentRefId()) ? "_" . $this->getParentRefId() : "") . "&client_id=" . CLIENT_ID;
     }
 
-    /**
-     *    return current internal_link
-     */
     public function getInternalLink() : string
     {
         return '';
     }
 
+    /**
+     * @return array{type: string, obj_id: int}
+     */
     public function _getXMLAttributes() : array
     {
-        return array('type' => $this->getType(),
-                     'obj_id' => $this->getObjId()
+        return array(
+            'type' => $this->getType(),
+            'obj_id' => $this->getObjId()
         );
     }
 
@@ -125,17 +122,11 @@ class ilSoapStructureObject
         return "StructureObject";
     }
 
-    /**
-     * set ref id for parent object (used for permanent link if set)
-     */
     public function setParentRefId(int $parentRefId) : void
     {
         $this->parentRefId = $parentRefId;
     }
 
-    /**
-     * read access to parents ref id
-     */
     public function getParentRefId() : ?int
     {
         return $this->parentRefId;
@@ -145,7 +136,6 @@ class ilSoapStructureObject
     {
         $attrs = $this->_getXMLAttributes();
 
-        // open tag
         $xml_writer->xmlStartTag($this->_getTagName(), $attrs);
 
         $xml_writer->xmlElement('Title', null, $this->getTitle());
@@ -155,7 +145,6 @@ class ilSoapStructureObject
 
         $xml_writer->xmlStartTag("StructureObjects");
 
-        // handle sub elements
         $structureObjects = $this->getStructureObjects();
 
         foreach ($structureObjects as $structureObject) {

--- a/webservice/soap/classes/class.ilSoapStructureObjectAdministration.php
+++ b/webservice/soap/classes/class.ilSoapStructureObjectAdministration.php
@@ -34,19 +34,19 @@ class ilSOAPStructureObjectAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         if (!$target_obj = ilObjectFactory::getInstanceByRefId($ref_id, false)) {
-            return $this->__raiseError('No valid reference id given.', 'Client');
+            return $this->raiseError('No valid reference id given.', 'Client');
         }
 
         $structureReaderClassname = "ilSoap" . strtoupper($target_obj->getType()) . "StructureReader";
         $filename = "./webservice/soap/classes/class." . $structureReaderClassname . ".php";
 
         if (!file_exists($filename)) {
-            return $this->__raiseError("Object type '" . $target_obj->getType() . "'is not supported.", 'Client');
+            return $this->raiseError("Object type '" . $target_obj->getType() . "'is not supported.", 'Client');
         }
 
         include_once $filename;
@@ -56,7 +56,7 @@ class ilSOAPStructureObjectAdministration extends ilSoapAdministration
         $structureObject = &$structureReader->getStructureObject();
         $xml_writer->setStructureObject($structureObject);
         if (!$xml_writer->start()) {
-            return $this->__raiseError('Cannot create object xml !', 'Server');
+            return $this->raiseError('Cannot create object xml !', 'Server');
         }
         return $xml_writer->getXML();
     }

--- a/webservice/soap/classes/class.ilSoapStructureObjectFactory.php
+++ b/webservice/soap/classes/class.ilSoapStructureObjectFactory.php
@@ -31,9 +31,8 @@ class ilSoapStructureObjectFactory
 {
     public function getInstanceForObject(ilObject $object) : ?ilSoapStructureObject
     {
-        $classname = ilSoapStructureObjectFactory::_getClassnameForType($object->getType());
-
-        if ($classname != null) {
+        $classname = $this->_getClassnameForType($object->getType());
+        if ($classname !== null) {
             switch ($object->getType()) {
                 case "lm":
                 case "glo":
@@ -44,9 +43,9 @@ class ilSoapStructureObjectFactory
                         $object->getLongDescription(),
                         $object->getRefId()
                     );
-                    break;
             }
         }
+
         return null;
     }
 
@@ -57,8 +56,8 @@ class ilSoapStructureObjectFactory
         string $description,
         int $parentRefId
     ) : ?ilSoapStructureObject {
-        $classname = ilSoapStructureObjectFactory::_getClassnameForType($type);
-        if ($classname == null) {
+        $classname = $this->_getClassnameForType($type);
+        if ($classname === null) {
             return null;
         }
 
@@ -68,6 +67,7 @@ class ilSoapStructureObjectFactory
     public function _getClassnameForType(string $type) : ?string
     {
         switch ($type) {
+            case "glo":
             case "lm":
                 include_once "./webservice/soap/classes/class.ilSoapRepositoryStructureObject.php";
                 return "ilSoapRepositoryStructureObject";
@@ -77,9 +77,6 @@ class ilSoapStructureObjectFactory
             case "pg":
                 include_once "./webservice/soap/classes/class.ilSoapLMPageStructureObject.php";
                 return "ilSoapLMPageStructureObject";
-            case "glo":
-                include_once "./webservice/soap/classes/class.ilSoapRepositoryStructureObject.php";
-                return "ilSoapRepositoryStructureObject";
             case "git":
                 include_once "./webservice/soap/classes/class.ilSoapGLOTermStructureObject.php";
                 return "ilSoapGLOTermStructureObject";
@@ -88,6 +85,7 @@ class ilSoapStructureObjectFactory
                 return "ilSoapGLOTermDefinitionStructureObject";
 
         }
+
         return null;
     }
 }

--- a/webservice/soap/classes/class.ilSoapStructureObjectXMLWriter.php
+++ b/webservice/soap/classes/class.ilSoapStructureObjectXMLWriter.php
@@ -18,7 +18,6 @@ class ilSoapStructureObjectXMLWriter extends ilXmlWriter
 {
     public string $xml;
     public ?ilSoapStructureObject $structureObject = null;
-    private int $user_id = 0;
 
     public function __construct()
     {
@@ -26,7 +25,6 @@ class ilSoapStructureObjectXMLWriter extends ilXmlWriter
 
         $ilUser = $DIC->user();
         parent::__construct();
-        $this->user_id = $ilUser->getId();
     }
 
     public function setStructureObject(ilSoapStructureObject $structureObject) : void
@@ -40,9 +38,9 @@ class ilSoapStructureObjectXMLWriter extends ilXmlWriter
             return false;
         }
 
-        $this->__buildHeader();
+        $this->buildHeader();
         $this->structureObject->exportXML($this);
-        $this->__buildFooter();
+        $this->buildFooter();
         return true;
     }
 
@@ -51,14 +49,14 @@ class ilSoapStructureObjectXMLWriter extends ilXmlWriter
         return $this->xmlDumpMem(false);
     }
 
-    public function __buildHeader() : void
+    private function buildHeader() : void
     {
         $this->xmlSetDtdDef("<!DOCTYPE RepositoryObject PUBLIC \"-//ILIAS//DTD UserImport//EN\" \"" . ILIAS_HTTP_PATH . "/xml/ilias_soap_structure_object_3_7.dtd\">");
         $this->xmlSetGenCmt("Internal Structure Information of Repository Object");
         $this->xmlHeader();
     }
 
-    public function __buildFooter() : void
+    private function buildFooter() : void
     {
     }
 }

--- a/webservice/soap/classes/class.ilSoapStructureReader.php
+++ b/webservice/soap/classes/class.ilSoapStructureReader.php
@@ -28,7 +28,7 @@ class ilSoapStructureReader
 
     public function isValid() : bool
     {
-        return $this->structureObject != null && is_a($this->structureObject, "ilSoapStructureObject");
+        return $this->structureObject instanceof \ilSoapStructureObject;
     }
 
     public function getObject() : ilObject

--- a/webservice/soap/classes/class.ilSoapTestAdministration.php
+++ b/webservice/soap/classes/class.ilSoapTestAdministration.php
@@ -89,45 +89,38 @@ class ilSoapTestAdministration extends ilSoapAdministration
 
                     $ilClientIniFile = $DIC['ilClientIniFile'];
                     $expires = $ilClientIniFile->readVariable('session', 'expire');
-                    if ($diff <= $expires) {
-                        return true;
-                    } else {
-                        return false;
-                    }
-                } else {
-                    return false;
+                    return $diff <= $expires;
                 }
-            } else {
+
                 return false;
             }
-        } else {
-            $result = $ilDB->queryF(
-                "SELECT user_fi FROM tst_active WHERE active_id = %s",
-                array('integer'),
-                array($active_id)
-            );
-            $row = $ilDB->fetchAssoc($result);
-            if ($row['user_fi'] == $ilUser->getId()) {
-                return true;
-            } else {
-                return false;
-            }
+
+            return false;
         }
+
+        $result = $ilDB->queryF(
+            "SELECT user_fi FROM tst_active WHERE active_id = %s",
+            array('integer'),
+            array($active_id)
+        );
+        $row = $ilDB->fetchAssoc($result);
+
+        return (int) $row['user_fi'] === $ilUser->getId();
     }
 
-    public function saveQuestion(string $sid, int $active_id, int $question_id, int $pass, int $solution)
+    public function saveQuestion(string $sid, int $active_id, int $question_id, int $pass, int $solution)// TODO PHP8-REVIEW Wrong type, mismatch with operations
     {
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
         if (!$this->isAllowedCall($sid, $active_id)) {
-            return $this->__raiseError("The required user information is only available for active users.", "");
+            return $this->raiseError("The required user information is only available for active users.", "");
         }
 
-        if (is_array($solution) && (array_key_exists("item", $solution))) {
+        if (is_array($solution) && (array_key_exists("item", $solution))) {// TODO PHP8-REVIEW Wrong type, missmatch with declaration
             $solution = $solution["item"];
         }
 
@@ -162,7 +155,7 @@ class ilSoapTestAdministration extends ilSoapAdministration
                 $solution
             ) {
                 $ilDB = $GLOBALS['DIC']['ilDB'];
-                if (($active_id > 0) && ($question_id > 0) && (strlen($pass) > 0)) {
+                if (($active_id > 0) && ($question_id > 0) && (strlen($pass) > 0)) {// TODO PHP8-REVIEW Wrong type, missmatch with declaration
                     $affectedRows = $ilDB->manipulateF(
                         "DELETE FROM tst_solutions WHERE active_fi = %s AND question_fi = %s AND pass = %s",
                         array('integer', 'integer', 'integer'),
@@ -185,7 +178,7 @@ class ilSoapTestAdministration extends ilSoapAdministration
                 }
             });
 
-            if ($totalrows != 0) {
+            if ($totalrows !== 0) {
                 include_once "./Modules/TestQuestionPool/classes/class.assQuestion.php";
                 $question = assQuestion::instantiateQuestion($question_id);
                 $question->setProcessLocker($processLocker);
@@ -193,8 +186,8 @@ class ilSoapTestAdministration extends ilSoapAdministration
             }
         });
 
-        if ($totalrows == 0) {
-            return $this->__raiseError(
+        if ($totalrows === 0) {
+            return $this->raiseError(
                 "Wrong solution data. ILIAS did not execute any database queries: Solution data: " . print_r(
                     $solution,
                     true
@@ -213,14 +206,14 @@ class ilSoapTestAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
         if (!$this->isAllowedCall($sid, $active_id)) {
-            return $this->__raiseError("The required user information is only available for active users.", "");
+            return $this->raiseError("The required user information is only available for active users.", "");
         }
 
-        $solutions = array();
+        $solutions = [];
         if (preg_match("/<values>(.*?)<\/values>/is", $solution, $matches)) {
             if (preg_match_all(
                 "/<value>(.*?)<\/value><value>(.*?)<\/value><points>(.*?)<\/points>/is",
@@ -229,7 +222,7 @@ class ilSoapTestAdministration extends ilSoapAdministration
                 PREG_SET_ORDER
             )) {
                 foreach ($matches as $match) {
-                    if (count($match) == 4) {
+                    if (count($match) === 4) {
                         for ($i = 1, $iMax = count($match); $i < $iMax; $i++) {
                             $solutions[] = trim($match[$i]);
                         }
@@ -238,16 +231,15 @@ class ilSoapTestAdministration extends ilSoapAdministration
             }
         }
 
-        if (count($solutions) == 0) {
-            return $this->__raiseError(
+        if (count($solutions) === 0) {
+            return $this->raiseError(
                 "Wrong solution data. ILIAS did not find one or more solution triplets: $solution",
                 ""
             );
         }
 
-        // Include main header
         $ilDB = $GLOBALS['DIC']['ilDB'];
-        if (($active_id > 0) && ($question_id > 0) && (strlen($pass) > 0)) {
+        if (($active_id > 0) && ($question_id > 0) && (strlen($pass) > 0)) {// TODO PHP8-REVIEW Wrong type, missmatch with declaration
             $affectedRows = $ilDB->manipulateF(
                 "DELETE FROM tst_solutions WHERE active_fi = %s AND question_fi = %s AND pass = %s",
                 array('integer', 'integer', 'integer'),
@@ -269,8 +261,8 @@ class ilSoapTestAdministration extends ilSoapAdministration
             ));
             $totalrows += $affectedRows;
         }
-        if ($totalrows == 0) {
-            return $this->__raiseError("Wrong solution data. ILIAS did not execute any database queries");
+        if ($totalrows === 0) {
+            return $this->raiseError("Wrong solution data. ILIAS did not execute any database queries");// TODO PHP8-REVIEW Missing argument
         }
 
         include_once "./Modules/TestQuestionPool/classes/class.assQuestion.php";
@@ -287,14 +279,14 @@ class ilSoapTestAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
         if (!$this->isAllowedCall($sid, $active_id, false)) {
-            return $this->__raiseError("The required user information is only available for active users.", "");
+            return $this->raiseError("The required user information is only available for active users.", "");
         }
         $solution = array();
-        // Include main header
+
         global $DIC;
 
         $ilDB = $DIC['ilDB'];
@@ -317,15 +309,15 @@ class ilSoapTestAdministration extends ilSoapAdministration
                 array('integer', 'integer'),
                 array($active_id, $question_id)
             );
-            if ($result->numRows() == 1) {
+            if ($result->numRows() === 1) {
                 $row = $ilDB->fetchAssoc($result);
-                $lastpass = $row["maxpass"];
+                $lastpass = (int) $row["maxpass"];
             }
         } else {
             $lastpass = $pass;
         }
 
-        if (($active_id > 0) && ($question_id > 0) && (strlen($lastpass) > 0)) {
+        if (($active_id > 0) && ($question_id > 0) && (strlen($lastpass) > 0)) {// TODO PHP8-REVIEW Wrong type, might be an integer
             $result = $ilDB->queryF(
                 "SELECT * FROM tst_solutions WHERE active_fi = %s AND question_fi = %s AND pass = %s",
                 array('integer', 'integer', 'integer'),
@@ -347,12 +339,12 @@ class ilSoapTestAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
         if (!$this->isAllowedCall($sid, $active_id, false)) {
-            if (!$this->checkActiveIdResultsAccess($active_id)) {
-                return $this->__raiseError("The required user information is only available for active users.", "");
+            if (!$this->checkActiveIdResultsAccess($active_id)) {// TODO PHP8-REVIEW Method undefined
+                return $this->raiseError("The required user information is only available for active users.", "");
             }
         }
 
@@ -385,7 +377,7 @@ class ilSoapTestAdministration extends ilSoapAdministration
         );
 
         $userdata = array();
-        if ($result->numRows() == 0) {
+        if ($result->numRows() === 0) {
             $userdata["fullname"] = $lng->txt("deleted_user");
             $userdata["title"] = "";
             $userdata["firstname"] = "";
@@ -393,7 +385,7 @@ class ilSoapTestAdministration extends ilSoapAdministration
             $userdata["login"] = "";
         } else {
             $data = $ilDB->fetchAssoc($result);
-            if (($user_id == ANONYMOUS_USER_ID) || ($anonymity)) {
+            if ((int) $user_id === ANONYMOUS_USER_ID || $anonymity) {
                 $userdata["fullname"] = $lng->txt("anonymous");
                 $userdata["title"] = "";
                 $userdata["firstname"] = "";
@@ -418,11 +410,11 @@ class ilSoapTestAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
         if (!$this->isAllowedCall($sid, $active_id, false)) {
-            return $this->__raiseError("The required user information is only available for active users.", "");
+            return $this->raiseError("The required user information is only available for active users.", "");
         }
 
         global $DIC;
@@ -435,7 +427,7 @@ class ilSoapTestAdministration extends ilSoapAdministration
             array('integer'),
             array($active_id)
         );
-        if ($result->numRows() != 1) {
+        if ($result->numRows() !== 1) {
             return -1;
         }
         $row = $ilDB->fetchAssoc($result);
@@ -454,11 +446,11 @@ class ilSoapTestAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
         if (!$this->isAllowedCall($sid, $active_id, false)) {
-            return $this->__raiseError("The required user information is only available for active users.", "");
+            return $this->raiseError("The required user information is only available for active users.", "");
         }
 
         global $DIC;
@@ -471,7 +463,7 @@ class ilSoapTestAdministration extends ilSoapAdministration
             array('integer'),
             array($active_id)
         );
-        if ($result->numRows() != 1) {
+        if ($result->numRows() !== 1) {
             return -1;
         }
         $row = $ilDB->fetchAssoc($result);
@@ -508,11 +500,11 @@ class ilSoapTestAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
         if (!$this->isAllowedCall($sid, $active_id, false)) {
-            return $this->__raiseError("The required user information is only available for active users.", "");
+            return $this->raiseError("The required user information is only available for active users.", "");
         }
 
         global $DIC;
@@ -525,7 +517,7 @@ class ilSoapTestAdministration extends ilSoapAdministration
             array('integer'),
             array($active_id)
         );
-        if ($result->numRows() != 1) {
+        if ($result->numRows() !== 1) {
             return 0;
         }
         $row = $ilDB->fetchAssoc($result);
@@ -541,11 +533,11 @@ class ilSoapTestAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
-        if (!strlen($test_ref_id)) {
-            return $this->__raiseError(
+        if (!($test_ref_id > 0)) {
+            return $this->raiseError(
                 'No test id given. Aborting!',
                 'Client'
             );
@@ -557,21 +549,21 @@ class ilSoapTestAdministration extends ilSoapAdministration
         $ilLog = $DIC['ilLog'];
 
         if (!$this->checkManageParticipantsAccess($test_ref_id)) {
-            return $this->__raiseError('no permission. Aborting!', 'Client');
+            return $this->raiseError('no permission. Aborting!', 'Client');
         }
 
         if (ilObject::_isInTrash($test_ref_id)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'Test is trashed. Aborting!',
                 'Client'
             );
         }
 
         if (!$tst = ilObjectFactory::getInstanceByRefId($test_ref_id, false)) {
-            return $this->__raiseError('No test found for id: ' . $test_ref_id, 'Client');
+            return $this->raiseError('No test found for id: ' . $test_ref_id, 'Client');
         }
-        if ($tst->getType() != 'tst') {
-            return $this->__raiseError(
+        if ($tst->getType() !== 'tst') {
+            return $this->raiseError(
                 'Object with ref_id ' . $test_ref_id . ' is not of type test. Aborting',
                 'Client'
             );
@@ -607,11 +599,11 @@ class ilSoapTestAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
-        if (!strlen($test_ref_id)) {
-            return $this->__raiseError(
+        if (!($test_ref_id > 0)) {
+            return $this->raiseError(
                 'No test id given. Aborting!',
                 'Client'
             );
@@ -623,21 +615,19 @@ class ilSoapTestAdministration extends ilSoapAdministration
         $ilLog = $DIC['ilLog'];
 
         if (ilObject::_isInTrash($test_ref_id)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'Test is trashed. Aborting!',
                 'Client'
             );
         }
 
-        // get obj_id
         if (!$obj_id = ilObject::_lookupObjectId($test_ref_id)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No test found for id: ' . $test_ref_id,
                 'Client'
             );
         }
 
-        // Check access
         $permission_ok = false;
         foreach ($ref_ids = ilObject::_getAllReferences($obj_id) as $ref_id) {
             if ($rbacsystem->checkAccess('write', $ref_id)) {
@@ -650,12 +640,12 @@ class ilSoapTestAdministration extends ilSoapAdministration
         }
 
         if (!$permission_ok) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No permission to edit the object with id: ' . $test_ref_id,
                 'Server'
             );
         }
-        // store into xml result set
+
         include_once './webservice/soap/classes/class.ilXMLResultSet.php';
         include_once './webservice/soap/classes/class.ilXMLResultSetWriter.php';
 
@@ -686,10 +676,10 @@ class ilSoapTestAdministration extends ilSoapAdministration
 
         if ($sum_only) {
             $data = $test_obj->getAllTestResults($participants, false);
-            // create xml
+
             $xmlResultSet->addColumn("maximum_points");
             $xmlResultSet->addColumn("received_points");
-            // skip titles
+
             $titles = array_shift($data);
             foreach ($data as $row) {
                 $xmlRow = new ilXMLResultSetRow();
@@ -704,7 +694,7 @@ class ilSoapTestAdministration extends ilSoapAdministration
             }
         } else {
             $data = $test_obj->getDetailedTestResults($participants);
-            // create xml
+
             $xmlResultSet->addColumn("question_id");
             $xmlResultSet->addColumn("question_title");
             $xmlResultSet->addColumn("maximum_points");
@@ -723,7 +713,7 @@ class ilSoapTestAdministration extends ilSoapAdministration
                 $xmlResultSet->addRow($xmlRow);
             }
         }
-        // create writer
+
         $xmlWriter = new ilXMLResultSetWriter($xmlResultSet);
         $xmlWriter->start();
         return $xmlWriter->getXML();

--- a/webservice/soap/classes/class.ilSoapTestAdministration.php
+++ b/webservice/soap/classes/class.ilSoapTestAdministration.php
@@ -169,7 +169,7 @@ class ilSoapTestAdministration extends ilSoapAdministration
                         array($active_id, $question_id, $pass)
                     );
                 }
-                for ($i = 0; $i < count($solution); $i += 3) {
+                for ($i = 0, $iMax = count($solution); $i < $iMax; $i += 3) {
                     $next_id = $ilDB->nextId('tst_solutions');
                     $affectedRows = $ilDB->insert("tst_solutions", array(
                         "solution_id" => array("integer", $next_id),
@@ -195,8 +195,10 @@ class ilSoapTestAdministration extends ilSoapAdministration
 
         if ($totalrows == 0) {
             return $this->__raiseError(
-                "Wrong solution data. ILIAS did not execute any database queries: Solution data: " . print_r($solution,
-                    true),
+                "Wrong solution data. ILIAS did not execute any database queries: Solution data: " . print_r(
+                    $solution,
+                    true
+                ),
                 'No result'
             );
         }
@@ -220,12 +222,16 @@ class ilSoapTestAdministration extends ilSoapAdministration
 
         $solutions = array();
         if (preg_match("/<values>(.*?)<\/values>/is", $solution, $matches)) {
-            if (preg_match_all("/<value>(.*?)<\/value><value>(.*?)<\/value><points>(.*?)<\/points>/is", $solution,
-                $matches, PREG_SET_ORDER)) {
+            if (preg_match_all(
+                "/<value>(.*?)<\/value><value>(.*?)<\/value><points>(.*?)<\/points>/is",
+                $solution,
+                $matches,
+                PREG_SET_ORDER
+            )) {
                 foreach ($matches as $match) {
                     if (count($match) == 4) {
-                        for ($i = 1; $i < count($match); $i++) {
-                            array_push($solutions, trim($match[$i]));
+                        for ($i = 1, $iMax = count($match); $i < $iMax; $i++) {
+                            $solutions[] = trim($match[$i]);
                         }
                     }
                 }
@@ -233,8 +239,10 @@ class ilSoapTestAdministration extends ilSoapAdministration
         }
 
         if (count($solutions) == 0) {
-            return $this->__raiseError("Wrong solution data. ILIAS did not find one or more solution triplets: $solution",
-                "");
+            return $this->__raiseError(
+                "Wrong solution data. ILIAS did not find one or more solution triplets: $solution",
+                ""
+            );
         }
 
         // Include main header
@@ -247,7 +255,7 @@ class ilSoapTestAdministration extends ilSoapAdministration
             );
         }
         $totalrows = 0;
-        for ($i = 0; $i < count($solutions); $i += 3) {
+        for ($i = 0, $iMax = count($solutions); $i < $iMax; $i += 3) {
             $next_id = $ilDB->nextId('tst_solutions');
             $affectedRows = $ilDB->insert("tst_solutions", array(
                 "solution_id" => array("integer", $next_id),
@@ -263,11 +271,11 @@ class ilSoapTestAdministration extends ilSoapAdministration
         }
         if ($totalrows == 0) {
             return $this->__raiseError("Wrong solution data. ILIAS did not execute any database queries");
-        } else {
-            include_once "./Modules/TestQuestionPool/classes/class.assQuestion.php";
-            $question = assQuestion::instantiateQuestion($question_id);
-            $question->calculateResultsFromSolution($active_id, $pass);
         }
+
+        include_once "./Modules/TestQuestionPool/classes/class.assQuestion.php";
+        $question = assQuestion::instantiateQuestion($question_id);
+        $question->calculateResultsFromSolution($active_id, $pass);
         return "TRUE";
     }
 
@@ -325,9 +333,9 @@ class ilSoapTestAdministration extends ilSoapAdministration
             );
             if ($result->numRows()) {
                 while ($row = $ilDB->fetchAssoc($result)) {
-                    array_push($solution, $row["value1"]);
-                    array_push($solution, $row["value2"]);
-                    array_push($solution, $row["points"]);
+                    $solution[] = $row["value1"];
+                    $solution[] = $row["value2"];
+                    $solution[] = $row["points"];
                 }
             }
         }
@@ -488,7 +496,7 @@ class ilSoapTestAdministration extends ilSoapAdministration
                 if ($qid == $question_id) {
                     $atposition = true;
                 } else {
-                    array_push($pointsforposition, $reachedpoints[$qid]);
+                    $pointsforposition[] = $reachedpoints[$qid];
                 }
             }
         }
@@ -563,8 +571,10 @@ class ilSoapTestAdministration extends ilSoapAdministration
             return $this->__raiseError('No test found for id: ' . $test_ref_id, 'Client');
         }
         if ($tst->getType() != 'tst') {
-            return $this->__raiseError('Object with ref_id ' . $test_ref_id . ' is not of type test. Aborting',
-                'Client');
+            return $this->__raiseError(
+                'Object with ref_id ' . $test_ref_id . ' is not of type test. Aborting',
+                'Client'
+            );
         }
 
         // Dirty hack

--- a/webservice/soap/classes/class.ilSoapUserAdministration.php
+++ b/webservice/soap/classes/class.ilSoapUserAdministration.php
@@ -41,7 +41,7 @@ class ilSoapUserAdministration extends ilSoapAdministration
         try {
             $this->initIlias();
         } catch (Exception $e) {
-            return $this->__raiseError($e->getMessage(), 'Server');
+            return $this->raiseError($e->getMessage(), 'Server');
         }
 
         // now try authentication
@@ -76,7 +76,7 @@ class ilSoapUserAdministration extends ilSoapAdministration
 
             default:
             case ilAuthStatus::STATUS_AUTHENTICATION_FAILED:
-                return $this->__raiseError(
+                return $this->raiseError(
                     $status->getReason(),
                     'Server'
                 );
@@ -91,8 +91,8 @@ class ilSoapUserAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         include_once './Services/Authentication/classes/class.ilSession.php';
@@ -106,14 +106,14 @@ class ilSoapUserAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         $user_name = trim($user_name);
 
-        if (!strlen($user_name)) {
-            return $this->__raiseError('No username given. Aborting', 'Client');
+        if ($user_name === '') {
+            return $this->raiseError('No username given. Aborting', 'Client');
         }
 
         global $DIC;
@@ -129,12 +129,12 @@ class ilSoapUserAdministration extends ilSoapAdministration
                 self::USER_FOLDER_ID
             )
         ) {
-            return $this->__raiseError('Check access failed. ' . self::USER_FOLDER_ID, 'Server');
+            return $this->raiseError('Check access failed. ' . self::USER_FOLDER_ID, 'Server');
         }
 
         $user_id = ilObjUser::getUserIdByLogin($user_name);
 
-        return $user_id ? $user_id : "0";
+        return $user_id;
     }
 
     public function getUser(string $sid, int $user_id)
@@ -142,8 +142,8 @@ class ilSoapUserAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
@@ -158,16 +158,17 @@ class ilSoapUserAdministration extends ilSoapAdministration
             self::USER_FOLDER_ID
         )
         ) {
-            return $this->__raiseError('Check access failed.', 'Server');
+            return $this->raiseError('Check access failed.', 'Server');
         }
 
         if ($ilUser->getLoginByUserId($user_id)) {
+            /** @var ilObjUser $tmp_user */
             $tmp_user = ilObjectFactory::getInstanceByObjId($user_id);
-            $usr_data = $this->__readUserData($tmp_user);
+            $usr_data = $this->readUserData($tmp_user);
 
             return $usr_data;
         }
-        return $this->__raiseError('User does not exist', 'Client');
+        return $this->raiseError('User does not exist', 'Client');
     }
 
     public function deleteUser(string $sid, int $user_id)
@@ -175,12 +176,12 @@ class ilSoapUserAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         if (!isset($user_id)) {
-            return $this->__raiseError('No user_id given. Aborting', 'Client');
+            return $this->raiseError('No user_id given. Aborting', 'Client');
         }
 
         global $DIC;
@@ -190,17 +191,17 @@ class ilSoapUserAdministration extends ilSoapAdministration
         $log = $DIC['log'];
 
         if (!$rbacsystem->checkAccess('delete', self::USER_FOLDER_ID)) {
-            return $this->__raiseError('Check access failed.', 'Server');
+            return $this->raiseError('Check access failed.', 'Server');
         }
 
         if (!$ilUser->getLoginByUserId($user_id)) {
-            return $this->__raiseError('User id: ' . $user_id . ' is not a valid identifier. Aborting', 'Client');
+            return $this->raiseError('User id: ' . $user_id . ' is not a valid identifier. Aborting', 'Client');
         }
-        if ($ilUser->getId() == $user_id) {
-            return $this->__raiseError('Cannot delete myself. Aborting', 'Client');
+        if ($ilUser->getId() === $user_id) {
+            return $this->raiseError('Cannot delete myself. Aborting', 'Client');
         }
-        if ($user_id == SYSTEM_USER_ID) {
-            return $this->__raiseError('Cannot delete root account. Aborting', 'Client');
+        if ($user_id === SYSTEM_USER_ID) {
+            return $this->raiseError('Cannot delete root account. Aborting', 'Client');
         }
         // Delete him
         $log->write('SOAP: deleteUser()');
@@ -210,7 +211,7 @@ class ilSoapUserAdministration extends ilSoapAdministration
         return true;
     }
 
-    public function __readUserData(\ilObjUser &$usr_obj) : array
+    private function readUserData(\ilObjUser $usr_obj) : array
     {
         $usr_data['usr_id'] = $usr_obj->getId();
         $usr_data['login'] = $usr_obj->getLogin();
@@ -265,8 +266,8 @@ class ilSoapUserAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         include_once './Services/User/classes/class.ilUserImportParser.php';
@@ -286,7 +287,7 @@ class ilSoapUserAdministration extends ilSoapAdministration
         $error = false;
 
         // validate to prevent wrong XMLs
-        $this->dom = @domxml_open_mem($usr_xml, DOMXML_LOAD_VALIDATING, $error);
+        $this->dom = @domxml_open_mem($usr_xml, DOMXML_LOAD_VALIDATING, $error);// TODO PHP8-REVIEW Property dynamically declared: Please define the typed property / TODO PHP8-REVIEW Constant undefined
         if ($error) {
             $msg = array();
             if (is_array($error)) {
@@ -296,8 +297,8 @@ class ilSoapUserAdministration extends ilSoapAdministration
             } else {
                 $msg[] = $error;
             }
-            $msg = join("\n", $msg);
-            return $this->__raiseError($msg, "Client");
+            $msg = implode("\n", $msg);
+            return $this->raiseError($msg, "Client");
         }
 
         switch ($conflict_rule) {
@@ -310,20 +311,18 @@ class ilSoapUserAdministration extends ilSoapAdministration
             default:
                 $conflict_rule = IL_FAIL_ON_CONFLICT;
         }
-        if ($folder_id == 0) {
-            if (!$access->checkAccess('create_usr', '', self::USER_FOLDER_ID)) {
-                return $this->__raiseError(
-                    'Missing permission for creating/modifying users accounts' . self::USER_FOLDER_ID . ' ' . $ilUser->getId(),
-                    'Server'
-                );
-            }
+        if ($folder_id === 0 && !$access->checkAccess('create_usr', '', self::USER_FOLDER_ID)) {
+            return $this->raiseError(
+                'Missing permission for creating/modifying users accounts' . self::USER_FOLDER_ID . ' ' . $ilUser->getId(),
+                'Server'
+            );
         }
 
         // folder id 0, means to check permission on user basis!
         // must have create user right in time_limit_owner property (which is ref_id of container)
-        if ($folder_id != 0) {
+        if ($folder_id !== 0) {
             // determine where to import
-            if ($folder_id == -1) {
+            if ($folder_id === -1) {
                 $folder_id = self::USER_FOLDER_ID;
             }
 
@@ -331,17 +330,17 @@ class ilSoapUserAdministration extends ilSoapAdministration
             $import_folder = ilObjectFactory::getInstanceByRefId($folder_id, false);
             // id does not exist
             if (!$import_folder) {
-                return $this->__raiseError('Wrong reference id.', 'Server');
+                return $this->raiseError('Wrong reference id.', 'Server');
             }
 
             // folder is not a folder, can also be a category
-            if ($import_folder->getType() != "usrf" && $import_folder->getType() != "cat") {
-                return $this->__raiseError('Folder must be a usr folder or a category.', 'Server');
+            if ($import_folder->getType() !== "usrf" && $import_folder->getType() !== "cat") {
+                return $this->raiseError('Folder must be a usr folder or a category.', 'Server');
             }
 
             // check access to folder
             if (!$rbacsystem->checkAccess('create_usr', $folder_id)) {
-                return $this->__raiseError(
+                return $this->raiseError(
                     'Missing permission for creating users within ' . $import_folder->getTitle(),
                     'Server'
                 );
@@ -358,10 +357,10 @@ class ilSoapUserAdministration extends ilSoapAdministration
             case IL_IMPORT_SUCCESS:
                 break;
             case IL_IMPORT_WARNING:
-                return $this->__getImportProtocolAsXML($importParser->getProtocol());
+                return $this->getImportProtocolAsXML($importParser->getProtocol());
                 break;
             case IL_IMPORT_FAILURE:
-                return $this->__getImportProtocolAsXML($importParser->getProtocol());
+                return $this->getImportProtocolAsXML($importParser->getProtocol());
         }
 
         // verify is ok, so get role assignments
@@ -386,19 +385,13 @@ class ilSoapUserAdministration extends ilSoapAdministration
                     $role_id = $internalId;
                     $role_name = $role_id;
                 }
-                /*				else // perhaps it is a rolename
-                                {
-                                    $role  = ilSoapUserAdministration::__getRoleForRolename ($role_id);
-                                    $role_name = $role->title;
-                                    $role_id = $role->role_id;
-                                }*/
             }
 
             if ($this->isPermittedRole($folder_id, $role_id)) {
                 $permitted_roles[$role_id] = $role_id;
             } else {
                 $role_name = ilObject::_lookupTitle($role_id);
-                return $this->__raiseError(
+                return $this->raiseError(
                     "Could not find role " . $role_name . ". Either you use an invalid/deleted role " .
                     "or you try to assign a local role into the non-standard user folder and this role is not in its subtree.",
                     'Server'
@@ -413,13 +406,18 @@ class ilSoapUserAdministration extends ilSoapAdministration
         foreach ($permitted_roles as $role_id => $role_name) {
             if ($role_id != "") {
                 if (in_array($role_id, $global_roles)) {
-                    if ($role_id == SYSTEM_ROLE_ID && !in_array(
-                        SYSTEM_ROLE_ID,
-                        $rbacreview->assignedRoles($ilUser->getId())
-                    )
-                        || ($folder_id != self::USER_FOLDER_ID && $folder_id != 0 && !ilObjRole::_getAssignUsersStatus($role_id))
+                    if (
+                        (
+                            $folder_id !== 0 &&
+                            $folder_id !== self::USER_FOLDER_ID &&
+                            !ilObjRole::_getAssignUsersStatus($role_id)
+                        ) ||
+                        (
+                            $role_id == SYSTEM_ROLE_ID &&
+                            !in_array(SYSTEM_ROLE_ID, $rbacreview->assignedRoles($ilUser->getId()), true)
+                        )
                     ) {
-                        return $this->__raiseError(
+                        return $this->raiseError(
                             $lng->txt("usrimport_with_specified_role_not_permitted") . " $role_name ($role_id)",
                             'Server'
                         );
@@ -428,7 +426,7 @@ class ilSoapUserAdministration extends ilSoapAdministration
                     $rolf = $rbacreview->getFoldersAssignedToRole($role_id, true);
                     if ($rbacreview->isDeleted($rolf[0])
                         || !$rbacsystem->checkAccess('write', $rolf[0])) {
-                        return $this->__raiseError(
+                        return $this->raiseError(
                             $lng->txt("usrimport_with_specified_role_not_permitted") . " $role_name ($role_id)",
                             "Server"
                         );
@@ -449,10 +447,10 @@ class ilSoapUserAdministration extends ilSoapAdministration
 
         $importParser->startParsing();
 
-        if ($importParser->getErrorLevel() != IL_IMPORT_FAILURE) {
-            return $this->__getUserMappingAsXML($importParser->getUserMapping());
+        if ($importParser->getErrorLevel() !== IL_IMPORT_FAILURE) {
+            return $this->getUserMappingAsXML($importParser->getUserMapping());
         }
-        return $this->__getImportProtocolAsXML($importParser->getProtocol());
+        return $this->getImportProtocolAsXML($importParser->getProtocol());
     }
 
     protected function isPermittedRole(int $a_folder, int $a_role)
@@ -480,7 +478,7 @@ class ilSoapUserAdministration extends ilSoapAdministration
             $ilLog->write(__METHOD__ . ': Check global role');
             // check assignment permission if called from local admin
 
-            if ($a_folder != self::USER_FOLDER_ID and $a_folder != 0) {
+            if ($a_folder !== self::USER_FOLDER_ID && $a_folder !== 0) {
                 $ilLog->write(__METHOD__ . ': ' . $a_folder);
                 include_once './Services/AccessControl/classes/class.ilObjRole.php';
                 if (!ilObjRole::_getAssignUsersStatus($a_role)) {
@@ -490,13 +488,14 @@ class ilSoapUserAdministration extends ilSoapAdministration
                 }
             }
             // exclude anonymous role from list
-            if ($a_role == ANONYMOUS_ROLE_ID) {
+            if ($a_role === ANONYMOUS_ROLE_ID) {
                 $ilLog->write(__METHOD__ . ': Anonymous role chosen.');
                 $checked_roles[$a_role] = false;
                 return false;
             }
             // do not allow to assign users to administrator role if current user does not has SYSTEM_ROLE_ID
-            if ($a_role == SYSTEM_ROLE_ID and !in_array(SYSTEM_ROLE_ID, $rbacreview->assignedRoles($ilUser->getId()))) {
+            if ($a_role === SYSTEM_ROLE_ID &&
+                !in_array(SYSTEM_ROLE_ID, $rbacreview->assignedRoles($ilUser->getId()), true)) {
                 $ilLog->write(__METHOD__ . ': System role assignment forbidden.');
                 $checked_roles[$a_role] = false;
                 return false;
@@ -531,7 +530,7 @@ class ilSoapUserAdministration extends ilSoapAdministration
             // isInSubtree variable with true. In all other cases it is initialized
             // with false, and only set to true if we find the object id of the
             // locally administrated category in the tree path to the local role.
-            if ($a_folder != self::USER_FOLDER_ID and $a_folder != 0 and !$tree->isGrandChild($a_folder, $rolf)) {
+            if ($a_folder !== self::USER_FOLDER_ID && $a_folder !== 0 && !$tree->isGrandChild($a_folder, $rolf)) {
                 $ilLog->write(__METHOD__ . ': Not in path of category.');
                 $checked_roles[$a_role] = false;
                 return false;
@@ -550,8 +549,8 @@ class ilSoapUserAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
@@ -562,15 +561,15 @@ class ilSoapUserAdministration extends ilSoapAdministration
         $rbacsystem = $DIC['rbacsystem'];
         $access = $DIC->access();
 
-        if ($ref_id == -1) {
+        if ($ref_id === -1) {
             $ref_id = self::USER_FOLDER_ID;
         }
 
         if (
-            $ref_id == self::USER_FOLDER_ID &&
+            $ref_id === self::USER_FOLDER_ID &&
             !$access->checkAccess('read_users', '', self::USER_FOLDER_ID)
         ) {
-            return $this->__raiseError('Access denied', "Client");
+            return $this->raiseError('Access denied', "Client");
         }
 
         $object = $this->checkObjectAccess($ref_id, array("crs", "cat", "grp", "usrf", "sess"), "read", true);
@@ -578,7 +577,7 @@ class ilSoapUserAdministration extends ilSoapAdministration
             return $object;
         }
 
-        $data = array();
+        $data = [];
         switch ($object->getType()) {
             case "usrf":
                 $data = ilObjUser::_getUsersForFolder(self::USER_FOLDER_ID, $active);
@@ -604,7 +603,7 @@ class ilSoapUserAdministration extends ilSoapAdministration
             case "sess":
                 $course_ref_id = $tree->checkForParentType($ref_id, 'crs');
                 if (!$course_ref_id) {
-                    return $this->__raiseError("No course for session", "Client");
+                    return $this->raiseError("No course for session", "Client");
                 }
 
                 $event_obj_id = ilObject::_lookupObjId($ref_id);
@@ -615,18 +614,15 @@ class ilSoapUserAdministration extends ilSoapAdministration
                 break;
         }
 
-        if (is_array($data)) {
-            include_once './Services/User/classes/class.ilUserXMLWriter.php';
+        include_once './Services/User/classes/class.ilUserXMLWriter.php';
 
-            $xmlWriter = new ilUserXMLWriter();
-            $xmlWriter->setObjects($data);
-            $xmlWriter->setAttachRoles($attachRoles);
+        $xmlWriter = new ilUserXMLWriter();
+        $xmlWriter->setObjects($data);
+        $xmlWriter->setAttachRoles($attachRoles);
 
-            if ($xmlWriter->start()) {
-                return $xmlWriter->getXML();
-            }
+        if ($xmlWriter->start()) {
+            return $xmlWriter->getXML();
         }
-        return $this->__raiseError('Error in processing information. This is likely a bug.', 'Server');
     }
 
     public function getUserForRole(string $sid, int $role_id, bool $attachRoles, int $active)
@@ -634,26 +630,26 @@ class ilSoapUserAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         include_once './Services/AccessControl/classes/class.ilObjRole.php';
         global $DIC;
 
         $ilDB = $DIC['ilDB'];
-        $rbacreview = $DIC['rbacreview'];
+        $rbacreview = $DIC->rbac()->review();
         $tree = $DIC->repositoryTree();
         $ilUser = $DIC->user();
         $access = $DIC->access();
 
         $global_roles = $rbacreview->getGlobalRoles();
 
-        if (in_array($role_id, $global_roles)) {
+        if (in_array($role_id, $global_roles, true)) {
             // global roles
-            if ($role_id == SYSTEM_ROLE_ID && !in_array(SYSTEM_ROLE_ID, $rbacreview->assignedRoles($ilUser->getId()))
-            ) {
-                return $this->__raiseError("Role access not permitted. ($role_id)", "Server");
+            if ($role_id === SYSTEM_ROLE_ID &&
+                !in_array(SYSTEM_ROLE_ID, $rbacreview->assignedRoles($ilUser->getId()), true)) {
+                return $this->raiseError("Role access not permitted. ($role_id)", "Server");
             }
         } else {
             // local roles
@@ -683,7 +679,7 @@ class ilSoapUserAdministration extends ilSoapAdministration
                 $access_granted = false;
             }
             if (!$access_granted || !count($rolfs)) {
-                return $this->__raiseError('Role access not permitted. ' . '(' . $role_id . ')', 'Server');
+                return $this->raiseError('Role access not permitted. ' . '(' . $role_id . ')', 'Server');
             }
         }
 
@@ -698,13 +694,13 @@ class ilSoapUserAdministration extends ilSoapAdministration
         if ($xmlWriter->start()) {
             return $xmlWriter->getXML();
         }
-        return $this->__raiseError('Error in getUsersForRole', 'Server');
+        return $this->raiseError('Error in getUsersForRole', 'Server');
     }
 
     /**
      *    Create XML ResultSet
      **/
-    public function __getImportProtocolAsXML(array $a_array) : string
+    private function getImportProtocolAsXML(array $a_array) : string
     {
         include_once './webservice/soap/classes/class.ilXMLResultSet.php';
         include_once './webservice/soap/classes/class.ilXMLResultSetWriter.php';
@@ -733,14 +729,14 @@ class ilSoapUserAdministration extends ilSoapAdministration
             return $xml_writer->getXML();
         }
 
-        return $this->__raiseError('Error in __getImportProtocolAsXML', 'Server');
+        return $this->raiseError('Error in __getImportProtocolAsXML', 'Server');
     }
 
     /**
      * return user  mapping as xml
      * @param array (user_id => login) $a_array
      */
-    public function __getUserMappingAsXML(array $a_array)
+    private function getUserMappingAsXML(array $a_array)
     {
         include_once './webservice/soap/classes/class.ilXMLResultSet.php';
         include_once './webservice/soap/classes/class.ilXMLResultSetWriter.php';
@@ -769,7 +765,7 @@ class ilSoapUserAdministration extends ilSoapAdministration
             return $xml_writer->getXML();
         }
 
-        return $this->__raiseError('Error in __getUserMappingAsXML', 'Server');
+        return $this->raiseError('Error in __getUserMappingAsXML', 'Server');
     }
 
     /**
@@ -792,8 +788,8 @@ class ilSoapUserAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
@@ -802,21 +798,21 @@ class ilSoapUserAdministration extends ilSoapAdministration
         $access = $DIC->access();
 
         if (!$access->checkAccess('read_users', '', self::USER_FOLDER_ID)) {
-            return $this->__raiseError('Check access failed.', 'Server');
+            return $this->raiseError('Check access failed.', 'Server');
         }
         if (!count($a_keyfields)) {
-            $this->__raiseError('At least one keyfield is needed', 'Client');
+            $this->raiseError('At least one keyfield is needed', 'Client');
         }
 
         if (!count($a_keyvalues)) {
-            $this->__raiseError('At least one keyvalue is needed', 'Client');
+            $this->raiseError('At least one keyvalue is needed', 'Client');
         }
 
-        if (!strcasecmp($query_operator, "and") == 0 || !strcasecmp($query_operator, "or") == 0) {
-            $this->__raiseError('Query operator must be either \'and\' or \'or\'', 'Client');
+        if (strcasecmp($query_operator, "and") !== 0 || strcasecmp($query_operator, "or") !== 0) {
+            $this->raiseError('Query operator must be either \'and\' or \'or\'', 'Client');
         }
 
-        $query = $this->__buildSearchQuery($a_keyfields, $query_operator, $a_keyvalues);
+        $query = $this->buildSearchQuery($a_keyfields, $query_operator, $a_keyvalues);
 
         $query = "SELECT usr_data.*, usr_pref.value AS language
 		          FROM usr_data
@@ -826,7 +822,7 @@ class ilSoapUserAdministration extends ilSoapAdministration
             "'language'
 		          WHERE 1 = 1 " . $query;
 
-        if (is_numeric($active) && $active > -1) {
+        if ($active > -1) {
             $query .= " AND active = " . $ilDB->quote($active);
         }
 
@@ -852,7 +848,7 @@ class ilSoapUserAdministration extends ilSoapAdministration
         if ($xmlWriter->start()) {
             return $xmlWriter->getXML();
         }
-        return $this->__raiseError('Error in searchUser', 'Server');
+        return $this->raiseError('Error in searchUser', 'Server');
     }
 
     /**
@@ -861,8 +857,7 @@ class ilSoapUserAdministration extends ilSoapAdministration
      * @param string $queryOperator
      * @param array of string $a_keyValues
      */
-
-    public function __buildSearchQuery(array $a_keyfields, string $queryOperator, array $a_keyvalues) : string
+    private function buildSearchQuery(array $a_keyfields, string $queryOperator, array $a_keyvalues) : string
     {
         global $DIC;
 
@@ -894,11 +889,11 @@ class ilSoapUserAdministration extends ilSoapAdministration
                 }
             }
             if (count($field_query)) {
-                $query [] = join(" " . strtoupper($queryOperator) . " ", $field_query);
+                $query [] = implode(" " . strtoupper($queryOperator) . " ", $field_query);
             }
         }
 
-        return count($query) ? " AND ((" . join(") OR (", $query) . "))" : "AND 0";
+        return count($query) ? " AND ((" . implode(") OR (", $query) . "))" : "AND 0";
     }
 
     /**
@@ -912,8 +907,8 @@ class ilSoapUserAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
@@ -925,23 +920,18 @@ class ilSoapUserAdministration extends ilSoapAdministration
 
         // check if own account
         $is_self = false;
-        if (is_array($a_user_ids) and count($a_user_ids) == 1) {
-            if (end($a_user_ids) == $ilUser->getId()) {
-                $is_self = true;
-            }
-        } elseif (is_numeric($a_user_ids)) {
-            if ($a_user_ids == $ilUser->getId()) {
+        if (count($a_user_ids) === 1) {
+            $usr_id = (int) end($a_user_ids);
+            if ($usr_id === $ilUser->getId()) {
                 $is_self = true;
             }
         }
 
-        if (!$access->checkAccess('read_users', '', self::USER_FOLDER_ID) && !$is_self) {
-            return $this->__raiseError('Check access failed.', 'Server');
+        if (!$is_self && !$access->checkAccess('read_users', '', self::USER_FOLDER_ID)) {
+            return $this->raiseError('Check access failed.', 'Server');
         }
 
-        // begin-patch filemanager
-        $data = ilObjUser::_getUserData((array) $a_user_ids);
-        // end-patch filemanager
+        $data = ilObjUser::_getUserData($a_user_ids);
 
         include_once './Services/User/classes/class.ilUserXMLWriter.php';
         $xmlWriter = new ilUserXMLWriter();
@@ -952,28 +942,23 @@ class ilSoapUserAdministration extends ilSoapAdministration
             return $xmlWriter->getXML();
         }
 
-        return $this->__raiseError('User does not exist', 'Client');
+        return $this->raiseError('User does not exist', 'Client');
     }
 
-    // has new mail
     public function hasNewMail(string $sid)
     {
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
 
         $ilUser = $DIC['ilUser'];
 
-        if (ilMailGlobalServices::getNewMailsData($ilUser)['count'] > 0) {
-            return true;
-        }
-
-        return false;
+        return ilMailGlobalServices::getNewMailsData($ilUser)['count'] > 0;
     }
 
     public function getUserIdBySid(string $sid)
@@ -981,8 +966,8 @@ class ilSoapUserAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         global $DIC;
@@ -996,7 +981,7 @@ class ilSoapUserAdministration extends ilSoapAdministration
         $data = $ilDB->fetchAssoc($res);
 
         if (!(int) $data['usr_id']) {
-            $this->__raiseError('User does not exist', 'Client');
+            $this->raiseError('User does not exist', 'Client');
         }
 
         return (int) $data['usr_id'];

--- a/webservice/soap/classes/class.ilSoapUserAdministration.php
+++ b/webservice/soap/classes/class.ilSoapUserAdministration.php
@@ -162,7 +162,7 @@ class ilSoapUserAdministration extends ilSoapAdministration
         }
 
         if ($ilUser->getLoginByUserId($user_id)) {
-            $tmp_user =  ilObjectFactory::getInstanceByObjId($user_id);
+            $tmp_user = ilObjectFactory::getInstanceByObjId($user_id);
             $usr_data = $this->__readUserData($tmp_user);
 
             return $usr_data;
@@ -312,8 +312,10 @@ class ilSoapUserAdministration extends ilSoapAdministration
         }
         if ($folder_id == 0) {
             if (!$access->checkAccess('create_usr', '', self::USER_FOLDER_ID)) {
-                return $this->__raiseError('Missing permission for creating/modifying users accounts' . self::USER_FOLDER_ID . ' ' . $ilUser->getId(),
-                    'Server');
+                return $this->__raiseError(
+                    'Missing permission for creating/modifying users accounts' . self::USER_FOLDER_ID . ' ' . $ilUser->getId(),
+                    'Server'
+                );
             }
         }
 
@@ -339,8 +341,10 @@ class ilSoapUserAdministration extends ilSoapAdministration
 
             // check access to folder
             if (!$rbacsystem->checkAccess('create_usr', $folder_id)) {
-                return $this->__raiseError('Missing permission for creating users within ' . $import_folder->getTitle(),
-                    'Server');
+                return $this->__raiseError(
+                    'Missing permission for creating users within ' . $import_folder->getTitle(),
+                    'Server'
+                );
             }
         }
 
@@ -394,9 +398,11 @@ class ilSoapUserAdministration extends ilSoapAdministration
                 $permitted_roles[$role_id] = $role_id;
             } else {
                 $role_name = ilObject::_lookupTitle($role_id);
-                return $this->__raiseError("Could not find role " . $role_name . ". Either you use an invalid/deleted role " .
+                return $this->__raiseError(
+                    "Could not find role " . $role_name . ". Either you use an invalid/deleted role " .
                     "or you try to assign a local role into the non-standard user folder and this role is not in its subtree.",
-                    'Server');
+                    'Server'
+                );
             }
         }
 
@@ -407,19 +413,25 @@ class ilSoapUserAdministration extends ilSoapAdministration
         foreach ($permitted_roles as $role_id => $role_name) {
             if ($role_id != "") {
                 if (in_array($role_id, $global_roles)) {
-                    if ($role_id == SYSTEM_ROLE_ID && !in_array(SYSTEM_ROLE_ID,
-                            $rbacreview->assignedRoles($ilUser->getId()))
+                    if ($role_id == SYSTEM_ROLE_ID && !in_array(
+                        SYSTEM_ROLE_ID,
+                        $rbacreview->assignedRoles($ilUser->getId())
+                    )
                         || ($folder_id != self::USER_FOLDER_ID && $folder_id != 0 && !ilObjRole::_getAssignUsersStatus($role_id))
                     ) {
-                        return $this->__raiseError($lng->txt("usrimport_with_specified_role_not_permitted") . " $role_name ($role_id)",
-                            'Server');
+                        return $this->__raiseError(
+                            $lng->txt("usrimport_with_specified_role_not_permitted") . " $role_name ($role_id)",
+                            'Server'
+                        );
                     }
                 } else {
                     $rolf = $rbacreview->getFoldersAssignedToRole($role_id, true);
                     if ($rbacreview->isDeleted($rolf[0])
                         || !$rbacsystem->checkAccess('write', $rolf[0])) {
-                        return $this->__raiseError($lng->txt("usrimport_with_specified_role_not_permitted") . " $role_name ($role_id)",
-                            "Server");
+                        return $this->__raiseError(
+                            $lng->txt("usrimport_with_specified_role_not_permitted") . " $role_name ($role_id)",
+                            "Server"
+                        );
                     }
                 }
             }
@@ -776,8 +788,7 @@ class ilSoapUserAdministration extends ilSoapAdministration
         array $a_keyvalues,
         bool $attach_roles,
         int $active
-    )
-    {
+    ) {
         $this->initAuth($sid);
         $this->initIlias();
 

--- a/webservice/soap/classes/class.ilSoapUserAdministration.php
+++ b/webservice/soap/classes/class.ilSoapUserAdministration.php
@@ -539,6 +539,8 @@ class ilSoapUserAdministration extends ilSoapAdministration
             $checked_roles[$a_role] = true;
             return true;
         }
+
+        // TODO PHP8-REVIEW Missing return value
     }
 
     /**
@@ -623,6 +625,8 @@ class ilSoapUserAdministration extends ilSoapAdministration
         if ($xmlWriter->start()) {
             return $xmlWriter->getXML();
         }
+
+        // TODO PHP8-REVIEW Missing return value
     }
 
     public function getUserForRole(string $sid, int $role_id, bool $attachRoles, int $active)

--- a/webservice/soap/classes/class.ilSoapUserAdministrationAdapter.php
+++ b/webservice/soap/classes/class.ilSoapUserAdministrationAdapter.php
@@ -27,26 +27,22 @@
  */
 class ilSoapUserAdministrationAdapter
 {
-    /*
-     * @var object Nusoap-Server
-     */
     public SoapServer $server;
 
     public function __construct()
     {
-        $this->server = new SoapServer();
-        $this->__registerMethods();
+        $this->server = new SoapServer();// TODO PHP8-REVIEW Missing argument
+        $this->registerMethods();
     }
 
-    public function start()
+    public function start() : void
     {
-        if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $this->server->handle();
         }
     }
 
-    // PRIVATE
-    public function __registerMethods()
+    private function registerMethods() : void
     {
         include_once './webservice/soap/include/inc.soap_functions.php';
 

--- a/webservice/soap/classes/class.ilSoapUtils.php
+++ b/webservice/soap/classes/class.ilSoapUtils.php
@@ -397,7 +397,7 @@ class ilSoapUtils extends ilSoapAdministration
             return 0;
         }
 
-        $orig = ilObjectFactory::getInstanceByRefId((int) $source_id);
+        $orig = ilObjectFactory::getInstanceByRefId($source_id);
         $new_obj = $orig->cloneObject((int) $target_id, $cp_options->getCopyId());
 
         if (!is_object($new_obj)) {
@@ -431,7 +431,7 @@ class ilSoapUtils extends ilSoapAdministration
         }
         $target_id = $mappings[$source_id];
 
-        $orig = ilObjectFactory::getInstanceByRefId((int) $source_id);
+        $orig = ilObjectFactory::getInstanceByRefId($source_id);
         $orig->cloneDependencies($target_id, $cp_options->getCopyId());
     }
 
@@ -510,7 +510,7 @@ class ilSoapUtils extends ilSoapAdministration
         }
         $target_id = $mappings[$parent_id];
 
-        $orig = ilObjectFactory::getInstanceByRefId((int) $source_id);
+        $orig = ilObjectFactory::getInstanceByRefId($source_id);
         $new_ref_id = $orig->createReference();
         $orig->putInTree($target_id);
         $orig->setPermissions($target_id);
@@ -585,7 +585,7 @@ class ilSoapUtils extends ilSoapAdministration
          * a new registration with the same login name in a few seconds ;-)
          *
          */
-        if ((int) $usr_id > 0) {
+        if ($usr_id > 0) {
             $query .= 'SELECT usr_id, create_date, reg_hash FROM usr_data '
                 . 'WHERE active = 0 '
                 . 'AND reg_hash IS NOT NULL '

--- a/webservice/soap/classes/class.ilSoapUtils.php
+++ b/webservice/soap/classes/class.ilSoapUtils.php
@@ -50,8 +50,8 @@ class ilSoapUtils extends ilSoapAdministration
         global $DIC;
         $logger = $DIC->logger->wsrv();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         include_once 'Services/Mail/classes/class.ilMail.php';
@@ -67,42 +67,39 @@ class ilSoapUtils extends ilSoapAdministration
                 foreach (libxml_get_errors() as $err) {
                     $error .= ($err->message . ' ');
                 }
-                return $this->__raiseError($error, 'CLIENT');
+                return $this->raiseError($error, 'CLIENT');
             }
             $parser->start();
         } catch (InvalidArgumentException|ilSaxParserException $e) {
             $logger->warning($e->getMessage());
-            return $this->__raiseError($e->getMessage(), 'CLIENT');
+            return $this->raiseError($e->getMessage(), 'CLIENT');
         }
         $mails = $parser->getMails();
         $ilUser = $DIC->user();
 
         foreach ($mails as $mail) {
-            // Prepare attachments
             include_once './Services/Mail/classes/class.ilFileDataMail.php';
             $file = new ilFileDataMail($ilUser->getId());
             $attachments = [];
             foreach ((array) $mail['attachments'] as $attachment) {
-                // TODO: Error handling
                 $file->storeAsAttachment($attachment['name'], $attachment['content']);
                 $attachments[] = ilFileUtils::_sanitizeFilemame($attachment['name']);
             }
 
             $mail_obj = new ilMail($ilUser->getId());
             $mail_obj->setSaveInSentbox(true);
-            $mail_obj->saveAttachments((array) $attachments);
+            $mail_obj->saveAttachments($attachments);
             $mail_obj->enqueue(
                 implode(',', (array) $mail['to']),
                 implode(',', (array) $mail['cc']),
                 implode(',', (array) $mail['bcc']),
                 $mail['subject'],
                 implode("\n", (array) $mail['body']),
-                (array) $attachments,
+                $attachments,
                 (bool) $mail['usePlaceholders']
             );
 
-            // Finally unlink attachments
-            foreach ((array) $attachments as $att) {
+            foreach ($attachments as $att) {
                 $file->unlinkFile($att);
             }
             $mail_obj->savePostData(
@@ -112,8 +109,7 @@ class ilSoapUtils extends ilSoapAdministration
                 '',
                 '',
                 '',
-                '',
-                false
+                ''
             );
         }
         return true;
@@ -124,8 +120,8 @@ class ilSoapUtils extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         include_once "./Services/MediaObjects/classes/class.ilObjMediaObject.php";
@@ -137,8 +133,8 @@ class ilSoapUtils extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         include_once "./Services/MediaObjects/classes/class.ilObjMediaObject.php";
@@ -154,8 +150,8 @@ class ilSoapUtils extends ilSoapAdministration
             $this->initAuth($sid);
             $this->initIlias();
 
-            if (!$this->__checkSession($sid)) {
-                return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+            if (!$this->checkSession($sid)) {
+                return $this->raiseError($this->getMessage(), $this->getMessageCode());
             }
         }
 
@@ -217,8 +213,8 @@ class ilSoapUtils extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            ilLoggerFactory::getLogger('obj')->error('Object cloning failed. Invalid session given: ' . $this->__getMessage());
+        if (!$this->checkSession($sid)) {
+            ilLoggerFactory::getLogger('obj')->error('Object cloning failed. Invalid session given: ' . $this->getMessage());
         }
 
         global $DIC;
@@ -295,10 +291,8 @@ class ilSoapUtils extends ilSoapAdministration
             return $default_mode;
         }
 
-        if ($this->findMappedReferenceForNode($cpo, $node)) {
-            if ($default_mode == \ilCopyWizardOptions::COPY_WIZARD_COPY) {
-                return \ilCopyWizardOptions::COPY_WIZARD_LINK_TO_TARGET;
-            }
+        if ($this->findMappedReferenceForNode($cpo, $node) && $default_mode == \ilCopyWizardOptions::COPY_WIZARD_COPY) {
+            return \ilCopyWizardOptions::COPY_WIZARD_LINK_TO_TARGET;
         }
         return $default_mode;
     }
@@ -317,7 +311,7 @@ class ilSoapUtils extends ilSoapAdministration
             $logger->debug('Validating node: ' . $ref_id . ' and root ' . $root);
             $logger->dump($DIC->repositoryTree()->getRelation($ref_id, $root));
 
-            if ($DIC->repositoryTree()->getRelation($ref_id, $root) != \ilTree::RELATION_CHILD) {
+            if ($DIC->repositoryTree()->getRelation($ref_id, $root) !== \ilTree::RELATION_CHILD) {
                 $logger->debug('Ignoring non child relation');
                 continue;
             }
@@ -545,8 +539,8 @@ class ilSoapUtils extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
 
         include_once('./Services/WebServices/ECS/classes/class.ilECSTaskScheduler.php');
@@ -569,7 +563,7 @@ class ilSoapUtils extends ilSoapAdministration
      * @param int    $usr_id User id of the actuator
      * @return    bool
      */
-    public function deleteExpiredDualOptInUserObjects(string $sid, int $usr_id)
+    public function deleteExpiredDualOptInUserObjects(string $sid, int $usr_id) : bool
     {
         $this->initAuth($sid);
         $this->initIlias();
@@ -616,15 +610,16 @@ class ilSoapUtils extends ilSoapAdministration
 
         $num_deleted_users = 0;
         while ($row = $ilDB->fetchAssoc($res)) {
-            if ($row['usr_id'] == ANONYMOUS_USER_ID || $row['usr_id'] == SYSTEM_USER_ID) {
-                continue;
-            }
-            if (!strlen($row['reg_hash'])) {
+            if ((int) $row['usr_id'] === ANONYMOUS_USER_ID || (int) $row['usr_id'] === SYSTEM_USER_ID) {
                 continue;
             }
 
-            if ((int) $oRegSettigs->getRegistrationHashLifetime() > 0 &&
-                $row['create_date'] != '' &&
+            if (($row['reg_hash'] ?? '') === '') {
+                continue;
+            }
+
+            if (($row['create_date'] ?? '') !== '' &&
+                $oRegSettigs->getRegistrationHashLifetime() > 0 &&
                 time() - $oRegSettigs->getRegistrationHashLifetime() > strtotime($row['create_date'])) {
                 $user = ilObjectFactory::getInstanceByObjId($row['usr_id'], false);
                 if ($user instanceof ilObjUser) {

--- a/webservice/soap/classes/class.ilSoapWebLinkAdministration.php
+++ b/webservice/soap/classes/class.ilSoapWebLinkAdministration.php
@@ -9,9 +9,6 @@ include_once './webservice/soap/classes/class.ilSoapAdministration.php';
  */
 class ilSoapWebLinkAdministration extends ilSoapAdministration
 {
-    /**
-     * Constructor
-     */
     public function __construct()
     {
         parent::__construct();
@@ -20,16 +17,16 @@ class ilSoapWebLinkAdministration extends ilSoapAdministration
     /**
      * Get Weblink xml
      */
-    public function readWebLink(string $sid, int $ref_id)
+    public function readWebLink(string $sid, int $request_ref_id)
     {
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
-        if (!$ref_id) {
-            return $this->__raiseError(
+        if (!$request_ref_id) {
+            return $this->raiseError(
                 'No ref id given. Aborting!',
                 'Client'
             );
@@ -41,21 +38,22 @@ class ilSoapWebLinkAdministration extends ilSoapAdministration
         $ilLog = $DIC['ilLog'];
 
         // get obj_id
-        if (!$obj_id = ilObject::_lookupObjectId($ref_id)) {
-            return $this->__raiseError(
-                'No weblink found for id: ' . $ref_id,
+        if (!$obj_id = ilObject::_lookupObjectId($request_ref_id)) {
+            return $this->raiseError(
+                'No weblink found for id: ' . $request_ref_id,
                 'Client'
             );
         }
 
-        if (ilObject::_isInTrash($ref_id)) {
-            return $this->__raiseError("Parent with ID $ref_id has been deleted.", 'Client');
+        if (ilObject::_isInTrash($request_ref_id)) {
+            return $this->raiseError("Parent with ID $request_ref_id has been deleted.", 'Client');
         }
 
         // Check access
         $permission_ok = false;
         $write_permission_ok = false;
-        foreach ($ref_ids = ilObject::_getAllReferences($obj_id) as $ref_id) {
+        $ref_ids = ilObject::_getAllReferences($obj_id);
+        foreach ($ref_ids as $ref_id) {
             if ($rbacsystem->checkAccess('edit', $ref_id)) {
                 $write_permission_ok = true;
                 break;
@@ -67,21 +65,21 @@ class ilSoapWebLinkAdministration extends ilSoapAdministration
         }
 
         if (!$permission_ok && !$write_permission_ok) {
-            return $this->__raiseError(
-                'No permission to edit the object with id: ' . $ref_id,
+            return $this->raiseError(
+                'No permission to edit the object with id: ' . $request_ref_id,
                 'Server'
             );
         }
 
         try {
             include_once './Modules/WebResource/classes/class.ilWebLinkXmlWriter.php';
-            $writer = new ilWebLinkXmlWriter();
+            $writer = new ilWebLinkXmlWriter();// TODO PHP8-REVIEW Missing argument
             $writer->setObjId($obj_id);
             $writer->write();
 
             return $writer->xmlDumpMem(true);
         } catch (UnexpectedValueException $e) {
-            return $this->__raiseError($e->getMessage(), 'Client');
+            return $this->raiseError($e->getMessage(), 'Client');
         }
     }
 
@@ -93,8 +91,8 @@ class ilSoapWebLinkAdministration extends ilSoapAdministration
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
         global $DIC;
 
@@ -103,25 +101,25 @@ class ilSoapWebLinkAdministration extends ilSoapAdministration
         $ilLog = $DIC['ilLog'];
 
         if (!$target_obj = ilObjectFactory::getInstanceByRefId($target_id, false)) {
-            return $this->__raiseError('No valid target given.', 'Client');
+            return $this->raiseError('No valid target given.', 'Client');
         }
 
         if (ilObject::_isInTrash($target_id)) {
-            return $this->__raiseError("Parent with ID $target_id has been deleted.", 'CLIENT_OBJECT_DELETED');
+            return $this->raiseError("Parent with ID $target_id has been deleted.", 'CLIENT_OBJECT_DELETED');
         }
 
         // Check access
         // TODO: read from object definition
         $allowed_types = array('cat', 'grp', 'crs', 'fold', 'root');
         if (!in_array($target_obj->getType(), $allowed_types)) {
-            return $this->__raiseError(
+            return $this->raiseError(
                 'No valid target type. Target must be reference id of "course, group, root, category or folder"',
                 'Client'
             );
         }
 
         if (!$rbacsystem->checkAccess('create', $target_id, "webr")) {
-            return $this->__raiseError('No permission to create weblink in target  ' . $target_id . '!', 'Client');
+            return $this->raiseError('No permission to create weblink in target  ' . $target_id . '!', 'Client');
         }
 
         // create object, put it into the tree and use the parser to update the settings
@@ -140,7 +138,7 @@ class ilSoapWebLinkAdministration extends ilSoapAdministration
             $parser->setMode(ilWebLinkXmlParser::MODE_CREATE);
             $parser->start();
         } catch (ilSaxParserException | ilWebLinkXmlParserException $e) {
-            return $this->__raiseError($e->getMessage(), 'Client');
+            return $this->raiseError($e->getMessage(), 'Client');
         }
 
         // Check if required
@@ -150,13 +148,13 @@ class ilSoapWebLinkAdministration extends ilSoapAdministration
     /**
      * update a weblink with id.
      */
-    public function updateWebLink(string $sid, int $ref_id, string $weblink_xml)
+    public function updateWebLink(string $sid, int $request_ref_id, string $weblink_xml)
     {
         $this->initAuth($sid);
         $this->initIlias();
 
-        if (!$this->__checkSession($sid)) {
-            return $this->__raiseError($this->__getMessage(), $this->__getMessageCode());
+        if (!$this->checkSession($sid)) {
+            return $this->raiseError($this->getMessage(), $this->getMessageCode());
         }
         global $DIC;
 
@@ -164,16 +162,16 @@ class ilSoapWebLinkAdministration extends ilSoapAdministration
         $tree = $DIC['tree'];
         $ilLog = $DIC['ilLog'];
 
-        if (ilObject::_isInTrash($ref_id)) {
-            return $this->__raiseError(
+        if (ilObject::_isInTrash($request_ref_id)) {
+            return $this->raiseError(
                 'Cannot perform update since weblink has been deleted.',
                 'CLIENT_OBJECT_DELETED'
             );
         }
         // get obj_id
-        if (!$obj_id = ilObject::_lookupObjectId($ref_id)) {
-            return $this->__raiseError(
-                'No weblink found for id: ' . $ref_id,
+        if (!$obj_id = ilObject::_lookupObjectId($request_ref_id)) {
+            return $this->raiseError(
+                'No weblink found for id: ' . $request_ref_id,
                 'CLIENT_OBJECT_NOT_FOUND'
             );
         }
@@ -188,16 +186,16 @@ class ilSoapWebLinkAdministration extends ilSoapAdministration
         }
 
         if (!$permission_ok) {
-            return $this->__raiseError(
-                'No permission to edit the weblink with id: ' . $ref_id,
+            return $this->raiseError(
+                'No permission to edit the weblink with id: ' . $request_ref_id,
                 'Server'
             );
         }
 
         $webl = ilObjectFactory::getInstanceByObjId($obj_id, false);
-        if (!is_object($webl) or $webl->getType() != "webr") {
-            return $this->__raiseError(
-                'Wrong obj id or type for weblink with id ' . $ref_id,
+        if (!is_object($webl) || $webl->getType() !== "webr") {
+            return $this->raiseError(
+                'Wrong obj id or type for weblink with id ' . $request_ref_id,
                 'Client'
             );
         }
@@ -208,7 +206,7 @@ class ilSoapWebLinkAdministration extends ilSoapAdministration
             $parser->setMode(ilWebLinkXmlParser::MODE_UPDATE);
             $parser->start();
         } catch (ilSaxParserException | ilWebLinkXmlParserException $e) {
-            return $this->__raiseError($e->getMessage(), 'Client');
+            return $this->raiseError($e->getMessage(), 'Client');
         }
 
         // Check if required

--- a/webservice/soap/classes/class.ilSoapWebLinkAdministration.php
+++ b/webservice/soap/classes/class.ilSoapWebLinkAdministration.php
@@ -114,8 +114,10 @@ class ilSoapWebLinkAdministration extends ilSoapAdministration
         // TODO: read from object definition
         $allowed_types = array('cat', 'grp', 'crs', 'fold', 'root');
         if (!in_array($target_obj->getType(), $allowed_types)) {
-            return $this->__raiseError('No valid target type. Target must be reference id of "course, group, root, category or folder"',
-                'Client');
+            return $this->__raiseError(
+                'No valid target type. Target must be reference id of "course, group, root, category or folder"',
+                'Client'
+            );
         }
 
         if (!$rbacsystem->checkAccess('create', $target_id, "webr")) {
@@ -163,8 +165,10 @@ class ilSoapWebLinkAdministration extends ilSoapAdministration
         $ilLog = $DIC['ilLog'];
 
         if (ilObject::_isInTrash($ref_id)) {
-            return $this->__raiseError('Cannot perform update since weblink has been deleted.',
-                'CLIENT_OBJECT_DELETED');
+            return $this->__raiseError(
+                'Cannot perform update since weblink has been deleted.',
+                'CLIENT_OBJECT_DELETED'
+            );
         }
         // get obj_id
         if (!$obj_id = ilObject::_lookupObjectId($ref_id)) {

--- a/webservice/soap/classes/class.ilXMLResultSet.php
+++ b/webservice/soap/classes/class.ilXMLResultSet.php
@@ -38,7 +38,7 @@ class ilXMLResultSet
 
     public function getColumnName(int $index) : ?string
     {
-        if (is_numeric($index) && ($index < 0 || $index > count($this->colspecs))) {
+        if ($index < 0 || $index > count($this->colspecs)) {
             return null;
         }
         return $this->colspecs[$index] instanceof ilXMLResultSetColumn ? $this->colspecs[$index]->getName() : null;
@@ -49,7 +49,7 @@ class ilXMLResultSet
      */
     public function addColumn(string $columnname) : void
     {
-        $this->colspecs [count($this->colspecs)] = new ilXMLResultSetColumn(count($this->colspecs), $columnname);
+        $this->colspecs[] = new ilXMLResultSetColumn(count($this->colspecs), $columnname);
     }
 
     /**
@@ -59,7 +59,7 @@ class ilXMLResultSet
     {
         $idx = 0;
         foreach ($this->colspecs as $colspec) {
-            if (strcasecmp($columnname, $colspec->getName()) == 0) {
+            if (strcasecmp($columnname, $colspec->getName()) === 0) {
                 return $idx;
             }
             $idx++;
@@ -72,7 +72,7 @@ class ilXMLResultSet
      */
     public function hasColumn(string $columnname) : bool
     {
-        return $this->getIndexForColumn($columnname) != -1;
+        return $this->getIndexForColumn($columnname) !== -1;
     }
 
     /**

--- a/webservice/soap/classes/class.ilXMLResultSetParser.php
+++ b/webservice/soap/classes/class.ilXMLResultSetParser.php
@@ -28,7 +28,7 @@ class ilXMLResultSetParser extends ilSaxParser
     }
 
     /**
-     * @param resource    reference to the xml parser
+     * @param XMLParser|resource A reference to the xml parser
      */
     public function setHandlers($a_xml_parser) : void
     {
@@ -38,9 +38,9 @@ class ilXMLResultSetParser extends ilSaxParser
     }
 
     /**
-     * @param resource $a_xml_parser xml parser
-     * @param string   $a_name       element name
-     * @param array    $a_attribs    element attributes array
+     * @param XMLParser|resource $a_xml_parser xml parser
+     * @param string $a_name element name
+     * @param array $a_attribs element attributes array
      * @return void
      */
     public function handlerBeginTag($a_xml_parser, string $a_name, array $a_attribs) : void
@@ -65,9 +65,9 @@ class ilXMLResultSetParser extends ilSaxParser
     }
 
     /**
-     * handler for end of element
-     * @param resource $a_xml_parser xml parser
-     * @param string   $a_name       element name
+     * Handler for end of element
+     * @param XMLParser|resource $a_xml_parser xml parser
+     * @param string $a_name element name
      * @return void
      */
     public function handlerEndTag($a_xml_parser, string $a_name) : void
@@ -82,14 +82,14 @@ class ilXMLResultSetParser extends ilSaxParser
     }
 
     /**
-     * handler for character data
-     * @param resource $a_xml_parser xml parser
-     * @param string   $a_data       character data
+     * Handler for character data
+     * @param XMLParser|resource $a_xml_parser xml parser
+     * @param string $a_data character data
      * @return void
      */
     public function handlerCharacterData($a_xml_parser, string $a_data) : void
     {
-        if ($a_data != "\n") {
+        if ($a_data !== "\n") {
             // Replace multiple tabs with one space
             $a_data = preg_replace("/\t+/", " ", $a_data);
             $this->cdata .= trim($a_data);

--- a/webservice/soap/classes/class.ilXMLResultSetRow.php
+++ b/webservice/soap/classes/class.ilXMLResultSetRow.php
@@ -28,6 +28,7 @@
  */
 class ilXMLResultSetRow
 {
+    /** @var array<int|string, string> */
     private array $columns = [];
 
     /**
@@ -41,6 +42,9 @@ class ilXMLResultSetRow
         $this->columns[$index] = $value;
     }
 
+    /**
+     * @return array<int|string, string>
+     */
     public function getColumns() : array
     {
         return $this->columns;
@@ -62,16 +66,17 @@ class ilXMLResultSetRow
      * @param int|string $idx
      * @return string
      */
-    public function getValue($idx)
+    public function getValue($idx) : string
     {
         if (is_string($idx) && !array_key_exists($idx, $this->columns)) {
             throw new DomainException('Invalid index given: ' . $idx);
-        } elseif (
-            is_int($idx) &&
-            ($idx < 0 || $idx >= count($this->columns))
-        ) {
+        }
+
+        if (is_int($idx) &&
+            ($idx < 0 || $idx >= count($this->columns))) {
             throw new DomainException("Index too small or too large: " . $idx);
         }
+
         return $this->columns[$idx];
     }
 }

--- a/webservice/soap/classes/class.ilXMLResultSetWriter.php
+++ b/webservice/soap/classes/class.ilXMLResultSetWriter.php
@@ -19,21 +19,21 @@ class ilXMLResultSetWriter extends ilXmlWriter
 
     public function start() : bool
     {
-        $this->__buildHeader();
-        $this->__buildColSpecs();
-        $this->__buildRows();
-        $this->__buildFooter();
+        $this->buildHeader();
+        $this->buildColSpecs();
+        $this->buildRows();
+        $this->buildFooter();
         return true;
     }
 
-    protected function __buildHeader() : void
+    private function buildHeader() : void
     {
         $this->xmlSetDtdDef("<!DOCTYPE result PUBLIC \"-//ILIAS//DTD XMLResultSet//EN\" \"" . ILIAS_HTTP_PATH . "/xml/ilias_xml_resultset_3_7.dtd\">");
         $this->xmlHeader();
         $this->xmlStartTag("result");
     }
 
-    protected function __buildColSpecs() : void
+    private function buildColSpecs() : void
     {
         $this->xmlStartTag("colspecs");
         foreach ($this->xmlResultSet->getColSpecs() as $colSpec) {
@@ -44,16 +44,16 @@ class ilXMLResultSetWriter extends ilXmlWriter
         $this->xmlEndTag("colspecs");
     }
 
-    protected function __buildRows() : void
+    private function buildRows() : void
     {
         $this->xmlStartTag("rows");
         foreach ($this->xmlResultSet->getRows() as $row) {
-            $this->__appendRow($row);
+            $this->appendRow($row);
         }
         $this->xmlEndTag("rows");
     }
 
-    protected function __appendRow(ilXMLResultSetRow $xmlResultSetRow) : void
+    private function appendRow(ilXMLResultSetRow $xmlResultSetRow) : void
     {
         $this->xmlStartTag('row', null);
         foreach ($xmlResultSetRow->getColumns() as $value) {
@@ -62,7 +62,7 @@ class ilXMLResultSetWriter extends ilXmlWriter
         $this->xmlEndTag('row');
     }
 
-    public function __buildFooter()
+    private function buildFooter() : void
     {
         $this->xmlEndTag('result');
     }

--- a/webservice/soap/include/inc.soap_functions.php
+++ b/webservice/soap/include/inc.soap_functions.php
@@ -844,7 +844,7 @@ class ilSoapFunctions
      */
     public static function buildHTTPPath()
     {
-        if ($_SERVER["HTTPS"] == "on") {
+        if ($_SERVER["HTTPS"] === "on") {
             $protocol = 'https://';
         } else {
             $protocol = 'http://';
@@ -930,34 +930,7 @@ class ilSoapFunctions
 
         return $sou->deleteExpiredDualOptInUserObjects($sid, $usr_id);
     }
-    
-    /*
-    public static function getSkillCompletionDateForTriggerRefId($sid, $usr_id, $a_ref_id)
-    {
-        include_once './webservice/soap/classes/class.ilSoapSkillAdministration.php';
-        $s = new ilSoapSkillAdministration();
 
-        $res = $s->getCompletionDateForTriggerRefId($sid, $usr_id, $a_ref_id);
-        return $res;
-    }
-
-    public static function checkSkillUserCertificateForTriggerRefId($sid, $usr_id, $a_ref_id)
-    {
-        include_once './webservice/soap/classes/class.ilSoapSkillAdministration.php';
-
-        $s = new ilSoapSkillAdministration();
-        return $s->checkUserCertificateForTriggerRefId($sid, $usr_id, $a_ref_id);
-    }
-
-    public static function getSkillTriggerOfAllCertificates($sid, $usr_id)
-    {
-        include_once './webservice/soap/classes/class.ilSoapSkillAdministration.php';
-
-        $s = new ilSoapSkillAdministration();
-        return $s->getTriggerOfAllCertificates($sid, $usr_id);
-    }
-    */
-    
     /**
      * Delete progress
      * @param string $sid
@@ -1111,7 +1084,7 @@ class ilSoapFunctions
         $soapHook = new ilSoapHook($DIC['component.factory']);
         // Method name may be invoked with namespace e.g. 'myMethod' vs 'ns:myMethod'
         if (strpos($name, ':') !== false) {
-            list($_, $name) = explode(':', $name);
+            [$_, $name] = explode(':', $name);
         }
         $method = $soapHook->getMethodByName($name);
         if ($method) {

--- a/webservice/soap/include/inc.soap_functions.php
+++ b/webservice/soap/include/inc.soap_functions.php
@@ -463,7 +463,7 @@ class ilSoapFunctions
 
         $sass = new ilSoapTestAdministration();
 
-        return $sass->saveQuestionResult($sid, $user_id, $test_id, $question_id, $pass, $solution);
+        return $sass->saveQuestionResult($sid, $user_id, $test_id, $question_id, $pass, $solution);// TODO PHP8-REVIEW Method undefined
     }
 
     public static function saveQuestion($sid, $active_id, $question_id, $pass, $solution)

--- a/webservice/soap/lib/ReleaseInfo.php
+++ b/webservice/soap/lib/ReleaseInfo.php
@@ -4,15 +4,14 @@ Versions:
 ???
 Patches:
 
- - smeyer: Fixed wrong order of fault body elements 
-	@see: www.ilias.de/mantis/view.php?id=8659
-	
-	line 1054
- 
+ - smeyer: Fixed wrong order of fault body elements
+    @see: www.ilias.de/mantis/view.php?id=8659
+
+    line 1054
+
 
 Alex, 29 Mar 2012: Added standard object creation to top of page, since PHP5.4
 throws a warning otherwise.
 
 smeyer: Removed deprecated set_magic_quotes_runtime line 2676
 */
-?>

--- a/webservice/soap/nusoapserver.php
+++ b/webservice/soap/nusoapserver.php
@@ -31,7 +31,7 @@
 * @package ilias
 */
 
-if (!defined('ILIAS_MODULE') || (defined('ILIAS_MODULE') && ILIAS_MODULE != "webservice/soap")) {
+if (!defined('ILIAS_MODULE') || (defined('ILIAS_MODULE') && ILIAS_MODULE !== "webservice/soap")) {
     //direct call to this endpoint
     chdir("../..");
     define("ILIAS_MODULE", "webservice/soap");

--- a/webservice/soap/server.php
+++ b/webservice/soap/server.php
@@ -11,12 +11,12 @@
 */
 
 chdir("../..");
-define("ILIAS_MODULE", "webservice/soap");
-define("IL_SOAPMODE_NUSOAP", 0);
-define("IL_SOAPMODE_INTERNAL", 1);
+const ILIAS_MODULE = "webservice/soap";
+const IL_SOAPMODE_NUSOAP = 0;
+const IL_SOAPMODE_INTERNAL = 1;
 
 // php7 only SOAPMODE_INTERNAL
-define('IL_SOAPMODE', IL_SOAPMODE_INTERNAL);
+const IL_SOAPMODE = IL_SOAPMODE_INTERNAL;
 include_once "Services/Context/classes/class.ilContext.php";
 ilContext::init(ilContext::CONTEXT_SOAP);
 
@@ -29,12 +29,12 @@ if ((bool) $ilIliasIniFile->readVariable('https', 'auto_https_detect_enabled')) 
     $headerValue = $ilIliasIniFile->readVariable('https', 'auto_https_detect_header_value');
 
     $headerName = "HTTP_" . str_replace("-", "_", strtoupper($headerName));
-    if (strcasecmp($_SERVER[$headerName], $headerValue) == 0) {
+    if (strcasecmp($_SERVER[$headerName], $headerValue) === 0) {
         $_SERVER['HTTPS'] = 'on';
     }
 }
 
-if (IL_SOAPMODE == IL_SOAPMODE_INTERNAL && strcasecmp($_SERVER["REQUEST_METHOD"], "post") == 0) {
+if (IL_SOAPMODE === IL_SOAPMODE_INTERNAL && strcasecmp($_SERVER["REQUEST_METHOD"], "post") === 0) {
     // This is a SOAP request
     include_once('webservice/soap/include/inc.soap_functions.php');
     $uri = ilSoapFunctions::buildHTTPPath() . '/webservice/soap/server.php';

--- a/webservice/soap/server.php
+++ b/webservice/soap/server.php
@@ -24,7 +24,7 @@ require_once("./Services/Init/classes/class.ilIniFile.php");
 $ilIliasIniFile = new ilIniFile("./ilias.ini.php");
 $ilIliasIniFile->read();
 
-if ((bool) $ilIliasIniFile->readVariable('https', 'auto_https_detect_enabled')) {
+if ($ilIliasIniFile->readVariable('https', 'auto_https_detect_enabled')) {
     $headerName = $ilIliasIniFile->readVariable('https', 'auto_https_detect_header_name');
     $headerValue = $ilIliasIniFile->readVariable('https', 'auto_https_detect_header_value');
 


### PR DESCRIPTION
Hi @smeyer-ilias,

I completed the review of the `webservice/soap` component.

Results:
- [ ] The code style is `PSR-2 + X` compliant
- [ ] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`: I found 6 usages of `$_GET`
- [ ] There is a `Unit Test Suite` with at least one unit test
- [ ] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [ ] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

I already fixed many trivial inspection profile issues.

--

Actions required:
- [ ] Please eliminate the super global variable usages.  The found super globals might be okay if there is a **good** reason to keep them (if so, please elaborate).
- [ ] Please add a unit test suite with at least one passing unit test
- [ ] I am not sure whether `webservice/soap/lib/nusoap.php` is compatible with PHP 8. Please check the list item above if you already checked this.
- [x] Please check my inline comments. Some of them might be just information, some require an action. You can use `TODO PHP8-REVIEW` when searching. I used the following types:
  - `// TODO PHP8-REVIEW Property dynamically declared`
  - `// TODO PHP8-REVIEW Method undefined`
  - `// TODO PHP8-REVIEW Constant undefined`
  - `// TODO PHP8-REVIEW Return type missing`
  - `// TODO PHP8-REVIEW Type hint missing`
  - `// TODO PHP8-REVIEW Missing argument`
  - `// TODO PHP8-REVIEW Wrong type`
  - `// TODO PHP8-REVIEW Unnecessary operations`
  - `// TODO PHP8-REVIEW Missing return value`

--

Actions suggested:
- [ ] You could remove many `(require|include)_once` directives

--

Summary:

- [ ] webservice/soap/include/inc.soap_functions.php
  - Return type declarations are missing for all methods. If the return value could be of different types, use `PHPDoc` comments instead, e.g. `@return bool|soap_fault|SoapFault`
  - Type hints are missing for all methods below `\ilSoapFunctions::deleteRole`
  - The `PHPDoc` comments are often wrong, e.g. `\ilSoapFunctions::moveObject`
  - Suggestion: `array` types could be described in regards to their shape (e.g. `string[]`, or `array{type: int, child: int}`)

- [ ] webservice/soap/classes/class.ilSoapWebLinkAdministration.php
  - Return type declarations are missing for all methods. If the return value could be of different types, use `PHPDoc` comments instead, e.g. `@return bool|soap_fault|SoapFault`
  - An argument is missing when creating an instance

- [ ] webservice/soap/classes/class.ilSoapUtils.php
  - Return type declarations are missing. If the return value could be of different types, use `PHPDoc` comments instead, e.g. `@return bool|soap_fault|SoapFault`
  - Suggestion: `array` types could be described in regards to their shape (e.g. `string[]`, or `array{type: int, child: int}`)

- [ ] webservice/soap/classes/class.ilSoapUserAdministrationAdapter.php
  - An argument is missing when creating an instance

- [ ] webservice/soap/classes/class.ilSoapUserAdministration.php
  - Return type declarations are missing. If the return value could be of different types, use `PHPDoc` comments instead, e.g. `@return bool|soap_fault|SoapFault`
  - Suggestion: `array` types could be described in regards to their shape (e.g. `string[]`, or `array{type: int, child: int}`)
  - Dynamic property declarations and undefined constants are used

- [ ] webservice/soap/classes/class.ilSoapTestAdministration.php 
  - Return type declarations are missing. If the return value could be of different types, use `PHPDoc` comments instead, e.g. `@return bool|soap_fault|SoapFault`
  - There are mismatches between type declarations (in type hints) and performed operations
  - Arguments are missing in method calls

- [ ] webservice/soap/classes/class.ilSoapStructureObjectAdministration.php
  - Return type declarations are missing. If the return value could be of different types, use `PHPDoc` comments instead, e.g. `@return bool|soap_fault|SoapFault`

- [ ] webservice/soap/classes/class.ilSoapStructureObject.php
  - Suggestion: `array` types could be described in regards to their shape (e.g. `string[]`, or `array{type: int, child: int}`)

- [ ] webservice/soap/classes/class.ilSoapSCORMAdministration.php
  - Return type declarations are missing. If the return value could be of different types, use `PHPDoc` comments instead, e.g. `@return bool|soap_fault|SoapFault`
  - Suggestion: `array` types could be described in regards to their shape (e.g. `string[]`, or `array{type: int, child: int}`)

- [ ] webservice/soap/classes/class.ilSoapRoleObjectXMLWriter.php
  - Suggestion: `array` types could be described in regards to their shape (e.g. `string[]`, or `array{type: int, child: int}`)

- [ ] webservice/soap/classes/class.ilSoapRBACAdministration.php
  - Return type declarations are missing. If the return value could be of different types, use `PHPDoc` comments instead, e.g. `@return bool|soap_fault|SoapFault`
  - Suggestion: `array` types could be described in regards to their shape (e.g. `string[]`, or `array{type: int, child: int}`)

- [ ] webservice/soap/classes/class.ilSoapObjectAdministration.php
  - Return type declarations are missing. If the return value could be of different types, use `PHPDoc` comments instead, e.g. `@return bool|soap_fault|SoapFault`
  - Suggestion: `array` types could be described in regards to their shape (e.g. `string[]`, or `array{type: int, child: int}`)

 - [ ] webservice/soap/classes/class.ilSoapMailXmlParser.php
   - Return type declarations are missing. If the return value could be of different types, use `PHPDoc` comments instead, e.g. `@return bool|soap_fault|SoapFault`
   - Suggestion: `array` types could be described in regards to their shape (e.g. `string[]`, or `array{type: int, child: int}`)

- [ ] webservice/soap/classes/class.ilSoapLearningProgressAdministration.php
  - Return type declarations are missing. If the return value could be of different types, use `PHPDoc` comments instead, e.g. `@return bool|soap_fault|SoapFault`
  - Suggestion: `array` types could be described in regards to their shape (e.g. `string[]`, or `array{type: int, child: int}`)

- [ ] webservice/soap/classes/class.ilSoapInstallationInfoXMLWriter.php
  - There are unnecessary operations
  - Suggestion: `array` types could be described in regards to their shape (e.g. `string[]`, or `array{type: int, child: int}`)

- [ ] webservice/soap/classes/class.ilSoapGroupAdministration.php
  - Return type declarations are missing. If the return value could be of different types, use `PHPDoc` comments instead, e.g. `@return bool|soap_fault|SoapFault`

- [ ] webservice/soap/classes/class.ilSoapFileAdministration.php
  - Return type declarations are missing. If the return value could be of different types, use `PHPDoc` comments instead, e.g. `@return bool|soap_fault|SoapFault`

- [ ] webservice/soap/classes/class.ilSoapExerciseAdministration.php
  - Return type declarations are missing. If the return value could be of different types, use `PHPDoc` comments instead, e.g. `@return bool|soap_fault|SoapFault`

- [ ] webservice/soap/classes/class.ilSoapDataCollectionAdministration.php
  - Return type declarations are missing. If the return value could be of different types, use `PHPDoc` comments instead, e.g. `@return bool|soap_fault|SoapFault`

- [ ] webservice/soap/classes/class.ilSoapCourseAdministration.php
  - Return type declarations are missing. If the return value could be of different types, use `PHPDoc` comments instead, e.g. `@return bool|soap_fault|SoapFault`
  - Wrong types are declared (in type hints) in regards to the operations/checks which are performed on the variables

- [ ] webservice/soap/classes/class.ilSoapAdministration.php
  - Return type declarations are missing. If the return value could be of different types, use `PHPDoc` comments instead, e.g. `@return bool|soap_fault|SoapFault`
  - Type hints are missing
  - Suggestion: `array` types could be described in regards to their shape (e.g. `string[]`, or `array{type: int, child: int}`)
  -  Properties are dynamically defined

- [ ] webservice/soap/classes/class.ilObjectXMLWriter.php
  - There are unnecessary operations

- [ ] webservice/soap/classes/class.ilObjectXMLParser.php
  - Type hints are missing
  - Suggestion: `array` types could be described in regards to their shape (e.g. `string[]`, or `array{type: int, child: int}`)

- [ ] webservice/soap/classes/class.ilCopyWizardSettingsXMLParser.php
  - Suggestion: `array` types could be described in regards to their shape (e.g. `string[]`, or `array{type: int, child: int}`)

--

Best regards,
@mjansenDatabay