### PR TITLE
Fix one case where an access to an undefined variable can occure

### DIFF
--- a/Services/Notifications/classes/ilNotificationDatabaseHandler.php
+++ b/Services/Notifications/classes/ilNotificationDatabaseHandler.php
@@ -183,7 +183,7 @@ class ilNotificationDatabaseHandler
         $result = [];
 
         while ($row = $ilDB->fetchAssoc($res)) {
-            if (!$result[$row['module']]) {
+            if (!isset($result[$row['module']])) {
                 $result[$row['module']] = [];
             }
 


### PR DESCRIPTION
Hi @mjansenDatabay 
Found one place where an access to an undefined array key can occur in the notification service.

Thanks,
@swiniker
