### PR TITLE
ILIAS8 Review Services/SOAPAuth

### DIFF
--- a/Services/SOAPAuth/classes/class.ilAuthProviderSoap.php
+++ b/Services/SOAPAuth/classes/class.ilAuthProviderSoap.php
@@ -57,10 +57,10 @@ class ilAuthProviderSoap extends ilAuthProvider implements ilAuthProviderInterfa
         $this->server_port = (string) $this->settings->get('soap_auth_port', '');
         $this->server_uri = (string) $this->settings->get('soap_auth_uri', '');
         $this->server_nms = (string) $this->settings->get('soap_auth_namespace', '');
-        $this->server_https = (bool) $this->settings->get('soap_auth_use_https', false);
-        $this->use_dot_net = (bool) $this->settings->get('use_dotnet', false);
+        $this->server_https = $this->settings->get('soap_auth_use_https', '');
+        $this->use_dot_net = (bool) $this->settings->get('use_dotnet', '');
 
-        $this->uri = $this->server_https ? 'https://' : 'http://';
+        $this->uri = (bool) $this->server_https ? 'https://' : 'http://';
         $this->uri .= $this->server_host;
 
         if ($this->server_port > 0) {
@@ -123,7 +123,7 @@ class ilAuthProviderSoap extends ilAuthProvider implements ilAuthProviderInterfa
 
         $soapAction = '';
         $nspref = '';
-        if ($this->use_dot_net) {
+        if ((bool) $this->use_dot_net) {
             $soapAction = $this->server_nms . '/isValidSession';
             $nspref = 'ns1:';
         }
@@ -186,22 +186,22 @@ class ilAuthProviderSoap extends ilAuthProvider implements ilAuthProviderInterfa
         $userObj->setLanguage($this->language->getDefaultLanguage());
 
         $userObj->setTimeLimitOwner(USER_FOLDER_ID);
-        $userObj->setTimeLimitUnlimited(1);
+        $userObj->setTimeLimitUnlimited(true);
         $userObj->setTimeLimitFrom(time());
         $userObj->setTimeLimitUntil(time());
         $userObj->setOwner(0);
         $userObj->create();
-        $userObj->setActive(1);
+        $userObj->setActive(true);
         $userObj->updateOwner();
         $userObj->saveAsNew(false);
         $userObj->writePrefs();
 
         $this->rbacAdmin->assignUser(
-            $this->settings->get('soap_auth_user_default_role', 4),
+            (int) $this->settings->get('soap_auth_user_default_role', '4'),
             $userObj->getId()
         );
 
-        if ($this->settings->get('soap_auth_account_mail', false)) {
+        if ((bool) $this->settings->get('soap_auth_account_mail', '')) {
             $registrationSettings = new ilRegistrationSettings();
             $registrationSettings->setPasswordGenerationStatus(true);
 

--- a/Services/SOAPAuth/dummy_client.php
+++ b/Services/SOAPAuth/dummy_client.php
@@ -42,6 +42,7 @@ echo '<form>' .
 
 echo "<br /><br />----------------------------------------------<br /><br /> Calling Server...";
 
+//TODO PHP8-REVIEW: Undefined class 'soap_client'
 // initialize soap client
 $client = new soap_client($server);
 if ($err = $client->getError()) {


### PR DESCRIPTION
Christian completed the review of the `Services/SoapAuth` component.

Results:

- [x] The code style is `PSR-2 + X` compliant
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION` outside GUI-classes
- [ ] There is a `Unit Test Suite` with at least one unit test - no test found
- [ ] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [ ] There are no serious `PhpStorm Code Inspection` issues left
- [x] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)
- [x] The following files contain modifications and comments to suggested code changes:
  - class.ilAuthProviderSoap.php
  - class.ilSOAPAuth.php
