### PR TITLE
Pass over rendered HTML to use in an uihook plugin for replacements (RTEGlobalTemplate)

### DIFF
--- a/Services/RTE/classes/class.ilRTEGlobalTemplate.php
+++ b/Services/RTE/classes/class.ilRTEGlobalTemplate.php
@@ -939,14 +939,12 @@ class ilRTEGlobalTemplate implements ilGlobalTemplateInterface
         $html = "";
         if (is_object($ilPluginAdmin)) {
             include_once("./Services/UIComponent/classes/class.ilUIHookProcessor.php");
+            $html = $ilLocator->getHTML();
             $uip = new ilUIHookProcessor(
                 "Services/Locator",
                 "main_locator",
-                array("locator_gui" => $ilLocator)
+                array("locator_gui" => $ilLocator, "html" => $html)
             );
-            if (!$uip->replaced()) {
-                $html = $ilLocator->getHTML();
-            }
             $html = $uip->getHTML($html);
         } else {
             $html = $ilLocator->getHTML();


### PR DESCRIPTION
Hello,

i added the html to the $a_pars array so this UIHook call behaves like the other UIHook->getHtml calls in ilTemplate.

The problem is when you make an UIHookPlugin that wants to replace something in the rendered html the whole partial will be blank, because there is no rendered html presend like in the other hook calls of getHtml.

The impact of this PR will be quite low. The UIHooks are always called, it justs adds a new parameter. As an uihook plugin developer i would assume this parameter is always filled with the rendered html in the first place, like its done here in the general ilTemplate hook: https://github.com/ILIAS-eLearning/ILIAS/blob/release_7/Services/UICore/classes/class.ilTemplate.php#L180

Note: You can close this PR if the getHtml is deprecated and should not be changed?

Greetings
Purhur