### PR TITLE
Database: Make offset optional in interface

### DIFF
--- a/Services/Database/interfaces/interface.ilDBInterface.php
+++ b/Services/Database/interfaces/interface.ilDBInterface.php
@@ -138,7 +138,7 @@ interface ilDBInterface
      */
     public function useSlave(bool $bool) : bool;
 
-    public function setLimit(int $limit, int $offset) : void;
+    public function setLimit(int $limit, int $offset = 0) : void;
 
     /**
      * Generate a like subquery.


### PR DESCRIPTION
This PR changes makes the `$offset` of `ilDBInterface::setLimit` optional, similar to the implementation.