### PR TITLE
PHP 8: Code Review `QTI`

### DIFF
--- a/Modules/LearningModule/classes/class.ilLearningModuleImporter.php
+++ b/Modules/LearningModule/classes/class.ilLearningModuleImporter.php
@@ -92,7 +92,7 @@ class ilLearningModuleImporter extends ilXmlImporter
         if (is_file($qti_file)) {
             $qtiParser = new ilQTIParser(
                 $qti_file,
-                IL_MO_VERIFY_QTI,
+                ilQTIParser::IL_MO_VERIFY_QTI,
                 0,
                 ""
             );
@@ -100,7 +100,7 @@ class ilLearningModuleImporter extends ilXmlImporter
             $founditems = &$qtiParser->getFoundItems();
             $testObj = new ilObjTest(0, true);
             if (count($founditems) > 0) {
-                $qtiParser = new ilQTIParser($qti_file, IL_MO_PARSE_QTI, 0, "");
+                $qtiParser = new ilQTIParser($qti_file, ilQTIParser::IL_MO_PARSE_QTI, 0, "");
                 $qtiParser->setTestObject($testObj);
                 $result = $qtiParser->startParsing();
                 $this->qtis = array_merge($this->qtis, $qtiParser->getImportMapping());

--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -1157,7 +1157,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
 
         // start verification of QTI files
         include_once "./Services/QTI/classes/class.ilQTIParser.php";
-        $qtiParser = new ilQTIParser($qti_file, IL_MO_VERIFY_QTI, 0, "");
+        $qtiParser = new ilQTIParser($qti_file, ilQTIParser::IL_MO_VERIFY_QTI, 0, "");
         $qtiParser->startParsing();
         $founditems = $qtiParser->getFoundItems();
         
@@ -1218,63 +1218,63 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
 
             switch ($item["type"]) {
                 case MULTIPLE_CHOICE_QUESTION_IDENTIFIER:
-                case QT_MULTIPLE_CHOICE_MR:
+                case ilQTIItem::QT_MULTIPLE_CHOICE_MR:
                     $importVerificationTpl->setVariable("QUESTION_TYPE", $this->lng->txt("assMultipleChoice"));
                     break;
                 case SINGLE_CHOICE_QUESTION_IDENTIFIER:
-                case QT_MULTIPLE_CHOICE_SR:
+                case ilQTIItem::QT_MULTIPLE_CHOICE_SR:
                     $importVerificationTpl->setVariable("QUESTION_TYPE", $this->lng->txt("assSingleChoice"));
                     break;
                 case KPRIM_CHOICE_QUESTION_IDENTIFIER:
-                case QT_KPRIM_CHOICE:
+                case ilQTIItem::QT_KPRIM_CHOICE:
                     $importVerificationTpl->setVariable("QUESTION_TYPE", $this->lng->txt("assKprimChoice"));
                     break;
                 case LONG_MENU_QUESTION_IDENTIFIER:
-                case QT_LONG_MENU:
+                case ilQTIItem::QT_LONG_MENU:
                     $importVerificationTpl->setVariable("QUESTION_TYPE", $this->lng->txt("assLongMenu"));
                     break;
                 case NUMERIC_QUESTION_IDENTIFIER:
-                case QT_NUMERIC:
+                case ilQTIItem::QT_NUMERIC:
                     $importVerificationTpl->setVariable("QUESTION_TYPE", $this->lng->txt("assNumeric"));
                     break;
                 case FORMULA_QUESTION_IDENTIFIER:
-                case QT_FORMULA:
+                case ilQTIItem::QT_FORMULA:
                     $importVerificationTpl->setVariable("QUESTION_TYPE", $this->lng->txt("assFormulaQuestion"));
                     break;
                 case TEXTSUBSET_QUESTION_IDENTIFIER:
-                case QT_TEXTSUBSET:
+                case ilQTIItem::QT_TEXTSUBSET:
                     $importVerificationTpl->setVariable("QUESTION_TYPE", $this->lng->txt("assTextSubset"));
                     break;
                 case CLOZE_TEST_IDENTIFIER:
-                case QT_CLOZE:
+                case ilQTIItem::QT_CLOZE:
                     $importVerificationTpl->setVariable("QUESTION_TYPE", $this->lng->txt("assClozeTest"));
                     break;
                 case ERROR_TEXT_IDENTIFIER:
-                case QT_ERRORTEXT:
+                case ilQTIItem::QT_ERRORTEXT:
                     $importVerificationTpl->setVariable("QUESTION_TYPE", $this->lng->txt("assErrorText"));
                     break;
                 case IMAGEMAP_QUESTION_IDENTIFIER:
-                case QT_IMAGEMAP:
+                case ilQTIItem::QT_IMAGEMAP:
                     $importVerificationTpl->setVariable("QUESTION_TYPE", $this->lng->txt("assImagemapQuestion"));
                     break;
                 case MATCHING_QUESTION_IDENTIFIER:
-                case QT_MATCHING:
+                case ilQTIItem::QT_MATCHING:
                     $importVerificationTpl->setVariable("QUESTION_TYPE", $this->lng->txt("assMatchingQuestion"));
                     break;
                 case ORDERING_QUESTION_IDENTIFIER:
-                case QT_ORDERING:
+                case ilQTIItem::QT_ORDERING:
                     $importVerificationTpl->setVariable("QUESTION_TYPE", $this->lng->txt("assOrderingQuestion"));
                     break;
                 case ORDERING_HORIZONTAL_IDENTIFIER:
-                case QT_ORDERING_HORIZONTAL:
+                case ilQTIItem::QT_ORDERING_HORIZONTAL:
                     $importVerificationTpl->setVariable("QUESTION_TYPE", $this->lng->txt("assOrderingHorizontal"));
                     break;
                 case TEXT_QUESTION_IDENTIFIER:
-                case QT_TEXT:
+                case ilQTIItem::QT_TEXT:
                     $importVerificationTpl->setVariable("QUESTION_TYPE", $this->lng->txt("assTextQuestion"));
                     break;
                 case FILE_UPLOAD_IDENTIFIER:
-                case QT_FILEUPLOAD:
+                case ilQTIItem::QT_FILEUPLOAD:
                     $importVerificationTpl->setVariable("QUESTION_TYPE", $this->lng->txt("assFileUpload"));
                     break;
             }
@@ -1335,7 +1335,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
             $map->addMapping('Modules/Test', 'tst', 'new_id', $newObj->getId());
             $imp->importObject($newObj, $fullPath, $fileName, 'tst', 'Modules/Test', true);
         } else {
-            $qtiParser = new ilQTIParser(ilSession::get("tst_import_qti_file"), IL_MO_PARSE_QTI, $questionParentObjId, $_POST["ident"]);
+            $qtiParser = new ilQTIParser(ilSession::get("tst_import_qti_file"), ilQTIParser::IL_MO_PARSE_QTI, $questionParentObjId, $_POST["ident"]);
             if (!isset($_POST["ident"]) || !is_array($_POST["ident"]) || !count($_POST["ident"])) {
                 $qtiParser->setIgnoreItemsEnabled(true);
             }

--- a/Modules/Test/classes/class.ilTestImporter.php
+++ b/Modules/Test/classes/class.ilTestImporter.php
@@ -69,7 +69,7 @@ class ilTestImporter extends ilXmlImporter
 
         // start parsing of QTI files
         include_once "./Services/QTI/classes/class.ilQTIParser.php";
-        $qtiParser = new ilQTIParser($qti_file, IL_MO_PARSE_QTI, $questionParentObjId, $idents);
+        $qtiParser = new ilQTIParser($qti_file, ilQTIParser::IL_MO_PARSE_QTI, $questionParentObjId, $idents);
         $qtiParser->setTestObject($newObj);
         $qtiParser->startParsing();
 

--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -524,7 +524,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
 
         // start verification of QTI files
         include_once "./Services/QTI/classes/class.ilQTIParser.php";
-        $qtiParser = new ilQTIParser($qti_file, IL_MO_VERIFY_QTI, 0, "");
+        $qtiParser = new ilQTIParser($qti_file, ilQTIParser::IL_MO_VERIFY_QTI, 0, "");
         $qtiParser->startParsing();
         $founditems = &$qtiParser->getFoundItems();
         if (count($founditems) == 0) {
@@ -714,7 +714,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         } else {
             // start parsing of QTI files
             include_once "./Services/QTI/classes/class.ilQTIParser.php";
-            $qtiParser = new ilQTIParser(ilSession::get("qpl_import_qti_file"), IL_MO_PARSE_QTI, $newObj->getId(), $_POST["ident"]);
+            $qtiParser = new ilQTIParser(ilSession::get("qpl_import_qti_file"), ilQTIParser::IL_MO_PARSE_QTI, $newObj->getId(), $_POST["ident"]);
             $qtiParser->startParsing();
 
             // import page data

--- a/Modules/TestQuestionPool/classes/class.ilTestQuestionPoolImporter.php
+++ b/Modules/TestQuestionPool/classes/class.ilTestQuestionPoolImporter.php
@@ -89,7 +89,7 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
         
         // start parsing of QTI files
         include_once "./Services/QTI/classes/class.ilQTIParser.php";
-        $qtiParser = new ilQTIParser($qti_file, IL_MO_PARSE_QTI, $newObj->getId(), $idents);
+        $qtiParser = new ilQTIParser($qti_file, ilQTIParser::IL_MO_PARSE_QTI, $newObj->getId(), $idents);
         $qtiParser->startParsing();
 
         // import page data

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assClozeTestImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assClozeTestImport.php
@@ -78,8 +78,8 @@ class assClozeTestImport extends assQuestionImport
                     switch (strtolower(get_class($response->getRenderType()))) {
                         case "ilqtirenderfib":
                             switch ($response->getRenderType()->getFibtype()) {
-                                case FIBTYPE_DECIMAL:
-                                case FIBTYPE_INTEGER:
+                                case ilQTIRenderFib::FIBTYPE_DECIMAL:
+                                case ilQTIRenderFib::FIBTYPE_INTEGER:
                                     array_push(
                                         $gaps,
                                         array(
@@ -93,7 +93,7 @@ class assClozeTestImport extends assQuestionImport
                                     );
                                     break;
                                 default:
-                                case FIBTYPE_STRING:
+                                case ilQTIRenderFib::FIBTYPE_STRING:
                                     array_push(
                                         $gaps,
                                         array("ident" => $response->getIdent(),

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assTextSubsetImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assTextSubsetImport.php
@@ -46,7 +46,7 @@ class assTextSubsetImport extends assQuestionImport
             switch ($entry["type"]) {
                 case "response":
                     $response = $presentation->response[$entry["index"]];
-                    if ($response->getResponseType() == RT_RESPONSE_STR) {
+                    if ($response->getResponseType() == ilQTIResponse::RT_RESPONSE_STR) {
                         array_push($idents, $response->getIdent());
                     }
                     break;
@@ -75,7 +75,7 @@ class assTextSubsetImport extends assQuestionImport
                     }
                 }
                 foreach ($respcondition->setvar as $setvar) {
-                    if ((strcmp($setvar->getVarname(), "matches") == 0) && ($setvar->getAction() == ACTION_ADD)) {
+                    if ((strcmp($setvar->getVarname(), "matches") == 0) && ($setvar->getAction() == ilQTISetvar::ACTION_ADD)) {
                         foreach ($responses[$respident] as $idx => $solutionarray) {
                             if (strlen($solutionarray["points"] == 0)) {
                                 $responses[$respident][$idx]["points"] = $setvar->getContent();

--- a/Services/QTI/classes/class.ilQTIAssessment.php
+++ b/Services/QTI/classes/class.ilQTIAssessment.php
@@ -1,27 +1,21 @@
-<?php
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+<?php declare(strict_types=1);
 
-require_once 'Services/QTI/interfaces/interface.ilQTIPresentationMaterialAware.php';
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
 * QTI assessment class
@@ -33,31 +27,19 @@ require_once 'Services/QTI/interfaces/interface.ilQTIPresentationMaterialAware.p
 */
 class ilQTIAssessment implements ilQTIPresentationMaterialAware
 {
-    public ?string $ident;
-    public ?string $title;
-    public ?string $xmllang;
-    public ?string $comment;
+    public ?string $ident = null;
+    public ?string $title = null;
+    public ?string $xmllang = null;
+    public ?string $comment = null;
     /** @var null|array{h: string, m: string, s: string} */
-    public ?array $duration;
+    public ?array $duration = null;
     /** @var array{label: string, entry: string}[] */
-    public array $qtimetadata;
+    public array $qtimetadata = [];
     /** @var ilQTIObjectives[] */
-    public array $objectives;
+    public array $objectives = [];
     /** @var ilQTIAssessmentcontrol[] */
-    public array $assessmentcontrol;
-    protected ilQTIPresentationMaterial $presentation_material;
-
-    public function __construct()
-    {
-        $this->ident = null;
-        $this->title = null;
-        $this->xmllang = null;
-        $this->comment = null;
-        $this->duration = null;
-        $this->qtimetadata = [];
-        $this->objectives = [];
-        $this->assessmentcontrol = [];
-    }
+    public array $assessmentcontrol = [];
+    protected ?ilQTIPresentationMaterial $presentation_material = null;
 
     public function setIdent(string $a_ident) : void
     {
@@ -89,7 +71,7 @@ class ilQTIAssessment implements ilQTIPresentationMaterialAware
         return $this->comment;
     }
 
-    public function setDuration(string $a_duration) : void
+    public function setDuration(string $a_duration) : void // TODO PHP8-REVIEW Check if this function is really used
     {
         if (preg_match("/P(\d+)Y(\d+)M(\d+)DT(\d+)H(\d+)M(\d+)S/", $a_duration, $matches)) {
             $this->duration = array(
@@ -126,19 +108,19 @@ class ilQTIAssessment implements ilQTIPresentationMaterialAware
         $this->qtimetadata[] = $a_metadata;
     }
 
-    public function addObjectives(?ilQTIObjectives $a_objectives) : void
+    public function addObjectives(?ilQTIObjectives $a_objectives) : void // TODO PHP8-REVIEW Should null really be allowed here as possible/useful value?
     {
         $this->objectives[] = $a_objectives;
     }
 
-    public function addAssessmentcontrol(ilQTIAssessmentcontrol $a_assessmentcontrol) : void
+    public function addAssessmentcontrol(?ilQTIAssessmentcontrol $a_assessmentcontrol) : void // TODO PHP8-REVIEW Should null really be allowed here as possible/useful value?
     {
         $this->assessmentcontrol[] = $a_assessmentcontrol;
     }
 
-    public function setPresentationMaterial(ilQTIPresentationMaterial $a_material) : void
+    public function setPresentationMaterial(ilQTIPresentationMaterial $presentation_material) : void
     {
-        $this->presentation_material = $a_material;
+        $this->presentation_material = $presentation_material;
     }
 
     public function getPresentationMaterial() : ?ilQTIPresentationMaterial

--- a/Services/QTI/classes/class.ilQTIAssessmentcontrol.php
+++ b/Services/QTI/classes/class.ilQTIAssessmentcontrol.php
@@ -1,25 +1,21 @@
-<?php
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
 * QTI assessmentcontrol class
@@ -31,18 +27,10 @@
 */
 class ilQTIAssessmentcontrol
 {
-    public string $hintswitch;
-    public string $solutionswitch;
-    public string $view;
-    public string $feedbackswitch;
-    
-    public function __construct()
-    {
-        $this->hintswitch = "";
-        $this->solutionswitch = "";
-        $this->view = "All";
-        $this->feedbackswitch = "";
-    }
+    public string $hintswitch = "";
+    public string $solutionswitch = "";
+    public string $view = "All";
+    public string $feedbackswitch = "";
 
     public function setView(string $a_view) : void
     {

--- a/Services/QTI/classes/class.ilQTIConditionvar.php
+++ b/Services/QTI/classes/class.ilQTIConditionvar.php
@@ -1,25 +1,21 @@
-<?php
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
 * QTI conditionvar class
@@ -32,45 +28,29 @@
 class ilQTIConditionvar
 {
     /** @var int[] */
-    public array $arr_not;
+    public array $arr_not = [];
     /** @var int[] */
-    public array $arr_and;
+    public array $arr_and = [];
     /** @var int[] */
-    public array $arr_or;
+    public array $arr_or = [];
     /** @var ilQTIResponseVar[] */
-    public array $varequal;
+    public array $varequal = [];
     /** @var ilQTIResponseVar[] */
-    public array $varlt;
+    public array $varlt = [];
     /** @var ilQTIResponseVar[] */
-    public array $varlte;
+    public array $varlte = [];
     /** @var ilQTIResponseVar[] */
-    public array $vargt;
+    public array $vargt = [];
     /** @var ilQTIResponseVar[] */
-    public array $vargte;
+    public array $vargte = [];
     /** @var ilQTIResponseVar[] */
-    public array $varsubset;
+    public array $varsubset = [];
     /** @var ilQTIResponseVar[] */
-    public array $varinside;
+    public array $varinside = [];
     /** @var ilQTIResponseVar[] */
-    public array $varsubstring;
+    public array $varsubstring = [];
     /** @var array{field: string, index: int} */
-    public array $order;
-    
-    public function __construct()
-    {
-        $this->arr_not = [];
-        $this->arr_and = [];
-        $this->arr_or = [];
-        $this->varequal = [];
-        $this->varlt = [];
-        $this->varlte = [];
-        $this->vargt = [];
-        $this->vargte = [];
-        $this->varsubset = [];
-        $this->varinside = [];
-        $this->varsubstring = [];
-        $this->order = [];
-    }
+    public array $order = [];
     
     public function addNot() : void
     {
@@ -141,28 +121,28 @@ class ilQTIConditionvar
     public function addResponseVar(ilQTIResponseVar $a_responsevar) : void
     {
         switch ($a_responsevar->getVartype()) {
-            case RESPONSEVAR_EQUAL:
+            case ilQTIResponseVar::RESPONSEVAR_EQUAL:
                 $this->addVarequal($a_responsevar);
                 break;
-            case RESPONSEVAR_LT:
+            case ilQTIResponseVar::RESPONSEVAR_LT:
                 $this->addVarlt($a_responsevar);
                 break;
-            case RESPONSEVAR_LTE:
+            case ilQTIResponseVar::RESPONSEVAR_LTE:
                 $this->addVarlte($a_responsevar);
                 break;
-            case RESPONSEVAR_GT:
+            case ilQTIResponseVar::RESPONSEVAR_GT:
                 $this->addVargt($a_responsevar);
                 break;
-            case RESPONSEVAR_GTE:
+            case ilQTIResponseVar::RESPONSEVAR_GTE:
                 $this->addVargte($a_responsevar);
                 break;
-            case RESPONSEVAR_SUBSET:
+            case ilQTIResponseVar::RESPONSEVAR_SUBSET:
                 $this->addVarsubset($a_responsevar);
                 break;
-            case RESPONSEVAR_INSIDE:
+            case ilQTIResponseVar::RESPONSEVAR_INSIDE:
                 $this->addVarinside($a_responsevar);
                 break;
-            case RESPONSEVAR_SUBSTRING:
+            case ilQTIResponseVar::RESPONSEVAR_SUBSTRING:
                 $this->addVarsubstring($a_responsevar);
                 break;
         }

--- a/Services/QTI/classes/class.ilQTIDecvar.php
+++ b/Services/QTI/classes/class.ilQTIDecvar.php
@@ -1,33 +1,21 @@
-<?php
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+<?php declare(strict_types=1);
 
-const VARTYPE_INTEGER = "1";
-const VARTYPE_STRING = "2";
-const VARTYPE_DECIMAL = "3";
-const VARTYPE_SCIENTIFIC = "4";
-const VARTYPE_BOOLEAN = "5";
-const VARTYPE_ENUMERATED = "6";
-const VARTYPE_SET = "7";
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
 * QTI decvar class
@@ -39,26 +27,22 @@ const VARTYPE_SET = "7";
 */
 class ilQTIDecvar
 {
-    public ?string $varname;
-    public ?string $vartype;
-    public ?string $defaultval;
-    public ?string $minvalue;
-    public ?string $maxvalue;
-    public ?string $members;
-    public ?string $cutvalue;
-    public ?string $content;
+    public const VARTYPE_INTEGER = "1";
+    public const VARTYPE_STRING = "2";
+    public const VARTYPE_DECIMAL = "3";
+    public const VARTYPE_SCIENTIFIC = "4";
+    public const VARTYPE_BOOLEAN = "5";
+    public const VARTYPE_ENUMERATED = "6";
+    public const VARTYPE_SET = "7";
 
-    public function __construct()
-    {
-        $this->varname = null;
-        $this->vartype = null;
-        $this->defaultval = null;
-        $this->minvalue = null;
-        $this->maxvalue = null;
-        $this->members = null;
-        $this->cutvalue = null;
-        $this->content = null;
-    }
+    public ?string $varname = null;
+    public ?string $vartype = null;
+    public ?string $defaultval = null;
+    public ?string $minvalue = null;
+    public ?string $maxvalue = null;
+    public ?string $members = null;
+    public ?string $cutvalue = null;
+    public ?string $content = null;
 
     public function setVarname(string $a_varname) : void
     {
@@ -75,31 +59,31 @@ class ilQTIDecvar
         switch (strtolower($a_vartype)) {
             case "integer":
             case "1":
-                $this->vartype = VARTYPE_INTEGER;
+                $this->vartype = self::VARTYPE_INTEGER;
                 break;
             case "string":
             case "2":
-                $this->vartype = VARTYPE_STRING;
+                $this->vartype = self::VARTYPE_STRING;
                 break;
             case "decimal":
             case "3":
-                $this->vartype = VARTYPE_DECIMAL;
+                $this->vartype = self::VARTYPE_DECIMAL;
                 break;
             case "scientific":
             case "4":
-                $this->vartype = VARTYPE_SCIENTIFIC;
+                $this->vartype = self::VARTYPE_SCIENTIFIC;
                 break;
             case "boolean":
             case "5":
-                $this->vartype = VARTYPE_BOOLEAN;
+                $this->vartype = self::VARTYPE_BOOLEAN;
                 break;
             case "enumerated":
             case "6":
-                $this->vartype = VARTYPE_ENUMERATED;
+                $this->vartype = self::VARTYPE_ENUMERATED;
                 break;
             case "set":
             case "7":
-                $this->vartype = VARTYPE_SET;
+                $this->vartype = self::VARTYPE_SET;
                 break;
         }
     }

--- a/Services/QTI/classes/class.ilQTIDisplayfeedback.php
+++ b/Services/QTI/classes/class.ilQTIDisplayfeedback.php
@@ -1,25 +1,21 @@
-<?php
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
 * QTI displayfeedback class
@@ -31,16 +27,9 @@
 */
 class ilQTIDisplayfeedback
 {
-    public ?string $feedbacktype;
-    public ?string $linkrefid;
-    public ?string $content;
-    
-    public function __construct()
-    {
-        $this->feedbacktype = null;
-        $this->linkrefid = null;
-        $this->content = null;
-    }
+    public ?string $feedbacktype = null;
+    public ?string $linkrefid = null;
+    public ?string $content = null;
 
     public function setFeedbacktype(string $a_feedbacktype) : void
     {

--- a/Services/QTI/classes/class.ilQTIFlowMat.php
+++ b/Services/QTI/classes/class.ilQTIFlowMat.php
@@ -1,27 +1,21 @@
-<?php
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+<?php declare(strict_types=1);
 
-require_once 'Services/QTI/interfaces/interface.ilQTIMaterialAware.php';
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
 * QTI flow_mat class
@@ -33,18 +27,11 @@ require_once 'Services/QTI/interfaces/interface.ilQTIMaterialAware.php';
 */
 class ilQTIFlowMat implements ilQTIMaterialAware
 {
-    public ?string $comment;
+    public ?string $comment = null;
     /** @var ilQTIFlowMat[] */
-    public array $flow_mat;
+    public array $flow_mat = [];
     /** @var ilQTIMaterial[] */
-    public array $material;
-    
-    public function __construct()
-    {
-        $this->comment = null;
-        $this->flow_mat = [];
-        $this->material = [];
-    }
+    public array $material = [];
 
     public function setComment(string $a_comment) : void
     {
@@ -56,14 +43,14 @@ class ilQTIFlowMat implements ilQTIMaterialAware
         return $this->comment;
     }
 
-    public function addFlow_mat(ilQTIFlowMat $a_flow_mat) : void
+    public function addFlowMat(ilQTIFlowMat $a_flow_mat) : void
     {
         $this->flow_mat[] = $a_flow_mat;
     }
 
-    public function addMaterial(ilQTIMaterial $a_material) : void
+    public function addMaterial(ilQTIMaterial $material) : void
     {
-        $this->material[] = $a_material;
+        $this->material[] = $material;
     }
 
     public function getMaterial(int $index) : ?ilQTIMaterial

--- a/Services/QTI/classes/class.ilQTIItem.php
+++ b/Services/QTI/classes/class.ilQTIItem.php
@@ -1,42 +1,21 @@
-<?php
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+<?php declare(strict_types=1);
 
-const QT_UNKNOWN = "unknown";
-const QT_KPRIM_CHOICE = "assKprimChoice";
-const QT_LONG_MENU = "assLongMenu";
-const QT_MULTIPLE_CHOICE_SR = "assSingleChoice";
-const QT_MULTIPLE_CHOICE_MR = "assMultipleChoice";
-const QT_CLOZE = "assClozeTest";
-const QT_ERRORTEXT = "assErrorText";
-const QT_MATCHING = "assMatchingQuestion";
-const QT_ORDERING = "assOrderingQuestion";
-const QT_ORDERING_HORIZONTAL = "assOrderingHorizontal";
-const QT_IMAGEMAP = "assImagemapQuestion";
-const QT_TEXT = "assTextQuestion";
-const QT_FILEUPLOAD = "assFileUpload";
-const QT_NUMERIC = "assNumeric";
-const QT_FORMULA = "assFormulaQuestion";
-const QT_TEXTSUBSET = "assTextSubset";
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
  * QTI item class
@@ -48,60 +27,53 @@ const QT_TEXTSUBSET = "assTextSubset";
  */
 class ilQTIItem
 {
-    public ?string $ident;
-    public ?string $title;
-    public ?string $maxattempts;
-    public ?string $label;
-    public ?string $xmllang;
-    public ?string $comment;
-    public ?string $ilias_version;
-    public ?string $author;
-    public ?string $questiontype;
+    public const QT_UNKNOWN = "unknown";
+    public const QT_KPRIM_CHOICE = "assKprimChoice";
+    public const QT_LONG_MENU = "assLongMenu";
+    public const QT_MULTIPLE_CHOICE_SR = "assSingleChoice";
+    public const QT_MULTIPLE_CHOICE_MR = "assMultipleChoice";
+    public const QT_CLOZE = "assClozeTest";
+    public const QT_ERRORTEXT = "assErrorText";
+    public const QT_MATCHING = "assMatchingQuestion";
+    public const QT_ORDERING = "assOrderingQuestion";
+    public const QT_ORDERING_HORIZONTAL = "assOrderingHorizontal";
+    public const QT_IMAGEMAP = "assImagemapQuestion";
+    public const QT_TEXT = "assTextQuestion";
+    public const QT_FILEUPLOAD = "assFileUpload";
+    public const QT_NUMERIC = "assNumeric";
+    public const QT_FORMULA = "assFormulaQuestion";
+    public const QT_TEXTSUBSET = "assTextSubset";
+
+    public ?string $ident = null;
+    public ?string $title = null;
+    public ?string $maxattempts = null;
+    public ?string $label = null;
+    public ?string $xmllang = null;
+    public ?string $comment = null;
+    public ?string $ilias_version = null;
+    public ?string $author = null;
+    public ?string $questiontype = null;
     /** @var null|array{h: string, m: string, s: string} */
-    public ?array $duration;
-    public ?ilQTIMaterial $questiontext;
+    public ?array $duration = null;
+    public ?ilQTIMaterial $questiontext = null;
     /** @var ilQTIResprocessing[] */
-    public array $resprocessing;
+    public array $resprocessing = [];
     /** @var ilQTIItemfeedback[] */
-    public array $itemfeedback;
-    public ?ilQTIPresentation $presentation;
+    public array $itemfeedback = [];
+    public ?ilQTIPresentation $presentation = null;
     /** @var (ilQTIResponse|ilQTIMaterial|null)[] */
-    public array $presentationitem;
+    public array $presentationitem = [];
     /**
      * @var array{solution: ilQTIMattext, gap_index: int}[]
      */
-    public array $suggested_solutions;
+    public array $suggested_solutions = [];
     /**
      * @var array{label: string, entry: string}[]
      */
-    public array $itemmetadata;
-    protected ?string $iliasSourceVersion;
-    protected ?string $iliasSourceNic;
-    protected array $response;
-
-    public function __construct()
-    {
-        $this->ident = null;
-        $this->title = null;
-        $this->maxattempts = null;
-        $this->label = null;
-        $this->xmllang = null;
-        $this->comment = null;
-        $this->ilias_version = null;
-        $this->author = null;
-        $this->questiontype = null;
-        $this->duration = null;
-        $this->questiontext = null;
-        $this->response = [];
-        $this->resprocessing = [];
-        $this->itemfeedback = [];
-        $this->presentation = null;
-        $this->presentationitem = [];
-        $this->suggested_solutions = [];
-        $this->itemmetadata = [];
-        $this->iliasSourceVersion = null;
-        $this->iliasSourceNic = null;
-    }
+    public array $itemmetadata = [];
+    protected ?string $iliasSourceVersion = null;
+    protected ?string $iliasSourceNic = null;
+    protected array $response = [];
 
     public function setIdent(string $a_ident) : void
     {
@@ -176,12 +148,12 @@ class ilQTIItem
         return $this->questiontext;
     }
     
-    public function addResprocessing(?ilQTIResprocessing $a_resprocessing) : void
+    public function addResprocessing(?ilQTIResprocessing $a_resprocessing) : void // TODO PHP8-REVIEW Should null really be allowed here as possible/useful value?
     {
         $this->resprocessing[] = $a_resprocessing;
     }
     
-    public function addItemfeedback(?ilQTIItemfeedback $a_itemfeedback) : void
+    public function addItemfeedback(?ilQTIItemfeedback $a_itemfeedback) : void // TODO PHP8-REVIEW Should null really be allowed here as possible/useful value?
     {
         $this->itemfeedback[] = $a_itemfeedback;
     }
@@ -225,10 +197,6 @@ class ilQTIItem
     {
         return $this->presentation;
     }
-    
-    public function collectResponses() : void
-    {
-    }
 
     public function setQuestiontype(string $a_questiontype) : void
     {
@@ -252,30 +220,30 @@ class ilQTIItem
     {
         switch ($this->questiontype) {
             case "ORDERING QUESTION":
-                return QT_ORDERING;
+                return self::QT_ORDERING;
             case "KPRIM CHOICE QUESTION":
-                return QT_KPRIM_CHOICE;
+                return self::QT_KPRIM_CHOICE;
             case "LONG MENU QUESTION":
-                return QT_LONG_MENU;
+                return self::QT_LONG_MENU;
             case "SINGLE CHOICE QUESTION":
-                return QT_MULTIPLE_CHOICE_SR;
+                return self::QT_MULTIPLE_CHOICE_SR;
             case "MULTIPLE CHOICE QUESTION":
                 break;
             case "MATCHING QUESTION":
-                return QT_MATCHING;
+                return self::QT_MATCHING;
             case "CLOZE QUESTION":
-                return QT_CLOZE;
+                return self::QT_CLOZE;
             case "IMAGE MAP QUESTION":
-                return QT_IMAGEMAP;
+                return self::QT_IMAGEMAP;
             case "TEXT QUESTION":
-                return QT_TEXT;
+                return self::QT_TEXT;
             case "NUMERIC QUESTION":
-                return QT_NUMERIC;
+                return self::QT_NUMERIC;
             case "TEXTSUBSET QUESTION":
-                return QT_TEXTSUBSET;
+                return self::QT_TEXTSUBSET;
         }
         if (!$this->presentation) {
-            return QT_UNKNOWN;
+            return self::QT_UNKNOWN;
         }
         foreach ($this->presentation->order as $entry) {
             if ('response' === $entry["type"]) {
@@ -286,7 +254,7 @@ class ilQTIItem
             }
         }
         if (strlen($this->questiontype) == 0) {
-            return QT_UNKNOWN;
+            return self::QT_UNKNOWN;
         }
 
         return $this->questiontype;
@@ -317,7 +285,7 @@ class ilQTIItem
         return $this->iliasSourceNic;
     }
 
-    public function setIliasSourceNic(?string $iliasSourceNic) : void
+    public function setIliasSourceNic(string $iliasSourceNic) : void
     {
         $this->iliasSourceNic = $iliasSourceNic;
     }
@@ -353,21 +321,21 @@ class ilQTIItem
     private function typeFromResponse(ilQTIResponse $response) : ?string
     {
         switch ($response->getResponsetype()) {
-            case RT_RESPONSE_LID:
+            case ilQTIResponse::RT_RESPONSE_LID:
                 switch ($response->getRCardinality()) {
-                    case R_CARDINALITY_ORDERED: return QT_ORDERING;
-                    case R_CARDINALITY_SINGLE: return QT_MULTIPLE_CHOICE_SR;
-                    case R_CARDINALITY_MULTIPLE: return QT_MULTIPLE_CHOICE_MR;
+                    case ilQTIResponse::R_CARDINALITY_ORDERED: return self::QT_ORDERING;
+                    case ilQTIResponse::R_CARDINALITY_SINGLE: return self::QT_MULTIPLE_CHOICE_SR;
+                    case ilQTIResponse::R_CARDINALITY_MULTIPLE: return self::QT_MULTIPLE_CHOICE_MR;
                 }
                 // no break
-            case RT_RESPONSE_XY: return QT_IMAGEMAP;
-            case RT_RESPONSE_STR:
+            case ilQTIResponse::RT_RESPONSE_XY: return self::QT_IMAGEMAP;
+            case ilQTIResponse::RT_RESPONSE_STR:
                 switch ($response->getRCardinality()) {
-                    case R_CARDINALITY_ORDERED: return QT_TEXT;
-                    case R_CARDINALITY_SINGLE: return QT_CLOZE;
+                    case ilQTIResponse::R_CARDINALITY_ORDERED: return self::QT_TEXT;
+                    case ilQTIResponse::R_CARDINALITY_SINGLE: return self::QT_CLOZE;
                 }
                 // no break
-            case RT_RESPONSE_GRP: return QT_MATCHING;
+            case ilQTIResponse::RT_RESPONSE_GRP: return self::QT_MATCHING;
 
             default: return null;
         }

--- a/Services/QTI/classes/class.ilQTIItemfeedback.php
+++ b/Services/QTI/classes/class.ilQTIItemfeedback.php
@@ -1,36 +1,21 @@
-<?php
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+<?php declare(strict_types=1);
 
-const VIEW_ALL = "1";
-const VIEW_ADMINISTRATOR = "2";
-const VIEW_ADMINAUTHORITY = "3";
-const VIEW_ASSESSOR = "4";
-const VIEW_AUTHOR = "5";
-const VIEW_CANDIDATE = "6";
-const VIEW_INVIGILATORPROCTOR = "7";
-const VIEW_PSYCHOMETRICIAN = "8";
-const VIEW_SCORER = "9";
-const VIEW_TUTOR = "10";
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
 * QTI itemfeedback class
@@ -42,65 +27,67 @@ const VIEW_TUTOR = "10";
 */
 class ilQTIItemfeedback
 {
-    public ?string $view;
-    public ?string $ident;
-    public ?string $title;
+    public const VIEW_ALL = "1";
+    public const VIEW_ADMINISTRATOR = "2";
+    public const VIEW_ADMINAUTHORITY = "3";
+    public const VIEW_ASSESSOR = "4";
+    public const VIEW_AUTHOR = "5";
+    public const VIEW_CANDIDATE = "6";
+    public const VIEW_INVIGILATORPROCTOR = "7";
+    public const VIEW_PSYCHOMETRICIAN = "8";
+    public const VIEW_SCORER = "9";
+    public const VIEW_TUTOR = "10";
+
+    public ?string $view = null;
+    public ?string $ident = null;
+    public ?string $title = null;
     /** @var ilQTIFlowmat[] */
-    public array $flow_mat;
+    public array $flow_mat = [];
     /** @var ilQTIMaterial[] */
-    public array $material;
-    
-    public function __construct()
-    {
-        $this->view = null;
-        $this->ident = null;
-        $this->title = null;
-        $this->flow_mat = [];
-        $this->material = [];
-    }
+    public array $material = [];
 
     public function setView(string $a_view) : void
     {
         switch (strtolower($a_view)) {
             case "1":
             case "all":
-                $this->view = VIEW_ALL;
+                $this->view = self::VIEW_ALL;
                 break;
             case "2":
             case "administrator":
-                $this->view = VIEW_ADMINISTRATOR;
+                $this->view = self::VIEW_ADMINISTRATOR;
                 break;
             case "3":
             case "adminauthority":
-                $this->view = VIEW_ADMINAUTHORITY;
+                $this->view = self::VIEW_ADMINAUTHORITY;
                 break;
             case "4":
             case "assessor":
-                $this->view = VIEW_ASSESSOR;
+                $this->view = self::VIEW_ASSESSOR;
                 break;
             case "5":
             case "author":
-                $this->view = VIEW_AUTHOR;
+                $this->view = self::VIEW_AUTHOR;
                 break;
             case "6":
             case "candidate":
-                $this->view = VIEW_CANDIDATE;
+                $this->view = self::VIEW_CANDIDATE;
                 break;
             case "7":
             case "invigilatorproctor":
-                $this->view = VIEW_INVIGILATORPROCTOR;
+                $this->view = self::VIEW_INVIGILATORPROCTOR;
                 break;
             case "8":
             case "psychometrician":
-                $this->view = VIEW_PSYCHOMETRICIAN;
+                $this->view = self::VIEW_PSYCHOMETRICIAN;
                 break;
             case "9":
             case "scorer":
-                $this->view = VIEW_SCORER;
+                $this->view = self::VIEW_SCORER;
                 break;
             case "10":
             case "tutor":
-                $this->view = VIEW_TUTOR;
+                $this->view = self::VIEW_TUTOR;
                 break;
         }
     }
@@ -120,7 +107,7 @@ class ilQTIItemfeedback
         return $this->ident;
     }
 
-    public function setTitle(?string $a_title) : void
+    public function setTitle(string $a_title) : void
     {
         $this->title = $a_title;
     }
@@ -130,7 +117,7 @@ class ilQTIItemfeedback
         return $this->title;
     }
 
-    public function addFlow_mat(ilQTIFlowmat $a_flow_mat) : void
+    public function addFlowMat(ilQTIFlowmat $a_flow_mat) : void
     {
         $this->flow_mat[] = $a_flow_mat;
     }

--- a/Services/QTI/classes/class.ilQTIMatapplet.php
+++ b/Services/QTI/classes/class.ilQTIMatapplet.php
@@ -1,25 +1,21 @@
-<?php
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
 * QTI matapplet class
@@ -31,28 +27,15 @@
 */
 class ilQTIMatapplet
 {
-    public ?string $embedded;
-    public ?string $label;
-    public ?string $uri;
-    public ?string $x0;
-    public ?string $y0;
-    public ?string $width;
-    public ?string $height;
-    public ?string $entityref;
-    public ?string $content;
-    
-    public function __construct()
-    {
-        $this->embedded = null;
-        $this->label = null;
-        $this->uri = null;
-        $this->x0 = null;
-        $this->y0 = null;
-        $this->width = null;
-        $this->height = null;
-        $this->entityref = null;
-        $this->content = null;
-    }
+    public ?string $embedded = null;
+    public ?string $label = null;
+    public ?string $uri = null;
+    public ?string $x0 = null;
+    public ?string $y0 = null;
+    public ?string $width = null;
+    public ?string $height = null;
+    public ?string $entityref = null;
+    public ?string $content = null;
 
     public function setEmbedded(string $a_embedded) : void
     {

--- a/Services/QTI/classes/class.ilQTIMaterial.php
+++ b/Services/QTI/classes/class.ilQTIMaterial.php
@@ -1,25 +1,21 @@
-<?php
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
 * QTI material class
@@ -31,32 +27,25 @@
 */
 class ilQTIMaterial
 {
-    public ?string $label;
-    public int $flow;
+    public ?string $label = null;
+    public int $flow = 0;
 
     /**
      * @var array{material: ilQTIMattext|ilQTIMatimage|ilQTIMatapplet|null, type: string}[]
      */
-    public array $materials;
-    
-    public function __construct()
-    {
-        $this->label = null;
-        $this->flow = 0;
-        $this->materials = [];
-    }
+    public array $materials = [];
 
-    public function addMattext(?ilQTIMattext $a_mattext) : void
+    public function addMattext(?ilQTIMattext $a_mattext) : void // TODO PHP8-REVIEW Should null really be allowed here as possible/useful value?
     {
         $this->materials[] = array("material" => $a_mattext, "type" => "mattext");
     }
 
-    public function addMatimage(?ilQTIMatimage $a_matimage) : void
+    public function addMatimage(?ilQTIMatimage $a_matimage) : void // TODO PHP8-REVIEW Should null really be allowed here as possible/useful value?
     {
         $this->materials[] = array("material" => $a_matimage, "type" => "matimage");
     }
 
-    public function addMatapplet(?ilQTIMatapplet $a_matapplet) : void
+    public function addMatapplet(?ilQTIMatapplet $a_matapplet) : void // TODO PHP8-REVIEW Should null really be allowed here as possible/useful value?
     {
         $this->materials[] = array("material" => $a_matapplet, "type" => "matapplet");
     }

--- a/Services/QTI/classes/class.ilQTIMatimage.php
+++ b/Services/QTI/classes/class.ilQTIMatimage.php
@@ -1,25 +1,21 @@
-<?php
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
 * QTI matimage class
@@ -33,30 +29,16 @@ class ilQTIMatimage
 {
     public const EMBEDDED_BASE64 = 'base64';
 
-    public ?string $imagetype;
-    public ?string $label;
-    public ?string $height;
-    public ?string $width;
-    public ?string $uri;
-    public ?string $embedded;
-    public ?string $x0;
-    public ?string $y0;
-    public ?string $entityref;
-    public ?string $content;
-    
-    public function __construct()
-    {
-        $this->imagetype = null;
-        $this->label = null;
-        $this->height = null;
-        $this->width = null;
-        $this->uri = null;
-        $this->embedded = null;
-        $this->x0 = null;
-        $this->y0 = null;
-        $this->entityref = null;
-        $this->content = null;
-    }
+    public ?string $imagetype = null;
+    public ?string $label = null;
+    public ?string $height = null;
+    public ?string $width = null;
+    public ?string $uri = null;
+    public ?string $embedded = null;
+    public ?string $x0 = null;
+    public ?string $y0 = null;
+    public ?string $entityref = null;
+    public ?string $content = null;
 
     public function setImagetype(string $a_imagetype) : void
     {
@@ -148,7 +130,7 @@ class ilQTIMatimage
         return $this->entityref;
     }
 
-    public function setContent(?string $a_content) : void
+    public function setContent(string $a_content) : void
     {
         $this->content = $a_content;
     }

--- a/Services/QTI/classes/class.ilQTIMattext.php
+++ b/Services/QTI/classes/class.ilQTIMattext.php
@@ -1,28 +1,21 @@
-<?php
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+<?php declare(strict_types=1);
 
-const SPACE_PRESERVE = "1";
-const SPACE_DEFAULT = "2";
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
 * QTI mattext class
@@ -34,34 +27,21 @@ const SPACE_DEFAULT = "2";
 */
 class ilQTIMattext
 {
-    public ?string $texttype;
-    public ?string $label;
-    public ?string $charset;
-    public ?string $uri;
-    public ?string $xmlspace;
-    public ?string $xmllang;
-    public ?string $entityref;
-    public ?string $width;
-    public ?string $height;
-    public ?string $x0;
-    public ?string $y0;
-    public ?string $content;
-    
-    public function __construct()
-    {
-        $this->texttype = null;
-        $this->label = null;
-        $this->charset = null;
-        $this->uri = null;
-        $this->xmlspace = null;
-        $this->xmllang = null;
-        $this->entityref = null;
-        $this->width = null;
-        $this->height = null;
-        $this->x0 = null;
-        $this->y0 = null;
-        $this->content = null;
-    }
+    public const SPACE_PRESERVE = "1";
+    public const SPACE_DEFAULT = "2";
+
+    public ?string $texttype = null;
+    public ?string $label = null;
+    public ?string $charset = null;
+    public ?string $uri = null;
+    public ?string $xmlspace = null;
+    public ?string $xmllang = null;
+    public ?string $entityref = null;
+    public ?string $width = null;
+    public ?string $height = null;
+    public ?string $x0 = null;
+    public ?string $y0 = null;
+    public ?string $content = null;
 
     public function setTexttype(string $a_texttype) : void
     {
@@ -138,11 +118,11 @@ class ilQTIMattext
         switch (strtolower($a_xmlspace)) {
             case "preserve":
             case "1":
-                $this->xmlspace = SPACE_PRESERVE;
+                $this->xmlspace = self::SPACE_PRESERVE;
                 break;
             case "default":
             case "2":
-                $this->xmlspace = SPACE_DEFAULT;
+                $this->xmlspace = self::SPACE_DEFAULT;
                 break;
         }
     }

--- a/Services/QTI/classes/class.ilQTIObjectives.php
+++ b/Services/QTI/classes/class.ilQTIObjectives.php
@@ -1,25 +1,21 @@
-<?php
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
 * QTI objectives class
@@ -32,14 +28,8 @@
 class ilQTIObjectives
 {
     /** @var ilQTIMaterial[] */
-    public array $materials;
-    public string $view;
-    
-    public function __construct()
-    {
-        $this->materials = [];
-        $this->view = "All";
-    }
+    public array $materials = [];
+    public string $view = "All";
     
     public function addMaterial(ilQTIMaterial $a_material) : void
     {

--- a/Services/QTI/classes/class.ilQTIOutcomes.php
+++ b/Services/QTI/classes/class.ilQTIOutcomes.php
@@ -1,25 +1,21 @@
-<?php
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
 * QTI outcomes label class
@@ -31,15 +27,9 @@
 */
 class ilQTIOutcomes
 {
-    public ?string $comment;
+    public ?string $comment = null;
     /** @var (null|ilQTIDecvar)[] */
-    public array $decvar;
-    
-    public function __construct()
-    {
-        $this->comment = null;
-        $this->decvar = [];
-    }
+    public array $decvar = [];
 
     public function setComment(string $a_comment) : void
     {
@@ -51,7 +41,7 @@ class ilQTIOutcomes
         return $this->comment;
     }
     
-    public function addDecvar(?ilQTIDecvar $a_decvar) : void
+    public function addDecvar(?ilQTIDecvar $a_decvar) : void // TODO PHP8-REVIEW Should null really be allowed here as possible/useful value?
     {
         $this->decvar[] = $a_decvar;
     }

--- a/Services/QTI/classes/class.ilQTIParser.php
+++ b/Services/QTI/classes/class.ilQTIParser.php
@@ -1,23 +1,21 @@
-<?php
-/******************************************************************************
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
-
-include_once("./Services/Xml/classes/class.ilSaxParser.php");
-include_once 'Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/class.ilAssQuestionTypeList.php';
-
-const IL_MO_PARSE_QTI = 1;
-const IL_MO_VERIFY_QTI = 2;
+ ********************************************************************
+ */
 
 /**
  * QTI Parser
@@ -30,155 +28,175 @@ const IL_MO_VERIFY_QTI = 2;
  */
 class ilQTIParser extends ilSaxParser
 {
-    public bool $hasRootElement;
+    public const IL_MO_PARSE_QTI = 1;
+    public const IL_MO_VERIFY_QTI = 2;
+
+    public bool $hasRootElement = false;
 
     /**
      * @var array<int, string>
      */
-    public array $path;
+    public array $path = [];
 
     /**
      * @var ilQTIItem[]
      */
-    public array $items;
+    public array $items = [];
 
-    public ?ilQTIItem $item;
+    public ?ilQTIItem $item = null;
 
     /**
      * @var SplObjectStorage<XmlParser|resource, int>
      */
     public $depth;
 
-    public string $qti_element;
+    public string $qti_element = "";
 
-    public bool $in_presentation;
+    public bool $in_presentation = false;
 
-    public bool $in_response;
+    public bool $in_response = false;
 
     /**
      * @var ilQTIRenderChoice|ilQTIRenderHotspot|ilQTIRenderFib|null
      */
-    public $render_type;
+    public $render_type = null;
 
-    public ?ilQTIResponseLabel $response_label;
+    public ?ilQTIResponseLabel $response_label = null;
 
-    public ?ilQTIMaterial $material;
+    public ?ilQTIMaterial $material = null;
 
-    public ?ilQTIMatimage $matimage;
+    public ?ilQTIMatimage $matimage = null;
 
-    public ?ilQTIResponse $response;
+    public ?ilQTIResponse $response = null;
 
-    public ?ilQTIResprocessing $resprocessing;
+    public ?ilQTIResprocessing $resprocessing = null;
 
-    public ?ilQTIOutcomes $outcomes;
+    public ?ilQTIOutcomes $outcomes = null;
 
-    public ?ilQTIDecvar $decvar;
+    public ?ilQTIDecvar $decvar = null;
 
-    public ?ilQTIRespcondition $respcondition;
+    public ?ilQTIRespcondition $respcondition = null;
 
-    public ?ilQTISetvar $setvar;
+    public ?ilQTISetvar $setvar = null;
 
-    public ?ilQTIDisplayfeedback $displayfeedback;
+    public ?ilQTIDisplayfeedback $displayfeedback = null;
 
-    public ?ilQTIItemfeedback $itemfeedback;
+    public ?ilQTIItemfeedback $itemfeedback = null;
 
     /**
      * @var ilQTIFlowMat[]
      */
-    public array $flow_mat;
+    public array $flow_mat = [];
 
-    public int $flow;
+    public int $flow = 0;
 
-    public ?ilQTIPresentation $presentation;
+    public ?ilQTIPresentation $presentation = null;
 
-    public ?ilQTIMattext $mattext;
+    public ?ilQTIMattext $mattext = null;
 
-    public ?bool $sametag;
+    public bool $sametag = false;
 
-    public ?string $characterbuffer;
+    public string $characterbuffer = "";
 
-    public ?ilQTIConditionvar $conditionvar;
+    public ?ilQTIConditionvar $conditionvar = null;
 
-    public int $parser_mode;
+    public int $parser_mode = 0;
 
     /**
      * @var string[]
      */
-    public array $import_idents;
+    public array $import_idents = [];
 
-    public int $qpl_id;
+    public int $qpl_id = 0;
 
-    public ?int $tst_id;
+    public ?int $tst_id = null;
 
-    public ?ilObjTest $tst_object;
+    public ?ilObjTest $tst_object = null;
 
-    public bool $do_nothing;
+    public bool $do_nothing = false;
 
-    public int $gap_index;
+    public int $gap_index = 0;
 
     /**
      * @var ilQTIAssessment[]
      */
-    public array $assessments;
+    public array $assessments = [];
 
-    public ?ilQTIAssessment $assessment;
+    public ?ilQTIAssessment $assessment = null;
 
-    public ?ilQTIAssessmentcontrol $assessmentcontrol;
+    public ?ilQTIAssessmentcontrol $assessmentcontrol = null;
 
-    public ?ilQTIObjectives $objectives;
+    public ?ilQTIObjectives $objectives = null;
 
-    public bool $in_assessment;
+    public bool $in_assessment = false;
 
-    public ?ilQTISection $section;
+    public ?ilQTISection $section = null;
 
     /**
-     * @var array<string, ['test' => mixed]>
+     * @var array<string, ['test' => mixed]> // TODO PHP8-REVIEW The phpdoc looks somehow broken
      */
-    public array $import_mapping;
+    public array $import_mapping = [];
 
-    public int $question_counter;
+    public int $question_counter = 1;
 
-    public ?bool $in_itemmetadata;
+    public bool $in_itemmetadata = false;
 
-    public bool $in_objectives;
+    public bool $in_objectives = false;
 
     /**
      * @var array{title: string, type: string, ident: string}[]
      */
-    public array $founditems;
+    public array $founditems = [];
 
-    public bool $verifyroot;
+    public bool $verifyroot = false;
 
-    public int $verifyqticomment;
+    public int $verifyqticomment = 0;
 
     public int $verifymetadatafield = 0;
 
-    public int $verifyfieldlabel;
+    public int $verifyfieldlabel = 0;
 
-    public string $verifyfieldlabeltext;
+    public string $verifyfieldlabeltext = "";
 
-    public int $verifyfieldentry;
+    public int $verifyfieldentry = 0;
 
-    public string $verifyfieldentrytext;
+    public string $verifyfieldentrytext = "";
 
     protected int $numImportedItems = 0;
 
-    protected ?ilQTIPresentationMaterial $prensentation_material;
+    protected ?ilQTIPresentationMaterial $prensentation_material = null;
 
     protected bool $in_prensentation_material = false;
 
     protected bool $ignoreItemsEnabled = false;
 
-    private ?ilQTIMatapplet $matapplet;
+    private ?ilQTIMatapplet $matapplet = null;
 
     /**
      * @var array{label: string, entry: string}
      */
-    private array $metadata;
+    private array $metadata = ["label" => "", "entry" => ""];
 
-    private ?ilQTIResponseVar $responsevar;
+    private ?ilQTIResponseVar $responsevar = null;
 
     protected ?string $questionSetType = null;
+
+    public function __construct(?string $a_xml_file, int $a_mode = self::IL_MO_PARSE_QTI, int $a_qpl_id = 0, string $a_import_idents = "")
+    {
+        global $lng;
+
+        $this->parser_mode = $a_mode;
+
+        parent::__construct($a_xml_file);
+
+        $this->qpl_id = $a_qpl_id;
+        if (is_array($a_import_idents)) { // TODO PHP8-REVIEW This can not happen anymore because the variable is typed as string. How the line below should be handled?
+            $this->import_idents = &$a_import_idents;
+        }
+
+        $this->lng = &$lng;
+        $this->depth = new SplObjectStorage();
+    }
 
     public function isIgnoreItemsEnabled() : bool
     {
@@ -190,99 +208,22 @@ class ilQTIParser extends ilSaxParser
         $this->ignoreItemsEnabled = $ignoreItemsEnabled;
     }
 
-    //  TODO: The following line gets me an parse error in PHP 4, but I found no hint that pass-by-reference is forbidden in PHP 4 ????
-    public function __construct(?string $a_xml_file, int $a_mode = IL_MO_PARSE_QTI, int $a_qpl_id = 0, string $a_import_idents = "")
-    {
-        global $lng;
-
-        $this->setParserMode($a_mode);
-
-        parent::__construct($a_xml_file);
-
-        $this->qpl_id = $a_qpl_id;
-        $this->import_idents = [];
-        if (is_array($a_import_idents)) {
-            $this->import_idents = &$a_import_idents;
-        }
-
-        $this->lng = &$lng;
-        $this->hasRootElement = false;
-        $this->import_mapping = [];
-        $this->assessments = [];
-        $this->assessment = null;
-        $this->section = null;
-        $this->path = [];
-        $this->items = [];
-        $this->item = null;
-        $this->depth = new SplObjectStorage();
-        $this->do_nothing = false;
-        $this->qti_element = "";
-        $this->in_presentation = false;
-        $this->in_objectives = false;
-        $this->in_response = false;
-        $this->render_type = null;
-        $this->response_label = null;
-        $this->material = null;
-        $this->response = null;
-        $this->assessmentcontrol = null;
-        $this->objectives = null;
-        $this->matimage = null;
-        $this->resprocessing = null;
-        $this->outcomes = null;
-        $this->decvar = null;
-        $this->respcondition = null;
-        $this->setvar = null;
-        $this->displayfeedback = null;
-        $this->itemfeedback = null;
-        $this->flow_mat = [];
-        $this->question_counter = 1;
-        $this->flow = 0;
-        $this->gap_index = 0;
-        $this->presentation = null;
-        $this->mattext = null;
-        $this->matapplet = null;
-        $this->sametag = false;
-        $this->in_assessment = false;
-        $this->characterbuffer = "";
-        $this->metadata = ["label" => "", "entry" => ""];
-        $this->responsevar = null;
-        $this->prensentation_material = null;
-        $this->in_itemmetadata = null;
-        $this->tst_object = null;
-        $this->tst_id = null;
-        $this->conditionvar = null;
-    }
-
     public function getQuestionSetType() : ?string
     {
         return $this->questionSetType;
     }
 
-    public function setQuestionSetType(?string $questionSetType) : void
+    public function setQuestionSetType(?string $questionSetType) : void // TODO PHP8-REVIEW Should null really be allowed here as possible/useful value?
     {
         $this->questionSetType = $questionSetType;
     }
 
-    public function setTestObject(?ilObjTest &$a_tst_object) : void
+    public function setTestObject(?ilObjTest &$a_tst_object) : void // TODO PHP8-REVIEW Should null really be allowed here as possible/useful value?
     {
         $this->tst_object = &$a_tst_object;
-        if (is_object($a_tst_object)) {
+        if (is_object($a_tst_object)) { // TODO PHP8-REVIEW If null is not allowed anymore, this check becomes propably needless
             $this->tst_id = $this->tst_object->getId();
         }
-    }
-
-    public function setParserMode(int $a_mode = IL_MO_PARSE_QTI) : void
-    {
-        $this->parser_mode = $a_mode;
-        $this->founditems = array();
-        $this->verifyroot = false;
-        $this->verifyqticomment = 0;
-        $this->verifymetadatafield = 0;
-        $this->verifyfieldlabel = 0;
-        $this->verifyfieldentry = 0;
-        $this->verifyfieldlabeltext = "";
-        $this->verifyfieldentrytext = "";
-        $this->question_counter = 1;
     }
 
     /**
@@ -306,7 +247,7 @@ class ilQTIParser extends ilSaxParser
     }
 
     /**
-     * @param XMLParser|resource
+     * @param XMLParser|resource $a_xml_parser
      */
     public function getParent($a_xml_parser) : string
     {
@@ -324,10 +265,10 @@ class ilQTIParser extends ilSaxParser
     public function handlerBeginTag($a_xml_parser, string $a_name, array $a_attribs) : void
     {
         switch ($this->parser_mode) {
-            case IL_MO_PARSE_QTI:
+            case self::IL_MO_PARSE_QTI:
                 $this->handlerParseBeginTag($a_xml_parser, $a_name, $a_attribs);
                 break;
-            case IL_MO_VERIFY_QTI:
+            case self::IL_MO_VERIFY_QTI:
                 $this->handlerVerifyBeginTag($a_xml_parser, $a_name, $a_attribs);
                 break;
         }
@@ -370,7 +311,7 @@ class ilQTIParser extends ilSaxParser
                 $this->in_itemmetadata = true;
                 break;
             case "qtimetadatafield":
-                $this->metadata = array("label" => "", "entry" => "");
+                $this->metadata = ["label" => "", "entry" => ""];
                 break;
             case "flow":
                 $this->flow++;
@@ -409,7 +350,7 @@ class ilQTIParser extends ilSaxParser
                 $this->varEqualBeginTag($a_attribs);
                 break;
             case "varlt":
-                $this->responsevar = new ilQTIResponseVar(RESPONSEVAR_LT);
+                $this->responsevar = new ilQTIResponseVar(ilQTIResponseVar::RESPONSEVAR_LT);
                 foreach ($a_attribs as $attribute => $value) {
                     switch (strtolower($attribute)) {
                         case "respident":
@@ -422,7 +363,7 @@ class ilQTIParser extends ilSaxParser
                 }
                 break;
             case "varlte":
-                $this->responsevar = new ilQTIResponseVar(RESPONSEVAR_LTE);
+                $this->responsevar = new ilQTIResponseVar(ilQTIResponseVar::RESPONSEVAR_LTE);
                 foreach ($a_attribs as $attribute => $value) {
                     switch (strtolower($attribute)) {
                         case "respident":
@@ -435,7 +376,7 @@ class ilQTIParser extends ilSaxParser
                 }
                 break;
             case "vargt":
-                $this->responsevar = new ilQTIResponseVar(RESPONSEVAR_GT);
+                $this->responsevar = new ilQTIResponseVar(ilQTIResponseVar::RESPONSEVAR_GT);
                 foreach ($a_attribs as $attribute => $value) {
                     switch (strtolower($attribute)) {
                         case "respident":
@@ -448,7 +389,7 @@ class ilQTIParser extends ilSaxParser
                 }
                 break;
             case "vargte":
-                $this->responsevar = new ilQTIResponseVar(RESPONSEVAR_GTE);
+                $this->responsevar = new ilQTIResponseVar(ilQTIResponseVar::RESPONSEVAR_GTE);
                 foreach ($a_attribs as $attribute => $value) {
                     switch (strtolower($attribute)) {
                         case "respident":
@@ -461,7 +402,7 @@ class ilQTIParser extends ilSaxParser
                 }
                 break;
             case "varsubset":
-                $this->responsevar = new ilQTIResponseVar(RESPONSEVAR_SUBSET);
+                $this->responsevar = new ilQTIResponseVar(ilQTIResponseVar::RESPONSEVAR_SUBSET);
                 foreach ($a_attribs as $attribute => $value) {
                     switch (strtolower($attribute)) {
                         case "respident":
@@ -477,7 +418,7 @@ class ilQTIParser extends ilSaxParser
                 }
                 break;
             case "varinside":
-                $this->responsevar = new ilQTIResponseVar(RESPONSEVAR_INSIDE);
+                $this->responsevar = new ilQTIResponseVar(ilQTIResponseVar::RESPONSEVAR_INSIDE);
                 foreach ($a_attribs as $attribute => $value) {
                     switch (strtolower($attribute)) {
                         case "respident":
@@ -493,7 +434,7 @@ class ilQTIParser extends ilSaxParser
                 }
                 break;
             case "varsubstring":
-                $this->responsevar = new ilQTIResponseVar(RESPONSEVAR_SUBSTRING);
+                $this->responsevar = new ilQTIResponseVar(ilQTIResponseVar::RESPONSEVAR_SUBSTRING);
                 foreach ($a_attribs as $attribute => $value) {
                     switch (strtolower($attribute)) {
                         case "case":
@@ -593,10 +534,10 @@ class ilQTIParser extends ilSaxParser
     public function handlerEndTag($a_xml_parser, string $a_name) : void
     {
         switch ($this->parser_mode) {
-            case IL_MO_PARSE_QTI:
+            case self::IL_MO_PARSE_QTI:
                 $this->handlerParseEndTag($a_xml_parser, $a_name);
                 break;
-            case IL_MO_VERIFY_QTI:
+            case self::IL_MO_VERIFY_QTI:
                 $this->handlerVerifyEndTag($a_xml_parser, $a_name);
                 break;
         }
@@ -664,7 +605,7 @@ class ilQTIParser extends ilSaxParser
                 if ($this->in_assessment) {
                     $this->assessment->addQtiMetadata($this->metadata);
                 }
-                $this->metadata = array("label" => "", "entry" => "");
+                $this->metadata = ["label" => "", "entry" => ""];
                 break;
             case "flow":
                 $this->flow--;
@@ -673,11 +614,11 @@ class ilQTIParser extends ilSaxParser
                 if (count($this->flow_mat)) {
                     $flow_mat = array_pop($this->flow_mat);
                     if (count($this->flow_mat)) {
-                        $this->flow_mat[count($this->flow_mat) - 1]->addFlow_mat($flow_mat);
+                        $this->flow_mat[count($this->flow_mat) - 1]->addFlowMat($flow_mat);
                     } elseif ($this->in_prensentation_material) {
                         $this->prensentation_material->addFlowMat($flow_mat);
                     } elseif ($this->itemfeedback != null) {
-                        $this->itemfeedback->addFlow_mat($flow_mat);
+                        $this->itemfeedback->addFlowMat($flow_mat);
                     } elseif ($this->response_label != null) {
                         $this->response_label->addFlow_mat($flow_mat);
                     }
@@ -918,10 +859,10 @@ class ilQTIParser extends ilSaxParser
     public function handlerCharacterData($a_xml_parser, string $a_data) : void
     {
         switch ($this->parser_mode) {
-            case IL_MO_PARSE_QTI:
+            case self::IL_MO_PARSE_QTI:
                 $this->handlerParseCharacterData($a_xml_parser, $a_data);
                 break;
-            case IL_MO_VERIFY_QTI:
+            case self::IL_MO_VERIFY_QTI:
                 $this->handlerVerifyCharacterData($a_xml_parser, $a_data);
                 break;
         }
@@ -1034,16 +975,14 @@ class ilQTIParser extends ilSaxParser
             case "assessment":
                 $this->assessment = $this->assessments[] = new ilQTIAssessment();
                 $this->in_assessment = true;
-                if (is_array($a_attribs)) {
-                    foreach ($a_attribs as $attribute => $value) {
-                        switch (strtolower($attribute)) {
-                            case "title":
-                                $this->assessment->setTitle($value);
-                                break;
-                            case "ident":
-                                $this->assessment->setIdent($value);
-                                break;
-                        }
+                foreach ($a_attribs as $attribute => $value) {
+                    switch (strtolower($attribute)) {
+                        case "title":
+                            $this->assessment->setTitle($value);
+                            break;
+                        case "ident":
+                            $this->assessment->setIdent($value);
+                            break;
                     }
                 }
                 break;
@@ -1051,7 +990,7 @@ class ilQTIParser extends ilSaxParser
                 $this->verifyroot = true;
                 break;
             case "qtimetadatafield":
-                $this->metadata = array("label" => "", "entry" => "");
+                $this->metadata = ["label" => "", "entry" => ""];
                 $this->verifymetadatafield = 1;
                 break;
             case "fieldlabel":
@@ -1068,37 +1007,33 @@ class ilQTIParser extends ilSaxParser
                 break;
             case "item":
                 $title = "";
-                if (is_array($a_attribs)) {
-                    foreach ($a_attribs as $attribute => $value) {
-                        switch (strtolower($attribute)) {
-                            case "title":
-                                $title = $value;
-                                break;
-                        }
+                foreach ($a_attribs as $attribute => $value) {
+                    switch (strtolower($attribute)) {
+                        case "title":
+                            $title = $value;
+                            break;
                     }
                 }
-                $this->founditems[] = array("title" => "$title", "type" => "", "ident" => $a_attribs["ident"]);
+                $this->founditems[] = ["title" => "$title", "type" => "", "ident" => $a_attribs["ident"]];
                 break;
             case "response_lid":
                 if (strlen($this->founditems[count($this->founditems) - 1]["type"]) == 0) {
                     // test for non ILIAS generated question types
-                    if (is_array($a_attribs)) {
-                        foreach ($a_attribs as $attribute => $value) {
-                            switch (strtolower($attribute)) {
-                                case "rcardinality":
-                                    switch (strtolower($value)) {
-                                        case "single":
-                                            $this->founditems[count($this->founditems) - 1]["type"] = QT_MULTIPLE_CHOICE_SR;
-                                            break;
-                                        case "multiple":
-                                            $this->founditems[count($this->founditems) - 1]["type"] = QT_MULTIPLE_CHOICE_MR;
-                                            break;
-                                        case "ordered":
-                                            $this->founditems[count($this->founditems) - 1]["type"] = QT_ORDERING;
-                                            break;
-                                    }
-                                    break;
-                            }
+                    foreach ($a_attribs as $attribute => $value) {
+                        switch (strtolower($attribute)) {
+                            case "rcardinality":
+                                switch (strtolower($value)) {
+                                    case "single":
+                                        $this->founditems[count($this->founditems) - 1]["type"] = ilQTIItem::QT_MULTIPLE_CHOICE_SR;
+                                        break;
+                                    case "multiple":
+                                        $this->founditems[count($this->founditems) - 1]["type"] = ilQTIItem::QT_MULTIPLE_CHOICE_MR;
+                                        break;
+                                    case "ordered":
+                                        $this->founditems[count($this->founditems) - 1]["type"] = ilQTIItem::QT_ORDERING;
+                                        break;
+                                }
+                                break;
                         }
                     }
                 }
@@ -1106,37 +1041,35 @@ class ilQTIParser extends ilSaxParser
             case "response_str":
                 if (strlen($this->founditems[count($this->founditems) - 1]["type"]) == 0) {
                     // test for non ILIAS generated question types
-                    if (is_array($a_attribs)) {
-                        foreach ($a_attribs as $attribute => $value) {
-                            switch (strtolower($attribute)) {
-                                case "rcardinality":
-                                    switch (strtolower($value)) {
-                                        case "single":
-                                            $this->founditems[count($this->founditems) - 1]["type"] = QT_CLOZE;
-                                            break;
-                                        case "ordered":
-                                            $this->founditems[count($this->founditems) - 1]["type"] = QT_TEXT;
-                                            break;
-                                    }
-                                    break;
-                            }
+                    foreach ($a_attribs as $attribute => $value) {
+                        switch (strtolower($attribute)) {
+                            case "rcardinality":
+                                switch (strtolower($value)) {
+                                    case "single":
+                                        $this->founditems[count($this->founditems) - 1]["type"] = ilQTIItem::QT_CLOZE;
+                                        break;
+                                    case "ordered":
+                                        $this->founditems[count($this->founditems) - 1]["type"] = ilQTIItem::QT_TEXT;
+                                        break;
+                                }
+                                break;
                         }
                     }
                 }
                 break;
             case "response_xy":
                 if (strlen($this->founditems[count($this->founditems) - 1]["type"]) == 0) {
-                    $this->founditems[count($this->founditems) - 1]["type"] = QT_IMAGEMAP;
+                    $this->founditems[count($this->founditems) - 1]["type"] = ilQTIItem::QT_IMAGEMAP;
                 }
                 break;
             case "response_num":
                 if (strlen($this->founditems[count($this->founditems) - 1]["type"]) == 0) {
-                    $this->founditems[count($this->founditems) - 1]["type"] = QT_NUMERIC;
+                    $this->founditems[count($this->founditems) - 1]["type"] = ilQTIItem::QT_NUMERIC;
                 }
                 break;
             case "response_grp":
                 if (strlen($this->founditems[count($this->founditems) - 1]["type"]) == 0) {
-                    $this->founditems[count($this->founditems) - 1]["type"] = QT_MATCHING;
+                    $this->founditems[count($this->founditems) - 1]["type"] = ilQTIItem::QT_MATCHING;
                 }
                 break;
             case "qticomment":
@@ -1144,13 +1077,11 @@ class ilQTIParser extends ilSaxParser
                 $this->verifyqticomment = 1;
                 break;
             case "presentation":
-                if (is_array($a_attribs)) {
-                    foreach ($a_attribs as $attribute => $value) {
-                        switch (strtolower($attribute)) {
-                            case "label":
-                                $this->founditems[count($this->founditems) - 1]["title"] = $value;
-                                break;
-                        }
+                foreach ($a_attribs as $attribute => $value) {
+                    switch (strtolower($attribute)) {
+                        case "label":
+                            $this->founditems[count($this->founditems) - 1]["title"] = $value;
+                            break;
                     }
                 }
                 break;
@@ -1193,7 +1124,7 @@ class ilQTIParser extends ilSaxParser
                 if ($this->in_assessment) {
                     $this->assessment->addQtiMetadata($this->metadata);
                 }
-                $this->metadata = array("label" => "", "entry" => "");
+                $this->metadata = ["label" => "", "entry" => ""];
                 break;
             case "fieldlabel":
                 $this->verifyfieldlabel = 0;
@@ -1241,14 +1172,10 @@ class ilQTIParser extends ilSaxParser
 
     /**
      * Get array of new created questions for import id.
-     * @return array<string, ['test' => mixed]>
+     * @return array<string, ['test' => mixed]> // TODO PHP8-REVIEW The phpdoc looks somehow broken
      */
     public function getImportMapping() : array
     {
-        if (!is_array($this->import_mapping)) {
-            return array();
-        }
-
         return $this->import_mapping;
     }
 
@@ -1257,7 +1184,7 @@ class ilQTIParser extends ilSaxParser
      */
     public function getQuestionIdMapping() : array
     {
-        $questionIdMapping = array();
+        $questionIdMapping = [];
 
         foreach ($this->getImportMapping() as $k => $v) {
             $oldQuestionId = substr($k, strpos($k, 'qst_') + strlen('qst_'));
@@ -1276,6 +1203,9 @@ class ilQTIParser extends ilSaxParser
         parent::setXMLContent($a_xml_content);
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function openXMLFile()
     {
         $xmlContent = file_get_contents($this->xml_file);
@@ -1316,7 +1246,7 @@ class ilQTIParser extends ilSaxParser
         //$xmlContent = preg_replace($reg, '', $xmlContent);
 
         // remove illegal chars escaped to html entities
-        $needles = array();
+        $needles = [];
         for ($i = 0x00, $max = 0x08; $i <= $max; $i += 0x01) {
             $needles[] = "&#{$i};";
         }
@@ -1364,7 +1294,7 @@ class ilQTIParser extends ilSaxParser
             return false; // no virus scan, no virus detected
         }
 
-        return (bool) $vs->scanBuffer($buffer);
+        return $vs->scanBuffer($buffer);
     }
 
     private function assessmentBeginTag(array $a_attribs) : void
@@ -1448,7 +1378,7 @@ class ilQTIParser extends ilSaxParser
 
     private function varEqualBeginTag(array $a_attribs) : void
     {
-        $this->responsevar = new ilQTIResponseVar(RESPONSEVAR_EQUAL);
+        $this->responsevar = new ilQTIResponseVar(ilQTIResponseVar::RESPONSEVAR_EQUAL);
         foreach ($a_attribs as $attribute => $value) {
             switch (strtolower($attribute)) {
                 case "case":
@@ -1469,19 +1399,19 @@ class ilQTIParser extends ilSaxParser
         $response_type = 0;
         switch (strtolower($a_name)) {
             case "response_lid":
-                $response_type = RT_RESPONSE_LID;
+                $response_type = ilQTIResponse::RT_RESPONSE_LID;
                 break;
             case "response_xy":
-                $response_type = RT_RESPONSE_XY;
+                $response_type = ilQTIResponse::RT_RESPONSE_XY;
                 break;
             case "response_str":
-                $response_type = RT_RESPONSE_STR;
+                $response_type = ilQTIResponse::RT_RESPONSE_STR;
                 break;
             case "response_num":
-                $response_type = RT_RESPONSE_NUM;
+                $response_type = ilQTIResponse::RT_RESPONSE_NUM;
                 break;
             case "response_grp":
-                $response_type = RT_RESPONSE_GRP;
+                $response_type = ilQTIResponse::RT_RESPONSE_GRP;
                 break;
         }
         $this->in_response = true;

--- a/Services/QTI/classes/class.ilQTIPresentation.php
+++ b/Services/QTI/classes/class.ilQTIPresentation.php
@@ -1,25 +1,21 @@
-<?php
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
 * QTI presentation class
@@ -31,37 +27,25 @@
 */
 class ilQTIPresentation
 {
-    public ?string $label;
-    public ?string $xmllang;
-    public ?string $x0;
-    public ?string $y0;
-    public ?string $width;
-    public ?string $height;
+    public ?string $label = null;
+    public ?string $xmllang = null;
+    public ?string $x0 = null;
+    public ?string $y0 = null;
+    public ?string $width = null;
+    public ?string $height = null;
+
     /** @var ilQTIMaterial[] */
-    public array $material;
+    public array $material = [];
 
     /**
      * @var ilQTIResponse[]
      */
-    public array $response;
+    public array $response = [];
 
     /**
      * @var array{type: string, index: int}[]
      */
-    public array $order;
-    
-    public function __construct()
-    {
-        $this->label = null;
-        $this->xmllang = null;
-        $this->x0 = null;
-        $this->y0 = null;
-        $this->width = null;
-        $this->height = null;
-        $this->response = [];
-        $this->material = [];
-        $this->order = [];
-    }
+    public array $order = [];
 
     public function setLabel(string $a_label) : void
     {

--- a/Services/QTI/classes/class.ilQTIPresentationMaterial.php
+++ b/Services/QTI/classes/class.ilQTIPresentationMaterial.php
@@ -1,7 +1,21 @@
-<?php
-/* Copyright (c) 1998-2014 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
-require_once 'Services/QTI/interfaces/interface.ilQTIFlowMatAware.php';
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
  * Class ilQTIPresentationMaterial

--- a/Services/QTI/classes/class.ilQTIRenderChoice.php
+++ b/Services/QTI/classes/class.ilQTIRenderChoice.php
@@ -1,28 +1,21 @@
-<?php
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+<?php declare(strict_types=1);
 
-const SHUFFLE_NO = "0";
-const SHUFFLE_YES = "1";
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
 * QTI render choice class
@@ -34,33 +27,27 @@ const SHUFFLE_YES = "1";
 */
 class ilQTIRenderChoice
 {
-    public string $shuffle;
-    public ?string $minnumber;
-    public ?string $maxnumber;
+    public const SHUFFLE_NO = "0";
+    public const SHUFFLE_YES = "1";
+
+    public string $shuffle = self::SHUFFLE_NO;
+    public ?string $minnumber = null;
+    public ?string $maxnumber = null;
     /** @var ilQTIResponseLabel[] */
-    public array $response_labels;
+    public array $response_labels = [];
     /** @var ilQTIMaterial[] */
-    public array $material;
-    
-    public function __construct()
-    {
-        $this->shuffle = SHUFFLE_NO;
-        $this->minnumber = null;
-        $this->maxnumber = null;
-        $this->response_labels = [];
-        $this->material = [];
-    }
+    public array $material = [];
 
     public function setShuffle(string $a_shuffle) : void
     {
         switch (strtolower($a_shuffle)) {
             case "0":
             case "no":
-                $this->shuffle = SHUFFLE_NO;
+                $this->shuffle = self::SHUFFLE_NO;
                 break;
             case "1":
             case "yes":
-                $this->shuffle = SHUFFLE_YES;
+                $this->shuffle = self::SHUFFLE_YES;
                 break;
         }
     }

--- a/Services/QTI/classes/class.ilQTIRenderFib.php
+++ b/Services/QTI/classes/class.ilQTIRenderFib.php
@@ -1,35 +1,21 @@
-<?php
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+<?php declare(strict_types=1);
 
-const PROMPT_BOX = "1";
-const PROMPT_DASHLINE = "2";
-const PROMPT_ASTERISK = "3";
-const PROMPT_UNDERLINE = "4";
-
-const FIBTYPE_STRING = "1";
-const FIBTYPE_INTEGER = "2";
-const FIBTYPE_DECIMAL = "3";
-const FIBTYPE_SCIENTIFIC = "4";
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
 * QTI render fib class
@@ -41,53 +27,48 @@ const FIBTYPE_SCIENTIFIC = "4";
 */
 class ilQTIRenderFib
 {
-    public ?string $minnumber;
-    public ?string $maxnumber;
-    /** @var ilQTIResponseLabel[] */
-    public array $response_labels;
-    /** @var ilQTIMaterial[] */
-    public array $material;
-    public ?string $prompt;
-    public string $encoding;
-    public ?string $fibtype;
-    public ?string $rows;
-    public ?string $maxchars;
-    public ?string $columns;
-    public ?string $charset;
+    public const PROMPT_BOX = "1";
+    public const PROMPT_DASHLINE = "2";
+    public const PROMPT_ASTERISK = "3";
+    public const PROMPT_UNDERLINE = "4";
 
-    public function __construct()
-    {
-        $this->minnumber = null;
-        $this->maxnumber = null;
-        $this->response_labels = [];
-        $this->material = [];
-        $this->prompt = null;
-        $this->encoding = "UTF-8";
-        $this->fibtype = null;
-        $this->rows = null;
-        $this->maxchars = null;
-        $this->columns = null;
-        $this->charset = null;
-    }
+    public const FIBTYPE_STRING = "1";
+    public const FIBTYPE_INTEGER = "2";
+    public const FIBTYPE_DECIMAL = "3";
+    public const FIBTYPE_SCIENTIFIC = "4";
+
+    public ?string $minnumber = null;
+    public ?string $maxnumber = null;
+    /** @var ilQTIResponseLabel[] */
+    public array $response_labels = [];
+    /** @var ilQTIMaterial[] */
+    public array $material = [];
+    public ?string $prompt = null;
+    public string $encoding = "UTF-8";
+    public ?string $fibtype = null;
+    public ?string $rows = null;
+    public ?string $maxchars = null;
+    public ?string $columns = null;
+    public ?string $charset = null;
 
     public function setPrompt(string $a_prompt) : void
     {
         switch (strtolower($a_prompt)) {
             case "1":
             case "box":
-                $this->prompt = PROMPT_BOX;
+                $this->prompt = self::PROMPT_BOX;
                 break;
             case "2":
             case "dashline":
-                $this->prompt = PROMPT_DASHLINE;
+                $this->prompt = self::PROMPT_DASHLINE;
                 break;
             case "3":
             case "asterisk":
-                $this->prompt = PROMPT_ASTERISK;
+                $this->prompt = self::PROMPT_ASTERISK;
                 break;
             case "4":
             case "underline":
-                $this->prompt = PROMPT_UNDERLINE;
+                $this->prompt = self::PROMPT_UNDERLINE;
                 break;
         }
     }
@@ -102,19 +83,19 @@ class ilQTIRenderFib
         switch (strtolower($a_fibtype)) {
             case "1":
             case "string":
-                $this->fibtype = FIBTYPE_STRING;
+                $this->fibtype = self::FIBTYPE_STRING;
                 break;
             case "2":
             case "integer":
-                $this->fibtype = FIBTYPE_INTEGER;
+                $this->fibtype = self::FIBTYPE_INTEGER;
                 break;
             case "3":
             case "decimal":
-                $this->fibtype = FIBTYPE_DECIMAL;
+                $this->fibtype = self::FIBTYPE_DECIMAL;
                 break;
             case "4":
             case "scientific":
-                $this->fibtype = FIBTYPE_SCIENTIFIC;
+                $this->fibtype = self::FIBTYPE_SCIENTIFIC;
                 break;
         }
     }

--- a/Services/QTI/classes/class.ilQTIRenderHotspot.php
+++ b/Services/QTI/classes/class.ilQTIRenderHotspot.php
@@ -1,28 +1,21 @@
-<?php
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+<?php declare(strict_types=1);
 
-const SHOWDRAW_NO = "1";
-const SHOWDRAW_YES = "2";
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
 * QTI render hotspot class
@@ -34,33 +27,27 @@ const SHOWDRAW_YES = "2";
 */
 class ilQTIRenderHotspot
 {
-    public string $showdraw;
-    public ?string $minnumber;
-    public ?string $maxnumber;
-    /** @var ilQTIResponseLabel[] */
-    public array $response_labels;
-    /** @var ilQTIMaterial[] */
-    public array $material;
+    public const SHOWDRAW_NO = "1";
+    public const SHOWDRAW_YES = "2";
 
-    public function __construct()
-    {
-        $this->showdraw = SHOWDRAW_NO;
-        $this->minnumber = null;
-        $this->maxnumber = null;
-        $this->response_labels = [];
-        $this->material = [];
-    }
+    public string $showdraw = self::SHOWDRAW_NO;
+    public ?string $minnumber = null;
+    public ?string $maxnumber = null;
+    /** @var ilQTIResponseLabel[] */
+    public array $response_labels = [];
+    /** @var ilQTIMaterial[] */
+    public array $material = [];
 
     public function setShowdraw(string $a_showdraw) : void
     {
         switch (strtolower($a_showdraw)) {
             case "1":
             case "no":
-                $this->showdraw = SHOWDRAW_NO;
+                $this->showdraw = self::SHOWDRAW_NO;
                 break;
             case "2":
             case "yes":
-                $this->showdraw = SHOWDRAW_YES;
+                $this->showdraw = self::SHOWDRAW_YES;
                 break;
         }
     }

--- a/Services/QTI/classes/class.ilQTIRespcondition.php
+++ b/Services/QTI/classes/class.ilQTIRespcondition.php
@@ -1,28 +1,21 @@
-<?php
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+<?php declare(strict_types=1);
 
-const CONTINUE_YES = "1";
-const CONTINUE_NO = "2";
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
 * QTI respcondition class
@@ -34,35 +27,28 @@ const CONTINUE_NO = "2";
 */
 class ilQTIRespcondition
 {
-    public ?string $continue;
-    public ?string $title;
-    public ?string $comment;
-    public ?ilQTIConditionvar $conditionvar;
+    public const CONTINUE_YES = "1";
+    public const CONTINUE_NO = "2";
+
+    public ?string $continue = null;
+    public ?string $title = null;
+    public ?string $comment = null;
+    public ?ilQTIConditionvar $conditionvar = null;
     /** @var ilQTISetvar[] */
-    public array $setvar;
+    public array $setvar = [];
     /** @var ilQTIDisplayfeedback[] */
-    public array $displayfeedback;
-    
-    public function __construct()
-    {
-        $this->continue = null;
-        $this->title = null;
-        $this->comment = null;
-        $this->conditionvar = null;
-        $this->setvar = [];
-        $this->displayfeedback = [];
-    }
+    public array $displayfeedback = [];
 
     public function setContinue(string $a_continue) : void
     {
         switch (strtolower($a_continue)) {
             case "1":
             case "yes":
-                $this->continue = CONTINUE_YES;
+                $this->continue = self::CONTINUE_YES;
                 break;
             case "2":
             case "no":
-                $this->continue = CONTINUE_NO;
+                $this->continue = self::CONTINUE_NO;
                 break;
         }
     }

--- a/Services/QTI/classes/class.ilQTIResponse.php
+++ b/Services/QTI/classes/class.ilQTIResponse.php
@@ -1,42 +1,21 @@
-<?php
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
-const RT_RESPONSE_LID = "1";
-const RT_RESPONSE_XY = "2";
-const RT_RESPONSE_STR = "3";
-const RT_RESPONSE_NUM = "4";
-const RT_RESPONSE_GRP = "5";
-const RT_RESPONSE_EXTENSION = "6";
+<?php declare(strict_types=1);
 
-const R_CARDINALITY_SINGLE = "1";
-const R_CARDINALITY_MULTIPLE = "2";
-const R_CARDINALITY_ORDERED = "3";
-
-const RTIMING_NO = "1";
-const RTIMING_YES = "2";
-
-const NUMTYPE_INTEGER = "1";
-const NUMTYPE_DECIMAL = "2";
-const NUMTYPE_SCIENTIFIC = "3";
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
     
 /**
 * QTI response class
@@ -48,35 +27,44 @@ const NUMTYPE_SCIENTIFIC = "3";
 */
 class ilQTIResponse
 {
-    public int $flow;
+    public const RT_RESPONSE_LID = "1";
+    public const RT_RESPONSE_XY = "2";
+    public const RT_RESPONSE_STR = "3";
+    public const RT_RESPONSE_NUM = "4";
+    public const RT_RESPONSE_GRP = "5";
+
+    public const R_CARDINALITY_SINGLE = "1";
+    public const R_CARDINALITY_MULTIPLE = "2";
+    public const R_CARDINALITY_ORDERED = "3";
+
+    public const RTIMING_NO = "1";
+    public const RTIMING_YES = "2";
+
+    public const NUMTYPE_INTEGER = "1";
+    public const NUMTYPE_DECIMAL = "2";
+    public const NUMTYPE_SCIENTIFIC = "3";
+
+    public int $flow = 0;
     /** @var int|string */
     public $response_type;
-    public ?string $ident;
-    public ?string $rcardinality;
+    public ?string $ident = null;
+    public ?string $rcardinality = null;
 
     /**
      * @var ilQTIRenderChoice|ilQTIRenderHotspot|ilQTIRenderFib|null
      */
-    public $render_type;
-    public ?ilQTIMaterial $material1;
-    public ?ilQTIMaterial $material2;
-    public ?string $rtiming;
-    public ?string $numtype;
+    public $render_type = null;
+    public ?ilQTIMaterial $material1 = null;
+    public ?ilQTIMaterial $material2 = null;
+    public ?string $rtiming = null;
+    public ?string $numtype = null;
 
     /**
      * @param string|int $a_response_type
      */
     public function __construct($a_response_type = 0)
     {
-        $this->flow = 0;
-        $this->render_type = null;
         $this->response_type = $a_response_type;
-        $this->ident = null;
-        $this->rcardinality = null;
-        $this->material1 = null;
-        $this->material2 = null;
-        $this->rtiming = null;
-        $this->numtype = null;
     }
 
     /**
@@ -110,15 +98,15 @@ class ilQTIResponse
         switch (strtolower($a_rcardinality)) {
             case "single":
             case "1":
-                $this->rcardinality = R_CARDINALITY_SINGLE;
+                $this->rcardinality = self::R_CARDINALITY_SINGLE;
                 break;
             case "multiple":
             case "2":
-                $this->rcardinality = R_CARDINALITY_MULTIPLE;
+                $this->rcardinality = self::R_CARDINALITY_MULTIPLE;
                 break;
             case "ordered":
             case "3":
-                $this->rcardinality = R_CARDINALITY_ORDERED;
+                $this->rcardinality = self::R_CARDINALITY_ORDERED;
                 break;
         }
     }
@@ -133,11 +121,11 @@ class ilQTIResponse
         switch (strtolower($a_rtiming)) {
             case "no":
             case "1":
-                $this->rtiming = RTIMING_NO;
+                $this->rtiming = self::RTIMING_NO;
                 break;
             case "yes":
             case "2":
-                $this->rtiming = RTIMING_YES;
+                $this->rtiming = self::RTIMING_YES;
                 break;
         }
     }
@@ -152,15 +140,15 @@ class ilQTIResponse
         switch (strtolower($a_numtype)) {
             case "integer":
             case "1":
-                $this->numtype = NUMTYPE_INTEGER;
+                $this->numtype = self::NUMTYPE_INTEGER;
                 break;
             case "decimal":
             case "2":
-                $this->numtype = NUMTYPE_DECIMAL;
+                $this->numtype = self::NUMTYPE_DECIMAL;
                 break;
             case "scientific":
             case "3":
-                $this->numtype = NUMTYPE_SCIENTIFIC;
+                $this->numtype = self::NUMTYPE_SCIENTIFIC;
                 break;
         }
     }

--- a/Services/QTI/classes/class.ilQTIResponseLabel.php
+++ b/Services/QTI/classes/class.ilQTIResponseLabel.php
@@ -1,35 +1,21 @@
-<?php
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+<?php declare(strict_types=1);
 
-const RSHUFFLE_NO = "1";
-const RSHUFFLE_YES = "2";
-
-const RAREA_ELLIPSE = "1";
-const RAREA_RECTANGLE = "2";
-const RAREA_BOUNDED = "3";
-
-const RRANGE_EXACT = "1";
-const RRANGE_RANGE = "2";
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
 * QTI response label class
@@ -41,43 +27,39 @@ const RRANGE_RANGE = "2";
 */
 class ilQTIResponseLabel
 {
-    public ?string $rshuffle;
-    public ?string $rarea;
-    public ?string $rrange;
-    public ?string $labelrefid;
-    public ?string $ident;
-    public ?string $match_group;
-    public ?string $match_max;
-    /** @var ilQTIMaterial[] */
-    public array $material;
-    /** @var ilQTIFlowMat[] */
-    public array $flow_mat;
-    public ?string $content;
+    public const RSHUFFLE_NO = "1";
+    public const RSHUFFLE_YES = "2";
 
-    public function __construct()
-    {
-        $this->rshuffle = null;
-        $this->rarea = null;
-        $this->rrange = null;
-        $this->labelrefid = null;
-        $this->ident = null;
-        $this->match_group = null;
-        $this->match_max = null;
-        $this->material = [];
-        $this->flow_mat = [];
-        $this->content = null;
-    }
+    public const RAREA_ELLIPSE = "1";
+    public const RAREA_RECTANGLE = "2";
+    public const RAREA_BOUNDED = "3";
+
+    public const RRANGE_EXACT = "1";
+    public const RRANGE_RANGE = "2";
+
+    public ?string $rshuffle = null;
+    public ?string $rarea = null;
+    public ?string $rrange = null;
+    public ?string $labelrefid = null;
+    public ?string $ident = null;
+    public ?string $match_group = null;
+    public ?string $match_max = null;
+    /** @var ilQTIMaterial[] */
+    public array $material = [];
+    /** @var ilQTIFlowMat[] */
+    public array $flow_mat = [];
+    public ?string $content = null;
 
     public function setRshuffle(string $a_rshuffle) : void
     {
         switch (strtolower($a_rshuffle)) {
             case "1":
             case "no":
-                $this->rshuffle = RSHUFFLE_NO;
+                $this->rshuffle = self::RSHUFFLE_NO;
                 break;
             case "2":
             case "yes":
-                $this->rshuffle = RSHUFFLE_YES;
+                $this->rshuffle = self::RSHUFFLE_YES;
                 break;
         }
     }
@@ -92,15 +74,15 @@ class ilQTIResponseLabel
         switch (strtolower($a_rarea)) {
             case "1":
             case "ellipse":
-                $this->rarea = RAREA_ELLIPSE;
+                $this->rarea = self::RAREA_ELLIPSE;
                 break;
             case "2":
             case "rectangle":
-                $this->rarea = RAREA_RECTANGLE;
+                $this->rarea = self::RAREA_RECTANGLE;
                 break;
             case "3":
             case "bounded":
-                $this->rarea = RAREA_BOUNDED;
+                $this->rarea = self::RAREA_BOUNDED;
                 break;
         }
     }
@@ -115,11 +97,11 @@ class ilQTIResponseLabel
         switch (strtolower($a_rrange)) {
             case "1":
             case "excact":
-                $this->rrange = RRANGE_EXACT;
+                $this->rrange = self::RRANGE_EXACT;
                 break;
             case "2":
             case "range":
-                $this->rrange = RRANGE_RANGE;
+                $this->rrange = self::RRANGE_RANGE;
                 break;
         }
     }

--- a/Services/QTI/classes/class.ilQTIResponseVar.php
+++ b/Services/QTI/classes/class.ilQTIResponseVar.php
@@ -1,44 +1,21 @@
-<?php
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+<?php declare(strict_types=1);
 
-const RESPONSEVAR_EQUAL = "1";
-const RESPONSEVAR_LT = "2";
-const RESPONSEVAR_LTE = "3";
-const RESPONSEVAR_GT = "4";
-const RESPONSEVAR_GTE = "5";
-const RESPONSEVAR_SUBSET = "6";
-const RESPONSEVAR_INSIDE = "7";
-const RESPONSEVAR_SUBSTRING = "8";
-
-const CASE_YES = "1";
-const CASE_NO = "2";
-
-const SETMATCH_PARTIAL = "1";
-const SETMATCH_EXACT = "2";
-
-const AREATYPE_ELLIPSE = "1";
-const AREATYPE_RECTANGLE = "2";
-const AREATYPE_BOUNDED = "3";
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
 * QTI response variable class
@@ -50,23 +27,36 @@ const AREATYPE_BOUNDED = "3";
 */
 class ilQTIResponseVar
 {
-    public ?string $vartype;
-    public ?string $case;
-    public ?string $respident;
-    public ?string $index;
-    public ?string $setmatch;
-    public ?string $areatype;
-    public ?string $content;
+    public const RESPONSEVAR_EQUAL = "1";
+    public const RESPONSEVAR_LT = "2";
+    public const RESPONSEVAR_LTE = "3";
+    public const RESPONSEVAR_GT = "4";
+    public const RESPONSEVAR_GTE = "5";
+    public const RESPONSEVAR_SUBSET = "6";
+    public const RESPONSEVAR_INSIDE = "7";
+    public const RESPONSEVAR_SUBSTRING = "8";
+
+    public const CASE_YES = "1";
+    public const CASE_NO = "2";
+
+    public const SETMATCH_PARTIAL = "1";
+    public const SETMATCH_EXACT = "2";
+
+    public const AREATYPE_ELLIPSE = "1";
+    public const AREATYPE_RECTANGLE = "2";
+    public const AREATYPE_BOUNDED = "3";
+
+    public ?string $vartype = null;
+    public ?string $case = null;
+    public ?string $respident = null;
+    public ?string $index = null;
+    public ?string $setmatch = null;
+    public ?string $areatype = null;
+    public ?string $content = null;
     
     public function __construct(string $a_vartype)
     {
         $this->setVartype($a_vartype);
-        $this->case = null;
-        $this->respident = null;
-        $this->index = null;
-        $this->setmatch = null;
-        $this->areatype = null;
-        $this->content = null;
     }
 
     public function setVartype(string $a_vartype) : void
@@ -84,11 +74,11 @@ class ilQTIResponseVar
         switch (strtolower($a_case)) {
             case "1":
             case "yes":
-                $this->case = CASE_YES;
+                $this->case = self::CASE_YES;
                 break;
             case "2":
             case "no":
-                $this->case = CASE_NO;
+                $this->case = self::CASE_NO;
                 break;
         }
     }
@@ -123,11 +113,11 @@ class ilQTIResponseVar
         switch (strtolower($a_setmatch)) {
             case "1":
             case "partial":
-                $this->setmatch = SETMATCH_PARTIAL;
+                $this->setmatch = self::SETMATCH_PARTIAL;
                 break;
             case "2":
             case "exact":
-                $this->setmatch = SETMATCH_EXACT;
+                $this->setmatch = self::SETMATCH_EXACT;
                 break;
         }
     }
@@ -142,15 +132,15 @@ class ilQTIResponseVar
         switch (strtolower($a_areatype)) {
             case "1":
             case "ellipse":
-                $this->areatype = AREATYPE_ELLIPSE;
+                $this->areatype = self::AREATYPE_ELLIPSE;
                 break;
             case "2":
             case "rectangle":
-                $this->areatype = AREATYPE_RECTANGLE;
+                $this->areatype = self::AREATYPE_RECTANGLE;
                 break;
             case "3":
             case "bounded":
-                $this->areatype = AREATYPE_BOUNDED;
+                $this->areatype = self::AREATYPE_BOUNDED;
                 break;
         }
     }

--- a/Services/QTI/classes/class.ilQTIResprocessing.php
+++ b/Services/QTI/classes/class.ilQTIResprocessing.php
@@ -1,25 +1,21 @@
-<?php
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
 * QTI resprocessing class
@@ -31,21 +27,11 @@
 */
 class ilQTIResprocessing
 {
-    public ?string $comment;
-    public ?ilQTIOutcomes $outcomes;
+    public ?string $comment = null;
+    public ?ilQTIOutcomes $outcomes = null;
     /** @var ilQTIRespcondition[] */
-    public array $respcondition;
-    public array $itemproc_extension;
-    public ?string $scoremodel;
-    
-    public function __construct()
-    {
-        $this->comment = null;
-        $this->outcomes = null;
-        $this->respcondition = [];
-        $this->itemproc_extension = [];
-        $this->scoremodel = null;
-    }
+    public array $respcondition = [];
+    public ?string $scoremodel = null;
 
     public function setComment(string $a_comment) : void
     {

--- a/Services/QTI/classes/class.ilQTISection.php
+++ b/Services/QTI/classes/class.ilQTISection.php
@@ -1,25 +1,21 @@
-<?php
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
 * QTI section class
@@ -31,23 +27,13 @@
 */
 class ilQTISection
 {
-    public ?string $ident;
-    public ?string $title;
-    public ?string $xmllang;
-    public ?string $comment;
+    public ?string $ident = null;
+    public ?string $title = null;
+    public ?string $xmllang = null;
+    public ?string $comment = null;
     /** @var null|array{h: string, m: string, s: string} */
-    public ?array $duration;
-    public ?ilQTIPresentationMaterial $presentation_material;
-
-    public function __construct()
-    {
-        $this->ident = null;
-        $this->title = null;
-        $this->xmllang = null;
-        $this->comment = null;
-        $this->duration = null;
-        $this->presentation_material = null;
-    }
+    public ?array $duration = null;
+    public ?ilQTIPresentationMaterial $presentation_material = null;
 
     public function setIdent(string $a_ident) : void
     {

--- a/Services/QTI/classes/class.ilQTISetvar.php
+++ b/Services/QTI/classes/class.ilQTISetvar.php
@@ -1,31 +1,21 @@
-<?php
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+<?php declare(strict_types=1);
 
-const ACTION_SET = "1";
-const ACTION_ADD = "2";
-const ACTION_SUBTRACT = "3";
-const ACTION_MULTIPLY = "4";
-const ACTION_DIVIDE = "5";
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
 * QTI setvar class
@@ -37,16 +27,15 @@ const ACTION_DIVIDE = "5";
 */
 class ilQTISetvar
 {
-    public ?string $varname;
-    public ?string $action;
-    public ?string $content;
+    public const ACTION_SET = "1";
+    public const ACTION_ADD = "2";
+    public const ACTION_SUBTRACT = "3";
+    public const ACTION_MULTIPLY = "4";
+    public const ACTION_DIVIDE = "5";
 
-    public function __construct()
-    {
-        $this->varname = null;
-        $this->action = null;
-        $this->content = null;
-    }
+    public ?string $varname = null;
+    public ?string $action = null;
+    public ?string $content = null;
 
     public function setVarname(string $a_varname) : void
     {
@@ -63,23 +52,23 @@ class ilQTISetvar
         switch (strtolower($a_action)) {
             case "set":
             case "1":
-                $this->action = ACTION_SET;
+                $this->action = self::ACTION_SET;
                 break;
             case "add":
             case "2":
-                $this->action = ACTION_ADD;
+                $this->action = self::ACTION_ADD;
                 break;
             case "subtract":
             case "3":
-                $this->action = ACTION_SUBTRACT;
+                $this->action = self::ACTION_SUBTRACT;
                 break;
             case "multiply":
             case "4":
-                $this->action = ACTION_MULTIPLY;
+                $this->action = self::ACTION_MULTIPLY;
                 break;
             case "divide":
             case "5":
-                $this->action = ACTION_DIVIDE;
+                $this->action = self::ACTION_DIVIDE;
                 break;
         }
     }

--- a/Services/QTI/classes/class.ilQtiMatImageSecurity.php
+++ b/Services/QTI/classes/class.ilQtiMatImageSecurity.php
@@ -1,8 +1,21 @@
-<?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
-require_once 'Modules/TestQuestionPool/classes/class.assQuestion.php';
-require_once 'Services/QTI/exceptions/class.ilQtiException.php';
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
  * @author        Björn Heyser <bheyser@databay.de>
@@ -13,7 +26,7 @@ require_once 'Services/QTI/exceptions/class.ilQtiException.php';
 class ilQtiMatImageSecurity
 {
     protected ilQTIMatimage $imageMaterial;
-    protected string $detectedMimeType;
+    protected string $detectedMimeType = "";
     
     public function __construct(ilQTIMatimage $imageMaterial)
     {

--- a/Services/QTI/exceptions/class.ilQtiException.php
+++ b/Services/QTI/exceptions/class.ilQtiException.php
@@ -1,7 +1,21 @@
-<?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
-require_once 'Services/Exceptions/classes/class.ilException.php';
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
  * @author        Björn Heyser <bheyser@databay.de>

--- a/Services/QTI/interfaces/interface.ilQTIFlowMatAware.php
+++ b/Services/QTI/interfaces/interface.ilQTIFlowMatAware.php
@@ -1,5 +1,21 @@
-<?php
-/* Copyright (c) 1998-2014 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
  * Interface ilQTIMaterialAware

--- a/Services/QTI/interfaces/interface.ilQTIMaterialAware.php
+++ b/Services/QTI/interfaces/interface.ilQTIMaterialAware.php
@@ -1,5 +1,21 @@
-<?php
-/* Copyright (c) 1998-2014 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
  * Interface ilQTIMaterialAware

--- a/Services/QTI/interfaces/interface.ilQTIPresentationMaterialAware.php
+++ b/Services/QTI/interfaces/interface.ilQTIPresentationMaterialAware.php
@@ -1,5 +1,21 @@
-<?php
-/* Copyright (c) 1998-2014 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
  * Interface ilQTIPresentationMaterialAware

--- a/Services/QTI/test/ilQTIAssessmentTest.php
+++ b/Services/QTI/test/ilQTIAssessmentTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQTIAssessmentTest extends TestCase

--- a/Services/QTI/test/ilQTIAssessmentcontrolTest.php
+++ b/Services/QTI/test/ilQTIAssessmentcontrolTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQTIAssessmentcontrolTest extends TestCase

--- a/Services/QTI/test/ilQTIConditionvarTest.php
+++ b/Services/QTI/test/ilQTIConditionvarTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQTIConditionvarTest extends TestCase

--- a/Services/QTI/test/ilQTIDecvarTest.php
+++ b/Services/QTI/test/ilQTIDecvarTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQTIDecvarTest extends TestCase
@@ -72,20 +89,20 @@ class ilQTIDecvarTest extends TestCase
     {
         class_exists(ilQTIDecvar::class); // Force autoload to define the constants.
         return [
-            ['integer', VARTYPE_INTEGER],
-            ['1', VARTYPE_INTEGER],
-            ['string', VARTYPE_STRING],
-            ['2', VARTYPE_STRING],
-            ['decimal', VARTYPE_DECIMAL],
-            ['3', VARTYPE_DECIMAL],
-            ['scientific', VARTYPE_SCIENTIFIC],
-            ['4', VARTYPE_SCIENTIFIC],
-            ['boolean', VARTYPE_BOOLEAN],
-            ['5', VARTYPE_BOOLEAN],
-            ['enumerated', VARTYPE_ENUMERATED],
-            ['6', VARTYPE_ENUMERATED],
-            ['set', VARTYPE_SET],
-            ['7', VARTYPE_SET],
+            ['integer', ilQTIDecvar::VARTYPE_INTEGER],
+            ['1', ilQTIDecvar::VARTYPE_INTEGER],
+            ['string', ilQTIDecvar::VARTYPE_STRING],
+            ['2', ilQTIDecvar::VARTYPE_STRING],
+            ['decimal', ilQTIDecvar::VARTYPE_DECIMAL],
+            ['3', ilQTIDecvar::VARTYPE_DECIMAL],
+            ['scientific', ilQTIDecvar::VARTYPE_SCIENTIFIC],
+            ['4', ilQTIDecvar::VARTYPE_SCIENTIFIC],
+            ['boolean', ilQTIDecvar::VARTYPE_BOOLEAN],
+            ['5', ilQTIDecvar::VARTYPE_BOOLEAN],
+            ['enumerated', ilQTIDecvar::VARTYPE_ENUMERATED],
+            ['6', ilQTIDecvar::VARTYPE_ENUMERATED],
+            ['set', ilQTIDecvar::VARTYPE_SET],
+            ['7', ilQTIDecvar::VARTYPE_SET],
             ['8', null],
             ['', null],
             ['Some random input.', null],

--- a/Services/QTI/test/ilQTIDisplayfeedbackTest.php
+++ b/Services/QTI/test/ilQTIDisplayfeedbackTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQTIDisplayfeedbackTest extends TestCase

--- a/Services/QTI/test/ilQTIFlowMatTest.php
+++ b/Services/QTI/test/ilQTIFlowMatTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQTIFlowMatTest extends TestCase

--- a/Services/QTI/test/ilQTIItemTest.php
+++ b/Services/QTI/test/ilQTIItemTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQTIItemTest extends TestCase

--- a/Services/QTI/test/ilQTIItemfeedbackTest.php
+++ b/Services/QTI/test/ilQTIItemfeedbackTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQTIItemfeedbackTest extends TestCase
@@ -38,26 +55,26 @@ class ilQTIItemfeedbackTest extends TestCase
     {
         class_exists(ilQTIItemfeedback::class); // Force autoload to define the constants.
         return [
-            ['1', VIEW_ALL],
-            ['all', VIEW_ALL],
-            ['2', VIEW_ADMINISTRATOR],
-            ['administrator', VIEW_ADMINISTRATOR],
-            ['3', VIEW_ADMINAUTHORITY],
-            ['adminauthority', VIEW_ADMINAUTHORITY],
-            ['4', VIEW_ASSESSOR],
-            ['assessor', VIEW_ASSESSOR],
-            ['5', VIEW_AUTHOR],
-            ['author', VIEW_AUTHOR],
-            ['6', VIEW_CANDIDATE],
-            ['candidate', VIEW_CANDIDATE],
-            ['7', VIEW_INVIGILATORPROCTOR],
-            ['invigilatorproctor', VIEW_INVIGILATORPROCTOR],
-            ['8', VIEW_PSYCHOMETRICIAN],
-            ['psychometrician', VIEW_PSYCHOMETRICIAN],
-            ['9', VIEW_SCORER],
-            ['scorer', VIEW_SCORER],
-            ['10', VIEW_TUTOR],
-            ['tutor', VIEW_TUTOR],
+            ['1', ilQTIItemfeedback::VIEW_ALL],
+            ['all', ilQTIItemfeedback::VIEW_ALL],
+            ['2', ilQTIItemfeedback::VIEW_ADMINISTRATOR],
+            ['administrator', ilQTIItemfeedback::VIEW_ADMINISTRATOR],
+            ['3', ilQTIItemfeedback::VIEW_ADMINAUTHORITY],
+            ['adminauthority', ilQTIItemfeedback::VIEW_ADMINAUTHORITY],
+            ['4', ilQTIItemfeedback::VIEW_ASSESSOR],
+            ['assessor', ilQTIItemfeedback::VIEW_ASSESSOR],
+            ['5', ilQTIItemfeedback::VIEW_AUTHOR],
+            ['author', ilQTIItemfeedback::VIEW_AUTHOR],
+            ['6', ilQTIItemfeedback::VIEW_CANDIDATE],
+            ['candidate', ilQTIItemfeedback::VIEW_CANDIDATE],
+            ['7', ilQTIItemfeedback::VIEW_INVIGILATORPROCTOR],
+            ['invigilatorproctor', ilQTIItemfeedback::VIEW_INVIGILATORPROCTOR],
+            ['8', ilQTIItemfeedback::VIEW_PSYCHOMETRICIAN],
+            ['psychometrician', ilQTIItemfeedback::VIEW_PSYCHOMETRICIAN],
+            ['9', ilQTIItemfeedback::VIEW_SCORER],
+            ['scorer', ilQTIItemfeedback::VIEW_SCORER],
+            ['10', ilQTIItemfeedback::VIEW_TUTOR],
+            ['tutor', ilQTIItemfeedback::VIEW_TUTOR],
             ['11', null],
             ['Random input.', null],
         ];

--- a/Services/QTI/test/ilQTIMatappletTest.php
+++ b/Services/QTI/test/ilQTIMatappletTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQTIMatappletTest extends TestCase

--- a/Services/QTI/test/ilQTIMaterialTest.php
+++ b/Services/QTI/test/ilQTIMaterialTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQTIMaterialTest extends TestCase

--- a/Services/QTI/test/ilQTIMatimageTest.php
+++ b/Services/QTI/test/ilQTIMatimageTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQTIMatimageTest extends TestCase

--- a/Services/QTI/test/ilQTIMattextTest.php
+++ b/Services/QTI/test/ilQTIMattextTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQTIMattextTest extends TestCase
@@ -100,10 +117,10 @@ class ilQTIMattextTest extends TestCase
     {
         class_exists(ilQTIMattext::class); // Force autoload to define the constants.
         return [
-            ['preserve', SPACE_PRESERVE],
-            [ '1', SPACE_PRESERVE],
-            ['default', SPACE_DEFAULT],
-            ['2', SPACE_DEFAULT],
+            ['preserve', ilQTIMattext::SPACE_PRESERVE],
+            [ '1', ilQTIMattext::SPACE_PRESERVE],
+            ['default', ilQTIMattext::SPACE_DEFAULT],
+            ['2', ilQTIMattext::SPACE_DEFAULT],
             ['Random input', null],
         ];
     }

--- a/Services/QTI/test/ilQTIObjectivesTest.php
+++ b/Services/QTI/test/ilQTIObjectivesTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQTIObjectivesTest extends TestCase

--- a/Services/QTI/test/ilQTIOutcomesTest.php
+++ b/Services/QTI/test/ilQTIOutcomesTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQTIOutcomesTest extends TestCase

--- a/Services/QTI/test/ilQTIParserTest.php
+++ b/Services/QTI/test/ilQTIParserTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use ILIAS\DI\Container;
 use PHPUnit\Framework\TestCase;
 

--- a/Services/QTI/test/ilQTIPresentationMaterialTest.php
+++ b/Services/QTI/test/ilQTIPresentationMaterialTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQTIPresentationMaterialTest extends TestCase

--- a/Services/QTI/test/ilQTIPresentationTest.php
+++ b/Services/QTI/test/ilQTIPresentationTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQTIPresentationTest extends TestCase

--- a/Services/QTI/test/ilQTIRenderChoiceTest.php
+++ b/Services/QTI/test/ilQTIRenderChoiceTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQTIRenderChoiceTest extends TestCase

--- a/Services/QTI/test/ilQTIRenderFibTest.php
+++ b/Services/QTI/test/ilQTIRenderFibTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQTIRenderFibTest extends TestCase
@@ -75,14 +92,14 @@ class ilQTIRenderFibTest extends TestCase
     {
         class_exists(ilQTIRenderFib::class); // Force autoload to define the constants.
         return [
-            ['1', PROMPT_BOX],
-            ['box', PROMPT_BOX],
-            ['2', PROMPT_DASHLINE],
-            ['dashline', PROMPT_DASHLINE],
-            ['3', PROMPT_ASTERISK],
-            ['asterisk', PROMPT_ASTERISK],
-            ['4', PROMPT_UNDERLINE],
-            ['underline', PROMPT_UNDERLINE],
+            ['1', ilQTIRenderFib::PROMPT_BOX],
+            ['box', ilQTIRenderFib::PROMPT_BOX],
+            ['2', ilQTIRenderFib::PROMPT_DASHLINE],
+            ['dashline', ilQTIRenderFib::PROMPT_DASHLINE],
+            ['3', ilQTIRenderFib::PROMPT_ASTERISK],
+            ['asterisk', ilQTIRenderFib::PROMPT_ASTERISK],
+            ['4', ilQTIRenderFib::PROMPT_UNDERLINE],
+            ['underline', ilQTIRenderFib::PROMPT_UNDERLINE],
         ];
     }
 
@@ -90,14 +107,14 @@ class ilQTIRenderFibTest extends TestCase
     {
         class_exists(ilQTIRenderFib::class); // Force autoload to define the constants.
         return [
-            ['1', FIBTYPE_STRING],
-            ['string', FIBTYPE_STRING],
-            ['2', FIBTYPE_INTEGER],
-            ['integer', FIBTYPE_INTEGER],
-            ['3', FIBTYPE_DECIMAL],
-            ['decimal', FIBTYPE_DECIMAL],
-            ['4', FIBTYPE_SCIENTIFIC],
-            ['scientific', FIBTYPE_SCIENTIFIC],
+            ['1', ilQTIRenderFib::FIBTYPE_STRING],
+            ['string', ilQTIRenderFib::FIBTYPE_STRING],
+            ['2', ilQTIRenderFib::FIBTYPE_INTEGER],
+            ['integer', ilQTIRenderFib::FIBTYPE_INTEGER],
+            ['3', ilQTIRenderFib::FIBTYPE_DECIMAL],
+            ['decimal', ilQTIRenderFib::FIBTYPE_DECIMAL],
+            ['4', ilQTIRenderFib::FIBTYPE_SCIENTIFIC],
+            ['scientific', ilQTIRenderFib::FIBTYPE_SCIENTIFIC],
         ];
     }
 }

--- a/Services/QTI/test/ilQTIRenderHotspotTest.php
+++ b/Services/QTI/test/ilQTIRenderHotspotTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQTIRenderHotspotTest extends TestCase

--- a/Services/QTI/test/ilQTIRespconditionTest.php
+++ b/Services/QTI/test/ilQTIRespconditionTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQTIRespconditionTest extends TestCase
@@ -37,10 +54,10 @@ class ilQTIRespconditionTest extends TestCase
     {
         class_exists(ilQTIRespcondition::class); // Force autoload to define the constants.
         return [
-            ['1', CONTINUE_YES],
-            ['yes', CONTINUE_YES],
-            ['2', CONTINUE_NO],
-            ['no', CONTINUE_NO],
+            ['1', ilQTIRespcondition::CONTINUE_YES],
+            ['yes', ilQTIRespcondition::CONTINUE_YES],
+            ['2', ilQTIRespcondition::CONTINUE_NO],
+            ['no', ilQTIRespcondition::CONTINUE_NO],
             ['Random input', null],
         ];
     }

--- a/Services/QTI/test/ilQTIResponseLabelTest.php
+++ b/Services/QTI/test/ilQTIResponseLabelTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQTIResponseLabelTest extends TestCase
@@ -79,10 +96,10 @@ class ilQTIResponseLabelTest extends TestCase
         class_exists(ilQTIResponseLabel::class); // Force autoload to define the constants.
 
         return [
-            ['1', RSHUFFLE_NO],
-            ['no', RSHUFFLE_NO],
-            ['2', RSHUFFLE_YES],
-            ['yes', RSHUFFLE_YES],
+            ['1', ilQTIResponseLabel::RSHUFFLE_NO],
+            ['no', ilQTIResponseLabel::RSHUFFLE_NO],
+            ['2', ilQTIResponseLabel::RSHUFFLE_YES],
+            ['yes', ilQTIResponseLabel::RSHUFFLE_YES],
             ['Random input', null],
         ];
     }
@@ -91,12 +108,12 @@ class ilQTIResponseLabelTest extends TestCase
     {
         class_exists(ilQTIResponseLabel::class); // Force autoload to define the constants.
         return [
-            ['1', RAREA_ELLIPSE],
-            ['ellipse', RAREA_ELLIPSE],
-            ['2', RAREA_RECTANGLE],
-            ['rectangle', RAREA_RECTANGLE],
-            ['3', RAREA_BOUNDED],
-            ['bounded', RAREA_BOUNDED],
+            ['1', ilQTIResponseLabel::RAREA_ELLIPSE],
+            ['ellipse', ilQTIResponseLabel::RAREA_ELLIPSE],
+            ['2', ilQTIResponseLabel::RAREA_RECTANGLE],
+            ['rectangle', ilQTIResponseLabel::RAREA_RECTANGLE],
+            ['3', ilQTIResponseLabel::RAREA_BOUNDED],
+            ['bounded', ilQTIResponseLabel::RAREA_BOUNDED],
             ['Random input', null],
         ];
     }
@@ -105,10 +122,10 @@ class ilQTIResponseLabelTest extends TestCase
     {
         class_exists(ilQTIResponseLabel::class); // Force autoload to define the constants.
         return [
-            ['1', RRANGE_EXACT],
-            ['excact', RRANGE_EXACT],
-            ['2', RRANGE_RANGE],
-            ['range', RRANGE_RANGE],
+            ['1', ilQTIResponseLabel::RRANGE_EXACT],
+            ['excact', ilQTIResponseLabel::RRANGE_EXACT],
+            ['2', ilQTIResponseLabel::RRANGE_RANGE],
+            ['range', ilQTIResponseLabel::RRANGE_RANGE],
         ];
     }
 }

--- a/Services/QTI/test/ilQTIResponseTest.php
+++ b/Services/QTI/test/ilQTIResponseTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQTIResponseTest extends TestCase
@@ -41,10 +58,10 @@ class ilQTIResponseTest extends TestCase
         class_exists(ilQTIResponse::class); // Force autoload to define the constants.
 
         return [
-            ['no', RTIMING_NO],
-            ['1', RTIMING_NO],
-            ['yes', RTIMING_YES],
-            ['2', RTIMING_YES],
+            ['no', ilQTIResponse::RTIMING_NO],
+            ['1', ilQTIResponse::RTIMING_NO],
+            ['yes', ilQTIResponse::RTIMING_YES],
+            ['2', ilQTIResponse::RTIMING_YES],
             ['Random input.', null],
         ];
     }
@@ -53,12 +70,12 @@ class ilQTIResponseTest extends TestCase
     {
         class_exists(ilQTIResponse::class); // Force autoload to define the constants.
         return [
-            ['integer', NUMTYPE_INTEGER],
-            ['1', NUMTYPE_INTEGER],
-            ['decimal', NUMTYPE_DECIMAL],
-            ['2', NUMTYPE_DECIMAL],
-            ['scientific', NUMTYPE_SCIENTIFIC],
-            ['3', NUMTYPE_SCIENTIFIC],
+            ['integer', ilQTIResponse::NUMTYPE_INTEGER],
+            ['1', ilQTIResponse::NUMTYPE_INTEGER],
+            ['decimal', ilQTIResponse::NUMTYPE_DECIMAL],
+            ['2', ilQTIResponse::NUMTYPE_DECIMAL],
+            ['scientific', ilQTIResponse::NUMTYPE_SCIENTIFIC],
+            ['3', ilQTIResponse::NUMTYPE_SCIENTIFIC],
             ['Random input.', null],
         ];
     }

--- a/Services/QTI/test/ilQTIResponseVarTest.php
+++ b/Services/QTI/test/ilQTIResponseVarTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQTIResponseVarTest extends TestCase
@@ -71,10 +88,10 @@ class ilQTIResponseVarTest extends TestCase
     {
         class_exists(ilQTIResponseVar::class); // Force autoload to define the constants.
         return [
-            ['1', CASE_YES],
-            ['yes', CASE_YES],
-            ['2', CASE_NO],
-            ['no', CASE_NO],
+            ['1', ilQTIResponseVar::CASE_YES],
+            ['yes', ilQTIResponseVar::CASE_YES],
+            ['2', ilQTIResponseVar::CASE_NO],
+            ['no', ilQTIResponseVar::CASE_NO],
         ];
     }
 
@@ -82,10 +99,10 @@ class ilQTIResponseVarTest extends TestCase
     {
         class_exists(ilQTIRespcondition::class); // Force autoload to define the constants.
         return [
-            ['1', SETMATCH_PARTIAL],
-            ['partial', SETMATCH_PARTIAL],
-            ['2', SETMATCH_EXACT],
-            ['exact', SETMATCH_EXACT],
+            ['1', ilQTIResponseVar::SETMATCH_PARTIAL],
+            ['partial', ilQTIResponseVar::SETMATCH_PARTIAL],
+            ['2', ilQTIResponseVar::SETMATCH_EXACT],
+            ['exact', ilQTIResponseVar::SETMATCH_EXACT],
         ];
     }
 
@@ -93,12 +110,12 @@ class ilQTIResponseVarTest extends TestCase
     {
         class_exists(ilQTIRespcondition::class); // Force autoload to define the constants.
         return [
-            ['1', AREATYPE_ELLIPSE],
-            ['ellipse', AREATYPE_ELLIPSE],
-            ['2', AREATYPE_RECTANGLE],
-            ['rectangle', AREATYPE_RECTANGLE],
-            ['3', AREATYPE_BOUNDED],
-            ['bounded', AREATYPE_BOUNDED],
+            ['1', ilQTIResponseVar::AREATYPE_ELLIPSE],
+            ['ellipse', ilQTIResponseVar::AREATYPE_ELLIPSE],
+            ['2', ilQTIResponseVar::AREATYPE_RECTANGLE],
+            ['rectangle', ilQTIResponseVar::AREATYPE_RECTANGLE],
+            ['3', ilQTIResponseVar::AREATYPE_BOUNDED],
+            ['bounded', ilQTIResponseVar::AREATYPE_BOUNDED],
         ];
     }
 }

--- a/Services/QTI/test/ilQTIResprocessingTest.php
+++ b/Services/QTI/test/ilQTIResprocessingTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQTIResprocessingTest extends TestCase

--- a/Services/QTI/test/ilQTISectionTest.php
+++ b/Services/QTI/test/ilQTISectionTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQTISectionTest extends TestCase

--- a/Services/QTI/test/ilQTISetvarTest.php
+++ b/Services/QTI/test/ilQTISetvarTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQTISetvarTest extends TestCase
@@ -37,16 +54,16 @@ class ilQTISetvarTest extends TestCase
     {
         class_exists(ilQTISetvar::class); // Force autoload to define the constants.
         return [
-            ['set', ACTION_SET],
-            ['1', ACTION_SET],
-            ['add', ACTION_ADD],
-            ['2', ACTION_ADD],
-            ['subtract', ACTION_SUBTRACT],
-            ['3', ACTION_SUBTRACT],
-            ['multiply', ACTION_MULTIPLY],
-            ['4', ACTION_MULTIPLY],
-            ['divide', ACTION_DIVIDE],
-            ['5', ACTION_DIVIDE],
+            ['set', ilQTISetvar::ACTION_SET],
+            ['1', ilQTISetvar::ACTION_SET],
+            ['add', ilQTISetvar::ACTION_ADD],
+            ['2', ilQTISetvar::ACTION_ADD],
+            ['subtract', ilQTISetvar::ACTION_SUBTRACT],
+            ['3', ilQTISetvar::ACTION_SUBTRACT],
+            ['multiply', ilQTISetvar::ACTION_MULTIPLY],
+            ['4', ilQTISetvar::ACTION_MULTIPLY],
+            ['divide', ilQTISetvar::ACTION_DIVIDE],
+            ['5', ilQTISetvar::ACTION_DIVIDE],
             ['6', null],
             ['Some input.', null],
         ];

--- a/Services/QTI/test/ilQtiMatImageSecurityTest.php
+++ b/Services/QTI/test/ilQtiMatImageSecurityTest.php
@@ -1,5 +1,22 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
 use PHPUnit\Framework\TestCase;
 
 class ilQtiMatImageSecurityTest extends TestCase

--- a/Services/QTI/test/ilServicesQTISuite.php
+++ b/Services/QTI/test/ilServicesQTISuite.php
@@ -1,5 +1,21 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2015 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 use PHPUnit\Framework\TestSuite;
 


### PR DESCRIPTION
Hello @lscharmer , 

I completed the review of the `Services/QTI` component.

Results:

- [x] The code style is `PSR-2 + X` compliant
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] There are no serious `PhpStorm Code Inspection` issues left
- [x] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

I also did some further changes:

- Added the correct license header
- introduced `strict_types` for PHP classes
- moved constants to the related classes and adjusted all occurrences (also in other components)
- moved initialization of variables from constructor to the place they are declared (where possible). IMO, this way is cleaner than the way with the constructor because it reduces complexity / redundancy. And AFAIK, it also prevents the `Typed property must not be accessed before initialization` error
- some more minor fixes / improvements

--

Actions needed:
- [x] Please check my inline comments. You can use `TODO PHP8-REVIEW` when searching for my comments.
- [x] Please check nullable variables: Many variables in this component are nullable. This is no good approach IMO and should only be used rarely, especially for variables with types like `int` or `string`. I would use defaults of the proper type instead, like `$id=0` or `$text=''`. But maybe the nullable variables are due to dependencies in other components, so maybe it would be too risky to make changes here and also too effortful. So see this point more as information.


Greetings
@tfamula