### PR TITLE
UI Components, fix alt text of bulky buttons and images, see: #30308

### DIFF
--- a/Services/Init/classes/Dependencies/InitUIFramework.php
+++ b/Services/Init/classes/Dependencies/InitUIFramework.php
@@ -220,6 +220,14 @@ class InitUIFramework
                             $c["refinery"],
                             $c["ui.pathresolver"]
                         ),
+                        new ILIAS\UI\Implementation\Component\Symbol\Icon\IconRendererFactory(
+                            $c["ui.factory"],
+                            $c["ui.template_factory"],
+                            $c["lng"],
+                            $c["ui.javascript_binding"],
+                            $c["refinery"],
+                            $c["ui.pathresolver"]
+                        ),
                         new ILIAS\UI\Implementation\Component\Input\Field\FieldRendererFactory(
                             $c["ui.factory"],
                             $c["ui.template_factory"],

--- a/Services/User/classes/class.ilUserAvatarResolver.php
+++ b/Services/User/classes/class.ilUserAvatarResolver.php
@@ -120,7 +120,7 @@ class ilUserAvatarResolver
 
         if ($this->useUploadedFile()) {
             return $this->ui->symbol()->avatar()->picture($this->uploaded_file, $this->login)
-                            ->withAlternativeText($alternative_text);
+                            ->withLabel($alternative_text);
         }
     
         if ($this->letter_avatars_activated === false) {
@@ -130,7 +130,7 @@ class ilUserAvatarResolver
             );
         }
 
-        return $this->ui->symbol()->avatar()->letter($this->login)->withAlternativeText($alternative_text);
+        return $this->ui->symbol()->avatar()->letter($this->login)->withLabel($alternative_text);
     }
 
     public function getLegacyPictureURL() : string

--- a/src/UI/Component/Button/Factory.php
+++ b/src/UI/Component/Button/Factory.php
@@ -301,9 +301,8 @@ interface Factory
      *        aria-attribute SHOULD be omitted. Further if the Button carries the aria-role "menuitem",
      *        the "aria-pressed" and "aria-checked"-attributes MUST be ommitted as well.
      *     3: >
-     *        If a Bulky Button contains a Icon Symbol with the same label as the Bulky Button, then the Label of the
-     *        Icon MUST be set to "" to avoid redundant alt tags which would render the Bulky Button cumbersome to be
-     *        processed by screenreaders.
+     *        If a Bulky Button contains a Symbol, then the Label of the Icon MUST be set to "" or be omitted completely
+     *        to avoid redundant alt tags which would render the Bulky Button cumbersome to be processed by screenreaders.
      * ---
      * @param	\ILIAS\UI\Component\Symbol\Symbol		$icon_or_glyph
      * @param	string		$label

--- a/src/UI/Component/Button/Factory.php
+++ b/src/UI/Component/Button/Factory.php
@@ -300,6 +300,10 @@ interface Factory
      *        If the Button is not stateful (which is the default), the
      *        aria-attribute SHOULD be omitted. Further if the Button carries the aria-role "menuitem",
      *        the "aria-pressed" and "aria-checked"-attributes MUST be ommitted as well.
+     *     3: >
+     *        If a Bulky Button contains a Icon Symbol with the same label as the Bulky Button, then the Label of the
+     *        Icon MUST be set to "" to avoid redundant alt tags which would render the Bulky Button cumbersome to be
+     *        processed by screenreaders.
      * ---
      * @param	\ILIAS\UI\Component\Symbol\Symbol		$icon_or_glyph
      * @param	string		$label

--- a/src/UI/Component/Link/Factory.php
+++ b/src/UI/Component/Link/Factory.php
@@ -69,6 +69,11 @@ interface Factory
      *        On screens larger than small size, Bulky Links MUST contain a symbol plus text.
      *     2: >
      *        On small-sized screens, Bulky Links SHOULD contain only a symbol.
+     *   accessibility:
+     *     1: >
+     *        If a Bulky Link contains a Icon Symbol with the same label as the Bulky Link, then the Label of the
+     *        Icon MUST be set to "" to avoid redundant alt tags which would render the Bulky Button cumbersome to be
+     *        processed by screenreaders.
      *
      * ---
      * @param	\ILIAS\UI\Component\Symbol\Symbol	$symbol

--- a/src/UI/Component/Link/Factory.php
+++ b/src/UI/Component/Link/Factory.php
@@ -71,10 +71,8 @@ interface Factory
      *        On small-sized screens, Bulky Links SHOULD contain only a symbol.
      *   accessibility:
      *     1: >
-     *        If a Bulky Link contains a Icon Symbol with the same label as the Bulky Link, then the Label of the
-     *        Icon MUST be set to "" to avoid redundant alt tags which would render the Bulky Button cumbersome to be
-     *        processed by screenreaders.
-     *
+     *        If a Bulky Link contains a Symbol, then the Label of the Icon MUST be set to "" or be omitted completely
+     *        to avoid redundant alt tags which would render the Bulky Link cumbersome to be processed by screenreaders.
      * ---
      * @param	\ILIAS\UI\Component\Symbol\Symbol	$symbol
      * @param	string	$label

--- a/src/UI/Component/Symbol/Avatar/Avatar.php
+++ b/src/UI/Component/Symbol/Avatar/Avatar.php
@@ -11,7 +11,5 @@ interface Avatar extends Symbol
 {
     public function getUsername() : string;
 
-    public function withAlternativeText(string $text) : Avatar;
-
-    public function getAlternativeText() : string;
+    public function withLabel(string $text) : Avatar;
 }

--- a/src/UI/Component/Symbol/Factory.php
+++ b/src/UI/Component/Symbol/Factory.php
@@ -42,7 +42,7 @@ interface Factory
      *     1: Icons MUST have a class indicating their usage.
      *     2: Icons MUST be tagged with a CSS-class indicating their size.
      *   accessibility:
-     *     1: Icons MUST bear an alt-text.
+     *     1: Icons MUST bear an alt-text. If the Icon has a purely decorative purpose, the aria-label MUST be set to "".
      *     2: Disabled Icons MUST bear an aria-label indicating the disabled status.
      *   wording:
      *     1: The alt-text MUST state the represented object-type.
@@ -96,6 +96,7 @@ interface Factory
      *       1: >
      *          The functionality triggered by the Glyph MUST be indicated to
      *          screen readers with the attributes aria-label or aria-labelledby.
+     *          If the Glyph has a purely decorative purpose, the aria-label MUST be set to "" or be completely omitted.
      * ---
      * @return  \ILIAS\UI\Component\Symbol\Glyph\Factory
      */

--- a/src/UI/Component/Symbol/Icon/Factory.php
+++ b/src/UI/Component/Symbol/Icon/Factory.php
@@ -33,7 +33,8 @@ interface Factory
      *        In their outlined version, Standard Icons MUST only use white as color for the stroke, to make filter easily
      *        applicable.
      *   accessibility:
-     *     1: Icons MUST have alt-tags.
+     *     1: Icons MUST have alt-tags. The only exception is, if the Icon is purely decorative and accompanied by some
+     *        text functioning as description of the icon. This is e.g. sometimes the case in Bulky Buttons or Bulky Links.
      * ---
      * @param   string $name
      * @param   string $label

--- a/src/UI/Component/Symbol/Icon/Factory.php
+++ b/src/UI/Component/Symbol/Icon/Factory.php
@@ -32,9 +32,6 @@ interface Factory
      *     2: >
      *        In their outlined version, Standard Icons MUST only use white as color for the stroke, to make filter easily
      *        applicable.
-     *   accessibility:
-     *     1: Icons MUST have alt-tags. The only exception is, if the Icon is purely decorative and accompanied by some
-     *        text functioning as description of the icon. This is e.g. sometimes the case in Bulky Buttons or Bulky Links.
      * ---
      * @param   string $name
      * @param   string $label

--- a/src/UI/Component/Symbol/Icon/Icon.php
+++ b/src/UI/Component/Symbol/Icon/Icon.php
@@ -24,18 +24,6 @@ interface Icon extends Symbol
     public function getName() : string;
 
     /**
-     * Get the label of this icon.
-     */
-    public function getLabel() : string;
-
-    /**
-     * Set the label of this icon. Note that this is normally achieved throught constructor and should only be used
-     * if there are specific reasons to change the label for a specific context. An example might be to set the label
-     * to an empty string in case the symbol is used only decorativly (a11y requirement).
-     */
-    public function withLabel(string $label) : Icon;
-
-    /**
      * Set the abbreviation for this icon.
      */
     public function withAbbreviation(string $abbreviation) : Icon;

--- a/src/UI/Component/Symbol/Icon/Icon.php
+++ b/src/UI/Component/Symbol/Icon/Icon.php
@@ -29,6 +29,13 @@ interface Icon extends Symbol
     public function getLabel() : string;
 
     /**
+     * Set the label of this icon. Note that this is normally achieved throught constructor and should only be used
+     * if there are specific reasons to change the label for a specific context. An example might be to set the label
+     * to an empty string in case the symbol is used only decorativly (a11y requirement).
+     */
+    public function withLabel(string $label) : Icon;
+
+    /**
      * Set the abbreviation for this icon.
      */
     public function withAbbreviation(string $abbreviation) : Icon;

--- a/src/UI/Component/Symbol/Symbol.php
+++ b/src/UI/Component/Symbol/Symbol.php
@@ -12,4 +12,8 @@ use ILIAS\UI\Component\JavaScriptBindable;
  */
 interface Symbol extends Component, JavaScriptBindable
 {
+    /**
+     * Get the label of this icon.
+     */
+    public function getLabel() : string;
 }

--- a/src/UI/Factory.php
+++ b/src/UI/Factory.php
@@ -826,7 +826,13 @@ interface Factory
      *   purpose: >
      *     Symbols are graphical representations of concepts or contexts
      *     quickly comprehensible or generally known to the user.
-     *
+     *   composition:
+     *     Symbols contain a graphical along with textual representation describing, what the graphic is depicting.
+     * rules:
+     *   accessibility:
+     *     1: Symbols MUST have labels which then might be used to display some alternative text (e.g. as alt attribute).
+     *     2: The label of the Symbol MUST NOT be displayed, if the Symbol has a purely decorative function (as e.g. in
+     *        primary buttons).
      * ---
      * @return \ILIAS\UI\Component\Symbol\Factory
      */

--- a/src/UI/Implementation/Component/Button/Renderer.php
+++ b/src/UI/Implementation/Component/Button/Renderer.php
@@ -287,11 +287,7 @@ class Renderer extends AbstractComponentRenderer
         Template $tpl
     ) : void {
         $renderer = $default_renderer->withAdditionalContext($component);
-        $symbol = $component->getIconOrGlyph();
-        if ($symbol instanceof Component\Symbol\Icon\Icon && $symbol->getLabel() == $component->getLabel()) {
-            $symbol = $symbol->withLabel('');
-        }
-        $tpl->setVariable("ICON_OR_GLYPH", $renderer->render($symbol));
+        $tpl->setVariable("ICON_OR_GLYPH", $renderer->render($component->getIconOrGlyph()));
         $label = $component->getLabel();
         if ($label !== null) {
             $tpl->setVariable("LABEL", $label);

--- a/src/UI/Implementation/Component/Button/Renderer.php
+++ b/src/UI/Implementation/Component/Button/Renderer.php
@@ -287,7 +287,11 @@ class Renderer extends AbstractComponentRenderer
         Template $tpl
     ) : void {
         $renderer = $default_renderer->withAdditionalContext($component);
-        $tpl->setVariable("ICON_OR_GLYPH", $renderer->render($component->getIconOrGlyph()));
+        $symbol = $component->getIconOrGlyph();
+        if ($symbol instanceof Component\Symbol\Icon\Icon && $symbol->getLabel() == $component->getLabel()) {
+            $symbol = $symbol->withLabel('');
+        }
+        $tpl->setVariable("ICON_OR_GLYPH", $renderer->render($symbol));
         $label = $component->getLabel();
         if ($label !== null) {
             $tpl->setVariable("LABEL", $label);

--- a/src/UI/Implementation/Component/Link/Renderer.php
+++ b/src/UI/Implementation/Component/Link/Renderer.php
@@ -58,12 +58,7 @@ class Renderer extends AbstractComponentRenderer
         $tpl_name = "tpl.bulky.html";
         $tpl = $this->setStandardVars($tpl_name, $component);
         $renderer = $default_renderer->withAdditionalContext($component);
-        $symbol = $component->getSymbol();
-        if ($symbol instanceof Component\Symbol\Icon\Icon && $symbol->getLabel() == $component->getLabel()) {
-            $symbol = $symbol->withLabel('');
-        }
-        $tpl->setVariable("SYMBOL", $renderer->render($symbol));
-
+        $tpl->setVariable("SYMBOL", $renderer->render($component->getSymbol()));
         $id = $this->bindJavaScript($component);
         $tpl->setVariable("ID", $id);
 

--- a/src/UI/Implementation/Component/Link/Renderer.php
+++ b/src/UI/Implementation/Component/Link/Renderer.php
@@ -58,7 +58,11 @@ class Renderer extends AbstractComponentRenderer
         $tpl_name = "tpl.bulky.html";
         $tpl = $this->setStandardVars($tpl_name, $component);
         $renderer = $default_renderer->withAdditionalContext($component);
-        $tpl->setVariable("SYMBOL", $renderer->render($component->getSymbol()));
+        $symbol = $component->getSymbol();
+        if ($symbol instanceof Component\Symbol\Icon\Icon && $symbol->getLabel() == $component->getLabel()) {
+            $symbol = $symbol->withLabel('');
+        }
+        $tpl->setVariable("SYMBOL", $renderer->render($symbol));
 
         $id = $this->bindJavaScript($component);
         $tpl->setVariable("ID", $id);

--- a/src/UI/Implementation/Component/Symbol/Avatar/Avatar.php
+++ b/src/UI/Implementation/Component/Symbol/Avatar/Avatar.php
@@ -14,7 +14,7 @@ abstract class Avatar implements C\Symbol\Avatar\Avatar
     use JavaScriptBindable;
 
     private string $username;
-    protected string $alternative_text = "";
+    protected string $label = '';
 
     public function __construct(string $username)
     {
@@ -26,15 +26,15 @@ abstract class Avatar implements C\Symbol\Avatar\Avatar
         return $this->username;
     }
 
-    public function withAlternativeText(string $text) : C\Symbol\Avatar\Avatar
+    public function withLabel(string $text) : C\Symbol\Avatar\Avatar
     {
         $clone = clone $this;
-        $clone->alternative_text = $text;
+        $clone->label = $text;
         return $clone;
     }
 
-    public function getAlternativeText() : string
+    public function getLabel() : string
     {
-        return $this->alternative_text;
+        return $this->label;
     }
 }

--- a/src/UI/Implementation/Component/Symbol/Avatar/Renderer.php
+++ b/src/UI/Implementation/Component/Symbol/Avatar/Renderer.php
@@ -13,9 +13,9 @@ class Renderer extends AbstractComponentRenderer
         $this->checkComponent($component);
         $tpl = null;
 
-        $alternative_text = $component->getAlternativeText();
-        if ($alternative_text == "") {
-            $alternative_text = $this->txt("user_avatar");
+        $label = $component->getLabel();
+        if ($label == "") {
+            $label = $this->txt("user_avatar");
         }
 
         /**
@@ -23,13 +23,13 @@ class Renderer extends AbstractComponentRenderer
          */
         if ($component instanceof Component\Symbol\Avatar\Letter) {
             $tpl = $this->getTemplate('tpl.avatar_letter.html', true, true);
-            $tpl->setVariable('ARIA_LABEL', $alternative_text);
+            $tpl->setVariable('ARIA_LABEL', $label);
             $tpl->setVariable('MODE', 'letter');
             $tpl->setVariable('TEXT', $component->getAbbreviation());
             $tpl->setVariable('COLOR', (string) $component->getBackgroundColorVariant());
         } elseif ($component instanceof Component\Symbol\Avatar\Picture) {
             $tpl = $this->getTemplate('tpl.avatar_picture.html', true, true);
-            $tpl->setVariable('ARIA_LABEL', $alternative_text);
+            $tpl->setVariable('ARIA_LABEL', $label);
             $tpl->setVariable('MODE', 'picture');
             $tpl->setVariable('CUSTOMIMAGE', $component->getPicturePath());
         }

--- a/src/UI/Implementation/Component/Symbol/Glyph/ButtonContextRenderer.php
+++ b/src/UI/Implementation/Component/Symbol/Glyph/ButtonContextRenderer.php
@@ -18,4 +18,9 @@ class ButtonContextRenderer extends Renderer
     {
         return $tpl;
     }
+
+    protected function renderLabel(Component\Component $component, Template $tpl) : Template
+    {
+        return $tpl;
+    }
 }

--- a/src/UI/Implementation/Component/Symbol/Glyph/Glyph.php
+++ b/src/UI/Implementation/Component/Symbol/Glyph/Glyph.php
@@ -68,17 +68,17 @@ class Glyph implements C\Symbol\Glyph\Glyph
 
     private string $type;
     private ?string $action;
-    private string $aria_label;
+    private string $label;
     private array $counters;
     private bool $highlighted;
     private bool $active = true;
 
-    public function __construct(string $type, string $aria_label, string $action = null)
+    public function __construct(string $type, string $label, string $action = null)
     {
         $this->checkArgIsElement("type", $type, self::$types, "glyph type");
 
         $this->type = $type;
-        $this->aria_label = $aria_label;
+        $this->label = $label;
         $this->action = $action;
         $this->counters = array();
         $this->highlighted = false;
@@ -95,9 +95,9 @@ class Glyph implements C\Symbol\Glyph\Glyph
     /**
      * @inheritdoc
      */
-    public function getAriaLabel() : string
+    public function getLabel() : string
     {
-        return $this->aria_label;
+        return $this->label;
     }
 
     /**

--- a/src/UI/Implementation/Component/Symbol/Glyph/Renderer.php
+++ b/src/UI/Implementation/Component/Symbol/Glyph/Renderer.php
@@ -43,7 +43,7 @@ class Renderer extends AbstractComponentRenderer
             $tpl->parseCurrentBlock();
         }
 
-        $tpl->setVariable("LABEL", $this->txt($component->getAriaLabel()));
+        $tpl = $this->renderLabel($component, $tpl);
 
         $id = $this->bindJavaScript($component);
 
@@ -55,6 +55,12 @@ class Renderer extends AbstractComponentRenderer
 
         $tpl->setVariable("GLYPH", $this->getInnerGlyphHTML($component, $default_renderer));
         return $tpl->get();
+    }
+
+    protected function renderLabel(Component\Component $component, Template $tpl) : Template
+    {
+        $tpl->setVariable("LABEL", $this->txt($component->getLabel()));
+        return $tpl;
     }
 
     protected function renderAction(Component\Component $component, Template $tpl) : Template

--- a/src/UI/Implementation/Component/Symbol/Icon/ButtonContextRenderer.php
+++ b/src/UI/Implementation/Component/Symbol/Icon/ButtonContextRenderer.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace ILIAS\UI\Implementation\Component\Symbol\Icon;
+
+use ILIAS\UI\Component;
+use ILIAS\UI\Implementation\Render\Template;
+
+class ButtonContextRenderer extends Renderer
+{
+    protected function renderLabel(Component\Component $component, Template $tpl) : Template
+    {
+        return $tpl;
+    }
+}

--- a/src/UI/Implementation/Component/Symbol/Icon/Icon.php
+++ b/src/UI/Implementation/Component/Symbol/Icon/Icon.php
@@ -48,16 +48,6 @@ abstract class Icon implements C\Symbol\Icon\Icon
     /**
      * @inheritdoc
      */
-    public function withLabel(string $label) : C\Symbol\Icon\Icon
-    {
-        $clone = clone $this;
-        $clone->label = $label;
-        return $clone;
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function withAbbreviation(string $abbreviation) : C\Symbol\Icon\Icon
     {
         $clone = clone $this;

--- a/src/UI/Implementation/Component/Symbol/Icon/Icon.php
+++ b/src/UI/Implementation/Component/Symbol/Icon/Icon.php
@@ -48,6 +48,16 @@ abstract class Icon implements C\Symbol\Icon\Icon
     /**
      * @inheritdoc
      */
+    public function withLabel(string $label) : C\Symbol\Icon\Icon
+    {
+        $clone = clone $this;
+        $clone->label = $label;
+        return $clone;
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function withAbbreviation(string $abbreviation) : C\Symbol\Icon\Icon
     {
         $clone = clone $this;

--- a/src/UI/Implementation/Component/Symbol/Icon/IconRendererFactory.php
+++ b/src/UI/Implementation/Component/Symbol/Icon/IconRendererFactory.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace ILIAS\UI\Implementation\Component\Symbol\Icon;
+
+use ILIAS\UI\Implementation\Render;
+use ILIAS\UI\Component;
+use ILIAS\UI\Implementation\Render\ComponentRenderer;
+
+class IconRendererFactory extends Render\DefaultRendererFactory
+{
+    public const USE_BUTTON_CONTEXT_FOR = [
+        'BulkyButton',
+        'BulkyLink'
+    ];
+
+    public function getRendererInContext(Component\Component $component, array $contexts) : ComponentRenderer
+    {
+        if (count(array_intersect(self::USE_BUTTON_CONTEXT_FOR, $contexts)) > 0) {
+            return new ButtonContextRenderer(
+                $this->ui_factory,
+                $this->tpl_factory,
+                $this->lng,
+                $this->js_binding,
+                $this->refinery,
+                $this->image_path_resolver
+            );
+        }
+        return new Renderer(
+            $this->ui_factory,
+            $this->tpl_factory,
+            $this->lng,
+            $this->js_binding,
+            $this->refinery,
+            $this->image_path_resolver
+        );
+    }
+}

--- a/src/UI/Implementation/Component/Symbol/Icon/Renderer.php
+++ b/src/UI/Implementation/Component/Symbol/Icon/Renderer.php
@@ -7,6 +7,7 @@ namespace ILIAS\UI\Implementation\Component\Symbol\Icon;
 use ILIAS\UI\Implementation\Render\AbstractComponentRenderer;
 use ILIAS\UI\Renderer as RendererInterface;
 use ILIAS\UI\Component;
+use ILIAS\UI\Implementation\Render\Template;
 
 class Renderer extends AbstractComponentRenderer
 {
@@ -36,7 +37,7 @@ class Renderer extends AbstractComponentRenderer
         $tpl->setVariable("NAME", $component->getName());
         $tpl->setVariable("SIZE", $component->getSize());
 
-        $tpl->setVariable("ALT", $component->getLabel());
+        $tpl = $this->renderLabel($component, $tpl);
 
         if ($component instanceof Component\Symbol\Icon\Standard) {
             $imagepath = $this->getStandardIconPath($component);
@@ -69,6 +70,12 @@ class Renderer extends AbstractComponentRenderer
         }
 
         return $tpl->get();
+    }
+
+    protected function renderLabel(Component\Component $component, Template $tpl) : Template
+    {
+        $tpl->setVariable('LABEL', $component->getLabel());
+        return $tpl;
     }
 
     protected function getStandardIconPath(Component\Symbol\Icon\Icon $icon) : string

--- a/src/UI/Implementation/Render/FSLoader.php
+++ b/src/UI/Implementation/Render/FSLoader.php
@@ -6,6 +6,7 @@ namespace ILIAS\UI\Implementation\Render;
 
 use ILIAS\UI\Component\Component;
 use ILIAS\UI\Implementation\Component\Symbol\Glyph\Glyph;
+use ILIAS\UI\Implementation\Component\Symbol\Icon\Icon;
 use ILIAS\UI\Implementation\Component\Input\Field\Input;
 
 /**
@@ -25,15 +26,18 @@ class FSLoader implements Loader
 
     private RendererFactory $default_renderer_factory;
     private RendererFactory $glyph_renderer_factory;
+    private RendererFactory $icon_renderer_factory;
     private RendererFactory $field_renderer_factory;
 
     public function __construct(
         RendererFactory $default_renderer_factory,
         RendererFactory $glyph_renderer_factory,
+        RendererFactory $icon_renderer_factory,
         RendererFactory $field_renderer_factory
     ) {
         $this->default_renderer_factory = $default_renderer_factory;
         $this->glyph_renderer_factory = $glyph_renderer_factory;
+        $this->icon_renderer_factory = $icon_renderer_factory;
         $this->field_renderer_factory = $field_renderer_factory;
     }
 
@@ -54,6 +58,9 @@ class FSLoader implements Loader
     {
         if ($component instanceof Glyph) {
             return $this->glyph_renderer_factory;
+        }
+        if ($component instanceof Icon) {
+            return $this->icon_renderer_factory;
         }
         if ($component instanceof Input) {
             return $this->field_renderer_factory;

--- a/src/UI/templates/default/Symbol/tpl.glyph.context_btn.html
+++ b/src/UI/templates/default/Symbol/tpl.glyph.context_btn.html
@@ -1,3 +1,3 @@
-<span class="glyph<!-- BEGIN highlighted --> highlighted<!-- END highlighted --><!-- BEGIN disabled --> disabled<!-- END disabled -->" aria-label="{LABEL}"<!-- BEGIN with_aria_disabled --> aria-disabled="{ARIA_DISABLED}"<!-- END with_aria_disabled --> role="img"<!-- BEGIN with_id --> id="{ID}"<!-- END with_id -->>
+<span class="glyph<!-- BEGIN highlighted --> highlighted<!-- END highlighted --><!-- BEGIN disabled --> disabled<!-- END disabled -->" <!-- BEGIN with_aria_disabled --> aria-disabled="{ARIA_DISABLED}"<!-- END with_aria_disabled --> role="img"<!-- BEGIN with_id --> id="{ID}"<!-- END with_id -->>
 {GLYPH}
 </span>

--- a/src/UI/templates/default/Symbol/tpl.icon.html
+++ b/src/UI/templates/default/Symbol/tpl.icon.html
@@ -1,7 +1,7 @@
 
 <img<!-- BEGIN with_id --> id="{ID}"<!-- END with_id -->
  class="icon {NAME} {SIZE}<!-- BEGIN disabled --> disabled<!-- END disabled --><!-- BEGIN outlined --> outlined<!-- END outlined -->"
- src="{CUSTOMIMAGE}" alt="{ALT}"
+ src="{CUSTOMIMAGE}" alt="{LABEL}"
 <!-- BEGIN aria_disabled --> aria-disabled="true"<!-- END aria_disabled -->
 <!-- BEGIN abbreviation --> data-abbreviation="{ABBREVIATION}"<!-- END abbreviation -->
 />

--- a/tests/UI/Base.php
+++ b/tests/UI/Base.php
@@ -16,6 +16,7 @@ use ILIAS\UI\Implementation\Render\DefaultRendererFactory;
 use ILIAS\UI\Implementation\DefaultRenderer;
 use ILIAS\UI\Implementation\Render;
 use ILIAS\UI\Implementation\Component\Symbol\Glyph\GlyphRendererFactory;
+use ILIAS\UI\Implementation\Component\Symbol\Icon\IconRendererFactory;
 use ILIAS\UI\Implementation\Component\Input\Field\FieldRendererFactory;
 use ILIAS\UI\Factory;
 use PHPUnit\Framework\TestCase;
@@ -337,6 +338,14 @@ abstract class ILIAS_UI_TestBase extends TestCase
                         $image_path_resolver
                     ),
                     new GlyphRendererFactory(
+                        $ui_factory,
+                        $tpl_factory,
+                        $lng,
+                        $js_binding,
+                        $refinery,
+                        $image_path_resolver
+                    ),
+                    new IconRendererFactory(
                         $ui_factory,
                         $tpl_factory,
                         $lng,

--- a/tests/UI/Client/Item/Notification/NotificationItemTest.html
+++ b/tests/UI/Client/Item/Notification/NotificationItemTest.html
@@ -1,6 +1,6 @@
 <ul class="il-maincontrols-metabar" role="menubar" style="visibility: hidden" aria-label="metabar_aria_label" id="id_11">
     <li role="none">
-        <button class="btn btn-bulky" id="id_1" role="menuitem" aria-haspopup="true"><span class="glyph" aria-label="notifications" role="img"><span class="glyphicon glyphicon-bell" aria-hidden="true"></span><span class="il-counter"><span class="badge badge-notify il-counter-novelty">2</span></span><span class="il-counter-spacer">2</span></span><span class="bulky-label">notification center</span></button>
+        <button class="btn btn-bulky" id="id_1" role="menuitem" aria-haspopup="true"><span class="glyph" role="img"><span class="glyphicon glyphicon-bell" aria-hidden="true"></span><span class="il-counter"><span class="badge badge-notify il-counter-novelty">2</span></span><span class="il-counter-spacer">2</span></span><span class="bulky-label">notification center</span></button>
         <div class="il-metabar-slates">
             <div class="il-maincontrols-slate disengaged" id="id_8">
                 <div class="il-maincontrols-slate-content" data-replace-marker="content">
@@ -16,7 +16,7 @@
                                             <button type="button" class="close" aria-label="close" id="id_3"><span aria-hidden="true">&times;</span></button>
                                             <div class="il-aggregate-notifications" data-aggregatedby="id_2">
                                                 <div class="il-maincontrols-slate il-maincontrols-slate-notification">
-                                                    <div class="il-maincontrols-slate-notification-title"><button class="btn btn-bulky" data-action=""><span class="glyph" aria-label="back" role="img"><span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span></span><span class="bulky-label">back</span></button></div>
+                                                    <div class="il-maincontrols-slate-notification-title"><button class="btn btn-bulky" data-action=""><span class="glyph" role="img"><span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span></span><span class="bulky-label">back</span></button></div>
                                                     <div class="il-maincontrols-slate-content"></div>
                                                 </div>
                                             </div>
@@ -49,7 +49,7 @@
                                             </div>
                                             <div class="il-aggregate-notifications" data-aggregatedby="id_6">
                                                 <div class="il-maincontrols-slate il-maincontrols-slate-notification">
-                                                    <div class="il-maincontrols-slate-notification-title"><button class="btn btn-bulky" data-action=""><span class="glyph" aria-label="back" role="img"><span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span></span><span class="bulky-label">back</span></button></div>
+                                                    <div class="il-maincontrols-slate-notification-title"><button class="btn btn-bulky" data-action=""><span class="glyph" role="img"><span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span></span><span class="bulky-label">back</span></button></div>
                                                     <div class="il-maincontrols-slate-content">
                                                         <div class="il-item-notification-replacement-container">
                                                             <div class="il-item il-notification-item" id="id_4">
@@ -60,7 +60,7 @@
                                                                         <button type="button" class="close" aria-label="close" id="id_5"><span aria-hidden="true">&times;</span></button>
                                                                         <div class="il-aggregate-notifications" data-aggregatedby="id_4">
                                                                             <div class="il-maincontrols-slate il-maincontrols-slate-notification">
-                                                                                <div class="il-maincontrols-slate-notification-title"><button class="btn btn-bulky" data-action=""><span class="glyph" aria-label="back" role="img"><span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span></span><span class="bulky-label">back</span></button></div>
+                                                                                <div class="il-maincontrols-slate-notification-title"><button class="btn btn-bulky" data-action=""><span class="glyph" role="img"><span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span></span><span class="bulky-label">back</span></button></div>
                                                                                 <div class="il-maincontrols-slate-content"></div>
                                                                             </div>
                                                                         </div>
@@ -82,7 +82,7 @@
         </div>
     </li>
     <li role="none">
-        <button class="btn btn-bulky" id="id_9" role="menuitem" aria-haspopup="true"><span class="glyph" aria-label="disclose" role="img"><span class="glyphicon glyphicon-option-vertical" aria-hidden="true"></span><span class="il-counter"><span class="badge badge-notify il-counter-status" style="display:none">0</span></span><span class="il-counter"><span class="badge badge-notify il-counter-novelty" style="display:none">0</span></span></span><span class="bulky-label">more</span></button>
+        <button class="btn btn-bulky" id="id_9" role="menuitem" aria-haspopup="true"><span class="glyph" role="img"><span class="glyphicon glyphicon-option-vertical" aria-hidden="true"></span><span class="il-counter"><span class="badge badge-notify il-counter-status" style="display:none">0</span></span><span class="il-counter"><span class="badge badge-notify il-counter-novelty" style="display:none">0</span></span></span><span class="bulky-label">more</span></button>
         <div class="il-metabar-slates">
             <div class="il-maincontrols-slate disengaged" id="id_10" role="menu">
                 <div class="il-maincontrols-slate-content" data-replace-marker="content"></div>

--- a/tests/UI/Component/Button/BulkyButtonTest.php
+++ b/tests/UI/Component/Button/BulkyButtonTest.php
@@ -221,4 +221,23 @@ class BulkyButtonTest extends ILIAS_UI_TestBase
             $r->render($b)
         );
     }
+
+    public function testRenderWithLabelAndAltImageSame() : void
+    {
+        $r = $this->getDefaultRenderer();
+        $b = $this->button_factory->bulky($this->icon, "Example", "http://www.ilias.de")
+                                  ->withEngagedState(false)
+                                  ->withAriaRole(I\Component\Button\Bulky::MENUITEM);
+
+        $expected = ''
+            . '<button class="btn btn-bulky" data-action="http://www.ilias.de" id="id_1" role="menuitem" aria-haspopup="true">'
+            . ' <img class="icon someExample small" src="./templates/default/images/icon_default.svg" alt=""/>'
+            . '	<span class="bulky-label">Example</span>'
+            . '</button>';
+
+        $this->assertHTMLEquals(
+            $expected,
+            $r->render($b)
+        );
+    }
 }

--- a/tests/UI/Component/Button/BulkyButtonTest.php
+++ b/tests/UI/Component/Button/BulkyButtonTest.php
@@ -161,7 +161,7 @@ class BulkyButtonTest extends ILIAS_UI_TestBase
         }
         return ''
             . '<button class="btn btn-bulky' . $engaged_class . '" data-action="http://www.ilias.de" id="id_1" ' . $aria_pressed . '>'
-            . '	<span class="glyph" aria-label="briefcase" role="img">'
+            . '	<span class="glyph" role="img">'
             . '		<span class="glyphicon glyphicon-briefcase" aria-hidden="true"></span>'
             . '	</span>'
             . '	<span class="bulky-label">label</span>'
@@ -175,7 +175,7 @@ class BulkyButtonTest extends ILIAS_UI_TestBase
 
         $expected = ''
             . '<button class="btn btn-bulky" data-action="http://www.ilias.de" id="id_1">'
-            . '	<img class="icon someExample small" src="./templates/default/images/icon_default.svg" alt="Example"/>'
+            . '	<img class="icon someExample small" src="./templates/default/images/icon_default.svg" alt=""/>'
             . '	<span class="bulky-label">label</span>'
             . '</button>';
 
@@ -193,7 +193,7 @@ class BulkyButtonTest extends ILIAS_UI_TestBase
 
         $expected = ''
             . '<button class="btn btn-bulky" data-action="http://www.ilias.de" id="id_1" role="menuitem">'
-            . ' <img class="icon someExample small" src="./templates/default/images/icon_default.svg" alt="Example"/>'
+            . ' <img class="icon someExample small" src="./templates/default/images/icon_default.svg" alt=""/>'
             . '	<span class="bulky-label">label</span>'
             . '</button>';
 
@@ -212,7 +212,7 @@ class BulkyButtonTest extends ILIAS_UI_TestBase
 
         $expected = ''
             . '<button class="btn btn-bulky" data-action="http://www.ilias.de" id="id_1" role="menuitem" aria-haspopup="true">'
-            . ' <img class="icon someExample small" src="./templates/default/images/icon_default.svg" alt="Example"/>'
+            . ' <img class="icon someExample small" src="./templates/default/images/icon_default.svg" alt=""/>'
             . '	<span class="bulky-label">label</span>'
             . '</button>';
 

--- a/tests/UI/Component/Input/Container/Filter/StandardFilterTest.php
+++ b/tests/UI/Component/Input/Container/Filter/StandardFilterTest.php
@@ -156,13 +156,13 @@ class StandardFilterTest extends ILIAS_UI_TestBase
         <div class="il-filter-bar">
 		<span class="il-filter-bar-opener" data-toggle="collapse" data-target=".il-filter-inputs-active,.il-filter-input-section" aria-expanded="false">
 			<button class="btn btn-bulky" data-action="" id="id_2">
-				<span class="glyph" aria-label="collapse_content" role="img">
+				<span class="glyph" role="img">
 				    <span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span>
                 </span>
 				<span class="bulky-label">filter</span>
 			</button>
 			<button class="btn btn-bulky" data-action="" id="id_3">
-				<span class="glyph" aria-label="expand_content" role="img">
+				<span class="glyph" role="img">
 				    <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
                 </span>
 				<span class="bulky-label">filter</span>
@@ -224,7 +224,7 @@ class StandardFilterTest extends ILIAS_UI_TestBase
 			<div class="col-md-6 col-lg-4 il-popover-container">
     			<div class="input-group">
 					<button class="btn btn-bulky" id="id_21">
-        				<span class="glyph" aria-label="add" role="img">
+        				<span class="glyph" role="img">
 							<span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
 						</span>
 					    <span class="bulky-label"></span>
@@ -234,13 +234,13 @@ class StandardFilterTest extends ILIAS_UI_TestBase
 			</div>
 			<div class="il-filter-controls">
 			    <button class="btn btn-bulky" data-action="" id="id_4">
-			        <span class="glyph" aria-label="apply" role="img">
+			        <span class="glyph" role="img">
 			            <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
                     </span>
                     <span class="bulky-label">apply</span>
                 </button>
                 <button class="btn btn-bulky" data-action="#" id="id_5">
-                    <span class="glyph" aria-label="reset" role="img">
+                    <span class="glyph" role="img">
                         <span class="glyphicon glyphicon-repeat" aria-hidden="true"></span>
                     </span>
                     <span class="bulky-label">reset</span>
@@ -290,13 +290,13 @@ EOT;
         <div class="il-filter-bar">
 		<span class="il-filter-bar-opener" data-toggle="collapse" data-target=".il-filter-inputs-active,.il-filter-input-section" aria-expanded="false">
 			<button class="btn btn-bulky" data-action="" id="id_2">
-				<span class="glyph" aria-label="collapse_content" role="img">
+				<span class="glyph" role="img">
 				    <span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span>
                 </span>
 				<span class="bulky-label">filter</span>
 			</button>
 			<button class="btn btn-bulky" data-action="" id="id_3">
-				<span class="glyph" aria-label="expand_content" role="img">
+				<span class="glyph" role="img">
 				    <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
                 </span>
 				<span class="bulky-label">filter</span>
@@ -358,7 +358,7 @@ EOT;
 			<div class="col-md-6 col-lg-4 il-popover-container">
     			<div class="input-group">
 					<button class="btn btn-bulky" id="id_21">
-        				<span class="glyph" aria-label="add" role="img">
+        				<span class="glyph" role="img">
 							<span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
 						</span>
 					    <span class="bulky-label"></span>
@@ -368,13 +368,13 @@ EOT;
 			</div>
 			<div class="il-filter-controls">
 			    <button class="btn btn-bulky" data-action="" id="id_4">
-			        <span class="glyph" aria-label="apply" role="img">
+			        <span class="glyph" role="img">
 			            <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
                     </span>
                     <span class="bulky-label">apply</span>
                 </button>
                 <button class="btn btn-bulky" data-action="#" id="id_5">
-                    <span class="glyph" aria-label="reset" role="img">
+                    <span class="glyph" role="img">
                         <span class="glyphicon glyphicon-repeat" aria-hidden="true"></span>
                     </span>
                     <span class="bulky-label">reset</span>
@@ -424,13 +424,13 @@ EOT;
         <div class="il-filter-bar">
 		<span class="il-filter-bar-opener" data-toggle="collapse" data-target=".il-filter-inputs-active,.il-filter-input-section" aria-expanded="true">
 			<button class="btn btn-bulky" data-action="" id="id_2">
-				<span class="glyph" aria-label="expand_content" role="img">
+				<span class="glyph" role="img">
 				    <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
                 </span>
 				<span class="bulky-label">filter</span>
 			</button>
 			<button class="btn btn-bulky" data-action="" id="id_3">
-				<span class="glyph" aria-label="collapse_content" role="img">
+				<span class="glyph" role="img">
 				    <span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span>
                 </span>
 				<span class="bulky-label">filter</span>
@@ -492,7 +492,7 @@ EOT;
 			<div class="col-md-6 col-lg-4 il-popover-container">
     			<div class="input-group">
 					<button class="btn btn-bulky" id="id_21">
-        				<span class="glyph" aria-label="add" role="img">
+        				<span class="glyph" role="img">
 							<span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
 						</span>
 					    <span class="bulky-label"></span>
@@ -502,13 +502,13 @@ EOT;
 			</div>
 			<div class="il-filter-controls">
 			    <button class="btn btn-bulky" data-action="" id="id_4">
-			        <span class="glyph" aria-label="apply" role="img">
+			        <span class="glyph" role="img">
 			            <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
                     </span>
                     <span class="bulky-label">apply</span>
                 </button>
                 <button class="btn btn-bulky" data-action="#" id="id_5">
-                    <span class="glyph" aria-label="reset" role="img">
+                    <span class="glyph" role="img">
                         <span class="glyphicon glyphicon-repeat" aria-hidden="true"></span>
                     </span>
                     <span class="bulky-label">reset</span>
@@ -558,13 +558,13 @@ EOT;
         <div class="il-filter-bar">
 		<span class="il-filter-bar-opener" data-toggle="collapse" data-target=".il-filter-inputs-active,.il-filter-input-section" aria-expanded="true">
 			<button class="btn btn-bulky" data-action="" id="id_2">
-				<span class="glyph" aria-label="expand_content" role="img">
+				<span class="glyph" role="img">
 				    <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
                 </span>
 				<span class="bulky-label">filter</span>
 			</button>
 			<button class="btn btn-bulky" data-action="" id="id_3">
-				<span class="glyph" aria-label="collapse_content" role="img">
+				<span class="glyph" role="img">
 				    <span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span>
                 </span>
 				<span class="bulky-label">filter</span>
@@ -626,7 +626,7 @@ EOT;
 			<div class="col-md-6 col-lg-4 il-popover-container">
     			<div class="input-group">
 					<button class="btn btn-bulky" id="id_21">
-        				<span class="glyph" aria-label="add" role="img">
+        				<span class="glyph" role="img">
 							<span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
 						</span>
 					    <span class="bulky-label"></span>
@@ -636,13 +636,13 @@ EOT;
 			</div>
 			<div class="il-filter-controls">
 			    <button class="btn btn-bulky" data-action="" id="id_4">
-			        <span class="glyph" aria-label="apply" role="img">
+			        <span class="glyph" role="img">
 			            <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
                     </span>
                     <span class="bulky-label">apply</span>
                 </button>
                 <button class="btn btn-bulky" data-action="#" id="id_5">
-                    <span class="glyph" aria-label="reset" role="img">
+                    <span class="glyph" role="img">
                         <span class="glyphicon glyphicon-repeat" aria-hidden="true"></span>
                     </span>
                     <span class="bulky-label">reset</span>

--- a/tests/UI/Component/Input/Field/FileInputTest.php
+++ b/tests/UI/Component/Input/Field/FileInputTest.php
@@ -27,6 +27,7 @@ use ILIAS\UI\Implementation\Component as I;
 use ILIAS\UI\Implementation\Component\Input\Field\FieldRendererFactory;
 use ILIAS\UI\Implementation\Component\SignalGenerator;
 use ILIAS\UI\Implementation\Component\Symbol\Glyph\GlyphRendererFactory;
+use ILIAS\UI\Implementation\Component\Symbol\Icon\IconRendererFactory;
 use ILIAS\UI\Implementation\Render\DefaultRendererFactory;
 use ILIAS\UI\Implementation\Render\FSLoader;
 use ILIAS\UI\Implementation\Render\JavaScriptBinding;
@@ -365,6 +366,14 @@ class FileInputTest extends ILIAS_UI_TestBase
                             $img_resolver
                         ),
                         new GlyphRendererFactory(
+                            $ui_factory,
+                            $tpl_factory,
+                            $lng,
+                            $js_binding,
+                            $refinery,
+                            $img_resolver
+                        ),
+                        new IconRendererFactory(
                             $ui_factory,
                             $tpl_factory,
                             $lng,

--- a/tests/UI/Component/Item/ItemNotificationTest.php
+++ b/tests/UI/Component/Item/ItemNotificationTest.php
@@ -257,7 +257,7 @@ class ItemNotificationTest extends ILIAS_UI_TestBase
 						<div class="il-maincontrols-slate il-maincontrols-slate-notification">
 							<div class="il-maincontrols-slate-notification-title">
 								<button class="btn btn-bulky" data-action="">
-									<span class="glyph" aria-label="back" role="img">
+									<span class="glyph" role="img">
 										<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 									</span>
 									<span class="bulky-label">back</span>
@@ -276,7 +276,7 @@ class ItemNotificationTest extends ILIAS_UI_TestBase
 													<div class="il-maincontrols-slate il-maincontrols-slate-notification">
 														<div class="il-maincontrols-slate-notification-title">
 															<button class="btn btn-bulky" data-action="">
-																<span class="glyph" aria-label="back" role="img">
+												 				<span class="glyph" role="img">
 																	<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 																</span>
 																<span class="bulky-label">back</span>

--- a/tests/UI/Component/Link/BulkyLinkTest.php
+++ b/tests/UI/Component/Link/BulkyLinkTest.php
@@ -170,4 +170,22 @@ class BulkyLinkTest extends ILIAS_UI_TestBase
             $r->render($b)
         );
     }
+
+    public function testRenderWithLabelAndAltImageSame() : void
+    {
+        $r = $this->getDefaultRenderer();
+        $b = $this->factory->bulky($this->icon, "Example", $this->target)
+                           ->withAriaRole(I\Button\Bulky::MENUITEM);
+
+        $expected = ''
+            . '<a class="il-link link-bulky" href="http://www.ilias.de" role="menuitem">'
+            . '<img class="icon someExample small" src="./templates/default/images/icon_default.svg"  alt=""/>'
+            . ' <span class="bulky-label">Example</span>'
+            . '</a>';
+
+        $this->assertHTMLEquals(
+            $expected,
+            $r->render($b)
+        );
+    }
 }

--- a/tests/UI/Component/Link/BulkyLinkTest.php
+++ b/tests/UI/Component/Link/BulkyLinkTest.php
@@ -105,7 +105,7 @@ class BulkyLinkTest extends ILIAS_UI_TestBase
 
         $expected = ''
             . '<a class="il-link link-bulky" href="http://www.ilias.de">'
-            . '	<span class="glyph" aria-label="briefcase" role="img">'
+            . '	<span class="glyph" role="img">'
             . '		<span class="glyphicon glyphicon-briefcase" aria-hidden="true"></span>'
             . '	</span>'
             . '	<span class="bulky-label">label</span>'
@@ -124,7 +124,7 @@ class BulkyLinkTest extends ILIAS_UI_TestBase
 
         $expected = ''
             . '<a class="il-link link-bulky" href="http://www.ilias.de">'
-            . '	<img class="icon someExample small" src="./templates/default/images/icon_default.svg" alt="Example"/>'
+            . '	<img class="icon someExample small" src="./templates/default/images/icon_default.svg" alt=""/>'
             . '	<span class="bulky-label">label</span>'
             . '</a>';
 
@@ -143,7 +143,7 @@ class BulkyLinkTest extends ILIAS_UI_TestBase
 
         $expected = ''
             . '<a class="il-link link-bulky" href="http://www.ilias.de" id="id_1">'
-            . '<img class="icon someExample small" src="./templates/default/images/icon_default.svg" alt="Example"/>'
+            . '<img class="icon someExample small" src="./templates/default/images/icon_default.svg" alt=""/>'
             . ' <span class="bulky-label">label</span>'
             . '</a>';
 
@@ -161,7 +161,7 @@ class BulkyLinkTest extends ILIAS_UI_TestBase
         
         $expected = ''
         . '<a class="il-link link-bulky" href="http://www.ilias.de" role="menuitem">'
-        . '<img class="icon someExample small" src="./templates/default/images/icon_default.svg" alt="Example"/>'
+        . '<img class="icon someExample small" src="./templates/default/images/icon_default.svg" alt=""/>'
         . ' <span class="bulky-label">label</span>'
         . '</a>';
                         

--- a/tests/UI/Component/MainControls/MainBarTest.php
+++ b/tests/UI/Component/MainControls/MainBarTest.php
@@ -242,7 +242,7 @@ class MainBarTest extends ILIAS_UI_TestBase
 							<li role="none"><button class="btn btn-bulky" data-action="#" id="id_1" role="menuitem" ><img class="icon custom small" src="" alt=""/><span class="bulky-label">TestEntry</span></button></li>
 							<li role="none"><button class="btn btn-bulky" data-action="#" id="id_2" role="menuitem" ><img class="icon custom small" src="" alt=""/><span class="bulky-label">TestEntry</span></button></li>
 							<li role="none"><button class="btn btn-bulky" id="id_3" role="menuitem" ><img class="icon custom small" src="" alt=""/><span class="bulky-label">1</span></button></li>
-							<li role="none"><button class="btn btn-bulky" id="id_9" role="menuitem" ><span class="glyph" aria-label="show_more" role="img"><span class="glyphicon glyphicon-option-horizontal" aria-hidden="true"></span></span><span class="bulky-label">mainbar_more_label</span></button></li>
+							<li role="none"><button class="btn btn-bulky" id="id_9" role="menuitem" ><span class="glyph" role="img"><span class="glyphicon glyphicon-option-horizontal" aria-hidden="true"></span></span><span class="bulky-label">mainbar_more_label</span></button></li>
 						</ul>
 					</div>
 				</nav>
@@ -283,7 +283,7 @@ class MainBarTest extends ILIAS_UI_TestBase
 
 					<div class="il-mainbar-close-slates">
 						<button class="btn btn-bulky" id="id_15" >
-							<span class="glyph" aria-label="collapse/back" role="img"><span class="glyphicon glyphicon-triangle-left" aria-hidden="true"></span></span>
+							<span class="glyph" role="img"><span class="glyphicon glyphicon-triangle-left" aria-hidden="true"></span></span>
 							<span class="bulky-label">close</span></button>
 					</div>
 				</div>

--- a/tests/UI/Component/MainControls/MetaBarTest.php
+++ b/tests/UI/Component/MainControls/MetaBarTest.php
@@ -160,7 +160,7 @@ class MetaBarTest extends ILIAS_UI_TestBase
       </li>
       <li role="none">
          <button class="btn btn-bulky" id="id_3" role="menuitem" aria-haspopup="true" >
-             <span class="glyph" aria-label="disclose" role="img">
+             <span class="glyph" role="img">
                 <span class="glyphicon glyphicon-option-vertical" aria-hidden="true"></span>
                 <span class="il-counter"><span class="badge badge-notify il-counter-status" style="display:none">0</span></span>
                 <span class="il-counter"><span class="badge badge-notify il-counter-novelty" style="display:none">0</span></span>

--- a/tests/UI/Component/MainControls/Slate/DrilldownSlateTest.php
+++ b/tests/UI/Component/MainControls/Slate/DrilldownSlateTest.php
@@ -82,7 +82,7 @@ class DrilldownSlateTest extends ILIAS_UI_TestBase
                         <header class="show-title show-backnav">
                             <h2>ddmenu</h2>
                             <div class="backnav">
-                                <button class="btn btn-bulky" id="id_1"><span class="glyph" aria-label="collapse/back" role="img"><span class="glyphicon glyphicon-triangle-left" aria-hidden="true"></span></span><span class="bulky-label"></span></button>
+                                <button class="btn btn-bulky" id="id_1"><span class="glyph" role="img"><span class="glyphicon glyphicon-triangle-left" aria-hidden="true"></span></span><span class="bulky-label"></span></button>
                             </div>
                         </header>
                         <ul>

--- a/tests/UI/Component/MainControls/Slate/NotificationSlateTest.php
+++ b/tests/UI/Component/MainControls/Slate/NotificationSlateTest.php
@@ -122,7 +122,7 @@ class NotificationSlateTest extends ILIAS_UI_TestBase
 							<div class="il-maincontrols-slate il-maincontrols-slate-notification">
 								<div class="il-maincontrols-slate-notification-title">
 									<button class="btn btn-bulky" data-action="">
-										<span class="glyph" aria-label="back" role="img">
+										<span class="glyph" role="img">
 											<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 										</span>
 										<span class="bulky-label">back</span>

--- a/tests/UI/Component/Menu/Drilldown/drilldown_test.html
+++ b/tests/UI/Component/Menu/Drilldown/drilldown_test.html
@@ -3,7 +3,7 @@
     <header class="show-title show-backnav"> 
         <h2>root</h2> 
         <div class="backnav">
-            <button class="btn btn-bulky" id="id_1" ><span class="glyph" aria-label="collapse/back" role="img"><span class="glyphicon glyphicon-triangle-left" aria-hidden="true"></span></span><span class="bulky-label"></span></button>
+            <button class="btn btn-bulky" id="id_1" ><span class="glyph" role="img"><span class="glyphicon glyphicon-triangle-left" aria-hidden="true"></span></span><span class="bulky-label"></span></button>
         </div> 
     </header>
 

--- a/tests/UI/Component/Symbol/Avatar/AvatarTest.php
+++ b/tests/UI/Component/Symbol/Avatar/AvatarTest.php
@@ -120,14 +120,14 @@ class AvatarTest extends ILIAS_UI_TestBase
     public function testAlternativeText() : void
     {
         $f = $this->getAvatarFactory();
-        $this->assertEquals("", $f->picture('', 'ro')->getAlternativeText());
-        $this->assertEquals("", $f->letter('', 'ro')->getAlternativeText());
+        $this->assertEquals("", $f->picture('', 'ro')->getLabel());
+        $this->assertEquals("", $f->letter('', 'ro')->getLabel());
         $this->assertEquals("alternative", $f->picture('', 'ro')
-                                             ->withAlternativeText("alternative")
-                                             ->getAlternativeText());
+                                             ->withLabel("alternative")
+                                             ->getLabel());
         $this->assertEquals("alternative", $f->letter('', 'ro')
-                                             ->withAlternativeText("alternative")
-                                             ->getAlternativeText());
+                                             ->withLabel("alternative")
+                                             ->getLabel());
     }
 
     public function testRenderingLetter() : void
@@ -165,7 +165,7 @@ class AvatarTest extends ILIAS_UI_TestBase
         $r = $this->getDefaultRenderer();
 
         $str = '/path/to/picture.jpg';
-        $letter = $f->picture($str, 'ro')->withAlternativeText("alternative");
+        $letter = $f->picture($str, 'ro')->withLabel("alternative");
         $html = $this->brutallyTrimHTML($r->render($letter));
         $expected = $this->brutallyTrimHTML('
 <span class="il-avatar il-avatar-picture il-avatar-size-large">	

--- a/tests/UI/Renderer/ComponentRendererFSLoaderTest.php
+++ b/tests/UI/Renderer/ComponentRendererFSLoaderTest.php
@@ -18,6 +18,10 @@ class ComponentRendererFSLoaderTest extends TestCase
      * @var I\Render\RendererFactory|mixed|MockObject
      */
     private $glyph_renderer;
+    /**
+     * @var I\Render\RendererFactory|mixed|MockObject
+     */
+    private $icon_renderer;
 
     protected function getComponentRendererFSLoader() : FSLoader
     {
@@ -40,8 +44,10 @@ class ComponentRendererFSLoaderTest extends TestCase
             $image_path_resolver
         );
         $this->glyph_renderer = $this->createMock(I\Render\RendererFactory::class);
+        $this->icon_renderer = $this->createMock(I\Render\RendererFactory::class);
+
         $field_renderer = $this->createMock(I\Render\RendererFactory::class);
-        return new FSLoader($default_renderer_factory, $this->glyph_renderer, $field_renderer);
+        return new FSLoader($default_renderer_factory, $this->glyph_renderer, $this->icon_renderer, $field_renderer);
     }
 
     public function test_getRenderer_successfully() : void


### PR DESCRIPTION
Fix of https://mantis.ilias.de/view.php?id=30308, redundant alt tags are an a11y issue. See report on mantis. 

This is intended to be pushed down to 7 as well if accepted.

Note that this could either be fixed on a client level by only setting a corresponding rule, or on directly while rendering. I decided to tackle this while rendering, since it will be hard, for all devs to a) remember setting always a tag except for b) when they have bulky buttons or links already offering a label. 