### PR TITLE
Composer: Add phpstan as development dependency

### DIFF
--- a/CI/PHPStan/constants.php
+++ b/CI/PHPStan/constants.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+/**
+ * This file contains constants for PHPStan analyis, see: https://phpstan.org/config-reference#constants
+ */
+
+// User an role specific constants
+const SYSTEM_USER_ID = 6;
+const ANONYMOUS_USER_ID = 13;
+const ANONYMOUS_ROLE_ID = 2;
+const SYSTEM_ROLE_ID = 14;
+
+// Folder specific constants
+const ROOT_FOLDER_ID = 1;
+const USER_FOLDER_ID = 7;
+const ROLE_FOLDER_ID = 8;
+const SYSTEM_FOLDER_ID = 9;
+const MAIL_SETTINGS_ID = 12;
+const RECOVERY_FOLDER_ID = 15;
+
+// Installation and environment specific constants
+const IL_INST_ID = '0';
+const CLIENT_ID = 'phpstan';
+const CLIENT_NAME = 'PHPStan';
+const ABSOLUTE_PATH = '/';
+const ILIAS_DATA_DIR = './external_data';
+const ILIAS_WEB_DIR = './data';
+const CLIENT_DATA_DIR = './external_data';
+const CLIENT_WEB_DIR = './data';
+
+// Mail system specific constants
+const MAILPATH = 'mail';

--- a/CI/PHPStan/phpstan.neon
+++ b/CI/PHPStan/phpstan.neon
@@ -1,0 +1,27 @@
+parameters:
+    level: 6
+    bootstrapFiles:
+        - constants.php
+    excludePaths:
+        - '%currentWorkingDirectory%/vendor/*'
+        - '%currentWorkingDirectory%/Customizing/*'
+        - '%currentWorkingDirectory%/CI/*'
+        - '%currentWorkingDirectory%/data/*'
+        - '%currentWorkingDirectory%/dicto/*'
+        - '%currentWorkingDirectory%/docs/*'
+        - '%currentWorkingDirectory%/lang/*'
+        - '%currentWorkingDirectory%/node_modules/*'
+        - '%currentWorkingDirectory%/templates/*'
+        - '%currentWorkingDirectory%/xml/*'
+        - '%currentWorkingDirectory%/.github/*'
+    earlyTerminatingMethodCalls:
+        ilCtrl:
+            - redirect
+            - redirectByClass
+            - redirectToURL
+        ilCtrlInterface:
+            - redirect
+            - redirectByClass
+            - redirectToURL
+        ILIAS\HTTP\RawHTTPServices:
+            - close

--- a/CI/PHPStan/run_check.sh
+++ b/CI/PHPStan/run_check.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./libs/composer/vendor/bin/phpstan analyse -c ./CI/PHPStan/phpstan.neon $@

--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,8 @@
 		"friendsofphp/php-cs-fixer": "^3.5",
 		"sebastian/environment": "^5.0",
 		"captainhook/captainhook": "^5.3",
-		"rector/rector": "^0.12.12"
+		"rector/rector": "^0.12.12",
+		"phpstan/phpstan": "^1.6"
 	},
 	"autoload": {
 		"psr-4" : {
@@ -424,6 +425,16 @@
 			"last_update": "2019-07-11",
 			"last_update_by": "Guido Vollbach <gvollbach@databaay.de",
 			"approved-by": "Jour Fixe",
+			"approved-date": "YYYY-MM-DD"
+		},
+		"phpstan/phpstan": {
+			"source": "https://github.com/phpstan/phpstanr",
+			"used_version": "1.6",
+			"added_by": "Michael Jansen <mjansen@databay.de>",
+			"wrapped_by": null,
+			"last_update": "2022-05-02",
+			"last_update_by": "",
+			"approved-by": "",
 			"approved-date": "YYYY-MM-DD"
 		},
 		"symfony/console": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a2cde8a45ad36f475ee33204a79f4010",
+    "content-hash": "dd8c22327224c6621a6c1482f3ce9022",
     "packages": [
         {
             "name": "cweagans/composer-patches",
@@ -8318,20 +8318,20 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.3.3",
+            "version": "1.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "151a51f6149855785fbd883e79768c0abc96b75f"
+                "reference": "6128620b98292e0b69ea6d799871d77163681c8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/151a51f6149855785fbd883e79768c0abc96b75f",
-                "reference": "151a51f6149855785fbd883e79768c0abc96b75f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/6128620b98292e0b69ea6d799871d77163681c8e",
+                "reference": "6128620b98292e0b69ea6d799871d77163681c8e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1|^8.0"
+                "php": "^7.2|^8.0"
             },
             "conflict": {
                 "phpstan/phpstan-shim": "*"
@@ -8341,11 +8341,6 @@
                 "phpstan.phar"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
             "autoload": {
                 "files": [
                     "bootstrap.php"
@@ -8358,9 +8353,27 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.3.3"
+                "source": "https://github.com/phpstan/phpstan/tree/1.6.3"
             },
-            "time": "2022-01-07T09:49:03+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpstan",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-04-28T11:27:53+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -10020,5 +10033,5 @@
         "ext-xml": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/docs/development/static_code_analysis.md
+++ b/docs/development/static_code_analysis.md
@@ -1,0 +1,43 @@
+# Static Code Analysis
+
+## PHPStan
+
+ILIAS uses [`PHPStan`](https://phpstan.org) as an optional tool for developers
+to find errors in the ILIAS code base without actually running it.
+
+### Configuration
+
+To provide a common configuration a shared config file is located in
+[`./CI/PHPStan/phpstan.neon`](../../CI/PHPStan/phpstan.neon).
+
+`PHPStan` provides the possibility to analyse the code based on specfic
+[rule levels](https://phpstan.org/user-guide/rule-levels).
+The level used in ILIAS is **level 6**, which includes the reporting of missing typehints.
+To prevent `False Positives` beingt reported related to global constants, developers can extend the constant collection
+defined in the [`constants.php`](../../CI/PHPStan/constants.php)
+
+### Analysis
+
+To run `PHPStan` you just need to execute the bash script:
+
+```bash
+./CI/PHPStan/run_check.sh
+```
+
+To run `PHPStan` in the context of a specific component, pass the respective folder name as argument:
+
+```bash
+./CI/PHPStan/run_check.sh Services/Mail
+```
+
+You can overwrite the rule level by passing a `--level` argument:
+
+```bash
+./CI/PHPStan/run_check.sh Services/Mail --level 3
+```
+
+### IDE Integration
+
+#### PHPStorm
+
+See: https://www.jetbrains.com/help/phpstorm/using-phpstan.html


### PR DESCRIPTION
This PR suggest to add `PHPStan` as explicit `Composer` development dependency.