### PR TITLE
Bibliographic: Fix default value for `$limit` parameter (PHP 8.1 / ILIAS 9)

### DIFF
--- a/Modules/Bibliographic/classes/FileReader/BibTex/class.ilBiblTexFileReader.php
+++ b/Modules/Bibliographic/classes/FileReader/BibTex/class.ilBiblTexFileReader.php
@@ -34,7 +34,7 @@ class ilBiblTexFileReader extends ilBiblFileReaderBase implements ilBiblFileRead
         
         // get entries
         $subject = $this->getFileContent();
-        $objects = preg_split("/\\@([\\w]*)/uix", $subject, null, PREG_SPLIT_DELIM_CAPTURE
+        $objects = preg_split("/\\@([\\w]*)/uix", $subject, -1, PREG_SPLIT_DELIM_CAPTURE
             | PREG_SPLIT_NO_EMPTY);
         
         if (in_array($objects[0], self::$ignored_keywords)) {


### PR DESCRIPTION
This PR fixes a PHP 8.1 issue with `null` used in `preg_split`. Of course it can be already merged for ILIAS 8.

See: https://www.php.net/manual/en/function.preg-split.php