### PR TITLE
Review: `Services/AccessControl`

### DIFF
--- a/Modules/OrgUnit/classes/class.ilOrgUnitPositionAccess.php
+++ b/Modules/OrgUnit/classes/class.ilOrgUnitPositionAccess.php
@@ -32,7 +32,7 @@ class ilOrgUnitPositionAccess implements ilOrgUnitPositionAccessHandler, ilOrgUn
     /**
      * @inheritdoc
      */
-    public function filterUserIdsForCurrentUsersPositionsAndPermission(array $user_ids, $permission)
+    public function filterUserIdsForCurrentUsersPositionsAndPermission(array $user_ids, string $permission) : array
     {
         $current_user_id = $this->getCurrentUsersId();
 
@@ -42,7 +42,7 @@ class ilOrgUnitPositionAccess implements ilOrgUnitPositionAccessHandler, ilOrgUn
     /**
      * @inheritdoc
      */
-    public function filterUserIdsForUsersPositionsAndPermission(array $user_ids, $for_user_id, $permission)
+    public function filterUserIdsForUsersPositionsAndPermission(array $user_ids, int $for_user_id, string $permission) : array
     {
         // FSX TODO no permission is checked or existing
         $assignment_of_user = $this->ua->getAssignmentsOfUserId($for_user_id);
@@ -57,7 +57,7 @@ class ilOrgUnitPositionAccess implements ilOrgUnitPositionAccessHandler, ilOrgUn
     /**
      * @inheritdoc
      */
-    public function isCurrentUserBasedOnPositionsAllowedTo($permission, array $on_user_ids)
+    public function isCurrentUserBasedOnPositionsAllowedTo(string $permission, array $on_user_ids) : bool
     {
         $current_user_id = $this->getCurrentUsersId();
 
@@ -67,7 +67,7 @@ class ilOrgUnitPositionAccess implements ilOrgUnitPositionAccessHandler, ilOrgUn
     /**
      * @inheritdoc
      */
-    public function isUserBasedOnPositionsAllowedTo($which_user_id, $permission, array $on_user_ids)
+    public function isUserBasedOnPositionsAllowedTo(int $which_user_id, string $permission, array $on_user_ids) : bool
     {
         $filtered_user_ids = $this->filterUserIdsForUsersPositionsAndPermission($on_user_ids, $which_user_id,
             $permission);
@@ -79,7 +79,7 @@ class ilOrgUnitPositionAccess implements ilOrgUnitPositionAccessHandler, ilOrgUn
     /**
      * @inheritdoc
      */
-    public function filterUserIdsByPositionOfCurrentUser($pos_perm, $ref_id, array $user_ids)
+    public function filterUserIdsByPositionOfCurrentUser(string $pos_perm, int $ref_id, array $user_ids) : array
     {
         // If context is not activated, return same array of $user_ids
         if (!$this->set->getObjectPositionSettingsByType($this->getTypeForRefId($ref_id))->isActive()) {
@@ -94,7 +94,7 @@ class ilOrgUnitPositionAccess implements ilOrgUnitPositionAccessHandler, ilOrgUn
     /**
      * @inheritdoc
      */
-    public function filterUserIdsByPositionOfUser($user_id, $pos_perm, $ref_id, array $user_ids)
+    public function filterUserIdsByPositionOfUser(int $user_id, string $pos_perm, int $ref_id, array $user_ids) : array
     {
         // If context is not activated, return same array of $user_ids
         if (!$this->set->getObjectPositionSettingsByType($this->getTypeForRefId($ref_id))->isActive()) {
@@ -153,7 +153,7 @@ class ilOrgUnitPositionAccess implements ilOrgUnitPositionAccessHandler, ilOrgUn
     /**
      * @inheritdoc
      */
-    public function checkPositionAccess($pos_perm, $ref_id)
+    public function checkPositionAccess(string $pos_perm, int $ref_id) : bool
     {
         // If context is not activated, return same array of $user_ids
         if (!$this->isPositionActiveForRefId($ref_id)) {
@@ -179,7 +179,7 @@ class ilOrgUnitPositionAccess implements ilOrgUnitPositionAccessHandler, ilOrgUn
     /**
      * @inheritdoc
      */
-    public function hasCurrentUserAnyPositionAccess($ref_id)
+    public function hasCurrentUserAnyPositionAccess(int $ref_id) : bool
     {
         // If context is not activated, return same array of $user_ids
         if (!$this->isPositionActiveForRefId($ref_id)) {
@@ -201,7 +201,7 @@ class ilOrgUnitPositionAccess implements ilOrgUnitPositionAccessHandler, ilOrgUn
     /**
      * @inheritdoc
      */
-    public function checkRbacOrPositionPermissionAccess($rbac_perm, $pos_perm, $ref_id)
+    public function checkRbacOrPositionPermissionAccess(string $rbac_perm, string $pos_perm, int $ref_id) : bool
     {
         global $DIC;
         // If RBAC allows, just return true
@@ -220,7 +220,7 @@ class ilOrgUnitPositionAccess implements ilOrgUnitPositionAccessHandler, ilOrgUn
     /**
      * @inheritdoc
      */
-    public function filterUserIdsByRbacOrPositionOfCurrentUser($rbac_perm, $pos_perm, $ref_id, array $user_ids)
+    public function filterUserIdsByRbacOrPositionOfCurrentUser(string $rbac_perm, string $pos_perm, int $ref_id, array $user_ids) : array
     {
         global $DIC;
         // If RBAC allows, just return true
@@ -238,7 +238,7 @@ class ilOrgUnitPositionAccess implements ilOrgUnitPositionAccessHandler, ilOrgUn
     /**
      * @inheritdoc
      */
-    public function hasUserRBACorAnyPositionAccess($rbac_perm, $ref_id)
+    public function hasUserRBACorAnyPositionAccess(string $rbac_perm, int $ref_id) : bool
     {
         global $DIC;
         if ($DIC->access()->checkAccess($rbac_perm, '', $ref_id)) {

--- a/Modules/OrgUnit/interfaces/class.ilOrgUnitPositionAccessHandler.php
+++ b/Modules/OrgUnit/interfaces/class.ilOrgUnitPositionAccessHandler.php
@@ -17,7 +17,7 @@ interface ilOrgUnitPositionAccessHandler
      *                                   ilOrgUnitPositionAccessHandler
      * @see getAvailablePositionRelatedPermissions for available permissions
      */
-    public function filterUserIdsForCurrentUsersPositionsAndPermission(array $user_ids, $permission);
+    public function filterUserIdsForCurrentUsersPositionsAndPermission(array $user_ids, string $permission) : array;
 
     /**
      * @param int[]  $user_ids           List of ILIAS-User-IDs which shall be filtered
@@ -29,7 +29,7 @@ interface ilOrgUnitPositionAccessHandler
      *                                   ilOrgUnitPositionAccessHandler
      * @see getAvailablePositionRelatedPermissions for available permissions
      */
-    public function filterUserIdsForUsersPositionsAndPermission(array $user_ids, $for_user_id, $permission);
+    public function filterUserIdsForUsersPositionsAndPermission(array $user_ids, int $for_user_id, string $permission) : array;
 
     /**
      * @param string $permission
@@ -37,7 +37,7 @@ interface ilOrgUnitPositionAccessHandler
      * @return bool
      * @see getAvailablePositionRelatedPermissions for available permissions
      */
-    public function isCurrentUserBasedOnPositionsAllowedTo($permission, array $on_user_ids);
+    public function isCurrentUserBasedOnPositionsAllowedTo(string $permission, array $on_user_ids) : bool;
 
     /**
      * @param int    $which_user_id Permission check for this ILIAS-User-ID
@@ -46,7 +46,7 @@ interface ilOrgUnitPositionAccessHandler
      * @return bool
      * @see getAvailablePositionRelatedPermissions for available permissions
      */
-    public function isUserBasedOnPositionsAllowedTo($which_user_id, $permission, array $on_user_ids);
+    public function isUserBasedOnPositionsAllowedTo(int $which_user_id, string $permission, array $on_user_ids) : bool;
 
     /**
      * @param string $pos_perm
@@ -54,13 +54,13 @@ interface ilOrgUnitPositionAccessHandler
      * @return bool
      * @see getAvailablePositionRelatedPermissions for available permissions
      */
-    public function checkPositionAccess($pos_perm, $ref_id);
+    public function checkPositionAccess(string $pos_perm, int $ref_id) : bool;
 
     /**
      * @param int $ref_id
      * @return bool
      */
-    public function hasCurrentUserAnyPositionAccess($ref_id);
+    public function hasCurrentUserAnyPositionAccess(int $ref_id) : bool;
 
     /**
      * @param string $pos_perm
@@ -69,7 +69,7 @@ interface ilOrgUnitPositionAccessHandler
      * @return int[]
      * @see getAvailablePositionRelatedPermissions for available permissions
      */
-    public function filterUserIdsByPositionOfCurrentUser($pos_perm, $ref_id, array $user_ids);
+    public function filterUserIdsByPositionOfCurrentUser(string $pos_perm, int $ref_id, array $user_ids) : array;
 
     /**
      * @param int    $user_id
@@ -79,5 +79,5 @@ interface ilOrgUnitPositionAccessHandler
      * @return int[]
      * @see getAvailablePositionRelatedPermissions for available permissions
      */
-    public function filterUserIdsByPositionOfUser($user_id, $pos_perm, $ref_id, array $user_ids);
+    public function filterUserIdsByPositionOfUser(int $user_id, string $pos_perm, int $ref_id, array $user_ids) : array;
 }

--- a/Modules/OrgUnit/interfaces/class.ilOrgUnitPositionAndRBACAccessHandler.php
+++ b/Modules/OrgUnit/interfaces/class.ilOrgUnitPositionAndRBACAccessHandler.php
@@ -16,7 +16,7 @@ interface ilOrgUnitPositionAndRBACAccessHandler
      * @param int    $ref_id             Reference-ID of the desired Object in the tree
      * @return bool
      */
-    public function checkRbacOrPositionPermissionAccess($rbac_perm, $pos_perm, $ref_id);
+    public function checkRbacOrPositionPermissionAccess(string $rbac_perm, string $pos_perm, int $ref_id) : bool;
 
     /**
      * @param string $rbac_perm
@@ -27,12 +27,12 @@ interface ilOrgUnitPositionAndRBACAccessHandler
      * @param int[]  $user_ids
      * @return int[]
      */
-    public function filterUserIdsByRbacOrPositionOfCurrentUser($rbac_perm, $pos_perm, $ref_id, array $user_ids);
+    public function filterUserIdsByRbacOrPositionOfCurrentUser(string $rbac_perm, string $pos_perm, int $ref_id, array $user_ids) : array;
 
     /**
      * @param string $rbac_perm
      * @param int    $ref_id
      * @return bool
      */
-    public function hasUserRBACorAnyPositionAccess($rbac_perm, $ref_id);
+    public function hasUserRBACorAnyPositionAccess(string $rbac_perm, int $ref_id) : bool;
 }

--- a/Services/AccessControl/classes/class.ilAccess.php
+++ b/Services/AccessControl/classes/class.ilAccess.php
@@ -386,7 +386,7 @@ class ilAccess implements ilAccessHandler
         $stored_access = $this->getStoredAccessResult($a_permission, $a_cmd, $a_ref_id, $a_user_id);
 
         //var_dump($stored_access);
-        if (count($stored_access)) {
+        if ($stored_access !== []) {
             if (isset($stored_access['info']) && $stored_access['info'] instanceof ilAccessInfo) {
                 $this->current_info = $stored_access["info"];
             }
@@ -512,7 +512,7 @@ class ilAccess implements ilAccessHandler
     ) : bool {
         $path = $this->repositoryTree->getPathId($a_ref_id);
         foreach ($path as $id) {
-            if ($a_ref_id == $id) {
+            if ($a_ref_id === $id) {
                 continue;
             }
             $access = $this->checkAccessOfUser($a_user_id, "read", "info", $id);
@@ -555,7 +555,7 @@ class ilAccess implements ilAccessHandler
         }
 
         // #10852 - member view check
-        if ($a_user_id == $this->user->getId()) {
+        if ($a_user_id === $this->user->getId()) {
             // #10905 - activate parent container ONLY
             $memview = ilMemberViewSettings::getInstance();
             if ($memview->isActiveForRefId($a_ref_id) &&
@@ -599,7 +599,7 @@ class ilAccess implements ilAccessHandler
         }
 
         // if current permission is visible and visible is set in activation
-        if ($a_permission == 'visible' and $item_data['visible']) {
+        if ($a_permission == 'visible' && $item_data['visible']) {
             $this->ac_cache[$cache_perm][$a_ref_id][$a_user_id] = true;
             return true;
         }
@@ -711,7 +711,7 @@ class ilAccess implements ilAccessHandler
             $a_obj_id,
             $a_user_id
         );
-        if (!($obj_access === true)) {
+        if ($obj_access !== true) {
             //Note: We must not add an info item here, because one is going
             //      to be added by the user function we just called a few
             //      lines above.

--- a/Services/AccessControl/classes/class.ilAccess.php
+++ b/Services/AccessControl/classes/class.ilAccess.php
@@ -736,7 +736,7 @@ class ilAccess implements ilAccessHandler
     /**
      * @inheritdoc
      */
-    public function filterUserIdsForCurrentUsersPositionsAndPermission(array $user_ids, $permission)
+    public function filterUserIdsForCurrentUsersPositionsAndPermission(array $user_ids, string $permission) : array
     {
         return $this->ilOrgUnitPositionAccess->filterUserIdsForCurrentUsersPositionsAndPermission(
             $user_ids,
@@ -747,7 +747,7 @@ class ilAccess implements ilAccessHandler
     /**
      * @inheritdoc
      */
-    public function filterUserIdsForUsersPositionsAndPermission(array $user_ids, $for_user_id, $permission)
+    public function filterUserIdsForUsersPositionsAndPermission(array $user_ids, int $for_user_id, string $permission) : array
     {
         return $this->ilOrgUnitPositionAccess->filterUserIdsForUsersPositionsAndPermission(
             $user_ids,
@@ -759,7 +759,7 @@ class ilAccess implements ilAccessHandler
     /**
      * @inheritdoc
      */
-    public function isCurrentUserBasedOnPositionsAllowedTo($permission, array $on_user_ids)
+    public function isCurrentUserBasedOnPositionsAllowedTo(string $permission, array $on_user_ids) : bool
     {
         return $this->ilOrgUnitPositionAccess->isCurrentUserBasedOnPositionsAllowedTo($permission, $on_user_ids);
     }
@@ -767,7 +767,7 @@ class ilAccess implements ilAccessHandler
     /**
      * @inheritdoc
      */
-    public function isUserBasedOnPositionsAllowedTo($which_user_id, $permission, array $on_user_ids)
+    public function isUserBasedOnPositionsAllowedTo(int $which_user_id, string $permission, array $on_user_ids) : bool
     {
         return $this->ilOrgUnitPositionAccess->isUserBasedOnPositionsAllowedTo(
             $which_user_id,
@@ -779,7 +779,7 @@ class ilAccess implements ilAccessHandler
     /**
      * @inheritdoc
      */
-    public function checkPositionAccess($pos_perm, $ref_id)
+    public function checkPositionAccess(string $pos_perm, int $ref_id) : bool
     {
         return $this->ilOrgUnitPositionAccess->checkPositionAccess($pos_perm, $ref_id);
     }
@@ -787,7 +787,7 @@ class ilAccess implements ilAccessHandler
     /**
      * @inheritdoc
      */
-    public function checkRbacOrPositionPermissionAccess($rbac_perm, $pos_perm, $ref_id)
+    public function checkRbacOrPositionPermissionAccess(string $rbac_perm, string $pos_perm, int $ref_id) : bool
     {
         return $this->ilOrgUnitPositionAccess->checkRbacOrPositionPermissionAccess($rbac_perm, $pos_perm, $ref_id);
     }
@@ -795,7 +795,7 @@ class ilAccess implements ilAccessHandler
     /**
      * @inheritdoc
      */
-    public function filterUserIdsByPositionOfCurrentUser($pos_perm, $ref_id, array $user_ids)
+    public function filterUserIdsByPositionOfCurrentUser(string $pos_perm, int $ref_id, array $user_ids) : array
     {
         return $this->ilOrgUnitPositionAccess->filterUserIdsByPositionOfCurrentUser($pos_perm, $ref_id, $user_ids);
     }
@@ -803,7 +803,7 @@ class ilAccess implements ilAccessHandler
     /**
      * @inheritdoc
      */
-    public function filterUserIdsByPositionOfUser($user_id, $pos_perm, $ref_id, array $user_ids)
+    public function filterUserIdsByPositionOfUser(int $user_id, string $pos_perm, int $ref_id, array $user_ids) : array
     {
         return $this->ilOrgUnitPositionAccess->filterUserIdsByPositionOfUser($user_id, $pos_perm, $ref_id, $user_ids);
     }
@@ -811,7 +811,7 @@ class ilAccess implements ilAccessHandler
     /**
      * @inheritdoc
      */
-    public function filterUserIdsByRbacOrPositionOfCurrentUser($rbac_perm, $pos_perm, $ref_id, array $user_ids)
+    public function filterUserIdsByRbacOrPositionOfCurrentUser(string $rbac_perm, string $pos_perm, int $ref_id, array $user_ids) : array
     {
         return $this->ilOrgUnitPositionAccess->filterUserIdsByRbacOrPositionOfCurrentUser(
             $rbac_perm,
@@ -824,7 +824,7 @@ class ilAccess implements ilAccessHandler
     /**
      * @inheritdoc
      */
-    public function hasCurrentUserAnyPositionAccess($ref_id)
+    public function hasCurrentUserAnyPositionAccess(int $ref_id) : bool
     {
         return $this->ilOrgUnitPositionAccess->hasCurrentUserAnyPositionAccess($ref_id);
     }
@@ -832,7 +832,7 @@ class ilAccess implements ilAccessHandler
     /**
      * @inheritdoc
      */
-    public function hasUserRBACorAnyPositionAccess($rbac_perm, $ref_id)
+    public function hasUserRBACorAnyPositionAccess(string $rbac_perm, int $ref_id) : bool
     {
         return $this->ilOrgUnitPositionAccess->hasUserRBACorAnyPositionAccess($rbac_perm, $ref_id);
     }

--- a/Services/AccessControl/classes/class.ilAccess.php
+++ b/Services/AccessControl/classes/class.ilAccess.php
@@ -197,7 +197,7 @@ class ilAccess implements ilAccessHandler
     /**
      * @inheritdoc
      */
-    public function setResults(array $a_results)
+    public function setResults(array $a_results) : void
     {
         $this->results = $a_results;
     }

--- a/Services/AccessControl/classes/class.ilAccess.php
+++ b/Services/AccessControl/classes/class.ilAccess.php
@@ -1,7 +1,21 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 /**
  * Class ilAccessHandler
  * Checks access for ILIAS objects
@@ -678,6 +692,7 @@ class ilAccess implements ilAccessHandler
 
         // use autoloader for standard objects
         if ($this->objDefinition->isPluginTypeName($a_type)) {
+            /** @noRector */
             include_once($location . "/class." . $full_class . ".php");
         }
 

--- a/Services/AccessControl/classes/class.ilAccessControlExporter.php
+++ b/Services/AccessControl/classes/class.ilAccessControlExporter.php
@@ -40,16 +40,10 @@ class ilAccessControlExporter extends ilXmlExporter
 
     /**
      * Get xml
-     * @param string $a_entity
-     * @param string $a_schema_version
-     * @param string $a_id
-     * @return string
      */
     public function getXmlRepresentation(string $a_entity, string $a_schema_version, string $a_id) : string
     {
         global $DIC;
-
-        $rbacreview = $DIC['rbacreview'];
 
         $writer = new ilRoleXmlExport();
 
@@ -66,7 +60,6 @@ class ilAccessControlExporter extends ilXmlExporter
      * Returns schema versions that the component can export to.
      * ILIAS chooses the first one, that has min/max constraints which
      * fit to the target release. Please put the newest on top.
-     * @return array
      */
     public function getValidSchemaVersions(string $a_entity) : array
     {

--- a/Services/AccessControl/classes/class.ilAccessControlExporter.php
+++ b/Services/AccessControl/classes/class.ilAccessControlExporter.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 /**
  * Role Exporter
  * @author  Stefan Meyer <meyer@leifos.com>

--- a/Services/AccessControl/classes/class.ilAccessControlImporter.php
+++ b/Services/AccessControl/classes/class.ilAccessControlImporter.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 /**
  * role role template xml importer
  * @author  Stefan Meyer <meyer@leifos.com>

--- a/Services/AccessControl/classes/class.ilAccessControlImporter.php
+++ b/Services/AccessControl/classes/class.ilAccessControlImporter.php
@@ -29,7 +29,6 @@ class ilAccessControlImporter extends ilXmlImporter
     /**
      * Import XML
      * @param
-     * @return void
      */
     public function importXmlRepresentation(
         string $a_entity,

--- a/Services/AccessControl/classes/class.ilAccessInfo.php
+++ b/Services/AccessControl/classes/class.ilAccessInfo.php
@@ -1,26 +1,20 @@
 <?php declare(strict_types=1);
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 /**
  * class ilAccessInfo
  * @author  Alex Killing <alex.killing@gmx.de>

--- a/Services/AccessControl/classes/class.ilAccessPermissionsStatusTableGUI.php
+++ b/Services/AccessControl/classes/class.ilAccessPermissionsStatusTableGUI.php
@@ -1,6 +1,22 @@
 <?php declare(strict_types=1);
 
 /**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
+/**
  * Table for Acces Permissons in Permission > Permission of User
  * @author  Fabian Wolf <wolf@leifos.com>
  * @ingroup ServicesAccessControl

--- a/Services/AccessControl/classes/class.ilAssignedUsersTableGUI.php
+++ b/Services/AccessControl/classes/class.ilAssignedUsersTableGUI.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 /**
  * TableGUI class for role administration
  * @author  Stefan Meyer <smeyer.ilias@gmx.de>

--- a/Services/AccessControl/classes/class.ilAssignedUsersTableGUI.php
+++ b/Services/AccessControl/classes/class.ilAssignedUsersTableGUI.php
@@ -122,8 +122,13 @@ class ilAssignedUsersTableGUI extends ilTable2GUI
         $link_contact = ilMailFormCall::getLinkTarget(
             $this->getParentObject(),
             $this->getParentCmd(),
-            array('fr' => rawurlencode(base64_encode($this->ctrl->getLinkTarget($this->getParentObject(),
-                'userassignment', '', false, false)))
+            array('fr' => rawurlencode(base64_encode($this->ctrl->getLinkTarget(
+                $this->getParentObject(),
+                'userassignment',
+                '',
+                false,
+                false
+            )))
             ),
             array('type' => 'new', 'rcp_to' => $a_set['login'])
         );

--- a/Services/AccessControl/classes/class.ilAssignedUsersTableGUI.php
+++ b/Services/AccessControl/classes/class.ilAssignedUsersTableGUI.php
@@ -83,8 +83,8 @@ class ilAssignedUsersTableGUI extends ilTable2GUI
         $usr_data = ilUserQuery::getUserListData(
             ilUtil::stripSlashes($this->getOrderField()),
             ilUtil::stripSlashes($this->getOrderDirection()),
-            ilUtil::stripSlashes($this->getOffset()),
-            ilUtil::stripSlashes($this->getLimit()),
+            $this->getOffset(),
+            $this->getLimit(),
             '',
             '',
             null,
@@ -93,8 +93,8 @@ class ilAssignedUsersTableGUI extends ilTable2GUI
             0,
             $this->getRoleId()
         );
-        $this->setMaxCount($usr_data["cnt"]);
-        $this->setData($usr_data["set"]);
+        $this->setMaxCount((int) $usr_data["cnt"]);
+        $this->setData((array) $usr_data["set"]);
     }
 
     /**

--- a/Services/AccessControl/classes/class.ilAvailableRolesStatusTableGUI.php
+++ b/Services/AccessControl/classes/class.ilAvailableRolesStatusTableGUI.php
@@ -1,6 +1,22 @@
 <?php declare(strict_types=1);
 
 /**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
+/**
  * Table for Available Roles in Permission > Permission of User
  * @author  Fabian Wolf <wolf@leifos.com>
  * @ingroup ServicesAccessControl

--- a/Services/AccessControl/classes/class.ilAvailableRolesStatusTableGUI.php
+++ b/Services/AccessControl/classes/class.ilAvailableRolesStatusTableGUI.php
@@ -26,7 +26,7 @@ class ilAvailableRolesStatusTableGUI extends ilTable2GUI
     /**
      * Constructor
      */
-    public function __construct($a_parent_obj, $a_parent_cmd)
+    public function __construct(?object $a_parent_obj, string $a_parent_cmd)
     {
         $this->setId('available_roles' . $a_parent_obj->user->getId());
         parent::__construct($a_parent_obj, $a_parent_cmd);

--- a/Services/AccessControl/classes/class.ilAvailableRolesStatusTableGUI.php
+++ b/Services/AccessControl/classes/class.ilAvailableRolesStatusTableGUI.php
@@ -21,8 +21,11 @@ class ilAvailableRolesStatusTableGUI extends ilTable2GUI
 
         $this->addColumn("", "status", "5%");
         $this->addColumn($this->lng->txt("role"), "role", "32%");
-        $this->addColumn(str_replace(" ", "&nbsp;", $this->lng->txt("info_permission_source")), "effective_from",
-            "32%");
+        $this->addColumn(
+            str_replace(" ", "&nbsp;", $this->lng->txt("info_permission_source")),
+            "effective_from",
+            "32%"
+        );
         $this->addColumn(str_replace(" ", "&nbsp;", $this->lng->txt("info_permission_origin")), "original_position");
     }
 

--- a/Services/AccessControl/classes/class.ilClaimingPermissionHelper.php
+++ b/Services/AccessControl/classes/class.ilClaimingPermissionHelper.php
@@ -3,16 +3,19 @@
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
-
+ *
+ *********************************************************************/
+ 
 /**
  * Claiming permission helper base class
  *

--- a/Services/AccessControl/classes/class.ilClaimingPermissionHelper.php
+++ b/Services/AccessControl/classes/class.ilClaimingPermissionHelper.php
@@ -134,8 +134,6 @@ abstract class ilClaimingPermissionHelper
      * Get context ids for context type (uses cache)
      *
      * @see self::readContextIds()
-     * @param int $a_context_type
-     * @return array
      */
     protected function getValidContextIds(int $a_context_type) : array
     {
@@ -224,7 +222,7 @@ abstract class ilClaimingPermissionHelper
         $valid = true;
         
         if (!is_array($this->plugins)) {
-            $this->plugins = (array) $this->getActivePlugins();
+            $this->plugins = $this->getActivePlugins();
         }
         
         foreach ($this->plugins as $plugin) {
@@ -248,7 +246,7 @@ abstract class ilClaimingPermissionHelper
         $adv_md_types = $obj_def->getAdvancedMetaDataTypes();
 
         $valid_accepted_types = array();
-        foreach ($adv_md_types as $idx => $value) {
+        foreach ($adv_md_types as $value) {
             if (in_array($value['obj_type'], $accepted_types) || in_array($value['sub_type'], $accepted_types)) {
                 array_push($valid_accepted_types, $value['obj_type']);
             }

--- a/Services/AccessControl/classes/class.ilObjRole.php
+++ b/Services/AccessControl/classes/class.ilObjRole.php
@@ -45,7 +45,7 @@ class ilObjRole extends ilObject
      * @param int    reference_id or object_id
      * @param bool    treat the id as reference_id (true) or object_id (false)
      */
-    public function __construct($a_id = 0, $a_call_by_reference = false)
+    public function __construct(int $a_id = 0, bool $a_call_by_reference = false)
     {
         global $DIC;
 

--- a/Services/AccessControl/classes/class.ilObjRole.php
+++ b/Services/AccessControl/classes/class.ilObjRole.php
@@ -1,7 +1,21 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 /**
  * Class ilObjRole
  * @author     Stefan Meyer <meyer@leifos.com>

--- a/Services/AccessControl/classes/class.ilObjRole.php
+++ b/Services/AccessControl/classes/class.ilObjRole.php
@@ -309,7 +309,7 @@ class ilObjRole extends ilObject
             }
 
             // users with last role found?
-            if (count($last_role_user_ids) > 0) {
+            if ($last_role_user_ids !== []) {
                 $user_names = array();
                 foreach ($last_role_user_ids as $user_id) {
                     // GET OBJECT TITLE
@@ -573,11 +573,11 @@ class ilObjRole extends ilObject
 
         $local_policies = array();
         foreach ($a_policies as $policy) {
-            if ($policy == $a_start or $policy == SYSTEM_FOLDER_ID) {
+            if ($policy == $a_start || $policy == SYSTEM_FOLDER_ID) {
                 $local_policies[] = $policy;
                 continue;
             }
-            if (!in_array('all', $a_filter) and !in_array(
+            if (!in_array('all', $a_filter) && !in_array(
                 ilObject::_lookupType(ilObject::_lookupObjId($policy)),
                 $a_filter
             )) {
@@ -605,7 +605,7 @@ class ilObjRole extends ilObject
         $node_stack = array();
 
         $start_node = current($a_nodes);
-        array_push($node_stack, $start_node);
+        $node_stack[] = $start_node;
         $this->updatePolicyStack($policy_stack, $start_node['child']);
 
         if ($a_operation_mode == self::MODE_READ_OPERATIONS) {
@@ -674,11 +674,11 @@ class ilObjRole extends ilObject
             }
 
             // Node has local policies => update permission stack and continue
-            if (in_array($node['child'], $a_policies) and ($node['child'] != SYSTEM_FOLDER_ID)) {
+            if (in_array($node['child'], $a_policies) && $node['child'] != SYSTEM_FOLDER_ID) {
                 $local_policy = true;
                 $this->updatePolicyStack($policy_stack, $node['child']);
                 $this->updateOperationStack($operation_stack, $node['child']);
-                array_push($node_stack, $node);
+                $node_stack[] = $node;
                 continue;
             }
 
@@ -702,7 +702,7 @@ class ilObjRole extends ilObject
                 $this->createPermissionIntersection($policy_stack, $perms[$node['type']], $node['child'], $node['type']);
                 if ($this->updateOperationStack($operation_stack, $node['child'])) {
                     $this->updatePolicyStack($policy_stack, $node['child']);
-                    array_push($node_stack, $node);
+                    $node_stack[] = $node;
                 }
             }
 
@@ -915,7 +915,7 @@ class ilObjRole extends ilObject
             );
         } else {
         }
-        if ($a_id and !$GLOBALS['DIC']['rbacreview']->isRoleAssignedToObject($this->getId(), $a_id)) {
+        if ($a_id && !$GLOBALS['DIC']['rbacreview']->isRoleAssignedToObject($this->getId(), $a_id)) {
             $this->rbac_admin->assignRoleToFolder($this->getId(), $a_id, "n");
         }
     }

--- a/Services/AccessControl/classes/class.ilObjRole.php
+++ b/Services/AccessControl/classes/class.ilObjRole.php
@@ -524,10 +524,7 @@ class ilObjRole extends ilObject
 
     /**
      * Change existing objects
-     * @param int $a_start_node
-     * @param int $a_mode
      * @param array filter Filter of object types (array('all') => change all objects
-     * @return void
      */
     public function changeExistingObjects(
         int $a_start_node,
@@ -572,8 +569,6 @@ class ilObjRole extends ilObject
     protected function deleteLocalPolicies(int $a_start, array $a_policies, array $a_filter) : array
     {
         global $DIC;
-
-        $rbacreview = $DIC['rbacreview'];
         $rbacadmin = $DIC['rbacadmin'];
 
         $local_policies = array();
@@ -792,9 +787,6 @@ class ilObjRole extends ilObject
 
     /**
      * Update operation stack
-     * @param array $a_stack
-     * @param int   $a_node
-     * @return bool
      */
     protected function updateOperationStack(
         array &$a_stack,
@@ -802,7 +794,6 @@ class ilObjRole extends ilObject
         bool $a_init = false
     ) : bool {
         $has_policies = null;
-        $policy_origin = null;
 
         if ($a_node == ROOT_FOLDER_ID) {
             $has_policies = true;
@@ -837,7 +828,6 @@ class ilObjRole extends ilObject
     protected function updatePolicyStack(array &$a_stack, int $a_node) : bool
     {
         $has_policies = null;
-        $policy_origin = null;
 
         if ($a_node == ROOT_FOLDER_ID) {
             $has_policies = true;
@@ -912,8 +902,6 @@ class ilObjRole extends ilObject
                 $template_id = $course_non_member_id;
                 break;
         }
-
-        $current_ops = $a_current_ops[$a_type];
 
         // Create intersection template permissions
         if ($template_id) {

--- a/Services/AccessControl/classes/class.ilObjRoleFolder.php
+++ b/Services/AccessControl/classes/class.ilObjRoleFolder.php
@@ -51,7 +51,7 @@ class ilObjRoleFolder extends ilObject
             return false;
         }
         // put here rolefolder specific stuff
-        $roles = $this->rbacreview->getRolesOfRoleFolder($this->getRefId());
+        $roles = $this->rbac_review->getRolesOfRoleFolder($this->getRefId());
         foreach ($roles as $role_id) {
             $roleObj = ilObjectFactory::getInstanceByObjId($role_id);
             $roleObj->setParent($this->getRefId());

--- a/Services/AccessControl/classes/class.ilObjRoleFolder.php
+++ b/Services/AccessControl/classes/class.ilObjRoleFolder.php
@@ -1,26 +1,20 @@
 <?php declare(strict_types=1);
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 /**
  * Class ilObjRoleFolder
  * @author     Stefan Meyer <meyer@leifos.com>

--- a/Services/AccessControl/classes/class.ilObjRoleFolder.php
+++ b/Services/AccessControl/classes/class.ilObjRoleFolder.php
@@ -63,7 +63,6 @@ class ilObjRoleFolder extends ilObject
         global $DIC;
 
         $rbacadmin = $DIC['rbacadmin'];
-        $rbacreview = $DIC['rbacreview'];
 
         $roleObj = new ilObjRole();
         $roleObj->setTitle($a_title);

--- a/Services/AccessControl/classes/class.ilObjRoleFolder.php
+++ b/Services/AccessControl/classes/class.ilObjRoleFolder.php
@@ -86,5 +86,4 @@ class ilObjRoleFolder extends ilObject
 
         return $roleObj;
     }
-
 }

--- a/Services/AccessControl/classes/class.ilObjRoleFolder.php
+++ b/Services/AccessControl/classes/class.ilObjRoleFolder.php
@@ -22,7 +22,7 @@
  */
 class ilObjRoleFolder extends ilObject
 {
-    public function __construct($a_id = 0, $a_call_by_reference = true)
+    public function __construct(int $a_id = 0, bool $a_call_by_reference = true)
     {
         $this->type = "rolf";
         parent::__construct($a_id, $a_call_by_reference);

--- a/Services/AccessControl/classes/class.ilObjRoleFolderAccess.php
+++ b/Services/AccessControl/classes/class.ilObjRoleFolderAccess.php
@@ -1,26 +1,20 @@
 <?php declare(strict_types=1);
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 /**
  * Class ilObjRootFolderAccess
  * @author     Alex Killing <alex.killing@gmx.de>

--- a/Services/AccessControl/classes/class.ilObjRoleFolderGUI.php
+++ b/Services/AccessControl/classes/class.ilObjRoleFolderGUI.php
@@ -1,26 +1,20 @@
 <?php declare(strict_types=1);
 
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2006 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 use ILIAS\HTTP\GlobalHttpState;
 use ILIAS\Refinery\Factory;

--- a/Services/AccessControl/classes/class.ilObjRoleFolderGUI.php
+++ b/Services/AccessControl/classes/class.ilObjRoleFolderGUI.php
@@ -398,7 +398,7 @@ class ilObjRoleFolderGUI extends ilObjectGUI
         if ($form->checkInput()) {
             $adjustment_type = $form->getInput('type');
             foreach ((array) $roles as $role_id) {
-                if ($role_id != $source) {
+                if ($role_id !== $source) {
                     $start_obj = $this->rbac_review->getRoleFolderOfRole($role_id);
                     $this->logger->debug('Start object: ' . $start_obj);
 
@@ -484,7 +484,7 @@ class ilObjRoleFolderGUI extends ilObjectGUI
         $form = $this->initCopyBehaviourForm();
         if ($form->checkInput()) {
             foreach ((array) $roles as $role_id) {
-                if ($role_id != $source) {
+                if ($role_id !== $source) {
                     $this->doRemoveRolePermissions($source, $role_id);
                 }
             }
@@ -596,7 +596,7 @@ class ilObjRoleFolderGUI extends ilObjectGUI
     protected function confirmDeleteObject() : void
     {
         $roles = $this->initRolesFromPOST();
-        if (!count($roles)) {
+        if ($roles === []) {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('select_one'), true);
             $this->ctrl->redirect($this, 'view');
         }
@@ -688,7 +688,7 @@ class ilObjRoleFolderGUI extends ilObjectGUI
 
     public function editSettingsObject(ilPropertyFormGUI $a_form = null) : void
     {
-        if (!$a_form) {
+        if ($a_form === null) {
             $a_form = $this->initSettingsForm();
         }
 

--- a/Services/AccessControl/classes/class.ilObjRoleFolderGUI.php
+++ b/Services/AccessControl/classes/class.ilObjRoleFolderGUI.php
@@ -260,7 +260,7 @@ class ilObjRoleFolderGUI extends ilObjectGUI
      */
     protected function chooseCopyBehaviourObject(?ilPropertyFormGUI $form = null) : void
     {
-        $copy_source = $this->initCopySourceFromGET();
+        $this->initCopySourceFromGET();
 
         $this->ctrl->saveParameter($this, 'csource');
         $this->tabs_gui->clearTargets();
@@ -744,7 +744,7 @@ class ilObjRoleFolderGUI extends ilObjectGUI
         $admin = new ilCheckboxInputGUI($GLOBALS['DIC']['lng']->txt('adm_adm_role_protect'), 'admin_role');
         $admin->setDisabled(!$this->rbac_review->isAssigned($user->getId(), SYSTEM_ROLE_ID));
         $admin->setInfo($this->lng->txt('adm_adm_role_protect_info'));
-        $admin->setChecked((bool) $security->isAdminRoleProtected());
+        $admin->setChecked($security->isAdminRoleProtected());
         $admin->setValue((string) 1);
         $form->addItem($admin);
 
@@ -786,7 +786,7 @@ class ilObjRoleFolderGUI extends ilObjectGUI
                 $privacy = ilPrivacySettings::getInstance();
 
                 $subitems = null;
-                if ((bool) $privacy->enabledRbacLog()) {
+                if ($privacy->enabledRbacLog()) {
                     $subitems = array('rbac_log_age' => $privacy->getRbacLogAge());
                 }
                 $fields = array('rbac_log' => array($privacy->enabledRbacLog(),

--- a/Services/AccessControl/classes/class.ilObjRoleFolderGUI.php
+++ b/Services/AccessControl/classes/class.ilObjRoleFolderGUI.php
@@ -43,7 +43,7 @@ class ilObjRoleFolderGUI extends ilObjectGUI
      * Constructor
      * @access    public
      */
-    public function __construct($a_data, $a_id, $a_call_by_reference)
+    public function __construct($a_data, int $a_id, bool $a_call_by_reference)
     {
         global $DIC;
 

--- a/Services/AccessControl/classes/class.ilObjRoleGUI.php
+++ b/Services/AccessControl/classes/class.ilObjRoleGUI.php
@@ -24,7 +24,7 @@ class ilObjRoleGUI extends ilObjectGUI
     protected int $obj_obj_id = 0;
     protected string $obj_obj_type = '';
     protected string $container_type = '';
-    protected $role_id = 0;
+    protected int $role_id = 0;
     protected ilRbacAdmin $rbacadmin;
     protected ilHelpGUI $help;
     private ilLogger $logger;
@@ -1264,11 +1264,11 @@ class ilObjRoleGUI extends ilObjectGUI
         }
     }
 
-    /*
+    /**
      * Ensure access to role for ref_id
      * @throws ilObjectException
      */
-    protected function ensureRoleAccessForContext()
+    protected function ensureRoleAccessForContext() : bool
     {
         // creation of roles
         if (
@@ -1296,4 +1296,4 @@ class ilObjRoleGUI extends ilObjectGUI
         }
         return true;
     }
-} // END class.ilObjRoleGUI
+}

--- a/Services/AccessControl/classes/class.ilObjRoleGUI.php
+++ b/Services/AccessControl/classes/class.ilObjRoleGUI.php
@@ -24,23 +24,19 @@ class ilObjRoleGUI extends ilObjectGUI
     protected int $obj_obj_id = 0;
     protected string $obj_obj_type = '';
     protected string $container_type = '';
-
     protected $role_id = 0;
-
     protected ilRbacAdmin $rbacadmin;
     protected ilHelpGUI $help;
-
     private ilLogger $logger;
-
     private GlobalHttpState $http;
     protected Factory $refinery;
-
-    /**
-     * Constructor
-     * @access public
-     */
-    public function __construct($a_data, $a_id, $a_call_by_reference = false, $a_prepare_output = true)
-    {
+    
+    public function __construct(
+        $a_data,
+        int $a_id,
+        bool $a_call_by_reference = false,
+        bool $a_prepare_output = true
+    ) {
         global $DIC;
 
         $this->rbacadmin = $DIC->rbac()->admin();
@@ -202,7 +198,7 @@ class ilObjRoleGUI extends ilObjectGUI
      */
     protected function showDefaultPermissionSettings() : bool
     {
-        return $this->objDefinition->isContainer($this->getContainerType());
+        return $this->obj_definition->isContainer($this->getContainerType());
     }
 
     protected function initFormRoleProperties(int $a_mode) : ilPropertyFormGUI

--- a/Services/AccessControl/classes/class.ilObjRoleGUI.php
+++ b/Services/AccessControl/classes/class.ilObjRoleGUI.php
@@ -517,7 +517,7 @@ class ilObjRoleGUI extends ilObjectGUI
         $this->permSaveObject(true);
     }
 
-    protected function adoptPermObject()
+    protected function adoptPermObject() : void
     {
         $output = array();
         $parent_role_ids = $this->rbac_review->getParentRoleIds($this->obj_ref_id, true);

--- a/Services/AccessControl/classes/class.ilObjRoleGUI.php
+++ b/Services/AccessControl/classes/class.ilObjRoleGUI.php
@@ -649,8 +649,7 @@ class ilObjRoleGUI extends ilObjectGUI
         }
         if (
             $this->obj_ref_id == ROLE_FOLDER_ID ||
-            $this->rbac_review->isAssignable($this->object->getId(), $this->obj_ref_id))
-        {
+            $this->rbac_review->isAssignable($this->object->getId(), $this->obj_ref_id)) {
             $this->rbacadmin->setProtected($this->obj_ref_id, $this->object->getId(), ilUtil::tf2yn($protected));
         }
         $recursive = false;

--- a/Services/AccessControl/classes/class.ilObjRoleGUI.php
+++ b/Services/AccessControl/classes/class.ilObjRoleGUI.php
@@ -1,7 +1,21 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 use ILIAS\HTTP\GlobalHttpState;
 use ILIAS\Refinery\Factory;
 

--- a/Services/AccessControl/classes/class.ilObjRoleGUI.php
+++ b/Services/AccessControl/classes/class.ilObjRoleGUI.php
@@ -521,7 +521,7 @@ class ilObjRoleGUI extends ilObjectGUI
         $output = array();
         $parent_role_ids = $this->rbac_review->getParentRoleIds($this->obj_ref_id, true);
         $ids = array();
-        foreach ($parent_role_ids as $id => $tmp) {
+        foreach (array_keys($parent_role_ids) as $id) {
             $ids[] = $id;
         }
         // Sort ids
@@ -628,7 +628,7 @@ class ilObjRoleGUI extends ilObjectGUI
             $subs = ilObjRole::getSubObjects($this->getParentType(), $a_show_admin_permissions);
         }
 
-        foreach ($subs as $subtype => $def) {
+        foreach (array_keys($subs) as $subtype) {
             // Delete per object type
             $this->rbacadmin->deleteRolePermission($this->object->getId(), $this->obj_ref_id, $subtype);
         }
@@ -790,7 +790,7 @@ class ilObjRoleGUI extends ilObjectGUI
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('err_role_not_assignable'), true);
             return;
         }
-        if (!$a_user_ids) {
+        if ($a_user_ids === []) {
             $GLOBALS['DIC']['lng']->loadLanguageModule('search');
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('search_err_user_not_exist'), true);
             return;
@@ -845,7 +845,7 @@ class ilObjRoleGUI extends ilObjectGUI
                 )
             );
         }
-        if (!count($selected_users)) {
+        if (count($selected_users) === 0) {
             $this->ilias->raiseError($this->lng->txt("no_checkbox"), $this->ilias->error_obj->MESSAGE);
         }
 
@@ -863,10 +863,10 @@ class ilObjRoleGUI extends ilObjectGUI
             $assigned_roles = $this->rbac_review->assignedRoles($user);
             $assigned_global_roles = array_intersect($assigned_roles, $global_roles);
 
-            if (count($assigned_roles) == 1 or (count($assigned_global_roles) == 1 and in_array(
+            if (count($assigned_roles) == 1 || count($assigned_global_roles) == 1 && in_array(
                 $this->object->getId(),
                 $assigned_global_roles
-            ))) {
+            )) {
                 $userObj = $this->ilias->obj_factory->getInstanceByObjId($user);
                 $last_role[$user] = $userObj->getFullName();
                 unset($userObj);
@@ -884,7 +884,7 @@ class ilObjRoleGUI extends ilObjectGUI
         $this->object->update();
 
         // raise error if last role was taken from a user...
-        if (count($last_role)) {
+        if ($last_role !== []) {
             $user_list = implode(", ", $last_role);
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('msg_is_last_role') . ': ' . $user_list . '<br />' . $this->lng->txt('msg_min_one_role'), true);
         } else {
@@ -1236,7 +1236,7 @@ class ilObjRoleGUI extends ilObjectGUI
                 )
             );
         }
-        if (!count($users)) {
+        if (count($users) === 0) {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('select_one'), true);
             $this->ctrl->redirect($this, 'userassignment');
         }

--- a/Services/AccessControl/classes/class.ilObjRoleGUI.php
+++ b/Services/AccessControl/classes/class.ilObjRoleGUI.php
@@ -290,7 +290,6 @@ class ilObjRoleGUI extends ilObjectGUI
     /**
      * Store form input in role object
      * @param object $role
-     * @return void
      */
     protected function loadRoleProperties(ilObjRole $role, ilPropertyFormGUI $form) : void
     {
@@ -592,7 +591,7 @@ class ilObjRoleGUI extends ilObjectGUI
             $this->error->raiseError($this->lng->txt('msg_no_perm_perm'), $this->error->WARNING);
         }
 
-        $this->object->setParent((int) $this->obj_ref_id);
+        $this->object->setParent($this->obj_ref_id);
         $this->object->delete();
         $this->tpl->setOnScreenMessage('success', $this->lng->txt('msg_deleted_role'), true);
 
@@ -779,7 +778,6 @@ class ilObjRoleGUI extends ilObjectGUI
 
     /**
      * @param int[]
-     * @return void
      */
     public function addUserObject(array $a_user_ids) : void
     {
@@ -1104,7 +1102,6 @@ class ilObjRoleGUI extends ilObjectGUI
 
     /**
      * Check if a confirmation about further settings is required or not
-     * @return bool
      */
     protected function isChangeExistingObjectsConfirmationRequired() : bool
     {
@@ -1122,9 +1119,7 @@ class ilObjRoleGUI extends ilObjectGUI
 
     /**
      * Show confirmation screen
-     * @param bool     $recursive
      * @param string[] $recursive_list
-     * @return void
      */
     protected function showChangeExistingObjectsConfirmation(bool $recursive, array $recursive_list) : void
     {

--- a/Services/AccessControl/classes/class.ilObjRoleTemplate.php
+++ b/Services/AccessControl/classes/class.ilObjRoleTemplate.php
@@ -53,9 +53,9 @@ class ilObjRoleTemplate extends ilObject
         return false;
     }
 
-    public function getFilterOfInternalTemplate()
+    public function getFilterOfInternalTemplate() : array
     {
-        $filter = array();
+        $filter = [];
         switch ($this->getTitle()) {
             case "il_grp_admin":
             case "il_grp_member":
@@ -86,4 +86,4 @@ class ilObjRoleTemplate extends ilObject
 
         return $filter;
     }
-} // END class.ilObjRoleTemplate
+}

--- a/Services/AccessControl/classes/class.ilObjRoleTemplate.php
+++ b/Services/AccessControl/classes/class.ilObjRoleTemplate.php
@@ -1,26 +1,20 @@
 <?php declare(strict_types=1);
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 /**
  * Class ilObjRoleTemplate
  * @author     Stefan Meyer <meyer@leifos.com>

--- a/Services/AccessControl/classes/class.ilObjRoleTemplate.php
+++ b/Services/AccessControl/classes/class.ilObjRoleTemplate.php
@@ -22,7 +22,7 @@
  */
 class ilObjRoleTemplate extends ilObject
 {
-    public function __construct($a_id = 0, $a_call_by_reference = false)
+    public function __construct(int $a_id = 0, bool $a_call_by_reference = false)
     {
         $this->type = "rolt";
         parent::__construct($a_id, $a_call_by_reference);

--- a/Services/AccessControl/classes/class.ilObjRoleTemplateGUI.php
+++ b/Services/AccessControl/classes/class.ilObjRoleTemplateGUI.php
@@ -38,7 +38,7 @@ class ilObjRoleTemplateGUI extends ilObjectGUI
     private GlobalHttpState $http;
     protected Factory $refinery;
 
-    public function __construct($a_data, $a_id, $a_call_by_reference)
+    public function __construct($a_data, int $a_id, bool $a_call_by_reference)
     {
         global $DIC;
 

--- a/Services/AccessControl/classes/class.ilObjRoleTemplateGUI.php
+++ b/Services/AccessControl/classes/class.ilObjRoleTemplateGUI.php
@@ -1,9 +1,23 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 use ILIAS\HTTP\GlobalHttpState;
 use ILIAS\Refinery\Factory;
-
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 /**
  * Class ilObjRoleTemplateGUI

--- a/Services/AccessControl/classes/class.ilObjRoleTemplateGUI.php
+++ b/Services/AccessControl/classes/class.ilObjRoleTemplateGUI.php
@@ -134,7 +134,7 @@ class ilObjRoleTemplateGUI extends ilObjectGUI
         if (!$this->rbac_system->checkAccess("create_rolt", $this->rolf_ref_id)) {
             $this->error->raiseError($this->lng->txt("permission_denied"), $this->error->MESSAGE);
         }
-        if (!$form) {
+        if ($form === null) {
             $form = $this->initFormRoleTemplate(self::FORM_MODE_CREATE);
         }
         $this->tpl->setContent($form->getHTML());
@@ -151,7 +151,7 @@ class ilObjRoleTemplateGUI extends ilObjectGUI
             $this->error->raiseError($this->lng->txt("msg_no_perm_write"), $this->error->MESSAGE);
         }
 
-        if (!$form) {
+        if ($form === null) {
             $form = $this->initFormRoleTemplate(self::FORM_MODE_EDIT);
         }
         $this->tpl->setContent($form->getHTML());
@@ -293,7 +293,7 @@ class ilObjRoleTemplateGUI extends ilObjectGUI
         //$rbacadmin->deleteRolePermission($this->object->getId(), $this->ref_id);
         $subs = ilObjRole::getSubObjects('root', false);
 
-        foreach ($subs as $subtype => $def) {
+        foreach (array_keys($subs) as $subtype) {
             // Delete per object type
             $this->rbac_admin->deleteRolePermission($this->object->getId(), $this->ref_id, $subtype);
         }

--- a/Services/AccessControl/classes/class.ilObjectPermissionStatusGUI.php
+++ b/Services/AccessControl/classes/class.ilObjectPermissionStatusGUI.php
@@ -12,11 +12,9 @@
 class ilObjectPermissionStatusGUI
 {
     public ilObjUser $user;
-    protected $lng;
-    protected $ctrl;
-
+    protected ilLanguage $lng;
+    protected ilCtrlInterface $ctrl;
     protected ilGlobalTemplateInterface $tpl;
-
     protected ilObject $object;
     protected ilRbacReview $rbacreview;
     protected ilToolbarGUI $toolbar;
@@ -324,9 +322,8 @@ class ilObjectPermissionStatusGUI
 
     /**
      * Access Permissions Table Data
-     * @return array
      */
-    public function getAccessPermissionTableData()
+    public function getAccessPermissionTableData() : array
     {
         global $DIC;
 

--- a/Services/AccessControl/classes/class.ilObjectPermissionStatusGUI.php
+++ b/Services/AccessControl/classes/class.ilObjectPermissionStatusGUI.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 /**
  * This class displays the permission status of a user concerning a specific object.
  * ("Permissions" -> "Permission of User")

--- a/Services/AccessControl/classes/class.ilObjectPermissionStatusGUI.php
+++ b/Services/AccessControl/classes/class.ilObjectPermissionStatusGUI.php
@@ -212,7 +212,7 @@ class ilObjectPermissionStatusGUI
 
         $cmds = call_user_func(array($full_class, "_getCommands"));
 
-        array_push($cmds, array('permission' => 'visible', 'cmd' => 'info'));
+        $cmds[] = array('permission' => 'visible', 'cmd' => 'info');
 
         return $cmds;
     }
@@ -285,7 +285,7 @@ class ilObjectPermissionStatusGUI
         $cmds = $this->getCommands($this->object->getType());
 
         foreach ($cmds as $cmd) {
-            if (!count($cmd)) {
+            if (count($cmd) === 0) {
                 continue;
             }
             $ilAccess->clear();
@@ -304,7 +304,7 @@ class ilObjectPermissionStatusGUI
         $okay = "il_ItemOkayProperty";
         $text = "";
 
-        if (!$infos) {
+        if ($infos === []) {
             $text = "<span class=\"" . $okay . "\">" . $this->lng->txt("access") . "</span><br/> ";
         } else {
             foreach ($infos as $info) {

--- a/Services/AccessControl/classes/class.ilObjectPermissionStatusGUI.php
+++ b/Services/AccessControl/classes/class.ilObjectPermissionStatusGUI.php
@@ -165,7 +165,6 @@ class ilObjectPermissionStatusGUI
 
     /**
      * get Assigned Valid Roles
-     * @return array
      */
     public function getAssignedValidRoles() : array
     {
@@ -220,7 +219,6 @@ class ilObjectPermissionStatusGUI
 
     /**
      * ilUser
-     * @return ilObjUser
      */
     public function getUser() : ilObjUser
     {
@@ -413,7 +411,6 @@ class ilObjectPermissionStatusGUI
 
     /**
      * Available Roles Table Data
-     * @return array
      */
     public function getAvailableRolesTableData() : array
     {

--- a/Services/AccessControl/classes/class.ilObjectRolePermissionTableGUI.php
+++ b/Services/AccessControl/classes/class.ilObjectRolePermissionTableGUI.php
@@ -30,7 +30,6 @@ class ilObjectRolePermissionTableGUI extends ilTable2GUI
     public const ROLE_FILTER_LOCAL_OBJECT = 5;
 
     private int $ref_id;
-    private array $roles = [];
     private array $tree_path_ids = [];
     private array $activeOperations = [];
     private array $visible_roles = [];
@@ -77,7 +76,7 @@ class ilObjectRolePermissionTableGUI extends ilTable2GUI
      */
     public function getPathIds() : array
     {
-        return (array) $this->tree_path_ids;
+        return $this->tree_path_ids;
     }
 
     /**
@@ -208,7 +207,7 @@ class ilObjectRolePermissionTableGUI extends ilTable2GUI
 
         // block role
         if (isset($a_set['show_block_row'])) {
-            foreach ($this->getVisibleRoles() as $counter => $role_info) {
+            foreach ($this->getVisibleRoles() as $role_info) {
                 $this->tpl->setCurrentBlock('role_block');
                 $this->tpl->setVariable('BLOCK_ROLE_ID', $role_info['obj_id']);
                 $this->tpl->setVariable('TXT_BLOCK', $this->lng->txt('role_block_role'));
@@ -349,7 +348,7 @@ class ilObjectRolePermissionTableGUI extends ilTable2GUI
         if (ilPermissionGUI::hasContainerCommands($this->getObjType())) {
             $roles = array();
             $local_roles = $this->review->getRolesOfObject($this->getRefId());
-            foreach ($this->getVisibleRoles() as $role_id => $role_data) {
+            foreach ($this->getVisibleRoles() as $role_data) {
                 $roles[$role_data['obj_id']] = array(
                     'blocked' => $role_data['blocked'],
                     'protected' => $role_data['protected'],
@@ -366,7 +365,7 @@ class ilObjectRolePermissionTableGUI extends ilTable2GUI
         // Protect permissions
         if (ilPermissionGUI::hasContainerCommands($this->getObjType())) {
             $roles = array();
-            foreach ($this->getVisibleRoles() as $role_id => $role_data) {
+            foreach ($this->getVisibleRoles() as $role_data) {
                 $roles[$role_data['obj_id']] = array(
                     'blocked' => $role_data['blocked'],
                     'protected_allowed' => $this->review->isAssignable($role_data['obj_id'], $this->getRefId()),
@@ -493,7 +492,6 @@ class ilObjectRolePermissionTableGUI extends ilTable2GUI
             $column_width = 100 / count($possible_roles);
             $column_width .= '%';
         } else {
-            $column_widht = "0%";
         }
 
         $all_roles = array();
@@ -564,7 +562,7 @@ class ilObjectRolePermissionTableGUI extends ilTable2GUI
             $this->tree->getPathId($this->getRefId())
         );
 
-        $reduced_path_hierarchy = (array) array_diff(
+        $reduced_path_hierarchy = array_diff(
             $path_hierarchy,
             array(
                 $this->getRefId(),

--- a/Services/AccessControl/classes/class.ilObjectRolePermissionTableGUI.php
+++ b/Services/AccessControl/classes/class.ilObjectRolePermissionTableGUI.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 /**
  * Table for object role permissions
  * @author  Stefan Meyer <meyer@leifos.com>

--- a/Services/AccessControl/classes/class.ilObjectRolePermissionTableGUI.php
+++ b/Services/AccessControl/classes/class.ilObjectRolePermissionTableGUI.php
@@ -165,8 +165,10 @@ class ilObjectRolePermissionTableGUI extends ilTable2GUI
                 $this->tpl->setCurrentBlock('role_option');
                 $this->tpl->setVariable('INHERIT_ROLE_ID', $role_id);
                 $this->tpl->setVariable('INHERIT_CHECKED', $role_info['local_policy'] ? 'checked=checked' : '');
-                $this->tpl->setVariable('INHERIT_DISABLED',
-                    ($role_info['protected'] or $role_info['isLocal'] or $role_info['blocked']) ? 'disabled="disabled"' : '');
+                $this->tpl->setVariable(
+                    'INHERIT_DISABLED',
+                    ($role_info['protected'] or $role_info['isLocal'] or $role_info['blocked']) ? 'disabled="disabled"' : ''
+                );
                 $this->tpl->setVariable('TXT_INHERIT', $this->lng->txt('rbac_local_policy'));
                 $this->tpl->setVariable('INHERIT_LONG', $this->lng->txt('perm_use_local_policy_desc'));
                 $this->tpl->parseCurrentBlock();
@@ -179,8 +181,10 @@ class ilObjectRolePermissionTableGUI extends ilTable2GUI
                 $this->tpl->setCurrentBlock('role_protect');
                 $this->tpl->setVariable('PROTECT_ROLE_ID', $role_id);
                 $this->tpl->setVariable('PROTECT_CHECKED', $role_info['protected_status'] ? 'checked=checked' : '');
-                $this->tpl->setVariable('PROTECT_DISABLED',
-                    $role_info['protected_allowed'] ? '' : 'disabled="disabled"');
+                $this->tpl->setVariable(
+                    'PROTECT_DISABLED',
+                    $role_info['protected_allowed'] ? '' : 'disabled="disabled"'
+                );
                 $this->tpl->setVariable('TXT_PROTECT', $this->lng->txt('role_protect_permissions'));
                 $this->tpl->setVariable('PROTECT_LONG', $this->lng->txt('role_protect_permissions_desc'));
                 $this->tpl->parseCurrentBlock();
@@ -284,8 +288,10 @@ class ilObjectRolePermissionTableGUI extends ilTable2GUI
             } elseif (substr($a_set['perm']['operation'], 0, 6) == 'create') {
                 $this->tpl->setVariable('PERM_LONG', $this->lng->txt('rbac_' . $a_set['perm']['operation']));
             } else {
-                $this->tpl->setVariable('PERM_LONG',
-                    $this->lng->txt($this->getObjType() . '_' . $a_set['perm']['operation']));
+                $this->tpl->setVariable(
+                    'PERM_LONG',
+                    $this->lng->txt($this->getObjType() . '_' . $a_set['perm']['operation'])
+                );
             }
 
             if ($role_info['protected'] || $role_info['blocked']) {
@@ -317,8 +323,10 @@ class ilObjectRolePermissionTableGUI extends ilTable2GUI
         // Read operations of role
         $operations = array();
         foreach ($this->getVisibleRoles() as $role_data) {
-            $operations[$role_data['obj_id']] = $this->review->getActiveOperationsOfRole($this->getRefId(),
-                $role_data['obj_id']);
+            $operations[$role_data['obj_id']] = $this->review->getActiveOperationsOfRole(
+                $this->getRefId(),
+                $role_data['obj_id']
+            );
         }
 
         $counter = 0;
@@ -557,8 +565,11 @@ class ilObjectRolePermissionTableGUI extends ilTable2GUI
             $parent = end($reduced_path_hierarchy);
             $p_type = ilObject::_lookupType(ilObject::_lookupObjId($parent));
             $p_title = ilObject::_lookupTitle(ilObject::_lookupObjId($parent));
-            $tp .= sprintf($this->lng->txt('perm_role_path_info_inheritance'), $this->lng->txt('obj_' . $p_type),
-                $p_title);
+            $tp .= sprintf(
+                $this->lng->txt('perm_role_path_info_inheritance'),
+                $this->lng->txt('obj_' . $p_type),
+                $p_title
+            );
         }
 
         return $tp;
@@ -588,7 +599,9 @@ class ilObjectRolePermissionTableGUI extends ilTable2GUI
         }
         $this->ctrl->setParameterByClass('ilobjrolegui', 'obj_id', $role['obj_id']);
 
-        return '<a class="tblheader" href="' . $this->ctrl->getLinkTargetByClass('ilobjrolegui',
-                '') . '" >' . $role_title . '</a>';
+        return '<a class="tblheader" href="' . $this->ctrl->getLinkTargetByClass(
+            'ilobjrolegui',
+            ''
+        ) . '" >' . $role_title . '</a>';
     }
 }

--- a/Services/AccessControl/classes/class.ilObjectRolePermissionTableGUI.php
+++ b/Services/AccessControl/classes/class.ilObjectRolePermissionTableGUI.php
@@ -149,8 +149,7 @@ class ilObjectRolePermissionTableGUI extends ilTable2GUI
 
         // Limit filter to local roles only for objects with group or course in path
         if (!$roles->getValue()) {
-            if ($tree->checkForParentType($this->getRefId(), 'crs') or
-                $tree->checkForParentType($this->getRefId(), 'grp')) {
+            if ($tree->checkForParentType($this->getRefId(), 'crs') || $tree->checkForParentType($this->getRefId(), 'grp')) {
                 $roles->setValue(self::ROLE_FILTER_LOCAL);
             } else {
                 $roles->setValue(self::ROLE_FILTER_ALL);
@@ -180,7 +179,7 @@ class ilObjectRolePermissionTableGUI extends ilTable2GUI
                 $this->tpl->setVariable('INHERIT_CHECKED', $role_info['local_policy'] ? 'checked=checked' : '');
                 $this->tpl->setVariable(
                     'INHERIT_DISABLED',
-                    ($role_info['protected'] or $role_info['isLocal'] or $role_info['blocked']) ? 'disabled="disabled"' : ''
+                    ($role_info['protected'] || $role_info['isLocal'] || $role_info['blocked']) ? 'disabled="disabled"' : ''
                 );
                 $this->tpl->setVariable('TXT_INHERIT', $this->lng->txt('rbac_local_policy'));
                 $this->tpl->setVariable('INHERIT_LONG', $this->lng->txt('perm_use_local_policy_desc'));
@@ -217,7 +216,7 @@ class ilObjectRolePermissionTableGUI extends ilTable2GUI
                 }
                 if (
                     ($role_info['protected'] == 'y') ||
-                    ($role_info['assign'] == 'y' and ($role_info['parent'] == $this->getRefId()))
+                    ($role_info['assign'] == 'y' && $role_info['parent'] == $this->getRefId())
                 ) {
                     $this->tpl->setVariable('BLOCK_DISABLED', 'disabled="disabled');
                 }
@@ -328,7 +327,7 @@ class ilObjectRolePermissionTableGUI extends ilTable2GUI
         $perms = array();
         $roles = array();
 
-        if (!count($this->getVisibleRoles())) {
+        if ($this->getVisibleRoles() === []) {
             $this->setData(array());
             return;
         }
@@ -414,7 +413,7 @@ class ilObjectRolePermissionTableGUI extends ilTable2GUI
         /*
          * Select all
          */
-        if ($no_creation_operations) {
+        if ($no_creation_operations !== []) {
             $perms[$counter]['show_select_all'] = 1;
             $perms[$counter]['ops'] = $no_creation_operations;
             $perms[$counter]['subtype'] = 'nocreation';
@@ -459,7 +458,7 @@ class ilObjectRolePermissionTableGUI extends ilTable2GUI
         }
 
         // Select all
-        if (count($creation_operations)) {
+        if ($creation_operations !== []) {
             $perms[$counter]['show_select_all'] = 1;
             $perms[$counter]['ops'] = $creation_operations;
             $perms[$counter]['subtype'] = 'creation';
@@ -488,7 +487,7 @@ class ilObjectRolePermissionTableGUI extends ilTable2GUI
             $possible_roles[] = $role;
         }
 
-        if (count($possible_roles)) {
+        if ($possible_roles !== []) {
             $column_width = 100 / count($possible_roles);
             $column_width .= '%';
         } else {
@@ -534,8 +533,7 @@ class ilObjectRolePermissionTableGUI extends ilTable2GUI
 
         // Show create at info
         if (
-            ($role['assign'] == 'y' and $role['role_type'] != 'global') or
-            ($role['assign'] == 'n' and $role['role_type'] != 'global')
+            $role['assign'] == 'y' && $role['role_type'] != 'global' || $role['assign'] == 'n' && $role['role_type'] != 'global'
         ) {
             $tp .= ': ';
 
@@ -571,7 +569,7 @@ class ilObjectRolePermissionTableGUI extends ilTable2GUI
         );
 
         // Inheritance
-        if ($role['assign'] == 'n' and count($reduced_path_hierarchy)) {
+        if ($role['assign'] == 'n' && count($reduced_path_hierarchy)) {
             $tp .= $inheritance_seperator;
 
             $parent = end($reduced_path_hierarchy);

--- a/Services/AccessControl/classes/class.ilObjectRoleTemplateOptionsTableGUI.php
+++ b/Services/AccessControl/classes/class.ilObjectRoleTemplateOptionsTableGUI.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 /**
  * Table for object role permissions
  * @author  Stefan Meyer <meyer@leifos.com>

--- a/Services/AccessControl/classes/class.ilObjectRoleTemplateOptionsTableGUI.php
+++ b/Services/AccessControl/classes/class.ilObjectRoleTemplateOptionsTableGUI.php
@@ -100,7 +100,7 @@ class ilObjectRoleTemplateOptionsTableGUI extends ilTable2GUI
         if (!$this->getShowOptions()) {
             return;
         }
-        if (isset($a_set['recursive']) and !$this->show_admin_permissions) {
+        if (isset($a_set['recursive']) && !$this->show_admin_permissions) {
             $this->tpl->setCurrentBlock('recursive');
             $this->tpl->setVariable('TXT_RECURSIVE', $this->lng->txt('change_existing_objects'));
             $this->tpl->setVariable('DESC_RECURSIVE', $this->lng->txt('change_existing_objects_desc'));

--- a/Services/AccessControl/classes/class.ilObjectRoleTemplatePermissionTableGUI.php
+++ b/Services/AccessControl/classes/class.ilObjectRoleTemplatePermissionTableGUI.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 /**
  * Table for object role permissions
  * @author  Stefan Meyer <meyer@leifos.com>

--- a/Services/AccessControl/classes/class.ilObjectRoleTemplatePermissionTableGUI.php
+++ b/Services/AccessControl/classes/class.ilObjectRoleTemplatePermissionTableGUI.php
@@ -231,7 +231,7 @@ class ilObjectRoleTemplatePermissionTableGUI extends ilTable2GUI
             $operation = $this->review->getOperation($ops_id);
 
             $perm['ops_id'] = $ops_id;
-            $perm['set'] = (in_array($ops_id, $operations) or $this->getRoleId() == SYSTEM_ROLE_ID);
+            $perm['set'] = (in_array($ops_id, $operations) || $this->getRoleId() == SYSTEM_ROLE_ID);
             $perm['name'] = $operation['operation'];
 
             $rows[] = $perm;
@@ -249,7 +249,7 @@ class ilObjectRoleTemplatePermissionTableGUI extends ilTable2GUI
             }
 
             $perm['ops_id'] = $ops_id;
-            $perm['set'] = (in_array($ops_id, $operations) or $this->getRoleId() == SYSTEM_ROLE_ID);
+            $perm['set'] = (in_array($ops_id, $operations) || $this->getRoleId() == SYSTEM_ROLE_ID);
 
             $perm['name'] = 'create_' . $info['name'];
             $perm['create_type'] = $info['name'];

--- a/Services/AccessControl/classes/class.ilPermission2GUI.php
+++ b/Services/AccessControl/classes/class.ilPermission2GUI.php
@@ -1,7 +1,21 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 use ILIAS\HTTP\GlobalHttpState;
 use ILIAS\Refinery\Factory;
 

--- a/Services/AccessControl/classes/class.ilPermissionGUI.php
+++ b/Services/AccessControl/classes/class.ilPermissionGUI.php
@@ -4,6 +4,7 @@
 /**
  * New PermissionGUI (extends from old ilPermission2GUI)
  * RBAC related output
+ *
  * @author       Stefan Meyer <smeyer.ilias@gmx.de>
  * @author       Sascha Hofmann <saschahofmann@gmx.de>
  * @version      $Id$
@@ -14,23 +15,26 @@ class ilPermissionGUI extends ilPermission2GUI
 {
     protected const CMD_PERM_POSITIONS = 'permPositions';
     protected const CMD_SAVE_POSITIONS_PERMISSIONS = 'savePositionsPermissions';
-
+    
     protected object $current_obj;
-
+    
     protected ilRecommendedContentManager $recommended_content_manager;
     protected ilToolbarGUI $toolbar;
-
+    protected \ILIAS\HTTP\Wrapper\WrapperFactory $wrapper;
+    
     public function __construct(object $a_gui_obj)
     {
         global $DIC;
-
+        
+        $this->wrapper = $DIC->http()->wrapper();
         $this->toolbar = $DIC->toolbar();
         parent::__construct($a_gui_obj);
         $this->recommended_content_manager = new ilRecommendedContentManager();
     }
-
+    
     /**
      * Execute command
+     *
      * @return
      */
     public function executeCommand()
@@ -42,7 +46,7 @@ class ilPermissionGUI extends ilPermission2GUI
         $next_class = $this->ctrl->getNextClass($this);
         switch ($next_class) {
             case "ilobjrolegui":
-
+                
                 $role_id = 0;
                 if ($this->http->wrapper()->query()->has('obj_id')) {
                     $role_id = $this->http->wrapper()->query()->retrieve(
@@ -54,25 +58,25 @@ class ilPermissionGUI extends ilPermission2GUI
                 $this->gui_obj = new ilObjRoleGUI("", $role_id, false, false);
                 $ret = $this->ctrl->forwardCommand($this->gui_obj);
                 break;
-
+            
             case 'ildidactictemplategui':
                 $this->ctrl->setReturn($this, 'perm');
                 $did = new ilDidacticTemplateGUI($this->gui_obj);
                 $this->ctrl->forwardCommand($did);
                 break;
-
+            
             case 'ilrepositorysearchgui':
                 // used for owner autocomplete
                 $rep_search = new ilRepositorySearchGUI();
                 $this->ctrl->forwardCommand($rep_search);
                 break;
-
+            
             case 'ilobjectpermissionstatusgui':
                 $this->__initSubTabs("perminfo");
                 $perm_stat = new ilObjectPermissionStatusGUI($this->gui_obj->getObject());
                 $this->ctrl->forwardCommand($perm_stat);
                 break;
-
+            
             default:
                 $cmd = $this->ctrl->getCmd();
                 $this->$cmd();
@@ -80,12 +84,12 @@ class ilPermissionGUI extends ilPermission2GUI
         }
         return true;
     }
-
+    
     public function getCurrentObject() : object
     {
         return $this->gui_obj->getObject();
     }
-
+    
     /**
      * Called after toolbar action applyTemplateSwitch
      */
@@ -96,7 +100,7 @@ class ilPermissionGUI extends ilPermission2GUI
         $dtpl_gui = new ilDidacticTemplateGUI($this->gui_obj);
         $this->ctrl->forwardCommand($dtpl_gui);
     }
-
+    
     public function perm(ilTable2GUI $table = null) : void
     {
         $dtpl = new ilDidacticTemplateGUI($this->gui_obj);
@@ -107,12 +111,12 @@ class ilPermissionGUI extends ilPermission2GUI
         )) {
             $this->toolbar->addSeparator();
         }
-
+        
         if ($this->objDefinition->hasLocalRoles($this->getCurrentObject()->getType()) and
             !$this->isAdministrationObject()
         ) {
             $this->toolbar->setFormAction($this->ctrl->getFormAction($this));
-
+            
             if (!$this->isAdminRoleFolder()) {
                 $this->toolbar->addButton(
                     $this->lng->txt('rbac_add_new_local_role'),
@@ -125,24 +129,24 @@ class ilPermissionGUI extends ilPermission2GUI
             );
         }
         $this->__initSubTabs("perm");
-
+        
         if (!$table instanceof ilTable2GUI) {
             $table = new ilObjectRolePermissionTableGUI($this, 'perm', $this->getCurrentObject()->getRefId());
         }
         $table->parse();
         $this->tpl->setContent($table->getHTML());
     }
-
+    
     protected function isAdminRoleFolder() : bool
     {
         return $this->getCurrentObject()->getRefId() == ROLE_FOLDER_ID;
     }
-
+    
     protected function isAdministrationObject() : bool
     {
         return $this->getCurrentObject()->getType() == 'adm';
     }
-
+    
     /**
      * Check if node is subobject of administration folder
      */
@@ -150,7 +154,7 @@ class ilPermissionGUI extends ilPermission2GUI
     {
         return (bool) $GLOBALS['DIC']['tree']->isGrandChild(SYSTEM_FOLDER_ID, $this->getCurrentObject()->getRefId());
     }
-
+    
     protected function applyFilter() : void
     {
         $table = new ilObjectRolePermissionTableGUI($this, 'perm', $this->getCurrentObject()->getRefId());
@@ -158,7 +162,7 @@ class ilPermissionGUI extends ilPermission2GUI
         $table->writeFilterToSession();
         $this->perm($table);
     }
-
+    
     protected function resetFilter() : void
     {
         $table = new ilObjectRolePermissionTableGUI($this, 'perm', $this->getCurrentObject()->getRefId());
@@ -166,19 +170,19 @@ class ilPermissionGUI extends ilPermission2GUI
         $table->resetFilter();
         $this->perm($table);
     }
-
+    
     public function applyRoleFilter(array $a_roles, int $a_filter_id) : array
     {
         // Always delete administrator role from view
         if (isset($a_roles[SYSTEM_ROLE_ID])) {
             unset($a_roles[SYSTEM_ROLE_ID]);
         }
-
+        
         switch ($a_filter_id) {
             // all roles in context
             case ilObjectRolePermissionTableGUI::ROLE_FILTER_ALL:
                 return $a_roles;
-
+            
             // only global roles
             case ilObjectRolePermissionTableGUI::ROLE_FILTER_GLOBAL:
                 $arr_global_roles = $this->rbacreview->getGlobalRoles();
@@ -187,7 +191,7 @@ class ilPermissionGUI extends ilPermission2GUI
                     unset($a_roles[$role_id]);
                 }
                 return $a_roles;
-
+            
             // only local roles (all local roles in context that are not defined at ROLE_FOLDER_ID)
             case ilObjectRolePermissionTableGUI::ROLE_FILTER_LOCAL:
                 $arr_global_roles = $this->rbacreview->getGlobalRoles();
@@ -196,7 +200,7 @@ class ilPermissionGUI extends ilPermission2GUI
                 }
                 return $a_roles;
                 break;
-
+            
             // only roles which use a local policy
             case ilObjectRolePermissionTableGUI::ROLE_FILTER_LOCAL_POLICY:
                 $arr_local_roles = $this->rbacreview->getRolesOfObject($this->getCurrentObject()->getRefId());
@@ -205,7 +209,7 @@ class ilPermissionGUI extends ilPermission2GUI
                     unset($a_roles[$role_id]);
                 }
                 return $a_roles;
-
+            
             // only true local role defined at current position
             case ilObjectRolePermissionTableGUI::ROLE_FILTER_LOCAL_OBJECT:
                 $arr_local_roles = $this->rbacreview->getRolesOfObject($this->getCurrentObject()->getRefId(), true);
@@ -214,53 +218,64 @@ class ilPermissionGUI extends ilPermission2GUI
                     unset($a_roles[$role_id]);
                 }
                 return $a_roles;
-
+            
             default:
                 return $a_roles;
         }
     }
-
+    
     protected function savePermissions()
     {
         global $DIC;
-
+        
         $rbacreview = $DIC['rbacreview'];
         $objDefinition = $DIC['objDefinition'];
         $rbacadmin = $DIC['rbacadmin'];
-
+        
         $table = new ilObjectRolePermissionTableGUI($this, 'perm', $this->getCurrentObject()->getRefId());
-
+        
         $roles = $this->applyRoleFilter(
             $rbacreview->getParentRoleIds($this->getCurrentObject()->getRefId()),
             (int) $table->getFilterItemByPostVar('role')->getValue()
         );
-
+        
         // Log history
         $log_old = ilRbacLog::gatherFaPa($this->getCurrentObject()->getRefId(), array_keys((array) $roles));
-
+        
         # all possible create permissions
         $possible_ops_ids = $rbacreview->getOperationsByTypeAndClass(
             $this->getCurrentObject()->getType(),
             'create'
         );
-
+        
         # createable (activated) create permissions
         $create_types = $objDefinition->getCreatableSubObjects(
             $this->getCurrentObject()->getType()
         );
         $createable_ops_ids = ilRbacReview::lookupCreateOperationIds(array_keys((array) $create_types));
-
-        foreach ((array) $roles as $role => $role_data) {
+        
+        $post_perm = $this->wrapper->post()->has('perm')
+            ? $this->wrapper->post()->retrieve(
+                'perm',
+                $this->refinery->kindlyTo()->dictOf(
+                    $this->refinery->kindlyTo()->dictOf(
+                        $this->refinery->kindlyTo()->int()
+                    )
+                )
+            )
+            : [];
+        
+        foreach ($roles as $role => $role_data) {
             if ($role_data['protected']) {
                 continue;
             }
-
-            $new_ops = array_keys((array) $_POST['perm'][$role]);
+            
+            $new_ops = array_keys((array) $post_perm[$role]);
             $old_ops = $rbacreview->getRoleOperationsOnObject(
                 $role,
                 $this->getCurrentObject()->getRefId()
             );
-
+            
             // Add operations which were enabled and are not activated.
             foreach ($possible_ops_ids as $create_ops_id) {
                 if (in_array($create_ops_id, $createable_ops_ids)) {
@@ -270,23 +285,34 @@ class ilPermissionGUI extends ilPermission2GUI
                     $new_ops[] = $create_ops_id;
                 }
             }
-
+            
             $rbacadmin->revokePermission(
                 $this->getCurrentObject()->getRefId(),
                 $role
             );
-
+            
             $rbacadmin->grantPermission(
                 $role,
                 array_unique($new_ops),
                 $this->getCurrentObject()->getRefId()
             );
         }
-
+        
         if (ilPermissionGUI::hasContainerCommands($this->getCurrentObject()->getType())) {
+            $inherit_post = $this->wrapper->post()->has('inherit')
+                ? $this->wrapper->post()->retrieve(
+                    'inherit',
+                    $this->refinery->kindlyTo()->dictOf(
+                        $this->refinery->kindlyTo()->bool()
+                    )
+                )
+                : [];
+            
             foreach ($roles as $role) {
+                $obj_id = (int) $role['obj_id'];
+                $parent_id = (int) $role['parent'];
                 // No action for local roles
-                if ($role['parent'] == $this->getCurrentObject()->getRefId() and $role['assign'] == 'y') {
+                if ($parent_id === $this->getCurrentObject()->getRefId() && $role['assign'] === 'y') {
                     continue;
                 }
                 // Nothing for protected roles
@@ -295,50 +321,60 @@ class ilPermissionGUI extends ilPermission2GUI
                 }
                 // Stop local policy
                 if (
-                    $role['parent'] == $this->getCurrentObject()->getRefId() and
-                    !isset($_POST['inherit'][$role['obj_id']]) and
-                    !$rbacreview->isBlockedAtPosition($role['obj_id'], $this->getCurrentObject()->getRefId())
+                    $parent_id === $this->getCurrentObject()->getRefId()
+                    && !isset($inherit_post[$obj_id])
+                    && !$rbacreview->isBlockedAtPosition($obj_id, $this->getCurrentObject()->getRefId())
                 ) {
                     ilLoggerFactory::getLogger('ac')->debug('Stop local policy for: ' . $role['obj_id']);
-                    $role_obj = ilObjectFactory::getInstanceByObjId($role['obj_id']);
+                    $role_obj = ilObjectFactory::getInstanceByObjId($obj_id);
                     $role_obj->setParent($this->getCurrentObject()->getRefId());
                     $role_obj->delete();
                     continue;
                 }
                 // Add local policy
-                if ($role['parent'] != $this->getCurrentObject()->getRefId() and isset($_POST['inherit'][$role['obj_id']])) {
+                if (
+                    $parent_id !== $this->getCurrentObject()->getRefId()
+                    && isset($inherit_post[$obj_id])
+                ) {
                     ilLoggerFactory::getLogger('ac')->debug('Create local policy');
                     $rbacadmin->copyRoleTemplatePermissions(
-                        $role['obj_id'],
-                        $role['parent'],
+                        $obj_id,
+                        $parent_id,
                         $this->getCurrentObject()->getRefId(),
-                        $role['obj_id']
+                        $obj_id
                     );
                     ilLoggerFactory::getLogger('ac')->debug('Assign role to folder');
-                    $rbacadmin->assignRoleToFolder($role['obj_id'], $this->getCurrentObject()->getRefId(), 'n');
+                    $rbacadmin->assignRoleToFolder($obj_id, $this->getCurrentObject()->getRefId(), 'n');
                 }
             }
         }
-
+        
         // Protect permissions
         if (ilPermissionGUI::hasContainerCommands($this->getCurrentObject()->getType())) {
+            $protected_post = $this->wrapper->post()->has('protect')
+                ? $this->wrapper->post()->retrieve(
+                    'protect',
+                    $this->refinery->kindlyTo()->dictOf($this->refinery->kindlyTo()->int())
+                )
+                : [];
             foreach ($roles as $role) {
-                if ($rbacreview->isAssignable($role['obj_id'], $this->getCurrentObject()->getRefId())) {
-                    if (isset($_POST['protect'][$role['obj_id']]) and
-                        !$rbacreview->isProtected($this->getCurrentObject()->getRefId(), $role['obj_id'])) {
-                        $rbacadmin->setProtected($this->getCurrentObject()->getRefId(), $role['obj_id'], 'y');
-                    } elseif (!isset($_POST['protect'][$role['obj_id']]) and
-                        $rbacreview->isProtected($this->getCurrentObject()->getRefId(), $role['obj_id'])) {
-                        $rbacadmin->setProtected($this->getCurrentObject()->getRefId(), $role['obj_id'], 'n');
+                $obj_id = (int) $role['obj_id'];
+                if ($rbacreview->isAssignable($obj_id, $this->getCurrentObject()->getRefId())) {
+                    if (isset($protected_post[$obj_id]) &&
+                        !$rbacreview->isProtected($this->getCurrentObject()->getRefId(), $obj_id)) {
+                        $rbacadmin->setProtected($this->getCurrentObject()->getRefId(), $obj_id, 'y');
+                    } elseif (!isset($protected_post[$obj_id]) &&
+                        $rbacreview->isProtected($this->getCurrentObject()->getRefId(), $obj_id)) {
+                        $rbacadmin->setProtected($this->getCurrentObject()->getRefId(), $obj_id, 'n');
                     }
                 }
             }
         }
-
+        
         $log_new = ilRbacLog::gatherFaPa($this->getCurrentObject()->getRefId(), array_keys((array) $roles));
         $log = ilRbacLog::diffFaPa($log_old, $log_new);
         ilRbacLog::add(ilRbacLog::EDIT_PERMISSIONS, $this->getCurrentObject()->getRefId(), $log);
-
+        
         $blocked_info = $this->getModifiedBlockedSettings();
         ilLoggerFactory::getLogger('ac')->debug('Blocked settings: ' . print_r($blocked_info, true));
         if ($blocked_info['num'] > 0) {
@@ -349,7 +385,7 @@ class ilPermissionGUI extends ilPermission2GUI
         $this->ctrl->redirect($this, 'perm');
         #$this->perm();
     }
-
+    
     protected function showConfirmBlockRole(array $a_blocked_info) : void
     {
         $info = '';
@@ -362,41 +398,53 @@ class ilPermissionGUI extends ilPermission2GUI
         if ($a_blocked_info['new_unblocked']) {
             $info .= ('<br />' . $this->lng->txt('role_confirm_unblock_role_info'));
         }
-
+        
         $this->tpl->setOnScreenMessage('info', $info);
-
+        
         $confirm = new ilConfirmationGUI();
         $confirm->setFormAction($this->ctrl->getFormAction($this));
         $confirm->setHeaderText($this->lng->txt('role_confirm_block_role_header'));
         $confirm->setConfirm($this->lng->txt('role_confirm_block_role'), 'modifyBlockRoles');
         $confirm->setCancel($this->lng->txt('cancel'), 'perm');
-
+        
         foreach ($a_blocked_info['new_blocked'] as $role_id) {
             $confirm->addItem(
                 'new_block[]',
-                $role_id,
+                (string) $role_id,
                 ilObjRole::_getTranslation(ilObject::_lookupTitle($role_id)) . ' ' . $this->lng->txt('role_blocked')
             );
         }
         foreach ($a_blocked_info['new_unblocked'] as $role_id) {
             $confirm->addItem(
                 'new_unblock[]',
-                $role_id,
+                (string) $role_id,
                 ilObjRole::_getTranslation(ilObject::_lookupTitle($role_id)) . ' ' . $this->lng->txt('role_unblocked')
             );
         }
         $this->tpl->setContent($confirm->getHTML());
     }
-
+    
     protected function modifyBlockRoles() : void
     {
-        $this->blockRoles((array) $_POST['new_block']);
-        $this->unblockRoles((array) $_POST['new_unblock']);
-
+        $this->blockRoles(
+            $this->wrapper->post()->has('new_block')
+                ? $this->wrapper->post()->retrieve(
+                    'new_block',
+                    $this->refinery->kindlyTo()->dictOf($this->refinery->kindlyTo()->int())
+                )
+                : []
+        );
+        $this->unblockRoles($this->wrapper->post()->has('new_unblock')
+            ? $this->wrapper->post()->retrieve(
+                'new_unblock',
+                $this->refinery->kindlyTo()->dictOf($this->refinery->kindlyTo()->int())
+            )
+            : []);
+        
         $this->tpl->setOnScreenMessage('info', $this->lng->txt('settings_saved'));
         $this->ctrl->redirect($this, 'perm');
     }
-
+    
     /**
      *
      */
@@ -408,13 +456,13 @@ class ilPermissionGUI extends ilPermission2GUI
             $role_obj = ilObjectFactory::getInstanceByObjId($role);
             $role_obj->setParent($this->getCurrentObject()->getRefId());
             $role_obj->delete();
-
+            
             $role_obj->changeExistingObjects(
                 $this->getCurrentObject()->getRefId(),
                 ilObjRole::MODE_UNPROTECTED_KEEP_LOCAL_POLICIES,
-                array('all')
+                ['all']
             );
-
+            
             // finally set blocked status
             $this->rbacadmin->setBlockedStatus(
                 $role,
@@ -423,25 +471,25 @@ class ilPermissionGUI extends ilPermission2GUI
             );
         }
     }
-
+    
     protected function blockRoles($roles) : void
     {
         foreach ($roles as $role) {
             // Set assign to 'y' only if it is a local role
             $assign = $this->rbacreview->isAssignable($role, $this->getCurrentObject()->getRefId()) ? 'y' : 'n';
-
+            
             // Delete permissions
             $this->rbacadmin->revokeSubtreePermissions($this->getCurrentObject()->getRefId(), $role);
-
+            
             // Delete template permissions
             $this->rbacadmin->deleteSubtreeTemplates($this->getCurrentObject()->getRefId(), $role);
-
+            
             $this->rbacadmin->assignRoleToFolder(
                 $role,
                 $this->getCurrentObject()->getRefId(),
                 $assign
             );
-
+            
             // finally set blocked status
             $this->rbacadmin->setBlockedStatus(
                 $role,
@@ -450,31 +498,31 @@ class ilPermissionGUI extends ilPermission2GUI
             );
         }
     }
-
+    
     public static function hasContainerCommands($a_type)
     {
         global $DIC;
-
+        
         $objDefinition = $DIC['objDefinition'];
         return $objDefinition->isContainer($a_type) and $a_type != 'root' and $a_type != 'adm' and $a_type != 'rolf';
     }
-
+    
     protected function displayImportRoleForm(ilPropertyFormGUI $form = null) : void
     {
         $this->tabs->clearTargets();
-
+        
         if (!$form) {
             $form = $this->initImportForm();
         }
         $this->tpl->setContent($form->getHTML());
     }
-
+    
     protected function doImportRole() : void
     {
         $form = $this->initImportForm();
         if ($form->checkInput()) {
             try {
-
+                
                 // For global roles set import id to parent of current ref_id (adm)
                 $imp = new ilImport($this->getCurrentObject()->getRefId());
                 $imp->getMapping()->addMapping(
@@ -483,7 +531,7 @@ class ilPermissionGUI extends ilPermission2GUI
                     (string) 0,
                     $this->getCurrentObject()->getRefId()
                 );
-
+                
                 $imp->importObject(
                     null,
                     $_FILES["importfile"]["tmp_name"],
@@ -504,7 +552,7 @@ class ilPermissionGUI extends ilPermission2GUI
         $this->tpl->setOnScreenMessage('failure', $this->lng->txt('err_check_input'));
         $this->displayImportRoleForm($form);
     }
-
+    
     /**
      * init import form
      */
@@ -515,14 +563,14 @@ class ilPermissionGUI extends ilPermission2GUI
         $form->setTitle($this->lng->txt('rbac_import_role'));
         $form->addCommandButton('doImportRole', $this->lng->txt('import'));
         $form->addCommandButton('perm', $this->lng->txt('cancel'));
-
+        
         $zip = new ilFileInputGUI($this->lng->txt('import_file'), 'importfile');
-        $zip->setSuffixes(array('zip'));
+        $zip->setSuffixes(['zip']);
         $form->addItem($zip);
-
+        
         return $form;
     }
-
+    
     protected function initRoleForm() : ilPropertyFormGUI
     {
         $form = new ilPropertyFormGUI();
@@ -530,7 +578,7 @@ class ilPermissionGUI extends ilPermission2GUI
         $form->setTitle($this->lng->txt('role_new'));
         $form->addCommandButton('addrole', $this->lng->txt('role_new'));
         $form->addCommandButton('perm', $this->lng->txt('cancel'));
-
+        
         $title = new ilTextInputGUI($this->lng->txt('title'), 'title');
         $title->setValidationRegexp('/^(?!il_).*$/');
         $title->setValidationFailureMessage($this->lng->txt('msg_role_reserved_prefix'));
@@ -538,17 +586,17 @@ class ilPermissionGUI extends ilPermission2GUI
         $title->setMaxLength(70);
         $title->setRequired(true);
         $form->addItem($title);
-
+        
         $desc = new ilTextAreaInputGUI($this->lng->txt('description'), 'desc');
         $desc->setCols(40);
         $desc->setRows(3);
         $form->addItem($desc);
-
+        
         $pro = new ilCheckboxInputGUI($this->lng->txt('role_protect_permissions'), 'pro');
         $pro->setInfo($this->lng->txt('role_protect_permissions_desc'));
         $pro->setValue((string) 1);
         $form->addItem($pro);
-
+        
         $pd = new ilCheckboxInputGUI($this->lng->txt('rbac_add_recommended_content'), 'desktop');
         $pd->setInfo(
             str_replace(
@@ -559,27 +607,29 @@ class ilPermissionGUI extends ilPermission2GUI
         );
         $pd->setValue((string) 1);
         $form->addItem($pd);
-
+        
         if (!$this->isInAdministration()) {
             $rights = new ilRadioGroupInputGUI($this->lng->txt("rbac_role_rights_copy"), 'rights');
             $option = new ilRadioOption($this->lng->txt("rbac_role_rights_copy_empty"), (string) 0);
             $rights->addOption($option);
-
+            
             $parent_role_ids = $this->rbacreview->getParentRoleIds($this->gui_obj->getObject()->getRefId(), true);
-            $ids = array();
+            $ids = [];
             foreach ($parent_role_ids as $id => $tmp) {
                 $ids[] = $id;
             }
-
+            
             // Sort ids
             $sorted_ids = ilUtil::_sortIds($ids, 'object_data', 'type DESC,title', 'obj_id');
-
+            
             $key = 0;
             foreach ($sorted_ids as $id) {
                 $par = $parent_role_ids[$id];
                 if ($par["obj_id"] != SYSTEM_ROLE_ID) {
                     $option = new ilRadioOption(
-                        ($par["type"] == 'role' ? $this->lng->txt('obj_role') : $this->lng->txt('obj_rolt')) . ": " . ilObjRole::_getTranslation($par["title"]),
+                        ($par["type"] == 'role' ? $this->lng->txt('obj_role') : $this->lng->txt(
+                            'obj_rolt'
+                        )) . ": " . ilObjRole::_getTranslation($par["title"]),
                         $par["obj_id"]
                     );
                     $option->setInfo($par["desc"]);
@@ -589,7 +639,7 @@ class ilPermissionGUI extends ilPermission2GUI
             }
             $form->addItem($rights);
         }
-
+        
         // Local policy only for containers
         if ($this->objDefinition->isContainer($this->getCurrentObject()->getType())) {
             $check = new ilCheckboxInputGui($this->lng->txt("rbac_role_rights_copy_change_existing"), 'existing');
@@ -598,7 +648,7 @@ class ilPermissionGUI extends ilPermission2GUI
         }
         return $form;
     }
-
+    
     /**
      * Show add role form
      */
@@ -608,7 +658,7 @@ class ilPermissionGUI extends ilPermission2GUI
         $form = $this->initRoleForm();
         $this->tpl->setContent($form->getHTML());
     }
-
+    
     /**
      * adds a local role
      * This method is only called when choose the option 'you may add local roles'. This option
@@ -620,21 +670,21 @@ class ilPermissionGUI extends ilPermission2GUI
         $form = $this->initRoleForm();
         if ($form->checkInput()) {
             $new_title = $form->getInput("title");
-
+            
             $role = new ilObjRole();
             $role->setTitle($new_title);
             $role->setDescription($form->getInput('desc'));
             $role->create();
-
+            
             $this->rbacadmin->assignRoleToFolder($role->getId(), $this->getCurrentObject()->getRefId());
-
+            
             // protect
             $this->rbacadmin->setProtected(
                 $this->getCurrentObject()->getRefId(),
                 $role->getId(),
                 $form->getInput('pro') ? 'y' : 'n'
             );
-
+            
             // copy rights
             $right_id_to_copy = $form->getInput("rights");
             if ($right_id_to_copy) {
@@ -646,24 +696,24 @@ class ilPermissionGUI extends ilPermission2GUI
                     $role->getId(),
                     false
                 );
-
+                
                 if ($form->getInput('existing')) {
                     if ($form->getInput('pro')) {
                         $role->changeExistingObjects(
                             $this->getCurrentObject()->getRefId(),
                             ilObjRole::MODE_PROTECTED_KEEP_LOCAL_POLICIES,
-                            array('all')
+                            ['all']
                         );
                     } else {
                         $role->changeExistingObjects(
                             $this->getCurrentObject()->getRefId(),
                             ilObjRole::MODE_UNPROTECTED_KEEP_LOCAL_POLICIES,
-                            array('all')
+                            ['all']
                         );
                     }
                 }
             }
-
+            
             // add to desktop items
             if ($form->getInput("desktop")) {
                 $this->recommended_content_manager->addRoleRecommendation(
@@ -671,7 +721,7 @@ class ilPermissionGUI extends ilPermission2GUI
                     $this->getCurrentObject()->getRefId()
                 );
             }
-
+            
             $this->tpl->setOnScreenMessage('success', $this->lng->txt("role_added"), true);
             $this->ctrl->redirect($this, 'perm');
         } else {
@@ -679,64 +729,92 @@ class ilPermissionGUI extends ilPermission2GUI
             $this->tpl->setContent($form->getHTML());
         }
     }
-
+    
     protected function getModifiedBlockedSettings() : array
     {
         global $DIC;
-
+        
         $rbacreview = $DIC['rbacreview'];
-
-        $blocked_info['new_blocked'] = array();
-        $blocked_info['new_unblocked'] = array();
+        
+        $blocked_info['new_blocked'] = [];
+        $blocked_info['new_unblocked'] = [];
         $blocked_info['num'] = 0;
-        foreach ((array) $_POST['visible_block'] as $role => $one) {
+        $visible_block = $this->wrapper->post()->has('visible_block')
+            ? $this->wrapper->post()->retrieve(
+                'visible_block',
+                $this->refinery->kindlyTo()->dictOf($this->refinery->kindlyTo()->int())
+            )
+            : [];
+        $block_post = $this->wrapper->post()->has('block')
+            ? $this->wrapper->post()->retrieve(
+                'block',
+                $this->refinery->kindlyTo()->dictOf($this->refinery->kindlyTo()->int())
+            )
+            : [];
+    
+    
+        foreach ($visible_block as $role => $one) {
             $blocked = $rbacreview->isBlockedAtPosition($role, $this->getCurrentObject()->getRefId());
-            if (isset($_POST['block'][$role]) && !$blocked) {
+            if (isset($block_post[$role]) && !$blocked) {
                 $blocked_info['new_blocked'][] = $role;
                 $blocked_info['num']++;
             }
-            if (!isset($_POST['block'][$role]) && $blocked) {
+            if (!isset($block_post[$role]) && $blocked) {
                 $blocked_info['new_unblocked'][] = $role;
                 $blocked_info['num']++;
             }
         }
         return $blocked_info;
     }
-
+    
     //
     // OrgUnit Position Permissions
     //
-
+    
     protected function permPositions() : void
     {
         $perm = self::CMD_PERM_POSITIONS;
         $this->__initSubTabs($perm);
-
+        
         $ref_id = $this->getCurrentObject()->getRefId();
         $table = new ilOrgUnitPermissionTableGUI($this, $perm, $ref_id);
         $table->collectData();
         $this->tpl->setContent($table->getHTML());
     }
-
+    
     protected function savePositionsPermissions() : void
     {
         $this->__initSubTabs(self::CMD_PERM_POSITIONS);
-
+        
         $positions = ilOrgUnitPosition::getArray(null, 'id');
         $ref_id = $this->getCurrentObject()->getRefId();
-
+        
         // handle local sets
+        $local_post = $this->wrapper->post()->has('local')
+            ? $this->wrapper->post()->retrieve(
+                'local',
+                $this->refinery->kindlyTo()->dictOf($this->refinery->kindlyTo()->int())
+            )
+            : [];
+        
         foreach ($positions as $position_id) {
-            if (isset($_POST['local'][$position_id])) {
+            if (isset($local_post[$position_id])) {
                 ilOrgUnitPermissionQueries::findOrCreateSetForRefId($ref_id, $position_id);
             } else {
                 ilOrgUnitPermissionQueries::removeLocalSetForRefId($ref_id, $position_id);
             }
         }
-
-        if ($_POST['position_perm']) {
-            foreach ($_POST['position_perm'] as $position_id => $ops) {
-                if (!isset($_POST['local'][$position_id])) {
+        
+        $position_perm_post = $this->wrapper->post()->has('position_perm')
+            ? $this->wrapper->post()->retrieve(
+                'position_perm',
+                $this->refinery->kindlyTo()->dictOf($this->refinery->kindlyTo()->int())
+            )
+            : [];
+        ;
+        if ($position_perm_post) {
+            foreach ($position_perm_post as $position_id => $ops) {
+                if (!isset($local_post[$position_id])) {
                     continue;
                 }
                 $ilOrgUnitPermission = ilOrgUnitPermissionQueries::getSetForRefId($ref_id, $position_id);

--- a/Services/AccessControl/classes/class.ilPermissionGUI.php
+++ b/Services/AccessControl/classes/class.ilPermissionGUI.php
@@ -70,7 +70,7 @@ class ilPermissionGUI extends ilPermission2GUI
                 }
                 $this->ctrl->setReturn($this, 'perm');
                 $this->gui_obj = new ilObjRoleGUI("", $role_id, false, false);
-                $ret = $this->ctrl->forwardCommand($this->gui_obj);
+                $this->ctrl->forwardCommand($this->gui_obj);
                 break;
             
             case 'ildidactictemplategui':
@@ -212,7 +212,6 @@ class ilPermissionGUI extends ilPermission2GUI
                     unset($a_roles[$role_id]);
                 }
                 return $a_roles;
-                break;
             
             // only roles which use a local policy
             case ilObjectRolePermissionTableGUI::ROLE_FILTER_LOCAL_POLICY:

--- a/Services/AccessControl/classes/class.ilPermissionGUI.php
+++ b/Services/AccessControl/classes/class.ilPermissionGUI.php
@@ -37,7 +37,7 @@ class ilPermissionGUI extends ilPermission2GUI
      *
      * @return
      */
-    public function executeCommand()
+    public function executeCommand() : void
     {
         // access to all functions in this class are only allowed if edit_permission is granted
         if (!$this->rbacsystem->checkAccess("edit_permission", $this->gui_obj->getObject()->getRefId())) {
@@ -82,7 +82,6 @@ class ilPermissionGUI extends ilPermission2GUI
                 $this->$cmd();
                 break;
         }
-        return true;
     }
     
     public function getCurrentObject() : object
@@ -499,12 +498,12 @@ class ilPermissionGUI extends ilPermission2GUI
         }
     }
     
-    public static function hasContainerCommands($a_type)
+    public static function hasContainerCommands(string $a_type) : bool
     {
         global $DIC;
         
         $objDefinition = $DIC['objDefinition'];
-        return $objDefinition->isContainer($a_type) and $a_type != 'root' and $a_type != 'adm' and $a_type != 'rolf';
+        return $objDefinition->isContainer($a_type) && $a_type != 'root' && $a_type != 'adm' && $a_type != 'rolf';
     }
     
     protected function displayImportRoleForm(ilPropertyFormGUI $form = null) : void

--- a/Services/AccessControl/classes/class.ilPermissionGUI.php
+++ b/Services/AccessControl/classes/class.ilPermissionGUI.php
@@ -237,7 +237,7 @@ class ilPermissionGUI extends ilPermission2GUI
         }
     }
     
-    protected function savePermissions()
+    protected function savePermissions() : void
     {
         global $DIC;
 
@@ -678,7 +678,7 @@ class ilPermissionGUI extends ilPermission2GUI
      * is displayed in the permission settings dialogue for an object
      * TODO: change this bahaviour
      */
-    protected function addRole()
+    protected function addRole() : void
     {
         $form = $this->initRoleForm();
         if ($form->checkInput()) {

--- a/Services/AccessControl/classes/class.ilPermissionGUI.php
+++ b/Services/AccessControl/classes/class.ilPermissionGUI.php
@@ -125,8 +125,7 @@ class ilPermissionGUI extends ilPermission2GUI
             $this->toolbar->addSeparator();
         }
         
-        if ($this->objDefinition->hasLocalRoles($this->getCurrentObject()->getType()) and
-            !$this->isAdministrationObject()
+        if ($this->objDefinition->hasLocalRoles($this->getCurrentObject()->getType()) && !$this->isAdministrationObject()
         ) {
             $this->toolbar->setFormAction($this->ctrl->getFormAction($this));
             
@@ -627,7 +626,7 @@ class ilPermissionGUI extends ilPermission2GUI
             
             $parent_role_ids = $this->rbacreview->getParentRoleIds($this->gui_obj->getObject()->getRefId(), true);
             $ids = [];
-            foreach ($parent_role_ids as $id => $tmp) {
+            foreach (array_keys($parent_role_ids) as $id) {
                 $ids[] = $id;
             }
             

--- a/Services/AccessControl/classes/class.ilRbacAdmin.php
+++ b/Services/AccessControl/classes/class.ilRbacAdmin.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 /**
  * Class ilRbacAdmin
  *  Core functions for role based access control.

--- a/Services/AccessControl/classes/class.ilRbacAdmin.php
+++ b/Services/AccessControl/classes/class.ilRbacAdmin.php
@@ -147,7 +147,7 @@ class ilRbacAdmin
         $ilAtomQuery = $this->db->buildAtomQuery();
         $ilAtomQuery->addTableLock('rbac_ua');
         $ilAtomQuery->addQueryCallable(
-            function (ilDBInterface $ilDB) use (&$ret, $a_role_id, $a_usr_id, $a_limit, $a_limited_roles) {
+            function (ilDBInterface $ilDB) use (&$ret, $a_role_id, $a_usr_id, $a_limit, $a_limited_roles) : void {
                 $ret = true;
                 $limit_query = 'SELECT COUNT(*) num FROM rbac_ua ' .
                     'WHERE ' . $ilDB->in('rol_id', (array) $a_limited_roles, false, 'integer');

--- a/Services/AccessControl/classes/class.ilRbacAdmin.php
+++ b/Services/AccessControl/classes/class.ilRbacAdmin.php
@@ -461,7 +461,7 @@ class ilRbacAdmin
             'AND parent = ' . $this->db->quote($a_dest_parent, 'integer');
         $res = $this->db->manipulate($query);
 
-        foreach ($operations as $row => $op) {
+        foreach ($operations as $op) {
             $query = 'INSERT INTO rbac_templates (rol_id,type,ops_id,parent) ' .
                 'VALUES (' .
                 $this->db->quote($a_dest_id, 'integer') . "," .
@@ -523,7 +523,7 @@ class ilRbacAdmin
         $query = 'INSERT INTO rbac_templates (rol_id,type,ops_id,parent) ' .
             'VALUES (?,?,?,?)';
         $sta = $this->db->prepareManip($query, array('integer', 'text', 'integer', 'integer'));
-        foreach ($operations as $key => $set) {
+        foreach ($operations as $set) {
             $this->db->execute($sta, array(
                 $a_dest_id,
                 $set['type'],

--- a/Services/AccessControl/classes/class.ilRbacAdmin.php
+++ b/Services/AccessControl/classes/class.ilRbacAdmin.php
@@ -173,8 +173,10 @@ class ilRbacAdmin
         // enhanced: only if we haven't had this role for this user
         if (!$alreadyAssigned) {
             $query = "INSERT INTO rbac_ua (usr_id, rol_id) " .
-                "VALUES (" . $this->db->quote($a_usr_id, 'integer') . "," . $this->db->quote($a_rol_id,
-                    'integer') . ")";
+                "VALUES (" . $this->db->quote($a_usr_id, 'integer') . "," . $this->db->quote(
+                    $a_rol_id,
+                    'integer'
+                ) . ")";
             $res = $this->db->manipulate($query);
 
             $this->rbacreview->setAssignedCacheEntry($a_rol_id, $a_usr_id, true);
@@ -265,8 +267,10 @@ class ilRbacAdmin
 
         $query = "INSERT INTO rbac_pa (rol_id,ops_id,ref_id) " .
             "VALUES " .
-            "(" . $this->db->quote($a_rol_id, 'integer') . "," . $this->db->quote($ops_ids,
-                'text') . "," . $this->db->quote($a_ref_id, 'integer') . ")";
+            "(" . $this->db->quote($a_rol_id, 'integer') . "," . $this->db->quote(
+                $ops_ids,
+                'text'
+            ) . "," . $this->db->quote($a_ref_id, 'integer') . ")";
         $res = $this->db->manipulate($query);
     }
 
@@ -395,8 +399,13 @@ class ilRbacAdmin
         bool $a_consider_protected = true
     ) : void {
         // Copy template permissions
-        $this->copyRoleTemplatePermissions($a_source_id, $a_source_parent, $a_dest_parent, $a_dest_id,
-            $a_consider_protected);
+        $this->copyRoleTemplatePermissions(
+            $a_source_id,
+            $a_source_parent,
+            $a_dest_parent,
+            $a_dest_id,
+            $a_consider_protected
+        );
         $ops = $this->rbacreview->getRoleOperationsOnObject($a_source_id, $a_source_parent);
 
         $this->revokePermission($a_dest_parent, $a_dest_id);
@@ -921,8 +930,11 @@ class ilRbacAdmin
                     default:
                         $this->grantPermission(
                             $role_id,
-                            $ops = $this->rbacreview->getOperationsOfRole($role_id, $node_data['type'],
-                                $role_data['parent']),
+                            $ops = $this->rbacreview->getOperationsOfRole(
+                                $role_id,
+                                $node_data['type'],
+                                $role_data['parent']
+                            ),
                             $node_id
                         );
                         break;

--- a/Services/AccessControl/classes/class.ilRbacAdmin.php
+++ b/Services/AccessControl/classes/class.ilRbacAdmin.php
@@ -275,7 +275,7 @@ class ilRbacAdmin
             array($a_rol_id, $a_ref_id)
         );
 
-        if (!count($a_ops)) {
+        if ($a_ops === []) {
             return;
         }
 
@@ -332,7 +332,7 @@ class ilRbacAdmin
             }
 
             // return if no role in array
-            if (!$role_ids) {
+            if ($role_ids === []) {
                 return;
             }
 
@@ -569,7 +569,7 @@ class ilRbacAdmin
         // and the other direction...
         foreach ($s2_ops as $type => $ops) {
             foreach ($ops as $op) {
-                if (!isset($s1_ops[$type]) or !in_array($op, $s1_ops[$type])) {
+                if (!isset($s1_ops[$type]) || !in_array($op, $s1_ops[$type])) {
                     $query = 'INSERT INTO rbac_templates (rol_id,type,ops_id,parent) ' .
                         'VALUES( ' .
                         $this->db->quote($a_dest_id, 'integer') . ', ' .
@@ -601,7 +601,7 @@ class ilRbacAdmin
 
         foreach ($s1_ops as $type => $ops) {
             foreach ($ops as $op) {
-                if (isset($d_ops[$type]) and in_array($op, $d_ops[$type])) {
+                if (isset($d_ops[$type]) && in_array($op, $d_ops[$type])) {
                     $query = 'DELETE FROM rbac_templates ' .
                         'WHERE rol_id = ' . $this->db->quote($a_dest_id, 'integer') . ' ' .
                         'AND type = ' . $this->db->quote($type, 'text') . ' ' .
@@ -752,7 +752,7 @@ class ilRbacAdmin
             }
             $real_local[] = $role_data;
         }
-        if (!count($real_local)) {
+        if ($real_local === []) {
             return;
         }
         // Create role folder
@@ -885,7 +885,7 @@ class ilRbacAdmin
             }
         }
 
-        if (!count($for_deletion) and !count($for_addition)) {
+        if ($for_deletion === [] && $for_addition === []) {
             $this->applyMovedObjectDidacticTemplates($a_ref_id, $a_old_parent);
             return;
         }
@@ -912,7 +912,7 @@ class ilRbacAdmin
                 continue;
             }
 
-            foreach ($for_deletion as $role_id => $role_data) {
+            foreach (array_keys($for_deletion) as $role_id) {
                 $this->deleteLocalRole($role_id, $node_id);
                 $this->revokePermission($node_id, $role_id, false);
                 //var_dump("<pre>",'REVOKE',$role_id,$node_id,$rolf_id,"</pre>");

--- a/Services/AccessControl/classes/class.ilRbacLog.php
+++ b/Services/AccessControl/classes/class.ilRbacLog.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 /**
  * class ilRbacLog
  *  Log changes in Rbac-related settings

--- a/Services/AccessControl/classes/class.ilRbacLog.php
+++ b/Services/AccessControl/classes/class.ilRbacLog.php
@@ -77,11 +77,11 @@ class ilRbacLog
         // roles
         foreach ((array) $a_old["ops"] as $role_id => $ops) {
             $diff = array_diff($ops, $a_new["ops"][$role_id]);
-            if (sizeof($diff)) {
+            if ($diff !== []) {
                 $result["ops"][$role_id]["rmv"] = array_values($diff);
             }
             $diff = array_diff($a_new["ops"][$role_id], $ops);
-            if (sizeof($diff)) {
+            if ($diff !== []) {
                 $result["ops"][$role_id]["add"] = array_values($diff);
             }
         }
@@ -93,11 +93,11 @@ class ilRbacLog
                 $result["inht"]["add"] = $a_new["inht"];
             } else {
                 $diff = array_diff($a_old["inht"], $a_new["inht"]);
-                if (sizeof($diff)) {
+                if ($diff !== []) {
                     $result["inht"]["rmv"] = array_values($diff);
                 }
                 $diff = array_diff($a_new["inht"], $a_old["inht"]);
-                if (sizeof($diff)) {
+                if ($diff !== []) {
                     $result["inht"]["add"] = array_values($diff);
                 }
             }
@@ -124,11 +124,11 @@ class ilRbacLog
                 $result[$type]["rmv"] = $a_old[$type];
             } else {
                 $diff = array_diff($a_old[$type], $a_new[$type]);
-                if (sizeof($diff)) {
+                if ($diff !== []) {
                     $result[$type]["rmv"] = array_values($diff);
                 }
                 $diff = array_diff($a_new[$type], $a_old[$type]);
-                if (sizeof($diff)) {
+                if ($diff !== []) {
                     $result[$type]["add"] = array_values($diff);
                 }
             }
@@ -143,7 +143,7 @@ class ilRbacLog
         $ilUser = $DIC->user();
         $ilDB = $DIC->database();
 
-        if (self::isValidAction($a_action) && sizeof($a_diff)) {
+        if (self::isValidAction($a_action) && count($a_diff)) {
             if ($a_source_ref_id) {
                 $a_diff["src"] = $a_source_ref_id;
             }

--- a/Services/AccessControl/classes/class.ilRbacLog.php
+++ b/Services/AccessControl/classes/class.ilRbacLog.php
@@ -147,7 +147,8 @@ class ilRbacLog
 
     protected static function isValidAction(int $a_action) : bool
     {
-        if (in_array($a_action,
+        if (in_array(
+            $a_action,
             [
                 self::EDIT_PERMISSIONS,
                 self::MOVE_OBJECT,
@@ -192,8 +193,10 @@ class ilRbacLog
             }
         }
 
-        $set = $ilDB->query("SELECT COUNT(*) FROM rbac_log WHERE ref_id = " . $ilDB->quote($a_ref_id,
-                "integer") . implode('', $where));
+        $set = $ilDB->query("SELECT COUNT(*) FROM rbac_log WHERE ref_id = " . $ilDB->quote(
+            $a_ref_id,
+            "integer"
+        ) . implode('', $where));
         $res = $ilDB->fetchAssoc($set);
         $count = array_pop($res);
 
@@ -226,7 +229,9 @@ class ilRbacLog
         $settings = ilPrivacySettings::getInstance();
         $max = $settings->getRbacLogAge();
 
-        $ilDB->query("DELETE FROM rbac_log WHERE created < " . $ilDB->quote(strtotime("-" . $max . "months"),
-                "integer"));
+        $ilDB->query("DELETE FROM rbac_log WHERE created < " . $ilDB->quote(
+            strtotime("-" . $max . "months"),
+            "integer"
+        ));
     }
 }

--- a/Services/AccessControl/classes/class.ilRbacLogTableGUI.php
+++ b/Services/AccessControl/classes/class.ilRbacLogTableGUI.php
@@ -129,8 +129,10 @@ class ilRbacLogTableGUI extends ilTable2GUI
             // added only
             foreach ($raw["ops"] as $role_id => $ops) {
                 foreach ($ops as $op) {
-                    $result[] = array("action" => sprintf($this->lng->txt("rbac_log_operation_add"),
-                        ilObject::_lookupTitle($role_id)),
+                    $result[] = array("action" => sprintf(
+                        $this->lng->txt("rbac_log_operation_add"),
+                        ilObject::_lookupTitle($role_id)
+                    ),
                                       "operation" => $this->getOPCaption($type, $op)
                     );
                 }
@@ -139,8 +141,10 @@ class ilRbacLogTableGUI extends ilTable2GUI
             foreach ($raw["ops"] as $role_id => $actions) {
                 foreach ($actions as $action => $ops) {
                     foreach ((array) $ops as $op) {
-                        $result[] = array("action" => sprintf($this->lng->txt("rbac_log_operation_" . $action),
-                            ilObject::_lookupTitle($role_id)),
+                        $result[] = array("action" => sprintf(
+                            $this->lng->txt("rbac_log_operation_" . $action),
+                            ilObject::_lookupTitle($role_id)
+                        ),
                                           "operation" => $this->getOPCaption($type, $op)
                         );
                     }
@@ -151,8 +155,10 @@ class ilRbacLogTableGUI extends ilTable2GUI
         if (isset($raw["inht"])) {
             foreach ($raw["inht"] as $action => $role_ids) {
                 foreach ((array) $role_ids as $role_id) {
-                    $result[] = array("action" => sprintf($this->lng->txt("rbac_log_inheritance_" . $action),
-                        ilObject::_lookupTitle($role_id))
+                    $result[] = array("action" => sprintf(
+                        $this->lng->txt("rbac_log_inheritance_" . $action),
+                        ilObject::_lookupTitle($role_id)
+                    )
                     );
                 }
             }
@@ -167,8 +173,10 @@ class ilRbacLogTableGUI extends ilTable2GUI
         foreach ($raw as $type => $actions) {
             foreach ($actions as $action => $ops) {
                 foreach ($ops as $op) {
-                    $result[] = array("action" => sprintf($this->lng->txt("rbac_log_operation_" . $action),
-                        $this->lng->txt("obj_" . $type)),
+                    $result[] = array("action" => sprintf(
+                        $this->lng->txt("rbac_log_operation_" . $action),
+                        $this->lng->txt("obj_" . $type)
+                    ),
                                       "operation" => $this->getOPCaption($type, $op)
                     );
                 }

--- a/Services/AccessControl/classes/class.ilRbacLogTableGUI.php
+++ b/Services/AccessControl/classes/class.ilRbacLogTableGUI.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 /**
  * Class ilRbacLogTableGUI
  * @author       Jörg Lützenkirchen <luetzenkirchen@leifos.com>

--- a/Services/AccessControl/classes/class.ilRbacLogTableGUI.php
+++ b/Services/AccessControl/classes/class.ilRbacLogTableGUI.php
@@ -199,9 +199,7 @@ class ilRbacLogTableGUI extends ilTable2GUI
     }
 
     /**
-     * @param string           $a_type
      * @param array|int|string $a_op
-     * @return string
      */
     protected function getOPCaption(string $a_type, $a_op) : string
     {

--- a/Services/AccessControl/classes/class.ilRbacLogTableGUI.php
+++ b/Services/AccessControl/classes/class.ilRbacLogTableGUI.php
@@ -9,10 +9,9 @@
  */
 class ilRbacLogTableGUI extends ilTable2GUI
 {
-    protected $operations = array();
-    protected $filter = array();
-    protected $action_map = array();
-
+    protected array $operations = [];
+    protected array $filter = [];
+    protected array $action_map = [];
     private int $ref_id;
 
     public function __construct(object $a_parent_obj, string $a_parent_cmd, int $a_ref_id)

--- a/Services/AccessControl/classes/class.ilRbacReview.php
+++ b/Services/AccessControl/classes/class.ilRbacReview.php
@@ -156,10 +156,10 @@ class ilRbacReview
 
         if (strlen($title_filter)) {
             $query .= (' AND ' . $this->db->like(
-                    'title',
-                    'text',
-                    $title_filter . '%'
-                ));
+                'title',
+                'text',
+                $title_filter . '%'
+            ));
         }
         $res = $this->db->query($query);
 
@@ -167,8 +167,8 @@ class ilRbacReview
             $row["description"] = (string) $row["description"];
             $row["desc"] = $row["description"];
             $row["user_id"] = (int) $row["owner"];
-            $row['obj_id']  = (int) $row['obj_id'];
-            $row['parent']  = (int) $row['parent'];
+            $row['obj_id'] = (int) $row['obj_id'];
+            $row['parent'] = (int) $row['parent'];
             $role_list[] = $row;
         }
         return $this->__setRoleType($role_list);
@@ -554,7 +554,6 @@ class ilRbacReview
      */
     public function getGlobalAssignableRoles() : array
     {
-
         $ga = [];
         foreach ($this->getGlobalRoles() as $role_id) {
             if (ilObjRole::_getAssignUsersStatus($role_id)) {
@@ -771,7 +770,6 @@ class ilRbacReview
      */
     public function isDeleted(int $a_node_id) : bool
     {
-
         $q = "SELECT tree FROM tree WHERE child =" . $this->db->quote($a_node_id, ilDBConstants::T_INTEGER) . " ";
         $r = $this->db->query($q);
         $row = $r->fetchRow(ilDBConstants::FETCHMODE_OBJECT);
@@ -830,8 +828,12 @@ class ilRbacReview
                     return array();
                 }
 
-                $where = 'WHERE ' . $this->db->in('rbac_fa.rol_id', $this->assignedRoles($a_user_id), false,
-                        'integer') . ' ';
+                $where = 'WHERE ' . $this->db->in(
+                    'rbac_fa.rol_id',
+                    $this->assignedRoles($a_user_id),
+                    false,
+                    'integer'
+                ) . ' ';
                 break;
         }
 
@@ -844,10 +846,10 @@ class ilRbacReview
 
         if (strlen($title_filter)) {
             $query .= (' AND ' . $this->db->like(
-                    'title',
-                    'text',
-                    '%' . $title_filter . '%'
-                ));
+                'title',
+                'text',
+                '%' . $title_filter . '%'
+            ));
         }
 
         $res = $this->db->query($query);
@@ -1046,8 +1048,10 @@ class ilRbacReview
             }
 
             if ($a_parent_roles[$role_id]['protected'] == true) {
-                $arr_lvl_roles_user = array_intersect($this->assignedRoles($ilUser->getId()),
-                    array_keys($a_role_hierarchy, $rolf_id));
+                $arr_lvl_roles_user = array_intersect(
+                    $this->assignedRoles($ilUser->getId()),
+                    array_keys($a_role_hierarchy, $rolf_id)
+                );
 
                 foreach ($arr_lvl_roles_user as $lvl_role_id) {
                     // check if role grants 'edit_permission' to parent

--- a/Services/AccessControl/classes/class.ilRbacReview.php
+++ b/Services/AccessControl/classes/class.ilRbacReview.php
@@ -1,5 +1,19 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * class ilRbacReview

--- a/Services/AccessControl/classes/class.ilRbacReview.php
+++ b/Services/AccessControl/classes/class.ilRbacReview.php
@@ -243,7 +243,7 @@ class ilRbacReview
      */
     protected function __setTemplateFilter(bool $a_templates) : string
     {
-        if ($a_templates === true) {
+        if ($a_templates) {
             $where = "WHERE " . $this->db->in('object_data.type', array('role', 'rolt'), false, 'text') . " ";
         } else {
             $where = "WHERE " . $this->db->in('object_data.type', array('role'), false, 'text') . " ";
@@ -320,7 +320,7 @@ class ilRbacReview
         $query = "SELECT usr_id FROM rbac_ua WHERE rol_id= " . $this->db->quote($a_rol_id, 'integer');
         $res = $this->db->query($query);
         while ($row = $this->db->fetchAssoc($res)) {
-            array_push($result_arr, (int) $row["usr_id"]);
+            $result_arr[] = (int) $row["usr_id"];
         }
         self::$assigned_users_cache[$a_rol_id] = $result_arr;
         return $result_arr;
@@ -401,7 +401,7 @@ class ilRbacReview
         while ($row = $this->db->fetchObject($res)) {
             $role_arr[] = $row->rol_id;
         }
-        return $role_arr ? $role_arr : array();
+        return $role_arr !== [] ? $role_arr : array();
     }
 
     /**
@@ -764,7 +764,7 @@ class ilRbacReview
             'WHERE assign = ' . $this->db->quote('n', 'text') . ' ' .
             'AND rol_id = ' . $this->db->quote($a_rol_id, 'integer') . ' ';
 
-        if ($a_filter) {
+        if ($a_filter !== []) {
             $query .= ('AND ' . $this->db->in('parent', (array) $a_filter, false, 'integer'));
         }
 
@@ -868,12 +868,12 @@ class ilRbacReview
             $prefix = substr($row["title"], 0, 3) == "il_";
 
             // all (assignable) internal local roles only
-            if ($a_filter == 4 and !$prefix) {
+            if ($a_filter == 4 && !$prefix) {
                 continue;
             }
 
             // all (assignable) non internal local roles only
-            if ($a_filter == 5 and $prefix) {
+            if ($a_filter == 5 && $prefix) {
                 continue;
             }
 
@@ -909,7 +909,7 @@ class ilRbacReview
         global $DIC;
 
         $ilDB = $DIC->database();
-        if (!count($operations)) {
+        if ($operations === []) {
             return array();
         }
 
@@ -967,7 +967,7 @@ class ilRbacReview
             $operations[] = ('create_' . $type);
         }
 
-        if (!count($operations)) {
+        if ($operations === []) {
             return array();
         }
 
@@ -1132,7 +1132,7 @@ class ilRbacReview
         // internal cache
         static $obj_cache = array();
 
-        if (isset($obj_cache[$a_role_id]) and $obj_cache[$a_role_id]) {
+        if (isset($obj_cache[$a_role_id]) && $obj_cache[$a_role_id]) {
             return $obj_cache[$a_role_id];
         }
 
@@ -1170,7 +1170,7 @@ class ilRbacReview
     {
         $rolf_list = $this->getFoldersAssignedToRole($a_role_id, false);
         $deleted = true;
-        if (count($rolf_list)) {
+        if ($rolf_list !== []) {
             foreach ($rolf_list as $rolf) {
                 // only list roles that are not set to status "deleted"
                 if (!$this->isDeleted($rolf)) {

--- a/Services/AccessControl/classes/class.ilRbacReview.php
+++ b/Services/AccessControl/classes/class.ilRbacReview.php
@@ -288,7 +288,6 @@ class ilRbacReview
     /**
      * Get the number of assigned users to roles (not properly deleted user accounts are not counted)
      * @param int[] $a_roles
-     * @return int
      */
     public function getNumberOfAssignedUsers(array $a_roles) : int
     {
@@ -353,7 +352,6 @@ class ilRbacReview
      * of a course or a group.
      * @param int        usr_id
      * @param int[]        role_ids
-     * @return    bool
      */
     public function isAssignedToAtLeastOneGivenRole(int $a_usr_id, array $a_role_ids) : bool
     {
@@ -815,7 +813,6 @@ class ilRbacReview
             // all (assignable) roles
             case self::FILTER_ALL:
                 return $this->getAssignableRoles(true, true, $title_filter);
-                break;
 
             // all (assignable) global roles
             case self::FILTER_ALL_GLOBAL:

--- a/Services/AccessControl/classes/class.ilRbacSystem.php
+++ b/Services/AccessControl/classes/class.ilRbacSystem.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 use ILIAS\HTTP\GlobalHttpState;
 use ILIAS\Refinery\Factory;

--- a/Services/AccessControl/classes/class.ilRbacSystem.php
+++ b/Services/AccessControl/classes/class.ilRbacSystem.php
@@ -70,7 +70,7 @@ class ilRbacSystem
 
     public static function getInstance() : ilRbacSystem
     {
-        if (!self::$instance) {
+        if (self::$instance === null) {
             self::$instance = new self();
         }
         return self::$instance;
@@ -217,7 +217,7 @@ class ilRbacSystem
             }
         }
 
-        if (count($ref_ids) > 0) {
+        if ($ref_ids !== []) {
             // Data is not in PA cache, perform database query
             $q = "SELECT * FROM rbac_pa " .
                 "WHERE " . $this->db->in("ref_id", $ref_ids, false, "integer");

--- a/Services/AccessControl/classes/class.ilRbacSystem.php
+++ b/Services/AccessControl/classes/class.ilRbacSystem.php
@@ -20,7 +20,7 @@ class ilRbacSystem
 
     protected static ?ilRbacSystem $instance = null;
 
-    protected $mem_view;
+    protected array $mem_view = [];
 
     protected static array $user_role_cache = [];
 

--- a/Services/AccessControl/classes/class.ilRoleAdoptPermissionTableGUI.php
+++ b/Services/AccessControl/classes/class.ilRoleAdoptPermissionTableGUI.php
@@ -1,6 +1,22 @@
 <?php declare(strict_types=1);
 
 /**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
+/**
  * Copy Permission Settings
  * @author  Fabian Wolf <wolf@leifos.com>
  * @ingroup ServiceAccessControl

--- a/Services/AccessControl/classes/class.ilRoleAutoComplete.php
+++ b/Services/AccessControl/classes/class.ilRoleAutoComplete.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 /**
  * Auto completion class for user lists
  * @author Stefan Meyer <meyer@leifos.com>

--- a/Services/AccessControl/classes/class.ilRoleSelectionTableGUI.php
+++ b/Services/AccessControl/classes/class.ilRoleSelectionTableGUI.php
@@ -1,26 +1,20 @@
 <?php declare(strict_types=1);
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2006 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 /**
  * @author  Stefan Meyer <meyer@leifos.com>
  * @version $Id$

--- a/Services/AccessControl/classes/class.ilRoleTableGUI.php
+++ b/Services/AccessControl/classes/class.ilRoleTableGUI.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 /**
  * TableGUI for the presentation og roles and role templates
  * @author  Stefan Meyer <smeyer.ilias@gmx.de>

--- a/Services/AccessControl/classes/class.ilRoleTableGUI.php
+++ b/Services/AccessControl/classes/class.ilRoleTableGUI.php
@@ -142,8 +142,10 @@ class ilRoleTableGUI extends ilTable2GUI
                 $this->addColumn($this->lng->txt('actions'), '', '10%');
                 $this->setTitle($this->lng->txt('objs_role'));
 
-                if ($GLOBALS['DIC']['rbacsystem']->checkAccess('delete',
-                    $this->getParentObject()->object->getRefId())) {
+                if ($GLOBALS['DIC']['rbacsystem']->checkAccess(
+                    'delete',
+                    $this->getParentObject()->object->getRefId()
+                )) {
                     $this->addMultiCommand('confirmDelete', $this->lng->txt('delete'));
                 }
                 break;

--- a/Services/AccessControl/classes/class.ilRoleTableGUI.php
+++ b/Services/AccessControl/classes/class.ilRoleTableGUI.php
@@ -101,10 +101,7 @@ class ilRoleTableGUI extends ilTable2GUI
         }
 
         if (
-            ($a_set['obj_id'] != ANONYMOUS_ROLE_ID and
-                $a_set['obj_id'] != SYSTEM_ROLE_ID and
-                substr($a_set['title_orig'], 0, 3) != 'il_') or
-            $this->getType() == self::TYPE_SEARCH) {
+            $a_set['obj_id'] != ANONYMOUS_ROLE_ID && $a_set['obj_id'] != SYSTEM_ROLE_ID && substr($a_set['title_orig'], 0, 3) != 'il_' || $this->getType() == self::TYPE_SEARCH) {
             $this->tpl->setVariable('VAL_ID', $a_set['obj_id']);
         }
         $this->tpl->setVariable('VAL_TITLE_LINKED', $a_set['title']);
@@ -311,7 +308,7 @@ class ilRoleTableGUI extends ilTable2GUI
                 $rows[$counter]['rtype'] = $auto ? self::TYPE_ROLT_AU : self::TYPE_ROLT_UD;
             } elseif ($role['parent'] == ROLE_FOLDER_ID) {
                 // Roles
-                if ($role['obj_id'] == ANONYMOUS_ROLE_ID or $role['obj_id'] == SYSTEM_ROLE_ID) {
+                if ($role['obj_id'] == ANONYMOUS_ROLE_ID || $role['obj_id'] == SYSTEM_ROLE_ID) {
                     $rows[$counter]['rtype'] = self::TYPE_GLOBAL_AU;
                 } else {
                     $rows[$counter]['rtype'] = self::TYPE_GLOBAL_UD;

--- a/Services/AccessControl/classes/class.ilRoleXmlExport.php
+++ b/Services/AccessControl/classes/class.ilRoleXmlExport.php
@@ -101,8 +101,6 @@ class ilRoleXmlExport extends ilXmlWriter
 
     /**
      * Write xml presentation of one role
-     * @param int $a_role_id
-     * @param int $a_rolf
      */
     private function writeRole(int $a_role_id, int $a_rolf) : void
     {

--- a/Services/AccessControl/classes/class.ilRoleXmlExport.php
+++ b/Services/AccessControl/classes/class.ilRoleXmlExport.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 /**
  * Xml export of roles and role templates
  * @author  Stefan Meyer <smeyer.ilias@gmx.de>

--- a/Services/AccessControl/classes/class.ilRoleXmlImporter.php
+++ b/Services/AccessControl/classes/class.ilRoleXmlImporter.php
@@ -205,7 +205,7 @@ class ilRoleXmlImporter
             $this->logger->debug('Creating new role template');
             $this->role = new ilObjRoleTemplate();
         }
-        $this->role->setImportId((string) $import_id);
+        $this->role->setImportId($import_id);
     }
 
     protected function parseXmlErrors() : string

--- a/Services/AccessControl/classes/class.ilRoleXmlImporter.php
+++ b/Services/AccessControl/classes/class.ilRoleXmlImporter.php
@@ -152,7 +152,7 @@ class ilRoleXmlImporter
                 $ops_id = (int) $operations[trim((string) $sxml_op)];
                 $ops = trim((string) $sxml_op);
 
-                if ($ops_group and $ops_id) {
+                if ($ops_group && $ops_id) {
                     $this->rbacadmin->setRolePermission(
                         $this->getRole()->getId(),
                         $ops_group,

--- a/Services/AccessControl/classes/class.ilRoleXmlImporter.php
+++ b/Services/AccessControl/classes/class.ilRoleXmlImporter.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 /**
  * Description of class
  * @author  Stefan Meyer <meyer@leifos.com>

--- a/Services/AccessControl/classes/class.ilRoleXmlImporter.php
+++ b/Services/AccessControl/classes/class.ilRoleXmlImporter.php
@@ -31,7 +31,6 @@ class ilRoleXmlImporter
         $this->language = $DIC->language();
 
         $this->role_folder = $a_role_folder_id;
-
     }
 
     public function setXml(string $a_xml) : void

--- a/Services/AccessControl/classes/class.ilSettingsPermissionGUI.php
+++ b/Services/AccessControl/classes/class.ilSettingsPermissionGUI.php
@@ -1,7 +1,21 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2015 ILIAS open source, Extended GPL, see docs/LICENSE */
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 /**
  * UI class for handling permissions that can be configured
  * having the write permission for an object

--- a/Services/AccessControl/classes/class.ilSettingsPermissionGUI.php
+++ b/Services/AccessControl/classes/class.ilSettingsPermissionGUI.php
@@ -171,7 +171,7 @@ class ilSettingsPermissionGUI
     /**
      * Show form
      */
-    public function showForm()
+    public function showForm() : void
     {
         $form = $this->initPermissionForm();
         $this->tpl->setContent($form->getHTML());

--- a/Services/AccessControl/classes/class.ilStartingPoint.php
+++ b/Services/AccessControl/classes/class.ilStartingPoint.php
@@ -17,15 +17,15 @@ class ilStartingPoint
     public const FALLBACK_RULE = 1;
     public const ROLE_BASED = 2;
     public const USER_SELECTION_RULE = 3;
-
-    protected $starting_point;
-    protected $starting_object;
-    protected $starting_position;
-    protected $rule_type;
-    protected $rule_options; // array serialized in db
+    
+    protected ?int $starting_point = null;
+    protected ?int $starting_object = null;
+    protected ?int $starting_position = null;
+    protected ?int $rule_type = null;
+    protected ?string $rule_options = null; // array serialized in db
     protected int $id;
-    protected $calendar_view;
-    protected $calendar_period;
+    protected ?int $calendar_view = null;
+    protected ?int $calendar_period = null;
 
     protected ilDBInterface $db;
 
@@ -130,7 +130,7 @@ class ilStartingPoint
         $this->calendar_period = $calendar_period;
     }
 
-    public function getRuleOptions() : int
+    public function getRuleOptions() : ?string
     {
         return $this->rule_options;
     }
@@ -183,19 +183,19 @@ class ilStartingPoint
     /**
      * get array with all roles which have starting point defined.
      */
-    public static function getRolesWithStartingPoint()
+    public static function getRolesWithStartingPoint() : array
     {
         global $DIC;
 
         $ilDB = $DIC['ilDB'];
         $query = "SELECT * FROM usr_starting_point WHERE rule_options LIKE %s";
-        $res = $ilDB->queryF($query, array('text'), array("%role_id%"));
+        $res = $ilDB->queryF($query, ['text'], ["%role_id%"]);
 
-        $roles = array();
+        $roles = [];
         while ($sp = $ilDB->fetchAssoc($res)) {
             $options = unserialize($sp['rule_options']);
 
-            $roles[$options['role_id']] = array(
+            $roles[$options['role_id']] = [
                 "id" => (int) $sp['id'],
                 "starting_point" => (int) $sp['starting_point'],
                 "starting_object" => (int) $sp['starting_object'],
@@ -204,7 +204,7 @@ class ilStartingPoint
                 "position" => (int) $sp['position'],
                 "role_id" => (int) $options['role_id'],
 
-            );
+            ];
         }
         return $roles;
     }

--- a/Services/AccessControl/classes/class.ilStartingPoint.php
+++ b/Services/AccessControl/classes/class.ilStartingPoint.php
@@ -118,7 +118,6 @@ class ilStartingPoint
 
     /**
      * Gets calendar view
-     * @return int
      */
     public function getCalendarView() : int
     {
@@ -127,7 +126,6 @@ class ilStartingPoint
 
     /**
      * Sets calendar view
-     * @param int $calendar_view
      */
     public function setCalendarView(int $calendar_view) : void
     {
@@ -151,7 +149,6 @@ class ilStartingPoint
 
     /**
      * Get all the starting points in database
-     * @return array
      */
     public static function getStartingPoints() : array
     {
@@ -181,7 +178,7 @@ class ilStartingPoint
     public static function onRoleDeleted(ilObjRole $role) : void
     {
         foreach (self::getRolesWithStartingPoint() as $roleId => $data) {
-            if ((int) $roleId === (int) $role->getId()) {
+            if ((int) $roleId === $role->getId()) {
                 $sp = new self((int) $data['id']);
                 $sp->delete();
             } elseif (
@@ -225,7 +222,6 @@ class ilStartingPoint
 
     /**
      * Get id and title of the roles without starting points
-     * @return array
      */
     public static function getGlobalRolesWithoutStartingPoint() : array
     {
@@ -351,7 +347,7 @@ class ilStartingPoint
     {
         $ord_const = 0;
         $rearranged = [];
-        foreach ($a_items as $k => $v) {
+        foreach ($a_items as $v) {
             $v['starting_position'] = $ord_const;
             $rearranged[$ord_const] = $v;
             $ord_const = $ord_const + 10;

--- a/Services/AccessControl/classes/class.ilStartingPoint.php
+++ b/Services/AccessControl/classes/class.ilStartingPoint.php
@@ -233,7 +233,7 @@ class ilStartingPoint
 
         $ids_roles_with_sp = array();
         foreach ($roles_with_starting_point as $role) {
-            array_push($ids_roles_with_sp, $role['role_id']);
+            $ids_roles_with_sp[] = $role['role_id'];
         }
 
         $ids_roles_without_sp = array_diff($global_roles, $ids_roles_with_sp);
@@ -350,7 +350,7 @@ class ilStartingPoint
         foreach ($a_items as $v) {
             $v['starting_position'] = $ord_const;
             $rearranged[$ord_const] = $v;
-            $ord_const = $ord_const + 10;
+            $ord_const += 10;
         }
         return $rearranged;
     }

--- a/Services/AccessControl/classes/class.ilStartingPoint.php
+++ b/Services/AccessControl/classes/class.ilStartingPoint.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2017 ILIAS open source, Extended GPL, see docs/LICENSE */
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 /**
  * Class ilStartingPoint
  * @author       Jesús López <lopez@leifos.com>

--- a/Services/AccessControl/exceptions/class.ilPermissionException.php
+++ b/Services/AccessControl/exceptions/class.ilPermissionException.php
@@ -3,16 +3,19 @@
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
-
+ *
+ *********************************************************************/
+ 
 /**
  * @author Alexander Killing <killing@leifos.de>
  */

--- a/Services/AccessControl/exceptions/class.ilRoleImporterException.php
+++ b/Services/AccessControl/exceptions/class.ilRoleImporterException.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2012 ILIAS open source, Extended GPL, see docs/LICENSE */
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 /**
  * Role import exception
  * @author Stefan Meyer <smeyer.ilias@gmx.de>

--- a/Services/AccessControl/interfaces/interface.ilAccessHandler.php
+++ b/Services/AccessControl/interfaces/interface.ilAccessHandler.php
@@ -1,6 +1,22 @@
 <?php declare(strict_types=1);
 
 /**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
+/**
  * Interface ilAccessHandler
  * This interface combines all available interfaces which can be called via global $ilAccess
  * @author Fabian Schmid <fs@studer-raimann.ch>

--- a/Services/AccessControl/interfaces/interface.ilRBACAccessHandler.php
+++ b/Services/AccessControl/interfaces/interface.ilRBACAccessHandler.php
@@ -1,6 +1,22 @@
 <?php declare(strict_types=1);
 
 /**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
+/**
  * Interface ilRBACAccessHandler
  * Checks access for ILIAS objects
  * @author  Alex Killing <alex.killing@gmx.de>

--- a/Services/AccessControl/service.xml
+++ b/Services/AccessControl/service.xml
@@ -11,7 +11,7 @@
             <parent id="adm">adm</parent>
 		</object>
 		<object id="role" class_name="Role" dir="classes"
-			checkbox="1" inherit="0" translate="0" rbac="0">
+			checkbox="1" inherit="0" translate="0" rbac="0" administration="1">
 		</object>
 		<object id="rolt" class_name="RoleTemplate" dir="classes"
 			checkbox="1" inherit="0" translate="0" rbac="0">

--- a/Services/AccessControl/test/ilRBACTest.php
+++ b/Services/AccessControl/test/ilRBACTest.php
@@ -1,27 +1,21 @@
 <?php declare(strict_types=1);
 
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2006 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 use PHPUnit\Framework\TestCase;
 use ILIAS\DI\Container;
 

--- a/Services/AccessControl/test/ilServicesAccessControlSuite.php
+++ b/Services/AccessControl/test/ilServicesAccessControlSuite.php
@@ -1,7 +1,21 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+ 
 use PHPUnit\Framework\TestSuite;
 
 class ilServicesAccessControlSuite extends TestSuite
@@ -9,6 +23,7 @@ class ilServicesAccessControlSuite extends TestSuite
     public static function suite() : TestSuite
     {
         $suite = new ilServicesAccessControlSuite();
+        /** @noRector */
         include_once("./Services/AccessControl/test/ilRBACTest.php");
         $suite->addTestSuite(ilRBACTest::class);
         return $suite;

--- a/Services/AccessControl/test/ilServicesAccessControlSuite.php
+++ b/Services/AccessControl/test/ilServicesAccessControlSuite.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestSuite;
 
 class ilServicesAccessControlSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : TestSuite
     {
         $suite = new ilServicesAccessControlSuite();
         include_once("./Services/AccessControl/test/ilRBACTest.php");

--- a/Services/Form/classes/class.ilSelectInputGUI.php
+++ b/Services/Form/classes/class.ilSelectInputGUI.php
@@ -159,7 +159,7 @@ class ilSelectInputGUI extends ilSubEnabledFormPropertyGUI implements ilTableFil
         }
         foreach ($this->getOptions() as $option_value => $option_text) {
             $tpl->setCurrentBlock("prop_select_option");
-            $tpl->setVariable("VAL_SELECT_OPTION", ilLegacyFormElementsUtil::prepareFormOutput($option_value));
+            $tpl->setVariable("VAL_SELECT_OPTION", ilLegacyFormElementsUtil::prepareFormOutput((string) $option_value));
             if ((string) $sel_value == (string) $option_value) {
                 $tpl->setVariable(
                     "CHK_SEL_OPTION",

--- a/Services/User/classes/class.ilUserQuery.php
+++ b/Services/User/classes/class.ilUserQuery.php
@@ -568,8 +568,8 @@ class ilUserQuery
         $query->setCourseGroupFilter($a_course_group_filter);
         $query->setRoleFilter($a_role_filter);
         $query->setUserFolder($a_user_folder_filter);
-        $query->setAdditionalFields($a_additional_fields);
-        $query->setUserFilter($a_user_filter);
+        $query->setAdditionalFields($a_additional_fields ?? []);
+        $query->setUserFilter($a_user_filter ?? []);
         $query->setFirstLetterLastname($a_first_letter);
         $query->setAuthenticationFilter($a_authentication_filter);
         return $query->query();


### PR DESCRIPTION
Hello @smeyer-ilias, 

I completed the review of the `Services/AccessControl` component.

Results:

- [x] The code style is `PSR-2 + X` compliant
- [ ] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`: I fixed all locations which still used SuperGlobals in this PR
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant): not relevant
- [ ] There are no serious `PhpStorm Code Inspection` issues left: I fixed all locations in this PR
- [ ] The types are fully documented (PhpDoc) or explicit PHP types are used (type hints, return types, typed properties): I implemented all missing declarations in this PR

--

Actions needed:
- [ ] Please review the changes in this PR, there are also some "scoutings" and improvements beside the MUST-package

Best regards,
@chfsx