### PR TITLE
PHP 8 Code Review MediaObjects 

### DIFF
--- a/Services/MediaObjects/Creation/class.CreationGUIRequest.php
+++ b/Services/MediaObjects/Creation/class.CreationGUIRequest.php
@@ -45,7 +45,10 @@ class CreationGUIRequest
     {
         return $this->int("pool_view");
     }
-
+    
+    /**
+     * @return int[]
+     */
     public function getIds() : array
     {
         return $this->intArray("id");

--- a/Services/MediaObjects/Creation/class.ilMediaCreationGUI.php
+++ b/Services/MediaObjects/Creation/class.ilMediaCreationGUI.php
@@ -29,7 +29,8 @@ class ilMediaCreationGUI
     public const POOL_VIEW_FOLDER = "fold";
     public const POOL_VIEW_ALL = "all";
     protected CreationGUIRequest $request;
-
+    
+    // PHP8-Review: parameter $accept_types with no value type specified in iterable type array.
     protected array $accept_types = [1,2,3,4];
     protected ilLanguage $lng;
     protected ilCtrl $ctrl;
@@ -38,6 +39,7 @@ class ilMediaCreationGUI
     protected Closure $after_url_saving;
     protected Closure $after_pool_insert;
     protected ilAccessHandler $access;
+    // PHP8-Review: parameter $all_suffixes, $all_mime_types with no value type specified in iterable type array.
     protected array $all_suffixes = [];
     protected array $all_mime_types = [];
     protected \ILIAS\DI\UIServices $ui;
@@ -45,6 +47,7 @@ class ilMediaCreationGUI
     protected string $pool_view = self::POOL_VIEW_FOLDER;
 
     public function __construct(
+        // PHP8-Review: parameter $accept_types with no value type specified in iterable type array.
         array $accept_types,
         Closure $after_upload,
         Closure $after_url_saving,
@@ -83,27 +86,32 @@ class ilMediaCreationGUI
     }
 
     public function setAllSuffixes(
+        // PHP8-Review: parameter $a_val with no value type specified in iterable type array.
         array $a_val
     ) : void {
         $this->all_suffixes = $a_val;
     }
-
+    
+    // PHP8-Review: return type has no value type specified in iterable type array
     public function getAllSuffixes() : array
     {
         return $this->all_suffixes;
     }
 
     public function setAllMimeTypes(
+        // PHP8-Review: parameter $a_val with no value type specified in iterable type array.
         array $a_val
     ) : void {
         $this->all_mime_types = $a_val;
     }
-
+    
+    // PHP8-Review: return type has no value type specified in iterable type array
     public function getAllMimeTypes() : array
     {
         return $this->all_mime_types;
     }
-
+    
+    // PHP8-Review: return type has no value type specified in iterable type array
     protected function getSuffixes() : array
     {
         $suffixes = [];
@@ -115,7 +123,8 @@ class ilMediaCreationGUI
         }
         return $suffixes;
     }
-
+    
+    // PHP8-Review: return type has no value type specified in iterable type array
     protected function getMimeTypes() : array
     {
         $mimes = [];

--- a/Services/MediaObjects/ImageMap/class.ImageMapEditSessionRepository.php
+++ b/Services/MediaObjects/ImageMap/class.ImageMapEditSessionRepository.php
@@ -28,6 +28,7 @@ class ImageMapEditSessionRepository
     {
     }
 
+    // PHP8-Review: no return type specified.
     protected function get(string $key)
     {
         if (\ilSession::has(self::KEY_BASE . $key)) {
@@ -36,6 +37,7 @@ class ImageMapEditSessionRepository
         return null;
     }
 
+    // PHP8-Review: parameter $val with no type specified.
     protected function set(string $key, $val) : void
     {
         \ilSession::set(self::KEY_BASE . $key, $val);
@@ -162,7 +164,10 @@ class ImageMapEditSessionRepository
         $this->set("il_targetframe", $target_frame);
         $this->set("il_anchor", $anchor);
     }
-
+    
+    /**
+     * @return string[]
+     */
     public function getInternalLink() : array
     {
         return [

--- a/Services/MediaObjects/ImageMap/class.ImageMapGUIRequest.php
+++ b/Services/MediaObjects/ImageMap/class.ImageMapGUIRequest.php
@@ -130,7 +130,8 @@ class ImageMapGUIRequest
     {
         return $this->str("area_link_ext");
     }
-
+    
+    // PHP8-Review: return type has no value type specified in iterable type array
     public function getArea() : array
     {
         return $this->strArray("area");

--- a/Services/MediaObjects/ImageMap/class.ImageMapManager.php
+++ b/Services/MediaObjects/ImageMap/class.ImageMapManager.php
@@ -152,7 +152,8 @@ class ImageMapManager
             $anchor
         );
     }
-
+    
+    // PHP8-Review: return type has no value type specified in iterable type array
     public function getInternalLink() : array
     {
         return $this->repo->getInternalLink();

--- a/Services/MediaObjects/ImageMap/class.ilImageMapTableGUI.php
+++ b/Services/MediaObjects/ImageMap/class.ilImageMapTableGUI.php
@@ -21,6 +21,7 @@
 class ilImageMapTableGUI extends ilTable2GUI
 {
     protected ilObjMediaObject $media_object;
+    // PHP8-Review: $highl_classes, $highl_modes type has no value type specified in iterable type array.
     protected array $highl_classes;
     protected array $highl_modes;
     protected ilAccessHandler $access;
@@ -99,7 +100,7 @@ class ilImageMapTableGUI extends ilTable2GUI
 
         $this->setData($areas);
     }
-    
+    // PHP8-Review: parameter $a_set with no value type specified in iterable type array.
     protected function fillRow(array $a_set) : void
     {
         $area = $a_set["area"];

--- a/Services/MediaObjects/ImageMap/class.ilMapArea.php
+++ b/Services/MediaObjects/ImageMap/class.ilMapArea.php
@@ -12,7 +12,7 @@
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  */
-
+// PHP8-Review: Define constant name can be replaced with 'const' syntax
 define("IL_AREA_RECT", "Rect");
 define("IL_AREA_CIRCLE", "Circle");
 define("IL_AREA_POLY", "Poly");

--- a/Services/MediaObjects/ImageMap/class.ilMapArea.php
+++ b/Services/MediaObjects/ImageMap/class.ilMapArea.php
@@ -207,6 +207,7 @@ class ilMapArea
      *
      * @param	int		$a_item_id		media item id
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public static function _getIntLinks(
         int $a_item_id
     ) : array {
@@ -237,6 +238,7 @@ class ilMapArea
     /**
      * Get areas for a certain target
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public static function _getMobsForTarget(
         string $a_type,
         string $a_target
@@ -258,7 +260,8 @@ class ilMapArea
         
         return $mobs;
     }
-
+    
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public static function getAllHighlightModes() : array
     {
         global $DIC;
@@ -282,7 +285,8 @@ class ilMapArea
     {
         return $this->highlight_mode;
     }
-
+    
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public static function getAllHighlightClasses() : array
     {
         global $DIC;
@@ -424,6 +428,7 @@ class ilMapArea
     /**
      * get link target (internal link only)
      */
+    // PHP8-Review: parameter $a_insert_inst with no type specified.
     public function getTarget($a_insert_inst = false) : string
     {
         $target = $this->il_target;

--- a/Services/MediaObjects/SubTitles/class.SubtitlesGUIRequest.php
+++ b/Services/MediaObjects/SubTitles/class.SubtitlesGUIRequest.php
@@ -30,12 +30,14 @@ class SubtitlesGUIRequest
             $refinery
         );
     }
-
+    
+    // PHP8-Review: return type has no value type specified in iterable type array
     public function getSrtFiles() : array
     {
         return $this->strArray("srt");
     }
-
+    
+    // PHP8-Review: return type has no value type specified in iterable type array
     public function getFiles() : array
     {
         return $this->strArray("file");

--- a/Services/MediaObjects/SubTitles/class.ilMobMultiSrtConfirmationTable2GUI.php
+++ b/Services/MediaObjects/SubTitles/class.ilMobMultiSrtConfirmationTable2GUI.php
@@ -54,6 +54,7 @@ class ilMobMultiSrtConfirmationTable2GUI extends ilTable2GUI
         $this->addCommandButton("cancelMultiSrt", $this->lng->txt("cancel"));
     }
 
+    // PHP8-Review: parameter $a_set with no value type specified in iterable type array.
     protected function fillRow(array $a_set) : void
     {
         $lng = $this->lng;

--- a/Services/MediaObjects/SubTitles/class.ilMobMultiSrtUpload.php
+++ b/Services/MediaObjects/SubTitles/class.ilMobMultiSrtUpload.php
@@ -53,6 +53,7 @@ class ilMobMultiSrtUpload
      * @throws ilException
      * @throws ilMobSrtUploadException
      */
+    // PHP8-Review: parameter $a_file with no value type specified in iterable type array.
     public function uploadMultipleSubtitleFile(
         array $a_file
     ) : void {
@@ -78,6 +79,7 @@ class ilMobMultiSrtUpload
     /**
      * Get all srt files of srt multi upload
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public function getMultiSrtFiles() : array
     {
         $items = array();

--- a/Services/MediaObjects/SubTitles/class.ilMobSubtitleTableGUI.php
+++ b/Services/MediaObjects/SubTitles/class.ilMobSubtitleTableGUI.php
@@ -49,6 +49,7 @@ class ilMobSubtitleTableGUI extends ilTable2GUI
         $this->addMultiCommand("confirmSrtDeletion", $lng->txt("delete"));
     }
     
+    // PHP8-Review: parameter $a_set with no value type specified in iterable type array.
     protected function fillRow(array $a_set) : void
     {
         $lng = $this->lng;

--- a/Services/MediaObjects/SubTitles/class.ilMultiSrtConfirmationTable2GUI.php
+++ b/Services/MediaObjects/SubTitles/class.ilMultiSrtConfirmationTable2GUI.php
@@ -58,6 +58,7 @@ class ilMultiSrtConfirmationTable2GUI extends ilTable2GUI
         $this->addCommandButton("cancelMultiSrt", $lng->txt("cancel"));
     }
 
+    // PHP8-Review: parameter $a_set with no value type specified in iterable type array.
     protected function fillRow(array $a_set) : void
     {
         $lng = $this->lng;

--- a/Services/MediaObjects/classes/class.ilExternalMediaAnalyzer.php
+++ b/Services/MediaObjects/classes/class.ilExternalMediaAnalyzer.php
@@ -37,6 +37,7 @@ class ilExternalMediaAnalyzer
     /**
      * Extract YouTube Parameter
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public static function extractYouTubeParameters(
         string $a_location
     ) : array {
@@ -70,6 +71,7 @@ class ilExternalMediaAnalyzer
     /**
      * Extract Flickr Parameter
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public static function extractFlickrParameters(
         string $a_location
     ) : array {
@@ -121,6 +123,7 @@ class ilExternalMediaAnalyzer
     /**
      * Extract GoogleVideo Parameter
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public static function extractGoogleVideoParameters(
         string $a_location
     ) : array {
@@ -152,6 +155,7 @@ class ilExternalMediaAnalyzer
     /**
      * Extract Vimeo Parameter
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public static function extractVimeoParameters(
         string $a_location
     ) : array {
@@ -183,6 +187,7 @@ class ilExternalMediaAnalyzer
     /**
      * Extract GoogleDocument Parameter
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public static function extractGoogleDocumentParameters(
         string $a_location
     ) : array {
@@ -216,8 +221,10 @@ class ilExternalMediaAnalyzer
     /**
      * Extract URL information to parameter array
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public static function extractUrlParameters(
         string $a_location,
+        // PHP8-Review: parameter $a_parameter with no value type specified in iterable type array.
         array $a_parameter
     ) : array {
         if (!is_array($a_parameter)) {

--- a/Services/MediaObjects/classes/class.ilFFmpeg.php
+++ b/Services/MediaObjects/classes/class.ilFFmpeg.php
@@ -19,6 +19,7 @@
  */
 class ilFFmpeg
 {
+    // PHP8-Review: $last_return type has no value type specified in iterable type array.
     public static ?array $last_return = array();
 
     /**
@@ -27,6 +28,7 @@ class ilFFmpeg
      * For source formats no specification is needed here. For target formats
      * we use fixed parameters that should result in best web media practice.
      */
+    // PHP8-Review: $formats type has no value type specified in iterable type array.
     public static array $formats = array(
         "video/3pgg" => array(
             "source" => true,
@@ -65,6 +67,7 @@ class ilFFmpeg
     /**
      * Get desired target mime types
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public static function getTargetMimeTypes() : array
     {
         $ttypes = array();
@@ -76,6 +79,7 @@ class ilFFmpeg
         return $ttypes;
     }
     
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public static function getSourceMimeTypes() : array
     {
         $ttypes = array();
@@ -102,6 +106,7 @@ class ilFFmpeg
     /**
      * Get possible target formats
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public static function getPossibleTargetMimeTypes(
         string $a_source_mime_type
     ) : array {
@@ -127,6 +132,7 @@ class ilFFmpeg
     /**
      * Execute ffmpeg
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public static function exec(string $args) : array
     {
         return ilShellUtil::execQuoted(self::getCmd(), $args);
@@ -135,6 +141,7 @@ class ilFFmpeg
     /**
      * Get all supported codecs
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public static function getSupportedCodecsInfo() : array
     {
         $codecs = self::exec("-codecs");
@@ -144,6 +151,7 @@ class ilFFmpeg
     /**
      * Get all supported formats
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public static function getSupportedFormatsInfo() : array
     {
         $formats = self::exec("-formats");
@@ -154,6 +162,7 @@ class ilFFmpeg
     /**
      * Get last return values
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public static function getLastReturnValues() : ?array
     {
         return self::$last_return;
@@ -186,8 +195,8 @@ class ilFFmpeg
         
         $sec = $a_sec;
         $cmd = "-y -i " . ilShellUtil::escapeShellArg(
-                $a_file
-            ) . " -r 1 -f image2 -vframes 1 -ss " . $sec . " " . ilShellUtil::escapeShellArg($target_file);
+            $a_file
+        ) . " -r 1 -f image2 -vframes 1 -ss " . $sec . " " . ilShellUtil::escapeShellArg($target_file);
         $ret = self::exec($cmd . " 2>&1");
         self::$last_return = $ret;
         

--- a/Services/MediaObjects/classes/class.ilMediaAnalyzer.php
+++ b/Services/MediaObjects/classes/class.ilMediaAnalyzer.php
@@ -20,6 +20,7 @@
  */
 class ilMediaAnalyzer
 {
+    // PHP8-Review: $file_info type has no value type specified in iterable type array.
     protected array $file_info;
     protected getID3 $getid3;
     public string $file;

--- a/Services/MediaObjects/classes/class.ilMediaImageUtil.php
+++ b/Services/MediaObjects/classes/class.ilMediaImageUtil.php
@@ -24,6 +24,7 @@ class ilMediaImageUtil
      * Get image size from location
      * @throws ilCurlConnectionException
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public static function getImageSize(string $a_location) : ?array
     {
         if (substr($a_location, 0, 4) == "http") {

--- a/Services/MediaObjects/classes/class.ilMediaItem.php
+++ b/Services/MediaObjects/classes/class.ilMediaItem.php
@@ -156,7 +156,7 @@ class ilMediaItem
                     return "gif";
                 }
                 break;
-            
+            // PHP8-Review: Duplicate branch in switch statement
             case "svg":
                 if ($im_types & IMG_PNG) {
                     return "png";
@@ -702,6 +702,7 @@ class ilMediaItem
             return false;
         }
         // do not allow to change the src attribute
+        // PHP8-Review: 'in_array' can be replaced with comparison
         if (in_array(strtolower(trim($a_par)), array("src"))) {
             return false;
         }

--- a/Services/MediaObjects/classes/class.ilMediaItem.php
+++ b/Services/MediaObjects/classes/class.ilMediaItem.php
@@ -34,9 +34,11 @@ class ilMediaItem
     public string $height = "";
     public string $caption = "";
     public string $halign = "";
+    // PHP8-Review: no value type specified in iterable type array.
     public array $parameters = [];
     public int $mob_id = 0;
     public int $nr = 0;
+    // PHP8-Review: no value type specified in iterable type array.
     public array $mapareas = [];
     public int $map_cnt = 0;
     /**
@@ -105,14 +107,12 @@ class ilMediaItem
     }
     
     /**
-    * returns the best supported image type by this PHP build
-    *
-    * @param	string	$desired_type	desired image type ("jpg" | "gif" | "png")
-    *
-    * @return    string                    supported image type ("jpg" | "gif" | "png" | "")
-    * @static
-    *
-    */
+     * returns the best supported image type by this PHP build
+     *
+     * @param string $a_desired_type
+     * @return string supported image type ("jpg" | "gif" | "png" | "")
+     * @static
+     */
     private static function getGDSupportedImageType(string $a_desired_type) : string
     {
         $a_desired_type = strtolower($a_desired_type);
@@ -251,7 +251,7 @@ class ilMediaItem
         }
     }
 
-    public function update()
+    public function update() : void
     {
         $ilDB = $this->db;
 
@@ -589,7 +589,8 @@ class ilMediaItem
     {
         return $this->mapareas[$nr - 1] ?? null;
     }
-
+    
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public function getMapAreas() : array
     {
         return $this->mapareas;
@@ -614,7 +615,8 @@ class ilMediaItem
     {
         $this->height = $a_height;
     }
-
+    
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public function getOriginalSize() : ?array
     {
         $mob_dir = ilObjMediaObject::_getDirectory($this->getMobId());
@@ -709,7 +711,8 @@ class ilMediaItem
 
         return true;
     }
-
+    
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public function getParameters() : array
     {
         return $this->parameters;
@@ -1153,6 +1156,7 @@ class ilMediaItem
      * get all internal links of map areas of a mob
      * @param int $a_mob_id media object id
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public static function _getMapAreasIntLinks(
         int $a_mob_id
     ) : array {
@@ -1202,6 +1206,7 @@ class ilMediaItem
      * @param string $a_hash upload hash
      * @return array
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public static function getMediaItemsForUploadHash(
         string $a_hash
     ) : array {

--- a/Services/MediaObjects/classes/class.ilMediaObjectDataSet.php
+++ b/Services/MediaObjects/classes/class.ilMediaObjectDataSet.php
@@ -51,7 +51,8 @@ class ilMediaObjectDataSet extends ilDataSet
     {
         return $this->use_previous_import_ids;
     }
-
+    
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public function getSupportedVersions() : array
     {
         return array("5.1.0", "4.3.0", "4.1.0");
@@ -62,6 +63,7 @@ class ilMediaObjectDataSet extends ilDataSet
         return "https://www.ilias.de/xml/Services/MediaObject/" . $a_entity;
     }
     
+    // PHP8-Review: return type has no value type specified in iterable type array.
     protected function getTypes(string $a_entity, string $a_version) : array
     {
         // mob
@@ -153,6 +155,7 @@ class ilMediaObjectDataSet extends ilDataSet
     public function readData(
         string $a_entity,
         string $a_version,
+        // PHP8-Review: parameter $a_ids with no value type specified in iterable type array.
         array $a_ids
     ) : void {
         $ilDB = $this->db;
@@ -260,9 +263,11 @@ class ilMediaObjectDataSet extends ilDataSet
     /**
      * Determine the dependent sets of data
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     protected function getDependencies(
         string $a_entity,
         string $a_version,
+        // PHP8-Review: parameter $a_rec, $a_ids with no value type specified in iterable type array.
         ?array $a_rec = null,
         ?array $a_ids = null
     ) : array {
@@ -280,10 +285,12 @@ class ilMediaObjectDataSet extends ilDataSet
         }
         return [];
     }
-
+    
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public function getXmlRecord(
         string $a_entity,
         string $a_version,
+        // PHP8-Review: parameter $a_set with no value type specified in iterable type array.
         array $a_set
     ) : array {
         if ($a_entity == "mob") {
@@ -296,6 +303,7 @@ class ilMediaObjectDataSet extends ilDataSet
     
     public function importRecord(
         string $a_entity,
+        // PHP8-Review: parameter $a_types, $a_rec with no value type specified in iterable type array.
         array $a_types,
         array $a_rec,
         ilImportMapping $a_mapping,

--- a/Services/MediaObjects/classes/class.ilMediaObjectUsagesTableGUI.php
+++ b/Services/MediaObjects/classes/class.ilMediaObjectUsagesTableGUI.php
@@ -109,6 +109,7 @@ class ilMediaObjectUsagesTableGUI extends ilTable2GUI
         $this->setData($agg_usages);
     }
     
+    // PHP8-Review: parameter $a_set with no value type specified in iterable type array.
     protected function fillRow(array $a_set) : void
     {
         $lng = $this->lng;

--- a/Services/MediaObjects/classes/class.ilMediaObjectsExporter.php
+++ b/Services/MediaObjects/classes/class.ilMediaObjectsExporter.php
@@ -27,10 +27,12 @@ class ilMediaObjectsExporter extends ilXmlExporter
         $this->ds = new ilMediaObjectDataSet();
         $this->ds->setDSPrefix("ds");
     }
-
+    
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public function getXmlExportTailDependencies(
         string $a_entity,
         string $a_target_release,
+        // PHP8-Review: parameter $a_ids with no value type specified in iterable type array.
         array $a_ids
     ) : array {
         $md_ids = array();
@@ -56,6 +58,7 @@ class ilMediaObjectsExporter extends ilXmlExporter
         return $this->ds->getXmlRepresentation($a_entity, $a_schema_version, [$a_id], "", true, true);
     }
 
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public function getValidSchemaVersions(
         string $a_entity
     ) : array {

--- a/Services/MediaObjects/classes/class.ilObjMediaObject.php
+++ b/Services/MediaObjects/classes/class.ilObjMediaObject.php
@@ -15,6 +15,7 @@
 
 use ILIAS\FileUpload\MimeType;
 
+// PHP8-Review: Define constant name can be replaced with 'const' syntax
 define("IL_MODE_ALIAS", 1);
 define("IL_MODE_OUTPUT", 2);
 define("IL_MODE_FULL", 3);
@@ -45,6 +46,7 @@ class ilObjMediaObject extends ilObject
         parent::__construct($a_id, false);
     }
 
+    // PHP8-Review: Parameter's name changed during inheritance
     public static function _exists(
         int $a_id,
         bool $a_reference = false,
@@ -108,6 +110,7 @@ class ilObjMediaObject extends ilObject
 
     protected function beforeMDUpdateListener(string $a_element) : bool
     {
+        // PHP8-Review: 'switch' with single 'case'
         switch ($a_element) {
             case 'General':
 

--- a/Services/MediaObjects/classes/class.ilObjMediaObject.php
+++ b/Services/MediaObjects/classes/class.ilObjMediaObject.php
@@ -28,7 +28,7 @@ class ilObjMediaObject extends ilObject
     protected ilObjUser $user;
     public bool $is_alias;
     public string $origin_id;
-    public array $media_items;
+    public array $media_items;  // PHP8-Review: type has no value type specified in iterable type array.
     public bool $contains_int_link;
 
     public function __construct(
@@ -184,6 +184,7 @@ class ilObjMediaObject extends ilObject
         $this->media_items[] = $a_item;
     }
 
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public function &getMediaItems() : array
     {
         return $this->media_items;
@@ -223,7 +224,7 @@ class ilObjMediaObject extends ilObject
         $this->media_items = $media_items;
     }
     
-    public function removeAllMediaItems()
+    public function removeAllMediaItems() : void
     {
         $this->media_items = array();
     }
@@ -277,7 +278,8 @@ class ilObjMediaObject extends ilObject
     {
         return $this->origin_id;
     }
-
+    
+    // PHP8-Review: parameter with no type specified
     public function create($a_create_meta_data = false, $a_save_media_items = true) : int
     {
         $id = parent::create();
@@ -309,7 +311,8 @@ class ilObjMediaObject extends ilObject
 
         return $id;
     }
-
+    
+    // PHP8-Review: parameter with no type specified
     public function update($a_upload = false) : bool
     {
         parent::update();
@@ -485,6 +488,7 @@ class ilObjMediaObject extends ilObject
     /**
      * Get files of directory
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public function getFilesOfDirectory(
         string $a_subdir = ""
     ) : array {
@@ -835,6 +839,7 @@ class ilObjMediaObject extends ilObject
         }
     }
 
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public static function _getMobsOfObject(
         string $a_type,
         int $a_id,
@@ -927,6 +932,7 @@ class ilObjMediaObject extends ilObject
     /**
      * get all usages of current media object
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public function getUsages(
         bool $a_include_history = true
     ) : array {
@@ -938,6 +944,7 @@ class ilObjMediaObject extends ilObject
      *
      * @todo: This should be all in one context -> mob id table
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public static function lookupUsages(
         int $a_id,
         bool $a_include_history = true
@@ -1030,6 +1037,7 @@ class ilObjMediaObject extends ilObject
      * see ilWebAccessChecker
      */
     public static function getParentObjectIdForUsage(
+        // PHP8-Review: parameter $a_usage with no value type specified in iterable type array.
         array $a_usage,
         bool $a_include_all_access_obj_ids = false
     ) : ?int {
@@ -1236,6 +1244,7 @@ class ilObjMediaObject extends ilObject
         string $a_file,
         int $a_width,
         int $a_height,
+        // PHP8-Review: parameter $a_constrain_prop with no type specified
         $a_constrain_prop = false
     ) : string {
         $file_path = pathinfo($a_file);
@@ -1267,6 +1276,7 @@ class ilObjMediaObject extends ilObject
         return $mime;
     }
 
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public static function _determineWidthHeight(
         string $a_format,
         string $a_type,
@@ -1511,6 +1521,7 @@ class ilObjMediaObject extends ilObject
      * Get all media objects linked in map areas of this media object
      * @param int[] $a_ignore array of IDs that should be ignored
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public function getLinkedMediaObjects(
         array $a_ignore = []
     ) : array {
@@ -1541,6 +1552,7 @@ class ilObjMediaObject extends ilObject
      * Get restricted file types (this is for the input form, this list
      * will be empty, if "allowed list" is empty)
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public static function getRestrictedFileTypes() : array
     {
         return array_filter(self::getAllowedFileTypes(), function ($v) {
@@ -1551,6 +1563,7 @@ class ilObjMediaObject extends ilObject
     /**
      * Get forbidden file types
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public static function getForbiddenFileTypes() : array
     {
         $mset = new ilSetting("mobs");
@@ -1568,6 +1581,7 @@ class ilObjMediaObject extends ilObject
     /**
      * Get allowed file types
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public static function getAllowedFileTypes() : array
     {
         $mset = new ilSetting("mobs");
@@ -1630,6 +1644,7 @@ class ilObjMediaObject extends ilObject
     }
     
     public function uploadVideoPreviewPic(
+        // PHP8-Review: parameter $a_prevpic with no value type specified in iterable type array.
         array $a_prevpic
     ) : void {
         // remove old one
@@ -1749,6 +1764,7 @@ class ilObjMediaObject extends ilObject
      * Upload multi srt file
      */
     public function uploadMultipleSubtitleFile(
+        // PHP8-Review: parameter $a_file with no value type specified in iterable type array.
         array $a_file
     ) : void {
         $lng = $this->lng;
@@ -1775,6 +1791,7 @@ class ilObjMediaObject extends ilObject
     /**
      * Get all srt files of srt multi upload
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public function getMultiSrtFiles() : array
     {
         $items = array();

--- a/Services/MediaObjects/classes/class.ilObjMediaObjectAccess.php
+++ b/Services/MediaObjects/classes/class.ilObjMediaObjectAccess.php
@@ -252,9 +252,9 @@ class ilObjMediaObjectAccess implements ilWACCheckingClass
     /**
      * Check access rights for glossary terms
      * This checks also learning modules linking the term
-     * @param    int         object id (glossary)
-     * @param    int         page id (definition)
-     * @return   bool     access given (true/false)
+     * @param int $obj_id       object id (glossary)
+     * @param int $page_id      page id (definition)
+     * @return bool            access given (true/false)
      */
     protected function checkAccessGlossaryTerm(
         int $obj_id,

--- a/Services/MediaObjects/classes/class.ilObjMediaObjectAccess.php
+++ b/Services/MediaObjects/classes/class.ilObjMediaObjectAccess.php
@@ -271,6 +271,7 @@ class ilObjMediaObjectAccess implements ilWACCheckingClass
 
         if ($sources) {
             foreach ($sources as $src) {
+                // PHP8-Review: 'switch' with single 'case'
                 switch ($src['type']) {
                     // Give access if term is linked by a learning module with read access.
                     // The term including media is shown by the learning module presentation!

--- a/Services/MediaObjects/classes/class.ilObjMediaObjectGUI.php
+++ b/Services/MediaObjects/classes/class.ilObjMediaObjectGUI.php
@@ -1432,6 +1432,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
     /**
      * set admin tabs
      */
+    // PHP8-Review: Method visibility should not be overridden
     public function setTabs() : void
     {
         // catch feedback message
@@ -1448,6 +1449,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
         }
     }
 
+    // PHP8-Review: Method visibility should not be overridden
     public function getTabs() : void
     {
         $ilHelp = $this->help;

--- a/Services/MediaObjects/classes/class.ilObjMediaObjectGUI.php
+++ b/Services/MediaObjects/classes/class.ilObjMediaObjectGUI.php
@@ -44,7 +44,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
     public bool $enabledmapareas = true;
 
     public function __construct(
-        $a_data,
+        $a_data,    // PHP8-Review: no type specified
         int $a_id = 0,
         bool $a_call_by_reference = false,
         bool $a_prepare_output = false
@@ -95,6 +95,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
      * Get adv md record type
      * @throws ilMediaObjectsException
      */
+    // PHP8-Review: return type has no value type specified in iterable type array.
     public function getAdvMdRecordObject() : ?array
     {
         if ($this->adv_type == null) {
@@ -260,6 +261,7 @@ class ilObjMediaObjectGUI extends ilObjectGUI
         $tpl->setContent($this->form_gui->getHTML());
     }
 
+    // PHP8-Review: parameter $a_mode: no type specified.
     public function initForm($a_mode = "create") : void
     {
         $lng = $this->lng;

--- a/Services/MediaObjects/classes/class.ilPlayerUtil.php
+++ b/Services/MediaObjects/classes/class.ilPlayerUtil.php
@@ -58,11 +58,17 @@ class ilPlayerUtil
         }
     }
     
+    /**
+     * @return string[]
+     */
     public static function getCssFilePaths() : array
     {
         return array(self::getLocalMediaElementCssPath());
     }
     
+    /**
+     * @return string[]
+     */
     public static function getJsFilePaths() : array
     {
         return array(

--- a/Services/MediaObjects/interfaces/interface.ilMobMultiSrtInt.php
+++ b/Services/MediaObjects/interfaces/interface.ilMobMultiSrtInt.php
@@ -23,7 +23,8 @@ interface ilMobMultiSrtInt
      * @return string upload directory
      */
     public function getUploadDir() : string;
-
+    
+    // PHP8-Review: return type has no value type specified in iterable type array.
     /**
      * @return array array of target media objects ids
      */

--- a/Services/MediaObjects/test/ImageMapEditSessionRepositoryTest.php
+++ b/Services/MediaObjects/test/ImageMapEditSessionRepositoryTest.php
@@ -26,7 +26,7 @@ class ImageMapEditSessionRepositoryTest extends TestCase
     /**
      * Test clear
      */
-    public function testClear()
+    public function testClear() : void
     {
         $repo = $this->repo;
 
@@ -48,7 +48,7 @@ class ImageMapEditSessionRepositoryTest extends TestCase
         );
     }
 
-    public function testTargetScript()
+    public function testTargetScript() : void
     {
         $repo = $this->repo;
         $repo->setTargetScript("ilias.php?a=1");
@@ -58,7 +58,7 @@ class ImageMapEditSessionRepositoryTest extends TestCase
         );
     }
 
-    public function testLinkType()
+    public function testLinkType() : void
     {
         $repo = $this->repo;
         $repo->setLinkType("ext");
@@ -68,7 +68,7 @@ class ImageMapEditSessionRepositoryTest extends TestCase
         );
     }
 
-    public function testAreaNr()
+    public function testAreaNr() : void
     {
         $repo = $this->repo;
         $repo->setAreaNr(4);
@@ -78,7 +78,7 @@ class ImageMapEditSessionRepositoryTest extends TestCase
         );
     }
 
-    public function testCoords()
+    public function testCoords() : void
     {
         $repo = $this->repo;
         $repo->setCoords("7,8,9,2");
@@ -88,7 +88,7 @@ class ImageMapEditSessionRepositoryTest extends TestCase
         );
     }
 
-    public function testAreaType()
+    public function testAreaType() : void
     {
         $repo = $this->repo;
         $repo->setAreaType("Rect");
@@ -98,7 +98,7 @@ class ImageMapEditSessionRepositoryTest extends TestCase
         );
     }
 
-    public function testExternalLink()
+    public function testExternalLink() : void
     {
         $repo = $this->repo;
         $repo->setExternalLink("https://www.ilias.de");

--- a/Services/MediaObjects/test/ilServicesMediaObjectsSuite.php
+++ b/Services/MediaObjects/test/ilServicesMediaObjectsSuite.php
@@ -22,7 +22,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilServicesMediaObjectsSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new self();
 


### PR DESCRIPTION
Hello @alex40724 ,

I completed the review of the Services/MediaObjects component.

Results:

- [x] The code style is PSR-2 + X compliant
- [x] No usage of $_GET / $_POST / $_REQUEST / $_SESSION
- [x] There is a Unit Test Suite with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] There are no serious PhpStorm Code Inspection issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)
--
We fixed some trivial issues reported by our inspection profile.
Please check our inline comments most of them might be just information. You can use PHP8-Review when searching.


Actions needed:
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

Best regards,
@katringross