### PR TITLE
Registration: Fix missing default value when using `stripslashes` (PHP 8.1 / ILIAS 9)

### DIFF
--- a/Services/Registration/classes/class.ilRegistrationSettings.php
+++ b/Services/Registration/classes/class.ilRegistrationSettings.php
@@ -54,11 +54,15 @@ class ilRegistrationSettings
 
     protected ilSetting $settings;
 
-    public function __construct()
+    public function __construct(ilSetting $settings = null)
     {
         global $DIC;
 
-        $this->settings = $DIC->settings();
+        if (null == $settings) {
+            $settings = $DIC->settings();
+        }
+
+        $this->settings = $settings;
         $this->read();
     }
 
@@ -265,7 +269,7 @@ class ilRegistrationSettings
         $this->reg_allow_codes = (bool) $this->settings->get('reg_allow_codes');
 
         $this->approve_recipient_ids = unserialize(
-            stripslashes($this->settings->get('approve_recipient', "")),
+            stripslashes($this->settings->get('approve_recipient', serialize([]))),
             ['allowed_classes' => false]
         ) ?: [];
 

--- a/Services/Registration/test/ilRegistrationSettingsTest.php
+++ b/Services/Registration/test/ilRegistrationSettingsTest.php
@@ -35,19 +35,10 @@ class ilRegistrationSettingsTest extends TestCase
 
     public function testConstruct(): void
     {
-        global $DIC;
-        /** @var $setting MockObject */
-        $ilSetting = $DIC['ilSetting'];
-        $ilSetting->method("get")->willReturnCallback(
-            function ($arg, $arg2 = null) {
-                if ($arg === 'approve_recipient' && $arg2=== "") {
-                    return "";
-                }
-                return null;
-            }
-        );
+        $settings = $this->getMockBuilder(ilSetting::class)->disableOriginalConstructor()->onlyMethods(['get'])->getMock();
+        $settings->method('get')->willReturn('');
 
-        $settings = new ilRegistrationSettings();
+        $settings = new ilRegistrationSettings($settings);
         $this->assertInstanceOf(ilRegistrationSettings::class, $settings);
     }
 


### PR DESCRIPTION
This PR fixes a PHP 8.1 issue with `null` used in `stripslashes`. Of course it can be already merged for ILIAS 8.