### PR TITLE
Fix 28308: Bibliographic link resolver

### DIFF
--- a/Modules/Bibliographic/classes/Admin/Library/class.ilBiblLibraryPresentationGUI.php
+++ b/Modules/Bibliographic/classes/Admin/Library/class.ilBiblLibraryPresentationGUI.php
@@ -129,7 +129,7 @@ class ilBiblLibraryPresentationGUI
 
     /**
      * @param String $a
-     * @param String $type
+     * @param ilBiblTypeInterface $type
      * @param array  $attributes
      * @param String $prefix
      *
@@ -140,7 +140,7 @@ class ilBiblLibraryPresentationGUI
      */
     public function formatAttribute($a, $type, $attributes, $prefix)
     {
-        if ($type == 'ris') {
+        if ($type->getStringRepresentation() === 'ris') {
             switch ($a) {
                 case 'ti':
                     $a = "title";
@@ -168,7 +168,7 @@ class ilBiblLibraryPresentationGUI
                     $a = "volume";
                     break;
             }
-        } elseif ($type = 'bib') {
+        } elseif ($type->getStringRepresentation() === 'bib') {
             switch ($a) {
                 case 'number':
                     $a = "issue";


### PR DESCRIPTION
This PR solves an issue where link-targets were generated with the wrong attribute-names as mentioned in https://mantis.ilias.de/view.php?id=28308. The fix was quite simple because the mapping of the different attribute-names was already implemented but the comparison of the `$type` variable was wrong, since an `ilBiblTypeInterface` object is passed rather than a string. 