### PR TITLE
ILIAS8 Review Services/CAS

### DIFF
--- a/Services/CAS/classes/class.ilCASAttributeToUser.php
+++ b/Services/CAS/classes/class.ilCASAttributeToUser.php
@@ -29,6 +29,7 @@ class ilCASAttributeToUser
     private ilCASSettings $settings;
 
 
+    //TODO PHP8-REVIEW: Method 'auth' is undefined.
     /**
      * Constructor
      *

--- a/Services/CAS/classes/class.ilCASSettings.php
+++ b/Services/CAS/classes/class.ilCASSettings.php
@@ -129,11 +129,13 @@ class ilCASSettings
         return $this->allow_local;
     }
 
-    public function setDefaultRole($a_role) : void
+    //TODO PHP8-REVIEW: Property declared dynamically
+    public function setDefaultRole(int $a_role) : void
     {
         $this->default_role = $a_role;
     }
 
+    //TODO PHP8-REVIEW: Property 'default_role' declared dynamically and probably undefined
     public function getDefaultRole() : int
     {
         return $this->default_role;

--- a/Services/CAS/classes/class.ilCASSettingsGUI.php
+++ b/Services/CAS/classes/class.ilCASSettingsGUI.php
@@ -195,7 +195,7 @@ class ilCASSettingsGUI
         }
 
         if (ilLDAPServer::isDataSourceActive(ilAuthUtils::AUTH_CAS)) {
-            $sync->setValue(ilCASSettings::SYNC_LDAP);
+            $sync->setValue((string) ilCASSettings::SYNC_LDAP);
         } else {
             $sync->setValue(
                 $this->getSettings()->isUserCreationEnabled() ?
@@ -266,7 +266,7 @@ class ilCASSettingsGUI
                         return;
                     }
 
-                    ilLDAPServer::toggleDataSource((int) $_REQUEST['ldap_sid'], ilAuthUtils::AUTH_CAS, true);
+                    ilLDAPServer::toggleDataSource((int) $_REQUEST['ldap_sid'], ilAuthUtils::AUTH_CAS, 1);
                     break;
             }
 


### PR DESCRIPTION
Christian completed the review of the `Services/CAS` component.

Results:

- [x] The code style is `PSR-2 + X` compliant
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION` outside GUI-classes
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [ ] There are no serious `PhpStorm Code Inspection` issues left
- [x] The types are fully documented (PhpDoc) or explicit PHP types are used (type hints, return types, typed properties)
- [x]  The following files contain modifications and comments to suggested code changes:

   - class.ilCASSettingsGUI.php
