### PR TITLE
Review `Services/Block`

### DIFF
--- a/Services/Block/classes/class.StandardGUIRequest.php
+++ b/Services/Block/classes/class.StandardGUIRequest.php
@@ -21,6 +21,11 @@ class StandardGUIRequest
 {
     use BaseGUIRequest;
 
+    /**
+     *
+     * @param string[] $passed_query_params
+     * @param string[] $passed_post_data
+     */
     public function __construct(
         \ILIAS\HTTP\Services $http,
         \ILIAS\Refinery\Factory $refinery,

--- a/Services/Block/classes/class.ilBlockGUI.php
+++ b/Services/Block/classes/class.ilBlockGUI.php
@@ -45,7 +45,7 @@ abstract class ilBlockGUI
     protected bool $allow_moving = true;
     protected array $move = array("left" => false, "right" => false, "up" => false, "down" => false);
     protected array $block_commands = array();
-    protected bool $max_count = false;
+    protected bool $max_count = false; //Todo Review PHP8: Are you sure you want a bool here? All assignments seem to be autocast from int.
     protected bool $close_command = false;
     protected bool $image = false;
     protected array $property = [];

--- a/Services/Block/classes/class.ilBlockSetting.php
+++ b/Services/Block/classes/class.ilBlockSetting.php
@@ -145,7 +145,7 @@ class ilBlockSetting
     ) : int {
         $detail = ilBlockSetting::_lookup($a_type, "detail", $a_user, $a_block_id);
 
-        if ($detail === false) {		// return a level of 2 (standard value)
+        if ($detail === false) {		// return a level of 2 (standard value); //Todo Review PHP8: This should always be false as $detail is string|null
             // if record does not exist
             return 2;
         } else {

--- a/Services/Block/classes/class.ilColumnGUI.php
+++ b/Services/Block/classes/class.ilColumnGUI.php
@@ -680,7 +680,7 @@ class ilColumnGUI
                         $nr = -16;
                     }
                     $side = ilBlockSetting::_lookupSide($type, $user_id);
-                    if ($side === false) {
+                    if ($side === false) { //Todo Review PHP8: This should always be false as $side is string|null
                         $side = $def_side;
                     }
                     if ($side == IL_COL_LEFT) {
@@ -713,7 +713,7 @@ class ilColumnGUI
                         $nr = $def_nr++;
                     }
                     $side = ilBlockSetting::_lookupSide($type, $user_id, $c_block["id"]);
-                    if ($side === false) {
+                    if ($side === false) { //Todo Review PHP8: This should always be false as $side is string|null
                         $side = IL_COL_RIGHT;
                     }
     

--- a/Services/Block/test/BlockSessionRepositoryTest.php
+++ b/Services/Block/test/BlockSessionRepositoryTest.php
@@ -24,7 +24,7 @@ class BlockSessionRepositoryTest extends TestCase
     /**
      * Test parent set/get
      */
-    public function testParent()
+    public function testParent() : void
     {
         $repo = $this->repo;
         $repo->setNavPar("one", "test");

--- a/Services/Block/test/ilServicesBlockSuite.php
+++ b/Services/Block/test/ilServicesBlockSuite.php
@@ -22,7 +22,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilServicesBlockSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : ilServicesBlockSuite
     {
         $suite = new self();
 


### PR DESCRIPTION
Hi @alex40724 

Here are the results of the `Services/Block` review.

### Results

- [x] The code style is PSR-2 + X compliant:
- [x] No usage of $_GET / $_POST / $_REQUEST / $_SESSION: 
- [x] There is a Unit Test Suite with at least one unit test:
- [x] The unit tests pass
- [ ] External libraries are compatible with PHP 8 (if relevant): _Not relevant_
- [ ] The types are fully documented (PHPDoc) or explicit PHP types are used (type hints, return types, typed properties)

### Comments
- You still rely heavily on automatic type conversion and it is not always obvious, if things will go right (see Todos)
- Array parameters could be specified more closely, defining what types are expected in arrays. In just added one I was fairly sure about.

### Changes made in this PR:
- Fixed CS
- Added some types and one array declaration in Params
- Added a few //Todo Review PHP8:

Best regards,
@swiniker