### PR TITLE
PHP 8: Code Review `ECS`

### DIFF
--- a/Services/WebServices/ECS/ROADMAP.md
+++ b/Services/WebServices/ECS/ROADMAP.md
@@ -1,0 +1,19 @@
+# Roadmap
+
+## Short Term
+Fix leftovers from Review:
+- Restructure the current UI. The Participant Screen tries to fit way to much unrelated information into one screen.
+- No usage of $_GET / $_POST / $_REQUEST / $_SESSION: The review  found 69 usages of $_REQUEST, 18 usages of $_GET, 4 usages of $_SESSION and 38 usages of $_POST.
+- Fix broken Advanced Metadata-Handling. This Code is broken since the Reworking of the AdvMetadata in 2014.
+
+## Mid Term
+- Rework the current way, messages are processed. Remove the need to leave already processed messages on the ECS server
+
+### Improve Architecture
+
+- Introduce repository pattern
+- Improve DI handling
+- Factor business logic out of UI classes
+
+## Long Term
+- Replace manual handling of the ECS Json Messages with Binding Code generated from the corresponding JSON Schema for Campus Connect

--- a/Services/WebServices/ECS/classes/Course/class.ilECSCourseAttribute.php
+++ b/Services/WebServices/ECS/classes/Course/class.ilECSCourseAttribute.php
@@ -21,7 +21,7 @@
  */
 class ilECSCourseAttribute
 {
-    private $id;// TODO PHP8-REVIEW Missing type
+    private int $id;
     private int $server_id = 0;
     private int $mid = 0;
     private string $name = '';

--- a/Services/WebServices/ECS/classes/Course/class.ilECSCourseAttribute.php
+++ b/Services/WebServices/ECS/classes/Course/class.ilECSCourseAttribute.php
@@ -21,7 +21,7 @@
  */
 class ilECSCourseAttribute
 {
-    private $id;
+    private $id;// TODO PHP8-REVIEW Missing type
     private int $server_id = 0;
     private int $mid = 0;
     private string $name = '';

--- a/Services/WebServices/ECS/classes/Course/class.ilECSCourseAttributes.php
+++ b/Services/WebServices/ECS/classes/Course/class.ilECSCourseAttributes.php
@@ -200,7 +200,7 @@ class ilECSCourseAttributes
                 'ORDER BY id';
         $res = $this->db->query($query);
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $this->attributes[] = new ilECSCourseAttribute($row->id);
+            $this->attributes[] = new ilECSCourseAttribute((int) $row->id);
         }
     }
 }

--- a/Services/WebServices/ECS/classes/Course/class.ilECSCourseCreationHandler.php
+++ b/Services/WebServices/ECS/classes/Course/class.ilECSCourseCreationHandler.php
@@ -84,9 +84,8 @@ class ilECSCourseCreationHandler
     
     /**
      * Set object created status
-     * @param bool $a_status
      */
-    public function setObjectCreated($a_status) : void//TODO PHP8-REVIEW Missing type hints
+    public function setObjectCreated(bool $a_status) : void
     {
         $this->object_created = $a_status;
     }
@@ -568,7 +567,7 @@ class ilECSCourseCreationHandler
      * Return 0 if object isn't imported.
      * Searches for the (hopefully) unique content id of an imported object
      */
-    protected function getImportId($a_content_id, $a_sub_id = null) : int// TODO PHP8-REVIEW Missing type hints
+    protected function getImportId(int $a_content_id, string $a_sub_id = null) : int
     {
         return ilECSImportManager::getInstance()->lookupObjIdByContentId(
             $this->getServer()->getServerId(),

--- a/Services/WebServices/ECS/classes/Course/class.ilECSCourseCreationHandler.php
+++ b/Services/WebServices/ECS/classes/Course/class.ilECSCourseCreationHandler.php
@@ -86,7 +86,7 @@ class ilECSCourseCreationHandler
      * Set object created status
      * @param bool $a_status
      */
-    public function setObjectCreated($a_status) : void
+    public function setObjectCreated($a_status) : void//TODO PHP8-REVIEW Missing type hints
     {
         $this->object_created = $a_status;
     }
@@ -568,7 +568,7 @@ class ilECSCourseCreationHandler
      * Return 0 if object isn't imported.
      * Searches for the (hopefully) unique content id of an imported object
      */
-    protected function getImportId($a_content_id, $a_sub_id = null)
+    protected function getImportId($a_content_id, $a_sub_id = null) : int// TODO PHP8-REVIEW Missing type hints
     {
         return ilECSImportManager::getInstance()->lookupObjIdByContentId(
             $this->getServer()->getServerId(),

--- a/Services/WebServices/ECS/classes/Course/class.ilECSCourseLmsUrl.php
+++ b/Services/WebServices/ECS/classes/Course/class.ilECSCourseLmsUrl.php
@@ -35,7 +35,7 @@ class ilECSCourseLmsUrl
     /**
      * Set url
      */
-    public function setUrl(string $a_url)
+    public function setUrl(string $a_url) : void
     {
         $this->url = $a_url;
     }

--- a/Services/WebServices/ECS/classes/Course/class.ilECSCourseMappingRule.php
+++ b/Services/WebServices/ECS/classes/Course/class.ilECSCourseMappingRule.php
@@ -33,7 +33,7 @@ class ilECSCourseMappingRule
     private string $attribute;
     private int $ref_id;
     private bool $is_filter = false;
-    private string $filter;
+    private string $filter = "";
     private array $filter_elements = [];
     private bool $create_subdir = true;
     private string $directory = '';
@@ -54,7 +54,7 @@ class ilECSCourseMappingRule
     /**
      * Lookup existing attributes
      */
-    public static function lookupLastExistingAttribute(int $a_sid, int $a_mid, int $a_ref_id) : array
+    public static function lookupLastExistingAttribute(int $a_sid, int $a_mid, int $a_ref_id) : string
     {
         global $DIC;
 
@@ -67,13 +67,16 @@ class ilECSCourseMappingRule
                 'ORDER BY rid ';
         $res = $ilDB->query($query);
         
-        $attributes = array();
+        $attributes = '';
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             $attributes = $row->attribute;
         }
         return $attributes;
     }
-    
+
+    /**
+     * @return int[]
+     */
     public static function getRuleRefIds(int $a_sid, int $a_mid) : array
     {
         global $DIC;
@@ -89,7 +92,7 @@ class ilECSCourseMappingRule
         $res = $ilDB->query($query);
         $ref_ids = array();
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $ref_ids[] = $row->ref_id;
+            $ref_ids[] = (int) $row->ref_id;
         }
         // check if ref_ids are in tree
         $checked_ref_ids = [];
@@ -309,7 +312,7 @@ class ilECSCourseMappingRule
 
         $res = $ilDB->query($query);
         if ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            return new ilECSCourseMappingRule($row->rid);
+            return new ilECSCourseMappingRule((int) $row->rid);
         }
         return new ilECSCourseMappingRule();
     }
@@ -344,7 +347,7 @@ class ilECSCourseMappingRule
         return $this->mid;
     }
     
-    public function setAttribute($a_att) : void
+    public function setAttribute(string $a_att) : void
     {
         $this->attribute = $a_att;
     }
@@ -354,7 +357,7 @@ class ilECSCourseMappingRule
         return $this->attribute;
     }
     
-    public function setRefId($a_ref_id) : void
+    public function setRefId(int $a_ref_id) : void
     {
         $this->ref_id = $a_ref_id;
     }
@@ -364,7 +367,7 @@ class ilECSCourseMappingRule
         return $this->ref_id;
     }
     
-    public function enableFilter($a_status) : void
+    public function enableFilter(bool $a_status) : void
     {
         $this->is_filter = $a_status;
     }
@@ -404,7 +407,7 @@ class ilECSCourseMappingRule
         return self::SUBDIR_VALUE;
     }
     
-    public function setDirectory($a_dir) : void
+    public function setDirectory(string $a_dir) : void
     {
         $this->directory = $a_dir;
     }
@@ -476,13 +479,13 @@ class ilECSCourseMappingRule
             'WHERE rid = ' . $this->db->quote($this->getRuleId(), 'integer');
         $res = $this->db->query($query);
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $this->setServerId($row->sid);
-            $this->setMid($row->mid);
-            $this->setRefId($row->ref_id);
+            $this->setServerId((int) $row->sid);
+            $this->setMid((int) $row->mid);
+            $this->setRefId((int) $row->ref_id);
             $this->setAttribute($row->attribute);
-            $this->enableFilter($row->is_filter);
+            $this->enableFilter((bool) $row->is_filter);
             $this->setFilter($row->filter);
-            $this->enableSubdirCreation($row->create_subdir);
+            $this->enableSubdirCreation((bool) $row->create_subdir);
             //TODO create database update step to remove unneed variable
             $this->setDirectory($row->directory);
         }

--- a/Services/WebServices/ECS/classes/Course/class.ilECSCourseMappingRule.php
+++ b/Services/WebServices/ECS/classes/Course/class.ilECSCourseMappingRule.php
@@ -30,10 +30,10 @@ class ilECSCourseMappingRule
     private int $rid;
     private int $sid;
     private int $mid;
-    private $attribute;// TODO PHP8-REVIEW Missing type
+    private string $attribute;
     private int $ref_id;
     private bool $is_filter = false;
-    private $filter;// TODO PHP8-REVIEW Missing type
+    private string $filter;
     private array $filter_elements = [];
     private bool $create_subdir = true;
     private string $directory = '';
@@ -349,7 +349,7 @@ class ilECSCourseMappingRule
         $this->attribute = $a_att;
     }
     
-    public function getAttribute()
+    public function getAttribute() : string
     {
         return $this->attribute;
     }
@@ -374,12 +374,12 @@ class ilECSCourseMappingRule
         return $this->is_filter;
     }
     
-    public function setFilter($a_filter) : void
+    public function setFilter(string $a_filter) : void
     {
         $this->filter = $a_filter;
     }
     
-    public function getFilter()
+    public function getFilter() : string
     {
         return $this->filter;
     }
@@ -389,7 +389,7 @@ class ilECSCourseMappingRule
         return $this->filter_elements;
     }
     
-    public function enableSubdirCreation($a_stat) : void
+    public function enableSubdirCreation(bool $a_stat) : void
     {
         $this->create_subdir = $a_stat;
     }

--- a/Services/WebServices/ECS/classes/Course/class.ilECSCourseMappingRule.php
+++ b/Services/WebServices/ECS/classes/Course/class.ilECSCourseMappingRule.php
@@ -30,10 +30,10 @@ class ilECSCourseMappingRule
     private int $rid;
     private int $sid;
     private int $mid;
-    private $attribute;
+    private $attribute;// TODO PHP8-REVIEW Missing type
     private int $ref_id;
     private bool $is_filter = false;
-    private $filter;
+    private $filter;// TODO PHP8-REVIEW Missing type
     private array $filter_elements = [];
     private bool $create_subdir = true;
     private string $directory = '';

--- a/Services/WebServices/ECS/classes/Mapping/class.ilECSMappingSettingsGUI.php
+++ b/Services/WebServices/ECS/classes/Mapping/class.ilECSMappingSettingsGUI.php
@@ -1181,9 +1181,8 @@ class ilECSMappingSettingsGUI
 
     /**
      * Set Sub tabs
-     * @param string $a_tab
      */
-    protected function setSubTabs($a_tab) : void//TODO PHP8-REVIEW Missing type hints
+    protected function setSubTabs(int $a_tab) : void
     {
         if ($a_tab === self::TAB_DIRECTORY) {
             $this->tabs->addSubTab(

--- a/Services/WebServices/ECS/classes/Mapping/class.ilECSMappingSettingsGUI.php
+++ b/Services/WebServices/ECS/classes/Mapping/class.ilECSMappingSettingsGUI.php
@@ -638,7 +638,7 @@ class ilECSMappingSettingsGUI
         $this->tabs->setTabActive('ecs_crs_allocation');
         $this->tabs->setSubTabActive('cAttributes');
 
-        $table = new ilECSCourseAttributesTableGUI(
+        $table = new ilECSCourseAttributesTableGUI(// TODO PHP8-REVIEW Undefined class
             $this,
             'attributes',
             $this->getServer()->getServerId(),
@@ -956,7 +956,7 @@ class ilECSMappingSettingsGUI
 
             $this->log->dump($res, ilLogLevel::DEBUG);
 
-            foreach ((array) $res->getLinkIds() as $cms_id) {
+            foreach ((array) $res->getLinkIds() as $cms_id) {// TODO PHP8-REVIEW Undefined method
                 $event = new ilECSEventQueueReader($this->getServer());
                 $event->add(
                     ilECSEventQueueReader::TYPE_DIRECTORY_TREES,
@@ -1183,7 +1183,7 @@ class ilECSMappingSettingsGUI
      * Set Sub tabs
      * @param string $a_tab
      */
-    protected function setSubTabs($a_tab) : void
+    protected function setSubTabs($a_tab) : void//TODO PHP8-REVIEW Missing type hints
     {
         if ($a_tab === self::TAB_DIRECTORY) {
             $this->tabs->addSubTab(

--- a/Services/WebServices/ECS/classes/Mapping/class.ilECSMappingUtils.php
+++ b/Services/WebServices/ECS/classes/Mapping/class.ilECSMappingUtils.php
@@ -46,13 +46,12 @@ class ilECSMappingUtils
     
     /**
      * Get mapping status as string
-     * @param int $a_status
      */
-    public static function mappingStatusToString($a_status)//TODO PHP8-REVIEW Missing type hints
+    public static function mappingStatusToString(int $a_status) : string
     {
         global $DIC;
 
-        return $DIC['lng']->txt('ecs_node_mapping_status_' . $a_status);
+        return $DIC->language()->txt('ecs_node_mapping_status_' . $a_status);
     }
     
     

--- a/Services/WebServices/ECS/classes/Mapping/class.ilECSMappingUtils.php
+++ b/Services/WebServices/ECS/classes/Mapping/class.ilECSMappingUtils.php
@@ -221,7 +221,7 @@ class ilECSMappingUtils
             ) {
                 continue;
             }
-            $options[$auth_string] = ilAuthUtils::getAuthModeTranslation($auth_int);
+            $options[$auth_string] = ilAuthUtils::getAuthModeTranslation((string) $auth_int);
         }
         return $options;
     }

--- a/Services/WebServices/ECS/classes/Mapping/class.ilECSMappingUtils.php
+++ b/Services/WebServices/ECS/classes/Mapping/class.ilECSMappingUtils.php
@@ -48,7 +48,7 @@ class ilECSMappingUtils
      * Get mapping status as string
      * @param int $a_status
      */
-    public static function mappingStatusToString($a_status)
+    public static function mappingStatusToString($a_status)//TODO PHP8-REVIEW Missing type hints
     {
         global $DIC;
 

--- a/Services/WebServices/ECS/classes/Mapping/class.ilECSNodeMappingAssignment.php
+++ b/Services/WebServices/ECS/classes/Mapping/class.ilECSNodeMappingAssignment.php
@@ -19,12 +19,12 @@
  */
 class ilECSNodeMappingAssignment
 {
-    private $server_id;// TODO PHP8-REVIEW Missing type
-    private $mid;// TODO PHP8-REVIEW Missing type
-    private $cs_root;// TODO PHP8-REVIEW Missing type
-    private $cs_id;// TODO PHP8-REVIEW Missing type
-    private $ref_id;// TODO PHP8-REVIEW Missing type
-    private $obj_id;// TODO PHP8-REVIEW Missing type
+    private int $server_id;
+    private int $mid;
+    private int $cs_root;
+    private int $cs_id;
+    private int $ref_id;
+    private int $obj_id;
 
     private bool $title_update = false;
     private bool $position_update = false;
@@ -34,10 +34,7 @@ class ilECSNodeMappingAssignment
     
     private ilDBInterface $db;
 
-    /**
-     * Constructor
-     */
-    public function __construct($a_server_id, $mid, $cs_root, $cs_id)
+    public function __construct(int $a_server_id, int $mid, int $cs_root, int $cs_id)
     {
         global $DIC;
         
@@ -56,62 +53,62 @@ class ilECSNodeMappingAssignment
         return $this->mapped;
     }
     
-    public function getServerId()
+    public function getServerId() : int
     {
         return $this->server_id;
     }
     
-    public function setServerId($a_id) : void
+    public function setServerId(int $a_id) : void
     {
         $this->server_id = $a_id;
     }
 
-    public function setMemberId($a_member_id) : void
+    public function setMembershipId(int $a_member_id) : void
     {
         $this->mid = $a_member_id;
     }
 
-    public function getMemberId()
+    public function getMembershipId() : int
     {
         return $this->mid;
     }
     
-    public function getTreeId()
+    public function getTreeId() : int
     {
         return $this->cs_root;
     }
 
-    public function setTreeId($root) : void
+    public function setTreeId(int $root) : void
     {
         $this->cs_root = $root;
     }
 
-    public function getCSId()
+    public function getCSId() : int
     {
         return $this->cs_id;
     }
 
-    public function setCSId($id) : void
+    public function setCSId(int $id) : void
     {
         $this->cs_id = $id;
     }
 
-    public function getRefId()
+    public function getRefId() : int
     {
         return $this->ref_id;
     }
 
-    public function setRefId($a_id) : void
+    public function setRefId(int $a_id) : void
     {
         $this->ref_id = $a_id;
     }
 
-    public function getObjId()
+    public function getObjId() : int
     {
         return $this->obj_id;
     }
 
-    public function setObjId($id) : void
+    public function setObjId(int $id) : void
     {
         $this->obj_id = $id;
     }
@@ -121,7 +118,7 @@ class ilECSNodeMappingAssignment
         return $this->title_update;
     }
 
-    public function enableTitleUpdate($enabled) : void
+    public function enableTitleUpdate(bool $enabled) : void
     {
         $this->title_update = $enabled;
     }
@@ -131,7 +128,7 @@ class ilECSNodeMappingAssignment
         return $this->position_update;
     }
 
-    public function enablePositionUpdate($enabled) : void
+    public function enablePositionUpdate(bool $enabled) : void
     {
         $this->position_update = $enabled;
     }
@@ -141,7 +138,7 @@ class ilECSNodeMappingAssignment
         return $this->tree_update;
     }
 
-    public function enableTreeUpdate($enabled) : void
+    public function enableTreeUpdate(bool $enabled) : void
     {
         $this->tree_update = $enabled;
     }
@@ -160,7 +157,7 @@ class ilECSNodeMappingAssignment
         $query = 'INSERT INTO ecs_node_mapping_a (server_id,mid,cs_root,cs_id,ref_id,obj_id,title_update,position_update,tree_update) ' .
             'VALUES( ' .
             $this->db->quote($this->getServerId(), 'integer') . ', ' .
-            $this->db->quote($this->getMemberId(), 'integer') . ', ' .
+            $this->db->quote($this->getMembershipId(), 'integer') . ', ' .
             $this->db->quote($this->getTreeId(), 'integer') . ', ' .
             $this->db->quote($this->getCSId(), 'integer') . ', ' .
             $this->db->quote($this->getRefId(), 'integer') . ', ' .
@@ -181,7 +178,7 @@ class ilECSNodeMappingAssignment
     {
         $query = 'DELETE FROM ecs_node_mapping_a ' .
             'WHERE server_id = ' . $this->db->quote($this->getServerId(), 'integer') . ' ' .
-            'AND mid = ' . $this->db->quote($this->getMemberId(), 'integer') . ' ' .
+            'AND mid = ' . $this->db->quote($this->getMembershipId(), 'integer') . ' ' .
             'AND cs_root = ' . $this->db->quote($this->getTreeId(), 'integer') . ' ' .
             'AND cs_id = ' . $this->db->quote($this->getCSId(), 'integer');
         $this->db->manipulate($query);
@@ -196,7 +193,7 @@ class ilECSNodeMappingAssignment
     {
         $query = 'SELECT * FROM ecs_node_mapping_a ' .
             'WHERE server_id = ' . $this->db->quote($this->getServerId(), 'integer') . ' ' .
-            'AND mid = ' . $this->db->quote($this->getMemberId(), 'integer') . ' ' .
+            'AND mid = ' . $this->db->quote($this->getMembershipId(), 'integer') . ' ' .
             'AND cs_root = ' . $this->db->quote($this->getTreeId(), 'integer') . ' ' .
             'AND cs_id = ' . $this->db->quote($this->getCSId(), 'integer') . ' ';
         $res = $this->db->query($query);

--- a/Services/WebServices/ECS/classes/Mapping/class.ilECSNodeMappingAssignment.php
+++ b/Services/WebServices/ECS/classes/Mapping/class.ilECSNodeMappingAssignment.php
@@ -19,12 +19,12 @@
  */
 class ilECSNodeMappingAssignment
 {
-    private $server_id;
-    private $mid;
-    private $cs_root;
-    private $cs_id;
-    private $ref_id;
-    private $obj_id;
+    private $server_id;// TODO PHP8-REVIEW Missing type
+    private $mid;// TODO PHP8-REVIEW Missing type
+    private $cs_root;// TODO PHP8-REVIEW Missing type
+    private $cs_id;// TODO PHP8-REVIEW Missing type
+    private $ref_id;// TODO PHP8-REVIEW Missing type
+    private $obj_id;// TODO PHP8-REVIEW Missing type
 
     private bool $title_update = false;
     private bool $position_update = false;

--- a/Services/WebServices/ECS/classes/Mapping/class.ilECSNodeMappingCmsExplorer.php
+++ b/Services/WebServices/ECS/classes/Mapping/class.ilECSNodeMappingCmsExplorer.php
@@ -24,16 +24,16 @@ class ilECSNodeMappingCmsExplorer extends ilExplorer
     public const SEL_TYPE_CHECK = 1;
     public const SEL_TYPE_RADIO = 2;
 
-    private $server_id;// TODO PHP8-REVIEW Missing type
-    private $mid;// TODO PHP8-REVIEW Missing type
-    private $tree_id;// TODO PHP8-REVIEW Missing type
+    private int $server_id;
+    private int $mid;
+    private int $tree_id;
 
     private array $checked_items = array();
     private string $post_var = '';
     private array $form_items = array();
     private int $type;
 
-    public function __construct($a_target, $a_server_id, $a_mid, $a_tree_id)
+    public function __construct(string $a_target, int $a_server_id, int $a_mid, int $a_tree_id)
     {
         parent::__construct($a_target);
 

--- a/Services/WebServices/ECS/classes/Mapping/class.ilECSNodeMappingCmsExplorer.php
+++ b/Services/WebServices/ECS/classes/Mapping/class.ilECSNodeMappingCmsExplorer.php
@@ -24,9 +24,9 @@ class ilECSNodeMappingCmsExplorer extends ilExplorer
     public const SEL_TYPE_CHECK = 1;
     public const SEL_TYPE_RADIO = 2;
 
-    private $server_id;
-    private $mid;
-    private $tree_id;
+    private $server_id;// TODO PHP8-REVIEW Missing type
+    private $mid;// TODO PHP8-REVIEW Missing type
+    private $tree_id;// TODO PHP8-REVIEW Missing type
 
     private array $checked_items = array();
     private string $post_var = '';

--- a/Services/WebServices/ECS/classes/Mapping/class.ilECSNodeMappingLocalExplorer.php
+++ b/Services/WebServices/ECS/classes/Mapping/class.ilECSNodeMappingLocalExplorer.php
@@ -24,17 +24,20 @@ class ilECSNodeMappingLocalExplorer extends ilExplorer
     public const SEL_TYPE_CHECK = 1;
     public const SEL_TYPE_RADIO = 2;
 
-    private array $checked_items = array();
+    /**
+     * @var int[]
+     */
+    private array $checked_items = [];
     private string $post_var = '';
-    private array $form_items = array();
+    private array $form_items = [];
     private int $type;
     
     private int $sid;
     private int $mid;
     
-    private array $mappings = array();
+    private array $mappings = [];
 
-    public function __construct($a_target, $a_sid, $a_mid)
+    public function __construct(string $a_target, int $a_sid, int $a_mid)
     {
         parent::__construct($a_target);
         
@@ -103,7 +106,7 @@ class ilECSNodeMappingLocalExplorer extends ilExplorer
         return $this->checked_items;
     }
 
-    public function isItemChecked($a_id) : bool
+    public function isItemChecked(int $a_id) : bool
     {
         return in_array($a_id, $this->checked_items, true);
     }
@@ -117,7 +120,7 @@ class ilECSNodeMappingLocalExplorer extends ilExplorer
         return $this->post_var;
     }
 
-    public function buildFormItem($a_node_id, $a_type) : string
+    public function buildFormItem($a_node_id, int $a_type) : string
     {
         if (!array_key_exists($a_type, $this->form_items) || !$this->form_items[$a_type]) {
             return '';
@@ -141,7 +144,11 @@ class ilECSNodeMappingLocalExplorer extends ilExplorer
         return '';
     }
 
-    public function formatObject($tpl, $a_node_id, $a_option, $a_obj_id = 0) : void
+    /**
+     * @param int|string $a_node_id
+     * @throws ilTemplateException
+     */
+    public function formatObject(ilTemplate $tpl, $a_node_id, array $a_option, $a_obj_id = 0) : void
     {
         if (!isset($a_node_id) || !is_array($a_option)) {
             $this->error->raiseError(get_class($this) . "::formatObject(): Missing parameter or wrong datatype! " .
@@ -153,6 +160,7 @@ class ilECSNodeMappingLocalExplorer extends ilExplorer
             if ($picture === 'plus') {
                 $tpl->setCurrentBlock("expander");
                 $tpl->setVariable("EXP_DESC", $this->lng->txt("expand"));
+                $this->setParamsGet([]);
                 $target = $this->createTarget('+', $a_node_id);
                 $tpl->setVariable("LINK_NAME", $a_node_id);
                 $tpl->setVariable("LINK_TARGET_EXPANDER", $target);
@@ -164,6 +172,7 @@ class ilECSNodeMappingLocalExplorer extends ilExplorer
             if ($picture === 'minus' && $this->show_minus) {
                 $tpl->setCurrentBlock("expander");
                 $tpl->setVariable("EXP_DESC", $this->lng->txt("collapse"));
+                $this->setParamsGet([]);
                 $target = $this->createTarget('-', $a_node_id);
                 $tpl->setVariable("LINK_NAME", $a_node_id);
                 $tpl->setVariable("LINK_TARGET_EXPANDER", $target);
@@ -189,13 +198,13 @@ class ilECSNodeMappingLocalExplorer extends ilExplorer
             $tpl->parseCurrentBlock();
         }
 
-        if ($formItem = ($this->buildFormItem($a_node_id, $a_option['type']) !== '')) {
+        if ($formItem = ($this->buildFormItem((int) $a_node_id, (int) $a_option['type']) !== '')) {
             $tpl->setCurrentBlock('check');
             $tpl->setVariable('OBJ_CHECK', $formItem);
             $tpl->parseCurrentBlock();
         }
 
-        if ($this->isClickable($a_option["type"], $a_node_id)) {	// output link
+        if ($this->isClickable($a_option["type"], (int) $a_node_id)) {	// output link
             $tpl->setCurrentBlock("link");
             //$target = (strpos($this->target, "?") === false) ?
             //	$this->target."?" : $this->target."&";
@@ -253,13 +262,9 @@ class ilECSNodeMappingLocalExplorer extends ilExplorer
 
 
 
-    /*
-    * overwritten method from base class
-    * @access	public
-    * @param	integer obj_id
-    * @param	integer array options
-    * @return	string
-    */
+    /**
+     * overwritten method from base class
+     */
     public function formatHeader(ilTemplate $tpl, $a_obj_id, array $a_option) : void
     {
         // custom icons
@@ -277,7 +282,7 @@ class ilECSNodeMappingLocalExplorer extends ilExplorer
         $tpl->setVariable("TXT_ALT_IMG", $title);
         $tpl->parseCurrentBlock();
 
-        if (($formItem = $this->buildFormItem($a_obj_id, $a_option['type'])) !== '') {
+        if (($formItem = $this->buildFormItem((int) $a_obj_id, (int) $a_option['type'])) !== '') {
             $tpl->setCurrentBlock('check');
             $tpl->setVariable('OBJ_CHECK', $formItem);
             $tpl->parseCurrentBlock();
@@ -314,10 +319,10 @@ class ilECSNodeMappingLocalExplorer extends ilExplorer
     {
         $mappings = array();
         foreach (ilECSCourseMappingRule::getRuleRefIds($this->getSid(), $this->getMid()) as $ref_id) {
-            $mappings[$ref_id] = array();
+            $mappings[$ref_id] = [];
         }
         
-        foreach ($mappings as $ref_id) {
+        foreach (array_keys($mappings) as $ref_id) {
             $this->mappings[$ref_id] = $this->tree->getPathId($ref_id, 1);
         }
         return true;

--- a/Services/WebServices/ECS/classes/Setup/ilECSUpdateSteps8.php
+++ b/Services/WebServices/ECS/classes/Setup/ilECSUpdateSteps8.php
@@ -111,4 +111,15 @@ class ilECSUpdateSteps8 implements ilDatabaseUpdateSteps
             );
         }
     }
+
+    public function step_6() : void
+    {
+        if ($this->db->tableColumnExists('ecs_part_settings', 'outgoing_auth_mode')) {
+            $this->db->renameTableColumn(
+                'ecs_part_settings',
+                'outgoing_auth_mode',
+                'outgoing_auth_modes'
+            );
+        }
+    }
 }

--- a/Services/WebServices/ECS/classes/Tree/class.ilECSCmsTreeSynchronizer.php
+++ b/Services/WebServices/ECS/classes/Tree/class.ilECSCmsTreeSynchronizer.php
@@ -26,8 +26,8 @@ class ilECSCmsTreeSynchronizer
     private ilTree $tree;
     
     private ?\ilECSSetting $server = null;
-    private $mid;// TODO PHP8-REVIEW Missing type
-    private $tree_id;// TODO PHP8-REVIEW Missing type
+    private int $mid;
+    private int $tree_id;
     private ?\ilECSCmsTree $ecs_tree = null;
     
     private array $default_settings = array();
@@ -142,7 +142,8 @@ class ilECSCmsTreeSynchronizer
         $import_obj_id = ilECSImportManager::getInstance()->lookupObjIdByContentId(
             $this->server->getServerId(),
             $this->mid,
-            $cms_data->getCmsId()
+            //TODO fix this cast
+            (int) $cms_data->getCmsId()
         );
         if (!$import_obj_id) {
             $this->logger->error('cms tree node not imported. tnode_id: ' . $a_tnode_id);
@@ -219,7 +220,8 @@ class ilECSCmsTreeSynchronizer
         $obj_id = ilECSImportManager::getInstance()->lookupObjIdByContentId(
             $this->server->getServerId(),
             $this->mid,
-            $data->getCmsId()
+            //TODO fix this cast
+            (int) $data->getCmsId()
         );
         if ($obj_id) {
             $refs = ilObject::_getAllReferences($obj_id);

--- a/Services/WebServices/ECS/classes/Tree/class.ilECSCmsTreeSynchronizer.php
+++ b/Services/WebServices/ECS/classes/Tree/class.ilECSCmsTreeSynchronizer.php
@@ -26,8 +26,8 @@ class ilECSCmsTreeSynchronizer
     private ilTree $tree;
     
     private ?\ilECSSetting $server = null;
-    private $mid;
-    private $tree_id;
+    private $mid;// TODO PHP8-REVIEW Missing type
+    private $tree_id;// TODO PHP8-REVIEW Missing type
     private ?\ilECSCmsTree $ecs_tree = null;
     
     private array $default_settings = array();

--- a/Services/WebServices/ECS/classes/Tree/class.ilECSDirectoryTreeConnector.php
+++ b/Services/WebServices/ECS/classes/Tree/class.ilECSDirectoryTreeConnector.php
@@ -24,10 +24,9 @@ class ilECSDirectoryTreeConnector extends ilECSConnector
 {
     /**
      * Get directory tree
-     * @return ilECSResult
      * @throws ilECSConnectorException
      */
-    public function getDirectoryTrees($a_mid = 0) : ?\ilECSResult
+    public function getDirectoryTrees(int $a_mid = 0) : ?\ilECSUriList
     {
         $this->path_postfix = '/campusconnect/directory_trees';
 
@@ -37,7 +36,7 @@ class ilECSDirectoryTreeConnector extends ilECSConnector
             $this->addHeader('Accept', 'text/uri-list');
             $this->addHeader('X-EcsQueryStrings', 'all=true');
             if ($a_mid) {
-                $this->addHeader('X-EcsReceiverMemberships', $a_mid);
+                $this->addHeader('X-EcsReceiverMemberships', (string) $a_mid);
             }
 
             $this->curl->setOpt(CURLOPT_HTTPHEADER, $this->getHeader());

--- a/Services/WebServices/ECS/classes/Tree/class.ilECSTreeReader.php
+++ b/Services/WebServices/ECS/classes/Tree/class.ilECSTreeReader.php
@@ -18,14 +18,13 @@
  * Reads and store cms tree in database
  *
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
- * $Id$
  */
 class ilECSTreeReader
 {
     private ilLogger $logger;
     
-    private $server_id;// TODO PHP8-REVIEW Missing type
-    private $mid;// TODO PHP8-REVIEW Missing type
+    private int $server_id;
+    private int $mid;
 
     /**
      * Constructor

--- a/Services/WebServices/ECS/classes/Tree/class.ilECSTreeReader.php
+++ b/Services/WebServices/ECS/classes/Tree/class.ilECSTreeReader.php
@@ -24,8 +24,8 @@ class ilECSTreeReader
 {
     private ilLogger $logger;
     
-    private $server_id;
-    private $mid;
+    private $server_id;// TODO PHP8-REVIEW Missing type
+    private $mid;// TODO PHP8-REVIEW Missing type
 
     /**
      * Constructor

--- a/Services/WebServices/ECS/classes/class.ilECSCommunityCache.php
+++ b/Services/WebServices/ECS/classes/class.ilECSCommunityCache.php
@@ -19,7 +19,8 @@
 */
 class ilECSCommunityCache
 {
-    protected static $instance;
+    /** @var array<int, array<int, self>>  */
+    protected static array $instance = [];
 
     protected int $server_id = 0;
     protected int $community_id = 0;

--- a/Services/WebServices/ECS/classes/class.ilECSCommunityReader.php
+++ b/Services/WebServices/ECS/classes/class.ilECSCommunityReader.php
@@ -116,10 +116,9 @@ class ilECSCommunityReader
     }
 
     /**
-     * @param int $a_pid
      * @return \ilECSParticipant[]
      */
-    public function getParticipantsByPid($a_pid) : array//TODO PHP8-REVIEW Missing type hints
+    public function getParticipantsByPid(int $a_pid) : array
     {
         $participants = [];
         foreach ($this->getCommunities() as $community) {

--- a/Services/WebServices/ECS/classes/class.ilECSCommunityReader.php
+++ b/Services/WebServices/ECS/classes/class.ilECSCommunityReader.php
@@ -119,7 +119,7 @@ class ilECSCommunityReader
      * @param int $a_pid
      * @return \ilECSParticipant[]
      */
-    public function getParticipantsByPid($a_pid) : array
+    public function getParticipantsByPid($a_pid) : array//TODO PHP8-REVIEW Missing type hints
     {
         $participants = [];
         foreach ($this->getCommunities() as $community) {

--- a/Services/WebServices/ECS/classes/class.ilECSConnector.php
+++ b/Services/WebServices/ECS/classes/class.ilECSConnector.php
@@ -28,7 +28,7 @@ class ilECSConnector
     public const HEADER_COMMUNITIES = 'X-EcsReceiverCommunities';
 
 
-    protected $path_postfix = '';
+    protected string $path_postfix = '';
     
     protected ?ilECSSetting $settings = null;
     protected ?ilCurlConnection $curl = null;

--- a/Services/WebServices/ECS/classes/class.ilECSDataMappingSetting.php
+++ b/Services/WebServices/ECS/classes/class.ilECSDataMappingSetting.php
@@ -27,10 +27,10 @@ class ilECSDataMappingSetting
 
     private int $server_id = 0;
     private int $mapping_type = 0;
-    private $ecs_field = 0;// TODO PHP8-REVIEW Missing type
-    private $advmd_id = 0;// TODO PHP8-REVIEW Missing type
+    private string $ecs_field = '';
+    private int $advmd_id = 0;
 
-    public function __construct($a_server_id = 0, $mapping_type = 0, $ecs_field = '')
+    public function __construct(int $a_server_id = 0, int $mapping_type = 0, string $ecs_field = '')
     {
         global $DIC;
 
@@ -43,9 +43,8 @@ class ilECSDataMappingSetting
 
     /**
      * set server id
-     * @param int $a_server_id
      */
-    public function setServerId($a_server_id) : void//TODO PHP8-REVIEW Missing type hints
+    public function setServerId(int $a_server_id) : void
     {
         $this->server_id = $a_server_id;
     }
@@ -58,11 +57,7 @@ class ilECSDataMappingSetting
         return $this->server_id;
     }
 
-    /**
-     *
-     * @param string $ecs_field
-     */
-    public function setECSField($ecs_field) : void//TODO PHP8-REVIEW Missing type hints
+    public function setECSField(string $ecs_field) : void
     {
         $this->ecs_field = $ecs_field;
     }
@@ -70,7 +65,7 @@ class ilECSDataMappingSetting
     /**
      * Get ecs field
      */
-    public function getECSField() : int
+    public function getECSField() : string
     {
         return $this->ecs_field;
     }
@@ -96,7 +91,7 @@ class ilECSDataMappingSetting
         return $this->advmd_id;
     }
 
-    public function setAdvMDId($a_id) : void
+    public function setAdvMDId(int $a_id) : void
     {
         $this->advmd_id = $a_id;
     }

--- a/Services/WebServices/ECS/classes/class.ilECSDataMappingSetting.php
+++ b/Services/WebServices/ECS/classes/class.ilECSDataMappingSetting.php
@@ -27,8 +27,8 @@ class ilECSDataMappingSetting
 
     private int $server_id = 0;
     private int $mapping_type = 0;
-    private $ecs_field = 0;
-    private $advmd_id = 0;
+    private $ecs_field = 0;// TODO PHP8-REVIEW Missing type
+    private $advmd_id = 0;// TODO PHP8-REVIEW Missing type
 
     public function __construct($a_server_id = 0, $mapping_type = 0, $ecs_field = '')
     {
@@ -45,7 +45,7 @@ class ilECSDataMappingSetting
      * set server id
      * @param int $a_server_id
      */
-    public function setServerId($a_server_id) : void
+    public function setServerId($a_server_id) : void//TODO PHP8-REVIEW Missing type hints
     {
         $this->server_id = $a_server_id;
     }
@@ -62,7 +62,7 @@ class ilECSDataMappingSetting
      *
      * @param string $ecs_field
      */
-    public function setECSField($ecs_field) : void
+    public function setECSField($ecs_field) : void//TODO PHP8-REVIEW Missing type hints
     {
         $this->ecs_field = $ecs_field;
     }

--- a/Services/WebServices/ECS/classes/class.ilECSDataMappingSettings.php
+++ b/Services/WebServices/ECS/classes/class.ilECSDataMappingSettings.php
@@ -27,11 +27,8 @@ class ilECSDataMappingSettings
     private ilDbInterface $db;
     /**
      * Singleton Constructor
-     *
-     * @access private
-     *
      */
-    private function __construct($a_server_id)
+    private function __construct(int $a_server_id)
     {
         global $DIC;
         $this->db = $DIC->database();
@@ -42,10 +39,8 @@ class ilECSDataMappingSettings
 
     /**
      * Get singleton instance
-     * @param int $a_server_id
-     * @return ilECSDataMappingSettings
      */
-    public static function getInstanceByServerId($a_server_id) : ilECSDataMappingSettings//TODO PHP8-REVIEW Missing type hints
+    public static function getInstanceByServerId(int $a_server_id) : ilECSDataMappingSettings
     {
         return self::$instances[$a_server_id] ?? (self::$instances[$a_server_id] = new ilECSDataMappingSettings($a_server_id));
     }

--- a/Services/WebServices/ECS/classes/class.ilECSDataMappingSettings.php
+++ b/Services/WebServices/ECS/classes/class.ilECSDataMappingSettings.php
@@ -45,7 +45,7 @@ class ilECSDataMappingSettings
      * @param int $a_server_id
      * @return ilECSDataMappingSettings
      */
-    public static function getInstanceByServerId($a_server_id) : ilECSDataMappingSettings
+    public static function getInstanceByServerId($a_server_id) : ilECSDataMappingSettings//TODO PHP8-REVIEW Missing type hints
     {
         return self::$instances[$a_server_id] ?? (self::$instances[$a_server_id] = new ilECSDataMappingSettings($a_server_id));
     }

--- a/Services/WebServices/ECS/classes/class.ilECSEContentDetails.php
+++ b/Services/WebServices/ECS/classes/class.ilECSEContentDetails.php
@@ -39,13 +39,8 @@ class ilECSEContentDetails
     
     /**
      * Get data from server
-     *
-     * @param int $a_server_id
-     * @param int $a_econtent_id
-     * @param string $a_resource_type
-     * @return ilECSEContentDetails
      */
-    public static function getInstanceFromServer($a_server_id, $a_econtent_id, $a_resource_type) : ilECSEContentDetails//TODO PHP8-REVIEW Missing type hints
+    public static function getInstanceFromServer(int $a_server_id, int $a_econtent_id, string $a_resource_type) : ilECSEContentDetails
     {
         $instance = new self();
         $instance->loadFromJson($instance->loadFromServer($a_server_id, $a_econtent_id, $a_resource_type));
@@ -53,7 +48,7 @@ class ilECSEContentDetails
     }
 
 
-    private function loadFromServer($a_server_id, $a_econtent_id, $a_resource_type) : ?object
+    private function loadFromServer(int $a_server_id, int $a_econtent_id, string $a_resource_type) : ?object
     {
         try {
             $connector = new ilECSConnector(ilECSSetting::getInstanceByServerId($a_server_id));

--- a/Services/WebServices/ECS/classes/class.ilECSEContentDetails.php
+++ b/Services/WebServices/ECS/classes/class.ilECSEContentDetails.php
@@ -45,7 +45,7 @@ class ilECSEContentDetails
      * @param string $a_resource_type
      * @return ilECSEContentDetails
      */
-    public static function getInstanceFromServer($a_server_id, $a_econtent_id, $a_resource_type) : ilECSEContentDetails
+    public static function getInstanceFromServer($a_server_id, $a_econtent_id, $a_resource_type) : ilECSEContentDetails//TODO PHP8-REVIEW Missing type hints
     {
         $instance = new self();
         $instance->loadFromJson($instance->loadFromServer($a_server_id, $a_econtent_id, $a_resource_type));

--- a/Services/WebServices/ECS/classes/class.ilECSEvent.php
+++ b/Services/WebServices/ECS/classes/class.ilECSEvent.php
@@ -24,18 +24,14 @@ class ilECSEvent
     public const DESTROYED = 'destroyed';
     public const NEW_EXPORT = 'new_export';
 
-    protected $json_obj;// TODO PHP8-REVIEW Missing type
+    protected object $json_obj;
     public string $status = '';
     public string $ressource = '';
     public int $ressource_id = 0;
     public ?string $ressource_type = '';
     
     /**
-     * Constructor
-     *
-     * @access public
      * @param object json object
-     *
      */
     public function __construct($json_obj)
     {

--- a/Services/WebServices/ECS/classes/class.ilECSEvent.php
+++ b/Services/WebServices/ECS/classes/class.ilECSEvent.php
@@ -24,10 +24,10 @@ class ilECSEvent
     public const DESTROYED = 'destroyed';
     public const NEW_EXPORT = 'new_export';
 
-    protected $json_obj;
+    protected $json_obj;// TODO PHP8-REVIEW Missing type
     public string $status = '';
     public string $ressource = '';
-    public $ressource_id = 0;
+    public int $ressource_id = 0;
     public ?string $ressource_type = '';
     
     /**

--- a/Services/WebServices/ECS/classes/class.ilECSEventQueueReader.php
+++ b/Services/WebServices/ECS/classes/class.ilECSEventQueueReader.php
@@ -82,11 +82,11 @@ class ilECSEventQueueReader
      * Get all resource ids by resource type
      *
      * @param ilECSSetting $server
-     * @param array $a_types
+     * @param int[] $a_types
      * @param bool $a_sender_only
-     * @return array type => ids
+     * @return array<int,int[]> type => ids
      */
-    protected static function getAllResourceIds(ilECSSetting $server, array $a_types, bool $a_sender_only = false) : array//TODO PHP8-REVIEW Missing type hints
+    protected static function getAllResourceIds(ilECSSetting $server, array $a_types, bool $a_sender_only = false) : array
     {
         $list = array();
         foreach ($a_types as $type) {

--- a/Services/WebServices/ECS/classes/class.ilECSEventQueueReader.php
+++ b/Services/WebServices/ECS/classes/class.ilECSEventQueueReader.php
@@ -86,7 +86,7 @@ class ilECSEventQueueReader
      * @param bool $a_sender_only
      * @return array type => ids
      */
-    protected static function getAllResourceIds(ilECSSetting $server, array $a_types, $a_sender_only = false) : array
+    protected static function getAllResourceIds(ilECSSetting $server, array $a_types, bool $a_sender_only = false) : array//TODO PHP8-REVIEW Missing type hints
     {
         $list = array();
         foreach ($a_types as $type) {

--- a/Services/WebServices/ECS/classes/class.ilECSImport.php
+++ b/Services/WebServices/ECS/classes/class.ilECSImport.php
@@ -55,11 +55,8 @@ class ilECSImport
     
     /**
      * Set imported
-     *
-     * @param bool $a_status import status
-     *
      */
-    public function setImported($a_status) : void//TODO PHP8-REVIEW Missing type hints
+    public function setImported(bool $a_status) : void
     {
         $this->imported = $a_status;
     }

--- a/Services/WebServices/ECS/classes/class.ilECSImport.php
+++ b/Services/WebServices/ECS/classes/class.ilECSImport.php
@@ -59,7 +59,7 @@ class ilECSImport
      * @param bool $a_status import status
      *
      */
-    public function setImported($a_status) : void
+    public function setImported($a_status) : void//TODO PHP8-REVIEW Missing type hints
     {
         $this->imported = $a_status;
     }

--- a/Services/WebServices/ECS/classes/class.ilECSImportManager.php
+++ b/Services/WebServices/ECS/classes/class.ilECSImportManager.php
@@ -66,7 +66,7 @@ class ilECSImportManager
     /**
      * Lookup obj_id by content id
      */
-    public function lookupObjIdByContentId($a_server_id, $a_mid, $a_content_id, $a_sub_id = null) : int // TODO PHP8-REVIEW Missing type hints
+    public function lookupObjIdByContentId(int $a_server_id, int $a_mid, int $a_content_id, string $a_sub_id = null) : int
     {
         $query = "SELECT obj_id FROM ecs_import " .
             "WHERE content_id = " . $this->db->quote($a_content_id, 'integer') . " " .
@@ -200,11 +200,8 @@ class ilECSImportManager
 
     /**
      * loogup obj_id by econtent and mid and server_id
-     *
-     * @param int econtent_id
-     *
      */
-    public function _lookupObjId($a_server_id, $a_econtent_id, $a_mid, $a_sub_id = null) : int// TODO PHP8-REVIEW Missing type hints
+    public function _lookupObjId(int $a_server_id, string $a_econtent_id, int $a_mid, ?string $a_sub_id = null) : int
     {
         $query = "SELECT obj_id FROM ecs_import " .
             "WHERE econtent_id = " . $this->db->quote($a_econtent_id, 'text') . " " .
@@ -228,9 +225,9 @@ class ilECSImportManager
      * Lookup mid
      *
      */
-    public function _lookupMID($a_server_id, $a_obj_id) : int// TODO PHP8-REVIEW Missing type hints
+    public function _lookupMID(int $a_server_id, int $a_obj_id) : int
     {
-        $query = "SELECT * FROM ecs_emport WHERE obj_id = " . $this->db->quote($a_obj_id) . " " .
+        $query = "SELECT * FROM ecs_import WHERE obj_id = " . $this->db->quote($a_obj_id) . " " .
             'AND server_id = ' . $this->db->quote($a_server_id, 'integer');
         $res = $this->db->query($query);
         if ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
@@ -271,9 +268,8 @@ class ilECSImportManager
 
     /**
      * Delete by server id
-     * @param int $a_server_id
      */
-    public function deleteByServer($a_server_id) : void//TODO PHP8-REVIEW Missing type hints
+    public function deleteByServer(int $a_server_id) : void
     {
         $query = 'DELETE FROM ecs_import ' .
             'WHERE server_id = ' . $this->db->quote($a_server_id, 'integer');
@@ -282,24 +278,23 @@ class ilECSImportManager
 
     /**
      * Delete ressources
+     *
+     * @param string[] $a_econtent_ids
      */
-    public function deleteRessources($a_server_id, $a_mid, $a_econtent_ids) : bool
+    public function deleteRessources(int $a_server_id, int $a_mid, array $a_econtent_ids) : bool
     {
         $query = 'DELETE FROM ecs_import ' .
                 'WHERE server_id = ' . $this->db->quote($a_server_id, 'integer') . ' ' .
                 'AND mid = ' . $this->db->quote($a_mid, 'integer') . ' ' .
-                'AND ' . $this->db->in('econtent_id', (array) $a_econtent_ids, false, 'text');
+                'AND ' . $this->db->in('econtent_id', $a_econtent_ids, false, 'text');
         $this->db->manipulate($query);
         return true;
     }
 
     /**
      * check if econtent is imported for a specific mid
-     *
-     * @param int econtent id
-     * @param int mid
      */
-    public function _isImported($a_server_id, $a_econtent_id, $a_mid, $a_sub_id = null) : int // TODO PHP8-REVIEW Missing type hints
+    public function _isImported(int $a_server_id, string $a_econtent_id, int $a_mid, ?string $a_sub_id = null) : int
     {
         return $this->_lookupObjId($a_server_id, $a_econtent_id, $a_mid, $a_sub_id);
     }

--- a/Services/WebServices/ECS/classes/class.ilECSImportManager.php
+++ b/Services/WebServices/ECS/classes/class.ilECSImportManager.php
@@ -66,7 +66,7 @@ class ilECSImportManager
     /**
      * Lookup obj_id by content id
      */
-    public function lookupObjIdByContentId($a_server_id, $a_mid, $a_content_id, $a_sub_id = null)
+    public function lookupObjIdByContentId($a_server_id, $a_mid, $a_content_id, $a_sub_id = null) : int // TODO PHP8-REVIEW Missing type hints
     {
         $query = "SELECT obj_id FROM ecs_import " .
             "WHERE content_id = " . $this->db->quote($a_content_id, 'integer') . " " .
@@ -81,7 +81,7 @@ class ilECSImportManager
         $res = $this->db->query($query);
 
         if ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            return $row->obj_id;
+            return (int) $row->obj_id;
         }
         return 0;
     }
@@ -204,7 +204,7 @@ class ilECSImportManager
      * @param int econtent_id
      *
      */
-    public function _lookupObjId($a_server_id, $a_econtent_id, $a_mid, $a_sub_id = null)
+    public function _lookupObjId($a_server_id, $a_econtent_id, $a_mid, $a_sub_id = null) : int// TODO PHP8-REVIEW Missing type hints
     {
         $query = "SELECT obj_id FROM ecs_import " .
             "WHERE econtent_id = " . $this->db->quote($a_econtent_id, 'text') . " " .
@@ -219,7 +219,7 @@ class ilECSImportManager
         $res = $this->db->query($query);
 
         if ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            return $row->obj_id;
+            return (int) $row->obj_id;
         }
         return 0;
     }
@@ -228,13 +228,13 @@ class ilECSImportManager
      * Lookup mid
      *
      */
-    public function _lookupMID($a_server_id, $a_obj_id)
+    public function _lookupMID($a_server_id, $a_obj_id) : int// TODO PHP8-REVIEW Missing type hints
     {
         $query = "SELECT * FROM ecs_emport WHERE obj_id = " . $this->db->quote($a_obj_id) . " " .
             'AND server_id = ' . $this->db->quote($a_server_id, 'integer');
         $res = $this->db->query($query);
         if ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            return $row->mid;
+            return (int) $row->mid;
         }
         return 0;
     }
@@ -273,7 +273,7 @@ class ilECSImportManager
      * Delete by server id
      * @param int $a_server_id
      */
-    public function deleteByServer($a_server_id) : void
+    public function deleteByServer($a_server_id) : void//TODO PHP8-REVIEW Missing type hints
     {
         $query = 'DELETE FROM ecs_import ' .
             'WHERE server_id = ' . $this->db->quote($a_server_id, 'integer');
@@ -299,7 +299,7 @@ class ilECSImportManager
      * @param int econtent id
      * @param int mid
      */
-    public function _isImported($a_server_id, $a_econtent_id, $a_mid, $a_sub_id = null)
+    public function _isImported($a_server_id, $a_econtent_id, $a_mid, $a_sub_id = null) : int // TODO PHP8-REVIEW Missing type hints
     {
         return $this->_lookupObjId($a_server_id, $a_econtent_id, $a_mid, $a_sub_id);
     }

--- a/Services/WebServices/ECS/classes/class.ilECSObjectSettings.php
+++ b/Services/WebServices/ECS/classes/class.ilECSObjectSettings.php
@@ -407,7 +407,6 @@ abstract class ilECSObjectSettings
      * Objects that are moved to the trash call ECS-Remove
      *
      * @see ilRepUtil
-     * @param array $a_subbtree_nodes
      */
     public static function _handleDelete(array $a_subbtree_nodes) : void
     {
@@ -531,7 +530,6 @@ abstract class ilECSObjectSettings
     
     /**
      * Handle permission update
-     * @param ilECSSetting $server
      */
     protected function handlePermissionUpdate(ilECSSetting $server) : void
     {
@@ -550,11 +548,8 @@ abstract class ilECSObjectSettings
     
     /**
      * Build core json structure
-     *
-     * @param string $a_etype
-     * @return object
      */
-    protected function getJsonCore($a_etype)//TODO PHP8-REVIEW Missing type hints
+    protected function getJsonCore(string $a_etype) : object
     {
         $json = new stdClass();
         $json->lang = 'en_EN'; // :TODO: obsolet?
@@ -570,12 +565,8 @@ abstract class ilECSObjectSettings
     
     /**
      * Add advanced metadata to json (export)
-     *
-     * @param object $a_json
-     * @param ilECSSetting $a_server
-     * @param array $a_definition
      */
-    protected function addMetadataToJson($a_json, ilECSSetting $a_server, array $a_definition) : void//TODO PHP8-REVIEW Missing type hints
+    protected function addMetadataToJson(object $a_json, ilECSSetting $a_server, array $a_definition) : void
     {
         $mappings = ilECSDataMappingSettings::getInstanceByServerId($a_server->getServerId());
         
@@ -618,7 +609,6 @@ abstract class ilECSObjectSettings
     /**
      * Build resource-specific json
      *
-     * @param ilECSSetting $a_server
      * @return mixed
      */
     abstract protected function buildJson(ilECSSetting $a_server);

--- a/Services/WebServices/ECS/classes/class.ilECSObjectSettings.php
+++ b/Services/WebServices/ECS/classes/class.ilECSObjectSettings.php
@@ -554,7 +554,7 @@ abstract class ilECSObjectSettings
      * @param string $a_etype
      * @return object
      */
-    protected function getJsonCore($a_etype)
+    protected function getJsonCore($a_etype)//TODO PHP8-REVIEW Missing type hints
     {
         $json = new stdClass();
         $json->lang = 'en_EN'; // :TODO: obsolet?
@@ -575,7 +575,7 @@ abstract class ilECSObjectSettings
      * @param ilECSSetting $a_server
      * @param array $a_definition
      */
-    protected function addMetadataToJson($a_json, ilECSSetting $a_server, array $a_definition) : void
+    protected function addMetadataToJson($a_json, ilECSSetting $a_server, array $a_definition) : void//TODO PHP8-REVIEW Missing type hints
     {
         $mappings = ilECSDataMappingSettings::getInstanceByServerId($a_server->getServerId());
         

--- a/Services/WebServices/ECS/classes/class.ilECSParticipantSetting.php
+++ b/Services/WebServices/ECS/classes/class.ilECSParticipantSetting.php
@@ -213,7 +213,7 @@ class ilECSParticipantSetting
         return $this->incoming_local_accounts;
     }
 
-    public function enableIncomingLocalAccounts(bool $a_status)
+    public function enableIncomingLocalAccounts(bool $a_status) : void
     {
         $this->incoming_local_accounts = $a_status;
     }
@@ -238,7 +238,10 @@ class ilECSParticipantSetting
         return $this->outgoing_auth_modes;
     }
 
-    public function getOutgoingExternalAuthModes()
+    /**
+     * @return string[]
+     */
+    public function getOutgoingExternalAuthModes() : array
     {
         return array_filter(
             $this->getOutgoingAuthModes(),
@@ -331,7 +334,7 @@ class ilECSParticipantSetting
     private function create() : bool
     {
         $query = 'INSERT INTO ecs_part_settings ' .
-            '(sid,mid,export,import,import_type,title,cname,token,dtoken,export_types, import_types) ' .
+            '(sid,mid,export,import,import_type,title,cname,token,dtoken,export_types, import_types, username_placeholders, incoming_auth_type, incoming_local_accounts, outgoing_auth_modes) ' .
             'VALUES( ' .
             $this->db->quote($this->getServerId(), 'integer') . ', ' .
             $this->db->quote($this->getMid(), 'integer') . ', ' .

--- a/Services/WebServices/ECS/classes/class.ilECSParticipantSettings.php
+++ b/Services/WebServices/ECS/classes/class.ilECSParticipantSettings.php
@@ -60,7 +60,7 @@ class ilECSParticipantSettings
         
         $mids = array();
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $mids[] = $row->mid;
+            $mids[] = (int) $row->mid;
         }
         return $mids;
     }

--- a/Services/WebServices/ECS/classes/class.ilECSParticipantSettings.php
+++ b/Services/WebServices/ECS/classes/class.ilECSParticipantSettings.php
@@ -70,14 +70,14 @@ class ilECSParticipantSettings
     /**
      * Lookup mid of current cms participant
      */
-    public function lookupCmsMid()
+    public function lookupCmsMid() : int
     {
         $query = 'SELECT mid FROM ecs_part_settings ' .
                 'WHERE sid = ' . $this->db->quote($this->server_id, 'integer') . ' ' .
                 'AND import_type = ' . $this->db->quote(ilECSParticipantSetting::IMPORT_CMS);
         $res = $this->db->query($query);
         if ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            return $row->mid;
+            return (int) $row->mid;
         }
         return 0;
     }

--- a/Services/WebServices/ECS/classes/class.ilECSRemoteUserRepository.php
+++ b/Services/WebServices/ECS/classes/class.ilECSRemoteUserRepository.php
@@ -150,6 +150,5 @@ class ilECSRemoteUserRepository
             return $this->getECSRemoteUserById($row->eru_id);
         }
         return null;
-
     }
 }

--- a/Services/WebServices/ECS/classes/class.ilECSSetting.php
+++ b/Services/WebServices/ECS/classes/class.ilECSSetting.php
@@ -36,25 +36,23 @@ class ilECSSetting
     public const PROTOCOL_HTTPS = 1;
     
     protected static ?array $instances = null;
-    protected static $configured;// TODO PHP8-REVIEW Missing type
 
-    private $server_id;// TODO PHP8-REVIEW Missing type
+    private int $server_id;
     private bool $active = false;
     private string $title = '';
     private int $auth_type = self::AUTH_CERTIFICATE;
-    private $server;// TODO PHP8-REVIEW Missing type
-    private $protocol;// TODO PHP8-REVIEW Missing type
-    private $port;// TODO PHP8-REVIEW Missing type
-    private $client_cert_path;// TODO PHP8-REVIEW Missing type
-    private $ca_cert_path;// TODO PHP8-REVIEW Missing type
-    private $cert_serial_number;// TODO PHP8-REVIEW Missing type
-    private $key_path;// TODO PHP8-REVIEW Missing type
-    private $key_password;// TODO PHP8-REVIEW Missing type
-    private $polling;// TODO PHP8-REVIEW Missing type
+    private string $server = '';
+    private int $protocol = self::PROTOCOL_HTTPS;
+    private int $port = 0;
+    private string $client_cert_path = '';
+    private string $ca_cert_path = '';
+    private ?string $cert_serial_number = '';
+    private string $key_path = '';
+    private string $key_password = '';
+    private int $polling = 0;
     private int $import_id = 0;
-    private $cert_serial;// TODO PHP8-REVIEW Missing type
-    private $global_role;// TODO PHP8-REVIEW Missing type
-    private int $duration;
+    private int $global_role = 0;
+    private int $duration = 0;
 
     private string $auth_user = '';
     private string $auth_pass = '';
@@ -105,7 +103,6 @@ class ilECSSetting
     /**
      * Checks if an ecs server is configured
      * @deprecated use ilECSServerSettings::getInstance()->serverExists()
-     * @return boolean
      */
     public static function ecsConfigured() : bool
     {
@@ -114,9 +111,8 @@ class ilECSSetting
 
     /**
      * Set title
-     * @param string $a_title
      */
-    public function setTitle($a_title) : void//TODO PHP8-REVIEW Missing type hints
+    public function setTitle(string $a_title) : void
     {
         $this->title = $a_title;
     }
@@ -197,7 +193,6 @@ class ilECSSetting
     
     /**
      * is enabled
-     *
      */
     public function isEnabled() : bool
     {
@@ -207,7 +202,7 @@ class ilECSSetting
     /**
      * set server
      */
-    public function setServer($a_server) : void
+    public function setServer(string $a_server) : void
     {
         $this->server = $a_server;
     }
@@ -215,7 +210,7 @@ class ilECSSetting
     /**
      * get server
      */
-    public function getServer()
+    public function getServer() : string
     {
         return $this->server;
     }
@@ -258,42 +253,31 @@ class ilECSSetting
     /**
      * set protocol
      */
-    public function setProtocol($a_prot) : void
+    public function setProtocol(int $a_prot) : void
     {
         $this->protocol = $a_prot;
     }
 
     /**
      * get protocol
-     *
-     * @access public
-     *
      */
-    public function getProtocol()
+    public function getProtocol() : int
     {
         return $this->protocol;
     }
     
     /**
      * set port
-     *
-     * @access public
-     * @param int port
-     *
      */
-    public function setPort($a_port) : void
+    public function setPort(int $a_port) : void
     {
         $this->port = $a_port;
     }
     
     /**
      * get port
-     *
-     * @access public
-     * @param
-     *
      */
-    public function getPort()
+    public function getPort() : int
     {
         return $this->port;
     }
@@ -305,10 +289,8 @@ class ilECSSetting
 
     /**
      * get certificate path
-     *
-     * @access public
      */
-    public function getClientCertPath()
+    public function getClientCertPath() : string
     {
         return $this->client_cert_path;
     }
@@ -316,33 +298,25 @@ class ilECSSetting
     /**
      * set ca cert path
      *
-     * @access public
      * @param string ca cert path
-     *
      */
-    public function setCACertPath($a_ca) : void
+    public function setCACertPath(string $a_ca) : void
     {
         $this->ca_cert_path = $a_ca;
     }
     
     /**
      * get ca cert path
-     *
-     * @access public
-     *
      */
-    public function getCACertPath()
+    public function getCACertPath() : string
     {
         return $this->ca_cert_path;
     }
     
     /**
      * get key path
-     *
-     * @access public
-     *
      */
-    public function getKeyPath()
+    public function getKeyPath() : string
     {
         return $this->key_path;
     }
@@ -350,22 +324,17 @@ class ilECSSetting
     /**
      * set key path
      *
-     * @access public
      * @param string key path
-     *
      */
-    public function setKeyPath($a_path) : void
+    public function setKeyPath(string $a_path) : void
     {
         $this->key_path = $a_path;
     }
     
     /**
      * get key password
-     *
-     * @access public
-     *
      */
-    public function getKeyPassword()
+    public function getKeyPassword() : string
     {
         return $this->key_password;
     }
@@ -373,11 +342,9 @@ class ilECSSetting
     /**
      * set key password
      *
-     * @access public
      * @param string key password
-     *
      */
-    public function setKeyPassword($a_pass) : void
+    public function setKeyPassword(string $a_pass) : void
     {
         $this->key_password = $a_pass;
     }
@@ -401,55 +368,38 @@ class ilECSSetting
     
     /**
      * set cert serial number
-     *
-     * @access public
-     * @param
-     *
      */
-    public function setCertSerialNumber($a_cert_serial) : void
+    public function setCertSerialNumber(string $a_cert_serial) : void
     {
         $this->cert_serial_number = $a_cert_serial;
     }
     
     /**
      * get cert serial number
-     *
-     * @access public
-     *
      */
-    public function getCertSerialNumber()
+    public function getCertSerialNumber() : ?string
     {
         return $this->cert_serial_number;
     }
     
     /**
      * get global role
-     *
-     * @access public
-     *
      */
-    public function getGlobalRole()
+    public function getGlobalRole() : int
     {
         return $this->global_role;
     }
     
     /**
      * set default global role
-     *
-     * @access public
-     *
-     * @param int role_id
      */
-    public function setGlobalRole($a_role_id) : void
+    public function setGlobalRole(int $a_role_id) : void
     {
         $this->global_role = $a_role_id;
     }
     
     /**
      * set Duration
-     *
-     * @param int duration
-     *
      */
     public function setDuration(int $a_duration) : void
     {
@@ -458,9 +408,6 @@ class ilECSSetting
     
     /**
      * get duration
-     *
-     * @access public
-     *
      */
     public function getDuration() : int
     {
@@ -469,9 +416,6 @@ class ilECSSetting
     
     /**
      * Get new user recipients
-     *
-     * @access public
-     *
      */
     public function getUserRecipients() : array
     {
@@ -516,9 +460,7 @@ class ilECSSetting
     /**
      * set EContent recipients
      *
-     * @access public
      * @param array of user obj_ids
-     *
      */
     public function setEContentRecipients(array $a_logins) : void
     {
@@ -622,7 +564,7 @@ class ilECSSetting
             $this->db->quote($this->getServerId(), 'integer') . ', ' .
             $this->db->quote((int) $this->isEnabled(), 'integer') . ', ' .
             $this->db->quote($this->getTitle(), 'text') . ', ' .
-            $this->db->quote((int) $this->getProtocol(), 'integer') . ', ' .
+            $this->db->quote($this->getProtocol(), 'integer') . ', ' .
             $this->db->quote($this->getServer(), 'text') . ', ' .
             $this->db->quote($this->getPort(), 'integer') . ', ' .
             $this->db->quote($this->getAuthType(), 'integer') . ', ' .
@@ -653,7 +595,7 @@ class ilECSSetting
             'server_id = ' . $this->db->quote($this->getServerId(), 'integer') . ', ' .
             'active = ' . $this->db->quote((int) $this->isEnabled(), 'integer') . ', ' .
             'title = ' . $this->db->quote($this->getTitle(), 'text') . ', ' .
-            'protocol = ' . $this->db->quote((int) $this->getProtocol(), 'integer') . ', ' .
+            'protocol = ' . $this->db->quote($this->getProtocol(), 'integer') . ', ' .
             'server = ' . $this->db->quote($this->getServer(), 'text') . ', ' .
             'port = ' . $this->db->quote($this->getPort(), 'integer') . ', ' .
             'auth_type = ' . $this->db->quote($this->getAuthType(), 'integer') . ', ' .
@@ -709,7 +651,7 @@ class ilECSSetting
             'WHERE server_id = ' . $this->db->quote($this->getServerId(), 'integer')
         );
         
-        $this->server_id = null;
+        $this->server_id = 0;
         return true;
     }
 
@@ -754,7 +696,7 @@ class ilECSSetting
             if (strpos($line, 'Serial Number:') !== false) {
                 $found = true;
                 $serial_line = explode(':', $line);
-                $serial = (int) trim($serial_line[1]);
+                $serial = trim($serial_line[1]);
                 break;
             }
         }
@@ -780,16 +722,18 @@ class ilECSSetting
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_ASSOC)) {
             $this->setServer($row['server']);
             $this->setTitle($row['title']);
-            $this->setProtocol($row['protocol']);
-            $this->setPort($row['port']);
+            $this->setProtocol((int) $row['protocol']);
+            $this->setPort((int) $row['port']);
             $this->setClientCertPath($row['client_cert_path']);
             $this->setCACertPath($row['ca_cert_path']);
             $this->setKeyPath($row['key_path']);
             $this->setKeyPassword($row['key_password']);
             $this->setImportId((int) $row['import_id']);
             $this->setEnabledStatus((bool) $row['active']);
-            $this->setCertSerialNumber($row['cert_serial']);
-            $this->setGlobalRole($row['global_role']);
+            if ($row['cert_serial']) {
+                $this->setCertSerialNumber($row['cert_serial']);
+            }
+            $this->setGlobalRole((int) $row['global_role']);
             $this->econtent_recipients = explode(',', $row['econtent_rcp']);
             $this->approval_recipients = explode(',', $row['approval_rcp']);
             $this->user_recipients = explode(',', $row['user_rcp']);

--- a/Services/WebServices/ECS/classes/class.ilECSSetting.php
+++ b/Services/WebServices/ECS/classes/class.ilECSSetting.php
@@ -36,32 +36,32 @@ class ilECSSetting
     public const PROTOCOL_HTTPS = 1;
     
     protected static ?array $instances = null;
-    protected static $configured;
+    protected static $configured;// TODO PHP8-REVIEW Missing type
 
-    private $server_id;
+    private $server_id;// TODO PHP8-REVIEW Missing type
     private bool $active = false;
     private string $title = '';
     private int $auth_type = self::AUTH_CERTIFICATE;
-    private $server;
-    private $protocol;
-    private $port;
-    private $client_cert_path;
-    private $ca_cert_path;
-    private $cert_serial_number;
-    private $key_path;
-    private $key_password;
-    private $polling;
+    private $server;// TODO PHP8-REVIEW Missing type
+    private $protocol;// TODO PHP8-REVIEW Missing type
+    private $port;// TODO PHP8-REVIEW Missing type
+    private $client_cert_path;// TODO PHP8-REVIEW Missing type
+    private $ca_cert_path;// TODO PHP8-REVIEW Missing type
+    private $cert_serial_number;// TODO PHP8-REVIEW Missing type
+    private $key_path;// TODO PHP8-REVIEW Missing type
+    private $key_password;// TODO PHP8-REVIEW Missing type
+    private $polling;// TODO PHP8-REVIEW Missing type
     private int $import_id = 0;
-    private $cert_serial;
-    private $global_role;
+    private $cert_serial;// TODO PHP8-REVIEW Missing type
+    private $global_role;// TODO PHP8-REVIEW Missing type
     private int $duration;
 
     private string $auth_user = '';
     private string $auth_pass = '';
     
-    private $user_recipients = array();
-    private array $econtent_recipients = array();
-    private $approval_recipients = array();
+    private array $user_recipients = [];
+    private array $econtent_recipients = [];
+    private array $approval_recipients = [];
     
     private ilDBInterface $db;
     private ilLogger $log;
@@ -116,7 +116,7 @@ class ilECSSetting
      * Set title
      * @param string $a_title
      */
-    public function setTitle($a_title) : void
+    public function setTitle($a_title) : void//TODO PHP8-REVIEW Missing type hints
     {
         $this->title = $a_title;
     }

--- a/Services/WebServices/ECS/classes/class.ilECSSettingsGUI.php
+++ b/Services/WebServices/ECS/classes/class.ilECSSettingsGUI.php
@@ -634,7 +634,7 @@ class ilECSSettingsGUI
      * Validate import types
      * @param array $import_types
      */
-    protected function validateImportTypes(&$import_types) : bool
+    protected function validateImportTypes(&$import_types) : bool//TODO PHP8-REVIEW Missing type hints
     {
         $num_cms = 0;
         foreach ((array) $import_types as $sid => $server) {
@@ -731,7 +731,7 @@ class ilECSSettingsGUI
      * Handle tabs for ECS data mapping
      * @param int $a_active
      */
-    protected function setMappingTabs($a_active) : void
+    protected function setMappingTabs($a_active) : void//TODO PHP8-REVIEW Missing type hints
     {
         $this->tabs_gui->clearTargets();
         $this->tabs_gui->clearSubTabs();
@@ -907,7 +907,7 @@ class ilECSSettingsGUI
      * @param int $a_server_id
      * @param int $mapping_type
      */
-    protected function initMappingsForm($a_server_id, $mapping_type) : ilPropertyFormGUI
+    protected function initMappingsForm($a_server_id, $mapping_type) : ilPropertyFormGUI//TODO PHP8-REVIEW Missing type hints
     {
         $mapping_settings = ilECSDataMappingSettings::getInstanceByServerId($a_server_id);
             

--- a/Services/WebServices/ECS/classes/class.ilECSUser.php
+++ b/Services/WebServices/ECS/classes/class.ilECSUser.php
@@ -137,9 +137,9 @@ class ilECSUser
         $this->email = ilUtil::stripSlashes(urldecode($this->source['ecs_email']));
         $this->institution = ilUtil::stripSlashes(urldecode($this->source['ecs_institution']));
         
-        if ($_GET['ecs_uid_hash']) {
+        if ($this->source['ecs_uid_hash']) {
             $this->uid_hash = ilUtil::stripSlashes(urldecode($this->source['ecs_uid_hash']));
-        } elseif ($_GET['ecs_uid']) {
+        } elseif ($this->source['ecs_uid']) {
             $this->uid_hash = ilUtil::stripSlashes(urldecode($this->source['ecs_uid']));
         }
     }

--- a/Services/WebServices/ECS/classes/class.ilECSUser.php
+++ b/Services/WebServices/ECS/classes/class.ilECSUser.php
@@ -23,14 +23,14 @@ class ilECSUser
 {
     private ilSetting $setting;
 
-    protected $source;
+    protected $source;// TODO PHP8-REVIEW Missing type
     
-    public $login;
-    public $email;
-    public $firstname;
-    public $lastname;
-    public $institution;
-    public $uid_hash;
+    public $login;// TODO PHP8-REVIEW Missing type
+    public $email;// TODO PHP8-REVIEW Missing type
+    public $firstname;// TODO PHP8-REVIEW Missing type
+    public $lastname;// TODO PHP8-REVIEW Missing type
+    public $institution;// TODO PHP8-REVIEW Missing type
+    public $uid_hash;// TODO PHP8-REVIEW Missing type
 
     protected string $external_account = '';
     protected string $auth_mode = '';

--- a/Services/WebServices/ECS/classes/class.ilECSUtils.php
+++ b/Services/WebServices/ECS/classes/class.ilECSUtils.php
@@ -125,13 +125,8 @@ class ilECSUtils
     
     /**
      * Convert ECS content to rule matchable values
-     *
-     * @param string $a_resource_id
-     * @param int $a_server_id
-     * @param object $a_ecs_content
-     * @param int $a_owner
      */
-    public static function getMatchableContent($a_resource_id, $a_server_id, $a_ecs_content, $a_owner) : array//TODO PHP8-REVIEW Missing type hints
+    public static function getMatchableContent(string $a_resource_id, int $a_server_id, object $a_ecs_content, int $a_owner) : array
     {
         // see ilECSCategoryMapping::getPossibleFields();
         $res = array();

--- a/Services/WebServices/ECS/classes/class.ilECSUtils.php
+++ b/Services/WebServices/ECS/classes/class.ilECSUtils.php
@@ -131,7 +131,7 @@ class ilECSUtils
      * @param object $a_ecs_content
      * @param int $a_owner
      */
-    public static function getMatchableContent($a_resource_id, $a_server_id, $a_ecs_content, $a_owner) : array
+    public static function getMatchableContent($a_resource_id, $a_server_id, $a_ecs_content, $a_owner) : array//TODO PHP8-REVIEW Missing type hints
     {
         // see ilECSCategoryMapping::getPossibleFields();
         $res = array();

--- a/Services/WebServices/ECS/classes/class.ilRemoteObjectBase.php
+++ b/Services/WebServices/ECS/classes/class.ilRemoteObjectBase.php
@@ -185,9 +185,9 @@ abstract class ilRemoteObjectBase extends ilObject2
     {
         $server_id = ilECSImportManager::getInstance()->lookupServerId($this->getId());
         $server = ilECSSetting::getInstanceByServerId($server_id);
-        
+        $setting = ilECSParticipantSetting::getInstance($server_id, $this->mid);
         $user = new ilECSUser($this->user);
-        $ecs_user_data = $user->toGET();
+        $ecs_user_data = $user->toGET($setting);
         $this->logger->info(__METHOD__ . ': Using ecs user data ' . $ecs_user_data);
         
         // check token mechanism enabled
@@ -354,11 +354,9 @@ abstract class ilRemoteObjectBase extends ilObject2
     /**
      * update remote object settings from ecs content
      *
-     * @param ilECSSetting $a_server
      * @param object $a_ecs_content object with object settings
-     * @param int $a_owner
      */
-    public function updateFromECSContent(ilECSSetting $a_server, $a_ecs_content, $a_owner) : void//TODO PHP8-REVIEW Missing type hints
+    public function updateFromECSContent(ilECSSetting $a_server, object $a_ecs_content, int $a_owner) : void
     {
         $this->logger->info('updateFromECSContent: ' . print_r($a_ecs_content, true));
         
@@ -402,12 +400,8 @@ abstract class ilRemoteObjectBase extends ilObject2
     /**
      * Add advanced metadata to json (export)
      *
-     * @param object $a_json
-     * @param ilECSSetting $a_server
-     * @param array $a_definition
-     * @param int $a_mapping_mode
      */
-    protected function importMetadataFromJson($a_json, ilECSSetting $a_server, array $a_definition, $a_mapping_mode) : void//TODO PHP8-REVIEW Missing type hints
+    protected function importMetadataFromJson(object $a_json, ilECSSetting $a_server, array $a_definition, int $a_mapping_mode) : void
     {
         $this->logger->info("importing metadata from json: " . print_r($a_json, true));
         

--- a/Services/WebServices/ECS/classes/class.ilRemoteObjectBase.php
+++ b/Services/WebServices/ECS/classes/class.ilRemoteObjectBase.php
@@ -25,7 +25,7 @@ abstract class ilRemoteObjectBase extends ilObject2
     protected ?string $remote_link = null;
     protected ?string $organization = null;
     protected ?int $mid = null;
-    protected $auth_hash = '';
+    protected string $auth_hash = '';
     
     protected string $realm_plain = '';
     
@@ -234,12 +234,8 @@ abstract class ilRemoteObjectBase extends ilObject2
             return false;
         }
     }
-    
-    /**
-     * Create remote object
-     *
-     * @param bool $clone_mode*/
-    protected function doCreate(bool $clone_mode = false,bool $a_clone_mode = false) : void
+
+    protected function doCreate(bool $clone_mode = false) : void
     {
         $fields = array(
             "obj_id" => array("integer", $this->getId()),
@@ -299,10 +295,7 @@ abstract class ilRemoteObjectBase extends ilObject2
             " WHERE obj_id = " . $this->db->quote($this->getId(), 'integer') . " ";
         $this->db->manipulate($query);
     }
-    
-    /**
-     * read settings
-     */
+
     protected function doRead() : void
     {
         $query = "SELECT * FROM " . $this->getTableName() .
@@ -365,7 +358,7 @@ abstract class ilRemoteObjectBase extends ilObject2
      * @param object $a_ecs_content object with object settings
      * @param int $a_owner
      */
-    public function updateFromECSContent(ilECSSetting $a_server, $a_ecs_content, $a_owner) : void
+    public function updateFromECSContent(ilECSSetting $a_server, $a_ecs_content, $a_owner) : void//TODO PHP8-REVIEW Missing type hints
     {
         $this->logger->info('updateFromECSContent: ' . print_r($a_ecs_content, true));
         
@@ -414,7 +407,7 @@ abstract class ilRemoteObjectBase extends ilObject2
      * @param array $a_definition
      * @param int $a_mapping_mode
      */
-    protected function importMetadataFromJson($a_json, ilECSSetting $a_server, array $a_definition, $a_mapping_mode) : void
+    protected function importMetadataFromJson($a_json, ilECSSetting $a_server, array $a_definition, $a_mapping_mode) : void//TODO PHP8-REVIEW Missing type hints
     {
         $this->logger->info("importing metadata from json: " . print_r($a_json, true));
         

--- a/Services/WebServices/ECS/classes/class.ilRemoteObjectBaseGUI.php
+++ b/Services/WebServices/ECS/classes/class.ilRemoteObjectBaseGUI.php
@@ -162,11 +162,12 @@ abstract class ilRemoteObjectBaseGUI extends ilObject2GUI
     {
         if (!$this->access->checkAccess("visible", "", $this->object->getRefId())) {
             $this->error->raiseError(
-                $this->lng->txt('msg_no_perm_read'), $this->error->MESSAGE
+                $this->lng->txt('msg_no_perm_read'),
+                $this->error->MESSAGE
             );
         }
 
-        $this->ctrl->setReturn($this,'call');
+        $this->ctrl->setReturn($this, 'call');
         $consent_gui = new ilECSUserConsentModalGUI(
             $this->user->getId(),
             $this->ref_id,
@@ -303,8 +304,8 @@ abstract class ilRemoteObjectBaseGUI extends ilObject2GUI
                 $this->getType(),
                 $this->object->getId()
             );
-            $record_gui->loadFromPost();
-            $record_gui->saveValues();
+            $record_gui->loadFromPost();// TODO PHP8-REVIEW Undefined method
+            $record_gui->saveValues();// TODO PHP8-REVIEW Undefined method
             
             $this->tpl->setOnScreenMessage('success', $this->lng->txt("settings_saved"));
             $this->editObject();
@@ -322,13 +323,8 @@ abstract class ilRemoteObjectBaseGUI extends ilObject2GUI
     protected function updateCustomValues(ilPropertyFormGUI $a_form) : void
     {
     }
-    
-    /**
-    * redirect script
-    *
-    * @param string $a_target
-    */
-    public static function _goto($a_target) : void
+
+    public static function _goto(string $a_target) : void
     {
         global $DIC;
 

--- a/Services/WebServices/ECS/classes/class.ilRemoteObjectBaseListGUI.php
+++ b/Services/WebServices/ECS/classes/class.ilRemoteObjectBaseListGUI.php
@@ -34,8 +34,8 @@ class ilRemoteObjectBaseListGUI extends ilObjectListGUI
     public function _lookupOrganization(string $table, int $a_obj_id) : string
     {
         $query = "SELECT organization FROM " . $this->db->quoteIdentifier(
-                $table
-            ) .
+            $table
+        ) .
             " WHERE obj_id = " . $this->db->quote($a_obj_id, 'integer') . " ";
         $res = $this->db->query($query);
         if ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
@@ -52,7 +52,8 @@ class ilRemoteObjectBaseListGUI extends ilObjectListGUI
         );
         $consent_gui = new ilECSUserConsentModalGUI(
             $this->user->getId(),
-            $this->ref_id);
+            $this->ref_id
+        );
 
         $shy_modal = $consent_gui->getTitleLink();
         if (!strlen($shy_modal)) {
@@ -72,10 +73,10 @@ class ilRemoteObjectBaseListGUI extends ilObjectListGUI
         string $title,
         string $description
     ) : ?RepositoryObject {
-
         $consent_gui = new ilECSUserConsentModalGUI(
             $this->user->getId(),
-            $ref_id);
+            $ref_id
+        );
         if ($consent_gui->hasConsented()) {
             return parent::getAsCard($ref_id, $obj_id, $type, $title, $description);
         }
@@ -95,7 +96,8 @@ class ilRemoteObjectBaseListGUI extends ilObjectListGUI
     {
         $consent_gui = new ilECSUserConsentModalGUI(
             $this->user->getId(),
-            $this->ref_id);
+            $this->ref_id
+        );
         $command = parent::createDefaultCommand($command);
         if ($consent_gui->hasConsented()) {
             return $command;

--- a/Services/WebServices/ECS/test/ilECSUserTest.php
+++ b/Services/WebServices/ECS/test/ilECSUserTest.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
+
+use ILIAS\DI\Container;
+use ILIAS\UI\Component\Legacy\Legacy;
+use ILIAS\UI\Factory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class ilSessionTest
+ */
+class ilECSUserTest extends TestCase
+{
+    protected function setUp() : void
+    {
+        $this->dic = new Container();
+        $GLOBALS['DIC'] = $this->dic;
+
+        $this->setGlobalVariable(
+            'ilSetting',
+            $this->getMockBuilder(ilSetting::class)->disableOriginalConstructor()->getMock()
+        );
+
+        parent::setUp();
+    }
+
+    /**
+     * @param string $name
+     * @param mixed  $value
+     */
+    protected function setGlobalVariable(string $name, $value) : void
+    {
+        global $DIC;
+
+        $GLOBALS[$name] = $value;
+
+        unset($DIC[$name]);
+        $DIC[$name] = static function ($c) use ($name) {
+            return $GLOBALS[$name];
+        };
+    }
+
+    public function testConstructorWithArray() : void
+    {
+        $testdata = [];
+        $testdata['ecs_login'] = 'testlogin';
+        $testdata['ecs_firstname'] = 'test_firstname';
+        $testdata['ecs_lastname'] = 'test_lastname';
+
+        $testdata['ecs_institution'] = 'test_institution';
+        $testdata['ecs_email'] = 'test@email.nowhere';
+        $testdata['ecs_uid_hash'] = 'test_hash';
+
+        $user = new ilECSUser($testdata);
+        $this->assertEquals('testlogin', $user->getLogin());
+    }
+}

--- a/Services/WebServices/ECS/test/ilServicesWebServicesECSSuite.php
+++ b/Services/WebServices/ECS/test/ilServicesWebServicesECSSuite.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
+use PHPUnit\Framework\TestSuite;
+
+class ilServicesWebServicesECSSuite extends TestSuite
+{
+    public static function suite() : self
+    {
+        $suite = new ilServicesWebServicesECSSuite();
+        require_once __DIR__ . '/ilECSUserTest.php';
+        $suite->addTestSuite(ilECSUserTest::class);
+
+        return $suite;
+    }
+}


### PR DESCRIPTION
Hello @pascalseeland, 

I completed the review of the `Services/WebServices/ECS` component.

Results:

- [x] The code style is `PSR-2 + X` compliant
- [ ] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`: I found 69 usages of `$_REQUEST`, 18 usages of `$_GET`, 4 usages of `$_SESSION` and 38 usages of `$_POST`.
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [ ] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

--

Actions needed:
- [ ] Please eliminate the usage of super global variables.
- [x] There is no dedicated unit test suite for `ECS`. I suggest to create a sub-suite like in `Services/Contact/BuddySystem`.
- [ ] Please check my inline comments. Some of them might be just information, some require an action. You can use `TODO PHP8-REVIEW` when searching.
  - TODO PHP8-REVIEW Undefined method
  - TODO PHP8-REVIEW Undefined class
  - TODO PHP8-REVIEW Missing type hints
  - TODO PHP8-REVIEW Missing type

Best regards,
@mjansenDatabay  