### PR TITLE
[FIX] 0032241: Cookies for each video might lead to HTTP 431

### DIFF
--- a/Modules/MediaCast/classes/class.ilObjMediaCastGUI.php
+++ b/Modules/MediaCast/classes/class.ilObjMediaCastGUI.php
@@ -1592,12 +1592,10 @@ class ilObjMediaCastGUI extends ilObjectGUI
                 );
                 
                 if (strcasecmp("Reference", $med->getLocationType()) == 0) {
-                    ilWACSignedPath::signFolderOfStartFile($med->getLocation());
-                    $mpl->setFile($med->getLocation());
+                    $mpl->setFile(ilWACSignedPath::signFile($med->getLocation()));
                 } else {
                     $path_to_file = ilObjMediaObject::_getURL($mob->getId()) . "/" . $med->getLocation();
-                    ilWACSignedPath::signFolderOfStartFile($path_to_file);
-                    $mpl->setFile($path_to_file);
+                    $mpl->setFile(ilWACSignedPath::signFile($path_to_file));
                 }
                 $mpl->setMimeType($med->getFormat());
                 //$mpl->setDisplayHeight($med->getHeight());


### PR DESCRIPTION
@alex40724 this fixes the issue in https://mantis.ilias.de/view.php?id=32241 by using URL-tokens instead of Cookie-Tokens.