### PR TITLE
Adding folders and files needed for Eclipse

### DIFF
--- a/tests/App/RootFolderTest.php
+++ b/tests/App/RootFolderTest.php
@@ -49,7 +49,9 @@ final class RootFolderTest extends TestCase
         'studip_referrer.php',
         'unzip_test_file.zip',
         'webdav.php',
-        '.DS_Store'
+        '.DS_Store',
+        '.buildpath',
+        '.project'
     ];
     
     private const ALLOWED_ROOT_FOLDER_DIRS = [
@@ -77,6 +79,7 @@ final class RootFolderTest extends TestCase
         'tests',
         'webservice',
         'xml',
+        '.settings'
     ];
 
     private function getAppRootFolderOrFail() : string


### PR DESCRIPTION
This is me kindly asking if we could also allow two files and a folder to let ILIAS be a happily tested and fully compliant member in an Eclipse Workspace. They are already part of .gitignore.