### PR TITLE
PHP 8 Code Review Awareness 

### DIFF
--- a/Services/Awareness/Administration/class.ilObjAwarenessAdministrationGUI.php
+++ b/Services/Awareness/Administration/class.ilObjAwarenessAdministrationGUI.php
@@ -24,6 +24,7 @@ class ilObjAwarenessAdministrationGUI extends ilObjectGUI
     protected \ILIAS\Awareness\AdminManager $admin_manager;
 
     public function __construct(
+        // PHP8-Review: parameter $a_data with no type specified
         $a_data,
         int $a_id,
         bool $a_call_by_reference = true,
@@ -120,7 +121,8 @@ class ilObjAwarenessAdministrationGUI extends ilObjectGUI
     /**
      * Edit settings.
      */
-    public function editSettings($a_form = null)
+    // PHP8-Review: parameter $a_form with no type specified
+    public function editSettings($a_form = null) : bool
     {
         $this->tabs_gui->setTabActive('settings');
         $this->setSubTabs("settings");
@@ -135,7 +137,7 @@ class ilObjAwarenessAdministrationGUI extends ilObjectGUI
     /**
      * Save settings
      */
-    public function saveSettings()
+    public function saveSettings() : void
     {
         $ilCtrl = $this->ctrl;
         
@@ -177,7 +179,7 @@ class ilObjAwarenessAdministrationGUI extends ilObjectGUI
     /**
      * Save settings
      */
-    public function cancel()
+    public function cancel() : void
     {
         $ilCtrl = $this->ctrl;
         
@@ -189,6 +191,7 @@ class ilObjAwarenessAdministrationGUI extends ilObjectGUI
      *
      * @access protected
      */
+    // PHP8-Review: no return type specified
     protected function initFormSettings()
     {
         $lng = $this->lng;

--- a/Services/Awareness/GlobalScreen/classes/class.ilAwarenessMetaBarProvider.php
+++ b/Services/Awareness/GlobalScreen/classes/class.ilAwarenessMetaBarProvider.php
@@ -30,7 +30,8 @@ class ilAwarenessMetaBarProvider extends AbstractStaticMetaBarProvider
     {
         return $this->if->identifier('awareness');
     }
-
+    
+    // PHP8-Review: return type has no value type specified in iterable type array
     public function getAllIdentifications() : array
     {
         return [$this->getId()];

--- a/Services/Awareness/Service/class.InternalDomainService.php
+++ b/Services/Awareness/Service/class.InternalDomainService.php
@@ -28,6 +28,7 @@ class InternalDomainService
     protected Container $dic;
     protected InternalRepoService $repo_service;
     protected InternalDataService $data_service;
+    // PHP8-Review: $managers, $collectors have no value type specified in iterable type array
     protected static array $managers = array();
     protected static array $collectors = array();
 

--- a/Services/Awareness/User/class.Collection.php
+++ b/Services/Awareness/User/class.Collection.php
@@ -21,6 +21,7 @@ namespace ILIAS\Awareness\User;
  */
 class Collection implements \Countable
 {
+    // PHP8-Review: $users has no value type specified in iterable type array
     protected array $users = array();
 
     /**

--- a/Services/Awareness/User/class.Collector.php
+++ b/Services/Awareness/User/class.Collector.php
@@ -26,6 +26,7 @@ use ILIAS\Awareness\InternalDomainService;
  */
 class Collector
 {
+    // PHP8-Review: $online_users, $online_user_ids, $collections have no value type specified in iterable type array
     protected static ?array $online_users = null;
     protected static array $online_user_ids = array();
     protected \ilRbacReview $rbacreview;
@@ -42,6 +43,7 @@ class Collector
         int $user_id,
         int $ref_id,
         InternalDataService $data_service,
+        // PHP8-Review: unused parameter $repo_service
         InternalRepoService $repo_service,
         InternalDomainService $domain_service
     ) {
@@ -54,7 +56,8 @@ class Collector
             ->admin($ref_id);
         $this->rbacreview = $domain_service->rbac()->review();
     }
-
+    
+    // PHP8-Review: return type has no value type specified in iterable type array
     public static function getOnlineUsers() : array
     {
         if (self::$online_users === null) {
@@ -76,6 +79,7 @@ class Collector
     /**
      * Collect users
      */
+    // PHP8-Review: return type has no value type specified in iterable type array
     public function collectUsers(bool $a_online_only = false) : array
     {
         $rbacreview = $this->rbacreview;
@@ -166,7 +170,8 @@ class Collector
 
         return $this->collections;
     }
-
+    
+    // PHP8-Review: no value type specified in iterable type array
     public function collectUsersFromProvider(Provider $prov, ?array $online_users) : Collection
     {
         $coll = $this->data_service->userCollection();

--- a/Services/Awareness/User/class.ProviderFactory.php
+++ b/Services/Awareness/User/class.ProviderFactory.php
@@ -23,6 +23,7 @@ use ILIAS\DI\Container;
  */
 class ProviderFactory
 {
+    // PHP8-Review: no value type specified in iterable type array
     protected static array $providers = array(
         array(
             "component" => "Services/Contact/BuddySystem",
@@ -71,7 +72,8 @@ class ProviderFactory
         foreach (self::$providers as $p) {
             $providers[] = new $p["class"]($this->dic);
         }
-
+    
+        // PHP8-Review: should return array<ILIAS\Awareness\User\Provider> but returns array<int, object>
         return $providers;
     }
 }

--- a/Services/Awareness/classes/class.AdminManager.php
+++ b/Services/Awareness/classes/class.AdminManager.php
@@ -32,7 +32,8 @@ class AdminManager
     protected \ilSetting $settings;
     protected int $user_id;
     protected int $ref_id = 0;
-
+    
+    // PHP8-Review: Constructor has an unused parameter $data_service, $repo_service
     public function __construct(
         int $ref_id,
         InternalDataService $data_service,
@@ -75,7 +76,8 @@ class AdminManager
     {
         return ($this->getActivationMode($provider_id) == self::MODE_INCL_OFFLINE);
     }
-
+    
+    // PHP8-Review: return type has no value type specified in iterable type array
     public function getModeOptions() : array
     {
         $options = array(

--- a/Services/Awareness/classes/class.Counter.php
+++ b/Services/Awareness/classes/class.Counter.php
@@ -32,12 +32,12 @@ class Counter
         $this->highlight_cnt = $highlight_cnt;
     }
 
-    public function getCount()
+    public function getCount() : int
     {
         return $this->cnt;
     }
 
-    public function getHighlightCount()
+    public function getHighlightCount() : int
     {
         return $this->highlight_cnt;
     }

--- a/Services/Awareness/classes/class.StandardGUIRequest.php
+++ b/Services/Awareness/classes/class.StandardGUIRequest.php
@@ -20,7 +20,8 @@ use ILIAS\Repository;
 class StandardGUIRequest
 {
     use Repository\BaseGUIRequest;
-
+    
+    // PHP8-Review: __construct() has parameter $passed_query_params, $passed_post_data with no value type specified in iterable type array
     public function __construct(
         \ILIAS\HTTP\Services $http,
         \ILIAS\Refinery\Factory $refinery,

--- a/Services/Awareness/classes/class.WidgetManager.php
+++ b/Services/Awareness/classes/class.WidgetManager.php
@@ -36,6 +36,7 @@ class WidgetManager
     protected int $ref_id = 0;
     protected User\Collector $user_collector;
     protected \ilUserActionCollector $action_collector;
+    // PHP8-Review: no value type specified in iterable type array
     protected array $user_collections;
     protected ?array $data = null;
     protected ?array $online_user_data = null;
@@ -128,7 +129,8 @@ class WidgetManager
         }
         return true;
     }
-
+    
+    // PHP8-Review: no return type specified
     public function processMetaBar()
     {
         $cache_period = (int) $this->settings->get("caching_period");
@@ -155,6 +157,7 @@ class WidgetManager
      * @param bool $a_online_only true, if only online users should be collected
      * @return array array of collections
      */
+    // PHP8-Review: return type has no value type specified in iterable type array
     public function getUserCollections(bool $a_online_only = false) : array
     {
         if (!isset($this->user_collections[(int) $a_online_only])) {
@@ -196,6 +199,7 @@ class WidgetManager
      * @param string $a_ts timestamp
      * @return array array of data objects
      */
+    // PHP8-Review: return type has no value type specified in iterable type array
     public function getOnlineUserData(string $a_ts = "") : array
     {
         $online_user_data = array();
@@ -265,6 +269,7 @@ class WidgetManager
      * @return array array of data objects
      * @throws \ilWACException
      */
+    // PHP8-Review: return type has no value type specified in iterable type array
     public function getListData(string $filter = "") : array
     {
         if ($this->user_id == ANONYMOUS_USER_ID) {

--- a/Services/Awareness/classes/class.ilAwarenessGUI.php
+++ b/Services/Awareness/classes/class.ilAwarenessGUI.php
@@ -33,7 +33,8 @@ class ilAwarenessGUI implements ilCtrlBaseClassInterface
     protected ilCtrl $ctrl;
     protected UIServices $ui;
     protected ilLanguage $lng;
-
+    
+    // PHP8-Review: Constructor has an unused parameter $data_service
     public function __construct(
         InternalDataService $data_service,
         InternalDomainService $domain_service,
@@ -90,6 +91,7 @@ class ilAwarenessGUI implements ilCtrlBaseClassInterface
      * Get awareness list (ajax)
      * @throws ilWACException
      */
+    // PHP8-Review: return type has no value type specified in iterable type array
     public function getAwarenessList(bool $return = false) : ?array
     {
         $filter = $this->request->getFilter();

--- a/Services/Awareness/classes/class.ilAwarenessGUI.php
+++ b/Services/Awareness/classes/class.ilAwarenessGUI.php
@@ -59,6 +59,7 @@ class ilAwarenessGUI implements ilCtrlBaseClassInterface
     {
         $cmd = $this->ctrl->getCmd();
 
+        // PHP8-Review: 'in_array' can be replaced with comparison
         if (in_array($cmd, array("getAwarenessList"))) {
             $this->$cmd();
         }

--- a/Services/Awareness/test/AwarenessSessionRepositoryTest.php
+++ b/Services/Awareness/test/AwarenessSessionRepositoryTest.php
@@ -19,7 +19,7 @@ class AwarenessSessionRepositoryTest extends TestCase
     {
     }
 
-    public function testCount()
+    public function testCount() : void
     {
         $repo = $this->repo;
         $repo->setCount(15);
@@ -29,7 +29,7 @@ class AwarenessSessionRepositoryTest extends TestCase
         );
     }
 
-    public function testHighlightCount()
+    public function testHighlightCount() : void
     {
         $repo = $this->repo;
         $repo->setHighlightCount(6);
@@ -39,7 +39,7 @@ class AwarenessSessionRepositoryTest extends TestCase
         );
     }
 
-    public function testLastUpdate()
+    public function testLastUpdate() : void
     {
         $repo = $this->repo;
         $repo->setLastUpdate(1234);
@@ -49,7 +49,7 @@ class AwarenessSessionRepositoryTest extends TestCase
         );
     }
 
-    public function testOnlineUsersTS()
+    public function testOnlineUsersTS() : void
     {
         $repo = $this->repo;
         $repo->setOnlineUsersTS("2022-01-01 16:00:05");

--- a/Services/Awareness/test/ilServicesAwarenessSuite.php
+++ b/Services/Awareness/test/ilServicesAwarenessSuite.php
@@ -22,6 +22,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilServicesAwarenessSuite extends TestSuite
 {
+    // PHP8-Review: no return type specified
     public static function suite()
     {
         $suite = new self();


### PR DESCRIPTION
Dear @alex40724 ,

I completed the review of the Services/Awareness component.

Results:

- [x] The code style is PSR-2 + X compliant
- [x] No usage of $_GET / $_POST / $_REQUEST / $_SESSION
- [x] There is a Unit Test Suite with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] There are no serious PhpStorm Code Inspection issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties) - some types are missing
--
We fixed some trivial issues reported by our inspection profile.
We marked some issues with comments, please search for PHP 8 Review.
--
Actions needed:
- [ ] Please have a look at our comments regarding missing types

Best regards,
@katringross