### PR TITLE
Remove deprecated header from PD and replace missing header for memberships

### DIFF
--- a/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemsBlockGUI.php
+++ b/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemsBlockGUI.php
@@ -506,8 +506,6 @@ class ilPDSelectedItemsBlockGUI extends ilBlockGUI implements ilDesktopItemHandl
 
     public function manageObject()
     {
-        $this->main_tpl->setTitle($this->lng->txt("dash_favourites"));
-
         $this->blockView->setIsInManageMode(true);
 
         $top_tb = new ilToolbarGUI();

--- a/Services/Membership/classes/class.ilMembershipOverviewGUI.php
+++ b/Services/Membership/classes/class.ilMembershipOverviewGUI.php
@@ -21,9 +21,8 @@ class ilMembershipOverviewGUI
      */
     protected $lng;
 
-
     /**
-     * @var \ilTemplate
+     * @var \ilGlobalPageTemplate
      */
     protected $main_tpl;
 
@@ -48,6 +47,7 @@ class ilMembershipOverviewGUI
 
         $next_class = $ctrl->getNextClass($this);
         $cmd = $ctrl->getCmd("show");
+        $this->main_tpl->setTitle($this->lng->txt("my_courses_groups"));
 
         switch ($next_class) {
             case "ilpdmembershipblockgui":
@@ -55,9 +55,7 @@ class ilMembershipOverviewGUI
                 $block = new ilPDMembershipBlockGUI(true);
                 $ret = $this->ctrl->forwardCommand($block);
                 if ($ret != "") {
-                    //$this->displayHeader();
                     $this->main_tpl->setContent($ret);
-                    //$this->tpl->printToStdout();
                 }
                 break;
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=32266
This removes a deprecated header from DP times and replace it with the on the missing occurences with the correct header for 
that call.