### PR TITLE
ILIAS8 Review Services/OpenIdConnect

### DIFF
--- a/Services/OpenIdConnect/classes/class.ilAuthFrontendCredentialsOpenIdConnect.php
+++ b/Services/OpenIdConnect/classes/class.ilAuthFrontendCredentialsOpenIdConnect.php
@@ -54,6 +54,7 @@ class ilAuthFrontendCredentialsOpenIdConnect extends ilAuthFrontendCredentials i
 
     protected function parseRedirectionTarget() : void
     {
+        //TODO PHP8-REVIEW: $DIC->http()->wrapper()->query()->retrieve('target', $DIC->refinery()->kindlyTo()->string()
         if (!empty($_GET['target'])) {
             $this->target = $_GET['target'];
             \ilSession::set(self::SESSION_TARGET, $this->target);

--- a/Services/OpenIdConnect/classes/class.ilAuthProviderOpenIdConnect.php
+++ b/Services/OpenIdConnect/classes/class.ilAuthProviderOpenIdConnect.php
@@ -106,6 +106,7 @@ class ilAuthProviderOpenIdConnect extends ilAuthProvider implements ilAuthProvid
             $this->getLogger()->dump($claims, \ilLogLevel::DEBUG);
             $status = $this->handleUpdate($status, $claims);
 
+            //TODO PHP8-REVIEW: usage of $_GET
             // @todo : provide a general solution for all authentication methods
             $_GET['target'] = (string) $this->getCredentials()->getRedirectionTarget();
 
@@ -166,6 +167,7 @@ class ilAuthProviderOpenIdConnect extends ilAuthProvider implements ilAuthProvid
             $status->setAuthenticatedUserId($user_id);
             $status->setStatus(ilAuthStatus::STATUS_AUTHENTICATED);
 
+            //TODO PHP8-REVIEW: usage of $_GET
             // @todo : provide a general solution for all authentication methods
             $_GET['target'] = (string) $this->getCredentials()->getRedirectionTarget();
         } catch (ilOpenIdConnectSyncForbiddenException $e) {

--- a/Services/OpenIdConnect/classes/class.ilOpenIdConnectSettings.php
+++ b/Services/OpenIdConnect/classes/class.ilOpenIdConnectSettings.php
@@ -443,6 +443,7 @@ class ilOpenIdConnectSettings
             $curl->close();
         }
 
+        //TODO PHP8-REVIEW: Variable '$result' is probably undefined
         return $result;
     }
 
@@ -451,25 +452,25 @@ class ilOpenIdConnectSettings
      */
     public function save() : void
     {
-        $this->storage->set('active', (int) $this->getActive());
+        $this->storage->set('active', $this->getActive() ? '1' : '0');
         $this->storage->set('provider', $this->getProvider());
         $this->storage->set('client_id', $this->getClientId());
         $this->storage->set('secret', $this->getSecret());
         $this->storage->set('scopes', (string) serialize($this->getAdditionalScopes()));
         $this->storage->set('le_img', $this->getLoginElementImage());
         $this->storage->set('le_text', $this->getLoginElemenText());
-        $this->storage->set('le_type', $this->getLoginElementType());
-        $this->storage->set('prompt_type', $this->getLoginPromptType());
-        $this->storage->set('logout_scope', $this->getLogoutScope());
-        $this->storage->set('custom_session', (int) $this->isCustomSession());
-        $this->storage->set('session_duration', (int) $this->getSessionDuration());
-        $this->storage->set('allow_sync', (int) $this->isSyncAllowed());
-        $this->storage->set('role', (int) $this->getRole());
+        $this->storage->set('le_type', (string) $this->getLoginElementType());
+        $this->storage->set('prompt_type', (string) $this->getLoginPromptType());
+        $this->storage->set('logout_scope', (string) $this->getLogoutScope());
+        $this->storage->set('custom_session', (string) $this->isCustomSession());
+        $this->storage->set('session_duration', (string) $this->getSessionDuration());
+        $this->storage->set('allow_sync', (string) $this->isSyncAllowed());
+        $this->storage->set('role', (string) $this->getRole());
         $this->storage->set('uid', (string) $this->getUidField());
 
         foreach ($this->getProfileMappingFields() as $field => $lang_key) {
             $this->storage->set('pmap_' . $field, $this->getProfileMappingFieldValue($field));
-            $this->storage->set('pumap_' . $field, $this->getProfileMappingFieldUpdate($field));
+            $this->storage->set('pumap_' . $field, $this->getProfileMappingFieldUpdate($field) ? '1' : '0');
         }
         $this->storage->set('role_mappings', (string) serialize($this->getRoleMappings()));
     }

--- a/Services/OpenIdConnect/classes/class.ilOpenIdConnectSettingsGUI.php
+++ b/Services/OpenIdConnect/classes/class.ilOpenIdConnectSettingsGUI.php
@@ -360,6 +360,7 @@ class ilOpenIdConnectSettingsGUI
             }
         }
 
+        //TODO PHP8-REVIEW: Variable '$scopes' is probably undefined
         $invalid_scopes = $this->settings->validateScopes((string) $form->getInput('provider'), (array) $scopes);
         if (!empty($invalid_scopes)) {
             $this->mainTemplate->setOnScreenMessage('failure', sprintf($this->lng->txt('auth_oidc_settings_invalid_scopes'), implode(",", $invalid_scopes)));
@@ -512,6 +513,8 @@ class ilOpenIdConnectSettingsGUI
         $this->settings->save();
         $this->mainTemplate->setOnScreenMessage('success', $this->lng->txt('settings_saved'), true);
         $this->ctrl->redirect($this, self::STAB_PROFILE);
+
+        return true;
     }
 
     protected function roles(\ilPropertyFormGUI $form = null) : void

--- a/Services/OpenIdConnect/classes/class.ilOpenIdConnectUserSync.php
+++ b/Services/OpenIdConnect/classes/class.ilOpenIdConnectUserSync.php
@@ -265,6 +265,7 @@ class ilOpenIdConnectUserSync
         if (!$connect_name) {
             return '';
         }
+        //TODO PHP8-REVIEW: expected type object|string, array provided
         if (!property_exists($this->user_info, $connect_name)) {
             $this->logger->debug('Cannot find property ' . $connect_name . ' in user info ');
             return '';


### PR DESCRIPTION
Christian completed the review of the `Services/OpenIdConnect` component.

Results:

- [x] The code style is `PSR-2 + X` compliant
- [ ] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`. 

- [x] External libraries are compatible with PHP 8 (if relevant)

- [x] The types are fully documented (PhpDoc) or explicit PHP types are used (type hints, return types, typed properties)

- [ ] There is a `Unit Test Suite` with at least one unit test

- [ ] The unit tests pass
- [ ] There are no serious `PhpStorm Code Inspection` issues left

- [x] The following files contain modifications and comments to suggested code changes:
  - class.ilAuthFrontendCredentialsOpenIdConnect.php
  - class.ilAuthProviderOpenIdConnect.php
  - class.ilOpenIdConnectSettings.php
  - class.ilOpenIdConnectSettingsGUI.php
  - class.ilOpenIdConnectUserSync.php

