### PR TITLE
Docs: update coding style

### DIFF
--- a/docs/development/coding-style.md
+++ b/docs/development/coding-style.md
@@ -2,34 +2,20 @@
 
 This is the coding style for the [ILIAS project](https://github.com/ILIAS-eLearning/ILIAS).
 
-## PSR-2 and additions
+## PSR-12 and additions
 
-The ILIAS coding standard is aligned to the widely used and established [PSR-2 standard](https://www.php-fig.org/psr/psr-2/)
+The ILIAS coding standard is aligned to the widely used and established [PSR-12 standard](https://www.php-fig.org/psr/psr-12/)
 of the [PHP Interop Group (PHP-FIG)](https://www.php-fig.org/), extended by the
 following additions:
 
-### Operators
+### Property and Variable Names
 
-Operators MUST have a space before and after the operator.
-
-Mathematical Operators:
+Names of properties and variables MUST be written in underscore-case:
 
 ```php
-$result = 1 + $value;
-```
+$foo_bar = 3;
+$this->foo_bar = 3;
 
-Comparsion Operators:
-
-```php
-if ($size > 0) {
-    // ...
-}
-```
-
-Concatenation Operator:
-
-```php
-$test = 'hello ' . $name . '!';
 ```
 
 ### Type cast
@@ -38,14 +24,6 @@ Spaces MUST be added after a type cast.
 
 ```php
 $foo = (int) '12345';
-```
-
-### Return Type Declaration
-
-Spaces MUST be added around a colon in return type declaration.
-
-```php
-function () : void {}
 ```
 
 ## Code Style Checks and Fixes


### PR DESCRIPTION
Hi everyone,

I hereby propose to update our coding-style definition slightly:

* Update from PSR-2 to PSR-12. A lot of new PHP-stuff hasn't been adressed in PSR-2.
* Hence, remove definitions that are covered by PSR-12.
* Change return type declaration style from `method() : return_type` to `method(): return_type` to make our style match PSR-12.
* Unrelated: make `underscore_case` mandatory for variable and property names, there hasn't been any convention here until now.

If this is accepted, we'll need to adjust our tooling accordingly and most likely will have another commit to rectify the codebase. I'm confident that the TB will fund these changes. I would propose to only apply this to ILIAS 8 and future versions, since ILIAS 7 will already look vastly different then ILIAS 8 due to the PHP 8-project, hence no immediate benefit to retrofit this change.

Best regards!