### PR TITLE
PHP8: Code Review `Services/Randomization`

### DIFF
--- a/Services/Randomization/classes/class.ilRandom.php
+++ b/Services/Randomization/classes/class.ilRandom.php
@@ -8,14 +8,6 @@
  */
 class ilRandom
 {
-
-    /**
-     * ilRandom constructor.
-     */
-    public function __construct()
-    {
-    }
-
     private function logIfPossible(callable $c) : void
     {
         global $DIC;
@@ -25,16 +17,8 @@ class ilRandom
         }
     }
 
-    public function int(int $min = null, int $max = null) : int
+    public function int(int $min = 0, int $max = PHP_INT_MAX) : int
     {
-        if (is_null($min)) {
-            $min = 0;
-        }
-
-        if (is_null($max)) {
-            $max = mt_getrandmax();
-        }
-
         try {
             return random_int($min, $max);
         } catch (Throwable $e) {

--- a/Services/Randomization/test/ilRandomTest.php
+++ b/Services/Randomization/test/ilRandomTest.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use ILIAS\DI\Container;
+use ILIAS\DI\LoggingServices;
+
+class ilRandomTest extends TestCase
+{
+    public function testConstruct() : void
+    {
+        $this->assertInstanceOf(\ilRandom::class, new ilRandom());
+    }
+
+    /**
+     * @dataProvider intArguments
+     */
+    public function testIntSuccessfully(int ...$arguments) : void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $random = new \ilRandom();
+         try {
+             $random->int(...$arguments);
+        } catch (Error $e) {
+            $this->fail('Expected no exception.');
+        }
+    }
+
+    public function testIntWithInvalidArguments() : void
+    {
+        $this->expectException(Error::class);
+        $random = new \ilRandom();
+
+        $random->int(10, 9);
+    }
+
+    public function testLogIfPossible() : void
+    {
+        $this->expectException(Error::class);
+
+        $logger = $this->getMockBuilder(\ilLogger::class)->disableOriginalConstructor()->getMock();
+        $logger->expects(self::once())->method('logStack')->with(\ilLogLevel::ERROR);
+        $logger->expects(self::once())->method('error');
+
+        $factory = $this->getMockBuilder(ilLoggerFactory::class)->disableOriginalConstructor()->getMock();
+        $factory->expects(self::once())->method('getComponentLogger')->with('rnd')->willReturn($logger);
+
+        $GLOBALS['DIC'] = new Container();
+        $GLOBALS['DIC']['ilLoggerFactory'] = static function () use ($factory) : ilLoggerFactory {
+            return $factory;
+        };
+        $random = new \ilRandom();
+        $random->int(10, 9);
+
+        unset($GLOBALS['DIC']);
+    }
+
+    public function intArguments() : array
+    {
+        return [
+            'No arguments can be provided' => [],
+            'One argument can be provided' => [34],
+            '2 arguments can be provided' => [-20, 30],
+            'The limit is inclusive' => [8, 8]
+        ];
+    }
+}


### PR DESCRIPTION
Hi @mjansenDatabay,

here are the results of the `Services/Randomization` review.

### Results
- [x] The code style is `PSR-2 + X` compliant
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [ ] There is a `Unit Test Suite` with at least one unit test
- [ ] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant)
- [x] There are no serious `PHPStorm Code Inspection` issues left
- [x] The types are fully documented (PHPDoc) or explict PHP types are used (type hints, return types, typed properties)

### Changes made in this PR:
- Add Unit Test for class `ilRandom`
- Remove empty `ilRandom` constructor
- Change default values from `null` to `0` and `PHP_INT_MAX` (I checked that there are no usages of `ilRandom::int` where `null` is given as an argument). The max value is changed from `mt_getrandmax` to `PHP_INT_MAX` because `mt_getrandmax` is not relevant for `random_int` only for `mt_rand` and related functions.

Best regards,
@lscharmer