### PR TITLE
Pass over rendered HTML to use in an uihook plugin for replacements (PersonalSkillGUI)

### DIFF
--- a/Services/Skill/classes/class.ilPersonalSkillsGUI.php
+++ b/Services/Skill/classes/class.ilPersonalSkillsGUI.php
@@ -512,15 +512,13 @@ class ilPersonalSkillsGUI
     public function getSkillHTML($a_top_skill_id, $a_user_id = 0, $a_edit = false, $a_tref_id = 0)
     {
         // user interface plugin slot + default rendering
+        $skill_html = $this->renderSkillHTML($a_top_skill_id, $a_user_id, $a_edit, $a_tref_id);
         $uip = new ilUIHookProcessor(
             "Services/Skill",
             "personal_skill_html",
             array("personal_skills_gui" => $this, "top_skill_id" => $a_top_skill_id, "user_id" => $a_user_id,
-                "edit" => $a_edit, "tref_id" => $a_tref_id)
+                "edit" => $a_edit, "tref_id" => $a_tref_id, "html" => $skill_html)
         );
-        if (!$uip->replaced()) {
-            $skill_html = $this->renderSkillHTML($a_top_skill_id, $a_user_id, $a_edit, $a_tref_id);
-        }
         $skill_html = $uip->getHTML($skill_html);
 
         return $skill_html;


### PR DESCRIPTION
Hello,

i added the html to the $a_pars array so this UIHook call behaves like the other UIHook->getHtml calls in ilTemplate.

The problem is when you make an UIHookPlugin that wants to replace something in the rendered html the whole partial will be blank, because there is no rendered html present like in the other hook calls of getHtml.

The impact of this PR will be quite low. The UIHooks are always called, it justs adds a new parameter. As an uihook plugin developer i would assume this parameter is always filled with the rendered html in the first place, like its done here in the general ilTemplate hook: https://github.com/ILIAS-eLearning/ILIAS/blob/release_7/Services/UICore/classes/class.ilTemplate.php#L180

Note: You can close this PR if the getHtml is deprecated and should not be changed?

Greetings
Purhur