### PR TITLE
Style/Content: PHP8 review

### DIFF
--- a/Services/Form/classes/class.ilSelectInputGUI.php
+++ b/Services/Form/classes/class.ilSelectInputGUI.php
@@ -159,7 +159,7 @@ class ilSelectInputGUI extends ilSubEnabledFormPropertyGUI implements ilTableFil
         }
         foreach ($this->getOptions() as $option_value => $option_text) {
             $tpl->setCurrentBlock("prop_select_option");
-            $tpl->setVariable("VAL_SELECT_OPTION", ilLegacyFormElementsUtil::prepareFormOutput($option_value));
+            $tpl->setVariable("VAL_SELECT_OPTION", ilLegacyFormElementsUtil::prepareFormOutput((string) $option_value));
             if ((string) $sel_value == (string) $option_value) {
                 $tpl->setVariable(
                     "CHK_SEL_OPTION",

--- a/Services/Style/Content/Access/class.StyleAccessManager.php
+++ b/Services/Style/Content/Access/class.StyleAccessManager.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -15,6 +15,8 @@
 
 namespace ILIAS\Style\Content\Access;
 
+use ilRbacSystem;
+
 /**
  * Manages access to content style editing
  * @author Alexander Killing <killing@leifos.de>
@@ -24,9 +26,9 @@ class StyleAccessManager
     protected bool $enable_write = false;
     protected int $ref_id = 0;
     protected int $user_id = 0;
-    protected \ilRbacSystem $rbacsystem;
+    protected ilRbacSystem $rbacsystem;
 
-    public function __construct(\ilRbacSystem $rbacsystem = null, int $ref_id = 0, int $user_id = 0)
+    public function __construct(ilRbacSystem $rbacsystem = null, int $ref_id = 0, int $user_id = 0)
     {
         global $DIC;
 

--- a/Services/Style/Content/Characteristic/Inputs/class.ilBackgroundImageInputGUI.php
+++ b/Services/Style/Content/Characteristic/Inputs/class.ilBackgroundImageInputGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system

--- a/Services/Style/Content/Characteristic/Inputs/class.ilBackgroundPositionInputGUI.php
+++ b/Services/Style/Content/Characteristic/Inputs/class.ilBackgroundPositionInputGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system

--- a/Services/Style/Content/Characteristic/Inputs/class.ilFontSizeInputGUI.php
+++ b/Services/Style/Content/Characteristic/Inputs/class.ilFontSizeInputGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -22,7 +22,7 @@ class ilFontSizeInputGUI extends ilFormPropertyGUI
 {
     protected ilObjUser $user;
 
-    protected $value = "";
+    protected string $value = "";
     
     public function __construct(string $a_title = "", string $a_postvar = "")
     {

--- a/Services/Style/Content/Characteristic/Inputs/class.ilNumericStyleValueInputGUI.php
+++ b/Services/Style/Content/Characteristic/Inputs/class.ilNumericStyleValueInputGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -81,7 +81,7 @@ class ilNumericStyleValueInputGUI extends ilFormPropertyGUI
         return true;
     }
 
-    public function getInput()
+    public function getInput() : array
     {
         return $this->strArray($this->getPostVar());
     }

--- a/Services/Style/Content/Characteristic/Inputs/class.ilTRBLBorderStyleInputGUI.php
+++ b/Services/Style/Content/Characteristic/Inputs/class.ilTRBLBorderStyleInputGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system

--- a/Services/Style/Content/Characteristic/Inputs/class.ilTRBLBorderWidthInputGUI.php
+++ b/Services/Style/Content/Characteristic/Inputs/class.ilTRBLBorderWidthInputGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This class represents a border width with all/top/right/bottom/left in a property form.
@@ -206,15 +206,8 @@ class ilTRBLBorderWidthInputGUI extends ilFormPropertyGUI
         $a_tpl->parseCurrentBlock();
     }
 
-    /**
-    * Set value by array
-    *
-    * @param	array	$a_values	value array
-    */
-    public function setValueByArray($a_values)
+    public function setValueByArray(array $a_values) : void
     {
-        $ilUser = $this->user;
-        
         if ($a_values[$this->getPostVar()]["all"]["type"] == "predefined") {
             $this->setAllValue($a_values[$this->getPostVar()]["all"]["pre_value"]);
         } else {

--- a/Services/Style/Content/Characteristic/Inputs/class.ilTRBLColorPickerInputGUI.php
+++ b/Services/Style/Content/Characteristic/Inputs/class.ilTRBLColorPickerInputGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * Color picker form for selecting color hexcodes using yui library (all/top/right/bottom/left)
  *

--- a/Services/Style/Content/Characteristic/Inputs/class.ilTRBLNumericStyleValueInputGUI.php
+++ b/Services/Style/Content/Characteristic/Inputs/class.ilTRBLNumericStyleValueInputGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -142,7 +142,7 @@ class ilTRBLNumericStyleValueInputGUI extends ilFormPropertyGUI
         return true;
     }
 
-    public function getInput()
+    public function getInput() : array
     {
         return $this->arrayArray($this->getPostVar());
     }

--- a/Services/Style/Content/Characteristic/class.Characteristic.php
+++ b/Services/Style/Content/Characteristic/class.Characteristic.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system

--- a/Services/Style/Content/Characteristic/class.CharacteristicCopyPasteSessionRepo.php
+++ b/Services/Style/Content/Characteristic/class.CharacteristicCopyPasteSessionRepo.php
@@ -1,8 +1,11 @@
-<?php
+<?php declare(strict_types=1);
 
 /* Copyright (c) 1998-2021 ILIAS open source, GPLv3, see LICENSE */
 
 namespace ILIAS\Style\Content;
+
+use ilSession;
+use stdClass;
 
 /**
  * @author Alexander Killing <killing@leifos.de>
@@ -19,17 +22,17 @@ class CharacteristicCopyPasteSessionRepo
             ?: new class() implements Session {
                 public function set(string $key, string $value) : void
                 {
-                    \ilSession::set($key, $value);
+                    ilSession::set($key, $value);
                 }
 
                 public function get(string $key) : string
                 {
-                    return (string) \ilSession::get($key);
+                    return (string) ilSession::get($key);
                 }
 
                 public function clear(string $key) : void
                 {
-                    \ilSession::clear($key);
+                    ilSession::clear($key);
                 }
             };
     }
@@ -44,10 +47,10 @@ class CharacteristicCopyPasteSessionRepo
         $this->session->set(self::SESSION_KEY, $style_cp);
     }
 
-    public function getData() : \stdClass
+    public function getData() : stdClass
     {
         $st_c = explode(":::", $this->getValue());
-        $data = new \stdClass();
+        $data = new stdClass();
         $data->style_id = $st_c[0] ?? 0;
         $data->style_type = $st_c[1] ?? "";
         $data->characteristics = explode("::", $st_c[2] ?? "");

--- a/Services/Style/Content/Characteristic/class.CharacteristicDBRepo.php
+++ b/Services/Style/Content/Characteristic/class.CharacteristicDBRepo.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -15,16 +15,19 @@
 
 namespace ILIAS\Style\Content;
 
+use ilDBInterface;
+use ilObjStyleSheet;
+
 /**
  * @author Alexander Killing <killing@leifos.de>
  */
 class CharacteristicDBRepo
 {
-    protected \ilDBInterface $db;
+    protected ilDBInterface $db;
     protected InternalDataService $factory;
 
     public function __construct(
-        \ilDBInterface $db,
+        ilDBInterface $db,
         InternalDataService $factory
     ) {
         $this->db = $db;
@@ -38,7 +41,7 @@ class CharacteristicDBRepo
         bool $hidden = false,
         int $order_nr = 0,
         bool $outdated = false
-    ) {
+    ) : void {
         $db = $this->db;
 
         $db->insert("style_char", [
@@ -64,7 +67,7 @@ class CharacteristicDBRepo
             ["integer", "text", "text"],
             [$style_id, $type, $char]
         );
-        if ($rec = $db->fetchAssoc($set)) {
+        if ($db->fetchAssoc($set)) {
             return true;
         }
         return false;
@@ -170,7 +173,7 @@ class CharacteristicDBRepo
         int $style_id,
         string $super_type
     ) : array {
-        $stypes = \ilObjStyleSheet::_getStyleSuperTypes();
+        $stypes = ilObjStyleSheet::_getStyleSuperTypes();
         $types = $stypes[$super_type];
 
         return $this->getByTypes(
@@ -325,7 +328,7 @@ class CharacteristicDBRepo
             [$style_id, $a_tag, $a_class, $a_mq_id, $a_custom, $a_type, $a_par]
         );
 
-        if ($rec = $set->fetchRow()) {
+        if ($set->fetchRow()) {
             $db->update(
                 "style_parameter",
                 [

--- a/Services/Style/Content/Characteristic/class.CharacteristicManager.php
+++ b/Services/Style/Content/Characteristic/class.CharacteristicManager.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -16,6 +16,8 @@
 namespace ILIAS\Style\Content;
 
 use ILIAS\Style\Content\Access;
+use ilObjUser;
+use ilObjStyleSheet;
 
 /**
  * Main business logic for characteristics
@@ -25,7 +27,7 @@ class CharacteristicManager
 {
     protected CharacteristicDBRepo $repo;
     protected ColorDBRepo $color_repo;
-    protected \ilObjUser $user;
+    protected ilObjUser $user;
     protected Access\StyleAccessManager $access_manager;
     protected CharacteristicCopyPasteSessionRepo $session;
     protected int $style_id;
@@ -36,7 +38,7 @@ class CharacteristicManager
         CharacteristicDBRepo $char_repo,
         CharacteristicCopyPasteSessionRepo $char_copy_paste_repo,
         ColorDBRepo $color_repo,
-        \ilObjUser $user
+        ilObjUser $user
     ) {
         $this->user = $user;
         $this->repo = $char_repo;
@@ -58,7 +60,7 @@ class CharacteristicManager
             $hidden
         );
 
-        \ilObjStyleSheet::_writeUpToDate($this->style_id, false);
+        ilObjStyleSheet::_writeUpToDate($this->style_id, false);
     }
 
     /**
@@ -131,7 +133,6 @@ class CharacteristicManager
 
     /**
      * Get characteristic by key
-     * @return Characteristic|null
      */
     public function getPresentationTitle(
         string $type,
@@ -247,14 +248,14 @@ class CharacteristicManager
     public function deleteCharacteristic(
         string $type,
         string $class
-    ) {
+    ) : void {
         if (!$this->access_manager->checkWrite()) {
             throw new ContentStyleNoPermissionException("No write permission for style.");
         }
-        $tag = \ilObjStyleSheet::_determineTag($type);
+        $tag = ilObjStyleSheet::_determineTag($type);
 
         // check, if characteristic is not a core style
-        $core_styles = \ilObjStyleSheet::_getCoreStyles();
+        $core_styles = ilObjStyleSheet::_getCoreStyles();
         if (empty($core_styles[$type . "." . $tag . "." . $class])) {
             $this->repo->deleteCharacteristic(
                 $this->style_id,
@@ -264,13 +265,13 @@ class CharacteristicManager
             );
         }
 
-        \ilObjStyleSheet::_writeUpToDate($this->style_id, false);
+        ilObjStyleSheet::_writeUpToDate($this->style_id, false);
     }
 
     public function setCopyCharacteristics(
         string $style_type,
         array $characteristics
-    ) {
+    ) : void {
         $this->session->set($this->style_id, $style_type, $characteristics);
     }
 
@@ -331,7 +332,7 @@ class CharacteristicManager
         $this->addCharacteristic($source_style_type, $new_char);
         $this->saveTitles($source_style_type, $new_char, $new_titles);
 
-        $from_style = new \ilObjStyleSheet($source_style_id);
+        $from_style = new ilObjStyleSheet($source_style_id);
 
         // todo fix using mq_id
         $pars = $from_style->getParametersOfClass($source_style_type, $source_char);
@@ -342,7 +343,7 @@ class CharacteristicManager
                 $colors[] = substr($v, 1);
             }
             $this->replaceParameter(
-                \ilObjStyleSheet::_determineTag($source_style_type),
+                ilObjStyleSheet::_determineTag($source_style_type),
                 $new_char,
                 $p,
                 $v,

--- a/Services/Style/Content/Characteristic/class.CharacteristicTableGUI.php
+++ b/Services/Style/Content/Characteristic/class.CharacteristicTableGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -17,17 +17,20 @@ namespace ILIAS\Style\Content;
 
 use ILIAS\Style;
 use ILIAS\Style\Content\Access;
+use ilObjStyleSheet;
+use ilTable2GUI;
+use ilObjStyleSheetGUI;
 
 /**
  * TableGUI class for characteristics
  *
  * @author Alexander Killing <killing@leifos.de>
  */
-class CharacteristicTableGUI extends \ilTable2GUI
+class CharacteristicTableGUI extends ilTable2GUI
 {
     protected Style\Content\CharacteristicManager $manager;
     protected Access\StyleAccessManager $access_manager;
-    protected \ilObjStyleSheet $style;
+    protected ilObjStyleSheet $style;
     protected string $super_type;
     protected bool $hideable;
     protected int $order_cnt = 0;
@@ -40,7 +43,7 @@ class CharacteristicTableGUI extends \ilTable2GUI
         object $a_parent_obj,
         string $a_parent_cmd,
         string $a_super_type,
-        \ilObjStyleSheet $a_style,
+        ilObjStyleSheet $a_style,
         Style\Content\CharacteristicManager $manager,
         Access\StyleAccessManager $access_manager
     ) {
@@ -54,7 +57,7 @@ class CharacteristicTableGUI extends \ilTable2GUI
 
         parent::__construct($a_parent_obj, $a_parent_cmd);
         $this->setExternalSorting(true);
-        $this->core_styles = \ilObjStyleSheet::_getCoreStyles();
+        $this->core_styles = ilObjStyleSheet::_getCoreStyles();
         $this->getItems();
         $this->setTitle($this->lng->txt("sty_" . $a_super_type . "_char"));
         $this->setLimit(9999);
@@ -62,13 +65,13 @@ class CharacteristicTableGUI extends \ilTable2GUI
         // check, whether any of the types is expandable
         $this->expandable = false;
         $this->hideable = false;
-        $all_super_types = \ilObjStyleSheet::_getStyleSuperTypes();
+        $all_super_types = ilObjStyleSheet::_getStyleSuperTypes();
         $types = $all_super_types[$this->super_type];
         foreach ($types as $t) {
-            if (\ilObjStyleSheet::_isExpandable($t)) {
+            if (ilObjStyleSheet::_isExpandable($t)) {
                 $this->expandable = true;
             }
-            if (\ilObjStyleSheet::_isHideable($t)) {
+            if (ilObjStyleSheet::_isHideable($t)) {
                 $this->hideable = true;
             }
         }
@@ -140,7 +143,7 @@ class CharacteristicTableGUI extends \ilTable2GUI
             $this->order_cnt = $this->order_cnt + 10;
             $this->tpl->setCurrentBlock("order");
             $this->tpl->setVariable("OCHAR", $char->getType() . "." .
-                \ilObjStyleSheet::_determineTag($char->getType()) .
+                ilObjStyleSheet::_determineTag($char->getType()) .
                 "." . $char->getCharacteristic());
             $this->tpl->setVariable("ORDER", $this->order_cnt);
             $this->tpl->parseCurrentBlock();
@@ -149,20 +152,20 @@ class CharacteristicTableGUI extends \ilTable2GUI
 
         $this->tpl->setCurrentBlock("checkbox");
         $this->tpl->setVariable("CHAR", $char->getType() . "." .
-            \ilObjStyleSheet::_determineTag($char->getType()) .
+            ilObjStyleSheet::_determineTag($char->getType()) .
                     "." . $char->getCharacteristic());
         $this->tpl->parseCurrentBlock();
 
         if ($this->hideable) {
-            if (!\ilObjStyleSheet::_isHideable($char->getType()) ||
+            if (!ilObjStyleSheet::_isHideable($char->getType()) ||
                 (!empty($this->core_styles[$char->getType() . "." .
-                \ilObjStyleSheet::_determineTag($char->getType()) .
+                ilObjStyleSheet::_determineTag($char->getType()) .
                 "." . $char->getCharacteristic()]))) {
                 $this->tpl->touchBlock("no_hide_checkbox");
             } else {
                 $this->tpl->setCurrentBlock("hide_checkbox");
                 $this->tpl->setVariable("CHAR", $char->getType() . "." .
-                    \ilObjStyleSheet::_determineTag($char->getType()) .
+                    ilObjStyleSheet::_determineTag($char->getType()) .
                     "." . $char->getCharacteristic());
                 if ($this->style->getHideStatus($char->getType(), $char->getCharacteristic())) {
                     $this->tpl->setVariable("CHECKED", "checked='checked'");
@@ -174,9 +177,9 @@ class CharacteristicTableGUI extends \ilTable2GUI
         // example
         $this->tpl->setVariable(
             "EXAMPLE",
-            \ilObjStyleSheetGUI::getStyleExampleHTML($char->getType(), $char->getCharacteristic())
+            ilObjStyleSheetGUI::getStyleExampleHTML($char->getType(), $char->getCharacteristic())
         );
-        $tag_str = \ilObjStyleSheet::_determineTag($char->getType()) . "." . $char->getCharacteristic();
+        $tag_str = ilObjStyleSheet::_determineTag($char->getType()) . "." . $char->getCharacteristic();
         $this->tpl->setVariable("TXT_TAG", $char->getCharacteristic());
         $this->tpl->setVariable("TXT_TYPE", $lng->txt("sty_type_" . $char->getType()));
 
@@ -197,7 +200,7 @@ class CharacteristicTableGUI extends \ilTable2GUI
                 $ilCtrl->getLinkTargetByClass("ilStyleCharacteristicGUI", "editTagStyle")
             );
 
-            if (!\ilObjStyleSheet::isCoreStyle($char->getType(), $char->getCharacteristic())) {
+            if (!ilObjStyleSheet::isCoreStyle($char->getType(), $char->getCharacteristic())) {
                 if ($char->isOutdated()) {
                     $this->tpl->setVariable("OUTDATED", $lng->txt("yes"));
                     $links[] = $ui->factory()->link()->standard(

--- a/Services/Style/Content/Characteristic/class.CharacteristicUIFactory.php
+++ b/Services/Style/Content/Characteristic/class.CharacteristicUIFactory.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -16,6 +16,8 @@
 namespace ILIAS\Style\Content;
 
 use ILIAS\Style\Content\Access\StyleAccessManager;
+use ilObjStyleSheet;
+use ilStyleCharacteristicGUI;
 
 /**
  * @author Alexander Killing <killing@leifos.de>
@@ -35,13 +37,13 @@ class CharacteristicUIFactory
 
     // characteristics editing
     public function ilStyleCharacteristicGUI(
-        \ilObjStyleSheet $style_sheet_obj,
+        ilObjStyleSheet $style_sheet_obj,
         string $super_type,
         StyleAccessManager $access_manager,
         CharacteristicManager $characteristic_manager,
         ImageManager $image_manager
-    ) : \ilStyleCharacteristicGUI {
-        return new \ilStyleCharacteristicGUI(
+    ) : ilStyleCharacteristicGUI {
+        return new ilStyleCharacteristicGUI(
             $this->domain_service,
             $this->gui_service,
             $style_sheet_obj,
@@ -57,7 +59,7 @@ class CharacteristicUIFactory
         object $a_parent_obj,
         string $a_parent_cmd,
         string $a_super_type,
-        \ilObjStyleSheet $a_style,
+        ilObjStyleSheet $a_style,
         CharacteristicManager $manager,
         Access\StyleAccessManager $access_manager
     ) : CharacteristicTableGUI {

--- a/Services/Style/Content/Characteristic/class.ilStyleCharacteristicGUI.php
+++ b/Services/Style/Content/Characteristic/class.ilStyleCharacteristicGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -16,6 +16,7 @@
 use ILIAS\UI\Component\Input\Container\Form;
 use ILIAS\Style\Content;
 use ILIAS\Style\Content\Access;
+use ILIAS\UI\Component\Input\Container\Form\Standard;
 
 /**
  * Characteristics UI
@@ -39,7 +40,7 @@ class ilStyleCharacteristicGUI
     protected Content\ImageManager $image_manager;
     protected Content\InternalGUIService $gui_service;
     protected Content\InternalDomainService $domain_service;
-    private \ilGlobalTemplateInterface $main_tpl;
+    private ilGlobalTemplateInterface $main_tpl;
 
     public function __construct(
         Content\InternalDomainService $domain_service,
@@ -455,7 +456,6 @@ class ilStyleCharacteristicGUI
 
     protected function editTagStyle() : void
     {
-        $tpl = $this->gui_service->mainTemplate();
         $ilToolbar = $this->gui_service->toolbar();
         $lng = $this->domain_service->lng();
         $ilCtrl = $this->gui_service->ctrl();
@@ -524,7 +524,6 @@ class ilStyleCharacteristicGUI
                 $basepar = $basepar[0];
 
                 $var = str_replace("-", "_", $basepar);
-                $up_par = strtoupper($var);
 
                 switch (ilObjStyleSheet::_getStyleParameterInputType($par)) {
                     case "select":
@@ -644,7 +643,7 @@ class ilStyleCharacteristicGUI
      */
     protected function getValues(ilPropertyFormGUI $form) : void
     {
-        $cur_parameters = $this->extractParametersOfTag(false);
+        $cur_parameters = $this->extractParametersOfTag();
         $parameters = ilObjStyleSheet::_getStyleParameters();
         foreach ($parameters as $p => $v) {
             $filtered_groups = ilObjStyleSheet::_getFilteredGroups();
@@ -771,7 +770,7 @@ class ilStyleCharacteristicGUI
 
                 case "color":
                     $color = trim($form->getInput($basepar));
-                    if ($color != "" && trim(substr($color, 0, 1) != "!")) {
+                    if ($color != "" && trim(substr($color, 0, 1)) != "!") {
                         $color = "#" . $color;
                     }
                     $this->writeStylePar($basepar, $color);
@@ -864,7 +863,7 @@ class ilStyleCharacteristicGUI
     /**
      * @throws ilCtrlException
      */
-    protected function getTagTitlesForm() : Form\Standard
+    protected function getTagTitlesForm() : Standard
     {
         $ui = $this->gui_service->ui();
         $f = $ui->factory();
@@ -976,7 +975,7 @@ class ilStyleCharacteristicGUI
         if (count($chars) > 0) {
             foreach ($chars as $c) {
                 $c_parts = explode(".", $c);
-                if (!\ilObjStyleSheet::isCoreStyle($c_parts[0], $c_parts[2])) {
+                if (!ilObjStyleSheet::isCoreStyle($c_parts[0], $c_parts[2])) {
                     $this->manager->saveOutdated(
                         $c_parts[0],
                         $c_parts[2],
@@ -1006,7 +1005,7 @@ class ilStyleCharacteristicGUI
         if (count($chars) > 0) {
             foreach ($chars as $c) {
                 $c_parts = explode(".", $c);
-                if (!\ilObjStyleSheet::isCoreStyle($c_parts[0], $c_parts[2])) {
+                if (!ilObjStyleSheet::isCoreStyle($c_parts[0], $c_parts[2])) {
                     $this->manager->saveOutdated(
                         $c_parts[0],
                         $c_parts[2],
@@ -1067,7 +1066,7 @@ class ilStyleCharacteristicGUI
      * Init past within style form
      * @throws ilCtrlException
      */
-    public function getPasteWithinStyleForm() : \ILIAS\UI\Component\Input\Container\Form\Standard
+    public function getPasteWithinStyleForm() : Standard
     {
         $ui = $this->gui_service->ui();
         $f = $ui->factory();
@@ -1091,7 +1090,7 @@ class ilStyleCharacteristicGUI
      * Init past from other style form
      * @throws ilCtrlException
      */
-    public function getPasteFromOtherStyleForm() : \ILIAS\UI\Component\Input\Container\Form\Standard
+    public function getPasteFromOtherStyleForm() : Standard
     {
         $ui = $this->gui_service->ui();
         $lng = $this->domain_service->lng();

--- a/Services/Style/Content/Characteristic/interface.Session.php
+++ b/Services/Style/Content/Characteristic/interface.Session.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system

--- a/Services/Style/Content/Color/class.ColorDBRepo.php
+++ b/Services/Style/Content/Color/class.ColorDBRepo.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -15,16 +15,18 @@
 
 namespace ILIAS\Style\Content;
 
+use ilDBInterface;
+
 /**
  * @author Alexander Killing <killing@leifos.de>
  */
 class ColorDBRepo
 {
-    protected \ilDBInterface $db;
+    protected ilDBInterface $db;
     protected InternalDataService $factory;
 
     public function __construct(
-        \ilDBInterface $db,
+        ilDBInterface $db,
         InternalDataService $factory
     ) {
         $this->db = $db;
@@ -57,7 +59,7 @@ class ColorDBRepo
         $set = $db->query("SELECT * FROM style_color WHERE " .
             "style_id = " . $db->quote($style_id, "integer") . " AND " .
             "color_name = " . $db->quote($a_color_name, "text"));
-        if ($rec = $db->fetchAssoc($set)) {
+        if ($db->fetchAssoc($set)) {
             return true;
         }
         return false;

--- a/Services/Style/Content/Color/class.ColorManager.php
+++ b/Services/Style/Content/Color/class.ColorManager.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -16,6 +16,7 @@
 namespace ILIAS\Style\Content;
 
 use ILIAS\Style\Content\Access;
+use ilObjStyleSheet;
 
 /**
  * @author Alexander Killing <killing@leifos.de>
@@ -85,7 +86,7 @@ class ColorManager
             $code
         );
 
-        \ilObjStyleSheet::_writeUpToDate($this->style_id, false);
+        ilObjStyleSheet::_writeUpToDate($this->style_id, false);
 
         // rename also the name in the style parameter values
         if ($name != $new_name) {

--- a/Services/Style/Content/Color/class.ilStyleColorTableGUI.php
+++ b/Services/Style/Content/Color/class.ilStyleColorTableGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -50,10 +50,10 @@ class ilStyleColorTableGUI extends ilTable2GUI
         $this->style_obj = $a_style_obj;
         
         $this->addColumn("", "", "1");	// checkbox
-        $this->addColumn($this->lng->txt("sty_color_name"), "");
-        $this->addColumn($this->lng->txt("sty_color_code"), "");
-        $this->addColumn($this->lng->txt("sty_color"), "");
-        $this->addColumn($this->lng->txt("sty_color_flavors"), "");
+        $this->addColumn($this->lng->txt("sty_color_name"));
+        $this->addColumn($this->lng->txt("sty_color_code"));
+        $this->addColumn($this->lng->txt("sty_color"));
+        $this->addColumn($this->lng->txt("sty_color_flavors"));
         $this->addColumn($this->lng->txt("sty_commands"), "", "1");
         $this->setEnableHeader(true);
         $this->setFormAction($ilCtrl->getFormAction($a_parent_obj));

--- a/Services/Style/Content/Container/class.ContainerDBRepository.php
+++ b/Services/Style/Content/Container/class.ContainerDBRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -15,27 +15,25 @@
 
 namespace ILIAS\Style\Content\Container;
 
+use ilDBInterface;
+
 /**
  * This repo stores infos on repository objects that are using booking managers as a service
  * (resource management).
- *
  * @author Alexander Killing <killing@leifos.de>
  */
 class ContainerDBRepository
 {
     const TABLE_NAME = 'sty_rep_container';
 
-    /**
-     * @var \ilDBInterface
-     */
-    protected $db;
+    protected ilDBInterface $db;
 
-    public function __construct(\ilDBInterface $db)
+    public function __construct(ilDBInterface $db)
     {
         $this->db = $db;
     }
 
-    public function updateReuse(int $ref_id, bool $reuse)
+    public function updateReuse(int $ref_id, bool $reuse) : void
     {
         $db = $this->db;
 

--- a/Services/Style/Content/Container/class.ContainerManager.php
+++ b/Services/Style/Content/Container/class.ContainerManager.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -15,7 +15,7 @@
 
 namespace ILIAS\Style\Content\Container;
 
-use \ILIAS\Style\Content\InternalRepoService;
+use ILIAS\Style\Content\InternalRepoService;
 
     /**
  * Manages container related content style behaviour
@@ -23,20 +23,9 @@ use \ILIAS\Style\Content\InternalRepoService;
  */
 class ContainerManager
 {
-    /**
-     * @var ContainerDBRepository
-     */
-    protected $container_repo;
-
-    /**
-     * @var int
-     */
-    protected $ref_id;
-
-    /**
-     * @var InternalRepoService
-     */
-    protected $repo_service;
+    protected ContainerDBRepository $container_repo;
+    protected int $ref_id;
+    protected InternalRepoService $repo_service;
 
     public function __construct(
         InternalRepoService $repo_service,
@@ -47,7 +36,7 @@ class ContainerManager
         $this->container_repo = $repo_service->repositoryContainer();
     }
 
-    public function saveReuse(bool $reuse)
+    public function saveReuse(bool $reuse) : void
     {
         $this->container_repo->updateReuse($this->ref_id, $reuse);
     }

--- a/Services/Style/Content/Exceptions/class.ContentStyleNoPermissionException.php
+++ b/Services/Style/Content/Exceptions/class.ContentStyleNoPermissionException.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -15,11 +15,12 @@
 
 namespace ILIAS\Style\Content;
 
+use ilException;
+
 /**
  * No permission for style exception
- *
  * @author Alexander Killing <killing@leifos.de>
  */
-class ContentStyleNoPermissionException extends \ilException
+class ContentStyleNoPermissionException extends ilException
 {
 }

--- a/Services/Style/Content/Images/class.Image.php
+++ b/Services/Style/Content/Images/class.Image.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system

--- a/Services/Style/Content/Images/class.ImageFileRepo.php
+++ b/Services/Style/Content/Images/class.ImageFileRepo.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -18,6 +18,9 @@ namespace ILIAS\Style\Content;
 use ILIAS\Filesystem;
 use ILIAS\Data\DataSize;
 use ILIAS\FileUpload\FileUpload;
+use Generator;
+use ILIAS\FileUpload\DTO\ProcessingStatus;
+use ILIAS\FileUpload\Location;
 
 /**
  * @author Alexander Killing <killing@leifos.de>
@@ -43,18 +46,18 @@ class ImageFileRepo
     // get image directory
     protected function dir(int $style_id) : string
     {
-        return str_replace("%id%", $style_id, self::DIR_PATH);
+        return str_replace("%id%", (string) $style_id, self::DIR_PATH);
     }
 
     /**
      * Get images of style
      * @param int $style_id
-     * @return \Generator
+     * @return Generator
      * @throws Filesystem\Exception\DirectoryNotFoundException
      */
     public function getImages(
         int $style_id
-    ) : \Generator {
+    ) : Generator {
         $dir = $this->dir($style_id);
         if ($this->web_files->hasDir($dir)) {
             foreach ($this->web_files->listContents($dir) as $meta) {
@@ -111,8 +114,8 @@ class ImageFileRepo
         if ($upload->hasUploads() && !$upload->hasBeenProcessed()) {
             $upload->process();
             $result = array_values($upload->getResults())[0];
-            if ($result->getStatus() == \ILIAS\FileUpload\DTO\ProcessingStatus::OK) {
-                $upload->moveFilesTo($dir, \ILIAS\FileUpload\Location::WEB);
+            if ($result->getStatus() == ProcessingStatus::OK) {
+                $upload->moveFilesTo($dir, Location::WEB);
             }
         }
     }

--- a/Services/Style/Content/Images/class.ImageManager.php
+++ b/Services/Style/Content/Images/class.ImageManager.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -18,6 +18,7 @@ namespace ILIAS\Style\Content;
 use ILIAS\Style\Content\Access;
 use ILIAS\Filesystem;
 use ilShellUtil;
+use Generator;
 
 /**
  * Main business logic for content style images
@@ -41,10 +42,10 @@ class ImageManager
 
     /**
      * Get images of style
-     * @return \Generator
+     * @return Generator
      * @throws Filesystem\Exception\DirectoryNotFoundException
      */
-    public function getImages() : \Generator
+    public function getImages() : Generator
     {
         return $this->repo->getImages($this->style_id);
     }

--- a/Services/Style/Content/Images/class.ImageUIFactory.php
+++ b/Services/Style/Content/Images/class.ImageUIFactory.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -16,6 +16,7 @@
 namespace ILIAS\Style\Content;
 
 use ILIAS\Style\Content\Access\StyleAccessManager;
+use ilContentStyleImageGUI;
 
 /**
  * @author Alexander Killing <killing@leifos.de>
@@ -36,8 +37,8 @@ class ImageUIFactory
     public function ilContentStyleImageGUI(
         StyleAccessManager $access_manager,
         ImageManager $image_manager
-    ) : \ilContentStyleImageGUI {
-        return new \ilContentStyleImageGUI(
+    ) : ilContentStyleImageGUI {
+        return new ilContentStyleImageGUI(
             $this->domain_service,
             $this->gui_service,
             $access_manager,

--- a/Services/Style/Content/Images/class.ilContentStyleImageGUI.php
+++ b/Services/Style/Content/Images/class.ilContentStyleImageGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -13,13 +13,11 @@
  * https://github.com/ILIAS-eLearning
  */
 
-use ILIAS\UI\Component\Input\Container\Form;
-use Psr\Http\Message;
 use ILIAS\Style\Content;
 use ILIAS\Style\Content\Access;
 
 /**
- * Conent style images UI
+ * Content style images UI
  *
  * @author Alexander Killing <killing@leifos.de>
  */

--- a/Services/Style/Content/Images/class.ilStyleImageTableGUI.php
+++ b/Services/Style/Content/Images/class.ilStyleImageTableGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -15,6 +15,7 @@
 
 use ILIAS\Style\Content\Access;
 use ILIAS\Style\Content;
+use ILIAS\DI\UIServices;
 
 /**
  * TableGUI class for style editor (image list)
@@ -25,9 +26,9 @@ class ilStyleImageTableGUI extends ilTable2GUI
 {
     protected ilAccessHandler $access;
     protected ilRbacSystem $rbacsystem;
-    protected \ilObjStyleSheet $style_obj;
+    protected ilObjStyleSheet $style_obj;
     protected Access\StyleAccessManager $access_manager;
-    protected \ILIAS\DI\UIServices $ui;
+    protected UIServices $ui;
     protected Content\ImageManager $image_manager;
 
     /**

--- a/Services/Style/Content/Object/class.ObjectDBRepository.php
+++ b/Services/Style/Content/Object/class.ObjectDBRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -15,23 +15,20 @@
 
 namespace ILIAS\Style\Content\Object;
 
+use ilDBInterface;
+
 /**
  * This repo stores infos on repository objects that are using booking managers as a service
  * (resource management).
- *
  * @author Alexander Killing <killing@leifos.de>
  */
 class ObjectDBRepository
 {
-    private const USAGE_TABLE_NAME = 'style_usage';
     const DATA_TABLE_NAME = 'style_data';
 
-    /**
-     * @var \ilDBInterface
-     */
-    protected \ilDBInterface $db;
+    protected ilDBInterface $db;
 
-    public function __construct(\ilDBInterface $db)
+    public function __construct(ilDBInterface $db)
     {
         $this->db = $db;
     }
@@ -73,7 +70,7 @@ class ObjectDBRepository
             [$style_id, $obj_id]
         );
 
-        if ($rec = $db->fetchAssoc($set)) {
+        if ($db->fetchAssoc($set)) {
             return true;
         }
         return false;

--- a/Services/Style/Content/Object/class.ObjectFacade.php
+++ b/Services/Style/Content/Object/class.ObjectFacade.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -15,8 +15,9 @@
 
 namespace ILIAS\Style\Content\Object;
 
-use \ILIAS\Style\Content\InternalDataService;
-use \ILIAS\Style\Content\InternalDomainService;
+use ILIAS\Style\Content\InternalDataService;
+use ILIAS\Style\Content\InternalDomainService;
+use ilObject;
 
 /**
  * External facade for object content styles
@@ -24,30 +25,11 @@ use \ILIAS\Style\Content\InternalDomainService;
  */
 class ObjectFacade
 {
-    /**
-     * @var ObjectManager
-     */
-    protected $object_manager;
-
-    /**
-     * @var int
-     */
-    protected $ref_id;
-
-    /**
-     * @var int
-     */
-    protected $obj_id;
-
-    /**
-     * @var InternalDataService
-     */
-    protected $data_service;
-
-    /**
-     * @var InternalDomainService
-     */
-    protected $domain_service;
+    protected ObjectManager $object_manager;
+    protected int $ref_id;
+    protected int $obj_id;
+    protected InternalDataService $data_service;
+    protected InternalDomainService $domain_service;
 
     public function __construct(
         InternalDataService $data_service,
@@ -58,7 +40,7 @@ class ObjectFacade
         $this->ref_id = $ref_id;
         $this->ref_id = ($obj_id > 0)
             ? $obj_id
-            : \ilObject::_lookupObjId($ref_id);
+            : ilObject::_lookupObjId($ref_id);
         $this->domain_service = $domain_service;
         $this->object_manager = $domain_service->object($this->ref_id, $obj_id);
     }
@@ -105,7 +87,7 @@ class ObjectFacade
     /**
      * Inherits a non local style from the parent container
      */
-    public function inheritFromParent()
+    public function inheritFromParent() : void
     {
         $this->object_manager->inheritFromParent();
     }

--- a/Services/Style/Content/Object/class.ilObjectContentStyleSettingsGUI.php
+++ b/Services/Style/Content/Object/class.ilObjectContentStyleSettingsGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -13,6 +13,11 @@
  * https://github.com/ILIAS-eLearning
  */
 
+use ILIAS\Style\Content\Object\ObjectManager;
+use ILIAS\Style\Content\Container\ContainerManager;
+use ILIAS\Style\Content\InternalDomainService;
+use ILIAS\Style\Content\InternalGUIService;
+
 /**
  * Style settings of a repository object
  * @author Alexander Killing <killing@leifos.de>
@@ -20,45 +25,18 @@
  */
 class ilObjectContentStyleSettingsGUI
 {
-    /**
-     * @var \ILIAS\Style\Content\Object\ObjectManager
-     */
-    protected $object_manager;
-
-    /**
-     * @var \ILIAS\Style\Content\Container\ContainerManager
-     */
-    protected $container_manager;
-
-    /**
-     * @var \ILIAS\Style\Content\InternalDomainService
-     */
-    protected $domain;
-
-    /**
-     * @var \ILIAS\Style\Content\InternalGUIService
-     */
-    protected $gui;
-
-    /**
-     * @var int
-     */
-    protected $current_style_id;
-
-    /**
-     * @var int
-     */
-    protected $ref_id;
-
-    /**
-     * @var int
-     */
-    protected $obj_id;
-    private \ilGlobalTemplateInterface $main_tpl;
+    protected ObjectManager $object_manager;
+    protected ContainerManager $container_manager;
+    protected InternalDomainService $domain;
+    protected InternalGUIService $gui;
+    protected int $current_style_id;
+    protected int $ref_id;
+    protected int $obj_id;
+    private ilGlobalTemplateInterface $main_tpl;
 
     public function __construct(
-        \ILIAS\Style\Content\InternalDomainService $domain_service,
-        \ILIAS\Style\Content\InternalGUIService $gui_service,
+        InternalDomainService $domain_service,
+        InternalGUIService $gui_service,
         ?int $current_style_id,
         int $ref_id,
         int $obj_id
@@ -142,7 +120,7 @@ class ilObjectContentStyleSettingsGUI
         $lng->loadLanguageModule("style");
 
         $form = new ilPropertyFormGUI();
-        $fixed_style = $settings->get("fixed_content_style_id");
+        $fixed_style = (int) $settings->get("fixed_content_style_id");
         if ($fixed_style > 0) {
             $st = new ilNonEditableValueGUI($lng->txt("style_current_style"));
             $st->setValue(ilObject::_lookupTitle($fixed_style) . " (" .
@@ -233,7 +211,6 @@ class ilObjectContentStyleSettingsGUI
         $style_gui = new ilObjStyleSheetGUI(
             "",
             $this->current_style_id,
-            false,
             false
         );
         $style_id = $ctrl->forwardCommand($style_gui);
@@ -279,7 +256,7 @@ class ilObjectContentStyleSettingsGUI
     /**
      * Save style settings
      */
-    protected function saveStyleSettings()
+    protected function saveStyleSettings() : void
     {
         $settings = $this->domain->settings();
         $lng = $this->domain->lng();
@@ -299,7 +276,6 @@ class ilObjectContentStyleSettingsGUI
 
     protected function saveIndividualStyleSettings() : void
     {
-        $settings = $this->domain->settings();
         $lng = $this->domain->lng();
         $ctrl = $this->gui->ctrl();
 

--- a/Services/Style/Content/Service/class.DomainService.php
+++ b/Services/Style/Content/Service/class.DomainService.php
@@ -15,7 +15,6 @@
 
 namespace ILIAS\Style\Content;
 
-use ILIAS\DI\Container;
 use ILIAS\Style\Content\Object\ObjectFacade;
 
 /**
@@ -25,9 +24,6 @@ use ILIAS\Style\Content\Object\ObjectFacade;
  */
 class DomainService
 {
-    /**
-     * @var InternalService
-     */
     private InternalService $internal;
 
     public function __construct(

--- a/Services/Style/Content/Service/class.GUIService.php
+++ b/Services/Style/Content/Service/class.GUIService.php
@@ -15,18 +15,16 @@
 
 namespace ILIAS\Style\Content;
 
-use ILIAS\DI\Container;
+use ilObjectContentStyleSettingsGUI;
+use ilGlobalTemplateInterface;
+use ilObjStyleSheet;
 
 /**
  * Facade for consumer gui interface
- *
  * @author Alexander Killing <killing@leifos.de>
  */
 class GUIService
 {
-    /**
-     * @var InternalService
-     */
     private InternalService $internal;
 
     public function __construct(
@@ -37,17 +35,13 @@ class GUIService
 
     public function objectSettingsClass(bool $lower = true) : string
     {
-        $class = \ilObjectContentStyleSettingsGUI::class;
-        if ($lower) {
-            $class = strtolower($class);
-        }
         return $this->internal->gui()->objectSettingsClass($lower);
     }
 
     public function objectSettingsGUIForRefId(
         ?int $selected_style_id,
         int $ref_id
-    ) : \ilObjectContentStyleSettingsGUI {
+    ) : ilObjectContentStyleSettingsGUI {
         return $this->internal->gui()->objectSettingsGUI(
             $selected_style_id,
             $ref_id
@@ -57,7 +51,7 @@ class GUIService
     public function objectSettingsGUIForObjId(
         int $selected_style_id,
         int $obj_id
-    ) : \ilObjectContentStyleSettingsGUI {
+    ) : ilObjectContentStyleSettingsGUI {
         return $this->internal->gui()->objectSettingsGUI(
             $selected_style_id,
             0,
@@ -75,9 +69,9 @@ class GUIService
     }
 
     // add effective style sheet path to global template
-    public function addCss(\ilGlobalTemplateInterface $tpl, int $ref_id, int $obj_id = 0) : void
+    public function addCss(ilGlobalTemplateInterface $tpl, int $ref_id, int $obj_id = 0) : void
     {
         $eff_style_id = $this->internal->domain()->object($ref_id, $obj_id)->getEffectiveStyleId();
-        $tpl->addCss(\ilObjStyleSheet::getContentStylePath($eff_style_id));
+        $tpl->addCss(ilObjStyleSheet::getContentStylePath($eff_style_id));
     }
 }

--- a/Services/Style/Content/Service/class.InternalDomainService.php
+++ b/Services/Style/Content/Service/class.InternalDomainService.php
@@ -20,8 +20,9 @@ use ILIAS\DI\Container;
 use ILIAS\Repository\GlobalDICDomainServices;
 use ILIAS\Style\Content\Container\ContainerManager;
 use ILIAS\Style\Content\Object\ObjectManager;
+use ilRbacSystem;
 
- /**
+/**
  * @author Alexander Killing <killing@leifos.de>
  */
 class InternalDomainService
@@ -31,7 +32,7 @@ class InternalDomainService
     protected Container $dic;
     protected InternalRepoService $repo_service;
     protected InternalDataService $data_service;
-    protected \ilRbacSystem $rbacsystem;
+    protected ilRbacSystem $rbacsystem;
 
     public function __construct(
         Container $DIC,

--- a/Services/Style/Content/Service/class.InternalGUIService.php
+++ b/Services/Style/Content/Service/class.InternalGUIService.php
@@ -17,6 +17,7 @@ namespace ILIAS\Style\Content;
 
 use ILIAS\DI\Container;
 use ILIAS\Repository\GlobalDICGUIServices;
+use ilObjectContentStyleSettingsGUI;
 
 /**
  * Content style internal ui factory
@@ -75,7 +76,7 @@ class InternalGUIService
     // get class name of object settings gui class
     public function objectSettingsClass(bool $lower = true) : string
     {
-        $class = \ilObjectContentStyleSettingsGUI::class;
+        $class = ilObjectContentStyleSettingsGUI::class;
         if ($lower) {
             $class = strtolower($class);
         }
@@ -87,8 +88,8 @@ class InternalGUIService
         ?int $selected_style_id,
         int $ref_id,
         int $obj_id = 0
-    ) : \ilObjectContentStyleSettingsGUI {
-        return new \ilObjectContentStyleSettingsGUI(
+    ) : ilObjectContentStyleSettingsGUI {
+        return new ilObjectContentStyleSettingsGUI(
             $this->domain_service,
             $this,
             $selected_style_id,

--- a/Services/Style/Content/Service/class.InternalRepoService.php
+++ b/Services/Style/Content/Service/class.InternalRepoService.php
@@ -17,6 +17,7 @@ namespace ILIAS\Style\Content;
 
 use ILIAS\Filesystem;
 use ILIAS\FileUpload\FileUpload;
+use ilDBInterface;
 
 /**
  * Content style internal repo service
@@ -24,7 +25,7 @@ use ILIAS\FileUpload\FileUpload;
  */
 class InternalRepoService
 {
-    protected \ilDBInterface $db;
+    protected ilDBInterface $db;
     protected InternalDataService $data_factory;
     protected ColorDBRepo $color_repo;
     protected CharacteristicDBRepo $characteristic_repo;
@@ -34,7 +35,7 @@ class InternalRepoService
 
     public function __construct(
         InternalDataService $data_factory,
-        \ilDBInterface $db,
+        ilDBInterface $db,
         Filesystem\Filesystem $web_files,
         FileUpload $upload
     ) {

--- a/Services/Style/Content/classes/class.StandardGUIRequest.php
+++ b/Services/Style/Content/classes/class.StandardGUIRequest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -16,14 +16,16 @@
 namespace ILIAS\Style\Content;
 
 use ILIAS\Repository;
+use ILIAS\HTTP\Services;
+use ILIAS\Refinery\Factory;
 
 class StandardGUIRequest
 {
     use Repository\BaseGUIRequest;
 
     public function __construct(
-        \ILIAS\HTTP\Services $http,
-        \ILIAS\Refinery\Factory $refinery,
+        Services $http,
+        Factory $refinery,
         ?array $passed_query_params = null,
         ?array $passed_post_data = null
     ) {

--- a/Services/Style/Content/classes/class.ilContentStyleSettings.php
+++ b/Services/Style/Content/classes/class.ilContentStyleSettings.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system

--- a/Services/Style/Content/classes/class.ilContentStyleSettingsGUI.php
+++ b/Services/Style/Content/classes/class.ilContentStyleSettingsGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -292,13 +292,13 @@ class ilContentStyleSettingsGUI
             $def_style = $ilSetting->get("default_content_style_id");
 
             if ($def_style != $this->request->getId()) {
-                $ilSetting->set("default_content_style_id", $this->request->getId());
+                $ilSetting->set("default_content_style_id", (string) $this->request->getId());
             } else {
                 $ilSetting->delete("default_content_style_id");
             }
             $this->tpl->setOnScreenMessage('success', $lng->txt("msg_obj_modified"), true);
         }
-        ilUtil::redirect($this->ctrl->getLinkTarget($this, "edit", "", false, false));
+        ilUtil::redirect($this->ctrl->getLinkTarget($this, "edit", ""));
     }
 
     /**
@@ -317,11 +317,11 @@ class ilContentStyleSettingsGUI
             if ($fixed_style == $this->request->getId()) {
                 $ilSetting->delete("fixed_content_style_id");
             } else {
-                $ilSetting->set("fixed_content_style_id", $this->request->getId());
+                $ilSetting->set("fixed_content_style_id", (string) $this->request->getId());
             }
             $this->tpl->setOnScreenMessage('success', $lng->txt("msg_obj_modified"), true);
         }
-        ilUtil::redirect($this->ctrl->getLinkTarget($this, "edit", "", false, false));
+        ilUtil::redirect($this->ctrl->getLinkTarget($this, "edit", ""));
     }
 
     public function saveActiveStyles() : void
@@ -329,12 +329,12 @@ class ilContentStyleSettingsGUI
         $styles = $this->cs_settings->getStyles();
         foreach ($styles as $style) {
             if ($this->request->getSelectedStandard($style["id"]) == 1) {
-                ilObjStyleSheet::_writeActive((int) $style["id"], 1);
+                ilObjStyleSheet::_writeActive((int) $style["id"], true);
             } else {
-                ilObjStyleSheet::_writeActive((int) $style["id"], 0);
+                ilObjStyleSheet::_writeActive((int) $style["id"], false);
             }
         }
-        ilUtil::redirect($this->ctrl->getLinkTarget($this, "edit", "", false, false));
+        ilUtil::redirect($this->ctrl->getLinkTarget($this, "edit", ""));
     }
 
     /**
@@ -419,6 +419,6 @@ class ilContentStyleSettingsGUI
 
         $this->tpl->setOnScreenMessage('success', $this->lng->txt("msg_obj_modified"), true);
 
-        ilUtil::redirect($this->ctrl->getLinkTarget($this, "edit", "", false, false));
+        ilUtil::redirect($this->ctrl->getLinkTarget($this, "edit", ""));
     }
 }

--- a/Services/Style/Content/classes/class.ilContentStylesTableGUI.php
+++ b/Services/Style/Content/classes/class.ilContentStylesTableGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -71,7 +71,6 @@ class ilContentStylesTableGUI extends ilTable2GUI
     {
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
-        $rbacsystem = $this->rbacsystem;
 
         if ($a_set["id"] > 0) {
             $this->tpl->setCurrentBlock("cb");

--- a/Services/Style/Content/classes/class.ilObjStyleSheet.php
+++ b/Services/Style/Content/classes/class.ilObjStyleSheet.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -12,8 +12,6 @@
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  */
-
-use ILIAS\Style\Content;
 
 /**
  * Class ilObjStyleSheet
@@ -285,7 +283,7 @@ class ilObjStyleSheet extends ilObject
         );
 
     // these types are expandable, i.e. the user can define new style classes
-    public static $expandable_types = array(
+    public static array $expandable_types = array(
             "text_block",
             "text_inline", "section", "media_cont", "media_caption", "table", "table_cell", "flist_li", "table_caption",
                 "list_o", "list_u",
@@ -579,10 +577,11 @@ class ilObjStyleSheet extends ilObject
         $this->lng = $DIC->language();
         $this->type = "sty";
         $this->style = array();
+        $this->ilias = $DIC["ilias"];
+
         if ($a_call_by_reference) {
             $this->ilias->raiseError("Can't instantiate style object via reference id.", $this->ilias->error_obj->FATAL);
         }
-
         parent::__construct($a_id, false);
     }
 
@@ -798,9 +797,9 @@ class ilObjStyleSheet extends ilObject
                     $clonable = true;
                 }
             } else {
-                $obj_ids = ilObjContentObject::_lookupContObjIdByStyleId($style_rec["id"]);
+                $obj_ids = ilObjContentObject::_lookupContObjIdByStyleId((int) $style_rec["id"]);
                 if (count($obj_ids) == 0) {
-                    $obj_ids = self::lookupObjectForStyle($style_rec["id"]);
+                    $obj_ids = self::lookupObjectForStyle((int) $style_rec["id"]);
                 }
                 foreach ($obj_ids as $id) {
                     $ref = ilObject::_getAllReferences($id);
@@ -813,7 +812,7 @@ class ilObjStyleSheet extends ilObject
             }
             if ($clonable) {
                 $clonable_styles[(int) $style_rec["id"]] =
-                    ilObject::_lookupTitle($style_rec["id"]);
+                    ilObject::_lookupTitle((int) $style_rec["id"]);
             }
         }
 
@@ -990,7 +989,7 @@ class ilObjStyleSheet extends ilObject
             array("integer", "text", "text"),
             array($this->getId(), $a_char, $a_style_type)
         );
-        if ($rec = $ilDB->fetchAssoc($set)) {
+        if ($ilDB->fetchAssoc($set)) {
             return true;
         }
         return false;
@@ -1565,7 +1564,7 @@ class ilObjStyleSheet extends ilObject
         }
         fclose($css_file);
         //	exit;
-        $this->setUpToDate(true);
+        $this->setUpToDate();
         $this->_writeUpToDate($this->getId(), true);
     }
 
@@ -1958,7 +1957,7 @@ class ilObjStyleSheet extends ilObject
         $file = pathinfo($file_name);
 
         // unzip file
-        if (strtolower($file["extension"] == "zip")) {
+        if (strtolower($file["extension"]) == "zip") {
             ilFileUtils::unzip($im_dir . "/" . $file_name);
             $subdir = basename($file["basename"], "." . $file["extension"]);
             if (!is_dir($im_dir . "/" . $subdir)) {
@@ -2299,7 +2298,7 @@ class ilObjStyleSheet extends ilObject
                         );
                             
                         // if not, create style parameter
-                        if (!($rec = $ilDB->fetchAssoc($set))) {
+                        if (!($ilDB->fetchAssoc($set))) {
                             $spid = $ilDB->nextId("style_parameter");
                             $st = $ilDB->manipulateF(
                                 "INSERT INTO style_parameter (id, style_id, type, class, tag, parameter, value) " .
@@ -2979,7 +2978,7 @@ class ilObjStyleSheet extends ilObject
         $ilDB = $this->db;
         
         $tid = $ilDB->nextId("style_template");
-        $ilDB->manipulate($q = "INSERT INTO style_template " .
+        $ilDB->manipulate("INSERT INTO style_template " .
             "(id, style_id, name, temp_type)" .
             " VALUES (" .
             $ilDB->quote($tid, "integer") . "," .
@@ -2989,7 +2988,7 @@ class ilObjStyleSheet extends ilObject
             ")");
         
         foreach ($a_classes as $t => $c) {
-            $ilDB->manipulate($q = "INSERT INTO style_template_class " .
+            $ilDB->manipulate("INSERT INTO style_template_class " .
                 "(template_id, class_type, class)" .
                 " VALUES (" .
                 $ilDB->quote($tid, "integer") . "," .
@@ -3025,7 +3024,7 @@ class ilObjStyleSheet extends ilObject
             "template_id = " . $ilDB->quote($a_t_id, "integer")
         );
         foreach ($a_classes as $t => $c) {
-            $ilDB->manipulate($q = "INSERT INTO style_template_class " .
+            $ilDB->manipulate("INSERT INTO style_template_class " .
                 "(template_id, class_type, class)" .
                 " VALUES (" .
                 $ilDB->quote($a_t_id, "integer") . "," .
@@ -3042,7 +3041,7 @@ class ilObjStyleSheet extends ilObject
     ) : void {
         $ilDB = $this->db;
 
-        $ilDB->manipulate($q = "INSERT INTO style_template_class " .
+        $ilDB->manipulate("INSERT INTO style_template_class " .
             "(template_id, class_type, class)" .
             " VALUES (" .
             $ilDB->quote($a_t_id, "integer") . "," .
@@ -3062,7 +3061,7 @@ class ilObjStyleSheet extends ilObject
         $set = $ilDB->query("SELECT * FROM style_template WHERE " .
             "style_id = " . $ilDB->quote($this->getId(), "integer") . " AND " .
             "name = " . $ilDB->quote($a_template_name, "text"));
-        if ($rec = $ilDB->fetchAssoc($set)) {
+        if ($ilDB->fetchAssoc($set)) {
             return true;
         }
         return false;

--- a/Services/Style/Content/classes/class.ilObjStyleSheetGUI.php
+++ b/Services/Style/Content/classes/class.ilObjStyleSheetGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -113,7 +113,7 @@ class ilObjStyleSheetGUI extends ilObjectGUI
         
         // #9440/#9489: prepareOutput will fail if not set properly
         if (!$this->object || $cmd == "create") {
-            $this->setCreationMode(true);
+            $this->setCreationMode();
         }
 
         switch ($next_class) {
@@ -171,7 +171,6 @@ class ilObjStyleSheetGUI extends ilObjectGUI
     public function createObject() : void
     {
         $tpl = $this->gui_service->ui()->mainTemplate();
-        $ctrl = $this->gui_service->ctrl();
 
         $ilHelp = $this->help;
         
@@ -422,7 +421,7 @@ class ilObjStyleSheetGUI extends ilObjectGUI
 
         // copy from default style or ... see #11330
         $default_style = $this->settings->get("default_content_style_id");
-        if (ilObject::_lookupType($default_style) == "sty") {
+        if (ilObject::_lookupType((int) $default_style) == "sty") {
             $style_obj = ilObjectFactory::getInstanceByObjId($default_style);
             $new_id = $style_obj->ilClone();
             $newObj = new ilObjStyleSheet($new_id);
@@ -434,7 +433,7 @@ class ilObjStyleSheetGUI extends ilObjectGUI
                 ilObjStyleSheet::getBasicZipPath(),
                 "style.zip",
                 "sty",
-                $a_comp = "Services/Style",
+                "Services/Style",
                 true
             );
 
@@ -456,7 +455,7 @@ class ilObjStyleSheetGUI extends ilObjectGUI
                 $cont_style_settings->addStyle($newObj->getId());
                 $cont_style_settings->update();
 
-                ilObjStyleSheet::_writeStandard($newObj->getId(), "1");
+                ilObjStyleSheet::_writeStandard($newObj->getId(), true);
                 $ctrl->returnToParent($this);
             }
         }
@@ -468,7 +467,7 @@ class ilObjStyleSheetGUI extends ilObjectGUI
 
         $form = $this->getCloneForm();
         $form->checkInput();
-        $new_id = null;
+        $new_id = 0;
 
         if ($form->getInput("source_style") > 0) {
             $style_obj = ilObjectFactory::getInstanceByObjId($form->getInput("source_style"));
@@ -483,7 +482,7 @@ class ilObjStyleSheetGUI extends ilObjectGUI
                 $cont_style_settings = new ilContentStyleSettings();
                 $cont_style_settings->addStyle($new_id);
                 $cont_style_settings->update();
-                ilObjStyleSheet::_writeStandard($new_id, "1");
+                ilObjStyleSheet::_writeStandard($new_id, true);
                 $ctrl->returnToParent($this);
             }
         }
@@ -535,7 +534,7 @@ class ilObjStyleSheetGUI extends ilObjectGUI
                 $cont_style_settings = new ilContentStyleSettings();
                 $cont_style_settings->addStyle($newObj->getId());
                 $cont_style_settings->update();
-                ilObjStyleSheet::_writeStandard($newObj->getId(), "1");
+                ilObjStyleSheet::_writeStandard($newObj->getId(), true);
                 $this->ctrl->returnToParent($this);
             }
         }
@@ -629,7 +628,6 @@ class ilObjStyleSheetGUI extends ilObjectGUI
 
     public function setTemplatesSubTabs() : void
     {
-        $lng = $this->lng;
         $ilTabs = $this->gui_service->tabs();
         $ilCtrl = $this->ctrl;
         
@@ -1653,7 +1651,7 @@ class ilObjStyleSheetGUI extends ilObjectGUI
             $l_input = new ilNumberInputGUI($lng->txt("sty_lightness_" . $ls), "lightness_" . $ls);
             $l_input->setMaxValue(100);
             $l_input->setMinValue(-100);
-            $l_input->setValue($v);
+            $l_input->setValue((string) $v);
             $l_input->setSize(4);
             $l_input->setMaxLength(4);
             $this->form_gui->addItem($l_input);

--- a/Services/Style/Content/classes/class.ilPasteStyleCharacteristicTableGUI.php
+++ b/Services/Style/Content/classes/class.ilPasteStyleCharacteristicTableGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use ILIAS\Style\Content;
 
@@ -50,7 +50,7 @@ class ilPasteStyleCharacteristicTableGUI extends ilTable2GUI
         //$this->addMultiCommand("", $lng->txt(""));
         $this->addCommandButton("pasteCharacteristics", $lng->txt("paste"));
         $this->addCommandButton("edit", $lng->txt("cancel"));
-        $this->addHiddenInput("from_style_id", $this->from_style_id);
+        $this->addHiddenInput("from_style_id", (string) $this->from_style_id);
     }
 
     /**

--- a/Services/Style/Content/classes/class.ilStyleImportParser.php
+++ b/Services/Style/Content/classes/class.ilStyleImportParser.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use ILIAS\Style\Content;
 

--- a/Services/Style/Content/classes/class.ilStyleMediaQueryTableGUI.php
+++ b/Services/Style/Content/classes/class.ilStyleMediaQueryTableGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system

--- a/Services/Style/Content/classes/class.ilTableTemplatesTableGUI.php
+++ b/Services/Style/Content/classes/class.ilTableTemplatesTableGUI.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system

--- a/Services/Style/Content/test/ContentStyleStandardGUIRequestTest.php
+++ b/Services/Style/Content/test/ContentStyleStandardGUIRequestTest.php
@@ -1,6 +1,8 @@
-<?php
+<?php declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use ILIAS\Style\Content\StandardGUIRequest;
+use ILIAS\Data\Factory;
 
 /**
  * Test clipboard repository
@@ -9,24 +11,17 @@ use PHPUnit\Framework\TestCase;
  */
 class ContentStyleStandardGUIRequestTest extends TestCase
 {
-    //protected $backupGlobals = false;
-
-    protected function setUp() : void
-    {
-        parent::setUp();
-    }
-
     protected function tearDown() : void
     {
     }
 
-    protected function getRequest(array $get, array $post) : \ILIAS\Style\Content\StandardGUIRequest
+    protected function getRequest(array $get, array $post) : StandardGUIRequest
     {
         $http_mock = $this->createMock(ILIAS\HTTP\Services::class);
         $lng_mock = $this->createMock(ilLanguage::class);
-        $data = new \ILIAS\Data\Factory();
+        $data = new Factory();
         $refinery = new \ILIAS\Refinery\Factory($data, $lng_mock);
-        return new \ILIAS\Style\Content\StandardGUIRequest(
+        return new StandardGUIRequest(
             $http_mock,
             $refinery,
             $get,
@@ -34,7 +29,7 @@ class ContentStyleStandardGUIRequestTest extends TestCase
         );
     }
 
-    public function testRefId()
+    public function testRefId() : void
     {
         $request = $this->getRequest(
             [
@@ -50,7 +45,7 @@ class ContentStyleStandardGUIRequestTest extends TestCase
     }
 
 
-    public function testTemplateId()
+    public function testTemplateId() : void
     {
         $request = $this->getRequest(
             [
@@ -65,7 +60,7 @@ class ContentStyleStandardGUIRequestTest extends TestCase
         );
     }
 
-    public function testCharacteristics()
+    public function testCharacteristics() : void
     {
         $request = $this->getRequest(
             [

--- a/Services/Style/test/ilServicesStyleSuite.php
+++ b/Services/Style/test/ilServicesStyleSuite.php
@@ -17,7 +17,9 @@ class ilServicesStyleSuite extends TestSuite
 
         // add each test class of the component
         include_once("./Services/Style/System/test/ilServicesStyleSystemSuite.php");
+        include_once("./Services/Style/Content/test/ilServicesStyleContentSuite.php");
         $suite->addTestSuite("ilServicesStyleSystemSuite");
+        $suite->addTestSuite("ilServicesStyleContentSuite");
         return $suite;
     }
 }


### PR DESCRIPTION
# Must-Package
### What must be the agreed minimum goal from the community?  - Whether developers, operators or users.

## Goals
 * [x] ILIAS can be used with PHP 8 without producing PHP-specific errors.
 * [x] Refactored code conforms to current coding styles
 * [ ] Elimination of all warnings and errors of the static code inspection (without weak | incl. undeclared variables)
   * 1 warning; pls have a look at ilObjectContentStyleSettingsGUI line 199; Method 'objectDefinition' is undefined
   * 3 weak warnings
 * [x] Transfer of GET params into Constructor
 * [x] Avoidance/reduction of POST accesses (e.g. through $form->getInput()) and switch to Request classes
 * [x] Use of SESSION (session object, alternative assignment of static session in constructor member variables)
 * [x] Documentation of all existing typifications as typehints (of parameters, return values and properties)
 * [x] Creation of a unit test infrastructure in the component

## Requirements and analysis criteria
* [x] Preserve unit test coverage even in refactoring.
* [ ]  Simple call of all tabs/screens (without e.g. delete and move actions) and fixing of the corresponding bugs
  * problems to create a Content-Style
* [x]  Checking of external libraries
* [x]  Basis of the refactoring and the reviews is, among others, ILIAS Development Documentation.

# Should-Package
### What do we need to do in the mid-term to catch recurring large code revisions and to refactor more than the minimum?

 * [x] Expansion of the unit test coverage
  * General and structural improvements and optimisations to the code base. For example ...
   * [ ]  ... in static functions and by removing static methods
   * [x]  ... by introducing return type declarations
   * ... by typification of all variables
     * [x] Input/output typing of methods
     * [x] Typification of member variables
 * [ ]   Use of UI components from the UI framework "KitchenSink" that have been introduced and established in the meantime. Reduction of legacy UI and legacy code.

# Sustainability-Package
### he developer community has identified topics that would also improve the quality of ILIAS from the point of view of PHP and ILIAS in general. Ideally, these topics could be directly addressed in the process of systematic refactoring.

* [x] Introduction and use of declarations of "strict_types" for data
* [ ]  Replace previous arrays with classes that enable ArrayAccess - in future also getter / setter
* [ ]  Switching previous arrays to generators/data objects