### PR TITLE
Bugfix/trunk/test and assessment/formula question

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
@@ -172,8 +172,7 @@ class assFormulaQuestionGUI extends assQuestionGUI
             $found_vars = array();
             $found_results = array();
 
-            
-            foreach ($_POST as $key => $value) {
+            foreach ($this->request->getParsedBody() as $key => $value) {
                 if (preg_match("/^unit_(\\\$v\d+)$/", $key, $matches)) {
                     array_push($found_vars, $matches[1]);
                 }
@@ -655,7 +654,7 @@ class assFormulaQuestionGUI extends assQuestionGUI
         if ($save) {
             $found_vars = array();
             $found_results = array();
-            foreach ($_POST as $key => $value) {
+            foreach ($this->request->getParsedBody() as $key => $value) {
                 if (preg_match("/^unit_(\\\$v\d+)$/", $key, $matches)) {
                     array_push($found_vars, $matches[1]);
                 }

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionVariable.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionVariable.php
@@ -50,7 +50,7 @@ class assFormulaQuestionVariable
             if ($this->getIntprecision() > $this->getRangeMax()) {
                 global $DIC;
                 $lng = $DIC['lng'];
-                ilUtil::sendFailure($lng->txt('err_divider_too_big'));
+                $DIC->ui()->factory()->messageBox()->failure($lng->txt('err_divider_too_big'));
             }
         }
         


### PR DESCRIPTION
Fixes an issue in the Test & Assessment preventing the FormulaQuestion 
from retrieving variables ($v...) and results ($r_...) from the $_POST array 
because direct access to $_POST is no longer possible.