### PR TITLE
TestQPL: Add missing return type declarations

### DIFF
--- a/Modules/TestQuestionPool/classes/Form/class.ilClozeGapInputBuilderGUI.php
+++ b/Modules/TestQuestionPool/classes/Form/class.ilClozeGapInputBuilderGUI.php
@@ -14,7 +14,7 @@ class ilClozeGapInputBuilderGUI extends ilSubEnabledFormPropertyGUI
      * Set Value.
      * @param    string $a_value Value
      */
-    public function setValue($a_value)
+    public function setValue($a_value) : void
     {
         $this->value = $a_value;
     }
@@ -29,7 +29,7 @@ class ilClozeGapInputBuilderGUI extends ilSubEnabledFormPropertyGUI
         return $this->value;
     }
 
-    public function setValueCombination($value)
+    public function setValueCombination($value) : void
     {
         $this->value_combination = $value;
     }
@@ -44,7 +44,7 @@ class ilClozeGapInputBuilderGUI extends ilSubEnabledFormPropertyGUI
         return (array) $this->value_combination;
     }
 
-    public function setValueCombinationFromDb($value)
+    public function setValueCombinationFromDb($value) : void
     {
         $return_array = array();
         if ($value) {
@@ -178,7 +178,7 @@ class ilClozeGapInputBuilderGUI extends ilSubEnabledFormPropertyGUI
         return !$error;
     }
 
-    public function setValueByArray($data)
+    public function setValueByArray($data) : void
     {
         $this->setValue($data);
     }
@@ -186,7 +186,7 @@ class ilClozeGapInputBuilderGUI extends ilSubEnabledFormPropertyGUI
     /**
      * @param ilTemplate $template
      */
-    public function insert(ilTemplate $template)
+    public function insert(ilTemplate $template) : void
     {
         global $DIC;
         $lng = $DIC['lng'];

--- a/Modules/TestQuestionPool/classes/RequestTrait.php
+++ b/Modules/TestQuestionPool/classes/RequestTrait.php
@@ -2,5 +2,4 @@
 
 trait QPRequestTrait
 {
-
 }

--- a/Modules/TestQuestionPool/classes/class.assAnswerBinaryState.php
+++ b/Modules/TestQuestionPool/classes/class.assAnswerBinaryState.php
@@ -116,7 +116,7 @@ class ASS_AnswerBinaryState extends ASS_AnswerSimple
      *
      * @see $state
      */
-    public function setState(bool $state = false)
+    public function setState(bool $state = false) : void
     {
         $this->checked = $state;
     }
@@ -128,7 +128,7 @@ class ASS_AnswerBinaryState extends ASS_AnswerSimple
      *
      * @see $state
      */
-    public function setChecked()
+    public function setChecked() : void
     {
         $this->checked = true;
     }
@@ -140,7 +140,7 @@ class ASS_AnswerBinaryState extends ASS_AnswerSimple
      *
      * @see $state
      */
-    public function setSet()
+    public function setSet() : void
     {
         $this->checked = true;
     }
@@ -152,7 +152,7 @@ class ASS_AnswerBinaryState extends ASS_AnswerSimple
      *
      * @see $state
      */
-    public function setUnset()
+    public function setUnset() : void
     {
         $this->checked = false;
     }
@@ -164,7 +164,7 @@ class ASS_AnswerBinaryState extends ASS_AnswerSimple
      *
      * @see $state
      */
-    public function setUnchecked()
+    public function setUnchecked() : void
     {
         $this->checked = false;
     }

--- a/Modules/TestQuestionPool/classes/class.assAnswerBinaryStateImage.php
+++ b/Modules/TestQuestionPool/classes/class.assAnswerBinaryStateImage.php
@@ -66,7 +66,7 @@ class ASS_AnswerBinaryStateImage extends ASS_AnswerBinaryState
      *
      * @see $image
      */
-    public function setImage($a_image = 0)
+    public function setImage($a_image = 0) : void
     {
         $this->image = $a_image;
     }

--- a/Modules/TestQuestionPool/classes/class.assAnswerCloze.php
+++ b/Modules/TestQuestionPool/classes/class.assAnswerCloze.php
@@ -61,7 +61,7 @@ class assAnswerCloze extends ASS_AnswerSimple
      * @param $bound string A string defining the lower bound of an answer for numeric gaps.
      * @TODO: Refactor method to get rid of "locale magic".
      */
-    public function setLowerBound(string $bound)
+    public function setLowerBound(string $bound) : void
     {
         $boundvalue = $this->getNumericValueFromText($bound);
         $value = $this->getNumericValueFromAnswerText();
@@ -78,7 +78,7 @@ class assAnswerCloze extends ASS_AnswerSimple
      * @param $bound string A string defining the upper bound of an answer for numeric gaps.
      * @TODO: Refactor method to get rid of "locale magic".
      */
-    public function setUpperBound(string $bound)
+    public function setUpperBound(string $bound) : void
     {
         $boundvalue = $this->getNumericValueFromText($bound);
         $value = $this->getNumericValueFromAnswerText();
@@ -127,7 +127,7 @@ class assAnswerCloze extends ASS_AnswerSimple
     /**
      * @param int $gap_size
      */
-    public function setGapSize(int $gap_size)
+    public function setGapSize(int $gap_size) : void
     {
         $this->gap_size = $gap_size;
     }

--- a/Modules/TestQuestionPool/classes/class.assAnswerImagemap.php
+++ b/Modules/TestQuestionPool/classes/class.assAnswerImagemap.php
@@ -76,7 +76,7 @@ class ASS_AnswerImagemap extends ASS_AnswerBinaryState
     * @access public
     * @see $coords
     */
-    public function setCoords(string $coords = "")
+    public function setCoords(string $coords = "") : void
     {
         $coords = preg_replace("/\s/", "", $coords);
         $this->coords = $coords;
@@ -95,7 +95,7 @@ class ASS_AnswerImagemap extends ASS_AnswerBinaryState
     }
 
 
-    public function setArea(string $area = "")
+    public function setArea(string $area = "") : void
     {
         $this->area = $area;
     }

--- a/Modules/TestQuestionPool/classes/class.assAnswerMatching.php
+++ b/Modules/TestQuestionPool/classes/class.assAnswerMatching.php
@@ -152,7 +152,7 @@ class ASS_AnswerMatching
     * @access public
     * @see $term_id
     */
-    public function setTermId($term_id = 0)
+    public function setTermId($term_id = 0) : void
     {
         if ($term_id >= 0) {
             $this->term_id = $term_id;
@@ -166,7 +166,7 @@ class ASS_AnswerMatching
     * @access public
     * @see $picture_or_definition_id
     */
-    public function setPictureId(int $picture_id = 0)
+    public function setPictureId(int $picture_id = 0) : void
     {
         if ($picture_id >= 0) {
             $this->picture_or_definition_id = $picture_id;
@@ -180,7 +180,7 @@ class ASS_AnswerMatching
     * @access public
     * @see $picture_or_definition_id
     */
-    public function setDefinitionId(int $definition_id = 0)
+    public function setDefinitionId(int $definition_id = 0) : void
     {
         if ($definition_id >= 0) {
             $this->picture_or_definition_id = $definition_id;
@@ -194,7 +194,7 @@ class ASS_AnswerMatching
     * @access public
     * @see $picture_or_definition
     */
-    public function setPicture(string $picture = "")
+    public function setPicture(string $picture = "") : void
     {
         $this->picture_or_definition = $picture;
     }
@@ -206,7 +206,7 @@ class ASS_AnswerMatching
     * @access public
     * @see $picture_or_definition
     */
-    public function setDefinition(string $definition = "")
+    public function setDefinition(string $definition = "") : void
     {
         $this->picture_or_definition = $definition;
     }
@@ -219,7 +219,7 @@ class ASS_AnswerMatching
     * @access public
     * @see $points
     */
-    public function setPoints(float $points = 0.0)
+    public function setPoints(float $points = 0.0) : void
     {
         $this->points = $points;
     }

--- a/Modules/TestQuestionPool/classes/class.assAnswerMultipleResponse.php
+++ b/Modules/TestQuestionPool/classes/class.assAnswerMultipleResponse.php
@@ -65,7 +65,7 @@ class ASS_AnswerMultipleResponse extends ASS_AnswerSimple
     * @access public
     * @see $state
     */
-    public function setPointsUnchecked($points_unchecked = 0.0)
+    public function setPointsUnchecked($points_unchecked = 0.0) : void
     {
         $new_points = str_replace(",", ".", $points_unchecked);
         
@@ -76,7 +76,7 @@ class ASS_AnswerMultipleResponse extends ASS_AnswerSimple
         }
     }
 
-    public function setPointsChecked($points_checked)
+    public function setPointsChecked($points_checked) : void
     {
         $this->setPoints($points_checked);
     }

--- a/Modules/TestQuestionPool/classes/class.assAnswerMultipleResponseImage.php
+++ b/Modules/TestQuestionPool/classes/class.assAnswerMultipleResponseImage.php
@@ -68,7 +68,7 @@ class ASS_AnswerMultipleResponseImage extends ASS_AnswerMultipleResponse
     * @access public
     * @see $image
     */
-    public function setImage($a_image = 0)
+    public function setImage($a_image = 0) : void
     {
         $this->image = $a_image;
     }

--- a/Modules/TestQuestionPool/classes/class.assAnswerSimple.php
+++ b/Modules/TestQuestionPool/classes/class.assAnswerSimple.php
@@ -145,7 +145,7 @@ class ASS_AnswerSimple
      *
      * @TODO Find usage and see if we can get rid of "magic ignorance" of the input value.
      */
-    public function setOrder($order = 0)
+    public function setOrder($order = 0) : void
     {
         if ($order >= 0) {
             $this->order = $order;
@@ -159,7 +159,7 @@ class ASS_AnswerSimple
      *
      * @see $id
      */
-    public function setId($id = -1)
+    public function setId($id = -1) : void
     {
         $this->id = $id;
     }
@@ -173,7 +173,7 @@ class ASS_AnswerSimple
      *
      * @see $answertext
      */
-    public function setAnswertext($answertext = "")
+    public function setAnswertext($answertext = "") : void
     {
         $this->answertext = $answertext;
     }
@@ -189,7 +189,7 @@ class ASS_AnswerSimple
      *
      * @TODO Find usages and see if we can get rid of "magic nullification" here.
      */
-    public function setPoints($points = 0.0)
+    public function setPoints($points = 0.0) : void
     {
         $new_points = str_replace(",", ".", $points);
         if ($this->checkPoints($new_points)) {

--- a/Modules/TestQuestionPool/classes/class.assAnswerTrueFalse.php
+++ b/Modules/TestQuestionPool/classes/class.assAnswerTrueFalse.php
@@ -108,7 +108,7 @@ class ASS_AnswerTrueFalse extends ASS_AnswerSimple
      *
      * @param boolean $correctness A boolean value indicating the correctness of the answer
      */
-    public function setCorrectness($correctness = false)
+    public function setCorrectness($correctness = false) : void
     {
         // force $this->correctness to be a string
         // ilDB->quote makes 1 from true and saving it to ENUM('1','0') makes that '0'!!!
@@ -121,7 +121,7 @@ class ASS_AnswerTrueFalse extends ASS_AnswerSimple
      *
      * @deprecated Use setCorrectness instead.
      */
-    public function setTrue()
+    public function setTrue() : void
     {
         $this->correctness = "1";
     }
@@ -131,7 +131,7 @@ class ASS_AnswerTrueFalse extends ASS_AnswerSimple
      *
      *@deprecated Use setCorrectness instead.
      */
-    public function setFalse()
+    public function setFalse() : void
     {
         $this->correctness = "0";
     }

--- a/Modules/TestQuestionPool/classes/class.assClozeGap.php
+++ b/Modules/TestQuestionPool/classes/class.assClozeGap.php
@@ -79,7 +79,7 @@ class assClozeGap
      *
      * @see $type for mapping.
      */
-    public function setType($a_type = 0)
+    public function setType($a_type = 0) : void
     {
         $this->type = $a_type;
     }
@@ -136,7 +136,7 @@ class assClozeGap
     * @access public
     * @see $items
     */
-    public function addItem($a_item)
+    public function addItem($a_item) : void
     {
         $order = $a_item->getOrder();
         if (array_key_exists($order, $this->items)) {
@@ -169,7 +169,7 @@ class assClozeGap
     * @access public
     * @see $items
     */
-    public function setItemPoints($order, $points)
+    public function setItemPoints($order, $points) : void
     {
         foreach ($this->items as $key => $item) {
             if ($item->getOrder() == $order) {
@@ -187,7 +187,7 @@ class assClozeGap
     * @access public
     * @see $items
     */
-    public function deleteItem($order)
+    public function deleteItem($order) : void
     {
         if (array_key_exists($order, $this->items)) {
             unset($this->items[$order]);
@@ -209,7 +209,7 @@ class assClozeGap
     * @access public
     * @see $items
     */
-    public function setItemLowerBound($order, $bound)
+    public function setItemLowerBound($order, $bound) : void
     {
         foreach ($this->items as $key => $item) {
             if ($item->getOrder() == $order) {
@@ -228,7 +228,7 @@ class assClozeGap
     * @access public
     * @see $items
     */
-    public function setItemUpperBound($order, $bound)
+    public function setItemUpperBound($order, $bound) : void
     {
         foreach ($this->items as $key => $item) {
             if ($item->getOrder() == $order) {
@@ -264,7 +264,7 @@ class assClozeGap
     * @access public
     * @see $items
     */
-    public function clearItems()
+    public function clearItems() : void
     {
         $this->items = array();
     }
@@ -276,7 +276,7 @@ class assClozeGap
      *
      * @param boolean $a_shuffle Shuffle state
      */
-    public function setShuffle($a_shuffle = true)
+    public function setShuffle($a_shuffle = true) : void
     {
         $this->shuffle = (bool) $a_shuffle;
     }
@@ -386,7 +386,7 @@ class assClozeGap
     /**
      * @param integer $gap_size
      */
-    public function setGapSize($gap_size)
+    public function setGapSize($gap_size) : void
     {
         $this->gap_size = $gap_size;
     }

--- a/Modules/TestQuestionPool/classes/class.assClozeGapCombination.php
+++ b/Modules/TestQuestionPool/classes/class.assClozeGapCombination.php
@@ -60,7 +60,7 @@ class assClozeGapCombination
         return $clean_array;
     }
     
-    public function saveGapCombinationToDb($question_id, $gap_combinations, $gap_values)
+    public function saveGapCombinationToDb($question_id, $gap_combinations, $gap_values) : void
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];
@@ -108,7 +108,7 @@ class assClozeGapCombination
             }
         }
     }
-    public static function importGapCombinationToDb($question_id, $gap_combinations)
+    public static function importGapCombinationToDb($question_id, $gap_combinations) : void
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];
@@ -144,7 +144,7 @@ class assClozeGapCombination
         }
     }
 
-    public static function clearGapCombinationsFromDb($question_id)
+    public static function clearGapCombinationsFromDb($question_id) : void
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];

--- a/Modules/TestQuestionPool/classes/class.assClozeTest.php
+++ b/Modules/TestQuestionPool/classes/class.assClozeTest.php
@@ -378,7 +378,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
      * @param $gap
      * @param $key
      */
-    protected function saveClozeGapItemsToDb($gap, $key)
+    protected function saveClozeGapItemsToDb($gap, $key) : void
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];
@@ -407,7 +407,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
      * @param $item				mixed Gap item data object.
      * @param $gap				mixed Gap data object.
      */
-    protected function saveClozeTextGapRecordToDb($next_id, $key, $item, $gap)
+    protected function saveClozeTextGapRecordToDb($next_id, $key, $item, $gap) : void
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];
@@ -444,7 +444,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
      * @param $item				mixed Gap item data object.
      * @param $gap				mixed Gap data object.
      */
-    protected function saveClozeSelectGapRecordToDb($next_id, $key, $item, $gap)
+    protected function saveClozeSelectGapRecordToDb($next_id, $key, $item, $gap) : void
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];
@@ -481,7 +481,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
      * @param $item				mixed Gap item data object.
      * @param $gap				mixed Gap data object.
      */
-    protected function saveClozeNumericGapRecordToDb($next_id, $key, $item, $gap)
+    protected function saveClozeNumericGapRecordToDb($next_id, $key, $item, $gap) : void
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];
@@ -544,7 +544,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
     * @access public
     * @see $gaps
     */
-    public function flushGaps()
+    public function flushGaps() : void
     {
         $this->gaps = array();
     }
@@ -558,7 +558,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
     * @access public
     * @see $cloze_text
     */
-    public function setClozeText($cloze_text = "")
+    public function setClozeText($cloze_text = "") : void
     {
         $this->gaps = array();
         $cloze_text = $this->cleanQuestiontext($cloze_text);
@@ -566,7 +566,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
         $this->createGapsFromQuestiontext();
     }
 
-    public function setClozeTextValue($cloze_text = "")
+    public function setClozeTextValue($cloze_text = "") : void
     {
         $this->cloze_text = $cloze_text;
     }
@@ -618,7 +618,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
     * @access public
     * @see $start_tag
     */
-    public function setStartTag($start_tag = "[gap]")
+    public function setStartTag($start_tag = "[gap]") : void
     {
         $this->start_tag = $start_tag;
     }
@@ -642,7 +642,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
     * @access public
     * @see $end_tag
     */
-    public function setEndTag($end_tag = "[/gap]")
+    public function setEndTag($end_tag = "[/gap]") : void
     {
         $this->end_tag = $end_tag;
     }
@@ -658,7 +658,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
     /**
      * @param string $feedbackMode
      */
-    public function setFeedbackMode($feedbackMode)
+    public function setFeedbackMode($feedbackMode) : void
     {
         $this->feedbackMode = $feedbackMode;
     }
@@ -669,7 +669,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
     * @access public
     * @see $gaps
     */
-    public function createGapsFromQuestiontext()
+    public function createGapsFromQuestiontext() : void
     {
         include_once "./Modules/TestQuestionPool/classes/class.assClozeGap.php";
         include_once "./Modules/TestQuestionPool/classes/class.assAnswerCloze.php";
@@ -695,7 +695,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
     *
     * @access private
     */
-    public function setGapType($gap_index, $gap_type)
+    public function setGapType($gap_index, $gap_type) : void
     {
         if (array_key_exists($gap_index, $this->gaps)) {
             $this->gaps[$gap_index]->setType($gap_type);
@@ -711,7 +711,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
     * @access public
     * @see $gaps
     */
-    public function setGapShuffle($gap_index = 0, $shuffle = 1)
+    public function setGapShuffle($gap_index = 0, $shuffle = 1) : void
     {
         if (array_key_exists($gap_index, $this->gaps)) {
             $this->gaps[$gap_index]->setShuffle($shuffle);
@@ -724,7 +724,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
     * @access public
     * @see $gaps
     */
-    public function clearGapAnswers()
+    public function clearGapAnswers() : void
     {
         foreach ($this->gaps as $gap_index => $gap) {
             $this->gaps[$gap_index]->clearItems();
@@ -757,7 +757,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
     * @access public
     * @see $gaps
     */
-    public function addGapAnswer($gap_index, $order, $answer)
+    public function addGapAnswer($gap_index, $order, $answer) : void
     {
         if (array_key_exists($gap_index, $this->gaps)) {
             if ($this->gaps[$gap_index]->getType() == CLOZE_NUMERIC) {
@@ -783,7 +783,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
         }
     }
 
-    public function setGapSize($gap_index, $order, $size)
+    public function setGapSize($gap_index, $order, $size) : void
     {
         if (array_key_exists($gap_index, $this->gaps)) {
             $this->gaps[$gap_index]->setGapSize($size);
@@ -800,7 +800,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
     * @access public
     * @see $gaps
     */
-    public function setGapAnswerPoints($gap_index, $order, $points)
+    public function setGapAnswerPoints($gap_index, $order, $points) : void
     {
         if (array_key_exists($gap_index, $this->gaps)) {
             $this->gaps[$gap_index]->setItemPoints($order, $points);
@@ -815,7 +815,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
     * @access public
     * @see $gaps
     */
-    public function addGapText($gap_index)
+    public function addGapText($gap_index) : void
     {
         if (array_key_exists($gap_index, $this->gaps)) {
             include_once "./Modules/TestQuestionPool/classes/class.assAnswerCloze.php";
@@ -836,7 +836,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
     * @access public
     * @see $gaps
     */
-    public function addGapAtIndex($gap, $index)
+    public function addGapAtIndex($gap, $index) : void
     {
         $this->gaps[$index] = $gap;
     }
@@ -851,7 +851,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
     * @access public
     * @see $gaps
     */
-    public function setGapAnswerLowerBound($gap_index, $order, $bound)
+    public function setGapAnswerLowerBound($gap_index, $order, $bound) : void
     {
         if (array_key_exists($gap_index, $this->gaps)) {
             $this->gaps[$gap_index]->setItemLowerBound($order, $bound);
@@ -868,7 +868,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
     * @access public
     * @see $gaps
     */
-    public function setGapAnswerUpperBound($gap_index, $order, $bound)
+    public function setGapAnswerUpperBound($gap_index, $order, $bound) : void
     {
         if (array_key_exists($gap_index, $this->gaps)) {
             $this->gaps[$gap_index]->setItemUpperBound($order, $bound);
@@ -1056,7 +1056,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
         return $clone->id;
     }
 
-    public function copyGapCombination($orgID, $newID)
+    public function copyGapCombination($orgID, $newID) : void
     {
         $assClozeGapCombinationObj = new assClozeGapCombination();
         $array = $assClozeGapCombinationObj->loadFromDb($orgID);
@@ -1068,7 +1068,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
     *
     * @access private
     */
-    public function updateClozeTextFromGaps()
+    public function updateClozeTextFromGaps() : void
     {
         $output = $this->getClozeText();
         foreach ($this->getGaps() as $gap_index => $gap) {
@@ -1093,7 +1093,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
     * @access public
     * @see $gaps
     */
-    public function deleteAnswerText($gap_index, $answer_index)
+    public function deleteAnswerText($gap_index, $answer_index) : void
     {
         if (array_key_exists($gap_index, $this->gaps)) {
             if ($this->gaps[$gap_index]->getItemCount() == 1) {
@@ -1115,7 +1115,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
     * @access public
     * @see $gaps
     */
-    public function deleteGap($gap_index)
+    public function deleteGap($gap_index) : void
     {
         if (array_key_exists($gap_index, $this->gaps)) {
             $output = $this->getClozeText();
@@ -1465,7 +1465,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
     * @see $textgap_rating
     * @access public
     */
-    public function setTextgapRating($a_textgap_rating)
+    public function setTextgapRating($a_textgap_rating) : void
     {
         switch ($a_textgap_rating) {
             case TEXTGAP_RATING_CASEINSENSITIVE:
@@ -1502,7 +1502,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
     * @see $identical_scoring
     * @access public
     */
-    public function setIdenticalScoring($a_identical_scoring)
+    public function setIdenticalScoring($a_identical_scoring) : void
     {
         $this->identical_scoring = ($a_identical_scoring) ? 1 : 0;
     }
@@ -1529,7 +1529,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
     * @param integer $a_text_len The text field length
     * @access public
     */
-    public function setFixedTextLength($a_text_len)
+    public function setFixedTextLength($a_text_len) : void
     {
         $this->fixedTextLength = $a_text_len;
     }
@@ -1587,12 +1587,12 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
         return $this->gap_combinations;
     }
 
-    public function setGapCombinationsExists($value)
+    public function setGapCombinationsExists($value) : void
     {
         $this->gap_combinations_exists = $value;
     }
 
-    public function setGapCombinations($value)
+    public function setGapCombinations($value) : void
     {
         $this->gap_combinations = $value;
     }

--- a/Modules/TestQuestionPool/classes/class.assClozeTestGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assClozeTestGUI.php
@@ -774,7 +774,7 @@ class assClozeTestGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
     /**
     * Create gaps from cloze text
     */
-    public function createGaps()
+    public function createGaps() : void
     {
         $this->writePostData(true);
         $this->object->saveToDb();
@@ -784,7 +784,7 @@ class assClozeTestGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
     /**
     * Remove a gap answer
     */
-    public function removegap()
+    public function removegap() : void
     {
         $this->writePostData(true);
         $this->object->deleteAnswerText($this->gapIndex, key($_POST['cmd']['removegap_' . $this->gapIndex]));
@@ -794,7 +794,7 @@ class assClozeTestGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
     /**
     * Add a gap answer
     */
-    public function addgap()
+    public function addgap() : void
     {
         $this->writePostData(true);
         $this->object->addGapAnswer($this->gapIndex, key($_POST['cmd']['addgap_' . $this->gapIndex]) + 1, "");
@@ -1533,7 +1533,7 @@ class assClozeTestGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
      * @param $gaptemplate
      * @param $solutiontext
      */
-    private function populateSolutiontextToGapTpl($gaptemplate, $gap, $solutiontext)
+    private function populateSolutiontextToGapTpl($gaptemplate, $gap, $solutiontext) : void
     {
         if ($this->renderPurposeSupportsFormHtml() || $this->isRenderPurposePrintPdf()) {
             $gaptemplate->setCurrentBlock('gap_span');
@@ -1724,7 +1724,7 @@ class assClozeTestGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
         }
     }
 
-    protected function populateGapCombinationCorrectionFormProperty(ilPropertyFormGUI $form, $gapCombi, $combiIndex)
+    protected function populateGapCombinationCorrectionFormProperty(ilPropertyFormGUI $form, $gapCombi, $combiIndex) : void
     {
         $header = new ilFormSectionHeaderGUI();
         $header->setTitle("Gap Combination " . ($combiIndex + 1));
@@ -1741,7 +1741,7 @@ class assClozeTestGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
      * @param assClozeGap $gap
      * @param integer $gapIndex
      */
-    protected function populateGapCorrectionFormProperties($form, $gap, $gapIndex, $hidePoints)
+    protected function populateGapCorrectionFormProperties($form, $gap, $gapIndex, $hidePoints) : void
     {
         $header = new ilFormSectionHeaderGUI();
         $header->setTitle($this->lng->txt("gap") . " " . ($gapIndex + 1));
@@ -1756,7 +1756,7 @@ class assClozeTestGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
         }
     }
 
-    protected function populateTextOrSelectGapCorrectionFormProperty($form, $gap, $gapIndex, $hidePoints)
+    protected function populateTextOrSelectGapCorrectionFormProperty($form, $gap, $gapIndex, $hidePoints) : void
     {
         require_once "Modules/TestQuestionPool/classes/forms/class.ilAssAnswerCorrectionsInputGUI.php";
         $values = new ilAssAnswerCorrectionsInputGUI($this->lng->txt("values"), "gap_" . $gapIndex);
@@ -1767,7 +1767,7 @@ class assClozeTestGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
         $form->addItem($values);
     }
 
-    protected function populateNumericGapCorrectionFormProperty($form, $item, $gapIndex, $hidePoints)
+    protected function populateNumericGapCorrectionFormProperty($form, $item, $gapIndex, $hidePoints) : void
     {
         $value = new ilNumberInputGUI($this->lng->txt('value'), "gap_" . $gapIndex . "_numeric");
         $value->allowDecimals(true);
@@ -1818,7 +1818,7 @@ class assClozeTestGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
         }
     }
 
-    protected function saveGapCorrectionFormProperty(ilPropertyFormGUI $form, assClozeGap $gap, $gapIndex)
+    protected function saveGapCorrectionFormProperty(ilPropertyFormGUI $form, assClozeGap $gap, $gapIndex) : void
     {
         if ($gap->getType() == CLOZE_TEXT || $gap->getType() == CLOZE_SELECT) {
             $this->saveTextOrSelectGapCorrectionFormProperty($form, $gap, $gapIndex);
@@ -1829,7 +1829,7 @@ class assClozeTestGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
         }
     }
 
-    protected function saveTextOrSelectGapCorrectionFormProperty(ilPropertyFormGUI $form, assClozeGap $gap, $gapIndex)
+    protected function saveTextOrSelectGapCorrectionFormProperty(ilPropertyFormGUI $form, assClozeGap $gap, $gapIndex) : void
     {
         $answers = $form->getItemByPostVar('gap_' . $gapIndex)->getValues();
 
@@ -1838,7 +1838,7 @@ class assClozeTestGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
         }
     }
 
-    protected function saveNumericGapCorrectionFormProperty(ilPropertyFormGUI $form, assAnswerCloze $item, $gapIndex)
+    protected function saveNumericGapCorrectionFormProperty(ilPropertyFormGUI $form, assAnswerCloze $item, $gapIndex) : void
     {
         $item->setAnswertext($form->getInput('gap_' . $gapIndex . '_numeric'));
         $item->setLowerBound($form->getInput('gap_' . $gapIndex . '_numeric_lower'));
@@ -1846,7 +1846,7 @@ class assClozeTestGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
         $item->setPoints((float) $form->getInput('gap_' . $gapIndex . '_numeric_points'));
     }
 
-    protected function saveGapCombinationCorrectionFormProperties(ilPropertyFormGUI $form)
+    protected function saveGapCombinationCorrectionFormProperties(ilPropertyFormGUI $form) : void
     {
         // please dont ask (!) -.-
 

--- a/Modules/TestQuestionPool/classes/class.assErrorText.php
+++ b/Modules/TestQuestionPool/classes/class.assErrorText.php
@@ -578,7 +578,7 @@ class assErrorText extends assQuestion implements ilObjQuestionScoringAdjustable
         return array();
     }
 
-    public function setErrorData($a_data)
+    public function setErrorData($a_data) : void
     {
         include_once "./Modules/TestQuestionPool/classes/class.assAnswerErrorText.php";
         $temp = $this->errordata;
@@ -981,12 +981,12 @@ class assErrorText extends assQuestion implements ilObjQuestionScoringAdjustable
     /**
     * Flush error data
     */
-    public function flushErrorData()
+    public function flushErrorData() : void
     {
         $this->errordata = array();
     }
 
-    public function addErrorData($text_wrong, $text_correct, $points)
+    public function addErrorData($text_wrong, $text_correct, $points) : void
     {
         include_once "./Modules/TestQuestionPool/classes/class.assAnswerErrorText.php";
         array_push($this->errordata, new assAnswerErrorText($text_wrong, $text_correct, $points));
@@ -1017,7 +1017,7 @@ class assErrorText extends assQuestion implements ilObjQuestionScoringAdjustable
     *
     * @param string $a_value Error text
     */
-    public function setErrorText($a_value)
+    public function setErrorText($a_value) : void
     {
         $this->errortext = $a_value;
     }
@@ -1037,7 +1037,7 @@ class assErrorText extends assQuestion implements ilObjQuestionScoringAdjustable
     *
     * @param double $a_value text size in percent
     */
-    public function setTextSize($a_value)
+    public function setTextSize($a_value) : void
     {
         // in self-assesment-mode value should always be set (and must not be null)
         if ($a_value === null) {
@@ -1061,7 +1061,7 @@ class assErrorText extends assQuestion implements ilObjQuestionScoringAdjustable
     *
     * @param double $a_value Points for wrong selection
     */
-    public function setPointsWrong($a_value)
+    public function setPointsWrong($a_value) : void
     {
         $this->points_wrong = $a_value;
     }

--- a/Modules/TestQuestionPool/classes/class.assErrorTextGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assErrorTextGUI.php
@@ -204,7 +204,7 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
     /**
     * Parse the error text
     */
-    public function analyze()
+    public function analyze() : void
     {
         $this->writePostData(true);
         $this->object->setErrorData($this->object->getErrorsFromText($_POST['errortext']));

--- a/Modules/TestQuestionPool/classes/class.assFileUpload.php
+++ b/Modules/TestQuestionPool/classes/class.assFileUpload.php
@@ -525,7 +525,7 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
     *
   * @param array Array with ID's of the file datasets
     */
-    protected function deleteUploadedFiles($files, $test_id, $active_id, $authorized)
+    protected function deleteUploadedFiles($files, $test_id, $active_id, $authorized) : void
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];
@@ -561,7 +561,7 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
      * @param int	$active_id
      * @param int	$pass
      */
-    protected function deleteUnusedFiles($test_id, $active_id, $pass)
+    protected function deleteUnusedFiles($test_id, $active_id, $pass) : void
     {
         // read all solutions (authorized and intermediate) from all steps
         $step = $this->getStep();
@@ -877,7 +877,7 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
      * @param	integer
      * @access	protected
      */
-    protected function handleSubmission($active_id, $pass, $obligationsAnswered, $authorized)
+    protected function handleSubmission($active_id, $pass, $obligationsAnswered, $authorized) : void
     {
         if (!$authorized) {
             return;
@@ -1035,7 +1035,7 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
     *
     * @param double $a_value Max file size
     */
-    public function setMaxSize($a_value)
+    public function setMaxSize($a_value) : void
     {
         $this->maxsize = $a_value;
     }
@@ -1068,7 +1068,7 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
     *
     * @param string $a_value Allowed file extensions
     */
-    public function setAllowedExtensions($a_value)
+    public function setAllowedExtensions($a_value) : void
     {
         $this->allowedextensions = strtolower(trim($a_value));
     }
@@ -1142,7 +1142,7 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
      *
      * @param int $test_id
      */
-    public function deliverFileUploadZIPFile($ref_id, $test_id, $test_title)
+    public function deliverFileUploadZIPFile($ref_id, $test_id, $test_title) : void
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];

--- a/Modules/TestQuestionPool/classes/class.assFlashQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assFlashQuestion.php
@@ -115,7 +115,7 @@ class assFlashQuestion extends assQuestion implements ilObjQuestionScoringAdjust
      * Moves an applet file (maybe stored in the PHP session) to its final filesystem destination
      * @throws \ilFileUtilsException
      */
-    protected function moveAppletIfExists()
+    protected function moveAppletIfExists() : void
     {
         if (ilSession::get('flash_upload_filename') != null &&
             file_exists(ilSession::get('flash_upload_filename')) && is_file(ilSession::get('flash_upload_filename'))
@@ -345,7 +345,7 @@ class assFlashQuestion extends assQuestion implements ilObjQuestionScoringAdjust
     * @access public
     * @see $points
     */
-    protected function copyApplet($question_id, $source_questionpool)
+    protected function copyApplet($question_id, $source_questionpool) : void
     {
         $flashpath = $this->getFlashPath();
         $flashpath_original = preg_replace("/([^\d])$this->id([^\d])/", "\${1}$question_id\${2}", $flashpath);
@@ -463,7 +463,7 @@ class assFlashQuestion extends assQuestion implements ilObjQuestionScoringAdjust
         return $result;
     }
 
-    public function deleteApplet()
+    public function deleteApplet() : void
     {
         @unlink($this->getFlashPath() . $this->getApplet());
         $this->applet = "";
@@ -607,7 +607,7 @@ class assFlashQuestion extends assQuestion implements ilObjQuestionScoringAdjust
         return $user_solution;
     }
 
-    public function setHeight($a_height)
+    public function setHeight($a_height) : void
     {
         if (!$a_height) {
             $a_height = 400;
@@ -620,7 +620,7 @@ class assFlashQuestion extends assQuestion implements ilObjQuestionScoringAdjust
         return $this->height;
     }
 
-    public function setWidth($a_width)
+    public function setWidth($a_width) : void
     {
         if (!$a_width) {
             $a_width = 550;
@@ -633,7 +633,7 @@ class assFlashQuestion extends assQuestion implements ilObjQuestionScoringAdjust
         return $this->width;
     }
 
-    public function setApplet($a_applet)
+    public function setApplet($a_applet) : void
     {
         $this->applet = $a_applet;
     }
@@ -643,12 +643,12 @@ class assFlashQuestion extends assQuestion implements ilObjQuestionScoringAdjust
         return $this->applet;
     }
 
-    public function addParameter($name, $value)
+    public function addParameter($name, $value) : void
     {
         $this->parameters[$name] = $value;
     }
 
-    public function setParameters($params)
+    public function setParameters($params) : void
     {
         if (is_array($params)) {
             $this->parameters = $params;
@@ -657,12 +657,12 @@ class assFlashQuestion extends assQuestion implements ilObjQuestionScoringAdjust
         }
     }
 
-    public function removeParameter($name)
+    public function removeParameter($name) : void
     {
         unset($this->parameters[$name]);
     }
 
-    public function clearParameters()
+    public function clearParameters() : void
     {
         $this->parameters = array();
     }

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestion.php
@@ -131,7 +131,7 @@ class assFormulaQuestion extends assQuestion implements iQuestionCondition
         return false;
     }
 
-    public function parseQuestionText()
+    public function parseQuestionText() : void
     {
         $this->clearResults();
         $this->clearVariables();
@@ -1310,7 +1310,7 @@ class assFormulaQuestion extends assQuestion implements iQuestionCondition
     /**
      * @param \ilUnitConfigurationRepository $unitrepository
      */
-    public function setUnitrepository($unitrepository)
+    public function setUnitrepository($unitrepository) : void
     {
         $this->unitrepository = $unitrepository;
     }

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
@@ -140,7 +140,7 @@ class assFormulaQuestionGUI extends assQuestionGUI
      * Suggest a range for a result
      * @access public
      */
-    public function suggestRange()
+    public function suggestRange() : void
     {
         if ($this->writePostData()) {
             $this->tpl->setOnScreenMessage('info', $this->getErrorMessage());
@@ -273,7 +273,7 @@ class assFormulaQuestionGUI extends assQuestionGUI
         }
     }
 
-    public function resetSavedPreviewSession()
+    public function resetSavedPreviewSession() : void
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];
@@ -816,13 +816,13 @@ class assFormulaQuestionGUI extends assQuestionGUI
         }
     }
 
-    public function parseQuestion()
+    public function parseQuestion() : void
     {
         $this->writePostData();
         $this->editQuestion();
     }
     
-    public function saveReturnFQ()
+    public function saveReturnFQ() : void
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];
@@ -900,7 +900,7 @@ class assFormulaQuestionGUI extends assQuestionGUI
         }
     }
 
-    public function saveFQ()
+    public function saveFQ() : void
     {
         $result = $this->writePostData();
 

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionResult.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionResult.php
@@ -142,7 +142,7 @@ class assFormulaQuestionResult
         return $result;
     }
 
-    public function findValidRandomVariables($variables, $results)
+    public function findValidRandomVariables($variables, $results) : void
     {
         include_once "./Services/Math/classes/class.EvalMath.php";
         $i = 0;
@@ -179,7 +179,7 @@ class assFormulaQuestionResult
         }
     }
 
-    public function suggestRange($variables, $results)
+    public function suggestRange($variables, $results) : void
     {
         
 //		@todo Check this
@@ -609,7 +609,7 @@ class assFormulaQuestionResult
      * Getter and Setter
      ************************************/
 
-    public function setResult($result)
+    public function setResult($result) : void
     {
         $this->result = $result;
     }
@@ -619,7 +619,7 @@ class assFormulaQuestionResult
         return $this->result;
     }
 
-    public function setRangeMin($range_min)
+    public function setRangeMin($range_min) : void
     {
         //		include_once "./Services/Math/classes/class.EvalMath.php";
         //		$math = new EvalMath();
@@ -651,7 +651,7 @@ class assFormulaQuestionResult
         return $this->getRangeMin();
     }
 
-    public function setRangeMax($range_max)
+    public function setRangeMax($range_max) : void
     {
         //		include_once "./Services/Math/classes/class.EvalMath.php";
         //		$math = new EvalMath();
@@ -683,7 +683,7 @@ class assFormulaQuestionResult
         return $this->getRangeMax();
     }
 
-    public function setTolerance($tolerance)
+    public function setTolerance($tolerance) : void
     {
         $this->tolerance = $tolerance;
     }
@@ -693,7 +693,7 @@ class assFormulaQuestionResult
         return $this->tolerance;
     }
 
-    public function setUnit($unit)
+    public function setUnit($unit) : void
     {
         $this->unit = $unit;
     }
@@ -703,7 +703,7 @@ class assFormulaQuestionResult
         return $this->unit;
     }
 
-    public function setFormula($formula)
+    public function setFormula($formula) : void
     {
         $this->formula = $formula;
     }
@@ -713,7 +713,7 @@ class assFormulaQuestionResult
         return $this->formula;
     }
 
-    public function setPoints($points)
+    public function setPoints($points) : void
     {
         $this->points = $points;
     }
@@ -723,7 +723,7 @@ class assFormulaQuestionResult
         return $this->points;
     }
 
-    public function setRatingSimple($rating_simple)
+    public function setRatingSimple($rating_simple) : void
     {
         $this->rating_simple = $rating_simple;
     }
@@ -733,7 +733,7 @@ class assFormulaQuestionResult
         return $this->rating_simple;
     }
 
-    public function setRatingSign($rating_sign)
+    public function setRatingSign($rating_sign) : void
     {
         $this->rating_sign = $rating_sign;
     }
@@ -743,7 +743,7 @@ class assFormulaQuestionResult
         return $this->rating_sign;
     }
 
-    public function setRatingValue($rating_value)
+    public function setRatingValue($rating_value) : void
     {
         $this->rating_value = $rating_value;
     }
@@ -753,7 +753,7 @@ class assFormulaQuestionResult
         return $this->rating_value;
     }
 
-    public function setRatingUnit($rating_unit)
+    public function setRatingUnit($rating_unit) : void
     {
         $this->rating_unit = $rating_unit;
     }
@@ -763,7 +763,7 @@ class assFormulaQuestionResult
         return $this->rating_unit;
     }
 
-    public function setPrecision($precision)
+    public function setPrecision($precision) : void
     {
         $this->precision = $precision;
     }
@@ -773,7 +773,7 @@ class assFormulaQuestionResult
         return $this->precision;
     }
 
-    public function setResultType($a_result_type)
+    public function setResultType($a_result_type) : void
     {
         $this->result_type = $a_result_type;
     }
@@ -783,7 +783,7 @@ class assFormulaQuestionResult
         return (int) $this->result_type;
     }
 
-    public function setRangeMaxTxt($range_max_txt)
+    public function setRangeMaxTxt($range_max_txt) : void
     {
         $this->range_max_txt = $range_max_txt;
     }
@@ -793,7 +793,7 @@ class assFormulaQuestionResult
         return $this->range_max_txt;
     }
 
-    public function setRangeMinTxt($range_min_txt)
+    public function setRangeMinTxt($range_min_txt) : void
     {
         $this->range_min_txt = $range_min_txt;
     }

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionUnit.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionUnit.php
@@ -28,7 +28,7 @@ class assFormulaQuestionUnit
     /**
      * @param array $data
      */
-    public function initFormArray(array $data)
+    public function initFormArray(array $data) : void
     {
         $this->id = $data['unit_id'];
         $this->unit = $data['unit'];
@@ -42,7 +42,7 @@ class assFormulaQuestionUnit
     /**
      * @param string $baseunit_title
      */
-    public function setBaseunitTitle($baseunit_title)
+    public function setBaseunitTitle($baseunit_title) : void
     {
         $this->baseunit_title = $baseunit_title;
     }
@@ -55,7 +55,7 @@ class assFormulaQuestionUnit
         return $this->baseunit_title;
     }
     
-    public function setId($id)
+    public function setId($id) : void
     {
         $this->id = $id;
     }
@@ -65,7 +65,7 @@ class assFormulaQuestionUnit
         return $this->id;
     }
 
-    public function setUnit($unit)
+    public function setUnit($unit) : void
     {
         $this->unit = $unit;
     }
@@ -75,7 +75,7 @@ class assFormulaQuestionUnit
         return $this->unit;
     }
 
-    public function setSequence($sequence)
+    public function setSequence($sequence) : void
     {
         $this->sequence = $sequence;
     }
@@ -85,7 +85,7 @@ class assFormulaQuestionUnit
         return $this->sequence;
     }
 
-    public function setFactor($factor)
+    public function setFactor($factor) : void
     {
         $this->factor = $factor;
     }
@@ -95,7 +95,7 @@ class assFormulaQuestionUnit
         return $this->factor;
     }
 
-    public function setBaseUnit($baseunit)
+    public function setBaseUnit($baseunit) : void
     {
         if (is_numeric($baseunit) && $baseunit > 0) {
             $this->baseunit = $baseunit;
@@ -113,7 +113,7 @@ class assFormulaQuestionUnit
         }
     }
     
-    public function setCategory($category)
+    public function setCategory($category) : void
     {
         $this->category = $category;
     }

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionUnitCategory.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionUnitCategory.php
@@ -37,7 +37,7 @@ class assFormulaQuestionUnitCategory
     /**
      * @param array $data
      */
-    public function initFormArray(array $data)
+    public function initFormArray(array $data) : void
     {
         $this->id = $data['category_id'];
         $this->category = $data['category'];
@@ -47,7 +47,7 @@ class assFormulaQuestionUnitCategory
     /**
      * @param $id
      */
-    public function setId($id)
+    public function setId($id) : void
     {
         $this->id = $id;
     }
@@ -63,7 +63,7 @@ class assFormulaQuestionUnitCategory
     /**
      * @param $category
      */
-    public function setCategory($category)
+    public function setCategory($category) : void
     {
         $this->category = $category;
     }
@@ -79,7 +79,7 @@ class assFormulaQuestionUnitCategory
     /**
      * @param int $question_fi
      */
-    public function setQuestionFi($question_fi)
+    public function setQuestionFi($question_fi) : void
     {
         $this->question_fi = $question_fi;
     }

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionVariable.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionVariable.php
@@ -45,7 +45,6 @@ class assFormulaQuestionVariable
 
     public function getRandomValue()
     {
-        
         if ($this->getPrecision() == 0) {
             if ($this->getIntprecision() > $this->getRangeMax()) {
                 global $DIC;
@@ -85,7 +84,7 @@ class assFormulaQuestionVariable
         return $calcval;
     }
 
-    public function setRandomValue()
+    public function setRandomValue() : void
     {
         $this->setValue($this->getRandomValue());
     }
@@ -94,7 +93,7 @@ class assFormulaQuestionVariable
      * Getter and Setter
      ************************************/
 
-    public function setValue($value)
+    public function setValue($value) : void
     {
         $this->value = $value;
     }
@@ -114,7 +113,7 @@ class assFormulaQuestionVariable
         }
     }
 
-    public function setPrecision($precision)
+    public function setPrecision($precision) : void
     {
         $this->precision = $precision;
     }
@@ -126,7 +125,7 @@ class assFormulaQuestionVariable
         return $this->precision;
     }
 
-    public function setVariable($variable)
+    public function setVariable($variable) : void
     {
         $this->variable = $variable;
     }
@@ -136,7 +135,7 @@ class assFormulaQuestionVariable
         return $this->variable;
     }
 
-    public function setRangeMin($range_min)
+    public function setRangeMin($range_min) : void
     {
         include_once "./Services/Math/classes/class.EvalMath.php";
         $math = new EvalMath();
@@ -151,7 +150,7 @@ class assFormulaQuestionVariable
         return (double) $this->range_min;
     }
 
-    public function setRangeMax($range_max)
+    public function setRangeMax($range_max) : void
     {
         include_once "./Services/Math/classes/class.EvalMath.php";
         $math = new EvalMath();
@@ -165,7 +164,7 @@ class assFormulaQuestionVariable
         return (double) $this->range_max;
     }
 
-    public function setUnit($unit)
+    public function setUnit($unit) : void
     {
         $this->unit = $unit;
     }
@@ -175,7 +174,7 @@ class assFormulaQuestionVariable
         return $this->unit;
     }
 
-    public function setIntprecision($intprecision)
+    public function setIntprecision($intprecision) : void
     {
         $this->intprecision = $intprecision;
     }
@@ -185,7 +184,7 @@ class assFormulaQuestionVariable
         return $this->intprecision;
     }
 
-    public function setRangeMaxTxt($range_max_txt)
+    public function setRangeMaxTxt($range_max_txt) : void
     {
         $this->range_max_txt = $range_max_txt;
     }
@@ -195,7 +194,7 @@ class assFormulaQuestionVariable
         return $this->range_max_txt;
     }
 
-    public function setRangeMinTxt($range_min_txt)
+    public function setRangeMinTxt($range_min_txt) : void
     {
         $this->range_min_txt = $range_min_txt;
     }

--- a/Modules/TestQuestionPool/classes/class.assImagemapQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assImagemapQuestion.php
@@ -82,7 +82,7 @@ class assImagemapQuestion extends assQuestion implements ilObjQuestionScoringAdj
      *
      * @param bool $is_multiple_choice
      */
-    public function setIsMultipleChoice($is_multiple_choice)
+    public function setIsMultipleChoice($is_multiple_choice) : void
     {
         $this->is_multiple_choice = $is_multiple_choice;
     }
@@ -308,7 +308,7 @@ class assImagemapQuestion extends assQuestion implements ilObjQuestionScoringAdj
         return $clone->id;
     }
 
-    public function duplicateImage($question_id, $objectId = null)
+    public function duplicateImage($question_id, $objectId = null) : void
     {
         global $DIC;
         $ilLog = $DIC['ilLog'];
@@ -337,7 +337,7 @@ class assImagemapQuestion extends assQuestion implements ilObjQuestionScoringAdj
         }
     }
 
-    public function copyImage($question_id, $source_questionpool)
+    public function copyImage($question_id, $source_questionpool) : void
     {
         $imagepath = $this->getImagePath();
         $imagepath_original = str_replace("/$this->id/images", "/$question_id/images", $imagepath);
@@ -449,7 +449,7 @@ class assImagemapQuestion extends assQuestion implements ilObjQuestionScoringAdj
     * @access public
     * @see $image_filename
     */
-    public function setImageFilename($image_filename, $image_tempfilename = "")
+    public function setImageFilename($image_filename, $image_tempfilename = "") : void
     {
         if (!empty($image_filename)) {
             $image_filename = str_replace(" ", "_", $image_filename);
@@ -512,7 +512,7 @@ class assImagemapQuestion extends assQuestion implements ilObjQuestionScoringAdj
         $coords = "",
         $area = "",
         $points_unchecked = 0.0
-    ) {
+    ) : void {
         include_once "./Modules/TestQuestionPool/classes/class.assAnswerImagemap.php";
         if (array_key_exists($order, $this->answers)) {
             // Insert answer
@@ -598,7 +598,7 @@ class assImagemapQuestion extends assQuestion implements ilObjQuestionScoringAdj
     * @access public
     * @see $answers
     */
-    public function deleteArea($index = 0)
+    public function deleteArea($index = 0) : void
     {
         if ($index < 0) {
             return;
@@ -626,7 +626,7 @@ class assImagemapQuestion extends assQuestion implements ilObjQuestionScoringAdj
     * @access public
     * @see $answers
     */
-    public function flushAnswers()
+    public function flushAnswers() : void
     {
         $this->answers = array();
     }
@@ -909,7 +909,7 @@ class assImagemapQuestion extends assQuestion implements ilObjQuestionScoringAdj
     /**
     * Deletes the image file
     */
-    public function deleteImage()
+    public function deleteImage() : void
     {
         $file = $this->getImagePath() . $this->getImageFilename();
         @unlink($file);

--- a/Modules/TestQuestionPool/classes/class.assImagemapQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assImagemapQuestionGUI.php
@@ -56,7 +56,7 @@ class assImagemapQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         return $cmd;
     }
     
-    protected function deleteImage()
+    protected function deleteImage() : void
     {
         $this->object->deleteImage();
         $this->object->saveToDb();
@@ -213,17 +213,17 @@ class assImagemapQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         return $form;
     }
 
-    public function addRect()
+    public function addRect() : void
     {
         $this->areaEditor('rect');
     }
     
-    public function addCircle()
+    public function addCircle() : void
     {
         $this->areaEditor('circle');
     }
     
-    public function addPoly()
+    public function addPoly() : void
     {
         $this->areaEditor('poly');
     }
@@ -231,7 +231,7 @@ class assImagemapQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
     /**
     * Saves a shape of the area editor
     */
-    public function saveShape()
+    public function saveShape() : void
     {
         $coords = "";
         switch ($_POST["shape"]) {
@@ -255,7 +255,7 @@ class assImagemapQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         $this->ctrl->redirect($this, 'editQuestion');
     }
 
-    public function areaEditor($shape = '')
+    public function areaEditor($shape = '') : void
     {
         $shape = (strlen($shape)) ? $shape : $_POST['shape'];
 
@@ -376,7 +376,7 @@ class assImagemapQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         $this->tpl->setVariable('QUESTION_DATA', $editorTpl->get());
     }
 
-    public function back()
+    public function back() : void
     {
         $this->tpl->setOnScreenMessage('info', $this->lng->txt('msg_cancel'), true);
         $this->ctrl->redirect($this, 'editQuestion');

--- a/Modules/TestQuestionPool/classes/class.assKprimChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assKprimChoice.php
@@ -81,7 +81,7 @@ class assKprimChoice extends assQuestion implements ilObjQuestionScoringAdjustab
         return "qpl_a_kprim";
     }
 
-    public function setShuffleAnswersEnabled($shuffleAnswersEnabled)
+    public function setShuffleAnswersEnabled($shuffleAnswersEnabled) : void
     {
         $this->shuffleAnswersEnabled = $shuffleAnswersEnabled;
     }
@@ -91,7 +91,7 @@ class assKprimChoice extends assQuestion implements ilObjQuestionScoringAdjustab
         return $this->shuffleAnswersEnabled;
     }
 
-    public function setAnswerType($answerType)
+    public function setAnswerType($answerType) : void
     {
         $this->answerType = $answerType;
     }
@@ -101,7 +101,7 @@ class assKprimChoice extends assQuestion implements ilObjQuestionScoringAdjustab
         return $this->answerType;
     }
 
-    public function setThumbSize($thumbSize)
+    public function setThumbSize($thumbSize) : void
     {
         $this->thumbSize = $thumbSize;
     }
@@ -111,7 +111,7 @@ class assKprimChoice extends assQuestion implements ilObjQuestionScoringAdjustab
         return $this->thumbSize;
     }
 
-    public function setScorePartialSolutionEnabled($scorePartialSolutionEnabled)
+    public function setScorePartialSolutionEnabled($scorePartialSolutionEnabled) : void
     {
         $this->scorePartialSolutionEnabled = $scorePartialSolutionEnabled;
     }
@@ -121,7 +121,7 @@ class assKprimChoice extends assQuestion implements ilObjQuestionScoringAdjustab
         return $this->scorePartialSolutionEnabled;
     }
 
-    public function setOptionLabel($optionLabel)
+    public function setOptionLabel($optionLabel) : void
     {
         $this->optionLabel = $optionLabel;
     }
@@ -131,7 +131,7 @@ class assKprimChoice extends assQuestion implements ilObjQuestionScoringAdjustab
         return $this->optionLabel;
     }
 
-    public function setCustomTrueOptionLabel($customTrueOptionLabel)
+    public function setCustomTrueOptionLabel($customTrueOptionLabel) : void
     {
         $this->customTrueOptionLabel = $customTrueOptionLabel;
     }
@@ -141,7 +141,7 @@ class assKprimChoice extends assQuestion implements ilObjQuestionScoringAdjustab
         return $this->customTrueOptionLabel;
     }
 
-    public function setCustomFalseOptionLabel($customFalseOptionLabel)
+    public function setCustomFalseOptionLabel($customFalseOptionLabel) : void
     {
         $this->customFalseOptionLabel = $customFalseOptionLabel;
     }
@@ -151,7 +151,7 @@ class assKprimChoice extends assQuestion implements ilObjQuestionScoringAdjustab
         return $this->customFalseOptionLabel;
     }
 
-    public function setSpecificFeedbackSetting($specificFeedbackSetting)
+    public function setSpecificFeedbackSetting($specificFeedbackSetting) : void
     {
         $this->specificFeedbackSetting = $specificFeedbackSetting;
     }
@@ -161,7 +161,7 @@ class assKprimChoice extends assQuestion implements ilObjQuestionScoringAdjustab
         return $this->specificFeedbackSetting;
     }
 
-    public function setAnswers($answers)
+    public function setAnswers($answers) : void
     {
         $this->answers = $answers;
     }
@@ -182,7 +182,7 @@ class assKprimChoice extends assQuestion implements ilObjQuestionScoringAdjustab
         return null;
     }
     
-    public function addAnswer(ilAssKprimChoiceAnswer $answer)
+    public function addAnswer(ilAssKprimChoiceAnswer $answer) : void
     {
         $this->answers[] = $answer;
     }
@@ -251,7 +251,7 @@ class assKprimChoice extends assQuestion implements ilObjQuestionScoringAdjustab
         parent::loadFromDb($questionId);
     }
     
-    private function loadAnswerData($questionId)
+    private function loadAnswerData($questionId) : void
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];
@@ -581,7 +581,7 @@ class assKprimChoice extends assQuestion implements ilObjQuestionScoringAdjustab
         return self::THUMB_PREFIX;
     }
 
-    public function rebuildThumbnails()
+    public function rebuildThumbnails() : void
     {
         if ($this->isSingleLineAnswerType($this->getAnswerType()) && $this->getThumbSize()) {
             foreach ($this->getAnswers() as $answer) {
@@ -592,7 +592,7 @@ class assKprimChoice extends assQuestion implements ilObjQuestionScoringAdjustab
         }
     }
     
-    protected function generateThumbForFile($path, $file)
+    protected function generateThumbForFile($path, $file) : void
     {
         $filename = $path . $file;
         if (@file_exists($filename)) {
@@ -614,7 +614,7 @@ class assKprimChoice extends assQuestion implements ilObjQuestionScoringAdjustab
         }
     }
 
-    public function handleFileUploads($answers, $files)
+    public function handleFileUploads($answers, $files) : void
     {
         foreach ($answers as $answer) {
             /* @var ilAssKprimChoiceAnswer $answer */
@@ -647,7 +647,7 @@ class assKprimChoice extends assQuestion implements ilObjQuestionScoringAdjustab
         return 0;
     }
     
-    public function removeAnswerImage($position)
+    public function removeAnswerImage($position) : void
     {
         $answer = $this->getAnswer($position);
         
@@ -840,7 +840,7 @@ class assKprimChoice extends assQuestion implements ilObjQuestionScoringAdjustab
         $this->cloneAnswerImages($dupQuestionId, $dupParentObjId, $origQuestionId, $origParentObjId);
     }
 
-    protected function cloneAnswerImages($sourceQuestionId, $sourceParentId, $targetQuestionId, $targetParentId)
+    protected function cloneAnswerImages($sourceQuestionId, $sourceParentId, $targetQuestionId, $targetParentId) : void
     {
         /** @var $ilLog ilLogger */
         global $DIC;
@@ -1024,7 +1024,7 @@ class assKprimChoice extends assQuestion implements ilObjQuestionScoringAdjustab
         return $startrow + $i + 1;
     }
     
-    public function moveAnswerDown($position)
+    public function moveAnswerDown($position) : bool
     {
         if ($position < 0 || $position >= (self::NUM_REQUIRED_ANSWERS - 1)) {
             return false;

--- a/Modules/TestQuestionPool/classes/class.assKprimChoiceGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assKprimChoiceGUI.php
@@ -43,7 +43,7 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
         return array('uploadImage', 'removeImage');
     }
     
-    protected function editQuestion(ilPropertyFormGUI $form = null)
+    protected function editQuestion(ilPropertyFormGUI $form = null) : void
     {
         if ($form === null) {
             $form = $this->buildEditForm();
@@ -54,7 +54,7 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
         $this->tpl->setVariable("QUESTION_DATA", $this->ctrl->getHTML($form));
     }
 
-    protected function uploadImage()
+    protected function uploadImage() : void
     {
         $result = $this->writePostData(true);
         
@@ -64,7 +64,7 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
         }
     }
     
-    public function removeImage()
+    public function removeImage() : void
     {
         $position = key($_POST['cmd']['removeImage']);
         $this->object->removeAnswerImage($position);
@@ -73,7 +73,7 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
         $this->editQuestion();
     }
 
-    public function downkprim_answers()
+    public function downkprim_answers() : void
     {
         if (isset($_POST['cmd'][__FUNCTION__]) && count($_POST['cmd'][__FUNCTION__])) {
             $this->object->moveAnswerDown(key($_POST['cmd'][__FUNCTION__]));
@@ -83,7 +83,7 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
         $this->editQuestion();
     }
 
-    public function upkprim_answers()
+    public function upkprim_answers() : void
     {
         if (isset($_POST['cmd'][__FUNCTION__]) && count($_POST['cmd'][__FUNCTION__])) {
             $this->object->moveAnswerUp(key($_POST['cmd'][__FUNCTION__]));
@@ -722,7 +722,7 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
         return $choiceKeys;
     }
     
-    private function populateSpecificFeedbackInline($user_solution, $answer_id, $template)
+    private function populateSpecificFeedbackInline($user_solution, $answer_id, $template) : void
     {
         require_once 'Modules/TestQuestionPool/classes/feedback/class.ilAssConfigurableMultiOptionQuestionFeedback.php';
         

--- a/Modules/TestQuestionPool/classes/class.assLongMenu.php
+++ b/Modules/TestQuestionPool/classes/class.assLongMenu.php
@@ -57,7 +57,7 @@ class assLongMenu extends assQuestion implements ilObjQuestionScoringAdjustable
     /**
      * @param mixed $answerType
      */
-    public function setAnswerType($answerType)
+    public function setAnswerType($answerType) : void
     {
         $this->answerType = $answerType;
     }
@@ -71,7 +71,7 @@ class assLongMenu extends assQuestion implements ilObjQuestionScoringAdjustable
     }
 
 
-    public function setCorrectAnswers($correct_answers)
+    public function setCorrectAnswers($correct_answers) : void
     {
         $this->correct_answers = $correct_answers;
     }
@@ -86,7 +86,7 @@ class assLongMenu extends assQuestion implements ilObjQuestionScoringAdjustable
         return "qpl_a_lome";
     }
     
-    private function buildFileName($gap_id)
+    private function buildFileName($gap_id) : ?string
     {
         try {
             $this->assertDirExists();
@@ -96,7 +96,7 @@ class assLongMenu extends assQuestion implements ilObjQuestionScoringAdjustable
         return null;
     }
 
-    public function setLongMenuTextValue($long_menu_text = "")
+    public function setLongMenuTextValue($long_menu_text = "") : void
     {
         $this->long_menu_text = $long_menu_text;
     }
@@ -106,12 +106,12 @@ class assLongMenu extends assQuestion implements ilObjQuestionScoringAdjustable
         return $this->long_menu_text;
     }
         
-    public function setAnswers($answers)
+    public function setAnswers($answers) : void
     {
         $this->answers = $answers;
     }
 
-    public function getAnswers()
+    public function getAnswers() : array
     {
         return $this->answers;
     }
@@ -127,12 +127,12 @@ class assLongMenu extends assQuestion implements ilObjQuestionScoringAdjustable
     /**
      * @param mixed $json_structure
      */
-    public function setJsonStructure($json_structure)
+    public function setJsonStructure($json_structure) : void
     {
         $this->json_structure = $json_structure;
     }
     
-    public function setSpecificFeedbackSetting($specificFeedbackSetting)
+    public function setSpecificFeedbackSetting($specificFeedbackSetting) : void
     {
         $this->specificFeedbackSetting = $specificFeedbackSetting;
     }
@@ -142,7 +142,7 @@ class assLongMenu extends assQuestion implements ilObjQuestionScoringAdjustable
         return $this->specificFeedbackSetting;
     }
 
-    public function setMinAutoComplete($minAutoComplete)
+    public function setMinAutoComplete($minAutoComplete) : void
     {
         $this->minAutoComplete = $minAutoComplete;
     }
@@ -270,7 +270,7 @@ class assLongMenu extends assQuestion implements ilObjQuestionScoringAdjustable
         $this->createFileFromArray();
     }
 
-    public function saveAnswerSpecificDataToDb()
+    public function saveAnswerSpecificDataToDb() : void
     {
         $this->clearAnswerSpecificDataFromDb($this->getId());
         $type_array = $this->getAnswerType();
@@ -301,7 +301,7 @@ class assLongMenu extends assQuestion implements ilObjQuestionScoringAdjustable
         $this->setPoints($points);
     }
     
-    private function createFileFromArray()
+    private function createFileFromArray() : void
     {
         $array = $this->getAnswers();
         $this->clearFolder();
@@ -342,12 +342,12 @@ class assLongMenu extends assQuestion implements ilObjQuestionScoringAdjustable
         return $answers;
     }
     
-    private function clearFolder($let_folder_exists = true)
+    private function clearFolder($let_folder_exists = true) : void
     {
         ilFileUtils::delDir($this->buildFolderName(), $let_folder_exists);
     }
     
-    private function assertDirExists()
+    private function assertDirExists() : void
     {
         $folder_name = $this->buildFolderName();
         if (!ilFileUtils::makeDirParents($folder_name)) {
@@ -409,7 +409,7 @@ class assLongMenu extends assQuestion implements ilObjQuestionScoringAdjustable
         parent::loadFromDb($question_id);
     }
 
-    private function loadCorrectAnswerData($question_id)
+    private function loadCorrectAnswerData($question_id) : void
     {
         $res = $this->db->queryF(
             "SELECT * FROM {$this->getAnswerTableName()} WHERE question_fi = %s ORDER BY gap_number, position ASC",
@@ -845,7 +845,7 @@ class assLongMenu extends assQuestion implements ilObjQuestionScoringAdjustable
         return false;
     }
 
-    public function clearAnswerSpecificDataFromDb($question_id)
+    public function clearAnswerSpecificDataFromDb($question_id) : void
     {
         $this->ilDB->manipulateF(
             'DELETE FROM ' . $this->getAnswerTableName() . ' WHERE question_fi = %s',
@@ -903,7 +903,7 @@ class assLongMenu extends assQuestion implements ilObjQuestionScoringAdjustable
     /**
      * @param $a_identical_scoring
      */
-    public function setIdenticalScoring($a_identical_scoring)
+    public function setIdenticalScoring($a_identical_scoring) : void
     {
         $this->identical_scoring = ($a_identical_scoring) ? 1 : 0;
     }

--- a/Modules/TestQuestionPool/classes/class.assLongMenuGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assLongMenuGUI.php
@@ -101,7 +101,7 @@ class assLongMenuGUI extends assQuestionGUI implements ilGuiQuestionScoringAdjus
         $this->saveTaxonomyAssignments();
     }
 
-    protected function editQuestion(ilPropertyFormGUI $form = null)
+    protected function editQuestion(ilPropertyFormGUI $form = null) : void
     {
         if ($form === null) {
             $form = $this->buildEditForm();

--- a/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
@@ -60,7 +60,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
     /**
      * @param mixed $isSingleline
      */
-    public function setIsSingleline($isSingleline)
+    public function setIsSingleline($isSingleline) : void
     {
         $this->isSingleline = $isSingleline;
     }
@@ -115,7 +115,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
     /**
      * @param int $selectionLimit
      */
-    public function setSelectionLimit($selectionLimit)
+    public function setSelectionLimit($selectionLimit) : void
     {
         $this->selectionLimit = $selectionLimit;
     }
@@ -157,7 +157,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
     /**
      * Rebuild the thumbnail images with a new thumbnail size
      */
-    protected function rebuildThumbnails()
+    protected function rebuildThumbnails() : void
     {
         if ($this->isSingleline && ($this->getThumbSize())) {
             foreach ($this->getAnswers() as $answer) {
@@ -180,7 +180,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
      * @param $path string
      * @param $file string
      */
-    protected function generateThumbForFile($path, $file)
+    protected function generateThumbForFile($path, $file) : void
     {
         $filename = $path . $file;
         if (@file_exists($filename)) {
@@ -436,7 +436,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
         $points_unchecked = 0.0,
         $order = 0,
         $answerimage = ""
-    ) {
+    ) : void {
         include_once "./Modules/TestQuestionPool/classes/class.assAnswerMultipleResponseImage.php";
         if (array_key_exists($order, $this->answers)) {
             // insert answer
@@ -504,7 +504,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
      * @param integer $index A nonnegative index of the n-th answer
      * @see $answers
      */
-    public function deleteAnswer($index = 0)
+    public function deleteAnswer($index = 0) : void
     {
         if ($index < 0) {
             return;
@@ -533,7 +533,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
      *
      * @see $answers
      */
-    public function flushAnswers()
+    public function flushAnswers() : void
     {
         $this->answers = array();
     }
@@ -836,7 +836,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
      *
      * @param string $image_filename Name of the image file to delete
      */
-    protected function deleteImage($image_filename)
+    protected function deleteImage($image_filename) : void
     {
         $imagepath = $this->getImagePath();
         @unlink($imagepath . $image_filename);
@@ -844,7 +844,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
         @unlink($thumbpath);
     }
 
-    public function duplicateImages($question_id, $objectId = null)
+    public function duplicateImages($question_id, $objectId = null) : void
     {
         /** @var $ilLog ilLogger */
         global $DIC;
@@ -895,7 +895,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
         }
     }
 
-    public function copyImages($question_id, $source_questionpool)
+    public function copyImages($question_id, $source_questionpool) : void
     {
         global $DIC;
         $ilLog = $DIC['ilLog'];
@@ -925,7 +925,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
     /**
      * Sync images of a MC question on synchronisation with the original question
      */
-    protected function syncImages()
+    protected function syncImages() : void
     {
         global $DIC;
         $ilLog = $DIC['ilLog'];
@@ -1019,7 +1019,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
         return $this->thumb_size;
     }
     
-    public function setThumbSize(?int $a_size)
+    public function setThumbSize(?int $a_size) : void
     {
         $this->thumb_size = $a_size;
     }
@@ -1084,7 +1084,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
         return json_encode($result);
     }
 
-    public function removeAnswerImage($index)
+    public function removeAnswerImage($index) : void
     {
         $answer = $this->answers[$index];
         if (is_object($answer)) {
@@ -1105,7 +1105,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
         return $multilineAnswerSetting;
     }
     
-    public function setMultilineAnswerSetting($a_setting = 0)
+    public function setMultilineAnswerSetting($a_setting = 0) : void
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];
@@ -1121,7 +1121,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
      *
      * @param integer $a_feedback_setting
      */
-    public function setSpecificFeedbackSetting($a_feedback_setting)
+    public function setSpecificFeedbackSetting($a_feedback_setting) : void
     {
         $this->feedback_setting = $a_feedback_setting;
     }
@@ -1205,7 +1205,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
      *
      * @param integer $questionId
      */
-    public function ensureNoInvalidObligation($questionId)
+    public function ensureNoInvalidObligation($questionId) : void
     {
         /** @var $ilDB ilDBInterface */
         global $DIC;

--- a/Modules/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
@@ -143,7 +143,7 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
     /**
      * Upload an image
      */
-    public function uploadchoice()
+    public function uploadchoice() : void
     {
         $this->writePostData(true);
         $position = key($_POST['cmd']['uploadchoice']);
@@ -153,7 +153,7 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
     /**
      * Remove an image
      */
-    public function removeimagechoice()
+    public function removeimagechoice() : void
     {
         $this->writePostData(true);
         $position = key($_POST['cmd']['removeimagechoice']);
@@ -165,7 +165,7 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
     /**
      * Add a new answer
      */
-    public function addchoice()
+    public function addchoice() : void
     {
         $this->writePostData(true);
         $position = key($_POST['cmd']['addchoice']);
@@ -176,7 +176,7 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
     /**
      * Remove an answer
      */
-    public function removechoice()
+    public function removechoice() : void
     {
         $this->writePostData(true);
         $position = key($_POST['cmd']['removechoice']);
@@ -613,7 +613,7 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
         return $this->useEmptySolutionInputChecked;
     }
     
-    public function setUseEmptySolutionInputChecked($useEmptySolutionInputChecked)
+    public function setUseEmptySolutionInputChecked($useEmptySolutionInputChecked) : void
     {
         $this->useEmptySolutionInputChecked = $useEmptySolutionInputChecked;
     }
@@ -984,7 +984,7 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
         return $tpl;
     }
 
-    private function populateSpecificFeedbackInline($user_solution, $answer_id, $template)
+    private function populateSpecificFeedbackInline($user_solution, $answer_id, $template) : void
     {
         if ($this->object->getSpecificFeedbackSetting() == 2) {
             foreach ($user_solution as $mc_solution) {

--- a/Modules/TestQuestionPool/classes/class.assNumeric.php
+++ b/Modules/TestQuestionPool/classes/class.assNumeric.php
@@ -287,13 +287,13 @@ class assNumeric extends assQuestion implements ilObjQuestionScoringAdjustable, 
         return $this->upper_limit;
     }
 
-    public function setLowerLimit($a_limit)
+    public function setLowerLimit($a_limit) : void
     {
         $a_limit = str_replace(',', '.', $a_limit);
         $this->lower_limit = $a_limit;
     }
 
-    public function setUpperLimit($a_limit)
+    public function setUpperLimit($a_limit) : void
     {
         $a_limit = str_replace(',', '.', $a_limit);
         $this->upper_limit = $a_limit;
@@ -584,7 +584,7 @@ class assNumeric extends assQuestion implements ilObjQuestionScoringAdjustable, 
      *
      * @param integer $maxchars The maximum number of characters
      */
-    public function setMaxChars($maxchars)
+    public function setMaxChars($maxchars) : void
     {
         $this->maxchars = $maxchars;
     }

--- a/Modules/TestQuestionPool/classes/class.assNumericRange.php
+++ b/Modules/TestQuestionPool/classes/class.assNumericRange.php
@@ -138,7 +138,7 @@ class assNumericRange
      *
      * @see $lowerlimit
     */
-    public function setLowerLimit($limit)
+    public function setLowerLimit($limit) : void
     {
         $this->lowerlimit = $limit;
     }
@@ -152,7 +152,7 @@ class assNumericRange
      *
      * @see $upperlimit
      */
-    public function setUpperLimit($limit)
+    public function setUpperLimit($limit) : void
     {
         $this->upperlimit = $limit;
     }
@@ -166,7 +166,7 @@ class assNumericRange
      *
      * @see $points
      */
-    public function setPoints($points)
+    public function setPoints($points) : void
     {
         $this->points = $points;
     }
@@ -180,7 +180,7 @@ class assNumericRange
      *
      * @see $order
      */
-    public function setOrder($order)
+    public function setOrder($order) : void
     {
         $this->order = $order;
     }

--- a/Modules/TestQuestionPool/classes/class.assOrderingHorizontal.php
+++ b/Modules/TestQuestionPool/classes/class.assOrderingHorizontal.php
@@ -546,7 +546,7 @@ class assOrderingHorizontal extends assQuestion implements ilObjQuestionScoringA
     *
     * @param string $a_value Order text
     */
-    public function setOrderText($a_value)
+    public function setOrderText($a_value) : void
     {
         $this->ordertext = $a_value;
     }
@@ -566,7 +566,7 @@ class assOrderingHorizontal extends assQuestion implements ilObjQuestionScoringA
     *
     * @param double $a_value Text size in percent
     */
-    public function setTextSize($a_value)
+    public function setTextSize($a_value) : void
     {
         if ($a_value >= 10) {
             $this->textsize = $a_value;
@@ -588,7 +588,7 @@ class assOrderingHorizontal extends assQuestion implements ilObjQuestionScoringA
     *
     * @param string $a_value Separator
     */
-    public function setSeparator($a_value)
+    public function setSeparator($a_value) : void
     {
         $this->separator = $a_value;
     }

--- a/Modules/TestQuestionPool/classes/class.assOrderingHorizontalGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assOrderingHorizontalGUI.php
@@ -334,7 +334,7 @@ class assOrderingHorizontalGUI extends assQuestionGUI implements ilGuiQuestionSc
     *
     * @access public
     */
-    public function saveFeedback()
+    public function saveFeedback() : void
     {
         include_once "./Services/AdvancedEditing/classes/class.ilObjAdvancedEditing.php";
         // @PHP8-CR: This appears as if the feedback feature was not implmented completely for the question type.

--- a/Modules/TestQuestionPool/classes/class.assOrderingQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assOrderingQuestion.php
@@ -243,7 +243,7 @@ class assOrderingQuestion extends assQuestion implements ilObjQuestionScoringAdj
         return $clone->id;
     }
     
-    protected function duplicateOrderlingElementList()
+    protected function duplicateOrderlingElementList() : void
     {
         $this->getOrderingElementList()->setQuestionId($this->getId());
         $this->getOrderingElementList()->distributeNewRandomIdentifiers();
@@ -319,7 +319,7 @@ class assOrderingQuestion extends assQuestion implements ilObjQuestionScoringAdj
         return $clone->id;
     }
 
-    public function duplicateImages($src_question_id, $src_object_id, $dest_question_id, $dest_object_id)
+    public function duplicateImages($src_question_id, $src_object_id, $dest_question_id, $dest_object_id) : void
     {
         global $DIC;
         $ilLog = $DIC['ilLog'];
@@ -349,7 +349,7 @@ class assOrderingQuestion extends assQuestion implements ilObjQuestionScoringAdj
      * simply use the working method duplicateImages(), we do not search the difference here
      * and we will delete this soon (!) currently no usage found, remove for il5.3
      */
-    public function copyImages($question_id, $source_questionpool)
+    public function copyImages($question_id, $source_questionpool) : void
     {
         global $DIC;
         $ilLog = $DIC['ilLog'];
@@ -381,7 +381,7 @@ class assOrderingQuestion extends assQuestion implements ilObjQuestionScoringAdj
     * @access public
     * @see $ordering_type
     */
-    public function setOrderingType($ordering_type = OQ_TERMS)
+    public function setOrderingType($ordering_type = OQ_TERMS) : void
     {
         $this->ordering_type = $ordering_type;
     }
@@ -566,7 +566,7 @@ class assOrderingQuestion extends assQuestion implements ilObjQuestionScoringAdj
     /**
      * @param ilAssOrderingElementList $orderingElementList
      */
-    public function setOrderingElementList($orderingElementList)
+    public function setOrderingElementList($orderingElementList) : void
     {
         $this->orderingElementList = $orderingElementList;
     }
@@ -633,7 +633,7 @@ class assOrderingQuestion extends assQuestion implements ilObjQuestionScoringAdj
     * @access public
     * @see $answers
     */
-    public function deleteAnswer($randomIdentifier)
+    public function deleteAnswer($randomIdentifier) : void
     {
         $this->getOrderingElementList()->removeElement(
             $this->getOrderingElementList()->getElementByRandomIdentifier($randomIdentifier)
@@ -729,7 +729,7 @@ class assOrderingQuestion extends assQuestion implements ilObjQuestionScoringAdj
         return md5($filename) . "." . $extension;
     }
     
-    protected function cleanImagefiles()
+    protected function cleanImagefiles() : void
     {
         if ($this->getOrderingType() == OQ_PICTURES) {
             if (@file_exists($this->getImagePath())) {
@@ -829,14 +829,14 @@ class assOrderingQuestion extends assQuestion implements ilObjQuestionScoringAdj
         return true;
     }
     
-    public function handleThumbnailCreation(ilAssOrderingElementList $elementList)
+    public function handleThumbnailCreation(ilAssOrderingElementList $elementList) : void
     {
         foreach ($elementList as $element) {
             $this->createImageThumbnail($element);
         }
     }
     
-    public function createImageThumbnail(ilAssOrderingElement $element)
+    public function createImageThumbnail(ilAssOrderingElement $element) : void
     {
         if ($this->getThumbGeometry()) {
             $imageFile = $this->getImagePath() . $element->getContent();
@@ -1072,7 +1072,7 @@ class assOrderingQuestion extends assQuestion implements ilObjQuestionScoringAdj
     *
     * @param integer $a_geometry Geometry
     */
-    public function setThumbGeometry($a_geometry)
+    public function setThumbGeometry($a_geometry) : void
     {
         $this->thumb_geometry = ($a_geometry < 1) ? 100 : $a_geometry;
     }
@@ -1092,7 +1092,7 @@ class assOrderingQuestion extends assQuestion implements ilObjQuestionScoringAdj
     *
     * @param integer $a_height Height
     */
-    public function setElementHeight($a_height)
+    public function setElementHeight($a_height) : void
     {
         $this->element_height = ($a_height < 20) ? "" : $a_height;
     }
@@ -1100,7 +1100,7 @@ class assOrderingQuestion extends assQuestion implements ilObjQuestionScoringAdj
     /*
     * Rebuild the thumbnail images with a new thumbnail size
     */
-    public function rebuildThumbnails()
+    public function rebuildThumbnails() : void
     {
         if ($this->getOrderingType() == OQ_PICTURES || $this->getOrderingType() == OQ_NESTED_PICTURES) {
             foreach ($this->getOrderElements() as $orderingElement) {
@@ -1114,7 +1114,7 @@ class assOrderingQuestion extends assQuestion implements ilObjQuestionScoringAdj
         return "thumb.";
     }
     
-    protected function generateThumbForFile($path, $file)
+    protected function generateThumbForFile($path, $file) : void
     {
         $filename = $path . $file;
         if (@file_exists($filename)) {
@@ -1208,7 +1208,7 @@ class assOrderingQuestion extends assQuestion implements ilObjQuestionScoringAdj
     /**
      * @param ilAssOrderingTextsInputGUI|ilAssOrderingImagesInputGUI|ilAssNestedOrderingElementsInputGUI $formField
      */
-    public function initOrderingElementAuthoringProperties(ilFormPropertyGUI $formField)
+    public function initOrderingElementAuthoringProperties(ilFormPropertyGUI $formField) : void
     {
         switch (true) {
             case $formField instanceof ilAssNestedOrderingElementsInputGUI:
@@ -1231,7 +1231,7 @@ class assOrderingQuestion extends assQuestion implements ilObjQuestionScoringAdj
     /**
      * @param ilFormPropertyGUI $formField
      */
-    public function initOrderingElementFormFieldLabels(ilFormPropertyGUI $formField)
+    public function initOrderingElementFormFieldLabels(ilFormPropertyGUI $formField) : void
     {
         $formField->setInfo($this->lng->txt('ordering_answer_sequence_info'));
         $formField->setTitle($this->lng->txt('answers'));
@@ -1592,7 +1592,7 @@ class assOrderingQuestion extends assQuestion implements ilObjQuestionScoringAdj
     }
     // fau.
     
-    protected function ensureImagePathExists()
+    protected function ensureImagePathExists() : void
     {
         if (!file_exists($this->getImagePath())) {
             ilFileUtils::makeDirParents($this->getImagePath());

--- a/Modules/TestQuestionPool/classes/class.assOrderingQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assOrderingQuestionGUI.php
@@ -56,7 +56,7 @@ class assOrderingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
     /**
      * @param boolean $clearAnswersOnWritingPostDataEnabled
      */
-    public function setClearAnswersOnWritingPostDataEnabled($clearAnswersOnWritingPostDataEnabled)
+    public function setClearAnswersOnWritingPostDataEnabled($clearAnswersOnWritingPostDataEnabled) : void
     {
         $this->clearAnswersOnWritingPostDataEnabled = $clearAnswersOnWritingPostDataEnabled;
     }
@@ -69,7 +69,7 @@ class assOrderingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         return $this->clearAnswersOnWritingPostDataEnabled;
     }
 
-    public function changeToPictures()
+    public function changeToPictures() : void
     {
         if ($this->object->getOrderingType() != OQ_NESTED_PICTURES && $this->object->getOrderingType() != OQ_PICTURES) {
             $this->setClearAnswersOnWritingPostDataEnabled(true);
@@ -86,7 +86,7 @@ class assOrderingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         $this->renderEditForm($form);
     }
 
-    public function changeToText()
+    public function changeToText() : void
     {
         if ($this->object->getOrderingType() != OQ_NESTED_TERMS && $this->object->getOrderingType() != OQ_TERMS) {
             $this->setClearAnswersOnWritingPostDataEnabled(true);
@@ -103,7 +103,7 @@ class assOrderingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         $this->renderEditForm($form);
     }
 
-    public function orderNestedTerms()
+    public function orderNestedTerms() : void
     {
         $this->writePostData(true);
         $this->object->setOrderingType(OQ_NESTED_TERMS);
@@ -112,7 +112,7 @@ class assOrderingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         $this->renderEditForm($this->buildEditForm());
     }
 
-    public function orderNestedPictures()
+    public function orderNestedPictures() : void
     {
         $this->writePostData(true);
         $this->object->setOrderingType(OQ_NESTED_PICTURES);
@@ -121,7 +121,7 @@ class assOrderingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         $this->renderEditForm($this->buildEditForm());
     }
     
-    public function removeElementImage()
+    public function removeElementImage() : void
     {
         $orderingInput = $this->object->buildOrderingImagesInputGui();
         $this->object->initOrderingElementAuthoringProperties($orderingInput);
@@ -164,7 +164,7 @@ class assOrderingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         $this->renderEditForm($form);
     }
 
-    public function uploadElementImage()
+    public function uploadElementImage() : void
     {
         $orderingInput = $this->object->buildOrderingImagesInputGui();
         $this->object->initOrderingElementAuthoringProperties($orderingInput);
@@ -367,7 +367,7 @@ class assOrderingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
     /**
      * Creates an output of the edit form for the question
      */
-    public function editQuestion($checkonly = false)
+    public function editQuestion($checkonly = false) : void
     {
         $this->renderEditForm($this->buildEditForm());
     }
@@ -708,7 +708,7 @@ class assOrderingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
      * @param $form
      * @throws ilTestQuestionPoolException
      */
-    protected function persistAuthoringForm($form)
+    protected function persistAuthoringForm($form) : void
     {
         $this->writeQuestionGenericPostData();
         $this->writeQuestionSpecificPostData($form);

--- a/Modules/TestQuestionPool/classes/class.assQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assQuestion.php
@@ -446,7 +446,7 @@ abstract class assQuestion
         $this->id = $id;
     }
 
-    public function setTestId(int $id = -1)
+    public function setTestId(int $id = -1) : void
     {
         $this->test_id = $id;
     }
@@ -963,7 +963,7 @@ abstract class assQuestion
     }
     
     /** @TODO Move this to a proper place. */
-    public static function _updateTestResultCache(int $active_id, ilAssQuestionProcessLocker $processLocker = null)
+    public static function _updateTestResultCache(int $active_id, ilAssQuestionProcessLocker $processLocker = null) : void
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];
@@ -3036,7 +3036,7 @@ abstract class assQuestion
         return 0;
     }
 
-    public function syncHints()
+    public function syncHints() : void
     {
         // delete hints of the original
         $this->db->manipulateF(
@@ -3189,7 +3189,7 @@ abstract class assQuestion
         return file_exists("Modules/TestQuestionPool/classes/class.{$questionType}GUI.php");
     }
 
-    public static function includeCoreClass($questionType, $withGuiClass)
+    public static function includeCoreClass($questionType, $withGuiClass) : void
     {
         if ($withGuiClass) {
             require_once "Modules/TestQuestionPool/classes/class.{$questionType}GUI.php";
@@ -3468,7 +3468,7 @@ abstract class assQuestion
         }
     }
 
-    public function syncSkillAssignments(int $srcParentId, int $srcQuestionId, int $trgParentId, int $trgQuestionId)
+    public function syncSkillAssignments(int $srcParentId, int $srcQuestionId, int $trgParentId, int $trgQuestionId) : void
     {
         require_once 'Modules/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentList.php';
         $assignmentList = new ilAssQuestionSkillAssignmentList($this->db);
@@ -4193,12 +4193,12 @@ abstract class assQuestion
         return $this->obligationsToBeConsidered;
     }
 
-    public function setObligationsToBeConsidered(bool $obligationsToBeConsidered)
+    public function setObligationsToBeConsidered(bool $obligationsToBeConsidered) : void
     {
         $this->obligationsToBeConsidered = $obligationsToBeConsidered;
     }
 
-    public function updateTimestamp()
+    public function updateTimestamp() : void
     {
         $this->db->manipulateF(
             "UPDATE qpl_questions SET tstamp = %s  WHERE question_id = %s",

--- a/Modules/TestQuestionPool/classes/class.assQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assQuestionGUI.php
@@ -412,7 +412,7 @@ abstract class assQuestionGUI
         return 0;
     }
 
-    public function assessment()
+    public function assessment() : void
     {
         $stats_table = new ilQuestionCumulatedStatisticsTableGUI($this, 'assessment', '', $this->object);
 
@@ -672,7 +672,7 @@ abstract class assQuestionGUI
         }
     }
     
-    public function saveEdit()
+    public function saveEdit() : void
     {
         $ilUser = $this->ilUser;
         $result = $this->writePostData();
@@ -952,7 +952,7 @@ abstract class assQuestionGUI
     }
 
     /** Why are you here? Some magic for plugins? */
-    public function outAdditionalOutput()
+    public function outAdditionalOutput() : void
     {
     }
 

--- a/Modules/TestQuestionPool/classes/class.assSingleChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assSingleChoice.php
@@ -153,7 +153,7 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
     /*
     * Rebuild the thumbnail images with a new thumbnail size
     */
-    protected function rebuildThumbnails()
+    protected function rebuildThumbnails() : void
     {
         if ($this->isSingleline && ($this->getThumbSize())) {
             foreach ($this->getAnswers() as $answer) {
@@ -169,7 +169,7 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
         return "thumb.";
     }
     
-    protected function generateThumbForFile($path, $file)
+    protected function generateThumbForFile($path, $file) : void
     {
         $filename = $path . $file;
         if (@file_exists($filename)) {
@@ -428,7 +428,7 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
         $points = 0.0,
         $order = 0,
         $answerimage = ""
-    ) {
+    ) : void {
         include_once "./Modules/TestQuestionPool/classes/class.assAnswerBinaryStateImage.php";
         if (array_key_exists($order, $this->answers)) {
             // insert answer
@@ -497,7 +497,7 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
     * @access public
     * @see $answers
     */
-    public function deleteAnswer($index = 0)
+    public function deleteAnswer($index = 0) : void
     {
         if ($index < 0) {
             return;
@@ -527,7 +527,7 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
     * @access public
     * @see $answers
     */
-    public function flushAnswers()
+    public function flushAnswers() : void
     {
         $this->answers = array();
     }
@@ -821,7 +821,7 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
     * @param string $image_filename Name of the image file to delete
     * @access private
     */
-    public function deleteImage($image_filename)
+    public function deleteImage($image_filename) : void
     {
         $imagepath = $this->getImagePath();
         @unlink($imagepath . $image_filename);
@@ -829,7 +829,7 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
         @unlink($thumbpath);
     }
 
-    public function duplicateImages($question_id, $objectId = null)
+    public function duplicateImages($question_id, $objectId = null) : void
     {
         global $DIC;
         $ilLog = $DIC['ilLog'];
@@ -860,7 +860,7 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
         }
     }
 
-    public function copyImages($question_id, $source_questionpool)
+    public function copyImages($question_id, $source_questionpool) : void
     {
         /** @var $ilLog ilLogger */
         global $DIC;
@@ -910,7 +910,7 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
     /**
     * Sync images of a MC question on synchronisation with the original question
     **/
-    protected function syncImages()
+    protected function syncImages() : void
     {
         global $DIC;
         $ilLog = $DIC['ilLog'];
@@ -999,7 +999,7 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
         return $this->thumb_size;
     }
     
-    public function setThumbSize($a_size)
+    public function setThumbSize($a_size) : void
     {
         $this->thumb_size = $a_size;
     }
@@ -1063,7 +1063,7 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
         return json_encode($result);
     }
     
-    public function removeAnswerImage($index)
+    public function removeAnswerImage($index) : void
     {
         $answer = $this->answers[$index];
         if (is_object($answer)) {
@@ -1092,7 +1092,7 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
         return $multilineAnswerSetting;
     }
     
-    public function setMultilineAnswerSetting($a_setting = 0)
+    public function setMultilineAnswerSetting($a_setting = 0) : void
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];
@@ -1108,7 +1108,7 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
      *
      * @param integer $a_feedback_setting
      */
-    public function setSpecificFeedbackSetting($a_feedback_setting)
+    public function setSpecificFeedbackSetting($a_feedback_setting) : void
     {
         $this->feedback_setting = $a_feedback_setting;
     }

--- a/Modules/TestQuestionPool/classes/class.assSingleChoiceGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assSingleChoiceGUI.php
@@ -169,7 +169,7 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
     /**
     * Upload an image
     */
-    public function uploadchoice()
+    public function uploadchoice() : void
     {
         $this->writePostData(true);
         $position = key($_POST['cmd']['uploadchoice']);
@@ -179,7 +179,7 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
     /**
     * Remove an image
     */
-    public function removeimagechoice()
+    public function removeimagechoice() : void
     {
         $this->writePostData(true);
         $position = key($_POST['cmd']['removeimagechoice']);
@@ -191,7 +191,7 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
     /**
     * Add a new answer
     */
-    public function addchoice()
+    public function addchoice() : void
     {
         $this->writePostData(true);
         $position = key($_POST['cmd']['addchoice']);
@@ -202,7 +202,7 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
     /**
     * Remove an answer
     */
-    public function removechoice()
+    public function removechoice() : void
     {
         $this->writePostData(true);
         $position = key($_POST['cmd']['removechoice']);
@@ -857,7 +857,7 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
         return $tpl;
     }
 
-    private function populateInlineFeedback($template, $answer_id, $user_solution)
+    private function populateInlineFeedback($template, $answer_id, $user_solution) : void
     {
         $feedbackOutputRequired = false;
 

--- a/Modules/TestQuestionPool/classes/class.assTextQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assTextQuestion.php
@@ -327,7 +327,7 @@ class assTextQuestion extends assQuestion implements ilObjQuestionScoringAdjusta
     * @access public
     * @see $maxNumOfChars
     */
-    public function setMaxNumOfChars($maxchars = 0)
+    public function setMaxNumOfChars($maxchars = 0) : void
     {
         $this->maxNumOfChars = $maxchars;
     }
@@ -343,7 +343,7 @@ class assTextQuestion extends assQuestion implements ilObjQuestionScoringAdjusta
     /**
      * @param bool $wordCounterEnabled
      */
-    public function setWordCounterEnabled($wordCounterEnabled)
+    public function setWordCounterEnabled($wordCounterEnabled) : void
     {
         $this->wordCounterEnabled = $wordCounterEnabled;
     }
@@ -758,7 +758,7 @@ class assTextQuestion extends assQuestion implements ilObjQuestionScoringAdjusta
     * @see $textgap_rating
     * @access public
     */
-    public function setTextRating($a_text_rating)
+    public function setTextRating($a_text_rating) : void
     {
         switch ($a_text_rating) {
             case TEXTGAP_RATING_CASEINSENSITIVE:
@@ -867,7 +867,7 @@ class assTextQuestion extends assQuestion implements ilObjQuestionScoringAdjusta
         $points_unchecked = 0.0,
         $order = 0,
         $answerimage = ""
-    ) {
+    ) : void {
         include_once "./Modules/TestQuestionPool/classes/class.assAnswerMultipleResponseImage.php";
 
         // add answer
@@ -912,7 +912,7 @@ class assTextQuestion extends assQuestion implements ilObjQuestionScoringAdjusta
      * @access public
      * @see $answers
      */
-    public function deleteAnswer($index = 0)
+    public function deleteAnswer($index = 0) : void
     {
         if ($index < 0) {
             return;
@@ -947,12 +947,12 @@ class assTextQuestion extends assQuestion implements ilObjQuestionScoringAdjusta
      * @access public
      * @see $answers
      */
-    public function flushAnswers()
+    public function flushAnswers() : void
     {
         $this->answers = array();
     }
 
-    public function setAnswers($answers)
+    public function setAnswers($answers) : void
     {
         if (isset($answers['answer'])) {
             $count = count($answers['answer']);
@@ -973,7 +973,7 @@ class assTextQuestion extends assQuestion implements ilObjQuestionScoringAdjusta
         }
     }
 
-    public function duplicateAnswers($original_id)
+    public function duplicateAnswers($original_id) : void
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];
@@ -1005,7 +1005,7 @@ class assTextQuestion extends assQuestion implements ilObjQuestionScoringAdjusta
      * This method implements a default behaviour. During the creation of a text question, the record which holds
      * the keyword relation is not existing, so keyword_relation defaults to 'one'.
      */
-    public function setKeywordRelation($a_relation)
+    public function setKeywordRelation($a_relation) : void
     {
         $this->keyword_relation = $a_relation;
     }

--- a/Modules/TestQuestionPool/classes/class.assTextQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assTextQuestionGUI.php
@@ -560,7 +560,7 @@ class assTextQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringA
         return $tpl->get();
     }
 
-    public function addSuggestedSolution()
+    public function addSuggestedSolution() : void
     {
         ilSession::set("subquestion_index", 0);
         if ($_POST["cmd"]["addSuggestedSolution"]) {

--- a/Modules/TestQuestionPool/classes/class.assTextSubset.php
+++ b/Modules/TestQuestionPool/classes/class.assTextSubset.php
@@ -176,7 +176,7 @@ class assTextSubset extends assQuestion implements ilObjQuestionScoringAdjustabl
     *
     * @access public
     */
-    public function addAnswer($answertext, $points, $order)
+    public function addAnswer($answertext, $points, $order) : void
     {
         include_once "./Modules/TestQuestionPool/classes/class.assAnswerBinaryStateImage.php";
         if (array_key_exists($order, $this->answers)) {
@@ -357,7 +357,7 @@ class assTextSubset extends assQuestion implements ilObjQuestionScoringAdjustabl
     * @access public
     * @see $answers
     */
-    public function deleteAnswer($index = 0)
+    public function deleteAnswer($index = 0) : void
     {
         if ($index < 0) {
             return;
@@ -383,7 +383,7 @@ class assTextSubset extends assQuestion implements ilObjQuestionScoringAdjustabl
     * @access public
     * @see $answers
     */
-    public function flushAnswers()
+    public function flushAnswers() : void
     {
         $this->answers = array();
     }
@@ -501,7 +501,7 @@ class assTextSubset extends assQuestion implements ilObjQuestionScoringAdjustabl
     * @see $textgap_rating
     * @access public
     */
-    public function setTextRating($a_text_rating)
+    public function setTextRating($a_text_rating) : void
     {
         switch ($a_text_rating) {
             case TEXTGAP_RATING_CASEINSENSITIVE:
@@ -560,7 +560,7 @@ class assTextSubset extends assQuestion implements ilObjQuestionScoringAdjustabl
     * @param integer $a_correct_anwers The number of correct answers
     * @access public
     */
-    public function setCorrectAnswers(int $a_correct_answers)
+    public function setCorrectAnswers(int $a_correct_answers) : void
     {
         $this->correctanswers = $a_correct_answers;
     }
@@ -701,7 +701,7 @@ class assTextSubset extends assQuestion implements ilObjQuestionScoringAdjustabl
     * Returns the answers of the question as a comma separated string
     *
     */
-    public function &joinAnswers()
+    public function &joinAnswers() : array
     {
         $join = array();
         foreach ($this->answers as $answer) {

--- a/Modules/TestQuestionPool/classes/class.assTextSubsetGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assTextSubsetGUI.php
@@ -102,7 +102,7 @@ class assTextSubsetGUI extends assQuestionGUI implements ilGuiQuestionScoringAdj
     /**
     * Add a new answer
     */
-    public function addanswers()
+    public function addanswers() : void
     {
         $this->writePostData(true);
         $position = key($_POST['cmd']['addanswers']);
@@ -113,7 +113,7 @@ class assTextSubsetGUI extends assQuestionGUI implements ilGuiQuestionScoringAdj
     /**
     * Remove an answer
     */
-    public function removeanswers()
+    public function removeanswers() : void
     {
         $this->writePostData(true);
         $position = key($_POST['cmd']['removeanswers']);

--- a/Modules/TestQuestionPool/classes/class.ilAnswerWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAnswerWizardInputGUI.php
@@ -55,7 +55,7 @@ class ilAnswerWizardInputGUI extends ilTextInputGUI
     *
     * @param	array	$a_value	Value
     */
-    public function setValues($a_values)
+    public function setValues($a_values) : void
     {
         $this->values = $a_values;
     }
@@ -75,7 +75,7 @@ class ilAnswerWizardInputGUI extends ilTextInputGUI
     *
     * @param	boolean	$a_value	Value
     */
-    public function setSingleline($a_value)
+    public function setSingleline($a_value) : void
     {
         $this->singleline = $a_value;
     }
@@ -95,7 +95,7 @@ class ilAnswerWizardInputGUI extends ilTextInputGUI
     *
     * @param	object	$a_value	test object
     */
-    public function setQuestionObject($a_value)
+    public function setQuestionObject($a_value) : void
     {
         $this->qstObject = &$a_value;
     }
@@ -115,7 +115,7 @@ class ilAnswerWizardInputGUI extends ilTextInputGUI
     *
     * @param	boolean	$a_allow_move Allow move
     */
-    public function setAllowMove($a_allow_move)
+    public function setAllowMove($a_allow_move) : void
     {
         $this->allowMove = $a_allow_move;
     }
@@ -141,7 +141,7 @@ class ilAnswerWizardInputGUI extends ilTextInputGUI
     /**
      * @param bool $allowAddRemove
      */
-    public function setAllowAddRemove($allowAddRemove)
+    public function setAllowAddRemove($allowAddRemove) : void
     {
         $this->allowAddRemove = $allowAddRemove;
     }
@@ -151,7 +151,7 @@ class ilAnswerWizardInputGUI extends ilTextInputGUI
      *
      * @param	boolean	$a_bool	true if the minimum value should be greater than minvalue
      */
-    public function setMinvalueShouldBeGreater($a_bool)
+    public function setMinvalueShouldBeGreater($a_bool) : void
     {
         $this->minvalueShouldBeGreater = $a_bool;
     }
@@ -170,7 +170,7 @@ class ilAnswerWizardInputGUI extends ilTextInputGUI
      *
      * @param	float	$a_minvalue	Minimum Value
      */
-    public function setMinValue($a_minvalue)
+    public function setMinValue($a_minvalue) : void
     {
         $this->minvalue = $a_minvalue;
     }
@@ -368,7 +368,7 @@ class ilAnswerWizardInputGUI extends ilTextInputGUI
         return "tpl.prop_answerwizardinput.html";
     }
     
-    protected function sanitizeSuperGlobalSubmitValue()
+    protected function sanitizeSuperGlobalSubmitValue() : void
     {
         if (isset($_POST[$this->getPostVar()]) && is_array($_POST[$this->getPostVar()])) {
             $_POST[$this->getPostVar()] = ilArrayUtil::stripSlashesRecursive($_POST[$this->getPostVar()]);

--- a/Modules/TestQuestionPool/classes/class.ilAssExcelFormatHelper.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssExcelFormatHelper.php
@@ -25,7 +25,7 @@ class ilAssExcelFormatHelper extends ilExcel
      * @param string $coordinates
      * @param string $value
      */
-    public function setFormattedExcelTitle($coordinates, $value)
+    public function setFormattedExcelTitle($coordinates, $value) : void
     {
         $this->setCellByCoordinates($coordinates, $value);
         $this->setColors($coordinates, EXCEL_BACKGROUND_COLOR);
@@ -91,7 +91,7 @@ class ilAssExcelFormatHelper extends ilExcel
     /**
      * @param int $stringEscaping
      */
-    public function setStringEscaping($stringEscaping)
+    public function setStringEscaping($stringEscaping) : void
     {
         $this->stringEscaping = $stringEscaping;
     }

--- a/Modules/TestQuestionPool/classes/class.ilAssFileUploadUploadsExporter.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssFileUploadUploadsExporter.php
@@ -83,7 +83,7 @@ class ilAssFileUploadUploadsExporter
     /**
      * @param int $refId
      */
-    public function setRefId($refId)
+    public function setRefId($refId) : void
     {
         $this->refId = $refId;
     }
@@ -99,7 +99,7 @@ class ilAssFileUploadUploadsExporter
     /**
      * @param int $testId
      */
-    public function setTestId($testId)
+    public function setTestId($testId) : void
     {
         $this->testId = $testId;
     }
@@ -115,7 +115,7 @@ class ilAssFileUploadUploadsExporter
     /**
      * @param string $testTitle
      */
-    public function setTestTitle($testTitle)
+    public function setTestTitle($testTitle) : void
     {
         $this->testTitle = $testTitle;
     }
@@ -131,7 +131,7 @@ class ilAssFileUploadUploadsExporter
     /**
      * @param ilObjFileHandlingQuestionType $question
      */
-    public function setQuestion($question)
+    public function setQuestion($question) : void
     {
         $this->question = $question;
     }
@@ -217,7 +217,7 @@ class ilAssFileUploadUploadsExporter
         return $participantData;
     }
     
-    private function collectUploadedFiles($solutionData, ilTestParticipantData $participantData)
+    private function collectUploadedFiles($solutionData, ilTestParticipantData $participantData) : void
     {
         foreach ($solutionData as $activeId => $passes) {
             if (!in_array($activeId, $participantData->getActiveIds())) {
@@ -254,7 +254,7 @@ class ilAssFileUploadUploadsExporter
         return $this->lng->txt('pass') . '_' . ($pass + 1);
     }
     
-    private function createFileUploadCollectionZipFile()
+    private function createFileUploadCollectionZipFile() : void
     {
         ilFileUtils::zip($this->tempDirPath . '/' . $this->mainFolderName, $this->tempZipFilePath);
         
@@ -268,7 +268,7 @@ class ilAssFileUploadUploadsExporter
         }
     }
 
-    private function removeFileUploadCollection()
+    private function removeFileUploadCollection() : void
     {
         ilFileUtils::delDir($this->tempDirPath);
     }

--- a/Modules/TestQuestionPool/classes/class.ilAssIncompleteQuestionPurger.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssIncompleteQuestionPurger.php
@@ -31,12 +31,12 @@ class ilAssIncompleteQuestionPurger
         return $this->ownerId;
     }
 
-    public function setOwnerId($ownerId)
+    public function setOwnerId($ownerId) : void
     {
         $this->ownerId = $ownerId;
     }
     
-    public function purge()
+    public function purge() : void
     {
         $questionIds = $this->getPurgableQuestionIds();
         $this->purgeQuestionIds($questionIds);
@@ -67,7 +67,7 @@ class ilAssIncompleteQuestionPurger
         return $questionIds;
     }
     
-    private function purgeQuestionIds($questionIds)
+    private function purgeQuestionIds($questionIds) : void
     {
         require_once 'Modules/TestQuestionPool/classes/class.assQuestion.php';
         
@@ -77,7 +77,7 @@ class ilAssIncompleteQuestionPurger
         }
     }
     
-    protected function setIgnoredContainerObjectTypes($ignoredContainerObjectTypes)
+    protected function setIgnoredContainerObjectTypes($ignoredContainerObjectTypes) : void
     {
         $this->ignoredContainerObjectTypes = $ignoredContainerObjectTypes;
     }

--- a/Modules/TestQuestionPool/classes/class.ilAssKprimChoiceAnswer.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssKprimChoiceAnswer.php
@@ -24,7 +24,7 @@ class ilAssKprimChoiceAnswer
     
     private $correctness;
 
-    public function setPosition($position)
+    public function setPosition($position) : void
     {
         $this->position = $position;
     }
@@ -34,7 +34,7 @@ class ilAssKprimChoiceAnswer
         return $this->position;
     }
 
-    public function setAnswertext($answertext)
+    public function setAnswertext($answertext) : void
     {
         $this->answertext = $answertext;
     }
@@ -44,7 +44,7 @@ class ilAssKprimChoiceAnswer
         return $this->answertext;
     }
 
-    public function setImageFile($imageFile)
+    public function setImageFile($imageFile) : void
     {
         $this->imageFile = $imageFile;
     }
@@ -54,7 +54,7 @@ class ilAssKprimChoiceAnswer
         return $this->imageFile;
     }
 
-    public function setImageFsDir($imageFsDir)
+    public function setImageFsDir($imageFsDir) : void
     {
         $this->imageFsDir = $imageFsDir;
     }
@@ -64,7 +64,7 @@ class ilAssKprimChoiceAnswer
         return $this->imageFsDir;
     }
 
-    public function setImageWebDir($imageWebDir)
+    public function setImageWebDir($imageWebDir) : void
     {
         $this->imageWebDir = $imageWebDir;
     }
@@ -77,7 +77,7 @@ class ilAssKprimChoiceAnswer
     /**
      * @param mixed $thumbPrefix
      */
-    public function setThumbPrefix($thumbPrefix)
+    public function setThumbPrefix($thumbPrefix) : void
     {
         $this->thumbPrefix = $thumbPrefix;
     }
@@ -90,7 +90,7 @@ class ilAssKprimChoiceAnswer
         return $this->thumbPrefix;
     }
 
-    public function setCorrectness($correctness)
+    public function setCorrectness($correctness) : void
     {
         $this->correctness = $correctness;
     }

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionAbstractPageObjectCommandForwarder.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionAbstractPageObjectCommandForwarder.php
@@ -79,7 +79,7 @@ abstract class ilAssQuestionAbstractPageObjectCommandForwarder
      *
      * @access protected
      */
-    abstract protected function ensurePageObjectExists($pageObjectType, $pageObjectId);
+    abstract protected function ensurePageObjectExists($pageObjectType, $pageObjectId) : void;
     
     /**
      * instantiates, initialises and returns a page object gui object

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionFeedbackEditingGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionFeedbackEditingGUI.php
@@ -116,7 +116,7 @@ class ilAssQuestionFeedbackEditingGUI
      *
      * @access public
      */
-    public function executeCommand()
+    public function executeCommand() : void
     {
         global $DIC; /* @var \ILIAS\DI\Container $DIC */
         $ilHelp = $DIC['ilHelp']; /* @var ilHelpGUI $ilHelp */
@@ -148,7 +148,7 @@ class ilAssQuestionFeedbackEditingGUI
     /**
      * Set content style
      */
-    protected function setContentStyle()
+    protected function setContentStyle() : void
     {
         $this->tpl->addCss(ilObjStyleSheet::getContentStylePath(0));
     }
@@ -158,7 +158,7 @@ class ilAssQuestionFeedbackEditingGUI
      *
      * @access private
      */
-    private function showFeedbackFormCmd()
+    private function showFeedbackFormCmd() : void
     {
         require_once "./Services/Style/Content/classes/class.ilObjStyleSheet.php";
         $this->tpl->setCurrentBlock("ContentStyle");
@@ -182,7 +182,7 @@ class ilAssQuestionFeedbackEditingGUI
      *
      * @access private
      */
-    private function saveFeedbackFormCmd()
+    private function saveFeedbackFormCmd() : void
     {
         $form = $this->buildForm();
         
@@ -287,7 +287,7 @@ class ilAssQuestionFeedbackEditingGUI
         return true;
     }
     
-    public function showSyncCmd()
+    public function showSyncCmd() : void
     {
         $this->questionGUI->originalSyncForm('', 'true');
     }

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionFeedbackPageObjectCommandForwarder.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionFeedbackPageObjectCommandForwarder.php
@@ -42,7 +42,7 @@ class ilAssQuestionFeedbackPageObjectCommandForwarder extends ilAssQuestionAbstr
     /**
      * forward method
      */
-    public function forward()
+    public function forward() : void
     {
         //$this->ensurePageObjectExists($_GET['feedback_type'], $_GET['feedback_id']);
         
@@ -65,7 +65,7 @@ class ilAssQuestionFeedbackPageObjectCommandForwarder extends ilAssQuestionAbstr
      *
      * @access protected
      */
-    public function ensurePageObjectExists($pageObjectType, $pageObjectId)
+    public function ensurePageObjectExists($pageObjectType, $pageObjectId) : void
     {
         include_once("./Modules/TestQuestionPool/classes/feedback/class.ilAssQuestionFeedback.php");
         if ($pageObjectType == ilAssQuestionFeedback::PAGE_OBJECT_TYPE_GENERIC_FEEDBACK) {

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionHint.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionHint.php
@@ -83,7 +83,7 @@ class ilAssQuestionHint
      * @access	public
      * @param	integer	$id
      */
-    public function setId($id)
+    public function setId($id) : void
     {
         $this->id = (int) $id;
     }
@@ -105,7 +105,7 @@ class ilAssQuestionHint
      * @access	public
      * @param	integer	$questionId
      */
-    public function setQuestionId($questionId)
+    public function setQuestionId($questionId) : void
     {
         $this->questionId = (int) $questionId;
     }
@@ -127,7 +127,7 @@ class ilAssQuestionHint
      * @access	public
      * @param	integer	$index
      */
-    public function setIndex($index)
+    public function setIndex($index) : void
     {
         $this->index = (int) $index;
     }
@@ -149,7 +149,7 @@ class ilAssQuestionHint
      * @access	public
      * @param	integer	$points
      */
-    public function setPoints($points)
+    public function setPoints($points) : void
     {
         $this->points = (float) $points;
     }
@@ -171,7 +171,7 @@ class ilAssQuestionHint
      * @access	public
      * @param	string	$text
      */
-    public function setText($text)
+    public function setText($text) : void
     {
         $this->text = $text;
     }
@@ -306,7 +306,7 @@ class ilAssQuestionHint
      * @param	self	$questionHint
      * @param	array	$hintDbRow
      */
-    public static function assignDbRow(self $questionHint, $hintDbRow)
+    public static function assignDbRow(self $questionHint, $hintDbRow) : void
     {
         foreach ($hintDbRow as $field => $value) {
             switch ($field) {

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionHintGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionHintGUI.php
@@ -75,7 +75,7 @@ class ilAssQuestionHintGUI extends ilAssQuestionHintAbstractGUI
      * @global	ilCtrl		$ilCtrl
      * @global	ilTemplate	$tpl
      */
-    private function showFormCmd(ilPropertyFormGUI $form = null)
+    private function showFormCmd(ilPropertyFormGUI $form = null) : void
     {
         global $DIC;
         $ilCtrl = $DIC['ilCtrl'];
@@ -109,7 +109,7 @@ class ilAssQuestionHintGUI extends ilAssQuestionHintAbstractGUI
      * @global	ilCtrl		$ilCtrl
      * @global	ilLanguage	$lng
      */
-    private function saveFormCmd()
+    private function saveFormCmd() : void
     {
         global $DIC;
         $ilCtrl = $DIC['ilCtrl'];
@@ -170,7 +170,7 @@ class ilAssQuestionHintGUI extends ilAssQuestionHintAbstractGUI
      * @access	private
      * @global	ilCtrl	$ilCtrl
      */
-    private function cancelFormCmd()
+    private function cancelFormCmd() : void
     {
         global $DIC;
         $ilCtrl = $DIC['ilCtrl'];

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionHintList.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionHintList.php
@@ -91,7 +91,7 @@ class ilAssQuestionHintList implements Iterator
      * @access	public
      * @param	ilAssQuestionHint	$questionHint
      */
-    public function addHint(ilAssQuestionHint $questionHint)
+    public function addHint(ilAssQuestionHint $questionHint) : void
     {
         $this->questionHints[] = $questionHint;
     }
@@ -147,7 +147,7 @@ class ilAssQuestionHintList implements Iterator
      *
      * @access	public
      */
-    public function reIndex()
+    public function reIndex() : void
     {
         $counter = 0;
         

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionHintPageObjectCommandForwarder.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionHintPageObjectCommandForwarder.php
@@ -72,7 +72,7 @@ class ilAssQuestionHintPageObjectCommandForwarder extends ilAssQuestionAbstractP
      *
      * @throws ilTestQuestionPoolException
      */
-    public function forward()
+    public function forward() : void
     {
         switch ($this->getPresentationMode()) {
             case self::PRESENTATION_MODE_AUTHOR:
@@ -99,7 +99,7 @@ class ilAssQuestionHintPageObjectCommandForwarder extends ilAssQuestionAbstractP
     /**
      * forwards the command to page object gui for author presentation
      */
-    private function buildPreviewPresentationPageObjectGUI()
+    private function buildPreviewPresentationPageObjectGUI() : ilAssHintPageGUI
     {
         $this->tabs->setBackTarget(
             $this->lng->txt('tst_question_hints_back_to_hint_list'),
@@ -123,7 +123,7 @@ class ilAssQuestionHintPageObjectCommandForwarder extends ilAssQuestionAbstractP
     /**
      * forwards the command to page object gui for author presentation
      */
-    private function buildRequestPresentationPageObjectGUI()
+    private function buildRequestPresentationPageObjectGUI() : ilAssHintPageGUI
     {
         $this->tabs->setBackTarget(
             $this->lng->txt('tst_question_hints_back_to_hint_list'),
@@ -147,7 +147,7 @@ class ilAssQuestionHintPageObjectCommandForwarder extends ilAssQuestionAbstractP
     /**
      * forwards the command to page object gui for author presentation
      */
-    private function buildAuthorPresentationPageObjectGUI()
+    private function buildAuthorPresentationPageObjectGUI() : ilAssHintPageGUI
     {
         $this->tabs->setBackTarget(
             $this->lng->txt('tst_question_hints_back_to_hint_list'),
@@ -185,7 +185,7 @@ class ilAssQuestionHintPageObjectCommandForwarder extends ilAssQuestionAbstractP
      * @param string $presentationMode
      * @throws ilTestQuestionPoolException
      */
-    public function setPresentationMode($presentationMode)
+    public function setPresentationMode($presentationMode) : void
     {
         switch ($presentationMode) {
             case self::PRESENTATION_MODE_AUTHOR:
@@ -202,7 +202,7 @@ class ilAssQuestionHintPageObjectCommandForwarder extends ilAssQuestionAbstractP
     /**
      * instantiates, initialises and returns a page object gui object
      */
-    protected function getPageObjectGUI($pageObjectType, $pageObjectId)
+    protected function getPageObjectGUI($pageObjectType, $pageObjectId) : ilAssHintPageGUI
     {
         include_once("./Modules/TestQuestionPool/classes/class.ilAssHintPageGUI.php");
         $pageObjectGUI = new ilAssHintPageGUI($pageObjectId);
@@ -218,7 +218,7 @@ class ilAssQuestionHintPageObjectCommandForwarder extends ilAssQuestionAbstractP
      *
      * @access protected
      */
-    protected function ensurePageObjectExists($pageObjectType, $pageObjectId)
+    protected function ensurePageObjectExists($pageObjectType, $pageObjectId) : void
     {
         include_once("./Modules/TestQuestionPool/classes/class.ilAssHintPage.php");
         if (!ilAssHintPage::_exists($pageObjectType, $pageObjectId)) {

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionHintRequestGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionHintRequestGUI.php
@@ -86,7 +86,7 @@ class ilAssQuestionHintRequestGUI extends ilAssQuestionHintAbstractGUI
      *
      * @access	private
      */
-    private function showListCmd()
+    private function showListCmd() : void
     {
         global $DIC;
         $ilCtrl = $DIC['ilCtrl'];
@@ -114,7 +114,7 @@ class ilAssQuestionHintRequestGUI extends ilAssQuestionHintAbstractGUI
      * @global	ilTemplate $tpl
      * @global	ilLanguage $lng
      */
-    private function showHintCmd()
+    private function showHintCmd() : void
     {
         global $DIC;
         $ilCtrl = $DIC['ilCtrl'];
@@ -182,7 +182,7 @@ class ilAssQuestionHintRequestGUI extends ilAssQuestionHintAbstractGUI
      * @global	ilTemplate $tpl
      * @global	ilLanguage $lng
      */
-    private function confirmRequestCmd()
+    private function confirmRequestCmd() : void
     {
         global $DIC;
         $ilCtrl = $DIC['ilCtrl'];
@@ -224,7 +224,7 @@ class ilAssQuestionHintRequestGUI extends ilAssQuestionHintAbstractGUI
      * @access	private
      * @global	ilCtrl $ilCtrl
      */
-    private function performRequestCmd()
+    private function performRequestCmd() : void
     {
         global $DIC;
         $ilCtrl = $DIC['ilCtrl'];
@@ -256,7 +256,7 @@ class ilAssQuestionHintRequestGUI extends ilAssQuestionHintAbstractGUI
      * @access	private
      * @global	ilCtrl $ilCtrl
      */
-    private function backToQuestionCmd()
+    private function backToQuestionCmd() : void
     {
         global $DIC;
         $ilCtrl = $DIC['ilCtrl'];
@@ -271,7 +271,7 @@ class ilAssQuestionHintRequestGUI extends ilAssQuestionHintAbstractGUI
      * @global ilTemplate $tpl
      * @param string $content
      */
-    private function populateContent($content)
+    private function populateContent($content) : void
     {
         global $DIC;
         $tpl = $DIC['tpl'];

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionHintRequestStatisticData.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionHintRequestStatisticData.php
@@ -49,7 +49,7 @@ class ilAssQuestionHintRequestStatisticData
      * @access public
      * @param integer $requestsPoints
      */
-    public function setRequestsPoints($requestsPoints)
+    public function setRequestsPoints($requestsPoints) : void
     {
         $this->requestsPoints = $requestsPoints;
     }
@@ -71,7 +71,7 @@ class ilAssQuestionHintRequestStatisticData
      * @access public
      * @param integer $requestsCount
      */
-    public function setRequestsCount($requestsCount)
+    public function setRequestsCount($requestsCount) : void
     {
         $this->requestsCount = $requestsCount;
     }

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionHintRequestStatisticRegister.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionHintRequestStatisticRegister.php
@@ -24,7 +24,7 @@ class ilAssQuestionHintRequestStatisticRegister
      * @param integer $qId
      * @param ilAssQuestionHintRequestStatisticData $request
      */
-    public function addRequestByTestPassIndexAndQuestionId($passIndex, $qId, ilAssQuestionHintRequestStatisticData $request)
+    public function addRequestByTestPassIndexAndQuestionId($passIndex, $qId, ilAssQuestionHintRequestStatisticData $request) : void
     {
         if (!isset($this->requestsByTestPassIndexAndQuestionId[$passIndex])) {
             $this->requestsByTestPassIndexAndQuestionId[$passIndex] = array();

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionHintTracking.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionHintTracking.php
@@ -26,7 +26,7 @@ class ilAssQuestionHintTracking
         $this->pass = $pass;
     }
 
-    public function setActiveId($activeId)
+    public function setActiveId($activeId) : void
     {
         $this->activeId = $activeId;
     }
@@ -36,7 +36,7 @@ class ilAssQuestionHintTracking
         return $this->activeId;
     }
 
-    public function setPass($pass)
+    public function setPass($pass) : void
     {
         $this->pass = $pass;
     }
@@ -46,7 +46,7 @@ class ilAssQuestionHintTracking
         return $this->pass;
     }
 
-    public function setQuestionId($questionId)
+    public function setQuestionId($questionId) : void
     {
         $this->questionId = $questionId;
     }
@@ -288,7 +288,7 @@ class ilAssQuestionHintTracking
      * @global	ilDBInterface				$ilDB
      * @param	ilAssQuestionHint	$questionHint
      */
-    public function storeRequest(ilAssQuestionHint $questionHint)
+    public function storeRequest(ilAssQuestionHint $questionHint) : void
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];
@@ -410,7 +410,7 @@ class ilAssQuestionHintTracking
      * Deletes all hint requests relating to a question included in given question ids
      * @param array[integer] $questionIds
      */
-    public static function deleteRequestsByQuestionIds($questionIds)
+    public static function deleteRequestsByQuestionIds($questionIds) : void
     {
         /**
          * @var $ilDB ilDBInterface
@@ -435,7 +435,7 @@ class ilAssQuestionHintTracking
      * @global ilDBInterface $ilDB
      * @param array[integer] $activeIds
      */
-    public static function deleteRequestsByActiveIds($activeIds)
+    public static function deleteRequestsByActiveIds($activeIds) : void
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionHintsGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionHintsGUI.php
@@ -73,12 +73,12 @@ class ilAssQuestionHintsGUI extends ilAssQuestionHintAbstractGUI
     /**
      * @param bool $editingEnabled
      */
-    public function setEditingEnabled(bool $editingEnabled)
+    public function setEditingEnabled(bool $editingEnabled) : void
     {
         $this->editingEnabled = $editingEnabled;
     }
 
-    public function executeCommand()
+    public function executeCommand() : void
     {
         global $DIC;
         $ilCtrl = $DIC['ilCtrl'];
@@ -136,7 +136,7 @@ class ilAssQuestionHintsGUI extends ilAssQuestionHintAbstractGUI
      * @access	private
      * @global	ilTemplate	$tpl
      */
-    private function showListCmd()
+    private function showListCmd() : void
     {
         global $DIC;
         $ilCtrl = $DIC['ilCtrl'];
@@ -192,7 +192,7 @@ class ilAssQuestionHintsGUI extends ilAssQuestionHintAbstractGUI
      * @global	ilTemplate	$tpl
      * @global	ilLanguage	$lng
      */
-    private function confirmDeleteCmd()
+    private function confirmDeleteCmd() : void
     {
         global $DIC;
         $ilCtrl = $DIC['ilCtrl'];
@@ -237,7 +237,7 @@ class ilAssQuestionHintsGUI extends ilAssQuestionHintAbstractGUI
      * @global	ilCtrl		$ilCtrl
      * @global	ilLanguage	$lng
      */
-    private function performDeleteCmd()
+    private function performDeleteCmd() : void
     {
         if (!$this->isEditingEnabled()) {
             return;
@@ -292,7 +292,7 @@ class ilAssQuestionHintsGUI extends ilAssQuestionHintAbstractGUI
      * @global	ilCtrl		$ilCtrl
      * @global	ilLanguage	$lng
      */
-    private function saveListOrderCmd()
+    private function saveListOrderCmd() : void
     {
         if (!$this->isEditingEnabled()) {
             return;
@@ -347,7 +347,7 @@ class ilAssQuestionHintsGUI extends ilAssQuestionHintAbstractGUI
      * @access	private
      * @global	ilCtrl	$ilCtrl
      */
-    private function cutToOrderingClipboardCmd()
+    private function cutToOrderingClipboardCmd() : void
     {
         if (!$this->isEditingEnabled()) {
             return;
@@ -375,7 +375,7 @@ class ilAssQuestionHintsGUI extends ilAssQuestionHintAbstractGUI
      * @global	ilCtrl		$ilCtrl
      * @global	ilLanguage	$lng
      */
-    private function pasteFromOrderingClipboardBeforeCmd()
+    private function pasteFromOrderingClipboardBeforeCmd() : void
     {
         if (!$this->isEditingEnabled()) {
             return;
@@ -435,7 +435,7 @@ class ilAssQuestionHintsGUI extends ilAssQuestionHintAbstractGUI
      * @global	ilCtrl		$ilCtrl
      * @global	ilLanguage	$lng
      */
-    private function pasteFromOrderingClipboardAfterCmd()
+    private function pasteFromOrderingClipboardAfterCmd() : void
     {
         if (!$this->isEditingEnabled()) {
             return;
@@ -495,7 +495,7 @@ class ilAssQuestionHintsGUI extends ilAssQuestionHintAbstractGUI
      * @global	ilCtrl		$ilCtrl
      * @global	ilLanguage	$lng
      */
-    private function resetOrderingClipboardCmd()
+    private function resetOrderingClipboardCmd() : void
     {
         global $DIC;
         $ilCtrl = $DIC['ilCtrl'];
@@ -514,7 +514,7 @@ class ilAssQuestionHintsGUI extends ilAssQuestionHintAbstractGUI
      * @access	private
      * @global	ilLanguage	$lng
      */
-    private function initHintOrderingClipboardNotification()
+    private function initHintOrderingClipboardNotification() : void
     {
         global $DIC;
         $lng = $DIC['lng'];
@@ -538,7 +538,7 @@ class ilAssQuestionHintsGUI extends ilAssQuestionHintAbstractGUI
      * @access	private
      * @param	integer	$hintId
      */
-    private function checkForExistingHintRelatingToCurrentQuestionAndRedirectOnFailure($hintId)
+    private function checkForExistingHintRelatingToCurrentQuestionAndRedirectOnFailure($hintId) : void
     {
         $questionHintList = ilAssQuestionHintList::getListByQuestionId($this->questionOBJ->getId());
         
@@ -580,7 +580,7 @@ class ilAssQuestionHintsGUI extends ilAssQuestionHintAbstractGUI
      * @global	ilLanguage	$lng
      * @param	array		$hintIds
      */
-    private function checkForSingleHintIdAndRedirectOnFailure($hintIds)
+    private function checkForSingleHintIdAndRedirectOnFailure($hintIds) : void
     {
         global $DIC;
         $ilCtrl = $DIC['ilCtrl'];
@@ -659,7 +659,7 @@ class ilAssQuestionHintsGUI extends ilAssQuestionHintAbstractGUI
         return $hintIndexes;
     }
     
-    public function confirmSyncCmd()
+    public function confirmSyncCmd() : void
     {
         $this->questionGUI->originalSyncForm('showHints');
     }
@@ -695,7 +695,7 @@ class ilAssQuestionHintsGUI extends ilAssQuestionHintAbstractGUI
      * @global	ilTemplate $tpl
      * @global	ilLanguage $lng
      */
-    private function showHintCmd()
+    private function showHintCmd() : void
     {
         global $DIC;
         $ilCtrl = $DIC['ilCtrl'];

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionHintsOrderingClipboard.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionHintsOrderingClipboard.php
@@ -46,7 +46,7 @@ class ilAssQuestionHintsOrderingClipboard
      *
      * @access	public
      */
-    public function resetStored()
+    public function resetStored() : void
     {
         $class = ilSession::get(__CLASS__);
         unset($class[$this->questionId]);
@@ -61,7 +61,7 @@ class ilAssQuestionHintsOrderingClipboard
      * @access	public
      * @param	integer	$hintId
      */
-    public function setStored($hintId)
+    public function setStored($hintId) : void
     {
         $class = ilSession::get(__CLASS__);
         $class[$this->questionId] = $hintId;

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionHintsTableGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionHintsTableGUI.php
@@ -123,7 +123,7 @@ class ilAssQuestionHintsTableGUI extends ilTable2GUI
      * @global	ilLanguage	$lng
      * @param	integer		$rowCount
      */
-    private function initAdministrationCommands($rowCount)
+    private function initAdministrationCommands($rowCount) : void
     {
         global $DIC;
         $ilCtrl = $DIC['ilCtrl'];
@@ -169,7 +169,7 @@ class ilAssQuestionHintsTableGUI extends ilTable2GUI
      * @global	ilCtrl		$ilCtrl
      * @global	ilLanguage	$lng
      */
-    private function initTestoutputCommands()
+    private function initTestoutputCommands() : void
     {
         if ($this->parent_obj instanceof ilAssQuestionHintsGUI) {
             return;
@@ -195,7 +195,7 @@ class ilAssQuestionHintsTableGUI extends ilTable2GUI
      * @global	ilLanguage	$lng
      * @param	integer		$rowCount
      */
-    private function initAdministrationColumns($rowCount)
+    private function initAdministrationColumns($rowCount) : void
     {
         global $DIC;
         $lng = $DIC['lng'];
@@ -223,7 +223,7 @@ class ilAssQuestionHintsTableGUI extends ilTable2GUI
      * @access	private
      * @global	ilLanguage	$lng
      */
-    private function initTestoutputColumns()
+    private function initTestoutputColumns() : void
     {
         global $DIC;
         $lng = $DIC['lng'];

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionList.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionList.php
@@ -170,7 +170,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         return $this->parentObjId;
     }
 
-    public function setParentObjId($parentObjId)
+    public function setParentObjId($parentObjId) : void
     {
         $this->parentObjId = $parentObjId;
     }
@@ -180,7 +180,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         return $this->parentObjType;
     }
 
-    public function setParentObjectType($parentObjType)
+    public function setParentObjectType($parentObjType) : void
     {
         $this->parentObjType = $parentObjType;
     }
@@ -196,12 +196,12 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
     /**
      * @param array $parentObjIdsFilter
      */
-    public function setParentObjIdsFilter($parentObjIdsFilter)
+    public function setParentObjIdsFilter($parentObjIdsFilter) : void
     {
         $this->parentObjIdsFilter = $parentObjIdsFilter;
     }
 
-    public function setQuestionInstanceTypeFilter($questionInstanceTypeFilter)
+    public function setQuestionInstanceTypeFilter($questionInstanceTypeFilter) : void
     {
         $this->questionInstanceTypeFilter = $questionInstanceTypeFilter;
     }
@@ -211,7 +211,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         return $this->questionInstanceTypeFilter;
     }
 
-    public function setIncludeQuestionIdsFilter($questionIdsFilter)
+    public function setIncludeQuestionIdsFilter($questionIdsFilter) : void
     {
         $this->includeQuestionIdsFilter = $questionIdsFilter;
     }
@@ -226,7 +226,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         return $this->excludeQuestionIdsFilter;
     }
     
-    public function setExcludeQuestionIdsFilter($excludeQuestionIdsFilter)
+    public function setExcludeQuestionIdsFilter($excludeQuestionIdsFilter) : void
     {
         $this->excludeQuestionIdsFilter = $excludeQuestionIdsFilter;
     }
@@ -236,24 +236,24 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         return $this->questionCompletionStatusFilter;
     }
     
-    public function setQuestionCompletionStatusFilter($questionCompletionStatusFilter)
+    public function setQuestionCompletionStatusFilter($questionCompletionStatusFilter) : void
     {
         $this->questionCompletionStatusFilter = $questionCompletionStatusFilter;
     }
 
-    public function addFieldFilter($fieldName, $fieldValue)
+    public function addFieldFilter($fieldName, $fieldValue) : void
     {
         $this->fieldFilters[$fieldName] = $fieldValue;
     }
     
-    public function addTaxonomyFilter($taxId, $taxNodes, $parentObjId, $parentObjType)
+    public function addTaxonomyFilter($taxId, $taxNodes, $parentObjId, $parentObjType) : void
     {
         $this->taxFilters[$taxId] = $taxNodes;
         $this->taxParentIds[$taxId] = $parentObjId;
         $this->taxParentTypes[$taxId] = $parentObjType;
     }
     
-    public function setAvailableTaxonomyIds($availableTaxonomyIds)
+    public function setAvailableTaxonomyIds($availableTaxonomyIds) : void
     {
         $this->availableTaxonomyIds = $availableTaxonomyIds;
     }
@@ -263,7 +263,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         return $this->availableTaxonomyIds;
     }
 
-    public function setAnswerStatusActiveId($answerStatusActiveId)
+    public function setAnswerStatusActiveId($answerStatusActiveId) : void
     {
         $this->answerStatusActiveId = $answerStatusActiveId;
     }
@@ -273,7 +273,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         return $this->answerStatusActiveId;
     }
 
-    public function setAnswerStatusFilter($answerStatusFilter)
+    public function setAnswerStatusFilter($answerStatusFilter) : void
     {
         $this->answerStatusFilter = $answerStatusFilter;
     }
@@ -288,7 +288,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
      *
      * @param bool $a_val join object_data
      */
-    public function setJoinObjectData($a_val)
+    public function setJoinObjectData($a_val) : void
     {
         $this->join_obj_data = $a_val;
     }
@@ -306,7 +306,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
     /**
      * @param array $forcedQuestionIds
      */
-    public function setForcedQuestionIds($forcedQuestionIds)
+    public function setForcedQuestionIds($forcedQuestionIds) : void
     {
         $this->forcedQuestionIds = $forcedQuestionIds;
     }
@@ -632,7 +632,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         return $query;
     }
     
-    public function load()
+    public function load() : void
     {
         $this->checkFilters();
         
@@ -741,7 +741,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         return $this->questions[$a_item_id]['title'];
     }
     
-    private function checkFilters()
+    private function checkFilters() : void
     {
         if (strlen($this->getAnswerStatusFilter()) && !$this->getAnswerStatusActiveId()) {
             require_once 'Modules/TestQuestionPool/exceptions/class.ilTestQuestionPoolException.php';

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionPageGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionPageGUI.php
@@ -46,7 +46,7 @@ class ilAssQuestionPageGUI extends ilPageObjectGUI
         return $this->originalPresentationTitle;
     }
 
-    public function setOriginalPresentationTitle($originalPresentationTitle)
+    public function setOriginalPresentationTitle($originalPresentationTitle) : void
     {
         $this->originalPresentationTitle = $originalPresentationTitle;
     }
@@ -89,7 +89,7 @@ class ilAssQuestionPageGUI extends ilPageObjectGUI
      * Set the HTML of a question info block below the title (number, status, ...)
      * @param string	$a_html
      */
-    public function setQuestionInfoHTML($a_html)
+    public function setQuestionInfoHTML($a_html) : void
     {
         $this->questionInfoHTML = $a_html;
     }
@@ -98,7 +98,7 @@ class ilAssQuestionPageGUI extends ilPageObjectGUI
      * Set the HTML of a question actions block below the title
      * @param string 	$a_html
      */
-    public function setQuestionActionsHTML($a_html)
+    public function setQuestionActionsHTML($a_html) : void
     {
         $this->questionActionsHTML = $a_html;
     }

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php
@@ -100,7 +100,7 @@ class ilAssQuestionPreviewGUI
         $this->randomGroup = $randomGroup;
     }
 
-    public function initQuestion($questionId, $parentObjId)
+    public function initQuestion($questionId, $parentObjId) : void
     {
         require_once 'Modules/TestQuestionPool/classes/class.assQuestion.php';
         
@@ -121,7 +121,7 @@ class ilAssQuestionPreviewGUI
         $this->questionGUI->setRenderPurpose(assQuestionGUI::RENDER_PURPOSE_DEMOPLAY);
     }
 
-    public function initPreviewSettings($parentRefId)
+    public function initPreviewSettings($parentRefId) : void
     {
         require_once 'Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewSettings.php';
         $this->previewSettings = new ilAssQuestionPreviewSettings($parentRefId);
@@ -129,7 +129,7 @@ class ilAssQuestionPreviewGUI
         $this->previewSettings->init();
     }
 
-    public function initPreviewSession($userId, $questionId)
+    public function initPreviewSession($userId, $questionId) : void
     {
         require_once 'Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewSession.php';
         $this->previewSession = new ilAssQuestionPreviewSession($userId, $questionId);
@@ -137,13 +137,13 @@ class ilAssQuestionPreviewGUI
         $this->previewSession->init();
     }
     
-    public function initHintTracking()
+    public function initHintTracking() : void
     {
         require_once 'Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewHintTracking.php';
         $this->hintTracking = new ilAssQuestionPreviewHintTracking($this->db, $this->previewSession);
     }
     
-    public function initStyleSheets()
+    public function initStyleSheets() : void
     {
         include_once("./Services/Style/Content/classes/class.ilObjStyleSheet.php");
         
@@ -156,7 +156,7 @@ class ilAssQuestionPreviewGUI
         $this->tpl->parseCurrentBlock();
     }
     
-    public function executeCommand()
+    public function executeCommand() : void
     {
         global $DIC; /* @var \ILIAS\DI\Container $DIC */
         $ilHelp = $DIC['ilHelp']; /* @var ilHelpGUI $ilHelp */
@@ -225,7 +225,7 @@ class ilAssQuestionPreviewGUI
         );
     }
     
-    private function showCmd($notesPanelHTML = '')
+    private function showCmd($notesPanelHTML = '') : void
     {
         $tpl = new ilTemplate('tpl.qpl_question_preview.html', true, true, 'Modules/TestQuestionPool');
 
@@ -245,7 +245,7 @@ class ilAssQuestionPreviewGUI
         $this->tpl->setContent($tpl->get());
     }
     
-    protected function handleInstantResponseRendering(ilTemplate $tpl)
+    protected function handleInstantResponseRendering(ilTemplate $tpl) : void
     {
         $renderHeader = false;
         $renderAnchor = false;
@@ -284,7 +284,7 @@ class ilAssQuestionPreviewGUI
         }
     }
     
-    private function resetCmd()
+    private function resetCmd() : void
     {
         $this->previewSession->setRandomizerSeed(null);
         $this->previewSession->setParticipantsSolution(null);
@@ -296,7 +296,7 @@ class ilAssQuestionPreviewGUI
         $this->ctrl->redirect($this, self::CMD_SHOW);
     }
     
-    private function instantResponseCmd()
+    private function instantResponseCmd() : void
     {
         if ($this->saveQuestionSolution()) {
             $this->previewSession->setInstantResponseActive(true);
@@ -307,13 +307,13 @@ class ilAssQuestionPreviewGUI
         $this->ctrl->redirect($this, self::CMD_SHOW);
     }
     
-    private function handleQuestionActionCmd()
+    private function handleQuestionActionCmd() : void
     {
         $this->questionOBJ->persistPreviewState($this->previewSession);
         $this->ctrl->redirect($this, self::CMD_SHOW);
     }
     
-    private function populatePreviewToolbar(ilTemplate $tpl)
+    private function populatePreviewToolbar(ilTemplate $tpl) : void
     {
         require_once 'Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewToolbarGUI.php';
         $toolbarGUI = new ilAssQuestionPreviewToolbarGUI($this->lng);
@@ -326,7 +326,7 @@ class ilAssQuestionPreviewGUI
         $tpl->setVariable('PREVIEW_TOOLBAR', $this->ctrl->getHTML($toolbarGUI));
     }
 
-    private function populateQuestionOutput(ilTemplate $tpl)
+    private function populateQuestionOutput(ilTemplate $tpl) : void
     {
         // FOR WHAT EXACTLY IS THIS USEFUL?
         $this->ctrl->setReturnByClass('ilAssQuestionPageGUI', 'view');
@@ -366,7 +366,7 @@ class ilAssQuestionPreviewGUI
         $tpl->setVariable('QUESTION_OUTPUT', $pageGUI->preview());
     }
     
-    protected function populateReachedPointsOutput(ilTemplate $tpl)
+    protected function populateReachedPointsOutput(ilTemplate $tpl) : void
     {
         $reachedPoints = $this->questionOBJ->calculateReachedPointsFromPreviewSession($this->previewSession);
         $maxPoints = $this->questionOBJ->getMaximumPoints();
@@ -382,7 +382,7 @@ class ilAssQuestionPreviewGUI
         $tpl->parseCurrentBlock();
     }
 
-    private function populateSolutionOutput(ilTemplate $tpl)
+    private function populateSolutionOutput(ilTemplate $tpl) : void
     {
         // FOR WHAT EXACTLY IS THIS USEFUL?
         $this->ctrl->setReturnByClass('ilAssQuestionPageGUI', 'view');
@@ -437,7 +437,7 @@ class ilAssQuestionPreviewGUI
         return $this->ctrl->getHTML($navGUI);
     }
     
-    private function populateGenericQuestionFeedback(ilTemplate $tpl)
+    private function populateGenericQuestionFeedback(ilTemplate $tpl) : void
     {
         if ($this->questionOBJ->isPreviewSolutionCorrect($this->previewSession)) {
             $feedback = $this->questionGUI->getGenericFeedbackOutputForCorrectSolution();
@@ -455,7 +455,7 @@ class ilAssQuestionPreviewGUI
         }
     }
 
-    private function populateSpecificQuestionFeedback(ilTemplate $tpl)
+    private function populateSpecificQuestionFeedback(ilTemplate $tpl) : void
     {
         $fb = $this->questionGUI->getSpecificFeedbackOutput(
             (array) $this->previewSession->getParticipantsSolution()
@@ -466,7 +466,7 @@ class ilAssQuestionPreviewGUI
         $tpl->parseCurrentBlock();
     }
     
-    protected function populateInstantResponseHeader(ilTemplate $tpl, $withFocusAnchor)
+    protected function populateInstantResponseHeader(ilTemplate $tpl, $withFocusAnchor) : void
     {
         if ($withFocusAnchor) {
             $tpl->setCurrentBlock('inst_resp_id');
@@ -520,7 +520,7 @@ class ilAssQuestionPreviewGUI
         return $this->questionOBJ->persistPreviewState($this->previewSession);
     }
 
-    public function gatewayConfirmHintRequestCmd()
+    public function gatewayConfirmHintRequestCmd() : void
     {
         if (!$this->saveQuestionSolution()) {
             $this->previewSession->setInstantResponseActive(false);
@@ -536,7 +536,7 @@ class ilAssQuestionPreviewGUI
         );
     }
 
-    public function gatewayShowHintListCmd()
+    public function gatewayShowHintListCmd() : void
     {
         if (!$this->saveQuestionSolution()) {
             $this->previewSession->setInstantResponseActive(false);
@@ -564,7 +564,7 @@ class ilAssQuestionPreviewGUI
         return $this->randomGroup->shuffleArray(new GivenSeed($this->previewSession->getRandomizerSeed()));
     }
     
-    protected function populateNotesPanel(ilTemplate $tpl, $notesPanelHTML)
+    protected function populateNotesPanel(ilTemplate $tpl, $notesPanelHTML) : void
     {
         if (!strlen($notesPanelHTML)) {
             $notesPanelHTML = $this->questionGUI->getNotesHTML();

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewHintTracking.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewHintTracking.php
@@ -85,7 +85,7 @@ class ilAssQuestionPreviewHintTracking
         );
     }
 
-    public function storeRequest(ilAssQuestionHint $questionHint)
+    public function storeRequest(ilAssQuestionHint $questionHint) : void
     {
         $this->previewSession->addRequestedHint($questionHint->getId());
     }

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewSession.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewSession.php
@@ -26,7 +26,7 @@ class ilAssQuestionPreviewSession
         $this->questionId = $questionId;
     }
     
-    public function init()
+    public function init() : void
     {
         $this->ensureSessionStructureExists();
     }
@@ -46,7 +46,7 @@ class ilAssQuestionPreviewSession
         return "u{$this->userId}::q{$this->questionId}";
     }
     
-    private function saveSessionValue($subIndex, $value)
+    private function saveSessionValue($subIndex, $value) : void
     {
         $val = ilSession::get(self::SESSION_BASEINDEX);
         $val[$this->getSessionContextIndex()][$subIndex] = $value;
@@ -68,7 +68,7 @@ class ilAssQuestionPreviewSession
         //return $_SESSION[self::SESSION_BASEINDEX][$this->getSessionContextIndex()][$subIndex];
     }
 
-    public function setInstantResponseActive($instantResponseActive)
+    public function setInstantResponseActive($instantResponseActive) : void
     {
         $this->saveSessionValue(self::SESSION_SUBINDEX_INSTANT_RESPONSE_ACTIVE, $instantResponseActive);
     }
@@ -78,7 +78,7 @@ class ilAssQuestionPreviewSession
         return $this->readSessionValue(self::SESSION_SUBINDEX_INSTANT_RESPONSE_ACTIVE);
     }
     
-    public function setParticipantsSolution($participantSolution)
+    public function setParticipantsSolution($participantSolution) : void
     {
         $this->saveSessionValue(self::SESSION_SUBINDEX_PARTICIPANT_SOLUTION, $participantSolution);
     }
@@ -117,7 +117,7 @@ class ilAssQuestionPreviewSession
         }
     }
     
-    public function addRequestedHint($hintId)
+    public function addRequestedHint($hintId) : void
     {
         $requestedHints = $this->readSessionValue(self::SESSION_SUBINDEX_REQUESTED_HINTS);
         $requestedHints[$hintId] = $hintId;
@@ -132,12 +132,12 @@ class ilAssQuestionPreviewSession
         return array();
     }
     
-    public function resetRequestedHints()
+    public function resetRequestedHints() : void
     {
         $this->saveSessionValue(self::SESSION_SUBINDEX_REQUESTED_HINTS, array());
     }
     
-    public function setRandomizerSeed($seed)
+    public function setRandomizerSeed($seed) : void
     {
         $this->saveSessionValue(self::SESSION_SUBINDEX_RANDOMIZER_SEED, $seed);
     }
@@ -152,7 +152,7 @@ class ilAssQuestionPreviewSession
         return ($this->getRandomizerSeed() !== null);
     }
 
-    private function ensureSessionStructureExists()
+    private function ensureSessionStructureExists() : void
     {
         if (!is_array(ilSession::get(self::SESSION_BASEINDEX))) {
             ilSession::set(self::SESSION_BASEINDEX, array());
@@ -162,7 +162,6 @@ class ilAssQuestionPreviewSession
 
         if (!isset($baseSession[$this->getSessionContextIndex()])) {
             $baseSession[$this->getSessionContextIndex()] = array();
-
         }
 
         $contextSession = &$baseSession[$this->getSessionContextIndex()];

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewSettings.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewSettings.php
@@ -30,7 +30,7 @@ class ilAssQuestionPreviewSettings
         $this->contextRefId = $contextRefId;
     }
 
-    public function init()
+    public function init() : void
     {
         if ($this->isTestRefId()) {
             $this->initSettingsWithTestObject();
@@ -46,7 +46,7 @@ class ilAssQuestionPreviewSettings
         return $objectType == 'tst';
     }
     
-    private function initSettingsWithTestObject()
+    private function initSettingsWithTestObject() : void
     {
         /* @var ilObjTest $testOBJ */
         $testOBJ = ilObjectFactory::getInstanceByRefId($this->contextRefId);
@@ -59,7 +59,7 @@ class ilAssQuestionPreviewSettings
         $this->setReachedPointsEnabled($testOBJ->getAnswerFeedbackPoints());
     }
 
-    private function initSettingsFromPostParameters()
+    private function initSettingsFromPostParameters() : void
     {
         // get from post or from toolbar instance if possible
         
@@ -70,7 +70,7 @@ class ilAssQuestionPreviewSettings
         $this->setReachedPointsEnabled(true);
     }
 
-    public function setContextRefId($contextRefId)
+    public function setContextRefId($contextRefId) : void
     {
         $this->contextRefId = $contextRefId;
     }
@@ -91,12 +91,12 @@ class ilAssQuestionPreviewSettings
     /**
      * @param bool $reachedPointsEnabled
      */
-    public function setReachedPointsEnabled(bool $reachedPointsEnabled)
+    public function setReachedPointsEnabled(bool $reachedPointsEnabled) : void
     {
         $this->reachedPointsEnabled = $reachedPointsEnabled;
     }
 
-    public function setGenericFeedbackEnabled($genericFeedbackEnabled)
+    public function setGenericFeedbackEnabled($genericFeedbackEnabled) : void
     {
         $this->genericFeedbackEnabled = $genericFeedbackEnabled;
     }
@@ -106,7 +106,7 @@ class ilAssQuestionPreviewSettings
         return $this->genericFeedbackEnabled;
     }
 
-    public function setSpecificFeedbackEnabled($specificFeedbackEnabled)
+    public function setSpecificFeedbackEnabled($specificFeedbackEnabled) : void
     {
         $this->specificFeedbackEnabled = $specificFeedbackEnabled;
     }
@@ -116,7 +116,7 @@ class ilAssQuestionPreviewSettings
         return $this->specificFeedbackEnabled;
     }
 
-    public function setHintProvidingEnabled($hintProvidingEnabled)
+    public function setHintProvidingEnabled($hintProvidingEnabled) : void
     {
         $this->hintProvidingEnabled = $hintProvidingEnabled;
     }
@@ -126,7 +126,7 @@ class ilAssQuestionPreviewSettings
         return $this->hintProvidingEnabled;
     }
 
-    public function setBestSolutionEnabled($bestSolutionEnabled)
+    public function setBestSolutionEnabled($bestSolutionEnabled) : void
     {
         $this->bestSolutionEnabled = $bestSolutionEnabled;
     }

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewToolbarGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewToolbarGUI.php
@@ -20,7 +20,7 @@ class ilAssQuestionPreviewToolbarGUI extends ilToolbarGUI
         parent::__construct();
     }
     
-    public function build()
+    public function build() : void
     {
         $button = \ilSubmitButton::getInstance();
         $button->setCaption("qpl_reset_preview");
@@ -30,7 +30,7 @@ class ilAssQuestionPreviewToolbarGUI extends ilToolbarGUI
         //$this->addFormButton($this->lng->txt('qpl_reset_preview'), $this->getResetPreviewCmd(), '', true);
     }
 
-    public function setResetPreviewCmd($resetPreviewCmd)
+    public function setResetPreviewCmd($resetPreviewCmd) : void
     {
         $this->resetPreviewCmd = $resetPreviewCmd;
     }

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionProcessLocker.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionProcessLocker.php
@@ -12,7 +12,7 @@ abstract class ilAssQuestionProcessLocker
     /**
      * @param callable $operation
      */
-    protected function executeOperation(callable $operation)
+    protected function executeOperation(callable $operation) : void
     {
         $operation();
     }
@@ -20,7 +20,7 @@ abstract class ilAssQuestionProcessLocker
     /**
      * @param callable $operation
      */
-    final public function executePersistWorkingStateLockOperation(callable $operation)
+    final public function executePersistWorkingStateLockOperation(callable $operation) : void
     {
         $this->onBeforeExecutingPersistWorkingStateOperation();
         $this->executeOperation($operation);
@@ -30,21 +30,21 @@ abstract class ilAssQuestionProcessLocker
     /**
      *
      */
-    protected function onBeforeExecutingPersistWorkingStateOperation()
+    protected function onBeforeExecutingPersistWorkingStateOperation() : void
     {
     }
 
     /**
      *
      */
-    protected function onAfterExecutingPersistWorkingStateOperation()
+    protected function onAfterExecutingPersistWorkingStateOperation() : void
     {
     }
 
     /**
      * @param callable $operation
      */
-    final public function executeUserSolutionUpdateLockOperation(callable $operation)
+    final public function executeUserSolutionUpdateLockOperation(callable $operation) : void
     {
         $this->onBeforeExecutingUserSolutionUpdateOperation();
         $this->executeOperation($operation);
@@ -54,21 +54,21 @@ abstract class ilAssQuestionProcessLocker
     /**
      *
      */
-    protected function onBeforeExecutingUserSolutionUpdateOperation()
+    protected function onBeforeExecutingUserSolutionUpdateOperation() : void
     {
     }
 
     /**
      *
      */
-    protected function onAfterExecutingUserSolutionUpdateOperation()
+    protected function onAfterExecutingUserSolutionUpdateOperation() : void
     {
     }
 
     /**
      * @param callable $operation
      */
-    final public function executeUserQuestionResultUpdateOperation(callable $operation)
+    final public function executeUserQuestionResultUpdateOperation(callable $operation) : void
     {
         $this->onBeforeExecutingUserQuestionResultUpdateOperation();
         $this->executeOperation($operation);
@@ -78,21 +78,21 @@ abstract class ilAssQuestionProcessLocker
     /**
      *
      */
-    protected function onBeforeExecutingUserQuestionResultUpdateOperation()
+    protected function onBeforeExecutingUserQuestionResultUpdateOperation() : void
     {
     }
 
     /**
      *
      */
-    protected function onAfterExecutingUserQuestionResultUpdateOperation()
+    protected function onAfterExecutingUserQuestionResultUpdateOperation() : void
     {
     }
 
     /**
      * @param callable $operation
      */
-    final public function executeUserPassResultUpdateLockOperation(callable $operation)
+    final public function executeUserPassResultUpdateLockOperation(callable $operation) : void
     {
         $this->onBeforeExecutingUserPassResultUpdateOperation();
         $this->executeOperation($operation);
@@ -102,21 +102,21 @@ abstract class ilAssQuestionProcessLocker
     /**
      *
      */
-    protected function onBeforeExecutingUserPassResultUpdateOperation()
+    protected function onBeforeExecutingUserPassResultUpdateOperation() : void
     {
     }
 
     /**
      *
      */
-    protected function onAfterExecutingUserPassResultUpdateOperation()
+    protected function onAfterExecutingUserPassResultUpdateOperation() : void
     {
     }
 
     /**
      * @param callable $operation
      */
-    final public function executeUserTestResultUpdateLockOperation(callable $operation)
+    final public function executeUserTestResultUpdateLockOperation(callable $operation) : void
     {
         $this->onBeforeExecutingUserTestResultUpdateOperation();
         $this->executeOperation($operation);
@@ -126,21 +126,21 @@ abstract class ilAssQuestionProcessLocker
     /**
      *
      */
-    protected function onBeforeExecutingUserTestResultUpdateOperation()
+    protected function onBeforeExecutingUserTestResultUpdateOperation() : void
     {
     }
 
     /**
      *
      */
-    protected function onAfterExecutingUserTestResultUpdateOperation()
+    protected function onAfterExecutingUserTestResultUpdateOperation() : void
     {
     }
 
     /**
      * @param callable $operation
      */
-    final public function executeUserSolutionAdoptLockOperation(callable $operation)
+    final public function executeUserSolutionAdoptLockOperation(callable $operation) : void
     {
         $this->onBeforeExecutingUserSolutionAdoptOperation();
         $this->executeOperation($operation);
@@ -150,14 +150,14 @@ abstract class ilAssQuestionProcessLocker
     /**
      *
      */
-    protected function onBeforeExecutingUserSolutionAdoptOperation()
+    protected function onBeforeExecutingUserSolutionAdoptOperation() : void
     {
     }
 
     /**
      *
      */
-    protected function onAfterExecutingUserSolutionAdoptOperation()
+    protected function onAfterExecutingUserSolutionAdoptOperation() : void
     {
     }
 }

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionProcessLockerDb.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionProcessLockerDb.php
@@ -39,7 +39,7 @@ class ilAssQuestionProcessLockerDb extends ilAssQuestionProcessLocker
         return $this->assessmentLogEnabled;
     }
 
-    public function setAssessmentLogEnabled($assessmentLogEnabled)
+    public function setAssessmentLogEnabled($assessmentLogEnabled) : void
     {
         $this->assessmentLogEnabled = $assessmentLogEnabled;
     }
@@ -80,7 +80,7 @@ class ilAssQuestionProcessLockerDb extends ilAssQuestionProcessLocker
     /**
      * {@inheritdoc}
      */
-    protected function onBeforeExecutingUserSolutionUpdateOperation()
+    protected function onBeforeExecutingUserSolutionUpdateOperation() : void
     {
         $tables = $this->getTablesUsedDuringSolutionUpdate();
 
@@ -97,7 +97,7 @@ class ilAssQuestionProcessLockerDb extends ilAssQuestionProcessLocker
     /**
      * {@inheritdoc}
      */
-    protected function onBeforeExecutingUserQuestionResultUpdateOperation()
+    protected function onBeforeExecutingUserQuestionResultUpdateOperation() : void
     {
         $this->atom_query = $this->db->buildAtomQuery();
         foreach ($this->getTablesUsedDuringResultUpdate() as $table) {
@@ -108,7 +108,7 @@ class ilAssQuestionProcessLockerDb extends ilAssQuestionProcessLocker
     /**
      * {@inheritdoc}
      */
-    protected function onBeforeExecutingUserSolutionAdoptOperation()
+    protected function onBeforeExecutingUserSolutionAdoptOperation() : void
     {
         $this->atom_query = $this->db->buildAtomQuery();
         foreach (array_merge(
@@ -122,7 +122,7 @@ class ilAssQuestionProcessLockerDb extends ilAssQuestionProcessLocker
     /**
      * {@inheritdoc}
      */
-    protected function onBeforeExecutingUserTestResultUpdateOperation()
+    protected function onBeforeExecutingUserTestResultUpdateOperation() : void
     {
         $this->atom_query = $this->db->buildAtomQuery();
         $this->atom_query->addTableLock('tst_result_cache');
@@ -133,7 +133,7 @@ class ilAssQuestionProcessLockerDb extends ilAssQuestionProcessLocker
     /**
      * {@inheritdoc}
      */
-    protected function executeOperation(callable $operation)
+    protected function executeOperation(callable $operation) : void
     {
         if ($this->atom_query) {
             $this->atom_query->addQueryCallable(function (ilDBInterface $ilDB) use ($operation) {

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionProcessLockerFactory.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionProcessLockerFactory.php
@@ -57,7 +57,7 @@ class ilAssQuestionProcessLockerFactory
     /**
      * @param int $questionId
      */
-    public function setQuestionId($questionId)
+    public function setQuestionId($questionId) : void
     {
         $this->questionId = $questionId;
     }
@@ -73,7 +73,7 @@ class ilAssQuestionProcessLockerFactory
     /**
      * @param int $userId
      */
-    public function setUserId($userId)
+    public function setUserId($userId) : void
     {
         $this->userId = $userId;
     }
@@ -89,7 +89,7 @@ class ilAssQuestionProcessLockerFactory
     /**
      * @param bool $assessmentLogEnabled
      */
-    public function setAssessmentLogEnabled($assessmentLogEnabled)
+    public function setAssessmentLogEnabled($assessmentLogEnabled) : void
     {
         $this->assessmentLogEnabled = $assessmentLogEnabled;
     }

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionProcessLockerFile.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionProcessLockerFile.php
@@ -35,7 +35,7 @@ class ilAssQuestionProcessLockerFile extends ilAssQuestionProcessLocker
     /**
      * {@inheritdoc}
      */
-    protected function onBeforeExecutingPersistWorkingStateOperation()
+    protected function onBeforeExecutingPersistWorkingStateOperation() : void
     {
         $this->requestLock(self::PROCESS_NAME_QUESTION_WORKING_STATE_UPDATE);
     }
@@ -43,7 +43,7 @@ class ilAssQuestionProcessLockerFile extends ilAssQuestionProcessLocker
     /**
      * {@inheritdoc}
      */
-    protected function onAfterExecutingPersistWorkingStateOperation()
+    protected function onAfterExecutingPersistWorkingStateOperation() : void
     {
         $this->releaseLock(self::PROCESS_NAME_QUESTION_WORKING_STATE_UPDATE);
     }
@@ -51,7 +51,7 @@ class ilAssQuestionProcessLockerFile extends ilAssQuestionProcessLocker
     /**
      * {@inheritdoc}
      */
-    protected function onBeforeExecutingUserSolutionAdoptOperation()
+    protected function onBeforeExecutingUserSolutionAdoptOperation() : void
     {
         $this->requestLock(self::PROCESS_NAME_QUESTION_WORKING_STATE_UPDATE);
     }
@@ -59,7 +59,7 @@ class ilAssQuestionProcessLockerFile extends ilAssQuestionProcessLocker
     /**
      * {@inheritdoc}
      */
-    protected function onAfterExecutingUserSolutionAdoptOperation()
+    protected function onAfterExecutingUserSolutionAdoptOperation() : void
     {
         $this->releaseLock(self::PROCESS_NAME_QUESTION_WORKING_STATE_UPDATE);
     }
@@ -67,7 +67,7 @@ class ilAssQuestionProcessLockerFile extends ilAssQuestionProcessLocker
     /**
      * @param string $processName
      */
-    private function requestLock($processName)
+    private function requestLock($processName) : void
     {
         $lockFilePath = $this->getLockFilePath($processName);
         $this->lockFileHandles[$processName] = fopen($lockFilePath, 'w');
@@ -87,7 +87,7 @@ class ilAssQuestionProcessLockerFile extends ilAssQuestionProcessLocker
     /**
      * @param string $processName
      */
-    private function releaseLock($processName)
+    private function releaseLock($processName) : void
     {
         flock($this->lockFileHandles[$processName], LOCK_UN);
         fclose($this->lockFileHandles[$processName]);

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionRelatedNavigationBarGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionRelatedNavigationBarGUI.php
@@ -45,7 +45,7 @@ class ilAssQuestionRelatedNavigationBarGUI
         return $this->hintListCmd;
     }
 
-    public function setHintListCmd($hintListCmd)
+    public function setHintListCmd($hintListCmd) : void
     {
         $this->hintListCmd = $hintListCmd;
     }
@@ -55,12 +55,12 @@ class ilAssQuestionRelatedNavigationBarGUI
         return $this->hintRequestCmd;
     }
 
-    public function setHintRequestCmd($hintRequestCmd)
+    public function setHintRequestCmd($hintRequestCmd) : void
     {
         $this->hintRequestCmd = $hintRequestCmd;
     }
 
-    public function setHintRequestsExist($hintRequestsExist)
+    public function setHintRequestsExist($hintRequestsExist) : void
     {
         $this->hintRequestsExist = $hintRequestsExist;
     }
@@ -70,7 +70,7 @@ class ilAssQuestionRelatedNavigationBarGUI
         return $this->hintRequestsExist;
     }
 
-    public function setHintRequestsPossible($hintRequestsPossible)
+    public function setHintRequestsPossible($hintRequestsPossible) : void
     {
         $this->hintRequestsPossible = $hintRequestsPossible;
     }
@@ -80,7 +80,7 @@ class ilAssQuestionRelatedNavigationBarGUI
         return $this->hintRequestsPossible;
     }
 
-    public function setHintProvidingEnabled($hintProvidingEnabled)
+    public function setHintProvidingEnabled($hintProvidingEnabled) : void
     {
         $this->hintProvidingEnabled = $hintProvidingEnabled;
     }
@@ -90,7 +90,7 @@ class ilAssQuestionRelatedNavigationBarGUI
         return $this->hintProvidingEnabled;
     }
 
-    public function setInstantResponseEnabled($instantFeedbackEnabled)
+    public function setInstantResponseEnabled($instantFeedbackEnabled) : void
     {
         $this->instantResponseEnabled = $instantFeedbackEnabled;
     }
@@ -100,7 +100,7 @@ class ilAssQuestionRelatedNavigationBarGUI
         return $this->instantResponseEnabled;
     }
 
-    public function setInstantResponseCmd($instantResponseCmd)
+    public function setInstantResponseCmd($instantResponseCmd) : void
     {
         $this->instantResponseCmd = $instantResponseCmd;
     }

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionSkillAssignment.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionSkillAssignment.php
@@ -81,7 +81,7 @@ class ilAssQuestionSkillAssignment
         $this->skill_tree_service = $DIC->skills()->tree();
     }
 
-    public function loadFromDb()
+    public function loadFromDb() : void
     {
         $query = "
 			SELECT obj_fi, question_fi, skill_base_fi, skill_tref_fi, skill_points, eval_mode
@@ -110,13 +110,13 @@ class ilAssQuestionSkillAssignment
         }
     }
     
-    public function loadComparisonExpressions()
+    public function loadComparisonExpressions() : void
     {
         $this->initSolutionComparisonExpressionList();
         $this->solutionComparisonExpressionList->load();
     }
 
-    public function saveToDb()
+    public function saveToDb() : void
     {
         if ($this->dbRecordExists()) {
             $this->db->update(
@@ -148,13 +148,13 @@ class ilAssQuestionSkillAssignment
         }
     }
 
-    public function saveComparisonExpressions()
+    public function saveComparisonExpressions() : void
     {
         $this->initSolutionComparisonExpressionList();
         $this->solutionComparisonExpressionList->save();
     }
 
-    public function deleteFromDb()
+    public function deleteFromDb() : void
     {
         $query = "
 			DELETE FROM qpl_qst_skl_assigns
@@ -173,7 +173,7 @@ class ilAssQuestionSkillAssignment
         $this->deleteComparisonExpressions();
     }
 
-    public function deleteComparisonExpressions()
+    public function deleteComparisonExpressions() : void
     {
         $this->initSolutionComparisonExpressionList();
         $this->solutionComparisonExpressionList->delete();
@@ -225,7 +225,7 @@ class ilAssQuestionSkillAssignment
     /**
      * @param int $skillPoints
      */
-    public function setSkillPoints($skillPoints)
+    public function setSkillPoints($skillPoints) : void
     {
         $this->skillPoints = $skillPoints;
     }
@@ -241,7 +241,7 @@ class ilAssQuestionSkillAssignment
     /**
      * @param int $questionId
      */
-    public function setQuestionId($questionId)
+    public function setQuestionId($questionId) : void
     {
         $this->questionId = $questionId;
     }
@@ -257,7 +257,7 @@ class ilAssQuestionSkillAssignment
     /**
      * @param int $skillBaseId
      */
-    public function setSkillBaseId($skillBaseId)
+    public function setSkillBaseId($skillBaseId) : void
     {
         $this->skillBaseId = $skillBaseId;
     }
@@ -273,7 +273,7 @@ class ilAssQuestionSkillAssignment
     /**
      * @param int $skillTrefId
      */
-    public function setSkillTrefId($skillTrefId)
+    public function setSkillTrefId($skillTrefId) : void
     {
         $this->skillTrefId = $skillTrefId;
     }
@@ -289,7 +289,7 @@ class ilAssQuestionSkillAssignment
     /**
      * @param int $parentObjId
      */
-    public function setParentObjId($parentObjId)
+    public function setParentObjId($parentObjId) : void
     {
         $this->parentObjId = $parentObjId;
     }
@@ -302,7 +302,7 @@ class ilAssQuestionSkillAssignment
         return $this->parentObjId;
     }
 
-    public function loadAdditionalSkillData()
+    public function loadAdditionalSkillData() : void
     {
         $this->setSkillTitle(
             ilBasicSkill::_lookupTitle($this->getSkillBaseId(), $this->getSkillTrefId())
@@ -323,7 +323,7 @@ class ilAssQuestionSkillAssignment
         $this->setSkillPath(implode(' > ', $nodes));
     }
 
-    public function setSkillTitle($skillTitle)
+    public function setSkillTitle($skillTitle) : void
     {
         $this->skillTitle = $skillTitle;
     }
@@ -333,7 +333,7 @@ class ilAssQuestionSkillAssignment
         return $this->skillTitle;
     }
 
-    public function setSkillPath($skillPath)
+    public function setSkillPath($skillPath) : void
     {
         $this->skillPath = $skillPath;
     }
@@ -348,7 +348,7 @@ class ilAssQuestionSkillAssignment
         return $this->evalMode;
     }
 
-    public function setEvalMode($evalMode)
+    public function setEvalMode($evalMode) : void
     {
         $this->evalMode = $evalMode;
     }
@@ -358,7 +358,7 @@ class ilAssQuestionSkillAssignment
         return $this->getEvalMode() == self::EVAL_MODE_BY_QUESTION_SOLUTION;
     }
 
-    public function initSolutionComparisonExpressionList()
+    public function initSolutionComparisonExpressionList() : void
     {
         $this->solutionComparisonExpressionList->setQuestionId($this->getQuestionId());
         $this->solutionComparisonExpressionList->setSkillBaseId($this->getSkillBaseId());

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentList.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentList.php
@@ -55,7 +55,7 @@ class ilAssQuestionSkillAssignmentList
     /**
      * @param int $parentObjId
      */
-    public function setParentObjId($parentObjId)
+    public function setParentObjId($parentObjId) : void
     {
         $this->parentObjId = $parentObjId;
     }
@@ -79,19 +79,19 @@ class ilAssQuestionSkillAssignmentList
     /**
      * @param int $questionIdFilter
      */
-    public function setQuestionIdFilter($questionIdFilter)
+    public function setQuestionIdFilter($questionIdFilter) : void
     {
         $this->questionIdFilter = $questionIdFilter;
     }
 
-    public function reset()
+    public function reset() : void
     {
         $this->assignments = array();
         $this->numAssignsBySkill = array();
         $this->maxPointsBySkill = array();
     }
 
-    public function addAssignment(ilAssQuestionSkillAssignment $assignment)
+    public function addAssignment(ilAssQuestionSkillAssignment $assignment) : void
     {
         if (!isset($this->assignments[$assignment->getQuestionId()])) {
             $this->assignments[$assignment->getQuestionId()] = array();
@@ -100,7 +100,7 @@ class ilAssQuestionSkillAssignmentList
         $this->assignments[$assignment->getQuestionId()][] = $assignment;
     }
 
-    private function incrementNumAssignsBySkill(ilAssQuestionSkillAssignment $assignment)
+    private function incrementNumAssignsBySkill(ilAssQuestionSkillAssignment $assignment) : void
     {
         $key = $this->buildSkillKey($assignment->getSkillBaseId(), $assignment->getSkillTrefId());
 
@@ -111,7 +111,7 @@ class ilAssQuestionSkillAssignmentList
         $this->numAssignsBySkill[$key]++;
     }
 
-    private function incrementMaxPointsBySkill(ilAssQuestionSkillAssignment $assignment)
+    private function incrementMaxPointsBySkill(ilAssQuestionSkillAssignment $assignment) : void
     {
         $key = $this->buildSkillKey($assignment->getSkillBaseId(), $assignment->getSkillTrefId());
 
@@ -122,7 +122,7 @@ class ilAssQuestionSkillAssignmentList
         $this->maxPointsBySkill[$key] += $assignment->getMaxSkillPoints();
     }
 
-    public function loadFromDb()
+    public function loadFromDb() : void
     {
         $this->reset();
 
@@ -181,7 +181,7 @@ class ilAssQuestionSkillAssignmentList
         return $skillBaseId . ':' . $skillTrefId;
     }
 
-    public function loadAdditionalSkillData()
+    public function loadAdditionalSkillData() : void
     {
         foreach ($this->assignments as $assignmentsByQuestion) {
             foreach ($assignmentsByQuestion as $assignment) {

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
@@ -89,7 +89,7 @@ class ilAssQuestionSkillAssignmentsGUI
     /**
      * @param string $assignmentConfigurationHintMessage
      */
-    public function setAssignmentConfigurationHintMessage($assignmentConfigurationHintMessage)
+    public function setAssignmentConfigurationHintMessage($assignmentConfigurationHintMessage) : void
     {
         $this->assignmentConfigurationHintMessage = $assignmentConfigurationHintMessage;
     }
@@ -97,7 +97,7 @@ class ilAssQuestionSkillAssignmentsGUI
     /**
      * @param array $questionOrderSequence
      */
-    public function setQuestionOrderSequence($questionOrderSequence)
+    public function setQuestionOrderSequence($questionOrderSequence) : void
     {
         $this->questionOrderSequence = $questionOrderSequence;
     }
@@ -113,7 +113,7 @@ class ilAssQuestionSkillAssignmentsGUI
     /**
      * @param ilAssQuestionList $questionList
      */
-    public function setQuestionList($questionList)
+    public function setQuestionList($questionList) : void
     {
         $this->questionList = $questionList;
     }
@@ -129,7 +129,7 @@ class ilAssQuestionSkillAssignmentsGUI
     /**
      * @param int $questionContainerId
      */
-    public function setQuestionContainerId($questionContainerId)
+    public function setQuestionContainerId($questionContainerId) : void
     {
         $this->questionContainerId = $questionContainerId;
     }
@@ -145,12 +145,12 @@ class ilAssQuestionSkillAssignmentsGUI
     /**
      * @param bool $assignmentEditingEnabled
      */
-    public function setAssignmentEditingEnabled($assignmentEditingEnabled)
+    public function setAssignmentEditingEnabled($assignmentEditingEnabled) : void
     {
         $this->assignmentEditingEnabled = $assignmentEditingEnabled;
     }
 
-    public function executeCommand()
+    public function executeCommand() : void
     {
         $nextClass = $this->ctrl->getNextClass();
         
@@ -190,7 +190,7 @@ class ilAssQuestionSkillAssignmentsGUI
         return false;
     }
 
-    private function saveSkillPointsCmd()
+    private function saveSkillPointsCmd() : void
     {
         $success = true;
 
@@ -243,7 +243,7 @@ class ilAssQuestionSkillAssignmentsGUI
         }
     }
 
-    private function updateSkillQuestionAssignmentsCmd()
+    private function updateSkillQuestionAssignmentsCmd() : void
     {
         $questionId = (int) $this->request->raw('question_id');
 
@@ -313,7 +313,7 @@ class ilAssQuestionSkillAssignmentsGUI
         $this->ctrl->redirect($this, self::CMD_SHOW_SKILL_QUEST_ASSIGNS);
     }
 
-    private function showSkillSelectionCmd()
+    private function showSkillSelectionCmd() : void
     {
         $this->ctrl->saveParameter($this, 'question_id');
         $questionId = (int) $this->request->raw('question_id');
@@ -353,7 +353,7 @@ class ilAssQuestionSkillAssignmentsGUI
         assQuestionGUI $questionGUI = null,
         ilAssQuestionSkillAssignment $assignment = null,
         ilPropertyFormGUI $form = null
-    ) {
+    ) : void {
         $this->handleAssignmentConfigurationHintMessage();
 
         $this->keepAssignmentParameters();
@@ -379,7 +379,7 @@ class ilAssQuestionSkillAssignmentsGUI
         $this->tpl->setContent($this->ctrl->getHTML($form) . '<br />' . $questionPageHTML);
     }
     
-    private function saveSkillQuestionAssignmentPropertiesFormCmd()
+    private function saveSkillQuestionAssignmentPropertiesFormCmd() : void
     {
         $questionId = (int) $this->request->raw('question_id');
         
@@ -458,7 +458,7 @@ class ilAssQuestionSkillAssignmentsGUI
         return $form;
     }
 
-    private function showSkillQuestionAssignmentsCmd($loadSkillPointsFromRequest = false)
+    private function showSkillQuestionAssignmentsCmd($loadSkillPointsFromRequest = false) : void
     {
         $this->handleAssignmentConfigurationHintMessage();
         
@@ -497,7 +497,7 @@ class ilAssQuestionSkillAssignmentsGUI
         return false;
     }
 
-    private function showSyncOriginalConfirmationCmd()
+    private function showSyncOriginalConfirmationCmd() : void
     {
         $questionId = (int) $this->request->raw('question_id');
 
@@ -513,7 +513,7 @@ class ilAssQuestionSkillAssignmentsGUI
         $this->tpl->setContent($this->ctrl->getHTML($confirmation));
     }
 
-    private function syncOriginalCmd()
+    private function syncOriginalCmd() : void
     {
         $questionId = (int) $_POST['question_id'];
 
@@ -680,7 +680,7 @@ class ilAssQuestionSkillAssignmentsGUI
         return true;
     }
 
-    private function keepAssignmentParameters()
+    private function keepAssignmentParameters() : void
     {
         $this->ctrl->saveParameter($this, 'question_id');
         $this->ctrl->saveParameter($this, 'skill_base_id');
@@ -712,7 +712,7 @@ class ilAssQuestionSkillAssignmentsGUI
         return $orderedQuestionsData;
     }
     
-    private function handleAssignmentConfigurationHintMessage()
+    private function handleAssignmentConfigurationHintMessage() : void
     {
         if ($this->getAssignmentConfigurationHintMessage()) {
             $this->tpl->setOnScreenMessage('info', $this->getAssignmentConfigurationHintMessage());

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionSkillUsagesTableGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionSkillUsagesTableGUI.php
@@ -79,7 +79,7 @@ class ilAssQuestionSkillUsagesTableGUI extends ilTable2GUI
         return false;
     }
     
-    private function showCmd()
+    private function showCmd() : void
     {
         $this->initColumns();
         
@@ -91,7 +91,7 @@ class ilAssQuestionSkillUsagesTableGUI extends ilTable2GUI
         $this->myTpl->setContent($this->myCtrl->getHTML($this));
     }
     
-    protected function initColumns()
+    protected function initColumns() : void
     {
         $this->addColumn($this->myLng->txt('qpl_qst_skl_usg_skill_col'), 'skill_title', '50%');
         $this->addColumn($this->myLng->txt('qpl_qst_skl_usg_numq_col'), 'num_questions', '');

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionSolutionComparisonExpression.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionSolutionComparisonExpression.php
@@ -58,7 +58,7 @@ class ilAssQuestionSolutionComparisonExpression
         $this->points = null;
     }
 
-    public function save()
+    public function save() : void
     {
         $this->db->replace(
             'qpl_qst_skl_sol_expr',
@@ -86,7 +86,7 @@ class ilAssQuestionSolutionComparisonExpression
     /**
      * @param ilDBInterface $db
      */
-    public function setDb($db)
+    public function setDb($db) : void
     {
         $this->db = $db;
     }
@@ -102,7 +102,7 @@ class ilAssQuestionSolutionComparisonExpression
     /**
      * @param int $questionId
      */
-    public function setQuestionId($questionId)
+    public function setQuestionId($questionId) : void
     {
         $this->questionId = $questionId;
     }
@@ -118,7 +118,7 @@ class ilAssQuestionSolutionComparisonExpression
     /**
      * @param int $skillBaseId
      */
-    public function setSkillBaseId($skillBaseId)
+    public function setSkillBaseId($skillBaseId) : void
     {
         $this->skillBaseId = $skillBaseId;
     }
@@ -134,7 +134,7 @@ class ilAssQuestionSolutionComparisonExpression
     /**
      * @param int $skillTrefId
      */
-    public function setSkillTrefId($skillTrefId)
+    public function setSkillTrefId($skillTrefId) : void
     {
         $this->skillTrefId = $skillTrefId;
     }
@@ -150,7 +150,7 @@ class ilAssQuestionSolutionComparisonExpression
     /**
      * @param int $orderIndex
      */
-    public function setOrderIndex($orderIndex)
+    public function setOrderIndex($orderIndex) : void
     {
         $this->orderIndex = $orderIndex;
     }
@@ -166,7 +166,7 @@ class ilAssQuestionSolutionComparisonExpression
     /**
      * @param string $expression
      */
-    public function setExpression($expression)
+    public function setExpression($expression) : void
     {
         $this->expression = $expression;
     }
@@ -182,7 +182,7 @@ class ilAssQuestionSolutionComparisonExpression
     /**
      * @param int $points
      */
-    public function setPoints($points)
+    public function setPoints($points) : void
     {
         $this->points = $points;
     }
@@ -190,7 +190,7 @@ class ilAssQuestionSolutionComparisonExpression
     /**
      * @param array $data
      */
-    public function initInstanceFromArray($data)
+    public function initInstanceFromArray($data) : void
     {
         $this->setQuestionId($data['question_fi']);
         $this->setSkillBaseId($data['skill_base_fi']);

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionSolutionComparisonExpressionList.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionSolutionComparisonExpressionList.php
@@ -50,7 +50,7 @@ class ilAssQuestionSolutionComparisonExpressionList
         $this->expressions = array();
     }
     
-    public function load()
+    public function load() : void
     {
         $query = "
 			SELECT *
@@ -73,7 +73,7 @@ class ilAssQuestionSolutionComparisonExpressionList
         }
     }
     
-    public function save()
+    public function save() : void
     {
         $this->delete();
         
@@ -85,7 +85,7 @@ class ilAssQuestionSolutionComparisonExpressionList
         }
     }
     
-    public function delete()
+    public function delete() : void
     {
         $query = "
 			DELETE FROM qpl_qst_skl_sol_expr
@@ -99,7 +99,7 @@ class ilAssQuestionSolutionComparisonExpressionList
         );
     }
     
-    public function add(ilAssQuestionSolutionComparisonExpression $expression)
+    public function add(ilAssQuestionSolutionComparisonExpression $expression) : void
     {
         $expression->setDb($this->db);
         $expression->setQuestionId($this->getQuestionId());
@@ -114,7 +114,7 @@ class ilAssQuestionSolutionComparisonExpressionList
         return $this->expressions;
     }
     
-    public function reset()
+    public function reset() : void
     {
         $this->expressions = array();
     }
@@ -130,7 +130,7 @@ class ilAssQuestionSolutionComparisonExpressionList
     /**
      * @param int $questionId
      */
-    public function setQuestionId($questionId)
+    public function setQuestionId($questionId) : void
     {
         $this->questionId = $questionId;
     }
@@ -146,7 +146,7 @@ class ilAssQuestionSolutionComparisonExpressionList
     /**
      * @param int $skillBaseId
      */
-    public function setSkillBaseId($skillBaseId)
+    public function setSkillBaseId($skillBaseId) : void
     {
         $this->skillBaseId = $skillBaseId;
     }
@@ -162,7 +162,7 @@ class ilAssQuestionSolutionComparisonExpressionList
     /**
      * @param int $skillTrefId
      */
-    public function setSkillTrefId($skillTrefId)
+    public function setSkillTrefId($skillTrefId) : void
     {
         $this->skillTrefId = $skillTrefId;
     }

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionUserSolutionAdopter.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionUserSolutionAdopter.php
@@ -82,7 +82,7 @@ class ilAssQuestionUserSolutionAdopter
     /**
      * @param int $userId
      */
-    public function setUserId($userId)
+    public function setUserId($userId) : void
     {
         $this->userId = $userId;
     }
@@ -98,7 +98,7 @@ class ilAssQuestionUserSolutionAdopter
     /**
      * @param int $activeId
      */
-    public function setActiveId($activeId)
+    public function setActiveId($activeId) : void
     {
         $this->activeId = $activeId;
     }
@@ -114,7 +114,7 @@ class ilAssQuestionUserSolutionAdopter
     /**
      * @param int $targetPass
      */
-    public function setTargetPass($targetPass)
+    public function setTargetPass($targetPass) : void
     {
         $this->targetPass = $targetPass;
     }
@@ -130,12 +130,12 @@ class ilAssQuestionUserSolutionAdopter
     /**
      * @param array $questionIds
      */
-    public function setQuestionIds($questionIds)
+    public function setQuestionIds($questionIds) : void
     {
         $this->questionIds = $questionIds;
     }
     
-    public function perform()
+    public function perform() : void
     {
         $this->processLockerFactory->setUserId($this->getUserId());
         
@@ -149,7 +149,7 @@ class ilAssQuestionUserSolutionAdopter
         }
     }
 
-    protected function adoptQuestionAnswer($questionId)
+    protected function adoptQuestionAnswer($questionId) : void
     {
         $this->resetTargetSolution($questionId);
         $this->resetTargetResult($questionId);
@@ -161,7 +161,7 @@ class ilAssQuestionUserSolutionAdopter
         }
     }
 
-    protected function resetTargetSolution($questionId)
+    protected function resetTargetSolution($questionId) : void
     {
         $this->db->execute(
             $this->getPreparedDeleteSolutionRecordsStatement(),
@@ -169,7 +169,7 @@ class ilAssQuestionUserSolutionAdopter
         );
     }
 
-    protected function resetTargetResult($questionId)
+    protected function resetTargetResult($questionId) : void
     {
         $this->db->execute(
             $this->getPreparedDeleteResultRecordStatement(),
@@ -204,7 +204,7 @@ class ilAssQuestionUserSolutionAdopter
         return $sourcePass;
     }
     
-    protected function adoptSourceResult($questionId, $sourcePass)
+    protected function adoptSourceResult($questionId, $sourcePass) : void
     {
         $res = $this->db->execute(
             $this->getPreparedSelectResultRecordStatement(),
@@ -221,7 +221,7 @@ class ilAssQuestionUserSolutionAdopter
         ));
     }
 
-    protected function getPreparedDeleteSolutionRecordsStatement()
+    protected function getPreparedDeleteSolutionRecordsStatement() : ilDBStatement
     {
         if (self::$preparedDeleteSolutionRecordsStatement === null) {
             self::$preparedDeleteSolutionRecordsStatement = $this->db->prepareManip(
@@ -233,7 +233,7 @@ class ilAssQuestionUserSolutionAdopter
         return self::$preparedDeleteSolutionRecordsStatement;
     }
 
-    protected function getPreparedSelectSolutionRecordsStatement()
+    protected function getPreparedSelectSolutionRecordsStatement() : ilDBStatement
     {
         if (self::$preparedSelectSolutionRecordsStatement === null) {
             $query = "
@@ -250,7 +250,7 @@ class ilAssQuestionUserSolutionAdopter
         return self::$preparedSelectSolutionRecordsStatement;
     }
 
-    protected function getPreparedInsertSolutionRecordStatement()
+    protected function getPreparedInsertSolutionRecordStatement() : ilDBStatement
     {
         if (self::$preparedInsertSolutionRecordStatement === null) {
             $query = "
@@ -270,7 +270,7 @@ class ilAssQuestionUserSolutionAdopter
         return self::$preparedInsertSolutionRecordStatement;
     }
 
-    protected function getPreparedDeleteResultRecordStatement()
+    protected function getPreparedDeleteResultRecordStatement() : ilDBStatement
     {
         if (self::$preparedDeleteResultRecordStatement === null) {
             self::$preparedDeleteResultRecordStatement = $this->db->prepareManip(
@@ -282,7 +282,7 @@ class ilAssQuestionUserSolutionAdopter
         return self::$preparedDeleteResultRecordStatement;
     }
 
-    protected function getPreparedSelectResultRecordStatement()
+    protected function getPreparedSelectResultRecordStatement() : ilDBStatement
     {
         if (self::$preparedSelectResultRecordStatement === null) {
             $query = "
@@ -299,7 +299,7 @@ class ilAssQuestionUserSolutionAdopter
         return self::$preparedSelectResultRecordStatement;
     }
 
-    protected function getPreparedInsertResultRecordStatement()
+    protected function getPreparedInsertResultRecordStatement() : ilDBStatement
     {
         if (self::$preparedInsertResultRecordStatement === null) {
             $query = "

--- a/Modules/TestQuestionPool/classes/class.ilErrorTextWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilErrorTextWizardInputGUI.php
@@ -47,7 +47,7 @@ class ilErrorTextWizardInputGUI extends ilTextInputGUI
     *
     * @param	integer	$a_size	Key size
     */
-    public function setKeySize($a_size)
+    public function setKeySize($a_size) : void
     {
         $this->key_size = $a_size;
     }
@@ -67,7 +67,7 @@ class ilErrorTextWizardInputGUI extends ilTextInputGUI
     *
     * @param	integer	$a_size	value size
     */
-    public function setValueSize($a_size)
+    public function setValueSize($a_size) : void
     {
         $this->value_size = $a_size;
     }
@@ -87,7 +87,7 @@ class ilErrorTextWizardInputGUI extends ilTextInputGUI
     *
     * @param	integer	$a_size	Key maxlength
     */
-    public function setKeyMaxlength($a_maxlength)
+    public function setKeyMaxlength($a_maxlength) : void
     {
         $this->key_maxlength = $a_maxlength;
     }
@@ -107,7 +107,7 @@ class ilErrorTextWizardInputGUI extends ilTextInputGUI
     *
     * @param	integer	$a_size	value maxlength
     */
-    public function setValueMaxlength($a_maxlength)
+    public function setValueMaxlength($a_maxlength) : void
     {
         $this->value_maxlength = $a_maxlength;
     }
@@ -127,7 +127,7 @@ class ilErrorTextWizardInputGUI extends ilTextInputGUI
     *
     * @param	string	$a_name	value name
     */
-    public function setValueName($a_name)
+    public function setValueName($a_name) : void
     {
         $this->value_name = $a_name;
     }
@@ -147,7 +147,7 @@ class ilErrorTextWizardInputGUI extends ilTextInputGUI
     *
     * @param	string	$a_name	value name
     */
-    public function setKeyName($a_name)
+    public function setKeyName($a_name) : void
     {
         $this->key_name = $a_name;
     }
@@ -167,7 +167,7 @@ class ilErrorTextWizardInputGUI extends ilTextInputGUI
     *
     * @param	array	$a_value	Value
     */
-    public function setValues($a_values)
+    public function setValues($a_values) : void
     {
         $this->values = $a_values;
     }

--- a/Modules/TestQuestionPool/classes/class.ilGlobalUnitConfigurationGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilGlobalUnitConfigurationGUI.php
@@ -42,10 +42,7 @@ class ilGlobalUnitConfigurationGUI extends ilUnitConfigurationGUI
         return $this->repository->getConsumerId() . '_global';
     }
 
-    /**
-     *
-     */
-    protected function showGlobalUnitCategories()
+    protected function showGlobalUnitCategories() : void
     {
         /**
          * @var $ilToolbar ilToolbarGUI
@@ -64,7 +61,7 @@ class ilGlobalUnitConfigurationGUI extends ilUnitConfigurationGUI
     /**
      * @param array $categories
      */
-    protected function showUnitCategories(array $categories)
+    protected function showUnitCategories(array $categories) : void
     {
         require_once 'Modules/TestQuestionPool/classes/tables/class.ilGlobalUnitCategoryTableGUI.php';
         $table = new ilGlobalUnitCategoryTableGUI($this, $this->getUnitCategoryOverviewCommand());

--- a/Modules/TestQuestionPool/classes/class.ilImageWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilImageWizardInputGUI.php
@@ -49,7 +49,7 @@ class ilImageWizardInputGUI extends ilTextInputGUI
     *
     * @param	array	$a_suffixes	Accepted Suffixes
     */
-    public function setSuffixes($a_suffixes)
+    public function setSuffixes($a_suffixes) : void
     {
         $this->suffixes = $a_suffixes;
     }
@@ -69,7 +69,7 @@ class ilImageWizardInputGUI extends ilTextInputGUI
     *
     * @param	array	$a_value	Value
     */
-    public function setValues($a_values)
+    public function setValues($a_values) : void
     {
         $this->values = $a_values;
     }
@@ -89,7 +89,7 @@ class ilImageWizardInputGUI extends ilTextInputGUI
     *
     * @param	object	$a_value	test object
     */
-    public function setQuestionObject($a_value)
+    public function setQuestionObject($a_value) : void
     {
         $this->qstObject = &$a_value;
     }
@@ -109,7 +109,7 @@ class ilImageWizardInputGUI extends ilTextInputGUI
     *
     * @param	boolean	$a_allow_move Allow move
     */
-    public function setAllowMove($a_allow_move)
+    public function setAllowMove($a_allow_move) : void
     {
         $this->allowMove = $a_allow_move;
     }

--- a/Modules/TestQuestionPool/classes/class.ilImagemapPreview.php
+++ b/Modules/TestQuestionPool/classes/class.ilImagemapPreview.php
@@ -75,7 +75,7 @@ class ilImagemapPreview
         $linecolor = "red",
         $bordercolor = "white",
         $fillcolor = "#FFFFFFA0"
-    ) {
+    ) : void {
         if (ini_get("safe_mode")) {
             if ((strpos($fillcolor, "#") !== false) || (strpos($fillcolor, "rgb") !== false)) {
                 $fillcolor = str_replace("\"", "", $fillcolor);
@@ -101,7 +101,7 @@ class ilImagemapPreview
         $linecolor = "red",
         $bordercolor = "white",
         $fillcolor = "#FFFFFFA0"
-    ) {
+    ) : void {
         $this->points[$index] = array(
             "coords" => "$coords",
             "linecolor" => '"' . $linecolor . '"',
@@ -127,7 +127,7 @@ class ilImagemapPreview
         }
     }
 
-    public function createPreview()
+    public function createPreview() : void
     {
         if (count($this->areas) + count($this->points) == 0) {
             return;

--- a/Modules/TestQuestionPool/classes/class.ilKVPWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilKVPWizardInputGUI.php
@@ -49,7 +49,7 @@ class ilKVPWizardInputGUI extends ilTextInputGUI
     *
     * @param	integer	$a_size	Key size
     */
-    public function setKeySize($a_size)
+    public function setKeySize($a_size) : void
     {
         $this->key_size = $a_size;
     }
@@ -69,7 +69,7 @@ class ilKVPWizardInputGUI extends ilTextInputGUI
     *
     * @param	integer	$a_size	value size
     */
-    public function setValueSize($a_size)
+    public function setValueSize($a_size) : void
     {
         $this->value_size = $a_size;
     }
@@ -89,7 +89,7 @@ class ilKVPWizardInputGUI extends ilTextInputGUI
     *
     * @param	integer	$a_size	Key maxlength
     */
-    public function setKeyMaxlength($a_maxlength)
+    public function setKeyMaxlength($a_maxlength) : void
     {
         $this->key_maxlength = $a_maxlength;
     }
@@ -109,7 +109,7 @@ class ilKVPWizardInputGUI extends ilTextInputGUI
     *
     * @param	integer	$a_size	value maxlength
     */
-    public function setValueMaxlength($a_maxlength)
+    public function setValueMaxlength($a_maxlength) : void
     {
         $this->value_maxlength = $a_maxlength;
     }
@@ -129,7 +129,7 @@ class ilKVPWizardInputGUI extends ilTextInputGUI
     *
     * @param	string	$a_name	value name
     */
-    public function setValueName($a_name)
+    public function setValueName($a_name) : void
     {
         $this->value_name = $a_name;
     }
@@ -149,7 +149,7 @@ class ilKVPWizardInputGUI extends ilTextInputGUI
     *
     * @param	string	$a_name	value name
     */
-    public function setKeyName($a_name)
+    public function setKeyName($a_name) : void
     {
         $this->key_name = $a_name;
     }
@@ -169,7 +169,7 @@ class ilKVPWizardInputGUI extends ilTextInputGUI
     *
     * @param	array	$a_value	Value
     */
-    public function setValues($a_values)
+    public function setValues($a_values) : void
     {
         $this->values = $a_values;
     }
@@ -189,7 +189,7 @@ class ilKVPWizardInputGUI extends ilTextInputGUI
     *
     * @param	boolean	$a_allow_move Allow move
     */
-    public function setAllowMove($a_allow_move)
+    public function setAllowMove($a_allow_move) : void
     {
         $this->allowMove = $a_allow_move;
     }

--- a/Modules/TestQuestionPool/classes/class.ilKprimChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilKprimChoiceWizardInputGUI.php
@@ -45,7 +45,7 @@ class ilKprimChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
         $this->ignoreMissingUploadsEnabled = false;
     }
 
-    public function setFiles($files)
+    public function setFiles($files) : void
     {
         $this->files = $files;
     }
@@ -55,7 +55,7 @@ class ilKprimChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
         return $this->files;
     }
 
-    public function setIgnoreMissingUploadsEnabled($ignoreMissingUploadsEnabled)
+    public function setIgnoreMissingUploadsEnabled($ignoreMissingUploadsEnabled) : void
     {
         $this->ignoreMissingUploadsEnabled = $ignoreMissingUploadsEnabled;
     }
@@ -424,7 +424,7 @@ class ilKprimChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
         return true;
     }
     
-    public function collectValidFiles()
+    public function collectValidFiles() : void
     {
         foreach ($_FILES[$this->getPostVar()]['error']['image'] as $index => $err) {
             if ($err > 0) {

--- a/Modules/TestQuestionPool/classes/class.ilLocalUnitConfigurationGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilLocalUnitConfigurationGUI.php
@@ -61,7 +61,7 @@ class ilLocalUnitConfigurationGUI extends ilUnitConfigurationGUI
     /**
      *
      */
-    public function executeCommand()
+    public function executeCommand() : void
     {
         /**
          * @var $ilHelp ilHelpGUI
@@ -78,7 +78,7 @@ class ilLocalUnitConfigurationGUI extends ilUnitConfigurationGUI
     /**
      *
      */
-    protected function handleSubtabs()
+    protected function handleSubtabs() : void
     {
         /**
          * @var $ilTabs ilTabsGUI
@@ -102,7 +102,7 @@ class ilLocalUnitConfigurationGUI extends ilUnitConfigurationGUI
     /**
      *
      */
-    protected function showLocalUnitCategories()
+    protected function showLocalUnitCategories() : void
     {
         /**
          * @var $ilToolbar ilToolbarGUI
@@ -136,7 +136,7 @@ class ilLocalUnitConfigurationGUI extends ilUnitConfigurationGUI
     /**
      * @param array $categories
      */
-    protected function showUnitCategories(array $categories)
+    protected function showUnitCategories(array $categories) : void
     {
         require_once 'Modules/TestQuestionPool/classes/tables/class.ilLocalUnitCategoryTableGUI.php';
         $table = new ilLocalUnitCategoryTableGUI($this, $this->getUnitCategoryOverviewCommand());
@@ -145,10 +145,7 @@ class ilLocalUnitConfigurationGUI extends ilUnitConfigurationGUI
         $this->tpl->setContent($table->getHTML());
     }
 
-    /**
-     *
-     */
-    protected function confirmImportGlobalCategory()
+    protected function confirmImportGlobalCategory() : void
     {
         if (!$this->request->isset('category_id')) {
             $this->showGlobalUnitCategories();
@@ -157,19 +154,13 @@ class ilLocalUnitConfigurationGUI extends ilUnitConfigurationGUI
         $this->confirmImportGlobalCategories(array($this->request->raw('category_id')));
     }
 
-    /**
-     *
-     */
-    protected function confirmImportGlobalCategories($category_ids)
+    protected function confirmImportGlobalCategories(array $category_ids) : void
     {
         // @todo: Confirmation Currently not implemented, so forward to import
         $this->importGlobalCategories($category_ids);
     }
 
-    /**
-     *
-     */
-    protected function importGlobalCategories($category_ids)
+    protected function importGlobalCategories(array $category_ids) : void
     {
         if ($this->isCRUDContext()) {
             $this->{$this->getDefaultCommand()}();

--- a/Modules/TestQuestionPool/classes/class.ilLogicalAnswerComparisonExpressionInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilLogicalAnswerComparisonExpressionInputGUI.php
@@ -13,7 +13,7 @@ require_once 'Modules/TestQuestionPool/classes/class.ilAssQuestionSolutionCompar
  */
 class ilLogicalAnswerComparisonExpressionInputGUI extends ilAnswerWizardInputGUI
 {
-    public function setValues($modelValues)
+    public function setValues($modelValues) : void
     {
         $formValues = array();
 
@@ -77,7 +77,7 @@ class ilLogicalAnswerComparisonExpressionInputGUI extends ilAnswerWizardInputGUI
         return "tpl.prop_lac_expression_input.html";
     }
     
-    protected function sanitizeSuperGlobalSubmitValue()
+    protected function sanitizeSuperGlobalSubmitValue() : void
     {
         if (isset($_POST[$this->getPostVar()]) && is_array($_POST[$this->getPostVar()])) {
             $_POST[$this->getPostVar()] = ilArrayUtil::stripSlashesRecursive($_POST[$this->getPostVar()], false);

--- a/Modules/TestQuestionPool/classes/class.ilMatchingPairWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilMatchingPairWizardInputGUI.php
@@ -58,7 +58,7 @@ class ilMatchingPairWizardInputGUI extends ilTextInputGUI
     *
     * @param	array	$a_terms	Terms
     */
-    public function setTerms($a_terms)
+    public function setTerms($a_terms) : void
     {
         $this->terms = $a_terms;
     }
@@ -68,7 +68,7 @@ class ilMatchingPairWizardInputGUI extends ilTextInputGUI
     *
     * @param	array	$a_definitions	Definitions
     */
-    public function setDefinitions($a_definitions)
+    public function setDefinitions($a_definitions) : void
     {
         $this->definitions = $a_definitions;
     }
@@ -78,7 +78,7 @@ class ilMatchingPairWizardInputGUI extends ilTextInputGUI
     *
     * @param	array	$a_pairs	Pairs
     */
-    public function setPairs($a_pairs)
+    public function setPairs($a_pairs) : void
     {
         $this->pairs = $a_pairs;
     }
@@ -88,7 +88,7 @@ class ilMatchingPairWizardInputGUI extends ilTextInputGUI
     *
     * @param	boolean	$a_allow_move Allow move
     */
-    public function setAllowMove($a_allow_move)
+    public function setAllowMove($a_allow_move) : void
     {
         $this->allowMove = $a_allow_move;
     }

--- a/Modules/TestQuestionPool/classes/class.ilMatchingWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilMatchingWizardInputGUI.php
@@ -41,7 +41,7 @@ class ilMatchingWizardInputGUI extends ilTextInputGUI
     *
     * @param	array	$a_suffixes	Accepted Suffixes
     */
-    public function setSuffixes($a_suffixes)
+    public function setSuffixes($a_suffixes) : void
     {
         $this->suffixes = $a_suffixes;
     }
@@ -61,7 +61,7 @@ class ilMatchingWizardInputGUI extends ilTextInputGUI
     *
     * @param	bool	$a_hide	Hide images
     */
-    public function setHideImages($a_hide)
+    public function setHideImages($a_hide) : void
     {
         $this->hideImages = $a_hide;
     }
@@ -71,7 +71,7 @@ class ilMatchingWizardInputGUI extends ilTextInputGUI
     *
     * @param	array	$a_value	Value
     */
-    public function setValues($a_values)
+    public function setValues($a_values) : void
     {
         $this->values = $a_values;
     }
@@ -86,12 +86,12 @@ class ilMatchingWizardInputGUI extends ilTextInputGUI
         return $this->values;
     }
 
-    public function setTextName($a_value)
+    public function setTextName($a_value) : void
     {
         $this->text_name = $a_value;
     }
     
-    public function setImageName($a_value)
+    public function setImageName($a_value) : void
     {
         $this->image_name = $a_value;
     }
@@ -101,7 +101,7 @@ class ilMatchingWizardInputGUI extends ilTextInputGUI
     *
     * @param	object	$a_value	test object
     */
-    public function setQuestionObject($a_value)
+    public function setQuestionObject($a_value) : void
     {
         $this->qstObject = &$a_value;
     }
@@ -121,7 +121,7 @@ class ilMatchingWizardInputGUI extends ilTextInputGUI
     *
     * @param	boolean	$a_allow_move Allow move
     */
-    public function setAllowMove($a_allow_move)
+    public function setAllowMove($a_allow_move) : void
     {
         $this->allowMove = $a_allow_move;
     }

--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPool.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPool.php
@@ -166,7 +166,7 @@ class ilObjQuestionPool extends ilObject
         return true;
     }
 
-    public function deleteQuestionpool()
+    public function deleteQuestionpool() : void
     {
         $questions = &$this->getAllQuestions();
 
@@ -192,7 +192,7 @@ class ilObjQuestionPool extends ilObject
     * @param integer $question_id The database id of the question
     * @access private
     */
-    public function deleteQuestion($question_id)
+    public function deleteQuestion($question_id) : void
     {
         include_once "./Modules/Test/classes/class.ilObjTest.php";
         include_once "./Modules/TestQuestionPool/classes/class.assQuestion.php";
@@ -206,7 +206,7 @@ class ilObjQuestionPool extends ilObject
     *
     * @access public
     */
-    public function loadFromDb()
+    public function loadFromDb() : void
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];
@@ -230,7 +230,7 @@ class ilObjQuestionPool extends ilObject
     *
     * @access public
     */
-    public function saveToDb()
+    public function saveToDb() : void
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];
@@ -410,7 +410,7 @@ class ilObjQuestionPool extends ilObject
     /**
      * @param ilXmlWriter $xmlWriter
      */
-    private function exportXMLSettings($xmlWriter)
+    private function exportXMLSettings($xmlWriter) : void
     {
         $xmlWriter->xmlStartTag('Settings');
 
@@ -427,7 +427,7 @@ class ilObjQuestionPool extends ilObject
     * @param	object		$a_xml_writer	ilXmlWriter object that receives the
     *										xml data
     */
-    public function objectToXmlWriter(ilXmlWriter &$a_xml_writer, $a_inst, $a_target_dir, &$expLog, $questions)
+    public function objectToXmlWriter(ilXmlWriter &$a_xml_writer, $a_inst, $a_target_dir, &$expLog, $questions) : void
     {
         global $DIC;
         $ilBench = $DIC['ilBench'];
@@ -476,7 +476,7 @@ class ilObjQuestionPool extends ilObject
      * @param ilXmlWriter $a_xml_writer
      * @param $questions
      */
-    protected function populateQuestionSkillAssignmentsXml(ilXmlWriter &$a_xml_writer, $questions)
+    protected function populateQuestionSkillAssignmentsXml(ilXmlWriter &$a_xml_writer, $questions) : void
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];
@@ -501,7 +501,7 @@ class ilObjQuestionPool extends ilObject
     * @param	object		$a_xml_writer	ilXmlWriter object that receives the
     *										xml data
     */
-    public function exportXMLMetaData(&$a_xml_writer)
+    public function exportXMLMetaData(&$a_xml_writer) : void
     {
         include_once("Services/MetaData/classes/class.ilMD2XML.php");
         $md2xml = new ilMD2XML($this->getId(), 0, $this->getType());
@@ -527,7 +527,7 @@ class ilObjQuestionPool extends ilObject
     * @param	object		$a_xml_writer	ilXmlWriter object that receives the
     *										xml data
     */
-    public function exportXMLPageObjects(&$a_xml_writer, $a_inst, &$expLog, $questions)
+    public function exportXMLPageObjects(&$a_xml_writer, $a_inst, &$expLog, $questions) : void
     {
         global $DIC;
         $ilBench = $DIC['ilBench'];
@@ -582,7 +582,7 @@ class ilObjQuestionPool extends ilObject
         }
     }
 
-    public function exportXMLMediaObjects(&$a_xml_writer, $a_inst, $a_target_dir, &$expLog)
+    public function exportXMLMediaObjects(&$a_xml_writer, $a_inst, $a_target_dir, &$expLog) : void
     {
         include_once("./Services/MediaObjects/classes/class.ilObjMediaObject.php");
 
@@ -601,7 +601,7 @@ class ilObjQuestionPool extends ilObject
     * export files of file itmes
     *
     */
-    public function exportFileItems($a_target_dir, &$expLog)
+    public function exportFileItems($a_target_dir, &$expLog) : void
     {
         include_once("./Modules/File/classes/class.ilObjFile.php");
 
@@ -618,7 +618,7 @@ class ilObjQuestionPool extends ilObject
     * (data_dir/qpl_data/qpl_<id>/export, depending on data
     * directory that is set in ILIAS setup/ini)
     */
-    public function createExportDirectory()
+    public function createExportDirectory() : void
     {
         include_once "./Services/Utilities/classes/class.ilUtil.php";
         $qpl_data_dir = ilFileUtils::getDataDir() . "/qpl_data";
@@ -698,7 +698,7 @@ class ilObjQuestionPool extends ilObject
     /**
     * set import directory
     */
-    public static function _setImportDirectory($a_import_dir = null)
+    public static function _setImportDirectory($a_import_dir = null) : void
     {
         if (strlen($a_import_dir)) {
             ilSession::set("qpl_import_dir", $a_import_dir);
@@ -849,7 +849,7 @@ class ilObjQuestionPool extends ilObject
     * @see online
     * @access public
     */
-    public function setOnline($a_online_status)
+    public function setOnline($a_online_status) : void
     {
         switch ($a_online_status) {
             case 0:
@@ -870,7 +870,7 @@ class ilObjQuestionPool extends ilObject
         return $this->online;
     }
 
-    public function setShowTaxonomies($showTaxonomies)
+    public function setShowTaxonomies($showTaxonomies) : void
     {
         $this->showTaxonomies = $showTaxonomies;
     }
@@ -880,7 +880,7 @@ class ilObjQuestionPool extends ilObject
         return $this->showTaxonomies;
     }
 
-    public function setNavTaxonomyId($navTaxonomyId)
+    public function setNavTaxonomyId($navTaxonomyId) : void
     {
         $this->navTaxonomyId = $navTaxonomyId;
     }
@@ -1022,7 +1022,7 @@ class ilObjQuestionPool extends ilObject
     * @param integer $question_id Object id of the question
     * @access private
     */
-    public function copyToClipboard($question_id)
+    public function copyToClipboard($question_id) : void
     {
         if (ilSession::get("qpl_clipboard") == null) {
             ilSession::set("qpl_clipboard", array());
@@ -1039,7 +1039,7 @@ class ilObjQuestionPool extends ilObject
     * @param integer $question_id Object id of the question
     * @access private
     */
-    public function moveToClipboard($question_id)
+    public function moveToClipboard($question_id) : void
     {
         if (ilSession::get("qpl_clipboard") == null) {
             ilSession::set("qpl_clipboard", array());
@@ -1050,7 +1050,7 @@ class ilObjQuestionPool extends ilObject
         //$_SESSION["qpl_clipboard"][$question_id] = array("question_id" => $question_id, "action" => "move");
     }
 
-    public function cleanupClipboard($deletedQuestionId)
+    public function cleanupClipboard($deletedQuestionId) : void
     {
         if (ilSession::get('qpl_clipboard') == null) {
             return;
@@ -1499,7 +1499,7 @@ class ilObjQuestionPool extends ilObject
     * @param integer $object_id Object id of the questionpool to examine
     * @access public
     */
-    public static function _updateQuestionCount($object_id)
+    public static function _updateQuestionCount($object_id) : void
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];
@@ -1539,7 +1539,7 @@ class ilObjQuestionPool extends ilObject
     /*
     * Remove all questions with owner = 0
     */
-    public function purgeQuestions()
+    public function purgeQuestions() : void
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];
@@ -1573,7 +1573,7 @@ class ilObjQuestionPool extends ilObject
     /**
      * @param boolean $skillServiceEnabled
      */
-    public function setSkillServiceEnabled($skillServiceEnabled)
+    public function setSkillServiceEnabled($skillServiceEnabled) : void
     {
         $this->skillServiceEnabled = $skillServiceEnabled;
     }
@@ -1591,7 +1591,7 @@ class ilObjQuestionPool extends ilObject
         return self::$isSkillManagementGloballyActivated;
     }
 
-    public function fromXML($xmlFile)
+    public function fromXML($xmlFile) : void
     {
         require_once 'Modules/TestQuestionPool/classes/class.ilObjQuestionPoolXMLParser.php';
         $parser = new ilObjQuestionPoolXMLParser($this, $xmlFile);

--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -447,7 +447,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
      * Gateway for exports initiated from workspace, as there is a generic
      * forward to {objTypeMainGUI}::export()
      */
-    protected function exportObject()
+    protected function exportObject() : void
     {
         global $DIC; /* @var ILIAS\DI\Container $DIC */
         $DIC->ctrl()->redirectByClass('ilQuestionPoolExportGUI');
@@ -456,7 +456,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     /**
     * download file
     */
-    public function downloadFileObject()
+    public function downloadFileObject() : void
     {
         $file = explode("_", $this->qplrequest->raw("file_id"));
         include_once("./Modules/File/classes/class.ilObjFile.php");
@@ -468,7 +468,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     /**
     * show fullscreen view
     */
-    public function fullscreenObject()
+    public function fullscreenObject() : void
     {
         include_once("./Modules/TestQuestionPool/classes/class.ilAssQuestionPageGUI.php");
         $page_gui = new ilAssQuestionPageGUI($this->qplrequest->raw("pg_id"));
@@ -479,7 +479,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     /**
     * set question list filter
     */
-    public function filterObject()
+    public function filterObject() : void
     {
         $this->questionsObject();
     }
@@ -487,7 +487,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     /**
     * resets filter
     */
-    public function resetFilterObject()
+    public function resetFilterObject() : void
     {
         $_POST["filter_text"] = "";
         $_POST["sel_filter_type"] = "";
@@ -497,7 +497,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     /**
     * download source code paragraph
     */
-    public function download_paragraphObject()
+    public function download_paragraphObject() : void
     {
         include_once("./Modules/TestQuestionPool/classes/class.ilAssQuestionPage.php");
         $pg_obj = new ilAssQuestionPage($this->qplrequest->raw("pg_id"));
@@ -698,7 +698,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     /**
     * imports question(s) into the questionpool (after verification)
     */
-    public function importVerifiedFileObject()
+    public function importVerifiedFileObject() : void
     {
         if ($_POST["questions_only"] == 1) {
             $newObj = &$this->object;
@@ -773,7 +773,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         }
     }
 
-    public function cancelImportObject()
+    public function cancelImportObject() : void
     {
         if ($_POST["questions_only"] == 1) {
             $this->ctrl->redirect($this, "questions");
@@ -785,7 +785,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     /**
     * imports question(s) into the questionpool
     */
-    public function uploadObject()
+    public function uploadObject() : void
     {
         $upload_valid = true;
         $form = $this->getImportQuestionsForm();
@@ -803,7 +803,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     /**
     * display the import form to import questions into the questionpool
     */
-    public function importQuestionsObject(ilPropertyFormGUI $form = null)
+    public function importQuestionsObject(ilPropertyFormGUI $form = null) : void
     {
         if (!$form instanceof ilPropertyFormGUI) {
             $form = $this->getImportQuestionsForm();
@@ -835,7 +835,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     /**
     * create new question
     */
-    public function &createQuestionObject()
+    public function &createQuestionObject() : void
     {
         if (ilObjAssessmentFolder::isAdditionalQuestionContentEditingModePageObjectEnabled()) {
             $addContEditMode = $_POST['add_quest_cont_edit_mode'];
@@ -856,7 +856,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     /**
     * create new question
     */
-    public function &createQuestionForTestObject()
+    public function &createQuestionForTestObject() : void
     {
         if (!$this->qplrequest->raw('q_id')) {
             require_once 'Modules/Test/classes/class.ilObjAssessmentFolder.php';
@@ -899,7 +899,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
             "&baseClass=ilObjQuestionPoolGUI");
     }
 
-    public function questionObject()
+    public function questionObject() : void
     {
         // @PHP8-CR: With this probably never working and no detectable usages, it would be a candidate for removal...
         // but it is one of the magic command-methods ($cmd.'Object' - pattern) so I live to leave this in here for now
@@ -912,7 +912,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     /**
     * delete questions confirmation screen
     */
-    public function deleteQuestionsObject()
+    public function deleteQuestionsObject() : void
     {
         global $DIC;
         $rbacsystem = $DIC['rbacsystem'];
@@ -943,7 +943,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     /**
     * delete questions
     */
-    public function confirmDeleteQuestionsObject()
+    public function confirmDeleteQuestionsObject() : void
     {
         // delete questions after confirmation
         foreach ($_POST["q_id"] as $key => $value) {
@@ -962,7 +962,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     /**
     * Cancel question deletion
     */
-    public function cancelDeleteQuestionsObject()
+    public function cancelDeleteQuestionsObject() : void
     {
         $this->ctrl->redirect($this, "questions");
     }
@@ -970,7 +970,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     /**
     * export question
     */
-    public function exportQuestionObject()
+    public function exportQuestionObject() : void
     {
         // export button was pressed
         if (array_key_exists('q_id', $_POST) && is_array($_POST['q_id']) && count($_POST['q_id']) > 0) {
@@ -990,7 +990,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         $this->ctrl->redirect($this, "questions");
     }
 
-    public function filterQuestionBrowserObject()
+    public function filterQuestionBrowserObject() : void
     {
         global $DIC; /* @var ILIAS\DI\Container $DIC */
         $enableComments = $DIC->rbac()->system()->checkAccess('write', $this->qplrequest->getRefId());
@@ -1005,7 +1005,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         $this->questionsObject();
     }
 
-    public function resetQuestionBrowserObject()
+    public function resetQuestionBrowserObject() : void
     {
         require_once 'Services/Taxonomy/classes/class.ilObjTaxonomy.php';
         $taxIds = ilObjTaxonomy::getUsageOfObject($this->object->getId());
@@ -1017,7 +1017,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         $this->questionsObject();
     }
 
-    protected function renoveImportFailsObject()
+    protected function renoveImportFailsObject() : void
     {
         require_once 'Modules/TestQuestionPool/classes/questions/class.ilAssQuestionSkillAssignmentImportFails.php';
         $qsaImportFails = new ilAssQuestionSkillAssignmentImportFails($this->object->getId());
@@ -1029,7 +1029,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     /**
     * list questions of question pool
     */
-    public function questionsObject()
+    public function questionsObject() : void
     {
         global $DIC;
         $rbacsystem = $DIC['rbacsystem'];
@@ -1156,7 +1156,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         throw new ilTestQuestionPoolException('question id does not relate to parent object!');
     }
 
-    private function createQuestionFormObject()
+    private function createQuestionFormObject() : void
     {
         global $DIC; /* @var \ILIAS\DI\Container $DIC */
         $ilHelp = $DIC['ilHelp']; /* @var ilHelpGUI $ilHelp */
@@ -1235,7 +1235,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     /**
      * Creates a print view for a question pool
      */
-    public function printObject()
+    public function printObject() : void
     {
         /**
          * @var $ilToolbar ilToolbarGUI
@@ -1279,7 +1279,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     /**
     * paste questios from the clipboard into the question pool
     */
-    public function pasteObject()
+    public function pasteObject() : void
     {
         if (ilSession::get("qpl_clipboard") != null) {
             if ($this->object->pasteFromClipboard()) {
@@ -1296,7 +1296,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     /**
     * copy one or more question objects to the clipboard
     */
-    public function copyObject()
+    public function copyObject() : void
     {
         if (isset($_POST["q_id"]) && is_array($_POST["q_id"]) && count($_POST["q_id"]) > 0) {
             foreach ($_POST["q_id"] as $key => $value) {
@@ -1315,7 +1315,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     /**
     * mark one or more question objects for moving
     */
-    public function moveObject()
+    public function moveObject() : void
     {
         if (isset($_POST["q_id"]) && is_array($_POST["q_id"]) && count($_POST["q_id"]) > 0) {
             foreach ($_POST["q_id"] as $key => $value) {
@@ -1331,7 +1331,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         $this->ctrl->redirect($this, "questions");
     }
 
-    public function createExportExcel()
+    public function createExportExcel() : void
     {
         global $DIC;
         $rbacsystem = $DIC['rbacsystem'];
@@ -1347,7 +1347,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     /**
     * edit question
     */
-    public function &editQuestionForTestObject()
+    public function &editQuestionForTestObject() : void
     {
         include_once "./Modules/TestQuestionPool/classes/class.assQuestionGUI.php";
         $q_gui = assQuestionGUI::_getQuestionGUI("", $this->qplrequest->getQuestionId());
@@ -1627,7 +1627,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         return true;
     }
 
-    private function addSettingsSubTabs(ilTabsGUI $tabs)
+    private function addSettingsSubTabs(ilTabsGUI $tabs) : void
     {
         $tabs->addSubTabTarget(
             'qpl_settings_subtab_general',
@@ -1649,7 +1649,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     * not very nice to set cmdClass/Cmd manually, if everything
     * works through ilCtrl in the future this may be changed
     */
-    public function infoScreenObject()
+    public function infoScreenObject() : void
     {
         $this->ctrl->setCmd("showSummary");
         $this->ctrl->setCmdClass("ilinfoscreengui");
@@ -1659,7 +1659,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     /**
     * show information screen
     */
-    public function infoScreenForward()
+    public function infoScreenForward() : void
     {
         global $DIC;
         $ilErr = $DIC['ilErr'];
@@ -1687,7 +1687,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     * @param integer $a_target The reference id of the question pool
     * @access	public
     */
-    public static function _goto($a_target)
+    public static function _goto($a_target) : void
     {
         global $DIC;
         $main_tpl = $DIC->ui()->mainTemplate();

--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolSettingsGeneralGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolSettingsGeneralGUI.php
@@ -87,7 +87,7 @@ class ilObjQuestionPoolSettingsGeneralGUI
     /**
      * Command Execution
      */
-    public function executeCommand()
+    public function executeCommand() : void
     {
         // allow only write access
         
@@ -111,7 +111,7 @@ class ilObjQuestionPoolSettingsGeneralGUI
         }
     }
 
-    private function showFormCmd(ilPropertyFormGUI $form = null)
+    private function showFormCmd(ilPropertyFormGUI $form = null) : void
     {
         if ($form === null) {
             $form = $this->buildForm();
@@ -120,7 +120,7 @@ class ilObjQuestionPoolSettingsGeneralGUI
         $this->tpl->setContent($this->ctrl->getHTML($form));
     }
     
-    private function saveFormCmd()
+    private function saveFormCmd() : void
     {
         $form = $this->buildForm();
         
@@ -146,7 +146,7 @@ class ilObjQuestionPoolSettingsGeneralGUI
         $this->ctrl->redirect($this, self::CMD_SHOW_FORM);
     }
 
-    private function performSaveForm(ilPropertyFormGUI $form)
+    private function performSaveForm(ilPropertyFormGUI $form) : void
     {
         global $DIC; /* @var \ILIAS\DI\Container $DIC */
         

--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolTaxonomyEditingCommandForwarder.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolTaxonomyEditingCommandForwarder.php
@@ -76,7 +76,7 @@ class ilObjQuestionPoolTaxonomyEditingCommandForwarder
     /**
      * forward method
      */
-    public function forward()
+    public function forward() : void
     {
         $this->tabs->setTabActive('settings');
         $this->lng->loadLanguageModule('tax');

--- a/Modules/TestQuestionPool/classes/class.ilQuestionEditGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilQuestionEditGUI.php
@@ -51,7 +51,7 @@ class ilQuestionEditGUI
     *
     * @param	boolean	$a_selfassessmenteditingmode	Self-Assessment Editing Mode
     */
-    public function setSelfAssessmentEditingMode($a_selfassessmenteditingmode)
+    public function setSelfAssessmentEditingMode($a_selfassessmenteditingmode) : void
     {
         $this->selfassessmenteditingmode = $a_selfassessmenteditingmode;
     }
@@ -71,7 +71,7 @@ class ilQuestionEditGUI
     *
     * @param	int	$a_defaultnroftries		Default Nr. of Tries
     */
-    public function setDefaultNrOfTries($a_defaultnroftries)
+    public function setDefaultNrOfTries($a_defaultnroftries) : void
     {
         $this->defaultnroftries = $a_defaultnroftries;
     }
@@ -91,7 +91,7 @@ class ilQuestionEditGUI
      *
      * @param	object	Page Config
      */
-    public function setPageConfig($a_val)
+    public function setPageConfig($a_val) : void
     {
         $this->page_config = $a_val;
     }
@@ -111,7 +111,7 @@ class ilQuestionEditGUI
     * Add a listener that is notified with the new question ID, when
     * a new question is saved
     */
-    public function addNewIdListener(&$a_object, $a_method, $a_parameters = "")
+    public function addNewIdListener(&$a_object, $a_method, $a_parameters = "") : void
     {
         $cnt = $this->new_id_listener_cnt;
         $this->new_id_listeners[$cnt]["object"] = &$a_object;
@@ -189,7 +189,7 @@ class ilQuestionEditGUI
     *
     * @param	int	$a_questionid	Question Id
     */
-    public function setQuestionId($a_questionid)
+    public function setQuestionId($a_questionid) : void
     {
         $this->questionid = $a_questionid;
         $_GET["q_id"] = $this->questionid; // TODO / TATS: How to address this?
@@ -210,7 +210,7 @@ class ilQuestionEditGUI
     *
     * @param	int	$a_poolrefid	Pool Ref ID
     */
-    public function setPoolRefId($a_poolrefid)
+    public function setPoolRefId($a_poolrefid) : void
     {
         //echo "<br>Setting Pool Ref ID:".$a_poolrefid;
         $this->poolrefid = $a_poolrefid;
@@ -233,7 +233,7 @@ class ilQuestionEditGUI
     *
     * @param	int	$a_poolobjid	Pool Obj Id
     */
-    public function setPoolObjId($a_poolobjid)
+    public function setPoolObjId($a_poolobjid) : void
     {
         //echo "<br>Setting Pool Obj ID:".$a_poolobjid;
         $this->poolobjid = $a_poolobjid;
@@ -255,7 +255,7 @@ class ilQuestionEditGUI
     *
     * @param	string	$a_questiontype	Question Type
     */
-    public function setQuestionType($a_questiontype)
+    public function setQuestionType($a_questiontype) : void
     {
         $this->questiontype = $a_questiontype;
         $_GET["q_type"] = $this->questiontype;

--- a/Modules/TestQuestionPool/classes/class.ilQuestionPoolSkillAdministrationGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilQuestionPoolSkillAdministrationGUI.php
@@ -94,7 +94,7 @@ class ilQuestionPoolSkillAdministrationGUI
         return false;
     }
 
-    public function manageTabs($activeSubTabId)
+    public function manageTabs($activeSubTabId) : void
     {
         $link = $this->ctrl->getLinkTargetByClass(
             'ilAssQuestionSkillAssignmentsGUI',
@@ -120,7 +120,7 @@ class ilQuestionPoolSkillAdministrationGUI
         $this->tabs->activateSubTab($activeSubTabId);
     }
 
-    public function executeCommand()
+    public function executeCommand() : void
     {
         if ($this->isAccessDenied()) {
             $this->ilias->raiseError($this->lng->txt("permission_denied"), $this->ilias->error_obj->MESSAGE);

--- a/Modules/TestQuestionPool/classes/class.ilQuestionPoolTaxonomiesDuplicator.php
+++ b/Modules/TestQuestionPool/classes/class.ilQuestionPoolTaxonomiesDuplicator.php
@@ -37,7 +37,7 @@ class ilQuestionPoolTaxonomiesDuplicator
         $this->duplicatedTaxonomiesKeysMap = new ilQuestionPoolDuplicatedTaxonomiesKeysMap();
     }
 
-    public function setSourceObjId($sourceObjId)
+    public function setSourceObjId($sourceObjId) : void
     {
         $this->sourceObjId = $sourceObjId;
     }
@@ -52,7 +52,7 @@ class ilQuestionPoolTaxonomiesDuplicator
         return $this->sourceObjType;
     }
 
-    public function setSourceObjType($sourceObjType)
+    public function setSourceObjType($sourceObjType) : void
     {
         $this->sourceObjType = $sourceObjType;
     }
@@ -62,7 +62,7 @@ class ilQuestionPoolTaxonomiesDuplicator
         return $this->targetObjId;
     }
 
-    public function setTargetObjId($targetObjId)
+    public function setTargetObjId($targetObjId) : void
     {
         $this->targetObjId = $targetObjId;
     }
@@ -72,12 +72,12 @@ class ilQuestionPoolTaxonomiesDuplicator
         return $this->targetObjType;
     }
 
-    public function setTargetObjType($targetObjType)
+    public function setTargetObjType($targetObjType) : void
     {
         $this->targetObjType = $targetObjType;
     }
 
-    public function setQuestionIdMapping($questionIdMapping)
+    public function setQuestionIdMapping($questionIdMapping) : void
     {
         $this->questionIdMapping = $questionIdMapping;
     }
@@ -87,7 +87,7 @@ class ilQuestionPoolTaxonomiesDuplicator
         return $this->questionIdMapping;
     }
 
-    public function duplicate($poolTaxonomyIds)
+    public function duplicate($poolTaxonomyIds) : void
     {
         foreach ($poolTaxonomyIds as $poolTaxId) {
             $this->duplicateTaxonomyFromPoolToTest($poolTaxId);
@@ -99,7 +99,7 @@ class ilQuestionPoolTaxonomiesDuplicator
         }
     }
 
-    private function duplicateTaxonomyFromPoolToTest($poolTaxonomyId)
+    private function duplicateTaxonomyFromPoolToTest($poolTaxonomyId) : void
     {
         $testTaxonomy = new ilObjTaxonomy();
         $testTaxonomy->create();
@@ -117,7 +117,7 @@ class ilQuestionPoolTaxonomiesDuplicator
         $this->duplicatedTaxonomiesKeysMap->addDuplicatedTaxonomy($poolTaxonomy, $testTaxonomy);
     }
 
-    private function transferAssignmentsFromOriginalToDuplicatedTaxonomy($originalTaxonomyId, $mappedTaxonomyId)
+    private function transferAssignmentsFromOriginalToDuplicatedTaxonomy($originalTaxonomyId, $mappedTaxonomyId) : void
     {
         $originalTaxAssignment = new ilTaxNodeAssignment($this->getSourceObjType(), $this->getSourceObjId(), 'quest', $originalTaxonomyId);
 

--- a/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
@@ -69,7 +69,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
     *
     * @param	array	$a_suffixes	Accepted Suffixes
     */
-    public function setSuffixes($a_suffixes)
+    public function setSuffixes($a_suffixes) : void
     {
         $this->suffixes = $a_suffixes;
     }
@@ -79,7 +79,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
     *
     * @param	array	$a_hide	Hide images
     */
-    public function setHideImages($a_hide)
+    public function setHideImages($a_hide) : void
     {
         $this->hideImages = $a_hide;
     }
@@ -94,7 +94,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
         return $this->suffixes;
     }
     
-    public function setShowPoints($a_value)
+    public function setShowPoints($a_value) : void
     {
         $this->showPoints = $a_value;
     }
@@ -109,7 +109,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
     *
     * @param	array	$a_value	Value
     */
-    public function setValues($a_values)
+    public function setValues($a_values) : void
     {
         $this->values = $a_values;
     }
@@ -129,7 +129,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
     *
     * @param	boolean	$a_value	Value
     */
-    public function setSingleline($a_value)
+    public function setSingleline($a_value) : void
     {
         $this->singleline = $a_value;
     }
@@ -149,7 +149,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
     *
     * @param	object	$a_value	test object
     */
-    public function setQuestionObject($a_value)
+    public function setQuestionObject($a_value) : void
     {
         $this->qstObject = &$a_value;
     }
@@ -169,7 +169,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
     *
     * @param	boolean	$a_allow_move Allow move
     */
-    public function setAllowMove($a_allow_move)
+    public function setAllowMove($a_allow_move) : void
     {
         $this->allowMove = $a_allow_move;
     }

--- a/Modules/TestQuestionPool/classes/class.ilSolutionExplorer.php
+++ b/Modules/TestQuestionPool/classes/class.ilSolutionExplorer.php
@@ -62,7 +62,7 @@ class ilSolutionExplorer extends ilExplorer
     /**
      * @param int $ref_id
      */
-    public function expandPathByRefId($ref_id)
+    public function expandPathByRefId($ref_id) : void
     {
         /**
          * @var $tree ilTree
@@ -86,11 +86,11 @@ class ilSolutionExplorer extends ilExplorer
         $this->expanded = ilSession::get($this->expand_variable);
     }
 
-    public function setSelectableType($a_type)
+    public function setSelectableType($a_type) : void
     {
         $this->selectable_type = $a_type;
     }
-    public function setRefId($a_ref_id)
+    public function setRefId($a_ref_id) : void
     {
         $this->ref_id = $a_ref_id;
     }

--- a/Modules/TestQuestionPool/classes/class.ilSuggestedSolutionSelectorGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilSuggestedSolutionSelectorGUI.php
@@ -35,7 +35,7 @@ class ilSuggestedSolutionSelectorGUI extends ilSubEnabledFormPropertyGUI
     *
     * @param	array	$a_options	Options. Array ("value" => "option_text")
     */
-    public function setOptions($a_options)
+    public function setOptions($a_options) : void
     {
         $this->options = $a_options;
     }
@@ -55,7 +55,7 @@ class ilSuggestedSolutionSelectorGUI extends ilSubEnabledFormPropertyGUI
     *
     * @param	string	$a_value	Value
     */
-    public function setValue($a_value)
+    public function setValue($a_value) : void
     {
         $this->value = $a_value;
     }
@@ -75,7 +75,7 @@ class ilSuggestedSolutionSelectorGUI extends ilSubEnabledFormPropertyGUI
     *
     * @param	string	$a_value	Value
     */
-    public function setInternalLink($a_value)
+    public function setInternalLink($a_value) : void
     {
         $this->intlink = $a_value;
     }
@@ -95,7 +95,7 @@ class ilSuggestedSolutionSelectorGUI extends ilSubEnabledFormPropertyGUI
     *
     * @param	string	$a_value	Internal link text
     */
-    public function setInternalLinkText($a_value)
+    public function setInternalLinkText($a_value) : void
     {
         $this->intlinktext = $a_value;
     }
@@ -115,7 +115,7 @@ class ilSuggestedSolutionSelectorGUI extends ilSubEnabledFormPropertyGUI
     *
     * @param	string	$a_add_command	add command
     */
-    public function setAddCommand($a_add_command)
+    public function setAddCommand($a_add_command) : void
     {
         $this->addCommand = $a_add_command;
     }
@@ -135,7 +135,7 @@ class ilSuggestedSolutionSelectorGUI extends ilSubEnabledFormPropertyGUI
     *
     * @param	array	$a_values	value array
     */
-    public function setValueByArray($a_values)
+    public function setValueByArray($a_values) : void
     {
         $this->setValue($a_values[$this->getPostVar()]);
     }
@@ -159,7 +159,7 @@ class ilSuggestedSolutionSelectorGUI extends ilSubEnabledFormPropertyGUI
         return $this->checkSubItemsInput();
     }
 
-    public function insert($a_tpl)
+    public function insert($a_tpl) : void
     {
         global $DIC;
         $lng = $DIC['lng'];

--- a/Modules/TestQuestionPool/classes/class.ilTestQuestionConfig.php
+++ b/Modules/TestQuestionPool/classes/class.ilTestQuestionConfig.php
@@ -126,7 +126,7 @@ class ilTestQuestionConfig
     /**
      * @param bool $previousPassSolutionReuseAllowed
      */
-    public function setPreviousPassSolutionReuseAllowed($previousPassSolutionReuseAllowed)
+    public function setPreviousPassSolutionReuseAllowed($previousPassSolutionReuseAllowed) : void
     {
         $this->previousPassSolutionReuseAllowed = $previousPassSolutionReuseAllowed;
     }
@@ -166,7 +166,7 @@ class ilTestQuestionConfig
     /**
      * @param bool $scoreEmptyMcSolutionsEnabled
      */
-    public function setScoreEmptyMcSolutionsEnabled($scoreEmptyMcSolutionsEnabled)
+    public function setScoreEmptyMcSolutionsEnabled($scoreEmptyMcSolutionsEnabled) : void
     {
         $this->scoreEmptyMcSolutionsEnabled = $scoreEmptyMcSolutionsEnabled;
     }

--- a/Modules/TestQuestionPool/classes/class.ilTestQuestionPoolImporter.php
+++ b/Modules/TestQuestionPool/classes/class.ilTestQuestionPoolImporter.php
@@ -200,7 +200,7 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
         return $name;
     }
     
-    protected function importQuestionSkillAssignments($xmlFile, ilImportMapping $mappingRegistry, $targetParentObjId)
+    protected function importQuestionSkillAssignments($xmlFile, ilImportMapping $mappingRegistry, $targetParentObjId) : void
     {
         require_once 'Modules/TestQuestionPool/classes/questions/class.ilAssQuestionSkillAssignmentXmlParser.php';
         $parser = new ilAssQuestionSkillAssignmentXmlParser($xmlFile);

--- a/Modules/TestQuestionPool/classes/class.ilUnitConfigurationGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilUnitConfigurationGUI.php
@@ -92,7 +92,7 @@ abstract class ilUnitConfigurationGUI
     /**
      * @param array $categories
      */
-    abstract protected function showUnitCategories(array $categories);
+    abstract protected function showUnitCategories(array $categories) : void;
 
     /**
      * @param int  $id
@@ -112,21 +112,21 @@ abstract class ilUnitConfigurationGUI
     /**
      *
      */
-    protected function handleSubtabs()
+    protected function handleSubtabs() : void
     {
     }
 
     /**
      * @param string $cmd
      */
-    protected function checkPermissions($cmd)
+    protected function checkPermissions($cmd) : void
     {
     }
 
     /**
      *
      */
-    public function executeCommand()
+    public function executeCommand() : void
     {
         $this->ctrl->saveParameter($this, 'category_id');
 
@@ -145,7 +145,7 @@ abstract class ilUnitConfigurationGUI
     /**
      *
      */
-    protected function confirmDeleteUnit()
+    protected function confirmDeleteUnit() : void
     {
         if (!$this->request->isset('unit_id')) {
             $this->showUnitsOfCategory();
@@ -159,7 +159,7 @@ abstract class ilUnitConfigurationGUI
     /**
      *
      */
-    protected function confirmDeleteUnits()
+    protected function confirmDeleteUnits() : void
     {
         if (!$this->isCRUDContext()) {
             $this->showUnitsOfCategory();
@@ -226,7 +226,7 @@ abstract class ilUnitConfigurationGUI
     /**
      *
      */
-    public function deleteUnits()
+    public function deleteUnits() : void
     {
         if (!$this->isCRUDContext()) {
             $this->showUnitsOfCategory();
@@ -286,7 +286,7 @@ abstract class ilUnitConfigurationGUI
     /**
      *
      */
-    protected function saveOrder()
+    protected function saveOrder() : void
     {
         if (!$this->isCRUDContext()) {
             $this->showUnitsOfCategory();
@@ -312,7 +312,7 @@ abstract class ilUnitConfigurationGUI
     /**
      * Save a unit
      */
-    protected function saveUnit()
+    protected function saveUnit() : void
     {
         if (!$this->isCRUDContext()) {
             $this->showUnitsOfCategory();
@@ -347,7 +347,7 @@ abstract class ilUnitConfigurationGUI
     /**
      *
      */
-    protected function showUnitModificationForm()
+    protected function showUnitModificationForm() : void
     {
         if (!$this->isCRUDContext()) {
             $this->showUnitsOfCategory();
@@ -370,7 +370,7 @@ abstract class ilUnitConfigurationGUI
     /**
      * Adds a new unit
      */
-    protected function addUnit()
+    protected function addUnit() : void
     {
         if (!$this->isCRUDContext()) {
             $this->showUnitsOfCategory();
@@ -405,7 +405,7 @@ abstract class ilUnitConfigurationGUI
     /**
      *
      */
-    protected function showUnitCreationForm()
+    protected function showUnitCreationForm() : void
     {
         if (!$this->isCRUDContext()) {
             $this->showUnitsOfCategory();
@@ -506,7 +506,7 @@ abstract class ilUnitConfigurationGUI
     /**
      *
      */
-    protected function showUnitsOfCategory()
+    protected function showUnitsOfCategory() : void
     {
         /**
          * @var $ilToolbar ilToolbarGUI
@@ -546,10 +546,7 @@ abstract class ilUnitConfigurationGUI
         $this->tpl->setContent($table->getHTML());
     }
 
-    /**
-     *
-     */
-    protected function showGlobalUnitCategories()
+    protected function showGlobalUnitCategories() : void
     {
         $categories = array_filter(
             $this->repository->getAllUnitCategories(),
@@ -574,7 +571,7 @@ abstract class ilUnitConfigurationGUI
     /**
      *
      */
-    protected function confirmDeleteCategory()
+    protected function confirmDeleteCategory() : void
     {
         if (!$this->request->isset('category_id')) {
             $this->{$this->getUnitCategoryOverviewCommand()}();
@@ -588,7 +585,7 @@ abstract class ilUnitConfigurationGUI
     /**
      *
      */
-    protected function confirmDeleteCategories()
+    protected function confirmDeleteCategories() : void
     {
         if (!$this->isCRUDContext()) {
             $this->{$this->getDefaultCommand()}();
@@ -658,7 +655,7 @@ abstract class ilUnitConfigurationGUI
     /**
      *
      */
-    protected function deleteCategories()
+    protected function deleteCategories() : void
     {
         if (!$this->isCRUDContext()) {
             $this->{$this->getDefaultCommand()}();
@@ -751,7 +748,7 @@ abstract class ilUnitConfigurationGUI
     /**
      *
      */
-    protected function addCategory()
+    protected function addCategory() : void
     {
         if (!$this->isCRUDContext()) {
             $this->{$this->getDefaultCommand()}();
@@ -782,7 +779,7 @@ abstract class ilUnitConfigurationGUI
     /**
      *
      */
-    protected function showUnitCategoryCreationForm()
+    protected function showUnitCategoryCreationForm() : void
     {
         if (!$this->isCRUDContext()) {
             $this->{$this->getDefaultCommand()}();
@@ -797,7 +794,7 @@ abstract class ilUnitConfigurationGUI
     /**
      *
      */
-    protected function saveCategory()
+    protected function saveCategory() : void
     {
         if (!$this->isCRUDContext()) {
             $this->{$this->getDefaultCommand()}();
@@ -829,7 +826,7 @@ abstract class ilUnitConfigurationGUI
     /**
      *
      */
-    protected function showUnitCategoryModificationForm()
+    protected function showUnitCategoryModificationForm() : void
     {
         if (!$this->isCRUDContext()) {
             $this->{$this->getDefaultCommand()}();

--- a/Modules/TestQuestionPool/classes/class.ilUnitConfigurationRepository.php
+++ b/Modules/TestQuestionPool/classes/class.ilUnitConfigurationRepository.php
@@ -47,7 +47,7 @@ class ilUnitConfigurationRepository
     /**
      * @param int $context_id
      */
-    public function setConsumerId($consumer_id)
+    public function setConsumerId($consumer_id) : void
     {
         $this->consumer_id = $consumer_id;
     }
@@ -124,7 +124,7 @@ class ilUnitConfigurationRepository
      * @param int $a_to_category_id
      * @param int $a_question_fi
      */
-    public function copyUnitsByCategories($a_from_category_id, $a_to_category_id, $a_question_fi)
+    public function copyUnitsByCategories($a_from_category_id, $a_to_category_id, $a_question_fi) : void
     {
         /**
          * @var $ilDB ilDBInterface
@@ -297,7 +297,7 @@ class ilUnitConfigurationRepository
         return null;
     }
 
-    protected function loadUnits()
+    protected function loadUnits() : void
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];
@@ -361,12 +361,12 @@ class ilUnitConfigurationRepository
         return $this->categorizedUnits;
     }
 
-    protected function clearUnits()
+    protected function clearUnits() : void
     {
         $this->units = array();
     }
 
-    protected function addUnit($unit)
+    protected function addUnit($unit) : void
     {
         $this->units[$unit->getId()] = $unit;
     }
@@ -491,7 +491,7 @@ class ilUnitConfigurationRepository
      * @param integer $unit_id
      * @param integer $sequence
      */
-    public function saveUnitOrder($unit_id, $sequence)
+    public function saveUnitOrder($unit_id, $sequence) : void
     {
         /**
          * @var $ilDB ilDBInterface
@@ -579,7 +579,7 @@ class ilUnitConfigurationRepository
      * @param assFormulaQuestionUnitCategory $category
      * @throws ilException
      */
-    public function saveCategory(assFormulaQuestionUnitCategory $category)
+    public function saveCategory(assFormulaQuestionUnitCategory $category) : void
     {
         /**
          * @var $ilDB ilDBInterface
@@ -607,7 +607,7 @@ class ilUnitConfigurationRepository
      * @param assFormulaQuestionUnitCategory $category
      * @throws ilException
      */
-    public function saveNewUnitCategory(assFormulaQuestionUnitCategory $category)
+    public function saveNewUnitCategory(assFormulaQuestionUnitCategory $category) : void
     {
         /**
          * @var $ilDB ilDBInterface
@@ -703,7 +703,7 @@ class ilUnitConfigurationRepository
     /**
      * @param assFormulaQuestionUnit $unit
      */
-    public function createNewUnit(assFormulaQuestionUnit $unit)
+    public function createNewUnit(assFormulaQuestionUnit $unit) : void
     {
         /**
          * @var $ilDB ilDBInterface
@@ -736,7 +736,7 @@ class ilUnitConfigurationRepository
     /**
      * @param assFormulaQuestionUnit $unit
      */
-    public function saveUnit(assFormulaQuestionUnit $unit)
+    public function saveUnit(assFormulaQuestionUnit $unit) : void
     {
         /**
          * @var $ilDB ilDBInterface
@@ -775,7 +775,7 @@ class ilUnitConfigurationRepository
      * @param int $a_from_consumer_id
      * @param int $a_to_consumer_id
      */
-    public function cloneUnits($a_from_consumer_id, $a_to_consumer_id)
+    public function cloneUnits($a_from_consumer_id, $a_to_consumer_id) : void
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];

--- a/Modules/TestQuestionPool/classes/class.ilUserQuestionResult.php
+++ b/Modules/TestQuestionPool/classes/class.ilUserQuestionResult.php
@@ -49,7 +49,7 @@ class ilUserQuestionResult
      * @param mixed $key
      * @param mixed $value
      */
-    public function addKeyValue($key, $value)
+    public function addKeyValue($key, $value) : void
     {
         $this->solutions[] = array(
             self::$USER_SOLUTION_IDENTIFIER_KEY => $key,
@@ -60,7 +60,7 @@ class ilUserQuestionResult
     /**
      * @param string $key
      */
-    public function removeByKey($key)
+    public function removeByKey($key) : void
     {
         foreach ($this->solutions as $array_key => $solution) {
             if ($solution[self::$USER_SOLUTION_IDENTIFIER_KEY] == $key) {
@@ -118,7 +118,7 @@ class ilUserQuestionResult
     /**
      * @param int $reached_percentage
      */
-    public function setReachedPercentage($reached_percentage)
+    public function setReachedPercentage($reached_percentage) : void
     {
         $this->reached_percentage = $reached_percentage;
     }

--- a/Modules/TestQuestionPool/classes/export/qti12/class.assClozeTestExport.php
+++ b/Modules/TestQuestionPool/classes/export/qti12/class.assClozeTestExport.php
@@ -517,7 +517,7 @@ class assClozeTestExport extends assQuestionExport
     /**
      * @param ilXmlWriter $xmlWriter
      */
-    protected function exportAnswerSpecificFeedbacks(ilXmlWriter $xmlWriter)
+    protected function exportAnswerSpecificFeedbacks(ilXmlWriter $xmlWriter) : void
     {
         require_once 'Modules/TestQuestionPool/classes/feedback/class.ilAssSpecificFeedbackIdentifierList.php';
         $feedbackIdentifierList = new ilAssSpecificFeedbackIdentifierList();

--- a/Modules/TestQuestionPool/classes/export/qti12/class.assQuestionExport.php
+++ b/Modules/TestQuestionPool/classes/export/qti12/class.assQuestionExport.php
@@ -37,7 +37,7 @@ class assQuestionExport
     /**
      * @param ilXmlWriter $a_xml_writer
      */
-    protected function addAnswerSpecificFeedback(ilXmlWriter $a_xml_writer, $answers)
+    protected function addAnswerSpecificFeedback(ilXmlWriter $a_xml_writer, $answers) : void
     {
         foreach ($answers as $index => $answer) {
             $linkrefid = "response_$index";
@@ -62,12 +62,12 @@ class assQuestionExport
     /**
      * @param ilXmlWriter $a_xml_writer
      */
-    protected function addGenericFeedback(ilXmlWriter $a_xml_writer)
+    protected function addGenericFeedback(ilXmlWriter $a_xml_writer) : void
     {
         $this->exportFeedbackOnly($a_xml_writer);
     }
     
-    public function exportFeedbackOnly($a_xml_writer)
+    public function exportFeedbackOnly($a_xml_writer) : void
     {
         $feedback_allcorrect = $this->object->feedbackOBJ->getGenericFeedbackExportPresentation(
             $this->object->getId(),
@@ -176,7 +176,7 @@ class assQuestionExport
      * @param string $fieldLabel
      * @param string $fieldValue
      */
-    final protected function addQtiMetaDataField(ilXmlWriter $a_xml_writer, $fieldLabel, $fieldValue)
+    final protected function addQtiMetaDataField(ilXmlWriter $a_xml_writer, $fieldLabel, $fieldValue) : void
     {
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, $fieldLabel);
@@ -192,7 +192,7 @@ class assQuestionExport
      * @access protected
      * @param ilXmlWriter $a_xml_writer
      */
-    final protected function addAdditionalContentEditingModeInformation(ilXmlWriter $a_xml_writer)
+    final protected function addAdditionalContentEditingModeInformation(ilXmlWriter $a_xml_writer) : void
     {
         $this->addQtiMetaDataField(
             $a_xml_writer,
@@ -204,7 +204,7 @@ class assQuestionExport
     /**
      * @param ilXmlWriter $xmlwriter
      */
-    protected function addGeneralMetadata(ilXmlWriter $xmlwriter)
+    protected function addGeneralMetadata(ilXmlWriter $xmlwriter) : void
     {
         $this->addQtiMetaDataField($xmlwriter, 'externalId', $this->object->getExternalId());
         

--- a/Modules/TestQuestionPool/classes/feedback/class.ilAssQuestionFeedback.php
+++ b/Modules/TestQuestionPool/classes/feedback/class.ilAssQuestionFeedback.php
@@ -401,7 +401,7 @@ abstract class ilAssQuestionFeedback
     /**
      * syncs the GENERIC feedback from a duplicated question back to the original question
      */
-    private function syncGenericFeedback(int $originalQuestionId, int $duplicateQuestionId)
+    private function syncGenericFeedback(int $originalQuestionId, int $duplicateQuestionId) : void
     {
         // delete generic feedback of the original question
         $this->db->manipulateF(

--- a/Modules/TestQuestionPool/classes/forms/class.ilAddAnswerModalFormGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilAddAnswerModalFormGUI.php
@@ -57,7 +57,7 @@ class ilAddAnswerModalFormGUI extends ilPropertyFormGUI
     /**
      * @param int $questionId
      */
-    public function setQuestionId(int $questionId)
+    public function setQuestionId(int $questionId) : void
     {
         $this->questionId = $questionId;
     }
@@ -73,7 +73,7 @@ class ilAddAnswerModalFormGUI extends ilPropertyFormGUI
     /**
      * @param int $questionIndex
      */
-    public function setQuestionIndex(int $questionIndex)
+    public function setQuestionIndex(int $questionIndex) : void
     {
         $this->questionIndex = $questionIndex;
     }
@@ -89,12 +89,12 @@ class ilAddAnswerModalFormGUI extends ilPropertyFormGUI
     /**
      * @param string $answerValue
      */
-    public function setAnswerValue(string $answerValue)
+    public function setAnswerValue(string $answerValue) : void
     {
         $this->answerValue = $answerValue;
     }
 
-    public function build()
+    public function build() : void
     {
         $answer = new ilNonEditableValueGUI($this->DIC->language()->txt('answer'));
         $answer->setPostVar('answer_presentation');

--- a/Modules/TestQuestionPool/classes/forms/class.ilAssAnswerCorrectionsInputGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilAssAnswerCorrectionsInputGUI.php
@@ -28,7 +28,7 @@ class ilAssAnswerCorrectionsInputGUI extends ilAnswerWizardInputGUI
     /**
      * @param bool $hidePointsEnabled
      */
-    public function setHidePointsEnabled(bool $hidePointsEnabled)
+    public function setHidePointsEnabled(bool $hidePointsEnabled) : void
     {
         $this->hidePointsEnabled = $hidePointsEnabled;
     }

--- a/Modules/TestQuestionPool/classes/forms/class.ilAssNestedOrderingElementsInputGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilAssNestedOrderingElementsInputGUI.php
@@ -100,7 +100,7 @@ class ilAssNestedOrderingElementsInputGUI extends ilMultipleNestedOrderingElemen
     /**
      * @param ilAssOrderingElementList $elementList
      */
-    public function setElementList(ilAssOrderingElementList $elementList)
+    public function setElementList(ilAssOrderingElementList $elementList) : void
     {
         $this->setIdentifiedMultiValues($elementList->getRandomIdentifierIndexedElements());
     }
@@ -118,7 +118,7 @@ class ilAssNestedOrderingElementsInputGUI extends ilMultipleNestedOrderingElemen
     /**
      * @param assOrderingQuestion $question
      */
-    public function prepareReprintable(assQuestion $question)
+    public function prepareReprintable(assQuestion $question) : void
     {
         $elementList = $this->getElementList($question->getId());
         
@@ -149,7 +149,7 @@ class ilAssNestedOrderingElementsInputGUI extends ilMultipleNestedOrderingElemen
     /**
      * @param string $context
      */
-    public function setContext($context)
+    public function setContext($context) : void
     {
         $this->context = $context;
     }
@@ -165,7 +165,7 @@ class ilAssNestedOrderingElementsInputGUI extends ilMultipleNestedOrderingElemen
     /**
      * @param string $uniquePrefix
      */
-    public function setUniquePrefix($uniquePrefix)
+    public function setUniquePrefix($uniquePrefix) : void
     {
         $this->uniquePrefix = $uniquePrefix;
     }
@@ -173,7 +173,7 @@ class ilAssNestedOrderingElementsInputGUI extends ilMultipleNestedOrderingElemen
     /**
      * @param mixed $orderingType
      */
-    public function setOrderingType($orderingType)
+    public function setOrderingType($orderingType) : void
     {
         $this->orderingType = $orderingType;
     }
@@ -189,7 +189,7 @@ class ilAssNestedOrderingElementsInputGUI extends ilMultipleNestedOrderingElemen
     /**
      * @param string $elementImagePath
      */
-    public function setElementImagePath($elementImagePath)
+    public function setElementImagePath($elementImagePath) : void
     {
         $this->elementImagePath = $elementImagePath;
     }
@@ -205,7 +205,7 @@ class ilAssNestedOrderingElementsInputGUI extends ilMultipleNestedOrderingElemen
     /**
      * @param string $thumbnailFilenamePrefix
      */
-    public function setThumbPrefix($thumbnailFilenamePrefix)
+    public function setThumbPrefix($thumbnailFilenamePrefix) : void
     {
         $this->thumbnailFilenamePrefix = $thumbnailFilenamePrefix;
     }
@@ -221,7 +221,7 @@ class ilAssNestedOrderingElementsInputGUI extends ilMultipleNestedOrderingElemen
     /**
      * @param $showCorrectnessIconsEnabled
      */
-    public function setShowCorrectnessIconsEnabled($showCorrectnessIconsEnabled)
+    public function setShowCorrectnessIconsEnabled($showCorrectnessIconsEnabled) : void
     {
         $this->showCorrectnessIconsEnabled = $showCorrectnessIconsEnabled;
     }
@@ -247,7 +247,7 @@ class ilAssNestedOrderingElementsInputGUI extends ilMultipleNestedOrderingElemen
      * @param bool $correctness
      * @param string $iconFilename
      */
-    public function setCorrectnessIconFilename($correctness, $iconFilename)
+    public function setCorrectnessIconFilename($correctness, $iconFilename) : void
     {
         $this->correctnessIcons[(bool) $correctness] = $iconFilename;
     }
@@ -265,7 +265,7 @@ class ilAssNestedOrderingElementsInputGUI extends ilMultipleNestedOrderingElemen
      * @param bool $correctness
      * @param string $langVar
      */
-    public function setCorrectnessLangVar($correctness, $langVar)
+    public function setCorrectnessLangVar($correctness, $langVar) : void
     {
         $this->correctnessLngVars[(bool) $correctness] = $langVar;
     }
@@ -292,7 +292,7 @@ class ilAssNestedOrderingElementsInputGUI extends ilMultipleNestedOrderingElemen
     /**
      * @param ilAssOrderingElementList $correctnessTrueElementList
      */
-    public function setCorrectnessTrueElementList(ilAssOrderingElementList $correctnessTrueElementList)
+    public function setCorrectnessTrueElementList(ilAssOrderingElementList $correctnessTrueElementList) : void
     {
         $this->correctnessTrueElementList = $correctnessTrueElementList;
     }

--- a/Modules/TestQuestionPool/classes/forms/class.ilAssOrderingFormValuesObjectsConverter.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilAssOrderingFormValuesObjectsConverter.php
@@ -59,7 +59,7 @@ class ilAssOrderingFormValuesObjectsConverter implements ilFormValuesManipulator
     /**
      * @param $context
      */
-    public function setContext($context)
+    public function setContext($context) : void
     {
         $this->context = $context;
     }
@@ -75,7 +75,7 @@ class ilAssOrderingFormValuesObjectsConverter implements ilFormValuesManipulator
     /**
      * @param $postVar
      */
-    public function setPostVar($postVar)
+    public function setPostVar($postVar) : void
     {
         $this->postVar = $postVar;
     }
@@ -85,7 +85,7 @@ class ilAssOrderingFormValuesObjectsConverter implements ilFormValuesManipulator
         return $this->imageRemovalCommand;
     }
     
-    public function setImageRemovalCommand($imageRemovalCommand)
+    public function setImageRemovalCommand($imageRemovalCommand) : void
     {
         $this->imageRemovalCommand = $imageRemovalCommand;
     }
@@ -98,7 +98,7 @@ class ilAssOrderingFormValuesObjectsConverter implements ilFormValuesManipulator
     /**
      * @param string $imageUrlPath
      */
-    public function setImageUrlPath($imageUrlPath)
+    public function setImageUrlPath($imageUrlPath) : void
     {
         $this->imageUrlPath = $imageUrlPath;
     }
@@ -114,7 +114,7 @@ class ilAssOrderingFormValuesObjectsConverter implements ilFormValuesManipulator
     /**
      * @param string $imageFsPath
      */
-    public function setImageFsPath($imageFsPath)
+    public function setImageFsPath($imageFsPath) : void
     {
         $this->imageFsPath = $imageFsPath;
     }
@@ -130,7 +130,7 @@ class ilAssOrderingFormValuesObjectsConverter implements ilFormValuesManipulator
     /**
      * @param string $thumbnailPrefix
      */
-    public function setThumbnailPrefix($thumbnailPrefix)
+    public function setThumbnailPrefix($thumbnailPrefix) : void
     {
         $this->thumbnailPrefix = $thumbnailPrefix;
     }

--- a/Modules/TestQuestionPool/classes/forms/class.ilAssOrderingImagesInputGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilAssOrderingImagesInputGUI.php
@@ -37,7 +37,7 @@ class ilAssOrderingImagesInputGUI extends ilMultipleImagesInputGUI
      *
      * @param $stylingDisabled
      */
-    public function setStylingDisabled($stylingDisabled)
+    public function setStylingDisabled($stylingDisabled) : void
     {
     }
     
@@ -54,7 +54,7 @@ class ilAssOrderingImagesInputGUI extends ilMultipleImagesInputGUI
     /**
      * @param ilAssOrderingElementList $elementList
      */
-    public function setElementList(ilAssOrderingElementList $elementList)
+    public function setElementList(ilAssOrderingElementList $elementList) : void
     {
         $this->setIdentifiedMultiValues($elementList->getRandomIdentifierIndexedElements());
     }

--- a/Modules/TestQuestionPool/classes/forms/class.ilAssOrderingQuestionAuthoringFormGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilAssOrderingQuestionAuthoringFormGUI.php
@@ -26,7 +26,7 @@ class ilAssOrderingQuestionAuthoringFormGUI extends ilAssQuestionAuthoringFormGU
         parent::__construct();
     }
     
-    protected function setAvailableCommandButtonIds($availableCommandButtonIds)
+    protected function setAvailableCommandButtonIds($availableCommandButtonIds) : void
     {
         $this->availableCommandButtonIds = $availableCommandButtonIds;
     }
@@ -36,7 +36,7 @@ class ilAssOrderingQuestionAuthoringFormGUI extends ilAssQuestionAuthoringFormGU
         return $this->availableCommandButtonIds;
     }
     
-    public function addSpecificOrderingQuestionCommandButtons(assOrderingQuestion $questionOBJ)
+    public function addSpecificOrderingQuestionCommandButtons(assOrderingQuestion $questionOBJ) : void
     {
         switch ($questionOBJ->getOrderingType()) {
             case OQ_TERMS:
@@ -104,12 +104,12 @@ class ilAssOrderingQuestionAuthoringFormGUI extends ilAssQuestionAuthoringFormGU
         );
     }
     
-    public function prepareValuesReprintable(assOrderingQuestion $questionOBJ)
+    public function prepareValuesReprintable(assOrderingQuestion $questionOBJ) : void
     {
         $this->getOrderingElementInputField()->prepareReprintable($questionOBJ);
     }
     
-    public function ensureReprintableFormStructure(assOrderingQuestion $questionOBJ)
+    public function ensureReprintableFormStructure(assOrderingQuestion $questionOBJ) : void
     {
         $this->renewOrderingElementInput($questionOBJ);
         $this->renewOrderingCommandButtons($questionOBJ);
@@ -119,7 +119,7 @@ class ilAssOrderingQuestionAuthoringFormGUI extends ilAssQuestionAuthoringFormGU
      * @param assOrderingQuestion $questionOBJ
      * @throws ilTestQuestionPoolException
      */
-    protected function renewOrderingElementInput(assOrderingQuestion $questionOBJ)
+    protected function renewOrderingElementInput(assOrderingQuestion $questionOBJ) : void
     {
         $replacingInput = $questionOBJ->buildOrderingElementInputGui();
         $questionOBJ->initOrderingElementAuthoringProperties($replacingInput);
@@ -133,7 +133,7 @@ class ilAssOrderingQuestionAuthoringFormGUI extends ilAssQuestionAuthoringFormGU
         return self::COMMAND_BUTTON_PREFIX . $orderingType;
     }
     
-    protected function renewOrderingCommandButtons(assOrderingQuestion $questionOBJ)
+    protected function renewOrderingCommandButtons(assOrderingQuestion $questionOBJ) : void
     {
         $this->clearCommandButtons();
         $this->addSpecificOrderingQuestionCommandButtons($questionOBJ);

--- a/Modules/TestQuestionPool/classes/forms/class.ilAssOrderingTextsInputGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilAssOrderingTextsInputGUI.php
@@ -28,7 +28,7 @@ class ilAssOrderingTextsInputGUI extends ilMultipleTextsInputGUI
      *
      * @param $stylingDisabled
      */
-    public function setStylingDisabled($stylingDisabled)
+    public function setStylingDisabled($stylingDisabled) : void
     {
     }
     
@@ -45,7 +45,7 @@ class ilAssOrderingTextsInputGUI extends ilMultipleTextsInputGUI
     /**
      * @param ilAssOrderingElementList $elementList
      */
-    public function setElementList(ilAssOrderingElementList $elementList)
+    public function setElementList(ilAssOrderingElementList $elementList) : void
     {
         $this->setIdentifiedMultiValues($elementList->getRandomIdentifierIndexedElements());
     }

--- a/Modules/TestQuestionPool/classes/forms/class.ilAssQuestionAuthoringFormGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilAssQuestionAuthoringFormGUI.php
@@ -25,7 +25,7 @@ class ilAssQuestionAuthoringFormGUI extends ilPropertyFormGUI
     /**
      * @param assQuestion $questionOBJ
      */
-    public function addGenericAssessmentQuestionCommandButtons(assQuestion $questionOBJ)
+    public function addGenericAssessmentQuestionCommandButtons(assQuestion $questionOBJ) : void
     {
         //if( !$this->object->getSelfAssessmentEditingMode() && !$_GET["calling_test"] )
         //	$this->addCommandButton("saveEdit", $this->lng->txt("save_edit"));

--- a/Modules/TestQuestionPool/classes/forms/class.ilAssQuestionSkillAssignmentPropertyFormGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilAssQuestionSkillAssignmentPropertyFormGUI.php
@@ -51,7 +51,7 @@ class ilAssQuestionSkillAssignmentPropertyFormGUI extends ilPropertyFormGUI
     /**
      * @param assQuestion $question
      */
-    public function setQuestion($question)
+    public function setQuestion($question) : void
     {
         $this->question = $question;
     }
@@ -67,7 +67,7 @@ class ilAssQuestionSkillAssignmentPropertyFormGUI extends ilPropertyFormGUI
     /**
      * @param ilAssQuestionSkillAssignment $assignment
      */
-    public function setAssignment($assignment)
+    public function setAssignment($assignment) : void
     {
         $this->assignment = $assignment;
     }
@@ -83,12 +83,12 @@ class ilAssQuestionSkillAssignmentPropertyFormGUI extends ilPropertyFormGUI
     /**
      * @param boolean $manipulationEnabled
      */
-    public function setManipulationEnabled($manipulationEnabled)
+    public function setManipulationEnabled($manipulationEnabled) : void
     {
         $this->manipulationEnabled = $manipulationEnabled;
     }
 
-    public function build()
+    public function build() : void
     {
         $this->setFormAction($this->ctrl->getFormAction($this->parentGUI));
 
@@ -126,7 +126,7 @@ class ilAssQuestionSkillAssignmentPropertyFormGUI extends ilPropertyFormGUI
         }
     }
 
-    private function populateFullProperties()
+    private function populateFullProperties() : void
     {
         $evaluationMode = new ilRadioGroupInputGUI($this->lng->txt('condition'), 'eval_mode');
         $evalOptionReachedQuestionPoints = new ilRadioOption(
@@ -184,7 +184,7 @@ class ilAssQuestionSkillAssignmentPropertyFormGUI extends ilPropertyFormGUI
         $evalOptionReachedQuestionPoints->addSubItem($questResultSkillPoints);
     }
     
-    private function populateLimitedProperties()
+    private function populateLimitedProperties() : void
     {
         $evaluationMode = new ilNonEditableValueGUI($this->lng->txt('condition'));
         $evaluationMode->setValue($this->lng->txt('qpl_skill_point_eval_by_quest_result'));

--- a/Modules/TestQuestionPool/classes/forms/class.ilIdentifiedMultiFilesJsPositionIndexRemover.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilIdentifiedMultiFilesJsPositionIndexRemover.php
@@ -14,7 +14,7 @@ class ilIdentifiedMultiFilesJsPositionIndexRemover extends ilIdentifiedMultiValu
         return $this->postVar;
     }
     
-    public function setPostVar($postVar)
+    public function setPostVar($postVar) : void
     {
         $this->postVar = $postVar;
     }
@@ -51,7 +51,7 @@ class ilIdentifiedMultiFilesJsPositionIndexRemover extends ilIdentifiedMultiValu
         return true;
     }
     
-    protected function prepareFileSubmit()
+    protected function prepareFileSubmit() : void
     {
         $_FILES[$this->getPostVar()] = $this->prepareMultiFilesSubmitValues(
             $_FILES[$this->getPostVar()]

--- a/Modules/TestQuestionPool/classes/forms/class.ilIdentifiedMultiValuesInputGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilIdentifiedMultiValuesInputGUI.php
@@ -37,7 +37,7 @@ abstract class ilIdentifiedMultiValuesInputGUI extends ilTextInputGUI implements
     /**
      * @param string $elementAddCmd
      */
-    public function setElementAddCmd($elementAddCmd)
+    public function setElementAddCmd($elementAddCmd) : void
     {
         $this->elementAddCmd = $elementAddCmd;
     }
@@ -47,7 +47,7 @@ abstract class ilIdentifiedMultiValuesInputGUI extends ilTextInputGUI implements
         return $this->elementRemoveCmd;
     }
     
-    public function setElementRemoveCmd($elementRemoveCmd)
+    public function setElementRemoveCmd($elementRemoveCmd) : void
     {
         $this->elementRemoveCmd = $elementRemoveCmd;
     }
@@ -57,7 +57,7 @@ abstract class ilIdentifiedMultiValuesInputGUI extends ilTextInputGUI implements
         return $this->elementMoveUpCommand;
     }
     
-    public function setElementMoveUpCommand($elementMoveUpCommand)
+    public function setElementMoveUpCommand($elementMoveUpCommand) : void
     {
         $this->elementMoveUpCommand = $elementMoveUpCommand;
     }
@@ -67,16 +67,20 @@ abstract class ilIdentifiedMultiValuesInputGUI extends ilTextInputGUI implements
         return $this->elementMoveDownCommand;
     }
     
-    public function setElementMoveDownCommand($elementMoveDownCommand)
+    public function setElementMoveDownCommand($elementMoveDownCommand) : void
     {
         $this->elementMoveDownCommand = $elementMoveDownCommand;
     }
     
-    public function setValues($values)
+    public function setValues($values) : void
     {
         throw new ilFormException('setter unsupported, use setIdentifiedMultiValues() instead!');
     }
-    
+
+    /**
+     * @return mixed
+     * @throws ilFormException
+     */
     public function getValues()
     {
         throw new ilFormException('setter unsupported, use setIdentifiedMultiValues() instead!');
@@ -102,7 +106,7 @@ abstract class ilIdentifiedMultiValuesInputGUI extends ilTextInputGUI implements
         throw new ilFormException('setter unsupported, use setIdentifiedMultiValues() instead!');
     }
     
-    final public function setIdentifiedMultiValues($values)
+    final public function setIdentifiedMultiValues($values) : void
     {
         $this->identified_multi_values = $this->prepareMultiValuesInput($values);
     }
@@ -206,7 +210,7 @@ abstract class ilIdentifiedMultiValuesInputGUI extends ilTextInputGUI implements
         $this->setIdentifiedMultiValuesByArray($a_values);
     }
     
-    protected function setIdentifiedMultiValuesByArray($a_values)
+    protected function setIdentifiedMultiValuesByArray($a_values) : void
     {
         $this->identified_multi_values = $a_values[$this->getPostVar()];
     }
@@ -252,7 +256,7 @@ abstract class ilIdentifiedMultiValuesInputGUI extends ilTextInputGUI implements
         return $this->formValuesManipulationChain;
     }
     
-    protected function addFormValuesManipulator(ilFormValuesManipulator $manipulator)
+    protected function addFormValuesManipulator(ilFormValuesManipulator $manipulator) : void
     {
         $this->formValuesManipulationChain[] = $manipulator;
     }
@@ -269,7 +273,7 @@ abstract class ilIdentifiedMultiValuesInputGUI extends ilTextInputGUI implements
         return $elemPostVar;
     }
     
-    public function prepareReprintable(assQuestion $question)
+    public function prepareReprintable(assQuestion $question) : void
     {
         $this->setIdentifiedMultiValues($this->getIdentifiedMultiValues());
     }

--- a/Modules/TestQuestionPool/classes/forms/class.ilImagemapCorrectionsInputGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilImagemapCorrectionsInputGUI.php
@@ -17,7 +17,7 @@ class ilImagemapCorrectionsInputGUI extends ilImagemapFileInputGUI
         $this->setAreasByArray($a_values[$this->getPostVar()]['coords']);
     }
     
-    public function setAreasByArray($a_areas)
+    public function setAreasByArray($a_areas) : void
     {
         if (is_array($a_areas['points'])) {
             foreach ($this->areas as $idx => $name) {

--- a/Modules/TestQuestionPool/classes/forms/class.ilImagemapFileInputGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilImagemapFileInputGUI.php
@@ -35,7 +35,7 @@ class ilImagemapFileInputGUI extends ilImageFileInputGUI
         parent::__construct($a_title, $a_postvar);
     }
     
-    public function setPointsUncheckedFieldEnabled($pointsUncheckedFieldEnabled)
+    public function setPointsUncheckedFieldEnabled($pointsUncheckedFieldEnabled) : void
     {
         $this->pointsUncheckedFieldEnabled = (bool) $pointsUncheckedFieldEnabled;
     }
@@ -45,7 +45,7 @@ class ilImagemapFileInputGUI extends ilImageFileInputGUI
         return $this->pointsUncheckedFieldEnabled;
     }
     
-    public function setAreas($a_areas)
+    public function setAreas($a_areas) : void
     {
         $this->areas = $a_areas;
     }
@@ -55,7 +55,7 @@ class ilImagemapFileInputGUI extends ilImageFileInputGUI
         return $this->line_color;
     }
     
-    public function setLineColor($a_color)
+    public function setLineColor($a_color) : void
     {
         $this->line_color = $a_color;
     }
@@ -65,7 +65,7 @@ class ilImagemapFileInputGUI extends ilImageFileInputGUI
         return $this->image_path;
     }
     
-    public function setImagePath($a_path)
+    public function setImagePath($a_path) : void
     {
         $this->image_path = $a_path;
     }
@@ -75,12 +75,12 @@ class ilImagemapFileInputGUI extends ilImageFileInputGUI
         return $this->image_path_web;
     }
     
-    public function setImagePathWeb($a_path_web)
+    public function setImagePathWeb($a_path_web) : void
     {
         $this->image_path_web = $a_path_web;
     }
     
-    public function setAreasByArray($a_areas)
+    public function setAreasByArray($a_areas) : void
     {
         if (is_array($a_areas['name'])) {
             $this->areas = array();

--- a/Modules/TestQuestionPool/classes/forms/class.ilMultiFilesSubmitRecursiveSlashesStripper.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilMultiFilesSubmitRecursiveSlashesStripper.php
@@ -23,7 +23,7 @@ class ilMultiFilesSubmitRecursiveSlashesStripper implements ilFormValuesManipula
     /**
      * @param string $postVar
      */
-    public function setPostVar($postVar)
+    public function setPostVar($postVar) : void
     {
         $this->postVar = $postVar;
     }
@@ -50,7 +50,7 @@ class ilMultiFilesSubmitRecursiveSlashesStripper implements ilFormValuesManipula
     /**
      * perform the strip slashing on files submit
      */
-    protected function manipulateFileSubmitValues()
+    protected function manipulateFileSubmitValues() : void
     {
         if ($_FILES) {
             $_FILES[$this->getPostVar()] = ilArrayUtil::stripSlashesRecursive(

--- a/Modules/TestQuestionPool/classes/forms/class.ilMultipleImagesAdditionalIndexLevelRemover.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilMultipleImagesAdditionalIndexLevelRemover.php
@@ -18,7 +18,7 @@ class ilMultipleImagesAdditionalIndexLevelRemover implements ilFormValuesManipul
         return $this->postVar;
     }
     
-    public function setPostVar($postVar)
+    public function setPostVar($postVar) : void
     {
         $this->postVar = $postVar;
     }

--- a/Modules/TestQuestionPool/classes/forms/class.ilMultipleImagesFileSubmissionDataCompletion.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilMultipleImagesFileSubmissionDataCompletion.php
@@ -14,7 +14,7 @@ class ilMultipleImagesFileSubmissionDataCompletion implements ilFormValuesManipu
         return $this->postVar;
     }
     
-    public function setPostVar($postVar)
+    public function setPostVar($postVar) : void
     {
         $this->postVar = $postVar;
     }

--- a/Modules/TestQuestionPool/classes/forms/class.ilMultipleImagesInputGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilMultipleImagesInputGUI.php
@@ -73,7 +73,7 @@ abstract class ilMultipleImagesInputGUI extends ilIdentifiedMultiValuesInputGUI
      *
      * @param	array	$a_suffixes	Accepted Suffixes
      */
-    public function setSuffixes($a_suffixes)
+    public function setSuffixes($a_suffixes) : void
     {
         $this->suffixes = $a_suffixes;
     }
@@ -99,7 +99,7 @@ abstract class ilMultipleImagesInputGUI extends ilIdentifiedMultiValuesInputGUI
     /**
      * @param string $imageRemovalCommand
      */
-    public function setImageRemovalCommand($imageRemovalCommand)
+    public function setImageRemovalCommand($imageRemovalCommand) : void
     {
         $this->imageRemovalCommand = $imageRemovalCommand;
     }
@@ -115,7 +115,7 @@ abstract class ilMultipleImagesInputGUI extends ilIdentifiedMultiValuesInputGUI
     /**
      * @param string $imageUploadCommand
      */
-    public function setImageUploadCommand($imageUploadCommand)
+    public function setImageUploadCommand($imageUploadCommand) : void
     {
         $this->imageUploadCommand = $imageUploadCommand;
     }
@@ -131,7 +131,7 @@ abstract class ilMultipleImagesInputGUI extends ilIdentifiedMultiValuesInputGUI
     /**
      * @param	boolean	$editElementOccuranceEnabled
      */
-    public function setEditElementOccuranceEnabled($editElementOccuranceEnabled)
+    public function setEditElementOccuranceEnabled($editElementOccuranceEnabled) : void
     {
         $this->editElementOccuranceEnabled = $editElementOccuranceEnabled;
     }
@@ -147,7 +147,7 @@ abstract class ilMultipleImagesInputGUI extends ilIdentifiedMultiValuesInputGUI
     /**
      * @param boolean $editElementOrderEnabled
      */
-    public function setEditElementOrderEnabled($editElementOrderEnabled)
+    public function setEditElementOrderEnabled($editElementOrderEnabled) : void
     {
         $this->editElementOrderEnabled = $editElementOrderEnabled;
     }

--- a/Modules/TestQuestionPool/classes/forms/class.ilMultipleNestedOrderingElementsInputGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilMultipleNestedOrderingElementsInputGUI.php
@@ -46,7 +46,7 @@ abstract class ilMultipleNestedOrderingElementsInputGUI extends ilIdentifiedMult
         $this->addFormValuesManipulator($manipulator);
     }
 
-    public function setInstanceId($instanceId)
+    public function setInstanceId($instanceId) : void
     {
         $this->instanceId = $instanceId;
     }
@@ -56,7 +56,7 @@ abstract class ilMultipleNestedOrderingElementsInputGUI extends ilIdentifiedMult
         return $this->instanceId;
     }
     
-    public function setInteractionEnabled($interactionEnabled)
+    public function setInteractionEnabled($interactionEnabled) : void
     {
         $this->interactionEnabled = $interactionEnabled;
     }
@@ -71,7 +71,7 @@ abstract class ilMultipleNestedOrderingElementsInputGUI extends ilIdentifiedMult
         return $this->nestingEnabled;
     }
     
-    public function setNestingEnabled($nestingEnabled)
+    public function setNestingEnabled($nestingEnabled) : void
     {
         $this->nestingEnabled = $nestingEnabled;
     }
@@ -81,7 +81,7 @@ abstract class ilMultipleNestedOrderingElementsInputGUI extends ilIdentifiedMult
         return $this->stylingDisabled;
     }
     
-    public function setStylingDisabled($stylingDisabled)
+    public function setStylingDisabled($stylingDisabled) : void
     {
         $this->stylingDisabled = $stylingDisabled;
     }
@@ -102,7 +102,7 @@ abstract class ilMultipleNestedOrderingElementsInputGUI extends ilIdentifiedMult
     /**
      * @param string $cssListClass
      */
-    public function setCssListClass($cssListClass)
+    public function setCssListClass($cssListClass) : void
     {
         $this->cssListClass = $cssListClass;
     }
@@ -126,7 +126,7 @@ abstract class ilMultipleNestedOrderingElementsInputGUI extends ilIdentifiedMult
     /**
      * @param string $cssHandleClass
      */
-    public function setCssHandleClass($cssHandleClass)
+    public function setCssHandleClass($cssHandleClass) : void
     {
         $this->cssHandleClass = $cssHandleClass;
     }
@@ -134,7 +134,7 @@ abstract class ilMultipleNestedOrderingElementsInputGUI extends ilIdentifiedMult
     /**
      * @param string $cssItemClass
      */
-    public function setCssItemClass($cssItemClass)
+    public function setCssItemClass($cssItemClass) : void
     {
         $this->cssItemClass = $cssItemClass;
     }
@@ -150,7 +150,7 @@ abstract class ilMultipleNestedOrderingElementsInputGUI extends ilIdentifiedMult
     /**
      * @param string $htmlListTag
      */
-    public function setHtmlListTag($htmlListTag)
+    public function setHtmlListTag($htmlListTag) : void
     {
         $this->htmlListTag = $htmlListTag;
     }
@@ -165,12 +165,12 @@ abstract class ilMultipleNestedOrderingElementsInputGUI extends ilIdentifiedMult
         return $this->listTpl;
     }
     
-    public function setListTpl($listTpl)
+    public function setListTpl($listTpl) : void
     {
         $this->listTpl = $listTpl;
     }
     
-    protected function initListTemplate()
+    protected function initListTemplate() : void
     {
         $this->setListTpl(
             new ilTemplate('tpl.prop_nested_ordering_list.html', true, true, 'Services/Form')
@@ -182,20 +182,20 @@ abstract class ilMultipleNestedOrderingElementsInputGUI extends ilIdentifiedMult
         return $this->getListTpl()->get();
     }
     
-    protected function renderListContainer()
+    protected function renderListContainer() : void
     {
         $this->getListTpl()->setCurrentBlock('list_container');
         $this->getListTpl()->setVariable('INSTANCE_ID', $this->getInstanceId());
         $this->getListTpl()->parseCurrentBlock();
     }
     
-    protected function renderListSnippet()
+    protected function renderListSnippet() : void
     {
         $this->getListTpl()->setCurrentBlock('list_snippet');
         $this->getListTpl()->parseCurrentBlock();
     }
 
-    protected function renderListItem($value, $identifier, $position)
+    protected function renderListItem($value, $identifier, $position) : void
     {
         $subPostVar = $this->getMultiValuePostVarSubField($identifier, self::POSTVAR_SUBFIELD_NEST_ELEM);
         $subFieldId = $this->getMultiValueSubFieldId($identifier, self::POSTVAR_SUBFIELD_NEST_ELEM);
@@ -227,7 +227,7 @@ abstract class ilMultipleNestedOrderingElementsInputGUI extends ilIdentifiedMult
      */
     abstract protected function getItemHtml($value, $identifier, $position, $itemSubFieldPostVar, $itemSubFieldId);
     
-    protected function renderBeginListItem($identifier)
+    protected function renderBeginListItem($identifier) : void
     {
         $this->getListTpl()->setCurrentBlock('begin_list_item');
         $this->getListTpl()->setVariable('LIST_ITEM_ID', $identifier);
@@ -236,7 +236,7 @@ abstract class ilMultipleNestedOrderingElementsInputGUI extends ilIdentifiedMult
         $this->renderListSnippet();
     }
     
-    protected function renderEndListItem()
+    protected function renderEndListItem() : void
     {
         $this->getListTpl()->setCurrentBlock('end_list_item');
         $this->getListTpl()->touchBlock('end_list_item');
@@ -244,7 +244,7 @@ abstract class ilMultipleNestedOrderingElementsInputGUI extends ilIdentifiedMult
         $this->renderListSnippet();
     }
     
-    protected function renderBeginSubList()
+    protected function renderBeginSubList() : void
     {
         $this->getListTpl()->setCurrentBlock('begin_sublist');
         $this->getListTpl()->setVariable('BEGIN_HTML_LIST_TAG', $this->getHtmlListTag());
@@ -253,7 +253,7 @@ abstract class ilMultipleNestedOrderingElementsInputGUI extends ilIdentifiedMult
         $this->renderListSnippet();
     }
     
-    protected function renderEndSubList()
+    protected function renderEndSubList() : void
     {
         $this->getListTpl()->setCurrentBlock('end_sublist');
         $this->getListTpl()->setVariable('END_HTML_LIST_TAG', $this->getHtmlListTag());

--- a/Modules/TestQuestionPool/classes/forms/class.ilMultipleTextsInputGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilMultipleTextsInputGUI.php
@@ -44,7 +44,7 @@ abstract class ilMultipleTextsInputGUI extends ilIdentifiedMultiValuesInputGUI
     /**
      * @param	boolean	$editElementOccuranceEnabled
      */
-    public function setEditElementOccuranceEnabled($editElementOccuranceEnabled)
+    public function setEditElementOccuranceEnabled($editElementOccuranceEnabled) : void
     {
         $this->editElementOccuranceEnabled = $editElementOccuranceEnabled;
     }
@@ -60,7 +60,7 @@ abstract class ilMultipleTextsInputGUI extends ilIdentifiedMultiValuesInputGUI
     /**
      * @param boolean $editElementOrderEnabled
      */
-    public function setEditElementOrderEnabled($editElementOrderEnabled)
+    public function setEditElementOrderEnabled($editElementOrderEnabled) : void
     {
         $this->editElementOrderEnabled = $editElementOrderEnabled;
     }

--- a/Modules/TestQuestionPool/classes/forms/class.ilTagInputGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilTagInputGUI.php
@@ -41,7 +41,7 @@ class ilTagInputGUI extends ilSubEnabledFormPropertyGUI
     /**
      * @param int $max_tags
      */
-    public function setMaxTags($max_tags)
+    public function setMaxTags($max_tags) : void
     {
         $this->max_tags = $max_tags;
     }
@@ -49,7 +49,7 @@ class ilTagInputGUI extends ilSubEnabledFormPropertyGUI
     /**
      * @param int $max_chars
      */
-    public function setMaxChars($max_chars)
+    public function setMaxChars($max_chars) : void
     {
         $this->max_chars = $max_chars;
     }
@@ -57,7 +57,7 @@ class ilTagInputGUI extends ilSubEnabledFormPropertyGUI
     /**
      * @param boolean $allow_duplicates
      */
-    public function setAllowDuplicates($allow_duplicates)
+    public function setAllowDuplicates($allow_duplicates) : void
     {
         $this->allow_duplicates = $allow_duplicates;
     }
@@ -65,7 +65,7 @@ class ilTagInputGUI extends ilSubEnabledFormPropertyGUI
     /**
      * @param boolean $js_self_init
      */
-    public function setJsSelfInit($js_self_init)
+    public function setJsSelfInit($js_self_init) : void
     {
         $this->js_self_init = $js_self_init;
     }
@@ -73,7 +73,7 @@ class ilTagInputGUI extends ilSubEnabledFormPropertyGUI
     /**
      * @param boolean $type_ahead
      */
-    public function setTypeAhead($type_ahead)
+    public function setTypeAhead($type_ahead) : void
     {
         $this->type_ahead = $type_ahead;
     }
@@ -81,7 +81,7 @@ class ilTagInputGUI extends ilSubEnabledFormPropertyGUI
     /**
      * @param boolean $type_ahead_ignore_case
      */
-    public function setTypeAheadIgnoreCase($type_ahead_ignore_case)
+    public function setTypeAheadIgnoreCase($type_ahead_ignore_case) : void
     {
         $this->type_ahead_ignore_case = $type_ahead_ignore_case;
     }
@@ -89,7 +89,7 @@ class ilTagInputGUI extends ilSubEnabledFormPropertyGUI
     /**
      * @param int $min_length
      */
-    public function setTypeAheadMinLength($min_length)
+    public function setTypeAheadMinLength($min_length) : void
     {
         $this->type_ahead_min_length = $min_length;
     }
@@ -97,7 +97,7 @@ class ilTagInputGUI extends ilSubEnabledFormPropertyGUI
     /**
      * @param int $limit
      */
-    public function setTypeAheadLimit($limit)
+    public function setTypeAheadLimit($limit) : void
     {
         $this->type_ahead_limit = $limit;
     }
@@ -105,7 +105,7 @@ class ilTagInputGUI extends ilSubEnabledFormPropertyGUI
     /**
      * @param boolean $highlight
      */
-    public function setTypeAheadHighlight($highlight)
+    public function setTypeAheadHighlight($highlight) : void
     {
         $this->type_ahead_highlight = $highlight;
     }
@@ -113,7 +113,7 @@ class ilTagInputGUI extends ilSubEnabledFormPropertyGUI
     /**
      * @param array $type_ahead_list
      */
-    public function setTypeAheadList($type_ahead_list)
+    public function setTypeAheadList($type_ahead_list) : void
     {
         $this->type_ahead_list = $type_ahead_list;
     }
@@ -123,7 +123,7 @@ class ilTagInputGUI extends ilSubEnabledFormPropertyGUI
      *
      * @param	array	$a_options	Options.
      */
-    public function setOptions($a_options)
+    public function setOptions($a_options) : void
     {
         $this->options = $a_options;
     }
@@ -163,7 +163,7 @@ class ilTagInputGUI extends ilSubEnabledFormPropertyGUI
     *
     * @param	array	$a_values	value array
     */
-    public function setValueByArray($a_values)
+    public function setValueByArray($a_values) : void
     {
         $this->setOptions($a_values[$this->getPostVar()]);
         foreach ($this->getSubItems() as $item) {
@@ -244,7 +244,7 @@ class ilTagInputGUI extends ilSubEnabledFormPropertyGUI
     /**
      * @param $a_tpl
      */
-    public function insert($a_tpl)
+    public function insert($a_tpl) : void
     {
         $a_tpl->setCurrentBlock("prop_generic");
         $a_tpl->setVariable("PROP_GENERIC", $this->render());

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assClozeTestImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assClozeTestImport.php
@@ -27,7 +27,7 @@ class assClozeTestImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping)
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping) : void
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assErrorTextImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assErrorTextImport.php
@@ -25,7 +25,7 @@ class assErrorTextImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping)
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping) : void
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assFileUploadImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assFileUploadImport.php
@@ -25,7 +25,7 @@ class assFileUploadImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping)
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping) : void
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assFlashQuestionImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assFlashQuestionImport.php
@@ -25,7 +25,7 @@ class assFlashQuestionImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping)
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping) : void
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assFormulaQuestionImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assFormulaQuestionImport.php
@@ -27,7 +27,7 @@ class assFormulaQuestionImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping)
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping) : void
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assImagemapQuestionImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assImagemapQuestionImport.php
@@ -27,7 +27,7 @@ class assImagemapQuestionImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping)
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping) : void
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assKprimChoiceImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assKprimChoiceImport.php
@@ -17,7 +17,7 @@ class assKprimChoiceImport extends assQuestionImport
      */
     public $object;
     
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping)
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping) : void
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assLongMenuImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assLongMenuImport.php
@@ -6,7 +6,7 @@ class assLongMenuImport extends assQuestionImport
 {
     public $object;
 
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping)
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping) : void
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assMatchingQuestionImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assMatchingQuestionImport.php
@@ -14,7 +14,7 @@ include_once "./Modules/TestQuestionPool/classes/import/qti12/class.assQuestionI
 */
 class assMatchingQuestionImport extends assQuestionImport
 {
-    public function saveImage($data, $filename)
+    public function saveImage($data, $filename) : void
     {
         $image = base64_decode($data);
         $imagepath = $this->object->getImagePath();
@@ -44,7 +44,7 @@ class assMatchingQuestionImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping)
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping) : void
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assMultipleChoiceImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assMultipleChoiceImport.php
@@ -27,7 +27,7 @@ class assMultipleChoiceImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping)
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping) : void
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assNumericImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assNumericImport.php
@@ -27,7 +27,7 @@ class assNumericImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping)
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping) : void
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assOrderingHorizontalImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assOrderingHorizontalImport.php
@@ -27,7 +27,7 @@ class assOrderingHorizontalImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping)
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping) : void
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assOrderingQuestionImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assOrderingQuestionImport.php
@@ -32,7 +32,7 @@ class assOrderingQuestionImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping)
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping) : void
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assQuestionImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assQuestionImport.php
@@ -162,14 +162,14 @@ class assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping)
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping) : void
     {
     }
 
     /**
      * @param ilQTIItem $item
      */
-    protected function addGeneralMetadata(ilQTIItem $item)
+    protected function addGeneralMetadata(ilQTIItem $item) : void
     {
         if ($item->getMetadataEntry('externalID')) {
             $this->object->setExternalId($item->getMetadataEntry('externalID'));

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assSingleChoiceImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assSingleChoiceImport.php
@@ -27,7 +27,7 @@ class assSingleChoiceImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping)
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping) : void
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assTextQuestionImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assTextQuestionImport.php
@@ -32,7 +32,7 @@ class assTextQuestionImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping)
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping) : void
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];
@@ -226,7 +226,7 @@ class assTextQuestionImport extends assQuestionImport
         }
     }
     
-    protected function fetchTermScoring($item)
+    protected function fetchTermScoring($item) : array
     {
         $termScoringString = $item->getMetadataEntry('termscoring');
         

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assTextSubsetImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assTextSubsetImport.php
@@ -27,7 +27,7 @@ class assTextSubsetImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping)
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping) : void
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];

--- a/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacAbstractExpression.php
+++ b/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacAbstractExpression.php
@@ -28,7 +28,7 @@ abstract class ilAssLacAbstractExpression extends ilAssLacAbstractComposite impl
      *
      * @param string $value
      */
-    public function parseValue($value)
+    public function parseValue($value) : void
     {
         $result = array();
         preg_match_all($this->getPattern(), $value, $result);

--- a/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacAnswerOfCurrentQuestionExpression.php
+++ b/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacAnswerOfCurrentQuestionExpression.php
@@ -35,7 +35,7 @@ class ilAssLacAnswerOfCurrentQuestionExpression extends ilAssLacAbstractExpressi
      *
      * @param array $matches
      */
-    protected function setMatches($matches)
+    protected function setMatches($matches) : void
     {
     }
 

--- a/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacAnswerOfQuestionExpression.php
+++ b/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacAnswerOfQuestionExpression.php
@@ -48,7 +48,7 @@ class ilAssLacAnswerOfQuestionExpression extends ilAssLacAbstractExpression impl
      *
      * @param array $matches
      */
-    protected function setMatches($matches)
+    protected function setMatches($matches) : void
     {
         $this->question_index = $matches[0][0];
     }

--- a/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacEmptyAnswerExpression.php
+++ b/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacEmptyAnswerExpression.php
@@ -86,7 +86,7 @@ class ilAssLacEmptyAnswerExpression extends ilAssLacAbstractExpression implement
      *
      * @param array $matches
      */
-    protected function setMatches($matches)
+    protected function setMatches($matches) : void
     {
         $this->matched = true;
     }

--- a/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacExclusiveResultExpression.php
+++ b/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacExclusiveResultExpression.php
@@ -49,7 +49,7 @@ class ilAssLacExclusiveResultExpression extends ilAssLacAbstractExpression imple
      *
      * @param array $matches
      */
-    protected function setMatches($matches)
+    protected function setMatches($matches) : void
     {
         $this->exclusive = array();
 

--- a/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacMatchingResultExpression.php
+++ b/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacMatchingResultExpression.php
@@ -57,7 +57,7 @@ class ilAssLacMatchingResultExpression extends ilAssLacAbstractExpression implem
      *
      * @param array $matches
      */
-    protected function setMatches($matches)
+    protected function setMatches($matches) : void
     {
         $this->left_numeric_value = $matches[1][0];
         $this->right_numeric_value = $matches[2][0];

--- a/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacNumberOfResultExpression.php
+++ b/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacNumberOfResultExpression.php
@@ -44,7 +44,7 @@ class ilAssLacNumberOfResultExpression extends ilAssLacAbstractExpression implem
      *
      * @param array $matches
      */
-    protected function setMatches($matches)
+    protected function setMatches($matches) : void
     {
         $this->numeric_value = $matches[0][0];
     }

--- a/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacNumericResultExpression.php
+++ b/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacNumericResultExpression.php
@@ -44,7 +44,7 @@ class ilAssLacNumericResultExpression extends ilAssLacAbstractExpression impleme
      *
      * @param array $matches
      */
-    protected function setMatches($matches)
+    protected function setMatches($matches) : void
     {
         $this->numeric_value = $matches[0][0];
     }

--- a/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacOrderingResultExpression.php
+++ b/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacOrderingResultExpression.php
@@ -48,7 +48,7 @@ class ilAssLacOrderingResultExpression extends ilAssLacAbstractExpression implem
      *
      * @param array $matches
      */
-    protected function setMatches($matches)
+    protected function setMatches($matches) : void
     {
         $this->ordering = array();
 

--- a/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacPercentageResultExpression.php
+++ b/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacPercentageResultExpression.php
@@ -44,7 +44,7 @@ class ilAssLacPercentageResultExpression extends ilAssLacAbstractExpression impl
      *
      * @param array $matches
      */
-    protected function setMatches($matches)
+    protected function setMatches($matches) : void
     {
         $this->numeric_value = $matches[0][0];
     }

--- a/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacResultOfAnswerOfCurrentQuestionExpression.php
+++ b/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacResultOfAnswerOfCurrentQuestionExpression.php
@@ -53,7 +53,7 @@ class ilAssLacResultOfAnswerOfCurrentQuestionExpression extends ilAssLacAbstract
      *
      * @param array $matches
      */
-    protected function setMatches($matches)
+    protected function setMatches($matches) : void
     {
         $this->answer_index = $matches[1][0];
     }

--- a/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacResultOfAnswerOfQuestionExpression.php
+++ b/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacResultOfAnswerOfQuestionExpression.php
@@ -61,7 +61,7 @@ class ilAssLacResultOfAnswerOfQuestionExpression extends ilAssLacAbstractExpress
      *
      * @param array $matches
      */
-    protected function setMatches($matches)
+    protected function setMatches($matches) : void
     {
         $this->question_index = $matches[1][0];
         $this->answer_index = $matches[2][0];

--- a/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacStringResultExpression.php
+++ b/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacStringResultExpression.php
@@ -54,7 +54,7 @@ class ilAssLacStringResultExpression extends ilAssLacAbstractExpression implemen
      *
      * @param array $matches
      */
-    protected function setMatches($matches)
+    protected function setMatches($matches) : void
     {
         $this->text = $matches[1][0];
     }

--- a/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Operations/ilAssLacAbstractOperation.php
+++ b/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Operations/ilAssLacAbstractOperation.php
@@ -25,7 +25,7 @@ abstract class ilAssLacAbstractOperation extends ilAssLacAbstractComposite
     /**
      * @param boolean $negated
      */
-    public function setNegated($negated)
+    public function setNegated($negated) : void
     {
         $this->negated = $negated;
     }

--- a/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/class.ilAssQuestionTypeList.php
+++ b/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/class.ilAssQuestionTypeList.php
@@ -33,7 +33,7 @@ class ilAssQuestionTypeList implements Iterator
         $this->db = $DIC['ilDB'];
     }
     
-    public function load()
+    public function load() : void
     {
         $res = $this->db->query("SELECT * FROM qpl_qst_type");
         

--- a/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacAbstractComposite.php
+++ b/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacAbstractComposite.php
@@ -22,7 +22,7 @@ abstract class ilAssLacAbstractComposite implements ilAssLacCompositeInterface
      *
      * @param ilAssLacCompositeInterface $node
      */
-    public function addNode(ilAssLacCompositeInterface $node)
+    public function addNode(ilAssLacCompositeInterface $node) : void
     {
         $this->nodes[] = $node;
     }

--- a/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacCompositeValidator.php
+++ b/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacCompositeValidator.php
@@ -44,7 +44,7 @@ class ilAssLacCompositeValidator
         $this->randomGroup = $DIC->refinery()->random();
     }
 
-    public function validate(ilAssLacAbstractComposite $composite)
+    public function validate(ilAssLacAbstractComposite $composite) : void
     {
         if (count($composite->nodes) > 0) {
             $this->validate($composite->nodes[0]);
@@ -55,7 +55,7 @@ class ilAssLacCompositeValidator
         return;
     }
 
-    private function validateSubTree(ilAssLacAbstractComposite $composite)
+    private function validateSubTree(ilAssLacAbstractComposite $composite) : void
     {
         if ($composite->nodes[0] instanceof ilAssLacQuestionExpressionInterface &&
             $composite->nodes[1] instanceof ilAssLacSolutionExpressionInterface
@@ -131,7 +131,7 @@ class ilAssLacCompositeValidator
      *
      * @throws ilAssLacAnswerValueNotExist
      */
-    private function validateClozeTest($answer_index, $question, $answer_expression, $question_index)
+    private function validateClozeTest($answer_index, $question, $answer_expression, $question_index) : void
     {
         if ($answer_index !== null) {
             $options = $question->getAvailableAnswerOptions($answer_index);
@@ -184,7 +184,7 @@ class ilAssLacCompositeValidator
      *
      * @throws ilAssLacAnswerIndexNotExist
      */
-    private function checkIfAnswerIndexOfQuestionExists($question, $question_index, $answer_index)
+    private function checkIfAnswerIndexOfQuestionExists($question, $question_index, $answer_index) : void
     {
         $answer_options = $question->getAvailableAnswerOptions($answer_index);
         if ($answer_options == null) {
@@ -198,7 +198,7 @@ class ilAssLacCompositeValidator
      *
      * @throws ilAssLacQuestionNotExist
      */
-    private function checkQuestionExists($question, $index)
+    private function checkQuestionExists($question, $index) : void
     {
         if ($question == null) {
             throw new ilAssLacQuestionNotExist($index);
@@ -232,7 +232,7 @@ class ilAssLacCompositeValidator
      *
      * @throws ilAssLacExpressionNotSupportedByQuestion
      */
-    private function checkAnswerExpressionExist($expressions, $answer_expression, $question_index)
+    private function checkAnswerExpressionExist($expressions, $answer_expression, $question_index) : void
     {
         if (!in_array($answer_expression::$identifier, $expressions)) {
             throw new ilAssLacExpressionNotSupportedByQuestion($answer_expression->getValue(), $question_index);
@@ -246,7 +246,7 @@ class ilAssLacCompositeValidator
      *
      * @throws ilAssLacOperatorNotSupportedByExpression
      */
-    private function checkOperatorExistForExpression($operators, $answer_expression, $pattern)
+    private function checkOperatorExistForExpression($operators, $answer_expression, $pattern) : void
     {
         if (!in_array($pattern, $operators)) {
             throw new ilAssLacOperatorNotSupportedByExpression($answer_expression->getValue(), $pattern);

--- a/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacConditionParser.php
+++ b/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacConditionParser.php
@@ -88,7 +88,7 @@ class ilAssLacConditionParser
      * @see ExpressionManufacturer::getPattern()
      * @see Parser::$expressions
      */
-    protected function fetchExpressions()
+    protected function fetchExpressions() : void
     {
         $manufacturer = ilAssLacExpressionManufacturer::_getInstance();
         $this->expressions = $manufacturer->match($this->condition);
@@ -101,7 +101,7 @@ class ilAssLacConditionParser
      * @see OperationManufacturer::getPattern()
      * @see Parser::$operators
      */
-    protected function fetchOperators()
+    protected function fetchOperators() : void
     {
         $manufacturer = ilAssLacOperationManufacturer::_getInstance();
         $this->operators = $manufacturer->match($this->condition);
@@ -114,7 +114,7 @@ class ilAssLacConditionParser
      * <br />
      * (n o n) o (n o n) o n
      */
-    protected function cannonicalizeCondition()
+    protected function cannonicalizeCondition() : void
     {
         $manufacturer = ilAssLacExpressionManufacturer::_getInstance();
         $this->condition = preg_replace($manufacturer->getPattern(), 'n', $this->condition);
@@ -130,7 +130,7 @@ class ilAssLacConditionParser
         }
     }
 
-    protected function checkBrackets()
+    protected function checkBrackets() : void
     {
         $num_brackets_open = substr_count($this->condition, "(");
         $num_brackets_close = substr_count($this->condition, ")");
@@ -213,7 +213,7 @@ class ilAssLacConditionParser
     /**
      * @param int $index
      */
-    protected function surroundNegationExpression($index)
+    protected function surroundNegationExpression($index) : void
     {
         $start = strpos($this->condition, "n", $index + 1);
         $end = false;

--- a/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacQuestionProvider.php
+++ b/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacQuestionProvider.php
@@ -24,7 +24,7 @@ class ilAssLacQuestionProvider
     /**
      * @param integer $questionId
      */
-    public function setQuestionId($questionId)
+    public function setQuestionId($questionId) : void
     {
         $this->questionId = $questionId;
     }
@@ -32,7 +32,7 @@ class ilAssLacQuestionProvider
     /**
      * @param iQuestionCondition $question
      */
-    public function setQuestion(iQuestionCondition $question)
+    public function setQuestion(iQuestionCondition $question) : void
     {
         $this->question = $question;
     }

--- a/Modules/TestQuestionPool/classes/questions/class.ilAssFileUploadFileTableCommandButton.php
+++ b/Modules/TestQuestionPool/classes/questions/class.ilAssFileUploadFileTableCommandButton.php
@@ -50,7 +50,7 @@ class ilAssFileUploadFileTableCommandButton extends ilSubmitButton
     /**
      * @param string $action
      */
-    public function setAction($action)
+    public function setAction($action) : void
     {
         $this->action = $action;
     }

--- a/Modules/TestQuestionPool/classes/questions/class.ilAssOrderingElement.php
+++ b/Modules/TestQuestionPool/classes/questions/class.ilAssOrderingElement.php
@@ -135,7 +135,7 @@ class ilAssOrderingElement
     /**
      * @param int $id
      */
-    public function setId($id)
+    public function setId($id) : void
     {
         $this->id = $id;
     }
@@ -151,7 +151,7 @@ class ilAssOrderingElement
     /**
      * @param $randomIdentifier
      */
-    public function setRandomIdentifier($randomIdentifier)
+    public function setRandomIdentifier($randomIdentifier) : void
     {
         $this->randomIdentifier = $randomIdentifier;
     }
@@ -167,7 +167,7 @@ class ilAssOrderingElement
     /**
      * @param int $solutionIdentifier
      */
-    public function setSolutionIdentifier($solutionIdentifier)
+    public function setSolutionIdentifier($solutionIdentifier) : void
     {
         $this->solutionIdentifier = $solutionIdentifier;
     }
@@ -175,7 +175,7 @@ class ilAssOrderingElement
     /**
      * @param int $indentation
      */
-    public function setIndentation($indentation)
+    public function setIndentation($indentation) : void
     {
         $this->indentation = $indentation;
     }
@@ -199,7 +199,7 @@ class ilAssOrderingElement
     /**
      * @param int $position
      */
-    public function setPosition($position)
+    public function setPosition($position) : void
     {
         $this->position = $position;
     }
@@ -215,7 +215,7 @@ class ilAssOrderingElement
     /**
      * @param string $content
      */
-    public function setContent($content)
+    public function setContent($content) : void
     {
         $this->content = $content;
     }
@@ -231,7 +231,7 @@ class ilAssOrderingElement
     /**
      * @param string $uploadImageFile
      */
-    public function setUploadImageFile($uploadImageFile)
+    public function setUploadImageFile($uploadImageFile) : void
     {
         $this->uploadImageFile = $uploadImageFile;
     }
@@ -247,7 +247,7 @@ class ilAssOrderingElement
     /**
      * @param string $uploadImageName
      */
-    public function setUploadImageName($uploadImageName)
+    public function setUploadImageName($uploadImageName) : void
     {
         $this->uploadImageName = $uploadImageName;
     }
@@ -271,7 +271,7 @@ class ilAssOrderingElement
     /**
      * @param bool $imageRemovalRequest
      */
-    public function setImageRemovalRequest($imageRemovalRequest)
+    public function setImageRemovalRequest($imageRemovalRequest) : void
     {
         $this->imageRemovalRequest = $imageRemovalRequest;
     }
@@ -287,7 +287,7 @@ class ilAssOrderingElement
     /**
      * @param string $imagePathWeb
      */
-    public function setImagePathWeb($imagePathWeb)
+    public function setImagePathWeb($imagePathWeb) : void
     {
         $this->imagePathWeb = $imagePathWeb;
     }
@@ -303,7 +303,7 @@ class ilAssOrderingElement
     /**
      * @param string $imagePathFs
      */
-    public function setImagePathFs($imagePathFs)
+    public function setImagePathFs($imagePathFs) : void
     {
         $this->imagePathFs = $imagePathFs;
     }
@@ -313,7 +313,7 @@ class ilAssOrderingElement
         return $this->imageThumbnailPrefix;
     }
     
-    public function setImageThumbnailPrefix($imageThumbnailPrefix)
+    public function setImageThumbnailPrefix($imageThumbnailPrefix) : void
     {
         $this->imageThumbnailPrefix = $imageThumbnailPrefix;
     }
@@ -472,7 +472,7 @@ class ilAssOrderingElement
         return true;
     }
     
-    public function setExportIdent($ident)
+    public function setExportIdent($ident) : void
     {
         if ($this->isExportIdent($ident)) {
             list($randomId, $solutionId, $pos, $indent) = explode(

--- a/Modules/TestQuestionPool/classes/questions/class.ilAssOrderingElementList.php
+++ b/Modules/TestQuestionPool/classes/questions/class.ilAssOrderingElementList.php
@@ -94,7 +94,7 @@ class ilAssOrderingElementList implements Iterator
     /**
      * @param integer $questionId
      */
-    public function setQuestionId($questionId)
+    public function setQuestionId($questionId) : void
     {
         $this->questionId = $questionId;
     }
@@ -102,7 +102,7 @@ class ilAssOrderingElementList implements Iterator
     /**
      * load elements from database
      */
-    public function loadFromDb()
+    public function loadFromDb() : void
     {
         global $DIC; /* @var ILIAS\DI\Container $DIC */
         $ilDB = $DIC['ilDB'];
@@ -132,7 +132,7 @@ class ilAssOrderingElementList implements Iterator
     /**
      * TODO: refactor to a select/update/insert strategy incl. deleting all except existing
      */
-    public function saveToDb()
+    public function saveToDb() : void
     {
         /** @var ilDBInterface $ilDB */
         $ilDB = isset($GLOBALS['DIC']) ? $GLOBALS['DIC']['ilDB'] : $GLOBALS['DIC']['ilDB'];
@@ -162,7 +162,7 @@ class ilAssOrderingElementList implements Iterator
     /**
      * clears the contents of all elements
      */
-    public function clearElementContents()
+    public function clearElementContents() : void
     {
         foreach ($this as $orderingElement) {
             $orderingElement->setContent('');
@@ -189,7 +189,7 @@ class ilAssOrderingElementList implements Iterator
         return $position == ($this->countElements() - 1);
     }
     
-    public function moveElementByPositions($currentPosition, $targetPosition)
+    public function moveElementByPositions($currentPosition, $targetPosition) : void
     {
         $movingElement = $this->getElementByPosition($currentPosition);
         $dodgingElement = $this->getElementByPosition($targetPosition);
@@ -217,7 +217,7 @@ class ilAssOrderingElementList implements Iterator
         $this->setElements($elementList->getElements());
     }
     
-    public function removeElement(ilAssOrderingElement $removeElement)
+    public function removeElement(ilAssOrderingElement $removeElement) : void
     {
         $elementList = new self();
         $elementList->setQuestionId($this->getQuestionId());
@@ -237,7 +237,7 @@ class ilAssOrderingElementList implements Iterator
     /**
      * resets elements
      */
-    public function resetElements()
+    public function resetElements() : void
     {
         $this->elements = array();
     }
@@ -245,7 +245,7 @@ class ilAssOrderingElementList implements Iterator
     /**
      * @param $elements
      */
-    public function setElements($elements)
+    public function setElements($elements) : void
     {
         $this->resetElements();
         
@@ -311,7 +311,7 @@ class ilAssOrderingElementList implements Iterator
     /**
      * @param ilAssOrderingElement $element
      */
-    public function addElement(ilAssOrderingElement $element)
+    public function addElement(ilAssOrderingElement $element) : void
     {
         if ($this->hasValidIdentifiers($element)) {
             $this->registerIdentifiers($element);
@@ -446,7 +446,7 @@ class ilAssOrderingElementList implements Iterator
     /**
      * @param ilAssOrderingElement $element
      */
-    protected function ensureValidIdentifiers(ilAssOrderingElement $element)
+    protected function ensureValidIdentifiers(ilAssOrderingElement $element) : void
     {
         $this->ensureValidIdentifier($element, self::IDENTIFIER_TYPE_SOLUTION);
         $this->ensureValidIdentifier($element, self::IDENTIFIER_TYPE_RANDOM);
@@ -456,7 +456,7 @@ class ilAssOrderingElementList implements Iterator
      * @param ilAssOrderingElement $element
      * @param string $identifierType
      */
-    protected function ensureValidIdentifier(ilAssOrderingElement $element, $identifierType)
+    protected function ensureValidIdentifier(ilAssOrderingElement $element, $identifierType) : void
     {
         $identifier = $this->fetchIdentifier($element, $identifierType);
         
@@ -470,7 +470,7 @@ class ilAssOrderingElementList implements Iterator
     /**
      * @param ilAssOrderingElement $element
      */
-    protected function registerIdentifiers(ilAssOrderingElement $element)
+    protected function registerIdentifiers(ilAssOrderingElement $element) : void
     {
         $this->registerIdentifier($element, self::IDENTIFIER_TYPE_SOLUTION);
         $this->registerIdentifier($element, self::IDENTIFIER_TYPE_RANDOM);
@@ -481,7 +481,7 @@ class ilAssOrderingElementList implements Iterator
      * @param string $identifierType
      * @throws ilTestQuestionPoolException
      */
-    protected function registerIdentifier(ilAssOrderingElement $element, $identifierType)
+    protected function registerIdentifier(ilAssOrderingElement $element, $identifierType) : void
     {
         if (!isset(self::$identifierRegistry[$identifierType][$this->getQuestionId()])) {
             self::$identifierRegistry[$identifierType][$this->getQuestionId()] = array();
@@ -538,7 +538,7 @@ class ilAssOrderingElementList implements Iterator
      * @param $identifier
      * @throws ilTestQuestionPoolException
      */
-    protected function populateIdentifier(ilAssOrderingElement $element, $identifierType, $identifier)
+    protected function populateIdentifier(ilAssOrderingElement $element, $identifierType, $identifier) : void
     {
         switch ($identifierType) {
             case self::IDENTIFIER_TYPE_SOLUTION: $element->setSolutionIdentifier($identifier); break;
@@ -578,7 +578,7 @@ class ilAssOrderingElementList implements Iterator
      * @param string $identifierType
      * @throws ilTestQuestionPoolException
      */
-    protected function throwUnknownIdentifierTypeException($identifierType)
+    protected function throwUnknownIdentifierTypeException($identifierType) : void
     {
         throw new ilTestQuestionPoolException(
             "unknown identifier type given (type: $identifierType)"
@@ -589,7 +589,7 @@ class ilAssOrderingElementList implements Iterator
      * @param string $identifierType
      * @throws ilTestQuestionPoolException
      */
-    protected function throwCouldNotBuildRandomIdentifierException($maxTries)
+    protected function throwCouldNotBuildRandomIdentifierException($maxTries) : void
     {
         throw new ilTestQuestionPoolException(
             "could not build random identifier (max tries: $maxTries)"
@@ -600,7 +600,7 @@ class ilAssOrderingElementList implements Iterator
      * @param string $randomIdentifier
      * @throws ilTestQuestionPoolException
      */
-    protected function throwMissingReorderPositionException($randomIdentifier)
+    protected function throwMissingReorderPositionException($randomIdentifier) : void
     {
         throw new ilTestQuestionPoolException(
             "cannot reorder element due to missing position (random identifier: $randomIdentifier)"
@@ -611,7 +611,7 @@ class ilAssOrderingElementList implements Iterator
      * @param array $randomIdentifiers
      * @throws ilTestQuestionPoolException
      */
-    protected function throwUnknownRandomIdentifiersException($randomIdentifiers)
+    protected function throwUnknownRandomIdentifiersException($randomIdentifiers) : void
     {
         throw new ilTestQuestionPoolException(
             'cannot reorder element due to one or more unknown random identifiers ' .
@@ -730,7 +730,7 @@ class ilAssOrderingElementList implements Iterator
     /**
      *
      */
-    public function distributeNewRandomIdentifiers()
+    public function distributeNewRandomIdentifiers() : void
     {
         foreach ($this as $element) {
             $element->setRandomIdentifier($this->buildRandomIdentifier());
@@ -811,7 +811,7 @@ class ilAssOrderingElementList implements Iterator
      * @param $randomIdentifiers
      * @throws ilTestQuestionPoolException
      */
-    public function reorderByRandomIdentifiers($randomIdentifiers)
+    public function reorderByRandomIdentifiers($randomIdentifiers) : void
     {
         $positionsMap = array_flip(array_values($randomIdentifiers));
         
@@ -841,7 +841,7 @@ class ilAssOrderingElementList implements Iterator
     /**
      * resets the indentation to level 0 for all elements in list
      */
-    public function resetElementsIndentations()
+    public function resetElementsIndentations() : void
     {
         foreach ($this as $element) {
             $element->setIndentation(0);
@@ -884,7 +884,7 @@ class ilAssOrderingElementList implements Iterator
     /**
      * @param ilAssOrderingElementList $otherList
      */
-    public function completeContentsFromElementList(self $otherList)
+    public function completeContentsFromElementList(self $otherList) : void
     {
         foreach ($this as $thisElement) {
             if (!$otherList->elementExistByRandomIdentifier($thisElement->getRandomIdentifier())) {

--- a/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionAssignedSkillList.php
+++ b/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionAssignedSkillList.php
@@ -18,7 +18,7 @@ class ilAssQuestionAssignedSkillList implements Iterator
      * @param integer $skillBaseId
      * @param integer $skillTrefId
      */
-    public function addSkill($skillBaseId, $skillTrefId)
+    public function addSkill($skillBaseId, $skillTrefId) : void
     {
         $this->skills[] = "{$skillBaseId}:{$skillTrefId}";
     }
@@ -81,7 +81,7 @@ class ilAssQuestionAssignedSkillList implements Iterator
         return array('skills');
     }
     
-    public function wakeup()
+    public function wakeup() : void
     {
         // TODO: Implement __wakeup() method.
     }

--- a/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionLifecycle.php
+++ b/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionLifecycle.php
@@ -43,7 +43,7 @@ class ilAssQuestionLifecycle
     /**
      * @param string $identifier
      */
-    public function setIdentifier($identifier)
+    public function setIdentifier($identifier) : void
     {
         $this->identifier = $identifier;
     }
@@ -143,7 +143,7 @@ class ilAssQuestionLifecycle
      * @param string $identifier
      * @throws ilTestQuestionPoolInvalidArgumentException
      */
-    public function validateIdentifier($identifier)
+    public function validateIdentifier($identifier) : void
     {
         if (!in_array($identifier, $this->getValidIdentifiers())) {
             throw new ilTestQuestionPoolInvalidArgumentException(

--- a/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionLomLifecycle.php
+++ b/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionLomLifecycle.php
@@ -48,7 +48,7 @@ class ilAssQuestionLomLifecycle
      * @param string $identifier
      * @throws ilTestQuestionPoolInvalidArgumentException
      */
-    public function setIdentifier($identifier)
+    public function setIdentifier($identifier) : void
     {
         $this->validateIdentifier($identifier);
         $this->identifier = $identifier;
@@ -66,7 +66,7 @@ class ilAssQuestionLomLifecycle
      * @param string $identifier
      * @throws ilTestQuestionPoolInvalidArgumentException
      */
-    public function validateIdentifier($identifier)
+    public function validateIdentifier($identifier) : void
     {
         if (!in_array($identifier, $this->getValidIdentifiers())) {
             throw new ilTestQuestionPoolInvalidArgumentException(

--- a/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionSkillAssignmentExporter.php
+++ b/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionSkillAssignmentExporter.php
@@ -45,7 +45,7 @@ class ilAssQuestionSkillAssignmentExporter
     /**
      * @param ilXmlWriter $xmlWriter
      */
-    public function setXmlWriter(ilXmlWriter $xmlWriter)
+    public function setXmlWriter(ilXmlWriter $xmlWriter) : void
     {
         $this->xmlWriter = $xmlWriter;
     }
@@ -61,7 +61,7 @@ class ilAssQuestionSkillAssignmentExporter
     /**
      * @param array $questionIds
      */
-    public function setQuestionIds($questionIds)
+    public function setQuestionIds($questionIds) : void
     {
         $this->questionIds = $questionIds;
     }
@@ -77,12 +77,12 @@ class ilAssQuestionSkillAssignmentExporter
     /**
      * @param ilAssQuestionSkillAssignmentList $assignmentList
      */
-    public function setAssignmentList($assignmentList)
+    public function setAssignmentList($assignmentList) : void
     {
         $this->assignmentList = $assignmentList;
     }
 
-    public function export()
+    public function export() : void
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];

--- a/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionSkillAssignmentImport.php
+++ b/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionSkillAssignmentImport.php
@@ -62,7 +62,7 @@ class ilAssQuestionSkillAssignmentImport
     /**
      * @param int $questionId
      */
-    public function setImportQuestionId($importQuestionId)
+    public function setImportQuestionId($importQuestionId) : void
     {
         $this->importQuestionId = $importQuestionId;
     }
@@ -78,7 +78,7 @@ class ilAssQuestionSkillAssignmentImport
     /**
      * @param int $skillBaseId
      */
-    public function setImportSkillBaseId($importSkillBaseId)
+    public function setImportSkillBaseId($importSkillBaseId) : void
     {
         $this->importSkillBaseId = $importSkillBaseId;
     }
@@ -94,7 +94,7 @@ class ilAssQuestionSkillAssignmentImport
     /**
      * @param int $skillTrefId
      */
-    public function setImportSkillTrefId($importSkillTrefId)
+    public function setImportSkillTrefId($importSkillTrefId) : void
     {
         $this->importSkillTrefId = $importSkillTrefId;
     }
@@ -118,7 +118,7 @@ class ilAssQuestionSkillAssignmentImport
     /**
      * @param string $importSkillTitle
      */
-    public function setImportSkillTitle($importSkillTitle)
+    public function setImportSkillTitle($importSkillTitle) : void
     {
         $this->importSkillTitle = $importSkillTitle;
     }
@@ -134,7 +134,7 @@ class ilAssQuestionSkillAssignmentImport
     /**
      * @param string $importSkillPath
      */
-    public function setImportSkillPath($importSkillPath)
+    public function setImportSkillPath($importSkillPath) : void
     {
         $this->importSkillPath = $importSkillPath;
     }
@@ -150,7 +150,7 @@ class ilAssQuestionSkillAssignmentImport
     /**
      * @param $evalMode
      */
-    public function setEvalMode($evalMode)
+    public function setEvalMode($evalMode) : void
     {
         $this->evalMode = $evalMode;
     }
@@ -166,7 +166,7 @@ class ilAssQuestionSkillAssignmentImport
     /**
      * @param int $skillPoints
      */
-    public function setSkillPoints($skillPoints)
+    public function setSkillPoints($skillPoints) : void
     {
         $this->skillPoints = $skillPoints;
     }
@@ -179,7 +179,7 @@ class ilAssQuestionSkillAssignmentImport
         return $this->skillPoints;
     }
     
-    public function initImportSolutionComparisonExpressionList()
+    public function initImportSolutionComparisonExpressionList() : void
     {
         $this->importSolutionComparisonExpressionList->setImportQuestionId($this->getImportQuestionId());
         $this->importSolutionComparisonExpressionList->setImportSkillBaseId($this->getImportSkillBaseId());
@@ -194,12 +194,12 @@ class ilAssQuestionSkillAssignmentImport
         return $this->importSolutionComparisonExpressionList;
     }
     
-    public function sleep()
+    public function sleep() : void
     {
         // TODO: Implement __sleep() method.
     }
     
-    public function wakeup()
+    public function wakeup() : void
     {
         // TODO: Implement __wakeup() method.
     }

--- a/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionSkillAssignmentImportFails.php
+++ b/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionSkillAssignmentImportFails.php
@@ -75,14 +75,14 @@ class ilAssQuestionSkillAssignmentImportFails
     /**
      * @param ilAssQuestionSkillAssignmentImportList $assignmentList
      */
-    public function registerFailedImports(ilAssQuestionSkillAssignmentImportList $assignmentList)
+    public function registerFailedImports(ilAssQuestionSkillAssignmentImportList $assignmentList) : void
     {
         $this->getSettings()->setStringifiedImports($this->buildSettingsKey(), serialize($assignmentList));
     }
     
     /**
      */
-    public function deleteRegisteredImportFails()
+    public function deleteRegisteredImportFails() : void
     {
         $this->getSettings()->deleteStringifiedImports($this->buildSettingsKey());
     }

--- a/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionSkillAssignmentImportList.php
+++ b/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionSkillAssignmentImportList.php
@@ -27,7 +27,7 @@ class ilAssQuestionSkillAssignmentImportList implements Iterator
     /**
      * @param ilAssQuestionSkillAssignmentImport $assignment
      */
-    public function addAssignment(ilAssQuestionSkillAssignmentImport $assignment)
+    public function addAssignment(ilAssQuestionSkillAssignmentImport $assignment) : void
     {
         $this->assignments[] = $assignment;
     }
@@ -79,12 +79,12 @@ class ilAssQuestionSkillAssignmentImportList implements Iterator
         return reset($this->assignments);
     }
     
-    public function sleep()
+    public function sleep() : void
     {
         // TODO: Implement __sleep() method.
     }
     
-    public function wakeup()
+    public function wakeup() : void
     {
         // TODO: Implement __wakeup() method.
     }

--- a/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionSkillAssignmentImporter.php
+++ b/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionSkillAssignmentImporter.php
@@ -67,7 +67,7 @@ class ilAssQuestionSkillAssignmentImporter
     /**
      * @param int $targetParentObjId
      */
-    public function setTargetParentObjId($targetParentObjId)
+    public function setTargetParentObjId($targetParentObjId) : void
     {
         $this->targetParentObjId = $targetParentObjId;
     }
@@ -91,7 +91,7 @@ class ilAssQuestionSkillAssignmentImporter
     /**
      * @param int $installationId
      */
-    public function setImportInstallationId($importInstallationId)
+    public function setImportInstallationId($importInstallationId) : void
     {
         $this->importInstallationId = $importInstallationId;
     }
@@ -107,7 +107,7 @@ class ilAssQuestionSkillAssignmentImporter
     /**
      * @param ilImportMapping $importMappingRegistry
      */
-    public function setImportMappingRegistry($importMappingRegistry)
+    public function setImportMappingRegistry($importMappingRegistry) : void
     {
         $this->importMappingRegistry = $importMappingRegistry;
     }
@@ -123,7 +123,7 @@ class ilAssQuestionSkillAssignmentImporter
     /**
      * @param string $importMappingComponent
      */
-    public function setImportMappingComponent($importMappingComponent)
+    public function setImportMappingComponent($importMappingComponent) : void
     {
         $this->importMappingComponent = $importMappingComponent;
     }
@@ -139,7 +139,7 @@ class ilAssQuestionSkillAssignmentImporter
     /**
      * @param ilAssQuestionSkillAssignmentImportList $importAssignmentList
      */
-    public function setImportAssignmentList($importAssignmentList)
+    public function setImportAssignmentList($importAssignmentList) : void
     {
         $this->importAssignmentList = $importAssignmentList;
     }
@@ -163,7 +163,7 @@ class ilAssQuestionSkillAssignmentImporter
     /**
      * @param ilAssQuestionSkillAssignmentList $successImportAssignmentList
      */
-    public function setSuccessImportAssignmentList($successImportAssignmentList)
+    public function setSuccessImportAssignmentList($successImportAssignmentList) : void
     {
         $this->successImportAssignmentList = $successImportAssignmentList;
     }
@@ -176,7 +176,7 @@ class ilAssQuestionSkillAssignmentImporter
         "creation_date" => $rec["creation_date"]);
     */
 
-    public function import()
+    public function import() : void
     {
         foreach ($this->getImportAssignmentList() as $assignment) {
             $foundSkillId = $this->getSkillIdMapping(

--- a/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionSkillAssignmentRegistry.php
+++ b/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionSkillAssignmentRegistry.php
@@ -41,7 +41,7 @@ class ilAssQuestionSkillAssignmentRegistry
      * @param int $chunkSize
      * @throws \InvalidArgumentException
      */
-    public function setChunkSize($chunkSize)
+    public function setChunkSize($chunkSize) : void
     {
         if (!is_numeric($chunkSize) || $chunkSize <= 0) {
             throw new \InvalidArgumentException(sprintf("The passed chunk size is not a valid/supported integer: %s", var_export($chunkSize, true)));
@@ -79,7 +79,7 @@ class ilAssQuestionSkillAssignmentRegistry
      * @param string $key
      * @param string $value A serialized value
      */
-    public function setStringifiedImports($key, $value)
+    public function setStringifiedImports($key, $value) : void
     {
         $i = 0;
 
@@ -102,7 +102,7 @@ class ilAssQuestionSkillAssignmentRegistry
     /**
      * @param string $key
      */
-    public function deleteStringifiedImports($key)
+    public function deleteStringifiedImports($key) : void
     {
         for ($i = 1, $numberOfChunks = $this->getNumberOfChunksByKey($key); $i <= $numberOfChunks; $i++) {
             $this->settings->delete($key . '_' . $i);

--- a/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionSolutionComparisonExpressionImport.php
+++ b/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionSolutionComparisonExpressionImport.php
@@ -63,7 +63,7 @@ class ilAssQuestionSolutionComparisonExpressionImport
     /**
      * @param int $importQuestionId
      */
-    public function setImportQuestionId($importQuestionId)
+    public function setImportQuestionId($importQuestionId) : void
     {
         $this->importQuestionId = $importQuestionId;
     }
@@ -79,7 +79,7 @@ class ilAssQuestionSolutionComparisonExpressionImport
     /**
      * @param int $importSkillBaseId
      */
-    public function setImportSkillBaseId($importSkillBaseId)
+    public function setImportSkillBaseId($importSkillBaseId) : void
     {
         $this->importSkillBaseId = $importSkillBaseId;
     }
@@ -95,7 +95,7 @@ class ilAssQuestionSolutionComparisonExpressionImport
     /**
      * @param int $importSkillTrefId
      */
-    public function setImportSkillTrefId($importSkillTrefId)
+    public function setImportSkillTrefId($importSkillTrefId) : void
     {
         $this->importSkillTrefId = $importSkillTrefId;
     }
@@ -111,7 +111,7 @@ class ilAssQuestionSolutionComparisonExpressionImport
     /**
      * @param int $orderIndex
      */
-    public function setOrderIndex($orderIndex)
+    public function setOrderIndex($orderIndex) : void
     {
         $this->orderIndex = $orderIndex;
     }
@@ -127,7 +127,7 @@ class ilAssQuestionSolutionComparisonExpressionImport
     /**
      * @param string $expression
      */
-    public function setExpression($expression)
+    public function setExpression($expression) : void
     {
         $this->expression = $expression;
     }
@@ -143,17 +143,17 @@ class ilAssQuestionSolutionComparisonExpressionImport
     /**
      * @param int $points
      */
-    public function setPoints($points)
+    public function setPoints($points) : void
     {
         $this->points = $points;
     }
     
-    public function sleep()
+    public function sleep() : void
     {
         // TODO: Implement __sleep() method.
     }
     
-    public function wakeup()
+    public function wakeup() : void
     {
         // TODO: Implement __wakeup() method.
     }

--- a/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionSolutionComparisonExpressionImportList.php
+++ b/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionSolutionComparisonExpressionImportList.php
@@ -54,7 +54,7 @@ class ilAssQuestionSolutionComparisonExpressionImportList implements Iterator
     /**
      * @param int $importQuestionId
      */
-    public function setImportQuestionId($importQuestionId)
+    public function setImportQuestionId($importQuestionId) : void
     {
         $this->importQuestionId = $importQuestionId;
     }
@@ -70,7 +70,7 @@ class ilAssQuestionSolutionComparisonExpressionImportList implements Iterator
     /**
      * @param int $importSkillBaseId
      */
-    public function setImportSkillBaseId($importSkillBaseId)
+    public function setImportSkillBaseId($importSkillBaseId) : void
     {
         $this->importSkillBaseId = $importSkillBaseId;
     }
@@ -86,7 +86,7 @@ class ilAssQuestionSolutionComparisonExpressionImportList implements Iterator
     /**
      * @param int $importSkillTrefId
      */
-    public function setImportSkillTrefId($importSkillTrefId)
+    public function setImportSkillTrefId($importSkillTrefId) : void
     {
         $this->importSkillTrefId = $importSkillTrefId;
     }
@@ -99,7 +99,7 @@ class ilAssQuestionSolutionComparisonExpressionImportList implements Iterator
         return $this->expressions;
     }
     
-    public function addExpression(ilAssQuestionSolutionComparisonExpressionImport $expression)
+    public function addExpression(ilAssQuestionSolutionComparisonExpressionImport $expression) : void
     {
         $expression->setImportQuestionId($this->getImportQuestionId());
         $expression->setImportSkillBaseId($this->getImportSkillBaseId());
@@ -148,12 +148,12 @@ class ilAssQuestionSolutionComparisonExpressionImportList implements Iterator
         return reset($this->expressions);
     }
     
-    public function sleep()
+    public function sleep() : void
     {
         // TODO: Implement __sleep() method.
     }
     
-    public function wakeup()
+    public function wakeup() : void
     {
         // TODO: Implement __wakeup() method.
     }

--- a/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionType.php
+++ b/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionType.php
@@ -54,7 +54,7 @@ class ilAssQuestionType
     /**
      * @param int $id
      */
-    public function setId($id)
+    public function setId($id) : void
     {
         $this->id = $id;
     }
@@ -70,7 +70,7 @@ class ilAssQuestionType
     /**
      * @param string $tag
      */
-    public function setTag($tag)
+    public function setTag($tag) : void
     {
         $this->tag = $tag;
     }
@@ -86,7 +86,7 @@ class ilAssQuestionType
     /**
      * @param bool $plugin
      */
-    public function setPlugin($plugin)
+    public function setPlugin($plugin) : void
     {
         $this->plugin = $plugin;
     }
@@ -102,7 +102,7 @@ class ilAssQuestionType
     /**
      * @param string $pluginName
      */
-    public function setPluginName($pluginName)
+    public function setPluginName($pluginName) : void
     {
         $this->pluginName = $pluginName;
     }

--- a/Modules/TestQuestionPool/classes/questions/class.ilAssSelfAssessmentQuestionFormatter.php
+++ b/Modules/TestQuestionPool/classes/questions/class.ilAssSelfAssessmentQuestionFormatter.php
@@ -109,7 +109,7 @@ class ilAssSelfAssessmentQuestionFormatter implements ilAssSelfAssessmentMigrato
     /**
      * @param assQuestion $question
      */
-    public static function prepareQuestionForLearningModule(assQuestion $question)
+    public static function prepareQuestionForLearningModule(assQuestion $question) : void
     {
         $question->migrateContentForLearningModule(new self());
     }

--- a/Modules/TestQuestionPool/classes/tables/class.assFileUploadFileTableGUI.php
+++ b/Modules/TestQuestionPool/classes/tables/class.assFileUploadFileTableGUI.php
@@ -71,14 +71,14 @@ class assFileUploadFileTableGUI extends ilTable2GUI
     /**
      * @param string $postVar
      */
-    public function setPostVar($postVar)
+    public function setPostVar($postVar) : void
     {
         $this->postVar = $postVar;
     }
     // hey.
 
     // hey: prevPassSolutions - support file reuse with table
-    public function initCommand(ilAssFileUploadFileTableCommandButton $commandButton, $postVar)
+    public function initCommand(ilAssFileUploadFileTableCommandButton $commandButton, $postVar) : void
     {
         if (count($this->getData())) {
             $this->enable('select_all');

--- a/Modules/TestQuestionPool/classes/tables/class.ilAnswerFrequencyStatisticTableGUI.php
+++ b/Modules/TestQuestionPool/classes/tables/class.ilAnswerFrequencyStatisticTableGUI.php
@@ -74,7 +74,7 @@ class ilAnswerFrequencyStatisticTableGUI extends ilTable2GUI
     /**
      * @param bool $actionsColumnEnabled
      */
-    public function setActionsColumnEnabled(bool $actionsColumnEnabled)
+    public function setActionsColumnEnabled(bool $actionsColumnEnabled) : void
     {
         $this->actionsColumnEnabled = $actionsColumnEnabled;
     }
@@ -90,7 +90,7 @@ class ilAnswerFrequencyStatisticTableGUI extends ilTable2GUI
     /**
      * @param string $additionalHtml
      */
-    public function setAdditionalHtml(string $additionalHtml)
+    public function setAdditionalHtml(string $additionalHtml) : void
     {
         $this->additionalHtml = $additionalHtml;
     }
@@ -98,7 +98,7 @@ class ilAnswerFrequencyStatisticTableGUI extends ilTable2GUI
     /**
      * @param string $additionalHtml
      */
-    public function addAdditionalHtml(string $additionalHtml)
+    public function addAdditionalHtml(string $additionalHtml) : void
     {
         $this->additionalHtml .= $additionalHtml;
     }
@@ -114,12 +114,12 @@ class ilAnswerFrequencyStatisticTableGUI extends ilTable2GUI
     /**
      * @param int $questionIndex
      */
-    public function setQuestionIndex(int $questionIndex)
+    public function setQuestionIndex(int $questionIndex) : void
     {
         $this->questionIndex = $questionIndex;
     }
     
-    public function initColumns()
+    public function initColumns() : void
     {
         $this->addColumn($this->DIC->language()->txt('tst_corr_answ_stat_tbl_header_answer'), '');
         $this->addColumn($this->DIC->language()->txt('tst_corr_answ_stat_tbl_header_frequency'), '');

--- a/Modules/TestQuestionPool/classes/tables/class.ilAssQuestionSkillAssignmentsTableGUI.php
+++ b/Modules/TestQuestionPool/classes/tables/class.ilAssQuestionSkillAssignmentsTableGUI.php
@@ -26,7 +26,7 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
      */
     private $manipulationsEnabled;
 
-    public function setSkillQuestionAssignmentList(ilAssQuestionSkillAssignmentList $assignmentList)
+    public function setSkillQuestionAssignmentList(ilAssQuestionSkillAssignmentList $assignmentList) : void
     {
         $this->skillQuestionAssignmentList = $assignmentList;
     }
@@ -42,7 +42,7 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
     /**
      * @param boolean $manipulationsEnabled
      */
-    public function setManipulationsEnabled($manipulationsEnabled)
+    public function setManipulationsEnabled($manipulationsEnabled) : void
     {
         $this->manipulationsEnabled = $manipulationsEnabled;
     }
@@ -66,7 +66,7 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
         $this->disable('select_all');
     }
     
-    public function init()
+    public function init() : void
     {
         $this->initColumns();
         
@@ -83,12 +83,12 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
     /**
      * @param bool $loadSkillPointsFromRequest
      */
-    public function loadSkillPointsFromRequest($loadSkillPointsFromRequest)
+    public function loadSkillPointsFromRequest($loadSkillPointsFromRequest) : void
     {
         $this->loadSkillPointsFromRequest = $loadSkillPointsFromRequest;
     }
 
-    private function initColumns()
+    private function initColumns() : void
     {
         $this->addColumn($this->lng->txt('tst_question'), 'question', '25%');
         $this->addColumn($this->lng->txt('tst_competence'), 'competence', '');

--- a/Modules/TestQuestionPool/classes/tables/class.ilGlobalUnitCategoryTableGUI.php
+++ b/Modules/TestQuestionPool/classes/tables/class.ilGlobalUnitCategoryTableGUI.php
@@ -8,10 +8,7 @@ require_once 'Modules/TestQuestionPool/classes/tables/class.ilUnitCategoryTableG
  */
 class ilGlobalUnitCategoryTableGUI extends ilUnitCategoryTableGUI
 {
-    /**
-     *
-     */
-    protected function populateTitle()
+    protected function populateTitle() : void
     {
         $this->setTitle($this->lng->txt('un_global_units') . ': ' . $this->lng->txt('categories'));
     }

--- a/Modules/TestQuestionPool/classes/tables/class.ilKprimChoiceAnswerFreqStatTableGUI.php
+++ b/Modules/TestQuestionPool/classes/tables/class.ilKprimChoiceAnswerFreqStatTableGUI.php
@@ -40,7 +40,7 @@ class ilKprimChoiceAnswerFreqStatTableGUI extends ilAnswerFrequencyStatisticTabl
     }
     
 
-    public function initColumns()
+    public function initColumns() : void
     {
         $lng = $this->DIC->language();
         $this->addColumn($lng->txt('tst_corr_answ_stat_tbl_header_answer'), '');

--- a/Modules/TestQuestionPool/classes/tables/class.ilLocalUnitCategoryTableGUI.php
+++ b/Modules/TestQuestionPool/classes/tables/class.ilLocalUnitCategoryTableGUI.php
@@ -8,10 +8,7 @@ require_once 'Modules/TestQuestionPool/classes/tables/class.ilUnitCategoryTableG
  */
 class ilLocalUnitCategoryTableGUI extends ilUnitCategoryTableGUI
 {
-    /**
-     *
-     */
-    protected function populateTitle()
+    protected function populateTitle() : void
     {
         if ($this->getParentObject()->isCRUDContext()) {
             $this->setTitle($this->lng->txt('un_local_units') . ': ' . $this->lng->txt('categories'));

--- a/Modules/TestQuestionPool/classes/tables/class.ilMatchingQuestionAnswerFreqStatTableGUI.php
+++ b/Modules/TestQuestionPool/classes/tables/class.ilMatchingQuestionAnswerFreqStatTableGUI.php
@@ -25,7 +25,7 @@ class ilMatchingQuestionAnswerFreqStatTableGUI extends ilAnswerFrequencyStatisti
         $this->setDefaultOrderField('term');
     }
     
-    public function initColumns()
+    public function initColumns() : void
     {
         $this->addColumn('Term', '');
         $this->addColumn('Definition', '');

--- a/Modules/TestQuestionPool/classes/tables/class.ilQuestionBrowserTableGUI.php
+++ b/Modules/TestQuestionPool/classes/tables/class.ilQuestionBrowserTableGUI.php
@@ -158,7 +158,7 @@ class ilQuestionBrowserTableGUI extends ilTable2GUI
     /**
      * @param bool $questionCommentingEnabled
      */
-    public function setQuestionCommentingEnabled(bool $questionCommentingEnabled)
+    public function setQuestionCommentingEnabled(bool $questionCommentingEnabled) : void
     {
         $this->questionCommentingEnabled = $questionCommentingEnabled;
     }
@@ -168,7 +168,7 @@ class ilQuestionBrowserTableGUI extends ilTable2GUI
         return in_array('comments', $this->getSelectedColumns());
     }
     
-    public function setQuestionData($questionData)
+    public function setQuestionData($questionData) : void
     {
         if ($this->isQuestionCommentingEnabled() && ($this->isCommentsColumnSelected() || $this->filter['commented'])) {
             foreach ($questionData as $key => $data) {
@@ -520,7 +520,7 @@ class ilQuestionBrowserTableGUI extends ilTable2GUI
         }
     }
     
-    public function setEditable($value)
+    public function setEditable($value) : void
     {
         $this->editable = $value;
     }
@@ -530,7 +530,7 @@ class ilQuestionBrowserTableGUI extends ilTable2GUI
         return $this->editable;
     }
 
-    public function setWriteAccess($value)
+    public function setWriteAccess($value) : void
     {
         $this->writeAccess = $value;
     }

--- a/Modules/TestQuestionPool/classes/tables/class.ilQuestionCumulatedStatisticsTableGUI.php
+++ b/Modules/TestQuestionPool/classes/tables/class.ilQuestionCumulatedStatisticsTableGUI.php
@@ -47,7 +47,7 @@ class ilQuestionCumulatedStatisticsTableGUI extends ilTable2GUI
     /**
      *
      */
-    protected function initColumns()
+    protected function initColumns() : void
     {
         $this->addColumn($this->lng->txt('result'), 'result');
         $this->addColumn($this->lng->txt('value'), 'value');
@@ -56,7 +56,7 @@ class ilQuestionCumulatedStatisticsTableGUI extends ilTable2GUI
     /**
      *
      */
-    protected function initData()
+    protected function initData() : void
     {
         $rows = array();
 

--- a/Modules/TestQuestionPool/classes/tables/class.ilQuestionInternalLinkSelectionTableGUI.php
+++ b/Modules/TestQuestionPool/classes/tables/class.ilQuestionInternalLinkSelectionTableGUI.php
@@ -45,7 +45,7 @@ class ilQuestionInternalLinkSelectionTableGUI extends ilTable2GUI
     /**
      *
      */
-    protected function initColumns()
+    protected function initColumns() : void
     {
         $this->addColumn($this->lng->txt('title'), 'title');
         $this->addColumn($this->lng->txt('description'), 'description');

--- a/Modules/TestQuestionPool/classes/tables/class.ilQuestionPoolImportVerificationTableGUI.php
+++ b/Modules/TestQuestionPool/classes/tables/class.ilQuestionPoolImportVerificationTableGUI.php
@@ -32,7 +32,7 @@ class ilQuestionPoolImportVerificationTableGUI extends ilTable2GUI
     /**
      *
      */
-    protected function initColumns()
+    protected function initColumns() : void
     {
         $this->addColumn('', '', '1%', true);
         $this->addColumn($this->lng->txt('question_title'));

--- a/Modules/TestQuestionPool/classes/tables/class.ilQuestionPoolPrintViewTableGUI.php
+++ b/Modules/TestQuestionPool/classes/tables/class.ilQuestionPoolPrintViewTableGUI.php
@@ -48,7 +48,7 @@ class ilQuestionPoolPrintViewTableGUI extends ilTable2GUI
         $this->disable('select_all');
     }
     
-    public function initColumns()
+    public function initColumns() : void
     {
         $this->addColumn($this->lng->txt("title"), 'title', '');
         
@@ -194,7 +194,7 @@ class ilQuestionPoolPrintViewTableGUI extends ilTable2GUI
         return $this->totalPoints;
     }
 
-    public function setTotalPoints($totalPoints)
+    public function setTotalPoints($totalPoints) : void
     {
         $this->totalPoints = $totalPoints;
     }

--- a/Modules/TestQuestionPool/classes/tables/class.ilQuestionUsagesTableGUI.php
+++ b/Modules/TestQuestionPool/classes/tables/class.ilQuestionUsagesTableGUI.php
@@ -46,7 +46,7 @@ class ilQuestionUsagesTableGUI extends ilTable2GUI
     /**
      *
      */
-    protected function initColumns()
+    protected function initColumns() : void
     {
         $this->addColumn($this->lng->txt('title'), 'title');
         $this->addColumn($this->lng->txt('author'), 'author');
@@ -56,7 +56,7 @@ class ilQuestionUsagesTableGUI extends ilTable2GUI
     /**
      *
      */
-    protected function initData()
+    protected function initData() : void
     {
         /**
          * @var $tree ilTree

--- a/Modules/TestQuestionPool/classes/tables/class.ilUnitCategoryTableGUI.php
+++ b/Modules/TestQuestionPool/classes/tables/class.ilUnitCategoryTableGUI.php
@@ -47,10 +47,7 @@ abstract class ilUnitCategoryTableGUI extends ilTable2GUI
         $this->setRowTemplate('tpl.unit_category_row.html', 'Modules/TestQuestionPool');
     }
 
-    /**
-     *
-     */
-    abstract protected function populateTitle();
+    abstract protected function populateTitle() : void;
 
     /**
      * @param array $row

--- a/Modules/TestQuestionPool/test/assAnswerBinaryStateImageTest.php
+++ b/Modules/TestQuestionPool/test/assAnswerBinaryStateImageTest.php
@@ -18,7 +18,7 @@ class assAnswerBinaryStateImageTest extends assBaseTestCase
         chdir('../../../');
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerBinaryStateImage.php';
@@ -29,7 +29,7 @@ class assAnswerBinaryStateImageTest extends assBaseTestCase
         $this->assertInstanceOf('ASS_AnswerBinaryStateImage', $instance);
     }
 
-    public function test_setGetImage()
+    public function test_setGetImage() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerBinaryStateImage.php';

--- a/Modules/TestQuestionPool/test/assAnswerBinaryStateTest.php
+++ b/Modules/TestQuestionPool/test/assAnswerBinaryStateTest.php
@@ -18,7 +18,7 @@ class assAnswerBinaryStateTest extends assBaseTestCase
         chdir('../../../');
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerBinaryState.php';
@@ -29,7 +29,7 @@ class assAnswerBinaryStateTest extends assBaseTestCase
         $this->assertInstanceOf('ASS_AnswerBinaryState', $instance);
     }
 
-    public function test_setGetState_shouldReturnUnchangedState()
+    public function test_setGetState_shouldReturnUnchangedState() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerBinaryState.php';
@@ -44,7 +44,7 @@ class assAnswerBinaryStateTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_isStateChecked_shouldReturnActualState()
+    public function test_isStateChecked_shouldReturnActualState() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerBinaryState.php';
@@ -59,7 +59,7 @@ class assAnswerBinaryStateTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_isStateSet_shouldReturnActualState()
+    public function test_isStateSet_shouldReturnActualState() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerBinaryState.php';
@@ -74,7 +74,7 @@ class assAnswerBinaryStateTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_isStateUnset_shouldReturnActualState()
+    public function test_isStateUnset_shouldReturnActualState() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerBinaryState.php';
@@ -89,7 +89,7 @@ class assAnswerBinaryStateTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_isStateUnchecked_shouldReturnActualState()
+    public function test_isStateUnchecked_shouldReturnActualState() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerBinaryState.php';
@@ -104,7 +104,7 @@ class assAnswerBinaryStateTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setChecked_shouldAlterState()
+    public function test_setChecked_shouldAlterState() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerBinaryState.php';
@@ -120,7 +120,7 @@ class assAnswerBinaryStateTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setUnchecked_shouldAlterState()
+    public function test_setUnchecked_shouldAlterState() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerBinaryState.php';
@@ -136,7 +136,7 @@ class assAnswerBinaryStateTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setSet_shouldAlterState()
+    public function test_setSet_shouldAlterState() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerBinaryState.php';
@@ -152,7 +152,7 @@ class assAnswerBinaryStateTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setUnset_shouldAlterState()
+    public function test_setUnset_shouldAlterState() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerBinaryState.php';

--- a/Modules/TestQuestionPool/test/assAnswerClozeTest.php
+++ b/Modules/TestQuestionPool/test/assAnswerClozeTest.php
@@ -18,7 +18,7 @@ class assAnswerClozeTest extends assBaseTestCase
         chdir('../../../');
     }
 
-    public function test_constructorShouldReturnInstance()
+    public function test_constructorShouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerCloze.php';
@@ -30,7 +30,7 @@ class assAnswerClozeTest extends assBaseTestCase
         $this->assertNotNull($instance);
     }
     
-    public function test_setGetLowerBound()
+    public function test_setGetLowerBound() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerCloze.php';
@@ -45,7 +45,7 @@ class assAnswerClozeTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
     
-    public function test_setGetLowerBond_GreaterThanAnswerShouldSetAnswertext()
+    public function test_setGetLowerBond_GreaterThanAnswerShouldSetAnswertext() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerCloze.php';
@@ -60,7 +60,7 @@ class assAnswerClozeTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
     
-    public function test_setGetLowerBound_nonNumericShouldSetAnswertext()
+    public function test_setGetLowerBound_nonNumericShouldSetAnswertext() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerCloze.php';
@@ -75,7 +75,7 @@ class assAnswerClozeTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
     
-    public function test_setGetUpperBound()
+    public function test_setGetUpperBound() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerCloze.php';
@@ -90,7 +90,7 @@ class assAnswerClozeTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
     
-    public function test_setGetUpperBound_smallerThanAnswerShouldSetAnswertext()
+    public function test_setGetUpperBound_smallerThanAnswerShouldSetAnswertext() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerCloze.php';
@@ -105,7 +105,7 @@ class assAnswerClozeTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetUpperBound_nonNumericShouldSetAnswertext()
+    public function test_setGetUpperBound_nonNumericShouldSetAnswertext() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerCloze.php';

--- a/Modules/TestQuestionPool/test/assAnswerErrorTextTest.php
+++ b/Modules/TestQuestionPool/test/assAnswerErrorTextTest.php
@@ -18,7 +18,7 @@ class assAnswerErrorTextTest extends assBaseTestCase
         chdir('../../../');
     }
 
-    public function test_instantiateObjectSimple()
+    public function test_instantiateObjectSimple() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerErrorText.php';
@@ -31,7 +31,7 @@ class assAnswerErrorTextTest extends assBaseTestCase
     }
 
     
-    public function test_instantiateObjectFull()
+    public function test_instantiateObjectFull() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerErrorText.php';
@@ -47,7 +47,7 @@ class assAnswerErrorTextTest extends assBaseTestCase
         $this->assertTrue(true);
     }
     
-    public function test_setGetPoints_valid()
+    public function test_setGetPoints_valid() : void
     {
         //$this->markTestIncomplete('Testing an uncommitted feature.');
         // Arrange
@@ -63,7 +63,7 @@ class assAnswerErrorTextTest extends assBaseTestCase
         $this->assertEquals($actual, $expected);
     }
 
-    public function test_setGetTextCorrect()
+    public function test_setGetTextCorrect() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerErrorText.php';
@@ -78,7 +78,7 @@ class assAnswerErrorTextTest extends assBaseTestCase
         $this->assertEquals($actual, $expected);
     }
 
-    public function test_setGetTextWrong_valid()
+    public function test_setGetTextWrong_valid() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerErrorText.php';
@@ -93,7 +93,7 @@ class assAnswerErrorTextTest extends assBaseTestCase
         $this->assertEquals($actual, $expected);
     }
 
-    public function test_setTextWrong_invalid()
+    public function test_setTextWrong_invalid() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerErrorText.php';

--- a/Modules/TestQuestionPool/test/assAnswerImagemapTest.php
+++ b/Modules/TestQuestionPool/test/assAnswerImagemapTest.php
@@ -18,7 +18,7 @@ class assAnswerImagemapTest extends assBaseTestCase
         chdir('../../../');
     }
 
-    public function test_instantiateObjectSimple()
+    public function test_instantiateObjectSimple() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerImagemap.php';
@@ -30,7 +30,7 @@ class assAnswerImagemapTest extends assBaseTestCase
         $this->assertInstanceOf('ASS_AnswerImagemap', $instance);
     }
     
-    public function test_setGetCoords()
+    public function test_setGetCoords() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerImagemap.php';
@@ -45,7 +45,7 @@ class assAnswerImagemapTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetArea()
+    public function test_setGetArea() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerImagemap.php';
@@ -60,7 +60,7 @@ class assAnswerImagemapTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetPointsUnchecked()
+    public function test_setGetPointsUnchecked() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerImagemap.php';
@@ -75,7 +75,7 @@ class assAnswerImagemapTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetPointsUnchecked_shouldNullifyOnNonNumericPoints()
+    public function test_setGetPointsUnchecked_shouldNullifyOnNonNumericPoints() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerImagemap.php';

--- a/Modules/TestQuestionPool/test/assAnswerMatchingDefinitionTest.php
+++ b/Modules/TestQuestionPool/test/assAnswerMatchingDefinitionTest.php
@@ -18,7 +18,7 @@ class assAnswerMatchingDefinitionTest extends assBaseTestCase
         chdir('../../../');
     }
 
-    public function test_instantiateObjectSimple()
+    public function test_instantiateObjectSimple() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerMatchingDefinition.php';

--- a/Modules/TestQuestionPool/test/assAnswerMatchingPairTest.php
+++ b/Modules/TestQuestionPool/test/assAnswerMatchingPairTest.php
@@ -18,7 +18,7 @@ class assAnswerMatchingPairTest extends assBaseTestCase
         chdir('../../../');
     }
 
-    public function test_instantiateObjectSimple()
+    public function test_instantiateObjectSimple() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerMatchingPair.php';
@@ -30,7 +30,7 @@ class assAnswerMatchingPairTest extends assBaseTestCase
         $this->assertInstanceOf('assAnswerMatchingPair', $instance);
     }
 
-    public function test_setGetTerm()
+    public function test_setGetTerm() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerMatchingPair.php';
@@ -45,7 +45,7 @@ class assAnswerMatchingPairTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetDefinition()
+    public function test_setGetDefinition() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerMatchingPair.php';
@@ -60,7 +60,7 @@ class assAnswerMatchingPairTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetPoints()
+    public function test_setGetPoints() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerMatchingPair.php';

--- a/Modules/TestQuestionPool/test/assAnswerMatchingTermTest.php
+++ b/Modules/TestQuestionPool/test/assAnswerMatchingTermTest.php
@@ -18,7 +18,7 @@ class assAnswerMatchingTermTest extends assBaseTestCase
         chdir('../../../');
     }
 
-    public function test_instantiateObjectSimple()
+    public function test_instantiateObjectSimple() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerMatchingTerm.php';
@@ -30,7 +30,7 @@ class assAnswerMatchingTermTest extends assBaseTestCase
         $this->assertInstanceOf('assAnswerMatchingTerm', $instance);
     }
 
-    public function test_setGetText()
+    public function test_setGetText() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerMatchingTerm.php';
@@ -45,7 +45,7 @@ class assAnswerMatchingTermTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetPicture()
+    public function test_setGetPicture() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerMatchingTerm.php';
@@ -60,7 +60,7 @@ class assAnswerMatchingTermTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_getUnsetPicture()
+    public function test_getUnsetPicture() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerMatchingTerm.php';
@@ -74,7 +74,7 @@ class assAnswerMatchingTermTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetIdentifier()
+    public function test_setGetIdentifier() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerMatchingTerm.php';

--- a/Modules/TestQuestionPool/test/assAnswerMatchingTest.php
+++ b/Modules/TestQuestionPool/test/assAnswerMatchingTest.php
@@ -18,7 +18,7 @@ class assAnswerMatchingTest extends assBaseTestCase
         chdir('../../../');
     }
 
-    public function test_instantiateObjectSimple()
+    public function test_instantiateObjectSimple() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerMatching.php';
@@ -30,7 +30,7 @@ class assAnswerMatchingTest extends assBaseTestCase
         $this->assertInstanceOf('ASS_AnswerMatching', $instance);
     }
 
-    public function test_setGetPoints()
+    public function test_setGetPoints() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerMatching.php';
@@ -45,7 +45,7 @@ class assAnswerMatchingTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetTermId()
+    public function test_setGetTermId() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerMatching.php';
@@ -60,7 +60,7 @@ class assAnswerMatchingTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetPicture()
+    public function test_setGetPicture() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerMatching.php';
@@ -75,7 +75,7 @@ class assAnswerMatchingTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetPictureId()
+    public function test_setGetPictureId() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerMatching.php';
@@ -90,7 +90,7 @@ class assAnswerMatchingTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetPictureId_NegativeShouldNotSetValue()
+    public function test_setGetPictureId_NegativeShouldNotSetValue() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerMatching.php';
@@ -105,7 +105,7 @@ class assAnswerMatchingTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetDefinition()
+    public function test_setGetDefinition() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerMatching.php';
@@ -120,7 +120,7 @@ class assAnswerMatchingTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetDefinitionId()
+    public function test_setGetDefinitionId() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerMatching.php';

--- a/Modules/TestQuestionPool/test/assAnswerMultipleResponseImageTest.php
+++ b/Modules/TestQuestionPool/test/assAnswerMultipleResponseImageTest.php
@@ -18,7 +18,7 @@ class assAnswerMultipleResponseImageTest extends assBaseTestCase
         chdir('../../../');
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerMultipleResponseImage.php';
@@ -29,7 +29,7 @@ class assAnswerMultipleResponseImageTest extends assBaseTestCase
         $this->assertInstanceOf('ASS_AnswerMultipleResponseImage', $instance);
     }
 
-    public function test_setGetImage()
+    public function test_setGetImage() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerMultipleResponseImage.php';

--- a/Modules/TestQuestionPool/test/assAnswerMultipleResponseTest.php
+++ b/Modules/TestQuestionPool/test/assAnswerMultipleResponseTest.php
@@ -18,7 +18,7 @@ class assAnswerMultipleResponseTest extends assBaseTestCase
         chdir('../../../');
     }
 
-    public function test_instantiateObjectSimple()
+    public function test_instantiateObjectSimple() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerMultipleResponse.php';
@@ -30,7 +30,7 @@ class assAnswerMultipleResponseTest extends assBaseTestCase
         $this->assertInstanceOf('ASS_AnswerMultipleResponse', $instance);
     }
 
-    public function test_setGetPointsUnchecked()
+    public function test_setGetPointsUnchecked() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerMultipleResponse.php';
@@ -45,7 +45,7 @@ class assAnswerMultipleResponseTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetPointsUnchecked_InvalidPointsBecomeZero()
+    public function test_setGetPointsUnchecked_InvalidPointsBecomeZero() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerMultipleResponse.php';
@@ -60,7 +60,7 @@ class assAnswerMultipleResponseTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetPointsChecked()
+    public function test_setGetPointsChecked() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerMultipleResponse.php';

--- a/Modules/TestQuestionPool/test/assAnswerOrderingTest.php
+++ b/Modules/TestQuestionPool/test/assAnswerOrderingTest.php
@@ -17,7 +17,7 @@ class assAnswerOrderingTest extends assBaseTestCase
         chdir('../../../');
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/questions/class.ilAssOrderingElement.php';
@@ -28,7 +28,7 @@ class assAnswerOrderingTest extends assBaseTestCase
         $this->assertInstanceOf('ilAssOrderingElement', $instance);
     }
 
-    public function test_setGetRandomId()
+    public function test_setGetRandomId() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/questions/class.ilAssOrderingElement.php';
@@ -43,7 +43,7 @@ class assAnswerOrderingTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetAnswerId()
+    public function test_setGetAnswerId() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/questions/class.ilAssOrderingElement.php';
@@ -59,7 +59,7 @@ class assAnswerOrderingTest extends assBaseTestCase
     }
 
 
-    public function test_setGetOrdeingDepth()
+    public function test_setGetOrdeingDepth() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/questions/class.ilAssOrderingElement.php';

--- a/Modules/TestQuestionPool/test/assAnswerSimpleTest.php
+++ b/Modules/TestQuestionPool/test/assAnswerSimpleTest.php
@@ -18,7 +18,7 @@ class assAnswerSimpleTest extends assBaseTestCase
         chdir('../../../');
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerSimple.php';
@@ -29,7 +29,7 @@ class assAnswerSimpleTest extends assBaseTestCase
         $this->assertInstanceOf('ASS_AnswerSimple', $instance);
     }
 
-    public function test_setGetId_shouldReturnUnchangedId()
+    public function test_setGetId_shouldReturnUnchangedId() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerSimple.php';
@@ -44,7 +44,7 @@ class assAnswerSimpleTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetAnswertext_shouldReturnUnchangedAnswertext()
+    public function test_setGetAnswertext_shouldReturnUnchangedAnswertext() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerSimple.php';
@@ -59,7 +59,7 @@ class assAnswerSimpleTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetPoints_shouldReturnUnchangedPoints()
+    public function test_setGetPoints_shouldReturnUnchangedPoints() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerSimple.php';
@@ -74,7 +74,7 @@ class assAnswerSimpleTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetPoints_shouldReturnUnchangedZeroOnNonNumericInput()
+    public function test_setGetPoints_shouldReturnUnchangedZeroOnNonNumericInput() : void
     {
         // Note: We want to get rid of this functionality in the class.
 
@@ -91,7 +91,7 @@ class assAnswerSimpleTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetOrder_shouldReturnUnchangedOrder()
+    public function test_setGetOrder_shouldReturnUnchangedOrder() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerSimple.php';

--- a/Modules/TestQuestionPool/test/assAnswerTrueFalseTest.php
+++ b/Modules/TestQuestionPool/test/assAnswerTrueFalseTest.php
@@ -18,7 +18,7 @@ class assAnswerTrueFalseTest extends assBaseTestCase
         chdir('../../../');
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerTrueFalse.php';
@@ -29,7 +29,7 @@ class assAnswerTrueFalseTest extends assBaseTestCase
         $this->assertInstanceOf('ASS_AnswerTrueFalse', $instance);
     }
 
-    public function test_setGetCorrectness_shouldReturnUnchangedState()
+    public function test_setGetCorrectness_shouldReturnUnchangedState() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerTrueFalse.php';
@@ -44,7 +44,7 @@ class assAnswerTrueFalseTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_isTrue_shouldReturnTrue()
+    public function test_isTrue_shouldReturnTrue() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerTrueFalse.php';
@@ -59,7 +59,7 @@ class assAnswerTrueFalseTest extends assBaseTestCase
         $this->assertEquals($expected, $instance->isCorrect());
     }
 
-    public function test_isFalse_shouldReturnFalseOnTrueState()
+    public function test_isFalse_shouldReturnFalseOnTrueState() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerTrueFalse.php';
@@ -74,7 +74,7 @@ class assAnswerTrueFalseTest extends assBaseTestCase
         $this->assertEquals($expected, $instance->isIncorrect());
     }
 
-    public function test_setFalseGetCorrectness_shouldReturnFalse()
+    public function test_setFalseGetCorrectness_shouldReturnFalse() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerTrueFalse.php';
@@ -89,7 +89,7 @@ class assAnswerTrueFalseTest extends assBaseTestCase
         $this->assertEquals((bool) $expected, (bool) $actual);
     }
 
-    public function test_setTrueIsTrue_shouldReturnUnchangedState()
+    public function test_setTrueIsTrue_shouldReturnUnchangedState() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerTrueFalse.php';
@@ -104,7 +104,7 @@ class assAnswerTrueFalseTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setFalseIsFalse_shouldReturnUnchangedState()
+    public function test_setFalseIsFalse_shouldReturnUnchangedState() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerTrueFalse.php';

--- a/Modules/TestQuestionPool/test/assClozeGapTest.php
+++ b/Modules/TestQuestionPool/test/assClozeGapTest.php
@@ -27,7 +27,7 @@ class assClozeGapTest extends assBaseTestCase
         $this->setGlobalVariable('ilUtils', $util_mock);
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeGap.php';
@@ -38,7 +38,7 @@ class assClozeGapTest extends assBaseTestCase
         $this->assertInstanceOf('assClozeGap', $instance);
     }
 
-    public function test_setGetType_shouldReturnUnchangedValue()
+    public function test_setGetType_shouldReturnUnchangedValue() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeGap.php';
@@ -53,7 +53,7 @@ class assClozeGapTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setType_shouldSetDefaultIfNotPassed()
+    public function test_setType_shouldSetDefaultIfNotPassed() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeGap.php';
@@ -68,7 +68,7 @@ class assClozeGapTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetShuffle_shouldReturnUnchangedValue()
+    public function test_setGetShuffle_shouldReturnUnchangedValue() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeGap.php';
@@ -83,7 +83,7 @@ class assClozeGapTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_arrayShuffle_shouldNotReturnArrayUnshuffled()
+    public function test_arrayShuffle_shouldNotReturnArrayUnshuffled() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeGap.php';
@@ -105,7 +105,7 @@ class assClozeGapTest extends assBaseTestCase
         $this->assertEquals($theExpected, $actual);
     }
     
-    public function test_addGetItem_shouldReturnValueUnchanged()
+    public function test_addGetItem_shouldReturnValueUnchanged() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeGap.php';
@@ -121,7 +121,7 @@ class assClozeGapTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_addGetItem_shouldReturnValueUnchangedMultiple()
+    public function test_addGetItem_shouldReturnValueUnchangedMultiple() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeGap.php';
@@ -139,7 +139,7 @@ class assClozeGapTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_getItem_shouldReturnNullIfNoItemAtGivenIndex()
+    public function test_getItem_shouldReturnNullIfNoItemAtGivenIndex() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeGap.php';
@@ -160,7 +160,7 @@ class assClozeGapTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
     
-    public function test_addGetItem_shouldReturnValueUnchangedMultiplePlus()
+    public function test_addGetItem_shouldReturnValueUnchangedMultiplePlus() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeGap.php';
@@ -183,7 +183,7 @@ class assClozeGapTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_getItems_shouldReturnItemsAdded()
+    public function test_getItems_shouldReturnItemsAdded() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeGap.php';
@@ -208,7 +208,7 @@ class assClozeGapTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_getItemsWithShuffle_shouldReturnItemsAddedShuffled()
+    public function test_getItemsWithShuffle_shouldReturnItemsAddedShuffled() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeGap.php';
@@ -242,7 +242,7 @@ class assClozeGapTest extends assBaseTestCase
         $this->assertEquals($shuffledArray, $actual);
     }
 
-    public function test_getItemsRaw_shouldReturnItemsAdded()
+    public function test_getItemsRaw_shouldReturnItemsAdded() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeGap.php';
@@ -265,7 +265,7 @@ class assClozeGapTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_getItemCount_shouldReturnCorrectCount()
+    public function test_getItemCount_shouldReturnCorrectCount() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeGap.php';
@@ -288,7 +288,7 @@ class assClozeGapTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setItemPoints_shouldSetItemPoints()
+    public function test_setItemPoints_shouldSetItemPoints() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeGap.php';
@@ -308,7 +308,7 @@ class assClozeGapTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_deleteItem_shouldDeleteGivenItem()
+    public function test_deleteItem_shouldDeleteGivenItem() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeGap.php';
@@ -331,7 +331,7 @@ class assClozeGapTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_clearItems_shouldClearItems()
+    public function test_clearItems_shouldClearItems() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeGap.php';
@@ -357,7 +357,7 @@ class assClozeGapTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setItemLowerBound_shouldSetItemsLowerBound()
+    public function test_setItemLowerBound_shouldSetItemsLowerBound() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeGap.php';
@@ -378,7 +378,7 @@ class assClozeGapTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setItemLowerBound_shouldSetItemsAnswerIfBoundTooHigh()
+    public function test_setItemLowerBound_shouldSetItemsAnswerIfBoundTooHigh() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeGap.php';
@@ -400,7 +400,7 @@ class assClozeGapTest extends assBaseTestCase
         $this->assertEquals($item_retrieved->getAnswerText(), $actual);
     }
 
-    public function test_setItemUpperBound_shouldSetItemsUpperBound()
+    public function test_setItemUpperBound_shouldSetItemsUpperBound() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeGap.php';
@@ -421,7 +421,7 @@ class assClozeGapTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setItemUpperBound_shouldSetItemsAnswerIfBoundTooLow()
+    public function test_setItemUpperBound_shouldSetItemsAnswerIfBoundTooLow() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeGap.php';
@@ -443,7 +443,7 @@ class assClozeGapTest extends assBaseTestCase
         $this->assertEquals($item_retrieved->getAnswerText(), $actual);
     }
 
-    public function test_getMaxWidth_shouldReturnCharacterCountOfLongestAnswertext()
+    public function test_getMaxWidth_shouldReturnCharacterCountOfLongestAnswertext() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeGap.php';
@@ -468,7 +468,7 @@ class assClozeGapTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_getBestSolutionIndexes_shouldReturnBestSolutionIndexes()
+    public function test_getBestSolutionIndexes_shouldReturnBestSolutionIndexes() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeGap.php';
@@ -493,7 +493,7 @@ class assClozeGapTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_getBestSolutionOutput_shouldReturnBestSolutionOutput_CaseText()
+    public function test_getBestSolutionOutput_shouldReturnBestSolutionOutput_CaseText() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeGap.php';
@@ -527,7 +527,7 @@ class assClozeGapTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_getBestSolutionOutput_shouldReturnBestSolutionOutput_CaseTextMulti()
+    public function test_getBestSolutionOutput_shouldReturnBestSolutionOutput_CaseTextMulti() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeGap.php';
@@ -563,7 +563,7 @@ class assClozeGapTest extends assBaseTestCase
         $this->assertTrue(($actual == $expected1) || ($actual == $expected2));
     }
 
-    public function test_getBestSolutionOutput_shouldReturnBestSolutionOutput_CaseNumeric()
+    public function test_getBestSolutionOutput_shouldReturnBestSolutionOutput_CaseNumeric() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeGap.php';
@@ -597,7 +597,7 @@ class assClozeGapTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_getBestSolutionOutput_shouldReturnEmptyStringOnUnknownType_WhichMakesNoSenseButK()
+    public function test_getBestSolutionOutput_shouldReturnEmptyStringOnUnknownType_WhichMakesNoSenseButK() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeGap.php';

--- a/Modules/TestQuestionPool/test/assClozeSelectGapTest.php
+++ b/Modules/TestQuestionPool/test/assClozeSelectGapTest.php
@@ -23,7 +23,7 @@ class assClozeSelectGapTest extends assBaseTestCase
         chdir('../../../');
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeSelectGap.php';
@@ -34,7 +34,7 @@ class assClozeSelectGapTest extends assBaseTestCase
         $this->assertInstanceOf('assClozeSelectGap', $instance);
     }
 
-    public function test_newlyInstatiatedObject_shouldReturnTrueOnGetShuffle()
+    public function test_newlyInstatiatedObject_shouldReturnTrueOnGetShuffle() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeSelectGap.php';
@@ -46,7 +46,7 @@ class assClozeSelectGapTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_arrayShuffle_shouldShuffleArray()
+    public function test_arrayShuffle_shouldShuffleArray() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeSelectGap.php';
@@ -59,7 +59,7 @@ class assClozeSelectGapTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_getItemswithShuffle_shouldReturnShuffledItems()
+    public function test_getItemswithShuffle_shouldReturnShuffledItems() : void
     {
         require_once './Modules/TestQuestionPool/classes/class.assClozeSelectGap.php';
         $instance = new assClozeSelectGap(1); // 1 - select gap
@@ -98,7 +98,7 @@ class assClozeSelectGapTest extends assBaseTestCase
         $this->assertEquals($actual, $expectedSequence);
     }
 
-    public function test_getItemswithoutShuffle_shouldReturnItemsInOrder()
+    public function test_getItemswithoutShuffle_shouldReturnItemsInOrder() : void
     {
         require_once './Modules/TestQuestionPool/classes/class.assClozeSelectGap.php';
         $instance = new assClozeSelectGap(1); // 1 - select gap

--- a/Modules/TestQuestionPool/test/assClozeTestGUITest.php
+++ b/Modules/TestQuestionPool/test/assClozeTestGUITest.php
@@ -39,7 +39,7 @@ class assClozeTestGUITest extends assBaseTestCase
         $this->setGlobalVariable('tpl', $this->getGlobalTemplateMock());
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         /**
          * @runInSeparateProcess

--- a/Modules/TestQuestionPool/test/assClozeTestTest.php
+++ b/Modules/TestQuestionPool/test/assClozeTestTest.php
@@ -35,7 +35,7 @@ class assClozeTestTest extends assBaseTestCase
         $this->setGlobalVariable('ilDB', $this->getDatabaseMock());
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeTest.php';
@@ -46,7 +46,7 @@ class assClozeTestTest extends assBaseTestCase
         $this->assertInstanceOf('assClozeTest', $instance);
     }
 
-    public function test_cleanQuestionText_shouldReturnCleanedText()
+    public function test_cleanQuestionText_shouldReturnCleanedText() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeTest.php';
@@ -59,7 +59,7 @@ class assClozeTestTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_isComplete_shouldReturnFalseIfIncomplete()
+    public function test_isComplete_shouldReturnFalseIfIncomplete() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeTest.php';
@@ -71,7 +71,7 @@ class assClozeTestTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetStartTag_shouldReturnValueUnchanged()
+    public function test_setGetStartTag_shouldReturnValueUnchanged() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeTest.php';
@@ -84,7 +84,7 @@ class assClozeTestTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetStartTag_defaultShoulBeApplied()
+    public function test_setGetStartTag_defaultShoulBeApplied() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeTest.php';
@@ -102,7 +102,7 @@ class assClozeTestTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetEndTag_shouldReturnValueUnchanged()
+    public function test_setGetEndTag_shouldReturnValueUnchanged() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeTest.php';
@@ -115,7 +115,7 @@ class assClozeTestTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetEndTag_defaultShoulBeApplied()
+    public function test_setGetEndTag_defaultShoulBeApplied() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeTest.php';
@@ -133,7 +133,7 @@ class assClozeTestTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_getQuestionType_shouldReturnQuestionType()
+    public function test_getQuestionType_shouldReturnQuestionType() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeTest.php';
@@ -145,7 +145,7 @@ class assClozeTestTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetIdenticalScoring_shouldReturnValueUnchanged()
+    public function test_setGetIdenticalScoring_shouldReturnValueUnchanged() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeTest.php';
@@ -158,7 +158,7 @@ class assClozeTestTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_getAdditionalTableName_shouldReturnAdditionalTableName()
+    public function test_getAdditionalTableName_shouldReturnAdditionalTableName() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeTest.php';
@@ -170,7 +170,7 @@ class assClozeTestTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_getAnswerTableName_shouldReturnAnswerTableName()
+    public function test_getAnswerTableName_shouldReturnAnswerTableName() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeTest.php';
@@ -182,7 +182,7 @@ class assClozeTestTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetFixedTextLength_shouldReturnValueUnchanged()
+    public function test_setGetFixedTextLength_shouldReturnValueUnchanged() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeTest.php';

--- a/Modules/TestQuestionPool/test/assErrorTextGUITest.php
+++ b/Modules/TestQuestionPool/test/assErrorTextGUITest.php
@@ -40,7 +40,7 @@ class assErrorTextGUITest extends assBaseTestCase
         $GLOBALS['ilUser'] = $user_mock;
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         //$this->markTestIncomplete('Needs mock.');
         // Arrange

--- a/Modules/TestQuestionPool/test/assErrorTextTest.php
+++ b/Modules/TestQuestionPool/test/assErrorTextTest.php
@@ -35,7 +35,7 @@ class assErrorTextTest extends assBaseTestCase
         $this->setGlobalVariable('ilDB', $this->getDatabaseMock());
     }
 
-    public function test_instantiateObjectSimple()
+    public function test_instantiateObjectSimple() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assErrorText.php';
@@ -47,7 +47,7 @@ class assErrorTextTest extends assBaseTestCase
         $this->assertInstanceOf('assErrorText', $instance);
     }
 
-    public function test_getErrorsFromText()
+    public function test_getErrorsFromText() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assErrorText.php';
@@ -71,7 +71,7 @@ class assErrorTextTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_getErrorsFromText_noMatch()
+    public function test_getErrorsFromText_noMatch() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assErrorText.php';
@@ -92,7 +92,7 @@ class assErrorTextTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_getErrorsFromText_emptyArgShouldPullInternal()
+    public function test_getErrorsFromText_emptyArgShouldPullInternal() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assErrorText.php';
@@ -117,7 +117,7 @@ class assErrorTextTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setErrordata_newError()
+    public function test_setErrordata_newError() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assErrorText.php';
@@ -137,7 +137,7 @@ class assErrorTextTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setErrordata_oldErrordataPresent()
+    public function test_setErrordata_oldErrordataPresent() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assErrorText.php';

--- a/Modules/TestQuestionPool/test/assFileUploadGUITest.php
+++ b/Modules/TestQuestionPool/test/assFileUploadGUITest.php
@@ -35,7 +35,7 @@ class assFileUploadGUITest extends assBaseTestCase
         $this->setGlobalVariable('ilDB', $this->getDatabaseMock());
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assFileUploadGUI.php';

--- a/Modules/TestQuestionPool/test/assFileUploadTest.php
+++ b/Modules/TestQuestionPool/test/assFileUploadTest.php
@@ -35,7 +35,7 @@ class assFileUploadTest extends assBaseTestCase
         $this->setGlobalVariable('ilDB', $this->getDatabaseMock());
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assFileUpload.php';

--- a/Modules/TestQuestionPool/test/assFlashQuestionTest.php
+++ b/Modules/TestQuestionPool/test/assFlashQuestionTest.php
@@ -35,7 +35,7 @@ class assFlashQuestionTest extends assBaseTestCase
         $this->setGlobalVariable('ilDB', $this->getDatabaseMock());
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assFlashQuestion.php';

--- a/Modules/TestQuestionPool/test/assFormulaQuestionGUITest.php
+++ b/Modules/TestQuestionPool/test/assFormulaQuestionGUITest.php
@@ -35,7 +35,7 @@ class assFormulaQuestionGUITest extends assBaseTestCase
         $this->setGlobalVariable('ilDB', $this->getDatabaseMock());
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assFormulaQuestionGUI.php';

--- a/Modules/TestQuestionPool/test/assFormulaQuestionTest.php
+++ b/Modules/TestQuestionPool/test/assFormulaQuestionTest.php
@@ -49,7 +49,7 @@ class assFormulaQuestionTest extends assBaseTestCase
         $userResult,
         $userResultUnit,
         $expectedResult
-    ) {
+    ) : void {
         $isCorrect = $result->isCorrect($variables, $results, $userResult, $userResultUnit);
         $this->assertEquals($expectedResult, $isCorrect);
     }

--- a/Modules/TestQuestionPool/test/assImagemapQuestionTest.php
+++ b/Modules/TestQuestionPool/test/assImagemapQuestionTest.php
@@ -35,7 +35,7 @@ class assImagemapQuestionTest extends assBaseTestCase
         $this->setGlobalVariable('ilDB', $this->getDatabaseMock());
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assImagemapQuestion.php';

--- a/Modules/TestQuestionPool/test/assKprimChoiceTest.php
+++ b/Modules/TestQuestionPool/test/assKprimChoiceTest.php
@@ -17,31 +17,31 @@ class assKprimChoiceTest extends assBaseTestCase
         $this->setGlobalVariable('tpl', $this->getGlobalTemplateMock());
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         $instance = new assKprimChoice();
         $this->assertInstanceOf('assKprimChoice', $instance);
     }
     
-    public function test_getQuestionType_shouldReturnQuestionType()
+    public function test_getQuestionType_shouldReturnQuestionType() : void
     {
         $obj = new assKprimChoice();
         $this->assertEquals('assKprimChoice', $obj->getQuestionType());
     }
 
-    public function test_getAdditionalTableName_shouldReturnAdditionalTableName()
+    public function test_getAdditionalTableName_shouldReturnAdditionalTableName() : void
     {
         $obj = new assKprimChoice();
         $this->assertEquals('qpl_qst_kprim', $obj->getAdditionalTableName());
     }
 
-    public function test_getAnswerTableName_shouldReturnAnswerTableName()
+    public function test_getAnswerTableName_shouldReturnAnswerTableName() : void
     {
         $obj = new assKprimChoice();
         $this->assertEquals('qpl_a_kprim', $obj->getAnswerTableName());
     }
 
-    public function test_isCompleteWithoutAnswer_shouldReturnTrue()
+    public function test_isCompleteWithoutAnswer_shouldReturnTrue() : void
     {
         $obj = new assKprimChoice();
         $this->assertEquals(false, $obj->isComplete());
@@ -53,7 +53,7 @@ class assKprimChoiceTest extends assBaseTestCase
         $this->assertEquals(true, $obj->isComplete());
     }
 
-    public function test_isCompleteWithAnswer_shouldReturnTrue()
+    public function test_isCompleteWithAnswer_shouldReturnTrue() : void
     {
         $obj = new assKprimChoice();
         $this->assertEquals(false, $obj->isComplete());
@@ -72,20 +72,20 @@ class assKprimChoiceTest extends assBaseTestCase
         $this->assertEquals(true, $obj->isComplete());
     }
     
-    public function test_isValidOptionLabel_shouldReturnTrue()
+    public function test_isValidOptionLabel_shouldReturnTrue() : void
     {
         $obj = new assKprimChoice();
         $this->assertEquals(false, $obj->isValidOptionLabel('not valid'));
         $this->assertEquals(true, $obj->isValidOptionLabel($obj::OPTION_LABEL_RIGHT_WRONG));
     }
 
-    public function test_isObligationPossible_shouldReturnTrue()
+    public function test_isObligationPossible_shouldReturnTrue() : void
     {
         $obj = new assKprimChoice();
         $this->assertEquals(true, $obj->isObligationPossible(1));
     }
 
-    public function test_getAnswer_shouldReturnAnswer()
+    public function test_getAnswer_shouldReturnAnswer() : void
     {
         $obj = new assKprimChoice();
         $ans = new ilAssKprimChoiceAnswer();
@@ -96,7 +96,7 @@ class assKprimChoiceTest extends assBaseTestCase
         $this->assertEquals(null, $obj->getAnswer(1));
     }
     
-    public function test_isValidAnswerType_shouldReturnTrue()
+    public function test_isValidAnswerType_shouldReturnTrue() : void
     {
         $obj = new assKprimChoice();
         $this->assertEquals(false, $obj->isValidAnswerType('not valid'));

--- a/Modules/TestQuestionPool/test/assLongMenuTest.php
+++ b/Modules/TestQuestionPool/test/assLongMenuTest.php
@@ -42,31 +42,31 @@ class assLongmenuTest extends assBaseTestCase
         $this->setGlobalVariable('ilDB', $this->getDatabaseMock());
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         $instance = new assLongMenu();
         $this->assertInstanceOf('assLongMenu', $instance);
     }
 
-    public function test_getAdditionalTableName_shouldReturnString()
+    public function test_getAdditionalTableName_shouldReturnString() : void
     {
         $instance = new assLongMenu();
         $this->assertEquals('qpl_qst_lome', $instance->getAdditionalTableName());
     }
 
-    public function test_getQuestionType_shouldReturnString()
+    public function test_getQuestionType_shouldReturnString() : void
     {
         $instance = new assLongMenu();
         $this->assertEquals('assLongMenu', $instance->getQuestionType());
     }
     
-    public function test_getAnswerTableName_shouldReturnString()
+    public function test_getAnswerTableName_shouldReturnString() : void
     {
         $instance = new assLongMenu();
         $this->assertEquals('qpl_a_lome', $instance->getAnswerTableName());
     }
 
-    public function test_correctAnswerDoesNotExistInAnswerOptions_shouldReturnTrue()
+    public function test_correctAnswerDoesNotExistInAnswerOptions_shouldReturnTrue() : void
     {
         $method = self::getMethod('correctAnswerDoesNotExistInAnswerOptions');
         $obj = new assLongMenu();
@@ -74,7 +74,7 @@ class assLongmenuTest extends assBaseTestCase
         $this->assertEquals(true, $value);
     }
 
-    public function test_correctAnswerDoesNotExistInAnswerOptions_shouldReturnFalse()
+    public function test_correctAnswerDoesNotExistInAnswerOptions_shouldReturnFalse() : void
     {
         $method = self::getMethod('correctAnswerDoesNotExistInAnswerOptions');
         $obj = new assLongMenu();
@@ -82,7 +82,7 @@ class assLongmenuTest extends assBaseTestCase
         $this->assertEquals(false, $value);
     }
 
-    public function test_getMaximumPoints_shouldBeFour()
+    public function test_getMaximumPoints_shouldBeFour() : void
     {
         $obj = new assLongMenu();
         $obj->setCorrectAnswers(array(	0 => array( 0 => array(0 => 'answer'),1 => '2', 2 => '1'),
@@ -91,7 +91,7 @@ class assLongmenuTest extends assBaseTestCase
         $this->assertEquals(4, $value);
     }
 
-    public function test_getMaximumPoints_shouldBeFourPointFive()
+    public function test_getMaximumPoints_shouldBeFourPointFive() : void
     {
         $obj = new assLongMenu();
         $obj->setCorrectAnswers(array(	0 => array( 0 => array(0 => 'answer'),1 => '2.25', 2 => '1'),
@@ -100,7 +100,7 @@ class assLongmenuTest extends assBaseTestCase
         $this->assertEquals(4.5, $value);
     }
 
-    public function test_isComplete_shouldBeFalse()
+    public function test_isComplete_shouldBeFalse() : void
     {
         $obj = new assLongMenu();
         $obj->setCorrectAnswers(array(	0 => array( 0 => array(0 => 'answer'),1 => '2.25', 2 => '1'),
@@ -109,7 +109,7 @@ class assLongmenuTest extends assBaseTestCase
         $this->assertEquals($obj->isComplete(), false);
     }
 
-    public function test_isComplete_shouldBeTrue()
+    public function test_isComplete_shouldBeTrue() : void
     {
         $obj = new assLongMenu();
         $obj->setCorrectAnswers(array(	0 => array( 0 => array(0 => 'answer'),1 => '2.25', 2 => '1'),
@@ -122,27 +122,27 @@ class assLongmenuTest extends assBaseTestCase
         $this->assertEquals($obj->isComplete(), true);
     }
 
-    public function test_checkQuestionCustomPart_shouldBeFalseBecauseNoCustomPart()
+    public function test_checkQuestionCustomPart_shouldBeFalseBecauseNoCustomPart() : void
     {
         $obj = new assLongMenu();
         $this->assertEquals($obj->checkQuestionCustomPart(), false);
     }
 
-    public function test_checkQuestionCustomPart_shouldBeFalseBecauseOnlyAnswers()
+    public function test_checkQuestionCustomPart_shouldBeFalseBecauseOnlyAnswers() : void
     {
         $obj = new assLongMenu();
         $obj->setAnswers(array(array(1,2,3,4)));
         $this->assertEquals($obj->checkQuestionCustomPart(), false);
     }
 
-    public function test_checkQuestionCustomPart_shouldBeFalseBecauseOnlyCorrectAnswers()
+    public function test_checkQuestionCustomPart_shouldBeFalseBecauseOnlyCorrectAnswers() : void
     {
         $obj = new assLongMenu();
         $obj->setCorrectAnswers(array(	0 => array( 0 => array(0 => 'answer'),1 => '2.25', 2 => '1'),
                                            1 => array( 0 => array(0 => 'answer'),1 => '2.25', 2 => '1')));
         $this->assertEquals($obj->checkQuestionCustomPart(), false);
     }
-    public function test_checkQuestionCustomPart_shouldBeFalseBecauseToManyCorrectAnswers()
+    public function test_checkQuestionCustomPart_shouldBeFalseBecauseToManyCorrectAnswers() : void
     {
         $obj = new assLongMenu();
         $obj->setCorrectAnswers(array(	0 => array( 0 => array(0 => 'answer'),1 => '2.25', 2 => '1'),
@@ -150,7 +150,7 @@ class assLongmenuTest extends assBaseTestCase
         $obj->setAnswers(array(array('answer')));
         $this->assertEquals($obj->checkQuestionCustomPart(), false);
     }
-    public function test_checkQuestionCustomPart_shouldBeFalseBecauseCorrectAnswerDoesNotExistsInAnswers()
+    public function test_checkQuestionCustomPart_shouldBeFalseBecauseCorrectAnswerDoesNotExistsInAnswers() : void
     {
         $obj = new assLongMenu();
         $obj->setCorrectAnswers(array(	0 => array( 0 => array(0 => 'answer'),1 => '2.25', 2 => '1')));
@@ -158,7 +158,7 @@ class assLongmenuTest extends assBaseTestCase
         $this->assertEquals($obj->checkQuestionCustomPart(), false);
     }
 
-    public function test_checkQuestionCustomPart_shouldBeFalseBecauseCorrectAnswerHasNoAnswers()
+    public function test_checkQuestionCustomPart_shouldBeFalseBecauseCorrectAnswerHasNoAnswers() : void
     {
         $obj = new assLongMenu();
         $obj->setCorrectAnswers(array(	0 => array( 0 => array(),1 => '2.25', 2 => '1')));
@@ -166,7 +166,7 @@ class assLongmenuTest extends assBaseTestCase
         $this->assertEquals($obj->checkQuestionCustomPart(), false);
     }
 
-    public function test_checkQuestionCustomPart_shouldBeFalseBecauseCorrectAnswerHasNoPoints()
+    public function test_checkQuestionCustomPart_shouldBeFalseBecauseCorrectAnswerHasNoPoints() : void
     {
         $obj = new assLongMenu();
         $obj->setCorrectAnswers(array(	0 => array( 0 => array())));
@@ -174,7 +174,7 @@ class assLongmenuTest extends assBaseTestCase
         $this->assertEquals($obj->checkQuestionCustomPart(), false);
     }
 
-    public function test_checkQuestionCustomPart_shouldBeFalseBecauseCorrectAnswerPointsAreZero()
+    public function test_checkQuestionCustomPart_shouldBeFalseBecauseCorrectAnswerPointsAreZero() : void
     {
         $obj = new assLongMenu();
         $obj->setCorrectAnswers(array(	0 => array( 0 => array('answer'),1 => 0, 2 => '1')));
@@ -182,7 +182,7 @@ class assLongmenuTest extends assBaseTestCase
         $this->assertEquals($obj->checkQuestionCustomPart(), false);
     }
 
-    public function test_checkQuestionCustomPart_shouldBeTrue()
+    public function test_checkQuestionCustomPart_shouldBeTrue() : void
     {
         $obj = new assLongMenu();
         $obj->setCorrectAnswers(array(	0 => array( 0 => array('answer'),1 => 1, 2 => '1')));
@@ -190,7 +190,7 @@ class assLongmenuTest extends assBaseTestCase
         $this->assertEquals($obj->checkQuestionCustomPart(), true);
     }
 
-    public function test_getSolutionSubmit_shouldReturnSolution()
+    public function test_getSolutionSubmit_shouldReturnSolution() : void
     {
         $obj = new assLongMenu();
         $array = array( 0 => 'squirrel', 1 => 'icebear');
@@ -198,13 +198,13 @@ class assLongmenuTest extends assBaseTestCase
         $this->assertEquals($obj->getSolutionSubmit(), $array);
     }
 
-    public function test_setAnswerType_shouldReturnGetAnswerType()
+    public function test_setAnswerType_shouldReturnGetAnswerType() : void
     {
         $obj = new assLongMenu();
         $obj->setAnswerType(0);
         $this->assertEquals(0, $obj->getAnswerType());
     }
-    public function test_setLongMenuTextValue_shouldReturnGetLongMenuTextValue()
+    public function test_setLongMenuTextValue_shouldReturnGetLongMenuTextValue() : void
     {
         $obj = new assLongMenu();
         $this->assertEquals('', $obj->getLongMenuTextValue());
@@ -212,14 +212,14 @@ class assLongmenuTest extends assBaseTestCase
         $this->assertEquals('dummy text', $obj->getLongMenuTextValue());
     }
 
-    public function test_setJsonStructure_shouldReturnGetJsonStructure()
+    public function test_setJsonStructure_shouldReturnGetJsonStructure() : void
     {
         $obj = new assLongMenu();
         $obj->setJsonStructure(json_encode(array(1 => 'bla')));
         $this->assertEquals('{"1":"bla"}', $obj->getJsonStructure());
     }
 
-    public function test_isShuffleAnswersEnabled_shouldReturnFalse()
+    public function test_isShuffleAnswersEnabled_shouldReturnFalse() : void
     {
         $obj = new assLongMenu();
         $this->assertEquals(false, $obj->isShuffleAnswersEnabled());

--- a/Modules/TestQuestionPool/test/assMatchingQuestionGUITest.php
+++ b/Modules/TestQuestionPool/test/assMatchingQuestionGUITest.php
@@ -35,7 +35,7 @@ class assMatchingQuestionGUITest extends assBaseTestCase
         $this->setGlobalVariable('ilDB', $this->getDatabaseMock());
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assMatchingQuestionGUI.php';

--- a/Modules/TestQuestionPool/test/assMatchingQuestionTest.php
+++ b/Modules/TestQuestionPool/test/assMatchingQuestionTest.php
@@ -35,7 +35,7 @@ class assMatchingQuestionTest extends assBaseTestCase
         $this->setGlobalVariable('ilDB', $this->getDatabaseMock());
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assMatchingQuestion.php';

--- a/Modules/TestQuestionPool/test/assMultipleChoiceGUITest.php
+++ b/Modules/TestQuestionPool/test/assMultipleChoiceGUITest.php
@@ -37,7 +37,7 @@ class assMultipleChoiceGUITest extends assBaseTestCase
         $this->setGlobalVariable('ilDB', $this->getDatabaseMock());
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assMultipleChoiceGUI.php';

--- a/Modules/TestQuestionPool/test/assMultipleChoiceTest.php
+++ b/Modules/TestQuestionPool/test/assMultipleChoiceTest.php
@@ -21,7 +21,7 @@ class assMultipleChoiceTest extends assBaseTestCase
         $this->setGlobalVariable('tpl', $this->getGlobalTemplateMock());
     }
 
-    public function test_isComplete_shouldReturnTrue()
+    public function test_isComplete_shouldReturnTrue() : void
     {
         $obj = new assMultipleChoice();
         $this->assertEquals(false, $obj->isComplete());
@@ -33,19 +33,19 @@ class assMultipleChoiceTest extends assBaseTestCase
         $this->assertEquals(true, $obj->isComplete());
     }
     
-    public function test_getThumbPrefix_shouldReturnString()
+    public function test_getThumbPrefix_shouldReturnString() : void
     {
         $obj = new assMultipleChoice();
         $this->assertEquals('thumb.', $obj->getThumbPrefix());
     }
 
-    public function test_setOutputType_shouldReturngetOutputType()
+    public function test_setOutputType_shouldReturngetOutputType() : void
     {
         $obj = new assMultipleChoice();
         $obj->setOutputType(0);
         $this->assertEquals(0, $obj->getOutputType());
     }
-    public function test_getAnswerCount_shouldReturnCount()
+    public function test_getAnswerCount_shouldReturnCount() : void
     {
         $obj = new assMultipleChoice();
         $this->assertEquals(0, $obj->getAnswerCount());
@@ -56,7 +56,7 @@ class assMultipleChoiceTest extends assBaseTestCase
         $this->assertEquals(1, $obj->getAnswerCount());
     }
 
-    public function test_flushAnswers_shouldClearAnswers()
+    public function test_flushAnswers_shouldClearAnswers() : void
     {
         $obj = new assMultipleChoice();
         $obj->addAnswer('1', 1, 0, 0);
@@ -66,39 +66,39 @@ class assMultipleChoiceTest extends assBaseTestCase
         $this->assertEquals(0, $obj->getAnswerCount());
     }
 
-    public function test_getQuestionType_shouldReturnQuestionType()
+    public function test_getQuestionType_shouldReturnQuestionType() : void
     {
         $obj = new assMultipleChoice();
         $this->assertEquals('assMultipleChoice', $obj->getQuestionType());
     }
 
-    public function test_getAdditionalTableName_shouldReturnAdditionalTableName()
+    public function test_getAdditionalTableName_shouldReturnAdditionalTableName() : void
     {
         $obj = new assMultipleChoice();
         $this->assertEquals('qpl_qst_mc', $obj->getAdditionalTableName());
     }
 
-    public function test_getAnswerTableName_shouldReturnAnswerTableName()
+    public function test_getAnswerTableName_shouldReturnAnswerTableName() : void
     {
         $obj = new assMultipleChoice();
         $this->assertEquals('qpl_a_mc', $obj->getAnswerTableName());
     }
 
-    public function test_getMaximumPoints_shouldReturnAnswerTableName()
+    public function test_getMaximumPoints_shouldReturnAnswerTableName() : void
     {
         $obj = new assMultipleChoice();
         $obj->addAnswer('Points for checked', 1, 0, 0);
         $obj->addAnswer('Points for checked', 1, 0, 1);
         $this->assertEquals(2, $obj->getMaximumPoints());
     }
-    public function test_getMaximumPointsIfMoreForUnchecked_shouldReturnAnswerTableName()
+    public function test_getMaximumPointsIfMoreForUnchecked_shouldReturnAnswerTableName() : void
     {
         $obj = new assMultipleChoice();
         $obj->addAnswer('Points for unchecked', 0, 1, 0);
         $obj->addAnswer('Points for unchecked', 0, 1, 1);
         $this->assertEquals(2, $obj->getMaximumPoints());
     }
-    public function test_getMaximumPointsMixed_shouldReturnAnswerTableName()
+    public function test_getMaximumPointsMixed_shouldReturnAnswerTableName() : void
     {
         $obj = new assMultipleChoice();
         $obj->addAnswer('Points for unchecked', 0, 1, 0);

--- a/Modules/TestQuestionPool/test/assNumericGUITest.php
+++ b/Modules/TestQuestionPool/test/assNumericGUITest.php
@@ -29,7 +29,7 @@ class assNumericGUITest extends assBaseTestCase
         $this->setGlobalVariable('tpl', $this->getGlobalTemplateMock());
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assNumericGUI.php';

--- a/Modules/TestQuestionPool/test/assNumericRangeTest.php
+++ b/Modules/TestQuestionPool/test/assNumericRangeTest.php
@@ -18,7 +18,7 @@ class assNumericRangeTest extends assBaseTestCase
         chdir('../../../');
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assNumericRange.php';
@@ -29,7 +29,7 @@ class assNumericRangeTest extends assBaseTestCase
         $this->assertInstanceOf('assNumericRange', $instance);
     }
 
-    public function test_setGetLowerLimit_shouldReturnUnchangedLowerLimit()
+    public function test_setGetLowerLimit_shouldReturnUnchangedLowerLimit() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assNumericRange.php';
@@ -44,7 +44,7 @@ class assNumericRangeTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetUpperLimit_shouldReturnUnchangedUpperLimit()
+    public function test_setGetUpperLimit_shouldReturnUnchangedUpperLimit() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assNumericRange.php';
@@ -59,7 +59,7 @@ class assNumericRangeTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setGetOrder_shouldReturnUnchangedOrder()
+    public function test_setGetOrder_shouldReturnUnchangedOrder() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assNumericRange.php';
@@ -74,7 +74,7 @@ class assNumericRangeTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_setPoints_shouldReturnUnchangedPoints()
+    public function test_setPoints_shouldReturnUnchangedPoints() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assNumericRange.php';
@@ -89,7 +89,7 @@ class assNumericRangeTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_contains_shouldReturnTrueIfValueIsContained()
+    public function test_contains_shouldReturnTrueIfValueIsContained() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assNumericRange.php';
@@ -105,7 +105,7 @@ class assNumericRangeTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_contains_shouldReturnFalseIfValueIsNotContained()
+    public function test_contains_shouldReturnFalseIfValueIsNotContained() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assNumericRange.php';
@@ -121,7 +121,7 @@ class assNumericRangeTest extends assBaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_contains_shouldReturnFalseIfValueIsHokum()
+    public function test_contains_shouldReturnFalseIfValueIsHokum() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assNumericRange.php';

--- a/Modules/TestQuestionPool/test/assNumericTest.php
+++ b/Modules/TestQuestionPool/test/assNumericTest.php
@@ -35,7 +35,7 @@ class assNumericTest extends assBaseTestCase
         $this->setGlobalVariable('ilDB', $this->getDatabaseMock());
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assNumeric.php';

--- a/Modules/TestQuestionPool/test/assOrderingHorizontalGUITest.php
+++ b/Modules/TestQuestionPool/test/assOrderingHorizontalGUITest.php
@@ -32,7 +32,7 @@ class assOrderingHorizontalGUITest extends assBaseTestCase
         $this->setGlobalVariable('ilDB', $this->getDatabaseMock());
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assOrderingHorizontalGUI.php';

--- a/Modules/TestQuestionPool/test/assOrderingHorizontalTest.php
+++ b/Modules/TestQuestionPool/test/assOrderingHorizontalTest.php
@@ -35,7 +35,7 @@ class assOrderingHorizontalTest extends assBaseTestCase
         $this->setGlobalVariable('ilDB', $this->getDatabaseMock());
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assOrderingHorizontal.php';

--- a/Modules/TestQuestionPool/test/assOrderingQuestionGUITest.php
+++ b/Modules/TestQuestionPool/test/assOrderingQuestionGUITest.php
@@ -35,7 +35,7 @@ class assOrderingQuestionGUITest extends assBaseTestCase
         $this->setGlobalVariable('ilDB', $this->getDatabaseMock());
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assOrderingQuestionGUI.php';

--- a/Modules/TestQuestionPool/test/assOrderingQuestionTest.php
+++ b/Modules/TestQuestionPool/test/assOrderingQuestionTest.php
@@ -35,7 +35,7 @@ class assOrderingQuestionTest extends assBaseTestCase
         $this->setGlobalVariable('ilDB', $this->getDatabaseMock());
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assOrderingQuestion.php';

--- a/Modules/TestQuestionPool/test/assSingleChoiceGUITest.php
+++ b/Modules/TestQuestionPool/test/assSingleChoiceGUITest.php
@@ -37,7 +37,7 @@ class assSingleChoiceGUITest extends assBaseTestCase
         $this->setGlobalVariable('ilDB', $this->getDatabaseMock());
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assSingleChoiceGUI.php';

--- a/Modules/TestQuestionPool/test/assSingleChoiceTest.php
+++ b/Modules/TestQuestionPool/test/assSingleChoiceTest.php
@@ -21,7 +21,7 @@ class assSingleChoiceTest extends assBaseTestCase
         $this->setGlobalVariable('tpl', $this->getGlobalTemplateMock());
     }
 
-    public function test_isComplete_shouldReturnTrue()
+    public function test_isComplete_shouldReturnTrue() : void
     {
         $obj = new assSingleChoice();
         $this->assertEquals(false, $obj->isComplete());
@@ -33,20 +33,20 @@ class assSingleChoiceTest extends assBaseTestCase
         $this->assertEquals(true, $obj->isComplete());
     }
 
-    public function test_getThumbPrefix_shouldReturnString()
+    public function test_getThumbPrefix_shouldReturnString() : void
     {
         $obj = new assSingleChoice();
         $this->assertEquals('thumb.', $obj->getThumbPrefix());
     }
 
-    public function test_setOutputType_shouldReturngetOutputType()
+    public function test_setOutputType_shouldReturngetOutputType() : void
     {
         $obj = new assSingleChoice();
         $obj->setOutputType(0);
         $this->assertEquals(0, $obj->getOutputType());
     }
 
-    public function test_getAnswerCount_shouldReturnCount()
+    public function test_getAnswerCount_shouldReturnCount() : void
     {
         $obj = new assSingleChoice();
         $this->assertEquals(0, $obj->getAnswerCount());
@@ -57,7 +57,7 @@ class assSingleChoiceTest extends assBaseTestCase
         $this->assertEquals(1, $obj->getAnswerCount());
     }
 
-    public function test_flushAnswers_shouldClearAnswers()
+    public function test_flushAnswers_shouldClearAnswers() : void
     {
         $obj = new assSingleChoice();
         $obj->addAnswer('1', 1, 0);
@@ -67,19 +67,19 @@ class assSingleChoiceTest extends assBaseTestCase
         $this->assertEquals(0, $obj->getAnswerCount());
     }
 
-    public function test_getQuestionType_shouldReturnQuestionType()
+    public function test_getQuestionType_shouldReturnQuestionType() : void
     {
         $obj = new assSingleChoice();
         $this->assertEquals('assSingleChoice', $obj->getQuestionType());
     }
 
-    public function test_getAdditionalTableName_shouldReturnAdditionalTableName()
+    public function test_getAdditionalTableName_shouldReturnAdditionalTableName() : void
     {
         $obj = new assSingleChoice();
         $this->assertEquals('qpl_qst_sc', $obj->getAdditionalTableName());
     }
 
-    public function test_getAnswerTableName_shouldReturnAnswerTableName()
+    public function test_getAnswerTableName_shouldReturnAnswerTableName() : void
     {
         $obj = new assSingleChoice();
         $this->assertEquals('qpl_a_sc', $obj->getAnswerTableName());

--- a/Modules/TestQuestionPool/test/assTextQuestionGUITest.php
+++ b/Modules/TestQuestionPool/test/assTextQuestionGUITest.php
@@ -32,7 +32,7 @@ class assTextQuestionGUITest extends assBaseTestCase
         $this->setGlobalVariable('ilDB', $this->getDatabaseMock());
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assTextQuestionGUI.php';

--- a/Modules/TestQuestionPool/test/assTextQuestionTest.php
+++ b/Modules/TestQuestionPool/test/assTextQuestionTest.php
@@ -35,7 +35,7 @@ class assTextQuestionTest extends assBaseTestCase
         $this->setGlobalVariable('ilDB', $this->getDatabaseMock());
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assTextQuestion.php';

--- a/Modules/TestQuestionPool/test/assTextSubsetGUITest.php
+++ b/Modules/TestQuestionPool/test/assTextSubsetGUITest.php
@@ -35,7 +35,7 @@ class assTextSubsetGUITest extends assBaseTestCase
         $this->setGlobalVariable('ilDB', $this->getDatabaseMock());
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assTextSubsetGUI.php';

--- a/Modules/TestQuestionPool/test/assTextSubsetTest.php
+++ b/Modules/TestQuestionPool/test/assTextSubsetTest.php
@@ -35,7 +35,7 @@ class assTextSubsetTest extends assBaseTestCase
         $this->setGlobalVariable('ilDB', $this->getDatabaseMock());
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assTextSubset.php';

--- a/Modules/TestQuestionPool/test/ilAssQuestionHintAbstractTest.php
+++ b/Modules/TestQuestionPool/test/ilAssQuestionHintAbstractTest.php
@@ -18,7 +18,7 @@ class ilAssQuestionHintAbstractTest extends assBaseTestCase
         chdir('../../../');
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerBinaryStateImage.php';

--- a/Modules/TestQuestionPool/test/ilAssQuestionHintListTest.php
+++ b/Modules/TestQuestionPool/test/ilAssQuestionHintListTest.php
@@ -18,7 +18,7 @@ class ilAssQuestionHintListTest extends assBaseTestCase
         chdir('../../../');
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.ilAssQuestionHintList.php';

--- a/Modules/TestQuestionPool/test/ilAssQuestionHintRequestStatisticDataTest.php
+++ b/Modules/TestQuestionPool/test/ilAssQuestionHintRequestStatisticDataTest.php
@@ -18,7 +18,7 @@ class ilAssQuestionHintRequestStatisticDataTest extends assBaseTestCase
         chdir('../../../');
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.ilAssQuestionHintRequestStatisticData.php';

--- a/Modules/TestQuestionPool/test/ilAssQuestionHintTest.php
+++ b/Modules/TestQuestionPool/test/ilAssQuestionHintTest.php
@@ -18,7 +18,7 @@ class ilAssQuestionHintTest extends assBaseTestCase
         chdir('../../../');
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.ilAssQuestionHint.php';

--- a/Modules/TestQuestionPool/test/ilAssQuestionHintTrackingTest.php
+++ b/Modules/TestQuestionPool/test/ilAssQuestionHintTrackingTest.php
@@ -18,7 +18,7 @@ class ilAssQuestionHintTrackingTest extends assBaseTestCase
         chdir('../../../');
     }
 
-    public function test_instantiateObject_shouldReturnInstance()
+    public function test_instantiateObject_shouldReturnInstance() : void
     {
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.ilAssQuestionHintTracking.php';

--- a/Modules/TestQuestionPool/test/ilAssQuestionSkillAssignmentRegistryTest.php
+++ b/Modules/TestQuestionPool/test/ilAssQuestionSkillAssignmentRegistryTest.php
@@ -32,7 +32,7 @@ class ilAssQuestionSkillAssignmentRegistryTest extends assBaseTestCase
      * @param callable $preCallback
      * @param callable $postCallback
      */
-    public function testSkillAssignmentsCanBetStoredAndFetchedBySerializationStrategy($value, $chunkSize, callable $preCallback, callable $postCallback)
+    public function testSkillAssignmentsCanBetStoredAndFetchedBySerializationStrategy($value, $chunkSize, callable $preCallback, callable $postCallback) : void
     {
         require_once 'Services/Administration/classes/class.ilSetting.php';
         $settingsMock = $this->getMockBuilder('ilSetting')->disableOriginalConstructor()->onlyMethods(array('set', 'get', 'delete'))->getMock();
@@ -71,7 +71,7 @@ class ilAssQuestionSkillAssignmentRegistryTest extends assBaseTestCase
     /**
      * @doesNotPerformAssertions
      */
-    public function testInvalidChunkSizeWillRaiseException()
+    public function testInvalidChunkSizeWillRaiseException() : void
     {
         require_once 'Services/Administration/classes/class.ilSetting.php';
         $settingsMock = $this->getMockBuilder('ilSetting')->disableOriginalConstructor()->onlyMethods(array('set', 'get', 'delete'))->getMock();


### PR DESCRIPTION
This commit adds missing return type declarations where the return type
was 100% obvious (mostly `void`)

All non `void` types (count: 15) can be determined based on the following diff executed on the PR branch:

```bash
git diff trunk | grep -E "^\+ " | grep -P '.*?\: +(?!void)'
```

- public function moveAnswerDown($position) : bool
- private function buildFileName($gap_id) : ?string
- public function getAnswers() : array
- public function &joinAnswers() : array
- private function buildPreviewPresentationPageObjectGUI() : ilAssHintPageGUI
- private function buildRequestPresentationPageObjectGUI() : ilAssHintPageGUI
- private function buildAuthorPresentationPageObjectGUI() : ilAssHintPageGUI
- protected function getPageObjectGUI($pageObjectType, $pageObjectId) : ilAssHintPageGUI
- protected function getPreparedDeleteSolutionRecordsStatement() : ilDBStatement
- protected function getPreparedSelectSolutionRecordsStatement() : ilDBStatement
- protected function getPreparedInsertSolutionRecordStatement() : ilDBStatement
- protected function getPreparedDeleteResultRecordStatement() : ilDBStatement
- protected function getPreparedSelectResultRecordStatement() : ilDBStatement
- protected function getPreparedInsertResultRecordStatement() : ilDBStatement
- protected function fetchTermScoring($item) : array
