### PR TITLE
bottom safe area inset for mainbar on mobile 32458

### DIFF
--- a/src/UI/templates/default/Layout/standardpage.less
+++ b/src/UI/templates/default/Layout/standardpage.less
@@ -342,7 +342,8 @@ footer {
 				-ms-grid-columns: 1fr;
 				grid-template-columns: 1fr;
 				-ms-grid-rows: 0 @il-standard-page-small-mainbar-height;
-				grid-template-rows: 0 @il-standard-page-small-mainbar-height;
+				grid-template-rows: 0 @il-standard-page-small-mainbar-height; // for browsers not supporting env()
+				grid-template-rows: 0 @il-standard-page-small-mainbar-height-w-bottom-safe-area;
 
 				.il-mainbar-close-slates {
 					display: none;
@@ -375,7 +376,8 @@ footer {
 					-ms-grid-columns: 1fr;
 				    grid-template-columns: 1fr;
 					-ms-grid-rows: 1fr @il-standard-page-small-mainbar-height;
-				    grid-template-rows: 1fr @il-standard-page-small-mainbar-height;
+					grid-template-rows: 1fr @il-standard-page-small-mainbar-height; // for browsers not supporting env()
+					grid-template-rows: 1fr @il-standard-page-small-mainbar-height-w-bottom-safe-area;
 					width: 100%;
 					.il-mainbar {
 						.shadow-top();
@@ -499,7 +501,8 @@ footer {
 		box-shadow: none;
 		display: -ms-flexbox;
 		display: flex;
-		max-height: @il-mainbar-small-btn-height;
+		max-height: @il-standard-page-small-mainbar-height; // for browsers not supporting env()
+		max-height: @il-standard-page-small-mainbar-height-w-bottom-safe-area;
 		overflow: hidden;
 		z-index: @il-standard-page-zindex-mainbar;
 	}

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -9311,6 +9311,7 @@ footer {
     grid-template-columns: 1fr;
     -ms-grid-rows: 0 50px;
     grid-template-rows: 0 50px;
+    grid-template-rows: 0 calc(50px + 1.2 * env(safe-area-inset-bottom));
   }
   .il-layout-page .nav.il-maincontrols .il-maincontrols-mainbar .il-mainbar-close-slates {
     display: none;
@@ -9344,6 +9345,7 @@ footer {
     grid-template-columns: 1fr;
     -ms-grid-rows: 1fr 50px;
     grid-template-rows: 1fr 50px;
+    grid-template-rows: 1fr calc(50px + 1.2 * env(safe-area-inset-bottom));
     width: 100%;
   }
   .il-layout-page.with-mainbar-slates-engaged .nav.il-maincontrols .il-maincontrols-mainbar .il-mainbar {
@@ -9442,6 +9444,7 @@ footer {
     display: -ms-flexbox;
     display: flex;
     max-height: 50px;
+    max-height: calc(50px + 1.2 * env(safe-area-inset-bottom));
     overflow: hidden;
     z-index: 996;
   }

--- a/templates/default/less/variables.less
+++ b/templates/default/less/variables.less
@@ -230,6 +230,7 @@ with the il- variable set here.
 //** for mobile (small devices)
 @il-standard-page-small-header-height: 45px;
 @il-standard-page-small-mainbar-height: 50px;
+@il-standard-page-small-mainbar-height-w-bottom-safe-area: calc(@il-standard-page-small-mainbar-height + 1.2 * env(safe-area-inset-bottom));
 @il-mainbar-small-btn-height: @il-standard-page-small-mainbar-height;
 @il-mainbar-small-btn-width: 75px;
 @il-metabar-small-entry-height: @il-standard-page-small-header-height;


### PR DESCRIPTION
This PR is addressing this mantis issue: https://mantis.ilias.de/view.php?id=32458

# Issue
Some iOS devices display UI elements on top of the mainbar.

# Change
A mobile device's **bottom safe area inset is now added to the mainbar's height.** This makes room to fit UI Overlays below the mainbar buttons. Read more on user agent environment variables here: https://developer.mozilla.org/en-US/docs/Web/CSS/env

Browsers not supporting env variables should skip this line of CSS code and fall back to the previous line where a fixed height is set preventing an unwanted collapse of the mainbar. Therefore, browser compatibility should remain the same.

# Test Environment
You can see this in action on the test instance previously created for the scroll bug: https://dev.cate-tms.de/ilias7mobile/