### PR TITLE
T&A fix for 32522

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
@@ -690,9 +690,12 @@ class assFormulaQuestionGUI extends assQuestionGUI
                         $custom_errors = true;
                     }
                     $intPrecision = $form->getItemByPostVar('intprecision_' . $variable->getVariable());
-                    if ($intPrecision->getValue() > $max_range->getValue()) {
-                        $intPrecision->setAlert($this->lng->txt('err_division'));
-                        $custom_errors = true;
+                    $decimal_spots = $form->getItemByPostVar('precision_' . $variable->getVariable());
+                    if ($decimal_spots->getValue() == 0) {
+                        if ($intPrecision->getValue() > $max_range->getValue()) {
+                            $intPrecision->setAlert($this->lng->txt('err_division'));
+                            $custom_errors = true;
+                        }
                     }
                 }
             }

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionVariable.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionVariable.php
@@ -47,10 +47,12 @@ class assFormulaQuestionVariable
     {
         
 //		@todo check this
-        if ($this->getIntprecision() > $this->getRangeMax()){
-            global $DIC;
-            $lng = $DIC['lng'];
-            ilUtil::sendFailure($lng->txt('err_divider_too_big'));
+        if ($this->getPrecision() == 0) {
+            if ($this->getIntprecision() > $this->getRangeMax()) {
+                global $DIC;
+                $lng = $DIC['lng'];
+                ilUtil::sendFailure($lng->txt('err_divider_too_big'));
+            }
         }
         
         include_once "./Services/Math/classes/class.ilMath.php";


### PR DESCRIPTION
Fixes the following Issue:
https://mantis.ilias.de/view.php?id=32522
checks if user wants to use decimal-spots. If the user wants the variable to have decimal spots, the divisibilty no longer matters and there is no need to check if there is a valid input for "Divisible by"