### PR TITLE
`Refinery`: Apply review feedback / Change license header / Streamline tests 

### DIFF
--- a/src/HTTP/Wrapper/SuperGlobalDropInReplacement.php
+++ b/src/HTTP/Wrapper/SuperGlobalDropInReplacement.php
@@ -4,6 +4,8 @@ namespace ILIAS\HTTP\Wrapper;
 
 use ILIAS\Refinery\Factory;
 use ILIAS\Refinery\KeyValueAccess;
+use LogicException;
+use OutOfBoundsException;
 
 /******************************************************************************
  *
@@ -39,7 +41,7 @@ class SuperGlobalDropInReplacement extends KeyValueAccess
     public function offsetSet($offset, $value) : void
     {
         if ($this->throwOnValueAssignment) {
-            throw new \OutOfBoundsException("Modifying global Request-Array such as \$_GET is not allowed!");
+            throw new OutOfBoundsException("Modifying global Request-Array such as \$_GET is not allowed!");
         }
 
         parent::offsetSet($offset, $value);
@@ -50,6 +52,6 @@ class SuperGlobalDropInReplacement extends KeyValueAccess
      */
     public function offsetUnset($offset) : void
     {
-        throw new \LogicException("Modifying global Request-Array such as \$_GET is not allowed!");
+        throw new LogicException("Modifying global Request-Array such as \$_GET is not allowed!");
     }
 }

--- a/src/Refinery/ByTrying.php
+++ b/src/Refinery/ByTrying.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2020 Nils Haagen <nils.haagen@concepts-and-training.de>, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery;
 

--- a/src/Refinery/ByTrying.php
+++ b/src/Refinery/ByTrying.php
@@ -40,7 +40,7 @@ class ByTrying implements Transformation
     /**
      * @inheritdoc
      */
-    protected function getError()
+    protected function getError() : callable
     {
         return $this->error;
     }

--- a/src/Refinery/ByTrying.php
+++ b/src/Refinery/ByTrying.php
@@ -18,8 +18,8 @@
 
 namespace ILIAS\Refinery;
 
+use Exception;
 use ILIAS\Data;
-use ilLanguage;
 
 class ByTrying implements Transformation
 {
@@ -27,19 +27,17 @@ class ByTrying implements Transformation
     use DeriveInvokeFromTransform;
     use ProblemBuilder;
 
+    /** @var Transformation[] */
+    private array $transformations;
+    private Data\Factory $data_factory;
+    /** @var callable */
+    private $error;
+
     /**
-     * @var Transformation[]
+     * @param Transformation[] $transformations
+     * @param Data\Factory $data_factory
      */
-    protected array $transformations;
-
-    protected Data\Factory $data_factory;
-
-    /**
-     * @var callable
-     */
-    protected $error;
-
-    public function __construct(array $transformations, Data\Factory $data_factory, ilLanguage $lng)
+    public function __construct(array $transformations, Data\Factory $data_factory)
     {
         $this->transformations = $transformations;
         $this->data_factory = $data_factory;
@@ -52,7 +50,7 @@ class ByTrying implements Transformation
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function getError() : callable
     {
@@ -60,7 +58,7 @@ class ByTrying implements Transformation
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function transform($from)
     {
@@ -71,6 +69,6 @@ class ByTrying implements Transformation
                 return $result->value();
             }
         }
-        throw new \Exception($this->getErrorMessage($from));
+        throw new Exception($this->getErrorMessage($from));
     }
 }

--- a/src/Refinery/Constraint.php
+++ b/src/Refinery/Constraint.php
@@ -1,7 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2017 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
-/* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery;
 

--- a/src/Refinery/Constraint.php
+++ b/src/Refinery/Constraint.php
@@ -33,17 +33,17 @@ interface Constraint extends Transformation
      *
      * Should not throw if accepts($value).
      *
-     * @throws  UnexpectedValueException if value does not comply with encoded constraint.
-     * @param   mixed  $value
-     * @return  null
+     * @param mixed $value
+     * @return null
+     * @throws UnexpectedValueException if value does not comply with encoded constraint.
      */
     public function check($value);
 
     /**
      * Tells if the provided value complies.
      *
-     * @param   mixed $value
-     * @return  bool
+     * @param mixed $value
+     * @return bool
      */
     public function accepts($value) : bool;
 
@@ -52,8 +52,8 @@ interface Constraint extends Transformation
      *
      * Should return null if accepts($value).
      *
-     * @param   mixed $value
-     * @return  string|null
+     * @param mixed $value
+     * @return string|null
      */
     public function problemWith($value) : ?string;
 
@@ -64,8 +64,8 @@ interface Constraint extends Transformation
      * Must replace the result with an error according to problemWith() if
      * !accepts($result->value()).
      *
-     * @param   Result $result
-     * @return  Result
+     * @param Result $result
+     * @return Result
      */
     public function applyTo(Result $result) : Result;
 
@@ -79,8 +79,8 @@ interface Constraint extends Transformation
      * The builder needs to be callable that takes two parameters:
      *
      *
-     * @param   callable  $builder
-     * @return  Constraint
+     * @param callable $builder
+     * @return self
      */
-    public function withProblemBuilder(callable $builder);
+    public function withProblemBuilder(callable $builder) : self;
 }

--- a/src/Refinery/ConstraintViolationException.php
+++ b/src/Refinery/ConstraintViolationException.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery;
 

--- a/src/Refinery/ConstraintViolationException.php
+++ b/src/Refinery/ConstraintViolationException.php
@@ -23,7 +23,6 @@ use UnexpectedValueException;
 /***
  * Signals the violation of some constraint on a value in a way that can be subject
  * to i18n.
- * @author  Niels Theen <ntheen@databay.de>
  */
 class ConstraintViolationException extends UnexpectedValueException
 {

--- a/src/Refinery/Container/AddLabels.php
+++ b/src/Refinery/Container/AddLabels.php
@@ -31,14 +31,13 @@ class AddLabels implements Transformation
 {
     use DeriveInvokeFromTransform;
 
-    /**
-     * @var string[] | int[]
-     */
-    protected array $labels;
+    /** @var string[]|int[] */
+    private array $labels;
     private Factory $factory;
 
     /**
-     * @param string[] | int[] $labels
+     * @param string[]|int[] $labels
+     * @param Factory $factory
      */
     public function __construct(array $labels, Factory $factory)
     {
@@ -47,9 +46,10 @@ class AddLabels implements Transformation
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
+     * @return array<int|string, mixed>
      */
-    public function transform($from)
+    public function transform($from) : array
     {
         if (!is_array($from)) {
             throw new InvalidArgumentException(__METHOD__ . " argument is not an array.");
@@ -63,7 +63,7 @@ class AddLabels implements Transformation
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function applyTo(Result $result) : Result
     {

--- a/src/Refinery/Container/AddLabels.php
+++ b/src/Refinery/Container/AddLabels.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\Container;
 

--- a/src/Refinery/Container/Group.php
+++ b/src/Refinery/Container/Group.php
@@ -22,7 +22,7 @@ class Group
     /**
      * Adds to any array keys for each value
      */
-    public function addLabels(array $labels) : addLabels
+    public function addLabels(array $labels) : AddLabels
     {
         return new AddLabels($labels, $this->dataFactory);
     }

--- a/src/Refinery/Container/Group.php
+++ b/src/Refinery/Container/Group.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\Container;
 

--- a/src/Refinery/Container/Group.php
+++ b/src/Refinery/Container/Group.php
@@ -21,9 +21,6 @@ namespace ILIAS\Refinery\Container;
 use ILIAS\Data\Factory;
 use ILIAS\Refinery\Transformation;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 class Group
 {
     private Factory $dataFactory;
@@ -35,14 +32,20 @@ class Group
 
     /**
      * Adds to any array keys for each value
+     * @param string[]|int[] $labels
+     * @return Transformation
      */
-    public function addLabels(array $labels) : AddLabels
+    public function addLabels(array $labels) : Transformation
     {
         return new AddLabels($labels, $this->dataFactory);
     }
 
-    public function mapValues(Transformation $trafo) : MapValues
+    /**
+     * Returns a transformation which applies the given transformation to
+     * the element of the array passed to the transformation
+     */
+    public function mapValues(Transformation $trafo) : Transformation
     {
-        return new MapValues($trafo, $this->dataFactory);
+        return new MapValues($trafo);
     }
 }

--- a/src/Refinery/Container/MapValues.php
+++ b/src/Refinery/Container/MapValues.php
@@ -34,18 +34,16 @@ class MapValues implements Transformation
 
     protected string $type;
     private Transformation $trafo;
-    private Factory $factory;
 
-    public function __construct(Transformation $trafo, Factory $factory)
+    public function __construct(Transformation $trafo)
     {
         $this->trafo = $trafo;
-        $this->factory = $factory;
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function transform($from)
+    public function transform($from) : array
     {
         if (!is_array($from)) {
             throw new InvalidArgumentException(__METHOD__ . " argument is not an array.");

--- a/src/Refinery/Container/MapValues.php
+++ b/src/Refinery/Container/MapValues.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\Container;
 

--- a/src/Refinery/Custom/Constraint.php
+++ b/src/Refinery/Custom/Constraint.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
 
 namespace ILIAS\Refinery\Custom;

--- a/src/Refinery/Custom/Constraint.php
+++ b/src/Refinery/Custom/Constraint.php
@@ -1,5 +1,20 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\Custom;
 

--- a/src/Refinery/Custom/Constraint.php
+++ b/src/Refinery/Custom/Constraint.php
@@ -34,15 +34,9 @@ class Constraint implements ConstraintInterface
 
     protected Data\Factory $data_factory;
     protected ilLanguage $lng;
-
-    /**
-     * @var callable
-     */
+    /** @var callable */
     protected $is_ok;
-
-    /**
-     * @var callable|string
-     */
+    /** @var callable|string */
     protected $error;
 
     /**
@@ -52,7 +46,10 @@ class Constraint implements ConstraintInterface
      *        values are provide.
      *      - the $value for which the error message should be build.
      *
-     * @param string|callable	$error
+     * @param callable $is_ok
+     * @param string|callable $error
+     * @param Data\Factory $data_factory
+     * @param ilLanguage $lng
      */
     public function __construct(callable $is_ok, $error, Data\Factory $data_factory, ilLanguage $lng)
     {
@@ -63,7 +60,7 @@ class Constraint implements ConstraintInterface
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function getError()
     {
@@ -71,7 +68,7 @@ class Constraint implements ConstraintInterface
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     final public function check($value)
     {
@@ -83,7 +80,7 @@ class Constraint implements ConstraintInterface
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     final public function accepts($value) : bool
     {
@@ -91,7 +88,7 @@ class Constraint implements ConstraintInterface
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     final public function problemWith($value) : ?string
     {
@@ -103,7 +100,7 @@ class Constraint implements ConstraintInterface
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     final public function applyTo(Result $result) : Result
     {

--- a/src/Refinery/Custom/Group.php
+++ b/src/Refinery/Custom/Group.php
@@ -1,5 +1,20 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * @author  Niels Theen <ntheen@databay.de>
@@ -7,20 +22,14 @@
 namespace ILIAS\Refinery\Custom;
 
 use ILIAS\Data\Factory;
+use ilLanguage;
 
 class Group
 {
-    /**
-     * @var Factory
-     */
-    private $dataFactory;
+    private Factory $dataFactory;
+    private ilLanguage $language;
 
-    /**
-     * @var \ilLanguage
-     */
-    private $language;
-
-    public function __construct(Factory $dataFactory, \ilLanguage $language)
+    public function __construct(Factory $dataFactory, ilLanguage $language)
     {
         $this->dataFactory = $dataFactory;
         $this->language = $language;
@@ -28,7 +37,7 @@ class Group
 
     /**
      * @param callable $callable
-     * @param $error
+     * @param string|callable $error
      * @return Constraint
      */
     public function constraint(callable $callable, $error) : Constraint
@@ -41,10 +50,6 @@ class Group
         );
     }
 
-    /**
-     * @param callable $transform
-     * @return Transformation
-     */
     public function transformation(callable $transform) : Transformation
     {
         return new Transformation($transform, $this->dataFactory);

--- a/src/Refinery/Custom/Group.php
+++ b/src/Refinery/Custom/Group.php
@@ -16,13 +16,12 @@
  *
  *********************************************************************/
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 namespace ILIAS\Refinery\Custom;
 
 use ILIAS\Data\Factory;
 use ilLanguage;
+use ILIAS\Refinery\Constraint as ConstraintInterface;
+use ILIAS\Refinery\Transformation as TransformationInterface;
 
 class Group
 {
@@ -38,9 +37,9 @@ class Group
     /**
      * @param callable $callable
      * @param string|callable $error
-     * @return Constraint
+     * @return ConstraintInterface
      */
-    public function constraint(callable $callable, $error) : Constraint
+    public function constraint(callable $callable, $error) : ConstraintInterface
     {
         return new Constraint(
             $callable,
@@ -50,8 +49,8 @@ class Group
         );
     }
 
-    public function transformation(callable $transform) : Transformation
+    public function transformation(callable $transform) : TransformationInterface
     {
-        return new Transformation($transform, $this->dataFactory);
+        return new Transformation($transform);
     }
 }

--- a/src/Refinery/Custom/Transformation.php
+++ b/src/Refinery/Custom/Transformation.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\Custom;
 

--- a/src/Refinery/Custom/Transformation.php
+++ b/src/Refinery/Custom/Transformation.php
@@ -20,16 +20,16 @@ class Transformation implements TransformationInterface
     /**
      * @var callable
      */
-    protected $transform;
+    protected $transformation;
     private Factory $factory;
 
     /**
-     * @param callable $transform
+     * @param callable $transformation
      * @param Factory $factory
      */
-    public function __construct(callable $transform, Factory $factory)
+    public function __construct(callable $transformation, Factory $factory)
     {
-        $this->transform = $transform;
+        $this->transformation = $transformation;
         $this->factory = $factory;
     }
 
@@ -38,6 +38,6 @@ class Transformation implements TransformationInterface
      */
     public function transform($from)
     {
-        return call_user_func($this->transform, $from);
+        return call_user_func($this->transformation, $from);
     }
 }

--- a/src/Refinery/Custom/Transformation.php
+++ b/src/Refinery/Custom/Transformation.php
@@ -31,24 +31,16 @@ class Transformation implements TransformationInterface
     use DeriveApplyToFromTransform;
     use DeriveInvokeFromTransform;
 
-    /**
-     * @var callable
-     */
-    protected $transformation;
-    private Factory $factory;
+    /** @var callable */
+    private $transformation;
 
-    /**
-     * @param callable $transformation
-     * @param Factory $factory
-     */
-    public function __construct(callable $transformation, Factory $factory)
+    public function __construct(callable $transformation)
     {
         $this->transformation = $transformation;
-        $this->factory = $factory;
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function transform($from)
     {

--- a/src/Refinery/DateTime/ChangeTimezone.php
+++ b/src/Refinery/DateTime/ChangeTimezone.php
@@ -36,9 +36,6 @@ class ChangeTimezone implements Transformation
 
     private DateTimeZone $timezone;
 
-    /**
-     * @param string $timezone
-     */
     public function __construct(string $timezone)
     {
         if (!in_array($timezone, timezone_identifiers_list(), true)) {
@@ -48,16 +45,16 @@ class ChangeTimezone implements Transformation
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function transform($from)
+    public function transform($from) : DateTimeImmutable
     {
         if (!$from instanceof DateTimeImmutable) {
             throw new InvalidArgumentException("$from is not a DateTimeImmutable-object", 1);
         }
         
         $ts = $from->format('Y-m-d H:i:s');
-        $to = new DateTimeImmutable($ts, $this->timezone);
-        return $to;
+
+        return new DateTimeImmutable($ts, $this->timezone);
     }
 }

--- a/src/Refinery/DateTime/ChangeTimezone.php
+++ b/src/Refinery/DateTime/ChangeTimezone.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2019 Nils Haagen <nils.haagen@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\DateTime;
 

--- a/src/Refinery/DateTime/Group.php
+++ b/src/Refinery/DateTime/Group.php
@@ -20,9 +20,6 @@ namespace ILIAS\Refinery\DateTime;
 
 use ILIAS\Refinery\Transformation;
 
-/**
- * @author  Nils Haagen <nils.haagen@concepts-and-training.de>
- */
 class Group
 {
     public function changeTimezone(string $timezone) : Transformation

--- a/src/Refinery/DateTime/Group.php
+++ b/src/Refinery/DateTime/Group.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\DateTime;
 

--- a/src/Refinery/DeriveApplyToFromTransform.php
+++ b/src/Refinery/DeriveApplyToFromTransform.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery;
 

--- a/src/Refinery/DeriveApplyToFromTransform.php
+++ b/src/Refinery/DeriveApplyToFromTransform.php
@@ -23,18 +23,16 @@ use ILIAS\Data\Result\Ok;
 use ILIAS\Data\Result\Error;
 use Exception;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 trait DeriveApplyToFromTransform
 {
     /**
-     * @param mixed $from
-     * @return mixed
-     * @throws Exception
+     * @inheritDoc
      */
     abstract public function transform($from);
 
+    /**
+     * @inheritDoc
+     */
     public function applyTo(Result $result) : Result
     {
         return $result->then(function ($value) : Result {

--- a/src/Refinery/DeriveInvokeFromTransform.php
+++ b/src/Refinery/DeriveInvokeFromTransform.php
@@ -1,5 +1,20 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery;
 

--- a/src/Refinery/DeriveInvokeFromTransform.php
+++ b/src/Refinery/DeriveInvokeFromTransform.php
@@ -21,22 +21,15 @@ namespace ILIAS\Refinery;
 use Exception;
 use InvalidArgumentException;
 
-/**
- * @author  Richard Klees <richard.klees@concepts-and-training.de>
- */
 trait DeriveInvokeFromTransform
 {
     /**
-     * @param mixed $from
-     * @return mixed
-     * @throws Exception
+     * @inheritDoc
      */
     abstract public function transform($from);
 
     /**
-     * @throws InvalidArgumentException  if the argument could not be transformed
-     * @param  mixed  $from
-     * @return mixed
+     * @inheritDoc
      */
     public function __invoke($from)
     {

--- a/src/Refinery/DeriveTransformFromApplyTo.php
+++ b/src/Refinery/DeriveTransformFromApplyTo.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery;
 

--- a/src/Refinery/DeriveTransformFromApplyTo.php
+++ b/src/Refinery/DeriveTransformFromApplyTo.php
@@ -21,17 +21,15 @@ namespace ILIAS\Refinery;
 use ILIAS\Data\Result;
 use Exception;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 trait DeriveTransformFromApplyTo
 {
+    /**
+     * @inheritDoc
+     */
     abstract public function applyTo(Result $result) : Result;
 
     /**
-     * @param mixed $from
-     * @return mixed
-     * @throws Exception
+     * @inheritDoc
      */
     public function transform($from)
     {

--- a/src/Refinery/Factory.php
+++ b/src/Refinery/Factory.php
@@ -121,7 +121,7 @@ class Factory
     /**
      * Contains constraints for null types
      */
-    public function null() : IsNull
+    public function null() : Constraint
     {
         return new IsNull($this->dataFactory, $this->language);
     }
@@ -164,7 +164,7 @@ class Factory
         return new RandomGroup();
     }
 
-    public function identity() : IdentityTransformation
+    public function identity() : Transformation
     {
         return new IdentityTransformation();
     }

--- a/src/Refinery/Factory.php
+++ b/src/Refinery/Factory.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery;
 

--- a/src/Refinery/Factory.php
+++ b/src/Refinery/Factory.php
@@ -23,9 +23,6 @@ use ILIAS\Refinery\To;
 use ILIAS\Refinery\Random\Group as RandomGroup;
 use ilLanguage;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 class Factory
 {
     private \ILIAS\Data\Factory $dataFactory;
@@ -159,7 +156,7 @@ class Factory
      */
     public function byTrying(array $transformations) : ByTrying
     {
-        return new ByTrying($transformations, $this->dataFactory, $this->language);
+        return new ByTrying($transformations, $this->dataFactory);
     }
 
     public function random() : RandomGroup

--- a/src/Refinery/IdentityTransformation.php
+++ b/src/Refinery/IdentityTransformation.php
@@ -1,6 +1,22 @@
 <?php declare(strict_types=1);
 
 /**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+/**
  * @author  Lukas Scharmer <lscharmer@databay.de>
  */
 namespace ILIAS\Refinery;

--- a/src/Refinery/IdentityTransformation.php
+++ b/src/Refinery/IdentityTransformation.php
@@ -16,12 +16,7 @@
  *
  *********************************************************************/
 
-/**
- * @author  Lukas Scharmer <lscharmer@databay.de>
- */
 namespace ILIAS\Refinery;
-
-use InvalidArgumentException;
 
 class IdentityTransformation implements Transformation
 {
@@ -29,7 +24,7 @@ class IdentityTransformation implements Transformation
     use DeriveApplyToFromTransform;
 
     /**
-     * @throws InvalidArgumentException
+     * @inheritDoc
      */
     public function transform($from)
     {

--- a/src/Refinery/In/Group.php
+++ b/src/Refinery/In/Group.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\In;
 

--- a/src/Refinery/In/Group.php
+++ b/src/Refinery/In/Group.php
@@ -20,15 +20,13 @@ namespace ILIAS\Refinery\In;
 
 use ILIAS\Refinery\Transformation;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 class Group
 {
-
     /**
      * Takes an array of transformations and performs them one after
      * another on the result of the previous transformation
+     * @param Transformation[] $inTransformations
+     * @return Transformation
      */
     public function series(array $inTransformations) : Transformation
     {
@@ -38,6 +36,8 @@ class Group
     /**
      * Takes an array of transformations and performs each on the
      * input value to form a tuple of the results
+     * @param Transformation[] $inTransformations
+     * @return Transformation
      */
     public function parallel(array $inTransformations) : Transformation
     {

--- a/src/Refinery/In/Parallel.php
+++ b/src/Refinery/In/Parallel.php
@@ -24,21 +24,16 @@ use ILIAS\Refinery\ConstraintViolationException;
 use ILIAS\Refinery\DeriveInvokeFromTransform;
 use InvalidArgumentException;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 class Parallel implements Transformation
 {
     use DeriveApplyToFromTransform;
     use DeriveInvokeFromTransform;
 
-    /**
-     * @var Transformation[]
-     */
+    /** @var Transformation[] */
     private array $transformationStrategies;
 
     /**
-     * @param array $transformations
+     * @param Transformation[] $transformations
      * @throws InvalidArgumentException
      */
     public function __construct(array $transformations)
@@ -58,11 +53,11 @@ class Parallel implements Transformation
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function transform($from)
+    public function transform($from) : array
     {
-        $results = array();
+        $results = [];
         foreach ($this->transformationStrategies as $strategy) {
             $results[] = $strategy->transform($from);
         }

--- a/src/Refinery/In/Parallel.php
+++ b/src/Refinery/In/Parallel.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\In;
 

--- a/src/Refinery/In/Series.php
+++ b/src/Refinery/In/Series.php
@@ -23,21 +23,16 @@ use ILIAS\Refinery\DeriveApplyToFromTransform;
 use ILIAS\Refinery\ConstraintViolationException;
 use ILIAS\Refinery\DeriveInvokeFromTransform;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 class Series implements Transformation
 {
     use DeriveApplyToFromTransform;
     use DeriveInvokeFromTransform;
 
-    /**
-     * @var Transformation[]
-     */
+    /** @var Transformation[] */
     private array $transformationStrategies;
 
     /**
-     * @param array $transformations
+     * @param Transformation[] $transformations
      */
     public function __construct(array $transformations)
     {
@@ -56,7 +51,7 @@ class Series implements Transformation
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function transform($from)
     {

--- a/src/Refinery/In/Series.php
+++ b/src/Refinery/In/Series.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\In;
 

--- a/src/Refinery/Integer/GreaterThan.php
+++ b/src/Refinery/Integer/GreaterThan.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\Integer;
 

--- a/src/Refinery/Integer/GreaterThan.php
+++ b/src/Refinery/Integer/GreaterThan.php
@@ -19,22 +19,19 @@
 namespace ILIAS\Refinery\Integer;
 
 use ILIAS\Data;
-use ILIAS\Refinery\Custom\Constraint as CustomConstraint;
+use ILIAS\Refinery\Custom\Constraint;
 use ilLanguage;
 
-class GreaterThan extends CustomConstraint
+class GreaterThan extends Constraint
 {
-    protected int $min;
-
     public function __construct(int $min, Data\Factory $data_factory, ilLanguage $lng)
     {
-        $this->min = $min;
         parent::__construct(
-            function ($value) : bool {
-                return $value > $this->min;
+            static function ($value) use ($min) : bool {
+                return $value > $min;
             },
-            function ($txt, $value) : string {
-                return (string) $txt("not_greater_than", $value, $this->min);
+            static function ($txt, $value) use ($min) : string {
+                return (string) $txt("not_greater_than", $value, $min);
             },
             $data_factory,
             $lng

--- a/src/Refinery/Integer/GreaterThanOrEqual.php
+++ b/src/Refinery/Integer/GreaterThanOrEqual.php
@@ -18,24 +18,20 @@
 
 namespace ILIAS\Refinery\Integer;
 
-use ILIAS\Refinery\Constraint;
 use ILIAS\Data;
-use ILIAS\Refinery\Custom\Constraint as CustomConstraint;
+use ILIAS\Refinery\Custom\Constraint;
 use ilLanguage;
 
-class GreaterThanOrEqual extends CustomConstraint implements Constraint
+class GreaterThanOrEqual extends Constraint
 {
-    protected int $min;
-
     public function __construct(int $min, Data\Factory $data_factory, ilLanguage $lng)
     {
-        $this->min = $min;
         parent::__construct(
-            function ($value) : bool {
-                return $value >= $this->min;
+            static function ($value) use ($min) : bool {
+                return $value >= $min;
             },
-            function ($txt, $value) : string {
-                return (string) $txt("not_greater_than_or_equal", $this->min);
+            static function ($txt, $value) use ($min) : string {
+                return (string) $txt("not_greater_than_or_equal", $min);
             },
             $data_factory,
             $lng

--- a/src/Refinery/Integer/GreaterThanOrEqual.php
+++ b/src/Refinery/Integer/GreaterThanOrEqual.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2021 Luka Stocker <luka.stocker@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\Integer;
 

--- a/src/Refinery/Integer/Group.php
+++ b/src/Refinery/Integer/Group.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\Integer;
 

--- a/src/Refinery/Integer/Group.php
+++ b/src/Refinery/Integer/Group.php
@@ -19,11 +19,9 @@
 namespace ILIAS\Refinery\Integer;
 
 use ILIAS\Data\Factory;
+use ILIAS\Refinery\Constraint;
 use ilLanguage;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 class Group
 {
     private Factory $dataFactory;
@@ -39,7 +37,7 @@ class Group
      * Creates a constraint that can be used to check if an integer value is
      * greater than the defined lower limit.
      */
-    public function isGreaterThan(int $minimum) : GreaterThan
+    public function isGreaterThan(int $minimum) : Constraint
     {
         return new GreaterThan($minimum, $this->dataFactory, $this->language);
     }
@@ -48,7 +46,7 @@ class Group
      * Creates a constraint that can be used to check if an integer value is
      * less than the defined upper limit.
      */
-    public function isLessThan(int $maximum) : LessThan
+    public function isLessThan(int $maximum) : Constraint
     {
         return new LessThan($maximum, $this->dataFactory, $this->language);
     }
@@ -57,7 +55,7 @@ class Group
      * Creates a constraint that can be used to check if an integer value is
      * greater than or equal the defined lower limit.
      */
-    public function isGreaterThanOrEqual(int $minimum) : GreaterThanOrEqual
+    public function isGreaterThanOrEqual(int $minimum) : Constraint
     {
         return new GreaterThanOrEqual($minimum, $this->dataFactory, $this->language);
     }
@@ -66,7 +64,7 @@ class Group
      * Creates a constraint that can be used to check if an integer value is
      * less than or equal the defined upper limit.
      */
-    public function isLessThanOrEqual(int $maximum) : LessThanOrEqual
+    public function isLessThanOrEqual(int $maximum) : Constraint
     {
         return new LessThanOrEqual($maximum, $this->dataFactory, $this->language);
     }

--- a/src/Refinery/Integer/LessThan.php
+++ b/src/Refinery/Integer/LessThan.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\Integer;
 

--- a/src/Refinery/Integer/LessThan.php
+++ b/src/Refinery/Integer/LessThan.php
@@ -19,22 +19,19 @@
 namespace ILIAS\Refinery\Integer;
 
 use ILIAS\Data;
-use ILIAS\Refinery\Custom\Constraint as CustomConstraint;
+use ILIAS\Refinery\Custom\Constraint;
 use ilLanguage;
 
-class LessThan extends CustomConstraint
+class LessThan extends Constraint
 {
-    protected int $max;
-
     public function __construct(int $max, Data\Factory $data_factory, ilLanguage $lng)
     {
-        $this->max = $max;
         parent::__construct(
-            function ($value) : bool {
-                return $value < $this->max;
+            static function ($value) use ($max) : bool {
+                return $value < $max;
             },
-            function ($txt, $value) : string {
-                return (string) $txt("not_less_than", $value, $this->max);
+            static function ($txt, $value) use ($max) : string {
+                return (string) $txt("not_less_than", $value, $max);
             },
             $data_factory,
             $lng

--- a/src/Refinery/Integer/LessThanOrEqual.php
+++ b/src/Refinery/Integer/LessThanOrEqual.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2021 Luka Stocker <luka.stocker@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\Integer;
 

--- a/src/Refinery/Integer/LessThanOrEqual.php
+++ b/src/Refinery/Integer/LessThanOrEqual.php
@@ -18,24 +18,20 @@
 
 namespace ILIAS\Refinery\Integer;
 
-use ILIAS\Refinery\Constraint;
 use ILIAS\Data;
-use ILIAS\Refinery\Custom\Constraint as CustomConstraint;
+use ILIAS\Refinery\Custom\Constraint;
 use ilLanguage;
 
-class LessThanOrEqual extends CustomConstraint implements Constraint
+class LessThanOrEqual extends Constraint
 {
-    protected int $max;
-
     public function __construct(int $max, Data\Factory $data_factory, ilLanguage $lng)
     {
-        $this->max = $max;
         parent::__construct(
-            function ($value) : bool {
-                return $value <= $this->max;
+            static function ($value) use ($max) : bool {
+                return $value <= $max;
             },
-            function ($txt, $value) : string {
-                return (string) $txt("not_less_than_or_equal", $this->max);
+            static function ($txt, $value) use ($max) : string {
+                return (string) $txt("not_less_than_or_equal", $max);
             },
             $data_factory,
             $lng

--- a/src/Refinery/IsNull.php
+++ b/src/Refinery/IsNull.php
@@ -20,10 +20,10 @@ class IsNull extends CustomConstraint
     public function __construct(Data\Factory $data_factory, ilLanguage $lng)
     {
         parent::__construct(
-            function ($value) {
+            static function ($value) : bool {
                 return is_null($value);
             },
-            function ($txt, $value) {
+            static function ($txt, $value) : string {
                 return $txt("not_a_null", gettype($value));
             },
             $data_factory,

--- a/src/Refinery/IsNull.php
+++ b/src/Refinery/IsNull.php
@@ -18,18 +18,11 @@
 
 namespace ILIAS\Refinery;
 
-use ILIAS\Refinery\Custom\Constraint as CustomConstraint;
+use ILIAS\Refinery\Custom\Constraint;
 use ILIAS\Data;
 use ilLanguage;
 
-/**
- * Class IsNull
- *
- * @package ILIAS\Refinery\Validation\Constraints
- *
- * @author  Fabian Schmid <fs@studer-raimann.ch>
- */
-class IsNull extends CustomConstraint
+class IsNull extends Constraint
 {
     public function __construct(Data\Factory $data_factory, ilLanguage $lng)
     {

--- a/src/Refinery/IsNull.php
+++ b/src/Refinery/IsNull.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2018 Fabian Schmid <fs@studer-raimann.ch> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery;
 

--- a/src/Refinery/KeyValueAccess.php
+++ b/src/Refinery/KeyValueAccess.php
@@ -82,7 +82,7 @@ class KeyValueAccess implements ArrayAccess, Countable
     /**
      * @inheritDoc
      */
-    public function count()
+    public function count() : int
     {
         return count($this->raw_values);
     }

--- a/src/Refinery/KeyValueAccess.php
+++ b/src/Refinery/KeyValueAccess.php
@@ -1,5 +1,21 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 namespace ILIAS\Refinery;
 
 use Closure;

--- a/src/Refinery/KeyValueAccess.php
+++ b/src/Refinery/KeyValueAccess.php
@@ -22,20 +22,11 @@ use Closure;
 use ArrayAccess;
 use Countable;
 
-/**
- * Class KeyValueAccess
- * @author Fabian Schmid <fs@studer-raimann.ch>
- */
 class KeyValueAccess implements ArrayAccess, Countable
 {
     private array $raw_values;
-    protected Transformation $trafo;
+    private Transformation $trafo;
 
-    /**
-     * KeyValueAccess constructor.
-     * @param array          $raw_values
-     * @param Transformation $trafo
-     */
     public function __construct(array $raw_values, Transformation $trafo)
     {
         $this->trafo = $trafo;

--- a/src/Refinery/KindlyTo/Group.php
+++ b/src/Refinery/KindlyTo/Group.php
@@ -1,7 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2020 Richard Klees, Extended GPL, see docs/LICENSE */
-/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\KindlyTo;
 

--- a/src/Refinery/KindlyTo/Group.php
+++ b/src/Refinery/KindlyTo/Group.php
@@ -215,7 +215,7 @@ class Group
      * This supports all data represented as PHP array.
      * This will accept array with more fields than expected, but drop the extra fields.
      *
-     * @param array<string,Transformation> $transformations
+     * @param array<string, Transformation> $transformations
      */
     public function recordOf(array $transformations) : Transformation
     {

--- a/src/Refinery/KindlyTo/Transformation/BooleanTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/BooleanTransformation.php
@@ -36,9 +36,9 @@ class BooleanTransformation implements Transformation
     use DeriveInvokeFromTransform;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function transform($from)
+    public function transform($from) : bool
     {
         if (is_bool($from)) {
             return $from;

--- a/src/Refinery/KindlyTo/Transformation/BooleanTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/BooleanTransformation.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\KindlyTo\Transformation;
 

--- a/src/Refinery/KindlyTo/Transformation/DateTimeTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/DateTimeTransformation.php
@@ -38,9 +38,9 @@ class DateTimeTransformation implements Transformation
     use DeriveInvokeFromTransform;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function transform($from)
+    public function transform($from) : DateTimeImmutable
     {
         if ($from instanceof DateTimeImmutable) {
             return $from;

--- a/src/Refinery/KindlyTo/Transformation/DateTimeTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/DateTimeTransformation.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\KindlyTo\Transformation;
 

--- a/src/Refinery/KindlyTo/Transformation/DictionaryTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/DictionaryTransformation.php
@@ -36,9 +36,10 @@ class DictionaryTransformation implements Transformation
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
+     * @return array<string, mixed>
      */
-    public function transform($from)
+    public function transform($from) : array
     {
         if (!is_array($from)) {
             throw new ConstraintViolationException(
@@ -59,6 +60,7 @@ class DictionaryTransformation implements Transformation
             $transformedValue = $this->transformation->transform($value);
             $result[(string) $key] = $transformedValue;
         }
+
         return $result;
     }
 }

--- a/src/Refinery/KindlyTo/Transformation/DictionaryTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/DictionaryTransformation.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\KindlyTo\Transformation;
 

--- a/src/Refinery/KindlyTo/Transformation/FloatTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/FloatTransformation.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\KindlyTo\Transformation;
 

--- a/src/Refinery/KindlyTo/Transformation/FloatTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/FloatTransformation.php
@@ -32,9 +32,9 @@ class FloatTransformation implements Transformation
     use DeriveInvokeFromTransform;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function transform($from)
+    public function transform($from) : float
     {
         if ($from !== INF && $from !== -INF && is_float($from) && !is_nan($from)) {
             return $from;

--- a/src/Refinery/KindlyTo/Transformation/IntegerTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/IntegerTransformation.php
@@ -31,9 +31,9 @@ class IntegerTransformation implements Transformation
     use DeriveInvokeFromTransform;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function transform($from)
+    public function transform($from) : int
     {
         if (is_int($from)) {
             return $from;

--- a/src/Refinery/KindlyTo/Transformation/IntegerTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/IntegerTransformation.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\KindlyTo\Transformation;
 

--- a/src/Refinery/KindlyTo/Transformation/ListTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/ListTransformation.php
@@ -35,9 +35,9 @@ class ListTransformation implements Transformation
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function transform($from)
+    public function transform($from) : array
     {
         if (!is_array($from)) {
             $from = [$from];
@@ -48,6 +48,7 @@ class ListTransformation implements Transformation
             $transformedVal = $this->transformation->transform($val);
             $result[] = $transformedVal;
         }
+
         return $result;
     }
 }

--- a/src/Refinery/KindlyTo/Transformation/ListTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/ListTransformation.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 Luka Kai Alexander Stocker, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\KindlyTo\Transformation;
 

--- a/src/Refinery/KindlyTo/Transformation/NullTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/NullTransformation.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2020 Nils Haagen <nils.haagen@concepts-and-training.de>, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\KindlyTo\Transformation;
 

--- a/src/Refinery/KindlyTo/Transformation/NullTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/NullTransformation.php
@@ -29,7 +29,7 @@ class NullTransformation implements Transformation
     use DeriveInvokeFromTransform;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function transform($from)
     {

--- a/src/Refinery/KindlyTo/Transformation/RecordTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/RecordTransformation.php
@@ -28,10 +28,11 @@ class RecordTransformation implements Transformation
     use DeriveApplyToFromTransform;
     use DeriveInvokeFromTransform;
 
+    /** @var array<string, Transformation> */
     private array $transformations;
 
     /**
-     *@param Transformation[] $transformations
+     * @param array<string, Transformation> $transformations
      */
     public function __construct(array $transformations)
     {
@@ -59,8 +60,9 @@ class RecordTransformation implements Transformation
 
     /**
      * @inheritDoc
+     * @return array<string, mixed>
      */
-    public function transform($from)
+    public function transform($from) : array
     {
         if (!is_array($from)) {
             throw new ConstraintViolationException(
@@ -81,6 +83,7 @@ class RecordTransformation implements Transformation
             }
             $result[$key] = $transformation->transform($from[$key]);
         }
+
         return $result;
     }
 }

--- a/src/Refinery/KindlyTo/Transformation/RecordTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/RecordTransformation.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\KindlyTo\Transformation;
 

--- a/src/Refinery/KindlyTo/Transformation/StringTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/StringTransformation.php
@@ -36,9 +36,9 @@ class StringTransformation implements Transformation
     use DeriveInvokeFromTransform;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function transform($from)
+    public function transform($from) : string
     {
         if (is_int($from) || is_float($from)) {
             return (string) $from;

--- a/src/Refinery/KindlyTo/Transformation/StringTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/StringTransformation.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\KindlyTo\Transformation;
 

--- a/src/Refinery/KindlyTo/Transformation/TupleTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/TupleTransformation.php
@@ -28,6 +28,7 @@ class TupleTransformation implements Transformation
     use DeriveApplyToFromTransform;
     use DeriveInvokeFromTransform;
 
+    /** @var Transformation[] */
     private array $transformations;
 
     /**
@@ -52,7 +53,7 @@ class TupleTransformation implements Transformation
     /**
      * @inheritDoc
      */
-    public function transform($from)
+    public function transform($from) : array
     {
         if (!is_array($from)) {
             $from = [$from];
@@ -72,7 +73,7 @@ class TupleTransformation implements Transformation
         foreach ($from as $key => $value) {
             if (!array_key_exists($key, $this->transformations)) {
                 throw new ConstraintViolationException(
-                    sprintf('Matching value "%s" not found', $value),
+                    sprintf('Matching key "%s" not found', $key),
                     'matching_values_not_found',
                     $value
                 );
@@ -80,6 +81,7 @@ class TupleTransformation implements Transformation
             $transformedValue = $this->transformations[$key]->transform($value);
             $result[] = $transformedValue;
         }
+
         return $result;
     }
 

--- a/src/Refinery/KindlyTo/Transformation/TupleTransformation.php
+++ b/src/Refinery/KindlyTo/Transformation/TupleTransformation.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\KindlyTo\Transformation;
 

--- a/src/Refinery/Logical/Group.php
+++ b/src/Refinery/Logical/Group.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\Logical;
 

--- a/src/Refinery/Logical/Group.php
+++ b/src/Refinery/Logical/Group.php
@@ -20,11 +20,9 @@ namespace ILIAS\Refinery\Logical;
 
 use ILIAS\Data\Factory;
 use ILIAS\Refinery\Custom\Constraint;
+use ILIAS\Refinery\Constraint as ConstraintInterface;
 use ilLanguage;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 class Group
 {
     private Factory $dataFactory;
@@ -36,22 +34,34 @@ class Group
         $this->language = $language;
     }
 
-    public function logicalOr(array $other) : LogicalOr
+    /**
+     * @param Constraint[] $other
+     * @return ConstraintInterface
+     */
+    public function logicalOr(array $other) : ConstraintInterface
     {
         return new LogicalOr($other, $this->dataFactory, $this->language);
     }
 
-    public function not(Constraint $constraint) : Not
+    public function not(Constraint $constraint) : ConstraintInterface
     {
         return new Not($constraint, $this->dataFactory, $this->language);
     }
 
-    public function parallel(array $constraints) : Parallel
+    /**
+     * @param Constraint[] $constraints
+     * @return ConstraintInterface
+     */
+    public function parallel(array $constraints) : ConstraintInterface
     {
         return new Parallel($constraints, $this->dataFactory, $this->language);
     }
 
-    public function sequential(array $constraints) : Sequential
+    /**
+     * @param Constraint[] $constraints
+     * @return ConstraintInterface
+     */
+    public function sequential(array $constraints) : ConstraintInterface
     {
         return new Sequential($constraints, $this->dataFactory, $this->language);
     }

--- a/src/Refinery/Logical/LogicalOr.php
+++ b/src/Refinery/Logical/LogicalOr.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2018 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\Logical;
 

--- a/src/Refinery/Logical/LogicalOr.php
+++ b/src/Refinery/Logical/LogicalOr.php
@@ -22,18 +22,8 @@ use ILIAS\Refinery\Custom\Constraint;
 use ILIAS\Data;
 use ilLanguage;
 
-/**
- * Class LogicalOr
- * @package ILIAS\Refinery\Validation\Constraints
- * @author  Michael Jansen <mjansen@databay.de>
- */
 class LogicalOr extends Constraint
 {
-    /**
-     * @var Constraint[]
-     */
-    protected array $other = [];
-
     /**
      * LogicalOr constructor.
      * @param Constraint[] $other
@@ -42,11 +32,9 @@ class LogicalOr extends Constraint
      */
     public function __construct(array $other, Data\Factory $data_factory, ilLanguage $lng)
     {
-        $this->other = $other;
-
         parent::__construct(
-            function ($value) {
-                foreach ($this->other as $constraint) {
+            static function ($value) use ($other) : bool {
+                foreach ($other as $constraint) {
                     if ($constraint->accepts($value)) {
                         return true;
                     }
@@ -54,10 +42,10 @@ class LogicalOr extends Constraint
 
                 return false;
             },
-            function ($value) {
+            static function ($value) use ($other) : string {
                 $problems = [];
 
-                foreach ($this->other as $constraint) {
+                foreach ($other as $constraint) {
                     $problems[] = $constraint->getErrorMessage($value);
                 }
 

--- a/src/Refinery/Logical/Not.php
+++ b/src/Refinery/Logical/Not.php
@@ -24,17 +24,14 @@ use ilLanguage;
 
 class Not extends Constraint
 {
-    protected Constraint $constraint;
-
     public function __construct(Constraint $constraint, Data\Factory $data_factory, ilLanguage $lng)
     {
-        $this->constraint = $constraint;
         parent::__construct(
-            function ($value) {
-                return !$this->constraint->accepts($value);
+            static function ($value) use ($constraint) {
+                return !$constraint->accepts($value);
             },
-            function ($txt, $value) {
-                return $txt("not_generic", $this->constraint->getErrorMessage($value));
+            static function ($txt, $value) use ($constraint) : string {
+                return (string) $txt("not_generic", $constraint->getErrorMessage($value));
             },
             $data_factory,
             $lng

--- a/src/Refinery/Logical/Not.php
+++ b/src/Refinery/Logical/Not.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\Logical;
 

--- a/src/Refinery/Logical/Parallel.php
+++ b/src/Refinery/Logical/Parallel.php
@@ -25,11 +25,6 @@ use ilLanguage;
 class Parallel extends Constraint
 {
     /**
-     * @var Constraint[]
-     */
-    protected array $constraints;
-
-    /**
      * There's a test to show this state will never be visible
      * ParallelTest::testCorrectErrorMessagesAfterMultiAccept
      *
@@ -37,14 +32,18 @@ class Parallel extends Constraint
      */
     protected array $failed_constraints;
 
+    /**
+     * @param Constraint[] $constraints
+     * @param Data\Factory $data_factory
+     * @param ilLanguage $lng
+     */
     public function __construct(array $constraints, Data\Factory $data_factory, ilLanguage $lng)
     {
-        $this->constraints = $constraints;
         parent::__construct(
-            function ($value) {
+            function ($value) use ($constraints) : bool {
                 $ret = true;
-                $this->failed_constraints = array();
-                foreach ($this->constraints as $constraint) {
+                $this->failed_constraints = [];
+                foreach ($constraints as $constraint) {
                     if (!$constraint->accepts($value)) {
                         $this->failed_constraints[] = $constraint;
                         $ret = false;
@@ -53,7 +52,7 @@ class Parallel extends Constraint
 
                 return $ret;
             },
-            function ($txt, $value) {
+            function ($txt, $value) : string {
                 $messages = [];
                 foreach ($this->failed_constraints as $constraint) {
                     $messages[] = $constraint->getErrorMessage($value);

--- a/src/Refinery/Logical/Parallel.php
+++ b/src/Refinery/Logical/Parallel.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\Logical;
 

--- a/src/Refinery/Logical/Sequential.php
+++ b/src/Refinery/Logical/Sequential.php
@@ -25,24 +25,23 @@ use ilLanguage;
 class Sequential extends Constraint
 {
     /**
-     * @var Constraint[]
-     */
-    protected array $constraints;
-
-    /**
      * There's a test to show this state will never be visible
      * SequentialTest::testCorrectErrorMessagesAfterMultiAccept
      *
      * @var Constraint
      */
-    protected Constraint $failed_constraint;
+    private Constraint $failed_constraint;
 
+    /**
+     * @param Constraint[] $constraints
+     * @param Data\Factory $data_factory
+     * @param ilLanguage $lng
+     */
     public function __construct(array $constraints, Data\Factory $data_factory, ilLanguage $lng)
     {
-        $this->constraints = $constraints;
         parent::__construct(
-            function ($value) {
-                foreach ($this->constraints as $constraint) {
+            function ($value) use ($constraints) : bool {
+                foreach ($constraints as $constraint) {
                     if (!$constraint->accepts($value)) {
                         $this->failed_constraint = $constraint;
                         return false;
@@ -51,7 +50,7 @@ class Sequential extends Constraint
 
                 return true;
             },
-            function ($txt, $value) {
+            function ($txt, $value) : string {
                 return $this->failed_constraint->getErrorMessage($value);
             },
             $data_factory,

--- a/src/Refinery/Logical/Sequential.php
+++ b/src/Refinery/Logical/Sequential.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\Logical;
 

--- a/src/Refinery/Numeric/Group.php
+++ b/src/Refinery/Numeric/Group.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\Numeric;
 

--- a/src/Refinery/Numeric/Group.php
+++ b/src/Refinery/Numeric/Group.php
@@ -19,11 +19,9 @@
 namespace ILIAS\Refinery\Numeric;
 
 use ILIAS\Data\Factory;
+use ILIAS\Refinery\Constraint;
 use ilLanguage;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 class Group
 {
     private Factory $dataFactory;
@@ -35,7 +33,7 @@ class Group
         $this->language = $language;
     }
 
-    public function isNumeric() : IsNumeric
+    public function isNumeric() : Constraint
     {
         return new IsNumeric($this->dataFactory, $this->language);
     }

--- a/src/Refinery/Numeric/IsNumeric.php
+++ b/src/Refinery/Numeric/IsNumeric.php
@@ -18,11 +18,11 @@
 
 namespace ILIAS\Refinery\Numeric;
 
-use ILIAS\Refinery\Custom\Constraint as CustomConstraint;
+use ILIAS\Refinery\Custom\Constraint;
 use ILIAS\Data;
 use ilLanguage;
 
-class IsNumeric extends CustomConstraint
+class IsNumeric extends Constraint
 {
     public function __construct(Data\Factory $data_factory, ilLanguage $lng)
     {
@@ -32,10 +32,10 @@ class IsNumeric extends CustomConstraint
             },
             static function ($txt, $value) : string {
                 if ('' === $value) {
-                    return $txt("not_numeric_empty_string");
+                    return (string) $txt("not_numeric_empty_string");
                 }
 
-                return $txt("not_numeric", $value);
+                return (string) $txt("not_numeric", $value);
             },
             $data_factory,
             $lng

--- a/src/Refinery/Numeric/IsNumeric.php
+++ b/src/Refinery/Numeric/IsNumeric.php
@@ -13,10 +13,10 @@ class IsNumeric extends CustomConstraint
     public function __construct(Data\Factory $data_factory, ilLanguage $lng)
     {
         parent::__construct(
-            function ($value) {
+            static function ($value) : bool {
                 return is_numeric($value);
             },
-            function ($txt, $value) {
+            static function ($txt, $value) : string {
                 if ('' === $value) {
                     return $txt("not_numeric_empty_string");
                 }

--- a/src/Refinery/Numeric/IsNumeric.php
+++ b/src/Refinery/Numeric/IsNumeric.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2017 Timon Amstutz <timon.amstutz@ilub.unibe.ch> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\Numeric;
 

--- a/src/Refinery/Password/Group.php
+++ b/src/Refinery/Password/Group.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\Password;
 

--- a/src/Refinery/Password/Group.php
+++ b/src/Refinery/Password/Group.php
@@ -19,11 +19,9 @@
 namespace ILIAS\Refinery\Password;
 
 use ILIAS\Data\Factory;
+use ILIAS\Refinery\Constraint;
 use ilLanguage;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 class Group
 {
     protected Factory $data_factory;
@@ -38,7 +36,7 @@ class Group
     /**
      * Get the constraint that a password has a minimum length.
      */
-    public function hasMinLength(int $min_length) : HasMinLength
+    public function hasMinLength(int $min_length) : Constraint
     {
         return new HasMinLength($min_length, $this->data_factory, $this->lng);
     }
@@ -46,7 +44,7 @@ class Group
     /**
      * Get the constraint that a password has upper case chars.
      */
-    public function hasUpperChars() : HasUpperChars
+    public function hasUpperChars() : Constraint
     {
         return new HasUpperChars($this->data_factory, $this->lng);
     }
@@ -54,7 +52,7 @@ class Group
     /**
      * Get the constraint that a password has lower case chars.
      */
-    public function hasLowerChars() : HasLowerChars
+    public function hasLowerChars() : Constraint
     {
         return new HasLowerChars($this->data_factory, $this->lng);
     }
@@ -62,7 +60,7 @@ class Group
     /**
      * Get the constraint that a password has numbers.
      */
-    public function hasNumbers() : HasNumbers
+    public function hasNumbers() : Constraint
     {
         return new HasNumbers($this->data_factory, $this->lng);
     }
@@ -70,7 +68,7 @@ class Group
     /**
      * Get the constraint that a password has special chars.
      */
-    public function hasSpecialChars() : HasSpecialChars
+    public function hasSpecialChars() : Constraint
     {
         return new HasSpecialChars($this->data_factory, $this->lng);
     }

--- a/src/Refinery/Password/HasLowerChars.php
+++ b/src/Refinery/Password/HasLowerChars.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2018 Nils Haagen <nils.haagen@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\Password;
 

--- a/src/Refinery/Password/HasLowerChars.php
+++ b/src/Refinery/Password/HasLowerChars.php
@@ -13,10 +13,10 @@ class HasLowerChars extends CustomConstraint
     public function __construct(Data\Factory $data_factory, ilLanguage $lng)
     {
         parent::__construct(
-            function (Data\Password $value) {
+            static function (Data\Password $value) : bool {
                 return (bool) preg_match('/[a-z]/', $value->toString());
             },
-            function ($value) {
+            static function ($value) : string {
                 return "Password must contain lower-case characters.";
             },
             $data_factory,

--- a/src/Refinery/Password/HasLowerChars.php
+++ b/src/Refinery/Password/HasLowerChars.php
@@ -18,11 +18,11 @@
 
 namespace ILIAS\Refinery\Password;
 
-use ILIAS\Refinery\Custom\Constraint as CustomConstraint;
+use ILIAS\Refinery\Custom\Constraint;
 use ILIAS\Data;
 use ilLanguage;
 
-class HasLowerChars extends CustomConstraint
+class HasLowerChars extends Constraint
 {
     public function __construct(Data\Factory $data_factory, ilLanguage $lng)
     {

--- a/src/Refinery/Password/HasMinLength.php
+++ b/src/Refinery/Password/HasMinLength.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2018 Nils Haagen <nils.haagen@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\Password;
 

--- a/src/Refinery/Password/HasMinLength.php
+++ b/src/Refinery/Password/HasMinLength.php
@@ -18,23 +18,20 @@
 
 namespace ILIAS\Refinery\Password;
 
-use ILIAS\Refinery\Custom\Constraint as CustomConstraint;
+use ILIAS\Refinery\Custom\Constraint;
 use ILIAS\Data;
 use ilLanguage;
 
-class HasMinLength extends CustomConstraint
+class HasMinLength extends Constraint
 {
-    protected int $min_length;
-
     public function __construct(int $min_length, Data\Factory $data_factory, ilLanguage $lng)
     {
-        $this->min_length = $min_length;
         parent::__construct(
-            function (Data\Password $value) {
-                return strlen($value->toString()) >= $this->min_length;
+            static function (Data\Password $value) use ($min_length) : bool {
+                return strlen($value->toString()) >= $min_length;
             },
-            function ($value) {
-                return "Password has a length less than '$this->min_length'.";
+            static function ($value) use ($min_length) : string {
+                return "Password has a length less than '$min_length'.";
             },
             $data_factory,
             $lng

--- a/src/Refinery/Password/HasNumbers.php
+++ b/src/Refinery/Password/HasNumbers.php
@@ -13,10 +13,10 @@ class HasNumbers extends CustomConstraint
     public function __construct(Data\Factory $data_factory, ilLanguage $lng)
     {
         parent::__construct(
-            function (Data\Password $value) {
+            static function (Data\Password $value) : bool {
                 return (bool) preg_match('/[0-9]/', $value->toString());
             },
-            function ($value) {
+            static function ($value) : string {
                 return "Password must contain numbers.";
             },
             $data_factory,

--- a/src/Refinery/Password/HasNumbers.php
+++ b/src/Refinery/Password/HasNumbers.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2018 Nils Haagen <nils.haagen@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\Password;
 

--- a/src/Refinery/Password/HasNumbers.php
+++ b/src/Refinery/Password/HasNumbers.php
@@ -18,11 +18,11 @@
 
 namespace ILIAS\Refinery\Password;
 
-use ILIAS\Refinery\Custom\Constraint as CustomConstraint;
+use ILIAS\Refinery\Custom\Constraint;
 use ILIAS\Data;
 use ilLanguage;
 
-class HasNumbers extends CustomConstraint
+class HasNumbers extends Constraint
 {
     public function __construct(Data\Factory $data_factory, ilLanguage $lng)
     {

--- a/src/Refinery/Password/HasSpecialChars.php
+++ b/src/Refinery/Password/HasSpecialChars.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2018 Nils Haagen <nils.haagen@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\Password;
 

--- a/src/Refinery/Password/HasSpecialChars.php
+++ b/src/Refinery/Password/HasSpecialChars.php
@@ -18,19 +18,19 @@
 
 namespace ILIAS\Refinery\Password;
 
-use ILIAS\Refinery\Custom\Constraint as CustomConstraint;
+use ILIAS\Refinery\Custom\Constraint;
 use ILIAS\Data;
 use ilLanguage;
 
-class HasSpecialChars extends CustomConstraint
+class HasSpecialChars extends Constraint
 {
-    protected static string $ALLOWED_CHARS = '/[,_.\-#\+\*?!%§\(\)\$]/u';
+    private const ALLOWED_CHARS = '/[,_.\-#\+\*?!%§\(\)\$]/u';
 
     public function __construct(Data\Factory $data_factory, ilLanguage $lng)
     {
         parent::__construct(
             static function (Data\Password $value) : bool {
-                return (bool) preg_match(static::$ALLOWED_CHARS, $value->toString());
+                return (bool) preg_match(self::ALLOWED_CHARS, $value->toString());
             },
             static function ($value) : string {
                 return "Password must contain special chars.";

--- a/src/Refinery/Password/HasSpecialChars.php
+++ b/src/Refinery/Password/HasSpecialChars.php
@@ -15,10 +15,10 @@ class HasSpecialChars extends CustomConstraint
     public function __construct(Data\Factory $data_factory, ilLanguage $lng)
     {
         parent::__construct(
-            function (Data\Password $value) {
+            static function (Data\Password $value) : bool {
                 return (bool) preg_match(static::$ALLOWED_CHARS, $value->toString());
             },
-            function ($value) {
+            static function ($value) : string {
                 return "Password must contain special chars.";
             },
             $data_factory,

--- a/src/Refinery/Password/HasUpperChars.php
+++ b/src/Refinery/Password/HasUpperChars.php
@@ -18,11 +18,11 @@
 
 namespace ILIAS\Refinery\Password;
 
-use ILIAS\Refinery\Custom\Constraint as CustomConstraint;
+use ILIAS\Refinery\Custom\Constraint;
 use ILIAS\Data;
 use ilLanguage;
 
-class HasUpperChars extends CustomConstraint
+class HasUpperChars extends Constraint
 {
     public function __construct(Data\Factory $data_factory, ilLanguage $lng)
     {

--- a/src/Refinery/Password/HasUpperChars.php
+++ b/src/Refinery/Password/HasUpperChars.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2018 Nils Haagen <nils.haagen@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\Password;
 

--- a/src/Refinery/Password/HasUpperChars.php
+++ b/src/Refinery/Password/HasUpperChars.php
@@ -13,10 +13,10 @@ class HasUpperChars extends CustomConstraint
     public function __construct(Data\Factory $data_factory, ilLanguage $lng)
     {
         parent::__construct(
-            function (Data\Password $value) {
+            static function (Data\Password $value) : bool {
                 return (bool) preg_match('/[A-Z]/', $value->toString());
             },
-            function ($value) {
+            static function ($value) : string {
                 return "Password must contain upper-case characters.";
             },
             $data_factory,

--- a/src/Refinery/ProblemBuilder.php
+++ b/src/Refinery/ProblemBuilder.php
@@ -4,7 +4,6 @@
 
 namespace ILIAS\Refinery;
 
-
 use Closure;
 use InvalidArgumentException;
 
@@ -41,10 +40,9 @@ trait ProblemBuilder
     /**
      * Get the closure to be passed to the error-function that does i18n and
      * sprintf.
-     *
      * @return  Closure
      */
-    final protected function getLngClosure()
+    final protected function getLngClosure() : Closure
     {
         return function () {
             $args = func_get_args();
@@ -53,12 +51,13 @@ trait ProblemBuilder
                     "Expected an id of a lang var as first parameter"
                 );
             }
+
             $error = $this->lng->txt($args[0]);
             if (count($args) > 1) {
                 $args[0] = $error;
                 for ($i = 0, $numArgs = count($args); $i < $numArgs; $i++) {
                     $v = $args[$i];
-                    if ((is_array($v) || (is_object($v) && !method_exists($v, "__toString")) || is_null($v))) {
+                    if (is_array($v) || is_null($v) || (is_object($v) && !method_exists($v, "__toString"))) {
                         if (is_array($v)) {
                             $args[$i] = "array";
                         } elseif (is_null($v)) {
@@ -70,6 +69,7 @@ trait ProblemBuilder
                 }
                 $error = sprintf(...$args);
             }
+
             return $error;
         };
     }

--- a/src/Refinery/ProblemBuilder.php
+++ b/src/Refinery/ProblemBuilder.php
@@ -29,9 +29,9 @@ trait ProblemBuilder
     abstract protected function getError();
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    final public function withProblemBuilder(callable $builder)
+    final public function withProblemBuilder(callable $builder) : self
     {
         $clone = clone $this;
         $clone->error = $builder;

--- a/src/Refinery/ProblemBuilder.php
+++ b/src/Refinery/ProblemBuilder.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2020 Nils Haagen <nils.haagen@concepts-and-training.de>, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery;
 
@@ -26,6 +40,8 @@ trait ProblemBuilder
 
     /**
      * Get the problem message
+     * @param mixed $value
+     * @return string
      */
     final public function getErrorMessage($value) : string
     {
@@ -38,9 +54,8 @@ trait ProblemBuilder
     }
 
     /**
-     * Get the closure to be passed to the error-function that does i18n and
-     * sprintf.
-     * @return  Closure
+     * Get the closure to be passed to the error-function that does i18n and sprintf.
+     * @return Closure
      */
     final protected function getLngClosure() : Closure
     {

--- a/src/Refinery/ROADMAP.md
+++ b/src/Refinery/ROADMAP.md
@@ -27,3 +27,7 @@ of the planned features of this service.
 * Unify the concepts of `Transformation` and `Constraints` and remove remaining
   unused classes.
 * Implement tree based XHTML Transformation for `MakeClickable` transformation
+* While adding explicit types for ILIAS 8 we noticed that there is a type problem with
+  the `src/Refinery/Logical/Group.php` and the respective contraints. All `Logicla` constraints depend on the
+  `\ILIAS\Refinery\ProblemBuilder::getErrorMessage`. This means only classes using the `ProblemBuilder` trait
+  can be passed as an argument when calling the factory methods in `src/Refinery/Logical/Group.php`.

--- a/src/Refinery/Random/Group.php
+++ b/src/Refinery/Random/Group.php
@@ -1,6 +1,22 @@
 <?php declare(strict_types=1);
 
 /**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+/**
  * @author  Lukas Scharmer <lscharmer@databay.de>
  */
 namespace ILIAS\Refinery\Random;

--- a/src/Refinery/Random/Group.php
+++ b/src/Refinery/Random/Group.php
@@ -16,9 +16,6 @@
  *
  *********************************************************************/
 
-/**
- * @author  Lukas Scharmer <lscharmer@databay.de>
- */
 namespace ILIAS\Refinery\Random;
 
 use ILIAS\Refinery\Transformation;

--- a/src/Refinery/Random/Seed/GivenSeed.php
+++ b/src/Refinery/Random/Seed/GivenSeed.php
@@ -1,6 +1,22 @@
 <?php declare(strict_types=1);
 
 /**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+/**
  * @author  Lukas Scharmer <lscharmer@databay.de>
  */
 namespace ILIAS\Refinery\Random\Seed;

--- a/src/Refinery/Random/Seed/GivenSeed.php
+++ b/src/Refinery/Random/Seed/GivenSeed.php
@@ -16,9 +16,6 @@
  *
  *********************************************************************/
 
-/**
- * @author  Lukas Scharmer <lscharmer@databay.de>
- */
 namespace ILIAS\Refinery\Random\Seed;
 
 class GivenSeed implements Seed
@@ -30,6 +27,9 @@ class GivenSeed implements Seed
         $this->seed = $seed;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function seedRandomGenerator() : void
     {
         mt_srand($this->seed);

--- a/src/Refinery/Random/Seed/RandomSeed.php
+++ b/src/Refinery/Random/Seed/RandomSeed.php
@@ -1,6 +1,22 @@
 <?php declare(strict_types=1);
 
 /**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+/**
  * @author  Lukas Scharmer <lscharmer@databay.de>
  */
 namespace ILIAS\Refinery\Random\Seed;

--- a/src/Refinery/Random/Seed/RandomSeed.php
+++ b/src/Refinery/Random/Seed/RandomSeed.php
@@ -16,9 +16,6 @@
  *
  *********************************************************************/
 
-/**
- * @author  Lukas Scharmer <lscharmer@databay.de>
- */
 namespace ILIAS\Refinery\Random\Seed;
 
 class RandomSeed extends GivenSeed
@@ -31,7 +28,7 @@ class RandomSeed extends GivenSeed
     public function createSeed() : int
     {
         $array = explode(' ', microtime());
-        $seed = $array[1] + ($array[0] * 100000);
+        $seed = ((int) $array[1]) + (((float) $array[0]) * 100000);
 
         return (int) $seed;
     }

--- a/src/Refinery/Random/Seed/Seed.php
+++ b/src/Refinery/Random/Seed/Seed.php
@@ -1,6 +1,22 @@
 <?php declare(strict_types=1);
 
 /**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+/**
  * @author  Lukas Scharmer <lscharmer@databay.de>
  */
 namespace ILIAS\Refinery\Random\Seed;

--- a/src/Refinery/Random/Seed/Seed.php
+++ b/src/Refinery/Random/Seed/Seed.php
@@ -16,12 +16,13 @@
  *
  *********************************************************************/
 
-/**
- * @author  Lukas Scharmer <lscharmer@databay.de>
- */
 namespace ILIAS\Refinery\Random\Seed;
 
 interface Seed
 {
+    /**
+     * Seeds a random number generator.
+     * @return void
+     */
     public function seedRandomGenerator() : void;
 }

--- a/src/Refinery/Random/Transformation/ShuffleTransformation.php
+++ b/src/Refinery/Random/Transformation/ShuffleTransformation.php
@@ -1,6 +1,22 @@
 <?php declare(strict_types=1);
 
 /**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+/**
  * @author  Lukas Scharmer <lscharmer@databay.de>
  */
 namespace ILIAS\Refinery\Random\Transformation;

--- a/src/Refinery/Random/Transformation/ShuffleTransformation.php
+++ b/src/Refinery/Random/Transformation/ShuffleTransformation.php
@@ -16,9 +16,6 @@
  *
  *********************************************************************/
 
-/**
- * @author  Lukas Scharmer <lscharmer@databay.de>
- */
 namespace ILIAS\Refinery\Random\Transformation;
 
 use ILIAS\Refinery\Random\Seed\Seed;

--- a/src/Refinery/Random/Transformation/ShuffleTransformation.php
+++ b/src/Refinery/Random/Transformation/ShuffleTransformation.php
@@ -30,18 +30,14 @@ class ShuffleTransformation implements Transformation
         $this->seed = $seed;
     }
 
-    /**
-     * @throws ConstraintViolationException
-     * @return array
-     */
-    public function transform($array)
+    public function transform($from) : array
     {
-        if (!is_array($array)) {
+        if (!is_array($from)) {
             throw new ConstraintViolationException('not an array', 'no_array');
         }
         $this->seed->seedRandomGenerator();
-        shuffle($array);
+        shuffle($from);
 
-        return $array;
+        return $from;
     }
 }

--- a/src/Refinery/String/CaseOfLabel.php
+++ b/src/Refinery/String/CaseOfLabel.php
@@ -1,5 +1,21 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 namespace ILIAS\Refinery\String;
 
 use ILIAS\Data\Factory;

--- a/src/Refinery/String/CaseOfLabel.php
+++ b/src/Refinery/String/CaseOfLabel.php
@@ -31,18 +31,14 @@ use ILIAS\Refinery\DeriveInvokeFromTransform;
  * Format a text for the title capitalization presentation (Specification at https://docu.ilias.de/goto_docu_pg_1430_42.html)
  *
  * Throws a LogicException in the transform method, if a not supported language is passed
- *
- * @package ILIAS\Refinery\String
- *
- * @author  studer + raimann ag - Team Custom 1 <support-custom1@studer-raimann.ch>
  */
 class CaseOfLabel implements Transformation
 {
     use DeriveApplyToFromTransform;
     use DeriveInvokeFromTransform;
 
-    protected string $language_key;
-    protected Factory $factory;
+    private string $language_key;
+    /** @var array<string, string[]>  */
     protected array $not_capitalize = [
         "en" => [
             // conjunctions
@@ -184,19 +180,17 @@ class CaseOfLabel implements Transformation
         ]
     ];
 
-    public function __construct(string $language_key, Factory $factory)
+    public function __construct(string $language_key)
     {
         $this->language_key = $language_key;
-        $this->factory = $factory;
     }
 
 
     /**
      * @inheritDoc
-     *
      * @throws LogicException
      */
-    public function transform($from)
+    public function transform($from) : string
     {
         if (!is_string($from)) {
             throw new InvalidArgumentException(__METHOD__ . " the argument is not a string.");
@@ -222,7 +216,7 @@ class CaseOfLabel implements Transformation
         return $to;
     }
 
-    protected function buildPatterns(array $words) : array
+    private function buildPatterns(array $words) : array
     {
         return array_reduce($words, function (array $patterns, string $word) : array {
             $patterns[$this->buildPattern($word)] = [ $this, "replaceHelper" ];
@@ -231,7 +225,7 @@ class CaseOfLabel implements Transformation
         }, []);
     }
 
-    protected function buildPattern(string $word) : string
+    private function buildPattern(string $word) : string
     {
         // Before the word muss be the start of the string or a space
         // After the word muss be the end of the string or a space
@@ -239,7 +233,7 @@ class CaseOfLabel implements Transformation
         return "/(\s|^)" . preg_quote($word, '/') . "(\s|$)/i";
     }
 
-    protected function replaceHelper(array $result) : string
+    private function replaceHelper(array $result) : string
     {
         return strtolower($result[0] ?? "");
     }

--- a/src/Refinery/String/EstimatedReadingTime.php
+++ b/src/Refinery/String/EstimatedReadingTime.php
@@ -34,7 +34,6 @@ class EstimatedReadingTime implements Transformation
     use DeriveInvokeFromTransform;
 
     private int $wordsPerMinute = 275;
-    private int $firstImageReadingTimeInSeconds = 12;
     private bool $withImages;
 
     public function __construct(bool $withImages)
@@ -43,9 +42,9 @@ class EstimatedReadingTime implements Transformation
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function transform($from)
+    public function transform($from) : int
     {
         if (!is_string($from)) {
             throw new InvalidArgumentException(__METHOD__ . " the argument is not a string.");

--- a/src/Refinery/String/EstimatedReadingTime.php
+++ b/src/Refinery/String/EstimatedReadingTime.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\String;
 

--- a/src/Refinery/String/Group.php
+++ b/src/Refinery/String/Group.php
@@ -19,12 +19,10 @@
 namespace ILIAS\Refinery\String;
 
 use ILIAS\Data\Factory;
+use ILIAS\Refinery\Constraint;
 use ILIAS\Refinery\Transformation;
 use ilLanguage;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 class Group
 {
     private Factory $dataFactory;
@@ -42,9 +40,9 @@ class Group
      *
      * @param int $minimum - minimum length of a string that will be checked
      *                       with the new constraint
-     * @return HasMinLength
+     * @return Constraint
      */
-    public function hasMinLength(int $minimum) : HasMinLength
+    public function hasMinLength(int $minimum) : Constraint
     {
         return new HasMinLength($minimum, $this->dataFactory, $this->language);
     }
@@ -55,9 +53,9 @@ class Group
      *
      * @param int $maximum - maximum length of a strings that will be checked
      *                       with the new constraint
-     * @return HasMaxLength
+     * @return Constraint
      */
-    public function hasMaxLength(int $maximum) : HasMaxLength
+    public function hasMaxLength(int $maximum) : Constraint
     {
         return new HasMaxLength($maximum, $this->dataFactory, $this->language);
     }
@@ -66,7 +64,7 @@ class Group
      * Creates a transformation that can be used to split a given
      * string by given delimiter.
      */
-    public function splitString(string $delimiter) : SplitString
+    public function splitString(string $delimiter) : Transformation
     {
         return new SplitString($delimiter, $this->dataFactory);
     }
@@ -76,7 +74,7 @@ class Group
      *
      * Uses php's strip_tags under the hood.
      */
-    public function stripTags() : StripTags
+    public function stripTags() : Transformation
     {
         return new StripTags();
     }
@@ -86,9 +84,9 @@ class Group
      *
      * Throws a LogicException in the transform method, if a not supported language is passed
      */
-    public function caseOfLabel(string $language_key) : CaseOfLabel
+    public function caseOfLabel(string $language_key) : Transformation
     {
-        return new CaseOfLabel($language_key, $this->dataFactory);
+        return new CaseOfLabel($language_key);
     }
 
     /**
@@ -100,7 +98,7 @@ class Group
      * Any images after the tenth image are counted at three seconds.
      * The reading time returned in minutes as a integer value.
      */
-    public function estimatedReadingTime(bool $withImages = false) : EstimatedReadingTime
+    public function estimatedReadingTime(bool $withImages = false) : Transformation
     {
         return new EstimatedReadingTime($withImages);
     }

--- a/src/Refinery/String/Group.php
+++ b/src/Refinery/String/Group.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\String;
 

--- a/src/Refinery/String/HasMaxLength.php
+++ b/src/Refinery/String/HasMaxLength.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2017 Jesús López <lopez@leifos.com> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\String;
 

--- a/src/Refinery/String/HasMaxLength.php
+++ b/src/Refinery/String/HasMaxLength.php
@@ -19,22 +19,19 @@
 namespace ILIAS\Refinery\String;
 
 use ILIAS\Data;
-use ILIAS\Refinery\Custom\Constraint as CustomConstraint;
+use ILIAS\Refinery\Custom\Constraint;
 use ilLanguage;
 
-class HasMaxLength extends CustomConstraint
+class HasMaxLength extends Constraint
 {
-    protected int $max_length;
-
     public function __construct(int $max_length, Data\Factory $data_factory, ilLanguage $lng)
     {
-        $this->max_length = $max_length;
         parent::__construct(
-            function ($value) {
-                return strlen($value) <= $this->max_length;
+            static function ($value) use ($max_length) : bool {
+                return strlen($value) <= $max_length;
             },
-            function ($txt, $value) {
-                return $txt("not_max_length", $this->max_length);
+            static function ($txt, $value) use ($max_length) : string {
+                return $txt("not_max_length", $max_length);
             },
             $data_factory,
             $lng

--- a/src/Refinery/String/HasMinLength.php
+++ b/src/Refinery/String/HasMinLength.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\String;
 

--- a/src/Refinery/String/HasMinLength.php
+++ b/src/Refinery/String/HasMinLength.php
@@ -19,23 +19,20 @@
 namespace ILIAS\Refinery\String;
 
 use ILIAS\Data;
-use ILIAS\Refinery\Custom\Constraint as CustomConstraint;
+use ILIAS\Refinery\Custom\Constraint;
 use ilLanguage;
 
-class HasMinLength extends CustomConstraint
+class HasMinLength extends Constraint
 {
-    protected int $min_length;
-
     public function __construct(int $min_length, Data\Factory $data_factory, ilLanguage $lng)
     {
-        $this->min_length = $min_length;
         parent::__construct(
-            function ($value) {
-                return strlen($value) >= $this->min_length;
+            static function ($value) use ($min_length) : bool {
+                return strlen($value) >= $min_length;
             },
-            function ($txt, $value) {
+            static function ($txt, $value) use ($min_length) : string {
                 $len = strlen($value);
-                return $txt("not_min_length", $len, $this->min_length);
+                return $txt("not_min_length", $len, $min_length);
             },
             $data_factory,
             $lng

--- a/src/Refinery/String/MakeClickable.php
+++ b/src/Refinery/String/MakeClickable.php
@@ -28,6 +28,9 @@ class MakeClickable implements Transformation
     use DeriveApplyToFromTransform;
     use DeriveInvokeFromTransform;
 
+    /**
+     * @inheritDoc
+     */
     public function transform($from) : string
     {
         $this->requireString($from);
@@ -64,6 +67,10 @@ class MakeClickable implements Transformation
         return strlen($string);
     }
 
+    /**
+     * @param mixed $maybeHTML
+     * @return void
+     */
     private function requireString($maybeHTML) : void
     {
         if (!is_string($maybeHTML)) {

--- a/src/Refinery/String/MakeClickable.php
+++ b/src/Refinery/String/MakeClickable.php
@@ -1,5 +1,21 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 namespace ILIAS\Refinery\String;
 
 use ILIAS\Refinery\Transformation;

--- a/src/Refinery/String/MakeClickable.php
+++ b/src/Refinery/String/MakeClickable.php
@@ -12,33 +12,30 @@ class MakeClickable implements Transformation
     use DeriveApplyToFromTransform;
     use DeriveInvokeFromTransform;
 
-    /**
-     * @return string
-     */
-    public function transform($maybeHTML)
+    public function transform($from) : string
     {
-        $this->requireString($maybeHTML);
+        $this->requireString($from);
 
         $endOfMatch = 0;
         $stringParts = [];
         $matches = [];
-        while (1 === preg_match('@(^|[^[:alnum:]])(((https?://)|(www.))[^[:cntrl:][:space:]<>\'"]+)([^[:alnum:]]|$)@', substr($maybeHTML, $endOfMatch), $matches)) {
+        while (1 === preg_match('@(^|[^[:alnum:]])(((https?://)|(www.))[^[:cntrl:][:space:]<>\'"]+)([^[:alnum:]]|$)@', substr($from, $endOfMatch), $matches)) {
             $oldIndex = $endOfMatch;
-            $endOfMatch += strpos(substr($maybeHTML, $endOfMatch), $matches[0]);
-            $stringParts[] = substr($maybeHTML, $oldIndex, $endOfMatch - $oldIndex);
+            $endOfMatch += strpos(substr($from, $endOfMatch), $matches[0]);
+            $stringParts[] = substr($from, $oldIndex, $endOfMatch - $oldIndex);
             $startOfMatch = $endOfMatch;
             $endOfMatch += strlen($matches[1] . $matches[2]);
-            if ($this->shouldReplace($maybeHTML, $startOfMatch, $endOfMatch)) {
+            if ($this->shouldReplace($from, $startOfMatch, $endOfMatch)) {
                 $maybeProtocol = '' === $matches[4] ? 'https://' : '';
-                $stringParts[] = sprintf('%s<a href="%s">%s</a>', $matches[1], $maybeProtocol . $matches[2], $matches[2], $matches[6]);
+                $stringParts[] = sprintf('%s<a href="%s">%s</a>', $matches[1], $maybeProtocol . $matches[2], $matches[2]);
                 continue;
             }
             $stringParts[] = $matches[1] . $matches[2];
         }
 
-        $stringParts[] = substr($maybeHTML, $endOfMatch);
+        $stringParts[] = substr($from, $endOfMatch);
 
-        return join('', $stringParts);
+        return implode('', $stringParts);
     }
 
     private function regexPos(string $regexp, string $string) : int

--- a/src/Refinery/String/SplitString.php
+++ b/src/Refinery/String/SplitString.php
@@ -31,7 +31,7 @@ class SplitString implements Transformation
 {
     use DeriveInvokeFromTransform;
 
-    protected string $delimiter;
+    private string $delimiter;
     private Factory $factory;
 
     public function __construct(string $delimiter, Factory $factory)
@@ -41,9 +41,10 @@ class SplitString implements Transformation
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
+     * @return string[]
      */
-    public function transform($from)
+    public function transform($from) : array
     {
         if (!is_string($from)) {
             throw new InvalidArgumentException(__METHOD__ . " the argument is not a string.");
@@ -53,7 +54,7 @@ class SplitString implements Transformation
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function applyTo(Result $result) : Result
     {

--- a/src/Refinery/String/SplitString.php
+++ b/src/Refinery/String/SplitString.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\String;
 

--- a/src/Refinery/String/StripTags.php
+++ b/src/Refinery/String/StripTags.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\String;
 

--- a/src/Refinery/String/StripTags.php
+++ b/src/Refinery/String/StripTags.php
@@ -32,9 +32,9 @@ class StripTags implements Transformation
     use DeriveInvokeFromTransform;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function transform($from)
+    public function transform($from) : string
     {
         if (!is_string($from)) {
             throw new InvalidArgumentException(__METHOD__ . " the argument is not a string.");

--- a/src/Refinery/To/Group.php
+++ b/src/Refinery/To/Group.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\To;
 

--- a/src/Refinery/To/Group.php
+++ b/src/Refinery/To/Group.php
@@ -31,17 +31,12 @@ use ILIAS\Refinery\To\Transformation\TupleTransformation;
 use ILIAS\Refinery\To\Transformation\DateTimeTransformation;
 use ILIAS\Refinery\Transformation;
 use ILIAS\Data\Factory;
+use InvalidArgumentException;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 class Group
 {
     private Factory $dataFactory;
 
-    /**
-     * @param Factory $dataFactory
-     */
     public function __construct(Factory $dataFactory)
     {
         $this->dataFactory = $dataFactory;
@@ -51,7 +46,7 @@ class Group
      * Returns an object that allows to transform a value
      * to a string value
      */
-    public function string() : StringTransformation
+    public function string() : Transformation
     {
         return new StringTransformation();
     }
@@ -60,7 +55,7 @@ class Group
      * Returns an object that allows to transform a value
      * to an integer value
      */
-    public function int() : IntegerTransformation
+    public function int() : Transformation
     {
         return new IntegerTransformation();
     }
@@ -69,7 +64,7 @@ class Group
      * Returns an object that allows to transform a value
      * to a float value
      */
-    public function float() : FloatTransformation
+    public function float() : Transformation
     {
         return new FloatTransformation();
     }
@@ -78,7 +73,7 @@ class Group
      * Returns an object that allows to transform a value
      * to a boolean value
      */
-    public function bool() : BooleanTransformation
+    public function bool() : Transformation
     {
         return new BooleanTransformation();
     }
@@ -120,6 +115,8 @@ class Group
      *
      * Using `ILIAS\Refinery\Factory::to()` will check if the value is identical
      * to the value after the transformation.
+     * @param Transformation[] $transformation
+     * @return Transformation
      */
     public function tupleOf(array $transformation) : Transformation
     {
@@ -139,6 +136,8 @@ class Group
      *
      * Using `ILIAS\Refinery\Factory::to()` will check if the value is identical
      * to the value after the transformation.
+     * @param array<string, Transformation> $transformations
+     * @return Transformation
      */
     public function recordOf(array $transformations) : Transformation
     {
@@ -150,12 +149,14 @@ class Group
      * existing class, with variations of constructor parameters OR returns
      * an transformation object to execute a certain method with variation of
      * parameters on the objects.
+     * @param string|array{0: object, 1: string} $classNameOrArray
+     * @return Transformation
      */
     public function toNew($classNameOrArray) : Transformation
     {
         if (is_array($classNameOrArray)) {
             if (2 !== count($classNameOrArray)) {
-                throw new \InvalidArgumentException('The array MUST contain exactly two elements');
+                throw new InvalidArgumentException('The array MUST contain exactly two elements');
             }
             return new NewMethodTransformation($classNameOrArray[0], $classNameOrArray[1]);
         }
@@ -169,10 +170,10 @@ class Group
      */
     public function data(string $dataType) : Transformation
     {
-        return $this->toNew(array($this->dataFactory, $dataType));
+        return $this->toNew([$this->dataFactory, $dataType]);
     }
 
-    public function dateTime() : DateTimeTransformation
+    public function dateTime() : Transformation
     {
         return new DateTimeTransformation();
     }

--- a/src/Refinery/To/Transformation/BooleanTransformation.php
+++ b/src/Refinery/To/Transformation/BooleanTransformation.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\To\Transformation;
 

--- a/src/Refinery/To/Transformation/BooleanTransformation.php
+++ b/src/Refinery/To/Transformation/BooleanTransformation.php
@@ -24,9 +24,6 @@ use ILIAS\Refinery\DeriveInvokeFromTransform;
 use ILIAS\Refinery\ProblemBuilder;
 use UnexpectedValueException;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 class BooleanTransformation implements Constraint
 {
     use DeriveApplyToFromTransform;
@@ -34,19 +31,25 @@ class BooleanTransformation implements Constraint
     use ProblemBuilder;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function transform($from)
+    public function transform($from) : bool
     {
         $this->check($from);
         return (bool) $from;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function getError() : string
     {
         return 'The value MUST be of type boolean.';
     }
 
+    /**
+     * @inheritDoc
+     */
     public function check($value)
     {
         if (!$this->accepts($value)) {
@@ -56,11 +59,17 @@ class BooleanTransformation implements Constraint
         return null;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function accepts($value) : bool
     {
         return is_bool($value);
     }
 
+    /**
+     * @inheritDoc
+     */
     public function problemWith($value) : ?string
     {
         if (!$this->accepts($value)) {

--- a/src/Refinery/To/Transformation/DateTimeTransformation.php
+++ b/src/Refinery/To/Transformation/DateTimeTransformation.php
@@ -36,22 +36,28 @@ class DateTimeTransformation implements Constraint
     use DeriveInvokeFromTransform;
     use ProblemBuilder;
 
-    protected string $error = '';
+    private string $error = '';
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function transform($from)
+    public function transform($from) : DateTimeImmutable
     {
         $this->check($from);
         return new DateTimeImmutable($from);
     }
 
+    /**
+     * @inheritDoc
+     */
     public function getError() : string
     {
         return $this->error;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function check($value)
     {
         if (!$this->accepts($value)) {
@@ -61,6 +67,9 @@ class DateTimeTransformation implements Constraint
         return null;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function accepts($value) : bool
     {
         try {
@@ -72,6 +81,9 @@ class DateTimeTransformation implements Constraint
         return true;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function problemWith($value) : ?string
     {
         if (!$this->accepts($value)) {

--- a/src/Refinery/To/Transformation/DateTimeTransformation.php
+++ b/src/Refinery/To/Transformation/DateTimeTransformation.php
@@ -33,7 +33,7 @@ class DateTimeTransformation implements Constraint
         return new DateTimeImmutable($from);
     }
 
-    public function getError()
+    public function getError() : string
     {
         return $this->error;
     }

--- a/src/Refinery/To/Transformation/DateTimeTransformation.php
+++ b/src/Refinery/To/Transformation/DateTimeTransformation.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2019 Nils Haagen <nils.haagen@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\To\Transformation;
 

--- a/src/Refinery/To/Transformation/DictionaryTransformation.php
+++ b/src/Refinery/To/Transformation/DictionaryTransformation.php
@@ -25,9 +25,6 @@ use ILIAS\Refinery\DeriveInvokeFromTransform;
 use ILIAS\Refinery\ProblemBuilder;
 use UnexpectedValueException;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 class DictionaryTransformation implements Constraint
 {
     use DeriveApplyToFromTransform;
@@ -42,13 +39,14 @@ class DictionaryTransformation implements Constraint
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
+     * @return array<string, mixed>
      */
-    public function transform($from)
+    public function transform($from) : array
     {
         $this->check($from);
 
-        $result = array();
+        $result = [];
         foreach ($from as $key => $value) {
             $transformedValue = $this->transformation->transform($value);
             $result[$key] = $transformedValue;
@@ -57,11 +55,17 @@ class DictionaryTransformation implements Constraint
         return $result;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function getError() : string
     {
         return 'The value MUST be an array with only string keys.';
     }
 
+    /**
+     * @inheritDoc
+     */
     public function check($value)
     {
         if (!$this->accepts($value)) {
@@ -71,6 +75,9 @@ class DictionaryTransformation implements Constraint
         return null;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function accepts($value) : bool
     {
         if (!is_array($value)) {
@@ -82,6 +89,9 @@ class DictionaryTransformation implements Constraint
         }, ARRAY_FILTER_USE_KEY)) === 0;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function problemWith($value) : ?string
     {
         if (!$this->accepts($value)) {

--- a/src/Refinery/To/Transformation/DictionaryTransformation.php
+++ b/src/Refinery/To/Transformation/DictionaryTransformation.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\To\Transformation;
 

--- a/src/Refinery/To/Transformation/DictionaryTransformation.php
+++ b/src/Refinery/To/Transformation/DictionaryTransformation.php
@@ -63,9 +63,9 @@ class DictionaryTransformation implements Constraint
             return false;
         }
 
-        return count(array_filter($value, function ($key) {
+        return count(array_filter($value, static function ($key) : bool {
             return !is_string($key);
-        }, ARRAY_FILTER_USE_KEY)) == 0;
+        }, ARRAY_FILTER_USE_KEY)) === 0;
     }
 
     public function problemWith($value) : ?string

--- a/src/Refinery/To/Transformation/FloatTransformation.php
+++ b/src/Refinery/To/Transformation/FloatTransformation.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\To\Transformation;
 

--- a/src/Refinery/To/Transformation/FloatTransformation.php
+++ b/src/Refinery/To/Transformation/FloatTransformation.php
@@ -24,9 +24,6 @@ use ILIAS\Refinery\DeriveInvokeFromTransform;
 use ILIAS\Refinery\ProblemBuilder;
 use UnexpectedValueException;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 class FloatTransformation implements Constraint
 {
     use DeriveApplyToFromTransform;
@@ -34,19 +31,25 @@ class FloatTransformation implements Constraint
     use ProblemBuilder;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function transform($from)
+    public function transform($from) : float
     {
         $this->check($from);
         return (float) $from;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function getError() : string
     {
         return 'The value MUST be of type string.';
     }
 
+    /**
+     * @inheritDoc
+     */
     public function check($value)
     {
         if (!$this->accepts($value)) {
@@ -56,11 +59,17 @@ class FloatTransformation implements Constraint
         return null;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function accepts($value) : bool
     {
         return is_float($value);
     }
 
+    /**
+     * @inheritDoc
+     */
     public function problemWith($value) : ?string
     {
         if (!$this->accepts($value)) {

--- a/src/Refinery/To/Transformation/IntegerTransformation.php
+++ b/src/Refinery/To/Transformation/IntegerTransformation.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\To\Transformation;
 

--- a/src/Refinery/To/Transformation/IntegerTransformation.php
+++ b/src/Refinery/To/Transformation/IntegerTransformation.php
@@ -24,9 +24,6 @@ use ILIAS\Refinery\DeriveInvokeFromTransform;
 use ILIAS\Refinery\ProblemBuilder;
 use UnexpectedValueException;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 class IntegerTransformation implements Constraint
 {
     use DeriveApplyToFromTransform;
@@ -34,19 +31,25 @@ class IntegerTransformation implements Constraint
     use ProblemBuilder;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function transform($from)
+    public function transform($from) : int
     {
         $this->check($from);
         return (int) $from;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function getError() : string
     {
         return 'The value MUST be of type integer.';
     }
 
+    /**
+     * @inheritDoc
+     */
     public function check($value)
     {
         if (!$this->accepts($value)) {
@@ -56,11 +59,17 @@ class IntegerTransformation implements Constraint
         return null;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function accepts($value) : bool
     {
         return is_int($value);
     }
 
+    /**
+     * @inheritDoc
+     */
     public function problemWith($value) : ?string
     {
         if (!$this->accepts($value)) {

--- a/src/Refinery/To/Transformation/ListTransformation.php
+++ b/src/Refinery/To/Transformation/ListTransformation.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\To\Transformation;
 

--- a/src/Refinery/To/Transformation/ListTransformation.php
+++ b/src/Refinery/To/Transformation/ListTransformation.php
@@ -25,9 +25,6 @@ use ILIAS\Refinery\ProblemBuilder;
 use UnexpectedValueException;
 use ILIAS\Refinery\Constraint;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 class ListTransformation implements Constraint
 {
     use DeriveApplyToFromTransform;
@@ -42,9 +39,9 @@ class ListTransformation implements Constraint
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function transform($from)
+    public function transform($from) : array
     {
         $this->check($from);
 
@@ -57,11 +54,17 @@ class ListTransformation implements Constraint
         return $result;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function getError() : string
     {
         return 'The value MUST be of type array.';
     }
 
+    /**
+     * @inheritDoc
+     */
     public function check($value)
     {
         if (!$this->accepts($value)) {
@@ -71,11 +74,17 @@ class ListTransformation implements Constraint
         return null;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function accepts($value) : bool
     {
         return is_array($value);
     }
 
+    /**
+     * @inheritDoc
+     */
     public function problemWith($value) : ?string
     {
         if (!$this->accepts($value)) {

--- a/src/Refinery/To/Transformation/NewMethodTransformation.php
+++ b/src/Refinery/To/Transformation/NewMethodTransformation.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\To\Transformation;
 

--- a/src/Refinery/To/Transformation/NewMethodTransformation.php
+++ b/src/Refinery/To/Transformation/NewMethodTransformation.php
@@ -23,9 +23,6 @@ use ILIAS\Refinery\Transformation;
 use ILIAS\Refinery\DeriveInvokeFromTransform;
 use InvalidArgumentException;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 class NewMethodTransformation implements Transformation
 {
     use DeriveApplyToFromTransform;
@@ -47,15 +44,14 @@ class NewMethodTransformation implements Transformation
     }
 
     /**
-     * @inheritdoc
-     * @return mixed
+     * @inheritDoc
      */
     public function transform($from)
     {
         if (false === is_array($from)) {
-            $from = array($from);
+            $from = [$from];
         }
 
-        return call_user_func_array(array($this->object, $this->method), $from);
+        return call_user_func_array([$this->object, $this->method], $from);
     }
 }

--- a/src/Refinery/To/Transformation/NewObjectTransformation.php
+++ b/src/Refinery/To/Transformation/NewObjectTransformation.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\To\Transformation;
 

--- a/src/Refinery/To/Transformation/NewObjectTransformation.php
+++ b/src/Refinery/To/Transformation/NewObjectTransformation.php
@@ -23,9 +23,6 @@ use ILIAS\Refinery\Transformation;
 use ReflectionClass;
 use ReflectionException;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 class NewObjectTransformation implements Transformation
 {
     use DeriveApplyToFromTransform;
@@ -38,7 +35,7 @@ class NewObjectTransformation implements Transformation
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      * @throws ReflectionException
      */
     public function transform($from)
@@ -50,7 +47,7 @@ class NewObjectTransformation implements Transformation
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      * @throws ReflectionException
      */
     public function __invoke($from)

--- a/src/Refinery/To/Transformation/RecordTransformation.php
+++ b/src/Refinery/To/Transformation/RecordTransformation.php
@@ -26,24 +26,18 @@ use ILIAS\Refinery\DeriveInvokeFromTransform;
 use ILIAS\Refinery\ProblemBuilder;
 use UnexpectedValueException;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 class RecordTransformation implements Constraint
 {
     use DeriveApplyToFromTransform;
     use DeriveInvokeFromTransform;
     use ProblemBuilder;
 
-    protected string $error = '';
-
-    /**
-     * @var Transformation[]
-     */
+    private string $error = '';
+    /** @var array<string, Transformation> */
     private array $transformations;
 
     /**
-     * @param Transformation[] $transformations
+     * @param array<string, Transformation> $transformations
      */
     public function __construct(array $transformations)
     {
@@ -58,7 +52,7 @@ class RecordTransformation implements Constraint
                 );
             }
 
-            if (false === is_string($key)) {
+            if (!is_string($key)) {
                 throw new ConstraintViolationException(
                     'The array key MUST be a string',
                     'key_is_not_a_string'
@@ -70,13 +64,14 @@ class RecordTransformation implements Constraint
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
+     * @return array<string, mixed>
      */
-    public function transform($from)
+    public function transform($from) : array
     {
         $this->check($from);
 
-        $result = array();
+        $result = [];
         foreach ($from as $key => $value) {
             $transformation = $this->transformations[$key];
             $transformedValue = $transformation->transform($value);
@@ -88,13 +83,16 @@ class RecordTransformation implements Constraint
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function getError() : string
     {
         return $this->error;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function check($value)
     {
         if (!$this->accepts($value)) {
@@ -104,6 +102,9 @@ class RecordTransformation implements Constraint
         return null;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function accepts($value) : bool
     {
         if (!$this->validateValueLength($value)) {
@@ -125,7 +126,7 @@ class RecordTransformation implements Constraint
         return true;
     }
 
-    private function validateValueLength($values) : bool
+    private function validateValueLength(array $values) : bool
     {
         $countOfValues = count($values);
         $countOfTransformations = count($this->transformations);
@@ -142,6 +143,9 @@ class RecordTransformation implements Constraint
         return true;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function problemWith($value) : ?string
     {
         if (!$this->accepts($value)) {

--- a/src/Refinery/To/Transformation/RecordTransformation.php
+++ b/src/Refinery/To/Transformation/RecordTransformation.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\To\Transformation;
 

--- a/src/Refinery/To/Transformation/StringTransformation.php
+++ b/src/Refinery/To/Transformation/StringTransformation.php
@@ -24,9 +24,6 @@ use ILIAS\Refinery\Constraint;
 use ILIAS\Refinery\ProblemBuilder;
 use UnexpectedValueException;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 class StringTransformation implements Constraint
 {
     use DeriveApplyToFromTransform;
@@ -34,19 +31,25 @@ class StringTransformation implements Constraint
     use ProblemBuilder;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function transform($from)
+    public function transform($from) : string
     {
         $this->check($from);
         return (string) $from;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function getError() : string
     {
         return 'The value MUST be of type string.';
     }
 
+    /**
+     * @inheritDoc
+     */
     public function check($value)
     {
         if (!$this->accepts($value)) {
@@ -56,11 +59,17 @@ class StringTransformation implements Constraint
         return null;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function accepts($value) : bool
     {
         return is_string($value);
     }
 
+    /**
+     * @inheritDoc
+     */
     public function problemWith($value) : ?string
     {
         if (!$this->accepts($value)) {

--- a/src/Refinery/To/Transformation/StringTransformation.php
+++ b/src/Refinery/To/Transformation/StringTransformation.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\To\Transformation;
 

--- a/src/Refinery/To/Transformation/TupleTransformation.php
+++ b/src/Refinery/To/Transformation/TupleTransformation.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\To\Transformation;
 

--- a/src/Refinery/To/Transformation/TupleTransformation.php
+++ b/src/Refinery/To/Transformation/TupleTransformation.php
@@ -26,24 +26,18 @@ use ILIAS\Refinery\DeriveInvokeFromTransform;
 use ILIAS\Refinery\ProblemBuilder;
 use UnexpectedValueException;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 class TupleTransformation implements Constraint
 {
     use DeriveApplyToFromTransform;
     use DeriveInvokeFromTransform;
     use ProblemBuilder;
 
-    protected string $error = '';
-
-    /**
-     * @var Transformation[]
-     */
+    private string $error = '';
+    /** @var Transformation[] */
     private array $transformations;
 
     /**
-     * @param array $transformations
+     * @param Transformation[] $transformations
      */
     public function __construct(array $transformations)
     {
@@ -63,13 +57,13 @@ class TupleTransformation implements Constraint
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function transform($from)
+    public function transform($from) : array
     {
         $this->check($from);
 
-        $result = array();
+        $result = [];
         foreach ($from as $key => $value) {
             $transformedValue = $this->transformations[$key]->transform($value);
             $result[] = $transformedValue;
@@ -79,13 +73,16 @@ class TupleTransformation implements Constraint
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function getError() : string
     {
         return $this->error;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function check($value)
     {
         if (!$this->accepts($value)) {
@@ -95,6 +92,9 @@ class TupleTransformation implements Constraint
         return null;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function accepts($value) : bool
     {
         if (!$this->isLengthOfValueAndTransformationEqual($value)) {
@@ -127,6 +127,9 @@ class TupleTransformation implements Constraint
         return true;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function problemWith($value) : ?string
     {
         if (!$this->accepts($value)) {

--- a/src/Refinery/To/Transformation/TupleTransformation.php
+++ b/src/Refinery/To/Transformation/TupleTransformation.php
@@ -87,13 +87,13 @@ class TupleTransformation implements Constraint
             return false;
         }
 
-        return count(array_filter($value, function ($key) {
+        return count(array_filter($value, function ($key) : bool {
             if (!array_key_exists($key, $this->transformations)) {
                 $this->error = sprintf('There is no entry "%s" defined in the transformation array', $key);
                 return true;
             }
             return false;
-        }, ARRAY_FILTER_USE_KEY)) == 0;
+        }, ARRAY_FILTER_USE_KEY)) === 0;
     }
 
     private function isLengthOfValueAndTransformationEqual($values) : bool

--- a/src/Refinery/Transformation.php
+++ b/src/Refinery/Transformation.php
@@ -35,9 +35,9 @@ interface Transformation
      * Perform the transformation.
      * Please use this for transformations. It's more performant than calling invoke.
      *
-     * @throws InvalidArgumentException  if the argument could not be transformed
-     * @param  mixed  $from
+     * @param mixed $from
      * @return mixed
+     * @throws InvalidArgumentException  if the argument could not be transformed
      */
     public function transform($from);
 
@@ -65,9 +65,9 @@ interface Transformation
     /**
      * Transformations should be callable. This MUST do the same as transform.
      *
-     * @throws InvalidArgumentException  if the argument could not be transformed
-     * @param  mixed  $from
+     * @param mixed $from
      * @return mixed
+     * @throws InvalidArgumentException  if the argument could not be transformed
      */
     public function __invoke($from);
 }

--- a/src/Refinery/Transformation.php
+++ b/src/Refinery/Transformation.php
@@ -1,7 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2017 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
-/* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery;
 

--- a/src/Refinery/URI/Group.php
+++ b/src/Refinery/URI/Group.php
@@ -18,12 +18,11 @@
 
 namespace ILIAS\Refinery\URI;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
+use ILIAS\Refinery\Transformation;
+
 class Group
 {
-    public function toString() : StringTransformation
+    public function toString() : Transformation
     {
         return new StringTransformation();
     }

--- a/src/Refinery/URI/Group.php
+++ b/src/Refinery/URI/Group.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\URI;
 

--- a/src/Refinery/URI/StringTransformation.php
+++ b/src/Refinery/URI/StringTransformation.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Refinery\URI;
 

--- a/src/Refinery/URI/StringTransformation.php
+++ b/src/Refinery/URI/StringTransformation.php
@@ -24,18 +24,15 @@ use ILIAS\Refinery\DeriveApplyToFromTransform;
 use ILIAS\Refinery\Transformation;
 use ILIAS\Refinery\DeriveInvokeFromTransform;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 class StringTransformation implements Transformation
 {
     use DeriveApplyToFromTransform;
     use DeriveInvokeFromTransform;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function transform($from)
+    public function transform($from) : string
     {
         if (false === $from instanceof URI) {
             throw new ConstraintViolationException(

--- a/src/Refinery/examples/In/01-parallel.php
+++ b/src/Refinery/examples/In/01-parallel.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * @author  Niels Theen <ntheen@databay.de>

--- a/src/Refinery/examples/In/01-parallel.php
+++ b/src/Refinery/examples/In/01-parallel.php
@@ -16,23 +16,20 @@
  *
  *********************************************************************/
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
-function parallel()
+function parallel() : bool
 {
     global $DIC;
 
     $refinery = $DIC->refinery();
 
     $transformation = $refinery->in()->parallel(
-        array(
+        [
             new ILIAS\Refinery\To\Transformation\IntegerTransformation(),
             new ILIAS\Refinery\To\Transformation\IntegerTransformation(),
-        )
+        ]
     );
 
     $result = $transformation->transform(5);
 
-    return assert(array(5, 5), $result);
+    return assert([5, 5], $result);
 }

--- a/src/Refinery/examples/In/02-series.php
+++ b/src/Refinery/examples/In/02-series.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * @author  Niels Theen <ntheen@databay.de>

--- a/src/Refinery/examples/In/02-series.php
+++ b/src/Refinery/examples/In/02-series.php
@@ -16,20 +16,17 @@
  *
  *********************************************************************/
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
-function series()
+function series() : bool
 {
     global $DIC;
 
     $refinery = $DIC->refinery();
 
     $transformation = $refinery->in()->series(
-        array(
+        [
             new ILIAS\Refinery\To\Transformation\IntegerTransformation(),
             new ILIAS\Refinery\To\Transformation\IntegerTransformation(),
-        )
+        ]
     );
 
     $result = $transformation->transform(5);

--- a/src/Refinery/examples/String/01-estimated-reading-time.php
+++ b/src/Refinery/examples/String/01-estimated-reading-time.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 function estimatedReadingTime()
 {

--- a/src/Refinery/examples/String/01-estimated-reading-time.php
+++ b/src/Refinery/examples/String/01-estimated-reading-time.php
@@ -16,7 +16,7 @@
  *
  *********************************************************************/
 
-function estimatedReadingTime()
+function estimatedReadingTime() : bool
 {
     global $DIC;
 

--- a/src/Refinery/examples/To/01-primitive.php
+++ b/src/Refinery/examples/To/01-primitive.php
@@ -16,10 +16,7 @@
  *
  *********************************************************************/
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
-function primitive()
+function primitive() : bool
 {
     global $DIC;
 

--- a/src/Refinery/examples/To/01-primitive.php
+++ b/src/Refinery/examples/To/01-primitive.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * @author  Niels Theen <ntheen@databay.de>

--- a/src/Refinery/examples/To/02-list.php
+++ b/src/Refinery/examples/To/02-list.php
@@ -16,10 +16,7 @@
  *
  *********************************************************************/
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
-function toList()
+function toList() : bool
 {
     global $DIC;
 
@@ -27,7 +24,7 @@ function toList()
 
     $transformation = $refinery->to()->listOf(new \ILIAS\Refinery\To\Transformation\IntegerTransformation());
 
-    $result = $transformation->transform(array(5, 1, 4));
+    $result = $transformation->transform([5, 1, 4]);
 
-    return assert(array(5, 1, 4) === $result);
+    return assert([5, 1, 4] === $result);
 }

--- a/src/Refinery/examples/To/02-list.php
+++ b/src/Refinery/examples/To/02-list.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * @author  Niels Theen <ntheen@databay.de>

--- a/src/Refinery/examples/To/03-dictionary.php
+++ b/src/Refinery/examples/To/03-dictionary.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * @author  Niels Theen <ntheen@databay.de>

--- a/src/Refinery/examples/To/03-dictionary.php
+++ b/src/Refinery/examples/To/03-dictionary.php
@@ -16,10 +16,7 @@
  *
  *********************************************************************/
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
-function toDictionary()
+function toDictionary() : bool
 {
     global $DIC;
 
@@ -27,7 +24,7 @@ function toDictionary()
 
     $transformation = $refinery->to()->dictOf(new \ILIAS\Refinery\To\Transformation\IntegerTransformation());
 
-    $result = $transformation->transform(array('sum' => 5, 'user_id' => 1, 'size' => 4));
+    $result = $transformation->transform(['sum' => 5, 'user_id' => 1, 'size' => 4]);
 
-    return assert(array('sum' => 5, 'user_id' => 1, 'size' => 4) === $result);
+    return assert(['sum' => 5, 'user_id' => 1, 'size' => 4] === $result);
 }

--- a/src/Refinery/examples/To/04-tuple.php
+++ b/src/Refinery/examples/To/04-tuple.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * @author  Niels Theen <ntheen@databay.de>

--- a/src/Refinery/examples/To/04-tuple.php
+++ b/src/Refinery/examples/To/04-tuple.php
@@ -16,23 +16,20 @@
  *
  *********************************************************************/
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
-function toTuple()
+function toTuple() : bool
 {
     global $DIC;
 
     $refinery = $DIC->refinery();
 
     $transformation = $refinery->to()->tupleOf(
-        array(
+        [
             new \ILIAS\Refinery\To\Transformation\IntegerTransformation(),
             new \ILIAS\Refinery\To\Transformation\IntegerTransformation()
-        )
+        ]
     );
 
-    $result = $transformation->transform(array(5, 1));
+    $result = $transformation->transform([5, 1]);
 
-    return assert(array(5, 1) === $result);
+    return assert([5, 1] === $result);
 }

--- a/src/Refinery/examples/To/05-record.php
+++ b/src/Refinery/examples/To/05-record.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * @author  Niels Theen <ntheen@databay.de>

--- a/src/Refinery/examples/To/05-record.php
+++ b/src/Refinery/examples/To/05-record.php
@@ -16,23 +16,20 @@
  *
  *********************************************************************/
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
-function toRecord()
+function toRecord() : bool
 {
     global $DIC;
 
     $refinery = $DIC->refinery();
 
     $transformation = $refinery->to()->recordOf(
-        array(
+        [
             'user_id' => new \ILIAS\Refinery\To\Transformation\IntegerTransformation(),
             'points' => new \ILIAS\Refinery\To\Transformation\IntegerTransformation()
-        )
+        ]
     );
 
-    $result = $transformation->transform(array('user_id' => 5, 'points' => 1));
+    $result = $transformation->transform(['user_id' => 5, 'points' => 1]);
 
-    return assert(array('user_id' => 5, 'points' => 1) === $result);
+    return assert(['user_id' => 5, 'points' => 1] === $result);
 }

--- a/src/Refinery/examples/To/06-to-new-object.php
+++ b/src/Refinery/examples/To/06-to-new-object.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * @author  Niels Theen <ntheen@databay.de>

--- a/src/Refinery/examples/To/06-to-new-object.php
+++ b/src/Refinery/examples/To/06-to-new-object.php
@@ -16,10 +16,7 @@
  *
  *********************************************************************/
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
-function toNewObject()
+function toNewObject() : bool
 {
     class SomeOtherClass
     {
@@ -47,7 +44,7 @@ function toNewObject()
             return $this->firstParameter;
         }
 
-        public function getSecodParameter() : string
+        public function getSecodParameter() : int
         {
             return $this->secondParameter;
         }

--- a/src/Refinery/examples/To/06-to-new-object.php
+++ b/src/Refinery/examples/To/06-to-new-object.php
@@ -9,9 +9,9 @@ function toNewObject()
 {
     class SomeOtherClass
     {
-        private $firstParameter;
-        private $secondParameter;
-        private $thirdParameter;
+        private string $firstParameter;
+        private int $secondParameter;
+        private string $thirdParameter;
 
         public function __construct(
             string $firstParameter,
@@ -27,17 +27,30 @@ function toNewObject()
         {
             return $this->firstParameter;
         }
-    }
+        
+        public function getFirstParameter() : string
+        {
+            return $this->firstParameter;
+        }
 
+        public function getSecodParameter() : string
+        {
+            return $this->secondParameter;
+        }
+
+        public function getThirdParameter() : string
+        {
+            return $this->thirdParameter;
+        }
+    }
+    
     global $DIC;
 
     $refinery = $DIC->refinery();
 
-    $transformation = $refinery->to()->toNew(
-        'SomeOtherClass'
-    );
+    $transformation = $refinery->to()->toNew(SomeOtherClass::class);
 
-    $result = $transformation->transform(array('firstParameter', 2, 'thirdParameter'));
+    $result = $transformation->transform(['firstParameter', 2, 'thirdParameter']);
 
-    return assert('firstParameter' === $result->say());
+    return assert('firstParameter' === $result->getFirstParameter());
 }

--- a/src/Refinery/examples/To/07-to-new-method.php
+++ b/src/Refinery/examples/To/07-to-new-method.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * @author  Niels Theen <ntheen@databay.de>

--- a/src/Refinery/examples/To/07-to-new-method.php
+++ b/src/Refinery/examples/To/07-to-new-method.php
@@ -16,10 +16,7 @@
  *
  *********************************************************************/
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
-function toList()
+function toList() : bool
 {
     class SomeClass
     {
@@ -36,10 +33,10 @@ function toList()
     $refinery = $DIC->refinery();
 
     $transformation = $refinery->to()->toNew(
-        array($instance, 'say')
+        [$instance, 'say']
     );
 
-    $result = $transformation->transform(array('Hello', ' World!'));
+    $result = $transformation->transform(['Hello', ' World!']);
 
     return assert('Hello World!' === $result);
 }

--- a/tests/Refinery/ByTrying/ByTryingTransformTest.php
+++ b/tests/Refinery/ByTrying/ByTryingTransformTest.php
@@ -1,29 +1,40 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2020 Nils Haagen <nils.haagen@concepts-and-training.de>, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
-require_once('./libs/composer/vendor/autoload.php');
-
+use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Tests\Refinery\TestCase;
 use ILIAS\Refinery\ConstraintViolationException;
-use ILIAS\Refinery;
-use ILIAS\Data;
+use ILIAS\Data\Factory as DataFactory;
 
-/**
- * Test ByTrying transformation
- */
 class ByTryingTransformationTest extends TestCase
 {
-    const ERROR = 'error_expected';
+    private const ERROR = 'error_expected';
 
-    public function setUp() : void
+    private Refinery $refinery;
+
+    protected function setUp() : void
     {
-        $df = new Data\Factory();
+        $df = new DataFactory();
         $lang = $this->getLanguage();
-        $this->refine = new \ILIAS\Refinery\Factory($df, $lang);
+        $this->refinery = new Refinery($df, $lang);
     }
 
-    public function NullOrNumericDataProvider()
+    public function NullOrNumericDataProvider() : array
     {
         return [
             'empty string' => ['', null],
@@ -42,12 +53,14 @@ class ByTryingTransformationTest extends TestCase
 
     /**
      * @dataProvider NullOrNumericDataProvider
+     * @param mixed $value
+     * @param mixed $expected
      */
-    public function testNullOrNumeric($value, $expected)
+    public function testNullOrNumeric($value, $expected) : void
     {
-        $transformation = $this->refine->byTrying([
-            $this->refine->numeric()->isNumeric(),
-            $this->refine->kindlyTo()->null()
+        $transformation = $this->refinery->byTrying([
+            $this->refinery->numeric()->isNumeric(),
+            $this->refinery->kindlyTo()->null()
         ]);
 
         if ($expected === self::ERROR) {
@@ -58,7 +71,7 @@ class ByTryingTransformationTest extends TestCase
     }
 
 
-    public function NullOrNumericOrStringDataProvider()
+    public function NullOrNumericOrStringDataProvider() : array
     {
         return [
             'string' => ['str', 'str'],
@@ -72,13 +85,15 @@ class ByTryingTransformationTest extends TestCase
 
     /**
      * @dataProvider NullOrNumericOrStringDataProvider
+     * @param mixed $value
+     * @param mixed $expected
      */
-    public function testNullOrNumericOrString($value, $expected)
+    public function testNullOrNumericOrString($value, $expected) : void
     {
-        $transformation = $this->refine->byTrying([
-            $this->refine->kindlyTo()->null(),
-            $this->refine->numeric()->isNumeric(),
-            $this->refine->to()->string()
+        $transformation = $this->refinery->byTrying([
+            $this->refinery->kindlyTo()->null(),
+            $this->refinery->numeric()->isNumeric(),
+            $this->refinery->to()->string()
         ]);
 
         if ($expected === self::ERROR) {
@@ -88,7 +103,7 @@ class ByTryingTransformationTest extends TestCase
         $this->assertEquals($expected, $transformed);
     }
 
-    public function StringOrNullDataProvider()
+    public function StringOrNullDataProvider() : array
     {
         return [
             'string' => ['str', 'str'],
@@ -101,12 +116,14 @@ class ByTryingTransformationTest extends TestCase
 
     /**
      * @dataProvider StringOrNullDataProvider
+     * @param mixed $value
+     * @param mixed $expected
      */
-    public function testStringOrNull($value, $expected)
+    public function testStringOrNull($value, $expected) : void
     {
-        $transformation = $this->refine->byTrying([
-            $this->refine->to()->string(),
-            $this->refine->kindlyTo()->null()
+        $transformation = $this->refinery->byTrying([
+            $this->refinery->to()->string(),
+            $this->refinery->kindlyTo()->null()
         ]);
 
         if ($expected === self::ERROR) {

--- a/tests/Refinery/ConstraintViolationExceptionTest.php
+++ b/tests/Refinery/ConstraintViolationExceptionTest.php
@@ -1,29 +1,42 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
+use ILIAS\Refinery\ConstraintViolationException;
+
 class ConstraintViolationExceptionTest extends TestCase
 {
-    public function testTranslationOfMessage()
+    public function testTranslationOfMessage() : void
     {
-        $that = $this;
-        $callback = function ($languageId) use ($that) {
-            $that->assertEquals('some_key', $languageId);
+        $callback = function (string $languageId) : string {
+            $this->assertEquals('some_key', $languageId);
             return 'Some text "%s" and "%s"';
         };
 
         try {
-            throw new \ILIAS\Refinery\ConstraintViolationException(
+            throw new ConstraintViolationException(
                 'This is an error message for developers',
                 'some_key',
                 'Value To Replace',
                 'Some important stuff'
             );
-        } catch (\ILIAS\Refinery\ConstraintViolationException $exception) {
+        } catch (ConstraintViolationException $exception) {
             $this->assertEquals(
                 'Some text "Value To Replace" and "Some important stuff"',
                 $exception->getTranslatedMessage($callback)

--- a/tests/Refinery/Container/GroupTest.php
+++ b/tests/Refinery/Container/GroupTest.php
@@ -1,46 +1,42 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\Container;
 
-use ILIAS\Data\Factory;
-use ILIAS\Refinery\Container\Group;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\Container\Group as ContainerGroup;
 use ILIAS\Refinery\Container\AddLabels;
 use ILIAS\Tests\Refinery\TestCase;
 
-require_once('./libs/composer/vendor/autoload.php');
-require_once('./tests/Refinery/TestCase.php');
-
 class GroupTest extends TestCase
 {
-    /**
-     * @var Group
-     */
-    private $group;
+    private ContainerGroup $group;
+    private DataFactory $dataFactory;
 
-    /**
-     * @var Factory
-     */
-    private $dataFactory;
-
-    /**
-     * @var \ilLanguage
-     */
-    private $language;
-
-    public function setUp() : void
+    protected function setUp() : void
     {
-        $this->dataFactory = new Factory();
-        $this->language = $this->getMockBuilder('\ilLanguage')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->group = new Group($this->dataFactory);
+        $this->dataFactory = new DataFactory();
+        $this->group = new ContainerGroup($this->dataFactory);
     }
 
-    public function testCustomConstraint()
+    public function testCustomConstraint() : void
     {
-        $instance = $this->group->addLabels(array('hello', 'world'));
+        $instance = $this->group->addLabels(['hello', 'world']);
         $this->assertInstanceOf(AddLabels::class, $instance);
     }
 }

--- a/tests/Refinery/Container/Transformation/AddLabelTest.php
+++ b/tests/Refinery/Container/Transformation/AddLabelTest.php
@@ -1,31 +1,44 @@
-<?php
-
-/* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
-
-use ILIAS\Refinery;
-use PHPUnit\Framework\TestCase;
+<?php declare(strict_types=1);
 
 /**
- * TestCase for AddLabel transformations
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * @author Stefan Hecken <stefan.hecken@concepts-and-training.de>
- */
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\Refinery\Container\AddLabels;
+use ILIAS\Refinery\Factory as Refinery;
+use PHPUnit\Framework\TestCase;
+use ILIAS\Data\Factory as DataFactory;
+
 class AddLabelTest extends TestCase
 {
-    protected static $labels = array("A", "B", "C");
-    protected static $test_array = array(1, 2, 3);
-    protected static $result_array = array("A" => 1, "B" => 2, "C" => 3);
-    /**
-     * @var ILIAS\Refinery\Factory
-     */
-    private $f;
+    /** @var string[]  */
+    private static array $labels = ["A", "B", "C"];
+    /** @var int[]  */
+    private static array $test_array = [1, 2, 3];
+    /** @var array<string, int>  */
+    private static array $result_array = ["A" => 1, "B" => 2, "C" => 3];
+
+    private ?Refinery $f;
+    private ?AddLabels $add_label;
 
     protected function setUp() : void
     {
-        $dataFactory = new ILIAS\Data\Factory();
-        $language = $this->createMock('\ilLanguage');
+        $dataFactory = new DataFactory();
+        $language = $this->createMock(ilLanguage::class);
 
-        $this->f = new ILIAS\Refinery\Factory($dataFactory, $language);
+        $this->f = new Refinery($dataFactory, $language);
         $this->add_label = $this->f->container()->addLabels(self::$labels);
     }
 
@@ -35,13 +48,13 @@ class AddLabelTest extends TestCase
         $this->add_label = null;
     }
 
-    public function testTransform()
+    public function testTransform() : void
     {
         $with = $this->add_label->transform(self::$test_array);
         $this->assertEquals(self::$result_array, $with);
     }
 
-    public function testTransformFails()
+    public function testTransformFails() : void
     {
         $raised = false;
         try {
@@ -54,7 +67,7 @@ class AddLabelTest extends TestCase
 
         $raised = false;
         try {
-            $without = array(1, 2, 3, 4);
+            $without = [1, 2, 3, 4];
             $with = $this->add_label->transform($without);
         } catch (InvalidArgumentException $e) {
             $raised = true;
@@ -80,14 +93,14 @@ class AddLabelTest extends TestCase
         $this->assertTrue($raised);
     }
 
-    public function testInvoke()
+    public function testInvoke() : void
     {
         $add_label = $this->f->container()->addLabels(self::$labels);
         $with = $add_label(self::$test_array);
         $this->assertEquals(self::$result_array, $with);
     }
 
-    public function testInvokeFails()
+    public function testInvokeFails() : void
     {
         $add_label = $this->f->container()->addLabels(self::$labels);
 
@@ -102,7 +115,7 @@ class AddLabelTest extends TestCase
 
         $raised = false;
         try {
-            $without = array(1, 2, 3, 4);
+            $without = [1, 2, 3, 4];
             $with = $add_label($without);
         } catch (InvalidArgumentException $e) {
             $raised = true;

--- a/tests/Refinery/Container/Transformation/AddLabelTest.php
+++ b/tests/Refinery/Container/Transformation/AddLabelTest.php
@@ -16,8 +16,8 @@
  *
  *********************************************************************/
 
-use ILIAS\Refinery\Container\AddLabels;
 use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Refinery\Transformation;
 use PHPUnit\Framework\TestCase;
 use ILIAS\Data\Factory as DataFactory;
 
@@ -31,7 +31,7 @@ class AddLabelTest extends TestCase
     private static array $result_array = ["A" => 1, "B" => 2, "C" => 3];
 
     private ?Refinery $f;
-    private ?AddLabels $add_label;
+    private ?Transformation $add_label;
 
     protected function setUp() : void
     {

--- a/tests/Refinery/Container/Transformation/MapValuesTest.php
+++ b/tests/Refinery/Container/Transformation/MapValuesTest.php
@@ -1,29 +1,49 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2021 - Daniel Weise <daniel.weise@concepts-and-training.de> - Extended GPL, see LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\Container\MapValues;
 use PHPUnit\Framework\TestCase;
 
 class MapValuesTest extends TestCase
 {
-    protected array $test_array = [
+    /** @var array<string, int> */
+    private array $test_array = [
         "A" => 260,
         "B" => 22,
         "C" => 4010
     ];
-    protected array $result_array = [
+    /** @var array<string, int> */
+    private array $result_array = [
         "A" => 520,
         "B" => 44,
         "C" => 8020
     ];
-    protected ILIAS\Refinery\Factory $f;
+    private ILIAS\Refinery\Factory $f;
+    private MapValues $map_values;
 
     protected function setUp() : void
     {
-        $dataFactory = new ILIAS\Data\Factory();
-        $language = $this->createMock('\ilLanguage');
+        $dataFactory = new DataFactory();
+        $language = $this->createMock(ilLanguage::class);
 
-        $this->f = new ILIAS\Refinery\Factory($dataFactory, $language);
+        $this->f = new Refinery($dataFactory, $language);
         $this->map_values = $this->f->container()->mapValues($this->f->custom()->transformation(fn ($v) => $v * 2));
     }
 

--- a/tests/Refinery/Container/Transformation/MapValuesTest.php
+++ b/tests/Refinery/Container/Transformation/MapValuesTest.php
@@ -19,6 +19,7 @@
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Refinery\Container\MapValues;
+use ILIAS\Refinery\Transformation;
 use PHPUnit\Framework\TestCase;
 
 class MapValuesTest extends TestCase
@@ -35,8 +36,8 @@ class MapValuesTest extends TestCase
         "B" => 44,
         "C" => 8020
     ];
-    private ILIAS\Refinery\Factory $f;
-    private MapValues $map_values;
+    private Refinery $f;
+    private Transformation $map_values;
 
     protected function setUp() : void
     {

--- a/tests/Refinery/Custom/GroupTest.php
+++ b/tests/Refinery/Custom/GroupTest.php
@@ -1,53 +1,57 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\Custom;
 
-use ILIAS\Data\Factory;
-use ILIAS\Refinery\Custom\Group;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\Custom\Group as CustomGroup;
+use ILIAS\Refinery\Custom\Transformation as CustomTransformation;
+use ILIAS\Refinery\Custom\Constraint as CustomConstraint;
 use ILIAS\Tests\Refinery\TestCase;
-
-require_once('./libs/composer/vendor/autoload.php');
-require_once('./tests/Refinery/TestCase.php');
+use ilLanguage;
 
 class GroupTest extends TestCase
 {
-    /**
-     * @var Group
-     */
-    private $group;
+    private CustomGroup $group;
+    private DataFactory $dataFactory;
+    private ilLanguage $language;
 
-    /**
-     * @var Factory
-     */
-    private $dataFactory;
-
-    /**
-     * @var \ilLanguage
-     */
-    private $language;
-
-    public function setUp() : void
+    protected function setUp() : void
     {
-        $this->dataFactory = new Factory();
-        $this->language = $this->getMockBuilder('\ilLanguage')
+        $this->dataFactory = new DataFactory();
+        $this->language = $this->getMockBuilder(ilLanguage::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->group = new Group($this->dataFactory, $this->language);
+        $this->group = new CustomGroup($this->dataFactory, $this->language);
     }
 
-    public function testCustomConstraint()
+    public function testCustomConstraint() : void
     {
-        $instance = $this->group->constraint(function () {
+        $instance = $this->group->constraint(static function () : void {
         }, 'some error');
-        $this->assertInstanceOf(\ILIAS\Refinery\Custom\Constraint::class, $instance);
+        $this->assertInstanceOf(CustomConstraint::class, $instance);
     }
 
-    public function testCustomTransformation()
+    public function testCustomTransformation() : void
     {
-        $instance = $this->group->transformation(function () {
+        $instance = $this->group->transformation(static function () : void {
         });
-        $this->assertInstanceOf(\ILIAS\Refinery\Custom\Transformation::class, $instance);
+        $this->assertInstanceOf(CustomTransformation::class, $instance);
     }
 }

--- a/tests/Refinery/Custom/Transformation/TransformationsCustomTest.php
+++ b/tests/Refinery/Custom/Transformation/TransformationsCustomTest.php
@@ -18,13 +18,14 @@
 
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\Transformation;
 use PHPUnit\Framework\TestCase;
 
 class TransformationsCustomTest extends TestCase
 {
     private const TEST_STRING = "Test";
 
-    private ?ILIAS\Refinery\Custom\Transformation $custom;
+    private ?Transformation $custom;
     private ?Refinery $f;
 
     protected function setUp() : void

--- a/tests/Refinery/Custom/Transformation/TransformationsCustomTest.php
+++ b/tests/Refinery/Custom/Transformation/TransformationsCustomTest.php
@@ -1,33 +1,36 @@
-<?php
-
-/* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
-
-use ILIAS\Refinery\Factory;
-use PHPUnit\Framework\TestCase;
+<?php declare(strict_types=1);
 
 /**
- * TestCase for Custom transformations
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * @author Stefan Hecken <stefan.hecken@concepts-and-training.de>
- */
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Data\Factory as DataFactory;
+use PHPUnit\Framework\TestCase;
+
 class TransformationsCustomTest extends TestCase
 {
-    const TEST_STRING = "Test";
+    private const TEST_STRING = "Test";
 
-    /**
-     * @var Transformation\Transformations\Custom
-     */
-    private $custom;
-
-    /**
-     * @var Factory
-     */
-    private $f;
+    private ?ILIAS\Refinery\Custom\Transformation $custom;
+    private ?Refinery $f;
 
     protected function setUp() : void
     {
-        $language = $this->createMock(\ilLanguage::class);
-        $this->f = new Factory(new ILIAS\Data\Factory(), $language);
+        $language = $this->createMock(ilLanguage::class);
+        $this->f = new Refinery(new DataFactory(), $language);
 
         $this->custom = $this->f->custom()->transformation(
             function ($value) {
@@ -45,17 +48,17 @@ class TransformationsCustomTest extends TestCase
         $this->custom = null;
     }
 
-    public function testTransform()
+    public function testTransform() : void
     {
         $result = $this->custom->transform(self::TEST_STRING);
         $this->assertEquals(self::TEST_STRING, $result);
     }
 
-    public function testTransformFails()
+    public function testTransformFails() : void
     {
         $raised = false;
         try {
-            $lower_string = $this->custom->transform(array());
+            $lower_string = $this->custom->transform([]);
         } catch (InvalidArgumentException $e) {
             $this->assertEquals("'array' is not a string.", $e->getMessage());
             $raised = true;
@@ -82,7 +85,7 @@ class TransformationsCustomTest extends TestCase
         $this->assertTrue($raised);
     }
 
-    public function testInvoke()
+    public function testInvoke() : void
     {
         $custom = $this->f->custom()->transformation(
             function ($value) {
@@ -97,7 +100,7 @@ class TransformationsCustomTest extends TestCase
         $this->assertEquals(self::TEST_STRING, $result);
     }
 
-    public function testInvokeFails()
+    public function testInvokeFails() : void
     {
         $custom = $this->f->custom()->transformation(
             function ($value) {
@@ -110,7 +113,7 @@ class TransformationsCustomTest extends TestCase
 
         $raised = false;
         try {
-            $lower_string = $custom(array());
+            $lower_string = $custom([]);
         } catch (InvalidArgumentException $e) {
             $this->assertEquals("'array' is not a string.", $e->getMessage());
             $raised = true;
@@ -137,9 +140,9 @@ class TransformationsCustomTest extends TestCase
         $this->assertTrue($raised);
     }
 
-    public function testApplyToWithValidValueReturnsAnOkResult()
+    public function testApplyToWithValidValueReturnsAnOkResult() : void
     {
-        $factory = new \ILIAS\Data\Factory();
+        $factory = new DataFactory();
         $valueObject = $factory->ok(self::TEST_STRING);
 
         $resultObject = $this->custom->applyTo($valueObject);

--- a/tests/Refinery/DateTime/GroupTest.php
+++ b/tests/Refinery/DateTime/GroupTest.php
@@ -1,42 +1,43 @@
-<?php
+<?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\DateTime;
 
-use ILIAS\Data\Factory;
 use ILIAS\Refinery\DateTime\Group;
 use ILIAS\Refinery\DateTime\ChangeTimezone;
 use ILIAS\Tests\Refinery\TestCase;
 
-require_once('./libs/composer/vendor/autoload.php');
-require_once('./tests/Refinery/TestCase.php');
-
 class GroupTest extends TestCase
 {
-    /**
-     * @var Group
-     */
-    private $group;
+    private Group $group;
 
-    /**
-     * @var Factory
-     */
-    private $dataFactory;
-
-    public function setUp() : void
+    protected function setUp() : void
     {
-        $this->dataFactory = new Factory();
-        $this->group = new Group($this->dataFactory);
+        $this->group = new Group();
     }
 
-    public function testChangeTimezone()
+    public function testChangeTimezone() : void
     {
         $instance = $this->group->changeTimezone('Europe/Berlin');
         $this->assertInstanceOf(ChangeTimezone::class, $instance);
     }
 
-    public function testChangeTimezoneWrongConstruction()
+    public function testChangeTimezoneWrongConstruction() : void
     {
         $this->expectException(\InvalidArgumentException::class);
         $instance = $this->group->changeTimezone('MiddleEarth/Minas_Morgul');

--- a/tests/Refinery/DateTime/Transformation/ChangeTimezoneTest.php
+++ b/tests/Refinery/DateTime/Transformation/ChangeTimezoneTest.php
@@ -1,30 +1,41 @@
-<?php
+<?php declare(strict_types=1);
 
-/* Copyright (c) 2019 Nils Haagen <nils.haagen@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
-use ILIAS\Data\Factory;
+use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Refinery\DateTime;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Testcase for timezone transformation
- */
 class ChangeTimezoneTest extends TestCase
 {
+    private DateTime\Group $dt;
+
     protected function setUp() : void
     {
-        $df = new Factory();
-        $this->dt = new DateTime\Group($df);
+        $this->dt = new DateTime\Group();
     }
 
-
-    public function testTransform()
+    public function testTransform() : void
     {
         $dat = '2019-05-26 13:15:01';
         $origin_tz = 'Europe/Berlin';
         $target_tz = 'Europe/London';
-        $origin = new \DateTimeImmutable($dat, new \DateTimeZone($origin_tz));
-        $expected = new \DateTimeImmutable($dat, new \DateTimeZone($target_tz));
+        $origin = new DateTimeImmutable($dat, new DateTimeZone($origin_tz));
+        $expected = new DateTimeImmutable($dat, new DateTimeZone($target_tz));
         $trans = $this->dt->changeTimezone($target_tz);
 
         $this->assertEquals(
@@ -33,12 +44,12 @@ class ChangeTimezoneTest extends TestCase
         );
     }
 
-    public function testTransformValues()
+    public function testTransformValues() : void
     {
         $dat = '2019-05-26 13:15:01';
         $origin_tz = 'Europe/Berlin';
         $target_tz = 'America/El_Salvador';
-        $origin = new \DateTimeImmutable($dat, new \DateTimeZone($origin_tz));
+        $origin = new DateTimeImmutable($dat, new DateTimeZone($origin_tz));
         $trans = $this->dt->changeTimezone($target_tz);
         $this->assertEquals(
             $dat,
@@ -46,39 +57,39 @@ class ChangeTimezoneTest extends TestCase
         );
     }
 
-    public function testNullTransform()
+    public function testNullTransform() : void
     {
         $trans = $this->dt->changeTimezone('Europe/Berlin');
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $trans->transform(null);
     }
 
-    public function testInvalidTransform()
+    public function testInvalidTransform() : void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $trans = $this->dt->changeTimezone('Europe/Berlin');
         $trans->transform('erroneous');
     }
 
-    public function testInvoke()
+    public function testInvoke() : void
     {
         $dat = '2019/05/26 16:05:22';
         $origin_tz = 'Europe/Berlin';
         $target_tz = 'Europe/London';
-        $origin = new \DateTimeImmutable($dat, new \DateTimeZone($origin_tz));
-        $expected = new \DateTimeImmutable($dat, new \DateTimeZone($target_tz));
+        $origin = new DateTimeImmutable($dat, new DateTimeZone($origin_tz));
+        $expected = new DateTimeImmutable($dat, new DateTimeZone($target_tz));
         $trans = $this->dt->changeTimezone($target_tz);
         $this->assertEquals($expected, $trans($origin));
     }
 
-    public function testApplyToOK()
+    public function testApplyToOK() : void
     {
         $trans = $this->dt->changeTimezone('Europe/London');
         $value = '2019/05/26';
-        $origin = new \DateTimeImmutable($value);
-        $expected = new \DateTimeImmutable($value, new \DateTimeZone('Europe/London'));
+        $origin = new DateTimeImmutable($value);
+        $expected = new DateTimeImmutable($value, new DateTimeZone('Europe/London'));
 
-        $df = new \ILIAS\Data\Factory();
+        $df = new DataFactory();
         $ok = $df->ok($origin);
 
         $result = $trans->applyTo($ok);
@@ -86,10 +97,10 @@ class ChangeTimezoneTest extends TestCase
         $this->assertFalse($result->isError());
     }
 
-    public function testApplyToFail()
+    public function testApplyToFail() : void
     {
         $trans = $this->dt->changeTimezone('Europe/London');
-        $df = new \ILIAS\Data\Factory();
+        $df = new DataFactory();
         $ok = $df->ok('not_a_date');
 
         $result = $trans->applyTo($ok);

--- a/tests/Refinery/FactoryTest.php
+++ b/tests/Refinery/FactoryTest.php
@@ -1,120 +1,140 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
 /**
- * @author  Niels Theen <ntheen@databay.de>
- */
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery;
 
-use ILIAS\Refinery\Factory;
-
-require_once('./libs/composer/vendor/autoload.php');
-require_once('./tests/Refinery/TestCase.php');
+use ILIAS\Refinery\ByTrying as ByTrying;
+use ILIAS\Refinery\Container\Group as ContainerGroup;
+use ILIAS\Refinery\Custom\Group as CustomGroup;
+use ILIAS\Refinery\DateTime\Group as DateTimeGroup;
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\IdentityTransformation;
+use ILIAS\Refinery\In\Group as InGroup;
+use ILIAS\Refinery\Integer\Group as IntegerGroup;
+use ILIAS\Refinery\Logical\Group as LogicalGroup;
+use ILIAS\Refinery\Numeric\Group as NumericGroup;
+use ILIAS\Refinery\Password\Group as PasswordGroup;
+use ILIAS\Refinery\String\Group as StringGroup;
+use ILIAS\Refinery\To\Group as ToGroup;
+use ILIAS\Refinery\URI\Group as URIGroup;
+use ilLanguage;
 
 class FactoryTest extends TestCase
 {
-    /**
-     * @var Factory
-     */
-    private $basicFactory;
+    private Refinery $basicFactory;
 
-    public function setUp() : void
+    protected function setUp() : void
     {
-        $language = $this->getMockBuilder('\ilLanguage')
+        $language = $this->getMockBuilder(ilLanguage::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->basicFactory = new Factory(new \ILIAS\Data\Factory(), $language);
+        $this->basicFactory = new Refinery(new DataFactory(), $language);
     }
 
-    public function testCreateToGroup()
+    public function testCreateToGroup() : void
     {
         $group = $this->basicFactory->to();
 
-        $this->assertInstanceOf(\ILIAS\Refinery\To\Group::class, $group);
+        $this->assertInstanceOf(ToGroup::class, $group);
     }
 
-    public function testCreateInGroup()
+    public function testCreateInGroup() : void
     {
         $group = $this->basicFactory->in();
 
-        $this->assertInstanceOf(\ILIAS\Refinery\In\Group::class, $group);
+        $this->assertInstanceOf(InGroup::class, $group);
     }
 
-    public function testCreateIntegerGroup()
+    public function testCreateIntegerGroup() : void
     {
         $group = $this->basicFactory->int();
 
-        $this->assertInstanceOf(\ILIAS\Refinery\Integer\Group::class, $group);
+        $this->assertInstanceOf(IntegerGroup::class, $group);
     }
 
-    public function testCreateStringGroup()
+    public function testCreateStringGroup() : void
     {
         $group = $this->basicFactory->string();
 
-        $this->assertInstanceOf(\ILIAS\Refinery\String\Group::class, $group);
+        $this->assertInstanceOf(StringGroup::class, $group);
     }
 
-    public function testCreateNumericGroup()
+    public function testCreateNumericGroup() : void
     {
         $group = $this->basicFactory->numeric();
 
-        $this->assertInstanceOf(\ILIAS\Refinery\Numeric\Group::class, $group);
+        $this->assertInstanceOf(NumericGroup::class, $group);
     }
 
-    public function testCreateLogicalGroup()
+    public function testCreateLogicalGroup() : void
     {
         $group = $this->basicFactory->logical();
 
-        $this->assertInstanceOf(\ILIAS\Refinery\Logical\Group::class, $group);
+        $this->assertInstanceOf(LogicalGroup::class, $group);
     }
 
-    public function testCreatePasswordGroup()
+    public function testCreatePasswordGroup() : void
     {
         $group = $this->basicFactory->password();
 
-        $this->assertInstanceOf(\ILIAS\Refinery\Password\Group::class, $group);
+        $this->assertInstanceOf(PasswordGroup::class, $group);
     }
 
-    public function testCreateCustomGroup()
+    public function testCreateCustomGroup() : void
     {
         $group = $this->basicFactory->custom();
 
-        $this->assertInstanceOf(\ILIAS\Refinery\Custom\Group::class, $group);
+        $this->assertInstanceOf(CustomGroup::class, $group);
     }
 
-    public function testCreateContainerGroup()
+    public function testCreateContainerGroup() : void
     {
         $group = $this->basicFactory->container();
 
-        $this->assertInstanceOf(\ILIAS\Refinery\Container\Group::class, $group);
+        $this->assertInstanceOf(ContainerGroup::class, $group);
     }
 
-    public function testCreateDateTimeGroup()
+    public function testCreateDateTimeGroup() : void
     {
         $group = $this->basicFactory->dateTime();
-        $this->assertInstanceOf(\ILIAS\Refinery\DateTime\Group::class, $group);
+        $this->assertInstanceOf(DateTimeGroup::class, $group);
     }
 
-    public function testCreateUriGrouo()
+    public function testCreateUriGrouo() : void
     {
         $group = $this->basicFactory->uri();
-        $this->assertInstanceOf(\ILIAS\Refinery\URI\Group::class, $group);
+        $this->assertInstanceOf(URIGroup::class, $group);
     }
 
-    public function testByTryingInGroup()
+    public function testByTryingInGroup() : void
     {
         $instance = $this->basicFactory->byTrying([
             $this->basicFactory->numeric(),
             $this->basicFactory->string()
         ]);
-        $this->assertInstanceOf(\ILIAS\Refinery\ByTrying::class, $instance);
+        $this->assertInstanceOf(ByTrying::class, $instance);
     }
 
-    public function testIdentity()
+    public function testIdentity() : void
     {
         $instance = $this->basicFactory->identity();
-        $this->assertInstanceOf(\ILIAS\Refinery\IdentityTransformation::class, $instance);
+        $this->assertInstanceOf(IdentityTransformation::class, $instance);
     }
 }

--- a/tests/Refinery/IdentityTransformationTest.php
+++ b/tests/Refinery/IdentityTransformationTest.php
@@ -1,11 +1,23 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
- * @author  Lukas Scharmer <lscharmer@databay.de>
- */
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 namespace ILIAS\Tests\Refinery;
 
-use ILIAS\Data\NotOKException;
 use ILIAS\Data\Result\Ok;
 use ILIAS\Data\Result\Error;
 use ILIAS\Refinery\IdentityTransformation;

--- a/tests/Refinery/In/BasicGroupTest.php
+++ b/tests/Refinery/In/BasicGroupTest.php
@@ -1,42 +1,48 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
 /**
- * @author  Niels Theen <ntheen@databay.de>
- */
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\In;
 
 use ILIAS\Refinery\In\Parallel;
 use ILIAS\Refinery\In\Series;
-use ILIAS\Refinery\In\Group;
+use ILIAS\Refinery\In\Group as InGroup;
 use ILIAS\Refinery\To\Transformation\IntegerTransformation;
 use ILIAS\Refinery\To\Transformation\StringTransformation;
 use ILIAS\Tests\Refinery\TestCase;
 
-require_once('./libs/composer/vendor/autoload.php');
-
 class BasicGroupTest extends TestCase
 {
-    /**
-     * @var Group
-     */
-    private $group;
+    private InGroup $group;
 
-    public function setUp() : void
+    protected function setUp() : void
     {
-        $this->group = new Group();
+        $this->group = new InGroup();
     }
-
-    public function testParallelInstanceCreated()
+    
+    public function testParallelInstanceCreated() : void
     {
-        $transformation = $this->group->parallel(array(new StringTransformation(), new IntegerTransformation()));
+        $transformation = $this->group->parallel([new StringTransformation(), new IntegerTransformation()]);
         $this->assertInstanceOf(Parallel::class, $transformation);
     }
 
-    public function testSeriesInstanceCreated()
+    public function testSeriesInstanceCreated() : void
     {
-        $transformation = $this->group->series(array(new StringTransformation(), new IntegerTransformation()));
+        $transformation = $this->group->series([new StringTransformation(), new IntegerTransformation()]);
         $this->assertInstanceOf(Series::class, $transformation);
     }
 }

--- a/tests/Refinery/In/Transformation/ParallelTest.php
+++ b/tests/Refinery/In/Transformation/ParallelTest.php
@@ -1,13 +1,23 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
 /**
- * @author  Niels Theen <ntheen@databay.de>
- */
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\In\Transformation;
 
-use ILIAS\BackgroundTasks\Exceptions\InvalidArgumentException;
 use ILIAS\Data\Result\Ok;
 use ILIAS\Refinery\In\Parallel;
 use ILIAS\Refinery\To\Transformation\FloatTransformation;
@@ -17,44 +27,41 @@ use ILIAS\Refinery\ConstraintViolationException;
 use ILIAS\Tests\Refinery\TestCase;
 use UnexpectedValueException;
 
-require_once('./libs/composer/vendor/autoload.php');
-
-
 class ParallelTest extends TestCase
 {
-    public function testParallelTransformation()
+    public function testParallelTransformation() : void
     {
         $parallel = new Parallel(
-            array(
+            [
                 new StringTransformation(),
                 new StringTransformation()
-            )
+            ]
         );
 
         $result = $parallel->transform('hello');
 
-        $this->assertEquals(array('hello', 'hello'), $result);
+        $this->assertEquals(['hello', 'hello'], $result);
     }
 
 
-    public function testParallelTransformationForApplyTo()
+    public function testParallelTransformationForApplyTo() : void
     {
         $parallel = new Parallel(
-            array(
+            [
                 new StringTransformation(),
                 new StringTransformation()
-            )
+            ]
         );
 
         $result = $parallel->applyTo(new Ok('hello'));
 
-        $this->assertEquals(array('hello', 'hello'), $result->value());
+        $this->assertEquals(['hello', 'hello'], $result->value());
     }
 
-    public function testParallelTransformationFailsBecauseOfInvalidType()
+    public function testParallelTransformationFailsBecauseOfInvalidType() : void
     {
         $this->expectNotToPerformAssertions();
-        $parallel = new Parallel(array(new StringTransformation()));
+        $parallel = new Parallel([new StringTransformation()]);
 
         try {
             $result = $parallel->transform(42.0);
@@ -65,14 +72,14 @@ class ParallelTest extends TestCase
         $this->fail();
     }
 
-    public function testParallelApply()
+    public function testParallelApply() : void
     {
         $parallel = new Parallel(
-            array(
+            [
                 new StringTransformation(),
                 new IntegerTransformation(),
                 new FloatTransformation()
-            )
+            ]
         );
 
         $result = $parallel->applyTo(new Ok(42));
@@ -80,16 +87,16 @@ class ParallelTest extends TestCase
         $this->assertTrue($result->isError());
     }
 
-    public function testInvalidTransformationThrowsException()
+    public function testInvalidTransformationThrowsException() : void
     {
         $this->expectNotToPerformAssertions();
 
         try {
             $parallel = new Parallel(
-                array(
+                [
                     new StringTransformation(),
                     'this is invalid'
-                )
+                ]
             );
         } catch (ConstraintViolationException $exception) {
             return;

--- a/tests/Refinery/In/Transformation/SeriesTest.php
+++ b/tests/Refinery/In/Transformation/SeriesTest.php
@@ -1,9 +1,20 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
 /**
- * @author  Niels Theen <ntheen@databay.de>
- */
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\In\Transformation;
 
@@ -15,39 +26,37 @@ use ILIAS\Refinery\ConstraintViolationException;
 use ILIAS\Tests\Refinery\TestCase;
 use UnexpectedValueException;
 
-require_once('./libs/composer/vendor/autoload.php');
-
 class SeriesTest extends TestCase
 {
-    public function testSeriesTransformation()
+    public function testSeriesTransformation() : void
     {
-        $series = new Series(array(new StringTransformation()));
+        $series = new Series([new StringTransformation()]);
 
         $result = $series->transform('hello');
 
         $this->assertEquals('hello', $result);
     }
 
-    public function testSeriesApplyTo()
+    public function testSeriesApplyTo() : void
     {
-        $series = new Series(array(
+        $series = new Series([
             new StringTransformation(),
             new StringTransformation()
-        ));
+        ]);
 
         $result = $series->applyTo(new Ok('hello'));
 
         $this->assertEquals('hello', $result->value());
     }
 
-    public function testSeriesTransformationFails()
+    public function testSeriesTransformationFails() : void
     {
         $this->expectNotToPerformAssertions();
 
-        $series = new Series(array(
+        $series = new Series([
             new IntegerTransformation(),
             new StringTransformation()
-        ));
+        ]);
 
         try {
             $result = $series->transform(42.0);
@@ -62,28 +71,28 @@ class SeriesTest extends TestCase
     /**
      * @throws \ilException
      */
-    public function testSeriesApply()
+    public function testSeriesApply() : void
     {
-        $series = new Series(array(
+        $series = new Series([
             new IntegerTransformation(),
             new StringTransformation()
-        ));
+        ]);
 
         $result = $series->applyTo(new Ok(42.0));
 
         $this->assertTrue($result->isError());
     }
 
-    public function testInvalidTransformationThrowsException()
+    public function testInvalidTransformationThrowsException() : void
     {
         $this->expectNotToPerformAssertions();
 
         try {
             $parallel = new Series(
-                array(
+                [
                     new StringTransformation(),
                     'this is invalid'
-                )
+                ]
             );
         } catch (ConstraintViolationException $exception) {
             return;

--- a/tests/Refinery/Integer/Constraints/GreaterThanConstraintTest.php
+++ b/tests/Refinery/Integer/Constraints/GreaterThanConstraintTest.php
@@ -1,75 +1,79 @@
-<?php
+<?php declare(strict_types=1);
 
-/* Copyright (c) 2018 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\Integer\Constraints;
 
-require_once("libs/composer/vendor/autoload.php");
-
-use ILIAS\Data;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\Integer\GreaterThan;
 use PHPUnit\Framework\TestCase;
+use ilLanguage;
 
 class GreaterThanConstraintTest extends TestCase
 {
-    /**
-     * @var Data\Factory
-     */
-    private $df;
+    private DataFactory $df;
+    private ilLanguage $lng;
+    private int $greater_than;
+    private GreaterThan $c;
 
-    /**
-     * @var ilLanguage
-     */
-    private $lng;
-
-    /**
-     * @var integer
-     */
-    private $greater_than;
-
-    public function setUp() : void
+    protected function setUp() : void
     {
-        $this->df = new Data\Factory();
-        $this->lng = $this->getMockBuilder(\ilLanguage::class)
+        $this->df = new DataFactory();
+        $this->lng = $this->getMockBuilder(ilLanguage::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $this->greater_than = 10;
 
-        $this->c = new \ILIAS\Refinery\Integer\GreaterThan(
+        $this->c = new GreaterThan(
             $this->greater_than,
             $this->df,
             $this->lng
         );
     }
 
-    public function testAccepts()
+    public function testAccepts() : void
     {
         $this->assertTrue($this->c->accepts(12));
     }
 
-    public function testNotAccepts()
+    public function testNotAccepts() : void
     {
         $this->assertFalse($this->c->accepts(2));
     }
 
-    public function testCheckSucceed()
+    public function testCheckSucceed() : void
     {
         $this->c->check(12);
         $this->assertTrue(true); // does not throw
     }
 
-    public function testCheckFails()
+    public function testCheckFails() : void
     {
         $this->expectException(\UnexpectedValueException::class);
         $this->c->check(2);
     }
 
-    public function testNoProblemWith()
+    public function testNoProblemWith() : void
     {
         $this->assertNull($this->c->problemWith(12));
     }
 
-    public function testProblemWith()
+    public function testProblemWith() : void
     {
         $this->lng
             ->expects($this->once())
@@ -80,7 +84,7 @@ class GreaterThanConstraintTest extends TestCase
         $this->assertEquals("-2-10-", $this->c->problemWith(2));
     }
 
-    public function testRestrictOk()
+    public function testRestrictOk() : void
     {
         $ok = $this->df->ok(12);
 
@@ -88,7 +92,7 @@ class GreaterThanConstraintTest extends TestCase
         $this->assertTrue($res->isOk());
     }
 
-    public function testRestrictNotOk()
+    public function testRestrictNotOk() : void
     {
         $not_ok = $this->df->ok(2);
 
@@ -96,7 +100,7 @@ class GreaterThanConstraintTest extends TestCase
         $this->assertFalse($res->isOk());
     }
 
-    public function testRestrictError()
+    public function testRestrictError() : void
     {
         $error = $this->df->error("error");
 
@@ -104,9 +108,9 @@ class GreaterThanConstraintTest extends TestCase
         $this->assertSame($error, $res);
     }
 
-    public function testWithProblemBuilder()
+    public function testWithProblemBuilder() : void
     {
-        $new_c = $this->c->withProblemBuilder(function () {
+        $new_c = $this->c->withProblemBuilder(static function () : string {
             return "This was a fault";
         });
         $this->assertEquals("This was a fault", $new_c->problemWith(2));

--- a/tests/Refinery/Integer/Constraints/GreaterThanConstraintTest.php
+++ b/tests/Refinery/Integer/Constraints/GreaterThanConstraintTest.php
@@ -19,6 +19,7 @@
 namespace ILIAS\Tests\Refinery\Integer\Constraints;
 
 use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\Constraint;
 use ILIAS\Refinery\Integer\GreaterThan;
 use PHPUnit\Framework\TestCase;
 use ilLanguage;
@@ -28,7 +29,7 @@ class GreaterThanConstraintTest extends TestCase
     private DataFactory $df;
     private ilLanguage $lng;
     private int $greater_than;
-    private GreaterThan $c;
+    private Constraint $c;
 
     protected function setUp() : void
     {

--- a/tests/Refinery/Integer/Constraints/GreaterThanOrEqualConstraintTest.php
+++ b/tests/Refinery/Integer/Constraints/GreaterThanOrEqualConstraintTest.php
@@ -1,10 +1,24 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2021 Luka Stocker <luka.stocker@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\Integer\Constraints;
 
-use ILIAS\Data;
+use ILIAS\Data\Factory as DataFactory;
 use PHPUnit\Framework\TestCase;
 use UnexpectedValueException;
 use ILIAS\Refinery\Integer\GreaterThanOrEqual;
@@ -12,12 +26,13 @@ use ilLanguage;
 
 class GreaterThanOrEqualConstraintTest extends TestCase
 {
-    private Data\Factory $df;
+    private DataFactory $df;
     private ilLanguage $lng;
+    private GreaterThanOrEqual $c;
 
-    public function setUp() : void
+    protected function setUp() : void
     {
-        $this->df = new Data\Factory();
+        $this->df = new DataFactory();
         $this->lng = $this->getMockBuilder(ilLanguage::class)
                           ->disableOriginalConstructor()
                           ->getMock();
@@ -95,7 +110,7 @@ class GreaterThanOrEqualConstraintTest extends TestCase
 
     public function testWithProblemBuilder() : void
     {
-        $new_c = $this->c->withProblemBuilder(function () {
+        $new_c = $this->c->withProblemBuilder(static function () : string {
             return "This was a fault";
         });
         $this->assertEquals("This was a fault", $new_c->problemWith(9));

--- a/tests/Refinery/Integer/Constraints/GreaterThanOrEqualConstraintTest.php
+++ b/tests/Refinery/Integer/Constraints/GreaterThanOrEqualConstraintTest.php
@@ -19,6 +19,7 @@
 namespace ILIAS\Tests\Refinery\Integer\Constraints;
 
 use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\Constraint;
 use PHPUnit\Framework\TestCase;
 use UnexpectedValueException;
 use ILIAS\Refinery\Integer\GreaterThanOrEqual;
@@ -28,7 +29,7 @@ class GreaterThanOrEqualConstraintTest extends TestCase
 {
     private DataFactory $df;
     private ilLanguage $lng;
-    private GreaterThanOrEqual $c;
+    private Constraint $c;
 
     protected function setUp() : void
     {

--- a/tests/Refinery/Integer/Constraints/LessThanConstraintTest.php
+++ b/tests/Refinery/Integer/Constraints/LessThanConstraintTest.php
@@ -19,6 +19,7 @@
 namespace ILIAS\Tests\Refinery\Integer\Constraints;
 
 use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\Constraint;
 use ILIAS\Refinery\Integer\LessThan;
 use ilLanguage;
 use PHPUnit\Framework\TestCase;
@@ -26,7 +27,7 @@ use UnexpectedValueException;
 
 class LessThanConstraintTest extends TestCase
 {
-    private LessThan $c;
+    private Constraint $c;
     private ilLanguage $lng;
     private DataFactory $df;
     private int $less_than;

--- a/tests/Refinery/Integer/Constraints/LessThanConstraintTest.php
+++ b/tests/Refinery/Integer/Constraints/LessThanConstraintTest.php
@@ -1,81 +1,80 @@
-<?php
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\Integer\Constraints;
 
-/* Copyright (c) 2018 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
-require_once("libs/composer/vendor/autoload.php");
-
-use ILIAS\Refinery;
-use ILIAS\Data;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\Integer\LessThan;
+use ilLanguage;
 use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
 
 class LessThanConstraintTest extends TestCase
 {
+    private LessThan $c;
+    private ilLanguage $lng;
+    private DataFactory $df;
+    private int $less_than;
 
-    /**
-     * @var \ILIAS\Refinery\Integer\LessThan
-     */
-    private $c;
-
-    /**
-     * @var
-     */
-    private $lng;
-
-    /**
-     * @var Data\Factory
-     */
-    private $df;
-
-    /**
-     * @var integer
-     */
-    private $less_than;
-
-    public function setUp() : void
+    protected function setUp() : void
     {
-        $this->df = new Data\Factory();
-        $this->lng = $this->getMockBuilder(\ilLanguage::class)
+        $this->df = new DataFactory();
+        $this->lng = $this->getMockBuilder(ilLanguage::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $this->less_than = 10;
 
-        $this->c = new \ILIAS\Refinery\Integer\LessThan(
+        $this->c = new LessThan(
             $this->less_than,
             $this->df,
             $this->lng
         );
     }
 
-    public function testAccepts()
+    public function testAccepts() : void
     {
         $this->assertTrue($this->c->accepts(2));
     }
 
-    public function testNotAccepts()
+    public function testNotAccepts() : void
     {
         $this->assertFalse($this->c->accepts(10));
     }
 
-    public function testCheckSucceed()
+    public function testCheckSucceed() : void
     {
         $this->c->check(2);
         $this->assertTrue(true); // does not throw
     }
 
-    public function testCheckFails()
+    public function testCheckFails() : void
     {
-        $this->expectException(\UnexpectedValueException::class);
+        $this->expectException(UnexpectedValueException::class);
         $this->c->check(11);
     }
 
-    public function testNoProblemWith()
+    public function testNoProblemWith() : void
     {
         $this->assertNull($this->c->problemWith(1));
     }
 
-    public function testProblemWith()
+    public function testProblemWith() : void
     {
         $this->lng
             ->expects($this->once())
@@ -86,7 +85,7 @@ class LessThanConstraintTest extends TestCase
         $this->assertEquals("-12-{$this->less_than}-", $this->c->problemWith("12"));
     }
 
-    public function testRestrictOk()
+    public function testRestrictOk() : void
     {
         $ok = $this->df->ok(1);
 
@@ -94,7 +93,7 @@ class LessThanConstraintTest extends TestCase
         $this->assertTrue($res->isOk());
     }
 
-    public function testRestrictNotOk()
+    public function testRestrictNotOk() : void
     {
         $not_ok = $this->df->ok(1234);
 
@@ -102,7 +101,7 @@ class LessThanConstraintTest extends TestCase
         $this->assertFalse($res->isOk());
     }
 
-    public function testRestrictError()
+    public function testRestrictError() : void
     {
         $error = $this->df->error("error");
 
@@ -110,9 +109,9 @@ class LessThanConstraintTest extends TestCase
         $this->assertSame($error, $res);
     }
 
-    public function testWithProblemBuilder()
+    public function testWithProblemBuilder() : void
     {
-        $new_c = $this->c->withProblemBuilder(function () {
+        $new_c = $this->c->withProblemBuilder(static function () : string {
             return "This was a fault";
         });
         $this->assertEquals("This was a fault", $new_c->problemWith(13));

--- a/tests/Refinery/Integer/Constraints/LessThanOrEqualConstraintTest.php
+++ b/tests/Refinery/Integer/Constraints/LessThanOrEqualConstraintTest.php
@@ -19,6 +19,7 @@
 namespace ILIAS\Tests\Refinery\Integer\Constraints;
 
 use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\Constraint;
 use PHPUnit\Framework\TestCase;
 use UnexpectedValueException;
 use ILIAS\Refinery\Integer\LessThanOrEqual;
@@ -28,7 +29,7 @@ class LessThanOrEqualConstraintTest extends TestCase
 {
     private DataFactory $df;
     private ilLanguage $lng;
-    private LessThanOrEqual $c;
+    private Constraint $c;
 
     protected function setUp() : void
     {

--- a/tests/Refinery/Integer/Constraints/LessThanOrEqualConstraintTest.php
+++ b/tests/Refinery/Integer/Constraints/LessThanOrEqualConstraintTest.php
@@ -1,10 +1,24 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2021 Luka Stocker <luka.stocker@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\Integer\Constraints;
 
-use ILIAS\Data;
+use ILIAS\Data\Factory as DataFactory;
 use PHPUnit\Framework\TestCase;
 use UnexpectedValueException;
 use ILIAS\Refinery\Integer\LessThanOrEqual;
@@ -12,12 +26,13 @@ use ilLanguage;
 
 class LessThanOrEqualConstraintTest extends TestCase
 {
-    private Data\Factory $df;
+    private DataFactory $df;
     private ilLanguage $lng;
+    private LessThanOrEqual $c;
 
-    public function setUp() : void
+    protected function setUp() : void
     {
-        $this->df = new Data\Factory();
+        $this->df = new DataFactory();
         $this->lng = $this->getMockBuilder(ilLanguage::class)
                           ->disableOriginalConstructor()
                           ->getMock();
@@ -95,7 +110,7 @@ class LessThanOrEqualConstraintTest extends TestCase
 
     public function testWithProblemBuilder() : void
     {
-        $new_c = $this->c->withProblemBuilder(function () {
+        $new_c = $this->c->withProblemBuilder(static function () : string {
             return "This was a fault";
         });
         $this->assertEquals("This was a fault", $new_c->problemWith(13));

--- a/tests/Refinery/Integer/GroupTest.php
+++ b/tests/Refinery/Integer/GroupTest.php
@@ -1,29 +1,44 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\Integer;
 
 use ILIAS\Data\Factory;
-use ILIAS\Refinery\Integer\Group;
+use ILIAS\Refinery\Integer\Group as IntegerGroup;
 use ILIAS\Refinery\Integer\GreaterThan;
 use ILIAS\Refinery\Integer\LessThan;
 use ILIAS\Tests\Refinery\TestCase;
 use ILIAS\Refinery\Integer\GreaterThanOrEqual;
 use ILIAS\Refinery\Integer\LessThanOrEqual;
+use ilLanguage;
 
 class GroupTest extends TestCase
 {
-    private Group $group;
+    private IntegerGroup $group;
 
-    public function setUp() : void
+    protected function setUp() : void
     {
         $dataFactory = new Factory();
-        $language = $this->getMockBuilder('\ilLanguage')
+        $language = $this->getMockBuilder(ilLanguage::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->group = new Group($dataFactory, $language);
+        $this->group = new IntegerGroup($dataFactory, $language);
     }
 
     public function testGreaterThanInstance() : void

--- a/tests/Refinery/KeyValueAccessTest.php
+++ b/tests/Refinery/KeyValueAccessTest.php
@@ -28,9 +28,6 @@ class KeyValueAccessTest extends PHPUnitTestCase
 {
     private Refinery $refinery;
 
-    /**
-     * @inheritDoc
-     */
     protected function setUp() : void
     {
         $this->refinery = new Refinery(new DataFactory, $this->createMock(ilLanguage::class));

--- a/tests/Refinery/KeyValueAccessTest.php
+++ b/tests/Refinery/KeyValueAccessTest.php
@@ -1,26 +1,39 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery;
 
 use ILIAS\Refinery\KeyValueAccess;
-use ILIAS\Refinery\Factory;
+use ILIAS\Refinery\Factory as Refinery;
+use ilLanguage;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+use ILIAS\Data\Factory as DataFactory;
 
-/**
- * Class KeyValueAccessTest
- * @author Fabian Schmid <fs@studer-raimann.ch>
- */
 class KeyValueAccessTest extends PHPUnitTestCase
 {
-    protected Factory $refinery;
+    private Refinery $refinery;
 
     /**
      * @inheritDoc
      */
     protected function setUp() : void
     {
-        $this->refinery = new Factory(new \ILIAS\Data\Factory(), $this->createMock(\ilLanguage::class));
+        $this->refinery = new Refinery(new DataFactory, $this->createMock(ilLanguage::class));
     }
 
     public function testAccess() : void

--- a/tests/Refinery/KindlyTo/GroupTest.php
+++ b/tests/Refinery/KindlyTo/GroupTest.php
@@ -1,9 +1,24 @@
-<?php
-/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\KindlyTo;
 
-use ILIAS\Refinery\KindlyTo\Group;
+use ILIAS\Refinery\KindlyTo\Group as KindlyToGroup;
 use ILIAS\Refinery\KindlyTo\Transformation\FloatTransformation;
 use ILIAS\Refinery\KindlyTo\Transformation\StringTransformation;
 use ILIAS\Refinery\KindlyTo\Transformation\BooleanTransformation;
@@ -16,56 +31,56 @@ use ILIAS\Tests\Refinery\TestCase;
 
 class GroupTest extends TestCase
 {
-    private $basicGroup;
+    private KindlyToGroup $basicGroup;
 
-    public function setUp() : void
+    protected function setUp() : void
     {
-        $this->basicGroup = new Group(new \ILIAS\Data\Factory());
+        $this->basicGroup = new KindlyToGroup(new \ILIAS\Data\Factory());
     }
 
-    public function testIsStringTransformationInstance()
+    public function testIsStringTransformationInstance() : void
     {
         $transformation = $this->basicGroup->string();
         $this->assertInstanceOf(StringTransformation::class, $transformation);
     }
 
-    public function testIsBooleanTransformationInstance()
+    public function testIsBooleanTransformationInstance() : void
     {
         $transformation = $this->basicGroup->bool();
         $this->assertInstanceOf(BooleanTransformation::class, $transformation);
     }
 
-    public function testIsDateTimeTransformationInterface()
+    public function testIsDateTimeTransformationInterface() : void
     {
         $transformation = $this->basicGroup->dateTime();
         $this->assertInstanceOf(DateTimeTransformation::class, $transformation);
     }
 
-    public function testIsIntegerTransformationInterface()
+    public function testIsIntegerTransformationInterface() : void
     {
         $transformation = $this->basicGroup->int();
         $this->assertInstanceOf(IntegerTransformation::class, $transformation);
     }
 
-    public function testIsFloatTransformationInterface()
+    public function testIsFloatTransformationInterface() : void
     {
         $transformation = $this->basicGroup->float();
         $this->assertInstanceOf(FloatTransformation::class, $transformation);
     }
 
-    public function testIsRecordTransformationInterface()
+    public function testIsRecordTransformationInterface() : void
     {
-        $transformation = $this->basicGroup->recordOf(array('tostring' => new StringTransformation()));
+        $transformation = $this->basicGroup->recordOf(['tostring' => new StringTransformation()]);
         $this->assertInstanceOf(RecordTransformation::class, $transformation);
     }
 
-    public function testIsTupleTransformationInterface()
+    public function testIsTupleTransformationInterface() : void
     {
-        $transformation = $this->basicGroup->tupleOf(array(new StringTransformation()));
+        $transformation = $this->basicGroup->tupleOf([new StringTransformation()]);
         $this->assertInstanceOf(TupleTransformation::class, $transformation);
     }
 
-    public function testNewDictionaryTransformation()
+    public function testNewDictionaryTransformation() : void
     {
         $transformation = $this->basicGroup->dictOf(new StringTransformation());
         $this->assertInstanceOf(DictionaryTransformation::class, $transformation);

--- a/tests/Refinery/KindlyTo/Transformation/BooleanTransformationTest.php
+++ b/tests/Refinery/KindlyTo/Transformation/BooleanTransformationTest.php
@@ -1,5 +1,20 @@
-<?php
-/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\KindlyTo\Transformation;
 
@@ -7,24 +22,21 @@ use ILIAS\Refinery\KindlyTo\Transformation\BooleanTransformation;
 use ILIAS\Tests\Refinery\TestCase;
 use ILIAS\Refinery\ConstraintViolationException;
 
-/**
- * Test transformations in this Group
- */
 class BooleanTransformationTest extends TestCase
 {
-    private $transformation;
+    private BooleanTransformation $transformation;
 
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->transformation = new BooleanTransformation();
     }
 
     /**
      * @dataProvider BooleanTestDataProvider
-     * @param $originVal
+     * @param mixed $originVal
      * @param bool $expectedVal
      */
-    public function testBooleanTransformation($originVal, $expectedVal)
+    public function testBooleanTransformation($originVal, bool $expectedVal) : void
     {
         $transformedValue = $this->transformation->transform($originVal);
         $this->assertIsBool($transformedValue);
@@ -33,15 +45,15 @@ class BooleanTransformationTest extends TestCase
 
     /**
      * @dataProvider TransformationFailureDataProvider
-     * @param $failingValue
+     * @param mixed $failingValue
      */
-    public function testTransformIsInvalid($failingValue)
+    public function testTransformIsInvalid($failingValue) : void
     {
         $this->expectException(ConstraintViolationException::class);
         $this->transformation->transform($failingValue);
     }
 
-    public function BooleanTestDataProvider()
+    public function BooleanTestDataProvider() : array
     {
         return [
             'true' => [true, true],
@@ -61,8 +73,7 @@ class BooleanTransformationTest extends TestCase
         ];
     }
 
-
-    public function TransformationFailureDataProvider()
+    public function TransformationFailureDataProvider() : array
     {
         return [
             'null' => [null],

--- a/tests/Refinery/KindlyTo/Transformation/DateTimeTransformationTest.php
+++ b/tests/Refinery/KindlyTo/Transformation/DateTimeTransformationTest.php
@@ -1,67 +1,84 @@
-<?php
-/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\KindlyTo\Transformation;
 
-require_once('./libs/composer/vendor/autoload.php');
-
+use DateTimeImmutable;
+use DateTimeInterface;
 use ILIAS\Refinery\ConstraintViolationException;
 use ILIAS\Refinery\KindlyTo\Transformation\DateTimeTransformation;
 use ILIAS\Tests\Refinery\TestCase;
 
-/**
- * Tests for DateTimeImmutable and Unix Timetable transformation
- */
-
 class DateTimeTransformationTest extends TestCase
 {
-    private $transformation;
+    private DateTimeTransformation $transformation;
 
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->transformation = new DateTimeTransformation();
     }
 
     /**
      * @dataProvider DateTimeTransformationDataProvider
-     * @param $originVal
-     * @param $expectedVal
+     * @param mixed $originVal
+     * @param DateTimeImmutable $expectedVal
      */
-    public function testDateTimeISOTransformation($originVal, $expectedVal)
+    public function testDateTimeISOTransformation($originVal, DateTimeImmutable $expectedVal) : void
     {
         $transformedValue = $this->transformation->transform($originVal);
         $this->assertIsObject($transformedValue);
-        $this->assertInstanceOf(\DateTimeImmutable::class, $transformedValue);
+        $this->assertInstanceOf(DateTimeImmutable::class, $transformedValue);
         $this->assertEquals($expectedVal, $transformedValue);
     }
 
     /**
      * @dataProvider TransformationFailureDataProvider
-     * @param $failingValue
+     * @param string$failingValue
      */
-    public function testTransformIsInvalid($failingValue)
+    public function testTransformIsInvalid(string $failingValue) : void
     {
         $this->expectException(ConstraintViolationException::class);
         $this->transformation->transform($failingValue);
     }
 
-    public function DateTimeTransformationDataProvider()
+    public function DateTimeTransformationDataProvider() : array
     {
-        $now = new \DateTimeImmutable();
+        $now = new DateTimeImmutable();
         return [
             'datetime' => [$now, $now],
-            'iso8601' => ['2020-07-06T12:23:05+0000',\DateTimeImmutable::createFromFormat(\DateTimeImmutable::ISO8601, '2020-07-06T12:23:05+0000')],
-            'atom' => ['2020-07-06T12:23:05+00:00',\DateTimeImmutable::createFromFormat(\DateTimeImmutable::ATOM, '2020-07-06T12:23:05+00:00')],
-            'rfc3339_ext' => ['2020-07-06T12:23:05.000+00:00',\DateTimeImmutable::createFromFormat(\DateTimeImmutable::RFC3339_EXTENDED, '2020-07-06T12:23:05.000+00:00')],
-            'cookie' => ['Monday, 06-Jul-2020 12:23:05 GMT+0000',\DateTimeImmutable::createFromFormat(\DateTimeImmutable::COOKIE, 'Monday, 06-Jul-2020 12:23:05 GMT+0000')],
-            'rfc822' => ['Mon, 06 Jul 20 12:23:05 +0000',\DateTimeImmutable::createFromFormat(\DateTimeImmutable::RFC822, 'Mon, 06 Jul 20 12:23:05 +0000')],
-            'rfc7231' => ['Mon, 06 Jul 2020 12:23:05 GMT',\DateTimeImmutable::createFromFormat(\DateTimeImmutable::RFC7231, 'Mon, 06 Jul 2020 12:23:05 GMT')],
-            'unix_timestamp' => [481556262, \DateTimeImmutable::createFromFormat(\DateTimeImmutable::ISO8601, '1985-04-05T13:37:42+0000')],
-            'unix_timestamp_float' => [481556262.4, \DateTimeImmutable::createFromFormat(\DateTimeImmutable::ISO8601, '1985-04-05T13:37:42+0000')]
+            'iso8601' => ['2020-07-06T12:23:05+0000',
+                DateTimeImmutable::createFromFormat(DateTimeInterface::ISO8601, '2020-07-06T12:23:05+0000')],
+            'atom' => ['2020-07-06T12:23:05+00:00',
+                DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, '2020-07-06T12:23:05+00:00')],
+            'rfc3339_ext' => ['2020-07-06T12:23:05.000+00:00',
+                DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, '2020-07-06T12:23:05.000+00:00')],
+            'cookie' => ['Monday, 06-Jul-2020 12:23:05 GMT+0000',
+                DateTimeImmutable::createFromFormat(DateTimeInterface::COOKIE, 'Monday, 06-Jul-2020 12:23:05 GMT+0000')],
+            'rfc822' => ['Mon, 06 Jul 20 12:23:05 +0000',
+                DateTimeImmutable::createFromFormat(DateTimeInterface::RFC822, 'Mon, 06 Jul 20 12:23:05 +0000')],
+            'rfc7231' => ['Mon, 06 Jul 2020 12:23:05 GMT',
+                DateTimeImmutable::createFromFormat(DateTimeInterface::RFC7231, 'Mon, 06 Jul 2020 12:23:05 GMT')],
+            'unix_timestamp' => [481556262, DateTimeImmutable::createFromFormat(DateTimeInterface::ISO8601, '1985-04-05T13:37:42+0000')],
+            'unix_timestamp_float' => [481556262.4, DateTimeImmutable::createFromFormat(DateTimeInterface::ISO8601, '1985-04-05T13:37:42+0000')]
         ];
     }
 
-    public function TransformationFailureDataProvider()
+    public function TransformationFailureDataProvider() : array
     {
         return [
             'no_matching_string_format' => ['hello']

--- a/tests/Refinery/KindlyTo/Transformation/DictionaryTransformationTest.php
+++ b/tests/Refinery/KindlyTo/Transformation/DictionaryTransformationTest.php
@@ -1,5 +1,20 @@
-<?php
-/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\KindlyTo\Transformation;
 
@@ -7,15 +22,16 @@ use ILIAS\Refinery\KindlyTo\Transformation\DictionaryTransformation;
 use ILIAS\Refinery\KindlyTo\Transformation\StringTransformation;
 use ILIAS\Refinery\ConstraintViolationException;
 use ILIAS\Tests\Refinery\TestCase;
+use stdClass;
 
 class DictionaryTransformationTest extends TestCase
 {
     /**
      * @dataProvider DictionaryTransformationDataProvider
-     * @param $originVal
-     * @param $expectedVal
+     * @param array $originVal
+     * @param array $expectedVal
      */
-    public function testDictionaryTransformation($originVal, $expectedVal)
+    public function testDictionaryTransformation(array $originVal, array $expectedVal) : void
     {
         $transformation = new DictionaryTransformation(new StringTransformation());
         $transformedValue = $transformation->transform($originVal);
@@ -25,24 +41,29 @@ class DictionaryTransformationTest extends TestCase
 
     /**
      * @dataProvider TransformationFailingDataProvider
-     * @param $failingVal
+     * @param mixed $failingVal
      */
-    public function testTransformationFailures($failingVal)
+    public function testTransformationFailures($failingVal) : void
     {
         $this->expectException(ConstraintViolationException::class);
         $transformation = new DictionaryTransformation(new StringTransformation());
         $transformation->transform($failingVal);
     }
 
-    public function TransformationFailingDataProvider()
+    public function TransformationFailingDataProvider() : array
     {
         return [
-            'key_not_a_string' => ['hello'],
-            'value_not_a_string' => ['hello' => 1]
+            'from_is_a_string' => ['hello'],
+            'from_is_an_int' => [1],
+            'from_is_an_float' => [3.141],
+            'from_is_null' => [null],
+            'from_is_a_bool' => [true],
+            'from_is_a_resource' => [fopen('php://memory', 'rb')],
+            'from_is_an_object' => [new stdClass()],
         ];
     }
 
-    public function DictionaryTransformationDataProvider()
+    public function DictionaryTransformationDataProvider() : array
     {
         return [
             'first_arr' => [['hello' => 'world'], ['hello' => 'world'] ],

--- a/tests/Refinery/KindlyTo/Transformation/FloatTransformationTest.php
+++ b/tests/Refinery/KindlyTo/Transformation/FloatTransformationTest.php
@@ -1,33 +1,42 @@
-<?php
+<?php declare(strict_types=1);
 
-/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\KindlyTo\Transformation;
-
-require_once('./libs/composer/vendor/autoload.php');
 
 use ILIAS\Refinery\ConstraintViolationException;
 use ILIAS\Refinery\KindlyTo\Transformation\FloatTransformation;
 use ILIAS\Tests\Refinery\TestCase;
 
-/**
- * Test transformations in this Group
- */
 class FloatTransformationTest extends TestCase
 {
-    private $transformation;
+    private FloatTransformation $transformation;
 
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->transformation = new FloatTransformation();
     }
 
     /**
      * @dataProvider FloatTestDataProvider
-     * @param $originVal
-     * @param $expectedVal
+     * @param mixed $originVal
+     * @param float $expectedVal
      */
-    public function testFloatTransformation($originVal, $expectedVal)
+    public function testFloatTransformation($originVal, float $expectedVal) : void
     {
         $transformedValue = $this->transformation->transform($originVal);
         $this->assertIsFloat($transformedValue);
@@ -36,9 +45,9 @@ class FloatTransformationTest extends TestCase
 
     /**
      * @dataProvider FailingTransformationDataProvider
-     * @param $failingVal
+     * @param mixed $failingVal
      */
-    public function testFailingTransformations($failingVal)
+    public function testFailingTransformations($failingVal) : void
     {
         $this->expectNotToPerformAssertions();
         try {
@@ -49,7 +58,7 @@ class FloatTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function FailingTransformationDataProvider()
+    public function FailingTransformationDataProvider() : array
     {
         return [
             'null' => [null],
@@ -68,7 +77,7 @@ class FloatTransformationTest extends TestCase
         ];
     }
 
-    public function FloatTestDataProvider()
+    public function FloatTestDataProvider() : array
     {
         return [
             'some_float' => [1.0, 1.0],

--- a/tests/Refinery/KindlyTo/Transformation/IntegerTransformationTest.php
+++ b/tests/Refinery/KindlyTo/Transformation/IntegerTransformationTest.php
@@ -1,5 +1,20 @@
-<?php
-/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\KindlyTo\Transformation;
 
@@ -7,24 +22,21 @@ use ILIAS\Refinery\ConstraintViolationException;
 use ILIAS\Refinery\KindlyTo\Transformation\IntegerTransformation;
 use ILIAS\Tests\Refinery\TestCase;
 
-/**
- * Test transformations in this Group
- */
 class IntegerTransformationTest extends TestCase
 {
-    private $transformation;
+    private IntegerTransformation $transformation;
 
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->transformation = new IntegerTransformation();
     }
 
     /**
      * @dataProvider IntegerTestDataProvider
-     * @param $originVal
-     * @param $expectedVal
+     * @param mixed $originVal
+     * @param int $expectedVal
      */
-    public function testIntegerTransformation($originVal, $expectedVal)
+    public function testIntegerTransformation($originVal, int $expectedVal) : void
     {
         $transformedValue = $this->transformation->transform($originVal);
         $this->assertIsInt($transformedValue);
@@ -33,19 +45,19 @@ class IntegerTransformationTest extends TestCase
 
     /**
      * @dataProvider TransformationFailureDataProvider
-     * @param $failingValue
+     * @param mixed $failingValue
      */
-    public function testTransformIsInvalid($failingValue)
+    public function testTransformIsInvalid($failingValue) : void
     {
         $this->expectException(ConstraintViolationException::class);
         $this->transformation->transform($failingValue);
     }
 
-    public function IntegerTestDataProvider()
+    public function IntegerTestDataProvider() : array
     {
         return [
-            'pos_bool' => [true, (int) 1],
-            'neg_bool' => [false, (int) 0],
+            'pos_bool' => [true, 1],
+            'neg_bool' => [false, 0],
             'float_val' => [20.5, 21],
             'float_val_round_up' => [0.51, 1],
             'float_val_round_down' => [0.49, 0],
@@ -57,7 +69,7 @@ class IntegerTransformationTest extends TestCase
         ];
     }
 
-    public function TransformationFailureDataProvider()
+    public function TransformationFailureDataProvider() : array
     {
         return [
             'bigger_than_int_max' => ["9223372036854775808"],

--- a/tests/Refinery/KindlyTo/Transformation/ListTransformationTest.php
+++ b/tests/Refinery/KindlyTo/Transformation/ListTransformationTest.php
@@ -1,26 +1,36 @@
-<?php
-/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\KindlyTo\Transformation;
-
-require_once('./libs/composer/vendor/autoload.php');
 
 use ILIAS\Refinery\KindlyTo\Transformation\ListTransformation;
 use ILIAS\Refinery\To\Transformation\StringTransformation;
 use ILIAS\Tests\Refinery\TestCase;
 use UnexpectedValueException;
 
-/**
- * Test transformations in this Group
- */
 class ListTransformationTest extends TestCase
 {
     /**
      * @dataProvider ArrayToListTransformationDataProvider
-     * @param $originValue
-     * @param $expectedValue
+     * @param mixed $originValue
+     * @param mixed $expectedValue
      */
-    public function testListTransformation($originValue, $expectedValue)
+    public function testListTransformation($originValue, $expectedValue) : void
     {
         $transformList = new ListTransformation(new StringTransformation());
         $transformedValue = $transformList->transform($originValue);
@@ -30,26 +40,26 @@ class ListTransformationTest extends TestCase
 
     /**
      * @dataProvider ArrayFailureDataProvider
-     * @param $origValue
+     * @param mixed $origValue
      */
-    public function testFailingTransformations($origValue)
+    public function testFailingTransformations($origValue) : void
     {
         $this->expectException(UnexpectedValueException::class);
         $transformList = new ListTransformation(new StringTransformation());
         $transformList->transform($origValue);
     }
 
-    public function ArrayToListTransformationDataProvider()
+    public function ArrayToListTransformationDataProvider() : array
     {
         return [
             'first_arr' => [['hello', 'world'], ['hello', 'world']],
-            'second_arr' => [['hello2','world2'], ['hello2', 'world2']],
-            'string_val' => ['hello world',['hello world']],
+            'second_arr' => [['hello2', 'world2'], ['hello2', 'world2']],
+            'string_val' => ['hello world', ['hello world']],
             'empty_array' => [[], []]
         ];
     }
 
-    public function ArrayFailureDataProvider()
+    public function ArrayFailureDataProvider() : array
     {
         return [
             'null_array' => [[null]],

--- a/tests/Refinery/KindlyTo/Transformation/NullTransformationTest.php
+++ b/tests/Refinery/KindlyTo/Transformation/NullTransformationTest.php
@@ -1,29 +1,35 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2020 Nils Haagen <nils.haagen@concepts-and-training.de>, Extended GPL, see docs/LICENSE */
-
-require_once('./libs/composer/vendor/autoload.php');
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 use ILIAS\Refinery\KindlyTo\Transformation\NullTransformation;
 use ILIAS\Tests\Refinery\TestCase;
 use ILIAS\Refinery\ConstraintViolationException;
 
-/**
- * Test kind transformation to null
- */
 class NullTransformationTest extends TestCase
 {
-    /**
-     * NullTransformation
-     */
-    protected $transformation;
+    private NullTransformation $transformation;
 
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->transformation = new NullTransformation();
     }
 
-    public function NullTestDataProvider()
+    public function NullTestDataProvider() : array
     {
         return [
             'empty string' => ['', true],
@@ -42,8 +48,11 @@ class NullTransformationTest extends TestCase
 
     /**
      * @dataProvider NullTestDataProvider
+     * @param mixed $value
+     * @param bool $valid
+     * @throws Exception
      */
-    public function testNullTransformation($value, bool $valid)
+    public function testNullTransformation($value, bool $valid) : void
     {
         if (!$valid) {
             $this->expectException(ConstraintViolationException::class);

--- a/tests/Refinery/KindlyTo/Transformation/RecordTransformationTest.php
+++ b/tests/Refinery/KindlyTo/Transformation/RecordTransformationTest.php
@@ -1,5 +1,20 @@
-<?php
-/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\KindlyTo\Transformation;
 
@@ -9,20 +24,18 @@ use ILIAS\Refinery\KindlyTo\Transformation\RecordTransformation;
 use ILIAS\Refinery\KindlyTo\Transformation\StringTransformation;
 use ILIAS\Tests\Refinery\TestCase;
 
-require_once('./libs/composer/vendor/autoload.php');
-
 class RecordTransformationTest extends TestCase
 {
-    const STRING_KEY = 'stringKey';
-    const INT_KEY = 'integerKey';
-    const SECOND_INT_KEY = 'integerKey2';
+    private const STRING_KEY = 'stringKey';
+    private const INT_KEY = 'integerKey';
+    private const SECOND_INT_KEY = 'integerKey2';
 
     /**
      * @dataProvider RecordTransformationDataProvider
-     * @param $originVal
-     * @param $expectedVal
+     * @param array $originVal
+     * @param array $expectedVal
      */
-    public function testRecordTransformationIsValid($originVal, $expectedVal)
+    public function testRecordTransformationIsValid(array $originVal, array $expectedVal) : void
     {
         $recTransform = new RecordTransformation(
             [
@@ -37,16 +50,16 @@ class RecordTransformationTest extends TestCase
 
     /**
      * @dataProvider RecordFailureDataProvider
-     * @param $origVal
+     * @param array $origVal
      */
-    public function testRecordTransformationFailures($origVal)
+    public function testRecordTransformationFailures(array $origVal) : void
     {
         $this->expectNotToPerformAssertions();
         $recTransformation = new RecordTransformation(
-            array(
+            [
                 self::STRING_KEY => new StringTransformation(),
                 self::INT_KEY => new IntegerTransformation()
-            )
+            ]
         );
 
         try {
@@ -57,7 +70,7 @@ class RecordTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testInvalidArray()
+    public function testInvalidArray() : void
     {
         $this->expectNotToPerformAssertions();
         try {
@@ -75,9 +88,9 @@ class RecordTransformationTest extends TestCase
 
     /**
      * @dataProvider RecordValueInvalidDataProvider
-     * @param $originalValue
+     * @param array $originalValue
      */
-    public function testInvalidValueDoesNotMatch($originalValue)
+    public function testInvalidValueDoesNotMatch(array $originalValue) : void
     {
         $this->expectNotToPerformAssertions();
         $recTransformation = new RecordTransformation(
@@ -95,28 +108,31 @@ class RecordTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function RecordTransformationDataProvider()
+    public function RecordTransformationDataProvider() : array
     {
         return [
             "exact_form" => [['stringKey' => 'hello', 'integerKey' => 1], ['stringKey' => 'hello', 'integerKey' => 1]],
 
-            'too_many_values' => [['stringKey' => 'hello', 'integerKey' => 1, 'secondIntKey' => 1],['stringKey' => 'hello', 'integerKey' => 1]]
+            'too_many_values' => [
+                ['stringKey' => 'hello', 'integerKey' => 1, 'secondIntKey' => 1],
+                ['stringKey' => 'hello', 'integerKey' => 1]
+            ]
         ];
     }
 
-    public function RecordFailureDataProvider()
+    public function RecordFailureDataProvider() : array
     {
         return [
             'too_little_values' => [['stringKey' => 'hello']],
-            'key_is_not_a_string' => [['testKey' => 'hello', ]],
+            'key_is_not_a_string' => [['testKey' => 'hello',]],
             'key_value_is_invalid' => [['stringKey' => 'hello', 'integerKey2' => 1]]
         ];
     }
 
-    public function RecordValueInvalidDataProvider()
+    public function RecordValueInvalidDataProvider() : array
     {
         return [
-            'invalid_value' => [array('stringKey' => 'hello', 'integerKey2' => 1)]
+            'invalid_value' => [['stringKey' => 'hello', 'integerKey2' => 1]]
         ];
     }
 }

--- a/tests/Refinery/KindlyTo/Transformation/StringTransformationTest.php
+++ b/tests/Refinery/KindlyTo/Transformation/StringTransformationTest.php
@@ -1,40 +1,51 @@
-<?php
-/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\KindlyTo\Transformation;
 
-require_once('./libs/composer/vendor/autoload.php');
-
 use ILIAS\Refinery\KindlyTo\Transformation\StringTransformation;
 use ILIAS\Tests\Refinery\TestCase;
+use stdClass;
 
-/**
- * Test transformations in this Group
- */
 class StringTransformationTest extends TestCase
 {
-    private $transformation;
+    private StringTransformation $transformation;
 
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->transformation = new StringTransformation();
     }
 
     /**
      * @dataProvider StringTestDataProvider
-     * @param $originVal
+     * @param mixed $originVal
      * @param string $expectedVal
      */
-    public function testStringTransformation($originVal, $expectedVal)
+    public function testStringTransformation($originVal, string $expectedVal) : void
     {
         $transformedValue = $this->transformation->transform($originVal);
         $this->assertIsString($transformedValue);
         $this->assertEquals($expectedVal, $transformedValue);
     }
 
-    public function StringTestDataProvider()
+    public function StringTestDataProvider() : array
     {
-        $obj = new class extends \StdClass {
+        $obj = new class extends stdClass {
             public function __toString()
             {
                 return 'an object';

--- a/tests/Refinery/KindlyTo/Transformation/TupleTransformationTest.php
+++ b/tests/Refinery/KindlyTo/Transformation/TupleTransformationTest.php
@@ -1,5 +1,20 @@
-<?php
-/* Copyright (c) 2020 Luka K. A. Stocker, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\KindlyTo\Transformation;
 
@@ -8,17 +23,16 @@ use ILIAS\Refinery\KindlyTo\Transformation\IntegerTransformation;
 use ILIAS\Refinery\KindlyTo\Transformation\TupleTransformation;
 use ILIAS\Tests\Refinery\TestCase;
 
-require_once('./libs/composer/vendor/autoload.php');
-
 class TupleTransformationTest extends TestCase
 {
-    const TUPLE_KEY = 'hello';
+    private const TUPLE_KEY = 'hello';
+
     /**
      * @dataProvider TupleTransformationDataProvider
-     * @param $originVal
-     * @param $expectedVal
+     * @param array $originVal
+     * @param array $expectedVal
      */
-    public function testTupleTransformation($originVal, $expectedVal)
+    public function testTupleTransformation(array $originVal, array $expectedVal) : void
     {
         $transformation = new TupleTransformation(
             [
@@ -33,9 +47,9 @@ class TupleTransformationTest extends TestCase
 
     /**
      * @dataProvider TupleFailingTransformationDataProvider
-     * @param $failingVal
+     * @param array $failingVal
      */
-    public function testNewTupleIsIncorrect($failingVal)
+    public function testNewTupleIsIncorrect(array $failingVal) : void
     {
         $this->expectNotToPerformAssertions();
         $transformation = new TupleTransformation(
@@ -55,9 +69,9 @@ class TupleTransformationTest extends TestCase
 
     /**
      * @dataProvider TupleTooManyValuesDataProvider
-     * @param $tooManyValues
+     * @param array $tooManyValues
      */
-    public function testTupleTooManyValues($tooManyValues)
+    public function testTupleTooManyValues(array $tooManyValues) : void
     {
         $this->expectNotToPerformAssertions();
         $transformation = new TupleTransformation(
@@ -75,24 +89,24 @@ class TupleTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function TupleTooManyValuesDataProvider()
+    public function TupleTooManyValuesDataProvider() : array
     {
         return [
-            'too_many_values' => [array(1,2,3)]
+            'too_many_values' => [[1,2,3]]
         ];
     }
 
-    public function TupleFailingTransformationDataProvider()
+    public function TupleFailingTransformationDataProvider() : array
     {
         return [
-            'incorrect_tuple' => [array(1, 2)]
+            'incorrect_tuple' => [[1, 2]]
         ];
     }
 
-    public function TupleTransformationDataProvider()
+    public function TupleTransformationDataProvider() : array
     {
         return [
-            'array_test01' => [array(1, 2), [1, 2]]
+            'array_test01' => [[1, 2], [1, 2]]
         ];
     }
 }

--- a/tests/Refinery/Logical/Constraint/LogicalOrTest.php
+++ b/tests/Refinery/Logical/Constraint/LogicalOrTest.php
@@ -1,25 +1,35 @@
-<?php
-/* Copyright (c) 1998-2018 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
-require_once 'libs/composer/vendor/autoload.php';
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
-use ILIAS\Data;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Refinery\Logical\LogicalOr;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Class LogicalOrTest
- * @author  Michael Jansen <mjansen@databay.de>
- */
 class LogicalOrTest extends TestCase
 {
     /**
      * @dataProvider constraintsProvider
      * @param LogicalOr $constraint
-     * @param           $okValue
-     * @param           $errorValue
+     * @param mixed $okValue
+     * @param mixed $errorValue
      */
-    public function testAccept(LogicalOr $constraint, $okValue, $errorValue)
+    public function testAccept(LogicalOr $constraint, $okValue, $errorValue) : void
     {
         $this->assertTrue($constraint->accepts($okValue));
         $this->assertFalse($constraint->accepts($errorValue));
@@ -28,16 +38,16 @@ class LogicalOrTest extends TestCase
     /**
      * @dataProvider constraintsProvider
      * @param LogicalOr $constraint
-     * @param           $okValue
-     * @param           $errorValue
+     * @param mixed $okValue
+     * @param mixed $errorValue
      */
-    public function testCheck(LogicalOr $constraint, $okValue, $errorValue)
+    public function testCheck(LogicalOr $constraint, $okValue, $errorValue) : void
     {
         $raised = false;
 
         try {
             $constraint->check($errorValue);
-        } catch (\UnexpectedValueException $e) {
+        } catch (UnexpectedValueException $e) {
             $raised = true;
         }
 
@@ -46,7 +56,7 @@ class LogicalOrTest extends TestCase
         try {
             $constraint->check($okValue);
             $raised = false;
-        } catch (\UnexpectedValueException $e) {
+        } catch (UnexpectedValueException $e) {
             $raised = true;
         }
 
@@ -56,10 +66,10 @@ class LogicalOrTest extends TestCase
     /**
      * @dataProvider constraintsProvider
      * @param LogicalOr $constraint
-     * @param           $okValue
-     * @param           $errorValue
+     * @param mixed $okValue
+     * @param mixed $errorValue
      */
-    public function testProblemWith(LogicalOr $constraint, $okValue, $errorValue)
+    public function testProblemWith(LogicalOr $constraint, $okValue, $errorValue) : void
     {
         $this->assertNull($constraint->problemWith($okValue));
         $this->assertIsString($constraint->problemWith($errorValue));
@@ -68,12 +78,12 @@ class LogicalOrTest extends TestCase
     /**
      * @dataProvider constraintsProvider
      * @param LogicalOr $constraint
-     * @param           $okValue
-     * @param           $errorValue
+     * @param mixed $okValue
+     * @param mixed $errorValue
      */
-    public function testRestrict(LogicalOr $constraint, $okValue, $errorValue)
+    public function testRestrict(LogicalOr $constraint, $okValue, $errorValue) : void
     {
-        $rf = new Data\Factory();
+        $rf = new DataFactory();
         $ok = $rf->ok($okValue);
         $ok2 = $rf->ok($errorValue);
         $error = $rf->error('text');
@@ -91,12 +101,12 @@ class LogicalOrTest extends TestCase
     /**
      * @dataProvider constraintsProvider
      * @param LogicalOr $constraint
-     * @param           $okValue
-     * @param           $errorValue
+     * @param mixed $okValue
+     * @param mixed $errorValue
      */
-    public function testWithProblemBuilder(LogicalOr $constraint, $okValue, $errorValue)
+    public function testWithProblemBuilder(LogicalOr $constraint, $okValue, $errorValue) : void
     {
-        $new_constraint = $constraint->withProblemBuilder(function () {
+        $new_constraint = $constraint->withProblemBuilder(static function () : string {
             return "This was a vault";
         });
         $this->assertEquals("This was a vault", $new_constraint->problemWith($errorValue));
@@ -107,13 +117,24 @@ class LogicalOrTest extends TestCase
      */
     public function constraintsProvider() : array
     {
-        $mock = $this->getMockBuilder(\ilLanguage::class)->disableOriginalConstructor()->getMock();
-        $data_factory = new Data\Factory();
+        $mock = $this->getMockBuilder(ilLanguage::class)->disableOriginalConstructor()->getMock();
+        $data_factory = new DataFactory();
 
-        $refinery = new \ILIAS\Refinery\Factory($data_factory, $mock);
+        $refinery = new Refinery($data_factory, $mock);
         return [
-            [$refinery->logical()->logicalOr([$refinery->int()->isLessThan(6), $refinery->int()->isGreaterThan(100)]), '5', 8],
-            [$refinery->logical()->logicalOr([$refinery->int()->isGreaterThan(5), $refinery->int()->isLessThan(2)]), 7, 3]
+            [
+                $refinery->logical()->logicalOr([
+                    $refinery->int()->isLessThan(6),
+                    $refinery->int()->isGreaterThan(100)
+                ]),
+                '5',
+                8
+            ],
+            [
+                $refinery->logical()->logicalOr([$refinery->int()->isGreaterThan(5), $refinery->int()->isLessThan(2)]),
+                7,
+                3
+            ]
         ];
     }
 }

--- a/tests/Refinery/Logical/Constraint/NotConstraintTest.php
+++ b/tests/Refinery/Logical/Constraint/NotConstraintTest.php
@@ -1,90 +1,85 @@
-<?php
+<?php declare(strict_types=1);
 
-/* Copyright (c) 2017, 2018, Stefan Hecken <stefan.hecken@concepts-and-training.de>, Richard Klees <richard.klees@concepts-and-training.de, Extended GPL, see docs/LICENSE */
-require_once("libs/composer/vendor/autoload.php");
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
-use ILIAS\Refinery;
-use ILIAS\Data;
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\Logical\Not;
 use PHPUnit\Framework\TestCase;
 
 class NotTest extends TestCase
 {
-    /**
-     * @var Data\Factory
-     */
-    private $df;
+    private DataFactory $df;
+    private ilLanguage $lng;
+    private Refinery $refinery;
+    private Not $not_true;
+    private Not $not_false;
 
-    /**
-     * @var \ilLanguage
-     */
-    private $lng;
-
-    /**
-     * @var \ILIAS\Refinery\Factory
-     */
-    private $refinery;
-
-    /**
-     * @var
-     */
-    private $not_true;
-
-    /**
-     * @var
-     */
-    private $not_false;
-
-    public function setUp() : void
+    protected function setUp() : void
     {
-        $this->df = new Data\Factory();
-        $this->lng = $this->createMock(\ilLanguage::class);
-        $this->refinery = new \ILIAS\Refinery\Factory($this->df, $this->lng);
+        $this->df = new DataFactory();
+        $this->lng = $this->createMock(ilLanguage::class);
+        $this->refinery = new Refinery($this->df, $this->lng);
 
         $group = $this->refinery->custom();
 
         $this->not_true = $this->refinery->logical()->not($group->constraint(
-            function ($v) {
+            static function ($v) : bool {
                 return true;
             },
             "not_true"
         ));
 
         $this->not_false = $this->refinery->logical()->not($group->constraint(
-            function ($v) {
+            static function ($v) : bool {
                 return false;
             },
             "not_false"
         ));
     }
 
-    public function testAccepts()
+    public function testAccepts() : void
     {
         $this->assertTrue($this->not_false->accepts(null));
     }
 
-    public function testNotAccepts()
+    public function testNotAccepts() : void
     {
         $this->assertFalse($this->not_true->accepts(null));
     }
 
-    public function testCheckSucceed()
+    public function testCheckSucceed() : void
     {
         $this->not_false->check(null);
         $this->assertTrue(true); // does not throw
     }
 
-    public function testCheckFails()
+    public function testCheckFails() : void
     {
-        $this->expectException(\UnexpectedValueException::class);
+        $this->expectException(UnexpectedValueException::class);
         $this->not_true->check(null);
     }
 
-    public function testNoProblemWith()
+    public function testNoProblemWith() : void
     {
         $this->assertNull($this->not_false->problemWith(null));
     }
 
-    public function testProblemWith()
+    public function testProblemWith() : void
     {
         $this->lng
             ->expects($this->once())
@@ -95,7 +90,7 @@ class NotTest extends TestCase
         $this->assertEquals("-not_true-", $this->not_true->problemWith(null));
     }
 
-    public function testRestrictOk()
+    public function testRestrictOk() : void
     {
         $ok = $this->df->ok(null);
 
@@ -103,7 +98,7 @@ class NotTest extends TestCase
         $this->assertTrue($res->isOk());
     }
 
-    public function testRestrictNotOk()
+    public function testRestrictNotOk() : void
     {
         $not_ok = $this->df->ok(null);
 
@@ -111,7 +106,7 @@ class NotTest extends TestCase
         $this->assertFalse($res->isOk());
     }
 
-    public function testRestrictError()
+    public function testRestrictError() : void
     {
         $error = $this->df->error("error");
 
@@ -119,9 +114,9 @@ class NotTest extends TestCase
         $this->assertSame($error, $res);
     }
 
-    public function testWithProblemBuilder()
+    public function testWithProblemBuilder() : void
     {
-        $new_c = $this->not_true->withProblemBuilder(function () {
+        $new_c = $this->not_true->withProblemBuilder(static function () : string {
             return "This was a fault";
         });
         $this->assertEquals("This was a fault", $new_c->problemWith(null));

--- a/tests/Refinery/Logical/Constraint/NotConstraintTest.php
+++ b/tests/Refinery/Logical/Constraint/NotConstraintTest.php
@@ -16,9 +16,9 @@
  *
  *********************************************************************/
 
+use ILIAS\Refinery\Constraint;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Data\Factory as DataFactory;
-use ILIAS\Refinery\Logical\Not;
 use PHPUnit\Framework\TestCase;
 
 class NotTest extends TestCase
@@ -26,8 +26,8 @@ class NotTest extends TestCase
     private DataFactory $df;
     private ilLanguage $lng;
     private Refinery $refinery;
-    private Not $not_true;
-    private Not $not_false;
+    private Constraint $not_true;
+    private Constraint $not_false;
 
     protected function setUp() : void
     {

--- a/tests/Refinery/Logical/Constraint/ParallelConstraintsTest.php
+++ b/tests/Refinery/Logical/Constraint/ParallelConstraintsTest.php
@@ -16,17 +16,16 @@
  *
  *********************************************************************/
 
-use ILIAS\Refinery\Custom\Constraint as CustomConstriant;
+use ILIAS\Refinery\Constraint;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Data\Factory as DataFactory;
-use  ILIAS\Refinery\Logical\Parallel;
 use PHPUnit\Framework\TestCase;
 
 class ParallelTest extends TestCase
 {
     private DataFactory $df;
     private ilLanguage $lng;
-    private Parallel $c;
+    private Constraint $c;
     private Refinery $refinery;
 
     protected function setUp() : void

--- a/tests/Refinery/Logical/Constraint/ParallelConstraintsTest.php
+++ b/tests/Refinery/Logical/Constraint/ParallelConstraintsTest.php
@@ -1,51 +1,51 @@
-<?php
-
-/* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
-require_once("libs/composer/vendor/autoload.php");
-
-use ILIAS\Refinery;
-use ILIAS\Data;
-use PHPUnit\Framework\TestCase;
+<?php declare(strict_types=1);
 
 /**
- * TestCase for the parellel constraint
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * @author Stefan Hecken <stefan.hecken@concepts-and-training.de>
- */
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\Refinery\Custom\Constraint as CustomConstriant;
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Data\Factory as DataFactory;
+use  ILIAS\Refinery\Logical\Parallel;
+use PHPUnit\Framework\TestCase;
+
 class ParallelTest extends TestCase
 {
-    /**
-     * @var Data\Factory
-     */
-    private $df;
-
-    /**
-     * @var \ilLanguage
-     */
-    private $lng;
-
-    /**
-     * @var \ILIAS\Refinery\Factory
-     */
-    private $refinery;
+    private DataFactory $df;
+    private ilLanguage $lng;
+    private Parallel $c;
+    private Refinery $refinery;
 
     protected function setUp() : void
     {
-        $this->df = new Data\Factory();
-        $this->lng = $this->createMock(\ilLanguage::class);
-        $this->refinery = new \ILIAS\Refinery\Factory($this->df, $this->lng);
+        $this->df = new DataFactory();
+        $this->lng = $this->createMock(ilLanguage::class);
+        $this->refinery = new Refinery($this->df, $this->lng);
 
         $group = $this->refinery->custom();
 
-        $this->less_than_3 = $group->constraint(
-            function ($value) {
+        $less_than_3 = $group->constraint(
+            static function ($value) : bool {
                 return $value < 3;
             },
             "not_less_than_3"
         );
 
-        $this->less_than_5 = $group->constraint(
-            function ($value) {
+        $less_than_5 = $group->constraint(
+            static function ($value) : bool {
                 return $value < 5;
             },
             "not_less_than_5"
@@ -53,37 +53,37 @@ class ParallelTest extends TestCase
 
         $this->c = $this->refinery
             ->logical()
-            ->parallel([$this->less_than_3, $this->less_than_5]);
+            ->parallel([$less_than_3, $less_than_5]);
     }
 
-    public function testAccepts()
+    public function testAccepts() : void
     {
         $this->assertTrue($this->c->accepts(2));
     }
 
-    public function testNotAccepts()
+    public function testNotAccepts() : void
     {
         $this->assertFalse($this->c->accepts(4));
     }
 
-    public function testCheckSucceed()
+    public function testCheckSucceed() : void
     {
         $this->c->check(2);
         $this->assertTrue(true); // does not throw
     }
 
-    public function testCheckFails()
+    public function testCheckFails() : void
     {
-        $this->expectException(\UnexpectedValueException::class);
+        $this->expectException(UnexpectedValueException::class);
         $this->c->check(6);
     }
 
-    public function testNoProblemWith()
+    public function testNoProblemWith() : void
     {
         $this->assertNull($this->c->problemWith(2));
     }
 
-    public function testProblemWith1()
+    public function testProblemWith1() : void
     {
         $this->lng
             ->expects($this->never())
@@ -92,7 +92,7 @@ class ParallelTest extends TestCase
         $this->assertEquals("not_less_than_3", $this->c->problemWith(4));
     }
 
-    public function testProblemWith2()
+    public function testProblemWith2() : void
     {
         $this->lng
             ->expects($this->never())
@@ -101,7 +101,7 @@ class ParallelTest extends TestCase
         $this->assertEquals("not_less_than_3 not_less_than_5", $this->c->problemWith(6));
     }
 
-    public function testRestrictOk()
+    public function testRestrictOk() : void
     {
         $ok = $this->df->ok(2);
 
@@ -109,7 +109,7 @@ class ParallelTest extends TestCase
         $this->assertTrue($res->isOk());
     }
 
-    public function testRestrictNotOk()
+    public function testRestrictNotOk() : void
     {
         $not_ok = $this->df->ok(7);
 
@@ -117,7 +117,7 @@ class ParallelTest extends TestCase
         $this->assertFalse($res->isOk());
     }
 
-    public function testRestrictError()
+    public function testRestrictError() : void
     {
         $error = $this->df->error("error");
 
@@ -125,9 +125,9 @@ class ParallelTest extends TestCase
         $this->assertSame($error, $res);
     }
 
-    public function testWithProblemBuilder()
+    public function testWithProblemBuilder() : void
     {
-        $new_c = $this->c->withProblemBuilder(function () {
+        $new_c = $this->c->withProblemBuilder(static function () : string {
             return "This was a fault";
         });
         $this->assertEquals("This was a fault", $new_c->problemWith(7));

--- a/tests/Refinery/Logical/Constraint/SequentialConstraintTest.php
+++ b/tests/Refinery/Logical/Constraint/SequentialConstraintTest.php
@@ -16,9 +16,9 @@
  *
  *********************************************************************/
 
+use ILIAS\Refinery\Constraint;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Data\Factory as DataFactory;
-use ILIAS\Refinery\Logical\Sequential;
 use PHPUnit\Framework\TestCase;
 
 class SequentialTest extends TestCase
@@ -26,7 +26,7 @@ class SequentialTest extends TestCase
     private DataFactory $df;
     private ilLanguage $lng;
     private Refinery $refinery;
-    private Sequential $c;
+    private Constraint $c;
 
     protected function setUp() : void
     {

--- a/tests/Refinery/Logical/Constraint/SequentialConstraintTest.php
+++ b/tests/Refinery/Logical/Constraint/SequentialConstraintTest.php
@@ -1,60 +1,49 @@
-<?php
-
-/* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
-require_once("libs/composer/vendor/autoload.php");
-
-use ILIAS\Refinery;
-use ILIAS\Data;
-use PHPUnit\Framework\TestCase;
+<?php declare(strict_types=1);
 
 /**
- * TestCase for the sequential constraint
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * @author Stefan Hecken <stefan.hecken@concepts-and-training.de>
- */
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\Logical\Sequential;
+use PHPUnit\Framework\TestCase;
+
 class SequentialTest extends TestCase
 {
-    /**
-     * @var Data\Factory
-     */
-    private $df;
-
-    /**
-     * @var \ilLanguage
-     */
-    private $lng;
-
-    /**
-     * @var \ILIAS\Refinery\Factory
-     */
-    private $refinery;
-
-    /**
-     * @var Refinery\Constraint
-     */
-    private $greater_than_3;
-
-    /**
-     * @var Refinery\Constraint
-     */
-    private $less_than_5;
+    private DataFactory $df;
+    private ilLanguage $lng;
+    private Refinery $refinery;
+    private Sequential $c;
 
     protected function setUp() : void
     {
-        $this->df = new Data\Factory();
-        $this->lng = $this->createMock(\ilLanguage::class);
-        $this->refinery = new \ILIAS\Refinery\Factory($this->df, $this->lng);
+        $this->df = new DataFactory();
+        $this->lng = $this->createMock(ilLanguage::class);
+        $this->refinery = new Refinery($this->df, $this->lng);
 
         $group = $this->refinery->custom();
 
-        $this->greater_than_3 = $group->constraint(
+        $greater_than_3 = $group->constraint(
             function ($value) {
                 return $value > 3;
             },
             "not_greater_than_3"
         );
 
-        $this->less_than_5 = $group->constraint(
+        $less_than_5 = $group->constraint(
             function ($value) {
                 return $value < 5;
             },
@@ -63,37 +52,37 @@ class SequentialTest extends TestCase
 
         $this->c = $this->refinery
             ->logical()
-            ->sequential([$this->greater_than_3, $this->less_than_5]);
+            ->sequential([$greater_than_3, $less_than_5]);
     }
 
-    public function testAccepts()
+    public function testAccepts() : void
     {
         $this->assertTrue($this->c->accepts(4));
     }
 
-    public function testNotAccepts()
+    public function testNotAccepts() : void
     {
         $this->assertFalse($this->c->accepts(2));
     }
 
-    public function testCheckSucceed()
+    public function testCheckSucceed() : void
     {
         $this->c->check(4);
         $this->assertTrue(true); // does not throw
     }
 
-    public function testCheckFails()
+    public function testCheckFails() : void
     {
-        $this->expectException(\UnexpectedValueException::class);
+        $this->expectException(UnexpectedValueException::class);
         $this->c->check(2);
     }
 
-    public function testNoProblemWith()
+    public function testNoProblemWith() : void
     {
         $this->assertNull($this->c->problemWith(4));
     }
 
-    public function testProblemWith1()
+    public function testProblemWith1() : void
     {
         $this->lng
             ->expects($this->never())
@@ -102,7 +91,7 @@ class SequentialTest extends TestCase
         $this->assertEquals("not_greater_than_3", $this->c->problemWith(2));
     }
 
-    public function testProblemWith2()
+    public function testProblemWith2() : void
     {
         $this->lng
             ->expects($this->never())
@@ -111,7 +100,7 @@ class SequentialTest extends TestCase
         $this->assertEquals("not_less_than_5", $this->c->problemWith(6));
     }
 
-    public function testRestrictOk()
+    public function testRestrictOk() : void
     {
         $ok = $this->df->ok(4);
 
@@ -119,7 +108,7 @@ class SequentialTest extends TestCase
         $this->assertTrue($res->isOk());
     }
 
-    public function testRestrictNotOk()
+    public function testRestrictNotOk() : void
     {
         $not_ok = $this->df->ok(7);
 
@@ -127,7 +116,7 @@ class SequentialTest extends TestCase
         $this->assertFalse($res->isOk());
     }
 
-    public function testRestrictError()
+    public function testRestrictError() : void
     {
         $error = $this->df->error("error");
 
@@ -135,9 +124,9 @@ class SequentialTest extends TestCase
         $this->assertSame($error, $res);
     }
 
-    public function testWithProblemBuilder()
+    public function testWithProblemBuilder() : void
     {
-        $new_c = $this->c->withProblemBuilder(function () {
+        $new_c = $this->c->withProblemBuilder(static function () : string {
             return "This was a fault";
         });
         $this->assertEquals("This was a fault", $new_c->problemWith(7));

--- a/tests/Refinery/Logical/GroupTest.php
+++ b/tests/Refinery/Logical/GroupTest.php
@@ -1,81 +1,76 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\Logical;
 
-use ILIAS\Data\Factory;
+use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Refinery\Integer\GreaterThan;
 use ILIAS\Refinery\Integer\LessThan;
 use ILIAS\Refinery\Logical\LogicalOr;
 use ILIAS\Refinery\Logical\Not;
 use ILIAS\Refinery\Logical\Parallel;
 use ILIAS\Refinery\Logical\Sequential;
-use ILIAS\Refinery\Logical\Group;
+use ILIAS\Refinery\Logical\Group as LogicalGroup;
 use ILIAS\Tests\Refinery\TestCase;
-
-require_once('./libs/composer/vendor/autoload.php');
+use ilLanguage;
 
 class GroupTest extends TestCase
 {
-    /**
-     * @var Group
-     */
-    private $group;
+    private LogicalGroup $group;
+    private DataFactory $dataFactory;
+    private ilLanguage $language;
+    private GreaterThan $greaterThanConstraint;
+    private LessThan $lessThanConstaint;
 
-    /**
-     * @var Factory
-     */
-    private $dataFactory;
-
-    /**
-     * @var \ilLanguage
-     */
-    private $language;
-
-    /**
-     * @var GreaterThan
-     */
-    private $greaterThanConstraint;
-
-    /**
-     * @var LessThan
-     */
-    private $lessThanConstaint;
-
-    public function setUp() : void
+    protected function setUp() : void
     {
-        $this->dataFactory = new Factory();
-        $this->language = $this->getMockBuilder('\ilLanguage')
+        $this->dataFactory = new DataFactory();
+        $this->language = $this->getMockBuilder(ilLanguage::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->group = new Group($this->dataFactory, $this->language);
+        $this->group = new LogicalGroup($this->dataFactory, $this->language);
 
         $this->greaterThanConstraint = new GreaterThan(2, $this->dataFactory, $this->language);
         $this->lessThanConstaint = new LessThan(5, $this->dataFactory, $this->language);
     }
 
-    public function testLogicalOrGroup()
+    public function testLogicalOrGroup() : void
     {
-        $instance = $this->group->logicalOr(array($this->greaterThanConstraint, $this->lessThanConstaint));
+        $instance = $this->group->logicalOr([$this->greaterThanConstraint, $this->lessThanConstaint]);
         $this->assertInstanceOf(LogicalOr::class, $instance);
     }
 
-    public function testNotGroup()
+    public function testNotGroup() : void
     {
         $instance = $this->group->not($this->greaterThanConstraint);
         $this->assertInstanceOf(Not::class, $instance);
     }
 
-    public function testParallelGroup()
+    public function testParallelGroup() : void
     {
-        $instance = $this->group->parallel(array($this->greaterThanConstraint, $this->lessThanConstaint));
+        $instance = $this->group->parallel([$this->greaterThanConstraint, $this->lessThanConstaint]);
         $this->assertInstanceOf(Parallel::class, $instance);
     }
 
-    public function testSequentialGroup()
+    public function testSequentialGroup() : void
     {
-        $instance = $this->group->sequential(array($this->greaterThanConstraint, $this->lessThanConstaint));
+        $instance = $this->group->sequential([$this->greaterThanConstraint, $this->lessThanConstaint]);
         $this->assertInstanceOf(Sequential::class, $instance);
     }
 }

--- a/tests/Refinery/Logical/GroupTest.php
+++ b/tests/Refinery/Logical/GroupTest.php
@@ -19,6 +19,7 @@
 namespace ILIAS\Tests\Refinery\Logical;
 
 use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\Constraint;
 use ILIAS\Refinery\Integer\GreaterThan;
 use ILIAS\Refinery\Integer\LessThan;
 use ILIAS\Refinery\Logical\LogicalOr;
@@ -34,8 +35,8 @@ class GroupTest extends TestCase
     private LogicalGroup $group;
     private DataFactory $dataFactory;
     private ilLanguage $language;
-    private GreaterThan $greaterThanConstraint;
-    private LessThan $lessThanConstaint;
+    private Constraint $greaterThanConstraint;
+    private Constraint $lessThanConstaint;
 
     protected function setUp() : void
     {

--- a/tests/Refinery/Null/Constraint/IsNullConstraintTest.php
+++ b/tests/Refinery/Null/Constraint/IsNullConstraintTest.php
@@ -1,51 +1,70 @@
-<?php
+<?php declare(strict_types=1);
 
-/* Copyright (c) 2018 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
-require_once("libs/composer/vendor/autoload.php");
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
-use ILIAS\Refinery\Factory;
-use ILIAS\Data;
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\IsNull;
 use PHPUnit\Framework\TestCase;
 
 class IsNullConstraintTest extends TestCase
 {
+    private DataFactory $df;
+    private ilLanguage $lng;
+    private Refinery $f;
+    private IsNull $c;
+
     public function setUp() : void
     {
-        $this->df = new Data\Factory();
-        $this->lng = $this->createMock(\ilLanguage::class);
-        $this->f = new Factory($this->df, $this->lng);
+        $this->df = new DataFactory();
+        $this->lng = $this->createMock(ilLanguage::class);
+        $this->f = new Refinery($this->df, $this->lng);
 
         $this->c = $this->f->null();
     }
 
-    public function testAccepts()
+    public function testAccepts() : void
     {
         $this->assertTrue($this->c->accepts(null));
     }
 
-    public function testNotAccepts()
+    public function testNotAccepts() : void
     {
         $this->assertFalse($this->c->accepts(2));
     }
 
-    public function testCheckSucceed()
+    public function testCheckSucceed() : void
     {
         $this->c->check(null);
         $this->assertTrue(true); // does not throw
     }
 
-    public function testCheckFails()
+    public function testCheckFails() : void
     {
-        $this->expectException(\UnexpectedValueException::class);
+        $this->expectException(UnexpectedValueException::class);
         $this->c->check(2);
     }
 
-    public function testNoProblemWith()
+    public function testNoProblemWith() : void
     {
         $this->assertNull($this->c->problemWith(null));
     }
 
-    public function testProblemWith()
+    public function testProblemWith() : void
     {
         $this->lng
             ->expects($this->once())
@@ -56,7 +75,7 @@ class IsNullConstraintTest extends TestCase
         $this->assertEquals("-integer-", $this->c->problemWith(2));
     }
 
-    public function testRestrictOk()
+    public function testRestrictOk() : void
     {
         $ok = $this->df->ok(null);
 
@@ -64,7 +83,7 @@ class IsNullConstraintTest extends TestCase
         $this->assertTrue($res->isOk());
     }
 
-    public function testRestrictNotOk()
+    public function testRestrictNotOk() : void
     {
         $not_ok = $this->df->ok(2);
 
@@ -72,7 +91,7 @@ class IsNullConstraintTest extends TestCase
         $this->assertFalse($res->isOk());
     }
 
-    public function testRestrictError()
+    public function testRestrictError() : void
     {
         $error = $this->df->error("error");
 
@@ -80,9 +99,9 @@ class IsNullConstraintTest extends TestCase
         $this->assertSame($error, $res);
     }
 
-    public function testWithProblemBuilder()
+    public function testWithProblemBuilder() : void
     {
-        $new_c = $this->c->withProblemBuilder(function () {
+        $new_c = $this->c->withProblemBuilder(static function () : string {
             return "This was a fault";
         });
         $this->assertEquals("This was a fault", $new_c->problemWith(2));

--- a/tests/Refinery/Null/Constraint/IsNullConstraintTest.php
+++ b/tests/Refinery/Null/Constraint/IsNullConstraintTest.php
@@ -18,7 +18,6 @@
 
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Data\Factory as DataFactory;
-use ILIAS\Refinery\IsNull;
 use PHPUnit\Framework\TestCase;
 
 class IsNullConstraintTest extends TestCase
@@ -26,9 +25,9 @@ class IsNullConstraintTest extends TestCase
     private DataFactory $df;
     private ilLanguage $lng;
     private Refinery $f;
-    private IsNull $c;
+    private \ILIAS\Refinery\Constraint $c;
 
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->df = new DataFactory();
         $this->lng = $this->createMock(ilLanguage::class);

--- a/tests/Refinery/Numeric/GroupTest.php
+++ b/tests/Refinery/Numeric/GroupTest.php
@@ -1,45 +1,46 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\Numeric;
 
-use ILIAS\Data\Factory;
-use ILIAS\Refinery\Integer\GreaterThan;
-use ILIAS\Refinery\Integer\LessThan;
+use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Refinery\Numeric\IsNumeric;
-use ILIAS\Refinery\Numeric\Group;
+use ILIAS\Refinery\Numeric\Group as NumericGroup;
 use ILIAS\Tests\Refinery\TestCase;
-
-require_once('./libs/composer/vendor/autoload.php');
+use ilLanguage;
 
 class GroupTest extends TestCase
 {
-    /**
-     * @var Group
-     */
-    private $group;
+    private NumericGroup $group;
+    private DataFactory $dataFactory;
+    private ilLanguage $language;
 
-    /**
-     * @var Factory
-     */
-    private $dataFactory;
-
-    /**
-     * @var \ilLanguage
-     */
-    private $language;
-
-    public function setUp() : void
+    protected function setUp() : void
     {
-        $this->dataFactory = new Factory();
-        $this->language = $this->getMockBuilder('\ilLanguage')
+        $this->dataFactory = new DataFactory();
+        $this->language = $this->getMockBuilder(ilLanguage::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->group = new Group($this->dataFactory, $this->language);
+        $this->group = new NumericGroup($this->dataFactory, $this->language);
     }
 
-    public function testIsNumericGroup()
+    public function testIsNumericGroup() : void
     {
         $instance = $this->group->isNumeric();
         $this->assertInstanceOf(IsNumeric::class, $instance);

--- a/tests/Refinery/Numeric/Validation/IsNumericConstraintTest.php
+++ b/tests/Refinery/Numeric/Validation/IsNumericConstraintTest.php
@@ -1,98 +1,117 @@
-<?php
+<?php declare(strict_types=1);
 
-/* Copyright (c) 2018 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
-require_once("libs/composer/vendor/autoload.php");
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
-use ILIAS\Refinery\Factory;
-use ILIAS\Data;
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\Numeric\IsNumeric;
 use PHPUnit\Framework\TestCase;
 
 class IsNumericConstraintTest extends TestCase
 {
-    public function setUp() : void
-    {
-        $this->df = new Data\Factory();
-        $this->lng = $this->createMock(\ilLanguage::class);
+    private DataFactory $df;
+    private ilLanguage $lng;
+    private Refinery $f;
+    private IsNumeric $c;
 
-        $this->f = new Factory($this->df, $this->lng);
+    protected function setUp() : void
+    {
+        $this->df = new DataFactory();
+        $this->lng = $this->createMock(ilLanguage::class);
+
+        $this->f = new Refinery($this->df, $this->lng);
 
         $this->c = $this->f->numeric()->isNumeric();
     }
 
-    public function testAccepts1()
+    public function testAccepts1() : void
     {
         $this->assertTrue($this->c->accepts(0));
     }
 
-    public function testAccepts2()
+    public function testAccepts2() : void
     {
         $this->assertTrue($this->c->accepts("1"));
     }
 
-    public function testAccepts3()
+    public function testAccepts3() : void
     {
         $this->assertTrue($this->c->accepts(1));
     }
 
-    public function testAccepts4()
+    public function testAccepts4() : void
     {
         $this->assertTrue($this->c->accepts(0x102));
     }
 
-    public function testAccepts5()
+    public function testAccepts5() : void
     {
         $this->assertTrue($this->c->accepts(0102));
     }
 
-    public function testAccepts6()
+    public function testAccepts6() : void
     {
         $this->assertTrue($this->c->accepts(0b101));
     }
 
-    public function testAccepts7()
+    public function testAccepts7() : void
     {
         $this->assertTrue($this->c->accepts(192e0));
     }
 
-    public function testAccepts8()
+    public function testAccepts8() : void
     {
         $this->assertTrue($this->c->accepts(9.1));
     }
 
-    public function testNotAccepts1()
+    public function testNotAccepts1() : void
     {
         $this->assertFalse($this->c->accepts(null));
     }
 
-    public function testNotAccepts2()
+    public function testNotAccepts2() : void
     {
         $this->assertFalse($this->c->accepts("foo"));
     }
 
-    public function testCheckSucceed()
+    public function testCheckSucceed() : void
     {
         $this->c->check(2);
         $this->assertTrue(true); // does not throw
     }
 
-    public function testCheckFails()
+    public function testCheckFails() : void
     {
         $this->lng
             ->method('txt')
-            ->will($this->returnCallback(function ($value) {
+            ->willReturnCallback(static function (string $value) : string {
                 return $value;
-            }))
+            })
         ;
         $this->expectException(\UnexpectedValueException::class);
         $this->c->check("");
     }
 
-    public function testNoProblemWith()
+    public function testNoProblemWith() : void
     {
         $this->assertNull($this->c->problemWith(2));
     }
 
-    public function testProblemWith()
+    public function testProblemWith() : void
     {
         $this->lng
             ->expects($this->once())
@@ -103,7 +122,7 @@ class IsNumericConstraintTest extends TestCase
         $this->assertEquals("-aa-", $this->c->problemWith("aa"));
     }
 
-    public function testRestrictOk()
+    public function testRestrictOk() : void
     {
         $ok = $this->df->ok(2);
 
@@ -111,7 +130,7 @@ class IsNumericConstraintTest extends TestCase
         $this->assertTrue($res->isOk());
     }
 
-    public function testRestrictNotOk()
+    public function testRestrictNotOk() : void
     {
         $not_ok = $this->df->ok("");
 
@@ -125,7 +144,7 @@ class IsNumericConstraintTest extends TestCase
         $this->assertFalse($res->isOk());
     }
 
-    public function testRestrictError()
+    public function testRestrictError() : void
     {
         $error = $this->df->error("error");
 
@@ -133,9 +152,9 @@ class IsNumericConstraintTest extends TestCase
         $this->assertSame($error, $res);
     }
 
-    public function testWithProblemBuilder()
+    public function testWithProblemBuilder() : void
     {
-        $new_c = $this->c->withProblemBuilder(function () {
+        $new_c = $this->c->withProblemBuilder(static function () : string {
             return "This was a fault";
         });
         $this->assertEquals("This was a fault", $new_c->problemWith(""));

--- a/tests/Refinery/Numeric/Validation/IsNumericConstraintTest.php
+++ b/tests/Refinery/Numeric/Validation/IsNumericConstraintTest.php
@@ -18,7 +18,6 @@
 
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Data\Factory as DataFactory;
-use ILIAS\Refinery\Numeric\IsNumeric;
 use PHPUnit\Framework\TestCase;
 
 class IsNumericConstraintTest extends TestCase
@@ -26,7 +25,7 @@ class IsNumericConstraintTest extends TestCase
     private DataFactory $df;
     private ilLanguage $lng;
     private Refinery $f;
-    private IsNumeric $c;
+    private \ILIAS\Refinery\Constraint $c;
 
     protected function setUp() : void
     {

--- a/tests/Refinery/Password/Constraint/PasswordContraintsTest.php
+++ b/tests/Refinery/Password/Constraint/PasswordContraintsTest.php
@@ -16,15 +16,11 @@
  *
  *********************************************************************/
 
-require_once("libs/composer/vendor/autoload.php");
-
-use ILIAS\Refinery;
-use ILIAS\Data;
+use ILIAS\Refinery\Constraint;
 use PHPUnit\Framework\TestCase;
 
 class PasswordContraintsTest extends TestCase
 {
-
     /**
      * Test a set of values
      *
@@ -37,41 +33,44 @@ class PasswordContraintsTest extends TestCase
         $refinery = new \ILIAS\Refinery\Factory($d, $lng);
         $v = $refinery->password();
 
-        return array(
-            array(
+        return [
+            [
                 $v->hasMinLength(3),
                 [$d->password('abc'), $d->password('abcd')],
                 [$d->password('a'), $d->password('ab')]
-            ),
-            array(
+            ],
+            [
                 $v->hasLowerChars(),
                 [$d->password('abc'), $d->password('AbC')],
                 [$d->password('AB'), $d->password('21'), $d->password('#*+')]
-            ),
+            ],
 
-            array(
+            [
                 $v->hasUpperChars(),
                 [$d->password('Abc'), $d->password('ABC')],
                 [$d->password('abc'), $d->password('21'), $d->password('#*+')]
-            ),
-            array(
+            ],
+            [
                 $v->hasNumbers(),
                 [$d->password('Ab1'), $d->password('123')],
                 [$d->password('abc'), $d->password('ABC'), $d->password('#*+')]
-            ),
+            ],
 
-            array(
+            [
                 $v->hasSpecialChars(),
                 [$d->password('Ab+'), $d->password('123#')],
                 [$d->password('abc'), $d->password('ABC'), $d->password('123')]
-            )
-        );
+            ]
+        ];
     }
 
     /**
      * @dataProvider constraintsProvider
+     * @param Constraint $constraint
+     * @param ILIAS\Data\Password[] $ok_values
+     * @param ILIAS\Data\Password[] $error_values
      */
-    public function testAccept($constraint, $ok_values, $error_values) : void
+    public function testAccept(Constraint $constraint, array $ok_values, array $error_values) : void
     {
         foreach ($ok_values as $ok_value) {
             $this->assertTrue($constraint->accepts($ok_value));

--- a/tests/Refinery/Password/Constraint/PasswordContraintsTest.php
+++ b/tests/Refinery/Password/Constraint/PasswordContraintsTest.php
@@ -1,6 +1,20 @@
-<?php
+<?php declare(strict_types=1);
 
-/* Copyright (c) 2018 Nils Haagen <nils.haagen@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 require_once("libs/composer/vendor/autoload.php");
 
@@ -8,11 +22,6 @@ use ILIAS\Refinery;
 use ILIAS\Data;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Test standard-constraints of a password.
- *
- * @author Nils Haagen <nils.haagen@concepts-and-training.de>
- */
 class PasswordContraintsTest extends TestCase
 {
 
@@ -21,7 +30,7 @@ class PasswordContraintsTest extends TestCase
      *
      * @return array[[$constraint,$ok_values,$error_values]]
      */
-    public function constraintsProvider()
+    public function constraintsProvider() : array
     {
         $lng = $this->createMock(\ilLanguage::class);
         $d = new \ILIAS\Data\Factory();
@@ -62,7 +71,7 @@ class PasswordContraintsTest extends TestCase
     /**
      * @dataProvider constraintsProvider
      */
-    public function testAccept($constraint, $ok_values, $error_values)
+    public function testAccept($constraint, $ok_values, $error_values) : void
     {
         foreach ($ok_values as $ok_value) {
             $this->assertTrue($constraint->accepts($ok_value));

--- a/tests/Refinery/Password/GroupTest.php
+++ b/tests/Refinery/Password/GroupTest.php
@@ -1,71 +1,74 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\Password;
 
-use ILIAS\Data\Factory;
+use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Refinery\Password\HasLowerChars;
 use ILIAS\Refinery\Password\HasMinLength;
 use ILIAS\Refinery\Password\HasNumbers;
 use ILIAS\Refinery\Password\HasSpecialChars;
 use ILIAS\Refinery\Password\HasUpperChars;
-use ILIAS\Refinery\Password\Group;
+use ILIAS\Refinery\Password\Group as PasswordGroup;
 use ILIAS\Tests\Refinery\TestCase;
-
-require_once('./libs/composer/vendor/autoload.php');
+use ilLanguage;
 
 class GroupTest extends TestCase
 {
-    /**
-     * @var Group
-     */
-    private $group;
+    private PasswordGroup $group;
+    private DataFactory $dataFactory;
+    private ilLanguage $language;
 
-    /**
-     * @var Factory
-     */
-    private $dataFactory;
-
-    /**
-     * @var \ilLanguage
-     */
-    private $language;
-
-    public function setUp() : void
+    protected function setUp() : void
     {
-        $this->dataFactory = new Factory();
-        $this->language = $this->getMockBuilder('\ilLanguage')
+        $this->dataFactory = new DataFactory();
+        $this->language = $this->getMockBuilder(ilLanguage::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->group = new Group($this->dataFactory, $this->language);
+        $this->group = new PasswordGroup($this->dataFactory, $this->language);
     }
-
-    public function testHasMinLength()
+    
+    public function testHasMinLength() : void
     {
         $instance = $this->group->hasMinLength(4);
         $this->assertInstanceOf(HasMinLength::class, $instance);
     }
 
-    public function testHasLowerChars()
+    public function testHasLowerChars() : void
     {
         $instance = $this->group->hasLowerChars();
         $this->assertInstanceOf(HasLowerChars::class, $instance);
     }
 
-    public function testHasNumbers()
+    public function testHasNumbers() : void
     {
         $instance = $this->group->hasNumbers();
         $this->assertInstanceOf(HasNumbers::class, $instance);
     }
 
-    public function testHasSpecialChars()
+    public function testHasSpecialChars() : void
     {
         $instance = $this->group->hasSpecialChars();
         $this->assertInstanceOf(HasSpecialChars::class, $instance);
     }
 
-    public function testHasUpperChars()
+    public function testHasUpperChars() : void
     {
         $instance = $this->group->hasUpperChars();
         $this->assertInstanceOf(HasUpperChars::class, $instance);

--- a/tests/Refinery/Random/GroupTest.php
+++ b/tests/Refinery/Random/GroupTest.php
@@ -1,12 +1,24 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
- * @author  Lukas Scharmer <lscharmer@databay.de>
- */
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 namespace ILIAS\Tests\Refinery\Random;
 
-use ILIAS\Refinery\Random\Group;
-use ILIAS\Refinery\Transformation;
+use ILIAS\Refinery\Random\Group as RandomGroup;
 use PHPUnit\Framework\TestCase;
 use ILIAS\Refinery\Random\Seed\Seed;
 use ILIAS\Refinery\Random\Transformation\ShuffleTransformation;
@@ -14,14 +26,11 @@ use ILIAS\Refinery\IdentityTransformation;
 
 class GroupTest extends TestCase
 {
-    /**
-     * @var Group
-     */
-    private $group;
+    private RandomGroup $group;
 
-    public function setUp() : void
+    protected function setUp() : void
     {
-        $this->group = new Group();
+        $this->group = new RandomGroup();
     }
 
     public function testShuffle() : void

--- a/tests/Refinery/Random/Transformation/ShuffleTransformationTest.php
+++ b/tests/Refinery/Random/Transformation/ShuffleTransformationTest.php
@@ -1,8 +1,21 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
- * @author  Lukas Scharmer <lscharmer@databay.de>
- */
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 namespace ILIAS\Tests\Refinery\Random\Transformation;
 
 use ILIAS\Refinery\Random\Transformation\ShuffleTransformation;
@@ -22,7 +35,7 @@ class ShuffleTransformationTest extends TestCase
         $expected = $this->shuffleWithSeed($value, $seed);
         $seedMock = $this->getMockBuilder(Seed::class)->getMock();
         $seedMock->expects(self::once())->method('seedRandomGenerator')->willReturnCallback(static function () use ($seed) : void {
-            \mt_srand($seed);
+            mt_srand($seed);
         });
 
         $result = (new ShuffleTransformation($seedMock))->transform($value);
@@ -40,8 +53,8 @@ class ShuffleTransformationTest extends TestCase
 
     private function shuffleWithSeed(array $array, int $seed) : array
     {
-        \mt_srand($seed);
-        \shuffle($array);
+        mt_srand($seed);
+        shuffle($array);
 
         return $array;
     }

--- a/tests/Refinery/String/Constraints/HasMaxLengthConstraintTest.php
+++ b/tests/Refinery/String/Constraints/HasMaxLengthConstraintTest.php
@@ -1,81 +1,80 @@
-<?php
+<?php declare(strict_types=1);
 
-/* Copyright (c) 2018 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
-require_once("libs/composer/vendor/autoload.php");
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
-use ILIAS\Refinery;
-use ILIAS\Data;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\String\HasMaxLength;
+use ILIAS\Refinery\Constraint;
 use PHPUnit\Framework\TestCase;
 
 class HasMaxLengthConstraintTest extends TestCase
 {
-    /**
-     * @var Data\Factory
-     */
-    private $df;
+    private DataFactory $df;
+    private ilLanguage $lng;
+    private int $max_length;
+    private Constraint $c;
 
-    /**
-     * @var \ilLanguage
-     */
-    private $lng;
-
-    /**
-     * @var integer
-     */
-    private $max_length;
-
-    /**
-     * @var Refinery\Constraint
-     */
-    private $c;
-
-    public function setUp() : void
+    protected function setUp() : void
     {
-        $this->df = new Data\Factory();
-        $this->lng = $this->createMock(\ilLanguage::class);
+        $this->df = new DataFactory();
+        $this->lng = $this->createMock(ilLanguage::class);
 
         $this->max_length = 2;
 
-        $this->c = new \ILIAS\Refinery\String\HasMaxLength(
+        $this->c = new HasMaxLength(
             $this->max_length,
             $this->df,
             $this->lng
         );
     }
 
-    public function testAccepts1()
+    public function testAccepts1() : void
     {
         $this->assertTrue($this->c->accepts("12"));
     }
 
-    public function testAccepts2()
+    public function testAccepts2() : void
     {
         $this->assertTrue($this->c->accepts("1"));
     }
 
-    public function testNotAccepts()
+    public function testNotAccepts() : void
     {
         $this->assertFalse($this->c->accepts("123"));
     }
 
-    public function testCheckSucceed()
+    public function testCheckSucceed() : void
     {
         $this->c->check("12");
         $this->assertTrue(true); // does not throw
     }
 
-    public function testCheckFails()
+    public function testCheckFails() : void
     {
         $this->expectException(\UnexpectedValueException::class);
         $this->c->check("123");
     }
 
-    public function testNoProblemWith()
+    public function testNoProblemWith() : void
     {
         $this->assertNull($this->c->problemWith("12"));
     }
 
-    public function testProblemWith()
+    public function testProblemWith() : void
     {
         $this->lng
             ->expects($this->once())
@@ -86,7 +85,7 @@ class HasMaxLengthConstraintTest extends TestCase
         $this->assertEquals("-2-", $this->c->problemWith("123"));
     }
 
-    public function testRestrictOk()
+    public function testRestrictOk() : void
     {
         $ok = $this->df->ok("12");
 
@@ -94,7 +93,7 @@ class HasMaxLengthConstraintTest extends TestCase
         $this->assertTrue($res->isOk());
     }
 
-    public function testRestrictNotOk()
+    public function testRestrictNotOk() : void
     {
         $not_ok = $this->df->ok("123");
 
@@ -102,7 +101,7 @@ class HasMaxLengthConstraintTest extends TestCase
         $this->assertFalse($res->isOk());
     }
 
-    public function testRestrictError()
+    public function testRestrictError() : void
     {
         $error = $this->df->error("error");
 
@@ -110,9 +109,9 @@ class HasMaxLengthConstraintTest extends TestCase
         $this->assertSame($error, $res);
     }
 
-    public function testWithProblemBuilder()
+    public function testWithProblemBuilder() : void
     {
-        $new_c = $this->c->withProblemBuilder(function () {
+        $new_c = $this->c->withProblemBuilder(static function () : string {
             return "This was a fault";
         });
         $this->assertEquals("This was a fault", $new_c->problemWith("123"));

--- a/tests/Refinery/String/Constraints/HasMinLengthConstraintTest.php
+++ b/tests/Refinery/String/Constraints/HasMinLengthConstraintTest.php
@@ -1,39 +1,37 @@
-<?php
+<?php declare(strict_types=1);
 
-/* Copyright (c) 2018 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
-require_once("libs/composer/vendor/autoload.php");
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
+use ILIAS\Refinery\Constraint;
 use ILIAS\Refinery\String\HasMinLength;
-use ILIAS\Refinery;
-use ILIAS\Data;
+use ILIAS\Data\Factory as DataFactory;
 use PHPUnit\Framework\TestCase;
 
 class HasMinLengthConstraintTest extends TestCase
 {
-    /**
-     * @var Data\Factory
-     */
-    private $df;
+    private DataFactory $df;
+    private ilLanguage $lng;
+    private int $min_length;
+    private Constraint $c;
 
-    /**
-     * @var \ilLanguage
-     */
-    private $lng;
-
-    /**
-     * @var integer
-     */
-    private $min_length;
-
-    /**
-     * @var Refinery\Constraint
-     */
-    private $c;
-
-    public function setUp() : void
+    protected function setUp() : void
     {
-        $this->df = new Data\Factory();
-        $this->lng = $this->createMock(\ilLanguage::class);
+        $this->df = new DataFactory();
+        $this->lng = $this->createMock(ilLanguage::class);
 
         $this->min_length = 10;
 
@@ -44,39 +42,39 @@ class HasMinLengthConstraintTest extends TestCase
         );
     }
 
-    public function testAccepts1()
+    public function testAccepts1() : void
     {
         $this->assertTrue($this->c->accepts("1234567890"));
     }
 
-    public function testAccepts2()
+    public function testAccepts2() : void
     {
         $this->assertTrue($this->c->accepts("12345678901"));
     }
 
-    public function testNotAccepts()
+    public function testNotAccepts() : void
     {
         $this->assertFalse($this->c->accepts("123456789"));
     }
 
-    public function testCheckSucceed()
+    public function testCheckSucceed() : void
     {
         $this->c->check("1234567890");
         $this->assertTrue(true); // does not throw
     }
 
-    public function testCheckFails()
+    public function testCheckFails() : void
     {
-        $this->expectException(\UnexpectedValueException::class);
+        $this->expectException(UnexpectedValueException::class);
         $this->c->check("");
     }
 
-    public function testNoProblemWith()
+    public function testNoProblemWith() : void
     {
         $this->assertNull($this->c->problemWith("1234567890"));
     }
 
-    public function testProblemWith()
+    public function testProblemWith() : void
     {
         $this->lng
             ->expects($this->once())
@@ -87,7 +85,7 @@ class HasMinLengthConstraintTest extends TestCase
         $this->assertEquals("-3-10-", $this->c->problemWith("123"));
     }
 
-    public function testRestrictOk()
+    public function testRestrictOk() : void
     {
         $ok = $this->df->ok("1234567890");
 
@@ -95,7 +93,7 @@ class HasMinLengthConstraintTest extends TestCase
         $this->assertTrue($res->isOk());
     }
 
-    public function testRestrictNotOk()
+    public function testRestrictNotOk() : void
     {
         $not_ok = $this->df->ok("1234");
 
@@ -103,7 +101,7 @@ class HasMinLengthConstraintTest extends TestCase
         $this->assertFalse($res->isOk());
     }
 
-    public function testRestrictError()
+    public function testRestrictError() : void
     {
         $error = $this->df->error("error");
 
@@ -111,9 +109,9 @@ class HasMinLengthConstraintTest extends TestCase
         $this->assertSame($error, $res);
     }
 
-    public function testWithProblemBuilder()
+    public function testWithProblemBuilder() : void
     {
-        $new_c = $this->c->withProblemBuilder(function () {
+        $new_c = $this->c->withProblemBuilder(static function () : string {
             return "This was a fault";
         });
         $this->assertEquals("This was a fault", $new_c->problemWith(""));

--- a/tests/Refinery/String/EstimatedReadingTimeTest.php
+++ b/tests/Refinery/String/EstimatedReadingTimeTest.php
@@ -1,37 +1,53 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 namespace ILIAS\Tests\Refinery\String;
 
-use ILIAS\Refinery\Factory;
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Data\Factory as DataFactory;
+use ilLanguage;
 use PHPUnit\Framework\TestCase;
+use stdClass;
+use InvalidArgumentException;
 
 class EstimatedReadingTimeTest extends TestCase
 {
-    const TEXT = <<<EOT
+    private const TEXT = <<<EOT
 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
 EOT;
-    const HTML = <<<EOT
+    private const HTML = <<<EOT
 <div>Lorem ipsum dolor <span style="color: red;">sit amet</span>, <img src="#" /> consetetur sadipscing elitr, sed diam nonumy eirmod <img src="#" />  tempor invidunt <img src="#" />  ut labore et dolore <img src="#" />  magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor <img src="#" />  sit amet. <img src="#" />  Lorem ipsum dolor <img src="#" />  sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, <img src="#" />  sed diam voluptua. <img src="#" />  At vero eos et accusam et justo duo dolores et ea rebum. Stet <img src="#" />  clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</div>
 EOT;
 
-    /** @var Factory */
-    private $refinery;
+    private Refinery $refinery;
     
-    /**
-     * @throws \ReflectionException
-     */
     protected function setUp() : void
     {
-        $this->refinery = new Factory(
-            $this->createMock(\ILIAS\Data\Factory::class),
-            $this->createMock(\ilLanguage::class)
+        $this->refinery = new Refinery(
+            $this->createMock(DataFactory::class),
+            $this->createMock(ilLanguage::class)
         );
-        
+
         parent::setUp();
     }
 
     /**
-     * @return array
+     * @return array[]
      */
     public function subjectProvider() : array
     {
@@ -39,10 +55,10 @@ EOT;
             [5],
             [6.3],
             [[]],
-            [new \stdClass()],
+            [new stdClass()],
             [true],
             [null],
-            [function () {
+            [static function () : void {
             }],
         ];
     }
@@ -55,7 +71,7 @@ EOT;
     {
         $readingTimeTrafo = $this->refinery->string()->estimatedReadingTime(true);
         
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $readingTimeTrafo->transform($from);
     }
 
@@ -107,10 +123,10 @@ EOT;
     public function testXTHMLCommentsMustNotAffectReadingTime() : void
     {
         $text = self::HTML;
-
+    
         $comment = '<script><!--a comment--></script>';
         $repetitions = 300;
-        $text = $text . str_repeat($comment, $repetitions);
+        $text .= str_repeat($comment, $repetitions);
 
         $onlyTextReadingTimeInfo = $this->refinery->string()->estimatedReadingTime();
         $this->assertEquals(

--- a/tests/Refinery/String/GroupTest.php
+++ b/tests/Refinery/String/GroupTest.php
@@ -1,32 +1,43 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\String;
 
-use ILIAS\Data\Factory;
-use ILIAS\Refinery\String\Group;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\String\Group as StringGroup;
 use ILIAS\Refinery\String\HasMinLength;
 use ILIAS\Refinery\String\HasMaxLength;
 use ILIAS\Tests\Refinery\TestCase;
 use ILIAS\Refinery\String\MakeClickable;
-
-require_once('./libs/composer/vendor/autoload.php');
+use ilLanguage;
 
 class GroupTest extends TestCase
 {
-    /**
-     * @var Group
-     */
-    private $group;
+    private StringGroup $group;
 
-    public function setUp() : void
+    protected function setUp() : void
     {
-        $dataFactory = new Factory();
-        $language = $this->getMockBuilder('\ilLanguage')
+        $dataFactory = new DataFactory();
+        $language = $this->getMockBuilder(ilLanguage::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->group = new Group($dataFactory, $language);
+        $this->group = new StringGroup($dataFactory, $language);
     }
 
     public function testGreaterThanInstance() : void

--- a/tests/Refinery/String/MakeClickableTest.php
+++ b/tests/Refinery/String/MakeClickableTest.php
@@ -1,5 +1,21 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 namespace ILIAS\Tests\Refinery\String;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Refinery/String/StripTagsTest.php
+++ b/tests/Refinery/String/StripTagsTest.php
@@ -17,8 +17,8 @@
  *********************************************************************/
 
 use ILIAS\Refinery\Factory as Refinery;
-use ILIAS\Refinery\String\StripTags;
 use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\Transformation;
 use PHPUnit\Framework\TestCase;
 
 class StripTagsTest extends TestCase
@@ -27,7 +27,7 @@ class StripTagsTest extends TestCase
     private const EXPECTED_RESULT = "I contain tags.";
     
     private Refinery $f;
-    private StripTags $strip_tags;
+    private Transformation $strip_tags;
 
     protected function setUp() : void
     {

--- a/tests/Refinery/String/StripTagsTest.php
+++ b/tests/Refinery/String/StripTagsTest.php
@@ -1,38 +1,52 @@
-<?php
-
-/* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
-
-use ILIAS\Refinery;
-use PHPUnit\Framework\TestCase;
+<?php declare(strict_types=1);
 
 /**
- * TestCase for SplitString transformations
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * @author Stefan Hecken <stefan.hecken@concepts-and-training.de>
- */
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Refinery\String\StripTags;
+use ILIAS\Data\Factory as DataFactory;
+use PHPUnit\Framework\TestCase;
+
 class StripTagsTest extends TestCase
 {
-    const STRING_TO_STRIP = "I <script>contain</a> tags.";
-    const EXPECTED_RESULT = "I contain tags.";
+    private const STRING_TO_STRIP = "I <script>contain</a> tags.";
+    private const EXPECTED_RESULT = "I contain tags.";
+    
+    private Refinery $f;
+    private StripTags $strip_tags;
 
     protected function setUp() : void
     {
-        $this->f = new \ILIAS\Refinery\Factory(
-            $this->createMock(\ILIAS\Data\Factory::class),
-            $language = $this->createMock('\ilLanguage')
+        $this->f = new Refinery(
+            $this->createMock(DataFactory::class),
+            $language = $this->createMock(ilLanguage::class)
         );
         $this->strip_tags = $this->f->string()->stripTags();
     }
 
-    public function testTransform()
+    public function testTransform() : void
     {
         $res = $this->strip_tags->transform(self::STRING_TO_STRIP);
         $this->assertEquals(self::EXPECTED_RESULT, $res);
     }
 
-    public function testNoString()
+    public function testNoString() : void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->strip_tags->transform(0);
     }
 }

--- a/tests/Refinery/String/Transformation/CaseOfLabelTest.php
+++ b/tests/Refinery/String/Transformation/CaseOfLabelTest.php
@@ -1,64 +1,56 @@
-<?php
+<?php declare(strict_types=1);
 
-declare(strict_types=1);
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
-use ILIAS\Data;
-use ILIAS\Refinery;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\Factory as Refinery ;
 use ILIAS\Refinery\String\CaseOfLabel;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Class CaseOfLabelTest
- *
- * @author  studer + raimann ag - Team Custom 1 <support-custom1@studer-raimann.ch>
- */
 class CaseOfLabelTest extends TestCase
 {
-    const LANGUAGE_KEY = "en";
-    const SENSELESS_LANGUAGE_KEY = "this_language_key_will_never_exist";
-    const TEST_STRING_1 = "I am a test string for the title capitalization and I hope that works even if it is complicated :)";
-    const TEST_STRING_2 = "I switch the computer on and go online";
-    const TEST_STRING_3 = "Now it is working";
-    const EXPECTED_RESULT_TEST_STRING_1 = "I Am a Test String for the Title Capitalization and I Hope that Works even if It Is Complicated :)";
-    const EXPECTED_RESULT_TEST_STRING_2 = "I Switch the Computer on and Go Online";
-    const EXPECTED_RESULT_TEST_STRING_3 = "Now It Is Working";
-    /**
-     * @var CaseOfLabel
-     */
-    protected $case_of_label_if_possible;
-    /**
-     * @var Refinery\Factory
-     */
-    protected $f;
+    private const LANGUAGE_KEY = "en";
+    private const SENSELESS_LANGUAGE_KEY = "this_language_key_will_never_exist";
+    private const TEST_STRING_1 = "I am a test string for the title capitalization and I hope that works even if it is complicated :)";
+    private const TEST_STRING_2 = "I switch the computer on and go online";
+    private const TEST_STRING_3 = "Now it is working";
+    private const EXPECTED_RESULT_TEST_STRING_1 = "I Am a Test String for the Title Capitalization and I Hope that Works even if It Is Complicated :)";
+    private const EXPECTED_RESULT_TEST_STRING_2 = "I Switch the Computer on and Go Online";
+    private const EXPECTED_RESULT_TEST_STRING_3 = "Now It Is Working";
 
+    private ?CaseOfLabel $case_of_label_if_possible;
+    private ?Refinery $f;
 
-    /**
-     *
-     */
     protected function setUp() : void
     {
-        $dataFactory = new Data\Factory();
+        $dataFactory = new DataFactory();
 
-        $language = $this->createMock('\\' . ilLanguage::class);
+        $language = $this->createMock(ilLanguage::class);
 
-        $this->f = new Refinery\Factory($dataFactory, $language);
+        $this->f = new Refinery($dataFactory, $language);
         $this->case_of_label_if_possible = $this->f->string()->caseOfLabel(self::LANGUAGE_KEY);
     }
 
-
-    /**
-     *
-     */
     protected function tearDown() : void
     {
         $this->f = null;
         $this->case_of_label_if_possible = null;
     }
 
-
-    /**
-     *
-     */
     public function testTransform1() : void
     {
         $str = $this->case_of_label_if_possible->transform(self::TEST_STRING_1);
@@ -66,10 +58,6 @@ class CaseOfLabelTest extends TestCase
         $this->assertEquals(self::EXPECTED_RESULT_TEST_STRING_1, $str);
     }
 
-
-    /**
-     *
-     */
     public function testTransform2() : void
     {
         $str = $this->case_of_label_if_possible->transform(self::TEST_STRING_2);
@@ -78,9 +66,6 @@ class CaseOfLabelTest extends TestCase
     }
 
 
-    /**
-     *
-     */
     public function testTransform3() : void
     {
         $str = $this->case_of_label_if_possible->transform(self::TEST_STRING_3);
@@ -88,10 +73,6 @@ class CaseOfLabelTest extends TestCase
         $this->assertEquals(self::EXPECTED_RESULT_TEST_STRING_3, $str);
     }
 
-
-    /**
-     *
-     */
     public function testTransformFails() : void
     {
         $raised = false;
@@ -122,10 +103,6 @@ class CaseOfLabelTest extends TestCase
         $this->assertTrue($raised);
     }
 
-
-    /**
-     *
-     */
     public function testInvoke() : void
     {
         $this->case_of_label_if_possible = $this->f->string()->caseOfLabel(self::LANGUAGE_KEY);
@@ -135,10 +112,6 @@ class CaseOfLabelTest extends TestCase
         $this->assertEquals(self::EXPECTED_RESULT_TEST_STRING_1, $str);
     }
 
-
-    /**
-     *
-     */
     public function testInvokeFails() : void
     {
         $this->case_of_label_if_possible = $this->f->string()->caseOfLabel(self::LANGUAGE_KEY);
@@ -171,13 +144,9 @@ class CaseOfLabelTest extends TestCase
         $this->assertTrue($raised);
     }
 
-
-    /**
-     *
-     */
     public function testApplyToWithValidValueReturnsAnOkResult() : void
     {
-        $factory = new Data\Factory();
+        $factory = new DataFactory();
 
         $valueObject = $factory->ok(self::TEST_STRING_1);
 
@@ -187,13 +156,9 @@ class CaseOfLabelTest extends TestCase
         $this->assertFalse($resultObject->isError());
     }
 
-
-    /**
-     *
-     */
     public function testApplyToWithInvalidValueWillLeadToErrorResult() : void
     {
-        $factory = new Data\Factory();
+        $factory = new DataFactory();
 
         $valueObject = $factory->ok(42);
 
@@ -202,10 +167,6 @@ class CaseOfLabelTest extends TestCase
         $this->assertTrue($resultObject->isError());
     }
 
-
-    /**
-     *
-     */
     public function testUnknownLanguageKey() : void
     {
         $this->case_of_label_if_possible = $this->f->string()->caseOfLabel(self::SENSELESS_LANGUAGE_KEY);

--- a/tests/Refinery/String/Transformation/CaseOfLabelTest.php
+++ b/tests/Refinery/String/Transformation/CaseOfLabelTest.php
@@ -18,7 +18,7 @@
 
 use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Refinery\Factory as Refinery ;
-use ILIAS\Refinery\String\CaseOfLabel;
+use ILIAS\Refinery\Transformation;
 use PHPUnit\Framework\TestCase;
 
 class CaseOfLabelTest extends TestCase
@@ -32,7 +32,7 @@ class CaseOfLabelTest extends TestCase
     private const EXPECTED_RESULT_TEST_STRING_2 = "I Switch the Computer on and Go Online";
     private const EXPECTED_RESULT_TEST_STRING_3 = "Now It Is Working";
 
-    private ?CaseOfLabel $case_of_label_if_possible;
+    private ?Transformation $case_of_label_if_possible;
     private ?Refinery $f;
 
     protected function setUp() : void

--- a/tests/Refinery/String/Transformation/SplitStringTest.php
+++ b/tests/Refinery/String/Transformation/SplitStringTest.php
@@ -16,7 +16,7 @@
  *
  *********************************************************************/
 
-use ILIAS\Refinery\String\SplitString;
+use ILIAS\Refinery\Transformation;
 use ILIAS\Data\Factory as DataFactory;
 use PHPUnit\Framework\TestCase;
 use ILIAS\Refinery\Factory as Refinery;
@@ -28,7 +28,7 @@ class SplitStringTest extends TestCase
     /** @var string[] */
     protected static array $result = ["I am", "a test string", "for split"];
 
-    private ?SplitString $split_string;
+    private ?Transformation $split_string;
     private ?Refinery $f;
 
     protected function setUp() : void

--- a/tests/Refinery/String/Transformation/SplitStringTest.php
+++ b/tests/Refinery/String/Transformation/SplitStringTest.php
@@ -1,30 +1,41 @@
-<?php
-
-/* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
-
-use ILIAS\Refinery;
-use PHPUnit\Framework\TestCase;
+<?php declare(strict_types=1);
 
 /**
- * TestCase for SplitString transformations
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * @author Stefan Hecken <stefan.hecken@concepts-and-training.de>
- */
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\Refinery\String\SplitString;
+use ILIAS\Data\Factory as DataFactory;
+use PHPUnit\Framework\TestCase;
+use ILIAS\Refinery\Factory as Refinery;
+
 class SplitStringTest extends TestCase
 {
-    const STRING_TO_SPLIT = "I am#a test string#for split";
-    protected static $result = array("I am", "a test string", "for split");
+    private const STRING_TO_SPLIT = "I am#a test string#for split";
 
-    /**
-     * @var Refinery\Transformations\SplitString
-     */
-    private $split_string;
+    /** @var string[] */
+    protected static array $result = ["I am", "a test string", "for split"];
+
+    private ?SplitString $split_string;
+    private ?Refinery $f;
 
     protected function setUp() : void
     {
-        $dataFactory = new \ILIAS\Data\Factory();
-        $language = $this->createMock('\ilLanguage');
-        $this->f = new \ILIAS\Refinery\Factory($dataFactory, $language);
+        $dataFactory = new DataFactory();
+        $language = $this->createMock(ilLanguage::class);
+        $this->f = new Refinery($dataFactory, $language);
         $this->split_string = $this->f->string()->splitString("#");
     }
 
@@ -34,13 +45,13 @@ class SplitStringTest extends TestCase
         $this->split_string = null;
     }
 
-    public function testTransform()
+    public function testTransform() : void
     {
         $arr = $this->split_string->transform(self::STRING_TO_SPLIT);
         $this->assertEquals(static::$result, $arr);
     }
 
-    public function testTransformFails()
+    public function testTransformFails() : void
     {
         $raised = false;
         try {
@@ -70,14 +81,14 @@ class SplitStringTest extends TestCase
         $this->assertTrue($raised);
     }
 
-    public function testInvoke()
+    public function testInvoke() : void
     {
         $split_string = $this->f->string()->splitString("#");
         $arr = $split_string(self::STRING_TO_SPLIT);
         $this->assertEquals(static::$result, $arr);
     }
 
-    public function testInvokeFails()
+    public function testInvokeFails() : void
     {
         $split_string = $this->f->string()->splitString("#");
 
@@ -109,9 +120,9 @@ class SplitStringTest extends TestCase
         $this->assertTrue($raised);
     }
 
-    public function testApplyToWithValidValueReturnsAnOkResult()
+    public function testApplyToWithValidValueReturnsAnOkResult() : void
     {
-        $factory = new \ILIAS\Data\Factory();
+        $factory = new DataFactory();
         $valueObject = $factory->ok(self::STRING_TO_SPLIT);
 
         $resultObject = $this->split_string->applyTo($valueObject);
@@ -120,9 +131,9 @@ class SplitStringTest extends TestCase
         $this->assertFalse($resultObject->isError());
     }
 
-    public function testApplyToWithInvalidValueWillLeadToErrorResult()
+    public function testApplyToWithInvalidValueWillLeadToErrorResult() : void
     {
-        $factory = new \ILIAS\Data\Factory();
+        $factory = new DataFactory();
         $valueObject = $factory->ok(42);
 
         $resultObject = $this->split_string->applyTo($valueObject);

--- a/tests/Refinery/TestCase.php
+++ b/tests/Refinery/TestCase.php
@@ -1,33 +1,47 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
 /**
- * @author  Niels Theen <ntheen@databay.de>
- */
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery;
 
 use ilGlobalTemplateInterface;
+use ilLanguage;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 
-require_once('./libs/composer/vendor/autoload.php');
-
-
-class ilLanguageMock extends \ilLanguage
+class ilLanguageMock extends ilLanguage
 {
-    public $requested = array();
+    /** @var string[] */
+    public array $requested = [];
+    public string $lang_module = 'common';
+
     public function __construct()
     {
     }
-    public function txt($a_topic, $a_default_lang_fallback_mod = "") : string
+
+    public function txt(string $a_topic, string $a_default_lang_fallback_mod = '') : string
     {
         $this->requested[] = $a_topic;
         return $a_topic;
     }
+
     public function toJS($a_lang_key, ilGlobalTemplateInterface $a_tpl = null) : void
     {
     }
-    public $lang_module = 'common';
+
     public function loadLanguageModule(string $a_module) : void
     {
     }
@@ -35,7 +49,7 @@ class ilLanguageMock extends \ilLanguage
 
 abstract class TestCase extends PHPUnitTestCase
 {
-    public function getLanguage()
+    public function getLanguage() : ilLanguageMock
     {
         return new ilLanguageMock();
     }

--- a/tests/Refinery/To/GroupTest.php
+++ b/tests/Refinery/To/GroupTest.php
@@ -1,14 +1,26 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
 /**
- * @author  Niels Theen <ntheen@databay.de>
- */
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\To;
 
 use ILIAS\Data\Alphanumeric;
-use ILIAS\Refinery\To\Group;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\To\Group as ToGroup;
 use ILIAS\Refinery\To\Transformation\BooleanTransformation;
 use ILIAS\Refinery\To\Transformation\DictionaryTransformation;
 use ILIAS\Refinery\To\Transformation\FloatTransformation;
@@ -19,61 +31,56 @@ use ILIAS\Refinery\To\Transformation\NewObjectTransformation;
 use ILIAS\Refinery\To\Transformation\RecordTransformation;
 use ILIAS\Refinery\To\Transformation\StringTransformation;
 use ILIAS\Refinery\To\Transformation\TupleTransformation;
-use ILIAS\Refinery\To\Transformation\DateTimeTransformation;
 use ILIAS\Tests\Refinery\TestCase;
-
-require_once('./libs/composer/vendor/autoload.php');
+use InvalidArgumentException;
 
 class GroupTest extends TestCase
 {
-    /**
-     * @var Group
-     */
-    private $basicGroup;
+    private ToGroup $basicGroup;
 
-    public function setUp() : void
+    protected function setUp() : void
     {
-        $this->basicGroup = new Group(new \ILIAS\Data\Factory());
+        $this->basicGroup = new ToGroup(new DataFactory());
     }
 
-    public function testIsIntegerTransformationInstance()
+    public function testIsIntegerTransformationInstance() : void
     {
         $transformation = $this->basicGroup->int();
 
         $this->assertInstanceOf(IntegerTransformation::class, $transformation);
     }
 
-    public function testIsStringTransformationInstance()
+    public function testIsStringTransformationInstance() : void
     {
         $transformation = $this->basicGroup->string();
 
         $this->assertInstanceOf(StringTransformation::class, $transformation);
     }
 
-    public function testIsFloatTransformationInstance()
+    public function testIsFloatTransformationInstance() : void
     {
         $transformation = $this->basicGroup->float();
 
         $this->assertInstanceOf(FloatTransformation::class, $transformation);
     }
 
-    public function testIsBooleanTransformationInstance()
+    public function testIsBooleanTransformationInstance() : void
     {
         $transformation = $this->basicGroup->bool();
 
         $this->assertInstanceOf(BooleanTransformation::class, $transformation);
     }
 
-    public function testListOfTransformation()
+    public function testListOfTransformation() : void
     {
         $transformation = $this->basicGroup->listOf(new StringTransformation());
 
         $this->assertInstanceOf(ListTransformation::class, $transformation);
     }
 
-    public function testTupleOfTransformation()
+    public function testTupleOfTransformation() : void
     {
-        $transformation = $this->basicGroup->tupleOf(array(new StringTransformation()));
+        $transformation = $this->basicGroup->tupleOf([new StringTransformation()]);
 
         $this->assertInstanceOf(TupleTransformation::class, $transformation);
     }
@@ -81,14 +88,14 @@ class GroupTest extends TestCase
     /**
      * @throws \ilException
      */
-    public function testRecordOfTransformation()
+    public function testRecordOfTransformation() : void
     {
-        $transformation = $this->basicGroup->recordOf(array('toString' => new StringTransformation()));
+        $transformation = $this->basicGroup->recordOf(['toString' => new StringTransformation()]);
 
         $this->assertInstanceOf(RecordTransformation::class, $transformation);
     }
 
-    public function testDictionaryOfTransformation()
+    public function testDictionaryOfTransformation() : void
     {
         $transformation = $this->basicGroup->dictOf(new StringTransformation());
 
@@ -98,9 +105,9 @@ class GroupTest extends TestCase
     /**
      * @throws \ilException
      */
-    public function testNewObjectTransformation()
+    public function testNewObjectTransformation() : void
     {
-        $transformation = $this->basicGroup->toNew((string) MyClass::class);
+        $transformation = $this->basicGroup->toNew(MyClass::class);
 
         $this->assertInstanceOf(NewObjectTransformation::class, $transformation);
     }
@@ -108,33 +115,33 @@ class GroupTest extends TestCase
     /**
      * @throws \ilException
      */
-    public function testNewMethodTransformation()
+    public function testNewMethodTransformation() : void
     {
-        $transformation = $this->basicGroup->toNew(array(new MyClass(), 'myMethod'));
+        $transformation = $this->basicGroup->toNew([new MyClass(), 'myMethod']);
 
         $this->assertInstanceOf(NewMethodTransformation::class, $transformation);
     }
 
-    public function testNewMethodTransformationThrowsExceptionBecauseToManyParametersAreGiven()
+    public function testNewMethodTransformationThrowsExceptionBecauseToManyParametersAreGiven() : void
     {
         $this->expectNotToPerformAssertions();
 
         try {
-            $transformation = $this->basicGroup->toNew(array(new MyClass(), 'myMethod', 'hello'));
-        } catch (\InvalidArgumentException $exception) {
+            $transformation = $this->basicGroup->toNew([new MyClass(), 'myMethod', 'hello']);
+        } catch (InvalidArgumentException $exception) {
             return;
         }
 
         $this->fail();
     }
 
-    public function testNewMethodTransformationThrowsExceptionBecauseToFewParametersAreGiven()
+    public function testNewMethodTransformationThrowsExceptionBecauseToFewParametersAreGiven() : void
     {
         $this->expectNotToPerformAssertions();
 
         try {
-            $transformation = $this->basicGroup->toNew(array(new MyClass()));
-        } catch (\InvalidArgumentException $exception) {
+            $transformation = $this->basicGroup->toNew([new MyClass()]);
+        } catch (InvalidArgumentException $exception) {
             return;
         }
 
@@ -144,13 +151,13 @@ class GroupTest extends TestCase
     /**
      * @throws \ilException
      */
-    public function testCreateDataTransformation()
+    public function testCreateDataTransformation() : void
     {
         $transformation = $this->basicGroup->data('alphanumeric');
 
         $this->assertInstanceOf(NewMethodTransformation::class, $transformation);
 
-        $result = $transformation->transform(array('hello'));
+        $result = $transformation->transform(['hello']);
 
         $this->assertInstanceOf(Alphanumeric::class, $result);
     }
@@ -158,8 +165,8 @@ class GroupTest extends TestCase
 
 class MyClass
 {
-    public function myMethod()
+    public function myMethod() : array
     {
-        return array($this->string, $this->integer);
+        return [$this->string, $this->integer];
     }
 }

--- a/tests/Refinery/To/Transformation/BooleanTransformationTest.php
+++ b/tests/Refinery/To/Transformation/BooleanTransformationTest.php
@@ -1,13 +1,22 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
 /**
- * @author  Niels Theen <ntheen@databay.de>
- */
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\To\Transformation;
-
-require_once('./libs/composer/vendor/autoload.php');
 
 use ILIAS\Data\Result;
 use ILIAS\Refinery\To\Transformation\BooleanTransformation;
@@ -16,17 +25,14 @@ use UnexpectedValueException;
 
 class BooleanTransformationTest extends TestCase
 {
-    /**
-     * @var BooleanTransformation
-     */
-    private $transformation;
+    private BooleanTransformation $transformation;
 
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->transformation = new BooleanTransformation();
     }
 
-    public function testIntegerToBooleanTransformation()
+    public function testIntegerToBooleanTransformation() : void
     {
         $this->expectNotToPerformAssertions();
 
@@ -38,7 +44,7 @@ class BooleanTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testNegativeIntegerToBooleanTransformation()
+    public function testNegativeIntegerToBooleanTransformation() : void
     {
         $this->expectNotToPerformAssertions();
 
@@ -50,7 +56,7 @@ class BooleanTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testZeroIntegerToBooleanTransformation()
+    public function testZeroIntegerToBooleanTransformation() : void
     {
         $this->expectNotToPerformAssertions();
 
@@ -62,7 +68,7 @@ class BooleanTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testStringToBooleanTransformation()
+    public function testStringToBooleanTransformation() : void
     {
         $this->expectNotToPerformAssertions();
 
@@ -74,7 +80,7 @@ class BooleanTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testFloatToBooleanTransformation()
+    public function testFloatToBooleanTransformation() : void
     {
         $this->expectNotToPerformAssertions();
 
@@ -86,7 +92,7 @@ class BooleanTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testNegativeFloatToBooleanTransformation()
+    public function testNegativeFloatToBooleanTransformation() : void
     {
         $this->expectNotToPerformAssertions();
 
@@ -98,7 +104,7 @@ class BooleanTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testZeroFloatToBooleanTransformation()
+    public function testZeroFloatToBooleanTransformation() : void
     {
         $this->expectNotToPerformAssertions();
 
@@ -110,19 +116,19 @@ class BooleanTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testPositiveBooleanToBooleanTransformation()
+    public function testPositiveBooleanToBooleanTransformation() : void
     {
         $transformedValue = $this->transformation->transform(true);
         $this->assertTrue($transformedValue);
     }
 
-    public function testNegativeBooleanToBooleanTransformation()
+    public function testNegativeBooleanToBooleanTransformation() : void
     {
         $transformedValue = $this->transformation->transform(false);
         $this->assertFalse($transformedValue);
     }
 
-    public function testStringToBooleanApply()
+    public function testStringToBooleanApply() : void
     {
         $resultObject = new Result\Ok('hello');
 
@@ -131,7 +137,7 @@ class BooleanTransformationTest extends TestCase
         $this->assertTrue($transformedObject->isError());
     }
 
-    public function testPositiveIntegerToBooleanApply()
+    public function testPositiveIntegerToBooleanApply() : void
     {
         $resultObject = new Result\Ok(200);
 
@@ -140,7 +146,7 @@ class BooleanTransformationTest extends TestCase
         $this->assertTrue($transformedObject->isError());
     }
 
-    public function testNegativeIntegerToBooleanApply()
+    public function testNegativeIntegerToBooleanApply() : void
     {
         $resultObject = new Result\Ok(-200);
 
@@ -149,7 +155,7 @@ class BooleanTransformationTest extends TestCase
         $this->assertTrue($transformedObject->isError());
     }
 
-    public function testZeroIntegerToBooleanApply()
+    public function testZeroIntegerToBooleanApply() : void
     {
         $resultObject = new Result\Ok(0);
 
@@ -158,7 +164,7 @@ class BooleanTransformationTest extends TestCase
         $this->assertTrue($transformedObject->isError());
     }
 
-    public function testFloatToBooleanApply()
+    public function testFloatToBooleanApply() : void
     {
         $resultObject = new Result\Ok(10.5);
 
@@ -167,7 +173,7 @@ class BooleanTransformationTest extends TestCase
         $this->assertTrue($transformedObject->isError());
     }
 
-    public function testBooleanToBooleanApply()
+    public function testBooleanToBooleanApply() : void
     {
         $resultObject = new Result\Ok(true);
 

--- a/tests/Refinery/To/Transformation/DateTimeTransformationTest.php
+++ b/tests/Refinery/To/Transformation/DateTimeTransformationTest.php
@@ -1,36 +1,41 @@
-<?php
+<?php declare(strict_types=1);
 
-/* Copyright (c) 2019 Nils Haagen <nils.haagen@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\To\Transformation;
 
-require_once('./libs/composer/vendor/autoload.php');
-
+use DateTimeImmutable;
 use ILIAS\Refinery\To\Transformation\DateTimeTransformation;
-use PHPUnit\Framework\TestCase as TestCase;
-use ILIAS\Data\Factory;
-use ILIAS\Data\Result;
+use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
 
-/**
- * TestCase for DateTime transformations
- */
 class DateTimeTransformationTest extends TestCase
 {
-    /**
-     * @var DateTimeTransformation
-     */
-    private $trans;
+    private DateTimeTransformation $trans;
 
     protected function setUp() : void
     {
-        $df = new Factory();
-        $this->trans = new DateTimeTransformation($df);
+        $this->trans = new DateTimeTransformation();
     }
 
-    public function testTransform()
+    public function testTransform() : void
     {
         $value = '26.05.1977';
-        $expected = new \DateTimeImmutable($value);
+        $expected = new DateTimeImmutable($value);
 
         $this->assertEquals(
             $expected,
@@ -38,16 +43,16 @@ class DateTimeTransformationTest extends TestCase
         );
     }
 
-    public function testInvalidTransform()
+    public function testInvalidTransform() : void
     {
-        $this->expectException(\UnexpectedValueException::class);
+        $this->expectException(UnexpectedValueException::class);
         $this->trans->transform('erroneous');
     }
 
-    public function testInvoke()
+    public function testInvoke() : void
     {
         $value = '2019/05/26';
-        $expected = new \DateTimeImmutable($value);
+        $expected = new DateTimeImmutable($value);
         $t = $this->trans;
 
         $this->assertEquals($expected, $t($value));

--- a/tests/Refinery/To/Transformation/DictionaryTransformationTest.php
+++ b/tests/Refinery/To/Transformation/DictionaryTransformationTest.php
@@ -1,9 +1,20 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
 /**
- * @author  Niels Theen <ntheen@databay.de>
- */
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\To\Transformation;
 
@@ -13,30 +24,28 @@ use ILIAS\Refinery\To\Transformation\StringTransformation;
 use ILIAS\Tests\Refinery\TestCase;
 use UnexpectedValueException;
 
-require_once('./libs/composer/vendor/autoload.php');
-
 class DictionaryTransformationTest extends TestCase
 {
     /**
      * @throws \ilException
      */
-    public function testDictionaryTransformationValid()
+    public function testDictionaryTransformationValid() : void
     {
         $transformation = new DictionaryTransformation(new StringTransformation());
 
-        $result = $transformation->transform(array('hello' => 'world'));
+        $result = $transformation->transform(['hello' => 'world']);
 
-        $this->assertEquals(array('hello' => 'world'), $result);
+        $this->assertEquals(['hello' => 'world'], $result);
     }
 
-    public function testDictionaryTransformationInvalidBecauseKeyIsNotAString()
+    public function testDictionaryTransformationInvalidBecauseKeyIsNotAString() : void
     {
         $this->expectNotToPerformAssertions();
 
         $transformation = new DictionaryTransformation(new StringTransformation());
 
         try {
-            $result = $transformation->transform(array('world'));
+            $result = $transformation->transform(['world']);
         } catch (UnexpectedValueException $exception) {
             return;
         }
@@ -44,14 +53,14 @@ class DictionaryTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testDictionaryTransformationInvalidBecauseValueIsNotAString()
+    public function testDictionaryTransformationInvalidBecauseValueIsNotAString() : void
     {
         $this->expectNotToPerformAssertions();
 
         $transformation = new DictionaryTransformation(new StringTransformation());
 
         try {
-            $result = $transformation->transform(array('hello' => 1));
+            $result = $transformation->transform(['hello' => 1]);
         } catch (UnexpectedValueException $exception) {
             return;
         }
@@ -59,7 +68,7 @@ class DictionaryTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testDictionaryTransformationNonArrayCanNotBeTransformedAndThrowsException()
+    public function testDictionaryTransformationNonArrayCanNotBeTransformedAndThrowsException() : void
     {
         $this->expectNotToPerformAssertions();
 
@@ -74,34 +83,34 @@ class DictionaryTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testDictionaryApplyValid()
+    public function testDictionaryApplyValid() : void
     {
         $transformation = new DictionaryTransformation(new StringTransformation());
 
-        $result = $transformation->applyTo(new Ok(array('hello' => 'world')));
+        $result = $transformation->applyTo(new Ok(['hello' => 'world']));
 
-        $this->assertEquals(array('hello' => 'world'), $result->value());
+        $this->assertEquals(['hello' => 'world'], $result->value());
     }
 
-    public function testDictionaryApplyInvalidBecauseKeyIsNotAString()
+    public function testDictionaryApplyInvalidBecauseKeyIsNotAString() : void
     {
         $transformation = new DictionaryTransformation(new StringTransformation());
 
-        $result = $transformation->applyTo(new Ok(array('world')));
+        $result = $transformation->applyTo(new Ok(['world']));
 
         $this->assertTrue($result->isError());
     }
 
-    public function testDictionaryApplyInvalidBecauseValueIsNotAString()
+    public function testDictionaryApplyInvalidBecauseValueIsNotAString() : void
     {
         $transformation = new DictionaryTransformation(new StringTransformation());
 
-        $result = $transformation->applyTo(new Ok(array('hello' => 1)));
+        $result = $transformation->applyTo(new Ok(['hello' => 1]));
 
         $this->assertTrue($result->isError());
     }
 
-    public function testDictonaryNonArrayToTransformThrowsException()
+    public function testDictonaryNonArrayToTransformThrowsException() : void
     {
         $transformation = new DictionaryTransformation(new StringTransformation());
 

--- a/tests/Refinery/To/Transformation/FloatTransformationTest.php
+++ b/tests/Refinery/To/Transformation/FloatTransformationTest.php
@@ -1,13 +1,22 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
 /**
- * @author  Niels Theen <ntheen@databay.de>
- */
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\To\Transformation;
-
-require_once('./libs/composer/vendor/autoload.php');
 
 use ILIAS\Data\Result;
 use ILIAS\Refinery\To\Transformation\FloatTransformation;
@@ -16,17 +25,14 @@ use UnexpectedValueException;
 
 class FloatTransformationTest extends TestCase
 {
-    /**
-     * @var FloatTransformation
-     */
-    private $transformation;
+    private FloatTransformation $transformation;
 
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->transformation = new FloatTransformation();
     }
 
-    public function testIntegerToFloatTransformation()
+    public function testIntegerToFloatTransformation() : void
     {
         $this->expectNotToPerformAssertions();
 
@@ -39,7 +45,7 @@ class FloatTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testStringToFloatTransformation()
+    public function testStringToFloatTransformation() : void
     {
         $this->expectNotToPerformAssertions();
 
@@ -52,14 +58,14 @@ class FloatTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testFloatToFloatTransformation()
+    public function testFloatToFloatTransformation() : void
     {
         $transformedValue = $this->transformation->transform(10.5);
 
         $this->assertEquals(10.5, $transformedValue);
     }
 
-    public function testNegativeIntegerToFloatTransformation()
+    public function testNegativeIntegerToFloatTransformation() : void
     {
         $this->expectNotToPerformAssertions();
 
@@ -72,7 +78,7 @@ class FloatTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testZeroIntegerToFloatTransformation()
+    public function testZeroIntegerToFloatTransformation() : void
     {
         $this->expectNotToPerformAssertions();
 
@@ -85,14 +91,14 @@ class FloatTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testZeroFloatToFloatTransformation()
+    public function testZeroFloatToFloatTransformation() : void
     {
         $transformedValue = $this->transformation->transform(0.0);
 
         $this->assertEquals(0.0, $transformedValue);
     }
 
-    public function testPositiveIntegerToFloatApply()
+    public function testPositiveIntegerToFloatApply() : void
     {
         $resultObject = new Result\Ok(200);
 
@@ -101,7 +107,7 @@ class FloatTransformationTest extends TestCase
         $this->assertTrue($transformedObject->isError());
     }
 
-    public function testNegativeIntegerToFloatApply()
+    public function testNegativeIntegerToFloatApply() : void
     {
         $resultObject = new Result\Ok(-200);
 
@@ -110,7 +116,7 @@ class FloatTransformationTest extends TestCase
         $this->assertTrue($transformedObject->isError());
     }
 
-    public function testZeroIntegerToFloatApply()
+    public function testZeroIntegerToFloatApply() : void
     {
         $resultObject = new Result\Ok(0);
 
@@ -119,7 +125,7 @@ class FloatTransformationTest extends TestCase
         $this->assertTrue($transformedObject->isError());
     }
 
-    public function testStringToFloatApply()
+    public function testStringToFloatApply() : void
     {
         $resultObject = new Result\Ok('hello');
 
@@ -128,7 +134,7 @@ class FloatTransformationTest extends TestCase
         $this->assertTrue($transformedObject->isError());
     }
 
-    public function testIntegerToFloatApply()
+    public function testIntegerToFloatApply() : void
     {
         $resultObject = new Result\Ok(200);
 
@@ -137,7 +143,7 @@ class FloatTransformationTest extends TestCase
         $this->assertTrue($transformedObject->isError());
     }
 
-    public function testFloatToFloatApply()
+    public function testFloatToFloatApply() : void
     {
         $resultObject = new Result\Ok(10.5);
 
@@ -146,7 +152,7 @@ class FloatTransformationTest extends TestCase
         $this->assertEquals(10.5, $transformedObject->value());
     }
 
-    public function testBooleanToFloatApply()
+    public function testBooleanToFloatApply() : void
     {
         $resultObject = new Result\Ok(true);
 

--- a/tests/Refinery/To/Transformation/IntegerTransformationTest.php
+++ b/tests/Refinery/To/Transformation/IntegerTransformationTest.php
@@ -1,13 +1,22 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
 /**
- * @author  Niels Theen <ntheen@databay.de>
- */
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\To\Transformation;
-
-require_once('./libs/composer/vendor/autoload.php');
 
 use ILIAS\Data\Result;
 use ILIAS\Refinery\To\Transformation\IntegerTransformation;
@@ -16,38 +25,35 @@ use UnexpectedValueException;
 
 class IntegerTransformationTest extends TestCase
 {
-    /**
-     * @var IntegerTransformation
-     */
-    private $transformation;
+    private IntegerTransformation $transformation;
 
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->transformation = new IntegerTransformation();
     }
 
-    public function testIntegerToIntegerTransformation()
+    public function testIntegerToIntegerTransformation() : void
     {
         $transformedValue = $this->transformation->transform(200);
 
         $this->assertEquals(200, $transformedValue);
     }
 
-    public function testNegativeIntegerToIntegerTransformation()
+    public function testNegativeIntegerToIntegerTransformation() : void
     {
         $transformedValue = $this->transformation->transform(-200);
 
         $this->assertEquals(-200, $transformedValue);
     }
 
-    public function testZeroIntegerToIntegerTransformation()
+    public function testZeroIntegerToIntegerTransformation() : void
     {
         $transformedValue = $this->transformation->transform(0);
 
         $this->assertEquals(0, $transformedValue);
     }
 
-    public function testStringToIntegerTransformation()
+    public function testStringToIntegerTransformation() : void
     {
         $this->expectNotToPerformAssertions();
 
@@ -60,7 +66,7 @@ class IntegerTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testFloatToIntegerTransformation()
+    public function testFloatToIntegerTransformation() : void
     {
         $this->expectNotToPerformAssertions();
 
@@ -73,7 +79,7 @@ class IntegerTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testPositiveBooleanToIntegerTransformation()
+    public function testPositiveBooleanToIntegerTransformation() : void
     {
         $this->expectNotToPerformAssertions();
 
@@ -86,7 +92,7 @@ class IntegerTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testNegativeBooleanToIntegerTransformation()
+    public function testNegativeBooleanToIntegerTransformation() : void
     {
         $this->expectNotToPerformAssertions();
 
@@ -99,7 +105,7 @@ class IntegerTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testStringToIntegerApply()
+    public function testStringToIntegerApply() : void
     {
         $resultObject = new Result\Ok('hello');
 
@@ -108,7 +114,7 @@ class IntegerTransformationTest extends TestCase
         $this->assertTrue($transformedObject->isError());
     }
 
-    public function testPositiveIntegerToIntegerApply()
+    public function testPositiveIntegerToIntegerApply() : void
     {
         $resultObject = new Result\Ok(200);
 
@@ -117,7 +123,7 @@ class IntegerTransformationTest extends TestCase
         $this->assertEquals(200, $transformedObject->value());
     }
 
-    public function testNegativeIntegerToIntegerApply()
+    public function testNegativeIntegerToIntegerApply() : void
     {
         $resultObject = new Result\Ok(-200);
 
@@ -126,7 +132,7 @@ class IntegerTransformationTest extends TestCase
         $this->assertEquals(-200, $transformedObject->value());
     }
 
-    public function testZeroIntegerToIntegerApply()
+    public function testZeroIntegerToIntegerApply() : void
     {
         $resultObject = new Result\Ok(0);
 
@@ -135,7 +141,7 @@ class IntegerTransformationTest extends TestCase
         $this->assertEquals(0, $transformedObject->value());
     }
 
-    public function testFloatToIntegerApply()
+    public function testFloatToIntegerApply() : void
     {
         $resultObject = new Result\Ok(10.5);
 
@@ -144,7 +150,7 @@ class IntegerTransformationTest extends TestCase
         $this->assertTrue($transformedObject->isError());
     }
 
-    public function testBooleanToIntegerApply()
+    public function testBooleanToIntegerApply() : void
     {
         $resultObject = new Result\Ok(true);
 

--- a/tests/Refinery/To/Transformation/ListTransformationTest.php
+++ b/tests/Refinery/To/Transformation/ListTransformationTest.php
@@ -1,9 +1,20 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
 /**
- * @author  Niels Theen <ntheen@databay.de>
- */
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\To\Transformation;
 
@@ -12,51 +23,50 @@ use ILIAS\Refinery\To\Transformation\ListTransformation;
 use ILIAS\Refinery\To\Transformation\StringTransformation;
 use ILIAS\Refinery\ConstraintViolationException;
 use ILIAS\Tests\Refinery\TestCase;
-
-require_once('./libs/composer/vendor/autoload.php');
+use UnexpectedValueException;
 
 class ListTransformationTest extends TestCase
 {
     /**
      * @throws \ilException
      */
-    public function testListTransformationIsValid()
+    public function testListTransformationIsValid() : void
     {
         $listTransformation = new ListTransformation(new StringTransformation());
 
-        $result = $listTransformation->transform(array('hello', 'world'));
+        $result = $listTransformation->transform(['hello', 'world']);
 
-        $this->assertEquals(array('hello', 'world'), $result);
+        $this->assertEquals(['hello', 'world'], $result);
     }
 
-    public function testTransformOnEmptyArrayReturnsEmptyList()
+    public function testTransformOnEmptyArrayReturnsEmptyList() : void
     {
         $listTransformation = new ListTransformation(new StringTransformation());
         $this->assertSame([], $listTransformation->transform([]));
     }
 
-    public function testApplyToOnEmptyArrayDoesNotFail()
+    public function testApplyToOnEmptyArrayDoesNotFail() : void
     {
         $listTransformation = new ListTransformation(new StringTransformation());
-        $result = $listTransformation->applyTo(new Ok(array()));
+        $result = $listTransformation->applyTo(new Ok([]));
         $this->assertFalse($result->isError());
     }
 
-    public function testTransformOnNullFails()
+    public function testTransformOnNullFails() : void
     {
         $this->expectNotToPerformAssertions();
 
         $listTransformation = new ListTransformation(new StringTransformation());
         try {
             $result = $listTransformation->transform(null);
-        } catch (\UnexpectedValueException $exception) {
+        } catch (UnexpectedValueException $exception) {
             return;
         }
 
         $this->fail();
     }
 
-    public function testApplyToOnNullFails()
+    public function testApplyToOnNullFails() : void
     {
         $listTransformation = new ListTransformation(new StringTransformation());
         $result = $listTransformation->applyTo(new Ok(null));
@@ -64,36 +74,36 @@ class ListTransformationTest extends TestCase
     }
 
 
-    public function testListTransformationIsInvalid()
+    public function testListTransformationIsInvalid() : void
     {
         $this->expectNotToPerformAssertions();
 
         $listTransformation = new ListTransformation(new StringTransformation());
 
         try {
-            $result = $listTransformation->transform(array('hello', 2));
-        } catch (\UnexpectedValueException $exception) {
+            $result = $listTransformation->transform(['hello', 2]);
+        } catch (UnexpectedValueException $exception) {
             return;
         }
 
         $this->fail();
     }
 
-    public function testListApplyIsValid()
+    public function testListApplyIsValid() : void
     {
         $listTransformation = new ListTransformation(new StringTransformation());
 
-        $result = $listTransformation->applyTo(new Ok(array('hello', 'world')));
+        $result = $listTransformation->applyTo(new Ok(['hello', 'world']));
 
-        $this->assertEquals(array('hello', 'world'), $result->value());
+        $this->assertEquals(['hello', 'world'], $result->value());
         $this->assertTrue($result->isOK());
     }
 
-    public function testListApplyIsInvalid()
+    public function testListApplyIsInvalid() : void
     {
         $listTransformation = new ListTransformation(new StringTransformation());
 
-        $result = $listTransformation->applyTo(new Ok(array('hello', 2)));
+        $result = $listTransformation->applyTo(new Ok(['hello', 2]));
 
         $this->assertTrue($result->isError());
     }

--- a/tests/Refinery/To/Transformation/NewMethodTransformationTest.php
+++ b/tests/Refinery/To/Transformation/NewMethodTransformationTest.php
@@ -1,133 +1,136 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
 /**
- * @author  Niels Theen <ntheen@databay.de>
- */
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\To\Transformation;
 
-use ILIAS\BackgroundTasks\Exceptions\InvalidArgumentException;
+use Error;
 use ILIAS\Data\Result\Ok;
 use ILIAS\DI\Exceptions\Exception;
 use ILIAS\Refinery\To\Transformation\NewMethodTransformation;
-use ILIAS\Refinery\ConstraintViolationException;
 use ILIAS\Tests\Refinery\TestCase;
-
-require_once('./libs/composer/vendor/autoload.php');
+use TypeError;
+use InvalidArgumentException;
 
 class NewMethodTransformationTest extends TestCase
 {
-    private $instance;
-
-    public function setUp() : void
-    {
-        $this->instance = new NewMethodTransformationTestClass();
-    }
-
     /**
      * @throws \ilException
      * @throws \ReflectionException
      */
-    public function testNewObjectTransformation()
+    public function testNewObjectTransformation() : void
     {
         $transformation = new NewMethodTransformation(new NewMethodTransformationTestClass(), 'myMethod');
 
-        $result = $transformation->transform(array('hello', 42));
+        $result = $transformation->transform(['hello', 42]);
 
-        $this->assertEquals(array('hello', 42), $result);
+        $this->assertEquals(['hello', 42], $result);
     }
 
-    public function testNewMethodTransformationThrowsTypeErrorOnInvalidConstructorArguments()
+    public function testNewMethodTransformationThrowsTypeErrorOnInvalidConstructorArguments() : void
     {
         $this->expectNotToPerformAssertions();
 
         $transformation = new NewMethodTransformation(new NewMethodTransformationTestClass(), 'myMethod');
 
         try {
-            $object = $transformation->transform(array('hello', 'world'));
-        } catch (\TypeError $exception) {
+            $object = $transformation->transform(['hello', 'world']);
+        } catch (TypeError $exception) {
             return;
         }
 
         $this->fail();
     }
 
-    public function testClassDoesNotExistWillThrowException()
+    public function testClassDoesNotExistWillThrowException() : void
     {
         $this->expectNotToPerformAssertions();
 
         try {
             $transformation = new NewMethodTransformation('BreakdanceMcFunkyPants', 'myMethod');
-        } catch (\Error $exception) {
+        } catch (Error $exception) {
             return;
         }
 
         $this->fail();
     }
 
-    public function testMethodDoesNotExistOnClassWillThrowException()
+    public function testMethodDoesNotExistOnClassWillThrowException() : void
     {
         $this->expectNotToPerformAssertions();
 
         try {
             $transformation = new NewMethodTransformation(new NewMethodTransformationTestClass(), 'someMethod');
-        } catch (\InvalidArgumentException $exception) {
+        } catch (InvalidArgumentException $exception) {
             return;
         }
 
         $this->fail();
     }
 
-    public function testPrivateMethodCanNotBeCalledInTransform()
+    public function testPrivateMethodCanNotBeCalledInTransform() : void
     {
         $this->expectNotToPerformAssertions();
 
         $transformation = new NewMethodTransformation(new NewMethodTransformationTestClass(), 'myPrivateMethod');
 
         try {
-            $object = $transformation->transform(array('hello', 10));
-        } catch (\Error $error) {
+            $object = $transformation->transform(['hello', 10]);
+        } catch (Error $error) {
             return;
         }
 
         $this->fail();
     }
 
-    public function testPrivateMethodCanNotBeCalledInApplyto()
+    public function testPrivateMethodCanNotBeCalledInApplyto() : void
     {
         $this->expectNotToPerformAssertions();
 
         $transformation = new NewMethodTransformation(new NewMethodTransformationTestClass(), 'myPrivateMethod');
         try {
-            $object = $transformation->applyTo(new Ok(array('hello', 10)));
-        } catch (\Error $error) {
+            $object = $transformation->applyTo(new Ok(['hello', 10]));
+        } catch (Error $error) {
             return;
         }
 
         $this->fail();
     }
 
-    public function testMethodThrowsExceptionInTransform()
+    public function testMethodThrowsExceptionInTransform() : void
     {
         $this->expectNotToPerformAssertions();
 
         $transformation = new NewMethodTransformation(new NewMethodTransformationTestClass(), 'methodThrowsException');
 
         try {
-            $object = $transformation->transform(array('hello', 10));
-        } catch (\Exception $exception) {
+            $object = $transformation->transform(['hello', 10]);
+        } catch (Exception $exception) {
             return;
         }
 
         $this->fail();
     }
 
-    public function testMethodThrowsExceptionInApplyTo()
+    public function testMethodThrowsExceptionInApplyTo() : void
     {
         $transformation = new NewMethodTransformation(new NewMethodTransformationTestClass(), 'methodThrowsException');
 
-        $object = $transformation->applyTo(new Ok(array('hello', 10)));
+        $object = $transformation->applyTo(new Ok(['hello', 10]));
 
         $this->assertTrue($object->isError());
     }
@@ -135,18 +138,18 @@ class NewMethodTransformationTest extends TestCase
 
 class NewMethodTransformationTestClass
 {
-    public function myMethod(string $string, int $integer)
+    public function myMethod(string $string, int $integer) : array
     {
-        return array($string, $integer);
+        return [$string, $integer];
     }
 
-    private function myPrivateMethod(string $string, int $integer)
+    private function myPrivateMethod(string $string, int $integer) : array
     {
-        return array($string, $integer);
+        return [$string, $integer];
     }
 
-    public function methodThrowsException(string $string, int $integer)
+    public function methodThrowsException(string $string, int $integer) : void
     {
-        throw new \Exception('SomeException');
+        throw new Exception('SomeException');
     }
 }

--- a/tests/Refinery/To/Transformation/NewObjectTransformationTest.php
+++ b/tests/Refinery/To/Transformation/NewObjectTransformationTest.php
@@ -1,43 +1,55 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
 /**
- * @author  Niels Theen <ntheen@databay.de>
- */
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\To\Transformation;
 
+use Error;
+use Exception;
 use ILIAS\Data\Result\Ok;
 use ILIAS\Refinery\To\Transformation\NewObjectTransformation;
 use ILIAS\Tests\Refinery\TestCase;
-
-require_once('./libs/composer/vendor/autoload.php');
+use TypeError;
 
 class NewObjectTransformationTest extends TestCase
 {
     /**
      * @throws \ReflectionException
      */
-    public function testNewObjectTransformation()
+    public function testNewObjectTransformation() : void
     {
         $transformation = new NewObjectTransformation(MyClass::class);
 
-        $object = $transformation->transform(array('hello', 42));
+        $object = $transformation->transform(['hello', 42]);
 
         $result = $object->myMethod();
 
-        $this->assertEquals(array('hello', 42), $result);
+        $this->assertEquals(['hello', 42], $result);
     }
 
-    public function testNewObjectTransformationThrowsTypeErrorOnInvalidConstructorArguments()
+    public function testNewObjectTransformationThrowsTypeErrorOnInvalidConstructorArguments() : void
     {
         $this->expectNotToPerformAssertions();
 
         $transformation = new NewObjectTransformation(MyClass::class);
 
         try {
-            $object = $transformation->transform(array('hello', 'world'));
-        } catch (\TypeError $exception) {
+            $object = $transformation->transform(['hello', 'world']);
+        } catch (TypeError $exception) {
             return;
         }
 
@@ -47,52 +59,52 @@ class NewObjectTransformationTest extends TestCase
     /**
      * @throws \ReflectionException
      */
-    public function testNewObjectApply()
+    public function testNewObjectApply() : void
     {
         $transformation = new NewObjectTransformation(MyClass::class);
 
-        $resultObject = $transformation->applyTo(new Ok(array('hello', 42)));
+        $resultObject = $transformation->applyTo(new Ok(['hello', 42]));
 
         $object = $resultObject->value();
 
         $result = $object->myMethod();
 
-        $this->assertEquals(array('hello', 42), $result);
+        $this->assertEquals(['hello', 42], $result);
     }
 
-    public function testNewObjectApplyResultsErrorObjectOnInvalidConstructorArguments()
+    public function testNewObjectApplyResultsErrorObjectOnInvalidConstructorArguments() : void
     {
         $this->expectNotToPerformAssertions();
 
         $transformation = new NewObjectTransformation(MyClass::class);
 
         try {
-            $resultObject = $transformation->applyTo(new Ok(array('hello', 'world')));
-        } catch (\Error $error) {
+            $resultObject = $transformation->applyTo(new Ok(['hello', 'world']));
+        } catch (Error $error) {
             return;
         }
 
         $this->fail();
     }
 
-    public function testExceptionInConstructorWillResultInErrorObject()
+    public function testExceptionInConstructorWillResultInErrorObject() : void
     {
         $transformation = new NewObjectTransformation(MyClassThrowsException::class);
 
-        $resultObject = $transformation->applyTo(new Ok(array('hello', 100)));
+        $resultObject = $transformation->applyTo(new Ok(['hello', 100]));
 
         $this->assertTrue($resultObject->isError());
     }
 
-    public function testExceptionInConstructorWillThrowException()
+    public function testExceptionInConstructorWillThrowException() : void
     {
         $this->expectNotToPerformAssertions();
 
         $transformation = new NewObjectTransformation(MyClassThrowsException::class);
 
         try {
-            $resultObject = $transformation->transform(array('hello', 100));
-        } catch (\Exception $exception) {
+            $resultObject = $transformation->transform(['hello', 100]);
+        } catch (Exception $exception) {
             return;
         }
 
@@ -102,9 +114,8 @@ class NewObjectTransformationTest extends TestCase
 
 class MyClass
 {
-    private $string;
-
-    private $integer;
+    private string $string;
+    private int $integer;
 
     public function __construct(string $string, int $integer)
     {
@@ -112,9 +123,9 @@ class MyClass
         $this->integer = $integer;
     }
 
-    public function myMethod()
+    public function myMethod() : array
     {
-        return array($this->string, $this->integer);
+        return [$this->string, $this->integer];
     }
 }
 
@@ -122,6 +133,6 @@ class MyClassThrowsException
 {
     public function __construct(string $string, int $integer)
     {
-        throw new \Exception();
+        throw new Exception();
     }
 }

--- a/tests/Refinery/To/Transformation/RecordTransformationTest.php
+++ b/tests/Refinery/To/Transformation/RecordTransformationTest.php
@@ -1,9 +1,20 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
 /**
- * @author  Niels Theen <ntheen@databay.de>
- */
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\To\Transformation;
 
@@ -14,35 +25,35 @@ use ILIAS\Refinery\To\Transformation\StringTransformation;
 use ILIAS\Tests\Refinery\TestCase;
 use UnexpectedValueException;
 
-require_once('./libs/composer/vendor/autoload.php');
-
 class RecordTransformationTest extends TestCase
 {
     /**
      * @throws \ilException
      */
-    public function testTransformationIsCorrect()
+    public function testTransformationIsCorrect() : void
     {
         $recordTransformation = new RecordTransformation(
-            array(
+            [
                 'stringTrafo' => new StringTransformation(),
-                'integerTrafo' => new IntegerTransformation())
+                'integerTrafo' => new IntegerTransformation()
+            ]
         );
 
-        $result = $recordTransformation->transform(array('stringTrafo' => 'hello', 'integerTrafo' => 1));
+        $result = $recordTransformation->transform(['stringTrafo' => 'hello', 'integerTrafo' => 1]);
 
-        $this->assertEquals(array('stringTrafo' => 'hello', 'integerTrafo' => 1), $result);
+        $this->assertEquals(['stringTrafo' => 'hello', 'integerTrafo' => 1], $result);
     }
 
-    public function testInvalidTransformationArray()
+    public function testInvalidTransformationArray() : void
     {
         $this->expectNotToPerformAssertions();
 
         try {
             $recordTransformation = new RecordTransformation(
-                array(
+                [
                     new StringTransformation(),
-                    new IntegerTransformation())
+                    new IntegerTransformation()
+                ]
             );
         } catch (UnexpectedValueException $exception) {
             return;
@@ -51,18 +62,19 @@ class RecordTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testTransformationIsInvalidBecauseValueDoesNotMatchWithTransformation()
+    public function testTransformationIsInvalidBecauseValueDoesNotMatchWithTransformation() : void
     {
         $this->expectNotToPerformAssertions();
 
         $recordTransformation = new RecordTransformation(
-            array(
+            [
                 'integerTrafo' => new IntegerTransformation(),
-                'anotherIntTrafo' => new IntegerTransformation())
+                'anotherIntTrafo' => new IntegerTransformation()
+            ]
         );
 
         try {
-            $result = $recordTransformation->transform(array('stringTrafo' => 'hello', 'anotherIntTrafo' => 1));
+            $result = $recordTransformation->transform(['stringTrafo' => 'hello', 'anotherIntTrafo' => 1]);
         } catch (UnexpectedValueException $exception) {
             return;
         }
@@ -70,18 +82,19 @@ class RecordTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testInvalidValueKey()
+    public function testInvalidValueKey() : void
     {
         $this->expectNotToPerformAssertions();
 
         $recordTransformation = new RecordTransformation(
-            array(
+            [
                 'stringTrafo' => new StringTransformation(),
-                'integerTrafo' => new IntegerTransformation())
+                'integerTrafo' => new IntegerTransformation()
+            ]
         );
 
         try {
-            $result = $recordTransformation->transform(array('stringTrafo' => 'hello', 'floatTrafo' => 1));
+            $result = $recordTransformation->transform(['stringTrafo' => 'hello', 'floatTrafo' => 1]);
         } catch (UnexpectedValueException $exception) {
             return;
         }
@@ -89,24 +102,25 @@ class RecordTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testInvalidToManyValues()
+    public function testInvalidToManyValues() : void
     {
         $this->expectNotToPerformAssertions();
 
         $recordTransformation = new RecordTransformation(
-            array(
+            [
                 'stringTrafo' => new StringTransformation(),
-                'integerTrafo' => new IntegerTransformation())
+                'integerTrafo' => new IntegerTransformation()
+            ]
         );
 
 
         try {
             $result = $recordTransformation->transform(
-                array(
+                [
                     'stringTrafo' => 'hello',
                     'integerTrafo' => 1,
                     'floatTrafo' => 1
-                )
+                ]
             );
         } catch (UnexpectedValueException $exception) {
             return;
@@ -115,18 +129,19 @@ class RecordTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testTransformationThrowsExceptionBecauseKeyIsNotAString()
+    public function testTransformationThrowsExceptionBecauseKeyIsNotAString() : void
     {
         $this->expectNotToPerformAssertions();
 
         $recordTransformation = new RecordTransformation(
-            array(
+            [
                 'stringTrafo' => new StringTransformation(),
-                'integerTrafo' => new IntegerTransformation())
+                'integerTrafo' => new IntegerTransformation()
+            ]
         );
 
         try {
-            $result = $recordTransformation->transform(array('someKey' => 'hello', 1));
+            $result = $recordTransformation->transform(['someKey' => 'hello', 1]);
         } catch (UnexpectedValueException $exception) {
             return;
         }
@@ -137,31 +152,33 @@ class RecordTransformationTest extends TestCase
     /**
      * @throws \ilException
      */
-    public function testApplyIsCorrect()
+    public function testApplyIsCorrect() : void
     {
         $recordTransformation = new RecordTransformation(
-            array(
+            [
                 'stringTrafo' => new StringTransformation(),
-                'integerTrafo' => new IntegerTransformation())
+                'integerTrafo' => new IntegerTransformation()
+            ]
         );
 
-        $result = $recordTransformation->applyTo(new Ok(array('stringTrafo' => 'hello', 'integerTrafo' => 1)));
+        $result = $recordTransformation->applyTo(new Ok(['stringTrafo' => 'hello', 'integerTrafo' => 1]));
 
-        $this->assertEquals(array('stringTrafo' => 'hello', 'integerTrafo' => 1), $result->value());
+        $this->assertEquals(['stringTrafo' => 'hello', 'integerTrafo' => 1], $result->value());
     }
 
     /**
      * @throws \ilException
      */
-    public function testApplyIsInvalidBecauseValueDoesNotMatchWithTransformation()
+    public function testApplyIsInvalidBecauseValueDoesNotMatchWithTransformation() : void
     {
         $recordTransformation = new RecordTransformation(
-            array(
+            [
                 'integerTrafo' => new IntegerTransformation(),
-                'anotherIntTrafo' => new IntegerTransformation())
+                'anotherIntTrafo' => new IntegerTransformation()
+            ]
         );
 
-        $result = $recordTransformation->applyTo(new Ok(array('stringTrafo' => 'hello', 'anotherIntTrafo' => 1)));
+        $result = $recordTransformation->applyTo(new Ok(['stringTrafo' => 'hello', 'anotherIntTrafo' => 1]));
 
         $this->assertTrue($result->isError());
     }
@@ -169,15 +186,16 @@ class RecordTransformationTest extends TestCase
     /**
      * @throws \ilException
      */
-    public function testInvalidValueKeyInApplyToMethod()
+    public function testInvalidValueKeyInApplyToMethod() : void
     {
         $recordTransformation = new RecordTransformation(
-            array(
+            [
                 'stringTrafo' => new StringTransformation(),
-                'integerTrafo' => new IntegerTransformation())
+                'integerTrafo' => new IntegerTransformation()
+            ]
         );
 
-        $result = $recordTransformation->applyTo(new Ok(array('stringTrafo' => 'hello', 'floatTrafo' => 1)));
+        $result = $recordTransformation->applyTo(new Ok(['stringTrafo' => 'hello', 'floatTrafo' => 1]));
 
         $this->assertTrue($result->isError());
     }
@@ -185,21 +203,22 @@ class RecordTransformationTest extends TestCase
     /**
      * @throws \ilException
      */
-    public function testInvalidToManyValuesInApplyToMethodCall()
+    public function testInvalidToManyValuesInApplyToMethodCall() : void
     {
         $recordTransformation = new RecordTransformation(
-            array(
+            [
                 'stringTrafo' => new StringTransformation(),
-                'integerTrafo' => new IntegerTransformation())
+                'integerTrafo' => new IntegerTransformation()
+            ]
         );
 
         $result = $recordTransformation->applyTo(
             new Ok(
-                array(
+                [
                     'stringTrafo' => 'hello',
                     'integerTrafo' => 1,
                     'floatTrafo' => 1
-                )
+                ]
             )
         );
 
@@ -209,15 +228,16 @@ class RecordTransformationTest extends TestCase
     /**
      * @throws \ilException
      */
-    public function testApplyThrowsExceptionBecauseKeyIsNotAString()
+    public function testApplyThrowsExceptionBecauseKeyIsNotAString() : void
     {
         $recordTransformation = new RecordTransformation(
-            array(
+            [
                 'stringTrafo' => new StringTransformation(),
-                'integerTrafo' => new IntegerTransformation())
+                'integerTrafo' => new IntegerTransformation()
+            ]
         );
 
-        $result = $recordTransformation->applyTo(new Ok(array('someKey' => 'hello', 1)));
+        $result = $recordTransformation->applyTo(new Ok(['someKey' => 'hello', 1]));
 
         $this->assertTrue($result->isError());
     }

--- a/tests/Refinery/To/Transformation/StringTransformationTest.php
+++ b/tests/Refinery/To/Transformation/StringTransformationTest.php
@@ -1,13 +1,22 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
 /**
- * @author  Niels Theen <ntheen@databay.de>
- */
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\To\Transformation;
-
-require_once('./libs/composer/vendor/autoload.php');
 
 use ILIAS\Data\Result;
 use ILIAS\Refinery\To\Transformation\StringTransformation;
@@ -16,24 +25,21 @@ use UnexpectedValueException;
 
 class StringTransformationTest extends TestCase
 {
-    /**
-     * @var StringTransformation
-     */
-    private $transformation;
+    private StringTransformation $transformation;
 
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->transformation = new StringTransformation();
     }
 
-    public function testStringToStringTransformation()
+    public function testStringToStringTransformation() : void
     {
         $transformedValue = $this->transformation->transform('hello');
 
         $this->assertEquals('hello', $transformedValue);
     }
 
-    public function testIntegerToStringTransformation()
+    public function testIntegerToStringTransformation() : void
     {
         $this->expectNotToPerformAssertions();
 
@@ -46,7 +52,7 @@ class StringTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testNegativeIntegerToIntegerTransformation()
+    public function testNegativeIntegerToIntegerTransformation() : void
     {
         $this->expectNotToPerformAssertions();
 
@@ -59,7 +65,7 @@ class StringTransformationTest extends TestCase
         $this->assertEquals('-200', $transformedValue);
     }
 
-    public function testZeroIntegerToIntegerTransformation()
+    public function testZeroIntegerToIntegerTransformation() : void
     {
         $this->expectNotToPerformAssertions();
 
@@ -72,7 +78,7 @@ class StringTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testFloatToStringTransformation()
+    public function testFloatToStringTransformation() : void
     {
         $this->expectNotToPerformAssertions();
 
@@ -87,7 +93,7 @@ class StringTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testPositiveBooleanToStringTransformation()
+    public function testPositiveBooleanToStringTransformation() : void
     {
         $this->expectNotToPerformAssertions();
 
@@ -100,7 +106,7 @@ class StringTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testNegativeBooleanToStringTransformation()
+    public function testNegativeBooleanToStringTransformation() : void
     {
         $this->expectNotToPerformAssertions();
 
@@ -113,7 +119,7 @@ class StringTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testStringToStringApply()
+    public function testStringToStringApply() : void
     {
         $resultObject = new Result\Ok('hello');
 
@@ -122,7 +128,7 @@ class StringTransformationTest extends TestCase
         $this->assertEquals('hello', $transformedObject->value());
     }
 
-    public function testPositiveIntegerToIntegerApply()
+    public function testPositiveIntegerToIntegerApply() : void
     {
         $resultObject = new Result\Ok(200);
 
@@ -131,7 +137,7 @@ class StringTransformationTest extends TestCase
         $this->assertTrue($transformedObject->isError());
     }
 
-    public function testNegativeIntegerToIntegerApply()
+    public function testNegativeIntegerToIntegerApply() : void
     {
         $resultObject = new Result\Ok(-200);
 
@@ -140,7 +146,7 @@ class StringTransformationTest extends TestCase
         $this->assertTrue($transformedObject->isError());
     }
 
-    public function testZeroIntegerToIntegerApply()
+    public function testZeroIntegerToIntegerApply() : void
     {
         $resultObject = new Result\Ok(0);
 
@@ -149,7 +155,7 @@ class StringTransformationTest extends TestCase
         $this->assertTrue($transformedObject->isError());
     }
 
-    public function testFloatToStringApply()
+    public function testFloatToStringApply() : void
     {
         $resultObject = new Result\Ok(10.5);
 
@@ -158,7 +164,7 @@ class StringTransformationTest extends TestCase
         $this->assertTrue($transformedObject->isError());
     }
 
-    public function testBooleanToStringApply()
+    public function testBooleanToStringApply() : void
     {
         $resultObject = new Result\Ok(true);
 

--- a/tests/Refinery/To/Transformation/TupleTransformationTest.php
+++ b/tests/Refinery/To/Transformation/TupleTransformationTest.php
@@ -1,9 +1,20 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
 /**
- * @author  Niels Theen <ntheen@databay.de>
- */
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\To\Transformation;
 
@@ -15,34 +26,32 @@ use ILIAS\Refinery\IsArrayOfSameType;
 use ILIAS\Tests\Refinery\TestCase;
 use UnexpectedValueException;
 
-require_once('./libs/composer/vendor/autoload.php');
-
 class TupleTransformationTest extends TestCase
 {
     /**
      * @throws \ilException
      */
-    public function testTupleTransformationsAreCorrect()
+    public function testTupleTransformationsAreCorrect() : void
     {
         $transformation = new TupleTransformation(
-            array(new IntegerTransformation(), new IntegerTransformation())
+            [new IntegerTransformation(), new IntegerTransformation()]
         );
 
-        $result = $transformation->transform(array(1, 2));
+        $result = $transformation->transform([1, 2]);
 
-        $this->assertEquals(array(1, 2), $result);
+        $this->assertEquals([1, 2], $result);
     }
 
-    public function testTupleIsIncorrectAndWillThrowException()
+    public function testTupleIsIncorrectAndWillThrowException() : void
     {
         $this->expectNotToPerformAssertions();
 
         $transformation = new TupleTransformation(
-            array(new IntegerTransformation(), new StringTransformation())
+            [new IntegerTransformation(), new StringTransformation()]
         );
 
         try {
-            $result = $transformation->transform(array(1, 2));
+            $result = $transformation->transform([1, 2]);
         } catch (UnexpectedValueException $exception) {
             return;
         }
@@ -50,16 +59,16 @@ class TupleTransformationTest extends TestCase
         $this->fail();
     }
 
-    public function testTupleIsIncorrectAndWillThrowException2()
+    public function testTupleIsIncorrectAndWillThrowException2() : void
     {
         $this->expectNotToPerformAssertions();
 
         $transformation = new TupleTransformation(
-            array(new IntegerTransformation(), 'hello' => new IntegerTransformation())
+            [new IntegerTransformation(), 'hello' => new IntegerTransformation()]
         );
 
         try {
-            $result = $transformation->transform(array(1, 2));
+            $result = $transformation->transform([1, 2]);
         } catch (UnexpectedValueException $exception) {
             return;
         }
@@ -68,62 +77,62 @@ class TupleTransformationTest extends TestCase
     }
 
 
-    public function testToManyValuesForTransformation()
+    public function testToManyValuesForTransformation() : void
     {
         $this->expectNotToPerformAssertions();
 
         $transformation = new TupleTransformation(
-            array(new IntegerTransformation(), new IntegerTransformation())
+            [new IntegerTransformation(), new IntegerTransformation()]
         );
 
         try {
-            $result = $transformation->transform(array(1, 2, 3));
+            $result = $transformation->transform([1, 2, 3]);
         } catch (UnexpectedValueException $exception) {
             return;
         }
         $this->fail();
     }
 
-    public function testTupleAppliesAreCorrect()
+    public function testTupleAppliesAreCorrect() : void
     {
         $transformation = new TupleTransformation(
-            array(new IntegerTransformation(), new IntegerTransformation())
+            [new IntegerTransformation(), new IntegerTransformation()]
         );
 
-        $result = $transformation->applyTo(new Result\Ok(array(1, 2)));
+        $result = $transformation->applyTo(new Result\Ok([1, 2]));
 
-        $this->assertEquals(array(1, 2), $result->value());
+        $this->assertEquals([1, 2], $result->value());
     }
 
-    public function testTupleAppliesAreIncorrectAndWillReturnErrorResult()
+    public function testTupleAppliesAreIncorrectAndWillReturnErrorResult() : void
     {
         $transformation = new TupleTransformation(
-            array(new IntegerTransformation(), new StringTransformation())
+            [new IntegerTransformation(), new StringTransformation()]
         );
 
-        $result = $transformation->applyTo(new Result\Ok(array(1, 2)));
+        $result = $transformation->applyTo(new Result\Ok([1, 2]));
 
         $this->assertTrue($result->isError());
     }
 
-    public function testToManyValuesForApply()
+    public function testToManyValuesForApply() : void
     {
         $transformation = new TupleTransformation(
-            array(new IntegerTransformation(), new StringTransformation())
+            [new IntegerTransformation(), new StringTransformation()]
         );
 
-        $result = $transformation->applyTo(new Result\Ok(array(1, 2, 3)));
+        $result = $transformation->applyTo(new Result\Ok([1, 2, 3]));
 
         $this->assertTrue($result->isError());
     }
 
-    public function testInvalidTransformationWillThrowException()
+    public function testInvalidTransformationWillThrowException() : void
     {
         $this->expectNotToPerformAssertions();
 
         try {
             $transformation = new TupleTransformation(
-                array(new IntegerTransformation(), 'hello')
+                [new IntegerTransformation(), 'hello']
             );
         } catch (UnexpectedValueException $exception) {
             return;

--- a/tests/Refinery/URI/GroupTest.php
+++ b/tests/Refinery/URI/GroupTest.php
@@ -1,25 +1,32 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
 /**
- * @author  Niels Theen <ntheen@databay.de>
- */
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\URI;
 
-require_once('./libs/composer/vendor/autoload.php');
-
-namespace ILIAS\Tests\Refinery\URI;
-
-use ILIAS\Refinery\URI\Group;
+use ILIAS\Refinery\URI\Group as URIGroup;
 use ILIAS\Refinery\URI\StringTransformation;
 use ILIAS\Tests\Refinery\TestCase;
 
 class GroupTest extends TestCase
 {
-    public function testStringTransformationInstance()
+    public function testStringTransformationInstance() : void
     {
-        $group = new Group();
+        $group = new URIGroup();
         $transformation = $group->toString();
         $this->assertInstanceOf(StringTransformation::class, $transformation);
     }

--- a/tests/Refinery/URI/StringTransformationTest.php
+++ b/tests/Refinery/URI/StringTransformationTest.php
@@ -1,13 +1,22 @@
-<?php
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
 /**
- * @author  Niels Theen <ntheen@databay.de>
- */
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Tests\Refinery\URI;
-
-require_once('./libs/composer/vendor/autoload.php');
 
 use ILIAS\Data\URI;
 use ILIAS\Refinery\ConstraintViolationException;
@@ -16,17 +25,14 @@ use ILIAS\Tests\Refinery\TestCase;
 
 class StringTransformationTest extends TestCase
 {
-    /**
-     * @var StringTransformation
-     */
-    private $transformation;
+    private StringTransformation $transformation;
 
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->transformation = new StringTransformation();
     }
-
-    public function testSimpleUri()
+    
+    public function testSimpleUri() : void
     {
         $uri = new URI('http://ilias.de');
         $transformedValue = $this->transformation->transform($uri);
@@ -34,7 +40,7 @@ class StringTransformationTest extends TestCase
         $this->assertEquals('http://ilias.de', $transformedValue);
     }
 
-    public function testUriWithPath()
+    public function testUriWithPath() : void
     {
         $uri = new URI('http://ilias.de/with/path');
         $transformedValue = $this->transformation->transform($uri);
@@ -42,7 +48,7 @@ class StringTransformationTest extends TestCase
         $this->assertEquals('http://ilias.de/with/path', $transformedValue);
     }
 
-    public function testUriWithFragment()
+    public function testUriWithFragment() : void
     {
         $uri = new URI('http://ilias.de/test.php#title');
         $transformedValue = $this->transformation->transform($uri);
@@ -50,7 +56,7 @@ class StringTransformationTest extends TestCase
         $this->assertEquals('http://ilias.de/test.php#title', $transformedValue);
     }
 
-    public function testSimpleUriWithQueryParameter()
+    public function testSimpleUriWithQueryParameter() : void
     {
         $uri = new URI('http://ilias.de?test=something&further=1');
         $transformedValue = $this->transformation->transform($uri);
@@ -58,7 +64,7 @@ class StringTransformationTest extends TestCase
         $this->assertEquals('http://ilias.de?test=something&further=1', $transformedValue);
     }
 
-    public function testUriWithQueryPathAndParameter()
+    public function testUriWithQueryPathAndParameter() : void
     {
         $uri = new URI('http://ilias.de/with/path?test=something&further=1');
         $transformedValue = $this->transformation->transform($uri);
@@ -66,7 +72,7 @@ class StringTransformationTest extends TestCase
         $this->assertEquals('http://ilias.de/with/path?test=something&further=1', $transformedValue);
     }
 
-    public function testTransformNotURIObjectFails()
+    public function testTransformNotURIObjectFails() : void
     {
         $this->expectException(ConstraintViolationException::class);
         $transformedValue = $this->transformation->transform('http://ilias.de');


### PR DESCRIPTION
This PR ...

- applies changes in regards to the feedback given in #4313 
- replaces the licenses header in all `src/Refinery` and `tests/Refinery` files
- uses interface types as return type declarations where appropriate (e.g. in `Groups`) and **not** concrete implementations
- streamlines the code (usages of `PHPDocs`, array syntax, types for closures, etc.)