### PR TITLE
Security: Added configurable (constant) authentication-time

### DIFF
--- a/Services/Init/classes/Dependencies/InitHttpServices.php
+++ b/Services/Init/classes/Dependencies/InitHttpServices.php
@@ -1,6 +1,21 @@
 <?php
 
 /**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+/**
  * Responsible for loading the UI Framework into the dependency injection container of ILIAS
  */
 class InitHttpServices
@@ -21,6 +36,12 @@ class InitHttpServices
 
         $container['http.response_sender_strategy'] = function ($c) {
             return new \ILIAS\HTTP\Response\Sender\DefaultResponseSenderStrategy();
+        };
+
+        $container['http.duration_factory'] = function ($c) {
+            return new \ILIAS\HTTP\Duration\DurationFactory(
+                new \ILIAS\HTTP\Duration\Increment\IncrementFactory()
+            );
         };
 
         $container['http.security'] = function ($c) {

--- a/Services/PrivacySecurity/classes/Setup/class.ilPrivacySecurityConfigStoredObjective.php
+++ b/Services/PrivacySecurity/classes/Setup/class.ilPrivacySecurityConfigStoredObjective.php
@@ -61,8 +61,11 @@ class ilPrivacySecurityConfigStoredObjective implements Setup\Objective
         $settings = $factory->settingsFor("common");
         $settings->set("https", $this->bool2string($this->config->getForceHttpsOnLogin()));
 
+        /** @var $settings ilSetting */
         if (null !== $this->config->getAuthDurationInMs()) {
             $settings->set("auth_duration", (string) $this->config->getAuthDurationInMs());
+        } else {
+            $settings->delete("auth_duration");
         }
 
         return $environment;

--- a/Services/PrivacySecurity/classes/Setup/class.ilPrivacySecurityConfigStoredObjective.php
+++ b/Services/PrivacySecurity/classes/Setup/class.ilPrivacySecurityConfigStoredObjective.php
@@ -50,6 +50,10 @@ class ilPrivacySecurityConfigStoredObjective implements Setup\Objective
         $settings = $factory->settingsFor("common");
         $settings->set("https", $this->bool2string($this->config->getForceHttpsOnLogin()));
 
+        if (null !== $this->config->getAuthDurationInMs()) {
+            $settings->set("auth_duration", (string) $this->config->getAuthDurationInMs());
+        }
+
         return $environment;
     }
 

--- a/Services/PrivacySecurity/classes/Setup/class.ilPrivacySecurityConfigStoredObjective.php
+++ b/Services/PrivacySecurity/classes/Setup/class.ilPrivacySecurityConfigStoredObjective.php
@@ -1,8 +1,19 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2019 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
-
-/* Copyright (c) 2020 Daniel Weise <daniel.weise@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
 
 use ILIAS\Setup;
 

--- a/Services/PrivacySecurity/classes/Setup/class.ilPrivacySecurityConfigStoredObjective.php
+++ b/Services/PrivacySecurity/classes/Setup/class.ilPrivacySecurityConfigStoredObjective.php
@@ -68,6 +68,12 @@ class ilPrivacySecurityConfigStoredObjective implements Setup\Objective
             $settings->delete("auth_duration");
         }
 
+        if (null !== $this->config->getAccountAssistanceDurationInMs()) {
+            $settings->set("account_assistance_duration", (string) $this->config->getAccountAssistanceDurationInMs());
+        } else {
+            $settings->delete("account_assistance_duration");
+        }
+
         return $environment;
     }
 

--- a/Services/PrivacySecurity/classes/Setup/class.ilPrivacySecuritySetupAgent.php
+++ b/Services/PrivacySecurity/classes/Setup/class.ilPrivacySecuritySetupAgent.php
@@ -57,7 +57,8 @@ class ilPrivacySecuritySetupAgent implements Setup\Agent
         return $this->refinery->custom()->transformation(function ($data) {
             return new ilPrivacySecuritySetupConfig(
                 (bool) ($data["https_enabled"] ?? false),
-                (isset($data["auth_duration"])) ? (int) $data["auth_duration"] : null
+                (isset($data["auth_duration"])) ? (int) $data["auth_duration"] : null,
+                (isset($data["account_assistance_duration"])) ? (int) $data["account_assistance_duration"] : null
             );
         });
     }

--- a/Services/PrivacySecurity/classes/Setup/class.ilPrivacySecuritySetupAgent.php
+++ b/Services/PrivacySecurity/classes/Setup/class.ilPrivacySecuritySetupAgent.php
@@ -1,6 +1,19 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2020 Daniel Weise <daniel.weise@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
 
 use ILIAS\Setup;
 use ILIAS\Refinery;

--- a/Services/PrivacySecurity/classes/Setup/class.ilPrivacySecuritySetupAgent.php
+++ b/Services/PrivacySecurity/classes/Setup/class.ilPrivacySecuritySetupAgent.php
@@ -43,7 +43,8 @@ class ilPrivacySecuritySetupAgent implements Setup\Agent
     {
         return $this->refinery->custom()->transformation(function ($data) {
             return new ilPrivacySecuritySetupConfig(
-                (bool) ($data["https_enabled"] ?? false)
+                (bool) ($data["https_enabled"] ?? false),
+                (isset($data["auth_duration"])) ? (int) $data["auth_duration"] : null
             );
         });
     }
@@ -65,7 +66,7 @@ class ilPrivacySecuritySetupAgent implements Setup\Agent
      */
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return $this->getInstallObjective($config);
     }
 
     /**

--- a/Services/PrivacySecurity/classes/Setup/class.ilPrivacySecuritySetupConfig.php
+++ b/Services/PrivacySecurity/classes/Setup/class.ilPrivacySecuritySetupConfig.php
@@ -20,12 +20,17 @@ use ILIAS\Setup;
 class ilPrivacySecuritySetupConfig implements Setup\Config
 {
     protected bool $force_https_on_login;
-    protected ?int $duration_in_ms;
+    protected ?int $authentication_duration_in_ms;
+    protected ?int $account_assistance_duration_in_ms;
 
-    public function __construct(bool $force_https_on_login = false, ?int $duration_in_ms = null)
-    {
+    public function __construct(
+        bool $force_https_on_login = false,
+        ?int $authentication_duration_in_ms = null,
+        ?int $account_assistance_duration_in_ms = null,
+    ) {
         $this->force_https_on_login = $force_https_on_login;
-        $this->duration_in_ms = $duration_in_ms;
+        $this->authentication_duration_in_ms = $authentication_duration_in_ms;
+        $this->account_assistance_duration_in_ms = $account_assistance_duration_in_ms;
     }
 
     public function getForceHttpsOnLogin() : bool
@@ -35,6 +40,11 @@ class ilPrivacySecuritySetupConfig implements Setup\Config
 
     public function getAuthDurationInMs() : ?int
     {
-        return $this->duration_in_ms;
+        return $this->authentication_duration_in_ms;
+    }
+
+    public function getAccountAssistanceDurationInMs() : ?int
+    {
+        return $this->account_assistance_duration_in_ms;
     }
 }

--- a/Services/PrivacySecurity/classes/Setup/class.ilPrivacySecuritySetupConfig.php
+++ b/Services/PrivacySecurity/classes/Setup/class.ilPrivacySecuritySetupConfig.php
@@ -1,23 +1,40 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2020 Daniel Weise <daniel.weise@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
 
 use ILIAS\Setup;
 
 class ilPrivacySecuritySetupConfig implements Setup\Config
 {
-    /**
-     * @var bool
-     */
     protected bool $force_https_on_login;
+    protected ?int $duration_in_ms;
 
-    public function __construct(bool $force_https_on_login = false)
+    public function __construct(bool $force_https_on_login = false, ?int $duration_in_ms = null)
     {
         $this->force_https_on_login = $force_https_on_login;
+        $this->duration_in_ms = $duration_in_ms;
     }
 
     public function getForceHttpsOnLogin() : bool
     {
         return $this->force_https_on_login;
+    }
+
+    public function getAuthDurationInMs() : ?int
+    {
+        return $this->duration_in_ms;
     }
 }

--- a/setup/README.md
+++ b/setup/README.md
@@ -442,10 +442,12 @@ are printed bold**, all other fields might be omitted. A minimal example is
 * *privacysecurity* (type: object)
     ```
 	"privacysecurity" : {
-		"https_enabled" : true
+		"https_enabled" : true,
+		"auth_duration" : 3000
 	},
     ```
   * *https_enabled* (type: boolean) forces https on login page, defaults to `false`
+  * *auth_duration* (type: integer) stretches the auth-duration on logins to the given amount in ms, defaults to `null`
 * *webservices* (type: object)
     ```
 	"webservices" : {

--- a/setup/README.md
+++ b/setup/README.md
@@ -443,11 +443,13 @@ are printed bold**, all other fields might be omitted. A minimal example is
     ```
 	"privacysecurity" : {
 		"https_enabled" : true,
-		"auth_duration" : 3000
+		"auth_duration" : 3000,
+		"account_assistance_duration" : 3000
 	},
     ```
   * *https_enabled* (type: boolean) forces https on login page, defaults to `false`
   * *auth_duration* (type: integer) stretches the auth-duration on logins to the given amount in ms, defaults to `null`
+  * *account_assistance_duration* (type: integer) stretches the password- and username-assistance duration to the given amount in ms, defaults to `null`
 * *webservices* (type: object)
     ```
 	"webservices" : {

--- a/src/HTTP/Duration/CallbackDuration.php
+++ b/src/HTTP/Duration/CallbackDuration.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system

--- a/src/HTTP/Duration/CallbackDuration.php
+++ b/src/HTTP/Duration/CallbackDuration.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+namespace ILIAS\HTTP\Duration;
+
+use Closure;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+class CallbackDuration extends Duration
+{
+    /**
+     * @return mixed|null
+     */
+    public function stretch(callable $callback)
+    {
+        $start_time = microtime(true);
+        $halted = true;
+
+        register_shutdown_function(static function () use (&$halted) {
+            if ($halted) {
+                throw new \LogicException("Callback could not be stretched because it halted the programm.");
+            }
+        });
+
+        $return = $callback();
+        $halted = false;
+
+        $elapsed_time_in_us = ((microtime(true) - $start_time) * self::S_TO_US);
+        $duration_in_us = ($this->duration_in_ms * self::MS_TO_US);
+
+        if ($elapsed_time_in_us > $duration_in_us) {
+            throw new \RuntimeException("Execution of callback exceeded the given duration and could not be stretched.");
+        }
+
+        if ($elapsed_time_in_us < $duration_in_us) {
+            usleep((int) round($duration_in_us - $elapsed_time_in_us));
+        }
+
+        return $return;
+    }
+}

--- a/src/HTTP/Duration/Duration.php
+++ b/src/HTTP/Duration/Duration.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+namespace ILIAS\HTTP\Duration;
+
+use ILIAS\HTTP\Duration\Increment\IncrementStrategy;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+abstract class Duration
+{
+    /**
+     * number used for converting seconds (s) into microseconds (us/µ) or vise-versa.
+     */
+    protected const S_TO_US = 1_000_000;
+
+    /**
+     * number used for converting miliseconds (ms) into microseconds (us/µ) or vise-versa.
+     */
+    protected const MS_TO_US = 1_000;
+
+    protected ?IncrementStrategy $increment = null;
+    protected int $duration_in_ms;
+
+    public function __construct(int $duration_in_ms)
+    {
+        $this->duration_in_ms = $duration_in_ms;
+    }
+
+    public function withIncrement(IncrementStrategy $increment) : self
+    {
+        $clone = clone $this;
+        $clone->increment = $increment;
+
+        return $clone;
+    }
+
+    public function increment() : self
+    {
+        if (null === $this->increment) {
+            return $this;
+        }
+
+        $clone = clone $this;
+        $clone->duration_in_ms = $clone->increment->increment($clone->duration_in_ms);
+
+        return $clone;
+    }
+
+    public function withDuration(int $duration_in_ms) : self
+    {
+        $clone = clone $this;
+        $clone->duration_in_ms = $duration_in_ms;
+
+        return $clone;
+    }
+
+    public function getDuration() : int
+    {
+        return $this->duration_in_ms;
+    }
+}

--- a/src/HTTP/Duration/DurationFactory.php
+++ b/src/HTTP/Duration/DurationFactory.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+namespace ILIAS\HTTP\Duration;
+
+use ILIAS\HTTP\Duration\Increment\IncrementFactory;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+class DurationFactory
+{
+    protected IncrementFactory $incrementFactory;
+
+    public function __construct(IncrementFactory $incrementFactory)
+    {
+        $this->incrementFactory = $incrementFactory;
+    }
+
+    public function callbackDuration(int $duration_in_ms) : CallbackDuration
+    {
+        return new CallbackDuration($duration_in_ms);
+    }
+
+    public function increments() : IncrementFactory
+    {
+        return $this->incrementFactory;
+    }
+}

--- a/src/HTTP/Duration/Increment/IncrementFactory.php
+++ b/src/HTTP/Duration/Increment/IncrementFactory.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+namespace ILIAS\HTTP\Duration\Increment;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+class IncrementFactory
+{
+    public function multiplier(float $multiplier) : MultiplierStrategy
+    {
+        return new MultiplierStrategy($multiplier);
+    }
+
+    public function constant(int $increment_in_ms) : StaticStrategy
+    {
+        return new StaticStrategy($increment_in_ms);
+    }
+}

--- a/src/HTTP/Duration/Increment/IncrementStrategy.php
+++ b/src/HTTP/Duration/Increment/IncrementStrategy.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+namespace ILIAS\HTTP\Duration\Increment;
+
+use ILIAS\HTTP\Duration\Duration;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+interface IncrementStrategy
+{
+    public function increment(int $duration_in_ms) : int;
+}

--- a/src/HTTP/Duration/Increment/MultiplierStrategy.php
+++ b/src/HTTP/Duration/Increment/MultiplierStrategy.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+namespace ILIAS\HTTP\Duration\Increment;
+
+use ILIAS\HTTP\Duration\Duration;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+class MultiplierStrategy implements IncrementStrategy
+{
+    protected float $multiplier;
+
+    public function __construct(float $multiplier)
+    {
+        $this->multiplier = $multiplier;
+    }
+
+    public function increment(int $duration_in_ms) : int
+    {
+        return ($duration_in_ms * $this->multiplier);
+    }
+}

--- a/src/HTTP/Duration/Increment/StaticStrategy.php
+++ b/src/HTTP/Duration/Increment/StaticStrategy.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+namespace ILIAS\HTTP\Duration\Increment;
+
+use ILIAS\HTTP\Duration\Duration;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+class StaticStrategy implements IncrementStrategy
+{
+    protected int $increment_in_ms;
+
+    public function __construct(int $increment_in_ms)
+    {
+        $this->increment_in_ms = $increment_in_ms;
+    }
+
+    public function increment(int $duration_in_ms) : int
+    {
+        return ($duration_in_ms + $this->increment_in_ms);
+    }
+}

--- a/src/HTTP/GlobalHttpState.php
+++ b/src/HTTP/GlobalHttpState.php
@@ -1,5 +1,19 @@
 <?php
-/* Copyright (c) 2016 Fabian Schmid <fs@studer-raimann.ch> Extended GPL, see docs/LICENSE */
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
 
 namespace ILIAS\HTTP;
 
@@ -9,20 +23,9 @@ use ILIAS\HTTP\Wrapper\WrapperFactory;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use ILIAS\HTTP\Duration\CallbackDuration;
+use ILIAS\HTTP\Duration\DurationFactory;
 
-/******************************************************************************
- *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
- *
- * If this is not the case or you just want to try ILIAS, you'll find
- * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
- *
- *****************************************************************************/
 /**
  * Interface GlobalHttpState
  *
@@ -38,6 +41,8 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 interface GlobalHttpState
 {
+    public function durations() : DurationFactory;
+
     public function wrapper() : WrapperFactory;
 
     /**

--- a/src/HTTP/RawHTTPServices.php
+++ b/src/HTTP/RawHTTPServices.php
@@ -1,5 +1,20 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
 namespace ILIAS\HTTP;
 
 use ILIAS\HTTP\Cookies\CookieJar;
@@ -8,22 +23,10 @@ use ILIAS\HTTP\Request\RequestFactory;
 use ILIAS\HTTP\Response\ResponseFactory;
 use ILIAS\HTTP\Response\Sender\ResponseSenderStrategy;
 use ILIAS\HTTP\Wrapper\WrapperFactory;
+use ILIAS\HTTP\Duration\DurationFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-/******************************************************************************
- *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
- *
- * If this is not the case or you just want to try ILIAS, you'll find
- * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
- *
- *****************************************************************************/
 /**
  * Provides an interface to the ILIAS HTTP services.
  *
@@ -35,6 +38,7 @@ class RawHTTPServices implements GlobalHttpState
     private \ILIAS\HTTP\Cookies\CookieJarFactory $cookieJarFactory;
     private \ILIAS\HTTP\Request\RequestFactory $requestFactory;
     private \ILIAS\HTTP\Response\ResponseFactory $responseFactory;
+    private \ILIAS\HTTP\Duration\DurationFactory $durationFactory;
     private ?\Psr\Http\Message\ServerRequestInterface $request = null;
     private ?\Psr\Http\Message\ResponseInterface $response = null;
 
@@ -45,15 +49,24 @@ class RawHTTPServices implements GlobalHttpState
      * @param ResponseSenderStrategy $senderStrategy   A response sender strategy.
      * @param CookieJarFactory       $cookieJarFactory Cookie Jar implementation.
      */
-    public function __construct(ResponseSenderStrategy $senderStrategy, CookieJarFactory $cookieJarFactory, RequestFactory $requestFactory, ResponseFactory $responseFactory)
-    {
+    public function __construct(
+        ResponseSenderStrategy $senderStrategy,
+        CookieJarFactory $cookieJarFactory,
+        RequestFactory $requestFactory,
+        ResponseFactory $responseFactory,
+        DurationFactory $durationFactory
+    ) {
         $this->sender = $senderStrategy;
         $this->cookieJarFactory = $cookieJarFactory;
-
         $this->requestFactory = $requestFactory;
         $this->responseFactory = $responseFactory;
+        $this->durationFactory = $durationFactory;
     }
 
+    public function durations() : DurationFactory
+    {
+        return $this->durationFactory;
+    }
 
     public function wrapper() : WrapperFactory
     {

--- a/src/HTTP/Services.php
+++ b/src/HTTP/Services.php
@@ -1,5 +1,20 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
 namespace ILIAS\HTTP;
 
 use ILIAS\HTTP\Cookies\CookieJar;
@@ -9,20 +24,8 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use ILIAS\DI\Container;
 use ILIAS\HTTP\Agent\AgentDetermination;
+use ILIAS\HTTP\Duration\DurationFactory;
 
-/******************************************************************************
- *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
- *
- * If this is not the case or you just want to try ILIAS, you'll find
- * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
- *
- *****************************************************************************/
 /**
  * Class Services
  * @author              Fabian Schmid <fs@studer-raimann.ch>
@@ -44,10 +47,16 @@ class Services implements GlobalHttpState
             $dic['http.response_sender_strategy'],
             $dic['http.cookie_jar_factory'],
             $dic['http.request_factory'],
-            $dic['http.response_factory']
+            $dic['http.response_factory'],
+            $dic['http.duration_factory']
         );
         $this->wrapper = new WrapperFactory($this->raw->request());
         $this->agent = new AgentDetermination();
+    }
+
+    public function durations() : DurationFactory
+    {
+        return $this->raw->durations();
     }
 
     public function wrapper() : WrapperFactory

--- a/tests/DI/HTTPServicesTest.php
+++ b/tests/DI/HTTPServicesTest.php
@@ -1,8 +1,18 @@
 <?php
+
 /**
- * Class HTTPServicesTest
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * @author  Nicolas Schäfli <ns@studer-raimann.ch>
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  */
 
 namespace ILIAS\DI;
@@ -18,22 +28,12 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use ILIAS\HTTP\RawHTTPServices;
 use ILIAS\HTTP\GlobalHttpState;
+use ILIAS\HTTP\Duration\DurationFactory;
 
-/******************************************************************************
- *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
- *
- * If this is not the case or you just want to try ILIAS, you'll find
- * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
- *
- *****************************************************************************/
 /**
  * Class HTTPServicesTest
+ *
+ * @author  Nicolas Schäfli <ns@studer-raimann.ch>
  *
  * @package                DI
  *
@@ -61,6 +61,10 @@ class HTTPServicesTest extends PHPUnitTestCase
      * @var ResponseSenderStrategy|MockObject $mockSenderStrategy
      */
     private ResponseSenderStrategy $mockSenderStrategy;
+    /**
+     * @var DurationFactory|MockObject $mockSenderStrategy
+     */
+    private DurationFactory $mockDurationFactory;
     private GlobalHttpState $httpState;
 
 
@@ -75,7 +79,9 @@ class HTTPServicesTest extends PHPUnitTestCase
 
         $this->mockCookieJarFactory = $this->getMockBuilder(CookieJarFactory::class)->getMock();
 
-        $this->httpState = new RawHTTPServices($this->mockSenderStrategy, $this->mockCookieJarFactory, $this->mockRequestFactory, $this->mockResponseFactory);
+        $this->mockDurationFactory = $this->createMock(DurationFactory::class);
+
+        $this->httpState = new RawHTTPServices($this->mockSenderStrategy, $this->mockCookieJarFactory, $this->mockRequestFactory, $this->mockResponseFactory, $this->mockDurationFactory);
     }
 
 

--- a/tests/HTTP/Services/CallbackDurationTest.php
+++ b/tests/HTTP/Services/CallbackDurationTest.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+namespace HTTP\Services;
+
+use PHPUnit\Framework\TestCase;
+use ILIAS\HTTP\Duration\CallbackDuration;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+class CallbackDurationTest extends TestCase
+{
+
+//    // there isn't a good way to test the shutdown-function with PHPUnit (yet?).
+//    public function testCallbackStretchingWithExit() : void
+//    {
+//        $callback = $this->getTestCallbackWithLength(1, true);
+//        $duration = new CallbackDuration(1);
+//
+//        $this->expectException(\LogicException::class);
+//        $this->expectExceptionMessage("Callback could not be stretched because it halted the programm.");
+//        $duration->stretch($callback);
+//    }
+
+    public function testCallbackStretchingWithTooLongExecutionTime() : void
+    {
+        $callback = $this->getTestCallbackWithLength(2);
+        $duration = new CallbackDuration(1);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("Execution of callback exceeded the given duration and could not be stretched.");
+        $duration->stretch($callback);
+    }
+
+    public function testCallbackStretching() : void
+    {
+        $callback = $this->getTestCallbackWithLength(1);
+        $duration = new CallbackDuration(2);
+
+        $start_time = microtime(true);
+        $duration->stretch($callback);
+        $end_time = microtime(true);
+
+        $elapsed_time = ($end_time - $start_time); // in microseconds (us)
+        $expected_duration_in_us = (0.002);
+
+        $this->assertGreaterThanOrEqual($expected_duration_in_us, ($end_time - $start_time));
+    }
+
+    protected function getTestCallbackWithLength(int $duration_in_ms, bool $should_halt = false) : callable
+    {
+        return static function () use ($duration_in_ms, $should_halt) {
+            usleep(1_000 * $duration_in_ms);
+            if ($should_halt) {
+                exit;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Hi all, this PR is based on #4460

As discussed with and commented by @klees I've come up with an implementation to stretch the execution-time of certain methods or functions to a specific duration. The reason behind this is as mentioned in the previous PR that an attacker could gather information about the existence of user-profiles by inspecting the response-time. To solve this issue I already applied this mechanism in the `ilStartUpGUI`. Because the execution time is different on each server I added a configuration to enable this feature and define the duration in milliseconds (ms). The configuration is located in `Users and Roles > Authentication and Registration` and is linked in `Users and Roles > Privacy and Security`. 

I didn't apply the mechanism in `ilAccountRegistrationGUI` (yet), because this implementation leaks information about the existence of profiles anyways and the mechanism wouldn't change that. 

The implementation of this mechanism is located in the HTTP service because I'd like to introduce the usage of increments (`IncrementStrategy`) that are bound to a users IP-address and will be applied on failed attempts in the future. 

There's a `register_shutdown_function` in my code that might seem weird but serves a crucial purpose: Ensure that given callbacks DO NOT contain exit-statements (as used in redirects e.g.). The implementation will throw an according exception if the ILIAS installation has dev-mode enabled (as all developers should have). This should warn developers that their code might not behave as expected and that they should look into their callback. 

Kind regards!