### PR TITLE
KS Video Player Element (v2)

### DIFF
--- a/src/UI/Component/Player/Factory.php
+++ b/src/UI/Component/Player/Factory.php
@@ -56,13 +56,6 @@ interface Factory
      * rules:
      *   accessibility:
      *     1: >
-     *        The play/pause button MUST be accessible via tab key and allow to start/stop the video when the
-     *        space/return key is being pressed.
-     *     2: >
-     *        The playing position SHOULD be adjustable by using the cursor left/right keys.
-     *     3: >
-     *        The volume SHOULD be adjustable by using the cursor up/down keys.
-     *     4: >
      *        A subtitle file SHOULD be provided, if the video content contains speech.
      *   style:
      *     1: >

--- a/src/UI/Component/Player/Factory.php
+++ b/src/UI/Component/Player/Factory.php
@@ -39,7 +39,7 @@ interface Factory
      * context:
      *   - Listing Items in Panels
      * ----
-     * @param string $source
+     * @param string $source relative web root path of an mp3 file or a URL of an external mp3 resource
      * @param string $transcript
      * @return \ILIAS\UI\Component\Player\Audio
      */
@@ -71,7 +71,8 @@ interface Factory
      *   - Main Content
      *   - Modal Content
      * ----
-     * @param string $source mp4 file path, youtube or vimeo url
+     * @param string $source relative web root path of an mp4 file, URL of an external mp4 resource,
+     *                       youtube or vimeo URL
      * @return \ILIAS\UI\Component\Player\Video
      */
     public function video(string $source) : Video;

--- a/src/UI/Component/Player/Factory.php
+++ b/src/UI/Component/Player/Factory.php
@@ -44,4 +44,35 @@ interface Factory
      * @return \ILIAS\UI\Component\Player\Audio
      */
     public function audio(string $source, string $transcript = "") : Audio;
+
+    /**
+     * ---
+     * description:
+     *   purpose: The Video component is used to play and control mp4 video files, youtube or vimeo videos.
+     *   composition: >
+     *       The Video component is composed by a video area, play/pause button, a playtime presentation,
+     *       a volume button, a volume slider and a time slider. Additionally it optionally
+     *       provides subtitles stored in WebVTT files, see https://en.wikipedia.org/wiki/WebVTT.
+     * rules:
+     *   accessibility:
+     *     1: >
+     *        The play/pause button MUST be accessible via tab key and allow to start/stop the video when the
+     *        space/return key is being pressed.
+     *     2: >
+     *        The playing position SHOULD be adjustable by using the cursor left/right keys.
+     *     3: >
+     *        The volume SHOULD be adjustable by using the cursor up/down keys.
+     *     4: >
+     *        A subtitle file SHOULD be provided, if the video content contains speech.
+     *   style:
+     *     1: >
+     *        The widget will be presented with the full width of its container.
+     * context:
+     *   - Main Content
+     *   - Modal Content
+     * ----
+     * @param string $source mp4 file path, youtube or vimeo url
+     * @return \ILIAS\UI\Component\Player\Video
+     */
+    public function video(string $source) : Video;
 }

--- a/src/UI/Component/Player/Video.php
+++ b/src/UI/Component/Player/Video.php
@@ -41,6 +41,7 @@ interface Video extends Player
 
     /**
      * Set initially shown poster image
+     * @param string $poster relative web root path of an image file, URL of an external image resource (png,jpg,svg,gif)
      */
     public function withPoster(string $poster) : \ILIAS\UI\Component\Player\Video;
 

--- a/src/UI/Component/Player/Video.php
+++ b/src/UI/Component/Player/Video.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\UI\Component\Player;
+
+use ILIAS\UI\Component\JavaScriptBindable;
+
+/**
+ * Interface for Video elements
+ * @author Alexander Killing <killing@leifos.de>
+ */
+interface Video extends Player
+{
+    /**
+     * Set a subtitle file path (vtt file). For WebVTT format, see https://en.wikipedia.org/wiki/WebVTT.
+     */
+    public function withAdditionalSubtitleFile(string $lang_key, string $subtitle_file) : \ILIAS\UI\Component\Player\Video;
+
+    /**
+     * Get subtitle files
+     * @return array<string,string>
+     */
+    public function getSubtitleFiles() : array;
+
+    /**
+     * Set initially shown poster image
+     */
+    public function withPoster(string $poster) : \ILIAS\UI\Component\Player\Video;
+
+    /**
+     * Get poster
+     */
+    public function getPoster() : string;
+}

--- a/src/UI/Component/Player/Video.php
+++ b/src/UI/Component/Player/Video.php
@@ -28,6 +28,8 @@ interface Video extends Player
 {
     /**
      * Set a subtitle file path (vtt file). For WebVTT format, see https://en.wikipedia.org/wiki/WebVTT.
+     * @param string $lang_key two letter lang key, e.g. "de", "en"
+     * @param string $subtitle_file relative web root path of a vtt file
      */
     public function withAdditionalSubtitleFile(string $lang_key, string $subtitle_file) : \ILIAS\UI\Component\Player\Video;
 
@@ -42,8 +44,5 @@ interface Video extends Player
      */
     public function withPoster(string $poster) : \ILIAS\UI\Component\Player\Video;
 
-    /**
-     * Get poster
-     */
     public function getPoster() : string;
 }

--- a/src/UI/Implementation/Component/Player/Video.php
+++ b/src/UI/Implementation/Component/Player/Video.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\UI\Implementation\Component\Player;
+
+use ILIAS\UI\Component as C;
+use ILIAS\UI\Implementation\Component\ComponentHelper;
+use ILIAS\UI\Implementation\Component\JavaScriptBindable;
+use ILIAS\UI\Implementation\Component\Triggerer;
+
+/**
+ * @author Alexander Killing <killing@leifos.de>
+ * @package ILIAS\UI\Implementation\Component\Player
+ */
+class Video extends Player implements C\Player\Video
+{
+    private string $src = "";
+    private string $poster = "";
+    private array $subtitle_files = [];
+
+    public function withAdditionalSubtitleFile(string $lang_key, string $subtitle_file) : C\Player\Video
+    {
+        $clone = clone $this;
+        $clone->subtitle_files[$lang_key] = $subtitle_file;
+        return $clone;
+    }
+
+    public function getSubtitleFiles() : array
+    {
+        return $this->subtitle_files;
+    }
+
+    public function withPoster(string $poster) : C\Player\Video
+    {
+        $clone = clone $this;
+        $clone->poster = $poster;
+        return $clone;
+    }
+
+    public function getPoster() : string
+    {
+        return $this->poster;
+    }
+}

--- a/src/UI/examples/Player/Video/subtitles_de.vtt
+++ b/src/UI/examples/Player/Video/subtitles_de.vtt
@@ -1,0 +1,12 @@
+WEBVTT
+Kind: captions
+Language: de
+
+00:00.000 --> 00:08.000
+Untertitel...
+
+00:08.000 --> 00:16.000
+Wellen...
+
+00:16.000 --> 00:24.000
+Steine.

--- a/src/UI/examples/Player/Video/subtitles_en.vtt
+++ b/src/UI/examples/Player/Video/subtitles_en.vtt
@@ -1,0 +1,12 @@
+WEBVTT
+Kind: captions
+Language: en
+
+00:00.000 --> 00:08.000
+Subtitles...
+
+00:08.000 --> 00:16.000
+Waves...
+
+00:16.000 --> 00:24.000
+Stones.

--- a/src/UI/examples/Player/Video/video_mp4.php
+++ b/src/UI/examples/Player/Video/video_mp4.php
@@ -16,23 +16,17 @@
  *
  *********************************************************************/
 
-namespace ILIAS\UI\Implementation\Component\Player;
+namespace ILIAS\UI\examples\Player\Video;
 
-use ILIAS\UI\Component\Player as P;
-
-/**
- * @author Alexander Killing <killing@leifos.de>
- * @package ILIAS\UI\Implementation\Component\Player
- */
-class Factory implements P\Factory
+function video_mp4() : string
 {
-    public function audio(string $source, string $transcript = "") : P\Audio
-    {
-        return new Audio($source, $transcript);
-    }
+    global $DIC;
+    $renderer = $DIC->ui()->renderer();
+    $f = $DIC->ui()->factory();
 
-    public function video(string $source) : P\Video
-    {
-        return new Video($source);
-    }
+    $video = $f->player()->video("https://files.ilias.de/ILIAS-Video.mp4");
+    $video = $video->withAdditionalSubtitleFile("en", "./src/UI/examples/Player/Video/subtitles_en.vtt");
+    $video = $video->withAdditionalSubtitleFile("de", "./src/UI/examples/Player/Video/subtitles_de.vtt");
+
+    return $renderer->render($video);
 }

--- a/src/UI/examples/Player/Video/video_mp4_poster.php
+++ b/src/UI/examples/Player/Video/video_mp4_poster.php
@@ -16,23 +16,16 @@
  *
  *********************************************************************/
 
-namespace ILIAS\UI\Implementation\Component\Player;
+namespace ILIAS\UI\examples\Player\Video;
 
-use ILIAS\UI\Component\Player as P;
-
-/**
- * @author Alexander Killing <killing@leifos.de>
- * @package ILIAS\UI\Implementation\Component\Player
- */
-class Factory implements P\Factory
+function video_mp4_poster() : string
 {
-    public function audio(string $source, string $transcript = "") : P\Audio
-    {
-        return new Audio($source, $transcript);
-    }
+    global $DIC;
+    $renderer = $DIC->ui()->renderer();
+    $f = $DIC->ui()->factory();
 
-    public function video(string $source) : P\Video
-    {
-        return new Video($source);
-    }
+    $video = $f->player()->video("https://files.ilias.de/ILIAS-Video.mp4");
+    $video = $video->withPoster("src/UI/examples/Image/HeaderIconLarge.svg");
+
+    return $renderer->render($video);
 }

--- a/src/UI/examples/Player/Video/video_vimeo.php
+++ b/src/UI/examples/Player/Video/video_vimeo.php
@@ -16,23 +16,15 @@
  *
  *********************************************************************/
 
-namespace ILIAS\UI\Implementation\Component\Player;
+namespace ILIAS\UI\examples\Player\Video;
 
-use ILIAS\UI\Component\Player as P;
-
-/**
- * @author Alexander Killing <killing@leifos.de>
- * @package ILIAS\UI\Implementation\Component\Player
- */
-class Factory implements P\Factory
+function video_vimeo() : string
 {
-    public function audio(string $source, string $transcript = "") : P\Audio
-    {
-        return new Audio($source, $transcript);
-    }
+    global $DIC;
+    $renderer = $DIC->ui()->renderer();
+    $f = $DIC->ui()->factory();
 
-    public function video(string $source) : P\Video
-    {
-        return new Video($source);
-    }
+    $video = $f->player()->video("https://vimeo.com/669475821?controls=0");
+
+    return $renderer->render($video);
 }

--- a/src/UI/examples/Player/Video/video_youtube.php
+++ b/src/UI/examples/Player/Video/video_youtube.php
@@ -16,23 +16,15 @@
  *
  *********************************************************************/
 
-namespace ILIAS\UI\Implementation\Component\Player;
+namespace ILIAS\UI\examples\Player\Video;
 
-use ILIAS\UI\Component\Player as P;
-
-/**
- * @author Alexander Killing <killing@leifos.de>
- * @package ILIAS\UI\Implementation\Component\Player
- */
-class Factory implements P\Factory
+function video_youtube() : string
 {
-    public function audio(string $source, string $transcript = "") : P\Audio
-    {
-        return new Audio($source, $transcript);
-    }
+    global $DIC;
+    $renderer = $DIC->ui()->renderer();
+    $f = $DIC->ui()->factory();
 
-    public function video(string $source) : P\Video
-    {
-        return new Video($source);
-    }
+    $video = $f->player()->video("https://www.youtube.com/watch?v=YSN2osYbshQ");
+
+    return $renderer->render($video);
 }

--- a/src/UI/templates/default/Player/tpl.video.html
+++ b/src/UI/templates/default/Player/tpl.video.html
@@ -1,0 +1,5 @@
+<div class="il-video-container">
+    <video class="il-video-player" id="{ID}" src="{SOURCE}" style="max-width: 100%;" preload="metadata" <!-- BEGIN poster -->poster="{POSTER_SOURCE}"<!-- END poster -->>
+        <!-- BEGIN track --><track kind="subtitles" src="{TRACK_SOURCE}" srclang="{TRACK_LANG}" /><!-- END track -->
+    </video>
+</div>

--- a/tests/UI/Component/Player/PlayerVideoTest.php
+++ b/tests/UI/Component/Player/PlayerVideoTest.php
@@ -1,0 +1,146 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+require_once(__DIR__ . "/../../../../libs/composer/vendor/autoload.php");
+require_once(__DIR__ . "/../../Base.php");
+
+use \ILIAS\UI\Component as C;
+use \ILIAS\UI\Implementation as I;
+
+/**
+ * @author Alexander Killing <killing@leifos.de>
+ */
+class PlayerVideoTest extends ILIAS_UI_TestBase
+{
+    public function getUIFactory() : NoUIFactory
+    {
+        return new class extends NoUIFactory {
+            public function modal() : C\Modal\Factory
+            {
+                return new I\Component\Modal\Factory(new I\Component\SignalGenerator());
+            }
+            public function button() : C\Button\Factory
+            {
+                return new I\Component\Button\Factory();
+            }
+        };
+    }
+
+    public function getFactory() : C\Player\Factory
+    {
+        return new I\Component\Player\Factory();
+    }
+
+    public function test_implements_factory_interface() : void
+    {
+        $f = $this->getFactory();
+
+        $video = $f->video("/foo");
+
+        $this->assertInstanceOf("ILIAS\\UI\\Component\\Player\\Video", $video);
+    }
+
+    public function test_get_title_get_source() : void
+    {
+        $f = $this->getFactory();
+
+        $video = $f->video("/foo");
+
+        $this->assertEquals("/foo", $video->getSource());
+    }
+
+    public function test_get_title_get_poster() : void
+    {
+        $f = $this->getFactory();
+
+        $video = $f->video("/foo")->withPoster("bar.jpg");
+
+        $this->assertEquals("bar.jpg", $video->getPoster());
+    }
+
+    public function test_get_title_get_subtitle_file() : void
+    {
+        $f = $this->getFactory();
+
+        $video = $f->video("/foo")->withAdditionalSubtitleFile("en", "subtitles.vtt");
+
+        $this->assertEquals(["en" => "subtitles.vtt"], $video->getSubtitleFiles());
+    }
+
+    public function test_render_video() : void
+    {
+        $f = $this->getFactory();
+        $r = $this->getDefaultRenderer();
+
+        $video = $f->video("/foo");
+
+        $html = $r->render($video);
+        $expected = <<<EOT
+<div class="il-video-container">
+    <video class="il-video-player" id="id_1" src="/foo" style="max-width: 100%;" preload="metadata" >
+    </video>
+</div>
+EOT;
+        $this->assertHTMLEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($html)
+        );
+    }
+
+    public function test_render_with_poster() : void
+    {
+        $f = $this->getFactory();
+        $r = $this->getDefaultRenderer();
+
+        $video = $f->video("/foo")->withPoster("bar.jpg");
+
+        $html = $r->render($video);
+
+        $expected = <<<EOT
+<div class="il-video-container">
+    <video class="il-video-player" id="id_1" src="/foo" style="max-width: 100%;" preload="metadata" poster="bar.jpg">
+    </video>
+</div>
+EOT;
+        $this->assertHTMLEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($html)
+        );
+    }
+
+    public function test_render_with_subtitles() : void
+    {
+        $f = $this->getFactory();
+        $r = $this->getDefaultRenderer();
+
+        $video = $f->video("/foo")->withAdditionalSubtitleFile("en", "subtitles.vtt");
+
+        $html = $r->render($video);
+        $expected = <<<EOT
+<div class="il-video-container">
+    <video class="il-video-player" id="id_1" src="/foo" style="max-width: 100%;" preload="metadata" >
+        <track kind="subtitles" src="subtitles.vtt" srclang="en" />
+    </video>
+</div>
+EOT;
+        $this->assertHTMLEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($html)
+        );
+    }
+}


### PR DESCRIPTION
This is a follow-up of PR https://github.com/ILIAS-eLearning/ILIAS/pull/4041

- The withSource mutator is gone.
- The binary file has been replaced by a reference to the external resource
- Video element is grouped as a Player
- License fixed
- checkStringArg removed
- source and poster parameter details added
- redundant Docstrings removed
- tests added

> Why do we need the additional div around the video-element?

The mediaelement.js library replaces the video element with all kind of new dom nodes. The purpose of the surrounding div is to make the element addressable by ILIAS CSS, even if the default here does not come with any CSS rules. Imagine someone would like to give all video elements a certain border or margin, this may become error-prone if relying on the mediaelement.js DOM nodes, which might change from version to version.

> A11y: Consider adding an alternative audio source as additional property, so consumers have a way to implement [WCAG success criterion "Audio-only and Video-only (Prerecorded)"](https://www.w3.org/WAI/WCAG21/quickref/#audio-only-and-video-only-prerecorded). This also should be another rule then.

I am not sure, how the component itself should tackle this. Please note that the criterion addresses **video-only** content:
https://www.w3.org/WAI/WCAG21/Understanding/audio-only-and-video-only-prerecorded#dfn-video-only
Meaning a video without an audio track. Usually you have an audio track in your mp4 file making it **not** video-only content. Additionally we have the VTT files that enable to present a text alternative. We could add a SHOULD rule that an audio track should be provided and for video-only files the context needs to provide alternatives (e.g. the page editor allows to add an additional audio element). But I wouldn't add additional mp3 files to this component somehow.


