### PR TITLE
PHP 8 Review: `Verification`

### DIFF
--- a/Services/Verification/classes/Certificate/class.ilCertificateVerificationObject.php
+++ b/Services/Verification/classes/Certificate/class.ilCertificateVerificationObject.php
@@ -25,13 +25,15 @@ class ilCertificateVerificationObject extends ilVerificationObject
         parent::__construct($a_id, $a_reference);
     }
 
-    protected function initType()
+    /**
+     * @inheritDoc
+     */
+    protected function initType() : void
     {
     }
 
     /**
-     * Return property map (name => type)
-     * @return array
+     * @inheritDoc
      */
     protected function getPropertyMap() : array
     {

--- a/Services/Verification/classes/class.ilVerificationObject.php
+++ b/Services/Verification/classes/class.ilVerificationObject.php
@@ -112,7 +112,7 @@ abstract class ilVerificationObject extends ilObject2
 
                 case self::TYPE_ARRAY:
                     if ($a_data) {
-                        $value = unserialize($a_data);
+                        $value = unserialize($a_data, ['allowed_classes' => false]);
                     }
                     break;
 
@@ -162,7 +162,7 @@ abstract class ilVerificationObject extends ilObject2
         return null;
     }
 
-    protected function doRead()
+    protected function doRead() : bool
     {
         $ilDB = $this->db;
 
@@ -183,12 +183,12 @@ abstract class ilVerificationObject extends ilObject2
         return false;
     }
 
-    public function doCreate()
+    protected function doCreate() : bool
     {
         return $this->saveProperties();
     }
-    
-    public function doUpdate()
+
+    protected function doUpdate() : bool
     {
         return $this->saveProperties();
     }
@@ -222,8 +222,8 @@ abstract class ilVerificationObject extends ilObject2
         }
         return false;
     }
-    
-    public function doDelete()
+
+    protected function doDelete() : bool
     {
         $ilDB = $this->db;
 
@@ -263,7 +263,7 @@ abstract class ilVerificationObject extends ilObject2
     {
         $file = $this->getProperty("file");
         if ($file) {
-            $path = $this->initStorage($this->getId(), "certificate");
+            $path = self::initStorage($this->getId(), "certificate");
             return $path . $file;
         }
         return "";

--- a/Services/Verification/classes/class.ilVerificationStorageFile.php
+++ b/Services/Verification/classes/class.ilVerificationStorageFile.php
@@ -25,12 +25,12 @@ class ilVerificationStorageFile extends ilFileSystemAbstractionStorage
         parent::__construct(self::STORAGE_DATA, true, $a_container_id);
     }
 
-    protected function getPathPostfix():string
+    protected function getPathPostfix() : string
     {
         return 'vrfc';
     }
 
-    protected function getPathPrefix():string
+    protected function getPathPrefix() : string
     {
         return 'ilVerification';
     }

--- a/Services/Verification/test/CertificateVerificationClassMapTest.php
+++ b/Services/Verification/test/CertificateVerificationClassMapTest.php
@@ -9,16 +9,11 @@ use PHPUnit\Framework\TestCase;
  */
 class CertificateVerificationClassMapTest extends TestCase
 {
-    protected function setUp() : void
-    {
-        parent::setUp();
-    }
-
     protected function tearDown() : void
     {
     }
 
-    public function testClassMap()
+    public function testClassMap() : void
     {
         $map = new ilCertificateVerificationClassMap();
         $this->assertEquals(

--- a/Services/Verification/test/ilServicesVerificationSuite.php
+++ b/Services/Verification/test/ilServicesVerificationSuite.php
@@ -22,7 +22,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilServicesVerificationSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new self();
 


### PR DESCRIPTION
Hello @alex40724, 

I completed the review of the `Services/Verification` component.

Results:

- [x] The code style is `PSR-2 + X` compliant
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

--

Actions needed:
None

Best regards,
@mjansenDatabay  