### PR TITLE
ILIAS8 Review Services/Export

### DIFF
--- a/Services/Export/classes/class.ilExportFileInfo.php
+++ b/Services/Export/classes/class.ilExportFileInfo.php
@@ -58,8 +58,10 @@ class ilExportFileInfo
         global $DIC;
 
         $ilDB = $DIC->database();
-        $ilDB->manipulate("DELETE FROM export_file_info WHERE obj_id = " . $ilDB->quote($a_obj_id,
-                ilDBConstants::T_INTEGER));
+        $ilDB->manipulate("DELETE FROM export_file_info WHERE obj_id = " . $ilDB->quote(
+            $a_obj_id,
+            ilDBConstants::T_INTEGER
+        ));
         return true;
     }
 
@@ -133,8 +135,10 @@ class ilExportFileInfo
                 $this->db->quote($this->getExportType(), 'text') . ', ' .
                 $this->db->quote($this->getFilename(), 'text') . ', ' .
                 $this->db->quote($this->getVersion(), 'text') . ', ' .
-                $this->db->quote($this->getCreationDate()->get(IL_CAL_DATETIME, '', ilTimeZone::UTC),
-                    'timestamp') . ' ' .
+                $this->db->quote(
+                    $this->getCreationDate()->get(IL_CAL_DATETIME, '', ilTimeZone::UTC),
+                    'timestamp'
+                ) . ' ' .
                 ")";
             $this->db->manipulate($query);
         }

--- a/Services/Export/classes/class.ilExportSelectionTableGUI.php
+++ b/Services/Export/classes/class.ilExportSelectionTableGUI.php
@@ -18,6 +18,8 @@ class ilExportSelectionTableGUI extends ilTable2GUI
     {
         global $DIC;
 
+        //TODO PHP8-Review: please check the usage of $_POST
+        /** @var ILIAS\HTTP\Wrapper\SuperGlobalDropInReplacement $_POST */
         $this->post_data = $_POST;
 
         $this->tree = $DIC->repositoryTree();
@@ -92,14 +94,18 @@ class ilExportSelectionTableGUI extends ilTable2GUI
             $this->tpl->touchBlock('padding');
             $this->tpl->touchBlock('end_padding');
         }
-        $this->tpl->setVariable('TREE_IMG',
-            ilObject::_getIcon(ilObject::_lookupObjId((int) $a_set['ref_id']), "tiny", $a_set['type']));
+        $this->tpl->setVariable(
+            'TREE_IMG',
+            ilObject::_getIcon(ilObject::_lookupObjId((int) $a_set['ref_id']), "tiny", $a_set['type'])
+        );
         $this->tpl->setVariable('TREE_ALT_IMG', $this->lng->txt('obj_' . $a_set['type']));
         $this->tpl->setVariable('TREE_TITLE', $a_set['title']);
 
         if ($a_set['last_export']) {
-            $this->tpl->setVariable('VAL_LAST_EXPORT',
-                ilDatePresentation::formatDate(new ilDateTime($a_set['last_export'], IL_CAL_UNIX)));
+            $this->tpl->setVariable(
+                'VAL_LAST_EXPORT',
+                ilDatePresentation::formatDate(new ilDateTime($a_set['last_export'], IL_CAL_UNIX))
+            );
         } else {
             $this->tpl->setVariable('VAL_LAST_EXPORT', $this->lng->txt('no_file'));
         }
@@ -114,8 +120,10 @@ class ilExportSelectionTableGUI extends ilTable2GUI
             $this->tpl->setVariable('TXT_EXPORT_E', $this->lng->txt('export_existing'));
             $this->tpl->setVariable('NAME_EXPORT_E', 'cp_options[' . $a_set['ref_id'] . '][type]');
             $this->tpl->setVariable('VALUE_EXPORT_E', ilExportOptions::EXPORT_EXISTING);
-            $this->tpl->setVariable('ID_EXPORT_E',
-                $a_set['depth'] . '_' . $a_set['type'] . '_' . $a_set['ref_id'] . '_export_e');
+            $this->tpl->setVariable(
+                'ID_EXPORT_E',
+                $a_set['depth'] . '_' . $a_set['type'] . '_' . $a_set['ref_id'] . '_export_e'
+            );
             $this->tpl->setVariable('EXPORT_E_CHECKED', 'checked="checked"');
             $this->tpl->parseCurrentBlock();
         } elseif (!$a_set['perm_export']) {
@@ -130,8 +138,10 @@ class ilExportSelectionTableGUI extends ilTable2GUI
             $this->tpl->setVariable('TXT_EXPORT', $this->lng->txt('export'));
             $this->tpl->setVariable('NAME_EXPORT', 'cp_options[' . $a_set['ref_id'] . '][type]');
             $this->tpl->setVariable('VALUE_EXPORT', ilExportOptions::EXPORT_BUILD);
-            $this->tpl->setVariable('ID_EXPORT',
-                $a_set['depth'] . '_' . $a_set['type'] . '_' . $a_set['ref_id'] . '_export');
+            $this->tpl->setVariable(
+                'ID_EXPORT',
+                $a_set['depth'] . '_' . $a_set['type'] . '_' . $a_set['ref_id'] . '_export'
+            );
             if ($selected == "EXPORT") {
                 $this->tpl->setVariable('EXPORT_CHECKED', 'checked="checked"');
             }

--- a/Services/Export/classes/class.ilExportTableGUI.php
+++ b/Services/Export/classes/class.ilExportTableGUI.php
@@ -110,8 +110,10 @@ class ilExportTableGUI extends ilTable2GUI
         $this->tpl->setVariable('VAL_TYPE', $type);
         $this->tpl->setVariable('VAL_FILE', $a_set['file']);
         $this->tpl->setVariable('VAL_SIZE', ilUtil::formatSize($a_set['size']));
-        $this->tpl->setVariable('VAL_DATE',
-            ilDatePresentation::formatDate(new ilDateTime($a_set['timestamp'], IL_CAL_UNIX)));
+        $this->tpl->setVariable(
+            'VAL_DATE',
+            ilDatePresentation::formatDate(new ilDateTime($a_set['timestamp'], IL_CAL_UNIX))
+        );
 
         $this->tpl->setVariable('TXT_DOWNLOAD', $this->lng->txt('download'));
 

--- a/Services/Export/classes/class.ilImport.php
+++ b/Services/Export/classes/class.ilImport.php
@@ -190,7 +190,8 @@ class ilImport
         if ($parser->getMainEntity() != $a_type) {
             throw new ilImportObjectTypeMismatchException(
                 "Object type does not match. Import file has type '" .
-                $parser->getMainEntity() . "' but import being processed for '" . $a_type . "'.");
+                $parser->getMainEntity() . "' but import being processed for '" . $a_type . "'."
+            );
         }
 
         // process export files
@@ -236,8 +237,10 @@ class ilImport
         $obj_map = $this->getMapping()->getMappingsOfEntity('Services/Container', 'objs');
         if (is_array($obj_map)) {
             foreach ($obj_map as $obj_id_old => $obj_id_new) {
-                ilObject::_writeImportId($obj_id_new,
-                    "il_" . $this->mapping->getInstallId() . "_" . ilObject::_lookupType($obj_id_new) . "_" . $obj_id_old);
+                ilObject::_writeImportId(
+                    $obj_id_new,
+                    "il_" . $this->mapping->getInstallId() . "_" . ilObject::_lookupType($obj_id_new) . "_" . $obj_id_old
+                );
             }
         }
 


### PR DESCRIPTION
Christian completed the review of the `Services/Export` component.

Results:

- [x] The code style is `PSR-2 + X` compliant

- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION` outside GUI-classes

- [x] There is a `Unit Test Suite` with at least one unit test

- [x] The unit tests pass

- [x] External libraries are compatible with PHP 8 (if relevant)
- [ ] There are no serious `PhpStorm Code Inspection` issues left
- [x] The types are fully documented (PhpDoc) or explicit PHP types are used (type hints, return types, typed properties)

