### PR TITLE
PHP 8 Review: `Notes`

### DIFF
--- a/Services/Notes/Administration/classes/class.ilObjCommentsSettingsGUI.php
+++ b/Services/Notes/Administration/classes/class.ilObjCommentsSettingsGUI.php
@@ -38,7 +38,7 @@ class ilObjCommentsSettingsGUI extends ilObjectGUI
         global $DIC;
 
         $this->lng = $DIC->language();
-        $this->rbacsystem = $DIC->rbac()->system();
+        $this->rbacsystem = $DIC->rbac()->system();// TODO PHP8-REVIEW Property declared dynamically
         $this->ctrl = $DIC->ctrl();
         $this->request = $DIC->http()->request();
         $this->tabs = $DIC->tabs();
@@ -80,7 +80,7 @@ class ilObjCommentsSettingsGUI extends ilObjectGUI
                 break;
 
             default:
-                if ($cmd == "view") {
+                if ($cmd === "view") {
                     $cmd = "editSettings";
                 }
                 if (in_array($cmd, ["editSettings", "saveSettings"])) {
@@ -181,7 +181,7 @@ class ilObjCommentsSettingsGUI extends ilObjectGUI
         $ctrl = $this->ctrl;
         $setting = $this->setting;
 
-        if ($request->getMethod() == "POST") {
+        if ($request->getMethod() === "POST") {
             $form = $form->withRequest($request);
             $data = $form->getData();
             if (is_array($data["sec"])) {

--- a/Services/Notes/Administration/classes/class.ilObjNotesSettingsGUI.php
+++ b/Services/Notes/Administration/classes/class.ilObjNotesSettingsGUI.php
@@ -39,6 +39,7 @@ class ilObjNotesSettingsGUI extends ilObjectGUI
 
         $this->lng = $DIC->language();
         $this->rbacsystem = $DIC->rbac()->system();
+        ;// TODO PHP8-REVIEW Property declared dynamically
         $this->error = $DIC["ilErr"];
         $this->ctrl = $DIC->ctrl();
         $this->request = $DIC->http()->request();
@@ -81,7 +82,7 @@ class ilObjNotesSettingsGUI extends ilObjectGUI
                 break;
 
             default:
-                if ($cmd == "view") {
+                if ($cmd === "view") {
                     $cmd = "editSettings";
                 }
                 if (in_array($cmd, ["editSettings", "saveSettings"])) {
@@ -153,7 +154,7 @@ class ilObjNotesSettingsGUI extends ilObjectGUI
         $ctrl = $this->ctrl;
         $setting = $this->setting;
 
-        if ($request->getMethod() == "POST") {
+        if ($request->getMethod() === "POST") {
             $form = $form->withRequest($request);
             $data = $form->getData();
             if (is_array($data["sec"])) {

--- a/Services/Notes/Administration/classes/class.ilObjNotesSettingsGUI.php
+++ b/Services/Notes/Administration/classes/class.ilObjNotesSettingsGUI.php
@@ -38,8 +38,7 @@ class ilObjNotesSettingsGUI extends ilObjectGUI
         global $DIC;
 
         $this->lng = $DIC->language();
-        $this->rbacsystem = $DIC->rbac()->system();
-        ;// TODO PHP8-REVIEW Property declared dynamically
+        $this->rbacsystem = $DIC->rbac()->system();// TODO PHP8-REVIEW Property declared dynamically
         $this->error = $DIC["ilErr"];
         $this->ctrl = $DIC->ctrl();
         $this->request = $DIC->http()->request();

--- a/Services/Notes/Export/class.ExportHelperGUI.php
+++ b/Services/Notes/Export/class.ExportHelperGUI.php
@@ -44,26 +44,29 @@ class ExportHelperGUI
         $mess = $factory->messageBox()->confirmation($message);
         $modal = $factory->modal()->roundtrip($title, [$mess]);
 
-        $b1 = $factory->button()->standard($this->lng->txt("no"), "")
-                      ->withAdditionalOnLoadCode(function ($id) use ($export_cmd, $js) {
-                          $cmd_js = ($js)
-                              ? $export_cmd
-                              : "window.location.href='$export_cmd'";
-                          return "document.querySelector('#$id').addEventListener('click', (e) => {
+        $b1 = $factory->button()
+            ->standard($this->lng->txt("no"), "")
+            ->withAdditionalOnLoadCode(static function ($id) use ($export_cmd, $js) : string {
+                $cmd_js = ($js)
+                    ? $export_cmd
+                    : "window.location.href='$export_cmd'";
+                return "document.querySelector('#$id').addEventListener('click', (e) => {
                     $('#$id').closest('.modal-content').find('button.close').click();
                     $cmd_js
                 });";
-                      });
-        $b2 = $factory->button()->standard($this->lng->txt("yes"), "")
-                      ->withAdditionalOnLoadCode(function ($id) use ($export_with_comments_cmd, $js) {
-                          $cmd_js = ($js)
-                              ? $export_with_comments_cmd
-                              : "window.location.href='$export_with_comments_cmd'";
-                          return "document.querySelector('#$id').addEventListener('click', (e) => {
+            });
+
+        $b2 = $factory->button()
+            ->standard($this->lng->txt("yes"), "")
+            ->withAdditionalOnLoadCode(static function ($id) use ($export_with_comments_cmd, $js) : string {
+                $cmd_js = ($js)
+                    ? $export_with_comments_cmd
+                    : "window.location.href='$export_with_comments_cmd'";
+                return "document.querySelector('#$id').addEventListener('click', (e) => {
                     $('#$id').closest('.modal-content').find('button.close').click();
                     $cmd_js
                 });";
-                      });
+            });
 
         $modal = $modal->withActionButtons([$b1, $b2]);
 

--- a/Services/Notes/Export/class.UserImageExporter.php
+++ b/Services/Notes/Export/class.UserImageExporter.php
@@ -44,7 +44,7 @@ class UserImageExporter
         );
         $user_ids = [];
         while ($rec = $db->fetchAssoc($set)) {
-            $user_ids[] = $rec["author"];
+            $user_ids[] = (int) $rec["author"];
         }
         $user_export = new \ILIAS\User\Export\UserHtmlExport();
         $user_export->exportUserImages($export_dir, $user_ids);

--- a/Services/Notes/Export/class.ilNotesDataSet.php
+++ b/Services/Notes/Export/class.ilNotesDataSet.php
@@ -27,7 +27,7 @@ class ilNotesDataSet extends ilDataSet
         return array("4.3.0");
     }
     
-    public function getXmlNamespace(string $a_entity, string $a_schema_version) : string
+    protected function getXmlNamespace(string $a_entity, string $a_schema_version) : string
     {
         return "https://www.ilias.de/xml/Services/Notes/" . $a_entity;
     }
@@ -37,7 +37,7 @@ class ilNotesDataSet extends ilDataSet
         string $a_version
     ) : array {
         // user notes
-        if ($a_entity == "user_notes") {
+        if ($a_entity === "user_notes") {
             switch ($a_version) {
                 case "4.3.0":
                     return array(
@@ -66,7 +66,7 @@ class ilNotesDataSet extends ilDataSet
         $ilDB = $this->db;
 
         // user notes
-        if ($a_entity == "user_notes") {
+        if ($a_entity === "user_notes") {
             switch ($a_version) {
                 case "4.3.0":
                     $this->getDirectDataFromQuery("SELECT id, rep_obj_id, obj_id, obj_type, type, " .
@@ -78,15 +78,6 @@ class ilNotesDataSet extends ilDataSet
                     break;
             }
         }
-    }
-    
-    protected function getDependencies(
-        string $a_entity,
-        string $a_version,
-        ?array $a_rec = null,
-        ?array $a_ids = null
-    ) : array {
-        return [];
     }
 
     public function importRecord(
@@ -102,14 +93,14 @@ class ilNotesDataSet extends ilDataSet
                 if ($usr_id > 0) {
                     // only import real user (assigned to personal desktop) notes
                     // here.
-                    if ((int) $a_rec["RepObjId"] == 0 &&
+                    if ((int) $a_rec["RepObjId"] === 0 &&
                         $a_rec["ObjId"] == $a_rec["Author"] &&
-                        $a_rec["Type"] == ilNote::PRIVATE &&
-                        $a_rec["ObjType"] == "pd") {
+                        $a_rec["Type"] === ilNote::PRIVATE &&
+                        $a_rec["ObjType"] === "pd") {
                         $note = new ilNote();
-                        $note->setObject("pd", 0, $usr_id);
+                        $note->setObject("pd", 0, (int) $usr_id);
                         $note->setType(ilNote::PRIVATE);
-                        $note->setAuthor($usr_id);
+                        $note->setAuthor((int) $usr_id);
                         $note->setText($a_rec["NoteText"]);
                         $note->setSubject($a_rec["Subject"]);
                         $note->setCreationDate($a_rec["CreationDate"]);

--- a/Services/Notes/GlobalScreen/classes/NotesMainBarProvider.php
+++ b/Services/Notes/GlobalScreen/classes/NotesMainBarProvider.php
@@ -44,7 +44,7 @@ class NotesMainBarProvider extends AbstractStaticMainMenuProvider
             ->withParent(StandardTopItemsProvider::getInstance()->getCommunicationIdentification())
             ->withPosition(50)
             ->withSymbol($icon)
-            ->withNonAvailableReason($this->dic->ui()->factory()->legacy("{$this->dic->language()->txt('component_not_active')}"))
+            ->withNonAvailableReason($this->dic->ui()->factory()->legacy($this->dic->language()->txt('component_not_active')))
             ->withAvailableCallable(
                 static function () use ($dic) : bool {
                     return !$dic->settings()->get("disable_comments");

--- a/Services/Notes/GlobalScreen/classes/NotesMainBarProvider.php
+++ b/Services/Notes/GlobalScreen/classes/NotesMainBarProvider.php
@@ -46,7 +46,7 @@ class NotesMainBarProvider extends AbstractStaticMainMenuProvider
             ->withSymbol($icon)
             ->withNonAvailableReason($this->dic->ui()->factory()->legacy("{$this->dic->language()->txt('component_not_active')}"))
             ->withAvailableCallable(
-                function () use ($dic) {
+                static function () use ($dic) : bool {
                     return !$dic->settings()->get("disable_comments");
                 }
             );
@@ -61,9 +61,9 @@ class NotesMainBarProvider extends AbstractStaticMainMenuProvider
             ->withParent(StandardTopItemsProvider::getInstance()->getPersonalWorkspaceIdentification())
             ->withPosition(70)
             ->withSymbol($icon)
-            ->withNonAvailableReason($this->dic->ui()->factory()->legacy("{$this->dic->language()->txt('component_not_active')}"))
+            ->withNonAvailableReason($this->dic->ui()->factory()->legacy($this->dic->language()->txt('component_not_active')))
             ->withAvailableCallable(
-                function () use ($dic) {
+                static function () use ($dic) : bool {
                     return !$dic->settings()->get("disable_notes");
                 }
             );

--- a/Services/Notes/classes/class.ilNote.php
+++ b/Services/Notes/classes/class.ilNote.php
@@ -244,7 +244,7 @@ class ilNote
 
         $this->sendNotifications();
         
-        $this->creation_date = ilNote::_lookupCreationDate($this->getId());
+        $this->creation_date = self::_lookupCreationDate($this->getId());
     }
 
     public function update() : void
@@ -267,7 +267,7 @@ class ilNote
             "id" => array("integer", $this->getId())
             ));
         
-        $this->update_date = ilNote::_lookupUpdateDate($this->getId());
+        $this->update_date = self::_lookupUpdateDate($this->getId());
 
         $this->sendNotifications(true);
     }
@@ -365,7 +365,7 @@ class ilNote
         $ilDB = $DIC->database();
         $ilUser = $DIC->user();
         
-        $author_where = ($a_type == ilNote::PRIVATE || $a_all_public == "n")
+        $author_where = ($a_type == self::PRIVATE || $a_all_public === "n")
             ? " AND author = " . $ilDB->quote($ilUser->getId(), "integer")
             : "";
 
@@ -464,7 +464,7 @@ class ilNote
         
         if ($a_mode == ilPDNotesGUI::PRIVATE_NOTES) {
             $q = "SELECT DISTINCT rep_obj_id FROM note WHERE " .
-                " type = " . $ilDB->quote(ilNote::PRIVATE, "integer") .
+                " type = " . $ilDB->quote(self::PRIVATE, "integer") .
                 " AND author = " . $ilDB->quote($ilUser->getId(), "integer") .
                 " AND (no_repository IS NULL OR no_repository < " . $ilDB->quote(1, "integer") . ")" .
                 " ORDER BY rep_obj_id";
@@ -481,7 +481,7 @@ class ilNote
         } else {
             // all objects where the user wrote at least one comment
             $q = "SELECT DISTINCT rep_obj_id FROM note WHERE " .
-                " type = " . $ilDB->quote(ilNote::PUBLIC, "integer") .
+                " type = " . $ilDB->quote(self::PUBLIC, "integer") .
                 " AND author = " . $ilDB->quote($ilUser->getId(), "integer") .
                 " AND (no_repository IS NULL OR no_repository < " . $ilDB->quote(1, "integer") . ")" .
                 " ORDER BY rep_obj_id";
@@ -491,7 +491,7 @@ class ilNote
             while ($rep_rec = $ilDB->fetchAssoc($set)) {
                 // #9343: deleted objects
                 if ($type = ilObject::_lookupType((int) $rep_rec["rep_obj_id"])) {
-                    if (ilNote::commentsActivated((int) $rep_rec["rep_obj_id"], 0, $type)) {
+                    if (self::commentsActivated((int) $rep_rec["rep_obj_id"], 0, $type)) {
                         $reps[] = array("rep_obj_id" => (int) $rep_rec["rep_obj_id"]);
                     }
                 }
@@ -519,7 +519,7 @@ class ilNote
                     }
                     if ($add) {
                         $type = ilObject::_lookupType($rec["rep_obj_id"]);
-                        if (ilNote::commentsActivated($rec["rep_obj_id"], "", $type)) {
+                        if (self::commentsActivated($rec["rep_obj_id"], "", $type)) {
                             $reps[] = array("rep_obj_id" => $rec["rep_obj_id"]);
                         }
                     }
@@ -527,7 +527,7 @@ class ilNote
             }
         }
                 
-        if (sizeof($reps)) {
+        if (count($reps)) {
             // check if notes/comments belong to objects in trash
             // see ilNoteGUI::showTargets()
             foreach ($reps as $idx => $rep) {
@@ -599,9 +599,9 @@ class ilNote
         $ilUser = $DIC->user();
         
         $q = "SELECT count(id) c, rep_obj_id, type FROM note WHERE " .
-            " ((type = " . $ilDB->quote(ilNote::PRIVATE, "integer") . " AND " .
+            " ((type = " . $ilDB->quote(self::PRIVATE, "integer") . " AND " .
             "author = " . $ilDB->quote($ilUser->getId(), "integer") . ") OR " .
-            " type = " . $ilDB->quote(ilNote::PUBLIC, "integer") . ") AND " .
+            " type = " . $ilDB->quote(self::PUBLIC, "integer") . ") AND " .
             $ilDB->in("rep_obj_id", $a_rep_obj_ids, false, "integer");
         
         if ($a_no_sub_objs) {
@@ -634,9 +634,9 @@ class ilNote
         $ilUser = $DIC->user();
         
         $q = "SELECT count(id) c, rep_obj_id, type FROM note WHERE " .
-            " ((type = " . $ilDB->quote(ilNote::PRIVATE, "integer") . " AND " .
+            " ((type = " . $ilDB->quote(self::PRIVATE, "integer") . " AND " .
             "author = " . $ilDB->quote($ilUser->getId(), "integer") . ") OR " .
-            " type = " . $ilDB->quote(ilNote::PUBLIC, "integer") . ") AND " .
+            " type = " . $ilDB->quote(self::PUBLIC, "integer") . ") AND " .
             " rep_obj_id = " . $ilDB->quote($a_rep_obj_id, "integer");
         
         if ($a_sub_obj_id !== null) {
@@ -690,17 +690,15 @@ class ilNote
                     " AND obj_type = " . $ilDB->quote($a_obj_type, "text")
                 );
             }
-        } else {
-            if ($a_activate) {
-                $q = "INSERT INTO note_settings " .
-                    "(rep_obj_id, obj_id, obj_type, activated) VALUES (" .
-                    $ilDB->quote($a_rep_obj_id, "integer") . "," .
-                    $ilDB->quote($a_obj_id, "integer") . "," .
-                    $ilDB->quote($a_obj_type, "text") . "," .
-                    $ilDB->quote(1, "integer") .
-                    ")";
-                $ilDB->manipulate($q);
-            }
+        } elseif ($a_activate) {
+            $q = "INSERT INTO note_settings " .
+                "(rep_obj_id, obj_id, obj_type, activated) VALUES (" .
+                $ilDB->quote($a_rep_obj_id, "integer") . "," .
+                $ilDB->quote($a_obj_id, "integer") . "," .
+                $ilDB->quote($a_obj_type, "text") . "," .
+                $ilDB->quote(1, "integer") .
+                ")";
+            $ilDB->manipulate($q);
         }
     }
     
@@ -767,7 +765,7 @@ class ilNote
         $type_lv = "";
 
         // no notifications for notes
-        if ($this->getType() == ilNote::PRIVATE) {
+        if ($this->getType() == self::PRIVATE) {
             return;
         }
 
@@ -788,28 +786,27 @@ class ilNote
 
         // repository objects, no blogs
         $ref_ids = array();
-        if (($sub_obj_id == 0 and $type != "blp") ||
-            in_array($type, array("pg", "wpg"))) {
+        if (($sub_obj_id == 0 && $type !== "blp") || in_array($type, array("pg", "wpg"), true)) {
             $obj_title = ilObject::_lookupTitle($rep_obj_id);
             $type_lv = "obj_" . $type;
             $ref_ids = ilObject::_getAllReferences($rep_obj_id);
         }
 
-        if ($type == "wpg") {
+        if ($type === "wpg") {
             $type_lv = "obj_wiki";
         }
-        if ($type == "pg") {
+        if ($type === "pg") {
             $type_lv = "obj_lm";
         }
-        if ($type == "blp") {
+        if ($type === "blp") {
             $obj_title = ilObject::_lookupTitle($rep_obj_id);
             $type_lv = "obj_blog";
         }
-        if ($type == "pfpg") {
+        if ($type === "pfpg") {
             $obj_title = ilObject::_lookupTitle($rep_obj_id);
             $type_lv = "portfolio";
         }
-        if ($type == "dcl") {
+        if ($type === "dcl") {
             $obj_title = ilObject::_lookupTitle($rep_obj_id);
             $type_lv = "obj_dcl";
         }
@@ -820,9 +817,9 @@ class ilNote
                 $link = "";
                 foreach ($ref_ids as $ref_id) {
                     if ($ilAccess->checkAccessOfUser($user_id, "read", "", $ref_id)) {
-                        if ($sub_obj_id == 0 and $type != "blog") {
+                        if ($sub_obj_id == 0 && $type !== "blog") {
                             $link = ilLink::_getLink($ref_id);
-                        } elseif ($type == "wpg") {
+                        } elseif ($type === "wpg") {
                             $title = ilWikiPage::lookupTitle($sub_obj_id);
                             $link = ilLink::_getStaticLink(
                                 $ref_id,
@@ -830,15 +827,15 @@ class ilNote
                                 true,
                                 "_" . ilWikiUtil::makeUrlTitle($title)
                             );
-                        } elseif ($type == "pg") {
+                        } elseif ($type === "pg") {
                             $link = ILIAS_HTTP_PATH . '/goto.php?client_id=' . CLIENT_ID . "&target=pg_" . $sub_obj_id . "_" . $ref_id;
                         }
                     }
                 }
-                if ($type == "blp") {
+                if ($type === "blp") {
                     // todo
                 }
-                if ($type == "pfpg") {
+                if ($type === "pfpg") {
                     $link = ILIAS_HTTP_PATH . '/goto.php?client_id=' . CLIENT_ID . "&target=prtf_" . $rep_obj_id;
                 }
 

--- a/Services/Notes/classes/class.ilNote.php
+++ b/Services/Notes/classes/class.ilNote.php
@@ -13,11 +13,11 @@
  * https://github.com/ILIAS-eLearning
  */
 
-define("IL_NOTE_UNLABELED", 0);
-define("IL_NOTE_IMPORTANT", 1);
-define("IL_NOTE_QUESTION", 2);
-define("IL_NOTE_PRO", 3);
-define("IL_NOTE_CONTRA", 4);
+const IL_NOTE_UNLABELED = 0;
+const IL_NOTE_IMPORTANT = 1;
+const IL_NOTE_QUESTION = 2;
+const IL_NOTE_PRO = 3;
+const IL_NOTE_CONTRA = 4;
 
 /**
  * Note class. Represents a single note.
@@ -365,7 +365,7 @@ class ilNote
         $ilDB = $DIC->database();
         $ilUser = $DIC->user();
         
-        $author_where = ($a_type == self::PRIVATE || $a_all_public === "n")
+        $author_where = ($a_type === self::PRIVATE || $a_all_public === "n")
             ? " AND author = " . $ilDB->quote($ilUser->getId(), "integer")
             : "";
 
@@ -393,8 +393,8 @@ class ilNote
         $set = $ilDB->query($q);
         $notes = array();
         while ($note_rec = $ilDB->fetchAssoc($set)) {
-            if ($a_filter != "") {
-                if (!is_array($a_filter)) {
+            if ($a_filter !== "") {
+                if (!is_array($a_filter)) {// TODO PHP8-REVIEW This makes no  sense, $a_filter is always a string
                     $a_filter = array($a_filter);
                 }
                 if (!in_array($note_rec["id"], $a_filter)) {
@@ -426,7 +426,7 @@ class ilNote
         $sub_where = (!$a_incl_sub)
             ? " AND obj_id = " . $ilDB->quote(0, "integer") : "";
 
-        if ($a_since != "") {
+        if ($a_since !== "") {
             $sub_where .= " AND creation_date > " . $ilDB->quote($a_since, "timestamp");
         }
 
@@ -462,7 +462,7 @@ class ilNote
         $ilUser = $DIC->user();
         $tree = $DIC->repositoryTree();
         
-        if ($a_mode == ilPDNotesGUI::PRIVATE_NOTES) {
+        if ($a_mode === ilPDNotesGUI::PRIVATE_NOTES) {
             $q = "SELECT DISTINCT rep_obj_id FROM note WHERE " .
                 " type = " . $ilDB->quote(self::PRIVATE, "integer") .
                 " AND author = " . $ilDB->quote($ilUser->getId(), "integer") .
@@ -670,7 +670,7 @@ class ilNote
 
         $ilDB = $DIC->database();
         
-        if ($a_obj_type == "") {
+        if ($a_obj_type === "") {
             $a_obj_type = "-";
         }
         $set = $ilDB->query(
@@ -680,8 +680,8 @@ class ilNote
             " AND obj_type = " . $ilDB->quote($a_obj_type, "text")
         );
         if ($rec = $ilDB->fetchAssoc($set)) {
-            if (($rec["activated"] == 0 && $a_activate) ||
-                ($rec["activated"] == 1 && !$a_activate)) {
+            if (((int) $rec["activated"] === 0 && $a_activate) ||
+                ((int) $rec["activated"] === 1 && !$a_activate)) {
                 $ilDB->manipulate(
                     "UPDATE note_settings SET " .
                     " activated = " . $ilDB->quote((int) $a_activate, "integer") .
@@ -719,7 +719,7 @@ class ilNote
             return true;
         }
         
-        if ($a_obj_type == "") {
+        if ($a_obj_type === "") {
             $a_obj_type = "-";
         }
         $set = $ilDB->query(
@@ -765,7 +765,7 @@ class ilNote
         $type_lv = "";
 
         // no notifications for notes
-        if ($this->getType() == self::PRIVATE) {
+        if ($this->getType() === self::PRIVATE) {
             return;
         }
 
@@ -854,7 +854,7 @@ class ilNote
 
                 $message .= $this->getText() . "\n\n";
 
-                if ($link != "") {
+                if ($link !== "") {
                     $message .= $ulng->txt('note_comment_notification_link') . ": " . $link . "\n\n";
                 }
 

--- a/Services/Notes/classes/class.ilNoteGUI.php
+++ b/Services/Notes/classes/class.ilNoteGUI.php
@@ -480,7 +480,7 @@ class ilNoteGUI
             : "";
 
         // title
-        if ($ilCtrl->isAsynch() && !$this->only_latest) {
+        if (!$this->only_latest && $ilCtrl->isAsynch()) {
             switch ($this->obj_type) {
                 case "grpr":
                 case "catr":
@@ -819,9 +819,9 @@ class ilNoteGUI
         
         if ($this->delete_note && count($notes) === 0) {
             return "";
-        } else {
-            return $tpl->get();
         }
+
+        return $tpl->get();
     }
     
     /**
@@ -878,9 +878,10 @@ class ilNoteGUI
     ) : bool {
         $ilUser = $this->user;
 
-        if ($a_note->getAuthor() === $ilUser->getId() && $ilUser->getId() !== ANONYMOUS_USER_ID) {
+        if ($ilUser->getId() !== ANONYMOUS_USER_ID && $a_note->getAuthor() === $ilUser->getId()) {
             return true;
         }
+
         return false;
     }
 

--- a/Services/Notes/classes/class.ilNoteGUI.php
+++ b/Services/Notes/classes/class.ilNoteGUI.php
@@ -305,10 +305,10 @@ class ilNoteGUI
             case "editNoteForm":
             case "addNote":
             case "updateNote":
-                if ($this->requested_note_type == ilNote::PRIVATE) {
+                if ($this->requested_note_type === ilNote::PRIVATE) {
                     $hide_comments = true;
                 }
-                if ($this->requested_note_type == ilNote::PUBLIC) {
+                if ($this->requested_note_type === ilNote::PUBLIC) {
                     $hide_notes = true;
                 }
                 break;
@@ -325,8 +325,7 @@ class ilNoteGUI
         }
 
         $nodes_col = false;
-        if ($this->private_enabled && ($ilUser->getId() != ANONYMOUS_USER_ID)
-            && !$hide_notes) {
+        if ($this->private_enabled && !$hide_notes && $ilUser->getId() !== ANONYMOUS_USER_ID) {
             $ntpl->setCurrentBlock("notes_col");
             $ntpl->setVariable("NOTES", $this->getNoteListHTML(ilNote::PRIVATE, $a_init_form));
             $ntpl->parseCurrentBlock();
@@ -343,12 +342,12 @@ class ilNoteGUI
         
         // Comments Settings
         if ($this->comments_settings && !$hide_comments && !$this->delete_note
-            && !$this->edit_note_form && !$this->add_note_form && $ilUser->getId() != ANONYMOUS_USER_ID) {
+            && !$this->edit_note_form && !$this->add_note_form && $ilUser->getId() !== ANONYMOUS_USER_ID) {
             //$active = $notes_settings->get("activate_".$id);
             $active = ilNote::commentsActivated($this->rep_obj_id, $this->obj_id, $this->obj_type);
 
             if ($active) {
-                if ($this->news_id == 0) {
+                if ($this->news_id === 0) {
                     $this->renderLink(
                         $ntpl,
                         "comments_settings",
@@ -432,7 +431,7 @@ class ilNoteGUI
 
         $mtype = "";
 
-        $suffix = ($a_type == ilNote::PRIVATE)
+        $suffix = ($a_type === ilNote::PRIVATE)
             ? "private"
             : "public";
         
@@ -512,7 +511,7 @@ class ilNoteGUI
         if ($this->delete_note) {
             $cnt_str = "";
         }
-        if ($a_type == ilNote::PRIVATE) {
+        if ($a_type === ilNote::PRIVATE) {
             $tpl->setVariable("TXT_NOTES", $lng->txt("private_notes") . $cnt_str);
             $ilCtrl->setParameterByClass("ilnotegui", "note_type", ilNote::PRIVATE);
         } else {
@@ -547,8 +546,8 @@ class ilNoteGUI
             && !$this->export_html && !$this->print && !$this->edit_note_form
             && !$this->add_note_form) {
             // never individually hide for anonymous users
-            if (($ilUser->getId() != ANONYMOUS_USER_ID)) {
-                if ($a_type == ilNote::PUBLIC) {
+            if ($ilUser->getId() !== ANONYMOUS_USER_ID) {
+                if ($a_type === ilNote::PUBLIC) {
                     $txt = $lng->txt("notes_hide_comments");
                 } else {
                     $txt = $lng->txt("hide_" . $suffix . "_notes");
@@ -556,7 +555,7 @@ class ilNoteGUI
                 $this->renderLink($tpl, "hide_notes", $txt, "hideNotes", "notes_top");
 
                 // show all public notes / my notes only switch
-                if ($a_type == ilNote::PUBLIC) {
+                if ($a_type === ilNote::PUBLIC) {
                     $this->renderLink(
                         $tpl,
                         "my_pub_notes",
@@ -570,7 +569,7 @@ class ilNoteGUI
         
         // show add new note text area
         if (!$this->edit_note_form && $user_setting_notes_by_type !== "n" &&
-            !$this->delete_note && $ilUser->getId() != ANONYMOUS_USER_ID && !$this->hide_new_form) {
+            !$this->delete_note && !$this->hide_new_form && $ilUser->getId() !== ANONYMOUS_USER_ID) {
             if ($a_init_form) {
                 $this->initNoteForm("create", $a_type);
             }
@@ -590,7 +589,7 @@ class ilNoteGUI
             $reldates = ilDatePresentation::useRelativeDates();
             ilDatePresentation::setUseRelativeDates(false);
             
-            if (sizeof($notes) && !$this->only_latest && $this->enable_sorting) {
+            if (!$this->only_latest && $this->enable_sorting && count($notes)) {
                 if ($this->manager->getSortAscending()) {
                     $sort_txt = $lng->txt("notes_sort_desc");
                     $sort_cmd = "listSortDesc";
@@ -608,8 +607,8 @@ class ilNoteGUI
                 }
 
 
-                if ($this->edit_note_form && ($note->getId() == $this->requested_note_id)
-                    && $a_type == $this->requested_note_type) {
+                if ($this->edit_note_form &&
+                    ($a_type === $this->requested_note_type && $note->getId() === $this->requested_note_id)) {
                     if ($a_init_form) {
                         $this->initNoteForm("edit", $a_type, $note);
                     }
@@ -620,10 +619,10 @@ class ilNoteGUI
                     $cnt_col = 2;
                     
                     // delete note stuff for all private notes
-                    if ($this->checkDeletion($note)
-                        && !$this->delete_note
+                    if (!$this->delete_note
                         && !$this->export_html && !$this->print
-                        && !$this->edit_note_form && !$this->add_note_form && !$this->no_actions) {
+                        && !$this->edit_note_form && !$this->add_note_form && !$this->no_actions
+                        && $this->checkDeletion($note)) {
                         $ilCtrl->setParameterByClass("ilnotegui", "note_id", $note->getId());
                         $this->renderLink(
                             $tpl,
@@ -662,7 +661,7 @@ class ilNoteGUI
                     $tpl->setVariable("CNT_COL", $cnt_col);
                     
                     // output author account
-                    if ($a_type == ilNote::PUBLIC && ilObject::_exists($note->getAuthor())) {
+                    if ($a_type === ilNote::PUBLIC && ilObject::_exists($note->getAuthor())) {
                         //$tpl->setCurrentBlock("author");
                         //$tpl->setVariable("VAL_AUTHOR", ilObjUser::_lookupLogin($note->getAuthor()));
                         //$tpl->parseCurrentBlock();
@@ -681,7 +680,7 @@ class ilNoteGUI
                     }
                     
                     // last edited
-                    if ($note->getUpdateDate() != null) {
+                    if ($note->getUpdateDate() !== null) {
                         $tpl->setVariable("TXT_LAST_EDIT", $lng->txt("last_edited_on"));
                         $tpl->setVariable(
                             "DATE_LAST_EDIT",
@@ -705,7 +704,7 @@ class ilNoteGUI
                     
 
                     $tpl->setCurrentBlock("note");
-                    $text = (trim($note->getText()) != "")
+                    $text = (trim($note->getText()) !== "")
                         ? nl2br($note->getText())
                         : "<p class='subtitle'>" . $lng->txt("note_content_removed") . "</p>";
                     $tpl->setVariable("NOTE_TEXT", $text);
@@ -726,7 +725,7 @@ class ilNoteGUI
             
             if (!$notes_given) {
                 $tpl->setCurrentBlock("no_notes");
-                if ($a_type == ilNote::PUBLIC && !$this->only_latest) {
+                if ($a_type === ilNote::PUBLIC && !$this->only_latest) {
                     $tpl->setVariable("NO_NOTES", $lng->txt("notes_no_comments"));
                 }
                 $tpl->parseCurrentBlock();
@@ -737,7 +736,7 @@ class ilNoteGUI
             // multiple items commands
             if ($this->multi_selection && !$this->delete_note && !$this->edit_note_form
                 && count($notes) > 0) {
-                if ($a_type == ilNote::PRIVATE) {
+                if ($a_type === ilNote::PRIVATE) {
                     $tpl->setCurrentBlock("delete_cmd");
                     $tpl->setVariable("TXT_DELETE_NOTES", $this->lng->txt("delete"));
                     $tpl->parseCurrentBlock();
@@ -772,7 +771,7 @@ class ilNoteGUI
         
         // message
         $mtxt = "";
-        switch ($this->requested_note_mess != "" ? $this->requested_note_mess : $this->note_mess) {
+        switch ($this->requested_note_mess !== "" ? $this->requested_note_mess : $this->note_mess) {
             case "mod":
                 $mtype = "success";
                 $mtxt = $lng->txt("msg_obj_modified");
@@ -780,14 +779,14 @@ class ilNoteGUI
                 
             case "ntsdel":
                 $mtype = "success";
-                $mtxt = ($a_type == ilNote::PRIVATE)
+                $mtxt = ($a_type === ilNote::PRIVATE)
                     ? $lng->txt("notes_notes_deleted")
                     : $lng->txt("notes_comments_deleted");
                 break;
 
             case "ntdel":
                 $mtype = "success";
-                $mtxt = ($a_type == ilNote::PRIVATE)
+                $mtxt = ($a_type === ilNote::PRIVATE)
                     ? $lng->txt("notes_note_deleted")
                     : $lng->txt("notes_comment_deleted");
                 break;
@@ -807,18 +806,18 @@ class ilNoteGUI
                 $mtxt = $lng->txt("no_checkbox");
                 break;
         }
-        if ($mtxt != "") {
+        if ($mtxt !== "") {
             $tpl->setVariable("MESS", ilUtil::getSystemMessageHTML($mtxt, $mtype));
         } else {
             $tpl->setVariable("MESS", "");
         }
 
-        if ($this->widget_header != "") {
+        if ($this->widget_header !== "") {
             $tpl->setVariable("WIDGET_HEADER", $this->widget_header);
         }
 
         
-        if ($this->delete_note && count($notes) == 0) {
+        if ($this->delete_note && count($notes) === 0) {
             return "";
         } else {
             return $tpl->get();
@@ -834,7 +833,7 @@ class ilNoteGUI
     ) : string {
         $objDefinition = $this->obj_definition;
         $parent_type = ilObject::_lookupType($parent_obj_id);
-        if ($parent_type == "") {
+        if ($parent_type === "") {
             return "";
         }
         $parent_class = "ilObj" . $objDefinition->getClassName($parent_type) . "GUI";
@@ -853,21 +852,21 @@ class ilNoteGUI
         $ilUser = $this->user;
         $ilSetting = $this->settings;
         
-        if ($ilUser->getId() == ANONYMOUS_USER_ID) {
+        if ($ilUser->getId() === ANONYMOUS_USER_ID) {
             return false;
         }
                 
-        $is_author = ($a_note->getAuthor() == $ilUser->getId());
+        $is_author = ($a_note->getAuthor() === $ilUser->getId());
         
-        if ($a_note->getType() == ilNote::PRIVATE && $is_author) {
+        if ($is_author && $a_note->getType() === ilNote::PRIVATE) {
+            return true;
+        }
+
+        if ($this->public_deletion_enabled && $a_note->getType() === ilNote::PUBLIC) {
             return true;
         }
         
-        if ($a_note->getType() == ilNote::PUBLIC && $this->public_deletion_enabled) {
-            return true;
-        }
-        
-        if ($a_note->getType() == ilNote::PUBLIC && $is_author && $ilSetting->get("comments_del_user", 0)) {
+        if ($is_author && $a_note->getType() === ilNote::PUBLIC && $ilSetting->get("comments_del_user", 0)) {
             return true;
         }
         
@@ -879,8 +878,7 @@ class ilNoteGUI
     ) : bool {
         $ilUser = $this->user;
 
-        if ($a_note->getAuthor() == $ilUser->getId()
-            && ($ilUser->getId() != ANONYMOUS_USER_ID)) {
+        if ($a_note->getAuthor() === $ilUser->getId() && $ilUser->getId() !== ANONYMOUS_USER_ID) {
             return true;
         }
         return false;
@@ -894,7 +892,7 @@ class ilNoteGUI
         $lng = $this->lng;
 
         $this->form_tpl = new ilTemplate("tpl.notes_edit.html", true, true, "Services/Notes");
-        $this->form_tpl->setVariable("LABEL", ($a_type == ilNote::PUBLIC)
+        $this->form_tpl->setVariable("LABEL", ($a_type === ilNote::PUBLIC)
             ? $lng->txt("comment")
             : $lng->txt("note"));
         
@@ -930,7 +928,7 @@ class ilNoteGUI
         $note = new ilNote($note_id);
         $target = $note->getObject();
         
-        if ($note->getAuthor() != $ilUser->getId()) {
+        if ($note->getAuthor() !== $ilUser->getId()) {
             return "";
         }
         
@@ -950,7 +948,7 @@ class ilNoteGUI
         $ilCtrl->clearParametersByClass("ilnotegui");
 
         // last edited
-        if ($note->getUpdateDate() != null) {
+        if ($note->getUpdateDate() !== null) {
             $tpl->setVariable("TXT_LAST_EDIT", $lng->txt("last_edited_on"));
             $tpl->setVariable(
                 "DATE_LAST_EDIT",
@@ -965,7 +963,7 @@ class ilNoteGUI
         }
         
         $tpl->setVariable("VAL_SUBJECT", $note->getSubject());
-        $text = (trim($note->getText()) != "")
+        $text = (trim($note->getText()) !== "")
             ? nl2br($note->getText())
             : "<p class='subtitle'>" . $lng->txt("note_content_removed") . "</p>";
         $tpl->setVariable("NOTE_TEXT", $text);
@@ -1019,7 +1017,7 @@ class ilNoteGUI
                             $link = "goto.php?target=sahs_" . $vis_ref_id;
                             if ($a_obj_type === "sco" || $a_obj_type === "seqc" || $a_obj_type === "chap" || $a_obj_type === "pg") {
                                 $sub_link = "goto.php?target=sahs_" . $vis_ref_id . "_" . $a_obj_id;
-                                $sub_title = ilSCORM2004Node::_lookupTitle($a_obj_id);
+                                $sub_title = ilSCORM2004Node::_lookupTitle($a_obj_id);// TODO PHP8-REVIEW This class is undefined
                             }
                         } elseif ($type === "poll") {
                             $link = ilLink::_getLink($vis_ref_id, "poll");
@@ -1051,7 +1049,7 @@ class ilNoteGUI
                         $par_id = $tree->getParentId($vis_ref_id);
 
                         // sub object link
-                        if ($sub_link != "") {
+                        if ($sub_link !== "") {
                             if ($this->export_html || $this->print) {
                                 $target_tpl->setCurrentBlock("exp_target_sub_object");
                             } else {
@@ -1152,7 +1150,7 @@ class ilNoteGUI
     ) : string {
         $ilUser = $this->user;
         
-        $suffix = ($this->requested_note_type == ilNote::PRIVATE)
+        $suffix = ($this->requested_note_type === ilNote::PRIVATE)
             ? "private"
             : "public";
         $ilUser->setPref("notes_" . $suffix, "y");
@@ -1187,7 +1185,7 @@ class ilNoteGUI
         $this->initNoteForm("create", $this->requested_note_type);
 
         //if ($this->form->checkInput())
-        if ($this->request->getNoteText() != "") {
+        if ($this->request->getNoteText() !== "") {
             $note = new ilNote();
             $note->setObject($this->obj_type, $this->rep_obj_id, $this->obj_id, $this->news_id);
             $note->setInRepository($this->repository_mode);
@@ -1251,7 +1249,7 @@ class ilNoteGUI
      */
     public function deleteNotes() : string
     {
-        if (count($this->request->getNoteIds()) == 0) {
+        if (count($this->request->getNoteIds()) === 0) {
             $this->note_mess = "noc";
         } else {
             $this->delete_note = true;

--- a/Services/Notes/classes/class.ilNoteGUI.php
+++ b/Services/Notes/classes/class.ilNoteGUI.php
@@ -298,8 +298,8 @@ class ilNoteGUI
         );
 
         // check, whether column is hidden due to processing in other column
-        $hide_comments = ($this->only == "notes");
-        $hide_notes = ($this->only == "comments");
+        $hide_comments = ($this->only === "notes");
+        $hide_notes = ($this->only === "comments");
         switch ($ilCtrl->getCmd()) {
             case "addNoteForm":
             case "editNoteForm":
@@ -316,7 +316,7 @@ class ilNoteGUI
 
 
         // temp workaround: only show comments (if both have been activated)
-        if ($this->private_enabled && $this->public_enabled && $this->only != "notes") {
+        if ($this->private_enabled && $this->public_enabled && $this->only !== "notes") {
             $this->private_enabled = false;
         }
 
@@ -569,7 +569,7 @@ class ilNoteGUI
         }
         
         // show add new note text area
-        if (!$this->edit_note_form && $user_setting_notes_by_type != "n" &&
+        if (!$this->edit_note_form && $user_setting_notes_by_type !== "n" &&
             !$this->delete_note && $ilUser->getId() != ANONYMOUS_USER_ID && !$this->hide_new_form) {
             if ($a_init_form) {
                 $this->initNoteForm("create", $a_type);
@@ -586,7 +586,7 @@ class ilNoteGUI
         }
         
         // list all notes
-        if ($user_setting_notes_by_type != "n" || !$this->enable_hiding) {
+        if ($user_setting_notes_by_type !== "n" || !$this->enable_hiding) {
             $reldates = ilDatePresentation::useRelativeDates();
             ilDatePresentation::setUseRelativeDates(false);
             
@@ -1015,15 +1015,15 @@ class ilNoteGUI
                         $title = ilObject::_lookupTitle($target["rep_obj_id"]);
 
                         $sub_link = $sub_title = "";
-                        if ($type == "sahs") {		// bad hack, needs general procedure
+                        if ($type === "sahs") {		// bad hack, needs general procedure
                             $link = "goto.php?target=sahs_" . $vis_ref_id;
-                            if ($a_obj_type == "sco" || $a_obj_type == "seqc" || $a_obj_type == "chap" || $a_obj_type == "pg") {
+                            if ($a_obj_type === "sco" || $a_obj_type === "seqc" || $a_obj_type === "chap" || $a_obj_type === "pg") {
                                 $sub_link = "goto.php?target=sahs_" . $vis_ref_id . "_" . $a_obj_id;
                                 $sub_title = ilSCORM2004Node::_lookupTitle($a_obj_id);
                             }
-                        } elseif ($type == "poll") {
+                        } elseif ($type === "poll") {
                             $link = ilLink::_getLink($vis_ref_id, "poll");
-                        } elseif ($a_obj_type != "pg") {
+                        } elseif ($a_obj_type !== "pg") {
                             if (!isset($this->item_list_gui[$type])) {
                                 $class = $objDefinition->getClassName($type);
                                 $full_class = "ilObj" . $class . "ListGUI";
@@ -1032,7 +1032,7 @@ class ilNoteGUI
 
                             // for references, get original title
                             // (link will lead to orignal, which basically is wrong though)
-                            if ($a_obj_type == "crsr" || $a_obj_type == "catr" || $a_obj_type == "grpr") {
+                            if ($a_obj_type === "crsr" || $a_obj_type === "catr" || $a_obj_type === "grpr") {
                                 $tgt_obj_id = ilContainerReference::_lookupTargetId($target["rep_obj_id"]);
                                 $title = ilObject::_lookupTitle($tgt_obj_id);
                             }
@@ -1318,7 +1318,7 @@ class ilNoteGUI
     {
         $ilUser = $this->user;
 
-        $suffix = ($this->requested_note_type == ilNote::PRIVATE)
+        $suffix = ($this->requested_note_type === ilNote::PRIVATE)
             ? "private"
             : "public";
         $ilUser->writePref("notes_" . $suffix, "y");
@@ -1330,7 +1330,7 @@ class ilNoteGUI
     {
         $ilUser = $this->user;
 
-        $suffix = ($this->requested_note_type == ilNote::PRIVATE)
+        $suffix = ($this->requested_note_type === ilNote::PRIVATE)
             ? "private"
             : "public";
         $ilUser->writePref("notes_" . $suffix, "n");
@@ -1369,11 +1369,7 @@ class ilNoteGUI
     ) : void {
         global $DIC;
 
-        if ($a_main_tpl != null) {
-            $tpl = $a_main_tpl;
-        } else {
-            $tpl = $DIC["tpl"];
-        }
+        $tpl = $a_main_tpl ?? $DIC["tpl"];
         $lng = $DIC->language();
 
         $lng->loadLanguageModule("notes");

--- a/Services/Notes/classes/class.ilPDNotesGUI.php
+++ b/Services/Notes/classes/class.ilPDNotesGUI.php
@@ -22,9 +22,7 @@ class ilPDNotesGUI
 {
     public const PUBLIC_COMMENTS = "publiccomments";
     public const PRIVATE_NOTES = "privatenotes";
-    /**
-     * @var mixed
-     */
+
     protected int $current_rel_obj;
     protected \ILIAS\Notes\StandardGUIRequest $request;
 
@@ -71,7 +69,7 @@ class ilPDNotesGUI
         // link from ilPDNotesBlockGUI
         $rel_obj = $this->request->getRelatedObjId();
         if ($rel_obj > 0) {
-            $mode = ($this->request->getNoteType() == ilNote::PRIVATE)
+            $mode = ($this->request->getNoteType() === ilNote::PRIVATE)
                 ? self::PRIVATE_NOTES
                 : self::PUBLIC_COMMENTS;
             $ilUser->writePref("pd_notes_mode", $mode);
@@ -80,7 +78,7 @@ class ilPDNotesGUI
         // edit link
         elseif ($this->request->getNoteId() > 0) {
             $note = new ilNote($this->request->getNoteId());
-            $mode = ($note->getType() == ilNote::PRIVATE) ? self::PRIVATE_NOTES : self::PUBLIC_COMMENTS;
+            $mode = ($note->getType() === ilNote::PRIVATE) ? self::PRIVATE_NOTES : self::PUBLIC_COMMENTS;
             $obj = $note->getObject();
             $ilUser->writePref("pd_notes_mode", $mode);
             $ilUser->writePref("pd_notes_rel_obj" . $mode, $obj["rep_obj_id"]);
@@ -117,7 +115,7 @@ class ilPDNotesGUI
             $t = $this->lng->txt("notes_comments");
         }
 
-        if ($this->getMode() == self::PRIVATE_NOTES) {
+        if ($this->getMode() === self::PRIVATE_NOTES) {
             $t = $this->lng->txt("private_notes");
             $this->tpl->setTitleIcon(ilUtil::getImagePath("icon_nots.svg"));
         } else {
@@ -140,7 +138,7 @@ class ilPDNotesGUI
         //var_dump($rel_objs);
         // prepend personal dektop, if first object
         //		if ($rel_objs[0]["rep_obj_id"] > 0 && $this->getMode() == ilPDNotesGUI::PRIVATE_NOTES)
-        if ($this->getMode() == ilPDNotesGUI::PRIVATE_NOTES) {
+        if ($this->getMode() === self::PRIVATE_NOTES) {
             $rel_objs = array_merge(
                 [0 => [
                     "rep_obj_id" => 0,
@@ -151,7 +149,7 @@ class ilPDNotesGUI
         }
 
         // #9410
-        if (!$rel_objs && $this->getMode() == ilPDNotesGUI::PUBLIC_COMMENTS) {
+        if (!$rel_objs && $this->getMode() === self::PUBLIC_COMMENTS) {
             $lng->loadLanguageModule("notes");
             $this->tpl->setOnScreenMessage('info', $lng->txt("msg_no_search_result"));
             return;
@@ -182,7 +180,7 @@ class ilPDNotesGUI
             $notes_gui = new ilNoteGUI(0, $ilUser->getId(), "pd", false, 0, false);
         }
         
-        if ($this->getMode() == ilPDNotesGUI::PRIVATE_NOTES) {
+        if ($this->getMode() === self::PRIVATE_NOTES) {
             $notes_gui->enablePrivateNotes(true);
             $notes_gui->enablePublicNotes(false);
         } else {
@@ -207,14 +205,12 @@ class ilPDNotesGUI
 
         $next_class = $this->ctrl->getNextClass($this);
 
-        if ($next_class == "ilnotegui") {
+        if ($next_class === "ilnotegui") {
             $html = $this->ctrl->forwardCommand($notes_gui);
+        } elseif ($this->getMode() === self::PRIVATE_NOTES) {
+            $html = $notes_gui->getOnlyNotesHTML();
         } else {
-            if ($this->getMode() == ilPDNotesGUI::PRIVATE_NOTES) {
-                $html = $notes_gui->getOnlyNotesHTML();
-            } else {
-                $html = $notes_gui->getOnlyCommentsHTML();
-            }
+            $html = $notes_gui->getOnlyCommentsHTML();
         }
         
         if (count($rel_objs) > 1 ||
@@ -266,7 +262,7 @@ class ilPDNotesGUI
         $ilUser = $this->user;
         $ilCtrl = $this->ctrl;
         
-        $ilUser->writePref("pd_notes_mode", ilPDNotesGUI::PRIVATE_NOTES);
+        $ilUser->writePref("pd_notes_mode", self::PRIVATE_NOTES);
         $ilCtrl->redirect($this, "");
     }
     
@@ -280,7 +276,7 @@ class ilPDNotesGUI
             $ilCtrl->redirect($this, "showPrivateNotes");
         }
         
-        $ilUser->writePref("pd_notes_mode", ilPDNotesGUI::PUBLIC_COMMENTS);
+        $ilUser->writePref("pd_notes_mode", self::PUBLIC_COMMENTS);
         $ilCtrl->redirect($this, "");
     }
 
@@ -289,11 +285,11 @@ class ilPDNotesGUI
         $ilUser = $this->user;
         $ilSetting = $this->settings;
         
-        if ($ilUser->getPref("pd_notes_mode") == ilPDNotesGUI::PUBLIC_COMMENTS &&
+        if ($ilUser->getPref("pd_notes_mode") === self::PUBLIC_COMMENTS &&
             !$ilSetting->get("disable_comments")) {
-            return ilPDNotesGUI::PUBLIC_COMMENTS;
-        } else {
-            return ilPDNotesGUI::PRIVATE_NOTES;
+            return self::PUBLIC_COMMENTS;
         }
+
+        return self::PRIVATE_NOTES;
     }
 }

--- a/Services/Notes/test/NotesSessionRepositoryTest.php
+++ b/Services/Notes/test/NotesSessionRepositoryTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\TestCase;
  */
 class NotesSessionRepositoryTest extends TestCase
 {
-    //protected $backupGlobals = false;
     protected \ILIAS\Notes\NotesSessionRepository $repo;
 
     protected function setUp() : void
@@ -25,7 +24,7 @@ class NotesSessionRepositoryTest extends TestCase
     /**
      * Test sort
      */
-    public function testSortAscending()
+    public function testSortAscending() : void
     {
         $repo = $this->repo;
         $repo->setSortAscending(true);

--- a/Services/Notes/test/ilServicesNotesSuite.php
+++ b/Services/Notes/test/ilServicesNotesSuite.php
@@ -23,7 +23,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilServicesNotesSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new self();
 


### PR DESCRIPTION
Hello @alex40724, 

I completed the review of the `Services/Notes` component.

Results:

- [x] The code style is `PSR-2 + X` compliant
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [ ] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

--

Actions needed:
- [ ] Please check my inline comments. Some of them are just information, some require an action. You can use `TODO PHP8-REVIEW` when searching for my comments.

Best regards,
@mjansenDatabay  