### PR TITLE
unified dashboard visibilities with common repository visibilities

### DIFF
--- a/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemsBlockMembershipsProvider.php
+++ b/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemsBlockMembershipsProvider.php
@@ -63,8 +63,7 @@ class ilPDSelectedItemsBlockMembershipsProvider implements ilPDSelectedItemsBloc
             $parentTreeLftValue = $item->getParentLftTree();
             $parentTreeLftValue = sprintf("%010d", $parentTreeLftValue);
 
-            if (!$this->access->checkAccess('read', '', $refId) &&
-                !$this->access->checkAccess('visible', '', $refId)) {
+            if (!$this->access->checkAccess('visible', '', $refId)) {
                 continue;
             }
 

--- a/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemsBlockSelectedItemsProvider.php
+++ b/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemsBlockSelectedItemsProvider.php
@@ -46,7 +46,7 @@ class ilPDSelectedItemsBlockSelectedItemsProvider implements ilPDSelectedItemsBl
         );
         $access_granted_favourites = [];
         foreach ($favourites as $idx => $favourite) {
-            if (!$this->access->checkAccess('read', '', $favourite['ref_id'])) {
+            if (!$this->access->checkAccess('visible', '', $favourite['ref_id'])) {
                 continue;
             }
             $access_granted_favourites[$idx] = $favourite;

--- a/Services/Repository/RecommendedContent/classes/class.ilDashboardRecommendedContentGUI.php
+++ b/Services/Repository/RecommendedContent/classes/class.ilDashboardRecommendedContentGUI.php
@@ -123,6 +123,9 @@ class ilDashboardRecommendedContentGUI
 
         foreach ($this->recommendations as $ref_id) {
             try {
+                if (!$DIC->access()->checkAccess('visible', '', $ref_id)) {
+                    continue;
+                }
                 $list_items[] = $this->getListItemForData($ref_id);
             } catch (ilException $e) {
                 continue;


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=32312

This PR unifies the visibility of repository items on the dashboard to be similar to the apperance inside of the repository.
This does not effect the scopes (Favourites, Groups and Courses, Recommendet Content) itself, only the content so this may cause empty scopes. This may lead to 3 minor inconsitencies:
- The user is told that he has not favourites while these may just be not visible for him.
- The recommended content may just display as a heading without context.
- The user is told that he has not courses and groups while these may just be not visible for him.

The first and last can possibly occur already, but are more likely to appear with this changes. Therefore a general, more satisfying solution could be discussed.