### PR TITLE
BackgroundTasks: Migrate to `__serialize`/`__unserialize` (PHP 8.1)

### DIFF
--- a/Modules/WorkspaceFolder/BackgroundTask/classes/class.ilWorkspaceCopyDefinition.php
+++ b/Modules/WorkspaceFolder/BackgroundTask/classes/class.ilWorkspaceCopyDefinition.php
@@ -128,21 +128,19 @@ class ilWorkspaceCopyDefinition extends AbstractValue
 
     public function getHash() : string
     {
-        return md5($this->serialize());
+        return md5(serialize($this));
     }
 
-    public function serialize() : string
+    public function __serialize() : array
     {
-        return serialize(
-            [
-                "copy_definition" => $this->getCopyDefinitions(),
-                "temp_dir" => $this->getTempDir(),
-                "object_wsp_ids" => implode(",", $this->getObjectWspIds()),
-                "num_files" => $this->getNumFiles(),
-                "sum_file_sizes" => $this->getSumFileSizes(),
-                "adheres_to_limit" => $this->getAdheresToLimit()
-            ]
-        );
+        return [
+            "copy_definition" => $this->getCopyDefinitions(),
+            "temp_dir" => $this->getTempDir(),
+            "object_wsp_ids" => implode(",", $this->getObjectWspIds()),
+            "num_files" => $this->getNumFiles(),
+            "sum_file_sizes" => $this->getSumFileSizes(),
+            "adheres_to_limit" => $this->getAdheresToLimit()
+        ];
     }
 
     /**
@@ -154,19 +152,31 @@ class ilWorkspaceCopyDefinition extends AbstractValue
         $this->copy_definitions = $value;
     }
 
-    /**
-     * Unserialize definitions
-     * @param string $data
-     */
-    public function unserialize($data)
+    public function __unserialize(array $data) : void
     {
-        $elements = unserialize($data);
+        $this->setCopyDefinitions($data["copy_definition"]);
+        $this->setTempDir($data['temp_dir']);
+        $this->setObjectWspIds(explode(",", $data["object_wsp_ids"]));
+        $this->setNumFiles($data["num_files"]);
+        $this->setSumFileSizes($data["sum_file_sizes"]);
+        $this->setAdheresToLimit($data["adheres_to_limit"]);
+    }
 
-        $this->setCopyDefinitions($elements["copy_definition"]);
-        $this->setTempDir($elements['temp_dir']);
-        $this->setObjectWspIds(explode(",", $elements["object_wsp_ids"]));
-        $this->setNumFiles($elements["num_files"]);
-        $this->setSumFileSizes($elements["sum_file_sizes"]);
-        $this->setAdheresToLimit($elements["adheres_to_limit"]);
+    public function serialize() : string
+    {
+        return serialize($this);
+    }
+
+    public function unserialize($data) : void
+    {
+        /** @var self $unserialized */
+        $unserialized = unserialize($data);
+
+        $this->setCopyDefinitions($unserialized->copy_definitions);
+        $this->setTempDir($unserialized->temp_dir);
+        $this->setObjectWspIds($unserialized->object_wsp_ids);
+        $this->setNumFiles($unserialized->num_files);
+        $this->setSumFileSizes($unserialized->sum_file_sizes);
+        $this->setAdheresToLimit($unserialized->adheres_to_limit);
     }
 }

--- a/Services/BackgroundTasks/classes/class.ilCopyDefinition.php
+++ b/Services/BackgroundTasks/classes/class.ilCopyDefinition.php
@@ -161,27 +161,25 @@ class ilCopyDefinition extends AbstractValue
      */
     public function getHash() : string
     {
-        return md5($this->serialize());
+        return md5(serialize($this));
     }
     
     /**
      * Serialize content
      * @return string
      */
-    public function serialize()
+    public function __serialize() : array
     {
-        return serialize(
-            [
-                "copy_definition" => $this->getCopyDefinitions(),
-                "temp_dir" => $this->getTempDir(),
-                "object_ref_ids" => implode(",", $this->getObjectRefIds()),
-                "num_files" => $this->getNumFiles(),
-                "sum_file_sizes" => $this->getSumFileSizes(),
-                "adheres_to_limit" => $this->getAdheresToLimit(),
-            ]
-        );
+        return [
+            "copy_definition" => $this->getCopyDefinitions(),
+            "temp_dir" => $this->getTempDir(),
+            "object_ref_ids" => implode(",", $this->getObjectRefIds()),
+            "num_files" => $this->getNumFiles(),
+            "sum_file_sizes" => $this->getSumFileSizes(),
+            "adheres_to_limit" => $this->getAdheresToLimit(),
+        ];
     }
-    
+
     /**
      * Set value
      * @param $value
@@ -192,18 +190,33 @@ class ilCopyDefinition extends AbstractValue
     }
     
     /**
-     * Unserialize definitions
-     * @param string $serialized
+     * @inheritDoc
      */
-    public function unserialize($serialized)
+    public function __unserialize(array $data) : void
     {
-        $elements = unserialize($serialized);
-        
-        $this->setCopyDefinitions($elements["copy_definition"]);
-        $this->setTempDir($elements['temp_dir']);
-        $this->setObjectRefIds(explode(",", $elements["object_ref_ids"]));
-        $this->setNumFiles($elements["num_files"]);
-        $this->setSumFileSizes($elements["sum_file_sizes"]);
-        $this->setAdheresToLimit($elements["adheres_to_limit"]);
+        $this->setCopyDefinitions($data["copy_definition"]);
+        $this->setTempDir($data['temp_dir']);
+        $this->setObjectRefIds(explode(",", $data["object_ref_ids"]));
+        $this->setNumFiles($data["num_files"]);
+        $this->setSumFileSizes($data["sum_file_sizes"]);
+        $this->setAdheresToLimit($data["adheres_to_limit"]);
+    }
+
+    public function serialize() : string
+    {
+        return serialize($this);
+    }
+
+    public function unserialize($data) : void
+    {
+        /** @var self $unserialized */
+        $unserialized = unserialize($data);
+
+        $this->setCopyDefinitions($unserialized->copy_definitions);
+        $this->setTempDir($unserialized->temp_dir);
+        $this->setObjectRefIds($unserialized->object_ref_ids);
+        $this->setNumFiles($unserialized->num_files);
+        $this->setSumFileSizes($unserialized->sum_file_sizes);
+        $this->setAdheresToLimit($unserialized->adheres_to_limit);
     }
 }

--- a/Services/Calendar/classes/BackgroundTasks/class.ilCalendarCopyDefinition.php
+++ b/Services/Calendar/classes/BackgroundTasks/class.ilCalendarCopyDefinition.php
@@ -87,20 +87,18 @@ class ilCalendarCopyDefinition extends AbstractValue
      */
     public function getHash() : string
     {
-        return md5($this->serialize());
+        return md5(serialize($this));
     }
 
     /**
      * @inheritDoc
      */
-    public function serialize()
+    public function __serialize() : array
     {
-        return serialize(
-            [
-                "copy_definition" => $this->getCopyDefinitions(),
-                "temp_dir" => $this->getTempDir()
-            ]
-        );
+        return [
+            "copy_definition" => $this->getCopyDefinitions(),
+            "temp_dir" => $this->getTempDir()
+        ];
     }
 
     /**
@@ -114,11 +112,23 @@ class ilCalendarCopyDefinition extends AbstractValue
     /**
      * @inheritDoc
      */
-    public function unserialize($serialized)
+    public function __unserialize(array $data) : void
     {
-        $elements = unserialize($serialized);
+        $this->setCopyDefinitions($data["copy_definition"]);
+        $this->setTempDir($data['temp_dir']);
+    }
 
-        $this->setCopyDefinitions($elements["copy_definition"]);
-        $this->setTempDir($elements['temp_dir']);
+    public function serialize() : string
+    {
+        return serialize($this);
+    }
+
+    public function unserialize($data) : void
+    {
+        /** @var self $unserialized */
+        $unserialized = unserialize($data);
+
+        $this->setCopyDefinitions($unserialized->copy_definitions);
+        $this->setTempDir($unserialized->temp_dir);
     }
 }

--- a/src/BackgroundTasks/Implementation/Values/AggregationValues/ListValue.php
+++ b/src/BackgroundTasks/Implementation/Values/AggregationValues/ListValue.php
@@ -117,30 +117,31 @@ class ListValue extends AbstractValue
         
         return $types;
     }
-    
-    /**
-     * String representation of object
-     * @link  http://php.net/manual/en/serializable.serialize.php
-     * @return string the string representation of the object or null
-     * @since 5.1.0
-     */
-    public function serialize()
+
+    public function serialize() : string
     {
-        return serialize($this->list);
+        return serialize($this);
+    }
+
+    public function unserialize($data) : void
+    {
+        /** @var self $unserialized */
+        $unserialized = unserialize($data);
+
+        $this->list = $unserialized->list;
+        $this->type = $unserialized->type;
+    }
+
+    public function __serialize() : array
+    {
+        return [
+            'list' => $this->list
+        ];
     }
     
-    /**
-     * Constructs the object
-     * @link  http://php.net/manual/en/serializable.unserialize.php
-     * @param string $serialized <p>
-     *                           The string representation of the object.
-     *                           </p>
-     * @return void
-     * @since 5.1.0
-     */
-    public function unserialize($serialized)
+    public function __unserialize(array $data) : void
     {
-        $this->list = unserialize($serialized);
+        $this->list = $data['list'];
         $this->type = $this->deriveType($this->list);
     }
     

--- a/src/BackgroundTasks/Implementation/Values/ScalarValues/ScalarValue.php
+++ b/src/BackgroundTasks/Implementation/Values/ScalarValues/ScalarValue.php
@@ -29,30 +29,30 @@ class ScalarValue extends AbstractValue
      * @var mixed|bool|float|int|string|null is_scalar() == true;
      */
     protected $value;
-    
-    /**
-     * String representation of object
-     * @link  http://php.net/manual/en/serializable.serialize.php
-     * @return string the string representation of the object or null
-     * @since 5.1.0
-     */
-    public function serialize()
+
+    public function serialize() : string
     {
-        return serialize($this->value);
+        return serialize($this);
+    }
+
+    public function unserialize($data) : void
+    {
+        /** @var self $unserialized */
+        $unserialized = unserialize($data);
+
+        $this->value = $unserialized->value;
     }
     
-    /**
-     * Constructs the object
-     * @link  http://php.net/manual/en/serializable.unserialize.php
-     * @param string $serialized <p>
-     *                           The string representation of the object.
-     *                           </p>
-     * @return void
-     * @since 5.1.0
-     */
-    public function unserialize($serialized)
+    public function __serialize() : array
     {
-        $this->value = unserialize($serialized);
+        return [
+            'value' => $this->value
+        ];
+    }
+    
+    public function __unserialize(array $data) : void
+    {
+        $this->value = $data['value'];
     }
     
     /**

--- a/src/BackgroundTasks/Implementation/Values/ThunkValue.php
+++ b/src/BackgroundTasks/Implementation/Values/ThunkValue.php
@@ -36,28 +36,23 @@ class ThunkValue extends AbstractValue
     {
         return $this->parentTask->getOutputType();
     }
-    
-    /**
-     * String representation of object
-     * @link  http://php.net/manual/en/serializable.serialize.php
-     * @return string the string representation of the object or null
-     * @since 5.1.0
-     */
-    public function serialize()
+
+    public function serialize() : string
     {
-        return '';
+        return serialize($this);
+    }
+
+    public function unserialize($data) : void
+    {
+        // Nothing to do.
     }
     
-    /**
-     * Constructs the object
-     * @link  http://php.net/manual/en/serializable.unserialize.php
-     * @param string $serialized <p>
-     *                           The string representation of the object.
-     *                           </p>
-     * @return void
-     * @since 5.1.0
-     */
-    public function unserialize($serialized)
+    public function __serialize() : array
+    {
+        return [];
+    }
+    
+    public function __unserialize(array $data) : void
     {
         // Nothing to do.
     }

--- a/src/BackgroundTasks/Serializable.php
+++ b/src/BackgroundTasks/Serializable.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *********************************************************************/
+
+namespace ILIAS\BackgroundTasks;
+
+interface Serializable extends \Serializable
+{
+    public function __serialize() : array;
+    
+    public function __unserialize(array $data) : void;
+}

--- a/src/BackgroundTasks/Value.php
+++ b/src/BackgroundTasks/Value.php
@@ -26,7 +26,7 @@ use ILIAS\BackgroundTasks\Types\Type;
  * The Value as a defined format of data passed between two tasks. IO MUST be serialisable
  * since it will bes stored in the database or somewhere else
  */
-interface Value extends \Serializable
+interface Value extends Serializable
 {
     
     /**

--- a/tests/BackgroundTasks/ValueTest.php
+++ b/tests/BackgroundTasks/ValueTest.php
@@ -13,7 +13,6 @@ require_once("libs/composer/vendor/autoload.php");
 /**
  * Class BackgroundTaskTest
  *
- * @runTestsInSeparateProcesses
  * @preserveGlobalState    disabled
  * @backupGlobals          disabled
  * @backupStaticAttributes disabled
@@ -26,9 +25,9 @@ class ValueTest extends TestCase
     {
         $integer = new IntegerValue();
         $integer->setValue(3);
-        $integer2 = new IntegerValue(3);
+        $integer2 = new IntegerValue();
         $integer2->setValue(3);
-        $integer3 = new IntegerValue(4);
+        $integer3 = new IntegerValue();
         $integer3->setValue(4);
 
         $this->assertEquals($integer->getValue(), 3);


### PR DESCRIPTION
This PR migrates the (in PHP 8.1) deprecated `Serializable` interface by **maintaining the public API**.

Changes made:
- The dependeny on the PHP core interface `Serializable` has been removed.
- A new `BackgroundTasks` related interface `Serializable` has been introduced **providing the known API** to `serialize()`/`unserialize()` a value.
- `serialize()`/`unserialize()` will internally call the new/recommended PHP methods `__serialize()`/`__unserialize()`.

See: https://wiki.php.net/rfc/phase_out_serializable