### PR TITLE
Review of Services/WebAccessChecker

### DIFF
--- a/Services/MediaObjects/classes/class.ilObjMediaObjectAccess.php
+++ b/Services/MediaObjects/classes/class.ilObjMediaObjectAccess.php
@@ -32,7 +32,7 @@ class ilObjMediaObjectAccess implements ilWACCheckingClass
         $this->access = $DIC->access();
     }
 
-    public function canBeDelivered(ilWACPath $ilWACPath)
+    public function canBeDelivered(ilWACPath $ilWACPath) : bool
     {
         preg_match("/.\\/data\\/.*\\/mm_([0-9]*)\\/.*/ui", $ilWACPath->getPath(), $matches);
         $obj_id = $matches[1];

--- a/Services/Style/classes/class.ilContentStyleWAC.php
+++ b/Services/Style/classes/class.ilContentStyleWAC.php
@@ -10,10 +10,8 @@ class ilContentStyleWAC implements ilWACCheckingClass
 
     /**
      * @param ilWACPath $ilWACPath
-     *
-     * @return bool
      */
-    public function canBeDelivered(ilWACPath $ilWACPath)
+    public function canBeDelivered(ilWACPath $ilWACPath) : bool
     {
         //preg_match("/.\\/data\\/.*\\/mm_([0-9]*)\\/.*/ui", $ilWACPath->getPath(), $matches);
         return true;

--- a/Services/WebAccessChecker/class.ilWACException.php
+++ b/Services/WebAccessChecker/class.ilWACException.php
@@ -20,17 +20,17 @@
  */
 class ilWACException extends ilException
 {
-    const CODE_NO_TYPE = 9001;
-    const CODE_NO_PATH = 9002;
-    const ACCESS_WITHOUT_CHECK = 9003;
-    const NO_CHECKING_INSTANCE = 9004;
-    const WRONG_PATH_TYPE = 9005;
-    const INITIALISATION_FAILED = 9006;
-    const DATA_DIR_NON_WRITEABLE = 9007;
-    const ACCESS_DENIED = 9010;
-    const ACCESS_DENIED_NO_PUB = 9011;
-    const ACCESS_DENIED_NO_LOGIN = 9012;
-    const MAX_LIFETIME = 9013;
+    public const CODE_NO_TYPE = 9001;
+    public const CODE_NO_PATH = 9002;
+    public const ACCESS_WITHOUT_CHECK = 9003;
+    public const NO_CHECKING_INSTANCE = 9004;
+    public const WRONG_PATH_TYPE = 9005;
+    public const INITIALISATION_FAILED = 9006;
+    public const DATA_DIR_NON_WRITEABLE = 9007;
+    public const ACCESS_DENIED = 9010;
+    public const ACCESS_DENIED_NO_PUB = 9011;
+    public const ACCESS_DENIED_NO_LOGIN = 9012;
+    public const MAX_LIFETIME = 9013;
     /**
      * @var array
      */
@@ -57,7 +57,7 @@ class ilWACException extends ilException
         $message = self::$messages[$code];
 
         if ($this->isNonEmptyString($additional_message)) {
-            $message = "\"{$this->message}\" with additional message: \"$additional_message\"";
+            $message = "\"$this->message\" with additional message: \"$additional_message\"";
         }
 
         //ilWACLog::getInstance()->write('Exception in ' . $this->getFile() . ':' . $this->getLine() . ': ' . $message);

--- a/Services/WebAccessChecker/classes/HttpServiceAware.php
+++ b/Services/WebAccessChecker/classes/HttpServiceAware.php
@@ -35,7 +35,7 @@ use ILIAS\HTTP\Services;
  */
 trait HttpServiceAware
 {
-    private static $http;
+    private static Services $http;
 
 
     /**
@@ -47,7 +47,7 @@ trait HttpServiceAware
      * @return Services  The current http global state of ILIAS.
      * @since 5.3
      */
-    protected static function http()
+    protected static function http() : Services //TODO-PHP8-REVIEW Please check if this trait is still need or if its usage can be replaced by using $DIC
     {
         if (self::$http === null) {
             self::$http = $GLOBALS['DIC']['http'];

--- a/Services/WebAccessChecker/classes/class.ilWACPath.php
+++ b/Services/WebAccessChecker/classes/class.ilWACPath.php
@@ -21,12 +21,12 @@
  */
 class ilWACPath
 {
-    const DIR_DATA = "data";
-    const DIR_SEC = "sec";
+    public const DIR_DATA = "data";
+    public const DIR_SEC = "sec";
     /**
      * Copy this without to regex101.com and test with some URL of files
      */
-    const REGEX = "(?<prefix>.*?)(?<path>(?<path_without_query>(?<secure_path_id>(?<module_path>\/data\/(?<client>[\w\-\.]*)\/(?<sec>sec\/|)(?<module_type>.*?)\/(?<module_identifier>.*\/|)))(?<appendix>[^\?\n]*)).*)";
+    public const REGEX = "(?<prefix>.*?)(?<path>(?<path_without_query>(?<secure_path_id>(?<module_path>\/data\/(?<client>[\w\-\.]*)\/(?<sec>sec\/|)(?<module_type>.*?)\/(?<module_identifier>.*\/|)))(?<appendix>[^\?\n]*)).*)";
     /**
      * @var string[]
      */
@@ -117,7 +117,7 @@ class ilWACPath
             $module_path = ('.' . (!isset($result['module_path']) || is_null($result['module_path']) ? '' : $result['module_path']));
         }
 
-        $this->setModulePath("$module_path");
+        $this->setModulePath($module_path);
         $this->setInSecFolder(isset($result['sec']) && $result['sec'] === 'sec/');
         $this->setPathWithoutQuery(
             '.' . (!isset($result['path_without_query']) || is_null($result['path_without_query']) ? '' : $result['path_without_query'])

--- a/Services/WebAccessChecker/classes/class.ilWACSignedPath.php
+++ b/Services/WebAccessChecker/classes/class.ilWACSignedPath.php
@@ -31,12 +31,12 @@ class ilWACSignedPath
 {
     use HttpServiceAware;
 
-    const WAC_TOKEN_ID = 'il_wac_token';
-    const WAC_TIMESTAMP_ID = 'il_wac_ts';
-    const WAC_TTL_ID = 'il_wac_ttl';
-    const TS_SUFFIX = 'ts';
-    const TTL_SUFFIX = 'ttl';
-    const MAX_LIFETIME = 600;
+    public const WAC_TOKEN_ID = 'il_wac_token';
+    public const WAC_TIMESTAMP_ID = 'il_wac_ts';
+    public const WAC_TTL_ID = 'il_wac_ttl';
+    public const TS_SUFFIX = 'ts';
+    public const TTL_SUFFIX = 'ttl';
+    public const MAX_LIFETIME = 600;
 
     protected ?ilWACPath $path_object = null;
     protected ?ilWACToken $token_instance = null;
@@ -80,7 +80,7 @@ class ilWACSignedPath
                 . $this->getTokenInstance()->getToken();
         }
 
-        $path = $path . '&' . self::WAC_TTL_ID . '=' . $this->getTokenInstance()->getTTL();
+        $path .= '&' . self::WAC_TTL_ID . '=' . $this->getTokenInstance()->getTTL();
 
         return $path . '&' . self::WAC_TIMESTAMP_ID . '='
             . $this->getTokenInstance()->getTimestamp();

--- a/Services/WebAccessChecker/classes/class.ilWACToken.php
+++ b/Services/WebAccessChecker/classes/class.ilWACToken.php
@@ -20,7 +20,7 @@
  */
 class ilWACToken
 {
-    const SALT_FILE_PATH = './data/wacsalt.php';
+    private const SALT_FILE_PATH = './data/wacsalt.php';
     protected static string $SALT = '';
     protected string $session_id = '';
     protected int $timestamp = 0;
@@ -45,7 +45,7 @@ class ilWACToken
         $this->setClient($client);
         $this->setPath($path);
         $session_id = session_id();
-        $this->setSessionId($session_id ? $session_id : '-');
+        $this->setSessionId($session_id ?: '-');
         if (isset($_SERVER['REMOTE_ADDR'])) {
             $this->setIp($_SERVER['REMOTE_ADDR']);
         }

--- a/Services/WebAccessChecker/interfaces/PathType.php
+++ b/Services/WebAccessChecker/interfaces/PathType.php
@@ -25,6 +25,6 @@ namespace ILIAS\WebAccessChecker;
  */
 interface PathType
 {
-    const FILE = 1;
-    const FOLDER = 2;
+    public const FILE = 1;
+    public const FOLDER = 2;
 }

--- a/Services/WebAccessChecker/interfaces/interface.ilWACCheckingClass.php
+++ b/Services/WebAccessChecker/interfaces/interface.ilWACCheckingClass.php
@@ -20,9 +20,5 @@
  */
 interface ilWACCheckingClass
 {
-
-    /**
-     * @return bool
-     */
-    public function canBeDelivered(ilWACPath $ilWACPath);
+    public function canBeDelivered(ilWACPath $ilWACPath) : bool;
 }

--- a/Services/WebAccessChecker/wac.php
+++ b/Services/WebAccessChecker/wac.php
@@ -14,15 +14,15 @@ require_once('./libs/composer/vendor/autoload.php');
 $container = new \ILIAS\DI\Container();
 
 //manually init http service
-$container['http.request_factory'] = fn ($c) => new \ILIAS\HTTP\Request\RequestFactoryImpl();
+$container['http.request_factory'] = static fn ($c) => new \ILIAS\HTTP\Request\RequestFactoryImpl();
 
-$container['http.response_factory'] = fn ($c) => new \ILIAS\HTTP\Response\ResponseFactoryImpl();
+$container['http.response_factory'] = static fn ($c) => new \ILIAS\HTTP\Response\ResponseFactoryImpl();
 
-$container['http.cookie_jar_factory'] = fn ($c) => new \ILIAS\HTTP\Cookies\CookieJarFactoryImpl();
+$container['http.cookie_jar_factory'] = static fn ($c) => new \ILIAS\HTTP\Cookies\CookieJarFactoryImpl();
 
-$container['http.response_sender_strategy'] = fn ($c) => new \ILIAS\HTTP\Response\Sender\DefaultResponseSenderStrategy();
+$container['http.response_sender_strategy'] = static fn ($c) => new \ILIAS\HTTP\Response\Sender\DefaultResponseSenderStrategy();
 
-$container['http'] = fn ($c) => new \ILIAS\HTTP\Services($c);
+$container['http'] = static fn ($c) => new \ILIAS\HTTP\Services($c);
 
 $GLOBALS["DIC"] = $container;
 


### PR DESCRIPTION
Hi @chfsx,

I completed the review of the Services/WebAccessChecker component.

Results:
- [x] The code is PSR-2
- [X] No usage of $_GET / $_POST / $_REQUEST / $_SESSION outside GUI-classes
- [X] There is a Unit Test Suite with at least one unit test
- [X] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [X] There are no serious PhpStorm Code Inspection issues left.
- [X] The types are fully documented (PhpDoc) or explicit PHP types are used (type hints, return types, typed properties).

Actions:
- [x] Check the inline comment where prefixed with TODO-PHP8-REVIEW in the HTTPServiceAware trait.
- [x] Check if the added Typing to ilWACCheckingClass is usefull. I did fix all depending classes (most where already typed with bool)

Kind regards,
Pascal