### PR TITLE
bugfix:  ilObjOrgUnitTree::$temporary_table_name requires initialization

### DIFF
--- a/Modules/OrgUnit/classes/class.ilObjOrgUnitTree.php
+++ b/Modules/OrgUnit/classes/class.ilObjOrgUnitTree.php
@@ -1,5 +1,18 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
 
 /**
  * Class ilObjOrgUnitTree

--- a/Modules/OrgUnit/classes/class.ilObjOrgUnitTree.php
+++ b/Modules/OrgUnit/classes/class.ilObjOrgUnitTree.php
@@ -10,7 +10,7 @@
 class ilObjOrgUnitTree
 {
     protected static ?string $temporary_table_name_getOrgUnitOfUser = null;
-    protected static string $temporary_table_name;
+    protected static ?string $temporary_table_name = null;
     protected static ?ilObjOrgUnitTree $instance = null;
     /** @var int[][] "employee" | "superior" => orgu_ref_id => role_id */
     private array $roles;


### PR DESCRIPTION
when requesting "Profile and Privacy" from metabar menu, the following error is thrown:

Error thrown with message "Typed static property ilObjOrgUnitTree::$temporary_table_name must not be accessed before initialization"
Stacktrace:
#12 Error in /srv/www/xyz/Modules/OrgUnit/classes/class.ilObjOrgUnitTree.php:375
#11 ilObjOrgUnitTree:buildTempTableWithUsrAssignements in /srv/www/xyz/Modules/OrgUnit/classes/PathStorage/class.ilOrgUnitPathStorage.php:77
#10 ilOrgUnitPathStorage:getTextRepresentationOfUsersOrgUnits in /srv/www/xyz/Services/User/classes/class.ilObjUser.php:2586
#9 ilObjUser:lookupOrgUnitsRepresentation in /srv/www/xyz/Services/User/classes/class.ilObjUser.php:2591
#8 ilObjUser:getOrgUnitsRepresentation in /srv/www/xyz/Services/User/classes/class.ilUserProfile.php:785
#7 ilUserProfile:addStandardFieldsToForm in /srv/www/xyz/Services/User/Profile/classes/class.ilPersonalProfileGUI.php:632
#6 ilPersonalProfileGUI:initPersonalDataForm in /srv/www/xyz/Services/User/Profile/classes/class.ilPersonalProfileGUI.php:582
#5 ilPersonalProfileGUI:showPersonalData in /srv/www/xyz/Services/User/Profile/classes/class.ilPersonalProfileGUI.php:122
#4 ilPersonalProfileGUI:executeCommand in /srv/www/xyz/Services/UICore/classes/class.ilCtrl.php:178
#3 ilCtrl:forwardCommand in /srv/www/xyz/Services/Dashboard/classes/class.ilDashboardGUI.php:107
#2 ilDashboardGUI:executeCommand in /srv/www/xyz/Services/UICore/classes/class.ilCtrl.php:178
#1 ilCtrl:forwardCommand in /srv/www/xyz/Services/UICore/classes/class.ilCtrl.php:153
#0 ilCtrl:callBaseClass in /srv/www/xyz/ilias.php:24