### PR TITLE
Review `Services/Migration`

### DIFF
--- a/Services/Migration/DBUpdate_3136/classes/class.ilDBUpdate3136.php
+++ b/Services/Migration/DBUpdate_3136/classes/class.ilDBUpdate3136.php
@@ -42,8 +42,8 @@ class ilDBUpdate3136
 
         $sql =
             "SELECT obj_id" . PHP_EOL
-            ."FROM object_data" . PHP_EOL
-            ."WHERE type = 'sty'" . PHP_EOL
+            . "FROM object_data" . PHP_EOL
+            . "WHERE type = 'sty'" . PHP_EOL
         ;
         $set = $db->query($sql);
 

--- a/Services/Migration/DBUpdate_3560/classes/class.ilDBUpdateNewObjectType.php
+++ b/Services/Migration/DBUpdate_3560/classes/class.ilDBUpdateNewObjectType.php
@@ -522,7 +522,7 @@ class ilDBUpdateNewObjectType
         foreach ($tmp as $role_id => $parents) {
             foreach ($parents as $parent_id => $ops_ids) {
                 // only if the target op is missing
-                if (sizeof($ops_ids) < 2 && in_array($source_op_id, $ops_ids)) {
+                if (count($ops_ids) < 2 && in_array($source_op_id, $ops_ids)) {
                     $values = [
                         "rol_id" => ["integer", $role_id],
                         "type" => ["text", $obj_type],
@@ -567,7 +567,6 @@ class ilDBUpdateNewObjectType
     /**
      * This method will apply the 'Initial Permissions Guideline' when introducing new object types.
      * This method does not apply permissions to existing obejcts in the ILIAS repository ('change existing objects').
-     * @param string $objectType
      * @param bool $hasLearningProgress A boolean flag whether the object type supports learning progress
      * @param bool $usedForAuthoring A boolean flag to tell whether the object type is mainly used for authoring
      * @see https://www.ilias.de/docu/goto_docu_wiki_wpage_2273_1357.html
@@ -605,7 +604,7 @@ class ilDBUpdateNewObjectType
         foreach (self::$initialPermissionDefinition as $roleType => $roles) {
             foreach ($roles as $roleTitle => $definition) {
                 if (
-                    true === $usedForAuthoring &&
+                    $usedForAuthoring &&
                     array_key_exists('ignore_for_authoring_objects', $definition) &&
                     true === $definition['ignore_for_authoring_objects']
                 ) {

--- a/Services/Migration/DBUpdate_3560/classes/class.ilDBUpdateNewObjectType.php
+++ b/Services/Migration/DBUpdate_3560/classes/class.ilDBUpdateNewObjectType.php
@@ -631,7 +631,7 @@ class ilDBUpdateNewObjectType
                     $operationIds = [];
 
                     if (array_key_exists('object', $definition) && is_array($definition['object'])) {
-                        $operationIds = array_merge($operationIds, (array) $definition['object']);
+                        $operationIds = array_merge($operationIds, $definition['object']);
                     }
 
                     if (array_key_exists('lp', $definition) && true === $definition['lp']) {

--- a/Services/Migration/DBUpdate_3560/classes/class.ilDBUpdateNewObjectType.php
+++ b/Services/Migration/DBUpdate_3560/classes/class.ilDBUpdateNewObjectType.php
@@ -194,9 +194,9 @@ class ilDBUpdateNewObjectType
 
         $sql =
             "SELECT typ_id" . PHP_EOL
-            ."FROM rbac_ta" . PHP_EOL
-            ."WHERE typ_id = " . $ilDB->quote($type_id, "integer") . PHP_EOL
-            ."AND ops_id = " . $ilDB->quote($ops_id, "integer") . PHP_EOL
+            . "FROM rbac_ta" . PHP_EOL
+            . "WHERE typ_id = " . $ilDB->quote($type_id, "integer") . PHP_EOL
+            . "AND ops_id = " . $ilDB->quote($ops_id, "integer") . PHP_EOL
         ;
         $res = $ilDB->query($sql);
 
@@ -224,9 +224,9 @@ class ilDBUpdateNewObjectType
 
         $sql =
             "SELECT typ_id" . PHP_EOL
-            ."FROM rbac_ta" . PHP_EOL
-            ."WHERE typ_id = " . $ilDB->quote($type_id, "integer") . PHP_EOL
-            ."AND ops_id = " . $ilDB->quote($ops_id, "integer") . PHP_EOL
+            . "FROM rbac_ta" . PHP_EOL
+            . "WHERE typ_id = " . $ilDB->quote($type_id, "integer") . PHP_EOL
+            . "AND ops_id = " . $ilDB->quote($ops_id, "integer") . PHP_EOL
         ;
 
         return (bool) $ilDB->numRows($ilDB->query($sql));
@@ -252,8 +252,8 @@ class ilDBUpdateNewObjectType
 
         $sql =
             "DELETE FROM rbac_ta" . PHP_EOL
-            ."WHERE typ_id = " . $ilDB->quote($type_id, "integer") . PHP_EOL
-            ."AND ops_id = " . $ilDB->quote($ops_id, "integer") . PHP_EOL
+            . "WHERE typ_id = " . $ilDB->quote($type_id, "integer") . PHP_EOL
+            . "AND ops_id = " . $ilDB->quote($ops_id, "integer") . PHP_EOL
         ;
         $GLOBALS['ilLog']->write(__METHOD__ . ': ' . $sql);
         $ilDB->manipulate($sql);
@@ -276,8 +276,8 @@ class ilDBUpdateNewObjectType
 
         $sql =
             "DELETE FROM rbac_templates" . PHP_EOL
-            ."WHERE type = " . $ilDB->quote($type, "text") . PHP_EOL
-            ."ops_id = " . $ilDB->quote($ops_id, "integer") . PHP_EOL
+            . "WHERE type = " . $ilDB->quote($type, "text") . PHP_EOL
+            . "ops_id = " . $ilDB->quote($ops_id, "integer") . PHP_EOL
         ;
         $GLOBALS['ilLog']->write(__METHOD__ . ': ' . $sql);
         $ilDB->manipulate($sql);
@@ -313,8 +313,8 @@ class ilDBUpdateNewObjectType
 
         $sql =
             "SELECT ops_id" . PHP_EOL
-            ."FROM rbac_operations" . PHP_EOL
-            ."WHERE operation = " . $ilDB->quote($operation, "text") . PHP_EOL
+            . "FROM rbac_operations" . PHP_EOL
+            . "WHERE operation = " . $ilDB->quote($operation, "text") . PHP_EOL
         ;
 
         $res = $ilDB->query($sql);
@@ -373,8 +373,8 @@ class ilDBUpdateNewObjectType
 
         $sql =
             "SELECT obj_id FROM object_data" . PHP_EOL
-            ."WHERE type = 'typ'" . PHP_EOL
-            ."AND title = " . $ilDB->quote($type, 'text') . PHP_EOL
+            . "WHERE type = 'typ'" . PHP_EOL
+            . "AND title = " . $ilDB->quote($type, 'text') . PHP_EOL
         ;
 
         $res = $ilDB->query($sql);
@@ -481,11 +481,11 @@ class ilDBUpdateNewObjectType
 
         $sql =
             "SELECT rpa.rol_id, rpa.ops_id, rpa.ref_id" . PHP_EOL
-            ."FROM rbac_pa rpa" . PHP_EOL
-            ."JOIN object_reference ref ON (ref.ref_id = rpa.ref_id)" . PHP_EOL
-            ."JOIN object_data od ON (od.obj_id = ref.obj_id AND od.type = " . $db->quote($obj_type, "text") . ")" . PHP_EOL
-            ."WHERE (" . $db->like("ops_id", "text", "%i:" . $source_op_id . "%") . PHP_EOL
-            ."OR " . $db->like("ops_id", "text", "%:\"" . $source_op_id . "\";%") . ")" . PHP_EOL
+            . "FROM rbac_pa rpa" . PHP_EOL
+            . "JOIN object_reference ref ON (ref.ref_id = rpa.ref_id)" . PHP_EOL
+            . "JOIN object_data od ON (od.obj_id = ref.obj_id AND od.type = " . $db->quote($obj_type, "text") . ")" . PHP_EOL
+            . "WHERE (" . $db->like("ops_id", "text", "%i:" . $source_op_id . "%") . PHP_EOL
+            . "OR " . $db->like("ops_id", "text", "%:\"" . $source_op_id . "\";%") . ")" . PHP_EOL
         ;
 
         while ($row = $db->fetchAssoc($db->query($sql))) {
@@ -496,9 +496,9 @@ class ilDBUpdateNewObjectType
 
                 $sql =
                     "UPDATE rbac_pa" . PHP_EOL
-                    ."SET ops_id = " . $db->quote(serialize($ops), "text") . PHP_EOL
-                    ."WHERE rol_id = " . $db->quote($row["rol_id"], "integer") . PHP_EOL
-                    ."AND ref_id = " . $db->quote($row["ref_id"], "integer") . PHP_EOL
+                    . "SET ops_id = " . $db->quote(serialize($ops), "text") . PHP_EOL
+                    . "WHERE rol_id = " . $db->quote($row["rol_id"], "integer") . PHP_EOL
+                    . "AND ref_id = " . $db->quote($row["ref_id"], "integer") . PHP_EOL
                 ;
 
                 $db->manipulate($sql);
@@ -509,10 +509,10 @@ class ilDBUpdateNewObjectType
         $tmp = [];
         $sql =
             "SELECT rol_id, parent, ops_id" . PHP_EOL
-            ."FROM rbac_templates" . PHP_EOL
-            ."WHERE type = " . $db->quote($obj_type, "text") . PHP_EOL
-            ."AND (ops_id = " . $db->quote($source_op_id, "integer") . PHP_EOL
-            ."OR ops_id = " . $db->quote($target_op_id, "integer") . ")" . PHP_EOL
+            . "FROM rbac_templates" . PHP_EOL
+            . "WHERE type = " . $db->quote($obj_type, "text") . PHP_EOL
+            . "AND (ops_id = " . $db->quote($source_op_id, "integer") . PHP_EOL
+            . "OR ops_id = " . $db->quote($target_op_id, "integer") . ")" . PHP_EOL
         ;
 
         while ($row = $db->fetchAssoc($db->query($sql))) {

--- a/Services/Migration/test/ilServicesMigrationSuite.php
+++ b/Services/Migration/test/ilServicesMigrationSuite.php
@@ -22,8 +22,6 @@ class ilServicesMigrationSuite extends TestSuite
 {
     public static function suite() : ilServicesMigrationSuite
     {
-        $suite = new ilServicesMigrationSuite();
-
-        return $suite;
+        return new ilServicesMigrationSuite();
     }
 }


### PR DESCRIPTION
Hello @klees, 

I completed the review of the `Services/Migration` component.

Results:

- [x] The code style is `PSR-2 + X` compliant
- [x] No usage of `$_GET` / `$_POST` / `$_REQUEST` / `$_SESSION`
- [ ] There is a `Unit Test Suite` with at least one unit test: Theres a suite but no tests. since this component will be removed, this seems ok.
- [ ] The unit tests pass: see above
- [x] External libraries are compatible with PHP 8 (if relevant): not relevant
- [x] There are no serious `PhpStorm Code Inspection` issues left
- [x] The types are fully documented (PhpDoc) or explicit PHP types are used (type hints, return types, typed properties): as far I can see, all remaining types are set

--


Best regards,
@chfsx