### PR TITLE
Review `Modules/LtiConsumer`

### DIFF
--- a/Modules/LTIConsumer/classes/Certificate/class.ilCertificateSettingsLTIConsumerFormRepository.php
+++ b/Modules/LTIConsumer/classes/Certificate/class.ilCertificateSettingsLTIConsumerFormRepository.php
@@ -60,9 +60,7 @@ class ilCertificateSettingsLTIConsumerFormRepository implements ilCertificateFor
 
     public function createForm(ilCertificateGUI $certificateGUI) : ilPropertyFormGUI
     {
-        $form = $this->settingsFormRepository->createForm($certificateGUI);
-
-        return $form;
+        return $this->settingsFormRepository->createForm($certificateGUI);
     }
 
 
@@ -70,14 +68,8 @@ class ilCertificateSettingsLTIConsumerFormRepository implements ilCertificateFor
     {
     }
 
-    /**
-     * @param string $content
-     * @return array
-     */
     public function fetchFormFieldData(string $content) : array
     {
-        $formFields = $this->settingsFormRepository->fetchFormFieldData($content);
-
-        return $formFields;
+        return $this->settingsFormRepository->fetchFormFieldData($content);
     }
 }

--- a/Modules/LTIConsumer/classes/Certificate/class.ilLTIConsumerPlaceholderDescription.php
+++ b/Modules/LTIConsumer/classes/Certificate/class.ilLTIConsumerPlaceholderDescription.php
@@ -29,11 +29,6 @@ class ilLTIConsumerPlaceholderDescription implements ilCertificatePlaceholderDes
 
     private array $placeholder;
 
-    /**
-     * @param ilDefaultPlaceholderDescription|null $defaultPlaceholderDescriptionObject
-     * @param ilLanguage|null $language
-     * @param ilUserDefinedFieldsPlaceholderDescription|null $userDefinedFieldPlaceHolderDescriptionObject
-     */
     public function __construct(
         ?ilDefaultPlaceholderDescription $defaultPlaceholderDescriptionObject = null,
         ?ilLanguage $language = null,

--- a/Modules/LTIConsumer/classes/Certificate/class.ilLTIConsumerPlaceholderValues.php
+++ b/Modules/LTIConsumer/classes/Certificate/class.ilLTIConsumerPlaceholderValues.php
@@ -42,12 +42,7 @@ class ilLTIConsumerPlaceholderValues implements ilCertificatePlaceholderValues
 
     /**
      * @param ilDefaultPlaceholderValues $defaultPlaceholderValues
-     * @param ilLanguage|null $language
-     * @param ilCertificateObjectHelper|null $objectHelper
      * @param ilCertificateTestObjectHelper|null $testObjectHelper
-     * @param ilCertificateUserObjectHelper|null $userObjectHelper
-     * @param ilCertificateLPStatusHelper|null $lpStatusHelper
-     * @param ilCertificateUtilHelper|null $utilHelper
      * @param ilDatePresentation|null $dateHelper
      */
     public function __construct(
@@ -97,9 +92,6 @@ class ilLTIConsumerPlaceholderValues implements ilCertificatePlaceholderValues
     }
 
     /**
-     * @param int $userId
-     * @param int $objId
-     * @return array
      * @throws ilDateTimeException
      * @throws ilException
      */
@@ -117,9 +109,6 @@ class ilLTIConsumerPlaceholderValues implements ilCertificatePlaceholderValues
     }
 
     /**
-     * @param int $userId
-     * @param int $objId
-     * @return array
      * @throws ilDatabaseException
      * @throws ilDateTimeException
      * @throws ilException
@@ -151,21 +140,11 @@ class ilLTIConsumerPlaceholderValues implements ilCertificatePlaceholderValues
         return $placeholders;
     }
 
-    /**
-     * @param ilObjLTIConsumer $object
-     * @return string
-     */
     protected function getMasteryScore(ilObjLTIConsumer $object) : string
     {
-        $masteryScore = sprintf('%0.2f %%', $object->getMasteryScorePercent());
-        return $masteryScore;
+        return sprintf('%0.2f %%', $object->getMasteryScorePercent());
     }
 
-    /**
-     * @param ilObjLTIConsumer $object
-     * @param int              $userId
-     * @return string
-     */
     protected function getReachedScore(ilObjLTIConsumer $object, int $userId) : string
     {
         $userResult = ilLTIConsumerResult::getByKeys($object->getId(), $userId);

--- a/Modules/LTIConsumer/classes/Certificate/class.ilLTIConsumerPlaceholderValues.php
+++ b/Modules/LTIConsumer/classes/Certificate/class.ilLTIConsumerPlaceholderValues.php
@@ -150,7 +150,7 @@ class ilLTIConsumerPlaceholderValues implements ilCertificatePlaceholderValues
         $userResult = ilLTIConsumerResult::getByKeys($object->getId(), $userId);
 
         $reachedScore = sprintf('%0.2f %%', 0);
-        if ($userResult) {
+        if ($userResult !== null) {
             $reachedScore = sprintf('%0.2f %%', $userResult->getResult() * 100);
         }
 

--- a/Modules/LTIConsumer/classes/Verification/class.ilLTIConsumerVerificationTableGUI.php
+++ b/Modules/LTIConsumer/classes/Verification/class.ilLTIConsumerVerificationTableGUI.php
@@ -25,8 +25,6 @@ class ilLTIConsumerVerificationTableGUI extends ilTable2GUI
 {
     /**
      * Constructor
-     * @param ilObjLTIConsumerVerificationGUI|null $a_parent_obj
-     * @param string|null                          $a_parent_cmd
      * @throws ilCtrlException
      */
     public function __construct(?ilObjLTIConsumerVerificationGUI $a_parent_obj, ?string $a_parent_cmd = "")
@@ -80,7 +78,6 @@ class ilLTIConsumerVerificationTableGUI extends ilTable2GUI
     
     /**
      * Fill template row
-     * @param array $a_set
      */
     protected function fillRow(array $a_set) : void
     {

--- a/Modules/LTIConsumer/classes/Verification/class.ilObjLTIConsumerVerificationAccess.php
+++ b/Modules/LTIConsumer/classes/Verification/class.ilObjLTIConsumerVerificationAccess.php
@@ -45,10 +45,6 @@ class ilObjLTIConsumerVerificationAccess extends ilObjectAccess
         if (isset($t_arr[2]) && $t_arr[2] == "wsp") {
             return ilSharedResourceGUI::hasAccess((int) $t_arr[1]);
         }
-        
-        if ($DIC->access()->checkAccess("read", "", (int) $t_arr[1])) {
-            return true;
-        }
-        return false;
+        return (bool) $DIC->access()->checkAccess("read", "", (int) $t_arr[1]);
     }
 }

--- a/Modules/LTIConsumer/classes/Verification/class.ilObjLTIConsumerVerificationGUI.php
+++ b/Modules/LTIConsumer/classes/Verification/class.ilObjLTIConsumerVerificationGUI.php
@@ -78,7 +78,7 @@ class ilObjLTIConsumerVerificationGUI extends ilObject2GUI
                 return;
             }
 
-            if ($newObj) {
+            if ($newObj !== null) {
                 $parent_id = $this->node_id;
                 $this->node_id = null;
                 $this->putObjectInTree($newObj, $parent_id);

--- a/Modules/LTIConsumer/classes/Verification/class.ilObjLTIConsumerVerificationGUI.php
+++ b/Modules/LTIConsumer/classes/Verification/class.ilObjLTIConsumerVerificationGUI.php
@@ -105,9 +105,6 @@ class ilObjLTIConsumerVerificationGUI extends ilObject2GUI
 
     /**
      * Render content
-     * @param bool $a_return
-     * @param bool $a_url
-     * @return string
      */
     public function render(bool $a_return = false, bool $a_url = false) : string
     {
@@ -171,7 +168,6 @@ class ilObjLTIConsumerVerificationGUI extends ilObject2GUI
     }
 
     /**
-     * @param string $key
      * @param mixed  $default
      * @return mixed|null
      */

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumeProvider.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumeProvider.php
@@ -681,7 +681,7 @@ class ilLTIConsumeProvider
      */
     public function save() : void
     {
-        if ($this->getId()) {
+        if ($this->getId() !== 0) {
             if ($this->hasProviderIconUploadInput()) {
                 $this->getProviderIcon()->handleUploadInputSubission($this->getProviderIconUploadInput());
                 $this->setProviderIconFilename($this->getProviderIcon()->getFilename());

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumeProvider.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumeProvider.php
@@ -129,7 +129,6 @@ class ilLTIConsumeProvider
 
     /**
      * ilLTIConsumeProvider constructor.
-     * @param int|null $providerId
      * @throws IOException
      */
     public function __construct(?int $providerId = null)
@@ -142,8 +141,6 @@ class ilLTIConsumeProvider
 
     /**
      * Inits class static
-     * @param int|null $providerId
-     * @return ilLTIConsumeProvider
      * @throws IOException
      */
     public static function getInstance(?int $providerId = null) : ilLTIConsumeProvider
@@ -151,194 +148,121 @@ class ilLTIConsumeProvider
         return new self($providerId);
     }
     
-    /**
-     * @return int
-     */
     public function getId() : int
     {
         return $this->id;
     }
     
-    /**
-     * @param int $id
-     */
     public function setId(int $id) : void
     {
         $this->id = $id;
     }
     
-    /**
-     * @return string
-     */
     public function getTitle() : string
     {
         return $this->title;
     }
     
-    /**
-     * @param string $title
-     */
     public function setTitle(string $title) : void
     {
         $this->title = $title;
     }
     
-    /**
-     * @return string
-     */
     public function getDescription() : string
     {
         return $this->description;
     }
     
-    /**
-     * @param string $description
-     */
     public function setDescription(string $description) : void
     {
         $this->description = $description;
     }
     
-    /**
-     * @return int
-     */
     public function getAvailability() : int
     {
         return $this->availability;
     }
     
-    /**
-     * @param int $availability
-     */
     public function setAvailability(int $availability) : void
     {
         $this->availability = $availability;
     }
     
-    /**
-     * @return string
-     */
     public function getRemarks() : string
     {
         return $this->remarks;
     }
     
-    /**
-     * @param string $remarks
-     */
     public function setRemarks(string $remarks) : void
     {
         $this->remarks = $remarks;
     }
     
-    /**
-     * @return int
-     */
     public function getTimeToDelete() : int
     {
         return $this->time_to_delete;
     }
     
-    /**
-     * @param int $time_to_delete
-     */
     public function setTimeToDelete(int $time_to_delete) : void
     {
         $this->time_to_delete = $time_to_delete;
     }
     
-    /**
-     * @return int
-     */
     public function getLogLevel() : int
     {
         return $this->log_level;
     }
 
-    //todo
-    /**
-     * @param int $log_level
-     */
     public function setLogLevel(int $log_level) : void
     {
         $this->log_level = $log_level;
     }
     
-    /**
-     * @return string
-     */
     public function getProviderUrl() : string
     {
         return $this->provider_url;
     }
     
-    /**
-     * @param string $provider_url
-     */
     public function setProviderUrl(string $provider_url) : void
     {
         $this->provider_url = $provider_url;
     }
     
-    /**
-     * @return string
-     */
     public function getProviderKey() : string
     {
         return $this->provider_key;
     }
     
-    /**
-     * @param string $provider_key
-     */
     public function setProviderKey(string $provider_key) : void
     {
         $this->provider_key = $provider_key;
     }
     
-    /**
-     * @return string
-     */
     public function getProviderSecret() : string
     {
         return $this->provider_secret;
     }
     
-    /**
-     * @param string $provider_secret
-     */
     public function setProviderSecret(string $provider_secret) : void
     {
         $this->provider_secret = $provider_secret;
     }
     
-    /**
-     * @return bool
-     */
     public function isProviderKeyCustomizable() : bool
     {
         return $this->provider_key_customizable;
     }
     
-    /**
-     * @param bool $provider_key_customizable
-     */
     public function setProviderKeyCustomizable(bool $provider_key_customizable) : void
     {
         $this->provider_key_customizable = $provider_key_customizable;
     }
     
-    /**
-     * @return string
-     */
     public function getProviderIconFilename() : string
     {
         return $this->provider_icon_filename;
     }
     
-    /**
-     * @param string $provider_icon_filename
-     */
     public function setProviderIconFilename(string $provider_icon_filename) : void
     {
         $this->provider_icon_filename = $provider_icon_filename;
@@ -349,9 +273,6 @@ class ilLTIConsumeProvider
         return $this->providerIcon;
     }
     
-    /**
-     * @return bool
-     */
     public function hasProviderIcon() : bool
     {
         if (!($this->providerIcon instanceof ilLTIConsumeProviderIcon)) {
@@ -361,17 +282,11 @@ class ilLTIConsumeProvider
         return (bool) strlen($this->providerIcon->getFilename());
     }
     
-    /**
-     * @param ilLTIConsumeProviderIcon $providerIcon
-     */
     public function setProviderIcon(ilLTIConsumeProviderIcon $providerIcon) : void
     {
         $this->providerIcon = $providerIcon;
     }
     
-    /**
-     * @return bool
-     */
     public function hasProviderIconUploadInput() : bool
     {
         return $this->providerIconUploadInput instanceof ilImageFileInputGUI;
@@ -390,9 +305,6 @@ class ilLTIConsumeProvider
         $this->providerIconUploadInput = $providerIconUploadInput;
     }
     
-    /**
-     * @return array
-     */
     public static function getCategoriesSelectOptions() : array
     {
         global $DIC; /* @var \ILIAS\DI\Container $DIC */
@@ -430,9 +342,6 @@ class ilLTIConsumeProvider
         return $categories;
     }
     
-    /**
-     * @return array
-     */
     public static function getValidCategories() : array
     {
         return [
@@ -444,339 +353,212 @@ class ilLTIConsumeProvider
         ];
     }
     
-    /**
-     * @param string $category
-     * @return bool
-     */
     public function isValidCategory(string $category) : bool
     {
         return in_array($category, self::getValidCategories());
     }
     
-    /**
-     * @return string
-     */
     public function getCategory() : string
     {
         return $this->category;
     }
     
-    /**
-     * @param string $category
-     */
     public function setCategory(string $category) : void
     {
         $this->category = $category;
     }
     
-    /**
-     * @return string
-     */
     public function getProviderXml() : string
     {
         return $this->provider_xml;
     }
     
-    /**
-     * @param string $provider_xml
-     */
     public function setProviderXml(string $provider_xml) : void
     {
         $this->provider_xml = $provider_xml;
     }
     
-    /**
-     * @return bool
-     */
     public function isExternalProvider() : bool
     {
         return $this->is_external_provider;
     }
     
-    /**
-     * @param bool $is_external_provider
-     */
     public function setIsExternalProvider(bool $is_external_provider) : void
     {
         $this->is_external_provider = $is_external_provider;
     }
     
-    /**
-     * @return string
-     */
     public function getLaunchMethod() : string
     {
         return $this->launch_method;
     }
     
-    /**
-     * @param string $launch_method
-     */
     public function setLaunchMethod(string $launch_method) : void
     {
         $this->launch_method = $launch_method;
     }
     
-    /**
-     * @return bool
-     */
     public function getHasOutcome() : bool
     {
         return $this->has_outcome;
     }
     
-    /**
-     * @param bool $has_outcome
-     */
     public function setHasOutcome(bool $has_outcome) : void
     {
         $this->has_outcome = $has_outcome;
     }
     
-    /**
-     * @return float
-     */
     public function getMasteryScore() : float
     {
         return $this->mastery_score;
     }
     
-    /**
-     * @param float $mastery_score
-     */
     public function setMasteryScore(float $mastery_score) : void
     {
         $this->mastery_score = $mastery_score;
     }
     
-    /**
-     * @return float
-     */
     public function getMasteryScorePercent() : float
     {
         return $this->mastery_score * 100;
     }
     
-    /**
-     * @param float $mastery_score_percent
-     */
     public function setMasteryScorePercent(float $mastery_score_percent) : void
     {
         $this->mastery_score = $mastery_score_percent / 100;
     }
 
-    /**
-     * @return bool
-     */
     public function isKeepLp() : bool
     {
         return $this->keep_lp;
     }
     
-    /**
-     * @param bool $keep_lp
-     */
     public function setKeepLp(bool $keep_lp) : void
     {
         $this->keep_lp = $keep_lp;
     }
     
 
-    /**
-     * @return int
-     */
     public function getPrivacyIdent() : int
     {
         return $this->privacy_ident;
     }
     
-    /**
-     * @param int $privacy_ident
-     */
     public function setPrivacyIdent(int $privacy_ident) : void
     {
         $this->privacy_ident = $privacy_ident;
     }
 
-    /**
-     * @return int
-     */
     public function getPrivacyName() : int
     {
         return $this->privacy_name;
     }
     
-    /**
-     * @param int $privacy_name
-     */
     public function setPrivacyName(int $privacy_name) : void
     {
         $this->privacy_name = $privacy_name;
     }
     
-    /**
-     * @return bool
-     */
     public function getIncludeUserPicture() : bool
     {
         return $this->include_user_picture;
     }
     
-    /**
-     * @param bool $include_user_picture
-     */
     public function setIncludeUserPicture(bool $include_user_picture) : void
     {
         $this->include_user_picture = $include_user_picture;
     }
 
-    /**
-     * @return string
-     */
     public function getPrivacyCommentDefault() : string
     {
         return $this->privacy_comment_default;
     }
     
-    /**
-     * @param string $privacy_comment_default
-     */
     public function setPrivacyCommentDefault(string $privacy_comment_default) : void
     {
         $this->privacy_comment_default = $privacy_comment_default;
     }
     
-    /**
-     * @return bool
-     */
     public function getAlwaysLearner() : bool
     {
         return $this->always_learner;
     }
     
-    /**
-     * @param bool $always_learner
-     */
     public function setAlwaysLearner(bool $always_learner) : void
     {
         $this->always_learner = $always_learner;
     }
     
-    /**
-     * @return bool
-     */
     public function getUseProviderId() : bool
     {
         return $this->use_provider_id;
     }
     
-    /**
-     * @param bool $use_provider_id
-     */
     public function setUseProviderId(bool $use_provider_id) : void
     {
         $this->use_provider_id = $use_provider_id;
     }
     
-    /**
-     * @return bool
-     */
     public function getUseXapi() : bool
     {
         return $this->use_xapi;
     }
     
-    /**
-     * @param bool $use_xapi
-     */
     public function setUseXapi(bool $use_xapi) : void
     {
         $this->use_xapi = $use_xapi;
     }
     
-    /**
-     * @return string
-     */
     public function getXapiLaunchUrl() : string
     {
         return $this->xapi_launch_url;
     }
     
-    /**
-     * @param string $xapi_launch_url
-     */
     public function setXapiLaunchUrl(string $xapi_launch_url) : void
     {
         $this->xapi_launch_url = $xapi_launch_url;
     }
     
-    /**
-     * @return string
-     */
     public function getXapiLaunchKey() : string
     {
         return $this->xapi_launch_key;
     }
     
-    /**
-     * @param string $xapi_launch_key
-     */
     public function setXapiLaunchKey(string $xapi_launch_key) : void
     {
         $this->xapi_launch_key = $xapi_launch_key;
     }
     
-    /**
-     * @return string
-     */
     public function getXapiLaunchSecret() : string
     {
         return $this->xapi_launch_secret;
     }
     
-    /**
-     * @param string $xapi_launch_secret
-     */
     public function setXapiLaunchSecret(string $xapi_launch_secret) : void
     {
         $this->xapi_launch_secret = $xapi_launch_secret;
     }
     
-    /**
-     * @return string
-     */
     public function getXapiActivityId() : string
     {
         return $this->xapi_activity_id;
     }
     
-    /**
-     * @param string $xapi_activity_id
-     */
     public function setXapiActivityId(string $xapi_activity_id) : void
     {
         $this->xapi_activity_id = $xapi_activity_id;
     }
     
-    /**
-     * @return string
-     */
     public function getCustomParams() : string
     {
         return $this->custom_params;
     }
     
-    /**
-     * @param string $custom_params
-     */
     public function setCustomParams(string $custom_params) : void
     {
         $this->custom_params = $custom_params;
     }
     
-    /**
-     * @return array
-     */
     public function getKeywordsArray() : array
     {
         $keywords = [];
@@ -788,72 +570,47 @@ class ilLTIConsumeProvider
         return $keywords;
     }
     
-    /**
-     * @return string
-     */
     public function getKeywords() : string
     {
         return $this->keywords;
     }
     
-    /**
-     * @param string $keywords
-     */
     public function setKeywords(string $keywords) : void
     {
         $this->keywords = $keywords;
     }
 
-    /**
-     * @return int
-     */
     public function getCreator() : int
     {
         return $this->creator;
     }
     
-    /**
-     * @param int $creator
-     */
     public function setCreator(int $creator) : void
     {
         $this->creator = $creator;
     }
     
-    /**
-     * @return int
-     */
     public function getAcceptedBy() : int
     {
         return $this->accepted_by;
     }
     
-    /**
-     * @param int $accepted_by
-     */
     public function setAcceptedBy(int $accepted_by) : void
     {
         $this->accepted_by = $accepted_by;
     }
     
-    /**
-     * @return bool
-     */
     public function isGlobal() : bool
     {
         return $this->is_global;
     }
     
-    /**
-     * @param bool $is_global
-     */
     public function setIsGlobal(bool $is_global) : void
     {
         $this->is_global = $is_global;
     }
 
     /**
-     * @param array $dbRow
      * @throws IOException
      */
     public function assignFromDbRow(array $dbRow) : void
@@ -963,9 +720,6 @@ class ilLTIConsumeProvider
         $DIC->database()->insert('lti_ext_provider', $this->getInsertUpdateFields());
     }
     
-    /**
-     * @return array
-     */
     protected function getInsertUpdateFields() : array
     {
         return array(

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumeProviderFormGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumeProviderFormGUI.php
@@ -35,7 +35,6 @@ class ilLTIConsumeProviderFormGUI extends ilPropertyFormGUI
     
     /**
      * ilLTIConsumeProviderFormGUI constructor.
-     * @param ilLTIConsumeProvider $provider
      */
     public function __construct(ilLTIConsumeProvider $provider)
     {
@@ -44,27 +43,16 @@ class ilLTIConsumeProviderFormGUI extends ilPropertyFormGUI
         $this->provider = $provider;
     }
     
-    /**
-     * @return bool
-     */
     public function isAdminContext() : bool
     {
         return $this->adminContext;
     }
     
-    /**
-     * @param bool $adminContext
-     */
     public function setAdminContext(bool $adminContext) : void
     {
         $this->adminContext = $adminContext;
     }
 
-    /**
-     * @param string $formaction
-     * @param string $saveCmd
-     * @param string $cancelCmd
-     */
     public function initForm(string $formaction, string $saveCmd, string $cancelCmd) : void
     {
         global $DIC; /* @var \ILIAS\DI\Container $DIC */

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumeProviderFormGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumeProviderFormGUI.php
@@ -62,7 +62,7 @@ class ilLTIConsumeProviderFormGUI extends ilPropertyFormGUI
         $this->addCommandButton($saveCmd, $lng->txt('save'));
         $this->addCommandButton($cancelCmd, $lng->txt('cancel'));
         
-        if ($this->provider->getId()) {
+        if ($this->provider->getId() !== 0) {
             $this->setTitle($lng->txt('lti_form_provider_edit'));
         } else {
             $this->setTitle($lng->txt('lti_form_provider_create'));

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumeProviderIcon.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumeProviderIcon.php
@@ -45,8 +45,6 @@ class ilLTIConsumeProviderIcon
     
     /**
      * ilLTIConsumeProviderIcon constructor.
-     * @param int $providerId
-     * @param string $filename
      * @throws \ILIAS\Filesystem\Exception\IOException
      */
     public function __construct(int $providerId, string $filename = '')
@@ -64,33 +62,21 @@ class ilLTIConsumeProviderIcon
         return "{$this->providerId}.{$fileExtension}";
     }
     
-    /**
-     * @return string
-     */
     public function getFilename() : string
     {
         return $this->filename;
     }
     
-    /**
-     * @param string $filename
-     */
     public function setFilename(string $filename) : void
     {
         $this->filename = $filename;
     }
     
-    /**
-     * @return string
-     */
     public function getRelativeDirectory() : string
     {
         return implode(DIRECTORY_SEPARATOR, self::$RELATIVE_DIRECTORY_PATH);
     }
     
-    /**
-     * @return string
-     */
     public function getRelativeFilePath() : string
     {
         return implode(DIRECTORY_SEPARATOR, [
@@ -98,9 +84,6 @@ class ilLTIConsumeProviderIcon
         ]);
     }
     
-    /**
-     * @return string
-     */
     public function getAbsoluteFilePath() : string
     {
         return implode(DIRECTORY_SEPARATOR, [
@@ -120,9 +103,6 @@ class ilLTIConsumeProviderIcon
         }
     }
     
-    /**
-     * @return bool
-     */
     public function exists() : bool
     {
         global $DIC; /* @var \ILIAS\DI\Container $DIC */
@@ -169,7 +149,6 @@ class ilLTIConsumeProviderIcon
     }
     
     /**
-     * @param string $uploadFile
      * @throws \ILIAS\FileUpload\Exception\IllegalStateException
      * @throws \ILIAS\Filesystem\Exception\FileNotFoundException
      * @throws \ILIAS\Filesystem\Exception\IOException
@@ -209,7 +188,6 @@ class ilLTIConsumeProviderIcon
     }
     
     /**
-     * @param ilImageFileInputGUI $fileInput
      * @throws \ILIAS\FileUpload\Exception\IllegalStateException
      * @throws \ILIAS\Filesystem\Exception\FileNotFoundException
      * @throws \ILIAS\Filesystem\Exception\IOException
@@ -230,9 +208,6 @@ class ilLTIConsumeProviderIcon
         }
     }
 
-    /**
-     * @return array
-     */
     public static function getSupportedFileExtensions() : array
     {
         return self::$SUPPORTED_FILE_EXTENSIONS;

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumeProviderIcon.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumeProviderIcon.php
@@ -107,7 +107,7 @@ class ilLTIConsumeProviderIcon
     {
         global $DIC; /* @var \ILIAS\DI\Container $DIC */
         
-        if (!strlen($this->getFilename())) {
+        if ($this->getFilename() === '') {
             return false;
         }
         

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumeProviderIcon.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumeProviderIcon.php
@@ -223,7 +223,6 @@ class ilLTIConsumeProviderIcon
         }
         
         // ilImageFileInputGUI does NOT come with a set value that could be fetched with
-        // $fileInput->getValue(). Instead ilImageFileInputGUI provides upload info in $_POST.
         $fileData = $DIC->http()->wrapper()->post()->retrieve($fileInput->getPostVar(), $DIC->refinery()->kindlyTo()->string());
 
         if ($fileData['tmp_name']) {

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumeProviderList.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumeProviderList.php
@@ -124,105 +124,66 @@ class ilLTIConsumeProviderList implements Iterator
         $this->idsFilter = $idsFilter;
     }
     
-    /**
-     * @return string
-     */
     public function getAvailabilityFilter() : string
     {
         return $this->availabilityFilter;
     }
     
-    /**
-     * @param string $availabilityFilter
-     */
     public function setAvailabilityFilter(string $availabilityFilter) : void
     {
         $this->availabilityFilter = $availabilityFilter;
     }
     
-    /**
-     * @return string
-     */
     public function getScopeFilter() : string
     {
         return $this->scopeFilter;
     }
     
-    /**
-     * @param string $scopeFilter
-     */
     public function setScopeFilter(string $scopeFilter) : void
     {
         $this->scopeFilter = $scopeFilter;
     }
     
-    /**
-     * @return int
-     */
     public function getCreatorFilter() : int
     {
         return $this->creatorFilter;
     }
     
-    /**
-     * @param int $creatorFilter
-     */
     public function setCreatorFilter(int $creatorFilter) : void
     {
         $this->creatorFilter = $creatorFilter;
     }
     
-    /**
-     * @return string
-     */
     public function getTitleFilter() : string
     {
         return $this->titleFilter;
     }
     
-    /**
-     * @param string $titleFilter
-     */
     public function setTitleFilter(string $titleFilter) : void
     {
         $this->titleFilter = $titleFilter;
     }
     
-    /**
-     * @return string
-     */
     public function getCategoryFilter() : string
     {
         return $this->categoryFilter;
     }
     
-    /**
-     * @param string $categoryFilter
-     */
     public function setCategoryFilter(string $categoryFilter) : void
     {
         $this->categoryFilter = $categoryFilter;
     }
     
-    /**
-     * @return string
-     */
     public function getKeywordFilter() : string
     {
         return $this->keywordFilter;
     }
     
-    /**
-     * @param string $keywordFilter
-     */
     public function setKeywordFilter(string $keywordFilter) : void
     {
         $this->keywordFilter = $keywordFilter;
     }
     
-    /**
-     * @return bool|null
-     */
     public function getHasOutcomeFilter() : ?bool
     {
         return $this->hasOutcomeFilter;
@@ -233,9 +194,6 @@ class ilLTIConsumeProviderList implements Iterator
         $this->hasOutcomeFilter = $hasOutcomeFilter;
     }
     
-    /**
-     * @return bool|null
-     */
     public function getIsExternalFilter() : ?bool
     {
         return $this->isExternalFilter;
@@ -246,9 +204,6 @@ class ilLTIConsumeProviderList implements Iterator
         $this->isExternalFilter = $isExternalFilter;
     }
     
-    /**
-     * @return bool|null
-     */
     public function getIsProviderKeyCustomizableFilter() : ?bool
     {
         return $this->isProviderKeyCustomizableFilter;
@@ -259,17 +214,12 @@ class ilLTIConsumeProviderList implements Iterator
         $this->isProviderKeyCustomizableFilter = $isProviderKeyCustomizableFilter;
     }
 
-    /**
-     * @param ilLTIConsumeProvider $provider
-     */
     public function add(ilLTIConsumeProvider $provider) : void
     {
         $this->providers[] = $provider;
     }
 
     /**
-     * @param int $providerId
-     * @return ilLTIConsumeProvider
      * @throws ilException
      */
     public function getById(int $providerId) : ilLTIConsumeProvider
@@ -356,13 +306,11 @@ class ilLTIConsumeProviderList implements Iterator
     
     protected function buildQuery() : string
     {
-        $query = "
+        return "
 			SELECT *
 			FROM lti_ext_provider
 			WHERE {$this->getWhereExpression()}
 		";
-        
-        return $query;
     }
 
     public function load() : void
@@ -409,36 +357,21 @@ class ilLTIConsumeProviderList implements Iterator
         }
     }
     
-    /**
-     * @param int $providerId
-     * @return bool
-     */
     public function hasUsages(int $providerId) : bool
     {
         return $this->hasUntrashedUsages($providerId) || $this->hasTrashedUsages($providerId);
     }
     
-    /**
-     * @param int $providerId
-     * @return bool
-     */
     public function hasUntrashedUsages(int $providerId) : bool
     {
         return isset($this->usagesUntrashed[$providerId]) && $this->usagesUntrashed[$providerId];
     }
     
-    /**
-     * @param int $providerId
-     * @return bool
-     */
     public function hasTrashedUsages(int $providerId) : bool
     {
         return isset($this->usagesTrashed[$providerId]) && $this->usagesTrashed[$providerId];
     }
     
-    /**
-     * @return array
-     */
     public function getTableData() : array
     {
         $this->loadUsages();
@@ -487,7 +420,7 @@ class ilLTIConsumeProviderList implements Iterator
     {
         $tableData = [];
         $i = 0;
-        foreach ($this->getTableData() as $key => $tableRow) {
+        foreach ($this->getTableData() as $tableRow) {
             if (!(bool) $tableRow['usages_trashed'] && !(bool) $tableRow['usages_untrashed']) {
                 continue;
             }
@@ -553,9 +486,6 @@ class ilLTIConsumeProviderList implements Iterator
         return key($this->providers);
     }
 
-    /**
-     * @return bool
-     */
     public function valid() : bool
     {
         return key($this->providers) !== null;

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumeProviderList.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumeProviderList.php
@@ -297,7 +297,7 @@ class ilLTIConsumeProviderList implements Iterator
         }
 
         
-        if (!count($conditions)) {
+        if (count($conditions) === 0) {
             return '1 = 1';
         }
         

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumeProviderSettingsGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumeProviderSettingsGUI.php
@@ -38,8 +38,6 @@ class ilLTIConsumeProviderSettingsGUI
 
     /**
      * ilLTIConsumerAccess constructor.
-     * @param ilObjLTIConsumer    $object
-     * @param ilLTIConsumerAccess $access
      */
     public function __construct(ilObjLTIConsumer $object, ilLTIConsumerAccess $access)
     {
@@ -90,8 +88,6 @@ class ilLTIConsumeProviderSettingsGUI
     }
 
     /**
-     * @param ilLTIConsumeProvider $provider
-     * @return ilLTIConsumeProviderFormGUI
      * @throws ilCtrlException
      */
     protected function buildForm(ilLTIConsumeProvider $provider) : ilLTIConsumeProviderFormGUI

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerAccess.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerAccess.php
@@ -31,17 +31,12 @@ class ilLTIConsumerAccess
     
     /**
      * ilLTIConsumerAccess constructor.
-     * @param ilObjLTIConsumer $object
      */
     public function __construct(ilObjLTIConsumer $object)
     {
         $this->object = $object;
     }
 
-    /**
-     * @param string $permission
-     * @return bool
-     */
     protected function checkAccess(string $permission) : bool
     {
         global $DIC; /* @var \ILIAS\DI\Container $DIC */
@@ -76,17 +71,11 @@ class ilLTIConsumerAccess
         return $this->checkAccess('edit_permission');
     }
     
-    /**
-     * @return bool
-     */
     public function hasLearningProgressAccess() : bool
     {
         return ilLearningProgressAccess::checkAccess($this->object->getRefId());
     }
     
-    /**
-     * @return bool
-     */
     public function hasStatementsAccess() : bool
     {
         if (!$this->object->getUseXapi()) {
@@ -100,9 +89,6 @@ class ilLTIConsumerAccess
         return $this->hasOutcomesAccess();
     }
     
-    /**
-     * @return bool
-     */
     public function hasHighscoreAccess() : bool
     {
 //        Todo -check
@@ -117,18 +103,11 @@ class ilLTIConsumerAccess
         return $this->hasOutcomesAccess();
     }
     
-    /**
-     * @param ilObjLTIConsumer $object
-     * @return ilLTIConsumerAccess
-     */
     public static function getInstance(ilObjLTIConsumer $object) : ilLTIConsumerAccess
     {
         return new self($object);
     }
     
-    /**
-     * @return bool
-     */
     public static function hasCustomProviderCreationAccess() : bool
     {
         global $DIC; /* @var \ILIAS\DI\Container $DIC */

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerAccess.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerAccess.php
@@ -59,11 +59,7 @@ class ilLTIConsumerAccess
     
     public function hasOutcomesAccess() : bool
     {
-        if ($this->checkAccess('read_outcomes')) {
-            return true;
-        }
-        
-        return false;
+        return $this->checkAccess('read_outcomes');
     }
     
     public function hasEditPermissionsAccess() : bool

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerAdministrationGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerAdministrationGUI.php
@@ -199,7 +199,6 @@ class ilLTIConsumerAdministrationGUI
     }
 
     /**
-     * @param ilLTIConsumeProviderFormGUI|null $form
      * @throws \ILIAS\Filesystem\Exception\IOException
      * @throws ilCtrlException
      */
@@ -302,9 +301,6 @@ class ilLTIConsumerAdministrationGUI
     }
 
     /**
-     * @param string $saveCommand
-     * @param string $cancelCommand
-     * @return ilPropertyFormGUI
      * @throws ilCtrlException
      */
     protected function buildProviderImportForm(string $saveCommand, string $cancelCommand) : \ilPropertyFormGUI
@@ -330,8 +326,6 @@ class ilLTIConsumerAdministrationGUI
     }
 
     /**
-     * @param string $providerXml
-     * @return ilLTIConsumeProvider
      * @throws \ILIAS\FileUpload\Exception\IllegalStateException
      * @throws \ILIAS\Filesystem\Exception\FileNotFoundException
      * @throws \ILIAS\Filesystem\Exception\IOException
@@ -359,7 +353,6 @@ class ilLTIConsumerAdministrationGUI
     }
 
     /**
-     * @return ilLTIConsumeProvider
      * @throws \ILIAS\FileUpload\Exception\IllegalStateException
      * @throws \ILIAS\Filesystem\Exception\FileNotFoundException
      * @throws \ILIAS\Filesystem\Exception\IOException
@@ -399,9 +392,6 @@ class ilLTIConsumerAdministrationGUI
     }
 
     /**
-     * @param string $url
-     * @param string $pId
-     * @return string|null
      * @throws \ILIAS\Filesystem\Exception\IOException
      */
     private function getIconXml(string $url, string $pId) : ?string
@@ -484,8 +474,6 @@ class ilLTIConsumerAdministrationGUI
     }
 
     /**
-     * @param ilLTIConsumeProviderFormGUI|null $form
-     * @return void
      * @throws \ILIAS\Filesystem\Exception\IOException
      * @throws ilCtrlException
      */
@@ -514,7 +502,6 @@ class ilLTIConsumerAdministrationGUI
     }
 
     /**
-     * @return void
      * @throws \ILIAS\FileUpload\Exception\IllegalStateException
      * @throws \ILIAS\Filesystem\Exception\FileNotFoundException
      * @throws \ILIAS\Filesystem\Exception\IOException
@@ -544,7 +531,6 @@ class ilLTIConsumerAdministrationGUI
     }
 
     /**
-     * @return void
      * @throws ilCtrlException
      */
     protected function acceptProviderAsGlobalMultiCmd() : void
@@ -572,7 +558,6 @@ class ilLTIConsumerAdministrationGUI
     }
 
     /**
-     * @return void
      * @throws ilCtrlException
      */
     protected function acceptProviderAsGlobalCmd() : void
@@ -607,7 +592,6 @@ class ilLTIConsumerAdministrationGUI
     }
 
     /**
-     * @return void
      * @throws ilCtrlException
      */
     protected function resetProviderToUserScopeMultiCmd() : void
@@ -635,7 +619,6 @@ class ilLTIConsumerAdministrationGUI
     }
 
     /**
-     * @return void
      * @throws ilCtrlException
      */
     protected function resetProviderToUserScopeCmd() : void
@@ -668,7 +651,6 @@ class ilLTIConsumerAdministrationGUI
     }
 
     /**
-     * @return void
      * @throws ilCtrlException
      */
     protected function deleteGlobalProviderMultiCmd() : void
@@ -689,7 +671,6 @@ class ilLTIConsumerAdministrationGUI
     }
 
     /**
-     * @return void
      * @throws ilCtrlException
      */
     protected function deleteGlobalProviderCmd() : void
@@ -711,7 +692,6 @@ class ilLTIConsumerAdministrationGUI
     }
 
     /**
-     * @return void
      * @throws ilCtrlException
      */
     protected function deleteUserProviderMultiCmd() : void
@@ -732,7 +712,6 @@ class ilLTIConsumerAdministrationGUI
     }
 
     /**
-     * @return void
      * @throws ilCtrlException
      */
     protected function deleteUserProviderCmd() : void
@@ -775,9 +754,6 @@ class ilLTIConsumerAdministrationGUI
     }
 
     /**
-     * @param array  $providers
-     * @param string $cancelCommand
-     * @return void
      * @throws ilCtrlException
      */
     protected function confirmDeleteProviders(array $providers, string $cancelCommand) : void
@@ -813,7 +789,6 @@ class ilLTIConsumerAdministrationGUI
     }
 
     /**
-     * @return void
      * @throws ilCtrlException
      */
     protected function performDeleteProvidersCmd() : void
@@ -833,11 +808,6 @@ class ilLTIConsumerAdministrationGUI
         $DIC->ctrl()->redirect($this, $DIC->http()->wrapper()->query()->retrieve(self::REDIRECTION_CMD_PARAMETER, $DIC->refinery()->kindlyTo()->string()));
     }
 
-    /**
-     * @param ilLTIConsumerAdministrationGUI $parentGui
-     * @param string      $parentCmd
-     * @return ilLTIConsumerProviderTableGUI
-     */
     protected function buildProviderTable(ilLTIConsumerAdministrationGUI $parentGui, string $parentCmd) : \ilLTIConsumerProviderTableGUI
     {
         $table = new ilLTIConsumerProviderTableGUI(
@@ -875,10 +845,6 @@ class ilLTIConsumerAdministrationGUI
     }
 
     /**
-     * @param ilLTIConsumeProvider $provider
-     * @param string               $saveCmd
-     * @param string               $cancelCmd
-     * @return ilLTIConsumeProviderFormGUI
      * @throws ilCtrlException
      */
     protected function buildProviderForm(ilLTIConsumeProvider $provider, string $saveCmd, string $cancelCmd) : \ilLTIConsumeProviderFormGUI
@@ -893,7 +859,6 @@ class ilLTIConsumerAdministrationGUI
     }
 
     /**
-     * @return ilLTIConsumeProvider
      * @throws \ILIAS\Filesystem\Exception\IOException
      */
     protected function fetchProvider() : \ilLTIConsumeProvider
@@ -968,7 +933,6 @@ class ilLTIConsumerAdministrationGUI
     }
 
     /**
-     * @return ilPropertyFormGUI
      * @throws ilCtrlException
      */
     protected function buildSettingsForm() : \ilPropertyFormGUI
@@ -984,10 +948,6 @@ class ilLTIConsumerAdministrationGUI
         return $form;
     }
     
-    /**
-     * @param array $providerIds
-     * @return ilLTIConsumeProviderList
-     */
     protected function getProviderListForIds(array $providerIds) : ilLTIConsumeProviderList
     {
         $providerList = new ilLTIConsumeProviderList();

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerAdministrationGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerAdministrationGUI.php
@@ -360,9 +360,12 @@ class ilLTIConsumerAdministrationGUI
     private function prepareProvider() : \ilLTIConsumeProvider
     {
         $provider = new ilLTIConsumeProvider();
+        // TODO PHP8 Review: Check/Resolve Type-Mismatch
         $provider->setTitle($this->getInput('title'));
+        // TODO PHP8 Review: Check/Resolve Type-Mismatch
         $provider->setDescription($this->getInput('description'));
         if (null !== $this->getInput('provider_url')) {
+            // TODO PHP8 Review: Check/Resolve Type-Mismatch
             $provider->setProviderUrl($this->getInput('provider_url'));
         }
         $provider->setIsGlobal(true);
@@ -370,6 +373,7 @@ class ilLTIConsumerAdministrationGUI
 
         // PROVIDER ICON
         $pId = $provider->getId();
+        // TODO PHP8 Review: Check/Resolve Type-Mismatch
         if (null !== $pIconFileName = $this->getIconXml($this->getInput('provider_icon'), (string) $pId)) {
             $provider->setProviderIconFilename($pIconFileName);
             $provider->update();

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerAdministrationGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerAdministrationGUI.php
@@ -388,7 +388,7 @@ class ilLTIConsumerAdministrationGUI
 
     /**
      * @param $key
-     * @return mixed
+     * @return mixed[]
      */
     private function getInput($key) : array
     {

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerAdministrationGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerAdministrationGUI.php
@@ -933,25 +933,6 @@ class ilLTIConsumerAdministrationGUI
         return $providers;
     }
     
-//    /**
-//     * @return string
-//     */
-//    protected function getContextRelatedRedirectionCommand()
-//    {
-//        if (isset($_GET[self::CONTEXT_PARAMETER])) {
-//            switch ($_GET[self::CONTEXT_PARAMETER]) {
-//                case self::CONTEXT_GLOBAL_PROVIDER:
-//
-//                    return self::CMD_SHOW_GLOBAL_PROVIDER;
-//
-//                case self::CONTEXT_USER_PROVIDER:
-//
-//                    return self::CMD_SHOW_USER_PROVIDER;
-//            }
-//        }
-//
-//        return '';
-//    }
     
     protected function showSettingsCmd(?ilPropertyFormGUI $form = null) : void
     {

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerDataService.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerDataService.php
@@ -44,29 +44,6 @@ class ilLTIConsumerDataService
     
     public static function initIlias($client_id) : void
     {
-        // if (isset($_GET["client_id"]))
-        // {
-        // $cookie_domain = $_SERVER['SERVER_NAME'];
-        // $cookie_path = dirname( $_SERVER['PHP_SELF'] );
-
-        // /* if ilias is called directly within the docroot $cookie_path
-        // is set to '/' expecting on servers running under windows..
-        // here it is set to '\'.
-        // in both cases a further '/' won't be appended due to the following regex
-        // */
-        // $cookie_path .= (!preg_match("/[\/|\\\\]$/", $cookie_path)) ? "/" : "";
-
-        // if($cookie_path == "\\") $cookie_path = '/';
-
-        // $cookie_domain = ''; // Temporary Fix
-
-        // setcookie("ilClientId", $_GET["client_id"], 0, $cookie_path, $cookie_domain);
-
-        // $_COOKIE["ilClientId"] = $_GET["client_id"];
-        // }
-
-
-
         define("CLIENT_ID", $client_id);
         define('IL_COOKIE_HTTPONLY', true); // Default Value
         define('IL_COOKIE_EXPIRE', 0);
@@ -74,26 +51,6 @@ class ilLTIConsumerDataService
         define('IL_COOKIE_DOMAIN', '');
         \ilContext::init(\ilContext::CONTEXT_SCORM);
         \ilInitialisation::initILIAS();
-        // Remember original values
-        // $_ORG_SERVER = array(
-          // 'HTTP_HOST'    => $_SERVER['HTTP_HOST'],
-          // 'REQUEST_URI'  => $_SERVER['REQUEST_URI'],
-          // 'PHP_SELF'     => $_SERVER['PHP_SELF'],
-        // );
-        // // Overwrite $_SERVER entries which would confuse ILIAS during initialisation
-        // $_SERVER['REQUEST_URI'] = '';
-        // $_SERVER['PHP_SELF']    = '/index.php';
-        // $_SERVER['HTTP_HOST']   = self::getIniHost();
-        // require_once "./Services/Utilities/classes/class.ilUtil.php";
-        // //ilInitialisation::initIliasIniFile();
-        // ilInitialisation::initClientIniFile();
-        // ilInitialisation::initDatabase();
-
-        // // Restore original, since this could lead to bad side-effects otherwise
-        // $_SERVER['HTTP_HOST']   = $_ORG_SERVER['HTTP_HOST'];
-        // $_SERVER['REQUEST_URI'] = $_ORG_SERVER['REQUEST_URI'];
-        // $_SERVER['PHP_SELF']    = $_ORG_SERVER['PHP_SELF'];
-        // ilInitialisation::initLog();//UK
     }
 }
 

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerEmbeddedContentGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerEmbeddedContentGUI.php
@@ -36,16 +36,12 @@ class ilLTIConsumerEmbeddedContentGUI
      */
     protected ilCmiXapiUser $cmixUser;
     
-    /**
-     * @param ilObjLTIConsumer $object
-     */
     public function __construct(ilObjLTIConsumer $object)
     {
         $this->object = $object;
     }
 
     /**
-     * @return void
      * @throws ilLtiConsumerException
      */
     public function executeCommand() : void
@@ -62,7 +58,6 @@ class ilLTIConsumerEmbeddedContentGUI
     }
 
     /**
-     * @return void
      * @throws ilCtrlException
      * @throws ilTemplateException
      */
@@ -81,7 +76,6 @@ class ilLTIConsumerEmbeddedContentGUI
     }
 
     /**
-     * @return void
      * @throws ilTemplateException
      */
     protected function showEmbedded() : void
@@ -111,9 +105,6 @@ class ilLTIConsumerEmbeddedContentGUI
         exit;
     }
     
-    /**
-     * @return array
-     */
     protected function getLaunchParameters() : array
     {
         global $DIC; /* @var \ILIAS\DI\Container $DIC */

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerLP.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerLP.php
@@ -39,9 +39,6 @@ class ilLTIConsumerLP extends ilObjectLP
         return ilLPObjSettings::LP_MODE_DEACTIVATED;
     }
     
-    /**
-     * @return array
-     */
     public function getValidModes() : array
     {
         return array(

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerLaunch.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerLaunch.php
@@ -25,13 +25,11 @@ use ILIAS\LTIOAuth;
  */
 class ilLTIConsumerLaunch
 {
-    private static string $last_oauth_base_string = "";
     // protected $context = null;
     protected int $ref_id;
 
     /**
      * ilObjLTIConsumerLaunch constructor.
-     * @param int $a_ref_id
      */
     public function __construct(int $a_ref_id)
     {
@@ -56,7 +54,7 @@ class ilLTIConsumerLaunch
 
             // check fromm inner to outer
             $path = array_reverse($tree->getPathFull($this->ref_id));
-            foreach ($path as $key => $row) {
+            foreach ($path as $row) {
                 if (in_array($row['type'], $a_valid_types)) {
                     // take an existing inner context outside a course
                     if (in_array($row['type'], array('cat', 'root')) && !empty($this->context)) {
@@ -82,17 +80,13 @@ class ilLTIConsumerLaunch
         switch ($a_type) {
             case "crs":
                 return "CourseOffering";
-                break;
             case "grp":
                 return "Group";
-                break;
             case "root":
                 return "urn:lti:context-type:ilias/RootNode";
-                break;
             case "cat":
             default:
                 return "urn:lti:context-type:ilias/Category";
-                break;
         }
     }
 

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerProviderSelectionFormTableGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerProviderSelectionFormTableGUI.php
@@ -30,11 +30,6 @@ class ilLTIConsumerProviderSelectionFormTableGUI extends ilPropertyFormGUI
 
     /**
      * ilLTIConsumerProviderSelectionFormGUI constructor.
-     * @param string              $newType
-     * @param ilObjLTIConsumerGUI $parentGui
-     * @param string              $parentCmd
-     * @param string              $applyFilterCmd
-     * @param string              $resetFilterCmd
      */
     public function __construct(string $newType, ilObjLTIConsumerGUI $parentGui, string $parentCmd, string $applyFilterCmd, string $resetFilterCmd)
     {
@@ -84,7 +79,6 @@ class ilLTIConsumerProviderSelectionFormTableGUI extends ilPropertyFormGUI
     }
 
     /**
-     * @param string $a_field
      * @return string|bool
      */
     public function getFilter(string $a_field)
@@ -92,7 +86,7 @@ class ilLTIConsumerProviderSelectionFormTableGUI extends ilPropertyFormGUI
         $field = $this->table->getFilterItemByPostVar($a_field);
         
         if ($field instanceof ilCheckboxInputGUI) {
-            return (bool) $field->getChecked();
+            return $field->getChecked();
         }
         
         return $field->getValue();

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerProviderTableGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerProviderTableGUI.php
@@ -109,209 +109,131 @@ class ilLTIConsumerProviderTableGUI extends ilTable2GUI
         return $this->title;
     }
     
-    /**
-     * @return string
-     */
     public function getEditProviderCmd() : string
     {
         return $this->editProviderCmd;
     }
     
-    /**
-     * @param string $editProviderCmd
-     */
     public function setEditProviderCmd(string $editProviderCmd) : void
     {
         $this->editProviderCmd = $editProviderCmd;
     }
     
-    /**
-     * @return string
-     */
     public function getAcceptProviderAsGlobalCmd() : string
     {
         return $this->acceptProviderAsGlobalCmd;
     }
     
-    /**
-     * @param string $acceptProviderAsGlobalCmd
-     */
     public function setAcceptProviderAsGlobalCmd(string $acceptProviderAsGlobalCmd) : void
     {
         $this->acceptProviderAsGlobalCmd = $acceptProviderAsGlobalCmd;
     }
     
-    /**
-     * @return string
-     */
     public function getAcceptProviderAsGlobalMultiCmd() : string
     {
         return $this->acceptProviderAsGlobalMultiCmd;
     }
     
-    /**
-     * @param string $acceptProviderAsGlobalMultiCmd
-     */
     public function setAcceptProviderAsGlobalMultiCmd(string $acceptProviderAsGlobalMultiCmd) : void
     {
         $this->acceptProviderAsGlobalMultiCmd = $acceptProviderAsGlobalMultiCmd;
     }
     
-    /**
-     * @return string
-     */
     public function getResetProviderToUserScopeCmd() : string
     {
         return $this->resetProviderToUserScopeCmd;
     }
     
-    /**
-     * @param string $resetProviderToUserScopeCmd
-     */
     public function setResetProviderToUserScopeCmd(string $resetProviderToUserScopeCmd) : void
     {
         $this->resetProviderToUserScopeCmd = $resetProviderToUserScopeCmd;
     }
     
-    /**
-     * @return string
-     */
     public function getResetProviderToUserScopeMultiCmd() : string
     {
         return $this->resetProviderToUserScopeMultiCmd;
     }
     
-    /**
-     * @param string $resetProviderToUserScopeMultiCmd
-     */
     public function setResetProviderToUserScopeMultiCmd(string $resetProviderToUserScopeMultiCmd) : void
     {
         $this->resetProviderToUserScopeMultiCmd = $resetProviderToUserScopeMultiCmd;
     }
     
-    /**
-     * @return string
-     */
     public function getSelectProviderCmd() : string
     {
         return $this->selectProviderCmd;
     }
     
-    /**
-     * @param string $selectProviderCmd
-     */
     public function setSelectProviderCmd(string $selectProviderCmd) : void
     {
         $this->selectProviderCmd = $selectProviderCmd;
     }
     
-    /**
-     * @return string
-     */
     public function getDeleteProviderCmd() : string
     {
         return $this->deleteProviderCmd;
     }
     
-    /**
-     * @param string $deleteProviderCmd
-     */
     public function setDeleteProviderCmd(string $deleteProviderCmd) : void
     {
         $this->deleteProviderCmd = $deleteProviderCmd;
     }
     
-    /**
-     * @return string
-     */
     public function getDeleteProviderMultiCmd() : string
     {
         return $this->deleteProviderMultiCmd;
     }
     
-    /**
-     * @param string $deleteProviderMultiCmd
-     */
     public function setDeleteProviderMultiCmd(string $deleteProviderMultiCmd) : void
     {
         $this->deleteProviderMultiCmd = $deleteProviderMultiCmd;
     }
     
-    /**
-     * @return bool
-     */
     public function isAvailabilityColumnEnabled() : bool
     {
         return $this->availabilityColumnEnabled;
     }
     
-    /**
-     * @param bool $availabilityColumnEnabled
-     */
     public function setAvailabilityColumnEnabled(bool $availabilityColumnEnabled) : void
     {
         $this->availabilityColumnEnabled = $availabilityColumnEnabled;
     }
     
-    /**
-     * @return bool
-     */
     public function isOwnProviderColumnEnabled() : bool
     {
         return $this->ownProviderColumnEnabled;
     }
     
-    /**
-     * @param bool $ownProviderColumnEnabled
-     */
     public function setOwnProviderColumnEnabled(bool $ownProviderColumnEnabled) : void
     {
         $this->ownProviderColumnEnabled = $ownProviderColumnEnabled;
     }
     
-    /**
-     * @return bool
-     */
     public function isProviderCreatorColumnEnabled() : bool
     {
         return $this->providerCreatorColumnEnabled;
     }
     
-    /**
-     * @param bool $providerCreatorColumnEnabled
-     */
     public function setProviderCreatorColumnEnabled(bool $providerCreatorColumnEnabled) : void
     {
         $this->providerCreatorColumnEnabled = $providerCreatorColumnEnabled;
     }
     
-    /**
-     * @return bool
-     */
     public function isActionsColumnEnabled() : bool
     {
         return $this->actionsColumnEnabled;
     }
     
-    /**
-     * @param bool $actionsColumnEnabled
-     */
     public function setActionsColumnEnabled(bool $actionsColumnEnabled) : void
     {
         $this->actionsColumnEnabled = $actionsColumnEnabled;
     }
     
-    /**
-     * @return bool
-     */
     public function isDetailedUsagesEnabled() : bool
     {
         return $this->detailedUsagesEnabled;
     }
     
-    /**
-     * @param bool $detailedUsagesEnabled
-     */
     public function setDetailedUsagesEnabled(bool $detailedUsagesEnabled) : void
     {
         $this->detailedUsagesEnabled = $detailedUsagesEnabled;

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerProviderTableGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerProviderTableGUI.php
@@ -727,6 +727,9 @@ class ilLTIConsumerProviderTableGUI extends ilTable2GUI
         return '';
     }
     
+    /**
+     * @return mixed[]
+     */
     protected function getActionItems(array $data) : array
     {
         global $DIC; /* @var \ILIAS\DI\Container $DIC */

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerProviderTableGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerProviderTableGUI.php
@@ -638,7 +638,7 @@ class ilLTIConsumerProviderTableGUI extends ilTable2GUI
         
         $items = $this->getActionItems($data);
         
-        if (count($items)) {
+        if ($items !== []) {
             return $DIC->ui()->renderer()->render(
                 $DIC->ui()->factory()->dropdown()->standard($items)->withLabel(
                     $DIC->language()->txt('actions')

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerProviderUsageTableGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerProviderUsageTableGUI.php
@@ -31,7 +31,6 @@ class ilLTIConsumerProviderUsageTableGUI extends ilTable2GUI
 
     /**
      * ilLTIConsumerProviderUsageTableGUI constructor.
-     * @param ilLTIConsumerAdministrationGUI $a_parent_obj
      * @param $a_parent_cmd
      */
     public function __construct(ilLTIConsumerAdministrationGUI $a_parent_obj, string $a_parent_cmd)
@@ -94,10 +93,6 @@ class ilLTIConsumerProviderUsageTableGUI extends ilTable2GUI
     }
 
     /**
-     * @param int    $objId
-     * @param int    $refId
-     * @param string $title
-     * @param bool   $trashed
      * @return array<string, string>
      */
     protected function buildLinkToUsedBy(int $objId, int $refId, string $title, bool $trashed) : array

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerResult.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerResult.php
@@ -41,7 +41,7 @@ class ilLTIConsumerResult
     /**
      * @var float|null
      */
-    public ?float $result;
+    public ?float $result = null;
 
     /**
      * Get a result by id

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerResult.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerResult.php
@@ -45,8 +45,6 @@ class ilLTIConsumerResult
 
     /**
      * Get a result by id
-     * @param int $a_id
-     * @return ilLTIConsumerResult|null
      */
     public static function getById(int $a_id) : ?ilLTIConsumerResult
     {
@@ -67,9 +65,6 @@ class ilLTIConsumerResult
 
     /**
      * Get a result by object and user key
-     * @param int       $a_obj_id
-     * @param int       $a_usr_id
-     * @param bool|null $a_create
      * @return ilLTIConsumerResult
      */
     public static function getByKeys(int $a_obj_id, int $a_usr_id, ?bool $a_create = false) : ?ilLTIConsumerResult

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerResult.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerResult.php
@@ -111,7 +111,7 @@ class ilLTIConsumerResult
     {
         global $DIC; /* @var \ILIAS\DI\Container $DIC */
 
-        if (!isset($this->usr_id) or !isset($this->obj_id)) {
+        if (!isset($this->usr_id) || !isset($this->obj_id)) {
             return false;
         }
         if (!isset($this->id)) {

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerResultService.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerResultService.php
@@ -53,56 +53,32 @@ class ilLTIConsumerResultService
     protected string $operation = '';
 
 
-    /**
-     * @return float
-     */
     public function getMasteryScore() : float
     {
         return $this->mastery_score;
     }
 
-    /**
-     * @param float $mastery_score
-     */
     public function setMasteryScore(float $mastery_score) : void
     {
         $this->mastery_score = $mastery_score;
     }
 
-    /**
-     * @return int
-     */
     public function getAvailability() : int
     {
         return $this->availability;
     }
 
-    /**
-     * @param int $availability
-     */
     public function setAvailability(int $availability) : void
     {
         $this->availability = $availability;
     }
 
-    /**
-     * @return bool
-     */
     public function isAvailable() : bool
     {
         if ($this->availability == 0) {
             return false;
         }
         return true;
-    }
-
-
-
-    /**
-     * Constructor: general initialisations
-     */
-    public function __construct()
-    {
     }
     
     /**
@@ -297,7 +273,6 @@ class ilLTIConsumerResultService
 
     /**
      * Send a "bad request" response
-     * @param string|null $message
      */
     protected function respondBadRequest(?string $message = null) : void
     {
@@ -327,7 +302,6 @@ class ilLTIConsumerResultService
 
     /**
      * Read the LTI Consumer object properties
-     * @param int $a_obj_id
      */
     private function readProperties(int $a_obj_id) : void
     {
@@ -351,7 +325,6 @@ class ilLTIConsumerResultService
 
     /**
      * Read the LTI Consumer object fields
-     * @param int $a_obj_id
      */
     private function readFields(int $a_obj_id) : void
     {
@@ -382,8 +355,6 @@ class ilLTIConsumerResultService
 
     /**
      * Check the reqest signature
-     * @param string $a_key
-     * @param string $a_secret
      * @return bool|Exception    Exception or true
      */
     private function checkSignature(string $a_key, string $a_secret)

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerScoringGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerScoringGUI.php
@@ -48,9 +48,6 @@ class ilLTIConsumerScoringGUI
     private \ilGlobalTemplateInterface $main_tpl;
 
 
-    /**
-     * @param ilObjLTIConsumer $object
-     */
     public function __construct(ilObjLTIConsumer $object)
     {
         global $DIC;
@@ -139,10 +136,6 @@ class ilLTIConsumerScoringGUI
         return $this;
     }
 
-    /**
-     * @param bool|null $scopeUserRank
-     * @return array
-     */
     private function getTableDataRange(?bool $scopeUserRank = false) : array
     {
         if (false === $scopeUserRank) {
@@ -185,21 +178,16 @@ class ilLTIConsumerScoringGUI
         return $this;
     }
 
-    /**
-     * @param string $tableId
-     * @return ilLTIConsumerScoringTableGUI
-     */
     protected function buildTableGUI(string $tableId) : ilLTIConsumerScoringTableGUI
     {
         $isMultiActorReport = $this->access->hasOutcomesAccess();
-        $table = new ilLTIConsumerScoringTableGUI(
+        return new ilLTIConsumerScoringTableGUI(
             $this,
             'show',
             $isMultiActorReport,
             $tableId,
             $this->access->hasOutcomesAccess()
         );
-        return $table;
     }
 
     public function getObject() : \ilObjLTIConsumer

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerScoringTableGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerScoringTableGUI.php
@@ -41,11 +41,6 @@ class ilLTIConsumerScoringTableGUI extends ilTable2GUI
 
     /**
      * ilLTIConsumerScoringTableGUI constructor.
-     * @param ilLTIConsumerScoringGUI $a_parent_obj
-     * @param string                  $a_parent_cmd
-     * @param bool                    $isMultiActorReport
-     * @param string                  $tableId
-     * @param bool                    $hasOutcomeAccess
      */
     public function __construct(ilLTIConsumerScoringGUI $a_parent_obj, string $a_parent_cmd, bool $isMultiActorReport, string $tableId, bool $hasOutcomeAccess)
     {

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerSettingsFormGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerSettingsFormGUI.php
@@ -30,10 +30,6 @@ class ilLTIConsumerSettingsFormGUI extends ilPropertyFormGUI
     
     /**
      * ilLTIConsumerSettingsFormGUI constructor.
-     * @param ilObjLTIConsumer $object
-     * @param string $formaction
-     * @param string $saveCommand
-     * @param string $cancelCommand
      */
     public function __construct(ilObjLTIConsumer $object, string $formaction, string $saveCommand, string $cancelCommand)
     {
@@ -44,12 +40,6 @@ class ilLTIConsumerSettingsFormGUI extends ilPropertyFormGUI
         $this->initForm($formaction, $saveCommand, $cancelCommand);
     }
 
-    /**
-     * @param string $formaction
-     * @param string $saveCommand
-     * @param string $cancelCommand
-     * @return void
-     */
     protected function initForm(string $formaction, string $saveCommand, string $cancelCommand) : void
     {
         global $DIC; /* @var \ILIAS\DI\Container $DIC */
@@ -221,9 +211,6 @@ class ilLTIConsumerSettingsFormGUI extends ilPropertyFormGUI
         }
     }
     
-    /**
-     * @param ilObjLTIConsumer $object
-     */
     public function initObject(ilObjLTIConsumer $object) : void
     {
         $object->setTitle($this->getInput('title'));

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerSettingsGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerSettingsGUI.php
@@ -47,8 +47,6 @@ class ilLTIConsumerSettingsGUI
 
     /**
      * ilLTIConsumerAccess constructor.
-     * @param ilObjLTIConsumer    $object
-     * @param ilLTIConsumerAccess $access
      */
     public function __construct(ilObjLTIConsumer $object, ilLTIConsumerAccess $access)
     {

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerSettingsGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerSettingsGUI.php
@@ -169,7 +169,7 @@ class ilLTIConsumerSettingsGUI
             $form->initObject($this->object);
             $this->object->update();
             
-            if ($oldMasteryScore != $this->object->getMasteryScore()) {
+            if ($oldMasteryScore !== $this->object->getMasteryScore()) {
                 ilLPStatusWrapper::_refreshStatus($this->object->getId());
             }
             

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerXapiStatementsGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerXapiStatementsGUI.php
@@ -172,7 +172,7 @@ class ilLTIConsumerXapiStatementsGUI
         $auto->setMoreLinkAvailable(true);
         
         //$auto->setLimit(ilUserAutoComplete::MAX_ENTRIES);
-        
+        // TODO PHP8 Review: Remove/Replace SuperGlobals
         $result = json_decode($auto->getList(ilUtil::stripSlashes($_REQUEST['term'])), true);
         
         echo json_encode($result);

--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerXapiStatementsGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerXapiStatementsGUI.php
@@ -35,9 +35,6 @@ class ilLTIConsumerXapiStatementsGUI
     protected ilLTIConsumerAccess $access;
     private \ilGlobalTemplateInterface $main_tpl;
     
-    /**
-     * @param ilObjLTIConsumer $object
-     */
     public function __construct(ilObjLTIConsumer $object)
     {
         global $DIC;
@@ -179,10 +176,6 @@ class ilLTIConsumerXapiStatementsGUI
         exit();
     }
     
-    /**
-     * @param ilCmiXapiStatementsTableGUI $table
-     * @param ilCmiXapiStatementsReportFilter $filter
-     */
     protected function initTableData(ilCmiXapiStatementsTableGUI $table, ilCmiXapiStatementsReportFilter $filter) : void
     {
         $aggregateEndPointUrl = str_replace(
@@ -212,9 +205,6 @@ class ilLTIConsumerXapiStatementsGUI
         $table->setMaxCount($statementsReport->getMaxCount());
     }
     
-    /**
-     * @return ilCmiXapiStatementsTableGUI
-     */
     protected function buildTableGUI() : ilCmiXapiStatementsTableGUI
     {
         $isMultiActorReport = $this->access->hasOutcomesAccess();

--- a/Modules/LTIConsumer/classes/class.ilObjLTIConsumer.php
+++ b/Modules/LTIConsumer/classes/class.ilObjLTIConsumer.php
@@ -78,8 +78,6 @@ class ilObjLTIConsumer extends ilObject2
 
     /**
      * ilObjLTIConsumer constructor.
-     * @param int $a_id
-     * @param bool $a_reference
      */
     public function __construct(int $a_id = 0, bool $a_reference = true)
     {
@@ -556,24 +554,18 @@ class ilObjLTIConsumer extends ilObject2
         return $retval;
     }
 
-    /**
-     * @return int
-     */
     public function getHighscoreMode() : int
     {
         switch (true) {
             case $this->getHighscoreOwnTable() && $this->getHighscoreTopTable():
                 return self::HIGHSCORE_SHOW_ALL_TABLES;
-                break;
 
             case $this->getHighscoreTopTable():
                 return self::HIGHSCORE_SHOW_TOP_TABLE;
-                break;
 
             case $this->getHighscoreOwnTable():
             default:
                 return self::HIGHSCORE_SHOW_OWN_TABLE;
-                break;
         }
     }
 
@@ -602,13 +594,6 @@ class ilObjLTIConsumer extends ilObject2
     }
     /* End GET/SET for highscore feature*/
     /**
-     * @param ilCmiXapiUser $cmixUser
-     * @param string        $token
-     * @param string        $contextType
-     * @param string        $contextId
-     * @param string        $contextTitle
-     * @param string|null   $returnUrl
-     * @return array
      * @throws ilWACException
      */
     public function buildLaunchParameters(ilCmiXapiUser $cmixUser, string $token, string $contextType, string $contextId, string $contextTitle, ?string $returnUrl = '') : array
@@ -715,8 +700,6 @@ class ilObjLTIConsumer extends ilObject2
             "data" => ($launch_vars + $custom_params)
         ];
         
-        $launchParameters = ilLTIConsumerLaunch::signOAuth($OAuthParams);
-        
-        return $launchParameters;
+        return ilLTIConsumerLaunch::signOAuth($OAuthParams);
     }
 }

--- a/Modules/LTIConsumer/classes/class.ilObjLTIConsumer.php
+++ b/Modules/LTIConsumer/classes/class.ilObjLTIConsumer.php
@@ -29,9 +29,9 @@ class ilObjLTIConsumer extends ilObject2
      * repository object activation settings (handled by ilObject)
      */
     protected bool $activationLimited;
-    protected ?int $activationStartingTime;
-    protected ?int $activationEndingTime;
-    protected ?bool $activationVisibility;
+    protected ?int $activationStartingTime = null;
+    protected ?int $activationEndingTime = null;
+    protected ?bool $activationVisibility = null;
     
     protected int $providerId = 0;
     
@@ -91,7 +91,7 @@ class ilObjLTIConsumer extends ilObject2
         $this->type = "lti";
     }
     
-    public function isActivationLimited() : ?bool
+    public function isActivationLimited() : bool
     {
         return $this->activationLimited;
     }

--- a/Modules/LTIConsumer/classes/class.ilObjLTIConsumerAccess.php
+++ b/Modules/LTIConsumer/classes/class.ilObjLTIConsumerAccess.php
@@ -28,7 +28,7 @@ class ilObjLTIConsumerAccess extends ilObjectAccess implements ilConditionHandli
      */
     public static function _getCommands() : array
     {
-        $commands = array(
+        return array(
             array(
                 "permission" => "read",
                 "cmd" => "infoScreen",
@@ -41,8 +41,6 @@ class ilObjLTIConsumerAccess extends ilObjectAccess implements ilConditionHandli
                 'lang_var' => 'settings'
             )
         );
-        
-        return $commands;
     }
 
     /**

--- a/Modules/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
@@ -47,7 +47,7 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
     public ?ilObject $object = null;
     protected ilLTIConsumerAccess $ltiAccess;
 
-    public function __construct($a_id = 0, $a_id_type = self::REPOSITORY_NODE_ID, $a_parent_node_id = 0)
+    public function __construct(int $a_id = 0, int $a_id_type = self::REPOSITORY_NODE_ID, int $a_parent_node_id = 0)
     {
         global $DIC;
         /* @var \ILIAS\DI\Container $DIC */

--- a/Modules/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
@@ -67,10 +67,6 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
         return 'lti';
     }
 
-    /**
-     * @param string $a_new_type
-     * @return array
-     */
     protected function initCreationForms(string $a_new_type) : array
     {
         global $DIC;
@@ -90,10 +86,6 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
         return $forms;
     }
 
-    /**
-     * @param string $a_new_type
-     * @return ilLTIConsumerProviderSelectionFormTableGUI
-     */
     protected function initCreateForm(string $a_new_type) : \ilLTIConsumerProviderSelectionFormTableGUI
     {
         global $DIC;
@@ -330,8 +322,6 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
     }
 
     /**
-     * @param string|null $a_sub_type
-     * @param int|null    $a_sub_id
      * @return ilObjectListGUI
      * @throws ilCtrlException
      */
@@ -870,7 +860,6 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
     }
 
     /**
-     * @param string $key
      * @param mixed  $default
      * @return mixed|null
      */

--- a/Modules/LTIConsumer/classes/class.ilObjLTIConsumerListGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilObjLTIConsumerListGUI.php
@@ -136,9 +136,8 @@ class ilObjLTIConsumerListGUI extends ilObjectListGUI
     }
 
     /**
-     * @return array
-     * @throws ilCtrlException
-     */
+                 * @throws ilCtrlException
+                 */
     public function getProperties() : array
     {
         global $DIC; /* @var \ILIAS\DI\Container $DIC */

--- a/Modules/LTIConsumer/result.php
+++ b/Modules/LTIConsumer/result.php
@@ -1,12 +1,12 @@
 <?php declare(strict_types=1);
 
 chdir("../../");
-
+// TODO PHP8 Review: Remove/Replace SuperGlobals
 if (!isset($_GET['client_id']) || !strlen($_GET['client_id'])) {
     header('HTTP/1.1 401 Authorization Required');
     exit;
 }
-
+// TODO PHP8 Review: Remove/Replace SuperGlobals
 \LTI\ilLTIConsumerDataService::initIlias($_GET['client_id']);
 
 $dic = $GLOBALS['DIC'];

--- a/Modules/LTIConsumer/src/OAuth.php
+++ b/Modules/LTIConsumer/src/OAuth.php
@@ -60,107 +60,105 @@ if (!class_exists('OAuthConsumer')) {
         }
     }
 }
-
-class OAuthToken
-{
-    // access tokens and request tokens
-    /** @var string */
-    public string $key;
-
-    /** @var string */
-    public string $secret;
-
-    /** @var callable|null */
-    public $callback = null;
-
-
-    /**
-     * @param string $key    = the token
-     * @param string $secret = the token secret
-     */
-    public function __construct(string $key, string $secret)
+if (!class_exists('OAuthToken')) {
+    class OAuthToken
     {
-        $this->key = $key;
-        $this->secret = $secret;
-    }
-
-
-    /**
-     * generates the basic string serialization of a token that a server
-     * would respond to request_token and access_token calls with
-     */
-    public function to_string() : string
-    {
-        /** @var string $key */
-        $key = OAuthUtil::urlencode_rfc3986($this->key);
-        /** @var string $secret */
-        $secret = OAuthUtil::urlencode_rfc3986($this->secret);
-        return "oauth_token=" . $key .
-        "&oauth_token_secret=" . $secret .
-        "&oauth_callback_confirmed=true";
-    }
-
-
-    /**
-     * @return string
-     */
-    public function __toString()
-    {
-        return $this->to_string();
+        // access tokens and request tokens
+        /** @var string */
+        public string $key;
+        
+        /** @var string */
+        public string $secret;
+        
+        /** @var callable|null */
+        public $callback = null;
+        
+        /**
+         * @param string $key    = the token
+         * @param string $secret = the token secret
+         */
+        public function __construct(string $key, string $secret)
+        {
+            $this->key = $key;
+            $this->secret = $secret;
+        }
+        
+        /**
+         * generates the basic string serialization of a token that a server
+         * would respond to request_token and access_token calls with
+         */
+        public function to_string() : string
+        {
+            /** @var string $key */
+            $key = OAuthUtil::urlencode_rfc3986($this->key);
+            /** @var string $secret */
+            $secret = OAuthUtil::urlencode_rfc3986($this->secret);
+            return "oauth_token=" . $key .
+                "&oauth_token_secret=" . $secret .
+                "&oauth_callback_confirmed=true";
+        }
+        
+        /**
+         * @return string
+         */
+        public function __toString()
+        {
+            return $this->to_string();
+        }
     }
 }
-
 /**
  * A class for implementing a Signature Method
  * See section 9 ("Signing Requests") in the spec
  */
-abstract class OAuthSignatureMethod
-{
-    /**
-     * Needs to return the name of the Signature Method (ie HMAC-SHA1)
-     */
-    abstract public function get_name() : string;
-
-    /**
-     * Build up the signature
-     * NOTE: The output of this function MUST NOT be urlencoded.
-     * the encoding is handled in OAuthRequest when the final
-     * request is serialized
-     * @param OAuthToken $token|null
-     */
-    abstract public function build_signature(OAuthRequest $request, OAuthConsumer $consumer, OAuthToken $token) : string;
-
-    /**
-     * Verifies that a given signature is correct
-     * @param OAuthRequest  $request
-     * @param OAuthConsumer $consumer
-     * @param OAuthToken    $token
-     * @param string        $signature
-     * @return bool
-     */
-    public function check_signature(OAuthRequest $request, OAuthConsumer $consumer, OAuthToken $token, string $signature) : bool
+if (!class_exists('OAuthSignatureMethod')) {
+    abstract class OAuthSignatureMethod
     {
-        $built = $this->build_signature($request, $consumer, $token);
+        /**
+         * Needs to return the name of the Signature Method (ie HMAC-SHA1)
+         */
+        abstract public function get_name() : string;
 
-        // Check for zero length, although unlikely here
-        if (strlen($built) == 0 || strlen($signature) == 0) {
-            return false;
+        /**
+         * Build up the signature
+         * NOTE: The output of this function MUST NOT be urlencoded.
+         * the encoding is handled in OAuthRequest when the final
+         * request is serialized
+         * @param OAuthToken $token|null
+         */
+        abstract public function build_signature(OAuthRequest $request, OAuthConsumer $consumer, OAuthToken $token) : string;
+
+        /**
+         * Verifies that a given signature is correct
+         * @param OAuthRequest  $request
+         * @param OAuthConsumer $consumer
+         * @param OAuthToken    $token
+         * @param string        $signature
+         * @return bool
+         */
+        public function check_signature(OAuthRequest $request, OAuthConsumer $consumer, OAuthToken $token, string $signature) : bool
+        {
+            $built = $this->build_signature($request, $consumer, $token);
+
+            // Check for zero length, although unlikely here
+            if (strlen($built) == 0 || strlen($signature) == 0) {
+                return false;
+            }
+
+            if (strlen($built) != strlen($signature)) {
+                return false;
+            }
+
+            // Avoid a timing leak with a (hopefully) time insensitive compare
+            $result = 0;
+            for ($i = 0; $i < strlen($signature); $i++) {
+                $result |= ord($built[$i]) ^ ord($signature[$i]);
+            }
+
+            return $result == 0;
         }
-
-        if (strlen($built) != strlen($signature)) {
-            return false;
-        }
-
-        // Avoid a timing leak with a (hopefully) time insensitive compare
-        $result = 0;
-        for ($i = 0; $i < strlen($signature); $i++) {
-            $result |= ord($built[$i]) ^ ord($signature[$i]);
-        }
-
-        return $result == 0;
     }
 }
-
 /**
  * The HMAC-SHA1 signature method uses the HMAC-SHA1 signature algorithm as defined in [RFC2104]
  * where the Signature Base String is the text and the key is the concatenated values (each first
@@ -168,75 +166,77 @@ abstract class OAuthSignatureMethod
  * character (ASCII code 38) even if empty.
  *   - Chapter 9.2 ("HMAC-SHA1")
  */
-class OAuthSignatureMethod_HMAC_SHA1 extends OAuthSignatureMethod
-{
-    public function get_name() : string
+if (!class_exists('OAuthSignatureMethod_HMAC_SHA1')) {
+    class OAuthSignatureMethod_HMAC_SHA1 extends OAuthSignatureMethod
     {
-        return "HMAC-SHA1";
-    }
+        public function get_name() : string
+        {
+            return "HMAC-SHA1";
+        }
 
 
-    /**
-     * @param OAuthToken $token|null
-     */
-    public function build_signature(OAuthRequest $request, OAuthConsumer $consumer, ?OAuthToken $token) : string
-    {
-        $base_string = $request->get_signature_base_string();
-        $request->base_string = $base_string;
+        /**
+         * @param OAuthToken $token|null
+         */
+        public function build_signature(OAuthRequest $request, OAuthConsumer $consumer, ?OAuthToken $token) : string
+        {
+            $base_string = $request->get_signature_base_string();
+            $request->base_string = $base_string;
 
-        $key_parts = [
+            $key_parts = [
             $consumer->secret,
             ($token) ? $token->secret : ""
         ];
 
-        /** @var array $key_parts */
-        $key_parts = OAuthUtil::urlencode_rfc3986($key_parts);
-        $key = implode('&', $key_parts);
+            /** @var array $key_parts */
+            $key_parts = OAuthUtil::urlencode_rfc3986($key_parts);
+            $key = implode('&', $key_parts);
 
-        return base64_encode(hash_hmac('sha1', $base_string, $key, true));
+            return base64_encode(hash_hmac('sha1', $base_string, $key, true));
+        }
     }
 }
-
 /**
  * The PLAINTEXT method does not provide any security protection and SHOULD only be used
  * over a secure channel such as HTTPS. It does not use the Signature Base String.
  *   - Chapter 9.4 ("PLAINTEXT")
  */
-class OAuthSignatureMethod_PLAINTEXT extends OAuthSignatureMethod
-{
-    public function get_name() : string
+if (!class_exists('OAuthSignatureMethod_PLAINTEXT')) {
+    class OAuthSignatureMethod_PLAINTEXT extends OAuthSignatureMethod
     {
-        return "PLAINTEXT";
-    }
+        public function get_name() : string
+        {
+            return "PLAINTEXT";
+        }
 
-    /**
-     * oauth_signature is set to the concatenated encoded values of the Consumer Secret and
-     * Token Secret, separated by a '&' character (ASCII code 38), even if either secret is
-     * empty. The result MUST be encoded again.
-     *   - Chapter 9.4.1 ("Generating Signatures")
-     * Please note that the second encoding MUST NOT happen in the SignatureMethod, as
-     * OAuthRequest handles this!
-     * @param OAuthRequest    $request
-     * @param OAuthConsumer   $consumer
-     * @param OAuthToken|null $token
-     * @return string
-     */
-    public function build_signature(OAuthRequest $request, OAuthConsumer $consumer, ?OAuthToken $token) : string
-    {
-        $key_parts = [
+        /**
+         * oauth_signature is set to the concatenated encoded values of the Consumer Secret and
+         * Token Secret, separated by a '&' character (ASCII code 38), even if either secret is
+         * empty. The result MUST be encoded again.
+         *   - Chapter 9.4.1 ("Generating Signatures")
+         * Please note that the second encoding MUST NOT happen in the SignatureMethod, as
+         * OAuthRequest handles this!
+         * @param OAuthRequest    $request
+         * @param OAuthConsumer   $consumer
+         * @param OAuthToken|null $token
+         * @return string
+         */
+        public function build_signature(OAuthRequest $request, OAuthConsumer $consumer, ?OAuthToken $token) : string
+        {
+            $key_parts = [
             $consumer->secret,
             ($token) ? $token->secret : ""
         ];
 
-        /** @var array $key_parts */
-        $key_parts = OAuthUtil::urlencode_rfc3986($key_parts);
-        $key = implode('&', $key_parts);
-        $request->base_string = $key;
+            /** @var array $key_parts */
+            $key_parts = OAuthUtil::urlencode_rfc3986($key_parts);
+            $key = implode('&', $key_parts);
+            $request->base_string = $key;
 
-        return $key;
+            return $key;
+        }
     }
 }
-
 /**
  * The RSA-SHA1 signature method uses the RSASSA-PKCS1-v1_5 signature algorithm as defined in
  * [RFC3447] section 8.2 (more simply known as PKCS#1), using SHA-1 as the hash function for
@@ -245,929 +245,935 @@ class OAuthSignatureMethod_PLAINTEXT extends OAuthSignatureMethod
  * specification.
  *   - Chapter 9.3 ("RSA-SHA1")
  */
-abstract class OAuthSignatureMethod_RSA_SHA1 extends OAuthSignatureMethod
-{
-    public function get_name() : string
+if (!class_exists('OAuthSignatureMethod_RSA_SHA1')) {
+    abstract class OAuthSignatureMethod_RSA_SHA1 extends OAuthSignatureMethod
     {
-        return "RSA-SHA1";
-    }
+        public function get_name() : string
+        {
+            return "RSA-SHA1";
+        }
 
 
-    /**
-     * Up to the SP to implement this lookup of keys. Possible ideas are:
-     * (1) do a lookup in a table of trusted certs keyed off of consumer
-     * (2) fetch via http using a url provided by the requester
-     * (3) some sort of specific discovery code based on request
-     *
-     * Either way should return a string representation of the certificate
-     *
-     * @param OAuthRequest &$request
-     */
-    abstract protected function fetch_public_cert(OAuthRequest &$request);
+        /**
+         * Up to the SP to implement this lookup of keys. Possible ideas are:
+         * (1) do a lookup in a table of trusted certs keyed off of consumer
+         * (2) fetch via http using a url provided by the requester
+         * (3) some sort of specific discovery code based on request
+         *
+         * Either way should return a string representation of the certificate
+         *
+         * @param OAuthRequest &$request
+         */
+        abstract protected function fetch_public_cert(OAuthRequest &$request);
 
 
-    /**
-     * Up to the SP to implement this lookup of keys. Possible ideas are:
-     * (1) do a lookup in a table of trusted certs keyed off of consumer
-     *
-     * Either way should return a string representation of the certificate
-     *
-     * @param OAuthRequest &$request
-     */
-    abstract protected function fetch_private_cert(OAuthRequest &$request);
+        /**
+         * Up to the SP to implement this lookup of keys. Possible ideas are:
+         * (1) do a lookup in a table of trusted certs keyed off of consumer
+         *
+         * Either way should return a string representation of the certificate
+         *
+         * @param OAuthRequest &$request
+         */
+        abstract protected function fetch_private_cert(OAuthRequest &$request);
 
 
-    public function build_signature(OAuthRequest $request, OAuthConsumer $consumer, OAuthToken $token) : string
-    {
-        $base_string = $request->get_signature_base_string();
-        $request->base_string = $base_string;
+        public function build_signature(OAuthRequest $request, OAuthConsumer $consumer, OAuthToken $token) : string
+        {
+            $base_string = $request->get_signature_base_string();
+            $request->base_string = $base_string;
 
-        // Fetch the private key cert based on the request
-        $cert = $this->fetch_private_cert($request);
+            // Fetch the private key cert based on the request
+            $cert = $this->fetch_private_cert($request);
 
-        // Pull the private key ID from the certificate
-        $privatekeyid = openssl_get_privatekey($cert);
+            // Pull the private key ID from the certificate
+            $privatekeyid = openssl_get_privatekey($cert);
 
-        // Sign using the key
-        openssl_sign($base_string, $signature, $privatekeyid);
+            // Sign using the key
+            openssl_sign($base_string, $signature, $privatekeyid);
 
-        // Release the key resource
-        openssl_free_key($privatekeyid);
+            // Release the key resource
+            openssl_free_key($privatekeyid);
 
-        return base64_encode($signature);
-    }
+            return base64_encode($signature);
+        }
 
 
-    public function check_signature(OAuthRequest $request, OAuthConsumer $consumer, OAuthToken $token, string $signature) : bool
-    {
-        $decoded_sig = base64_decode($signature);
+        public function check_signature(OAuthRequest $request, OAuthConsumer $consumer, OAuthToken $token, string $signature) : bool
+        {
+            $decoded_sig = base64_decode($signature);
 
-        $base_string = $request->get_signature_base_string();
+            $base_string = $request->get_signature_base_string();
 
-        // Fetch the public key cert based on the request
-        $cert = $this->fetch_public_cert($request);
+            // Fetch the public key cert based on the request
+            $cert = $this->fetch_public_cert($request);
 
-        // Pull the public key ID from the certificate
-        $publickeyid = openssl_get_publickey($cert);
+            // Pull the public key ID from the certificate
+            $publickeyid = openssl_get_publickey($cert);
 
-        // Check the computed signature against the one passed in the query
-        $ok = openssl_verify($base_string, $decoded_sig, $publickeyid);
+            // Check the computed signature against the one passed in the query
+            $ok = openssl_verify($base_string, $decoded_sig, $publickeyid);
 
-        // Release the key resource
-        openssl_free_key($publickeyid);
+            // Release the key resource
+            openssl_free_key($publickeyid);
 
-        return $ok == 1;
+            return $ok == 1;
+        }
     }
 }
-
-class OAuthRequest
-{
-    /** @var array */
-    protected array $parameters;
-
-    /** @var string */
-    protected string $http_method;
-
-    /** @var string */
-    protected string $http_url;
-
-    // for debug purposes
-    /** @var string|null */
-    public ?string $base_string = null;
-
-    /** @var string */
-    public static string $version = '1.0';
-
-    /** @var string */
-    public static string $POST_INPUT = 'php://input';
-
-
-    /**
-     * @param string     $http_method
-     * @param string     $http_url
-     * @param array|null $parameters
-     * @return void
-     */
-    public function __construct(string $http_method, string $http_url, ?array $parameters = null)
+if (!class_exists('OAuthRequest')) {
+    class OAuthRequest
     {
-        $parameters = ($parameters) ? $parameters : [];
-        $parameters = array_merge(OAuthUtil::parse_parameters((string) parse_url($http_url, PHP_URL_QUERY)), $parameters);
-        $this->parameters = $parameters;
-        $this->http_method = $http_method;
-        $this->http_url = $http_url;
-    }
+        /** @var array */
+        protected array $parameters;
 
-    /**
-     * attempt to build up a request from what was passed to the server
-     * @param string|null $http_method
-     * @param string|null $http_url
-     * @param array|null  $parameters
-     * @return OAuthRequest
-     */
-    public static function from_request(?string $http_method = null, ?string $http_url = null, ?array $parameters = null) : OAuthRequest
-    {
-        $scheme = (!isset($_SERVER['HTTPS']) || $_SERVER['HTTPS'] != "on")
+        /** @var string */
+        protected string $http_method;
+
+        /** @var string */
+        protected string $http_url;
+
+        // for debug purposes
+        /** @var string|null */
+        public ?string $base_string = null;
+
+        /** @var string */
+        public static string $version = '1.0';
+
+        /** @var string */
+        public static string $POST_INPUT = 'php://input';
+
+
+        /**
+         * @param string     $http_method
+         * @param string     $http_url
+         * @param array|null $parameters
+         * @return void
+         */
+        public function __construct(string $http_method, string $http_url, ?array $parameters = null)
+        {
+            $parameters = ($parameters) ? $parameters : [];
+            $parameters = array_merge(OAuthUtil::parse_parameters((string) parse_url($http_url, PHP_URL_QUERY)), $parameters);
+            $this->parameters = $parameters;
+            $this->http_method = $http_method;
+            $this->http_url = $http_url;
+        }
+
+        /**
+         * attempt to build up a request from what was passed to the server
+         * @param string|null $http_method
+         * @param string|null $http_url
+         * @param array|null  $parameters
+         * @return OAuthRequest
+         */
+        public static function from_request(?string $http_method = null, ?string $http_url = null, ?array $parameters = null) : OAuthRequest
+        {
+            $scheme = (!isset($_SERVER['HTTPS']) || $_SERVER['HTTPS'] != "on")
             ? 'http'
             : 'https';
 
-        //SPECIAL FOR LTI BEGIN
-        global $UseHttpHostInsteadOfServerName;
-        if ($UseHttpHostInsteadOfServerName == true) {
-            $port = "";
-            if ($_SERVER['SERVER_PORT'] != "80" && $_SERVER['SERVER_PORT'] != "443" &&
+            //SPECIAL FOR LTI BEGIN
+            global $UseHttpHostInsteadOfServerName;
+            if ($UseHttpHostInsteadOfServerName == true) {
+                $port = "";
+                if ($_SERVER['SERVER_PORT'] != "80" && $_SERVER['SERVER_PORT'] != "443" &&
             strpos(':', $_SERVER['HTTP_HOST']) < 0) {
-                $port = ':' . $_SERVER['SERVER_PORT'] ;
-            }
-            $http_url = ($http_url) ? $http_url : $scheme .
+                    $port = ':' . $_SERVER['SERVER_PORT'] ;
+                }
+                $http_url = ($http_url) ? $http_url : $scheme .
                 '://' . $_SERVER['HTTP_HOST'] .
                 $port .
                 $_SERVER['REQUEST_URI'];
-        } else {
-            $http_url = ($http_url) ? $http_url : $scheme .
+            } else {
+                $http_url = ($http_url) ? $http_url : $scheme .
                 '://' . $_SERVER['SERVER_NAME'] .
                 ':' .
                 $_SERVER['SERVER_PORT'] .
                 $_SERVER['REQUEST_URI'];
-        }
-        //SPECIAL FOR LTI END
+            }
+            //SPECIAL FOR LTI END
 
-        $http_method = ($http_method) ? $http_method : $_SERVER['REQUEST_METHOD'];
+            $http_method = ($http_method) ? $http_method : $_SERVER['REQUEST_METHOD'];
 
-        // We weren't handed any parameters, so let's find the ones relevant to
-        // this request.
-        // If you run XML-RPC or similar you should use this to provide your own
-        // parsed parameter-list
-        if (!$parameters) {
-            // Find request headers
-            $request_headers = OAuthUtil::get_headers();
+            // We weren't handed any parameters, so let's find the ones relevant to
+            // this request.
+            // If you run XML-RPC or similar you should use this to provide your own
+            // parsed parameter-list
+            if (!$parameters) {
+                // Find request headers
+                $request_headers = OAuthUtil::get_headers();
 
-            // Parse the query-string to find GET parameters
-            $parameters = OAuthUtil::parse_parameters($_SERVER['QUERY_STRING']);
+                // Parse the query-string to find GET parameters
+                $parameters = OAuthUtil::parse_parameters($_SERVER['QUERY_STRING']);
 
-            // It's a POST request of the proper content-type, so parse POST
-            // parameters and add those overriding any duplicates from GET
-            if ($http_method == "POST"
+                // It's a POST request of the proper content-type, so parse POST
+                // parameters and add those overriding any duplicates from GET
+                if ($http_method == "POST"
                 && isset($request_headers['Content-Type'])
                 && strstr($request_headers['Content-Type'], 'application/x-www-form-urlencoded')
             ) {
-                $post_data = OAuthUtil::parse_parameters(
-                    file_get_contents(self::$POST_INPUT)
-                );
-                $parameters = array_merge($parameters, $post_data);
-            }
+                    $post_data = OAuthUtil::parse_parameters(
+                        file_get_contents(self::$POST_INPUT)
+                    );
+                    $parameters = array_merge($parameters, $post_data);
+                }
 
-            // We have a Authorization-header with OAuth data. Parse the header
-            // and add those overriding any duplicates from GET or POST
-            if (isset($request_headers['Authorization'])
+                // We have a Authorization-header with OAuth data. Parse the header
+                // and add those overriding any duplicates from GET or POST
+                if (isset($request_headers['Authorization'])
                 && substr($request_headers['Authorization'], 0, 6) == 'OAuth '
             ) {
-                $header_parameters = OAuthUtil::split_header(
-                    $request_headers['Authorization']
-                );
-                $parameters = array_merge($parameters, $header_parameters);
+                    $header_parameters = OAuthUtil::split_header(
+                        $request_headers['Authorization']
+                    );
+                    $parameters = array_merge($parameters, $header_parameters);
+                }
             }
+
+            return new OAuthRequest($http_method, $http_url, $parameters);
         }
 
-        return new OAuthRequest($http_method, $http_url, $parameters);
-    }
-
-    /**
-     * pretty much a helper function to set up the request
-     * @param OAuthConsumer   $consumer
-     * @param OAuthToken|null $token
-     * @param string          $http_method
-     * @param string          $http_url
-     * @param array|null      $parameters
-     * @return OAuthRequest
-     */
-    public static function from_consumer_and_token(OAuthConsumer $consumer, ?OAuthToken $token, string $http_method, string $http_url, ?array $parameters = null) : OAuthRequest
-    {
-        $parameters = ($parameters) ? $parameters : [];
-        $defaults = ["oauth_version" => OAuthRequest::$version,
+        /**
+         * pretty much a helper function to set up the request
+         * @param OAuthConsumer   $consumer
+         * @param OAuthToken|null $token
+         * @param string          $http_method
+         * @param string          $http_url
+         * @param array|null      $parameters
+         * @return OAuthRequest
+         */
+        public static function from_consumer_and_token(OAuthConsumer $consumer, ?OAuthToken $token, string $http_method, string $http_url, ?array $parameters = null) : OAuthRequest
+        {
+            $parameters = ($parameters) ? $parameters : [];
+            $defaults = ["oauth_version" => OAuthRequest::$version,
                             "oauth_nonce" => OAuthRequest::generate_nonce(),
                             "oauth_timestamp" => OAuthRequest::generate_timestamp(),
                             "oauth_consumer_key" => $consumer->key];
-        if ($token) {
-            $defaults['oauth_token'] = $token->key;
-        }
-
-        $parameters = array_merge($defaults, $parameters);
-
-        return new OAuthRequest($http_method, $http_url, $parameters);
-    }
-
-
-    public function set_parameter(string $name, string $value, bool $allow_duplicates = true) : void
-    {
-        if ($allow_duplicates && isset($this->parameters[$name])) {
-            // We have already added parameter(s) with this name, so add to the list
-            if (is_scalar($this->parameters[$name])) {
-                // This is the first duplicate, so transform scalar (string)
-                // into an array so we can add the duplicates
-                $this->parameters[$name] = [$this->parameters[$name]];
+            if ($token) {
+                $defaults['oauth_token'] = $token->key;
             }
 
-            $this->parameters[$name][] = $value;
-        } else {
-            $this->parameters[$name] = $value;
-        }
-    }
+            $parameters = array_merge($defaults, $parameters);
 
-
-    /**
-     * @return mixed|null
-     */
-    public function get_parameter(string $name)
-    {
-        return isset($this->parameters[$name]) ? $this->parameters[$name] : null;
-    }
-
-
-    /**
-     * @return array|null
-     */
-    public function get_parameters() : array
-    {
-        return $this->parameters;
-    }
-
-
-    public function unset_parameter(string $name) : void
-    {
-        unset($this->parameters[$name]);
-    }
-
-
-    /**
-     * The request parameters, sorted and concatenated into a normalized string.
-     */
-    public function get_signable_parameters() : string
-    {
-        // Grab all parameters
-        $params = $this->parameters;
-
-        // Remove oauth_signature if present
-        // Ref: Spec: 9.1.1 ("The oauth_signature parameter MUST be excluded.")
-        if (isset($params['oauth_signature'])) {
-            unset($params['oauth_signature']);
+            return new OAuthRequest($http_method, $http_url, $parameters);
         }
 
-        return OAuthUtil::build_http_query($params);
-    }
+
+        public function set_parameter(string $name, string $value, bool $allow_duplicates = true) : void
+        {
+            if ($allow_duplicates && isset($this->parameters[$name])) {
+                // We have already added parameter(s) with this name, so add to the list
+                if (is_scalar($this->parameters[$name])) {
+                    // This is the first duplicate, so transform scalar (string)
+                    // into an array so we can add the duplicates
+                    $this->parameters[$name] = [$this->parameters[$name]];
+                }
+
+                $this->parameters[$name][] = $value;
+            } else {
+                $this->parameters[$name] = $value;
+            }
+        }
 
 
-    /**
-     * Returns the base string of this request
-     *
-     * The base string defined as the method, the url
-     * and the parameters (normalized), each urlencoded
-     * and the concated with &.
-     */
-    public function get_signature_base_string() : string
-    {
-        $parts = [
+        /**
+         * @return mixed|null
+         */
+        public function get_parameter(string $name)
+        {
+            return isset($this->parameters[$name]) ? $this->parameters[$name] : null;
+        }
+
+
+        /**
+         * @return array|null
+         */
+        public function get_parameters() : array
+        {
+            return $this->parameters;
+        }
+
+
+        public function unset_parameter(string $name) : void
+        {
+            unset($this->parameters[$name]);
+        }
+
+
+        /**
+         * The request parameters, sorted and concatenated into a normalized string.
+         */
+        public function get_signable_parameters() : string
+        {
+            // Grab all parameters
+            $params = $this->parameters;
+
+            // Remove oauth_signature if present
+            // Ref: Spec: 9.1.1 ("The oauth_signature parameter MUST be excluded.")
+            if (isset($params['oauth_signature'])) {
+                unset($params['oauth_signature']);
+            }
+
+            return OAuthUtil::build_http_query($params);
+        }
+
+
+        /**
+         * Returns the base string of this request
+         *
+         * The base string defined as the method, the url
+         * and the parameters (normalized), each urlencoded
+         * and the concated with &.
+         */
+        public function get_signature_base_string() : string
+        {
+            $parts = [
             $this->get_normalized_http_method(),
             $this->get_normalized_http_url(),
             $this->get_signable_parameters()
         ];
 
-        /** @var array $parts */
-        $parts = OAuthUtil::urlencode_rfc3986($parts);
+            /** @var array $parts */
+            $parts = OAuthUtil::urlencode_rfc3986($parts);
 
-        return implode('&', $parts);
-    }
-
-
-    /**
-     * just uppercases the http method
-     */
-    public function get_normalized_http_method() : string
-    {
-        return strtoupper($this->http_method);
-    }
+            return implode('&', $parts);
+        }
 
 
-    /**
-     * parses the url and rebuilds it to be
-     * scheme://host/path
-     */
-    public function get_normalized_http_url() : string
-    {
-        $parts = parse_url($this->http_url);
+        /**
+         * just uppercases the http method
+         */
+        public function get_normalized_http_method() : string
+        {
+            return strtoupper($this->http_method);
+        }
 
-        $scheme = (isset($parts['scheme'])) ? $parts['scheme'] : 'http';
-        $port = (isset($parts['port'])) ? $parts['port'] : (($scheme == 'https') ? '443' : '80');
-        $host = (isset($parts['host'])) ? strtolower($parts['host']) : '';
-        $path = (isset($parts['path'])) ? $parts['path'] : '';
 
-        if (($scheme == 'https' && $port != '443')
+        /**
+         * parses the url and rebuilds it to be
+         * scheme://host/path
+         */
+        public function get_normalized_http_url() : string
+        {
+            $parts = parse_url($this->http_url);
+
+            $scheme = (isset($parts['scheme'])) ? $parts['scheme'] : 'http';
+            $port = (isset($parts['port'])) ? $parts['port'] : (($scheme == 'https') ? '443' : '80');
+            $host = (isset($parts['host'])) ? strtolower($parts['host']) : '';
+            $path = (isset($parts['path'])) ? $parts['path'] : '';
+
+            if (($scheme == 'https' && $port != '443')
             || ($scheme == 'http' && $port != '80')) {
-            $host = "$host:$port";
-        }
-        return "$scheme://$host$path";
-    }
-
-
-    /**
-     * builds a url usable for a GET request
-     */
-    public function to_url() : string
-    {
-        $post_data = $this->to_postdata();
-        $out = $this->get_normalized_http_url();
-        if ($post_data) {
-            $out .= '?' . $post_data;
-        }
-        return $out;
-    }
-
-
-    /**
-     * builds the data one would send in a POST request
-     */
-    public function to_postdata() : string
-    {
-        return OAuthUtil::build_http_query($this->parameters);
-    }
-
-    /**
-     * builds the Authorization: header
-     * @param string|null $realm
-     * @return string
-     * @throws OAuthException
-     */
-    public function to_header(?string $realm = null) : string
-    {
-        $first = true;
-        if (!is_null($realm)) {
-            /** @var string $realm */
-            $realm = OAuthUtil::urlencode_rfc3986($realm);
-            $out = 'Authorization: OAuth realm="' . $realm . '"';
-            $first = false;
-        } else {
-            $out = 'Authorization: OAuth';
-        }
-
-        foreach ($this->parameters as $k => $v) {
-            if (substr($k, 0, 5) != "oauth") {
-                continue;
+                $host = "$host:$port";
             }
-            if (is_array($v)) {
-                throw new OAuthException('Arrays not supported in headers');
-            }
-            $out .= ($first) ? ' ' : ',';
-            /** @var string $key */
-            $key = OAuthUtil::urlencode_rfc3986($k);
-            /** @var string $value */
-            $value = OAuthUtil::urlencode_rfc3986($v);
-            $out .= $key . '="' . $value . '"';
-            $first = false;
+            return "$scheme://$host$path";
         }
-        return $out;
-    }
 
 
-    /**
-     * @return string
-     */
-    public function __toString()
-    {
-        return $this->to_url();
-    }
+        /**
+         * builds a url usable for a GET request
+         */
+        public function to_url() : string
+        {
+            $post_data = $this->to_postdata();
+            $out = $this->get_normalized_http_url();
+            if ($post_data) {
+                $out .= '?' . $post_data;
+            }
+            return $out;
+        }
 
 
-    public function sign_request(OAuthSignatureMethod $signature_method, OAuthConsumer $consumer, ?OAuthToken $token) : void
-    {
-        $this->set_parameter(
-            "oauth_signature_method",
-            $signature_method->get_name(),
-            false
-        );
-        $signature = $this->build_signature($signature_method, $consumer, $token);
-        $this->set_parameter("oauth_signature", $signature, false);
-    }
+        /**
+         * builds the data one would send in a POST request
+         */
+        public function to_postdata() : string
+        {
+            return OAuthUtil::build_http_query($this->parameters);
+        }
+
+        /**
+         * builds the Authorization: header
+         * @param string|null $realm
+         * @return string
+         * @throws OAuthException
+         */
+        public function to_header(?string $realm = null) : string
+        {
+            $first = true;
+            if (!is_null($realm)) {
+                /** @var string $realm */
+                $realm = OAuthUtil::urlencode_rfc3986($realm);
+                $out = 'Authorization: OAuth realm="' . $realm . '"';
+                $first = false;
+            } else {
+                $out = 'Authorization: OAuth';
+            }
+
+            foreach ($this->parameters as $k => $v) {
+                if (substr($k, 0, 5) != "oauth") {
+                    continue;
+                }
+                if (is_array($v)) {
+                    throw new OAuthException('Arrays not supported in headers');
+                }
+                $out .= ($first) ? ' ' : ',';
+                /** @var string $key */
+                $key = OAuthUtil::urlencode_rfc3986($k);
+                /** @var string $value */
+                $value = OAuthUtil::urlencode_rfc3986($v);
+                $out .= $key . '="' . $value . '"';
+                $first = false;
+            }
+            return $out;
+        }
 
 
-    public function build_signature(OAuthSignatureMethod $signature_method, OAuthConsumer $consumer, ?OAuthToken $token) : string
-    {
-        $signature = $signature_method->build_signature($this, $consumer, $token);
-        return $signature;
-    }
+        /**
+         * @return string
+         */
+        public function __toString()
+        {
+            return $this->to_url();
+        }
 
 
-    /**
-     * util function: current timestamp
-     */
-    private static function generate_timestamp() : int
-    {
-        return time();
-    }
+        public function sign_request(OAuthSignatureMethod $signature_method, OAuthConsumer $consumer, ?OAuthToken $token) : void
+        {
+            $this->set_parameter(
+                "oauth_signature_method",
+                $signature_method->get_name(),
+                false
+            );
+            $signature = $this->build_signature($signature_method, $consumer, $token);
+            $this->set_parameter("oauth_signature", $signature, false);
+        }
 
 
-    /**
-     * util function: current nonce
-     */
-    private static function generate_nonce() : string
-    {
-        $mt = microtime();
-        $rand = mt_rand();
+        public function build_signature(OAuthSignatureMethod $signature_method, OAuthConsumer $consumer, ?OAuthToken $token) : string
+        {
+            $signature = $signature_method->build_signature($this, $consumer, $token);
+            return $signature;
+        }
 
-        return md5($mt . $rand); // md5s look nicer than numbers
+
+        /**
+         * util function: current timestamp
+         */
+        private static function generate_timestamp() : int
+        {
+            return time();
+        }
+
+
+        /**
+         * util function: current nonce
+         */
+        private static function generate_nonce() : string
+        {
+            $mt = microtime();
+            $rand = mt_rand();
+
+            return md5($mt . $rand); // md5s look nicer than numbers
+        }
     }
 }
-
-class OAuthServer
-{
-    /** @var int */
-    protected int $timestamp_threshold = 300; // in seconds, five minutes
-
-    /** @var string */
-    protected string $version = '1.0'; // hi blaine
-
-    /** @var array */
-    protected array $signature_methods = [];
-
-    /** @var OAuthDataStore */
-    protected OAuthDataStore $data_store;
-
-
-    /**
-     * @param OAuthDataStore $data_store
-     */
-    public function __construct(OAuthDataStore $data_store)
+if (!class_exists('OAuthServer')) {
+    class OAuthServer
     {
-        $this->data_store = $data_store;
-    }
+        /** @var int */
+        protected int $timestamp_threshold = 300; // in seconds, five minutes
+
+        /** @var string */
+        protected string $version = '1.0'; // hi blaine
+
+        /** @var array */
+        protected array $signature_methods = [];
+
+        /** @var OAuthDataStore */
+        protected OAuthDataStore $data_store;
 
 
-    public function add_signature_method(OAuthSignatureMethod $signature_method) : void
-    {
-        $this->signature_methods[$signature_method->get_name()] =
+        /**
+         * @param OAuthDataStore $data_store
+         */
+        public function __construct(OAuthDataStore $data_store)
+        {
+            $this->data_store = $data_store;
+        }
+
+
+        public function add_signature_method(OAuthSignatureMethod $signature_method) : void
+        {
+            $this->signature_methods[$signature_method->get_name()] =
             $signature_method;
-    }
-
-
-    // high level functions
-    /**
-     * process a request_token request
-     * returns the request token on success
-     */
-    public function fetch_request_token(OAuthRequest &$request) : OAuthToken
-    {
-        $this->getVersion($request);
-
-        $consumer = $this->getConsumer($request);
-
-        // no token required for the initial token request
-        $token = null;
-
-        $this->checkSignature($request, $consumer, $token);
-
-        // Rev A change
-        $callback = $request->get_parameter('oauth_callback');
-        $new_token = $this->data_store->new_request_token($consumer, $callback);
-
-        return $new_token;
-    }
-
-
-    /**
-     * process an access_token request
-     * returns the access token on success
-     */
-    public function fetch_access_token(OAuthRequest &$request) : OAuthToken
-    {
-        $this->getVersion($request);
-
-        $consumer = $this->getConsumer($request);
-
-        // requires authorized request token
-        $token = $this->getToken($request, $consumer, "request");
-
-        $this->checkSignature($request, $consumer, $token);
-
-        // Rev A change
-        $verifier = $request->get_parameter('oauth_verifier');
-        $new_token = $this->data_store->new_access_token($token, $consumer, $verifier);
-
-        return $new_token;
-    }
-
-
-    /**
-     * verify an api call, checks all the parameters
-     *
-     * @return OAuthConsumer[]|OAuthToken[]
-     */
-    public function verify_request(OAuthRequest &$request) : array
-    {
-        $this->getVersion($request);
-        $consumer = $this->getConsumer($request);
-        $token = $this->getToken($request, $consumer, "access");
-        $this->checkSignature($request, $consumer, $token);
-        return [$consumer, $token];
-    }
-
-
-    // Internals from here
-    /**
-     * version 1
-     */
-    private function getVersion(OAuthRequest &$request) : string
-    {
-        $version = $request->get_parameter("oauth_version");
-        if (!$version) {
-            // Service Providers MUST assume the protocol version to be 1.0 if this parameter is not present.
-            // Chapter 7.0 ("Accessing Protected Ressources")
-            $version = '1.0';
         }
-        if ($version !== $this->version) {
-            throw new OAuthException("OAuth version '$version' not supported");
+
+
+        // high level functions
+        /**
+         * process a request_token request
+         * returns the request token on success
+         */
+        public function fetch_request_token(OAuthRequest &$request) : OAuthToken
+        {
+            $this->getVersion($request);
+
+            $consumer = $this->getConsumer($request);
+
+            // no token required for the initial token request
+            $token = null;
+
+            $this->checkSignature($request, $consumer, $token);
+
+            // Rev A change
+            $callback = $request->get_parameter('oauth_callback');
+            $new_token = $this->data_store->new_request_token($consumer, $callback);
+
+            return $new_token;
         }
-        return $version;
-    }
 
-    /**
-     * figure out the signature with some defaults
-     * @param OAuthRequest $request
-     * @return string
-     * @throws OAuthException
-     */
-    private function getSignatureMethod(OAuthRequest $request) : string
-    {
-        $signature_method = $request->get_parameter("oauth_signature_method");
 
-        if (!$signature_method) {
-            //Special LTI BEGIN
-            global $DefaultSignatureMethodPlaintext;
-            if ($DefaultSignatureMethodPlaintext == true) {
-                $signature_method = "PLAINTEXT";
-            } else {
-                // According to chapter 7 ("Accessing Protected Ressources") the signature-method
-                // parameter is required, and we can't just fallback to PLAINTEXT
-                throw new OAuthException('No signature method parameter. This parameter is required');
+        /**
+         * process an access_token request
+         * returns the access token on success
+         */
+        public function fetch_access_token(OAuthRequest &$request) : OAuthToken
+        {
+            $this->getVersion($request);
+
+            $consumer = $this->getConsumer($request);
+
+            // requires authorized request token
+            $token = $this->getToken($request, $consumer, "request");
+
+            $this->checkSignature($request, $consumer, $token);
+
+            // Rev A change
+            $verifier = $request->get_parameter('oauth_verifier');
+            $new_token = $this->data_store->new_access_token($token, $consumer, $verifier);
+
+            return $new_token;
+        }
+
+
+        /**
+         * verify an api call, checks all the parameters
+         *
+         * @return OAuthConsumer[]|OAuthToken[]
+         */
+        public function verify_request(OAuthRequest &$request) : array
+        {
+            $this->getVersion($request);
+            $consumer = $this->getConsumer($request);
+            $token = $this->getToken($request, $consumer, "access");
+            $this->checkSignature($request, $consumer, $token);
+            return [$consumer, $token];
+        }
+
+
+        // Internals from here
+        /**
+         * version 1
+         */
+        private function getVersion(OAuthRequest &$request) : string
+        {
+            $version = $request->get_parameter("oauth_version");
+            if (!$version) {
+                // Service Providers MUST assume the protocol version to be 1.0 if this parameter is not present.
+                // Chapter 7.0 ("Accessing Protected Ressources")
+                $version = '1.0';
             }
-            //Special LTI END
+            if ($version !== $this->version) {
+                throw new OAuthException("OAuth version '$version' not supported");
+            }
+            return $version;
         }
 
-        if (!in_array($signature_method, array_keys($this->signature_methods))) {
-            throw new OAuthException(
-                "Signature method '$signature_method' not supported " .
+        /**
+         * figure out the signature with some defaults
+         * @param OAuthRequest $request
+         * @return string
+         * @throws OAuthException
+         */
+        private function getSignatureMethod(OAuthRequest $request) : string
+        {
+            $signature_method = $request->get_parameter("oauth_signature_method");
+
+            if (!$signature_method) {
+                //Special LTI BEGIN
+                global $DefaultSignatureMethodPlaintext;
+                if ($DefaultSignatureMethodPlaintext == true) {
+                    $signature_method = "PLAINTEXT";
+                } else {
+                    // According to chapter 7 ("Accessing Protected Ressources") the signature-method
+                    // parameter is required, and we can't just fallback to PLAINTEXT
+                    throw new OAuthException('No signature method parameter. This parameter is required');
+                }
+                //Special LTI END
+            }
+
+            if (!in_array($signature_method, array_keys($this->signature_methods))) {
+                throw new OAuthException(
+                    "Signature method '$signature_method' not supported " .
                 "try one of the following: " .
                 implode(", ", array_keys($this->signature_methods))
-            );
-        }
-        return $this->signature_methods[$signature_method];
-    }
-
-
-    /**
-     * try to find the consumer for the provided request's consumer key
-     *
-     * @param OAuthRequest $request
-     */
-    private function getConsumer(OAuthRequest $request) : OAuthConsumer
-    {
-        $consumer_key = $request->get_parameter("oauth_consumer_key");
-
-        if (!$consumer_key) {
-            throw new OAuthException("Invalid consumer key");
-        }
-
-        $consumer = $this->data_store->lookup_consumer($consumer_key);
-        if (!$consumer) {
-            throw new OAuthException("Invalid consumer");
-        }
-
-        return $consumer;
-    }
-
-
-    /**
-     * try to find the token for the provided request's token key
-     *
-     * @throws OAuthException
-     */
-    private function getToken(OAuthRequest $request, OAuthConsumer $consumer, string $token_type = "access") : OAuthToken
-    {
-        $token_field = $request->get_parameter('oauth_token');
-
-        if (!empty($token_field)) {
-            $token = $this->data_store->lookup_token($consumer, $token_type, $token_field);
-            if (!$token) {
-                throw new OAuthException('Invalid ' . $token_type . ' token: ' . $token_field);
-            }
-        } else {
-            $token = new OAuthToken('', '');
-        }
-        return $token;
-    }
-
-
-    /**
-     * all-in-one function to check the signature on a request
-     * should guess the signature method appropriately
-     *
-     * @param OAuthRequest $request
-     * @param OAuthConsumer $consumer
-     * @param OAuthToken $token|null
-     * @throws OAuthException
-     */
-    private function checkSignature(OAuthRequest $request, OAuthConsumer $consumer, OAuthToken $token = null) : void
-    {
-        // this should probably be in a different method
-        $timestamp = $request->get_parameter('oauth_timestamp');
-        $nonce = $request->get_parameter('oauth_nonce');
-
-        $this->checkTimestamp($timestamp);
-        $this->checkNonce($consumer, $token, $nonce, $timestamp);
-
-        $signature_method = 'OAuthSignatureMethod_' . $this->getSignatureMethod($request);
-        /** @psalm-suppress InvalidStringClass */
-        $method = new $signature_method;
-
-        $signature = $request->get_parameter('oauth_signature');
-        $valid_sig = $method->checkSignature(
-            $request,
-            $consumer,
-            $token,
-            $signature
-        );
-
-        if (!$valid_sig) {
-            throw new OAuthException("Invalid signature");
-        }
-    }
-
-
-    /**
-     * check that the timestamp is new enough
-     *
-     * @throws OAuthException
-     */
-    private function checkTimestamp(?int $timestamp) : void
-    {
-        if (!$timestamp) {
-            throw new OAuthException(
-                'Missing timestamp parameter. The parameter is required'
-            );
-        }
-
-        // verify that timestamp is recentish
-        $now = time();
-        if (abs($now - $timestamp) > $this->timestamp_threshold) {
-            throw new OAuthException(
-                "Expired timestamp, yours $timestamp, ours $now"
-            );
-        }
-    }
-
-
-    /**
-     * check that the nonce is not repeated
-     *
-     * @throws OAuthException
-     */
-    private function checkNonce(OAuthConsumer $consumer, ?OAuthToken $token, string $nonce, int $timestamp) : void
-    {
-        if (!$nonce) {
-            throw new OAuthException(
-                'Missing nonce parameter. The parameter is required'
-            );
-        }
-
-        // verify that the nonce is uniqueish
-        $found = $this->data_store->lookup_nonce(
-            $consumer,
-            $token,
-            $nonce,
-            $timestamp
-        );
-        if ($found) {
-            throw new OAuthException("Nonce already used: $nonce");
-        }
-    }
-}
-
-abstract class OAuthDataStore
-{
-    abstract public function lookup_consumer(string $consumer_key);
-
-
-    abstract public function lookup_token(OAuthConsumer $consumer, string $token_type, string $token);
-
-
-    abstract public function lookup_nonce(OAuthConsumer $consumer, ?OAuthToken $token, string $nonce, int $timestamp);
-
-
-    /**
-     * @param callable|null $callback
-     */
-    abstract public function new_request_token(OAuthConsumer $consumer, ?string $callback = null);
-
-    /**
-     * @param OAuthToken    $token
-     * @param OAuthConsumer $consumer
-     * @param string|null   $verifier
-     */
-    abstract public function new_access_token(OAuthToken $token, OAuthConsumer $consumer, ?string $verifier = null);
-}
-
-class OAuthUtil
-{
-    /**
-     * @param mixed $input
-     * @return string|array
-     */
-    public static function urlencode_rfc3986($input)
-    {
-        if (is_array($input)) {
-            return array_map(['ILIAS\LTIOAuth\OAuthUtil', 'urlencode_rfc3986'], $input);
-        } elseif (is_scalar($input)) {
-            return str_replace(
-                '+',
-                ' ',
-                str_replace('%7E', '~', rawurlencode(strval($input)))
-            );
-        } else {
-            return '';
-        }
-    }
-
-
-    /**
-     * This decode function isn't taking into consideration the above
-     * modifications to the encoding process. However, this method doesn't
-     * seem to be used anywhere so leaving it as is.
-     */
-    public static function urldecode_rfc3986(string $string) : string
-    {
-        return urldecode($string);
-    }
-
-
-    /**
-     * Utility function for turning the Authorization: header into
-     * parameters, has to do some unescaping
-     * Can filter out any non-oauth parameters if needed (default behaviour)
-     * May 28th, 2010 - method updated to tjerk.meesters for a speed improvement.
-     *                  see http://code.google.com/p/oauth/issues/detail?id=163
-     *
-     * @return array<int|string, string>
-     */
-    public static function split_header(string $header, bool $only_allow_oauth_parameters = true) : array
-    {
-        $params = [];
-        if (preg_match_all(
-            '/(' . ($only_allow_oauth_parameters ? 'oauth_' : '') . '[a-z_-]*)=(:?"([^"]*)"|([^,]*))/',
-            $header,
-            $matches
-        )) {
-            foreach ($matches[1] as $i => $h) {
-                $params[$h] = OAuthUtil::urldecode_rfc3986(empty($matches[3][$i]) ? $matches[4][$i] : $matches[3][$i]);
-            }
-            if (isset($params['realm'])) {
-                unset($params['realm']);
-            }
-        }
-        return $params;
-    }
-
-
-    /**
-     * helper to try to sort out headers for people who aren't running apache
-     *
-     * @return array<string, mixed>
-     */
-    public static function get_headers() : array
-    {
-        if (function_exists('apache_request_headers')) {
-            // we need this to get the actual Authorization: header
-            // because apache tends to tell us it doesn't exist
-            $headers = getallheaders();
-
-            // sanitize the output of apache_request_headers because
-            // we always want the keys to be Cased-Like-This and arh()
-            // returns the headers in the same case as they are in the
-            // request
-            $out = [];
-            foreach ($headers as $key => $value) {
-                $key = str_replace(
-                    " ",
-                    "-",
-                    ucwords(strtolower(str_replace("-", " ", $key)))
                 );
-                $out[$key] = $value;
             }
-        } else {
-            // otherwise we don't have apache and are just going to have to hope
-            // that $_SERVER actually contains what we need
-            $out = [];
-            if (isset($_SERVER['CONTENT_TYPE'])) {
-                $out['Content-Type'] = $_SERVER['CONTENT_TYPE'];
-            }
-            if (isset($_ENV['CONTENT_TYPE'])) {
-                $out['Content-Type'] = $_ENV['CONTENT_TYPE'];
+            return $this->signature_methods[$signature_method];
+        }
+
+
+        /**
+         * try to find the consumer for the provided request's consumer key
+         *
+         * @param OAuthRequest $request
+         */
+        private function getConsumer(OAuthRequest $request) : OAuthConsumer
+        {
+            $consumer_key = $request->get_parameter("oauth_consumer_key");
+
+            if (!$consumer_key) {
+                throw new OAuthException("Invalid consumer key");
             }
 
-            foreach ($_SERVER as $key => $value) {
-                if (substr($key, 0, 5) == "HTTP_") {
-                    // this is chaos, basically it is just there to capitalize the first
-                    // letter of every word that is not an initial HTTP and strip HTTP
-                    // code from przemek
+            $consumer = $this->data_store->lookup_consumer($consumer_key);
+            if (!$consumer) {
+                throw new OAuthException("Invalid consumer");
+            }
+
+            return $consumer;
+        }
+
+
+        /**
+         * try to find the token for the provided request's token key
+         *
+         * @throws OAuthException
+         */
+        private function getToken(OAuthRequest $request, OAuthConsumer $consumer, string $token_type = "access") : OAuthToken
+        {
+            $token_field = $request->get_parameter('oauth_token');
+
+            if (!empty($token_field)) {
+                $token = $this->data_store->lookup_token($consumer, $token_type, $token_field);
+                if (!$token) {
+                    throw new OAuthException('Invalid ' . $token_type . ' token: ' . $token_field);
+                }
+            } else {
+                $token = new OAuthToken('', '');
+            }
+            return $token;
+        }
+
+
+        /**
+         * all-in-one function to check the signature on a request
+         * should guess the signature method appropriately
+         *
+         * @param OAuthRequest $request
+         * @param OAuthConsumer $consumer
+         * @param OAuthToken $token|null
+         * @throws OAuthException
+         */
+        private function checkSignature(OAuthRequest $request, OAuthConsumer $consumer, OAuthToken $token = null) : void
+        {
+            // this should probably be in a different method
+            $timestamp = $request->get_parameter('oauth_timestamp');
+            $nonce = $request->get_parameter('oauth_nonce');
+
+            $this->checkTimestamp($timestamp);
+            $this->checkNonce($consumer, $token, $nonce, $timestamp);
+
+            $signature_method = 'OAuthSignatureMethod_' . $this->getSignatureMethod($request);
+            /** @psalm-suppress InvalidStringClass */
+            $method = new $signature_method;
+
+            $signature = $request->get_parameter('oauth_signature');
+            $valid_sig = $method->checkSignature(
+                $request,
+                $consumer,
+                $token,
+                $signature
+            );
+
+            if (!$valid_sig) {
+                throw new OAuthException("Invalid signature");
+            }
+        }
+
+
+        /**
+         * check that the timestamp is new enough
+         *
+         * @throws OAuthException
+         */
+        private function checkTimestamp(?int $timestamp) : void
+        {
+            if (!$timestamp) {
+                throw new OAuthException(
+                    'Missing timestamp parameter. The parameter is required'
+                );
+            }
+
+            // verify that timestamp is recentish
+            $now = time();
+            if (abs($now - $timestamp) > $this->timestamp_threshold) {
+                throw new OAuthException(
+                    "Expired timestamp, yours $timestamp, ours $now"
+                );
+            }
+        }
+
+
+        /**
+         * check that the nonce is not repeated
+         *
+         * @throws OAuthException
+         */
+        private function checkNonce(OAuthConsumer $consumer, ?OAuthToken $token, string $nonce, int $timestamp) : void
+        {
+            if (!$nonce) {
+                throw new OAuthException(
+                    'Missing nonce parameter. The parameter is required'
+                );
+            }
+
+            // verify that the nonce is uniqueish
+            $found = $this->data_store->lookup_nonce(
+                $consumer,
+                $token,
+                $nonce,
+                $timestamp
+            );
+            if ($found) {
+                throw new OAuthException("Nonce already used: $nonce");
+            }
+        }
+    }
+}
+if (!class_exists('OAuthDataStore')) {
+    abstract class OAuthDataStore
+    {
+        abstract public function lookup_consumer(string $consumer_key);
+
+
+        abstract public function lookup_token(OAuthConsumer $consumer, string $token_type, string $token);
+
+
+        abstract public function lookup_nonce(OAuthConsumer $consumer, ?OAuthToken $token, string $nonce, int $timestamp);
+
+
+        /**
+         * @param callable|null $callback
+         */
+        abstract public function new_request_token(OAuthConsumer $consumer, ?string $callback = null);
+
+        /**
+         * @param OAuthToken    $token
+         * @param OAuthConsumer $consumer
+         * @param string|null   $verifier
+         */
+        abstract public function new_access_token(OAuthToken $token, OAuthConsumer $consumer, ?string $verifier = null);
+    }
+}
+if (!class_exists('OAuthUtil')) {
+    class OAuthUtil
+    {
+        /**
+         * @param mixed $input
+         * @return string|array
+         */
+        public static function urlencode_rfc3986($input)
+        {
+            if (is_array($input)) {
+                return array_map(['ILIAS\LTIOAuth\OAuthUtil', 'urlencode_rfc3986'], $input);
+            } elseif (is_scalar($input)) {
+                return str_replace(
+                    '+',
+                    ' ',
+                    str_replace('%7E', '~', rawurlencode(strval($input)))
+                );
+            } else {
+                return '';
+            }
+        }
+
+
+        /**
+         * This decode function isn't taking into consideration the above
+         * modifications to the encoding process. However, this method doesn't
+         * seem to be used anywhere so leaving it as is.
+         */
+        public static function urldecode_rfc3986(string $string) : string
+        {
+            return urldecode($string);
+        }
+
+
+        /**
+         * Utility function for turning the Authorization: header into
+         * parameters, has to do some unescaping
+         * Can filter out any non-oauth parameters if needed (default behaviour)
+         * May 28th, 2010 - method updated to tjerk.meesters for a speed improvement.
+         *                  see http://code.google.com/p/oauth/issues/detail?id=163
+         *
+         * @return array<int|string, string>
+         */
+        public static function split_header(string $header, bool $only_allow_oauth_parameters = true) : array
+        {
+            $params = [];
+            if (preg_match_all(
+                '/(' . ($only_allow_oauth_parameters ? 'oauth_' : '') . '[a-z_-]*)=(:?"([^"]*)"|([^,]*))/',
+                $header,
+                $matches
+            )) {
+                foreach ($matches[1] as $i => $h) {
+                    $params[$h] = OAuthUtil::urldecode_rfc3986(empty($matches[3][$i]) ? $matches[4][$i] : $matches[3][$i]);
+                }
+                if (isset($params['realm'])) {
+                    unset($params['realm']);
+                }
+            }
+            return $params;
+        }
+
+
+        /**
+         * helper to try to sort out headers for people who aren't running apache
+         *
+         * @return array<string, mixed>
+         */
+        public static function get_headers() : array
+        {
+            if (function_exists('apache_request_headers')) {
+                // we need this to get the actual Authorization: header
+                // because apache tends to tell us it doesn't exist
+                $headers = getallheaders();
+
+                // sanitize the output of apache_request_headers because
+                // we always want the keys to be Cased-Like-This and arh()
+                // returns the headers in the same case as they are in the
+                // request
+                $out = [];
+                foreach ($headers as $key => $value) {
                     $key = str_replace(
                         " ",
                         "-",
-                        ucwords(strtolower(str_replace("_", " ", substr($key, 5))))
+                        ucwords(strtolower(str_replace("-", " ", $key)))
                     );
                     $out[$key] = $value;
                 }
-            }
-            // The "Authorization" header may get turned into "Auth".
-            if (isset($out['Auth'])) {
-                $out['Authorization'] = $out['Auth'];
-            }
-        }
-        return $out;
-    }
-
-
-    /**
-     * This function takes a input like a=b&a=c&d=e and returns the parsed
-     * parameters like this
-     * array('a' => array('b','c'), 'd' => 'e')
-     *
-     * @return mixed[]
-     */
-    public static function parse_parameters(string $input) : array
-    {
-        if (!strlen($input)) {
-            return [];
-        }
-
-        $pairs = explode('&', $input);
-
-        $parsed_parameters = [];
-        foreach ($pairs as $pair) {
-            $split = explode('=', $pair, 2);
-            $parameter = OAuthUtil::urldecode_rfc3986($split[0]);
-            $value = isset($split[1]) ? OAuthUtil::urldecode_rfc3986($split[1]) : '';
-
-            if (isset($parsed_parameters[$parameter])) {
-                // We have already recieved parameter(s) with this name, so add to the list
-                // of parameters with this name
-
-                if (is_scalar($parsed_parameters[$parameter])) {
-                    // This is the first duplicate, so transform scalar (string) into an array
-                    // so we can add the duplicates
-                    $parsed_parameters[$parameter] = [$parsed_parameters[$parameter]];
+            } else {
+                // otherwise we don't have apache and are just going to have to hope
+                // that $_SERVER actually contains what we need
+                $out = [];
+                if (isset($_SERVER['CONTENT_TYPE'])) {
+                    $out['Content-Type'] = $_SERVER['CONTENT_TYPE'];
+                }
+                if (isset($_ENV['CONTENT_TYPE'])) {
+                    $out['Content-Type'] = $_ENV['CONTENT_TYPE'];
                 }
 
-                $parsed_parameters[$parameter][] = $value;
-            } else {
-                $parsed_parameters[$parameter] = $value;
-            }
-        }
-        return $parsed_parameters;
-    }
-
-
-    /**
-     * @param mixed[] $params
-     */
-    public static function build_http_query(array $params) : string
-    {
-        if (!$params) {
-            return '';
-        }
-
-        // Urlencode both keys and values
-        /** @var array $keys */
-        $keys = OAuthUtil::urlencode_rfc3986(array_keys($params));
-        /** @var array $values */
-        $values = OAuthUtil::urlencode_rfc3986(array_values($params));
-        $params = array_combine($keys, $values);
-
-        // Parameters are sorted by name, using lexicographical byte value ordering.
-        // Ref: Spec: 9.1.1 (1)
-        uksort($params, 'strcmp');
-
-        $pairs = [];
-        foreach ($params as $parameter => $value) {
-            if (is_array($value)) {
-                // If two or more parameters share the same name, they are sorted by their value
-                // Ref: Spec: 9.1.1 (1)
-                // June 12th, 2010 - changed to sort because of issue 164 by hidetaka
-                sort($value, SORT_STRING);
-                foreach ($value as $duplicate_value) {
-                    $pairs[] = $parameter . '=' . $duplicate_value;
+                foreach ($_SERVER as $key => $value) {
+                    if (substr($key, 0, 5) == "HTTP_") {
+                        // this is chaos, basically it is just there to capitalize the first
+                        // letter of every word that is not an initial HTTP and strip HTTP
+                        // code from przemek
+                        $key = str_replace(
+                            " ",
+                            "-",
+                            ucwords(strtolower(str_replace("_", " ", substr($key, 5))))
+                        );
+                        $out[$key] = $value;
+                    }
                 }
-            } else {
-                $pairs[] = $parameter . '=' . $value;
+                // The "Authorization" header may get turned into "Auth".
+                if (isset($out['Auth'])) {
+                    $out['Authorization'] = $out['Auth'];
+                }
             }
+            return $out;
         }
-        // For each parameter, the name is separated from the corresponding value by an '=' character (ASCII code 61)
-        // Each name-value pair is separated by an '&' character (ASCII code 38)
-        return implode('&', $pairs);
+
+
+        /**
+         * This function takes a input like a=b&a=c&d=e and returns the parsed
+         * parameters like this
+         * array('a' => array('b','c'), 'd' => 'e')
+         *
+         * @return mixed[]
+         */
+        public static function parse_parameters(string $input) : array
+        {
+            if (!strlen($input)) {
+                return [];
+            }
+
+            $pairs = explode('&', $input);
+
+            $parsed_parameters = [];
+            foreach ($pairs as $pair) {
+                $split = explode('=', $pair, 2);
+                $parameter = OAuthUtil::urldecode_rfc3986($split[0]);
+                $value = isset($split[1]) ? OAuthUtil::urldecode_rfc3986($split[1]) : '';
+
+                if (isset($parsed_parameters[$parameter])) {
+                    // We have already recieved parameter(s) with this name, so add to the list
+                    // of parameters with this name
+
+                    if (is_scalar($parsed_parameters[$parameter])) {
+                        // This is the first duplicate, so transform scalar (string) into an array
+                        // so we can add the duplicates
+                        $parsed_parameters[$parameter] = [$parsed_parameters[$parameter]];
+                    }
+
+                    $parsed_parameters[$parameter][] = $value;
+                } else {
+                    $parsed_parameters[$parameter] = $value;
+                }
+            }
+            return $parsed_parameters;
+        }
+
+
+        /**
+         * @param mixed[] $params
+         */
+        public static function build_http_query(array $params) : string
+        {
+            if (!$params) {
+                return '';
+            }
+
+            // Urlencode both keys and values
+            /** @var array $keys */
+            $keys = OAuthUtil::urlencode_rfc3986(array_keys($params));
+            /** @var array $values */
+            $values = OAuthUtil::urlencode_rfc3986(array_values($params));
+            $params = array_combine($keys, $values);
+
+            // Parameters are sorted by name, using lexicographical byte value ordering.
+            // Ref: Spec: 9.1.1 (1)
+            uksort($params, 'strcmp');
+
+            $pairs = [];
+            foreach ($params as $parameter => $value) {
+                if (is_array($value)) {
+                    // If two or more parameters share the same name, they are sorted by their value
+                    // Ref: Spec: 9.1.1 (1)
+                    // June 12th, 2010 - changed to sort because of issue 164 by hidetaka
+                    sort($value, SORT_STRING);
+                    foreach ($value as $duplicate_value) {
+                        $pairs[] = $parameter . '=' . $duplicate_value;
+                    }
+                } else {
+                    $pairs[] = $parameter . '=' . $value;
+                }
+            }
+            // For each parameter, the name is separated from the corresponding value by an '=' character (ASCII code 61)
+            // Each name-value pair is separated by an '&' character (ASCII code 38)
+            return implode('&', $pairs);
+        }
     }
 }

--- a/Modules/LTIConsumer/src/OAuth.php
+++ b/Modules/LTIConsumer/src/OAuth.php
@@ -293,6 +293,7 @@ if (!class_exists('OAuthSignatureMethod_RSA_SHA1')) {
             openssl_sign($base_string, $signature, $privatekeyid);
 
             // Release the key resource
+            // TODO PHP8 Review: openssl_free_key is deprecated
             openssl_free_key($privatekeyid);
 
             return base64_encode($signature);
@@ -315,6 +316,7 @@ if (!class_exists('OAuthSignatureMethod_RSA_SHA1')) {
             $ok = openssl_verify($base_string, $decoded_sig, $publickeyid);
 
             // Release the key resource
+            // TODO PHP8 Review: openssl_free_key is deprecated
             openssl_free_key($publickeyid);
 
             return $ok == 1;
@@ -479,6 +481,7 @@ if (!class_exists('OAuthRequest')) {
         /**
          * @return mixed|null
          */
+        // TODO PHP8 Review: Missing Return type Declaration
         public function get_parameter(string $name)
         {
             return isset($this->parameters[$name]) ? $this->parameters[$name] : null;
@@ -984,6 +987,8 @@ if (!class_exists('OAuthUtil')) {
          * @param mixed $input
          * @return string|array
          */
+        // TODO PHP8 Review: Missing Return type Declaration
+        // TODO PHP8 Review: Missing Parameter Type Declaration
         public static function urlencode_rfc3986($input)
         {
             if (is_array($input)) {

--- a/Modules/LTIConsumer/src/TrivialOAuthDataStore.php
+++ b/Modules/LTIConsumer/src/TrivialOAuthDataStore.php
@@ -15,12 +15,10 @@ class TrivialOAuthDataStore extends OAuthDataStore
     public function lookup_consumer($consumer_key) : ?\OAuthConsumer
     {
         if (strpos($consumer_key, "http://") === 0) {
-            $consumer = new OAuthConsumer($consumer_key, "secret", null);
-            return $consumer;
+            return new OAuthConsumer($consumer_key, "secret", null);
         }
         if ($this->consumers[$consumer_key]) {
-            $consumer = new OAuthConsumer($consumer_key, $this->consumers[$consumer_key], null);
-            return $consumer;
+            return new OAuthConsumer($consumer_key, $this->consumers[$consumer_key], null);
         }
         return null;
     }

--- a/Modules/LTIConsumer/test/ilModulesLTIConsumerSuite.php
+++ b/Modules/LTIConsumer/test/ilModulesLTIConsumerSuite.php
@@ -14,7 +14,6 @@ require_once __DIR__ . '/bootstrap.php';
 class ilModulesLTIConsumerSuite extends TestSuite
 {
     /**
-     * @return self
      * @throws ReflectionException
      */
     public static function suite() : self


### PR DESCRIPTION
Hello @Uwe-Kohnle, 

I completed the review of the `Modules/LtiConsumer` component. I tried to pack things in separate commits.

Results:

- [x] The code style is `PSR-2 + X` compliant
- [ ] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`: I marked them with `TODO PHP8 Review: Remove/Replace SuperGlobals` comments
- [x] There is a `Unit Test Suite` with at least one unit test
- [x] The unit tests pass
- [x] External libraries are compatible with PHP 8 (if relevant): seems to be compatible, but this wrapper here looks quite strange: `Modules/LTIConsumer/src/OAuth.php`
- [ ] There are no serious `PhpStorm Code Inspection` issues left: Have a look at the comments in PR
- [ ] The types are fully documented (PhpDoc) or explict PHP types are used (type hints, return types, typed properties): Have a look at the comments in PR

--

Actions needed:
- [ ] Please check my inline comments. Some of them are just information, some require an action. You can use `TODO PHP8 Review` when searching. 
- [ ] Several analytic tools failed with `Modules/LTIConsumer/src/OAuth.php`, I needed some more `if(!class_exists...`. What is this file all about?
- [ ] There is another "endpoint" which could be of some interest `Modules/LTIConsumer/result.php` concerning security, additionally with the cloned Initialisation
- [ ] The file `Modules/LTIConsumer/classes/class.ilLTIConsumerDataService.php` contains more than one class!

Best regards,
@chfsx