### PR TITLE
Review `Services/Table`

### DIFF
--- a/Services/Table/classes/class.TableGUIRequest.php
+++ b/Services/Table/classes/class.TableGUIRequest.php
@@ -35,16 +35,25 @@ class TableGUIRequest
         );
     }
 
+    /**
+     * @param string $prefix
+     */
     public function getExportMode($prefix) : bool
     {
         return (bool) $this->int($prefix . "_xpt");
     }
 
+    /**
+     * @param string $prefix
+     */
     public function getTemplate($prefix) : string
     {
         return $this->str($prefix . "_tpl");
     }
 
+    /**
+     * @param string $prefix
+     */
     public function getRows($prefix) : ?int
     {
         $rows = $this->str($prefix . "_trows");
@@ -59,6 +68,9 @@ class TableGUIRequest
         return $this->str("postvar");
     }
 
+    /**
+     * @param int $nr
+     */
     public function getNavPar(string $np, $nr = 0) : string
     {
         if ($nr > 0) {
@@ -67,21 +79,33 @@ class TableGUIRequest
         return $this->str($np);
     }
 
+    /**
+     * @param string $id
+     */
     public function getFF($id) : array
     {
         return $this->strArray("tblff" . $id);
     }
 
+    /**
+     * @param string $id
+     */
     public function getFS($id) : array
     {
         return $this->strArray("tblfs" . $id);
     }
 
+    /**
+     * @param string $id
+     */
     public function getFSH($id) : bool
     {
         return (bool) $this->int("tblfsh" . $id);
     }
 
+    /**
+     * @param string $id
+     */
     public function getFSF($id) : bool
     {
         return (bool) $this->int("tblfsf" . $id);

--- a/Services/Table/classes/class.ilTable2GUI.php
+++ b/Services/Table/classes/class.ilTable2GUI.php
@@ -115,7 +115,7 @@ class ilTable2GUI extends ilTableGUI
     protected \ilGlobalTemplateInterface $main_tpl;
 
     public function __construct(
-        ?object $a_parent_obj,
+        ?object $a_parent_obj, //ToDo PHP8 Review: I would suggest to be more specific on the object-Type expected here, or at least give a hint in a PHPdoc-Comment, what requirements need to be met by the object?
         string $a_parent_cmd = "",
         string $a_template_context = ""
     ) {
@@ -172,11 +172,6 @@ class ilTable2GUI extends ilTableGUI
         }
     }
 
-    /**
-     *
-     * @param
-     * @return
-     */
     protected function getRequestedValues() : void
     {
         if (is_null($this->table_request)) {
@@ -530,7 +525,7 @@ class ilTable2GUI extends ilTableGUI
             if (array_key_exists($a_input_item->getFieldId(), $this->restore_filter_values)) {
                 $this->setFilterValue($a_input_item, $this->restore_filter_values[$a_input_item->getFieldId()]);
             } else {
-                $this->setFilterValue($a_input_item, null); // #14949
+                $this->setFilterValue($a_input_item, null); // #14949 //Todo PHP8 Review: Second parameter can not be Null.
             }
         }
     }
@@ -2044,7 +2039,7 @@ class ilTable2GUI extends ilTableGUI
             $sep = "<span>&nbsp;&nbsp;&nbsp;&nbsp;</span>";
 
             // previous link
-            if ($LinkBar != "") {
+            if ($LinkBar != "") { //ToDo PHP8 Review: $LinkBar will always be '' and thus the condition will always be false.
                 $LinkBar .= $sep;
             }
             if ($this->custom_prev_next && $this->custom_prev != "") {
@@ -2065,7 +2060,7 @@ class ilTable2GUI extends ilTableGUI
             $sep = "<span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>";
 
             // show next link (if not last page)
-            if ($LinkBar != "") {
+            if ($LinkBar != "") { //ToDo PHP8 Review: $LinkBar will never be '' and thus the condition will always be true.
                 $LinkBar .= $sep;
             }
             if ($this->custom_prev_next && $this->custom_next != "") {
@@ -2081,7 +2076,7 @@ class ilTable2GUI extends ilTableGUI
             $sep = "<span>&nbsp;&nbsp;&nbsp;&nbsp;</span>";
 
             if (count($offset_arr) && !$this->getDisplayAsBlock() && !$this->custom_prev_next) {
-                if ($LinkBar != "") {
+                if ($LinkBar != "") { //ToDo PHP8 Review: $LinkBar will never be '' and thus the condition will always be true.
                     $LinkBar .= $sep;
                 }
                 $LinkBar .=

--- a/Services/Table/classes/class.ilTablePropertiesStorage.php
+++ b/Services/Table/classes/class.ilTablePropertiesStorage.php
@@ -163,6 +163,7 @@ class ilTablePropertiesStorage implements ilCtrlBaseClassInterface
 
     /**
      * Check if given property id is valid
+     * @var string|int $a_property
      */
     public function isValidProperty($a_property) : bool
     {

--- a/Services/Table/classes/trait.ilTableCommandHelper.php
+++ b/Services/Table/classes/trait.ilTableCommandHelper.php
@@ -47,7 +47,8 @@ trait ilTableCommandHelper
 
         if ($post_parameters->has('table_top_cmd')) {
             // this var contains the pressed table-top or -bottom command.
-            $multi_cmd = $post_parameters->retrieve('table_top_cmd',
+            $multi_cmd = $post_parameters->retrieve(
+                'table_top_cmd',
                 $refinery->custom()->transformation(
                     static function ($post_array) : ?string {
                         return is_array($post_array) ? key($post_array) : null;

--- a/Services/Table/test/TableGUIRequestTest.php
+++ b/Services/Table/test/TableGUIRequestTest.php
@@ -34,7 +34,7 @@ class TableGUIRequestTest extends TestCase
         );
     }
 
-    public function testTableId()
+    public function testTableId() : void
     {
         $request = $this->getRequest(
             [
@@ -49,7 +49,7 @@ class TableGUIRequestTest extends TestCase
         );
     }
 
-    public function testRows()
+    public function testRows() : void
     {
         $request = $this->getRequest(
             [

--- a/Services/Table/test/ilServicesTableSuite.php
+++ b/Services/Table/test/ilServicesTableSuite.php
@@ -22,7 +22,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilServicesTableSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : ilServicesTableSuite
     {
         $suite = new self();
 


### PR DESCRIPTION
Hi @alex40724 

Here are the results of the `Services/Table` review.

### Results

- [ ] The code style is PSR-2 + X compliant: _CS-Fixer made changes to 1 files_
- [x] No usage of $_GET / $_POST / $_REQUEST / $_SESSION
- [x] There is a Unit Test Suite with at least one unit test
- [x] The unit tests pass
- [ ] External libraries are compatible with PHP 8 (if relevant): _Not relevant_
- [ ] The types are fully documented (PHPDoc) or explicit PHP types are used (type hints, return types, typed properties)

### Comments
- Shouldn't setParentTable(), getFieldId(), and writeToSession() be on the ilTableFilterItem-Interface as you absolutely need them?

### Changes made in this PR:
- Fixed CS
- Added some types
- Added five //ToDo PHP8 Review: - Comments

Best regards,
@swiniker