### PR TITLE
Review `Services/VirusScanner`

### DIFF
--- a/Services/VirusScanner/classes/Setup/class.ilVirusScannerConfigStoredObjective.php
+++ b/Services/VirusScanner/classes/Setup/class.ilVirusScannerConfigStoredObjective.php
@@ -1,23 +1,26 @@
-<?php
+<?php declare(strict_types=1);
 
-use ILIAS\Setup;
-
-/******************************************************************************
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
+
+use ILIAS\Setup;
+
 class ilVirusScannerConfigStoredObjective implements Setup\Objective
 {
-    protected \ilVirusScannerSetupConfig $config;
+    protected ilVirusScannerSetupConfig $config;
 
     public function __construct(
         ilVirusScannerSetupConfig $config
@@ -41,7 +44,7 @@ class ilVirusScannerConfigStoredObjective implements Setup\Objective
     }
 
     /**
-     * @return \ilIniFilesLoadedObjective[]
+     * @return ilIniFilesLoadedObjective[]
      */
     public function getPreconditions(Setup\Environment $environment) : array
     {
@@ -54,7 +57,7 @@ class ilVirusScannerConfigStoredObjective implements Setup\Objective
     {
         $ini = $environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI);
 
-        $ini->setVariable("tools", "vscantype", (string) $this->config->getVirusScanner());
+        $ini->setVariable("tools", "vscantype", $this->config->getVirusScanner());
         $ini->setVariable("tools", "scancommand", (string) $this->config->getPathToScan());
         $ini->setVariable("tools", "cleancommand", (string) $this->config->getPathToClean());
         $ini->setVariable("tools", "icap_host", (string) $this->config->getIcapHost());

--- a/Services/VirusScanner/classes/Setup/class.ilVirusScannerMetricsCollectedObjective.php
+++ b/Services/VirusScanner/classes/Setup/class.ilVirusScannerMetricsCollectedObjective.php
@@ -1,33 +1,36 @@
-<?php
+<?php declare(strict_types=1);
 
-use ILIAS\Setup;
-
-/******************************************************************************
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
+
+use ILIAS\Setup;
+
 class ilVirusScannerMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
 {
     /**
-     * @return \ilIniFilesLoadedObjective[]
+     * @return ilIniFilesLoadedObjective[]
      */
-    public function getTentativePreconditions(Setup\Environment $environment) : array
+    protected function getTentativePreconditions(Setup\Environment $environment) : array
     {
         return [
             new ilIniFilesLoadedObjective()
         ];
     }
 
-    public function collectFrom(Setup\Environment $environment, Setup\Metrics\Storage $storage) : void
+    protected function collectFrom(Setup\Environment $environment, Setup\Metrics\Storage $storage) : void
     {
         $ini = $environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI);
         if (!$ini) {

--- a/Services/VirusScanner/classes/Setup/class.ilVirusScannerSetupAgent.php
+++ b/Services/VirusScanner/classes/Setup/class.ilVirusScannerSetupAgent.php
@@ -1,22 +1,25 @@
-<?php
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 use ILIAS\Refinery;
 use ILIAS\Refinery\Factory;
 use ILIAS\Setup;
 
-/******************************************************************************
- *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
- *
- * If this is not the case or you just want to try ILIAS, you'll find
- * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
- *
- *****************************************************************************/
 class ilVirusScannerSetupAgent implements Setup\Agent
 {
     use Setup\Agent\HasNoNamedObjective;
@@ -36,7 +39,7 @@ class ilVirusScannerSetupAgent implements Setup\Agent
 
     public function getArrayToConfigTransformation() : Refinery\Transformation
     {
-        return $this->refinery->custom()->transformation(fn ($data) : \ilVirusScannerSetupConfig => new ilVirusScannerSetupConfig(
+        return $this->refinery->custom()->transformation(fn ($data) : ilVirusScannerSetupConfig => new ilVirusScannerSetupConfig(
             $data["virusscanner"] ?? ilVirusScannerSetupConfig::VIRUS_SCANNER_NONE,
             $data["path_to_scan"] ?? null,
             $data["path_to_clean"] ?? null,

--- a/Services/VirusScanner/classes/Setup/class.ilVirusScannerSetupConfig.php
+++ b/Services/VirusScanner/classes/Setup/class.ilVirusScannerSetupConfig.php
@@ -1,20 +1,23 @@
-<?php
+<?php declare(strict_types=1);
 
-use ILIAS\Setup;
-
-/******************************************************************************
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
+
+use ILIAS\Setup;
+
 class ilVirusScannerSetupConfig implements Setup\Config
 {
     public const VIRUS_SCANNER_NONE = "none";

--- a/Services/VirusScanner/classes/Setup/class.ilVirusScannerSetupConfig.php
+++ b/Services/VirusScanner/classes/Setup/class.ilVirusScannerSetupConfig.php
@@ -17,11 +17,11 @@ use ILIAS\Setup;
  *****************************************************************************/
 class ilVirusScannerSetupConfig implements Setup\Config
 {
-    const VIRUS_SCANNER_NONE = "none";
-    const VIRUS_SCANNER_SOPHOS = "sophos";
-    const VIRUS_SCANNER_ANTIVIR = "antivir";
-    const VIRUS_SCANNER_CLAMAV = "clamav";
-    const VIRUS_SCANNER_ICAP = "icap";
+    public const VIRUS_SCANNER_NONE = "none";
+    private const VIRUS_SCANNER_SOPHOS = "sophos";
+    private const VIRUS_SCANNER_ANTIVIR = "antivir";
+    private const VIRUS_SCANNER_CLAMAV = "clamav";
+    private const VIRUS_SCANNER_ICAP = "icap";
 
     protected string $virus_scanner;
 

--- a/Services/VirusScanner/classes/class.ilVirusScanner.php
+++ b/Services/VirusScanner/classes/class.ilVirusScanner.php
@@ -1,17 +1,21 @@
-<?php
-/******************************************************************************
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
+
 class ilVirusScanner
 {
     public string $type;
@@ -111,9 +115,9 @@ class ilVirusScanner
     protected function scanFileFromBuffer(string $buffer) : bool
     {
         $bufferFile = $this->createBufferFile($buffer);
-        $isInfected = $this->scanFile($bufferFile);
+        $infection = $this->scanFile($bufferFile);
         $this->removeBufferFile($bufferFile);
-        return $isInfected;
+        return $infection !== '';
     }
 
     protected function createBufferFile(string $buffer) : string
@@ -128,17 +132,17 @@ class ilVirusScanner
         $this->scanFilePath = $file_path;
         $this->scanFileOrigName = $org_name;
 
-        if ($org_name == "infected.txt" or $org_name == "cleanable.txt") {
+        if ($org_name === "infected.txt" || $org_name === "cleanable.txt") {
             $this->scanFileIsInfected = true;
             $this->scanResult =
                 "FILE INFECTED: [" . $file_path . "] (VIRUS: simulated)";
             $this->logScanResult();
             return $this->scanResult;
-        } else {
-            $this->scanFileIsInfected = false;
-            $this->scanResult = "";
-            return "";
         }
+
+        $this->scanFileIsInfected = false;
+        $this->scanResult = "";
+        return "";
     }
 
     public function logScanResult() : void
@@ -162,19 +166,19 @@ class ilVirusScanner
         $this->cleanFilePath = $file_path;
         $this->cleanFileOrigName = $org_name;
 
-        if ($org_name == "cleanable.txt") {
+        if ($org_name === "cleanable.txt") {
             $this->cleanFileIsCleaned = true;
             $this->cleanResult =
                 "FILE CLEANED: [" . $file_path . "] (VIRUS: simulated)";
             $this->logCleanResult();
             return $this->cleanResult;
-        } else {
-            $this->cleanFileIsCleaned = false;
-            $this->cleanResult =
-                "FILE NOT CLEANED: [" . $file_path . "] (VIRUS: simulated)";
-            $this->logCleanResult();
-            return "";
         }
+
+        $this->cleanFileIsCleaned = false;
+        $this->cleanResult =
+            "FILE NOT CLEANED: [" . $file_path . "] (VIRUS: simulated)";
+        $this->logCleanResult();
+        return "";
     }
 
     public function logCleanResult() : void

--- a/Services/VirusScanner/classes/class.ilVirusScanner.php
+++ b/Services/VirusScanner/classes/class.ilVirusScanner.php
@@ -38,7 +38,7 @@ class ilVirusScanner
 
     public string $cleanResult;
 
-    public $ilias;
+    public ilErrorHandling $error;
 
     public ilLanguage $lng;
 
@@ -47,11 +47,11 @@ class ilVirusScanner
     public function __construct(string $scan_command, string $clean_command)
     {
         global $DIC;
-        $ilias = $DIC['ilias'];
+        $error = $DIC['ilErr'];
         $lng = $DIC->language();
         $log = $DIC->logger();
 
-        $this->ilias = $ilias;
+        $this->error = $error;
         $this->lng = $lng;
         $this->log = $log;
         $this->scanCommand = $scan_command;

--- a/Services/VirusScanner/classes/class.ilVirusScanner.php
+++ b/Services/VirusScanner/classes/class.ilVirusScanner.php
@@ -74,8 +74,8 @@ class ilVirusScanner
         $lng = $DIC->language();
         
         if ((defined('IL_VIRUS_SCANNER') && IL_VIRUS_SCANNER !== 'None') || (defined(
-                    'IL_ICAP_HOST'
-                ) && IL_ICAP_HOST !== '')) {
+            'IL_ICAP_HOST'
+        ) && IL_ICAP_HOST !== '')) {
             $vs = ilVirusScannerFactory::_getInstance();
             if (($vs_txt = $vs->scanFile($a_file, $a_orig_name)) !== '') {
                 if ($a_clean && defined('IL_VIRUS_CLEAN_COMMAND') && IL_VIRUS_CLEAN_COMMAND !== '') {

--- a/Services/VirusScanner/classes/class.ilVirusScannerAntiVir.php
+++ b/Services/VirusScanner/classes/class.ilVirusScannerAntiVir.php
@@ -1,17 +1,21 @@
-<?php
-/******************************************************************************
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
+
 class ilVirusScannerAntiVir extends ilVirusScanner
 {
     public function __construct(string $scan_command, string $clean_command)
@@ -36,9 +40,9 @@ class ilVirusScannerAntiVir extends ilVirusScanner
             $this->scanFileIsInfected = true;
             $this->logScanResult();
             return $this->scanResult;
-        } else {
-            $this->scanFileIsInfected = false;
-            return "";
         }
+
+        $this->scanFileIsInfected = false;
+        return "";
     }
 }

--- a/Services/VirusScanner/classes/class.ilVirusScannerClamAV.php
+++ b/Services/VirusScanner/classes/class.ilVirusScannerClamAV.php
@@ -14,7 +14,7 @@
  *****************************************************************************/
 class ilVirusScannerClamAV extends ilVirusScanner
 {
-    const ADD_SCAN_PARAMS = '--no-summary -i';
+    private const ADD_SCAN_PARAMS = '--no-summary -i';
 
     public function __construct(string $scan_command, string $clean_command)
     {

--- a/Services/VirusScanner/classes/class.ilVirusScannerClamAV.php
+++ b/Services/VirusScanner/classes/class.ilVirusScannerClamAV.php
@@ -1,17 +1,21 @@
-<?php
-/******************************************************************************
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
+
 class ilVirusScannerClamAV extends ilVirusScanner
 {
     private const ADD_SCAN_PARAMS = '--no-summary -i';
@@ -34,7 +38,7 @@ class ilVirusScannerClamAV extends ilVirusScanner
 
     protected function isBufferScanPossible() : bool
     {
-        $functions = array('proc_open', 'proc_close');
+        $functions = ['proc_open', 'proc_close'];
 
         foreach ($functions as $func) {
             if (function_exists($func)) {
@@ -49,13 +53,13 @@ class ilVirusScannerClamAV extends ilVirusScanner
 
     protected function processBufferScan(string $buffer) : bool
     {
-        $descriptor_spec = array(
-            0 => array("pipe", "r"),  // stdin is a pipe that the child will read from
-            1 => array("pipe", "w"),  // stdout is a pipe that the child will write to
-            2 => array("pipe", "w")        // stderr for the child
-        );
+        $descriptor_spec = [
+            0 => ["pipe", "r"],  // stdin is a pipe that the child will read from
+            1 => ["pipe", "w"],  // stdout is a pipe that the child will write to
+            2 => ["pipe", "w"]        // stderr for the child
+        ];
 
-        $pipes = array(); // will look like follows after passing
+        $pipes = []; // will look like follows after passing
         // 0 => writeable handle connected to child stdin
         // 1 => readable handle connected to child stdout
 
@@ -76,7 +80,7 @@ class ilVirusScannerClamAV extends ilVirusScanner
 
         $return = proc_close($process);
 
-        return $this->hasDetections($detectionReport);
+        return (bool) $this->hasDetections($detectionReport);
     }
 
     protected function buildScanCommand(string $file = '-') : string
@@ -107,9 +111,9 @@ class ilVirusScannerClamAV extends ilVirusScanner
             $this->scanFileIsInfected = true;
             $this->logScanResult();
             return $this->scanResult;
-        } else {
-            $this->scanFileIsInfected = false;
-            return "";
         }
+
+        $this->scanFileIsInfected = false;
+        return "";
     }
 }

--- a/Services/VirusScanner/classes/class.ilVirusScannerFactory.php
+++ b/Services/VirusScanner/classes/class.ilVirusScannerFactory.php
@@ -1,27 +1,28 @@
-<?php
-/******************************************************************************
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
-/**
- * Class ilVirusScannerFactory
- */
+ *********************************************************************/
+
 class ilVirusScannerFactory
 {
     public static function _getInstance() : ilVirusScanner
     {
         $vs = null;
 
-        if (IL_VIRUS_SCANNER == "icap") {
+        if (IL_VIRUS_SCANNER === "icap") {
             if (strlen(IL_ICAP_CLIENT) > 0) {
                 $vs = new ilVirusScannerICapClient('', '');
             } else {

--- a/Services/VirusScanner/classes/class.ilVirusScannerICapClient.php
+++ b/Services/VirusScanner/classes/class.ilVirusScannerICapClient.php
@@ -1,17 +1,21 @@
-<?php
-/******************************************************************************
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
+
 class ilVirusScannerICapClient extends ilVirusScanner
 {
     private const HEADER_INFECTION_FOUND = 'X-Infection-Found';

--- a/Services/VirusScanner/classes/class.ilVirusScannerICapClient.php
+++ b/Services/VirusScanner/classes/class.ilVirusScannerICapClient.php
@@ -14,7 +14,7 @@
  *****************************************************************************/
 class ilVirusScannerICapClient extends ilVirusScanner
 {
-    const HEADER_INFECTION_FOUND = 'X-Infection-Found';
+    private const HEADER_INFECTION_FOUND = 'X-Infection-Found';
 
     public function __construct(string $scan_command, string $clean_command)
     {

--- a/Services/VirusScanner/classes/class.ilVirusScannerICapRemote.php
+++ b/Services/VirusScanner/classes/class.ilVirusScannerICapRemote.php
@@ -1,17 +1,21 @@
-<?php
-/******************************************************************************
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
+
 class ilVirusScannerICapRemote extends ilVirusScanner
 {
     private string $host;
@@ -24,14 +28,14 @@ class ilVirusScannerICapRemote extends ilVirusScanner
     {
         parent::__construct($scan_command, $clean_command);
         $this->host = IL_ICAP_HOST;
-        $this->port = IL_ICAP_PORT;
+        $this->port = (int) IL_ICAP_PORT;
     }
 
     public function options(string $service) : array
     {
         $request = $this->getRequest('OPTIONS', $service);
         $response = $this->send($request);
-        if (strlen($response) > 0) {
+        if ($response !== '') {
             return $this->parseResponse($response);
         }
         return [];
@@ -124,7 +128,7 @@ class ilVirusScannerICapRemote extends ilVirusScanner
         return socket_last_error($this->socket);
     }
 
-    private function disconnect()
+    private function disconnect() : void
     {
         socket_shutdown($this->socket);
         socket_close($this->socket);
@@ -148,18 +152,18 @@ class ilVirusScannerICapRemote extends ilVirusScanner
                 }
                 $parts = preg_split('/ +/', $line, 3);
                 $response['protocol'] = [
-                    'icap' => isset($parts[0]) ? $parts[0] : '',
-                    'code' => isset($parts[1]) ? $parts[1] : '',
-                    'message' => isset($parts[2]) ? $parts[2] : '',
+                    'icap' => $parts[0] ?? '',
+                    'code' => $parts[1] ?? '',
+                    'message' => $parts[2] ?? '',
                 ];
                 continue;
             }
             if ('' === $line) {
                 break;
             }
-            $parts = preg_split('/: /', $line, 2);
+            $parts = explode(": ", $line, 2);
             if (isset($parts[0])) {
-                $response['headers'][$parts[0]] = isset($parts[1]) ? $parts[1] : '';
+                $response['headers'][$parts[0]] = $parts[1] ?? '';
             }
         }
         $body = preg_split('/\r?\n\r?\n/', $string, 2);
@@ -167,10 +171,10 @@ class ilVirusScannerICapRemote extends ilVirusScanner
             $response['rawBody'] = $body[1];
             if (array_key_exists('Encapsulated', $response['headers'])) {
                 $encapsulated = [];
-                $params = preg_split('/, /', $response['headers']['Encapsulated']);
+                $params = explode(", ", $response['headers']['Encapsulated']);
                 if (count($params) > 0) {
                     foreach ($params as $param) {
-                        $parts = preg_split('/=/', $param);
+                        $parts = explode("=", $param);
                         if (count($parts) !== 2) {
                             continue;
                         }

--- a/Services/VirusScanner/classes/class.ilVirusScannerICapRemote.php
+++ b/Services/VirusScanner/classes/class.ilVirusScannerICapRemote.php
@@ -201,7 +201,7 @@ class ilVirusScannerICapRemote extends ilVirusScanner
     /**
      * @return array<string, array<string, string>>|array<string, string>
      */
-    public function respMod($service, array $body = [], array $headers = []) : array
+    public function respMod(string $service, array $body = [], array $headers = []) : array
     {
         $request = $this->getRequest('RESPMOD', $service, $body, $headers);
         $response = $this->send($request);

--- a/Services/VirusScanner/classes/class.ilVirusScannerICapRemoteAvClient.php
+++ b/Services/VirusScanner/classes/class.ilVirusScannerICapRemoteAvClient.php
@@ -15,9 +15,9 @@
 
 class ilVirusScannerICapRemoteAvClient extends ilVirusScannerICapRemote
 {
-    const HEADER = 'headers';
-    const HEADER_VIOLATION_FOUND = 'X-Violations-Found';
-    const HEADER_INFECTION_FOUND = 'X-Infection-Found';
+    private const HEADER = 'headers';
+    private const HEADER_VIOLATION_FOUND = 'X-Violations-Found';
+    private const HEADER_INFECTION_FOUND = 'X-Infection-Found';
 
     public function __construct(string $scan_command, string $clean_command)
     {

--- a/Services/VirusScanner/classes/class.ilVirusScannerICapRemoteAvClient.php
+++ b/Services/VirusScanner/classes/class.ilVirusScannerICapRemoteAvClient.php
@@ -1,17 +1,20 @@
-<?php
-/******************************************************************************
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
 
 class ilVirusScannerICapRemoteAvClient extends ilVirusScannerICapRemote
 {
@@ -53,25 +56,24 @@ class ilVirusScannerICapRemoteAvClient extends ilVirusScannerICapRemote
         $virus_found = false;
         if (array_key_exists(self::HEADER, $header)) {
             $header = $header[self::HEADER];
-            if (array_key_exists(self::HEADER_VIOLATION_FOUND, $header)) {
-                if ($header[self::HEADER_VIOLATION_FOUND] > 0) {
-                    $virus_found = true;
-                }
+            if (array_key_exists(self::HEADER_VIOLATION_FOUND, $header) && $header[self::HEADER_VIOLATION_FOUND] > 0) {
+                $virus_found = true;
             }
-            if (array_key_exists(self::HEADER_INFECTION_FOUND, $header)) {
-                if (strlen($header[self::HEADER_INFECTION_FOUND]) > 0) {
-                    $infection_split = preg_split('/;/', $header[self::HEADER_INFECTION_FOUND]);
-                    foreach ($infection_split as $infection) {
-                        $parts = preg_split('/=/', $infection);
-                        if ($parts !== false &&
-                            is_array($parts) &&
-                            count($parts) > 0 &&
-                            strlen($parts[0]) > 0) {
-                            $this->log->warning(trim($parts[0]) . ': ' . trim($parts[1]));
-                        }
+            if (array_key_exists(
+                self::HEADER_INFECTION_FOUND,
+                $header
+            ) && $header[self::HEADER_INFECTION_FOUND] !== '') {
+                $infection_split = explode(";", $header[self::HEADER_INFECTION_FOUND]);
+                foreach ($infection_split as $infection) {
+                    $parts = explode("=", $infection);
+                    if ($parts !== false &&
+                        is_array($parts) &&
+                        count($parts) > 0 &&
+                        $parts[0] !== '') {
+                        $this->log->warning(trim($parts[0]) . ': ' . trim($parts[1]));
                     }
-                    $virus_found = true;
                 }
+                $virus_found = true;
             }
         }
         return $virus_found;

--- a/Services/VirusScanner/classes/class.ilVirusScannerPreProcessor.php
+++ b/Services/VirusScanner/classes/class.ilVirusScannerPreProcessor.php
@@ -29,7 +29,8 @@ final class ilVirusScannerPreProcessor implements PreProcessor
     }
 
     public function process(FileStream $stream, Metadata $metadata) : ProcessingStatus
-    {;
+    {
+        ;
         $uri = $stream->getMetadata()["uri"];
         // chmod($uri, 0755); // we must find a way e.g. ClamAV can read the file
         if ($this->scanner->scanFile($uri) !== "") {

--- a/Services/VirusScanner/classes/class.ilVirusScannerPreProcessor.php
+++ b/Services/VirusScanner/classes/class.ilVirusScannerPreProcessor.php
@@ -30,7 +30,6 @@ final class ilVirusScannerPreProcessor implements PreProcessor
 
     public function process(FileStream $stream, Metadata $metadata) : ProcessingStatus
     {
-        ;
         $uri = $stream->getMetadata()["uri"];
         // chmod($uri, 0755); // we must find a way e.g. ClamAV can read the file
         if ($this->scanner->scanFile($uri) !== "") {

--- a/Services/VirusScanner/classes/class.ilVirusScannerPreProcessor.php
+++ b/Services/VirusScanner/classes/class.ilVirusScannerPreProcessor.php
@@ -1,23 +1,25 @@
-<?php
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 use ILIAS\Filesystem\Stream\FileStream;
 use ILIAS\FileUpload\DTO\Metadata;
 use ILIAS\FileUpload\DTO\ProcessingStatus;
 use ILIAS\FileUpload\Processor\PreProcessor;
-
-/******************************************************************************
- *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
- *
- * If this is not the case or you just want to try ILIAS, you'll find
- * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
- *
- *****************************************************************************/
 
 final class ilVirusScannerPreProcessor implements PreProcessor
 {

--- a/Services/VirusScanner/classes/class.ilVirusScannerSophos.php
+++ b/Services/VirusScanner/classes/class.ilVirusScannerSophos.php
@@ -1,17 +1,21 @@
-<?php
-/******************************************************************************
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
+
 class ilVirusScannerSophos extends ilVirusScanner
 {
     public function __construct(string $scan_command, string $clean_command)
@@ -33,15 +37,15 @@ class ilVirusScannerSophos extends ilVirusScanner
         $this->scanResult = implode("\n", $out);
 
         // sophie could be called
-        if ($ret == 0) {
+        if ((int) $ret === 0) {
             if (preg_match("/FILE INFECTED/", $this->scanResult)) {
                 $this->scanFileIsInfected = true;
                 $this->logScanResult();
                 return $this->scanResult;
-            } else {
-                $this->scanFileIsInfected = false;
-                return "";
             }
+
+            $this->scanFileIsInfected = false;
+            return "";
         }
 
         // sophie has failed (probably the daemon doesn't run)
@@ -62,21 +66,21 @@ class ilVirusScannerSophos extends ilVirusScanner
         // 1  If  the user interrupts SWEEP (usually by pressing control-C) or kills the process.
         // 2  If some error preventing further execution is discovered.
         // 3  If viruses or virus fragments are discovered.
-        if ($ret == 0) {
+        if ((int) $ret === 0) {
             $this->cleanFileIsCleaned = false;
             return "";
-        } elseif ($ret == 3) {
+        } elseif ((int) $ret === 3) {
             $this->scanFileIsInfected = true;
             $this->logScanResult();
             return $this->scanResult;
-        } else {
-            $this->error->raiseError(
-                $this->lng->txt("virus_scan_error") . " "
-                . $this->lng->txt("virus_scan_message") . " "
-                . $this->scanResult,
-                $this->error->WARNING
-            );
         }
+
+        $this->error->raiseError(
+            $this->lng->txt("virus_scan_error") . " "
+            . $this->lng->txt("virus_scan_message") . " "
+            . $this->scanResult,
+            $this->error->WARNING
+        );
     }
 
     public function cleanFile(string $file_path, string $org_name = "") : string
@@ -109,12 +113,12 @@ class ilVirusScannerSophos extends ilVirusScanner
         // 32     If there has been an integrity check failure.
         // 36     If unsurvivable errors have occurred.
         // 40     If execution has been interrupted.
-        if ($ret == 20) {
+        if ((int) $ret === 20) {
             $this->cleanFileIsCleaned = true;
             return $this->cleanResult;
-        } else {
-            $this->cleanFileIsCleaned = false;
-            return "";
         }
+
+        $this->cleanFileIsCleaned = false;
+        return "";
     }
 }

--- a/Services/VirusScanner/classes/class.ilVirusScannerSophos.php
+++ b/Services/VirusScanner/classes/class.ilVirusScannerSophos.php
@@ -70,11 +70,11 @@ class ilVirusScannerSophos extends ilVirusScanner
             $this->logScanResult();
             return $this->scanResult;
         } else {
-            $this->ilias->raiseError(
+            $this->error->raiseError(
                 $this->lng->txt("virus_scan_error") . " "
                 . $this->lng->txt("virus_scan_message") . " "
                 . $this->scanResult,
-                $this->ilias->error_obj->WARNING
+                $this->error->WARNING
             );
         }
     }

--- a/Services/VirusScanner/classes/class.ilVirusScannerSophos.php
+++ b/Services/VirusScanner/classes/class.ilVirusScannerSophos.php
@@ -63,7 +63,7 @@ class ilVirusScannerSophos extends ilVirusScanner
         // 2  If some error preventing further execution is discovered.
         // 3  If viruses or virus fragments are discovered.
         if ($ret == 0) {
-            $this->scanFileIsCleaned = false;
+            $this->cleanFileIsCleaned = false;
             return "";
         } elseif ($ret == 3) {
             $this->scanFileIsInfected = true;


### PR DESCRIPTION
Hi @rschenk0 

Here are the results of the `Services/VirusScanner` review.

### Results

- [ ] The code style is PSR-2 + X compliant:_CS-Fixer changed two files_
- [x] No usage of $_GET / $_POST / $_REQUEST / $_SESSION: 
- [ ] There is a Unit Test Suite with at least one unit test:
- [ ] The unit tests pass
- [ ] External libraries are compatible with PHP 8 (if relevant): _Not relevant_
- [ ] The types are fully documented (PHPDoc) or explicit PHP types are used (type hints, return types, typed properties)

### Comments
- ilVirusScannerConfigStoredObjective line 52: It might be a good idea as $config is nullable to add a check for it and throw an explicit exception instead of potentially just letting it crash and burn.
- The component would be a good place to introduce declare strict_types. I see only two failing functions that are easily fixable: ilVirusScannerscanFileFromBuffer() and scanFileFromBuffer()

### Changes made in this PR:
- Fixed CS
- Scoped Constants
- Some additionnal fixes

Best regards,
@swiniker