### PR TITLE
Updating Execution of PHPUnit

### DIFF
--- a/CI/PHPUnit/phpunit.xml
+++ b/CI/PHPUnit/phpunit.xml
@@ -9,6 +9,8 @@
          beStrictAboutTestsThatDoNotTestAnything="true"
          failOnRisky="true"
          failOnWarning="true"
+         backupGlobals="true"
+         executionOrder="random"
         >
     <testsuites>
         <testsuite name="unit">

--- a/CI/PHPUnit/run_tests.sh
+++ b/CI/PHPUnit/run_tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./libs/composer/vendor/phpunit/phpunit/phpunit -c ./CI/PHPUnit/phpunit.xml --order-by random $@
+./libs/composer/vendor/phpunit/phpunit/phpunit -c ./CI/PHPUnit/phpunit.xml $@


### PR DESCRIPTION
While trying to fix the failing unit-tests we were once more forced to acknowledge the fundamental fragility of the current unittest-infrastructure. There are tests relying on a certain state of the system as a whole. To mitigate these risks the TB decided to change the execution order of the tests to random and to backup and restore globals for each test.
Thus with this PR we:
Added backupGlobals='true'
Moved executionOrder='random' from command-line to config.