### PR TITLE
Review `\Services\Logging`

### DIFF
--- a/Services/Logging/classes/Setup/class.ilLoggingConfigStoredObjective.php
+++ b/Services/Logging/classes/Setup/class.ilLoggingConfigStoredObjective.php
@@ -56,8 +56,7 @@ class ilLoggingConfigStoredObjective implements Objective
         $ini->setVariable(
             "log",
             "error_path",
-            $this->config->getErrorlogDir
-            () ?? ''
+            $this->config->getErrorlogDir() ?? ''
         );
 
         if (!$ini->write()) {

--- a/Services/Logging/classes/class.ilLog.php
+++ b/Services/Logging/classes/class.ilLog.php
@@ -83,6 +83,9 @@ class ilLog
         }
     }
 
+    /**
+     * @param int $a_log_level
+     */
     public function checkLogLevel($a_log_level) : int
     {
         if (empty($a_log_level)) {
@@ -187,6 +190,9 @@ class ilLog
     * specified in ilias.ini:
     * [log]
     * level = "<level>" possible values are fatal,warning,message
+    *
+    *
+    * @param ?int $a_log_level
     *
     */
     public function write(string $a_msg, $a_log_level = null) : void

--- a/Services/Logging/classes/class.ilLog.php
+++ b/Services/Logging/classes/class.ilLog.php
@@ -51,8 +51,7 @@ class ilLog
         string $a_tag = "",
         bool $a_enabled = true,
         ?int $a_log_level = null
-    )
-    {
+    ) {
         // init vars
 
         $this->FATAL = ilLogLevel::CRITICAL;

--- a/Services/Logging/classes/class.ilLogComponentLevels.php
+++ b/Services/Logging/classes/class.ilLogComponentLevels.php
@@ -39,6 +39,9 @@ class ilLogComponentLevels
         return self::$instance;
     }
     
+    /**
+     * @param string $a_component_id
+     */
     public static function updateFromXML($a_component_id) : bool
     {
         global $DIC;
@@ -70,7 +73,7 @@ class ilLogComponentLevels
         return $this->components;
     }
     
-    public function read()
+    public function read() : void
     {
         $query = 'SELECT * FROM log_components ';
         $res = $this->db->query($query);

--- a/Services/Logging/classes/class.ilLogComponentTableGUI.php
+++ b/Services/Logging/classes/class.ilLogComponentTableGUI.php
@@ -35,7 +35,7 @@ class ilLogComponentTableGUI extends ilTable2GUI
     /**
      * init table
      */
-    public function init()
+    public function init() : void
     {
         $this->setFormAction($this->ctrl->getFormAction($this->getParentObject()));
         $this->settings = ilLoggingDBSettings::getInstance();
@@ -76,7 +76,7 @@ class ilLogComponentTableGUI extends ilTable2GUI
                 $row['component'] = 'Root';
                 $row['component_sortable'] = '_' . $row['component'];
             } else {
-                $row['component'] = ilComponent::lookupComponentName($component->getComponentId());
+                $row['component'] = ilComponent::lookupComponentName($component->getComponentId()); //Todo PHP8 Review: ilComponent doesn't exist.
                 $row['component_sortable'] = $row['component'];
             }
             $row['level'] = (int) $component->getLevel();
@@ -103,7 +103,7 @@ class ilLogComponentTableGUI extends ilTable2GUI
 
         $levels = new ilSelectInputGUI('', 'level[' . $a_set['id'] . ']');
         $levels->setOptions($array_options);
-        $levels->setValue((int) $a_set['level']);
+        $levels->setValue($a_set['level']);
         $this->tpl->setVariable('C_SELECT_LEVEL', $levels->render());
     }
 }

--- a/Services/Logging/classes/class.ilLogger.php
+++ b/Services/Logging/classes/class.ilLogger.php
@@ -93,6 +93,8 @@ abstract class ilLogger
      * write log message
      * @deprecated since version 5.1
      * @see ilLogger->info(), ilLogger()->debug(), ...
+     *
+     * @param int $_level
      */
     public function write(string $a_message, $a_level = ilLogLevel::INFO) : void
     {

--- a/Services/Logging/classes/class.ilLoggingDBSettings.php
+++ b/Services/Logging/classes/class.ilLoggingDBSettings.php
@@ -164,7 +164,7 @@ class ilLoggingDBSettings implements ilLoggingSettings
     /**
      * Update setting
      */
-    public function update()
+    public function update() : void
     {
         $this->getStorage()->set('level', (string) $this->getLevel());
         $this->getStorage()->set('cache', (string) $this->isCacheEnabled());
@@ -180,7 +180,7 @@ class ilLoggingDBSettings implements ilLoggingSettings
      *
      * @access private
      */
-    private function read()
+    private function read() : void
     {
         $this->setLevel((int) $this->getStorage()->get('level', (string) $this->level));
         $this->enableCaching((bool) $this->getStorage()->get('cache', (string) $this->cache));

--- a/Services/Logging/classes/class.ilLoggingSetupSettings.php
+++ b/Services/Logging/classes/class.ilLoggingSetupSettings.php
@@ -13,7 +13,7 @@ class ilLoggingSetupSettings implements ilLoggingSettings
     private string $log_file = '';
     
     
-    public function init()
+    public function init() : void
     {
         $ilIliasIniFile = new ilIniFile("./ilias.ini.php");
         $ilIliasIniFile->read();

--- a/Services/Logging/classes/class.ilObjLoggingSettings.php
+++ b/Services/Logging/classes/class.ilObjLoggingSettings.php
@@ -8,7 +8,7 @@
 */
 class ilObjLoggingSettings extends ilObject
 {
-    public function __construct($a_id = 0, $a_call_by_reference = true)
+    public function __construct(int $a_id = 0, bool $a_call_by_reference = true)
     {
         $this->type = "logs";
         parent::__construct($a_id, $a_call_by_reference);

--- a/Services/Logging/classes/class.ilObjLoggingSettingsGUI.php
+++ b/Services/Logging/classes/class.ilObjLoggingSettingsGUI.php
@@ -26,8 +26,12 @@ class ilObjLoggingSettingsGUI extends ilObjectGUI
     protected Refinery $refinery;
     protected Services $http;
 
-
-    public function __construct($a_data, $a_id, $a_call_by_reference, $a_prepare_output = true)
+    /**
+     *
+     * @param mixed $a_data
+     * @param boolean $a_prepare_output
+     */
+    public function __construct($a_data, int $a_id, bool $a_call_by_reference, bool $a_prepare_output = true)
     {
         global $DIC;
         
@@ -91,7 +95,7 @@ class ilObjLoggingSettingsGUI extends ilObjectGUI
         }
     }
     
-    public function setSubTabs($a_section)
+    public function setSubTabs(string $a_section) : void
     {
         $this->tabs_gui->addSubTab(
             static::SUB_SECTION_MAIN,
@@ -232,7 +236,7 @@ class ilObjLoggingSettingsGUI extends ilObjectGUI
     /**
      * Save form
      */
-    protected function saveComponentLevels()
+    protected function saveComponentLevels() : void
     {
         $this->checkPermission('write');
 
@@ -253,7 +257,7 @@ class ilObjLoggingSettingsGUI extends ilObjectGUI
         $this->ctrl->redirect($this, 'components');
     }
     
-    protected function resetComponentLevels()
+    protected function resetComponentLevels() : void
     {
         $this->checkPermission('write');
         foreach (ilLogComponentLevels::getInstance()->getLogComponents() as $component) {

--- a/Services/Logging/classes/error/class.ilLoggerCronCleanErrorFiles.php
+++ b/Services/Logging/classes/error/class.ilLoggerCronCleanErrorFiles.php
@@ -89,7 +89,7 @@ class ilLoggerCronCleanErrorFiles extends ilCronJob
         return $result;
     }
 
-    protected function readLogDir($path) : array
+    protected function readLogDir(string $path) : array
     {
         $ret = array();
 
@@ -104,7 +104,7 @@ class ilLoggerCronCleanErrorFiles extends ilCronJob
         return $ret;
     }
 
-    protected function deleteFile($path) : void
+    protected function deleteFile(string $path) : void
     {
         unlink($path);
     }

--- a/Services/Logging/classes/error/class.ilLoggingErrorSettings.php
+++ b/Services/Logging/classes/error/class.ilLoggingErrorSettings.php
@@ -56,7 +56,7 @@ class ilLoggingErrorSettings
     /**
      * reads the values from ilias.ini.php
      */
-    protected function read()
+    protected function read() : void
     {
         if ($this->ilias_ini instanceof ilIniFile) {
             $this->setFolder((string) $this->ilias_ini->readVariable("log", "error_path"));
@@ -69,7 +69,7 @@ class ilLoggingErrorSettings
     /**
      * writes mail recipient into client.ini.php
      */
-    public function update()
+    public function update() : void
     {
         if ($this->gClientIniFile instanceof \ilIniFile) {
             $this->gClientIniFile->addGroup("log");

--- a/Services/Logging/classes/public/class.ilLoggerFactory.php
+++ b/Services/Logging/classes/public/class.ilLoggerFactory.php
@@ -30,7 +30,7 @@ class ilLoggerFactory
     private ilLoggingSettings $settings;
     protected Container $dic;
     
-    private bool $enabled;
+    private bool $enabled; //ToDo PHP8 Review: This is a private var never read only written and should probably be removed.
 
     /**
      * @var array<string, ilComponentLogger>


### PR DESCRIPTION
Hi @smeyer-ilias  

Here are the results of the `Services\Logging` review.

### Results

- [ ] The code style is PSR-2 + X compliant: _CS-Fixer changed two files_
- [ ] No usage of $_GET / $_POST / $_REQUEST / $_SESSION: _I can still find at least 9 uses of $POST, $_GET, $_SESSION, $_SERVER that seem to be unnecessary. Please at least explain, why you absolutly need them._
- [ ] There is a Unit Test Suite with at least one unit test:
- [ ] The unit tests pass
- [ ] External libraries are compatible with PHP 8 (if relevant): _They seem to be, but could you please update to the latest version: We are stuck on 2.3.5 current would be 2.5.0_
- [ ] The types are fully documented (PHPDoc) or explicit PHP types are used (type hints, return types, typed properties)

### Comments
- Array parameters could be specified more closely, defining what types are expected in arrays (just one example ilSystemStyleLessVariable::references.

### Changes made in this PR:
- Some additionnal fixes (mostly types)
- Added one  `//Todo PHP8 Review`

Best regards,
@swiniker