### PR TITLE
TestQuestionPool: Fix `strlen` usage for non strings (PHP 8.1 / ILIAS 9)

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assKprimChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assKprimChoice.php
@@ -363,8 +363,11 @@ class assKprimChoice extends assQuestion implements ilObjQuestionScoringAdjustab
             if (is_null($answer->getCorrectness())) {
                 return false;
             }
-            
-            if (!strlen($answer->getAnswertext()) && !strlen($answer->getImageFile())) {
+
+            if (
+                (!is_string($answer->getAnswertext()) || $answer->getAnswertext() === '') &&
+                (!is_string($answer->getImageFile()) || $answer->getImageFile() === '')
+            ) {
                 return false;
             }
         }


### PR DESCRIPTION
This PR fixes a PHP 8.1 issue (deprecation) caused by non strings passed to `strlen` to check if both, the answer text and the image file of a `KprimChoice` question are **not** given.

This can be already merged for ILIAS 8.