### PR TITLE
Review bibliographfic list item

### DIFF
--- a/Modules/Bibliographic/classes/Admin/Facade/class.ilBiblAdminFactoryFacade.php
+++ b/Modules/Bibliographic/classes/Admin/Facade/class.ilBiblAdminFactoryFacade.php
@@ -20,7 +20,7 @@ class ilBiblAdminFactoryFacade implements ilBiblAdminFactoryFacadeInterface
      *
      * @param \ilObjBibliographicAdmin $ilObjBibliographicAdmin
      */
-    public function __construct(ilObjBibliographicAdmin $ilObjBibliographicAdmin, $type_id)
+    public function __construct(ilObjBibliographicAdmin $ilObjBibliographicAdmin, int $type_id)
     {
         $this->object_id = $ilObjBibliographicAdmin->getId();
         $this->ref_id = $ilObjBibliographicAdmin->getRefId();

--- a/Modules/Bibliographic/classes/Admin/Facade/class.ilBiblAdminFactoryFacade.php
+++ b/Modules/Bibliographic/classes/Admin/Facade/class.ilBiblAdminFactoryFacade.php
@@ -7,7 +7,6 @@
  */
 class ilBiblAdminFactoryFacade implements ilBiblAdminFactoryFacadeInterface
 {
-
     protected \ilBiblTranslationFactory $translation_factory;
     protected \ilBiblFieldFactory $field_factory;
     protected \ilBiblTypeInterface $type;

--- a/Modules/Bibliographic/classes/Admin/Facade/class.ilBiblAdminLibraryFacade.php
+++ b/Modules/Bibliographic/classes/Admin/Facade/class.ilBiblAdminLibraryFacade.php
@@ -7,7 +7,6 @@
  */
 class ilBiblAdminLibraryFacade implements ilBiblAdminLibraryFacadeInterface
 {
-
     protected int $object_id;
     protected int $ref_id;
 

--- a/Modules/Bibliographic/classes/Admin/Library/class.ilBiblLibraryFormGUI.php
+++ b/Modules/Bibliographic/classes/Admin/Library/class.ilBiblLibraryFormGUI.php
@@ -54,7 +54,7 @@ class ilBiblLibraryFormGUI extends ilPropertyFormGUI
         $this->addItem($img);
         $show_in_list = new ilCheckboxInputGUI($this->lng()
             ->txt("bibl_library_show_in_list"), 'show_in_list');
-        $show_in_list->setValue(1);
+        $show_in_list->setValue('1');
         $this->addItem($show_in_list);
         if ($this->object->getId()) {
             $this->addCommandButton('update', $this->lng()->txt('save'));

--- a/Modules/Bibliographic/classes/Admin/Library/class.ilBiblLibraryFormGUI.php
+++ b/Modules/Bibliographic/classes/Admin/Library/class.ilBiblLibraryFormGUI.php
@@ -38,7 +38,7 @@ class ilBiblLibraryFormGUI extends ilPropertyFormGUI
      *
      * @access private
      */
-    private function initForm(): void
+    private function initForm() : void
     {
         $this->setFormAction($this->ctrl()->getFormActionByClass(ilBiblLibraryGUI::class));
         $name = new ilTextInputGUI($this->lng()->txt("bibl_library_name"), 'name');
@@ -68,7 +68,7 @@ class ilBiblLibraryFormGUI extends ilPropertyFormGUI
     }
 
 
-    private function fillForm(): void
+    private function fillForm() : void
     {
         $this->setValuesByArray(array(
             'name' => $this->object->getName(),
@@ -79,7 +79,7 @@ class ilBiblLibraryFormGUI extends ilPropertyFormGUI
     }
 
 
-    public function saveObject(): bool
+    public function saveObject() : bool
     {
         if (!$this->checkInput()) {
             return false;

--- a/Modules/Bibliographic/classes/Admin/Library/class.ilBiblLibraryGUI.php
+++ b/Modules/Bibliographic/classes/Admin/Library/class.ilBiblLibraryGUI.php
@@ -169,7 +169,7 @@ class ilBiblLibraryGUI
     private function getInstanceFromRequest() : \ilBiblLibraryInterface
     {
         $ilBibliographicSetting = $this->facade->libraryFactory()
-            ->findById($_REQUEST[self::F_LIB_ID]);
+            ->findById($_REQUEST[self::F_LIB_ID]); //Todo PHP8 Review: Direct Access to $_REQUEST
 
         return $ilBibliographicSetting;
     }

--- a/Modules/Bibliographic/classes/Admin/Library/class.ilBiblLibraryPresentationGUI.php
+++ b/Modules/Bibliographic/classes/Admin/Library/class.ilBiblLibraryPresentationGUI.php
@@ -20,7 +20,7 @@ class ilBiblLibraryPresentationGUI
     }
     
     /**
-     * @param              $type
+     * @param string $type
      * @deprecated REFACTOR Mit Attribute Objekten arbeiten statt mit Array. Evtl. URL Erstellung vereinfachen
      */
     public function generateLibraryLink(ilBiblEntry $entry, $type) : string

--- a/Modules/Bibliographic/classes/Admin/Library/class.ilBiblLibraryPresentationGUI.php
+++ b/Modules/Bibliographic/classes/Admin/Library/class.ilBiblLibraryPresentationGUI.php
@@ -6,7 +6,6 @@
  */
 class ilBiblLibraryPresentationGUI
 {
-    
     protected \ilBiblLibraryInterface $library;
     protected \ilBiblFactoryFacade $facade;
     
@@ -17,7 +16,7 @@ class ilBiblLibraryPresentationGUI
     public function __construct(\ilBiblLibraryInterface $library, \ilBiblFactoryFacade $facade)
     {
         $this->library = $library;
-        $this->facade  = $facade;
+        $this->facade = $facade;
     }
     
     /**
@@ -27,9 +26,9 @@ class ilBiblLibraryPresentationGUI
     public function generateLibraryLink(ilBiblEntry $entry, $type) : string
     {
         $attributes = $this->facade->entryFactory()->loadParsedAttributesByEntryId($entry->getId());
-        $type       = $this->facade->typeFactory()->getInstanceForString($type);
-        $attr       = [];
-        $prefix     = '';
+        $type = $this->facade->typeFactory()->getInstanceForString($type);
+        $attr = [];
+        $prefix = '';
         switch ($type->getId()) {
             case ilBiblTypeFactoryInterface::DATA_TYPE_BIBTEX:
                 $prefix = "bib_default_";

--- a/Modules/Bibliographic/classes/Admin/Library/class.ilBiblLibraryTableGUI.php
+++ b/Modules/Bibliographic/classes/Admin/Library/class.ilBiblLibraryTableGUI.php
@@ -61,7 +61,7 @@ class ilBiblLibraryTableGUI extends ilTable2GUI
     }
 
 
-    protected function initColumns(): void
+    protected function initColumns() : void
     {
         $this->addColumn($this->lng()->txt('bibl_library_name'), '', '30%');
         $this->addColumn($this->lng()->txt('bibl_library_url'), '' . '30%');

--- a/Modules/Bibliographic/classes/Admin/class.ilObjBibliographicAdmin.php
+++ b/Modules/Bibliographic/classes/Admin/class.ilObjBibliographicAdmin.php
@@ -16,8 +16,8 @@ class ilObjBibliographicAdmin extends ilObject
     /**
      * Constructor
      *
-     * @param integer    reference_id or object_id
-     * @param boolean    treat the id as reference_id (true) or object_id (false)
+     * @param integer    $a_id reference_id or object_id
+     * @param boolean    $a_call_by_reference treat the id as reference_id (true) or object_id (false)
      */
     public function __construct($a_id = 0, $a_call_by_reference = true)
     {

--- a/Modules/Bibliographic/classes/Attribute/class.ilBiblAttributeFactory.php
+++ b/Modules/Bibliographic/classes/Attribute/class.ilBiblAttributeFactory.php
@@ -6,7 +6,6 @@
 
 class ilBiblAttributeFactory implements ilBiblAttributeFactoryInterface
 {
-
     protected \ilBiblFieldFactoryInterface $field_factory;
     protected ilDBInterface $db;
 

--- a/Modules/Bibliographic/classes/Attribute/class.ilBiblAttributeFactory.php
+++ b/Modules/Bibliographic/classes/Attribute/class.ilBiblAttributeFactory.php
@@ -51,9 +51,6 @@ WHERE a.name = %s AND d.id = %s";
      */
     public function sortAttributes(array $attributes) : array
     {
-        /**
-         * @var $attribute \ilBiblAttributeInterface
-         */
         $sorted = [];
         $type_id = $this->field_factory->getType()->getId();
         $max = 0;

--- a/Modules/Bibliographic/classes/Data/class.ilBiblData.php
+++ b/Modules/Bibliographic/classes/Data/class.ilBiblData.php
@@ -42,8 +42,6 @@ class ilBiblData extends ActiveRecord implements ilBiblDataInterface
      */
     protected ?int $id = null;
     /**
-     * @var
-     *
      * @con_has_field  true
      * @con_fieldtype  text
      * @con_length     256
@@ -51,8 +49,6 @@ class ilBiblData extends ActiveRecord implements ilBiblDataInterface
      */
     protected ?string $filename = null;
     /**
-     * @var
-     *
      * @con_has_field  true
      * @con_fieldtype  integer
      * @con_length     1
@@ -60,8 +56,6 @@ class ilBiblData extends ActiveRecord implements ilBiblDataInterface
      */
     protected ?int $is_online = null;
     /**
-     * @var
-     *
      * @con_has_field  true
      * @con_fieldtype  integer
      * @con_length     1

--- a/Modules/Bibliographic/classes/Data/class.ilBiblData.php
+++ b/Modules/Bibliographic/classes/Data/class.ilBiblData.php
@@ -115,7 +115,7 @@ class ilBiblData extends ActiveRecord implements ilBiblDataInterface
     
     public function isOnline() : bool
     {
-        return (bool)$this->is_online;
+        return (bool) $this->is_online;
     }
 
 

--- a/Modules/Bibliographic/classes/Entry/class.ilBiblEntry.php
+++ b/Modules/Bibliographic/classes/Entry/class.ilBiblEntry.php
@@ -37,14 +37,12 @@ class ilBiblEntry extends ActiveRecord implements ilBiblEntryInterface
      */
     protected ?int $id = null;
     /**
-     * @var
      * @con_has_field  true
      * @con_fieldtype  integer
      * @con_length     4
      */
     protected ?int $data_id = null;
     /**
-     * @var
      * @con_has_field  true
      * @con_fieldtype  text
      * @con_length     50

--- a/Modules/Bibliographic/classes/Entry/class.ilBiblEntry.php
+++ b/Modules/Bibliographic/classes/Entry/class.ilBiblEntry.php
@@ -103,5 +103,4 @@ class ilBiblEntry extends ActiveRecord implements ilBiblEntryInterface
     {
         return $this->overview;
     }
-    
 }

--- a/Modules/Bibliographic/classes/Entry/class.ilBiblEntryDetailPresentationGUI.php
+++ b/Modules/Bibliographic/classes/Entry/class.ilBiblEntryDetailPresentationGUI.php
@@ -106,7 +106,7 @@ class ilBiblEntryDetailPresentationGUI
     /**
      * This feature has to be discussed by JF first
      *
-     * @param $string
+     * string @param $string
      */
     public static function prepareLatex($string) : string
     {

--- a/Modules/Bibliographic/classes/Entry/class.ilBiblEntryDetailPresentationGUI.php
+++ b/Modules/Bibliographic/classes/Entry/class.ilBiblEntryDetailPresentationGUI.php
@@ -26,7 +26,7 @@ class ilBiblEntryDetailPresentationGUI
     }
 
 
-    private function initHelp(): void
+    private function initHelp() : void
     {
         global $DIC;
 
@@ -38,7 +38,7 @@ class ilBiblEntryDetailPresentationGUI
     }
 
 
-    private function initTabs(): void
+    private function initTabs() : void
     {
         $this->tabs()->clearTargets();
         $this->tabs()->setBackTarget(
@@ -48,7 +48,7 @@ class ilBiblEntryDetailPresentationGUI
     }
 
 
-    public function getHTML(): string
+    public function getHTML() : string
     {
         $this->initHelp();
         $this->initTabs();
@@ -72,7 +72,7 @@ class ilBiblEntryDetailPresentationGUI
     /**
      * @param \ilPropertyFormGUI $form
      */
-    protected function renderAttributes(ilPropertyFormGUI $form): void
+    protected function renderAttributes(ilPropertyFormGUI $form) : void
     {
         $attributes = $this->facade->attributeFactory()->getAttributesForEntry($this->entry);
         $sorted = $this->facade->attributeFactory()->sortAttributes($attributes);
@@ -89,7 +89,7 @@ class ilBiblEntryDetailPresentationGUI
     /**
      * @param \ilPropertyFormGUI $form
      */
-    protected function renderLibraries(ilPropertyFormGUI $form): void
+    protected function renderLibraries(ilPropertyFormGUI $form) : void
     {
         // generate/render links to libraries
         // TODO REFACTOR
@@ -108,7 +108,7 @@ class ilBiblEntryDetailPresentationGUI
      *
      * @param $string
      */
-    public static function prepareLatex($string): string
+    public static function prepareLatex($string) : string
     {
         return $string;
         static $init;

--- a/Modules/Bibliographic/classes/Entry/class.ilBiblEntryFactory.php
+++ b/Modules/Bibliographic/classes/Entry/class.ilBiblEntryFactory.php
@@ -134,10 +134,10 @@ class ilBiblEntryFactory implements ilBiblEntryFactoryInterface
                 if (!$value) {
                     continue;
                 }
-                if ($filter->getOperator() === "IN" && is_array($filter->getFieldValue())) {
+                if ($filter->getOperator() === "IN" && is_array($filter->getFieldValue())) { //ToDo PHP8 Review: This will always evaluate to false as getFieldValue returns a string.
                     $types[] = "text";
                     $values[] = $filter->getFieldName();
-                    $q .= " AND e.id IN (SELECT a.entry_id FROM il_bibl_attribute AS a WHERE a.name = %s AND " . $this->db->in("a.value", $value, false, "text") . ")";
+                    $q .= " AND e.id IN (SELECT a.entry_id FROM il_bibl_attribute AS a WHERE a.name = %s AND " . $this->db->in("a.value", $value, false, "text") . ")"; //ToDo PHP8 Review: ...and if it would ever get here it would fail here as $value is string.
                 } else {
                     $types[] = "text";
                     $values[] = $filter->getFieldName();
@@ -175,7 +175,7 @@ class ilBiblEntryFactory implements ilBiblEntryFactoryInterface
     /**
      * @return \ilBiblAttribute[]
      */
-    public function getAllAttributesByEntryId($id) : array
+    public function getAllAttributesByEntryId(int $id) : array
     {
         return ilBiblAttribute::where(array('entry_id' => $id))->get();
     }
@@ -191,7 +191,7 @@ class ilBiblEntryFactory implements ilBiblEntryFactoryInterface
     }
     
     /**
-     * @param $attributes ilBiblFieldInterface[]
+     * @param ilBiblFieldInterface[] $attributes
      */
     public function setAttributes(array $attributes) : void
     {

--- a/Modules/Bibliographic/classes/Entry/class.ilBiblEntryFactory.php
+++ b/Modules/Bibliographic/classes/Entry/class.ilBiblEntryFactory.php
@@ -7,7 +7,6 @@
  */
 class ilBiblEntryFactory implements ilBiblEntryFactoryInterface
 {
-    
     protected int $bibliographic_obj_id;
     protected int $entry_id;
     protected string $type;
@@ -25,9 +24,9 @@ class ilBiblEntryFactory implements ilBiblEntryFactoryInterface
     public function __construct(ilBiblFieldFactoryInterface $field_factory, \ilBiblTypeInterface $file_type, ilBiblOverviewModelFactoryInterface $overview_factory)
     {
         global $DIC;
-        $this->db               = $DIC->database();
-        $this->file_type        = $file_type;
-        $this->field_factory    = $field_factory;
+        $this->db = $DIC->database();
+        $this->file_type = $file_type;
+        $this->field_factory = $field_factory;
         $this->overview_factory = $overview_factory;
     }
     
@@ -37,7 +36,7 @@ class ilBiblEntryFactory implements ilBiblEntryFactoryInterface
     public function loadParsedAttributesByEntryId(int $entry_id) : array
     {
         $ilBiblEntry = ilBiblEntry::where(array('id' => $entry_id))->first();
-        $attributes  = $this->getAllAttributesByEntryId($entry_id);
+        $attributes = $this->getAllAttributesByEntryId($entry_id);
         
         if ($this->file_type->getId() == ilBiblTypeFactoryInterface::DATA_TYPE_RIS) {
             //for RIS-Files also add the type;
@@ -110,7 +109,7 @@ class ilBiblEntryFactory implements ilBiblEntryFactoryInterface
     
     public function filterEntriesForTable(int $object_id, ilBiblTableQueryInfo $info = null) : array
     {
-        $entries       = $this->filterEntryIdsForTableAsArray($object_id, $info);
+        $entries = $this->filterEntryIdsForTableAsArray($object_id, $info);
         $entry_objects = [];
         foreach ($entries as $entry_id => $entry) {
             $entry_objects[$entry_id] = $this->findByIdAndTypeString($entry['type'], $entry['id']);
@@ -124,7 +123,7 @@ class ilBiblEntryFactory implements ilBiblEntryFactoryInterface
      */
     public function filterEntryIdsForTableAsArray(int $object_id, ?ilBiblTableQueryInfo $info = null) : array
     {
-        $types  = ["integer"];
+        $types = ["integer"];
         $values = [$object_id];
         
         $filters = $info->getFilters();
@@ -136,15 +135,15 @@ class ilBiblEntryFactory implements ilBiblEntryFactoryInterface
                     continue;
                 }
                 if ($filter->getOperator() === "IN" && is_array($filter->getFieldValue())) {
-                    $types[]  = "text";
+                    $types[] = "text";
                     $values[] = $filter->getFieldName();
-                    $q        .= " AND e.id IN (SELECT a.entry_id FROM il_bibl_attribute AS a WHERE a.name = %s AND " . $this->db->in("a.value", $value, false, "text") . ")";
+                    $q .= " AND e.id IN (SELECT a.entry_id FROM il_bibl_attribute AS a WHERE a.name = %s AND " . $this->db->in("a.value", $value, false, "text") . ")";
                 } else {
-                    $types[]  = "text";
+                    $types[] = "text";
                     $values[] = $filter->getFieldName();
-                    $types[]  = "text";
+                    $types[] = "text";
                     $values[] = "{$value}";
-                    $q        .= " AND e.id IN (SELECT a.entry_id FROM il_bibl_attribute AS a WHERE a.name = %s AND a.value {$filter->getOperator()} %s )";
+                    $q .= " AND e.id IN (SELECT a.entry_id FROM il_bibl_attribute AS a WHERE a.name = %s AND a.value {$filter->getOperator()} %s )";
                 }
             }
         } else {
@@ -153,11 +152,11 @@ class ilBiblEntryFactory implements ilBiblEntryFactoryInterface
                         WHERE data_id = %s";
         }
         $entries = [];
-        $set     = $this->db->queryF($q, $types, $values);
+        $set = $this->db->queryF($q, $types, $values);
         
         $i = 0;
         while ($rec = $this->db->fetchAssoc($set)) {
-            $entries[$i]['entry_id']   = $rec['id'];
+            $entries[$i]['entry_id'] = $rec['id'];
             $entries[$i]['entry_type'] = $rec['type'];
             $i++;
         }

--- a/Modules/Bibliographic/classes/Entry/class.ilBiblEntryTableGUI.php
+++ b/Modules/Bibliographic/classes/Entry/class.ilBiblEntryTableGUI.php
@@ -70,7 +70,7 @@ class ilBiblEntryTableGUI extends ilTable2GUI
     /**
      * @param $field
      */
-    protected function addAndReadFilterItem(ilTableFilterItem $field): void
+    protected function addAndReadFilterItem(ilTableFilterItem $field) : void
     {
         $this->addFilterItem($field);
         $field->readFromSession();
@@ -110,7 +110,7 @@ class ilBiblEntryTableGUI extends ilTable2GUI
     }
 
 
-    protected function initData(): void
+    protected function initData() : void
     {
         $query = new ilBiblTableQueryInfo();
         /**

--- a/Modules/Bibliographic/classes/Entry/class.ilBiblEntryTablePresentationGUI.php
+++ b/Modules/Bibliographic/classes/Entry/class.ilBiblEntryTablePresentationGUI.php
@@ -7,7 +7,6 @@
  */
 class ilBiblEntryTablePresentationGUI
 {
-    
     protected \ilBiblEntry $entry;
     protected string $html = '';
     protected \ilBiblFactoryFacadeInterface $facade;
@@ -27,7 +26,7 @@ class ilBiblEntryTablePresentationGUI
      * @return mixed|string
      * @deprecated Has to be refactored. Active records verwenden statt array
      */
-    protected function render(): void
+    protected function render() : void
     {
         $attributes = $this->facade->entryFactory()->loadParsedAttributesByEntryId($this->getEntry()->getId());
         //Get the model which declares which attributes to show in the overview table and how to show them
@@ -93,22 +92,22 @@ class ilBiblEntryTablePresentationGUI
         $this->setHtml($single_entry);
     }
     
-    public function getHtml(): string
+    public function getHtml() : string
     {
         return $this->html;
     }
     
-    public function setHtml(string $html): void
+    public function setHtml(string $html) : void
     {
         $this->html = $html;
     }
     
-    public function getEntry(): \ilBiblEntry
+    public function getEntry() : \ilBiblEntry
     {
         return $this->entry;
     }
     
-    public function setEntry(\ilBiblEntry $entry): void
+    public function setEntry(\ilBiblEntry $entry) : void
     {
         $this->entry = $entry;
     }

--- a/Modules/Bibliographic/classes/Entry/class.ilBiblEntryTablePresentationGUI.php
+++ b/Modules/Bibliographic/classes/Entry/class.ilBiblEntryTablePresentationGUI.php
@@ -23,7 +23,6 @@ class ilBiblEntryTablePresentationGUI
     }
     
     /**
-     * @return mixed|string
      * @deprecated Has to be refactored. Active records verwenden statt array
      */
     protected function render() : void

--- a/Modules/Bibliographic/classes/Facade/class.ilBiblFactoryFacade.php
+++ b/Modules/Bibliographic/classes/Facade/class.ilBiblFactoryFacade.php
@@ -7,7 +7,6 @@
  */
 class ilBiblFactoryFacade implements ilBiblFactoryFacadeInterface
 {
-
     protected \ilBiblLibraryFactory $library_factory;
     protected \ilBiblAttributeFactoryInterface $attribute_factory;
     protected int $object_id;

--- a/Modules/Bibliographic/classes/Field/class.ilBiblAdminFieldGUI.php
+++ b/Modules/Bibliographic/classes/Field/class.ilBiblAdminFieldGUI.php
@@ -35,7 +35,7 @@ abstract class ilBiblAdminFieldGUI
         $this->facade = $facade;
     }
     
-    public function executeCommand()
+    public function executeCommand() : void
     {
         $nextClass = $this->ctrl()->getNextClass();
         $this->tabs()->activateTab(ilObjBibliographicAdminGUI::TAB_FIELDS);

--- a/Modules/Bibliographic/classes/Field/class.ilBiblAdminFieldTableGUI.php
+++ b/Modules/Bibliographic/classes/Field/class.ilBiblAdminFieldTableGUI.php
@@ -128,13 +128,18 @@ class ilBiblAdminFieldTableGUI extends ilTable2GUI
         $this->ctrl()
              ->setParameter($this->parent_obj, ilBiblAdminRisFieldGUI::FIELD_IDENTIFIER, $field->getId());
         $this->ctrl()
-             ->setParameterByClass(ilBiblTranslationGUI::class, ilBiblAdminRisFieldGUI::FIELD_IDENTIFIER,
-                 $field->getId());
+             ->setParameterByClass(
+                 ilBiblTranslationGUI::class,
+                 ilBiblAdminRisFieldGUI::FIELD_IDENTIFIER,
+                 $field->getId()
+             );
 
         $txt = $this->lng()->txt('translate');
         $selectionList->addItem($txt, '', $this->ctrl()
-                                               ->getLinkTargetByClass(ilBiblTranslationGUI::class,
-                                                   ilBiblTranslationGUI::CMD_DEFAULT));
+                                               ->getLinkTargetByClass(
+                                                   ilBiblTranslationGUI::class,
+                                                   ilBiblTranslationGUI::CMD_DEFAULT
+                                               ));
 
         $this->tpl->setVariable('VAL_ACTIONS', $selectionList->getHTML());
     }

--- a/Modules/Bibliographic/classes/Field/class.ilBiblAdminFieldTableGUI.php
+++ b/Modules/Bibliographic/classes/Field/class.ilBiblAdminFieldTableGUI.php
@@ -66,9 +66,6 @@ class ilBiblAdminFieldTableGUI extends ilTable2GUI
         $this->addAndReadFilterItem($field);
     }
 
-    /**
-     * @param $field
-     */
     protected function addAndReadFilterItem(ilTableFilterItem $field) : void
     {
         $this->addFilterItem($field);

--- a/Modules/Bibliographic/classes/Field/class.ilBiblField.php
+++ b/Modules/Bibliographic/classes/Field/class.ilBiblField.php
@@ -35,7 +35,6 @@ class ilBiblField extends ActiveRecord implements ilBiblFieldInterface
      */
     protected ?int $id = null;
     /**
-     * @var
      * @con_has_field  true
      * @con_fieldtype  text
      * @con_length     50

--- a/Modules/Bibliographic/classes/Field/class.ilBiblFieldFactory.php
+++ b/Modules/Bibliographic/classes/Field/class.ilBiblFieldFactory.php
@@ -7,7 +7,6 @@
  */
 class ilBiblFieldFactory implements ilBiblFieldFactoryInterface
 {
-
     protected \ilBiblTypeInterface $type;
 
 
@@ -197,13 +196,13 @@ class ilBiblFieldFactory implements ilBiblFieldFactoryInterface
     }
 
 
-    private function getARInstance(int $type, string $identifier): ?\ilBiblField
+    private function getARInstance(int $type, string $identifier) : ?\ilBiblField
     {
         return ilBiblField::where(["identifier" => $identifier, "data_type" => $type])->first();
     }
 
 
-    private function getCollectionForFilter(ilBiblTypeInterface $type, ilBiblTableQueryInfoInterface $queryInfo = null): \ActiveRecordList
+    private function getCollectionForFilter(ilBiblTypeInterface $type, ilBiblTableQueryInfoInterface $queryInfo = null) : \ActiveRecordList
     {
         $collection = ilBiblField::getCollection();
 

--- a/Modules/Bibliographic/classes/Field/class.ilBiblFieldFactory.php
+++ b/Modules/Bibliographic/classes/Field/class.ilBiblFieldFactory.php
@@ -36,7 +36,7 @@ class ilBiblFieldFactory implements ilBiblFieldFactoryInterface
     public function findById(int $id) : ilBiblFieldInterface
     {
         /**
-         * @var $inst ilBiblField
+         * @var ilBiblField $inst
          */
         $inst = ilBiblField::findOrFail($id);
         if ($this->type->isStandardField($inst->getIdentifier()) != $inst->isStandardField()) {

--- a/Modules/Bibliographic/classes/FieldFilter/class.ilBiblFieldFilterFactory.php
+++ b/Modules/Bibliographic/classes/FieldFilter/class.ilBiblFieldFilterFactory.php
@@ -21,7 +21,7 @@ class ilBiblFieldFilterFactory implements ilBiblFieldFilterFactoryInterface
     /**
      * @inheritDoc
      */
-    public function findByFieldId(int $id): ?\ilBiblFieldFilter
+    public function findByFieldId(int $id) : ?\ilBiblFieldFilter
     {
         /** @noinspection PhpIncompatibleReturnTypeInspection */
         return ilBiblFieldFilter::where(['field_id' => $id])->first();

--- a/Modules/Bibliographic/classes/FieldFilter/class.ilBiblFieldFilterFormGUI.php
+++ b/Modules/Bibliographic/classes/FieldFilter/class.ilBiblFieldFilterFormGUI.php
@@ -131,9 +131,6 @@ class ilBiblFieldFilterFormGUI extends ilPropertyFormGUI
     }
 
 
-    /**
-     * @return bool|string
-     */
     public function saveObject() : bool
     {
         if (!$this->fillObject()) {

--- a/Modules/Bibliographic/classes/FieldFilter/class.ilBiblFieldFilterFormGUI.php
+++ b/Modules/Bibliographic/classes/FieldFilter/class.ilBiblFieldFilterFormGUI.php
@@ -41,7 +41,7 @@ class ilBiblFieldFilterFormGUI extends ilPropertyFormGUI
     }
 
 
-    public function initForm(): void
+    public function initForm() : void
     {
         $this->setTarget('_top');
 
@@ -105,14 +105,14 @@ class ilBiblFieldFilterFormGUI extends ilPropertyFormGUI
     }
 
 
-    public function fillForm(): void
+    public function fillForm() : void
     {
         $array = array(self::F_FIELD_ID => $this->filter->getFieldId(), self::F_FILTER_TYPE => $this->filter->getFilterType(),);
         $this->setValuesByArray($array);
     }
 
 
-    protected function fillObject(): bool
+    protected function fillObject() : bool
     {
         if (!$this->checkInput()) {
             return false;
@@ -134,7 +134,7 @@ class ilBiblFieldFilterFormGUI extends ilPropertyFormGUI
     /**
      * @return bool|string
      */
-    public function saveObject(): bool
+    public function saveObject() : bool
     {
         if (!$this->fillObject()) {
             return false;
@@ -144,7 +144,7 @@ class ilBiblFieldFilterFormGUI extends ilPropertyFormGUI
     }
 
 
-    protected function initButtons(): void
+    protected function initButtons() : void
     {
         if ($this->filter->getId()) {
             $this->addCommandButton(ilBiblFieldFilterGUI::CMD_UPDATE, $this->lng()->txt('save'));

--- a/Modules/Bibliographic/classes/FieldFilter/class.ilBiblFieldFilterPresentationGUI.php
+++ b/Modules/Bibliographic/classes/FieldFilter/class.ilBiblFieldFilterPresentationGUI.php
@@ -26,7 +26,7 @@ class ilBiblFieldFilterPresentationGUI
     }
 
 
-    public function getFilterItem(): \ilTableFilterItem
+    public function getFilterItem() : \ilTableFilterItem
     {
         $field = $this->facade->fieldFactory()->findById($this->getFilter()->getFieldId());
         $translated = $this->facade->translationFactory()->translate($field);
@@ -60,13 +60,13 @@ class ilBiblFieldFilterPresentationGUI
     }
 
 
-    public function getFilter(): \ilBiblFieldFilterInterface
+    public function getFilter() : \ilBiblFieldFilterInterface
     {
         return $this->filter;
     }
 
 
-    public function setFilter(\ilBiblFieldFilterInterface $filter): void
+    public function setFilter(\ilBiblFieldFilterInterface $filter) : void
     {
         $this->filter = $filter;
     }

--- a/Modules/Bibliographic/classes/FieldFilter/class.ilBiblFieldFilterTableGUI.php
+++ b/Modules/Bibliographic/classes/FieldFilter/class.ilBiblFieldFilterTableGUI.php
@@ -26,7 +26,7 @@ class ilBiblFieldFilterTableGUI extends ilTable2GUI
         $this->parent_obj = $a_parent_obj;
 
         $f = $this->dic()->ui()->factory();
-        $this->modal = $f->modal()->roundtrip('---', $f->legacy(''))->withAsyncRenderUrl($this->ctrl()->getLinkTarget($this->parent_obj, ilBiblFieldFilterGUI::CMD_EDIT));
+        $this->modal = $f->modal()->roundtrip('---', [$f->legacy('')])->withAsyncRenderUrl($this->ctrl()->getLinkTarget($this->parent_obj, ilBiblFieldFilterGUI::CMD_EDIT));
 
         $this->setId(self::TBL_ID);
         $this->setPrefix(self::TBL_ID);
@@ -64,12 +64,9 @@ class ilBiblFieldFilterTableGUI extends ilTable2GUI
     }
 
 
-    /**
-     * @param $field
-     */
-    protected function addAndReadFilterItem(ilFormPropertyGUI $field) : void
+    protected function addAndReadFilterItem(ilTableFilterItem $field) : void
     {
-        $this->addFilterItem($field);
+        $this->addFilterItem($field); //
         $field->readFromSession();
         if ($field instanceof ilCheckboxInputGUI) {
             $this->filter[$field->getPostVar()] = $field->getChecked();

--- a/Modules/Bibliographic/classes/FieldFilter/class.ilBiblFieldFilterTableGUI.php
+++ b/Modules/Bibliographic/classes/FieldFilter/class.ilBiblFieldFilterTableGUI.php
@@ -49,7 +49,7 @@ class ilBiblFieldFilterTableGUI extends ilTable2GUI
     }
 
 
-    protected function initColumns(): void
+    protected function initColumns() : void
     {
         $this->addColumn($this->lng()->txt('field'), 'field');
         $this->addColumn($this->lng()->txt('filter_type'), 'filter_type');
@@ -57,7 +57,7 @@ class ilBiblFieldFilterTableGUI extends ilTable2GUI
     }
 
 
-    protected function addFilterItems(): void
+    protected function addFilterItems() : void
     {
         $field = new ilTextInputGUI($this->lng()->txt('field'), 'field');
         $this->addAndReadFilterItem($field);
@@ -67,7 +67,7 @@ class ilBiblFieldFilterTableGUI extends ilTable2GUI
     /**
      * @param $field
      */
-    protected function addAndReadFilterItem(ilFormPropertyGUI $field): void
+    protected function addAndReadFilterItem(ilFormPropertyGUI $field) : void
     {
         $this->addFilterItem($field);
         $field->readFromSession();
@@ -110,7 +110,7 @@ class ilBiblFieldFilterTableGUI extends ilTable2GUI
     /**
      * @param \ilBiblFieldFilter $ilBiblFieldFilter
      */
-    protected function addActionMenu(ilBiblFieldFilter $ilBiblFieldFilter): void
+    protected function addActionMenu(ilBiblFieldFilter $ilBiblFieldFilter) : void
     {
         $this->ctrl()->setParameterByClass(ilBiblFieldFilterGUI::class, ilBiblFieldFilterGUI::FILTER_ID, $ilBiblFieldFilter->getId());
 
@@ -133,7 +133,7 @@ class ilBiblFieldFilterTableGUI extends ilTable2GUI
     }
 
 
-    protected function parseData(): void
+    protected function parseData() : void
     {
         $this->determineOffsetAndOrder();
         $this->determineLimit();

--- a/Modules/Bibliographic/classes/FileReader/BibTex/class.ilBiblTexFileReader.php
+++ b/Modules/Bibliographic/classes/FileReader/BibTex/class.ilBiblTexFileReader.php
@@ -6,7 +6,6 @@
  */
 class ilBiblTexFileReader extends ilBiblFileReaderBase implements ilBiblFileReaderInterface
 {
-    
     protected static array $ignored_keywords = array('Preamble');
     
     /**
@@ -20,7 +19,7 @@ class ilBiblTexFileReader extends ilBiblFileReaderBase implements ilBiblFileRead
         // get entries
         $subject = $this->getFileContent();
         $objects = preg_split("/\\@([\\w]*)/uix", $subject, null, PREG_SPLIT_DELIM_CAPTURE
-            |PREG_SPLIT_NO_EMPTY);
+            | PREG_SPLIT_NO_EMPTY);
         
         if (in_array($objects[0], self::$ignored_keywords)) {
             $objects = array_splice($objects, 2);

--- a/Modules/Bibliographic/classes/FileReader/BibTex/class.ilBiblTexFileReader.php
+++ b/Modules/Bibliographic/classes/FileReader/BibTex/class.ilBiblTexFileReader.php
@@ -158,11 +158,7 @@ class ilBiblTexFileReader extends ilBiblFileReaderBase implements ilBiblFileRead
         $this->setFileContent(str_replace(array_values($bibtex_special_chars), array_keys($bibtex_special_chars), $this->getFileContent()));
     }
     
-    /**
-     * @param $s
-     * @return string|mixed|void
-     */
-    protected function removeBomUtf8($s)
+    protected function removeBomUtf8(string $s) : string
     {
         if (substr($s, 0, 3) == chr(hexdec('EF')) . chr(hexdec('BB')) . chr(hexdec('BF'))) {
             return substr($s, 3);

--- a/Modules/Bibliographic/classes/FileReader/Ris/class.ilBiblRisFileReaderWrapper.php
+++ b/Modules/Bibliographic/classes/FileReader/Ris/class.ilBiblRisFileReaderWrapper.php
@@ -13,7 +13,7 @@ class ilBiblRisFileReaderWrapper
      * @param $content
      * @return mixed[]
      */
-    public function parseContent($content): array
+    public function parseContent($content) : array
     {
         $RISReader = new RISReader();
 

--- a/Modules/Bibliographic/classes/FileReader/Ris/class.ilBiblRisFileReaderWrapper.php
+++ b/Modules/Bibliographic/classes/FileReader/Ris/class.ilBiblRisFileReaderWrapper.php
@@ -10,7 +10,7 @@ class ilBiblRisFileReaderWrapper
 {
 
     /**
-     * @param $content
+     * @param string $content
      * @return mixed[]
      */
     public function parseContent($content) : array

--- a/Modules/Bibliographic/classes/FileReader/class.ilBiblFileReaderBase.php
+++ b/Modules/Bibliographic/classes/FileReader/class.ilBiblFileReaderBase.php
@@ -59,7 +59,7 @@ abstract class ilBiblFileReaderBase implements ilBiblFileReaderInterface
     /**
      * @param $string
      */
-    protected function convertStringToUTF8($string): string
+    protected function convertStringToUTF8($string) : string
     {
         if (!function_exists('mb_detect_encoding') || !function_exists('mb_detect_order')
             || !function_exists("mb_convert_encoding")
@@ -88,7 +88,7 @@ abstract class ilBiblFileReaderBase implements ilBiblFileReaderInterface
         return $string;
     }
 
-    public function getFileContent(): string
+    public function getFileContent() : string
     {
         return $this->file_content;
     }
@@ -101,7 +101,7 @@ abstract class ilBiblFileReaderBase implements ilBiblFileReaderInterface
     /**
      * @inheritDoc
      */
-    public function parseContentToEntries(ilObjBibliographic $bib): array
+    public function parseContentToEntries(ilObjBibliographic $bib) : array
     {
         $entries_from_file = $this->parseContent();
         $entry_instances = [];

--- a/Modules/Bibliographic/classes/FileReader/class.ilBiblFileReaderBase.php
+++ b/Modules/Bibliographic/classes/FileReader/class.ilBiblFileReaderBase.php
@@ -56,21 +56,15 @@ abstract class ilBiblFileReaderBase implements ilBiblFileReaderInterface
         return true;
     }
 
-    /**
-     * @param $string
-     */
-    protected function convertStringToUTF8($string) : string
+    protected function convertStringToUTF8(string $string) : string
     {
         if (!function_exists('mb_detect_encoding') || !function_exists('mb_detect_order')
             || !function_exists("mb_convert_encoding")
         ) {
             return $string;
         }
-        try {
-            ob_end_clean();
-        } catch (Throwable $t) {
-            //
-        }
+
+        ob_end_clean();
 
         $mb_detect_encoding = mb_detect_encoding($string);
         mb_detect_order(array(self::ENCODING_UTF_8, self::ENCODING_ISO_8859_1));
@@ -93,7 +87,7 @@ abstract class ilBiblFileReaderBase implements ilBiblFileReaderInterface
         return $this->file_content;
     }
 
-    public function setFileContent(string $file_content)
+    public function setFileContent(string $file_content) : void
     {
         $this->file_content = $file_content;
     }
@@ -101,7 +95,7 @@ abstract class ilBiblFileReaderBase implements ilBiblFileReaderInterface
     /**
      * @inheritDoc
      */
-    public function parseContentToEntries(ilObjBibliographic $bib) : array
+    public function parseContentToEntries(ilObjBibliographic $bib) : array //ToDo PHP8 Review: This seems not to work with Bib files as the type is NOT set in key "entrytype", but as node-type with @-notation. Thus $type will stay null and this will fail on line 141.
     {
         $entries_from_file = $this->parseContent();
         $entry_instances = [];
@@ -133,7 +127,7 @@ abstract class ilBiblFileReaderBase implements ilBiblFileReaderInterface
                 $x++;
             }
             /**
-             * @var $entry_model ilBiblEntry
+             * @var ilBiblEntry $entry_model
              */
             //create the entry and fill data into database by executing doCreate()
             $entry_factory = $this->getEntryFactory();

--- a/Modules/Bibliographic/classes/FileReader/class.ilBiblFileReaderFactory.php
+++ b/Modules/Bibliographic/classes/FileReader/class.ilBiblFileReaderFactory.php
@@ -6,7 +6,6 @@
  */
 class ilBiblFileReaderFactory implements ilBiblFileReaderFactoryInterface
 {
-    
     public function getByType(
         int $type,
         ilBiblEntryFactoryInterface $entry_factory,

--- a/Modules/Bibliographic/classes/OverviewModel/class.ilBiblOverviewModelFactory.php
+++ b/Modules/Bibliographic/classes/OverviewModel/class.ilBiblOverviewModelFactory.php
@@ -20,7 +20,7 @@ class ilBiblOverviewModelFactory implements ilBiblOverviewModelFactoryInterface
             return self::$models;
         }
         /**
-         * @var $overviewModels ilBiblOverviewModel[]
+         * @var ilBiblOverviewModel[] $overviewModels
          */
         $overviewModels = ilBiblOverviewModel::get();
         $overviewModelsArray = array();

--- a/Modules/Bibliographic/classes/OverviewModel/class.ilBiblOverviewModelFactory.php
+++ b/Modules/Bibliographic/classes/OverviewModel/class.ilBiblOverviewModelFactory.php
@@ -7,7 +7,6 @@
 
 class ilBiblOverviewModelFactory implements ilBiblOverviewModelFactoryInterface
 {
-
     protected static array $models = [];
 
 
@@ -15,7 +14,7 @@ class ilBiblOverviewModelFactory implements ilBiblOverviewModelFactoryInterface
      * @deprecated REFACTOR use active record. Create ilBiblOverviewModel AR, Factory and Interface
      * @return mixed[]
      */
-    private function getAllOverviewModels(): array
+    private function getAllOverviewModels() : array
     {
         if (count(self::$models) > 0) {
             return self::$models;

--- a/Modules/Bibliographic/classes/TableQuery/class.ilBiblTableQueryFilter.php
+++ b/Modules/Bibliographic/classes/TableQuery/class.ilBiblTableQueryFilter.php
@@ -7,7 +7,6 @@
  */
 class ilBiblTableQueryFilter implements ilBiblTableQueryFilterInterface
 {
-
     protected string $field_name = '';
     protected string $field_value = '';
     protected string $operator = '=';

--- a/Modules/Bibliographic/classes/Translation/class.ilBiblTranslationTableGUI.php
+++ b/Modules/Bibliographic/classes/Translation/class.ilBiblTranslationTableGUI.php
@@ -43,7 +43,7 @@ class ilBiblTranslationTableGUI extends ilTable2GUI
     }
 
 
-    protected function initColumns(): void
+    protected function initColumns() : void
     {
         $this->addColumn($this->lng()->txt('bibl_translation_select'), '', '15px', true);
         $this->addColumn($this->lng()->txt('bibl_translation_lang'));
@@ -52,7 +52,7 @@ class ilBiblTranslationTableGUI extends ilTable2GUI
     }
 
 
-    protected function parseData(): void
+    protected function parseData() : void
     {
         $data = $this->translation_facory->getAllTranslationsForFieldAsArray($this->field);
         $this->setData($data);

--- a/Modules/Bibliographic/classes/Types/Ris/class.ilRis.php
+++ b/Modules/Bibliographic/classes/Types/Ris/class.ilRis.php
@@ -238,22 +238,12 @@ class ilRis implements ilBiblTypeInterface
         );
 
 
-    /**
-     * @param $field_name
-     *
-     * @return bool
-     */
     public function isStandardField(string $field_name) : bool
     {
         return in_array(strtoupper($field_name), self::$standard_fields);
     }
 
 
-    /**
-     * @param $entry_ype
-     *
-     * @return bool
-     */
     public function isEntryType(string $entry_ype) : bool
     {
         return in_array(strtoupper($entry_ype), self::$entry_types);

--- a/Modules/Bibliographic/classes/class.ilBibliographicDataSet.php
+++ b/Modules/Bibliographic/classes/class.ilBibliographicDataSet.php
@@ -168,7 +168,7 @@ class ilBibliographicDataSet extends ilDataSet
     /**
      * Build data array, data is read from cache except bibl object itself
      */
-    protected function _readData(string $a_entity, array $a_ids): void
+    protected function _readData(string $a_entity, array $a_ids) : void
     {
         switch ($a_entity) {
             case 'bibl':
@@ -191,7 +191,7 @@ class ilBibliographicDataSet extends ilDataSet
     }
 
 
-    public function exportLibraryFile(int $a_id): void
+    public function exportLibraryFile(int $a_id) : void
     {
         $obj = new ilObjBibliographic($a_id);
         $fileAbsolutePath = $obj->getLegacyAbsolutePath();

--- a/Modules/Bibliographic/classes/class.ilBibliographicExporter.php
+++ b/Modules/Bibliographic/classes/class.ilBibliographicExporter.php
@@ -12,7 +12,6 @@
  */
 class ilBibliographicExporter extends ilXmlExporter
 {
-
     protected ?\ilBibliographicDataSet $ds = null;
     /**
      * @var mixed|null

--- a/Modules/Bibliographic/classes/class.ilBibliographicImporter.php
+++ b/Modules/Bibliographic/classes/class.ilBibliographicImporter.php
@@ -9,7 +9,6 @@
  */
 class ilBibliographicImporter extends ilXmlImporter
 {
-
     protected ?\ilBibliographicDataSet $ds = null;
 
 

--- a/Modules/Bibliographic/classes/class.ilObjBibliographic.php
+++ b/Modules/Bibliographic/classes/class.ilObjBibliographic.php
@@ -17,7 +17,6 @@ use ILIAS\DI\Container;
  */
 class ilObjBibliographic extends ilObject2
 {
-
     protected \ilBiblFileReaderFactory $bib_filereader_factory;
     protected \ilBiblTypeFactory $bib_type_factory;
     protected \ilBiblEntryFactory $bib_entry_factory;

--- a/Modules/Bibliographic/classes/class.ilObjBibliographic.php
+++ b/Modules/Bibliographic/classes/class.ilObjBibliographic.php
@@ -13,7 +13,6 @@ use ILIAS\DI\Container;
  * @author  Fabian Schmid <fs@studer-raimann.ch>
  * @author  Thibeau Fuhrer <thf@studer-raimann.ch>
  * @version $Id: class.ilObjBibliographic.php 2012-01-11 10:37:11Z otruffer $
- * @extends ilObject2
  */
 class ilObjBibliographic extends ilObject2
 {
@@ -40,14 +39,11 @@ class ilObjBibliographic extends ilObject2
 
     /**
      * If bibliographic object exists, read it's data from database, otherwise create it
-     * @param $existant_bibl_id int is not set when object is getting created
+     * @param int $existant_bibl_id is not set when object is getting created
      */
     public function __construct(int $existant_bibl_id = 0)
     {
         global $DIC;
-        /**
-         * @var $DIC Container
-         */
 
         $this->storage = $DIC->resourceStorage();
         $this->stakeholder = new ilObjBibliographicStakeholder();
@@ -295,8 +291,9 @@ class ilObjBibliographic extends ilObject2
     /**
      * Clone BIBL
      * @param ilObjBibliographic $new_obj
-     * @param                    $a_target_id
+     * @param int                $a_target_id
      * @param int                $a_copy_id copy id
+     * @param bool               $a_copy_id copy id
      */
     public function doCloneObject($new_obj, $a_target_id, $a_copy_id = null, $a_omit_tree = false) : \ilObjBibliographic
     {
@@ -354,7 +351,7 @@ class ilObjBibliographic extends ilObject2
             $this->bib_attribute_factory
         );
         $reader->readContent($this->getResourceId());
-        $this->entries = $reader->parseContentToEntries($this);
+        $this->entries = $reader->parseContentToEntries($this); //ToDo PHP8 Review: Shouldn't parseContentToEntries be on the interface?
     }
 
     public function setFileType(int $file_type) : void
@@ -413,7 +410,7 @@ class ilObjBibliographic extends ilObject2
     }
 
     /**
-     * @param $filename
+     * @param string $filename
      */
     public function determineFileTypeByFileName($filename) : int
     {

--- a/Modules/Bibliographic/classes/class.ilObjBibliographicAccess.php
+++ b/Modules/Bibliographic/classes/class.ilObjBibliographicAccess.php
@@ -23,7 +23,7 @@ class ilObjBibliographicAccess extends ilObjectAccess
      *    );
      * @return array<int, array<string, string>>|array<int, array<string, string|bool>>
      */
-    public static function _getCommands(): array
+    public static function _getCommands() : array
     {
         $commands = array(
             array(
@@ -40,7 +40,7 @@ class ilObjBibliographicAccess extends ilObjectAccess
     }
 
 
-    public static function _checkGoto(string $target): bool
+    public static function _checkGoto(string $target) : bool
     {
         global $DIC;
         $ilAccess = $DIC['ilAccess'];
@@ -122,7 +122,7 @@ class ilObjBibliographicAccess extends ilObjectAccess
      * @param $ref_id
      * @param $obj_id
      */
-    private static function checkEntryIdMatch($obj_id, $entry_id): bool
+    private static function checkEntryIdMatch($obj_id, $entry_id) : bool
     {
         /**
          * @var $ilBiblEntry ilBiblEntry

--- a/Modules/Bibliographic/classes/class.ilObjBibliographicAccess.php
+++ b/Modules/Bibliographic/classes/class.ilObjBibliographicAccess.php
@@ -75,7 +75,7 @@ class ilObjBibliographicAccess extends ilObjectAccess
         if ($DIC->http()->wrapper()->query()->has(ilObjBibliographicGUI::P_ENTRY_ID)) {
             $entry_id = $DIC->http()->wrapper()->query()->retrieve(
                 ilObjBibliographicGUI::P_ENTRY_ID,
-                $DIC->refinery()->to()->int()
+                $DIC->refinery()->kindlyTo()->int()
             );
             if (!self::checkEntryIdMatch($obj_id, $entry_id)) {
                 return false;
@@ -118,14 +118,10 @@ class ilObjBibliographicAccess extends ilObjectAccess
     }
 
 
-    /**
-     * @param $ref_id
-     * @param $obj_id
-     */
-    private static function checkEntryIdMatch($obj_id, $entry_id) : bool
+    private static function checkEntryIdMatch(int $obj_id, int $entry_id) : bool
     {
         /**
-         * @var $ilBiblEntry ilBiblEntry
+         * @var ilBiblEntry $ilBiblEntry
          */
         $ilBiblEntry = ilBiblEntry::find($entry_id);
         if (is_null($ilBiblEntry)) {
@@ -141,7 +137,7 @@ class ilObjBibliographicAccess extends ilObjectAccess
      *
      * @param int $a_id bibl id
      */
-    public static function _lookupOnline(int $a_id)
+    public static function _lookupOnline(int $a_id) //ToDo PHP8 Review: Missing Return Type Declaration
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];

--- a/Modules/Bibliographic/classes/class.ilObjBibliographicAdminGUI.php
+++ b/Modules/Bibliographic/classes/class.ilObjBibliographicAdminGUI.php
@@ -27,14 +27,11 @@ class ilObjBibliographicAdminGUI extends ilObjectGUI
     /**
      * ilObjBibliographicAdminGUI constructor.
      *
-     * @param      $a_data
-     * @param      $a_id
-     * @param bool $a_call_by_reference
-     * @param bool $a_prepare_output
+     * @param mixed $a_data
      *
      * @throws \ilObjectException
      */
-    public function __construct($a_data, $a_id, $a_call_by_reference = true, $a_prepare_output = true)
+    public function __construct($a_data, int $a_id, bool $a_call_by_reference = true, bool $a_prepare_output = true)
     {
         parent::__construct($a_data, $a_id, $a_call_by_reference, $a_prepare_output);
         $this->type = 'bibs';
@@ -45,7 +42,6 @@ class ilObjBibliographicAdminGUI extends ilObjectGUI
 
 
     /**
-     * @return bool|void$
      * @throws ilCtrlException
      */
     public function executeCommand() : void

--- a/Modules/Bibliographic/classes/class.ilObjBibliographicAdminGUI.php
+++ b/Modules/Bibliographic/classes/class.ilObjBibliographicAdminGUI.php
@@ -48,7 +48,7 @@ class ilObjBibliographicAdminGUI extends ilObjectGUI
      * @return bool|void$
      * @throws ilCtrlException
      */
-    public function executeCommand(): void
+    public function executeCommand() : void
     {
         $next_class = $this->ctrl->getNextClass($this);
         switch ($next_class) {
@@ -82,13 +82,13 @@ class ilObjBibliographicAdminGUI extends ilObjectGUI
     }
 
 
-    protected function view(): void
+    protected function view() : void
     {
         $this->ctrl->redirectByClass(ilBiblAdminRisFieldGUI::class);
     }
 
 
-    public function getAdminTabs(): void
+    public function getAdminTabs() : void
     {
         global $DIC;
         $rbacsystem = $DIC['rbacsystem'];
@@ -114,13 +114,13 @@ class ilObjBibliographicAdminGUI extends ilObjectGUI
     }
 
 
-    public function getTabsGui(): \ilTabsGUI
+    public function getTabsGui() : \ilTabsGUI
     {
         return $this->tabs_gui;
     }
 
 
-    public function setTabsGui(\ilTabsGUI $tabs_gui): void
+    public function setTabsGui(\ilTabsGUI $tabs_gui) : void
     {
         $this->tabs_gui = $tabs_gui;
     }

--- a/Modules/Bibliographic/classes/class.ilObjBibliographicGUI.php
+++ b/Modules/Bibliographic/classes/class.ilObjBibliographicGUI.php
@@ -146,7 +146,7 @@ class ilObjBibliographicGUI extends ilObject2GUI implements ilDesktopItemHandlin
             case strtolower(ilObjFileGUI::class):
                 $this->prepareOutput();
                 $this->dic()->tabs()->setTabActive(self::TAB_ID_RECORDS);
-                $this->ctrl->forwardCommand(new ilObjFile($this));
+                $this->ctrl->forwardCommand(new ilObjFile($this)); //ToDo PHP8 Review: This can't work as $this != int.
                 break;
             case strtolower(ilExportGUI::class):
                 $this->prepareOutput();
@@ -629,7 +629,7 @@ class ilObjBibliographicGUI extends ilObject2GUI implements ilDesktopItemHandlin
         $DIC->ctrl()->redirect($this, "");
     }
 
-    public function addNews($obj_id, string $change = 'created') : void
+    public function addNews(int $obj_id, string $change = 'created') : void
     {
         global $DIC;
 

--- a/Modules/Bibliographic/classes/class.ilObjBibliographicListGUI.php
+++ b/Modules/Bibliographic/classes/class.ilObjBibliographicListGUI.php
@@ -14,7 +14,7 @@ class ilObjBibliographicListGUI extends ilObjectListGUI
     /**
      * initialisation
      */
-    public function init(): void
+    public function init() : void
     {
         $this->lng->loadLanguageModule('bibl');
         $this->copy_enabled = true;
@@ -37,7 +37,7 @@ class ilObjBibliographicListGUI extends ilObjectListGUI
      *                    "property" (string) => property name
      *                    "value" (string) => property value
      */
-    public function getProperties(): array
+    public function getProperties() : array
     {
         global $DIC;
         $lng = $DIC['lng'];

--- a/Modules/Bibliographic/classes/class.ilObjBibliographicListGUI.php
+++ b/Modules/Bibliographic/classes/class.ilObjBibliographicListGUI.php
@@ -5,8 +5,6 @@
  *
  * @author  Oskar Truffer <ot@studer-raimann.ch>
  * @author  Martin Studer <ms@studer-raimann.ch>
- *
- * @extends ilObjectListGUI
  */
 class ilObjBibliographicListGUI extends ilObjectListGUI
 {

--- a/Modules/Bibliographic/interfaces/Attribute/interface.ilBiblAttributeFactoryInterface.php
+++ b/Modules/Bibliographic/interfaces/Attribute/interface.ilBiblAttributeFactoryInterface.php
@@ -6,7 +6,6 @@
 
 interface ilBiblAttributeFactoryInterface
 {
-
     public function getPossibleValuesForFieldAndObject(ilBiblFieldInterface $field, int $object_id) : array;
 
     /**

--- a/Modules/Bibliographic/interfaces/Attribute/interface.ilBiblAttributeInterface.php
+++ b/Modules/Bibliographic/interfaces/Attribute/interface.ilBiblAttributeInterface.php
@@ -6,7 +6,6 @@
 
 interface ilBiblAttributeInterface
 {
-    
     public function getEntryId() : int;
     
     public function setEntryId(int $entry_id) : void;

--- a/Modules/Bibliographic/interfaces/Data/class.ilBiblDataFactoryInterface.php
+++ b/Modules/Bibliographic/interfaces/Data/class.ilBiblDataFactoryInterface.php
@@ -6,6 +6,5 @@
 
 interface ilBiblDataFactoryInterface
 {
-    
     public function getIlBiblDataById(int $id) : ?ilBiblData;
 }

--- a/Modules/Bibliographic/interfaces/Data/class.ilBiblDataInterface.php
+++ b/Modules/Bibliographic/interfaces/Data/class.ilBiblDataInterface.php
@@ -6,7 +6,6 @@
 
 interface ilBiblDataInterface
 {
-    
     public function getId() : ?int;
     
     public function setId(int $id) : void;

--- a/Modules/Bibliographic/interfaces/Entry/interface.ilBiblEntryInterface.php
+++ b/Modules/Bibliographic/interfaces/Entry/interface.ilBiblEntryInterface.php
@@ -6,7 +6,6 @@
  */
 interface ilBiblEntryInterface
 {
-    
     public function setId(int $id) : void;
     
     public function getId() : ?int;
@@ -19,5 +18,5 @@ interface ilBiblEntryInterface
     
     public function setType(string $type) : void;
     
-    public function getOverview():string;
+    public function getOverview() : string;
 }

--- a/Modules/Bibliographic/interfaces/Facade/interface.ilBiblAdminFactoryFacadeInterface.php
+++ b/Modules/Bibliographic/interfaces/Facade/interface.ilBiblAdminFactoryFacadeInterface.php
@@ -6,7 +6,6 @@
  */
 interface ilBiblAdminFactoryFacadeInterface
 {
-
     public function typeFactory() : \ilBiblTypeFactoryInterface;
 
     public function type() : \ilBiblTypeInterface;

--- a/Modules/Bibliographic/interfaces/Facade/interface.ilBiblAdminLibraryFacadeInterface.php
+++ b/Modules/Bibliographic/interfaces/Facade/interface.ilBiblAdminLibraryFacadeInterface.php
@@ -6,7 +6,6 @@
  */
 interface ilBiblAdminLibraryFacadeInterface
 {
-
     public function iliasObjId() : int;
 
     public function iliasRefId() : int;

--- a/Modules/Bibliographic/interfaces/Facade/interface.ilBiblFactoryFacadeInterface.php
+++ b/Modules/Bibliographic/interfaces/Facade/interface.ilBiblFactoryFacadeInterface.php
@@ -6,7 +6,6 @@
  */
 interface ilBiblFactoryFacadeInterface
 {
-
     public function typeFactory() : \ilBiblTypeFactoryInterface;
 
     public function overviewModelFactory() : \ilBiblOverviewModelFactoryInterface;

--- a/Modules/Bibliographic/interfaces/FileReader/interface.ilBiblFileReaderInterface.php
+++ b/Modules/Bibliographic/interfaces/FileReader/interface.ilBiblFileReaderInterface.php
@@ -8,7 +8,6 @@ use ILIAS\ResourceStorage\Identification\ResourceIdentification;
  */
 interface ilBiblFileReaderInterface
 {
-    
     public function readContent(ResourceIdentification $identification) : bool;
     
     /**

--- a/Modules/Bibliographic/interfaces/Library/interface.ilBiblLibraryFactoryInterface.php
+++ b/Modules/Bibliographic/interfaces/Library/interface.ilBiblLibraryFactoryInterface.php
@@ -6,7 +6,6 @@
  */
 interface ilBiblLibraryFactoryInterface
 {
-
     public function getAll() : array;
 
     public function findById(int $id) : \ilBiblLibraryInterface;

--- a/Modules/Bibliographic/interfaces/Library/interface.ilBiblLibraryInterface.php
+++ b/Modules/Bibliographic/interfaces/Library/interface.ilBiblLibraryInterface.php
@@ -6,7 +6,6 @@
  */
 interface ilBiblLibraryInterface
 {
-    
     public function getId() : ?int;
     
     public function setId(int $id) : void;

--- a/Modules/Bibliographic/interfaces/OverviewModel/class.ilBiblOverviewModelInterface.php
+++ b/Modules/Bibliographic/interfaces/OverviewModel/class.ilBiblOverviewModelInterface.php
@@ -6,7 +6,6 @@
 
 interface ilBiblOverviewModelInterface
 {
-    
     public function getOvmId() : ?int;
     
     public function setOvmId(int $ovm_id) : void;

--- a/Modules/Bibliographic/interfaces/TableQuery/interface.ilBiblTableQueryFilterInterface.php
+++ b/Modules/Bibliographic/interfaces/TableQuery/interface.ilBiblTableQueryFilterInterface.php
@@ -12,7 +12,6 @@
  */
 interface ilBiblTableQueryFilterInterface
 {
-    
     public function getFieldName() : string;
     
     public function setFieldName(string $field_name) : void;

--- a/Modules/Bibliographic/interfaces/Translation/interface.ilBiblTranslationInterface.php
+++ b/Modules/Bibliographic/interfaces/Translation/interface.ilBiblTranslationInterface.php
@@ -6,7 +6,6 @@
  */
 interface ilBiblTranslationInterface
 {
-    
     public function getId() : ?int;
     
     public function setId(int $id) : void;

--- a/Modules/Bibliographic/interfaces/Type/interface.ilBiblTypeInterface.php
+++ b/Modules/Bibliographic/interfaces/Type/interface.ilBiblTypeInterface.php
@@ -6,7 +6,6 @@
  */
 interface ilBiblTypeInterface
 {
-    
     public function isStandardField(string $identifier) : bool;
     
     public function isEntryType(string $identifier) : bool;


### PR DESCRIPTION
Hi @chfsx  

Here are the results of the `Services/Block` review.

### Results

- [ ] The code style is PSR-2 + X compliant: _CS-Fixer changed 28 Files_
- [ ] No usage of $_GET / $_POST / $_REQUEST / $_SESSION: _You have one direct access to $_REQUEST (marked by a Todo) and one additional access to $_FILE (ilObjBibliographficGUI line 591) that could maybe also be avoided_
- [ ] There is a Unit Test Suite with at least one unit test: _There are no Unit Tests_
- [ ] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant): _The RISReader hasn't been updated since 2012, it seems to work with PHP8, but I haven't tested it (just ran the Rector-Profile to see if it proposed changes)_
- [ ] The types are fully documented (PHPDoc) or explicit PHP types are used (type hints, return types, typed properties)

### Comments

- Saving Settings fails when not uploading a tile image. The error is in ilObjBibliographic on line 152 as $has_valid_upload is true because the previous $upload->hasUploads() returns true. Didn't look deep enough into it to be sure if the problem is here or in ILIAS\FileUpload.
- Editing or Deleting a Filter fails with "Typed property ilBiblFieldFilter::$field_id must not be accessed before initialization"

### Changes made in this PR:
- Fixed CS
- Added some types and one array declaration in Params
- Fixed a few obvious problems
- Added a few //Todo PHP8 Review:

Best regards,
@swiniker