### PR TITLE
Tasks: PHP8 review

### DIFF
--- a/Services/Tasks/DerivedTasks/classes/class.ilDerivedTaskCollector.php
+++ b/Services/Tasks/DerivedTasks/classes/class.ilDerivedTaskCollector.php
@@ -9,7 +9,7 @@
  */
 class ilDerivedTaskCollector
 {
-    protected \ilTaskService $service;
+    protected ilTaskService $service;
 
     /**
      * Constructor

--- a/Services/Tasks/DerivedTasks/classes/class.ilDerivedTaskFactory.php
+++ b/Services/Tasks/DerivedTasks/classes/class.ilDerivedTaskFactory.php
@@ -9,13 +9,12 @@
  */
 class ilDerivedTaskFactory
 {
-    protected \ilTaskServiceDependencies $_deps;
+    protected ilTaskServiceDependencies $_deps;
 
-    protected \ilTaskService $service;
+    protected ilTaskService $service;
 
     /**
      * Constructor
-     * @param ilTaskServiceDependencies $_deps
      */
     public function __construct(ilTaskService $service)
     {
@@ -33,11 +32,8 @@ class ilDerivedTaskFactory
 
     /**
      * Entry collector
-     *
-     * @param
-     * @return
      */
-    public function collector() : \ilDerivedTaskCollector
+    public function collector() : ilDerivedTaskCollector
     {
         return new ilDerivedTaskCollector($this->service);
     }
@@ -46,7 +42,7 @@ class ilDerivedTaskFactory
      * Get all task providers
      *
      * @param bool $active_only get only active providers
-     * @param int $user_id get instances for user with user id
+     * @param int|null $user_id get instances for user with user id
      * @return ilLearningHistoryProviderInterface[]
      */
     public function getAllProviders(bool $active_only = false, int $user_id = null) : array

--- a/Services/Tasks/DerivedTasks/classes/class.ilDerivedTaskProviderMasterFactory.php
+++ b/Services/Tasks/DerivedTasks/classes/class.ilDerivedTaskProviderMasterFactory.php
@@ -2,6 +2,8 @@
 
 /* Copyright (c) 1998-2021 ILIAS open source, GPLv3, see LICENSE */
 
+use ILIAS\Survey\Tasks\DerivedTaskProviderFactory;
+
 /**
  * Derived task providers factory
  *
@@ -9,15 +11,15 @@
  */
 class ilDerivedTaskProviderMasterFactory
 {
-    protected \ilTaskService $service;
+    protected ilTaskService $service;
 
     /**
      * @var ilDerivedTaskProviderFactory[]
      */
     protected array $default_provider_factories = array(
         ilExerciseDerivedTaskProviderFactory::class,
-        \ilForumDerivedTaskProviderFactory::class,
-        \ILIAS\Survey\Tasks\DerivedTaskProviderFactory::class,
+        ilForumDerivedTaskProviderFactory::class,
+        DerivedTaskProviderFactory::class,
         ilBlogDerivedTaskProviderFactory::class
     );
 
@@ -32,7 +34,7 @@ class ilDerivedTaskProviderMasterFactory
     public function __construct(ilTaskService $service, $provider_factories = null)
     {
         if (is_null($provider_factories)) {
-            $this->provider_factories = array_map(fn ($class) : \ilDerivedTaskProviderFactory => new $class($service), $this->default_provider_factories);
+            $this->provider_factories = array_map(fn ($class) : ilDerivedTaskProviderFactory => new $class($service), $this->default_provider_factories);
         } else {
             $this->provider_factories = $provider_factories;
         }

--- a/Services/Tasks/DerivedTasks/classes/class.ilDerivedTaskService.php
+++ b/Services/Tasks/DerivedTasks/classes/class.ilDerivedTaskService.php
@@ -9,9 +9,9 @@
  */
 class ilDerivedTaskService
 {
-    protected \ilTaskServiceDependencies $_deps;
+    protected ilTaskServiceDependencies $_deps;
 
-    protected \ilTaskService $service;
+    protected ilTaskService $service;
 
     /**
      * Constructor
@@ -24,8 +24,6 @@ class ilDerivedTaskService
 
     /**
      * Subservice for derived tasks
-     *
-     * @return ilDerivedTaskService
      */
     public function factory() : ilDerivedTaskFactory
     {

--- a/Services/Tasks/DerivedTasks/classes/class.ilDerivedTasksGUI.php
+++ b/Services/Tasks/DerivedTasks/classes/class.ilDerivedTasksGUI.php
@@ -2,6 +2,9 @@
 
 /* Copyright (c) 1998-2021 ILIAS open source, GPLv3, see LICENSE */
 
+use ILIAS\DI\Container;
+use ILIAS\DI\UIServices;
+
 /**
  * Derived tasks list
  *
@@ -9,51 +12,20 @@
  */
 class ilDerivedTasksGUI implements ilCtrlBaseClassInterface
 {
-    /**
-     * @var \ILIAS\DI\Container
-     */
-    protected ?\ILIAS\DI\Container $dic;
-
-    /**
-     * @var ilCtrl
-     */
-    protected $ctrl;
-
-    /**
-     * @var ilTemplate
-     */
-    protected $main_tpl;
-
-    /**
-     * @var ilTaskService
-     */
-    protected $task;
-
-    /**
-     * @var ilObjUser
-     */
-    protected $user;
-
-    /**
-     * @var \ILIAS\DI\UIServices
-     */
-    protected $ui;
-
-    /**
-     * @var ilLanguage
-     */
-    protected $lng;
-
-    /**
-     * @var ilHelp
-     */
-    protected $help;
+    protected ?Container $dic;
+    protected ilCtrl $ctrl;
+    protected ilGlobalTemplateInterface $main_tpl;
+    protected ilTaskService $task;
+    protected ilObjUser $user;
+    protected UIServices $ui;
+    protected ilLanguage $lng;
+    protected ilHelpGUI $help;
 
     /**
      * Constructor
-     * @param \ILIAS\DI\Container|null $dic
+     * @param Container|null $dic
      */
-    public function __construct(\ILIAS\DI\Container $di_container = null)
+    public function __construct(Container $di_container = null)
     {
         global $DIC;
 
@@ -85,7 +57,7 @@ class ilDerivedTasksGUI implements ilCtrlBaseClassInterface
         $next_class = $ctrl->getNextClass($this);
         $cmd = $ctrl->getCmd("show");
 
-        if (in_array($cmd, array("show"))) {
+        if ($cmd == "show") {
             $this->$cmd();
         }
         $main_tpl->printToStdout();

--- a/Services/Tasks/GlobalScreen/classes/DerivedTaskMainBarProvider.php
+++ b/Services/Tasks/GlobalScreen/classes/DerivedTaskMainBarProvider.php
@@ -5,6 +5,7 @@
 use ILIAS\GlobalScreen\Scope\MainMenu\Provider\AbstractStaticMainMenuProvider;
 use ILIAS\MainMenu\Provider\StandardTopItemsProvider;
 use ILIAS\UI\Component\Symbol\Icon\Standard;
+use ilDerivedTasksGUI;
 
 /**
  * Main menu entry for derived tasks
@@ -38,7 +39,7 @@ class DerivedTaskMainBarProvider extends AbstractStaticMainMenuProvider
             ->withTitle($title)
             ->withPosition(40)
             ->withSymbol($icon)
-            ->withAction($dic->ctrl()->getLinkTargetByClass([\ilDerivedTasksGUI::class], ""))
+            ->withAction($dic->ctrl()->getLinkTargetByClass([ilDerivedTasksGUI::class], ""))
             ->withParent(StandardTopItemsProvider::getInstance()->getPersonalWorkspaceIdentification())
             ->withVisibilityCallable(
                 fn () : bool => true

--- a/Services/Tasks/classes/class.ilPDTasksBlockGUI.php
+++ b/Services/Tasks/classes/class.ilPDTasksBlockGUI.php
@@ -2,6 +2,8 @@
 
 /* Copyright (c) 1998-2021 ILIAS open source, GPLv3, see LICENSE */
 
+use ILIAS\UI\Component\Item\Item;
+
 /**
  * BlockGUI class for Tasks on PD
  *
@@ -224,7 +226,7 @@ class ilPDTasksBlockGUI extends ilBlockGUI
     /**
      * @inheritdoc
      */
-    protected function getListItemForData(array $data) : ?\ILIAS\UI\Component\Item\Item
+    protected function getListItemForData(array $data) : ?Item
     {
         $factory = $this->ui->factory();
         $lng = $this->lng;

--- a/Services/Tasks/classes/class.ilTaskService.php
+++ b/Services/Tasks/classes/class.ilTaskService.php
@@ -2,6 +2,8 @@
 
 /* Copyright (c) 1998-2021 ILIAS open source, GPLv3, see LICENSE */
 
+use ILIAS\DI\UIServices;
+
 /**
  * Task service
  *
@@ -9,7 +11,7 @@
  */
 class ilTaskService
 {
-    protected \ilTaskServiceDependencies $_deps;
+    protected ilTaskServiceDependencies $_deps;
 
     /**
      * This constructor contains all evil dependencies, that should e.g. be replaced for testing.
@@ -21,8 +23,8 @@ class ilTaskService
     public function __construct(
         ilObjUser $user,
         ilLanguage $lng,
-        \ILIAS\DI\UIServices $ui,
-        \ilAccessHandler $access,
+        UIServices $ui,
+        ilAccessHandler $access,
         array $derived_task_provider_factories = null
     ) {
         $derived_task_provider_master_factory = new ilDerivedTaskProviderMasterFactory($this, $derived_task_provider_factories);
@@ -46,7 +48,7 @@ class ilTaskService
      *
      * @return ilDerivedTaskService
      */
-    public function derived() : \ilDerivedTaskService
+    public function derived() : ilDerivedTaskService
     {
         return new ilDerivedTaskService($this);
     }

--- a/Services/Tasks/classes/class.ilTaskServiceDependencies.php
+++ b/Services/Tasks/classes/class.ilTaskServiceDependencies.php
@@ -2,6 +2,8 @@
 
 /* Copyright (c) 1998-2021 ILIAS open source, GPLv3, see LICENSE */
 
+use ILIAS\DI\UIServices;
+
 /**
  * Task service dependencies
  *
@@ -9,15 +11,15 @@
  */
 class ilTaskServiceDependencies
 {
-    protected \ilLanguage $lng;
+    protected ilLanguage $lng;
 
-    protected \ILIAS\DI\UIServices $ui;
+    protected UIServices $ui;
 
-    protected \ilObjUser $user;
+    protected ilObjUser $user;
 
-    protected \ilAccessHandler $access;
+    protected ilAccessHandler $access;
 
-    protected \ilDerivedTaskProviderMasterFactory $derived_task_provider_master_factory;
+    protected ilDerivedTaskProviderMasterFactory $derived_task_provider_master_factory;
 
     /**
      * Constructor
@@ -25,9 +27,9 @@ class ilTaskServiceDependencies
     public function __construct(
         ilObjUser $user,
         ilLanguage $lng,
-        \ILIAS\DI\UIServices $ui,
-        \ilAccessHandler $access,
-        \ilDerivedTaskProviderMasterFactory $derived_task_provider_master_factory
+        UIServices $ui,
+        ilAccessHandler $access,
+        ilDerivedTaskProviderMasterFactory $derived_task_provider_master_factory
     ) {
         $this->lng = $lng;
         $this->ui = $ui;
@@ -39,7 +41,7 @@ class ilTaskServiceDependencies
     /**
      * Get derived task provider master factory
      */
-    public function getDerivedTaskProviderMasterFactory() : \ilDerivedTaskProviderMasterFactory
+    public function getDerivedTaskProviderMasterFactory() : ilDerivedTaskProviderMasterFactory
     {
         return $this->derived_task_provider_master_factory;
     }
@@ -47,7 +49,7 @@ class ilTaskServiceDependencies
     /**
      * Get language object
      */
-    public function language() : \ilLanguage
+    public function language() : ilLanguage
     {
         return $this->lng;
     }
@@ -55,7 +57,7 @@ class ilTaskServiceDependencies
     /**
      * Get current user
      */
-    public function user() : \ilObjUser
+    public function user() : ilObjUser
     {
         return $this->user;
     }
@@ -63,7 +65,7 @@ class ilTaskServiceDependencies
     /**
      * Get ui service
      */
-    public function ui() : \ILIAS\DI\UIServices
+    public function ui() : UIServices
     {
         return $this->ui;
     }
@@ -71,7 +73,7 @@ class ilTaskServiceDependencies
     /**
      * Get access
      */
-    protected function getAccess() : \ilAccessHandler
+    protected function getAccess() : ilAccessHandler
     {
         return $this->access;
     }

--- a/Services/Tasks/test/class.ilDummyDerivedTaskProvider.php
+++ b/Services/Tasks/test/class.ilDummyDerivedTaskProvider.php
@@ -9,10 +9,7 @@
  */
 class ilDummyDerivedTaskProvider implements ilDerivedTaskProvider
 {
-    /**
-     * @var ilTaskService
-     */
-    protected $task_service;
+    protected ilTaskService $task_service;
 
     /**
      * Constructor

--- a/Services/Tasks/test/class.ilDummyDerivedTaskProviderFactory.php
+++ b/Services/Tasks/test/class.ilDummyDerivedTaskProviderFactory.php
@@ -9,10 +9,7 @@
  */
 class ilDummyDerivedTaskProviderFactory implements ilDerivedTaskProviderFactory
 {
-    /**
-     * @var ilTaskService
-     */
-    protected $task_service;
+    protected ilTaskService $task_service;
 
     /**
      * Constructor

--- a/Services/Tasks/test/ilDerivedTaskCollectorTest.php
+++ b/Services/Tasks/test/ilDerivedTaskCollectorTest.php
@@ -6,9 +6,9 @@ require_once __DIR__ . '/bootstrap.php';
 /**
  * @author  <killing@leifos.de>
  */
-class ilDerivedTaskCollectorTest extends \ilTasksTestBase
+class ilDerivedTaskCollectorTest extends ilTasksTestBase
 {
-    public function testGetEntries()
+    public function testGetEntries() : void
     {
         /** @var ilTaskService $service */
         $service = $this->getTaskServiceMock();

--- a/Services/Tasks/test/ilDerivedTaskFactoryTest.php
+++ b/Services/Tasks/test/ilDerivedTaskFactoryTest.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/bootstrap.php';
 /**
  * @author  <killing@leifos.de>
  */
-class ilDerivedTaskFactoryTest extends \ilTasksTestBase
+class ilDerivedTaskFactoryTest extends ilTasksTestBase
 {
     public function testConstructor()
     {
@@ -17,7 +17,7 @@ class ilDerivedTaskFactoryTest extends \ilTasksTestBase
         $this->assertTrue($factory instanceof ilDerivedTaskFactory);
     }
 
-    public function testTask()
+    public function testTask() : void
     {
         /** @var ilTaskService $service */
         $service = $this->getTaskServiceMock();
@@ -33,7 +33,7 @@ class ilDerivedTaskFactoryTest extends \ilTasksTestBase
         $this->assertEquals(0, $task->getWspId());
     }
 
-    public function testCollector()
+    public function testCollector() : void
     {
         /** @var ilTaskService $service */
         $service = $this->getTaskServiceMock();
@@ -44,13 +44,13 @@ class ilDerivedTaskFactoryTest extends \ilTasksTestBase
         $this->assertTrue($task instanceof ilDerivedTaskCollector);
     }
 
-    public function testAllProviders()
+    public function testAllProviders() : void
     {
         /** @var ilTaskService $service */
         $service = $this->getTaskServiceMock();
         $factory = $service->derived()->factory();
 
-        $providers = $factory->getAllProviders(false, null);
+        $providers = $factory->getAllProviders();
         $this->assertTrue($providers[0] instanceof ilDerivedTaskProvider);
     }
 }

--- a/Services/Tasks/test/ilDerivedTaskTest.php
+++ b/Services/Tasks/test/ilDerivedTaskTest.php
@@ -6,37 +6,37 @@ require_once __DIR__ . '/bootstrap.php';
 /**
  * @author  <killing@leifos.de>
  */
-class ilDerivedTaskTest extends \ilTasksTestBase
+class ilDerivedTaskTest extends ilTasksTestBase
 {
-    public function testTitle()
+    public function testTitle() : void
     {
         $task = new ilDerivedTask("title", 99, 1234, 1000, 0);
 
         $this->assertEquals('title', $task->getTitle());
     }
 
-    public function testRefId()
+    public function testRefId() : void
     {
         $task = new ilDerivedTask("title", 99, 1234, 1000, 0);
 
         $this->assertEquals(99, $task->getRefId());
     }
 
-    public function testDeadline()
+    public function testDeadline() : void
     {
         $task = new ilDerivedTask("title", 99, 1234, 1000, 0);
 
         $this->assertEquals(1234, $task->getDeadline());
     }
 
-    public function testStartingTime()
+    public function testStartingTime() : void
     {
         $task = new ilDerivedTask("title", 99, 1234, 1000, 0);
 
         $this->assertEquals(1000, $task->getStartingTime());
     }
 
-    public function testWspId()
+    public function testWspId() : void
     {
         $task = new ilDerivedTask("title", 99, 1234, 1000, 0);
 

--- a/Services/Tasks/test/ilServicesTasksSuite.php
+++ b/Services/Tasks/test/ilServicesTasksSuite.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestSuite;
  */
 class ilServicesTasksSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : ilServicesTasksSuite
     {
 
         //PHPUnit_Framework_Error_Deprecated::$enabled = FALSE;


### PR DESCRIPTION
# Must-Package
### What must be the agreed minimum goal from the community?  - Whether developers, operators or users.

## Goals
 * [ ] ILIAS can be used with PHP 8 without producing PHP-specific errors.
   * can't test guis, derived classes don't work
 * [x] Refactored code conforms to current coding styles
 * [x] Elimination of all warnings and errors of the static code inspection (without weak | incl. undeclared variables)
 * [x] Transfer of GET params into Constructor
 * [x] Avoidance/reduction of POST accesses (e.g. through $form->getInput()) and switch to Request classes
 * [x] Use of SESSION (session object, alternative assignment of static session in constructor member variables)
 * [x] Documentation of all existing typifications as typehints (of parameters, return values and properties)
 * [x] Creation of a unit test infrastructure in the component

## Requirements and analysis criteria
* [x] Preserve unit test coverage even in refactoring.
* [ ]  Simple call of all tabs/screens (without e.g. delete and move actions) and fixing of the corresponding bugs
  * can't test guis, derived classes don't work
* [x]  Checking of external libraries
* [x]  Basis of the refactoring and the reviews is, among others, ILIAS Development Documentation.

# Should-Package
### What do we need to do in the mid-term to catch recurring large code revisions and to refactor more than the minimum?

 * x ] Expansion of the unit test coverage
  * General and structural improvements and optimisations to the code base. For example ...
   * [ ]  ... in static functions and by removing static methods
   * [x]  ... by introducing return type declarations
   * ... by typification of all variables
     * [x] Input/output typing of methods
     * [x] Typification of member variables
 * [ ]   Use of UI components from the UI framework "KitchenSink" that have been introduced and established in the meantime. Reduction of legacy UI and legacy code.

# Sustainability-Package
### he developer community has identified topics that would also improve the quality of ILIAS from the point of view of PHP and ILIAS in general. Ideally, these topics could be directly addressed in the process of systematic refactoring.

* [ ] Introduction and use of declarations of "strict_types" for data
* [ ]  Replace previous arrays with classes that enable ArrayAccess - in future also getter / setter
* [ ]  Switching previous arrays to generators/data objects