### PR TITLE
VirusScanner: Add unit test suite

### DIFF
--- a/Services/VirusScanner/classes/class.ilVirusScanner.php
+++ b/Services/VirusScanner/classes/class.ilVirusScanner.php
@@ -49,7 +49,7 @@ class ilVirusScanner
         global $DIC;
         $ilias = $DIC['ilias'];
         $lng = $DIC->language();
-        $log = $DIC->logger();
+        $log = $DIC->logger()->root();
 
         $this->ilias = $ilias;
         $this->lng = $lng;

--- a/Services/VirusScanner/phpunit.xml
+++ b/Services/VirusScanner/phpunit.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" stopOnFailure="false" backupGlobals="false" bootstrap="./test/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">classes</directory>
+      <directory suffix=".php">interfaces</directory>
+      <directory suffix=".php">exceptions</directory>
+    </include>
+    <report>
+      <html outputDirectory="build/coverage" highLowerBound="80"/>
+    </report>
+  </coverage>
+  <testsuite name="ilServicesVirusScannerSuite">
+    <file>./test/ilServicesVirusScannerSuite.php</file>
+  </testsuite>
+  <logging>
+    <testdoxHtml outputFile="build/dox.html"/>
+  </logging>
+</phpunit>

--- a/Services/VirusScanner/test/VirusScannerBaseTest.php
+++ b/Services/VirusScanner/test/VirusScannerBaseTest.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\DI\Container;
+use PHPUnit\Framework\TestCase;
+
+abstract class VirusScannerBaseTest extends TestCase
+{
+    protected function setUp() : void
+    {
+        $GLOBALS['DIC'] = new Container();
+
+        parent::setUp();
+    }
+
+    protected function setGlobalVariable(string $name, $value) : void
+    {
+        global $DIC;
+
+        $GLOBALS[$name] = $value;
+
+        unset($DIC[$name]);
+        $DIC[$name] = static function (Container $c) use ($name) {
+            return $GLOBALS[$name];
+        };
+    }
+}

--- a/Services/VirusScanner/test/VirusScannerFactoryTest.php
+++ b/Services/VirusScanner/test/VirusScannerFactoryTest.php
@@ -16,12 +16,15 @@
  *
  *********************************************************************/
 
+require_once __DIR__ . '/bootstrap.php';
+
 /**
  * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
 class VirusScannerFactoryTest extends VirusScannerBaseTest
 {
-    public static ilLogger $fakeLogger;
+    public static ilLogger $logger;
 
     protected function setUp() : void
     {
@@ -36,8 +39,8 @@ class VirusScannerFactoryTest extends VirusScannerBaseTest
         }
 
         $logger = $this->getMockBuilder(ilLogger::class)->disableOriginalConstructor()->getMock();
-        self::$fakeLogger = $logger;
-        
+        self::$logger = $logger;
+
         $logger_factory = new class extends ilLoggerFactory {
             public function __construct()
             {
@@ -45,12 +48,12 @@ class VirusScannerFactoryTest extends VirusScannerBaseTest
 
             public static function getRootLogger() : ilLogger
             {
-                return VirusScannerFactoryTest::$fakeLogger;
+                return VirusScannerFactoryTest::$logger;
             }
 
             public function getComponentLogger(string $a_component_id) : ilLogger
             {
-                return VirusScannerFactoryTest::$fakeLogger;
+                return VirusScannerFactoryTest::$logger;
             }
         };
 
@@ -60,8 +63,6 @@ class VirusScannerFactoryTest extends VirusScannerBaseTest
             $this->getMockBuilder(ilLanguage::class)->disableOriginalConstructor()->getMock()
         );
 
-        
-        
         $this->setGlobalVariable('ilLoggerFactory', $logger_factory);
     }
 

--- a/Services/VirusScanner/test/VirusScannerFactoryTest.php
+++ b/Services/VirusScanner/test/VirusScannerFactoryTest.php
@@ -1,0 +1,96 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+/**
+ * @runTestsInSeparateProcesses
+ */
+class VirusScannerFactoryTest extends VirusScannerBaseTest
+{
+    public static ilLogger $fakeLogger;
+
+    protected function setUp() : void
+    {
+        parent::setUp();
+
+        if (!defined('IL_VIRUS_SCAN_COMMAND')) {
+            define("IL_VIRUS_SCAN_COMMAND", 'phpunitscan');
+        }
+
+        if (!defined('IL_VIRUS_CLEAN_COMMAND')) {
+            define("IL_VIRUS_CLEAN_COMMAND", 'phpunitclean');
+        }
+
+        $logger = $this->getMockBuilder(ilLogger::class)->disableOriginalConstructor()->getMock();
+        self::$fakeLogger = $logger;
+        
+        $logger_factory = new class extends ilLoggerFactory {
+            public function __construct()
+            {
+            }
+
+            public static function getRootLogger() : ilLogger
+            {
+                return VirusScannerFactoryTest::$fakeLogger;
+            }
+
+            public function getComponentLogger(string $a_component_id) : ilLogger
+            {
+                return VirusScannerFactoryTest::$fakeLogger;
+            }
+        };
+
+        $this->setGlobalVariable('ilias', $this->getMockBuilder(ILIAS::class)->disableOriginalConstructor()->getMock());
+        $this->setGlobalVariable(
+            'lng',
+            $this->getMockBuilder(ilLanguage::class)->disableOriginalConstructor()->getMock()
+        );
+
+        
+        
+        $this->setGlobalVariable('ilLoggerFactory', $logger_factory);
+    }
+
+    public function testSophosScanStrategyCanBeRetrievedAccordingToGlobalSetting() : void
+    {
+        define("IL_VIRUS_SCANNER", 'Sophos');
+
+        self::assertInstanceOf(ilVirusScannerSophos::class, ilVirusScannerFactory::_getInstance());
+    }
+
+    public function testAntiVirScanStrategyCanBeRetrievedAccordingToGlobalSetting() : void
+    {
+        define("IL_VIRUS_SCANNER", 'AntiVir');
+
+        self::assertInstanceOf(ilVirusScannerAntiVir::class, ilVirusScannerFactory::_getInstance());
+    }
+
+    public function testClamAvScanStrategyCanBeRetrievedAccordingToGlobalSetting() : void
+    {
+        define("IL_VIRUS_SCANNER", 'ClamAV');
+
+        self::assertInstanceOf(ilVirusScannerClamAV::class, ilVirusScannerFactory::_getInstance());
+    }
+
+    public function testIcapClientScanStrategyCanBeRetrievedAccordingToGlobalSetting() : void
+    {
+        define("IL_VIRUS_SCANNER", 'icap');
+        define("IL_ICAP_CLIENT", 'phpunit');
+
+        self::assertInstanceOf(ilVirusScannerICapClient::class, ilVirusScannerFactory::_getInstance());
+    }
+}

--- a/Services/VirusScanner/test/bootstrap.php
+++ b/Services/VirusScanner/test/bootstrap.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+require_once 'libs/composer/vendor/autoload.php';
+require_once __DIR__ . '/VirusScannerBaseTest.php';

--- a/Services/VirusScanner/test/ilServicesVirusScannerSuite.php
+++ b/Services/VirusScanner/test/ilServicesVirusScannerSuite.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use PHPUnit\Framework\TestSuite;
+
+require_once __DIR__ . '/bootstrap.php';
+
+class ilServicesVirusScannerSuite extends TestSuite
+{
+    public static function suite() : self
+    {
+        $suite = new self();
+
+        require_once __DIR__ . '/VirusScannerFactoryTest.php';
+        $suite->addTestSuite(VirusScannerFactoryTest::class);
+
+        return $suite;
+    }
+}


### PR DESCRIPTION
This PR adds a unit test suite for the `Services/VirusScanner` component. The tests must run in separate processes because the code under test heavily relies on global constants, which cannot be re-defined within a single process.