### PR TITLE
ilServer: Fix missing form action

### DIFF
--- a/Modules/SystemFolder/classes/class.ilObjSystemFolderGUI.php
+++ b/Modules/SystemFolder/classes/class.ilObjSystemFolderGUI.php
@@ -1758,7 +1758,8 @@ class ilObjSystemFolderGUI extends ilObjectGUI
         
         include_once("Services/Form/classes/class.ilPropertyFormGUI.php");
         $this->form = new ilPropertyFormGUI();
-        
+        $this->form->setFormAction($this->ctrl->getFormAction($this, 'saveJavaServer'));
+
         // pdf fonts
         $pdf = new ilFormSectionHeaderGUI();
         $pdf->setTitle($this->lng->txt('rpc_pdf_generation'));


### PR DESCRIPTION
Mantis Issue: https://mantis.ilias.de/view.php?id=32639

This PR has to be cherry-picked to `trunk` (and maybe to `release_8`, depending on the date of merge).