### PR TITLE
Remove old usages of notifications from external consumers

### DIFF
--- a/Services/COPage/Editor/js/src/components/paragraph/ui/paragraph-ui.js
+++ b/Services/COPage/Editor/js/src/components/paragraph/ui/paragraph-ui.js
@@ -559,26 +559,6 @@ export default class ParagraphUI {
       $('#il_EditPage').replaceWith(o.responseText);
       this.reInitUI();
       il.IntLink.refresh();
-      if (o.argument.osd_text && o.argument.osd_text != "") {
-        OSDNotifier = OSDNotifications({
-          initialNotifications: [{
-            notification_osd_id: 123,
-            valid_until: 0,
-            visible_for: 3,
-            data: {
-              title: "",
-              link: false,
-              iconPath: false,
-              shortDescription: o.argument.osd_text,
-              handlerParams: {
-                osd: {
-                  closable: false
-                }
-              }
-            }
-          }]
-        });
-      }
     }
   }
 

--- a/Services/COPage/Editor/js/src/ui/page-modifier.js
+++ b/Services/COPage/Editor/js/src/ui/page-modifier.js
@@ -95,27 +95,6 @@ export default class PageModifier {
     }
   }
 
-  showToast(text) {
-    const OSDNotifier = OSDNotifications({
-      initialNotifications: [{
-        notification_osd_id: 123,
-        valid_until: 0,
-        visible_for: 3,
-        data: {
-          title: "",
-          link: false,
-          iconPath: false,
-          shortDescription: text,
-          handlerParams: {
-            osd: {
-              closable: false
-            }
-          }
-        }
-      }]
-    });
-  }
-
   showModal(title, content, button_txt, onclick) {
     const uiModel = this.pageUI.uiModel;
 


### PR DESCRIPTION
Since the major changes inside of then notifications for trunk (see https://docu.ilias.de/goto_docu_wiki_wpage_6494_1357.html) this occurences dont have any functionality within the current state.

This is a proposal to remove this occurences.