### PR TITLE
Php 8: Code Review Statistics and Learning Progress

### DIFF
--- a/Services/Tracking/classes/class.ilChangeEvent.php
+++ b/Services/Tracking/classes/class.ilChangeEvent.php
@@ -105,7 +105,6 @@ class ilChangeEvent
         $a_ext_rc = null,
         $a_ext_time = null
     ) : void {
-
         global $DIC;
 
         $ilDB = $DIC['ilDB'];

--- a/Services/Tracking/classes/class.ilLPCronObjectStatistics.php
+++ b/Services/Tracking/classes/class.ilLPCronObjectStatistics.php
@@ -91,7 +91,7 @@ class ilLPCronObjectStatistics extends ilCronJob
     /**
      * gather course data
      */
-    protected function gatherCourseLPData()
+    protected function gatherCourseLPData() : int
     {
         $count = 0;
 
@@ -154,7 +154,7 @@ class ilLPCronObjectStatistics extends ilCronJob
         return $count;
     }
 
-    protected function gatherTypesData()
+    protected function gatherTypesData() : int
     {
         $count = 0;
         $data = ilTrQuery::getObjectTypeStatistics();
@@ -183,7 +183,7 @@ class ilLPCronObjectStatistics extends ilCronJob
         return $count;
     }
 
-    protected function gatherUserData()
+    protected function gatherUserData() : int
     {
         $count = 0;
         $to = mktime(23, 59, 59, date("m", $this->date), date("d", $this->date), date("Y", $this->date));

--- a/Services/Tracking/classes/class.ilLPObjSettings.php
+++ b/Services/Tracking/classes/class.ilLPObjSettings.php
@@ -274,7 +274,7 @@ class ilLPObjSettings
      * @access public
      * @param int new obj id
      */
-    public function cloneSettings($a_new_obj_id)
+    public function cloneSettings(int $a_new_obj_id) : bool
     {
         global $DIC;
 

--- a/Services/Tracking/classes/class.ilLPStatusFactory.php
+++ b/Services/Tracking/classes/class.ilLPStatusFactory.php
@@ -22,7 +22,6 @@ class ilLPStatusFactory
             self::$instance = new self();
         }
         return self::$instance;
-
     }
 
     private function __construct()
@@ -62,6 +61,7 @@ class ilLPStatusFactory
                     return self::_getClassById($a_obj_id, $mode);
                 }
             } else {
+                // PHP8-Review: Expression result is not used anywhere
                 self::includeClass($class);
                 self::$class_by_obj_id[$a_obj_id] = $class;
                 return $class;
@@ -86,6 +86,7 @@ class ilLPStatusFactory
         // id is ignored in the moment
         switch ($a_type) {
             case 'event':
+                // PHP8-Review: Expression result is not used anywhere
                 self::includeClass('ilLPStatusEvent');
                 return 'ilLPStatusEvent';
 
@@ -117,6 +118,7 @@ class ilLPStatusFactory
                     return self::_getInstance($a_obj_id, $mode);
                 }
             } else {
+                // PHP8-Review: Expression result is not used anywhere
                 self::includeClass($class);
                 return new $class($a_obj_id);
             }

--- a/Services/Tracking/classes/class.ilLPXmlWriter.php
+++ b/Services/Tracking/classes/class.ilLPXmlWriter.php
@@ -97,7 +97,7 @@ class ilLPXmlWriter extends ilXmlWriter
         $this->xmlClear();
     }
 
-    public function addLPInformation()
+    public function addLPInformation() : void
     {
         $this->xmlStartTag('LPData', array());
         $set = $this->db->query(

--- a/Services/Tracking/classes/class.ilLearningProgressBaseGUI.php
+++ b/Services/Tracking/classes/class.ilLearningProgressBaseGUI.php
@@ -276,7 +276,6 @@ class ilLearningProgressBaseGUI
 
     public function __buildHeader() : void
     {
-    
     }
 
     /**
@@ -359,13 +358,17 @@ class ilLearningProgressBaseGUI
             }
 
             if ($mode == ilLPObjSettings::LP_MODE_VISITS) {
-                $info->addProperty($this->lng->txt('trac_required_visits'),
-                    (string) ilLPObjSettings::_lookupVisits($details_id));
+                $info->addProperty(
+                    $this->lng->txt('trac_required_visits'),
+                    (string) ilLPObjSettings::_lookupVisits($details_id)
+                );
             }
 
             if ($seconds = ilMDEducational::_getTypicalLearningTimeSeconds($details_id)) {
-                $info->addProperty($this->lng->txt('meta_typical_learning_time'),
-                    ilDatePresentation::secondsToString($seconds));
+                $info->addProperty(
+                    $this->lng->txt('meta_typical_learning_time'),
+                    ilDatePresentation::secondsToString($seconds)
+                );
             }
             return true;
         }
@@ -398,7 +401,8 @@ class ilLearningProgressBaseGUI
             // status
             $i_tpl = new ilTemplate("tpl.lp_edit_manual_info_page.html", true, true, "Services/Tracking");
             $i_tpl->setVariable("INFO_EDITED", $this->lng->txt("trac_info_edited"));
-            $i_tpl->setVariable("SELECT_STATUS",
+            $i_tpl->setVariable(
+                "SELECT_STATUS",
                 ilLegacyFormElementsUtil::formSelect(
                     (int) ilLPMarks::_hasCompleted(
                         $user_id,
@@ -603,7 +607,6 @@ class ilLearningProgressBaseGUI
     {
         $form = $this->initEditUserForm($user_id, $obj_id);
         if ($form->checkInput()) {
-
             $marks = new ilLPMarks($obj_id, $user_id);
             $marks->setMark($form->getInput("mark"));
             $marks->setComment($form->getInput("comment"));

--- a/Services/Tracking/classes/class.ilObjUserTracking.php
+++ b/Services/Tracking/classes/class.ilObjUserTracking.php
@@ -153,7 +153,7 @@ class ilObjUserTracking extends ilObject
 
     public function hasExtendedData(int $a_code) : bool
     {
-        return (bool) ($this->extended_data&$a_code);
+        return (bool) ($this->extended_data & $a_code);
     }
 
     public function updateSettings()

--- a/Services/Tracking/classes/class.ilObjUserTracking.php
+++ b/Services/Tracking/classes/class.ilObjUserTracking.php
@@ -32,7 +32,7 @@ class ilObjUserTracking extends ilObject
 
     protected ilSetting $settings;
 
-    public function __construct($a_id = 0, $a_call_by_reference = true)
+    public function __construct(int $a_id = 0, bool $a_call_by_reference = true)
     {
         global $DIC;
 

--- a/Services/Tracking/classes/class.ilObjUserTrackingGUI.php
+++ b/Services/Tracking/classes/class.ilObjUserTrackingGUI.php
@@ -14,7 +14,7 @@ class ilObjUserTrackingGUI extends ilObjectGUI
     protected ilErrorHandling $error;
     protected ilObjectDefinition $objectDefinition;
 
-    public function __construct($a_data, $a_id, $a_call_by_reference)
+    public function __construct(array $a_data, int $a_id, bool $a_call_by_reference)
     {
         global $DIC;
 

--- a/Services/Tracking/classes/class.ilTrQuery.php
+++ b/Services/Tracking/classes/class.ilTrQuery.php
@@ -35,10 +35,14 @@ class ilTrQuery
                 " u_mode, type, visits, mark, u_comment" .
                 " FROM object_data" .
                 " LEFT JOIN ut_lp_settings ON (ut_lp_settings.obj_id = object_data.obj_id)" .
-                " LEFT JOIN read_event ON (read_event.obj_id = object_data.obj_id AND read_event.usr_id = " . $ilDB->quote($a_user_id,
-                    "integer") . ")" .
-                " LEFT JOIN ut_lp_marks ON (ut_lp_marks.obj_id = object_data.obj_id AND ut_lp_marks.usr_id = " . $ilDB->quote($a_user_id,
-                    "integer") . ")" .
+                " LEFT JOIN read_event ON (read_event.obj_id = object_data.obj_id AND read_event.usr_id = " . $ilDB->quote(
+                    $a_user_id,
+                    "integer"
+                ) . ")" .
+                " LEFT JOIN ut_lp_marks ON (ut_lp_marks.obj_id = object_data.obj_id AND ut_lp_marks.usr_id = " . $ilDB->quote(
+                    $a_user_id,
+                    "integer"
+                ) . ")" .
                 // " WHERE (u_mode IS NULL OR u_mode <> ".$ilDB->quote(ilLPObjSettings::LP_MODE_DEACTIVATED, "integer").")".
                 " WHERE " . $ilDB->in("object_data.obj_id", $obj_ids, false, "integer") .
                 " ORDER BY title";
@@ -87,8 +91,10 @@ class ilTrQuery
 
         $lo_lp_status = ilLOUserResults::getObjectiveStatusForLP($a_user_id, $a_obj_id, $a_objective_ids);
 
-        $query = "SELECT crs_id, crs_objectives.objective_id AS obj_id, title," . $ilDB->quote("lobj",
-                "text") . " AS type" .
+        $query = "SELECT crs_id, crs_objectives.objective_id AS obj_id, title," . $ilDB->quote(
+            "lobj",
+            "text"
+        ) . " AS type" .
             " FROM crs_objectives" .
             " WHERE " . $ilDB->in("crs_objectives.objective_id", $a_objective_ids, false, "integer") .
             " AND active = " . $ilDB->quote(1, "integer") .
@@ -248,8 +254,10 @@ class ilTrQuery
             " AND read_event.obj_id = " . $ilDB->quote($obj_id, "integer") . ")" .
             " LEFT JOIN ut_lp_marks ON (ut_lp_marks.usr_id = usr_data.usr_id " .
             " AND ut_lp_marks.obj_id = " . $ilDB->quote($obj_id, "integer") . ")" .
-            " LEFT JOIN usr_pref ON (usr_pref.usr_id = usr_data.usr_id AND keyword = " . $ilDB->quote("language",
-                "text") . ")" .
+            " LEFT JOIN usr_pref ON (usr_pref.usr_id = usr_data.usr_id AND keyword = " . $ilDB->quote(
+                "language",
+                "text"
+            ) . ")" .
             self::buildFilters($where, $a_filters);
 
         $queries = array(array("fields" => $fields, "query" => $query));
@@ -304,8 +312,12 @@ class ilTrQuery
         }
 
         if (is_array($a_udf) && count($a_udf) > 0) {
-            $query = "SELECT usr_id, field_id, value FROM udf_text WHERE " . $ilDB->in("field_id", $a_udf, false,
-                    "integer");
+            $query = "SELECT usr_id, field_id, value FROM udf_text WHERE " . $ilDB->in(
+                "field_id",
+                $a_udf,
+                false,
+                "integer"
+            );
             $set = $ilDB->query($query);
             $udf = array();
             while ($row = $ilDB->fetchAssoc($set)) {
@@ -327,8 +339,12 @@ class ilTrQuery
                 $all_public[] = $row["usr_id"];
             }
             $query = "SELECT usr_id,keyword FROM usr_pref WHERE " . $ilDB->like("keyword", "text", "public_%", false) .
-                " AND value = " . $ilDB->quote("y", "text") . " AND " . $ilDB->in("usr_id", $all_public, false,
-                    "integer");
+                " AND value = " . $ilDB->quote("y", "text") . " AND " . $ilDB->in(
+                    "usr_id",
+                    $all_public,
+                    false,
+                    "integer"
+                );
             $set = $ilDB->query($query);
             $public = array();
             while ($row = $ilDB->fetchAssoc($set)) {
@@ -474,8 +490,11 @@ class ilTrQuery
             // #15379 - objectives data
             if ($objects["objectives_parent_id"]) {
                 $objtv_ids = ilCourseObjective::_getObjectiveIds($objects["objectives_parent_id"], true);
-                foreach (self::getObjectivesStatusForUser($a_user_id, $objects["objectives_parent_id"],
-                    $objtv_ids) as $item) {
+                foreach (self::getObjectivesStatusForUser(
+                    $a_user_id,
+                    $objects["objectives_parent_id"],
+                    $objtv_ids
+                ) as $item) {
                     $result["set"][] = $item;
                     $result["cnt"]++;
                 }
@@ -530,8 +549,10 @@ class ilTrQuery
             " mark, e_comment" .
             " FROM event" .
             " JOIN event_appointment ON (event.obj_id = event_appointment.event_id)" .
-            " LEFT JOIN event_participants ON (event_participants.event_id = event.obj_id AND usr_id = " . $ilDB->quote($a_user_id,
-                "integer") . ")" .
+            " LEFT JOIN event_participants ON (event_participants.event_id = event.obj_id AND usr_id = " . $ilDB->quote(
+                $a_user_id,
+                "integer"
+            ) . ")" .
             " WHERE " . $ilDB->in("obj_id", $obj_ids, false, "integer");
         $set = $ilDB->query($query);
         $sessions = array();
@@ -643,8 +664,10 @@ class ilTrQuery
             " AND obj_id = " . $ilDB->quote($obj_id, "integer") . ")" .
             " LEFT JOIN ut_lp_marks ON (ut_lp_marks.usr_id = usr_data.usr_id " .
             " AND ut_lp_marks.obj_id = " . $ilDB->quote($obj_id, "integer") . ")" .
-            " LEFT JOIN usr_pref ON (usr_pref.usr_id = usr_data.usr_id AND keyword = " . $ilDB->quote("language",
-                "text") . ")" .
+            " LEFT JOIN usr_pref ON (usr_pref.usr_id = usr_data.usr_id AND keyword = " . $ilDB->quote(
+                "language",
+                "text"
+            ) . ")" .
             self::buildFilters($where, $a_filters, true);
 
         $fields[] = 'COUNT(usr_data.usr_id) AS user_count';
@@ -880,8 +903,10 @@ class ilTrQuery
                     case "status":
                         if ($value == ilLPStatus::LP_STATUS_NOT_ATTEMPTED_NUM) {
                             // #10645 - not_attempted is default
-                            $where[] = "(ut_lp_marks.status = " . $ilDB->quote(ilLPStatus::LP_STATUS_NOT_ATTEMPTED_NUM,
-                                    "text") .
+                            $where[] = "(ut_lp_marks.status = " . $ilDB->quote(
+                                ilLPStatus::LP_STATUS_NOT_ATTEMPTED_NUM,
+                                "text"
+                            ) .
                                 " OR ut_lp_marks.status IS NULL)";
                             break;
                         }
@@ -903,12 +928,16 @@ class ilTrQuery
                             }
                         } else {
                             if ($value["from"]) {
-                                $having[] = "ROUND(AVG(ut_lp_marks." . $id . ")) >= " . $ilDB->quote($value["from"],
-                                        "integer");
+                                $having[] = "ROUND(AVG(ut_lp_marks." . $id . ")) >= " . $ilDB->quote(
+                                    $value["from"],
+                                    "integer"
+                                );
                             }
                             if ($value["to"]) {
-                                $having[] = "ROUND(AVG(ut_lp_marks." . $id . ")) <= " . $ilDB->quote($value["to"],
-                                        "integer");
+                                $having[] = "ROUND(AVG(ut_lp_marks." . $id . ")) <= " . $ilDB->quote(
+                                    $value["to"],
+                                    "integer"
+                                );
                             }
                         }
                         break;
@@ -961,22 +990,30 @@ class ilTrQuery
                     case "read_count":
                         if (!$a_aggregate) {
                             if ($value["from"]) {
-                                $where[] = "(read_event." . $id . "+read_event.childs_" . $id . ") >= " . $ilDB->quote($value["from"],
-                                        "integer");
+                                $where[] = "(read_event." . $id . "+read_event.childs_" . $id . ") >= " . $ilDB->quote(
+                                    $value["from"],
+                                    "integer"
+                                );
                             }
                             if ($value["to"]) {
-                                $where[] = "((read_event." . $id . "+read_event.childs_" . $id . ") <= " . $ilDB->quote($value["to"],
-                                        "integer") .
+                                $where[] = "((read_event." . $id . "+read_event.childs_" . $id . ") <= " . $ilDB->quote(
+                                    $value["to"],
+                                    "integer"
+                                ) .
                                     " OR (read_event." . $id . "+read_event.childs_" . $id . ") IS NULL)";
                             }
                         } else {
                             if ($value["from"]) {
-                                $having[] = "SUM(read_event." . $id . "+read_event.childs_" . $id . ") >= " . $ilDB->quote($value["from"],
-                                        "integer");
+                                $having[] = "SUM(read_event." . $id . "+read_event.childs_" . $id . ") >= " . $ilDB->quote(
+                                    $value["from"],
+                                    "integer"
+                                );
                             }
                             if ($value["to"]) {
-                                $having[] = "SUM(read_event." . $id . "+read_event.childs_" . $id . ") <= " . $ilDB->quote($value["to"],
-                                        "integer");
+                                $having[] = "SUM(read_event." . $id . "+read_event.childs_" . $id . ") <= " . $ilDB->quote(
+                                    $value["to"],
+                                    "integer"
+                                );
                             }
                         }
                         break;
@@ -984,22 +1021,30 @@ class ilTrQuery
                     case "spent_seconds":
                         if (!$a_aggregate) {
                             if ($value["from"]) {
-                                $where[] = "(read_event." . $id . "+read_event.childs_" . $id . ") >= " . $ilDB->quote($value["from"],
-                                        "integer");
+                                $where[] = "(read_event." . $id . "+read_event.childs_" . $id . ") >= " . $ilDB->quote(
+                                    $value["from"],
+                                    "integer"
+                                );
                             }
                             if ($value["to"]) {
-                                $where[] = "((read_event." . $id . "+read_event.childs_" . $id . ") <= " . $ilDB->quote($value["to"],
-                                        "integer") .
+                                $where[] = "((read_event." . $id . "+read_event.childs_" . $id . ") <= " . $ilDB->quote(
+                                    $value["to"],
+                                    "integer"
+                                ) .
                                     " OR (read_event." . $id . "+read_event.childs_" . $id . ") IS NULL)";
                             }
                         } else {
                             if ($value["from"]) {
-                                $having[] = "ROUND(AVG(read_event." . $id . "+read_event.childs_" . $id . ")) >= " . $ilDB->quote($value["from"],
-                                        "integer");
+                                $having[] = "ROUND(AVG(read_event." . $id . "+read_event.childs_" . $id . ")) >= " . $ilDB->quote(
+                                    $value["from"],
+                                    "integer"
+                                );
                             }
                             if ($value["to"]) {
-                                $having[] = "ROUND(AVG(read_event." . $id . "+read_event.childs_" . $id . ")) <= " . $ilDB->quote($value["to"],
-                                        "integer");
+                                $having[] = "ROUND(AVG(read_event." . $id . "+read_event.childs_" . $id . ")) <= " . $ilDB->quote(
+                                    $value["to"],
+                                    "integer"
+                                );
                             }
                         }
                         break;
@@ -1119,7 +1164,6 @@ class ilTrQuery
         bool $a_refresh_status = true,
         ?array $a_user_ids = null
     ) : array {
-
         $object_ids = array($a_parent_obj_id);
         $ref_ids = array($a_parent_obj_id => $a_parent_ref_id);
         $objectives_parent_id = $scorm = $subitems = false;
@@ -1129,8 +1173,10 @@ class ilTrQuery
         switch ($mode) {
             // what about LP_MODE_SCORM_PACKAGE ?
             case ilLPObjSettings::LP_MODE_SCORM:
-                $status_scorm = get_class(ilLPStatusFactory::_getInstance($a_parent_obj_id,
-                    ilLPObjSettings::LP_MODE_SCORM));
+                $status_scorm = get_class(ilLPStatusFactory::_getInstance(
+                    $a_parent_obj_id,
+                    ilLPObjSettings::LP_MODE_SCORM
+                ));
                 $scorm = $status_scorm::_getStatusInfo($a_parent_obj_id);
                 break;
 
@@ -1342,8 +1388,10 @@ class ilTrQuery
                     " AND read_event.obj_id = " . $ilDB->quote($obj_id, "integer") . ")" .
                     " LEFT JOIN ut_lp_marks ON (ut_lp_marks.usr_id = usr_data.usr_id " .
                     " AND ut_lp_marks.obj_id = " . $ilDB->quote($obj_id, "integer") . ")" .
-                    " LEFT JOIN usr_pref ON (usr_pref.usr_id = usr_data.usr_id AND keyword = " . $ilDB->quote("language",
-                        "text") . ")" .
+                    " LEFT JOIN usr_pref ON (usr_pref.usr_id = usr_data.usr_id AND keyword = " . $ilDB->quote(
+                        "language",
+                        "text"
+                    ) . ")" .
                     self::buildFilters($where);
 
                 $raw = self::executeQueries(array(array("fields" => $fields, "query" => $query)), "login");

--- a/Services/Tracking/classes/collection/class.ilLPCollectionOfLMChapters.php
+++ b/Services/Tracking/classes/collection/class.ilLPCollectionOfLMChapters.php
@@ -10,8 +10,11 @@
 class ilLPCollectionOfLMChapters extends ilLPCollection
 {
     protected static array $possible_items = array();
-
-    public function getPossibleItems($a_ref_id)
+    
+    /**
+     * @return array|mixed
+     */
+    public function getPossibleItems(int $a_ref_id)
     {
         if (!isset(self::$possible_items[$a_ref_id])) {
             $obj_id = ilObject::_lookupObjectId($a_ref_id);
@@ -34,7 +37,10 @@ class ilLPCollectionOfLMChapters extends ilLPCollection
 
         return self::$possible_items[$a_ref_id];
     }
-
+    
+    /**
+     * @return array
+     */
     public function getTableGUIData(int $a_parent_ref_id) : array
     {
         $data = array();

--- a/Services/Tracking/classes/collection/class.ilLPCollectionOfRepositoryObjects.php
+++ b/Services/Tracking/classes/collection/class.ilLPCollectionOfRepositoryObjects.php
@@ -318,7 +318,6 @@ class ilLPCollectionOfRepositoryObjects extends ilLPCollection
             " WHERE obj_id = " . $this->db->quote($this->obj_id, "integer") .
             " AND " . $this->db->in("item_id", $all_item_ids, false, "integer");
         $this->db->manipulate($query);
-
     }
 
     public function releaseGrouping(array $a_item_ids) : void

--- a/Services/Tracking/classes/collection/class.ilLPCollectionOfSCOs.php
+++ b/Services/Tracking/classes/collection/class.ilLPCollectionOfSCOs.php
@@ -14,7 +14,6 @@ class ilLPCollectionOfSCOs extends ilLPCollection
     public function getPossibleItems() : array
     {
         if (!isset(self::$possible_items[$this->obj_id])) {
-
             $items = array();
 
             switch (ilObjSAHSLearningModule::_lookupSubType($this->obj_id)) {
@@ -110,10 +109,14 @@ class ilLPCollectionOfSCOs extends ilLPCollection
         global $DIC;
         switch (ilObjSAHSLearningModule::_lookupSubType($this->obj_id)) {
             case 'scorm':
-                $res_a = $DIC->database()->query('SELECT import_id, identifierref FROM sc_item WHERE obj_id = ' . $DIC->database()->quote($item_a_id,
-                        'integer'))->fetchAssoc();
-                $res_b = $DIC->database()->query('SELECT import_id, identifierref FROM sc_item WHERE obj_id = ' . $DIC->database()->quote($item_b_id,
-                        'integer'))->fetchAssoc();
+                $res_a = $DIC->database()->query('SELECT import_id, identifierref FROM sc_item WHERE obj_id = ' . $DIC->database()->quote(
+                    $item_a_id,
+                    'integer'
+                ))->fetchAssoc();
+                $res_b = $DIC->database()->query('SELECT import_id, identifierref FROM sc_item WHERE obj_id = ' . $DIC->database()->quote(
+                    $item_b_id,
+                    'integer'
+                ))->fetchAssoc();
                 return (
                     $res_a
                     && $res_b
@@ -121,10 +124,14 @@ class ilLPCollectionOfSCOs extends ilLPCollection
                     && ($res_a['identifierref'] == $res_b['identifierref'])
                 );
             case 'scorm2004':
-                $res_a = $DIC->database()->query('SELECT id, resourceid FROM cp_item WHERE cp_node_id = ' . $DIC->database()->quote($item_a_id,
-                        'integer'))->fetchAssoc();
-                $res_b = $DIC->database()->query('SELECT id, resourceid FROM cp_item WHERE cp_node_id = ' . $DIC->database()->quote($item_b_id,
-                        'integer'))->fetchAssoc();
+                $res_a = $DIC->database()->query('SELECT id, resourceid FROM cp_item WHERE cp_node_id = ' . $DIC->database()->quote(
+                    $item_a_id,
+                    'integer'
+                ))->fetchAssoc();
+                $res_b = $DIC->database()->query('SELECT id, resourceid FROM cp_item WHERE cp_node_id = ' . $DIC->database()->quote(
+                    $item_b_id,
+                    'integer'
+                ))->fetchAssoc();
                 return (
                     $res_a
                     && $res_b

--- a/Services/Tracking/classes/learning_history/class.ilTrackingLearningHistoryProvider.php
+++ b/Services/Tracking/classes/learning_history/class.ilTrackingLearningHistoryProvider.php
@@ -31,8 +31,11 @@ class ilTrackingLearningHistoryProvider extends ilAbstractLearningHistoryProvide
         $this->lng->loadLanguageModule("trac");
         $from = new ilDateTime($ts_start, IL_CAL_UNIX);
         $to = new ilDateTime($ts_end, IL_CAL_UNIX);
-        $completions = ilLPMarks::getCompletionsOfUser($this->getUserId(), $from->get(IL_CAL_DATETIME),
-            $to->get(IL_CAL_DATETIME));
+        $completions = ilLPMarks::getCompletionsOfUser(
+            $this->getUserId(),
+            $from->get(IL_CAL_DATETIME),
+            $to->get(IL_CAL_DATETIME)
+        );
         $entries = [];
         foreach ($completions as $c) {
             $ts = new ilDateTime($c["status_changed"], IL_CAL_DATETIME);

--- a/Services/Tracking/classes/object_statistics/class.ilLPObjectStatisticsDailyTableGUI.php
+++ b/Services/Tracking/classes/object_statistics/class.ilLPObjectStatisticsDailyTableGUI.php
@@ -139,13 +139,15 @@ class ilLPObjectStatisticsDailyTableGUI extends ilLPTableBaseGUI
         }
 
         if ($objects) {
-
             $yearmonth = explode("-", $this->filter["yearmonth"]);
             if (sizeof($yearmonth) == 1) {
                 $stat_objects = ilTrQuery::getObjectDailyStatistics($objects, $yearmonth[0]);
             } else {
-                $stat_objects = ilTrQuery::getObjectDailyStatistics($objects, (string) $yearmonth[0],
-                    (string) $yearmonth[1]);
+                $stat_objects = ilTrQuery::getObjectDailyStatistics(
+                    $objects,
+                    (string) $yearmonth[0],
+                    (string) $yearmonth[1]
+                );
             }
 
             foreach ($stat_objects as $obj_id => $hours) {

--- a/Services/Tracking/classes/object_statistics/class.ilLPObjectStatisticsLPTableGUI.php
+++ b/Services/Tracking/classes/object_statistics/class.ilLPObjectStatisticsLPTableGUI.php
@@ -246,8 +246,12 @@ class ilLPObjectStatisticsLPTableGUI extends ilLPTableBaseGUI
 
                 if ($this->is_chart) {
                     // get data for single days (used in chart display)
-                    foreach (ilTrQuery::getObjectLPStatistics($objects, $yearmonth[0], (int) $yearmonth[1],
-                        true) as $item) {
+                    foreach (ilTrQuery::getObjectLPStatistics(
+                        $objects,
+                        $yearmonth[0],
+                        (int) $yearmonth[1],
+                        true
+                    ) as $item) {
                         $this->chart_data[$item["obj_id"]][$item["dd"]] = $item;
                     }
                 }
@@ -263,7 +267,6 @@ class ilLPObjectStatisticsLPTableGUI extends ilLPTableBaseGUI
         }
 
         $this->setData($data);
-
     }
 
     protected function getDetailItems(int $a_obj_id) : void

--- a/Services/Tracking/classes/object_statistics/class.ilLPObjectStatisticsTableGUI.php
+++ b/Services/Tracking/classes/object_statistics/class.ilLPObjectStatisticsTableGUI.php
@@ -152,8 +152,11 @@ class ilLPObjectStatisticsTableGUI extends ilLPTableBaseGUI
                     }
                 }
             } else {
-                foreach (ilTrQuery::getObjectAccessStatistics($objects, (string) $yearmonth[0],
-                    (string) $yearmonth[1]) as $obj_id => $days) {
+                foreach (ilTrQuery::getObjectAccessStatistics(
+                    $objects,
+                    (string) $yearmonth[0],
+                    (string) $yearmonth[1]
+                ) as $obj_id => $days) {
                     $data[$obj_id]["obj_id"] = $obj_id;
                     $data[$obj_id]["title"] = ilObject::_lookupTitle($obj_id);
 

--- a/Services/Tracking/classes/repository_statistics/class.ilLPCollectionSettingsTableGUI.php
+++ b/Services/Tracking/classes/repository_statistics/class.ilLPCollectionSettingsTableGUI.php
@@ -25,7 +25,6 @@ class ilLPCollectionSettingsTableGUI extends ilTable2GUI
         parent::__construct($a_parent_obj, $a_parent_cmd);
 
         $this->setShowRowsSelector(false);
-
     }
 
     public function getNode() : int
@@ -62,7 +61,6 @@ class ilLPCollectionSettingsTableGUI extends ilTable2GUI
 
     protected function fillRow(array $a_set) : void
     {
-
         $this->tpl->setCurrentBlock('item_row');
         $this->tpl->setVariable('ITEM_ID', $a_set['id']);
         $this->tpl->setVariable('COLL_TITLE', $a_set['title']);
@@ -91,8 +89,10 @@ class ilLPCollectionSettingsTableGUI extends ilTable2GUI
                 $this->tpl->setVariable('COLL_FRAME', ilFrameTargetInfo::_getFrame('MainContent'));
 
                 $path = new ilPathGUI();
-                $this->tpl->setVariable('COLL_PATH',
-                    $this->lng->txt('path') . ': ' . $path->getPath($this->getNode(), $a_set['ref_id']));
+                $this->tpl->setVariable(
+                    'COLL_PATH',
+                    $this->lng->txt('path') . ': ' . $path->getPath($this->getNode(), $a_set['ref_id'])
+                );
 
                 $mode_suffix = '';
                 if (
@@ -199,7 +199,8 @@ class ilLPCollectionSettingsTableGUI extends ilTable2GUI
                     ilLegacyFormElementsUtil::formSelect($day, 'tlt[' . $a_set['id'] . '][d]', $options, false, true)
                 );
 
-                $this->tpl->setVariable("SEL_TLT",
+                $this->tpl->setVariable(
+                    "SEL_TLT",
                     ilLegacyFormElementsUtil::makeTimeSelect(
                         'tlt[' . $a_set['id'] . ']',
                         true,

--- a/Services/Tracking/classes/repository_statistics/class.ilLPListOfProgressGUI.php
+++ b/Services/Tracking/classes/repository_statistics/class.ilLPListOfProgressGUI.php
@@ -83,6 +83,7 @@ class ilLPListOfProgressGUI extends ilLearningProgressBaseGUI
         // show back to list
         $crs_id = 0;
         if ($this->http->wrapper()->query()->has('crs_id')) {
+            // PHP8-Review: Required parameter '$transformation' missing
             $crs_id = $this->http->wrapper()->query()->retrieve(
                 $this->refinery->kindlyTo()->int()
             );
@@ -136,8 +137,17 @@ class ilLPListOfProgressGUI extends ilLearningProgressBaseGUI
         if (count($obj_ids) > 0) {
             // seems obsolete
             $personal_only = !ilLearningProgressAccess::checkPermission('read_learning_progress', $this->getRefId());
-            $lp_table = new ilLPProgressTableGUI($this, "details", $this->tracked_user, $obj_ids, true,
-                $this->details_mode, $personal_only, $this->details_obj_id, $this->details_id);
+            $lp_table = new ilLPProgressTableGUI(
+                $this,
+                "details",
+                $this->tracked_user,
+                $obj_ids,
+                true,
+                $this->details_mode,
+                $personal_only,
+                $this->details_obj_id,
+                $this->details_id
+            );
             $this->tpl->setVariable("LP_OBJECTS", $lp_table->getHTML());
         }
 
@@ -151,8 +161,18 @@ class ilLPListOfProgressGUI extends ilLearningProgressBaseGUI
         // User info
         $info = new ilInfoScreenGUI($this);
         $info->setFormAction($this->ctrl->getFormAction($this));
-        $lp_table = new ilLPProgressTableGUI($this, "", $this->tracked_user, null, false, null, false, null, null,
-            $this->getMode());
+        $lp_table = new ilLPProgressTableGUI(
+            $this,
+            "",
+            $this->tracked_user,
+            null,
+            false,
+            null,
+            false,
+            null,
+            null,
+            $this->getMode()
+        );
         $this->tpl->setVariable("LP_OBJECTS", $lp_table->getHTML());
 
         $this->tpl->setVariable("LEGEND", $this->__getLegendHTML());

--- a/Services/Tracking/classes/repository_statistics/class.ilLPProgressTableGUI.php
+++ b/Services/Tracking/classes/repository_statistics/class.ilLPProgressTableGUI.php
@@ -140,8 +140,12 @@ class ilLPProgressTableGUI extends ilLPTableBaseGUI
                     $obj_ids = $this->searchObjects($this->getCurrentFilter(true), "read");
 
                     // check for LP relevance
-                    foreach (ilObjectLP::getLPMemberships($this->tracked_user->getId(), $obj_ids, null,
-                        true) as $obj_id => $status) {
+                    foreach (ilObjectLP::getLPMemberships(
+                        $this->tracked_user->getId(),
+                        $obj_ids,
+                        null,
+                        true
+                    ) as $obj_id => $status) {
                         if (!$status) {
                             unset($obj_ids[$obj_id]);
                         }
@@ -152,21 +156,30 @@ class ilLPProgressTableGUI extends ilLPTableBaseGUI
         if ($obj_ids) {
             switch ($this->mode) {
                 case ilLPObjSettings::LP_MODE_SCORM:
-                    $data = ilTrQuery::getSCOsStatusForUser($this->tracked_user->getId(), $this->parent_obj_id,
-                        $obj_ids);
+                    $data = ilTrQuery::getSCOsStatusForUser(
+                        $this->tracked_user->getId(),
+                        $this->parent_obj_id,
+                        $obj_ids
+                    );
                     break;
 
                 case ilLPObjSettings::LP_MODE_OBJECTIVES:
-                    $data = ilTrQuery::getObjectivesStatusForUser($this->tracked_user->getId(), $this->parent_obj_id,
-                        $obj_ids);
+                    $data = ilTrQuery::getObjectivesStatusForUser(
+                        $this->tracked_user->getId(),
+                        $this->parent_obj_id,
+                        $obj_ids
+                    );
                     break;
 
                 case ilLPObjSettings::LP_MODE_COLLECTION_MANUAL:
                 case ilLPObjSettings::LP_MODE_COLLECTION_TLT:
                 case ilLPObjSettings::LP_MODE_COLLECTION_MOBS:
                     if ($this->tracked_user) {
-                        $data = ilTrQuery::getSubItemsStatusForUser($this->tracked_user->getId(), $this->parent_obj_id,
-                            $obj_ids);
+                        $data = ilTrQuery::getSubItemsStatusForUser(
+                            $this->tracked_user->getId(),
+                            $this->parent_obj_id,
+                            $obj_ids
+                        );
                     }
                     break;
 
@@ -176,8 +189,10 @@ class ilLPProgressTableGUI extends ilLPTableBaseGUI
                         if (!$item["status"] && !$this->filter["status"] && !$this->details) {
                             unset($data[$idx]);
                         } else {
-                            $data[$idx]["offline"] = ilLearningProgressBaseGUI::isObjectOffline($item["obj_id"],
-                                $item["type"]);
+                            $data[$idx]["offline"] = ilLearningProgressBaseGUI::isObjectOffline(
+                                $item["obj_id"],
+                                $item["type"]
+                            );
                         }
                     }
                     break;
@@ -221,9 +236,13 @@ class ilLPProgressTableGUI extends ilLPTableBaseGUI
         } elseif ($this->has_object_subitems) {
             $this->tpl->setCurrentBlock("status_details");
 
-            $this->tpl->setVariable('STATUS_CHANGED_VAL',
-                ilDatePresentation::formatDate(new ilDateTime($a_set['status_changed'],
-                    IL_CAL_DATETIME)));
+            $this->tpl->setVariable(
+                'STATUS_CHANGED_VAL',
+                ilDatePresentation::formatDate(new ilDateTime(
+                    $a_set['status_changed'],
+                    IL_CAL_DATETIME
+                ))
+            );
 
             $olp = ilObjectLP::getInstance($a_set["obj_id"]);
             $this->tpl->setVariable("MODE_TEXT", $olp->getModeText($a_set["u_mode"]));
@@ -282,8 +301,10 @@ class ilLPProgressTableGUI extends ilLPTableBaseGUI
                     $ref_id = $a_set["ref_ids"];
                     $ref_id = array_shift($ref_id);
                     $this->ctrl->setParameterByClass($this->ctrl->getCmdClass(), 'details_id', $ref_id);
-                    $this->tpl->setVariable("HREF_COMMAND",
-                        $this->ctrl->getLinkTargetByClass($this->ctrl->getCmdClass(), 'details'));
+                    $this->tpl->setVariable(
+                        "HREF_COMMAND",
+                        $this->ctrl->getLinkTargetByClass($this->ctrl->getCmdClass(), 'details')
+                    );
                     $this->ctrl->setParameterByClass($this->ctrl->getCmdClass(), 'details_id', '');
                     $this->tpl->setVariable("TXT_COMMAND", $this->lng->txt('trac_subitems'));
                     $this->tpl->parseCurrentBlock();
@@ -349,8 +370,10 @@ class ilLPProgressTableGUI extends ilLPTableBaseGUI
         $a_csv->addColumn(ilLearningProgressBaseGUI::_getStatusText($a_set["status"]));
 
         ilDatePresentation::setUseRelativeDates(false);
-        $a_csv->addColumn(ilDatePresentation::formatDate(new ilDateTime($a_set['status_changed'],
-            IL_CAL_DATETIME)));
+        $a_csv->addColumn(ilDatePresentation::formatDate(new ilDateTime(
+            $a_set['status_changed'],
+            IL_CAL_DATETIME
+        )));
         ilDatePresentation::resetToDefaults();
 
         if (!$this->isPercentageAvailable($a_set['obj_id'])) {

--- a/Services/Tracking/classes/repository_statistics/class.ilTrMatrixTableGUI.php
+++ b/Services/Tracking/classes/repository_statistics/class.ilTrMatrixTableGUI.php
@@ -266,8 +266,14 @@ class ilTrMatrixTableGUI extends ilLPTableBaseGUI
                 }
             }
 
-            $data = ilTrQuery::getUserObjectMatrix($this->ref_id, $collection["object_ids"], $this->filter["name"],
-                $a_user_fields, $a_privary_fields, $check_agreement);
+            $data = ilTrQuery::getUserObjectMatrix(
+                $this->ref_id,
+                $collection["object_ids"],
+                $this->filter["name"],
+                $a_user_fields,
+                $a_privary_fields,
+                $check_agreement
+            );
             if ($collection["objectives_parent_id"] && $data["users"]) {
                 // sub-items: learning objectives
                 $objectives = ilTrQuery::getUserObjectiveMatrix($collection["objectives_parent_id"], $data["users"]);
@@ -409,8 +415,10 @@ class ilTrMatrixTableGUI extends ilLPTableBaseGUI
 
                     $this->tpl->setCurrentBlock("objects");
                     $this->tpl->setVariable("VAL_STATUS", $this->parseValue("status", (string) $status, ""));
-                    $this->tpl->setVariable("VAL_PERCENTAGE",
-                        $this->parseValue("percentage", (string) $percentage, ""));
+                    $this->tpl->setVariable(
+                        "VAL_PERCENTAGE",
+                        $this->parseValue("percentage", (string) $percentage, "")
+                    );
                     $this->tpl->parseCurrentBlock();
                     break;
 

--- a/Services/Tracking/classes/repository_statistics/class.ilTrObjectUsersPropsTableGUI.php
+++ b/Services/Tracking/classes/repository_statistics/class.ilTrObjectUsersPropsTableGUI.php
@@ -222,8 +222,12 @@ class ilTrObjectUsersPropsTableGUI extends ilLPTableBaseGUI
                 case "last_access":
                 case "create_date":
                 case 'status_changed':
-                    $item = $this->addFilterItemByMetaType($column, ilTable2GUI::FILTER_DATETIME_RANGE, true,
-                        $meta["txt"]);
+                    $item = $this->addFilterItemByMetaType(
+                        $column,
+                        ilTable2GUI::FILTER_DATETIME_RANGE,
+                        true,
+                        $meta["txt"]
+                    );
                     $this->filter[$column] = $item->getDate();
                     break;
 
@@ -234,8 +238,12 @@ class ilTrObjectUsersPropsTableGUI extends ilLPTableBaseGUI
 
                 case "read_count":
                 case "percentage":
-                    $item = $this->addFilterItemByMetaType($column, ilTable2GUI::FILTER_NUMBER_RANGE, true,
-                        $meta["txt"]);
+                    $item = $this->addFilterItemByMetaType(
+                        $column,
+                        ilTable2GUI::FILTER_NUMBER_RANGE,
+                        true,
+                        $meta["txt"]
+                    );
                     $this->filter[$column] = $item->getValue();
                     break;
 
@@ -251,8 +259,12 @@ class ilTrObjectUsersPropsTableGUI extends ilLPTableBaseGUI
                     break;
 
                 case "sel_country":
-                    $item = $this->addFilterItemByMetaType("sel_country", ilTable2GUI::FILTER_SELECT, true,
-                        $meta["txt"]);
+                    $item = $this->addFilterItemByMetaType(
+                        "sel_country",
+                        ilTable2GUI::FILTER_SELECT,
+                        true,
+                        $meta["txt"]
+                    );
 
                     $options = array();
                     foreach (ilCountry::getCountryCodes() as $c) {
@@ -285,8 +297,12 @@ class ilTrObjectUsersPropsTableGUI extends ilLPTableBaseGUI
 
                 case "spent_seconds":
                     if (ilObjectLP::supportsSpentSeconds($this->type)) {
-                        $item = $this->addFilterItemByMetaType("spent_seconds", ilTable2GUI::FILTER_DURATION_RANGE,
-                            true, $meta["txt"]);
+                        $item = $this->addFilterItemByMetaType(
+                            "spent_seconds",
+                            ilTable2GUI::FILTER_DURATION_RANGE,
+                            true,
+                            $meta["txt"]
+                        );
                         $this->filter["spent_seconds"]["from"] = $item->getCombinationItem("from")->getValueInSeconds();
                         $this->filter["spent_seconds"]["to"] = $item->getCombinationItem("to")->getValueInSeconds();
                     }
@@ -348,16 +364,20 @@ class ilTrObjectUsersPropsTableGUI extends ilLPTableBaseGUI
             if ($this->has_collection ||
                 $this->objDefinition->isContainer($this->type)) {
                 $this->tpl->setCurrentBlock("item_command");
-                $this->tpl->setVariable("HREF_COMMAND",
-                    $this->ctrl->getLinkTargetByClass("illplistofobjectsgui", "userdetails"));
+                $this->tpl->setVariable(
+                    "HREF_COMMAND",
+                    $this->ctrl->getLinkTargetByClass("illplistofobjectsgui", "userdetails")
+                );
                 $this->tpl->setVariable("TXT_COMMAND", $this->lng->txt('details'));
                 $this->tpl->parseCurrentBlock();
             }
 
             if ($this->has_edit) {
                 $this->tpl->setCurrentBlock("item_command");
-                $this->tpl->setVariable("HREF_COMMAND",
-                    $this->ctrl->getLinkTargetByClass("illplistofobjectsgui", "edituser"));
+                $this->tpl->setVariable(
+                    "HREF_COMMAND",
+                    $this->ctrl->getLinkTargetByClass("illplistofobjectsgui", "edituser")
+                );
                 $this->tpl->setVariable("TXT_COMMAND", $this->lng->txt('edit'));
                 $this->tpl->parseCurrentBlock();
             }

--- a/Services/Tracking/classes/repository_statistics/class.ilTrSummaryTableGUI.php
+++ b/Services/Tracking/classes/repository_statistics/class.ilTrSummaryTableGUI.php
@@ -380,8 +380,10 @@ class ilTrSummaryTableGUI extends ilLPTableBaseGUI
                 $data["set"][$idx]["title"] = $sess->getFirstAppointment()->appointmentToString();
             }
 
-            $data["set"][$idx]["offline"] = ilLearningProgressBaseGUI::isObjectOffline($result["obj_id"],
-                $result["type"]);
+            $data["set"][$idx]["offline"] = ilLearningProgressBaseGUI::isObjectOffline(
+                $result["obj_id"],
+                $result["type"]
+            );
 
             // #13807
             if ($result["ref_ids"]) {
@@ -412,8 +414,11 @@ class ilTrSummaryTableGUI extends ilLPTableBaseGUI
                 "f" => $this->lng->txt("gender_f"),
             ));
             $data["set"][$idx]["city"] = $this->getItemsPercentages($result["city"], $users_no);
-            $data["set"][$idx]["sel_country"] = $this->getItemsPercentages($result["sel_country"], $users_no,
-                $this->getSelCountryCodes());
+            $data["set"][$idx]["sel_country"] = $this->getItemsPercentages(
+                $result["sel_country"],
+                $users_no,
+                $this->getSelCountryCodes()
+            );
             $data["set"][$idx]["mark"] = $this->getItemsPercentages($result["mark"], $users_no);
             $data["set"][$idx]["language"] = $this->getItemsPercentages($result["language"], $users_no, $languages);
 
@@ -636,8 +641,10 @@ class ilTrSummaryTableGUI extends ilLPTableBaseGUI
 
                     if (!$this->anonymized) {
                         $this->ctrl->setParameterByClass($this->ctrl->getCmdClass(), 'details_id', $ref_id);
-                        $this->tpl->setVariable("URL_DETAILS",
-                            $this->ctrl->getLinkTargetByClass($this->ctrl->getCmdClass(), 'details'));
+                        $this->tpl->setVariable(
+                            "URL_DETAILS",
+                            $this->ctrl->getLinkTargetByClass($this->ctrl->getCmdClass(), 'details')
+                        );
                         $this->ctrl->setParameterByClass($this->ctrl->getCmdClass(), 'details_id', '');
                         $this->tpl->setVariable("TXT_DETAILS", $this->lng->txt('trac_participants'));
                     } else {

--- a/Services/Tracking/classes/repository_statistics/class.ilTrUserObjectsPropsTableGUI.php
+++ b/Services/Tracking/classes/repository_statistics/class.ilTrUserObjectsPropsTableGUI.php
@@ -50,8 +50,10 @@ class ilTrUserObjectsPropsTableGUI extends ilLPTableBaseGUI
 
         foreach ($this->getSelectedColumns() as $c) {
             $l = $c;
-            if (in_array($l,
-                array("last_access", "first_access", "read_count", "spent_seconds", "mark", "status", "percentage"))) {
+            if (in_array(
+                $l,
+                array("last_access", "first_access", "read_count", "spent_seconds", "mark", "status", "percentage")
+            )) {
                 $l = "trac_" . $l;
             }
             if ($l == "u_comment") {
@@ -242,8 +244,10 @@ class ilTrUserObjectsPropsTableGUI extends ilLPTableBaseGUI
                 if ($a_set[$c] != "" || $c == "status") {
                     switch ($c) {
                         case "first_access":
-                            $val = ilDatePresentation::formatDate(new ilDateTime($a_set[$c],
-                                IL_CAL_DATETIME));
+                            $val = ilDatePresentation::formatDate(new ilDateTime(
+                                $a_set[$c],
+                                IL_CAL_DATETIME
+                            ));
                             break;
 
                         case "last_access":
@@ -263,15 +267,19 @@ class ilTrUserObjectsPropsTableGUI extends ilLPTableBaseGUI
                                 $timing = $this->showTimingsWarning($a_set["ref_id"], $this->user_id);
                                 if ($timing) {
                                     if ($timing !== true) {
-                                        $timing = ": " . ilDatePresentation::formatDate(new ilDate($timing,
-                                                IL_CAL_UNIX));
+                                        $timing = ": " . ilDatePresentation::formatDate(new ilDate(
+                                            $timing,
+                                            IL_CAL_UNIX
+                                        ));
                                     } else {
                                         $timing = "";
                                     }
                                     $this->tpl->setCurrentBlock('warning_img');
                                     $this->tpl->setVariable('WARNING_IMG', ilUtil::getImagePath('time_warn.svg'));
-                                    $this->tpl->setVariable('WARNING_ALT',
-                                        $this->lng->txt('trac_time_passed') . $timing);
+                                    $this->tpl->setVariable(
+                                        'WARNING_ALT',
+                                        $this->lng->txt('trac_time_passed') . $timing
+                                    );
                                     $this->tpl->parseCurrentBlock();
                                 }
                             }
@@ -281,8 +289,10 @@ class ilTrUserObjectsPropsTableGUI extends ilLPTableBaseGUI
                             if (!ilObjectLP::supportsSpentSeconds($a_set["type"])) {
                                 $val = "-";
                             } else {
-                                $val = ilDatePresentation::secondsToString($a_set[$c],
-                                    ($a_set[$c] < 3600 ? true : false)); // #14858
+                                $val = ilDatePresentation::secondsToString(
+                                    $a_set[$c],
+                                    ($a_set[$c] < 3600 ? true : false)
+                                ); // #14858
                             }
                             break;
 
@@ -383,8 +393,10 @@ class ilTrUserObjectsPropsTableGUI extends ilLPTableBaseGUI
             if (!in_array($a_set["type"], array("sco", "lobj")) && !$this->getPrintMode()) {
                 $this->tpl->setCurrentBlock("item_command");
                 $this->ctrl->setParameterByClass("illplistofobjectsgui", "userdetails_id", $a_set["ref_id"]);
-                $this->tpl->setVariable("HREF_COMMAND",
-                    $this->ctrl->getLinkTargetByClass("illplistofobjectsgui", 'edituser'));
+                $this->tpl->setVariable(
+                    "HREF_COMMAND",
+                    $this->ctrl->getLinkTargetByClass("illplistofobjectsgui", 'edituser')
+                );
                 $this->tpl->setVariable("TXT_COMMAND", $this->lng->txt('edit'));
                 $this->ctrl->setParameterByClass("illplistofobjectsgui", "userdetails_id", "");
                 $this->tpl->parseCurrentBlock();

--- a/Services/Tracking/classes/status/class.ilLPStatusCollection.php
+++ b/Services/Tracking/classes/status/class.ilLPStatusCollection.php
@@ -27,7 +27,6 @@
  */
 class ilLPStatusCollection extends ilLPStatus
 {
-
     public static function _getNotAttempted(int $a_obj_id) : array
     {
         $users = array();

--- a/Services/Tracking/classes/status/class.ilLPStatusCollectionMobs.php
+++ b/Services/Tracking/classes/status/class.ilLPStatusCollectionMobs.php
@@ -77,10 +77,14 @@ class ilLPStatusCollectionMobs extends ilLPStatus
 
         $users = ilChangeEvent::lookupUsersInProgress($a_obj_id);
         foreach ($users as $user_id) {
-            if ((!is_array($res["user_status"]["in_progress"]) || !in_array($user_id,
-                        $res["user_status"]["in_progress"])) &&
-                (!is_array($res["user_status"]["completed"]) || !in_array($user_id,
-                        $res["user_status"]["completed"]))) {
+            if ((!is_array($res["user_status"]["in_progress"]) || !in_array(
+                $user_id,
+                $res["user_status"]["in_progress"]
+            )) &&
+                (!is_array($res["user_status"]["completed"]) || !in_array(
+                    $user_id,
+                    $res["user_status"]["completed"]
+                ))) {
                 $res["user_status"]["in_progress"][] = (int) $user_id;
             }
         }

--- a/Services/Tracking/classes/status/class.ilLPStatusExerciseReturned.php
+++ b/Services/Tracking/classes/status/class.ilLPStatusExerciseReturned.php
@@ -27,7 +27,6 @@
  */
 class ilLPStatusExerciseReturned extends ilLPStatus
 {
-
     public static function _getNotAttempted(int $a_obj_id) : array
     {
         $users = array();

--- a/Services/Tracking/classes/status/class.ilLPStatusManual.php
+++ b/Services/Tracking/classes/status/class.ilLPStatusManual.php
@@ -7,7 +7,6 @@
  */
 class ilLPStatusManual extends ilLPStatus
 {
-
     public static function _getInProgress(int $a_obj_id) : array
     {
         $users = ilChangeEvent::lookupUsersInProgress($a_obj_id);

--- a/Services/Tracking/classes/status/class.ilLPStatusObjectives.php
+++ b/Services/Tracking/classes/status/class.ilLPStatusObjectives.php
@@ -80,8 +80,10 @@ class ilLPStatusObjectives extends ilLPStatus
         if ($status_info['num_objectives']) {
             $in = $ilDB->in('objective_id', $status_info['objectives'], false, 'integer');
 
-            foreach (ilLOUserResults::getSummarizedObjectiveStatusForLP($a_obj_id,
-                $status_info['objectives']) as $user_id => $user_status) {
+            foreach (ilLOUserResults::getSummarizedObjectiveStatusForLP(
+                $a_obj_id,
+                $status_info['objectives']
+            ) as $user_id => $user_status) {
                 $status_info['user_status'][$user_status][] = $user_id;
             }
 
@@ -126,8 +128,11 @@ class ilLPStatusObjectives extends ilLPStatus
                     $objectives = ilCourseObjective::_getObjectiveIds($a_obj_id, true);
                     if ($objectives) {
                         // #14051 - getSummarizedObjectiveStatusForLP() might return null
-                        $objtv_status = ilLOUserResults::getSummarizedObjectiveStatusForLP($a_obj_id, $objectives,
-                            $a_usr_id);
+                        $objtv_status = ilLOUserResults::getSummarizedObjectiveStatusForLP(
+                            $a_obj_id,
+                            $objectives,
+                            $a_usr_id
+                        );
                         if ($objtv_status !== null) {
                             $status = $objtv_status;
                         }

--- a/Services/Tracking/classes/status/class.ilLPStatusSCORM.php
+++ b/Services/Tracking/classes/status/class.ilLPStatusSCORM.php
@@ -93,8 +93,10 @@ class ilLPStatusSCORM extends ilLPStatus
         switch ($status_info['subtype']) {
             case 'hacp':
             case 'aicc':
-                $status_info['num_completed'] = ilObjSCORMTracking::_getCountCompletedPerUser($status_info['scos'],
-                    $a_obj_id);
+                $status_info['num_completed'] = ilObjSCORMTracking::_getCountCompletedPerUser(
+                    $status_info['scos'],
+                    $a_obj_id
+                );
 
                 foreach (ilObjAICCLearningModule::_getTrackingItems($a_obj_id) as $item) {
                     if (in_array($item['obj_id'], $status_info['scos'])) {
@@ -105,8 +107,10 @@ class ilLPStatusSCORM extends ilLPStatus
                 break;
 
             case 'scorm':
-                $status_info['num_completed'] = ilObjSCORMTracking::_getCountCompletedPerUser($status_info['scos'],
-                    $a_obj_id);
+                $status_info['num_completed'] = ilObjSCORMTracking::_getCountCompletedPerUser(
+                    $status_info['scos'],
+                    $a_obj_id
+                );
 
                 foreach ($status_info['scos'] as $sco_id) {
                     $status_info['scos_title'][$sco_id] = ilSCORMItem::_lookupTitle($sco_id);
@@ -115,8 +119,11 @@ class ilLPStatusSCORM extends ilLPStatus
                 break;
 
             case "scorm2004":
-                $status_info['num_completed'] = ilSCORM2004Tracking::_getCountCompletedPerUser($status_info['scos'],
-                    $a_obj_id, true);
+                $status_info['num_completed'] = ilSCORM2004Tracking::_getCountCompletedPerUser(
+                    $status_info['scos'],
+                    $a_obj_id,
+                    true
+                );
                 foreach ($status_info['scos'] as $sco_id) {
                     $status_info['scos_title'][$sco_id] = ilObjSCORM2004LearningModule::_lookupItemTitle($sco_id);
                 }

--- a/Services/Tracking/classes/status/class.ilLPStatusTestPassed.php
+++ b/Services/Tracking/classes/status/class.ilLPStatusTestPassed.php
@@ -119,7 +119,6 @@ class ilLPStatusTestPassed extends ilLPStatus
 
         if ($rec = $this->db->fetchAssoc($res)) {
             if ($rec['sequences'] > 0) {
-
                 $test_obj = new ilObjTest($a_obj_id, false);
                 $is_passed = ilObjTestAccess::_isPassed($a_usr_id, $a_obj_id);
 

--- a/Services/Tracking/classes/status/class.ilLPStatusTypicalLearningTime.php
+++ b/Services/Tracking/classes/status/class.ilLPStatusTypicalLearningTime.php
@@ -8,7 +8,6 @@
  */
 class ilLPStatusTypicalLearningTime extends ilLPStatus
 {
-
     public static function _getInProgress(int $a_obj_id) : array
     {
         global $DIC;

--- a/Services/Tracking/test/ilServicesTrackingSuite.php
+++ b/Services/Tracking/test/ilServicesTrackingSuite.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestSuite;
 
 class ilServicesTrackingSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new ilServicesTrackingSuite();
 


### PR DESCRIPTION
Hello @smeyer-ilias,

I completed the review of the Services/Tracking component.

Results:

 

- [ ] The code style is PSR-2 + X compliant 
- [ ]  No usage of $_GET / $_POST / $_REQUEST / $_SESSION - Usage   of $_REQUEST in file class.ilLPTableBaseGUI.php (LINES 142, 143, 145, 146 and   170). Usage of $_SESSION in file class.ilLearningProgressGUI.php (lines 110,   160, 163, 169, 174 and 175). Usage of $_GET param in constructor in file   class.ilLPListOfProgressGUI.php. Usage of $_POST in file   class.ilLPListOfSettingsGUI.php.
- [ ]  There is a Unit Test Suite with at least one unit test - the folder and the suite exits, but the test is not doing anything
- [ ]  The unit tests pass
- [x]  External libraries are compatible with PHP 8 (if relevant)
- [x]  There are no serious PhpStorm Code Inspection issues left only some minor issues
- [ ]  The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties) - many Explicit Types or PHPDoc declarations are missing

- We fixed some trivial issues reported by our inspection profile.

Actions needed:

- [ ] Please add a unit test suite with at least one passing unit test
- [ ] Please eliminate the usage of super global variables.
- [ ] Please check our inline comments. Some of them might be just information, some require an action. You can use PHP8-Review when searching.
- [ ] Please make sure the code style is PSR-2 + X compliant