### PR TITLE
Pass over rendered HTML to use in an uihook plugin for replacements (ilContainerContentGUI)

### DIFF
--- a/Services/Container/classes/class.ilContainerContentGUI.php
+++ b/Services/Container/classes/class.ilContainerContentGUI.php
@@ -248,14 +248,15 @@ abstract class ilContainerContentGUI
                 
                 // user interface plugin slot + default rendering
                 include_once("./Services/UIComponent/classes/class.ilUIHookProcessor.php");
+                $html = $ilCtrl->getHTML($column_gui);
                 $uip = new ilUIHookProcessor(
                     "Services/Container",
                     "right_column",
-                    array("container_content_gui" => $this)
+                    array(
+                        "container_content_gui" => $this,
+                        "html" => $html
+                    )
                 );
-                if (!$uip->replaced()) {
-                    $html = $ilCtrl->getHTML($column_gui);
-                }
                 $html = $uip->getHTML($html);
             }
         }


### PR DESCRIPTION
Hello,

i added the html to the $a_pars array so this UIHook call behaves like the other UIHook->getHtml calls in ilTemplate.

The problem is when you make an UIHookPlugin that wants to replace something in the rendered html the whole partial will be blank, because there is no rendered html presend like in the other hook calls of getHtml. 

The impact of this PR will be quite low. The UIHooks are always called, it justs adds a new parameter. As an uihook plugin developer i would assume this parameter is always filled with the rendered html in the first place, like its done here in the general ilTemplate hook: https://github.com/ILIAS-eLearning/ILIAS/blob/release_7/Services/UICore/classes/class.ilTemplate.php#L180

Note: You can close this PR if the getHtml is deprecated and should not be changed?

Greetings
Purhur