### PR TITLE
PHP 8: Code Review `News`

### DIFF
--- a/Services/News/Timeline/classes/class.ilTimelineGUI.php
+++ b/Services/News/Timeline/classes/class.ilTimelineGUI.php
@@ -57,7 +57,7 @@ class ilTimelineGUI
         $keys = array_keys($this->items);
         foreach ($this->items as $k => $i) {
             $next = null;
-            if (isset($keys[$k + 1]) && isset($this->items[$keys[$k + 1]])) {
+            if (isset($keys[$k + 1], $this->items[$keys[$k + 1]])) {
                 $next = $this->items[$keys[$k + 1]];
             }
 

--- a/Services/News/Timeline/classes/class.ilTimelineGUI.php
+++ b/Services/News/Timeline/classes/class.ilTimelineGUI.php
@@ -20,7 +20,8 @@
  */
 class ilTimelineGUI
 {
-    protected array $items = array();
+    /** @var ilTimelineItemInt[] */
+    protected array $items = [];
     protected ilLanguage $lng;
     protected ilGlobalTemplateInterface $tpl;
 
@@ -61,7 +62,7 @@ class ilTimelineGUI
             }
 
             $dt = $i->getDateTime();
-            if (is_null($next) || $dt->get(IL_CAL_FKT_DATE, "Y-m-d") != $next->getDateTime()->get(IL_CAL_FKT_DATE, "Y-m-d")) {
+            if (is_null($next) || $dt->get(IL_CAL_FKT_DATE, "Y-m-d") !== $next->getDateTime()->get(IL_CAL_FKT_DATE, "Y-m-d")) {
                 $t->setCurrentBlock("badge");
                 $t->setVariable("DAY", $dt->get(IL_CAL_FKT_DATE, "d"));
                 $t->setVariable("MONTH", $this->lng->txt("month_" . $dt->get(IL_CAL_FKT_DATE, "m") . "_short"));

--- a/Services/News/classes/Provider/NewsMainBarProvider.php
+++ b/Services/News/classes/Provider/NewsMainBarProvider.php
@@ -42,9 +42,9 @@ class NewsMainBarProvider extends AbstractStaticMainMenuProvider
                 ->withParent(StandardTopItemsProvider::getInstance()->getCommunicationIdentification())
                 ->withPosition(30)
                 ->withSymbol($icon)
-                ->withNonAvailableReason($this->dic->ui()->factory()->legacy("{$this->dic->language()->txt('component_not_active')}"))
+                ->withNonAvailableReason($this->dic->ui()->factory()->legacy($this->dic->language()->txt('component_not_active')))
                 ->withAvailableCallable(
-                    function () use ($dic) {
+                    static function () use ($dic) : bool {
                         return !($dic->settings()->get("block_activated_news") === null);
                     }
                 ),

--- a/Services/News/classes/class.ilNewsCache.php
+++ b/Services/News/classes/class.ilNewsCache.php
@@ -29,8 +29,7 @@ class ilNewsCache extends ilCache
 
         $this->settings = $DIC->settings();
         $news_set = new ilSetting("news");
-        $news_set->get("acc_cache_mins");
-        
+
         parent::__construct("ServicesNews", "News", true);
         $this->setExpiresAfter($news_set->get("acc_cache_mins") * 60);
         if ((int) $news_set->get("acc_cache_mins") === 0) {

--- a/Services/News/classes/class.ilNewsCache.php
+++ b/Services/News/classes/class.ilNewsCache.php
@@ -33,14 +33,14 @@ class ilNewsCache extends ilCache
         
         parent::__construct("ServicesNews", "News", true);
         $this->setExpiresAfter($news_set->get("acc_cache_mins") * 60);
-        if ((int) $news_set->get("acc_cache_mins") == 0) {
+        if ((int) $news_set->get("acc_cache_mins") === 0) {
             self::$disabled = true;
         }
     }
     
     public function isDisabled() : bool
     {
-        return self::$disabled or parent::isDisabled();
+        return self::$disabled || parent::isDisabled();
     }
     
     protected function readEntry(string $a_id) : bool

--- a/Services/News/classes/class.ilNewsData.php
+++ b/Services/News/classes/class.ilNewsData.php
@@ -63,7 +63,7 @@ class ilNewsData
      * Delete a news item
      * @param ilNewsItem $news_item
      */
-    public function delete(ilNewsItem $news_item)
+    public function delete(ilNewsItem $news_item) : void
     {
         $news_item->delete();
     }

--- a/Services/News/classes/class.ilNewsDataSet.php
+++ b/Services/News/classes/class.ilNewsDataSet.php
@@ -21,7 +21,7 @@ class ilNewsDataSet extends ilDataSet
 {
     public function getSupportedVersions() : array
     {
-        return array("5.4.0", "4.1.0");
+        return ["5.4.0", "4.1.0"];
     }
     
     protected function getXmlNamespace(string $a_entity, string $a_schema_version) : string
@@ -31,11 +31,11 @@ class ilNewsDataSet extends ilDataSet
     
     protected function getTypes(string $a_entity, string $a_version) : array
     {
-        if ($a_entity == "news") {
+        if ($a_entity === "news") {
             switch ($a_version) {
                 case "4.1.0":
                 case "5.4.0":
-                    return array(
+                    return [
                         "Id" => "integer",
                         "Title" => "text",
                         "Content" => "text",
@@ -50,13 +50,13 @@ class ilNewsDataSet extends ilDataSet
                         "ContentIsLangVar" => "integer",
                         "MobId" => "integer",
                         "Playtime" => "text"
-                        );
+                    ];
             }
         }
-        if ($a_entity == "news_settings") {
+        if ($a_entity === "news_settings") {
             switch ($a_version) {
                 case "5.4.0":
-                    return array(
+                    return [
                         "ObjId" => "integer",
                         "PublicFeed" => "integer",
                         "DefaultVisibility" => "text",
@@ -64,7 +64,7 @@ class ilNewsDataSet extends ilDataSet
                         "HideNewsPerDate" => "integer",
                         "HideNewsDate" => "text",
                         "PublicNotifications" => "integer"
-                    );
+                    ];
             }
         }
         return [];
@@ -75,10 +75,10 @@ class ilNewsDataSet extends ilDataSet
         $ilDB = $this->db;
 
         if (!is_array($a_ids)) {
-            $a_ids = array($a_ids);
+            $a_ids = [$a_ids];
         }
                 
-        if ($a_entity == "news") {
+        if ($a_entity === "news") {
             switch ($a_version) {
                 case "4.1.0":
                 case "5.4.0":
@@ -92,7 +92,7 @@ class ilNewsDataSet extends ilDataSet
             }
         }
 
-        if ($a_entity == "news_settings") {
+        if ($a_entity === "news_settings") {
             switch ($a_version) {
                 case "5.4.0":
                     foreach ($a_ids as $obj_id) {
@@ -108,24 +108,9 @@ class ilNewsDataSet extends ilDataSet
             }
         }
     }
-    
-    /**
-     * Determine the dependent sets of data
-     */
-    protected function getDependencies(
-        string $a_entity,
-        string $a_version,
-        ?array $a_rec = null,
-        ?array $a_ids = null
-    ) : array {
-        return [];
-    }
-    
+
     public function importRecord(string $a_entity, array $a_types, array $a_rec, ilImportMapping $a_mapping, string $a_schema_version) : void
     {
-        //echo $a_entity;
-        //var_dump($a_rec);
-
         switch ($a_entity) {
             case "news":
                 $mob_id = null;
@@ -136,24 +121,23 @@ class ilNewsDataSet extends ilDataSet
                     ":" . $a_rec["ContextSubObjType"];
                 $context = $a_mapping->getMapping("Services/News", "news_context", $c);
                 $context = explode(":", $context);
-//var_dump($c);
-//var_dump($a_mapping->mappings["Services/News"]["news_context"]);
+
                 $newObj = new ilNewsItem();
                 $newObj->setTitle($a_rec["Title"]);
                 $newObj->setContent($a_rec["Content"]);
                 $newObj->setPriority($a_rec["Priority"]);
-                $newObj->setContextObjId($context[0]);
+                $newObj->setContextObjId((int) $context[0]);
                 $newObj->setContextObjType($context[1]);
-                $newObj->setContextSubObjId($context[2]);
+                $newObj->setContextSubObjId((int) $context[2]);
                 $newObj->setContextSubObjType($context[3]);
                 $newObj->setContentType($a_rec["ContentType"]);
                 $newObj->setVisibility($a_rec["Visibility"]);
                 $newObj->setContentLong($a_rec["ContentLong"]);
                 $newObj->setContentIsLangVar($a_rec["ContentIsLangVar"]);
-                $newObj->setMobId($mob_id);
+                $newObj->setMobId((int) $mob_id);
                 $newObj->setPlaytime($a_rec["Playtime"]);
                 $newObj->create();
-                $a_mapping->addMapping("Services/News", "news", $a_rec["Id"], $newObj->getId());
+                $a_mapping->addMapping("Services/News", "news", $a_rec["Id"], (string) $newObj->getId());
                 break;
 
             case "news_settings":
@@ -161,7 +145,7 @@ class ilNewsDataSet extends ilDataSet
                 $dummy_dataset = new ilObjectDataSet();
                 $new_obj_id = $dummy_dataset->getNewObjId($a_mapping, $a_rec["ObjId"]);
 
-                if ($new_obj_id > 0 && $a_schema_version == "5.4.0") {
+                if ($new_obj_id > 0 && $a_schema_version === "5.4.0") {
                     foreach ([
                         "public_feed" => "PublicFeed",
                         "keep_rss_min" => "KeepRssMin",

--- a/Services/News/classes/class.ilNewsExporter.php
+++ b/Services/News/classes/class.ilNewsExporter.php
@@ -29,27 +29,27 @@ class ilNewsExporter extends ilXmlExporter
         $this->ds->setDSPrefix("ds");
     }
 
-
     /**
      * @return		array		array of array with keys "component", entity", "ids"
      */
     public function getXmlExportHeadDependencies(string $a_entity, string $a_target_release, array $a_ids) : array
     {
-        $mob_ids = array();
+        $mob_ids = [];
 
         foreach ($a_ids as $id) {
-            $mob_id = ilNewsItem::_lookupMobId($id);
+            $mob_id = ilNewsItem::_lookupMobId((int) $id);
             if ($mob_id > 0) {
                 $mob_ids[$mob_id] = $mob_id;
             }
         }
 
-        return array(
-            array(
+        return [
+            [
                 "component" => "Services/MediaObjects",
                 "entity" => "mob",
-                "ids" => $mob_ids)
-            );
+                "ids" => $mob_ids
+            ]
+        ];
     }
 
     public function getXmlRepresentation(string $a_entity, string $a_schema_version, string $a_id) : string
@@ -59,19 +59,21 @@ class ilNewsExporter extends ilXmlExporter
 
     public function getValidSchemaVersions(string $a_entity) : array
     {
-        return array(
-            "5.4.0" => array(
+        return [
+            "5.4.0" => [
                 "namespace" => "https://www.ilias.de/Services/News/news/5_4",
                 "xsd_file" => "ilias_news_5_4.xsd",
                 "uses_dataset" => true,
                 "min" => "5.4.0",
-                "max" => ""),
-            "4.1.0" => array(
+                "max" => ""
+            ],
+            "4.1.0" => [
                 "namespace" => "https://www.ilias.de/Services/News/news/4_1",
                 "xsd_file" => "ilias_news_4_1.xsd",
                 "uses_dataset" => true,
                 "min" => "4.1.0",
-                "max" => "")
-        );
+                "max" => ""
+            ]
+        ];
     }
 }

--- a/Services/News/classes/class.ilNewsForContextBlockGUI.php
+++ b/Services/News/classes/class.ilNewsForContextBlockGUI.php
@@ -73,18 +73,21 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
         $this->setLimit(5);
         $this->setEnableNumInfo(true);
         
-        $this->dynamic = false;
-        $this->acache = new ilNewsCache();
-        $cres = unserialize($this->acache->getEntry($ilUser->getId() . ":" . $this->std_request->getRefId()));
-        $this->cache_hit = false;
+        $this->dynamic = false;// TODO PHP8-REVIEW Property declared dynamically
+        $this->acache = new ilNewsCache();// TODO PHP8-REVIEW Property declared dynamically
+        $cres = unserialize(
+            $this->acache->getEntry($ilUser->getId() . ":" . $this->std_request->getRefId()),
+            ["allowed_classes" => false]
+        );
+        $this->cache_hit = false;// TODO PHP8-REVIEW Property declared dynamically
 
-        if ($this->acache->getLastAccessStatus() == "hit" && is_array($cres)) {
+        if ($this->acache->getLastAccessStatus() === "hit" && is_array($cres)) {
             self::$st_data = ilNewsItem::prepareNewsDataFromCache($cres);
             $this->cache_hit = true;
         }
         if ($this->getDynamic() && !$this->cache_hit) {
             $this->dynamic = true;
-            $data = array();
+            $data = [];
         } else {
             if (!empty(self::$st_data)) {
                 $data = self::$st_data;
@@ -123,7 +126,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
         // workaround, better: reduce constructor and introduce
         //$prevent_aggregation = $this->getProperty("prevent_aggregation");
         $prevent_aggregation = true;
-        if ($ilCtrl->getContextObjType() != "frm") {
+        if ($ilCtrl->getContextObjType() !== "frm") {
             $forum_grouping = true;
         } else {
             $forum_grouping = false;
@@ -165,7 +168,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
 
         $ilCtrl = $DIC->ctrl();
         
-        if ($ilCtrl->getCmdClass() == "ilnewsitemgui") {
+        if ($ilCtrl->getCmdClass() === "ilnewsitemgui") {
             return IL_SCREEN_FULL;
         }
         
@@ -279,7 +282,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
 
             if (in_array($obj_class, ilNewsForContextBlockGUI::OBJECTS_WITH_NEWS_SUBTAB)) {
                 $this->addBlockCommand(
-                    $ilCtrl->getLinkTargetByClass(array("ilrepositorygui", $parent_gui, "ilcontainernewssettingsgui"), "show"),
+                    $ilCtrl->getLinkTargetByClass(["ilrepositorygui", $parent_gui, "ilcontainernewssettingsgui"], "show"),
                     $lng->txt("settings")
                 );
             } else {
@@ -317,7 +320,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
         }
 
         $en = "";
-        if ($ilUser->getPref("il_feed_js") == "n") {
+        if ($ilUser->getPref("il_feed_js") === "n") {
             //			$en = getJSEnabler();
         }
 
@@ -414,7 +417,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
                 $context_ref = $news["ref_id"];
             }
             
-            $lang_type = in_array($type, array("sahs", "lm", "htlm"))
+            $lang_type = in_array($type, ["sahs", "lm", "htlm"])
                 ? "lres"
                 : "obj_" . $type;
 
@@ -494,15 +497,16 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
         }
 
         if (!is_array($c) && is_object($news) && $news->getId() > 0
-            && ilNewsItem::_lookupContextObjId($news->getId()) != $ilCtrl->getContextObjId()) {
+            && ilNewsItem::_lookupContextObjId($news->getId()) !== $ilCtrl->getContextObjId()) {
             throw new ilException("News ID does not match object context.");
         }
 
 
         // collect news items to show
-        $news_list = array();
+        $news_list = [];
         if (isset($c["aggregation"]) && is_array($c["aggregation"])) {	// we have an aggregation
-            $news_list[] = array("ref_id" => $c["agg_ref_id"],
+            $news_list[] = [
+                "ref_id" => $c["agg_ref_id"],
                 "agg_ref_id" => $c["agg_ref_id"],
                 "aggregation" => $c["aggregation"],
                 "user_id" => "",
@@ -516,7 +520,8 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
                 "content_is_lang_var" => false,
                 "loc_context" => $this->std_request->getNewsContext(),
                 "context_obj_type" => $news->getContextObjType(),
-                "title" => "");
+                "title" => ""
+            ];
 
             foreach ($c["aggregation"] as $c_item) {
                 ilNewsItem::_setRead($ilUser->getId(), $c_item["id"]);
@@ -525,7 +530,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
                 $news_list[] = $c_item;
             }
         } else {								// no aggregation, simple news item
-            $news_list[] = array(
+            $news_list[] = [
                 "id" => $news->getId(),
                 "ref_id" => $this->std_request->getNewsContext(),
                 "user_id" => $news->getUserId(),
@@ -543,14 +548,15 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
                 "content_is_lang_var" => $news->getContentIsLangVar(),
                 "content_text_is_lang_var" => $news->getContentTextIsLangVar(),
                 "loc_context" => $this->std_request->getNewsContext(),
-                "title" => $news->getTitle());
+                "title" => $news->getTitle()
+            ];
             ilNewsItem::_setRead($ilUser->getId(), $this->std_request->getNewsId());
         }
 
         $row_css = "";
         $cache_deleted = false;
         foreach ($news_list as $item) {
-            $row_css = ($row_css != "tblrow1")
+            $row_css = ($row_css !== "tblrow1")
                     ? "tblrow1"
                     : "tblrow2";
 
@@ -589,14 +595,14 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
             // media player
             $ui_renderer = $this->ui->renderer();
             $ui_factory = $this->ui->factory();
-            $this->ui->factory();
-            if ($item["mob_id"] > 0 && ilObject::_exists($item["mob_id"])) {
-                $media_path = $this->getMediaPath($item["mob_id"]);
+
+            if ($item["mob_id"] > 0 && ilObject::_exists((int) $item["mob_id"])) {
+                $media_path = $this->getMediaPath((int) $item["mob_id"]);
                 $mime = ilObjMediaObject::getMimeType($media_path);
-                if (in_array($mime, array("image/jpeg", "image/svg+xml", "image/gif", "image/png"))) {
+                if (in_array($mime, ["image/jpeg", "image/svg+xml", "image/gif", "image/png"])) {
                     $title = basename($media_path);
                     $html = $ui_renderer->render($ui_factory->image()->responsive($media_path, $title));
-                } elseif (in_array($mime, array("audio/mpeg", "audio/ogg", "video/mp4", "video/x-flv", "video/webm"))) {
+                } elseif (in_array($mime, ["audio/mpeg", "audio/ogg", "video/mp4", "video/x-flv", "video/webm"])) {
                     $mp = new ilMediaPlayerGUI();
                     $mp->setFile($media_path);
                     $mp->setDisplayHeight(200);
@@ -674,7 +680,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
                 $obj_title = ilObject::_lookupTitle($obj_id);
                 
                 // file hack, not nice
-                if ($obj_type == "file") {
+                if ($obj_type === "file") {
                     $ilCtrl->setParameterByClass("ilrepositorygui", "ref_id", $item["ref_id"]);
                     $url = $ilCtrl->getLinkTargetByClass("ilrepositorygui", "sendfile");
                     $ilCtrl->setParameterByClass("ilrepositorygui", "ref_id", $this->std_request->getRefId());
@@ -690,7 +696,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
                 
                 // forum hack, not nice
                 $add = "";
-                if ($obj_type == "frm" && $item["context_sub_obj_type"] == "pos"
+                if ($obj_type === "frm" && $item["context_sub_obj_type"] === "pos"
                     && $item["context_sub_obj_id"] > 0) {
                     $pos = $item["context_sub_obj_id"];
                     $thread = ilObjForumAccess::_getThreadForPosting($pos);
@@ -700,7 +706,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
                 }
 
                 // wiki hack, not nice
-                if ($obj_type == "wiki" && $item["context_sub_obj_type"] == "wpg"
+                if ($obj_type === "wiki" && $item["context_sub_obj_type"] === "wpg"
                     && $item["context_sub_obj_id"] > 0) {
                     $wptitle = ilWikiPage::lookupTitle($item["context_sub_obj_id"]);
                     if ($wptitle != "") {
@@ -712,14 +718,14 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
                     $obj_type . "_" . $item["ref_id"] . $add;
 
                 // lm page hack, not nice
-                if (in_array($obj_type, array("lm")) && $item["context_sub_obj_type"] == "pg"
+                if (in_array($obj_type, ["lm"]) && $item["context_sub_obj_type"] === "pg"
                     && $item["context_sub_obj_id"] > 0) {
                     $url_target = "./goto.php?client_id=" . rawurlencode(CLIENT_ID) . "&target=" .
                         "pg_" . $item["context_sub_obj_id"] . "_" . $item["ref_id"];
                 }
                 
                 // blog posting hack, not nice
-                if ($obj_type == "blog" && $item["context_sub_obj_type"] == "blp"
+                if ($obj_type === "blog" && $item["context_sub_obj_type"] === "blp"
                     && $item["context_sub_obj_id"] > 0) {
                     $url_target = "./goto.php?client_id=" . rawurlencode(CLIENT_ID) . "&target=" .
                         "blog_" . $item["ref_id"] . "_" . $item["context_sub_obj_id"];
@@ -882,9 +888,9 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
         if ($ilCtrl->isAsynch()) {
             echo $this->getHTML();
             exit;
-        } else {
-            $ilCtrl->returnToParent($this);
         }
+
+        $ilCtrl->returnToParent($this);
     }
     
     /**
@@ -1241,19 +1247,19 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
             return false;
         }
 
-        if ($ilCtrl->getCmd() == "hideNotifications" ||
-            $ilCtrl->getCmd() == "showNotifications") {
+        if ($ilCtrl->getCmd() === "hideNotifications" ||
+            $ilCtrl->getCmd() === "showNotifications") {
             return false;
         }
         
-        if ($ilCtrl->getCmdClass() != "ilcolumngui" && $ilCtrl->getCmd() != "enableJS") {
+        if ($ilCtrl->getCmdClass() !== "ilcolumngui" && $ilCtrl->getCmd() !== "enableJS") {
             $sess_feed_js = "";
             if (ilSession::get("il_feed_js") != "") {
                 $sess_feed_js = ilSession::get("il_feed_js");
             }
             
-            if ($sess_feed_js != "n" &&
-                ($ilUser->getPref("il_feed_js") != "n" || $sess_feed_js == "y")) {
+            if ($sess_feed_js !== "n" &&
+                ($ilUser->getPref("il_feed_js") !== "n" || $sess_feed_js === "y")) {
                 // do not get feed dynamically, if cache hit is given.
                 //				if (!$this->feed->checkCacheHit())
                 //				{

--- a/Services/News/classes/class.ilNewsForContextBlockGUI.php
+++ b/Services/News/classes/class.ilNewsForContextBlockGUI.php
@@ -69,7 +69,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
         $lng->loadLanguageModule("news");
         $ilHelp->addHelpSection("news_block");
         
-        $this->setBlockId($ilCtrl->getContextObjId());
+        $this->setBlockId((string) $ilCtrl->getContextObjId());
         $this->setLimit(5);
         $this->setEnableNumInfo(true);
         
@@ -229,7 +229,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
             $this->getBlockType(),
             "hide_news_block",
             0,
-            $this->block_id
+            (int) $this->block_id
         );
 
         if ($this->getProperty("title") != "") {
@@ -240,17 +240,15 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
             $this->getBlockType(),
             "public_feed",
             0,
-            $this->block_id
+            (int) $this->block_id
         );
-        if ($public_feed) {
-            if ($enable_internal_rss) {
-                // @todo: rss icon HTML: ilRSSButtonGUI::get(ilRSSButtonGUI::ICON_RSS)
-                $this->addBlockCommand(
-                    ILIAS_HTTP_PATH . "/feed.php?client_id=" . rawurlencode(CLIENT_ID) . "&" .
-                        "ref_id=" . $this->std_request->getRefId(),
-                    $lng->txt("news_feed_url")
-                );
-            }
+        if ($public_feed && $enable_internal_rss) {
+            // @todo: rss icon HTML: ilRSSButtonGUI::get(ilRSSButtonGUI::ICON_RSS)
+            $this->addBlockCommand(
+                ILIAS_HTTP_PATH . "/feed.php?client_id=" . rawurlencode(CLIENT_ID) . "&" .
+                    "ref_id=" . $this->std_request->getRefId(),
+                $lng->txt("news_feed_url")
+            );
         }
 
         // add edit commands
@@ -298,22 +296,23 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
                 $this->getBlockType(),
                 "hide_news_block",
                 0,
-                $this->block_id
+                (int) $this->block_id
             )) {
             return "";
         }
 
         // do not display empty news blocks for users
         // who do not have write permission
-        if (count($this->getData()) == 0 && !$this->getEnableEdit() &&
-            $this->getRepositoryMode() && !$this->dynamic
-            && (!$news_set->get("enable_rss_for_internal") ||
+        if (!$this->dynamic && !$this->getEnableEdit() && $this->getRepositoryMode() && count($this->getData()) === 0 &&
+            (
+                !$news_set->get("enable_rss_for_internal") ||
                 !ilBlockSetting::_lookup(
                     $this->getBlockType(),
                     "public_feed",
                     0,
-                    $this->block_id
-                ))) {
+                    (int) $this->block_id
+                )
+            )) {
             return "";
         }
 
@@ -336,16 +335,16 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
             $this->getBlockType(),
             "view",
             $ilUser->getId(),
-            $this->block_id
+            (int) $this->block_id
         );
 
         // check whether notices and messages exist
         $got_notices = $got_messages = false;
         foreach ($this->data as $row) {
-            if ($row["priority"] == 0) {
+            if ((int) $row["priority"] === 0) {
                 $got_notices = true;
             }
-            if ($row["priority"] == 1) {
+            if ((int) $row["priority"] === 1) {
                 $got_messages = true;
             }
         }
@@ -487,8 +486,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
         $c = current($this->data);
         $curr_cnt = 1;
 
-        while ($c["id"] > 0 &&
-             $c["id"] != $this->std_request->getNewsId()) {
+        while ($c["id"] > 0 && (int) $c["id"] !== $this->std_request->getNewsId()) {
             $previous = $c;
             $c = next($this->data);
             $curr_cnt++;
@@ -624,8 +622,8 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
                 $obj_id = ilObject::_lookupObjId($item["ref_id"]);
                 $tpl->setCurrentBlock("access");
                 $tpl->setVariable("TXT_ACCESS", $lng->txt("news_news_item_visibility"));
-                if ($item["visibility"] == NEWS_PUBLIC ||
-                    ($item["priority"] == 0 &&
+                if ($item["visibility"] === NEWS_PUBLIC ||
+                    ((int) $item["priority"] === 0 &&
                     ilBlockSetting::_lookup(
                         "news",
                         "public_notifications",
@@ -821,7 +819,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
         if ($mob_id > 0) {
             $mob = new ilObjMediaObject($mob_id);
             $med = $mob->getMediaItem("Standard");
-            if (strcasecmp("Reference", $med->getLocationType()) == 0) {
+            if (strcasecmp("Reference", $med->getLocationType()) === 0) {
                 $media_path = $med->getLocation();
             } else {
                 $media_path = ilObjMediaObject::_getURL($mob->getId()) . "/" . $med->getLocation();
@@ -851,7 +849,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
             "view",
             "",
             $ilUser->getId(),
-            $this->block_id
+            (int) $this->block_id
         );
 
         // reload data
@@ -877,7 +875,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
             "view",
             "hide_notifications",
             $ilUser->getId(),
-            $this->block_id
+            (int) $this->block_id
         );
 
         // reload data
@@ -920,34 +918,34 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
             $this->getBlockType(),
             "public_notifications",
             0,
-            $this->block_id
+            (int) $this->block_id
         );
         $public_feed = ilBlockSetting::_lookup(
             $this->getBlockType(),
             "public_feed",
             0,
-            $this->block_id
+            (int) $this->block_id
         );
         $hide_block = ilBlockSetting::_lookup(
             $this->getBlockType(),
             "hide_news_block",
             0,
-            $this->block_id
+            (int) $this->block_id
         );
         $hide_news_per_date = ilBlockSetting::_lookup(
             $this->getBlockType(),
             "hide_news_per_date",
             0,
-            $this->block_id
+            (int) $this->block_id
         );
         $hide_news_date = ilBlockSetting::_lookup(
             $this->getBlockType(),
             "hide_news_date",
             0,
-            $this->block_id
+            (int) $this->block_id
         );
 
-        if ($hide_news_date != "") {
+        if (is_string($hide_news_date) && $hide_news_date !== '') {
             $hide_news_date = explode(" ", $hide_news_date);
         }
 
@@ -961,7 +959,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
                 "hide_news_block"
             );
             $ch->setInfo($lng->txt("news_hide_news_block_info"));
-            $ch->setChecked($hide_block);
+            $ch->setChecked((bool) $hide_block);
             $this->settings_form->addItem($ch);
             
             $hnpd = new ilCheckboxInputGUI(
@@ -969,33 +967,29 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
                 "hide_news_per_date"
             );
             $hnpd->setInfo($lng->txt("news_hide_news_per_date_info"));
-            $hnpd->setChecked($hide_news_per_date);
+            $hnpd->setChecked((bool) $hide_news_per_date);
             
             $dt_prop = new ilDateTimeInputGUI(
                 $lng->txt("news_hide_news_date"),
                 "hide_news_date"
             );
             $dt_prop->setRequired(true);
-            if ($hide_news_date != "") {
+            if (is_array($hide_news_date) && count($hide_news_date) === 2) {
                 $dt_prop->setDate(new ilDateTime($hide_news_date[0] . ' ' . $hide_news_date[1], IL_CAL_DATETIME));
             }
-            #$dt_prop->setDate($hide_news_date[0]);
-            #$dt_prop->setTime($hide_news_date[1]);
             $dt_prop->setShowTime(true);
-            //$dt_prop->setInfo($lng->txt("news_hide_news_date_info"));
             $hnpd->addSubItem($dt_prop);
                 
             $this->settings_form->addItem($hnpd);
         }
 
         // default visibility
-        if ($this->getProperty("default_visibility_option") &&
-            $enable_internal_rss) {
+        if ($enable_internal_rss && $this->getProperty("default_visibility_option")) {
             $default_visibility = ilBlockSetting::_lookup(
                 $this->getBlockType(),
                 "default_visibility",
                 0,
-                $this->block_id
+                (int) $this->block_id
             );
             if ($default_visibility == "") {
                 $default_visibility =
@@ -1015,14 +1009,13 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
         }
 
         // public notifications
-        if ($this->getProperty("public_notifications_option") &&
-            $enable_internal_rss) {
+        if ($enable_internal_rss && $this->getProperty("public_notifications_option")) {
             $ch = new ilCheckboxInputGUI(
                 $lng->txt("news_notifications_public"),
                 "notifications_public"
             );
             $ch->setInfo($lng->txt("news_notifications_public_info"));
-            $ch->setChecked($public);
+            $ch->setChecked((bool) $public);
             $this->settings_form->addItem($ch);
         }
 
@@ -1033,18 +1026,10 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
                 "notifications_public_feed"
             );
             $ch->setInfo($lng->txt("news_public_feed_info"));
-            $ch->setChecked($public_feed);
+            $ch->setChecked((bool) $public_feed);
             $this->settings_form->addItem($ch);
         }
 
-        
-        //$this->settings_form->addCheckboxProperty($lng->txt("news_public_feed"), "notifications_public_feed",
-        //	"1", $public_feed, $lng->txt("news_public_feed_info"));
-        //if ($this->getProperty("public_notifications_option"))
-        //{
-        //	$this->settings_form->addCheckboxProperty($lng->txt("news_notifications_public"), "notifications_public",
-        //		"1", $public, $lng->txt("news_notifications_public_info"));
-        //}
         $this->settings_form->addCommandButton("saveSettings", $lng->txt("save"));
         $this->settings_form->addCommandButton("cancelSettings", $lng->txt("cancel"));
         $this->settings_form->setFormAction($ilCtrl->getFormAction($this));
@@ -1068,7 +1053,6 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
         $news_set = new ilSetting("news");
         $enable_internal_rss = $news_set->get("enable_rss_for_internal");
 
-        //$public_notification = ilBlockSetting::_lookup(self::$block_type, "public_notifications",0, $block_id);
         $public_feed = ilBlockSetting::_lookup(
             self::$block_type,
             "public_feed",
@@ -1136,21 +1120,21 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
                     "public_notifications",
                     $form->getInput("notifications_public"),
                     0,
-                    $this->block_id
+                    (int) $this->block_id
                 );
                 ilBlockSetting::_write(
                     $this->getBlockType(),
                     "public_feed",
                     $form->getInput("notifications_public_feed"),
                     0,
-                    $this->block_id
+                    (int) $this->block_id
                 );
                 ilBlockSetting::_write(
                     $this->getBlockType(),
                     "default_visibility",
                     $form->getInput("default_visibility"),
                     0,
-                    $this->block_id
+                    (int) $this->block_id
                 );
             }
             
@@ -1160,26 +1144,26 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
                     "hide_news_block",
                     $form->getInput("hide_news_block"),
                     0,
-                    $this->block_id
+                    (int) $this->block_id
                 );
                 ilBlockSetting::_write(
                     $this->getBlockType(),
                     "hide_news_per_date",
                     $form->getInput("hide_news_per_date"),
                     0,
-                    $this->block_id
+                    (int) $this->block_id
                 );
 
                 // hide date
                 $hd = $this->settings_form->getItemByPostVar("hide_news_date");
                 $hide_date = $hd->getDate();
-                if ($form->getInput("hide_news_per_date") && $hide_date != null) {
+                if ($hide_date instanceof ilDateTime && $form->getInput("hide_news_per_date")) {
                     ilBlockSetting::_write(
                         $this->getBlockType(),
                         "hide_news_date",
                         $hide_date->get(IL_CAL_DATETIME),
                         0,
-                        $this->block_id
+                        (int) $this->block_id
                     );
                 } else {
                     ilBlockSetting::_write(
@@ -1187,7 +1171,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
                         "hide_news_date",
                         "",
                         0,
-                        $this->block_id
+                        (int) $this->block_id
                     );
                 }
             }
@@ -1208,7 +1192,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
         $lng = $this->lng;
         $ilUser = $this->user;
         
-        $title = ilObject::_lookupTitle($this->block_id);
+        $title = ilObject::_lookupTitle((int) $this->block_id);
         
         $tpl = new ilTemplate("tpl.show_feed_url.html", true, true, "Services/News");
         $tpl->setVariable(
@@ -1314,7 +1298,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
         $rel_tpl->setVariable("BLOCK_ID", "block_" . $this->getBlockType() . "_" . $this->getBlockId());
         $rel_tpl->setVariable(
             "TARGET",
-            $ilCtrl->getLinkTargetByClass(strtolower(get_class($this)), "enableJS", true, "", false)
+            $ilCtrl->getLinkTargetByClass(strtolower(get_class($this)), "enableJS", true, "", false)// TODO PHP8-REVIEW I am not 100% sure here, but the passed types do not match the defined paraemters
         );
             
         return $rel_tpl->get();
@@ -1344,8 +1328,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
     // New rendering
     //
 
-    protected $new_rendering = true;
-
+    protected $new_rendering = true;// TODO PHP8-REVIEW I suggest to move this to the top of the class
 
     protected function getListItemForData(array $data) : ?\ILIAS\UI\Component\Item\Item
     {
@@ -1354,10 +1337,6 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
         $props = [
             $this->lng->txt("date") => $info["creation_date"]
         ];
-
-
-        // @todo: fix this
-        // $info["user_read"]
 
         $factory = $this->ui->factory();
         $item = $factory->item()->standard($factory->link()->standard($info["news_title"], $info["url"]))

--- a/Services/News/classes/class.ilNewsForContextBlockGUI.php
+++ b/Services/News/classes/class.ilNewsForContextBlockGUI.php
@@ -88,13 +88,11 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
         if ($this->getDynamic() && !$this->cache_hit) {
             $this->dynamic = true;
             $data = [];
+        } elseif (!empty(self::$st_data)) {
+            $data = self::$st_data;
         } else {
-            if (!empty(self::$st_data)) {
-                $data = self::$st_data;
-            } else {
-                $data = $this->getNewsData();
-                self::$st_data = $data;
-            }
+            $data = $this->getNewsData();
+            self::$st_data = $data;
         }
 
         $this->setTitle($lng->txt("news_internal_news"));
@@ -270,7 +268,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
             $ilCtrl->setParameter($this, "add_mode", "");
         }
 
-        if ($this->getProperty("settings") == true) {
+        if ($this->getProperty("settings")) {
             $ref_id = $this->std_request->getRefId();
             $obj_def = $DIC["objDefinition"];
             $obj_id = ilObject::_lookupObjectId($ref_id);
@@ -280,7 +278,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
 
             $ilCtrl->setParameterByClass("ilcontainernewssettingsgui", "ref_id", $ref_id);
 
-            if (in_array($obj_class, ilNewsForContextBlockGUI::OBJECTS_WITH_NEWS_SUBTAB)) {
+            if (in_array($obj_class, self::OBJECTS_WITH_NEWS_SUBTAB)) {
                 $this->addBlockCommand(
                     $ilCtrl->getLinkTargetByClass(["ilrepositorygui", $parent_gui, "ilcontainernewssettingsgui"], "show"),
                     $lng->txt("settings")
@@ -320,7 +318,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
         }
 
         $en = "";
-        if ($ilUser->getPref("il_feed_js") === "n") {
+        if ($ilUser->getPref("il_feed_js") === "n") {// TODO PHP8-REVIEW This block can be removed
             //			$en = getJSEnabler();
         }
 
@@ -484,7 +482,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
         $tpl = new ilTemplate("tpl.show_news.html", true, true, "Services/News");
 
         // get current item in data set
-        $previous = $next = "";
+        $previous = "";
         reset($this->data);
         $c = current($this->data);
         $curr_cnt = 1;
@@ -718,8 +716,10 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
                     $obj_type . "_" . $item["ref_id"] . $add;
 
                 // lm page hack, not nice
-                if (in_array($obj_type, ["lm"]) && $item["context_sub_obj_type"] === "pg"
-                    && $item["context_sub_obj_id"] > 0) {
+                if (
+                    $item["context_sub_obj_type"] === "pg" &&
+                    $item["context_sub_obj_id"] > 0 &&
+                    in_array($obj_type, ["lm"], true)) {
                     $url_target = "./goto.php?client_id=" . rawurlencode(CLIENT_ID) . "&target=" .
                         "pg_" . $item["context_sub_obj_id"] . "_" . $item["ref_id"];
                 }
@@ -861,10 +861,10 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
 
         if ($ilCtrl->isAsynch()) {
             echo $this->getHTML();
-            exit;
-        } else {
-            $ilCtrl->returnToParent($this);
+            exit;// TODO PHP8-REVIEW This could be refactored by using the HTTP service
         }
+
+        $ilCtrl->returnToParent($this);
     }
     
     public function hideNotifications() : void
@@ -887,7 +887,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
 
         if ($ilCtrl->isAsynch()) {
             echo $this->getHTML();
-            exit;
+            exit;// TODO PHP8-REVIEW This could be refactored by using the HTTP service
         }
 
         $ilCtrl->returnToParent($this);
@@ -1337,7 +1337,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
         ilSession::set("il_feed_js", "y");
         $ilUser->writePref("il_feed_js", "y");
         echo $this->getHTML();
-        exit;
+        exit;// TODO PHP8-REVIEW This could be refactored by using the HTTP service
     }
 
     //

--- a/Services/News/classes/class.ilNewsForContextTableGUI.php
+++ b/Services/News/classes/class.ilNewsForContextTableGUI.php
@@ -81,8 +81,8 @@ class ilNewsForContextTableGUI extends ilTable2GUI
         if ($enable_internal_rss) {
             $this->tpl->setCurrentBlock("access");
             $this->tpl->setVariable("TXT_ACCESS", $lng->txt("news_news_item_visibility"));
-            if ($a_set["visibility"] == NEWS_PUBLIC ||
-                ($a_set["priority"] == 0 &&
+            if ($a_set["visibility"] === NEWS_PUBLIC ||
+                ((int) $a_set["priority"] === 0 &&
                 ilBlockSetting::_lookup(
                     "news",
                     "public_notifications",
@@ -97,7 +97,7 @@ class ilNewsForContextTableGUI extends ilTable2GUI
         }
 
         // last update
-        if ($a_set["creation_date"] != $a_set["update_date"]) {
+        if ($a_set["creation_date"] !== $a_set["update_date"]) {
             $this->tpl->setCurrentBlock("ni_update");
             $this->tpl->setVariable("TXT_LAST_UPDATE", $lng->txt("last_update"));
             $this->tpl->setVariable(

--- a/Services/News/classes/class.ilNewsForContextTableGUI.php
+++ b/Services/News/classes/class.ilNewsForContextTableGUI.php
@@ -23,9 +23,8 @@ class ilNewsForContextTableGUI extends ilTable2GUI
     protected int $perm_ref_id = 0;
     protected ilAccessHandler $access;
 
-
     public function __construct(
-        object $a_parent_obj,
+        object $a_parent_obj,// TODO PHP8-REVIEW Maybe you can use the class of the consuming GUI or (if there are several) add a list of valid types by using PHPDoc comments
         string $a_parent_cmd = "",
         int $a_perm_ref_id = 0
     ) {

--- a/Services/News/classes/class.ilNewsItem.php
+++ b/Services/News/classes/class.ilNewsItem.php
@@ -64,7 +64,7 @@ class ilNewsItem
     protected int $content_is_lang_var = 0;
     protected int $mob_id = 0;
     protected string $playtime = "";
-    private static bool $privFeedId = false;
+    private static bool $privFeedId = false;// TODO PHP8-REVIEW Maybe this should be an int (have a look at the assignments at the bottom of this class)?
     private bool $limitation = false;
     protected bool $content_text_is_lang_var = false;
     private ilGlobalTemplateInterface $main_tpl;
@@ -248,12 +248,12 @@ class ilNewsItem
     public function setContentIsLangVar(
         bool $a_content_is_lang_var = false
     ) : void {
-        $this->content_is_lang_var = $a_content_is_lang_var;
+        $this->content_is_lang_var = (int) $a_content_is_lang_var;// TODO PHP8-REVIEW Maybe the better approch is to make the variable of type bool, please decide
     }
 
     public function getContentIsLangVar() : bool
     {
-        return $this->content_is_lang_var;
+        return (bool) $this->content_is_lang_var;// TODO PHP8-REVIEW Maybe the better approch is to make the variable of type bool, please decide
     }
 
     public function setMobId(int $a_mob_id) : void
@@ -354,17 +354,17 @@ class ilNewsItem
         $this->setContentType($rec["content_type"]);
         $this->setCreationDate($rec["creation_date"]);
         $this->setUpdateDate($rec["update_date"]);
-        $this->setUserId($rec["user_id"]);
-        $this->setUpdateUserId($rec["update_user_id"]);
+        $this->setUserId((int) $rec["user_id"]);
+        $this->setUpdateUserId((int) $rec["update_user_id"]);
         $this->setVisibility($rec["visibility"]);
         $this->setContentLong((string) $rec["content_long"]);
-        $this->setPriority($rec["priority"]);
-        $this->setContentIsLangVar($rec["content_is_lang_var"]);
-        $this->setContentTextIsLangVar((int) $rec["content_text_is_lang_var"]);
+        $this->setPriority((int) $rec["priority"]);
+        $this->setContentIsLangVar((bool) $rec["content_is_lang_var"]);
+        $this->setContentTextIsLangVar((bool) $rec["content_text_is_lang_var"]);
         $this->setMobId((int) $rec["mob_id"]);
         $this->setPlaytime((string) $rec["playtime"]);
-        $this->setMobPlayCounter($rec["mob_cnt_play"]);
-        $this->setMobDownloadCounter($rec["mob_cnt_download"]);
+        $this->setMobPlayCounter((int) $rec["mob_cnt_play"]);
+        $this->setMobDownloadCounter((int) $rec["mob_cnt_download"]);
         $this->setContentHtml((bool) $rec["content_html"]);
     }
 
@@ -436,7 +436,7 @@ class ilNewsItem
                 $ilDB->setLimit($rec["cnt"] - $max_items, 0);
                 $del_set = $ilDB->query($query);
                 while ($del_item = $ilDB->fetchAssoc($del_set)) {
-                    $del_news = new ilNewsItem($del_item["id"]);
+                    $del_news = new ilNewsItem((int) $del_item["id"]);
                     $del_news->delete();
                 }
             }
@@ -516,7 +516,7 @@ class ilNewsItem
             $pd_items = $fav_rep->getFavouritesOfUser($a_user_id);
             foreach ($pd_items as $item) {
                 if (!in_array($item["ref_id"], $ref_ids)) {
-                    $ref_ids[] = $item["ref_id"];
+                    $ref_ids[] = (int) $item["ref_id"];
                 }
             }
             
@@ -615,12 +615,12 @@ class ilNewsItem
             if (!ilContainer::_lookupContainerSetting(
                 $obj_id,
                 'cont_use_news',
-                true
+                '1'
             ) || (
                 !ilContainer::_lookupContainerSetting(
                     $obj_id,
                     'cont_show_news',
-                    true
+                    '1'
                 ) && !ilContainer::_lookupContainerSetting(
                     $obj_id,
                     'news_timeline'
@@ -743,8 +743,8 @@ class ilNewsItem
         $obj_ids = [];
         $ref_id = [];
         foreach ($nodes as $node) {
-            $ref_ids[] = $node["child"];
-            $obj_ids[] = $node["obj_id"];
+            $ref_ids[] = (int) $node["child"];
+            $obj_ids[] = (int) $node["obj_id"];
         }
 
         $ilObjDataCache->preloadReferenceCache($ref_ids);
@@ -766,13 +766,13 @@ class ilNewsItem
             
             if (!$a_only_public) {
                 if (!$a_user_id) {
-                    $acc = $ilAccess->checkAccess("read", "", $node["child"]);
+                    $acc = $ilAccess->checkAccess("read", "", (int) $node["child"]);
                 } else {
                     $acc = $ilAccess->checkAccessOfUser(
                         $a_user_id,
                         "read",
                         "",
-                        $node["child"]
+                        (int) $node["child"]
                     );
                 }
                 if (!$acc) {
@@ -875,7 +875,7 @@ class ilNewsItem
         foreach ($news as $k => $v) {
             // aggregate file related news
             if ($v["context_obj_type"] === "file") {
-                if ($first_file == "") {
+                if ($first_file === "") {
                     $first_file = $k;
                 } else {
                     $to_del[] = $k;
@@ -943,7 +943,7 @@ class ilNewsItem
                 continue;
             }
 
-            if (!$a_only_public && !$ilAccess->checkAccess("read", "", $node["child"])) {
+            if (!$a_only_public && !$ilAccess->checkAccess("read", "", (int) $node["child"])) {
                 continue;
             }
             $ref_id[$node["obj_id"]] = $node["child"];
@@ -1030,7 +1030,7 @@ class ilNewsItem
             $and = " AND creation_date >= " . $ilDB->quote($limit_ts, "timestamp") . " ";
         }
         
-        if ($a_starting_date != "") {
+        if ($a_starting_date !== "") {
             $and .= " AND creation_date > " . $ilDB->quote($a_starting_date, "timestamp") . " ";
         }
 
@@ -1092,7 +1092,7 @@ class ilNewsItem
                     "news",
                     "public_notifications",
                     0,
-                    $rec["context_obj_id"]
+                    (int) $rec["context_obj_id"]
                 )))) {
                 $result[$rec["id"]] = $rec;
             }
@@ -1103,7 +1103,7 @@ class ilNewsItem
         // this is not very performant, but I do not have a better
         // idea. The keep_rss_min setting is currently (Jul 2012) only set
         // by mediacasts
-        if ($a_time_period != "" && $a_for_rss_use) {
+        if ($a_time_period && $a_for_rss_use) {
             $keep_rss_min = ilBlockSetting::_lookup(
                 "news",
                 "keep_rss_min",
@@ -1117,7 +1117,7 @@ class ilNewsItem
                     $a_starting_date,
                     $a_no_auto_generated,
                     $a_oldest_first,
-                    $keep_rss_min
+                    (int) $keep_rss_min
                 );
             }
         }
@@ -1145,6 +1145,7 @@ class ilNewsItem
 
     /**
      * @deprecated will move to ilNewsData
+     * @return int[]
      */
     public function checkNewsExistsForObjects(
         array $objects,
@@ -1163,7 +1164,7 @@ class ilNewsItem
             " AND creation_date >= " . $ilDB->quote($limit_ts, "timestamp"));
         while ($rec = $ilDB->fetchAssoc($query)) {
             if ($objects[$rec["context_obj_id"]]["type"] == $rec["context_obj_type"]) {
-                $all[] = $rec["id"];
+                $all[] = (int) $rec["id"];
             }
         }
 
@@ -1192,7 +1193,7 @@ class ilNewsItem
             $and = " AND creation_date >= " . $ilDB->quote($limit_ts, "timestamp") . " ";
         }
             
-        if ($a_starting_date != "") {
+        if ($a_starting_date !== "") {
             $and .= " AND creation_date > " . $ilDB->quote($a_starting_date, "timestamp") . " ";
         }
 
@@ -1292,14 +1293,6 @@ class ilNewsItem
             ],
             []
         );
-        
-        /*
-        $ilDB->manipulate("DELETE FROM il_news_read WHERE ".
-            "user_id = ".$ilDB->quote($a_user_id, "integer").
-            " AND news_id = ".$ilDB->quote($a_news_id, "integer"));
-        $ilDB->manipulate("INSERT INTO il_news_read (user_id, news_id) VALUES (".
-            $ilDB->quote($a_user_id, "integer").",".
-            $ilDB->quote($a_news_id, "integer").")");*/
 
         $ilAppEventHandler->raise(
             "Services/News",
@@ -1366,7 +1359,7 @@ class ilNewsItem
             $path = $tree->getPathFull($a_ref_id);
             
             foreach ($path as $key => $row) {
-                if (!in_array($row["type"], ["root", "cat", "crs", "fold", "grp"])) {
+                if (!in_array($row["type"], ["root", "cat", "crs", "fold", "grp"], true)) {
                     continue;
                 }
 
@@ -1374,7 +1367,7 @@ class ilNewsItem
                     "news",
                     "default_visibility",
                     0,
-                    $row["obj_id"]
+                    (int) $row["obj_id"]
                 );
                     
                 if ($visibility != "") {
@@ -1417,6 +1410,7 @@ class ilNewsItem
     /**
      * Get all news of a context
      * @deprecated will move to ilNewsData
+     * @return ilNewsItem[]
      */
     public static function getNewsOfContext(
         int $a_context_obj_id,
@@ -1429,7 +1423,7 @@ class ilNewsItem
         $ilDB = $DIC->database();
         $and = "";
         
-        if ($a_context_obj_id == 0 || $a_context_obj_type == "") {
+        if ($a_context_obj_id === 0 || $a_context_obj_type === "") {
             return [];
         }
 
@@ -1439,7 +1433,7 @@ class ilNewsItem
         }
         
         // get news records
-        $query = "SELECT * FROM il_news_item" .
+        $query = "SELECT id FROM il_news_item" .
             " WHERE context_obj_id = " . $ilDB->quote($a_context_obj_id, "integer") .
             " AND context_obj_type = " . $ilDB->quote($a_context_obj_type, "text") .
             $and;
@@ -1448,7 +1442,7 @@ class ilNewsItem
 
         $news_arr = [];
         while ($news = $ilDB->fetchAssoc($news_set)) {
-            $news_arr[] = new ilNewsItem($news["id"]);
+            $news_arr[] = new ilNewsItem((int) $news["id"]);
         }
         return $news_arr;
     }
@@ -1487,7 +1481,7 @@ class ilNewsItem
             $ilDB->quote($a_news_id, "integer");
         $set = $ilDB->query($query);
         $rec = $ilDB->fetchAssoc($set);
-        return $rec["title"];
+        return $rec["title"] ?? '';
     }
 
     /**
@@ -1505,7 +1499,7 @@ class ilNewsItem
         $set = $ilDB->query($query);
         $rec = $ilDB->fetchAssoc($set);
 
-        return $rec["visibility"];
+        return $rec["visibility"] ?? NEWS_USERS;
     }
 
     /**
@@ -1522,7 +1516,7 @@ class ilNewsItem
             $ilDB->quote($a_news_id, "integer");
         $set = $ilDB->query($query);
         $rec = $ilDB->fetchAssoc($set);
-        return $rec["mob_id"] ?? 0;
+        return (int) ($rec["mob_id"] ?? 0);
     }
 
     /**
@@ -1546,7 +1540,7 @@ class ilNewsItem
             $and = " AND creation_date >= " . $ilDB->quote($limit_ts, "timestamp") . " ";
         }
 
-        if ($a_starting_date != "") {
+        if ($a_starting_date !== "") {
             $and .= " AND creation_date >= " . $ilDB->quote($a_starting_date, "timestamp");
         }
 
@@ -1693,7 +1687,7 @@ class ilNewsItem
         $ilDB = $DIC->database();
         
         // Determine how many rows should be deleted
-        $query = "SELECT * " .
+        $query = "SELECT id " .
             "FROM il_news_item " .
             "WHERE " .
                 "context_obj_id = " . $ilDB->quote($a_context_obj_id, "integer") .
@@ -1704,7 +1698,7 @@ class ilNewsItem
         $set = $ilDB->query($query);
         $rec = $ilDB->fetchAssoc($set);
         
-        return (int) $rec["id"];
+        return (int) ($rec["id"] ?? 0);
     }
 
     /**
@@ -1758,7 +1752,7 @@ class ilNewsItem
 
         $ilDB = $DIC->database();
         
-        $query = "SELECT * " .
+        $query = "SELECT id " .
             "FROM il_news_item " .
             "WHERE " .
                 " mob_id = " . $ilDB->quote($a_mob_id, "integer");
@@ -1782,7 +1776,7 @@ class ilNewsItem
 
         $ilDB = $DIC->database();
         
-        $query = "SELECT * " .
+        $query = "SELECT context_obj_id " .
             "FROM il_news_item " .
             "WHERE " .
                 " id = " . $ilDB->quote($a_news_id, "integer");

--- a/Services/News/classes/class.ilNewsItem.php
+++ b/Services/News/classes/class.ilNewsItem.php
@@ -378,28 +378,28 @@ class ilNewsItem
 
         // insert new record into db
         $this->setId($ilDB->nextId("il_news_item"));
-        $ilDB->insert("il_news_item", array(
-            "id" => array("integer", $this->getId()),
-            "title" => array("text", $this->getTitle()),
-            "content" => array("clob", $this->getContent()),
-            "content_html" => array("integer", (int) $this->getContentHtml()),
-            "context_obj_id" => array("integer", $this->getContextObjId()),
-            "context_obj_type" => array("text", $this->getContextObjType()),
-            "context_sub_obj_id" => array("integer", $this->getContextSubObjId()),
-            "context_sub_obj_type" => array("text", $this->getContextSubObjType()),
-            "content_type" => array("text", $this->getContentType()),
-            "creation_date" => array("timestamp", ilUtil::now()),
-            "update_date" => array("timestamp", ilUtil::now()),
-            "user_id" => array("integer", $this->getUserId()),
-            "update_user_id" => array("integer", $this->getUpdateUserId()),
-            "visibility" => array("text", $this->getVisibility()),
-            "content_long" => array("clob", $this->getContentLong()),
-            "priority" => array("integer", $this->getPriority()),
-            "content_is_lang_var" => array("integer", $this->getContentIsLangVar()),
-            "content_text_is_lang_var" => array("integer", (int) $this->getContentTextIsLangVar()),
-            "mob_id" => array("integer", $this->getMobId()),
-            "playtime" => array("text", $this->getPlaytime())
-        ));
+        $ilDB->insert("il_news_item", [
+            "id" => ["integer", $this->getId()],
+            "title" => ["text", $this->getTitle()],
+            "content" => ["clob", $this->getContent()],
+            "content_html" => ["integer", (int) $this->getContentHtml()],
+            "context_obj_id" => ["integer", $this->getContextObjId()],
+            "context_obj_type" => ["text", $this->getContextObjType()],
+            "context_sub_obj_id" => ["integer", $this->getContextSubObjId()],
+            "context_sub_obj_type" => ["text", $this->getContextSubObjType()],
+            "content_type" => ["text", $this->getContentType()],
+            "creation_date" => ["timestamp", ilUtil::now()],
+            "update_date" => ["timestamp", ilUtil::now()],
+            "user_id" => ["integer", $this->getUserId()],
+            "update_user_id" => ["integer", $this->getUpdateUserId()],
+            "visibility" => ["text", $this->getVisibility()],
+            "content_long" => ["clob", $this->getContentLong()],
+            "priority" => ["integer", $this->getPriority()],
+            "content_is_lang_var" => ["integer", $this->getContentIsLangVar()],
+            "content_text_is_lang_var" => ["integer", (int) $this->getContentTextIsLangVar()],
+            "mob_id" => ["integer", $this->getMobId()],
+            "playtime" => ["text", $this->getPlaytime()]
+        ]);
 
         
         $news_set = new ilSetting("news");
@@ -453,37 +453,37 @@ class ilNewsItem
     {
         $ilDB = $this->db;
 
-        $fields = array(
-            "title" => array("text", $this->getTitle()),
-            "content" => array("clob", $this->getContent()),
-            "content_html" => array("integer", (int) $this->getContentHtml()),
-            "context_obj_id" => array("integer", $this->getContextObjId()),
-            "context_obj_type" => array("text", $this->getContextObjType()),
-            "context_sub_obj_id" => array("integer", $this->getContextSubObjId()),
-            "context_sub_obj_type" => array("text", $this->getContextSubObjType()),
-            "content_type" => array("text", $this->getContentType()),
-            "user_id" => array("integer", $this->getUserId()),
-            "update_user_id" => array("integer", $this->getUpdateUserId()),
-            "visibility" => array("text", $this->getVisibility()),
-            "content_long" => array("clob", $this->getContentLong()),
-            "priority" => array("integer", $this->getPriority()),
-            "content_is_lang_var" => array("integer", $this->getContentIsLangVar()),
-            "content_text_is_lang_var" => array("integer", (int) $this->getContentTextIsLangVar()),
-            "mob_id" => array("integer", $this->getMobId()),
-            "mob_cnt_play" => array("integer", $this->getMobPlayCounter()),
-            "mob_cnt_download" => array("integer", $this->getMobDownloadCounter()),
-            "playtime" => array("text", $this->getPlaytime())
-        );
+        $fields = [
+            "title" => ["text", $this->getTitle()],
+            "content" => ["clob", $this->getContent()],
+            "content_html" => ["integer", (int) $this->getContentHtml()],
+            "context_obj_id" => ["integer", $this->getContextObjId()],
+            "context_obj_type" => ["text", $this->getContextObjType()],
+            "context_sub_obj_id" => ["integer", $this->getContextSubObjId()],
+            "context_sub_obj_type" => ["text", $this->getContextSubObjType()],
+            "content_type" => ["text", $this->getContentType()],
+            "user_id" => ["integer", $this->getUserId()],
+            "update_user_id" => ["integer", $this->getUpdateUserId()],
+            "visibility" => ["text", $this->getVisibility()],
+            "content_long" => ["clob", $this->getContentLong()],
+            "priority" => ["integer", $this->getPriority()],
+            "content_is_lang_var" => ["integer", $this->getContentIsLangVar()],
+            "content_text_is_lang_var" => ["integer", (int) $this->getContentTextIsLangVar()],
+            "mob_id" => ["integer", $this->getMobId()],
+            "mob_cnt_play" => ["integer", $this->getMobPlayCounter()],
+            "mob_cnt_download" => ["integer", $this->getMobDownloadCounter()],
+            "playtime" => ["text", $this->getPlaytime()]
+        ];
 
         $now = ilUtil::now();
         if ($a_as_new) {
-            $fields["creation_date"] = array("timestamp", $now);
+            $fields["creation_date"] = ["timestamp", $now];
         }
-        $fields["update_date"] = array("timestamp", $now);
+        $fields["update_date"] = ["timestamp", $now];
 
-        $ilDB->update("il_news_item", $fields, array(
-            "id" => array("integer", $this->getId())
-        ));
+        $ilDB->update("il_news_item", $fields, [
+            "id" => ["integer", $this->getId()]
+        ]);
     }
 
 
@@ -511,7 +511,7 @@ class ilNewsItem
         // this is currently not used
         $ref_ids = [];
         
-        if (ilObjUser::_lookupPref($a_user_id, "pd_items_news") != "n") {
+        if (ilObjUser::_lookupPref($a_user_id, "pd_items_news") !== "n") {
             // get all items of the personal desktop
             $pd_items = $fav_rep->getFavouritesOfUser($a_user_id);
             foreach ($pd_items as $item) {
@@ -536,7 +536,7 @@ class ilNewsItem
             }
         }
         
-        $data = array();
+        $data = [];
 
         foreach ($ref_ids as $ref_id) {
             if (!$a_only_public) {
@@ -547,11 +547,11 @@ class ilNewsItem
                     continue;
                 }
             }
-            if (ilNewsItem::getPrivateFeedId() != false) {
+            if (self::getPrivateFeedId() != false) {
                 global $DIC;
 
                 $rbacsystem = $DIC->rbac()->system();
-                $acc = $rbacsystem->checkAccessOfUser(ilNewsItem::getPrivateFeedId(), "read", $ref_id);
+                $acc = $rbacsystem->checkAccessOfUser(self::getPrivateFeedId(), "read", $ref_id);
             
                 if (!$acc) {
                     continue;
@@ -577,7 +577,7 @@ class ilNewsItem
                 $a_cnt[$ref_id] = count($news);
             }
 
-            $data = ilNewsItem::mergeNews($data, $news);
+            $data = self::mergeNews($data, $news);
         }
 
         $data = ilArrayUtil::sortArray($data, "creation_date", "desc", false, true);
@@ -603,14 +603,14 @@ class ilNewsItem
         bool $a_ignore_date_filter = false,
         int $a_user_id = null,
         int $a_limit = 0,
-        array $a_excluded = array()
+        array $a_excluded = []
     ) : array {
         $obj_id = ilObject::_lookupObjId($a_ref_id);
         $obj_type = ilObject::_lookupType($obj_id);
 
         // get starting date
         $starting_date = "";
-        if ($obj_type == "grp" || $obj_type == "crs") {
+        if ($obj_type === "grp" || $obj_type === "crs") {
             // see #31471, #30687, and ilMembershipNotification
             if (!ilContainer::_lookupContainerSetting(
                 $obj_id,
@@ -645,7 +645,7 @@ class ilNewsItem
             }
         }
 
-        if ($obj_type == "cat" && !$a_stopnesting) {
+        if ($obj_type === "cat" && !$a_stopnesting) {
             $news = $this->getAggregatedChildNewsData(
                 $a_ref_id,
                 $a_only_public,
@@ -654,7 +654,7 @@ class ilNewsItem
                 $starting_date,
                 $a_no_auto_generated
             );
-        } elseif (($obj_type == "grp" || $obj_type == "crs") &&
+        } elseif (($obj_type === "grp" || $obj_type === "crs") &&
             !$a_stopnesting) {
             $news = $this->getAggregatedNewsData(
                 $a_ref_id,
@@ -677,7 +677,7 @@ class ilNewsItem
                 $starting_date,
                 $a_no_auto_generated
             );
-            $unset = array();
+            $unset = [];
             foreach ($news as $k => $v) {
                 if (!$a_only_public || $v["visibility"] == NEWS_PUBLIC ||
                     ($v["priority"] == 0 &&
@@ -719,14 +719,14 @@ class ilNewsItem
         bool $a_no_auto_generated = false,
         int $a_user_id = null,
         int $a_limit = 0,
-        array $a_exclude = array()
+        array $a_exclude = []
     ) : array {
         $tree = $this->tree;
         $ilAccess = $this->access;
         $ilObjDataCache = $this->obj_data_cache;
         
         // get news of parent object
-        $data = array();
+        $data = [];
         
         // get subtree
         $cur_node = $tree->getNodeData($a_ref_id);
@@ -735,7 +735,7 @@ class ilNewsItem
         if ($cur_node) {
             $nodes = $tree->getSubTree($cur_node, true);
         } else {
-            $nodes = array();
+            $nodes = [];
         }
         
         // preload object data cache
@@ -753,11 +753,11 @@ class ilNewsItem
         }
         
         // no check, for which of the objects any news are available
-        $news_obj_ids = ilNewsItem::filterObjIdsPerNews($obj_ids, $a_time_period, $a_starting_date);
+        $news_obj_ids = self::filterObjIdsPerNews($obj_ids, $a_time_period, $a_starting_date);
         //$news_obj_ids = $obj_ids;
         
         // get news for all subtree nodes
-        $contexts = array();
+        $contexts = [];
         foreach ($nodes as $node) {
             // only go on, if news are available
             if (!in_array($node["obj_id"], $news_obj_ids)) {
@@ -781,8 +781,10 @@ class ilNewsItem
             }
             
             $ref_id[$node["obj_id"]] = $node["child"];
-            $contexts[] = array("obj_id" => $node["obj_id"],
-                "obj_type" => $node["type"]);
+            $contexts[] = [
+                "obj_id" => $node["obj_id"],
+                "obj_type" => $node["type"]
+            ];
         }
         
         // sort and return
@@ -797,12 +799,12 @@ class ilNewsItem
             $a_exclude
         );
                 
-        $to_del = array();
+        $to_del = [];
         foreach ($news as $k => $v) {
             $news[$k]["ref_id"] = $ref_id[$v["context_obj_id"]];
         }
         
-        $data = ilNewsItem::mergeNews($data, $news);
+        $data = self::mergeNews($data, $news);
         $data = ilArrayUtil::sortArray($data, "creation_date", "desc", false, true);
         
         if (!$a_prevent_aggregation) {
@@ -819,8 +821,8 @@ class ilNewsItem
         array $news,
         bool $a_group_posting_sequence = false
     ) : array {
-        $to_del = array();
-        $forums = array();
+        $to_del = [];
+        $forums = [];
         $last_aggregation_forum = 0;
         
         // aggregate
@@ -830,7 +832,7 @@ class ilNewsItem
                 $forums[$last_aggregation_forum] = "";
             }
 
-            if ($v["context_obj_type"] == "frm") {
+            if ($v["context_obj_type"] === "frm") {
                 if ($forums[$v["context_obj_id"]] == "") {
                     // $forums[forum_id] = news_id;
                     $forums[$v["context_obj_id"]] = $k;
@@ -869,10 +871,10 @@ class ilNewsItem
         int $a_ref_id
     ) : array {
         $first_file = "";
-        $to_del = array();
+        $to_del = [];
         foreach ($news as $k => $v) {
             // aggregate file related news
-            if ($v["context_obj_type"] == "file") {
+            if ($v["context_obj_type"] === "file") {
                 if ($first_file == "") {
                     $first_file = $k;
                 } else {
@@ -926,15 +928,15 @@ class ilNewsItem
         $nodes = $tree->getChilds($a_ref_id);
         
         // no check, for which of the objects any news are available
-        $obj_ids = array();
+        $obj_ids = [];
         foreach ($nodes as $node) {
             $obj_ids[] = $node["obj_id"];
         }
-        $news_obj_ids = ilNewsItem::filterObjIdsPerNews($obj_ids, $a_time_period, $a_starting_date);
+        $news_obj_ids = self::filterObjIdsPerNews($obj_ids, $a_time_period, $a_starting_date);
         //$news_obj_ids = $obj_ids;
 
         // get news for all subtree nodes
-        $contexts = array();
+        $contexts = [];
         foreach ($nodes as $node) {
             // only go on, if news are available
             if (!in_array($node["obj_id"], $news_obj_ids)) {
@@ -945,8 +947,10 @@ class ilNewsItem
                 continue;
             }
             $ref_id[$node["obj_id"]] = $node["child"];
-            $contexts[] = array("obj_id" => $node["obj_id"],
-                "obj_type" => $node["type"]);
+            $contexts[] = [
+                "obj_id" => $node["obj_id"],
+                "obj_type" => $node["type"]
+            ];
         }
         
         $news = $this->queryNewsForMultipleContexts(
@@ -959,7 +963,7 @@ class ilNewsItem
         foreach ($news as $k => $v) {
             $news[$k]["ref_id"] = $ref_id[$v["context_obj_id"]];
         }
-        $data = ilNewsItem::mergeNews($data, $news);
+        $data = self::mergeNews($data, $news);
         
         // sort and return
         $data = ilArrayUtil::sortArray($data, "creation_date", "desc", false, true);
@@ -1044,7 +1048,7 @@ class ilNewsItem
             ? " creation_date ASC, id ASC "
             : " creation_date DESC, id DESC ";
 
-        if ($a_for_rss_use && ilNewsItem::getPrivateFeedId() == false) {
+        if ($a_for_rss_use && self::getPrivateFeedId() == false) {
             $query = "SELECT * " .
                 "FROM il_news_item " .
                 " WHERE " .
@@ -1052,12 +1056,12 @@ class ilNewsItem
                     " AND context_obj_type = " . $ilDB->quote($this->getContextObjType(), "text") .
                     $and .
                     " ORDER BY " . $ordering;
-        } elseif (ilNewsItem::getPrivateFeedId() != false) {
+        } elseif (self::getPrivateFeedId() != false) {
             $query = "SELECT il_news_item.* " .
                 ", il_news_read.user_id user_read " .
                 "FROM il_news_item LEFT JOIN il_news_read " .
                 "ON il_news_item.id = il_news_read.news_id AND " .
-                " il_news_read.user_id = " . $ilDB->quote(ilNewsItem::getPrivateFeedId(), "integer") .
+                " il_news_read.user_id = " . $ilDB->quote(self::getPrivateFeedId(), "integer") .
                 " WHERE " .
                     "context_obj_id = " . $ilDB->quote($this->getContextObjId(), "integer") .
                     " AND context_obj_type = " . $ilDB->quote($this->getContextObjType(), "text") .
@@ -1077,12 +1081,12 @@ class ilNewsItem
         }
         //echo $query;
         $set = $ilDB->query($query);
-        $result = array();
+        $result = [];
         while ($rec = $ilDB->fetchAssoc($set)) {
             if ($a_limit > 0 && count($result) >= $a_limit) {
                 continue;
             }
-            if (!$a_for_rss_use || (ilNewsItem::getPrivateFeedId() != false) || ($rec["visibility"] == NEWS_PUBLIC ||
+            if (!$a_for_rss_use || (self::getPrivateFeedId() != false) || ($rec["visibility"] == NEWS_PUBLIC ||
                 ($rec["priority"] == 0 &&
                 ilBlockSetting::_lookup(
                     "news",
@@ -1130,7 +1134,7 @@ class ilNewsItem
     {
         global $DIC;
         $ilDB = $DIC->database();
-        $news = array();
+        $news = [];
         $set = $ilDB->query("SELECT * FROM il_news_item " .
             " WHERE " . $ilDB->in("id", $a_news_ids, false, "integer"));
         while ($rec = $ilDB->fetchAssoc($set)) {
@@ -1148,7 +1152,7 @@ class ilNewsItem
     ) : array {
         $ilDB = $this->db;
         
-        $all = array();
+        $all = [];
 
         $limit_ts = self::handleTimePeriod($a_time_period);
 
@@ -1177,7 +1181,7 @@ class ilNewsItem
         bool $a_no_auto_generated = false,
         int $a_user_id = null,
         int $a_limit = 0,
-        array $a_exclude = array()
+        array $a_exclude = []
     ) : array {
         $ilDB = $this->db;
         $ilUser = $this->user;
@@ -1204,27 +1208,27 @@ class ilNewsItem
             $and .= " AND " . $ilDB->in("id", $a_exclude, true, "integer") . " ";
         }
 
-        $ids = array();
-        $type = array();
+        $ids = [];
+        $type = [];
 
         foreach ($a_contexts as $cont) {
             $ids[] = $cont["obj_id"];
             $type[$cont["obj_id"]] = $cont["obj_type"];
         }
         
-        if ($a_for_rss_use && ilNewsItem::getPrivateFeedId() == false) {
+        if ($a_for_rss_use && self::getPrivateFeedId() == false) {
             $query = "SELECT * " .
                 "FROM il_news_item " .
                 " WHERE " .
                     $ilDB->in("context_obj_id", $ids, false, "integer") . " " .
                     $and .
                     " ORDER BY creation_date DESC ";
-        } elseif (ilNewsItem::getPrivateFeedId() != false) {
+        } elseif (self::getPrivateFeedId() != false) {
             $query = "SELECT il_news_item.* " .
                 ", il_news_read.user_id as user_read " .
                 "FROM il_news_item LEFT JOIN il_news_read " .
                 "ON il_news_item.id = il_news_read.news_id AND " .
-                " il_news_read.user_id = " . $ilDB->quote(ilNewsItem::getPrivateFeedId(), "integer") .
+                " il_news_read.user_id = " . $ilDB->quote(self::getPrivateFeedId(), "integer") .
                 " WHERE " .
                     $ilDB->in("context_obj_id", $ids, false, "integer") . " " .
                     $and .
@@ -1247,10 +1251,10 @@ class ilNewsItem
         }
 
         $set = $ilDB->query($query);
-        $result = array();
+        $result = [];
         while ($rec = $ilDB->fetchAssoc($set)) {
             if ($type[$rec["context_obj_id"]] == $rec["context_obj_type"]) {
-                if (!$a_for_rss_use || ilNewsItem::getPrivateFeedId() != false || ($rec["visibility"] == NEWS_PUBLIC ||
+                if (!$a_for_rss_use || self::getPrivateFeedId() != false || ($rec["visibility"] == NEWS_PUBLIC ||
                     ($rec["priority"] == 0 &&
                     ilBlockSetting::_lookup(
                         "news",
@@ -1282,11 +1286,11 @@ class ilNewsItem
         
         $ilDB->replace(
             "il_news_read",
-            array(
-                "user_id" => array("integer", $a_user_id),
-                "news_id" => array("integer", $a_news_id)
-                ),
-            array()
+            [
+                "user_id" => ["integer", $a_user_id],
+                "news_id" => ["integer", $a_news_id]
+            ],
+            []
         );
         
         /*
@@ -1300,7 +1304,7 @@ class ilNewsItem
         $ilAppEventHandler->raise(
             "Services/News",
             "readNews",
-            array("user_id" => $a_user_id, "news_ids" => array($a_news_id))
+            ["user_id" => $a_user_id, "news_ids" => [$a_news_id]]
         );
     }
     
@@ -1324,7 +1328,7 @@ class ilNewsItem
         $ilAppEventHandler->raise(
             "Services/News",
             "unreadNews",
-            array("user_id" => $a_user_id, "news_ids" => array($a_news_id))
+            ["user_id" => $a_user_id, "news_ids" => [$a_news_id]]
         );
     }
     
@@ -1362,7 +1366,7 @@ class ilNewsItem
             $path = $tree->getPathFull($a_ref_id);
             
             foreach ($path as $key => $row) {
-                if (!in_array($row["type"], array("root", "cat","crs", "fold", "grp"))) {
+                if (!in_array($row["type"], ["root", "cat", "crs", "fold", "grp"])) {
                     continue;
                 }
 
@@ -1551,7 +1555,7 @@ class ilNewsItem
         //" WHERE context_obj_id IN (".implode(ilUtil::quoteArray($a_obj_ids),",").")".$and;
 
         $set = $ilDB->query($query);
-        $objs = array();
+        $objs = [];
         while ($rec = $ilDB->fetchAssoc($set)) {
             $objs[] = $rec["obj_id"];
         }
@@ -1606,7 +1610,7 @@ class ilNewsItem
             $cnt = count($a_aggregation);
             
             // forums
-            if ($a_context_obj_type == "frm") {
+            if ($a_context_obj_type === "frm") {
                 if ($cnt > 1) {
                     return sprintf($lng->txt("news_x_postings"), $cnt);
                 } else {
@@ -1615,7 +1619,7 @@ class ilNewsItem
             } else {	// files
                 $up_cnt = $cr_cnt = 0;
                 foreach ($a_aggregation as $item) {
-                    if ($item["title"] == "file_updated") {
+                    if ($item["title"] === "file_updated") {
                         $up_cnt++;
                     } else {
                         $cr_cnt++;
@@ -1642,9 +1646,9 @@ class ilNewsItem
                     return ilObjectPlugin::lookupTxtById($a_context_obj_type, $a_title);
                 }
                 return $lng->txt($a_title);
-            } else {
-                return $a_title;
             }
+
+            return $a_title;
         }
     }
 
@@ -1668,9 +1672,9 @@ class ilNewsItem
             }
             $lng->loadLanguageModule($a_context_obj_type);
             return $lng->txt($a_content);
-        } else {
-            return $a_content;
         }
+
+        return $a_content;
     }
 
     /**
@@ -1734,7 +1738,7 @@ class ilNewsItem
         $id = (int) $rec["id"];
         if ($a_only_today) {
             $now = ilUtil::now();
-            if (substr($now, 0, 10) != substr($rec["update_date"], 0, 10)) {
+            if (strpos($rec["update_date"], substr($now, 0, 10)) !== 0) {
                 $id = 0;
             }
         }
@@ -1758,10 +1762,10 @@ class ilNewsItem
             "WHERE " .
                 " mob_id = " . $ilDB->quote($a_mob_id, "integer");
                 
-        $usages = array();
+        $usages = [];
         $set = $ilDB->query($query);
         while ($rec = $ilDB->fetchAssoc($set)) {
-            $usages[$rec["id"]] = array("type" => "news", "id" => $rec["id"]);
+            $usages[$rec["id"]] = ["type" => "news", "id" => $rec["id"]];
         }
         
         return $usages;
@@ -1809,7 +1813,7 @@ class ilNewsItem
         $news_set = new ilSetting("news");
         $allow_shorter_periods = $news_set->get("allow_shorter_periods");
         $allow_longer_periods = $news_set->get("allow_longer_periods");
-        $default_per = ilNewsItem::_lookupDefaultPDPeriod();
+        $default_per = self::_lookupDefaultPDPeriod();
         
         $per = ilBlockSetting::_lookup(
             "pdnews",
@@ -1847,7 +1851,7 @@ class ilNewsItem
      */
     public static function setPrivateFeedId(int $a_userId) : void
     {
-        ilNewsItem::$privFeedId = $a_userId;
+        self::$privFeedId = $a_userId;
     }
 
     /**
@@ -1855,7 +1859,7 @@ class ilNewsItem
      */
     public static function getPrivateFeedId() : int
     {
-        return ilNewsItem::$privFeedId;
+        return self::$privFeedId;
     }
     
     /**
@@ -1876,7 +1880,7 @@ class ilNewsItem
         }
         
         $m_item = $mob->getMediaItem($a_purpose);
-        if ($m_item->getLocationType() != "Reference") {
+        if ($m_item->getLocationType() !== "Reference") {
             $file = $mob_dir . "/" . $m_item->getLocation();
             if (file_exists($file) && is_file($file)) {
                 if ($a_increase_download_cnt) {
@@ -1884,17 +1888,17 @@ class ilNewsItem
                 }
                 ilFileDelivery::deliverFileLegacy($file, $m_item->getLocation(), "", false, false, false);
                 return true;
-            } else {
-                $this->main_tpl->setOnScreenMessage('failure', "File not found!", true);
-                return false;
             }
-        } else {
-            if ($a_increase_download_cnt) {
-                $this->increaseDownloadCounter();
-            }
-            ilUtil::redirect($m_item->getLocation());
+
+            $this->main_tpl->setOnScreenMessage('failure', "File not found!", true);
+            return false;
         }
-        return false;
+
+        if ($a_increase_download_cnt) {
+            $this->increaseDownloadCounter();
+        }
+
+        ilUtil::redirect($m_item->getLocation());
     }
     
     /**
@@ -1948,12 +1952,12 @@ class ilNewsItem
         $news_ids = array_keys($data);
         $set = $ilDB->query("SELECT id FROM il_news_item " .
             " WHERE " . $ilDB->in("id", $news_ids, false, "integer"));
-        $existing_ids = array();
+        $existing_ids = [];
         while ($rec = $ilDB->fetchAssoc($set)) {
-            $existing_ids[] = $rec["id"];
+            $existing_ids[] = (int) $rec["id"];
         }
         //var_dump($existing_ids);
-        $existing_news = array();
+        $existing_news = [];
         foreach ($data as $k => $v) {
             if (in_array($k, $existing_ids)) {
                 $existing_news[$k] = $v;

--- a/Services/News/classes/class.ilNewsItemGUI.php
+++ b/Services/News/classes/class.ilNewsItemGUI.php
@@ -44,7 +44,7 @@ class ilNewsItemGUI
     protected int $requested_news_item_id;
     protected string $add_mode;
     protected StandardGUIRequest $std_request;
-    private \ilGlobalTemplateInterface $main_tpl;
+    private ilGlobalTemplateInterface $main_tpl;
 
     public function __construct()
     {
@@ -263,7 +263,7 @@ class ilNewsItemGUI
     }
 
     // FORM NewsItem: Get current values for NewsItem form.
-    public function getValuesNewsItem(\ilPropertyFormGUI $a_form) : void
+    public function getValuesNewsItem(ilPropertyFormGUI $a_form) : void
     {
         $values = [];
 
@@ -340,7 +340,7 @@ class ilNewsItemGUI
     {
         $ilCtrl = $this->ctrl;
 
-        if ($this->add_mode == "block") {
+        if ($this->add_mode === "block") {
             $ilCtrl->returnToParent($this);
         } else {
             $ilCtrl->redirect($this, "editNews");
@@ -370,7 +370,7 @@ class ilNewsItemGUI
             // delete old media object
             $media_delete = $this->std_request->getDeleteMedia();
             if ($media["name"] != "" || $media_delete != "") {
-                if ($this->news_item->getMobId() > 0 && ilObject::_lookupType($this->news_item->getMobId()) == "mob") {
+                if ($this->news_item->getMobId() > 0 && ilObject::_lookupType($this->news_item->getMobId()) === "mob") {
                     $old_mob_id = $this->news_item->getMobId();
                 }
                 $this->news_item->setMobId(0);
@@ -415,7 +415,7 @@ class ilNewsItemGUI
     {
         $ilCtrl = $this->ctrl;
 
-        if ($this->add_mode == "block") {
+        if ($this->add_mode === "block") {
             $ilCtrl->returnToParent($this);
         } else {
             return $this->editNews();
@@ -595,7 +595,7 @@ class ilNewsItemGUI
 
     public static function isRteActivated() : bool
     {
-        if (ilObjAdvancedEditing::_getRichTextEditor() == "") {
+        if (ilObjAdvancedEditing::_getRichTextEditor() === "") {
             return false;
         }
         return true;

--- a/Services/News/classes/class.ilNewsItemGUI.php
+++ b/Services/News/classes/class.ilNewsItemGUI.php
@@ -101,7 +101,7 @@ class ilNewsItemGUI
     {
         // check, if news item id belongs to context
         if (isset($this->news_item) && $this->news_item->getId() > 0
-            && ilNewsItem::_lookupContextObjId($this->news_item->getId()) != $this->getContextObjId()) {
+            && ilNewsItem::_lookupContextObjId($this->news_item->getId()) !== $this->getContextObjId()) {
             throw new ilException("News ID does not match object context.");
         }
 
@@ -216,7 +216,7 @@ class ilNewsItemGUI
         $text_area = new ilTextAreaInputGUI($lng->txt("news_news_item_content"), "news_content");
         $text_area->setInfo("");
         $text_area->setRequired(false);
-        $text_area->setRows("4");
+        $text_area->setRows(4);
         $form->addItem($text_area);
 
         // Property Visibility
@@ -297,9 +297,6 @@ class ilNewsItemGUI
             $this->news_item->setContent($form->getInput("news_content"));
             $this->news_item->setVisibility($form->getInput("news_visibility"));
 
-            //			$data = $form->getInput('media');
-            //			var_dump($data);
-
             $media = $_FILES["media"];
             if ($media["name"] != "") {
                 $mob = ilObjMediaObject::_saveTempFileAsMediaObject($media["name"], $media["tmp_name"], true);
@@ -311,11 +308,8 @@ class ilNewsItemGUI
             if (self::isRteActivated()) {
                 $this->news_item->setContentHtml(true);
             }
-            //$this->news_item->setContentLong($form->getInput("news_content_long"));
 
             // changed
-            //$this->news_item->setContextObjId($this->ctrl->getContextObjId());
-            //$this->news_item->setContextObjType($this->ctrl->getContextObjType());
             $this->news_item->setContextObjId($this->getContextObjId());
             $this->news_item->setContextObjType($this->getContextObjType());
             $this->news_item->setContextSubObjId($this->getContextSubObjId());
@@ -458,7 +452,7 @@ class ilNewsItemGUI
         }
 
         // check whether at least one item is selected
-        if (count($this->std_request->getNewsIds()) == 0) {
+        if (count($this->std_request->getNewsIds()) === 0) {
             $this->main_tpl->setOnScreenMessage('failure', $lng->txt("no_checkbox"));
             return $this->editNews();
         }
@@ -502,16 +496,12 @@ class ilNewsItemGUI
 
         $block_gui = new ilNewsForContextBlockGUI();
 
-        //$block_gui->setParentClass("ilinfoscreengui");
-        //$block_gui->setParentCmd("showSummary");
         $block_gui->setEnableEdit($this->getEnableEdit());
 
 
         $news_item = new ilNewsItem();
 
         // changed
-        //$news_item->setContextObjId($this->ctrl->getContextObjId());
-        //$news_item->setContextObjType($this->ctrl->getContextObjType());
         $news_item->setContextObjId($this->getContextObjId());
         $news_item->setContextObjType($this->getContextObjType());
         $news_item->setContextSubObjId($this->getContextSubObjId());

--- a/Services/News/classes/class.ilNewsItemGUI.php
+++ b/Services/News/classes/class.ilNewsItemGUI.php
@@ -74,7 +74,7 @@ class ilNewsItemGUI
             $this->news_item = new ilNewsItem($this->requested_news_item_id);
         }
 
-        $this->ctrl->saveParameter($this, array("news_item_id"));
+        $this->ctrl->saveParameter($this, ["news_item_id"]);
 
         // Init EnableEdit.
         $this->setEnableEdit(false);
@@ -232,14 +232,14 @@ class ilNewsItemGUI
 
         // media
         $media = new ilFileInputGUI($lng->txt('news_media'), 'media');
-        $media->setSuffixes(array("jpeg", "jpg", "png", "gif", "mp4", "mp3"));
+        $media->setSuffixes(["jpeg", "jpg", "png", "gif", "mp4", "mp3"]);
         $media->setRequired(false);
         $media->setALlowDeletion(true);
         $media->setValue(" ");
         $form->addItem($media);
         
         // save and cancel commands
-        if (in_array($a_mode, array(self::FORM_CREATE, self::FORM_RE_CREATE))) {
+        if (in_array($a_mode, [self::FORM_CREATE, self::FORM_RE_CREATE])) {
             $form->addCommandButton("saveNewsItem", $lng->txt("save"), "news_btn_create");
             $form->addCommandButton("cancelSaveNewsItem", $lng->txt("cancel"), "news_btn_cancel_create");
         } else {
@@ -265,7 +265,7 @@ class ilNewsItemGUI
     // FORM NewsItem: Get current values for NewsItem form.
     public function getValuesNewsItem(\ilPropertyFormGUI $a_form) : void
     {
-        $values = array();
+        $values = [];
 
         $values["news_title"] = $this->news_item->getTitle();
         $values["news_content"] = $this->news_item->getContent() . $this->news_item->getContentLong();
@@ -538,7 +538,7 @@ class ilNewsItemGUI
         $news_item->setContextSubObjType($this->getContextSubObjType());
 
         $perm_ref_id = 0;
-        if (in_array($this->getContextObjType(), array("cat", "grp", "crs", "root"))) {
+        if (in_array($this->getContextObjType(), ["cat", "grp", "crs", "root"])) {
             $data = $news_item->getNewsForRefId(
                 $this->requested_ref_id,
                 false,

--- a/Services/News/classes/class.ilNewsRendererFactory.php
+++ b/Services/News/classes/class.ilNewsRendererFactory.php
@@ -19,7 +19,8 @@
  */
 class ilNewsRendererFactory
 {
-    protected static array $renderer = array();
+    /** @var array<string, ilNewsDefaultRendererGUI> */
+    protected static array $renderer = [];
 
     public static function getRenderer(string $a_context_obj_type) : ilNewsRendererGUI
     {

--- a/Services/News/classes/class.ilNewsTimelineGUI.php
+++ b/Services/News/classes/class.ilNewsTimelineGUI.php
@@ -164,16 +164,16 @@ class ilNewsTimelineGUI
         $timeline = ilTimelineGUI::getInstance();
 
         // get like widget
-        $obj_ids = array_unique(array_map(function ($a) {
-            return $a["context_obj_id"];
+        $obj_ids = array_unique(array_map(static function (array $a) : int {
+            return (int) $a["context_obj_id"];
         }, $news_data));
         $likef = new ilLikeFactoryGUI();
         $like_gui = $likef->widget($obj_ids);
 
         $js_items = [];
         foreach ($news_data as $d) {
-            $news_item = new ilNewsItem($d["id"]);
-            $item = ilNewsTimelineItemGUI::getInstance($news_item, $d["ref_id"], $like_gui);
+            $news_item = new ilNewsItem((int) $d["id"]);
+            $item = ilNewsTimelineItemGUI::getInstance($news_item, (int) $d["ref_id"], $like_gui);
             $item->setUserEditAll($this->getUserEditAll());
             $timeline->addItem($item);
             $js_items[$d["id"]] = [
@@ -238,16 +238,16 @@ class ilNewsTimelineGUI
         $timeline = ilTimelineGUI::getInstance();
 
         // get like widget
-        $obj_ids = array_unique(array_map(static function ($a) {
-            return $a["context_obj_id"];
+        $obj_ids = array_unique(array_map(static function ($a) : int {
+            return (int) $a["context_obj_id"];
         }, $news_data));
         $likef = new ilLikeFactoryGUI();
         $like_gui = $likef->widget($obj_ids);
 
         $js_items = [];
         foreach ($news_data as $d) {
-            $news_item = new ilNewsItem($d["id"]);
-            $item = ilNewsTimelineItemGUI::getInstance($news_item, $d["ref_id"], $like_gui);
+            $news_item = new ilNewsItem((int) $d["id"]);
+            $item = ilNewsTimelineItemGUI::getInstance($news_item, (int) $d["ref_id"], $like_gui);
             $item->setUserEditAll($this->getUserEditAll());
             $timeline->addItem($item);
             $js_items[$d["id"]] = [
@@ -357,7 +357,7 @@ class ilNewsTimelineGUI
 
             $obj_id = ilObject::_lookupObjectId($this->ref_id);
 
-            if ($news_item->getContextObjId() == $obj_id) {
+            if ($news_item->getContextObjId() === $obj_id) {
                 $news_item->setUpdateUserId($this->user->getId());
                 $news_item->update();
 

--- a/Services/News/classes/class.ilNewsTimelineGUI.php
+++ b/Services/News/classes/class.ilNewsTimelineGUI.php
@@ -98,7 +98,7 @@ class ilNewsTimelineGUI
             case "illikegui":
                 $i = new ilNewsItem($this->news_id);
                 $likef = new ilLikeFactoryGUI();
-                $like_gui = $likef->widget(array($i->getContextObjId()));
+                $like_gui = $likef->widget([$i->getContextObjId()]);
                 $ctrl->saveParameter($this, "news_id");
                 $like_gui->setObject(
                     $i->getContextObjId(),
@@ -127,7 +127,7 @@ class ilNewsTimelineGUI
                 break;
 
             default:
-                if (in_array($cmd, array("show", "save", "update", "loadMore", "remove", "updateNewsItem"))) {
+                if (in_array($cmd, ["show", "save", "update", "loadMore", "remove", "updateNewsItem"])) {
                     $this->$cmd();
                 }
         }
@@ -170,13 +170,13 @@ class ilNewsTimelineGUI
         $likef = new ilLikeFactoryGUI();
         $like_gui = $likef->widget($obj_ids);
 
-        $js_items = array();
+        $js_items = [];
         foreach ($news_data as $d) {
             $news_item = new ilNewsItem($d["id"]);
             $item = ilNewsTimelineItemGUI::getInstance($news_item, $d["ref_id"], $like_gui);
             $item->setUserEditAll($this->getUserEditAll());
             $timeline->addItem($item);
-            $js_items[$d["id"]] = array(
+            $js_items[$d["id"]] = [
                 "id" => $d["id"],
                 "user_id" => $d["user_id"],
                 "title" => $d["title"],
@@ -186,7 +186,7 @@ class ilNewsTimelineGUI
                 "visibility" => $d["visibility"],
                 "content_type" => $d["content_type"],
                 "mob_id" => $d["mob_id"]
-            );
+            ];
         }
 
         $this->tpl->addOnLoadCode("il.News.setItems(" . json_encode($js_items, JSON_THROW_ON_ERROR) . ");");
@@ -238,19 +238,19 @@ class ilNewsTimelineGUI
         $timeline = ilTimelineGUI::getInstance();
 
         // get like widget
-        $obj_ids = array_unique(array_map(function ($a) {
+        $obj_ids = array_unique(array_map(static function ($a) {
             return $a["context_obj_id"];
         }, $news_data));
         $likef = new ilLikeFactoryGUI();
         $like_gui = $likef->widget($obj_ids);
 
-        $js_items = array();
+        $js_items = [];
         foreach ($news_data as $d) {
             $news_item = new ilNewsItem($d["id"]);
             $item = ilNewsTimelineItemGUI::getInstance($news_item, $d["ref_id"], $like_gui);
             $item->setUserEditAll($this->getUserEditAll());
             $timeline->addItem($item);
-            $js_items[$d["id"]] = array(
+            $js_items[$d["id"]] = [
                 "id" => $d["id"],
                 "user_id" => $d["user_id"],
                 "title" => $d["title"],
@@ -260,7 +260,7 @@ class ilNewsTimelineGUI
                 "visibility" => $d["visibility"],
                 "content_type" => $d["content_type"],
                 "mob_id" => $d["mob_id"]
-            );
+            ];
         }
 
         $obj = new stdClass();

--- a/Services/News/classes/class.ilNewsTimelineGUI.php
+++ b/Services/News/classes/class.ilNewsTimelineGUI.php
@@ -267,16 +267,16 @@ class ilNewsTimelineGUI
         $obj->data = $js_items;
         $obj->html = $timeline->render(true);
 
-        echo json_encode($obj, JSON_THROW_ON_ERROR);
+        echo json_encode($obj, JSON_THROW_ON_ERROR);// TODO PHP8-REVIEW This could be refactored by using the HTTP service
         exit;
     }
 
     protected function updateNewsItem() : void
     {
-        if ($this->std_request->getNewsAction() == "save") {
+        if ($this->std_request->getNewsAction() === "save") {
             $this->save();
         }
-        if ($this->std_request->getNewsAction() == "update") {
+        if ($this->std_request->getNewsAction() === "update") {
             $this->update();
         }
     }
@@ -344,7 +344,7 @@ class ilNewsTimelineGUI
 
             // delete old media object
             if ($media["name"] != "" || $this->std_request->getDeleteMedia() > 0) {
-                if ($news_item->getMobId() > 0 && ilObject::_lookupType($news_item->getMobId()) == "mob") {
+                if ($news_item->getMobId() > 0 && ilObject::_lookupType($news_item->getMobId()) === "mob") {
                     $old_mob_id = $news_item->getMobId();
                 }
                 $news_item->setMobId(0);
@@ -378,10 +378,10 @@ class ilNewsTimelineGUI
     public function remove() : void
     {
         $news_item = new ilNewsItem($this->std_request->getNewsId());
-        if ($this->user->getId() == $news_item->getUserId() || $this->getUserEditAll()) {
+        if ($this->getUserEditAll() || $this->user->getId() === $news_item->getUserId()) {
             $news_item->delete();
         }
-        exit;
+        exit;// TODO PHP8-REVIEW This could be refactored by using the HTTP service
     }
 
     protected function getEditModal($form = null) : string

--- a/Services/News/classes/class.ilNewsTimelineItemGUI.php
+++ b/Services/News/classes/class.ilNewsTimelineItemGUI.php
@@ -29,13 +29,13 @@ class ilNewsTimelineItemGUI implements ilTimelineItemInt
     protected int $news_item_ref_id;
     protected int $ref_id;
     protected ilCtrl $ctrl;
-    protected \ilLikeGUI $like_gui;
+    protected ilLikeGUI $like_gui;
     protected StandardGUIRequest $std_request;
 
     protected function __construct(
         ilNewsItem $a_news_item,
         int $a_news_ref_id,
-        \ilLikeGUI $a_like_gui
+        ilLikeGUI $a_like_gui
     ) {
         global $DIC;
 
@@ -57,7 +57,7 @@ class ilNewsTimelineItemGUI implements ilTimelineItemInt
     public static function getInstance(
         ilNewsItem $a_news_item,
         int $a_news_ref_id,
-        \ilLikeGUI $a_like_gui
+        ilLikeGUI $a_like_gui
     ) : self {
         return new self($a_news_item, $a_news_ref_id, $a_like_gui);
     }
@@ -298,7 +298,7 @@ class ilNewsTimelineItemGUI implements ilTimelineItemInt
         if ($i->getMobId() > 0) {
             $mob = new ilObjMediaObject($i->getMobId());
             $med = $mob->getMediaItem("Standard");
-            if (strcasecmp("Reference", $med->getLocationType()) == 0) {
+            if (strcasecmp("Reference", $med->getLocationType()) === 0) {
                 $media_path = $med->getLocation();
             } else {
                 $media_path = ilObjMediaObject::_getURL($mob->getId()) . "/" . $med->getLocation();

--- a/Services/News/classes/class.ilNewsTimelineItemGUI.php
+++ b/Services/News/classes/class.ilNewsTimelineItemGUI.php
@@ -106,11 +106,11 @@ class ilNewsTimelineItemGUI implements ilTimelineItemInt
         $obj_id = $i->getContextObjId();
 
         // edited?
-        if ($i->getCreationDate() != $i->getUpdateDate()) {
+        if ($i->getCreationDate() !== $i->getUpdateDate()) {
             $tpl->setCurrentBlock("edited");
             $update_date = new ilDateTime($i->getUpdateDate(), IL_CAL_DATETIME);
             $tpl->setVariable("TXT_EDITED", $this->lng->txt("cont_news_edited"));
-            if ($i->getUpdateUserId() > 0 && ($i->getUpdateUserId() != $i->getUserId())) {
+            if ($i->getUpdateUserId() > 0 && ($i->getUpdateUserId() !== $i->getUserId())) {
                 $tpl->setVariable("TXT_USR_EDITED", ilUserUtil::getNamePresentation(
                     $i->getUpdateUserId(),
                     false,
@@ -123,7 +123,7 @@ class ilNewsTimelineItemGUI implements ilTimelineItemInt
         }
 
         // context object link
-        if ($this->news_item_ref_id > 0 && $this->ref_id != $this->news_item_ref_id) {
+        if ($this->news_item_ref_id > 0 && $this->ref_id !== $this->news_item_ref_id) {
             $tpl->setCurrentBlock("object");
             $tpl->setVariable("OBJ_TITLE", ilObject::_lookupTitle($obj_id));
             $tpl->setVariable("OBJ_IMG", ilObject::_getIcon($obj_id));
@@ -167,7 +167,7 @@ class ilNewsTimelineItemGUI implements ilTimelineItemInt
         $list->setHeaderIcon(ilAdvancedSelectionListGUI::DOWN_ARROW_DARK);
         $list->setUseImages(false);
 
-        if ($i->getPriority() == 1 && ($i->getUserId() == $this->user->getId() || $this->getUserEditAll())) {
+        if ($i->getPriority() === 1 && ($i->getUserId() === $this->user->getId() || $this->getUserEditAll())) {
             $list->addItem(
                 $this->lng->txt("edit"),
                 "",
@@ -209,7 +209,7 @@ class ilNewsTimelineItemGUI implements ilTimelineItemInt
         $ui_factory = $DIC->ui()->factory();
         $ui_renderer = $DIC->ui()->renderer();
 
-        if (in_array($mime, array("image/jpeg", "image/svg+xml", "image/gif", "image/png"))) {
+        if (in_array($mime, ["image/jpeg", "image/svg+xml", "image/gif", "image/png"])) {
             $item_id = "il-news-modal-img-" . $i->getId();
             $title = basename($media_path);
             $image = $ui_renderer->render($ui_factory->image()->responsive($media_path, $title));
@@ -219,7 +219,7 @@ class ilNewsTimelineItemGUI implements ilTimelineItemInt
             $img_tpl->setVariable("IMAGE", $image);
 
             $html = $img_tpl->get();
-        } elseif (in_array($mime, array("audio/mpeg", "audio/ogg", "video/mp4", "video/x-flv", "video/webm"))) {
+        } elseif (in_array($mime, ["audio/mpeg", "audio/ogg", "video/mp4", "video/x-flv", "video/webm"])) {
             $mp = new ilMediaPlayerGUI();
             $mp->setFile($media_path);
             $html = $mp->getMediaPlayerHtml();
@@ -242,7 +242,7 @@ class ilNewsTimelineItemGUI implements ilTimelineItemInt
 
         $modal_html = "";
 
-        if (in_array($mime, array("image/jpeg", "image/svg+xml", "image/gif", "image/png"))) {
+        if (in_array($mime, ["image/jpeg", "image/svg+xml", "image/gif", "image/png"])) {
             $title = basename($media_path);
             $item_id = "il-news-modal-img-" . $i->getId();
             $image = $ui_renderer->render($ui_factory->image()->responsive($media_path, $title));

--- a/Services/News/classes/class.ilNewsTimelineItemGUI.php
+++ b/Services/News/classes/class.ilNewsTimelineItemGUI.php
@@ -161,9 +161,6 @@ class ilNewsTimelineItemGUI implements ilTimelineItemInt
         $list = new ilAdvancedSelectionListGUI();
         $list->setListTitle("");
         $list->setId("news_tl_act_" . $i->getId());
-        //$list->setSelectionHeaderClass("small");
-        //$list->setItemLinkClass("xsmall");
-        //$list->setLinksMode("il_ContainerItemCommand2");
         $list->setHeaderIcon(ilAdvancedSelectionListGUI::DOWN_ARROW_DARK);
         $list->setUseImages(false);
 
@@ -284,7 +281,6 @@ class ilNewsTimelineItemGUI implements ilTimelineItemInt
         );
         $note_gui->setDefaultCommand("getWidget");
 
-        //ilNoteGUI::getListCommentsJSCall($this->ajax_hash, $redraw_js)
         $html .= $this->ctrl->getHTML($note_gui);
 
         $this->ctrl->setParameterByClass("ilnewstimelinegui", "news_id", $this->std_request->getNewsId());

--- a/Services/News/classes/class.ilObjNewsSettingsGUI.php
+++ b/Services/News/classes/class.ilObjNewsSettingsGUI.php
@@ -51,7 +51,7 @@ class ilObjNewsSettingsGUI extends ilObjectGUI
                 break;
 
             default:
-                if (!$cmd || $cmd == 'view') {
+                if ($cmd === null || $cmd === '' || $cmd === 'view') {
                     $cmd = "editSettings";
                 }
 

--- a/Services/News/classes/class.ilObjNewsSettingsGUI.php
+++ b/Services/News/classes/class.ilObjNewsSettingsGUI.php
@@ -122,7 +122,7 @@ class ilObjNewsSettingsGUI extends ilObjectGUI
         );
         $cb_prop->setValue("1");
         $cb_prop->setInfo($lng->txt("news_enable_internal_news_info"));
-        $cb_prop->setChecked($enable_internal_news);
+        $cb_prop->setChecked((bool) $enable_internal_news);
         $form->addItem($cb_prop);
 
         // Default Visibility
@@ -144,7 +144,7 @@ class ilObjNewsSettingsGUI extends ilObjectGUI
         );
         $nr_sel->setInfo($lng->txt("news_nr_of_items_info"));
         $nr_sel->setOptions($nr_opts);
-        $nr_sel->setValue($news_set->get("max_items"));
+        $nr_sel->setValue((string) $news_set->get("max_items"));
         $form->addItem($nr_sel);
 
         // Access Cache
@@ -155,7 +155,7 @@ class ilObjNewsSettingsGUI extends ilObjectGUI
         );
         $min_sel->setInfo($lng->txt("news_cache_info"));
         $min_sel->setOptions($min_opts);
-        $min_sel->setValue($news_set->get("acc_cache_mins"));
+        $min_sel->setValue((string) $news_set->get("acc_cache_mins"));
         $form->addItem($min_sel);
         
         // PD News Period
@@ -170,7 +170,7 @@ class ilObjNewsSettingsGUI extends ilObjectGUI
         );
         $per_sel->setInfo($lng->txt("news_pd_period_info"));
         $per_sel->setOptions($per_opts);
-        $per_sel->setValue(ilNewsItem::_lookupDefaultPDPeriod());
+        $per_sel->setValue((string) ilNewsItem::_lookupDefaultPDPeriod());
         $form->addItem($per_sel);
 
         // Allow user to choose lower values
@@ -180,7 +180,7 @@ class ilObjNewsSettingsGUI extends ilObjectGUI
         );
         $sp_prop->setValue("1");
         $sp_prop->setInfo($lng->txt("news_allow_shorter_periods_info"));
-        $sp_prop->setChecked($allow_shorter_periods);
+        $sp_prop->setChecked((bool) $allow_shorter_periods);
         $form->addItem($sp_prop);
 
         // Allow user to choose higher values
@@ -190,7 +190,7 @@ class ilObjNewsSettingsGUI extends ilObjectGUI
         );
         $lp_prop->setValue("1");
         $lp_prop->setInfo($lng->txt("news_allow_longer_periods_info"));
-        $lp_prop->setChecked($allow_longer_periods);
+        $lp_prop->setChecked((bool) $allow_longer_periods);
         $form->addItem($lp_prop);
 
         // Enable rss for internal news
@@ -200,7 +200,7 @@ class ilObjNewsSettingsGUI extends ilObjectGUI
         );
         $cb_prop->setValue("1");
         $cb_prop->setInfo($lng->txt("news_enable_internal_rss_info"));
-        $cb_prop->setChecked($enable_internal_rss);
+        $cb_prop->setChecked((bool) $enable_internal_rss);
 
         // RSS News Period
         $rssp_opts = [
@@ -247,7 +247,7 @@ class ilObjNewsSettingsGUI extends ilObjectGUI
         );
         $cb_prop->setValue("1");
         $cb_prop->setInfo($lng->txt("news_enable_private_feed_info"));
-        $cb_prop->setChecked($enable_private_feed);
+        $cb_prop->setChecked((bool) $enable_private_feed);
         $form->addItem($cb_prop);
 
         if ($ilAccess->checkAccess('write', '', $this->object->getRefId())) {
@@ -267,7 +267,7 @@ class ilObjNewsSettingsGUI extends ilObjectGUI
         if (!$ilAccess->checkAccess('write', '', $this->object->getRefId())) {
             $ilCtrl->redirect($this, "view");
         }
-        
+
         // empty news cache
         $this->acache = new ilNewsCache();
         $this->acache->deleteAllEntries();
@@ -290,10 +290,10 @@ class ilObjNewsSettingsGUI extends ilObjectGUI
             $news_set->set("rss_period", $form->getInput("news_rss_period"));
             $news_set->set("rss_title_format", $form->getInput("rss_title_format"));
 
-            if ($form->getInput("enable_internal_rss") != 0) {
+            if ($form->getInput("enable_internal_rss")) {
                 $news_set->set("enable_private_feed", $form->getInput("enable_private_feed"));
             } else {
-                $news_set->set("enable_private_feed", 0);
+                $news_set->set("enable_private_feed", '0');
             }
 
             $this->tpl->setOnScreenMessage('success', $this->lng->txt("settings_saved"), true);

--- a/Services/News/classes/class.ilObjNewsSettingsGUI.php
+++ b/Services/News/classes/class.ilObjNewsSettingsGUI.php
@@ -68,7 +68,7 @@ class ilObjNewsSettingsGUI extends ilObjectGUI
             $this->tabs_gui->addTarget(
                 "news_edit_news_settings",
                 $this->ctrl->getLinkTarget($this, "editSettings"),
-                array("editSettings", "view")
+                ["editSettings", "view"]
             );
         }
 
@@ -76,7 +76,7 @@ class ilObjNewsSettingsGUI extends ilObjectGUI
             $this->tabs_gui->addTarget(
                 "perm_settings",
                 $this->ctrl->getLinkTargetByClass('ilpermissiongui', "perm"),
-                array(),
+                [],
                 'ilpermissiongui'
             );
         }
@@ -137,7 +137,7 @@ class ilObjNewsSettingsGUI extends ilObjectGUI
         $form->addItem($radio_group);
 
         // Number of news items per object
-        $nr_opts = array(50 => 50, 100 => 100, 200 => 200);
+        $nr_opts = [50 => 50, 100 => 100, 200 => 200];
         $nr_sel = new ilSelectInputGUI(
             $lng->txt("news_nr_of_items"),
             "news_max_items"
@@ -148,7 +148,7 @@ class ilObjNewsSettingsGUI extends ilObjectGUI
         $form->addItem($nr_sel);
 
         // Access Cache
-        $min_opts = array(0 => 0, 1 => 1, 2 => 2, 5 => 5, 10 => 10, 20 => 20, 30 => 30, 60 => 60);
+        $min_opts = [0 => 0, 1 => 1, 2 => 2, 5 => 5, 10 => 10, 20 => 20, 30 => 30, 60 => 60];
         $min_sel = new ilSelectInputGUI(
             $lng->txt("news_cache"),
             "news_acc_cache_mins"
@@ -159,10 +159,11 @@ class ilObjNewsSettingsGUI extends ilObjectGUI
         $form->addItem($min_sel);
         
         // PD News Period
-        $per_opts = array(
+        $per_opts = [
             7 => "1 " . $lng->txt("week"),
             30 => "1 " . $lng->txt("month"),
-            366 => "1 " . $lng->txt("year"));
+            366 => "1 " . $lng->txt("year")
+        ];
         $per_sel = new ilSelectInputGUI(
             $lng->txt("news_pd_period"),
             "news_pd_period"
@@ -202,7 +203,7 @@ class ilObjNewsSettingsGUI extends ilObjectGUI
         $cb_prop->setChecked($enable_internal_rss);
 
         // RSS News Period
-        $rssp_opts = array(
+        $rssp_opts = [
             2 => "2 " . $lng->txt("days"),
             3 => "3 " . $lng->txt("days"),
             5 => "5 " . $lng->txt("days"),
@@ -213,7 +214,7 @@ class ilObjNewsSettingsGUI extends ilObjectGUI
             120 => "4 " . $lng->txt("months"),
             180 => "6 " . $lng->txt("months"),
             365 => "1 " . $lng->txt("year")
-        );
+        ];
         $rssp_sel = new ilSelectInputGUI(
             $lng->txt("news_rss_period"),
             "news_rss_period"
@@ -228,10 +229,10 @@ class ilObjNewsSettingsGUI extends ilObjectGUI
         $form->addItem($sh);
 
         // title format for rss entries
-        $options = array(
+        $options = [
             "" => $lng->txt("news_rss_title_format_obj_news"),
             "news_obj" => $lng->txt("news_rss_title_format_news_obj"),
-        );
+        ];
         $si = new ilSelectInputGUI($lng->txt("news_rss_title_format"), "rss_title_format");
         $si->setOptions($options);
         $si->setValue($rss_title_format);

--- a/Services/News/classes/class.ilPDNewsBlockGUI.php
+++ b/Services/News/classes/class.ilPDNewsBlockGUI.php
@@ -54,7 +54,7 @@ class ilPDNewsBlockGUI extends ilNewsForContextBlockGUI
         );
 
         $this->acache = new ilNewsCache();
-        $cres = unserialize($this->acache->getEntry($this->user->getId() . ":0"));
+        $cres = unserialize($this->acache->getEntry($this->user->getId() . ":0"), ["allowed_classes" => false]);
         $this->cache_hit = false;
         if ($this->acache->getLastAccessStatus() == "hit" && is_array($cres)) {
             self::$st_data = ilNewsItem::prepareNewsDataFromCache($cres);
@@ -63,7 +63,7 @@ class ilPDNewsBlockGUI extends ilNewsForContextBlockGUI
 
         if ($this->getDynamic() && !$this->cache_hit) {
             $this->dynamic = true;
-            $data = array();
+            $data = [];
         } else {
             // do not ask two times for the data (e.g. if user displays a
             // single item on the personal desktop and the news block is
@@ -112,11 +112,6 @@ class ilPDNewsBlockGUI extends ilNewsForContextBlockGUI
     public function getBlockType() : string
     {
         return self::$block_type;
-    }
-
-    protected function isRepositoryObject() : bool
-    {
-        return false;
     }
 
     public static function getScreenMode() : string
@@ -258,11 +253,6 @@ class ilPDNewsBlockGUI extends ilNewsForContextBlockGUI
         return $content_block->getHTML();
     }
 
-    public function showNews() : string
-    {
-        return parent::showNews();
-    }
-
     public function editSettings(ilPropertyFormGUI $a_private_form = null) : string
     {
         $ilUser = $this->user;
@@ -285,7 +275,7 @@ class ilPDNewsBlockGUI extends ilNewsForContextBlockGUI
 
             $form->setTableWidth("100%");
 
-            $per_opts = array(
+            $per_opts = [
                 2 => "2 " . $lng->txt("days"),
                 3 => "3 " . $lng->txt("days"),
                 5 => "5 " . $lng->txt("days"),
@@ -295,9 +285,10 @@ class ilPDNewsBlockGUI extends ilNewsForContextBlockGUI
                 60 => "2 " . $lng->txt("months"),
                 120 => "4 " . $lng->txt("months"),
                 180 => "6 " . $lng->txt("months"),
-                366 => "1 " . $lng->txt("year"));
+                366 => "1 " . $lng->txt("year")
+            ];
 
-            $unset = array();
+            $unset = [];
             foreach ($per_opts as $k => $opt) {
                 if (!$allow_shorter_periods && ($k < $default_per)) {
                     $unset[$k] = $k;
@@ -371,13 +362,6 @@ class ilPDNewsBlockGUI extends ilNewsForContextBlockGUI
         return $feed_form;
     }
 
-    public function cancelSettings() : void
-    {
-        $ilCtrl = $this->ctrl;
-        
-        $ilCtrl->returnToParent($this);
-    }
-    
     public function saveSettings() : string
     {
         $ilCtrl = $this->ctrl;

--- a/Services/News/classes/class.ilPDNewsBlockGUI.php
+++ b/Services/News/classes/class.ilPDNewsBlockGUI.php
@@ -56,12 +56,12 @@ class ilPDNewsBlockGUI extends ilNewsForContextBlockGUI
         $this->acache = new ilNewsCache();
         $cres = unserialize($this->acache->getEntry($this->user->getId() . ":0"), ["allowed_classes" => false]);
         $this->cache_hit = false;
-        if ($this->acache->getLastAccessStatus() == "hit" && is_array($cres)) {
+        if (is_array($cres) && $this->acache->getLastAccessStatus() === "hit") {
             self::$st_data = ilNewsItem::prepareNewsDataFromCache($cres);
             $this->cache_hit = true;
         }
 
-        if ($this->getDynamic() && !$this->cache_hit) {
+        if (!$this->cache_hit && $this->getDynamic()) {
             $this->dynamic = true;
             $data = [];
         } else {
@@ -189,7 +189,7 @@ class ilPDNewsBlockGUI extends ilNewsForContextBlockGUI
         }
 
         $en = "";
-        if ($ilUser->getPref("il_feed_js") == "n") {
+        if ($ilUser->getPref("il_feed_js") === "n") {
             $en = $this->getJSEnabler();
         }
 

--- a/Services/News/classes/class.ilPDNewsBlockGUI.php
+++ b/Services/News/classes/class.ilPDNewsBlockGUI.php
@@ -211,7 +211,7 @@ class ilPDNewsBlockGUI extends ilNewsForContextBlockGUI
             $tpl->setVariable("TXT_PRIV_TITLE", $lng->txt("news_get_priv_feed_title"));
             
             // #14365
-            if ($ilUser->_getFeedPass($GLOBALS['DIC']['ilUser']->getId())) {
+            if (ilObjUser::_getFeedPass($GLOBALS['DIC']['ilUser']->getId())) {
                 $tpl->setVariable("TXT_PRIV_INFO", $lng->txt("news_get_priv_feed_info"));
                 $tpl->setVariable("TXT_PRIV_FEED_URL", $lng->txt("news_feed_url"));
                 $tpl->setVariable(
@@ -305,18 +305,10 @@ class ilPDNewsBlockGUI extends ilNewsForContextBlockGUI
                 $lng->txt("news_pd_period"),
                 "news_pd_period"
             );
-            //$per_sel->setInfo($lng->txt("news_pd_period_info"));
             $per_sel->setOptions($per_opts);
-            $per_sel->setValue($per);
+            $per_sel->setValue((string) $per);
             $form->addItem($per_sel);
         
-            //$form->addCheckboxProperty($lng->txt("news_public_feed"), "notifications_public_feed",
-            //	"1", $public_feed, $lng->txt("news_public_feed_info"));
-            //if ($this->getProperty("public_notifications_option"))
-            //{
-            //	$form->addCheckboxProperty($lng->txt("news_notifications_public"), "notifications_public",
-            //		"1", $public, $lng->txt("news_notifications_public_info"));
-            //}
             $form->addCommandButton("saveSettings", $lng->txt("save"));
             $form->addCommandButton("cancelSettings", $lng->txt("cancel"));
             
@@ -327,7 +319,7 @@ class ilPDNewsBlockGUI extends ilNewsForContextBlockGUI
             if (!$a_private_form) {
                 $a_private_form = $this->initPrivateSettingsForm();
             }
-            $returnForm .= ($returnForm == "")
+            $returnForm .= ($returnForm === "")
                 ? $a_private_form->getHTML()
                 : "<br>" . $a_private_form->getHTML();
         }
@@ -348,7 +340,7 @@ class ilPDNewsBlockGUI extends ilNewsForContextBlockGUI
         $feed_form->setTableWidth("100%");
 
         $enable_private_feed = new ilCheckboxInputGUI($lng->txt("news_enable_private_feed"), "enable_private_feed");
-        $enable_private_feed->setChecked($ilUser->_getFeedPass($ilUser->getId()));
+        $enable_private_feed->setChecked((bool) ilObjUser::_getFeedPass($ilUser->getId()));
         $feed_form->addItem($enable_private_feed);
 
         $passwd = new ilPasswordInputGUI($lng->txt("password"), "desired_password");
@@ -374,7 +366,7 @@ class ilPDNewsBlockGUI extends ilNewsForContextBlockGUI
             "news_pd_period",
             $this->std_request->getDashboardPeriod(),
             $ilUser->getId(),
-            $this->block_id
+            (int) $this->block_id// TODO PHP8-REVIEW Not sure about this cast, but an int is exptected and a string is passed
         );
         
         $cache = new ilNewsCache();
@@ -394,7 +386,7 @@ class ilPDNewsBlockGUI extends ilNewsForContextBlockGUI
         if ($form->checkInput()) {
             // Deactivate private Feed - just delete the password
             if (!$form->getInput("enable_private_feed")) {
-                $ilUser->_setFeedPass($ilUser->getId(), "");
+                ilObjUser::_setFeedPass($ilUser->getId(), "");
                 $this->main_tpl->setOnScreenMessage('success', $lng->txt("priv_feed_disabled"), true);
                 // $ilCtrl->returnToParent($this);
                 $ilCtrl->redirect($this, "showFeedUrl");
@@ -404,7 +396,7 @@ class ilPDNewsBlockGUI extends ilNewsForContextBlockGUI
                     $form->getItemByPostVar("desired_password")->setAlert($lng->txt("passwd_equals_ilpasswd"));
                     $this->main_tpl->setOnScreenMessage('failure', $lng->txt("form_input_not_valid"));
                 } else {
-                    $ilUser->_setFeedPass($ilUser->getId(), $passwd);
+                    ilObjUser::_setFeedPass($ilUser->getId(), $passwd);
                     $this->main_tpl->setOnScreenMessage('success', $lng->txt("saved_successfully"), true);
                     $ilCtrl->redirect($this, "showFeedUrl");
                 }

--- a/Services/News/classes/class.ilPDNewsGUI.php
+++ b/Services/News/classes/class.ilPDNewsGUI.php
@@ -87,8 +87,8 @@ class ilPDNewsGUI
         $lng = $this->lng;
         $tpl = $this->tpl;
 
-        $ref_ids = array();
-        $obj_ids = array();
+        $ref_ids = [];
+        $obj_ids = [];
         $pd_items = $this->fav_manager->getFavouritesOfUser($ilUser->getId());
         foreach ($pd_items as $item) {
             $ref_ids[] = $item["ref_id"];
@@ -107,7 +107,7 @@ class ilPDNewsGUI
         // related objects (contexts) of news
         $contexts[0] = $lng->txt("news_all_items");
         
-        $conts = array();
+        $conts = [];
         $sel_has_news = false;
         foreach ($ref_ids as $ref_id) {
             $obj_id = ilObject::_lookupObjId($ref_id);
@@ -119,9 +119,9 @@ class ilPDNewsGUI
             }
         }
         
-        $cnt = array();
+        $cnt = [];
         $nitem = new ilNewsItem();
-        $news_items = $nitem->_getNewsItemsOfUser(
+        $news_items = ilNewsItem::_getNewsItemsOfUser(
             $ilUser->getId(),
             false,
             true,
@@ -168,7 +168,7 @@ class ilPDNewsGUI
         $news_per = $this->std_request->getNewsPer();
 
         $this->ctrl->setParameter($this, "news_ref_id", $news_ref_id);
-        $ilUser->writePref("news_sel_ref_id", $news_ref_id);
+        $ilUser->writePref("news_sel_ref_id", (string) $news_ref_id);
         if ($news_per > 0) {
             ilSession::set("news_pd_news_per", $news_per);
         }
@@ -179,7 +179,7 @@ class ilPDNewsGUI
     {
         $ilUser = $this->user;
         $this->ctrl->setParameter($this, "news_ref_id", 0);
-        $ilUser->writePref("news_sel_ref_id", 0);
+        $ilUser->writePref("news_sel_ref_id", '0');
         ilSession::clear("news_pd_news_per");
         $this->ctrl->redirect($this, "view");
     }

--- a/Services/News/classes/class.ilPDNewsGUI.php
+++ b/Services/News/classes/class.ilPDNewsGUI.php
@@ -91,8 +91,8 @@ class ilPDNewsGUI
         $obj_ids = [];
         $pd_items = $this->fav_manager->getFavouritesOfUser($ilUser->getId());
         foreach ($pd_items as $item) {
-            $ref_ids[] = $item["ref_id"];
-            $obj_ids[] = $item["obj_id"];
+            $ref_ids[] = (int) $item["ref_id"];
+            $obj_ids[] = (int) $item["obj_id"];
         }
         
         $sel_ref_id = ($this->std_request->getNewsRefId() > 0)
@@ -114,7 +114,7 @@ class ilPDNewsGUI
             $title = ilObject::_lookupTitle($obj_id);
             
             $conts[$ref_id] = $title;
-            if ($sel_ref_id == $ref_id) {
+            if ((int) $sel_ref_id === $ref_id) {
                 $sel_has_news = true;
             }
         }
@@ -140,7 +140,7 @@ class ilPDNewsGUI
         
         
         if ($sel_ref_id > 0) {
-            $obj_id = ilObject::_lookupObjId($sel_ref_id);
+            $obj_id = ilObject::_lookupObjId((int) $sel_ref_id);
             $obj_type = ilObject::_lookupType($obj_id);
             $nitem->setContextObjId($obj_id);
             $nitem->setContextObjType($obj_type);

--- a/Services/News/classes/class.ilPDNewsTableGUI.php
+++ b/Services/News/classes/class.ilPDNewsTableGUI.php
@@ -22,14 +22,14 @@ use ILIAS\News\StandardGUIRequest;
 class ilPDNewsTableGUI extends ilTable2GUI
 {
     protected string $selected_context;
-    protected array $contexts;
+    protected array $contexts;// TODO PHP8-REVIEW Maybe you can specify the shape of the array
     protected ilObjUser $user;
     protected StandardGUIRequest $std_request;
 
     public function __construct(
-        object $a_parent_obj,
+        object $a_parent_obj,// TODO PHP8-REVIEW Maybe you can use the class of the consuming GUI or (if there are several) add a list of valid types by using PHPDoc comments
         string $a_parent_cmd,
-        array $a_contexts,
+        array $a_contexts,// TODO PHP8-REVIEW Maybe you can specify the shape of the array
         string $a_selected_context
     ) {
         global $DIC;
@@ -103,7 +103,7 @@ class ilPDNewsTableGUI extends ilTable2GUI
 
         $si = new ilSelectInputGUI($this->lng->txt("news_time_period"), "news_per");
         $si->setOptions($options);
-        $si->setValue($per);
+        $si->setValue((string) $per);
         $this->addFilterItem($si);
         
         // related to...
@@ -122,7 +122,7 @@ class ilPDNewsTableGUI extends ilTable2GUI
         $enable_internal_rss = $news_set->get("enable_rss_for_internal");
 
         // context
-        $obj_id = ilObject::_lookupObjId($a_set["ref_id"]);
+        $obj_id = ilObject::_lookupObjId((int) $a_set["ref_id"]);
         $obj_type = ilObject::_lookupType($obj_id);
         $obj_title = ilObject::_lookupTitle($obj_id);
             
@@ -130,10 +130,10 @@ class ilPDNewsTableGUI extends ilTable2GUI
         if ($a_set["user_id"] > 0) {
             $this->tpl->setCurrentBlock("user_info");
             if ($obj_type === "frm") {
-                if (ilForumProperties::_isAnonymized($a_set["context_obj_id"])) {
+                if (ilForumProperties::_isAnonymized((int) $a_set["context_obj_id"])) {
                     if ($a_set["context_sub_obj_type"] === "pos" &&
                         $a_set["context_sub_obj_id"] > 0) {
-                        $post = new ilForumPost($a_set["context_sub_obj_id"]);
+                        $post = new ilForumPost((int) $a_set["context_sub_obj_id"]);
                         if (is_string($post->getUserAlias()) && $post->getUserAlias() !== '') {
                             $this->tpl->setVariable("VAL_AUTHOR", ilUtil::stripSlashes($post->getUserAlias()));
                         } else {
@@ -142,24 +142,24 @@ class ilPDNewsTableGUI extends ilTable2GUI
                     } else {
                         $this->tpl->setVariable("VAL_AUTHOR", $lng->txt("forums_anonymous"));
                     }
-                } elseif (ilObject::_exists($a_set["user_id"])) {
-                    $user_obj = new ilObjUser($a_set["user_id"]);
+                } elseif (ilObject::_exists((int) $a_set["user_id"])) {
+                    $user_obj = new ilObjUser((int) $a_set["user_id"]);
                     $this->tpl->setVariable("VAL_AUTHOR", $user_obj->getLogin());
                 }
-            } elseif (ilObject::_exists($a_set["user_id"])) {
-                $this->tpl->setVariable("VAL_AUTHOR", ilObjUser::_lookupLogin($a_set["user_id"]));
+            } elseif (ilObject::_exists((int) $a_set["user_id"])) {
+                $this->tpl->setVariable("VAL_AUTHOR", ilObjUser::_lookupLogin((int) $a_set["user_id"]));
             }
             $this->tpl->setVariable("TXT_AUTHOR", $lng->txt("author"));
             $this->tpl->parseCurrentBlock();
         }
         
         // media player
-        if ($a_set["content_type"] == NEWS_AUDIO &&
-            $a_set["mob_id"] > 0 && ilObject::_exists($a_set["mob_id"])) {
-            $mob = new ilObjMediaObject($a_set["mob_id"]);
+        if ($a_set["content_type"] === NEWS_AUDIO &&
+            $a_set["mob_id"] > 0 && ilObject::_exists((int) $a_set["mob_id"])) {
+            $mob = new ilObjMediaObject((int) $a_set["mob_id"]);
             $med = $mob->getMediaItem("Standard");
             $mpl = new ilMediaPlayerGUI();
-            $mpl->setFile(ilObjMediaObject::_getDirectory($a_set["mob_id"]) . "/" .
+            $mpl->setFile(ilObjMediaObject::_getDirectory((int) $a_set["mob_id"]) . "/" .
                 $med->getLocation());
             $this->tpl->setCurrentBlock("player");
             $this->tpl->setVariable(
@@ -173,8 +173,8 @@ class ilPDNewsTableGUI extends ilTable2GUI
         if ($enable_internal_rss) {
             $this->tpl->setCurrentBlock("access");
             $this->tpl->setVariable("TXT_ACCESS", $lng->txt("news_news_item_visibility"));
-            if ($a_set["visibility"] == NEWS_PUBLIC ||
-                ($a_set["priority"] == 0 &&
+            if ($a_set["visibility"] === NEWS_PUBLIC ||
+                ((int) $a_set["priority"] === 0 &&
                 ilBlockSetting::_lookup(
                     "news",
                     "public_notifications",
@@ -194,7 +194,11 @@ class ilPDNewsTableGUI extends ilTable2GUI
             $this->tpl->setVariable(
                 "VAL_CONTENT",
                 nl2br($this->makeClickable(
-                    ilNewsItem::determineNewsContent($a_set["context_obj_type"], $a_set["content"], $a_set["content_text_is_lang_var"])
+                    ilNewsItem::determineNewsContent(
+                        $a_set["context_obj_type"],
+                        $a_set["content"],
+                        (bool) $a_set["content_text_is_lang_var"]
+                    )
                 ))
             );
             $this->tpl->parseCurrentBlock();
@@ -219,7 +223,7 @@ class ilPDNewsTableGUI extends ilTable2GUI
         if ($obj_type === "frm" && $a_set["context_sub_obj_type"] === "pos"
             && $a_set["context_sub_obj_id"] > 0) {
             $pos = $a_set["context_sub_obj_id"];
-            $thread = ilObjForumAccess::_getThreadForPosting($pos);
+            $thread = ilObjForumAccess::_getThreadForPosting((int) $pos);
             if ($thread > 0) {
                 $add = "_" . $thread . "_" . $pos;
             }
@@ -243,7 +247,7 @@ class ilPDNewsTableGUI extends ilTable2GUI
         // wiki hack, not nice
         if ($obj_type === "wiki" && $a_set["context_sub_obj_type"] === "wpg"
             && $a_set["context_sub_obj_id"] > 0) {
-            $wptitle = ilWikiPage::lookupTitle($a_set["context_sub_obj_id"]);
+            $wptitle = ilWikiPage::lookupTitle((int) $a_set["context_sub_obj_id"]);
             if ($wptitle != "") {
                 $add = "_" . ilWikiUtil::makeUrlTitle($wptitle);
             }

--- a/Services/News/classes/class.ilPDNewsTableGUI.php
+++ b/Services/News/classes/class.ilPDNewsTableGUI.php
@@ -75,7 +75,7 @@ class ilPDNewsTableGUI extends ilTable2GUI
         $allow_longer_periods = $news_set->get("allow_longer_periods");
         $default_per = ilNewsItem::_lookupDefaultPDPeriod();
 
-        $options = array(
+        $options = [
             2 => sprintf($lng->txt("news_period_x_days"), 2),
             3 => sprintf($lng->txt("news_period_x_days"), 3),
             5 => sprintf($lng->txt("news_period_x_days"), 5),
@@ -85,9 +85,10 @@ class ilPDNewsTableGUI extends ilTable2GUI
             60 => sprintf($lng->txt("news_period_x_months"), 2),
             120 => sprintf($lng->txt("news_period_x_months"), 4),
             180 => sprintf($lng->txt("news_period_x_months"), 6),
-            366 => $lng->txt("news_period_1_year"));
+            366 => $lng->txt("news_period_1_year")
+        ];
             
-        $unset = array();
+        $unset = [];
         foreach ($options as $k => $opt) {
             if (!$allow_shorter_periods && ($k < $default_per)) {
                 $unset[$k] = $k;
@@ -128,12 +129,12 @@ class ilPDNewsTableGUI extends ilTable2GUI
         // user
         if ($a_set["user_id"] > 0) {
             $this->tpl->setCurrentBlock("user_info");
-            if ($obj_type == "frm") {
+            if ($obj_type === "frm") {
                 if (ilForumProperties::_isAnonymized($a_set["context_obj_id"])) {
-                    if ($a_set["context_sub_obj_type"] == "pos" &&
+                    if ($a_set["context_sub_obj_type"] === "pos" &&
                         $a_set["context_sub_obj_id"] > 0) {
                         $post = new ilForumPost($a_set["context_sub_obj_id"]);
-                        if ($post->getUserAlias() != "") {
+                        if (is_string($post->getUserAlias()) && $post->getUserAlias() !== '') {
                             $this->tpl->setVariable("VAL_AUTHOR", ilUtil::stripSlashes($post->getUserAlias()));
                         } else {
                             $this->tpl->setVariable("VAL_AUTHOR", $lng->txt("forums_anonymous"));
@@ -141,16 +142,12 @@ class ilPDNewsTableGUI extends ilTable2GUI
                     } else {
                         $this->tpl->setVariable("VAL_AUTHOR", $lng->txt("forums_anonymous"));
                     }
-                } else {
-                    if (ilObject::_exists($a_set["user_id"])) {
-                        $user_obj = new ilObjUser($a_set["user_id"]);
-                        $this->tpl->setVariable("VAL_AUTHOR", $user_obj->getLogin());
-                    }
+                } elseif (ilObject::_exists($a_set["user_id"])) {
+                    $user_obj = new ilObjUser($a_set["user_id"]);
+                    $this->tpl->setVariable("VAL_AUTHOR", $user_obj->getLogin());
                 }
-            } else {
-                if (ilObject::_exists($a_set["user_id"])) {
-                    $this->tpl->setVariable("VAL_AUTHOR", ilObjUser::_lookupLogin($a_set["user_id"]));
-                }
+            } elseif (ilObject::_exists($a_set["user_id"])) {
+                $this->tpl->setVariable("VAL_AUTHOR", ilObjUser::_lookupLogin($a_set["user_id"]));
             }
             $this->tpl->setVariable("TXT_AUTHOR", $lng->txt("author"));
             $this->tpl->parseCurrentBlock();
@@ -219,7 +216,7 @@ class ilPDNewsTableGUI extends ilTable2GUI
 
         // forum hack, not nice
         $add = "";
-        if ($obj_type == "frm" && $a_set["context_sub_obj_type"] == "pos"
+        if ($obj_type === "frm" && $a_set["context_sub_obj_type"] === "pos"
             && $a_set["context_sub_obj_id"] > 0) {
             $pos = $a_set["context_sub_obj_id"];
             $thread = ilObjForumAccess::_getThreadForPosting($pos);
@@ -229,7 +226,7 @@ class ilPDNewsTableGUI extends ilTable2GUI
         }
 
         // file hack, not nice
-        if ($obj_type == "file") {
+        if ($obj_type === "file") {
             $ilCtrl->setParameterByClass("ilrepositorygui", "ref_id", $a_set["ref_id"]);
             $url = $ilCtrl->getLinkTargetByClass("ilrepositorygui", "sendfile");
             $ilCtrl->setParameterByClass("ilrepositorygui", "ref_id", $this->std_request->getRefId());
@@ -244,7 +241,7 @@ class ilPDNewsTableGUI extends ilTable2GUI
         }
 
         // wiki hack, not nice
-        if ($obj_type == "wiki" && $a_set["context_sub_obj_type"] == "wpg"
+        if ($obj_type === "wiki" && $a_set["context_sub_obj_type"] === "wpg"
             && $a_set["context_sub_obj_id"] > 0) {
             $wptitle = ilWikiPage::lookupTitle($a_set["context_sub_obj_id"]);
             if ($wptitle != "") {
@@ -257,7 +254,7 @@ class ilPDNewsTableGUI extends ilTable2GUI
             $obj_type . "_" . $a_set["ref_id"] . $add;
 
         // lm page hack, not nice
-        if (in_array($obj_type, array("dbk", "lm")) && $a_set["context_sub_obj_type"] == "pg"
+        if (in_array($obj_type, ["dbk", "lm"], true) && $a_set["context_sub_obj_type"] === "pg"
             && $a_set["context_sub_obj_id"] > 0) {
             $url_target = "./goto.php?client_id=" . rawurlencode(CLIENT_ID) . "&target=" .
                 "pg_" . $a_set["context_sub_obj_id"] . "_" . $a_set["ref_id"];

--- a/Services/News/classes/class.ilPDNewsTableGUI.php
+++ b/Services/News/classes/class.ilPDNewsTableGUI.php
@@ -254,8 +254,9 @@ class ilPDNewsTableGUI extends ilTable2GUI
             $obj_type . "_" . $a_set["ref_id"] . $add;
 
         // lm page hack, not nice
-        if (in_array($obj_type, ["dbk", "lm"], true) && $a_set["context_sub_obj_type"] === "pg"
-            && $a_set["context_sub_obj_id"] > 0) {
+        if ($a_set["context_sub_obj_type"] === "pg" &&
+            $a_set["context_sub_obj_id"] > 0 &&
+            in_array($obj_type, ["dbk", "lm"], true)) {
             $url_target = "./goto.php?client_id=" . rawurlencode(CLIENT_ID) . "&target=" .
                 "pg_" . $a_set["context_sub_obj_id"] . "_" . $a_set["ref_id"];
         }

--- a/Services/News/classes/class.ilRSSButtonGUI.php
+++ b/Services/News/classes/class.ilRSSButtonGUI.php
@@ -39,7 +39,7 @@ class ilRSSButtonGUI
     ) : string {
         $tpl = new ilTemplate("tpl.rss_icon.html", true, true, "Services/News");
 
-        if ($a_href != "") {
+        if ($a_href !== "") {
             $tpl->setCurrentBlock("a_start");
             $tpl->setVariable("HREF", $a_href);
             $tpl->parseCurrentBlock();

--- a/Services/News/test/NewsContextTest.php
+++ b/Services/News/test/NewsContextTest.php
@@ -7,11 +7,6 @@ use PHPUnit\Framework\TestCase;
  */
 class NewsContextTest extends TestCase
 {
-    protected function setUp() : void
-    {
-        parent::setUp();
-    }
-
     protected function tearDown() : void
     {
     }
@@ -19,7 +14,7 @@ class NewsContextTest extends TestCase
     /**
      * Test admin view
      */
-    public function testContextProperties()
+    public function testContextProperties() : void
     {
         $context = new ilNewsContext(
             1,

--- a/Services/News/test/ilServicesNewsSuite.php
+++ b/Services/News/test/ilServicesNewsSuite.php
@@ -23,7 +23,7 @@ require_once 'libs/composer/vendor/autoload.php';
  */
 class ilServicesNewsSuite extends TestSuite
 {
-    public static function suite()
+    public static function suite() : self
     {
         $suite = new self();
 


### PR DESCRIPTION
Hi @alex40724,

I completed the review of the `News` component.

Results:
- [x] The code style is `PSR-2 + X` compliant
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`:
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [ ] There are no serious `PhpStorm Code Inspection` issues left
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties)

Actions:
- [ ] Please check my inline comments. Some of them might be just information, some require an action. You can use `TODO PHP8-REVIEW` when searching.

Kind regards,
@mjansenDatabay 