### PR TITLE
Database: link update/migration-readme in docs

### DIFF
--- a/Services/Database/README.md
+++ b/Services/Database/README.md
@@ -160,66 +160,11 @@ $DIC->database()->update("table_name", array(
 ));
 ```
 
-## Database Update Script
-If you need to add, modify or rename tables or columns to the ILIAS database you need to add steps to the so called **database update script**. You find it in the directory **setup/sql**. It is called db\_update<nr>.php, the current one is always the one with the highest sequence number. The steps of this script are executed in the ILIAS setup in the database section of a client.
- 
-A typical DB update step looks like this:
+## Database Updates
 
-```php
-<#2950>
-<?php
-        $ilDB->modifyTableColumn('table_properties', 'value',
-                array("type" => "text", "length" => 4000, "notnull" => true));
-?>
-```
-
-The step starts with a sequential number <#Nr> and continues with a code block. It is important to understand that this **sequence of database update steps** is part of the **main ILIAS development branch**. You should never try to add steps in a "patched" version of ILIAS to this scripts, since these numbers identify a state of the database that must be given for all ILIAS installations (with the exception of plugins that add their own tables).
- 
-Core developers that add steps to this script must be subscribed to the ILIAS developer mailing list. We announced the creation of bug fix development branches and their relationship to the main development in this list, with a special focus on the database update script.
-
-### Hotfix Scripts (Bugfix Branches)
-When **stable bugfix branches** and **trunk** development in ILIAS go in parallel, only one branch can define new database steps in the database update script. This is usually the trunk development. However it may be necessary that tables or columns need to be added or modified for a bug fix within a stable branch.
- 
-For this purpose we have so called **hotfix scripts**. They work similar as the database update script, but have their **own numbering**. Their filename starts with the main release number, e.g. ```setup/sql/5_4_hotfixes.php``` for ILIAS **5.4.x**.
-
-```php
-<#3>
-<?php        
-        $ilDB->addTableColumn(
-                'export_options',
-                'pos',
-                array(
-                        'type'         => 'integer', 
-                        'length'         => 4,
-                        'notnull'        => true,
-                        'default'        => 0
-                )
-        );
-?>
-```
-
-Adding a step to the hotfix script is never enough. You must **ensure** that the **trunk database script is synchronized accordingly**. Add a new step that creates the same state, regardless of whether the hotfix has been applied to an installation or not (which we do not now):
-
-```php
-<#3205>
-<?php
-        if(!$ilDB->tableColumnExists('export_options','pos'))
-        {
-                $ilDB->addTableColumn(
-                        'export_options',
-                        'pos',
-                        array(
-                                'type'                 => 'integer', 
-                                'length'         => 4,
-                                'notnull'        => true,
-                                'default'        => 0
-                        )
-                );
-        }
-?>
-```
-
-Note the `if(!$ilDB->tableColumnExists(...))` statement above, which is very important for these cases. There is a `if(!$ilDB->tableExists('...'))` as well.
+Please have a look into [this document](docs/development/database-updates.md) for
+directions on database migrations and schema updates are to be integrated into the
+system.
 
 ## Creating, Modifying and Deleting Tables
 Since ILIAS 4.0 tables will are defined in an abstracted way in ILIAS. Only the following `$ilDB` methods may be used, to create, modify and delete tables in the database update script.

--- a/docs/development/database-updates.md
+++ b/docs/development/database-updates.md
@@ -18,10 +18,13 @@ Previous versions of ILIAS supported the so called `db-update-files`. These file
 will keep on working for some time technically, but are deprecated as decided by
 the [Jour Fixe on 2021-06-08](https://docu.ilias.de/goto_docu_wiki_wpage_5889_1357.html).
 
+General directions on how to use the database in ILIAS are to be found [in the according
+readme of Services/Database](Services/Database/README.md).
+
 ## Schema Updates
 
 To create a schema update, you first need an integration with the setup. Create
-a class that implements from `ILIAS\Setup\Agent`, you MUST put it in the subfolder
+a class that implements `ILIAS\Setup\Agent`, you MUST put it in the subfolder
 `classes/Setup` in your component. If you only want to introduce some update steps
 you could just extend from the `NullAgent`.
 


### PR DESCRIPTION
Hi @chfsx,

as discussed some time ago, this adjusts the README of `Services/Database` according to the new mechanism for database update steps.

After all, every developer may take care of our shared inventory of documentation =)

Best regards!