### PR TITLE
KS: Item with Lead Avatar

### DIFF
--- a/src/UI/Component/Item/Factory.php
+++ b/src/UI/Component/Item/Factory.php
@@ -17,7 +17,7 @@ interface Factory
      *   composition: >
      *       A list item consists of a title and the following optional elements:
      *       description, action drop down, audio player element, properties (name/value),
-     *       a text or image or icon lead, a progress meter chart and a color.
+     *       a text, image, icon or avatar lead, a progress meter chart and a color.
      *       Property values MAY be interactive by using a Shy Buttons or a Link.
      * rules:
      *    accessibility:

--- a/src/UI/Component/Item/Standard.php
+++ b/src/UI/Component/Item/Standard.php
@@ -10,6 +10,7 @@ use \ILIAS\UI\Component\Player\Audio;
 use ILIAS\UI\Component\Chart\ProgressMeter\ProgressMeter;
 use ILIAS\Data\Color;
 use ILIAS\UI\Component\Dropdown\Standard as DropdownStandard;
+use ILIAS\UI\Component\Symbol\Avatar\Avatar;
 
 /**
  * Interface Standard Item
@@ -43,6 +44,11 @@ interface Standard extends Item
     public function withLeadIcon(Icon $icon) : Standard;
 
     /**
+     * Set avatar as lead
+     */
+    public function withLeadAvatar(Avatar $avatar) : Standard;
+
+    /**
      * Set image as lead
      */
     public function withLeadText(string $text) : Standard;
@@ -53,7 +59,7 @@ interface Standard extends Item
     public function withNoLead() : Standard;
 
     /**
-     * @return null|string|Image|Icon
+     * @return null|string|Image|Icon|Avatar
      */
     public function getLead();
 

--- a/src/UI/Implementation/Component/Item/Renderer.php
+++ b/src/UI/Implementation/Component/Item/Renderer.php
@@ -14,6 +14,7 @@ use ILIAS\UI\Implementation\Render\Template;
 use ILIAS\UI\Component\Button;
 use ILIAS\UI\Component\Link\Link;
 use ILIAS\UI\Implementation\Render\ResourceRegistry;
+use ILIAS\UI\Component\Symbol\Avatar\Avatar;
 
 class Renderer extends AbstractComponentRenderer
 {
@@ -108,7 +109,7 @@ class Renderer extends AbstractComponentRenderer
                 $tpl->setVariable("LEAD_IMAGE", $default_renderer->render($lead));
                 $tpl->parseCurrentBlock();
             }
-            if ($lead instanceof Icon) {
+            if ($lead instanceof Icon || $lead instanceof Avatar) {
                 $tpl->setCurrentBlock("lead_icon");
                 $tpl->setVariable("LEAD_ICON", $default_renderer->render($lead));
                 $tpl->parseCurrentBlock();

--- a/src/UI/Implementation/Component/Item/Standard.php
+++ b/src/UI/Implementation/Component/Item/Standard.php
@@ -9,13 +9,14 @@ use ILIAS\Data\Color;
 use ILIAS\UI\Component\Image\Image;
 use ILIAS\UI\Component\Player\Audio;
 use ILIAS\UI\Component\Symbol\Icon\Icon;
+use ILIAS\UI\Component\Symbol\Avatar\Avatar;
 
 class Standard extends Item implements C\Item\Standard
 {
     protected ?Color $color = null;
 
     /**
-     * @var null|string|Image
+     * @var null|string|Image|Avatar
      */
     protected $lead = null;
     protected ?C\Chart\ProgressMeter\ProgressMeter $chart = null;
@@ -46,6 +47,16 @@ class Standard extends Item implements C\Item\Standard
     {
         $clone = clone $this;
         $clone->lead = $image;
+        return $clone;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function withLeadAvatar(Avatar $avatar) : C\Item\Standard
+    {
+        $clone = clone $this;
+        $clone->lead = $avatar;
         return $clone;
     }
 

--- a/src/UI/examples/Item/Standard/with_lead_avatar.php
+++ b/src/UI/examples/Item/Standard/with_lead_avatar.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Item\Standard;
+
+/**
+ * With Lead Avatar
+ */
+function with_lead_avatar()
+{
+    global $DIC;
+    $f = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+    $actions = $f->dropdown()->standard(array(
+        $f->button()->shy("ILIAS", "https://www.ilias.de"),
+        $f->button()->shy("GitHub", "https://www.github.com")
+    ));
+    $app_item1 = $f->item()->standard("Max Mustermann")
+        ->withActions($actions)
+        ->withProperties(array(
+            "Last Login" => "24.11.2011",
+            "Location" => "Hamburg"))
+        ->withDescription("Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.")
+        ->withLeadAvatar($f->symbol()->avatar()->letter('mm'));
+    $app_item2 = $f->item()->standard("Erika Mustermann")
+        ->withActions($actions)
+        ->withProperties(array(
+            "Last Login" => "3.12.2018",
+            "Location" => "Berlin"))
+        ->withDescription("Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.")
+        ->withLeadAvatar($f->symbol()->avatar()->picture('./templates/default/images/no_photo_xsmall.jpg', 'demo.user'));
+    return $renderer->render([$app_item1, $f->divider()->horizontal(), $app_item2]);
+}

--- a/tests/UI/Component/Item/ItemTest.php
+++ b/tests/UI/Component/Item/ItemTest.php
@@ -8,6 +8,8 @@ require_once(__DIR__ . "/../../Base.php");
 use ILIAS\UI\Component as C;
 use ILIAS\UI\Implementation as I;
 use ILIAS\Data;
+use ILIAS\UI\Implementation\Component\Symbol\Avatar\Letter;
+use ILIAS\UI\Implementation\Component\Symbol\Avatar\Picture;
 
 /**
  * Test items
@@ -108,6 +110,28 @@ class ItemTest extends ILIAS_UI_TestBase
         $c = $f->standard("title")->withLeadIcon($icon);
 
         $this->assertEquals($icon, $c->getLead());
+    }
+
+    public function test_with_lead_letter_avatar() : void
+    {
+        $f = $this->getFactory();
+
+        $avatar = new Letter('il');
+
+        $c = $f->standard("title")->withLeadAvatar($avatar);
+
+        $this->assertEquals($avatar, $c->getLead());
+    }
+
+    public function test_with_lead_picture_avatar() : void
+    {
+        $f = $this->getFactory();
+
+        $avatar = new Picture('./templates/default/images/no_photo_xsmall.jpg', 'demo.user');
+
+        $c = $f->standard("title")->withLeadAvatar($avatar);
+
+        $this->assertEquals($avatar, $c->getLead());
     }
 
     public function test_with_lead_text() : void
@@ -256,6 +280,69 @@ EOT;
             <div class="il-item-title">title</div>
 		</div>
 	</div>
+</div>
+EOT;
+
+        $this->assertHTMLEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($html)
+        );
+    }
+
+    public function test_render_lead_letter_avatar() : void
+    {
+        $f = $this->getFactory();
+        $r = $this->getDefaultRenderer();
+
+        $avatar = new Letter('il');
+
+        $c = $f->standard("title")->withLeadAvatar($avatar);
+
+        $html = $r->render($c);
+
+        $expected = <<<EOT
+<div class="il-item il-std-item ">
+    <div class="media">
+        <div class="media-left">
+            <span class="il-avatar il-avatar-letter il-avatar-size-large il-avatar-letter-color-11" aria-label="user_avatar" role="img">
+                <span class="abbreviation">il</span>
+            </span>
+        </div>
+        <div class="media-body">
+            <div class="il-item-title">title</div>
+        </div>
+    </div>
+</div>
+EOT;
+
+        $this->assertHTMLEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($html)
+        );
+    }
+
+    public function test_render_lead_picture_avatar() : void
+    {
+        $f = $this->getFactory();
+        $r = $this->getDefaultRenderer();
+
+        $avatar = new Picture('./templates/default/images/no_photo_xsmall.jpg', 'demo.user');
+
+        $c = $f->standard("title")->withLeadAvatar($avatar);
+
+        $html = $r->render($c);
+        $expected = <<<EOT
+<div class="il-item il-std-item ">
+    <div class="media">
+        <div class="media-left">
+            <span class="il-avatar il-avatar-picture il-avatar-size-large">
+                <img src="./templates/default/images/no_photo_xsmall.jpg" alt="user_avatar"/>
+            </span>
+        </div>
+        <div class="media-body">
+            <div class="il-item-title">title</div>
+        </div>
+    </div>
 </div>
 EOT;
 


### PR DESCRIPTION
This is needed to switch the comments overview to the KS, see FW:

https://docu.ilias.de/goto_docu_wiki_wpage_6964_1357.html

Rule Change: https://github.com/ILIAS-eLearning/ILIAS/pull/4398/files#diff-b84dddcb4040f0309648a00e52da9ede0b8c05dd33ac7aa7ba4cc02e9ab607a5

In this implementation the visual behaviour is identical to the Lead Icons (fixed size), not to the Lead Images (gaining size with more space). I thought this would be more appropriate, the massive sized Avatars in the FW entry look strange imo. Also this way there is less code change needed, no changes done in Avatar implementation or in the complex Item template. The PR includes a full implementation, incl. unit tests and examples.

<img width="595" alt="Bildschirmfoto 2022-04-21 um 17 38 55" src="https://user-images.githubusercontent.com/1221841/164498213-e9aa69b8-221b-46cd-8316-22380c679065.png">
