### PR TITLE
`ilStr`: Don't pass null as `$offset` parameter anymore (PHP 8.1 / ILIAS 9)

### DIFF
--- a/Services/Utilities/classes/class.ilStr.php
+++ b/Services/Utilities/classes/class.ilStr.php
@@ -52,7 +52,7 @@ class ilStr
     public static function strIPos(string $a_haystack, string $a_needle, ?int $a_offset = null)
     {
         if (function_exists("mb_stripos")) {
-            return mb_stripos($a_haystack, $a_needle, $a_offset, "UTF-8");
+            return mb_stripos($a_haystack, $a_needle, $a_offset ?? 0, "UTF-8");
         } else {
             return stripos($a_haystack, $a_needle, $a_offset);
         }


### PR DESCRIPTION
This PR fixes a PHP 8.1 issue with `null` being used as default value of `mb_stripos`. Of course it can be merged for ILIAS 8 as well. I did not want to adapt the consumer code and add type casts for unknown code, so I decided to add a corresponding check against `null`.

See: https://www.php.net/manual/en/function.mb-stripos.php