### PR TITLE
0020916: missing function split() in /webservice/soap/lib/nusoap.php

### DIFF
--- a/webservice/soap/lib/nusoap.php
+++ b/webservice/soap/lib/nusoap.php
@@ -3319,7 +3319,7 @@ class soap_transport_http extends nusoap_base {
 	 */
 	function parseCookie($cookie_str) {
 		$cookie_str = str_replace('; ', ';', $cookie_str) . ';';
-		$data = split(';', $cookie_str);
+		$data = preg_split(';', $cookie_str);
 		$value_str = $data[0];
 
 		$cookie_param = 'domain=';


### PR DESCRIPTION
@smeyer-ilias I replaced deprecated split by preg_split according to fix in library https://github.com/f00b4r/nusoap/blob/e83219ee1add324124fea8e448b4cfddf782f8ff/src/nusoap.php#L3456