### PR TITLE
remove Union Types for php 7.4 compat

### DIFF
--- a/Services/LTI/classes/InternalProvider/class.ilAuthProviderLTI.php
+++ b/Services/LTI/classes/InternalProvider/class.ilAuthProviderLTI.php
@@ -43,7 +43,7 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
      * @return int|string auth_mode
      */
     // TODO PHP8 Review: Union Types are not supported by PHP 7.4! int|string
-    public static function getKeyByAuthMode(string $a_auth_mode) : int|string
+    public static function getKeyByAuthMode(string $a_auth_mode)
     {
         $auth_arr = explode('_', $a_auth_mode);
         if (count($auth_arr) > 1) {

--- a/Services/LTI/src/HTTPMessage.php
+++ b/Services/LTI/src/HTTPMessage.php
@@ -35,7 +35,7 @@ class HTTPMessage
      * @var bool|string|string[] $requestHeaders
      */
     // TODO PHP8 Review: Union Types are not supported by PHP 7.4!
-    public string|array|bool $requestHeaders = '';
+    public $requestHeaders = '';
 
     /**
      * Response body.

--- a/Services/LTI/src/ToolProvider/ConsumerNonce.php
+++ b/Services/LTI/src/ToolProvider/ConsumerNonce.php
@@ -29,7 +29,7 @@ class ConsumerNonce
      * @var int|null $expires
      */
     // TODO PHP8 Review: Union Types are not supported by PHP 7.4!
-    public int|null $expires = null;
+    public $expires = null;
 
     /**
          * Tool Consumer to which this nonce applies.

--- a/Services/LTI/src/ToolProvider/ResourceLink.php
+++ b/Services/LTI/src/ToolProvider/ResourceLink.php
@@ -613,7 +613,7 @@ EOF;
      * @return array|bool Array of User objects or False if the request was not successful
      */
     // TODO PHP8 Review: Union Types are not supported by PHP 7.4!
-    public function doMembershipsService(bool $withGroups = false) : bool|array
+    public function doMembershipsService(bool $withGroups = false)
     {
         $users = array();
         $oldUsers = $this->getUserResultSourcedIDs(true, ToolProvider::ID_SCOPE_RESOURCE);

--- a/Services/LTI/src/ToolProvider/Service/Membership.php
+++ b/Services/LTI/src/ToolProvider/Service/Membership.php
@@ -20,7 +20,7 @@ class Membership extends Service
      * @var ToolProvider\Context|ToolProvider\ResourceLink $source
      */
     // TODO PHP8 Review: Union Types are not supported by PHP 7.4!
-    private ToolProvider\Context|ToolProvider\ResourceLink $source;
+    private $source;
 
     /**
      * Class constructor.

--- a/Services/LTI/src/ToolProvider/ToolProvider.php
+++ b/Services/LTI/src/ToolProvider/ToolProvider.php
@@ -261,14 +261,14 @@ class ToolProvider
      * @var string|string[]|null $mediaTypes
      */
     // TODO PHP8 Review: Union Types are not supported by PHP 7.4!
-    protected string|array|null $mediaTypes = null;
+    protected $mediaTypes = null;
     /**
      * URL to redirect user to on successful completion of the request.
      *
      * @var string|string[]|null $documentTargets
      */
     // TODO PHP8 Review: Union Types are not supported by PHP 7.4!
-    protected string|array|null $documentTargets = null;
+    protected $documentTargets = null;
     /**
      * HTML to be displayed on a successful completion of the request.
      *


### PR DESCRIPTION
Hi Uwe,

hier ein schneller Fix für die Union Types die nicht in php7.4 unterstützt werden. Führt im Moment zu einem Bug in der Auth Administration. Da ich mir nicht sicher bin, ob es da für php7.4 einen anderen Workaround gibt habe ich die Review-Kommentare nochmal drin gelassen, werden das später noch mit den anderen ToDos aufräumen. 

LG,
Stefan