### PR TITLE
ILIAS8 Review Services/LDAP

### DIFF
--- a/Services/LDAP/classes/class.ilLDAPAttributeToUser.php
+++ b/Services/LDAP/classes/class.ilLDAPAttributeToUser.php
@@ -122,7 +122,8 @@ class ilLDAPAttributeToUser
         $importParser->setRoleAssignment(ilLDAPRoleAssignmentRules::getAllPossibleRoles($this->getServer()->getServerId()));
         $importParser->setFolderId(7);
         $importParser->startParsing();
-        $importParser->getProtocol();
+        //TODO PHP8-REVIEW: Expression result unused
+        #$importParser->getProtocol();
         
         return true;
     }
@@ -343,7 +344,7 @@ class ilLDAPAttributeToUser
                             continue 2;
                         }
                         $this->initUserDefinedFields();
-                        $definition = $this->udf->getDefinition($id_data[1]);
+                        $definition = $this->udf->getDefinition((int) $id_data[1]);
                         $this->writer->xmlElement(
                             'UserDefinedField',
                             array('Id' => $definition['il_id'],

--- a/Services/LDAP/classes/class.ilLDAPPlugin.php
+++ b/Services/LDAP/classes/class.ilLDAPPlugin.php
@@ -20,12 +20,13 @@
 */
 abstract class ilLDAPPlugin extends ilPlugin
 {
+    //TODO PHP8-REVIEW: 'strcasecmp' expects params string $string1, string $string2
     /**
      * Check if user data matches a keyword value combination
      * @return
      * @param object $a_user_data
-     * @param object $a_keyword
-     * @param object $a_value
+     * @param string $a_keyword
+     * @param string $a_value
      */
     protected function checkValue($a_user_data, $a_keyword, $a_value)
     {

--- a/Services/LDAP/classes/class.ilLDAPQuery.php
+++ b/Services/LDAP/classes/class.ilLDAPQuery.php
@@ -57,6 +57,7 @@ class ilLDAPQuery
     public function __construct(ilLDAPServer $a_server, string $a_url = '')
     {
         global $DIC;
+        //TODO PHP8-REVIEW: WARNING Method 'auth' is undefined
         $this->logger = $DIC->logger()->auth();
 
         $this->settings = $a_server;
@@ -231,6 +232,7 @@ class ilLDAPQuery
         $estimated_results = 0;
         do {
             try {
+                //TODO PHP8-REVIEW:  'ldap_control_paged_result' was removed in 8.0 PHP version
                 $res = ldap_control_paged_result($this->lh, self::PAGINATION_SIZE, true, $cookie);
                 if ($res === false) {
                     throw new ilLDAPPagingException('Result pagination failed.');
@@ -249,6 +251,7 @@ class ilLDAPQuery
             $tmp_result->setResult($res);
             $tmp_result->run();
             try {
+                //TODO PHP8-REVIEW:  'ldap_control_paged_result_response' was removed in 8.0 PHP version
                 ldap_control_paged_result_response($this->lh, $res, $cookie, $estimated_results);
                 $this->logger->debug('Estimated number of results: ' . $estimated_results);
             } catch (Exception $e) {
@@ -258,6 +261,7 @@ class ilLDAPQuery
         } while ($cookie !== null && $cookie != '');
 
         // finally reset cookie
+        //TODO PHP8-REVIEW:  'ldap_control_paged_result' was removed in 8.0 PHP version
         ldap_control_paged_result($this->lh, 10000, false, $cookie);
         return $tmp_result;
     }
@@ -317,7 +321,7 @@ class ilLDAPQuery
         $group_names = $this->getServer()->getGroupNames();
         
         if (!count($group_names)) {
-            $this->logger()->debug('No LDAP group restrictions found');
+            $this->logger->debug('No LDAP group restrictions found');
             return true;
         }
         
@@ -520,7 +524,8 @@ class ilLDAPQuery
     {
         return $this->settings->getAuthenticationMappingKey();
     }
-    
+
+    //TODO PHP8-REVIEW: Variable '$res' is probably undefined
     /**
      * Query by scope
      * IL_SCOPE_SUB => ldap_search
@@ -664,7 +669,7 @@ class ilLDAPQuery
      * @param
      *
      */
-    private function fetchUserProfileFields() : array
+    private function fetchUserProfileFields() : void
     {
         $this->user_fields = array_merge(
             array($this->settings->getUserAttribute()),

--- a/Services/LDAP/classes/class.ilLDAPRoleAssignmentRule.php
+++ b/Services/LDAP/classes/class.ilLDAPRoleAssignmentRule.php
@@ -84,10 +84,11 @@ class ilLDAPRoleAssignmentRule
         $row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT);
         return $row->num > 0;
     }
-    
+
+    //TODO PHP8-REVIEW: type of '$a_user_data' should be an array like in $this->isGroupMember
     /**
      * Check if a rule matches
-     * @param object $a_user_data
+     * @param array $a_user_data
      */
     public function matches($a_user_data) : bool
     {
@@ -121,6 +122,7 @@ class ilLDAPRoleAssignmentRule
                 return $this->isGroupMember($a_user_data);
                 
         }
+        return false;
     }
     
     protected function wildcardCompare(string $a_str1, string $a_str2) : bool
@@ -381,6 +383,7 @@ class ilLDAPRoleAssignmentRule
             case self::TYPE_ATTRIBUTE:
                 return $this->getAttributeName() . '=' . $this->getAttributeValue();
         }
+        return '';
     }
     
     

--- a/Services/LDAP/classes/class.ilLDAPRoleAssignmentRules.php
+++ b/Services/LDAP/classes/class.ilLDAPRoleAssignmentRules.php
@@ -126,12 +126,12 @@ class ilLDAPRoleAssignmentRules
         return $roles;
     }
     
-    
+    //TODO PHP8-REVIEW: $a_usr_data should be an array, $a_usr_name's type is not defined
     /**
      *
      * @return array role data
      * @param object $a_usr_id
-     * @param object $a_usr_data
+     * @param array $a_usr_data
      */
     public static function getAssignmentsForCreation(int $a_server_id, $a_usr_name, $a_usr_data) : array
     {

--- a/Services/LDAP/classes/class.ilLDAPRoleAssignmentTableGUI.php
+++ b/Services/LDAP/classes/class.ilLDAPRoleAssignmentTableGUI.php
@@ -37,7 +37,7 @@ class ilLDAPRoleAssignmentTableGUI extends ilTable2GUI
         $this->ctrl = $ilCtrl;
         
         parent::__construct($a_parent_obj, $a_parent_cmd);
-        $this->addColumn('', '', 1);
+        $this->addColumn('', '');
         $this->addColumn($this->lng->txt('ldap_rule_type'), 'type', "20%");
         $this->addColumn($this->lng->txt('ldap_ilias_role'), 'role', "30%");
         $this->addColumn($this->lng->txt('ldap_rule_condition'), 'condition', "20%");
@@ -83,7 +83,8 @@ class ilLDAPRoleAssignmentTableGUI extends ilTable2GUI
         $this->ctrl->setParameter($this->getParentObject(), 'rule_id', $a_set['id']);
         $this->tpl->setVariable('EDIT_LINK', $this->ctrl->getLinkTarget($this->getParentObject(), 'editRoleAssignment'));
     }
-    
+
+    //TODO PHP8-REVIEW: Variable '$records_arr' is probably undefined
     /**
      * Parse
      *

--- a/Services/LDAP/classes/class.ilLDAPSettingsGUI.php
+++ b/Services/LDAP/classes/class.ilLDAPSettingsGUI.php
@@ -196,12 +196,15 @@ class ilLDAPSettingsGUI
     {
         if (!$this->ilAccess->checkAccess('write', '', $this->ref_id)) {
             $this->main_tpl->setOnScreenMessage('failure', $this->lng->txt('permission_denied'), true);
+            //TODO PHP8-REVIEW: Method 'roleAssignment' is undefined
             $this->roleAssignment();
             return false;
         }
 
         $this->initFormRoleAssignments('edit');
+
         if (!$this->form->checkInput() or ($err = $this->checkRoleAssignmentInput((int) $_REQUEST['rule_id']))) {
+            //TODO PHP8-REVIEW: Variable '$err' is probably undefined
             if ($err) {
                 $this->main_tpl->setOnScreenMessage('failure', $this->lng->txt($err));
             }
@@ -283,12 +286,14 @@ class ilLDAPSettingsGUI
     {
         if (!$this->ilAccess->checkAccess('write', '', $this->ref_id)) {
             $this->main_tpl->setOnScreenMessage('failure', $this->lng->txt('permission_denied'), true);
+            //TODO PHP8-REVIEW: Method 'roleAssignment' is undefined
             $this->roleAssignment();
             return false;
         }
 
         $this->initFormRoleAssignments('create');
         if (!$this->form->checkInput() or ($err = $this->checkRoleAssignmentInput())) {
+            //TODO PHP8-REVIEW: Variable '$err' is probably undefined
             if ($err) {
                 $this->main_tpl->setOnScreenMessage('failure', $this->lng->txt($err));
             }
@@ -376,6 +381,7 @@ class ilLDAPSettingsGUI
     {
         if (!$this->ilAccess->checkAccess('write', '', $this->ref_id)) {
             $this->main_tpl->setOnScreenMessage('failure', $this->lng->txt('permission_denied'), true);
+            //TODO PHP8-REVIEW: Method 'roleAssignment' is undefined
             $this->roleAssignment();
             return false;
         }
@@ -483,14 +489,14 @@ class ilLDAPSettingsGUI
         $this->rule = ilLDAPRoleAssignmentRule::_getInstanceByRuleId($a_rule_id);
         $this->rule->setServerId($this->getServer()->getServerId());
         $this->rule->enableAddOnUpdate((int) $_SESSION['ldap_role_ass']['add_on_update']);
-        $this->rule->enableRemoveOnUpdate((int) $_SESSION['ldap_role_ass']['remove_on_update']);
+        $this->rule->enableRemoveOnUpdate((bool) $_SESSION['ldap_role_ass']['remove_on_update']);
         $this->rule->setType(ilUtil::stripSlashes($_SESSION['ldap_role_ass']['type']));
         $this->rule->setDN(ilUtil::stripSlashes($_SESSION['ldap_role_ass']['dn']));
         $this->rule->setMemberAttribute(ilUtil::stripSlashes($_SESSION['ldap_role_ass']['at']));
-        $this->rule->setMemberIsDN(ilUtil::stripSlashes($_SESSION['ldap_role_ass']['isdn']));
+        $this->rule->setMemberIsDN((bool) ilUtil::stripSlashes($_SESSION['ldap_role_ass']['isdn']));
         $this->rule->setAttributeName(ilUtil::stripSlashes($_SESSION['ldap_role_ass']['name']));
         $this->rule->setAttributeValue(ilUtil::stripSlashes($_SESSION['ldap_role_ass']['value']));
-        $this->rule->setPluginId(ilUtil::stripSlashes($_SESSION['ldap_role_ass']['plugin']));
+        $this->rule->setPluginId((int) ilUtil::stripSlashes($_SESSION['ldap_role_ass']['plugin']));
         return true;
     }
     
@@ -523,7 +529,7 @@ class ilLDAPSettingsGUI
         $this->mapping->clearRules();
         
         foreach (ilLDAPAttributeMappingUtils::_getMappingRulesByClass($_POST['mapping_template']) as $key => $value) {
-            $this->mapping->setRule($key, $value, 0);
+            $this->mapping->setRule($key, $value, false);
         }
         $this->userMapping();
         return;
@@ -535,12 +541,12 @@ class ilLDAPSettingsGUI
         $this->tabs_gui->setTabActive('role_mapping');
         
         foreach ($this->getMappingFields() as $key) {
-            $this->mapping->setRule($key, ilUtil::stripSlashes($_POST[$key . '_value']), (int) $_POST[$key . '_update']);
+            $this->mapping->setRule($key, ilUtil::stripSlashes($_POST[$key . '_value']), (bool) $_POST[$key . '_update']);
         }
         $this->initUserDefinedFields();
         foreach ($this->udf->getDefinitions() as $definition) {
             $key = 'udf_' . $definition['field_id'];
-            $this->mapping->setRule($key, ilUtil::stripSlashes($_POST[$key . '_value']), (int) $_POST[$key . '_update']);
+            $this->mapping->setRule($key, ilUtil::stripSlashes($_POST[$key . '_value']), (bool) $_POST[$key . '_update']);
         }
         
         $this->mapping->save();
@@ -815,13 +821,13 @@ class ilLDAPSettingsGUI
     /*
      * Update Settings
      */
-    public function save() : bool
+    public function save() : void
     {
         $this->setSubTabs();
         $this->tabs_gui->setTabActive('settings');
         
         $this->initForm();
-        if ($this->form_gui->checkInput()) {
+        if ($check = $this->form_gui->checkInput()) {
             $this->server->toggleActive((bool) $this->form_gui->getInput('active'));
             $this->server->enableAuthentication(!(bool) $this->form_gui->getInput('ds'));
             $this->server->setName($this->form_gui->getInput('server_name'));
@@ -856,7 +862,7 @@ class ilLDAPSettingsGUI
                 $this->main_tpl->setOnScreenMessage('failure', $this->ilErr->getMessage());
                 $this->form_gui->setValuesByPost();
                 $this->tpl->setContent($this->form_gui->getHtml());
-                return false;
+                #return false;
             }
             
             // Update or create
@@ -873,11 +879,13 @@ class ilLDAPSettingsGUI
     
             $this->main_tpl->setOnScreenMessage('success', $this->lng->txt('settings_saved'), true);
             $this->ctrl->redirect($this, 'serverList');
-            return true;
+            #return true;
         }
-        
-        $this->form_gui->setValuesByPost();
-        return $this->tpl->setContent($this->form_gui->getHtml());
+
+        if ($check) {
+            $this->form_gui->setValuesByPost();
+            $this->tpl->setContent($this->form_gui->getHtml());
+        }
     }
     
     
@@ -1066,14 +1074,14 @@ class ilLDAPSettingsGUI
         $role = new ilRadioGroupInputGUI($this->lng->txt('ldap_ilias_role'), 'role_name');
         $role->setRequired(true);
         
-        $global = new ilRadioOption($this->lng->txt('ldap_global_role'), 0);
+        $global = new ilRadioOption($this->lng->txt('ldap_global_role'), '0');
         $role->addOption($global);
         
         $role_select = new ilSelectInputGUI('', 'role_id');
         $role_select->setOptions($this->prepareGlobalRoleSelection());
         $global->addSubItem($role_select);
         
-        $local = new ilRadioOption($this->lng->txt('ldap_local_role'), 1);
+        $local = new ilRadioOption($this->lng->txt('ldap_local_role'), '1');
         $role->addOption($local);
         
         $role_search = new ilRoleAutoCompleteInputGUI('', 'role_search', $this, 'addRoleAutoCompleteObject');
@@ -1105,7 +1113,7 @@ class ilLDAPSettingsGUI
         $group->setRequired(true);
         
         // Option by group
-        $radio_group = new ilRadioOption($this->lng->txt('ldap_role_by_group'), ilLDAPRoleAssignmentRule::TYPE_GROUP);
+        $radio_group = new ilRadioOption($this->lng->txt('ldap_role_by_group'), (string) ilLDAPRoleAssignmentRule::TYPE_GROUP);
         
         $dn = new ilTextInputGUI($this->lng->txt('ldap_group_dn'), 'dn');
         #$dn->setValue($current_rule->getDN());
@@ -1127,7 +1135,7 @@ class ilLDAPSettingsGUI
         $group->addOption($radio_group);
         
         // Option by Attribute
-        $radio_attribute = new ilRadioOption($this->lng->txt('ldap_role_by_attribute'), ilLDAPRoleAssignmentRule::TYPE_ATTRIBUTE);
+        $radio_attribute = new ilRadioOption($this->lng->txt('ldap_role_by_attribute'), (string) ilLDAPRoleAssignmentRule::TYPE_ATTRIBUTE);
         $name = new ilTextInputGUI($this->lng->txt('ldap_role_at_name'), 'name');
         #$name->setValue($current_rule->getAttributeName());
         $name->setSize(32);
@@ -1148,7 +1156,7 @@ class ilLDAPSettingsGUI
         
         // Option by Plugin
         $pl_active = $this->component_repository->getPluginSlotById("ldaphk")->hasActivePlugins();
-        $pl = new ilRadioOption($this->lng->txt('ldap_plugin'), 3);
+        $pl = new ilRadioOption($this->lng->txt('ldap_plugin'), '3');
         $pl->setInfo($this->lng->txt('ldap_plugin_info'));
         $pl->setDisabled(!$pl_active);
         
@@ -1266,14 +1274,14 @@ class ilLDAPSettingsGUI
         $user->setValue($this->server->getRoleBindDN());
         $user->setSize(50);
         $user->setMaxLength(255);
-        $binding->addCombinationItem(0, $user, $this->lng->txt('ldap_role_bind_user'));
+        $binding->addCombinationItem('0', $user, $this->lng->txt('ldap_role_bind_user'));
         $pass = new ilPasswordInputGUI("");
         $pass->setPostVar("role_bind_pass");
         $pass->setValue($this->server->getRoleBindPassword());
         $pass->setSize(12);
         $pass->setMaxLength(36);
         $pass->setRetype(false);
-        $binding->addCombinationItem(1, $pass, $this->lng->txt('ldap_role_bind_pass'));
+        $binding->addCombinationItem('1', $pass, $this->lng->txt('ldap_role_bind_pass'));
         $propertie_form->addItem($binding);
         
         $this->tpl->addBlockFile('ADM_CONTENT', 'adm_content', 'tpl.ldap_role_mappings.html', 'Services/LDAP');


### PR DESCRIPTION
Christian completed the review of the `Services/LDAP` component.

Results:

- [x] The code style is `PSR-2 + X` compliant
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION` outside GUI-classes
- [ ] There is a `Unit Test Suite` with at least one unit test
- [ ] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [ ] There are no serious `PhpStorm Code Inspection` issues left
- [x] The following files contain modifications and comments to suggested code changes:
  - class.ilLDAPAttributeToUser.php
  - class.ilLDAPPlugin.php
  - class.ilLDAPQuery.php
  - class.ilLDAPRoleAssignmentRule.php
  - class.ilLDAPRoleAssignmentRules.php
  - class.ilLDAPSettingsGUI.php

