### PR TITLE
Notifications: Switch to objective based approach for administration …

### DIFF
--- a/Services/Notifications/classes/Setup/ilNotificationUpdateAgent.php
+++ b/Services/Notifications/classes/Setup/ilNotificationUpdateAgent.php
@@ -1,9 +1,6 @@
 <?php declare(strict_types = 1);
 
-use ILIAS\Setup;
-
-/******************************************************************************
- *
+/**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
  *
@@ -14,20 +11,63 @@ use ILIAS\Setup;
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *     https://www.ilias.de
- *     https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
 
-/**
- * @author Ingmar Szmais <iszmais@databay.de>
- */
-class ilNotificationUpdateAgent extends Setup\Agent\NullAgent
+use ILIAS\Setup;
+use ILIAS\Refinery;
+use ILIAS\Setup\Environment;
+
+class ilNotificationUpdateAgent implements Setup\Agent
 {
+    use Setup\Agent\HasNoNamedObjective;
+
+    public function hasConfig() : bool
+    {
+        return false;
+    }
+
+    public function getArrayToConfigTransformation() : Refinery\Transformation
+    {
+        throw new LogicException('Agent has no config.');
+    }
+
+    public function getInstallObjective(Setup\Config $config = null) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
+
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new ilDatabaseUpdateStepsExecutedObjective(
-            new ilNotificationUpdateSteps()
-        );
+        return new class(new ilNotificationUpdateSteps()) extends ilDatabaseUpdateStepsExecutedObjective {
+            public function getPreconditions(Environment $environment) : array
+            {
+                $preconditions = parent::getPreconditions($environment);
+                
+                $preconditions[] = new ilTreeAdminNodeAddedObjective(
+                    'nota',
+                    'Notification Service Administration Object'
+                );
+
+                return $preconditions;
+            }
+        };
+    }
+
+    public function getBuildArtifactObjective() : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
+
+    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
+
+    public function getMigrations() : array
+    {
+        return [];
     }
 }

--- a/Services/Notifications/classes/Setup/ilNotificationUpdateSteps.php
+++ b/Services/Notifications/classes/Setup/ilNotificationUpdateSteps.php
@@ -1,7 +1,6 @@
 <?php declare(strict_types = 1);
 
-/******************************************************************************
- *
+/**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
  *
@@ -12,29 +11,23 @@
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *     https://www.ilias.de
- *     https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
 
-use ILIAS\Notifications\ilNotificationSetupHelper;
-
-/**
- * @author Ingmar Szmais <iszmais@databay.de>
- */
 class ilNotificationUpdateSteps implements ilDatabaseUpdateSteps
 {
-    protected \ilDBInterface $db;
+    protected ilDBInterface $db;
 
     public function prepare(ilDBInterface $db) : void
     {
         $this->db = $db;
     }
-    
+
     public function step_1() : void
     {
-        include_once('./Services/Migration/DBUpdate_3560/classes/class.ilDBUpdateNewObjectType.php');
-        ilDBUpdateNewObjectType::addAdminNode('nota', 'Notification Service Administration Object');
+        // Creation of administration node forced by \ilTreeAdminNodeAddedObjective
     }
 
     public function step_2() : void


### PR DESCRIPTION
…node creation

This PR changes the approach of creating an administration node to an objective-based mechanism. Since `ilDBUpdateNewObjectType::addAdminNode` is marked as deprecated with the merge of #3925 the new approach should be more sustainable.