### PR TITLE
ILIAS8 Review Services/AuthApache

### DIFF
--- a/Services/AuthApache/classes/class.ilAuthProviderApache.php
+++ b/Services/AuthApache/classes/class.ilAuthProviderApache.php
@@ -61,6 +61,7 @@ class ilAuthProviderApache extends ilAuthProvider implements ilAuthProviderAccou
             'trim',
             str_getcsv($this->getSettings()->get('apache_auth_indicator_value', ''))
         ));
+        //TODO PHP8-REVIEW: $DIC->http()->request()->getServerParams()['apache_auth_indicator_name']
         if (!in_array($_SERVER[$this->getSettings()->get('apache_auth_indicator_name', '')], $validIndicatorValues, true)) {
             $this->getLogger()->warning('Apache authentication failed (indicator name <-> value');
             $this->handleAuthenticationFail($status, 'err_wrong_login');


### PR DESCRIPTION
Hi @pascalseeland ,

Christian completed the review of the `Services/AuthApache` component.

Results:

- [x] The code is `PSR-2 + X` compliant
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION` outside GUI-classes
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] There are no serious `PhpStorm Code Inspection` issues left
- [x] The types are fully documented (PhpDoc) or explicit PHP types are used (type hints, return types, typed properties)

![psCI](https://user-images.githubusercontent.com/4147731/162806523-fbcc7137-afc7-4194-bca7-320a0517f141.png)

