### PR TITLE
PHP 8: Enhance PHP types in global test administration

### DIFF
--- a/Modules/Test/classes/class.ilObjAssessmentFolder.php
+++ b/Modules/Test/classes/class.ilObjAssessmentFolder.php
@@ -1,297 +1,264 @@
-<?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
-require_once "./Services/Object/classes/class.ilObject.php";
-require_once 'Modules/TestQuestionPool/classes/class.ilAssQuestionProcessLocker.php';
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilObjAssessmentFolder
- *
- * @author	Helmut Schottmüller <hschottm@gmx.de>
- * @author	Björn Heyser <bheyser@databay.de>
- *
- * @version	$Id$
- *
- * @ingroup ModulesTest
+ * @author    Helmut Schottmüller <hschottm@gmx.de>
+ * @author    Björn Heyser <bheyser@databay.de>
+ * @ingroup   ModulesTest
  */
 class ilObjAssessmentFolder extends ilObject
 {
-    const ADDITIONAL_QUESTION_CONTENT_EDITING_MODE_PAGE_OBJECT_DISABLED = 0;
-    const ADDITIONAL_QUESTION_CONTENT_EDITING_MODE_PAGE_OBJECT_ENABLED = 1;
+    public const ADDITIONAL_QUESTION_CONTENT_EDITING_MODE_PAGE_OBJECT_DISABLED = 0;
+    public const ADDITIONAL_QUESTION_CONTENT_EDITING_MODE_PAGE_OBJECT_ENABLED = 1;
 
-    const ASS_PROC_LOCK_MODE_NONE = 'none';
-    const ASS_PROC_LOCK_MODE_FILE = 'file';
-    const ASS_PROC_LOCK_MODE_DB = 'db';
+    public const ASS_PROC_LOCK_MODE_NONE = 'none';
+    public const ASS_PROC_LOCK_MODE_FILE = 'file';
+    public const ASS_PROC_LOCK_MODE_DB = 'db';
 
-    const SETTINGS_KEY_SKL_TRIG_NUM_ANSWERS_BARRIER = 'ass_skl_trig_num_answ_barrier';
-    const DEFAULT_SKL_TRIG_NUM_ANSWERS_BARRIER = 1;
-    
-    public $setting;
-    
-    /**
-    * Constructor
-    * @access	public
-    * @param	integer	reference_id or object_id
-    * @param	boolean	treat the id as reference_id (true) or object_id (false)
-    */
-    public function __construct($a_id = 0, $a_call_by_reference = true)
+    private const SETTINGS_KEY_SKL_TRIG_NUM_ANSWERS_BARRIER = 'ass_skl_trig_num_answ_barrier';
+    public const DEFAULT_SKL_TRIG_NUM_ANSWERS_BARRIER = 1;
+
+    public ilSetting $setting;
+
+    public function __construct(int $a_id = 0, bool $a_call_by_reference = true)
     {
-        include_once "./Services/Administration/classes/class.ilSetting.php";
-        $this->setting = new ilSetting("assessment");
-        $this->type = "assf";
+        $this->setting = new ilSetting('assessment');
+        $this->type = 'assf';
         parent::__construct($a_id, $a_call_by_reference);
     }
 
-    /**
-    * update object data
-    *
-    * @access	public
-    * @return	boolean
-    */
-    public function update() : bool
+    public static function getSkillTriggerAnswerNumberBarrier() : int
     {
-        if (!parent::update()) {
-            return false;
-        }
-
-        // put here object specific stuff
-
-        return true;
-    }
-
-    public static function getSkillTriggerAnswerNumberBarrier() : ?string
-    {
-        require_once 'Services/Administration/classes/class.ilSetting.php';
         $assSettings = new ilSetting('assessment');
-        
-        return $assSettings->get(
+
+        return (int) $assSettings->get(
             self::SETTINGS_KEY_SKL_TRIG_NUM_ANSWERS_BARRIER,
-            self::DEFAULT_SKL_TRIG_NUM_ANSWERS_BARRIER
+            (string) self::DEFAULT_SKL_TRIG_NUM_ANSWERS_BARRIER
         );
     }
 
-    /**
-    * delete object and all related data
-    *
-    * @access	public
-    * @return	boolean	true if all object data were removed; false if only a references were removed
-    */
-    public function delete() : bool
+    public function _enableAssessmentLogging(bool $a_enable) : void
     {
-        // always call parent delete function first!!
-        if (!parent::delete()) {
-            return false;
-        }
+        $setting = new ilSetting('assessment');
 
-        //put here your module specific stuff
-
-        return true;
+        $setting->set('assessment_logging', (string) ((int) $a_enable));
     }
 
-    /**
-    * enable assessment logging
-    */
-    public function _enableAssessmentLogging($a_enable)
+    public function _setLogLanguage(string $a_language) : void
     {
-        $setting = new ilSetting("assessment");
+        $setting = new ilSetting('assessment');
 
-        if ($a_enable) {
-            $setting->set("assessment_logging", 1);
-        } else {
-            $setting->set("assessment_logging", 0);
-        }
+        $setting->set('assessment_log_language', $a_language);
     }
 
-    /**
-    * set the log language
-    */
-    public function _setLogLanguage($a_language)
-    {
-        $setting = new ilSetting("assessment");
-
-        $setting->set("assessment_log_language", $a_language);
-    }
-
-    /**
-     * check wether assessment logging is enabled or not
-     */
     public static function _enabledAssessmentLogging() : bool
     {
-        $setting = new ilSetting("assessment");
+        $setting = new ilSetting('assessment');
 
-        return (boolean) $setting->get("assessment_logging");
+        return (bool) $setting->get('assessment_logging', '0');
     }
-    
+
     /**
-    * Returns the forbidden questiontypes for ILIAS
-    */
-    public static function _getForbiddenQuestionTypes()
+     * Returns the forbidden questiontypes for ILIAS
+     * @return int[]
+     */
+    public static function _getForbiddenQuestionTypes() : array
     {
-        $setting = new ilSetting("assessment");
-        $types = $setting->get("forbidden_questiontypes");
-        $result = array();
-        if (strlen(trim($types)) == 0) {
-            $result = array();
+        $setting = new ilSetting('assessment');
+        $types = $setting->get('forbidden_questiontypes', '');
+        $result = [];
+
+        if ($types === '') {
+            $result = [];
         } else {
-            $result = unserialize($types);
+            $result = unserialize($types, ['allowed_classes' => false]);
         }
-        return $result;
+
+        return array_filter(array_map('intval', $result));
     }
 
     /**
-    * Sets the forbidden questiontypes for ILIAS
-    *
-    * @param array $a_types An array containing the database ID's of the forbidden question types
-    */
-    public function _setForbiddenQuestionTypes($a_types)
+     * Sets the forbidden questiontypes for ILIAS
+     * @param int[] $typeIds An array containing the database ID's of the forbidden question types
+     */
+    public function _setForbiddenQuestionTypes(array $typeIds) : void
     {
-        $setting = new ilSetting("assessment");
-        $types = "";
-        if (is_array($a_types) && (count($a_types) > 0)) {
-            $types = serialize($a_types);
-        }
-        $setting->set("forbidden_questiontypes", $types);
-    }
-    
-    /**
-    * retrieve the log language for assessment logging
-    */
-    public static function _getLogLanguage() : ?string
-    {
-        $setting = new ilSetting("assessment");
+        $setting = new ilSetting('assessment');
 
-        $lang = $setting->get("assessment_log_language");
-        if (strlen($lang) == 0) {
-            $lang = "en";
+        $types = '';
+        if ($typeIds !== []) {
+            $types = serialize(array_map('intval', $typeIds));
         }
+
+        $setting->set('forbidden_questiontypes', $types);
+    }
+
+    public static function _getLogLanguage() : string
+    {
+        $setting = new ilSetting('assessment');
+
+        $lang = $setting->get('assessment_log_language', '');
+        if ($lang === '') {
+            $lang = 'en';
+        }
+
         return $lang;
     }
-    
+
     /**
      * Returns the fact wether manually scoreable
      * question types exist or not
-     *
-     * @static
-     * @access	public
-     *
-     * @return	boolean		$mananuallyScoreableQuestionTypesExists
      */
     public static function _mananuallyScoreableQuestionTypesExists() : bool
     {
-        if (count(self::_getManualScoring()) > 0) {
-            return true;
-        }
-        
-        return false;
+        return count(self::_getManualScoring()) > 0;
     }
 
     /**
-    * Retrieve the manual scoring settings
-    */
-    public static function _getManualScoring()
+     * Retrieve the manual scoring settings
+     * @return int[]
+     */
+    public static function _getManualScoring() : array
     {
-        $setting = new ilSetting("assessment");
+        $setting = new ilSetting('assessment');
 
-        $types = $setting->get("assessment_manual_scoring");
-        return explode(",", $types);
+        $types = $setting->get('assessment_manual_scoring', '');
+        return array_filter(array_map('intval', explode(',', $types)));
     }
 
     /**
-    * Retrieve the manual scoring settings as type strings
-    */
-    public static function _getManualScoringTypes()
+     * Retrieve the manual scoring settings as type strings
+     * @return string[]
+     */
+    public static function _getManualScoringTypes() : array
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];
-        
-        $result = $ilDB->query("SELECT * FROM qpl_qst_type");
-        $dbtypes = array();
+
+        $setting = new ilSetting('assessment');
+        $typeIds = array_filter(array_map('intval', explode(',', $setting->get('assessment_manual_scoring', ''))));
+        $manualScoringTypes = [];
+
+        $result = $ilDB->query('SELECT question_type_id, type_tag FROM qpl_qst_type');
         while ($row = $ilDB->fetchAssoc($result)) {
-            $dbtypes[$row["question_type_id"]] = $row["type_tag"];
+            if (in_array((int) $row['question_type_id'], $typeIds, true)) {
+                $manualScoringTypes[] = $row['type_tag'];
+            }
         }
-        $setting = new ilSetting("assessment");
-        $types = $setting->get("assessment_manual_scoring");
-        $ids = explode(",", $types);
-        foreach ($ids as $key => $value) {
-            $ids[$key] = $dbtypes[$value];
-        }
-        return $ids;
+        return array_filter($manualScoringTypes);
     }
 
     /**
-    * Set the manual scoring settings
-    *
-    * @param array $type_ids An array containing the database ids of the question types which could be scored manually
-    */
-    public function _setManualScoring($type_ids)
-    {
-        $setting = new ilSetting("assessment");
-        if ((!is_array($type_ids)) || (count($type_ids) == 0)) {
-            $setting->delete("assessment_manual_scoring");
-        } else {
-            $setting->set("assessment_manual_scoring", implode(",", $type_ids));
-        }
-    }
-
-    public static function getScoringAdjustableQuestions()
-    {
-        $setting = new ilSetting("assessment");
-
-        $types = $setting->get("assessment_scoring_adjustment");
-        return explode(",", $types);
-    }
-    
-    public static function setScoringAdjustableQuestions($type_ids)
-    {
-        $setting = new ilSetting("assessment");
-        if ((!is_array($type_ids)) || (count($type_ids) == 0)) {
-            $setting->delete("assessment_scoring_adjustment");
-        } else {
-            $setting->set("assessment_scoring_adjustment", implode(",", $type_ids));
-        }
-    }
-
-    public static function getScoringAdjustmentEnabled() : ?string
-    {
-        $setting = new ilSetting("assessment");
-        return $setting->get('assessment_adjustments_enabled');
-    }
-
-    public static function setScoringAdjustmentEnabled($active)
+     * Set the manual scoring settings
+     * @param int[] $type_ids An array containing the database ids of the question types which could be scored manually
+     */
+    public function _setManualScoring(array $type_ids) : void
     {
         $setting = new ilSetting('assessment');
-        $setting->set('assessment_adjustments_enabled', (bool) $active);
+        if ($type_ids === []) {
+            $setting->delete('assessment_manual_scoring');
+        } else {
+            $setting->set('assessment_manual_scoring', implode(',', $type_ids));
+        }
     }
 
     /**
-    * Add an assessment log entry
-    *
-    * @param integer $user_id The user id of the acting user
-    * @param integer $object_id The database id of the modified test object
-    * @param string $logtext The textual description for the log entry
-    * @param integer $question_id The database id of a modified question (optional)
-    * @param integer $original_id The database id of the original of a modified question (optional)
-    */
-    public static function _addLog($user_id, $object_id, $logtext, $question_id = "", $original_id = "", $test_only = false, $test_ref_id = null)
+     * @return int[]
+     */
+    public static function getScoringAdjustableQuestions() : array
     {
+        $setting = new ilSetting('assessment');
+
+        $types = $setting->get('assessment_scoring_adjustment');
+        return array_filter(array_map('intval', explode(',', $types)));
+    }
+
+    /**
+     * @param int[] $type_ids
+     * @return void
+     */
+    public static function setScoringAdjustableQuestions(array $type_ids) : void
+    {
+        $setting = new ilSetting('assessment');
+        if ($type_ids === []) {
+            $setting->delete('assessment_scoring_adjustment');
+        } else {
+            $setting->set('assessment_scoring_adjustment', implode(',', $type_ids));
+        }
+    }
+
+    public static function getScoringAdjustmentEnabled() : bool
+    {
+        $setting = new ilSetting('assessment');
+        return (bool) $setting->get('assessment_adjustments_enabled', '0');
+    }
+
+    public static function setScoringAdjustmentEnabled(bool $active) : void
+    {
+        $setting = new ilSetting('assessment');
+        $setting->set('assessment_adjustments_enabled', (string) ((int) $active));
+    }
+
+    /**
+     * Add an assessment log entry
+     * @param int    $user_id     The user id of the acting user
+     * @param int    $object_id   The database id of the modified test object
+     * @param string $logtext     The textual description for the log entry
+     * @param int    $question_id The database id of a modified question (optional)
+     * @param int    $original_id The database id of the original of a modified question (optional)
+     * @param bool   $test_only
+     * @param int    $test_ref_id
+     */
+    public static function _addLog(
+        $user_id,
+        $object_id,
+        $logtext,
+        $question_id = 0,
+        $original_id = 0,
+        $test_only = false,
+        $test_ref_id = 0
+    ) : void {
         global $DIC;
         $ilUser = $DIC['ilUser'];
         $ilDB = $DIC['ilDB'];
-        if (strlen($question_id) == 0) {
-            $question_id = null;
+
+        $question_id = 0;
+        if (is_numeric($question_id)) {
+            $question_id = (int) $question_id;
         }
-        if (strlen($original_id) == 0) {
-            $original_id = null;
+
+        $original_id = 0;
+        if (is_numeric($original_id)) {
+            $original_id = (int) $original_id;
         }
-        if (strlen($test_ref_id) == 0) {
-            $test_ref_id = null;
+
+        $test_ref_id = 0;
+        if (is_numeric($test_ref_id)) {
+            $test_ref_id = (int) $test_ref_id;
         }
-        $only = ($test_only == true) ? 1 : 0;
+
+        $only = ($test_only === true) ? 1 : 0;
         $next_id = $ilDB->nextId('ass_log');
         $affectedRows = $ilDB->manipulateF(
             "INSERT INTO ass_log (ass_log_id, user_fi, obj_fi, logtext, question_fi, original_fi, test_only, ref_id, tstamp) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)",
-            array('integer', 'integer', 'integer', 'text', 'integer', 'integer', 'text', 'integer', 'integer'),
-            array(
+            ['integer', 'integer', 'integer', 'text', 'integer', 'integer', 'text', 'integer', 'integer'],
+            [
                 $next_id,
                 $user_id,
                 $object_id,
@@ -301,269 +268,250 @@ class ilObjAssessmentFolder extends ilObject
                 $only,
                 $test_ref_id,
                 time()
-            )
+            ]
         );
     }
-    
+
     /**
-    * Retrieve assessment log datasets from the database
-    *
-    * @param string $ts_from Timestamp of the starting date/time period
-    * @param string $ts_to Timestamp of the ending date/time period
-    * @param integer $test_id Database id of the ILIAS test object
-    * @return array Array containing the datasets between $ts_from and $ts_to for the test with the id $test_id
-    */
-    public static function getLog($ts_from, $ts_to, $test_id, $test_only = false) : array
+     * Retrieve assessment log datasets from the database
+     * @param int $ts_from Timestamp of the starting date/time period
+     * @param int $ts_to   Timestamp of the ending date/time period
+     * @param int $test_id Database id of the ILIAS test object
+     * @return array<string, mixed>[] Array containing the datasets between $ts_from and $ts_to for the test with the id $test_id
+     */
+    public static function getLog(int $ts_from, int $ts_to, int $test_id, bool $test_only = false) : array
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];
-        
-        $log = array();
-        if ($test_only == true) {
+
+        $log = [];
+        if ($test_only === true) {
             $result = $ilDB->queryF(
                 "SELECT * FROM ass_log WHERE obj_fi = %s AND tstamp > %s AND tstamp < %s AND test_only = %s ORDER BY tstamp",
-                array('integer','integer','integer','text'),
-                array(
+                ['integer', 'integer', 'integer', 'text'],
+                [
                     $test_id,
                     $ts_from,
                     $ts_to,
                     1
-                )
+                ]
             );
         } else {
             $result = $ilDB->queryF(
                 "SELECT * FROM ass_log WHERE obj_fi = %s AND tstamp > %s AND tstamp < %s ORDER BY tstamp",
-                array('integer','integer','integer'),
-                array(
+                ['integer', 'integer', 'integer'],
+                [
                     $test_id,
                     $ts_from,
                     $ts_to
-                )
+                ]
             );
         }
         while ($row = $ilDB->fetchAssoc($result)) {
             if (!array_key_exists($row["tstamp"], $log)) {
-                $log[$row["tstamp"]] = array();
+                $log[$row["tstamp"]] = [];
             }
-            array_push($log[$row["tstamp"]], $row);
+            $log[$row["tstamp"]][] = $row;
         }
         krsort($log);
         // flatten array
-        $log_array = array();
+        $log_array = [];
         foreach ($log as $key => $value) {
             foreach ($value as $index => $row) {
-                array_push($log_array, $row);
+                $log_array[] = $row;
             }
         }
         return $log_array;
     }
-    
+
     /**
-    * Retrieve assessment log datasets from the database
-    *
-    * @param string $ts_from Timestamp of the starting date/time period
-    * @param string $ts_to Timestamp of the ending date/time period
-    * @param integer $test_id Database id of the ILIAS test object
-    * @return array Array containing the datasets between $ts_from and $ts_to for the test with the id $test_id
-    */
-    public static function _getLog($ts_from, $ts_to, $test_id, $test_only = false) : array
+     * Retrieve assessment log datasets from the database
+     * @param int $ts_from Timestamp of the starting date/time period
+     * @param int $ts_to   Timestamp of the ending date/time period
+     * @param integer $test_id Database id of the ILIAS test object
+     * @return array<string, mixed>[] Array containing the datasets between $ts_from and $ts_to for the test with the id $test_id
+     */
+    public static function _getLog(int $ts_from, int $ts_to, int $test_id, bool $test_only = false) : array
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];
-        
-        $log = array();
-        if ($test_only == true) {
+
+        $log = [];
+        if ($test_only === true) {
             $result = $ilDB->queryF(
                 "SELECT * FROM ass_log WHERE obj_fi = %s AND tstamp > %s AND tstamp < %s AND test_only = %s ORDER BY tstamp",
-                array('integer', 'integer', 'integer', 'text'),
-                array($test_id, $ts_from, $ts_to, 1)
+                ['integer', 'integer', 'integer', 'text'],
+                [$test_id, $ts_from, $ts_to, 1]
             );
         } else {
             $result = $ilDB->queryF(
                 "SELECT * FROM ass_log WHERE obj_fi = %s AND tstamp > %s AND tstamp < %s ORDER BY tstamp",
-                array('integer', 'integer', 'integer'),
-                array($test_id, $ts_from, $ts_to)
+                ['integer', 'integer', 'integer'],
+                [$test_id, $ts_from, $ts_to]
             );
         }
         while ($row = $ilDB->fetchAssoc($result)) {
             if (!array_key_exists($row["tstamp"], $log)) {
-                $log[$row["tstamp"]] = array();
+                $log[$row["tstamp"]] = [];
             }
             $type_href = "";
-            if (array_key_exists("ref_id", $row)) {
-                if ($row["ref_id"] > 0) {
-                    $type = ilObject::_lookupType($row['ref_id'], true);
-                    switch ($type) {
-                        case "tst":
-                            $type_href = sprintf("goto.php?target=tst_%s&amp;client_id=" . CLIENT_ID, $row["ref_id"]);
-                            break;
-                        case "cat":
-                            $type_href = sprintf("goto.php?target=cat_%s&amp;client_id=" . CLIENT_ID, $row["ref_id"]);
-                            break;
-                    }
+            if (array_key_exists("ref_id", $row) && $row["ref_id"] > 0) {
+                $type = ilObject::_lookupType($row['ref_id'], true);
+                switch ($type) {
+                    case "tst":
+                        $type_href = sprintf("goto.php?target=tst_%s&amp;client_id=" . CLIENT_ID, $row["ref_id"]);
+                        break;
+                    case "cat":
+                        $type_href = sprintf("goto.php?target=cat_%s&amp;client_id=" . CLIENT_ID, $row["ref_id"]);
+                        break;
                 }
             }
             $row["href"] = $type_href;
-            array_push($log[$row["tstamp"]], $row);
+            $log[$row["tstamp"]][] = $row;
         }
         krsort($log);
         // flatten array
-        $log_array = array();
+        $log_array = [];
         foreach ($log as $key => $value) {
             foreach ($value as $index => $row) {
-                array_push($log_array, $row);
+                $log_array[] = $row;
             }
         }
         return $log_array;
     }
-    
+
     /**
-    * Returns the number of log entries for a given test id
-    *
-    * @param integer $test_obj_id Database id of the ILIAS test object
-    * @return integer The number of log entries for the test object
-    */
-    public function getNrOfLogEntries($test_obj_id) : int
+     * Returns the number of log entries for a given test id
+     * @param int $test_obj_id Database id of the ILIAS test object
+     * @return int The number of log entries for the test object
+     */
+    public function getNrOfLogEntries(int $test_obj_id) : int
     {
         global $DIC;
-        $ilDB = $DIC['ilDB'];
+        $ilDB = $DIC->database();
+
         $result = $ilDB->queryF(
             "SELECT COUNT(obj_fi) logcount FROM ass_log WHERE obj_fi = %s",
-            array('integer'),
-            array($test_obj_id)
+            ['integer'],
+            [$test_obj_id]
         );
         if ($result->numRows()) {
             $row = $ilDB->fetchAssoc($result);
-            return $row["logcount"];
-        } else {
-            return 0;
+            return (int) $row["logcount"];
         }
+
+        return 0;
     }
-    
+
     /**
-    * Returns the full path output of an object
-    *
-    * @param integer $ref_id The reference id of the object
-    * @return string The full path with hyperlinks to the path elements
-    */
-    public function getFullPath($ref_id) : string
+     * Deletes the log entries for a given array of test object IDs
+     * @param int[] $a_array An array containing the object IDs of the tests
+     */
+    public function deleteLogEntries(array $a_array) : void
     {
         global $DIC;
-        $tree = $DIC['tree'];
-        $path = $tree->getPathFull($ref_id);
-        $pathelements = array();
-        foreach ($path as $id => $data) {
-            if ($id == 0) {
-                array_push($pathelements, ilLegacyFormElementsUtil::prepareFormOutput($this->lng->txt("repository")));
-            } else {
-                array_push($pathelements, "<a href=\"./goto.php?target=" . $data["type"] . "_" . $data["ref_id"] . "&amp;client=" . CLIENT_ID . "\">" .
-                    ilLegacyFormElementsUtil::prepareFormOutput($data["title"]) . "</a>");
-            }
-        }
-        return implode("&nbsp;&gt;&nbsp;", $pathelements);
-    }
-    
-    /**
-    * Deletes the log entries for a given array of test object IDs
-    *
-    * @param array $a_array An array containing the object IDs of the tests
-    */
-    public function deleteLogEntries($a_array)
-    {
-        global $DIC;
-        $ilDB = $DIC['ilDB'];
-        $ilUser = $DIC['ilUser'];
-        
+        $ilDB = $DIC->database();
+        $ilUser = $DIC->user();
+
         foreach ($a_array as $object_id) {
             $affectedRows = $ilDB->manipulateF(
                 "DELETE FROM ass_log WHERE obj_fi = %s",
-                array('integer'),
-                array($object_id)
+                ['integer'],
+                [$object_id]
             );
             self::_addLog($ilUser->getId(), $object_id, $this->lng->txt("assessment_log_deleted"));
         }
     }
-    
+
     /**
-     * returns the fact wether content editing with ilias page editor is enabled for questions or not
-     *
-     * @global ilSetting $ilSetting
-     * @return bool $isPageEditorEnabled
+     * Returns the fact wether content editing with ilias page editor is enabled for questions or not
      */
     public static function isAdditionalQuestionContentEditingModePageObjectEnabled() : bool
     {
-        require_once 'Modules/TestQuestionPool/classes/class.assQuestion.php';
-        
         global $DIC;
-        $ilSetting = $DIC['ilSetting'];
-        
+        $ilSetting = $DIC->settings();
+
         $isPageEditorEnabled = $ilSetting->get(
             'enable_tst_page_edit',
-            self::ADDITIONAL_QUESTION_CONTENT_EDITING_MODE_PAGE_OBJECT_DISABLED
+            (string) self::ADDITIONAL_QUESTION_CONTENT_EDITING_MODE_PAGE_OBJECT_DISABLED
         );
-        
-        return $isPageEditorEnabled;
+
+        return (bool) $isPageEditorEnabled;
     }
-    
-    public function getAssessmentProcessLockMode() : ?string
+
+    public function getAssessmentProcessLockMode() : string
     {
         return $this->setting->get('ass_process_lock_mode', self::ASS_PROC_LOCK_MODE_NONE);
     }
 
-    public function setAssessmentProcessLockMode($lockMode)
+    public function setAssessmentProcessLockMode(string $lockMode) : void
     {
         $this->setting->set('ass_process_lock_mode', $lockMode);
     }
-    
+
+    /**
+     * @return string[]
+     */
     public static function getValidAssessmentProcessLockModes() : array
     {
-        return array(self::ASS_PROC_LOCK_MODE_NONE, self::ASS_PROC_LOCK_MODE_FILE, self::ASS_PROC_LOCK_MODE_DB);
+        return [
+            self::ASS_PROC_LOCK_MODE_NONE,
+            self::ASS_PROC_LOCK_MODE_FILE,
+            self::ASS_PROC_LOCK_MODE_DB
+        ];
     }
-    
-    public function getSkillTriggeringNumAnswersBarrier() : ?string
+
+    public function getSkillTriggeringNumAnswersBarrier() : string
     {
         return $this->setting->get(
             'ass_skl_trig_num_answ_barrier',
-            self::DEFAULT_SKL_TRIG_NUM_ANSWERS_BARRIER
+            (string) self::DEFAULT_SKL_TRIG_NUM_ANSWERS_BARRIER
         );
     }
-    
-    public function setSkillTriggeringNumAnswersBarrier($skillTriggeringNumAnswersBarrier)
+
+    public function setSkillTriggeringNumAnswersBarrier(int $skillTriggeringNumAnswersBarrier) : void
     {
-        $this->setting->set('ass_skl_trig_num_answ_barrier', $skillTriggeringNumAnswersBarrier);
+        $this->setting->set('ass_skl_trig_num_answ_barrier', (string) $skillTriggeringNumAnswersBarrier);
     }
 
-    public function setExportEssayQuestionsWithHtml($value)
+    public function setExportEssayQuestionsWithHtml(bool $value) : void
     {
-        $this->setting->set('export_essay_qst_with_html', $value);
+        $this->setting->set('export_essay_qst_with_html', (string) ((int) $value));
     }
 
-    public function getExportEssayQuestionsWithHtml() : ?string
+    public function getExportEssayQuestionsWithHtml() : bool
     {
-        return $this->setting->get('export_essay_qst_with_html');
+        return (bool) $this->setting->get('export_essay_qst_with_html', '0');
     }
-    
-    public function fetchScoringAdjustableTypes($allQuestionTypes) : array
+
+    /**
+     * @param array<string, array{question_type_id: int, type_tag: string, plugin: int, plugin_name: string|null}> $allQuestionTypes
+     * @return array<string, array{question_type_id: int, type_tag: string, plugin: int, plugin_name: string|null}>
+     * @throws ilTestQuestionPoolInvalidArgumentException
+     */
+    public function fetchScoringAdjustableTypes(array $allQuestionTypes) : array
     {
-        require_once 'Modules/TestQuestionPool/classes/class.assQuestionGUI.php';
-        $scoringAdjustableQuestionTypes = array();
-        
+        $scoringAdjustableQuestionTypes = [];
+
         foreach ($allQuestionTypes as $type => $typeData) {
             $questionGui = assQuestionGUI::_getQuestionGUI($typeData['type_tag']);
-            
+
             if ($this->questionSupportsScoringAdjustment($questionGui)) {
                 $scoringAdjustableQuestionTypes[$type] = $typeData;
             }
         }
-        
+
         return $scoringAdjustableQuestionTypes;
     }
     
-    private function questionSupportsScoringAdjustment(\assQuestionGUI $question_object) : bool
+    private function questionSupportsScoringAdjustment(assQuestionGUI $question_object) : bool
     {
-        return ($question_object instanceof ilGuiQuestionScoringAdjustable
-            || $question_object instanceof ilGuiAnswerScoringAdjustable)
-        && ($question_object->object instanceof ilObjQuestionScoringAdjustable
-            || $question_object->object instanceof ilObjAnswerScoringAdjustable);
+        return (
+            $question_object instanceof ilGuiQuestionScoringAdjustable ||
+            $question_object instanceof ilGuiAnswerScoringAdjustable
+        ) && (
+            $question_object->object instanceof ilObjQuestionScoringAdjustable ||
+            $question_object->object instanceof ilObjAnswerScoringAdjustable
+        );
     }
 }

--- a/Modules/Test/classes/class.ilObjAssessmentFolderAccess.php
+++ b/Modules/Test/classes/class.ilObjAssessmentFolderAccess.php
@@ -1,15 +1,21 @@
-<?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
-
-require_once("./Services/Object/classes/class.ilObjectAccess.php");
+<?php declare(strict_types=1);
 
 /**
- * Class ilObjRootFolderAccess
- *
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *********************************************************************/
+
+/**
+ * Class ilObjAssessmentFolderAccess
  * @author Helmut Schottmüller <helmut.schottmueller@mac.com>
- *
- * @version $Id$
- *
  * @ingroup ModulesTest
  */
 class ilObjAssessmentFolderAccess extends ilObjectAccess

--- a/Modules/Test/classes/class.ilObjAssessmentFolderGUI.php
+++ b/Modules/Test/classes/class.ilObjAssessmentFolderGUI.php
@@ -1,23 +1,30 @@
-<?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
-require_once "./Services/Object/classes/class.ilObjectGUI.php";
-
-require_once 'Modules/Test/classes/class.ilObjTest.php';
-require_once 'Modules/TestQuestionPool/classes/class.ilAssQuestionProcessLocker.php';
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilObjAssessmentFolderGUI
- *
  * @author Helmut Schottmüller <hschottm@gmx.de>
  * @ilCtrl_Calls ilObjAssessmentFolderGUI: ilPermissionGUI, ilSettingsTemplateGUI, ilGlobalUnitConfigurationGUI
  */
 class ilObjAssessmentFolderGUI extends ilObjectGUI
 {
     protected \ILIAS\Test\InternalRequestService $testrequest;
-    /**
-     * Constructor
-     */
+
     public function __construct($a_data, int $a_id = 0, bool $a_call_by_reference = true, bool $a_prepare_output = true)
     {
         global $DIC;
@@ -33,6 +40,12 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
         $this->lng->loadLanguageModule('assessment');
     }
     
+    private function getAssessmentFolder() : ilObjAssessmentFolder
+    {
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
+        return $this->object;
+    }
+
     public function executeCommand() : void
     {
         /**
@@ -50,7 +63,6 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
         switch ($next_class) {
             case 'ilpermissiongui':
                 $ilTabs->activateTab('perm_settings');
-                include_once("Services/AccessControl/classes/class.ilPermissionGUI.php");
                 $perm_gui = new ilPermissionGUI($this);
                 $ret = $this->ctrl->forwardCommand($perm_gui);
                 break;
@@ -60,14 +72,12 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
                 break;
 
             case 'ilglobalunitconfigurationgui':
-                if (!$rbacsystem->checkAccess('visible,read', $this->object->getRefId())) {
+                if (!$rbacsystem->checkAccess('visible,read', $this->getAssessmentFolder()->getRefId())) {
                     $this->ilias->raiseError($this->lng->txt('permission_denied'), $this->ilias->error_obj->WARNING);
                 }
 
                 $ilTabs->setTabActive('units');
 
-                require_once 'Modules/TestQuestionPool/classes/class.ilGlobalUnitConfigurationGUI.php';
-                require_once 'Modules/TestQuestionPool/classes/class.ilUnitConfigurationRepository.php';
                 $gui = new ilGlobalUnitConfigurationGUI(
                     new ilUnitConfigurationRepository(0)
                 );
@@ -85,45 +95,20 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
         }
     }
 
-
-    /**
-    * save object
-    * @access	public
-    */
-    public function saveObject() : void
-    {
-        global $DIC;
-        $rbacadmin = $DIC['rbacadmin'];
-
-        // create and insert forum in objecttree
-        parent::saveObject();
-
-        // put here object specific stuff
-
-        // always send a message
-        $this->tpl->setOnScreenMessage('success', $this->lng->txt("object_added"), true);
-
-        $this->ctrl->redirect($this);
-    }
-
-
-    /**
-    * display assessment folder settings form
-    */
     public function settingsObject(ilPropertyFormGUI $form = null) : void
     {
         global $DIC;
         $ilTabs = $DIC['ilTabs'];
-                
+
         $ilTabs->setTabActive('settings');
 
         if ($form === null) {
             $form = $this->buildSettingsForm();
         }
-        
+
         $this->tpl->setVariable("ADM_CONTENT", $form->getHTML());
     }
-    
+
     private function buildSettingsForm() : ilPropertyFormGUI
     {
         /**
@@ -131,9 +116,7 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
          */
         global $DIC;
         $ilAccess = $DIC['ilAccess'];
-        
-        include_once "./Modules/TestQuestionPool/classes/class.ilObjQuestionPool.php";
-        include_once("./Services/Form/classes/class.ilPropertyFormGUI.php");
+
         $form = new ilPropertyFormGUI();
         $form->setFormAction($this->ctrl->getFormAction($this));
         $form->setTableWidth("100%");
@@ -145,19 +128,25 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
 
         // question process locking behaviour (e.g. on saving users working data)
         $chb = new ilCheckboxInputGUI($this->lng->txt('ass_process_lock'), 'ass_process_lock');
-        $chb->setChecked($this->object->getAssessmentProcessLockMode() != ilObjAssessmentFolder::ASS_PROC_LOCK_MODE_NONE);
+        $chb->setChecked($this->getAssessmentFolder()->getAssessmentProcessLockMode() !== ilObjAssessmentFolder::ASS_PROC_LOCK_MODE_NONE);
         $chb->setInfo($this->lng->txt('ass_process_lock_desc'));
         $form->addItem($chb);
         $rg = new ilRadioGroupInputGUI($this->lng->txt('ass_process_lock_mode'), 'ass_process_lock_mode');
         $rg->setRequired(true);
-        $opt = new ilRadioOption($this->lng->txt('ass_process_lock_mode_file'), ilObjAssessmentFolder::ASS_PROC_LOCK_MODE_FILE);
+        $opt = new ilRadioOption(
+            $this->lng->txt('ass_process_lock_mode_file'),
+            ilObjAssessmentFolder::ASS_PROC_LOCK_MODE_FILE
+        );
         $opt->setInfo($this->lng->txt('ass_process_lock_mode_file_desc'));
         $rg->addOption($opt);
-        $opt = new ilRadioOption($this->lng->txt('ass_process_lock_mode_db'), ilObjAssessmentFolder::ASS_PROC_LOCK_MODE_DB);
+        $opt = new ilRadioOption(
+            $this->lng->txt('ass_process_lock_mode_db'),
+            ilObjAssessmentFolder::ASS_PROC_LOCK_MODE_DB
+        );
         $opt->setInfo($this->lng->txt('ass_process_lock_mode_db_desc'));
         $rg->addOption($opt);
-        if ($this->object->getAssessmentProcessLockMode() != ilObjAssessmentFolder::ASS_PROC_LOCK_MODE_NONE) {
-            $rg->setValue($this->object->getAssessmentProcessLockMode());
+        if ($this->getAssessmentFolder()->getAssessmentProcessLockMode() !== ilObjAssessmentFolder::ASS_PROC_LOCK_MODE_NONE) {
+            $rg->setValue($this->getAssessmentFolder()->getAssessmentProcessLockMode());
         }
         $chb->addSubItem($rg);
 
@@ -166,7 +155,7 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
         if ($this->testrequest->isset('imap_line_color')) {
             $imap_line_color = $this->testrequest->str('imap_line_color');
         }
-        if (strlen($imap_line_color) == 0) {
+        if ($imap_line_color == '') {
             $imap_line_color = 'FF0000';
         }
 
@@ -182,8 +171,8 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
         $userCriteria->setInfo($this->lng->txt('user_criteria_desc'));
         $userCriteria->setRequired(true);
 
-        $fields = array('usr_id', 'login', 'email', 'matriculation', 'ext_account');
-        $usr_fields = array();
+        $fields = ['usr_id', 'login', 'email', 'matriculation', 'ext_account'];
+        $usr_fields = [];
         foreach ($fields as $field) {
             $usr_fields[$field] = $field;
         }
@@ -200,24 +189,27 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
         $numRequiredAnswers->allowDecimals(false);
         $numRequiredAnswers->setMinValue(1);
         $numRequiredAnswers->setMinvalueShouldBeGreater(false);
-        $numRequiredAnswers->setValue($this->object->getSkillTriggeringNumAnswersBarrier());
+        $numRequiredAnswers->setValue((string) $this->getAssessmentFolder()->getSkillTriggeringNumAnswersBarrier());
         $form->addItem($numRequiredAnswers);
 
         $ceeqwh = new ilCheckboxInputGUI($this->lng->txt('export_essay_qst_with_html'), 'export_essay_qst_with_html');
-        $ceeqwh->setChecked($this->object->getExportEssayQuestionsWithHtml());
+        $ceeqwh->setChecked($this->getAssessmentFolder()->getExportEssayQuestionsWithHtml());
         $ceeqwh->setInfo($this->lng->txt('export_essay_qst_with_html_desc'));
         $form->addItem($ceeqwh);
-        
+
         // question settings
         $header = new ilFormSectionHeaderGUI();
         $header->setTitle($this->lng->txt("assf_questiontypes"));
         $form->addItem($header);
 
         // available question types
-        $allowed = new ilCheckboxGroupInputGUI($this->lng->txt('assf_allowed_questiontypes'), "chb_allowed_questiontypes");
+        $allowed = new ilCheckboxGroupInputGUI(
+            $this->lng->txt('assf_allowed_questiontypes'),
+            "chb_allowed_questiontypes"
+        );
         $questiontypes = ilObjQuestionPool::_getQuestionTypes(true);
         $forbidden_types = ilObjAssessmentFolder::_getForbiddenQuestionTypes();
-        $allowedtypes = array();
+        $allowedtypes = [];
         foreach ($questiontypes as $qt) {
             if (!in_array($qt['question_type_id'], $forbidden_types)) {
                 $allowedtypes[] = $qt['question_type_id'];
@@ -231,82 +223,97 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
         $form->addItem($allowed);
 
         // manual scoring
-        $manual = new ilCheckboxGroupInputGUI($this->lng->txt('assessment_log_manual_scoring_activate'), "chb_manual_scoring");
+        $manual = new ilCheckboxGroupInputGUI(
+            $this->lng->txt('assessment_log_manual_scoring_activate'),
+            "chb_manual_scoring"
+        );
         $manscoring = ilObjAssessmentFolder::_getManualScoring();
         $manual->setValue($manscoring);
         foreach ($questiontypes as $type_name => $qtype) {
-            $manual->addOption(new ilCheckboxOption($type_name, $qtype["question_type_id"]));
+            $manual->addOption(new ilCheckboxOption($type_name, (string) $qtype["question_type_id"]));
         }
         $manual->setInfo($this->lng->txt('assessment_log_manual_scoring_desc'));
         $form->addItem($manual);
 
         // scoring adjustment active
-        $scoring_activation = new ilCheckboxInputGUI($this->lng->txt('assessment_scoring_adjust'), 'chb_scoring_adjust');
-        $scoring_activation->setChecked($this->object->getScoringAdjustmentEnabled());
+        $scoring_activation = new ilCheckboxInputGUI(
+            $this->lng->txt('assessment_scoring_adjust'),
+            'chb_scoring_adjust'
+        );
+        $scoring_activation->setChecked($this->getAssessmentFolder()->getScoringAdjustmentEnabled());
         $scoring_activation->setInfo($this->lng->txt('assessment_scoring_adjust_desc'));
         $form->addItem($scoring_activation);
 
         // scoring adjustment
-        $scoring = new ilCheckboxGroupInputGUI($this->lng->txt('assessment_log_scoring_adjustment_activate'), "chb_scoring_adjustment");
-        $scoring_active = $this->object->getScoringAdjustableQuestions();
+        $scoring = new ilCheckboxGroupInputGUI(
+            $this->lng->txt('assessment_log_scoring_adjustment_activate'),
+            "chb_scoring_adjustment"
+        );
+        $scoring_active = $this->getAssessmentFolder()->getScoringAdjustableQuestions();
         $scoring->setValue($scoring_active);
-        foreach ($this->object->fetchScoringAdjustableTypes($questiontypes) as $type_name => $qtype) {
-            $scoring->addOption(new ilCheckboxOption($type_name, $qtype["question_type_id"]));
+
+        foreach ($this->getAssessmentFolder()->fetchScoringAdjustableTypes($questiontypes) as $type_name => $qtype) {
+            $scoring->addOption(
+                new ilCheckboxOption($type_name, (string) $qtype["question_type_id"])
+            );
         }
         $scoring->setInfo($this->lng->txt('assessment_log_scoring_adjustment_desc'));
         $form->addItem($scoring);
 
-        if ($ilAccess->checkAccess("write", "", $this->object->getRefId())) {
+        if ($ilAccess->checkAccess("write", "", $this->getAssessmentFolder()->getRefId())) {
             $form->addCommandButton("saveSettings", $this->lng->txt("save"));
         }
 
         return $form;
     }
-    
+
     /**
-    * Save Assessment settings
-    */
+     * Save Assessment settings
+     */
     public function saveSettingsObject() : void
     {
         global $DIC;
         $ilAccess = $DIC['ilAccess'];
-        if (!$ilAccess->checkAccess("write", "", $this->object->getRefId())) {
+        if (!$ilAccess->checkAccess("write", "", $this->getAssessmentFolder()->getRefId())) {
             $this->ctrl->redirect($this, 'settings');
         }
-    
+
         $form = $this->buildSettingsForm();
         if (!$form->checkInput()) {
             $form->setValuesByPost();
             $this->settingsObject($form);
             return;
         }
-        
-        $this->object->setSkillTriggeringNumAnswersBarrier((int) $_POST['num_req_answers']);
-        $this->object->setExportEssayQuestionsWithHtml((int) $_POST["export_essay_qst_with_html"] == 1);
-        $this->object->_setManualScoring($_POST["chb_manual_scoring"]);
-        include_once "./Modules/TestQuestionPool/classes/class.ilObjQuestionPool.php";
+
+        $this->getAssessmentFolder()->setSkillTriggeringNumAnswersBarrier((int) $_POST['num_req_answers']);
+        $this->getAssessmentFolder()->setExportEssayQuestionsWithHtml((bool) $_POST["export_essay_qst_with_html"]);
+        $this->getAssessmentFolder()->_setManualScoring($_POST["chb_manual_scoring"]);
         $questiontypes = ilObjQuestionPool::_getQuestionTypes(true);
-        $forbidden_types = array();
+        $forbidden_types = [];
         foreach ($questiontypes as $name => $row) {
             if (!in_array($row["question_type_id"], $_POST["chb_allowed_questiontypes"])) {
-                $forbidden_types[] = $row["question_type_id"];
+                $forbidden_types[] = (int) $row["question_type_id"];
             }
         }
-        $this->object->_setForbiddenQuestionTypes($forbidden_types);
-        
-        $this->object->setScoringAdjustmentEnabled($_POST['chb_scoring_adjust']);
-        $scoring_types = array();
+        $this->getAssessmentFolder()->_setForbiddenQuestionTypes($forbidden_types);
+
+        $this->getAssessmentFolder()->setScoringAdjustmentEnabled((bool) $_POST['chb_scoring_adjust']);
+        $scoring_types = [];
         foreach ($questiontypes as $name => $row) {
             if (in_array($row["question_type_id"], (array) $_POST["chb_scoring_adjustment"])) {
                 $scoring_types[] = $row["question_type_id"];
             }
         }
-        $this->object->setScoringAdjustableQuestions($scoring_types);
-        
+        $this->getAssessmentFolder()->setScoringAdjustableQuestions($scoring_types);
+
         if (!$_POST['ass_process_lock']) {
-            $this->object->setAssessmentProcessLockMode(ilObjAssessmentFolder::ASS_PROC_LOCK_MODE_NONE);
-        } elseif (in_array($_POST['ass_process_lock_mode'], ilObjAssessmentFolder::getValidAssessmentProcessLockModes())) {
-            $this->object->setAssessmentProcessLockMode($_POST['ass_process_lock_mode']);
+            $this->getAssessmentFolder()->setAssessmentProcessLockMode(ilObjAssessmentFolder::ASS_PROC_LOCK_MODE_NONE);
+        } elseif (in_array(
+            $_POST['ass_process_lock_mode'],
+            ilObjAssessmentFolder::getValidAssessmentProcessLockModes(),
+            true
+        )) {
+            $this->getAssessmentFolder()->setAssessmentProcessLockMode($_POST['ass_process_lock_mode']);
         }
 
         $assessmentSetting = new ilSetting('assessment');
@@ -320,10 +327,10 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
 
         $this->ctrl->redirect($this, 'settings');
     }
-    
+
     /**
-    * Called when the a log should be shown
-    */
+     * Called when the a log should be shown
+     */
     public function showLogObject() : void
     {
         $form = $this->getLogDataOutputForm();
@@ -332,10 +339,10 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
         $form->setValuesByPost();
         $this->logsObject($form);
     }
-    
+
     /**
-    * Called when the a log should be exported
-    */
+     * Called when the a log should be exported
+     */
     public function exportLogObject() : void
     {
         $form = $this->getLogDataOutputForm();
@@ -345,38 +352,37 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
             return;
         }
 
-        $test = $form->getInput('sel_test');
+        $test = (int) $form->getInput('sel_test');
         $from = $form->getItemByPostVar('log_from')->getDate()->get(IL_CAL_UNIX);
         $until = $form->getItemByPostVar('log_until')->getDate()->get(IL_CAL_UNIX);
 
-        $csv = array();
+        $csv = [];
         $separator = ";";
-        $row = array(
-                $this->lng->txt("assessment_log_datetime"),
-                $this->lng->txt("user"),
-                $this->lng->txt("assessment_log_text"),
-                $this->lng->txt("question")
-        );
-        include_once "./Modules/Test/classes/class.ilObjTest.php";
-        include_once "./Modules/TestQuestionPool/classes/class.assQuestion.php";
+        $row = [
+            $this->lng->txt("assessment_log_datetime"),
+            $this->lng->txt("user"),
+            $this->lng->txt("assessment_log_text"),
+            $this->lng->txt("question")
+        ];
+
         $available_tests = ilObjTest::_getAvailableTests(1);
         $csv[] = ilCSVUtil::processCSVRow($row, true, $separator);
         $log_output = ilObjAssessmentFolder::getLog($from, $until, $test);
-        $users = array();
+        $users = [];
         foreach ($log_output as $key => $log) {
             if (!array_key_exists($log["user_fi"], $users)) {
-                $users[$log["user_fi"]] = ilObjUser::_lookupName($log["user_fi"]);
+                $users[$log["user_fi"]] = ilObjUser::_lookupName((int) $log["user_fi"]);
             }
             $title = "";
             if ($log["question_fi"] || $log["original_fi"]) {
-                $title = assQuestion::_getQuestionTitle($log["question_fi"]);
-                if (strlen($title) == 0) {
-                    $title = assQuestion::_getQuestionTitle($log["original_fi"]);
+                $title = assQuestion::_getQuestionTitle((int) $log["question_fi"]);
+                if ($title === '') {
+                    $title = assQuestion::_getQuestionTitle((int) $log["original_fi"]);
                 }
                 $title = $this->lng->txt("assessment_log_question") . ": " . $title;
             }
-            $csvrow = array();
-            $date = new ilDateTime($log['tstamp'], IL_CAL_UNIX);
+            $csvrow = [];
+            $date = new ilDateTime((int) $log['tstamp'], IL_CAL_UNIX);
             $csvrow[] = $date->get(IL_CAL_FKT_DATE, 'Y-m-d H:i');
             $csvrow[] = trim($users[$log["user_fi"]]["title"] . " " . $users[$log["user_fi"]]["firstname"] . " " . $users[$log["user_fi"]]["lastname"]);
             $csvrow[] = trim($log["logtext"]);
@@ -398,7 +404,6 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
      */
     protected function getLogDataOutputForm() : ilPropertyFormGUI
     {
-        require_once 'Services/Form/classes/class.ilPropertyFormGUI.php';
         $form = new ilPropertyFormGUI();
         $form->setPreventDoubleSubmission(false);
         $form->setFormAction($this->ctrl->getFormAction($this));
@@ -421,22 +426,20 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
         $until->setRequired(true);
         $form->addItem($until);
 
-        require_once 'Modules/Test/classes/class.ilObjTest.php';
-        require_once 'Modules/TestQuestionPool/classes/class.assQuestion.php';
         $available_tests = ilObjTest::_getAvailableTests(1);
 
         // tests
         $fortest = new ilSelectInputGUI($this->lng->txt('assessment_log_for_test'), "sel_test");
         $fortest->setRequired(true);
-        $sorted_options = array();
+        $sorted_options = [];
         foreach ($available_tests as $key => $value) {
-            $sorted_options[] = array(
-                'title' => ilLegacyFormElementsUtil::prepareFormOutput($value) . " [" . $this->object->getNrOfLogEntries($key) . " " . $this->lng->txt("assessment_log_log_entries") . "]",
+            $sorted_options[] = [
+                'title' => ilLegacyFormElementsUtil::prepareFormOutput($value) . " [" . $this->getAssessmentFolder()->getNrOfLogEntries((int) $key) . " " . $this->lng->txt("assessment_log_log_entries") . "]",
                 'key' => $key
-            );
+            ];
         }
         $sorted_options = ilArrayUtil::sortArray($sorted_options, 'title', 'asc');
-        $options = array('' => $this->lng->txt('please_choose'));
+        $options = ['' => $this->lng->txt('please_choose')];
         foreach ($sorted_options as $option) {
             $options[$option['key']] = $option['title'];
         }
@@ -445,7 +448,7 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
 
         $form->addCommandButton('showLog', $this->lng->txt('show'));
         $form->addCommandButton('exportLog', $this->lng->txt('export'));
-        
+
         return $form;
     }
 
@@ -470,8 +473,8 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
 
         if (!($form instanceof ilPropertyFormGUI)) {
             $form = $this->getLogDataOutputForm();
-            
-            $values = array();
+
+            $values = [];
             if ($this->testrequest->isset('sel_test')) {
                 $p_test = $values['sel_test'] = $this->testrequest->int('sel_test');
             }
@@ -488,15 +491,15 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
                 $untildate = time();
             }
 
-            $values['log_from'] = new ilDateTime($fromdate, IL_CAL_UNIX);
-            $values['log_until'] = new ilDateTime($untildate, IL_CAL_UNIX);
+            $values['log_from'] = (new ilDateTime($fromdate, IL_CAL_UNIX))->get(IL_CAL_DATETIME);
+            $values['log_until'] = (new ilDateTime($untildate, IL_CAL_UNIX))->get(IL_CAL_DATETIME);
 
             $form->setValuesByArray($values);
         } else {
             $fromdate_input = $form->getItemByPostVar('log_from')->getDate();
             $untildate_input = $form->getItemByPostVar('log_until')->getDate();
             if ($fromdate_input instanceof ilDateTime && $untildate_input instanceof ilDateTime) {
-                $p_test = $form->getInput('sel_test');
+                $p_test = (int) $form->getInput('sel_test');
 
                 $fromdate = $fromdate_input->get(IL_CAL_UNIX);
                 $untildate = $untildate_input->get(IL_CAL_UNIX);
@@ -510,15 +513,15 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
         $template->setVariable("FORM", $form->getHTML());
 
         if ($p_test) {
-            require_once "Services/Link/classes/class.ilLink.php";
-            include_once "./Modules/Test/classes/tables/class.ilAssessmentFolderLogTableGUI.php";
             $table_gui = new ilAssessmentFolderLogTableGUI($this, 'logs');
             $log_output = ilObjAssessmentFolder::getLog($fromdate, $untildate, $p_test);
 
             $self = $this;
             array_walk($log_output, static function (&$row) use ($self) {
+                $row['location_href'] = '';
+                $row['location_txt'] = '';
                 if (is_numeric($row['ref_id']) && $row['ref_id'] > 0) {
-                    $row['location_href'] = ilLink::_getLink($row['ref_id'], 'tst');
+                    $row['location_href'] = ilLink::_getLink((int) $row['ref_id'], 'tst');
                     $row['location_txt'] = $self->lng->txt("perma_link");
                 }
             });
@@ -530,22 +533,22 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
     }
 
     /**
-    * Deletes the log entries for one or more tests
-    */
+     * Deletes the log entries for one or more tests
+     */
     public function deleteLogObject() : void
     {
         if (is_array($_POST["chb_test"]) && (count($_POST["chb_test"]))) {
-            $this->object->deleteLogEntries($_POST["chb_test"]);
+            $this->getAssessmentFolder()->deleteLogEntries($_POST["chb_test"]);
             $this->tpl->setOnScreenMessage('success', $this->lng->txt("ass_log_deleted"));
         } else {
             $this->tpl->setOnScreenMessage('info', $this->lng->txt("ass_log_delete_no_selection"));
         }
         $this->logAdminObject();
     }
-    
+
     /**
-    * Administration output for assessment log files
-    */
+     * Administration output for assessment log files
+     */
     public function logAdminObject() : void
     {
         global $DIC;
@@ -554,23 +557,21 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
 
         $ilTabs->activateTab('logs');
 
-        $a_write_access = ($ilAccess->checkAccess("write", "", $this->object->getRefId())) ? true : false;
-        
-        include_once "./Modules/Test/classes/tables/class.ilAssessmentFolderLogAdministrationTableGUI.php";
+        $a_write_access = ($ilAccess->checkAccess("write", "", $this->getAssessmentFolder()->getRefId())) ? true : false;
+
         $table_gui = new ilAssessmentFolderLogAdministrationTableGUI($this, 'logAdmin', $a_write_access);
-        include_once "./Modules/Test/classes/class.ilObjTest.php";
-        require_once "./Services/Link/classes/class.ilLink.php";
+
         $available_tests = ilObjTest::_getAvailableTests(false);
-        $data = array();
+        $data = [];
         foreach ($available_tests as $ref_id => $title) {
             $obj_id = ilObject::_lookupObjectId($ref_id);
-            $data[] = array(
+            $data[] = [
                 "title" => $title,
-                "nr" => $this->object->getNrOfLogEntries($obj_id),
+                "nr" => $this->getAssessmentFolder()->getNrOfLogEntries((int) $obj_id),
                 "id" => $obj_id,
                 "location_href" => ilLink::_getLink($ref_id, 'tst'),
                 "location_txt" => $this->lng->txt("perma_link")
-            );
+            ];
         }
         $table_gui->setData($data);
         $this->tpl->setVariable('ADM_CONTENT', $table_gui->getHTML());
@@ -590,7 +591,7 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
         $ilTabs->addSubTabTarget(
             "settings",
             $this->ctrl->getLinkTarget($this, "showLogSettings"),
-            array("saveLogSettings", "showLogSettings"),
+            ["saveLogSettings", "showLogSettings"],
             ""
         );
 
@@ -598,15 +599,15 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
         $ilTabs->addSubTabTarget(
             "ass_log_output",
             $this->ctrl->getLinkTarget($this, "logs"),
-            array("logs", "showLog", "exportLog"),
+            ["logs", "showLog", "exportLog"],
             ""
         );
-    
+
         // log administration
         $ilTabs->addSubTabTarget(
             "ass_log_admin",
             $this->ctrl->getLinkTarget($this, "logAdmin"),
-            array("logAdmin", "deleteLog"),
+            ["logAdmin", "deleteLog"],
             "",
             ""
         );
@@ -629,12 +630,12 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
                 $this->getLogdataSubtabs();
                 break;
         }
-        
-        if ($rbacsystem->checkAccess("visible,read", $this->object->getRefId())) {
+
+        if ($rbacsystem->checkAccess("visible,read", $this->getAssessmentFolder()->getRefId())) {
             $this->tabs_gui->addTarget(
                 "settings",
                 $this->ctrl->getLinkTarget($this, "settings"),
-                array("settings","","view"),
+                ["settings", "", "view"],
                 "",
                 ""
             );
@@ -642,7 +643,7 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
             $this->tabs_gui->addTarget(
                 "logs",
                 $this->ctrl->getLinkTarget($this, "showLogSettings"),
-                array('saveLogSettings', 'showLogSettings', "logs","showLog", "exportLog", "logAdmin", "deleteLog"),
+                ['saveLogSettings', 'showLogSettings', "logs", "showLog", "exportLog", "logAdmin", "deleteLog"],
                 "",
                 ""
             );
@@ -653,14 +654,19 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
                 $this->ctrl->getLinkTargetByClass("ilsettingstemplategui", "")
             );
 
-            $this->tabs_gui->addTarget('units', $this->ctrl->getLinkTargetByClass('ilGlobalUnitConfigurationGUI', ''), '', 'ilglobalunitconfigurationgui');
+            $this->tabs_gui->addTarget(
+                'units',
+                $this->ctrl->getLinkTargetByClass('ilGlobalUnitConfigurationGUI', ''),
+                '',
+                'ilglobalunitconfigurationgui'
+            );
         }
 
-        if ($rbacsystem->checkAccess('edit_permission', $this->object->getRefId())) {
+        if ($rbacsystem->checkAccess('edit_permission', $this->getAssessmentFolder()->getRefId())) {
             $this->tabs_gui->addTarget(
                 "perm_settings",
-                $this->ctrl->getLinkTargetByClass(array(get_class($this),'ilpermissiongui'), "perm"),
-                array("perm","info","owner"),
+                $this->ctrl->getLinkTargetByClass([get_class($this), 'ilpermissiongui'], "perm"),
+                ["perm", "info", "owner"],
                 'ilpermissiongui'
             );
         }
@@ -675,10 +681,10 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
 
         if (!($form instanceof ilPropertyFormGUI)) {
             $form = $this->getLogSettingsForm();
-            $form->setValuesByArray(array(
+            $form->setValuesByArray([
                 'chb_assessment_logging' => ilObjAssessmentFolder::_enabledAssessmentLogging(),
                 'reporting_language' => ilObjAssessmentFolder::_getLogLanguage()
-            ));
+            ]);
         }
 
         $this->tpl->setContent($form->getHTML());
@@ -695,15 +701,15 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
         global $DIC;
         $ilAccess = $DIC['ilAccess'];
 
-        if (!$ilAccess->checkAccess('write', '', $this->object->getRefId())) {
+        if (!$ilAccess->checkAccess('write', '', $this->getAssessmentFolder()->getRefId())) {
             $this->ilias->raiseError($this->lng->txt("permission_denied"), $this->ilias->error_obj->WARNING);
         }
 
         $form = $this->getLogSettingsForm();
         if ($form->checkInput()) {
-            $this->object->_enableAssessmentLogging((int) $form->getInput('chb_assessment_logging'));
-            $this->object->_setLogLanguage($form->getInput('reporting_language'));
-            $this->object->update();
+            $this->getAssessmentFolder()->_enableAssessmentLogging((bool) $form->getInput('chb_assessment_logging'));
+            $this->getAssessmentFolder()->_setLogLanguage((string) $form->getInput('reporting_language'));
+            $this->getAssessmentFolder()->update();
             $this->tpl->setOnScreenMessage('success', $this->lng->txt('saved_successfully'));
         }
 
@@ -722,7 +728,6 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
         global $DIC;
         $ilAccess = $DIC['ilAccess'];
 
-        require_once 'Services/Form/classes/class.ilPropertyFormGUI.php';
         $form = new ilPropertyFormGUI();
         $form->setFormAction($this->ctrl->getFormAction($this, 'saveLogSettings'));
         $form->setTitle($this->lng->txt('assessment_log_logging'));
@@ -732,17 +737,20 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
         $logging->setOptionTitle($this->lng->txt('activate_assessment_logging'));
         $form->addItem($logging);
 
-        $reporting = new ilSelectInputGUI($this->lng->txt('assessment_settings_reporting_language'), 'reporting_language');
+        $reporting = new ilSelectInputGUI(
+            $this->lng->txt('assessment_settings_reporting_language'),
+            'reporting_language'
+        );
         $languages = $this->lng->getInstalledLanguages();
         $this->lng->loadLanguageModule('meta');
-        $options = array();
+        $options = [];
         foreach ($languages as $lang) {
             $options[$lang] = $this->lng->txt('meta_l_' . $lang);
         }
         $reporting->setOptions($options);
         $form->addItem($reporting);
 
-        if ($ilAccess->checkAccess('write', '', $this->object->getRefId())) {
+        if ($ilAccess->checkAccess('write', '', $this->getAssessmentFolder()->getRefId())) {
             $form->addCommandButton('saveLogSettings', $this->lng->txt('save'));
         }
 
@@ -756,12 +764,11 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
 
         $ilTabs->setTabActive('templates');
 
-        require_once 'Services/Administration/classes/class.ilSettingsTemplateGUI.php';
         $gui = new ilSettingsTemplateGUI(self::getSettingsTemplateConfig());
 
         $this->ctrl->forwardCommand($gui);
     }
-    
+
     /**
      * @return ilTestSettingsTemplateConfig
      */
@@ -770,7 +777,6 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
         global $DIC;
         $lng = $DIC['lng'];
 
-        require_once 'Modules/Test/classes/class.ilTestSettingsTemplateConfig.php';
         $config = new ilTestSettingsTemplateConfig($lng);
         $config->init();
 

--- a/Modules/Test/classes/tables/class.ilAssessmentFolderLogAdministrationTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilAssessmentFolderLogAdministrationTableGUI.php
@@ -1,20 +1,28 @@
-<?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
-
-
-include_once('./Services/Table/classes/class.ilTable2GUI.php');
+<?php declare(strict_types=1);
 
 /**
-*
-* @author Helmut Schottmüller <ilias@aurealis.de>
-* @version $Id$
-*
-* @ingroup ModulesTest
-*/
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
+/**
+ * @author Helmut Schottmüller <ilias@aurealis.de>
+ * @ingroup ModulesTest
+ */
 class ilAssessmentFolderLogAdministrationTableGUI extends ilTable2GUI
 {
-    public function __construct($a_parent_obj, $a_parent_cmd, $a_write_access = false)
+    public function __construct(ilObjAssessmentFolderGUI $a_parent_obj, string $a_parent_cmd, bool $a_write_access = false)
     {
         parent::__construct($a_parent_obj, $a_parent_cmd);
 
@@ -43,23 +51,16 @@ class ilAssessmentFolderLogAdministrationTableGUI extends ilTable2GUI
             $this->enable('select_all');
         }
 
-        //$this->numericOrdering('nr');
         $this->setDefaultOrderField("title");
         $this->setDefaultOrderDirection("asc");
-        
+
         $this->setPrefix('chb_test');
-        
+
         $this->enable('header');
         $this->enable('sort');
     }
 
-    /**
-     * fill row
-     * @access public
-     * @param
-     * @return void
-     */
-    public function fillRow(array $a_set) : void
+    protected function fillRow(array $a_set) : void
     {
         $this->tpl->setVariable("TITLE", ilLegacyFormElementsUtil::prepareFormOutput($a_set['title']));
         $this->tpl->setVariable("NR", $a_set['nr']);
@@ -68,11 +69,8 @@ class ilAssessmentFolderLogAdministrationTableGUI extends ilTable2GUI
         $this->tpl->setVariable("LOCATION_TXT", $a_set['location_txt']);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function numericOrdering(string $a_field) : bool
     {
-        return 'nr' == $a_field;
+        return 'nr' === $a_field;
     }
 }

--- a/Modules/Test/classes/tables/class.ilAssessmentFolderLogTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilAssessmentFolderLogTableGUI.php
@@ -1,20 +1,28 @@
-<?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
-
-
-include_once('./Services/Table/classes/class.ilTable2GUI.php');
+<?php declare(strict_types=1);
 
 /**
-*
-* @author Helmut Schottmüller <ilias@aurealis.de>
-* @version $Id$
-*
-* @ingroup ModulesTest
-*/
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
+/**
+ * @author Helmut Schottmüller <ilias@aurealis.de>
+ * @ingroup ModulesTest
+ */
 class ilAssessmentFolderLogTableGUI extends ilTable2GUI
 {
-    public function __construct($a_parent_obj, $a_parent_cmd)
+    public function __construct(ilObjAssessmentFolderGUI $a_parent_obj, string $a_parent_cmd)
     {
         parent::__construct($a_parent_obj, $a_parent_cmd);
 
@@ -32,41 +40,44 @@ class ilAssessmentFolderLogTableGUI extends ilTable2GUI
         $this->addColumn($this->lng->txt("user"), 'user', '20%');
         $this->addColumn($this->lng->txt("assessment_log_text"), 'message', '50%');
         $this->addColumn($this->lng->txt("ass_location"), '', '20%');
-    
+
         $this->setRowTemplate("tpl.il_as_tst_assessment_log_row.html", "Modules/Test");
 
         $this->setFormAction($this->ctrl->getFormAction($a_parent_obj, $a_parent_cmd));
 
         $this->setDefaultOrderField("date");
         $this->setDefaultOrderDirection("asc");
-        
+
         $this->enable('header');
         $this->enable('sort');
         $this->disable('select_all');
     }
 
-    public function fillRow(array $a_set) : void
+    protected function fillRow(array $a_set) : void
     {
-        $this->tpl->setVariable("DATE", ilDatePresentation::formatDate(new ilDateTime($a_set['tstamp'], IL_CAL_UNIX)));
-        $user = ilObjUser::_lookupName($a_set["user_fi"]);
+        $this->tpl->setVariable("DATE", ilDatePresentation::formatDate(new ilDateTime((int) $a_set['tstamp'], IL_CAL_UNIX)));
+        $user = ilObjUser::_lookupName((int) $a_set["user_fi"]);
         $this->tpl->setVariable(
             "USER",
             ilLegacyFormElementsUtil::prepareFormOutput(
                 trim($user["title"] . " " . $user["firstname"] . " " . $user["lastname"])
             )
         );
+
         $title = "";
         if ($a_set["question_fi"] || $a_set["original_fi"]) {
-            include_once "./Modules/TestQuestionPool/classes/class.assQuestion.php";
-            $title = assQuestion::_getQuestionTitle($a_set["question_fi"]);
-            if (strlen($title) == 0) {
-                $title = assQuestion::_getQuestionTitle($a_set["original_fi"]);
+            $title = assQuestion::_getQuestionTitle((int) $a_set["question_fi"]);
+            if ($title === '') {
+                $title = assQuestion::_getQuestionTitle((int) $a_set["original_fi"]);
             }
             $title = $this->lng->txt("assessment_log_question") . ": " . $title;
         }
-        $this->tpl->setVariable("MESSAGE", ilLegacyFormElementsUtil::prepareFormOutput($a_set['logtext']) . ((strlen($title)) ?  " (" . $title . ")" : ''));
+        $this->tpl->setVariable(
+            "MESSAGE",
+            ilLegacyFormElementsUtil::prepareFormOutput($a_set['logtext']) . (($title !== '') ? " (" . $title . ")" : '')
+        );
 
-        if (strlen($a_set['location_href']) > 0 && strlen($a_set['location_txt']) > 0) {
+        if ($a_set['location_href'] !== '' && $a_set['location_txt'] !== '') {
             $this->tpl->setVariable("LOCATION_HREF", $a_set['location_href']);
             $this->tpl->setVariable("LOCATION_TXT", $a_set['location_txt']);
         }

--- a/Modules/Test/test/tables/ilAssessmentFolderLogAdministrationTableGUITest.php
+++ b/Modules/Test/test/tables/ilAssessmentFolderLogAdministrationTableGUITest.php
@@ -9,7 +9,7 @@
 class ilAssessmentFolderLogAdministrationTableGUITest extends ilTestBaseTestCase
 {
     private ilAssessmentFolderLogAdministrationTableGUI $tableGui;
-    private ilObjTestGUI $parentObj_mock;
+    private ilObjAssessmentFolderGUI $parentObj_mock;
 
     protected function setUp() : void
     {
@@ -17,7 +17,7 @@ class ilAssessmentFolderLogAdministrationTableGUITest extends ilTestBaseTestCase
 
         $lng_mock = $this->createMock(ilLanguage::class);
         $ctrl_mock = $this->createMock(ilCtrl::class);
-        $ctrl_mock->expects($this->any())
+        $ctrl_mock
                   ->method("getFormAction")
                   ->willReturnCallback(function () {
                       return "testFormAction";
@@ -32,8 +32,8 @@ class ilAssessmentFolderLogAdministrationTableGUITest extends ilTestBaseTestCase
         $this->setGlobalVariable("component.factory", $component_factory);
         $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
-        $this->parentObj_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();
-        $this->parentObj_mock->expects($this->any())->method('getObject')->willReturn($this->createMock(ilObjTest::class));
+        $this->parentObj_mock = $this->getMockBuilder(ilObjAssessmentFolderGUI::class)->disableOriginalConstructor()->onlyMethods(['getObject'])->getMock();
+        $this->parentObj_mock->method('getObject')->willReturn($this->createMock(ilObjTest::class));
 
         $this->tableGui = new ilAssessmentFolderLogAdministrationTableGUI($this->parentObj_mock, "");
     }

--- a/Modules/Test/test/tables/ilAssessmentFolderLogTableGUITest.php
+++ b/Modules/Test/test/tables/ilAssessmentFolderLogTableGUITest.php
@@ -9,7 +9,7 @@
 class ilAssessmentFolderLogTableGUITest extends ilTestBaseTestCase
 {
     private ilAssessmentFolderLogTableGUI $tableGui;
-    private ilObjTestGUI $parentObj_mock;
+    private ilObjAssessmentFolderGUI $parentObj_mock;
 
     protected function setUp() : void
     {
@@ -17,7 +17,7 @@ class ilAssessmentFolderLogTableGUITest extends ilTestBaseTestCase
 
         $lng_mock = $this->createMock(ilLanguage::class);
         $ctrl_mock = $this->createMock(ilCtrl::class);
-        $ctrl_mock->expects($this->any())
+        $ctrl_mock
                   ->method("getFormAction")
                   ->willReturnCallback(function () {
                       return "testFormAction";
@@ -33,8 +33,8 @@ class ilAssessmentFolderLogTableGUITest extends ilTestBaseTestCase
         $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
-        $this->parentObj_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();
-        $this->parentObj_mock->expects($this->any())->method('getObject')->willReturn($this->createMock(ilObjTest::class));
+        $this->parentObj_mock = $this->getMockBuilder(ilObjAssessmentFolderGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();
+        $this->parentObj_mock->method('getObject')->willReturn($this->createMock(ilObjTest::class));
         $this->tableGui = new ilAssessmentFolderLogTableGUI($this->parentObj_mock, "");
     }
 

--- a/Modules/TestQuestionPool/classes/class.assTextQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assTextQuestion.php
@@ -813,7 +813,7 @@ class assTextQuestion extends assQuestion implements ilObjQuestionScoringAdjusta
         $assessment_folder = new ilObjAssessmentFolder();
 
         $string_escaping_org_value = $worksheet->getStringEscaping();
-        if ($assessment_folder->getExportEssayQuestionsWithHtml() == 1) {
+        if ($assessment_folder->getExportEssayQuestionsWithHtml()) {
             $worksheet->setStringEscaping(false);
         }
 


### PR DESCRIPTION
This PR enhances the PHP types used in the global `Test Administration`.

@mbecker-databay There is still an issue with calling `protected` methods of `\ILIAS\Repository\BaseGUIRequest`.