### PR TITLE
Fix MimeType recognition for Office 2003 and newer

### DIFF
--- a/src/ResourceStorage/Resource/InfoResolver/StreamInfoResolver.php
+++ b/src/ResourceStorage/Resource/InfoResolver/StreamInfoResolver.php
@@ -2,6 +2,7 @@
 
 namespace ILIAS\ResourceStorage\Resource\InfoResolver;
 
+use ILIAS\FileUpload\MimeType;
 use ILIAS\Filesystem\Stream\FileStream;
 use DateTimeImmutable;
 
@@ -63,6 +64,10 @@ class StreamInfoResolver extends AbstractInfoResolver implements InfoResolver
             $this->mime_type = finfo_buffer($finfo, $this->file_stream->read(100));
             if ($this->file_stream->isSeekable()) {
                 $this->file_stream->rewind();
+            }
+            //All MS-Types are 'application/zip' we need to look at the extension to determine the type.
+            if ($this->mime_type === 'application/zip' && $this->suffix !== 'zip') {
+                $this->mime_type = $this->getMSFileTypeFromSuffix();
             }
         }
     }
@@ -126,5 +131,15 @@ class StreamInfoResolver extends AbstractInfoResolver implements InfoResolver
     public function getSize() : int
     {
         return $this->size;
+    }
+    
+    protected function getMSFileTypeFromSuffix() : string
+    {
+        $mime_types_array = MimeType::getExt2MimeMap();
+        $suffix_with_dot = '.' . $this->getSuffix();
+        if (array_key_exists($suffix_with_dot, $mime_types_array)) {
+            return $mime_types_array[$suffix_with_dot];
+        }
+        return 'application/zip';
     }
 }


### PR DESCRIPTION
This fixes: https://mantis.ilias.de/view.php?id=32428

There would be an alternative solution if we move all mime-type detection ton a extension-based approach. Personally I prefer the mixed approach proposed here, but I could also provide a PR for the alternative approach.

If accepted this should be cherry-picked to ILIAS 7