### PR TITLE
PHP 8: Code Review `Administration`

### DIFF
--- a/Services/Administration/GlobalScreen/classes/AdministrationMainBarProvider.php
+++ b/Services/Administration/GlobalScreen/classes/AdministrationMainBarProvider.php
@@ -62,7 +62,7 @@ class AdministrationMainBarProvider extends AbstractStaticMainMenuProvider
                 // Entries
                 $links = [];
                 foreach ($group_items as $group_item) {
-                    if ($group_item == "---") {
+                    if ($group_item === "---") {
                         continue;
                     }
 
@@ -185,7 +185,7 @@ class AdministrationMainBarProvider extends AbstractStaticMainMenuProvider
         $items = array();
         foreach ($new_objects as $c) {
             // check visibility
-            if ($tree->getParentId($c["ref_id"]) == ROOT_FOLDER_ID && $c["type"] !== "adm"
+            if ($c["type"] !== "adm" && $tree->getParentId($c["ref_id"]) === ROOT_FOLDER_ID
                 && $admin_request->getAdminMode() !== "repository"
             ) {
                 continue;
@@ -233,12 +233,12 @@ class AdministrationMainBarProvider extends AbstractStaticMainMenuProvider
             $groups[$group] = array();
             $entries_since_last_sep = false;
             foreach ($entries as $e) {
-                if ($e == "---" || (isset($titems[$e]["type"]) && $titems[$e]["type"] != "")) {
-                    if ($e == "---" && $entries_since_last_sep) {
+                if ($e === "---" || (isset($titems[$e]["type"]) && $titems[$e]["type"] != "")) {
+                    if ($e === "---" && $entries_since_last_sep) {
                         $groups[$group][] = $e;
                         $entries_since_last_sep = false;
                     } else {
-                        if ($e != "---") {
+                        if ($e !== "---") {
                             $groups[$group][] = $e;
                             $entries_since_last_sep = true;
                         }

--- a/Services/Administration/GlobalScreen/classes/AdministrationMainBarProvider.php
+++ b/Services/Administration/GlobalScreen/classes/AdministrationMainBarProvider.php
@@ -1,17 +1,23 @@
-<?php namespace ILIAS\Administration;
+<?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
+namespace ILIAS\Administration;
 
 use ILIAS\GlobalScreen\Helper\BasicAccessCheckClosuresSingleton;
 use ILIAS\GlobalScreen\Scope\MainMenu\Provider\AbstractStaticMainMenuProvider;
@@ -64,7 +70,7 @@ class AdministrationMainBarProvider extends AbstractStaticMainMenuProvider
                         ->withIsOutlined(true);
                     
                     $ref_id = $titems[$group_item]["ref_id"];
-                    if ($admin_request->getAdminMode() != 'repository' && $ref_id == ROOT_FOLDER_ID) {
+                    if ($admin_request->getAdminMode() !== 'repository' && $ref_id == ROOT_FOLDER_ID) {
                         $identification = $this->if->identifier('mm_adm_rep');
                         $action = "ilias.php?baseClass=ilAdministrationGUI&ref_id=" . $ref_id . "&admin_mode=repository";
                     } else {
@@ -145,7 +151,7 @@ class AdministrationMainBarProvider extends AbstractStaticMainMenuProvider
             $new_objects[$object["title"] . ":" . $object["child"]]
                 = $object;
             // have to set it manually as translation type of main node cannot be "sys" as this type is a orgu itself.
-            if ($object["type"] == "orgu") {
+            if ($object["type"] === "orgu") {
                 $new_objects[$object["title"] . ":" . $object["child"]]["title"] = $lng->txt("objs_orgu");
             }
         }
@@ -179,15 +185,15 @@ class AdministrationMainBarProvider extends AbstractStaticMainMenuProvider
         $items = array();
         foreach ($new_objects as $c) {
             // check visibility
-            if ($tree->getParentId($c["ref_id"]) == ROOT_FOLDER_ID && $c["type"] != "adm"
-                && $admin_request->getAdminMode() != "repository"
+            if ($tree->getParentId($c["ref_id"]) == ROOT_FOLDER_ID && $c["type"] !== "adm"
+                && $admin_request->getAdminMode() !== "repository"
             ) {
                 continue;
             }
             // these objects may exist due to test cases that didnt clear
             // data properly
-            if ($c["type"] == "" || $c["type"] == "objf"
-                || $c["type"] == "xxx"
+            if ($c["type"] == "" || $c["type"] === "objf"
+                || $c["type"] === "xxx"
             ) {
                 continue;
             }

--- a/Services/Administration/GlobalScreen/classes/class.ilAdminGSToolProvider.php
+++ b/Services/Administration/GlobalScreen/classes/class.ilAdminGSToolProvider.php
@@ -1,17 +1,21 @@
 <?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 use ILIAS\GlobalScreen\Scope\Tool\Provider\AbstractDynamicToolProvider;
 use ILIAS\GlobalScreen\ScreenContext\Stack\CalledContexts;
@@ -54,8 +58,6 @@ class ilAdminGSToolProvider extends AbstractDynamicToolProvider
 
     private function getTree() : string
     {
-        $exp = new ilAdministrationExplorerGUI("ilAdministrationGUI", "showTree");
-
-        return $exp->getHTML();
+        return (new ilAdministrationExplorerGUI("ilAdministrationGUI", "showTree"))->getHTML();
     }
 }

--- a/Services/Administration/classes/Setup/class.ilSettingsFactoryExistsObjective.php
+++ b/Services/Administration/classes/Setup/class.ilSettingsFactoryExistsObjective.php
@@ -1,17 +1,21 @@
 <?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 use ILIAS\Setup;
 

--- a/Services/Administration/classes/class.AdminGUIRequest.php
+++ b/Services/Administration/classes/class.AdminGUIRequest.php
@@ -93,7 +93,7 @@ class AdminGUIRequest
     public function getSelectedIds() : array
     {
         $ids = $this->intArray("id");
-        if (count($ids) == 0) {
+        if (count($ids) === 0) {
             if ($this->getItemRefId() > 0) {
                 return [$this->getItemRefId()];
             }

--- a/Services/Administration/classes/class.AdminGUIRequest.php
+++ b/Services/Administration/classes/class.AdminGUIRequest.php
@@ -1,17 +1,21 @@
 <?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 namespace ILIAS\Administration;
 

--- a/Services/Administration/classes/class.MemorySetting.php
+++ b/Services/Administration/classes/class.MemorySetting.php
@@ -1,17 +1,21 @@
 <?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 namespace ILIAS\Administration;
 
@@ -49,7 +53,7 @@ class MemorySetting implements Setting
         string $a_keyword,
         ?string $a_default_value = null
     ) : ?string {
-        if ($a_keyword == "ilias_version") {
+        if ($a_keyword === "ilias_version") {
             return ILIAS_VERSION;
         }
         return self::$setting[$this->module][$a_keyword] ??

--- a/Services/Administration/classes/class.SettingsTemplateGUIRequest.php
+++ b/Services/Administration/classes/class.SettingsTemplateGUIRequest.php
@@ -1,17 +1,21 @@
 <?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 namespace ILIAS\Administration;
 

--- a/Services/Administration/classes/class.ilAdministrationCommandGUI.php
+++ b/Services/Administration/classes/class.ilAdministrationCommandGUI.php
@@ -74,7 +74,7 @@ class ilAdministrationCommandGUI
 
         $to_delete = $this->request->getSelectedIds();
 
-        if (count($to_delete) == 0) {
+        if (count($to_delete) === 0) {
             $ilErr->raiseError($this->lng->txt('no_checkbox'), $ilErr->MESSAGE);
         }
 

--- a/Services/Administration/classes/class.ilAdministrationCommandGUI.php
+++ b/Services/Administration/classes/class.ilAdministrationCommandGUI.php
@@ -1,17 +1,21 @@
 <?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 use ILIAS\Administration\AdminGUIRequest;
 

--- a/Services/Administration/classes/class.ilAdministrationExplorerGUI.php
+++ b/Services/Administration/classes/class.ilAdministrationExplorerGUI.php
@@ -1,17 +1,21 @@
 <?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 use ILIAS\Administration\AdminGUIRequest;
 
@@ -67,7 +71,7 @@ class ilAdministrationExplorerGUI extends ilTreeExplorerGUI
 
         $white = array();
         foreach ($objDefinition->getSubObjectsRecursively("root") as $rtype) {
-            if ($rtype["name"] != "itgr" && !$objDefinition->isSideBlock($rtype["name"])) {
+            if ($rtype["name"] !== "itgr" && !$objDefinition->isSideBlock($rtype["name"])) {
                 $white[] = $rtype["name"];
             }
         }
@@ -78,13 +82,13 @@ class ilAdministrationExplorerGUI extends ilTreeExplorerGUI
         }
     }
 
-    public function getNodeContent($a_node) : string
+    public function getNodeContent($a_node) : string//PHP8Review: missing typehint (array)
     {
         $lng = $this->lng;
         
         $title = $a_node["title"];
         if ($a_node["child"] == $this->getNodeId($this->getRootNode())) {
-            if ($title == "ILIAS") {
+            if ($title === "ILIAS") {
                 $title = $lng->txt("repository");
             }
         }
@@ -92,19 +96,19 @@ class ilAdministrationExplorerGUI extends ilTreeExplorerGUI
         return $title;
     }
     
-    public function getNodeIcon($a_node) : string
+    public function getNodeIcon($a_node) : string//PHP8Review: missing typehint (array)
     {
         $obj_id = ilObject::_lookupObjId($a_node["child"]);
         return ilObject::_getIcon($obj_id, "tiny", $a_node["type"]);
     }
 
-    public function getNodeIconAlt($a_node) : string
+    public function getNodeIconAlt($a_node) : string//PHP8Review: missing typehint (array)
     {
         $lng = $this->lng;
 
         if ($a_node["child"] == $this->getNodeId($this->getRootNode())) {
             $title = $a_node["title"];
-            if ($title == "ILIAS") {
+            if ($title === "ILIAS") {
                 $title = $lng->txt("repository");
             }
             return $lng->txt("icon") . " " . $title;
@@ -114,16 +118,13 @@ class ilAdministrationExplorerGUI extends ilTreeExplorerGUI
         return parent::getNodeIconAlt($a_node);
     }
     
-    public function isNodeHighlighted($a_node) : bool
+    public function isNodeHighlighted($a_node) : bool//PHP8Review: missing typehint (array)
     {
-        if ($a_node["child"] == $this->cur_ref_id ||
-            ($this->cur_ref_id == 0 && $a_node["child"] == $this->getNodeId($this->getRootNode()))) {
-            return true;
-        }
-        return false;
+        return $a_node["child"] == $this->cur_ref_id ||
+            ($this->cur_ref_id == 0 && $a_node["child"] == $this->getNodeId($this->getRootNode()));
     }
     
-    public function getNodeHref($a_node) : string
+    public function getNodeHref($a_node) : string//PHP8Review: missing typehint (array)
     {
         $ilCtrl = $this->ctrl;
         $objDefinition = $this->obj_definition;
@@ -137,18 +138,18 @@ class ilAdministrationExplorerGUI extends ilTreeExplorerGUI
         return $link;
     }
 
-    public function isNodeVisible($a_node) : bool
+    public function isNodeVisible($a_node) : bool//PHP8Review: missing typehint (array)
     {
         $rbacsystem = $this->rbacsystem;
 
         $visible = $rbacsystem->checkAccess('visible', $a_node["child"]);
-        if ($a_node["type"] == "rolf" && $a_node["child"] != ROLE_FOLDER_ID) {
+        if ($a_node["type"] === "rolf" && $a_node["child"] != ROLE_FOLDER_ID) {
             return false;
         }
         return $visible;
     }
     
-    public function sortChilds(array $a_childs, $a_parent_node_id) : array
+    public function sortChilds(array $a_childs, $a_parent_node_id) : array//PHP8Review: missing typehint (int)
     {
         $objDefinition = $this->obj_definition;
 
@@ -163,7 +164,7 @@ class ilAdministrationExplorerGUI extends ilTreeExplorerGUI
 
         if (empty($this->type_grps[$parent_type])) {
             $this->type_grps[$parent_type] =
-                $objDefinition->getGroupedRepositoryObjectTypes($parent_type);
+                $objDefinition::getGroupedRepositoryObjectTypes($parent_type);
         }
         $group = array();
         
@@ -183,7 +184,7 @@ class ilAdministrationExplorerGUI extends ilTreeExplorerGUI
                 $group = $sort->sortItems($group);
                 
                 // need extra session sorting here
-                if ($t == "sess") {
+                if ($t === "sess") {
                 }
                 
                 foreach ($group[$t] as $k => $item) {
@@ -195,7 +196,7 @@ class ilAdministrationExplorerGUI extends ilTreeExplorerGUI
         return $childs;
     }
 
-    public function getChildsOfNode($a_parent_node_id) : array
+    public function getChildsOfNode($a_parent_node_id) : array//PHP8Review: missing typehint (array)
     {
         $rbacsystem = $this->rbacsystem;
         
@@ -206,10 +207,8 @@ class ilAdministrationExplorerGUI extends ilTreeExplorerGUI
         return parent::getChildsOfNode($a_parent_node_id);
     }
     
-    public function isNodeClickable($a_node) : bool
+    public function isNodeClickable($a_node) : bool//PHP8Review: missing typehint (array)
     {
-        $rbacsystem = $this->rbacsystem;
-
-        return $rbacsystem->checkAccess('read', $a_node["child"]);
+        return $this->rbacsystem->checkAccess('read', $a_node["child"]);
     }
 }

--- a/Services/Administration/classes/class.ilAdministrationExplorerGUI.php
+++ b/Services/Administration/classes/class.ilAdministrationExplorerGUI.php
@@ -121,7 +121,7 @@ class ilAdministrationExplorerGUI extends ilTreeExplorerGUI
     public function isNodeHighlighted($a_node) : bool//PHP8Review: missing typehint (array)
     {
         return $a_node["child"] == $this->cur_ref_id ||
-            ($this->cur_ref_id == 0 && $a_node["child"] == $this->getNodeId($this->getRootNode()));
+            ($this->cur_ref_id === 0 && $a_node["child"] == $this->getNodeId($this->getRootNode()));
     }
     
     public function getNodeHref($a_node) : string//PHP8Review: missing typehint (array)
@@ -170,7 +170,7 @@ class ilAdministrationExplorerGUI extends ilTreeExplorerGUI
         
         foreach ($a_childs as $child) {
             $g = $objDefinition->getGroupOfObj($child["type"]);
-            if ($g == "") {
+            if ($g === null || $g === "") {
                 $g = $child["type"];
             }
             $group[$g][] = $child;

--- a/Services/Administration/classes/class.ilAdministrationGUI.php
+++ b/Services/Administration/classes/class.ilAdministrationGUI.php
@@ -107,7 +107,7 @@ class ilAdministrationGUI implements ilCtrlBaseClassInterface
         $this->ctrl->saveParameter($this, array("ref_id", "admin_mode"));
 
         $this->admin_mode = $this->request->getAdminMode();
-        if ($this->admin_mode != ilObjectGUI::ADMIN_MODE_REPOSITORY) {
+        if ($this->admin_mode !== ilObjectGUI::ADMIN_MODE_REPOSITORY) {
             $this->admin_mode = ilObjectGUI::ADMIN_MODE_SETTINGS;
         }
     

--- a/Services/Administration/classes/class.ilAdministrationGUI.php
+++ b/Services/Administration/classes/class.ilAdministrationGUI.php
@@ -1,17 +1,21 @@
 <?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 use ILIAS\Administration\AdminGUIRequest;
 
@@ -154,15 +158,15 @@ class ilAdministrationGUI implements ilCtrlBaseClassInterface
 
         // set next_class directly for page translations
         // (no cmdNode is given in translation link)
-        if ($this->ctrl->getCmdClass() == "ilobjlanguageextgui") {
+        if ($this->ctrl->getCmdClass() === "ilobjlanguageextgui") {
             $next_class = "ilobjlanguageextgui";
         } else {
             $next_class = $this->ctrl->getNextClass($this);
         }
 
         if ((
-            $next_class == "iladministrationgui" || $next_class == ""
-        ) && ($this->ctrl->getCmd() == "return")) {
+            $next_class === "iladministrationgui" || $next_class == ""
+        ) && ($this->ctrl->getCmd() === "return")) {
             // get GUI of current object
             $obj_type = ilObject::_lookupType($this->cur_ref_id, true);
             $class_name = $this->objDefinition->getClassName($obj_type);
@@ -178,7 +182,7 @@ class ilAdministrationGUI implements ilCtrlBaseClassInterface
             default:
             
                 // forward all other classes to gui commands
-                if ($next_class != "" && $next_class != "iladministrationgui") {
+                if ($next_class != "" && $next_class !== "iladministrationgui") {
                     // check db update
                     $dbupdate = new ilDBUpdate($ilDB);
                     if (!$dbupdate->getDBVersionStatus()) {
@@ -193,8 +197,8 @@ class ilAdministrationGUI implements ilCtrlBaseClassInterface
                     }
                     // get gui class instance
                     $class_name = $this->ctrl->getClassForClasspath($class_path);
-                    if (($next_class == "ilobjrolegui" || $next_class == "ilobjusergui"
-                        || $next_class == "ilobjroletemplategui")) {
+                    if (($next_class === "ilobjrolegui" || $next_class === "ilobjusergui"
+                        || $next_class === "ilobjroletemplategui")) {
                         if ($this->requested_obj_id > 0) {
                             $this->gui_obj = new $class_name(null, $this->requested_obj_id, false, false);
                             $this->gui_obj->setCreationMode(false);
@@ -249,11 +253,11 @@ class ilAdministrationGUI implements ilCtrlBaseClassInterface
      */
     public function forward() : void
     {
-        if ($this->admin_mode != "repository") {	// settings
+        if ($this->admin_mode !== "repository") {	// settings
             if ($this->request->getRefId() == USER_FOLDER_ID) {
                 $this->ctrl->setParameter($this, "ref_id", USER_FOLDER_ID);
                 $this->ctrl->setParameterByClass("iladministrationgui", "admin_mode", "settings");
-                if (ilObject::_lookupType($this->request->getJumpToUserId()) == "usr") {
+                if (ilObject::_lookupType($this->request->getJumpToUserId()) === "usr") {
                     $this->ctrl->setParameterByClass(
                         "ilobjuserfoldergui",
                         "jmpToUser",
@@ -302,7 +306,7 @@ class ilAdministrationGUI implements ilCtrlBaseClassInterface
     {
         global $DIC;
 
-        if ($this->admin_mode != "repository") {
+        if ($this->admin_mode !== "repository") {
             return;
         }
 

--- a/Services/Administration/classes/class.ilAdministrationSettingsFormHandler.php
+++ b/Services/Administration/classes/class.ilAdministrationSettingsFormHandler.php
@@ -1,17 +1,21 @@
 <?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 /**
  * Administration settings form handler
@@ -20,7 +24,10 @@
  */
 class ilAdministrationSettingsFormHandler
 {
-    protected static $OBJ_MAP;
+    /**
+     * @var array<string, int>
+     */
+    protected static array $OBJ_MAP;
     
     public const FORM_PRIVACY = 1;
     public const FORM_SECURITY = 2;
@@ -68,18 +75,18 @@ class ilAdministrationSettingsFormHandler
         
         $map = array("adm" => SYSTEM_FOLDER_ID);
         foreach ($tree->getChilds(SYSTEM_FOLDER_ID) as $obj) {
-            $map[$obj["type"]] = $obj["ref_id"];
+            $map[$obj["type"]] = (int) $obj["ref_id"];
         }
 
         self::$OBJ_MAP = $map;
     }
 
-    protected static function getRefId($a_obj_type) : int
+    protected static function getRefId(string $a_obj_type) : int
     {
         if (!is_array(self::$OBJ_MAP)) {
             self::initObjectMap();
         }
-        return (int) (self::$OBJ_MAP[$a_obj_type] ?? 0);
+        return self::$OBJ_MAP[$a_obj_type] ?? 0;
     }
     
     public static function getSettingsGUIInstance(string $a_settings_obj_type) : ilObjectGUI
@@ -172,7 +179,7 @@ class ilAdministrationSettingsFormHandler
         
         $gui = new ilCronManagerGUI();
         $data = $gui->addToExternalSettingsForm($a_form_id);
-        if (is_array($data) && sizeof($data)) {
+        if (is_array($data) && count($data)) {
             self::parseFieldDefinition("cron", $a_form, $parent_gui, $data);
         }
     }
@@ -198,10 +205,7 @@ class ilAdministrationSettingsFormHandler
             $a_field_value = "-";
         }
 
-        if (is_numeric($a_field_value) || $a_field_value !== "") {
-            return true;
-        }
-        return false;
+        return is_numeric($a_field_value) || $a_field_value !== "";
     }
     
     protected static function parseFieldDefinition(
@@ -242,7 +246,7 @@ class ilAdministrationSettingsFormHandler
                 $area_caption = "obj_" . $a_type;
             }
 
-            if (is_array($fields) && sizeof($fields) == 2) {
+            if (is_array($fields) && count($fields) === 2) {
                 $cmd = $fields[0];
                 $fields = $fields[1];
                 if (is_array($fields)) {

--- a/Services/Administration/classes/class.ilGitInformation.php
+++ b/Services/Administration/classes/class.ilGitInformation.php
@@ -1,17 +1,21 @@
 <?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 /**
  * Class ilGitInformation
@@ -19,6 +23,9 @@
  */
 class ilGitInformation implements ilVersionControlInformation
 {
+    /**
+     * @var string[]|null
+     */
     private static ?array $revision_information = null;
 
     private static function detect() : void

--- a/Services/Administration/classes/class.ilObjExternalToolsSettings.php
+++ b/Services/Administration/classes/class.ilObjExternalToolsSettings.php
@@ -1,17 +1,21 @@
 <?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 /**
  * Class ilObjExternalToolsSettings

--- a/Services/Administration/classes/class.ilObjExternalToolsSettingsAccess.php
+++ b/Services/Administration/classes/class.ilObjExternalToolsSettingsAccess.php
@@ -1,17 +1,21 @@
 <?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 /**
  * Class ilObjExternalToolsSettingsAccess

--- a/Services/Administration/classes/class.ilObjExternalToolsSettingsGUI.php
+++ b/Services/Administration/classes/class.ilObjExternalToolsSettingsGUI.php
@@ -1,17 +1,21 @@
 <?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 /**
  * Class ilObjExternalToolsSettingsGUI
@@ -119,7 +123,7 @@ class ilObjExternalToolsSettingsGUI extends ilObjectGUI
         $form->addItem($types);
 
         // map data server property
-        if ($type == "openlayers") {
+        if ($type === "openlayers") {
             $tile = new ilTextInputGUI($lng->txt("maps_tile_server"), "tile");
             $tile->setValue(ilMapUtil::getStdTileServers());
             $tile->setInfo(sprintf($lng->txt("maps_custom_tile_server_info"), ilMapUtil::DEFAULT_TILE));
@@ -165,7 +169,7 @@ class ilObjExternalToolsSettingsGUI extends ilObjectGUI
 
         $form = $this->getMapsForm();
         if ($form->checkInput()) {
-            if ($form->getInput("type") == 'openlayers' && 'openlayers' == ilMapUtil::getType()) {
+            if ($form->getInput("type") === 'openlayers' && 'openlayers' === ilMapUtil::getType()) {
                 ilMapUtil::setStdTileServers($form->getInput("title"));
                 ilMapUtil::setStdGeolocationServer(
                     $form->getInput("geolocation")
@@ -185,10 +189,10 @@ class ilObjExternalToolsSettingsGUI extends ilObjectGUI
     }
     
     // init sub tabs
-    public function __initSubTabs(string $a_cmd) : void
+    public function __initSubTabs(string $a_cmd) : void//PHP8Review: Its recommended not to use self defined __ prefixes. Since this affects multiple space i just leave a recommendation to change that here
     {
-        $maps = $a_cmd == 'editMaps';
-        $mathjax = $a_cmd == 'editMathJax';
+        $maps = $a_cmd === 'editMaps';
+        $mathjax = $a_cmd === 'editMathJax';
 
         $this->tabs_gui->addSubTabTarget(
             "maps_extt_maps",
@@ -239,7 +243,7 @@ class ilObjExternalToolsSettingsGUI extends ilObjectGUI
 
             default:
                 $this->tabs_gui->setTabActive('settings');
-                if (!$cmd || $cmd == 'view') {
+                if (!$cmd || $cmd === 'view') {
                     $cmd = "editMaps";
                 }
                 $cmd .= "Object";

--- a/Services/Administration/classes/class.ilObjExternalToolsSettingsGUI.php
+++ b/Services/Administration/classes/class.ilObjExternalToolsSettingsGUI.php
@@ -25,6 +25,9 @@
  */
 class ilObjExternalToolsSettingsGUI extends ilObjectGUI
 {
+    public ilRbacSystem $rbacsystem;
+    public ilRbacReview $rbacreview;
+
     public function __construct(
         $a_data,
         int $a_id,
@@ -178,7 +181,7 @@ class ilObjExternalToolsSettingsGUI extends ilObjectGUI
                 ilMapUtil::setApiKey($form->getInput("api_key"));
             }
 
-            ilMapUtil::setActivated($form->getInput("enable") == "1");
+            ilMapUtil::setActivated($form->getInput("enable") === "1");
             ilMapUtil::setType($form->getInput("type"));
             $location = $form->getInput("std_location");
             ilMapUtil::setStdLatitude($location["latitude"]);

--- a/Services/Administration/classes/class.ilObjRecoveryFolder.php
+++ b/Services/Administration/classes/class.ilObjRecoveryFolder.php
@@ -1,17 +1,21 @@
 <?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 /**
  * Class ilObjRecoveryFolder

--- a/Services/Administration/classes/class.ilObjRecoveryFolderAccess.php
+++ b/Services/Administration/classes/class.ilObjRecoveryFolderAccess.php
@@ -1,17 +1,21 @@
 <?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 /**
  * Class ilObjRootFolderAccess

--- a/Services/Administration/classes/class.ilObjRecoveryFolderGUI.php
+++ b/Services/Administration/classes/class.ilObjRecoveryFolderGUI.php
@@ -28,6 +28,7 @@ use ILIAS\Administration\AdminGUIRequest;
 class ilObjRecoveryFolderGUI extends ilContainerGUI
 {
     protected AdminGUIRequest $admin_request;
+    public ilRbacSystem $rbacsystem;
 
     public function __construct(
         $a_data,

--- a/Services/Administration/classes/class.ilObjRecoveryFolderGUI.php
+++ b/Services/Administration/classes/class.ilObjRecoveryFolderGUI.php
@@ -1,17 +1,21 @@
 <?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 use ILIAS\Administration\AdminGUIRequest;
 

--- a/Services/Administration/classes/class.ilObjRecoveryFolderListGUI.php
+++ b/Services/Administration/classes/class.ilObjRecoveryFolderListGUI.php
@@ -1,17 +1,21 @@
 <?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 /**
  * @author Alexander Killing <killing@leifos.de>

--- a/Services/Administration/classes/class.ilSetting.php
+++ b/Services/Administration/classes/class.ilSetting.php
@@ -102,11 +102,7 @@ class ilSetting implements \ILIAS\Administration\Setting
         if ($a_keyword === "ilias_version") {
             return ILIAS_VERSION;
         }
-        if (isset($this->setting[$a_keyword])) {
-            return $this->setting[$a_keyword];
-        } else {
-            return $a_default_value;
-        }
+        return $this->setting[$a_keyword] ?? $a_default_value;
     }
     
     public function deleteAll() : void
@@ -158,7 +154,7 @@ class ilSetting implements \ILIAS\Administration\Setting
             self::$value_type = self::_getValueType();
         }
 
-        if (self::$value_type === 'text' and strlen($a_val) >= 4000) {
+        if (self::$value_type === 'text' && strlen($a_val) >= 4000) {
             global $DIC;
             $DIC->ui()->mainTemplate()->setOnScreenMessage('failure', $DIC->language()->txt('setting_value_truncated'), true);
             $a_val = substr($a_val, 0, 4000);
@@ -179,7 +175,7 @@ class ilSetting implements \ILIAS\Administration\Setting
     public function setScormDebug(string $a_key, string $a_val) : void
     {
         $ilDB = $this->db;
-        if ($a_val != "1") {
+        if ($a_val !== "1") {
             $ilDB->query("UPDATE sahs_lm SET debug = 'n'");
         }
         $this->set($a_key, $a_val);
@@ -230,9 +226,10 @@ class ilSetting implements \ILIAS\Administration\Setting
 
         $old_type = self::_getValueType();
 
-        if ($a_new_type == $old_type) {
+        if ($a_new_type === $old_type) {
             return false;
-        } elseif ($a_new_type === 'clob') {
+        }
+        if ($a_new_type === 'clob') {
             $ilDB->addTableColumn(
                 'settings',
                 'value2',
@@ -246,7 +243,8 @@ class ilSetting implements \ILIAS\Administration\Setting
             $ilDB->renameTableColumn('settings', 'value2', 'value');
 
             return true;
-        } elseif ($a_new_type === 'text') {
+        }
+        if ($a_new_type === 'text') {
             $ilDB->addTableColumn(
                 'settings',
                 'value2',
@@ -261,9 +259,8 @@ class ilSetting implements \ILIAS\Administration\Setting
             $ilDB->renameTableColumn('settings', 'value2', 'value');
 
             return true;
-        } else {
-            return false;
         }
+        return false;
     }
 
 

--- a/Services/Administration/classes/class.ilSetting.php
+++ b/Services/Administration/classes/class.ilSetting.php
@@ -1,17 +1,21 @@
 <?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 /**
  * ILIAS Setting Class
@@ -95,7 +99,7 @@ class ilSetting implements \ILIAS\Administration\Setting
         string $a_keyword,
         ?string $a_default_value = null
     ) : ?string {
-        if ($a_keyword == "ilias_version") {
+        if ($a_keyword === "ilias_version") {
             return ILIAS_VERSION;
         }
         if (isset($this->setting[$a_keyword])) {
@@ -154,7 +158,7 @@ class ilSetting implements \ILIAS\Administration\Setting
             self::$value_type = self::_getValueType();
         }
 
-        if (self::$value_type == 'text' and strlen($a_val) >= 4000) {
+        if (self::$value_type === 'text' and strlen($a_val) >= 4000) {
             global $DIC;
             $DIC->ui()->mainTemplate()->setOnScreenMessage('failure', $DIC->language()->txt('setting_value_truncated'), true);
             $a_val = substr($a_val, 0, 4000);
@@ -178,7 +182,7 @@ class ilSetting implements \ILIAS\Administration\Setting
         if ($a_val != "1") {
             $ilDB->query("UPDATE sahs_lm SET debug = 'n'");
         }
-        ilSetting::set($a_key, $a_val);
+        $this->set($a_key, $a_val);
     }
     
     public static function _lookupValue(
@@ -204,7 +208,7 @@ class ilSetting implements \ILIAS\Administration\Setting
         $analyzer = new ilDBAnalyzer();
         $info = $analyzer->getFieldInformation('settings');
 
-        if ($info['value']['type'] == 'clob') {
+        if ($info['value']['type'] === 'clob') {
             return 'clob';
         } else {
             return 'text';
@@ -228,7 +232,7 @@ class ilSetting implements \ILIAS\Administration\Setting
 
         if ($a_new_type == $old_type) {
             return false;
-        } elseif ($a_new_type == 'clob') {
+        } elseif ($a_new_type === 'clob') {
             $ilDB->addTableColumn(
                 'settings',
                 'value2',
@@ -242,7 +246,7 @@ class ilSetting implements \ILIAS\Administration\Setting
             $ilDB->renameTableColumn('settings', 'value2', 'value');
 
             return true;
-        } elseif ($a_new_type == 'text') {
+        } elseif ($a_new_type === 'text') {
             $ilDB->addTableColumn(
                 'settings',
                 'value2',

--- a/Services/Administration/classes/class.ilSettingsFactory.php
+++ b/Services/Administration/classes/class.ilSettingsFactory.php
@@ -36,14 +36,14 @@ class ilSettingsFactory
      */
     public function settingsFor(string $a_module = "common") : ilSetting
     {
-        $tmp_dic = $GLOBALS["DIC"] ?? null;
+        $tmp_dic = $GLOBALS["DIC"] ?? null;//PHP8Review: This may not be a critical Global but i still would recommend to use a global call here or even better to integrate it into the classes attributes
         try {
             // ilSetting pulls the database once in the constructor, we force it to
             // use ours.
             $DIC = new ILIAS\DI\Container();
             $DIC["ilDB"] = $this->db;
             $DIC["ilBench"] = null;
-            $GLOBALS["DIC"] = $DIC;
+            $GLOBALS["DIC"] = $DIC;//PHP8Review: This may not be a critical Global but i still would recommend to use a global call here
 
             // Always load from db, as caching could be implemented as a
             // decorator to this.
@@ -58,7 +58,7 @@ class ilSettingsFactory
                 $settings->get("dummy", "dummy")
             );
         } finally {
-            $GLOBALS["DIC"] = $tmp_dic;
+            $GLOBALS["DIC"] = $tmp_dic;//PHP8Review: This may not be a critical Global but i still would recommend to use a global call here
         }
 
         return $settings;

--- a/Services/Administration/classes/class.ilSettingsFactory.php
+++ b/Services/Administration/classes/class.ilSettingsFactory.php
@@ -1,17 +1,21 @@
 <?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 /**
  * A factory that builds ilSettings that can be used for DI.

--- a/Services/Administration/classes/class.ilSettingsTemplate.php
+++ b/Services/Administration/classes/class.ilSettingsTemplate.php
@@ -103,7 +103,7 @@ class ilSettingsTemplate
 
     /**
      * Set setting
-     * @param mixed $a_value
+     * @param array|string $a_value//PHP8Review: You may specificy the array further
      */
     public function setSetting(
         string $a_setting,
@@ -113,7 +113,7 @@ class ilSettingsTemplate
         if ($this->getConfig()) {
             $settings = $this->getConfig()->getSettings();
 
-            if ($settings[$a_setting]['type'] == ilSettingsTemplateConfig::CHECKBOX) {
+            if ($settings[$a_setting]['type'] === ilSettingsTemplateConfig::CHECKBOX) {
                 if (is_array($a_value)) {
                     $a_value = serialize($a_value);
                 } else {
@@ -344,14 +344,10 @@ class ilSettingsTemplate
         return $settings_template;
     }
 
-    /**
-     * Lookup property
-     * @return	mixed	property value
-     */
     protected static function lookupProperty(
         int $a_id,
         string $a_prop
-    ) {
+    ) : string {
         global $DIC;
 
         $ilDB = $DIC->database();
@@ -376,8 +372,8 @@ class ilSettingsTemplate
     
     public static function translate(string $a_title_desc) : string
     {
-        if (substr($a_title_desc, 0, 3) === 'il_') {
-            return $GLOBALS['lng']->txt($a_title_desc);
+        if (str_starts_with($a_title_desc, 'il_')) {
+            return $GLOBALS['lng']->txt($a_title_desc);//PHP8Review: This may not be a critical Global but i still would recommend to use a global call here
         }
         return $a_title_desc;
     }

--- a/Services/Administration/classes/class.ilSettingsTemplate.php
+++ b/Services/Administration/classes/class.ilSettingsTemplate.php
@@ -1,17 +1,21 @@
 <?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 /**
  * Settings template application class
@@ -113,7 +117,7 @@ class ilSettingsTemplate
                 if (is_array($a_value)) {
                     $a_value = serialize($a_value);
                 } else {
-                    $a_value = unserialize($a_value);
+                    $a_value = unserialize($a_value);//PHP8Review: Use the options parameter to specificy the serialized classes for security
                 }
             }
         }
@@ -372,7 +376,7 @@ class ilSettingsTemplate
     
     public static function translate(string $a_title_desc) : string
     {
-        if (substr($a_title_desc, 0, 3) == 'il_') {
+        if (substr($a_title_desc, 0, 3) === 'il_') {
             return $GLOBALS['lng']->txt($a_title_desc);
         }
         return $a_title_desc;

--- a/Services/Administration/classes/class.ilSettingsTemplateConfig.php
+++ b/Services/Administration/classes/class.ilSettingsTemplateConfig.php
@@ -1,17 +1,21 @@
 <?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 /**
  * Settings template config class

--- a/Services/Administration/classes/class.ilSettingsTemplateGUI.php
+++ b/Services/Administration/classes/class.ilSettingsTemplateGUI.php
@@ -263,7 +263,7 @@ class ilSettingsTemplateGUI
             if (isset($set[$s["id"]])) {
                 $values["set_" . $s["id"]] = true;
 
-                if ($s['type'] == ilSettingsTemplateConfig::CHECKBOX) {
+                if ($s['type'] === ilSettingsTemplateConfig::CHECKBOX) {
                     if (!is_array($set[$s["id"]]["value"])) {
                         $ar = unserialize($set[$s["id"]]["value"]);//PHP8Review: Use the options parameter to specificy the serialized classes for security
                     } else {
@@ -308,7 +308,7 @@ class ilSettingsTemplateGUI
     /**
      * Update settings template
      */
-    public function updateSettingsTemplate()
+    public function updateSettingsTemplate() : void
     {
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
@@ -366,7 +366,7 @@ class ilSettingsTemplateGUI
         $tpl = $this->tpl;
         $lng = $this->lng;
 
-        if (count($this->request->getTemplateIds()) == 0) {
+        if (count($this->request->getTemplateIds()) === 0) {
             $this->tpl->setOnScreenMessage('info', $lng->txt("no_checkbox"), true);
             $ilCtrl->redirect($this, "listSettingsTemplates");
         } else {

--- a/Services/Administration/classes/class.ilSettingsTemplateGUI.php
+++ b/Services/Administration/classes/class.ilSettingsTemplateGUI.php
@@ -1,17 +1,21 @@
 <?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 use ILIAS\Administration\SettingsTemplateGUIRequest;
 
@@ -67,7 +71,7 @@ class ilSettingsTemplateGUI
         $this->$cmd();
     }
 
-    public function setConfig(ilSettingsTemplateConfig $a_val)
+    public function setConfig(ilSettingsTemplateConfig $a_val) : void
     {
         $this->config = $a_val;
     }
@@ -131,7 +135,7 @@ class ilSettingsTemplateGUI
         $tpl->setContent($this->form->getHTML());
     }
 
-    public function initSettingsTemplateForm($a_mode = "edit") : void
+    public function initSettingsTemplateForm(string $a_mode = "edit") : void
     {
         $lng = $this->lng;
         $ilCtrl = $this->ctrl;
@@ -206,7 +210,7 @@ class ilSettingsTemplateGUI
                                         case ilSettingsTemplateConfig::CHECKBOX:
                                                 $chbs = new ilCheckboxGroupInputGUI($lng->txt("adm_value"), "value_" . $s["id"]);
                                                 foreach ($s['options'] as $key => $value) {
-                                                    $chbs->addOption($c = new ilCheckboxInputGUI($value, $key));
+                                                    $chbs->addOption($c = new ilCheckboxInputGUI($value, $key));//PHP8Review: Miss matching parameter
                                                     $c->setValue($key);
                                                 }
                                                 $cb->addSubItem($chbs);
@@ -223,7 +227,7 @@ class ilSettingsTemplateGUI
 
         if ($this->rbacsystem->checkAccess('write', $this->request->getRefId())) {
             // save and cancel commands
-            if ($a_mode == "create") {
+            if ($a_mode === "create") {
                 $this->form->addCommandButton("saveSettingsTemplate", $lng->txt("save"));
                 $this->form->addCommandButton("listSettingsTemplates", $lng->txt("cancel"));
                 $this->form->setTitle($lng->txt("adm_add_settings_template"));
@@ -261,7 +265,7 @@ class ilSettingsTemplateGUI
 
                 if ($s['type'] == ilSettingsTemplateConfig::CHECKBOX) {
                     if (!is_array($set[$s["id"]]["value"])) {
-                        $ar = unserialize($set[$s["id"]]["value"]);
+                        $ar = unserialize($set[$s["id"]]["value"]);//PHP8Review: Use the options parameter to specificy the serialized classes for security
                     } else {
                         $ar = $set[$s["id"]]["value"];
                     }

--- a/Services/Administration/classes/class.ilSettingsTemplateTableGUI.php
+++ b/Services/Administration/classes/class.ilSettingsTemplateTableGUI.php
@@ -1,17 +1,21 @@
 <?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 use ILIAS\Administration\SettingsTemplateGUIRequest;
 

--- a/Services/Administration/interfaces/interface.Setting.php
+++ b/Services/Administration/interfaces/interface.Setting.php
@@ -1,17 +1,21 @@
 <?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 namespace ILIAS\Administration;
 

--- a/Services/Administration/interfaces/interface.ilAdministrationCommandHandling.php
+++ b/Services/Administration/interfaces/interface.ilAdministrationCommandHandling.php
@@ -1,17 +1,21 @@
 <?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 /**
  * Interface for GUI classes (PDGUI, LuceneSearchGUI...) that have to

--- a/Services/Administration/interfaces/interface.ilVersionControlInformation.php
+++ b/Services/Administration/interfaces/interface.ilVersionControlInformation.php
@@ -1,17 +1,21 @@
 <?php
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 /**
  * Class ilVersionControlInformation

--- a/Services/Administration/test/AdminGUIRequestTest.php
+++ b/Services/Administration/test/AdminGUIRequestTest.php
@@ -1,5 +1,22 @@
 <?php
 
+/******************************************************************************
+ *
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
+
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -37,7 +54,7 @@ class AdminGUIRequestTest extends TestCase
     /**
      * Test ref id
      */
-    public function testRefId()
+    public function testRefId() : void
     {
         $request = $this->getRequest(
             [
@@ -55,7 +72,7 @@ class AdminGUIRequestTest extends TestCase
     /**
      * Test no ref id
      */
-    public function testNoRefId()
+    public function testNoRefId() : void
     {
         $request = $this->getRequest(
             [
@@ -72,7 +89,7 @@ class AdminGUIRequestTest extends TestCase
     /**
      * Test admin mode
      */
-    public function testAdminMode()
+    public function testAdminMode() : void
     {
         $request = $this->getRequest(
             [
@@ -90,7 +107,7 @@ class AdminGUIRequestTest extends TestCase
     /**
      * Test selected ids
      */
-    public function testSelectedIds()
+    public function testSelectedIds() : void
     {
         $request = $this->getRequest(
             [
@@ -109,7 +126,7 @@ class AdminGUIRequestTest extends TestCase
     /**
      * Test new type
      */
-    public function testNewType()
+    public function testNewType() : void
     {
         $request = $this->getRequest(
             [
@@ -127,7 +144,7 @@ class AdminGUIRequestTest extends TestCase
     /**
      * Test user id
      */
-    public function testUserId()
+    public function testUserId() : void
     {
         $request = $this->getRequest(
             [
@@ -145,7 +162,7 @@ class AdminGUIRequestTest extends TestCase
     /**
      * Test plugin id
      */
-    public function testPluginId()
+    public function testPluginId() : void
     {
         $request = $this->getRequest(
             [

--- a/Services/Administration/test/ilServicesAdministrationSuite.php
+++ b/Services/Administration/test/ilServicesAdministrationSuite.php
@@ -1,17 +1,21 @@
 <?php declare(strict_types=1);
 
-/**
+/******************************************************************************
+ *
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- */
+ *     https://www.ilias.de
+ *     https://github.com/ILIAS-eLearning
+ *
+ *****************************************************************************/
 
 use PHPUnit\Framework\TestSuite;
 
@@ -22,7 +26,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilServicesAdministrationSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new self();
 


### PR DESCRIPTION
Hi, @alex40724  

This is an complete review of the `Services/Administration` component.

Results:
- [ ] The code style is `PSR-2 + X` compliant
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION` _(I encoutered some uses of $GLOBAL, see commentary)_
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [ ] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

I also fixed some trivial inspection profile issues.

### Further actions needed:
- All unsolved Problems are marked with `//PHP8Review: ` Preffix.
- You may add `declare(strict_types=1);` to all php files (or at least most with a few exceptions). Im aware that this might not work due to side effects in every file, but i assume most a allready strict and therfore compatible.
- Optional: I encurage you to take a quick look trough you function docs. I Encontered some wich dont provide any additional information to the function or properties. Therefore they are just non-beneficial addition wich may cause inconsistencies in further code developments. 

Best regards,
@iszmais  