### PR TITLE
LTI: fix syntax

### DIFF
--- a/Services/LTI/classes/class.ilLTIRouterGUI.php
+++ b/Services/LTI/classes/class.ilLTIRouterGUI.php
@@ -45,7 +45,7 @@ class ilLTIRouterGUI implements ilCtrlBaseClassInterface
 
         if (is_file($class_file)) {
             //ToDo: check - was $gui = $next_class::getInstance(); // Singleton!
-            $gui = $next_class::ilLTIViewGUI::getInstance();
+            $gui = $next_class::getInstance();
 //            $gui = call_user_func([$next_class, 'getInstance']);
             $this->ilCtrl->forwardCommand($gui);
         } else {


### PR DESCRIPTION
Hi @Uwe-Kohnle,

tests are broken since yesterday, this fixes syntax and hence (hopefully) the tests.

Best regards!