### PR TITLE
Pass over rendered HTML to use in an uihook plugin for replacements (DashboardGUI)

### DIFF
--- a/Services/Dashboard/classes/class.ilDashboardGUI.php
+++ b/Services/Dashboard/classes/class.ilDashboardGUI.php
@@ -494,14 +494,15 @@ class ilDashboardGUI
                 
                 // user interface plugin slot + default rendering
                 include_once("./Services/UIComponent/classes/class.ilUIHookProcessor.php");
+                $html = $ilCtrl->getHTML($column_gui);
                 $uip = new ilUIHookProcessor(
                     "Services/Dashboard",
                     "left_column",
-                    array("personal_desktop_gui" => $this)
+                    array(
+                        "personal_desktop_gui" => $this,
+                        "html" => $html
+                    )
                 );
-                if (!$uip->replaced()) {
-                    $html = $ilCtrl->getHTML($column_gui);
-                }
                 $html = $uip->getHTML($html);
             }
         }

--- a/Services/Dashboard/classes/class.ilDashboardGUI.php
+++ b/Services/Dashboard/classes/class.ilDashboardGUI.php
@@ -406,15 +406,15 @@ class ilDashboardGUI
 
                     // user interface plugin slot + default rendering
                     include_once("./Services/UIComponent/classes/class.ilUIHookProcessor.php");
+                    $html = $this->getMainContent();
                     $uip = new ilUIHookProcessor(
                         "Services/Dashboard",
                         "center_column",
-                        array("personal_desktop_gui" => $this)
+                        array(
+                            "personal_desktop_gui" => $this,
+                            "html" => $html
+                        )
                     );
-                    if (!$uip->replaced()) {
-                        $html = $this->getMainContent();
-                        //$html = $ilCtrl->getHTML($column_gui);
-                    }
                     $html = $uip->getHTML($html);
                 }
             }
@@ -450,14 +450,15 @@ class ilDashboardGUI
                 
                 // user interface plugin slot + default rendering
                 include_once("./Services/UIComponent/classes/class.ilUIHookProcessor.php");
+                $html = $ilCtrl->getHTML($column_gui);
                 $uip = new ilUIHookProcessor(
                     "Services/Dashboard",
                     "right_column",
-                    array("personal_desktop_gui" => $this)
+                    array(
+                        "personal_desktop_gui" => $this,
+                        "html" => $html
+                    )
                 );
-                if (!$uip->replaced()) {
-                    $html = $ilCtrl->getHTML($column_gui);
-                }
                 $html = $uip->getHTML($html);
             }
         }


### PR DESCRIPTION
Hello,

i added the html to the $a_pars array so this UIHook call behaves like the other `UIHook->getHtml` calls in `ilTemplate`.

The problem is when you make an UIHookPlugin that wants to replace something in the rendered html the whole page will be blank, because there is no way you can not completely replace the dashboard html. 

The impact of this PR will be quite low. The UIHooks are always called, it justs adds a `new` parameter. As an uihook plugin developer i would assume this parameter is always filled with the rendered html in the first place, like its done here in the general ilTemplate hook: https://github.com/ILIAS-eLearning/ILIAS/blob/release_7/Services/UICore/classes/class.ilTemplate.php#L180

Greetings
Purhur