### PR TITLE
ilStaticCache::set() must return bool

### DIFF
--- a/Services/GlobalCache/classes/Static/class.ilStaticCache.php
+++ b/Services/GlobalCache/classes/Static/class.ilStaticCache.php
@@ -30,7 +30,8 @@ class ilStaticCache extends ilGlobalCacheService
      */
     public function set(string $key, $serialized_value, int $ttl = null) : bool
     {
-        return self::$cache[$this->getComponent()][$key] = $serialized_value;
+        self::$cache[$this->getComponent()][$key] = $serialized_value;
+        return true;
     }
 
     /**


### PR DESCRIPTION
Hi @chfsx ,

a PHP Fatal Error occurs when performing setup command 'migrate':

PHP Fatal error:  Uncaught ILIAS\Setup\UnachievableException: Problem in DB-Update: 0 Return value of ilStaticCache::set() must be of the type bool, array returned in /***/trunk8/Services/GlobalCache/classes/Static/class.ilStaticCache.php:33#0 /***/trunk8/Services/GlobalCache/classes/class.ilGlobalCache.php(307): ilStaticCache->set()
#1 /***/trunk8/Services/Language/classes/class.ilCachedLanguage.php(62): ilGlobalCache->set()
#2 /***/trunk8/Services/Language/classes/class.ilCachedLanguage.php(29): ilCachedLanguage->writeToCache()
#3 /***/trunk8/Services/Language/classes/class.ilCachedLanguage.php(107): ilCachedLanguage->__construct()
#4 /***/trunk8/Services/Language/classes/class.ilLanguage.php(91): ilCachedLanguage::getInstance()
#5 /***/trunk8/Services/Language/classes/class.ilLanguage.php(374): ilLanguage->__construct in /***/trunk8/Services/Database/classes/Setup/class.ilDatabaseUpdatedObjective.php on line 72