### PR TITLE
UI: Large Dropzones

### DIFF
--- a/src/UI/Component/Dropzone/File/Standard.php
+++ b/src/UI/Component/Dropzone/File/Standard.php
@@ -47,4 +47,8 @@ interface Standard extends File
      * Get the button to upload the files to the server.
      */
     public function getUploadButton() : ?Button;
+    
+    public function withLargeZone() : Standard;
+    
+    public function withSmallZone() : Standard;
 }

--- a/src/UI/Implementation/Component/Dropzone/File/Renderer.php
+++ b/src/UI/Implementation/Component/Dropzone/File/Renderer.php
@@ -79,10 +79,21 @@ class Renderer extends AbstractComponentRenderer
             $dropzone->getTitle(),
             [$dropzone->getForm()]
         );
-
-        $template = $this->getTemplate("tpl.dropzone.html", true, true);
+    
+        switch ($dropzone->getSize()) {
+            case Standard::SIZE_SMALL:
+            default:
+                $additional_class = 'ui-dropzone-small';
+                break;
+            case Standard::SIZE_LARGE:
+                $additional_class = 'ui-dropzone-large';
+        }
+        $template_file = "tpl.dropzone.html";
+        
+        $template = $this->getTemplate($template_file, true, true);
         $template->setVariable('MODAL', $default_renderer->render($modal));
         $template->setVariable('MESSAGE', $dropzone->getMessage());
+        $template->setVariable('DROPZONE_SIZE_CLASS', $additional_class);
 
         $upload_button = $dropzone->getUploadButton();
         if (null !== $upload_button) {

--- a/src/UI/Implementation/Component/Dropzone/File/Standard.php
+++ b/src/UI/Implementation/Component/Dropzone/File/Standard.php
@@ -32,8 +32,11 @@ use ilLanguage;
  */
 class Standard extends File implements StandardInterface
 {
+    const SIZE_SMALL = 16;
+    const SIZE_LARGE = 32;
     protected string $message = "";
     protected ?Button $upload_button = null;
+    protected int $size = self::SIZE_SMALL;
 
     public function withMessage(string $message) : self
     {
@@ -57,5 +60,24 @@ class Standard extends File implements StandardInterface
     public function getUploadButton() : ?Button
     {
         return $this->upload_button;
+    }
+    
+    public function withLargeZone() : Standard
+    {
+        $clone = clone $this;
+        $clone->size = self::SIZE_LARGE;
+        return $clone;
+    }
+    
+    public function withSmallZone() : Standard
+    {
+        $clone = clone $this;
+        $clone->size = self::SIZE_SMALL;
+        return $clone;
+    }
+    
+    public function getSize() : int
+    {
+        return $this->size;
     }
 }

--- a/src/UI/examples/Dropzone/File/Standard/large.php
+++ b/src/UI/examples/Dropzone/File/Standard/large.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Dropzone\File\Standard;
+
+function large()
+{
+    global $DIC;
+
+    $factory = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+    $dropzone = $factory
+        ->dropzone()->file()->standard(
+            (new \ilUIAsyncDemoFileUploadHandlerGUI()),
+            '#'
+        )
+        ->withLargeZone()
+        ->withUploadButton(
+            $factory->button()->shy('Upload files', '#')
+        )
+        ->withMessage('Drag files in here to upload them!')
+        ->withTitle('Upload your files here');
+
+    return $renderer->render($dropzone);
+}

--- a/src/UI/templates/default/Dropzone/dropzone.less
+++ b/src/UI/templates/default/Dropzone/dropzone.less
@@ -7,30 +7,34 @@
 	margin-bottom: @il-margin-xs-horizontal;
 	padding: @il-margin-base-vertical;
 	width: 100%;
-}
-
-.ui-dropzone-wrapper {
-	background: none;
-	border: none;
+    .btn {
+      padding: revert;
+    }
 }
 
 .ui-dropzone.highlight {
 	border: @il-dropzone-border-width @il-dropzone-border-style @il-dropzone-border-color;
-	border-radius: @il-dropzone-border-radius;
 	background: @il-dropzone-highlight-bg;
-	padding: calc(@il-padding-base-vertical - @il-dropzone-border-width);
 }
 
 .ui-dropzone.highlight-current {
 	border: @il-dropzone-border-width @il-dropzone-border-style @il-dropzone-border-color-hover;
 	background-color: @il-dropzone-hover-bg;
-	padding: calc(@il-padding-base-vertical - @il-dropzone-border-width);
 }
 
 .ui-dropzone-message {
 	font-size: @il-font-size-base;
 	margin-bottom: @il-margin-base-vertical;
 	float: right;
+}
+
+.ui-dropzone-wrapper {
+  background: none;
+  border: none;
+
+  &.highlight {
+    padding: calc(@il-padding-base-vertical - @il-dropzone-border-width);
+  }
 }
 
 .ui-dropzone-container button {
@@ -45,4 +49,25 @@
 .ui-dropzone .form-group input,
 .ui-dropzone .form-group textarea {
 	width: 100%;
+}
+
+.ui-dropzone-large {
+  background-color: @il-dropzone-large-bg;
+  border-radius: @il-dropzone-large-border-radius;
+  border-width: @il-dropzone-large-border-width;
+
+  .ui-dropzone-container {
+    text-align: center;
+    padding: @il-dropzone-large-padding;
+    .btn, .ui-dropzone-message {
+      margin: auto;
+      display: block;
+      clear: both;
+      float: inherit;
+    }
+  }
+}
+
+.ui-dropzone-large.highlight {
+  border-width: @il-dropzone-large-border-width;
 }

--- a/src/UI/templates/default/Dropzone/tpl.dropzone.html
+++ b/src/UI/templates/default/Dropzone/tpl.dropzone.html
@@ -1,4 +1,4 @@
-<div id="{ID}" class="ui-dropzone {WRAPPER_CLASS}">
+<div id="{ID}" class="ui-dropzone {DROPZONE_SIZE_CLASS} {WRAPPER_CLASS}">
     {MODAL}
     <div class="ui-dropzone-container">
         <span class="ui-dropzone-message">{MESSAGE}</span>

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -7272,25 +7272,28 @@ button.list-group-item-danger.active:focus {
   padding: 3px;
   width: 100%;
 }
-.ui-dropzone-wrapper {
-  background: none;
-  border: none;
+.ui-dropzone .btn {
+  padding: revert;
 }
 .ui-dropzone.highlight {
   border: 1px dashed #757575;
-  border-radius: 0px;
   background: #FFFFD6;
-  padding: calc(3px - 1px);
 }
 .ui-dropzone.highlight-current {
   border: 1px dashed #5b5b5b;
   background-color: #FFF9BC;
-  padding: calc(3px - 1px);
 }
 .ui-dropzone-message {
   font-size: 0.875rem;
   margin-bottom: 3px;
   float: right;
+}
+.ui-dropzone-wrapper {
+  background: none;
+  border: none;
+}
+.ui-dropzone-wrapper.highlight {
+  padding: calc(3px - 1px);
 }
 .ui-dropzone-container button {
   font-size: 0.875rem;
@@ -7301,6 +7304,25 @@ button.list-group-item-danger.active:focus {
 .ui-dropzone .form-group input,
 .ui-dropzone .form-group textarea {
   width: 100%;
+}
+.ui-dropzone-large {
+  background-color: #ffff5;
+  border-radius: 0px;
+  border-width: 2px;
+}
+.ui-dropzone-large .ui-dropzone-container {
+  text-align: center;
+  padding: 6rem;
+}
+.ui-dropzone-large .ui-dropzone-container .btn,
+.ui-dropzone-large .ui-dropzone-container .ui-dropzone-message {
+  margin: auto;
+  display: block;
+  clear: both;
+  float: inherit;
+}
+.ui-dropzone-large.highlight {
+  border-width: 2px;
 }
 .btn {
   font-size: 0.75rem;

--- a/templates/default/less/variables.less
+++ b/templates/default/less/variables.less
@@ -555,7 +555,11 @@ with the il- variable set here.
 @il-dropzone-filelist-border-type: solid;
 @il-dropzone-filelist-border-width: @il-dropzone-border-width;
 @il-dropzone-filelist-border-radius: @il-dropzone-border-radius;
-
+//** Large Dropzone
+@il-dropzone-large-padding: 6rem;
+@il-dropzone-large-bg: #ffff5;
+@il-dropzone-large-border-width: @il-dropzone-border-width * 2;
+@il-dropzone-large-border-radius: 0px;
 
 //== Popover
 //

--- a/tests/UI/Component/Dropzone/File/StandardTest.php
+++ b/tests/UI/Component/Dropzone/File/StandardTest.php
@@ -12,7 +12,7 @@ class StandardTest extends FileTestBase
     public function testRenderStandard() : void
     {
         $expected_html = $this->brutallyTrimHTML('
-            <div id="id_5" class="ui-dropzone ">
+            <div id="id_5" class="ui-dropzone ui-dropzone-small ">
                 <div class="modal fade il-modal-roundtrip" tabindex="-1" role="dialog" id="id_1">
                     <div class="modal-dialog" role="document" data-replace-marker="component">
                         <div class="modal-content">
@@ -49,12 +49,57 @@ class StandardTest extends FileTestBase
         );
 
         $this->assertEquals($expected_html, $this->getDropzoneHtml($dropzone));
+    
+        $dropzone = $dropzone->withSmallZone();
+        $this->assertEquals($expected_html, $this->getDropzoneHtml($dropzone));
+    }
+    
+    public function testRenderStandardLarge() : void
+    {
+        $expected_html = $this->brutallyTrimHTML('
+            <div id="id_5" class="ui-dropzone ui-dropzone-large ">
+                <div class="modal fade il-modal-roundtrip" tabindex="-1" role="dialog" id="id_1">
+                    <div class="modal-dialog" role="document" data-replace-marker="component">
+                        <div class="modal-content">
+                            <div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button><span class="modal-title"></span></div>
+                            <div class="modal-body">
+                                <form role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" action="#" method="post" novalidate="novalidate">
+                                    <div class="il-standard-form-header clearfix">
+                                        <div class="il-standard-form-cmd"><button class="btn btn-default" data-action="">save</button></div>
+                                    </div>
+                                    <div class="form-group row"><label for="id_4" class="control-label col-sm-3"></label>
+                                        <div class="col-sm-9">
+                                            <div id="id_4" class="ui-input-file">
+                                                <div class="ui-input-file-input-list ui-input-dynamic-inputs-list"></div>
+                                                <div class="ui-input-file-input-dropzone"><button class="btn btn-link" data-action="#" id="id_3">select_files_from_computer</button><span class="ui-input-file-input-error-msg" data-dz-error-msg></span></div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="il-standard-form-footer clearfix">
+                                        <div class="il-standard-form-cmd"><button class="btn btn-default" data-action="">save</button></div>
+                                    </div>
+                                </form>
+                            </div>
+                            <div class="modal-footer"><button class="btn btn-default" data-dismiss="modal" aria-label="Close">cancel</button></div>
+                        </div>
+                    </div>
+                </div>
+                <div class="ui-dropzone-container"><span class="ui-dropzone-message"></span></div>
+            </div>
+        ');
+        
+        $dropzone = $this->factory->standard(
+            $this->getUploadHandlerMock(),
+            '#'
+        )->withLargeZone();
+        
+        $this->assertEquals($expected_html, $this->getDropzoneHtml($dropzone));
     }
 
     public function testRenderStandardWithUploadButton() : void
     {
         $expected_html = $this->brutallyTrimHTML('
-            <div id="id_6" class="ui-dropzone ">
+            <div id="id_6" class="ui-dropzone ui-dropzone-small ">
                 <div class="modal fade il-modal-roundtrip" tabindex="-1" role="dialog" id="id_1">
                     <div class="modal-dialog" role="document" data-replace-marker="component">
                         <div class="modal-content">
@@ -98,7 +143,7 @@ class StandardTest extends FileTestBase
     public function testRenderStandardWithMetadata() : void
     {
         $expected_html = $this->brutallyTrimHTML('
-            <div id="id_6" class="ui-dropzone ">
+            <div id="id_6" class="ui-dropzone ui-dropzone-small ">
                 <div class="modal fade il-modal-roundtrip" tabindex="-1" role="dialog" id="id_1">
                     <div class="modal-dialog" role="document" data-replace-marker="component">
                         <div class="modal-content">
@@ -141,7 +186,7 @@ class StandardTest extends FileTestBase
     public function testRenderStandardWithMessage() : void
     {
         $expected_html = $this->brutallyTrimHTML('
-            <div id="id_5" class="ui-dropzone ">
+            <div id="id_5" class="ui-dropzone ui-dropzone-small ">
                 <div class="modal fade il-modal-roundtrip" tabindex="-1" role="dialog" id="id_1">
                     <div class="modal-dialog" role="document" data-replace-marker="component">
                         <div class="modal-content">
@@ -183,7 +228,7 @@ class StandardTest extends FileTestBase
     public function testRenderStandardWithTitle() : void
     {
         $expected_html = $this->brutallyTrimHTML('
-            <div id="id_5" class="ui-dropzone ">
+            <div id="id_5" class="ui-dropzone ui-dropzone-small ">
                 <div class="modal fade il-modal-roundtrip" tabindex="-1" role="dialog" id="id_1">
                     <div class="modal-dialog" role="document" data-replace-marker="component">
                         <div class="modal-content">


### PR DESCRIPTION
@klees / @Amstutz we currently have defined "larger" dropzone for files, only the small one. We currently refactor some locations which uses a legacy forminput (see e.g. #4479) which could replaced with a large dropbox instead of a UI\Input.

A large Dropzone would look like this:
![Bildschirmfoto 2022-05-05 um 08 34 05](https://user-images.githubusercontent.com/6661332/166874162-6a9a5058-7cbb-474e-8759-e012688dca0b.png)

