### PR TITLE
Bugfix0032606: .il_InfoScreenProperty should use @il-text-light-color

### DIFF
--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -17350,7 +17350,7 @@ div.ilInfoScreenSec h2.ilHeader {
 .il_InfoScreenProperty {
   padding: 15px;
   vertical-align: top;
-  color: #737373;
+  color: #6f6f6f;
   font-style: italic;
 }
 .il_InfoScreenPropertyValue {

--- a/templates/default/less/Services/InfoScreen/delos.less
+++ b/templates/default/less/Services/InfoScreen/delos.less
@@ -12,7 +12,7 @@ div.ilInfoScreenSec h2.ilHeader {
 .il_InfoScreenProperty {
 	padding: 15px;
 	vertical-align: top;
-	color: @il-neutral-light-color;
+	color: @il-text-light-color;
 	font-style: italic;
 }
 


### PR DESCRIPTION
Hi @all,

I fixed the color of .il_InfoScreenProperty to further streamline the ILIAS color scheme and to prevent accessibility issues.

See: https://mantis.ilias.de/view.php?id=32606

Greetings, 
Enrico