### PR TITLE
Global Screen, Empty Mainbar, fix for #31844

### DIFF
--- a/src/GlobalScreen/Scope/Layout/Provider/PagePart/StandardPagePartProvider.php
+++ b/src/GlobalScreen/Scope/Layout/Provider/PagePart/StandardPagePartProvider.php
@@ -138,6 +138,11 @@ class StandardPagePartProvider implements PagePartProvider
             }
         }
 
+        //We now only after applying all filters if there are really items for presentation
+        if(count($main_bar->getEntries()) == 0 && count($main_bar->getToolEntries()) == 0) {
+            return null;
+        }
+
         return $main_bar;
     }
 


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=31844 for some more context.

Note, that the current hasItems items check seems not sufficient, since there will be filters applied later, to check if those items are really rendered. So we only know AFTER the logic of the function, how many items there really are.

Note II: if the help is active, the mainbar will always be rendered, since there is always one item in there (maybe not visible, but it is in there).