### PR TITLE
#32437: Fix submission of unchecked switchable group

### DIFF
--- a/Services/Dashboard/classes/class.ilDashboardGUI.php
+++ b/Services/Dashboard/classes/class.ilDashboardGUI.php
@@ -135,35 +135,6 @@ class ilDashboardGUI
     {
         global $DIC;
 
-        $form = $DIC->ui()->factory()->input()->container()->form()->standard(
-            $DIC->ctrl()->getFormActionByClass(self::class, 'submit'),
-            [
-                'grp' => $DIC->ui()->factory()->input()->field()->switchableGroup([
-                    'o1' => $DIC->ui()->factory()->input()->field()->group([
-                        't1' => $DIC->ui()->factory()->input()->field()->text('text input 1'),
-                    ]),
-
-                    'o2' => $DIC->ui()->factory()->input()->field()->group([
-                        't2' => $DIC->ui()->factory()->input()->field()->text('text input 2'),
-                    ]),
-                ], 'choose one'),
-            ]
-        );
-
-        if ($DIC->ctrl()->getCmd() === 'submit') {
-            $form = $form->withRequest($DIC->http()->request());
-            $data = $form->getData();
-            $x = 1;
-        }
-
-        $DIC->ui()->mainTemplate()->setContent(
-            $DIC->ui()->renderer()->render($form)
-        );
-
-        $DIC->ui()->mainTemplate()->printToStdout();
-
-        die;
-
         $context = $DIC->globalScreen()->tool()->context();
         $context->stack()->desktop();
 

--- a/Services/Dashboard/classes/class.ilDashboardGUI.php
+++ b/Services/Dashboard/classes/class.ilDashboardGUI.php
@@ -135,6 +135,35 @@ class ilDashboardGUI
     {
         global $DIC;
 
+        $form = $DIC->ui()->factory()->input()->container()->form()->standard(
+            $DIC->ctrl()->getFormActionByClass(self::class, 'submit'),
+            [
+                'grp' => $DIC->ui()->factory()->input()->field()->switchableGroup([
+                    'o1' => $DIC->ui()->factory()->input()->field()->group([
+                        't1' => $DIC->ui()->factory()->input()->field()->text('text input 1'),
+                    ]),
+
+                    'o2' => $DIC->ui()->factory()->input()->field()->group([
+                        't2' => $DIC->ui()->factory()->input()->field()->text('text input 2'),
+                    ]),
+                ], 'choose one'),
+            ]
+        );
+
+        if ($DIC->ctrl()->getCmd() === 'submit') {
+            $form = $form->withRequest($DIC->http()->request());
+            $data = $form->getData();
+            $x = 1;
+        }
+
+        $DIC->ui()->mainTemplate()->setContent(
+            $DIC->ui()->renderer()->render($form)
+        );
+
+        $DIC->ui()->mainTemplate()->printToStdout();
+
+        die;
+
         $context = $DIC->globalScreen()->tool()->context();
         $context->stack()->desktop();
 

--- a/src/UI/Implementation/Component/Input/Field/SwitchableGroup.php
+++ b/src/UI/Implementation/Component/Input/Field/SwitchableGroup.php
@@ -109,15 +109,20 @@ class SwitchableGroup extends Group implements Field\SwitchableGroup
             throw new \LogicException("Can only collect if input has a name.");
         }
 
+        $key = null;
         if (!$this->isDisabled()) {
-            $key = $post_input->get($this->getName());
-            $clone = $this->withValue($key);
-            $clone->inputs[$key] = $clone->inputs[$key]->withInput($post_input);
+            $key = $post_input->getOr($this->getName(), $key);
+            if (null !== $key) {
+                $clone = $this->withValue($key);
+                $clone->inputs[$key] = $clone->inputs[$key]->withInput($post_input);
+            } else {
+                $clone = $this;
+            }
         } else {
             $clone = $this;
         }
 
-        if ($clone->inputs[$key]->getContent()->isError()) {
+        if (null !== $key && $clone->inputs[$key]->getContent()->isError()) {
             $clone->content = $clone->data_factory->error($this->lng->txt("ui_error_in_group"));
         } else {
             $clone->content = $this->applyOperationsTo($clone->getValue());

--- a/tests/UI/Component/Input/Field/SwitchableGroupInputTest.php
+++ b/tests/UI/Component/Input/Field/SwitchableGroupInputTest.php
@@ -196,7 +196,7 @@ class SwitchableGroupInputTest extends ILIAS_UI_TestBase
 
         $input_data
             ->expects($this->once())
-            ->method("get")
+            ->method("getOr")
             ->with("name0")
             ->willReturn("child1");
 
@@ -246,7 +246,7 @@ class SwitchableGroupInputTest extends ILIAS_UI_TestBase
 
         $input_data
             ->expects($this->once())
-            ->method("get")
+            ->method("getOr")
             ->with("name0")
             ->willReturn("child2");
 
@@ -293,7 +293,7 @@ class SwitchableGroupInputTest extends ILIAS_UI_TestBase
 
         $input_data
             ->expects($this->once())
-            ->method("get")
+            ->method("getOr")
             ->with("name0")
             ->willReturn("child2");
 
@@ -327,7 +327,7 @@ class SwitchableGroupInputTest extends ILIAS_UI_TestBase
 
         $input_data
             ->expects($this->once())
-            ->method("get")
+            ->method("getOr")
             ->with("name0")
             ->willReturn(123);
 


### PR DESCRIPTION
Hi @Amstutz and @klees 

I've opened a ticket (https://mantis.ilias.de/view.php?id=32437) but figured it's an easy fix, therefore I opened this PR =).

I assume this change solves two problems at once, because from how I read it, if the switchable group was disabled there would've been an undefined-offset and call on null error on at `if ($clone->inputs[$key]->getContent()->isError()) { ...`.

I adjusted the tests because I changed `InputData::get()` to `InputData::getOr()`.

Cheers!