### PR TITLE
XmlHandling: Reset global error handling state

### DIFF
--- a/Modules/CmiXapi/classes/class.ilCmiXapiImporter.php
+++ b/Modules/CmiXapi/classes/class.ilCmiXapiImporter.php
@@ -179,8 +179,9 @@ class ilCmiXapiImporter extends ilXmlImporter
         $xmlRoot = null;
         $xml = $DIC->filesystem()->temp()->readStream($this->_relImportDir . '/properties.xml');
         if ($xml != false) {
-            libxml_use_internal_errors(true);
+            $use_internal_errors = libxml_use_internal_errors(true);
             $xmlRoot = simplexml_load_string((string) $xml);
+            libxml_use_internal_errors($use_internal_errors);
         }
         foreach ($this->_dataset->_cmixSettingsProperties as $key => $property) {
             $this->_moduleProperties[$key] = trim($xmlRoot->$key->__toString());

--- a/Modules/Course/classes/Objectives/class.ilLOXmlParser.php
+++ b/Modules/Course/classes/Objectives/class.ilLOXmlParser.php
@@ -57,8 +57,9 @@ class ilLOXmlParser
 
     public function parse() : void
     {
-        libxml_use_internal_errors(true);
+        $use_internal_errors = libxml_use_internal_errors(true);
         $root = simplexml_load_string(trim($this->xml));
+        libxml_use_internal_errors($use_internal_errors);
         if (!$root instanceof SimpleXMLElement) {
             $this->logger->debug('XML is: ' . $this->xml . $root);
             $this->logger->debug('Error parsing objective xml: ' . $this->parseXmlErrors());
@@ -74,8 +75,9 @@ class ilLOXmlParser
      */
     public function parseObjectDependencies() : void
     {
-        libxml_use_internal_errors(true);
+        $use_internal_errors = libxml_use_internal_errors(true);
         $root = simplexml_load_string(trim($this->xml));
+        libxml_use_internal_errors($use_internal_errors);
         if (!$root instanceof SimpleXMLElement) {
             $this->logger->debug('XML is: ' . $this->xml . $root);
             $this->logger->debug('Error parsing objective xml: ' . $this->parseXmlErrors());

--- a/Services/AccessControl/classes/class.ilRoleXmlImporter.php
+++ b/Services/AccessControl/classes/class.ilRoleXmlImporter.php
@@ -78,9 +78,9 @@ class ilRoleXmlImporter
      */
     public function import() : void
     {
-        libxml_use_internal_errors(true);
-
+        $use_internal_errors = libxml_use_internal_errors(true);
         $root = simplexml_load_string($this->getXml());
+        libxml_use_internal_errors($use_internal_errors);
 
         if (!$root instanceof SimpleXMLElement) {
             throw new ilRoleImporterException($this->parseXmlErrors());

--- a/Services/COPage/classes/class.ilPCParagraph.php
+++ b/Services/COPage/classes/class.ilPCParagraph.php
@@ -668,9 +668,9 @@ class ilPCParagraph extends ilPageContent
 
     protected static function isValidTagContent(string $content) : bool
     {
-        libxml_use_internal_errors(true);
+        $use_internal_errors = libxml_use_internal_errors(true);
         $sxe = simplexml_load_string("<?xml version='1.0'?><dummy>" . $content . "</dummy>");
-        libxml_use_internal_errors(false);
+        libxml_use_internal_errors($use_internal_errors);
         return ($sxe !== false);
     }
 

--- a/Services/COPage/test/PCParagraphTest.php
+++ b/Services/COPage/test/PCParagraphTest.php
@@ -76,9 +76,9 @@ class PCParagraphTest extends TestCase
 
         foreach ($cases as $case) {
             $text = ilPCParagraph::_input2xml($case, "en", true, false);
-            libxml_use_internal_errors(true);
+            $use_internal_errors = libxml_use_internal_errors(true);
             $sxe = simplexml_load_string("<?xml version='1.0'?><dummy>" . $text . "</dummy>");
-            libxml_use_internal_errors(false);
+            libxml_use_internal_errors($use_internal_errors);
             $res = true;
             if ($sxe === false) {
                 $res = $text;

--- a/Services/Container/Export/class.ilContainerImporter.php
+++ b/Services/Container/Export/class.ilContainerImporter.php
@@ -91,8 +91,9 @@ class ilContainerImporter extends ilXmlImporter
 
     protected function handleOfflineStatus(string $xml, ilImportMapping $mapping) : void
     {
-        libxml_use_internal_errors(true);
+        $use_internal_errors = libxml_use_internal_errors(true);
         $root = simplexml_load_string($xml);
+        libxml_use_internal_errors($use_internal_errors);
         if ($root === false) {
             $errors = '';
             foreach (libxml_get_errors() as $err) {

--- a/Services/DidacticTemplate/classes/class.ilDidacticTemplateImport.php
+++ b/Services/DidacticTemplate/classes/class.ilDidacticTemplateImport.php
@@ -48,12 +48,13 @@ class ilDidacticTemplateImport
     public function import(int $a_dtpl_id = 0) : ilDidacticTemplateSetting
     {
         $root = null;
-        libxml_use_internal_errors(true);
+        $use_internal_errors = libxml_use_internal_errors(true);
         switch ($this->getInputType()) {
             case self::IMPORT_FILE:
                 $root = simplexml_load_file($this->getInputFile());
                 break;
         }
+        libxml_use_internal_errors($use_internal_errors);
         if (!$root instanceof SimpleXMLElement) {
             throw new ilDidacticTemplateImportException(
                 $this->parseXmlErrors()


### PR DESCRIPTION
This PR resets the global XML error handling state after it has been modified by different ILIAS components.