### PR TITLE
Setup: implement strict update path

### DIFF
--- a/Modules/DataCollection/classes/class.ilDataCollectionGlobalTemplate.php
+++ b/Modules/DataCollection/classes/class.ilDataCollectionGlobalTemplate.php
@@ -99,7 +99,7 @@ class ilDataCollectionGlobalTemplate implements ilGlobalTemplateInterface
         if (DEVMODE) {
             $php = ", PHP " . phpversion();
         }
-        $ftpl->setVariable("ILIAS_VERSION", $ilSetting->get("ilias_version") . $php);
+        $ftpl->setVariable("ILIAS_VERSION", ILIAS_VERSION . $php);
 
         $link_items = array();
 
@@ -440,7 +440,7 @@ class ilDataCollectionGlobalTemplate implements ilGlobalTemplateInterface
         $ilSetting = $DIC->settings();
 
         if (is_object($ilSetting)) {        // maybe this one can be removed
-            $vers = "vers=" . str_replace(array(".", " "), "-", $ilSetting->get("ilias_version"));
+            $vers = "vers=" . str_replace(array(".", " "), "-", ILIAS_VERSION);
 
             if (DEVMODE) {
                 $vers .= '-' . time();

--- a/Modules/LTIConsumer/classes/class.ilObjLTIConsumer.php
+++ b/Modules/LTIConsumer/classes/class.ilObjLTIConsumer.php
@@ -683,7 +683,7 @@ class ilObjLTIConsumer extends ilObject2
             "tool_consumer_instance_contact_email" => $DIC->settings()->get("admin_email"),
             "launch_presentation_css_url" => "",
             "tool_consumer_info_product_family_code" => "ilias",
-            "tool_consumer_info_version" => $DIC->settings()->get("ilias_version"),
+            "tool_consumer_info_version" => ILIAS_VERSION,
             "lis_result_sourcedid" => $token,
             "lis_outcome_service_url" => ILIAS_HTTP_PATH . "/Modules/LTIConsumer/result.php?client_id=" . CLIENT_ID,
             "role_scope_mentor" => ""

--- a/Modules/SystemFolder/classes/class.ilObjSystemFolderGUI.php
+++ b/Modules/SystemFolder/classes/class.ilObjSystemFolderGUI.php
@@ -1059,7 +1059,7 @@ class ilObjSystemFolderGUI extends ilObjectGUI
         
         // ilias version
         $ne = new ilNonEditableValueGUI($lng->txt("ilias_version"), "");
-        $ne->setValue($ilSetting->get("ilias_version"));
+        $ne->setValue(ILIAS_VERSION);
         $this->form->addItem($ne);
 
         // host

--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -6045,7 +6045,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         $a_xml_writer->xmlStartTag("qtimetadata");
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "ILIAS_VERSION");
-        $a_xml_writer->xmlElement("fieldentry", null, $this->ilias->getSetting("ilias_version"));
+        $a_xml_writer->xmlElement("fieldentry", null, ILIAS_VERSION);
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         // anonymity

--- a/Services/Administration/classes/class.ilSetting.php
+++ b/Services/Administration/classes/class.ilSetting.php
@@ -99,9 +99,6 @@ class ilSetting implements \ILIAS\Administration\Setting
         string $a_keyword,
         ?string $a_default_value = null
     ) : ?string {
-        if ($a_keyword === "ilias_version") {
-            return ILIAS_VERSION;
-        }
         return $this->setting[$a_keyword] ?? $a_default_value;
     }
     

--- a/Services/RTE/classes/class.ilRTEGlobalTemplate.php
+++ b/Services/RTE/classes/class.ilRTEGlobalTemplate.php
@@ -122,7 +122,7 @@ class ilRTEGlobalTemplate implements ilGlobalTemplateInterface
 
         $vers = '';
         if (is_object($ilSetting)) {
-            $vers = 'vers=' . str_replace(['.', ' '], '-', $ilSetting->get('ilias_version', ''));
+            $vers = 'vers=' . str_replace(['.', ' '], '-', ILIAS_VERSION);
 
             if (defined('DEVMODE') && DEVMODE) {
                 $vers .= '-' . time();

--- a/Services/UICore/classes/Screen/PageContentProvider.php
+++ b/Services/UICore/classes/Screen/PageContentProvider.php
@@ -108,7 +108,7 @@ class PageContentProvider extends AbstractModificationProvider
 
             $links = [];
             // ILIAS Version and Text
-            $ilias_version = $this->dic->settings()->get('ilias_version');
+            $ilias_version = ILIAS_VERSION;
             $text = "powered by ILIAS (v{$ilias_version})";
 
             // Imprint

--- a/Services/UICore/classes/class.ilGlobalTemplate.php
+++ b/Services/UICore/classes/class.ilGlobalTemplate.php
@@ -144,7 +144,7 @@ class ilGlobalTemplate implements ilGlobalTemplateInterface
         if (DEVMODE) {
             $php = ", PHP " . PHP_VERSION;
         }
-        $ftpl->setVariable("ILIAS_VERSION", $ilSetting->get("ilias_version") . $php);
+        $ftpl->setVariable("ILIAS_VERSION", ILIAS_VERSION . $php);
 
         $link_items = [];
 
@@ -392,7 +392,7 @@ class ilGlobalTemplate implements ilGlobalTemplateInterface
 
         $vers = '';
         if (is_object($ilSetting)) {        // maybe this one can be removed
-            $vers = "vers=" . str_replace([".", " "], "-", $ilSetting->get("ilias_version"));
+            $vers = "vers=" . str_replace([".", " "], "-", ILIAS_VERSION);
 
             if (DEVMODE) {
                 $vers .= '-' . time();

--- a/Services/Utilities/classes/class.ilUtil.php
+++ b/Services/Utilities/classes/class.ilUtil.php
@@ -161,7 +161,7 @@ class ilUtil
         }
         $vers = "";
         if ($mode != "filesystem") {
-            $vers = str_replace(" ", "-", $ilSetting->get("ilias_version"));
+            $vers = str_replace(" ", "-", ILIAS_VERSION);
             $vers = "?vers=" . str_replace(".", "-", $vers);
             // use version from template xml to force reload on changes
             $skin = ilStyleDefinition::getSkins()[ilStyleDefinition::getCurrentSkin()];
@@ -183,7 +183,7 @@ class ilUtil
         
         // add version as parameter to force reload for new releases
         if ($mode != "filesystem") {
-            $vers = str_replace(" ", "-", $ilSetting->get("ilias_version"));
+            $vers = str_replace(" ", "-", ILIAS_VERSION);
             $vers = "?vers=" . str_replace(".", "-", $vers);
         }
         

--- a/setup/classes/class.ilNoMajorVersionSkippedConditionObjective.php
+++ b/setup/classes/class.ilNoMajorVersionSkippedConditionObjective.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\Setup;
+use ILIAS\Data;
+
+class ilNoMajorVersionSkippedConditionObjective implements Setup\Objective
+{
+    protected Data\Factory $data_factory;
+
+    public function __construct(Data\Factory $data_factory)
+    {
+        $this->data_factory = $data_factory;
+    }
+
+    public function getHash() : string
+    {
+        return hash(
+            "sha256",
+            get_class($this)
+        );
+    }
+
+    public function getLabel() : string
+    {
+        return "No major version is skipped in update.";
+    }
+
+    public function isNotable() : bool
+    {
+        return true;
+    }
+
+    public function getPreconditions(Setup\Environment $environment) : array
+    {
+        return [
+            new ilSettingsFactoryExistsObjective()
+        ];
+    }
+
+    public function achieve(Setup\Environment $environment) : Setup\Environment
+    {
+        $factory = $environment->getResource(Setup\Environment::RESOURCE_SETTINGS_FACTORY);
+        $settings = $factory->settingsFor("common");
+
+        // TODO ILIAS 9: This special case can vanish with ILIAS 9. It exists to make sure that
+        // installations on version 7.0 or greater can update to ILIAS 8. This is checked by
+        // looking into the version string (which is only updated starting with 8 and had a
+        // very old value previously) and the db_version (which is 5751 with ILIAS 7.0).
+        $current_version_string = $settings->get(ilVersionWrittenToSettingsObjective::ILIAS_VERSION_KEY);
+        if ($current_version_string === "3.2.3 2004-11-22" && (int) $settings->get("db_version") >= 5751) {
+            return $environment;
+        }
+
+        $current_version = $this->data_factory->version($current_version_string);
+        $target_version = $this->data_factory->version(ILIAS_VERSION_NUMERIC);
+
+        if (($target_version->getMajor() - $current_version->getMajor()) > 1) {
+            throw new Setup\NotExecutableException(
+                "Updates may only be performed from one major version to the " .
+                "next, no major versions may be skipped."
+            );
+        }
+
+        return $environment;
+    }
+
+    public function isApplicable(Setup\Environment $environment) : bool
+    {
+        return true;
+    }
+}

--- a/setup/classes/class.ilNoVersionDowngradeConditionObjective.php
+++ b/setup/classes/class.ilNoVersionDowngradeConditionObjective.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\Setup;
+use ILIAS\Data;
+
+class ilNoVersionDowngradeConditionObjective implements Setup\Objective
+{
+    protected Data\Factory $data_factory;
+
+    public function __construct(Data\Factory $data_factory)
+    {
+        $this->data_factory = $data_factory;
+    }
+
+    public function getHash() : string
+    {
+        return hash(
+            "sha256",
+            get_class($this)
+        );
+    }
+
+    public function getLabel() : string
+    {
+        return "No downgrade is performed.";
+    }
+
+    public function isNotable() : bool
+    {
+        return true;
+    }
+
+    public function getPreconditions(Setup\Environment $environment) : array
+    {
+        return [
+            new ilSettingsFactoryExistsObjective()
+        ];
+    }
+
+    public function achieve(Setup\Environment $environment) : Setup\Environment
+    {
+        $factory = $environment->getResource(Setup\Environment::RESOURCE_SETTINGS_FACTORY);
+        $settings = $factory->settingsFor("common");
+
+        $current_version = $this->data_factory->version($settings->get(ilVersionWrittenToSettingsObjective::ILIAS_VERSION_KEY));
+        $target_version = $this->data_factory->version(ILIAS_VERSION_NUMERIC);
+
+        if ($target_version->isSmallerThan($current_version)) {
+            throw new Setup\NotExecutableException(
+                "Downgrades of versions may not be performed, you are running " .
+                "$current_version and target $target_version"
+            );
+        }
+
+        return $environment;
+    }
+
+    public function isApplicable(Setup\Environment $environment) : bool
+    {
+        return true;
+    }
+}

--- a/setup/classes/class.ilSetupAgent.php
+++ b/setup/classes/class.ilSetupAgent.php
@@ -102,10 +102,22 @@ class ilSetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
+        $objectives = [
+            new Setup\Objective\ObjectiveWithPreconditions(
+                new ilVersionWrittenToSettingsObjective($this->data),
+                new ilNoMajorVersionSkippedConditionObjective($this->data),
+                new ilNoVersionDowngradeConditionObjective($this->data)
+            )
+        ];
         if ($config !== null) {
-            return new ilSetupConfigStoredObjective($config);
+            $objectives[] = new ilSetupConfigStoredObjective($config);
         }
-        return new Setup\Objective\NullObjective();
+
+        return new Setup\ObjectiveCollection(
+            "Complete common ILIAS objectives.",
+            false,
+            ...$objectives
+        );
     }
 
     /**

--- a/setup/classes/class.ilVersionWrittenToSettingsObjective.php
+++ b/setup/classes/class.ilVersionWrittenToSettingsObjective.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\Setup;
+use ILIAS\Data;
+
+class ilVersionWrittenToSettingsObjective implements Setup\Objective
+{
+    public const ILIAS_VERSION_KEY = "ilias_version";
+
+    protected Data\Factory $data_factory;
+
+    public function __construct(Data\Factory $data_factory)
+    {
+        $this->data_factory = $data_factory;
+    }
+
+    public function getHash() : string
+    {
+        return hash(
+            "sha256",
+            get_class($this)
+        );
+    }
+
+    public function getLabel() : string
+    {
+        return "The ILIAS Version is written to the settings.";
+    }
+
+    public function isNotable() : bool
+    {
+        return true;
+    }
+
+    public function getPreconditions(Setup\Environment $environment) : array
+    {
+        return [
+            new ilSettingsFactoryExistsObjective()
+        ];
+    }
+
+    public function achieve(Setup\Environment $environment) : Setup\Environment
+    {
+        $factory = $environment->getResource(Setup\Environment::RESOURCE_SETTINGS_FACTORY);
+        $settings = $factory->settingsFor("common");
+
+        $current_version = $this->data_factory->version(ILIAS_VERSION_NUMERIC);
+        $settings->set(self::ILIAS_VERSION_KEY, (string) $current_version);
+
+        return $environment;
+    }
+
+    public function isApplicable(Setup\Environment $environment) : bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
Hi everyone,

just want to announce these changes to implement [strict update paths for the setup](https://docu.ilias.de/goto_docu_wiki_wpage_6911_1357.html).

The major changes are:
1. `ilSettings` will return the value for `common/ilias_version` from the database instead of ignoring the database and just returning a constant. The locations using `common/ilias_version` from `ilSettings` have been changed to directly use the constant to maintain their current behaviour.
2. The setup now blocks downgrades and updates that skip a major version, based on the version of the code from the aforementioned constant and the installed ILIAS version from `common/ilias_version`. The latter will be updated by the setup as of this PR.

The changes described in 1 could also be used to match `common/ilias_version` from the database with the version announced by the code to prevent the execution of the system when database and code don't match. Maybe this is something for `Services/Init` (@pascalseeland)

I kindly ask @alex40724 as current maintainer of `Services/Administration` to look into the change in `ilSettings`.

Best regards!

**EDIT**: The previous info that developers might manually update their db was removed. @chfsx had the aweseome idea to use the db_version as marker for the ILIAS version, so we can make sure that people only upgrade to ILIAS 8 from ILIAS 7, even if the version in the database indicates we are on ILIAS 3.4. Thanks!