### PR TITLE
#27113: Scoring by Question allows manual scoring of unanswered quest…

### DIFF
--- a/Modules/Test/classes/class.ilTestScoringByQuestionsGUI.php
+++ b/Modules/Test/classes/class.ilTestScoringByQuestionsGUI.php
@@ -82,6 +82,7 @@ class ilTestScoringByQuestionsGUI extends ilTestScoringGUI
         $qst_id = $table->getFilterItemByPostVar('question')->getValue();
         $passNr = $table->getFilterItemByPostVar('pass')->getValue();
         $finalized_filter = $table->getFilterItemByPostVar('finalize_evaluation')->getValue();
+        $answered_filter = $table->getFilterItemByPostVar('only_answered')->getChecked();
         $table_data = [];
         $selected_questionData = null;
         $complete_feedback = $this->object->getCompleteManualFeedback($qst_id);
@@ -120,10 +121,13 @@ class ilTestScoringByQuestionsGUI extends ilTestScoringGUI
                         ($finalized_filter != self::ONLY_FINALIZED || $feedback['finalized_evaluation'] == 1) &&
                         ($finalized_filter != self::EXCEPT_FINALIZED || $feedback['finalized_evaluation'] != 1);
 
+                    $check_answered = ($answered_filter == false || $questionData['answered']);
+
                     if (
                         isset($questionData['qid']) &&
                         $questionData['qid'] == $selected_questionData['question_id'] &&
-                        $check_filter
+                        $check_filter &&
+                        $check_answered
                     ) {
                         $table_data[] = [
                             'pass_id' => $passNr - 1,

--- a/Modules/Test/classes/tables/class.ilTestManScoringParticipantsBySelectedQuestionAndPassTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilTestManScoringParticipantsBySelectedQuestionAndPassTableGUI.php
@@ -119,6 +119,12 @@ class ilTestManScoringParticipantsBySelectedQuestionAndPassTableGUI extends ilTa
         $this->addFilterItem($pass);
         $pass->readFromSession();
         $this->filter['pass'] = $pass->getValue();
+
+        $only_answered = new ilCheckboxInputGUI($this->lng->txt('tst_man_scoring_only_answered'),'only_answered');
+        $this->addFilterItem($only_answered);
+        $only_answered->readFromSession();;
+        $this->filter['only_answered'] = $only_answered->getChecked();
+
         $correction = new ilSelectInputGUI(
             $this->lng->txt('finalized_evaluation'),
             'finalize_evaluation'

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -11310,7 +11310,7 @@ ecs#:#ecs_cmap_att_module#:#Modul
 ecs#:#ecs_cmap_att_venue#:#Ort
 assessment#:#tst_man_scoring_by_part#:#Bewertung nach Teilnehmer
 assessment#:#tst_man_scoring_by_qst#:#Bewertung nach Frage
-assessment#:#tst_man_scoring_only_answered#:#Nur beantwortetete
+assessment#:#tst_man_scoring_only_answered#:#Nur beantwortete
 assessment#:#tst_no_scorable_qst_available#:#Keine manuell bewertbare Frage verfügbar
 assessment#:#part_received_a_of_b_points#:#Der Teilnehmer hat %s von %s möglichen Punkten erreicht.
 assessment#:#answers_of#:#Antworten von:

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -11310,6 +11310,7 @@ ecs#:#ecs_cmap_att_module#:#Modul
 ecs#:#ecs_cmap_att_venue#:#Ort
 assessment#:#tst_man_scoring_by_part#:#Bewertung nach Teilnehmer
 assessment#:#tst_man_scoring_by_qst#:#Bewertung nach Frage
+assessment#:#tst_man_scoring_only_answered#:#Nur beantwortetete
 assessment#:#tst_no_scorable_qst_available#:#Keine manuell bewertbare Frage verfügbar
 assessment#:#part_received_a_of_b_points#:#Der Teilnehmer hat %s von %s möglichen Punkten erreicht.
 assessment#:#answers_of#:#Antworten von:

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -11324,6 +11324,7 @@ ecs#:#ecs_cmap_att_module#:#Module
 ecs#:#ecs_cmap_att_venue#:#Venue
 assessment#:#tst_man_scoring_by_part#:#Scoring by Participant
 assessment#:#tst_man_scoring_by_qst#:#Scoring by Question
+assessment#:#tst_man_scoring_only_answered#:#Only answered
 assessment#:#tst_no_scorable_qst_available#:#No question to score available
 assessment#:#part_received_a_of_b_points#:#The participant received %s of %s possible points
 assessment#:#answers_of#:#Answers of:


### PR DESCRIPTION
…ions

Added the checkbox on the "Scoring by Question" screen according to the JF from 7 FEB 2022. The checkbox actually does not filer out questions in die dropdown, but the participants presented for a selected question. This is how a table filter is expected to work.