### PR TITLE
rollback of rbac_.. to rbac.. name change

### DIFF
--- a/Modules/Chatroom/classes/class.ilObjChatroom.php
+++ b/Modules/Chatroom/classes/class.ilObjChatroom.php
@@ -176,7 +176,7 @@ class ilObjChatroom extends ilObject
 
         $room->saveSettings($original_settings);
 
-        $rbac_log_roles = $this->rbac_review->getParentRoleIds($newObj->getRefId(), false);
+        $rbac_log_roles = $this->rbacreview->getParentRoleIds($newObj->getRefId(), false);
         $rbac_log = ilRbacLog::gatherFaPa($newObj->getRefId(), array_keys($rbac_log_roles), true);
         ilRbacLog::add(ilRbacLog::CREATE_OBJECT, $newObj->getRefId(), $rbac_log);
 

--- a/Modules/Chatroom/classes/class.ilObjChatroomGUI.php
+++ b/Modules/Chatroom/classes/class.ilObjChatroomGUI.php
@@ -301,7 +301,7 @@ class ilObjChatroomGUI extends ilChatroomObjectGUI implements ilCtrlSecurityInte
 
         // create permission is already checked in createObject.
         // This check here is done to prevent hacking attempts
-        if (!$this->rbac_system->checkAccess('create', $refId, $new_type)) {
+        if (!$this->rbacsystem->checkAccess('create', $refId, $new_type)) {
             $this->ilias->raiseError(
                 $this->lng->txt('no_create_permission'),
                 $this->ilias->error_obj->MESSAGE
@@ -330,7 +330,7 @@ class ilObjChatroomGUI extends ilChatroomObjectGUI implements ilCtrlSecurityInte
             'private_rooms_enabled' => 0
         ]);
 
-        $rbac_log_roles = $this->rbac_review->getParentRoleIds($newObj->getRefId());
+        $rbac_log_roles = $this->rbacreview->getParentRoleIds($newObj->getRefId());
         $rbac_log = ilRbacLog::gatherFaPa($newObj->getRefId(), array_keys($rbac_log_roles), true);
         ilRbacLog::add(ilRbacLog::CREATE_OBJECT, $newObj->getRefId(), $rbac_log);
 

--- a/Modules/ContentPage/classes/class.ilObjContentPageAdministrationGUI.php
+++ b/Modules/ContentPage/classes/class.ilObjContentPageAdministrationGUI.php
@@ -55,11 +55,11 @@ class ilObjContentPageAdministrationGUI extends ilObjectGUI
 
     public function getAdminTabs() : void
     {
-        if ($this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess('visible,read', $this->object->getRefId())) {
             $this->tabs_gui->addTarget('settings', $this->ctrl->getLinkTargetByClass(self::class, self::CMD_EDIT));
         }
 
-        if ($this->rbac_system->checkAccess('edit_permission', $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess('edit_permission', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 'perm_settings',
                 $this->ctrl->getLinkTargetByClass(ilPermissionGUI::class, 'perm'),
@@ -71,7 +71,7 @@ class ilObjContentPageAdministrationGUI extends ilObjectGUI
 
     public function executeCommand() : void
     {
-        if (!$this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess('visible,read', $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 

--- a/Modules/Course/classes/class.ilObjCourse.php
+++ b/Modules/Course/classes/class.ilObjCourse.php
@@ -816,7 +816,7 @@ class ilObjCourse extends ilContainer implements ilMembershipRegistrationCodes
         if (!$admin || !$new_admin || !$this->getRefId() || !$new_obj->getRefId()) {
             $this->course_logger->debug('Error cloning auto generated role: il_crs_admin');
         }
-        $this->rbac_admin->copyRolePermissions($admin, $this->getRefId(), $new_obj->getRefId(), $new_admin, true);
+        $this->rbacadmin->copyRolePermissions($admin, $this->getRefId(), $new_obj->getRefId(), $new_admin, true);
         $this->course_logger->debug('Finished copying of role crs_admin.');
 
         $tutor = $this->getDefaultTutorRole();
@@ -824,7 +824,7 @@ class ilObjCourse extends ilContainer implements ilMembershipRegistrationCodes
         if (!$tutor || !$new_tutor) {
             $this->course_logger->info('Error cloning auto generated role: il_crs_tutor');
         }
-        $this->rbac_admin->copyRolePermissions($tutor, $this->getRefId(), $new_obj->getRefId(), $new_tutor, true);
+        $this->rbacadmin->copyRolePermissions($tutor, $this->getRefId(), $new_obj->getRefId(), $new_tutor, true);
         $this->course_logger->info('Finished copying of role crs_tutor.');
 
         $member = $this->getDefaultMemberRole();
@@ -832,7 +832,7 @@ class ilObjCourse extends ilContainer implements ilMembershipRegistrationCodes
         if (!$member || !$new_member) {
             $this->course_logger->debug('Error cloning auto generated role: il_crs_member');
         }
-        $this->rbac_admin->copyRolePermissions($member, $this->getRefId(), $new_obj->getRefId(), $new_member, true);
+        $this->rbacadmin->copyRolePermissions($member, $this->getRefId(), $new_obj->getRefId(), $new_member, true);
         $this->course_logger->debug('Finished copying of role crs_member.');
     }
 
@@ -1294,9 +1294,9 @@ class ilObjCourse extends ilContainer implements ilMembershipRegistrationCodes
      */
     public function setParentRolePermissions(int $a_parent_ref) : bool
     {
-        $parent_roles = $this->rbac_review->getParentRoleIds($a_parent_ref);
+        $parent_roles = $this->rbacreview->getParentRoleIds($a_parent_ref);
         foreach ($parent_roles as $parent_role) {
-            $this->rbac_admin->initIntersectionPermissions(
+            $this->rbacadmin->initIntersectionPermissions(
                 $this->getRefId(),
                 $parent_role['obj_id'],
                 $parent_role['parent'],
@@ -1340,10 +1340,10 @@ class ilObjCourse extends ilContainer implements ilMembershipRegistrationCodes
     {
         if (empty($this->local_roles)) {
             $this->local_roles = array();
-            $role_arr = $this->rbac_review->getRolesOfRoleFolder($this->getRefId());
+            $role_arr = $this->rbacreview->getRolesOfRoleFolder($this->getRefId());
 
             foreach ($role_arr as $role_id) {
-                if ($this->rbac_review->isAssignable($role_id, $this->getRefId()) == true) {
+                if ($this->rbacreview->isAssignable($role_id, $this->getRefId()) == true) {
                     $role_Obj = ilObjectFactory::getInstanceByObjId($role_id);
                     if ($a_translate) {
                         $role_name = ilObjRole::_getTranslation($role_Obj->getTitle());
@@ -1373,7 +1373,7 @@ class ilObjCourse extends ilContainer implements ilMembershipRegistrationCodes
             $crs_id = $this->getRefId();
         }
 
-        $role_arr = $this->rbac_review->getRolesOfRoleFolder($crs_id);
+        $role_arr = $this->rbacreview->getRolesOfRoleFolder($crs_id);
 
         $arr_crsDefaultRoles = [];
         foreach ($role_arr as $role_id) {
@@ -1404,7 +1404,7 @@ class ilObjCourse extends ilContainer implements ilMembershipRegistrationCodes
      */
     public function __getLocalRoles() : array
     {
-        return $this->rbac_review->getRolesOfRoleFolder($this->getRefId(), false);
+        return $this->rbacreview->getRolesOfRoleFolder($this->getRefId(), false);
     }
 
     public function __deleteSettings() : void

--- a/Modules/Course/classes/class.ilObjCourseGUI.php
+++ b/Modules/Course/classes/class.ilObjCourseGUI.php
@@ -2237,7 +2237,7 @@ class ilObjCourseGUI extends ilContainerGUI
                 if (
                     !($this->object->getMailToMembersType() == ilCourseConstants::MAIL_ALLOWED_ALL ||
                         $this->access->checkAccess('manage_members', "", $this->object->getRefId())) &&
-                    $this->rbac_system->checkAccess('internal_mail', $mail->getMailObjectReferenceId())) {
+                    $this->rbacsystem->checkAccess('internal_mail', $mail->getMailObjectReferenceId())) {
                     $this->error->raiseError($this->lng->txt("msg_no_perm_read"), $this->error->MESSAGE);
                 }
 
@@ -2345,7 +2345,7 @@ class ilObjCourseGUI extends ilContainerGUI
                     && !$this->access->checkAccess("read", '', $this->object->getRefId())
                     || $cmd == 'join'
                     || $cmd == 'subscribe') {
-                    if ($this->rbac_system->checkAccess('join', $this->object->getRefId()) &&
+                    if ($this->rbacsystem->checkAccess('join', $this->object->getRefId()) &&
                         !ilCourseParticipants::_isParticipant($this->object->getRefId(), $this->user->getId())) {
                         $this->ctrl->redirectByClass("ilCourseRegistrationGUI");
                     } else {
@@ -2717,7 +2717,7 @@ class ilObjCourseGUI extends ilContainerGUI
             $settings = ilMemberViewSettings::getInstance();
             if ($settings->isActive() && $settings->getContainer() != $this->object->getRefId()) {
                 $settings->setContainer($this->object->getRefId());
-                $this->rbac_system->initMemberView();
+                $this->rbacsystem->initMemberView();
             }
         }
         return parent::prepareOutput($show_subobjects);

--- a/Modules/DataCollection/classes/Table/class.ilDclTableHelper.php
+++ b/Modules/DataCollection/classes/Table/class.ilDclTableHelper.php
@@ -18,7 +18,7 @@ class ilDclTableHelper
     /**
      * @var ilRbacReview
      */
-    protected $rbac_review;
+    protected $rbacreview;
     /**
      * @var ilObjUser
      */
@@ -32,20 +32,20 @@ class ilDclTableHelper
      * ilDclTableHelper constructor.
      * @param int           $obj_id
      * @param int           $ref_id
-     * @param ilRbacReview  $rbac_review
+     * @param ilRbacReview  $rbacreview
      * @param ilObjUser     $user
      * @param ilDBInterface $database
      */
     public function __construct(
         int $obj_id,
         int $ref_id,
-        ilRbacReview $rbac_review,
+        ilRbacReview $rbacreview,
         ilObjUser $user,
         ilDBInterface $database
     ) {
         $this->obj_id = $obj_id;
         $this->ref_id = $ref_id;
-        $this->rbac_review = $rbac_review;
+        $this->rbacreview = $rbacreview;
         $this->user = $user;
         $this->database = $database;
     }
@@ -65,7 +65,7 @@ class ilDclTableHelper
         //check if there are roles with rbac read right on the datacollection but without read right on any table view
         $roles_with_no_read_right_on_any_standard_view = array_diff($roles_with_read_acces_ids, $roles_ids);
 
-        $roles_data = $this->rbac_review->getRolesForIDs($roles_with_no_read_right_on_any_standard_view, true);
+        $roles_data = $this->rbacreview->getRolesForIDs($roles_with_no_read_right_on_any_standard_view, true);
         $role_titles = [];
         if (!empty($roles_data)) {
             foreach ($roles_data as $role_data) {
@@ -81,11 +81,11 @@ class ilDclTableHelper
      */
     protected function getRolesIdsWithReadAccessOnDataCollection()
     {
-        $rbac_roles = $this->rbac_review->getParentRoleIds($this->ref_id);
+        $rbac_roles = $this->rbacreview->getParentRoleIds($this->ref_id);
         $roles_with_read_acces_ids = [];
         //get all roles with read access on data collection
         foreach ($rbac_roles as $role) {
-            $operations = $this->rbac_review->getActiveOperationsOfRole($this->ref_id, $role['rol_id']);
+            $operations = $this->rbacreview->getActiveOperationsOfRole($this->ref_id, $role['rol_id']);
             //3 corresponds to the read rbac right
             if (!empty($operations) && in_array(3, $operations)) {
                 $roles_with_read_acces_ids[] = $role['rol_id'];
@@ -167,7 +167,7 @@ class ilDclTableHelper
 
         $user_ids_with_read_right_on_any_standard_view = [];
         foreach ($roles_ids as $role_id) {
-            $assigned_users = $this->rbac_review->assignedUsers($role_id);
+            $assigned_users = $this->rbacreview->assignedUsers($role_id);
             if (!empty($assigned_users)) {
                 $user_ids_with_read_right_on_any_standard_view[] = array_merge($user_ids_with_read_right_on_any_standard_view,
                     $assigned_users);

--- a/Modules/Group/classes/class.ilObjGroup.php
+++ b/Modules/Group/classes/class.ilObjGroup.php
@@ -744,7 +744,7 @@ class ilObjGroup extends ilContainer implements ilMembershipRegistrationCodes
         if (!$admin || !$new_admin || !$this->getRefId() || !$new_obj->getRefId()) {
             $this->logger->warning('Error cloning auto generated rol: il_grp_admin');
         }
-        $this->rbac_admin->copyRolePermissions($admin, $this->getRefId(), $new_obj->getRefId(), $new_admin, true);
+        $this->rbacadmin->copyRolePermissions($admin, $this->getRefId(), $new_obj->getRefId(), $new_admin, true);
         $this->logger->info('Finished copying of role il_grp_admin.');
 
         $member = $this->getDefaultMemberRole();
@@ -752,7 +752,7 @@ class ilObjGroup extends ilContainer implements ilMembershipRegistrationCodes
         if (!$member || !$new_member) {
             $this->logger->warning('Error cloning auto generated rol: il_grp_member');
         }
-        $this->rbac_admin->copyRolePermissions($member, $this->getRefId(), $new_obj->getRefId(), $new_member, true);
+        $this->rbacadmin->copyRolePermissions($member, $this->getRefId(), $new_obj->getRefId(), $new_member, true);
         $this->logger->info('Finished copying of role il_grp_member.');
     }
 
@@ -797,7 +797,7 @@ class ilObjGroup extends ilContainer implements ilMembershipRegistrationCodes
     {
         $arr_groupRoles = $this->getMemberRoles($a_user_id);
         foreach ($arr_groupRoles as $groupRole) {
-            $this->rbac_admin->deassignUser($groupRole, $a_user_id);
+            $this->rbacadmin->deassignUser($groupRole, $a_user_id);
         }
         return true;
     }
@@ -813,7 +813,7 @@ class ilObjGroup extends ilContainer implements ilMembershipRegistrationCodes
         $rol = $this->getLocalGroupRoles();
         $mem_arr = [];
         foreach ($rol as $value) {
-            foreach ($this->rbac_review->assignedUsers($value) as $member_id) {
+            foreach ($this->rbacreview->assignedUsers($value) as $member_id) {
                 array_push($usr_arr, $member_id);
             }
         }
@@ -867,7 +867,7 @@ class ilObjGroup extends ilContainer implements ilMembershipRegistrationCodes
         $usr_arr = array();
         $roles = $this->getDefaultGroupRoles();
 
-        foreach ($this->rbac_review->assignedUsers($this->getDefaultAdminRole()) as $member_id) {
+        foreach ($this->rbacreview->assignedUsers($this->getDefaultAdminRole()) as $member_id) {
             array_push($usr_arr, $member_id);
         }
         return $usr_arr;
@@ -880,7 +880,7 @@ class ilObjGroup extends ilContainer implements ilMembershipRegistrationCodes
     protected function getDefaultGroupRoles() : array
     {
         $grp_id = $this->getRefId();
-        $role_arr = $this->rbac_review->getRolesOfRoleFolder($grp_id);
+        $role_arr = $this->rbacreview->getRolesOfRoleFolder($grp_id);
         $arr_grpDefaultRoles = [];
         foreach ($role_arr as $role_id) {
             $role = ilObjectFactory::getInstanceByObjId($role_id, false);
@@ -907,10 +907,10 @@ class ilObjGroup extends ilContainer implements ilMembershipRegistrationCodes
     {
         if (empty($this->local_roles)) {
             $this->local_roles = array();
-            $role_arr = $this->rbac_review->getRolesOfRoleFolder($this->getRefId());
+            $role_arr = $this->rbacreview->getRolesOfRoleFolder($this->getRefId());
 
             foreach ($role_arr as $role_id) {
-                if ($this->rbac_review->isAssignable($role_id, $this->getRefId()) == true) {
+                if ($this->rbacreview->isAssignable($role_id, $this->getRefId()) == true) {
                     $role = ilObjectFactory::getInstanceByObjId($role_id, false);
                     if ($a_translate) {
                         $role_name = ilObjRole::_getTranslation($role->getTitle());
@@ -1021,7 +1021,7 @@ class ilObjGroup extends ilContainer implements ilMembershipRegistrationCodes
     public function getMemberRoles(int $a_user_id) : array
     {
         return array_intersect(
-            $this->rbac_review->assignedRoles($a_user_id),
+            $this->rbacreview->assignedRoles($a_user_id),
             $this->getLocalGroupRoles()
         );
     }
@@ -1029,7 +1029,7 @@ class ilObjGroup extends ilContainer implements ilMembershipRegistrationCodes
     public function isAdmin(int $a_userId) : bool
     {
         $grp_Roles = $this->getDefaultGroupRoles();
-        if (in_array($a_userId, $this->rbac_review->assignedUsers($grp_Roles["grp_admin_role"]))) {
+        if (in_array($a_userId, $this->rbacreview->assignedUsers($grp_Roles["grp_admin_role"]))) {
             return true;
         } else {
             return false;
@@ -1067,18 +1067,18 @@ class ilObjGroup extends ilContainer implements ilMembershipRegistrationCodes
      */
     public function setParentRolePermissions(int $a_parent_ref) : bool
     {
-        $parent_roles = $this->rbac_review->getParentRoleIds($a_parent_ref);
+        $parent_roles = $this->rbacreview->getParentRoleIds($a_parent_ref);
         foreach ($parent_roles as $parent_role) {
             if ($parent_role['parent'] == $this->getRefId()) {
                 continue;
             }
-            if ($this->rbac_review->isProtected((int) $parent_role['parent'], (int) $parent_role['rol_id'])) {
-                $operations = $this->rbac_review->getOperationsOfRole(
+            if ($this->rbacreview->isProtected((int) $parent_role['parent'], (int) $parent_role['rol_id'])) {
+                $operations = $this->rbacreview->getOperationsOfRole(
                     (int) $parent_role['obj_id'],
                     $this->getType(),
                     (int) $parent_role['parent']
                 );
-                $this->rbac_admin->grantPermission(
+                $this->rbacadmin->grantPermission(
                     (int) $parent_role['obj_id'],
                     $operations,
                     $this->getRefId()
@@ -1086,7 +1086,7 @@ class ilObjGroup extends ilContainer implements ilMembershipRegistrationCodes
                 continue;
             }
 
-            $this->rbac_admin->initIntersectionPermissions(
+            $this->rbacadmin->initIntersectionPermissions(
                 $this->getRefId(),
                 (int) $parent_role['obj_id'],
                 (int) $parent_role['parent'],
@@ -1129,8 +1129,8 @@ class ilObjGroup extends ilContainer implements ilMembershipRegistrationCodes
 
     public function _isMember(int $a_user_id, int $a_ref_id, string $a_field = '') : bool
     {
-        $local_roles = $this->rbac_review->getRolesOfRoleFolder($a_ref_id, false);
-        $user_roles = $this->rbac_review->assignedRoles($a_user_id);
+        $local_roles = $this->rbacreview->getRolesOfRoleFolder($a_ref_id, false);
+        $user_roles = $this->rbacreview->assignedRoles($a_user_id);
 
         // Used for membership limitations -> check membership by given field
         if ($a_field) {
@@ -1176,11 +1176,11 @@ class ilObjGroup extends ilContainer implements ilMembershipRegistrationCodes
         $ref_ids = ilObject::_getAllReferences($a_obj_id);
         $ref_id = current($ref_ids);
 
-        $local_roles = $this->rbac_review->getRolesOfRoleFolder($ref_id, false);
+        $local_roles = $this->rbacreview->getRolesOfRoleFolder($ref_id, false);
 
         $users = array();
         foreach ($local_roles as $role_id) {
-            $users = array_merge($users, $this->rbac_review->assignedUsers($role_id));
+            $users = array_merge($users, $this->rbacreview->assignedUsers($role_id));
         }
         return array_unique($users);
     }

--- a/Modules/HTMLLearningModule/classes/class.ilObjFileBasedLMGUI.php
+++ b/Modules/HTMLLearningModule/classes/class.ilObjFileBasedLMGUI.php
@@ -361,7 +361,7 @@ class ilObjFileBasedLMGUI extends ilObjectGUI
 
     public function editObject() : void
     {
-        if (!$this->rbac_system->checkAccess("visible,write", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("visible,write", $this->object->getRefId())) {
             throw new ilPermissionException($this->lng->txt("permission_denied"));
         }
     }

--- a/Modules/IndividualAssessment/test/AccessControl/ilIndividualAssessmentAccessHandlerTest.php
+++ b/Modules/IndividualAssessment/test/AccessControl/ilIndividualAssessmentAccessHandlerTest.php
@@ -18,11 +18,11 @@ class ilIndividualAssessmentAccessHandlerTest extends TestCase
     /**
      * @var ilRbacAdmin|mixed|MockObject
      */
-    private $rbac_admin;
+    private $rbacadmin;
     /**
      * @var ilRbacReview|mixed|MockObject
      */
-    private $rbac_review;
+    private $rbacreview;
     /**
      * @var ilObjUser|mixed|MockObject
      */
@@ -32,8 +32,8 @@ class ilIndividualAssessmentAccessHandlerTest extends TestCase
     {
         $this->iass_object = $this->createMock(ilObjIndividualAssessment::class);
         $this->access_handler = $this->createMock(ilAccessHandler::class);
-        $this->rbac_admin = $this->createMock(ilRbacAdmin::class);
-        $this->rbac_review = $this->createMock(ilRbacReview::class);
+        $this->rbacadmin = $this->createMock(ilRbacAdmin::class);
+        $this->rbacreview = $this->createMock(ilRbacReview::class);
         $this->obj_user = $this->createMock(ilObjUser::class);
     }
 
@@ -42,8 +42,8 @@ class ilIndividualAssessmentAccessHandlerTest extends TestCase
         $obj = new ilIndividualAssessmentAccessHandler(
             $this->iass_object,
             $this->access_handler,
-            $this->rbac_admin,
-            $this->rbac_review,
+            $this->rbacadmin,
+            $this->rbacreview,
             $this->obj_user
         );
 

--- a/Modules/LearningModule/classes/class.ilObjLearningResourcesSettingsGUI.php
+++ b/Modules/LearningModule/classes/class.ilObjLearningResourcesSettingsGUI.php
@@ -53,7 +53,7 @@ class ilObjLearningResourcesSettingsGUI extends ilObjectGUI
 
         $this->prepareOutput();
 
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             throw new ilPermissionException($this->lng->txt('no_permission'));
         }
 
@@ -75,9 +75,9 @@ class ilObjLearningResourcesSettingsGUI extends ilObjectGUI
 
     public function getAdminTabs() : void
     {
-        $rbac_system = $this->rbac_system;
+        $rbacsystem = $this->rbacsystem;
 
-        if ($rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "cont_edit_lrs_settings",
                 $this->ctrl->getLinkTarget($this, "editSettings"),
@@ -85,7 +85,7 @@ class ilObjLearningResourcesSettingsGUI extends ilObjectGUI
             );
         }
 
-        if ($rbac_system->checkAccess('edit_permission', $this->object->getRefId())) {
+        if ($rbacsystem->checkAccess('edit_permission', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "perm_settings",
                 $this->ctrl->getLinkTargetByClass('ilpermissiongui', "perm"),

--- a/Modules/LearningSequence/classes/Members/class.ilLearningSequenceMembershipGUI.php
+++ b/Modules/LearningSequence/classes/Members/class.ilLearningSequenceMembershipGUI.php
@@ -33,7 +33,7 @@ class ilLearningSequenceMembershipGUI extends ilMembershipGUI
     protected ilObject $obj;
     protected ilObjUserTracking $obj_user_tracking;
     protected ilPrivacySettings $privacy_settings;
-    protected ilRbacReview $rbac_review;
+    protected ilRbacReview $rbacreview;
     protected ilSetting $settings;
     protected ilToolbarGUI $toolbar;
     protected ILIAS\HTTP\Wrapper\RequestWrapper $request_wrapper;
@@ -45,7 +45,7 @@ class ilLearningSequenceMembershipGUI extends ilMembershipGUI
         ilObject $obj,
         ilObjUserTracking $obj_user_tracking,
         ilPrivacySettings $privacy_settings,
-        ilRbacReview $rbac_review,
+        ilRbacReview $rbacreview,
         ilSetting $settings,
         ilToolbarGUI $toolbar,
         ILIAS\HTTP\Wrapper\RequestWrapper $request_wrapper,
@@ -57,7 +57,7 @@ class ilLearningSequenceMembershipGUI extends ilMembershipGUI
         $this->obj = $obj;
         $this->obj_user_tracking = $obj_user_tracking;
         $this->privacy_settings = $privacy_settings;
-        $this->rbac_review = $rbac_review;
+        $this->rbacreview = $rbacreview;
         $this->settings = $settings;
         $this->toolbar = $toolbar;
         $this->request_wrapper = $request_wrapper;
@@ -214,7 +214,7 @@ class ilLearningSequenceMembershipGUI extends ilMembershipGUI
             $this->privacy_settings,
             $this->lng,
             $this->access,
-            $this->rbac_review,
+            $this->rbacreview,
             $this->settings
         );
     }

--- a/Modules/LearningSequence/classes/Members/class.ilLearningSequenceParticipantsTableGUI.php
+++ b/Modules/LearningSequence/classes/Members/class.ilLearningSequenceParticipantsTableGUI.php
@@ -23,7 +23,7 @@ class ilLearningSequenceParticipantsTableGUI extends ilParticipantTableGUI
     protected ilObjUserTracking $obj_user_tracking;
     protected ilPrivacySettings $privacy_settings;
     protected ilAccess $access;
-    protected ilRbacReview $rbac_review;
+    protected ilRbacReview $rbacreview;
     protected ilSetting $settings;
 
     public function __construct(
@@ -33,7 +33,7 @@ class ilLearningSequenceParticipantsTableGUI extends ilParticipantTableGUI
         ilPrivacySettings $privacy_settings,
         ilLanguage $lng,
         ilAccess $access,
-        ilRbacReview $rbac_review,
+        ilRbacReview $rbacreview,
         ilSetting $settings
     ) {
         $this->parent_gui = $parent_gui;
@@ -43,7 +43,7 @@ class ilLearningSequenceParticipantsTableGUI extends ilParticipantTableGUI
         $this->privacy_settings = $privacy_settings;
         $this->lng = $lng;
         $this->access = $access;
-        $this->rbac_review = $rbac_review;
+        $this->rbacreview = $rbacreview;
         $this->settings = $settings;
 
         $this->lng->loadLanguageModule('lso');
@@ -325,7 +325,7 @@ class ilLearningSequenceParticipantsTableGUI extends ilParticipantTableGUI
             $user_id = $ud['usr_id'];
 
             if ($this->current_filter['roles']) {
-                if (!$this->rbac_review->isAssigned($user_id, $this->current_filter['roles'])) {
+                if (!$this->rbacreview->isAssigned($user_id, $this->current_filter['roles'])) {
                     continue;
                 }
             }
@@ -344,7 +344,7 @@ class ilLearningSequenceParticipantsTableGUI extends ilParticipantTableGUI
 
             $roles = array();
             foreach ($local_roles as $role_id => $role_name) {
-                if ($this->rbac_review->isAssigned((int) $user_id, $role_id)) {
+                if ($this->rbacreview->isAssigned($user_id, $role_id)) {
                     $roles[] = $role_name;
                 }
             }

--- a/Modules/LearningSequence/classes/Xml/class.ilLearningSequenceXMLWriter.php
+++ b/Modules/LearningSequence/classes/Xml/class.ilLearningSequenceXMLWriter.php
@@ -21,19 +21,19 @@ class ilLearningSequenceXMLWriter extends ilXmlWriter
     protected ilObjLearningSequence $ls_object;
     protected ilSetting $settings;
     protected ilLPObjSettings $lp_settings;
-    protected ilRbacReview $rbac_review;
+    protected ilRbacReview $rbacreview;
     protected ilLearningSequenceSettings $ls_settings;
 
     public function __construct(
         ilObjLearningSequence $ls_object,
         ilSetting $settings,
         ilLPObjSettings $lp_settings,
-        ilRbacReview $rbac_review
+        ilRbacReview $rbacreview
     ) {
         $this->ls_object = $ls_object;
         $this->settings = $settings;
         $this->lp_settings = $lp_settings;
-        $this->rbac_review = $rbac_review;
+        $this->rbacreview = $rbacreview;
 
         $this->ls_settings = $ls_object->getLSSettings();
     }

--- a/Modules/LearningSequence/classes/class.ilLearningSequenceExporter.php
+++ b/Modules/LearningSequence/classes/class.ilLearningSequenceExporter.php
@@ -19,14 +19,14 @@
 class ilLearningSequenceExporter extends ilXmlExporter
 {
     protected ilSetting $settings;
-    protected ilRbacReview $rbac_review;
+    protected ilRbacReview $rbacreview;
 
     public function init() : void
     {
         global $DIC;
 
         $this->settings = $DIC["ilSetting"];
-        $this->rbac_review = $DIC["rbacreview"];
+        $this->rbacreview = $DIC["rbacreview"];
     }
 
     public function getXmlRepresentation(string $a_entity, string $a_schema_version, string $a_id) : string
@@ -58,7 +58,7 @@ class ilLearningSequenceExporter extends ilXmlExporter
             $ls_object,
             $this->settings,
             $lp_settings,
-            $this->rbac_review
+            $this->rbacreview
         );
     }
 

--- a/Modules/LearningSequence/classes/class.ilLearningSequenceImporter.php
+++ b/Modules/LearningSequence/classes/class.ilLearningSequenceImporter.php
@@ -19,7 +19,7 @@
 class ilLearningSequenceImporter extends ilXmlImporter
 {
     protected ilObjUser $user;
-    protected ilRbacAdmin $rbac_admin;
+    protected ilRbacAdmin $rbacadmin;
     protected ilLogger $log;
     protected ilObject $obj;
     protected array $data;
@@ -28,7 +28,7 @@ class ilLearningSequenceImporter extends ilXmlImporter
     {
         global $DIC;
         $this->user = $DIC["ilUser"];
-        $this->rbac_admin = $DIC["rbacadmin"];
+        $this->rbacadmin = $DIC["rbacadmin"];
         $this->log = $DIC["ilLoggerFactory"]->getRootLogger();
     }
 

--- a/Modules/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
+++ b/Modules/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
@@ -107,7 +107,7 @@ class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClass
     protected ilNavigationHistory $navigation_history;
     protected ilObjectService $obj_service;
     protected ilObjLearningSequence $ls_object;
-    protected ilRbacReview $rbac_review;
+    protected ilRbacReview $rbacreview;
     protected ilHelpGUI $help;
     protected ILIAS\UI\Factory $ui_factory;
     protected ILIAS\UI\Renderer $ui_renderer;
@@ -205,7 +205,7 @@ class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClass
         $this->help = $DIC['ilHelp'];
         $this->settings = $DIC['ilSetting'];
         $this->access = $DIC['ilAccess'];
-        $this->rbac_review = $DIC['rbacreview'];
+        $this->rbacreview = $DIC['rbacreview'];
         $this->ui_factory = $DIC['ui.factory'];
         $this->ui_renderer = $DIC['ui.renderer'];
 
@@ -543,7 +543,7 @@ class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClass
             $this->getObject(),
             $this->getTrackingObject(),
             ilPrivacySettings::getInstance(),
-            $this->rbac_review,
+            $this->rbacreview,
             $this->settings,
             $this->toolbar,
             $this->request_wrapper,

--- a/Modules/MediaCast/classes/class.ilObjMediaCastSettingsGUI.php
+++ b/Modules/MediaCast/classes/class.ilObjMediaCastSettingsGUI.php
@@ -60,7 +60,7 @@ class ilObjMediaCastSettingsGUI extends ilObjectGUI
 
         $this->prepareOutput();
 
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             throw new ilPermissionException($this->lng->txt('no_permission'));
         }
 
@@ -83,9 +83,9 @@ class ilObjMediaCastSettingsGUI extends ilObjectGUI
 
     public function getAdminTabs() : void
     {
-        $rbac_system = $this->rbac_system;
+        $rbacsystem = $this->rbacsystem;
 
-        if ($rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "mcst_edit_settings",
                 $this->ctrl->getLinkTarget($this, "editSettings"),
@@ -93,7 +93,7 @@ class ilObjMediaCastSettingsGUI extends ilObjectGUI
             );
         }
 
-        if ($rbac_system->checkAccess('edit_permission', $this->object->getRefId())) {
+        if ($rbacsystem->checkAccess('edit_permission', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "perm_settings",
                 $this->ctrl->getLinkTargetByClass('ilpermissiongui', "perm"),

--- a/Modules/MediaPool/classes/class.ilObjMediaPoolGUI.php
+++ b/Modules/MediaPool/classes/class.ilObjMediaPoolGUI.php
@@ -604,7 +604,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
 
             $upload_factory = new ilImportDirectoryFactory();
             $media_upload = $upload_factory->getInstanceForComponent(ilImportDirectoryFactory::TYPE_MOB);
-            if ($media_upload->exists() && $this->rbac_system->checkAccess("visible", SYSTEM_FOLDER_ID)) {
+            if ($media_upload->exists() && $this->rbacsystem->checkAccess("visible", SYSTEM_FOLDER_ID)) {
                 $ilToolbar->addButton(
                     $lng->txt("mep_create_from_upload_dir"),
                     $ilCtrl->getLinkTargetByClass("ilfilesystemgui", "listFiles")
@@ -1482,7 +1482,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
 
         $this->checkPermission("write");
 
-        if ($this->rbac_system->checkAccess("visible", SYSTEM_FOLDER_ID)) {
+        if ($this->rbacsystem->checkAccess("visible", SYSTEM_FOLDER_ID)) {
 
             // action type
             $options = array(
@@ -1518,7 +1518,7 @@ class ilObjMediaPoolGUI extends ilObject2GUI
         $upload_dir = $mob_import_directory->getAbsolutePath();
 
         $files = $this->mep_request->getFiles();
-        if ($this->rbac_system->checkAccess("visible", SYSTEM_FOLDER_ID)) {
+        if ($this->rbacsystem->checkAccess("visible", SYSTEM_FOLDER_ID)) {
             foreach ($files as $f) {
                 $f = str_replace("..", "", $f);
                 $fullpath = $upload_dir . "/" . $f;

--- a/Modules/OrgUnit/classes/class.ilObjOrgUnit.php
+++ b/Modules/OrgUnit/classes/class.ilObjOrgUnit.php
@@ -16,8 +16,6 @@ class ilObjOrgUnit extends ilContainer
     protected static int $root_id = 0;
     private ilDBInterface $ilDb;
     private ilAppEventHandler $ilAppEventHandler;
-    private ilRbacReview $rbacreview;
-    private ilRbacAdmin $rbacadmin;
 
     /**
      * Cache storing OrgUnit objects that have OrgUnit types with custom icons assigned
@@ -49,8 +47,8 @@ class ilObjOrgUnit extends ilContainer
     {
         parent::read();
         /** @var */
-        $sql = 'SELECT * FROM ' . self::TABLE_NAME . ' WHERE orgu_id = ' .  $this->ilDb->quote($this->getId(), 'integer');
-        $set =  $this->ilDb->query($sql);
+        $sql = 'SELECT * FROM ' . self::TABLE_NAME . ' WHERE orgu_id = ' . $this->ilDb->quote($this->getId(), 'integer');
+        $set = $this->ilDb->query($sql);
         if ($this->ilDb->numRows($set)) {
             $rec = $this->ilDb->fetchObject($set);
             $this->setOrgUnitTypeId($rec->orgu_type_id);
@@ -70,8 +68,10 @@ class ilObjOrgUnit extends ilContainer
     public function update() : bool
     {
         parent::update();
-        $sql = 'SELECT * FROM ' . self::TABLE_NAME . ' WHERE orgu_id = ' . $this->ilDb->quote($this->getId(),
-                'integer');
+        $sql = 'SELECT * FROM ' . self::TABLE_NAME . ' WHERE orgu_id = ' . $this->ilDb->quote(
+            $this->getId(),
+            'integer'
+        );
         $set = $this->ilDb->query($sql);
         if ($this->ilDb->numRows($set)) {
             $this->ilDb->update(self::TABLE_NAME, array(
@@ -87,8 +87,11 @@ class ilObjOrgUnit extends ilContainer
         }
         // Update selection for advanced meta data of the type
         if ($this->getOrgUnitTypeId()) {
-            ilAdvancedMDRecord::saveObjRecSelection($this->getId(), 'orgu_type',
-                $this->getOrgUnitType()->getAssignedAdvancedMDRecordIds());
+            ilAdvancedMDRecord::saveObjRecSelection(
+                $this->getId(),
+                'orgu_type',
+                $this->getOrgUnitType()->getAssignedAdvancedMDRecordIds()
+            );
         } else {
             // If no type is assigned, delete relations by passing an empty array
             ilAdvancedMDRecord::saveObjRecSelection($this->getId(), 'orgu_type', array());
@@ -207,7 +210,6 @@ class ilObjOrgUnit extends ilContainer
      */
     public function assignUsersToEmployeeRole(array $user_ids) : void
     {
-
         $position_id = ilOrgUnitPosition::getCorePositionId(ilOrgUnitPosition::CORE_POSITION_EMPLOYEE);
 
         foreach ($user_ids as $user_id) {
@@ -277,7 +279,6 @@ class ilObjOrgUnit extends ilContainer
      */
     public function assignUserToLocalRole(int $role_id, int $user_id) : bool
     {
-
         $arrLocalRoles = $this->rbacreview->getLocalRoles($this->getRefId());
         if (!in_array($role_id, $arrLocalRoles)) {
             return false;
@@ -350,8 +351,10 @@ class ilObjOrgUnit extends ilContainer
      */
     public function getTranslations()
     {
-        $q = "SELECT * FROM object_translation WHERE obj_id = " . $this->ilDb->quote($this->getId(),
-                'integer') . " ORDER BY lang_default DESC";
+        $q = "SELECT * FROM object_translation WHERE obj_id = " . $this->ilDb->quote(
+            $this->getId(),
+            'integer'
+        ) . " ORDER BY lang_default DESC";
         $r = $this->db->query($q);
 
         $data = [];
@@ -435,8 +438,10 @@ class ilObjOrgUnit extends ilContainer
      */
     public function deleteTranslation(string $a_lang) : void
     {
-        $query = "DELETE FROM object_translation WHERE obj_id= " . $this->quote($this->getId(),
-                'integer') . " AND lang_code = "
+        $query = "DELETE FROM object_translation WHERE obj_id= " . $this->quote(
+            $this->getId(),
+            'integer'
+        ) . " AND lang_code = "
             . $this->quote($a_lang, 'text');
         $this->ilDb->manipulate($query);
     }
@@ -451,8 +456,10 @@ class ilObjOrgUnit extends ilContainer
         }
 
         $query = "INSERT INTO object_translation " . "(obj_id,title,description,lang_code,lang_default) " . "VALUES " . "("
-            . $this->ilDb->quote($this->getId(), 'integer') . "," . $this->ilDb->quote($a_title,
-                'text') . "," . $this->ilDb->quote($a_desc, 'text') . ","
+            . $this->ilDb->quote($this->getId(), 'integer') . "," . $this->ilDb->quote(
+                $a_title,
+                'text'
+            ) . "," . $this->ilDb->quote($a_desc, 'text') . ","
             . $this->ilDb->quote($a_lang, 'text') . "," . $this->ilDb->quote($a_lang_default, 'integer') . ")";
         $this->ilDb->manipulate($query);
     }
@@ -476,8 +483,10 @@ class ilObjOrgUnit extends ilContainer
 
         $query .= ", lang_default = " . $this->ilDb->quote($lang_default, 'integer') . " ";
 
-        $query .= " WHERE obj_id = " . $this->ilDb->quote($this->getId(),
-                'integer') . " AND lang_code = " . $this->ilDb->quote($lang, 'text');
+        $query .= " WHERE obj_id = " . $this->ilDb->quote(
+            $this->getId(),
+            'integer'
+        ) . " AND lang_code = " . $this->ilDb->quote($lang, 'text');
         $this->ilDb->manipulate($query);
     }
 

--- a/Modules/Session/classes/class.ilObjSessionGUI.php
+++ b/Modules/Session/classes/class.ilObjSessionGUI.php
@@ -1976,9 +1976,9 @@ class ilObjSessionGUI extends ilObjectGUI implements ilDesktopItemHandling
 
     public function getDefaultMemberRole() : int
     {
-        $rbac_review = $this->rbacreview;
+        $rbacreview = $this->rbacreview;
 
-        $local_roles = $rbac_review->getRolesOfRoleFolder($this->object->getRefId(), false);
+        $local_roles = $rbacreview->getRolesOfRoleFolder($this->object->getRefId(), false);
         
         foreach ($local_roles as $role_id) {
             $title = ilObject::_lookupTitle($role_id);
@@ -1994,7 +1994,7 @@ class ilObjSessionGUI extends ilObjectGUI implements ilDesktopItemHandling
      */
     public function getLocalRoles() : array
     {
-        $rbac_review = $this->rbacreview;
+        $rbacreview = $this->rbacreview;
 
         return $this->rbacreview->getRolesOfRoleFolder($this->object->getRefId(), false);
     }

--- a/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeAdminGUI.php
+++ b/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeAdminGUI.php
@@ -41,7 +41,7 @@ class ilObjStudyProgrammeAdminGUI extends ilObjectGUI
     public function executeCommand() : void
     {
         //Check Permissions globally for all SubGUIs. We only check write permissions
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt("no_permission"), $this->error->WARNING);
         }
         $next_class = $this->ctrl->getNextClass($this);
@@ -128,7 +128,7 @@ class ilObjStudyProgrammeAdminGUI extends ilObjectGUI
 
     public function getAdminTabs() : void
     {
-        if ($this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess('visible,read', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 'settings',
                 $this->ctrl->getLinkTargetByClass('ilObjStudyProgrammeAdminGUI', 'view')
@@ -142,7 +142,7 @@ class ilObjStudyProgrammeAdminGUI extends ilObjectGUI
                 )
             );
         }
-        if ($this->rbac_system->checkAccess('edit_permission', $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess('edit_permission', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 'perm_settings',
                 $this->ctrl->getLinkTargetByClass('ilpermissiongui', 'perm'),

--- a/Modules/StudyProgramme/classes/model/AutoMemberships/class.ilStudyProgrammeMembershipSourceReaderRole.php
+++ b/Modules/StudyProgramme/classes/model/AutoMemberships/class.ilStudyProgrammeMembershipSourceReaderRole.php
@@ -22,12 +22,12 @@
 class ilStudyProgrammeMembershipSourceReaderRole implements ilStudyProgrammeMembershipSourceReader
 {
     protected int $src_id;
-    protected ilRbacReview $rbac_review;
+    protected ilRbacReview $rbacreview;
 
-    public function __construct(ilRbacReview $rbac_review, int $src_id)
+    public function __construct(ilRbacReview $rbacreview, int $src_id)
     {
         $this->src_id = $src_id;
-        $this->rbac_review = $rbac_review;
+        $this->rbacreview = $rbacreview;
     }
 
     /**
@@ -37,7 +37,7 @@ class ilStudyProgrammeMembershipSourceReaderRole implements ilStudyProgrammeMemb
     {
         return array_map(
             'intval',
-            $this->rbac_review->assignedUsers($this->src_id)
+            $this->rbacreview->assignedUsers($this->src_id)
         );
     }
 }

--- a/Modules/Survey/Administration/class.ilObjSurveyAdministrationGUI.php
+++ b/Modules/Survey/Administration/class.ilObjSurveyAdministrationGUI.php
@@ -187,7 +187,7 @@ class ilObjSurveyAdministrationGUI extends ilObjectGUI
     {
         $lng = $this->lng;
 
-        if ($this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->tabs_gui->addTab(
                 "settings",
                 $lng->txt("settings"),

--- a/Modules/SystemFolder/classes/class.ilObjSystemFolderGUI.php
+++ b/Modules/SystemFolder/classes/class.ilObjSystemFolderGUI.php
@@ -31,7 +31,7 @@ class ilObjSystemFolderGUI extends ilObjectGUI
     /**
      * @var ilRbacSystem
      */
-    protected $rbacsystem;
+    protected ilRbacSystem $rbacsystem;
 
     /**
      * @var ilObjectDefinition
@@ -1154,7 +1154,6 @@ class ilObjSystemFolderGUI extends ilObjectGUI
             $data,
             $lng,
             $interface_finder
-            []
         );
 
         $st = new StatusCommand($agent_finder);

--- a/Modules/WebResource/classes/class.ilObjWebResourceAdministrationGUI.php
+++ b/Modules/WebResource/classes/class.ilObjWebResourceAdministrationGUI.php
@@ -50,7 +50,7 @@ class ilObjWebResourceAdministrationGUI extends ilObjectGUI
         $cmd = $this->ctrl->getCmd();
         $this->prepareOutput();
 
-        if (!$this->rbac_system->checkAccess(
+        if (!$this->rbacsystem->checkAccess(
             "visible,read",
             $this->object->getRefId()
         )) {
@@ -78,7 +78,7 @@ class ilObjWebResourceAdministrationGUI extends ilObjectGUI
 
     public function getAdminTabs() : void
     {
-        if ($this->rbac_system->checkAccess(
+        if ($this->rbacsystem->checkAccess(
             "visible,read",
             $this->object->getRefId()
         )) {
@@ -89,7 +89,7 @@ class ilObjWebResourceAdministrationGUI extends ilObjectGUI
             );
         }
 
-        if ($this->rbac_system->checkAccess(
+        if ($this->rbacsystem->checkAccess(
             "edit_permission",
             $this->object->getRefId()
         )) {

--- a/Modules/Wiki/classes/class.ilObjWikiSettingsGUI.php
+++ b/Modules/Wiki/classes/class.ilObjWikiSettingsGUI.php
@@ -61,7 +61,7 @@ class ilObjWikiSettingsGUI extends ilObject2GUI
 
         $this->prepareOutput();
 
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $ilErr->raiseError($this->lng->txt('no_permission'), $ilErr->WARNING);
         }
 
@@ -88,7 +88,7 @@ class ilObjWikiSettingsGUI extends ilObject2GUI
         
         $ilTabs->activateTab("settings");
 
-        if ($this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             if (!$form) {
                 $form = $this->initForm();
                 $this->populateWithCurrentSettings($form);

--- a/Services/AccessControl/classes/class.ilObjRole.php
+++ b/Services/AccessControl/classes/class.ilObjRole.php
@@ -274,13 +274,13 @@ class ilObjRole extends ilObject
         global $DIC;
 
         // Temporary bugfix
-        if ($this->rbac_review->hasMultipleAssignments($this->getId())) {
+        if ($this->rbacreview->hasMultipleAssignments($this->getId())) {
             $this->logger->warning('Found role with multiple assignments: role_id: ' . $this->getId());
             $this->logger->warning('Aborted deletion of role.');
             return false;
         }
 
-        if ($this->rbac_review->isAssignable($this->getId(), $this->getParent())) {
+        if ($this->rbacreview->isAssignable($this->getId(), $this->getParent())) {
             $this->logger->debug('Handling assignable role...');
             // do not delete a global role, if the role is the last
             // role a user is assigned to.
@@ -295,11 +295,11 @@ class ilObjRole extends ilObject
                 // The role is a global role: check if
                 // we find users who aren't assigned to any
                 // other global role than this one.
-                $user_ids = $this->rbac_review->assignedUsers($this->getId());
+                $user_ids = $this->rbacreview->assignedUsers($this->getId());
 
                 foreach ($user_ids as $user_id) {
                     // get all roles each user has
-                    $role_ids = $this->rbac_review->assignedRoles($user_id);
+                    $role_ids = $this->rbacreview->assignedRoles($user_id);
 
                     // is last role?
                     if (count($role_ids) == 1) {
@@ -325,7 +325,7 @@ class ilObjRole extends ilObject
                     $users . "<br/>" . $this->lng->txt("msg_user_last_role2"), $this->ilias->error_obj->WARNING);
             } else {
                 $this->logger->debug('Starting deletion of assignable role: role_id: ' . $this->getId());
-                $this->rbac_admin->deleteRole($this->getId(), $this->getParent());
+                $this->rbacadmin->deleteRole($this->getId(), $this->getParent());
 
                 // Delete ldap role group mappings
                 ilLDAPRoleGroupMappingSettings::_deleteByRole($this->getId());
@@ -340,7 +340,7 @@ class ilObjRole extends ilObject
         } else {
             $this->logger->debug('Starting deletion of linked role: role_id ' . $this->getId());
             // linked local role: INHERITANCE WAS STOPPED, SO DELETE ONLY THIS LOCAL ROLE
-            $this->rbac_admin->deleteLocalRole($this->getId(), $this->getParent());
+            $this->rbacadmin->deleteLocalRole($this->getId(), $this->getParent());
         }
         return true;
     }
@@ -350,7 +350,7 @@ class ilObjRole extends ilObject
      */
     public function getCountMembers() : int
     {
-        return count($this->rbac_review->assignedUsers($this->getId()));
+        return count($this->rbacreview->assignedUsers($this->getId()));
     }
 
     public static function _getTranslation(string $a_role_title) : string
@@ -487,7 +487,7 @@ class ilObjRole extends ilObject
 
     public function __getPermissionDefinitions() : array
     {
-        $operation_info = $this->rbac_review->getOperationAssignment();
+        $operation_info = $this->rbacreview->getOperationAssignment();
         $rbac_objects = $rbac_operations = [];
         foreach ($operation_info as $info) {
             if ($this->obj_definition->getDevMode($info['type'])) {
@@ -538,7 +538,7 @@ class ilObjRole extends ilObject
         $nodes = $this->tree->getRbacSubtreeInfo($a_start_node);
 
         // get local policies
-        $all_local_policies = $this->rbac_review->getObjectsWithStopedInheritance($this->getId());
+        $all_local_policies = $this->rbacreview->getObjectsWithStopedInheritance($this->getId());
 
         // filter relevant roles
         $local_policies = array();
@@ -651,7 +651,7 @@ class ilObjRole extends ilObject
             if ($node['child'] == $start_node['child']) {
                 if ($this->isHandledObjectType($a_filter, $a_exclusion_filter, $node['type'])) {
                     if ($rbac_log_active) {
-                        $rbac_log_roles = $this->rbac_review->getParentRoleIds($node['child'], false);
+                        $rbac_log_roles = $this->rbacreview->getParentRoleIds($node['child'], false);
                         $rbac_log_old = ilRbacLog::gatherFaPa((int) $node['child'], array_keys($rbac_log_roles));
                     }
 
@@ -688,7 +688,7 @@ class ilObjRole extends ilObject
             }
 
             if ($rbac_log_active) {
-                $rbac_log_roles = $this->rbac_review->getParentRoleIds($node['child'], false);
+                $rbac_log_roles = $this->rbacreview->getParentRoleIds($node['child'], false);
                 $rbac_log_old = ilRbacLog::gatherFaPa((int) $node['child'], array_keys($rbac_log_roles));
             }
 
@@ -799,13 +799,13 @@ class ilObjRole extends ilObject
             $has_policies = true;
             $policy_origin = ROLE_FOLDER_ID;
         } else {
-            $has_policies = $this->rbac_review->getLocalPolicies($a_node);
+            $has_policies = $this->rbacreview->getLocalPolicies($a_node);
             $policy_origin = $a_node;
 
             if ($a_init) {
-                $parent_roles = $this->rbac_review->getParentRoleIds($a_node, false);
+                $parent_roles = $this->rbacreview->getParentRoleIds($a_node, false);
                 if ($parent_roles[$this->getId()]) {
-                    $a_stack[] = $this->rbac_review->getAllOperationsOfRole(
+                    $a_stack[] = $this->rbacreview->getAllOperationsOfRole(
                         $this->getId(),
                         $parent_roles[$this->getId()]['parent']
                     );
@@ -818,7 +818,7 @@ class ilObjRole extends ilObject
             return false;
         }
 
-        $a_stack[] = $this->rbac_review->getAllOperationsOfRole(
+        $a_stack[] = $this->rbacreview->getAllOperationsOfRole(
             $this->getId(),
             $policy_origin
         );
@@ -833,7 +833,7 @@ class ilObjRole extends ilObject
             $has_policies = true;
             $policy_origin = ROLE_FOLDER_ID;
         } else {
-            $has_policies = $this->rbac_review->getLocalPolicies($a_node);
+            $has_policies = $this->rbacreview->getLocalPolicies($a_node);
             $policy_origin = $a_node;
         }
 
@@ -905,7 +905,7 @@ class ilObjRole extends ilObject
 
         // Create intersection template permissions
         if ($template_id) {
-            $this->rbac_admin->copyRolePermissionIntersection(
+            $this->rbacadmin->copyRolePermissionIntersection(
                 $template_id,
                 ROLE_FOLDER_ID,
                 $this->getId(),
@@ -916,7 +916,7 @@ class ilObjRole extends ilObject
         } else {
         }
         if ($a_id && !$GLOBALS['DIC']['rbacreview']->isRoleAssignedToObject($this->getId(), $a_id)) {
-            $this->rbac_admin->assignRoleToFolder($this->getId(), $a_id, "n");
+            $this->rbacadmin->assignRoleToFolder($this->getId(), $a_id, "n");
         }
     }
 }

--- a/Services/AccessControl/classes/class.ilObjRoleFolder.php
+++ b/Services/AccessControl/classes/class.ilObjRoleFolder.php
@@ -45,7 +45,7 @@ class ilObjRoleFolder extends ilObject
             return false;
         }
         // put here rolefolder specific stuff
-        $roles = $this->rbac_review->getRolesOfRoleFolder($this->getRefId());
+        $roles = $this->rbacreview->getRolesOfRoleFolder($this->getRefId());
         foreach ($roles as $role_id) {
             $roleObj = ilObjectFactory::getInstanceByObjId($role_id);
             $roleObj->setParent($this->getRefId());

--- a/Services/AccessControl/classes/class.ilObjRoleFolderGUI.php
+++ b/Services/AccessControl/classes/class.ilObjRoleFolderGUI.php
@@ -129,18 +129,18 @@ class ilObjRoleFolderGUI extends ilObjectGUI
     {
         $this->tabs_gui->activateTab('view');
 
-        if (!$this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess('visible,read', $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('permission_denied'), $this->error->MESSAGE);
         }
 
-        if ($this->rbac_system->checkAccess('create_role', $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess('create_role', $this->object->getRefId())) {
             $this->ctrl->setParameter($this, 'new_type', 'role');
             $this->toolbar->addButton(
                 $this->lng->txt('rolf_create_role'),
                 $this->ctrl->getLinkTarget($this, 'create')
             );
         }
-        if ($this->rbac_system->checkAccess('create_rolt', $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess('create_rolt', $this->object->getRefId())) {
             $this->ctrl->setParameter($this, 'new_type', 'rolt');
             $this->toolbar->addButton(
                 $this->lng->txt('rolf_create_rolt'),
@@ -150,8 +150,8 @@ class ilObjRoleFolderGUI extends ilObjectGUI
         }
 
         if (
-            $this->rbac_system->checkAccess('create_rolt', $this->object->getRefId()) ||
-            $this->rbac_system->checkAccess('create_rolt', $this->object->getRefId())
+            $this->rbacsystem->checkAccess('create_rolt', $this->object->getRefId()) ||
+            $this->rbacsystem->checkAccess('create_rolt', $this->object->getRefId())
         ) {
             $this->toolbar->addButton(
                 $this->lng->txt('rbac_import_role'),
@@ -177,7 +177,7 @@ class ilObjRoleFolderGUI extends ilObjectGUI
             $this->ctrl->getLinkTarget($this, 'view')
         );
 
-        if (!$this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess('visible,read', $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('permission_denied'), $this->error->MESSAGE);
         }
 
@@ -399,7 +399,7 @@ class ilObjRoleFolderGUI extends ilObjectGUI
             $adjustment_type = $form->getInput('type');
             foreach ((array) $roles as $role_id) {
                 if ($role_id !== $source) {
-                    $start_obj = $this->rbac_review->getRoleFolderOfRole($role_id);
+                    $start_obj = $this->rbacreview->getRoleFolderOfRole($role_id);
                     $this->logger->debug('Start object: ' . $start_obj);
 
                     switch ($adjustment_type) {
@@ -461,14 +461,14 @@ class ilObjRoleFolderGUI extends ilObjectGUI
      */
     protected function doAddRolePermissions(int $source, int $target) : void
     {
-        $source_definition = $this->rbac_review->getRoleFolderOfRole($source);
+        $source_definition = $this->rbacreview->getRoleFolderOfRole($source);
         $this->rbacadmin->copyRolePermissionUnion(
             $source,
             $source_definition,
             $target,
-            $this->rbac_review->getRoleFolderOfRole($target),
+            $this->rbacreview->getRoleFolderOfRole($target),
             $target,
-            $this->rbac_review->getRoleFolderOfRole($target)
+            $this->rbacreview->getRoleFolderOfRole($target)
         );
     }
 
@@ -500,12 +500,12 @@ class ilObjRoleFolderGUI extends ilObjectGUI
     {
         $this->logger->debug('Remove permission source: ' . $source);
         $this->logger->debug('Remove permission target: ' . $target);
-        $source_obj = $this->rbac_review->getRoleFolderOfRole($source);
+        $source_obj = $this->rbacreview->getRoleFolderOfRole($source);
         $this->rbacadmin->copyRolePermissionSubtract(
             $source,
             $source_obj,
             $target,
-            $this->rbac_review->getRoleFolderOfRole($target)
+            $this->rbacreview->getRoleFolderOfRole($target)
         );
     }
 
@@ -514,8 +514,8 @@ class ilObjRoleFolderGUI extends ilObjectGUI
      */
     protected function doCopyRole(int $source, int $target) : void
     {
-        $target_obj = $this->rbac_review->getRoleFolderOfRole($target);
-        $source_obj = $this->rbac_review->getRoleFolderOfRole($source);
+        $target_obj = $this->rbacreview->getRoleFolderOfRole($target);
+        $source_obj = $this->rbacreview->getRoleFolderOfRole($source);
         // Copy role template permissions
         $this->rbacadmin->copyRoleTemplatePermissions(
             $source,
@@ -540,15 +540,15 @@ class ilObjRoleFolderGUI extends ilObjectGUI
             throw new InvalidArgumentException('Missing parameter: start object');
         }
         // the mode is unchanged and read out from the target object
-        $target_ref_id = $this->rbac_review->getRoleFolderOfRole($a_target_role);
-        if ($this->rbac_review->isProtected($target_ref_id, $a_target_role)) {
+        $target_ref_id = $this->rbacreview->getRoleFolderOfRole($a_target_role);
+        if ($this->rbacreview->isProtected($target_ref_id, $a_target_role)) {
             $mode = \ilObjRole::MODE_PROTECTED_KEEP_LOCAL_POLICIES;
         } else {
             $mode = \ilObjRole::MODE_UNPROTECTED_KEEP_LOCAL_POLICIES;
         }
         $operation_stack = [];
         if ($a_operation_mode !== \ilObjRole::MODE_READ_OPERATIONS) {
-            $operation_stack[] = $this->rbac_review->getAllOperationsOfRole($a_source_role, $this->ref_id);
+            $operation_stack[] = $this->rbacreview->getAllOperationsOfRole($a_source_role, $this->ref_id);
         }
         $this->logger->debug('Current operation stack');
         $this->logger->dump($operation_stack, ilLogLevel::DEBUG);
@@ -625,7 +625,7 @@ class ilObjRoleFolderGUI extends ilObjectGUI
      */
     protected function deleteRoleObject() : void
     {
-        if (!$this->rbac_system->checkAccess('delete', $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess('delete', $this->object->getRefId())) {
             $this->error->raiseError(
                 $this->lng->txt('msg_no_perm_delete'),
                 $this->error->MESSAGE
@@ -637,7 +637,7 @@ class ilObjRoleFolderGUI extends ilObjectGUI
             $obj = ilObjectFactory::getInstanceByObjId($id, false);
 
             if ($obj->getType() == "role") {
-                $rolf_arr = $this->rbac_review->getFoldersAssignedToRole($obj->getId(), true);
+                $rolf_arr = $this->rbacreview->getFoldersAssignedToRole($obj->getId(), true);
                 $obj->setParent($rolf_arr[0]);
             }
 
@@ -712,7 +712,7 @@ class ilObjRoleFolderGUI extends ilObjectGUI
             $privacy->setRbacLogAge((int) $form->getInput('rbac_log_age'));
             $privacy->save();
 
-            if ($this->rbac_review->isAssigned($user->getId(), SYSTEM_ROLE_ID)) {
+            if ($this->rbacreview->isAssigned($user->getId(), SYSTEM_ROLE_ID)) {
                 $security = ilSecuritySettings::_getInstance();
                 $security->protectedAdminRole((bool) $form->getInput('admin_role'));
                 $security->save();
@@ -742,7 +742,7 @@ class ilObjRoleFolderGUI extends ilObjectGUI
 
         // protected admin
         $admin = new ilCheckboxInputGUI($GLOBALS['DIC']['lng']->txt('adm_adm_role_protect'), 'admin_role');
-        $admin->setDisabled(!$this->rbac_review->isAssigned($user->getId(), SYSTEM_ROLE_ID));
+        $admin->setDisabled(!$this->rbacreview->isAssigned($user->getId(), SYSTEM_ROLE_ID));
         $admin->setInfo($this->lng->txt('adm_adm_role_protect_info'));
         $admin->setChecked($security->isAdminRoleProtected());
         $admin->setValue((string) 1);

--- a/Services/AccessControl/classes/class.ilObjRoleGUI.php
+++ b/Services/AccessControl/classes/class.ilObjRoleGUI.php
@@ -329,7 +329,7 @@ class ilObjRoleGUI extends ilObjectGUI
      */
     public function createObject() : void
     {
-        if (!$this->rbac_system->checkAccess('create_role', $this->obj_ref_id)) {
+        if (!$this->rbacsystem->checkAccess('create_role', $this->obj_ref_id)) {
             $this->error->raiseError($this->lng->txt('permission_denied'), $this->error->WARNING);
         }
         $form = $this->initFormRoleProperties(self::MODE_GLOBAL_CREATE);
@@ -346,7 +346,7 @@ class ilObjRoleGUI extends ilObjectGUI
         // Show copy role button
         if ($this->object->getId() != SYSTEM_ROLE_ID) {
             $this->toolbar->setFormAction($this->ctrl->getFormAction($this));
-            if ($this->rbac_review->isDeleteable($this->object->getId(), $this->obj_ref_id)) {
+            if ($this->rbacreview->isDeleteable($this->object->getId(), $this->obj_ref_id)) {
                 $this->toolbar->addButton(
                     $this->lng->txt('rbac_delete_role'),
                     $this->ctrl->getLinkTarget($this, 'confirmDeleteRole')
@@ -433,7 +433,7 @@ class ilObjRoleGUI extends ilObjectGUI
                 $this->lng->txt("adopt_perm_from_template"),
                 $this->ctrl->getLinkTarget($this, 'adoptPerm')
             );
-            if ($this->rbac_review->isDeleteable($this->object->getId(), $this->obj_ref_id)) {
+            if ($this->rbacreview->isDeleteable($this->object->getId(), $this->obj_ref_id)) {
                 $this->toolbar->addButton(
                     $this->lng->txt('rbac_delete_role'),
                     $this->ctrl->getLinkTarget($this, 'confirmDeleteRole')
@@ -519,7 +519,7 @@ class ilObjRoleGUI extends ilObjectGUI
     protected function adoptPermObject() : void
     {
         $output = array();
-        $parent_role_ids = $this->rbac_review->getParentRoleIds($this->obj_ref_id, true);
+        $parent_role_ids = $this->rbacreview->getParentRoleIds($this->obj_ref_id, true);
         $ids = array();
         foreach (array_keys($parent_role_ids) as $id) {
             $ids[] = $id;
@@ -560,7 +560,7 @@ class ilObjRoleGUI extends ilObjectGUI
         }
 
         $question = $this->lng->txt('rbac_role_delete_qst');
-        if ($this->rbac_review->isAssigned($ilUser->getId(), $this->object->getId())) {
+        if ($this->rbacreview->isAssigned($ilUser->getId(), $this->object->getId())) {
             $question .= ('<br />' . $this->lng->txt('rbac_role_delete_self'));
         }
         $this->tpl->setOnScreenMessage('question', $question);
@@ -658,7 +658,7 @@ class ilObjRoleGUI extends ilObjectGUI
         }
         if (
             $this->obj_ref_id == ROLE_FOLDER_ID ||
-            $this->rbac_review->isAssignable($this->object->getId(), $this->obj_ref_id)) {
+            $this->rbacreview->isAssignable($this->object->getId(), $this->obj_ref_id)) {
             $this->rbacadmin->setProtected($this->obj_ref_id, $this->object->getId(), ilUtil::tf2yn($protected));
         }
         $recursive = false;
@@ -756,7 +756,7 @@ class ilObjRoleGUI extends ilObjectGUI
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt("msg_perm_adopted_from_itself"), true);
         } else {
             $this->rbacadmin->deleteRolePermission($this->object->getId(), $this->obj_ref_id);
-            $parentRoles = $this->rbac_review->getParentRoleIds($this->obj_ref_id, true);
+            $parentRoles = $this->rbacreview->getParentRoleIds($this->obj_ref_id, true);
             $this->rbacadmin->copyRoleTemplatePermissions(
                 $source,
                 $parentRoles[$source]["parent"],
@@ -785,7 +785,7 @@ class ilObjRoleGUI extends ilObjectGUI
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('msg_no_perm_assign_user_to_role'), true);
             return;
         }
-        if (!$this->rbac_review->isAssignable($this->object->getId(), $this->obj_ref_id) &&
+        if (!$this->rbacreview->isAssignable($this->object->getId(), $this->obj_ref_id) &&
             $this->obj_ref_id != ROLE_FOLDER_ID) {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('err_role_not_assignable'), true);
             return;
@@ -796,7 +796,7 @@ class ilObjRoleGUI extends ilObjectGUI
             return;
         }
 
-        $assigned_users_all = $this->rbac_review->assignedUsers($this->object->getId());
+        $assigned_users_all = $this->rbacreview->assignedUsers($this->object->getId());
 
         // users to assign
         $assigned_users_new = array_diff($a_user_ids, array_intersect($a_user_ids, $assigned_users_all));
@@ -858,9 +858,9 @@ class ilObjRoleGUI extends ilObjectGUI
 
         // check for each user if the current role is his last global role before deassigning him
         $last_role = array();
-        $global_roles = $this->rbac_review->getGlobalRoles();
+        $global_roles = $this->rbacreview->getGlobalRoles();
         foreach ($selected_users as $user) {
-            $assigned_roles = $this->rbac_review->assignedRoles($user);
+            $assigned_roles = $this->rbacreview->assignedRoles($user);
             $assigned_global_roles = array_intersect($assigned_roles, $global_roles);
 
             if (count($assigned_roles) == 1 || count($assigned_global_roles) == 1 && in_array(
@@ -919,7 +919,7 @@ class ilObjRoleGUI extends ilObjectGUI
         if (
             $this->object->getId() != SYSTEM_ROLE_ID ||
             (
-                !$this->rbac_review->isAssigned($ilUser->getId(), SYSTEM_ROLE_ID) or
+                !$this->rbacreview->isAssigned($ilUser->getId(), SYSTEM_ROLE_ID) or
                 !ilSecuritySettings::_getInstance()->isAdminRoleProtected()
             )
         ) {
@@ -1005,7 +1005,7 @@ class ilObjRoleGUI extends ilObjectGUI
 
     protected function getTabs() : void
     {
-        $base_role_container = $this->rbac_review->getFoldersAssignedToRole($this->object->getId(), true);
+        $base_role_container = $this->rbacreview->getFoldersAssignedToRole($this->object->getId(), true);
 
         $activate_role_edit = false;
 
@@ -1094,7 +1094,7 @@ class ilObjRoleGUI extends ilObjectGUI
         $a_perm_obj = $a_perm_obj ?: $a_perm_global;
 
         if ($this->obj_ref_id == ROLE_FOLDER_ID) {
-            return $this->rbac_system->checkAccess($a_perm_global, $this->obj_ref_id);
+            return $this->rbacsystem->checkAccess($a_perm_global, $this->obj_ref_id);
         } else {
             return $this->access->checkAccess($a_perm_obj, '', $this->obj_ref_id);
         }
@@ -1106,14 +1106,14 @@ class ilObjRoleGUI extends ilObjectGUI
     protected function isChangeExistingObjectsConfirmationRequired() : bool
     {
         // Role is protected
-        if ($this->rbac_review->isProtected($this->obj_ref_id, $this->object->getId())) {
+        if ($this->rbacreview->isProtected($this->obj_ref_id, $this->object->getId())) {
             // TODO: check if recursive_list is enabled
             // and if yes: check if inheritance is broken for the relevant object types
-            return count($this->rbac_review->getFoldersAssignedToRole($this->object->getId())) > 1;
+            return count($this->rbacreview->getFoldersAssignedToRole($this->object->getId())) > 1;
         } else {
             // TODO: check if recursive_list is enabled
             // and if yes: check if inheritance is broken for the relevant object types
-            return count($this->rbac_review->getFoldersAssignedToRole($this->object->getId())) > 1;
+            return count($this->rbacreview->getFoldersAssignedToRole($this->object->getId())) > 1;
         }
     }
 
@@ -1289,7 +1289,7 @@ class ilObjRoleGUI extends ilObjectGUI
 
         $possible_roles = [];
         try {
-            $possible_roles = $this->rbac_review->getRolesOfObject(
+            $possible_roles = $this->rbacreview->getRolesOfObject(
                 $this->obj_ref_id,
                 false
             );

--- a/Services/AccessControl/classes/class.ilObjRoleTemplate.php
+++ b/Services/AccessControl/classes/class.ilObjRoleTemplate.php
@@ -32,7 +32,7 @@ class ilObjRoleTemplate extends ilObject
     {
         // put here role template specific stuff
         // delete rbac permissions
-        $this->rbac_admin->deleteTemplate($this->getId());
+        $this->rbacadmin->deleteTemplate($this->getId());
 
         // always call parent delete function at the end!!
         return parent::delete();

--- a/Services/AccessControl/classes/class.ilObjRoleTemplateGUI.php
+++ b/Services/AccessControl/classes/class.ilObjRoleTemplateGUI.php
@@ -33,7 +33,7 @@ class ilObjRoleTemplateGUI extends ilObjectGUI
 
     private int $rolf_ref_id;
 
-    protected ilRbacAdmin $rbac_admin;
+    protected ilRbacAdmin $rbacadmin;
 
     private GlobalHttpState $http;
     protected Factory $refinery;
@@ -42,7 +42,7 @@ class ilObjRoleTemplateGUI extends ilObjectGUI
     {
         global $DIC;
 
-        $this->rbac_admin = $DIC->rbac()->admin();
+        $this->rbacadmin = $DIC->rbac()->admin();
 
         $this->type = "rolt";
         parent::__construct($a_data, $a_id, $a_call_by_reference, false);
@@ -131,7 +131,7 @@ class ilObjRoleTemplateGUI extends ilObjectGUI
 
     public function createObject(ilPropertyFormGUI $form = null) : void
     {
-        if (!$this->rbac_system->checkAccess("create_rolt", $this->rolf_ref_id)) {
+        if (!$this->rbacsystem->checkAccess("create_rolt", $this->rolf_ref_id)) {
             $this->error->raiseError($this->lng->txt("permission_denied"), $this->error->MESSAGE);
         }
         if ($form === null) {
@@ -147,7 +147,7 @@ class ilObjRoleTemplateGUI extends ilObjectGUI
     {
         $this->tabs_gui->activateTab('settings');
 
-        if (!$this->rbac_system->checkAccess("write", $this->rolf_ref_id)) {
+        if (!$this->rbacsystem->checkAccess("write", $this->rolf_ref_id)) {
             $this->error->raiseError($this->lng->txt("msg_no_perm_write"), $this->error->MESSAGE);
         }
 
@@ -160,7 +160,7 @@ class ilObjRoleTemplateGUI extends ilObjectGUI
     public function updateObject() : void
     {
         // check write access
-        if (!$this->rbac_system->checkAccess("write", $this->rolf_ref_id)) {
+        if (!$this->rbacsystem->checkAccess("write", $this->rolf_ref_id)) {
             $this->error->raiseError($this->lng->txt("msg_no_perm_modify_rolt"), $this->error->WARNING);
         }
 
@@ -168,7 +168,7 @@ class ilObjRoleTemplateGUI extends ilObjectGUI
         if ($form->checkInput()) {
             $this->object->setTitle($form->getInput('title'));
             $this->object->setDescription($form->getInput('desc'));
-            $this->rbac_admin->setProtected(
+            $this->rbacadmin->setProtected(
                 $this->rolf_ref_id,
                 $this->object->getId(),
                 $form->getInput('protected') ? 'y' : 'n'
@@ -184,7 +184,7 @@ class ilObjRoleTemplateGUI extends ilObjectGUI
 
     public function saveObject() : void
     {
-        if (!$this->rbac_system->checkAccess("create_rolt", $this->rolf_ref_id)) {
+        if (!$this->rbacsystem->checkAccess("create_rolt", $this->rolf_ref_id)) {
             $this->ilias->raiseError($this->lng->txt("msg_no_perm_create_rolt"), $this->ilias->error_obj->WARNING);
         }
         $form = $this->initFormRoleTemplate();
@@ -193,8 +193,8 @@ class ilObjRoleTemplateGUI extends ilObjectGUI
             $roltObj->setTitle($form->getInput('title'));
             $roltObj->setDescription($form->getInput('desc'));
             $roltObj->create();
-            $this->rbac_admin->assignRoleToFolder($roltObj->getId(), $this->rolf_ref_id, 'n');
-            $this->rbac_admin->setProtected(
+            $this->rbacadmin->assignRoleToFolder($roltObj->getId(), $this->rolf_ref_id, 'n');
+            $this->rbacadmin->setProtected(
                 $this->rolf_ref_id,
                 $roltObj->getId(),
                 $form->getInput('protected') ? 'y' : 'n'
@@ -211,7 +211,7 @@ class ilObjRoleTemplateGUI extends ilObjectGUI
 
     protected function permObject() : void
     {
-        if (!$this->rbac_system->checkAccess('edit_permission', $this->ref_id)) {
+        if (!$this->rbacsystem->checkAccess('edit_permission', $this->ref_id)) {
             $this->error->raiseError($this->lng->txt('msg_no_perm_perm'), $this->error->MESSAGE);
             return;
         }
@@ -272,7 +272,7 @@ class ilObjRoleTemplateGUI extends ilObjectGUI
      */
     protected function permSaveObject() : void
     {
-        if (!$this->rbac_system->checkAccess('write', $this->rolf_ref_id)) {
+        if (!$this->rbacsystem->checkAccess('write', $this->rolf_ref_id)) {
             $this->error->raiseError($this->lng->txt('msg_no_perm_perm'), $this->error->MESSAGE);
             return;
         }
@@ -295,11 +295,11 @@ class ilObjRoleTemplateGUI extends ilObjectGUI
 
         foreach (array_keys($subs) as $subtype) {
             // Delete per object type
-            $this->rbac_admin->deleteRolePermission($this->object->getId(), $this->ref_id, $subtype);
+            $this->rbacadmin->deleteRolePermission($this->object->getId(), $this->ref_id, $subtype);
         }
 
         foreach ($template_permissions as $key => $ops_array) {
-            $this->rbac_admin->setRolePermission($this->object->getId(), $key, $ops_array, $this->rolf_ref_id);
+            $this->rbacadmin->setRolePermission($this->object->getId(), $key, $ops_array, $this->rolf_ref_id);
         }
 
         // update object data entry (to update last modification date)
@@ -319,14 +319,14 @@ class ilObjRoleTemplateGUI extends ilObjectGUI
             );
         }
 
-        if (!$this->rbac_system->checkAccess('write', $this->rolf_ref_id)) {
+        if (!$this->rbacsystem->checkAccess('write', $this->rolf_ref_id)) {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('msg_no_perm_perm'), true);
         } elseif ($this->obj_id == $source) {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt("msg_perm_adopted_from_itself"), true);
         } else {
-            $this->rbac_admin->deleteRolePermission($this->obj_id, $this->rolf_ref_id);
-            $parentRoles = $this->rbac_review->getParentRoleIds($this->rolf_ref_id, true);
-            $this->rbac_admin->copyRoleTemplatePermissions(
+            $this->rbacadmin->deleteRolePermission($this->obj_id, $this->rolf_ref_id);
+            $parentRoles = $this->rbacreview->getParentRoleIds($this->rolf_ref_id, true);
+            $this->rbacadmin->copyRoleTemplatePermissions(
                 $source,
                 $parentRoles[$source]["parent"],
                 $this->rolf_ref_id,
@@ -354,14 +354,14 @@ class ilObjRoleTemplateGUI extends ilObjectGUI
     {
         $this->tabs_gui->setBackTarget($this->lng->txt('btn_back'), $this->ctrl->getParentReturn($this));
 
-        if ($this->rbac_system->checkAccess('write', $this->ref_id)) {
+        if ($this->rbacsystem->checkAccess('write', $this->ref_id)) {
             $this->tabs_gui->addTab(
                 'settings',
                 $this->lng->txt('settings'),
                 $this->ctrl->getLinkTarget($this, 'edit')
             );
         }
-        if ($this->rbac_system->checkAccess('edit_permission', $this->ref_id)) {
+        if ($this->rbacsystem->checkAccess('edit_permission', $this->ref_id)) {
             $this->tabs_gui->addTab(
                 'perm',
                 $this->lng->txt('default_perm_settings'),

--- a/Services/AdvancedEditing/classes/class.ilObjAdvancedEditingGUI.php
+++ b/Services/AdvancedEditing/classes/class.ilObjAdvancedEditingGUI.php
@@ -50,7 +50,7 @@ class ilObjAdvancedEditingGUI extends ilObjectGUI
     
     public function executeCommand() : void
     {
-        if (!$this->rbac_system->checkAccess('read', $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess('read', $this->object->getRefId())) {
             $mess = str_replace("%s", $this->object->getTitle(), $this->lng->txt("msg_no_perm_read_item"));
             $this->ilias->raiseError($mess, $this->ilias->error_obj->WARNING);
         }
@@ -164,7 +164,7 @@ class ilObjAdvancedEditingGUI extends ilObjectGUI
     
     protected function getTabs() : void
     {
-        if ($this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "adve_page_editor_settings",
                 $this->ctrl->getLinkTarget($this, "showGeneralPageEditorSettings"),
@@ -186,7 +186,7 @@ class ilObjAdvancedEditingGUI extends ilObjectGUI
             );
         }
 
-        if ($this->rbac_system->checkAccess('edit_permission', $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess('edit_permission', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "perm_settings",
                 $this->ctrl->getLinkTargetByClass(array(get_class($this),'ilpermissiongui'), "perm"),

--- a/Services/Authentication/classes/class.ilObjAuthSettingsGUI.php
+++ b/Services/Authentication/classes/class.ilObjAuthSettingsGUI.php
@@ -49,7 +49,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
     */
     public function authSettingsObject() : void
     {
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->ilias->raiseError($this->lng->txt("permission_denied"), $this->ilias->error_obj->MESSAGE);
         }
 
@@ -135,7 +135,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
 
         $generalSettingsTpl->setVariable("TXT_CONFIGURE", $this->lng->txt("auth_configure"));
 
-        if ($this->rbac_system->checkAccess("write", $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess("write", $this->object->getRefId())) {
             $generalSettingsTpl->setVariable("TXT_AUTH_REMARK", $this->lng->txt("auth_remark_non_local_auth"));
             $generalSettingsTpl->setCurrentBlock('auth_mode_submit');
             $generalSettingsTpl->setVariable("TXT_SUBMIT", $this->lng->txt("save"));
@@ -156,7 +156,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
         $generalSettingsTpl->setVariable("TXT_AUTH_ROLES", $this->lng->txt("auth_active_roles"));
         $generalSettingsTpl->setVariable("TXT_ROLE", $this->lng->txt("obj_role"));
         $generalSettingsTpl->setVariable("TXT_ROLE_AUTH_MODE", $this->lng->txt("auth_role_auth_mode"));
-        if ($this->rbac_system->checkAccess("write", $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess("write", $this->object->getRefId())) {
             $generalSettingsTpl->setVariable("CMD_SUBMIT_ROLES", "updateAuthRoles");
             $generalSettingsTpl->setVariable('BTN_SUBMIT_ROLES', $this->lng->txt('save'));
         }
@@ -222,7 +222,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
      */
     public function loginInfoObject() : void
     {
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->ilias->raiseError($this->lng->txt("permission_denied"), $this->ilias->error_obj->MESSAGE);
         }
 
@@ -253,7 +253,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
 
     public function setAuthModeObject() : void
     {
-        if (!$this->rbac_system->checkAccess("write", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("write", $this->object->getRefId())) {
             $this->ilias->raiseError($this->lng->txt("permission_denied"), $this->ilias->error_obj->MESSAGE);
         }
         
@@ -320,7 +320,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
     */
     public function editSOAPObject() : void
     {
-        if (!$this->rbac_system->checkAccess("read", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("read", $this->object->getRefId())) {
             $this->ilias->raiseError($this->lng->txt("permission_denied"), $this->ilias->error_obj->MESSAGE);
         }
 
@@ -330,7 +330,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
         $this->tpl->addBlockFile('ADM_CONTENT', 'adm_content', 'tpl.auth_soap.html', 'Services/Authentication');
         
         // compose role list
-        $role_list = $this->rbac_review->getRolesByFilter(2, $this->object->getId());
+        $role_list = $this->rbacreview->getRolesByFilter(2, $this->object->getId());
         $roles = array();
         
         foreach ($role_list as $role) {
@@ -343,7 +343,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
         $soap_config->setTitle($this->lng->txt("auth_soap_auth"));
         $soap_config->setDescription($this->lng->txt("auth_soap_auth_desc"));
         $soap_config->setFormAction($this->ctrl->getFormAction($this, "editSOAP"));
-        if ($this->rbac_system->checkAccess("write", $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess("write", $this->object->getRefId())) {
             $soap_config->addCommandButton("saveSOAP", $this->lng->txt("save"));
             $soap_config->addCommandButton("editSOAP", $this->lng->txt("cancel"));
         }
@@ -505,7 +505,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
     */
     public function saveSOAPObject() : void
     {
-        if (!$this->rbac_system->checkAccess("write", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("write", $this->object->getRefId())) {
             $this->ilias->raiseError($this->lng->txt("permission_denied"), $this->ilias->error_obj->MESSAGE);
         }
 
@@ -550,7 +550,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
     */
     public function editScriptObject() : void
     {
-        if (!$this->rbac_system->checkAccess("write", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("write", $this->object->getRefId())) {
             $this->ilias->raiseError($this->lng->txt("permission_denied"), $this->ilias->error_obj->MESSAGE);
         }
         
@@ -653,7 +653,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
     
     public function updateAuthRolesObject() : void
     {
-        if (!$this->rbac_system->checkAccess("write", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("write", $this->object->getRefId())) {
             $this->ilias->raiseError($this->lng->txt("permission_denied"), $this->ilias->error_obj->MESSAGE);
         }
         
@@ -771,7 +771,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
         $cmd = $this->ctrl->getCmd();
         $this->prepareOutput();
 
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('msg_no_perm_read'), $this->error->WARNING);
         }
         
@@ -864,7 +864,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
     {
         $this->ctrl->setParameter($this, "ref_id", $this->object->getRefId());
 
-        if ($this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "authentication_settings",
                 $this->ctrl->getLinkTarget($this, "authSettings"),
@@ -928,7 +928,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
             );
         }
 
-        if ($this->rbac_system->checkAccess('edit_permission', $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess('edit_permission', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "perm_settings",
                 $this->ctrl->getLinkTargetByClass(array(get_class($this),'ilpermissiongui'), "perm"),
@@ -1041,7 +1041,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
         $chb_local_create_account->setValue('1');
         $chb_enabled->addSubitem($chb_local_create_account);
 
-        $roles = $this->rbac_review->getGlobalRolesArray();
+        $roles = $this->rbacreview->getGlobalRolesArray();
         $select = new ilSelectInputGUI($this->lng->txt('apache_default_role'), 'apache_default_role');
         $roleOptions = [];
         foreach ($roles as $role) {

--- a/Services/Calendar/classes/class.ilObjCalendarSettingsGUI.php
+++ b/Services/Calendar/classes/class.ilObjCalendarSettingsGUI.php
@@ -53,7 +53,7 @@ class ilObjCalendarSettingsGUI extends ilObjectGUI
 
         $this->prepareOutput();
 
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 
@@ -97,7 +97,7 @@ class ilObjCalendarSettingsGUI extends ilObjectGUI
 
     public function settings(?ilPropertyFormGUI $form = null) : void
     {
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
         $this->tabs_gui->setTabActive('settings');

--- a/Services/Certificate/classes/class.ilObjCertificateSettingsGUI.php
+++ b/Services/Certificate/classes/class.ilObjCertificateSettingsGUI.php
@@ -49,7 +49,7 @@ class ilObjCertificateSettingsGUI extends ilObjectGUI
 
         $this->prepareOutput();
 
-        if (!$this->rbac_system->checkAccess('read', $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess('read', $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 
@@ -72,7 +72,7 @@ class ilObjCertificateSettingsGUI extends ilObjectGUI
 
     public function getAdminTabs() : void
     {
-        if ($this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess('visible,read', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 'settings',
                 $this->ctrl->getLinkTarget($this, 'settings'),
@@ -80,7 +80,7 @@ class ilObjCertificateSettingsGUI extends ilObjectGUI
             );
         }
 
-        if ($this->rbac_system->checkAccess('edit_permission', $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess('edit_permission', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 'perm_settings',
                 $this->ctrl->getLinkTargetByClass(ilPermissionGUI::class, 'perm'),
@@ -151,7 +151,7 @@ class ilObjCertificateSettingsGUI extends ilObjectGUI
         $format->setInfo($this->lng->txt("certificate_page_format_info"));
         $form->addItem($format);
 
-        if ($this->rbac_system->checkAccess('write', $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess('write', $this->object->getRefId())) {
             $form->addCommandButton('save', $this->lng->txt('save'));
         }
 

--- a/Services/Component/classes/Settings/class.ilObjComponentSettingsGUI.php
+++ b/Services/Component/classes/Settings/class.ilObjComponentSettingsGUI.php
@@ -35,7 +35,7 @@ class ilObjComponentSettingsGUI extends ilObjectGUI
     public const P_ADMIN_MODE = 'admin_mode';
 
     protected ilTabsGUI $tabs;
-    protected ilRbacSystem $rbac_system;
+    protected ilRbacSystem $rbacsystem;
     protected ilDBInterface $db;
     protected ilComponentRepository $component_repository;
     protected ilComponentFactory $component_factory;
@@ -53,7 +53,7 @@ class ilObjComponentSettingsGUI extends ilObjectGUI
 
         $this->tabs = $DIC->tabs();
         $this->ctrl = $DIC->ctrl();
-        $this->rbac_system = $DIC->rbac()->system();
+        $this->rbacsystem = $DIC->rbac()->system();
         $this->db = $DIC->database();
         $this->type = self::TYPE;
         $this->component_repository = $DIC["component.repository"];
@@ -74,7 +74,7 @@ class ilObjComponentSettingsGUI extends ilObjectGUI
 
         $this->prepareOutput();
 
-        if (!$this->rbac_system->checkAccess('read', $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess('read', $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 
@@ -282,7 +282,7 @@ class ilObjComponentSettingsGUI extends ilObjectGUI
 
     public function getAdminTabs() : void
     {
-        if ($this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->tabs_gui->addTab(
                 self::TAB_PLUGINS,
                 $this->lng->txt("cmps_plugins"),
@@ -290,7 +290,7 @@ class ilObjComponentSettingsGUI extends ilObjectGUI
             );
         }
 
-        if ($this->rbac_system->checkAccess('edit_permission', $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess('edit_permission', $this->object->getRefId())) {
             $this->tabs_gui->addTab(
                 "perm_settings",
                 $this->lng->txt("perm_settings"),

--- a/Services/Contact/classes/class.ilObjContactAdministrationGUI.php
+++ b/Services/Contact/classes/class.ilObjContactAdministrationGUI.php
@@ -26,6 +26,10 @@ use ILIAS\Notifications\ilNotificationDatabaseHandler;
  */
 class ilObjContactAdministrationGUI extends ilObject2GUI
 {
+    protected \ILIAS\DI\Container $dic;
+    protected ilErrorHandling $error;
+    public ilLanguage $lng;
+
     public function __construct(int $a_id = 0, int $a_id_type = self::REPOSITORY_NODE_ID, int $a_parent_node_id = 0)
     {
         parent::__construct($a_id, $a_id_type, $a_parent_node_id);

--- a/Services/Dashboard/Access/class.DashboardAccess.php
+++ b/Services/Dashboard/Access/class.DashboardAccess.php
@@ -22,7 +22,7 @@ namespace ILIAS\Dashboard\Access;
  */
 class DashboardAccess
 {
-    protected \ilRbacSystem $rbac_system;
+    protected \ilRbacSystem $rbacsystem;
     protected \ilDBInterface $db;
     protected static int $setting_ref_id = 0;
 
@@ -31,7 +31,7 @@ class DashboardAccess
         global $DIC;
 
         $this->db = $DIC->database();
-        $this->rbac_system = $DIC->rbac()->system();
+        $this->rbacsystem = $DIC->rbac()->system();
     }
 
     /**
@@ -57,6 +57,6 @@ class DashboardAccess
 
     public function canChangePresentation(int $user_id) : bool
     {
-        return $this->rbac_system->checkAccessOfUser($user_id, "change_presentation", $this->getSettingsRefId());
+        return $this->rbacsystem->checkAccessOfUser($user_id, "change_presentation", $this->getSettingsRefId());
     }
 }

--- a/Services/DidacticTemplate/classes/class.ilObjObjectTemplateAdministrationGUI.php
+++ b/Services/DidacticTemplate/classes/class.ilObjObjectTemplateAdministrationGUI.php
@@ -61,7 +61,7 @@ class ilObjObjectTemplateAdministrationGUI extends ilObjectGUI
             );
         }
 
-        if ($this->rbac_system->checkAccess('edit_permission', $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess('edit_permission', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "perm_settings",
                 $this->ctrl->getLinkTargetByClass('ilpermissiongui', "perm"),

--- a/Services/FileServices/classes/class.ilObjFileServicesGUI.php
+++ b/Services/FileServices/classes/class.ilObjFileServicesGUI.php
@@ -117,7 +117,7 @@ class ilObjFileServicesGUI extends ilObject2GUI
      */
     public function getAdminTabs() : void
     {
-        if ($this->rbac_system->checkAccess(
+        if ($this->rbacsystem->checkAccess(
             "visible,read",
             $this->object->getRefId()
         )
@@ -128,7 +128,7 @@ class ilObjFileServicesGUI extends ilObject2GUI
                 [self::CMD_EDIT_SETTINGS, "view"]
             );
         }
-        if ($this->rbac_system->checkAccess(
+        if ($this->rbacsystem->checkAccess(
             'edit_permission',
             $this->object->getRefId()
         )

--- a/Services/Help/classes/class.ilObjHelpSettingsGUI.php
+++ b/Services/Help/classes/class.ilObjHelpSettingsGUI.php
@@ -64,7 +64,7 @@ class ilObjHelpSettingsGUI extends ilObject2GUI
 
         $this->prepareOutput();
 
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             throw new ilPermissionException($this->lng->txt('no_permission'));
         }
 

--- a/Services/Logging/classes/class.ilObjLoggingSettingsGUI.php
+++ b/Services/Logging/classes/class.ilObjLoggingSettingsGUI.php
@@ -127,7 +127,7 @@ class ilObjLoggingSettingsGUI extends ilObjectGUI
 
     public function settings(ilPropertyFormGUI $form = null)
     {
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('permission_denied'), $this->error->MESSAGE);
         }
         
@@ -144,7 +144,7 @@ class ilObjLoggingSettingsGUI extends ilObjectGUI
 
     public function updateSettings() : void
     {
-        if (!$this->rbac_system->checkAccess('write', $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess('write', $this->object->getRefId())) {
             $this->ilias->raiseError($this->lng->txt("permission_denied"), $this->ilias->error_obj->MESSAGE);
         }
         $form = $this->initFormSettings();

--- a/Services/Mail/classes/class.ilObjMailGUI.php
+++ b/Services/Mail/classes/class.ilObjMailGUI.php
@@ -74,17 +74,17 @@ class ilObjMailGUI extends ilObjectGUI
 
     private function isEditingAllowed() : bool
     {
-        return $this->rbac_system->checkAccess('write', $this->object->getRefId());
+        return $this->rbacsystem->checkAccess('write', $this->object->getRefId());
     }
 
     private function isViewAllowed() : bool
     {
-        return $this->rbac_system->checkAccess('read', $this->object->getRefId());
+        return $this->rbacsystem->checkAccess('read', $this->object->getRefId());
     }
 
     private function isPermissionChangeAllowed() : bool
     {
-        return $this->rbac_system->checkAccess('edit_permission', $this->object->getRefId());
+        return $this->rbacsystem->checkAccess('edit_permission', $this->object->getRefId());
     }
 
     public function getAdminTabs() : void

--- a/Services/MainMenu/classes/class.ilObjMainMenuGUI.php
+++ b/Services/MainMenu/classes/class.ilObjMainMenuGUI.php
@@ -9,7 +9,7 @@
 class ilObjMainMenuGUI extends ilObject2GUI
 {
     private ilMMTabHandling $tab_handling;
-    protected ilRbacSystem $rbac_system;
+    protected ilRbacSystem $rbacsystem;
     protected ilTabsGUI $tabs;
     public ilLanguage $lng;
     protected ilCtrl $ctrl;
@@ -38,7 +38,7 @@ class ilObjMainMenuGUI extends ilObject2GUI
         $this->ctrl = $DIC['ilCtrl'];
         $this->tpl = $DIC['tpl'];
         $this->tree = $DIC['tree'];
-        $this->rbac_system = $DIC['rbacsystem'];
+        $this->rbacsystem = $DIC['rbacsystem'];
         $this->tab_handling = new ilMMTabHandling($this->ref_id);
         
         $this->assignObject();

--- a/Services/MediaObjects/classes/class.ilObjMediaObjectsSettingsGUI.php
+++ b/Services/MediaObjects/classes/class.ilObjMediaObjectsSettingsGUI.php
@@ -53,7 +53,7 @@ class ilObjMediaObjectsSettingsGUI extends ilObjectGUI
 
         $this->prepareOutput();
 
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 

--- a/Services/Membership/classes/class.ilMembershipAdministrationGUI.php
+++ b/Services/Membership/classes/class.ilMembershipAdministrationGUI.php
@@ -49,7 +49,7 @@ abstract class ilMembershipAdministrationGUI extends ilObjectGUI
 
         $this->prepareOutput();
 
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt("no_permission"), $this->error->WARNING);
         }
 
@@ -84,7 +84,7 @@ abstract class ilMembershipAdministrationGUI extends ilObjectGUI
 
     public function getAdminTabs() : void
     {
-        if ($this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "settings",
                 $this->ctrl->getLinkTarget($this, "editSettings"),
@@ -92,7 +92,7 @@ abstract class ilMembershipAdministrationGUI extends ilObjectGUI
             );
         }
 
-        if ($this->rbac_system->checkAccess("edit_permission", $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess("edit_permission", $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "perm_settings",
                 $this->ctrl->getLinkTargetByClass("ilpermissiongui", "perm"),

--- a/Services/MetaData/classes/class.ilMDEditorGUI.php
+++ b/Services/MetaData/classes/class.ilMDEditorGUI.php
@@ -26,7 +26,7 @@ class ilMDEditorGUI
     protected ilTabsGUI $tabs_gui;
     protected Factory $ui_factory;
     protected Renderer $ui_renderer;
-    protected ilRbacSystem $rbac_system;
+    protected ilRbacSystem $rbacsystem;
     protected ilTree $tree;
     protected ilToolbarGUI $toolbarGUI;
     protected ilMDSettings $md_settings;
@@ -54,7 +54,7 @@ class ilMDEditorGUI
         $this->tpl = $DIC->ui()->mainTemplate();
         $this->tabs_gui = $DIC->tabs();
         $this->ctrl = $DIC->ctrl();
-        $this->rbac_system = $DIC->rbac()->system();
+        $this->rbacsystem = $DIC->rbac()->system();
         $this->tree = $DIC->repositoryTree();
         $this->toolbarGUI = $DIC->toolbar();
 

--- a/Services/MetaData/classes/class.ilObjMDSettingsGUI.php
+++ b/Services/MetaData/classes/class.ilObjMDSettingsGUI.php
@@ -83,7 +83,7 @@ class ilObjMDSettingsGUI extends ilObjectGUI
 
         $this->prepareOutput();
 
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 
@@ -140,7 +140,7 @@ class ilObjMDSettingsGUI extends ilObjectGUI
 
     public function getAdminTabs() : void
     {
-        if ($this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "md_general_settings",
                 $this->ctrl->getLinkTarget($this, "showGeneralSettings"),
@@ -161,7 +161,7 @@ class ilObjMDSettingsGUI extends ilObjectGUI
             );
         }
 
-        if ($this->rbac_system->checkAccess('edit_permission', $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess('edit_permission', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "perm_settings",
                 $this->ctrl->getLinkTargetByClass('ilpermissiongui', "perm"),

--- a/Services/News/classes/class.ilObjNewsSettingsGUI.php
+++ b/Services/News/classes/class.ilObjNewsSettingsGUI.php
@@ -39,7 +39,7 @@ class ilObjNewsSettingsGUI extends ilObjectGUI
 
         $this->prepareOutput();
 
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             throw new ilPermissionException($this->lng->txt('no_permission'));
         }
 
@@ -62,7 +62,7 @@ class ilObjNewsSettingsGUI extends ilObjectGUI
 
     public function getAdminTabs() : void
     {
-        $rbacsystem = $this->rbac_system;
+        $rbacsystem = $this->rbacsystem;
 
         if ($rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->tabs_gui->addTarget(

--- a/Services/Object/classes/class.ilObjObjectFolderGUI.php
+++ b/Services/Object/classes/class.ilObjObjectFolderGUI.php
@@ -40,7 +40,7 @@ class ilObjObjectFolderGUI extends ilObjectGUI
     */
     public function viewObject() : void
     {
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt("permission_denied"), $this->error->MESSAGE);
         }
 
@@ -95,7 +95,7 @@ class ilObjObjectFolderGUI extends ilObjectGUI
 
     protected function getTabs() : void
     {
-        if ($this->rbac_system->checkAccess('edit_permission', $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess('edit_permission', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "settings",
                 $this->ctrl->getLinkTarget($this, "view"),

--- a/Services/Object/classes/class.ilObjTypeDefinitionGUI.php
+++ b/Services/Object/classes/class.ilObjTypeDefinitionGUI.php
@@ -42,7 +42,7 @@ class ilObjTypeDefinitionGUI extends ilObjectGUI
         $this->data["ctrl"] = [];
         $this->data["cols"] = ["type", "operation", "description", "status"];
 
-        $ops_valid = $this->rbac_review->getOperationsOnType(
+        $ops_valid = $this->rbacreview->getOperationsOnType(
             $this->request_wrapper->retrieve("obj_id", $this->refinery->kindlyTo()->int())
         );
 
@@ -170,11 +170,11 @@ class ilObjTypeDefinitionGUI extends ilObjectGUI
         $ref_id = $this->request_wrapper->retrieve("ref_id", $this->refinery->kindlyTo()->int());
         $obj_id = $this->request_wrapper->retrieve("obj_id", $this->refinery->kindlyTo()->int());
 
-        if (!$this->rbac_system->checkAccess('edit_permission', $ref_id)) {
+        if (!$this->rbacsystem->checkAccess('edit_permission', $ref_id)) {
             $this->error->raiseError($this->lng->txt("permission_denied"), $this->error->WARNING);
         }
 
-        $ops_valid = $this->rbac_review->getOperationsOnType($obj_id);
+        $ops_valid = $this->rbacreview->getOperationsOnType($obj_id);
 
         $ids = $this->post_wrapper->retrieve(
             "id",
@@ -183,13 +183,13 @@ class ilObjTypeDefinitionGUI extends ilObjectGUI
         foreach ($ids as $ops_id => $status) {
             if ($status == 'enabled') {
                 if (!in_array($ops_id, $ops_valid)) {
-                    $this->rbac_admin->assignOperationToObject($obj_id, $ops_id);
+                    $this->rbacadmin->assignOperationToObject($obj_id, $ops_id);
                 }
             }
 
             if ($status == 'disabled') {
                 if (in_array($ops_id, $ops_valid)) {
-                    $this->rbac_admin->deassignOperationFromObject($obj_id, $ops_id);
+                    $this->rbacadmin->deassignOperationFromObject($obj_id, $ops_id);
                 }
             }
         }
@@ -208,7 +208,7 @@ class ilObjTypeDefinitionGUI extends ilObjectGUI
     public function editObject() : void
     {
         $ref_id = $this->request_wrapper->retrieve("ref_id", $this->refinery->kindlyTo()->int());
-        if (!$this->rbac_system->checkAccess("edit_permission", $ref_id)) {
+        if (!$this->rbacsystem->checkAccess("edit_permission", $ref_id)) {
             $this->error->raiseError($this->lng->txt("permission_denied"), $this->error->MESSAGE);
         }
 
@@ -218,7 +218,7 @@ class ilObjTypeDefinitionGUI extends ilObjectGUI
         $this->data["ctrl"] = [];
         $this->data["cols"] = ["type", "operation", "description", "status"];
 
-        $ops_valid = $this->rbac_review->getOperationsOnType($this->obj_id);
+        $ops_valid = $this->rbacreview->getOperationsOnType($this->obj_id);
 
         if ($ops_arr = ilRbacReview::_getOperationList()) {
             $options = ["e" => "enabled","d" => "disabled"];
@@ -339,7 +339,7 @@ class ilObjTypeDefinitionGUI extends ilObjectGUI
 
     protected function getTabs() : void
     {
-        if ($this->rbac_system->checkAccess('edit_permission', $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess('edit_permission', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "settings",
                 $this->ctrl->getLinkTarget($this, "view"),

--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -37,8 +37,8 @@ class ilObject
     protected ?ilErrorHandling $error;
     protected ilTree $tree;
     protected ?ilAppEventHandler $app_event_handler;
-    protected ilRbacAdmin $rbac_admin;
-    protected ilRbacReview $rbac_review;
+    protected ilRbacAdmin $rbacadmin;
+    protected ilRbacReview $rbacreview;
     protected ilObjUser $user;
     protected ilLanguage $lng;
 
@@ -99,11 +99,11 @@ class ilObject
         }
 
         if (isset($DIC["rbacadmin"])) {
-            $this->rbac_admin = $DIC["rbacadmin"];
+            $this->rbacadmin = $DIC["rbacadmin"];
         }
 
         if (isset($DIC["rbacreview"])) {
-            $this->rbac_review = $DIC["rbacreview"];
+            $this->rbacreview = $DIC["rbacreview"];
         }
 
         if ($id == 0) {
@@ -1193,17 +1193,17 @@ class ilObject
      */
     public function setParentRolePermissions(int $parent_ref_id) : bool
     {
-        $parent_roles = $this->rbac_review->getParentRoleIds($parent_ref_id);
+        $parent_roles = $this->rbacreview->getParentRoleIds($parent_ref_id);
         foreach ($parent_roles as $parent_role) {
             if ($parent_role['obj_id'] == SYSTEM_ROLE_ID) {
                 continue;
             }
-            $operations = $this->rbac_review->getOperationsOfRole(
+            $operations = $this->rbacreview->getOperationsOfRole(
                 (int) $parent_role['obj_id'],
                 $this->getType(),
                 (int) $parent_role['parent']
             );
-            $this->rbac_admin->grantPermission(
+            $this->rbacadmin->grantPermission(
                 (int) $parent_role['obj_id'],
                 $operations,
                 $this->getRefId()
@@ -1267,7 +1267,7 @@ class ilObject
     public function delete() : bool
     {
         global $DIC;
-        $rbac_admin = $DIC["rbacadmin"];
+        $rbacadmin = $DIC["rbacadmin"];
 
         $remove = false;
 
@@ -1373,7 +1373,7 @@ class ilObject
             // DONE: method overwritten in ilObjRole & ilObjUser.
             // this call only applies for objects in rbac (not usr,role,rolt)
             // TODO: Do this for role templates too
-            $rbac_admin->revokePermission($this->getRefId(), 0, false);
+            $rbacadmin->revokePermission($this->getRefId(), 0, false);
 
             ilRbacLog::delete($this->getRefId());
 
@@ -1557,7 +1557,7 @@ class ilObject
         global $DIC;
 
         $ilUser = $DIC["ilUser"];
-        $rbac_admin = $DIC["rbacadmin"];
+        $rbacadmin = $DIC["rbacadmin"];
 
         $class_name = ('ilObj' . $this->obj_definition->getClassName($this->getType()));
         
@@ -1592,7 +1592,7 @@ class ilObject
             // when copying from personal workspace we have no current ref id
             if ($this->getRefId()) {
                 // copy local roles
-                $rbac_admin->copyLocalRoles($this->getRefId(), $new_obj->getRefId());
+                $rbacadmin->copyLocalRoles($this->getRefId(), $new_obj->getRefId());
             }
         } else {
             ilLoggerFactory::getLogger('obj')->debug('Tree copy is disabled');

--- a/Services/Object/classes/class.ilObject2GUI.php
+++ b/Services/Object/classes/class.ilObject2GUI.php
@@ -62,9 +62,9 @@ abstract class ilObject2GUI extends ilObjectGUI
     protected ArrayBasedRequestWrapper $post_wrapper;
     protected RequestWrapper $request_wrapper;
     protected Factory $refinery;
-    protected ilRbacAdmin $rbac_admin;
-    protected ilRbacSystem $rbac_system;
-    protected ilRbacReview $rbac_review;
+    protected ilRbacAdmin $rbacadmin;
+    protected ilRbacSystem $rbacsystem;
+    protected ilRbacReview $rbacreview;
 
     protected int $request_ref_id;
     protected int $id_type;
@@ -101,9 +101,9 @@ abstract class ilObject2GUI extends ilObjectGUI
         $this->request_wrapper = $DIC->http()->wrapper()->query();
         $this->refinery = $DIC->refinery();
         $this->retriever = new ilObjectRequestRetriever($DIC->http()->wrapper(), $this->refinery);
-        $this->rbac_admin = $DIC->rbac()->admin();
-        $this->rbac_system = $DIC->rbac()->system();
-        $this->rbac_review = $DIC->rbac()->review();
+        $this->rbacadmin = $DIC->rbac()->admin();
+        $this->rbacsystem = $DIC->rbac()->system();
+        $this->rbacreview = $DIC->rbac()->review();
 
         $tree = $DIC["tree"];
 
@@ -678,7 +678,7 @@ abstract class ilObject2GUI extends ilObjectGUI
                 $obj->setPermissions($parent_node_id);
 
                 // rbac log
-                $rbac_log_roles = $this->rbac_review->getParentRoleIds($this->node_id, false);
+                $rbac_log_roles = $this->rbacreview->getParentRoleIds($this->node_id, false);
                 $rbac_log = ilRbacLog::gatherFaPa($this->node_id, array_keys($rbac_log_roles), true);
                 ilRbacLog::add(ilRbacLog::CREATE_OBJECT, $this->node_id, $rbac_log);
 

--- a/Services/Object/classes/class.ilObjectGUI.php
+++ b/Services/Object/classes/class.ilObjectGUI.php
@@ -45,9 +45,9 @@ class ilObjectGUI
     protected ilAccessHandler $access;
     protected ilSetting $settings;
     protected ilToolbarGUI $toolbar;
-    protected ilRbacAdmin $rbac_admin;
-    protected ilRbacSystem $rbac_system;
-    protected ilRbacReview $rbac_review;
+    protected ilRbacAdmin $rbacadmin;
+    protected ilRbacSystem $rbacsystem;
+    protected ilRbacReview $rbacreview;
     protected ilObjectService $object_service;
     protected ilObjectDefinition $obj_definition;
     protected ilGlobalTemplateInterface $tpl;
@@ -105,9 +105,9 @@ class ilObjectGUI
         $this->access = $DIC->access();
         $this->settings = $DIC->settings();
         $this->toolbar = $DIC->toolbar();
-        $this->rbac_admin = $DIC->rbac()->admin();
-        $this->rbac_system = $DIC->rbac()->system();
-        $this->rbac_review = $DIC->rbac()->review();
+        $this->rbacadmin = $DIC->rbac()->admin();
+        $this->rbacsystem = $DIC->rbac()->system();
+        $this->rbacreview = $DIC->rbac()->review();
         $this->object_service = $DIC->object();
         $this->obj_definition = $DIC["objDefinition"];
         $this->tpl = $DIC["tpl"];
@@ -884,7 +884,7 @@ class ilObjectGUI
         // END ChangeEvent: Record save object.
 
         // rbac log
-        $rbac_log_roles = $this->rbac_review->getParentRoleIds($this->ref_id, false);
+        $rbac_log_roles = $this->rbacreview->getParentRoleIds($this->ref_id, false);
         $rbac_log = ilRbacLog::gatherFaPa($this->ref_id, array_keys($rbac_log_roles), true);
         ilRbacLog::add(ilRbacLog::CREATE_OBJECT, $this->ref_id, $rbac_log);
         

--- a/Services/PrivacySecurity/classes/class.ilObjPrivacySecurityGUI.php
+++ b/Services/PrivacySecurity/classes/class.ilObjPrivacySecurityGUI.php
@@ -64,7 +64,7 @@ class ilObjPrivacySecurityGUI extends ilObjectGUI
 
         $this->prepareOutput();
 
-        if (!$this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess('visible,read', $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 
@@ -91,7 +91,7 @@ class ilObjPrivacySecurityGUI extends ilObjectGUI
      */
     public function getAdminTabs() : void
     {
-        if ($this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "show_privacy",
                 $this->ctrl->getLinkTarget($this, "showPrivacy"),
@@ -104,7 +104,7 @@ class ilObjPrivacySecurityGUI extends ilObjectGUI
             );
         }
 
-        if ($this->rbac_system->checkAccess('edit_permission', $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess('edit_permission', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "perm_settings",
                 $this->ctrl->getLinkTargetByClass('ilpermissiongui', "perm"),

--- a/Services/Search/classes/class.ilObjSearchSettingsGUI.php
+++ b/Services/Search/classes/class.ilObjSearchSettingsGUI.php
@@ -63,7 +63,7 @@ class ilObjSearchSettingsGUI extends ilObjectGUI
 
     public function settingsObject(?ilPropertyFormGUI $form = null) : bool
     {
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('permission_denied'), $this->error->MESSAGE);
         }
         $this->tabs_gui->setTabActive('settings');
@@ -82,7 +82,7 @@ class ilObjSearchSettingsGUI extends ilObjectGUI
 
     protected function getTabs() : void
     {
-        if ($this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "settings",
                 $this->ctrl->getLinkTarget($this, "settings"),
@@ -92,14 +92,14 @@ class ilObjSearchSettingsGUI extends ilObjectGUI
             );
         }
 
-        if ($this->rbac_system->checkAccess('read', $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess('read', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 'lucene_advanced_settings',
                 $this->ctrl->getLinkTarget($this, 'advancedLuceneSettings')
             );
         }
 
-        if ($this->rbac_system->checkAccess('read', $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess('read', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 'lucene_settings_tab',
                 $this->ctrl->getLinkTarget($this, 'luceneSettings')
@@ -107,7 +107,7 @@ class ilObjSearchSettingsGUI extends ilObjectGUI
         }
 
 
-        if ($this->rbac_system->checkAccess('edit_permission', $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess('edit_permission', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "perm_settings",
                 $this->ctrl->getLinkTargetByClass(array(get_class($this),'ilpermissiongui'), "perm"),

--- a/Services/Skill/Service/classes/class.SkillInternalManagerService.php
+++ b/Services/Skill/Service/classes/class.SkillInternalManagerService.php
@@ -35,20 +35,20 @@ class SkillInternalManagerService
     protected int $skmg_ref_id = 0;
     protected \ilTree $repository_tree;
     protected Tree\SkillTreeFactory $skill_tree_factory;
-    protected \ilRbacSystem $rbac_system;
+    protected \ilRbacSystem $rbacsystem;
     protected int $usr_id = 0;
 
     public function __construct(
         int $skmg_ref_id,
         \ilTree $repository_tree,
         Tree\SkillTreeFactory $skill_tree_factory,
-        \ilRbacSystem $rbac_system,
+        \ilRbacSystem $rbacsystem,
         int $usr_id
     ) {
         $this->skmg_ref_id = $skmg_ref_id;
         $this->repository_tree = $repository_tree;
         $this->skill_tree_factory = $skill_tree_factory;
-        $this->rbac_system = $rbac_system;
+        $this->rbacsystem = $rbacsystem;
         $this->usr_id = $usr_id;
     }
 
@@ -84,11 +84,11 @@ class SkillInternalManagerService
 
     public function getTreeAccessManager(int $obj_ref_id) : SkillTreeAccess
     {
-        return new SkillTreeAccess($this->rbac_system, $obj_ref_id, $this->usr_id);
+        return new SkillTreeAccess($this->rbacsystem, $obj_ref_id, $this->usr_id);
     }
 
     public function getManagementAccessManager(int $skmg_ref_id) : SkillManagementAccess
     {
-        return new SkillManagementAccess($this->rbac_system, $skmg_ref_id, $this->usr_id);
+        return new SkillManagementAccess($this->rbacsystem, $skmg_ref_id, $this->usr_id);
     }
 }

--- a/Services/Skill/Service/classes/class.SkillInternalService.php
+++ b/Services/Skill/Service/classes/class.SkillInternalService.php
@@ -33,18 +33,18 @@ class SkillInternalService
      */
     protected int $skmg_ref_id = 0;
     protected \ilTree $repository_tree;
-    protected \ilRbacSystem $rbac_system;
+    protected \ilRbacSystem $rbacsystem;
     protected int $usr_id = 0;
     protected HTTP\Services $http;
     protected Refinery\Factory $refinery;
 
-    public function __construct(int $skmg_ref_id, \ilTree $repository_tree, \ilRbacSystem $rbac_system, int $usr_id)
+    public function __construct(int $skmg_ref_id, \ilTree $repository_tree, \ilRbacSystem $rbacsystem, int $usr_id)
     {
         global $DIC;
 
         $this->skmg_ref_id = $skmg_ref_id;
         $this->repository_tree = $repository_tree;
-        $this->rbac_system = $rbac_system;
+        $this->rbacsystem = $rbacsystem;
         $this->usr_id = $usr_id;
         $this->http = $DIC->http();
         $this->refinery = $DIC->refinery();
@@ -61,7 +61,7 @@ class SkillInternalService
             $this->skmg_ref_id,
             $this->repository_tree,
             $this->factory()->tree(),
-            $this->rbac_system,
+            $this->rbacsystem,
             $this->usr_id
         );
     }

--- a/Services/Skill/Service/classes/class.SkillService.php
+++ b/Services/Skill/Service/classes/class.SkillService.php
@@ -30,7 +30,7 @@ class SkillService implements SkillServiceInterface
      */
     protected int $skmg_ref_id = 0;
     protected \ilTree $repository_tree;
-    protected \ilRbacSystem $rbac_system;
+    protected \ilRbacSystem $rbacsystem;
     protected int $usr_id = 0;
 
     public function __construct()
@@ -40,7 +40,7 @@ class SkillService implements SkillServiceInterface
         $this->repository_tree = $DIC->repositoryTree();
         $skmg_obj = current(\ilObject::_getObjectsByType("skmg"));
         $this->skmg_ref_id = (int) current(\ilObject::_getAllReferences($skmg_obj["obj_id"]));
-        $this->rbac_system = $DIC->rbac()->system();
+        $this->rbacsystem = $DIC->rbac()->system();
         $this->usr_id = $DIC->user()->getId();
     }
 
@@ -67,7 +67,7 @@ class SkillService implements SkillServiceInterface
         return new SkillInternalService(
             $this->skmg_ref_id,
             $this->repository_tree,
-            $this->rbac_system,
+            $this->rbacsystem,
             $this->usr_id
         );
     }

--- a/Services/Style/classes/class.ilObjStyleSettingsGUI.php
+++ b/Services/Style/classes/class.ilObjStyleSettingsGUI.php
@@ -106,7 +106,7 @@ class ilObjStyleSettingsGUI extends ilObjectGUI
     */
     public function getTabs() : void
     {
-        if ($this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->tabs_gui->addTab(
                 "system_styles",
                 $this->lng->txt("system_styles"),
@@ -126,7 +126,7 @@ class ilObjStyleSettingsGUI extends ilObjectGUI
             );
         }
 
-        if ($this->rbac_system->checkAccess('edit_permission', $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess('edit_permission', $this->object->getRefId())) {
             $this->tabs_gui->addTab(
                 "perm_settings",
                 $this->lng->txt("perm_settings"),

--- a/Services/SystemCheck/classes/class.ilObjSystemCheckGUI.php
+++ b/Services/SystemCheck/classes/class.ilObjSystemCheckGUI.php
@@ -111,10 +111,10 @@ class ilObjSystemCheckGUI extends ilObjectGUI
 
     public function getAdminTabs() : void
     {
-        if ($this->rbac_system->checkAccess('read', $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess('read', $this->object->getRefId())) {
             $this->tabs_gui->addTarget('overview', $this->ctrl->getLinkTarget($this, 'overview'));
         }
-        if ($this->rbac_system->checkAccess('edit_permission', $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess('edit_permission', $this->object->getRefId())) {
             $this->tabs_gui->addTarget('perm_settings', $this->ctrl->getLinkTargetByClass(array(get_class($this), 'ilpermissiongui'), 'perm'), array('perm', 'info', 'owner'), 'ilpermissiongui');
         }
     }

--- a/Services/TermsOfService/classes/class.ilObjTermsOfServiceGUI.php
+++ b/Services/TermsOfService/classes/class.ilObjTermsOfServiceGUI.php
@@ -123,7 +123,7 @@ class ilObjTermsOfServiceGUI extends ilObject2GUI implements ilTermsOfServiceCon
 
     public function getAdminTabs() : void
     {
-        if ($this->rbac_system->checkAccess('read', $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess('read', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 'tos_agreement_documents_tab_label',
                 $this->ctrl->getLinkTargetByClass(ilTermsOfServiceDocumentGUI::class),
@@ -132,7 +132,7 @@ class ilObjTermsOfServiceGUI extends ilObject2GUI implements ilTermsOfServiceCon
             );
         }
 
-        if ($this->rbac_system->checkAccess('read', $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess('read', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 'settings',
                 $this->ctrl->getLinkTarget($this, 'settings'),
@@ -142,8 +142,8 @@ class ilObjTermsOfServiceGUI extends ilObject2GUI implements ilTermsOfServiceCon
         }
 
         if (
-            (defined('USER_FOLDER_ID') && $this->rbac_system->checkAccess('read', USER_FOLDER_ID)) &&
-            $this->rbac_system->checkAccess('read', $this->object->getRefId())
+            (defined('USER_FOLDER_ID') && $this->rbacsystem->checkAccess('read', USER_FOLDER_ID)) &&
+            $this->rbacsystem->checkAccess('read', $this->object->getRefId())
         ) {
             $this->tabs_gui->addTarget(
                 'tos_acceptance_history',
@@ -153,7 +153,7 @@ class ilObjTermsOfServiceGUI extends ilObject2GUI implements ilTermsOfServiceCon
             );
         }
 
-        if ($this->rbac_system->checkAccess('edit_permission', $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess('edit_permission', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 'perm_settings',
                 $this->ctrl->getLinkTargetByClass([self::class, ilPermissionGUI::class], 'perm'),
@@ -171,7 +171,7 @@ class ilObjTermsOfServiceGUI extends ilObject2GUI implements ilTermsOfServiceCon
             $obj,
             $this->ctrl->getFormAction($this, 'saveSettings'),
             'saveSettings',
-            $this->rbac_system->checkAccess('write', $this->object->getRefId())
+            $this->rbacsystem->checkAccess('write', $this->object->getRefId())
         );
 
         ilAdministrationSettingsFormHandler::addFieldsToForm(
@@ -185,7 +185,7 @@ class ilObjTermsOfServiceGUI extends ilObject2GUI implements ilTermsOfServiceCon
 
     protected function saveSettings() : void
     {
-        if (!$this->rbac_system->checkAccess('write', $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess('write', $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('permission_denied'), $this->error->MESSAGE);
         }
 
@@ -213,7 +213,7 @@ class ilObjTermsOfServiceGUI extends ilObject2GUI implements ilTermsOfServiceCon
 
     protected function settings() : void
     {
-        if (!$this->rbac_system->checkAccess('read', $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess('read', $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('permission_denied'), $this->error->MESSAGE);
         }
 

--- a/Services/Tracking/classes/class.ilObjUserTrackingGUI.php
+++ b/Services/Tracking/classes/class.ilObjUserTrackingGUI.php
@@ -91,7 +91,7 @@ class ilObjUserTrackingGUI extends ilObjectGUI
             get_class($this)
         );
 
-        if ($this->rbac_system->checkAccess("visible,read", $this->ref_id)) {
+        if ($this->rbacsystem->checkAccess("visible,read", $this->ref_id)) {
             if (ilObjUserTracking::_enabledObjectStatistics()) {
                 $this->tabs_gui->addTarget(
                     "statistics",
@@ -145,7 +145,7 @@ class ilObjUserTrackingGUI extends ilObjectGUI
 
     public function settingsObject(?ilPropertyFormGUI $a_form = null) : void
     {
-        if (!$this->rbac_system->checkAccess(
+        if (!$this->rbacsystem->checkAccess(
             "visible,read",
             $this->object->getRefId()
         )) {

--- a/Services/WebDAV/classes/class.ilObjWebDAVGUI.php
+++ b/Services/WebDAV/classes/class.ilObjWebDAVGUI.php
@@ -72,7 +72,7 @@ class ilObjWebDAVGUI extends ilObjectGUI
     
     public function getAdminTabs() : void
     {
-        if ($this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if ($this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->tabs_gui->addTab(
                 'webdav_general_settings',
                 $this->lng->txt("webdav_general_settings"),
@@ -119,7 +119,7 @@ class ilObjWebDAVGUI extends ilObjectGUI
     {
         $this->tabs_gui->activateTab('webdav_general_settings');
 
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->error_handling->raiseError(
                 $this->lng->txt("no_permission"),
                 $this->error_handling->WARNING
@@ -133,7 +133,7 @@ class ilObjWebDAVGUI extends ilObjectGUI
     
     public function saveSettings() : void
     {
-        if (!$this->rbac_system->checkAccess("write", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("write", $this->object->getRefId())) {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('no_permission'), true);
             $this->ctrl->redirect($this, self::SETTING_COMMANDS['edit']);
         }

--- a/Services/WebServices/ECS/classes/class.ilObjECSSettingsGUI.php
+++ b/Services/WebServices/ECS/classes/class.ilObjECSSettingsGUI.php
@@ -43,7 +43,7 @@ class ilObjECSSettingsGUI extends ilObjectGUI
 
         $this->prepareOutput();
 
-        if (!$this->rbac_system->checkAccess("visible,read", $this->object->getRefId())) {
+        if (!$this->rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
             $this->error->raiseError($this->lng->txt('no_permission'), $this->error->WARNING);
         }
 


### PR DESCRIPTION
When refactoring, I overdid it a bit by renaming rbac_.. variables. So I'm trying to revert to the old naming. Hopefully that fixes the mess.