### PR TITLE
Really Remove Random Test-Button

### DIFF
--- a/Modules/Test/ROADMAP.md
+++ b/Modules/Test/ROADMAP.md
@@ -1,0 +1,11 @@
+# Roadmap
+
+Priorities for the development of the Test & Assessment and the Test Question Pool depend on developer resources provided by a handfull of organizations. Thus no promises are made on timeframes.
+
+## Prioritized
+* Reducing the number of reported issues in Test & Assessment
+* Defining a concise interface for questions.
+* Separating the Test-Player from the Questions and the Question-Pool.
+
+## Others
+* Fixing access to Learning Status when access to test results is limited (see: [Mantis 25064](https://mantis.ilias.de/view.php?id=25064&nbn=9))


### PR DESCRIPTION
This is some final clean-up to set https://docu.ilias.de/goto_docu_wiki_wpage_6791_1357.html to "Removed
from Code". @mbecker-databay please update the FR after merging, I will then the set it to Accepted by customer and we can finally close this.