### PR TITLE
Remove Personal Desktop Sidebar sorting from dashboard

### DIFF
--- a/Modules/Course/classes/class.ilCourseContentGUI.php
+++ b/Modules/Course/classes/class.ilCourseContentGUI.php
@@ -373,12 +373,6 @@ class ilCourseContentGUI
             $column_gui->setEnableEdit(true);
         }
         
-        // Allow movement of blocks for tutors
-        if ($this->is_tutor &&
-            $this->container_gui->isActiveAdministrationPanel()) {
-            $column_gui->setEnableMovement(true);
-        }
-        
         // Configure Settings, if administration panel is on
         if ($this->is_tutor) {
             $column_gui->setBlockProperty("news", "settings", true);

--- a/Services/Block/classes/class.ilBlockSetting.php
+++ b/Services/Block/classes/class.ilBlockSetting.php
@@ -200,17 +200,6 @@ class ilBlockSetting
     }
 
     /**
-    * Lookup number.
-    *
-    */
-    public static function _lookupNr($a_type, $a_user = 0, $a_block_id = 0)
-    {
-        $nr = ilBlockSetting::_lookup($a_type, "nr", $a_user, $a_block_id);
-
-        return $nr;
-    }
-
-    /**
     * Write number to database.
     *
     */

--- a/Services/Block/classes/class.ilColumnGUI.php
+++ b/Services/Block/classes/class.ilColumnGUI.php
@@ -61,8 +61,6 @@ class ilColumnGUI
     protected $rep_block_types = array("feed","poll");
     protected $block_property = array();
     protected $admincommands = false;
-    protected $movementmode = null;
-    protected $enablemovement = false;
 
     /**
      * @var ilAdvancedSelectionListGUI
@@ -328,46 +326,6 @@ class ilColumnGUI
     public function getAdminCommands()
     {
         return $this->admincommands;
-    }
-
-    /**
-    * Set Movement Mode.
-    *
-    * @param	boolean	$a_movementmode	Movement Mode
-    */
-    public function setMovementMode($a_movementmode)
-    {
-        $this->movementmode = $a_movementmode;
-    }
-
-    /**
-    * Get Movement Mode.
-    *
-    * @return	boolean	Movement Mode
-    */
-    public function getMovementMode()
-    {
-        return $this->movementmode;
-    }
-
-    /**
-    * Set Enable Movement.
-    *
-    * @param	boolean	$a_enablemovement	Enable Movement
-    */
-    public function setEnableMovement($a_enablemovement)
-    {
-        $this->enablemovement = $a_enablemovement;
-    }
-
-    /**
-    * Get Enable Movement.
-    *
-    * @return	boolean	Enable Movement
-    */
-    public function getEnableMovement()
-    {
-        return $this->enablemovement;
     }
 
     /**
@@ -798,11 +756,7 @@ class ilColumnGUI
                 $type = self::$block_types[$class];
 
                 if ($this->isGloballyActivated($type)) {
-                    $nr = ilBlockSetting::_lookupNr($type, $user_id);
-                    if ($nr === false) {
-                        $nr = $def_nr++;
-                    }
-                    
+                    $nr = $def_nr++;
                     
                     // extra handling for system messages, feedback block and news
                     if ($type == "news") {		// always show news first
@@ -847,10 +801,7 @@ class ilColumnGUI
                 
                 if ($this->isGloballyActivated($type)) {
                     $class = array_search($type, self::$block_types);
-                    $nr = ilBlockSetting::_lookupNr($type, $user_id, $c_block["id"]);
-                    if ($nr === false) {
-                        $nr = $def_nr++;
-                    }
+                    $nr = $def_nr++;
                     $side = ilBlockSetting::_lookupSide($type, $user_id, $c_block["id"]);
                     if ($side === false) {
                         $side = IL_COL_RIGHT;
@@ -882,10 +833,7 @@ class ilColumnGUI
                         
                         $type = $block_type;
                         $class = array_search($type, self::$block_types);
-                        $nr = ilBlockSetting::_lookupNr($type, $user_id, $c_block["id"]);
-                        if ($nr === false) {
-                            $nr = $def_nr++;
-                        }
+                        $nr = $def_nr++;
                         $side = ilBlockSetting::_lookupSide($type, $user_id, $c_block["id"]);
                         if ($side === false) {
                             $side = IL_COL_RIGHT;

--- a/Services/Container/classes/class.ilContainerGUI.php
+++ b/Services/Container/classes/class.ilContainerGUI.php
@@ -2493,12 +2493,6 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
     {
         $ilAccess = $this->access;
         parent::setColumnSettings($column_gui);
-
-        if ($ilAccess->checkAccess("write", "", $this->object->getRefId()) &&
-            $this->isActiveAdministrationPanel() &&
-            $this->allowBlocksMoving()) {
-            $column_gui->setEnableMovement(true);
-        }
         
         $column_gui->setRepositoryItems(
             $this->object->getSubItems($this->isActiveAdministrationPanel(), true)

--- a/Services/Dashboard/classes/class.ilDashboardGUI.php
+++ b/Services/Dashboard/classes/class.ilDashboardGUI.php
@@ -764,10 +764,6 @@ class ilDashboardGUI
      */
     public function initColumn($a_column_gui)
     {
-        $pd_set = new ilSetting("pd");
-        if ($pd_set->get("enable_block_moving")) {
-            $a_column_gui->setEnableMovement(true);
-        }
         $a_column_gui->setActionMenu($this->action_menu);
     }
     

--- a/Services/Dashboard/classes/class.ilPersonalDesktopSettingsRepository.php
+++ b/Services/Dashboard/classes/class.ilPersonalDesktopSettingsRepository.php
@@ -203,24 +203,4 @@ class ilPersonalDesktopSettingsRepository
     {
         $this->settings->set("block_activated_pdfrmpostdraft", (int) $active);
     }
-
-    /**
-     * block moving enabled?
-     *
-     * @return bool
-     */
-    protected function ifMoveBlocks()
-    {
-        return (bool) $this->settings->get('enable_block_moving', 0);
-    }
-
-    /**
-     * Enable block moving
-     *
-     * @param bool $active
-     */
-    protected function enableMoveBlocks(bool $active = true)
-    {
-        $this->settings->set("enable_block_moving", (int) $active);
-    }
 }

--- a/setup/sql/6_hotfixes.php
+++ b/setup/sql/6_hotfixes.php
@@ -1712,3 +1712,8 @@ if ( !$ilDB->tableColumnExists('cmix_settings', 'switch_to_review') ) {
     ));
 }
 ?>
+<#74>
+<?php
+$ilDB->manipulateF('DELETE FROM settings WHERE keyword = %s', ['text'], ['enable_block_moving']);
+$ilDB->manipulate('DELETE FROM il_block_setting WHERE ' . $ilDB->like('type', 'text', 'pd%'));
+?>


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=32379

This PR removes leftovers of the PD sorting wich still affect the Dashboard.

As decided in https://docu.ilias.de/goto_docu_wiki_wpage_5593_1357.html all kinds of user specific sortings should be removed.