### PR TITLE
A11Y Documents: Use correct return type declaration for `jsonSerialize` (PHP 8.1 / ILIAS 9)

### DIFF
--- a/Services/Accessibility/classes/Criteria/class.ilAccessibilityCriterionConfig.php
+++ b/Services/Accessibility/classes/Criteria/class.ilAccessibilityCriterionConfig.php
@@ -55,10 +55,7 @@ class ilAccessibilityCriterionConfig extends ArrayObject implements ilAccessibil
         $this->exchangeArray($data);
     }
 
-    /**
-     * @return array
-     */
-    public function jsonSerialize()
+    public function jsonSerialize() : array
     {
         return $this->getArrayCopy();
     }


### PR DESCRIPTION
This PR fixes a PHP 8.1 issue (deprecation) caused by a missing return value. Of course it can be already merged for ILIAS 8.