### PR TITLE
Fix #28229: Notification aggregates aren't properly removed

### DIFF
--- a/src/UI/templates/js/Item/notification.js
+++ b/src/UI/templates/js/Item/notification.js
@@ -425,13 +425,17 @@ il.UI.item = il.UI.item || {};
 			 * @param $close_button
 			 */
 			var removeNotificationItem = function () {
-				if(!hasSibblings()){
-					getParentSlateOfItem().hide();
-					if(isAggregate()) {
-                        getParentSlateOfItem().show().siblings().show();
-					}
-				}
-				$item.children().remove();
+				console.log("item: ", $item);
+				console.log("parents children: ", getParentSlateOfItem().children());
+				console.log("aggregates: ", getAggregatesOfItem());
+
+				// if(!hasSibblings()){
+				// 	getParentSlateOfItem().hide();
+				// 	if(isAggregate()) {
+                //         getParentSlateOfItem().show().siblings().show();
+				// 	}
+				// }
+				// $item.children().remove();
 			};
 
 			/**
@@ -439,7 +443,7 @@ il.UI.item = il.UI.item || {};
 			 * @returns jQuery Object of the Aggregates of the Item
 			 */
 			var getAggregatesOfItem = function(){
-				$parent = getParentSlateOfItem().parent();
+				let $parent = getParentSlateOfItem().parent();
 				if(!$parent.length){
 					$parent = $('body');
 				}
@@ -503,7 +507,7 @@ il.UI.item = il.UI.item || {};
 			var getNotificationsTriggererIfAny = function(){
 				var $meta_bar = getMetaBarOfItemIfIsInOne();
 				if($meta_bar.length){
-					var $notification_glyph = $meta_bar.find('.il-maincontrols-metabar > .btn-bulky .glyphicon-bell');
+					var $notification_glyph = $meta_bar.find('.btn-bulky .glyphicon-bell');
 					return $notification_glyph.parents('.btn-bulky');
 				}
 			}


### PR DESCRIPTION
Hi @Amstutz 

I've opened a PR that solves the first issue that occurred when reproducing https://mantis.ilias.de/view.php?id=28229 (where I uncovered your method-of-doom =)) that lead to an invalid object being passed to `UI.counter.getCounterObject()`. 

Now to recap the issue briefly: when aggregated notifications are displayed in the notification center, the notification.js should remove the "parent" slate too if it was the last child. Though I couldn't quite figure out how to achieve this and hoped you could point me in the right direction. As you can see in `removeNotificationItem()` there are already a few debug-statements, because I figured the handling of said problem should be done there (right?).

Best regards!