### PR TITLE
ILIAS8 Review Services/PDFGeneration

### DIFF
--- a/Services/PDFGeneration/classes/Setup/class.ilPDFGenerationSetupAgent.php
+++ b/Services/PDFGeneration/classes/Setup/class.ilPDFGenerationSetupAgent.php
@@ -42,11 +42,13 @@ class ilPDFGenerationSetupAgent implements Setup\Agent
         ));
     }
 
+    //TODO PHP8-REVIEW: Parameter '$config' type is not compatible with declaration. Expects ilPDFGenerationSetupConfig
     public function getInstallObjective(Setup\Config $config = null) : Setup\Objective
     {
         return new ilPDFGenerationConfigStoredObjective($config);
     }
 
+    //TODO PHP8-REVIEW: Parameter '$config' type is not compatible with declaration. Expects ilPDFGenerationSetupConfig
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
         if ($config !== null) {

--- a/Services/PDFGeneration/classes/class.ilObjPDFGeneration.php
+++ b/Services/PDFGeneration/classes/class.ilObjPDFGeneration.php
@@ -14,7 +14,6 @@
  *****************************************************************************/
 class ilObjPDFGeneration extends ilObject2
 {
-
     protected function initType() : void
     {
         $this->type = 'pdfg';

--- a/Services/PDFGeneration/classes/class.ilObjPDFGenerationGUI.php
+++ b/Services/PDFGeneration/classes/class.ilObjPDFGenerationGUI.php
@@ -222,15 +222,15 @@ class ilObjPDFGenerationGUI extends ilObject2GUI
         $renderer_obj->addConfigElementsToForm($form, $service, $purpose);
 
         $form->setValuesByPost();
+        //TODO PHP8-REVIEW: 'if' statement with common parts
         if ($renderer_obj->validateConfigInForm($form, $service, $purpose)) {
             $config = $renderer_obj->getConfigFromForm($form, $service, $purpose);
             ilPDFGeneratorUtils::saveRendererPurposeConfig($service, $purpose, $renderer, $config);
             $this->tpl->setOnScreenMessage('success', $this->lng->txt('config_saved'), true);
-            $this->ctrl->redirect($this, "view");
         } else {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('config_not_saved'), true); // TODO: Needs better handling.
-            $this->ctrl->redirect($this, "view");
         }
+        $this->ctrl->redirect($this, "view");
     }
 
     protected function doCleanUp() : void

--- a/Services/PDFGeneration/classes/class.ilPDFGeneratorUtils.php
+++ b/Services/PDFGeneration/classes/class.ilPDFGeneratorUtils.php
@@ -144,11 +144,11 @@ class ilPDFGeneratorUtils
         );
     }
 
-    public static function getRendererConfig(string $service, string $purpose, string $renderer): array
+    public static function getRendererConfig(string $service, string $purpose, string $renderer) : array
     {
         global $DIC;
         $ilDB = $DIC->database();
-
+        
         $query = 'SELECT config FROM pdfgen_conf WHERE renderer = ' . $ilDB->quote($renderer, 'text') .
             ' AND service = ' . $ilDB->quote($service, 'text') . ' AND purpose = ' . $ilDB->quote($purpose, 'text');
 
@@ -189,8 +189,10 @@ class ilPDFGeneratorUtils
     public static function getRendererInstance(string $renderer) : object
     {
         global $DIC;
-        /** @var ilDB $ilDB */
-        $ilDB = $DIC['ilDB'];
+        //TODO PHP8-REVIEW: Undefined class 'ilDB'. Use $DIC->database instead.
+        #/** @var ilDB $ilDB */
+        #$ilDB = $DIC['ilDB'];
+        $ilDB = $DIC->database();
 
         $result = $ilDB->query('SELECT path FROM pdfgen_renderer WHERE renderer = ' . $ilDB->quote($renderer, 'text'));
 
@@ -236,7 +238,8 @@ class ilPDFGeneratorUtils
         );
     }
 
-    public static function getRendererMapForPurpose(string $service, string $purpose)
+    //TODO PHP8-REVIEW: Missing function's return type declaration. Expects ?array
+    public static function getRendererMapForPurpose(string $service, string $purpose) : ?array
     {
         global $DIC;
         $ilDB = $DIC->database();

--- a/Services/PDFGeneration/classes/class.ilTCPDFGenerator.php
+++ b/Services/PDFGeneration/classes/class.ilTCPDFGenerator.php
@@ -14,6 +14,18 @@
  *****************************************************************************/
 class ilTCPDFGenerator
 {
+    //TODO PHP8-REVIEW: undefined methods called
+    //Method 'getCreator' is undefined
+    //Method 'getAuthor' is undefined
+    //Method 'getTitle' is undefined
+    //Method 'getSubject' is undefined
+    //Method 'getKeywords' is undefined
+    //Method 'getMarginLeft' is undefined
+    //Method 'getMarginTop' is undefined
+    //Method 'getMarginRight' is undefined
+    //Method 'getAutoPageBreak' is undefined
+    //Method 'getMarginBottom' is undefined
+    //Method 'getImageScale' is undefined
     public static function generatePDF(ilPDFGenerationJob $job) : void
     {
         $pdf = new TCPDF(PDF_PAGE_ORIENTATION, PDF_UNIT, PDF_PAGE_FORMAT, true, 'UTF-8', false);

--- a/Services/PDFGeneration/classes/factory/class.ilHtmlToPdfTransformerFactory.php
+++ b/Services/PDFGeneration/classes/factory/class.ilHtmlToPdfTransformerFactory.php
@@ -38,10 +38,11 @@ class ilHtmlToPdfTransformerFactory
         return $output;
     }
 
+    //TODO PHP8-REVIEW: missing return type
     /**
      * @throws Exception
      */
-    public function deliverPDFFromHTMLString(array $src, string $output, string $delivery_type, string $service, string $purpose)
+    public function deliverPDFFromHTMLString(array $src, string $output, string $delivery_type, string $service, string $purpose) : bool|string
     {
         $map = ilPDFGeneratorUtils::getRendererMapForPurpose($service, $purpose);
         $renderer = ilPDFGeneratorUtils::getRendererInstance($map['selected']);
@@ -61,7 +62,8 @@ class ilHtmlToPdfTransformerFactory
         return $this->deliverPDF($output, $delivery_type);
     }
 
-    protected function deliverPDF(string $file, string $delivery_type)
+    //TODO PHP8-REVIEW: missing return type
+    protected function deliverPDF(string $file, string $delivery_type) : bool|string
     {
         if (file_exists($file)) {
             if (strtoupper($delivery_type) === self::PDF_OUTPUT_DOWNLOAD) {
@@ -75,6 +77,8 @@ class ilHtmlToPdfTransformerFactory
         }
         return false;
     }
+
+
     protected function createOneFileFromArray(array $src) : string
     {
         $tmp_file = dirname(reset($src)) . '/complete_pages_overview.html';

--- a/Services/PDFGeneration/test/ilWkhtmlToPdfConfigTest.php
+++ b/Services/PDFGeneration/test/ilWkhtmlToPdfConfigTest.php
@@ -1,15 +1,15 @@
 <?php
 /* Copyright (c) 1998-2014 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once __DIR__ .'/../classes/renderer/wkhtmltopdf/class.ilWkhtmlToPdfConfig.php';
+require_once __DIR__ . '/../classes/renderer/wkhtmltopdf/class.ilWkhtmlToPdfConfig.php';
 use PHPUnit\Framework\TestCase;
+
 /**
  * Class ilWebkitHtmlToPdfTransformerTest
  * @package ilPdfGenerator
  */
-class ilWkhtmlToPdfConfigTest  extends TestCase
+class ilWkhtmlToPdfConfigTest extends TestCase
 {
-
     const COOKIE_STRING = '--cookie "PHPSESSID" "" --cookie "ilClientId" "1" ';
     /**
      * @var ilWkhtmlToPdfConfig
@@ -39,7 +39,6 @@ class ilWkhtmlToPdfConfigTest  extends TestCase
         $this->assertSame('2cm', $this->config->getMarginRight());
         $this->assertSame('0.5cm', $this->config->getMarginBottom());
         $this->assertSame('2cm', $this->config->getMarginTop());
-
     }
 
     public function testDefaultConfigCommandline()
@@ -77,7 +76,7 @@ class ilWkhtmlToPdfConfigTest  extends TestCase
     public function testGetCommandLineConfigWithGrayscale()
     {
         $this->config->setGreyscale(true);
-        $exp = $this->default_start . '--grayscale ' .  $this->default_end;
+        $exp = $this->default_start . '--grayscale ' . $this->default_end;
         $this->assertSame($exp, $this->config->getCommandLineConfig());
     }
 
@@ -109,7 +108,7 @@ class ilWkhtmlToPdfConfigTest  extends TestCase
         $this->config->setHeaderTextLeft('Left');
         $this->config->setHeaderTextCenter('Center');
         $this->config->setHeaderTextRight('Right');
-        $exp = $this->default_start .'--orientation Portrait --page-size A4 --javascript-delay 500 --margin-bottom 0.5cm --margin-left 0.5cm --margin-right 2cm --margin-top 2cm --header-html "<div><b>Test</b></div>" --header-spacing 1 --quiet ' . self::COOKIE_STRING;
+        $exp = $this->default_start . '--orientation Portrait --page-size A4 --javascript-delay 500 --margin-bottom 0.5cm --margin-left 0.5cm --margin-right 2cm --margin-top 2cm --header-html "<div><b>Test</b></div>" --header-spacing 1 --quiet ' . self::COOKIE_STRING;
         $this->assertSame($exp, $this->config->getCommandLineConfig());
     }
 
@@ -129,7 +128,7 @@ class ilWkhtmlToPdfConfigTest  extends TestCase
         $this->config->setFooterType(ilPDFGenerationConstants::FOOTER_HTML);
         $this->config->setFooterHtml('<div><b>Test</b></div>');
         $this->config->setFooterHtmlSpacing(2);
-        $exp = $this->default_start .'--orientation Portrait --page-size A4 --javascript-delay 500 --margin-bottom 0.5cm --margin-left 0.5cm --margin-right 2cm --margin-top 2cm --footer-html "<div><b>Test</b></div>" --footer-spacing 2 --quiet ' . self::COOKIE_STRING;
+        $exp = $this->default_start . '--orientation Portrait --page-size A4 --javascript-delay 500 --margin-bottom 0.5cm --margin-left 0.5cm --margin-right 2cm --margin-top 2cm --footer-html "<div><b>Test</b></div>" --footer-spacing 2 --quiet ' . self::COOKIE_STRING;
         $this->assertSame($exp, $this->config->getCommandLineConfig());
     }
 
@@ -146,21 +145,21 @@ class ilWkhtmlToPdfConfigTest  extends TestCase
     public function testGetCommandLineConfigWithEnabledForms()
     {
         $this->config->setEnabledForms(true);
-        $exp = ' --zoom 1 --enable-external-links --enable-forms --orientation Portrait --page-size A4 --javascript-delay 500 --margin-bottom 0.5cm --margin-left 0.5cm --margin-right 2cm --margin-top 2cm --quiet '. self::COOKIE_STRING;
+        $exp = ' --zoom 1 --enable-external-links --enable-forms --orientation Portrait --page-size A4 --javascript-delay 500 --margin-bottom 0.5cm --margin-left 0.5cm --margin-right 2cm --margin-top 2cm --quiet ' . self::COOKIE_STRING;
         $this->assertSame($exp, $this->config->getCommandLineConfig());
     }
 
     public function testGetCommandLineConfigWithEnabledExternalLinks()
     {
         $this->config->setExternalLinks(true);
-        $exp = ' --zoom 1 --enable-external-links --disable-forms --orientation Portrait --page-size A4 --javascript-delay 500 --margin-bottom 0.5cm --margin-left 0.5cm --margin-right 2cm --margin-top 2cm --quiet '. self::COOKIE_STRING;
+        $exp = ' --zoom 1 --enable-external-links --disable-forms --orientation Portrait --page-size A4 --javascript-delay 500 --margin-bottom 0.5cm --margin-left 0.5cm --margin-right 2cm --margin-top 2cm --quiet ' . self::COOKIE_STRING;
         $this->assertSame($exp, $this->config->getCommandLineConfig());
     }
 
     public function testGetCommandLineConfigWithEnabledLowQuality()
     {
         $this->config->setLowQuality(true);
-        $exp = ' --zoom 1 --enable-external-links --disable-forms --lowquality --orientation Portrait --page-size A4 --javascript-delay 500 --margin-bottom 0.5cm --margin-left 0.5cm --margin-right 2cm --margin-top 2cm --quiet '. self::COOKIE_STRING;
+        $exp = ' --zoom 1 --enable-external-links --disable-forms --lowquality --orientation Portrait --page-size A4 --javascript-delay 500 --margin-bottom 0.5cm --margin-left 0.5cm --margin-right 2cm --margin-top 2cm --quiet ' . self::COOKIE_STRING;
         $this->assertSame($exp, $this->config->getCommandLineConfig());
     }
 
@@ -169,56 +168,56 @@ class ilWkhtmlToPdfConfigTest  extends TestCase
     public function testGetCommandLineConfigWithEnabledPrintMediaType()
     {
         $this->config->setPrintMediaType(true);
-        $exp = ' --zoom 1 --enable-external-links --disable-forms --orientation Portrait --print-media-type --page-size A4 --javascript-delay 500 --margin-bottom 0.5cm --margin-left 0.5cm --margin-right 2cm --margin-top 2cm --quiet '. self::COOKIE_STRING;
+        $exp = ' --zoom 1 --enable-external-links --disable-forms --orientation Portrait --print-media-type --page-size A4 --javascript-delay 500 --margin-bottom 0.5cm --margin-left 0.5cm --margin-right 2cm --margin-top 2cm --quiet ' . self::COOKIE_STRING;
         $this->assertSame($exp, $this->config->getCommandLineConfig());
     }
 
     public function testGetCommandLineConfigWithEnabledCustomStyleSheet()
     {
         $this->config->setUserStylesheet('my_super_css_class.css');
-        $exp = ' --zoom 1 --enable-external-links --disable-forms --user-style-sheet "my_super_css_class.css" --orientation Portrait --page-size A4 --javascript-delay 500 --margin-bottom 0.5cm --margin-left 0.5cm --margin-right 2cm --margin-top 2cm --quiet '. self::COOKIE_STRING;
+        $exp = ' --zoom 1 --enable-external-links --disable-forms --user-style-sheet "my_super_css_class.css" --orientation Portrait --page-size A4 --javascript-delay 500 --margin-bottom 0.5cm --margin-left 0.5cm --margin-right 2cm --margin-top 2cm --quiet ' . self::COOKIE_STRING;
         $this->assertSame($exp, $this->config->getCommandLineConfig());
     }
 
     public function testGetCommandLineConfigWithCheckbox()
     {
         $this->config->setCheckboxSvg('checkbox.svg');
-        $exp = ' --zoom 1 --enable-external-links --disable-forms --orientation Portrait --page-size A4 --javascript-delay 500 --checkbox-svg "checkbox.svg" --margin-bottom 0.5cm --margin-left 0.5cm --margin-right 2cm --margin-top 2cm --quiet '. self::COOKIE_STRING;
+        $exp = ' --zoom 1 --enable-external-links --disable-forms --orientation Portrait --page-size A4 --javascript-delay 500 --checkbox-svg "checkbox.svg" --margin-bottom 0.5cm --margin-left 0.5cm --margin-right 2cm --margin-top 2cm --quiet ' . self::COOKIE_STRING;
         $this->assertSame($exp, $this->config->getCommandLineConfig());
     }
 
     public function testGetCommandLineConfigWithCheckedCheckbox()
     {
         $this->config->setCheckboxCheckedSvg('checkbox_checked.svg');
-        $exp = ' --zoom 1 --enable-external-links --disable-forms --orientation Portrait --page-size A4 --javascript-delay 500 --checkbox-checked-svg "checkbox_checked.svg" --margin-bottom 0.5cm --margin-left 0.5cm --margin-right 2cm --margin-top 2cm --quiet '. self::COOKIE_STRING;
+        $exp = ' --zoom 1 --enable-external-links --disable-forms --orientation Portrait --page-size A4 --javascript-delay 500 --checkbox-checked-svg "checkbox_checked.svg" --margin-bottom 0.5cm --margin-left 0.5cm --margin-right 2cm --margin-top 2cm --quiet ' . self::COOKIE_STRING;
         $this->assertSame($exp, $this->config->getCommandLineConfig());
     }
 
     public function testGetCommandLineConfigWithRadiobutton()
     {
         $this->config->setRadioButtonSvg('radiobutton.svg');
-        $exp = ' --zoom 1 --enable-external-links --disable-forms --orientation Portrait --page-size A4 --javascript-delay 500 --radiobutton-svg "radiobutton.svg" --margin-bottom 0.5cm --margin-left 0.5cm --margin-right 2cm --margin-top 2cm --quiet '. self::COOKIE_STRING;
+        $exp = ' --zoom 1 --enable-external-links --disable-forms --orientation Portrait --page-size A4 --javascript-delay 500 --radiobutton-svg "radiobutton.svg" --margin-bottom 0.5cm --margin-left 0.5cm --margin-right 2cm --margin-top 2cm --quiet ' . self::COOKIE_STRING;
         $this->assertSame($exp, $this->config->getCommandLineConfig());
     }
 
     public function testGetCommandLineConfigWithCheckedRadiobutton()
     {
         $this->config->setRadioButtonCheckedSvg('radiobutton_checked.svg');
-        $exp = ' --zoom 1 --enable-external-links --disable-forms --orientation Portrait --page-size A4 --javascript-delay 500 --radiobutton-checked-svg "radiobutton_checked.svg" --margin-bottom 0.5cm --margin-left 0.5cm --margin-right 2cm --margin-top 2cm --quiet '. self::COOKIE_STRING;
+        $exp = ' --zoom 1 --enable-external-links --disable-forms --orientation Portrait --page-size A4 --javascript-delay 500 --radiobutton-checked-svg "radiobutton_checked.svg" --margin-bottom 0.5cm --margin-left 0.5cm --margin-right 2cm --margin-top 2cm --quiet ' . self::COOKIE_STRING;
         $this->assertSame($exp, $this->config->getCommandLineConfig());
     }
 
     public function testGetCommandLineConfigWithDisabledExternalLinks()
     {
         $this->config->setExternalLinks(false);
-        $exp = ' --zoom 1 --disable-external-links --disable-forms --orientation Portrait --page-size A4 --javascript-delay 500 --margin-bottom 0.5cm --margin-left 0.5cm --margin-right 2cm --margin-top 2cm --quiet '. self::COOKIE_STRING;
+        $exp = ' --zoom 1 --disable-external-links --disable-forms --orientation Portrait --page-size A4 --javascript-delay 500 --margin-bottom 0.5cm --margin-left 0.5cm --margin-right 2cm --margin-top 2cm --quiet ' . self::COOKIE_STRING;
         $this->assertSame($exp, $this->config->getCommandLineConfig());
     }
 
     public function testGetCommandLineConfigWithLandscape()
     {
         $this->config->setOrientation('Landscape');
-        $exp = ' --zoom 1 --enable-external-links --disable-forms --orientation Landscape --page-size A4 --javascript-delay 500 --margin-bottom 0.5cm --margin-left 0.5cm --margin-right 2cm --margin-top 2cm --quiet '. self::COOKIE_STRING;
+        $exp = ' --zoom 1 --enable-external-links --disable-forms --orientation Landscape --page-size A4 --javascript-delay 500 --margin-bottom 0.5cm --margin-left 0.5cm --margin-right 2cm --margin-top 2cm --quiet ' . self::COOKIE_STRING;
         $this->assertSame($exp, $this->config->getCommandLineConfig());
     }
 


### PR DESCRIPTION
Christian completed the review of the `Services/PdfGeneration` component.

Results:

- [x] The code style is `PSR-2 + X` compliant
- [ ] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`. Found some usages, see 'Actions needed'
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [ ] There are no serious `PhpStorm Code I nspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

--

Actions needed:

-  Please check my inline comments. Some of them might be just information, some require an action. You can use `TODO PHP8-REVIEW` when searching.

- Please check/eliminate the usage of super globals. 
  You can use the following regex to find their occurrences: `^(?!\s*\/\/|\s*\/\*|\s+\*).*\$_(SESSION|GET|POST|REQUEST).*$`
  To replace usage of $_POST to get e. g. a string value you can use: `$DIC->http()->wrapper()->post()->retrieve('thePostKey', $DIC->refinery()->kindlyTo()->string())`
