### PR TITLE
PHP 8: Code Review `Category and Repository`

### DIFF
--- a/Modules/Category/Export/class.ilCategoryExporter.php
+++ b/Modules/Category/Export/class.ilCategoryExporter.php
@@ -30,34 +30,35 @@ class ilCategoryExporter extends ilXmlExporter
     public function getXmlExportHeadDependencies(string $a_entity, string $a_target_release, array $a_ids) : array
     {
         // always trigger container because of co-page(s)
-        return array(
-            array(
+        return [
+            [
                 'component' => 'Services/Container',
                 'entity' => 'struct',
                 'ids' => $a_ids
-            )
-        );
+            ]
+        ];
     }
     
     public function getXmlExportTailDependencies(string $a_entity, string $a_target_release, array $a_ids) : array
     {
-        if ($a_entity == "cat") {
-            $tax_ids = array();
+        if ($a_entity === "cat") {
+            $tax_ids = [];
             foreach ($a_ids as $id) {
-                $t_ids = ilObjTaxonomy::getUsageOfObject($id);
+                $t_ids = ilObjTaxonomy::getUsageOfObject((int) $id);
                 if (count($t_ids) > 0) {
                     $tax_ids[$t_ids[0]] = $t_ids[0];
                 }
             }
 
-            return array(
-                array(
+            return [
+                [
                     "component" => "Services/Taxonomy",
                     "entity" => "tax",
-                    "ids" => $tax_ids)
-                );
+                    "ids" => $tax_ids
+                ]
+            ];
         }
-        return array();
+        return [];
     }
 
     /**
@@ -66,7 +67,7 @@ class ilCategoryExporter extends ilXmlExporter
      */
     public function getXmlRepresentation(string $a_entity, string $a_schema_version, string $a_id) : string
     {
-        $all_ref = ilObject::_getAllReferences($a_id);
+        $all_ref = ilObject::_getAllReferences((int) $a_id);
         $cat_ref_id = end($all_ref);
         $category = ilObjectFactory::getInstanceByRefId($cat_ref_id, false);
 
@@ -89,14 +90,15 @@ class ilCategoryExporter extends ilXmlExporter
      */
     public function getValidSchemaVersions(string $a_entity) : array
     {
-        return array(
-            "4.3.0" => array(
+        return [
+            "4.3.0" => [
                 "namespace" => "https://www.ilias.de/Modules/Category/cat/4_3",
                 "xsd_file" => "ilias_cat_4_3.xsd",
                 "uses_dataset" => false,
                 "min" => "4.3.0",
-                "max" => "")
-        );
+                "max" => ""
+            ]
+        ];
     }
 
     /**

--- a/Modules/Category/Export/class.ilCategoryImportParser.php
+++ b/Modules/Category/Export/class.ilCategoryImportParser.php
@@ -67,11 +67,6 @@ class ilCategoryImportParser extends ilSaxParser
         xml_set_character_data_handler($a_xml_parser, 'handlerCharacterData');
     }
 
-    public function startParsing() : void
-    {
-        parent::startParsing();
-    }
-
     // generate a tag with given name and attributes
     public function buildTag(
         string $type,
@@ -80,7 +75,7 @@ class ilCategoryImportParser extends ilSaxParser
     ) : string {
         $tag = "<";
 
-        if ($type == "end") {
+        if ($type === "end") {
             $tag .= "/";
         }
 
@@ -97,7 +92,13 @@ class ilCategoryImportParser extends ilSaxParser
         return $tag;
     }
 
-    public function handlerBeginTag($a_xml_parser, $a_name, $a_attribs) : void
+    /**
+     * @param XMLParser|resource $a_xml_parser
+     * @param string $a_name
+     * @param array  $a_attribs
+     * @return void
+     */
+    public function handlerBeginTag($a_xml_parser, string $a_name, array $a_attribs) : void
     {
         switch ($a_name) {
             case "Category":
@@ -119,19 +120,22 @@ class ilCategoryImportParser extends ilSaxParser
         }
     }
 
-
-    public function handlerEndTag($a_xml_parser, $a_name) : void
+    /**
+     * @param XMLParser|resource $a_xml_parser
+     * @param string $a_name
+     * @return void
+     */
+    public function handlerEndTag($a_xml_parser, string $a_name) : void
     {
         switch ($a_name) {
             case "Category":
-                unset($this->category);
-                unset($this->parent[$this->parent_cnt - 1]);
+                unset($this->category, $this->parent[$this->parent_cnt - 1]);
                 $this->parent_cnt--;
                 break;
 
             case "CategorySpec":
                 $is_def = 0;
-                if ($this->cur_spec_lang == $this->default_language) {
+                if ($this->cur_spec_lang === $this->default_language) {
                     $this->category->setTitle($this->cur_title);
                     $this->category->setDescription($this->cur_description);
                     $this->category->update();
@@ -157,14 +161,18 @@ class ilCategoryImportParser extends ilSaxParser
         $this->cdata = "";
     }
 
-    public function handlerCharacterData($a_xml_parser, $a_data) : void
+    /**
+     * @param XMLParser|resource $a_xml_parser
+     * @param string $a_data
+     * @return void
+     */
+    public function handlerCharacterData($a_xml_parser, string $a_data) : void
     {
         // i don't know why this is necessary, but
         // the parser seems to convert "&gt;" to ">" and "&lt;" to "<"
         // in character data, but we don't want that, because it's the
         // way we mask user html in our content, so we convert back...
-        $a_data = str_replace("<", "&lt;", $a_data);
-        $a_data = str_replace(">", "&gt;", $a_data);
+        $a_data = str_replace(["<", ">"], ["&lt;", "&gt;"], $a_data);
 
         // DELETE WHITESPACES AND NEWLINES OF CHARACTER DATA
         $a_data = preg_replace("/\n/", "", $a_data);

--- a/Modules/Category/Export/class.ilCategoryImporter.php
+++ b/Modules/Category/Export/class.ilCategoryImporter.php
@@ -37,30 +37,29 @@ class ilCategoryImporter extends ilXmlImporter
         ilImportMapping $a_mapping
     ) : void {
         if ($new_id = $a_mapping->getMapping('Services/Container', 'objs', $a_id)) {
-            $refs = ilObject::_getAllReferences($new_id);
+            $refs = ilObject::_getAllReferences((int) $new_id);
             $this->category = ilObjectFactory::getInstanceByRefId(end($refs), false);
         }
         // Mapping for containers without subitems
         elseif ($new_id = $a_mapping->getMapping('Services/Container', 'refs', 0)) {
-            $this->category = ilObjectFactory::getInstanceByRefId($new_id, false);
+            $this->category = ilObjectFactory::getInstanceByRefId((int) $new_id, false);
         } elseif (!$this->category instanceof ilObjCategory) {
             $this->category = new ilObjCategory();
             $this->category->create();
         }
-
 
         try {
             $parser = new ilCategoryXmlParser($a_xml, 0);
             $parser->setCategory($this->category);
             $parser->setMode(ilCategoryXmlParser::MODE_UPDATE);
             $parser->startParsing();
-            $a_mapping->addMapping('Modules/Category', 'cat', $a_id, $this->category->getId());
+            $a_mapping->addMapping('Modules/Category', 'cat', $a_id, (string) $this->category->getId());
         } catch (ilSaxParserException | Exception $e) {
             $GLOBALS['ilLog']->write(__METHOD__ . ': Parsing failed with message, "' . $e->getMessage() . '".');
         }
 
         foreach ($a_mapping->getMappingsOfEntity('Services/Container', 'objs') as $old => $new) {
-            $type = ilObject::_lookupType($new);
+            $type = ilObject::_lookupType((int) $new);
             
             // see ilGlossaryImporter::importXmlRepresentation()
             // see ilTaxonomyDataSet::importRecord()
@@ -87,7 +86,7 @@ class ilCategoryImporter extends ilXmlImporter
     ) : void {
         $maps = $a_mapping->getMappingsOfEntity("Modules/Category", "cat");
         foreach ($maps as $old => $new) {
-            if ($old != "new_id" && (int) $old > 0) {
+            if ($old !== "new_id" && (int) $old > 0) {
                 // get all new taxonomys of this object
                 $new_tax_ids = $a_mapping->getMapping("Services/Taxonomy", "tax_usage_of_obj", $old);
                 $tax_ids = explode(":", $new_tax_ids);

--- a/Modules/Category/Export/class.ilCategoryXmlParser.php
+++ b/Modules/Category/Export/class.ilCategoryXmlParser.php
@@ -25,7 +25,7 @@ class ilCategoryXmlParser extends ilSaxParser
 
     private ?ilObjCategory $cat = null;
     private int $parent_id = 0;
-    private array $current_translation = array();
+    private array $current_translation = [];
     private string $current_container_setting;
     protected ilLogger $cat_log;
     protected int $mode;
@@ -35,7 +35,7 @@ class ilCategoryXmlParser extends ilSaxParser
     {
         parent::__construct(null);
 
-        $this->mode = ilCategoryXmlParser::MODE_CREATE;
+        $this->mode = self::MODE_CREATE;
         $this->parent_id = $a_parent_id;
         $this->setXMLContent($a_xml);
 
@@ -48,7 +48,7 @@ class ilCategoryXmlParser extends ilSaxParser
     }
 
     /**
-     * @return mixed[]
+     * @return array
      */
     protected function getCurrentTranslation() : array
     {
@@ -66,11 +66,17 @@ class ilCategoryXmlParser extends ilSaxParser
     {
         parent::startParsing();
 
-        if ($this->mode !== ilCategoryXmlParser::MODE_CREATE) {
+        if ($this->mode !== self::MODE_CREATE) {
             $this->cat->update();
         }
     }
 
+    /**
+     * @param XMLParser|resource $a_xml_parser
+     * @param string $a_name
+     * @param array  $a_attribs
+     * @return void
+     */
     public function handlerBeginTag($a_xml_parser, string $a_name, array $a_attribs) : void
     {
         switch ($a_name) {
@@ -82,7 +88,7 @@ class ilCategoryXmlParser extends ilSaxParser
                 break;
 
             case 'Translation':
-                $this->current_translation = array();
+                $this->current_translation = [];
                 $this->current_translation['default'] = $a_attribs['default'] ? 1 : 0;
                 $this->current_translation['lang'] = $a_attribs['language'];
                 break;
@@ -98,6 +104,11 @@ class ilCategoryXmlParser extends ilSaxParser
         }
     }
 
+    /**
+     * @param XMLParser|resource $a_xml_parser
+     * @param string $a_name
+     * @return void
+     */
     public function handlerEndTag($a_xml_parser, string $a_name) : void
     {
         switch ($a_name) {
@@ -152,11 +163,13 @@ class ilCategoryXmlParser extends ilSaxParser
         $this->cdata = '';
     }
 
+    /**
+     * @param XMLParser|resource $a_xml_parser
+     * @param string $a_data
+     * @return void
+     */
     public function handlerCharacterData($a_xml_parser, string $a_data) : void
     {
-        #$a_data = str_replace("<","&lt;",$a_data);
-        #$a_data = str_replace(">","&gt;",$a_data);
-
         if (!empty($a_data)) {
             $this->cdata .= $a_data;
         }
@@ -168,8 +181,7 @@ class ilCategoryXmlParser extends ilSaxParser
         /**
          * mode can be create or update
          */
-        if ($this->mode == ilCategoryXmlParser::MODE_CREATE) {
-            //$this->create();
+        if ($this->mode === self::MODE_CREATE) {
             $this->getCategory()->create();
             $this->getCategory()->createReference();
             $this->getCategory()->putInTree($this->getParentId());
@@ -189,7 +201,7 @@ class ilCategoryXmlParser extends ilSaxParser
         $this->cat = $cat;
     }
 
-    public function getCategory() : ?\ilObjCategory
+    public function getCategory() : ?ilObjCategory
     {
         return $this->cat;
     }

--- a/Modules/Category/Export/class.ilCategoryXmlWriter.php
+++ b/Modules/Category/Export/class.ilCategoryXmlWriter.php
@@ -54,7 +54,7 @@ class ilCategoryXmlWriter extends ilXmlWriter
 
     public function export(bool $a_with_header = true) : void
     {
-        if ($this->getMode() == self::MODE_EXPORT) {
+        if ($this->getMode() === self::MODE_EXPORT) {
             if ($a_with_header) {
                 $this->buildHeader();
             }
@@ -104,12 +104,13 @@ class ilCategoryXmlWriter extends ilXmlWriter
         foreach ($translations as $translation) {
             $this->xmlStartTag(
                 'Translation',
-                array(
-                'default' => (int) $translation['lang_default'],
-                'language' => $translation['lang_code'])
+                [
+                    'default' => (int) $translation['lang_default'],
+                    'language' => $translation['lang_code']
+                ]
             );
-            $this->xmlElement('Title', array(), $translation['title']);
-            $this->xmlElement('Description', array(), $translation['description']);
+            $this->xmlElement('Title', [], $translation['title']);
+            $this->xmlElement('Description', [], $translation['description']);
             $this->xmlEndTag('Translation');
         }
         $this->xmlEndTag('Translations');

--- a/Modules/Category/classes/class.ilCategoryAssignRoleTableGUI.php
+++ b/Modules/Category/classes/class.ilCategoryAssignRoleTableGUI.php
@@ -20,7 +20,7 @@
 class ilCategoryAssignRoleTableGUI extends ilTable2GUI
 {
     public function __construct(
-        object $a_parent_obj,
+        object $a_parent_obj,// TODO PHP8-REVIEW Maybe you can use the class of the consuming GUI or (if there are several) add a list of valid types by using PHPDoc comments
         string $a_parent_cmd
     ) {
         global $DIC;

--- a/Modules/Category/classes/class.ilCategoryConditionController.php
+++ b/Modules/Category/classes/class.ilCategoryConditionController.php
@@ -20,18 +20,18 @@
  */
 class ilCategoryConditionController implements ilConditionControllerInterface
 {
-    public function isContainerConditionController($a_container_ref_id) : bool
+    public function isContainerConditionController($a_container_ref_id) : bool// TODO PHP8-REVIEW Missing type hint, depends on review of `Condisitions`, please contact your colleague
     {
         return false;
     }
 
-    public function getConditionSetForRepositoryObject($a_container_child_ref_id) : ilConditionSet
+    public function getConditionSetForRepositoryObject($a_container_child_ref_id) : ilConditionSet// TODO PHP8-REVIEW Missing type hint, depends on review of `Condisitions`, please contact your colleague
     {
         global $DIC;
 
         $f = $DIC->conditions()->factory();
 
-        $conditions = array();
+        $conditions = [];
         /*if ($a_container_child_ref_id == 72) {
             //			$conditions[] = $f->condition($f->repositoryTrigger(73), $f->operator()->passed());
         }*/

--- a/Modules/Category/classes/class.ilObjCategory.php
+++ b/Modules/Category/classes/class.ilObjCategory.php
@@ -56,30 +56,32 @@ class ilObjCategory extends ilContainer
         $ilAppEventHandler->raise(
             'Modules/Category',
             'delete',
-            array('object' => $this,
-                'obj_id' => $this->getId())
+            [
+                'object' => $this,
+                'obj_id' => $this->getId()
+            ]
         );
         
         return true;
     }
 
-    public function cloneObject(int $a_target_id, int $a_copy_id = 0, bool $a_omit_tree = false) : ?ilObject
+    public function cloneObject(int $target_id, int $copy_id = 0, bool $omit_tree = false) : ?ilObject
     {
-        $new_obj = parent::cloneObject($a_target_id, $a_copy_id, $a_omit_tree);
+        $new_obj = parent::cloneObject($target_id, $copy_id, $omit_tree);
 
         return $new_obj;
     }
     
-    public function cloneDependencies(int $a_target_id, int $a_copy_id) : bool
+    public function cloneDependencies(int $target_id, int $copy_id) : bool
     {
-        parent::cloneDependencies($a_target_id, $a_copy_id);
+        parent::cloneDependencies($target_id, $copy_id);
     
                                 
         // clone taxonomies
 
         $all_tax = ilObjTaxonomy::getUsageOfObject($this->getId());
-        if (sizeof($all_tax)) {
-            $cwo = ilCopyWizardOptions::_getInstance($a_copy_id);
+        if (count($all_tax)) {
+            $cwo = ilCopyWizardOptions::_getInstance($copy_id);
             $mappings = $cwo->getMappings();
             
             foreach ($all_tax as $old_tax_id) {
@@ -90,7 +92,7 @@ class ilObjCategory extends ilContainer
                     $tax_map = $old_tax->getNodeMapping();
                 
                     // assign new taxonomy to new category
-                    ilObjTaxonomy::saveUsage($new_tax->getId(), ilObject::_lookupObjId($a_target_id));
+                    ilObjTaxonomy::saveUsage($new_tax->getId(), ilObject::_lookupObjId($target_id));
                                                         
                     // clone assignments (for all sub-items)
                     foreach ($mappings as $old_ref_id => $new_ref_id) {
@@ -101,7 +103,7 @@ class ilObjCategory extends ilContainer
                                                                     
                             $tax_ass = new ilTaxNodeAssignment($obj_type, $old_obj_id, "obj", $old_tax_id);
                             $assignmts = $tax_ass->getAssignmentsOfItem($old_obj_id);
-                            if (sizeof($assignmts)) {
+                            if (count($assignmts)) {
                                 $new_tax_ass = new ilTaxNodeAssignment($obj_type, $new_obj_id, "obj", $new_tax->getId());
                                 foreach ($assignmts as $a) {
                                     if ($tax_map[$a["node_id"]]) {

--- a/Modules/Category/classes/class.ilObjCategoryAccess.php
+++ b/Modules/Category/classes/class.ilObjCategoryAccess.php
@@ -33,10 +33,10 @@ class ilObjCategoryAccess extends ilObjectAccess
      *		array("permission" => "write", "cmd" => "edit", "lang_var" => "edit"),
      *	);
      */
-    public static function _getCommands() :array
+    public static function _getCommands() : array
     {
-        $commands = array();
-        $commands[] = array("permission" => "read", "cmd" => "render", "lang_var" => "show", "default" => true);
+        $commands = [];
+        $commands[] = ["permission" => "read", "cmd" => "render", "lang_var" => "show", "default" => true];
 
 
         // BEGIN WebDAV
@@ -45,8 +45,8 @@ class ilObjCategoryAccess extends ilObjectAccess
             $commands[] = $webdav_obj->retrieveWebDAVCommandArrayForActionMenu();
         }
         // END WebDAV
-        $commands[] = array("permission" => "write", "cmd" => "enableAdministrationPanel", "lang_var" => "edit_content");
-        $commands[] = array("permission" => "write", "cmd" => "edit", "lang_var" => "settings");
+        $commands[] = ["permission" => "write", "cmd" => "enableAdministrationPanel", "lang_var" => "edit_content"];
+        $commands[] = ["permission" => "write", "cmd" => "edit", "lang_var" => "settings"];
         
         return $commands;
     }
@@ -62,12 +62,12 @@ class ilObjCategoryAccess extends ilObjectAccess
         
         $t_arr = explode("_", $target);
 
-        if ($t_arr[0] != "cat" || ((int) $t_arr[1]) <= 0) {
+        if ($t_arr[0] !== "cat" || ((int) $t_arr[1]) <= 0) {
             return false;
         }
 
-        if ($ilAccess->checkAccess("read", "", $t_arr[1]) ||
-            $ilAccess->checkAccess("visible", "", $t_arr[1])) {
+        if ($ilAccess->checkAccess("read", "", (int) $t_arr[1]) ||
+            $ilAccess->checkAccess("visible", "", (int) $t_arr[1])) {
             return true;
         }
         return false;

--- a/Modules/Category/classes/class.ilObjCategoryGUI.php
+++ b/Modules/Category/classes/class.ilObjCategoryGUI.php
@@ -49,7 +49,7 @@ class ilObjCategoryGUI extends ilContainerGUI
         /** @var \ILIAS\DI\Container $DIC */
         global $DIC;
 
-        $this->rbacsystem = $DIC->rbac()->system();
+        $this->rbacsystem = $DIC->rbac()->system();// TODO PHP8-REVIEW Property dynamically declared
         $this->nav_history = $DIC["ilNavigationHistory"];
         $this->access = $DIC->access();
         $this->ctrl = $DIC->ctrl();
@@ -62,7 +62,7 @@ class ilObjCategoryGUI extends ilContainerGUI
         $this->settings = $DIC->settings();
         $this->tpl = $DIC["tpl"];
         $this->toolbar = $DIC->toolbar();
-        $this->rbacreview = $DIC->rbac()->review();
+        $this->rbacreview = $DIC->rbac()->review();// TODO PHP8-REVIEW Property dynamically declared
         $this->rbacadmin = $DIC->rbac()->admin();
         //global $ilCtrl;
 
@@ -103,14 +103,14 @@ class ilObjCategoryGUI extends ilContainerGUI
         switch ($next_class) {
 
             case strtolower(ilRepositoryTrashGUI::class):
-                $ru = new \ilRepositoryTrashGUI($this);
+                $ru = new ilRepositoryTrashGUI($this);
                 $this->ctrl->setReturn($this, 'trash');
                 $this->ctrl->forwardCommand($ru);
                 break;
 
             case "ilobjusergui":
                 $this->tabs_gui->setTabActive('administrate_users');
-                if ($this->cat_request->getObjId() == 0) {
+                if ($this->cat_request->getObjId() === 0) {
                     $this->gui_obj = new ilObjUserGUI(
                         "",
                         $this->cat_request->getRefId(),
@@ -140,8 +140,7 @@ class ilObjCategoryGUI extends ilContainerGUI
                 $this->gui_obj = new ilObjUserFolderGUI(
                     "",
                     $this->cat_request->getRefId(),
-                    true,
-                    false
+                    true
                 );
                 $this->gui_obj->setUserOwnerId($this->cat_request->getRefId());
                 $this->gui_obj->setCreationMode($this->creation_mode);
@@ -183,7 +182,7 @@ class ilObjCategoryGUI extends ilContainerGUI
             case "ilcontainerpagegui":
                 $this->prepareOutput(false);
                 $ret = $this->forwardToPageObject();
-                if ($ret != "") {
+                if ($ret !== "") {
                     $this->tpl->setContent($ret);
                 }
                 $header_action = false;
@@ -282,7 +281,7 @@ class ilObjCategoryGUI extends ilContainerGUI
                 break;
 
             default:
-                if ($cmd == "infoScreen") {
+                if ($cmd === "infoScreen") {
                     $this->checkPermission("visible");
                 } else {
                     $this->checkPermission("read");
@@ -341,7 +340,7 @@ class ilObjCategoryGUI extends ilContainerGUI
             $tax->setMultiple(true);
             $tax->setListInfo($this->lng->txt("cntr_tax_list_info"));
             $taxonomies = $this->getTaxonomiesForRefId();
-            if (sizeof($taxonomies)) {
+            if (count($taxonomies)) {
                 $md_gui->setTaxonomySettings(function ($form) {
                     $tax = $this->getTaxonomiesForRefId();
                     $block = new ilCheckboxGroupInputGUI($this->lng->txt("cntr_taxonomy_show_sideblock"), "sblock");
@@ -357,10 +356,10 @@ class ilObjCategoryGUI extends ilContainerGUI
                             ilObject::_lookupDescription($tax_id)
                         );
 
-                        if ($tax_item["source"] != $this->object->getRefId()) {
+                        if ((int) $tax_item["source"] !== $this->object->getRefId()) {
                             $loc = new ilLocatorGUI();
                             $loc->setTextOnly(true);
-                            $loc->addRepositoryItems($tax_item["source"]);
+                            $loc->addRepositoryItems((int) $tax_item["source"]);
                             $option->setInfo($loc->getHTML());
                         }
 
@@ -374,7 +373,7 @@ class ilObjCategoryGUI extends ilContainerGUI
                     $block->setValue($value);
                 }, function ($form) {
                     $taxonomies = $this->getTaxonomiesForRefId();
-                    if (sizeof($taxonomies)) {
+                    if (count($taxonomies)) {
                         $sblock = $form->getInput("sblock");
 
                         $prefix = self::CONTAINER_SETTING_TAXBLOCK;
@@ -408,7 +407,7 @@ class ilObjCategoryGUI extends ilContainerGUI
         $ilHelp = $this->help;
         $ilAccess = $this->access;
 
-        if ($this->ctrl->getCmd() == "editPageContent") {
+        if ($this->ctrl->getCmd() === "editPageContent") {
             return;
         }
 
@@ -423,15 +422,15 @@ class ilObjCategoryGUI extends ilContainerGUI
 
             //BEGIN ChangeEvent add info tab to category object
             if ($this->info_screen_enabled) {
-                $force_active = $this->ctrl->getNextClass() == "ilinfoscreengui"
-                    || strtolower($this->cat_request->getCmdClass()) == "ilnotegui";
+                $force_active = $this->ctrl->getNextClass() === "ilinfoscreengui"
+                    || strtolower($this->cat_request->getCmdClass()) === "ilnotegui";
                 $this->tabs_gui->addTarget(
                     "info_short",
                     $this->ctrl->getLinkTargetByClass(
-                        array("ilobjcategorygui", "ilinfoscreengui"),
+                        ["ilobjcategorygui", "ilinfoscreengui"],
                         "showSummary"
                     ),
-                    array("showSummary","", "infoScreen"),
+                    ["showSummary", "", "infoScreen"],
                     "",
                     "",
                     $force_active
@@ -441,7 +440,7 @@ class ilObjCategoryGUI extends ilContainerGUI
         }
         
         if ($rbacsystem->checkAccess('write', $this->ref_id)) {
-            $force_active = ($this->ctrl->getCmd() == "edit");
+            $force_active = ($this->ctrl->getCmd() === "edit");
             $this->tabs_gui->addTarget(
                 "settings",
                 $this->ctrl->getLinkTarget($this, "edit"),
@@ -472,8 +471,7 @@ class ilObjCategoryGUI extends ilContainerGUI
             }
         }
 
-        if (
-            ilUserAccountSettings::getInstance()->isLocalUserAdministrationEnabled() and
+        if (ilUserAccountSettings::getInstance()->isLocalUserAdministrationEnabled() &&
             $rbacsystem->checkAccess('cat_administrate_users', $this->ref_id)) {
             $this->tabs_gui->addTarget(
                 "administrate_users",
@@ -516,7 +514,7 @@ class ilObjCategoryGUI extends ilContainerGUI
 
     public function viewObject() : void
     {
-        if (strtolower($this->cat_request->getBaseClass()) == "iladministrationgui") {
+        if (strtolower($this->cat_request->getBaseClass()) === "iladministrationgui") {
             parent::viewObject();
             return;
         }
@@ -611,7 +609,7 @@ class ilObjCategoryGUI extends ilContainerGUI
         $info->addMetaDataSections($this->object->getId(), 0, $this->object->getType());
         
         // forward the command
-        if ($ilCtrl->getNextClass() == "ilinfoscreengui") {
+        if ($ilCtrl->getNextClass() === "ilinfoscreengui") {
             $ilCtrl->forwardCommand($info);
         } else {
             return $ilCtrl->getHTML($info);
@@ -751,11 +749,11 @@ class ilObjCategoryGUI extends ilContainerGUI
         // sorting
         $form = $this->initSortingForm(
             $form,
-            array(
+            [
                     ilContainer::SORT_TITLE,
                     ilContainer::SORT_CREATION,
                     ilContainer::SORT_MANUAL
-                )
+            ]
         );
 
         // block limit
@@ -778,14 +776,14 @@ class ilObjCategoryGUI extends ilContainerGUI
         ilObjectServiceSettingsGUI::initServiceSettingsForm(
             $this->object->getId(),
             $form,
-            array(
+            [
                     ilObjectServiceSettingsGUI::INFO_TAB_VISIBILITY,
                     ilObjectServiceSettingsGUI::NEWS_VISIBILITY,
                     ilObjectServiceSettingsGUI::TAXONOMIES,
                     ilObjectServiceSettingsGUI::CUSTOM_METADATA,
                     ilObjectServiceSettingsGUI::TAG_CLOUD,
                     ilObjectServiceSettingsGUI::FILTER
-                )
+            ]
         );
 
         $form->addCommandButton("update", $this->lng->txt("save"));
@@ -842,14 +840,14 @@ class ilObjCategoryGUI extends ilContainerGUI
                 ilObjectServiceSettingsGUI::updateServiceSettingsForm(
                     $this->object->getId(),
                     $form,
-                    array(
+                    [
                         ilObjectServiceSettingsGUI::INFO_TAB_VISIBILITY,
                         ilObjectServiceSettingsGUI::NEWS_VISIBILITY,
                         ilObjectServiceSettingsGUI::TAXONOMIES,
                         ilObjectServiceSettingsGUI::CUSTOM_METADATA,
                         ilObjectServiceSettingsGUI::TAG_CLOUD,
                         ilObjectServiceSettingsGUI::FILTER
-                    )
+                    ]
                 );
 
                 // block limit
@@ -935,7 +933,8 @@ class ilObjCategoryGUI extends ilContainerGUI
             "Modules/Category"
         );
 
-        if (count($rbacreview->getGlobalAssignableRoles()) or in_array(SYSTEM_ROLE_ID, $rbacreview->assignedRoles($ilUser->getId()))) {
+        if (count($rbacreview->getGlobalAssignableRoles()) ||
+            in_array(SYSTEM_ROLE_ID, $rbacreview->assignedRoles($ilUser->getId()), true)) {
             $ilToolbar->addButton(
                 $this->lng->txt('add_user'),
                 $this->ctrl->getLinkTargetByClass('ilobjusergui', 'create')
@@ -970,7 +969,7 @@ class ilObjCategoryGUI extends ilContainerGUI
     protected function addUserAutoCompleteObject() : void
     {
         $auto = new ilUserAutoComplete();
-        $auto->setSearchFields(array('login','firstname','lastname','email'));
+        $auto->setSearchFields(['login', 'firstname', 'lastname', 'email']);
         $auto->enableFieldSearchableCheck(true);
         //$auto->isMoreLinkAvailable(true);
 
@@ -987,8 +986,8 @@ class ilObjCategoryGUI extends ilContainerGUI
         $this->checkPermission("cat_administrate_users");
 
         foreach ($this->cat_request->getUserIds() as $user_id) {
-            if (!in_array($user_id, ilLocalUser::_getAllUserIds($this->object->getRefId()))) {
-                die('user id not valid');
+            if (!in_array($user_id, ilLocalUser::_getAllUserIds($this->object->getRefId()), true)) {
+                die('user id not valid');// TODO PHP8-REVIEW Throw an exception instead and log the issue
             }
             if (!$tmp_obj = ilObjectFactory::getInstanceByObjId($user_id, false)) {
                 continue;
@@ -1002,7 +1001,7 @@ class ilObjCategoryGUI extends ilContainerGUI
     public function deleteUsersObject() : void
     {
         $this->checkPermission("cat_administrate_users");
-        if ($this->cat_request->getIds() == 0) {
+        if ($this->cat_request->getIds() === []) {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('no_users_selected'));
             $this->listUsersObject();
             return;
@@ -1033,7 +1032,7 @@ class ilObjCategoryGUI extends ilContainerGUI
         
         $this->checkPermission("cat_administrate_users");
 
-        if ($this->cat_request->getObjId() == 0) {
+        if ($this->cat_request->getObjId() === 0) {
             $this->tpl->setOnScreenMessage('failure', 'no_user_selected');
             $this->listUsersObject();
             return;
@@ -1047,33 +1046,26 @@ class ilObjCategoryGUI extends ilContainerGUI
         $ilHelp->setSubScreenId("assign_roles");
 
 
-        $roles = $this->__getAssignableRoles();
-        
-        if (!count($roles)) {
-            #ilUtil::sendInfo($this->lng->txt('no_roles_user_can_be_assigned_to'));
-            #$this->listUsersObject();
-
-            #return true;
-        }
+        $roles = $this->getAssignableRoles();
         
         $ass_roles = $rbacreview->assignedRoles($this->cat_request->getObjId());
 
         $counter = 0;
-        $f_result = array();
+        $f_result = [];
         
         foreach ($roles as $role) {
-            $role_obj = ilObjectFactory::getInstanceByObjId($role['obj_id']);
+            $role_obj = ilObjectFactory::getInstanceByObjId((int) $role['obj_id']);
             
             $disabled = false;
             $f_result[$counter]['checkbox'] = ilLegacyFormElementsUtil::formCheckbox(
-                in_array($role['obj_id'], $ass_roles) ? 1 : 0,
+                in_array((int) $role['obj_id'], $ass_roles, true) ? 1 : 0,
                 'role_ids[]',
                 $role['obj_id'],
                 $disabled
             );
-            $f_result[$counter]['title'] = $role_obj->getTitle() ? $role_obj->getTitle() : "";
+            $f_result[$counter]['title'] = $role_obj->getTitle() ?: "";
             $f_result[$counter]['desc'] = $role_obj->getDescription() ?: "";
-            $f_result[$counter]['type'] = $role['role_type'] == 'global' ?
+            $f_result[$counter]['type'] = $role['role_type'] === 'global' ?
                 $this->lng->txt('global') :
                 $this->lng->txt('local');
             
@@ -1096,16 +1088,16 @@ class ilObjCategoryGUI extends ilContainerGUI
         $this->checkPermission("cat_administrate_users");
 
         // check hack
-        if ($this->cat_request->getObjId() == 0 or
-            !in_array($this->cat_request->getObjId(), ilLocalUser::_getAllUserIds())) {
+        if ($this->cat_request->getObjId() === 0 ||
+            !in_array($this->cat_request->getObjId(), ilLocalUser::_getAllUserIds(), true)) {
             $this->tpl->setOnScreenMessage('failure', 'no_user_selected');
             $this->listUsersObject();
             return;
         }
-        $roles = $this->__getAssignableRoles();
+        $roles = $this->getAssignableRoles();
 
         // check minimum one global role
-        if (!$this->__checkGlobalRoles($this->cat_request->getRoleIds())) {
+        if (!$this->checkGlobalRoles($this->cat_request->getRoleIds())) {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('no_global_role_left'));
             $this->assignRolesObject();
             return;
@@ -1114,10 +1106,10 @@ class ilObjCategoryGUI extends ilContainerGUI
         $new_role_ids = $this->cat_request->getRoleIds();
         $assigned_roles = $rbacreview->assignedRoles($this->cat_request->getObjId());
         foreach ($roles as $role) {
-            if (in_array($role['obj_id'], $new_role_ids) and !in_array($role['obj_id'], $assigned_roles)) {
+            if (in_array((int) $role['obj_id'], $new_role_ids, true) && !in_array((int) $role['obj_id'], $assigned_roles, true)) {
                 $rbacadmin->assignUser((int) $role['obj_id'], $this->cat_request->getObjId());
             }
-            if (in_array($role['obj_id'], $assigned_roles) and !in_array($role['obj_id'], $new_role_ids)) {
+            if (in_array((int) $role['obj_id'], $assigned_roles, true) && !in_array((int) $role['obj_id'], $new_role_ids, true)) {
                 $rbacadmin->deassignUser((int) $role['obj_id'], $this->cat_request->getObjId());
             }
         }
@@ -1126,7 +1118,7 @@ class ilObjCategoryGUI extends ilContainerGUI
     }
 
     // PRIVATE
-    public function __getAssignableRoles() : array
+    private function getAssignableRoles() : array
     {
         $rbacreview = $this->rbacreview;
         $ilUser = $this->user;
@@ -1134,20 +1126,20 @@ class ilObjCategoryGUI extends ilContainerGUI
         // check local user
         $tmp_obj = ilObjectFactory::getInstanceByObjId($this->cat_request->getObjId());
         // Admin => all roles
-        if (in_array(SYSTEM_ROLE_ID, $rbacreview->assignedRoles($ilUser->getId()))) {
+        if (in_array(SYSTEM_ROLE_ID, $rbacreview->assignedRoles($ilUser->getId()), true)) {
             $global_roles = $rbacreview->getGlobalRolesArray();
-        } elseif ($tmp_obj->getTimeLimitOwner() == $this->object->getRefId()) {
+        } elseif ($tmp_obj->getTimeLimitOwner() === $this->object->getRefId()) {
             $global_roles = $rbacreview->getGlobalAssignableRoles();
         } else {
-            $global_roles = array();
+            $global_roles = [];
         }
-        return $roles = array_merge(
+        return array_merge(
             $global_roles,
             $rbacreview->getAssignableChildRoles($this->object->getRefId())
         );
     }
 
-    public function __checkGlobalRoles($new_assigned) : bool
+    private function checkGlobalRoles($new_assigned) : bool
     {
         $rbacreview = $this->rbacreview;
         $ilUser = $this->user;
@@ -1156,22 +1148,22 @@ class ilObjCategoryGUI extends ilContainerGUI
 
         // return true if it's not a local user
         $tmp_obj = ilObjectFactory::getInstanceByObjId($this->cat_request->getObjId());
-        if ($tmp_obj->getTimeLimitOwner() != $this->object->getRefId() and
-           !in_array(SYSTEM_ROLE_ID, $rbacreview->assignedRoles($ilUser->getId()))) {
+        if ($tmp_obj->getTimeLimitOwner() !== $this->object->getRefId() &&
+           !in_array(SYSTEM_ROLE_ID, $rbacreview->assignedRoles($ilUser->getId()), true)) {
             return true;
         }
 
         // new assignment by form
-        $new_assigned = $new_assigned ?: array();
+        $new_assigned = $new_assigned ?: [];
         $assigned = $rbacreview->assignedRoles($this->cat_request->getObjId());
 
         // all assignable globals
-        if (!in_array(SYSTEM_ROLE_ID, $rbacreview->assignedRoles($ilUser->getId()))) {
+        if (!in_array(SYSTEM_ROLE_ID, $rbacreview->assignedRoles($ilUser->getId()), true)) {
             $ga = $rbacreview->getGlobalAssignableRoles();
         } else {
             $ga = $rbacreview->getGlobalRolesArray();
         }
-        $global_assignable = array();
+        $global_assignable = [];
         foreach ($ga as $role) {
             $global_assignable[] = $role['obj_id'];
         }
@@ -1180,13 +1172,13 @@ class ilObjCategoryGUI extends ilContainerGUI
         $all_assigned_roles = array_intersect($assigned, $rbacreview->getGlobalRoles());
         $main_assigned_roles = array_diff($all_assigned_roles, $global_assignable);
 
-        if (!count($new_visible_assigned_roles) and !count($main_assigned_roles)) {
+        if (!count($new_visible_assigned_roles) && !count($main_assigned_roles)) {
             return false;
         }
         return true;
     }
     
-    public static function _goto($a_target) : void
+    public static function _goto($a_target) : void// TODO PHP8-REVIEW Missing type hint, but this might be an issue of the `goto.php` to be discussed with all code maintainers
     {
         global $DIC;
         $main_tpl = $DIC->ui()->mainTemplate();
@@ -1235,18 +1227,18 @@ class ilObjCategoryGUI extends ilContainerGUI
         
         // see ilTaxMDGUI::getSelectableTaxonomies()
         
-        $res = array();
+        $res = [];
         foreach ($tree->getPathFull($this->object->getRefId()) as $node) {
             //if ($node["ref_id"] != $this->object->getRefId())
             {
                 // find all defined taxes for parent node, activation is not relevant
                 $node_taxes = ilObjTaxonomy::getUsageOfObject($node["obj_id"], true);
-                if (sizeof($node_taxes)) {
+                if (count($node_taxes)) {
                     foreach ($node_taxes as $node_tax) {
-                        $res[$node_tax["tax_id"]] = array(
+                        $res[$node_tax["tax_id"]] = [
                             "title" => $node_tax["title"]
                         , "source" => $node["child"]
-                        );
+                        ];
                     }
                 }
             }
@@ -1256,15 +1248,14 @@ class ilObjCategoryGUI extends ilContainerGUI
         return $res;
     }
 
-
     protected function getActiveBlocks() : array
     {
-        $res = array();
+        $res = [];
         
         $prefix = self::CONTAINER_SETTING_TAXBLOCK;
         
         foreach (ilContainer::_getContainerSettings($this->object->getId()) as $keyword => $value) {
-            if (substr($keyword, 0, strlen($prefix)) == $prefix && $value) {
+            if ($value && strpos($keyword, $prefix) === 0) {
                 $res[] = substr($keyword, strlen($prefix));
             }
         }

--- a/Modules/Category/classes/class.ilObjCategoryListGUI.php
+++ b/Modules/Category/classes/class.ilObjCategoryListGUI.php
@@ -80,22 +80,6 @@ class ilObjCategoryListGUI extends ilObjectListGUI
         return false;
     }
 
-    /**
-    * Get command target frame.
-    *
-    * Overwrite this method if link frame is not current frame
-    *
-    * @param	string		$cmd			command
-    *
-    * @return	string		command target frame
-    */
-    public function getCommandFrame(string $cmd) : string
-    {
-        // begin-patch fm
-        return parent::getCommandFrame($cmd);
-        // end-patch fm
-    }
-
     public function getCommandLink(string $cmd) : string
     {
         $ilCtrl = $this->ctrl;

--- a/Modules/Category/test/CatStandardGUIRequestTest.php
+++ b/Modules/Category/test/CatStandardGUIRequestTest.php
@@ -9,13 +9,6 @@ use PHPUnit\Framework\TestCase;
  */
 class CatStandardGUIRequestTest extends TestCase
 {
-    //protected $backupGlobals = false;
-
-    protected function setUp() : void
-    {
-        parent::setUp();
-    }
-
     protected function tearDown() : void
     {
     }
@@ -37,7 +30,7 @@ class CatStandardGUIRequestTest extends TestCase
     /**
      * Test ref id
      */
-    public function testRefId()
+    public function testRefId() : void
     {
         $request = $this->getRequest(
             [
@@ -55,7 +48,7 @@ class CatStandardGUIRequestTest extends TestCase
     /**
      * Test no ref id
      */
-    public function testNoRefId()
+    public function testNoRefId() : void
     {
         $request = $this->getRequest(
             [
@@ -72,7 +65,7 @@ class CatStandardGUIRequestTest extends TestCase
     /**
      * Test base class
      */
-    public function testBaseClass()
+    public function testBaseClass() : void
     {
         $request = $this->getRequest(
             [
@@ -90,7 +83,7 @@ class CatStandardGUIRequestTest extends TestCase
     /**
      * Test cmd class
      */
-    public function testCmdClass()
+    public function testCmdClass() : void
     {
         $request = $this->getRequest(
             [
@@ -108,7 +101,7 @@ class CatStandardGUIRequestTest extends TestCase
     /**
      * Test term
      */
-    public function testTerm()
+    public function testTerm() : void
     {
         $request = $this->getRequest(
             [
@@ -126,7 +119,7 @@ class CatStandardGUIRequestTest extends TestCase
     /**
      * Test term by post
      */
-    public function testTermByPost()
+    public function testTermByPost() : void
     {
         $request = $this->getRequest(
             [
@@ -145,7 +138,7 @@ class CatStandardGUIRequestTest extends TestCase
     /**
      * Test that post values overwrite get values
      */
-    public function testPostBeatsGet()
+    public function testPostBeatsGet() : void
     {
         $request = $this->getRequest(
             [
@@ -165,7 +158,7 @@ class CatStandardGUIRequestTest extends TestCase
     /**
      * Test fetch all
      */
-    public function testFetchAll()
+    public function testFetchAll() : void
     {
         $request = $this->getRequest(
             [
@@ -183,7 +176,7 @@ class CatStandardGUIRequestTest extends TestCase
     /**
      * Test role ids
      */
-    public function testRoleIds()
+    public function testRoleIds() : void
     {
         $request = $this->getRequest(
             [
@@ -204,7 +197,7 @@ class CatStandardGUIRequestTest extends TestCase
     /**
      * Test user ids
      */
-    public function testUserIds()
+    public function testUserIds() : void
     {
         $request = $this->getRequest(
             [
@@ -225,7 +218,7 @@ class CatStandardGUIRequestTest extends TestCase
     /**
      * Test obj id
      */
-    public function testObjId()
+    public function testObjId() : void
     {
         $request = $this->getRequest(
             [

--- a/Modules/Category/test/ilModulesCategorySuite.php
+++ b/Modules/Category/test/ilModulesCategorySuite.php
@@ -22,7 +22,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilModulesCategorySuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new self();
 

--- a/Modules/CategoryReference/Export/class.ilCategoryReferenceImporter.php
+++ b/Modules/CategoryReference/Export/class.ilCategoryReferenceImporter.php
@@ -21,19 +21,12 @@
  */
 class ilCategoryReferenceImporter extends ilContainerReferenceImporter
 {
-        
-    /**
-     * Get reference type
-     */
     protected function getType() : string
     {
         return 'catr';
     }
     
-    /**
-     * Init xml parser
-     */
-    protected function initParser($a_xml) : ilContainerReferenceXmlParser
+    protected function initParser(string $a_xml) : ilContainerReferenceXmlParser
     {
         return new ilCategoryReferenceXmlParser($a_xml);
     }

--- a/Modules/CategoryReference/classes/class.ilObjCategoryReferenceAccess.php
+++ b/Modules/CategoryReference/classes/class.ilObjCategoryReferenceAccess.php
@@ -34,7 +34,7 @@ class ilObjCategoryReferenceAccess extends ilContainerReferenceAccess
      *		array("permission" => "write", "cmd" => "edit", "lang_var" => "edit"),
      *	);
      */
-    public static function _getCommands($a_ref_id = null) : array
+    public static function _getCommands($a_ref_id = null) : array// TODO PHP8-REVIEW There is no parameter defined in the base class / Furthermore the type is missing here
     {
         global $DIC;
 
@@ -42,10 +42,10 @@ class ilObjCategoryReferenceAccess extends ilContainerReferenceAccess
 
         if ($ilAccess->checkAccess('write', '', $a_ref_id)) {
             // Only local (reference specific commands)
-            $commands = array(
-                array("permission" => "visible", "cmd" => "", "lang_var" => "show","default" => true),
-                array("permission" => "write", "cmd" => "editReference", "lang_var" => "settings")
-            );
+            $commands = [
+                ["permission" => "visible", "cmd" => "", "lang_var" => "show", "default" => true],
+                ["permission" => "write", "cmd" => "editReference", "lang_var" => "settings"]
+            ];
         } else {
             $commands = ilObjCategoryAccess::_getCommands();
         }

--- a/Modules/CategoryReference/classes/class.ilObjCategoryReferenceGUI.php
+++ b/Modules/CategoryReference/classes/class.ilObjCategoryReferenceGUI.php
@@ -37,12 +37,7 @@ class ilObjCategoryReferenceGUI extends ilContainerReferenceGUI implements ilCtr
         parent::__construct($a_data, $a_id, true, false);
     }
 
-    public function executeCommand() : void
-    {
-        parent::executeCommand();
-    }
-
-    public static function _goto($a_target)
+    public static function _goto($a_target) : void// TODO PHP8-REVIEW Missing type hint, but this might be an issue of the `goto.php` to be discussed with all code maintainers
     {
         $target_ref_id = ilContainerReference::_lookupTargetRefId(ilObject::_lookupObjId($a_target));
         ilObjCategoryGUI::_goto($target_ref_id);

--- a/Modules/CategoryReference/classes/class.ilObjCategoryReferenceListGUI.php
+++ b/Modules/CategoryReference/classes/class.ilObjCategoryReferenceListGUI.php
@@ -113,7 +113,7 @@ class ilObjCategoryReferenceListGUI extends ilObjCategoryListGUI
         // general commands array
         $this->commands = ilObjCategoryReferenceAccess::_getCommands($this->reference_ref_id);
 
-        if ($ilAccess->checkAccess('write', '', $this->reference_ref_id) or $this->deleted) {
+        if ($this->deleted || $ilAccess->checkAccess('write', '', $this->reference_ref_id)) {
             $this->info_screen_enabled = false;
         } else {
             $this->info_screen_enabled = true;
@@ -127,14 +127,16 @@ class ilObjCategoryReferenceListGUI extends ilObjCategoryListGUI
         $tree = $this->tree;
 
         $props = parent::getProperties();
-        
+
         // offline
         if ($tree->isDeleted($this->ref_id)) {
-            $props[] = array("alert" => true, "property" => $lng->txt("status"),
-                "value" => $lng->txt("reference_deleted"));
+            $props[] = [
+                "alert" => true, "property" => $lng->txt("status"),
+                "value" => $lng->txt("reference_deleted")
+            ];
         }
 
-        return $props ?: array();
+        return $props;
     }
     
     public function checkCommandAccess(

--- a/Modules/CategoryReference/test/CategoryReferenceTest.php
+++ b/Modules/CategoryReference/test/CategoryReferenceTest.php
@@ -9,8 +9,6 @@ use PHPUnit\Framework\TestCase;
  */
 class CategoryReferenceTest extends TestCase
 {
-    //protected $backupGlobals = false;
-
     protected function setUp() : void
     {
         $dic = new ILIAS\DI\Container();
@@ -23,8 +21,8 @@ class CategoryReferenceTest extends TestCase
             $this->createConfiguredMock(
                 ilAccess::class,
                 [
-                "checkAccess" => true
-            ]
+                    "checkAccess" => true
+                ]
             )
         );
     }
@@ -52,7 +50,7 @@ class CategoryReferenceTest extends TestCase
     /**
      * Test commands
      */
-    public function testCommands()
+    public function testCommands() : void
     {
         $commands = ilObjCategoryReferenceAccess::_getCommands(10);
         $this->assertIsArray($commands);

--- a/Modules/CategoryReference/test/ilModulesCategoryReferenceSuite.php
+++ b/Modules/CategoryReference/test/ilModulesCategoryReferenceSuite.php
@@ -22,7 +22,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilModulesCategoryReferenceSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new self();
 

--- a/Modules/CourseReference/classes/class.ilCourseReferenceImporter.php
+++ b/Modules/CourseReference/classes/class.ilCourseReferenceImporter.php
@@ -16,21 +16,13 @@ include_once './Services/ContainerReference/classes/class.ilContainerReferenceIm
 */
 class ilCourseReferenceImporter extends ilContainerReferenceImporter
 {
-        
-    /**
-     * Get reference type
-     */
     protected function getType() : string
     {
         return 'crsr';
     }
     
-    /**
-     * Init xml parser
-     */
-    protected function initParser($a_xml) : ilContainerReferenceXmlParser
+    protected function initParser(string $a_xml) : ilContainerReferenceXmlParser
     {
-        include_once './Modules/CourseReference/classes/class.ilCourseReferenceXmlParser.php';
         return new ilCourseReferenceXmlParser($a_xml);
     }
 }

--- a/Modules/Folder/classes/class.ilFolderExporter.php
+++ b/Modules/Folder/classes/class.ilFolderExporter.php
@@ -26,13 +26,13 @@ class ilFolderExporter extends ilXmlExporter
     public function getXmlExportHeadDependencies(string $a_entity, string $a_target_release, array $a_ids) : array
     {
         // always trigger container because of co-page(s)
-        return array(
-            array(
+        return [
+            [
                 'component' => 'Services/Container',
                 'entity' => 'struct',
                 'ids' => $a_ids
-            )
-        );
+            ]
+        ];
     }
     
     public function getXmlRepresentation(string $a_entity, string $a_schema_version, string $a_id) : string
@@ -40,7 +40,7 @@ class ilFolderExporter extends ilXmlExporter
         try {
             $writer = null;
             $writer = new ilFolderXmlWriter(false);
-            $writer->setObjId($a_id);
+            $writer->setObjId((int) $a_id);
             $writer->write();
             return $writer->xmlDumpMem(false);
         } catch (UnexpectedValueException $e) {
@@ -51,13 +51,14 @@ class ilFolderExporter extends ilXmlExporter
     
     public function getValidSchemaVersions(string $a_entity) : array
     {
-        return array(
-            "4.1.0" => array(
+        return [
+            "4.1.0" => [
                 "namespace" => "https://www.ilias.de/Modules/Folder/fold/4_1",
                 "xsd_file" => "ilias_fold_4_1.xsd",
                 "uses_dataset" => false,
                 "min" => "4.1.0",
-                "max" => "")
-        );
+                "max" => ""
+            ]
+        ];
     }
 }

--- a/Modules/Folder/classes/class.ilFolderImporter.php
+++ b/Modules/Folder/classes/class.ilFolderImporter.php
@@ -30,9 +30,9 @@ class ilFolderImporter extends ilXmlImporter
     public function importXmlRepresentation(string $a_entity, string $a_id, string $a_xml, ilImportMapping $a_mapping) : void
     {
         if ($new_id = $a_mapping->getMapping('Services/Container', 'objs', $a_id)) {
-            $this->folder = ilObjectFactory::getInstanceByObjId($new_id, false);
-        } elseif ($new_id = $a_mapping->getMapping('Services/Container', 'refs', 0)) {
-            $this->folder = ilObjectFactory::getInstanceByRefId($new_id, false);
+            $this->folder = ilObjectFactory::getInstanceByObjId((int) $new_id, false);
+        } elseif ($new_id = $a_mapping->getMapping('Services/Container', 'refs', '0')) {
+            $this->folder = ilObjectFactory::getInstanceByRefId((int) $new_id, false);
         } elseif (!$this->folder instanceof ilObjFolder) {
             $this->folder = new ilObjFolder();
             $this->folder->create();
@@ -41,7 +41,7 @@ class ilFolderImporter extends ilXmlImporter
         try {
             $parser = new ilFolderXmlParser($this->folder, $a_xml);
             $parser->start();
-            $a_mapping->addMapping('Modules/Folder', 'fold', $a_id, $this->folder->getId());
+            $a_mapping->addMapping('Modules/Folder', 'fold', $a_id, (string) $this->folder->getId());
         } catch (ilSaxParserException $e) {
             $GLOBALS['ilLog']->write(__METHOD__ . ': Parsing failed with message, "' . $e->getMessage() . '".');
         }

--- a/Modules/Folder/classes/class.ilFolderLP.php
+++ b/Modules/Folder/classes/class.ilFolderLP.php
@@ -20,11 +20,11 @@
  */
 class ilFolderLP extends ilObjectLP
 {
-    public static function getDefaultModes(bool $a_lp_active) : array
+    public static function getDefaultModes(bool $lp_active) : array
     {
-        return array(
+        return [
             ilLPObjSettings::LP_MODE_DEACTIVATED
-        );
+        ];
     }
     
     public function getDefaultMode() : int
@@ -34,9 +34,9 @@ class ilFolderLP extends ilObjectLP
     
     public function getValidModes() : array
     {
-        return array(
+        return [
             ilLPObjSettings::LP_MODE_DEACTIVATED,
             ilLPObjSettings::LP_MODE_COLLECTION
-        );
+        ];
     }
 }

--- a/Modules/Folder/classes/class.ilFolderXmlParser.php
+++ b/Modules/Folder/classes/class.ilFolderXmlParser.php
@@ -21,13 +21,10 @@
 class ilFolderXmlParser extends ilSaxParser
 {
     protected ilErrorHandling $error;
-    private ?ilObject $folder = null;
+    private ilObject $folder;
     protected string $cdata = "";
 
-    /**
-     * Constructor
-     */
-    public function __construct($folder, $xml)
+    public function __construct(ilObject $folder, string $xml)
     {
         global $DIC;
 
@@ -43,7 +40,7 @@ class ilFolderXmlParser extends ilSaxParser
         $this->folder = $folder;
     }
 
-    public function getFolder() : ?\ilObject
+    public function getFolder() : ilObject
     {
         return $this->folder;
     }
@@ -64,8 +61,10 @@ class ilFolderXmlParser extends ilSaxParser
     }
 
     /**
-     * handler for begin of element
-     * @param	resource	$a_xml_parser		xml parser
+     * @param XMLParser|resource $a_xml_parser
+     * @param string $a_name
+     * @param array  $a_attribs
+     * @return void
      */
     public function handlerBeginTag($a_xml_parser, string $a_name, array $a_attribs) : void
     {
@@ -84,7 +83,9 @@ class ilFolderXmlParser extends ilSaxParser
     }
 
     /**
-     * @param	resource	$a_xml_parser		xml parser
+     * @param XMLParser|resource $a_xml_parser
+     * @param string $a_name
+     * @return void
      */
     public function handlerEndTag($a_xml_parser, string $a_name) : void
     {
@@ -110,14 +111,14 @@ class ilFolderXmlParser extends ilSaxParser
         $this->cdata = '';
     }
 
-
-
     /**
-     * @param	resource	$a_xml_parser		xml parser
+     * @param XMLParser|resource $a_xml_parser
+     * @param string $a_data
+     * @return void
      */
     public function handlerCharacterData($a_xml_parser, string $a_data) : void
     {
-        if ($a_data != "\n") {
+        if ($a_data !== "\n") {
             // Replace multiple tabs with one space
             $a_data = preg_replace("/\t+/", " ", $a_data);
             $this->cdata .= $a_data;

--- a/Modules/Folder/classes/class.ilFolderXmlWriter.php
+++ b/Modules/Folder/classes/class.ilFolderXmlWriter.php
@@ -41,9 +41,9 @@ class ilFolderXmlWriter extends ilXmlWriter
         if ($this->add_header) {
             $this->buildHeader();
         }
-        $this->xmlStartTag('Folder', array('Id' => $this->folder->getId()));
-        $this->xmlElement('Title', array(), $this->folder->getTitle());
-        $this->xmlElement('Description', array(), $this->folder->getDescription());
+        $this->xmlStartTag('Folder', ['Id' => $this->folder->getId()]);
+        $this->xmlElement('Title', [], $this->folder->getTitle());
+        $this->xmlElement('Description', [], $this->folder->getDescription());
         ilContainerSortingSettings::_exportContainerSortingSettings($this, $this->obj_id);
         $this->xmlEndTag('Folder');
     }
@@ -65,7 +65,7 @@ class ilFolderXmlWriter extends ilXmlWriter
         if (!$this->folder = ilObjectFactory::getInstanceByObjId($this->obj_id, false)) {
             throw new UnexpectedValueException('Invalid obj_id given: ' . $this->obj_id);
         }
-        if ($this->folder->getType() != 'fold') {
+        if ($this->folder->getType() !== 'fold') {
             throw new UnexpectedValueException('Invalid obj_id given. Object is not of type folder');
         }
     }

--- a/Modules/Folder/classes/class.ilObjFolder.php
+++ b/Modules/Folder/classes/class.ilObjFolder.php
@@ -42,9 +42,9 @@ class ilObjFolder extends ilContainer
         $this->folder_tree = $a_tree;
     }
     
-    public function cloneObject(int $a_target_id, int $a_copy_id = 0, bool $a_omit_tree = false) : ?ilObject
+    public function cloneObject(int $target_id, int $copy_id = 0, bool $omit_tree = false) : ?ilObject
     {
-        $new_obj = parent::cloneObject($a_target_id, $a_copy_id, $a_omit_tree);
+        $new_obj = parent::cloneObject($target_id, $copy_id, $omit_tree);
         
         // Copy learning progress settings
         $obj_settings = new ilLPObjSettings($this->getId());
@@ -54,7 +54,7 @@ class ilObjFolder extends ilContainer
         return $new_obj;
     }
 
-    public function putInTree(int $a_parent_ref) : void
+    public function putInTree(int $parent_ref_id) : void
     {
         $tree = $this->tree;
         
@@ -64,18 +64,18 @@ class ilObjFolder extends ilContainer
 
         if ($this->withReferences()) {
             // put reference id into tree
-            $this->folder_tree->insertNode($this->getRefId(), $a_parent_ref);
+            $this->folder_tree->insertNode($this->getRefId(), $parent_ref_id);
         } else {
             // put object id into tree
-            $this->folder_tree->insertNode($this->getId(), $a_parent_ref);
+            $this->folder_tree->insertNode($this->getId(), $parent_ref_id);
         }
     }
     
-    public function cloneDependencies(int $a_target_id, int $a_copy_id) : bool
+    public function cloneDependencies(int $target_id, int $copy_id) : bool
     {
-        parent::cloneDependencies($a_target_id, $a_copy_id);
+        parent::cloneDependencies($target_id, $copy_id);
 
-        ilObjectActivation::cloneDependencies($this->getRefId(), $a_target_id, $a_copy_id);
+        ilObjectActivation::cloneDependencies($this->getRefId(), $target_id, $copy_id);
         
         return true;
     }
@@ -94,9 +94,9 @@ class ilObjFolder extends ilContainer
         }
         if ($container_ref_id) {
             $view_mode = ilObjCourseAccess::_lookupViewMode(ilObject::_lookupObjId($container_ref_id));
-            if ($view_mode == ilContainer::VIEW_SESSIONS ||
-                $view_mode == ilContainer::VIEW_BY_TYPE ||
-                $view_mode == ilContainer::VIEW_SIMPLE) {
+            if ($view_mode === ilContainer::VIEW_SESSIONS ||
+                $view_mode === ilContainer::VIEW_BY_TYPE ||
+                $view_mode === ilContainer::VIEW_SIMPLE) {
                 $view = $view_mode;
             }
         }

--- a/Modules/Folder/classes/class.ilObjFolderAccess.php
+++ b/Modules/Folder/classes/class.ilObjFolderAccess.php
@@ -24,16 +24,16 @@ class ilObjFolderAccess extends ilObjectAccess
 
     private static function getFolderSettings() : ilSetting
     {
-        if (is_null(ilObjFolderAccess::$folderSettings)) {
-            ilObjFolderAccess::$folderSettings = new ilSetting('fold');
+        if (is_null(self::$folderSettings)) {
+            self::$folderSettings = new ilSetting('fold');
         }
-        return ilObjFolderAccess::$folderSettings;
+        return self::$folderSettings;
     }
 
     public function _checkAccess(string $cmd, string $permission, int $ref_id, int $obj_id, ?int $user_id = null) : bool
     {
-        if ($cmd == "download" &&
-            !ilObjFolderAccess::hasDownloadAction($ref_id)) {
+        if ($cmd === "download" &&
+            !self::hasDownloadAction($ref_id)) {
             return false;
         }
         return true;
@@ -41,20 +41,20 @@ class ilObjFolderAccess extends ilObjectAccess
 
     public static function _getCommands() : array
     {
-        $commands = array();
-        $commands[] = array("permission" => "read", "cmd" => "view", "lang_var" => "show", "default" => true);
+        $commands = [];
+        $commands[] = ["permission" => "read", "cmd" => "view", "lang_var" => "show", "default" => true];
 
         // why here, why read permission? it just needs info_screen_enabled = true in ilObjCategoryListGUI (alex, 30.7.2008)
         // this is not consistent, with all other objects...
         //$commands[] = array("permission" => "read", "cmd" => "showSummary", "lang_var" => "info_short", "enable_anonymous" => "false");
-        $commands[] = array("permission" => "read", "cmd" => "download", "lang_var" => "download"); // #18805
+        $commands[] = ["permission" => "read", "cmd" => "download", "lang_var" => "download"]; // #18805
         // BEGIN WebDAV: Mount Webfolder.
         if (ilDAVActivationChecker::_isActive()) {
             $webdav_obj = new ilObjWebDAV();
             $commands[] = $webdav_obj->retrieveWebDAVCommandArrayForActionMenu();
         }
-        $commands[] = array("permission" => "write", "cmd" => "enableAdministrationPanel", "lang_var" => "edit_content");
-        $commands[] = array("permission" => "write", "cmd" => "edit", "lang_var" => "settings");
+        $commands[] = ["permission" => "write", "cmd" => "enableAdministrationPanel", "lang_var" => "edit_content"];
+        $commands[] = ["permission" => "write", "cmd" => "edit", "lang_var" => "settings"];
         
         return $commands;
     }
@@ -62,8 +62,8 @@ class ilObjFolderAccess extends ilObjectAccess
     
     private static function hasDownloadAction(int $ref_id) : bool
     {
-        $settings = ilObjFolderAccess::getFolderSettings();
-        if ($settings->get("enable_download_folder", 0) != 1) {
+        $settings = self::getFolderSettings();
+        if ((int) $settings->get("enable_download_folder", '0') !== 1) {
             return false;
         }
         return true;
@@ -77,12 +77,12 @@ class ilObjFolderAccess extends ilObjectAccess
 
         $t_arr = explode("_", $target);
 
-        if ($t_arr[0] != "fold" || ((int) $t_arr[1]) <= 0) {
+        if ($t_arr[0] !== "fold" || ((int) $t_arr[1]) <= 0) {
             return false;
         }
 
-        if ($ilAccess->checkAccess("read", "", $t_arr[1]) ||
-            $ilAccess->checkAccess("visible", "", $t_arr[1])) {
+        if ($ilAccess->checkAccess("read", "", (int) $t_arr[1]) ||
+            $ilAccess->checkAccess("visible", "", (int) $t_arr[1])) {
             return true;
         }
         return false;

--- a/Modules/Folder/classes/class.ilObjFolderGUI.php
+++ b/Modules/Folder/classes/class.ilObjFolderGUI.php
@@ -47,7 +47,7 @@ class ilObjFolderGUI extends ilContainerGUI
         $this->ctrl = $DIC->ctrl();
         $this->lng = $DIC->language();
         $this->access = $DIC->access();
-        $this->rbacsystem = $DIC->rbac()->system();
+        $this->rbacsystem = $DIC->rbac()->system();// TODO PHP8-REVIEW This property is dynamically declared
         $this->help = $DIC["ilHelp"];
         $this->error = $DIC["ilErr"];
         $this->tpl = $DIC["tpl"];
@@ -66,7 +66,7 @@ class ilObjFolderGUI extends ilContainerGUI
     public function viewObject() : void
     {
         $this->checkPermission('read');
-        if (strtolower($this->folder_request->getBaseClass()) == "iladministrationgui") {
+        if (strtolower($this->folder_request->getBaseClass()) === "iladministrationgui") {
             parent::viewObject();
             return;
         }
@@ -102,7 +102,7 @@ class ilObjFolderGUI extends ilContainerGUI
         $header_action = true;
         switch ($next_class) {
             case strtolower(ilRepositoryTrashGUI::class):
-                $ru = new \ilRepositoryTrashGUI($this);
+                $ru = new ilRepositoryTrashGUI($this);
                 $this->ctrl->setReturn($this, 'trash');
                 $this->ctrl->forwardCommand($ru);
                 break;
@@ -125,7 +125,7 @@ class ilObjFolderGUI extends ilContainerGUI
                 $this->prepareOutput();
 
                 $new_gui = new ilLearningProgressGUI(
-                    ilLearningProgressGUI::LP_CONTEXT_REPOSITORY,
+                    ilLearningProgressBaseGUI::LP_CONTEXT_REPOSITORY,
                     $this->object->getRefId(),
                     $this->folder_request->getUserId() ?: $ilUser->getId()
                 );
@@ -137,7 +137,7 @@ class ilObjFolderGUI extends ilContainerGUI
             case "ilcontainerpagegui":
                 $this->prepareOutput(false);
                 $ret = $this->forwardToPageObject();
-                if ($ret != "") {
+                if ($ret !== "") {
                     $this->tpl->setContent($ret);
                 }
                 $header_action = false;
@@ -285,12 +285,12 @@ class ilObjFolderGUI extends ilContainerGUI
 
         $this->initSortingForm(
             $form,
-            array(
+            [
                 ilContainer::SORT_INHERIT,
                 ilContainer::SORT_TITLE,
                 ilContainer::SORT_CREATION,
                 ilContainer::SORT_MANUAL
-            )
+            ]
         );
 
         $form->addCommandButton("update", $this->lng->txt("save"));
@@ -299,12 +299,12 @@ class ilObjFolderGUI extends ilContainerGUI
         return $form;
     }
 
-    protected function getEditFormCustomValues(array &$values) : void
+    protected function getEditFormCustomValues(array &$a_values) : void
     {
         // we cannot use $this->object->getOrderType()
         // if set to inherit it will be translated to parent setting
         $sort = new ilContainerSortingSettings($this->object->getId());
-        $values["sor"] = $sort->getSortMode();
+        $a_values["sor"] = $sort->getSortMode();
     }
 
     protected function updateCustom(ilPropertyFormGUI $form) : void
@@ -427,15 +427,15 @@ class ilObjFolderGUI extends ilContainerGUI
             );
 
             //BEGIN ChangeEvent add info tab to category object
-            $force_active = $this->ctrl->getNextClass() == "ilinfoscreengui"
-                || strtolower($this->ctrl->getCmdClass()) == "ilnotegui";
+            $force_active = $this->ctrl->getNextClass() === "ilinfoscreengui"
+                || strtolower($this->ctrl->getCmdClass()) === "ilnotegui";
             $this->tabs_gui->addTarget(
                 "info_short",
                 $this->ctrl->getLinkTargetByClass(
-                    array("ilobjfoldergui", "ilinfoscreengui"),
+                    ["ilobjfoldergui", "ilinfoscreengui"],
                     "showSummary"
                 ),
-                array("showSummary","", "infoScreen"),
+                ["showSummary", "", "infoScreen"],
                 "",
                 "",
                 $force_active
@@ -450,7 +450,7 @@ class ilObjFolderGUI extends ilContainerGUI
                 "edit",
                 "",
                 "",
-                ($ilCtrl->getCmd() == "edit")
+                ($ilCtrl->getCmd() === "edit")
             );
         }
 
@@ -458,9 +458,9 @@ class ilObjFolderGUI extends ilContainerGUI
         if (ilLearningProgressAccess::checkAccess($this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 'learning_progress',
-                $this->ctrl->getLinkTargetByClass(array('ilobjfoldergui','illearningprogressgui'), ''),
+                $this->ctrl->getLinkTargetByClass(['ilobjfoldergui', 'illearningprogressgui'], ''),
                 '',
-                array('illplistofobjectsgui','illplistofsettingsgui','illearningprogressgui','illplistofprogressgui')
+                ['illplistofobjectsgui', 'illplistofsettingsgui', 'illearningprogressgui', 'illplistofprogressgui']
             );
         }
 
@@ -477,18 +477,17 @@ class ilObjFolderGUI extends ilContainerGUI
         if ($rbacsystem->checkAccess('edit_permission', $this->ref_id)) {
             $this->tabs_gui->addTarget(
                 "perm_settings",
-                $this->ctrl->getLinkTargetByClass(array(get_class($this),'ilpermissiongui'), "perm"),
-                array("perm","info","owner"),
+                $this->ctrl->getLinkTargetByClass([get_class($this), 'ilpermissiongui'], "perm"),
+                ["perm", "info", "owner"],
                 'ilpermissiongui'
             );
         }
-
     }
 
     /**
     * goto target group
     */
-    public static function _goto($a_target)
+    public static function _goto($a_target) : void// TODO PHP8-REVIEW Missing type hint, but this might be an issue of the `goto.php` to be discussed with all code maintainers
     {
         global $DIC;
 
@@ -527,26 +526,26 @@ class ilObjFolderGUI extends ilContainerGUI
     /**
      * show possible sub objects selection list
      */
-    public function showPossibleSubObjects() : void
+    protected function showPossibleSubObjects() : void
     {
         $gui = new ilObjectAddNewItemGUI($this->object->getRefId());
         $gui->render();
     }
 
     
-    protected function forwardToTimingsView()
+    protected function forwardToTimingsView() : void
     {
         $tree = $this->tree;
         
         if (!$crs_ref = $tree->checkForParentType($this->ref_id, 'crs')) {
             return;
         }
-        if (!$this->ctrl->getCmd() and ilObjCourse::_lookupViewMode(ilObject::_lookupObjId($crs_ref)) == ilContainer::VIEW_TIMING) {
+        if (!$this->ctrl->getCmd() && ilObjCourse::_lookupViewMode(ilObject::_lookupObjId($crs_ref)) === ilContainer::VIEW_TIMING) {
             if (!ilSession::has('crs_timings')) {
                 ilSession::set('crs_timings', true);
             }
             
-            if (ilSession::get('crs_timings') == true) {
+            if (ilSession::get('crs_timings')) {
                 $course_content_obj = new ilCourseContentGUI($this);
                 $this->ctrl->setCmdClass(get_class($course_content_obj));
                 $this->ctrl->setCmd('editUserTimings');

--- a/Modules/Folder/classes/class.ilObjFolderListGUI.php
+++ b/Modules/Folder/classes/class.ilObjFolderListGUI.php
@@ -56,7 +56,7 @@ class ilObjFolderListGUI extends ilObjectListGUI
         switch ($cmd) {
             default:
 
-                if ($cmd == 'mount_webfolder' && ilDAVActivationChecker::_isActive()) {
+                if ($cmd === 'mount_webfolder' && ilDAVActivationChecker::_isActive()) {
                     global $DIC;
                     $uri_builder = new ilWebDAVUriBuilder($DIC->http()->request());
                     $uri_builder->getUriToMountInstructionModalByRef($this->ref_id);

--- a/Modules/Folder/test/FoldStandardGUIRequestTest.php
+++ b/Modules/Folder/test/FoldStandardGUIRequestTest.php
@@ -9,13 +9,6 @@ use PHPUnit\Framework\TestCase;
  */
 class FoldStandardGUIRequestTest extends TestCase
 {
-    //protected $backupGlobals = false;
-
-    protected function setUp() : void
-    {
-        parent::setUp();
-    }
-
     protected function tearDown() : void
     {
     }
@@ -37,7 +30,7 @@ class FoldStandardGUIRequestTest extends TestCase
     /**
      * Test ref id
      */
-    public function testRefId()
+    public function testRefId() : void
     {
         $request = $this->getRequest(
             [
@@ -55,7 +48,7 @@ class FoldStandardGUIRequestTest extends TestCase
     /**
      * Test no ref id
      */
-    public function testNoRefId()
+    public function testNoRefId() : void
     {
         $request = $this->getRequest(
             [
@@ -72,7 +65,7 @@ class FoldStandardGUIRequestTest extends TestCase
     /**
      * Test base class
      */
-    public function testBaseClass()
+    public function testBaseClass() : void
     {
         $request = $this->getRequest(
             [
@@ -90,7 +83,7 @@ class FoldStandardGUIRequestTest extends TestCase
     /**
      * Test cmd class
      */
-    public function testCmdClass()
+    public function testCmdClass() : void
     {
         $request = $this->getRequest(
             [
@@ -108,7 +101,7 @@ class FoldStandardGUIRequestTest extends TestCase
     /**
      * Test user id
      */
-    public function testUserId()
+    public function testUserId() : void
     {
         $request = $this->getRequest(
             [

--- a/Modules/Folder/test/ilModulesFolderSuite.php
+++ b/Modules/Folder/test/ilModulesFolderSuite.php
@@ -22,7 +22,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilModulesFolderSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new self();
 

--- a/Modules/GroupReference/classes/class.ilGroupReferenceImporter.php
+++ b/Modules/GroupReference/classes/class.ilGroupReferenceImporter.php
@@ -14,23 +14,13 @@ include_once './Services/ContainerReference/classes/class.ilContainerReferenceIm
 */
 class ilGroupReferenceImporter extends ilContainerReferenceImporter
 {
-
-    /**
-     * Get reference type
-     * @return string
-     */
     protected function getType() : string
     {
         return 'grpr';
     }
 
-    /**
-     * @param string $a_xml
-     * @return ilContainerReferenceXmlParser
-     */
-    protected function initParser($a_xml) : ilContainerReferenceXmlParser
+    protected function initParser(string $a_xml) : ilContainerReferenceXmlParser
     {
-        include_once './Modules/GroupReference/classes/class.ilGroupReferenceXmlParser.php';
         return new ilGroupReferenceXmlParser($a_xml);
     }
 }

--- a/Modules/RootFolder/classes/class.ilObjRootFolder.php
+++ b/Modules/RootFolder/classes/class.ilObjRootFolder.php
@@ -47,19 +47,20 @@ class ilObjRootFolder extends ilContainer
 
         $num = 0;
 
-        $data["Fobject"] = array();
+        $data["Fobject"] = [];
         while ($row = $r->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $data["Fobject"][$num] = array("title" => $row->title,
-                                          "desc" => $row->description,
-                                          "lang" => $row->lang_code
-                                          );
+            $data["Fobject"][$num] = [
+                "title" => $row->title,
+                "desc" => $row->description,
+                "lang" => $row->lang_code
+            ];
             $num++;
         }
 
         // first entry is always the default language
         $data["default_language"] = 0;
 
-        return $data ?: array();
+        return $data ?: [];
     }
 
     // remove translations of current category
@@ -88,7 +89,7 @@ class ilObjRootFolder extends ilContainer
     {
         global $ilDB;
 
-        if (empty($a_title)) {
+        if ($a_title === '') {
             $a_title = "NO TITLE";
         }
 

--- a/Modules/RootFolder/classes/class.ilObjRootFolderAccess.php
+++ b/Modules/RootFolder/classes/class.ilObjRootFolderAccess.php
@@ -34,11 +34,13 @@ class ilObjRootFolderAccess extends ilObjectAccess
      */
     public static function _getCommands() : array
     {
-        $commands = array(
-            array("permission" => "read", "cmd" => "render", "lang_var" => "show",
-                "default" => true),
-            array("permission" => "write", "cmd" => "edit", "lang_var" => "edit"),
-        );
+        $commands = [
+            [
+                "permission" => "read", "cmd" => "render", "lang_var" => "show",
+                "default" => true
+            ],
+            ["permission" => "write", "cmd" => "edit", "lang_var" => "edit"],
+        ];
         
         return $commands;
     }

--- a/Modules/RootFolder/classes/class.ilObjRootFolderGUI.php
+++ b/Modules/RootFolder/classes/class.ilObjRootFolderGUI.php
@@ -81,7 +81,7 @@ class ilObjRootFolderGUI extends ilContainerGUI
                 "edit",
                 get_class($this),
                 "",
-                $cmd == 'edit'
+                $cmd === 'edit'
             );
         }
 
@@ -96,7 +96,7 @@ class ilObjRootFolderGUI extends ilContainerGUI
 
         switch ($next_class) {
             case strtolower(ilRepositoryTrashGUI::class):
-                $ru = new \ilRepositoryTrashGUI($this);
+                $ru = new ilRepositoryTrashGUI($this);
                 $this->ctrl->setReturn($this, 'trash');
                 $this->ctrl->forwardCommand($ru);
                 break;
@@ -105,7 +105,7 @@ class ilObjRootFolderGUI extends ilContainerGUI
             case "ilcontainerpagegui":
                 $this->prepareOutput(false);
                 $ret = $this->forwardToPageObject();
-                if ($ret != "") {
+                if ($ret !== "") {
                     $this->tpl->setContent($ret);
                 }
                 break;
@@ -160,7 +160,7 @@ class ilObjRootFolderGUI extends ilContainerGUI
                 break;
 
             default:
-                if ($cmd == "infoScreen") {
+                if ($cmd === "infoScreen") {
                     $this->checkPermission("visible");
                 } else {
                     try {
@@ -192,8 +192,8 @@ class ilObjRootFolderGUI extends ilContainerGUI
 
         ilObjectListGUI::prepareJsLinks(
             "",
-            $this->ctrl->getLinkTargetByClass(array("ilcommonactiondispatchergui", "ilnotegui"), "", "", true, false),
-            $this->ctrl->getLinkTargetByClass(array("ilcommonactiondispatchergui", "iltagginggui"), "", "", true, false)
+            $this->ctrl->getLinkTargetByClass(["ilcommonactiondispatchergui", "ilnotegui"], "", "", true, false),
+            $this->ctrl->getLinkTargetByClass(["ilcommonactiondispatchergui", "iltagginggui"], "", "", true, false)
         );
         
         $ilTabs->activateTab("view_content");
@@ -207,7 +207,7 @@ class ilObjRootFolderGUI extends ilContainerGUI
     {
         $this->checkPermission('read');
 
-        if (strtolower($this->root_request->getBaseClass()) == "iladministrationgui") {
+        if (strtolower($this->root_request->getBaseClass()) === "iladministrationgui") {
             parent::viewObject();
         }
 
@@ -221,9 +221,9 @@ class ilObjRootFolderGUI extends ilContainerGUI
         parent::setTitleAndDescription();
         $this->tpl->setDescription("");
         if (!ilContainer::_lookupContainerSetting($this->object->getId(), "hide_header_icon_and_title")) {
-            if ($this->object->getTitle() == "ILIAS") {
+            if ($this->object->getTitle() === "ILIAS") {
                 $this->tpl->setTitle($lng->txt("repository"));
-            } elseif ($this->object->getDescription() != "") {
+            } elseif ($this->object->getDescription() !== "") {
                 $this->tpl->setDescription($this->object->getDescription()); // #13479
             }
         }
@@ -268,11 +268,11 @@ class ilObjRootFolderGUI extends ilContainerGUI
 
         $this->initSortingForm(
             $form,
-            array(
+            [
                     ilContainer::SORT_TITLE,
                     ilContainer::SORT_CREATION,
                     ilContainer::SORT_MANUAL
-                )
+            ]
         );
 
 
@@ -300,54 +300,54 @@ class ilObjRootFolderGUI extends ilContainerGUI
 
         if (!$this->checkPermissionBool("write")) {
             throw new ilPermissionException($this->lng->txt("msg_no_perm_write"));
-        } else {
-            $form = $this->initEditForm();
-            if ($form->checkInput()) {
-                $this->saveSortingSettings($form);
+        }
 
-                // list presentation
-                $this->saveListPresentation($form);
+        $form = $this->initEditForm();
+        if ($form->checkInput()) {
+            $this->saveSortingSettings($form);
 
-                if ($ilSetting->get('custom_icons')) {
-                    global $DIC;
-                    /** @var \ilObjectCustomIconFactory $customIconFactory */
-                    $customIconFactory = $DIC['object.customicons.factory'];
-                    $customIcon = $customIconFactory->getByObjId($this->object->getId(), $this->object->getType());
+            // list presentation
+            $this->saveListPresentation($form);
 
-                    /** @var \ilImageFileInputGUI $item */
-                    $fileData = (array) $form->getInput('cont_icon');
-                    $item = $form->getItemByPostVar('cont_icon');
+            if ($ilSetting->get('custom_icons')) {
+                global $DIC;
+                /** @var ilObjectCustomIconFactory $customIconFactory */
+                $customIconFactory = $DIC['object.customicons.factory'];
+                $customIcon = $customIconFactory->getByObjId($this->object->getId(), $this->object->getType());
 
-                    if ($item->getDeletionFlag()) {
-                        $customIcon->remove();
-                    }
+                /** @var ilImageFileInputGUI $item */
+                $fileData = (array) $form->getInput('cont_icon');
+                $item = $form->getItemByPostVar('cont_icon');
 
-                    if ($fileData['tmp_name']) {
-                        $customIcon->saveFromHttpRequest();
-                    }
+                if ($item->getDeletionFlag()) {
+                    $customIcon->remove();
                 }
 
-                // custom icon
-                $obj_service->commonSettings()->legacyForm($form, $this->object)->saveTitleIconVisibility();
-
-                // BEGIN ChangeEvent: Record update
-                global $ilUser;
-                ilChangeEvent::_recordWriteEvent($this->object->getId(), $ilUser->getId(), 'update');
-                ilChangeEvent::_catchupWriteEvents($this->object->getId(), $ilUser->getId());
-                // END ChangeEvent: Record update
-
-                $this->tpl->setOnScreenMessage('success', $this->lng->txt("msg_obj_modified"), true);
-                $this->ctrl->redirect($this, "edit");
+                if ($fileData['tmp_name']) {
+                    $customIcon->saveFromHttpRequest();
+                }
             }
 
-            // display form to correct errors
-            $this->setEditTabs();
-            $form->setValuesByPost();
-            $this->tpl->setContent($form->getHTML());
+            // custom icon
+            $obj_service->commonSettings()->legacyForm($form, $this->object)->saveTitleIconVisibility();
+
+            // BEGIN ChangeEvent: Record update
+            global $ilUser;
+            ilChangeEvent::_recordWriteEvent($this->object->getId(), $ilUser->getId(), 'update');
+            ilChangeEvent::_catchupWriteEvents($this->object->getId(), $ilUser->getId());
+            // END ChangeEvent: Record update
+
+            $this->tpl->setOnScreenMessage('success', $this->lng->txt("msg_obj_modified"), true);
+            $this->ctrl->redirect($this, "edit");
         }
+
+        // display form to correct errors
+        $this->setEditTabs();
+        $form->setValuesByPost();
+        $this->tpl->setContent($form->getHTML());
     }
 
-    public static function _goto($a_target)
+    public static function _goto($a_target) : void// TODO PHP8-REVIEW Missing type hint, but this might be an issue of the `goto.php` to be discussed with all code maintainers
     {
         ilObjectGUI::_gotoRepositoryRoot(true);
     }

--- a/Modules/RootFolder/test/RootStandardGUIRequestTest.php
+++ b/Modules/RootFolder/test/RootStandardGUIRequestTest.php
@@ -9,13 +9,6 @@ use PHPUnit\Framework\TestCase;
  */
 class RootStandardGUIRequestTest extends TestCase
 {
-    //protected $backupGlobals = false;
-
-    protected function setUp() : void
-    {
-        parent::setUp();
-    }
-
     protected function tearDown() : void
     {
     }
@@ -37,7 +30,7 @@ class RootStandardGUIRequestTest extends TestCase
     /**
      * Test ref id
      */
-    public function testRefId()
+    public function testRefId() : void
     {
         $request = $this->getRequest(
             [
@@ -55,7 +48,7 @@ class RootStandardGUIRequestTest extends TestCase
     /**
      * Test no ref id
      */
-    public function testNoRefId()
+    public function testNoRefId() : void
     {
         $request = $this->getRequest(
             [
@@ -72,7 +65,7 @@ class RootStandardGUIRequestTest extends TestCase
     /**
      * Test base class
      */
-    public function testBaseClass()
+    public function testBaseClass() : void
     {
         $request = $this->getRequest(
             [

--- a/Modules/RootFolder/test/ilModulesRootFolderSuite.php
+++ b/Modules/RootFolder/test/ilModulesRootFolderSuite.php
@@ -22,7 +22,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilModulesRootFolderSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new self();
 

--- a/Services/Container/Content/class.ilContainerBlockPropertiesStorageGUI.php
+++ b/Services/Container/Content/class.ilContainerBlockPropertiesStorageGUI.php
@@ -49,7 +49,7 @@ class ilContainerBlockPropertiesStorageGUI
         $ilCtrl = $this->ctrl;
 
         $cmd = $ilCtrl->getCmd();
-        if (in_array($cmd, array("store"))) {
+        if (in_array($cmd, ["store"], true)) {
             $this->$cmd();
         }
     }

--- a/Services/Container/Content/class.ilContainerByTypeContentGUI.php
+++ b/Services/Container/Content/class.ilContainerByTypeContentGUI.php
@@ -46,11 +46,11 @@ class ilContainerByTypeContentGUI extends ilContainerContentGUI
         if ($this->item_manager->getExpanded($a_item_id) !== null) {
             return $this->item_manager->getExpanded($a_item_id);
         }
-        if ($a_item_id == $this->force_details) {
+        if ($a_item_id == $this->force_details) {// TODO PHP8-REVIEW int vs. bool?
             return self::DETAILS_ALL;
-        } else {
-            return self::DETAILS_TITLE;
         }
+
+        return self::DETAILS_TITLE;
     }
 
     public function getMainContent() : string
@@ -76,8 +76,8 @@ class ilContainerByTypeContentGUI extends ilContainerContentGUI
 
         // Show introduction, if repository is empty
         // @todo: maybe we move this
-        if ((!is_array($this->items) || count($this->items) == 0) &&
-            $this->getContainerObject()->getRefId() == ROOT_FOLDER_ID &&
+        if ((!is_array($this->items) || count($this->items) === 0) &&
+            $this->getContainerObject()->getRefId() === ROOT_FOLDER_ID &&
             $ilAccess->checkAccess("write", "", $this->getContainerObject()->getRefId())) {
             $html = $this->getIntroduction();
         } else {	// show item list otherwise
@@ -98,7 +98,7 @@ class ilContainerByTypeContentGUI extends ilContainerContentGUI
         $output_html = $this->getContainerGUI()->getContainerPageHTML();
         
         // get embedded blocks
-        if ($output_html != "") {
+        if ($output_html !== "") {
             $output_html = $this->insertPageEmbeddedBlocks($output_html);
         }
 
@@ -116,7 +116,7 @@ class ilContainerByTypeContentGUI extends ilContainerContentGUI
                 foreach ($this->items[$type] as $item_data) {
                     $item_ref_id = $item_data["child"];
 
-                    if ($this->block_limit > 0 && !$this->getContainerGUI()->isActiveItemOrdering() && $position == $this->block_limit + 1) {
+                    if ($this->block_limit > 0 && $position == $this->block_limit + 1 && !$this->getContainerGUI()->isActiveItemOrdering()) {
                         if ($position == $this->block_limit + 1) {
                             // render more button
                             $this->renderer->addShowMoreButton($type);
@@ -143,7 +143,7 @@ class ilContainerByTypeContentGUI extends ilContainerContentGUI
     {
         $this->handleSessionExpand();
 
-        if ($this->getContainerObject()->getType() == 'crs') {
+        if ($this->getContainerObject()->getType() === 'crs') {
             if ($session = ilSessionAppointment::lookupNextSessionByCourse($this->getContainerObject()->getRefId())) {
                 $this->force_details = $session;
             } elseif ($session = ilSessionAppointment::lookupLastSessionByCourse($this->getContainerObject()->getRefId())) {

--- a/Services/Container/Content/class.ilContainerContentGUI.php
+++ b/Services/Container/Content/class.ilContainerContentGUI.php
@@ -24,7 +24,7 @@ abstract class ilContainerContentGUI
     public const VIEW_MODE_LIST = 0;
     public const VIEW_MODE_TILE = 1;
 
-    protected \ilGlobalTemplateInterface $tpl;
+    protected ilGlobalTemplateInterface $tpl;
     protected ilCtrl $ctrl;
     protected ilObjUser $user;
     protected ilLanguage $lng;
@@ -74,7 +74,7 @@ abstract class ilContainerContentGUI
 
         $this->log = ilLoggerFactory::getLogger('cont');
 
-        $this->view_mode = (ilContainer::_lookupContainerSetting($this->container_obj->getId(), "list_presentation") == "tile" && !$this->container_gui->isActiveAdministrationPanel() && !$this->container_gui->isActiveOrdering())
+        $this->view_mode = (ilContainer::_lookupContainerSetting($this->container_obj->getId(), "list_presentation") === "tile" && !$this->container_gui->isActiveAdministrationPanel() && !$this->container_gui->isActiveOrdering())
             ? self::VIEW_MODE_TILE
             : self::VIEW_MODE_LIST;
 
@@ -134,7 +134,7 @@ abstract class ilContainerContentGUI
         // note: we do not want to get the center html in case of
         // asynchronous calls to blocks in the right column (e.g. news)
         // see #13012
-        if ($ilCtrl->getNextClass() == "ilcolumngui" &&
+        if ($ilCtrl->getNextClass() === "ilcolumngui" &&
             $ilCtrl->isAsynch()) {
             $tpl->setRightContent($this->getRightColumnHTML());
         }
@@ -152,13 +152,13 @@ abstract class ilContainerContentGUI
         // END ChangeEvent: record read event.
         
         $html = $this->getCenterColumnHTML();
-        if (strlen($html)) {
+        if ($html !== '') {
             $tpl->setContent($html);
         }
 
         // see above, all other cases (this was the old position of setRightContent,
         // maybe the position above is ok and all ifs can be removed)
-        if ($ilCtrl->getNextClass() != "ilcolumngui" ||
+        if ($ilCtrl->getNextClass() !== "ilcolumngui" ||
             !$ilCtrl->isAsynch()) {
             $tpl->setRightContent($this->getRightColumnHTML());
         }
@@ -176,20 +176,20 @@ abstract class ilContainerContentGUI
 
         $column_gui = new ilColumnGUI($obj_type, IL_COL_RIGHT);
 
-        if ($column_gui->getScreenMode() == IL_SCREEN_FULL) {
+        if ($column_gui::getScreenMode() === IL_SCREEN_FULL) {
             return "";
         }
 
         $this->getContainerGUI()->setColumnSettings($column_gui);
         
-        if ($ilCtrl->getNextClass() == "ilcolumngui" &&
-            $column_gui->getCmdSide() == IL_COL_RIGHT &&
-            $column_gui->getScreenMode() == IL_SCREEN_SIDE) {
+        if ($ilCtrl->getNextClass() === "ilcolumngui" &&
+            $column_gui::getCmdSide() === IL_COL_RIGHT &&
+            $column_gui::getScreenMode() === IL_SCREEN_SIDE) {
             $html = $ilCtrl->forwardCommand($column_gui);
         } else {
             $render_content = ($ilCtrl->getNextClass() == "" &&
                 in_array($ilCtrl->getCmd(), ["view", "render"]));
-            $render_content = false;
+            $render_content = false;// TODO PHP8-REVIEW Variable is immediatly overwritten
             if (!$ilCtrl->isAsynch() || $render_content) {
                 $html = "";
                 
@@ -197,7 +197,7 @@ abstract class ilContainerContentGUI
                 $uip = new ilUIHookProcessor(
                     "Services/Container",
                     "right_column",
-                    array("container_content_gui" => $this)
+                    ["container_content_gui" => $this]
                 );
                 if (!$uip->replaced()) {
                     $html = $ilCtrl->getHTML($column_gui);
@@ -222,7 +222,7 @@ abstract class ilContainerContentGUI
 
         $tpl->addOnLoadCode("il.Object.setRatingUrl('" .
             $ilCtrl->getLinkTargetByClass(
-                array(get_class($this->container_gui), "ilcommonactiondispatchergui", "ilratinggui"),
+                [get_class($this->container_gui), "ilcommonactiondispatchergui", "ilratinggui"],
                 "saveRating",
                 "",
                 true,
@@ -232,7 +232,7 @@ abstract class ilContainerContentGUI
         switch ($ilCtrl->getNextClass()) {
             case "ilcolumngui":
                 $this->container_gui->setSideColumnReturn();
-                $html = $this->__forwardToColumnGUI();
+                $html = $this->forwardToColumnGUI();
                 break;
                 
             default:
@@ -261,7 +261,7 @@ abstract class ilContainerContentGUI
         $this->renderer = new ilContainerRenderer(
             ($this->getContainerGUI()->isActiveAdministrationPanel() && !$this->clipboard->hasEntries()),
             $this->getContainerGUI()->isMultiDownloadEnabled(),
-            $this->getContainerGUI()->isActiveOrdering() && (get_class($this) != "ilContainerObjectiveGUI") // no block sorting in objective view
+            $this->getContainerGUI()->isActiveOrdering() && (get_class($this) !== "ilContainerObjectiveGUI") // no block sorting in objective view
             ,
             $sorting->getBlockPositions(),
             $this->container_gui,
@@ -272,7 +272,7 @@ abstract class ilContainerContentGUI
     /**
      * Get columngui output
      */
-    private function __forwardToColumnGUI() : string
+    private function forwardToColumnGUI() : string
     {
         $ilCtrl = $this->ctrl;
         $html = "";
@@ -284,16 +284,15 @@ abstract class ilContainerContentGUI
         $obj_type = ilObject::_lookupType($obj_id);
 
         if (!$ilCtrl->isAsynch()) {
-            //if ($column_gui->getScreenMode() != IL_SCREEN_SIDE)
-            if (ilColumnGUI::getScreenMode() != IL_SCREEN_SIDE) {
+            if (ilColumnGUI::getScreenMode() !== IL_SCREEN_SIDE) {
                 // right column wants center
-                if (ilColumnGUI::getCmdSide() == IL_COL_RIGHT) {
+                if (ilColumnGUI::getCmdSide() === IL_COL_RIGHT) {
                     $column_gui = new ilColumnGUI($obj_type, IL_COL_RIGHT);
                     $this->getContainerGUI()->setColumnSettings($column_gui);
                     $html = $ilCtrl->forwardCommand($column_gui);
                 }
                 // left column wants center
-                if (ilColumnGUI::getCmdSide() == IL_COL_LEFT) {
+                if (ilColumnGUI::getCmdSide() === IL_COL_LEFT) {
                     $column_gui = new ilColumnGUI($obj_type, IL_COL_LEFT);
                     $this->getContainerGUI()->setColumnSettings($column_gui);
                     $html = $ilCtrl->forwardCommand($column_gui);
@@ -340,9 +339,9 @@ abstract class ilContainerContentGUI
         }
 
         // unique js-ids
-        $item_list_gui->setParentRefId((int) $item_data["parent"] ?? 0);
+        $item_list_gui->setParentRefId((int) ($item_data["parent"] ?? 0));
         
-        $item_list_gui->setDefaultCommandParameters(array());
+        $item_list_gui->setDefaultCommandParameters([]);
         $item_list_gui->disableTitleLink(false);
         $item_list_gui->resetConditionTarget();
 
@@ -350,12 +349,12 @@ abstract class ilContainerContentGUI
             $item_list_gui->enablePath(
                 true,
                 $this->container_obj->getRefId(),
-                new \ilSessionClassificationPathGUI()
+                new ilSessionClassificationPathGUI()
             );
         }
 
         // show administration command buttons (or not)
-        if (!$this->getContainerGUI()->isActiveAdministrationPanel()) {
+        if (!$this->getContainerGUI()->isActiveAdministrationPanel()) {// TODO PHP8-REVIEW This block should be removed IMO
             //			$item_list_gui->enableDelete(false);
 //			$item_list_gui->enableLink(false);
 //			$item_list_gui->enableCut(false);
@@ -422,7 +421,7 @@ abstract class ilContainerContentGUI
     {
         // item groups
         if (isset($this->embedded_block["itgr"]) && is_array($this->embedded_block["itgr"])) {
-            $item_groups = array();
+            $item_groups = [];
             if (isset($this->items["itgr"]) && is_array($this->items["itgr"])) {
                 foreach ($this->items["itgr"] as $ig) {
                     $item_groups[$ig["ref_id"]] = $ig;
@@ -441,7 +440,7 @@ abstract class ilContainerContentGUI
             foreach ($this->embedded_block["type"] as $type) {
                 if (isset($this->items[$type]) && is_array($this->items[$type]) && $this->renderer->addTypeBlock($type)) {
                     // :TODO: obsolete?
-                    if ($type == 'sess') {
+                    if ($type === 'sess') {
                         $this->items['sess'] = ilArrayUtil::sortArray($this->items['sess'], 'start', 'ASC', true, true);
                     }
                     
@@ -482,18 +481,19 @@ abstract class ilContainerContentGUI
 
         $view_mode = $this->getViewMode();
         if ($item_group_list_presentation != "") {
-            $view_mode = ($item_group_list_presentation == "tile")
+            $view_mode = ($item_group_list_presentation === "tile")
                 ? self::VIEW_MODE_TILE
                 : self::VIEW_MODE_LIST;
         }
 
-        if ($view_mode == self::VIEW_MODE_TILE) {
+        if ($view_mode === self::VIEW_MODE_TILE) {
             return $this->renderCard($a_item_data, $a_position, $a_force_icon, $a_pos_prefix);
         }
 
         $item_list_gui = $this->getItemGUI($a_item_data);
-        if ($ilSetting->get("icon_position_in_lists") == "item_rows" ||
-            $a_item_data["type"] == "sess" || $a_force_icon) {
+        if ($a_item_data["type"] === "sess" ||
+            $a_force_icon ||
+            $ilSetting->get("icon_position_in_lists") === "item_rows") {
             $item_list_gui->enableIcon(true);
         }
 
@@ -504,14 +504,14 @@ abstract class ilContainerContentGUI
             $item_list_gui->enableDownloadCheckbox((int) $a_item_data["ref_id"]);
         }
         
-        if ($this->getContainerGUI()->isActiveItemOrdering() && ($a_item_data['type'] != 'sess' || get_class($this) != 'ilContainerSessionsContentGUI')) {
+        if ($this->getContainerGUI()->isActiveItemOrdering() && ($a_item_data['type'] !== 'sess' || get_class($this) !== 'ilContainerSessionsContentGUI')) {
             $item_list_gui->setPositionInputField(
                 $a_pos_prefix . "[" . $a_item_data["ref_id"] . "]",
                 sprintf('%d', $a_position * 10)
             );
         }
         
-        if ($a_item_data['type'] == 'sess' and get_class($this) != 'ilContainerObjectiveGUI') {
+        if ($a_item_data['type'] === 'sess' && get_class($this) !== 'ilContainerObjectiveGUI') {
             switch ($this->getDetailsLevel($a_item_data['obj_id'])) {
                 case self::DETAILS_TITLE:
                     $item_list_gui->setDetailsLevel(ilObjectListGUI::DETAILS_MINIMAL);
@@ -543,12 +543,11 @@ abstract class ilContainerContentGUI
         }
 
         // show subitems
-        if ($a_item_data['type'] == 'sess' and (
-                                            $this->getDetailsLevel($a_item_data['obj_id']) != self::DETAILS_TITLE or
-                                            $this->getContainerGUI()->isActiveAdministrationPanel() or
-                                            $this->getContainerGUI()->isActiveItemOrdering()
-                                            )
-        ) {
+        if ($a_item_data['type'] === 'sess' && (
+            $this->getDetailsLevel($a_item_data['obj_id']) !== self::DETAILS_TITLE ||
+            $this->getContainerGUI()->isActiveAdministrationPanel() ||
+            $this->getContainerGUI()->isActiveItemOrdering()
+        )) {
             $pos = 1;
                         
             $items = ilObjectActivation::getItemsByEvent($a_item_data['obj_id']);
@@ -569,10 +568,10 @@ abstract class ilContainerContentGUI
                 $item_list_gui2->enableItemDetailLinks(false);
                 
                 // unique js-ids
-                $item_list_gui2->setParentRefId((int) $a_item_data['ref_id'] ?? 0);
+                $item_list_gui2->setParentRefId((int) ($a_item_data['ref_id'] ?? 0));
                 
                 // @see mantis 10488
-                if (!$item_readable and !$ilAccess->checkAccess('write', '', $item['ref_id'])) {
+                if (!$item_readable && !$ilAccess->checkAccess('write', '', $item['ref_id'])) {
                     $item_list_gui2->forceVisibleOnly(true);
                 }
                 
@@ -602,7 +601,7 @@ abstract class ilContainerContentGUI
                 );
                                         
                 $this->determineAdminCommands($item["ref_id"], $item_list_gui2->adminCommandsIncluded());
-                if (strlen($sub_item_html)) {
+                if ($sub_item_html !== '') {
                     $item_list_gui->addSubItemHTML($sub_item_html);
                 }
             }
@@ -766,7 +765,7 @@ abstract class ilContainerContentGUI
         
         if (empty($this->type_grps)) {
             $this->type_grps =
-                $objDefinition->getGroupedRepositoryObjectTypes($this->getContainerObject()->getType());
+                $objDefinition::getGroupedRepositoryObjectTypes($this->getContainerObject()->getType());
         }
         return $this->type_grps;
     }
@@ -816,12 +815,12 @@ abstract class ilContainerContentGUI
         $items = ilObjectActivation::getItemsByItemGroup($a_itgr['ref_id']);
 
         // get all valid ids (this is filtered)
-        $all_ids = array_map(function ($i) {
-            return $i["child"];
+        $all_ids = array_map(static function (array $i) : int {
+            return (int) $i["child"];
         }, $this->items["_all"]);
 
         // remove filtered items
-        $items = array_filter($items, function ($i) use ($all_ids) {
+        $items = array_filter($items, static function (array $i) use ($all_ids) : bool {
             return in_array($i["ref_id"], $all_ids);
         });
 
@@ -855,17 +854,17 @@ abstract class ilContainerContentGUI
             $ilUser->getId(),
             "opened"
         );
-        if ($stored_val != "" && $beh != ilItemGroupBehaviour::ALWAYS_OPEN) {
-            $beh = ($stored_val == "1")
+        if ($stored_val !== "" && $beh !== ilItemGroupBehaviour::ALWAYS_OPEN) {
+            $beh = ($stored_val === "1")
                 ? ilItemGroupBehaviour::EXPANDABLE_OPEN
                 : ilItemGroupBehaviour::EXPANDABLE_CLOSED;
         }
 
-        $data = array(
+        $data = [
             "behaviour" => $beh,
             "store-url" => "./ilias.php?baseClass=ilcontainerblockpropertiesstoragegui&cmd=store" .
                 "&cont_block_id=itgr_" . $a_itgr['ref_id']
-        );
+        ];
         if (ilObjItemGroup::lookupHideTitle($a_itgr["obj_id"]) &&
             !$this->getContainerGUI()->isActiveAdministrationPanel()) {
             $this->renderer->addCustomBlock($a_itgr["ref_id"], "", $commands_html, $data);

--- a/Services/Container/Content/class.ilContainerObjectiveGUI.php
+++ b/Services/Container/Content/class.ilContainerObjectiveGUI.php
@@ -23,7 +23,7 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
     public const MATERIALS_TESTS = 1;
     public const MATERIALS_OTHER = 2;
 
-    private \ilLogger $logger;
+    private ilLogger $logger;
     protected ilTabsGUI $tabs;
     protected array $objective_map;
     protected ilToolbarGUI $toolbar;
@@ -140,13 +140,11 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
 
         // reset results by setting or for admins
         if (
-            ilLOSettings::getInstanceByObjId($this->getContainerObject()->getId())->isResetResultsEnabled() or
+            ilLOSettings::getInstanceByObjId($this->getContainerObject()->getId())->isResetResultsEnabled() ||
             $ilAccess->checkAccess('write', '', $this->getContainerObject()->getRefId())
         ) {
-            if ($has_results) {
-                if (!$is_manage && !$is_order) {
-                    $this->showButton('askReset', $lng->txt('crs_reset_results'));
-                }
+            if ($has_results && !$is_manage && !$is_order) {
+                $this->showButton('askReset', $lng->txt('crs_reset_results'));
             }
         }
 
@@ -164,7 +162,7 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
         $lng = $this->lng;
         
         $status = ilCourseObjectiveResultCache::getStatus($ilUser->getId(), $this->getContainerObject()->getId());
-        if ($status == ilCourseObjectiveResult::IL_OBJECTIVE_STATUS_EMPTY) {
+        if ($status === ilCourseObjectiveResult::IL_OBJECTIVE_STATUS_EMPTY) {
             return;
         }
         $info_tpl = new ilTemplate('tpl.crs_objectives_view_info_table.html', true, true, 'Modules/Course');
@@ -185,7 +183,7 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
         $has_container_page = false;
         if (!$a_is_order) {
             $output_html = $this->getContainerGUI()->getContainerPageHTML();
-            if ($output_html != "") {
+            if ($output_html !== "") {
                 $has_container_page = true;
                 $this->output_html .= $this->insertPageEmbeddedBlocks($output_html);
             }
@@ -199,7 +197,7 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
         
         $this->objective_list_gui = new ilCourseObjectiveListGUI();
         $this->objective_list_gui->setContainerObject($this->getContainerGUI());
-        if ($ilSetting->get("icon_position_in_lists") == "item_rows") {
+        if ($ilSetting->get("icon_position_in_lists") === "item_rows") {
             $this->objective_list_gui->enableIcon(true);
         }
         
@@ -224,7 +222,7 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
             if (
                 $has_initial &&
                 (
-                    !isset($lur_data[$objective_id]) or
+                    !isset($lur_data[$objective_id]) ||
                     ilLOUtils::hasActiveRun(
                         $this->container_obj->getId(),
                         ilLOSettings::getInstanceByObjId($this->container_obj->getId())->getInitialTest(),
@@ -232,7 +230,7 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
                     )
                 )
             ) {
-                $lur_data[$objective_id] = array("type" => ilLOSettings::TYPE_TEST_INITIAL);
+                $lur_data[$objective_id] = ["type" => ilLOSettings::TYPE_TEST_INITIAL];
             }
 
             if ($html = $this->renderObjective($objective_id, $has_lo_page, $acc, $lur_data[$objective_id])) {
@@ -327,7 +325,7 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
         int $a_mode = null,
         bool $a_is_manage = false,
         bool $a_as_accordion = false
-    ) {
+    ) : void {
         $lng = $this->lng;
 
         $this->clearAdminCommandsDetermination();
@@ -336,20 +334,20 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
             $this->objective_map = $this->buildObjectiveMap();
             
             // all rows
-            $item_r = array();
+            $item_r = [];
             
             $position = 1;
             foreach ($this->items["_all"] as $k => $item_data) {
-                if ($a_mode == self::MATERIALS_TESTS and $item_data['type'] != 'tst') {
+                if ($a_mode === self::MATERIALS_TESTS && $item_data['type'] !== 'tst') {
                     continue;
                 }
-                if ($item_data['type'] == 'itgr') {
+                if ($item_data['type'] === 'itgr') {
                     continue;
                 }
                 if (!$a_is_manage) {
                     // if test object is qualified or initial do not show here
                     $assignments = ilLOTestAssignments::getInstance($this->getContainerObject()->getId());
-                    if ($assignments->getTypeByTest($item_data['child']) != ilLOSettings::TYPE_TEST_UNDEFINED) {
+                    if ($assignments->getTypeByTest($item_data['child']) !== ilLOSettings::TYPE_TEST_UNDEFINED) {
                         continue;
                     }
                 }
@@ -359,9 +357,9 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
                     $this->rendered_items[$item_data['child']] = true;
                     
                     // TODO: Position (DONE ?)
-                    $html = $this->renderItem($item_data, $position++, !($a_mode == self::MATERIALS_TESTS));
+                    $html = $this->renderItem($item_data, $position++, !($a_mode === self::MATERIALS_TESTS));
                     if ($html != "") {
-                        $item_r[] = array("html" => $html, "id" => $item_data["child"], "type" => $item_data["type"]);
+                        $item_r[] = ["html" => $html, "id" => $item_data["child"], "type" => $item_data["type"]];
                     }
                 }
             }
@@ -390,7 +388,7 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
                     }
 
                     // :TODO:
-                    if ($a_mode != self::MATERIALS_TESTS) {
+                    if ($a_mode !== self::MATERIALS_TESTS) {
                         $pos = $this->getItemGroupsHTML();
                     }
                 
@@ -416,7 +414,7 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
                     $acc = new ilAccordionGUI();
                     $acc->setId("crsobjtvmat" . $a_mode . "_" . $this->container_obj->getId());
                     
-                    $acc_content = array();
+                    $acc_content = [];
                     foreach ($item_r as $h) {
                         $acc_content[] = $h["html"];
                     }
@@ -430,7 +428,7 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
     
     protected function buildObjectiveMap() : array
     {
-        $objective_map = array();
+        $objective_map = [];
         // begin-patch lok
         if (count($objective_ids = ilCourseObjective::_getObjectiveIds($this->getContainerObject()->getId(), true))) {
             // end-patch lok
@@ -479,40 +477,40 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
         $item_ref_id = $a_item["ref_id"];
         
         if (is_array($this->objective_map)) {
-            $details = array();
+            $details = [];
             if (isset($this->objective_map["material"][$item_ref_id])) {
                 // #12965
                 foreach ($this->objective_map["material"][$item_ref_id] as $objective_id) {
                     $ilCtrl->setParameterByClass('ilcourseobjectivesgui', 'objective_id', $objective_id);
-                    $url = $ilCtrl->getLinkTargetByClass(array('illoeditorgui', 'ilcourseobjectivesgui'), 'edit');
+                    $url = $ilCtrl->getLinkTargetByClass(['illoeditorgui', 'ilcourseobjectivesgui'], 'edit');
                     $ilCtrl->setParameterByClass('ilcourseobjectivesgui', 'objective_id', '');
 
-                    $details[] = array(
+                    $details[] = [
                         'desc' => $lng->txt('crs_loc_tab_materials') . ': ',
                         'target' => '_top',
                         'link' => $url,
                         'name' => $this->objective_map["names"][$objective_id]
-                    );
+                    ];
                 }
             }
             if ($this->objective_map["test_i"] == $item_ref_id) {
                 $ilCtrl->setParameterByClass('illoeditorgui', 'tt', 1);
-                $details[] = array(
+                $details[] = [
                     'desc' => '',
                     'target' => '_top',
                     'link' => $ilCtrl->getLinkTargetByClass('illoeditorgui', 'testOverview'),
                     'name' => $lng->txt('crs_loc_tab_itest')
-                );
+                ];
                 $ilCtrl->setParameterByClass('illoeditorgui', 'tt', 0);
             }
             if ($this->objective_map["test_q"] == $item_ref_id) {
                 $ilCtrl->setParameterByClass('illoeditorgui', 'tt', 2);
-                $details[] = array(
+                $details[] = [
                     'desc' => '',
                     'target' => '_top',
                     'link' => $ilCtrl->getLinkTargetByClass('illoeditorgui', 'testOverview'),
                     'name' => $lng->txt('crs_loc_tab_qtest')
-                );
+                ];
                 $ilCtrl->setParameterByClass('illoeditorgui', 'tt', 0);
             }
             
@@ -527,18 +525,18 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
                         $ilCtrl->setParameterByClass('illoeditorgui', 'tt', 2);
                     }
                     foreach ($items as $objtv_title) {
-                        $details[] = array(
+                        $details[] = [
                             'desc' => '',
                             'target' => '_top',
                             'link' => $ilCtrl->getLinkTargetByClass('illoeditorgui', 'testsOverview'),
                             'name' => $caption . " (" . $this->lng->txt("crs_loc_learning_objective") . ": " . $objtv_title . ")"
-                        );
+                        ];
                     }
                     $ilCtrl->setParameterByClass('illoeditorgui', 'tt', 0);
                 }
             }
         
-            if (sizeof($details)) {
+            if (count($details)) {
                 $a_item_list_gui->enableItemDetailLinks(true);
                 $a_item_list_gui->setItemDetailLinks($details, $lng->txt('crs_loc_settings_tbl') . ': ');
             } else {
@@ -558,7 +556,7 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
         }
         
         if ($a_item['objective_id']) {
-            $a_item_list_gui->setDefaultCommandParameters(array('objective_id' => $a_item['objective_id']));
+            $a_item_list_gui->setDefaultCommandParameters(['objective_id' => $a_item['objective_id']]);
             
             
             if ($this->loc_settings->getQualifiedTest() == $a_item['ref_id']) {
@@ -607,24 +605,22 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
         int $a_objective_id,
         int $a_user_id
     ) : array {
-        if ($this->loc_settings->getQualifiedTest() == $a_item_ref_id) {
+        if ($this->loc_settings->getQualifiedTest() === $a_item_ref_id) {
             // Check for existing test run, and decrease tries, reset final if run exists
             $active = ilObjTest::isParticipantsLastPassActive(
                 $a_item_ref_id,
                 $a_user_id
             );
             
-            if ($active) {
-                if (ilLOTestRun::lookupRunExistsForObjective(
-                    ilObject::_lookupObjId($a_item_ref_id),
-                    $a_objective_id,
-                    $a_user_id
-                )) {
-                    if ($a_res['tries'] > 0) {
-                        --$a_res['tries'];
-                    }
-                    $a_res['is_final'] = 0;
+            if ($active && ilLOTestRun::lookupRunExistsForObjective(
+                ilObject::_lookupObjId($a_item_ref_id),
+                $a_objective_id,
+                $a_user_id
+            )) {
+                if ($a_res['tries'] > 0) {
+                    --$a_res['tries'];
                 }
+                $a_res['is_final'] = 0;
             }
         }
         return $a_res;
@@ -657,7 +653,7 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
         $objectives_lm_obj = new ilCourseObjectiveMaterials($a_objective_id);
         
         // #13381 - map material assignment to position
-        $sort_map = array();
+        $sort_map = [];
         foreach ($objectives_lm_obj->getMaterials() as $item) {
             $sort_map[$item["lm_ass_id"]] = $item["position"];
         }
@@ -665,7 +661,7 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
         $is_manage = $this->getContainerGUI()->isActiveAdministrationPanel();
         $is_order = $this->getContainerGUI()->isActiveOrdering();
                 
-        $sort_content = array();
+        $sort_content = [];
         
         foreach ($items as $item) {
             if ($this->getDetailsLevel($a_objective_id) < self::DETAILS_ALL) {
@@ -693,10 +689,11 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
                         " &rsaquo; " . ilLMObject::_lookupTitle($chapter['obj_id']) .
                         " (" . $lng->txt('obj_' . $chapter['type']) . ")";
 
-                    $item_list_gui2->setDefaultCommandParameters(array(
+                    $item_list_gui2->setDefaultCommandParameters([
                         "obj_id" => $chapter['obj_id'],
                         "focus_id" => $chapter['obj_id'],
-                        "focus_return" => $this->container_obj->getRefId()));
+                        "focus_return" => $this->container_obj->getRefId()
+                    ]);
 
                     if ($is_order) {
                         $item_list_gui2->setPositionInputField(
@@ -741,7 +738,7 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
             }
         }
         
-        if ($this->getDetailsLevel($a_objective_id) == self::DETAILS_ALL) {
+        if ($this->getDetailsLevel($a_objective_id) === self::DETAILS_ALL) {
             $this->objective_list_gui->enableCommands(false);
         } else {
             $this->objective_list_gui->enableCommands(true);
@@ -768,55 +765,55 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
                 $objective->getDescription(),
                 ($is_manage || $is_order)
             );
-        } else {
-            $acc_content = $sort_content;
-            
-            $initial_shown = false;
-            $initial_test_ref_id = $this->getTestAssignments()->getTestByObjective($a_objective_id, ilLOSettings::TYPE_TEST_INITIAL);
-            $initial_test_obj_id = ilObject::_lookupObjId($initial_test_ref_id);
+        }
 
-            if (
-                $initial_test_obj_id &&
-                $this->getSettings()->hasSeparateInitialTests() &&
-                !ilObjTestAccess::checkCondition($initial_test_obj_id, ilConditionHandler::OPERATOR_FINISHED, '', $ilUser->getId())
-            ) {
-                $acc_content[] = $this->renderTest(
-                    $this->getTestAssignments()->getTestByObjective($a_objective_id, ilLOSettings::TYPE_TEST_INITIAL),
-                    $a_objective_id,
-                    true
-                );
-                $initial_shown = true;
-            } elseif ($this->getSettings()->hasSeparateQualifiedTests()) {
-                $acc_content[] = $this->renderTest(
-                    $this->getTestAssignments()->getTestByObjective($a_objective_id, ilLOSettings::TYPE_TEST_QUALIFIED),
-                    $a_objective_id,
-                    false
-                );
-            }
-            
-            $co_page = null;
-            if (ilPageUtil::_existsAndNotEmpty("lobj", $objective->getObjectiveId())) {
-                $a_has_lo_page = true;
-                
-                $page_gui = new ilLOPageGUI($objective->getObjectiveId());
-                
-                $page_gui->setStyleId(
-                    $this->content_style_domain->getEffectiveStyleId()
-                );
-                $page_gui->setPresentationTitle("");
-                $page_gui->setTemplateOutput(false);
-                $page_gui->setHeader("");
-                
-                $co_page = "<div class='ilContObjectiveIntro'>" . $page_gui->showPage() . "</div>";
-            }
-            
-            $a_accordion->addItem(
-                $this->buildAccordionTitle($objective, $a_lo_result),
-                $co_page .
-                    $this->buildAccordionContent($acc_content),
-                ($this->request->getObjectiveId() == $objective->getObjectiveId())
+        $acc_content = $sort_content;
+
+        $initial_shown = false;
+        $initial_test_ref_id = $this->getTestAssignments()->getTestByObjective($a_objective_id, ilLOSettings::TYPE_TEST_INITIAL);
+        $initial_test_obj_id = ilObject::_lookupObjId($initial_test_ref_id);
+
+        if (
+            $initial_test_obj_id &&
+            $this->getSettings()->hasSeparateInitialTests() &&
+            !ilObjTestAccess::checkCondition($initial_test_obj_id, ilConditionHandler::OPERATOR_FINISHED, '', $ilUser->getId())
+        ) {
+            $acc_content[] = $this->renderTest(
+                $this->getTestAssignments()->getTestByObjective($a_objective_id, ilLOSettings::TYPE_TEST_INITIAL),
+                $a_objective_id,
+                true
+            );
+            $initial_shown = true;
+        } elseif ($this->getSettings()->hasSeparateQualifiedTests()) {
+            $acc_content[] = $this->renderTest(
+                $this->getTestAssignments()->getTestByObjective($a_objective_id, ilLOSettings::TYPE_TEST_QUALIFIED),
+                $a_objective_id,
+                false
             );
         }
+
+        $co_page = null;
+        if (ilPageUtil::_existsAndNotEmpty("lobj", $objective->getObjectiveId())) {
+            $a_has_lo_page = true;
+            
+            $page_gui = new ilLOPageGUI($objective->getObjectiveId());
+            
+            $page_gui->setStyleId(
+                $this->content_style_domain->getEffectiveStyleId()
+            );
+            $page_gui->setPresentationTitle("");
+            $page_gui->setTemplateOutput(false);
+            $page_gui->setHeader("");
+            
+            $co_page = "<div class='ilContObjectiveIntro'>" . $page_gui->showPage() . "</div>";
+        }
+
+        $a_accordion->addItem(
+            $this->buildAccordionTitle($objective, $a_lo_result),
+            $co_page . $this->buildAccordionContent($acc_content),
+            ($this->request->getObjectiveId() === $objective->getObjectiveId())
+        );
+
         return "";
     }
 
@@ -831,7 +828,7 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
         $ilUser = $this->user;
         $initial_status = null;
         
-        $res = array();
+        $res = [];
                 
         $lo_ass = ilLOTestAssignments::getInstance($this->getContainerObject()->getId());
                 
@@ -1053,7 +1050,7 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
         $has_completed =
             ($a_lo_result["status"] == ilLOUserResults::STATUS_COMPLETED);
 
-        $next_step = $progress_txt = $bar_color = $test_url = $initial_sub = null;
+        $next_step = '';
 
         if (
             $is_qualified ||
@@ -1064,17 +1061,15 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
                 $next_step = $lng->txt("crs_loc_progress_do_qualifying_again");
             }
         } // initial test
-        else {
-            if ($a_lo_result["status"]) {
-                $next_step =
-                    $has_completed ?
-                        $lng->txt("crs_loc_progress_do_qualifying") :
-                        $lng->txt("crs_loc_suggested");
-            } else {
-                $next_step = $a_has_initial_test ?
-                    $lng->txt("crs_loc_progress_no_result_do_initial") :
-                    $lng->txt("crs_loc_progress_no_result_no_initial");
-            }
+        elseif ($a_lo_result["status"]) {
+            $next_step =
+                $has_completed ?
+                    $lng->txt("crs_loc_progress_do_qualifying") :
+                    $lng->txt("crs_loc_suggested");
+        } else {
+            $next_step = $a_has_initial_test ?
+                $lng->txt("crs_loc_progress_no_result_do_initial") :
+                $lng->txt("crs_loc_progress_no_result_no_initial");
         }
         return $next_step;
     }
@@ -1142,22 +1137,20 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
             }
         }
         // initial test
+        elseif ($a_lo_result["status"]) {
+            $progress_txt = $lng->txt("crs_loc_progress_result_itest");
+            $tt_txt = $lng->txt("crs_loc_tab_itest") . ": " . $tt_txt;
+            
+            $bar_color = "ilCourseObjectiveProgressBarNeutral";
+            $next_step = $has_completed
+                ? $lng->txt("crs_loc_progress_do_qualifying")
+                : $lng->txt("crs_loc_suggested");
+        }
+        // not attempted: no progress bar
         else {
-            if ($a_lo_result["status"]) {
-                $progress_txt = $lng->txt("crs_loc_progress_result_itest");
-                $tt_txt = $lng->txt("crs_loc_tab_itest") . ": " . $tt_txt;
-                
-                $bar_color = "ilCourseObjectiveProgressBarNeutral";
-                $next_step = $has_completed
-                    ? $lng->txt("crs_loc_progress_do_qualifying")
-                    : $lng->txt("crs_loc_suggested");
-            }
-            // not attempted: no progress bar
-            else {
-                $next_step = $a_has_initial_test
-                    ? $lng->txt("crs_loc_progress_no_result_do_initial")
-                    : $lng->txt("crs_loc_progress_no_result_no_initial");
-            }
+            $next_step = $a_has_initial_test
+                ? $lng->txt("crs_loc_progress_no_result_do_initial")
+                : $lng->txt("crs_loc_progress_no_result_no_initial");
         }
         
         // link to test statistics
@@ -1236,12 +1229,12 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
         }
 
         if ($initial_res !== null) {
-            $link = \ilLOUtils::getTestResultLinkForUser(
+            $link = ilLOUtils::getTestResultLinkForUser(
                 $a_lo_result["itest"],
                 $a_lo_result["user_id"]
             );
 
-            if (strlen($link)) {
+            if ($link !== '') {
                 $tpl->setCurrentBlock('i_with_link');
                 $tpl->setVariable(
                     'IBTN',
@@ -1276,12 +1269,12 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
         }
 
         if ($qual_res !== null) {
-            $link = \ilLOUtils::getTestResultLinkForUser(
+            $link = ilLOUtils::getTestResultLinkForUser(
                 $a_lo_result["qtest"],
                 $a_lo_result["user_id"]
             );
 
-            if (strlen($link)) {
+            if ($link !== '') {
                 $tpl->setCurrentBlock('q_with_link');
                 $tpl->setVariable(
                     'QBTN',
@@ -1313,7 +1306,7 @@ class ilContainerObjectiveGUI extends ilContainerContentGUI
             $a_objective->getObjectiveId(),
             $a_lo_result
         );
-        if (strlen($summary)) {
+        if ($summary !== '') {
             $tpl->setCurrentBlock('objective_summary');
             $tpl->setVariable('SUMMARY_TXT', $summary);
             $tpl->parseCurrentBlock();

--- a/Services/Container/Content/class.ilContainerRenderer.php
+++ b/Services/Container/Content/class.ilContainerRenderer.php
@@ -94,12 +94,12 @@ class ilContainerRenderer
         string $a_prefix = null,
         string $a_postfix = null
     ) : bool {
-        if ($a_type != "itgr" &&
+        if ($a_type !== "itgr" &&
             !$this->hasTypeBlock($a_type)) {
-            $this->type_blocks[$a_type] = array(
+            $this->type_blocks[$a_type] = [
                 "prefix" => $a_prefix
                 ,"postfix" => $a_postfix
-            );
+            ];
             return true;
         }
         return false;
@@ -121,11 +121,11 @@ class ilContainerRenderer
         array $a_data = []
     ) : bool {
         if (!$this->hasCustomBlock($a_id)) {
-            $this->custom_blocks[$a_id] = array(
+            $this->custom_blocks[$a_id] = [
                 "caption" => $a_caption
                 ,"actions" => $a_actions
                 ,"data" => $a_data
-            );
+            ];
             return true;
         }
         return false;
@@ -178,10 +178,9 @@ class ilContainerRenderer
         if (!$this->hasItem($a_id)) {
             return;
         }
-        
-        unset($this->item_ids[$a_id]);
-        unset($this->hidden_items[$a_id]);
-        
+
+        unset($this->item_ids[$a_id], $this->hidden_items[$a_id]);
+
         foreach (array_keys($this->items) as $item_id) {
             $parts = explode(self::UNIQUE_SEPARATOR, $item_id);
             if (array_pop($parts) == $a_id) {
@@ -194,7 +193,7 @@ class ilContainerRenderer
                 $parts = explode(self::UNIQUE_SEPARATOR, $item_id);
                 if (array_pop($parts) == $a_id) {
                     unset($this->block_items[$block_id][$idx]);
-                    if (!sizeof($this->block_items[$block_id])) {
+                    if (!count($this->block_items[$block_id])) {
                         unset($this->block_items[$block_id]);
                     }
                     break;
@@ -228,10 +227,10 @@ class ilContainerRenderer
         $a_item_html,
         bool $a_force = false
     ) : bool {
-        if ($this->isValidBlock($a_block_id) &&
-            $a_item_type != "itgr" &&
+        if ($a_item_type !== "itgr" &&
+            $this->isValidBlock($a_block_id) &&
             (!$this->hasItem($a_item_id) || $a_force)) {
-            if (is_string($a_item_html) && trim($a_item_html) == "") {
+            if (is_string($a_item_html) && trim($a_item_html) === "") {
                 return false;
             }
             if (!$a_item_html) {
@@ -242,10 +241,10 @@ class ilContainerRenderer
             // #16563 - item_id (== ref_id) is NOT unique, adding parent block id
             $uniq_id = $a_block_id . self::UNIQUE_SEPARATOR . $a_item_id;
         
-            $this->items[$uniq_id] = array(
+            $this->items[$uniq_id] = [
                 "type" => $a_item_type
                 ,"html" => $a_item_html
-            );
+            ];
             
             // #18326
             $this->item_ids[$a_item_id] = true;
@@ -270,10 +269,10 @@ class ilContainerRenderer
         string $a_url,
         bool $a_active = false
     ) : void {
-        $this->details[$a_level] = array(
+        $this->details[$a_level] = [
             "url" => $a_url
             ,"active" => $a_active
-        );
+        ];
     }
     
     public function resetDetails() : void
@@ -305,17 +304,19 @@ class ilContainerRenderer
         $block_tpl = $this->initBlockTemplate();
         
         foreach ($this->processBlockPositions() as $block_id) {
-            if (array_key_exists($block_id, $this->custom_blocks)) {
-                if ($this->renderHelperCustomBlock($block_tpl, $block_id)) {
-                    $this->addSeparatorRow($block_tpl);
-                    $valid = true;
-                }
+            if (array_key_exists($block_id, $this->custom_blocks) && $this->renderHelperCustomBlock(
+                $block_tpl,
+                $block_id
+            )) {
+                $this->addSeparatorRow($block_tpl);
+                $valid = true;
             }
-            if (array_key_exists($block_id, $this->type_blocks)) {
-                if ($this->renderHelperTypeBlock($block_tpl, $block_id)) {
-                    $this->addSeparatorRow($block_tpl);
-                    $valid = true;
-                }
+            if (array_key_exists($block_id, $this->type_blocks) && $this->renderHelperTypeBlock(
+                $block_tpl,
+                $block_id
+            )) {
+                $this->addSeparatorRow($block_tpl);
+                $valid = true;
             }
         }
         
@@ -358,7 +359,7 @@ class ilContainerRenderer
     protected function processBlockPositions() : array
     {
         // manual order
-        if (is_array($this->block_custom_pos) && sizeof($this->block_custom_pos)) {
+        if (is_array($this->block_custom_pos) && count($this->block_custom_pos)) {
             $tmp = $this->block_pos;
             $this->block_pos = [];
             foreach ($this->block_custom_pos as $idx => $block_id) {
@@ -368,7 +369,7 @@ class ilContainerRenderer
             }
             
             // at least some manual are valid
-            if (sizeof($this->block_pos)) {
+            if (count($this->block_pos)) {
                 // append missing blocks from default order
                 $last = max($this->block_pos);
                 foreach (array_keys($tmp) as $block_id) {
@@ -384,7 +385,7 @@ class ilContainerRenderer
         }
         
         // add missing blocks to order
-        $last = sizeof($this->block_pos)
+        $last = count($this->block_pos)
             ? max($this->block_pos)
             : 0;
         foreach (array_keys($this->custom_blocks) as $block_id) {
@@ -452,14 +453,15 @@ class ilContainerRenderer
             }
 
             // determine view mode and tile size
+            $tile_size = ilContainer::TILE_SMALL;
             $view_mode = $this->getViewMode();
-            if ($view_mode == ilContainerContentGUI::VIEW_MODE_TILE) {
+            if ($view_mode === ilContainerContentGUI::VIEW_MODE_TILE) {
                 $tile_size = ilContainer::_lookupContainerSetting($this->container_gui->getObject()->getId(), "tile_size");
             }
             if (is_numeric($a_block_id)) {
                 $item_group = new ilObjItemGroup($a_block_id);
-                if ($item_group->getListPresentation() != "") {
-                    $view_mode = ($item_group->getListPresentation() == "tile")
+                if ($item_group->getListPresentation() !== "") {
+                    $view_mode = ($item_group->getListPresentation() === "tile")
                         ? ilContainerContentGUI::VIEW_MODE_TILE
                         : ilContainerContentGUI::VIEW_MODE_LIST;
                     $tile_size = $item_group->getTileSize();
@@ -485,7 +487,7 @@ class ilContainerRenderer
                     $a_block["data"] ?? []
                 );
 
-                if ($view_mode == ilContainerContentGUI::VIEW_MODE_LIST) {
+                if ($view_mode === ilContainerContentGUI::VIEW_MODE_LIST) {
                     if (isset($a_block["prefix"]) && $a_block["prefix"]) {
                         $this->addStandardRow($a_block_tpl, $a_block["prefix"]);
                     }
@@ -493,7 +495,7 @@ class ilContainerRenderer
 
                 if (isset($this->block_items[$a_block_id])) {
                     foreach ($this->block_items[$a_block_id] as $item_id) {
-                        if ($view_mode == ilContainerContentGUI::VIEW_MODE_LIST) {
+                        if ($view_mode === ilContainerContentGUI::VIEW_MODE_LIST) {
                             $this->addStandardRow($a_block_tpl, $this->items[$item_id]["html"], (int) $item_id);
                         } else {
                             $cards[] = $this->items[$item_id]["html"];
@@ -501,13 +503,13 @@ class ilContainerRenderer
                     }
                 }
 
-                if ($view_mode == ilContainerContentGUI::VIEW_MODE_LIST) {
+                if ($view_mode === ilContainerContentGUI::VIEW_MODE_LIST) {
                     if (isset($a_block["postfix"]) && $a_block["postfix"]) {
                         $this->addStandardRow($a_block_tpl, $a_block["postfix"]);
                     }
                 }
 
-                if ($view_mode == ilContainerContentGUI::VIEW_MODE_TILE) {
+                if ($view_mode === ilContainerContentGUI::VIEW_MODE_TILE) {
                     $f = $this->ui->factory();
                     $renderer = $this->ui->renderer();
 
@@ -602,17 +604,17 @@ class ilContainerRenderer
             $this->renderSelectAllBlock($a_tpl);
         } elseif ($this->enable_multi_download) {
             if ($a_type) {
-                $a_types_in_block = array($a_type);
+                $a_types_in_block = [$a_type];
             }
             foreach ($a_types_in_block as $type) {
-                if (in_array($type, $this->getDownloadableTypes())) {
+                if (in_array($type, $this->getDownloadableTypes(), true)) {
                     $this->renderSelectAllBlock($a_tpl);
                     break;
                 }
             }
         }
                 
-        if ($a_text == "" && $a_type != "") {
+        if ($a_text === "" && $a_type !== "") {
             if (!$objDefinition->isPlugin($a_type)) {
                 $title = $lng->txt("objs_" . $a_type);
             } else {
@@ -630,14 +632,13 @@ class ilContainerRenderer
                 $a_tpl->setVariable("DATA_VALUE", $v);
                 $a_tpl->parseCurrentBlock();
 
-                if ($k == "behaviour" && $v == ilItemGroupBehaviour::EXPANDABLE_CLOSED) {
+                if ($k === "behaviour" && $v == ilItemGroupBehaviour::EXPANDABLE_CLOSED) {
                     $a_tpl->touchBlock("container_items_hide");
                 }
             }
         }
 
-        if ($ilSetting->get("icon_position_in_lists") != "item_rows" &&
-            $a_type != "") {
+        if ($a_type !== "" && $ilSetting->get("icon_position_in_lists") !== "item_rows") {
             $icon = ilUtil::getImagePath("icon_" . $a_type . ".svg");
 
             $a_tpl->setCurrentBlock("container_header_row_image");
@@ -647,7 +648,7 @@ class ilContainerRenderer
             $a_tpl->setCurrentBlock("container_header_row");
         }
     
-        if ($a_order_id != "") {
+        if ($a_order_id !== "") {
             $a_tpl->setVariable("BLOCK_HEADER_ORDER_NAME", "position[blocks][" . $a_order_id . "]");
             $a_tpl->setVariable("BLOCK_HEADER_ORDER_NUM", (++$this->order_cnt) * 10);
         }
@@ -703,14 +704,14 @@ class ilContainerRenderer
      */
     protected function getDownloadableTypes() : array
     {
-        return array("fold", "file");
+        return ["fold", "file"];
     }
     
     public function renderDetails(ilTemplate $a_tpl) : void
     {
         $lng = $this->lng;
         
-        if (sizeof($this->details)) {
+        if (count($this->details)) {
             $a_tpl->setCurrentBlock('container_details_row');
             $a_tpl->setVariable('TXT_DETAILS', $lng->txt('details'));
             $a_tpl->parseCurrentBlock();

--- a/Services/Container/Content/class.ilContainerSessionsContentGUI.php
+++ b/Services/Container/Content/class.ilContainerSessionsContentGUI.php
@@ -47,9 +47,9 @@ class ilContainerSessionsContentGUI extends ilContainerContentGUI
         }
         if (in_array($a_item_id, $this->force_details)) {
             return self::DETAILS_ALL;
-        } else {
-            return self::DETAILS_TITLE;
         }
+
+        return self::DETAILS_TITLE;
     }
 
     public function getMainContent() : string
@@ -64,12 +64,12 @@ class ilContainerSessionsContentGUI extends ilContainerContentGUI
             "Services/Container"
         );
 
-        $this->__showMaterials($tpl);
+        $this->showMaterials($tpl);
             
         return $tpl->get();
     }
 
-    public function __showMaterials(ilTemplate $a_tpl) : void
+    private function showMaterials(ilTemplate $a_tpl) : void
     {
         $lng = $this->lng;
 
@@ -123,7 +123,7 @@ class ilContainerSessionsContentGUI extends ilContainerContentGUI
             
             foreach ($this->items["_all"] as $item_data) {
                 // #14599
-                if ($item_data["type"] == "sess" || $item_data["type"] == "itgr") {
+                if ($item_data["type"] === "sess" || $item_data["type"] === "itgr") {
                     continue;
                 }
                 
@@ -209,7 +209,7 @@ class ilContainerSessionsContentGUI extends ilContainerContentGUI
         if ($session = ilSessionAppointment::lookupNextSessionByCourse($this->getContainerObject()->getRefId())) {
             $this->force_details = $session;
         } elseif ($session = ilSessionAppointment::lookupLastSessionByCourse($this->getContainerObject()->getRefId())) {
-            $this->force_details = array($session);
+            $this->force_details = [$session];
         }
     }
 
@@ -236,13 +236,13 @@ class ilContainerSessionsContentGUI extends ilContainerContentGUI
             !$include_side_block &&
             $items['sess'] &&
             is_array($items['sess']) &&
-            (($container->getViewMode() == ilContainer::VIEW_SESSIONS) || ($container->getViewMode() == ilContainer::VIEW_INHERIT)) &&
-            $container->isSessionLimitEnabled()
+            $container->isSessionLimitEnabled() &&
+            ($container->getViewMode() === ilContainer::VIEW_SESSIONS || $container->getViewMode() === ilContainer::VIEW_INHERIT)
         ) {
             $limit_sessions = true;
         }
 
-        if ($container->getViewMode() == ilContainer::VIEW_INHERIT) {
+        if ($container->getViewMode() === ilContainer::VIEW_INHERIT) {
             $parent = $tree->checkForParentType($container->getRefId(), 'crs');
             $crs = ilObjectFactory::getInstanceByRefId($parent, false);
             if (!$crs instanceof ilObjCourse) {
@@ -287,8 +287,8 @@ class ilContainerSessionsContentGUI extends ilContainerContentGUI
         }
         $sessions = ilArrayUtil::sortArray($session_rbac_checked, 'start', 'ASC', true, false);
         //$sessions = ilUtil::sortArray($this->items['sess'],'start','ASC',true,false);
-        $today = new ilDate(date('Ymd', time()), IL_CAL_DATE);
-        $previous = $current = $next = array();
+        $today = new ilDate(date('Ymd'), IL_CAL_DATE);
+        $previous = $current = $next = [];
         foreach ($sessions as $key => $item) {
             $start = new ilDateTime($item['start'], IL_CAL_UNIX);
             $end = new ilDateTime($item['end'], IL_CAL_UNIX);

--- a/Services/Container/Content/class.ilContainerSimpleContentGUI.php
+++ b/Services/Container/Content/class.ilContainerSimpleContentGUI.php
@@ -52,12 +52,12 @@ class ilContainerSimpleContentGUI extends ilContainerContentGUI
         // @todo
         //		$this->__showFeedBack();
 
-        $this->__showMaterials($tpl);
+        $this->showMaterials($tpl);
             
         return $tpl->get();
     }
 
-    public function __showMaterials(
+    private function showMaterials(
         ilTemplate $a_tpl
     ) : void {
         $lng = $this->lng;
@@ -70,7 +70,7 @@ class ilContainerSimpleContentGUI extends ilContainerContentGUI
         $output_html = $this->getContainerGUI()->getContainerPageHTML();
         
         // get embedded blocks
-        if ($output_html != "") {
+        if ($output_html !== "") {
             $output_html = $this->insertPageEmbeddedBlocks($output_html);
         }
 
@@ -103,7 +103,7 @@ class ilContainerSimpleContentGUI extends ilContainerContentGUI
     {
         $this->handleSessionExpand();
 
-        if ($this->getContainerObject()->getType() == 'crs') {
+        if ($this->getContainerObject()->getType() === 'crs') {
             if ($session = ilSessionAppointment::lookupNextSessionByCourse($this->getContainerObject()->getRefId())) {
                 $this->force_details = $session;
             } elseif ($session = ilSessionAppointment::lookupLastSessionByCourse($this->getContainerObject()->getRefId())) {
@@ -122,8 +122,8 @@ class ilContainerSimpleContentGUI extends ilContainerContentGUI
         }
         if ($a_item_id == $this->force_details) {
             return self::DETAILS_ALL;
-        } else {
-            return self::DETAILS_TITLE;
         }
+
+        return self::DETAILS_TITLE;
     }
 }

--- a/Services/Container/Export/class.ilContainerExporter.php
+++ b/Services/Container/Export/class.ilContainerExporter.php
@@ -35,68 +35,70 @@ class ilContainerExporter extends ilXmlExporter
     
     public function getXmlExportTailDependencies(string $a_entity, string $a_target_release, array $a_ids) : array
     {
-        if ($a_entity != 'struct') {
+        if ($a_entity !== 'struct') {
             return [];
         }
         
         
-        $res = array();
+        $res = [];
         
         // pages
         
-        $pg_ids = array();
+        $pg_ids = [];
         
         // container pages
         foreach ($a_ids as $id) {
-            if (ilContainerPage::_exists("cont", $id)) {
+            if (ilContainerPage::_exists("cont", (int) $id)) {
                 $pg_ids[] = "cont:" . $id;
             }
         }
         
         // container start objects pages
         foreach ($a_ids as $id) {
-            if (ilContainerStartObjectsPage::_exists("cstr", $id)) {
+            if (ilContainerStartObjectsPage::_exists("cstr", (int) $id)) {
                 $pg_ids[] = "cstr:" . $id;
             }
         }
         
-        if (sizeof($pg_ids)) {
-            $res[] = array(
+        if (count($pg_ids)) {
+            $res[] = [
                 "component" => "Services/COPage",
                 "entity" => "pg",
                 "ids" => $pg_ids
-            );
+            ];
         }
         
         // style
-        $style_ids = array();
+        $style_ids = [];
         foreach ($a_ids as $id) {
             // see #24888
-            $style = $this->content_style_domain->styleForObjId($id);
+            $style = $this->content_style_domain->styleForObjId((int) $id);
             $style_id = $style->getEffectiveStyleId();
             if ($style_id > 0) {
                 $style_ids[] = $style_id;
             }
         }
-        if (sizeof($style_ids)) {
-            $res[] = array(
+        if (count($style_ids)) {
+            $res[] = [
                 "component" => "Services/Style",
                 "entity" => "sty",
                 "ids" => $style_ids
-            );
+            ];
         }
 
         // service settings
-        $res[] = array(
+        $res[] = [
             "component" => "Services/Object",
             "entity" => "common",
-            "ids" => $a_ids);
+            "ids" => $a_ids
+        ];
 
         // skill profiles
-        $res[] = array(
+        $res[] = [
             "component" => "Services/Skill",
             "entity" => "skl_local_prof",
-            "ids" => $a_ids);
+            "ids" => $a_ids
+        ];
 
         // news settings
         $res[] = [
@@ -113,7 +115,7 @@ class ilContainerExporter extends ilXmlExporter
         global $DIC;
 
         $log = $DIC->logger()->root();
-        if ($a_entity == 'struct') {
+        if ($a_entity === 'struct') {
             $log->debug(__METHOD__ . ': Received id = ' . $a_id);
             $ref_ids = ilObject::_getAllReferences((int) $a_id);
             $writer = new ilContainerXmlWriter(end($ref_ids));
@@ -131,13 +133,14 @@ class ilContainerExporter extends ilXmlExporter
      */
     public function getValidSchemaVersions(string $a_entity) : array
     {
-        return array(
-            "4.1.0" => array(
+        return [
+            "4.1.0" => [
                 "namespace" => "https://www.ilias.de/Modules/Folder/fold/4_1",
                 "xsd_file" => "ilias_fold_4_1.xsd",
                 "uses_dataset" => false,
                 "min" => "4.1.0",
-                "max" => "")
-        );
+                "max" => ""
+            ]
+        ];
     }
 }

--- a/Services/Container/Export/class.ilContainerImporter.php
+++ b/Services/Container/Export/class.ilContainerImporter.php
@@ -59,11 +59,9 @@ class ilContainerImporter extends ilXmlImporter
             $new_pg_id = array_pop($parts);
             $new_obj_id = $a_mapping->getMapping('Services/Container', 'objs', $old_obj_id);
             // see bug #22718, this missed a check for the pg type
-            if (in_array($pg_type, array("crs", "grp", "fold", "cont"))) {
-                if ($new_obj_id > 0) {
-                    ilPageObject::_writeParentId($pg_type, $new_pg_id, $new_obj_id);
-                    $this->cont_log->debug('write parent id, type: ' . $pg_type . ", page id: " . $new_pg_id . ", parent id: " . $new_obj_id);
-                }
+            if ($new_obj_id > 0 && in_array($pg_type, ["crs", "grp", "fold", "cont"], true)) {
+                ilPageObject::_writeParentId($pg_type, (int) $new_pg_id, (int) $new_obj_id);
+                $this->cont_log->debug('write parent id, type: ' . $pg_type . ", page id: " . $new_pg_id . ", parent id: " . $new_obj_id);
             }
         }
         
@@ -72,7 +70,7 @@ class ilContainerImporter extends ilXmlImporter
         foreach ($sty_map as $old_sty_id => $new_sty_id) {
             if (isset(ilContainerXmlParser::$style_map[$old_sty_id])) {
                 foreach (ilContainerXmlParser::$style_map[$old_sty_id] as $obj_id) {
-                    ilObjStyleSheet::writeStyleUsage($obj_id, $new_sty_id);
+                    ilObjStyleSheet::writeStyleUsage((int) $obj_id, (int) $new_sty_id);
                 }
             }
         }
@@ -80,14 +78,14 @@ class ilContainerImporter extends ilXmlImporter
         // skills
         $crs_map = $a_mapping->getMappingsOfEntity('Modules/Course', 'crs');
         $new_crs_obj_id = end($crs_map);
-        $new_crs_ref_id = ilObject::_getAllReferences($new_crs_obj_id);
-        $new_crs_ref_id = end($new_crs_ref_id);
+        $new_crs_ref_ids = ilObject::_getAllReferences((int) $new_crs_obj_id);
+        $new_crs_ref_id = end($new_crs_ref_ids);
 
         $skl_local_prof_map = $a_mapping->getMappingsOfEntity('Services/Skill', 'skl_local_prof');
         foreach ($skl_local_prof_map as $old_prof_id => $new_prof_id) {
-            $prof = new ilSkillProfile($new_prof_id);
+            $prof = new ilSkillProfile((int) $new_prof_id);
             $prof->updateRefIdAfterImport((int) $new_crs_ref_id);
-            $prof->addRoleToProfile(ilParticipants::getDefaultMemberRole($new_crs_ref_id));
+            $prof->addRoleToProfile(ilParticipants::getDefaultMemberRole((int) $new_crs_ref_id));
         }
     }
 
@@ -107,10 +105,10 @@ class ilContainerImporter extends ilXmlImporter
             $ref_id = 0;
             $offline = null;
             foreach ($item->attributes() as $name => $value) {
-                if ((string) $name == 'Offline') {
+                if ((string) $name === 'Offline') {
                     $offline = $value;
                 }
-                if ((string) $name == 'RefId') {
+                if ((string) $name === 'RefId') {
                     $ref_id = (string) $value;
                 }
             }
@@ -142,7 +140,7 @@ class ilContainerImporter extends ilXmlImporter
         $tree = $DIC->repositoryTree();
         $parent_id = $tree->getParentId($ref_id);
         if ($parent_id) {
-            return (int) $parent_id === (int) $mapping->getTargetId();
+            return $parent_id === $mapping->getTargetId();
         }
         return false;
     }

--- a/Services/Container/Export/class.ilContainerXmlParser.php
+++ b/Services/Container/Export/class.ilContainerXmlParser.php
@@ -27,7 +27,7 @@ class ilContainerXmlParser
     private ?ilImportMapping $mapping = null;
     private string $xml = '';
     private int $root_id = 0;
-    public static array $style_map = array();
+    public static array $style_map = [];
 
     public function __construct(
         ilImportMapping $mapping,
@@ -52,7 +52,7 @@ class ilContainerXmlParser
         $sxml = simplexml_load_string($this->xml);
         $this->root_id = $a_root_id;
         foreach ($sxml->Item as $item) {
-            $this->initItem($item, (int) $this->mapping->getTargetId());
+            $this->initItem($item, $this->mapping->getTargetId());
         }
     }
     
@@ -79,7 +79,7 @@ class ilContainerXmlParser
             $new_ref = $this->mapping->getMapping('Services/Container', 'refs', 0);
             
             // see below and ilContainerImporter::finalProcessing()
-            $this->mapping->addMapping('Services/Container', 'objs', $obj_id, ilObject::_lookupObjId($new_ref));
+            $this->mapping->addMapping('Services/Container', 'objs', $obj_id, ilObject::_lookupObjId((int) $new_ref));
         }
         
         if (!$new_ref) {
@@ -184,12 +184,12 @@ class ilContainerXmlParser
         // A mapping for this object already exists => create reference
         $new_obj_id = $this->getMapping()->getMapping('Services/Container', 'objs', $obj_id);
         if ($new_obj_id) {
-            $obj = ilObjectFactory::getInstanceByObjId($new_obj_id, false);
+            $obj = ilObjectFactory::getInstanceByObjId((int) $new_obj_id, false);
             if ($obj instanceof  ilObject) {
                 $obj->createReference();
                 $obj->putInTree($parent_node);
                 $obj->setPermissions($parent_node);
-                $this->mapping->addMapping('Services/Container', 'refs', $ref_id, $obj->getRefId());
+                $this->mapping->addMapping('Services/Container', 'refs', (string) $ref_id, (string) $obj->getRefId());
                 return $obj->getRefId();
             }
         }
@@ -210,8 +210,8 @@ class ilContainerXmlParser
         $new->putInTree($parent_node);
         $new->setPermissions($parent_node);
         
-        $this->mapping->addMapping('Services/Container', 'objs', $obj_id, $new->getId());
-        $this->mapping->addMapping('Services/Container', 'refs', $ref_id, $new->getRefId());
+        $this->mapping->addMapping('Services/Container', 'objs', (string) $obj_id, (string) $new->getId());
+        $this->mapping->addMapping('Services/Container', 'refs', (string) $ref_id, (string) $new->getRefId());
         
         return $new->getRefId();
     }

--- a/Services/Container/Export/class.ilContainerXmlWriter.php
+++ b/Services/Container/Export/class.ilContainerXmlWriter.php
@@ -58,7 +58,7 @@ class ilContainerXmlWriter extends ilXmlWriter
         // because of the co-page-stuff (incl. styles) we also need to process the container itself
         if ($a_ref_id != $this->source) {
             $mode = $this->exp_options->getOptionByRefId($a_ref_id, ilExportOptions::KEY_ITEM_MODE);
-            if ($mode == null or $mode == ilExportOptions::EXPORT_OMIT) {
+            if ($mode == null || $mode == ilExportOptions::EXPORT_OMIT) {
                 return;
             }
         }
@@ -100,31 +100,31 @@ class ilContainerXmlWriter extends ilXmlWriter
         
         $this->xmlStartTag(
             'Timing',
-            array(
+            [
                 'Type' => $item['timing_type'],
                 'Visible' => $item['visible'],
                 'Changeable' => $item['changeable'],
-                )
+            ]
         );
         if ($item['timing_start']) {
             $tmp_date = new ilDateTime($item['timing_start'], IL_CAL_UNIX);
-            $this->xmlElement('Start', array(), $tmp_date->get(IL_CAL_DATETIME, '', ilTimeZone::UTC));
+            $this->xmlElement('Start', [], $tmp_date->get(IL_CAL_DATETIME, '', ilTimeZone::UTC));
         }
         if ($item['timing_end']) {
             $tmp_date = new ilDateTime($item['timing_end'], IL_CAL_UNIX);
-            $this->xmlElement('End', array(), $tmp_date->get(IL_CAL_DATETIME, '', ilTimeZone::UTC));
+            $this->xmlElement('End', [], $tmp_date->get(IL_CAL_DATETIME, '', ilTimeZone::UTC));
         }
         if ($item['suggestion_start']) {
             $tmp_date = new ilDateTime($item['suggestion_start'], IL_CAL_UNIX);
-            $this->xmlElement('SuggestionStart', array(), $tmp_date->get(IL_CAL_DATETIME, '', ilTimeZone::UTC));
+            $this->xmlElement('SuggestionStart', [], $tmp_date->get(IL_CAL_DATETIME, '', ilTimeZone::UTC));
         }
         if ($item['suggestion_end']) {
             $tmp_date = new ilDateTime($item['suggestion_end'], IL_CAL_UNIX);
-            $this->xmlElement('SuggestionEnd', array(), $tmp_date->get(IL_CAL_DATETIME, '', ilTimeZone::UTC));
+            $this->xmlElement('SuggestionEnd', [], $tmp_date->get(IL_CAL_DATETIME, '', ilTimeZone::UTC));
         }
         if ($item['earliest_start'] ?? false) {
             $tmp_date = new ilDateTime($item['earliest_start'], IL_CAL_UNIX);
-            $this->xmlElement('EarliestStart', array(), $tmp_date->get(IL_CAL_DATETIME, '', ilTimeZone::UTC));
+            $this->xmlElement('EarliestStart', [], $tmp_date->get(IL_CAL_DATETIME, '', ilTimeZone::UTC));
         }
 
         $this->xmlEndTag('Timing');

--- a/Services/Container/Filter/classes/class.ilContainerFilterAdminGUI.php
+++ b/Services/Container/Filter/classes/class.ilContainerFilterAdminGUI.php
@@ -58,7 +58,7 @@ class ilContainerFilterAdminGUI
 
         switch ($next_class) {
             default:
-                if (in_array($cmd, array("show", "selectFields", "saveFields"))) {
+                if (in_array($cmd, ["show", "selectFields", "saveFields"])) {
                     $this->$cmd();
                 }
         }
@@ -114,7 +114,7 @@ class ilContainerFilterAdminGUI
         $service = $this->container_filter_service;
 
 
-        $fields[] = array();
+        $fields[] = [];
 
 
         // current filter set
@@ -165,7 +165,7 @@ class ilContainerFilterAdminGUI
         $ctrl = $this->ctrl;
 
         $fields = [];
-        if ($request->getMethod() == "POST") {
+        if ($request->getMethod() === "POST") {
             $form = $form->withRequest($request);
             $data = $form->getData();
 

--- a/Services/Container/Filter/classes/class.ilContainerFilterAdvMDAdapter.php
+++ b/Services/Container/Filter/classes/class.ilContainerFilterAdvMDAdapter.php
@@ -45,7 +45,7 @@ class ilContainerFilterAdvMDAdapter
         $records = [];
         foreach ($this->types as $type) {
             foreach (ilAdvancedMDRecord::_getActivatedRecordsByObjectType($type) as $record_obj) {
-                if ($record_obj->isActive() && $record_obj->getParentObject() == 0) {
+                if ($record_obj->isActive() && $record_obj->getParentObject() === 0) {
                     $records[] = $record_obj;
                 }
             }
@@ -61,7 +61,7 @@ class ilContainerFilterAdvMDAdapter
     {
         $fields = array_filter(ilAdvancedMDFieldDefinition::getInstancesByRecordId($a_record_id), function ($f) {
             /** @var ilAdvancedMDFieldDefinition $f */
-            return in_array($f->getType(), $this->supported_types);
+            return in_array($f->getType(), $this->supported_types, true);
         });
         return $fields;
     }
@@ -74,7 +74,7 @@ class ilContainerFilterAdvMDAdapter
     {
         $lng = $this->lng;
 
-        if ($record_id == 0) {
+        if ($record_id === 0) {
             return $lng->txt("cont_std_filter_title_" . $filter_id);
         }
 

--- a/Services/Container/Filter/classes/class.ilContainerFilterFieldData.php
+++ b/Services/Container/Filter/classes/class.ilContainerFilterFieldData.php
@@ -20,7 +20,7 @@
  */
 class ilContainerFilterFieldData
 {
-    protected \ilDBInterface $db;
+    protected ilDBInterface $db;
 
     public function __construct()
     {
@@ -37,8 +37,8 @@ class ilContainerFilterFieldData
         $set = $db->queryF(
             "SELECT * FROM cont_filter_field " .
             " WHERE ref_id = %s ",
-            array("integer"),
-            array($ref_id)
+            ["integer"],
+            [$ref_id]
         );
         while ($rec = $db->fetchAssoc($set)) {
             if ($rec["record_set_id"] > 0 && !ilAdvancedMDFieldDefinition::exists($rec["field_id"])) {
@@ -50,7 +50,7 @@ class ilContainerFilterFieldData
         }
         $filter = ilArrayUtil::sortArray($filter, "sort", "asc", true);
 
-        $filter = array_map(function ($i) {
+        $filter = array_map(static function (array $i) : ilContainerFilterField {
             return $i["field"];
         }, $filter);
 
@@ -64,16 +64,16 @@ class ilContainerFilterFieldData
         $db->manipulateF(
             "DELETE FROM cont_filter_field WHERE " .
             " ref_id = %s",
-            array("integer"),
-            array($ref_id)
+            ["integer"],
+            [$ref_id]
         );
 
         foreach ($set->getFields() as $f) {
-            $db->insert("cont_filter_field", array(
-                "ref_id" => array("integer", $ref_id),
-                "record_set_id" => array("integer", $f->getRecordSetId()),
-                "field_id" => array("integer", $f->getFieldId())
-            ));
+            $db->insert("cont_filter_field", [
+                "ref_id" => ["integer", $ref_id],
+                "record_set_id" => ["integer", $f->getRecordSetId()],
+                "field_id" => ["integer", $f->getFieldId()]
+            ]);
         }
     }
 }

--- a/Services/Container/Filter/classes/class.ilContainerFilterService.php
+++ b/Services/Container/Filter/classes/class.ilContainerFilterService.php
@@ -84,14 +84,14 @@ class ilContainerFilterService
     {
         return new ilContainerFilterSet(
             [
-            $this->field(0, ilContainerFilterField::STD_FIELD_TITLE),
-            $this->field(0, ilContainerFilterField::STD_FIELD_DESCRIPTION),
-            $this->field(0, ilContainerFilterField::STD_FIELD_TITLE_DESCRIPTION),
-            $this->field(0, ilContainerFilterField::STD_FIELD_KEYWORD),
-            $this->field(0, ilContainerFilterField::STD_FIELD_AUTHOR),
-            $this->field(0, ilContainerFilterField::STD_FIELD_COPYRIGHT),
-            $this->field(0, ilContainerFilterField::STD_FIELD_TUTORIAL_SUPPORT),
-            $this->field(0, ilContainerFilterField::STD_FIELD_OBJECT_TYPE)
+                $this->field(0, ilContainerFilterField::STD_FIELD_TITLE),
+                $this->field(0, ilContainerFilterField::STD_FIELD_DESCRIPTION),
+                $this->field(0, ilContainerFilterField::STD_FIELD_TITLE_DESCRIPTION),
+                $this->field(0, ilContainerFilterField::STD_FIELD_KEYWORD),
+                $this->field(0, ilContainerFilterField::STD_FIELD_AUTHOR),
+                $this->field(0, ilContainerFilterField::STD_FIELD_COPYRIGHT),
+                $this->field(0, ilContainerFilterField::STD_FIELD_TUTORIAL_SUPPORT),
+                $this->field(0, ilContainerFilterField::STD_FIELD_OBJECT_TYPE)
             ]
         );
     }

--- a/Services/Container/Filter/classes/class.ilContainerFilterSet.php
+++ b/Services/Container/Filter/classes/class.ilContainerFilterSet.php
@@ -25,7 +25,7 @@ class ilContainerFilterSet
      */
     protected array $filters;
     /**
-     * @var int[]
+     * @var string[]
      */
     protected array $ids = [];
 
@@ -37,8 +37,7 @@ class ilContainerFilterSet
     {
         $this->filters = $filters;
 
-        $this->ids = array_map(function ($f) {
-            /** @var ilContainerFilterField $f */
+        $this->ids = array_map(static function (ilContainerFilterField $f) : string {
             return $f->getRecordSetId() . "_" . $f->getFieldId();
         }, $filters);
     }
@@ -59,6 +58,6 @@ class ilContainerFilterSet
      */
     public function has(int $record_set_id, int $field_id) : bool
     {
-        return in_array($record_set_id . "_" . $field_id, $this->ids);
+        return in_array($record_set_id . "_" . $field_id, $this->ids, true);
     }
 }

--- a/Services/Container/Filter/classes/class.ilContainerFilterTableGUI.php
+++ b/Services/Container/Filter/classes/class.ilContainerFilterTableGUI.php
@@ -41,13 +41,12 @@ class ilContainerFilterTableGUI extends ilTable2GUI
     {
         $service = $this->container_filter_service;
 
-        $items = array_map(function ($i) use ($service) {
-            /** @var ilContainerFilterField $i */
-            return array(
+        $items = array_map(static function (ilContainerFilterField $i) use ($service) : array {
+            return [
                 "record_set_id" => $i->getRecordSetId(),
                 "record_title" => $service->util()->getContainerRecordTitle($i->getRecordSetId()),
                 "field_title" => $service->util()->getContainerFieldTitle($i->getRecordSetId(), $i->getFieldId())
-            );
+            ];
         }, $service->data()->getFilterSetForRefId($this->ref_id)->getFields());
         return $items;
     }

--- a/Services/Container/Filter/classes/class.ilContainerFilterUtil.php
+++ b/Services/Container/Filter/classes/class.ilContainerFilterUtil.php
@@ -46,7 +46,7 @@ class ilContainerFilterUtil
     ) : string {
         $lng = $this->lng;
 
-        if ($record_id == 0) {
+        if ($record_id === 0) {
             return $lng->txt("cont_std_filter_title_" . $field_id);
         }
 
@@ -62,7 +62,7 @@ class ilContainerFilterUtil
     {
         $lng = $this->lng;
 
-        if ($record_id == 0) {
+        if ($record_id === 0) {
             return $lng->txt("cont_std_record_title");
         }
 
@@ -110,7 +110,7 @@ class ilContainerFilterUtil
 
         foreach ($set->getFields() as $field) {
             // standard fields
-            if ($field->getRecordSetId() == 0) {
+            if ($field->getRecordSetId() === 0) {
                 $title = $service->util()->getContainerFieldTitle(0, $field->getFieldId());
                 $key = "std_" . $field->getFieldId();
                 switch ($field->getFieldId()) {

--- a/Services/Container/Filter/classes/class.ilContainerUserFilter.php
+++ b/Services/Container/Filter/classes/class.ilContainerUserFilter.php
@@ -25,7 +25,7 @@ class ilContainerUserFilter
 {
     protected ?array $data;
 
-    public function __construct($data)
+    public function __construct(?array $data)
     {
         $this->data = $data;
     }
@@ -40,7 +40,7 @@ class ilContainerUserFilter
         $empty = true;
         if (is_array($this->data)) {
             foreach ($this->data as $d) {
-                if (trim($d) != "") {
+                if (trim($d) !== "") {
                     $empty = false;
                 }
             }

--- a/Services/Container/MemberView/MemberViewLayoutProvider.php
+++ b/Services/Container/MemberView/MemberViewLayoutProvider.php
@@ -17,12 +17,10 @@ use ILIAS\Data\URI;
 use ILIAS\GlobalScreen\Scope\Layout\Builder\StandardPageBuilder;
 use ILIAS\GlobalScreen\Scope\Layout\Factory\PageBuilderModification;
 use ILIAS\GlobalScreen\Scope\Layout\Provider\AbstractModificationProvider;
-use ILIAS\GlobalScreen\Scope\Layout\Provider\ModificationProvider;
 use ILIAS\GlobalScreen\Scope\Layout\Provider\PagePart\PagePartProvider;
 use ILIAS\GlobalScreen\ScreenContext\Stack\CalledContexts;
 use ILIAS\GlobalScreen\ScreenContext\Stack\ContextCollection;
 use ILIAS\UI\Component\Layout\Page\Page;
-use ILIAS\UI\Component\Layout\Page\Standard;
 use ILIAS\UI\Component\MainControls\ModeInfo;
 use ilLink;
 use ilMemberViewSettings;
@@ -33,7 +31,7 @@ use ilObject;
  *
  * @author Fabian Schmid <fs@studer-raimann.ch>
  */
-class MemberViewLayoutProvider extends AbstractModificationProvider implements ModificationProvider
+class MemberViewLayoutProvider extends AbstractModificationProvider
 {
     /**
      * @inheritDoc
@@ -53,7 +51,7 @@ class MemberViewLayoutProvider extends AbstractModificationProvider implements M
         $url = new URI(ilLink::_getLink(
             $ref_id,
             ilObject::_lookupType(ilObject::_lookupObjId($ref_id)),
-            array('mv' => 0)
+            ['mv' => 0]
         ));
 
         $modeinfo = $dic->ui()->factory()->mainControls()->modeInfo(
@@ -77,7 +75,7 @@ class MemberViewLayoutProvider extends AbstractModificationProvider implements M
         return $this->factory->page()
             ->withLowPriority()
             ->withModification(
-                function (PagePartProvider $parts) use ($mv_mode_info) : Page {
+                static function (PagePartProvider $parts) use ($mv_mode_info) : Page {
                     $p = new StandardPageBuilder();
                     $page = $p->build($parts);
                     return $page->withModeInfo($mv_mode_info);

--- a/Services/Container/MemberView/class.ilMemberViewGUI.php
+++ b/Services/Container/MemberView/class.ilMemberViewGUI.php
@@ -34,7 +34,7 @@ class ilMemberViewGUI
         $ilTabs = $DIC->tabs();
         
         // No course or group in path => aborting
-        if (!$tree->checkForParentType($a_ref_id, 'crs') and
+        if (!$tree->checkForParentType($a_ref_id, 'crs') &&
             !$tree->checkForParentType($a_ref_id, 'grp')) {
             return false;
         }
@@ -42,7 +42,7 @@ class ilMemberViewGUI
         // TODO: check edit_permission
         
         $type = ilObject::_lookupType(ilObject::_lookupObjId($a_ref_id));
-        if (($type == 'crs' or $type == 'grp') and $ilAccess->checkAccess('write', '', $a_ref_id)) {
+        if (($type === 'crs' || $type === 'grp') && $ilAccess->checkAccess('write', '', $a_ref_id)) {
             $ilCtrl->setParameterByClass("ilrepositorygui", "ref_id", $a_ref_id);
             $ilCtrl->setParameterByClass("ilrepositorygui", "mv", "1");
             $ilCtrl->setParameterByClass("ilrepositorygui", "set_mode", "flat");

--- a/Services/Container/MemberView/class.ilMemberViewSettings.php
+++ b/Services/Container/MemberView/class.ilMemberViewSettings.php
@@ -46,17 +46,12 @@ class ilMemberViewSettings
         $this->ctrl = $DIC->ctrl();
         $this->logger = $DIC->logger()->cont();
         $this->read();
-        $this->container_service = $DIC
-            ->container();
+        $this->container_service = $DIC->container();
     }
-
 
     public static function getInstance() : ilMemberViewSettings
     {
-        if (self::$instance != null) {
-            return self::$instance;
-        }
-        return self::$instance = new ilMemberViewSettings();
+        return self::$instance ?? (self::$instance = new ilMemberViewSettings());
     }
 
     public function getContainer() : ?int
@@ -98,8 +93,8 @@ class ilMemberViewSettings
                 return $mv_status = false;
             }
 
-            if (!in_array($this->getCurrentRefId(), $this->container_items) and
-                $this->getContainer() != $this->getCurrentRefId()
+            if (!in_array($this->getCurrentRefId(), $this->container_items) &&
+                $this->getContainer() !== $this->getCurrentRefId()
             ) {
                 // outside of course
                 return $mv_status = false;
@@ -121,7 +116,7 @@ class ilMemberViewSettings
         
         if (
             !in_array($a_ref_id, $this->container_items) &&
-            $this->getContainer() != $a_ref_id) {
+            $this->getContainer() !== $a_ref_id) {
             return false;
         }
         return true;
@@ -185,7 +180,7 @@ class ilMemberViewSettings
             if (
                 $this->getCurrentRefId() &&
                 !in_array($this->getCurrentRefId(), $this->container_items) &&
-                $this->getCurrentRefId() != $this->getContainer()
+                $this->getCurrentRefId() !== $this->getContainer()
             ) {
                 $this->deactivate();
             }
@@ -207,7 +202,7 @@ class ilMemberViewSettings
             return $this->current_ref_id = $ref_id;
         }
         $target_str = (string) ($this->request->getQueryParams()['target'] ?? '');
-        if (strlen($target_str)) {
+        if ($target_str !== '') {
             $target_arr = explode('_', $target_str);
             if (isset($target_arr[1]) && (int) $target_arr[1]) {
                 $this->current_ref_id = (int) $target_arr[1];

--- a/Services/Container/News/class.ilContainerNewsSettingsGUI.php
+++ b/Services/Container/News/class.ilContainerNewsSettingsGUI.php
@@ -54,7 +54,7 @@ class ilContainerNewsSettingsGUI
 
         switch ($next_class) {
             default:
-                if (in_array($cmd, array("show", "save"))) {
+                if (in_array($cmd, ["show", "save"])) {
                     $this->$cmd();
                 }
         }
@@ -107,12 +107,10 @@ class ilContainerNewsSettingsGUI
         }
 
         // Cron Notifications (courses and groups)
-        if ($this->has_cron_notifications) {
-            if (in_array(ilObject::_lookupType($this->object->getId()), array('crs', 'grp'))) {
-                $ref_ids = ilObject::_getAllReferences($this->object->getId());
-                $ref_id = array_pop($ref_ids);
-                ilMembershipNotifications::addToSettingsForm($ref_id, $form, null);
-            }
+        if ($this->has_cron_notifications && in_array(ilObject::_lookupType($this->object->getId()), ['crs', 'grp'])) {
+            $ref_ids = ilObject::_getAllReferences($this->object->getId());
+            $ref_id = array_pop($ref_ids);
+            ilMembershipNotifications::addToSettingsForm($ref_id, $form, null);
         }
 
         $block_id = $this->ctrl->getContextObjId();
@@ -194,12 +192,12 @@ class ilContainerNewsSettingsGUI
             }
             if ($this->setting->get('block_activated_news')) {
                 //save contextblock settings
-                $context_block_settings = array(
+                $context_block_settings = [
                     "public_feed" => $form->getInput("notifications_public_feed") ?? "",
                     "default_visibility" => $form->getInput("default_visibility"),
                     "hide_news_per_date" => $form->getInput("hide_news_per_date"),
                     "hide_news_date" => $form->getInput("hide_news_date")
-                );
+                ];
                 if ($this->has_public_notification) {
                     $context_block_settings["public_notifications"] =
                         $form->getInput('public_notifications');
@@ -207,7 +205,7 @@ class ilContainerNewsSettingsGUI
 
                 ilNewsForContextBlockGUI::writeSettings($context_block_settings);
 
-                if (in_array(ilObject::_lookupType($this->object->getId()), array('crs', 'grp'))) {
+                if (in_array(ilObject::_lookupType($this->object->getId()), ['crs', 'grp'])) {
                     $ref_ids = ilObject::_getAllReferences($this->object->getId());
                     $ref_id = array_pop($ref_ids);
 
@@ -250,7 +248,7 @@ class ilContainerNewsSettingsGUI
 
     public function getCronNotifications() : bool
     {
-        return $this->getCronNotifications();
+        return $this->getCronNotifications();// TODO PHP8-REVIEW Infinite recursion
     }
 
     public function setHideByDate(bool $a_value) : void

--- a/Services/Container/Page/class.ilContainerPageGUI.php
+++ b/Services/Container/Page/class.ilContainerPageGUI.php
@@ -70,7 +70,7 @@ class ilContainerPageGUI extends ilPageObjectGUI
         $class = $this->obj_definition->getClassName($type);
 
         $items = [];
-        if ($class != "") {
+        if ($class !== "") {
             $items[] = $ui->factory()->link()->standard(
                 $lng->txt("obj_sty"),
                 $ctrl->getLinkTargetByClass([

--- a/Services/Container/Skills/classes/class.ilContProfileTableGUI.php
+++ b/Services/Container/Skills/classes/class.ilContProfileTableGUI.php
@@ -83,18 +83,18 @@ class ilContProfileTableGUI extends ilTable2GUI
         $profiles = [];
         if ($this->skmg_settings->getLocalAssignmentOfProfiles()) {
             foreach ($this->container_global_profiles->getProfiles() as $gp) {
-                $profiles[$gp["profile_id"]] = array(
+                $profiles[$gp["profile_id"]] = [
                     "profile_id" => $gp["profile_id"],
                     "title" => ilSkillProfile::lookupTitle($gp["profile_id"])
-                );
+                ];
             }
         }
         if ($this->skmg_settings->getAllowLocalProfiles()) {
             foreach ($this->container_local_profiles->getProfiles() as $lp) {
-                $profiles[$lp["profile_id"]] = array(
+                $profiles[$lp["profile_id"]] = [
                     "profile_id" => $lp["profile_id"],
                     "title" => ilSkillProfile::lookupTitle($lp["profile_id"])
-                );
+                ];
             }
         }
         ksort($profiles);
@@ -124,7 +124,7 @@ class ilContProfileTableGUI extends ilTable2GUI
         $ctrl->setParameterByClass("ilskillprofilegui", "local_context", true);
 
         if (ilSkillProfile::lookupRefId($a_set["profile_id"]) > 0) {
-            $items = array(
+            $items = [
                 $ui_factory->link()->standard(
                     $lng->txt("edit"),
                     $ctrl->getLinkTargetByClass("ilskillprofilegui", "showLevelsWithLocalContext")
@@ -133,14 +133,14 @@ class ilContProfileTableGUI extends ilTable2GUI
                     $lng->txt("delete"),
                     $ctrl->getLinkTarget($this->parent_obj, "confirmDeleteSingleLocalProfile")
                 )
-            );
+            ];
         } else {
-            $items = array(
+            $items = [
                 $ui_factory->link()->standard(
                     $lng->txt("remove"),
                     $ctrl->getLinkTarget($this->parent_obj, "confirmRemoveSingleGlobalProfile")
                 )
-            );
+            ];
         }
 
         $dropdown = $this->ui_factory->dropdown()->standard($items)->withLabel($lng->txt("actions"));

--- a/Services/Container/Skills/classes/class.ilContSkillAdminGUI.php
+++ b/Services/Container/Skills/classes/class.ilContSkillAdminGUI.php
@@ -106,16 +106,20 @@ class ilContSkillAdminGUI
             default:
                 if (
                     ($this->access->checkAccess("write", "", $this->ref_id) &&
-                        in_array($cmd, array("listCompetences", "settings", "saveSettings", "selectSkill",
-                        "saveSelectedSkill", "confirmRemoveSelectedSkill", "removeSelectedSkill",
-                        "listProfiles", "saveSelectedProfile", "confirmRemoveSelectedGlobalProfiles",
-                        "removeSelectedGlobalProfiles", "confirmRemoveSingleGlobalProfile", "removeSingleGlobalProfile",
-                        "confirmDeleteSingleLocalProfile", "deleteSingleLocalProfile",
-                        "confirmDeleteSelectedLocalProfiles", "deleteSelectedLocalProfiles")))
+                        in_array($cmd, [
+                            "listCompetences", "settings", "saveSettings", "selectSkill",
+                            "saveSelectedSkill", "confirmRemoveSelectedSkill", "removeSelectedSkill",
+                            "listProfiles", "saveSelectedProfile", "confirmRemoveSelectedGlobalProfiles",
+                            "removeSelectedGlobalProfiles", "confirmRemoveSingleGlobalProfile", "removeSingleGlobalProfile",
+                            "confirmDeleteSingleLocalProfile", "deleteSingleLocalProfile",
+                            "confirmDeleteSelectedLocalProfiles", "deleteSelectedLocalProfiles"
+                        ]))
                     ||
                     ($this->access->checkAccess("grade", "", $this->ref_id) &&
-                        in_array($cmd, array("listMembers", "assignCompetences",
-                            "saveCompetenceAssignment", "publishAssignments", "deassignCompetencesConfirm", "deassignCompetences")))
+                        in_array($cmd, [
+                            "listMembers", "assignCompetences",
+                            "saveCompetenceAssignment", "publishAssignments", "deassignCompetencesConfirm", "deassignCompetences"
+                        ]))
                 ) {
                     $this->$cmd();
                 }
@@ -167,9 +171,9 @@ class ilContSkillAdminGUI
             $skill = new ilBasicSkill($sk["skill_id"]);
 
             // skill level options
-            $options = array(
+            $options = [
                 "-1" => $this->lng->txt("cont_skill_do_not_set"),
-                );
+            ];
             foreach ($skill->getLevelData() as $l) {
                 $options[$l["id"]] = $l["title"];
             }
@@ -197,7 +201,7 @@ class ilContSkillAdminGUI
         $path = $this->skill_tree_service->getSkillTreePath($a_skill_id, $a_tref_id);
         $titles = [];
         foreach ($path as $v) {
-            if ($v["type"] != "skrt" && !($v["skill_id"] == $a_skill_id && $v["tref_id"] == $a_tref_id)) {
+            if ($v["type"] !== "skrt" && !($v["skill_id"] == $a_skill_id && $v["tref_id"] == $a_tref_id)) {
                 $titles[] = $v["title"];
             }
         }
@@ -250,10 +254,10 @@ class ilContSkillAdminGUI
             }
         }
 
-        if (count($not_changed) == 0) {
+        if (count($not_changed) === 0) {
             $this->tpl->setOnScreenMessage('success', $lng->txt("cont_skll_published"), true);
         } else {
-            $names = array_map(function ($id) {
+            $names = array_map(static function ($id) {
                 return ilUserUtil::getNamePresentation($id, false, false, "", true);
             }, $not_changed);
             $this->tpl->setOnScreenMessage('info', $lng->txt("cont_skll_published_some_not") . " (" . implode("; ", $names) . ")", true);
@@ -276,7 +280,7 @@ class ilContSkillAdminGUI
             $user_ids[] = $this->requested_usr_id;
         }
 
-        if (!is_array($user_ids) || count($user_ids) == 0) {
+        if (!is_array($user_ids) || count($user_ids) === 0) {
             $this->tpl->setOnScreenMessage('info', $lng->txt("no_checkbox"), true);
             $ctrl->redirect($this, "listMembers");
         } else {
@@ -487,7 +491,7 @@ class ilContSkillAdminGUI
 
         $profile_id = $this->requested_selected_profile_id;
 
-        if (!$profile_id > 0) {
+        if (!($profile_id > 0)) {
             $this->tpl->setOnScreenMessage('info', $lng->txt("cont_skill_no_profile_selected"), true);
             $ctrl->redirect($this, "listProfiles");
         }
@@ -558,7 +562,7 @@ class ilContSkillAdminGUI
 
         $profile_id = (int) $this->params["profile_id"];
 
-        if (!$profile_id > 0) {
+        if (!($profile_id > 0)) {
             $this->tpl->setOnScreenMessage('failure', $lng->txt("error_sry_error"), true);
             $ctrl->redirect($this, "listProfiles");
         } else {
@@ -609,7 +613,7 @@ class ilContSkillAdminGUI
             $cgui->setConfirm($lng->txt("delete"), "deleteSelectedLocalProfiles");
 
             foreach ($this->requested_profile_ids as $i) {
-                if (!ilSkillProfile::lookupRefId($i) > 0) {
+                if (!(ilSkillProfile::lookupRefId($i) > 0)) {
                     $this->tpl->setOnScreenMessage('info', $lng->txt("cont_skill_deletion_not_possible"), true);
                     $ctrl->redirect($this, "listProfiles");
                 }
@@ -649,7 +653,7 @@ class ilContSkillAdminGUI
 
         $profile_id = (int) $this->params["profile_id"];
 
-        if (!$profile_id > 0) {
+        if (!($profile_id > 0)) {
             $this->tpl->setOnScreenMessage('failure', $lng->txt("error_sry_error"), true);
             $ctrl->redirect($this, "listProfiles");
         } else {

--- a/Services/Container/Skills/classes/class.ilContSkillCollector.php
+++ b/Services/Container/Skills/classes/class.ilContSkillCollector.php
@@ -72,12 +72,12 @@ class ilContSkillCollector
         $p_skills = [];
 
         foreach ($this->getProfileSkills() as $ps) {
-            $p_skills[$ps["base_skill_id"] . "-" . $ps["tref_id"]] = array(
+            $p_skills[$ps["base_skill_id"] . "-" . $ps["tref_id"]] = [
                 "base_skill_id" => $ps["base_skill_id"],
                 "tref_id" => $ps["tref_id"],
                 "title" => $ps["title"],
                 "profile" => $ps["profile"]
-            );
+            ];
         }
 
         $this->pres_skills = array_merge($s_skills, $p_skills);
@@ -87,12 +87,12 @@ class ilContSkillCollector
 
     protected function getSingleSkills() : array
     {
-        $s_skills = array_map(function ($v) {
-            return array(
+        $s_skills = array_map(static function (array $v) : array {
+            return [
                 "base_skill_id" => $v["skill_id"],
                 "tref_id" => $v["tref_id"],
                 "title" => ilBasicSkill::_lookupTitle($v["skill_id"], $v["tref_id"])
-            );
+            ];
         }, $this->container_skills->getSkills());
 
         return $s_skills;
@@ -107,12 +107,12 @@ class ilContSkillCollector
                 $profile = new ilSkillProfile($gp["profile_id"]);
                 $sklvs = $profile->getSkillLevels();
                 foreach ($sklvs as $s) {
-                    $p_skills[] = array(
+                    $p_skills[] = [
                         "base_skill_id" => $s["base_skill_id"],
                         "tref_id" => $s["tref_id"],
                         "title" => ilBasicSkill::_lookupTitle($s["base_skill_id"], $s["tref_id"]),
                         "profile" => $profile->getTitle()
-                    );
+                    ];
                 }
             }
         }
@@ -123,12 +123,12 @@ class ilContSkillCollector
                 $profile = new ilSkillProfile($lp["profile_id"]);
                 $sklvs = $profile->getSkillLevels();
                 foreach ($sklvs as $s) {
-                    $p_skills[] = array(
+                    $p_skills[] = [
                         "base_skill_id" => $s["base_skill_id"],
                         "tref_id" => $s["tref_id"],
                         "title" => ilBasicSkill::_lookupTitle($s["base_skill_id"], $s["tref_id"]),
                         "profile" => $profile->getTitle()
-                    );
+                    ];
                 }
             }
         }

--- a/Services/Container/Skills/classes/class.ilContSkillMemberTableGUI.php
+++ b/Services/Container/Skills/classes/class.ilContSkillMemberTableGUI.php
@@ -33,7 +33,7 @@ class ilContSkillMemberTableGUI extends ilTable2GUI
     protected ilContainerSkills $container_skills;
     protected UIServices $ui;
 
-    public function __construct($a_parent_obj, string $a_parent_cmd, ilContainerSkills $a_cont_skills)
+    public function __construct($a_parent_obj, string $a_parent_cmd, ilContainerSkills $a_cont_skills)// TODO PHP8-REVIEW Maybe you can use the class of the consuming GUI or (if there are several) add a list of valid types by using PHPDoc comments
     {
         global $DIC;
 
@@ -77,12 +77,12 @@ class ilContSkillMemberTableGUI extends ilTable2GUI
         $members = [];
         foreach ($p->getMembers() as $m) {
             $name = ilObjUser::_lookupName($m);
-            $members[] = array(
+            $members[] = [
                 "id" => $m,
                 "name" => $name["lastname"] . ", " . $name["firstname"],
                 "login" => $name["login"],
                 "skills" => []
-            );
+            ];
         }
         return $members;
     }

--- a/Services/Container/Skills/classes/class.ilContSkillPresentationGUI.php
+++ b/Services/Container/Skills/classes/class.ilContSkillPresentationGUI.php
@@ -80,7 +80,7 @@ class ilContSkillPresentationGUI
                 break;
             
             default:
-                if ($cmd == "show") {
+                if ($cmd === "show") {
                     $this->$cmd();
                 }
         }

--- a/Services/Container/Skills/classes/class.ilContainerGlobalProfiles.php
+++ b/Services/Container/Skills/classes/class.ilContainerGlobalProfiles.php
@@ -71,9 +71,9 @@ class ilContainerGlobalProfiles
 
     public function addProfile(int $a_profile_id) : void
     {
-        $this->profiles[$a_profile_id] = array(
+        $this->profiles[$a_profile_id] = [
             "profile_id" => $a_profile_id
-        );
+        ];
     }
 
     public function removeProfile(int $a_profile_id) : void

--- a/Services/Container/Skills/classes/class.ilContainerMemberSkills.php
+++ b/Services/Container/Skills/classes/class.ilContainerMemberSkills.php
@@ -97,9 +97,9 @@ class ilContainerMemberSkills
      */
     public function getOrderedSkillLevels() : array
     {
-        $skill_levels = array_map(function ($a, $k) {
+        $skill_levels = array_map(static function ($a, $k) : array {
             $s = explode(":", $k);
-            return array("level_id" => $a, "skill_id" => $s[0], "tref_id" => $s[1]);
+            return ["level_id" => $a, "skill_id" => $s[0], "tref_id" => $s[1]];
         }, $this->getSkillLevels(), array_keys($this->getSkillLevels()));
 
         $vtree = $this->tree_service->getGlobalVirtualSkillTree();

--- a/Services/Container/Skills/classes/class.ilContainerSkills.php
+++ b/Services/Container/Skills/classes/class.ilContainerSkills.php
@@ -61,10 +61,10 @@ class ilContainerSkills
 
     public function addSkill(int $a_skill_id, int $a_tref_id) : void
     {
-        $this->skills[$a_skill_id . "-" . $a_tref_id] = array(
+        $this->skills[$a_skill_id . "-" . $a_tref_id] = [
             "skill_id" => $a_skill_id,
             "tref_id" => $a_tref_id
-        );
+        ];
     }
 
     public function removeSkill(int $a_skill_id, int $a_tref_id) : void

--- a/Services/Container/Skills/classes/class.ilSkillContainerGUIRequest.php
+++ b/Services/Container/Skills/classes/class.ilSkillContainerGUIRequest.php
@@ -17,8 +17,6 @@
  ********************************************************************
  */
 
-use ILIAS\HTTP;
-use ILIAS\Refinery;
 use ILIAS\Skill\Service\SkillGUIRequest;
 
 /**

--- a/Services/Container/Sorting/class.ilContainerSortingSettings.php
+++ b/Services/Container/Sorting/class.ilContainerSortingSettings.php
@@ -19,7 +19,8 @@
 class ilContainerSortingSettings
 {
     protected ilTree $tree;
-    private static array $instances = array();
+    /** @var array<int, self>  */
+    private static array $instances = [];
     protected int $obj_id;
     protected int $sort_mode = ilContainer::SORT_TITLE;
     protected int $sort_direction = ilContainer::SORT_DIRECTION_ASC;
@@ -42,11 +43,7 @@ class ilContainerSortingSettings
     
     public static function getInstanceByObjId(int $a_obj_id) : self
     {
-        if (isset(self::$instances[$a_obj_id])) {
-            return self::$instances[$a_obj_id];
-        }
-
-        return self::$instances[$a_obj_id] = new self($a_obj_id);
+        return self::$instances[$a_obj_id] ?? (self::$instances[$a_obj_id] = new self($a_obj_id));
     }
     
     /**
@@ -54,14 +51,14 @@ class ilContainerSortingSettings
      */
     public function loadEffectiveSettings() : self
     {
-        if ($this->getSortMode() != ilContainer::SORT_INHERIT) {
+        if ($this->getSortMode() !== ilContainer::SORT_INHERIT) {
             return $this;
         }
 
         $effective_settings = $this->getInheritedSettings($this->obj_id);
         $inherited = clone $this;
         
-        if ($effective_settings->getSortMode() == ilContainer::SORT_INHERIT) {
+        if ($effective_settings->getSortMode() === ilContainer::SORT_INHERIT) {
             $inherited->setSortMode(ilContainer::SORT_TITLE);
         } else {
             $inherited->setSortMode($effective_settings->getSortMode());
@@ -87,7 +84,7 @@ class ilContainerSortingSettings
             $parent_obj_id = ilObject::_lookupObjId($cont_ref_id);
             $parent_settings = self::getInstanceByObjId($parent_obj_id);
             
-            if ($parent_settings->getSortMode() == ilContainer::SORT_INHERIT) {
+            if ($parent_settings->getSortMode() === ilContainer::SORT_INHERIT) {
                 return $this->getInheritedSettings($parent_obj_id);
             }
             return $parent_settings;
@@ -109,12 +106,12 @@ class ilContainerSortingSettings
 
         $ilDB = $DIC->database();
         
-        $query = "SELECT * FROM container_sorting_set " .
+        $query = "SELECT sort_mode FROM container_sorting_set " .
             "WHERE obj_id = " . $ilDB->quote($a_obj_id, 'integer') . " ";
         $res = $ilDB->query($query);
         
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            return $row->sort_mode;
+            return (int) $row->sort_mode;
         }
         return ilContainer::SORT_INHERIT;
     }
@@ -126,13 +123,13 @@ class ilContainerSortingSettings
         $ilDB = $DIC->database();
 
         // Try to read from table
-        $query = "SELECT * FROM container_sorting_set " .
+        $query = "SELECT sort_mode FROM container_sorting_set " .
             "WHERE obj_id = " . $ilDB->quote($a_obj_id, 'integer') . " ";
         $res = $ilDB->query($query);
         
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            if ($row->sort_mode != ilContainer::SORT_INHERIT) {
-                return $row->sort_mode;
+            if ((int) $row->sort_mode !== ilContainer::SORT_INHERIT) {
+                return (int) $row->sort_mode;
             }
         }
         return self::lookupSortModeFromParentContainer($a_obj_id);
@@ -264,10 +261,10 @@ class ilContainerSortingSettings
             
         $res = $this->db->query($query);
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $this->sort_mode = $row->sort_mode;
-            $this->sort_direction = $row->sort_direction;
-            $this->new_items_position = $row->new_items_position;
-            $this->new_items_order = $row->new_items_order;
+            $this->sort_mode = (int) $row->sort_mode;
+            $this->sort_direction = (int) $row->sort_direction;
+            $this->new_items_position = (int) $row->new_items_position;
+            $this->new_items_order = (int) $row->new_items_order;
             return;
         }
     }
@@ -307,7 +304,7 @@ class ilContainerSortingSettings
     ) : void {
         $settings = self::getInstanceByObjId($obj_id);
 
-        $attr = array();
+        $attr = [];
         switch ($settings->getSortMode()) {
             case ilContainer::SORT_MANUAL:
                 $order = 'Title';
@@ -323,38 +320,38 @@ class ilContainerSortingSettings
                         break;
                 }
 
-                $attr = array(
-                    'direction' => $settings->getSortDirection() == ilContainer::SORT_DIRECTION_ASC ? "ASC" : "DESC",
-                    'position' => $settings->getSortNewItemsPosition() == ilContainer::SORT_NEW_ITEMS_POSITION_BOTTOM ? "Bottom" : "Top",
+                $attr = [
+                    'direction' => $settings->getSortDirection() === ilContainer::SORT_DIRECTION_ASC ? "ASC" : "DESC",
+                    'position' => $settings->getSortNewItemsPosition() === ilContainer::SORT_NEW_ITEMS_POSITION_BOTTOM ? "Bottom" : "Top",
                     'order' => $order,
                     'type' => 'Manual'
-                );
+                ];
 
                 break;
 
             case ilContainer::SORT_CREATION:
-                $attr = array(
-                    'direction' => $settings->getSortDirection() == ilContainer::SORT_DIRECTION_ASC ? "ASC" : "DESC",
+                $attr = [
+                    'direction' => $settings->getSortDirection() === ilContainer::SORT_DIRECTION_ASC ? "ASC" : "DESC",
                     'type' => 'Creation'
-                );
+                ];
                 break;
 
             case ilContainer::SORT_TITLE:
-                $attr = array(
-                    'direction' => $settings->getSortDirection() == ilContainer::SORT_DIRECTION_ASC ? "ASC" : "DESC",
+                $attr = [
+                    'direction' => $settings->getSortDirection() === ilContainer::SORT_DIRECTION_ASC ? "ASC" : "DESC",
                     'type' => 'Title'
-                );
+                ];
                 break;
             case ilContainer::SORT_ACTIVATION:
-                $attr = array(
-                    'direction' => $settings->getSortDirection() == ilContainer::SORT_DIRECTION_ASC ? "ASC" : "DESC",
+                $attr = [
+                    'direction' => $settings->getSortDirection() === ilContainer::SORT_DIRECTION_ASC ? "ASC" : "DESC",
                     'type' => 'Activation'
-                );
+                ];
                 break;
             case ilContainer::SORT_INHERIT:
-                $attr = array(
+                $attr = [
                     'type' => 'Inherit'
-                );
+                ];
         }
         $xml->xmlElement('Sort', $attr);
     }

--- a/Services/Container/StartObjects/class.ilContainerStartObjects.php
+++ b/Services/Container/StartObjects/class.ilContainerStartObjects.php
@@ -41,7 +41,7 @@ class ilContainerStartObjects
         $this->setRefId($a_object_ref_id);
         $this->setObjId($a_object_id);
 
-        $this->__read();
+        $this->read();
     }
     
     protected function setObjId(int $a_id) : void
@@ -66,15 +66,15 @@ class ilContainerStartObjects
     
     public function getStartObjects() : array
     {
-        return $this->start_objs ?: array();
+        return $this->start_objs ?: [];
     }
         
-    protected function __read() : void
+    protected function read() : void
     {
         $tree = $this->tree;
         $ilDB = $this->db;
 
-        $this->start_objs = array();
+        $this->start_objs = [];
 
         $query = "SELECT * FROM crs_start" .
             " WHERE crs_id = " . $ilDB->quote($this->getObjId(), 'integer') .
@@ -146,7 +146,7 @@ class ilContainerStartObjects
         return false;
     }
 
-    public function __deleteAll() : void
+    public function __deleteAll() : void// TODO PHP8-REVIEW This method is called anywhere and can be removed iMO
     {
         $ilDB = $this->db;
         
@@ -254,7 +254,7 @@ class ilContainerStartObjects
         $mappings = $cwo->getMappings();
         foreach ($this->getStartObjects() as $data) {
             $item_ref_id = $data['item_ref_id'];
-            if (isset($mappings[$item_ref_id]) and $mappings[$item_ref_id]) {
+            if (isset($mappings[$item_ref_id]) && $mappings[$item_ref_id]) {
                 $ilLog->write(__METHOD__ . ': Clone start object nr. ' . $item_ref_id);
                 $start->add($mappings[$item_ref_id]);
             } else {
@@ -276,9 +276,7 @@ class ilContainerStartObjects
             'WHERE crs_id = ' . $ilDB->quote($a_container_id, 'integer') . ' ' .
             'AND item_ref_id = ' . $ilDB->quote($a_item_ref_id, 'integer');
         $res = $ilDB->query($query);
-        if ($res->numRows() >= 1) {
-            return true;
-        }
-        return false;
+
+        return $res->numRows() >= 1;
     }
 }

--- a/Services/Container/StartObjects/class.ilContainerStartObjectsContentTableGUI.php
+++ b/Services/Container/StartObjects/class.ilContainerStartObjectsContentTableGUI.php
@@ -29,7 +29,7 @@ class ilContainerStartObjectsContentTableGUI extends ilTable2GUI
     protected ilFavouritesManager $fav_manager;
     
     public function __construct(
-        object $a_parent_obj,
+        object $a_parent_obj,// TODO PHP8-REVIEW Maybe you can use the class of the consuming GUI or (if there are several) add a list of valid types by using PHPDoc comments
         string $a_parent_cmd,
         ilContainerStartObjects $a_start_objects,
         bool $a_enable_desktop = true
@@ -79,7 +79,7 @@ class ilContainerStartObjectsContentTableGUI extends ilTable2GUI
         $lm_continue = new ilCourseLMHistory($this->start_object->getRefId(), $ilUser->getId());
         $continue_data = $lm_continue->getLMHistory();
 
-        $items = array();
+        $items = [];
         $counter = 0;
         foreach ($this->start_object->getStartObjects() as $start) {
             $obj_id = $ilObjDataCache->lookupObjId((int) $start['item_ref_id']);
@@ -98,7 +98,7 @@ class ilContainerStartObjectsContentTableGUI extends ilTable2GUI
             }
             
             // add/remove desktop
-            $actions = array();
+            $actions = [];
             if ($this->enable_desktop) {
                 // add to desktop link
                 if (!$this->fav_manager->ifIsFavourite($ilUser->getId(), $ref_id)) {
@@ -119,7 +119,7 @@ class ilContainerStartObjectsContentTableGUI extends ilTable2GUI
             }
             
             $default_params = null;
-            if ($type == "tst") {
+            if ($type === "tst") {
                 $default_params["crs_show_result"] = $ref_id;
             }
             /* continue is currently inactive
@@ -131,13 +131,14 @@ class ilContainerStartObjectsContentTableGUI extends ilTable2GUI
             }
             */
 
-            if ($accomplished == 'accomplished') {
+            if ($accomplished === 'accomplished') {
                 $icon = ilUtil::getImagePath("icon_ok.svg");
             } else {
                 $icon = ilUtil::getImagePath("icon_not_ok.svg");
             }
             
-            $items[] = array("nr" => ++$counter,
+            $items[] = [
+                "nr" => ++$counter,
                 "obj_id" => $obj_id,
                 "ref_id" => $ref_id,
                 "type" => $type,
@@ -146,7 +147,8 @@ class ilContainerStartObjectsContentTableGUI extends ilTable2GUI
                 "description" => $ilObjDataCache->lookupDescription($obj_id),
                 "status" => $this->lng->txt('crs_objective_' . $accomplished),
                 "status_img" => $icon,
-                "actions" => $actions);
+                "actions" => $actions
+            ];
         }
         
         $preloader = new ilObjectListGUIPreloader(ilObjectListGUI::CONTEXT_REPOSITORY);
@@ -156,7 +158,6 @@ class ilContainerStartObjectsContentTableGUI extends ilTable2GUI
         $preloader->preload();
         unset($preloader);
 
-        reset($items);
         $this->setData($items);
     }
         
@@ -182,7 +183,7 @@ class ilContainerStartObjectsContentTableGUI extends ilTable2GUI
             $item_list_gui = $this->item_list_guis[$a_type];
         }
         
-        $item_list_gui->setDefaultCommandParameters(array());
+        $item_list_gui->setDefaultCommandParameters([]);
         
         return $item_list_gui;
     }

--- a/Services/Container/StartObjects/class.ilContainerStartObjectsGUI.php
+++ b/Services/Container/StartObjects/class.ilContainerStartObjectsGUI.php
@@ -33,15 +33,8 @@ class ilContainerStartObjectsGUI
     protected ilObject $object;
     protected ilContainerStartObjects $start_object;
     protected StandardGUIRequest $request;
-    /**
-     * @var \ILIAS\Style\Content\GUIService
-     */
-    protected $content_style_gui;
-
-    /**
-     * @var \ILIAS\Style\Content\Object\ObjectFacade
-     */
-    protected $content_style_domain;
+    protected \ILIAS\Style\Content\GUIService $content_style_gui;
+    protected \ILIAS\Style\Content\Object\ObjectFacade $content_style_domain;
 
     public function __construct(ilObject $a_parent_obj)
     {
@@ -190,7 +183,7 @@ class ilContainerStartObjectsGUI
     
     protected function askDeleteStarterObject() : void
     {
-        if (count($this->request->getStartObjIds()) == 0) {
+        if (count($this->request->getStartObjIds()) === 0) {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('select_one'), true);
             $this->ctrl->redirect($this, "listStructure");
         }
@@ -222,7 +215,7 @@ class ilContainerStartObjectsGUI
     {
         $this->checkPermission('write');
         
-        if (count($this->request->getStartObjIds()) == 0) {
+        if (count($this->request->getStartObjIds()) === 0) {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('select_one'), true);
         } else {
             foreach ($this->request->getStartObjIds() as $starter_id) {
@@ -248,7 +241,7 @@ class ilContainerStartObjectsGUI
     {
         $this->checkPermission('write');
 
-        if (count($this->request->getStartObjIds()) == 0) {
+        if (count($this->request->getStartObjIds()) === 0) {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('select_one'), true);
             $this->ctrl->redirect($this, "selectStarter");
         }

--- a/Services/Container/StartObjects/class.ilContainerStartObjectsPageGUI.php
+++ b/Services/Container/StartObjects/class.ilContainerStartObjectsPageGUI.php
@@ -27,7 +27,7 @@ class ilContainerStartObjectsPageGUI extends ilPageObjectGUI
     /**
     * Constructor
     */
-    public function __construct($a_id = 0, $a_old_nr = 0, $a_lang = "")
+    public function __construct($a_id = 0, $a_old_nr = 0, $a_lang = "")// TODO PHP8-REVIEW Type hints are missing
     {
         parent::__construct("cstr", $a_id, $a_old_nr, false, $a_lang);
     }

--- a/Services/Container/StartObjects/class.ilContainerStartObjectsTableGUI.php
+++ b/Services/Container/StartObjects/class.ilContainerStartObjectsTableGUI.php
@@ -22,7 +22,7 @@ class ilContainerStartObjectsTableGUI extends ilTable2GUI
     protected ilContainerStartObjects $start_obj; // [ilContainerStartObjects]
     
     public function __construct(
-        object $a_parent_obj,
+        object $a_parent_obj,// TODO PHP8-REVIEW Maybe you can use the class of the consuming GUI or (if there are several) add a list of valid types by using PHPDoc comments
         string $a_parent_cmd,
         ilContainerStartObjects $a_start_objects
     ) {
@@ -41,7 +41,7 @@ class ilContainerStartObjectsTableGUI extends ilTable2GUI
         
         $this->addColumn('', '', 1);
         
-        if ($a_parent_cmd == 'listStructure') {
+        if ($a_parent_cmd === 'listStructure') {
             $this->addColumn($this->lng->txt('cntr_ordering'), 'pos', '5%');
         }
         
@@ -50,7 +50,7 @@ class ilContainerStartObjectsTableGUI extends ilTable2GUI
         $this->addColumn($this->lng->txt('description'), 'description');
         
         // add
-        if ($a_parent_cmd != 'listStructure') {
+        if ($a_parent_cmd !== 'listStructure') {
             $this->setTitle($this->lng->txt('crs_select_starter'));
             $this->addMultiCommand('addStarter', $this->lng->txt('crs_add_starter'));
             $this->addCommandButton('listStructure', $this->lng->txt('cancel'));
@@ -71,10 +71,10 @@ class ilContainerStartObjectsTableGUI extends ilTable2GUI
         $this->setFormAction($this->ctrl->getFormAction($a_parent_obj));
         $this->setSelectAllCheckbox('starter');
                             
-        $data = array();
+        $data = [];
         
         // add
-        if ($a_parent_cmd != 'listStructure') {
+        if ($a_parent_cmd !== 'listStructure') {
             $data = $this->getPossibleObjects();
         }
         // list
@@ -87,7 +87,7 @@ class ilContainerStartObjectsTableGUI extends ilTable2GUI
     
     protected function getPossibleObjects() : array
     {
-        $data = array();
+        $data = [];
         foreach ($this->start_obj->getPossibleStarters() as $item_ref_id) {
             $tmp_obj = ilObjectFactory::getInstanceByRefId($item_ref_id);
 
@@ -96,7 +96,7 @@ class ilContainerStartObjectsTableGUI extends ilTable2GUI
             $data[$item_ref_id]['type'] = $this->lng->txt('obj_' . $tmp_obj->getType());
             $data[$item_ref_id]['icon'] = ilObject::_getIcon($tmp_obj->getId(), 'tiny');
 
-            if (strlen($tmp_obj->getDescription())) {
+            if ($tmp_obj->getDescription() !== '') {
                 $data[$item_ref_id]['description'] = $tmp_obj->getDescription();
             }
         }
@@ -106,7 +106,7 @@ class ilContainerStartObjectsTableGUI extends ilTable2GUI
     
     protected function getStartObjects() : array
     {
-        $data = array();
+        $data = [];
         $counter = 0;
         foreach ($this->start_obj->getStartObjects() as $start_id => $item) {
             $tmp_obj = ilObjectFactory::getInstanceByRefId($item['item_ref_id']);
@@ -119,7 +119,7 @@ class ilContainerStartObjectsTableGUI extends ilTable2GUI
             $counter += 10;
             $data[$item['item_ref_id']]['pos'] = $counter;
 
-            if (strlen($tmp_obj->getDescription())) {
+            if ($tmp_obj->getDescription() !== '') {
                 $data[$item['item_ref_id']]['description'] = $tmp_obj->getDescription();
             }
         }
@@ -129,7 +129,7 @@ class ilContainerStartObjectsTableGUI extends ilTable2GUI
 
     protected function fillRow(array $a_set) : void
     {
-        if ($this->getParentCmd() == 'listStructure') {
+        if ($this->getParentCmd() === 'listStructure') {
             $this->tpl->setCurrentBlock('pos_bl');
             $this->tpl->setVariable("POS_ID", $a_set["id"]);
             $this->tpl->setVariable("POS", $a_set["pos"]);

--- a/Services/Container/classes/BackgroundTasks/class.ilDownloadContainerFilesBackgroundTask.php
+++ b/Services/Container/classes/BackgroundTasks/class.ilDownloadContainerFilesBackgroundTask.php
@@ -63,7 +63,7 @@ class ilDownloadContainerFilesBackgroundTask
         //TODO: fix ilUtil zip stuff
         // Error If name starts "-"
         // error massage from ilUtil->execQuoted = ["","zip error: Invalid command arguments (short option 'a' not supported)"]
-        if (substr($this->bucket_title, 0, 1) === "-") {
+        if ($this->bucket_title[0] === "-") {
             $this->bucket_title = ltrim($this->bucket_title, "-");
         }
 

--- a/Services/Container/classes/class.StandardGUIRequest.php
+++ b/Services/Container/classes/class.StandardGUIRequest.php
@@ -123,6 +123,7 @@ class StandardGUIRequest
         return $this->int("oobj");
     }
 
+    /** @return int[] */
     public function getNodes() : array
     {
         if ($this->int("node") > 0) {
@@ -141,26 +142,30 @@ class StandardGUIRequest
         return $this->arrayArray("position");
     }
 
+    /** @return int[] */
     public function getTrashIds() : array
     {
         return $this->intArray("trash_id");
     }
 
+    /** @return int[] */
     public function getAlreadyRenderedRefIds() : array
     {
         $ids = $this->strArray("ids");
-        $ref_ids = array_map(function ($i) {
+        $ref_ids = array_map(static function (string $i) : int {
             $parts = explode("_", $i);
-            return $parts[2];
+            return (int) $parts[2];
         }, $ids);
         return $ref_ids;
     }
 
+    /** @return int[] */
     public function getStartObjPositions() : array
     {
         return $this->intArray("pos");
     }
 
+    /** @return int[] */
     public function getStartObjIds() : array
     {
         return $this->intArray("starter");

--- a/Services/Container/classes/class.ilContainer.php
+++ b/Services/Container/classes/class.ilContainer.php
@@ -139,7 +139,7 @@ class ilContainer extends ilObject
     
     public function getContainerDirectory() : string
     {
-        return $this->_getContainerDirectory($this->getId());
+        return self::_getContainerDirectory($this->getId());
     }
     
     public static function _getContainerDirectory(int $a_id) : string
@@ -200,22 +200,16 @@ class ilContainer extends ilObject
 
     public function isNewsTimelineEffective() : bool
     {
-        if ($this->getUseNews()) {
-            if ($this->getNewsTimeline()) {
-                return true;
-            }
+        if ($this->getUseNews() && $this->getNewsTimeline()) {
+            return true;
         }
         return false;
     }
 
     public function isNewsTimelineLandingPageEffective() : bool
     {
-        if ($this->getUseNews()) {
-            if ($this->getNewsTimeline()) {
-                if ($this->getNewsTimelineLandingPage()) {
-                    return true;
-                }
-            }
+        if ($this->getUseNews() && $this->getNewsTimeline() && $this->getNewsTimelineLandingPage()) {
+            return true;
         }
         return false;
     }
@@ -250,7 +244,7 @@ class ilContainer extends ilObject
 
         $ilDB = $DIC->database();
         
-        $q = "SELECT * FROM container_settings WHERE " .
+        $q = "SELECT value FROM container_settings WHERE " .
                 " id = " . $ilDB->quote($a_id, 'integer') . " AND " .
                 " keyword = " . $ilDB->quote($a_keyword, 'text');
         $set = $ilDB->query($q);
@@ -259,10 +253,8 @@ class ilContainer extends ilObject
         if (isset($rec['value'])) {
             return $rec["value"];
         }
-        if ($a_default_value === null) {
-            return '';
-        }
-        return $a_default_value;
+
+        return $a_default_value ?? '';
     }
 
     public static function _writeContainerSetting(
@@ -301,9 +293,9 @@ class ilContainer extends ilObject
 
         $ilDB = $DIC->database();
         
-        $res = array();
+        $res = [];
         
-        $sql = "SELECT * FROM container_settings WHERE " .
+        $sql = "SELECT keyword, value FROM container_settings WHERE " .
                 " id = " . $ilDB->quote($a_id, 'integer');
         $set = $ilDB->query($sql);
         while ($row = $ilDB->fetchAssoc($set)) {
@@ -328,7 +320,7 @@ class ilContainer extends ilObject
         
         $sql = "DELETE FROM container_settings WHERE " .
                 " id = " . $ilDB->quote($a_id, 'integer');
-        if ($a_keyword != "") {
+        if ($a_keyword !== "") {
             if (!$a_keyword_like) {
                 $sql .= " AND keyword = " . $ilDB->quote($a_keyword, "text");
             } else {
@@ -344,20 +336,20 @@ class ilContainer extends ilObject
     ) : void {
         // container settings
         $settings = self::_getContainerSettings($a_obj_id);
-        if (sizeof($settings)) {
+        if (count($settings)) {
             $a_xml->xmlStartTag("ContainerSettings");
             
             foreach ($settings as $keyword => $value) {
                 // :TODO: proper custom icon export/import
-                if (stristr($keyword, "icon")) {
+                if (stripos($keyword, "icon") !== false) {
                     continue;
                 }
                 
                 $a_xml->xmlStartTag(
                     'ContainerSetting',
-                    array(
+                    [
                         'id' => $keyword,
-                    )
+                    ]
                 );
                 
                 $a_xml->xmlData($value);
@@ -400,7 +392,7 @@ class ilContainer extends ilObject
         // #20614 - copy style
         $style_id = $this->getStyleSheetId();
         if ($style_id > 0) {
-            if (!!ilObjStyleSheet::_lookupStandard($style_id)) {
+            if (ilObjStyleSheet::_lookupStandard($style_id)) {
                 $style_obj = ilObjectFactory::getInstanceByObjId($style_id);
                 $new_id = $style_obj->ilClone();
                 $new_obj->setStyleSheetId($new_id);
@@ -453,7 +445,7 @@ class ilContainer extends ilObject
         ilContainerSorting::_getInstance($this->getId())->cloneSorting($target_id, $copy_id);
 
         // fix internal links to other objects
-        ilContainer::fixInternalLinksAfterCopy($target_id, $copy_id, $this->getRefId());
+        self::fixInternalLinksAfterCopy($target_id, $copy_id, $this->getRefId());
         
         // fix item group references in page content
         ilObjItemGroup::fixContainerItemGroupRefsAfterCloning($this, $copy_id);
@@ -506,7 +498,7 @@ class ilContainer extends ilObject
         $wizard_options->read();
         $wizard_options->storeTree($clone_source);
         
-        if ($a_submode == ilObjectCopyGUI::SUBMODE_CONTENT_ONLY) {
+        if ($a_submode === ilObjectCopyGUI::SUBMODE_CONTENT_ONLY) {
             ilLoggerFactory::getLogger('obj')->info('Copy content only...');
             ilLoggerFactory::getLogger('obj')->debug('Added mapping, source ID: ' . $clone_source . ', target ID: ' . $ref_id);
             $wizard_options->read();
@@ -526,17 +518,17 @@ class ilContainer extends ilObject
         $ilLog->write(__METHOD__ . ': Trying to call Soap client...');
         if ($soap_client->init()) {
             ilLoggerFactory::getLogger('obj')->info('Calling soap clone method');
-            $res = $soap_client->call('ilClone', array($new_session_id . '::' . $client_id, $copy_id));
+            $res = $soap_client->call('ilClone', [$new_session_id . '::' . $client_id, $copy_id]);
         } else {
             ilLoggerFactory::getLogger('obj')->warning('SOAP clone call failed. Calling clone method manually');
             $wizard_options->disableSOAP();
             $wizard_options->read();
             $res = ilSoapFunctions::ilClone($new_session_id . '::' . $client_id, $copy_id);
         }
-        return array(
+        return [
                 'copy_id' => $copy_id,
                 'ref_id' => (int) $res
-        );
+        ];
     }
 
     /**
@@ -558,12 +550,12 @@ class ilContainer extends ilObject
 
     public function getViewMode() : int
     {
-        return ilContainer::VIEW_BY_TYPE;
+        return self::VIEW_BY_TYPE;
     }
     
     public function getOrderType() : int
     {
-        return $this->order_type ?: ilContainer::SORT_TITLE;
+        return $this->order_type ?: self::SORT_TITLE;
     }
 
     public function setOrderType(int $a_value) : void
@@ -612,7 +604,7 @@ class ilContainer extends ilObject
         bool $a_admin_panel_enabled = false,
         bool $a_include_side_block = false,
         int $a_get_single = 0,
-        \ilContainerUserFilter $container_user_filter = null
+        ilContainerUserFilter $container_user_filter = null
     ) : array {
         $objDefinition = $this->obj_definition;
 
@@ -637,7 +629,7 @@ class ilContainer extends ilObject
             if ($current) {
                 $class_provider->setSelection($current);
                 $filtered = $class_provider->getFilteredObjects();
-                $objects = array_filter($objects, function ($i) use ($filtered) {
+                $objects = array_filter($objects, static function (array $i) use ($filtered) : bool {
                     return (is_array($filtered) && in_array($i["obj_id"], $filtered));
                 });
                 //if (count($filtered) > 0) {
@@ -650,7 +642,7 @@ class ilContainer extends ilObject
         }
 
         $found = false;
-        $all_ref_ids = array();
+        $all_ref_ids = [];
 
         $preloader = null;
         if (!self::$data_preloaded) {
@@ -670,8 +662,7 @@ class ilContainer extends ilObject
             }
             
             // hide object types in devmode
-            if ($objDefinition->getDevMode($object["type"]) || $object["type"] == "adm"
-                || $object["type"] == "rolf") {
+            if ($object["type"] === "adm" || $object["type"] === "rolf" || $objDefinition->getDevMode($object["type"])) {
                 continue;
             }
             
@@ -681,12 +672,14 @@ class ilContainer extends ilObject
             }
 
             // BEGIN WebDAV: Don't display hidden Files, Folders and Categories
-            if (in_array($object['type'], array('file','fold','cat'))) {
-                if (ilObjFileAccess::_isFileHidden($object['title'])) {
-                    $this->setHiddenFilesFound(true);
-                    if (!$a_admin_panel_enabled) {
-                        continue;
-                    }
+            if (in_array(
+                $object['type'],
+                ['file', 'fold', 'cat'],
+                true
+            ) && ilObjFileAccess::_isFileHidden($object['title'])) {
+                $this->setHiddenFilesFound(true);
+                if (!$a_admin_panel_enabled) {
+                    continue;
                 }
             }
             // END WebDAV: Don't display hidden Files, Folders and Categories
@@ -697,7 +690,7 @@ class ilContainer extends ilObject
             }
             
             // filter out items that are attached to an event
-            if (in_array($object['ref_id'], $event_items) && !$classification_filter_active) {
+            if (!$classification_filter_active && in_array($object['ref_id'], $event_items)) {
                 continue;
             }
             
@@ -735,7 +728,7 @@ class ilContainer extends ilObject
             $this->items[$type][$key] = $object;
                         
             $this->items["_all"][$key] = $object;
-            if ($object["type"] != "sess") {
+            if ($object["type"] !== "sess") {
                 $this->items["_non_sess"][$key] = $object;
             }
         }
@@ -768,7 +761,7 @@ class ilContainer extends ilObject
         $objDefinition = $this->obj_definition;
         
         if (empty($this->type_grps)) {
-            $this->type_grps = $objDefinition->getGroupedRepositoryObjectTypes($this->getType());
+            $this->type_grps = $objDefinition::getGroupedRepositoryObjectTypes($this->getType());
         }
         return $this->type_grps;
     }
@@ -810,25 +803,25 @@ class ilContainer extends ilObject
         $log = ilLoggerFactory::getLogger("cont");
         $log->debug("Create Container, id: " . $this->getId());
 
-        self::_writeContainerSetting($this->getId(), "news_timeline", (int) $this->getNewsTimeline());
-        self::_writeContainerSetting($this->getId(), "news_timeline_incl_auto", (int) $this->getNewsTimelineAutoEntries());
-        self::_writeContainerSetting($this->getId(), "news_timeline_landing_page", (int) $this->getNewsTimelineLandingPage());
-        self::_writeContainerSetting($this->getId(), ilObjectServiceSettingsGUI::NEWS_VISIBILITY, (int) $this->getNewsBlockActivated());
-        self::_writeContainerSetting($this->getId(), ilObjectServiceSettingsGUI::USE_NEWS, (int) $this->getUseNews());
+        self::_writeContainerSetting($this->getId(), "news_timeline", (string) ((int) $this->getNewsTimeline()));
+        self::_writeContainerSetting($this->getId(), "news_timeline_incl_auto", (string) ((int) $this->getNewsTimelineAutoEntries()));
+        self::_writeContainerSetting($this->getId(), "news_timeline_landing_page", (string) ((int) $this->getNewsTimelineLandingPage()));
+        self::_writeContainerSetting($this->getId(), ilObjectServiceSettingsGUI::NEWS_VISIBILITY, (string) ((int) $this->getNewsBlockActivated()));
+        self::_writeContainerSetting($this->getId(), ilObjectServiceSettingsGUI::USE_NEWS, (string) ((int) $this->getUseNews()));
 
         return $ret;
     }
 
-    public function putInTree(int $parent_ref) : void
+    public function putInTree(int $parent_ref_id) : void
     {
-        parent::putInTree($parent_ref);
+        parent::putInTree($parent_ref_id);
 
         // copy title, icon actions visibilities
-        if (self::_lookupContainerSetting(ilObject::_lookupObjId($parent_ref), "hide_header_icon_and_title")) {
-            self::_writeContainerSetting($this->getId(), "hide_header_icon_and_title", true);
+        if (self::_lookupContainerSetting(ilObject::_lookupObjId($parent_ref_id), "hide_header_icon_and_title")) {
+            self::_writeContainerSetting($this->getId(), "hide_header_icon_and_title", '1');
         }
-        if (self::_lookupContainerSetting(ilObject::_lookupObjId($parent_ref), "hide_top_actions")) {
-            self::_writeContainerSetting($this->getId(), "hide_top_actions", true);
+        if (self::_lookupContainerSetting(ilObject::_lookupObjId($parent_ref_id), "hide_top_actions")) {
+            self::_writeContainerSetting($this->getId(), "hide_top_actions", '1');
         }
     }
 
@@ -846,11 +839,11 @@ class ilContainer extends ilObject
         $log = ilLoggerFactory::getLogger("cont");
         $log->debug("Update Container, id: " . $this->getId());
 
-        self::_writeContainerSetting($this->getId(), "news_timeline", (int) $this->getNewsTimeline());
-        self::_writeContainerSetting($this->getId(), "news_timeline_incl_auto", (int) $this->getNewsTimelineAutoEntries());
-        self::_writeContainerSetting($this->getId(), "news_timeline_landing_page", (int) $this->getNewsTimelineLandingPage());
-        self::_writeContainerSetting($this->getId(), ilObjectServiceSettingsGUI::NEWS_VISIBILITY, (int) $this->getNewsBlockActivated());
-        self::_writeContainerSetting($this->getId(), ilObjectServiceSettingsGUI::USE_NEWS, (int) $this->getUseNews());
+        self::_writeContainerSetting($this->getId(), "news_timeline", (string) ((int) $this->getNewsTimeline()));
+        self::_writeContainerSetting($this->getId(), "news_timeline_incl_auto", (string) (int) $this->getNewsTimelineAutoEntries());
+        self::_writeContainerSetting($this->getId(), "news_timeline_landing_page", (string) ((int) ($this->getNewsTimelineLandingPage())));
+        self::_writeContainerSetting($this->getId(), ilObjectServiceSettingsGUI::NEWS_VISIBILITY, (string) ((int) $this->getNewsBlockActivated()));
+        self::_writeContainerSetting($this->getId(), ilObjectServiceSettingsGUI::USE_NEWS, (string) ((int) $this->getUseNews()));
 
         return $ret;
     }
@@ -869,15 +862,15 @@ class ilContainer extends ilObject
 
     public function readContainerSettings() : void
     {
-        $this->setNewsTimeline(self::_lookupContainerSetting($this->getId(), "news_timeline"));
-        $this->setNewsTimelineAutoEntries(self::_lookupContainerSetting($this->getId(), "news_timeline_incl_auto"));
-        $this->setNewsTimelineLandingPage(self::_lookupContainerSetting($this->getId(), "news_timeline_landing_page"));
-        $this->setNewsBlockActivated(self::_lookupContainerSetting(
+        $this->setNewsTimeline((bool) self::_lookupContainerSetting($this->getId(), "news_timeline"));
+        $this->setNewsTimelineAutoEntries((bool) self::_lookupContainerSetting($this->getId(), "news_timeline_incl_auto"));
+        $this->setNewsTimelineLandingPage((bool) self::_lookupContainerSetting($this->getId(), "news_timeline_landing_page"));
+        $this->setNewsBlockActivated((bool) self::_lookupContainerSetting(
             $this->getId(),
             ilObjectServiceSettingsGUI::NEWS_VISIBILITY,
             $this->setting->get('block_activated_news', true)
         ));
-        $this->setUseNews(self::_lookupContainerSetting($this->getId(), ilObjectServiceSettingsGUI::USE_NEWS, true));
+        $this->setUseNews((bool) self::_lookupContainerSetting($this->getId(), ilObjectServiceSettingsGUI::USE_NEWS, true));
     }
 
 
@@ -895,7 +888,7 @@ class ilContainer extends ilObject
         // using long descriptions?
         $short_desc = $ilSetting->get("rep_shorten_description");
         $short_desc_max_length = $ilSetting->get("rep_shorten_description_length");
-        if (!$short_desc || $short_desc_max_length != ilObject::DESC_LENGTH) {
+        if (!$short_desc || (int) $short_desc_max_length !== ilObject::DESC_LENGTH) {
             // using (part of) shortened description
             if ($short_desc && $short_desc_max_length && $short_desc_max_length < ilObject::DESC_LENGTH) {
                 foreach ($objects as $key => $object) {
@@ -908,11 +901,11 @@ class ilContainer extends ilObject
             }
             // using (part of) long description
             else {
-                $obj_ids = array();
+                $obj_ids = [];
                 foreach ($objects as $key => $object) {
                     $obj_ids[] = $object["obj_id"];
                 }
-                if (sizeof($obj_ids)) {
+                if (count($obj_ids)) {
                     $long_desc = ilObject::getLongDescriptions($obj_ids);
                     foreach ($objects as $key => $object) {
                         // #12166 - keep translation, ignore long description
@@ -1023,22 +1016,22 @@ class ilContainer extends ilObject
             return $objects;
         }
 
-        if ($container_user_filter->isEmpty() && !ilContainer::_lookupContainerSetting($this->getId(), "filter_show_empty", false)) {
+        if ($container_user_filter->isEmpty() && !self::_lookupContainerSetting($this->getId(), "filter_show_empty", false)) {
             return [];
         }
 
         $result = null;
 
-        $obj_ids = array_map(function ($i) {
-            return $i["obj_id"];
+        $obj_ids = array_map(static function (array $i) : int {
+            return (int) $i["obj_id"];
         }, $objects);
         $filter_data = $container_user_filter->getData();
         if (is_array($filter_data)) {
             foreach ($filter_data as $key => $val) {
-                if (count($obj_ids) == 0) {    // stop if no object ids are left
+                if (count($obj_ids) === 0) {    // stop if no object ids are left
                     continue;
                 }
-                if (!in_array(substr($key, 0, 4), ["adv_", "std_"])) {
+                if (!in_array(substr($key, 0, 4), ["adv_", "std_"], true)) {
                     continue;
                 }
                 if ($val == "") {
@@ -1047,23 +1040,23 @@ class ilContainer extends ilObject
                 $field_id = substr($key, 4);
                 $val = ilUtil::stripSlashes($val);
                 $query_parser = new ilQueryParser($val);
-                if (substr($key, 0, 4) == "std_") {
+                if (strpos($key, "std_") === 0) {
                     // object type
-                    if ($field_id == ilContainerFilterField::STD_FIELD_OBJECT_TYPE) {
+                    if ((int) $field_id === ilContainerFilterField::STD_FIELD_OBJECT_TYPE) {
                         $result = null;
                         $set = $db->queryF(
                             "SELECT obj_id FROM object_data " .
                             " WHERE  " . $db->in("obj_id", $obj_ids, false, "integer") .
                             " AND type = %s",
-                            array("text"),
-                            array($val)
+                            ["text"],
+                            [$val]
                         );
                         $result_obj_ids = [];
                         while ($rec = $db->fetchAssoc($set)) {
                             $result_obj_ids[] = $rec["obj_id"];
                         }
                         $obj_ids = array_intersect($obj_ids, $result_obj_ids);
-                    } elseif ($field_id == ilContainerFilterField::STD_FIELD_ONLINE) {
+                    } elseif ((int) $field_id === ilContainerFilterField::STD_FIELD_ONLINE) {
                         if (in_array($val, [1, 2])) {
                             $online_where = ($val == 1)
                                 ? " (offline <> " . $db->quote(1, "integer") . " OR offline IS NULL) "
@@ -1083,29 +1076,29 @@ class ilContainer extends ilObject
                             $obj_ids = array_intersect($obj_ids, $result_obj_ids);
                             $obj_ids = $this->legacyOnlineFilter($obj_ids, $objects, $val);
                         }
-                    } elseif ($field_id == ilContainerFilterField::STD_FIELD_TUTORIAL_SUPPORT) {
+                    } elseif ((int) $field_id === ilContainerFilterField::STD_FIELD_TUTORIAL_SUPPORT) {
                         $result = null;
                         $set = $db->queryF(
                             "SELECT DISTINCT(obj_id) FROM obj_members m JOIN usr_data u ON (u.usr_id = m.usr_id) " .
                             " WHERE  " . $db->in("m.obj_id", $obj_ids, false, "integer") .
                             " AND " . $db->like("u.lastname", "text", $val) .
                             " AND m.contact = %s",
-                            array("integer"),
-                            array(1)
+                            ["integer"],
+                            [1]
                         );
                         $result_obj_ids = [];
                         while ($rec = $db->fetchAssoc($set)) {
                             $result_obj_ids[] = $rec["obj_id"];
                         }
                         $obj_ids = array_intersect($obj_ids, $result_obj_ids);
-                    } elseif ($field_id == ilContainerFilterField::STD_FIELD_COPYRIGHT) {
+                    } elseif ((int) $field_id === ilContainerFilterField::STD_FIELD_COPYRIGHT) {
                         $result = null;
                         $set = $db->queryF(
                             "SELECT DISTINCT(rbac_id) FROM il_meta_rights " .
                             " WHERE  " . $db->in("rbac_id", $obj_ids, false, "integer") .
                             " AND description = %s ",
-                            array("text"),
-                            array('il_copyright_entry__' . IL_INST_ID . '__' . $val)
+                            ["text"],
+                            ['il_copyright_entry__' . IL_INST_ID . '__' . $val]
                         );
                         $result_obj_ids = [];
                         while ($rec = $db->fetchAssoc($set)) {
@@ -1168,7 +1161,7 @@ class ilContainer extends ilObject
                     $adv_md_search = ilObjectSearchFactory::_getAdvancedMDSearchInstance($query_parser);
                     //$adv_md_search->setFilter($this->filter);	// this could be set to an array of object types
                     $adv_md_search->setDefinition($field);            // e.g. ilAdvancedMDFieldDefinitionSelectMulti
-                    $adv_md_search->setIdFilter(array(0));
+                    $adv_md_search->setIdFilter([0]);
                     $adv_md_search->setSearchElement($field_form);    // e.g. ilADTEnumSearchBridgeMulti
                     $result = $adv_md_search->performSearch();
                 }
@@ -1176,8 +1169,8 @@ class ilContainer extends ilObject
                 // intersect results
                 if ($result instanceof ilSearchResult) {
                     $result_obj_ids = array_map(
-                        function ($i) {
-                            return $i["obj_id"];
+                        static function (array $i) : int {
+                            return (int) $i["obj_id"];
                         },
                         $result->getEntries()
                     );
@@ -1185,7 +1178,7 @@ class ilContainer extends ilObject
                 }
             }
         }
-        $objects = array_filter($objects, function ($o) use ($obj_ids) {
+        $objects = array_filter($objects, static function (array $o) use ($obj_ids) : bool {
             return in_array($o["obj_id"], $obj_ids);
         });
 
@@ -1208,11 +1201,11 @@ class ilContainer extends ilObject
     ) : array {
         $legacy_types = ["glo", "wiki", "qpl", "book", "dcl", "prtt"];
         foreach ($legacy_types as $type) {
-            $lobjects = array_filter($objects, function ($o) use ($type) {
-                return ($o["type"] == $type);
+            $lobjects = array_filter($objects, static function (array $o) use ($type) : bool {
+                return ($o["type"] === $type);
             });
-            $lobj_ids = array_map(function ($i) {
-                return $i["obj_id"];
+            $lobj_ids = array_map(static function (array $i) : int {
+                return (int) $i["obj_id"];
             }, $lobjects);
             $status = [];
             switch ($type) {
@@ -1242,7 +1235,7 @@ class ilContainer extends ilObject
                     break;
             }
             foreach ($status as $obj_id => $online) {
-                if ($val == 1 && !$online || $val == 2 && $online) {
+                if (($val == 1 && !$online) || ($val == 2 && $online)) {
                     if (($key = array_search($obj_id, $obj_ids)) !== false) {
                         unset($obj_ids[$key]);
                     }

--- a/Services/Container/classes/class.ilContainerAccess.php
+++ b/Services/Container/classes/class.ilContainerAccess.php
@@ -16,7 +16,7 @@
 /**
  * @author Alexander Killing <killing@leifos.de>
  */
-class ilContainerAccess implements \ilWACCheckingClass
+class ilContainerAccess implements ilWACCheckingClass
 {
     public function canBeDelivered(ilWACPath $ilWACPath) : bool
     {
@@ -24,7 +24,7 @@ class ilContainerAccess implements \ilWACCheckingClass
 
         $access = $DIC->access();
 
-        preg_match("/\\/obj_([\\d]*)\\//uism", $ilWACPath->getPath(), $results);
+        preg_match("/\\/obj_([\\d]*)\\//uim", $ilWACPath->getPath(), $results);
         foreach (ilObject2::_getAllReferences($results[1]) as $ref_id) {
             if ($access->checkAccess('visible', '', $ref_id) || $access->checkAccess('read', '', $ref_id)) {
                 return true;

--- a/Services/Container/classes/class.ilContainerGUI.php
+++ b/Services/Container/classes/class.ilContainerGUI.php
@@ -74,7 +74,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $this->error = $DIC["ilErr"];
         $this->obj_definition = $DIC["objDefinition"];
         $this->rbacadmin = $DIC->rbac()->admin();
-        $this->rbacreview = $DIC->rbac()->review();
+        $this->rbacreview = $DIC->rbac()->review();// TODO PHP8-REVIEW Property dynamically declared
         $this->log = $DIC["ilLog"];
         $this->obj_data_cache = $DIC["ilObjDataCache"];
         $this->toolbar = $DIC->toolbar();
@@ -85,7 +85,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $rbacsystem = $DIC->rbac()->system();
         $lng = $DIC->language();
 
-        $this->rbacsystem = $rbacsystem;
+        $this->rbacsystem = $rbacsystem;// TODO PHP8-REVIEW Property dynamically declared
 
         $lng->loadLanguageModule("cntr");
         $lng->loadLanguageModule('cont');
@@ -115,7 +115,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $this->container_filter_service = new ilContainerFilterService();
         $this->initFilter();
         $cs = $DIC->contentStyle();
-        $this->content_style_gui = $cs->gui();
+        $this->content_style_gui = $cs->gui();// TODO PHP8-REVIEW Property dynamically declared
         $this->content_style_domain = $cs->domain();
     }
 
@@ -129,7 +129,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         switch ($next_class) {
             // page editing
             case "ilcontainerpagegui":
-                if ($this->requested_redirectSource != "ilinternallinkgui") {
+                if ($this->requested_redirectSource !== "ilinternallinkgui") {
                     $ret = $this->forwardToPageObject();
                     $tpl->setContent($ret);
                 } else {
@@ -161,9 +161,9 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $current_tpl_id = ilDidacticTemplateObjSettings::lookupTemplateId(
             $this->object->getRefId()
         );
-        $new_tpl_id = (int) $this->getDidacticTemplateVar('dtpl');
+        $new_tpl_id = $this->getDidacticTemplateVar('dtpl');
 
-        if ($new_tpl_id != $current_tpl_id) {
+        if ($new_tpl_id !== $current_tpl_id) {
             // redirect to didactic template confirmation
             $this->ctrl->setReturn($this, 'edit');
             $this->ctrl->setCmdClass('ildidactictemplategui');
@@ -182,7 +182,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $ilTabs = $this->tabs;
         $ilCtrl = $this->ctrl;
         $cmd = $ilCtrl->getCmd();
-        if (in_array($cmd, array("displayMediaFullscreen", "downloadFile", "displayMedia"))) {
+        if (in_array($cmd, ["displayMediaFullscreen", "downloadFile", "displayMedia"])) {
             $this->checkPermission("read");
         } else {
             $this->checkPermission("write");
@@ -190,7 +190,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
         $ilTabs->clearTargets();
 
-        if ($this->requested_redirectSource == "ilinternallinkgui") {
+        if ($this->requested_redirectSource === "ilinternallinkgui") {
             exit;
         }
 
@@ -296,7 +296,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     public function prepareOutput(bool $show_subobjects = true) : bool
     {
         if (parent::prepareOutput($show_subobjects)) {    // return false in admin mode
-            if ($this->getCreationMode() != true && $show_subobjects) {
+            if ($show_subobjects === true && $this->getCreationMode() === false) {
                 ilMemberViewGUI::showMemberViewSwitch($this->object->getRefId());
             }
         }
@@ -385,12 +385,12 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
         // it is important not to show the subobjects/admin panel here, since
         // we will create nested forms in case, e.g. a news/calendar item is added
-        if ($ilCtrl->getNextClass() != "ilcolumngui") {
+        if ($ilCtrl->getNextClass() !== "ilcolumngui") {
             $this->showAdministrationPanel();
             $this->showPossibleSubObjects();
 
-            if ($user->getId() != ANONYMOUS_USER_ID &&
-                is_object($this->object) &&
+            if (is_object($this->object) &&
+                $user->getId() !== ANONYMOUS_USER_ID &&
                 $this->rbacsystem->checkAccess("write", $this->object->getRefId())
             ) {
                 if ($ilSetting->get("enable_cat_page_edit")) {
@@ -418,7 +418,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     /**
      * render the object
      */
-    public function renderBlockAsynchObject()
+    public function renderBlockAsynchObject() : void
     {
         $container_view = $this->getContentGUI();
         echo $container_view->getSingleTypeBlockAsynch(
@@ -501,7 +501,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                     );
                 }
             }
-            if ($this->object->getType() == 'crs' or $this->object->getType() == 'grp') {
+            if ($this->object->getType() === 'crs' || $this->object->getType() === 'grp') {
                 if ($this->object->gotItems()) {
                     $toolbar->addSeparator();
                 }
@@ -525,61 +525,58 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             if ($this->object->gotItems()) {
                 $main_tpl->setPageFormAction($this->ctrl->getFormAction($this));
             }
-        } else {
-            if ($this->edit_order) {
-                if ($this->object->gotItems() and $ilAccess->checkAccess("write", "", $this->object->getRefId())) {
-                    if ($this->isActiveOrdering()) {
-                        // #11843
-                        $main_tpl->setPageFormAction($this->ctrl->getFormAction($this));
-
-                        $toolbar = new ilToolbarGUI();
-                        $this->ctrl->setParameter($this, "type", "");
-                        $this->ctrl->setParameter($this, "item_ref_id", "");
-
-                        $toolbar->addFormButton(
-                            $this->lng->txt('sorting_save'),
-                            'saveSorting'
-                        );
-
-                        $main_tpl->addAdminPanelToolbar($toolbar, true, false);
-                    }
-                }
-            }
-
-            // bugfix mantis 24559
-            // undoing an erroneous change inside mantis 23516 by adding "Download Multiple Objects"-functionality for non-admins
-            // as they don't have the possibility to use the multi-download-capability of the manage-tab
-            elseif ($this->isMultiDownloadEnabled()) {
-                // bugfix mantis 0021272
-                $ref_id = $this->requested_ref_id;
-                $num_files = $this->tree->getChildsByType($ref_id, "file");
-                $num_folders = $this->tree->getChildsByType($ref_id, "fold");
-                if (count($num_files) > 0 or count($num_folders) > 0) {
+        } elseif ($this->edit_order) {
+            if ($this->object->gotItems() && $ilAccess->checkAccess("write", "", $this->object->getRefId())) {
+                if ($this->isActiveOrdering()) {
                     // #11843
-                    $GLOBALS['tpl']->setPageFormAction($this->ctrl->getFormAction($this));
+                    $main_tpl->setPageFormAction($this->ctrl->getFormAction($this));
 
                     $toolbar = new ilToolbarGUI();
                     $this->ctrl->setParameter($this, "type", "");
                     $this->ctrl->setParameter($this, "item_ref_id", "");
 
                     $toolbar->addFormButton(
-                        $this->lng->txt('download_selected_items'),
-                        'download'
+                        $this->lng->txt('sorting_save'),
+                        'saveSorting'
                     );
 
-                    $GLOBALS['tpl']->addAdminPanelToolbar(
-                        $toolbar,
-                        $this->object->gotItems(),
-                        $this->object->gotItems()
-                    );
-                } else {
-                    $this->tpl->setOnScreenMessage('info', $this->lng->txt('msg_no_downloadable_objects'), true);
+                    $main_tpl->addAdminPanelToolbar($toolbar, true, false);
                 }
+            }
+        }
+        // bugfix mantis 24559
+        // undoing an erroneous change inside mantis 23516 by adding "Download Multiple Objects"-functionality for non-admins
+        // as they don't have the possibility to use the multi-download-capability of the manage-tab
+        elseif ($this->isMultiDownloadEnabled()) {
+            // bugfix mantis 0021272
+            $ref_id = $this->requested_ref_id;
+            $num_files = $this->tree->getChildsByType($ref_id, "file");
+            $num_folders = $this->tree->getChildsByType($ref_id, "fold");
+            if (count($num_files) > 0 || count($num_folders) > 0) {
+                // #11843
+                $GLOBALS['tpl']->setPageFormAction($this->ctrl->getFormAction($this));
+
+                $toolbar = new ilToolbarGUI();
+                $this->ctrl->setParameter($this, "type", "");
+                $this->ctrl->setParameter($this, "item_ref_id", "");
+
+                $toolbar->addFormButton(
+                    $this->lng->txt('download_selected_items'),
+                    'download'
+                );
+
+                $GLOBALS['tpl']->addAdminPanelToolbar(
+                    $toolbar,
+                    $this->object->gotItems(),
+                    $this->object->gotItems()
+                );
+            } else {
+                $this->tpl->setOnScreenMessage('info', $this->lng->txt('msg_no_downloadable_objects'), true);
             }
         }
     }
 
-    public function __showTimingsButton($tpl) : bool
+    public function __showTimingsButton($tpl) : bool// TODO PHP8-REVIEW This method is called anywhere and can be removed IMO
     {
         $tree = $this->tree;
 
@@ -609,7 +606,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
     public function editPageFrameObject() : void
     {
-        $this->ctrl->redirectByClass(array(static::class, "ilcontainerpagegui"), "edit");
+        $this->ctrl->redirectByClass([static::class, "ilcontainerpagegui"], "edit");
     }
 
     public function cancelPageContentObject() : void
@@ -631,7 +628,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             "Services/Container"
         );
 
-        $type_ordering = array(
+        $type_ordering = [
             "cat",
             "fold",
             "crs",
@@ -648,11 +645,11 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             "mep",
             "qpl",
             "spl"
-        );
+        ];
 
         $childs = $tree->getChilds($this->requested_ref_id);
         foreach ($childs as $child) {
-            if (in_array($child["type"], array("lm", "sahs", "htlm"))) {
+            if (in_array($child["type"], ["lm", "sahs", "htlm"])) {
                 $cnt["lres"]++;
             } else {
                 $cnt[$child["type"]]++;
@@ -663,7 +660,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $tpl->setVariable("TXT_HELP_HEADER", $lng->txt("help"));
         foreach ($type_ordering as $type) {
             $tpl->setCurrentBlock("row");
-            if ($type != "lres") {
+            if ($type !== "lres") {
                 $tpl->setVariable(
                     "TYPE",
                     $lng->txt("objs_" . $type) .
@@ -719,13 +716,13 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $ilSetting = $this->settings;
 
         $nbsp = true;
-        if ($ilSetting->get("icon_position_in_lists") == "item_rows") {
+        if ($ilSetting->get("icon_position_in_lists") === "item_rows") {
             $icon = ilUtil::getImagePath("icon_" . $a_image_type . ".svg");
             $alt = $this->lng->txt("obj_" . $a_image_type);
 
             if ($ilSetting->get('custom_icons')) {
                 global $DIC;
-                /** @var \ilObjectCustomIconFactory $customIconFactory */
+                /** @var ilObjectCustomIconFactory $customIconFactory */
                 $customIconFactory = $DIC['object.customicons.factory'];
                 $customIcon = $customIconFactory->getPresenterByObjId($a_item_obj_id, $a_image_type);
 
@@ -748,7 +745,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             $nbsp = false;
         }
         if ($this->isActiveAdministrationPanel() &&
-            ilContainerSortingSettings::_lookupSortMode($this->object->getId()) == ilContainer::SORT_MANUAL) {
+            ilContainerSortingSettings::_lookupSortMode($this->object->getId()) === ilContainer::SORT_MANUAL) {
             $a_tpl->setCurrentBlock('block_position');
             $a_tpl->setVariable('POS_TYPE', $a_image_type);
             $a_tpl->setVariable('POS_ID', $a_item_ref_id);
@@ -788,7 +785,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $lng = $this->lng;
 
         if (!$this->isActiveAdministrationPanel()
-            || strtolower($this->ctrl->getCmdClass()) != "ilcontainerpagegui") {
+            || strtolower($this->ctrl->getCmdClass()) !== "ilcontainerpagegui") {
             return;
         }
 
@@ -806,7 +803,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $this->tabs_gui->addTarget(
             "edit",
             $this->ctrl->getLinkTargetByClass("ilcontainerpagegui", "view"),
-            array("", "view"),
+            ["", "view"],
             "ilcontainerpagegui"
         );
 
@@ -840,7 +837,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             }
         }
 
-        if ($ilUser->getId() != ANONYMOUS_USER_ID &&
+        if ($ilUser->getId() !== ANONYMOUS_USER_ID &&
             (
                 $this->adminCommands ||
                 (is_object($this->object) &&
@@ -861,8 +858,8 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 );
             }
         }
-        if ($ilUser->getId() != ANONYMOUS_USER_ID &&
-            is_object($this->object) &&
+        if (is_object($this->object) &&
+            $ilUser->getId() !== ANONYMOUS_USER_ID &&
             $this->rbacsystem->checkAccess("write", $this->object->getRefId()) /* &&
             $this->object->getOrderType() == ilContainer::SORT_MANUAL */ // always on because of custom block order
         ) {
@@ -880,16 +877,16 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             $this->tabs_gui->addTarget(
                 "perm_settings",
                 $this->ctrl->getLinkTargetByClass([get_class($this), 'ilpermissiongui'], "perm"),
-                array("perm", "info", "owner"),
+                ["perm", "info", "owner"],
                 'ilpermissiongui'
             );
-            if ($ilCtrl->getNextClass() == "ilpermissiongui") {
+            if ($ilCtrl->getNextClass() === "ilpermissiongui") {
                 $this->tabs_gui->activateTab("perm_settings");
             }
         }
 
         // show clipboard
-        if (strtolower($this->std_request->getBaseClass()) == "ilrepositorygui" &&
+        if (strtolower($this->std_request->getBaseClass()) === "ilrepositorygui" &&
             $this->clipboard->hasEntries()) {
             $this->tabs_gui->addTarget(
                 "clipboard",
@@ -937,7 +934,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     public function isActiveItemOrdering() : bool
     {
         if ($this->isActiveOrdering()) {
-            return (ilContainerSortingSettings::_lookupSortMode($this->object->getId()) == ilContainer::SORT_MANUAL);
+            return (ilContainerSortingSettings::_lookupSortMode($this->object->getId()) === ilContainer::SORT_MANUAL);
         }
         return false;
     }
@@ -970,7 +967,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $ids = $this->std_request->getSelectedIds();
         $no_cut = [];
 
-        if (count($ids) == 0) {
+        if (count($ids) === 0) {
             $ilErr->raiseError($this->lng->txt("no_checkbox"), $ilErr->MESSAGE);
         }
 
@@ -985,7 +982,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
             // CHECK DELETE PERMISSION OF ALL OBJECTS IN ACTUAL SUBTREE
             foreach ($subtree_nodes as $node) {
-                if ($node['type'] == 'rolf') {
+                if ($node['type'] === 'rolf') {
                     continue;
                 }
 
@@ -996,7 +993,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         }
         // IF THERE IS ANY OBJECT WITH NO PERMISSION TO 'delete'
         if (count($no_cut)) {
-            $titles = array();
+            $titles = [];
             foreach ($no_cut as $cut_id) {
                 $titles[] = ilObject::_lookupTitle(ilObject::_lookupObjId($cut_id));
             }
@@ -1029,7 +1026,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
         $ids = $this->std_request->getSelectedIds();
 
-        if (count($ids) == 0) {
+        if (count($ids) === 0) {
             $ilErr->raiseError($this->lng->txt("no_checkbox"), $ilErr->MESSAGE);
         }
 
@@ -1051,7 +1048,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
             // CHECK COPY PERMISSION OF ALL OBJECTS IN ACTUAL SUBTREE
             foreach ($subtree_nodes as $node) {
-                if ($node['type'] == 'rolf') {
+                if ($node['type'] === 'rolf') {
                     continue;
                 }
 
@@ -1067,7 +1064,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
         // IF THERE IS ANY OBJECT WITH NO PERMISSION TO 'delete'
         if (is_array($no_copy) && count($no_copy)) {
-            $titles = array();
+            $titles = [];
             foreach ($no_copy as $copy_id) {
                 $titles[] = ilObject::_lookupTitle(ilObject::_lookupObjId($copy_id));
             }
@@ -1079,7 +1076,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
         // if we have a single container, set it as source id and redirect to ilObjectCopyGUI
         $ids = $this->std_request->getSelectedIds();
-        if ($ids == 1) {
+        if (count($ids) === 1) {
             $ilCtrl->setParameterByClass("ilobjectcopygui", "source_id", $ids[0]);
         } else {
             $ilCtrl->setParameterByClass("ilobjectcopygui", "source_ids", implode("_", $ids));
@@ -1104,11 +1101,11 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
         $ids = $this->std_request->getSelectedIds();
 
-        if (count($ids) == 0) {
+        if (count($ids) === 0) {
             $object = ilObjectFactory::getInstanceByRefId($this->requested_ref_id);
             $object_type = $object->getType();
-            if ($object_type == "fold") {
-                $ids = array($this->requested_ref_id);
+            if ($object_type === "fold") {
+                $ids = [$this->requested_ref_id];
                 $initiated_by_folder_action = true;
             } else {
                 $ilErr->raiseError($this->lng->txt("no_checkbox"), $ilErr->MESSAGE);
@@ -1130,7 +1127,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
     public function getBucketTitle() : string
     {
-        return $bucket_title = ilFileUtils::getASCIIFilename($this->object->getTitle());
+        return ilFileUtils::getASCIIFilename($this->object->getTitle());
     }
 
     /**
@@ -1148,7 +1145,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
         $ids = $this->std_request->getSelectedIds();
 
-        if (count($ids) == 0) {
+        if (count($ids) === 0) {
             $ilErr->raiseError($this->lng->txt("no_checkbox"), $ilErr->MESSAGE);
         }
 
@@ -1160,7 +1157,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
             $object = ilObjectFactory::getInstanceByRefId($ref_id);
 
-            if (!$this->objDefinition->allowLink($object->getType())) {
+            if (!$this->obj_definition->allowLink($object->getType())) {
                 $no_link[] = $object->getType();
             }
         }
@@ -1184,7 +1181,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $this->clipboard->setRefIds($ids);
 
         $suffix = 'p';
-        if (count($this->clipboard->getRefIds()) == 1) {
+        if (count($this->clipboard->getRefIds()) === 1) {
             $suffix = 's';
         }
         $this->tpl->setOnScreenMessage('info', $this->lng->txt("msg_link_clipboard_" . $suffix), true);
@@ -1202,7 +1199,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         //var_dump($this->getReturnLocation("clear",$this->ctrl->getLinkTarget($this)),get_class($this));
 
         // only redirect if clipboard was cleared
-        if ($this->ctrl->getCmd() == "clear") {
+        if ($this->ctrl->getCmd() === "clear") {
             $this->tpl->setOnScreenMessage('success', $this->lng->txt("msg_clear_clipboard"), true);
             // fixed mantis 0018474: Clear Clipboard redirects to Subtab View, instead of Subtab "Edit Multiple"
             $this->ctrl->redirect($this, 'render');
@@ -1228,14 +1225,14 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $no_paste = [];
 
         $command = $this->clipboard->getCmd();
-        if (!in_array($command, array('cut', 'link', 'copy'))) {
+        if (!in_array($command, ['cut', 'link', 'copy'])) {
             $message = __METHOD__ . ": cmd was neither 'cut', 'link' nor 'copy'; may be a hack attempt!";
             $ilErr->raiseError($message, $ilErr->WARNING);
         }
 
         $nodes = $this->std_request->getNodes();
 
-        if (count($nodes) == 0) {
+        if (count($nodes) === 0) {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('select_at_least_one_object'));
             switch ($command) {
                 case 'link':
@@ -1248,7 +1245,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         }
 
         // this loop does all checks
-        $folder_objects_cache = array();
+        $folder_objects_cache = [];
         foreach ($this->clipboard->getRefIds() as $ref_id) {
             $obj_data = ilObjectFactory::getInstanceByRefId($ref_id);
             $current_parent_id = $tree->getParentId($obj_data->getRefId());
@@ -1279,8 +1276,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 }
 
                 // CHECK IF PASTE OBJECT SHALL BE CHILD OF ITSELF
-                if ($tree->isGrandChild($ref_id, $folder_ref_id) ||
-                    $ref_id == $folder_ref_id) {
+                if ($ref_id == $folder_ref_id || $tree->isGrandChild($ref_id, $folder_ref_id)) {
                     $is_child[] = sprintf(
                         $this->lng->txt('msg_paste_object_not_in_itself'),
                         $obj_data->getTitle() . ' [' . $obj_data->getRefId() . ']'
@@ -1288,9 +1284,9 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 }
 
                 // CHECK IF OBJECT IS ALLOWED TO CONTAIN PASTED OBJECT AS SUBOBJECT
-                if (!in_array(
+                if (!array_key_exists(
                     $obj_data->getType(),
-                    array_keys($folder_objects_cache[$folder_ref_id]->getPossibleSubObjects())
+                    $folder_objects_cache[$folder_ref_id]->getPossibleSubObjects()
                 )) {
                     $not_allowed_subobject[] = sprintf(
                         $this->lng->txt('msg_obj_may_not_contain_objects_of_type'),
@@ -1305,26 +1301,26 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         ////////////////////////////
         // process checking results
         $error = "";
-        if (count($exists) && $command != "copy") {
+        if ($command !== "copy" && count($exists)) {
             $error .= implode('<br />', $exists);
         }
 
         if (count($is_child)) {
-            $error .= $error != '' ? '<br />' : '';
+            $error .= $error !== '' ? '<br />' : '';
             $error .= implode('<br />', $is_child);
         }
 
         if (count($not_allowed_subobject)) {
-            $error .= $error != '' ? '<br />' : '';
+            $error .= $error !== '' ? '<br />' : '';
             $error .= implode('<br />', $not_allowed_subobject);
         }
 
         if (count($no_paste)) {
-            $error .= $error != '' ? '<br />' : '';
+            $error .= $error !== '' ? '<br />' : '';
             $error .= implode('<br />', $no_paste);
         }
 
-        if ($error != '') {
+        if ($error !== '') {
             $this->tpl->setOnScreenMessage('failure', $error);
             switch ($command) {
                 case 'link':
@@ -1348,10 +1344,10 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
 
         // process COPY command
-        if ($command == 'copy') {
+        if ($command === 'copy') {
             foreach ($nodes as $folder_ref_id) {
                 foreach ($ref_ids as $ref_id) {
-                    $revIdMapping = array();
+                    $revIdMapping = [];
 
                     $oldNode_data = $tree->getNodeData($ref_id);
                     if ($oldNode_data['parent'] == $folder_ref_id) {
@@ -1385,7 +1381,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         } // END COPY
 
         // process CUT command
-        if ($command == 'cut') {
+        if ($command === 'cut') {
             foreach ($nodes as $folder_ref_id) {
                 foreach ($ref_ids as $ref_id) {
                     // Store old parent
@@ -1422,9 +1418,9 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         } // END CUT
 
         // process LINK command
-        if ($command == 'link') {
+        if ($command === 'link') {
             $subnodes = [];
-            $linked_to_folders = array();
+            $linked_to_folders = [];
 
             $rbac_log_active = ilRbacLog::isActive();
 
@@ -1479,7 +1475,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             }
 
             $suffix = 'p';
-            if (count($ref_ids) == 1) {
+            if (count($ref_ids) === 1) {
                 $suffix = 's';
             }
 
@@ -1509,7 +1505,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
         $ilTabs->setTabActive('view_content');
 
-        if (!in_array($this->clipboard->getCmd(), array('link', 'copy', 'cut'))) {
+        if (!in_array($this->clipboard->getCmd(), ['link', 'copy', 'cut'])) {
             $message = __METHOD__ . ": Unknown action.";
             $ilErr->raiseError($message, $ilErr->WARNING);
         }
@@ -1522,7 +1518,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         }
         $output = $exp->getHTML();
 
-        $txt_var = ($cmd == "copy")
+        $txt_var = ($cmd === "copy")
             ? "copy"
             : "paste";
 
@@ -1578,7 +1574,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $this->showPasteTreeObject();
     }
 
-    public function initAndDisplayMoveIntoObjectObject()
+    public function initAndDisplayMoveIntoObjectObject() : void
     {
         $this->showPasteTreeObject();
     }
@@ -1603,7 +1599,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $not_allowed_subobject = [];
 
 
-        if (!in_array($this->clipboard->getCmd(), array("cut", "link", "copy"))) {
+        if (!in_array($this->clipboard->getCmd(), ["cut", "link", "copy"])) {
             $message = get_class(
                 $this
             ) . "::pasteObject(): cmd was neither 'cut','link' or 'copy'; may be a hack attempt!";
@@ -1621,7 +1617,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             }
 
             // CHECK IF REFERENCE ALREADY EXISTS
-            if ($this->object->getRefId() == $this->tree->getParentId($obj_data->getRefId())) {
+            if ($this->object->getRefId() === $this->tree->getParentId($obj_data->getRefId())) {
                 $exists[] = $ref_id;
                 break;
             }
@@ -1638,7 +1634,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             // CHECK IF OBJECT IS ALLOWED TO CONTAIN PASTED OBJECT AS SUBOBJECT
             $obj_type = $obj_data->getType();
 
-            if (!in_array($obj_type, array_keys($this->object->getPossibleSubObjects()))) {
+            if (!array_key_exists($obj_type, $this->object->getPossibleSubObjects())) {
                 $not_allowed_subobject[] = $obj_data->getType();
             }
         }
@@ -1646,7 +1642,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         ////////////////////////////
         // process checking results
         // BEGIN WebDAV: Copying an object into the same container is allowed
-        if (count($exists) > 0 && $this->clipboard->getCmd() != "copy") {
+        if (count($exists) > 0 && $this->clipboard->getCmd() !== "copy") {
             // END WebDAV: Copying an object into the same container is allowed
             $ilErr->raiseError($this->lng->txt("msg_obj_exists"), $ilErr->MESSAGE);
         }
@@ -1685,12 +1681,12 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
         // BEGIN WebDAV: Support a copy command in the repository
         // process COPY command
-        if ($this->clipboard->getCmd() == "copy") {
+        if ($this->clipboard->getCmd() === "copy") {
             $this->clipboard->clear();
 
             // new implementation, redirects to ilObjectCopyGUI
             $ilCtrl->setParameterByClass("ilobjectcopygui", "target", $this->object->getRefId());
-            if (count($ref_ids) == 1) {
+            if (count($ref_ids) === 1) {
                 $ilCtrl->setParameterByClass("ilobjectcopygui", "source_id", $ref_ids[0]);
             } else {
                 $ilCtrl->setParameterByClass("ilobjectcopygui", "source_ids", implode("_", $ref_ids));
@@ -1702,7 +1698,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         // END WebDAV: Support a Copy command in the repository
 
         // process CUT command
-        if ($this->clipboard->getCmd() == "cut") {
+        if ($this->clipboard->getCmd() === "cut") {
             foreach ($ref_ids as $ref_id) {
                 // Store old parent
                 $old_parent = $tree->getParentId($ref_id);
@@ -1734,7 +1730,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         // process LINK command
         $ref_id = 0;
         $subnodes = [];
-        if ($this->clipboard->getCmd() == "link") {
+        if ($this->clipboard->getCmd() === "link") {
             foreach ($ref_ids as $ref_id) {
                 // get node data
                 $top_node = $this->tree->getNodeData($ref_id);
@@ -1772,12 +1768,12 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         // clear clipboard
         $this->clearObject();
 
-        if ($last_cmd == "cut") {
+        if ($last_cmd === "cut") {
             $this->tpl->setOnScreenMessage('success', $this->lng->txt("msg_cut_copied"), true);
         } // BEGIN WebDAV: Support a copy command in repository
-        elseif ($last_cmd == "copy") {
+        elseif ($last_cmd === "copy") {
             $this->tpl->setOnScreenMessage('success', $this->lng->txt("msg_cloned"), true);
-        } elseif ($last_cmd == 'link') {
+        } elseif ($last_cmd === 'link') {
             // END WebDAV: Support copy command in repository
             $this->tpl->setOnScreenMessage('success', $this->lng->txt("msg_linked"), true);
         }
@@ -1805,22 +1801,22 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             $ilErr->raiseError($this->lng->txt("permission_denied"), $ilErr->WARNING);
         }
 
-        $data = array();
+        $data = [];
         foreach ($this->clipboard->getRefIds() as $ref_id) {
             if (!$tmp_obj = ilObjectFactory::getInstanceByRefId($ref_id, false)) {
                 continue;
             }
 
-            $data[] = array(
+            $data[] = [
                 "type" => $tmp_obj->getType(),
                 "type_txt" => $this->lng->txt("obj_" . $tmp_obj->getType()),
                 "title" => $tmp_obj->getTitle(),
-                "cmd" => ($this->clipboard->getCmd() == "cut") ? $this->lng->txt("move") : $this->lng->txt(
+                "cmd" => ($this->clipboard->getCmd() === "cut") ? $this->lng->txt("move") : $this->lng->txt(
                     $this->clipboard->getCmd()
                 ),
                 "ref_id" => $ref_id,
                 "obj_id" => $tmp_obj->getId()
-            );
+            ];
 
             unset($tmp_obj);
         }
@@ -1859,9 +1855,9 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $ilAccess = $this->access;
         parent::setColumnSettings($column_gui);
 
-        if ($ilAccess->checkAccess("write", "", $this->object->getRefId()) &&
-            $this->isActiveAdministrationPanel() &&
-            $this->allowBlocksMoving()) {
+        if ($this->isActiveAdministrationPanel() &&
+            $this->allowBlocksMoving() &&
+            $ilAccess->checkAccess("write", "", $this->object->getRefId())) {
             $column_gui->setEnableMovement(true);
         }
 
@@ -1976,9 +1972,9 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
         // clone the source node
         $srcObj = ilObjectFactory::getInstanceByRefId($srcRef);
-        error_log(__METHOD__ . ' cloning srcRef=' . $srcRef . ' dstRef=' . $dstRef . '...');
+        error_log(__METHOD__ . ' cloning srcRef=' . $srcRef . ' dstRef=' . $dstRef . '...');// TODO PHP8-REVIEW We should use the logger from the $DIC instead
         $newRef = $srcObj->cloneObject($dstRef)->getRefId();
-        error_log(__METHOD__ . ' ...cloning... newRef=' . $newRef . '...');
+        error_log(__METHOD__ . ' ...cloning... newRef=' . $newRef . '...');// TODO PHP8-REVIEW We should use the logger from the $DIC instead
 
         // We must immediately apply a new name to the object, to
         // prevent confusion of WebDAV clients about having two objects with identical
@@ -1997,15 +1993,13 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         foreach ($tree->getChilds($srcRef) as $child) {
             // Don't clone role folders, because it does not make sense to clone local roles
             // FIXME - Maybe it does make sense (?)
-            if ($child["type"] != 'rolf') {
+            if ($child["type"] !== 'rolf') {
                 $this->cloneNodes($child["ref_id"], $newRef, $mapping);
-            } else {
-                if (count($rolf = $tree->getChildsByType($newRef, "rolf"))) {
-                    $mapping[$rolf[0]["ref_id"]] = $child["ref_id"];
-                }
+            } elseif (count($rolf = $tree->getChildsByType($newRef, "rolf"))) {
+                $mapping[$rolf[0]["ref_id"]] = $child["ref_id"];
             }
         }
-        error_log(__METHOD__ . ' ...cloned srcRef=' . $srcRef . ' dstRef=' . $dstRef . ' newRef=' . $newRef);
+        error_log(__METHOD__ . ' ...cloned srcRef=' . $srcRef . ' dstRef=' . $dstRef . ' newRef=' . $newRef);// TODO PHP8-REVIEW We should use the logger from the $DIC instead
         return $newRef;
     }
     // END PATCH WebDAV: Support a copy command in the repository
@@ -2054,13 +2048,13 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     }
 
 
-    public function editStylePropertiesObject()
+    public function editStylePropertiesObject() : void
     {
         $this->content_style_gui
             ->redirectToObjectSettings();
     }
 
-    protected function showContainerPageTabs()
+    protected function showContainerPageTabs() : void
     {
         $ctrl = $this->ctrl;
         $tabs = $this->tabs;
@@ -2068,7 +2062,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $style_id = $this->content_style_domain
             ->styleForRefId($this->object->getRefId())
             ->getEffectiveStyleId();
-        if (ilObject::_lookupType($style_id) == "sty") {
+        if (ilObject::_lookupType($style_id) === "sty") {
             $page_gui->setStyleId($style_id);
         } else {
             $style_id = 0;
@@ -2086,11 +2080,12 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $type = ilObject::_lookupType($obj_id);
 
         // this should be done via container-object->getSubItem in the future
-        $data = array("child" => $ref_id,
-                      "ref_id" => $ref_id,
-                      "obj_id" => $obj_id,
-                      "type" => $type
-        );
+        $data = [
+            "child" => $ref_id,
+            "ref_id" => $ref_id,
+            "obj_id" => $obj_id,
+            "type" => $type
+        ];
         $item_list_gui = ilObjectListGUIFactory::_getListGUIByType($type);
         $item_list_gui->setContainerObject($this);
 
@@ -2111,8 +2106,8 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         // include plugin slot for async item list
         foreach ($this->component_factory->getActivePluginsInSlot("uihk") as $plugin) {
             $gui_class = $plugin->getUIClassInstance();
-            $resp = $gui_class->getHTML("Services/Container", "async_item_list", array("html" => $html));
-            if ($resp["mode"] != ilUIHookPluginGUI::KEEP) {
+            $resp = $gui_class->getHTML("Services/Container", "async_item_list", ["html" => $html]);
+            if ((string) $resp["mode"] !== ilUIHookPluginGUI::KEEP) {
                 $html = $gui_class->modifyHTML($html, $resp);
             }
         }
@@ -2256,7 +2251,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     public function initFormTitleDescription(ilPropertyFormGUI $form) : void
     {
         $trans = null;
-        if ($this->getCreationMode() != true) {
+        if ($this->getCreationMode() === false) {
             /** @var ilObjectTranslation $trans */
             $trans = $this->object->getObjectTranslation();
         }
@@ -2266,7 +2261,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $title->setMaxLength(ilObject::TITLE_LENGTH);
         $form->addItem($title);
 
-        if ($this->getCreationMode() != true && sizeof($trans->getLanguages()) > 1) {
+        if ($this->getCreationMode() === false && count($trans->getLanguages()) > 1) {
             $languages = ilMDLanguageItem::_getLanguages();
             $title->setInfo(
                 $this->lng->txt("language") . ": " . $languages[$trans->getDefaultLanguage()] .
@@ -2281,7 +2276,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $desc->setCols(40);
         $form->addItem($desc);
 
-        if ($this->getCreationMode() != true) {
+        if ($this->getCreationMode() === false) {
             $title->setValue($trans->getDefaultTitle());
             $desc->setValue($trans->getDefaultDescription());
         }
@@ -2394,7 +2389,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
     protected function saveListPresentation(ilPropertyFormGUI $form) : void
     {
-        $val = ($form->getInput('list_presentation') == "tile")
+        $val = ($form->getInput('list_presentation') === "tile")
             ? "tile"
             : "";
         ilContainer::_writeContainerSetting($this->object->getId(), "list_presentation", $val);
@@ -2413,7 +2408,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         ilRadioOption $element,
         string $a_prefix
     ) : ilRadioOption {
-        if ($a_prefix == 'manual') {
+        if ($a_prefix === 'manual') {
             $txt = $this->lng->txt('sorting_new_items_direction');
         } else {
             $txt = $this->lng->txt('sorting_direction');
@@ -2450,7 +2445,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         ilRadioOption $element,
         string $a_prefix,
         array $a_sorting_settings
-    ) {
+    ) : ilRadioOption {
         $position = new ilRadioGroupInputGUI(
             $this->lng->txt('sorting_new_items_position'),
             $a_prefix . '_new_items_position'
@@ -2551,7 +2546,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
         $this->tabs_gui->activateTab('trash');
 
-        $trash_table = new \ilTrashTableGUI($this, 'trash', $this->object->getRefId());
+        $trash_table = new ilTrashTableGUI($this, 'trash', $this->object->getRefId());
         $trash_table->init();
         $trash_table->parse();
 
@@ -2573,7 +2568,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
     protected function trashHandleFilter(bool $action_apply, bool $action_reset) : void
     {
-        $trash_table = new \ilTrashTableGUI($this, 'trash', $this->object->getRefId());
+        $trash_table = new ilTrashTableGUI($this, 'trash', $this->object->getRefId());
         $trash_table->init();
         $trash_table->resetOffset();
         if ($action_reset) {
@@ -2592,11 +2587,11 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         $this->ctrl->redirect($this, "trash");
     }
 
-    protected function restoreToNewLocationObject(\ilPropertyFormGUI $form = null) : void
+    protected function restoreToNewLocationObject(ilPropertyFormGUI $form = null) : void
     {
         $this->tabs_gui->activateTab('trash');
 
-        $ru = new \ilRepositoryTrashGUI($this);
+        $ru = new ilRepositoryTrashGUI($this);
         $ru->restoreToNewLocation();
     }
 
@@ -2632,7 +2627,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         // ilRepositorySelectorExplorerGUI only handles static rules for
         // parent-child-relations and not the dynamic relationsships
         // required for the SP (see #16909).
-        $exp->setTypeWhiteList(array("root", "cat", "grp", "crs", "fold"));
+        $exp->setTypeWhiteList(["root", "cat", "grp", "crs", "fold"]);
 
         // Not all types are allowed in the LearningSequence
         // Extend whitelist, if all selected types are possible subojects of LSO
@@ -2653,7 +2648,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             }
         }
 
-        if ($cmd == "link") {
+        if ($cmd === "link") {
             $exp->setSelectMode("nodes", true);
         } else {
             $exp->setSelectMode("nodes[]", false);

--- a/Services/Container/test/ContentViewManagerTest.php
+++ b/Services/Container/test/ContentViewManagerTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\TestCase;
  */
 class ContentViewManagerTest extends TestCase
 {
-    //protected $backupGlobals = false;
     protected \ILIAS\Container\Content\ViewManager $manager;
 
     protected function setUp() : void
@@ -26,7 +25,7 @@ class ContentViewManagerTest extends TestCase
     /**
      * Test admin view
      */
-    public function testAdminView()
+    public function testAdminView() : void
     {
         $manager = $this->manager;
 
@@ -45,7 +44,7 @@ class ContentViewManagerTest extends TestCase
     /**
      * Test content view
      */
-    public function testContentView()
+    public function testContentView() : void
     {
         $manager = $this->manager;
 

--- a/Services/Container/test/ilServicesContainerSuite.php
+++ b/Services/Container/test/ilServicesContainerSuite.php
@@ -22,7 +22,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilServicesContainerSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new self();
 

--- a/Services/ContainerReference/classes/class.ilContainerReference.php
+++ b/Services/ContainerReference/classes/class.ilContainerReference.php
@@ -67,7 +67,7 @@ class ilContainerReference extends ilObject
         return null;
     }
      
-    public static function _lookupTitle($a_id) : string
+    public static function _lookupTitle(int $obj_id) : string
     {
         global $DIC;
 
@@ -75,14 +75,14 @@ class ilContainerReference extends ilObject
          
         $query = 'SELECT title,title_type FROM container_reference cr ' .
                  'JOIN object_data od ON cr.obj_id = od.obj_id ' .
-                 'WHERE cr.obj_id = ' . $ilDB->quote($a_id, 'integer');
+                 'WHERE cr.obj_id = ' . $ilDB->quote($obj_id, 'integer');
         $res = $ilDB->query($query);
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            if ($row->title_type == ilContainerReference::TITLE_TYPE_CUSTOM) {
-                return $row->title;
+            if ((int) $row->title_type === self::TITLE_TYPE_CUSTOM) {
+                return (string) $row->title;
             }
         }
-        return ilContainerReference::_lookupTargetTitle($a_id);
+        return self::_lookupTargetTitle($obj_id);
     }
     
     public static function _lookupTargetTitle(int $a_obj_id) : string
@@ -96,7 +96,7 @@ class ilContainerReference extends ilObject
             "WHERE cr.obj_id = " . $ilDB->quote($a_obj_id, 'integer');
         $res = $ilDB->query($query);
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            return $row->title;
+            return (string) $row->title;
         }
         return '';
     }
@@ -130,9 +130,9 @@ class ilContainerReference extends ilObject
         $query = "SELECT * FROM container_reference " .
             "WHERE target_obj_id = " . $ilDB->quote($a_target_id, 'integer') . " ";
         $res = $ilDB->query($query);
-        $ret = array();
+        $ret = [];
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $ret[] = $row->obj_id;
+            $ret[] = (int) $row->obj_id;
         }
         return $ret;
     }
@@ -178,25 +178,24 @@ class ilContainerReference extends ilObject
         $res = $ilDB->query($query);
         
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $this->setTargetId($row->target_obj_id);
-            $this->setTitleType($row->title_type);
+            $this->setTargetId((int) $row->target_obj_id);
+            $this->setTitleType((int) $row->title_type);
         }
         $ref_ids = ilObject::_getAllReferences($this->getTargetId());
         $this->setTargetRefId(current($ref_ids));
         
-        if ($this->getTitleType() == ilContainerReference::TITLE_TYPE_REUSE) {
-            #$this->title = $this->lng->txt('reference_of').' '.ilObject::_lookupTitle($this->getTargetId());
+        if ($this->getTitleType() === self::TITLE_TYPE_REUSE) {
             $this->title = ilObject::_lookupTitle($this->getTargetId());
         }
     }
 
     public function getPresentationTitle() : string
     {
-        if ($this->getTitleType() == self::TITLE_TYPE_CUSTOM) {
+        if ($this->getTitleType() === self::TITLE_TYPE_CUSTOM) {
             return $this->getTitle();
-        } else {
-            return $this->lng->txt('reference_of') . ' ' . $this->getTitle();
         }
+
+        return $this->lng->txt('reference_of') . ' ' . $this->getTitle();
     }
     
     public function update() : bool
@@ -234,9 +233,9 @@ class ilContainerReference extends ilObject
         return true;
     }
     
-    public function cloneObject(int $a_target_id, int $a_copy_id = 0, bool $a_omit_tree = false) : ?ilObject
+    public function cloneObject(int $target_id, int $copy_id = 0, bool $omit_tree = false) : ?ilObject
     {
-        $new_obj = parent::cloneObject($a_target_id, $a_copy_id, $a_omit_tree);
+        $new_obj = parent::cloneObject($target_id, $copy_id, $omit_tree);
         $new_obj->setTargetId($this->getTargetId());
         $new_obj->setTitleType($this->getTitleType());
         $new_obj->update();

--- a/Services/ContainerReference/classes/class.ilContainerReferenceAccess.php
+++ b/Services/ContainerReference/classes/class.ilContainerReferenceAccess.php
@@ -19,11 +19,6 @@
  */
 class ilContainerReferenceAccess extends ilObjectAccess
 {
-    public function _checkAccess(string $cmd, string $permission, int $ref_id, int $obj_id, ?int $user_id = null) : bool
-    {
-        return true;
-    }
-    
     /**
      * Check if target is accessible and not deleted
      */
@@ -41,7 +36,7 @@ class ilContainerReferenceAccess extends ilObjectAccess
         $res = $ilDB->query($query);
         $target_id = 0;
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $target_id = $row->target_obj_id;
+            $target_id = (int) $row->target_obj_id;
         }
         $target_ref_ids = ilObject::_getAllReferences($target_id);
         $target_ref_id = current($target_ref_ids);

--- a/Services/ContainerReference/classes/class.ilContainerReferenceExporter.php
+++ b/Services/ContainerReference/classes/class.ilContainerReferenceExporter.php
@@ -26,25 +26,24 @@ abstract class ilContainerReferenceExporter extends ilXmlExporter
 
         $log = $DIC->logger()->root();
 
-        include_once './Services/Export/classes/class.ilExportOptions.php';
         $eo = ilExportOptions::getInstance();
 
         $obj_id = end($a_ids);
 
         $log->debug(__METHOD__ . ': ' . $obj_id);
         if ($eo->getOption(ilExportOptions::KEY_ROOT) != $obj_id) {
-            return array();
+            return [];
         }
         if (count(ilExportOptions::getInstance()->getSubitemsForExport()) > 1) {
-            return array(
-                array(
+            return [
+                [
                     'component' => 'Services/Container',
                     'entity' => 'struct',
                     'ids' => $a_ids
-                )
-            );
+                ]
+            ];
         }
-        return array();
+        return [];
     }
     
     abstract protected function initWriter(ilContainerReference $ref) : ilContainerReferenceXmlWriter;
@@ -55,7 +54,7 @@ abstract class ilContainerReferenceExporter extends ilXmlExporter
 
         $log = $DIC->logger()->root();
 
-        $refs = ilObject::_getAllReferences($a_id);
+        $refs = ilObject::_getAllReferences((int) $a_id);
         $ref_ref_id = end($refs);
         $ref = ilObjectFactory::getInstanceByRefId($ref_ref_id, false);
 
@@ -74,14 +73,15 @@ abstract class ilContainerReferenceExporter extends ilXmlExporter
      */
     public function getValidSchemaVersions(string $a_entity) : array
     {
-        return array(
-            "4.3.0" => array(
+        return [
+            "4.3.0" => [
                 "namespace" => "https://www.ilias.de/Modules/CategoryReference/catr/4_3",
                 "xsd_file" => "ilias_catr_4_3.xsd",
                 "uses_dataset" => false,
                 "min" => "4.3.0",
-                "max" => "")
-        );
+                "max" => ""
+            ]
+        ];
     }
 
     public function init() : void

--- a/Services/ContainerReference/classes/class.ilContainerReferenceGUI.php
+++ b/Services/ContainerReference/classes/class.ilContainerReferenceGUI.php
@@ -26,7 +26,7 @@ class ilContainerReferenceGUI extends ilObjectGUI
 
     protected ilTabsGUI $tabs;
     protected ilErrorHandling $error;
-    protected array $existing_objects = array();
+    protected array $existing_objects = [];
 
     protected string $target_type;
     protected string $reference_type;
@@ -62,7 +62,7 @@ class ilContainerReferenceGUI extends ilObjectGUI
         $ilCtrl = $this->ctrl;
         $ilTabs = $this->tabs;
 
-        if ($this->cont_request->getCreationMode() == self::MODE_CREATE) {
+        if ($this->cont_request->getCreationMode() === self::MODE_CREATE) {
             $this->setCreationMode(true);
         }
 
@@ -84,7 +84,7 @@ class ilContainerReferenceGUI extends ilObjectGUI
                 break;
 
             default:
-                if (!$cmd || $cmd == 'view') {
+                if ($cmd === null || $cmd === '' || $cmd === 'view') {
                     $cmd = "edit";
                 }
                 $cmd .= "Object";
@@ -133,7 +133,7 @@ class ilContainerReferenceGUI extends ilObjectGUI
     {
         $ilAccess = $this->access;
         
-        if ($this->cont_request->getTargetId() == 0) {
+        if ($this->cont_request->getTargetId() === 0) {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('select_one'));
             $this->createObject();
             return;
@@ -160,9 +160,9 @@ class ilContainerReferenceGUI extends ilObjectGUI
     {
         $target_obj_id = ilObject::_lookupObjId((int) $this->form->getInput('target_id'));
         $new_object->setTargetId($target_obj_id);
+        $new_object->setTitleType((int) $this->form->getInput('title_type'));
 
-        $new_object->setTitleType($this->form->getInput('title_type'));
-        if ($this->form->getInput('title_type') == ilContainerReference::TITLE_TYPE_CUSTOM) {
+        if ((int) $this->form->getInput('title_type') === ilContainerReference::TITLE_TYPE_CUSTOM) {
             $new_object->setTitle($this->form->getInput('title'));
         }
 
@@ -200,11 +200,11 @@ class ilContainerReferenceGUI extends ilObjectGUI
         $main_tpl->setContent($form->getHTML());
     }
     
-    protected function initForm($a_mode = self::MODE_EDIT) : ilPropertyFormGUI
+    protected function initForm(int $a_mode = self::MODE_EDIT) : ilPropertyFormGUI
     {
         $form = new ilPropertyFormGUI();
 
-        if ($a_mode == self::MODE_CREATE) {
+        if ($a_mode === self::MODE_CREATE) {
             $form->setTitle($this->lng->txt($this->getReferenceType() . '_new'));
 
             $this->ctrl->setParameter($this, 'creation_mode', $a_mode);
@@ -218,7 +218,7 @@ class ilContainerReferenceGUI extends ilObjectGUI
         }
 
         $form->setFormAction($this->ctrl->getFormAction($this));
-        if ($a_mode == self::MODE_CREATE) {
+        if ($a_mode === self::MODE_CREATE) {
             $form->addCommandButton('save', $this->lng->txt('create'));
             $form->addCommandButton('cancel', $this->lng->txt('cancel'));
         } else {
@@ -227,18 +227,18 @@ class ilContainerReferenceGUI extends ilObjectGUI
 
         // title type
         $ttype = new ilRadioGroupInputGUI($this->lng->txt('title'), 'title_type');
-        if ($a_mode == self::MODE_EDIT) {
+        if ($a_mode === self::MODE_EDIT) {
             $ttype->setValue($this->object->getTitleType());
         } else {
-            $ttype->setValue(ilContainerReference::TITLE_TYPE_REUSE);
+            $ttype->setValue((string) ilContainerReference::TITLE_TYPE_REUSE);
         }
 
         $reuse = new ilRadioOption($this->lng->txt('objref_reuse_title'));
-        $reuse->setValue(ilContainerReference::TITLE_TYPE_REUSE);
+        $reuse->setValue((string) ilContainerReference::TITLE_TYPE_REUSE);
         $ttype->addOption($reuse);
         
         $custom = new ilRadioOption($this->lng->txt('objref_custom_title'));
-        $custom->setValue(ilContainerReference::TITLE_TYPE_CUSTOM);
+        $custom->setValue((string) ilContainerReference::TITLE_TYPE_CUSTOM);
         
         // title
         $title = new ilTextInputGUI($this->lng->txt('title'), 'title');
@@ -246,7 +246,7 @@ class ilContainerReferenceGUI extends ilObjectGUI
         $title->setMaxLength(ilObject::TITLE_LENGTH);
         $title->setRequired(true);
 
-        if ($a_mode == self::MODE_EDIT) {
+        if ($a_mode === self::MODE_EDIT) {
             $title->setValue($this->object->getTitle());
         }
 
@@ -258,16 +258,16 @@ class ilContainerReferenceGUI extends ilObjectGUI
         $repo = new ilRepositorySelector2InputGUI($this->lng->txt("objref_edit_ref"), "target_id");
         //$repo->setParent($this);
         $repo->setRequired(true);
-        $repo->getExplorerGUI()->setSelectableTypes(array($this->getTargetType()));
+        $repo->getExplorerGUI()->setSelectableTypes([$this->getTargetType()]);
         $repo->getExplorerGUI()->setTypeWhiteList(
             array_merge(
-                array($this->getTargetType()),
-                array("root", "cat", "grp", "fold", "crs")
+                [$this->getTargetType()],
+                ["root", "cat", "grp", "fold", "crs"]
             )
         );
         $repo->setInfo($this->lng->txt($this->getReferenceType() . '_edit_info'));
 
-        if ($a_mode == self::MODE_EDIT) {
+        if ($a_mode === self::MODE_EDIT) {
             $repo->getExplorerGUI()->setPathOpen($this->object->getTargetRefId());
             $repo->setValue($this->object->getTargetRefId());
         }
@@ -277,7 +277,7 @@ class ilContainerReferenceGUI extends ilObjectGUI
         return $form;
     }
 
-    protected function loadPropertiesFromSettingsForm(\ilPropertyFormGUI $form) : bool
+    protected function loadPropertiesFromSettingsForm(ilPropertyFormGUI $form) : bool
     {
         global $DIC;
 
@@ -285,7 +285,7 @@ class ilContainerReferenceGUI extends ilObjectGUI
         $access = $DIC->access();
 
         $this->object->setTitleType($form->getInput('title_type'));
-        if ($form->getInput('title_type') == ilContainerReference::TITLE_TYPE_CUSTOM) {
+        if ((int) $form->getInput('title_type') === ilContainerReference::TITLE_TYPE_CUSTOM) {
             $this->object->setTitle($form->getInput('title'));
         }
 
@@ -297,7 +297,7 @@ class ilContainerReferenceGUI extends ilObjectGUI
             $form->getItemByPostVar('target_id')->setAlert($this->lng->txt('permission_denied'));
         }
         // check target type
-        if (ilObject::_lookupType($form->getInput('target_id'), true) != $this->target_type) {
+        if (ilObject::_lookupType($form->getInput('target_id'), true) !== $this->target_type) {
             $ok = false;
             $form->getItemByPostVar('target_id')->setAlert(
                 $this->lng->txt('objref_failure_target_type') .
@@ -307,7 +307,7 @@ class ilContainerReferenceGUI extends ilObjectGUI
         }
 
         $this->object->setTargetId(
-            \ilObject::_lookupObjId((int) $form->getInput('target_id'))
+            ilObject::_lookupObjId((int) $form->getInput('target_id'))
         );
 
         return $ok;
@@ -352,15 +352,15 @@ class ilContainerReferenceGUI extends ilObjectGUI
             $this->tabs_gui->addTarget(
                 "settings",
                 $this->ctrl->getLinkTarget($this, "edit"),
-                array(),
+                [],
                 ""
             );
         }
         if ($this->access->checkAccess('edit_permission', '', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "perm_settings",
-                $this->ctrl->getLinkTargetByClass(array(get_class($this),'ilpermissiongui'), "perm"),
-                array("perm","info","owner"),
+                $this->ctrl->getLinkTargetByClass([get_class($this), 'ilpermissiongui'], "perm"),
+                ["perm", "info", "owner"],
                 'ilpermissiongui'
             );
         }

--- a/Services/ContainerReference/classes/class.ilContainerReferenceImporter.php
+++ b/Services/ContainerReference/classes/class.ilContainerReferenceImporter.php
@@ -37,8 +37,8 @@ abstract class ilContainerReferenceImporter extends ilXmlImporter
      * Get reference type
      */
     abstract protected function getType() : string;
-    
-    abstract protected function initParser($a_xml) : ilContainerReferenceXmlParser;
+
+    abstract protected function initParser(string $a_xml) : ilContainerReferenceXmlParser;
     
     protected function getReference() : ilContainerReference
     {
@@ -56,23 +56,20 @@ abstract class ilContainerReferenceImporter extends ilXmlImporter
         $objDefinition = $DIC["objDefinition"];
         $log = $DIC->logger()->root();
 
-        include_once './Modules/Category/classes/class.ilObjCategory.php';
         if ($new_id = $a_mapping->getMapping('Services/Container', 'objs', $a_id)) {
-            $refs = ilObject::_getAllReferences($new_id);
+            $refs = ilObject::_getAllReferences((int) $new_id);
             $this->initReference(end($refs));
         }
         // Mapping for containers without subitems
         elseif ($new_id = $a_mapping->getMapping('Services/Container', 'refs', 0)) {
-            $this->initReference($new_id);
+            $this->initReference((int) $new_id);
         } elseif (!$this->getReference() instanceof ilContainerReference) {
             $this->initReference();
             $this->getReference()->create();
         }
 
         try {
-            /**
-             * @var $parser ilContainerReferenceXmlParser
-             */
+            /** @var ilContainerReferenceXmlParser $parser */
             $parser = $this->initParser($a_xml);
             $parser->setImportMapping($a_mapping);
             $parser->setReference($this->getReference());
@@ -83,7 +80,7 @@ abstract class ilContainerReferenceImporter extends ilXmlImporter
                 $objDefinition->getComponentForType($this->getType()),
                 $this->getType(),
                 $a_id,
-                $this->getReference()->getId()
+                (string) $this->getReference()->getId()
             );
         } catch (ilSaxParserException | Exception $e) {
             $log->error(__METHOD__ . ': Parsing failed with message, "' . $e->getMessage() . '".');

--- a/Services/ContainerReference/classes/class.ilContainerReferenceXmlParser.php
+++ b/Services/ContainerReference/classes/class.ilContainerReferenceXmlParser.php
@@ -38,7 +38,7 @@ class ilContainerReferenceXmlParser extends ilSaxParser
 
         parent::__construct(null);
 
-        $this->mode = ilContainerReferenceXmlParser::MODE_CREATE;
+        $this->mode = self::MODE_CREATE;
         $this->setXMLContent($a_xml);
 
         $this->logger = $DIC->logger()->exp();
@@ -61,7 +61,12 @@ class ilContainerReferenceXmlParser extends ilSaxParser
         xml_set_character_data_handler($a_xml_parser, 'handlerCharacterData');
     }
 
-
+    /**
+     * @param XMLParser|resource $a_xml_parser
+     * @param string $a_name
+     * @param array $a_attribs
+     * @return void
+     */
     public function handlerBeginTag(
         $a_xml_parser,
         string $a_name,
@@ -96,7 +101,7 @@ class ilContainerReferenceXmlParser extends ilSaxParser
 
     protected function parseTargetId(string $attribute_target) : int
     {
-        if (!strlen($attribute_target)) {
+        if ($attribute_target === '') {
             $this->logger->debug('No target id provided');
             return 0;
         }
@@ -111,7 +116,11 @@ class ilContainerReferenceXmlParser extends ilSaxParser
         return $obj_mapping_id;
     }
 
-
+    /**
+     * @param XMLParser|resource $a_xml_parser
+     * @param string $a_name
+     * @return void
+     */
     public function handlerEndTag(
         $a_xml_parser,
         string $a_name
@@ -122,7 +131,7 @@ class ilContainerReferenceXmlParser extends ilSaxParser
                 break;
 
             case 'Title':
-                if ($this->getReference()->getTitleType() == ilContainerReference::TITLE_TYPE_CUSTOM) {
+                if ($this->getReference()->getTitleType() === ilContainerReference::TITLE_TYPE_CUSTOM) {
                     $this->getReference()->setTitle(trim($this->cdata));
                 }
                 break;
@@ -130,13 +139,15 @@ class ilContainerReferenceXmlParser extends ilSaxParser
         $this->cdata = '';
     }
 
+    /**
+     * @param XMLParser|resource $a_xml_parser
+     * @param string $a_data
+     * @return void
+     */
     public function handlerCharacterData(
         $a_xml_parser,
         string $a_data
     ) : void {
-        #$a_data = str_replace("<","&lt;",$a_data);
-        #$a_data = str_replace(">","&gt;",$a_data);
-
         if (!empty($a_data)) {
             $this->cdata .= $a_data;
         }
@@ -148,7 +159,7 @@ class ilContainerReferenceXmlParser extends ilSaxParser
 
     protected function save() : void
     {
-        if ($this->mode == ilCategoryXmlParser::MODE_CREATE) {
+        if ($this->mode === ilCategoryXmlParser::MODE_CREATE) {
             $this->create();
             $this->getReference()->create();
             $this->getReference()->createReference();
@@ -169,7 +180,7 @@ class ilContainerReferenceXmlParser extends ilSaxParser
         $this->ref = $ref;
     }
 
-    public function getReference() : ?\ilContainerReference
+    public function getReference() : ?ilContainerReference
     {
         return $this->ref;
     }

--- a/Services/ContainerReference/classes/class.ilContainerReferenceXmlWriter.php
+++ b/Services/ContainerReference/classes/class.ilContainerReferenceXmlWriter.php
@@ -54,7 +54,7 @@ class ilContainerReferenceXmlWriter extends ilXmlWriter
 
     public function export(bool $a_with_header = true) : void
     {
-        if ($this->getMode() == self::MODE_EXPORT) {
+        if ($this->getMode() === self::MODE_EXPORT) {
             if ($a_with_header) {
                 $this->buildHeader();
             }
@@ -81,21 +81,21 @@ class ilContainerReferenceXmlWriter extends ilXmlWriter
     
     protected function buildTarget() : void
     {
-        $this->xmlElement('Target', array('id' => $this->getReference()->getTargetId()));
+        $this->xmlElement('Target', ['id' => $this->getReference()->getTargetId()]);
     }
     
     protected function buildTitle() : void
     {
         $title = '';
-        if ($this->getReference()->getTitleType() == ilContainerReference::TITLE_TYPE_CUSTOM) {
+        if ($this->getReference()->getTitleType() === ilContainerReference::TITLE_TYPE_CUSTOM) {
             $title = $this->getReference()->getTitle();
         }
         
         $this->xmlElement(
             'Title',
-            array(
+            [
                     'type' => $this->getReference()->getTitleType()
-                ),
+            ],
             $title
         );
     }

--- a/Services/ContainerReference/classes/class.ilContainerSelectionExplorer.php
+++ b/Services/ContainerReference/classes/class.ilContainerSelectionExplorer.php
@@ -64,12 +64,11 @@ class ilContainerSelectionExplorer extends ilExplorer
     public function isClickable(string $a_type, $a_ref_id = 0) : bool
     {
         $ilAccess = $this->access;
-        
-        if ($this->getTargetType() == $a_type) {
-            if ($ilAccess->checkAccess('visible', '', $a_ref_id)) {
-                return true;
-            }
+
+        if ($this->getTargetType() === $a_type && $ilAccess->checkAccess('visible', '', $a_ref_id)) {
+            return true;
         }
+
         return false;
     }
 
@@ -84,12 +83,12 @@ class ilContainerSelectionExplorer extends ilExplorer
     {
         $lng = $this->lng;
 
-        $tpl = new ilTemplate("tpl.tree.html", true, true, "Services/UIComponent/Explorer");
+        $tpl = new ilTemplate("tpl.tree.html", true, true, "Services/UIComponent/Explorer");// TODO PHP8-REVIEW Why is this overwritten? Are you sure this is correct?
 
         $tpl->setCurrentBlock("text");
         $tpl->setVariable("OBJ_TITLE", $lng->txt("repository"));
         $tpl->parseCurrentBlock();
 
-        $this->output[] = $tpl->get();
+        $this->output[] = $tpl->get();// TODO PHP8-REVIEW `$this->output` is a string, so this operator (`[]`) is not supported
     }
 }

--- a/Services/ContainerReference/test/ContRefStandardGUIRequestTest.php
+++ b/Services/ContainerReference/test/ContRefStandardGUIRequestTest.php
@@ -9,13 +9,6 @@ use PHPUnit\Framework\TestCase;
  */
 class ContRefStandardGUIRequestTest extends TestCase
 {
-    //protected $backupGlobals = false;
-
-    protected function setUp() : void
-    {
-        parent::setUp();
-    }
-
     protected function tearDown() : void
     {
     }
@@ -37,7 +30,7 @@ class ContRefStandardGUIRequestTest extends TestCase
     /**
      * Test ref id
      */
-    public function testRefId()
+    public function testRefId() : void
     {
         $request = $this->getRequest(
             [
@@ -55,7 +48,7 @@ class ContRefStandardGUIRequestTest extends TestCase
     /**
      * Test no ref id
      */
-    public function testNoRefId()
+    public function testNoRefId() : void
     {
         $request = $this->getRequest(
             [
@@ -72,7 +65,7 @@ class ContRefStandardGUIRequestTest extends TestCase
     /**
      * Test target id
      */
-    public function testTargetId()
+    public function testTargetId() : void
     {
         $request = $this->getRequest(
             [
@@ -90,7 +83,7 @@ class ContRefStandardGUIRequestTest extends TestCase
     /**
      * Test new type
      */
-    public function testNewType()
+    public function testNewType() : void
     {
         $request = $this->getRequest(
             [
@@ -108,7 +101,7 @@ class ContRefStandardGUIRequestTest extends TestCase
     /**
      * Test creation mode
      */
-    public function testCreationMode()
+    public function testCreationMode() : void
     {
         $request = $this->getRequest(
             [

--- a/Services/ContainerReference/test/ilServicesContainerReferenceSuite.php
+++ b/Services/ContainerReference/test/ilServicesContainerReferenceSuite.php
@@ -22,7 +22,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilServicesContainerReferenceSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new self();
 

--- a/Services/Repository/Administration/class.ilAdminSubItemsTableGUI.php
+++ b/Services/Repository/Administration/class.ilAdminSubItemsTableGUI.php
@@ -31,7 +31,7 @@ class ilAdminSubItemsTableGUI extends ilTable2GUI
     protected ClipboardManager $clipboard;
 
     public function __construct(
-        object $a_parent_obj,
+        object $a_parent_obj,// TODO PHP8-REVIEW Maybe it is worth to add the specific GUI class or a list of classes via PHPDoc comments
         string $a_parent_cmd,
         int $a_ref_id,
         bool $editable = false
@@ -74,36 +74,29 @@ class ilAdminSubItemsTableGUI extends ilTable2GUI
         $this->setDefaultOrderDirection("asc");
         
         // TODO: Needs other solution
-        if (ilObject::_lookupType($a_ref_id, true) == 'chac') {
+        if (ilObject::_lookupType($a_ref_id, true) === 'chac') {
             $this->getItems();
             return;
         }
-        
 
-        if (ilObject::_lookupType($a_ref_id, true) != "recf") {
+        if (ilObject::_lookupType($a_ref_id, true) !== "recf") {
             if ($this->clipboard->hasEntries()) {
                 if ($this->isEditable()) {
                     $this->addCommandButton("paste", $lng->txt("paste"));
                     $this->addCommandButton("clear", $lng->txt("clear"));
                 }
-            } else {
-                if ($this->isEditable()) {
-                    $this->addMultiCommand("cut", $lng->txt("cut"));
-                    $this->addMultiCommand("delete", $lng->txt("delete"));
-                    $this->addMultiCommand("link", $lng->txt("link"));
-                }
+            } elseif ($this->isEditable()) {
+                $this->addMultiCommand("cut", $lng->txt("cut"));
+                $this->addMultiCommand("delete", $lng->txt("delete"));
+                $this->addMultiCommand("link", $lng->txt("link"));
             }
-        } else {
-            if ($this->clipboard->hasEntries()) {
-                if ($this->isEditable()) {
-                    $this->addCommandButton("clear", $lng->txt("clear"));
-                }
-            } else {
-                if ($this->isEditable()) {
-                    $this->addMultiCommand("cut", $lng->txt("cut"));
-                    $this->addMultiCommand("removeFromSystem", $lng->txt("btn_remove_system"));
-                }
+        } elseif ($this->clipboard->hasEntries()) {
+            if ($this->isEditable()) {
+                $this->addCommandButton("clear", $lng->txt("clear"));
             }
+        } elseif ($this->isEditable()) {
+            $this->addMultiCommand("cut", $lng->txt("cut"));
+            $this->addMultiCommand("removeFromSystem", $lng->txt("btn_remove_system"));
         }
         $this->getItems();
     }
@@ -119,7 +112,7 @@ class ilAdminSubItemsTableGUI extends ilTable2GUI
         $objDefinition = $this->obj_definition;
         $tree = $this->tree;
         
-        $items = array();
+        $items = [];
         $childs = $tree->getChilds($this->ref_id);
         foreach ($childs as $key => $val) {
             // visible
@@ -133,7 +126,7 @@ class ilAdminSubItemsTableGUI extends ilTable2GUI
             }
             
             // don't show administration in root node list
-            if ($val["type"] == "adm") {
+            if ($val["type"] === "adm") {
                 continue;
             }
             if (!$this->parent_obj->isVisible($val["ref_id"], $val["type"])) {
@@ -150,13 +143,11 @@ class ilAdminSubItemsTableGUI extends ilTable2GUI
         $objDefinition = $this->obj_definition;
         $ilCtrl = $this->ctrl;
 
-        //		$this->tpl->setVariable("", );
-        
         // surpress checkbox for particular object types AND the system role
         if (!$objDefinition->hasCheckbox($a_set["type"]) ||
-            $a_set["obj_id"] == SYSTEM_ROLE_ID ||
-            $a_set["obj_id"] == SYSTEM_USER_ID ||
-            $a_set["obj_id"] == ANONYMOUS_ROLE_ID) {
+            (int) $a_set["obj_id"] === SYSTEM_ROLE_ID ||
+            (int) $a_set["obj_id"] === SYSTEM_USER_ID ||
+            (int) $a_set["obj_id"] === ANONYMOUS_ROLE_ID) {
             $this->tpl->touchBlock("no_checkbox");
         } else {
             $this->tpl->setCurrentBlock("checkbox");
@@ -173,21 +164,19 @@ class ilAdminSubItemsTableGUI extends ilTable2GUI
                     
         // TODO: broken! fix me
         $title = $a_set["title"];
-        if ($this->clipboard->hasEntries()) {
-            if (in_array($a_set["ref_id"], $this->clipboard->getRefIds())) {
-                switch ($this->clipboard->getCmd()) {
-                    case "cut":
-                        $title = "<del>" . $title . "</del>";
-                        break;
-    
-                    case "copy":
-                        $title = "<font color=\"green\">+</font>  " . $title;
-                        break;
-                            
-                    case "link":
-                        $title = "<font color=\"black\"><</font> " . $title;
-                        break;
-                }
+        if ($this->clipboard->hasEntries() && in_array($a_set["ref_id"], $this->clipboard->getRefIds())) {
+            switch ($this->clipboard->getCmd()) {
+                case "cut":
+                    $title = "<del>" . $title . "</del>";
+                    break;
+
+                case "copy":
+                    $title = "<font color=\"green\">+</font>  " . $title;
+                    break;
+                        
+                case "link":
+                    $title = "<font color=\"black\"><</font> " . $title;
+                    break;
             }
         }
         $this->tpl->setVariable("VAL_TITLE", $title);

--- a/Services/Repository/Administration/class.ilModulesTableGUI.php
+++ b/Services/Repository/Administration/class.ilModulesTableGUI.php
@@ -27,7 +27,7 @@ class ilModulesTableGUI extends ilTable2GUI
     protected ilComponentRepository $component_repository;
     
     public function __construct(
-        object $a_parent_obj,
+        object $a_parent_obj,// TODO PHP8-REVIEW Maybe you can use the class of the consuming GUI or (if there are several) add a list of valid types by using PHPDoc comments
         string $a_parent_cmd = "",
         bool $a_has_write = false
     ) {
@@ -79,18 +79,18 @@ class ilModulesTableGUI extends ilTable2GUI
         $lng = $this->lng;
         
         // unassigned objects should be last
-        $this->pos_group_options = array(0 => $lng->txt("rep_new_item_group_unassigned"));
+        $this->pos_group_options = [0 => $lng->txt("rep_new_item_group_unassigned")];
         $pos_group_map[0] = "9999";
         
         foreach (ilObjRepositorySettings::getNewItemGroups() as $item) {
             // #12807
-            if ($item["type"] == ilObjRepositorySettings::NEW_ITEM_GROUP_TYPE_GROUP) {
+            if ((int) $item["type"] === ilObjRepositorySettings::NEW_ITEM_GROUP_TYPE_GROUP) {
                 $this->pos_group_options[$item["id"]] = $item["title"];
                 $pos_group_map[$item["id"]] = $item["pos"];
             }
         }
                 
-        $obj_types = array();
+        $obj_types = [];
         
         // parse modules
         foreach ($this->component_repository->getComponents() as $mod) {
@@ -98,9 +98,11 @@ class ilModulesTableGUI extends ilTable2GUI
                 continue;
             }
             $has_repo = false;
-            $rep_types =
-                $objDefinition->getRepositoryObjectTypesForComponent(ilComponentInfo::TYPE_MODULES, $mod->getName());
-            if (sizeof($rep_types) > 0) {
+            $rep_types = $objDefinition::getRepositoryObjectTypesForComponent(
+                ilComponentInfo::TYPE_MODULES,
+                $mod->getName()
+            );
+            if (count($rep_types) > 0) {
                 foreach ($rep_types as $ridx => $rt) {
                     // we only want to display repository modules
                     if ($rt["repository"]) {
@@ -112,13 +114,13 @@ class ilModulesTableGUI extends ilTable2GUI
             }
             if ($has_repo) {
                 foreach ($rep_types as $rt) {
-                    $obj_types[$rt["id"]] = array(
+                    $obj_types[$rt["id"]] = [
                         "object" => $rt["class_name"],
                         "caption" => $lng->txt("obj_" . $rt["id"]),
                         "subdir" => $mod->getName(),
                         "grp" => $rt["grp"],
                         "default_pos" => $rt["default_pos"]
-                    );
+                    ];
                 }
             }
         }
@@ -128,7 +130,7 @@ class ilModulesTableGUI extends ilTable2GUI
         $obj_types = $this->getPluginComponents($obj_types, ilComponentInfo::TYPE_MODULES, "OrgUnit", "orguext");
 
         // parse positions
-        $data = array();
+        $data = [];
         foreach ($obj_types as $obj_type => $item) {
             $org_pos = $ilSetting->get("obj_add_new_pos_" . $obj_type);
             if (!(int) $org_pos) {
@@ -148,18 +150,18 @@ class ilModulesTableGUI extends ilTable2GUI
                 $group = $group["name"];
             }
 
-            $data[] = array(
+            $data[] = [
                 "id" => $obj_type,
                 "object" => $item["object"],
                 "caption" => $item["caption"],
                 "subdir" => $item["subdir"],
                 "pos" => (int) substr($org_pos, 4),
                 "pos_group" => $pos_grp_id,
-                "creation" => !(bool) $ilSetting->get("obj_dis_creation_" . $obj_type, false),
+                "creation" => !$ilSetting->get("obj_dis_creation_" . $obj_type, false),
                 "group_id" => $item["grp"],
                 "group" => $group,
                 "sort_key" => (int) $org_pos
-            );
+            ];
         }
         
         $data = ilArrayUtil::sortArray($data, "sort_key", "asc", true);
@@ -169,7 +171,7 @@ class ilModulesTableGUI extends ilTable2GUI
     
     protected function fillRow(array $a_set) : void
     {
-        if ($a_set["pos_group"] != $this->old_grp_id) {
+        if ((int) $a_set["pos_group"] !== $this->old_grp_id) {
             $this->tpl->setCurrentBlock("pos_grp_bl");
             $this->tpl->setVariable("TXT_POS_GRP", $this->pos_group_options[$a_set["pos_group"]]);
             $this->tpl->parseCurrentBlock();
@@ -177,7 +179,7 @@ class ilModulesTableGUI extends ilTable2GUI
             $this->tpl->setCurrentBlock("tbl_content");
             $this->tpl->parseCurrentBlock();
             
-            $this->css_row = ($this->css_row != "tblrow1")
+            $this->css_row = ($this->css_row !== "tblrow1")
                     ? "tblrow1"
                     : "tblrow2";
             $this->tpl->setVariable("CSS_ROW", $this->css_row);
@@ -237,13 +239,13 @@ class ilModulesTableGUI extends ilTable2GUI
         $lng = $this->lng;
         $plugins = $this->component_repository->getPluginSlotById($slotId)->getActivePlugins();
         foreach ($plugins as $plugin) {
-            $obj_types[$plugin->getId()] = array(
+            $obj_types[$plugin->getId()] = [
                 "object" => $plugin->getName(),
                 "caption" => ilObjectPlugin::lookupTxtById($plugin->getId(), "obj_" . $plugin->getId()),
                 "subdir" => $lng->txt("cmps_plugin"),
                 "grp" => "",
                 "default_pos" => 2000
-            );
+            ];
         }
         return $obj_types;
     }

--- a/Services/Repository/Administration/class.ilNewItemGroupTableGUI.php
+++ b/Services/Repository/Administration/class.ilNewItemGroupTableGUI.php
@@ -21,10 +21,10 @@
 class ilNewItemGroupTableGUI extends ilTable2GUI
 {
     protected bool $has_write;
-    protected \ilGlobalTemplateInterface $main_tpl;
+    protected ilGlobalTemplateInterface $main_tpl;
     
     public function __construct(
-        object $a_parent_obj,
+        object $a_parent_obj,// TODO PHP8-REVIEW Maybe you can use the class of the consuming GUI or (if there are several) add a list of valid types by using PHPDoc comments
         string $a_parent_cmd = "",
         bool $a_has_write = false
     ) {
@@ -73,26 +73,26 @@ class ilNewItemGroupTableGUI extends ilTable2GUI
     {
         $lng = $this->lng;
         
-        $data = array();
+        $data = [];
                 
         $subitems = ilObjRepositorySettings::getNewItemGroupSubItems();
         
         if ($subitems[0]) {
             $this->main_tpl->setOnScreenMessage('info', sprintf(
                 $lng->txt("rep_new_item_group_unassigned_subitems"),
-                is_array($subitems[0]) ? sizeof($subitems[0]) : 0
+                is_array($subitems[0]) ? count($subitems[0]) : 0
             ));
             unset($subitems[0]);
         }
         
         foreach (ilObjRepositorySettings::getNewItemGroups() as $item) {
-            $data[] = array(
+            $data[] = [
                 "id" => $item["id"],
                 "pos" => $item["pos"],
                 "title" => $item["title"],
                 "type" => $item["type"],
-                "subitems" => is_array($subitems[$item["id"]]) ? sizeof($subitems[$item["id"]]) : 0
-            );
+                "subitems" => is_array($subitems[$item["id"]]) ? count($subitems[$item["id"]]) : 0
+            ];
         }
         
         $data = ilArrayUtil::sortArray($data, "pos", "asc", true);
@@ -114,7 +114,7 @@ class ilNewItemGroupTableGUI extends ilTable2GUI
         $this->tpl->setVariable("VAL_POS", $a_set["pos"]);
         $this->tpl->setVariable("TXT_TITLE", $a_set["title"]);
         
-        if ($a_set["type"] == ilObjRepositorySettings::NEW_ITEM_GROUP_TYPE_GROUP) {
+        if ((int) $a_set["type"] === ilObjRepositorySettings::NEW_ITEM_GROUP_TYPE_GROUP) {
             $this->tpl->setVariable("VAL_ITEMS", $a_set["subitems"]);
 
             if ($this->has_write) {

--- a/Services/Repository/Administration/class.ilObjRepositorySettings.php
+++ b/Services/Repository/Administration/class.ilObjRepositorySettings.php
@@ -107,7 +107,7 @@ class ilObjRepositorySettings extends ilObject
         if ($sub_items) {
             foreach ($sub_items as $obj_type) {
                 $old_pos = $ilSetting->get("obj_add_new_pos_" . $obj_type);
-                if (strlen($old_pos) == 8) {
+                if (strlen($old_pos) === 8) {
                     $new_pos = "9999" . substr($old_pos, 4);
                     $ilSetting->set("obj_add_new_pos_" . $obj_type, $new_pos);
                     $ilSetting->set("obj_add_new_pos_grp_" . $obj_type, 0);
@@ -131,12 +131,12 @@ class ilObjRepositorySettings extends ilObject
         $def_lng = $lng->getDefaultLanguage();
         $usr_lng = $ilUser->getLanguage();
         
-        $res = array();
+        $res = [];
         
         $set = $ilDB->query("SELECT * FROM il_new_item_grp ORDER BY pos");
         while ($row = $ilDB->fetchAssoc($set)) {
-            if ($row["type"] == self::NEW_ITEM_GROUP_TYPE_GROUP) {
-                $row["titles"] = unserialize($row["titles"]);
+            if ((int) $row["type"] === self::NEW_ITEM_GROUP_TYPE_GROUP) {
+                $row["titles"] = unserialize($row["titles"], ["allowed_classes" => false]);
 
                 $title = $row["titles"][$usr_lng];
                 if (!$title) {
@@ -180,7 +180,7 @@ class ilObjRepositorySettings extends ilObject
         $component_repository = $DIC["component.repository"];
         $objDefinition = $DIC["objDefinition"];
         
-        $res = array();
+        $res = [];
         
         // parse modules
         foreach ($component_repository->getComponents() as $mod) {
@@ -189,7 +189,7 @@ class ilObjRepositorySettings extends ilObject
             }
             $has_repo = false;
             $rep_types = $objDefinition->getRepositoryObjectTypesForComponent(ilComponentInfo::TYPE_MODULES, $mod->getName());
-            if (sizeof($rep_types) > 0) {
+            if (count($rep_types) > 0) {
                 foreach ($rep_types as $ridx => $rt) {
                     // we only want to display repository modules
                     if ($rt["repository"]) {
@@ -221,10 +221,10 @@ class ilObjRepositorySettings extends ilObject
 
         $ilSetting = $DIC->settings();
         
-        $res = array();
+        $res = [];
         
         foreach (self::getAllObjTypes() as $type) {
-            $pos_grp = $ilSetting->get("obj_add_new_pos_grp_" . $type, 0);
+            $pos_grp = $ilSetting->get("obj_add_new_pos_grp_" . $type, '0');
             $res[$pos_grp][] = $type;
         }
         
@@ -237,18 +237,18 @@ class ilObjRepositorySettings extends ilObject
 
         $lng = $DIC->language();
         
-        $res = array();
+        $res = [];
                                 
-        $groups = array(
-            "organisation" => array("fold", "sess", "cat", "catr", "crs", "crsr", "grp", "grpr", "itgr", "book", "prg", "prgr"),
-            "communication" => array("frm", "chtr"),
+        $groups = [
+            "organisation" => ["fold", "sess", "cat", "catr", "crs", "crsr", "grp", "grpr", "itgr", "book", "prg", "prgr"],
+            "communication" => ["frm", "chtr"],
             "breaker1" => null,
-            "content" => array("file", "webr", "feed", "copa", "wiki", "blog", "lm", "htlm", "sahs", 'cmix', 'lti', "lso", "glo", "dcl", "bibl", "mcst", "mep"),
+            "content" => ["file", "webr", "feed", "copa", "wiki", "blog", "lm", "htlm", "sahs", 'cmix', 'lti', "lso", "glo", "dcl", "bibl", "mcst", "mep"],
             "breaker2" => null,
-            "assessment" => array("exc", "tst", "qpl", "iass"),
-            "feedback" => array("poll", "svy", "spl"),
-            "templates" => array("prtt")
-        );
+            "assessment" => ["exc", "tst", "qpl", "iass"],
+            "feedback" => ["poll", "svy", "spl"],
+            "templates" => ["prtt"]
+        ];
         
         $pos = 0;
         foreach ($groups as $group => $items) {
@@ -258,11 +258,13 @@ class ilObjRepositorySettings extends ilObject
             if (is_array($items)) {
                 $title = $lng->txt("rep_add_new_def_grp_" . $group);
                 
-                $res["groups"][$grp_id] = array("id" => $grp_id,
-                    "titles" => array($lng->getUserLanguage() => $title),
+                $res["groups"][$grp_id] = [
+                    "id" => $grp_id,
+                    "titles" => [$lng->getUserLanguage() => $title],
                     "pos" => $pos,
                     "type" => self::NEW_ITEM_GROUP_TYPE_GROUP,
-                    "title" => $title);
+                    "title" => $title
+                ];
 
                 foreach ($items as $idx => $item) {
                     $res["items"][$item] = $grp_id;
@@ -272,11 +274,13 @@ class ilObjRepositorySettings extends ilObject
             } else {
                 $title = "COL_SEP";
                 
-                $res["groups"][$grp_id] = array("id" => $grp_id,
-                    "titles" => array($lng->getUserLanguage() => $title),
+                $res["groups"][$grp_id] = [
+                    "id" => $grp_id,
+                    "titles" => [$lng->getUserLanguage() => $title],
                     "pos" => $pos,
                     "type" => self::NEW_ITEM_GROUP_TYPE_SEPARATOR,
-                    "title" => $title);
+                    "title" => $title
+                ];
             }
         }
         

--- a/Services/Repository/Administration/class.ilObjRepositorySettingsGUI.php
+++ b/Services/Repository/Administration/class.ilObjRepositorySettingsGUI.php
@@ -38,7 +38,7 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
 
         $this->error = $DIC["ilErr"];
         $this->access = $DIC->access();
-        $this->rbacsystem = $DIC->rbac()->system();
+        $this->rbacsystem = $DIC->rbac()->system();// TODO PHP8-REVIEW Property is declared dynamically
         $this->settings = $DIC->settings();
         $this->folder_settings = new ilSetting('fold');
         $this->ctrl = $DIC->ctrl();
@@ -153,10 +153,10 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
         $form->addItem($si);*/
 
         //
-        $options = array(
+        $options = [
             "" => $this->lng->txt("adm_rep_tree_only_container"),
             "tree" => $this->lng->txt("adm_all_resource_types")
-            );
+        ];
 
         // repository tree
         $radg = new ilRadioGroupInputGUI($this->lng->txt("adm_rep_tree_presentation"), "tree_pres");
@@ -273,7 +273,7 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
         $dl_prop = new ilCheckboxInputGUI($this->lng->txt("enable_download_folder"), "enable_download_folder");
         $dl_prop->setValue('1');
         // default value should reflect previous behaviour (-> 0)
-        $dl_prop->setChecked($this->folder_settings->get("enable_download_folder", 0) == 1);
+        $dl_prop->setChecked((int) $this->folder_settings->get("enable_download_folder", '0') === 1);
         $dl_prop->setInfo($this->lng->txt('enable_download_folder_info'));
         $form->addItem($dl_prop);
 
@@ -281,7 +281,7 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
         $dl_prop = new ilCheckboxInputGUI($this->lng->txt("enable_multi_download"), "enable_multi_download");
         $dl_prop->setValue('1');
         // default value should reflect previous behaviour (-> 0)
-        $dl_prop->setChecked($this->folder_settings->get("enable_multi_download", 0) == 1);
+        $dl_prop->setChecked((int) $this->folder_settings->get("enable_multi_download", '1') === 1);
         $dl_prop->setInfo($this->lng->txt('enable_multi_download_info'));
         $form->addItem($dl_prop);
 
@@ -419,11 +419,11 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
 
             $this->folder_settings->set(
                 "enable_download_folder",
-                $form->getInput("enable_download_folder") == 1
+                (int) $form->getInput("enable_download_folder") === 1
             );
             $this->folder_settings->set(
                 "enable_multi_download",
-                $form->getInput("enable_multi_download") == 1
+                (int) $form->getInput("enable_multi_download") === 1
             );
             if ($form->getInput('change_event_tracking')) {
                 ilChangeEvent::_activate();
@@ -491,7 +491,7 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
         $this->customIcons($form);
     }
     
-    protected function setModuleSubTabs($a_active) : void
+    protected function setModuleSubTabs($a_active) : void// TODO PHP8-REVIEW Type hint is missing
     {
         $this->tabs_gui->activateTab('modules');
         
@@ -533,18 +533,17 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
         $item_groups = $this->admin_gui_request->getNewItemGroups();
         $item_positions = $this->admin_gui_request->getNewItemPositions();
 
-        if (count($item_groups) == 0 ||
-            count($item_positions) == 0 ||
+        if (count($item_groups) === 0 || count($item_positions) === 0 ||
             !$ilAccess->checkAccess('write', '', $this->object->getRefId())) {
             $ilCtrl->redirect($this, "listModules");
         }
         
-        $grp_pos_map = array(0 => 9999);
+        $grp_pos_map = [0 => 9999];
         foreach (ilObjRepositorySettings::getNewItemGroups() as $item) {
             $grp_pos_map[$item["id"]] = $item["pos"];
         }
         
-        $type_pos_map = array();
+        $type_pos_map = [];
         $item_enablings = $this->admin_gui_request->getNewItemEnablings();
         foreach ($item_positions as $obj_type => $pos) {
             $grp_id = ($item_groups[$obj_type] ?? 0);
@@ -553,7 +552,7 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
             // enable creation?
             $ilSetting->set(
                 "obj_dis_creation_" . $obj_type,
-                !($item_enablings[$obj_type] ?? false)
+                (string) ((int) (!($item_enablings[$obj_type] ?? false)))// TODO PHP8-REVIEW The resolved type of `$item_enablings` is `int` / I guess you want an `'1'` or `'0'` here as a result
             );
         }
         
@@ -600,7 +599,7 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
         $this->tpl->setContent($grp_table->getHTML());
     }
     
-    protected function initNewItemGroupForm($a_grp_id = false) : ilPropertyFormGUI
+    protected function initNewItemGroupForm($a_grp_id = false) : ilPropertyFormGUI// TODO PHP8-REVIEW Type hint is missing
     {
         $this->setModuleSubTabs("new_item_groups");
         
@@ -616,7 +615,7 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
         $form->addItem($title);
         
         foreach ($this->lng->getInstalledLanguages() as $lang_id) {
-            if ($lang_id != $def_lng) {
+            if ($lang_id !== $def_lng) {
                 $title = new ilTextInputGUI($this->lng->txt("translation"), "title_" . $lang_id);
                 $title->setInfo($this->lng->txt("meta_l_" . $lang_id));
                 $form->addItem($title);
@@ -662,7 +661,7 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
     {
         $form = $this->initNewItemGroupForm();
         if ($form->checkInput()) {
-            $titles = array();
+            $titles = [];
             foreach ($this->lng->getInstalledLanguages() as $lang_id) {
                 $titles[$lang_id] = $form->getInput("title_" . $lang_id);
             }
@@ -703,7 +702,7 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
         
         $form = $this->initNewItemGroupForm($grp_id);
         if ($form->checkInput()) {
-            $titles = array();
+            $titles = [];
             foreach ($this->lng->getInstalledLanguages() as $lang_id) {
                 $titles[$lang_id] = $form->getInput("title_" . $lang_id);
             }
@@ -734,7 +733,7 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
         if (count($group_order) > 0) {
             ilObjRepositorySettings::updateNewItemGroupOrder($group_order);
                                     
-            $grp_pos_map = array();
+            $grp_pos_map = [];
             foreach (ilObjRepositorySettings::getNewItemGroups() as $item) {
                 $grp_pos_map[$item["id"]] = str_pad($item["pos"], 4, "0", STR_PAD_LEFT);
             }
@@ -745,7 +744,7 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
                 if ($grp_id) {
                     foreach ($subitems as $obj_type) {
                         $old_pos = $ilSetting->get("obj_add_new_pos_" . $obj_type);
-                        if (strlen($old_pos) == 8) {
+                        if (strlen($old_pos) === 8) {
                             $new_pos = $grp_pos_map[$grp_id] . substr($old_pos, 4);
                             $ilSetting->set("obj_add_new_pos_" . $obj_type, $new_pos);
                         }
@@ -761,7 +760,7 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
     protected function confirmDeleteNewItemGroup() : void
     {
         $group_ids = $this->admin_gui_request->getNewItemGroupIds();
-        if (count($group_ids) == 0) {
+        if (count($group_ids) === 0) {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt("select_one"));
             $this->listNewItemGroups();
             return;
@@ -788,7 +787,7 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
     protected function deleteNewItemGroup() : void
     {
         $group_ids = $this->admin_gui_request->getNewItemGroupIds();
-        if (count($group_ids) == 0) {
+        if (count($group_ids) === 0) {
             $this->listNewItemGroups();
             return;
         }
@@ -801,26 +800,28 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
         $this->ctrl->redirect($this, "listNewItemGroups");
     }
     
-    public function addToExternalSettingsForm($a_form_id) : ?array
+    public function addToExternalSettingsForm($a_form_id) : ?array// TODO PHP8-REVIEW Type hint is missing
     {
         $ilSetting = $this->settings;
         
         switch ($a_form_id) {
             case ilAdministrationSettingsFormHandler::FORM_LP:
                 
-                $fields = array('trac_show_repository_views' => array(ilChangeEvent::_isActive(), ilAdministrationSettingsFormHandler::VALUE_BOOL));
+                $fields = ['trac_show_repository_views' => [ilChangeEvent::_isActive(), ilAdministrationSettingsFormHandler::VALUE_BOOL]];
                                                 
-                return array(array("view", $fields));
+                return [["view", $fields]];
                 
                 
             case ilAdministrationSettingsFormHandler::FORM_TAGGING:
                 
-                $fields = array(
-                    'adm_show_comments_tagging_in_lists' => array($ilSetting->get('comments_tagging_in_lists'), ilAdministrationSettingsFormHandler::VALUE_BOOL,
-                        array('adm_show_comments_tagging_in_lists_tags' => array($ilSetting->get('comments_tagging_in_lists_tags'), ilAdministrationSettingsFormHandler::VALUE_BOOL))
-                ));
+                $fields = [
+                    'adm_show_comments_tagging_in_lists' => [
+                        $ilSetting->get('comments_tagging_in_lists'), ilAdministrationSettingsFormHandler::VALUE_BOOL,
+                        ['adm_show_comments_tagging_in_lists_tags' => [$ilSetting->get('comments_tagging_in_lists_tags'), ilAdministrationSettingsFormHandler::VALUE_BOOL]]
+                    ]
+                ];
                 
-                return array(array("view", $fields));
+                return [["view", $fields]];
         }
         return null;
     }

--- a/Services/Repository/Clipboard/class.ClipboardSessionRepository.php
+++ b/Services/Repository/Clipboard/class.ClipboardSessionRepository.php
@@ -69,7 +69,7 @@ class ClipboardSessionRepository
 
     public function hasEntries() : bool
     {
-        return (count($this->getRefIds()) > 0 && $this->getCmd() != "");
+        return (count($this->getRefIds()) > 0 && $this->getCmd() !== "");
     }
 
     public function clear() : void

--- a/Services/Repository/Favourites/classes/class.ilFavouritesDBRepository.php
+++ b/Services/Repository/Favourites/classes/class.ilFavouritesDBRepository.php
@@ -18,12 +18,13 @@
  */
 class ilFavouritesDBRepository
 {
+    /** @var array<string, bool>  */
     public static array $is_desktop_item = [];
     protected ilDBInterface $db;
     protected ilTree $tree;
 
     public function __construct(
-        \ilDBInterface $db = null,
+        ilDBInterface $db = null,
         ilTree $tree = null
     ) {
         global $DIC;
@@ -56,8 +57,8 @@ class ilFavouritesDBRepository
             $db->manipulateF(
                 "INSERT INTO desktop_item (item_id, type, user_id, parameters) VALUES " .
                 " (%s,%s,%s,%s)",
-                array("integer", "text", "integer", "text"),
-                array($ref_id,$type,$user_id,"")
+                ["integer", "text", "integer", "text"],
+                [$ref_id, $type, $user_id, ""]
             );
         }
     }
@@ -70,8 +71,8 @@ class ilFavouritesDBRepository
         $db->manipulateF(
             "DELETE FROM desktop_item WHERE " .
             " item_id = %s AND user_id = %s",
-            array("integer", "integer"),
-            array($ref_id, $user_id)
+            ["integer", "integer"],
+            [$ref_id, $user_id]
         );
     }
 
@@ -94,12 +95,12 @@ class ilFavouritesDBRepository
                 " WHERE " .
                 "it.item_id = oref.ref_id AND " .
                 "oref.obj_id = obj.obj_id AND " .
-                "it.user_id = %s", array("integer"), array($user_id));
-            $items = $all_parent_path = array();
+                "it.user_id = %s", ["integer"], [$user_id]);
+            $items = $all_parent_path = [];
             while ($item_rec = $ilDB->fetchAssoc($item_set)) {
-                if ($tree->isInTree($item_rec["ref_id"])
-                    && $item_rec["type"] != "rolf"
-                    && $item_rec["type"] != "itgr") {	// due to bug 11508
+                if ($item_rec["type"] !== "rolf" &&
+                    $item_rec["type"] !== "itgr" &&
+                    $tree->isInTree($item_rec["ref_id"])) { // due to bug 11508
                     $parent_ref = $tree->getParentId($item_rec["ref_id"]);
 
                     if (!isset($all_parent_path[$parent_ref])) {
@@ -116,18 +117,20 @@ class ilFavouritesDBRepository
                     $title = ilObject::_lookupTitle($item_rec["obj_id"]);
                     $desc = ilObject::_lookupDescription($item_rec["obj_id"]);
                     $items[$parent_path . $title . $item_rec["ref_id"]] =
-                        array("ref_id" => $item_rec["ref_id"],
+                        [
+                            "ref_id" => $item_rec["ref_id"],
                             "obj_id" => $item_rec["obj_id"],
                             "type" => $item_rec["type"],
                             "title" => $title,
                             "description" => $desc,
-                            "parent_ref" => $parent_ref);
+                            "parent_ref" => $parent_ref
+                        ];
                 }
             }
         } else {
-            $items = array();
+            $items = [];
             foreach ($a_types as $a_type) {
-                if ($a_type == "itgr") {
+                if ($a_type === "itgr") {
                     continue;
                 }
                 $item_set = $ilDB->queryF(
@@ -138,17 +141,19 @@ class ilFavouritesDBRepository
                     "it.type = %s AND " .
                     "it.user_id = %s " .
                     "ORDER BY title",
-                    array("text", "integer"),
-                    array($a_type, $user_id)
+                    ["text", "integer"],
+                    [$a_type, $user_id]
                 );
 
                 while ($item_rec = $ilDB->fetchAssoc($item_set)) {
                     $title = ilObject::_lookupTitle($item_rec["obj_id"]);
                     $desc = ilObject::_lookupDescription($item_rec["obj_id"]);
                     $items[$title . $a_type . $item_rec["ref_id"]] =
-                        array("ref_id" => $item_rec["ref_id"],
+                        [
+                            "ref_id" => $item_rec["ref_id"],
                             "obj_id" => $item_rec["obj_id"], "type" => $a_type,
-                            "title" => $title, "description" => $desc);
+                            "title" => $title, "description" => $desc
+                        ];
                 }
             }
         }
@@ -165,8 +170,8 @@ class ilFavouritesDBRepository
             $item_set = $db->queryF(
                 "SELECT item_id FROM desktop_item WHERE " .
                 "item_id = %s AND user_id = %s",
-                array("integer", "integer"),
-                array($ref_id, $user_id)
+                ["integer", "integer"],
+                [$ref_id, $user_id]
             );
 
             if ($db->fetchAssoc($item_set)) {

--- a/Services/Repository/Favourites/classes/class.ilFavouritesListGUI.php
+++ b/Services/Repository/Favourites/classes/class.ilFavouritesListGUI.php
@@ -72,9 +72,9 @@ class ilFavouritesListGUI
             )
             ]));
             return $this->ui->renderer()->render([$panel]);
-        } else {
-            $pdblock = new ilPDSelectedItemsBlockGUI();
-            return $pdblock->getNoItemFoundContent();
         }
+
+        $pdblock = new ilPDSelectedItemsBlockGUI();
+        return $pdblock->getNoItemFoundContent();
     }
 }

--- a/Services/Repository/PluginSlot/class.ilObjPluginDispatchGUI.php
+++ b/Services/Repository/PluginSlot/class.ilObjPluginDispatchGUI.php
@@ -48,7 +48,7 @@ class ilObjPluginDispatchGUI
         $next_class = $ilCtrl->getNextClass();
         $cmd_class = $ilCtrl->getCmdClass();
 
-        if ($cmd_class != "ilobjplugindispatchgui" && $cmd_class != "") {
+        if ($cmd_class !== "ilobjplugindispatchgui" && $cmd_class !== "" && $cmd_class !== null) {
             $class_path = $ilCtrl->lookupClassPath($next_class);
             include_once($class_path);
             $class_name = $ilCtrl->getClassForClasspath($class_path);
@@ -76,7 +76,7 @@ class ilObjPluginDispatchGUI
         $ilCtrl = $this->ctrl;
         
         $type = ilObject::_lookupType($this->request->getRefId(), true);
-        if ($type != "") {
+        if ($type !== "") {
             $plugin = ilObjectPlugin::getPluginObjectByType($type);
             if ($plugin) {
                 $gui_cn = "ilObj" . $plugin->getPluginName() . "GUI";

--- a/Services/Repository/PluginSlot/class.ilObjectPlugin.php
+++ b/Services/Repository/PluginSlot/class.ilObjectPlugin.php
@@ -21,7 +21,7 @@
 abstract class ilObjectPlugin extends ilObject2
 {
     protected ilPlugin $plugin;
-    protected static array $plugin_by_type = [];
+    protected static array $plugin_by_type = [];// TODO PHP8-REVIEW This seems to be unused
     protected ilComponentFactory $component_factory;
 
     public function __construct(int $a_ref_id = 0)
@@ -44,8 +44,7 @@ abstract class ilObjectPlugin extends ilObject2
         $component_factory = $DIC["component.factory"];
         try {
             return $component_factory->getPlugin($type);
-        }
-        catch (\InvalidArgumentException $e) {
+        } catch (InvalidArgumentException $e) {
             ilLoggerFactory::getLogger("obj")->log("There was an error while instantiating repo plugin obj of type: $type. Error: $e");
         }
         return null;
@@ -101,6 +100,6 @@ abstract class ilObjectPlugin extends ilObject2
         $pl = self::getPluginObjectByType($pluginId);
         $pl->loadLanguageModule();
 
-        return $lng->exists($pl->getPrefix() . "_" . $langVar);
+        return $lng->exists($pl->getPrefix() . "_" . $langVar);// TODO PHP8-REVIEW According to SCA the method `getPrefix` does not exists for all possible types of `$pl`
     }
 }

--- a/Services/Repository/PluginSlot/class.ilObjectPluginAccess.php
+++ b/Services/Repository/PluginSlot/class.ilObjectPluginAccess.php
@@ -31,17 +31,12 @@ class ilObjectPluginAccess extends ilObjectAccess
         $this->access = $DIC->access();
     }
 
-    public function _checkAccess(string $cmd, string $permission, int $ref_id, int $obj_id, ?int $user_id = null) : bool
-    {
-        return true;
-    }
-
     /**
     * check condition
     *
     * this method is called by ilConditionHandler
     */
-    public function _checkCondition($a_obj_id, $a_operator, $a_value, $a_usr_id = 0)
+    public function _checkCondition($a_obj_id, $a_operator, $a_value, $a_usr_id = 0)// TODO PHP8-REVIEW Missing type hints and return type declarations
     {
         return true;
     }
@@ -57,7 +52,7 @@ class ilObjectPluginAccess extends ilObjectAccess
         
         $t_arr = explode("_", $target);
 
-        if ($ilAccess->checkAccess("read", "", $t_arr[1])) {
+        if ($ilAccess->checkAccess("read", "", (int) $t_arr[1])) {
             return true;
         }
         return false;
@@ -66,6 +61,6 @@ class ilObjectPluginAccess extends ilObjectAccess
     // this is called by permission -> check permissions of user screen
     public static function _getCommands() : array
     {
-        return array();
+        return [];
     }
 }

--- a/Services/Repository/PluginSlot/class.ilObjectPluginGUI.php
+++ b/Services/Repository/PluginSlot/class.ilObjectPluginGUI.php
@@ -72,7 +72,7 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
             $tpl->setTitleIcon(ilObject::_getIcon($this->object->getId()));
 
             // set tabs
-            if (strtolower($this->slot_request->getBaseClass()) != "iladministrationgui") {
+            if (strtolower($this->slot_request->getBaseClass()) !== "iladministrationgui") {
                 $this->setTabs();
                 $this->setLocator();
             } else {
@@ -134,17 +134,16 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 
             case 'illearningprogressgui':
                 $user_id = $this->user->getId();
-                if ($this->access->checkAccess(
+                if ($this->slot_request->getUserId() > 0 && $this->access->checkAccess(
                     'write',
                     "",
                     $this->object->getRefId()
-                ) &&
-                    $this->slot_request->getUserId() > 0) {
+                )) {
                     $user_id = $this->slot_request->getUserId();
                 }
                 $ilTabs->setTabActive("learning_progress");
                 $new_gui = new ilLearningProgressGUI(
-                    ilLearningProgressGUI::LP_CONTEXT_REPOSITORY,
+                    ilLearningProgressBaseGUI::LP_CONTEXT_REPOSITORY,
                     $this->object->getRefId(),
                     $user_id
                 );
@@ -155,19 +154,19 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
                 $this->ctrl->forwardCommand($gui);
                 break;
             default:
-                if ($this->getCreationMode() || $cmd == "save") {
+                if ($cmd === "save" && $this->getCreationMode()) {
                     $this->$cmd();
                     return;
                 }
                 if (!$cmd) {
                     $cmd = $this->getStandardCmd();
                 }
-                if ($cmd == "infoScreen") {
+                if ($cmd === "infoScreen") {
                     $ilCtrl->setCmd("showSummary");
                     $ilCtrl->setCmdClass("ilinfoscreengui");
                     $this->infoScreen();
                 } else {
-                    $this->performCommand($cmd);
+                    $this->performCommand($cmd);// TODO PHP8-REVIEW This method does not exists, it should be made abstract or implemented with an empty body
                 }
                 break;
         }
@@ -232,7 +231,7 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
      */
     protected function initCreationForms(string $new_type) : array
     {
-        $forms = array();
+        $forms = [];
         $forms[self::CFORM_NEW] = $this->initCreateForm($new_type);
 
         if ($this->supportsExport()) {
@@ -327,7 +326,7 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
         $form->setTitle($this->lng->txt("import"));
 
         $fi = new ilFileInputGUI($this->lng->txt("import_file"), "importfile");
-        $fi->setSuffixes(array("zip"));
+        $fi->setSuffixes(["zip"]);
         $fi->setRequired(true);
         $form->addItem($fi);
 
@@ -345,7 +344,7 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 
         $ilCtrl->setTargetScript('ilias.php');
         $ilCtrl->setParameterByClass(get_class($this), "ref_id", $new_object->getRefId());
-        $ilCtrl->redirectByClass(array("ilobjplugindispatchgui", get_class($this)), $this->getAfterCreationCmd());
+        $ilCtrl->redirectByClass(["ilobjplugindispatchgui", get_class($this)], $this->getAfterCreationCmd());
     }
 
     /**
@@ -386,7 +385,7 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
             $ilTabs->addTarget(
                 "perm_settings",
                 $ilCtrl->getLinkTargetByClass("ilpermissiongui", "perm"),
-                array("perm", "info", "owner"),
+                ["perm", "info", "owner"],
                 'ilpermissiongui'
             );
         }
@@ -437,7 +436,7 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
     /**
      * Goto redirection
      */
-    public static function _goto($a_target)
+    public static function _goto($a_target) : void// TODO PHP8-REVIEW Missing type hint, but this might be an issue of the `goto.php` to be discussed with all code maintainers
     {
         global $DIC;
         $main_tpl = $DIC->ui()->mainTemplate();
@@ -453,11 +452,11 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
         if ($ilAccess->checkAccess("read", "", $ref_id)) {
             $ilCtrl->setTargetScript('ilias.php');
             $ilCtrl->setParameterByClass($class_name, "ref_id", $ref_id);
-            $ilCtrl->redirectByClass(array("ilobjplugindispatchgui", $class_name), "");
+            $ilCtrl->redirectByClass(["ilobjplugindispatchgui", $class_name], "");
         } elseif ($ilAccess->checkAccess("visible", "", $ref_id)) {
             $ilCtrl->setTargetScript('ilias.php');
             $ilCtrl->setParameterByClass($class_name, "ref_id", $ref_id);
-            $ilCtrl->redirectByClass(array("ilobjplugindispatchgui", $class_name), "infoScreen");
+            $ilCtrl->redirectByClass(["ilobjplugindispatchgui", $class_name], "infoScreen");
         } elseif ($ilAccess->checkAccess("read", "", ROOT_FOLDER_ID)) {
             $main_tpl->setOnScreenMessage('failure', sprintf(
                 $lng->txt("msg_no_perm_read_item"),
@@ -469,7 +468,7 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
 
     protected function supportsExport() : bool
     {
-        $component_repository = $this->component_repository;
+        $component_repository = $this->component_repository;// TODO PHP8-REVIEW This property does not exist
 
         return $component_repository->getPluginSlotById("robj")->getPluginByName($this->getPlugin()->getPluginName())->supportsExport();
     }

--- a/Services/Repository/PluginSlot/class.ilObjectPluginListGUI.php
+++ b/Services/Repository/PluginSlot/class.ilObjectPluginListGUI.php
@@ -23,6 +23,7 @@
 abstract class ilObjectPluginListGUI extends ilObjectListGUI
 {
     protected ilComponentFactory $component_factory;
+    protected ?ilObjectPlugin $plugin;
 
     public function __construct(int $a_context = self::CONTEXT_REPOSITORY)
     {
@@ -35,8 +36,6 @@ abstract class ilObjectPluginListGUI extends ilObjectListGUI
         $this->lng = $DIC->language();
         $this->user = $DIC->user();
     }
-
-    protected ?ilObjectPlugin $plugin;
 
     final public function init() : void
     {
@@ -77,7 +76,6 @@ abstract class ilObjectPluginListGUI extends ilObjectListGUI
     {
         return $this->plugin->txt($a_str);
     }
-    
 
     public function getCommandFrame(string $cmd) : string
     {

--- a/Services/Repository/PluginSlot/class.ilRepositoryObjectPlugin.php
+++ b/Services/Repository/PluginSlot/class.ilRepositoryObjectPlugin.php
@@ -97,7 +97,7 @@ abstract class ilRepositoryObjectPlugin extends ilPlugin
         // object database and that all permissions exist
         $type = $this->getId();
         
-        if (substr($type, 0, 1) != "x") {
+        if (strpos($type, "x") !== 0) {
             throw new ilPluginException("Object plugin type must start with an x. Current type is " . $type . ".");
         }
         
@@ -125,7 +125,7 @@ abstract class ilRepositoryObjectPlugin extends ilPlugin
 
         // add rbac operations
         // 1: edit_permissions, 2: visible, 3: read, 4:write, 6:delete
-        $ops = array(1, 2, 3, 4, 6);
+        $ops = [1, 2, 3, 4, 6];
         if ($this->allowCopy()) {
             $ops[] = ilRbacReview::_getOperationIdByName("copy");
         }
@@ -172,20 +172,18 @@ abstract class ilRepositoryObjectPlugin extends ilPlugin
                 " WHERE type = " . $ilDB->quote("typ", "text") .
                 " AND title = " . $ilDB->quote($par_type, "text")
             );
-            if ($rec = $ilDB->fetchAssoc($set)) {
-                if ($rec["obj_id"] > 0) {
-                    $set = $ilDB->query(
-                        "SELECT * FROM rbac_ta " .
-                        " WHERE typ_id = " . $ilDB->quote($rec["obj_id"], "integer") .
-                        " AND ops_id = " . $ilDB->quote($create_ops_id, "integer")
-                    );
-                    if (!$ilDB->fetchAssoc($set)) {
-                        $ilDB->manipulate("INSERT INTO rbac_ta " .
-                            "(typ_id, ops_id) VALUES (" .
-                            $ilDB->quote($rec["obj_id"], "integer") . "," .
-                            $ilDB->quote($create_ops_id, "integer") .
-                            ")");
-                    }
+            if (($rec = $ilDB->fetchAssoc($set)) && $rec["obj_id"] > 0) {
+                $set = $ilDB->query(
+                    "SELECT * FROM rbac_ta " .
+                    " WHERE typ_id = " . $ilDB->quote($rec["obj_id"], "integer") .
+                    " AND ops_id = " . $ilDB->quote($create_ops_id, "integer")
+                );
+                if (!$ilDB->fetchAssoc($set)) {
+                    $ilDB->manipulate("INSERT INTO rbac_ta " .
+                        "(typ_id, ops_id) VALUES (" .
+                        $ilDB->quote($rec["obj_id"], "integer") . "," .
+                        $ilDB->quote($create_ops_id, "integer") .
+                        ")");
                 }
             }
         }
@@ -221,7 +219,7 @@ abstract class ilRepositoryObjectPlugin extends ilPlugin
      */
     public function getParentTypes() : array
     {
-        $par_types = array("root", "cat", "crs", "grp", "fold");
+        $par_types = ["root", "cat", "crs", "grp", "fold"];
         return $par_types;
     }
 

--- a/Services/Repository/PluginSlot/class.ilRepositoryObjectPluginSlot.php
+++ b/Services/Repository/PluginSlot/class.ilRepositoryObjectPluginSlot.php
@@ -29,7 +29,7 @@ class ilRepositoryObjectPluginSlot
         $plugins = $component_repository->getPluginSlotById("robj")->getActivePlugins();
         foreach ($plugins as $plugin) {
             $pl_id = $plugin->getId();
-            $a_obj_array[$pl_id] = array("name" => $pl_id, "lng" => $pl_id, "plugin" => true);
+            $a_obj_array[$pl_id] = ["name" => $pl_id, "lng" => $pl_id, "plugin" => true];
         }
 
         return $a_obj_array;
@@ -69,8 +69,8 @@ class ilRepositoryObjectPluginSlot
         }
 
         $slot = $component_repository->getPluginSlotById("robj");
-        if ($slot->hasPluginName($pname)) {
-            $plugin = $slot->getPluginByName($pname);
+        if ($slot->hasPluginName($pname)) {// TODO PHP8-REVIEW `$pname` is undefined, maybe `$a_type` must be used instead
+            $plugin = $slot->getPluginByName($pname);// TODO PHP8-REVIEW `$pname` is undefined, maybe `$a_type` must be used instead
             if (!$a_active_status || $plugin->isActive()) {
                 if ($plugin->supportsLearningProgress()) {
                     return true;

--- a/Services/Repository/RecommendedContent/classes/class.ilDashboardRecommendedContentGUI.php
+++ b/Services/Repository/RecommendedContent/classes/class.ilDashboardRecommendedContentGUI.php
@@ -34,7 +34,7 @@ class ilDashboardRecommendedContentGUI
     protected ilFavouritesManager $fav_manager;
     protected ilObjectDefinition $objDefinition;
     protected int $requested_item_ref_id;
-    private \ilGlobalTemplateInterface $main_tpl;
+    private ilGlobalTemplateInterface $main_tpl;
 
     public function __construct()
     {
@@ -67,7 +67,7 @@ class ilDashboardRecommendedContentGUI
 
         switch ($next_class) {
             default:
-                if (in_array($cmd, array("remove", "makeFavourite"))) {
+                if (in_array($cmd, ["remove", "makeFavourite"])) {
                     $this->$cmd();
                 }
         }
@@ -75,7 +75,7 @@ class ilDashboardRecommendedContentGUI
 
     public function render() : string
     {
-        if (count($this->recommendations) == 0) {
+        if (count($this->recommendations) === 0) {
             return "";
         }
         return $this->ui->renderer()->render(
@@ -198,7 +198,6 @@ class ilDashboardRecommendedContentGUI
         return (clone self::$list_by_type[$a_type]);
     }
 
-    // Remove from list
     protected function remove() : void
     {
         $ctrl = $this->ctrl;

--- a/Services/Repository/RecommendedContent/classes/class.ilRecommendedContentDBRepository.php
+++ b/Services/Repository/RecommendedContent/classes/class.ilRecommendedContentDBRepository.php
@@ -31,7 +31,7 @@ class ilRecommendedContentDBRepository
 {
     protected ilDBInterface $db;
 
-    public function __construct(\ilDBInterface $db = null)
+    public function __construct(ilDBInterface $db = null)
     {
         global $DIC;
 
@@ -178,7 +178,7 @@ class ilRecommendedContentDBRepository
     /**
      * Get recommendations of roles
      *
-     * @param $role_ids int[] role ids
+     * @param int[] $role_ids
      * @return int[] ref ids of recommendations
      */
     public function getRecommendationsOfRoles(array $role_ids) : array
@@ -189,7 +189,8 @@ class ilRecommendedContentDBRepository
             "SELECT DISTINCT ref_id FROM rep_rec_content_role " .
             " WHERE " . $db->in("role_id", $role_ids, false, "integer")
         );
-        return array_column($db->fetchAll($set), "ref_id");
+
+        return array_map('intval', array_column($db->fetchAll($set), "ref_id"));
     }
     
     /**
@@ -206,7 +207,8 @@ class ilRecommendedContentDBRepository
             ["integer", "integer"],
             [$user_id, false]
         );
-        return array_column($db->fetchAll($set), "ref_id");
+
+        return array_map('intval', array_column($db->fetchAll($set), "ref_id"));
     }
 
     /**
@@ -223,9 +225,9 @@ class ilRecommendedContentDBRepository
             ["integer", "integer"],
             [$user_id, true]
         );
-        return array_column($db->fetchAll($set), "ref_id");
-    }
 
+        return array_map('intval', array_column($db->fetchAll($set), "ref_id"));
+    }
 
     /**
      * Open recommendations of user (by role or object, without declined ones)
@@ -244,8 +246,8 @@ class ilRecommendedContentDBRepository
 
         // filter declined recommendations
         $declined_recommendations = $this->getDeclinedUserObjectRecommendations($user_id);
-        return array_filter($recommendations, function ($i) use ($declined_recommendations) {
-            return !in_array($i, $declined_recommendations);
+        return array_filter($recommendations, static function (int $i) use ($declined_recommendations) : bool {
+            return !in_array($i, $declined_recommendations, true);
         });
     }
 }

--- a/Services/Repository/RecommendedContent/classes/class.ilRecommendedContentManager.php
+++ b/Services/Repository/RecommendedContent/classes/class.ilRecommendedContentManager.php
@@ -105,9 +105,9 @@ class ilRecommendedContentManager
         // filter out favourites
         $favourites = $this->fav_manager->getFavouritesOfUser($user_id);
         $favourites_ref_ids = array_column($favourites, "ref_id");
-
-        return array_filter($recommendations, function ($i) use ($favourites_ref_ids) {
-            return !in_array($i, $favourites_ref_ids);
+        
+        return array_filter($recommendations, static function (int $i) use ($favourites_ref_ids) : bool {
+            return !in_array($i, $favourites_ref_ids, true);
         });
     }
 

--- a/Services/Repository/RecommendedContent/classes/class.ilRecommendedContentRoleConfigGUI.php
+++ b/Services/Repository/RecommendedContent/classes/class.ilRecommendedContentRoleConfigGUI.php
@@ -77,8 +77,7 @@ class ilRecommendedContentRoleConfigGUI
         $main_tpl = $this->main_tpl;
         $ctrl = $this->ctrl;
 
-        if (!$rbacreview->isAssignable($this->role_id, $this->node_ref_id) &&
-            $this->node_ref_id != ROLE_FOLDER_ID) {
+        if ($this->node_ref_id !== ROLE_FOLDER_ID && !$rbacreview->isAssignable($this->role_id, $this->node_ref_id)) {
             $this->main_tpl->setOnScreenMessage('info', $this->lng->txt('rep_no_assign_rec_content_to_role'));
         } else {
             if ($rbacsystem->checkAccess('push_desktop_items', USER_FOLDER_ID)) {
@@ -103,7 +102,7 @@ class ilRecommendedContentRoleConfigGUI
 
         $main_tpl = $this->main_tpl;
 
-        if (count($this->requested_item_ref_ids) == 0) {
+        if (count($this->requested_item_ref_ids) === 0) {
             $this->main_tpl->setOnScreenMessage('failure', $this->lng->txt('select_one'));
             $this->listItems();
             return;

--- a/Services/Repository/RecommendedContent/classes/class.ilRecommendedContentRoleTableGUI.php
+++ b/Services/Repository/RecommendedContent/classes/class.ilRecommendedContentRoleTableGUI.php
@@ -30,7 +30,7 @@ class ilRecommendedContentRoleTableGUI extends ilTable2GUI
         ilRecommendedContentRoleConfigGUI $a_parent_obj,
         string $a_parent_cmd,
         int $role_id,
-        \ilRecommendedContentManager $manager
+        ilRecommendedContentManager $manager
     ) {
         global $DIC;
 

--- a/Services/Repository/Service/trait.BaseGUIRequest.php
+++ b/Services/Repository/Service/trait.BaseGUIRequest.php
@@ -45,7 +45,7 @@ trait BaseGUIRequest
         Refinery\Factory $refinery,
         ?array $passed_query_params = null,
         ?array $passed_post_data = null
-    ) {
+    ) : void {
         $this->http = $http;
         $this->refinery = $refinery;
         $this->passed_post_data = $passed_post_data;
@@ -53,9 +53,9 @@ trait BaseGUIRequest
     }
 
     // get integer parameter kindly
-    protected function int($key) : int
+    protected function int(string $key) : int
     {
-        if ($this->str($key) == "") {
+        if ($this->str($key) === "") {
             return 0;
         }
         $t = $this->refinery->kindlyTo()->int();
@@ -63,7 +63,7 @@ trait BaseGUIRequest
     }
 
     // get integer array kindly
-    protected function intArray($key) : array
+    protected function intArray(string $key) : array
     {
         if (!$this->isArray($key)) {
             return [];
@@ -73,7 +73,7 @@ trait BaseGUIRequest
                 // keep keys(!), transform all values to int
                 return array_column(
                     array_map(
-                        function ($k, $v) {
+                        static function ($k, $v) : array {
                             return [$k, (int) $v];
                         },
                         array_keys($arr),
@@ -88,14 +88,14 @@ trait BaseGUIRequest
     }
 
     // get string parameter kindly
-    protected function str($key) : string
+    protected function str(string $key) : string
     {
         $t = $this->refinery->kindlyTo()->string();
         return \ilUtil::stripSlashes((string) ($this->get($key, $t) ?? ""));
     }
 
     // get string array kindly
-    protected function strArray($key) : array
+    protected function strArray(string $key) : array
     {
         if (!$this->isArray($key)) {
             return [];
@@ -105,7 +105,7 @@ trait BaseGUIRequest
                 // keep keys(!), transform all values to string
                 return array_column(
                     array_map(
-                        function ($k, $v) {
+                        static function ($k, $v) : array {
                             if (is_array($v)) {
                                 $v = "";
                             }
@@ -123,7 +123,7 @@ trait BaseGUIRequest
     }
 
     // get string array kindly
-    protected function arrayArray($key) : array
+    protected function arrayArray(string $key) : array
     {
         if (!$this->isArray($key)) {
             return [];
@@ -133,7 +133,7 @@ trait BaseGUIRequest
                 // keep keys(!), transform all values to string
                 return array_column(
                     array_map(
-                        function ($k, $v) {
+                        static function ($k, $v) : array {
                             return [$k, (array) $v];
                         },
                         array_keys($arr),
@@ -176,7 +176,7 @@ trait BaseGUIRequest
     /**
      * @return mixed|null
      */
-    protected function raw($key)
+    protected function raw(string $key)
     {
         $no_transform = $this->refinery->custom()->transformation(function ($v) {
             return $v;

--- a/Services/Repository/Service/trait.GlobalDICDomainServices.php
+++ b/Services/Repository/Service/trait.GlobalDICDomainServices.php
@@ -39,7 +39,7 @@ trait GlobalDICDomainServices
     protected \ilSetting $settings;
     protected \ilObjectDefinition $object_definition;
 
-    protected function initDomainServices(\ILIAS\DI\Container $DIC)
+    protected function initDomainServices(\ILIAS\DI\Container $DIC) : void
     {
         $this->repo_tree = $DIC->repositoryTree();
         $this->access = $DIC->access();

--- a/Services/Repository/Service/trait.GlobalDICGUIServices.php
+++ b/Services/Repository/Service/trait.GlobalDICGUIServices.php
@@ -37,7 +37,7 @@ trait GlobalDICGUIServices
     protected \ilTabsGUI $tabs;
     protected \ilLocatorGUI $locator;
 
-    protected function initGUIServices(\ILIAS\DI\Container $DIC)
+    protected function initGUIServices(\ILIAS\DI\Container $DIC) : void
     {
         $this->ui = $DIC->ui();
         $this->object_service = $DIC->object();

--- a/Services/Repository/Trash/class.TrashGUIRequest.php
+++ b/Services/Repository/Trash/class.TrashGUIRequest.php
@@ -38,10 +38,10 @@ class TrashGUIRequest
             return $trash_ids;
         }
         $trash_ids = $this->str("trash_ids");
-        if ($trash_ids == "") {
+        if ($trash_ids === "") {
             return [];
-        } else {
-            return explode(",", $trash_ids);
         }
+
+        return explode(",", $trash_ids);
     }
 }

--- a/Services/Repository/Trash/class.ilRepDependenciesTableGUI.php
+++ b/Services/Repository/Trash/class.ilRepDependenciesTableGUI.php
@@ -52,11 +52,11 @@ class ilRepDependenciesTableGUI extends ilTable2GUI
         $this->disable("footer");
         $this->setEnableTitle(true);
 
-        $deps = array();
+        $deps = [];
         foreach ($a_deps as $id => $d) {
             foreach ($d as $id2 => $ms) {
                 foreach ($ms as $m) {
-                    $deps[] = array("dep_obj" => $id2, "del_obj" => $id, "message" => $m);
+                    $deps[] = ["dep_obj" => $id2, "del_obj" => $id, "message" => $m];
                 }
             }
         }

--- a/Services/Repository/Trash/class.ilRepUtil.php
+++ b/Services/Repository/Trash/class.ilRepUtil.php
@@ -57,7 +57,7 @@ class ilRepUtil
         $log = $ilLog;
         
         // Remove duplicate ids from array
-        $a_ids = array_unique((array) $a_ids);
+        $a_ids = array_unique($a_ids);
 
         // FOR ALL SELECTED OBJECTS
         $not_deletable = [];
@@ -77,7 +77,7 @@ class ilRepUtil
 
             // CHECK DELETE PERMISSION OF ALL OBJECTS
             foreach ($subtree_nodes as $node) {
-                if ($node['type'] == 'rolf') {
+                if ($node['type'] === 'rolf') {
                     continue;
                 }
                 if (!$rbacsystem->checkAccess('delete', $node["child"])) {
@@ -89,7 +89,7 @@ class ilRepUtil
 
         // IF THERE IS ANY OBJECT WITH NO PERMISSION TO DELETE
         if (is_array($not_deletable) && count($not_deletable) > 0) {
-            $not_deletable_titles = array();
+            $not_deletable_titles = [];
             foreach ($not_deletable as $key => $ref_id) {
                 $obj_id = ilObject::_lookupObjId($ref_id);
                 $not_deletable_titles[] = ilObject::_lookupTitle($obj_id);
@@ -106,56 +106,57 @@ class ilRepUtil
             // alex: this branch looks suspicious to me... I deactivate it for
             // now. Objects that aren't in the tree should overwrite this method.
             throw new ilRepositoryException($lng->txt("ilRepUtil::deleteObjects: Type information missing."));
-        } else {
-            // SAVE SUBTREE AND DELETE SUBTREE FROM TREE
-            $affected_ids = array();
-            $affected_parents = array();
-            foreach ($a_ids as $id) {
-                if ($tree->isDeleted($id)) {
-                    $log->write(__METHOD__ . ': Object with ref_id: ' . $id . ' already deleted.');
-                    throw new ilRepositoryException($lng->txt("msg_obj_already_deleted"));
-                }
-                
-                // DELETE OLD PERMISSION ENTRIES
-                $subnodes = $tree->getSubtree($tree->getNodeData($id));
+        }
 
-                foreach ($subnodes as $subnode) {
-                    $rbacadmin->revokePermission((int) $subnode["child"]);
-
-                    $affected_ids[$subnode["child"]] = $subnode["child"];
-                    $affected_parents[$subnode["child"]] = $subnode["parent"];
-                }
-                
-                // TODO: needs other handling
-                // This class shouldn't have to know anything about ECS
-                ilECSObjectSettings::_handleDelete($subnodes);
-                if (!$tree->moveToTrash($id, true, $user->getId())) {
-                    $log->write(__METHOD__ . ': Object with ref_id: ' . $id . ' already deleted.');
-                    throw new ilRepositoryException($lng->txt("msg_obj_already_deleted"));
-                }
-
-                // write log entry
-                $log->write("ilObjectGUI::confirmedDeleteObject(), moved ref_id " . $id .
-                    " to trash");
-                
-                $affected_ids[$id] = $id;
+        // SAVE SUBTREE AND DELETE SUBTREE FROM TREE
+        $affected_ids = [];
+        $affected_parents = [];
+        foreach ($a_ids as $id) {
+            if ($tree->isDeleted($id)) {
+                $log->write(__METHOD__ . ': Object with ref_id: ' . $id . ' already deleted.');
+                throw new ilRepositoryException($lng->txt("msg_obj_already_deleted"));
             }
             
-            // send global events
-            foreach ($affected_ids as $aid) {
-                $ilAppEventHandler->raise(
-                    "Services/Object",
-                    "toTrash",
-                    array( "obj_id" => ilObject::_lookupObjId($aid),
-                           "ref_id" => $aid,
-                           "old_parent_ref_id" => $affected_parents[$aid]
-                         )
-                );
+            // DELETE OLD PERMISSION ENTRIES
+            $subnodes = $tree->getSubtree($tree->getNodeData($id));
+
+            foreach ($subnodes as $subnode) {
+                $rbacadmin->revokePermission((int) $subnode["child"]);
+
+                $affected_ids[$subnode["child"]] = $subnode["child"];
+                $affected_parents[$subnode["child"]] = $subnode["parent"];
             }
+            
+            // TODO: needs other handling
+            // This class shouldn't have to know anything about ECS
+            ilECSObjectSettings::_handleDelete($subnodes);
+            if (!$tree->moveToTrash($id, true, $user->getId())) {
+                $log->write(__METHOD__ . ': Object with ref_id: ' . $id . ' already deleted.');
+                throw new ilRepositoryException($lng->txt("msg_obj_already_deleted"));
+            }
+
+            // write log entry
+            $log->write("ilObjectGUI::confirmedDeleteObject(), moved ref_id " . $id .
+                " to trash");
+            
+            $affected_ids[$id] = $id;
         }
-        
+
+        // send global events
+        foreach ($affected_ids as $aid) {
+            $ilAppEventHandler->raise(
+                "Services/Object",
+                "toTrash",
+                [
+                    "obj_id" => ilObject::_lookupObjId($aid),
+                    "ref_id" => $aid,
+                    "old_parent_ref_id" => $affected_parents[$aid]
+                ]
+            );
+        }
+
         if (!$ilSetting->get('enable_trash')) {
-            ilRepUtil::removeObjectsFromSystem($a_ids);
+            self::removeObjectsFromSystem($a_ids);
         }
     }
     
@@ -180,22 +181,23 @@ class ilRepUtil
 
         $log = $ilLog;
 
-        $affected_ids = array();
+        $affected_ids = [];
         
         // DELETE THEM
+        $a_ref_ids = array_map('intval', $a_ref_ids);
         foreach ($a_ref_ids as $id) {
             $saved_tree = null;
             // GET COMPLETE NODE_DATA OF ALL SUBTREE NODES
             if (!$a_from_recovery_folder) {
-                $trees = \ilTree::lookupTreesForNode($id);
+                $trees = ilTree::lookupTreesForNode($id);
                 $tree_id = end($trees);
 
                 if ($tree_id) {
-                    $saved_tree = new \ilTree((int) $tree_id);
+                    $saved_tree = new ilTree($tree_id);
                     $node_data = $saved_tree->getNodeData($id);
                     $subtree_nodes = $saved_tree->getSubTree($node_data);
                 } else {
-                    throw new \ilRepositoryException('No valid tree id found for node id: ' . $id);
+                    throw new ilRepositoryException('No valid tree id found for node id: ' . $id);
                 }
             } else {
                 $node_data = $tree->getNodeData($id);
@@ -217,13 +219,13 @@ class ilRepUtil
 
             // remember already checked deleted node_ids
             if (!$a_from_recovery_folder) {
-                $checked[] = -(int) $id;
+                $checked[] = -$id;
             } else {
                 $checked[] = $id;
             }
 
             // dive in recursive manner in each already deleted subtrees and remove these objects too
-            ilRepUtil::removeDeletedNodes($id, $checked, true, $affected_ids);
+            self::removeDeletedNodes($id, $checked, true, $affected_ids);
 
             foreach ($subtree_nodes as $node) {
                 if (!$node_obj = ilObjectFactory::getInstanceByRefId($node["ref_id"], false)) {
@@ -234,17 +236,18 @@ class ilRepUtil
                 $log->write("ilObjectGUI::removeFromSystemObject(), delete obj_id: " . $node_obj->getId() .
                     ", ref_id: " . $node_obj->getRefId() . ", type: " . $node_obj->getType() . ", " .
                     "title: " . $node_obj->getTitle());
-                $affected_ids[$node["ref_id"]] = array(
+                $affected_ids[$node["ref_id"]] = [
                                                     "ref_id" => $node["ref_id"],
                                                     "obj_id" => $node_obj->getId(),
                                                     "type" => $node_obj->getType(),
-                                                    "old_parent_ref_id" => $node["parent"]);
+                                                    "old_parent_ref_id" => $node["parent"]
+                ];
                     
                 // this is due to bug #1860 (even if this will not completely fix it)
                 // and the fact, that media pool folders may find their way into
                 // the recovery folder (what results in broken pools, if the are deleted)
                 // Alex, 2006-07-21
-                if (!$a_from_recovery_folder || $node_obj->getType() != "fold") {
+                if (!$a_from_recovery_folder || $node_obj->getType() !== "fold") {
                     $node_obj->delete();
                 }
             }
@@ -268,10 +271,12 @@ class ilRepUtil
             $ilAppEventHandler->raise(
                 "Services/Object",
                 "delete",
-                array("obj_id" => $aid["obj_id"],
-                "ref_id" => $aid["ref_id"],
-                "type" => $aid["type"],
-                "old_parent_ref_id" => $aid["old_parent_ref_id"])
+                [
+                    "obj_id" => $aid["obj_id"],
+                    "ref_id" => $aid["ref_id"],
+                    "type" => $aid["type"],
+                    "old_parent_ref_id" => $aid["old_parent_ref_id"]
+                ]
             );
         }
     }
@@ -304,11 +309,11 @@ class ilRepUtil
                 $deleted_tree = new ilTree($row->tree);
                 $a_checked[] = $row->tree;
 
-                $row->tree = $row->tree * (-1);
+                $row->tree *= (-1);
                 $del_node_data = $deleted_tree->getNodeData($row->tree);
                 $del_subtree_nodes = $deleted_tree->getSubTree($del_node_data);
 
-                ilRepUtil::removeDeletedNodes($row->tree, $a_checked, $a_delete_objects, $a_affected_ids);
+                self::removeDeletedNodes($row->tree, $a_checked, $a_delete_objects, $a_affected_ids);
             
                 if ($a_delete_objects) {
                     foreach ($del_subtree_nodes as $node) {
@@ -318,11 +323,12 @@ class ilRepUtil
                         $log->write("ilObjectGUI::removeDeletedNodes(), delete obj_id: " . $node_obj->getId() .
                             ", ref_id: " . $node_obj->getRefId() . ", type: " . $node_obj->getType() . ", " .
                             "title: " . $node_obj->getTitle());
-                        $a_affected_ids[$node["ref_id"]] = array(
+                        $a_affected_ids[$node["ref_id"]] = [
                                                             "ref_id" => $node["ref_id"],
                                                             "obj_id" => $node_obj->getId(),
                                                             "type" => $node_obj->getType(),
-                                                            "old_parent_ref_id" => $node["parent"]);
+                                                            "old_parent_ref_id" => $node["parent"]
+                        ];
                                                         
                         $node_obj->delete();
                     }
@@ -372,16 +378,16 @@ class ilRepUtil
             throw new ilRepositoryException($lng->txt("msg_no_perm_paste") . " " . implode(',', $no_create));
         }
         
-        $affected_ids = array();
+        $affected_ids = [];
         
         foreach ($a_ref_ids as $id) {
             $affected_ids[$id] = $id;
 
             // INSERT AND SET PERMISSIONS
             try {
-                $tree_ids = \ilTree::lookupTreesForNode($id);
+                $tree_ids = ilTree::lookupTreesForNode($id);
                 $tree_id = $tree_ids[0];
-                ilRepUtil::insertSavedNodes($id, $a_cur_ref_id, $tree_id, $affected_ids);
+                self::insertSavedNodes($id, $a_cur_ref_id, $tree_id, $affected_ids);
             } catch (Exception $e) {
                 throw new ilRepositoryException('Restore from trash failed with message: ' . $e->getMessage());
             }
@@ -412,7 +418,7 @@ class ilRepUtil
             $ilAppEventHandler->raise(
                 "Services/Object",
                 "undelete",
-                array("obj_id" => ilObject::_lookupObjId($id), "ref_id" => $id)
+                ["obj_id" => ilObject::_lookupObjId($id), "ref_id" => $id]
             );
         }
     }
@@ -445,8 +451,7 @@ class ilRepUtil
             throw $e;
         }
         
-        $factory = new ilObjectFactory();
-        $ref_obj = $factory->getInstanceByRefId($a_source_id, false);
+        $ref_obj = ilObjectFactory::getInstanceByRefId($a_source_id, false);
         if ($ref_obj instanceof ilObject) {
             $lroles = $GLOBALS['rbacreview']->getRolesOfRoleFolder($a_source_id, true);
             foreach ($lroles as $role_id) {
@@ -459,7 +464,7 @@ class ilRepUtil
             }
         }
         foreach ($childs as $child) {
-            ilRepUtil::insertSavedNodes($child["child"], $a_source_id, $a_tree_id, $a_affected_ids);
+            self::insertSavedNodes($child["child"], $a_source_id, $a_tree_id, $a_affected_ids);
         }
     }
     
@@ -474,7 +479,7 @@ class ilRepUtil
     ) : array {
         $ilDB = $this->db;
         
-        $res = array();
+        $res = [];
         
         $set = $ilDB->query("SELECT child" .
             " FROM tree" .
@@ -513,7 +518,7 @@ class ilRepUtil
         
         $ref_ids_in_tree = $tree->getSubTree($tree->getNodeData(ROOT_FOLDER_ID), false, [$a_type]);
         if ($ref_ids_in_tree) {
-            $this->deleteObjects(null, $ref_ids_in_tree);
+            self::deleteObjects(null, $ref_ids_in_tree);
         }
         
         if ($ilSetting->get('enable_trash')) {
@@ -553,7 +558,7 @@ class ilRepUtil
                     " WHERE ops_id = " . $ilDB->quote($create_ops_id, "integer"));
                 
                 // container create
-                foreach (array("root", "cat", "crs", "grp", "fold") as $parent_type) {
+                foreach (["root", "cat", "crs", "grp", "fold"] as $parent_type) {
                     $parent_type_id = $this->getObjectTypeId($parent_type);
                     if ($parent_type_id) {
                         $ilDB->manipulate("DELETE FROM rbac_ta" .

--- a/Services/Repository/Trash/class.ilTrashTableGUI.php
+++ b/Services/Repository/Trash/class.ilTrashTableGUI.php
@@ -28,7 +28,7 @@ class ilTrashTableGUI extends ilTable2GUI
     private array $current_filter = [];
 
     public function __construct(
-        object $a_parent_obj,
+        object $a_parent_obj,// TODO PHP8-REVIEW Maybe you can use the class of the consuming GUI or (if there are several) add a list of valid types by using PHPDoc comments
         string $a_parent_cmd,
         int $ref_id
     ) {
@@ -51,7 +51,7 @@ class ilTrashTableGUI extends ilTable2GUI
     {
         $this->setTitle(
             $this->lng->txt('rep_trash_table_title') . ' "' .
-            \ilObject::_lookupTitle(\ilObject::_lookupObjId($this->ref_id)) . '" '
+            ilObject::_lookupTitle(ilObject::_lookupObjId($this->ref_id)) . '" '
         );
 
         $this->addColumn('', '', 1, 1);
@@ -90,14 +90,14 @@ class ilTrashTableGUI extends ilTable2GUI
     {
         $this->setDefaultFilterVisiblity(true);
 
-        $type = new \ilMultiSelectInputGUI(
+        $type = new ilMultiSelectInputGUI(
             $this->lng->txt('type'),
             'type'
         );
 
-        $type = $this->addFilterItemByMetaType(
+        $type = $this->addFilterItemByMetaType(// TODO PHP8-REVIEW `$type` is overwritten here
             'type',
-            \ilTable2GUI::FILTER_SELECT,
+            ilTable2GUI::FILTER_SELECT,
             false,
             $this->lng->txt('type')
         );
@@ -106,7 +106,7 @@ class ilTrashTableGUI extends ilTable2GUI
 
         $title = $this->addFilterItemByMetaType(
             'title',
-            \ilTable2GUI::FILTER_TEXT,
+            ilTable2GUI::FILTER_TEXT,
             false,
             $this->lng->txt('title')
         );
@@ -114,7 +114,7 @@ class ilTrashTableGUI extends ilTable2GUI
 
         $deleted_by = $this->addFilterItemByMetaType(
             'deleted_by',
-            \ilTable2GUI::FILTER_TEXT,
+            ilTable2GUI::FILTER_TEXT,
             false,
             $this->lng->txt('rep_trash_table_col_deleted_by')
         );
@@ -122,7 +122,7 @@ class ilTrashTableGUI extends ilTable2GUI
 
         $deleted = $this->addFilterItemByMetaType(
             'deleted',
-            \ilTable2GUI::FILTER_DATE_RANGE,
+            ilTable2GUI::FILTER_DATE_RANGE,
             false,
             $this->lng->txt('rep_trash_table_col_deleted_on')
         );
@@ -135,7 +135,7 @@ class ilTrashTableGUI extends ilTable2GUI
 
         $max_trash_entries = 0;
 
-        $trash_tree_reader = new \ilTreeTrashQueries();
+        $trash_tree_reader = new ilTreeTrashQueries();
         $items = $trash_tree_reader->getTrashNodeForContainer(
             $this->ref_id,
             $this->current_filter,
@@ -157,7 +157,7 @@ class ilTrashTableGUI extends ilTable2GUI
             $row['description'] = $item->getDescription();
             $row['deleted_by_id'] = $item->getDeletedBy();
             $row['deleted_by'] = $this->lng->txt('rep_trash_deleted_by_unknown');
-            if ($login = \ilObjUser::_lookupLogin($row['deleted_by_id'])) {
+            if ($login = ilObjUser::_lookupLogin($row['deleted_by_id'])) {
                 $row['deleted_by'] = $login;
             }
             $row['deleted'] = $item->getDeleted();
@@ -174,7 +174,7 @@ class ilTrashTableGUI extends ilTable2GUI
     {
         $this->tpl->setVariable('ID', $a_set['id']);
         $this->tpl->setVariable('VAL_TITLE', $a_set['title']);
-        if (strlen(trim($a_set['description']))) {
+        if (trim($a_set['description']) !== '') {
             $this->tpl->setCurrentBlock('with_desc');
             $this->tpl->setVariable('VAL_DESC', $a_set['description']);
             $this->tpl->parseCurrentBlock();
@@ -186,14 +186,14 @@ class ilTrashTableGUI extends ilTable2GUI
         $this->tpl->setVariable('PATH', $path->getPath($this->ref_id, $a_set['id']));
         $this->tpl->parseCurrentBlock();
 
-        $img = \ilObject::_getIcon(
+        $img = ilObject::_getIcon(
             (int) $a_set['obj_id'],
             'small',
             $a_set['type']
         );
-        if (strlen($img)) {
+        if ($img !== '') {
             $alt = ($this->obj_definition->isPlugin($a_set['type']))
-                ? $this->lng->txt('icon') . ' ' . \ilObjectPlugin::lookupTxtById($a_set['type'], 'obj_' . $a_set['type'])
+                ? $this->lng->txt('icon') . ' ' . ilObjectPlugin::lookupTxtById($a_set['type'], 'obj_' . $a_set['type'])
                 : $this->lng->txt('icon') . ' ' . $this->lng->txt('obj_' . $a_set['type'])
             ;
             $this->tpl->setVariable('IMG_PATH', $img);
@@ -202,23 +202,23 @@ class ilTrashTableGUI extends ilTable2GUI
 
         $this->tpl->setVariable('VAL_DELETED_BY', $a_set['deleted_by']);
 
-        $dt = new \ilDateTime($a_set['deleted'], IL_CAL_DATETIME);
-        $this->tpl->setVariable('VAL_DELETED_ON', \ilDatePresentation::formatDate($dt));
+        $dt = new ilDateTime($a_set['deleted'], IL_CAL_DATETIME);
+        $this->tpl->setVariable('VAL_DELETED_ON', ilDatePresentation::formatDate($dt));
         $this->tpl->setVariable('VAL_SUBS', (string) (int) $a_set['num_subs']);
     }
 
     protected function prepareTypeFilterTypes() : array
     {
-        $trash = new \ilTreeTrashQueries();
+        $trash = new ilTreeTrashQueries();
         $subs = $trash->getTrashedNodeTypesForContainer($this->ref_id);
 
 
         $options = [];
         foreach ($subs as $type) {
-            if ($type == 'rolf') {
+            if ($type === 'rolf') {
                 continue;
             }
-            if ($type == 'root') {
+            if ($type === 'root') {
                 continue;
             }
 

--- a/Services/Repository/TreeValidator/class.ilValidator.php
+++ b/Services/Repository/TreeValidator/class.ilValidator.php
@@ -45,10 +45,12 @@ class ilValidator
      * inconsistencies as well.
      * Werner, 2007-04-16
      */
-    public array $object_types_exclude = array("adm","root","mail","usrf","objf","lngf",
-        "trac","taxf","auth","rolf","assf","svyf","extt","adve","fold");
+    public array $object_types_exclude = [
+        "adm", "root", "mail", "usrf", "objf", "lngf",
+        "trac", "taxf", "auth", "rolf", "assf", "svyf", "extt", "adve", "fold"
+    ];
 
-    public array $mode = array(
+    public array $mode = [
                         "scan" => true,		// gather information about corrupted entries
                         "dump_tree" => false,		// dump tree
                         "clean" => false,		// remove all unusable entries & renumber tree
@@ -56,7 +58,7 @@ class ilValidator
                         "purge" => false,		// delete all objects with invalid parent from system
                         "restore_trash" => false,		// restore all objects in trash to RecoveryFolder
                         "purge_trash" => false		// delete all objects in trash from system
-                    );
+    ];
 
     public array $invalid_references = [];
     public array $invalid_childs = [];
@@ -74,7 +76,7 @@ class ilValidator
     /**
      * contains correct registrated objects but data are corrupted (experimental)
      */
-    public array $invalid_objects = array();
+    public array $invalid_objects = [];
     public bool $logging = false;    // true enables scan log
     public ?ilLog $scan_log = null;
     public string $scan_log_file = "scanlog.log";
@@ -133,12 +135,12 @@ class ilValidator
      */
     public function setMode(string $a_mode, bool $a_value) : bool
     {
-        if ((!in_array($a_mode, array_keys($this->mode)) and $a_mode != "all") or !is_bool($a_value)) {
+        if ((!array_key_exists($a_mode, $this->mode) && $a_mode !== "all") || !is_bool($a_value)) {
             $this->throwError(INVALID_PARAM, FATAL, DEBUG);
             return false;
         }
         
-        if ($a_mode == "all") {
+        if ($a_mode === "all") {
             foreach ($this->mode as $mode => $value) {
                 $this->mode[$mode] = $a_value;
             }
@@ -155,7 +157,7 @@ class ilValidator
     public function isModeEnabled(
         string $a_mode
     ) : bool {
-        if (!in_array($a_mode, array_keys($this->mode))) {
+        if (!array_key_exists($a_mode, $this->mode)) {
             $this->throwError(VALIDATER_UNKNOWN_MODE, WARNING, DEBUG);
             return false;
         }
@@ -343,12 +345,10 @@ class ilValidator
 
         if (!$this->isModeEnabled("restore_trash")) {
             $summary .= $lng->txt("disabled");
+        } elseif ($this->restoreTrash()) {
+            $summary .= strtolower($lng->txt("done"));
         } else {
-            if ($this->restoreTrash()) {
-                $summary .= strtolower($lng->txt("done"));
-            } else {
-                $summary .= $lng->txt("nothing_to_restore") . $lng->txt("skipped");
-            }
+            $summary .= $lng->txt("nothing_to_restore") . $lng->txt("skipped");
         }
         
         // STEP 6: Purging...
@@ -377,12 +377,10 @@ class ilValidator
         
         if (!$this->isModeEnabled("purge_trash")) {
             $summary .= $lng->txt("disabled");
+        } elseif ($this->purgeTrash()) {
+            $summary .= strtolower($lng->txt("done"));
         } else {
-            if ($this->purgeTrash()) {
-                $summary .= strtolower($lng->txt("done"));
-            } else {
-                $summary .= $lng->txt("nothing_to_purge") . $lng->txt("skipped");
-            }
+            $summary .= $lng->txt("nothing_to_purge") . $lng->txt("skipped");
         }
         
         // STEP 8: Initialize gaps in tree
@@ -419,7 +417,7 @@ class ilValidator
         }
         
         // init
-        $this->missing_objects = array();
+        $this->missing_objects = [];
     
         $this->writeScanLogLine("\nfindMissingObjects:");
         
@@ -441,7 +439,7 @@ class ilValidator
         while ($row = $r->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             #if (!in_array($row->type,$this->object_types_exclude))
             if (!$this->isExcludedFromRecovery($row->type, $row->obj_id)) {
-                $this->missing_objects[] = array(
+                $this->missing_objects[] = [
                                                     "obj_id" => $row->obj_id,
                                                     "type" => $row->type,
                                                     "ref_id" => $row->ref_id,
@@ -451,7 +449,7 @@ class ilValidator
                                                     "owner" => $row->owner,
                                                     "create_date" => $row->create_date,
                                                     "last_update" => $row->last_update
-                                                );
+                ];
             }
         }
         
@@ -483,7 +481,7 @@ class ilValidator
         }
         
         // init
-        $this->invalid_rolefolders = array();
+        $this->invalid_rolefolders = [];
         
         $this->writeScanLogLine("\nfindInvalidRolefolders:");
 
@@ -496,7 +494,7 @@ class ilValidator
         $r = $this->db->query($q);
         
         while ($row = $r->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $this->invalid_rolefolders[] = array(
+            $this->invalid_rolefolders[] = [
                                                 "obj_id" => $row->obj_id,
                                                 "type" => $row->type,
                                                 "ref_id" => $row->ref_id,
@@ -506,7 +504,7 @@ class ilValidator
                                                 "owner" => $row->owner,
                                                 "create_date" => $row->create_date,
                                                 "last_update" => $row->last_update
-                                            );
+            ];
         }
         
         // find rolfs within RECOVERY FOLDER
@@ -518,7 +516,7 @@ class ilValidator
         $r = $this->db->query($q);
         
         while ($row = $r->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $this->invalid_rolefolders[] = array(
+            $this->invalid_rolefolders[] = [
                                                 "obj_id" => $row->obj_id,
                                                 "type" => $row->type,
                                                 "ref_id" => $row->ref_id,
@@ -528,7 +526,7 @@ class ilValidator
                                                 "owner" => $row->owner,
                                                 "create_date" => $row->create_date,
                                                 "last_update" => $row->last_update
-                                            );
+            ];
         }
             
         $this->filterWorkspaceObjects($this->invalid_rolefolders);
@@ -557,7 +555,7 @@ class ilValidator
         }
         
         // init
-        $this->invalid_rbac_entries = array();
+        $this->invalid_rbac_entries = [];
         
         $this->writeScanLogLine("\nfindInvalidRBACEntries:");
 
@@ -569,7 +567,7 @@ class ilValidator
         $r = $this->db->query($q);
         
         while ($row = $r->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $this->invalid_rolefolders[] = array(
+            $this->invalid_rolefolders[] = [
                                                 "obj_id" => $row->obj_id,
                                                 "type" => $row->type,
                                                 "ref_id" => $row->ref_id,
@@ -579,7 +577,7 @@ class ilValidator
                                                 "owner" => $row->owner,
                                                 "create_date" => $row->create_date,
                                                 "last_update" => $row->last_update
-                                            );
+            ];
         }
         
         // find rolfs within RECOVERY FOLDER
@@ -591,7 +589,7 @@ class ilValidator
         $r = $this->db->query($q);
         
         while ($row = $r->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $this->invalid_rolefolders[] = array(
+            $this->invalid_rolefolders[] = [
                                                 "obj_id" => $row->obj_id,
                                                 "type" => $row->type,
                                                 "ref_id" => $row->ref_id,
@@ -601,7 +599,7 @@ class ilValidator
                                                 "owner" => $row->owner,
                                                 "create_date" => $row->create_date,
                                                 "last_update" => $row->last_update
-                                            );
+            ];
         }
             
         $this->filterWorkspaceObjects($this->invalid_rolefolders);
@@ -643,7 +641,7 @@ class ilValidator
         }
 
         // init
-        $this->invalid_references = array();
+        $this->invalid_references = [];
         
         $this->writeScanLogLine("\nfindInvalidReferences:");
         $q = "SELECT object_reference.* FROM object_reference " .
@@ -653,11 +651,11 @@ class ilValidator
         $r = $this->db->query($q);
 
         while ($row = $r->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $this->invalid_references[] = array(
+            $this->invalid_references[] = [
                                             "ref_id" => $row->ref_id,
                                             "obj_id" => $row->obj_id,
                                             "msg" => "Object does not exist."
-                                            );
+            ];
         }
 
         $this->filterWorkspaceObjects($this->invalid_references);
@@ -692,7 +690,7 @@ class ilValidator
         }
 
         // init
-        $this->invalid_childs = array();
+        $this->invalid_childs = [];
 
         $this->writeScanLogLine("\nfindInvalidChilds:");
 
@@ -702,11 +700,11 @@ class ilValidator
              "WHERE object_reference.ref_id IS NULL or object_data.obj_id IS NULL";
         $r = $this->db->query($q);
         while ($row = $r->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $this->invalid_childs[] = array(
+            $this->invalid_childs[] = [
                                             "child" => $row->child,
                                             "ref_id" => $row->ref_id,
                                             "msg" => "No object found"
-                                            );
+            ];
         }
 
         if (count($this->invalid_childs) > 0) {
@@ -742,7 +740,7 @@ class ilValidator
         }
 
         // init
-        $this->unbound_objects = array();
+        $this->unbound_objects = [];
 
         $this->writeScanLogLine("\nfindUnboundObjects:");
 
@@ -756,12 +754,12 @@ class ilValidator
         while ($row = $r->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             // exclude deleted nodes
             if ($row->deleted === null) {
-                $this->unbound_objects[] = array(
+                $this->unbound_objects[] = [
                                                 "child" => $row->child,
                                                 "parent" => $row->parent,
                                                 "tree" => $row->tree,
                                                 "msg" => "No valid parent node found"
-                                                );
+                ];
             }
         }
 
@@ -790,7 +788,7 @@ class ilValidator
         }
 
         // init
-        $this->deleted_objects = array();
+        $this->deleted_objects = [];
 
         $this->writeScanLogLine("\nfindDeletedObjects:");
 
@@ -806,7 +804,7 @@ class ilValidator
         while ($row = $r->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             $tmp_date = new ilDateTime($row->deleted, IL_CAL_DATETIME);
             
-            $this->deleted_objects[] = array(
+            $this->deleted_objects[] = [
                                             "child" => $row->child,
                                             "parent" => $row->parent,
                                             "tree" => $row->tree,
@@ -818,11 +816,11 @@ class ilValidator
                                             "deleted_timestamp" => $tmp_date->get(IL_CAL_UNIX),
                                             "create_date" => $row->create_date,
                                             "last_update" => $row->last_update
-                                            );
+            ];
         }
 
         if (count($this->deleted_objects) > 0) {
-            $this->writeScanLogArray(array(array_keys($this->deleted_objects[0])));
+            $this->writeScanLogArray([array_keys($this->deleted_objects[0])]);
             $this->writeScanLogArray($this->deleted_objects);
             return true;
         }
@@ -878,7 +876,7 @@ class ilValidator
 
         $this->writeScanLogLine("\nremoveInvalidReferences:");
 
-        if ($a_invalid_refs === null and isset($this->invalid_references)) {
+        if ($a_invalid_refs === null && isset($this->invalid_references)) {
             $a_invalid_refs = &$this->invalid_references;
         }
 
@@ -888,7 +886,7 @@ class ilValidator
             return false;
         }
         // no unbound references found. do nothing
-        if (count($a_invalid_refs) == 0) {
+        if (count($a_invalid_refs) === 0) {
             $this->writeScanLogLine("none");
             return false;
         }
@@ -941,7 +939,7 @@ class ilValidator
 
         $this->writeScanLogLine("\nremoveInvalidChilds:");
 
-        if ($a_invalid_childs === null and isset($this->invalid_childs)) {
+        if ($a_invalid_childs === null && isset($this->invalid_childs)) {
             $a_invalid_childs = &$this->invalid_childs;
         }
 
@@ -952,7 +950,7 @@ class ilValidator
         }
 
         // no unbound childs found. do nothing
-        if (count($a_invalid_childs) == 0) {
+        if (count($a_invalid_childs) === 0) {
             $this->writeScanLogLine("none");
             return false;
         }
@@ -1002,7 +1000,7 @@ class ilValidator
 
         $this->writeScanLogLine("\nremoveInvalidRolefolders:");
 
-        if ($a_invalid_rolefolders === null and isset($this->invalid_rolefolders)) {
+        if ($a_invalid_rolefolders === null && isset($this->invalid_rolefolders)) {
             $a_invalid_rolefolders = $this->invalid_rolefolders;
         }
 
@@ -1013,7 +1011,7 @@ class ilValidator
         }
 
         // no invalid rolefolders found. do nothing
-        if (count($a_invalid_rolefolders) == 0) {
+        if (count($a_invalid_rolefolders) === 0) {
             $this->writeScanLogLine("none");
             return false;
         }
@@ -1073,7 +1071,7 @@ class ilValidator
 
         $this->writeScanLogLine("\nrestoreMissingObjects:");
 
-        if ($a_missing_objects === null and isset($this->missing_objects)) {
+        if ($a_missing_objects === null && isset($this->missing_objects)) {
             $a_missing_objects = $this->missing_objects;
         }
 
@@ -1084,7 +1082,7 @@ class ilValidator
         }
 
         // no missing objects found. do nothing
-        if (count($a_missing_objects) == 0) {
+        if (count($a_missing_objects) === 0) {
             $this->writeScanLogLine("none");
             return false;
         }
@@ -1145,9 +1143,10 @@ class ilValidator
             $this->throwError(INVALID_PARAM, WARNING, DEBUG);
             return false;
         }
-        
-        $query = "INSERT INTO object_reference (ref_id,obj_id) " .
-            "VALUES (" . $next_id = $ilDB->nextId('object_reference') . "," . $this->db->quote($a_obj_id, 'integer') . " )";
+
+        $next_id = $ilDB->nextId('object_reference');
+        $query = "INSERT INTO object_reference (ref_id, obj_id) " .
+            "VALUES (" . $this->db->quote($next_id, 'integer') . ", " . $this->db->quote($a_obj_id, 'integer') . ")";
         $res = $ilDB->manipulate($query);
 
         $message = sprintf(
@@ -1178,7 +1177,7 @@ class ilValidator
 
         $this->writeScanLogLine("\nrestoreUnboundObjects:");
 
-        if ($a_unbound_objects === null and isset($this->unbound_objects)) {
+        if ($a_unbound_objects === null && isset($this->unbound_objects)) {
             $a_unbound_objects = $this->unbound_objects;
         }
 
@@ -1216,7 +1215,7 @@ class ilValidator
 
         $this->writeScanLogLine("\nrestoreTrash:");
     
-        if ($a_deleted_objects === null and isset($this->deleted_objects)) {
+        if ($a_deleted_objects === null && isset($this->deleted_objects)) {
             $a_deleted_objects = $this->deleted_objects;
         }
 
@@ -1272,7 +1271,7 @@ class ilValidator
         }
 
         // no invalid parents found. do nothing
-        if (count($a_nodes) == 0) {
+        if (count($a_nodes) === 0) {
             $this->writeScanLogLine("none");
             return false;
         }
@@ -1287,7 +1286,7 @@ class ilValidator
         // don't save rolefolders, remove them
         // TODO process ROLE_FOLDER_ID
         foreach ($a_nodes as $key => $node) {
-            if ($node["type"] == "rolf") {
+            if ($node["type"] === "rolf") {
                 // delete old tree entries
                 $tree->deleteTree($node);
 
@@ -1330,7 +1329,7 @@ class ilValidator
         }
 
         // no invalid parents found. do nothing
-        if (count($a_nodes) == 0) {
+        if (count($a_nodes) === 0) {
             $this->writeScanLogLine("none");
             return false;
         }
@@ -1339,8 +1338,8 @@ class ilValidator
         restore starts here
         ********************/
 
-        $subnodes = array();
-        $topnode = array();
+        $subnodes = [];
+        $topnode = [];
 
         $message = sprintf(
             '%s::restoreSubTrees(): Started...',
@@ -1355,11 +1354,10 @@ class ilValidator
             
             // don't save rolefolders, remove them
             // TODO process ROLE_FOLDER_ID
-            if ($topnode["type"] == "rolf") {
+            if ($topnode["type"] === "rolf") {
                 $rolfObj = ilObjectFactory::getInstanceByRefId($topnode["child"]);
                 $rolfObj->delete();
-                unset($top_node);
-                unset($rolfObj);
+                unset($top_node, $rolfObj);
                 continue;
             }
 
@@ -1422,7 +1420,7 @@ class ilValidator
 
         $this->writeScanLogLine("\npurgeTrash:");
     
-        if ($a_nodes === null and isset($this->deleted_objects)) {
+        if ($a_nodes === null && isset($this->deleted_objects)) {
             $a_nodes = $this->deleted_objects;
         }
         $message = sprintf(
@@ -1452,7 +1450,7 @@ class ilValidator
 
         $this->writeScanLogLine("\npurgeUnboundObjects:");
 
-        if ($a_nodes === null and isset($this->unbound_objects)) {
+        if ($a_nodes === null && isset($this->unbound_objects)) {
             $a_nodes = $this->unbound_objects;
         }
 
@@ -1483,7 +1481,7 @@ class ilValidator
 
         $this->writeScanLogLine("\npurgeMissingObjects:");
 
-        if ($a_nodes === null and isset($this->missing_objects)) {
+        if ($a_nodes === null && isset($this->missing_objects)) {
             $a_nodes = $this->missing_objects;
         }
 
@@ -1521,7 +1519,7 @@ class ilValidator
         $type_limit = $ilUser->getPref("systemcheck_type_limit");
         if ($type_limit) {
             $type_limit = trim($type_limit);
-            if (strlen($type_limit) == 0) {
+            if ($type_limit === '') {
                 $type_limit = null;
             }
         }
@@ -1659,10 +1657,10 @@ class ilValidator
                         break;
                 }
                 
-                $arg_list[] = array(
+                $arg_list[] = [
                                     "type" => $type,
                                     "value" => "(" . $value . ")"
-                                    );
+                ];
             }
             
             foreach ($arg_list as $arg) {
@@ -1678,7 +1676,7 @@ class ilValidator
         if ($error->getUserInfo()) {
             printf("<br/>Parameter details:");
             echo "<pre>";
-            var_dump($call_loc["args"]);
+            var_dump($call_loc["args"]);// TODO PHP8-REVIEW This should be removed and the ilLogger should be used instead
             echo "</pre>";
         }
         
@@ -1772,7 +1770,7 @@ class ilValidator
         // erroneous.).
         $q = 'SELECT child FROM tree GROUP BY child HAVING COUNT(*) > 1';
         $r = $this->db->query($q);
-        $duplicateNodes = array();
+        $duplicateNodes = [];
         while ($row = $r->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             $duplicateNodes[] = $row->child;
         }
@@ -1797,7 +1795,7 @@ class ilValidator
         // We use a stack to represent the path to the current node.
         // This allows us to do analyze the tree structure without having
         // to implement a recursive algorithm.
-        $stack = array();
+        $stack = [];
         $error_count = 0;
         $repository_tree_count = 0;
         $trash_trees_count = 0;
@@ -1837,21 +1835,21 @@ class ilValidator
                             // In this case, they do not have a row in table object_reference.
                             // We are not interested in dumping these file objects.
                             continue 2;
-                        } else {
-                            // File objects which have a row in table object_reference, but
-                            // none in table tree are an error.
-                            $error_count++;
-                            $isRowOkay = false;
-                            $isParentOkay = false;
-                            $isLftOkay = false;
-                            $isRgtOkay = false;
-                            $isDepthOkay = false;
                         }
+
+                        // File objects which have a row in table object_reference, but
+                        // none in table tree are an error.
+                        $error_count++;
+                        $isRowOkay = false;
+                        $isParentOkay = false;
+                        $isLftOkay = false;
+                        $isRgtOkay = false;
+                        $isDepthOkay = false;
                         break;
                         
                     default:
                         // ignore folders on media pools
-                        if ($row->type == "fold" && $this->isMediaFolder($row->obj_id)) {
+                        if ($row->type === "fold" && $this->isMediaFolder($row->obj_id)) {
                             continue 2;
                         }
                         $error_count++;
@@ -1921,8 +1919,8 @@ class ilValidator
             }
             
             // Initialize the stack and the previous number if we are in a new tree
-            if (count($stack) == 0 || $stack[0]->tree != $row->tree) {
-                $stack = array();
+            if (count($stack) === 0 || $stack[0]->tree != $row->tree) {
+                $stack = [];
                 $previousNumber = $row->lft - 1;
                 $this->writeScanLogLine('<tr><td>&nbsp;</td></tr>');
             }
@@ -1982,7 +1980,7 @@ class ilValidator
                     $isParentOkay = false;
                     $isRowOkay = false;
                 }
-                if ($GLOBALS['ilSetting']->get('main_tree_impl', 'ns') == 'ns') {
+                if ($GLOBALS['ilSetting']->get('main_tree_impl', 'ns') === 'ns') {
                     if ($parent->lft >= $row->lft) {
                         $isLftOkay = false;
                         $isRowOkay = false;
@@ -1995,12 +1993,10 @@ class ilValidator
             }
 
             // Check lft rgt
-            if ($GLOBALS['ilSetting']->get('main_tree_impl', 'ns') == 'ns') {
-                if ($row->lft >= $row->rgt) {
-                    $isLftOkay = false;
-                    $isRgtOkay = false;
-                    $isRowOkay = false;
-                }
+            if ($row->lft >= $row->rgt && $GLOBALS['ilSetting']->get('main_tree_impl', 'ns') === 'ns') {
+                $isLftOkay = false;
+                $isRgtOkay = false;
+                $isRowOkay = false;
             }
             if (in_array($row->child, $duplicateNodes)) {
                 $isChildOkay = false;
@@ -2025,7 +2021,7 @@ class ilValidator
 
             // Check for gap between siblings,
             // and eventually write a log line
-            if ($GLOBALS['ilSetting']->get('main_tree_impl', 'ns') == 'ns') {
+            if ($GLOBALS['ilSetting']->get('main_tree_impl', 'ns') === 'ns') {
                 $gap = $row->lft - $previousNumber - 1;
                 $previousNumber = $row->lft;
                 if ($gap > 0) {
@@ -2160,7 +2156,7 @@ class ilValidator
         $ilDB = $this->db;
         
         if (!is_array($this->media_pool_ids)) {
-            $this->media_pool_ids = array();
+            $this->media_pool_ids = [];
             $query = "SELECT child FROM mep_tree ";
             $res = $ilDB->query($query);
             while ($row = $ilDB->fetchObject($res)) {
@@ -2190,7 +2186,7 @@ class ilValidator
         $ilDB = $this->db;
         
         if ($this->workspace_object_ids === null) {
-            $this->workspace_object_ids = array();
+            $this->workspace_object_ids = [];
             
             // workspace objects
             $set = $ilDB->query("SELECT DISTINCT(obj_id) FROM object_reference_ws");
@@ -2210,7 +2206,7 @@ class ilValidator
         array &$a_data,
         string $a_index = "obj_id"
     ) : void {
-        if (sizeof($a_data)) {
+        if (count($a_data)) {
             $this->initWorkspaceObjects();
             
             // remove workspace objects from result objects

--- a/Services/Repository/classes/class.ilRepositoryAppEventListener.php
+++ b/Services/Repository/classes/class.ilRepositoryAppEventListener.php
@@ -41,7 +41,7 @@ class ilRepositoryAppEventListener implements ilAppEventListener
                     case "beforeDeletion":
 
 
-                        if ($a_parameter["object"]->getType() == "usr") {
+                        if ($a_parameter["object"]->getType() === "usr") {
 
                             // remove recommended content
                             $rec_manager = new ilRecommendedContentManager();
@@ -52,7 +52,7 @@ class ilRepositoryAppEventListener implements ilAppEventListener
                             $rec_manager->removeFavouritesOfUser((int) $a_parameter["object"]->getId());
                         }
 
-                        if ($a_parameter["object"]->getType() == "role") {
+                        if ($a_parameter["object"]->getType() === "role") {
 
                             // remove recommended content
                             $rec_manager = new ilRecommendedContentManager();

--- a/Services/Repository/classes/class.ilRepositoryExplorer.php
+++ b/Services/Repository/classes/class.ilRepositoryExplorer.php
@@ -54,7 +54,7 @@ class ilRepositoryExplorer extends ilExplorer
         $this->ctrl = $ilCtrl;
 
 
-        $this->force_open_path = array();
+        $this->force_open_path = [];
         $this->request = $DIC->repository()->internal()->gui()->standardRequest();
 
 
@@ -67,13 +67,13 @@ class ilRepositoryExplorer extends ilExplorer
 
         // please do not uncomment this
         if ($ilSetting->get("repository_tree_pres") == "" ||
-            ($ilSetting->get("rep_tree_limit_grp_crs") && $a_top_node == 0)) {
+            ($ilSetting->get("rep_tree_limit_grp_crs") && $a_top_node === 0)) {
             foreach ($objDefinition->getExplorerContainerTypes() as $type) {
                 $this->addFilter($type);
             }
             $this->setFiltered(true);
             $this->setFilterMode(IL_FM_POSITIVE);
-        } elseif ($ilSetting->get("repository_tree_pres") == "all_types") {
+        } elseif ($ilSetting->get("repository_tree_pres") === "all_types") {
             foreach ($objDefinition->getAllRBACObjects() as $rtype) {
                 $this->addFilter($rtype);
             }
@@ -116,13 +116,13 @@ class ilRepositoryExplorer extends ilExplorer
 
             case "grp":
                 $ilCtrl->setParameterByClass("ilobjgroupgui", "ref_id", $a_node_id);
-                $link = $ilCtrl->getLinkTargetByClass(array("ilrepositorygui", "ilobjgroupgui"), "");
+                $link = $ilCtrl->getLinkTargetByClass(["ilrepositorygui", "ilobjgroupgui"], "");
                 $ilCtrl->setParameterByClass("ilobjgroupgui", "ref_id", $ref_id);
                 return $link;
 
             case "crs":
                 $ilCtrl->setParameterByClass("ilobjcoursegui", "ref_id", $a_node_id);
-                $link = $ilCtrl->getLinkTargetByClass(array("ilrepositorygui", "ilobjcoursegui"), "view");
+                $link = $ilCtrl->getLinkTargetByClass(["ilrepositorygui", "ilobjcoursegui"], "view");
                 $ilCtrl->setParameterByClass("ilobjcoursegui", "ref_id", $ref_id);
                 return $link;
 
@@ -146,7 +146,7 @@ class ilRepositoryExplorer extends ilExplorer
 
     public function getImage(string $a_name, string $a_type = "", $a_obj_id = "") : string
     {
-        if ($a_type != "") {
+        if ($a_type !== "") {
             return ilObject::_getIcon((int) $a_obj_id, "tiny", $a_type);
         }
         
@@ -158,7 +158,7 @@ class ilRepositoryExplorer extends ilExplorer
         $rbacsystem = $this->rbacsystem;
         $ilDB = $this->db;
 
-        if (!ilConditionHandler::_checkAllConditionsOfTarget($a_ref_id, $a_obj_id)) {
+        if (!ilConditionHandler::_checkAllConditionsOfTarget($a_ref_id, $a_obj_id)) {// TODO PHP8-REVIEW `$a_obj_id` is not defined
             return false;
         }
 
@@ -206,28 +206,28 @@ class ilRepositoryExplorer extends ilExplorer
             default:
                 if ($rbacsystem->checkAccess("read", $a_ref_id)) {
                     // check if lm is online
-                    if ($a_type == "lm") {
+                    if ($a_type === "lm") {
                         $lm_obj = new ilObjLearningModule($a_ref_id);
                         if (($lm_obj->getOfflineStatus()) && (!$rbacsystem->checkAccess('write', $a_ref_id))) {
                             return false;
                         }
                     }
                     // check if fblm is online
-                    if ($a_type == "htlm") {
+                    if ($a_type === "htlm") {
                         $lm_obj = new ilObjFileBasedLM($a_ref_id);
                         if (($lm_obj->getOfflineStatus()) && (!$rbacsystem->checkAccess('write', $a_ref_id))) {
                             return false;
                         }
                     }
                     // check if fblm is online
-                    if ($a_type == "sahs") {
+                    if ($a_type === "sahs") {
                         $lm_obj = new ilObjSAHSLearningModule($a_ref_id);
                         if (($lm_obj->getOfflineStatus()) && (!$rbacsystem->checkAccess('write', $a_ref_id))) {
                             return false;
                         }
                     }
                     // check if glossary is online
-                    if ($a_type == "glo") {
+                    if ($a_type === "glo") {
                         $obj_id = ilObject::_lookupObjectId($a_ref_id);
                         if ((!ilObjGlossary::_lookupOnline($obj_id)) &&
                             (!$rbacsystem->checkAccess('write', $a_ref_id))) {
@@ -241,7 +241,7 @@ class ilRepositoryExplorer extends ilExplorer
         }
     }
 
-    public function showChilds($a_parent_id, $a_obj_id = 0) : bool
+    public function showChilds($a_parent_id, $a_obj_id = 0) : bool// TODO PHP8-REVIEW The signature (of this class and the derivatives) differs from the signature of the parent method
     {
         $rbacsystem = $this->rbacsystem;
 
@@ -253,9 +253,9 @@ class ilRepositoryExplorer extends ilExplorer
         }
         if ($rbacsystem->checkAccess("read", $a_parent_id)) {
             return true;
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     public function isVisible($a_ref_id, string $a_type) : bool
@@ -276,7 +276,7 @@ class ilRepositoryExplorer extends ilExplorer
         }
         if ($container_parent_id) {
             // do not display session materials for container course/group
-            if ($ilSetting->get("repository_tree_pres") == "all_types" && $container_parent_id != $a_ref_id) {
+            if ($container_parent_id !== $a_ref_id && $ilSetting->get("repository_tree_pres") === "all_types") {
                 // get container event items only once
                 if (!isset($this->session_materials[$container_parent_id])) {
                     $this->session_materials[$container_parent_id] = ilEventItems::_getItemsOfContainer($container_parent_id);
@@ -310,7 +310,7 @@ class ilRepositoryExplorer extends ilExplorer
         $tpl->setCurrentBlock("icon");
         $nd = $tree->getNodeData(ROOT_FOLDER_ID);
         $title = $nd["title"];
-        if ($title == "ILIAS") {
+        if ($title === "ILIAS") {
             $title = $lng->txt("repository");
         }
 
@@ -345,14 +345,13 @@ class ilRepositoryExplorer extends ilExplorer
             $parent_type = ilObject::_lookupType($a_parent_obj_id);
         } else {
             $parent_type = "dummy";
-            $this->type_grps["dummy"] = array("root" => "dummy");
+            $this->type_grps["dummy"] = ["root" => "dummy"];
         }
 
         if (empty($this->type_grps[$parent_type])) {
-            $this->type_grps[$parent_type] =
-                $objDefinition->getGroupedRepositoryObjectTypes($parent_type);
+            $this->type_grps[$parent_type] = $objDefinition->getGroupedRepositoryObjectTypes($parent_type);
         }
-        $group = array();
+        $group = [];
         
         foreach ($a_nodes as $node) {
             $g = $objDefinition->getGroupOfObj($node["type"]);
@@ -362,7 +361,7 @@ class ilRepositoryExplorer extends ilExplorer
             $group[$g][] = $node;
         }
 
-        $nodes = array();
+        $nodes = [];
         foreach ($this->type_grps[$parent_type] as $t => $g) {
             if (is_array($group[$t])) {
                 // do we have to sort this group??
@@ -370,7 +369,7 @@ class ilRepositoryExplorer extends ilExplorer
                 $group = $sort->sortItems($group);
                 
                 // need extra session sorting here
-                if ($t == "sess") {
+                if ($t === "sess") {// TODO PHP8-REVIEW This empty block should be removed
                 }
                 
                 foreach ($group[$t] as $k => $item) {

--- a/Services/Repository/classes/class.ilRepositoryExplorerGUI.php
+++ b/Services/Repository/classes/class.ilRepositoryExplorerGUI.php
@@ -38,7 +38,7 @@ class ilRepositoryExplorerGUI extends ilTreeExplorerGUI
     protected int $top_node_id;
 
     public function __construct(
-        $a_parent_obj,
+        $a_parent_obj,// TODO PHP8-REVIEW Maybe you can use the class of the consuming GUI or (if there are several) add a list of valid types by using PHPDoc comments. If different types are allowed, use the PHPDoc comments.
         string $a_parent_cmd
     ) {
         /** @var \ILIAS\DI\Container $DIC */
@@ -68,10 +68,10 @@ class ilRepositoryExplorerGUI extends ilTreeExplorerGUI
         $this->setAjax(true);
         $this->setOrderField("title");
         if ($ilSetting->get("repository_tree_pres") == "" ||
-            ($ilSetting->get("rep_tree_limit_grp_crs") && $this->top_node_id == 0)) {
+            ($ilSetting->get("rep_tree_limit_grp_crs") && $this->top_node_id === 0)) {
             $this->setTypeWhiteList($objDefinition->getExplorerContainerTypes());
-        } elseif ($ilSetting->get("repository_tree_pres") == "all_types") {
-            $white = array();
+        } elseif ($ilSetting->get("repository_tree_pres") === "all_types") {
+            $white = [];
             foreach ($objDefinition->getSubObjectsRecursively("root") as $rtype) {
                 if (/* $rtype["name"] != "itgr" && */ !$objDefinition->isSideBlock($rtype["name"])) {
                     $white[] = $rtype["name"];
@@ -105,10 +105,10 @@ class ilRepositoryExplorerGUI extends ilTreeExplorerGUI
         $title = $a_node["title"];
                         
         if ($a_node["child"] == $this->getNodeId($this->getRootNode())) {
-            if ($title == "ILIAS") {
+            if ($title === "ILIAS") {
                 $title = $lng->txt("repository");
             }
-        } elseif ($a_node["type"] == "sess" &&
+        } elseif ($a_node["type"] === "sess" &&
             !trim($title)) {
             // #14367 - see ilObjSessionListGUI
             $app_info = ilSessionAppointment::_lookupAppointment($a_node["obj_id"]);
@@ -130,7 +130,7 @@ class ilRepositoryExplorerGUI extends ilTreeExplorerGUI
 
         if ($a_node["child"] == $this->getNodeId($this->getRootNode())) {
             $title = $a_node["title"];
-            if ($title == "ILIAS") {
+            if ($title === "ILIAS") {
                 $title = $lng->txt("repository");
             }
             return $title;
@@ -142,8 +142,8 @@ class ilRepositoryExplorerGUI extends ilTreeExplorerGUI
     
     public function isNodeHighlighted($a_node) : bool
     {
-        if ($a_node["child"] == $this->cur_ref_id ||
-            ($this->cur_ref_id == "" && $a_node["child"] == $this->getNodeId($this->getRootNode()))) {
+        if ((int) $a_node["child"] === $this->cur_ref_id ||
+            ($this->cur_ref_id === 0 && (int) $a_node["child"] === (int) $this->getNodeId($this->getRootNode()))) {
             return true;
         }
         return false;
@@ -172,13 +172,13 @@ class ilRepositoryExplorerGUI extends ilTreeExplorerGUI
 
             case "grp":
                 $ilCtrl->setParameterByClass("ilobjgroupgui", "ref_id", $a_node["child"]);
-                $link = $ilCtrl->getLinkTargetByClass(array("ilrepositorygui", "ilobjgroupgui"), "");
+                $link = $ilCtrl->getLinkTargetByClass(["ilrepositorygui", "ilobjgroupgui"], "");
                 $ilCtrl->setParameterByClass("ilobjgroupgui", "ref_id", $this->cur_ref_id);
                 return $link;
 
             case "crs":
                 $ilCtrl->setParameterByClass("ilobjcoursegui", "ref_id", $a_node["child"]);
-                $link = $ilCtrl->getLinkTargetByClass(array("ilrepositorygui", "ilobjcoursegui"), "view");
+                $link = $ilCtrl->getLinkTargetByClass(["ilrepositorygui", "ilobjcoursegui"], "view");
                 $ilCtrl->setParameterByClass("ilobjcoursegui", "ref_id", $this->cur_ref_id);
                 return $link;
 
@@ -190,7 +190,7 @@ class ilRepositoryExplorerGUI extends ilTreeExplorerGUI
 
             case 'prg':
                 $ilCtrl->setParameterByClass("ilobjstudyprogrammegui", "ref_id", $a_node["child"]);
-                $link = $ilCtrl->getLinkTargetByClass(array("ilrepositorygui", "ilobjstudyprogrammegui"), "view");
+                $link = $ilCtrl->getLinkTargetByClass(["ilrepositorygui", "ilobjstudyprogrammegui"], "view");
                 $ilCtrl->setParameterByClass("ilobjstudyprogrammegui", "ref_id", $this->cur_ref_id);
                 return $link;
 
@@ -210,7 +210,7 @@ class ilRepositoryExplorerGUI extends ilTreeExplorerGUI
             return false;
         }
 
-        if ($ilSetting->get("repository_tree_pres") == "all_types") {
+        if ($ilSetting->get("repository_tree_pres") === "all_types") {
             /*$container_parent_id = $tree->checkForParentType($a_node["child"], 'grp');
             if (!$container_parent_id) {
                 $container_parent_id = $tree->checkForParentType($a_node["child"], 'crs');
@@ -219,7 +219,7 @@ class ilRepositoryExplorerGUI extends ilTreeExplorerGUI
             $container_parent_id = $this->getParentCourseOrGroup($a_node["child"]);
             if ($container_parent_id > 0) {
                 // do not display session materials for container course/group
-                if ($container_parent_id != $a_node["child"]) {
+                if ($container_parent_id !== (int) $a_node["child"]) {
                     // get container event items only once
                     if (!isset($this->session_materials[$container_parent_id])) {
                         $this->session_materials[$container_parent_id] = ilEventItems::_getItemsOfContainer($container_parent_id);
@@ -258,23 +258,23 @@ class ilRepositoryExplorerGUI extends ilTreeExplorerGUI
             $parent_type = ilObject::_lookupType($parent_obj_id);
         } else {
             $parent_type = "dummy";
-            $this->type_grps["dummy"] = array("root" => "dummy");
+            $this->type_grps["dummy"] = ["root" => "dummy"];
         }
 
         // alex: if this is not initialized, things are messed up
         // see bug 0015978
-        $this->type_grps = array();
+        $this->type_grps = [];
 
         $this->type_grps[$parent_type] =
-            $objDefinition->getGroupedRepositoryObjectTypes($parent_type);
+            $objDefinition::getGroupedRepositoryObjectTypes($parent_type);
 
         // #14465 - item groups
-        $group = array();
-        $igroup = array(); // used for item groups, see bug #0015978
-        $in_any_group = array();
+        $group = [];
+        $igroup = []; // used for item groups, see bug #0015978
+        $in_any_group = [];
         foreach ($a_childs as $child) {
             // item group: get childs
-            if ($child["type"] == "itgr") {
+            if ($child["type"] === "itgr") {
                 $g = $child["child"];
                 $items = ilObjectActivation::getItemsByItemGroup($g);
                 if ($items) {
@@ -317,7 +317,7 @@ class ilRepositoryExplorerGUI extends ilTreeExplorerGUI
         if (is_array($block_pos) && count($block_pos) > 0) {
             $tmp = $this->type_grps[$parent_type];
 
-            $this->type_grps[$parent_type] = array();
+            $this->type_grps[$parent_type] = [];
             foreach ($block_pos as $block_type) {
                 // type group
                 if (!is_numeric($block_type) &&
@@ -328,12 +328,12 @@ class ilRepositoryExplorerGUI extends ilTreeExplorerGUI
                 // item group
                 else {
                     // using item group ref id directly
-                    $this->type_grps[$parent_type][$block_type] = array();
+                    $this->type_grps[$parent_type][$block_type] = [];
                 }
             }
 
             // append missing
-            if (sizeof($tmp)) {
+            if (count($tmp)) {
                 foreach ($tmp as $block_type => $grp) {
                     $this->type_grps[$parent_type][$block_type] = $grp;
                 }
@@ -342,8 +342,8 @@ class ilRepositoryExplorerGUI extends ilTreeExplorerGUI
             unset($tmp);
         }
 
-        $childs = array();
-        $done = array();
+        $childs = [];
+        $done = [];
 
         foreach ($this->type_grps[$parent_type] as $t => $g) {
             // type group
@@ -405,12 +405,12 @@ class ilRepositoryExplorerGUI extends ilTreeExplorerGUI
         $rbacsystem = $this->rbacsystem;
         
         if (!$rbacsystem->checkAccess("read", $a_parent_node_id)) {
-            return array();
+            return [];
         }
 
         $obj_id = ilObject::_lookupObjId($a_parent_node_id);
         if (!ilConditionHandler::_checkAllConditionsOfTarget($a_parent_node_id, $obj_id)) {
-            return array();
+            return [];
         }
 
         $childs = parent::getChildsOfNode($a_parent_node_id);
@@ -476,28 +476,28 @@ class ilRepositoryExplorerGUI extends ilTreeExplorerGUI
             default:
                 if ($rbacsystem->checkAccess("read", $a_node["child"])) {
                     // check if lm is online
-                    if ($a_node["type"] == "lm") {
+                    if ($a_node["type"] === "lm") {
                         $lm_obj = new ilObjLearningModule($a_node["child"]);
                         if (($lm_obj->getOfflineStatus()) && (!$rbacsystem->checkAccess('write', $a_node["child"]))) {
                             return false;
                         }
                     }
                     // check if fblm is online
-                    if ($a_node["type"] == "htlm") {
+                    if ($a_node["type"] === "htlm") {
                         $lm_obj = new ilObjFileBasedLM($a_node["child"]);
                         if (($lm_obj->getOfflineStatus()) && (!$rbacsystem->checkAccess('write', $a_node["child"]))) {
                             return false;
                         }
                     }
                     // check if fblm is online
-                    if ($a_node["type"] == "sahs") {
+                    if ($a_node["type"] === "sahs") {
                         $lm_obj = new ilObjSAHSLearningModule($a_node["child"]);
                         if (($lm_obj->getOfflineStatus()) && (!$rbacsystem->checkAccess('write', $a_node["child"]))) {
                             return false;
                         }
                     }
                     // check if glossary is online
-                    if ($a_node["type"] == "glo") {
+                    if ($a_node["type"] === "glo") {
                         $obj_id = ilObject::_lookupObjectId($a_node["child"]);
                         if ((!ilObjGlossary::_lookupOnline($obj_id)) &&
                             (!$rbacsystem->checkAccess('write', $a_node["child"]))) {
@@ -519,7 +519,7 @@ class ilRepositoryExplorerGUI extends ilTreeExplorerGUI
         $tree = $DIC->repositoryTree();
 
         $top_node = 0;
-        if ($setting->get("rep_tree_limit_grp_crs") && $ref_id > 0) {
+        if ($ref_id > 0 && $setting->get("rep_tree_limit_grp_crs")) {
             $path = $tree->getPathId($ref_id);
             foreach ($path as $n) {
                 if ($top_node > 0) {
@@ -527,7 +527,7 @@ class ilRepositoryExplorerGUI extends ilTreeExplorerGUI
                 }
                 if (in_array(
                     ilObject::_lookupType(ilObject::_lookupObjId($n)),
-                    array("crs", "grp")
+                    ["crs", "grp"]
                 )) {
                     $top_node = $n;
                 }

--- a/Services/Repository/classes/class.ilRepositoryGUI.php
+++ b/Services/Repository/classes/class.ilRepositoryGUI.php
@@ -93,7 +93,7 @@ class ilRepositoryGUI implements ilCtrlBaseClassInterface
 
         $this->creation_mode = false;
 
-        $this->ctrl->saveParameter($this, array("ref_id"));
+        $this->ctrl->saveParameter($this, ["ref_id"]);
         $this->ctrl->setReturn($this, "");
 
         $this->request = $DIC->repository()->internal()->gui()->standardRequest();
@@ -105,7 +105,7 @@ class ilRepositoryGUI implements ilCtrlBaseClassInterface
         }
     }
 
-    protected function redirectToRoot()
+    protected function redirectToRoot() : void
     {
         $ctrl = $this->ctrl;
         $ctrl->setParameterByClass(
@@ -115,7 +115,7 @@ class ilRepositoryGUI implements ilCtrlBaseClassInterface
         );
 
         // #10033
-        $_GET = array("baseClass" => "ilRepositoryGUI");
+        $_GET = ["baseClass" => "ilRepositoryGUI"];// TODO PHP8-REVIEW The request is/shoul be immutable, please fix this
         $ctrl->redirectByClass(self::class, "");
     }
 
@@ -141,7 +141,7 @@ class ilRepositoryGUI implements ilCtrlBaseClassInterface
         // determined by "new_type" parameter
         $new_type = $this->request->getNewType();
 
-        if ($new_type != "" && $new_type != "sty") {
+        if ($new_type !== "" && $new_type !== "sty") {
             $this->creation_mode = true;
             $ilHelp->setScreenIdComponent($new_type);
             $ilHelp->setDefaultScreenId(ilHelpGUI::ID_PART_SCREEN, "create");
@@ -153,7 +153,7 @@ class ilRepositoryGUI implements ilCtrlBaseClassInterface
         if ($this->creation_mode) {
             $obj_type = $new_type;
             $class_name = $this->objDefinition->getClassName($obj_type);
-            if (strtolower($class_name) != "user") {
+            if (strtolower($class_name) !== "user") {
                 $next_class = strtolower("ilObj" . $class_name . "GUI");
             } else {
                 $next_class = $this->ctrl->getNextClass();
@@ -167,32 +167,32 @@ class ilRepositoryGUI implements ilCtrlBaseClassInterface
 
             ilLoggerFactory::getLogger('obj')->debug($this->ctrl->getNextClass() . ' <-> ' . $class_name);
 
-            if ($this->ctrl->getNextClass() != strtolower('ilObj' . $class_name . 'GUI')) {
+            if ($this->ctrl->getNextClass() !== strtolower('ilObj' . $class_name . 'GUI')) {
                 $this->ctrl->setCmdClass($next_class);
             }
         } elseif ((($next_class = $this->ctrl->getNextClass($this)) == "")
-            || ($next_class == "ilrepositorygui" && $this->ctrl->getCmd() == "return")) {
+            || ($next_class === "ilrepositorygui" && $this->ctrl->getCmd() === "return")) {
             // get GUI of current object
             $obj_type = ilObject::_lookupType($this->cur_ref_id, true);
             $class_name = $this->objDefinition->getClassName($obj_type);
             $next_class = strtolower("ilObj" . $class_name . "GUI");
 
             $this->ctrl->setCmdClass($next_class);
-            if ($this->ctrl->getCmd() == "return") {
+            if ($this->ctrl->getCmd() === "return") {
                 $this->ctrl->setCmd("");
             }
         }
 
         // commands that are always handled by repository gui
         // to do: move to container
-        if ($cmd == "showRepTree") {
+        if ($cmd === "showRepTree") {
             $next_class = "";
         }
 
         switch ($next_class) {
             default:
                 // forward all other classes to gui commands
-                if ($next_class != "" && $next_class != "ilrepositorygui") {
+                if ($next_class !== null && $next_class !== "" && $next_class !== "ilrepositorygui") {
                     $class_path = $this->ctrl->lookupClassPath($next_class);
                     // get gui class instance
                     //require_once($class_path);
@@ -203,12 +203,10 @@ class ilRepositoryGUI implements ilCtrlBaseClassInterface
                         } else {
                             $this->gui_obj = new $class_name("", $this->cur_ref_id, true, false);
                         }
+                    } elseif (is_subclass_of($class_name, "ilObject2GUI")) {
+                        $this->gui_obj = new $class_name(0, ilObject2GUI::REPOSITORY_NODE_ID, $this->cur_ref_id);
                     } else {
-                        if (is_subclass_of($class_name, "ilObject2GUI")) {
-                            $this->gui_obj = new $class_name(0, ilObject2GUI::REPOSITORY_NODE_ID, $this->cur_ref_id);
-                        } else {
-                            $this->gui_obj = new $class_name("", 0, true, false);
-                        }
+                        $this->gui_obj = new $class_name("", 0, true, false);
                     }
                     $this->gui_obj->setCreationMode($this->creation_mode);
                     $this->ctrl->setReturn($this, "return");
@@ -218,7 +216,7 @@ class ilRepositoryGUI implements ilCtrlBaseClassInterface
                     $cmd = (string) $this->ctrl->getCmd("");
 
                     // check read access for category
-                    if ($this->cur_ref_id > 0 && !$rbacsystem->checkAccess("read", $this->cur_ref_id) && $cmd != "showRepTree") {
+                    if ($cmd !== "showRepTree" && $this->cur_ref_id > 0 && !$rbacsystem->checkAccess("read", $this->cur_ref_id)) {
                         $ilErr->raiseError($lng->txt("permission_denied"), $ilErr->MESSAGE);
                         $this->tpl->printToStdout();
                     } else {

--- a/Services/Repository/classes/class.ilRepositorySelectorExplorerGUI.php
+++ b/Services/Repository/classes/class.ilRepositorySelectorExplorerGUI.php
@@ -41,7 +41,7 @@ class ilRepositorySelectorExplorerGUI extends ilTreeExplorerGUI
     protected int $cur_ref_id;
 
     /**
-     * @param object|array $a_parent_obj parent gui class or class array
+     * @param object|string[] $a_parent_obj parent gui class or class array
      * @param object|string $a_selection_gui gui class that should be called for the selection command
      */
     public function __construct(
@@ -82,16 +82,16 @@ class ilRepositorySelectorExplorerGUI extends ilTreeExplorerGUI
         $this->setOrderField("title");
 
         // per default: all object types, except item groups
-        $white = array();
+        $white = [];
         foreach ($objDefinition->getSubObjectsRecursively("root") as $rtype) {
-            if ($rtype["name"] != "itgr" && !$objDefinition->isSideBlock($rtype["name"])) {
+            if ($rtype["name"] !== "itgr" && !$objDefinition->isSideBlock($rtype["name"])) {
                 $white[] = $rtype["name"];
             }
         }
         $this->setTypeWhiteList($white);
 
         // always open the path to the current ref id
-        $this->setPathOpen((int) $this->tree->readRootId());
+        $this->setPathOpen($this->tree->readRootId());
         if ($this->cur_ref_id > 0) {
             $this->setPathOpen($this->cur_ref_id);
         }
@@ -118,10 +118,8 @@ class ilRepositorySelectorExplorerGUI extends ilTreeExplorerGUI
         }
 
         $title = $a_node["title"];
-        if ($a_node["child"] == $this->getNodeId($this->getRootNode())) {
-            if ($title == "ILIAS") {
-                $title = $lng->txt("repository");
-            }
+        if ($title === "ILIAS" && (int) $a_node["child"] === (int) $this->getNodeId($this->getRootNode())) {
+            $title = $lng->txt("repository");
         }
 
         return $title;
@@ -139,7 +137,7 @@ class ilRepositorySelectorExplorerGUI extends ilTreeExplorerGUI
 
         if ($a_node["child"] == $this->getNodeId($this->getRootNode())) {
             $title = $a_node["title"];
-            if ($title == "ILIAS") {
+            if ($title === "ILIAS") {
                 $title = $lng->txt("repository");
             }
             return $lng->txt("icon") . " " . $title;
@@ -152,14 +150,14 @@ class ilRepositorySelectorExplorerGUI extends ilTreeExplorerGUI
     public function isNodeHighlighted($a_node) : bool
     {
         if ($this->getHighlightedNode()) {
-            if ($this->getHighlightedNode() == $a_node["child"]) {
+            if ((int) $this->getHighlightedNode() === (int) $a_node["child"]) {
                 return true;
             }
             return false;
         }
 
-        if ($a_node["child"] == $this->cur_ref_id ||
-            ($this->cur_ref_id == "" && $a_node["child"] == $this->getNodeId($this->getRootNode()))) {
+        if ((int) $a_node["child"] === $this->cur_ref_id ||
+            ($this->cur_ref_id === 0 && (int) $a_node["child"] === (int) $this->getNodeId($this->getRootNode()))) {
             return true;
         }
         return false;
@@ -169,7 +167,7 @@ class ilRepositorySelectorExplorerGUI extends ilTreeExplorerGUI
     {
         $ilCtrl = $this->ctrl;
 
-        if ($this->select_postvar == "") {
+        if ($this->select_postvar === "") {
             $ilCtrl->setParameterByClass($this->selection_gui, $this->selection_par, $a_node["child"]);
             $link = $ilCtrl->getLinkTargetByClass($this->selection_gui, $this->selection_cmd);
             $ilCtrl->setParameterByClass($this->selection_gui, $this->selection_par, "");
@@ -201,14 +199,14 @@ class ilRepositorySelectorExplorerGUI extends ilTreeExplorerGUI
             $parent_type = ilObject::_lookupType($parent_obj_id);
         } else {
             $parent_type = "dummy";
-            $this->type_grps["dummy"] = array("root" => "dummy");
+            $this->type_grps["dummy"] = ["root" => "dummy"];
         }
 
         if (empty($this->type_grps[$parent_type])) {
             $this->type_grps[$parent_type] =
-                $objDefinition->getGroupedRepositoryObjectTypes($parent_type);
+                $objDefinition::getGroupedRepositoryObjectTypes($parent_type);
         }
-        $group = array();
+        $group = [];
 
         foreach ($a_childs as $child) {
             $g = $objDefinition->getGroupOfObj($child["type"]);
@@ -220,11 +218,11 @@ class ilRepositorySelectorExplorerGUI extends ilTreeExplorerGUI
 
         // #14587 - $objDefinition->getGroupedRepositoryObjectTypes does NOT include side blocks!
         $wl = $this->getTypeWhiteList();
-        if (is_array($wl) && in_array("poll", $wl)) {
-            $this->type_grps[$parent_type]["poll"] = array();
+        if (is_array($wl) && in_array("poll", $wl, true)) {
+            $this->type_grps[$parent_type]["poll"] = [];
         }
 
-        $childs = array();
+        $childs = [];
         foreach ($this->type_grps[$parent_type] as $t => $g) {
             if (isset($group[$t])) {
                 // do we have to sort this group??
@@ -232,7 +230,7 @@ class ilRepositorySelectorExplorerGUI extends ilTreeExplorerGUI
                 $group = $sort->sortItems($group);
 
                 // need extra session sorting here
-                if ($t == "sess") {
+                if ($t === "sess") {// TODO PHP8-REVIEW This empty block should be removed
                 }
 
                 foreach ($group[$t] as $k => $item) {
@@ -249,7 +247,7 @@ class ilRepositorySelectorExplorerGUI extends ilTreeExplorerGUI
         $ilAccess = $this->access;
 
         if (!$ilAccess->checkAccess("read", "", $a_parent_node_id)) {
-            return array();
+            return [];
         }
 
         return parent::getChildsOfNode($a_parent_node_id);
@@ -259,7 +257,7 @@ class ilRepositorySelectorExplorerGUI extends ilTreeExplorerGUI
     {
         $ilAccess = $this->access;
 
-        if ($this->select_postvar != "") {
+        if ($this->select_postvar !== "") {// TODO PHP8-REVIEW This empty block should be removed
             // return false; #14354
         }
 
@@ -268,7 +266,7 @@ class ilRepositorySelectorExplorerGUI extends ilTreeExplorerGUI
         }
 
         if (is_array($this->getClickableTypes()) && count($this->getClickableTypes()) > 0) {
-            return in_array($a_node["type"], $this->getClickableTypes());
+            return in_array($a_node["type"], $this->getClickableTypes(), true);
         }
 
         return true;
@@ -307,7 +305,7 @@ class ilRepositorySelectorExplorerGUI extends ilTreeExplorerGUI
     protected function isNodeSelectable($a_node) : bool
     {
         if (count($this->getSelectableTypes())) {
-            return in_array($a_node['type'], $this->getSelectableTypes());
+            return in_array($a_node['type'], $this->getSelectableTypes(), true);
         }
         return true;
     }

--- a/Services/Repository/test/ClipboardSessionRepositoryTest.php
+++ b/Services/Repository/test/ClipboardSessionRepositoryTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\TestCase;
  */
 class ClipboardSessionRepositoryTest extends TestCase
 {
-    //protected $backupGlobals = false;
     protected \ILIAS\Repository\Clipboard\ClipboardSessionRepository $clipboard;
 
     protected function setUp() : void
@@ -26,7 +25,7 @@ class ClipboardSessionRepositoryTest extends TestCase
     /**
      * Test clear
      */
-    public function testClear()
+    public function testClear() : void
     {
         $clipboard = $this->clipboard;
         $clipboard->setCmd("test");
@@ -50,7 +49,7 @@ class ClipboardSessionRepositoryTest extends TestCase
     /**
      * Test cmd set/get
      */
-    public function testCmd()
+    public function testCmd() : void
     {
         $clipboard = $this->clipboard;
         $clipboard->setCmd("test");
@@ -63,7 +62,7 @@ class ClipboardSessionRepositoryTest extends TestCase
     /**
      * Test ref ids set/get
      */
-    public function testRefIds()
+    public function testRefIds() : void
     {
         $clipboard = $this->clipboard;
         $clipboard->setRefIds([4]);
@@ -76,7 +75,7 @@ class ClipboardSessionRepositoryTest extends TestCase
     /**
      * Test parent set/get
      */
-    public function testParent()
+    public function testParent() : void
     {
         $clipboard = $this->clipboard;
         $clipboard->setParent(5);
@@ -89,7 +88,7 @@ class ClipboardSessionRepositoryTest extends TestCase
     /**
      * Test hasEntries returns false if ref ids, but no cmd is given
      */
-    public function testHasEntriesNoCmd()
+    public function testHasEntriesNoCmd() : void
     {
         $clipboard = $this->clipboard;
         $clipboard->setRefIds([4]);
@@ -102,7 +101,7 @@ class ClipboardSessionRepositoryTest extends TestCase
     /**
      * Test hasEntries returns true if ref ids and cmd is given
      */
-    public function testHasEntriesCmd()
+    public function testHasEntriesCmd() : void
     {
         $clipboard = $this->clipboard;
         $clipboard->setRefIds([4]);
@@ -116,7 +115,7 @@ class ClipboardSessionRepositoryTest extends TestCase
     /**
      * Test hasEntries returns false if empty ref ids array and cmd is given
      */
-    public function testHasEntriesCmdEmptyRefIds()
+    public function testHasEntriesCmdEmptyRefIds() : void
     {
         $clipboard = $this->clipboard;
         $clipboard->setRefIds([]);

--- a/Services/Repository/test/ilServicesRepositorySuite.php
+++ b/Services/Repository/test/ilServicesRepositorySuite.php
@@ -22,7 +22,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilServicesRepositorySuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new self();
 


### PR DESCRIPTION
Hi @alex40724,

I completed the review of the `Category and Repository` components.

Folders:
- Services/Repository
- Services/Container
- Modules/Category
- Modules/CategoryReference
- Modules/Folder
- Modules/RootFolder
- Services/ContainerReference

Results:
- [ ] The code style is `PSR-2 + X` compliant
- [ ] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`: I found 1 usage of `$_GET`
  - `\ilRepositoryGUI::redirectToRoot`
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [ ] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

Actions:
- [ ] Please check my inline comments. Some of them might be just information, some require an action. You can use `TODO PHP8-REVIEW` when searching.
- [ ] Please have detailed look at `Services/Repository/TreeValidator/class.ilValidator.php`. I did not fix/comment every issue in this file, but there are several **undefined** constants/variables/etc..

Kind regards,
@mjansenDatabay 