### PR TITLE
ilCtrl: Fixed appendage of empty URL parameters and empty command & -classes

### DIFF
--- a/Services/UICore/classes/class.ilCtrl.php
+++ b/Services/UICore/classes/class.ilCtrl.php
@@ -251,9 +251,13 @@ class ilCtrl implements ilCtrlInterface
     /**
      * @inheritDoc
      */
-    public function setCmd(string $a_cmd) : void
+    public function setCmd(?string $a_cmd) : void
     {
-        $this->context->setCmd($a_cmd);
+        if (!empty($a_cmd)) {
+            $this->context->setCmd($a_cmd);
+        } else {
+            $this->context->setCmd(null);
+        }
     }
 
     /**
@@ -271,6 +275,8 @@ class ilCtrl implements ilCtrlInterface
     {
         if (!empty($a_cmd_class)) {
             $this->context->setCmdClass($a_cmd_class);
+        } else {
+            $this->context->setCmdClass(null);
         }
     }
 
@@ -1106,7 +1112,7 @@ class ilCtrl implements ilCtrlInterface
     ) : string {
         // only append value if it exists and can be cast
         // to string.
-        if (null !== $value && !is_array($value) && !is_object($value)) {
+        if (!empty($value) && !is_array($value) && !is_object($value)) {
             // declare ampersand escaped or not, according to
             // the given argument.
             $ampersand = ($is_escaped) ? '&amp;' : '&';

--- a/Services/UICore/classes/class.ilCtrlContext.php
+++ b/Services/UICore/classes/class.ilCtrlContext.php
@@ -184,7 +184,7 @@ class ilCtrlContext implements ilCtrlContextInterface
     /**
      * @inheritDoc
      */
-    public function setCmdClass(string $cmd_class) : ilCtrlContextInterface
+    public function setCmdClass(?string $cmd_class) : ilCtrlContextInterface
     {
         $path = $this->path_factory->find($this, $cmd_class);
 
@@ -210,7 +210,7 @@ class ilCtrlContext implements ilCtrlContextInterface
     /**
      * @inheritDoc
      */
-    public function setCmd(string $cmd) : ilCtrlContextInterface
+    public function setCmd(?string $cmd) : ilCtrlContextInterface
     {
         $this->cmd = $cmd;
 

--- a/Services/UICore/interfaces/interface.ilCtrlContextInterface.php
+++ b/Services/UICore/interfaces/interface.ilCtrlContextInterface.php
@@ -79,10 +79,10 @@ interface ilCtrlContextInterface
     /**
      * Sets the current contexts command class.
      *
-     * @param string $cmd_class
+     * @param string|null $cmd_class
      * @return ilCtrlContextInterface
      */
-    public function setCmdClass(string $cmd_class) : ilCtrlContextInterface;
+    public function setCmdClass(?string $cmd_class) : ilCtrlContextInterface;
 
     /**
      * Returns the command class of this context.
@@ -95,10 +95,10 @@ interface ilCtrlContextInterface
      * Sets the command which the current command- or baseclass
      * should perform.
      *
-     * @param string $cmd
+     * @param string|null $cmd
      * @return self
      */
-    public function setCmd(string $cmd) : self;
+    public function setCmd(?string $cmd) : self;
 
     /**
      * Returns the command which the current command- or baseclass

--- a/Services/UICore/interfaces/interface.ilCtrlInterface.php
+++ b/Services/UICore/interfaces/interface.ilCtrlInterface.php
@@ -92,9 +92,9 @@ interface ilCtrlInterface
      * @deprecated this method should not be used anymore, as all commands
      *             should be passed as $_GET or $_POST parameters.
      *
-     * @param string $a_cmd
+     * @param string|null $a_cmd
      */
-    public function setCmd(string $a_cmd) : void;
+    public function setCmd(?string $a_cmd) : void;
 
     /**
      * Returns the command class which should be executed next.
@@ -109,7 +109,7 @@ interface ilCtrlInterface
      * @deprecated this method should not be used anymore, as all command
      *             classes should be passed by $_GET or $_POST parameters.
      *
-     * @param object|string $a_cmd_class
+     * @param object|string|null $a_cmd_class
      */
     public function setCmdClass($a_cmd_class) : void;
 


### PR DESCRIPTION
Fixes https://mantis.ilias.de/view.php?id=32645 and https://mantis.ilias.de/view.php?id=32638.