### PR TITLE
Test: Replace `strftime` usage with `date` (PHP 8.1 / ILIAS 9)

### DIFF
--- a/Modules/Test/classes/class.ilTestSession.php
+++ b/Modules/Test/classes/class.ilTestSession.php
@@ -428,7 +428,7 @@ class ilTestSession
     
     public function setSubmittedTimestamp()
     {
-        $this->submittedTimestamp = strftime("%Y-%m-%d %H:%M:%S");
+        $this->submittedTimestamp = date('Y-m-d H:i:s');
     }
 
     public function setLastFinishedPass($lastFinishedPass)


### PR DESCRIPTION
This PR fixes a PHP 8.1 issue with the deprecated function`strftime`, which is replaced by `date`. Of course it can be already merged for ILIAS 8.

See: https://www.php.net/manual/en/function.strftime.php