### PR TITLE
Fix 0031516: Profile Picture Broken

### DIFF
--- a/Services/User/classes/class.ilUserAvatarResolver.php
+++ b/Services/User/classes/class.ilUserAvatarResolver.php
@@ -78,9 +78,6 @@ class ilUserAvatarResolver
 
     private function init() : void
     {
-        if ($this->letter_avatars_activated === false) {
-            return;
-        }
         $in = $this->db->in('usr_pref.keyword', array('public_upload', 'public_profile'), false, 'text');
         $res = $this->db->queryF(
             "


### PR DESCRIPTION
This fixes https://mantis.ilias.de/view.php?id=31516

Removed a return statement in ilUserAvatarresolver::init() 
when "Letter Avatare" is deactivated