### PR TITLE
UI: allow null as false for checkbox input (#29645)

### DIFF
--- a/src/UI/Implementation/Component/Input/Field/Checkbox.php
+++ b/src/UI/Implementation/Component/Input/Field/Checkbox.php
@@ -46,6 +46,8 @@ class Checkbox extends Input implements C\Input\Field\Checkbox, C\Changeable, C\
      */
     public function withValue($value) : C\Input\Field\Input
     {
+        $value = $value ?? false;
+
         if (!is_bool($value)) {
             throw new InvalidArgumentException(
                 "Unknown value type for checkbox: " . gettype($value)

--- a/tests/UI/Component/Input/Field/CheckboxInputTest.php
+++ b/tests/UI/Component/Input/Field/CheckboxInputTest.php
@@ -255,4 +255,12 @@ class CheckboxInputTest extends ILIAS_UI_TestBase
         $this->assertIsString($checkbox->getContent()->value());
         $this->assertEquals($new_value, $checkbox->getContent()->value());
     }
+
+    public function testNullValue() : void
+    {
+        $f = $this->buildFactory();
+        $checkbox = $f->checkbox("label");
+        $checkbox->withValue(null);
+        $this->assertEquals(false, $checkbox->getValue());
+    }
 }


### PR DESCRIPTION
Hi everybody,

this fixes https://mantis.ilias.de/view.php?id=29645. Rather simple, small behaviour improvement of the checkbox for developers.

Best regards!